### PR TITLE
fix: address nitpicks deferred from PR #16

### DIFF
--- a/app/providers/fundamentals.py
+++ b/app/providers/fundamentals.py
@@ -29,7 +29,7 @@ class FundamentalsSnapshot:
     cash: Decimal | None
     debt: Decimal | None  # total debt
     net_debt: Decimal | None
-    shares_outstanding: int | None
+    shares_outstanding: int | None  # DB column must be BIGINT — large-caps exceed 2^31 (e.g. AAPL ~15bn)
     book_value: Decimal | None  # per share
     eps: Decimal | None  # diluted EPS, TTM
 

--- a/sql/001_init.sql
+++ b/sql/001_init.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS fundamentals_snapshot (
     cash NUMERIC(20,4),
     debt NUMERIC(20,4),
     net_debt NUMERIC(20,4),
-    shares_outstanding NUMERIC(20,4),
+    shares_outstanding NUMERIC(20,4),  -- NUMERIC not INTEGER: large-caps exceed 2^31; NUMERIC also handles fractional shares
     book_value NUMERIC(20,4),
     eps NUMERIC(20,4),
     custom_json JSONB,

--- a/tests/test_provider_interfaces.py
+++ b/tests/test_provider_interfaces.py
@@ -91,6 +91,10 @@ class TestCompaniesHouseStub:
 
 
 class TestNewsProviderIsAbstract:
+    # No concrete stub exists for NewsProvider — v1 has no dedicated news provider.
+    # The news service (issue #5) will decide the source (eToro feed, RSS, etc.) and
+    # add an implementations/news.py at that point. This test confirms the ABC is
+    # correctly defined so it cannot be accidentally instantiated directly.
     def test_cannot_instantiate_news_provider_directly(self) -> None:
         with pytest.raises(TypeError):
             NewsProvider()  # type: ignore[abstract]


### PR DESCRIPTION
## Issue reference

No issue — these are nitpicks deferred from PR #16 review that must not be left on the table.

## Summary

Two nitpicks from the PR #16 Claude review were not addressed before merge. This PR closes them rather than leaving them as silent technical debt.

## Changes

- `app/providers/fundamentals.py` — added inline comment to `shares_outstanding: int | None` noting the DB column must be BIGINT-scale; large-cap share counts (e.g. Apple ~15bn) exceed 32-bit INTEGER range
- `sql/001_init.sql` — added comment to `shares_outstanding NUMERIC(20,4)` column explaining why NUMERIC is used over INTEGER (handles large counts and fractional shares)
- `tests/test_provider_interfaces.py` — added comment to `TestNewsProviderIsAbstract` explaining why no concrete stub test exists, so future developers don't assume it was accidentally omitted

## Security model

No execution path touched. Comments and documentation only.

## Testing

- No logic changed — existing tests still pass
- CI green on push