### PR TITLE
fix: align project name and default DB name to 'ebull'

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -5,7 +5,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     app_env: str = "dev"
-    database_url: str = "postgresql://postgres:postgres@localhost:5432/trader_os"
+    database_url: str = "postgresql://postgres:postgres@localhost:5432/ebull"
 
     etoro_read_api_key: str | None = None
     etoro_write_api_key: str | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "trader-os"
+name = "ebull"
 version = "0.1.0"
 description = "Long-horizon AI-assisted investment engine for eToro"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- `pyproject.toml`: `name = "trader-os"` → `"ebull"`
- `app/config.py`: default `database_url` DB name `trader_os` → `ebull`

`trader-os` was the internal spec name from the original architecture docs. The GitHub repo, all branches, and all tooling already use `eBull`. This eliminates the low-grade identity drift flagged in a repo health review.

**No logic changes.** Anyone with an existing local `.env` file pointing at `trader_os` is unaffected — `database_url` is fully overridable via env var.

## Security model
No execution path changes.

## Pre-push checklist
- [x] `uv run ruff check .` — no issues
- [x] `uv run ruff format --check .` — no issues
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest tests/` — 112 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)