### PR TITLE
fix(#32): address post-merge warnings from PR review

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -274,8 +274,13 @@ def daily_thesis_refresh() -> None:
         logger.error("daily_thesis_refresh: ANTHROPIC_API_KEY not set, skipping")
         return
 
-    with psycopg.connect(settings.database_url) as conn:
-        stale = find_stale_instruments(conn, tier=1)
+    logger.info("daily_thesis_refresh: checking for stale Tier 1 instruments")
+    try:
+        with psycopg.connect(settings.database_url) as conn:
+            stale = find_stale_instruments(conn, tier=1)
+    except Exception:
+        logger.error("daily_thesis_refresh: failed to query stale instruments", exc_info=True)
+        return
 
     if not stale:
         logger.info("daily_thesis_refresh: no stale Tier 1 instruments found")

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -420,6 +420,21 @@ def _make_two_call_client(writer_json: dict, critic_json: dict) -> MagicMock:
 
 
 class TestGenerateThesis:
+    """
+    All tests in this class patch `_utcnow` to a fixed value so that
+    `_assemble_context`'s news cutoff calculation is deterministic.
+    Without this patch, tests that inject news rows with controlled
+    timestamps would fail non-deterministically when wall-clock time
+    diverges from _NOW.
+    """
+
+    def setup_method(self) -> None:
+        self._utcnow_patcher = patch("app.services.thesis._utcnow", return_value=_NOW)
+        self._utcnow_patcher.start()
+
+    def teardown_method(self) -> None:
+        self._utcnow_patcher.stop()
+
     def test_returns_thesis_result_with_correct_version(self) -> None:
         # INSERT RETURNING gives version=1
         conn = _make_conn(insert_returns_version=1)


### PR DESCRIPTION
## Summary

Two warnings from the final APPROVE review on PR #32 were not actioned before merge. This PR fixes both.

- **Scheduler error handling:** `daily_thesis_refresh` now wraps the initial `find_stale_instruments` DB call in `try/except` with `exc_info=True`. A connection failure previously propagated as an unhandled exception — it now logs an actionable error and returns cleanly.
- **Deterministic test clock:** `TestGenerateThesis` gains `setup_method`/`teardown_method` that pins `app.services.thesis._utcnow` to `_NOW` for every test in the class. `_assemble_context` uses `_utcnow()` to compute the 30-day news cutoff; without this patch, tests that inject news rows with controlled timestamps would fail non-deterministically as wall-clock time drifts.

## Security model

No new DB access patterns. The scheduler change only adds exception handling around an existing `psycopg.connect` call — no auth or query changes.

## Conscious tradeoffs

None. Both changes are strictly corrective.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 185 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)