### PR TITLE
chore: tighten merge gate and add self-review rules from review prevention notes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -138,74 +138,11 @@ wastes a review round.
 
 ## Self-review before pushing
 
-Before committing, open `git diff origin/HEAD` and read top to bottom. The review agent reads the same diff fresh, with no knowledge of intent. Match that posture — read what is there, not what you meant.
+Before committing, open `git diff origin/HEAD` and read top to bottom. The review agent reads the same diff fresh with no knowledge of intent — match that posture.
 
-### SQL — every query must pass these before push
+Full checklist with rules and examples: `.claude/skills/engineering/pre-push-checklist.md`
 
-**Determinism**
-- Every `fetchone()` call: does the query have `ORDER BY`? Without it the result row is non-deterministic.
-- Any query fetching "the latest" row: has both `ORDER BY <ts> DESC` and `LIMIT 1`.
-
-**Row access**
-- No `row[0]`, `row[1]` positional indexing on cursor results. Use `row_factory=psycopg.rows.dict_row` and access by name. Positional indexing silently corrupts if a column is ever added before the indexed column.
-
-**Atomic writes**
-- Any `MAX(...) + 1` version or sequence: computed as a scalar subquery inside VALUES, not a separate SELECT then INSERT. Two-step is a TOCTOU race.
-- Any `INSERT ... SELECT WHERE ...`: what happens when the WHERE matches zero rows? Trace it.
-
-**Transactions**
-- No network calls or file I/O inside `with conn.transaction()`. All I/O before the transaction.
-
-**NULL**
-- Any `col != 'value'` on a nullable column: NULLs are excluded silently. Decide and document.
-- Parameterised NULL equality: `col IS NOT DISTINCT FROM %s` (matches NULL). Parameterised NULL inequality: `col IS DISTINCT FROM %s` (excludes NULL). Neither uses bare `IS %s`.
-
-**Parameters**
-- No f-strings or `.format()` in SQL strings. Named params `%(name)s` with dicts.
-- `IN` clauses: `= ANY(%s)` with a list, not `IN %s` with a tuple.
-
-### Python — every file must pass these
-
-- Read-only sequence parameters: `Sequence[T]` not `list[T]`.
-- Bounded string values: `Literal["a", "b"]` not `str`. Defined once at module level.
-- `Optional[X]`: replace with `X | None`.
-- Dicts into jsonb columns: `Jsonb(my_dict)` not `json.dumps()`.
-- Imports: alphabetically sorted within each `from X import ...`; blank line between stdlib / third-party / first-party groups.
-
-### Tests — each test must prove something
-
-- Asserts on a specific value, not just `is not None`.
-- Boundary case exists: first row, zero results, failure path.
-- Any code that calls `_utcnow()` (directly or transitively): patches it.
-- Mocks match the real library's semantics — psycopg `fetchone()` returns `None` not a `MagicMock`.
-- Mock `spec=` set so unexpected attribute access raises, not silently returns another mock.
-
-### Sequential evaluation loops with shared resource limits
-
-In any loop that evaluates candidates against a shared resource constraint (position count, sector cap, cash):
-- Maintain a mutable accumulator updated after each approval, so each candidate is checked against held-state PLUS already-approved-this-pass state.
-- If the loop is split into phases (e.g. held instruments first, then unowned), add a comment at the phase boundary explaining that the ordering is load-bearing and why.
-- Before pushing: grep for all resource-check calls (e.g. `_sector_pct`) in the file and verify each one either receives a pending accumulator OR has an explicit ordering-dependency comment.
-
-### Error escalation from helpers called by orchestrators
-
-When a helper raises an exception and is called from an orchestrator with `except Exception`, a raise in the helper aborts the entire run with zero output. Prefer log-and-return in helpers for data-inconsistency cases, reserving raise for genuine programmer errors (invariant violations that cannot happen in correct code). Before pushing: trace every helper that raises — who catches it, and what is the failure scope?
-
-### Free-text dedup and log counts
-
-- Any dedup logic comparing free-text strings: the expected string must be derived from the same helper as the production code — never a hardcoded literal. A format change must propagate automatically.
-- Any "complete: total=N" log line after a filter step: split into `generated=N` and `written=M`. Compute N before the filter, M after.
-
-### Same-class-of-problem scan
-
-After fixing any instance of a problem, grep the whole file (and codebase if it's a pattern) for the same issue before pushing. Never assume the fix was isolated.
-
-| Found | Grep for |
-|---|---|
-| `fetchone()` without ORDER BY | every `fetchone()` call |
-| Positional `row[0]` | `\[[0-9]\]` on cursor results (covers all single-digit indices) |
-| `json.dumps` into jsonb | `json.dumps` in services/ |
-| `Optional[` or `Union[X, None]` | `Optional\[` and `Union\[` — replace all with `X \| None` |
-| `list[` read-only param | function signatures with `list[` |
-| `dict_row` added to one cursor | grep whole file — every cursor must use `dict_row`, not just the flagged one |
-| `_sector_pct` or similar resource check | all call sites — verify accumulator or ordering comment |
+Detailed standards by category:
+- SQL correctness: `.claude/skills/engineering/sql-correctness.md`
+- Python hygiene: `.claude/skills/engineering/python-hygiene.md`
+- Test quality: `.claude/skills/engineering/test-quality.md`

--- a/.claude/skills/engineering/pre-push-checklist.md
+++ b/.claude/skills/engineering/pre-push-checklist.md
@@ -1,0 +1,85 @@
+# pre-push-checklist
+
+Run before every push. No exceptions. No bypassing CI to "let it catch things."
+
+## Gate — all four must be green
+
+```
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+Fix failures before pushing. If `uv` is not on PATH, run `where uv` to find it and add to shell config.
+
+## Then read `git diff origin/HEAD` top to bottom
+
+Adopt the reviewer's posture: read what is there, not what you intended.
+
+---
+
+## SQL checks
+
+For every query in the diff:
+
+- [ ] `fetchone()` — is there an `ORDER BY`? Without it the result is non-deterministic
+- [ ] "Latest row" query — has both `ORDER BY <ts> DESC` and `LIMIT 1`?
+- [ ] Row access — `row["name"]` not `row[0]`? `dict_row` applied to all cursors in the file?
+- [ ] Sequence/version — `MAX()+1` inside a scalar subquery in VALUES, not a two-step SELECT then INSERT?
+- [ ] `INSERT ... SELECT WHERE` — what happens when WHERE matches zero rows? Trace the first-row case.
+- [ ] `conn.transaction()` — any network call or file I/O inside? Must not be.
+- [ ] Nullable column comparisons — `IS DISTINCT FROM` not `!=` when NULLs should be included?
+- [ ] Parameters — no f-strings, no `.format()` in SQL; `= ANY(%s)` not `IN %s`?
+
+---
+
+## Python checks
+
+- [ ] Read-only sequence params typed `Sequence[T]`, not `list[T]`?
+- [ ] Bounded string values typed as `Literal[...]`, defined once at module level?
+- [ ] `Optional[X]` replaced with `X | None`?
+- [ ] Dict passed to jsonb column wrapped with `Jsonb(...)`, not `json.dumps()`?
+- [ ] Imports alphabetically sorted within groups; stdlib / third-party / first-party separated by blank lines?
+- [ ] Sequential evaluation loop with a shared resource limit (position count, sector cap)? Accumulators updated after each approval?
+- [ ] Any helper that raises — who catches it? Does a raise here abort an entire orchestration run?
+- [ ] Any dedup on free-text strings — expected value derived from a helper, not a hardcoded literal?
+- [ ] Any "total=N" log line after a filter step — split into `generated=N written=M`?
+
+---
+
+## Test checks
+
+- [ ] Every test asserts a specific value, not just `is not None`?
+- [ ] Boundary cases covered: first row, zero results, failure path?
+- [ ] Any code calling `_utcnow()` — is it patched in the test?
+- [ ] Mocks: `fetchone()` returns `None` not `MagicMock`; `spec=` set on attribute-accessed mocks?
+- [ ] Free-text comparisons derived from helpers, not hardcoded?
+
+---
+
+## Same-class scan — after any fix
+
+| Found | Grep for |
+|---|---|
+| `fetchone()` without ORDER BY | every `fetchone()` in the file |
+| Positional `row[0]` | `\[[0-9]\]` on cursor results |
+| `json.dumps` into jsonb | `json.dumps` in services/ |
+| `Optional[` or `Union[` | `Optional\[` and `Union\[` |
+| `list[` read-only param | function signatures with `list[` |
+| `dict_row` added to one cursor | all cursor calls in the file |
+| Resource-check call (e.g. `_sector_pct`) | all call sites — accumulator or ordering comment? |
+
+---
+
+## Review comment handling
+
+After the review posts — read the **full body**, not just the verdict.
+
+- BLOCKING: fix before any further push
+- WARNING: fix on this PR, or open a `tech-debt` issue and put the number in the reply
+- NITPICK: fix if trivial; otherwise open a `tech-debt` issue and put the number in the reply
+- PREVENTION: extract each note to this file or the relevant skill before merging
+- Nothing silently discarded — every comment gets a reply
+
+**Merge gate:** APPROVE + all WARNINGs and NITPICKs resolved or issued + all PREVENTION notes extracted + CI green on the most recent commit.

--- a/.claude/skills/engineering/python-hygiene.md
+++ b/.claude/skills/engineering/python-hygiene.md
@@ -1,0 +1,117 @@
+# python-hygiene
+
+Engineering standard for Python code quality in this stack (Python 3.11+, Pydantic v2, psycopg3).
+
+## Type annotations
+
+**Sequence vs list for read-only parameters**
+```python
+# Wrong — implies the function may mutate the input
+def process(ids: list[int]) -> None: ...
+
+# Correct — read-only, accepts any sequence
+def process(ids: Sequence[int]) -> None: ...
+```
+Use `list[T]` only when the function appends, pops, or assigns into the parameter.
+
+**Literal for bounded string values**
+```python
+# Wrong — accepts any string
+action: str
+
+# Correct — validates at type-check time
+Action = Literal["BUY", "ADD", "HOLD", "EXIT"]
+action: Action
+```
+Define once at module level, import everywhere. No magic strings.
+
+**Optional/Union**
+```python
+# Wrong — verbose, pre-3.10 style
+from typing import Optional, Union
+x: Optional[str]
+y: Union[str, int]
+
+# Correct
+x: str | None
+y: str | int
+```
+
+**from __future__ import annotations**
+Add at the top of every new file for forward reference support.
+
+## JSONB columns
+
+```python
+# Wrong — psycopg3 cannot infer jsonb from a plain dict
+conn.execute("INSERT INTO t (data) VALUES (%s)", [{"key": "val"}])
+
+# Correct
+from psycopg.types.json import Jsonb
+conn.execute("INSERT INTO t (data) VALUES (%s)", [Jsonb({"key": "val"})])
+```
+
+## Imports
+
+Within each `from X import a, b, c`: names alphabetically sorted. Blank line between:
+1. stdlib
+2. third-party
+3. first-party
+
+Run `uv run ruff check --select I .` to verify. Any import sort violation fails CI.
+
+## Error escalation from helpers
+
+When a helper raises and is called from an orchestrator with `except Exception`, the raise aborts the entire run with zero output. For data-inconsistency cases (unexpected-but-recoverable), prefer log-and-return so partial results are produced. Reserve raise for genuine programmer errors — invariant violations that cannot occur in correct code.
+
+Before pushing any helper that raises: trace who catches it and what the failure scope is. If a single bad instrument would kill the whole batch run, that's the wrong failure mode.
+
+## Sequential evaluation loops with shared resource limits
+
+Any loop evaluating candidates against a shared constraint (position count, sector cap, cash) must maintain a mutable accumulator updated after each approval:
+
+```python
+pending_count: int = 0
+pending_sector_pct: dict[str, float] = {}
+
+for candidate in ranked:
+    ok, reason = _evaluate(candidate, ..., pending_count, pending_sector_pct)
+    if ok:
+        pending_count += 1
+        pending_sector_pct[sector] = pending_sector_pct.get(sector, 0.0) + alloc
+```
+
+Without this, each candidate is evaluated against the committed DB state only — approving 10 candidates in the same sector when the cap should have stopped at 5.
+
+If evaluation is split into phases (held instruments first, then unowned), add a comment at the phase boundary:
+```python
+# Evaluation order: held instruments (EXIT/ADD/HOLD) BEFORE unowned (BUY).
+# This ordering is load-bearing: <explain why correctness depends on it>.
+```
+
+Before pushing: grep for all resource-check calls in the file and verify each has either an accumulator parameter or an ordering-dependency comment.
+
+## Free-text dedup
+
+Any dedup logic that compares explanation/rationale strings must derive the expected string from the same helper as the production code — never a hardcoded literal:
+
+```python
+# Wrong — breaks silently when format changes
+prior_rationale = "No action trigger met; score=0.600 rank=2"
+
+# Correct — format change propagates automatically
+prior_rationale = _hold_rationale({"total_score": 0.60, "rank": 2}, quote_is_fallback=False)
+```
+
+## Log counts after filtering
+
+Any function with a "complete: total=N" log that follows a filter/dedup step must split counts:
+
+```python
+# Wrong — N includes suppressed HOLDs
+logger.info("complete: total=%d", len(recommendations))
+
+# Correct
+logger.info("complete: generated=%d written=%d", len(recommendations), written)
+```
+Compute `generated` before the filter, `written` after.

--- a/.claude/skills/engineering/sql-correctness.md
+++ b/.claude/skills/engineering/sql-correctness.md
@@ -1,0 +1,72 @@
+# sql-correctness
+
+Engineering standard for writing correct SQL in this stack (psycopg3 + PostgreSQL 16).
+
+## Atomic versioning — no two-step sequences
+
+Never compute a sequence value as a separate SELECT then INSERT. That's a TOCTOU race: two concurrent writers can read the same MAX and produce duplicate versions.
+
+**Wrong:**
+```python
+version = conn.execute("SELECT COALESCE(MAX(version), 0) + 1 FROM t WHERE id = %s", [id]).fetchone()[0]
+conn.execute("INSERT INTO t (id, version) VALUES (%s, %s)", [id, version])
+```
+
+**Correct — scalar subquery inside VALUES:**
+```sql
+INSERT INTO t (id, version, ...)
+VALUES (
+    %(id)s,
+    (SELECT COALESCE(MAX(version), 0) + 1 FROM t WHERE id = %(id)s),
+    ...
+)
+```
+
+This is atomic. COALESCE handles NULL from MAX on an empty table — always trace the first-row case.
+
+## INSERT ... SELECT zero-rows trap
+
+`INSERT INTO t SELECT ... FROM t WHERE condition` inserts zero rows silently when WHERE matches nothing. No error is raised. Always trace what happens on the very first row for a given key.
+
+## fetchone() requires ORDER BY
+
+Any `fetchone()` without an explicit `ORDER BY` returns a non-deterministic row. Any query for "the latest" row needs both `ORDER BY <timestamp> DESC` and `LIMIT 1`.
+
+After fixing a missing ORDER BY: grep the whole file for every `fetchone()` call — a partial fix is worse than none.
+
+## No positional row access
+
+`row[0]`, `row[1]` silently returns wrong data if a column is ever added before the indexed column. Use `row_factory=psycopg.rows.dict_row` and access by name: `row["column_name"]`.
+
+Apply `dict_row` consistently to every cursor in a file. A partial migration (some cursors named, some positional) is a latent bug. After switching one cursor, grep the file for `row[0]` and `row[1]`.
+
+## No I/O inside transactions
+
+No HTTP calls, no external API calls, no file reads inside `with conn.transaction()`. A slow or failed network call holds a DB lock for its duration.
+
+Pattern: do all I/O first, then open the transaction for the writes only.
+
+## NULL in comparisons
+
+`col != 'value'` excludes NULLs silently — they are neither equal nor not-equal. Decide whether NULLs should be included and use the right form:
+- Include NULLs: `col IS DISTINCT FROM 'value'`
+- Parameterised NULL equality: `col IS NOT DISTINCT FROM %s`
+- Never: `col IS %s` — illegal in psycopg3
+
+## Parameterisation
+
+- Named params: `%(name)s` with a dict
+- Positional params: `%s` with a list or tuple
+- Never f-strings or `.format()` in SQL strings — SQL injection vector
+- `IN` clauses: `= ANY(%s)` with a list, not `IN %s` with a tuple
+- Literal `%` in LIKE patterns: `%%`
+
+## Same-class scan after any fix
+
+| Found | Grep for |
+|---|---|
+| `fetchone()` missing ORDER BY | every `fetchone()` in the file |
+| Positional `row[0]` | `\[[0-9]\]` on cursor results |
+| `MAX(` in a two-step sequence | `MAX(` in service files |
+| `json.dumps` into jsonb | `json.dumps` in services/ |
+| `dict_row` added to one cursor | all cursor calls in the file |

--- a/.claude/skills/engineering/test-quality.md
+++ b/.claude/skills/engineering/test-quality.md
@@ -1,0 +1,77 @@
+# test-quality
+
+Engineering standard for writing tests that prove something. A test that doesn't assert observable behaviour is noise, not coverage.
+
+## A test must assert on a specific value
+
+```python
+# Noise — proves nothing except no crash
+def test_generate_thesis():
+    result = generate_thesis(...)
+    assert result is not None
+
+# Coverage — proves the contract
+def test_generate_thesis_returns_correct_version():
+    result = generate_thesis(...)
+    assert result.thesis_version == 1
+    assert result.stance == "buy"
+    assert result.confidence == pytest.approx(0.8)
+```
+
+## Mandatory boundary cases
+
+For every function, identify and test:
+- **First row / empty table** — does an INSERT using `MAX()` work when there are no prior rows?
+- **Zero results** — does a query returning a list handle the empty case without raising?
+- **None / null fields** — does optional data come back as `None`, not raise `AttributeError`?
+- **Failure path** — does a best-effort operation (API call, critic scoring) fail gracefully without blocking the happy path?
+
+These aren't edge cases. They're the first things a reviewer checks.
+
+## Mock discipline
+
+**Match what the real library returns.** psycopg `fetchone()` returns `None` on exhaustion — not a `MagicMock`. A mock that returns `MagicMock` instead of `None` will never trigger the None-check branch.
+
+**Use `spec=` on MagicMock** so accessing an unexpected attribute raises `AttributeError` rather than silently returning another mock:
+```python
+mock_conn = MagicMock(spec=psycopg.Connection)
+```
+
+**Patch at the point of use**, not the point of definition:
+```python
+# Wrong — patches the original, not where it's imported
+patch("datetime.datetime.now")
+
+# Correct — patches the name as used in the module under test
+patch("app.services.thesis._utcnow")
+```
+
+**SQL text-dispatch mocks** that match on substrings must document branch priority. INSERT branches must come before SELECT branches because a scalar subquery inside VALUES contains `SELECT ... FROM table` as a substring. Add a comment noting what structural SQL defects this matching approach cannot catch.
+
+## Time-dependent code
+
+Any function calling `_utcnow()` — directly or transitively — must have it patched in tests. If unsure whether a function calls it transitively, read the call chain. An unpatched `_utcnow()` makes the test non-deterministic.
+
+## Free-text comparisons
+
+Any test comparing a rationale or explanation string must derive the expected value from the same helper used in production — never a hardcoded literal:
+
+```python
+# Wrong — breaks silently when production format changes
+assert rec.rationale == "No action trigger met; score=0.600 rank=2"
+
+# Correct — format change propagates automatically
+assert rec.rationale == _hold_rationale(score_row, quote_is_fallback=False)
+```
+
+## DB write + return value consistency
+
+If a function both writes to the DB and returns a result object, there must be a test verifying the returned object matches what was written. Silent divergence between in-memory and persisted state is a real bug class.
+
+## Test naming
+
+Method names describe the scenario and expected outcome:
+- `test_first_thesis_gets_version_1` ✓
+- `test_insert` ✗
+
+No test longer than ~20 lines. If it's longer, the function under test probably does too much, or the test is testing too many things at once.


### PR DESCRIPTION
## Summary

- Adds four engineering practice skill files under `.claude/skills/engineering/` — discoverable alongside the domain skills, version-controlled, no ticket references, general principles only:
  - `pre-push-checklist.md` — full gate commands + per-category checks + same-class scan table + review comment handling
  - `sql-correctness.md` — ORDER BY on fetchone, positional row access, atomic versioning (TOCTOU), I/O in transactions, NULL handling, parameterisation
  - `python-hygiene.md` — Sequence/Literal/Jsonb, error escalation scope from helpers, sequential loop accumulators, free-text dedup, log count discipline
  - `test-quality.md` — behaviour assertions, boundary cases, mock discipline, time patching, free-text comparisons

- Slims CLAUDE.md: self-review section now references the skill files rather than duplicating content inline

- Tightens the merge gate (step 8): APPROVE alone is not sufficient — all WARNINGs and NITPICKs must be fixed or have tech-debt issue numbers, and all PREVENTION notes must be extracted before merging

## Security model

Documentation-only change. No functional code modified.

## Tradeoffs

Standards now live in `.claude/skills/engineering/` (visible, versionable, browsable) rather than buried in a long CLAUDE.md. The trade-off is that CLAUDE.md now has pointers rather than full content — acceptable because the skills load on demand and the pointers make them discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)