### PR TITLE
fix: rename trader-os to eBull in README and FastAPI title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,43 @@
-# trader-os
+# eBull
 
 Long-horizon AI-assisted investment engine for eToro.
 
-This starter repo is intentionally opinionated:
-- Python backend
+- Python backend with FastAPI
 - PostgreSQL as the system of record
 - Claude Code skills / agents / hooks for research and execution discipline
 - SQL-first schema for auditability
 - Demo-first, live-small-capital later
 
-## What this skeleton contains
+## Repo structure
 
-- `docs/` design and policy docs
-- `.claude/` project guidance, skills, agents, and hook notes
-- `sql/001_init.sql` initial Postgres schema
-- `app/` minimal Python service skeleton
-- `docker-compose.yml` for local Postgres
+- `app/` — services, providers, workers, and API
+- `sql/` — Postgres migrations (001–010)
+- `docs/` — architecture, scoring model, trading policy, tax engine
+- `.claude/` — project guidance, skills, agents, and hooks
+- `tests/` — pytest suite
+- `docker-compose.yml` — local Postgres
 
-## Suggested build order
+## Current state
 
-1. Create the database with `sql/001_init.sql`
-2. Read:
-   - `docs/architecture.md`
-   - `docs/scoring-model.md`
-   - `docs/trading-policy.md`
-   - `docs/tax-engine.md`
-3. Open `.claude/CLAUDE.md` in Claude Code
-4. Implement services in this order:
-   - universe sync
-   - market data
-   - filings
-   - thesis engine
-   - ranking engine
-   - portfolio manager
-   - execution guard
-   - tax ledger
-5. Use Demo keys before anything live
+Backend services implemented:
+- Universe sync
+- Market data (OHLCV, quotes, features)
+- Filings and fundamentals (SEC EDGAR, Companies House, FMP)
+- News and sentiment
+- Scoring and ranking engine
+- Portfolio manager
+- Execution guard
+
+Remaining backend:
+- Thesis engine (#6)
+- eToro order client (#10)
+- Tax ledger (#11)
+- Coverage tier management (#12)
+
+Not yet started:
+- API layer (REST endpoints for frontend)
+- Frontend / dashboard
+- Ops monitoring and admin controls
 
 ## Local setup
 
@@ -44,11 +46,6 @@ cp .env.example .env
 docker compose up -d
 ```
 
-This repo is a scaffold, not a production-ready trading system.
-You still need to implement:
-- eToro API client
-- filings/news/macro providers
-- job scheduling
-- actual order placement
-- reconciliation
-- proper tests
+## Build order
+
+See `.claude/CLAUDE.md` and `docs/architecture.md` for detailed guidance.

--- a/app/main.py
+++ b/app/main.py
@@ -24,7 +24,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     yield
 
 
-app = FastAPI(title="trader-os", version="0.1.0", lifespan=lifespan)
+app = FastAPI(title="eBull", version="0.1.0", lifespan=lifespan)
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary

- Renames `# trader-os` → `# eBull` in README.md heading
- Updates `FastAPI(title="trader-os")` → `FastAPI(title="eBull")` in `app/main.py`
- Replaces the stale scaffold description in README with a current-state summary listing implemented services, remaining backend work, and not-yet-started tracks

## Context

`docs/settled-decisions.md` records `eBull` as the canonical project name and `trader-os` as retired. These two files were the last public-facing references using the old name.

The README also still described the repo as a starter scaffold with a "you still need to implement" list, despite 10 migrations and 11 services already being built. Updated to reflect reality.

## Security model

No security implications. Doc and title string changes only.

## Test plan

- [x] `uv run ruff check .` — pass
- [x] `uv run ruff format --check .` — pass
- [x] `uv run pyright` — pass
- [x] `uv run pytest` — 349 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)