### PR TITLE
fix: reduce review workflow noise with incremental diff and output rules

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,10 +30,17 @@ jobs:
           EVENT_ACTION: ${{ github.event.action }}
         run: |
           if [ "$EVENT_ACTION" = "synchronize" ] && [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
-            git diff "$BEFORE_SHA"..HEAD > incremental.diff 2>/dev/null || echo "(incremental diff unavailable)" > incremental.diff
-            echo "Incremental diff: $(wc -l < incremental.diff) lines"
+            if git diff "$BEFORE_SHA"..HEAD > incremental.diff 2>&1; then
+              echo "has_incremental=true" > incremental_flag.txt
+              echo "Incremental diff: $(wc -l < incremental.diff) lines"
+            else
+              echo "::warning::git diff $BEFORE_SHA..HEAD failed — falling back to full diff only"
+              echo "has_incremental=false" > incremental_flag.txt
+              : > incremental.diff
+            fi
           else
-            echo "(first review — no incremental diff available)" > incremental.diff
+            echo "has_incremental=false" > incremental_flag.txt
+            : > incremental.diff
           fi
 
       - name: Get PR description
@@ -78,6 +85,7 @@ jobs:
 
           diff = open('pr.diff', encoding='utf-8', errors='replace').read()
           incremental = open('incremental.diff', encoding='utf-8', errors='replace').read()
+          flag = open('incremental_flag.txt').read().strip()
           desc = open('pr_desc.txt').read()
           comments_raw = open('pr_comments.txt').read().strip()
           issue = open('linked_issue.txt').read().strip()
@@ -89,8 +97,8 @@ jobs:
 
           issue_section = "## Linked Issue / Ticket\n\n" + issue
 
-          # Build the incremental diff section
-          has_incremental = not incremental.startswith("(")
+          # Flag file written by shell step — no string-matching heuristic
+          has_incremental = flag == "has_incremental=true"
           incremental_section = ""
           if has_incremental:
               incremental_section = (


### PR DESCRIPTION
## What changed

Four improvements to `.github/workflows/claude-review.yml` to reduce false positives and wasted review cycles.

### 1. Incremental diff on follow-up pushes

On `synchronize` events, the workflow now generates `git diff <before>..HEAD` alongside the full PR diff. The reviewer prompt instructs it to **focus on the incremental changes** and use the full diff only for context. On first review (`opened`/`ready_for_review`), only the full diff is shown — no change to first-review behavior.

### 2. Stronger output rules — no withdrawn investigations

New "Output rules" section replaces the old format instructions. Key addition: "Think before you write. If you determine during analysis that an issue is not real, is already fixed, or should be withdrawn — do NOT include it in the output at all."

Previously, the reviewer would write multi-paragraph investigations under BLOCKING headers, then conclude "Withdrawing." This wasted tokens and reader time. The new instruction eliminates this pattern.

### 3. Comment history guidance

Explicit instruction that fixes requested by a previous review round are not "silent reverts." The most recent review+response pair represents the current discussion state. The old instruction ("Do NOT re-raise issues already addressed") was too weak — the reviewer would re-raise issues with different framing.

### 4. Product name fix

`trader-os` → `eBull` in the system prompt. Aligns with the canonical product name in `docs/settled-decisions.md`.

## Why

PR #66 required 5 review rounds. Rounds 3-4 exhibited:
- Re-raised issues that were already fixed (unchanged code re-evaluated)
- Multi-paragraph withdrawn investigations under BLOCKING headers (3 in round 5 alone)
- A round-3-requested fix misidentified as a "silent revert" of the round-2 fix (comment history confusion)

These changes target the root causes without reducing review coverage — the full diff is still available for context, and all severity levels are still checked.

## Security model

No auth or secret changes. The workflow still uses `secrets.ANTHROPIC_API_KEY` and `secrets.GITHUB_TOKEN` with the same `read` + `write` permissions.

## Test plan

- [ ] Open a PR with an initial push — verify review runs normally (no incremental diff, full diff only)
- [ ] Push a follow-up commit — verify incremental diff appears in the review prompt and the reviewer focuses on new changes
- [ ] Confirm the reviewer does not include withdrawn investigations under severity headings