### PR TITLE
fix: review prompt — ban findings-then-retract pattern

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -124,6 +124,23 @@ jobs:
               "- Do not explain how the code works — the author wrote it\n"
               "- Do not re-raise issues resolved in the comment history\n"
               "- Do not flag: unchanged code, intentional removals explained in PR, demo/dry-run safe defaults\n\n"
+
+              "## Verify before posting — no retractions\n"
+              "For every finding you draft, verify it against the diff, the PR description, "
+              "and your knowledge of the stack BEFORE assigning a severity. If verification "
+              "shows the finding is wrong or the author has already explained it, **delete the "
+              "finding entirely**. Do not post it with a retraction.\n\n"
+              "Severity is a commitment, not a draft. BLOCKING means: 'I have verified this is "
+              "wrong and it must be fixed before merge.' If you are not sure, it is not BLOCKING.\n\n"
+              "**Banned phrases** — if you would write any of these, delete the finding instead:\n"
+              "- 'Actually, ...' / 'On second thought ...' / 'Wait, ...'\n"
+              "- 'Withdrawing' / 'Retracting' / 'Never mind'\n"
+              "- 'Not a real issue' / 'Not actually a problem'\n"
+              "- 'After inspecting ... this is fine'\n"
+              "- Any sentence that contradicts an earlier sentence in the same finding\n"
+              "Each finding must be a single, committed claim. No narration of your own "
+              "verification process. The author should never see a BLOCKING that ends in "
+              "'withdrawing'.\n\n"
           )
 
           if has_incremental:
@@ -145,7 +162,8 @@ jobs:
               "## Output format\n\n"
               "**Be terse.** Do all reasoning internally. Only output findings and verdict. "
               "One sentence per item. No preamble, no analysis narrative, no restating what the code does.\n\n"
-              "If an issue is not real after analysis, do not include it at all.\n"
+              "**If an issue is not real after analysis, do not include it at all.** This is "
+              "non-negotiable. Do not post a finding and then retract it in the same comment.\n"
               "Only include a section if it has items. No empty sections.\n\n"
               "### [BLOCKING] — must fix before merge\n"
               "`file:line` — what is wrong (one sentence). Omit section if none.\n\n"


### PR DESCRIPTION
## Summary

The Claude review workflow has been posting findings and retracting them in the same comment body. Most recently in #81:

> ### [BLOCKING]
> `app/api/auth.py:57` — `settings.api_key` is read at call time ... if `credentials.credentials` is ever bytes ... this will raise `TypeError` rather than returning 401 ...
>
> Actually, inspecting Starlette source: `credentials` is always `str`. Withdrawing — not a real issue.

This wastes author attention and forces a `REBUTTED` reply through the strict resolution contract even when both parties agreed the finding was wrong before it was posted. It happened **twice in the same review** on #81.

The previous prompt already contained "If an issue is not real after analysis, do not include it at all" — but the model ignored it because it wasn't framed as a hard rule.

## What this changes

Only `.github/workflows/claude-review.yml`. No code changes.

1. **New "Verify before posting — no retractions" section** spelling out that severity is a commitment, not a draft, and findings must be **deleted** (not retracted) when verification refutes them. BLOCKING means "I have verified this is wrong and it must be fixed before merge."
2. **Banned-phrase list** that the model is told to treat as a deletion trigger:
   - "Actually...", "On second thought...", "Wait..."
   - "Withdrawing", "Retracting", "Never mind"
   - "Not a real issue", "Not actually a problem"
   - "After inspecting ... this is fine"
   - Any sentence that contradicts an earlier sentence in the same finding
3. **Strengthened the existing output-format line** so it reads "**This is non-negotiable. Do not post a finding and then retract it in the same comment.**"

## Why a banned-phrase list

LLMs ignore soft "be terse" instructions but reliably notice explicit phrase bans. This is the same lever the existing prompt already uses for "no preamble" and "no analysis narrative" — it just wasn't applied to retractions.

## Out of scope

- Restructuring the review into multi-turn (verify → emit). That would be the principled fix but is a much larger change to the workflow.
- Changing the resolution contract in CLAUDE.md. The contract is correct; the problem is upstream.

## Validation

- YAML parses (`yaml.safe_load`)
- Embedded `build_prompt.py` heredoc parses (`ast.parse`)
- No Python code paths touched, so the existing test suite is unaffected

## Test plan

- [x] Workflow YAML is valid
- [x] Embedded Python script still parses
- [ ] Observe next 2-3 review rounds on real PRs to confirm no more retraction comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)