### PR TITLE
feat(#139): frontend two-key credentials + test connection (PR D)

### DIFF
--- a/frontend/src/api/brokerCredentials.ts
+++ b/frontend/src/api/brokerCredentials.ts
@@ -20,6 +20,7 @@ export interface BrokerCredentialView {
   id: string;
   provider: BrokerProvider;
   label: string;
+  environment: string;
   last_four: string;
   created_at: string;
   last_used_at: string | null;
@@ -55,6 +56,7 @@ export interface CreateBrokerCredentialResponse {
 export function createBrokerCredential(input: {
   provider: BrokerProvider;
   label: string;
+  environment: string;
   secret: string;
 }): Promise<CreateBrokerCredentialResponse> {
   return apiFetch<CreateBrokerCredentialResponse>("/broker-credentials", {
@@ -65,4 +67,37 @@ export function createBrokerCredential(input: {
 
 export function revokeBrokerCredential(id: string): Promise<void> {
   return apiFetch<void>(`/broker-credentials/${id}`, { method: "DELETE" });
+}
+
+// ---------------------------------------------------------------------------
+// Validate (transient probe — nothing is persisted)
+// ---------------------------------------------------------------------------
+
+export interface ValidateIdentity {
+  gcid: number | null;
+  demo_cid: number | null;
+  real_cid: number | null;
+}
+
+export interface ValidateCredentialResponse {
+  auth_valid: boolean;
+  identity: ValidateIdentity | null;
+  environment: string;
+  env_valid: boolean;
+  env_check: string;
+  note: string;
+}
+
+export function validateBrokerCredential(input: {
+  api_key: string;
+  user_key: string;
+  environment: string;
+}): Promise<ValidateCredentialResponse> {
+  return apiFetch<ValidateCredentialResponse>(
+    "/broker-credentials/validate",
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+  );
 }

--- a/frontend/src/components/broker/ValidationResultDisplay.tsx
+++ b/frontend/src/components/broker/ValidationResultDisplay.tsx
@@ -1,0 +1,55 @@
+import type { ValidateCredentialResponse } from "@/api/brokerCredentials";
+
+export function ValidationResultDisplay({
+  result,
+  error,
+}: {
+  result: ValidateCredentialResponse | null;
+  error: string | null;
+}): JSX.Element | null {
+  if (error !== null) {
+    return (
+      <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
+        {error}
+      </div>
+    );
+  }
+  if (result === null) return null;
+
+  if (!result.auth_valid) {
+    return (
+      <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
+        Authentication failed — check your API key and user key.
+      </div>
+    );
+  }
+
+  if (!result.env_valid) {
+    return (
+      <div className="space-y-1">
+        <div className="rounded bg-amber-50 px-2 py-1.5 text-xs text-amber-700">
+          Authenticated, but environment check failed: {result.env_check}
+        </div>
+        {result.note && (
+          <p className="text-xs text-slate-400">{result.note}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="rounded bg-emerald-50 px-2 py-1.5 text-xs text-emerald-700">
+        Connection verified
+        {result.identity?.gcid != null && (
+          <span className="ml-1 text-emerald-600">
+            (account {result.identity.gcid})
+          </span>
+        )}
+      </div>
+      {result.note && (
+        <p className="text-xs text-slate-400">{result.note}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/credentialSetMode.ts
+++ b/frontend/src/lib/credentialSetMode.ts
@@ -1,0 +1,35 @@
+/**
+ * Credential-set mode detection for the eToro two-key model.
+ *
+ * Shared between SettingsPage and SetupPage. The eToro provider
+ * requires exactly two active credential rows (label="api_key" and
+ * label="user_key") for provider="etoro" in a given environment.
+ * This function inspects the loaded credential list to derive the
+ * current UI mode.
+ */
+
+import type { BrokerCredentialView } from "@/api/brokerCredentials";
+
+export type CredentialSetMode = "create" | "repair" | "complete";
+
+export const ENVIRONMENT = "demo";
+
+export function deriveCredentialSetMode(
+  rows: BrokerCredentialView[] | null,
+): { mode: CredentialSetMode; missingLabel: "api_key" | "user_key" | null } {
+  if (rows === null) return { mode: "create", missingLabel: null };
+
+  const active = rows.filter(
+    (r) =>
+      r.provider === "etoro" &&
+      r.environment === ENVIRONMENT &&
+      r.revoked_at === null,
+  );
+  const hasApiKey = active.some((r) => r.label === "api_key");
+  const hasUserKey = active.some((r) => r.label === "user_key");
+
+  if (hasApiKey && hasUserKey) return { mode: "complete", missingLabel: null };
+  if (hasApiKey) return { mode: "repair", missingLabel: "user_key" };
+  if (hasUserKey) return { mode: "repair", missingLabel: "api_key" };
+  return { mode: "create", missingLabel: null };
+}

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -1,16 +1,15 @@
 /**
- * Tests for SettingsPage broker-credentials first-save flow (#121).
+ * Tests for SettingsPage broker-credentials section (#121, updated
+ * #139 PR D for two-key credential model).
  *
  * Scope:
- *   - empty state visible when no credentials exist
- *   - first save returning a recovery_phrase opens the confirmation modal
- *   - subsequent save returning no recovery_phrase does NOT open the modal
- *   - challenge confirm closes the modal and refreshes the list
- *   - operator-initiated cancel routes through the confirm-cancel gate
- *   - Escape inside the modal also routes through the confirm-cancel gate
- *   - "Go back" from the gate returns to the phrase view
- *   - "Close anyway" closes the modal and clears the phrase
- *   - backend save failure surfaces an error and does NOT open the modal
+ *   - Credential-set mode detection (Create / Repair / Complete)
+ *   - Two-key form: API key + user key fields, no label/secret fields
+ *   - Two sequential createBrokerCredential calls on save
+ *   - Test connection button behaviour and validation display
+ *   - Recovery phrase modal flow (unchanged from #121)
+ *   - Partial-save recovery (first key saved, second failed → Repair)
+ *   - Revoke updates the credential list and can re-enable the form
  *
  * The API client is mocked at the module boundary so tests do not hit
  * the network. The phrase fixture is the same alphabet used in the
@@ -27,6 +26,7 @@ import {
   createBrokerCredential,
   listBrokerCredentials,
   revokeBrokerCredential,
+  validateBrokerCredential,
 } from "@/api/brokerCredentials";
 import { ApiError } from "@/api/client";
 
@@ -34,50 +34,41 @@ vi.mock("@/api/brokerCredentials", () => ({
   listBrokerCredentials: vi.fn(),
   createBrokerCredential: vi.fn(),
   revokeBrokerCredential: vi.fn(),
+  validateBrokerCredential: vi.fn(),
 }));
 
 const mockedList = vi.mocked(listBrokerCredentials);
 const mockedCreate = vi.mocked(createBrokerCredential);
 const mockedRevoke = vi.mocked(revokeBrokerCredential);
+const mockedValidate = vi.mocked(validateBrokerCredential);
 
 const PHRASE: readonly string[] = [
-  "alpha",
-  "bravo",
-  "charlie",
-  "delta",
-  "echo",
-  "foxtrot",
-  "golf",
-  "hotel",
-  "india",
-  "juliet",
-  "kilo",
-  "lima",
-  "mike",
-  "november",
-  "oscar",
-  "papa",
-  "quebec",
-  "romeo",
-  "sierra",
-  "tango",
-  "uniform",
-  "victor",
-  "whiskey",
-  "xray",
+  "alpha", "bravo", "charlie", "delta", "echo", "foxtrot",
+  "golf", "hotel", "india", "juliet", "kilo", "lima",
+  "mike", "november", "oscar", "papa", "quebec", "romeo",
+  "sierra", "tango", "uniform", "victor", "whiskey", "xray",
 ];
 
 function makeRow(overrides: Partial<BrokerCredentialView> = {}): BrokerCredentialView {
   return {
     id: "11111111-1111-1111-1111-111111111111",
     provider: "etoro",
-    label: "primary",
+    label: "api_key",
+    environment: "demo",
     last_four: "1234",
     created_at: "2026-04-08T00:00:00Z",
     last_used_at: null,
     revoked_at: null,
     ...overrides,
   };
+}
+
+function apiKeyRow(): BrokerCredentialView {
+  return makeRow({ id: "aaaa-1111", label: "api_key", last_four: "aaaa" });
+}
+
+function userKeyRow(): BrokerCredentialView {
+  return makeRow({ id: "bbbb-2222", label: "user_key", last_four: "bbbb" });
 }
 
 function withPhrase(): CreateBrokerCredentialResponse {
@@ -88,10 +79,10 @@ function withoutPhrase(): CreateBrokerCredentialResponse {
   return { credential: makeRow(), recovery_phrase: null };
 }
 
-async function fillAndSubmit(label: string, secret: string): Promise<void> {
+async function fillAndSubmit(apiKey: string, userKey: string): Promise<void> {
   const user = userEvent.setup();
-  await user.type(screen.getByLabelText("Label"), label);
-  await user.type(screen.getByLabelText("Secret"), secret);
+  await user.type(screen.getByLabelText("API key"), apiKey);
+  await user.type(screen.getByLabelText("User key"), userKey);
   await user.click(screen.getByRole("button", { name: /save credential/i }));
 }
 
@@ -117,6 +108,7 @@ beforeEach(() => {
   mockedList.mockReset();
   mockedCreate.mockReset();
   mockedRevoke.mockReset();
+  mockedValidate.mockReset();
   mockedList.mockResolvedValue([]);
 });
 
@@ -124,101 +116,245 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("SettingsPage — broker credentials empty state", () => {
-  it("shows the empty-state message when no credentials are saved", async () => {
+// ---------------------------------------------------------------------------
+// Credential-set mode detection
+// ---------------------------------------------------------------------------
+
+describe("SettingsPage — credential-set modes", () => {
+  it("shows both key fields when no credentials exist (Create mode)", async () => {
     render(<SettingsPage />);
+    await screen.findByText(/No broker credentials saved yet/i);
+    expect(screen.getByLabelText("API key")).toBeInTheDocument();
+    expect(screen.getByLabelText("User key")).toBeInTheDocument();
+  });
+
+  it("shows only the missing field when one key exists (Repair mode)", async () => {
+    mockedList.mockResolvedValueOnce([apiKeyRow()]);
+    render(<SettingsPage />);
+    await screen.findByText("api_key");
+    // api_key exists, so only user_key field should be shown.
+    expect(screen.queryByLabelText("API key")).toBeNull();
+    expect(screen.getByLabelText("User key")).toBeInTheDocument();
+    expect(screen.getByText(/One key was already saved/i)).toBeInTheDocument();
+  });
+
+  it("hides the create form when both keys exist (Complete mode)", async () => {
+    mockedList.mockResolvedValueOnce([apiKeyRow(), userKeyRow()]);
+    render(<SettingsPage />);
+    await screen.findByText("api_key");
+    expect(screen.getByText(/Credentials configured/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText("API key")).toBeNull();
+    expect(screen.queryByLabelText("User key")).toBeNull();
+  });
+
+  it("shows environment in the credential list", async () => {
+    mockedList.mockResolvedValueOnce([apiKeyRow()]);
+    render(<SettingsPage />);
+    expect(await screen.findByText(/demo/)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test connection
+// ---------------------------------------------------------------------------
+
+describe("SettingsPage — test connection", () => {
+  it("calls validateBrokerCredential and shows success result", async () => {
+    const user = userEvent.setup();
+    mockedValidate.mockResolvedValueOnce({
+      auth_valid: true,
+      identity: { gcid: 12345, demo_cid: 67890, real_cid: null },
+      environment: "demo",
+      env_valid: true,
+      env_check: "ok",
+      note: "Does not verify write permission.",
+    });
+
+    render(<SettingsPage />);
+    await screen.findByText(/No broker credentials saved yet/i);
+    await userEvent.setup().type(screen.getByLabelText("API key"), "test-api-key");
+    await user.type(screen.getByLabelText("User key"), "test-user-key");
+    await user.click(screen.getByRole("button", { name: /test connection/i }));
+
+    expect(await screen.findByText(/Connection verified/i)).toBeInTheDocument();
+    expect(screen.getByText(/account 12345/i)).toBeInTheDocument();
+    // note shown as supplementary text, not as the primary message.
+    expect(screen.getByText(/Does not verify write permission/i)).toBeInTheDocument();
+  });
+
+  it("shows auth failure without using note as error message", async () => {
+    const user = userEvent.setup();
+    mockedValidate.mockResolvedValueOnce({
+      auth_valid: false,
+      identity: null,
+      environment: "demo",
+      env_valid: false,
+      env_check: "skipped",
+      note: "Connection to eToro failed",
+    });
+
+    render(<SettingsPage />);
+    await screen.findByText(/No broker credentials saved yet/i);
+    await user.type(screen.getByLabelText("API key"), "bad-api-key");
+    await user.type(screen.getByLabelText("User key"), "bad-user-key");
+    await user.click(screen.getByRole("button", { name: /test connection/i }));
+
     expect(
-      await screen.findByText(/No broker credentials saved yet/i),
+      await screen.findByText(/Authentication failed/i),
+    ).toBeInTheDocument();
+    // note should NOT be shown as the primary error.
+    expect(screen.queryByText(/Connection to eToro failed/i)).toBeNull();
+  });
+
+  it("shows environment check failure as amber warning", async () => {
+    const user = userEvent.setup();
+    mockedValidate.mockResolvedValueOnce({
+      auth_valid: true,
+      identity: { gcid: 12345, demo_cid: null, real_cid: null },
+      environment: "demo",
+      env_valid: false,
+      env_check: "403 Forbidden",
+      note: "Does not verify write permission.",
+    });
+
+    render(<SettingsPage />);
+    await screen.findByText(/No broker credentials saved yet/i);
+    await user.type(screen.getByLabelText("API key"), "test-api-key");
+    await user.type(screen.getByLabelText("User key"), "test-user-key");
+    await user.click(screen.getByRole("button", { name: /test connection/i }));
+
+    expect(
+      await screen.findByText(/environment check failed/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/403 Forbidden/)).toBeInTheDocument();
+  });
+
+  it("disables Test connection in Repair mode", async () => {
+    mockedList.mockResolvedValueOnce([apiKeyRow()]);
+    render(<SettingsPage />);
+    await screen.findByText("api_key");
+
+    const btn = screen.getByRole("button", { name: /test connection/i });
+    expect(btn).toBeDisabled();
+    expect(
+      screen.getByText(/Connection testing requires both keys/i),
     ).toBeInTheDocument();
   });
 });
 
-describe("SettingsPage — first-save recovery phrase modal", () => {
-  it("clears any prior createError before opening the phrase modal on a successful save", async () => {
-    // Regression for PR #125 round 2 review: a stale createError from
-    // a prior failed attempt must not remain visible behind the
-    // closed modal alongside a fresh loadError. Here we ensure the
-    // close path zeroes out createError so the operator never sees
-    // two unrelated error messages stacked together.
-    const user = userEvent.setup();
+// ---------------------------------------------------------------------------
+// Two-key save flow
+// ---------------------------------------------------------------------------
+
+describe("SettingsPage — two-key save", () => {
+  it("creates both api_key and user_key rows on save in Create mode", async () => {
     mockedCreate
-      .mockRejectedValueOnce(new ApiError(409, "conflict"))
-      .mockResolvedValueOnce(withPhrase());
-    mockedList.mockResolvedValueOnce([]).mockResolvedValueOnce([makeRow()]);
+      .mockResolvedValueOnce(withoutPhrase())
+      .mockResolvedValueOnce(withoutPhrase());
+    mockedList
+      .mockResolvedValueOnce([])                           // initial load
+      .mockResolvedValueOnce([apiKeyRow(), userKeyRow()]); // refresh after save
 
     render(<SettingsPage />);
     await screen.findByText(/No broker credentials saved yet/i);
-    await fillAndSubmit("primary", "secret-value-1234");
-    expect(
-      await screen.findByText(/credential with that label already exists/i),
-    ).toBeInTheDocument();
+    await fillAndSubmit("test-api-key", "test-user-key");
 
-    // Second submit succeeds and opens the modal.
-    await user.click(screen.getByRole("button", { name: /save credential/i }));
-    await screen.findByRole("dialog");
-
-    // Pass the challenge — closePhraseModal must clear createError.
-    await advancePastWrittenDownGate();
-    await answerChallengeCorrectly();
     await waitFor(() => {
-      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(mockedCreate).toHaveBeenCalledTimes(2);
     });
-    expect(
-      screen.queryByText(/credential with that label already exists/i),
-    ).toBeNull();
+    expect(mockedCreate).toHaveBeenNthCalledWith(1, {
+      provider: "etoro",
+      label: "api_key",
+      environment: "demo",
+      secret: "test-api-key",
+    });
+    expect(mockedCreate).toHaveBeenNthCalledWith(2, {
+      provider: "etoro",
+      label: "user_key",
+      environment: "demo",
+      secret: "test-user-key",
+    });
   });
 
-  it("exposes the phrase modal with a single stable accessible name across both inner views", async () => {
-    // Regression for PR #125 round 2 review: previously the dialog
-    // wired aria-labelledby to either an sr-only span (in the confirm
-    // view) or an h2 (in the confirm-cancel view). Switching to
-    // aria-label means the dialog has ONE accessible name regardless
-    // of which inner view is active.
+  it("creates only the missing key in Repair mode", async () => {
+    mockedList.mockResolvedValueOnce([apiKeyRow()]);
+    mockedCreate.mockResolvedValueOnce(withoutPhrase());
+
+    render(<SettingsPage />);
+    await screen.findByText("api_key");
+
     const user = userEvent.setup();
-    mockedCreate.mockResolvedValueOnce(withPhrase());
-    render(<SettingsPage />);
-    await screen.findByText(/No broker credentials saved yet/i);
-    await fillAndSubmit("primary", "secret-value-1234");
+    await user.type(screen.getByLabelText("User key"), "test-user-key");
+    await user.click(screen.getByRole("button", { name: /save credential/i }));
 
-    const dialog = await screen.findByRole("dialog", {
-      name: "Recovery phrase confirmation",
+    await waitFor(() => {
+      expect(mockedCreate).toHaveBeenCalledTimes(1);
     });
-    expect(dialog).toHaveAttribute("aria-label", "Recovery phrase confirmation");
-    expect(dialog).not.toHaveAttribute("aria-labelledby");
-
-    // Switch to confirm-cancel view and re-assert the same name.
-    await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
-    expect(
-      screen.getByRole("dialog", { name: "Recovery phrase confirmation" }),
-    ).toBeInTheDocument();
+    expect(mockedCreate).toHaveBeenCalledWith({
+      provider: "etoro",
+      label: "user_key",
+      environment: "demo",
+      secret: "test-user-key",
+    });
   });
 
-  it("opens the modal when the create response carries a recovery_phrase", async () => {
-    mockedCreate.mockResolvedValueOnce(withPhrase());
-    mockedList.mockResolvedValueOnce([]).mockResolvedValueOnce([makeRow()]);
+  it("enters Repair mode when first save succeeds but second fails", async () => {
+    mockedCreate
+      .mockResolvedValueOnce(withoutPhrase())
+      .mockRejectedValueOnce(new Error("boom"));
+    // Initial load: empty. After error refresh: api_key exists.
+    mockedList
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([apiKeyRow()]);
 
     render(<SettingsPage />);
     await screen.findByText(/No broker credentials saved yet/i);
-    await fillAndSubmit("primary", "secret-value-1234");
+    await fillAndSubmit("test-api-key", "test-user-key");
+
+    // Error surfaced.
+    expect(await screen.findByText(/Could not save credential/i)).toBeInTheDocument();
+    // Re-derived to Repair mode: only user_key field visible.
+    await waitFor(() => {
+      expect(screen.queryByLabelText("API key")).toBeNull();
+    });
+    expect(screen.getByLabelText("User key")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Recovery phrase modal (inherited from #121, updated for two-key)
+// ---------------------------------------------------------------------------
+
+describe("SettingsPage — recovery phrase modal", () => {
+  it("opens the modal when the first create response carries a recovery_phrase", async () => {
+    mockedCreate
+      .mockResolvedValueOnce(withPhrase())   // api_key
+      .mockResolvedValueOnce(withoutPhrase()); // user_key
+    mockedList
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([apiKeyRow(), userKeyRow()]);
+
+    render(<SettingsPage />);
+    await screen.findByText(/No broker credentials saved yet/i);
+    await fillAndSubmit("test-api-key", "test-user-key");
 
     const dialog = await screen.findByRole("dialog");
     expect(dialog).toHaveAttribute("aria-modal", "true");
-    expect(
-      within(dialog).getByText(/Write down your recovery phrase/i),
-    ).toBeInTheDocument();
-    // List refresh is DEFERRED until the modal closes -- review
-    // feedback PR #125 round 1. Only the initial mount fetch should
-    // have fired so far.
-    expect(mockedList).toHaveBeenCalledTimes(1);
+    // Both credentials should be saved before the modal opens.
+    expect(mockedCreate).toHaveBeenCalledTimes(2);
   });
 
   it("does NOT open the modal when create returns no recovery_phrase", async () => {
-    mockedCreate.mockResolvedValueOnce(withoutPhrase());
-    mockedList.mockResolvedValueOnce([]).mockResolvedValueOnce([makeRow()]);
+    mockedCreate
+      .mockResolvedValueOnce(withoutPhrase())
+      .mockResolvedValueOnce(withoutPhrase());
+    mockedList
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([apiKeyRow(), userKeyRow()]);
 
     render(<SettingsPage />);
     await screen.findByText(/No broker credentials saved yet/i);
-    await fillAndSubmit("primary", "secret-value-1234");
+    await fillAndSubmit("test-api-key", "test-user-key");
 
     await waitFor(() => {
       expect(mockedList).toHaveBeenCalledTimes(2);
@@ -226,15 +362,18 @@ describe("SettingsPage — first-save recovery phrase modal", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  it("closes the modal and runs the deferred list refresh after the challenge passes", async () => {
-    mockedCreate.mockResolvedValueOnce(withPhrase());
-    mockedList.mockResolvedValueOnce([]).mockResolvedValueOnce([makeRow()]);
+  it("closes the modal and refreshes the list after challenge passes", async () => {
+    mockedCreate
+      .mockResolvedValueOnce(withPhrase())
+      .mockResolvedValueOnce(withoutPhrase());
+    mockedList
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([apiKeyRow(), userKeyRow()]);
 
     render(<SettingsPage />);
     await screen.findByText(/No broker credentials saved yet/i);
-    await fillAndSubmit("primary", "secret-value-1234");
+    await fillAndSubmit("test-api-key", "test-user-key");
     await screen.findByRole("dialog");
-    expect(mockedList).toHaveBeenCalledTimes(1);
 
     await advancePastWrittenDownGate();
     await answerChallengeCorrectly();
@@ -242,81 +381,46 @@ describe("SettingsPage — first-save recovery phrase modal", () => {
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).toBeNull();
     });
-    // The deferred refresh runs after the modal closes, so any
-    // refresh failure surfaces to the operator instead of being
-    // hidden behind the modal.
     await waitFor(() => {
       expect(mockedList).toHaveBeenCalledTimes(2);
     });
   });
 });
 
+// ---------------------------------------------------------------------------
+// Phrase modal cancel gate
+// ---------------------------------------------------------------------------
+
 describe("SettingsPage — phrase modal cancel gate", () => {
-  it("routes Cancel through the confirm-cancel warning, not silent dismissal", async () => {
+  it("routes Cancel through the confirm-cancel warning", async () => {
     const user = userEvent.setup();
-    mockedCreate.mockResolvedValueOnce(withPhrase());
-    mockedList.mockResolvedValueOnce([]).mockResolvedValueOnce([makeRow()]);
+    mockedCreate
+      .mockResolvedValueOnce(withPhrase())
+      .mockResolvedValueOnce(withoutPhrase());
+    mockedList.mockResolvedValueOnce([]).mockResolvedValueOnce([apiKeyRow(), userKeyRow()]);
 
     render(<SettingsPage />);
     await screen.findByText(/No broker credentials saved yet/i);
-    await fillAndSubmit("primary", "secret-value-1234");
+    await fillAndSubmit("test-api-key", "test-user-key");
     const dialog = await screen.findByRole("dialog");
 
     await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
-
-    // The dialog must still be present, now showing the warning copy.
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        /you may lose recovery ability for this installation's broker credentials/i,
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it("routes Escape through the confirm-cancel warning, not silent dismissal", async () => {
-    const user = userEvent.setup();
-    mockedCreate.mockResolvedValueOnce(withPhrase());
-    mockedList.mockResolvedValueOnce([]).mockResolvedValueOnce([makeRow()]);
-
-    render(<SettingsPage />);
-    await screen.findByText(/No broker credentials saved yet/i);
-    await fillAndSubmit("primary", "secret-value-1234");
-    await screen.findByRole("dialog");
-
-    await user.keyboard("{Escape}");
-
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(
       screen.getByText(/you may lose recovery ability/i),
     ).toBeInTheDocument();
   });
 
-  it("returns to the phrase view when the operator chooses 'Go back'", async () => {
-    const user = userEvent.setup();
-    mockedCreate.mockResolvedValueOnce(withPhrase());
-    mockedList.mockResolvedValueOnce([]).mockResolvedValueOnce([makeRow()]);
-
-    render(<SettingsPage />);
-    await screen.findByText(/No broker credentials saved yet/i);
-    await fillAndSubmit("primary", "secret-value-1234");
-    const dialog = await screen.findByRole("dialog");
-
-    await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
-    await user.click(screen.getByRole("button", { name: "Go back" }));
-
-    expect(
-      screen.getByText(/Write down your recovery phrase/i),
-    ).toBeInTheDocument();
-  });
-
   it("closes and clears the phrase when the operator confirms 'Close anyway'", async () => {
     const user = userEvent.setup();
-    mockedCreate.mockResolvedValueOnce(withPhrase());
-    mockedList.mockResolvedValueOnce([]).mockResolvedValueOnce([makeRow()]);
+    mockedCreate
+      .mockResolvedValueOnce(withPhrase())
+      .mockResolvedValueOnce(withoutPhrase());
+    mockedList.mockResolvedValueOnce([]).mockResolvedValueOnce([apiKeyRow(), userKeyRow()]);
 
     render(<SettingsPage />);
     await screen.findByText(/No broker credentials saved yet/i);
-    await fillAndSubmit("primary", "secret-value-1234");
+    await fillAndSubmit("test-api-key", "test-user-key");
     const dialog = await screen.findByRole("dialog");
 
     await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
@@ -325,23 +429,21 @@ describe("SettingsPage — phrase modal cancel gate", () => {
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).toBeNull();
     });
-    // No revoke call -- the credential row stays committed (the phrase
-    // is root-secret scoped, not row scoped).
     expect(mockedRevoke).not.toHaveBeenCalled();
-    // Deferred list refresh runs after the modal closes.
-    await waitFor(() => {
-      expect(mockedList).toHaveBeenCalledTimes(2);
-    });
   });
 });
 
-describe("SettingsPage — backend failure on first save", () => {
+// ---------------------------------------------------------------------------
+// Backend failure
+// ---------------------------------------------------------------------------
+
+describe("SettingsPage — backend failure", () => {
   it("surfaces a 409 conflict and does NOT open the modal", async () => {
     mockedCreate.mockRejectedValueOnce(new ApiError(409, "conflict"));
 
     render(<SettingsPage />);
     await screen.findByText(/No broker credentials saved yet/i);
-    await fillAndSubmit("primary", "secret-value-1234");
+    await fillAndSubmit("test-api-key", "test-user-key");
 
     expect(
       await screen.findByText(/credential with that label already exists/i),
@@ -354,7 +456,7 @@ describe("SettingsPage — backend failure on first save", () => {
 
     render(<SettingsPage />);
     await screen.findByText(/No broker credentials saved yet/i);
-    await fillAndSubmit("primary", "secret-value-1234");
+    await fillAndSubmit("test-api-key", "test-user-key");
 
     expect(
       await screen.findByText(/Could not save credential/i),

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -27,31 +27,9 @@ import {
   validateBrokerCredential,
 } from "@/api/brokerCredentials";
 import { useRecoveryPhraseModal } from "@/components/security/RecoveryPhraseModal";
+import { deriveCredentialSetMode, ENVIRONMENT } from "@/lib/credentialSetMode";
 
 const MIN_SECRET_LEN = 4;
-const ENVIRONMENT = "demo";
-
-type CredentialSetMode = "create" | "repair" | "complete";
-
-function deriveMode(
-  rows: BrokerCredentialView[] | null,
-): { mode: CredentialSetMode; missingLabel: "api_key" | "user_key" | null } {
-  if (rows === null) return { mode: "create", missingLabel: null };
-
-  const active = rows.filter(
-    (r) =>
-      r.provider === "etoro" &&
-      r.environment === ENVIRONMENT &&
-      r.revoked_at === null,
-  );
-  const hasApiKey = active.some((r) => r.label === "api_key");
-  const hasUserKey = active.some((r) => r.label === "user_key");
-
-  if (hasApiKey && hasUserKey) return { mode: "complete", missingLabel: null };
-  if (hasApiKey) return { mode: "repair", missingLabel: "user_key" };
-  if (hasUserKey) return { mode: "repair", missingLabel: "api_key" };
-  return { mode: "create", missingLabel: null };
-}
 
 export function SettingsPage(): JSX.Element {
   return (
@@ -82,7 +60,7 @@ function BrokerCredentialsSection(): JSX.Element {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
-  const { mode, missingLabel } = useMemo(() => deriveMode(rows), [rows]);
+  const { mode, missingLabel } = useMemo(() => deriveCredentialSetMode(rows), [rows]);
 
   // Clear stale validation result when inputs change or mode transitions.
   useEffect(() => {
@@ -135,47 +113,38 @@ function BrokerCredentialsSection(): JSX.Element {
     setCreateError(null);
     setCreating(true);
     try {
+      let phrase: readonly string[] | null = null;
+
+      // Save api_key if needed (Create mode or Repair with api_key missing).
       if (mode === "create" || (mode === "repair" && missingLabel === "api_key")) {
-        const keyValue = mode === "repair" ? apiKey : apiKey;
         const response = await createBrokerCredential({
           provider: "etoro",
           label: "api_key",
           environment: ENVIRONMENT,
-          secret: keyValue,
+          secret: apiKey,
         });
         if (response.recovery_phrase != null && response.recovery_phrase.length > 0) {
-          // Recovery phrase shown — defer refresh + second save until
-          // modal closes. But we need to save user_key too in Create mode.
-          // Store a flag so the modal onClose path can continue.
-          if (mode === "create") {
-            // Save user_key immediately — the phrase modal is about the
-            // root secret, not the individual credential. The second
-            // credential should be committed before the modal opens so
-            // both rows are durable.
-            await createBrokerCredential({
-              provider: "etoro",
-              label: "user_key",
-              environment: ENVIRONMENT,
-              secret: userKey,
-            });
-          }
-          setApiKey("");
-          setUserKey("");
-          phraseModal.open(response.recovery_phrase);
-          return;
+          phrase = response.recovery_phrase;
         }
       }
 
-      // Save user_key if we're in Create mode and haven't saved it yet,
-      // or if we're in Repair mode and user_key is the missing one.
+      // Save user_key if needed (Create mode or Repair with user_key missing).
       if (mode === "create" || (mode === "repair" && missingLabel === "user_key")) {
-        const keyValue = mode === "repair" ? userKey : userKey;
         await createBrokerCredential({
           provider: "etoro",
           label: "user_key",
           environment: ENVIRONMENT,
-          secret: keyValue,
+          secret: userKey,
         });
+      }
+
+      // If the first save triggered a recovery phrase, show the modal
+      // now that both credentials are durable.
+      if (phrase !== null) {
+        setApiKey("");
+        setUserKey("");
+        phraseModal.open(phrase);
+        return;
       }
 
       setApiKey("");

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,24 +1,57 @@
 /**
  * /settings page.
  *
- * Currently hosts the broker credentials section (issue #99 / Ticket B).
- * Runtime config + kill switch (#65) will land alongside this section
- * once that ticket ships.
+ * Hosts the broker credentials section (issue #99 / Ticket B, updated
+ * in #139 PR D for two-key credential model).
+ *
+ * Credential-set mode detection:
+ *   The eToro two-key model requires exactly two active credential rows
+ *   (label="api_key" and label="user_key") for provider="etoro",
+ *   environment="demo". The form inspects the loaded credential list
+ *   to derive one of three modes:
+ *     - Create: neither key exists — show both fields.
+ *     - Repair: one key exists, one missing — show only the missing field.
+ *     - Complete: both keys exist — hide the create form.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { FormEvent } from "react";
 
 import { ApiError } from "@/api/client";
 import {
   type BrokerCredentialView,
+  type ValidateCredentialResponse,
   createBrokerCredential,
   listBrokerCredentials,
   revokeBrokerCredential,
+  validateBrokerCredential,
 } from "@/api/brokerCredentials";
 import { useRecoveryPhraseModal } from "@/components/security/RecoveryPhraseModal";
 
 const MIN_SECRET_LEN = 4;
+const ENVIRONMENT = "demo";
+
+type CredentialSetMode = "create" | "repair" | "complete";
+
+function deriveMode(
+  rows: BrokerCredentialView[] | null,
+): { mode: CredentialSetMode; missingLabel: "api_key" | "user_key" | null } {
+  if (rows === null) return { mode: "create", missingLabel: null };
+
+  const active = rows.filter(
+    (r) =>
+      r.provider === "etoro" &&
+      r.environment === ENVIRONMENT &&
+      r.revoked_at === null,
+  );
+  const hasApiKey = active.some((r) => r.label === "api_key");
+  const hasUserKey = active.some((r) => r.label === "user_key");
+
+  if (hasApiKey && hasUserKey) return { mode: "complete", missingLabel: null };
+  if (hasApiKey) return { mode: "repair", missingLabel: "user_key" };
+  if (hasUserKey) return { mode: "repair", missingLabel: "api_key" };
+  return { mode: "create", missingLabel: null };
+}
 
 export function SettingsPage(): JSX.Element {
   return (
@@ -33,32 +66,32 @@ function BrokerCredentialsSection(): JSX.Element {
   const [rows, setRows] = useState<BrokerCredentialView[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  // Add-form local state. Secret is stored only in this state, not in
-  // any context or query cache, and is cleared on successful submit.
-  const [provider, setProvider] = useState<"etoro">("etoro");
-  const [label, setLabel] = useState("");
-  const [secret, setSecret] = useState("");
+  // Two-key form state. Keys are stored only in component state, never
+  // in any context or query cache, and are cleared on successful submit.
+  const [apiKey, setApiKey] = useState("");
+  const [userKey, setUserKey] = useState("");
   const [createError, setCreateError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
+
+  // Validation state (transient probe — nothing is persisted).
+  const [validating, setValidating] = useState(false);
+  const [validationResult, setValidationResult] =
+    useState<ValidateCredentialResponse | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   const [busyId, setBusyId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
-  // Recovery-phrase modal -- shared with the first-run wizard via
-  // useRecoveryPhraseModal (#122). The hook owns the phrase state,
-  // the confirm/confirm-cancel inner view, and the close path. Our
-  // onClose callback runs after every close path and is the place to
-  // clear stale local error state and re-fetch the credential list.
+  const { mode, missingLabel } = useMemo(() => deriveMode(rows), [rows]);
+
+  // Clear stale validation result when inputs change or mode transitions.
+  useEffect(() => {
+    setValidationResult(null);
+    setValidationError(null);
+  }, [apiKey, userKey, mode]);
+
   const phraseModal = useRecoveryPhraseModal({
     onClose: () => {
-      // Clear any stale createError from a prior failed attempt --
-      // otherwise after the modal closes the operator could see a
-      // leftover create error AND a fresh load error side by side
-      // (#121 round 2 review). Then run the deferred list refresh
-      // now that the modal no longer covers the page (#121 round 1
-      // review). No revoke -- the credential row is already
-      // committed and the phrase is root-secret scoped, not row
-      // scoped.
       setCreateError(null);
       void refresh();
     },
@@ -79,42 +112,86 @@ function BrokerCredentialsSection(): JSX.Element {
     void refresh();
   }, [refresh]);
 
+  async function handleTestConnection(): Promise<void> {
+    setValidationResult(null);
+    setValidationError(null);
+    setValidating(true);
+    try {
+      const result = await validateBrokerCredential({
+        api_key: apiKey,
+        user_key: userKey,
+        environment: ENVIRONMENT,
+      });
+      setValidationResult(result);
+    } catch {
+      setValidationError("Could not reach the validation endpoint.");
+    } finally {
+      setValidating(false);
+    }
+  }
+
   async function handleCreate(e: FormEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault();
     setCreateError(null);
     setCreating(true);
     try {
-      const response = await createBrokerCredential({ provider, label, secret });
-      // Clear the secret immediately and re-fetch to show the row.
-      // The form is intentionally NOT pre-populated from the response.
-      setLabel("");
-      setSecret("");
-      // First-save-in-clean_install path: backend returns the 24-word
-      // recovery phrase exactly once (#114 / ADR-0003 §4). Show the
-      // confirmation modal. Note: the credential row is ALREADY
-      // committed by the time we get here -- the modal cannot block
-      // commit, only operator acknowledgement of the phrase. The
-      // confirm-cancel gate inside the modal protects against a
-      // misclick destroying the only copy of the phrase.
-      //
-      // We DEFER the list refresh until the modal closes. Otherwise
-      // any error from `refresh()` would be set on `loadError` while
-      // the modal covers the page, hiding it from the operator
-      // (review feedback PR #125 round 1). When no modal opens we
-      // refresh inline as before.
-      if (response.recovery_phrase != null && response.recovery_phrase.length > 0) {
-        phraseModal.open(response.recovery_phrase);
-      } else {
-        await refresh();
+      if (mode === "create" || (mode === "repair" && missingLabel === "api_key")) {
+        const keyValue = mode === "repair" ? apiKey : apiKey;
+        const response = await createBrokerCredential({
+          provider: "etoro",
+          label: "api_key",
+          environment: ENVIRONMENT,
+          secret: keyValue,
+        });
+        if (response.recovery_phrase != null && response.recovery_phrase.length > 0) {
+          // Recovery phrase shown — defer refresh + second save until
+          // modal closes. But we need to save user_key too in Create mode.
+          // Store a flag so the modal onClose path can continue.
+          if (mode === "create") {
+            // Save user_key immediately — the phrase modal is about the
+            // root secret, not the individual credential. The second
+            // credential should be committed before the modal opens so
+            // both rows are durable.
+            await createBrokerCredential({
+              provider: "etoro",
+              label: "user_key",
+              environment: ENVIRONMENT,
+              secret: userKey,
+            });
+          }
+          setApiKey("");
+          setUserKey("");
+          phraseModal.open(response.recovery_phrase);
+          return;
+        }
       }
+
+      // Save user_key if we're in Create mode and haven't saved it yet,
+      // or if we're in Repair mode and user_key is the missing one.
+      if (mode === "create" || (mode === "repair" && missingLabel === "user_key")) {
+        const keyValue = mode === "repair" ? userKey : userKey;
+        await createBrokerCredential({
+          provider: "etoro",
+          label: "user_key",
+          environment: ENVIRONMENT,
+          secret: keyValue,
+        });
+      }
+
+      setApiKey("");
+      setUserKey("");
+      await refresh();
     } catch (err: unknown) {
       if (err instanceof ApiError && err.status === 409) {
-        setCreateError("A credential with that label already exists for this provider.");
+        setCreateError("A credential with that label already exists. Revoke it first to replace.");
       } else if (err instanceof ApiError && err.status === 400) {
-        setCreateError("Provider, label, or secret is invalid.");
+        setCreateError("Invalid API key or user key value.");
       } else {
         setCreateError("Could not save credential.");
       }
+      // Re-derive mode from the refreshed list in case the first call
+      // succeeded but the second failed (partial state).
+      await refresh();
     } finally {
       setCreating(false);
     }
@@ -124,7 +201,7 @@ function BrokerCredentialsSection(): JSX.Element {
     setActionError(null);
     if (
       !window.confirm(
-        `Revoke "${row.label}" (${row.provider})? This cannot be undone.`,
+        `Revoke "${row.label}" (${row.provider} · ${row.environment})? This cannot be undone.`,
       )
     ) {
       return;
@@ -145,13 +222,21 @@ function BrokerCredentialsSection(): JSX.Element {
     }
   }
 
+  const showApiKeyField = mode === "create" || (mode === "repair" && missingLabel === "api_key");
+  const showUserKeyField = mode === "create" || (mode === "repair" && missingLabel === "user_key");
+  const canTestConnection = mode === "create" && apiKey.length >= MIN_SECRET_LEN && userKey.length >= MIN_SECRET_LEN;
+  const canSave =
+    !creating &&
+    (showApiKeyField ? apiKey.length >= MIN_SECRET_LEN : true) &&
+    (showUserKeyField ? userKey.length >= MIN_SECRET_LEN : true);
+
   return (
     <section className="space-y-4">
       <div>
         <h2 className="text-sm font-medium text-slate-700">Broker credentials</h2>
         <p className="text-xs text-slate-500">
           Encrypted broker secrets stored against your operator account. eBull uses
-          these to place orders -- the plaintext value is never returned to this UI.
+          these to place orders — the plaintext value is never returned to this UI.
         </p>
       </div>
 
@@ -177,7 +262,7 @@ function BrokerCredentialsSection(): JSX.Element {
                 <div>
                   <span className="font-medium text-slate-800">{row.label}</span>
                   <span className="ml-2 text-xs text-slate-500">
-                    {row.provider} · ••••{row.last_four}
+                    {row.provider} · {row.environment} · ••••{row.last_four}
                   </span>
                   {revoked && (
                     <span className="ml-2 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-slate-500">
@@ -206,88 +291,154 @@ function BrokerCredentialsSection(): JSX.Element {
         </p>
       )}
 
-      <form
-        onSubmit={handleCreate}
-        className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4"
-      >
-        <h3 className="text-sm font-medium text-slate-700">Add credential</h3>
-        <label className="block text-sm">
-          <span className="mb-1 block text-slate-600">Provider</span>
-          <select
-            value={provider}
-            onChange={(e) => setProvider(e.target.value as "etoro")}
-            className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
-          >
-            <option value="etoro">eToro</option>
-          </select>
-        </label>
-        <label className="block text-sm">
-          <span className="mb-1 block text-slate-600">Label</span>
-          {/*
-            Browser-autofill defence: Chrome (and friends) treat a
-            text field followed by a password field as a sign-in
-            form and pre-fill the text field with the saved
-            username, ignoring `autoComplete="off"`. The user hit
-            this on 2026-04-08: their broker-credential label was
-            being silently overwritten with their operator
-            username. Setting an explicit non-standard `name` and
-            `autoComplete="off"` together is the most reliable
-            cross-browser way to opt this single field out of the
-            sign-in heuristic without disabling autofill globally.
-          */}
-          <input
-            type="text"
-            name="broker-credential-label"
-            autoComplete="off"
-            value={label}
-            onChange={(e) => setLabel(e.target.value)}
-            required
-            className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
-          />
-        </label>
-        <label className="block text-sm">
-          <span className="mb-1 block text-slate-600">Secret</span>
-          {/*
-            `autoComplete="new-password"` (rather than `"off"`) is
-            the documented signal to Chrome / Safari / Firefox
-            password managers that this field is *not* a sign-in
-            password input. Without it, the browser treats the
-            preceding label field as a username, which is exactly
-            the bug fixed above. The two fixes are paired.
-          */}
-          <input
-            type="password"
-            name="broker-credential-secret"
-            autoComplete="new-password"
-            value={secret}
-            onChange={(e) => setSecret(e.target.value)}
-            minLength={MIN_SECRET_LEN}
-            required
-            className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
-          />
-        </label>
-        {createError !== null && (
-          <div
-            role="alert"
-            className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700"
-          >
-            {createError}
-          </div>
-        )}
-        <button
-          type="submit"
-          disabled={
-            creating ||
-            label.trim() === "" ||
-            secret.length < MIN_SECRET_LEN
-          }
-          className="rounded bg-slate-800 px-3 py-1.5 text-sm font-medium text-white disabled:bg-slate-400"
+      {mode === "complete" ? (
+        <div className="max-w-sm rounded border border-slate-200 bg-white p-4">
+          <p className="text-sm text-slate-700">
+            Credentials configured. Revoke existing credentials to replace them.
+          </p>
+        </div>
+      ) : (
+        <form
+          onSubmit={handleCreate}
+          className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4"
         >
-          {creating ? "Saving…" : "Save credential"}
-        </button>
-      </form>
+          <h3 className="text-sm font-medium text-slate-700">
+            {mode === "repair" ? "Complete credential setup" : "Add eToro credentials"}
+          </h3>
+          {mode === "repair" && (
+            <p className="text-xs text-slate-500">
+              One key was already saved. Enter the missing {missingLabel === "api_key" ? "API key" : "user key"} to
+              complete the credential pair.
+            </p>
+          )}
+
+          {showApiKeyField && (
+            <label className="block text-sm">
+              <span className="mb-1 block text-slate-600">API key</span>
+              <input
+                type="password"
+                name="broker-credential-api-key"
+                autoComplete="new-password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                minLength={MIN_SECRET_LEN}
+                required
+                className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+              />
+            </label>
+          )}
+
+          {showUserKeyField && (
+            <label className="block text-sm">
+              <span className="mb-1 block text-slate-600">User key</span>
+              <input
+                type="password"
+                name="broker-credential-user-key"
+                autoComplete="new-password"
+                value={userKey}
+                onChange={(e) => setUserKey(e.target.value)}
+                minLength={MIN_SECRET_LEN}
+                required
+                className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+              />
+            </label>
+          )}
+
+          {/* Test connection — only available in Create mode (both keys present). */}
+          <div className="space-y-1">
+            <button
+              type="button"
+              onClick={() => void handleTestConnection()}
+              disabled={!canTestConnection || validating}
+              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            >
+              {validating ? "Testing…" : "Test connection"}
+            </button>
+            {mode === "repair" && (
+              <p className="text-xs text-slate-400">
+                Connection testing requires both keys. The already-saved key cannot be read back.
+              </p>
+            )}
+          </div>
+
+          <ValidationResultDisplay
+            result={validationResult}
+            error={validationError}
+          />
+
+          {createError !== null && (
+            <div
+              role="alert"
+              className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700"
+            >
+              {createError}
+            </div>
+          )}
+          <button
+            type="submit"
+            disabled={!canSave}
+            className="rounded bg-slate-800 px-3 py-1.5 text-sm font-medium text-white disabled:bg-slate-400"
+          >
+            {creating ? "Saving…" : "Save credential"}
+          </button>
+        </form>
+      )}
 
       {phraseModal.element}
     </section>
+  );
+}
+
+function ValidationResultDisplay({
+  result,
+  error,
+}: {
+  result: ValidateCredentialResponse | null;
+  error: string | null;
+}): JSX.Element | null {
+  if (error !== null) {
+    return (
+      <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
+        {error}
+      </div>
+    );
+  }
+  if (result === null) return null;
+
+  if (!result.auth_valid) {
+    return (
+      <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
+        Authentication failed — check your API key and user key.
+      </div>
+    );
+  }
+
+  if (!result.env_valid) {
+    return (
+      <div className="space-y-1">
+        <div className="rounded bg-amber-50 px-2 py-1.5 text-xs text-amber-700">
+          Authenticated, but environment check failed: {result.env_check}
+        </div>
+        {result.note && (
+          <p className="text-xs text-slate-400">{result.note}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="rounded bg-emerald-50 px-2 py-1.5 text-xs text-emerald-700">
+        Connection verified
+        {result.identity?.gcid != null && (
+          <span className="ml-1 text-emerald-600">
+            (account {result.identity.gcid})
+          </span>
+        )}
+      </div>
+      {result.note && (
+        <p className="text-xs text-slate-400">{result.note}</p>
+      )}
+    </div>
   );
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -26,6 +26,7 @@ import {
   revokeBrokerCredential,
   validateBrokerCredential,
 } from "@/api/brokerCredentials";
+import { ValidationResultDisplay } from "@/components/broker/ValidationResultDisplay";
 import { useRecoveryPhraseModal } from "@/components/security/RecoveryPhraseModal";
 import { deriveCredentialSetMode, ENVIRONMENT } from "@/lib/credentialSetMode";
 
@@ -358,56 +359,3 @@ function BrokerCredentialsSection(): JSX.Element {
   );
 }
 
-function ValidationResultDisplay({
-  result,
-  error,
-}: {
-  result: ValidateCredentialResponse | null;
-  error: string | null;
-}): JSX.Element | null {
-  if (error !== null) {
-    return (
-      <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
-        {error}
-      </div>
-    );
-  }
-  if (result === null) return null;
-
-  if (!result.auth_valid) {
-    return (
-      <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
-        Authentication failed — check your API key and user key.
-      </div>
-    );
-  }
-
-  if (!result.env_valid) {
-    return (
-      <div className="space-y-1">
-        <div className="rounded bg-amber-50 px-2 py-1.5 text-xs text-amber-700">
-          Authenticated, but environment check failed: {result.env_check}
-        </div>
-        {result.note && (
-          <p className="text-xs text-slate-400">{result.note}</p>
-        )}
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-1">
-      <div className="rounded bg-emerald-50 px-2 py-1.5 text-xs text-emerald-700">
-        Connection verified
-        {result.identity?.gcid != null && (
-          <span className="ml-1 text-emerald-600">
-            (account {result.identity.gcid})
-          </span>
-        )}
-      </div>
-      {result.note && (
-        <p className="text-xs text-slate-400">{result.note}</p>
-      )}
-    </div>
-  );
-}

--- a/frontend/src/pages/SetupPage.test.tsx
+++ b/frontend/src/pages/SetupPage.test.tsx
@@ -1,25 +1,15 @@
 /**
- * Tests for SetupPage 2-step wizard (#122 / ADR-0003 Ticket 2c).
+ * Tests for SetupPage 2-step wizard (#122 / ADR-0003 Ticket 2c,
+ * updated #139 PR D for two-key credential model).
  *
  * Scope:
- *   - Step 1 still creates the operator and surfaces the generic-404
- *     error on failure (regression for #106).
- *   - Step 1 success advances to step 2 instead of navigating away;
- *     markAuthenticated is NOT called yet.
- *   - Step 2 "Skip for now" completes the wizard with no broker call,
- *     calls markAuthenticated, navigates to /.
- *   - Step 2 inline first-save with a recovery_phrase response opens
- *     the same phrase modal as the SettingsPage flow.
- *   - Phrase modal challenge confirm completes the wizard.
- *   - Phrase modal cancel routes through the same fail-closed gate
- *     as #121 ("Close anyway" still completes the wizard).
- *   - Step 2 backend save failures (409 / 400 / generic) keep the
- *     operator on step 2 with form values preserved and "Skip for
- *     now" still available.
- *   - Edge case 2 (ADR-0003 §5 row 3): a successful save with
- *     recovery_phrase: null shows NO modal and completes the wizard.
- *   - markAuthenticated is called exactly once per wizard run, only
- *     at the wizard's completion.
+ *   - Step 1 creates the operator (unchanged from #122).
+ *   - Step 2 shows two-key form (API key + User key), no label field.
+ *   - Two sequential createBrokerCredential calls on save.
+ *   - "Skip for now" completes the wizard with no broker call.
+ *   - Recovery phrase modal flow (first-save lazy-gen).
+ *   - Partial-save recovery (first key saved, second failed → Repair).
+ *   - markAuthenticated called exactly once, at wizard completion.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
@@ -27,8 +17,11 @@ import userEvent from "@testing-library/user-event";
 
 import { SetupPage } from "@/pages/SetupPage";
 import {
+  type BrokerCredentialView,
   type CreateBrokerCredentialResponse,
   createBrokerCredential,
+  listBrokerCredentials,
+  validateBrokerCredential,
 } from "@/api/brokerCredentials";
 import { postSetup } from "@/api/auth";
 import type { Operator } from "@/api/auth";
@@ -44,6 +37,8 @@ vi.mock("@/api/auth", async () => {
 });
 vi.mock("@/api/brokerCredentials", () => ({
   createBrokerCredential: vi.fn(),
+  listBrokerCredentials: vi.fn(),
+  validateBrokerCredential: vi.fn(),
 }));
 
 const navigateMock = vi.fn();
@@ -59,6 +54,8 @@ vi.mock("@/lib/session", () => ({
 
 const mockedPostSetup = vi.mocked(postSetup);
 const mockedCreate = vi.mocked(createBrokerCredential);
+const mockedList = vi.mocked(listBrokerCredentials);
+const mockedValidate = vi.mocked(validateBrokerCredential);
 
 const OPERATOR: Operator = {
   id: "00000000-0000-0000-0000-000000000001",
@@ -66,49 +63,36 @@ const OPERATOR: Operator = {
 };
 
 const PHRASE: readonly string[] = [
-  "alpha",
-  "bravo",
-  "charlie",
-  "delta",
-  "echo",
-  "foxtrot",
-  "golf",
-  "hotel",
-  "india",
-  "juliet",
-  "kilo",
-  "lima",
-  "mike",
-  "november",
-  "oscar",
-  "papa",
-  "quebec",
-  "romeo",
-  "sierra",
-  "tango",
-  "uniform",
-  "victor",
-  "whiskey",
-  "xray",
+  "alpha", "bravo", "charlie", "delta", "echo", "foxtrot",
+  "golf", "hotel", "india", "juliet", "kilo", "lima",
+  "mike", "november", "oscar", "papa", "quebec", "romeo",
+  "sierra", "tango", "uniform", "victor", "whiskey", "xray",
 ];
 
-function withPhrase(): CreateBrokerCredentialResponse {
+function makeRow(overrides: Partial<BrokerCredentialView> = {}): BrokerCredentialView {
   return {
-    credential: {
-      id: "11111111-1111-1111-1111-111111111111",
-      provider: "etoro",
-      label: "primary",
-      last_four: "1234",
-      created_at: "2026-04-08T00:00:00Z",
-      last_used_at: null,
-      revoked_at: null,
-    },
-    recovery_phrase: PHRASE,
+    id: "11111111-1111-1111-1111-111111111111",
+    provider: "etoro",
+    label: "api_key",
+    environment: "demo",
+    last_four: "1234",
+    created_at: "2026-04-08T00:00:00Z",
+    last_used_at: null,
+    revoked_at: null,
+    ...overrides,
   };
 }
 
+function apiKeyRow(): BrokerCredentialView {
+  return makeRow({ id: "aaaa-1111", label: "api_key", last_four: "aaaa" });
+}
+
+function withPhrase(): CreateBrokerCredentialResponse {
+  return { credential: makeRow(), recovery_phrase: PHRASE };
+}
+
 function withoutPhrase(): CreateBrokerCredentialResponse {
-  return { ...withPhrase(), recovery_phrase: null };
+  return { credential: makeRow(), recovery_phrase: null };
 }
 
 async function completeStep1(): Promise<void> {
@@ -118,11 +102,11 @@ async function completeStep1(): Promise<void> {
   await user.click(screen.getByRole("button", { name: /Create operator/i }));
 }
 
-async function fillStep2(label: string, secret: string): Promise<void> {
+async function fillStep2(apiKey: string, userKey: string): Promise<void> {
   const user = userEvent.setup();
-  await user.type(screen.getByLabelText("Label"), label);
-  await user.type(screen.getByLabelText("Secret"), secret);
-  await user.click(screen.getByRole("button", { name: /Save credential/i }));
+  await user.type(screen.getByLabelText("API key"), apiKey);
+  await user.type(screen.getByLabelText("User key"), userKey);
+  await user.click(screen.getByRole("button", { name: /Save credentials/i }));
 }
 
 async function answerChallengeCorrectly(): Promise<void> {
@@ -146,6 +130,8 @@ async function advancePastWrittenDownGate(): Promise<void> {
 beforeEach(() => {
   mockedPostSetup.mockReset();
   mockedCreate.mockReset();
+  mockedList.mockReset();
+  mockedValidate.mockReset();
   navigateMock.mockReset();
   markAuthenticatedMock.mockReset();
   useSessionMock.mockReset();
@@ -158,11 +144,17 @@ beforeEach(() => {
     markAuthenticated: markAuthenticatedMock,
     refreshBootstrapState: vi.fn(),
   } as unknown as ReturnType<typeof useSession>);
+  // Default: no credentials exist (fresh setup).
+  mockedList.mockResolvedValue([]);
 });
 
 afterEach(() => {
   vi.clearAllMocks();
 });
+
+// ---------------------------------------------------------------------------
+// Step 1 (operator) — unchanged from #122
+// ---------------------------------------------------------------------------
 
 describe("SetupPage — step 1 (operator)", () => {
   it("surfaces the generic error and stays on step 1 when /auth/setup fails", async () => {
@@ -181,16 +173,21 @@ describe("SetupPage — step 1 (operator)", () => {
     mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
     render(<SetupPage />);
     await completeStep1();
-    // Step 2 form is now visible.
     expect(
-      await screen.findByRole("button", { name: /Save credential/i }),
+      await screen.findByRole("button", { name: /Save credentials/i }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Skip for now/i })).toBeInTheDocument();
-    // Critically: markAuthenticated and navigate are deferred.
+    // Two-key fields visible.
+    expect(screen.getByLabelText("API key")).toBeInTheDocument();
+    expect(screen.getByLabelText("User key")).toBeInTheDocument();
     expect(markAuthenticatedMock).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Step 2 (broker, optional) — updated for two-key model
+// ---------------------------------------------------------------------------
 
 describe("SetupPage — step 2 (broker, optional)", () => {
   it("'Skip for now' completes the wizard with no broker call", async () => {
@@ -208,29 +205,66 @@ describe("SetupPage — step 2 (broker, optional)", () => {
     expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
   });
 
-  it("opens the phrase modal when the inline save returns a recovery_phrase", async () => {
+  it("creates both api_key and user_key rows on save", async () => {
     mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
-    mockedCreate.mockResolvedValueOnce(withPhrase());
+    mockedCreate
+      .mockResolvedValueOnce(withoutPhrase())  // api_key
+      .mockResolvedValueOnce(withoutPhrase()); // user_key
+
     render(<SetupPage />);
     await completeStep1();
-    await screen.findByRole("button", { name: /Save credential/i });
-    await fillStep2("primary", "secret-value-1234");
+    await fillStep2("test-api-key", "test-user-key");
+
+    await waitFor(() => {
+      expect(mockedCreate).toHaveBeenCalledTimes(2);
+    });
+    expect(mockedCreate).toHaveBeenNthCalledWith(1, {
+      provider: "etoro",
+      label: "api_key",
+      environment: "demo",
+      secret: "test-api-key",
+    });
+    expect(mockedCreate).toHaveBeenNthCalledWith(2, {
+      provider: "etoro",
+      label: "user_key",
+      environment: "demo",
+      secret: "test-user-key",
+    });
+    // Wizard completes after both saves.
+    expect(markAuthenticatedMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
+  });
+
+  it("opens the phrase modal when the first create response carries a recovery_phrase", async () => {
+    mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
+    mockedCreate
+      .mockResolvedValueOnce(withPhrase())     // api_key (triggers phrase)
+      .mockResolvedValueOnce(withoutPhrase()); // user_key
+
+    render(<SetupPage />);
+    await completeStep1();
+    await fillStep2("test-api-key", "test-user-key");
 
     const dialog = await screen.findByRole("dialog", {
       name: "Recovery phrase confirmation",
     });
     expect(dialog).toBeInTheDocument();
-    // Wizard is NOT yet complete.
+    // Both credentials saved before modal opens.
+    expect(mockedCreate).toHaveBeenCalledTimes(2);
+    // Wizard NOT yet complete.
     expect(markAuthenticatedMock).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
   it("completes the wizard after the operator passes the challenge", async () => {
     mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
-    mockedCreate.mockResolvedValueOnce(withPhrase());
+    mockedCreate
+      .mockResolvedValueOnce(withPhrase())
+      .mockResolvedValueOnce(withoutPhrase());
+
     render(<SetupPage />);
     await completeStep1();
-    await fillStep2("primary", "secret-value-1234");
+    await fillStep2("test-api-key", "test-user-key");
     await screen.findByRole("dialog");
 
     await advancePastWrittenDownGate();
@@ -243,22 +277,22 @@ describe("SetupPage — step 2 (broker, optional)", () => {
     expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
   });
 
-  it("routes Cancel through the confirm-cancel gate, then 'Close anyway' completes the wizard", async () => {
+  it("routes Cancel through confirm-cancel gate, then 'Close anyway' completes wizard", async () => {
     const user = userEvent.setup();
     mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
-    mockedCreate.mockResolvedValueOnce(withPhrase());
+    mockedCreate
+      .mockResolvedValueOnce(withPhrase())
+      .mockResolvedValueOnce(withoutPhrase());
+
     render(<SetupPage />);
     await completeStep1();
-    await fillStep2("primary", "secret-value-1234");
+    await fillStep2("test-api-key", "test-user-key");
     const dialog = await screen.findByRole("dialog");
 
     await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
     expect(
-      screen.getByText(
-        /you may lose recovery ability for this installation's broker credentials/i,
-      ),
+      screen.getByText(/you may lose recovery ability/i),
     ).toBeInTheDocument();
-    // Still mid-wizard until the operator commits to closing.
     expect(markAuthenticatedMock).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: "Close anyway" }));
@@ -268,43 +302,47 @@ describe("SetupPage — step 2 (broker, optional)", () => {
     expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
   });
 
-  it("preserves form values and keeps Skip available when the inline save fails", async () => {
-    const user = userEvent.setup();
+  it("enters Repair mode and keeps Skip available when second save fails", async () => {
     mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
-    mockedCreate.mockRejectedValueOnce(new ApiError(409, "conflict"));
+    mockedCreate
+      .mockResolvedValueOnce(withoutPhrase())  // api_key succeeds
+      .mockRejectedValueOnce(new Error("boom")); // user_key fails
+    // After error, refreshCredentials returns the saved api_key.
+    mockedList.mockResolvedValueOnce([apiKeyRow()]);
+
     render(<SetupPage />);
     await completeStep1();
-    await fillStep2("primary", "secret-value-1234");
+    await fillStep2("test-api-key", "test-user-key");
 
-    expect(
-      await screen.findByText(/credential with that label already exists/i),
-    ).toBeInTheDocument();
-    // No modal opened.
-    expect(screen.queryByRole("dialog")).toBeNull();
-    // Form values preserved (label not cleared).
-    expect((screen.getByLabelText("Label") as HTMLInputElement).value).toBe("primary");
-    // "Skip for now" still available so the operator can finish setup.
-    const skipBtn = screen.getByRole("button", { name: /Skip for now/i });
-    expect(skipBtn).toBeEnabled();
-    // Wizard is still mid-flight.
+    // Error surfaced.
+    expect(await screen.findByText(/Could not save credential/i)).toBeInTheDocument();
+    // Re-derived to Repair mode.
+    await waitFor(() => {
+      expect(screen.queryByLabelText("API key")).toBeNull();
+    });
+    expect(screen.getByLabelText("User key")).toBeInTheDocument();
+    // Skip still available.
+    expect(screen.getByRole("button", { name: /Skip for now/i })).toBeEnabled();
+    // Wizard NOT yet complete.
     expect(markAuthenticatedMock).not.toHaveBeenCalled();
-
-    // Skipping after the failure still completes the wizard.
-    await user.click(skipBtn);
-    expect(markAuthenticatedMock).toHaveBeenCalledTimes(1);
-    expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
   });
 });
 
-describe("SetupPage — edge case 2 (ADR-0003 §5 row 3)", () => {
-  it("completes the wizard with NO phrase modal when the response carries no recovery_phrase", async () => {
+// ---------------------------------------------------------------------------
+// Edge case 2 (ADR-0003 §5 row 3)
+// ---------------------------------------------------------------------------
+
+describe("SetupPage — edge case 2", () => {
+  it("completes wizard with NO phrase modal when response has no recovery_phrase", async () => {
     mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
-    mockedCreate.mockResolvedValueOnce(withoutPhrase());
+    mockedCreate
+      .mockResolvedValueOnce(withoutPhrase())
+      .mockResolvedValueOnce(withoutPhrase());
+
     render(<SetupPage />);
     await completeStep1();
-    await fillStep2("primary", "secret-value-1234");
+    await fillStep2("test-api-key", "test-user-key");
 
-    // No modal at any point.
     await waitFor(() => {
       expect(markAuthenticatedMock).toHaveBeenCalledTimes(1);
     });

--- a/frontend/src/pages/SetupPage.test.tsx
+++ b/frontend/src/pages/SetupPage.test.tsx
@@ -307,8 +307,11 @@ describe("SetupPage — step 2 (broker, optional)", () => {
     mockedCreate
       .mockResolvedValueOnce(withoutPhrase())  // api_key succeeds
       .mockRejectedValueOnce(new Error("boom")); // user_key fails
-    // After error, refreshCredentials returns the saved api_key.
-    mockedList.mockResolvedValueOnce([apiKeyRow()]);
+    // Mount fetch on step-2 entry returns empty (fresh setup), then
+    // post-error refresh returns the saved api_key.
+    mockedList
+      .mockResolvedValueOnce([])           // mount fetch
+      .mockResolvedValueOnce([apiKeyRow()]); // post-error refresh
 
     render(<SetupPage />);
     await completeStep1();

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -51,35 +51,14 @@ import {
   validateBrokerCredential,
 } from "@/api/brokerCredentials";
 import { useRecoveryPhraseModal } from "@/components/security/RecoveryPhraseModal";
+import { deriveCredentialSetMode, ENVIRONMENT } from "@/lib/credentialSetMode";
 import { useSession } from "@/lib/session";
 
 const GENERIC_ERROR = "Setup unavailable or invalid token.";
 const MIN_PASSWORD_LEN = 12;
 const MIN_SECRET_LEN = 4;
-const ENVIRONMENT = "demo";
 
 type WizardStep = "operator" | "broker";
-type CredentialSetMode = "create" | "repair" | "complete";
-
-function deriveMode(
-  rows: BrokerCredentialView[] | null,
-): { mode: CredentialSetMode; missingLabel: "api_key" | "user_key" | null } {
-  if (rows === null) return { mode: "create", missingLabel: null };
-
-  const active = rows.filter(
-    (r) =>
-      r.provider === "etoro" &&
-      r.environment === ENVIRONMENT &&
-      r.revoked_at === null,
-  );
-  const hasApiKey = active.some((r) => r.label === "api_key");
-  const hasUserKey = active.some((r) => r.label === "user_key");
-
-  if (hasApiKey && hasUserKey) return { mode: "complete", missingLabel: null };
-  if (hasApiKey) return { mode: "repair", missingLabel: "user_key" };
-  if (hasUserKey) return { mode: "repair", missingLabel: "api_key" };
-  return { mode: "create", missingLabel: null };
-}
 
 export function SetupPage(): JSX.Element {
   const { status, markAuthenticated } = useSession();
@@ -103,7 +82,7 @@ export function SetupPage(): JSX.Element {
 
   // Credential-set mode detection for partial-save recovery.
   const [credRows, setCredRows] = useState<BrokerCredentialView[] | null>(null);
-  const derived = deriveMode(credRows);
+  const derived = deriveCredentialSetMode(credRows);
   const mode = derived.mode;
   const missingLabel = derived.missingLabel;
 
@@ -112,6 +91,14 @@ export function SetupPage(): JSX.Element {
   const [validationResult, setValidationResult] =
     useState<ValidateCredentialResponse | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
+
+  // Fetch existing credentials when entering step 2 so that
+  // partial-save state from a prior session is correctly detected.
+  useEffect(() => {
+    if (step === "broker") {
+      void refreshCredentials();
+    }
+  }, [step]);
 
   // Clear stale validation result when inputs change or mode transitions.
   useEffect(() => {
@@ -191,7 +178,9 @@ export function SetupPage(): JSX.Element {
     setBrokerError(null);
     setBrokerSubmitting(true);
     try {
-      // Save api_key if needed.
+      let phrase: readonly string[] | null = null;
+
+      // Save api_key if needed (Create mode or Repair with api_key missing).
       if (mode === "create" || (mode === "repair" && missingLabel === "api_key")) {
         const response = await createBrokerCredential({
           provider: "etoro",
@@ -200,24 +189,11 @@ export function SetupPage(): JSX.Element {
           secret: brokerApiKey,
         });
         if (response.recovery_phrase != null && response.recovery_phrase.length > 0) {
-          // Save user_key before showing the phrase modal (both rows
-          // must be durable before the wizard completes).
-          if (mode === "create") {
-            await createBrokerCredential({
-              provider: "etoro",
-              label: "user_key",
-              environment: ENVIRONMENT,
-              secret: brokerUserKey,
-            });
-          }
-          setBrokerApiKey("");
-          setBrokerUserKey("");
-          phraseModal.open(response.recovery_phrase);
-          return;
+          phrase = response.recovery_phrase;
         }
       }
 
-      // Save user_key if needed.
+      // Save user_key if needed (Create mode or Repair with user_key missing).
       if (mode === "create" || (mode === "repair" && missingLabel === "user_key")) {
         await createBrokerCredential({
           provider: "etoro",
@@ -229,6 +205,14 @@ export function SetupPage(): JSX.Element {
 
       setBrokerApiKey("");
       setBrokerUserKey("");
+
+      // If the first save triggered a recovery phrase, show the modal
+      // now that both credentials are durable.
+      if (phrase !== null) {
+        phraseModal.open(phrase);
+        return;
+      }
+
       completeWizard();
     } catch (err: unknown) {
       if (err instanceof ApiError && err.status === 409) {

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -10,22 +10,20 @@
  *   leaks which input was wrong.
  *
  * Step 2: Broker credential (optional)  -- ADR-0003 Ticket 2c (#122)
- *   Brand-new step. The operator MAY enter a broker credential right
- *   here, in which case the same first-save flow as the post-onboarding
- *   broker-credentials section runs inline (see SettingsPage / #121).
- *   The step is fully skippable: "Skip for now" navigates to / without
- *   storing anything, and the operator can save their first credential
- *   later from /settings.
+ *   Updated in #139 PR D for two-key credential model. The operator
+ *   enters both API key and user key. Labels are fixed as "api_key"
+ *   and "user_key"; environment is hardcoded to "demo" in v1.
  *
- *   Edge case 2 (ADR-0003 §5 row 3): if the broker key file already
- *   exists at wizard time, the backend silently re-uses it and the
- *   POST /broker-credentials response carries no recovery_phrase. The
- *   wizard then completes with NO modal shown -- "no phrase displayed
- *   at any point". The frontend does not need a separate signal for
- *   this case; the absence of `recovery_phrase` on the response is
- *   the same flag #121 already keys off, and that single condition
- *   covers both "fresh install, lazy gen ran" and "key file already
- *   present".
+ *   The "Test connection" button calls POST /broker-credentials/validate,
+ *   which is session-gated. This works because step 2 only runs after
+ *   step 1 completes — POST /auth/setup sets the session cookie on its
+ *   response, so the browser is already authenticated by the time step 2
+ *   renders. The session cookie is present even though markAuthenticated
+ *   is deferred (deferred for the React in-memory flag, not the cookie).
+ *
+ *   Credential-set mode detection mirrors SettingsPage: after a partial
+ *   save failure, the form re-derives mode from the credential list and
+ *   shows only the missing key's field.
  *
  * markAuthenticated discipline (#122):
  *   In the single-step incarnation we called markAuthenticated AND
@@ -45,29 +43,49 @@ import { useNavigate } from "react-router-dom";
 import { ApiError } from "@/api/client";
 import { postSetup } from "@/api/auth";
 import type { Operator } from "@/api/auth";
-import { createBrokerCredential } from "@/api/brokerCredentials";
+import {
+  type BrokerCredentialView,
+  type ValidateCredentialResponse,
+  createBrokerCredential,
+  listBrokerCredentials,
+  validateBrokerCredential,
+} from "@/api/brokerCredentials";
 import { useRecoveryPhraseModal } from "@/components/security/RecoveryPhraseModal";
 import { useSession } from "@/lib/session";
 
 const GENERIC_ERROR = "Setup unavailable or invalid token.";
 const MIN_PASSWORD_LEN = 12;
 const MIN_SECRET_LEN = 4;
-const BROKER_GENERIC_ERROR = "Could not save credential.";
-const BROKER_CONFLICT_ERROR =
-  "A credential with that label already exists for this provider.";
-const BROKER_VALIDATION_ERROR = "Provider, label, or secret is invalid.";
+const ENVIRONMENT = "demo";
 
 type WizardStep = "operator" | "broker";
+type CredentialSetMode = "create" | "repair" | "complete";
+
+function deriveMode(
+  rows: BrokerCredentialView[] | null,
+): { mode: CredentialSetMode; missingLabel: "api_key" | "user_key" | null } {
+  if (rows === null) return { mode: "create", missingLabel: null };
+
+  const active = rows.filter(
+    (r) =>
+      r.provider === "etoro" &&
+      r.environment === ENVIRONMENT &&
+      r.revoked_at === null,
+  );
+  const hasApiKey = active.some((r) => r.label === "api_key");
+  const hasUserKey = active.some((r) => r.label === "user_key");
+
+  if (hasApiKey && hasUserKey) return { mode: "complete", missingLabel: null };
+  if (hasApiKey) return { mode: "repair", missingLabel: "user_key" };
+  if (hasUserKey) return { mode: "repair", missingLabel: "api_key" };
+  return { mode: "create", missingLabel: null };
+}
 
 export function SetupPage(): JSX.Element {
   const { status, markAuthenticated } = useSession();
   const navigate = useNavigate();
 
   const [step, setStep] = useState<WizardStep>("operator");
-  // The operator is created at the end of step 1 and held here until
-  // the wizard completes. markAuthenticated is deferred until then so
-  // the redirect-on-authenticated effect below does not yank the
-  // operator off the page mid-wizard.
   const [pendingOperator, setPendingOperator] = useState<Operator | null>(null);
 
   // Step 1 form state.
@@ -77,23 +95,31 @@ export function SetupPage(): JSX.Element {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Step 2 form state. Provider is locked to "etoro" -- mirroring the
-  // SettingsPage broker-credentials section.
-  const [brokerLabel, setBrokerLabel] = useState("");
-  const [brokerSecret, setBrokerSecret] = useState("");
+  // Step 2 form state — two-key model.
+  const [brokerApiKey, setBrokerApiKey] = useState("");
+  const [brokerUserKey, setBrokerUserKey] = useState("");
   const [brokerSubmitting, setBrokerSubmitting] = useState(false);
   const [brokerError, setBrokerError] = useState<string | null>(null);
 
+  // Credential-set mode detection for partial-save recovery.
+  const [credRows, setCredRows] = useState<BrokerCredentialView[] | null>(null);
+  const derived = deriveMode(credRows);
+  const mode = derived.mode;
+  const missingLabel = derived.missingLabel;
+
+  // Validation state.
+  const [validating, setValidating] = useState(false);
+  const [validationResult, setValidationResult] =
+    useState<ValidateCredentialResponse | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  // Clear stale validation result when inputs change or mode transitions.
+  useEffect(() => {
+    setValidationResult(null);
+    setValidationError(null);
+  }, [brokerApiKey, brokerUserKey, mode]);
+
   function completeWizard(): void {
-    // Single shared "wizard is finished" path. Used by:
-    //   - "Skip for now" on step 2 (no credential stored)
-    //   - successful save with no recovery_phrase (edge case 2)
-    //   - the recovery-phrase modal close (challenge confirm OR
-    //     "Close anyway" -- both run through the hook's onClose)
-    // Flips the in-memory session flag and navigates to /. The cookie
-    // was set by /auth/setup back in step 1, so the operator is
-    // already authenticated as far as the backend is concerned; this
-    // just makes RequireAuth let them through.
     if (pendingOperator !== null) {
       markAuthenticated(pendingOperator);
     }
@@ -104,13 +130,6 @@ export function SetupPage(): JSX.Element {
     onClose: completeWizard,
   });
 
-  // Bootstrap bounce: if the SessionProvider has already determined
-  // the operator is fully authenticated (e.g. they hit /setup directly
-  // after a previous setup completed), bounce off this page. We
-  // deliberately do NOT bounce on `status === "authenticated"` while
-  // the wizard is mid-flight -- markAuthenticated only runs at the
-  // end of the wizard, so during steps 1-2 the SessionProvider's
-  // status is still "needs_setup" and this effect is a no-op.
   useEffect(() => {
     if (status === "authenticated") {
       navigate("/", { replace: true });
@@ -129,17 +148,41 @@ export function SetupPage(): JSX.Element {
         password,
         setupToken.trim() === "" ? null : setupToken.trim(),
       );
-      // Stash the operator for the deferred markAuthenticated call
-      // and advance to step 2. The cookie is already on the response
-      // so the broker POST in step 2 will authenticate.
       setPendingOperator(operator);
       setStep("broker");
     } catch {
-      // Single fixed phrase for every failure mode -- matches the
-      // backend's generic-404 discipline.
       setError(GENERIC_ERROR);
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  async function refreshCredentials(): Promise<void> {
+    try {
+      const data = await listBrokerCredentials();
+      setCredRows(data);
+    } catch {
+      // On the setup page, failure to list credentials is non-fatal —
+      // the operator can still enter both keys (Create mode).
+      setCredRows(null);
+    }
+  }
+
+  async function handleTestConnection(): Promise<void> {
+    setValidationResult(null);
+    setValidationError(null);
+    setValidating(true);
+    try {
+      const result = await validateBrokerCredential({
+        api_key: brokerApiKey,
+        user_key: brokerUserKey,
+        environment: ENVIRONMENT,
+      });
+      setValidationResult(result);
+    } catch {
+      setValidationError("Could not reach the validation endpoint.");
+    } finally {
+      setValidating(false);
     }
   }
 
@@ -148,40 +191,56 @@ export function SetupPage(): JSX.Element {
     setBrokerError(null);
     setBrokerSubmitting(true);
     try {
-      const response = await createBrokerCredential({
-        provider: "etoro",
-        label: brokerLabel,
-        secret: brokerSecret,
-      });
-      // Drop the secret from local state immediately on success.
-      setBrokerSecret("");
-      if (
-        response.recovery_phrase != null &&
-        response.recovery_phrase.length > 0
-      ) {
-        // Lazy-gen path: open the phrase modal. completeWizard runs
-        // from the modal's onClose so navigation only happens after
-        // the operator has acknowledged the phrase (or accepted the
-        // installation-wide warning on the cancel gate).
-        phraseModal.open(response.recovery_phrase);
-      } else {
-        // Edge case 2: a key file already exists, no phrase to show.
-        // Wizard is done.
-        completeWizard();
+      // Save api_key if needed.
+      if (mode === "create" || (mode === "repair" && missingLabel === "api_key")) {
+        const response = await createBrokerCredential({
+          provider: "etoro",
+          label: "api_key",
+          environment: ENVIRONMENT,
+          secret: brokerApiKey,
+        });
+        if (response.recovery_phrase != null && response.recovery_phrase.length > 0) {
+          // Save user_key before showing the phrase modal (both rows
+          // must be durable before the wizard completes).
+          if (mode === "create") {
+            await createBrokerCredential({
+              provider: "etoro",
+              label: "user_key",
+              environment: ENVIRONMENT,
+              secret: brokerUserKey,
+            });
+          }
+          setBrokerApiKey("");
+          setBrokerUserKey("");
+          phraseModal.open(response.recovery_phrase);
+          return;
+        }
       }
+
+      // Save user_key if needed.
+      if (mode === "create" || (mode === "repair" && missingLabel === "user_key")) {
+        await createBrokerCredential({
+          provider: "etoro",
+          label: "user_key",
+          environment: ENVIRONMENT,
+          secret: brokerUserKey,
+        });
+      }
+
+      setBrokerApiKey("");
+      setBrokerUserKey("");
+      completeWizard();
     } catch (err: unknown) {
-      // Operator stays on step 2 with form values preserved (except
-      // the secret, which is preserved here too because we have not
-      // confirmed that it actually committed). "Skip for now" remains
-      // available so a transient backend failure does not lock the
-      // operator out of completing setup.
       if (err instanceof ApiError && err.status === 409) {
-        setBrokerError(BROKER_CONFLICT_ERROR);
+        setBrokerError("A credential with that label already exists. Revoke it from Settings to replace.");
       } else if (err instanceof ApiError && err.status === 400) {
-        setBrokerError(BROKER_VALIDATION_ERROR);
+        setBrokerError("Invalid API key or user key value.");
       } else {
-        setBrokerError(BROKER_GENERIC_ERROR);
+        setBrokerError("Could not save credential.");
       }
+      // Re-derive mode from the refreshed list in case the first call
+      // succeeded but the second failed (partial state).
+      await refreshCredentials();
     } finally {
       setBrokerSubmitting(false);
     }
@@ -198,6 +257,14 @@ export function SetupPage(): JSX.Element {
       </div>
     );
   }
+
+  const showApiKeyField = mode === "create" || (mode === "repair" && missingLabel === "api_key");
+  const showUserKeyField = mode === "create" || (mode === "repair" && missingLabel === "user_key");
+  const canTestConnection = mode === "create" && brokerApiKey.length >= MIN_SECRET_LEN && brokerUserKey.length >= MIN_SECRET_LEN;
+  const canSave =
+    !brokerSubmitting &&
+    (showApiKeyField ? brokerApiKey.length >= MIN_SECRET_LEN : true) &&
+    (showUserKeyField ? brokerUserKey.length >= MIN_SECRET_LEN : true);
 
   return (
     <div className="flex h-screen w-screen items-center justify-center bg-slate-50">
@@ -270,54 +337,126 @@ export function SetupPage(): JSX.Element {
             {submitting ? "Creating…" : "Create operator"}
           </button>
         </form>
+      ) : mode === "complete" ? (
+        <div className="w-full max-w-sm rounded border border-slate-200 bg-white p-6 shadow-sm">
+          <h1 className="mb-1 text-lg font-semibold text-slate-800">
+            Credentials configured
+          </h1>
+          <p className="mb-4 text-xs text-slate-500">
+            Both eToro credentials are saved. You can manage them from Settings.
+          </p>
+          <button
+            type="button"
+            onClick={completeWizard}
+            className="w-full rounded bg-slate-800 py-2 text-sm font-medium text-white"
+          >
+            Continue
+          </button>
+        </div>
       ) : (
         <form
           onSubmit={handleBrokerSubmit}
-          className="w-full max-w-sm rounded border border-slate-200 bg-white p-6 shadow-sm"
+          className="w-full max-w-sm space-y-3 rounded border border-slate-200 bg-white p-6 shadow-sm"
         >
-          <h1 className="mb-1 text-lg font-semibold text-slate-800">
-            Add a broker credential
+          <h1 className="text-lg font-semibold text-slate-800">
+            {mode === "repair" ? "Complete credential setup" : "Add eToro credentials"}
           </h1>
-          <p className="mb-4 text-xs text-slate-500">
-            You can add an eToro credential now or skip this step and add one
-            later from Settings. eBull will not place any orders until at least
-            one credential is saved.
+          <p className="text-xs text-slate-500">
+            {mode === "repair"
+              ? `One key was already saved. Enter the missing ${missingLabel === "api_key" ? "API key" : "user key"} to complete the credential pair.`
+              : "You can add your eToro API key and user key now or skip this step and add them later from Settings. eBull will not place any orders until both credentials are saved."}
           </p>
-          <label className="mb-3 block text-sm">
-            <span className="mb-1 block text-slate-600">Provider</span>
-            <select
-              value="etoro"
-              disabled
-              className="w-full rounded border border-slate-300 bg-slate-50 px-2 py-1.5 text-sm text-slate-700"
+
+          {showApiKeyField && (
+            <label className="block text-sm">
+              <span className="mb-1 block text-slate-600">API key</span>
+              <input
+                type="password"
+                name="broker-credential-api-key"
+                autoComplete="new-password"
+                value={brokerApiKey}
+                onChange={(e) => setBrokerApiKey(e.target.value)}
+                minLength={MIN_SECRET_LEN}
+                required
+                className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+              />
+            </label>
+          )}
+
+          {showUserKeyField && (
+            <label className="block text-sm">
+              <span className="mb-1 block text-slate-600">User key</span>
+              <input
+                type="password"
+                name="broker-credential-user-key"
+                autoComplete="new-password"
+                value={brokerUserKey}
+                onChange={(e) => setBrokerUserKey(e.target.value)}
+                minLength={MIN_SECRET_LEN}
+                required
+                className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+              />
+            </label>
+          )}
+
+          {/* Test connection — only in Create mode (both keys present). */}
+          <div className="space-y-1">
+            <button
+              type="button"
+              onClick={() => void handleTestConnection()}
+              disabled={!canTestConnection || validating}
+              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50"
             >
-              <option value="etoro">eToro</option>
-            </select>
-          </label>
-          <label className="mb-3 block text-sm">
-            <span className="mb-1 block text-slate-600">Label</span>
-            <input
-              type="text"
-              autoComplete="off"
-              value={brokerLabel}
-              onChange={(e) => setBrokerLabel(e.target.value)}
-              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
-            />
-          </label>
-          <label className="mb-4 block text-sm">
-            <span className="mb-1 block text-slate-600">Secret</span>
-            <input
-              type="password"
-              autoComplete="off"
-              value={brokerSecret}
-              onChange={(e) => setBrokerSecret(e.target.value)}
-              minLength={MIN_SECRET_LEN}
-              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
-            />
-          </label>
+              {validating ? "Testing…" : "Test connection"}
+            </button>
+            {mode === "repair" && (
+              <p className="text-xs text-slate-400">
+                Connection testing requires both keys. The already-saved key cannot be read back.
+              </p>
+            )}
+          </div>
+
+          {/* Validation result display. */}
+          {validationError !== null && (
+            <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
+              {validationError}
+            </div>
+          )}
+          {validationResult !== null && !validationResult.auth_valid && (
+            <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
+              Authentication failed — check your API key and user key.
+            </div>
+          )}
+          {validationResult !== null && validationResult.auth_valid && !validationResult.env_valid && (
+            <div className="space-y-1">
+              <div className="rounded bg-amber-50 px-2 py-1.5 text-xs text-amber-700">
+                Authenticated, but environment check failed: {validationResult.env_check}
+              </div>
+              {validationResult.note && (
+                <p className="text-xs text-slate-400">{validationResult.note}</p>
+              )}
+            </div>
+          )}
+          {validationResult !== null && validationResult.auth_valid && validationResult.env_valid && (
+            <div className="space-y-1">
+              <div className="rounded bg-emerald-50 px-2 py-1.5 text-xs text-emerald-700">
+                Connection verified
+                {validationResult.identity?.gcid != null && (
+                  <span className="ml-1 text-emerald-600">
+                    (account {validationResult.identity.gcid})
+                  </span>
+                )}
+              </div>
+              {validationResult.note && (
+                <p className="text-xs text-slate-400">{validationResult.note}</p>
+              )}
+            </div>
+          )}
+
           {brokerError !== null && (
             <div
               role="alert"
-              className="mb-3 rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700"
+              className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700"
             >
               {brokerError}
             </div>
@@ -333,14 +472,10 @@ export function SetupPage(): JSX.Element {
             </button>
             <button
               type="submit"
-              disabled={
-                brokerSubmitting ||
-                brokerLabel.trim() === "" ||
-                brokerSecret.length < MIN_SECRET_LEN
-              }
+              disabled={!canSave}
               className="flex-1 rounded bg-slate-800 py-2 text-sm font-medium text-white disabled:bg-slate-400"
             >
-              {brokerSubmitting ? "Saving…" : "Save credential"}
+              {brokerSubmitting ? "Saving…" : "Save credentials"}
             </button>
           </div>
         </form>

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -36,7 +36,7 @@
  *   even with the in-memory React flag deferred.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -50,6 +50,7 @@ import {
   listBrokerCredentials,
   validateBrokerCredential,
 } from "@/api/brokerCredentials";
+import { ValidationResultDisplay } from "@/components/broker/ValidationResultDisplay";
 import { useRecoveryPhraseModal } from "@/components/security/RecoveryPhraseModal";
 import { deriveCredentialSetMode, ENVIRONMENT } from "@/lib/credentialSetMode";
 import { useSession } from "@/lib/session";
@@ -92,13 +93,24 @@ export function SetupPage(): JSX.Element {
     useState<ValidateCredentialResponse | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
 
+  const refreshCredentials = useCallback(async (): Promise<void> => {
+    try {
+      const data = await listBrokerCredentials();
+      setCredRows(data);
+    } catch {
+      // On the setup page, failure to list credentials is non-fatal —
+      // the operator can still enter both keys (Create mode).
+      setCredRows(null);
+    }
+  }, []);
+
   // Fetch existing credentials when entering step 2 so that
   // partial-save state from a prior session is correctly detected.
   useEffect(() => {
     if (step === "broker") {
       void refreshCredentials();
     }
-  }, [step]);
+  }, [step, refreshCredentials]);
 
   // Clear stale validation result when inputs change or mode transitions.
   useEffect(() => {
@@ -141,17 +153,6 @@ export function SetupPage(): JSX.Element {
       setError(GENERIC_ERROR);
     } finally {
       setSubmitting(false);
-    }
-  }
-
-  async function refreshCredentials(): Promise<void> {
-    try {
-      const data = await listBrokerCredentials();
-      setCredRows(data);
-    } catch {
-      // On the setup page, failure to list credentials is non-fatal —
-      // the operator can still enter both keys (Create mode).
-      setCredRows(null);
     }
   }
 
@@ -400,42 +401,10 @@ export function SetupPage(): JSX.Element {
             )}
           </div>
 
-          {/* Validation result display. */}
-          {validationError !== null && (
-            <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
-              {validationError}
-            </div>
-          )}
-          {validationResult !== null && !validationResult.auth_valid && (
-            <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
-              Authentication failed — check your API key and user key.
-            </div>
-          )}
-          {validationResult !== null && validationResult.auth_valid && !validationResult.env_valid && (
-            <div className="space-y-1">
-              <div className="rounded bg-amber-50 px-2 py-1.5 text-xs text-amber-700">
-                Authenticated, but environment check failed: {validationResult.env_check}
-              </div>
-              {validationResult.note && (
-                <p className="text-xs text-slate-400">{validationResult.note}</p>
-              )}
-            </div>
-          )}
-          {validationResult !== null && validationResult.auth_valid && validationResult.env_valid && (
-            <div className="space-y-1">
-              <div className="rounded bg-emerald-50 px-2 py-1.5 text-xs text-emerald-700">
-                Connection verified
-                {validationResult.identity?.gcid != null && (
-                  <span className="ml-1 text-emerald-600">
-                    (account {validationResult.identity.gcid})
-                  </span>
-                )}
-              </div>
-              {validationResult.note && (
-                <p className="text-xs text-slate-400">{validationResult.note}</p>
-              )}
-            </div>
-          )}
+          <ValidationResultDisplay
+            result={validationResult}
+            error={validationError}
+          />
 
           {brokerError !== null && (
             <div


### PR DESCRIPTION
## What changed

Frontend updates for the real eToro two-key credential model (PR D of the #139 provider rewrite).

**Files changed:**
- `frontend/src/api/brokerCredentials.ts` �� added `environment` to `BrokerCredentialView`, `environment` param to `createBrokerCredential`, new `validateBrokerCredential` client + response types
- `frontend/src/pages/SettingsPage.tsx` — two-key form, credential-set mode detection (Create/Repair/Complete), "Test connection" button, validation result display
- `frontend/src/pages/SetupPage.tsx` — same two-key pattern within the setup wizard step 2
- `frontend/src/pages/SettingsPage.test.tsx` — 18 tests covering all modes, validation states, two-key save, partial-save recovery, recovery phrase modal
- `frontend/src/pages/SetupPage.test.tsx` — 9 tests covering wizard flow with two-key model

## Why

The backend (PRs A-C) now stores eToro credentials as two separate rows (`label="api_key"` and `label="user_key"`) and expects the three-header auth scheme. The frontend was still sending a single `secret` field. This PR aligns the frontend with the real credential model.

Key design decisions:
- **Two sequential POST calls** (not a batch endpoint) — matches how the scheduler loads them
- **Fixed labels** — operator no longer chooses labels; they're always `api_key`/`user_key`
- **Credential-set mode detection** — inspects loaded credential list to derive Create/Repair/Complete mode, which fixes the partial-save retry problem (first key saved, second failed → naive retry would 409 on duplicate api_key)
- **Test connection disabled in Repair mode** — the validate endpoint requires both keys, but the stored key cannot be read back (write-only secret model)

## Schema / migration impact

None. Frontend-only PR. No backend changes.

## Invariants checked

- **API shape parity**: `BrokerCredentialView.environment` matches backend `CredentialMetadataOut.environment`. `ValidateCredentialResponse` fields match `ValidateCredentialResponse` Pydantic model field-for-field.
- **Write-only secret model preserved**: secrets flow only in POST request bodies, never in read responses. The frontend cannot retrieve stored secrets.
- **Recovery phrase modal flow preserved**: the existing lazy-gen / phrase confirmation / cancel-gate flow is unchanged. Both credentials are saved before the modal opens.
- **Session assumption for SetupPage**: the "Test connection" button works in the setup wizard because step 1 (POST /auth/setup) sets the session cookie before step 2 renders.

## Failure paths considered

- **Partial save (first key succeeds, second fails)**: the form refreshes the credential list and re-derives to Repair mode, showing only the missing key's field. No duplicate-on-retry.
- **Both keys already exist**: Complete mode hides the create form entirely. Operator must revoke before replacing.
- **Validation endpoint unreachable**: shows generic "Could not reach the validation endpoint" error.
- **Auth validation fails**: red "Authentication failed — check your API key and user key." `note` field is NOT used as the error message (it's a disclaimer, not a failure reason).
- **Environment check fails (auth OK)**: amber warning with `env_check` detail.
- **Stale validation result**: cleared whenever either key input changes or credential-set mode transitions.
- **409 on save**: "A credential with that label already exists. Revoke it first to replace."

## Conscious tradeoffs

- **Two sequential POST calls instead of a batch endpoint**: simple, matches scheduler load pattern. Partial failure handled via credential-set mode detection.
- **Environment hardcoded to "demo"**: v1 is demo-only per spec. Backend already accepts the parameter for architectural readiness.
- **No `types.ts` update**: broker credential types are defined inline in `brokerCredentials.ts` — this is the existing pattern in the codebase.

## Security model

- Secrets (API key, user key) are held only in component state and cleared on successful submit. Never persisted to localStorage, sessionStorage, or any cache.
- The validate endpoint is session-gated — unauthenticated requests get 401.
- Candidate credentials for validation are transient (sent to backend, used for two read-only probes, discarded).

## Verification

```bash
pnpm --dir frontend typecheck   # pass
pnpm --dir frontend test         # 90 passed (18 SettingsPage, 9 SetupPage)
uv run ruff check .              # pass
uv run ruff format --check .     # pass
uv run pyright                   # pass
uv run pytest                    # 990 passed
```