### PR TITLE
feat(#146): job orchestration cleanup — prerequisites, conditional catch-up, log noise

### DIFF
--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -71,7 +71,7 @@ class JobRunResponse(BaseModel):
     job_name: str
     started_at: datetime
     finished_at: datetime | None
-    status: Literal["running", "success", "failure"]
+    status: Literal["running", "success", "failure", "skipped"]
     row_count: int | None
     error_msg: str | None
 

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -94,7 +94,7 @@ class KillSwitchStateResponse(BaseModel):
 
 class JobHealthResponse(BaseModel):
     name: str
-    last_status: Literal["running", "success", "failure"] | None
+    last_status: Literal["running", "success", "failure", "skipped"] | None
     last_started_at: datetime | None
     last_finished_at: datetime | None
     detail: str
@@ -115,7 +115,7 @@ class JobOverviewResponse(BaseModel):
     cadence_kind: Literal["hourly", "daily", "weekly"]
     next_run_time: datetime
     next_run_time_source: Literal["declared"]  # see module docstring
-    last_status: Literal["running", "success", "failure"] | None
+    last_status: Literal["running", "success", "failure", "skipped"] | None
     last_started_at: datetime | None
     last_finished_at: datetime | None
     detail: str

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -341,7 +341,7 @@ class JobRuntime:
         skipped: list[tuple[str, str]] = []  # (name, reason)
         processed: set[str] = set()
         try:
-            with psycopg.connect(self._database_url) as conn:
+            with psycopg.connect(self._database_url, autocommit=True) as conn:
                 for name in overdue:
                     job = catch_up_jobs[name]
                     if job.prerequisite is not None:
@@ -518,7 +518,7 @@ class JobRuntime:
             # bypass prerequisites so the operator can force a run).
             if job is not None and job.prerequisite is not None:
                 try:
-                    with psycopg.connect(database_url) as conn:
+                    with psycopg.connect(database_url, autocommit=True) as conn:
                         met, reason = job.prerequisite(conn)
                         if not met:
                             record_job_skip(conn, job_name, reason)

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -58,7 +58,7 @@ from apscheduler.triggers.cron import CronTrigger
 
 from app.config import settings
 from app.jobs.locks import JobAlreadyRunning, JobLock
-from app.services.ops_monitor import fetch_latest_successful_runs
+from app.services.ops_monitor import fetch_latest_successful_runs, record_job_skip
 from app.workers.scheduler import (
     JOB_DAILY_CIK_REFRESH,
     JOB_DAILY_NEWS_REFRESH,
@@ -231,6 +231,11 @@ class JobRuntime:
             thread_name_prefix="job-manual",
         )
         self._started = False
+        # Name → ScheduledJob lookup for prerequisite checks in the
+        # scheduled-fire path.
+        self._job_registry: dict[str, ScheduledJob] = {
+            job.name: job for job in SCHEDULED_JOBS if job.name in self._invokers
+        }
 
     # -- lifecycle ---------------------------------------------------------
 
@@ -277,11 +282,9 @@ class JobRuntime:
           (per ``compute_next_run``) is at or before ``now``, it is
           overdue.
 
-        Overdue jobs are submitted to the manual executor through the
-        same ``_wrap_invoker`` path as scheduled fires, so advisory
-        locks serialise catch-up against concurrent scheduled or
-        manual runs. Failures are logged and do not prevent other
-        catch-up jobs from firing.
+        Overdue jobs whose prerequisite check returns ``False`` are
+        skipped with a ``job_runs`` row of status='skipped' and a
+        single INFO log line.
 
         The DB query is a single round trip (one SELECT for all job
         names). The connection is opened, used, and closed within this
@@ -325,12 +328,45 @@ class JobRuntime:
             logger.info("catch-up: all jobs are current; nothing to fire")
             return
 
-        logger.info(
-            "catch-up: firing %d overdue job(s): %s",
-            len(overdue),
-            sorted(overdue),
-        )
-        for name in overdue:
+        # Check prerequisites for overdue jobs and split into
+        # fire-list vs skip-list.
+        firing: list[str] = []
+        skipped: list[tuple[str, str]] = []  # (name, reason)
+        try:
+            with psycopg.connect(self._database_url) as conn:
+                for name in overdue:
+                    job = catch_up_jobs[name]
+                    if job.prerequisite is not None:
+                        met, reason = job.prerequisite(conn)
+                        if not met:
+                            skipped.append((name, reason))
+                            record_job_skip(conn, name, reason)
+                            continue
+                    firing.append(name)
+        except Exception:
+            logger.exception("catch-up: prerequisite check failed; firing all overdue jobs")
+            firing = overdue
+            skipped = []
+
+        for name, reason in skipped:
+            logger.info("catch-up: skipping %s — prerequisite not met: %s", name, reason)
+
+        total = len(firing) + len(skipped)
+        if firing:
+            logger.info(
+                "catch-up: firing %d of %d overdue job(s) (%d skipped): %s",
+                len(firing),
+                total,
+                len(skipped),
+                sorted(firing),
+            )
+        elif skipped:
+            logger.info(
+                "catch-up: all %d overdue job(s) skipped (no upstream data)",
+                total,
+            )
+
+        for name in firing:
             invoker = self._invokers[name]
             wrapped = self._wrap_invoker(name, invoker)
             fut = self._manual_executor.submit(wrapped)
@@ -451,19 +487,46 @@ class JobRuntime:
             logger.error("executor future raised unexpectedly: %s", exc, exc_info=exc)
 
     def _wrap_invoker(self, job_name: str, invoker: Callable[[], None]) -> Callable[[], None]:
-        """Wrap a scheduled invoker with the per-job advisory lock.
+        """Wrap a scheduled invoker with prerequisite check + advisory lock.
 
-        The scheduled fire path takes the lock inside the worker (no
-        operator is waiting for a synchronous response, so we do not
-        need the surface-level 409 path the manual trigger uses).
-        Lock contention here is a normal condition -- a scheduled
-        fire that overlaps a still-running manual trigger -- and is
-        logged at INFO and skipped, not raised, because APScheduler
-        would otherwise log a noisy traceback for an expected race.
+        The scheduled fire path checks the prerequisite (if any) before
+        acquiring the lock.  If the prerequisite is not met, a
+        ``job_runs`` row with status='skipped' is recorded and the
+        invoker is not called.
+
+        Lock contention is a normal condition -- a scheduled fire that
+        overlaps a still-running manual trigger -- and is logged at INFO
+        and skipped, not raised, because APScheduler would otherwise log
+        a noisy traceback for an expected race.
         """
         database_url = self._database_url
+        job = self._job_registry.get(job_name)
 
         def wrapped() -> None:
+            # Prerequisite gate (scheduled fires only — manual triggers
+            # bypass prerequisites so the operator can force a run).
+            if job is not None and job.prerequisite is not None:
+                try:
+                    with psycopg.connect(database_url) as conn:
+                        met, reason = job.prerequisite(conn)
+                        if not met:
+                            record_job_skip(conn, job_name, reason)
+                            logger.info(
+                                "scheduled fire of %r skipped — prerequisite not met: %s",
+                                job_name,
+                                reason,
+                            )
+                            return
+                except Exception:
+                    # If the prerequisite check itself fails, let the
+                    # job run — failing open is safer than silently
+                    # skipping real work.
+                    logger.warning(
+                        "prerequisite check for %r failed; running job anyway",
+                        job_name,
+                        exc_info=True,
+                    )
+
             try:
                 with JobLock(database_url, job_name):
                     invoker()

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -329,9 +329,12 @@ class JobRuntime:
             return
 
         # Check prerequisites for overdue jobs and split into
-        # fire-list vs skip-list.
+        # fire-list vs skip-list.  ``processed`` tracks jobs that have
+        # already been categorised (and, for skips, committed to the DB)
+        # so the fallback path does not re-fire already-skipped jobs.
         firing: list[str] = []
         skipped: list[tuple[str, str]] = []  # (name, reason)
+        processed: set[str] = set()
         try:
             with psycopg.connect(self._database_url) as conn:
                 for name in overdue:
@@ -339,14 +342,18 @@ class JobRuntime:
                     if job.prerequisite is not None:
                         met, reason = job.prerequisite(conn)
                         if not met:
-                            skipped.append((name, reason))
                             record_job_skip(conn, name, reason)
+                            skipped.append((name, reason))
+                            processed.add(name)
                             continue
                     firing.append(name)
+                    processed.add(name)
         except Exception:
-            logger.exception("catch-up: prerequisite check failed; firing all overdue jobs")
-            firing = overdue
-            skipped = []
+            logger.exception("catch-up: prerequisite check failed; firing unprocessed overdue jobs")
+            # Only fire jobs that were not already processed (skipped
+            # jobs already have committed job_runs rows).
+            firing = [n for n in overdue if n not in processed]
+            skipped = [(n, r) for n, r in skipped if n in processed]
 
         for name, reason in skipped:
             logger.info("catch-up: skipping %s — prerequisite not met: %s", name, reason)

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -330,8 +330,13 @@ class JobRuntime:
 
         # Check prerequisites for overdue jobs and split into
         # fire-list vs skip-list.  ``processed`` tracks jobs that have
-        # already been categorised (and, for skips, committed to the DB)
-        # so the fallback path does not re-fire already-skipped jobs.
+        # already been categorised so the fallback path does not
+        # re-fire already-skipped jobs.
+        #
+        # ``processed.add(name)`` is called BEFORE ``record_job_skip``
+        # so that if the skip recording raises after committing the
+        # row, the job is still marked as processed and won't be
+        # double-fired in the fallback path.
         firing: list[str] = []
         skipped: list[tuple[str, str]] = []  # (name, reason)
         processed: set[str] = set()
@@ -342,9 +347,9 @@ class JobRuntime:
                     if job.prerequisite is not None:
                         met, reason = job.prerequisite(conn)
                         if not met:
+                            processed.add(name)
                             record_job_skip(conn, name, reason)
                             skipped.append((name, reason))
-                            processed.add(name)
                             continue
                     firing.append(name)
                     processed.add(name)
@@ -353,7 +358,6 @@ class JobRuntime:
             # Only fire jobs that were not already processed (skipped
             # jobs already have committed job_runs rows).
             firing = [n for n in overdue if n not in processed]
-            skipped = [(n, r) for n, r in skipped if n in processed]
 
         for name, reason in skipped:
             logger.info("catch-up: skipping %s — prerequisite not met: %s", name, reason)

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -337,20 +337,18 @@ def record_job_skip(
     single atomic insert is the honest representation.
     """
     now = now or _utcnow()
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            """
-            INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count, error_msg)
-            VALUES (%(name)s, %(ts)s, %(ts)s, 'skipped', 0, %(reason)s)
-            RETURNING run_id
-            """,
-            {"name": job_name, "ts": now, "reason": reason},
-        )
-        row = cur.fetchone()
+    row = conn.execute(
+        """
+        INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count, error_msg)
+        VALUES (%(name)s, %(ts)s, %(ts)s, 'skipped', 0, %(reason)s)
+        RETURNING run_id
+        """,
+        {"name": job_name, "ts": now, "reason": reason},
+    ).fetchone()
     conn.commit()
     if row is None:
         raise RuntimeError("job_runs INSERT returned no row")
-    return int(row["run_id"])
+    return int(row[0])
 
 
 def check_job_health(

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -101,7 +101,7 @@ _LAYER_QUERIES: dict[LayerName, str] = {
 # (previous_count * threshold), it is flagged as a potential broken source.
 _SPIKE_RATIO_THRESHOLD: float = 0.5
 
-JobStatus = Literal["running", "success", "failure"]
+JobStatus = Literal["running", "success", "failure", "skipped"]
 
 LayerStatus = Literal["ok", "stale", "empty", "error"]
 
@@ -319,6 +319,40 @@ def record_job_finish(
     conn.commit()
 
 
+def record_job_skip(
+    conn: psycopg.Connection[Any],
+    job_name: str,
+    reason: str,
+    *,
+    now: datetime | None = None,
+) -> int:
+    """Record a skipped job run (prerequisite not met).
+
+    Inserts a single ``job_runs`` row with ``status='skipped'``,
+    ``started_at = finished_at = now``, and the skip reason in
+    ``error_msg``.  Returns the ``run_id``.
+
+    This is intentionally separate from the start/finish pair used by
+    ``_tracked_job`` — a skipped job has no execution phase, so a
+    single atomic insert is the honest representation.
+    """
+    now = now or _utcnow()
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count, error_msg)
+            VALUES (%(name)s, %(ts)s, %(ts)s, 'skipped', 0, %(reason)s)
+            RETURNING run_id
+            """,
+            {"name": job_name, "ts": now, "reason": reason},
+        )
+        row = cur.fetchone()
+    conn.commit()
+    if row is None:
+        raise RuntimeError("job_runs INSERT returned no row")
+    return int(row["run_id"])
+
+
 def check_job_health(
     conn: psycopg.Connection[Any],
     job_name: str,
@@ -346,7 +380,11 @@ def check_job_health(
     status: JobStatus = row["status"]
     detail = ""
 
-    if status == "failure":
+    if status == "skipped":
+        detail = f"{job_name}: last run skipped"
+        if row["error_msg"]:
+            detail += f" — {row['error_msg']}"
+    elif status == "failure":
         detail = f"{job_name}: last run failed"
         if row["error_msg"]:
             detail += f" — {row['error_msg']}"

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -337,18 +337,19 @@ def record_job_skip(
     single atomic insert is the honest representation.
     """
     now = now or _utcnow()
-    row = conn.execute(
-        """
-        INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count, error_msg)
-        VALUES (%(name)s, %(ts)s, %(ts)s, 'skipped', 0, %(reason)s)
-        RETURNING run_id
-        """,
-        {"name": job_name, "ts": now, "reason": reason},
-    ).fetchone()
-    conn.commit()
-    if row is None:
-        raise RuntimeError("job_runs INSERT returned no row")
-    return int(row[0])
+    with conn.transaction():
+        row = conn.execute(
+            """
+            INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count, error_msg)
+            VALUES (%(name)s, %(ts)s, %(ts)s, 'skipped', 0, %(reason)s)
+            RETURNING run_id
+            """,
+            {"name": job_name, "ts": now, "reason": reason},
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("job_runs INSERT returned no row")
+        run_id = int(row[0])
+    return run_id
 
 
 def check_job_health(

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -332,9 +332,14 @@ def record_job_skip(
     ``started_at = finished_at = now``, and the skip reason in
     ``error_msg``.  Returns the ``run_id``.
 
+    Callers open the connection with ``autocommit=True``.
+    ``conn.transaction()`` wraps the INSERT in an explicit
+    ``BEGIN``/``COMMIT`` pair (psycopg v3 does this when the
+    connection is in autocommit mode).
+
     This is intentionally separate from the start/finish pair used by
     ``_tracked_job`` — a skipped job has no execution phase, so a
-    single atomic insert is the honest representation.
+    single insert is the honest representation.
     """
     now = now or _utcnow()
     with conn.transaction():

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -341,6 +341,9 @@ def record_job_skip(
     ``_tracked_job`` — a skipped job has no execution phase, so a
     single insert is the honest representation.
     """
+    assert conn.autocommit, (
+        "record_job_skip requires autocommit=True so conn.transaction() issues a real BEGIN/COMMIT, not a savepoint"
+    )
     now = now or _utcnow()
     with conn.transaction():
         row = conn.execute(

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -29,6 +29,8 @@ from typing import Any, Literal
 
 import anthropic
 import psycopg
+import psycopg.rows
+import psycopg.sql
 
 from app.config import settings
 from app.providers.implementations.companies_house import CompaniesHouseFilingsProvider
@@ -176,34 +178,41 @@ JOB_DAILY_TAX_RECONCILIATION = "daily_tax_reconciliation"
 # catch-up summary log line.
 
 
+def _exists(conn: psycopg.Connection[Any], sql: psycopg.sql.SQL) -> bool:
+    """Run a ``SELECT EXISTS(...)`` query and return the boolean result.
+
+    Uses an explicit ``tuple_row`` factory so the result is always
+    positional, regardless of the connection-level ``row_factory``.
+    """
+    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+        row = cur.execute(sql).fetchone()
+    return row is not None and bool(row[0])
+
+
 def _has_coverage_tier12(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     """True if at least one Tier 1 or Tier 2 coverage row exists."""
-    row = conn.execute("SELECT EXISTS(SELECT 1 FROM coverage WHERE coverage_tier IN (1, 2)) AS ok").fetchone()
-    if row is not None and row[0]:
+    if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM coverage WHERE coverage_tier IN (1, 2))")):
         return (True, "")
     return (False, "no Tier 1/2 coverage rows")
 
 
 def _has_any_coverage(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     """True if the coverage table has at least one row."""
-    row = conn.execute("SELECT EXISTS(SELECT 1 FROM coverage) AS ok").fetchone()
-    if row is not None and row[0]:
+    if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM coverage)")):
         return (True, "")
     return (False, "coverage table is empty")
 
 
 def _has_scores(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     """True if at least one score row exists."""
-    row = conn.execute("SELECT EXISTS(SELECT 1 FROM scores) AS ok").fetchone()
-    if row is not None and row[0]:
+    if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM scores)")):
         return (True, "")
     return (False, "no scores rows")
 
 
 def _has_tier1_stale_theses(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     """True if at least one Tier 1 instrument exists (thesis staleness is checked by the job itself)."""
-    row = conn.execute("SELECT EXISTS(SELECT 1 FROM coverage WHERE coverage_tier = 1) AS ok").fetchone()
-    if row is not None and row[0]:
+    if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM coverage WHERE coverage_tier = 1)")):
         return (True, "")
     return (False, "no Tier 1 instruments")
 
@@ -260,13 +269,10 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         cadence=Cadence.weekly(weekday=0, hour=5, minute=0),
         prerequisite=_has_any_coverage,
     ),
-    # -- On-demand: not part of the default scheduled flow ---------------
-    ScheduledJob(
-        name=JOB_DAILY_TAX_RECONCILIATION,
-        description="Ingest new fills into tax_lots and re-run disposal matching.",
-        cadence=Cadence.daily(hour=23, minute=0),
-        catch_up_on_boot=False,
-    ),
+    # -- On-demand jobs are NOT listed here.  They stay in _INVOKERS
+    # (runtime.py) so "Run now" in the Admin UI works, but they are
+    # not registered with APScheduler and do not participate in
+    # catch-up.  Currently on-demand: daily_tax_reconciliation.
 ]
 
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -22,10 +22,10 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
-from typing import Literal
+from typing import Any, Literal
 
 import anthropic
 import psycopg
@@ -125,6 +125,15 @@ class Cadence:
         return f"weekly on {weekday_names[self.weekday]} at {self.hour:02d}:{self.minute:02d} UTC"
 
 
+PrerequisiteResult = tuple[bool, str]
+"""(met, reason) — True if the prerequisite is satisfied; reason explains why not."""
+
+# Type alias for prerequisite callables.  Each takes a psycopg connection
+# and returns (met, reason).  The connection is opened by the caller
+# (catch-up or scheduled-fire path) and closed after the check.
+PrerequisiteFn = Callable[[psycopg.Connection[Any]], PrerequisiteResult]
+
+
 @dataclass(frozen=True)
 class ScheduledJob:
     """A registered scheduled job."""
@@ -138,6 +147,11 @@ class ScheduledJob:
     # too expensive or have side-effects that make cold-start firing
     # undesirable.
     catch_up_on_boot: bool = True
+    # Optional prerequisite check.  When set, the catch-up and
+    # scheduled-fire paths call this before running the job.  If
+    # the check returns (False, reason), the job is skipped and a
+    # ``job_runs`` row with status='skipped' is recorded.
+    prerequisite: PrerequisiteFn | None = None
 
 
 # Job-name constants. Every ``_tracked_job(...)`` call site below references
@@ -153,54 +167,105 @@ JOB_WEEKLY_COVERAGE_REVIEW = "weekly_coverage_review"
 JOB_DAILY_TAX_RECONCILIATION = "daily_tax_reconciliation"
 
 
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+#
+# Each returns (met: bool, reason: str).  The reason is recorded in the
+# job_runs.error_msg column when the job is skipped and in the boot
+# catch-up summary log line.
+
+
+def _has_coverage_tier12(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if at least one Tier 1 or Tier 2 coverage row exists."""
+    row = conn.execute("SELECT EXISTS(SELECT 1 FROM coverage WHERE coverage_tier IN (1, 2)) AS ok").fetchone()
+    if row is not None and row[0]:
+        return (True, "")
+    return (False, "no Tier 1/2 coverage rows")
+
+
+def _has_any_coverage(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if the coverage table has at least one row."""
+    row = conn.execute("SELECT EXISTS(SELECT 1 FROM coverage) AS ok").fetchone()
+    if row is not None and row[0]:
+        return (True, "")
+    return (False, "coverage table is empty")
+
+
+def _has_scores(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if at least one score row exists."""
+    row = conn.execute("SELECT EXISTS(SELECT 1 FROM scores) AS ok").fetchone()
+    if row is not None and row[0]:
+        return (True, "")
+    return (False, "no scores rows")
+
+
+def _has_tier1_stale_theses(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if at least one Tier 1 instrument exists (thesis staleness is checked by the job itself)."""
+    row = conn.execute("SELECT EXISTS(SELECT 1 FROM coverage WHERE coverage_tier = 1) AS ok").fetchone()
+    if row is not None and row[0]:
+        return (True, "")
+    return (False, "no Tier 1 instruments")
+
+
 # Declared schedule. Hours/minutes are deliberate-but-arbitrary placeholders
 # until APScheduler is wired — the values are stable enough for operator UI
 # planning but should not be treated as the live truth. See module docstring.
 SCHEDULED_JOBS: list[ScheduledJob] = [
+    # -- Always-on: data infrastructure, no prerequisites ----------------
     ScheduledJob(
         name=JOB_NIGHTLY_UNIVERSE_SYNC,
         description="Sync the eToro tradable instrument universe to the local DB.",
         cadence=Cadence.daily(hour=2, minute=0),
     ),
     ScheduledJob(
-        name=JOB_HOURLY_MARKET_REFRESH,
-        description="Refresh quotes and candles for all active Tier 1/2 instruments.",
-        cadence=Cadence.hourly(minute=5),
-    ),
-    ScheduledJob(
         name=JOB_DAILY_CIK_REFRESH,
         description="Refresh the SEC ticker→CIK mapping in external_identifiers.",
         cadence=Cadence.daily(hour=3, minute=0),
+    ),
+    # -- Pipeline: skip when upstream data is absent ---------------------
+    ScheduledJob(
+        name=JOB_HOURLY_MARKET_REFRESH,
+        description="Refresh quotes and candles for all active Tier 1/2 instruments.",
+        cadence=Cadence.hourly(minute=5),
+        prerequisite=_has_coverage_tier12,
     ),
     ScheduledJob(
         name=JOB_DAILY_RESEARCH_REFRESH,
         description="Refresh fundamentals and filings for active Tier 1/2 instruments.",
         cadence=Cadence.daily(hour=3, minute=30),
+        prerequisite=_has_coverage_tier12,
     ),
     ScheduledJob(
         name=JOB_DAILY_NEWS_REFRESH,
         description="Fetch, deduplicate, and score news events for active Tier 1/2 instruments.",
         cadence=Cadence.daily(hour=4, minute=0),
+        prerequisite=_has_coverage_tier12,
     ),
     ScheduledJob(
         name=JOB_DAILY_THESIS_REFRESH,
         description="Regenerate theses for stale Tier 1 instruments.",
         cadence=Cadence.daily(hour=4, minute=30),
+        prerequisite=_has_tier1_stale_theses,
     ),
     ScheduledJob(
         name=JOB_MORNING_CANDIDATE_REVIEW,
         description="Re-score, rank, and generate trade recommendations for Tier 1 candidates.",
         cadence=Cadence.daily(hour=6, minute=0),
+        prerequisite=_has_scores,
     ),
     ScheduledJob(
         name=JOB_WEEKLY_COVERAGE_REVIEW,
         description="Review coverage tier assignments; promote/demote instruments.",
         cadence=Cadence.weekly(weekday=0, hour=5, minute=0),
+        prerequisite=_has_any_coverage,
     ),
+    # -- On-demand: not part of the default scheduled flow ---------------
     ScheduledJob(
         name=JOB_DAILY_TAX_RECONCILIATION,
         description="Ingest new fills into tax_lots and re-run disposal matching.",
         cadence=Cadence.daily(hour=23, minute=0),
+        catch_up_on_boot=False,
     ),
 ]
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -49,7 +49,7 @@ export interface ConfigResponse {
 
 export type LayerStatus = "ok" | "stale" | "empty" | "error";
 export type OverallStatus = "ok" | "degraded" | "down";
-export type JobLastStatus = "running" | "success" | "failure" | null;
+export type JobLastStatus = "running" | "success" | "failure" | "skipped" | null;
 export type CadenceKind = "hourly" | "daily" | "weekly";
 
 export interface LayerHealthResponse {
@@ -109,7 +109,7 @@ export interface JobsListResponse {
 // /jobs/runs (app/api/jobs.py — issue #13 PR B)
 // ---------------------------------------------------------------------------
 
-export type JobRunStatus = "running" | "success" | "failure";
+export type JobRunStatus = "running" | "success" | "failure" | "skipped";
 
 export interface JobRunResponse {
   run_id: number;

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -40,6 +40,7 @@ const STATUS_TONE: Record<string, string> = {
   success: "text-emerald-600",
   failure: "text-red-600",
   running: "text-amber-600",
+  skipped: "text-slate-400",
 };
 
 export function AdminPage() {

--- a/sql/020_job_runs_skipped_status.sql
+++ b/sql/020_job_runs_skipped_status.sql
@@ -1,0 +1,13 @@
+-- Migration 020: add 'skipped' status to job_runs
+--
+-- Jobs that are skipped due to unmet prerequisites (e.g. no coverage rows,
+-- missing API keys) are now recorded with status='skipped' instead of
+-- status='success' with row_count=0.  This lets the Admin UI distinguish
+-- "ran and did nothing" from "deliberately skipped because upstream data
+-- was not ready".
+--
+-- Issue: #146
+
+ALTER TABLE job_runs
+    DROP CONSTRAINT job_runs_status_check,
+    ADD CONSTRAINT job_runs_status_check CHECK (status IN ('running', 'success', 'failure', 'skipped'));

--- a/sql/020_job_runs_skipped_status.sql
+++ b/sql/020_job_runs_skipped_status.sql
@@ -8,6 +8,10 @@
 --
 -- Issue: #146
 
+BEGIN;
+
 ALTER TABLE job_runs
     DROP CONSTRAINT job_runs_status_check,
     ADD CONSTRAINT job_runs_status_check CHECK (status IN ('running', 'success', 'failure', 'skipped'));
+
+COMMIT;

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -284,6 +284,22 @@ _NO_CATCHUP_JOB = ScheduledJob(
     catch_up_on_boot=False,
 )
 
+_PREREQ_MET_JOB = ScheduledJob(
+    name="prereq_met_job",
+    description="test with met prerequisite",
+    cadence=Cadence.daily(hour=2, minute=0),
+    catch_up_on_boot=True,
+    prerequisite=lambda _conn: (True, ""),
+)
+
+_PREREQ_UNMET_JOB = ScheduledJob(
+    name="prereq_unmet_job",
+    description="test with unmet prerequisite",
+    cadence=Cadence.daily(hour=2, minute=0),
+    catch_up_on_boot=True,
+    prerequisite=lambda _conn: (False, "no coverage rows"),
+)
+
 
 def _make_catchup_runtime(
     jobs: list[ScheduledJob],
@@ -304,6 +320,12 @@ def _make_catchup_runtime(
     monkeypatch.setattr(
         "app.jobs.runtime.fetch_latest_successful_runs",
         lambda _conn, _names: latest_runs or {},
+    )
+
+    # Stub record_job_skip so catch-up can record skips without a real DB.
+    monkeypatch.setattr(
+        "app.jobs.runtime.record_job_skip",
+        lambda _conn, _name, _reason: 0,
     )
 
     # Stub psycopg.connect so _catch_up gets a no-op connection.
@@ -482,3 +504,190 @@ class TestCatchUpOnBoot:
         rt._catch_up()
         rt._manual_executor.shutdown(wait=True)
         assert fired == ["daily_job"]
+
+
+# ---------------------------------------------------------------------------
+# Catch-up with prerequisites
+# ---------------------------------------------------------------------------
+
+
+class TestCatchUpPrerequisites:
+    """Tests for prerequisite-gated catch-up on boot."""
+
+    def test_unmet_prerequisite_skips_overdue_job(
+        self,
+        patched_runtime: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fired: list[str] = []
+
+        def invoker() -> None:
+            fired.append("prereq_unmet_job")
+
+        rt, _ = _make_catchup_runtime(
+            [_PREREQ_UNMET_JOB],
+            {"prereq_unmet_job": invoker},
+            monkeypatch,
+            latest_runs={},  # never run → overdue
+        )
+        rt._catch_up()
+        rt._manual_executor.shutdown(wait=True)
+        assert fired == []  # skipped, not fired
+
+    def test_met_prerequisite_fires_overdue_job(
+        self,
+        patched_runtime: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fired: list[str] = []
+
+        def invoker() -> None:
+            fired.append("prereq_met_job")
+
+        rt, _ = _make_catchup_runtime(
+            [_PREREQ_MET_JOB],
+            {"prereq_met_job": invoker},
+            monkeypatch,
+            latest_runs={},
+        )
+        rt._catch_up()
+        rt._manual_executor.shutdown(wait=True)
+        assert fired == ["prereq_met_job"]
+
+    def test_mixed_prerequisites_only_met_jobs_fire(
+        self,
+        patched_runtime: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fired: list[str] = []
+
+        def met_invoker() -> None:
+            fired.append("prereq_met_job")
+
+        def unmet_invoker() -> None:
+            fired.append("prereq_unmet_job")
+
+        rt, _ = _make_catchup_runtime(
+            [_PREREQ_MET_JOB, _PREREQ_UNMET_JOB],
+            {"prereq_met_job": met_invoker, "prereq_unmet_job": unmet_invoker},
+            monkeypatch,
+            latest_runs={},
+        )
+        rt._catch_up()
+        rt._manual_executor.shutdown(wait=True)
+        assert fired == ["prereq_met_job"]
+
+    def test_no_prerequisite_job_fires_normally(
+        self,
+        patched_runtime: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Jobs without a prerequisite (None) are always fired when overdue."""
+        fired: list[str] = []
+
+        def invoker() -> None:
+            fired.append("daily_job")
+
+        rt, _ = _make_catchup_runtime(
+            [_DAILY_JOB],
+            {"daily_job": invoker},
+            monkeypatch,
+            latest_runs={},
+        )
+        rt._catch_up()
+        rt._manual_executor.shutdown(wait=True)
+        assert fired == ["daily_job"]
+
+    def test_prerequisite_check_records_skip(
+        self,
+        patched_runtime: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When a prerequisite is unmet, record_job_skip is called."""
+        skip_calls: list[tuple[str, str]] = []
+
+        monkeypatch.setattr("app.jobs.runtime.SCHEDULED_JOBS", [_PREREQ_UNMET_JOB])
+        monkeypatch.setattr(
+            "app.jobs.runtime.fetch_latest_successful_runs",
+            lambda _conn, _names: {},
+        )
+        monkeypatch.setattr(
+            "app.jobs.runtime.record_job_skip",
+            lambda _conn, name, reason: skip_calls.append((name, reason)) or 0,
+        )
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        monkeypatch.setattr("app.jobs.runtime.psycopg.connect", lambda _url: mock_conn)
+        monkeypatch.setattr(
+            "app.jobs.runtime.datetime",
+            type("_FakeDT", (), {"now": staticmethod(lambda tz: _NOW)}),
+        )
+
+        rt = JobRuntime(
+            database_url="postgresql://stub/stub",
+            invokers={"prereq_unmet_job": lambda: None},  # type: ignore[dict-item]
+        )
+        rt._catch_up()
+        rt._manual_executor.shutdown(wait=True)
+        assert len(skip_calls) == 1
+        assert skip_calls[0] == ("prereq_unmet_job", "no coverage rows")
+
+
+# ---------------------------------------------------------------------------
+# Scheduled-fire prerequisite gate
+# ---------------------------------------------------------------------------
+
+
+class TestScheduledFirePrerequisite:
+    """Tests for prerequisite checking in the scheduled-fire wrapper."""
+
+    def test_unmet_prerequisite_skips_scheduled_fire(
+        self,
+        patched_runtime: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        invocations: list[int] = []
+
+        def invoker() -> None:
+            invocations.append(1)
+
+        # Stub record_job_skip.
+        monkeypatch.setattr(
+            "app.jobs.runtime.record_job_skip",
+            lambda _conn, _name, _reason: 0,
+        )
+
+        # Stub psycopg.connect for the prerequisite check.
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        monkeypatch.setattr("app.jobs.runtime.psycopg.connect", lambda _url: mock_conn)
+        monkeypatch.setattr("app.jobs.runtime.SCHEDULED_JOBS", [_PREREQ_UNMET_JOB])
+
+        rt = _make_runtime({"prereq_unmet_job": invoker})
+        wrapped = rt._wrap_invoker("prereq_unmet_job", invoker)
+        wrapped()
+        assert invocations == []  # invoker was NOT called
+
+    def test_met_prerequisite_runs_scheduled_fire(
+        self,
+        patched_runtime: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        invocations: list[int] = []
+
+        def invoker() -> None:
+            invocations.append(1)
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        monkeypatch.setattr("app.jobs.runtime.psycopg.connect", lambda _url: mock_conn)
+        monkeypatch.setattr("app.jobs.runtime.SCHEDULED_JOBS", [_PREREQ_MET_JOB])
+
+        rt = _make_runtime({"prereq_met_job": invoker})
+        wrapped = rt._wrap_invoker("prereq_met_job", invoker)
+        wrapped()
+        assert invocations == [1]

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -239,25 +239,36 @@ class TestStartWiring:
 
 
 class TestProductionInvokerRegistry:
-    """The production ``_INVOKERS`` map must equal ``SCHEDULED_JOBS``.
+    """Every scheduled job must have an invoker; on-demand jobs may exist
+    in ``_INVOKERS`` without a ``SCHEDULED_JOBS`` entry.
 
-    Drift guard for PR B: a job declared in the registry without an
-    invoker would silently 404 on the manual trigger endpoint, and an
-    invoker without a registry entry would never run on its cadence.
-    Both states are bugs we want to catch at the test layer rather
-    than discovering in production.
+    Drift guard: a job declared in the registry without an invoker
+    would silently 404 on the manual trigger endpoint.
     """
 
-    def test_invokers_cover_every_scheduled_job(self) -> None:
+    def test_every_scheduled_job_has_an_invoker(self) -> None:
         from app.jobs.runtime import _INVOKERS
         from app.workers.scheduler import SCHEDULED_JOBS
 
         registry_names = {job.name for job in SCHEDULED_JOBS}
         invoker_names = set(_INVOKERS.keys())
-        assert registry_names == invoker_names, (
-            f"Drift between SCHEDULED_JOBS and _INVOKERS:\n"
-            f"  in registry but not wired: {sorted(registry_names - invoker_names)}\n"
-            f"  wired but not in registry: {sorted(invoker_names - registry_names)}"
+        missing = registry_names - invoker_names
+        assert not missing, f"Scheduled jobs without invokers (would never fire): {sorted(missing)}"
+
+    def test_every_invoker_is_scheduled_or_on_demand(self) -> None:
+        """On-demand jobs live in _INVOKERS but not SCHEDULED_JOBS.
+
+        This test documents the expected on-demand set so adding a new
+        invoker without scheduling it is a deliberate, visible choice.
+        """
+        from app.jobs.runtime import _INVOKERS
+        from app.workers.scheduler import SCHEDULED_JOBS
+
+        registry_names = {job.name for job in SCHEDULED_JOBS}
+        invoker_names = set(_INVOKERS.keys())
+        on_demand = invoker_names - registry_names
+        assert on_demand == {"daily_tax_reconciliation"}, (
+            f"Unexpected on-demand invokers (update this test if intentional): {sorted(on_demand)}"
         )
 
 

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -343,7 +343,7 @@ def _make_catchup_runtime(
     mock_conn = MagicMock()
     mock_conn.__enter__ = MagicMock(return_value=mock_conn)
     mock_conn.__exit__ = MagicMock(return_value=False)
-    monkeypatch.setattr("app.jobs.runtime.psycopg.connect", lambda _url: mock_conn)
+    monkeypatch.setattr("app.jobs.runtime.psycopg.connect", lambda _url, **_kw: mock_conn)
 
     # Pin the clock.
     monkeypatch.setattr(
@@ -630,7 +630,7 @@ class TestCatchUpPrerequisites:
         mock_conn = MagicMock()
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
         mock_conn.__exit__ = MagicMock(return_value=False)
-        monkeypatch.setattr("app.jobs.runtime.psycopg.connect", lambda _url: mock_conn)
+        monkeypatch.setattr("app.jobs.runtime.psycopg.connect", lambda _url, **_kw: mock_conn)
         monkeypatch.setattr(
             "app.jobs.runtime.datetime",
             type("_FakeDT", (), {"now": staticmethod(lambda tz: _NOW)}),
@@ -674,7 +674,7 @@ class TestScheduledFirePrerequisite:
         mock_conn = MagicMock()
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
         mock_conn.__exit__ = MagicMock(return_value=False)
-        monkeypatch.setattr("app.jobs.runtime.psycopg.connect", lambda _url: mock_conn)
+        monkeypatch.setattr("app.jobs.runtime.psycopg.connect", lambda _url, **_kw: mock_conn)
         monkeypatch.setattr("app.jobs.runtime.SCHEDULED_JOBS", [_PREREQ_UNMET_JOB])
 
         rt = _make_runtime({"prereq_unmet_job": invoker})
@@ -695,7 +695,7 @@ class TestScheduledFirePrerequisite:
         mock_conn = MagicMock()
         mock_conn.__enter__ = MagicMock(return_value=mock_conn)
         mock_conn.__exit__ = MagicMock(return_value=False)
-        monkeypatch.setattr("app.jobs.runtime.psycopg.connect", lambda _url: mock_conn)
+        monkeypatch.setattr("app.jobs.runtime.psycopg.connect", lambda _url, **_kw: mock_conn)
         monkeypatch.setattr("app.jobs.runtime.SCHEDULED_JOBS", [_PREREQ_MET_JOB])
 
         rt = _make_runtime({"prereq_met_job": invoker})

--- a/tests/test_ops_monitor.py
+++ b/tests/test_ops_monitor.py
@@ -34,6 +34,7 @@ from app.services.ops_monitor import (
     get_kill_switch_status,
     get_system_health,
     record_job_finish,
+    record_job_skip,
     record_job_start,
 )
 
@@ -263,6 +264,36 @@ class TestRecordJobFinish:
 
 
 # ---------------------------------------------------------------------------
+# TestRecordJobSkip
+# ---------------------------------------------------------------------------
+
+
+class TestRecordJobSkip:
+    """Test job skip recording."""
+
+    def test_returns_run_id(self) -> None:
+        conn = _make_conn([_make_cursor([{"run_id": 99}])])
+        run_id = record_job_skip(conn, "test_job", "no coverage rows", now=_NOW)
+        assert run_id == 99
+        conn.commit.assert_called_once()
+
+    def test_inserts_skipped_status_with_reason(self) -> None:
+        cur = _make_cursor([{"run_id": 1}])
+        conn = _make_conn([cur])
+        record_job_skip(conn, "my_job", "no Tier 1/2 coverage rows", now=_NOW)
+        call_args = cur.execute.call_args
+        params = call_args[0][1]
+        assert params["name"] == "my_job"
+        assert params["reason"] == "no Tier 1/2 coverage rows"
+        assert "skipped" in call_args[0][0]
+
+    def test_raises_if_no_row_returned(self) -> None:
+        conn = _make_conn([_make_cursor([])])
+        with pytest.raises(RuntimeError, match="no row"):
+            record_job_skip(conn, "test_job", "reason", now=_NOW)
+
+
+# ---------------------------------------------------------------------------
 # TestCheckJobHealth
 # ---------------------------------------------------------------------------
 
@@ -337,6 +368,26 @@ class TestCheckJobHealth:
         result = check_job_health(conn, "test_job")
         assert result.last_status == "running"
         assert "still in progress" in result.detail
+
+    def test_skipped_run_shows_reason(self) -> None:
+        conn = _make_conn(
+            [
+                _make_cursor(
+                    [
+                        {
+                            "status": "skipped",
+                            "started_at": _NOW,
+                            "finished_at": _NOW,
+                            "error_msg": "no Tier 1/2 coverage rows",
+                        }
+                    ]
+                )
+            ]
+        )
+        result = check_job_health(conn, "test_job")
+        assert result.last_status == "skipped"
+        assert "skipped" in result.detail
+        assert "no Tier 1/2 coverage rows" in result.detail
 
     @patch("app.services.ops_monitor._utcnow", return_value=_NOW)
     def test_stuck_running_treated_as_failure(self, mock_now: MagicMock) -> None:

--- a/tests/test_ops_monitor.py
+++ b/tests/test_ops_monitor.py
@@ -271,8 +271,8 @@ class TestRecordJobFinish:
 class TestRecordJobSkip:
     """Test job skip recording.
 
-    ``record_job_skip`` uses ``conn.execute(...).fetchone()`` directly
-    (no separate cursor block).
+    ``record_job_skip`` uses ``conn.transaction()`` + ``conn.execute()``
+    (no separate cursor block, no explicit ``conn.commit()``).
     """
 
     @staticmethod
@@ -287,7 +287,7 @@ class TestRecordJobSkip:
         conn = self._conn_returning((99,))
         run_id = record_job_skip(conn, "test_job", "no coverage rows", now=_NOW)
         assert run_id == 99
-        conn.commit.assert_called_once()
+        conn.transaction.assert_called_once()
 
     def test_inserts_skipped_status_with_reason(self) -> None:
         conn = self._conn_returning((1,))
@@ -302,6 +302,12 @@ class TestRecordJobSkip:
         conn = self._conn_returning(None)
         with pytest.raises(RuntimeError, match="no row"):
             record_job_skip(conn, "test_job", "reason", now=_NOW)
+
+    def test_does_not_call_conn_commit_directly(self) -> None:
+        """Commit is handled by conn.transaction(), not conn.commit()."""
+        conn = self._conn_returning((1,))
+        record_job_skip(conn, "test_job", "reason", now=_NOW)
+        conn.commit.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ops_monitor.py
+++ b/tests/test_ops_monitor.py
@@ -269,26 +269,37 @@ class TestRecordJobFinish:
 
 
 class TestRecordJobSkip:
-    """Test job skip recording."""
+    """Test job skip recording.
+
+    ``record_job_skip`` uses ``conn.execute(...).fetchone()`` directly
+    (no separate cursor block).
+    """
+
+    @staticmethod
+    def _conn_returning(row: tuple[Any, ...] | None) -> MagicMock:
+        conn = _make_conn([])
+        result = MagicMock()
+        result.fetchone.return_value = row
+        conn.execute.return_value = result
+        return conn
 
     def test_returns_run_id(self) -> None:
-        conn = _make_conn([_make_cursor([{"run_id": 99}])])
+        conn = self._conn_returning((99,))
         run_id = record_job_skip(conn, "test_job", "no coverage rows", now=_NOW)
         assert run_id == 99
         conn.commit.assert_called_once()
 
     def test_inserts_skipped_status_with_reason(self) -> None:
-        cur = _make_cursor([{"run_id": 1}])
-        conn = _make_conn([cur])
+        conn = self._conn_returning((1,))
         record_job_skip(conn, "my_job", "no Tier 1/2 coverage rows", now=_NOW)
-        call_args = cur.execute.call_args
+        call_args = conn.execute.call_args
         params = call_args[0][1]
         assert params["name"] == "my_job"
         assert params["reason"] == "no Tier 1/2 coverage rows"
         assert "skipped" in call_args[0][0]
 
     def test_raises_if_no_row_returned(self) -> None:
-        conn = _make_conn([_make_cursor([])])
+        conn = self._conn_returning(None)
         with pytest.raises(RuntimeError, match="no row"):
             record_job_skip(conn, "test_job", "reason", now=_NOW)
 

--- a/tests/test_ops_monitor.py
+++ b/tests/test_ops_monitor.py
@@ -278,6 +278,7 @@ class TestRecordJobSkip:
     @staticmethod
     def _conn_returning(row: tuple[Any, ...] | None) -> MagicMock:
         conn = _make_conn([])
+        conn.autocommit = True
         result = MagicMock()
         result.fetchone.return_value = row
         conn.execute.return_value = result

--- a/tests/test_workers_scheduler_registry.py
+++ b/tests/test_workers_scheduler_registry.py
@@ -37,19 +37,20 @@ class TestRegistryShape:
         for job in SCHEDULED_JOBS:
             assert job.description.strip(), f"job {job.name} has empty description"
 
-    def test_every_job_constant_is_in_registry(self) -> None:
-        # Every JOB_* constant in the scheduler module must appear in the
-        # registry — otherwise a function references a name that the
-        # operator visibility endpoint never reports on.
+    def test_every_job_constant_is_scheduled_or_on_demand(self) -> None:
+        # Every JOB_* constant must be either in SCHEDULED_JOBS or in the
+        # documented on-demand set.  On-demand jobs have a constant and
+        # an invoker but are not registered with APScheduler.
+        from app.jobs.runtime import _INVOKERS
+
         constants = {
             value for name, value in vars(scheduler).items() if name.startswith("JOB_") and isinstance(value, str)
         }
         registry_names = {job.name for job in SCHEDULED_JOBS}
-        assert constants == registry_names, (
-            f"drift between JOB_* constants and SCHEDULED_JOBS: "
-            f"only-in-constants={constants - registry_names}, "
-            f"only-in-registry={registry_names - constants}"
-        )
+        invoker_names = set(_INVOKERS.keys())
+        # Every constant must appear in at least one of the two sets.
+        unaccounted = constants - registry_names - invoker_names
+        assert not unaccounted, f"JOB_* constants not in SCHEDULED_JOBS or _INVOKERS: {sorted(unaccounted)}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #146. Depends on #148 (#145).

- **Classify jobs into tiers**: Always-on (universe_sync, cik_refresh), Pipeline (market_refresh, research, news, thesis, candidate_review, coverage_review), On-demand (tax_reconciliation)
- **Conditional catch-up**: On boot, overdue pipeline jobs check prerequisites before firing. Unmet prerequisites record a `job_runs` row with `status='skipped'` and a clear single-line log explaining why
- **Scheduled-fire prerequisite gate**: Pipeline jobs on their regular schedule also check prerequisites before running (manual triggers bypass prerequisites so operators can force runs)
- **Reduce log noise**: Boot catch-up produces one consolidated summary log line; skipped jobs get a single INFO line each instead of spraying multi-line "0 rows" output

### Schema

- Migration 020: extends `job_runs.status` CHECK constraint to include `'skipped'`

### Backend

- `PrerequisiteFn` type + 4 prerequisite functions: `_has_coverage_tier12`, `_has_any_coverage`, `_has_scores`, `_has_tier1_stale_theses`
- `ScheduledJob.prerequisite` field (optional callable)
- `record_job_skip()` in ops_monitor — atomic single-row insert for skip events
- `_catch_up()` splits overdue jobs into fire-list vs skip-list based on prerequisites
- `_wrap_invoker()` checks prerequisites before acquiring the advisory lock
- `check_job_health()` surfaces skipped status with reason in the detail string

### API

- `JobHealthResponse`, `JobOverviewResponse`, `JobRunResponse` Literal types updated to include `'skipped'`
- `overall_status` derivation unchanged — `skipped` is not treated as degraded

### Frontend

- `JobRunStatus` and `JobLastStatus` types updated
- `STATUS_TONE` map in AdminPage includes `skipped` with slate-400 styling

### Security model

- No new endpoints or auth changes
- Prerequisite functions execute read-only queries against the same connection used by the catch-up/scheduler path
- `record_job_skip` uses parameterised queries only

### Tradeoffs

- Prerequisites are checked on a separate DB connection from the job execution — a prerequisite that passes at check time could become unmet by the time the job runs. This is acceptable because the job functions themselves already handle empty data gracefully (they just do 0 work)
- Manual triggers bypass prerequisites intentionally — the operator should be able to force any job

## Test plan

- [x] 1005 backend tests pass (11 new: 3 record_job_skip, 1 check_job_health skipped, 5 catch-up prerequisites, 2 scheduled-fire prerequisites)
- [x] 93 frontend tests pass
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `pnpm --dir frontend typecheck` — clean
- [x] Migration 020 applied to dev DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)