### PR TITLE
feat(#147): instruments browse page with search, filters, and pagination

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -118,6 +118,7 @@ def _parse_quote(row: dict[str, object]) -> QuoteSnapshot | None:
 @router.get("", response_model=InstrumentListResponse)
 def list_instruments(
     conn: psycopg.Connection[object] = Depends(get_conn),
+    search: str | None = Query(default=None, max_length=100),
     sector: str | None = Query(default=None),
     coverage_tier: int | None = Query(default=None, ge=1, le=3),
     exchange: str | None = Query(default=None),
@@ -127,6 +128,8 @@ def list_instruments(
     """Paginated instrument list with optional filters.
 
     Filters:
+      - search: prefix match on symbol or case-insensitive substring on
+        instrument_display_name (company_name)
       - sector: exact match on instruments.sector
       - coverage_tier: exact match (1/2/3); untiered instruments excluded
       - exchange: exact match on instruments.exchange
@@ -137,6 +140,12 @@ def list_instruments(
     where_clauses: list[str] = []
     filter_params: dict[str, object] = {}
 
+    if search is not None:
+        search = search.strip()
+        if search:
+            where_clauses.append("(i.symbol ILIKE %(search_prefix)s OR i.company_name ILIKE %(search_contains)s)")
+            filter_params["search_prefix"] = f"{search}%"
+            filter_params["search_contains"] = f"%{search}%"
     if sector is not None:
         where_clauses.append("i.sector = %(sector)s")
         filter_params["sector"] = sector

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { LoginPage } from "@/pages/LoginPage";
 import { SetupPage } from "@/pages/SetupPage";
 import { RecoverPage } from "@/pages/RecoverPage";
 import { OperatorsPage } from "@/pages/OperatorsPage";
+import { InstrumentsPage } from "@/pages/InstrumentsPage";
 
 export function App() {
   return (
@@ -30,6 +31,7 @@ export function App() {
         >
           <Route index element={<DashboardPage />} />
           <Route path="rankings" element={<RankingsPage />} />
+          <Route path="instruments" element={<InstrumentsPage />} />
           <Route path="instruments/:instrumentId" element={<InstrumentDetailPage />} />
           <Route path="recommendations" element={<RecommendationsPage />} />
           <Route path="admin" element={<AdminPage />} />

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -1,0 +1,28 @@
+import { apiFetch } from "@/api/client";
+import type { InstrumentListResponse } from "@/api/types";
+
+export interface InstrumentsQuery {
+  search: string | null;
+  sector: string | null;
+  coverage_tier: number | null;
+  exchange: string | null;
+  offset: number;
+  limit: number;
+}
+
+export const INSTRUMENTS_PAGE_LIMIT = 50;
+
+export function fetchInstruments(
+  query: InstrumentsQuery,
+): Promise<InstrumentListResponse> {
+  const params = new URLSearchParams();
+  if (query.search) params.set("search", query.search);
+  if (query.sector) params.set("sector", query.sector);
+  if (query.coverage_tier !== null)
+    params.set("coverage_tier", String(query.coverage_tier));
+  if (query.exchange) params.set("exchange", query.exchange);
+  params.set("offset", String(query.offset));
+  params.set("limit", String(query.limit));
+  const qs = params.toString();
+  return apiFetch<InstrumentListResponse>(`/instruments?${qs}`);
+}

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -16,11 +16,11 @@ export function fetchInstruments(
   query: InstrumentsQuery,
 ): Promise<InstrumentListResponse> {
   const params = new URLSearchParams();
-  if (query.search) params.set("search", query.search);
-  if (query.sector) params.set("sector", query.sector);
+  if (query.search !== null) params.set("search", query.search);
+  if (query.sector !== null) params.set("sector", query.sector);
   if (query.coverage_tier !== null)
     params.set("coverage_tier", String(query.coverage_tier));
-  if (query.exchange) params.set("exchange", query.exchange);
+  if (query.exchange !== null) params.set("exchange", query.exchange);
   params.set("offset", String(query.offset));
   params.set("limit", String(query.limit));
   const qs = params.toString();

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { NavLink } from "react-router-dom";
 
 const NAV_ITEMS: { to: string; label: string; end?: boolean }[] = [
   { to: "/", label: "Dashboard", end: true },
+  { to: "/instruments", label: "Instruments" },
   { to: "/rankings", label: "Rankings" },
   { to: "/recommendations", label: "Recommendations" },
   { to: "/admin", label: "Admin" },

--- a/frontend/src/pages/InstrumentsPage.test.tsx
+++ b/frontend/src/pages/InstrumentsPage.test.tsx
@@ -1,0 +1,319 @@
+/**
+ * Tests for InstrumentsPage (#147).
+ *
+ * Scope:
+ *   - loading, empty, error, data states
+ *   - search input triggers refetch with debounce
+ *   - filter changes trigger refetch
+ *   - pagination controls
+ *   - sortable column headers
+ *   - coverage tier badge rendering
+ *   - instrument rows link to detail page
+ *
+ * API mocked at module boundary — tests exercise the page state machine,
+ * not the network layer.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+import { InstrumentsPage } from "@/pages/InstrumentsPage";
+import { fetchInstruments } from "@/api/instruments";
+import type { InstrumentListResponse } from "@/api/types";
+
+vi.mock("@/api/instruments", () => ({
+  fetchInstruments: vi.fn(),
+  INSTRUMENTS_PAGE_LIMIT: 50,
+}));
+
+const mockedFetch = vi.mocked(fetchInstruments);
+
+function makeResponse(
+  overrides: Partial<InstrumentListResponse> = {},
+): InstrumentListResponse {
+  return {
+    items: [
+      {
+        instrument_id: 1,
+        symbol: "AAPL",
+        company_name: "Apple Inc.",
+        exchange: "NASDAQ",
+        currency: "USD",
+        sector: "Technology",
+        is_tradable: true,
+        coverage_tier: 1,
+        latest_quote: {
+          bid: 185.5,
+          ask: 185.6,
+          last: 185.55,
+          spread_pct: 0.054,
+          quoted_at: "2026-04-08T12:00:00Z",
+        },
+      },
+      {
+        instrument_id: 2,
+        symbol: "MSFT",
+        company_name: "Microsoft Corp.",
+        exchange: "NASDAQ",
+        currency: "USD",
+        sector: "Technology",
+        is_tradable: true,
+        coverage_tier: 2,
+        latest_quote: {
+          bid: 420.0,
+          ask: 420.1,
+          last: 420.05,
+          spread_pct: 0.024,
+          quoted_at: "2026-04-08T12:00:00Z",
+        },
+      },
+      {
+        instrument_id: 3,
+        symbol: "JPM",
+        company_name: "JPMorgan Chase",
+        exchange: "NYSE",
+        currency: "USD",
+        sector: "Financial Services",
+        is_tradable: true,
+        coverage_tier: null,
+        latest_quote: null,
+      },
+    ],
+    total: 3,
+    offset: 0,
+    limit: 50,
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <InstrumentsPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockedFetch.mockReset();
+  mockedFetch.mockResolvedValue(makeResponse());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Data rendering
+// ---------------------------------------------------------------------------
+
+describe("InstrumentsPage — data rendering", () => {
+  it("renders instrument rows with symbols and company names", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Apple Inc.")).toBeInTheDocument();
+    expect(screen.getByText("MSFT")).toBeInTheDocument();
+    expect(screen.getByText("Microsoft Corp.")).toBeInTheDocument();
+    expect(screen.getByText("JPM")).toBeInTheDocument();
+  });
+
+  it("renders coverage tier badges in the table", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+    });
+    // Tier badges are <span> elements inside the table, distinct from <option> elements
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("Tier 1")).toBeInTheDocument();
+    expect(within(table).getByText("Tier 2")).toBeInTheDocument();
+  });
+
+  it("renders dash for null coverage tier", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+    });
+    // JPM has null coverage_tier — rendered as em-dash
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders total instrument count", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("3 instruments")).toBeInTheDocument();
+    });
+  });
+
+  it("renders instrument symbols as links to detail page", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+    });
+    const link = screen.getByText("AAPL").closest("a");
+    expect(link).toHaveAttribute("href", "/instruments/1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty and error states
+// ---------------------------------------------------------------------------
+
+describe("InstrumentsPage — empty and error states", () => {
+  it("shows empty state when no instruments exist", async () => {
+    mockedFetch.mockResolvedValue(makeResponse({ items: [], total: 0 }));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("No instruments found")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Run the universe sync job/)).toBeInTheDocument();
+  });
+
+  it("shows filter-aware empty state when filters are active", async () => {
+    // First render with data to populate sector dropdown
+    mockedFetch.mockResolvedValue(makeResponse());
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+    });
+
+    // Now return empty for the filtered query
+    mockedFetch.mockResolvedValue(makeResponse({ items: [], total: 0 }));
+    const user = userEvent.setup();
+    // Find tier select by its parent label structure
+    const tierLabel = screen.getByText("Tier", { selector: "label" });
+    const tierSelect = tierLabel.parentElement!.querySelector("select")!;
+    await user.selectOptions(tierSelect, "1");
+
+    await waitFor(() => {
+      expect(screen.getByText("No instruments found")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Try adjusting/)).toBeInTheDocument();
+  });
+
+  it("shows error state on fetch failure", async () => {
+    mockedFetch.mockRejectedValue(new Error("network"));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load/)).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Search
+// ---------------------------------------------------------------------------
+
+describe("InstrumentsPage — search", () => {
+  it("debounced search triggers refetch with search param", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    const searchInput = screen.getByPlaceholderText(/Symbol or company name/);
+    await user.type(searchInput, "App");
+
+    await waitFor(() => {
+      const calls = mockedFetch.mock.calls;
+      const lastCall = calls[calls.length - 1]!;
+      expect(lastCall[0]).toMatchObject({ search: "App" });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filters
+// ---------------------------------------------------------------------------
+
+describe("InstrumentsPage — filters", () => {
+  it("tier filter triggers refetch with coverage_tier param", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    // Find tier select by its parent label structure
+    const tierLabel = screen.getByText("Tier", { selector: "label" });
+    const tierSelect = tierLabel.parentElement!.querySelector("select")!;
+    await user.selectOptions(tierSelect, "1");
+
+    await waitFor(() => {
+      const calls = mockedFetch.mock.calls;
+      const lastCall = calls[calls.length - 1]!;
+      expect(lastCall[0]).toMatchObject({ coverage_tier: 1 });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+describe("InstrumentsPage — pagination", () => {
+  it("shows pagination controls when total exceeds page limit", async () => {
+    mockedFetch.mockResolvedValue(makeResponse({ total: 120 }));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Previous")).toBeDisabled();
+    expect(screen.getByText("Next")).not.toBeDisabled();
+  });
+
+  it("clicking Next fetches next page", async () => {
+    mockedFetch.mockResolvedValue(makeResponse({ total: 120 }));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Next"));
+
+    await waitFor(() => {
+      const calls = mockedFetch.mock.calls;
+      const lastCall = calls[calls.length - 1]!;
+      expect(lastCall[0]).toMatchObject({ offset: 50 });
+    });
+  });
+
+  it("hides pagination when total fits in one page", async () => {
+    mockedFetch.mockResolvedValue(makeResponse({ total: 3 }));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Previous")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+describe("InstrumentsPage — sorting", () => {
+  it("clicking a column header toggles sort direction", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    // Symbol column is default asc — click to toggle to desc
+    const symbolHeader = screen.getByText("Instrument");
+    await user.click(symbolHeader);
+
+    // After clicking default asc column, should be desc — MSFT first
+    await waitFor(() => {
+      const rows = screen.getAllByRole("row");
+      // Row 0 is header; row 1 should be MSFT (desc order)
+      expect(rows[1]).toHaveTextContent("MSFT");
+    });
+  });
+});

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -1,0 +1,425 @@
+/**
+ * Instruments browse page (#147).
+ *
+ * Single async source: GET /instruments. Supports search, sector/exchange/
+ * coverage-tier filters, and server-side pagination. Columns are sortable
+ * client-side within the current page (server-side sort is symbol ASC).
+ *
+ * Each instrument row links to /instruments/:id (detail page, #62).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+
+import {
+  fetchInstruments,
+  INSTRUMENTS_PAGE_LIMIT,
+  type InstrumentsQuery,
+} from "@/api/instruments";
+import type { InstrumentListItem } from "@/api/types";
+import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+import { formatMoney } from "@/lib/format";
+
+// ---------------------------------------------------------------------------
+// Filter state
+// ---------------------------------------------------------------------------
+
+interface Filters {
+  search: string;
+  sector: string | null;
+  exchange: string | null;
+  coverage_tier: number | null;
+}
+
+const INITIAL_FILTERS: Filters = {
+  search: "",
+  sector: null,
+  exchange: null,
+  coverage_tier: null,
+};
+
+// ---------------------------------------------------------------------------
+// Sort state (client-side within the fetched page)
+// ---------------------------------------------------------------------------
+
+type SortKey = "symbol" | "sector" | "exchange" | "coverage_tier" | "last";
+type SortDir = "asc" | "desc";
+
+function compare(a: unknown, b: unknown, dir: SortDir): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+  if (typeof a === "string" && typeof b === "string") {
+    const cmp = a.localeCompare(b);
+    return dir === "asc" ? cmp : -cmp;
+  }
+  if (typeof a === "number" && typeof b === "number") {
+    return dir === "asc" ? a - b : b - a;
+  }
+  return 0;
+}
+
+function sortValue(item: InstrumentListItem, key: SortKey): unknown {
+  switch (key) {
+    case "symbol":
+      return item.symbol;
+    case "sector":
+      return item.sector;
+    case "exchange":
+      return item.exchange;
+    case "coverage_tier":
+      return item.coverage_tier;
+    case "last":
+      return item.latest_quote?.last ?? null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Coverage tier badge
+// ---------------------------------------------------------------------------
+
+const TIER_TONE: Record<number, string> = {
+  1: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  2: "bg-blue-50 text-blue-700 border-blue-200",
+  3: "bg-slate-50 text-slate-600 border-slate-200",
+};
+
+function TierBadge({ tier }: { tier: number | null }) {
+  if (tier === null) {
+    return <span className="text-xs text-slate-400">—</span>;
+  }
+  const tone = TIER_TONE[tier] ?? "bg-slate-50 text-slate-600 border-slate-200";
+  return (
+    <span
+      className={`inline-block rounded border px-1.5 py-0.5 text-[10px] font-medium ${tone}`}
+    >
+      Tier {tier}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+export function InstrumentsPage() {
+  const [filters, setFilters] = useState<Filters>(INITIAL_FILTERS);
+  const [page, setPage] = useState(0);
+  const [sort, setSort] = useState<{ key: SortKey; dir: SortDir }>({
+    key: "symbol",
+    dir: "asc",
+  });
+
+  // Debounced search: apply after 300ms of inactivity.
+  const [searchInput, setSearchInput] = useState("");
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setFilters((prev) => ({ ...prev, search: searchInput }));
+      setPage(0);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const query: InstrumentsQuery = useMemo(
+    () => ({
+      search: filters.search || null,
+      sector: filters.sector,
+      exchange: filters.exchange,
+      coverage_tier: filters.coverage_tier,
+      offset: page * INSTRUMENTS_PAGE_LIMIT,
+      limit: INSTRUMENTS_PAGE_LIMIT,
+    }),
+    [filters, page],
+  );
+
+  // useAsync captures fn via a ref — fresh arrow per render is fine.
+  const result = useAsync(() => fetchInstruments(query), [query]);
+
+  // Extract distinct sectors and exchanges from data for filter dropdowns.
+  // This gives us a good-enough set from the current page; a full enum
+  // endpoint would be better but is not in scope.
+  const [knownSectors, setKnownSectors] = useState<string[]>([]);
+  const [knownExchanges, setKnownExchanges] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!result.data) return;
+    setKnownSectors((prev) => {
+      const next = new Set(prev);
+      for (const item of result.data!.items) {
+        if (item.sector) next.add(item.sector);
+      }
+      return Array.from(next).sort();
+    });
+    setKnownExchanges((prev) => {
+      const next = new Set(prev);
+      for (const item of result.data!.items) {
+        if (item.exchange) next.add(item.exchange);
+      }
+      return Array.from(next).sort();
+    });
+  }, [result.data]);
+
+  const sorted = useMemo(() => {
+    if (!result.data) return [];
+    return [...result.data.items].sort((a, b) =>
+      compare(sortValue(a, sort.key), sortValue(b, sort.key), sort.dir),
+    );
+  }, [result.data, sort]);
+
+  const toggleSort = useCallback(
+    (key: SortKey) => {
+      setSort((prev) =>
+        prev.key === key
+          ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
+          : { key, dir: "asc" },
+      );
+    },
+    [],
+  );
+
+  const totalPages = result.data
+    ? Math.ceil(result.data.total / INSTRUMENTS_PAGE_LIMIT)
+    : 0;
+
+  const handleFilterChange = useCallback(
+    (key: keyof Omit<Filters, "search">, value: string | number | null) => {
+      setFilters((prev) => ({ ...prev, [key]: value || null }));
+      setPage(0);
+    },
+    [],
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold text-slate-800">Instruments</h1>
+        {result.data && (
+          <span className="text-xs text-slate-500">
+            {result.data.total.toLocaleString()} instruments
+          </span>
+        )}
+      </div>
+
+      {/* Search + filters bar */}
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex-1">
+          <label className="mb-1 block text-xs font-medium text-slate-600">
+            Search
+          </label>
+          <input
+            type="text"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Symbol or company name…"
+            className="w-full rounded border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+          />
+        </div>
+
+        <FilterSelect
+          label="Sector"
+          value={filters.sector ?? ""}
+          options={knownSectors}
+          onChange={(v) => handleFilterChange("sector", v)}
+        />
+        <FilterSelect
+          label="Exchange"
+          value={filters.exchange ?? ""}
+          options={knownExchanges}
+          onChange={(v) => handleFilterChange("exchange", v)}
+        />
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-600">
+            Tier
+          </label>
+          <select
+            value={filters.coverage_tier ?? ""}
+            onChange={(e) =>
+              handleFilterChange(
+                "coverage_tier",
+                e.target.value ? Number(e.target.value) : null,
+              )
+            }
+            className="rounded border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-700"
+          >
+            <option value="">All</option>
+            <option value="1">Tier 1</option>
+            <option value="2">Tier 2</option>
+            <option value="3">Tier 3</option>
+          </select>
+        </div>
+      </div>
+
+      <Section title="Results">
+        {result.loading ? (
+          <SectionSkeleton rows={10} />
+        ) : result.error !== null ? (
+          <SectionError onRetry={result.refetch} />
+        ) : sorted.length === 0 ? (
+          <EmptyState
+            title="No instruments found"
+            description={
+              filters.search || filters.sector || filters.exchange || filters.coverage_tier !== null
+                ? "Try adjusting your search or filters."
+                : "No instruments have been synced yet. Run the universe sync job from the Admin page."
+            }
+          />
+        ) : (
+          <>
+            <InstrumentsTable
+              items={sorted}
+              sort={sort}
+              onToggleSort={toggleSort}
+            />
+            {totalPages > 1 && (
+              <div className="mt-3 flex items-center justify-between text-xs text-slate-500">
+                <span>
+                  Page {page + 1} of {totalPages}
+                </span>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    disabled={page === 0}
+                    onClick={() => setPage((p) => p - 1)}
+                    className="rounded border border-slate-200 bg-white px-2 py-1 font-medium text-slate-600 hover:bg-slate-50 disabled:opacity-40"
+                  >
+                    Previous
+                  </button>
+                  <button
+                    type="button"
+                    disabled={page >= totalPages - 1}
+                    onClick={() => setPage((p) => p + 1)}
+                    className="rounded border border-slate-200 bg-white px-2 py-1 font-medium text-slate-600 hover:bg-slate-50 disabled:opacity-40"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Filter select
+// ---------------------------------------------------------------------------
+
+function FilterSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (value: string | null) => void;
+}) {
+  return (
+    <div>
+      <label className="mb-1 block text-xs font-medium text-slate-600">
+        {label}
+      </label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value || null)}
+        className="rounded border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-700"
+      >
+        <option value="">All</option>
+        {options.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Instruments table
+// ---------------------------------------------------------------------------
+
+const COLUMNS: { key: SortKey; label: string; align?: "right" }[] = [
+  { key: "symbol", label: "Instrument" },
+  { key: "sector", label: "Sector" },
+  { key: "exchange", label: "Exchange" },
+  { key: "coverage_tier", label: "Tier" },
+  { key: "last", label: "Last price", align: "right" },
+];
+
+function SortIndicator({ active, dir }: { active: boolean; dir: SortDir }) {
+  if (!active) return <span className="ml-1 text-slate-300">↕</span>;
+  return (
+    <span className="ml-1 text-slate-600">
+      {dir === "asc" ? "↑" : "↓"}
+    </span>
+  );
+}
+
+function InstrumentsTable({
+  items,
+  sort,
+  onToggleSort,
+}: {
+  items: InstrumentListItem[];
+  sort: { key: SortKey; dir: SortDir };
+  onToggleSort: (key: SortKey) => void;
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead className="text-xs uppercase tracking-wide text-slate-500">
+          <tr>
+            {COLUMNS.map((col) => (
+              <th
+                key={col.key}
+                className={`cursor-pointer select-none py-2 pr-4 ${col.align === "right" ? "text-right" : ""}`}
+                onClick={() => onToggleSort(col.key)}
+              >
+                {col.label}
+                <SortIndicator
+                  active={sort.key === col.key}
+                  dir={sort.dir}
+                />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {items.map((item) => (
+            <tr key={item.instrument_id} className="align-top hover:bg-slate-50">
+              <td className="py-2 pr-4">
+                <Link
+                  to={`/instruments/${item.instrument_id}`}
+                  className="text-blue-600 hover:underline"
+                >
+                  <span className="font-medium">{item.symbol}</span>
+                </Link>
+                <div className="text-xs text-slate-500">{item.company_name}</div>
+              </td>
+              <td className="py-2 pr-4 text-xs text-slate-600">
+                {item.sector ?? "—"}
+              </td>
+              <td className="py-2 pr-4 text-xs text-slate-600">
+                {item.exchange ?? "—"}
+              </td>
+              <td className="py-2 pr-4">
+                <TierBadge tier={item.coverage_tier} />
+              </td>
+              <td className="py-2 pr-0 text-right text-xs tabular-nums text-slate-600">
+                {item.latest_quote?.last != null
+                  ? formatMoney(item.latest_quote.last)
+                  : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -143,6 +143,13 @@ export function InstrumentsPage() {
   const [knownSectors, setKnownSectors] = useState<string[]>([]);
   const [knownExchanges, setKnownExchanges] = useState<string[]>([]);
 
+  // Reset accumulated filter options when filters change (prevents stale
+  // options from prior queries lingering in the dropdowns).
+  useEffect(() => {
+    setKnownSectors([]);
+    setKnownExchanges([]);
+  }, [filters]);
+
   useEffect(() => {
     if (!result.data) return;
     setKnownSectors((prev) => {
@@ -271,6 +278,7 @@ export function InstrumentsPage() {
               items={sorted}
               sort={sort}
               onToggleSort={toggleSort}
+              pageScopedSort={totalPages > 1}
             />
             {totalPages > 1 && (
               <div className="mt-3 flex items-center justify-between text-xs text-slate-500">
@@ -365,10 +373,12 @@ function InstrumentsTable({
   items,
   sort,
   onToggleSort,
+  pageScopedSort,
 }: {
   items: InstrumentListItem[];
   sort: { key: SortKey; dir: SortDir };
   onToggleSort: (key: SortKey) => void;
+  pageScopedSort: boolean;
 }) {
   return (
     <div className="overflow-x-auto">
@@ -380,6 +390,7 @@ function InstrumentsTable({
                 key={col.key}
                 className={`cursor-pointer select-none py-2 pr-4 ${col.align === "right" ? "text-right" : ""}`}
                 onClick={() => onToggleSort(col.key)}
+                title={pageScopedSort ? "Sorts within this page only" : undefined}
               >
                 {col.label}
                 <SortIndicator
@@ -389,6 +400,13 @@ function InstrumentsTable({
               </th>
             ))}
           </tr>
+          {pageScopedSort && sort.key !== "symbol" && (
+            <tr>
+              <td colSpan={COLUMNS.length} className="pb-1 text-[10px] normal-case tracking-normal text-slate-400">
+                Sorted within this page only. Server order is by symbol.
+              </td>
+            </tr>
+          )}
         </thead>
         <tbody className="divide-y divide-slate-100">
           {items.map((item) => (

--- a/tests/test_api_instruments.py
+++ b/tests/test_api_instruments.py
@@ -207,6 +207,35 @@ class TestListInstruments:
         assert resp.status_code == 200
         assert resp.json()["items"][0]["latest_quote"] is None
 
+    def test_filter_by_search(self) -> None:
+        row = _make_instrument_row(symbol="AAPL", company_name="Apple Inc")
+        conn = _with_conn([[{"cnt": 1}], [row]])
+        resp = client.get("/instruments", params={"search": "AAP"})
+
+        assert resp.status_code == 200
+        cur = conn.cursor.return_value
+        # Both count and items queries should receive search params
+        count_params = cur.execute.call_args_list[0][0][1]
+        assert count_params["search_prefix"] == "AAP%"
+        assert count_params["search_contains"] == "%AAP%"
+        items_params = cur.execute.call_args_list[1][0][1]
+        assert items_params["search_prefix"] == "AAP%"
+        assert items_params["search_contains"] == "%AAP%"
+
+    def test_search_whitespace_only_ignored(self) -> None:
+        """A search string of only whitespace should be treated as no search."""
+        conn = _with_conn([[{"cnt": 0}], []])
+        resp = client.get("/instruments", params={"search": "   "})
+
+        assert resp.status_code == 200
+        cur = conn.cursor.return_value
+        count_params = cur.execute.call_args_list[0][0][1]
+        assert "search_prefix" not in count_params
+
+    def test_search_max_length_rejected(self) -> None:
+        resp = client.get("/instruments", params={"search": "a" * 101})
+        assert resp.status_code == 422
+
     def test_filter_by_sector(self) -> None:
         row = _make_instrument_row(sector="Technology")
         conn = _with_conn([[{"cnt": 1}], [row]])
@@ -284,6 +313,15 @@ class TestListInstruments:
         assert "limit" not in count_params
         assert "offset" not in count_params
         assert count_params["sector"] == "Tech"
+
+    def test_search_count_query_includes_where_clause(self) -> None:
+        """COUNT query must include the ILIKE search filter when search is active."""
+        conn = _with_conn([[{"cnt": 0}], []])
+        client.get("/instruments", params={"search": "App"})
+
+        cur = conn.cursor.return_value
+        count_sql: str = cur.execute.call_args_list[0][0][0]
+        assert "ILIKE" in count_sql
 
     def test_count_query_omits_coverage_join_when_no_tier_filter(self) -> None:
         """When coverage_tier filter is not active, COUNT query should not join coverage."""


### PR DESCRIPTION
## Summary

- Add `search` query param to `GET /instruments` backend endpoint with ILIKE prefix match on `symbol` and case-insensitive substring match on `company_name`
- New `/instruments` frontend page with debounced search (300ms), sector/exchange/tier filter dropdowns, server-side pagination, client-side sortable columns, coverage tier badges, and click-through links to `/instruments/:id`
- Route wired in `App.tsx`, "Instruments" nav link added to `Sidebar.tsx`

## What changed

### Backend (`app/api/instruments.py`)
- Added `search` query param (`max_length=100`) to `list_instruments`
- Search uses `ILIKE %(search_prefix)s` on `symbol` and `ILIKE %(search_contains)s` on `company_name` — parameterised, no injection risk
- Whitespace-only search strings are treated as no search
- Search filter is included in both COUNT and items queries

### Frontend
- **`frontend/src/api/instruments.ts`** — thin fetcher for `GET /instruments` with query params
- **`frontend/src/pages/InstrumentsPage.tsx`** — full page component:
  - Debounced search input (300ms) to avoid hammering backend
  - Sector and exchange filter dropdowns populated from fetched data
  - Coverage tier filter with Tier 1/2/3 options
  - Server-side pagination (50 per page) with Previous/Next controls
  - Client-side sortable columns (symbol, sector, exchange, tier, last price)
  - Coverage tier colour-coded badges (emerald/blue/slate)
  - Each row links to `/instruments/:id` for detail page (#62)
  - Proper loading/error/empty states using existing `Section`, `SectionSkeleton`, `SectionError`, `EmptyState` components
  - Empty state distinguishes "no results for filters" vs "no instruments synced yet"
- **`frontend/src/App.tsx`** — added route
- **`frontend/src/layout/Sidebar.tsx`** — added "Instruments" nav link

### Tests
- **`tests/test_api_instruments.py`** — 4 new tests: search param propagation, whitespace-only ignored, max_length rejection, COUNT query ILIKE inclusion
- **`frontend/src/pages/InstrumentsPage.test.tsx`** — 14 tests covering data rendering, tier badges, empty/error states, filter-aware empty state, search debounce, tier filter, pagination controls, and column sorting

## Settled decisions
- No settled decisions directly apply. Search uses ILIKE (not `to_tsvector`) as the simpler option per issue guidance.

## Prevention log
- **JOIN fan-out**: `quotes` and `coverage` are 1:1 tables — LEFT JOIN is fan-out-safe. Documented in `QuoteSnapshot` docstring.
- No other entries apply.

## Security model
- Search input is parameterised via `%(search_prefix)s` / `%(search_contains)s` — no SQL injection risk
- `max_length=100` on search param prevents oversized input
- `coverage_tier` validated `ge=1, le=3` by FastAPI
- No auth changes — page is behind existing `RequireAuth`

## Scope notes
- Issue mentions "Link from Dashboard" and "Link from Rankings rows" — these are deferred to #62 (instrument detail page) which is the click-through destination
- Filter dropdowns accumulate known values from fetched pages rather than a dedicated enum endpoint — good enough for now

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 1011 passed
- [x] `pnpm --dir frontend typecheck` — clean
- [x] `pnpm --dir frontend test` — 107 passed

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)