### PR TITLE
docs: extract falsy-string param suppression to prevention log

### DIFF
--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -488,3 +488,11 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `result.rowcount` is `-1` in psycopg v3 when the server does not report a row count. Code using `if result.rowcount is not None else 0` passes `-1` through to `tracker.row_count`, producing invalid row counts in job history.
 - Prevention: Guard `result.rowcount` with an explicit check: raise on `-1` rather than silently clamping with `max()`. A `-1` from a DML statement that should report a count (INSERT, UPDATE, DELETE) indicates a genuine server-side anomaly that must surface as an error, not be hidden.
 - Enforced in: this prevention log
+
+---
+
+### Falsy-string suppression in frontend API fetcher params
+- First seen in: #147
+- Symptom: `if (query.search)` in an API fetcher suppressed the query param for any falsy-but-valid string (e.g. `"0"`). The declared type was `string | null`, but the guard treated `""` and `"0"` identically to `null`.
+- Prevention: In frontend API fetcher files, use `!== null` (or `!== undefined`) to gate nullable string params — never bare truthiness. Grep `if \(query\.\w+\)` in `frontend/src/api/` and confirm each match uses explicit null/undefined checks.
+- Enforced in: this prevention log


### PR DESCRIPTION
## Summary

- Extract prevention log entry from #159 review PREVENTION comment
- Documents the falsy-string truthiness guard pattern in frontend API fetchers

Doc-only change, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)