### PR TITLE
feat(#62): instrument detail page

### DIFF
--- a/frontend/src/api/filings.ts
+++ b/frontend/src/api/filings.ts
@@ -1,0 +1,16 @@
+import { apiFetch } from "@/api/client";
+import type { FilingsListResponse } from "@/api/types";
+
+export function fetchFilings(
+  instrumentId: number,
+  offset = 0,
+  limit = 10,
+): Promise<FilingsListResponse> {
+  const params = new URLSearchParams({
+    offset: String(offset),
+    limit: String(limit),
+  });
+  return apiFetch<FilingsListResponse>(
+    `/filings/${instrumentId}?${params.toString()}`,
+  );
+}

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from "@/api/client";
-import type { InstrumentListResponse } from "@/api/types";
+import type { InstrumentDetail, InstrumentListResponse } from "@/api/types";
 
 export interface InstrumentsQuery {
   search: string | null;
@@ -25,4 +25,10 @@ export function fetchInstruments(
   params.set("limit", String(query.limit));
   const qs = params.toString();
   return apiFetch<InstrumentListResponse>(`/instruments?${qs}`);
+}
+
+export function fetchInstrumentDetail(
+  instrumentId: number,
+): Promise<InstrumentDetail> {
+  return apiFetch<InstrumentDetail>(`/instruments/${instrumentId}`);
 }

--- a/frontend/src/api/news.ts
+++ b/frontend/src/api/news.ts
@@ -1,0 +1,16 @@
+import { apiFetch } from "@/api/client";
+import type { NewsListResponse } from "@/api/types";
+
+export function fetchNews(
+  instrumentId: number,
+  offset = 0,
+  limit = 10,
+): Promise<NewsListResponse> {
+  const params = new URLSearchParams({
+    offset: String(offset),
+    limit: String(limit),
+  });
+  return apiFetch<NewsListResponse>(
+    `/news/${instrumentId}?${params.toString()}`,
+  );
+}

--- a/frontend/src/api/scoreHistory.ts
+++ b/frontend/src/api/scoreHistory.ts
@@ -1,0 +1,12 @@
+import { apiFetch } from "@/api/client";
+import type { ScoreHistoryResponse } from "@/api/types";
+
+export function fetchScoreHistory(
+  instrumentId: number,
+  limit = 30,
+): Promise<ScoreHistoryResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  return apiFetch<ScoreHistoryResponse>(
+    `/rankings/history/${instrumentId}?${params.toString()}`,
+  );
+}

--- a/frontend/src/api/theses.ts
+++ b/frontend/src/api/theses.ts
@@ -1,0 +1,22 @@
+import { apiFetch } from "@/api/client";
+import type { ThesisDetail, ThesisHistoryResponse } from "@/api/types";
+
+export function fetchLatestThesis(
+  instrumentId: number,
+): Promise<ThesisDetail> {
+  return apiFetch<ThesisDetail>(`/theses/${instrumentId}`);
+}
+
+export function fetchThesisHistory(
+  instrumentId: number,
+  offset = 0,
+  limit = 20,
+): Promise<ThesisHistoryResponse> {
+  const params = new URLSearchParams({
+    offset: String(offset),
+    limit: String(limit),
+  });
+  return apiFetch<ThesisHistoryResponse>(
+    `/theses/${instrumentId}/history?${params.toString()}`,
+  );
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -335,3 +335,111 @@ export interface RankingsListResponse {
   model_version: string;
   scored_at: string | null;
 }
+
+// ---------------------------------------------------------------------------
+// /rankings/history/{instrument_id} (app/api/scores.py)
+// ---------------------------------------------------------------------------
+
+export interface ScoreHistoryItem {
+  scored_at: string;
+  total_score: number | null;
+  raw_total: number | null;
+  quality_score: number | null;
+  value_score: number | null;
+  turnaround_score: number | null;
+  momentum_score: number | null;
+  sentiment_score: number | null;
+  confidence_score: number | null;
+  penalties_json: Record<string, unknown>[] | null;
+  explanation: string | null;
+  rank: number | null;
+  rank_delta: number | null;
+  model_version: string;
+}
+
+export interface ScoreHistoryResponse {
+  instrument_id: number;
+  items: ScoreHistoryItem[];
+}
+
+// ---------------------------------------------------------------------------
+// /theses/{instrument_id} (app/api/theses.py)
+// ---------------------------------------------------------------------------
+
+export interface ThesisDetail {
+  thesis_id: number;
+  instrument_id: number;
+  thesis_version: number;
+  thesis_type: string;
+  stance: string;
+  confidence_score: number | null;
+  buy_zone_low: number | null;
+  buy_zone_high: number | null;
+  base_value: number | null;
+  bull_value: number | null;
+  bear_value: number | null;
+  break_conditions_json: string[] | null;
+  memo_markdown: string;
+  critic_json: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface ThesisHistoryResponse {
+  instrument_id: number;
+  items: ThesisDetail[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+// ---------------------------------------------------------------------------
+// /filings/{instrument_id} (app/api/filings.py)
+// ---------------------------------------------------------------------------
+
+export interface FilingItem {
+  filing_event_id: number;
+  instrument_id: number;
+  filing_date: string;
+  filing_type: string | null;
+  provider: string;
+  source_url: string | null;
+  primary_document_url: string | null;
+  extracted_summary: string | null;
+  red_flag_score: number | null;
+  created_at: string;
+}
+
+export interface FilingsListResponse {
+  instrument_id: number;
+  symbol: string | null;
+  items: FilingItem[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+// ---------------------------------------------------------------------------
+// /news/{instrument_id} (app/api/news.py)
+// ---------------------------------------------------------------------------
+
+export interface NewsItem {
+  news_event_id: number;
+  instrument_id: number;
+  event_time: string;
+  source: string | null;
+  headline: string;
+  category: string | null;
+  sentiment_score: number | null;
+  importance_score: number | null;
+  snippet: string | null;
+  url: string | null;
+}
+
+export interface NewsListResponse {
+  instrument_id: number;
+  symbol: string | null;
+  items: NewsItem[];
+  total: number;
+  offset: number;
+  limit: number;
+}

--- a/frontend/src/lib/safeUrl.ts
+++ b/frontend/src/lib/safeUrl.ts
@@ -1,0 +1,20 @@
+/**
+ * Validates that a URL string uses a safe scheme (http or https).
+ *
+ * Returns the URL unchanged if valid, or null if the scheme is
+ * dangerous (e.g. javascript:, data:, vbscript:).  Used to sanitise
+ * external URLs from the API before rendering them as href attributes.
+ */
+export function safeExternalUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return url;
+    }
+    return null;
+  } catch {
+    // Relative URLs or malformed strings — reject.
+    return null;
+  }
+}

--- a/frontend/src/pages/InstrumentDetailPage.test.tsx
+++ b/frontend/src/pages/InstrumentDetailPage.test.tsx
@@ -1,0 +1,438 @@
+/**
+ * Tests for InstrumentDetailPage (#62).
+ *
+ * Scope:
+ *   - Header renders instrument metadata and quote
+ *   - 404 instrument shows "not found" empty state
+ *   - Thesis section: renders latest thesis, empty when 404
+ *   - Score history: renders table, empty when no data
+ *   - Filings: renders table, empty when no data
+ *   - News: renders table, empty when no data
+ *   - Recommendations: renders table, empty when no data
+ *   - Position: shown when held, hidden when not
+ *   - Per-section error isolation (one failing section doesn't blank others)
+ *
+ * API clients are mocked at the module boundary.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { InstrumentDetailPage } from "@/pages/InstrumentDetailPage";
+import { fetchInstrumentDetail } from "@/api/instruments";
+import { fetchLatestThesis } from "@/api/theses";
+import { fetchScoreHistory } from "@/api/scoreHistory";
+import { fetchFilings } from "@/api/filings";
+import { fetchNews } from "@/api/news";
+import { fetchRecommendations } from "@/api/recommendations";
+import { fetchPortfolio } from "@/api/portfolio";
+import { ApiError } from "@/api/client";
+import type {
+  InstrumentDetail,
+  ThesisDetail,
+  ScoreHistoryResponse,
+  FilingsListResponse,
+  NewsListResponse,
+  RecommendationsListResponse,
+  PortfolioResponse,
+} from "@/api/types";
+
+vi.mock("@/api/instruments", () => ({
+  fetchInstrumentDetail: vi.fn(),
+  fetchInstruments: vi.fn(),
+}));
+vi.mock("@/api/theses", () => ({ fetchLatestThesis: vi.fn() }));
+vi.mock("@/api/scoreHistory", () => ({ fetchScoreHistory: vi.fn() }));
+vi.mock("@/api/filings", () => ({ fetchFilings: vi.fn() }));
+vi.mock("@/api/news", () => ({ fetchNews: vi.fn() }));
+vi.mock("@/api/recommendations", () => ({
+  fetchRecommendations: vi.fn(),
+  fetchRecommendation: vi.fn(),
+}));
+vi.mock("@/api/portfolio", () => ({ fetchPortfolio: vi.fn() }));
+
+const mockedInstrument = vi.mocked(fetchInstrumentDetail);
+const mockedThesis = vi.mocked(fetchLatestThesis);
+const mockedScores = vi.mocked(fetchScoreHistory);
+const mockedFilings = vi.mocked(fetchFilings);
+const mockedNews = vi.mocked(fetchNews);
+const mockedRecs = vi.mocked(fetchRecommendations);
+const mockedPortfolio = vi.mocked(fetchPortfolio);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeInstrument(overrides: Partial<InstrumentDetail> = {}): InstrumentDetail {
+  return {
+    instrument_id: 42,
+    symbol: "AAPL",
+    company_name: "Apple Inc.",
+    exchange: "NASDAQ",
+    currency: "USD",
+    sector: "Technology",
+    industry: "Consumer Electronics",
+    country: "US",
+    is_tradable: true,
+    first_seen_at: "2024-01-01T00:00:00Z",
+    last_seen_at: "2024-06-01T00:00:00Z",
+    coverage_tier: 1,
+    latest_quote: {
+      bid: 190.5,
+      ask: 191.0,
+      last: 190.75,
+      spread_pct: 0.0026,
+      quoted_at: "2024-06-01T12:00:00Z",
+    },
+    external_identifiers: [],
+    ...overrides,
+  };
+}
+
+function makeThesis(overrides: Partial<ThesisDetail> = {}): ThesisDetail {
+  return {
+    thesis_id: 1,
+    instrument_id: 42,
+    thesis_version: 1,
+    thesis_type: "compounder",
+    stance: "buy",
+    confidence_score: 0.85,
+    buy_zone_low: 180,
+    buy_zone_high: 195,
+    base_value: 220,
+    bull_value: 260,
+    bear_value: 160,
+    break_conditions_json: ["Revenue growth < 5%"],
+    memo_markdown: "Strong fundamentals and growing margins.",
+    critic_json: { risk: "Valuation stretched" },
+    created_at: "2024-06-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+const emptyScores: ScoreHistoryResponse = { instrument_id: 42, items: [] };
+const emptyFilings: FilingsListResponse = {
+  instrument_id: 42,
+  symbol: "AAPL",
+  items: [],
+  total: 0,
+  offset: 0,
+  limit: 10,
+};
+const emptyNews: NewsListResponse = {
+  instrument_id: 42,
+  symbol: "AAPL",
+  items: [],
+  total: 0,
+  offset: 0,
+  limit: 10,
+};
+const emptyRecs: RecommendationsListResponse = {
+  items: [],
+  total: 0,
+  offset: 0,
+  limit: 50,
+};
+const emptyPortfolio: PortfolioResponse = {
+  positions: [],
+  position_count: 0,
+  total_aum: 0,
+  cash_balance: null,
+};
+
+function renderPage(instrumentId = "42") {
+  return render(
+    <MemoryRouter initialEntries={[`/instruments/${instrumentId}`]}>
+      <Routes>
+        <Route path="instruments/:instrumentId" element={<InstrumentDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockedInstrument.mockResolvedValue(makeInstrument());
+  mockedThesis.mockResolvedValue(makeThesis());
+  mockedScores.mockResolvedValue(emptyScores);
+  mockedFilings.mockResolvedValue(emptyFilings);
+  mockedNews.mockResolvedValue(emptyNews);
+  mockedRecs.mockResolvedValue(emptyRecs);
+  mockedPortfolio.mockResolvedValue(emptyPortfolio);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("InstrumentDetailPage — header", () => {
+  it("renders instrument symbol, name, and metadata", async () => {
+    renderPage();
+    expect(await screen.findByText("AAPL")).toBeInTheDocument();
+    expect(screen.getByText("Apple Inc.")).toBeInTheDocument();
+    expect(screen.getByText(/Technology/)).toBeInTheDocument();
+    expect(screen.getByText(/NASDAQ/)).toBeInTheDocument();
+    expect(screen.getByText("Tier 1")).toBeInTheDocument();
+  });
+
+  it("renders latest quote with bid/ask and spread", async () => {
+    renderPage();
+    await screen.findByText("AAPL");
+    expect(screen.getByText(/Bid/)).toBeInTheDocument();
+    expect(screen.getByText(/Ask/)).toBeInTheDocument();
+    expect(screen.getByText(/Spread/)).toBeInTheDocument();
+  });
+
+  it("shows not-tradable badge when instrument is not tradable", async () => {
+    mockedInstrument.mockResolvedValueOnce(makeInstrument({ is_tradable: false }));
+    renderPage();
+    expect(await screen.findByText("Not tradable")).toBeInTheDocument();
+  });
+});
+
+describe("InstrumentDetailPage — 404", () => {
+  it("shows not-found state when instrument returns 404", async () => {
+    mockedInstrument.mockRejectedValueOnce(
+      new ApiError(404, "Not found"),
+    );
+    renderPage();
+    expect(await screen.findByText("Instrument not found")).toBeInTheDocument();
+    expect(screen.getByText(/Back to instruments/)).toBeInTheDocument();
+  });
+
+  it("shows invalid instrument for non-numeric ID", async () => {
+    renderPage("abc");
+    expect(await screen.findByText("Invalid instrument")).toBeInTheDocument();
+  });
+});
+
+describe("InstrumentDetailPage — thesis section", () => {
+  it("renders thesis with stance, type, memo, and critic output", async () => {
+    renderPage();
+    await screen.findByText("AAPL");
+    expect(screen.getByText("buy")).toBeInTheDocument();
+    expect(screen.getByText(/compounder/)).toBeInTheDocument();
+    expect(screen.getByText(/Strong fundamentals/)).toBeInTheDocument();
+    expect(screen.getByText("Critic")).toBeInTheDocument();
+    expect(screen.getByText(/Valuation stretched/)).toBeInTheDocument();
+  });
+
+  it("renders break conditions", async () => {
+    renderPage();
+    await screen.findByText("AAPL");
+    expect(screen.getByText("Revenue growth < 5%")).toBeInTheDocument();
+  });
+
+  it("shows empty state when thesis returns 404", async () => {
+    mockedThesis.mockRejectedValueOnce(new ApiError(404, "No thesis"));
+    renderPage();
+    await screen.findByText("AAPL");
+    expect(screen.getByText("No thesis generated yet")).toBeInTheDocument();
+  });
+});
+
+describe("InstrumentDetailPage — score history", () => {
+  it("renders score table when data exists", async () => {
+    mockedScores.mockResolvedValueOnce({
+      instrument_id: 42,
+      items: [
+        {
+          scored_at: "2024-06-01T00:00:00Z",
+          total_score: 78.5,
+          raw_total: 80,
+          quality_score: 85,
+          value_score: 70,
+          turnaround_score: null,
+          momentum_score: 60,
+          sentiment_score: 55,
+          confidence_score: 0.9,
+          penalties_json: null,
+          explanation: null,
+          rank: 3,
+          rank_delta: -1,
+          model_version: "v1-balanced",
+        },
+      ],
+    });
+    renderPage();
+    await screen.findByText("AAPL");
+    // Find score data in the score history section
+    const section = screen.getByText("Score history").closest("section")!;
+    expect(within(section).getByText("78.5")).toBeInTheDocument();
+    expect(within(section).getByText("3")).toBeInTheDocument();
+    expect(within(section).getByText("-1")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no scores", async () => {
+    renderPage();
+    await screen.findByText("AAPL");
+    expect(screen.getByText("No scoring data available")).toBeInTheDocument();
+  });
+});
+
+describe("InstrumentDetailPage — filings", () => {
+  it("shows empty state when no filings", async () => {
+    renderPage();
+    await screen.findByText("AAPL");
+    expect(screen.getByText("No filing events recorded")).toBeInTheDocument();
+  });
+
+  it("renders filings table when data exists", async () => {
+    mockedFilings.mockResolvedValueOnce({
+      instrument_id: 42,
+      symbol: "AAPL",
+      items: [
+        {
+          filing_event_id: 1,
+          instrument_id: 42,
+          filing_date: "2024-05-15",
+          filing_type: "10-Q",
+          provider: "sec_edgar",
+          source_url: "https://sec.gov/filing/123",
+          primary_document_url: null,
+          extracted_summary: "Revenue up 8% YoY",
+          red_flag_score: 0.2,
+          created_at: "2024-05-16T00:00:00Z",
+        },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 10,
+    });
+    renderPage();
+    await screen.findByText("AAPL");
+    expect(screen.getByText("10-Q")).toBeInTheDocument();
+    expect(screen.getByText("Revenue up 8% YoY")).toBeInTheDocument();
+  });
+});
+
+describe("InstrumentDetailPage — news", () => {
+  it("shows empty state when no news", async () => {
+    renderPage();
+    await screen.findByText("AAPL");
+    expect(screen.getByText("No news events in the last 30 days")).toBeInTheDocument();
+  });
+
+  it("renders news table when data exists", async () => {
+    mockedNews.mockResolvedValueOnce({
+      instrument_id: 42,
+      symbol: "AAPL",
+      items: [
+        {
+          news_event_id: 1,
+          instrument_id: 42,
+          event_time: "2024-06-01T08:00:00Z",
+          source: "Reuters",
+          headline: "Apple launches new product",
+          category: "product",
+          sentiment_score: 0.7,
+          importance_score: 0.8,
+          snippet: "Apple announced...",
+          url: "https://reuters.com/article/1",
+        },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 10,
+    });
+    renderPage();
+    await screen.findByText("AAPL");
+    expect(screen.getByText("Apple launches new product")).toBeInTheDocument();
+    expect(screen.getByText("Reuters")).toBeInTheDocument();
+  });
+});
+
+describe("InstrumentDetailPage — recommendations", () => {
+  it("shows empty state when no recommendations", async () => {
+    renderPage();
+    await screen.findByText("AAPL");
+    expect(screen.getByText("No recommendations yet")).toBeInTheDocument();
+  });
+
+  it("renders recommendation table with action and status pills", async () => {
+    mockedRecs.mockResolvedValueOnce({
+      items: [
+        {
+          recommendation_id: 1,
+          instrument_id: 42,
+          symbol: "AAPL",
+          company_name: "Apple Inc.",
+          action: "BUY",
+          status: "executed",
+          rationale: "Strong thesis",
+          score_id: 1,
+          model_version: "v1-balanced",
+          suggested_size_pct: 0.05,
+          target_entry: 190,
+          cash_balance_known: true,
+          created_at: "2024-05-20T00:00:00Z",
+        },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 50,
+    });
+    renderPage();
+    await screen.findByText("AAPL");
+    const section = screen.getByText("Recommendation history").closest("section")!;
+    expect(within(section).getByText("BUY")).toBeInTheDocument();
+    expect(within(section).getByText("executed")).toBeInTheDocument();
+    expect(within(section).getByText("Strong thesis")).toBeInTheDocument();
+  });
+});
+
+describe("InstrumentDetailPage — position", () => {
+  it("shows position section when instrument is held", async () => {
+    mockedPortfolio.mockResolvedValueOnce({
+      positions: [
+        {
+          instrument_id: 42,
+          symbol: "AAPL",
+          company_name: "Apple Inc.",
+          open_date: "2024-03-01",
+          avg_cost: 185,
+          current_units: 10,
+          cost_basis: 1850,
+          market_value: 1910,
+          unrealized_pnl: 60,
+          updated_at: "2024-06-01T00:00:00Z",
+        },
+      ],
+      position_count: 1,
+      total_aum: 1910,
+      cash_balance: 500,
+    });
+    renderPage();
+    await screen.findByText("AAPL");
+    expect(screen.getByText("Position")).toBeInTheDocument();
+    // Check that market value is rendered
+    const section = screen.getByText("Position").closest("section")!;
+    expect(within(section).getByText("Market value")).toBeInTheDocument();
+  });
+
+  it("hides position section when instrument is not held", async () => {
+    renderPage();
+    await screen.findByText("AAPL");
+    expect(screen.queryByText("Position")).toBeNull();
+  });
+});
+
+describe("InstrumentDetailPage — section error isolation", () => {
+  it("shows header even when thesis fails with non-404 error", async () => {
+    mockedThesis.mockRejectedValueOnce(new Error("network error"));
+    renderPage();
+    // Header renders fine
+    expect(await screen.findByText("AAPL")).toBeInTheDocument();
+    // Thesis section shows retry button
+    expect(screen.getByText(/Failed to load/)).toBeInTheDocument();
+    // Other sections still render their empty states
+    expect(screen.getByText("No scoring data available")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/InstrumentDetailPage.test.tsx
+++ b/frontend/src/pages/InstrumentDetailPage.test.tsx
@@ -144,7 +144,7 @@ function renderPage(instrumentId = "42") {
   return render(
     <MemoryRouter initialEntries={[`/instruments/${instrumentId}`]}>
       <Routes>
-        <Route path="instruments/:instrumentId" element={<InstrumentDetailPage />} />
+        <Route path="/instruments/:instrumentId" element={<InstrumentDetailPage />} />
       </Routes>
     </MemoryRouter>,
   );

--- a/frontend/src/pages/InstrumentDetailPage.tsx
+++ b/frontend/src/pages/InstrumentDetailPage.tsx
@@ -1,15 +1,602 @@
-import { useParams } from "react-router-dom";
+/**
+ * /instruments/:instrumentId — single instrument deep-dive page (#62).
+ *
+ * Sections load independently via useAsync so a slow or failing endpoint
+ * does not block the entire page.  Each section owns its own loading /
+ * error / empty state per the async-data-loading skill.
+ *
+ * Content:
+ *   - Header: symbol, name, sector, exchange, tier, latest quote
+ *   - Thesis: latest memo (markdown rendered as preformatted), stance,
+ *     confidence, thesis type, critic output
+ *   - Score history: table of recent scores
+ *   - Filings feed: recent filing events
+ *   - News feed: recent news events
+ *   - Recommendation history: past recommendations for this instrument
+ *   - Position: quantity, cost basis, market value, P&L (hidden if not held)
+ */
+
+import { Link, useParams } from "react-router-dom";
+
+import { ApiError } from "@/api/client";
+import { fetchFilings } from "@/api/filings";
+import { fetchInstrumentDetail } from "@/api/instruments";
+import { fetchNews } from "@/api/news";
+import { fetchPortfolio } from "@/api/portfolio";
+import { fetchRecommendations } from "@/api/recommendations";
+import { fetchScoreHistory } from "@/api/scoreHistory";
+import { fetchLatestThesis } from "@/api/theses";
+import type {
+  FilingItem,
+  InstrumentDetail,
+  NewsItem,
+  PositionItem,
+  RecommendationListItem,
+  ScoreHistoryItem,
+  ThesisDetail,
+} from "@/api/types";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
+import { ErrorBanner } from "@/components/states/ErrorBanner";
+import {
+  formatDateTime,
+  formatMoney,
+  formatNumber,
+  formatPct,
+} from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TIER_LABELS: Record<number, string> = { 1: "Tier 1", 2: "Tier 2", 3: "Tier 3" };
+
+function tierBadge(tier: number | null) {
+  if (tier === null) return <span className="text-xs text-slate-400">—</span>;
+  const label = TIER_LABELS[tier] ?? `Tier ${tier}`;
+  const color =
+    tier === 1
+      ? "bg-emerald-100 text-emerald-700"
+      : tier === 2
+        ? "bg-blue-100 text-blue-700"
+        : "bg-slate-100 text-slate-600";
+  return (
+    <span className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-medium ${color}`}>
+      {label}
+    </span>
+  );
+}
+
+const STANCE_COLORS: Record<string, string> = {
+  buy: "bg-emerald-100 text-emerald-700",
+  hold: "bg-slate-100 text-slate-600",
+  watch: "bg-amber-100 text-amber-700",
+  avoid: "bg-red-100 text-red-700",
+};
+
+const ACTION_COLORS: Record<string, string> = {
+  BUY: "bg-emerald-100 text-emerald-700",
+  ADD: "bg-emerald-50 text-emerald-600",
+  HOLD: "bg-slate-100 text-slate-600",
+  EXIT: "bg-red-100 text-red-700",
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  proposed: "bg-amber-100 text-amber-700",
+  approved: "bg-blue-100 text-blue-700",
+  rejected: "bg-red-100 text-red-700",
+  executed: "bg-emerald-100 text-emerald-700",
+};
+
+function pill(text: string, colorMap: Record<string, string>) {
+  const cls = colorMap[text] ?? "bg-slate-100 text-slate-600";
+  return (
+    <span className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-medium uppercase ${cls}`}>
+      {text}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
 
 export function InstrumentDetailPage() {
-  const { instrumentId } = useParams<{ instrumentId: string }>();
+  const { instrumentId: rawId } = useParams<{ instrumentId: string }>();
+  const instrumentId = Number(rawId);
+
+  if (!rawId || Number.isNaN(instrumentId)) {
+    return (
+      <div className="space-y-4">
+        <EmptyState title="Invalid instrument" description="The instrument ID in the URL is not valid.">
+          <Link to="/instruments" className="text-sm text-blue-600 hover:underline">
+            Back to instruments
+          </Link>
+        </EmptyState>
+      </div>
+    );
+  }
+
+  return <InstrumentDetailContent instrumentId={instrumentId} />;
+}
+
+function InstrumentDetailContent({ instrumentId }: { instrumentId: number }) {
+  // Each section loads independently — useAsync captures fn via a ref.
+  const instrument = useAsync(
+    () => fetchInstrumentDetail(instrumentId),
+    [instrumentId],
+  );
+  const thesis = useAsync(
+    () => fetchLatestThesis(instrumentId),
+    [instrumentId],
+  );
+  const scores = useAsync(
+    () => fetchScoreHistory(instrumentId),
+    [instrumentId],
+  );
+  const filings = useAsync(
+    () => fetchFilings(instrumentId),
+    [instrumentId],
+  );
+  const news = useAsync(
+    () => fetchNews(instrumentId),
+    [instrumentId],
+  );
+  const recommendations = useAsync(
+    () => fetchRecommendations({ action: null, status: null, instrument_id: instrumentId }),
+    [instrumentId],
+  );
+  const portfolio = useAsync(() => fetchPortfolio(), []);
+
+  // Instrument 404 is a page-level error, not a section error.
+  const is404 =
+    instrument.error instanceof ApiError && instrument.error.status === 404;
+
+  if (is404) {
+    return (
+      <div className="space-y-4">
+        <EmptyState title="Instrument not found" description="This instrument does not exist or has been removed.">
+          <Link to="/instruments" className="text-sm text-blue-600 hover:underline">
+            Back to instruments
+          </Link>
+        </EmptyState>
+      </div>
+    );
+  }
+
+  // All sources failed — page-level banner.
+  const allFailed =
+    instrument.error &&
+    thesis.error &&
+    scores.error &&
+    filings.error &&
+    news.error &&
+    recommendations.error;
+
+  if (allFailed) {
+    return (
+      <div className="space-y-4">
+        <ErrorBanner message="All data sources failed. Check the browser console for details." />
+      </div>
+    );
+  }
+
+  const position = portfolio.data?.positions.find(
+    (p) => p.instrument_id === instrumentId,
+  ) ?? null;
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-xl font-semibold">Instrument {instrumentId}</h1>
-      <EmptyState
-        title="No instrument detail yet"
-        description="Instrument details will appear here once #62 wires up GET /instruments/{id}."
-      />
+    <div className="space-y-6">
+      {/* Header */}
+      <HeaderSection instrument={instrument} />
+
+      {/* Position (hidden if not held) */}
+      {!portfolio.loading && !portfolio.error && position !== null && (
+        <PositionSection position={position} />
+      )}
+
+      {/* Thesis */}
+      <Section title="Thesis">
+        {thesis.loading ? (
+          <SectionSkeleton rows={5} />
+        ) : thesis.error ? (
+          isNotFound(thesis.error) ? (
+            <EmptyState
+              title="No thesis generated yet"
+              description="A thesis will appear here once the thesis engine has run for this instrument."
+            />
+          ) : (
+            <SectionError onRetry={thesis.refetch} />
+          )
+        ) : thesis.data ? (
+          <ThesisContent thesis={thesis.data} />
+        ) : null}
+      </Section>
+
+      {/* Score history */}
+      <Section title="Score history">
+        {scores.loading ? (
+          <SectionSkeleton rows={4} />
+        ) : scores.error ? (
+          <SectionError onRetry={scores.refetch} />
+        ) : scores.data && scores.data.items.length > 0 ? (
+          <ScoreHistoryTable items={scores.data.items} />
+        ) : (
+          <EmptyState
+            title="No scoring data available"
+            description="Scores will appear here once the ranking engine has run."
+          />
+        )}
+      </Section>
+
+      {/* Filings */}
+      <Section title="Filings">
+        {filings.loading ? (
+          <SectionSkeleton rows={3} />
+        ) : filings.error ? (
+          isNotFound(filings.error) ? (
+            <EmptyState title="Instrument not found for filings" />
+          ) : (
+            <SectionError onRetry={filings.refetch} />
+          )
+        ) : filings.data && filings.data.items.length > 0 ? (
+          <FilingsTable items={filings.data.items} />
+        ) : (
+          <EmptyState title="No filing events recorded" description="Filings will appear here once the filings ingestion job has run." />
+        )}
+      </Section>
+
+      {/* News */}
+      <Section title="News">
+        {news.loading ? (
+          <SectionSkeleton rows={3} />
+        ) : news.error ? (
+          isNotFound(news.error) ? (
+            <EmptyState title="Instrument not found for news" />
+          ) : (
+            <SectionError onRetry={news.refetch} />
+          )
+        ) : news.data && news.data.items.length > 0 ? (
+          <NewsTable items={news.data.items} />
+        ) : (
+          <EmptyState
+            title="No news events in the last 30 days"
+            description="News will appear here once the news ingestion job has run."
+          />
+        )}
+      </Section>
+
+      {/* Recommendations */}
+      <Section title="Recommendation history">
+        {recommendations.loading ? (
+          <SectionSkeleton rows={3} />
+        ) : recommendations.error ? (
+          <SectionError onRetry={recommendations.refetch} />
+        ) : recommendations.data && recommendations.data.items.length > 0 ? (
+          <RecommendationsTable items={recommendations.data.items} />
+        ) : (
+          <EmptyState
+            title="No recommendations yet"
+            description="Recommendations will appear here once the portfolio manager has run."
+          />
+        )}
+      </Section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function isNotFound(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}
+
+function HeaderSection({
+  instrument,
+}: {
+  instrument: { data: InstrumentDetail | null; loading: boolean; error: unknown; refetch: () => void };
+}) {
+  if (instrument.loading) {
+    return (
+      <div className="animate-pulse space-y-2">
+        <div className="h-6 w-48 rounded bg-slate-100" />
+        <div className="h-4 w-72 rounded bg-slate-100" />
+      </div>
+    );
+  }
+  if (instrument.error) {
+    return <SectionError onRetry={instrument.refetch} />;
+  }
+  const d = instrument.data;
+  if (!d) return null;
+
+  const q = d.latest_quote;
+  return (
+    <div>
+      <div className="flex items-center gap-3">
+        <h1 className="text-xl font-semibold text-slate-800">{d.symbol}</h1>
+        {tierBadge(d.coverage_tier)}
+        {!d.is_tradable && (
+          <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700">
+            Not tradable
+          </span>
+        )}
+      </div>
+      <p className="mt-0.5 text-sm text-slate-600">{d.company_name}</p>
+      <p className="mt-0.5 text-xs text-slate-500">
+        {[d.sector, d.exchange, d.currency, d.country].filter(Boolean).join(" · ")}
+      </p>
+      {q && (
+        <p className="mt-1 text-sm tabular-nums text-slate-700">
+          Bid {formatMoney(q.bid)} · Ask {formatMoney(q.ask)}
+          {q.spread_pct !== null && <> · Spread {formatPct(q.spread_pct)}</>}
+          <span className="ml-2 text-xs text-slate-400">as of {formatDateTime(q.quoted_at)}</span>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function PositionSection({ position }: { position: PositionItem }) {
+  const p = position;
+  const pnlColor = p.unrealized_pnl >= 0 ? "text-emerald-700" : "text-red-700";
+  return (
+    <Section title="Position">
+      <div className="grid grid-cols-2 gap-x-8 gap-y-1 text-sm sm:grid-cols-4">
+        <div>
+          <span className="text-xs text-slate-500">Units</span>
+          <p className="tabular-nums">{formatNumber(p.current_units, 2)}</p>
+        </div>
+        <div>
+          <span className="text-xs text-slate-500">Cost basis</span>
+          <p className="tabular-nums">{formatMoney(p.cost_basis)}</p>
+        </div>
+        <div>
+          <span className="text-xs text-slate-500">Market value</span>
+          <p className="tabular-nums">{formatMoney(p.market_value)}</p>
+        </div>
+        <div>
+          <span className="text-xs text-slate-500">Unrealized P&L</span>
+          <p className={`tabular-nums ${pnlColor}`}>
+            {formatMoney(p.unrealized_pnl)}
+            {p.cost_basis > 0 && (
+              <span className="ml-1 text-xs">
+                ({formatPct(p.unrealized_pnl / p.cost_basis)})
+              </span>
+            )}
+          </p>
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+function ThesisContent({ thesis }: { thesis: ThesisDetail }) {
+  const t = thesis;
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        {pill(t.stance, STANCE_COLORS)}
+        <span className="text-xs text-slate-500">
+          {t.thesis_type} · v{t.thesis_version}
+        </span>
+        {t.confidence_score !== null && (
+          <span className="text-xs text-slate-500">
+            Confidence: {formatNumber(t.confidence_score, 1)}
+          </span>
+        )}
+        <span className="text-xs text-slate-400">
+          {formatDateTime(t.created_at)}
+        </span>
+      </div>
+
+      {/* Valuation range */}
+      {(t.base_value !== null || t.bull_value !== null || t.bear_value !== null) && (
+        <div className="flex gap-4 text-xs text-slate-600">
+          {t.bear_value !== null && <span>Bear: {formatMoney(t.bear_value)}</span>}
+          {t.base_value !== null && <span>Base: {formatMoney(t.base_value)}</span>}
+          {t.bull_value !== null && <span>Bull: {formatMoney(t.bull_value)}</span>}
+        </div>
+      )}
+
+      {/* Buy zone */}
+      {(t.buy_zone_low !== null || t.buy_zone_high !== null) && (
+        <p className="text-xs text-slate-500">
+          Buy zone: {formatMoney(t.buy_zone_low)} – {formatMoney(t.buy_zone_high)}
+        </p>
+      )}
+
+      {/* Memo */}
+      <pre className="whitespace-pre-wrap rounded bg-slate-50 p-3 text-sm text-slate-700">
+        {t.memo_markdown}
+      </pre>
+
+      {/* Break conditions */}
+      {t.break_conditions_json && t.break_conditions_json.length > 0 && (
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Break conditions
+          </h3>
+          <ul className="mt-1 list-inside list-disc text-sm text-slate-600">
+            {t.break_conditions_json.map((c, i) => (
+              <li key={i}>{c}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Critic output */}
+      {t.critic_json !== null && (
+        <div className="rounded border border-amber-200 bg-amber-50 p-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+            Critic
+          </h3>
+          <pre className="mt-1 whitespace-pre-wrap text-sm text-amber-800">
+            {JSON.stringify(t.critic_json, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ScoreHistoryTable({ items }: { items: ScoreHistoryItem[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-100 text-left text-xs text-slate-500">
+            <th className="px-2 py-2">Date</th>
+            <th className="px-2 py-2 text-right">Total</th>
+            <th className="px-2 py-2 text-right">Rank</th>
+            <th className="px-2 py-2 text-right">Δ</th>
+            <th className="px-2 py-2 text-right">Quality</th>
+            <th className="px-2 py-2 text-right">Value</th>
+            <th className="px-2 py-2 text-right">Momentum</th>
+            <th className="px-2 py-2 text-right">Sentiment</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((s) => (
+            <tr key={s.scored_at} className="border-b border-slate-50">
+              <td className="px-2 py-2 text-xs text-slate-500">{formatDateTime(s.scored_at)}</td>
+              <td className="px-2 py-2 text-right tabular-nums">{formatNumber(s.total_score, 1)}</td>
+              <td className="px-2 py-2 text-right tabular-nums">{s.rank ?? "—"}</td>
+              <td className="px-2 py-2 text-right tabular-nums">
+                {s.rank_delta !== null ? (s.rank_delta > 0 ? `+${s.rank_delta}` : String(s.rank_delta)) : "—"}
+              </td>
+              <td className="px-2 py-2 text-right tabular-nums">{formatNumber(s.quality_score, 1)}</td>
+              <td className="px-2 py-2 text-right tabular-nums">{formatNumber(s.value_score, 1)}</td>
+              <td className="px-2 py-2 text-right tabular-nums">{formatNumber(s.momentum_score, 1)}</td>
+              <td className="px-2 py-2 text-right tabular-nums">{formatNumber(s.sentiment_score, 1)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function FilingsTable({ items }: { items: FilingItem[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-100 text-left text-xs text-slate-500">
+            <th className="px-2 py-2">Date</th>
+            <th className="px-2 py-2">Type</th>
+            <th className="px-2 py-2">Summary</th>
+            <th className="px-2 py-2 text-right">Risk</th>
+            <th className="px-2 py-2">Link</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((f) => (
+            <tr key={f.filing_event_id} className="border-b border-slate-50">
+              <td className="px-2 py-2 text-xs text-slate-500">{f.filing_date}</td>
+              <td className="px-2 py-2 text-xs">{f.filing_type ?? "—"}</td>
+              <td className="max-w-sm truncate px-2 py-2">{f.extracted_summary ?? "—"}</td>
+              <td className="px-2 py-2 text-right tabular-nums">
+                {f.red_flag_score !== null ? formatNumber(f.red_flag_score, 1) : "—"}
+              </td>
+              <td className="px-2 py-2">
+                {f.source_url ? (
+                  <a
+                    href={f.source_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline"
+                  >
+                    View
+                  </a>
+                ) : (
+                  "—"
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function NewsTable({ items }: { items: NewsItem[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-100 text-left text-xs text-slate-500">
+            <th className="px-2 py-2">Time</th>
+            <th className="px-2 py-2">Headline</th>
+            <th className="px-2 py-2 text-right">Sentiment</th>
+            <th className="px-2 py-2 text-right">Importance</th>
+            <th className="px-2 py-2">Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((n) => (
+            <tr key={n.news_event_id} className="border-b border-slate-50">
+              <td className="px-2 py-2 text-xs text-slate-500">{formatDateTime(n.event_time)}</td>
+              <td className="max-w-sm truncate px-2 py-2">
+                {n.url ? (
+                  <a
+                    href={n.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline"
+                  >
+                    {n.headline}
+                  </a>
+                ) : (
+                  n.headline
+                )}
+              </td>
+              <td className="px-2 py-2 text-right tabular-nums">
+                {n.sentiment_score !== null ? formatNumber(n.sentiment_score, 2) : "—"}
+              </td>
+              <td className="px-2 py-2 text-right tabular-nums">
+                {n.importance_score !== null ? formatNumber(n.importance_score, 2) : "—"}
+              </td>
+              <td className="px-2 py-2 text-xs text-slate-500">{n.source ?? "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RecommendationsTable({ items }: { items: RecommendationListItem[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-100 text-left text-xs text-slate-500">
+            <th className="px-2 py-2">Date</th>
+            <th className="px-2 py-2">Action</th>
+            <th className="px-2 py-2">Status</th>
+            <th className="px-2 py-2">Rationale</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((r) => (
+            <tr key={r.recommendation_id} className="border-b border-slate-50">
+              <td className="px-2 py-2 text-xs text-slate-500">{formatDateTime(r.created_at)}</td>
+              <td className="px-2 py-2">{pill(r.action, ACTION_COLORS)}</td>
+              <td className="px-2 py-2">{pill(r.status, STATUS_COLORS)}</td>
+              <td className="max-w-md truncate px-2 py-2">{r.rationale}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/frontend/src/pages/InstrumentDetailPage.tsx
+++ b/frontend/src/pages/InstrumentDetailPage.tsx
@@ -48,6 +48,7 @@ import {
   formatNumber,
   formatPct,
 } from "@/lib/format";
+import { safeExternalUrl } from "@/lib/safeUrl";
 import { useAsync } from "@/lib/useAsync";
 
 // ---------------------------------------------------------------------------
@@ -169,14 +170,17 @@ function InstrumentDetailContent({ instrumentId }: { instrumentId: number }) {
     );
   }
 
-  // All sources failed — page-level banner.
+  // All sources failed — page-level banner.  Every useAsync result on
+  // this page must be listed here; omitting one lets the banner fire
+  // too eagerly.
   const allFailed =
     instrument.error &&
     thesis.error &&
     scores.error &&
     filings.error &&
     news.error &&
-    recommendations.error;
+    recommendations.error &&
+    portfolio.error;
 
   if (allFailed) {
     return (
@@ -464,8 +468,8 @@ function ScoreHistoryTable({ items }: { items: ScoreHistoryItem[] }) {
           </tr>
         </thead>
         <tbody>
-          {items.map((s) => (
-            <tr key={s.scored_at} className="border-b border-slate-50">
+          {items.map((s, idx) => (
+            <tr key={`${s.scored_at}-${idx}`} className="border-b border-slate-50">
               <td className="px-2 py-2 text-xs text-slate-500">{formatDateTime(s.scored_at)}</td>
               <td className="px-2 py-2 text-right tabular-nums">{formatNumber(s.total_score, 1)}</td>
               <td className="px-2 py-2 text-right tabular-nums">{s.rank ?? "—"}</td>
@@ -507,9 +511,9 @@ function FilingsTable({ items }: { items: FilingItem[] }) {
                 {f.red_flag_score !== null ? formatNumber(f.red_flag_score, 1) : "—"}
               </td>
               <td className="px-2 py-2">
-                {f.source_url ? (
+                {safeExternalUrl(f.source_url) ? (
                   <a
-                    href={f.source_url}
+                    href={safeExternalUrl(f.source_url)!}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-600 hover:underline"
@@ -546,9 +550,9 @@ function NewsTable({ items }: { items: NewsItem[] }) {
             <tr key={n.news_event_id} className="border-b border-slate-50">
               <td className="px-2 py-2 text-xs text-slate-500">{formatDateTime(n.event_time)}</td>
               <td className="max-w-sm truncate px-2 py-2">
-                {n.url ? (
+                {safeExternalUrl(n.url) ? (
                   <a
-                    href={n.url}
+                    href={safeExternalUrl(n.url)!}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-600 hover:underline"

--- a/frontend/src/pages/InstrumentDetailPage.tsx
+++ b/frontend/src/pages/InstrumentDetailPage.tsx
@@ -502,30 +502,33 @@ function FilingsTable({ items }: { items: FilingItem[] }) {
           </tr>
         </thead>
         <tbody>
-          {items.map((f) => (
-            <tr key={f.filing_event_id} className="border-b border-slate-50">
-              <td className="px-2 py-2 text-xs text-slate-500">{f.filing_date}</td>
-              <td className="px-2 py-2 text-xs">{f.filing_type ?? "—"}</td>
-              <td className="max-w-sm truncate px-2 py-2">{f.extracted_summary ?? "—"}</td>
-              <td className="px-2 py-2 text-right tabular-nums">
-                {f.red_flag_score !== null ? formatNumber(f.red_flag_score, 1) : "—"}
-              </td>
-              <td className="px-2 py-2">
-                {safeExternalUrl(f.source_url) ? (
-                  <a
-                    href={safeExternalUrl(f.source_url)!}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 hover:underline"
-                  >
-                    View
-                  </a>
-                ) : (
-                  "—"
-                )}
-              </td>
-            </tr>
-          ))}
+          {items.map((f) => {
+            const href = safeExternalUrl(f.source_url);
+            return (
+              <tr key={f.filing_event_id} className="border-b border-slate-50">
+                <td className="px-2 py-2 text-xs text-slate-500">{f.filing_date}</td>
+                <td className="px-2 py-2 text-xs">{f.filing_type ?? "—"}</td>
+                <td className="max-w-sm truncate px-2 py-2">{f.extracted_summary ?? "—"}</td>
+                <td className="px-2 py-2 text-right tabular-nums">
+                  {f.red_flag_score !== null ? formatNumber(f.red_flag_score, 1) : "—"}
+                </td>
+                <td className="px-2 py-2">
+                  {href ? (
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:underline"
+                    >
+                      View
+                    </a>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>
@@ -546,13 +549,15 @@ function NewsTable({ items }: { items: NewsItem[] }) {
           </tr>
         </thead>
         <tbody>
-          {items.map((n) => (
+          {items.map((n) => {
+            const href = safeExternalUrl(n.url);
+            return (
             <tr key={n.news_event_id} className="border-b border-slate-50">
               <td className="px-2 py-2 text-xs text-slate-500">{formatDateTime(n.event_time)}</td>
               <td className="max-w-sm truncate px-2 py-2">
-                {safeExternalUrl(n.url) ? (
+                {href ? (
                   <a
-                    href={safeExternalUrl(n.url)!}
+                    href={href}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-600 hover:underline"
@@ -571,7 +576,8 @@ function NewsTable({ items }: { items: NewsItem[] }) {
               </td>
               <td className="px-2 py-2 text-xs text-slate-500">{n.source ?? "—"}</td>
             </tr>
-          ))}
+          );
+          })}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary

Builds the single-instrument deep-dive page that ties together all research and execution data for one name, as specified in #62.

- **Backend**: no changes — all 7 endpoints already exist (`GET /instruments/{id}`, `/theses/{id}`, `/theses/{id}/history`, `/rankings/history/{id}`, `/filings/{id}`, `/news/{id}`, `/portfolio`, `/recommendations`)
- **Frontend types**: added ThesisDetail, ThesisHistoryResponse, FilingItem, FilingsListResponse, NewsItem, NewsListResponse, ScoreHistoryItem, ScoreHistoryResponse to `types.ts`
- **Frontend fetchers**: 5 new fetcher files (theses, filings, news, scoreHistory) + `fetchInstrumentDetail` added to existing instruments fetcher
- **InstrumentDetailPage**: full rewrite of the stub with 7 independently-loaded sections

## Content sections

| Section | Source | Empty state |
|---|---|---|
| Header | `GET /instruments/{id}` | N/A (page-level 404 if missing) |
| Position | `GET /portfolio` | Hidden entirely if not held |
| Thesis | `GET /theses/{id}` | "No thesis generated yet" (404 → empty, not error) |
| Score history | `GET /rankings/history/{id}` | "No scoring data available" |
| Filings | `GET /filings/{id}` | "No filing events recorded" |
| News | `GET /news/{id}` | "No news events in the last 30 days" |
| Recommendations | `GET /recommendations?instrument_id=` | "No recommendations yet" |

## Loading / error architecture

Per the async-data-loading skill:
- Each section uses its own `useAsync` call — one failing endpoint cannot blank another
- Loading: `SectionSkeleton` per section
- Error: `SectionError` with Retry per section (except thesis 404 → empty state)
- All sources failed: page-level `ErrorBanner`
- Invalid/non-numeric ID: "Invalid instrument" with back link
- Instrument 404: "Instrument not found" with back link

## Security model

- All endpoints require auth (session cookie)
- Read-only page — no write actions
- No user input interpolated into queries (instrument ID is numeric, parsed with `Number()`)

## Settled decisions applied

- Thesis versioning: append-only, critic in `critic_json` rendered separately (amber panel with "Critic" label)
- Thesis types/stances: rendered as pills with correct color semantics
- Score auditability: rank + rank_delta shown in score history table
- Provider design: fetchers are thin typed wrappers, no business logic

## Prevention log entries applied

- Falsy-string suppression: all fetcher params use `!== null` (no nullable string params in these fetchers, but pattern followed)

## Test plan

- [x] 19 frontend tests covering all sections, empty states, error isolation, 404, invalid ID
- [x] 1017 backend tests pass (no backend changes)
- [x] 136 frontend tests pass (11 test files)
- [x] TypeScript, ruff, pyright all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)