### PR TITLE
fix(#165): break coverage bootstrap deadlock — seed initial T2 cohort

### DIFF
--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -824,24 +824,28 @@ def bootstrap_tier2_cohort(
     bootstrap rationale so the audit trail explains why these instruments
     were promoted without the usual score/thesis prerequisites.
     """
+    # Check T1/T2 count outside any transaction to avoid an empty
+    # commit on every subsequent (no-op) run.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT COUNT(*) AS cnt FROM coverage WHERE coverage_tier IN (1, 2)")
+        row = cur.fetchone()
+        t12_count = int(row["cnt"]) if row is not None else 0
+
+    if t12_count > 0:
+        logger.info(
+            "bootstrap_tier2_cohort: %d T1/T2 rows already exist, skipping",
+            t12_count,
+        )
+        return BootstrapResult(promoted=0, skipped_reason="T1/T2 coverage already exists")
+
+    candidates = _select_bootstrap_candidates(conn, cap)
+    if not candidates:
+        logger.warning("bootstrap_tier2_cohort: no eligible T3 instruments found")
+        return BootstrapResult(promoted=0, skipped_reason="no eligible T3 instruments")
+
+    # All writes (UPDATE coverage + INSERT coverage_audit) are inside a
+    # single transaction so either all promotions land or none do.
     with conn.transaction():
-        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-            cur.execute("SELECT COUNT(*) AS cnt FROM coverage WHERE coverage_tier IN (1, 2)")
-            row = cur.fetchone()
-            t12_count = int(row["cnt"]) if row is not None else 0
-
-        if t12_count > 0:
-            logger.info(
-                "bootstrap_tier2_cohort: %d T1/T2 rows already exist, skipping",
-                t12_count,
-            )
-            return BootstrapResult(promoted=0, skipped_reason="T1/T2 coverage already exists")
-
-        candidates = _select_bootstrap_candidates(conn, cap)
-        if not candidates:
-            logger.warning("bootstrap_tier2_cohort: no eligible T3 instruments found")
-            return BootstrapResult(promoted=0, skipped_reason="no eligible T3 instruments")
-
         promoted = 0
         for cand in candidates:
             instrument_id = int(cand["instrument_id"])
@@ -866,8 +870,8 @@ def bootstrap_tier2_cohort(
             _apply_tier_change(conn, change)
             promoted += 1
 
-        logger.info(
-            "bootstrap_tier2_cohort: promoted %d instruments from T3 to T2",
-            promoted,
-        )
-        return BootstrapResult(promoted=promoted, skipped_reason=None)
+    logger.info(
+        "bootstrap_tier2_cohort: promoted %d instruments from T3 to T2",
+        promoted,
+    )
+    return BootstrapResult(promoted=promoted, skipped_reason=None)

--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -825,6 +825,9 @@ def bootstrap_tier2_cohort(
     Each promotion is recorded in ``coverage_audit`` with a clear
     bootstrap rationale so the audit trail explains why these instruments
     were promoted without the usual score/thesis prerequisites.
+
+    Concurrency: an advisory lock (``pg_advisory_xact_lock``) inside
+    the transaction prevents duplicate promotions if two runs overlap.
     """
     # Advisory lock + transaction makes the check-then-act atomic even
     # under READ COMMITTED.  The lock is released when the transaction

--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -27,6 +27,7 @@ Promotion is one step per review cycle (T3→T2 or T2→T1, never T3→T1).
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
@@ -53,6 +54,9 @@ DEMOTE_T2_TO_T3_SCORE: float = 0.45
 
 # Tier 1 hard cap
 TIER_1_CAP: int = 50
+
+# Bootstrap: max instruments to promote from T3→T2 on first run
+BOOTSTRAP_T2_CAP: int = 200
 
 # Review frequency mapping — duplicated from thesis.py; extract when touched next
 _REVIEW_FREQUENCY_DAYS: dict[str, int] = {
@@ -746,3 +750,124 @@ def seed_coverage(
         seeded = result.rowcount
         logger.info("seed_coverage: seeded %d instruments at Tier 3", seeded)
         return SeedResult(seeded=seeded, already_populated=False)
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap: break the T3-only deadlock
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    """Outcome of ``bootstrap_tier2_cohort``."""
+
+    promoted: int
+    skipped_reason: str | None
+
+
+def _select_bootstrap_candidates(
+    conn: psycopg.Connection[Any],
+    cap: int,
+) -> Sequence[dict[str, Any]]:
+    """Select the best T3 instruments for initial T2 promotion.
+
+    Ranking criteria (descending priority):
+      1. Has a CIK mapping — enables SEC filings ingestion.
+      2. Symbol alphabetical — deterministic tiebreak for reproducibility.
+
+    Sector diversity is not applied because sector data is NULL for all
+    eToro-sourced instruments at bootstrap time.  Once fundamentals are
+    ingested for the T2 cohort, the weekly coverage review can use real
+    sector data for subsequent promotion decisions.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT
+                i.instrument_id,
+                i.symbol,
+                (e.external_identifier_id IS NOT NULL) AS has_cik
+            FROM instruments i
+            JOIN coverage c ON c.instrument_id = i.instrument_id
+            LEFT JOIN external_identifiers e
+                ON  e.instrument_id = i.instrument_id
+                AND e.identifier_type = 'cik'
+                AND e.is_primary = TRUE
+            WHERE i.is_tradable = TRUE
+              AND c.coverage_tier = 3
+            ORDER BY
+                (e.external_identifier_id IS NOT NULL) DESC,
+                i.symbol ASC
+            LIMIT %(cap)s
+            """,
+            {"cap": cap},
+        )
+        return cur.fetchall()
+
+
+def bootstrap_tier2_cohort(
+    conn: psycopg.Connection[Any],
+    cap: int = BOOTSTRAP_T2_CAP,
+) -> BootstrapResult:
+    """Promote an initial cohort from T3 to T2 to break the pipeline deadlock.
+
+    The normal promotion path (T3→T2) requires a thesis and a score, but
+    thesis generation and scoring only run for T1/T2 instruments.  When
+    the entire coverage table is T3 — as it is after first-run seeding —
+    no job can produce the data that promotion depends on.
+
+    This function fires **once**, when no T1/T2 coverage rows exist, to
+    seed a starter T2 cohort.  Subsequent runs detect existing T1/T2 rows
+    and skip immediately.
+
+    Each promotion is recorded in ``coverage_audit`` with a clear
+    bootstrap rationale so the audit trail explains why these instruments
+    were promoted without the usual score/thesis prerequisites.
+    """
+    with conn.transaction():
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT COUNT(*) AS cnt FROM coverage WHERE coverage_tier IN (1, 2)")
+            row = cur.fetchone()
+            t12_count = int(row["cnt"]) if row is not None else 0
+
+        if t12_count > 0:
+            logger.info(
+                "bootstrap_tier2_cohort: %d T1/T2 rows already exist, skipping",
+                t12_count,
+            )
+            return BootstrapResult(promoted=0, skipped_reason="T1/T2 coverage already exists")
+
+        candidates = _select_bootstrap_candidates(conn, cap)
+        if not candidates:
+            logger.warning("bootstrap_tier2_cohort: no eligible T3 instruments found")
+            return BootstrapResult(promoted=0, skipped_reason="no eligible T3 instruments")
+
+        promoted = 0
+        for cand in candidates:
+            instrument_id = int(cand["instrument_id"])
+            symbol = cand["symbol"]
+            has_cik = bool(cand["has_cik"])
+
+            evidence: dict[str, object] = {
+                "symbol": symbol,
+                "has_cik": has_cik,
+                "bootstrap_cap": cap,
+                "reason": "initial T2 seed to break pipeline deadlock",
+            }
+
+            change = TierChange(
+                instrument_id=instrument_id,
+                old_tier=3,
+                new_tier=2,
+                change_type="promotion",
+                rationale=f"bootstrap: T3→T2 seed (has_cik={has_cik})",
+                evidence=evidence,
+            )
+            _apply_tier_change(conn, change)
+            promoted += 1
+
+        logger.info(
+            "bootstrap_tier2_cohort: promoted %d instruments from T3 to T2",
+            promoted,
+        )
+        return BootstrapResult(promoted=promoted, skipped_reason=None)

--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -824,28 +824,26 @@ def bootstrap_tier2_cohort(
     bootstrap rationale so the audit trail explains why these instruments
     were promoted without the usual score/thesis prerequisites.
     """
-    # Check T1/T2 count outside any transaction to avoid an empty
-    # commit on every subsequent (no-op) run.
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute("SELECT COUNT(*) AS cnt FROM coverage WHERE coverage_tier IN (1, 2)")
-        row = cur.fetchone()
-        t12_count = int(row["cnt"]) if row is not None else 0
-
-    if t12_count > 0:
-        logger.info(
-            "bootstrap_tier2_cohort: %d T1/T2 rows already exist, skipping",
-            t12_count,
-        )
-        return BootstrapResult(promoted=0, skipped_reason="T1/T2 coverage already exists")
-
-    candidates = _select_bootstrap_candidates(conn, cap)
-    if not candidates:
-        logger.warning("bootstrap_tier2_cohort: no eligible T3 instruments found")
-        return BootstrapResult(promoted=0, skipped_reason="no eligible T3 instruments")
-
-    # All writes (UPDATE coverage + INSERT coverage_audit) are inside a
-    # single transaction so either all promotions land or none do.
+    # Count check + candidate selection + writes are all inside one
+    # transaction so the check-then-act is atomic.  On no-op runs this
+    # commits an empty transaction — negligible cost for a nightly job.
     with conn.transaction():
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT COUNT(*) AS cnt FROM coverage WHERE coverage_tier IN (1, 2)")
+            row = cur.fetchone()
+            t12_count = int(row["cnt"]) if row is not None else 0
+
+        if t12_count > 0:
+            logger.info(
+                "bootstrap_tier2_cohort: %d T1/T2 rows already exist, skipping",
+                t12_count,
+            )
+            return BootstrapResult(promoted=0, skipped_reason="T1/T2 coverage already exists")
+
+        candidates = _select_bootstrap_candidates(conn, cap)
+        if not candidates:
+            logger.warning("bootstrap_tier2_cohort: no eligible T3 instruments found")
+            return BootstrapResult(promoted=0, skipped_reason="no eligible T3 instruments")
         promoted = 0
         for cand in candidates:
             instrument_id = int(cand["instrument_id"])

--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -57,6 +57,8 @@ TIER_1_CAP: int = 50
 
 # Bootstrap: max instruments to promote from T3→T2 on first run
 BOOTSTRAP_T2_CAP: int = 200
+# Advisory lock ID for bootstrap_tier2_cohort (arbitrary; unique within the app)
+_BOOTSTRAP_LOCK_ID: int = 737_001
 
 # Review frequency mapping — duplicated from thesis.py; extract when touched next
 _REVIEW_FREQUENCY_DAYS: dict[str, int] = {
@@ -827,10 +829,12 @@ def bootstrap_tier2_cohort(
     # Advisory lock + transaction makes the check-then-act atomic even
     # under READ COMMITTED.  The lock is released when the transaction
     # ends, so concurrent callers block rather than both seeing count=0.
-    _BOOTSTRAP_LOCK_ID = 737_001  # arbitrary; unique within the app
     with conn.transaction():
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-            cur.execute("SELECT pg_advisory_xact_lock(%(lock_id)s)", {"lock_id": _BOOTSTRAP_LOCK_ID})
+            cur.execute(
+                "SELECT pg_advisory_xact_lock(%(lock_id)s::bigint)",
+                {"lock_id": _BOOTSTRAP_LOCK_ID},
+            )
             cur.execute("SELECT COUNT(*) AS cnt FROM coverage WHERE coverage_tier IN (1, 2)")
             row = cur.fetchone()
             t12_count = int(row["cnt"]) if row is not None else 0

--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -781,6 +781,10 @@ def _select_bootstrap_candidates(
     eToro-sourced instruments at bootstrap time.  Once fundamentals are
     ingested for the T2 cohort, the weekly coverage review can use real
     sector data for subsequent promotion decisions.
+
+    Requires: caller must hold an active transaction with the bootstrap
+    advisory lock (``pg_advisory_xact_lock(_BOOTSTRAP_LOCK_ID)``) so
+    the candidate read is atomic with the subsequent writes.
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(

--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -824,11 +824,13 @@ def bootstrap_tier2_cohort(
     bootstrap rationale so the audit trail explains why these instruments
     were promoted without the usual score/thesis prerequisites.
     """
-    # Count check + candidate selection + writes are all inside one
-    # transaction so the check-then-act is atomic.  On no-op runs this
-    # commits an empty transaction — negligible cost for a nightly job.
+    # Advisory lock + transaction makes the check-then-act atomic even
+    # under READ COMMITTED.  The lock is released when the transaction
+    # ends, so concurrent callers block rather than both seeing count=0.
+    _BOOTSTRAP_LOCK_ID = 737_001  # arbitrary; unique within the app
     with conn.transaction():
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT pg_advisory_xact_lock(%(lock_id)s)", {"lock_id": _BOOTSTRAP_LOCK_ID})
             cur.execute("SELECT COUNT(*) AS cnt FROM coverage WHERE coverage_tier IN (1, 2)")
             row = cur.fetchone()
             t12_count = int(row["cnt"]) if row is not None else 0

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -38,7 +38,7 @@ from app.providers.implementations.etoro import EtoroMarketDataProvider
 from app.providers.implementations.fmp import FmpFundamentalsProvider
 from app.providers.implementations.sec_edgar import SecFilingsProvider
 from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
-from app.services.coverage import review_coverage, seed_coverage
+from app.services.coverage import bootstrap_tier2_cohort, review_coverage, seed_coverage
 from app.services.filings import FilingsRefreshSummary, refresh_filings, upsert_cik_mapping
 from app.services.fundamentals import refresh_fundamentals
 from app.services.market_data import refresh_market_data
@@ -472,6 +472,20 @@ def nightly_universe_sync() -> None:
                     "Coverage seed: seeded=%d already_populated=%s",
                     seed_result.seeded,
                     seed_result.already_populated,
+                )
+
+            # Bootstrap: if no T1/T2 coverage rows exist, promote an
+            # initial cohort to T2 so downstream jobs (market data,
+            # filings, scoring) can start producing data.  This is a
+            # one-time operation — once T2 rows exist it becomes a no-op.
+            with conn.transaction():
+                bootstrap_result = bootstrap_tier2_cohort(conn)
+                row_count += bootstrap_result.promoted
+                tracker.row_count = row_count
+                logger.info(
+                    "Coverage bootstrap: promoted=%d skipped_reason=%s",
+                    bootstrap_result.promoted,
+                    bootstrap_result.skipped_reason,
                 )
 
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -478,15 +478,16 @@ def nightly_universe_sync() -> None:
             # initial cohort to T2 so downstream jobs (market data,
             # filings, scoring) can start producing data.  This is a
             # one-time operation — once T2 rows exist it becomes a no-op.
-            with conn.transaction():
-                bootstrap_result = bootstrap_tier2_cohort(conn)
-                row_count += bootstrap_result.promoted
-                tracker.row_count = row_count
-                logger.info(
-                    "Coverage bootstrap: promoted=%d skipped_reason=%s",
-                    bootstrap_result.promoted,
-                    bootstrap_result.skipped_reason,
-                )
+            # No outer conn.transaction() — bootstrap_tier2_cohort manages
+            # its own transaction internally.
+            bootstrap_result = bootstrap_tier2_cohort(conn)
+            row_count += bootstrap_result.promoted
+            tracker.row_count = row_count
+            logger.info(
+                "Coverage bootstrap: promoted=%d skipped_reason=%s",
+                bootstrap_result.promoted,
+                bootstrap_result.skipped_reason,
+            )
 
 
 def hourly_market_refresh() -> None:

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1126,8 +1126,8 @@ class TestBootstrapTier2Cohort:
         assert inner["bootstrap_cap"] == BOOTSTRAP_T2_CAP
         assert "deadlock" in inner["reason"]
 
-    def test_writes_inside_transaction(self) -> None:
-        """All promotion writes must be in a single transaction."""
+    def test_count_and_writes_inside_single_transaction(self) -> None:
+        """Count check + promotion writes must be in one transaction (no TOCTOU)."""
         candidates = [self._make_candidate(1, "AAPL")]
         conn = self._mock_conn(t12_count=0, candidates=candidates)
         bootstrap_tier2_cohort(conn)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -16,11 +16,13 @@ Coverage:
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from app.services.coverage import (
+    BOOTSTRAP_T2_CAP,
     DEMOTE_T1_TO_T2_SCORE,
     DEMOTE_T2_TO_T3_SCORE,
     PROMOTE_T2_TO_T1_CONFIDENCE,
@@ -35,6 +37,7 @@ from app.services.coverage import (
     _evaluate_promotion,
     _has_tier1_required_data,
     _is_thesis_fresh,
+    bootstrap_tier2_cohort,
     override_tier,
     review_coverage,
     seed_coverage,
@@ -976,3 +979,160 @@ class TestSeedCoverage:
         conn = self._mock_conn(coverage_count=0, inserted_rows=10)
         seed_coverage(conn)
         conn.transaction.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_tier2_cohort
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapTier2Cohort:
+    """
+    Tests for the bootstrap function that breaks the T3-only deadlock.
+
+    The bootstrap fires once when no T1/T2 coverage rows exist, promotes
+    up to BOOTSTRAP_T2_CAP instruments to T2, and becomes a no-op on all
+    subsequent runs.
+    """
+
+    @staticmethod
+    def _make_candidate(
+        instrument_id: int,
+        symbol: str,
+        has_cik: bool = True,
+    ) -> dict[str, object]:
+        return {
+            "instrument_id": instrument_id,
+            "symbol": symbol,
+            "has_cik": has_cik,
+        }
+
+    def _mock_conn(
+        self,
+        t12_count: int,
+        candidates: list[dict[str, object]] | None = None,
+    ) -> MagicMock:
+        """Build a mock connection for bootstrap_tier2_cohort tests.
+
+        Cursor calls are dispatched by SQL substring:
+          - "coverage_tier IN (1, 2)" → returns t12_count
+          - candidate SELECT → returns candidates list
+
+        conn.execute is recorded for later assertion (UPDATE + INSERT audit).
+        """
+        conn = MagicMock()
+        self._writes: list[tuple[str, dict[str, Any]]] = []
+
+        def _record_execute(sql: str, params: dict[str, Any] | None = None) -> MagicMock:
+            if params is not None:
+                self._writes.append((sql, params))
+            return MagicMock()
+
+        conn.execute.side_effect = _record_execute
+
+        # Track cursor calls in order: first is T1/T2 count, second is candidates
+        cursor_calls: list[MagicMock] = []
+
+        # Cursor 1: T1/T2 count
+        count_cursor = MagicMock()
+        count_cursor.fetchone.return_value = {"cnt": t12_count}
+        count_cursor.__enter__ = MagicMock(return_value=count_cursor)
+        count_cursor.__exit__ = MagicMock(return_value=False)
+        cursor_calls.append(count_cursor)
+
+        # Cursor 2: candidate selection (only if t12_count == 0)
+        if candidates is not None:
+            cand_cursor = MagicMock()
+            cand_cursor.fetchall.return_value = candidates
+            cand_cursor.__enter__ = MagicMock(return_value=cand_cursor)
+            cand_cursor.__exit__ = MagicMock(return_value=False)
+            cursor_calls.append(cand_cursor)
+
+        conn.cursor.side_effect = cursor_calls
+
+        conn.transaction.return_value.__enter__ = MagicMock(return_value=None)
+        conn.transaction.return_value.__exit__ = MagicMock(return_value=False)
+
+        return conn
+
+    def test_promotes_when_no_t12_exist(self) -> None:
+        """When T1/T2 count is 0, bootstrap promotes the candidate set to T2."""
+        candidates = [
+            self._make_candidate(1, "AAPL", has_cik=True),
+            self._make_candidate(2, "MSFT", has_cik=True),
+            self._make_candidate(3, "ZZZ", has_cik=False),
+        ]
+        conn = self._mock_conn(t12_count=0, candidates=candidates)
+        result = bootstrap_tier2_cohort(conn)
+
+        assert result.promoted == 3
+        assert result.skipped_reason is None
+
+        # Each promotion writes: 1 UPDATE coverage + 1 INSERT coverage_audit
+        update_writes = [w for w in self._writes if "UPDATE coverage" in w[0]]
+        audit_writes = [w for w in self._writes if "INSERT INTO coverage_audit" in w[0]]
+        assert len(update_writes) == 3
+        assert len(audit_writes) == 3
+
+        # Verify audit records have correct change_type and rationale
+        for _, params in audit_writes:
+            assert params["change_type"] == "promotion"
+            assert params["old_tier"] == 3
+            assert params["new_tier"] == 2
+            rationale = str(params["rationale"])
+            assert "bootstrap" in rationale
+
+    def test_skips_when_t12_exist(self) -> None:
+        """When T1/T2 rows already exist, bootstrap is a no-op."""
+        conn = self._mock_conn(t12_count=5)
+        result = bootstrap_tier2_cohort(conn)
+
+        assert result.promoted == 0
+        assert result.skipped_reason == "T1/T2 coverage already exists"
+        # No candidate query or writes should have happened
+        assert len(self._writes) == 0
+
+    def test_skips_when_no_eligible_candidates(self) -> None:
+        """When T1/T2 count is 0 but no T3 candidates qualify, return 0."""
+        conn = self._mock_conn(t12_count=0, candidates=[])
+        result = bootstrap_tier2_cohort(conn)
+
+        assert result.promoted == 0
+        assert result.skipped_reason == "no eligible T3 instruments"
+
+    def test_respects_cap_parameter(self) -> None:
+        """The cap limits how many instruments are promoted."""
+        candidates = [self._make_candidate(i, f"SYM{i}") for i in range(5)]
+        conn = self._mock_conn(t12_count=0, candidates=candidates)
+        result = bootstrap_tier2_cohort(conn, cap=5)
+
+        # The mock returns exactly 5 candidates (the SQL LIMIT is the cap);
+        # all 5 should be promoted.
+        assert result.promoted == 5
+
+    def test_evidence_includes_bootstrap_metadata(self) -> None:
+        """Each audit record carries bootstrap-specific evidence."""
+        candidates = [self._make_candidate(42, "AAPL", has_cik=True)]
+        conn = self._mock_conn(t12_count=0, candidates=candidates)
+        bootstrap_tier2_cohort(conn)
+
+        audit_writes = [w for w in self._writes if "INSERT INTO coverage_audit" in w[0]]
+        assert len(audit_writes) == 1
+        evidence_raw = audit_writes[0][1]["evidence_json"]
+        # evidence_json is wrapped in Jsonb; access the inner obj
+        inner: dict[str, Any] = evidence_raw.obj if hasattr(evidence_raw, "obj") else evidence_raw
+        assert inner["symbol"] == "AAPL"
+        assert inner["has_cik"] is True
+        assert inner["bootstrap_cap"] == BOOTSTRAP_T2_CAP
+        assert "deadlock" in inner["reason"]
+
+    def test_runs_inside_transaction(self) -> None:
+        """The count check and all promotions must be in the same transaction."""
+        candidates = [self._make_candidate(1, "AAPL")]
+        conn = self._mock_conn(t12_count=0, candidates=candidates)
+        bootstrap_tier2_cohort(conn)
+        conn.transaction.assert_called_once()
+
+    def test_default_cap_matches_constant(self) -> None:
+        """Verify the default cap parameter is BOOTSTRAP_T2_CAP."""
+        assert BOOTSTRAP_T2_CAP == 200

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1137,6 +1137,7 @@ class TestBootstrapTier2Cohort:
         count_cursor = self._cursor_mocks[0]
         lock_sql = str(count_cursor.execute.call_args_list[0])
         assert "pg_advisory_xact_lock" in lock_sql
+        assert "::bigint" in lock_sql
 
     def test_default_cap_matches_constant(self) -> None:
         """Verify the default cap parameter is BOOTSTRAP_T2_CAP."""

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1114,7 +1114,7 @@ class TestBootstrapTier2Cohort:
         """Each audit record carries bootstrap-specific evidence."""
         candidates = [self._make_candidate(42, "AAPL", has_cik=True)]
         conn = self._mock_conn(t12_count=0, candidates=candidates)
-        bootstrap_tier2_cohort(conn)
+        bootstrap_tier2_cohort(conn, cap=BOOTSTRAP_T2_CAP)
 
         audit_writes = [w for w in self._writes if "INSERT INTO coverage_audit" in w[0]]
         assert len(audit_writes) == 1
@@ -1126,8 +1126,8 @@ class TestBootstrapTier2Cohort:
         assert inner["bootstrap_cap"] == BOOTSTRAP_T2_CAP
         assert "deadlock" in inner["reason"]
 
-    def test_runs_inside_transaction(self) -> None:
-        """The count check and all promotions must be in the same transaction."""
+    def test_writes_inside_transaction(self) -> None:
+        """All promotion writes must be in a single transaction."""
         candidates = [self._make_candidate(1, "AAPL")]
         conn = self._mock_conn(t12_count=0, candidates=candidates)
         bootstrap_tier2_cohort(conn)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1049,6 +1049,7 @@ class TestBootstrapTier2Cohort:
             cursor_calls.append(cand_cursor)
 
         conn.cursor.side_effect = cursor_calls
+        self._cursor_mocks = cursor_calls
 
         conn.transaction.return_value.__enter__ = MagicMock(return_value=None)
         conn.transaction.return_value.__exit__ = MagicMock(return_value=False)
@@ -1126,12 +1127,16 @@ class TestBootstrapTier2Cohort:
         assert inner["bootstrap_cap"] == BOOTSTRAP_T2_CAP
         assert "deadlock" in inner["reason"]
 
-    def test_count_and_writes_inside_single_transaction(self) -> None:
-        """Count check + promotion writes must be in one transaction (no TOCTOU)."""
+    def test_advisory_lock_and_writes_inside_single_transaction(self) -> None:
+        """Advisory lock + count check + writes must share one transaction."""
         candidates = [self._make_candidate(1, "AAPL")]
         conn = self._mock_conn(t12_count=0, candidates=candidates)
         bootstrap_tier2_cohort(conn)
         conn.transaction.assert_called_once()
+        # The count cursor (first) must have the advisory lock call
+        count_cursor = self._cursor_mocks[0]
+        lock_sql = str(count_cursor.execute.call_args_list[0])
+        assert "pg_advisory_xact_lock" in lock_sql
 
     def test_default_cap_matches_constant(self) -> None:
         """Verify the default cap parameter is BOOTSTRAP_T2_CAP."""


### PR DESCRIPTION
## Summary

Closes #165.

The entire pipeline was built, wired, scheduled, and running — but producing zero data. Every downstream job skipped every cycle because of a bootstrap deadlock:

- `nightly_universe_sync` seeded 12,133 instruments at **T3**
- `hourly_market_refresh` skipped ("no Tier 1/2 coverage rows")
- `daily_research_refresh` skipped (same)
- `daily_thesis_refresh` skipped ("no Tier 1 instruments")
- `morning_candidate_review` skipped ("no scores rows")
- `weekly_coverage_review` ran but found nothing to promote (T3→T2 requires score ≥ 0.55 + thesis, but scoring and thesis only run for T1/T2)

**Root cause:** circular dependency — promotion requires data that can only be produced for already-promoted instruments.

## Changes

### `app/services/coverage.py`
- Added `BOOTSTRAP_T2_CAP = 200` constant
- Added `BootstrapResult` dataclass
- Added `_select_bootstrap_candidates()` — selects tradable T3 instruments ranked by data readiness (CIK mapping → SEC filings available, then alphabetical for deterministic tiebreak)
- Added `bootstrap_tier2_cohort()` — fires once when no T1/T2 exist, promotes up to 200 instruments to T2, records each in `coverage_audit` with bootstrap rationale

### `app/workers/scheduler.py`
- Wired `bootstrap_tier2_cohort()` call after `seed_coverage()` in `nightly_universe_sync`. Full first-run sequence: sync universe → seed T3 → bootstrap T2 cohort.

### `tests/test_coverage.py`
- 7 new tests: promotes when no T1/T2 exist, skips when T1/T2 exist, skips when no candidates, respects cap, evidence metadata, transaction atomicity, default cap constant

## Security model

- No new endpoints or auth changes
- Bootstrap only fires when `COUNT(*) FROM coverage WHERE coverage_tier IN (1, 2)` returns 0
- All promotions audited in `coverage_audit` with `change_type = 'promotion'`
- No changes to prerequisite functions — they still correctly gate all jobs

## What happens after this merges

Next `nightly_universe_sync` run (or manual trigger via `POST /jobs/nightly_universe_sync/run`) will:
1. See T3-only state
2. Promote ~200 instruments to T2 (those with CIK mappings first)
3. Next `hourly_market_refresh` populates `quotes` + `price_daily` for the T2 cohort
4. Next `daily_research_refresh` populates `filing_events` + `fundamentals_snapshot`
5. `weekly_coverage_review` can now organically promote T2→T1 based on real data
6. Once T1 exists: thesis generation, scoring, and recommendations start flowing

## Tradeoffs

- **No sector diversity in bootstrap selection** — `sector` is NULL for all eToro instruments at this stage. Once fundamentals are ingested for the T2 cohort, the weekly review has real sector data.
- **200 is a reasonable starter** — large enough to produce meaningful data, small enough that the first market refresh won't be blocked by rate limits.

## Test plan

- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run pyright` passes
- [x] `uv run pytest` — 1024 passed, 1 skipped
- [ ] After merge: trigger `nightly_universe_sync` manually, verify T2 rows appear in `coverage`, verify `hourly_market_refresh` stops skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)