### PR TITLE
feat: reusable Pagination component with numbered pages

### DIFF
--- a/frontend/src/components/ui/Pagination.test.tsx
+++ b/frontend/src/components/ui/Pagination.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { Pagination } from "./Pagination";
+
+describe("Pagination", () => {
+  it("renders nothing when totalPages <= 1", () => {
+    const { container } = render(
+      <Pagination page={0} totalPages={1} onPageChange={vi.fn()} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders page numbers for small page count", () => {
+    render(<Pagination page={0} totalPages={4} onPageChange={vi.fn()} />);
+    expect(screen.getByText("Page 1 of 4")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("marks current page with aria-current", () => {
+    render(<Pagination page={1} totalPages={4} onPageChange={vi.fn()} />);
+    const btn = screen.getByText("2");
+    expect(btn).toHaveAttribute("aria-current", "page");
+    expect(screen.getByText("1")).not.toHaveAttribute("aria-current");
+  });
+
+  it("disables Previous on first page", () => {
+    render(<Pagination page={0} totalPages={5} onPageChange={vi.fn()} />);
+    expect(screen.getByText("Previous")).toBeDisabled();
+    expect(screen.getByText("Next")).not.toBeDisabled();
+  });
+
+  it("disables Next on last page", () => {
+    render(<Pagination page={4} totalPages={5} onPageChange={vi.fn()} />);
+    expect(screen.getByText("Next")).toBeDisabled();
+    expect(screen.getByText("Previous")).not.toBeDisabled();
+  });
+
+  it("calls onPageChange with correct index on page click", async () => {
+    const onChange = vi.fn();
+    render(<Pagination page={0} totalPages={5} onPageChange={onChange} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByText("3"));
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+
+  it("calls onPageChange on Previous click", async () => {
+    const onChange = vi.fn();
+    render(<Pagination page={2} totalPages={5} onPageChange={onChange} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Previous"));
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it("calls onPageChange on Next click", async () => {
+    const onChange = vi.fn();
+    render(<Pagination page={2} totalPages={5} onPageChange={onChange} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Next"));
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+
+  it("renders ellipsis for large page counts", () => {
+    render(<Pagination page={5} totalPages={20} onPageChange={vi.fn()} />);
+    const ellipses = screen.getAllByText("...");
+    expect(ellipses.length).toBe(2); // one before, one after
+    // First and last page always visible
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("20")).toBeInTheDocument();
+    // Window around current (page 5 = display 6)
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("6")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
+  it("no leading ellipsis when current is near start", () => {
+    render(<Pagination page={1} totalPages={20} onPageChange={vi.fn()} />);
+    // Pages 1,2,3 visible + last page, one trailing ellipsis
+    const ellipses = screen.getAllByText("...");
+    expect(ellipses.length).toBe(1);
+  });
+
+  it("no trailing ellipsis when current is near end", () => {
+    render(<Pagination page={18} totalPages={20} onPageChange={vi.fn()} />);
+    const ellipses = screen.getAllByText("...");
+    expect(ellipses.length).toBe(1);
+  });
+});

--- a/frontend/src/components/ui/Pagination.tsx
+++ b/frontend/src/components/ui/Pagination.tsx
@@ -1,0 +1,109 @@
+/**
+ * Reusable numbered pagination bar.
+ *
+ * Renders Previous / page numbers / Next with ellipsis for large ranges.
+ * Designed for operator surfaces — compact, slate palette, tabular layout.
+ */
+
+// ---------------------------------------------------------------------------
+// Page range with ellipsis
+// ---------------------------------------------------------------------------
+
+/** Visible page slots: always show first, last, and a window around current. */
+function pageRange(current: number, total: number): (number | "ellipsis")[] {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i);
+  }
+
+  const pages = new Set<number>();
+  // Always include first and last
+  pages.add(0);
+  pages.add(total - 1);
+  // Window of 1 around current
+  for (let i = current - 1; i <= current + 1; i++) {
+    if (i >= 0 && i < total) pages.add(i);
+  }
+
+  const sorted = [...pages].sort((a, b) => a - b);
+  const result: (number | "ellipsis")[] = [];
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i]! - sorted[i - 1]! > 1) {
+      result.push("ellipsis");
+    }
+    result.push(sorted[i]!);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface PaginationProps {
+  /** Zero-based current page index. */
+  page: number;
+  /** Total number of pages. */
+  totalPages: number;
+  /** Called with the new zero-based page index. */
+  onPageChange: (page: number) => void;
+}
+
+const BTN_BASE =
+  "rounded border px-2 py-1 text-xs font-medium transition-colors";
+const BTN_IDLE =
+  "border-slate-200 bg-white text-slate-600 hover:bg-slate-50";
+const BTN_ACTIVE =
+  "border-blue-400 bg-blue-50 text-blue-700";
+const BTN_DISABLED =
+  "border-slate-200 bg-white text-slate-300 cursor-not-allowed";
+
+export function Pagination({ page, totalPages, onPageChange }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const slots = pageRange(page, totalPages);
+
+  return (
+    <div className="mt-3 flex items-center justify-between text-xs text-slate-500">
+      <span>
+        Page {page + 1} of {totalPages}
+      </span>
+      <div className="flex gap-1">
+        <button
+          type="button"
+          disabled={page === 0}
+          onClick={() => onPageChange(page - 1)}
+          className={`${BTN_BASE} ${page === 0 ? BTN_DISABLED : BTN_IDLE}`}
+        >
+          Previous
+        </button>
+
+        {slots.map((slot, i) =>
+          slot === "ellipsis" ? (
+            <span key={`e${i}`} className="px-1 text-slate-400">
+              ...
+            </span>
+          ) : (
+            <button
+              key={slot}
+              type="button"
+              onClick={() => onPageChange(slot)}
+              className={`${BTN_BASE} ${slot === page ? BTN_ACTIVE : BTN_IDLE}`}
+              aria-current={slot === page ? "page" : undefined}
+            >
+              {slot + 1}
+            </button>
+          ),
+        )}
+
+        <button
+          type="button"
+          disabled={page >= totalPages - 1}
+          onClick={() => onPageChange(page + 1)}
+          className={`${BTN_BASE} ${page >= totalPages - 1 ? BTN_DISABLED : BTN_IDLE}`}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/InstrumentsPage.test.tsx
+++ b/frontend/src/pages/InstrumentsPage.test.tsx
@@ -264,6 +264,27 @@ describe("InstrumentsPage — pagination", () => {
     });
     expect(screen.getByText("Previous")).toBeDisabled();
     expect(screen.getByText("Next")).not.toBeDisabled();
+    // Page number buttons rendered
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("clicking a page number fetches that page", async () => {
+    mockedFetch.mockResolvedValue(makeResponse({ total: 120 }));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("3"));
+
+    await waitFor(() => {
+      const calls = mockedFetch.mock.calls;
+      const lastCall = calls[calls.length - 1]!;
+      expect(lastCall[0]).toMatchObject({ offset: 100 });
+    });
   });
 
   it("clicking Next fetches next page", async () => {

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -19,6 +19,7 @@ import {
 import type { InstrumentListItem } from "@/api/types";
 import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
+import { Pagination } from "@/components/ui/Pagination";
 import { useAsync } from "@/lib/useAsync";
 import { formatMoney } from "@/lib/format";
 
@@ -280,31 +281,11 @@ export function InstrumentsPage() {
               onToggleSort={toggleSort}
               pageScopedSort={totalPages > 1}
             />
-            {totalPages > 1 && (
-              <div className="mt-3 flex items-center justify-between text-xs text-slate-500">
-                <span>
-                  Page {page + 1} of {totalPages}
-                </span>
-                <div className="flex gap-2">
-                  <button
-                    type="button"
-                    disabled={page === 0}
-                    onClick={() => setPage((p) => p - 1)}
-                    className="rounded border border-slate-200 bg-white px-2 py-1 font-medium text-slate-600 hover:bg-slate-50 disabled:opacity-40"
-                  >
-                    Previous
-                  </button>
-                  <button
-                    type="button"
-                    disabled={page >= totalPages - 1}
-                    onClick={() => setPage((p) => p + 1)}
-                    className="rounded border border-slate-200 bg-white px-2 py-1 font-medium text-slate-600 hover:bg-slate-50 disabled:opacity-40"
-                  >
-                    Next
-                  </button>
-                </div>
-              </div>
-            )}
+            <Pagination
+              page={page}
+              totalPages={totalPages}
+              onPageChange={setPage}
+            />
           </>
         )}
       </Section>


### PR DESCRIPTION
## Summary

- Extracts a reusable `Pagination` component (`components/ui/Pagination.tsx`) that renders numbered page buttons with ellipsis for large ranges, plus Previous/Next
- Replaces the prev/next-only inline pagination in `InstrumentsPage` with the new component
- Any future paginated page imports the same component for consistent navigation

## What changed

- **New**: `Pagination` component — shows first/last pages, a window around the current page, and ellipsis gaps. Follows operator UI conventions (slate palette, compact density, blue highlight for active page, `aria-current="page"`)
- **Modified**: `InstrumentsPage` — swapped 20-line inline pagination block for a single `<Pagination />` call
- **Tests**: 11 tests for the Pagination component (render states, click handlers, ellipsis logic, edge cases). Updated InstrumentsPage tests to cover page number clicking

## Security model

No security implications — pure frontend UI component with no API calls or state mutations.

## Test plan

- [x] Pagination renders nothing for single-page results
- [x] Page numbers render for small page counts (<=7)
- [x] Ellipsis renders for large page counts
- [x] Current page has `aria-current="page"`
- [x] Previous disabled on first page, Next disabled on last page
- [x] Click handlers fire with correct zero-based page index
- [x] InstrumentsPage pagination integration tests pass
- [x] Frontend typecheck clean
- [x] All 148 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)