### PR TITLE
feat(#169): remove tier gates, eliminate bootstrap hack, simplify cadences

### DIFF
--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -27,7 +27,6 @@ Promotion is one step per review cycle (T3→T2 or T2→T1, never T3→T1).
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
@@ -54,11 +53,6 @@ DEMOTE_T2_TO_T3_SCORE: float = 0.45
 
 # Tier 1 hard cap
 TIER_1_CAP: int = 50
-
-# Bootstrap: max instruments to promote from T3→T2 on first run
-BOOTSTRAP_T2_CAP: int = 200
-# Advisory lock ID for bootstrap_tier2_cohort (arbitrary; unique within the app)
-_BOOTSTRAP_LOCK_ID: int = 737_001
 
 # Review frequency mapping — duplicated from thesis.py; extract when touched next
 _REVIEW_FREQUENCY_DAYS: dict[str, int] = {
@@ -283,16 +277,16 @@ def _evaluate_promotion(snap: InstrumentSnapshot, now: datetime) -> TierChange |
     evidence = _build_evidence(snap)
 
     if snap.current_tier == 3:
-        # T3 → T2: total_score >= 0.55, thesis exists, instrument tradable
+        # T3 → T2: total_score >= 0.55, instrument tradable.
+        # Thesis is NOT required — deterministic signals (fundamentals,
+        # price action) are sufficient for T3→T2.  Thesis kicks in at T2
+        # to enable T2→T1 promotion.
         reasons: list[str] = []
         if snap.total_score is None or snap.total_score < PROMOTE_T3_TO_T2_SCORE:
-            return None
-        if snap.thesis_created_at is None:
             return None
         if not snap.is_tradable:
             return None
         reasons.append(f"score={snap.total_score:.3f} >= {PROMOTE_T3_TO_T2_SCORE}")
-        reasons.append("thesis exists")
         reasons.append("instrument tradable")
         return TierChange(
             instrument_id=snap.instrument_id,
@@ -752,137 +746,3 @@ def seed_coverage(
         seeded = result.rowcount
         logger.info("seed_coverage: seeded %d instruments at Tier 3", seeded)
         return SeedResult(seeded=seeded, already_populated=False)
-
-
-# ---------------------------------------------------------------------------
-# Bootstrap: break the T3-only deadlock
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class BootstrapResult:
-    """Outcome of ``bootstrap_tier2_cohort``."""
-
-    promoted: int
-    skipped_reason: str | None
-
-
-def _select_bootstrap_candidates(
-    conn: psycopg.Connection[Any],
-    cap: int,
-) -> Sequence[dict[str, Any]]:
-    """Select the best T3 instruments for initial T2 promotion.
-
-    Ranking criteria (descending priority):
-      1. Has a CIK mapping — enables SEC filings ingestion.
-      2. Symbol alphabetical — deterministic tiebreak for reproducibility.
-
-    Sector diversity is not applied because sector data is NULL for all
-    eToro-sourced instruments at bootstrap time.  Once fundamentals are
-    ingested for the T2 cohort, the weekly coverage review can use real
-    sector data for subsequent promotion decisions.
-
-    Requires: caller must hold an active transaction with the bootstrap
-    advisory lock (``pg_advisory_xact_lock(_BOOTSTRAP_LOCK_ID)``) so
-    the candidate read is atomic with the subsequent writes.
-    """
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            """
-            SELECT
-                i.instrument_id,
-                i.symbol,
-                (e.external_identifier_id IS NOT NULL) AS has_cik
-            FROM instruments i
-            JOIN coverage c ON c.instrument_id = i.instrument_id
-            LEFT JOIN external_identifiers e
-                ON  e.instrument_id = i.instrument_id
-                AND e.identifier_type = 'cik'
-                AND e.is_primary = TRUE
-            WHERE i.is_tradable = TRUE
-              AND c.coverage_tier = 3
-            ORDER BY
-                (e.external_identifier_id IS NOT NULL) DESC,
-                i.symbol ASC
-            LIMIT %(cap)s
-            """,
-            {"cap": cap},
-        )
-        return cur.fetchall()
-
-
-def bootstrap_tier2_cohort(
-    conn: psycopg.Connection[Any],
-    cap: int = BOOTSTRAP_T2_CAP,
-) -> BootstrapResult:
-    """Promote an initial cohort from T3 to T2 to break the pipeline deadlock.
-
-    The normal promotion path (T3→T2) requires a thesis and a score, but
-    thesis generation and scoring only run for T1/T2 instruments.  When
-    the entire coverage table is T3 — as it is after first-run seeding —
-    no job can produce the data that promotion depends on.
-
-    This function fires **once**, when no T1/T2 coverage rows exist, to
-    seed a starter T2 cohort.  Subsequent runs detect existing T1/T2 rows
-    and skip immediately.
-
-    Each promotion is recorded in ``coverage_audit`` with a clear
-    bootstrap rationale so the audit trail explains why these instruments
-    were promoted without the usual score/thesis prerequisites.
-
-    Concurrency: an advisory lock (``pg_advisory_xact_lock``) inside
-    the transaction prevents duplicate promotions if two runs overlap.
-    """
-    # Advisory lock + transaction makes the check-then-act atomic even
-    # under READ COMMITTED.  The lock is released when the transaction
-    # ends, so concurrent callers block rather than both seeing count=0.
-    with conn.transaction():
-        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-            cur.execute(
-                "SELECT pg_advisory_xact_lock(%(lock_id)s::bigint)",
-                {"lock_id": _BOOTSTRAP_LOCK_ID},
-            )
-            cur.execute("SELECT COUNT(*) AS cnt FROM coverage WHERE coverage_tier IN (1, 2)")
-            row = cur.fetchone()
-            t12_count = int(row["cnt"]) if row is not None else 0
-
-        if t12_count > 0:
-            logger.info(
-                "bootstrap_tier2_cohort: %d T1/T2 rows already exist, skipping",
-                t12_count,
-            )
-            return BootstrapResult(promoted=0, skipped_reason="T1/T2 coverage already exists")
-
-        candidates = _select_bootstrap_candidates(conn, cap)
-        if not candidates:
-            logger.warning("bootstrap_tier2_cohort: no eligible T3 instruments found")
-            return BootstrapResult(promoted=0, skipped_reason="no eligible T3 instruments")
-        promoted = 0
-        for cand in candidates:
-            instrument_id = int(cand["instrument_id"])
-            symbol = cand["symbol"]
-            has_cik = bool(cand["has_cik"])
-
-            evidence: dict[str, object] = {
-                "symbol": symbol,
-                "has_cik": has_cik,
-                "bootstrap_cap": cap,
-                "reason": "initial T2 seed to break pipeline deadlock",
-            }
-
-            change = TierChange(
-                instrument_id=instrument_id,
-                old_tier=3,
-                new_tier=2,
-                change_type="promotion",
-                rationale=f"bootstrap: T3→T2 seed (has_cik={has_cik})",
-                evidence=evidence,
-            )
-            _apply_tier_change(conn, change)
-            promoted += 1
-
-    logger.info(
-        "bootstrap_tier2_cohort: promoted %d instruments from T3 to T2",
-        promoted,
-    )
-    return BootstrapResult(promoted=promoted, skipped_reason=None)

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -846,15 +846,17 @@ def compute_rankings(
     if model_version not in _WEIGHT_MODES:
         raise KeyError(f"Unknown model_version: {model_version!r}")
 
-    # Eligible instruments
+    # Eligible instruments — all tradable instruments with at least some data.
+    # No tier gate: scoring runs for every instrument that has fundamentals,
+    # price history, or a thesis.  This lets T3 instruments accumulate scores
+    # so the weekly coverage review can promote them to T2 on deterministic
+    # signals alone.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as elig_cur:
         elig_cur.execute(
             """
             SELECT DISTINCT i.instrument_id
             FROM instruments i
-            JOIN coverage c ON c.instrument_id = i.instrument_id
             WHERE i.is_tradable = TRUE
-              AND c.coverage_tier = 1
               AND (
                   EXISTS (SELECT 1 FROM theses t WHERE t.instrument_id = i.instrument_id)
                   OR EXISTS (SELECT 1 FROM fundamentals_snapshot f WHERE f.instrument_id = i.instrument_id)
@@ -867,7 +869,7 @@ def compute_rankings(
 
     instrument_ids = [int(r["instrument_id"]) for r in rows]
     if not instrument_ids:
-        logger.info("compute_rankings: no eligible Tier 1 instruments found")
+        logger.info("compute_rankings: no eligible instruments found")
         return RankingResult(scored=[], model_version=model_version)
 
     logger.info("compute_rankings: scoring %d eligible instrument(s) [model=%s]", len(instrument_ids), model_version)

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -846,16 +846,17 @@ def compute_rankings(
     if model_version not in _WEIGHT_MODES:
         raise KeyError(f"Unknown model_version: {model_version!r}")
 
-    # Eligible instruments — all tradable instruments with at least some data.
-    # No tier gate: scoring runs for every instrument that has fundamentals,
-    # price history, or a thesis.  This lets T3 instruments accumulate scores
-    # so the weekly coverage review can promote them to T2 on deterministic
-    # signals alone.
+    # Eligible instruments — all tradable instruments with a coverage row
+    # and at least some data.  No tier gate: scoring runs for every tier
+    # (including T3) so the weekly coverage review can promote on
+    # deterministic signals alone.  The coverage JOIN ensures scores are
+    # only created for instruments that review_coverage can see.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as elig_cur:
         elig_cur.execute(
             """
             SELECT DISTINCT i.instrument_id
             FROM instruments i
+            JOIN coverage c ON c.instrument_id = i.instrument_id
             WHERE i.is_tradable = TRUE
               AND (
                   EXISTS (SELECT 1 FROM theses t WHERE t.instrument_id = i.instrument_id)

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -38,7 +38,7 @@ from app.providers.implementations.etoro import EtoroMarketDataProvider
 from app.providers.implementations.fmp import FmpFundamentalsProvider
 from app.providers.implementations.sec_edgar import SecFilingsProvider
 from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
-from app.services.coverage import bootstrap_tier2_cohort, review_coverage, seed_coverage
+from app.services.coverage import review_coverage, seed_coverage
 from app.services.filings import FilingsRefreshSummary, refresh_filings, upsert_cik_mapping
 from app.services.fundamentals import refresh_fundamentals
 from app.services.market_data import refresh_market_data
@@ -203,6 +203,13 @@ def _has_any_coverage(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     return (False, "coverage table is empty")
 
 
+def _has_any_tradable(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if at least one tradable instrument exists."""
+    if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM instruments WHERE is_tradable = TRUE)")):
+        return (True, "")
+    return (False, "no tradable instruments")
+
+
 def _has_scores(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     """True if at least one score row exists."""
     if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM scores)")):
@@ -222,11 +229,8 @@ def _has_tier1_stale_theses(conn: psycopg.Connection[Any]) -> PrerequisiteResult
 # planning but should not be treated as the live truth. See module docstring.
 SCHEDULED_JOBS: list[ScheduledJob] = [
     # -- Always-on: data infrastructure, no prerequisites ----------------
-    ScheduledJob(
-        name=JOB_NIGHTLY_UNIVERSE_SYNC,
-        description="Sync the eToro tradable instrument universe to the local DB.",
-        cadence=Cadence.daily(hour=2, minute=0),
-    ),
+    # nightly_universe_sync is on-demand only (eToro's instrument list
+    # barely changes).  It stays in _INVOKERS for "Run now" in the Admin UI.
     ScheduledJob(
         name=JOB_DAILY_CIK_REFRESH,
         description="Refresh the SEC ticker→CIK mapping in external_identifiers.",
@@ -241,9 +245,9 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_DAILY_RESEARCH_REFRESH,
-        description="Refresh fundamentals and filings for active Tier 1/2 instruments.",
+        description="Refresh fundamentals and filings for all tradable instruments.",
         cadence=Cadence.daily(hour=3, minute=30),
-        prerequisite=_has_coverage_tier12,
+        prerequisite=_has_any_tradable,
     ),
     ScheduledJob(
         name=JOB_DAILY_NEWS_REFRESH,
@@ -474,20 +478,7 @@ def nightly_universe_sync() -> None:
                     seed_result.already_populated,
                 )
 
-            # Bootstrap: if no T1/T2 coverage rows exist, promote an
-            # initial cohort to T2 so downstream jobs (market data,
-            # filings, scoring) can start producing data.  This is a
-            # one-time operation — once T2 rows exist it becomes a no-op.
-            # No outer conn.transaction() — bootstrap_tier2_cohort manages
-            # its own transaction internally.
-            bootstrap_result = bootstrap_tier2_cohort(conn)
-            row_count += bootstrap_result.promoted
             tracker.row_count = row_count
-            logger.info(
-                "Coverage bootstrap: promoted=%d skipped_reason=%s",
-                bootstrap_result.promoted,
-                bootstrap_result.skipped_reason,
-            )
 
 
 def hourly_market_refresh() -> None:
@@ -564,12 +555,17 @@ def daily_cik_refresh() -> None:
 
 def daily_research_refresh() -> None:
     """
-    Refresh fundamentals and filings for all active Tier 1/2 instruments.
+    Refresh fundamentals and filings for all tradable instruments.
 
     Runs daily. Fetches:
-      - FMP fundamentals snapshot (latest) for each covered symbol
+      - FMP fundamentals snapshot (latest) for each tradable symbol
       - SEC EDGAR filing metadata for US instruments with a known CIK
       - Companies House filing metadata for UK instruments with a company_number
+
+    No tier gate — fundamentals and filings are cheap batch operations.
+    Hydrating data for the full universe lets scoring produce scores for
+    T3 instruments, enabling the weekly coverage review to promote them
+    to T2 on deterministic signals alone.
     """
     if not settings.fmp_api_key:
         logger.error("daily_research_refresh: FMP_API_KEY not set, skipping fundamentals")
@@ -582,15 +578,13 @@ def daily_research_refresh() -> None:
                 """
                 SELECT i.symbol, i.instrument_id::text
                 FROM instruments i
-                JOIN coverage c ON c.instrument_id = i.instrument_id
                 WHERE i.is_tradable = TRUE
-                  AND c.coverage_tier IN (1, 2)
                 ORDER BY i.symbol
                 """
             ).fetchall()
 
         if not rows:
-            logger.info("daily_research_refresh: no covered instruments found, skipping")
+            logger.info("daily_research_refresh: no tradable instruments found, skipping")
             tracker.row_count = 0
             return
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -203,13 +203,6 @@ def _has_any_coverage(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     return (False, "coverage table is empty")
 
 
-def _has_any_tradable(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
-    """True if at least one tradable instrument exists."""
-    if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM instruments WHERE is_tradable = TRUE)")):
-        return (True, "")
-    return (False, "no tradable instruments")
-
-
 def _has_scores(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     """True if at least one score row exists."""
     if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM scores)")):
@@ -247,7 +240,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         name=JOB_DAILY_RESEARCH_REFRESH,
         description="Refresh fundamentals and filings for all tradable instruments.",
         cadence=Cadence.daily(hour=3, minute=30),
-        prerequisite=_has_any_tradable,
+        prerequisite=_has_any_coverage,
     ),
     ScheduledJob(
         name=JOB_DAILY_NEWS_REFRESH,

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -16,13 +16,11 @@ Coverage:
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from app.services.coverage import (
-    BOOTSTRAP_T2_CAP,
     DEMOTE_T1_TO_T2_SCORE,
     DEMOTE_T2_TO_T3_SCORE,
     PROMOTE_T2_TO_T1_CONFIDENCE,
@@ -37,7 +35,6 @@ from app.services.coverage import (
     _evaluate_promotion,
     _has_tier1_required_data,
     _is_thesis_fresh,
-    bootstrap_tier2_cohort,
     override_tier,
     review_coverage,
     seed_coverage,
@@ -205,7 +202,8 @@ class TestPromotionT3ToT2:
         snap = _snap(current_tier=3, total_score=PROMOTE_T3_TO_T2_SCORE)
         assert _evaluate_promotion(snap, _NOW) is not None
 
-    def test_no_thesis_blocks(self) -> None:
+    def test_no_thesis_does_not_block(self) -> None:
+        """T3→T2 does not require a thesis — deterministic signals suffice."""
         snap = InstrumentSnapshot(
             instrument_id=1,
             symbol="X",
@@ -220,7 +218,9 @@ class TestPromotionT3ToT2:
             has_quote=True,
             spread_flag=False,
         )
-        assert _evaluate_promotion(snap, _NOW) is None
+        result = _evaluate_promotion(snap, _NOW)
+        assert result is not None
+        assert result.new_tier == 2
 
     def test_not_tradable_blocks(self) -> None:
         snap = _snap(current_tier=3, total_score=0.60, is_tradable=False)
@@ -721,6 +721,29 @@ class TestReviewCoverage:
         assert result.promotions[0].new_tier == 2
 
     @patch("app.services.coverage._utcnow", return_value=_NOW)
+    def test_promotion_t3_to_t2_without_thesis(self, _mock_now: MagicMock) -> None:
+        """T3→T2 does NOT require a thesis — deterministic signals suffice."""
+        snap = InstrumentSnapshot(
+            instrument_id=1,
+            symbol="AAPL",
+            is_tradable=True,
+            current_tier=3,
+            review_frequency=None,
+            total_score=0.60,
+            thesis_stance=None,
+            thesis_confidence=None,
+            thesis_created_at=None,
+            has_fundamentals=True,
+            has_quote=True,
+            spread_flag=False,
+        )
+        conn = self._mock_conn_for_snapshots([snap])
+        result = review_coverage(conn)
+        assert len(result.promotions) == 1
+        assert result.promotions[0].new_tier == 2
+        assert "thesis" not in result.promotions[0].rationale.lower()
+
+    @patch("app.services.coverage._utcnow", return_value=_NOW)
     def test_demotion_t1_to_t2(self, _mock_now: MagicMock) -> None:
         snap = _snap(instrument_id=1, current_tier=1, total_score=0.50)
         conn = self._mock_conn_for_snapshots([snap])
@@ -979,166 +1002,3 @@ class TestSeedCoverage:
         conn = self._mock_conn(coverage_count=0, inserted_rows=10)
         seed_coverage(conn)
         conn.transaction.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# bootstrap_tier2_cohort
-# ---------------------------------------------------------------------------
-
-
-class TestBootstrapTier2Cohort:
-    """
-    Tests for the bootstrap function that breaks the T3-only deadlock.
-
-    The bootstrap fires once when no T1/T2 coverage rows exist, promotes
-    up to BOOTSTRAP_T2_CAP instruments to T2, and becomes a no-op on all
-    subsequent runs.
-    """
-
-    @staticmethod
-    def _make_candidate(
-        instrument_id: int,
-        symbol: str,
-        has_cik: bool = True,
-    ) -> dict[str, object]:
-        return {
-            "instrument_id": instrument_id,
-            "symbol": symbol,
-            "has_cik": has_cik,
-        }
-
-    def _mock_conn(
-        self,
-        t12_count: int,
-        candidates: list[dict[str, object]] | None = None,
-    ) -> MagicMock:
-        """Build a mock connection for bootstrap_tier2_cohort tests.
-
-        Cursor calls are dispatched by SQL substring:
-          - "coverage_tier IN (1, 2)" → returns t12_count
-          - candidate SELECT → returns candidates list
-
-        conn.execute is recorded for later assertion (UPDATE + INSERT audit).
-        """
-        conn = MagicMock()
-        self._writes: list[tuple[str, dict[str, Any]]] = []
-
-        def _record_execute(sql: str, params: dict[str, Any] | None = None) -> MagicMock:
-            if params is not None:
-                self._writes.append((sql, params))
-            return MagicMock()
-
-        conn.execute.side_effect = _record_execute
-
-        # Track cursor calls in order: first is T1/T2 count, second is candidates
-        cursor_calls: list[MagicMock] = []
-
-        # Cursor 1: T1/T2 count
-        count_cursor = MagicMock()
-        count_cursor.fetchone.return_value = {"cnt": t12_count}
-        count_cursor.__enter__ = MagicMock(return_value=count_cursor)
-        count_cursor.__exit__ = MagicMock(return_value=False)
-        cursor_calls.append(count_cursor)
-
-        # Cursor 2: candidate selection (only if t12_count == 0)
-        if candidates is not None:
-            cand_cursor = MagicMock()
-            cand_cursor.fetchall.return_value = candidates
-            cand_cursor.__enter__ = MagicMock(return_value=cand_cursor)
-            cand_cursor.__exit__ = MagicMock(return_value=False)
-            cursor_calls.append(cand_cursor)
-
-        conn.cursor.side_effect = cursor_calls
-        self._cursor_mocks = cursor_calls
-
-        conn.transaction.return_value.__enter__ = MagicMock(return_value=None)
-        conn.transaction.return_value.__exit__ = MagicMock(return_value=False)
-
-        return conn
-
-    def test_promotes_when_no_t12_exist(self) -> None:
-        """When T1/T2 count is 0, bootstrap promotes the candidate set to T2."""
-        candidates = [
-            self._make_candidate(1, "AAPL", has_cik=True),
-            self._make_candidate(2, "MSFT", has_cik=True),
-            self._make_candidate(3, "ZZZ", has_cik=False),
-        ]
-        conn = self._mock_conn(t12_count=0, candidates=candidates)
-        result = bootstrap_tier2_cohort(conn)
-
-        assert result.promoted == 3
-        assert result.skipped_reason is None
-
-        # Each promotion writes: 1 UPDATE coverage + 1 INSERT coverage_audit
-        update_writes = [w for w in self._writes if "UPDATE coverage" in w[0]]
-        audit_writes = [w for w in self._writes if "INSERT INTO coverage_audit" in w[0]]
-        assert len(update_writes) == 3
-        assert len(audit_writes) == 3
-
-        # Verify audit records have correct change_type and rationale
-        for _, params in audit_writes:
-            assert params["change_type"] == "promotion"
-            assert params["old_tier"] == 3
-            assert params["new_tier"] == 2
-            rationale = str(params["rationale"])
-            assert "bootstrap" in rationale
-
-    def test_skips_when_t12_exist(self) -> None:
-        """When T1/T2 rows already exist, bootstrap is a no-op."""
-        conn = self._mock_conn(t12_count=5)
-        result = bootstrap_tier2_cohort(conn)
-
-        assert result.promoted == 0
-        assert result.skipped_reason == "T1/T2 coverage already exists"
-        # No candidate query or writes should have happened
-        assert len(self._writes) == 0
-
-    def test_skips_when_no_eligible_candidates(self) -> None:
-        """When T1/T2 count is 0 but no T3 candidates qualify, return 0."""
-        conn = self._mock_conn(t12_count=0, candidates=[])
-        result = bootstrap_tier2_cohort(conn)
-
-        assert result.promoted == 0
-        assert result.skipped_reason == "no eligible T3 instruments"
-
-    def test_respects_cap_parameter(self) -> None:
-        """The cap limits how many instruments are promoted."""
-        candidates = [self._make_candidate(i, f"SYM{i}") for i in range(5)]
-        conn = self._mock_conn(t12_count=0, candidates=candidates)
-        result = bootstrap_tier2_cohort(conn, cap=5)
-
-        # The mock returns exactly 5 candidates (the SQL LIMIT is the cap);
-        # all 5 should be promoted.
-        assert result.promoted == 5
-
-    def test_evidence_includes_bootstrap_metadata(self) -> None:
-        """Each audit record carries bootstrap-specific evidence."""
-        candidates = [self._make_candidate(42, "AAPL", has_cik=True)]
-        conn = self._mock_conn(t12_count=0, candidates=candidates)
-        bootstrap_tier2_cohort(conn, cap=BOOTSTRAP_T2_CAP)
-
-        audit_writes = [w for w in self._writes if "INSERT INTO coverage_audit" in w[0]]
-        assert len(audit_writes) == 1
-        evidence_raw = audit_writes[0][1]["evidence_json"]
-        # evidence_json is wrapped in Jsonb; access the inner obj
-        inner: dict[str, Any] = evidence_raw.obj if hasattr(evidence_raw, "obj") else evidence_raw
-        assert inner["symbol"] == "AAPL"
-        assert inner["has_cik"] is True
-        assert inner["bootstrap_cap"] == BOOTSTRAP_T2_CAP
-        assert "deadlock" in inner["reason"]
-
-    def test_advisory_lock_and_writes_inside_single_transaction(self) -> None:
-        """Advisory lock + count check + writes must share one transaction."""
-        candidates = [self._make_candidate(1, "AAPL")]
-        conn = self._mock_conn(t12_count=0, candidates=candidates)
-        bootstrap_tier2_cohort(conn)
-        conn.transaction.assert_called_once()
-        # The count cursor (first) must have the advisory lock call
-        count_cursor = self._cursor_mocks[0]
-        lock_sql = str(count_cursor.execute.call_args_list[0])
-        assert "pg_advisory_xact_lock" in lock_sql
-        assert "::bigint" in lock_sql
-
-    def test_default_cap_matches_constant(self) -> None:
-        """Verify the default cap parameter is BOOTSTRAP_T2_CAP."""
-        assert BOOTSTRAP_T2_CAP == 200

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -209,13 +209,13 @@ class TestStartWiring:
         # Wire an invoker for a name that IS in SCHEDULED_JOBS, plus
         # one that is not. start() should register the first and
         # silently ignore the second.
-        from app.workers.scheduler import JOB_NIGHTLY_UNIVERSE_SYNC
+        from app.workers.scheduler import JOB_DAILY_CIK_REFRESH
 
         added: list[str] = []
 
         rt = _make_runtime(
             {
-                JOB_NIGHTLY_UNIVERSE_SYNC: lambda: None,
+                JOB_DAILY_CIK_REFRESH: lambda: None,
                 "not_in_registry": lambda: None,
             }
         )
@@ -229,7 +229,7 @@ class TestStartWiring:
 
         rt.start()
 
-        assert added == [f"recurring:{JOB_NIGHTLY_UNIVERSE_SYNC}"]
+        assert added == [f"recurring:{JOB_DAILY_CIK_REFRESH}"]
 
     def test_double_start_raises(self, patched_runtime: None) -> None:
         rt = _make_runtime({})
@@ -267,7 +267,7 @@ class TestProductionInvokerRegistry:
         registry_names = {job.name for job in SCHEDULED_JOBS}
         invoker_names = set(_INVOKERS.keys())
         on_demand = invoker_names - registry_names
-        assert on_demand == {"daily_tax_reconciliation"}, (
+        assert on_demand == {"daily_tax_reconciliation", "nightly_universe_sync"}, (
             f"Unexpected on-demand invokers (update this test if intentional): {sorted(on_demand)}"
         )
 


### PR DESCRIPTION
## Summary

Breaks the pipeline circular dependency that prevented self-bootstrapping. The pipeline had a deadlock: scoring only ran for T1, thesis only ran for T1, T3→T2 required both score and thesis, and the bootstrap hack that force-promoted 200 instruments to T2 left them stuck there because scoring wouldn't look at T2.

- **Remove thesis requirement from T3→T2 promotion** — deterministic signals (fundamentals + price action) are sufficient. 55% of the score weight (quality, turnaround, momentum) is computable without AI. Thesis kicks in at T2 for T2→T1 promotion.
- **Widen scoring eligibility** from Tier 1 only → all tradable instruments with data. No tier gate on scoring.
- **Widen daily_research_refresh** from T1/T2 → all tradable instruments. Fundamentals and filings are cheap batch operations. Freshness skip from #168 prevents redundant API calls.
- **Remove nightly_universe_sync from scheduled jobs** — on-demand only. eToro's instrument list barely changes.
- **Delete bootstrap hack entirely** — `BootstrapResult`, `BOOTSTRAP_T2_CAP`, `_BOOTSTRAP_LOCK_ID`, `_select_bootstrap_candidates`, `bootstrap_tier2_cohort` all removed.

## Pipeline flow after this change

```
Universe sync (on-demand) → seeds T3 coverage for all tradable
CIK refresh (daily) → maps tickers to CIKs
Research refresh (daily, ALL tradable) → fundamentals + filings
Scoring (daily, ALL with data) → quality + turnaround from deterministic data
Coverage review (weekly) → T3→T2 on score >= 0.55 alone
Hourly market refresh (T1/T2) → quotes + candles for promoted instruments
Thesis generation (daily, T1) → AI analysis for top-tier
Coverage review → T2→T1 needs thesis + score >= 0.70
```

## Settled decisions preserved

- Scoring model remains heuristic, explicit, auditable — only eligibility filter changed
- Provider boundary unchanged — all changes in service/scheduler layer
- Tier system preserved — gates removed on data collection and scoring, not on tiers themselves
- T2→T1 promotion still requires thesis, confidence >= 0.60, fresh thesis, liquidity pass

## Security model

No auth changes. No new endpoints. No provider modifications.

## Conscious tradeoffs

- `daily_research_refresh` goes from ~200 to ~12K instruments. First run will take ~50 min (FMP rate limit). Subsequent runs skip fresh data via #168 freshness logic.
- `daily_cik_refresh` stays daily (issue suggested monthly but Cadence system lacks monthly kind — daily is fine, single idempotent HTTP call).
- Initial candle load for all instruments deferred — pipeline self-bootstraps on fundamentals alone.

## Test plan

- [x] `test_no_thesis_does_not_block` — T3→T2 promotion succeeds without thesis
- [x] `test_promotion_t3_to_t2_without_thesis` — integration test via `review_coverage`
- [x] Bootstrap tests removed (7 tests for deleted code)
- [x] `test_start_only_registers_intersection` — updated to use a scheduled job
- [x] `test_every_invoker_is_scheduled_or_on_demand` — updated expected on-demand set
- [x] All 1044 tests pass (lint, format, pyright, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)