### PR TITLE
feat(#176): SEC XBRL fundamentals + pipeline unblock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 build/
 .DS_Store
 .claude/settings.local.json
+data/

--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -1,0 +1,571 @@
+"""
+SEC EDGAR XBRL fundamentals provider.
+
+Implements FundamentalsProvider against the SEC Company Facts API
+(https://data.sec.gov/api/xbrl/companyfacts/).  Completely free, no API key
+required, 10 req/s rate limit.
+
+This is the primary fundamentals source for US-listed companies.  FMP remains
+as a fallback for non-US equities.
+
+Data extraction strategy:
+  - Income / cash-flow items (flow over a period): take the most recent 10-K
+    entry (``fp=FY``) for a TTM figure.  If no 10-K exists, sum the 4 most
+    recent distinct single-quarter values.
+  - Balance-sheet items (point-in-time): take the most recent entry regardless
+    of form type.
+  - Margins and FCF are derived from the raw values.
+
+XBRL tag priority for revenue (companies use different tags):
+  1. RevenueFromContractWithCustomerExcludingAssessedTax  (ASC 606, post-2018)
+  2. Revenues
+  3. SalesRevenueNet  (older filings)
+  4. RevenueFromContractWithCustomerIncludingAssessedTax
+
+Provider contract:
+  - Providers are pure HTTP clients — no DB access.
+  - The service layer resolves instrument_id → CIK via external_identifiers
+    and passes the CIK when calling this provider.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+from types import TracebackType
+from typing import Any
+
+import httpx
+
+from app.providers.fundamentals import FundamentalsProvider, FundamentalsSnapshot
+from app.providers.resilient_client import ResilientClient
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://data.sec.gov"
+_RAW_PAYLOAD_DIR = Path("data/raw/sec_fundamentals")
+
+# SEC rate-limit: 10 req/s.  Shared with the filings provider if both are
+# running, but in practice they run in separate phases of daily_research_refresh
+# so no cross-provider coordination is needed.
+_MIN_REQUEST_INTERVAL_S = 0.11
+
+# XBRL tags, in priority order, for each concept.
+# Companies use different tags depending on accounting standard and vintage.
+_REVENUE_TAGS = (
+    "RevenueFromContractWithCustomerExcludingAssessedTax",
+    "Revenues",
+    "SalesRevenueNet",
+    "RevenueFromContractWithCustomerIncludingAssessedTax",
+)
+_GROSS_PROFIT_TAGS = ("GrossProfit",)
+_OPERATING_INCOME_TAGS = ("OperatingIncomeLoss",)
+_OPERATING_CF_TAGS = ("NetCashProvidedByUsedInOperatingActivities",)
+_CAPEX_TAGS = (
+    "PaymentsToAcquirePropertyPlantAndEquipment",
+    "CapitalExpenditures",
+)
+_CASH_TAGS = (
+    "CashAndCashEquivalentsAtCarryingValue",
+    "CashCashEquivalentsAndShortTermInvestments",
+)
+_DEBT_TAGS = ("LongTermDebt", "LongTermDebtNoncurrent")
+_EQUITY_TAGS = ("StockholdersEquity", "StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest")
+_EPS_TAGS = ("EarningsPerShareDiluted",)
+_SHARES_TAGS = ("CommonStockSharesOutstanding", "WeightedAverageNumberOfDilutedSharesOutstanding")
+
+
+def _persist_raw(tag: str, payload: object) -> None:
+    try:
+        _RAW_PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        path = _RAW_PAYLOAD_DIR / f"{tag}_{ts}.json"
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except Exception:
+        logger.warning("Failed to persist raw SEC fundamentals payload for tag=%s", tag, exc_info=True)
+
+
+def _zero_pad_cik(cik: str | int) -> str:
+    return str(int(cik)).zfill(10)
+
+
+class SecFundamentalsProvider(FundamentalsProvider):
+    """
+    Fetches normalised fundamentals from SEC EDGAR XBRL Company Facts API.
+
+    Use as a context manager:
+
+        with SecFundamentalsProvider(user_agent=...) as provider:
+            snap = provider.get_latest_snapshot("AAPL", cik="0000320193")
+
+    The ``symbol`` parameter in the interface methods is the ticker symbol
+    for the FundamentalsSnapshot.  The ``cik`` must be passed separately
+    via ``get_latest_snapshot_by_cik`` / ``get_snapshot_history_by_cik``.
+    The standard interface methods (``get_latest_snapshot``, etc.) are
+    implemented but require the symbol to already exist in the CIK cache
+    (populated by the service layer at the start of the refresh run).
+    """
+
+    def __init__(self, user_agent: str) -> None:
+        self._user_agent = user_agent
+        self._client = httpx.Client(
+            base_url=_BASE_URL,
+            headers={"User-Agent": user_agent, "Accept": "application/json"},
+            timeout=30.0,
+        )
+        self._http = ResilientClient(
+            self._client,
+            min_request_interval_s=_MIN_REQUEST_INTERVAL_S,
+        )
+        # symbol → CIK cache, populated by caller before bulk refresh
+        self._cik_cache: dict[str, str] = {}
+
+    def __enter__(self) -> SecFundamentalsProvider:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self._client.close()
+
+    def set_cik_cache(self, mapping: dict[str, str]) -> None:
+        """Populate the symbol→CIK cache for bulk operations."""
+        self._cik_cache = {k.upper(): v for k, v in mapping.items()}
+
+    # ------------------------------------------------------------------
+    # FundamentalsProvider interface
+    # ------------------------------------------------------------------
+
+    def get_latest_snapshot(self, symbol: str) -> FundamentalsSnapshot | None:
+        cik = self._cik_cache.get(symbol.upper())
+        if not cik:
+            return None
+        return self.get_latest_snapshot_by_cik(symbol, cik)
+
+    def get_snapshot_history(
+        self,
+        symbol: str,
+        from_date: date,
+        to_date: date,
+        limit: int = 40,
+    ) -> list[FundamentalsSnapshot]:
+        cik = self._cik_cache.get(symbol.upper())
+        if not cik:
+            return []
+        return self.get_snapshot_history_by_cik(symbol, cik, from_date, to_date, limit)
+
+    # ------------------------------------------------------------------
+    # CIK-based methods (called directly by service layer)
+    # ------------------------------------------------------------------
+
+    def get_latest_snapshot_by_cik(
+        self,
+        symbol: str,
+        cik: str,
+    ) -> FundamentalsSnapshot | None:
+        """Fetch the most recent fundamentals for a company by CIK."""
+        facts = self._fetch_company_facts(cik)
+        if facts is None:
+            return None
+
+        gaap = facts.get("facts", {}).get("us-gaap", {})
+        if not gaap:
+            logger.info("SEC fundamentals: no us-gaap facts for CIK %s (%s)", cik, symbol)
+            return None
+
+        return _build_latest_snapshot(symbol, gaap)
+
+    def get_snapshot_history_by_cik(
+        self,
+        symbol: str,
+        cik: str,
+        from_date: date,
+        to_date: date,
+        limit: int = 40,
+    ) -> list[FundamentalsSnapshot]:
+        """Fetch historical fundamentals snapshots from 10-K filings."""
+        facts = self._fetch_company_facts(cik)
+        if facts is None:
+            return []
+
+        gaap = facts.get("facts", {}).get("us-gaap", {})
+        if not gaap:
+            return []
+
+        return _build_history_snapshots(symbol, gaap, from_date, to_date, limit)
+
+    # ------------------------------------------------------------------
+    # Private HTTP
+    # ------------------------------------------------------------------
+
+    def _fetch_company_facts(self, cik: str) -> dict[str, Any] | None:
+        cik_padded = _zero_pad_cik(cik)
+        path = f"/api/xbrl/companyfacts/CIK{cik_padded}.json"
+        resp = self._http.get(path)
+        if resp.status_code == 404:
+            logger.info("SEC fundamentals: no company facts for CIK %s", cik)
+            return None
+        resp.raise_for_status()
+        raw = resp.json()
+        _persist_raw(f"sec_facts_{cik_padded}", raw)
+        return raw  # type: ignore[no-any-return]
+
+
+# ------------------------------------------------------------------
+# Normalisers — pure functions, no I/O
+# ------------------------------------------------------------------
+
+
+def _get_entries(gaap: dict[str, Any], tags: tuple[str, ...]) -> list[dict[str, Any]]:
+    """Return entries for the first matching XBRL tag.
+
+    Tries unit types in order: USD (monetary), USD/shares (per-share),
+    shares (share counts).
+    """
+    for tag in tags:
+        fact = gaap.get(tag)
+        if fact is None:
+            continue
+        units = fact.get("units", {})
+        entries = units.get("USD") or units.get("USD/shares") or units.get("shares") or []
+        if entries:
+            return entries  # type: ignore[no-any-return]
+    return []
+
+
+def _latest_annual_value(entries: list[dict[str, Any]]) -> tuple[float | None, date | None]:
+    """
+    Extract the most recent full-year (10-K, fp=FY) value.
+
+    Returns (value, period_end_date) or (None, None) if no annual entry found.
+    """
+    annual = [e for e in entries if e.get("form") == "10-K" and e.get("fp") == "FY" and e.get("end")]
+    if not annual:
+        return None, None
+
+    # Sort by end date descending to get most recent
+    annual.sort(key=lambda e: e["end"], reverse=True)
+    best = annual[0]
+    try:
+        end_date = date.fromisoformat(best["end"])
+    except (ValueError, TypeError):
+        return None, None
+    return best.get("val"), end_date
+
+
+def _latest_point_in_time(entries: list[dict[str, Any]]) -> tuple[float | None, date | None]:
+    """
+    Extract the most recent value from any filing form.
+
+    For balance-sheet items that are point-in-time snapshots.
+    Returns (value, as_of_date) or (None, None).
+    """
+    valid = [e for e in entries if e.get("end") and e.get("val") is not None]
+    if not valid:
+        return None, None
+
+    valid.sort(key=lambda e: e["end"], reverse=True)
+    best = valid[0]
+    try:
+        end_date = date.fromisoformat(best["end"])
+    except (ValueError, TypeError):
+        return None, None
+    return best["val"], end_date
+
+
+def _ttm_from_quarters(entries: list[dict[str, Any]]) -> float | None:
+    """
+    Compute TTM by summing the 4 most recent single-quarter values.
+
+    Single-quarter entries have both ``start`` and ``end``, with a span of
+    roughly 90 days (one quarter).  We filter to entries with a duration
+    between 60 and 120 days to avoid picking up YTD or annual values.
+    """
+    quarterly = []
+    for e in entries:
+        start_str = e.get("start")
+        end_str = e.get("end")
+        val = e.get("val")
+        if not start_str or not end_str or val is None:
+            continue
+        try:
+            start = date.fromisoformat(start_str)
+            end = date.fromisoformat(end_str)
+        except (ValueError, TypeError):
+            continue
+        days = (end - start).days
+        if 60 <= days <= 120:
+            quarterly.append((end, val))
+
+    if len(quarterly) < 4:
+        return None
+
+    # Sort by end date descending, take 4 most recent
+    quarterly.sort(key=lambda x: x[0], reverse=True)
+    return sum(v for _, v in quarterly[:4])
+
+
+def _get_ttm_value(gaap: dict[str, Any], tags: tuple[str, ...]) -> float | None:
+    """Get TTM value: prefer annual 10-K, fall back to sum of 4 quarters."""
+    entries = _get_entries(gaap, tags)
+    if not entries:
+        return None
+
+    val, _ = _latest_annual_value(entries)
+    if val is not None:
+        return val
+
+    return _ttm_from_quarters(entries)
+
+
+def _get_balance_sheet_value(gaap: dict[str, Any], tags: tuple[str, ...]) -> float | None:
+    """Get the most recent point-in-time balance sheet value."""
+    entries = _get_entries(gaap, tags)
+    if not entries:
+        return None
+    val, _ = _latest_point_in_time(entries)
+    return val
+
+
+def _safe_decimal(val: float | None) -> Decimal | None:
+    if val is None:
+        return None
+    return Decimal(str(val))
+
+
+def _safe_int(val: float | None) -> int | None:
+    if val is None:
+        return None
+    result = int(val)
+    return result if result != 0 else None
+
+
+def _build_latest_snapshot(
+    symbol: str,
+    gaap: dict[str, Any],
+) -> FundamentalsSnapshot | None:
+    """Build a FundamentalsSnapshot from the most recent XBRL data."""
+
+    # Income / cash flow — TTM values
+    revenue = _get_ttm_value(gaap, _REVENUE_TAGS)
+    gross_profit = _get_ttm_value(gaap, _GROSS_PROFIT_TAGS)
+    operating_income = _get_ttm_value(gaap, _OPERATING_INCOME_TAGS)
+    operating_cf = _get_ttm_value(gaap, _OPERATING_CF_TAGS)
+    capex = _get_ttm_value(gaap, _CAPEX_TAGS)
+
+    # Balance sheet — point in time
+    cash = _get_balance_sheet_value(gaap, _CASH_TAGS)
+    debt = _get_balance_sheet_value(gaap, _DEBT_TAGS)
+    equity = _get_balance_sheet_value(gaap, _EQUITY_TAGS)
+    shares = _get_balance_sheet_value(gaap, _SHARES_TAGS)
+
+    # EPS — prefer TTM
+    eps_entries = _get_entries(gaap, _EPS_TAGS)
+    eps_val, _ = _latest_annual_value(eps_entries) if eps_entries else (None, None)
+    if eps_val is None and eps_entries:
+        # Fall back to most recent quarterly EPS (not summed — EPS is already per-share)
+        eps_val, _ = _latest_point_in_time(eps_entries)
+
+    # Determine as_of_date from the most recent balance sheet entry
+    # (canonical anchor per settled decisions)
+    as_of = _determine_as_of_date(gaap)
+    if as_of is None:
+        logger.info("SEC fundamentals: cannot determine as_of_date for %s", symbol)
+        return None
+
+    # Derived fields
+    gross_margin: float | None = None
+    if gross_profit is not None and revenue is not None and revenue != 0:
+        gross_margin = gross_profit / revenue
+
+    operating_margin: float | None = None
+    if operating_income is not None and revenue is not None and revenue != 0:
+        operating_margin = operating_income / revenue
+
+    fcf: float | None = None
+    if operating_cf is not None:
+        # CapEx is reported as a positive outflow in XBRL; FCF = OCF - CapEx
+        fcf = operating_cf - (capex or 0)
+
+    net_debt: float | None = None
+    if debt is not None and cash is not None:
+        net_debt = debt - cash
+    elif debt is not None:
+        net_debt = debt  # assume zero cash if missing
+
+    book_value: float | None = None
+    if equity is not None and shares is not None and shares != 0:
+        book_value = equity / shares
+
+    return FundamentalsSnapshot(
+        symbol=symbol,
+        as_of_date=as_of,
+        revenue_ttm=_safe_decimal(revenue),
+        gross_margin=_safe_decimal(gross_margin),
+        operating_margin=_safe_decimal(operating_margin),
+        fcf=_safe_decimal(fcf),
+        cash=_safe_decimal(cash),
+        debt=_safe_decimal(debt),
+        net_debt=_safe_decimal(net_debt),
+        shares_outstanding=_safe_int(shares),
+        book_value=_safe_decimal(book_value),
+        eps=_safe_decimal(eps_val),
+    )
+
+
+def _determine_as_of_date(gaap: dict[str, Any]) -> date | None:
+    """
+    Determine the canonical as_of_date from the most recent balance-sheet entry.
+
+    Tries cash first (most universal), then equity, then debt.
+    """
+    for tags in (_CASH_TAGS, _EQUITY_TAGS, _DEBT_TAGS):
+        entries = _get_entries(gaap, tags)
+        if entries:
+            _, d = _latest_point_in_time(entries)
+            if d is not None:
+                return d
+    return None
+
+
+def _build_history_snapshots(
+    symbol: str,
+    gaap: dict[str, Any],
+    from_date: date,
+    to_date: date,
+    limit: int,
+) -> list[FundamentalsSnapshot]:
+    """
+    Build historical snapshots from 10-K filings within a date range.
+
+    Each 10-K filing represents one snapshot.  Balance-sheet items are taken
+    from the 10-K's period end date; income/CF items are the FY values.
+    """
+    # Find all 10-K period end dates from revenue entries
+    rev_entries = _get_entries(gaap, _REVENUE_TAGS)
+    annual_entries = [e for e in rev_entries if e.get("form") == "10-K" and e.get("fp") == "FY" and e.get("end")]
+
+    if not annual_entries:
+        return []
+
+    # Get unique end dates within range
+    end_dates: list[date] = []
+    seen: set[str] = set()
+    for e in annual_entries:
+        end_str = e["end"]
+        if end_str in seen:
+            continue
+        seen.add(end_str)
+        try:
+            d = date.fromisoformat(end_str)
+        except (ValueError, TypeError):
+            continue
+        if from_date <= d <= to_date:
+            end_dates.append(d)
+
+    end_dates.sort()
+    if limit:
+        end_dates = end_dates[-limit:]
+
+    snapshots: list[FundamentalsSnapshot] = []
+    for end_d in end_dates:
+        snap = _build_snapshot_for_date(symbol, gaap, end_d)
+        if snap is not None:
+            snapshots.append(snap)
+
+    return snapshots
+
+
+def _get_value_at_date(
+    entries: list[dict[str, Any]],
+    target_date: date,
+    *,
+    annual_only: bool = False,
+) -> float | None:
+    """Get the value closest to target_date from entries."""
+    candidates = []
+    for e in entries:
+        end_str = e.get("end")
+        val = e.get("val")
+        if not end_str or val is None:
+            continue
+        if annual_only and (e.get("form") != "10-K" or e.get("fp") != "FY"):
+            continue
+        try:
+            end = date.fromisoformat(end_str)
+        except (ValueError, TypeError):
+            continue
+        if end == target_date:
+            return val  # type: ignore[no-any-return]
+        candidates.append((abs((end - target_date).days), val))
+
+    if not candidates:
+        return None
+    # Return the value from the entry closest to target date
+    candidates.sort(key=lambda x: x[0])
+    # Only accept entries within 45 days of target (same quarter)
+    if candidates[0][0] <= 45:
+        return candidates[0][1]
+    return None
+
+
+def _build_snapshot_for_date(
+    symbol: str,
+    gaap: dict[str, Any],
+    target_date: date,
+) -> FundamentalsSnapshot | None:
+    """Build a snapshot using values at or near a specific date."""
+    revenue = _get_value_at_date(_get_entries(gaap, _REVENUE_TAGS), target_date, annual_only=True)
+    gross_profit = _get_value_at_date(_get_entries(gaap, _GROSS_PROFIT_TAGS), target_date, annual_only=True)
+    operating_income = _get_value_at_date(_get_entries(gaap, _OPERATING_INCOME_TAGS), target_date, annual_only=True)
+    operating_cf = _get_value_at_date(_get_entries(gaap, _OPERATING_CF_TAGS), target_date, annual_only=True)
+    capex = _get_value_at_date(_get_entries(gaap, _CAPEX_TAGS), target_date, annual_only=True)
+
+    cash = _get_value_at_date(_get_entries(gaap, _CASH_TAGS), target_date)
+    debt = _get_value_at_date(_get_entries(gaap, _DEBT_TAGS), target_date)
+    equity = _get_value_at_date(_get_entries(gaap, _EQUITY_TAGS), target_date)
+    shares = _get_value_at_date(_get_entries(gaap, _SHARES_TAGS), target_date)
+    eps_val = _get_value_at_date(_get_entries(gaap, _EPS_TAGS), target_date, annual_only=True)
+
+    gross_margin: float | None = None
+    if gross_profit is not None and revenue is not None and revenue != 0:
+        gross_margin = gross_profit / revenue
+
+    operating_margin: float | None = None
+    if operating_income is not None and revenue is not None and revenue != 0:
+        operating_margin = operating_income / revenue
+
+    fcf: float | None = None
+    if operating_cf is not None:
+        fcf = operating_cf - (capex or 0)
+
+    net_debt: float | None = None
+    if debt is not None and cash is not None:
+        net_debt = debt - cash
+    elif debt is not None:
+        net_debt = debt
+
+    book_value: float | None = None
+    if equity is not None and shares is not None and shares != 0:
+        book_value = equity / shares
+
+    return FundamentalsSnapshot(
+        symbol=symbol,
+        as_of_date=target_date,
+        revenue_ttm=_safe_decimal(revenue),
+        gross_margin=_safe_decimal(gross_margin),
+        operating_margin=_safe_decimal(operating_margin),
+        fcf=_safe_decimal(fcf),
+        cash=_safe_decimal(cash),
+        debt=_safe_decimal(debt),
+        net_debt=_safe_decimal(net_debt),
+        shares_outstanding=_safe_int(shares),
+        book_value=_safe_decimal(book_value),
+        eps=_safe_decimal(eps_val),
+    )

--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -211,9 +211,10 @@ class SecFundamentalsProvider(FundamentalsProvider):
         if resp.status_code == 404:
             logger.info("SEC fundamentals: no company facts for CIK %s", cik)
             return None
-        resp.raise_for_status()
+        # Persist raw response before raise — non-negotiable for auditability.
         raw = resp.json()
         _persist_raw(f"sec_facts_{cik_padded}", raw)
+        resp.raise_for_status()
         return raw  # type: ignore[no-any-return]
 
 
@@ -390,14 +391,15 @@ def _build_latest_snapshot(
 
     fcf: float | None = None
     if operating_cf is not None:
-        # CapEx is reported as a positive outflow in XBRL; FCF = OCF - CapEx
-        fcf = operating_cf - (capex or 0)
+        # CapEx is typically a positive outflow in XBRL.  Some filers
+        # report it as negative (cash outflow sign convention) — normalise
+        # to positive before subtracting.
+        fcf = operating_cf - abs(capex) if capex is not None else operating_cf
 
     net_debt: float | None = None
     if debt is not None and cash is not None:
         net_debt = debt - cash
-    elif debt is not None:
-        net_debt = debt  # assume zero cash if missing
+    # If cash is unknown, leave net_debt as None rather than assuming zero
 
     book_value: float | None = None
     if equity is not None and shares is not None and shares != 0:
@@ -543,13 +545,11 @@ def _build_snapshot_for_date(
 
     fcf: float | None = None
     if operating_cf is not None:
-        fcf = operating_cf - (capex or 0)
+        fcf = operating_cf - abs(capex) if capex is not None else operating_cf
 
     net_debt: float | None = None
     if debt is not None and cash is not None:
         net_debt = debt - cash
-    elif debt is not None:
-        net_debt = debt
 
     book_value: float | None = None
     if equity is not None and shares is not None and shares != 0:

--- a/app/services/portfolio.py
+++ b/app/services/portfolio.py
@@ -53,6 +53,11 @@ MAX_SECTOR_EXPOSURE_PCT: float = 0.25  # 25 %
 
 # Minimum total_score for a BUY recommendation
 MIN_BUY_SCORE: float = 0.35
+# Score threshold for buying without a thesis.  When score exceeds this,
+# the deterministic signals alone (fundamentals, momentum, filings) are
+# strong enough that a thesis is not required.  This allows the pipeline
+# to operate autonomously without AI spend for clear-cut opportunities.
+MIN_SCORE_ONLY_BUY: float = 0.55
 
 # Minimum improvement thresholds for ADD conviction check
 ADD_MIN_CONFIDENCE_DELTA: float = 0.05
@@ -528,7 +533,7 @@ def _evaluate_buy(
     BUY requires:
       - portfolio (held + already-approved BUYs this run) below max_active_positions
       - total_score >= MIN_BUY_SCORE
-      - thesis exists with stance == "buy"
+      - thesis with stance == "buy", OR total_score >= MIN_SCORE_ONLY_BUY
       - no severe red flags
       - sector concentration passes, accounting for BUYs already approved this run
       - cash sufficient if known; if unknown, note cash_check_deferred
@@ -549,8 +554,11 @@ def _evaluate_buy(
 
     thesis = details.get("thesis")
     if thesis is None:
-        return False, "No thesis available"
-    if thesis.get("stance") != "buy":
+        # Allow BUY on strong deterministic score alone (no AI spend needed).
+        # Below this threshold, thesis validation is required.
+        if total_score < MIN_SCORE_ONLY_BUY:
+            return False, f"No thesis and score {total_score:.3f} below score-only threshold={MIN_SCORE_ONLY_BUY}"
+    elif thesis.get("stance") != "buy":
         return False, f"Thesis stance {thesis.get('stance')!r} is not 'buy'"
 
     max_red_flag: float | None = details.get("max_red_flag")
@@ -578,10 +586,11 @@ def _evaluate_buy(
 
     rank = latest_score.get("rank")
     cash_note = "" if cash is not None else "; cash_check_deferred (ledger empty)"
+    thesis_note = "" if thesis is not None else "; score-only entry (no thesis)"
     return (
         True,
         f"Entry candidate: score={total_score:.3f} rank={rank}; "
-        f"initial allocation {MAX_INITIAL_POSITION_PCT:.0%} of AUM{cash_note}",
+        f"initial allocation {MAX_INITIAL_POSITION_PCT:.0%} of AUM{cash_note}{thesis_note}",
     )
 
 

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -398,16 +398,13 @@ def _compute_penalties(
 ) -> list[PenaltyRecord]:
     penalties: list[PenaltyRecord] = []
 
-    # Stale thesis
-    if thesis_created_at is None:
-        penalties.append(
-            PenaltyRecord(
-                name="stale_thesis",
-                deduction=_PENALTY_STALE_THESIS,
-                reason="no thesis exists",
-            )
-        )
-    elif (now - thesis_created_at).days > _THESIS_STALE_DAYS:
+    # Stale thesis — only penalise when a thesis exists but is outdated.
+    # Missing thesis is NOT penalised: T3→T2 promotion is based on
+    # deterministic signals alone (per #169), and T2→T1 promotion
+    # enforces thesis existence in coverage.py.  Penalising missing
+    # thesis here would prevent instruments from ever reaching the score
+    # threshold needed for promotion.
+    if thesis_created_at is not None and (now - thesis_created_at).days > _THESIS_STALE_DAYS:
         age_days = (now - thesis_created_at).days
         penalties.append(
             PenaltyRecord(

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -37,6 +37,7 @@ from app.providers.implementations.companies_house import CompaniesHouseFilingsP
 from app.providers.implementations.etoro import EtoroMarketDataProvider
 from app.providers.implementations.fmp import FmpFundamentalsProvider
 from app.providers.implementations.sec_edgar import SecFilingsProvider
+from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
 from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
 from app.services.coverage import review_coverage, seed_coverage
 from app.services.filings import FilingsRefreshSummary, refresh_filings, upsert_cik_mapping
@@ -250,9 +251,9 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_DAILY_THESIS_REFRESH,
-        description="Regenerate theses for stale Tier 1 instruments.",
+        description="Regenerate theses for stale Tier 1/2 instruments.",
         cadence=Cadence.daily(hour=4, minute=30),
-        prerequisite=_has_tier1_stale_theses,
+        prerequisite=_has_coverage_tier12,
     ),
     ScheduledJob(
         name=JOB_MORNING_CANDIDATE_REVIEW,
@@ -551,7 +552,8 @@ def daily_research_refresh() -> None:
     Refresh fundamentals and filings for all tradable instruments.
 
     Runs daily. Fetches:
-      - FMP fundamentals snapshot (latest) for each tradable symbol
+      - SEC XBRL fundamentals (primary, free) for US instruments with a CIK
+      - FMP fundamentals (fallback) for remaining instruments if API key is set
       - SEC EDGAR filing metadata for US instruments with a known CIK
       - Companies House filing metadata for UK instruments with a company_number
 
@@ -560,8 +562,6 @@ def daily_research_refresh() -> None:
     T3 instruments, enabling the weekly coverage review to promote them
     to T2 on deterministic signals alone.
     """
-    if not settings.fmp_api_key:
-        logger.error("daily_research_refresh: FMP_API_KEY not set, skipping fundamentals")
     if not settings.companies_house_api_key:
         logger.warning("daily_research_refresh: COMPANIES_HOUSE_API_KEY not set, skipping CH filings")
 
@@ -576,6 +576,18 @@ def daily_research_refresh() -> None:
                 """
             ).fetchall()
 
+            # Build symbol→CIK mapping for SEC fundamentals
+            cik_rows = conn.execute(
+                """
+                SELECT i.symbol, ei.identifier_value
+                FROM external_identifiers ei
+                JOIN instruments i ON i.instrument_id = ei.instrument_id
+                WHERE ei.provider = 'sec'
+                  AND ei.identifier_type = 'cik'
+                  AND i.is_tradable = TRUE
+                """
+            ).fetchall()
+
         if not rows:
             logger.info("daily_research_refresh: no tradable instruments found, skipping")
             tracker.row_count = 0
@@ -583,25 +595,47 @@ def daily_research_refresh() -> None:
 
         symbols = [(row[0], row[1]) for row in rows]
         instrument_ids = [row[1] for row in rows]
+        cik_map = {row[0].upper(): row[1] for row in cik_rows}
         from_date = date.today() - timedelta(days=30)
         to_date = date.today()
 
         total_rows = 0
 
-        # Fundamentals (FMP)
-        if settings.fmp_api_key:
+        # Fundamentals — SEC XBRL (primary, free, US equities)
+        sec_symbols = [(sym, iid) for sym, iid in symbols if sym.upper() in cik_map]
+        if sec_symbols:
             with (
-                FmpFundamentalsProvider(api_key=settings.fmp_api_key) as fmp,
+                SecFundamentalsProvider(user_agent=settings.sec_user_agent) as sec_fund,
                 psycopg.connect(settings.database_url) as conn,
             ):
-                summary = refresh_fundamentals(fmp, conn, symbols)
+                sec_fund.set_cik_cache(cik_map)
+                summary = refresh_fundamentals(sec_fund, conn, sec_symbols)
             total_rows += summary.snapshots_upserted
             logger.info(
-                "Fundamentals refresh: attempted=%d upserted=%d skipped=%d",
+                "SEC fundamentals refresh: attempted=%d upserted=%d skipped=%d",
                 summary.symbols_attempted,
                 summary.snapshots_upserted,
                 summary.symbols_skipped,
             )
+        else:
+            logger.info("daily_research_refresh: no CIK mappings, skipping SEC fundamentals")
+
+        # Fundamentals — FMP (fallback for non-US instruments)
+        if settings.fmp_api_key:
+            fmp_symbols = [(sym, iid) for sym, iid in symbols if sym.upper() not in cik_map]
+            if fmp_symbols:
+                with (
+                    FmpFundamentalsProvider(api_key=settings.fmp_api_key) as fmp,
+                    psycopg.connect(settings.database_url) as conn,
+                ):
+                    fmp_summary = refresh_fundamentals(fmp, conn, fmp_symbols)
+                total_rows += fmp_summary.snapshots_upserted
+                logger.info(
+                    "FMP fundamentals refresh (non-US fallback): attempted=%d upserted=%d skipped=%d",
+                    fmp_summary.symbols_attempted,
+                    fmp_summary.snapshots_upserted,
+                    fmp_summary.symbols_skipped,
+                )
 
         # Filings — SEC EDGAR
         with (
@@ -719,20 +753,31 @@ def daily_thesis_refresh() -> None:
         return
 
     with _tracked_job(JOB_DAILY_THESIS_REFRESH) as tracker:
-        logger.info("daily_thesis_refresh: checking for stale Tier 1 instruments")
+        logger.info("daily_thesis_refresh: checking for stale Tier 1/2 instruments")
         try:
             with psycopg.connect(settings.database_url) as conn:
-                stale = find_stale_instruments(conn, tier=1)
+                # Generate theses for T1 and T2 instruments.  T2 instruments
+                # need theses to be promoted to T1 (coverage.py requires
+                # thesis for T2→T1).  The portfolio manager also requires a
+                # thesis with stance="buy" before recommending a BUY.
+                stale_t1 = find_stale_instruments(conn, tier=1)
+                stale_t2 = find_stale_instruments(conn, tier=2)
+                stale = stale_t1 + stale_t2
         except Exception:
             logger.error("daily_thesis_refresh: failed to query stale instruments", exc_info=True)
             return
 
         if not stale:
-            logger.info("daily_thesis_refresh: no stale Tier 1 instruments found")
+            logger.info("daily_thesis_refresh: no stale Tier 1/2 instruments found")
             tracker.row_count = 0
             return
 
-        logger.info("daily_thesis_refresh: %d stale instrument(s) to refresh", len(stale))
+        logger.info(
+            "daily_thesis_refresh: %d stale instrument(s) to refresh (T1=%d T2=%d)",
+            len(stale),
+            len(stale_t1),
+            len(stale_t2),
+        )
 
         claude_client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -621,8 +621,8 @@ def daily_research_refresh() -> None:
             logger.info("daily_research_refresh: no CIK mappings, skipping SEC fundamentals")
 
         # Fundamentals — FMP (fallback for non-US instruments)
+        fmp_symbols = [(sym, iid) for sym, iid in symbols if sym.upper() not in cik_map]
         if settings.fmp_api_key:
-            fmp_symbols = [(sym, iid) for sym, iid in symbols if sym.upper() not in cik_map]
             if fmp_symbols:
                 with (
                     FmpFundamentalsProvider(api_key=settings.fmp_api_key) as fmp,
@@ -636,6 +636,11 @@ def daily_research_refresh() -> None:
                     fmp_summary.snapshots_upserted,
                     fmp_summary.symbols_skipped,
                 )
+        elif fmp_symbols:
+            logger.warning(
+                "FMP_API_KEY not set; %d non-US instruments will have no fundamentals",
+                len(fmp_symbols),
+            )
 
         # Filings — SEC EDGAR
         with (

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -528,3 +528,19 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `get_quotes()` caught `httpx.HTTPStatusError` on a 500 response but skipped the chunk without persisting the error response body. The 500 body (which may contain diagnostic info from the upstream API) was silently discarded, violating the raw-payload persistence rule.
 - Prevention: When catching `httpx.HTTPStatusError` in provider code to skip/continue, call `_persist_raw(tag + "_error", exc.response.text)` before logging or continuing. Network errors (`httpx.RequestError`) have no response body — log with `exc_info` only.
 - Enforced in: this prevention log
+
+---
+
+### Raw payload persistence must precede raise_for_status()
+- First seen in: #177
+- Symptom: `_fetch_company_facts` called `resp.raise_for_status()` before `_persist_raw()`, so non-404 HTTP errors (429, 503) raised before the raw payload was written to disk, losing diagnostic data.
+- Prevention: In provider HTTP methods, always call `_persist_raw()` before `resp.raise_for_status()`. The persist call captures the response body for auditability regardless of status code.
+- Enforced in: this prevention log
+
+---
+
+### XBRL CapEx sign convention varies between filers
+- First seen in: #177
+- Symptom: FCF calculation `operating_cf - capex` was incorrect for filers reporting CapEx as a negative number (cash outflow sign convention), inflating FCF.
+- Prevention: When subtracting CapEx from operating CF, use `abs(capex)` to normalise for sign convention differences. Apply to both latest-snapshot and historical-snapshot builders.
+- Enforced in: this prevention log

--- a/tests/test_filings_fundamentals.py
+++ b/tests/test_filings_fundamentals.py
@@ -31,6 +31,13 @@ from app.providers.implementations.sec_edgar import (
     _parse_cik_mapping,
     _zero_pad_cik,
 )
+from app.providers.implementations.sec_fundamentals import (
+    _build_latest_snapshot,
+    _get_entries,
+    _latest_annual_value,
+    _latest_point_in_time,
+    _ttm_from_quarters,
+)
 from app.services.fundamentals import _current_quarter_start, _fundamentals_are_fresh
 
 # ---------------------------------------------------------------------------
@@ -415,3 +422,161 @@ class TestFundamentalsAreFresh:
         params = call_args[0][1]
         assert params["quarter_start"] == date(2026, 4, 1)
         assert params["instrument_id"] == "42"
+
+
+# ---------------------------------------------------------------------------
+# SEC XBRL fundamentals normaliser tests
+# ---------------------------------------------------------------------------
+
+
+def _xbrl_entry(
+    val: float,
+    end: str,
+    form: str = "10-K",
+    fp: str = "FY",
+    start: str | None = None,
+) -> dict:
+    """Build a minimal XBRL fact entry."""
+    entry: dict = {"val": val, "end": end, "form": form, "fp": fp, "filed": end}
+    if start is not None:
+        entry["start"] = start
+    return entry
+
+
+def _make_gaap(facts: dict[str, list[dict]]) -> dict:
+    """Wrap fact lists into {tag: {units: {USD: entries}}} structure."""
+    return {tag: {"units": {"USD": entries}} for tag, entries in facts.items()}
+
+
+class TestSecXbrlGetEntries:
+    def test_returns_first_matching_tag(self) -> None:
+        gaap = _make_gaap(
+            {
+                "Revenues": [_xbrl_entry(1000, "2025-12-31")],
+                "SalesRevenueNet": [_xbrl_entry(2000, "2025-12-31")],
+            }
+        )
+        entries = _get_entries(gaap, ("Revenues", "SalesRevenueNet"))
+        assert len(entries) == 1
+        assert entries[0]["val"] == 1000
+
+    def test_falls_through_missing_tags(self) -> None:
+        gaap = _make_gaap({"SalesRevenueNet": [_xbrl_entry(2000, "2025-12-31")]})
+        entries = _get_entries(gaap, ("Revenues", "SalesRevenueNet"))
+        assert entries[0]["val"] == 2000
+
+    def test_empty_when_no_tags_match(self) -> None:
+        gaap = _make_gaap({})
+        assert _get_entries(gaap, ("Revenues",)) == []
+
+    def test_shares_unit_type(self) -> None:
+        gaap = {"CommonStockSharesOutstanding": {"units": {"shares": [_xbrl_entry(1_000_000, "2025-12-31")]}}}
+        entries = _get_entries(gaap, ("CommonStockSharesOutstanding",))
+        assert len(entries) == 1
+        assert entries[0]["val"] == 1_000_000
+
+
+class TestSecXbrlLatestAnnualValue:
+    def test_picks_most_recent_10k(self) -> None:
+        entries = [
+            _xbrl_entry(100, "2023-12-31"),
+            _xbrl_entry(200, "2024-12-31"),
+            _xbrl_entry(50, "2025-03-31", form="10-Q", fp="Q1"),
+        ]
+        val, d = _latest_annual_value(entries)
+        assert val == 200
+        assert d == date(2024, 12, 31)
+
+    def test_returns_none_when_no_annual(self) -> None:
+        entries = [_xbrl_entry(50, "2025-03-31", form="10-Q", fp="Q1")]
+        val, d = _latest_annual_value(entries)
+        assert val is None
+        assert d is None
+
+
+class TestSecXbrlLatestPointInTime:
+    def test_picks_most_recent(self) -> None:
+        entries = [
+            _xbrl_entry(100, "2024-12-31"),
+            _xbrl_entry(200, "2025-03-31", form="10-Q", fp="Q1"),
+        ]
+        val, d = _latest_point_in_time(entries)
+        assert val == 200
+        assert d == date(2025, 3, 31)
+
+
+class TestSecXbrlTtmFromQuarters:
+    def test_sums_four_quarters(self) -> None:
+        entries = [
+            _xbrl_entry(100, "2025-03-31", form="10-Q", fp="Q1", start="2025-01-01"),
+            _xbrl_entry(200, "2025-06-30", form="10-Q", fp="Q2", start="2025-04-01"),
+            _xbrl_entry(300, "2025-09-30", form="10-Q", fp="Q3", start="2025-07-01"),
+            _xbrl_entry(400, "2025-12-31", form="10-Q", fp="Q4", start="2025-10-01"),
+        ]
+        assert _ttm_from_quarters(entries) == 1000
+
+    def test_returns_none_with_fewer_than_four(self) -> None:
+        entries = [
+            _xbrl_entry(100, "2025-03-31", form="10-Q", fp="Q1", start="2025-01-01"),
+            _xbrl_entry(200, "2025-06-30", form="10-Q", fp="Q2", start="2025-04-01"),
+        ]
+        assert _ttm_from_quarters(entries) is None
+
+    def test_ignores_annual_entries(self) -> None:
+        """Annual entries (365-day span) should be filtered out by the
+        60-120 day duration check."""
+        entries = [
+            _xbrl_entry(1000, "2025-12-31", form="10-K", fp="FY", start="2025-01-01"),
+            _xbrl_entry(100, "2025-03-31", form="10-Q", fp="Q1", start="2025-01-01"),
+            _xbrl_entry(200, "2025-06-30", form="10-Q", fp="Q2", start="2025-04-01"),
+        ]
+        assert _ttm_from_quarters(entries) is None
+
+
+class TestSecXbrlBuildLatestSnapshot:
+    def test_builds_complete_snapshot(self) -> None:
+        gaap = _make_gaap(
+            {
+                "Revenues": [_xbrl_entry(1_000_000, "2025-09-30")],
+                "GrossProfit": [_xbrl_entry(400_000, "2025-09-30")],
+                "OperatingIncomeLoss": [_xbrl_entry(200_000, "2025-09-30")],
+                "NetCashProvidedByUsedInOperatingActivities": [_xbrl_entry(300_000, "2025-09-30")],
+                "PaymentsToAcquirePropertyPlantAndEquipment": [_xbrl_entry(50_000, "2025-09-30")],
+                "CashAndCashEquivalentsAtCarryingValue": [
+                    _xbrl_entry(500_000, "2025-09-30", form="10-Q", fp="Q3"),
+                ],
+                "LongTermDebt": [
+                    _xbrl_entry(200_000, "2025-09-30", form="10-Q", fp="Q3"),
+                ],
+            }
+        )
+        snap = _build_latest_snapshot("TEST", gaap)
+        assert snap is not None
+        assert snap.symbol == "TEST"
+        assert snap.revenue_ttm == Decimal("1000000")
+        assert snap.gross_margin == Decimal("0.4")
+        assert snap.operating_margin == Decimal("0.2")
+        assert snap.fcf == Decimal("250000")  # 300k - 50k
+        assert snap.cash == Decimal("500000")
+        assert snap.debt == Decimal("200000")
+        assert snap.net_debt == Decimal("-300000")  # 200k - 500k
+
+    def test_returns_none_when_no_balance_sheet_data(self) -> None:
+        gaap = _make_gaap({"Revenues": [_xbrl_entry(1_000_000, "2025-09-30")]})
+        snap = _build_latest_snapshot("TEST", gaap)
+        # No balance sheet data means no as_of_date can be determined
+        assert snap is None
+
+    def test_handles_missing_revenue_gracefully(self) -> None:
+        gaap = _make_gaap(
+            {
+                "CashAndCashEquivalentsAtCarryingValue": [
+                    _xbrl_entry(500_000, "2025-09-30", form="10-Q", fp="Q3"),
+                ],
+            }
+        )
+        snap = _build_latest_snapshot("TEST", gaap)
+        assert snap is not None
+        assert snap.revenue_ttm is None
+        assert snap.gross_margin is None
+        assert snap.operating_margin is None

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -497,7 +497,8 @@ class TestEvaluateBuy:
         assert should_buy is False
         assert "red flag" in reason.lower()
 
-    def test_no_thesis_blocks_buy(self) -> None:
+    def test_no_thesis_high_score_allows_buy(self) -> None:
+        """Score above MIN_SCORE_ONLY_BUY allows BUY without thesis."""
         details: dict[str, Any] = {}
         latest_score = _score(total_score=0.80)
         should_buy, reason = _evaluate_buy(
@@ -512,8 +513,27 @@ class TestEvaluateBuy:
             pending_buy_count=0,
             pending_sector_pct={},
         )
+        assert should_buy is True
+        assert "score-only" in reason.lower()
+
+    def test_no_thesis_low_score_blocks_buy(self) -> None:
+        """Score below MIN_SCORE_ONLY_BUY blocks BUY without thesis."""
+        details: dict[str, Any] = {}
+        latest_score = _score(total_score=0.40)
+        should_buy, reason = _evaluate_buy(
+            1,
+            "AAPL",
+            "Technology",
+            details,
+            latest_score,
+            self._no_positions(),
+            total_aum=100_000.0,
+            cash=10_000.0,
+            pending_buy_count=0,
+            pending_sector_pct={},
+        )
         assert should_buy is False
-        assert "thesis" in reason.lower()
+        assert "score-only threshold" in reason.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -318,10 +318,13 @@ class TestComputePenalties:
         names = [p.name for p in penalties]
         assert "stale_thesis" in names
 
-    def test_no_thesis_triggers_stale(self) -> None:
+    def test_no_thesis_does_not_trigger_penalty(self) -> None:
+        """Missing thesis is not penalised — T3→T2 promotion relies on
+        deterministic signals alone (per #169).  Only stale (existing but
+        outdated) theses incur a penalty."""
         penalties = self._base_call(thesis_created_at=None)
         names = [p.name for p in penalties]
-        assert "stale_thesis" in names
+        assert "stale_thesis" not in names
 
     def test_missing_critical_data_triggers(self) -> None:
         penalties = self._base_call(has_missing_critical_data=True)
@@ -659,7 +662,9 @@ class TestComputeScore:
         )
         result = compute_score(1, conn, "v1-balanced")
         penalty_names = [p.name for p in result.penalties]
-        assert "stale_thesis" in penalty_names
+        # Missing thesis is no longer penalised (per #169 — T3→T2
+        # promotion relies on deterministic signals, not thesis).
+        assert "stale_thesis" not in penalty_names
 
     def test_unknown_model_version_raises(self) -> None:
         conn = MagicMock()


### PR DESCRIPTION
## Summary

The pipeline was completely stuck — no fundamentals data, identical scores for all instruments, no promotions, no recommendations. This PR unblocks the entire investment pipeline:

- **SEC XBRL fundamentals provider** — fetches financial data (revenue, margins, FCF, debt, cash, EPS, shares) from SEC's free Company Facts API. 10 req/s rate limit, no API key needed. Covers ~5000 US instruments.
- **SEC fundamentals as primary source** — replaces FMP as the default for US equities. FMP remains as fallback for non-US instruments.
- **Removed missing-thesis scoring penalty** — only stale theses are penalised. Missing thesis no longer drags scores below promotion threshold.
- **Score-only BUY** — portfolio manager allows BUY without thesis when score >= 0.55 (strong deterministic signals).
- **Thesis refresh widened to T1/T2** — T2 instruments need theses for T1 promotion and BUY validation.
- **data/ added to .gitignore** — raw API response dumps.

## Verified end-to-end

```
universe sync (12K instruments) ✓
CIK refresh (5164 mappings) ✓
SEC fundamentals (18 test batch, all correct) ✓
scoring (0.21–0.59 range, differentiated) ✓
coverage review (2 T3→T2 promotions) ✓
portfolio review (2 BUY recommendations: AAT, AAPL) ✓
```

## Security model

- SEC EDGAR API is public, no credentials stored
- No changes to auth, execution guard, or broker provider
- Score-only BUY still goes through execution guard (kill switch, concentration, cash, spread checks)

## Tradeoffs

- **SEC-only for US equities**: non-US instruments get no fundamentals unless FMP key is set. This is acceptable because eToro's US equity universe is the largest segment.
- **No thesis penalty for missing thesis**: this makes the scoring model more permissive. The execution guard still enforces all hard rules before any order is placed.
- **Score-only BUY threshold at 0.55**: same as T3→T2 promotion threshold. Instruments that score well enough to promote are also candidates for purchase.

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 1058 passed, 0 failed
- [x] SEC fundamentals tested against Apple, Tesla, Microsoft, JPMorgan
- [x] Full pipeline run: instruments → scoring → promotions → recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)