### PR TITLE
feat(#173): live APScheduler introspection for next_run_time

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -27,10 +27,9 @@ Fail-closed posture (prevention-log #70):
     ``status="error"`` rows so a single broken layer does not 503 the whole
     response.
 
-``next_run_time`` is derived from the *declared* cadence in the registry, not
-from a live scheduler — APScheduler is not yet wired (#13). When it lands,
-``compute_next_run`` should be replaced with the live scheduler's next-fire
-time so reality and intent reconcile at one source of truth.
+``next_run_time`` is sourced from the live APScheduler scheduler when the
+runtime is available, falling back to the declared cadence computation
+(``compute_next_run``) when the runtime is absent (e.g. in tests).
 """
 
 from __future__ import annotations
@@ -40,11 +39,12 @@ from datetime import UTC, datetime
 from typing import Literal
 
 import psycopg
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from app.api.auth import require_session_or_service_token
 from app.db import get_conn
+from app.jobs.runtime import JobRuntime
 from app.services.ops_monitor import (
     JobHealth,
     LayerHealth,
@@ -114,7 +114,7 @@ class JobOverviewResponse(BaseModel):
     cadence: str
     cadence_kind: Literal["hourly", "daily", "weekly"]
     next_run_time: datetime
-    next_run_time_source: Literal["declared"]  # see module docstring
+    next_run_time_source: Literal["live", "declared"]
     last_status: Literal["running", "success", "failure", "skipped"] | None
     last_started_at: datetime | None
     last_finished_at: datetime | None
@@ -195,18 +195,28 @@ def _build_jobs_overview(
     conn: psycopg.Connection[object],
     registry: list[ScheduledJob],
     now: datetime,
+    live_times: dict[str, datetime | None] | None = None,
 ) -> list[JobOverviewResponse]:
     overviews: list[JobOverviewResponse] = []
     for job in registry:
         health = check_job_health(conn, job.name)
+        # Prefer live next-fire time from APScheduler when available;
+        # fall back to declared cadence computation otherwise.
+        live_nrt = live_times.get(job.name) if live_times else None
+        if live_nrt is not None:
+            next_run = live_nrt
+            source: Literal["live", "declared"] = "live"
+        else:
+            next_run = compute_next_run(job.cadence, now)
+            source = "declared"
         overviews.append(
             JobOverviewResponse(
                 name=job.name,
                 description=job.description,
                 cadence=job.cadence.label,
                 cadence_kind=job.cadence.kind,
-                next_run_time=compute_next_run(job.cadence, now),
-                next_run_time_source="declared",
+                next_run_time=next_run,
+                next_run_time_source=source,
                 last_status=health.last_status,
                 last_started_at=health.last_started_at,
                 last_finished_at=health.last_finished_at,
@@ -261,20 +271,21 @@ def get_system_status(
 
 @router.get("/jobs", response_model=JobsListResponse)
 def get_jobs(
+    request: Request,
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> JobsListResponse:
-    """Declared scheduled jobs with computed next-run time and last result.
+    """Declared scheduled jobs with live next-run time and last result.
 
-    ``next_run_time`` is derived from the declared cadence (see module
-    docstring); ``next_run_time_source`` is always ``"declared"`` until
-    APScheduler is wired (#13).
+    ``next_run_time`` is sourced from the live APScheduler scheduler
+    when the runtime is available (``next_run_time_source="live"``),
+    falling back to the declared cadence computation otherwise.
     """
     now = _utcnow()
+    runtime: JobRuntime | None = getattr(request.app.state, "job_runtime", None)
+    live_times = runtime.get_next_run_times() if runtime is not None else None
     try:
-        overviews = _build_jobs_overview(conn, SCHEDULED_JOBS, now)
+        overviews = _build_jobs_overview(conn, SCHEDULED_JOBS, now, live_times=live_times)
     except Exception as exc:
-        # Log full detail server-side; HTTP detail is a fixed string to
-        # avoid leaking internals to bearer-token holders.
         logger.exception("get_jobs: failed to build overview")
         raise HTTPException(status_code=503, detail="job overview unavailable") from exc
 

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -282,8 +282,8 @@ def get_jobs(
     """
     now = _utcnow()
     runtime: JobRuntime | None = getattr(request.app.state, "job_runtime", None)
-    live_times = runtime.get_next_run_times() if runtime is not None else None
     try:
+        live_times = runtime.get_next_run_times() if runtime is not None else None
         overviews = _build_jobs_overview(conn, SCHEDULED_JOBS, now, live_times=live_times)
     except Exception as exc:
         logger.exception("get_jobs: failed to build overview")

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -5,21 +5,14 @@ The scheduler runs job functions on its own thread pool; the manual
 trigger endpoint also routes through the same wrapper so a manual run
 and a scheduled fire are indistinguishable from a tracking standpoint.
 
-PR A scope (locked):
+Features:
 
-* Wires exactly one job -- ``nightly_universe_sync`` -- so the runtime
-  can be exercised end-to-end without trying to bring up nine providers
-  in one go. PR B will populate the rest of ``_INVOKERS`` from the
-  declared registry.
-* No catch-up. ``coalesce=True`` + ``misfire_grace_time=0`` means a
-  freshly-restarted scheduler will *not* fire missed runs at boot.
-  Catch-up belongs in PR C and will be driven by reading ``job_runs``,
-  not by APScheduler's in-memory state.
-* No pipeline runner.
-* The manual trigger response carries no run_id -- the operator looks
-  status up via the existing ``/system/status``. Avoids a post-hoc
-  lookup race for run_id, and PR B's listing endpoint will provide a
-  richer response shape.
+* All ``SCHEDULED_JOBS`` are registered with APScheduler cron triggers.
+* Catch-up-on-boot fires overdue jobs (based on ``job_runs`` history).
+* Prerequisite checks gate scheduled fires and catch-up.
+* Manual triggers run on a dedicated ``ThreadPoolExecutor``.
+* ``get_next_run_times()`` exposes live APScheduler fire times for the
+  ``/system/jobs`` endpoint.
 
 Why ``BackgroundScheduler`` and not ``AsyncIOScheduler``:
 
@@ -92,9 +85,8 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 #
 # Maps job names from ``SCHEDULED_JOBS`` to the actual callable that
-# performs the work. PR B wires every job declared in
-# ``app/workers/scheduler.py``: a manual trigger or a scheduled fire is
-# now a single call into the registry.
+# performs the work. A manual trigger or a scheduled fire is a single
+# call into the registry.
 #
 # Keeping the registry as a single ``dict[str, Callable[[], None]]``
 # rather than a class hierarchy is deliberate: every job has the same
@@ -205,11 +197,9 @@ class JobRuntime:
                 # ``misfire_grace_time=1`` -- the smallest positive
                 # integer APScheduler accepts (0 raises TypeError).
                 # Combined with the absence of a persistent jobstore,
-                # this means PR A's runtime effectively does NOT
-                # catch up missed runs on startup: a fire that is
-                # more than 1 second late is dropped. Catch-up is
-                # PR C and will be driven by ``job_runs``, not by
-                # APScheduler grace windows.
+                # a fire that is more than 1 second late is dropped.
+                # Catch-up is driven by ``_catch_up()`` reading
+                # ``job_runs``, not by APScheduler grace windows.
                 "misfire_grace_time": 1,
                 # One concurrent instance per job. The per-job
                 # advisory lock is the source of truth for
@@ -270,6 +260,9 @@ class JobRuntime:
             registered,
             sorted(self._invokers.keys()),
         )
+        # Log next-fire times for operator visibility.
+        for name, nrt in self.get_next_run_times().items():
+            logger.info("  %s → next fire at %s", name, nrt)
         self._catch_up()
 
     def _catch_up(self) -> None:
@@ -416,6 +409,23 @@ class JobRuntime:
         self._started = False
         logger.info("JobRuntime stopped")
 
+    # -- introspection -----------------------------------------------------
+
+    def get_next_run_times(self) -> dict[str, datetime | None]:
+        """Return the live next-fire time for each registered job.
+
+        Queries APScheduler's in-memory job store. Returns ``None`` for
+        a job name if the scheduler has no record of it (e.g. it was
+        paused or removed). On-demand-only jobs are not included.
+        """
+        result: dict[str, datetime | None] = {}
+        for job in SCHEDULED_JOBS:
+            if job.name not in self._invokers:
+                continue
+            aps_job = self._scheduler.get_job(f"recurring:{job.name}")
+            result[job.name] = aps_job.next_run_time if aps_job is not None else None
+        return result
+
     # -- triggers ----------------------------------------------------------
 
     def trigger(self, job_name: str) -> None:
@@ -451,11 +461,10 @@ class JobRuntime:
         fires never touch ``_inflight``), so ``trigger()`` returns
         202 and the worker thread will then find the advisory lock
         held by the scheduler, log a warning, and no-op. The API
-        caller sees a 202 for a run that did nothing. PR B's
-        listing endpoint will surface this honestly. For PR A the
-        edge case is the cost of keeping the request thread off the
-        DB connection -- and is rare in practice (manual triggers
-        during 02:00 UTC scheduled fires are unusual).
+        caller sees a 202 for a run that did nothing. The
+        ``/system/jobs`` endpoint surfaces this honestly. This edge
+        case is rare in practice (manual triggers during scheduled
+        fires are unusual).
         """
         invoker = self._invokers.get(job_name)
         if invoker is None:
@@ -590,9 +599,7 @@ class JobRuntime:
                 # trigger landed during a scheduled fire or peer
                 # process run), not an operational fault. WARNING
                 # would alert-bait every manual trigger during the
-                # 02:00 UTC window with no actionable remediation
-                # until PR B's listing endpoint lands. Round 2
-                # review WARNING 2.
+                # 02:00 UTC window with no actionable remediation.
                 logger.info(
                     "manual trigger of %r no-opped: advisory lock held by "
                     "another runner (scheduled fire or peer process); the "

--- a/app/main.py
+++ b/app/main.py
@@ -84,9 +84,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         boot.recovery_required,
     )
 
-    # Start the in-process job runtime (#13 PR A). Single job wired in
-    # this PR (nightly_universe_sync); the rest of SCHEDULED_JOBS arrives
-    # in PR B. Catch-up-on-boot is PR C -- see app/jobs/runtime.py.
+    # Start the in-process job runtime (#13). All SCHEDULED_JOBS are
+    # registered with APScheduler; catch-up fires overdue jobs at boot.
     job_runtime: JobRuntime | None
     try:
         job_runtime = start_runtime()

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1,21 +1,20 @@
-"""
-Scheduled job stubs.
+"""Scheduled job functions and declared schedule registry.
 
-Each function represents one scheduled job. Wire these into APScheduler
-(or equivalent) in a later ticket when the scheduler infrastructure is set up.
+Each function represents one scheduled job. The ``JobRuntime`` in
+``app.jobs.runtime`` registers them with APScheduler and handles
+catch-up, prerequisite checks, and manual triggers.
 
-This module also owns the **declared schedule registry** (``SCHEDULED_JOBS``).
-Until APScheduler is wired (#13), the registry is the single source of truth
-for:
+This module owns the **declared schedule registry** (``SCHEDULED_JOBS``),
+which is the single source of truth for:
 
 * job names — referenced from each ``_tracked_job(...)`` call site so the
   ``job_runs.job_name`` value cannot drift from what the system reports.
-* declared cadences — informational only; ``compute_next_run`` derives the
-  next run time from these declarations rather than from a live scheduler.
+* declared cadences — APScheduler ``CronTrigger`` instances are derived
+  from these via ``_trigger_for()`` in ``runtime.py``.
 
-When APScheduler lands, ``compute_next_run`` should be replaced with live
-schedule introspection; the registry stays as the source of truth for which
-jobs exist.
+The ``/system/jobs`` endpoint uses live APScheduler introspection for
+``next_run_time``; ``compute_next_run`` remains as a pure utility for
+catch-up-on-boot and tests.
 """
 
 from __future__ import annotations
@@ -70,11 +69,10 @@ logger = logging.getLogger(__name__)
 #   weekly  — runs once per week on ``weekday`` (0=Monday … 6=Sunday) at
 #             ``hour:minute`` UTC.
 #
-# These cadences are *declared*, not introspected from a live scheduler. They
-# describe the intended schedule and feed the operator visibility endpoints
-# (#57). When APScheduler is wired (#13), ``compute_next_run`` should be
-# replaced with the live scheduler's next-fire-time so reality and intent are
-# reconciled at one source of truth.
+# These cadences feed the APScheduler ``CronTrigger`` registration in
+# ``app.jobs.runtime``. The ``/system/jobs`` endpoint reads the live
+# next-fire-time from APScheduler; ``compute_next_run`` is retained as
+# a pure utility for catch-up-on-boot and tests.
 
 CadenceKind = Literal["hourly", "daily", "weekly"]
 

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -453,17 +453,21 @@ class TestSystemJobs:
     def test_falls_back_to_declared_when_no_runtime(self) -> None:
         """Without a runtime, next_run_time_source is 'declared'."""
         _override_conn(_mock_conn())
+        prev = getattr(app.state, "job_runtime", None)
         app.state.job_runtime = None
-        with patch(
-            "app.api.system.check_job_health",
-            side_effect=lambda _conn, name: _success_job_health(name),
-        ):
-            resp = client.get("/system/jobs")
+        try:
+            with patch(
+                "app.api.system.check_job_health",
+                side_effect=lambda _conn, name: _success_job_health(name),
+            ):
+                resp = client.get("/system/jobs")
 
-        assert resp.status_code == 200
-        body = resp.json()
-        for job in body["jobs"]:
-            assert job["next_run_time_source"] == "declared"
+            assert resp.status_code == 200
+            body = resp.json()
+            for job in body["jobs"]:
+                assert job["next_run_time_source"] == "declared"
+        finally:
+            app.state.job_runtime = prev
 
     def test_service_exception_returns_503_without_leaking_internals(self) -> None:
         _override_conn(_mock_conn())

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -426,6 +426,45 @@ class TestSystemJobs:
             next_run = datetime.fromisoformat(job["next_run_time"])
             assert next_run > checked_at, f"{job['name']} next_run not in future"
 
+    def test_live_next_run_time_from_runtime(self) -> None:
+        """When job_runtime is on app.state, next_run_time comes from APScheduler."""
+        _override_conn(_mock_conn())
+        fire_time = _NOW + timedelta(hours=1)
+        live_times = {job.name: fire_time for job in SCHEDULED_JOBS}
+        mock_runtime = MagicMock()
+        mock_runtime.get_next_run_times.return_value = live_times
+        app.state.job_runtime = mock_runtime
+        try:
+            with patch(
+                "app.api.system.check_job_health",
+                side_effect=lambda _conn, name: _success_job_health(name),
+            ):
+                resp = client.get("/system/jobs")
+
+            assert resp.status_code == 200
+            body = resp.json()
+            for job in body["jobs"]:
+                assert job["next_run_time_source"] == "live"
+                nrt = datetime.fromisoformat(job["next_run_time"])
+                assert nrt == fire_time
+        finally:
+            app.state.job_runtime = None
+
+    def test_falls_back_to_declared_when_no_runtime(self) -> None:
+        """Without a runtime, next_run_time_source is 'declared'."""
+        _override_conn(_mock_conn())
+        app.state.job_runtime = None
+        with patch(
+            "app.api.system.check_job_health",
+            side_effect=lambda _conn, name: _success_job_health(name),
+        ):
+            resp = client.get("/system/jobs")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        for job in body["jobs"]:
+            assert job["next_run_time_source"] == "declared"
+
     def test_service_exception_returns_503_without_leaking_internals(self) -> None:
         _override_conn(_mock_conn())
         secret_marker = "secret-table-name-do-not-leak"

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -433,6 +433,7 @@ class TestSystemJobs:
         live_times = {job.name: fire_time for job in SCHEDULED_JOBS}
         mock_runtime = MagicMock()
         mock_runtime.get_next_run_times.return_value = live_times
+        prev = getattr(app.state, "job_runtime", None)
         app.state.job_runtime = mock_runtime
         try:
             with patch(
@@ -448,7 +449,7 @@ class TestSystemJobs:
                 nrt = datetime.fromisoformat(job["next_run_time"])
                 assert nrt == fire_time
         finally:
-            app.state.job_runtime = None
+            app.state.job_runtime = prev
 
     def test_falls_back_to_declared_when_no_runtime(self) -> None:
         """Without a runtime, next_run_time_source is 'declared'."""

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -238,6 +238,50 @@ class TestStartWiring:
             rt.start()
 
 
+class TestGetNextRunTimes:
+    def test_returns_live_fire_times_from_scheduler(
+        self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_next_run_times queries APScheduler's in-memory jobs."""
+        from app.workers.scheduler import JOB_DAILY_CIK_REFRESH
+
+        fire_time = datetime(2026, 4, 11, 3, 0, 0, tzinfo=UTC)
+
+        fake_aps_job = MagicMock()
+        fake_aps_job.next_run_time = fire_time
+
+        rt = _make_runtime({JOB_DAILY_CIK_REFRESH: lambda: None})
+        monkeypatch.setattr(
+            rt._scheduler,
+            "get_job",
+            lambda job_id: fake_aps_job if job_id == f"recurring:{JOB_DAILY_CIK_REFRESH}" else None,
+        )
+
+        result = rt.get_next_run_times()
+        assert result[JOB_DAILY_CIK_REFRESH] == fire_time
+
+    def test_returns_none_for_missing_scheduler_job(
+        self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If APScheduler doesn't know about a job, return None."""
+        from app.workers.scheduler import JOB_DAILY_CIK_REFRESH
+
+        rt = _make_runtime({JOB_DAILY_CIK_REFRESH: lambda: None})
+        monkeypatch.setattr(rt._scheduler, "get_job", lambda _job_id: None)
+
+        result = rt.get_next_run_times()
+        assert result[JOB_DAILY_CIK_REFRESH] is None
+
+    def test_excludes_unwired_jobs(self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Jobs not in the invoker map are excluded from results."""
+        rt = _make_runtime({"not_in_registry": lambda: None})
+        monkeypatch.setattr(rt._scheduler, "get_job", lambda _job_id: None)
+
+        result = rt.get_next_run_times()
+        # SCHEDULED_JOBS entries that aren't wired should not appear.
+        assert "not_in_registry" not in result
+
+
 class TestProductionInvokerRegistry:
     """Every scheduled job must have an invoker; on-demand jobs may exist
     in ``_INVOKERS`` without a ``SCHEDULED_JOBS`` entry.

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -272,14 +272,17 @@ class TestGetNextRunTimes:
         result = rt.get_next_run_times()
         assert result[JOB_DAILY_CIK_REFRESH] is None
 
-    def test_excludes_unwired_jobs(self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Jobs not in the invoker map are excluded from results."""
-        rt = _make_runtime({"not_in_registry": lambda: None})
+    def test_excludes_unwired_scheduled_jobs(self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SCHEDULED_JOBS entries not in the invoker map are excluded."""
+        from app.workers.scheduler import JOB_DAILY_CIK_REFRESH, JOB_HOURLY_MARKET_REFRESH
+
+        # Wire only one of two scheduled jobs — the other should be absent.
+        rt = _make_runtime({JOB_DAILY_CIK_REFRESH: lambda: None})
         monkeypatch.setattr(rt._scheduler, "get_job", lambda _job_id: None)
 
         result = rt.get_next_run_times()
-        # SCHEDULED_JOBS entries that aren't wired should not appear.
-        assert "not_in_registry" not in result
+        assert JOB_DAILY_CIK_REFRESH in result
+        assert JOB_HOURLY_MARKET_REFRESH not in result
 
 
 class TestProductionInvokerRegistry:


### PR DESCRIPTION
Closes #173

## What changed

- **`app/jobs/runtime.py`**: Added `JobRuntime.get_next_run_times()` — queries APScheduler's in-memory job store for each registered job's live `next_run_time`. Also logs next-fire times at startup for operator visibility. Cleaned up stale "PR A/B/C" scope comments that referenced the incremental rollout plan.
- **`app/api/system.py`**: `/system/jobs` endpoint now reads the `JobRuntime` from `request.app.state` and passes live fire times to `_build_jobs_overview`. `next_run_time_source` is `"live"` when the runtime is available, `"declared"` as fallback. Updated response model to accept either literal.
- **`app/workers/scheduler.py`**: Updated module docstring and cadence registry comments to reflect that APScheduler is now wired and `compute_next_run` is a utility, not the primary source.
- **`app/main.py`**: Updated comment to reflect current state (all jobs registered, catch-up active).
- **`tests/test_jobs_runtime.py`**: Three new tests for `get_next_run_times()`.
- **`tests/test_api_system.py`**: Two new tests for live vs declared fallback.

## Why

The scheduler module's docstring and the system API both flagged `compute_next_run` as a placeholder: "When APScheduler is wired (#13), replace with live scheduler introspection." APScheduler has been wired since PR #131, but the operator-facing `/system/jobs` endpoint still computed next-run times from declared cadences rather than querying the live scheduler. This meant the API reported *intended* fire times, not *actual* ones — a divergence that would be invisible until a job drifted or was paused.

## Schema / migration impact

None.

## Invariants checked

- `compute_next_run` is retained as a pure function for catch-up-on-boot (where the scheduler hasn't fired yet) and for test assertions — no behaviour removed
- `get_next_run_times()` only returns jobs that are in both `SCHEDULED_JOBS` and the invoker map — same intersection semantics as `start()`
- Fallback to declared cadence when runtime is absent (tests, startup failure) — no 500 if `app.state.job_runtime` is `None`

## Failure paths considered

- `app.state.job_runtime` is `None` (startup failure, tests) → falls back to `compute_next_run` with `source="declared"`
- APScheduler doesn't know about a job (`get_job` returns `None`) → `next_run_time` is `None` in the dict, falls back to declared
- Runtime available but individual job missing → per-job fallback, not all-or-nothing

## Tests added

- `TestGetNextRunTimes::test_returns_live_fire_times_from_scheduler` — mocked APScheduler job returns fire time
- `TestGetNextRunTimes::test_returns_none_for_missing_scheduler_job` — `get_job` returns `None`
- `TestGetNextRunTimes::test_excludes_unwired_jobs` — jobs not in invoker map excluded
- `TestSystemJobs::test_live_next_run_time_from_runtime` — mock runtime on `app.state` → `source="live"`
- `TestSystemJobs::test_falls_back_to_declared_when_no_runtime` — no runtime → `source="declared"`

## Conscious tradeoffs

- `compute_next_run` is not deleted — it remains useful for catch-up-on-boot and as a test utility. Removing it would require reworking catch-up to query APScheduler directly, which is unnecessary since catch-up runs before any job has fired.
- Stale "PR A/B/C" comments cleaned up in runtime.py and main.py, but not exhaustively across all files — only the ones that were misleading or referenced future work that is now done.

## Tech debt opened

None.