### PR TITLE
feat(#175): sync positions and cash from eToro broker

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -55,6 +55,7 @@ from app.services.ops_monitor import fetch_latest_successful_runs, record_job_sk
 from app.workers.scheduler import (
     JOB_DAILY_CIK_REFRESH,
     JOB_DAILY_NEWS_REFRESH,
+    JOB_DAILY_PORTFOLIO_SYNC,
     JOB_DAILY_RESEARCH_REFRESH,
     JOB_DAILY_TAX_RECONCILIATION,
     JOB_DAILY_THESIS_REFRESH,
@@ -68,6 +69,7 @@ from app.workers.scheduler import (
     compute_next_run,
     daily_cik_refresh,
     daily_news_refresh,
+    daily_portfolio_sync,
     daily_research_refresh,
     daily_tax_reconciliation,
     daily_thesis_refresh,
@@ -107,6 +109,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_DAILY_RESEARCH_REFRESH: daily_research_refresh,
     JOB_DAILY_NEWS_REFRESH: daily_news_refresh,
     JOB_DAILY_THESIS_REFRESH: daily_thesis_refresh,
+    JOB_DAILY_PORTFOLIO_SYNC: daily_portfolio_sync,
     JOB_MORNING_CANDIDATE_REVIEW: morning_candidate_review,
     JOB_WEEKLY_COVERAGE_REVIEW: weekly_coverage_review,
     JOB_DAILY_TAX_RECONCILIATION: daily_tax_reconciliation,

--- a/app/providers/broker.py
+++ b/app/providers/broker.py
@@ -12,6 +12,7 @@ balance).  It does not own DB access or domain logic.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, Literal
@@ -46,7 +47,7 @@ class BrokerPosition:
 class BrokerPortfolio:
     """Snapshot of the broker account: positions + available cash."""
 
-    positions: list[BrokerPosition]
+    positions: Sequence[BrokerPosition]
     available_cash: Decimal
     raw_payload: dict[str, Any]
 

--- a/app/providers/broker.py
+++ b/app/providers/broker.py
@@ -4,8 +4,9 @@ Broker provider interface.
 eToro is the v1 implementation.  All domain code imports this interface only —
 never the concrete provider.
 
-The broker provider handles write operations: placing orders, closing positions,
-and checking order status.  It does not own DB access or domain logic.
+The broker provider handles trading operations (placing orders, closing
+positions, checking status) and portfolio reads (open positions, account
+balance).  It does not own DB access or domain logic.
 """
 
 from __future__ import annotations
@@ -30,9 +31,29 @@ class BrokerOrderResult:
     raw_payload: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class BrokerPosition:
+    """A single open position as reported by the broker."""
+
+    instrument_id: int
+    units: Decimal
+    open_price: Decimal
+    current_price: Decimal
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BrokerPortfolio:
+    """Snapshot of the broker account: positions + available cash."""
+
+    positions: list[BrokerPosition]
+    available_cash: Decimal
+    raw_payload: dict[str, Any]
+
+
 class BrokerProvider(ABC):
     """
-    Interface for broker write operations.
+    Interface for broker operations.
 
     v1 implementation: EtoroBrokerProvider
     """
@@ -66,4 +87,12 @@ class BrokerProvider(ABC):
         Check the current status of a previously placed order.
 
         Returns the latest state from the broker.
+        """
+
+    @abstractmethod
+    def get_portfolio(self) -> BrokerPortfolio:
+        """
+        Fetch the current portfolio from the broker.
+
+        Returns all open positions and available cash.
         """

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -11,7 +11,6 @@ Trading endpoints are environment-scoped: /demo/ prefix for demo, no prefix for 
 
 from __future__ import annotations
 
-import json
 import logging
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -36,13 +35,19 @@ logger = logging.getLogger(__name__)
 _RAW_PAYLOAD_DIR = Path("data/raw/etoro_broker")
 
 
-def _persist_raw(tag: str, payload: object) -> None:
-    """Write raw API response to disk before normalisation."""
+def _persist_raw(tag: str, payload: bytes) -> None:
+    """Write raw API response bytes to disk before normalisation.
+
+    Re-raises ``OSError`` subclasses (permission denied, disk full) so the
+    caller knows the file was not written.  Other exceptions are logged.
+    """
     try:
         _RAW_PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
         ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
         path = _RAW_PAYLOAD_DIR / f"{tag}_{ts}.json"
-        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        path.write_bytes(payload)
+    except OSError:
+        raise
     except Exception:
         logger.warning("Failed to persist raw payload for tag=%s", tag, exc_info=True)
 
@@ -403,9 +408,9 @@ class EtoroBrokerProvider(BrokerProvider):
             f"{self._info_prefix}/portfolio",
             headers=self._request_headers(),
         )
-        raw = response.json()
-        _persist_raw("etoro_portfolio", raw)
+        _persist_raw("etoro_portfolio", response.content)
         response.raise_for_status()
+        raw = response.json()
 
         portfolio = raw.get("clientPortfolio") or {}
         raw_positions: list[dict[str, Any]] = portfolio.get("positions") or []

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -38,9 +38,9 @@ _RAW_PAYLOAD_DIR = Path("data/raw/etoro_broker")
 def _persist_raw(tag: str, payload: bytes) -> None:
     """Write raw API response bytes to disk before normalisation.
 
-    Best-effort: must not block the primary read path.  Logs at ERROR
-    for OS-level failures (disk full, permission denied) and WARNING
-    for anything else.
+    Raises ``OSError`` on disk-level failures (permission denied, disk full)
+    so the caller can decide whether to abort or continue.  Non-OS exceptions
+    are logged and swallowed.
     """
     try:
         _RAW_PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
@@ -48,7 +48,7 @@ def _persist_raw(tag: str, payload: bytes) -> None:
         path = _RAW_PAYLOAD_DIR / f"{tag}_{ts}.json"
         path.write_bytes(payload)
     except OSError:
-        logger.error("OS error persisting raw payload for tag=%s", tag, exc_info=True)
+        raise
     except Exception:
         logger.warning("Failed to persist raw payload for tag=%s", tag, exc_info=True)
 
@@ -409,7 +409,13 @@ class EtoroBrokerProvider(BrokerProvider):
             f"{self._info_prefix}/portfolio",
             headers=self._request_headers(),
         )
-        _persist_raw("etoro_portfolio", response.content)
+        try:
+            _persist_raw("etoro_portfolio", response.content)
+        except OSError:
+            logger.error(
+                "Failed to persist raw portfolio payload — continuing with response",
+                exc_info=True,
+            )
         response.raise_for_status()
         raw = response.json()
 

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -11,18 +11,41 @@ Trading endpoints are environment-scoped: /demo/ prefix for demo, no prefix for 
 
 from __future__ import annotations
 
+import json
 import logging
+from datetime import UTC, datetime
 from decimal import Decimal
+from pathlib import Path
 from types import TracebackType
 from typing import Any
 
 import httpx
 
 from app.config import settings
-from app.providers.broker import BrokerOrderResult, BrokerProvider, OrderStatus
+from app.providers.broker import (
+    BrokerOrderResult,
+    BrokerPortfolio,
+    BrokerPosition,
+    BrokerProvider,
+    OrderStatus,
+)
 from app.providers.resilient_client import ResilientClient
 
 logger = logging.getLogger(__name__)
+
+_RAW_PAYLOAD_DIR = Path("data/raw/etoro_broker")
+
+
+def _persist_raw(tag: str, payload: object) -> None:
+    """Write raw API response to disk before normalisation."""
+    try:
+        _RAW_PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        path = _RAW_PAYLOAD_DIR / f"{tag}_{ts}.json"
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except Exception:
+        logger.warning("Failed to persist raw payload for tag=%s", tag, exc_info=True)
+
 
 # Actions the service layer is allowed to send to place_order.
 # EXIT is routed to close_position by the service layer and must never
@@ -366,6 +389,50 @@ class EtoroBrokerProvider(BrokerProvider):
             )
 
         return _normalise_order_info_response(raw, broker_order_ref)
+
+    # ------------------------------------------------------------------
+    # Portfolio reads
+    # ------------------------------------------------------------------
+
+    def get_portfolio(self) -> BrokerPortfolio:
+        """Fetch open positions and available cash from the eToro portfolio endpoint.
+
+        Raises on HTTP or network errors (caller should handle).
+        """
+        response = self._http_read.get(
+            f"{self._info_prefix}/portfolio",
+            headers=self._request_headers(),
+        )
+        raw = response.json()
+        _persist_raw("etoro_portfolio", raw)
+        response.raise_for_status()
+
+        portfolio = raw.get("clientPortfolio") or {}
+        raw_positions: list[dict[str, Any]] = portfolio.get("positions") or []
+        credit = portfolio.get("credit")
+
+        positions: list[BrokerPosition] = []
+        for pos in raw_positions:
+            if not isinstance(pos, dict):
+                continue
+            iid = pos.get("instrumentID")
+            if iid is None:
+                continue
+            positions.append(
+                BrokerPosition(
+                    instrument_id=int(iid),
+                    units=Decimal(str(pos.get("units", 0))),
+                    open_price=Decimal(str(pos.get("openPrice", 0))),
+                    current_price=Decimal(str(pos.get("currentPrice", 0))),
+                    raw_payload=pos,
+                )
+            )
+
+        return BrokerPortfolio(
+            positions=positions,
+            available_cash=Decimal(str(credit)) if credit is not None else Decimal("0"),
+            raw_payload=raw,
+        )
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -38,8 +38,9 @@ _RAW_PAYLOAD_DIR = Path("data/raw/etoro_broker")
 def _persist_raw(tag: str, payload: bytes) -> None:
     """Write raw API response bytes to disk before normalisation.
 
-    Re-raises ``OSError`` subclasses (permission denied, disk full) so the
-    caller knows the file was not written.  Other exceptions are logged.
+    Best-effort: must not block the primary read path.  Logs at ERROR
+    for OS-level failures (disk full, permission denied) and WARNING
+    for anything else.
     """
     try:
         _RAW_PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
@@ -47,7 +48,7 @@ def _persist_raw(tag: str, payload: bytes) -> None:
         path = _RAW_PAYLOAD_DIR / f"{tag}_{ts}.json"
         path.write_bytes(payload)
     except OSError:
-        raise
+        logger.error("OS error persisting raw payload for tag=%s", tag, exc_info=True)
     except Exception:
         logger.warning("Failed to persist raw payload for tag=%s", tag, exc_info=True)
 

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -146,12 +146,13 @@ def sync_portfolio(
     for agg in broker_positions.values():
         if agg.instrument_id in local_instrument_ids:
             # Existing local position — update from broker.
+            # Only refresh units and PnL; leave avg_cost/cost_basis
+            # untouched — for eBull-originated positions, the local
+            # cost basis is authoritative for tax-lot and P&L history.
             conn.execute(
                 """
                 UPDATE positions SET
                     current_units  = %(units)s,
-                    avg_cost       = %(avg_cost)s,
-                    cost_basis     = %(cost_basis)s,
                     unrealized_pnl = %(upnl)s,
                     updated_at     = %(now)s
                 WHERE instrument_id = %(iid)s
@@ -159,8 +160,6 @@ def sync_portfolio(
                 {
                     "iid": agg.instrument_id,
                     "units": agg.units,
-                    "avg_cost": agg.avg_open_price,
-                    "cost_basis": agg.avg_open_price * agg.units,
                     "upnl": agg.unrealized_pnl,
                     "now": now,
                 },

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -1,0 +1,195 @@
+"""Portfolio sync — reconcile local positions and cash against the broker.
+
+Fetches the broker's current portfolio (open positions + available cash)
+and reconciles against the local ``positions`` and ``cash_ledger`` tables.
+
+This is a **read-from-broker, write-to-local-DB** operation. It never
+places orders or modifies broker state.
+
+Reconciliation rules:
+
+* **Broker position exists locally**: update ``current_units`` and
+  ``unrealized_pnl`` from the broker snapshot.
+* **Broker position is new locally**: insert a new ``positions`` row.
+  The position was opened outside eBull (manual trade, copy trading).
+* **Local position absent from broker**: the position was closed outside
+  eBull. Zero out ``current_units`` and log a warning.
+* **Cash**: record a ``broker_sync`` event in ``cash_ledger`` with the
+  delta between the broker's reported available cash and the local
+  ``SUM(amount)`` from ``cash_ledger``.  If delta is zero (within a
+  tolerance), no event is recorded.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+from app.providers.broker import BrokerPortfolio
+
+logger = logging.getLogger(__name__)
+
+# Cash deltas smaller than this are considered rounding noise.
+_CASH_SYNC_TOLERANCE = Decimal("0.01")
+
+
+@dataclass
+class PortfolioSyncResult:
+    """Summary of a portfolio sync run."""
+
+    positions_updated: int
+    positions_opened_externally: int
+    positions_closed_externally: int
+    cash_delta: Decimal
+    broker_cash: Decimal
+    local_cash: Decimal
+
+
+def sync_portfolio(
+    conn: psycopg.Connection[Any],
+    portfolio: BrokerPortfolio,
+    now: datetime | None = None,
+) -> PortfolioSyncResult:
+    """Reconcile local state against a broker portfolio snapshot.
+
+    Must be called inside a transaction (autocommit=False, the default).
+    The caller is responsible for committing.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+
+    updated = 0
+    opened_externally = 0
+    closed_externally = 0
+
+    # Build a lookup of broker positions by instrument_id.
+    broker_positions = {bp.instrument_id: bp for bp in portfolio.positions}
+
+    # Fetch all local positions with units > 0.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        local_rows = cur.execute(
+            """
+            SELECT instrument_id, current_units
+            FROM positions
+            WHERE current_units > 0
+            """
+        ).fetchall()
+    local_instrument_ids = {row["instrument_id"] for row in local_rows}
+
+    # 1. Upsert broker positions into local state.
+    for bp in portfolio.positions:
+        unrealized = (bp.current_price - bp.open_price) * bp.units
+        if bp.instrument_id in local_instrument_ids:
+            # Existing local position — update from broker.
+            conn.execute(
+                """
+                UPDATE positions SET
+                    current_units  = %(units)s,
+                    unrealized_pnl = %(upnl)s,
+                    updated_at     = %(now)s
+                WHERE instrument_id = %(iid)s
+                """,
+                {
+                    "iid": bp.instrument_id,
+                    "units": bp.units,
+                    "upnl": unrealized,
+                    "now": now,
+                },
+            )
+            updated += 1
+        else:
+            # New position from broker — opened externally.
+            conn.execute(
+                """
+                INSERT INTO positions
+                    (instrument_id, open_date, avg_cost, current_units,
+                     cost_basis, unrealized_pnl, updated_at)
+                VALUES
+                    (%(iid)s, %(date)s, %(price)s, %(units)s,
+                     %(cost)s, %(upnl)s, %(now)s)
+                ON CONFLICT (instrument_id) DO UPDATE SET
+                    current_units  = EXCLUDED.current_units,
+                    avg_cost       = EXCLUDED.avg_cost,
+                    cost_basis     = EXCLUDED.cost_basis,
+                    unrealized_pnl = EXCLUDED.unrealized_pnl,
+                    updated_at     = EXCLUDED.updated_at
+                """,
+                {
+                    "iid": bp.instrument_id,
+                    "date": now.date(),
+                    "price": bp.open_price,
+                    "units": bp.units,
+                    "cost": bp.open_price * bp.units,
+                    "upnl": unrealized,
+                    "now": now,
+                },
+            )
+            opened_externally += 1
+            logger.warning(
+                "Position for instrument %d found on broker but not locally — "
+                "opened externally (units=%.4f, open_price=%.4f)",
+                bp.instrument_id,
+                bp.units,
+                bp.open_price,
+            )
+
+    # 2. Zero out local positions absent from broker.
+    for row in local_rows:
+        iid = row["instrument_id"]
+        if iid not in broker_positions:
+            conn.execute(
+                """
+                UPDATE positions SET
+                    current_units  = 0,
+                    unrealized_pnl = 0,
+                    updated_at     = %(now)s
+                WHERE instrument_id = %(iid)s
+                """,
+                {"iid": iid, "now": now},
+            )
+            closed_externally += 1
+            logger.warning(
+                "Local position for instrument %d not found on broker — closed externally, zeroing units",
+                iid,
+            )
+
+    # 3. Reconcile cash.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        local_cash_row = cur.execute("SELECT COALESCE(SUM(amount), 0) AS total FROM cash_ledger").fetchone()
+    local_cash = Decimal(str(local_cash_row["total"])) if local_cash_row else Decimal("0")
+    broker_cash = portfolio.available_cash
+    cash_delta = broker_cash - local_cash
+
+    if abs(cash_delta) > _CASH_SYNC_TOLERANCE:
+        conn.execute(
+            """
+            INSERT INTO cash_ledger (event_time, event_type, amount, currency, note)
+            VALUES (%(time)s, 'broker_sync', %(amount)s, 'USD', %(note)s)
+            """,
+            {
+                "time": now,
+                "amount": cash_delta,
+                "note": f"Broker sync: broker={broker_cash}, local={local_cash}, delta={cash_delta}",
+            },
+        )
+        logger.info(
+            "Cash reconciliation: broker=%.2f local=%.2f delta=%.2f",
+            broker_cash,
+            local_cash,
+            cash_delta,
+        )
+
+    return PortfolioSyncResult(
+        positions_updated=updated,
+        positions_opened_externally=opened_externally,
+        positions_closed_externally=closed_externally,
+        cash_delta=cash_delta,
+        broker_cash=broker_cash,
+        local_cash=local_cash,
+    )

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -23,6 +23,7 @@ Reconciliation rules:
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -31,7 +32,7 @@ from typing import Any
 import psycopg
 import psycopg.rows
 
-from app.providers.broker import BrokerPortfolio
+from app.providers.broker import BrokerPortfolio, BrokerPosition
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,63 @@ class PortfolioSyncResult:
     local_cash: Decimal
 
 
+@dataclass
+class _AggregatedPosition:
+    """Broker positions for the same instrument, aggregated."""
+
+    instrument_id: int
+    units: Decimal
+    avg_open_price: Decimal
+    unrealized_pnl: Decimal
+    earliest_open_date_raw: str | None
+    raw_payloads: list[dict[str, Any]]
+
+
+def _aggregate_by_instrument(
+    positions: Sequence[BrokerPosition],
+) -> dict[int, _AggregatedPosition]:
+    """Group broker positions by instrument_id and aggregate.
+
+    eToro can return multiple open positionIDs for the same instrumentID.
+    We sum units, compute weighted-average open price, compute total
+    unrealised PnL from the raw rows, and keep the earliest open date.
+    """
+    from collections import defaultdict
+
+    buckets: dict[int, list[BrokerPosition]] = defaultdict(list)
+    for bp in positions:
+        buckets[bp.instrument_id].append(bp)
+
+    result: dict[int, _AggregatedPosition] = {}
+    for iid, group in buckets.items():
+        _zero = Decimal("0")
+        total_units = sum((bp.units for bp in group), start=_zero)
+        total_cost = sum((bp.open_price * bp.units for bp in group), start=_zero)
+        total_pnl = sum(
+            ((bp.current_price - bp.open_price) * bp.units for bp in group),
+            start=_zero,
+        )
+        avg_price = total_cost / total_units if total_units > 0 else _zero
+
+        # Earliest open date among the raw payloads (if any provide it).
+        open_dates: list[str] = []
+        for bp in group:
+            raw_open = bp.raw_payload.get("openDateTime")
+            if isinstance(raw_open, str):
+                open_dates.append(raw_open)
+        open_dates.sort()
+
+        result[iid] = _AggregatedPosition(
+            instrument_id=iid,
+            units=total_units,
+            avg_open_price=avg_price,
+            unrealized_pnl=total_pnl,
+            earliest_open_date_raw=open_dates[0] if open_dates else None,
+            raw_payloads=[bp.raw_payload for bp in group],
+        )
+    return result
+
+
 def sync_portfolio(
     conn: psycopg.Connection[Any],
     portfolio: BrokerPortfolio,
@@ -68,8 +126,10 @@ def sync_portfolio(
     opened_externally = 0
     closed_externally = 0
 
-    # Build a lookup of broker positions by instrument_id.
-    broker_positions = {bp.instrument_id: bp for bp in portfolio.positions}
+    # Aggregate broker positions by instrument_id.  eToro can return
+    # multiple positionIDs for the same instrument; we must reconcile
+    # against aggregated totals, not individual rows.
+    broker_positions = _aggregate_by_instrument(portfolio.positions)
 
     # Fetch all local positions with units > 0.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -83,37 +143,37 @@ def sync_portfolio(
     local_instrument_ids = {row["instrument_id"] for row in local_rows}
 
     # 1. Upsert broker positions into local state.
-    for bp in portfolio.positions:
-        unrealized = (bp.current_price - bp.open_price) * bp.units
-        if bp.instrument_id in local_instrument_ids:
+    for agg in broker_positions.values():
+        if agg.instrument_id in local_instrument_ids:
             # Existing local position — update from broker.
             conn.execute(
                 """
                 UPDATE positions SET
                     current_units  = %(units)s,
+                    avg_cost       = %(avg_cost)s,
+                    cost_basis     = %(cost_basis)s,
                     unrealized_pnl = %(upnl)s,
                     updated_at     = %(now)s
                 WHERE instrument_id = %(iid)s
                 """,
                 {
-                    "iid": bp.instrument_id,
-                    "units": bp.units,
-                    "upnl": unrealized,
+                    "iid": agg.instrument_id,
+                    "units": agg.units,
+                    "avg_cost": agg.avg_open_price,
+                    "cost_basis": agg.avg_open_price * agg.units,
+                    "upnl": agg.unrealized_pnl,
                     "now": now,
                 },
             )
             updated += 1
         else:
             # New position from broker — opened externally.
-            # Try to extract actual open date from broker raw payload;
-            # fall back to sync time if the broker doesn't provide it.
-            # Known limitation: eToro's OpenAPI spec does not document
-            # an openDateTime field, so this may always fall back.
+            # Use the earliest open date from the aggregated broker
+            # payloads; fall back to sync time if unavailable.
             open_date = now.date()
-            raw_open = bp.raw_payload.get("openDateTime")
-            if isinstance(raw_open, str):
+            if agg.earliest_open_date_raw is not None:
                 try:
-                    open_date = datetime.fromisoformat(raw_open).date()
+                    open_date = datetime.fromisoformat(agg.earliest_open_date_raw).date()
                 except ValueError:
                     pass
             conn.execute(
@@ -129,25 +189,26 @@ def sync_portfolio(
                     avg_cost       = EXCLUDED.avg_cost,
                     cost_basis     = EXCLUDED.cost_basis,
                     unrealized_pnl = EXCLUDED.unrealized_pnl,
+                    open_date      = EXCLUDED.open_date,
                     updated_at     = EXCLUDED.updated_at
                 """,
                 {
-                    "iid": bp.instrument_id,
+                    "iid": agg.instrument_id,
                     "date": open_date,
-                    "price": bp.open_price,
-                    "units": bp.units,
-                    "cost": bp.open_price * bp.units,
-                    "upnl": unrealized,
+                    "price": agg.avg_open_price,
+                    "units": agg.units,
+                    "cost": agg.avg_open_price * agg.units,
+                    "upnl": agg.unrealized_pnl,
                     "now": now,
                 },
             )
             opened_externally += 1
             logger.warning(
                 "Position for instrument %d found on broker but not locally — "
-                "opened externally (units=%.4f, open_price=%.4f)",
-                bp.instrument_id,
-                bp.units,
-                bp.open_price,
+                "opened externally (units=%.4f, avg_open_price=%.4f)",
+                agg.instrument_id,
+                agg.units,
+                agg.avg_open_price,
             )
 
     # 2. Zero out local positions absent from broker.

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -105,6 +105,17 @@ def sync_portfolio(
             updated += 1
         else:
             # New position from broker — opened externally.
+            # Try to extract actual open date from broker raw payload;
+            # fall back to sync time if the broker doesn't provide it.
+            # Known limitation: eToro's OpenAPI spec does not document
+            # an openDateTime field, so this may always fall back.
+            open_date = now.date()
+            raw_open = bp.raw_payload.get("openDateTime")
+            if isinstance(raw_open, str):
+                try:
+                    open_date = datetime.fromisoformat(raw_open).date()
+                except ValueError:
+                    pass
             conn.execute(
                 """
                 INSERT INTO positions
@@ -122,7 +133,7 @@ def sync_portfolio(
                 """,
                 {
                     "iid": bp.instrument_id,
-                    "date": now.date(),
+                    "date": open_date,
                     "price": bp.open_price,
                     "units": bp.units,
                     "cost": bp.open_price * bp.units,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -844,6 +844,7 @@ def daily_portfolio_sync() -> None:
 
         with psycopg.connect(settings.database_url) as conn:
             result = sync_portfolio(conn, portfolio)
+            conn.commit()
 
         tracker.row_count = (
             result.positions_updated + result.positions_opened_externally + result.positions_closed_externally

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -45,6 +45,7 @@ from app.services.market_data import refresh_market_data
 from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
 from app.services.ops_monitor import check_row_count_spike, record_job_finish, record_job_start
 from app.services.portfolio import run_portfolio_review
+from app.services.portfolio_sync import sync_portfolio
 from app.services.scoring import compute_rankings
 from app.services.sentiment import ClaudeSentimentScorer
 from app.services.tax_ledger import ingest_tax_events, run_disposal_matching
@@ -166,6 +167,7 @@ JOB_DAILY_THESIS_REFRESH = "daily_thesis_refresh"
 JOB_MORNING_CANDIDATE_REVIEW = "morning_candidate_review"
 JOB_WEEKLY_COVERAGE_REVIEW = "weekly_coverage_review"
 JOB_DAILY_TAX_RECONCILIATION = "daily_tax_reconciliation"
+JOB_DAILY_PORTFOLIO_SYNC = "daily_portfolio_sync"
 
 
 # ---------------------------------------------------------------------------
@@ -252,6 +254,11 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         description="Regenerate theses for stale Tier 1/2 instruments.",
         cadence=Cadence.daily(hour=4, minute=30),
         prerequisite=_has_coverage_tier12,
+    ),
+    ScheduledJob(
+        name=JOB_DAILY_PORTFOLIO_SYNC,
+        description="Sync positions and cash from eToro broker to local state.",
+        cadence=Cadence.daily(hour=5, minute=30),
     ),
     ScheduledJob(
         name=JOB_MORNING_CANDIDATE_REVIEW,
@@ -811,6 +818,46 @@ def daily_thesis_refresh() -> None:
         generated,
         skipped,
     )
+
+
+def daily_portfolio_sync() -> None:
+    """Sync positions and cash from eToro to local state.
+
+    Runs before morning_candidate_review so recommendations use fresh
+    portfolio data. Requires eToro broker credentials; skips gracefully
+    if credentials are missing.
+    """
+    from app.providers.implementations.etoro_broker import EtoroBrokerProvider
+
+    creds = _load_etoro_credentials(JOB_DAILY_PORTFOLIO_SYNC)
+    if creds is None:
+        return
+
+    api_key, user_key = creds
+    with _tracked_job(JOB_DAILY_PORTFOLIO_SYNC) as tracker:
+        with EtoroBrokerProvider(
+            api_key=api_key,
+            user_key=user_key,
+            env=settings.etoro_env,
+        ) as broker:
+            portfolio = broker.get_portfolio()
+
+        with psycopg.connect(settings.database_url) as conn:
+            result = sync_portfolio(conn, portfolio)
+
+        tracker.row_count = (
+            result.positions_updated + result.positions_opened_externally + result.positions_closed_externally
+        )
+        logger.info(
+            "Portfolio sync complete: updated=%d opened_ext=%d closed_ext=%d "
+            "broker_cash=%.2f local_cash=%.2f delta=%.2f",
+            result.positions_updated,
+            result.positions_opened_externally,
+            result.positions_closed_externally,
+            result.broker_cash,
+            result.local_cash,
+            result.cash_delta,
+        )
 
 
 def morning_candidate_review() -> None:

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -10,7 +10,7 @@ No network calls — all HTTP interactions are mocked.
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import httpx
 
@@ -577,10 +577,12 @@ FIXTURE_FULL_PORTFOLIO_RESPONSE = {
 }
 
 
+@patch("app.providers.implementations.etoro_broker._persist_raw")
 class TestGetPortfolio:
-    def test_returns_positions_and_cash(self) -> None:
+    def test_returns_positions_and_cash(self, _mock_persist: MagicMock) -> None:
         mock_resp = MagicMock()
         mock_resp.json.return_value = FIXTURE_FULL_PORTFOLIO_RESPONSE
+        mock_resp.content = b"{}"
         mock_resp.status_code = 200
         mock_resp.raise_for_status = MagicMock()
 
@@ -603,9 +605,10 @@ class TestGetPortfolio:
         assert p2.instrument_id == 1002
         assert p2.units == Decimal("10.0")
 
-    def test_empty_portfolio(self) -> None:
+    def test_empty_portfolio(self, _mock_persist: MagicMock) -> None:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"clientPortfolio": {"positions": [], "credit": 100000}}
+        mock_resp.content = b"{}"
         mock_resp.status_code = 200
         mock_resp.raise_for_status = MagicMock()
 
@@ -615,12 +618,13 @@ class TestGetPortfolio:
 
             result = broker.get_portfolio()
 
-        assert result.positions == []
+        assert len(result.positions) == 0
         assert result.available_cash == Decimal("100000")
 
-    def test_missing_credit_defaults_to_zero(self) -> None:
+    def test_missing_credit_defaults_to_zero(self, _mock_persist: MagicMock) -> None:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"clientPortfolio": {"positions": []}}
+        mock_resp.content = b"{}"
         mock_resp.status_code = 200
         mock_resp.raise_for_status = MagicMock()
 
@@ -632,9 +636,10 @@ class TestGetPortfolio:
 
         assert result.available_cash == Decimal("0")
 
-    def test_calls_correct_endpoint(self) -> None:
+    def test_calls_correct_endpoint(self, _mock_persist: MagicMock) -> None:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"clientPortfolio": {"positions": [], "credit": 0}}
+        mock_resp.content = b"{}"
         mock_resp.status_code = 200
         mock_resp.raise_for_status = MagicMock()
 

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -548,3 +548,101 @@ class TestRequestBodyShape:
             body = broker._http_write.post.call_args.kwargs["json"]
             assert body["InstrumentID"] == 1001
             assert body["UnitsToDeduct"] is None
+
+
+# ---------------------------------------------------------------------------
+# get_portfolio
+# ---------------------------------------------------------------------------
+
+FIXTURE_FULL_PORTFOLIO_RESPONSE = {
+    "clientPortfolio": {
+        "positions": [
+            {
+                "instrumentID": 1001,
+                "positionID": 98765,
+                "units": 5.0,
+                "openPrice": 150.00,
+                "currentPrice": 160.00,
+            },
+            {
+                "instrumentID": 1002,
+                "positionID": 98766,
+                "units": 10.0,
+                "openPrice": 50.00,
+                "currentPrice": 48.50,
+            },
+        ],
+        "credit": 50000.50,
+    },
+}
+
+
+class TestGetPortfolio:
+    def test_returns_positions_and_cash(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = FIXTURE_FULL_PORTFOLIO_RESPONSE
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+
+            result = broker.get_portfolio()
+
+        assert len(result.positions) == 2
+        assert result.available_cash == Decimal("50000.50")
+
+        p1 = result.positions[0]
+        assert p1.instrument_id == 1001
+        assert p1.units == Decimal("5.0")
+        assert p1.open_price == Decimal("150.0")
+        assert p1.current_price == Decimal("160.0")
+
+        p2 = result.positions[1]
+        assert p2.instrument_id == 1002
+        assert p2.units == Decimal("10.0")
+
+    def test_empty_portfolio(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"clientPortfolio": {"positions": [], "credit": 100000}}
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+
+            result = broker.get_portfolio()
+
+        assert result.positions == []
+        assert result.available_cash == Decimal("100000")
+
+    def test_missing_credit_defaults_to_zero(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"clientPortfolio": {"positions": []}}
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+
+            result = broker.get_portfolio()
+
+        assert result.available_cash == Decimal("0")
+
+    def test_calls_correct_endpoint(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"clientPortfolio": {"positions": [], "credit": 0}}
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+
+            broker.get_portfolio()
+
+            url = broker._http_read.get.call_args.args[0]
+            assert url == "/api/v1/trading/info/demo/portfolio"

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -8,7 +8,11 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from app.providers.broker import BrokerPortfolio, BrokerPosition
-from app.services.portfolio_sync import PortfolioSyncResult, sync_portfolio
+from app.services.portfolio_sync import (
+    PortfolioSyncResult,
+    _aggregate_by_instrument,
+    sync_portfolio,
+)
 
 _NOW = datetime(2026, 4, 10, 5, 30, tzinfo=UTC)
 
@@ -109,6 +113,8 @@ class TestExistingPositionUpdate:
         params = update_calls[0].args[1]
         assert params["iid"] == 42
         assert params["units"] == Decimal("5")
+        assert params["avg_cost"] == Decimal("100")
+        assert params["cost_basis"] == Decimal("500")
         # unrealized = (120 - 100) * 5 = 100
         assert params["upnl"] == Decimal("100")
         assert params["now"] == _NOW
@@ -306,3 +312,165 @@ class TestMixedScenario:
         assert result.positions_updated == 1
         assert result.positions_opened_externally == 1
         assert result.positions_closed_externally == 1
+
+
+class TestAggregateByInstrument:
+    """Multiple broker positions for the same instrument are aggregated."""
+
+    def test_single_position_passes_through(self) -> None:
+        bp = _pos(instrument_id=42, units=Decimal("10"), open_price=Decimal("100"), current_price=Decimal("110"))
+        agg = _aggregate_by_instrument([bp])
+        assert 42 in agg
+        assert agg[42].units == Decimal("10")
+        assert agg[42].avg_open_price == Decimal("100")
+        # PnL: (110-100)*10 = 100
+        assert agg[42].unrealized_pnl == Decimal("100")
+
+    def test_two_positions_same_instrument_are_summed(self) -> None:
+        p1 = _pos(
+            instrument_id=42,
+            units=Decimal("10"),
+            open_price=Decimal("100"),
+            current_price=Decimal("120"),
+        )
+        p2 = _pos(
+            instrument_id=42,
+            units=Decimal("5"),
+            open_price=Decimal("80"),
+            current_price=Decimal("120"),
+        )
+        agg = _aggregate_by_instrument([p1, p2])
+
+        assert len(agg) == 1
+        a = agg[42]
+        assert a.units == Decimal("15")
+        # weighted avg: (100*10 + 80*5) / 15 = 1400/15 ≈ 93.333...
+        expected_avg = (Decimal("100") * Decimal("10") + Decimal("80") * Decimal("5")) / Decimal("15")
+        assert a.avg_open_price == expected_avg
+        # PnL: (120-100)*10 + (120-80)*5 = 200 + 200 = 400
+        assert a.unrealized_pnl == Decimal("400")
+        assert len(a.raw_payloads) == 2
+
+    def test_different_instruments_stay_separate(self) -> None:
+        p1 = _pos(instrument_id=1)
+        p2 = _pos(instrument_id=2)
+        agg = _aggregate_by_instrument([p1, p2])
+        assert len(agg) == 2
+        assert 1 in agg
+        assert 2 in agg
+
+    def test_earliest_open_date_is_selected(self) -> None:
+        p1 = BrokerPosition(
+            instrument_id=42,
+            units=Decimal("10"),
+            open_price=Decimal("100"),
+            current_price=Decimal("110"),
+            raw_payload={"openDateTime": "2026-03-20T10:00:00Z"},
+        )
+        p2 = BrokerPosition(
+            instrument_id=42,
+            units=Decimal("5"),
+            open_price=Decimal("80"),
+            current_price=Decimal("110"),
+            raw_payload={"openDateTime": "2026-03-10T08:00:00Z"},
+        )
+        agg = _aggregate_by_instrument([p1, p2])
+
+        # Earliest date should win.
+        assert agg[42].earliest_open_date_raw == "2026-03-10T08:00:00Z"
+
+    def test_zero_units_returns_zero_avg_price(self) -> None:
+        """Guard against division-by-zero from bad broker data."""
+        p = _pos(
+            instrument_id=42,
+            units=Decimal("0"),
+            open_price=Decimal("100"),
+            current_price=Decimal("110"),
+        )
+        agg = _aggregate_by_instrument([p])
+        assert agg[42].avg_open_price == Decimal(0)
+
+
+class TestMultiPositionSync:
+    """End-to-end: multiple broker positions for one instrument sync correctly."""
+
+    def test_duplicate_instrument_updates_once_with_aggregated_values(self) -> None:
+        """Two broker positions for instrument 42 should produce a single UPDATE."""
+        p1 = _pos(
+            instrument_id=42,
+            units=Decimal("10"),
+            open_price=Decimal("100"),
+            current_price=Decimal("120"),
+        )
+        p2 = _pos(
+            instrument_id=42,
+            units=Decimal("5"),
+            open_price=Decimal("80"),
+            current_price=Decimal("120"),
+        )
+        conn = _mock_conn(local_positions=[(42, Decimal("10"))], local_cash=Decimal("0"))
+        result = sync_portfolio(conn, _portfolio([p1, p2]), now=_NOW)
+
+        assert result.positions_updated == 1
+        assert result.positions_opened_externally == 0
+
+        update_calls = [
+            c for c in conn.execute.call_args_list if isinstance(c.args[0], str) and "UPDATE positions SET" in c.args[0]
+        ]
+        assert len(update_calls) == 1
+        params = update_calls[0].args[1]
+        assert params["units"] == Decimal("15")
+        # avg_cost = (100*10 + 80*5) / 15 = 1400/15
+        expected_avg = (Decimal("100") * Decimal("10") + Decimal("80") * Decimal("5")) / Decimal("15")
+        assert params["avg_cost"] == expected_avg
+        assert params["cost_basis"] == expected_avg * Decimal("15")
+        # PnL: (120-100)*10 + (120-80)*5 = 200 + 200 = 400
+        assert params["upnl"] == Decimal("400")
+
+    def test_duplicate_instrument_inserts_once_with_aggregated_values(self) -> None:
+        """Two broker positions for a new instrument should produce a single INSERT."""
+        p1 = _pos(
+            instrument_id=99,
+            units=Decimal("10"),
+            open_price=Decimal("100"),
+            current_price=Decimal("120"),
+        )
+        p2 = _pos(
+            instrument_id=99,
+            units=Decimal("5"),
+            open_price=Decimal("80"),
+            current_price=Decimal("120"),
+        )
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("0"))
+        result = sync_portfolio(conn, _portfolio([p1, p2]), now=_NOW)
+
+        assert result.positions_opened_externally == 1
+
+        insert_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if isinstance(c.args[0], str) and "INSERT INTO positions" in c.args[0]
+        ]
+        assert len(insert_calls) == 1
+        params = insert_calls[0].args[1]
+        assert params["units"] == Decimal("15")
+        expected_avg = (Decimal("100") * Decimal("10") + Decimal("80") * Decimal("5")) / Decimal("15")
+        assert params["price"] == expected_avg
+
+
+class TestReopenedPositionOpenDate:
+    """ON CONFLICT should update open_date for reopened positions."""
+
+    def test_upsert_includes_open_date_in_conflict_clause(self) -> None:
+        """Verify the INSERT's ON CONFLICT SET includes open_date."""
+        pos = _pos(instrument_id=99)
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("0"))
+        sync_portfolio(conn, _portfolio([pos]), now=_NOW)
+
+        insert_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if isinstance(c.args[0], str) and "INSERT INTO positions" in c.args[0]
+        ]
+        sql = insert_calls[0].args[0]
+        assert "open_date      = EXCLUDED.open_date" in sql

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -1,0 +1,276 @@
+"""Tests for app.services.portfolio_sync — broker→local reconciliation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+from app.providers.broker import BrokerPortfolio, BrokerPosition
+from app.services.portfolio_sync import PortfolioSyncResult, sync_portfolio
+
+_NOW = datetime(2026, 4, 10, 5, 30, tzinfo=UTC)
+
+
+def _pos(
+    instrument_id: int = 1,
+    units: Decimal = Decimal("10"),
+    open_price: Decimal = Decimal("100"),
+    current_price: Decimal = Decimal("110"),
+) -> BrokerPosition:
+    return BrokerPosition(
+        instrument_id=instrument_id,
+        units=units,
+        open_price=open_price,
+        current_price=current_price,
+        raw_payload={},
+    )
+
+
+def _portfolio(
+    positions: list[BrokerPosition] | None = None,
+    available_cash: Decimal = Decimal("5000"),
+) -> BrokerPortfolio:
+    return BrokerPortfolio(
+        positions=positions or [],
+        available_cash=available_cash,
+        raw_payload={},
+    )
+
+
+def _mock_conn(
+    local_positions: list[tuple[int, Decimal]] | None = None,
+    local_cash: Decimal = Decimal("0"),
+) -> MagicMock:
+    """Build a mock connection with canned SELECT/cursor results.
+
+    The service uses two patterns:
+    - ``conn.cursor(row_factory=...)`` for SELECTs (returns dict rows)
+    - ``conn.execute(...)`` for writes (UPDATE/INSERT)
+
+    Cursor SQL dispatch matches on substrings.  Priority:
+    - 'FROM positions' → local position rows as dicts
+    - 'FROM cash_ledger' → local cash sum as dict
+    - Everything else → default MagicMock
+
+    Note: substring matching cannot detect structural SQL errors like
+    wrong column order or missing WHERE clauses.
+    """
+    conn = MagicMock()
+    raw_positions = local_positions or []
+
+    # Dict-style rows matching dict_row factory output.
+    position_rows = [{"instrument_id": iid, "current_units": units} for iid, units in raw_positions]
+
+    def _cursor_execute(sql: str, params: dict[str, Any] | None = None) -> MagicMock:
+        result = MagicMock()
+        stripped = sql.strip()
+        if "FROM positions" in stripped:
+            result.fetchall.return_value = position_rows
+        elif "FROM cash_ledger" in stripped:
+            result.fetchone.return_value = {"total": local_cash}
+        return result
+
+    mock_cursor = MagicMock()
+    mock_cursor.execute.side_effect = _cursor_execute
+    mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_cursor.__exit__ = MagicMock(return_value=False)
+    conn.cursor.return_value = mock_cursor
+
+    return conn
+
+
+class TestExistingPositionUpdate:
+    """Broker position already exists locally → UPDATE."""
+
+    def test_updates_units_and_pnl(self) -> None:
+        pos = _pos(instrument_id=42, units=Decimal("5"), open_price=Decimal("100"), current_price=Decimal("120"))
+        conn = _mock_conn(
+            local_positions=[(42, Decimal("5"))],
+            local_cash=Decimal("5000"),
+        )
+        result = sync_portfolio(conn, _portfolio([pos], Decimal("5000")), now=_NOW)
+
+        assert result.positions_updated == 1
+        assert result.positions_opened_externally == 0
+        assert result.positions_closed_externally == 0
+
+    def test_passes_correct_params_to_update(self) -> None:
+        pos = _pos(instrument_id=42, units=Decimal("5"), open_price=Decimal("100"), current_price=Decimal("120"))
+        conn = _mock_conn(local_positions=[(42, Decimal("5"))], local_cash=Decimal("5000"))
+        sync_portfolio(conn, _portfolio([pos], Decimal("5000")), now=_NOW)
+
+        # Find the UPDATE call
+        update_calls = [
+            c for c in conn.execute.call_args_list if isinstance(c.args[0], str) and "UPDATE positions SET" in c.args[0]
+        ]
+        assert len(update_calls) == 1
+        params = update_calls[0].args[1]
+        assert params["iid"] == 42
+        assert params["units"] == Decimal("5")
+        # unrealized = (120 - 100) * 5 = 100
+        assert params["upnl"] == Decimal("100")
+        assert params["now"] == _NOW
+
+
+class TestExternallyOpenedPosition:
+    """Broker has a position not in local DB → INSERT."""
+
+    def test_counts_as_opened_externally(self) -> None:
+        pos = _pos(instrument_id=99)
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("0"))
+        result = sync_portfolio(conn, _portfolio([pos]), now=_NOW)
+
+        assert result.positions_opened_externally == 1
+        assert result.positions_updated == 0
+
+    def test_inserts_with_correct_cost_basis(self) -> None:
+        pos = _pos(instrument_id=99, units=Decimal("3"), open_price=Decimal("50"), current_price=Decimal("55"))
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("0"))
+        sync_portfolio(conn, _portfolio([pos]), now=_NOW)
+
+        insert_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if isinstance(c.args[0], str) and "INSERT INTO positions" in c.args[0]
+        ]
+        assert len(insert_calls) == 1
+        params = insert_calls[0].args[1]
+        assert params["iid"] == 99
+        assert params["units"] == Decimal("3")
+        assert params["price"] == Decimal("50")
+        # cost_basis = open_price * units = 150
+        assert params["cost"] == Decimal("150")
+        # unrealized = (55 - 50) * 3 = 15
+        assert params["upnl"] == Decimal("15")
+
+
+class TestExternallyClosedPosition:
+    """Local position absent from broker → zero out."""
+
+    def test_zeros_out_missing_position(self) -> None:
+        conn = _mock_conn(
+            local_positions=[(7, Decimal("10"))],
+            local_cash=Decimal("0"),
+        )
+        # Empty broker portfolio — position 7 was closed externally.
+        result = sync_portfolio(conn, _portfolio([]), now=_NOW)
+
+        assert result.positions_closed_externally == 1
+        assert result.positions_updated == 0
+
+    def test_sends_zero_units_in_update(self) -> None:
+        conn = _mock_conn(
+            local_positions=[(7, Decimal("10"))],
+            local_cash=Decimal("0"),
+        )
+        sync_portfolio(conn, _portfolio([]), now=_NOW)
+
+        update_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if isinstance(c.args[0], str) and "UPDATE positions SET" in c.args[0] and "current_units  = 0" in c.args[0]
+        ]
+        assert len(update_calls) == 1
+        assert update_calls[0].args[1]["iid"] == 7
+
+
+class TestCashReconciliation:
+    """Cash sync records a broker_sync event for non-trivial deltas."""
+
+    def test_records_positive_delta(self) -> None:
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("1000"))
+        result = sync_portfolio(conn, _portfolio([], Decimal("1500")), now=_NOW)
+
+        assert result.cash_delta == Decimal("500")
+        assert result.broker_cash == Decimal("1500")
+        assert result.local_cash == Decimal("1000")
+
+        insert_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if isinstance(c.args[0], str) and "INSERT INTO cash_ledger" in c.args[0]
+        ]
+        assert len(insert_calls) == 1
+        params = insert_calls[0].args[1]
+        assert params["amount"] == Decimal("500")
+        assert params["time"] == _NOW
+
+    def test_records_negative_delta(self) -> None:
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("2000"))
+        result = sync_portfolio(conn, _portfolio([], Decimal("1800")), now=_NOW)
+
+        assert result.cash_delta == Decimal("-200")
+
+    def test_skips_insert_within_tolerance(self) -> None:
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("1000"))
+        result = sync_portfolio(conn, _portfolio([], Decimal("1000.005")), now=_NOW)
+
+        assert result.cash_delta == Decimal("0.005")
+        # No cash_ledger INSERT because delta < 0.01 tolerance.
+        insert_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if isinstance(c.args[0], str) and "INSERT INTO cash_ledger" in c.args[0]
+        ]
+        assert len(insert_calls) == 0
+
+    def test_exact_tolerance_boundary_skips(self) -> None:
+        """Delta exactly at tolerance (0.01) is NOT greater than tolerance → skip."""
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("1000"))
+        sync_portfolio(conn, _portfolio([], Decimal("1000.01")), now=_NOW)
+
+        insert_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if isinstance(c.args[0], str) and "INSERT INTO cash_ledger" in c.args[0]
+        ]
+        assert len(insert_calls) == 0
+
+    def test_just_above_tolerance_records(self) -> None:
+        """Delta just above tolerance triggers the insert."""
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("1000"))
+        sync_portfolio(conn, _portfolio([], Decimal("1000.011")), now=_NOW)
+
+        insert_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if isinstance(c.args[0], str) and "INSERT INTO cash_ledger" in c.args[0]
+        ]
+        assert len(insert_calls) == 1
+
+
+class TestEmptyPortfolio:
+    """Broker returns zero positions and zero cash."""
+
+    def test_empty_broker_no_local_state(self) -> None:
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("0"))
+        result = sync_portfolio(conn, _portfolio([], Decimal("0")), now=_NOW)
+
+        assert result == PortfolioSyncResult(
+            positions_updated=0,
+            positions_opened_externally=0,
+            positions_closed_externally=0,
+            cash_delta=Decimal("0"),
+            broker_cash=Decimal("0"),
+            local_cash=Decimal("0"),
+        )
+
+
+class TestMixedScenario:
+    """Multiple positions: one updated, one new, one closed."""
+
+    def test_all_three_reconciliation_paths(self) -> None:
+        broker_positions = [
+            _pos(instrument_id=1, units=Decimal("10")),  # exists locally → update
+            _pos(instrument_id=2, units=Decimal("5")),  # new → opened externally
+        ]
+        local = [(1, Decimal("10")), (3, Decimal("8"))]  # 3 missing from broker → closed
+
+        conn = _mock_conn(local_positions=local, local_cash=Decimal("0"))
+        result = sync_portfolio(conn, _portfolio(broker_positions), now=_NOW)
+
+        assert result.positions_updated == 1
+        assert result.positions_opened_externally == 1
+        assert result.positions_closed_externally == 1

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -145,6 +145,38 @@ class TestExternallyOpenedPosition:
         # unrealized = (55 - 50) * 3 = 15
         assert params["upnl"] == Decimal("15")
 
+    def test_open_date_defaults_to_now_without_raw_field(self) -> None:
+        pos = _pos(instrument_id=99)
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("0"))
+        sync_portfolio(conn, _portfolio([pos]), now=_NOW)
+
+        insert_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if isinstance(c.args[0], str) and "INSERT INTO positions" in c.args[0]
+        ]
+        assert insert_calls[0].args[1]["date"] == _NOW.date()
+
+    def test_open_date_extracted_from_raw_payload(self) -> None:
+        pos = BrokerPosition(
+            instrument_id=99,
+            units=Decimal("5"),
+            open_price=Decimal("100"),
+            current_price=Decimal("110"),
+            raw_payload={"openDateTime": "2026-03-15T10:30:00Z"},
+        )
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("0"))
+        sync_portfolio(conn, _portfolio([pos]), now=_NOW)
+
+        insert_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if isinstance(c.args[0], str) and "INSERT INTO positions" in c.args[0]
+        ]
+        from datetime import date
+
+        assert insert_calls[0].args[1]["date"] == date(2026, 3, 15)
+
 
 class TestExternallyClosedPosition:
     """Local position absent from broker → zero out."""

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -113,11 +113,12 @@ class TestExistingPositionUpdate:
         params = update_calls[0].args[1]
         assert params["iid"] == 42
         assert params["units"] == Decimal("5")
-        assert params["avg_cost"] == Decimal("100")
-        assert params["cost_basis"] == Decimal("500")
         # unrealized = (120 - 100) * 5 = 100
         assert params["upnl"] == Decimal("100")
         assert params["now"] == _NOW
+        # avg_cost/cost_basis must NOT appear — local cost basis is authoritative.
+        assert "avg_cost" not in params
+        assert "cost_basis" not in params
 
 
 class TestExternallyOpenedPosition:
@@ -420,12 +421,10 @@ class TestMultiPositionSync:
         assert len(update_calls) == 1
         params = update_calls[0].args[1]
         assert params["units"] == Decimal("15")
-        # avg_cost = (100*10 + 80*5) / 15 = 1400/15
-        expected_avg = (Decimal("100") * Decimal("10") + Decimal("80") * Decimal("5")) / Decimal("15")
-        assert params["avg_cost"] == expected_avg
-        assert params["cost_basis"] == expected_avg * Decimal("15")
         # PnL: (120-100)*10 + (120-80)*5 = 200 + 200 = 400
         assert params["upnl"] == Decimal("400")
+        # avg_cost/cost_basis must NOT be overwritten from broker data.
+        assert "avg_cost" not in params
 
     def test_duplicate_instrument_inserts_once_with_aggregated_values(self) -> None:
         """Two broker positions for a new instrument should produce a single INSERT."""


### PR DESCRIPTION
Closes #175

## What changed

1. **`app/providers/broker.py`** — Added `BrokerPosition` and `BrokerPortfolio` dataclasses to the abstract broker interface. Added `get_portfolio()` abstract method.

2. **`app/providers/implementations/etoro_broker.py`** — Implemented `get_portfolio()` against the real eToro `/portfolio` endpoint. Added `_persist_raw()` helper that writes the raw JSON response to disk before `raise_for_status()` (prevention log requirement). Parses positions from `clientPortfolio.positions` and cash from `clientPortfolio.credit`.

3. **`app/services/portfolio_sync.py`** — New service module. `sync_portfolio()` reconciles a broker portfolio snapshot against local `positions` and `cash_ledger` tables:
   - **Existing positions**: UPDATE units and unrealized P&L
   - **Externally opened**: INSERT with ON CONFLICT upsert (positions opened via eToro UI or copy trading)
   - **Externally closed**: zero out units for local positions absent from broker
   - **Cash**: record a `broker_sync` event in `cash_ledger` when delta exceeds $0.01 tolerance

4. **`app/workers/scheduler.py`** — Wired `daily_portfolio_sync` job at 05:30 UTC (before `morning_candidate_review` at 06:00). Uses `_load_etoro_credentials` pattern.

5. **`app/jobs/runtime.py`** — Registered `daily_portfolio_sync` in `_INVOKERS`.

## Why

The system needs to know what positions it holds and how much cash is available before it can make and execute trade recommendations. This is the read-from-broker side — no orders are placed or broker state modified.

## Schema / migration impact

None. Uses existing `positions` and `cash_ledger` tables.

## Invariants checked

- No external I/O inside DB transactions — broker HTTP call completes before `psycopg.connect()`
- Atomic upsert via `ON CONFLICT (instrument_id) DO UPDATE` for externally opened positions
- Named column access via `dict_row` — no positional `row[0]`
- All SQL uses parameterised queries (`%(name)s`)
- Raw API response persisted to disk before `raise_for_status()` (can debug 4xx/5xx after the fact)
- Cash tolerance boundary uses strict `>` (delta exactly at $0.01 is not recorded)

## Failure paths considered

- Empty portfolio (zero positions, zero cash) — produces a no-op sync result
- Missing `credit` field in API response — defaults to `Decimal("0")`
- Position entries with missing `instrumentID` — skipped
- Non-dict position entries — skipped
- `fetchone()` returning `None` for cash query — defaults to `Decimal("0")`

## Tests added

**Broker provider** (`test_broker_provider.py` — 4 new tests):
- `test_returns_positions_and_cash` — parses full portfolio response
- `test_empty_portfolio` — handles missing positions array
- `test_missing_credit_defaults_to_zero` — handles missing credit field
- `test_calls_correct_endpoint` — verifies HTTP path

**Sync service** (`test_portfolio_sync.py` — 13 tests):
- Existing position update: counts + correct UPDATE params (units, P&L, timestamp)
- Externally opened: counts + correct INSERT params (cost basis, unrealized P&L)
- Externally closed: counts + zeroing UPDATE with correct instrument ID
- Cash reconciliation: positive delta, negative delta, within-tolerance skip
- Cash tolerance boundaries: exact boundary skips, just-above-boundary records
- Empty portfolio with no local state: produces zero-delta no-op result
- Mixed scenario: all three reconciliation paths in one call

## Conscious tradeoffs

- Portfolio sync is read-only from broker, write-only to local DB. No attempt to resolve conflicts or place corrective orders — that's execution layer responsibility.
- Cash reconciliation uses a simple delta from `SUM(cash_ledger)`. Does not attempt to attribute the delta to specific events (fees, dividends, deposits).
- `_persist_raw` writes to `data/raw/etoro_broker/` which is gitignored. No structured persistence to DB for raw payloads — the disk copy is for debugging only.

## Tech debt opened

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)