### PR TITLE
fix(#182): correct eToro portfolio field names and guard empty responses

### DIFF
--- a/.claude/skills/engineering/python-hygiene.md
+++ b/.claude/skills/engineering/python-hygiene.md
@@ -58,6 +58,15 @@ Within each `from X import a, b, c`: names alphabetically sorted. Blank line bet
 2. third-party
 3. first-party
 
+**All imports at the top of the file.** Never import inside a function or method body. This includes test files — `import pytest` belongs at module level with the other imports, not inside a test case. Ruff does not enforce this by default (`PLC0415` is opt-in), so it is on the author to catch it in pre-flight review.
+
+Exceptions are rare and narrow:
+
+- Avoiding a genuine circular import that cannot be resolved by rearranging modules.
+- Lazy-loading an expensive optional dependency that is only used on a cold path.
+
+Every inline import must have a comment explaining *which* exception applies.
+
 Run `uv run ruff check --select I .` to verify. Any import sort violation fails CI.
 
 ## Error escalation from helpers

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -430,12 +430,25 @@ class EtoroBrokerProvider(BrokerProvider):
             iid = pos.get("instrumentID")
             if iid is None:
                 continue
+            # eToro's /portfolio endpoint returns `openRate` for the entry
+            # price and does NOT include a current price field at all.
+            # Current market price must be fetched separately from
+            # /api/v1/market-data/instruments/rates if needed.
+            #
+            # We set current_price = open_price as a neutral placeholder so
+            # the PnL aggregation `(current_price - open_price) * units`
+            # evaluates to zero instead of `(0 - open_rate) * units` (a
+            # large negative number). The portfolio API computes live
+            # unrealised PnL from the `quotes` table on read, so this
+            # placeholder is only used by sync-time aggregation and is
+            # never surfaced to the dashboard.
+            open_rate = Decimal(str(pos.get("openRate", 0)))
             positions.append(
                 BrokerPosition(
                     instrument_id=int(iid),
                     units=Decimal(str(pos.get("units", 0))),
-                    open_price=Decimal(str(pos.get("openPrice", 0))),
-                    current_price=Decimal(str(pos.get("currentPrice", 0))),
+                    open_price=open_rate,
+                    current_price=open_rate,
                     raw_payload=pos,
                 )
             )

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -211,6 +211,22 @@ def sync_portfolio(
             )
 
     # 2. Zero out local positions absent from broker.
+    #
+    # Guard: if the broker returned zero positions but we have local open
+    # positions, treat this as a likely API failure (auth lapse, stale
+    # session, or transient error returning HTTP 200 with an empty body)
+    # rather than a legitimate "user liquidated everything" event.
+    # Raising here marks the job as failed in `job_runs`, alerting the
+    # operator, and prevents silent data loss on the positions table.
+    # Legitimate liquidation is expected to be a per-position event, not
+    # a whole-portfolio wipe in a single cycle.
+    if not broker_positions and local_rows:
+        raise RuntimeError(
+            f"Broker returned empty positions but {len(local_rows)} local "
+            f"position(s) exist — refusing to zero out local state. "
+            f"Likely an upstream API failure (auth, session, or transient)."
+        )
+
     for row in local_rows:
         iid = row["instrument_id"]
         if iid not in broker_positions:

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -547,6 +547,15 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 
 ---
 
+### Guard-ordering in raise-before-write tests
+
+- First seen in: #184
+- Symptom: Test for a guard that is supposed to raise *before* any writes asserted only that a specific write kind (zero-out UPDATEs) was absent from `conn.execute.call_args_list` after the exception. A broken guard that raised *after* one or more real writes could still satisfy the assertion as long as the writes were of a different shape.
+- Prevention: When asserting "guard prevents writes," check that the entire write-channel call list is empty at the point of raising — e.g. `assert conn.execute.call_args_list == []` if the production code routes all writes through `conn.execute` — rather than filtering for the specific write shape the guard is supposed to prevent. The strongest form of the assertion is "zero writes of any kind," not "zero writes of the kind I expected."
+- Enforced in: this prevention log
+
+---
+
 ### Fragile SQL string matching in tests breaks silently under whitespace changes
 
 - First seen in: #184

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -544,3 +544,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: FCF calculation `operating_cf - capex` was incorrect for filers reporting CapEx as a negative number (cash outflow sign convention), inflating FCF.
 - Prevention: When subtracting CapEx from operating CF, use `abs(capex)` to normalise for sign convention differences. Apply to both latest-snapshot and historical-snapshot builders.
 - Enforced in: this prevention log
+
+---
+
+### Fragile SQL string matching in tests breaks silently under whitespace changes
+
+- First seen in: #184
+- Symptom: Test asserted against the exact SQL fragment `"current_units  = 0"` (two spaces, matching column alignment in the production query). Any reformat that changes whitespace would make the substring match return no hits, and the `assert len(matches) == 1` would silently pass or a `not in` assertion would become vacuously true — the test would stop catching regressions without failing.
+- Prevention: When matching raw SQL strings in tests, normalise whitespace first (`re.sub(r"\s+", " ", sql)`) and match the normalised form, or — better — extract a named helper (e.g. `_is_zero_out_update(sql)`) so the fragile concern is isolated. Never embed whitespace-alignment in a test literal.
+- Enforced in: this prevention log

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -554,6 +554,10 @@ class TestRequestBodyShape:
 # get_portfolio
 # ---------------------------------------------------------------------------
 
+# Field names match the real eToro /portfolio endpoint:
+# - `openRate` (not `openPrice`) is the entry price
+# - no current-price field exists in this endpoint — current prices
+#   must be fetched separately from /instruments/rates
 FIXTURE_FULL_PORTFOLIO_RESPONSE = {
     "clientPortfolio": {
         "positions": [
@@ -561,15 +565,13 @@ FIXTURE_FULL_PORTFOLIO_RESPONSE = {
                 "instrumentID": 1001,
                 "positionID": 98765,
                 "units": 5.0,
-                "openPrice": 150.00,
-                "currentPrice": 160.00,
+                "openRate": 150.00,
             },
             {
                 "instrumentID": 1002,
                 "positionID": 98766,
                 "units": 10.0,
-                "openPrice": 50.00,
-                "currentPrice": 48.50,
+                "openRate": 50.00,
             },
         ],
         "credit": 50000.50,
@@ -599,11 +601,17 @@ class TestGetPortfolio:
         assert p1.instrument_id == 1001
         assert p1.units == Decimal("5.0")
         assert p1.open_price == Decimal("150.0")
-        assert p1.current_price == Decimal("160.0")
+        # current_price is a neutral placeholder (= open_price) because the
+        # portfolio endpoint doesn't provide a current price. This makes
+        # sync-time PnL aggregation evaluate to zero instead of producing
+        # bogus negative values.
+        assert p1.current_price == Decimal("150.0")
 
         p2 = result.positions[1]
         assert p2.instrument_id == 1002
         assert p2.units == Decimal("10.0")
+        assert p2.open_price == Decimal("50.0")
+        assert p2.current_price == Decimal("50.0")
 
     def test_empty_portfolio(self, _mock_persist: MagicMock) -> None:
         mock_resp = MagicMock()

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
@@ -15,6 +16,20 @@ from app.services.portfolio_sync import (
 )
 
 _NOW = datetime(2026, 4, 10, 5, 30, tzinfo=UTC)
+
+
+def _is_zero_out_update(sql_arg: Any) -> bool:
+    """True if ``sql_arg`` is the zero-out UPDATE SQL.
+
+    Whitespace-tolerant: the production SQL aligns column names with
+    extra spaces (``current_units  = 0``), but the test must not break
+    if that alignment ever changes.  We normalise runs of whitespace
+    to a single space before substring-matching.
+    """
+    if not isinstance(sql_arg, str):
+        return False
+    normalised = re.sub(r"\s+", " ", sql_arg)
+    return "UPDATE positions SET" in normalised and "current_units = 0" in normalised
 
 
 def _pos(
@@ -215,11 +230,7 @@ class TestExternallyClosedPosition:
         broker_pos = _pos(instrument_id=8, units=Decimal("1"))
         sync_portfolio(conn, _portfolio([broker_pos]), now=_NOW)
 
-        update_calls = [
-            c
-            for c in conn.execute.call_args_list
-            if isinstance(c.args[0], str) and "UPDATE positions SET" in c.args[0] and "current_units  = 0" in c.args[0]
-        ]
+        update_calls = [c for c in conn.execute.call_args_list if _is_zero_out_update(c.args[0])]
         assert len(update_calls) == 1
         assert update_calls[0].args[1]["iid"] == 7
 
@@ -255,9 +266,7 @@ class TestEmptyBrokerGuard:
             sync_portfolio(conn, _portfolio([]), now=_NOW)
 
         # No zero-out UPDATEs must have been issued.
-        zero_updates = [
-            c for c in conn.execute.call_args_list if isinstance(c.args[0], str) and "current_units  = 0" in c.args[0]
-        ]
+        zero_updates = [c for c in conn.execute.call_args_list if _is_zero_out_update(c.args[0])]
         assert zero_updates == []
 
     def test_empty_broker_with_empty_local_does_not_raise(self) -> None:

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -186,25 +186,34 @@ class TestExternallyOpenedPosition:
 
 
 class TestExternallyClosedPosition:
-    """Local position absent from broker → zero out."""
+    """Local position absent from broker → zero out.
+
+    Tests use a non-empty broker portfolio (containing at least one
+    unrelated position) so the whole-portfolio-empty guard does not
+    fire.  See ``TestEmptyBrokerGuard`` for that path.
+    """
 
     def test_zeros_out_missing_position(self) -> None:
+        # Local has two open positions; broker only reports one of them.
+        # This isolates the close path — no insert side-effect from a
+        # broker-only instrument.
         conn = _mock_conn(
-            local_positions=[(7, Decimal("10"))],
+            local_positions=[(7, Decimal("10")), (8, Decimal("1"))],
             local_cash=Decimal("0"),
         )
-        # Empty broker portfolio — position 7 was closed externally.
-        result = sync_portfolio(conn, _portfolio([]), now=_NOW)
+        broker_pos = _pos(instrument_id=8, units=Decimal("1"))
+        result = sync_portfolio(conn, _portfolio([broker_pos]), now=_NOW)
 
         assert result.positions_closed_externally == 1
-        assert result.positions_updated == 0
+        assert result.positions_opened_externally == 0
 
     def test_sends_zero_units_in_update(self) -> None:
         conn = _mock_conn(
-            local_positions=[(7, Decimal("10"))],
+            local_positions=[(7, Decimal("10")), (8, Decimal("1"))],
             local_cash=Decimal("0"),
         )
-        sync_portfolio(conn, _portfolio([]), now=_NOW)
+        broker_pos = _pos(instrument_id=8, units=Decimal("1"))
+        sync_portfolio(conn, _portfolio([broker_pos]), now=_NOW)
 
         update_calls = [
             c
@@ -213,6 +222,52 @@ class TestExternallyClosedPosition:
         ]
         assert len(update_calls) == 1
         assert update_calls[0].args[1]["iid"] == 7
+
+
+class TestEmptyBrokerGuard:
+    """Empty broker + non-empty local state → refuse to zero out.
+
+    A legitimate "user liquidated everything in one cycle" scenario is
+    indistinguishable from an upstream API failure returning HTTP 200
+    with an empty body.  To prevent silent data loss on the positions
+    table, the sync raises — the tracked-job wrapper records the failure
+    in ``job_runs`` so operators are alerted.
+    """
+
+    def test_raises_when_broker_empty_but_local_has_positions(self) -> None:
+        import pytest
+
+        conn = _mock_conn(
+            local_positions=[(7, Decimal("10"))],
+            local_cash=Decimal("0"),
+        )
+        with pytest.raises(RuntimeError, match="empty positions"):
+            sync_portfolio(conn, _portfolio([]), now=_NOW)
+
+    def test_does_not_zero_any_positions_when_raising(self) -> None:
+        import pytest
+
+        conn = _mock_conn(
+            local_positions=[(7, Decimal("10")), (8, Decimal("5"))],
+            local_cash=Decimal("0"),
+        )
+        with pytest.raises(RuntimeError):
+            sync_portfolio(conn, _portfolio([]), now=_NOW)
+
+        # No zero-out UPDATEs must have been issued.
+        zero_updates = [
+            c for c in conn.execute.call_args_list if isinstance(c.args[0], str) and "current_units  = 0" in c.args[0]
+        ]
+        assert zero_updates == []
+
+    def test_empty_broker_with_empty_local_does_not_raise(self) -> None:
+        """Boundary: fully empty on both sides is a valid no-op."""
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("0"))
+        result = sync_portfolio(conn, _portfolio([], Decimal("0")), now=_NOW)
+        assert result.positions_closed_externally == 0
+        assert result.positions_opened_externally == 0
+        assert result.positions_updated == 0
+        assert result.cash_delta == Decimal("0")
 
 
 class TestCashReconciliation:

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -8,6 +8,8 @@ from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from app.providers.broker import BrokerPortfolio, BrokerPosition
 from app.services.portfolio_sync import (
     PortfolioSyncResult,
@@ -246,8 +248,6 @@ class TestEmptyBrokerGuard:
     """
 
     def test_raises_when_broker_empty_but_local_has_positions(self) -> None:
-        import pytest
-
         conn = _mock_conn(
             local_positions=[(7, Decimal("10"))],
             local_cash=Decimal("0"),
@@ -256,8 +256,6 @@ class TestEmptyBrokerGuard:
             sync_portfolio(conn, _portfolio([]), now=_NOW)
 
     def test_does_not_zero_any_positions_when_raising(self) -> None:
-        import pytest
-
         conn = _mock_conn(
             local_positions=[(7, Decimal("10")), (8, Decimal("5"))],
             local_cash=Decimal("0"),

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -252,10 +252,24 @@ class TestEmptyBrokerGuard:
             local_positions=[(7, Decimal("10"))],
             local_cash=Decimal("0"),
         )
-        with pytest.raises(RuntimeError, match="empty positions"):
+        # Match on the distinctive "refusing to zero" phrase from the
+        # guard's error message rather than generic substrings, so an
+        # accidental RuntimeError raised elsewhere in the call stack
+        # would not satisfy this assertion.
+        with pytest.raises(RuntimeError, match="refusing to zero"):
             sync_portfolio(conn, _portfolio([]), now=_NOW)
 
-    def test_does_not_zero_any_positions_when_raising(self) -> None:
+    def test_guard_raises_before_any_write(self) -> None:
+        """Strongest form of the guard test: raise happens before any write.
+
+        The production code's ``conn.execute(...)`` path is used only
+        for writes (UPDATE/INSERT); reads go through
+        ``conn.cursor(...)``.  So if the guard fires *before* the
+        zeroing loop, ``conn.execute.call_args_list`` must be empty at
+        the point of raising.  This catches a broken guard that moves
+        to *after* the zeroing loop (or partway through it) because
+        any UPDATE issued before the raise would leave a recorded call.
+        """
         conn = _mock_conn(
             local_positions=[(7, Decimal("10")), (8, Decimal("5"))],
             local_cash=Decimal("0"),
@@ -263,9 +277,9 @@ class TestEmptyBrokerGuard:
         with pytest.raises(RuntimeError):
             sync_portfolio(conn, _portfolio([]), now=_NOW)
 
-        # No zero-out UPDATEs must have been issued.
-        zero_updates = [c for c in conn.execute.call_args_list if _is_zero_out_update(c.args[0])]
-        assert zero_updates == []
+        # Zero writes must have occurred. Stronger than "no zero-out
+        # updates" — catches any write attempted before the raise.
+        assert conn.execute.call_args_list == []
 
     def test_empty_broker_with_empty_local_does_not_raise(self) -> None:
         """Boundary: fully empty on both sides is a valid no-op."""


### PR DESCRIPTION
## Summary

Fixes two bugs in the broker portfolio sync that together caused silent data loss and bogus `cost_basis=0` rows on externally-opened positions.

Closes #182.

## Bug 1 — parser read non-existent fields

The eToro `/api/v1/trading/info/demo/portfolio` endpoint returns `openRate` (not `openPrice`) for the entry price, and does **not** include a current-price field at all. The parser in `app/providers/implementations/etoro_broker.py` was calling `pos.get("openPrice", 0)` and `pos.get("currentPrice", 0)`, so every broker position came back with `open_price=0` and `current_price=0`.

Downstream consequences:
- Sync-time PnL aggregation `(current_price - open_price) * units` evaluated to `0 - 0 = 0` — merely incorrect for existing positions (dashboard recomputes from `quotes` anyway).
- For **externally-opened positions**, the INSERT computed `cost_basis = open_price * units = 0 * units = 0`. This is the user-visible bug that triggered the dashboard screenshot in #182 — positions showed up with the wrong units because stale zeroed-cost rows were being written every sync cycle.

**Fix**: read `openRate`, and set `current_price = open_price` as a neutral placeholder so sync-time PnL evaluates to zero rather than `(0 - open_rate) * units` (a large negative). The portfolio API computes live unrealised PnL from the `quotes` table on read, so this placeholder never reaches users.

Codex second-opinion confirmed the placeholder is safe across current call sites: `BrokerPosition.current_price` only flows into `_aggregate_by_instrument()` for sync-time `unrealized_pnl`; dashboard and API valuation always recompute from `quotes` or fall back to `cost_basis`.

## Bug 2 — silent zero-out on empty broker response

`sync_portfolio` unconditionally zeroed out every local open position absent from the broker's returned positions list. If the broker returned an empty list with non-empty local state, every local position would be zeroed.

This is **indistinguishable** from a transient upstream API failure returning HTTP 200 with an empty body (auth lapse, stale session, etc.) and is vastly more likely than a user liquidating their entire portfolio in a single sync cycle. Legitimate liquidation is a per-position event.

**Fix**: raise `RuntimeError` when `broker_positions` is empty and `local_rows` is non-empty. The `_tracked_job` wrapper in `app/workers/scheduler.py` catches the exception and records `status='failure'` with `error_msg` in the `job_runs` table, alerting operators without silently destroying the positions table.

The both-empty boundary (no local state, no broker state) remains a valid no-op.

## Security model

No change to the authN/authZ model. This is a **read-from-broker, write-to-local-DB** operation; it never places orders or modifies broker state. The fix strengthens resilience against upstream API failures by failing loudly rather than corrupting local state.

## Conscious tradeoff — partial response truncation

The guard only protects the "fully empty broker positions" failure mode. A **partial** or **truncated** broker response (one or more positions, but not all of them) could still zero out locals missing from that partial response. This is a remaining data-loss shape flagged by Codex. I'm deferring it for this PR because:
- The observed failure in #182 is the fully-empty shape.
- Detecting partial truncation requires a cross-check signal we don't currently have (e.g., a `totalCount` field, or last-known-good snapshot comparison).
- The fix for the partial-truncation path belongs in its own ticket with its own design.

If this matters, I can raise a follow-up issue; flag in review and I'll open it.

## Tests

- `FIXTURE_FULL_PORTFOLIO_RESPONSE` now uses the real `openRate` field names.
- `test_returns_positions_and_cash` asserts the placeholder behaviour (`current_price == open_price`).
- `TestExternallyClosedPosition` reworked so local has two positions and broker reports one — this isolates the close path without a broker-only instrument also triggering an insert side-effect.
- New `TestEmptyBrokerGuard` class:
  - raises `RuntimeError` when broker empty + local non-empty
  - asserts **no** zero-out UPDATEs are issued when raising (order of operations matters)
  - both-empty boundary is a valid no-op

## Codex pre-push review

Second-opinion diff review via Codex returned **no blockers**. Non-blocking notes were addressed: closed-position tests now isolate the close path cleanly, and the both-empty test passes `Decimal("0")` cash to match its "no-op" description.

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run pytest` — 1101 passed, 1 skipped
- [x] `uv run pytest tests/test_broker_provider.py tests/test_portfolio_sync.py` — 65 passed
- [ ] One-time data repair: delete stale `cost_basis=0` rows from the dev DB post-merge (handled separately, outside this PR)
- [ ] Trigger a manual portfolio sync against the live demo account and verify positions show correct aggregated units and non-zero `cost_basis`