### PR TITLE
feat(#180): positions.source column for provenance tracking

### DIFF
--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel
 from app.api._helpers import parse_optional_float
 from app.api.auth import require_session_or_service_token
 from app.db import get_conn
+from app.domain.positions import PositionSource
 
 router = APIRouter(
     prefix="/portfolio",
@@ -55,6 +56,7 @@ class PositionItem(BaseModel):
     cost_basis: float
     market_value: float
     unrealized_pnl: float
+    source: PositionSource
     updated_at: datetime
 
 
@@ -95,6 +97,7 @@ def _parse_position(row: dict[str, object]) -> PositionItem:
         cost_basis=cost_basis,
         market_value=market_value,
         unrealized_pnl=unrealized_pnl,
+        source=row["source"],  # type: ignore[arg-type]
         updated_at=row["updated_at"],  # type: ignore[arg-type]
     )
 
@@ -130,7 +133,7 @@ def get_portfolio(
     positions_sql = """
         SELECT p.instrument_id, i.symbol, i.company_name,
                p.open_date, p.avg_cost, p.current_units, p.cost_basis,
-               p.updated_at,
+               p.source, p.updated_at,
                q.last
         FROM positions p
         JOIN instruments i USING (instrument_id)

--- a/app/domain/positions.py
+++ b/app/domain/positions.py
@@ -1,0 +1,29 @@
+"""Domain types for the positions table.
+
+Shared between the write paths (``order_client`` for eBull-placed
+orders, ``portfolio_sync`` for externally-discovered positions) and
+the read paths (``services.portfolio``, ``api.portfolio``).  Keeping
+the type here avoids a service-to-service import that would otherwise
+have write-side modules depending on each other just to share a
+string literal.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+#: Provenance of the *currently-open* position on a ``positions`` row.
+#:
+#: - ``"ebull"``       — the currently-open units were opened (or
+#:                       reopened) by eBull's execution layer.
+#: - ``"broker_sync"`` — the currently-open units were opened
+#:                       externally (eToro UI, copy trading, etc.) and
+#:                       discovered via the broker portfolio sync.
+#:
+#: "Currently-open" is the key qualifier.  On a close/reopen cycle the
+#: source is reset to reflect the new opener — see the CASE WHEN
+#: logic in ``order_client._update_position_buy`` and
+#: ``portfolio_sync.sync_portfolio``.  Preserving source across a
+#: close/reopen cycle would mislead the execution guard about who is
+#: currently managing the position.
+PositionSource = Literal["ebull", "broker_sync"]

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -315,6 +315,15 @@ def _update_position_buy(
             -- preserve the existing source — an eBull ADD into an
             -- already-open broker_sync position shouldn't claim
             -- ownership of the original external open.
+            --
+            -- Evaluation order: in Postgres ON CONFLICT DO UPDATE,
+            -- every SET expression reads from the *pre-update* row
+            -- snapshot — SET is not a sequential assignment.  So
+            -- `positions.current_units` in this CASE WHEN refers to
+            -- the value BEFORE the `current_units = ...` assignment
+            -- above, regardless of SET ordering.  See
+            -- https://www.postgresql.org/docs/current/sql-insert.html
+            -- (ON CONFLICT DO UPDATE — "existing row" semantics).
             source        = CASE
                 WHEN positions.current_units <= 0
                     THEN EXCLUDED.source

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -299,14 +299,27 @@ def _update_position_buy(
     conn.execute(
         """
         INSERT INTO positions
-            (instrument_id, open_date, avg_cost, current_units, cost_basis, updated_at)
+            (instrument_id, open_date, avg_cost, current_units,
+             cost_basis, source, updated_at)
         VALUES
-            (%(iid)s, %(date)s, %(price)s, %(units)s, %(cost)s, %(now)s)
+            (%(iid)s, %(date)s, %(price)s, %(units)s,
+             %(cost)s, 'ebull', %(now)s)
         ON CONFLICT (instrument_id) DO UPDATE SET
             current_units = positions.current_units + EXCLUDED.current_units,
             cost_basis    = positions.cost_basis + EXCLUDED.cost_basis,
             avg_cost      = (positions.cost_basis + EXCLUDED.cost_basis)
                             / NULLIF(positions.current_units + EXCLUDED.current_units, 0),
+            -- Reset source on reopen: if the existing row is fully
+            -- closed (current_units <= 0) this BUY is reopening it
+            -- under eBull, so source flips to 'ebull'. Otherwise
+            -- preserve the existing source — an eBull ADD into an
+            -- already-open broker_sync position shouldn't claim
+            -- ownership of the original external open.
+            source        = CASE
+                WHEN positions.current_units <= 0
+                    THEN EXCLUDED.source
+                ELSE positions.source
+            END,
             updated_at    = EXCLUDED.updated_at
         """,
         {

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -179,16 +179,28 @@ def sync_portfolio(
                 """
                 INSERT INTO positions
                     (instrument_id, open_date, avg_cost, current_units,
-                     cost_basis, unrealized_pnl, updated_at)
+                     cost_basis, unrealized_pnl, source, updated_at)
                 VALUES
                     (%(iid)s, %(date)s, %(price)s, %(units)s,
-                     %(cost)s, %(upnl)s, %(now)s)
+                     %(cost)s, %(upnl)s, 'broker_sync', %(now)s)
                 ON CONFLICT (instrument_id) DO UPDATE SET
                     current_units  = EXCLUDED.current_units,
                     avg_cost       = EXCLUDED.avg_cost,
                     cost_basis     = EXCLUDED.cost_basis,
                     unrealized_pnl = EXCLUDED.unrealized_pnl,
                     open_date      = EXCLUDED.open_date,
+                    -- Reset source on reopen: if the existing row is
+                    -- fully closed (current_units <= 0) this conflict
+                    -- path is reopening it externally, so the new
+                    -- opener ('broker_sync') becomes the source.
+                    -- Otherwise preserve the existing source (adds to
+                    -- an already-open position shouldn't flip
+                    -- ownership).
+                    source         = CASE
+                        WHEN positions.current_units <= 0
+                            THEN EXCLUDED.source
+                        ELSE positions.source
+                    END,
                     updated_at     = EXCLUDED.updated_at
                 """,
                 {

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -196,6 +196,16 @@ def sync_portfolio(
                     -- Otherwise preserve the existing source (adds to
                     -- an already-open position shouldn't flip
                     -- ownership).
+                    --
+                    -- Evaluation order: in Postgres ON CONFLICT DO
+                    -- UPDATE, every SET expression reads from the
+                    -- *pre-update* row snapshot — SET is not a
+                    -- sequential assignment.  So `positions.current_units`
+                    -- in this CASE WHEN refers to the value BEFORE the
+                    -- `current_units = EXCLUDED.current_units` assignment
+                    -- above, regardless of SET ordering.  See
+                    -- https://www.postgresql.org/docs/current/sql-insert.html
+                    -- (ON CONFLICT DO UPDATE — "existing row" semantics).
                     source         = CASE
                         WHEN positions.current_units <= 0
                             THEN EXCLUDED.source

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -562,3 +562,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: Test asserted against the exact SQL fragment `"current_units  = 0"` (two spaces, matching column alignment in the production query). Any reformat that changes whitespace would make the substring match return no hits, and the `assert len(matches) == 1` would silently pass or a `not in` assertion would become vacuously true — the test would stop catching regressions without failing.
 - Prevention: When matching raw SQL strings in tests, normalise whitespace first (`re.sub(r"\s+", " ", sql)`) and match the normalised form, or — better — extract a named helper (e.g. `_is_zero_out_update(sql)`) so the fragile concern is isolated. Never embed whitespace-alignment in a test literal.
 - Enforced in: this prevention log
+
+---
+
+### SQL-shape tests on single-path calls can't exercise the ON CONFLICT branch
+
+- First seen in: #185
+- Symptom: Tests for the reset-on-reopen `CASE WHEN positions.current_units <= 0 THEN EXCLUDED.source ELSE positions.source END` asserted the CASE WHEN text appears in the captured SQL after calling `sync_portfolio` once with `local_positions=[]`. Because the mock guarantees the INSERT path (no pre-existing row), Postgres never reaches the ON CONFLICT branch — the assertion passes purely because the text is present in the INSERT string, not because the conflict branch was actually evaluated. A broken CASE WHEN (wrong predicate, swapped arms) would still pass.
+- Prevention: SQL-shape assertions are only meaningful for clauses that the single code path being exercised will actually run. For ON CONFLICT / CASE WHEN / trigger-gated logic, either (a) drive the mock to produce an actual conflict and assert on effects, or (b) write a DB-level integration test against a real schema that inserts, reinserts, and reads back the resolved value. Never rely on substring-in-SQL as a proxy for "the conflict branch works."
+- Enforced in: this prevention log

--- a/sql/021_positions_source.sql
+++ b/sql/021_positions_source.sql
@@ -1,0 +1,46 @@
+-- Migration 021: add provenance column to positions
+--
+-- Distinguishes positions created by eBull's execution layer from those
+-- discovered via broker portfolio sync (externally opened via the eToro
+-- UI or copy trading). Required so the execution guard and other
+-- consumers can tell eBull-managed positions from externally-held ones.
+--
+-- Semantics of `source`:
+--   'ebull'       — currently-open position is one eBull actively
+--                   opened or reopened via its own execution layer.
+--   'broker_sync' — currently-open position was opened externally and
+--                   discovered via the eToro portfolio sync.
+--
+-- "Currently-open" is the key qualifier. On reopen (current_units <= 0
+-- then a fresh BUY lands), callers reset `source` to reflect the new
+-- opener — see CASE WHEN logic in order_client._update_position_buy
+-- and portfolio_sync.sync_portfolio.  Preserving source across a
+-- close/reopen cycle would mislead the guard about who is currently
+-- managing the position.
+--
+-- Existing rows are backfilled to 'broker_sync' because the only
+-- INSERT path that ran before this migration was
+-- portfolio_sync (PR #179).  The 'ebull' code path only came online
+-- with PR #181 (execute approved orders, issue #174), and the
+-- positions table has not yet had an eBull-originated row.
+--
+-- Migration strategy:
+--   1. ADD COLUMN with NOT NULL DEFAULT 'broker_sync' — non-volatile
+--      default avoids a table rewrite on Postgres 11+; existing rows
+--      inherit the default atomically with the metadata update.
+--   2. DROP DEFAULT afterwards so every future INSERT must specify
+--      source explicitly.  Prevents silent "default to broker_sync"
+--      bugs on any future INSERT path that forgets the column.
+--
+-- Issue: #180
+
+BEGIN;
+
+ALTER TABLE positions
+    ADD COLUMN source TEXT NOT NULL DEFAULT 'broker_sync'
+    CHECK (source IN ('ebull', 'broker_sync'));
+
+ALTER TABLE positions
+    ALTER COLUMN source DROP DEFAULT;
+
+COMMIT;

--- a/tests/test_api_portfolio.py
+++ b/tests/test_api_portfolio.py
@@ -38,6 +38,7 @@ def _make_position_row(
     avg_cost: float | None = 180.00,
     current_units: float = 10.0,
     cost_basis: float = 1800.00,
+    source: str = "ebull",
     updated_at: datetime = _NOW,
     last: float | None = 190.00,
 ) -> dict[str, Any]:
@@ -50,6 +51,7 @@ def _make_position_row(
         "avg_cost": avg_cost,
         "current_units": current_units,
         "cost_basis": cost_basis,
+        "source": source,
         "updated_at": updated_at,
         "last": last,
     }
@@ -273,6 +275,19 @@ class TestGetPortfolio:
         resp = client.get("/portfolio")
         assert resp.status_code == 200
         assert resp.json()["positions"][0]["open_date"] == "2026-01-15"
+
+    def test_source_exposed_in_response(self) -> None:
+        """source column (ebull vs broker_sync) is passed through to the API response."""
+        ebull_pos = _make_position_row(instrument_id=1, symbol="AAPL", source="ebull")
+        broker_pos = _make_position_row(instrument_id=2, symbol="MSFT", source="broker_sync")
+        _with_conn([[ebull_pos, broker_pos], [_make_cash_row(0.0)]])
+
+        resp = client.get("/portfolio")
+        assert resp.status_code == 200
+        items = resp.json()["positions"]
+        by_symbol = {item["symbol"]: item for item in items}
+        assert by_symbol["AAPL"]["source"] == "ebull"
+        assert by_symbol["MSFT"]["source"] == "broker_sync"
 
     def test_zero_unit_positions_excluded_by_sql_filter(self) -> None:
         """Zero-unit positions are excluded via WHERE filter in the SQL query.

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -687,8 +687,22 @@ class TestUpdatePositionBuySource:
     external open.
     """
 
-    def test_insert_sets_source_to_ebull(self) -> None:
-        """New BUY → INSERT has literal 'ebull'."""
+    def test_insert_emits_source_literal_and_reopen_reset_clause(self) -> None:
+        """INSERT carries the 'ebull' literal AND the reset CASE WHEN.
+
+        With a mocked connection, ``_update_position_buy`` captures a
+        single SQL string per call regardless of whether Postgres would
+        take the INSERT or the ON CONFLICT branch at runtime — the
+        branch decision is made by the planner, not by us.  So the
+        unit-level guarantee we can assert here is SQL *shape*: a
+        single captured string must contain both the hard-coded VALUES
+        literal and the reset CASE WHEN, evaluated together from one
+        call.
+
+        End-to-end verification that Postgres actually routes closed
+        rows through the reset arm is tracked in the DB integration
+        test backlog (#186) — unreachable from a mocked connection.
+        """
         conn = _make_conn([])
         _update_position_buy(
             conn,
@@ -701,30 +715,13 @@ class TestUpdatePositionBuySource:
         assert conn.execute.call_count == 1
         sql = conn.execute.call_args_list[0].args[0]
         normalised = re.sub(r"\s+", " ", sql)
-        # Hard-coded 'ebull' literal in the VALUES list — no parameter
-        # placeholder.
-        assert "'ebull'" in normalised
+
+        # Hard-coded VALUES literal — no parameter placeholder.
         assert "INSERT INTO positions" in normalised
-
-    def test_insert_conflict_clause_resets_source_on_reopen(self) -> None:
-        """ON CONFLICT DO UPDATE uses CASE WHEN to reset source for reopen.
-
-        Reset condition: when the existing row is fully closed
-        (``current_units <= 0``), overwrite source with EXCLUDED
-        (``'ebull'``); otherwise preserve the existing source.  This is
-        expressed in SQL, not Python, so the assertion checks the SQL
-        shape.
-        """
-        conn = _make_conn([])
-        _update_position_buy(
-            conn,
-            instrument_id=42,
-            filled_price=Decimal("100"),
-            filled_units=Decimal("5"),
-            now=_NOW,
-        )
-        sql = conn.execute.call_args_list[0].args[0]
-        normalised = re.sub(r"\s+", " ", sql)
+        assert "'ebull'" in normalised
+        # Reset CASE WHEN: pre-update row fully closed → overwrite
+        # source; otherwise preserve.  Postgres evaluates CASE against
+        # the pre-update row, so SET-list ordering is irrelevant.
         assert "positions.current_units <= 0" in normalised
         assert "EXCLUDED.source" in normalised
         assert "ELSE positions.source" in normalised

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -32,6 +32,7 @@ Cursor call order inside execute_order (demo EXIT):
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
@@ -45,6 +46,7 @@ from app.services.order_client import (
     _load_latest_quote_price,
     _load_position_units,
     _synthetic_fill,
+    _update_position_buy,
     execute_order,
 )
 from app.services.runtime_config import RuntimeConfig, RuntimeConfigCorrupt
@@ -666,3 +668,63 @@ class TestExecuteOrderRuntimeConfigCorrupt:
 
         # No order should have been persisted, no audit row written.
         conn.transaction.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestUpdatePositionBuySource
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePositionBuySource:
+    """Verify _update_position_buy writes ``source='ebull'`` and resets on reopen.
+
+    Issue #180 — the positions ``source`` column identifies who currently
+    manages the open units.  Every eBull-originated BUY must insert
+    ``'ebull'``.  On reopen (ON CONFLICT into a closed row), source must
+    flip to ``'ebull'`` too; on ADD into an already-open position, the
+    existing source must be preserved so an ebull ADD into a
+    broker_sync-owned position doesn't claim ownership of the original
+    external open.
+    """
+
+    def test_insert_sets_source_to_ebull(self) -> None:
+        """New BUY → INSERT has literal 'ebull'."""
+        conn = _make_conn([])
+        _update_position_buy(
+            conn,
+            instrument_id=42,
+            filled_price=Decimal("100"),
+            filled_units=Decimal("5"),
+            now=_NOW,
+        )
+
+        assert conn.execute.call_count == 1
+        sql = conn.execute.call_args_list[0].args[0]
+        normalised = re.sub(r"\s+", " ", sql)
+        # Hard-coded 'ebull' literal in the VALUES list — no parameter
+        # placeholder.
+        assert "'ebull'" in normalised
+        assert "INSERT INTO positions" in normalised
+
+    def test_insert_conflict_clause_resets_source_on_reopen(self) -> None:
+        """ON CONFLICT DO UPDATE uses CASE WHEN to reset source for reopen.
+
+        Reset condition: when the existing row is fully closed
+        (``current_units <= 0``), overwrite source with EXCLUDED
+        (``'ebull'``); otherwise preserve the existing source.  This is
+        expressed in SQL, not Python, so the assertion checks the SQL
+        shape.
+        """
+        conn = _make_conn([])
+        _update_position_buy(
+            conn,
+            instrument_id=42,
+            filled_price=Decimal("100"),
+            filled_units=Decimal("5"),
+            now=_NOW,
+        )
+        sql = conn.execute.call_args_list[0].args[0]
+        normalised = re.sub(r"\s+", " ", sql)
+        assert "positions.current_units <= 0" in normalised
+        assert "EXCLUDED.source" in normalised
+        assert "ELSE positions.source" in normalised

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -543,8 +543,21 @@ class TestPositionSource:
     new opener is reflected.
     """
 
-    def test_insert_sets_source_to_broker_sync(self) -> None:
-        """New broker-discovered position → INSERT has literal 'broker_sync'."""
+    def test_insert_emits_source_literal_and_reopen_reset_clause(self) -> None:
+        """INSERT carries the 'broker_sync' literal AND the reset CASE WHEN.
+
+        With a mocked connection, ``sync_portfolio`` captures a single
+        SQL string per call regardless of whether Postgres would take
+        the INSERT or the ON CONFLICT branch at runtime — the branch
+        decision is made by the planner, not by us.  So the unit-level
+        guarantee we can assert here is SQL *shape*: a single captured
+        string must contain both the hard-coded VALUES literal and the
+        reset CASE WHEN, evaluated together from one call.
+
+        End-to-end verification that Postgres actually routes closed
+        rows through the reset arm is tracked in the DB integration
+        test backlog (#186) — unreachable from a mocked connection.
+        """
         pos = _pos(instrument_id=99)
         conn = _mock_conn(local_positions=[], local_cash=Decimal("0"))
         sync_portfolio(conn, _portfolio([pos]), now=_NOW)
@@ -556,34 +569,14 @@ class TestPositionSource:
         ]
         assert len(insert_calls) == 1
         sql = insert_calls[0].args[0]
-        # Literal — no parameter placeholder — matches the production
-        # SQL's hard-coded 'broker_sync' value.  Whitespace-tolerant
-        # via normalisation to avoid brittle alignment dependence.
         normalised = re.sub(r"\s+", " ", sql)
+
+        # Hard-coded VALUES literal — no parameter placeholder.
         assert "'broker_sync'" in normalised
-
-    def test_insert_conflict_clause_resets_source_on_reopen(self) -> None:
-        """ON CONFLICT DO UPDATE uses CASE WHEN to reset source for reopen.
-
-        The reset semantics are: when the existing row is fully closed
-        (``current_units <= 0``), overwrite source with the incoming
-        ``'broker_sync'``; otherwise preserve the existing source.  This
-        behaviour is expressed in SQL via a CASE WHEN clause, not in
-        Python, so the assertion checks the SQL shape.
-        """
-        pos = _pos(instrument_id=99)
-        conn = _mock_conn(local_positions=[], local_cash=Decimal("0"))
-        sync_portfolio(conn, _portfolio([pos]), now=_NOW)
-
-        insert_calls = [
-            c
-            for c in conn.execute.call_args_list
-            if isinstance(c.args[0], str) and "INSERT INTO positions" in c.args[0]
-        ]
-        sql = insert_calls[0].args[0]
-        normalised = re.sub(r"\s+", " ", sql)
-        # The reset condition: when the existing row is fully closed,
-        # overwrite source from EXCLUDED; otherwise keep what's there.
+        # Reset CASE WHEN: when the pre-update row is fully closed,
+        # overwrite source with EXCLUDED; otherwise preserve the
+        # existing source.  Postgres evaluates CASE against the
+        # pre-update row, so SET-list ordering is irrelevant.
         assert "positions.current_units <= 0" in normalised
         assert "EXCLUDED.source" in normalised
         assert "ELSE positions.source" in normalised

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -533,6 +533,84 @@ class TestMultiPositionSync:
         assert params["price"] == expected_avg
 
 
+class TestPositionSource:
+    """Verify INSERT path writes source='broker_sync' and handles close/reopen.
+
+    Issue #180 — positions rows carry a ``source`` column identifying who
+    currently manages the open units.  The sync path (broker-discovered)
+    must always insert ``'broker_sync'`` and, on reopen (the ON CONFLICT
+    path where the existing row has zero units), reset source so the
+    new opener is reflected.
+    """
+
+    def test_insert_sets_source_to_broker_sync(self) -> None:
+        """New broker-discovered position → INSERT has literal 'broker_sync'."""
+        pos = _pos(instrument_id=99)
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("0"))
+        sync_portfolio(conn, _portfolio([pos]), now=_NOW)
+
+        insert_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if isinstance(c.args[0], str) and "INSERT INTO positions" in c.args[0]
+        ]
+        assert len(insert_calls) == 1
+        sql = insert_calls[0].args[0]
+        # Literal — no parameter placeholder — matches the production
+        # SQL's hard-coded 'broker_sync' value.  Whitespace-tolerant
+        # via normalisation to avoid brittle alignment dependence.
+        normalised = re.sub(r"\s+", " ", sql)
+        assert "'broker_sync'" in normalised
+
+    def test_insert_conflict_clause_resets_source_on_reopen(self) -> None:
+        """ON CONFLICT DO UPDATE uses CASE WHEN to reset source for reopen.
+
+        The reset semantics are: when the existing row is fully closed
+        (``current_units <= 0``), overwrite source with the incoming
+        ``'broker_sync'``; otherwise preserve the existing source.  This
+        behaviour is expressed in SQL via a CASE WHEN clause, not in
+        Python, so the assertion checks the SQL shape.
+        """
+        pos = _pos(instrument_id=99)
+        conn = _mock_conn(local_positions=[], local_cash=Decimal("0"))
+        sync_portfolio(conn, _portfolio([pos]), now=_NOW)
+
+        insert_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if isinstance(c.args[0], str) and "INSERT INTO positions" in c.args[0]
+        ]
+        sql = insert_calls[0].args[0]
+        normalised = re.sub(r"\s+", " ", sql)
+        # The reset condition: when the existing row is fully closed,
+        # overwrite source from EXCLUDED; otherwise keep what's there.
+        assert "positions.current_units <= 0" in normalised
+        assert "EXCLUDED.source" in normalised
+        assert "ELSE positions.source" in normalised
+
+    def test_update_path_does_not_overwrite_source(self) -> None:
+        """Existing open position — UPDATE must NOT touch source.
+
+        When the broker reports units for a position we already have
+        open locally, we update units and unrealized_pnl only.  The
+        source column must not appear in the UPDATE SQL at all — adding
+        it would silently flip ebull-owned positions to broker_sync on
+        every sync cycle.
+        """
+        pos = _pos(instrument_id=42, units=Decimal("5"), open_price=Decimal("100"), current_price=Decimal("120"))
+        conn = _mock_conn(local_positions=[(42, Decimal("5"))], local_cash=Decimal("5000"))
+        sync_portfolio(conn, _portfolio([pos], Decimal("5000")), now=_NOW)
+
+        update_calls = [
+            c for c in conn.execute.call_args_list if isinstance(c.args[0], str) and "UPDATE positions SET" in c.args[0]
+        ]
+        assert len(update_calls) == 1
+        sql = update_calls[0].args[0]
+        # The update path updates only units/pnl/updated_at.  "source ="
+        # must not appear, else we would clobber ebull ownership.
+        assert "source" not in sql.lower()
+
+
 class TestReopenedPositionOpenDate:
     """ON CONFLICT should update open_date for reopened positions."""
 


### PR DESCRIPTION
Closes #180.

## Summary

Adds a `source` column to the `positions` table so downstream consumers (execution guard, audit, UI) can tell eBull-managed positions from externally-held ones without heuristics.

- `'ebull'` — currently-open units opened by eBull's execution layer
- `'broker_sync'` — currently-open units discovered via the broker portfolio sync (eToro UI, copy trading, etc.)

## Semantics: "currently-open", not "first-ever origin"

The column reflects **who manages the currently-open units**, not who first touched the instrument. This distinction only matters on a close/reopen cycle:

| Scenario | Behaviour | Where |
|---|---|---|
| New row inserted by portfolio_sync | `source = 'broker_sync'` | [portfolio_sync.py:182](app/services/portfolio_sync.py#L182) |
| New row inserted by order_client BUY | `source = 'ebull'` | [order_client.py:303](app/services/order_client.py#L303) |
| ON CONFLICT into closed row (`current_units <= 0`) | Reset to `EXCLUDED.source` (new opener) | both writers |
| ON CONFLICT into open row (ADD) | Preserve existing `source` | both writers |

Both writers express the reset in SQL:

```sql
source = CASE
    WHEN positions.current_units <= 0
        THEN EXCLUDED.source
    ELSE positions.source
END,
```

Preserving source across a close/reopen cycle would mislead the execution guard about who currently manages the position. Preserving source on ADD means an eBull ADD into a broker_sync-owned position cannot silently claim ownership of the original external open.

## Migration

[sql/021_positions_source.sql](sql/021_positions_source.sql):

1. `ALTER TABLE positions ADD COLUMN source TEXT NOT NULL DEFAULT 'broker_sync' CHECK (source IN ('ebull', 'broker_sync'))` — non-volatile default avoids a table rewrite and backfills every existing row atomically.
2. `ALTER COLUMN source DROP DEFAULT` — so every future INSERT path must pass `source` explicitly. Prevents silent "fall back to broker_sync" bugs.

**Backfill is safe**: prior to this PR, the only code path that ever inserted into `positions` was `portfolio_sync` (PR #179). The `'ebull'` path only came online with PR #181 (execute approved orders) and has not placed a production order yet — so every existing row is legitimately `broker_sync`. Verified on the dev DB: all 5 existing rows are `broker_sync`.

## Shared type placement

`PositionSource = Literal["ebull", "broker_sync"]` lives in [app/domain/positions.py](app/domain/positions.py) — a new `app/domain/` directory — so `order_client` and `portfolio_sync` don't need to import each other just to share a string literal. The API read path consumes the same type in [app/api/portfolio.py](app/api/portfolio.py#L59).

## Read path

[GET /portfolio](app/api/portfolio.py) now returns `source` per position so the frontend can distinguish provenance without another query. Existing test builder updated; one focused test (`test_source_exposed_in_response`) asserts the pass-through.

## Test coverage

**Unit tests** (new):
- `TestPositionSource` in [test_portfolio_sync.py](tests/test_portfolio_sync.py): INSERT literal is `'broker_sync'`; ON CONFLICT has the reset CASE WHEN; UPDATE path does not touch source.
- `TestUpdatePositionBuySource` in [test_order_client.py](tests/test_order_client.py): INSERT literal is `'ebull'`; ON CONFLICT has the reset CASE WHEN.
- `test_source_exposed_in_response` in [test_api_portfolio.py](tests/test_api_portfolio.py): end-to-end pass-through of source through the API.

**Acknowledged gap**: the reset-on-reopen tests assert SQL shape rather than round-tripping through a real Postgres row. This was a deliberate tradeoff — this repo doesn't yet have a live-DB upsert-integration fixture, and adding one here is out of scope for the provenance work. The migration is exercised end-to-end by `tests/smoke/test_app_boots.py` which runs against the real dev DB, so the column's NOT NULL + CHECK constraint is covered by every smoke run.

**Existing suite**: 1107 passed, 1 skipped. Lint, format, typecheck all clean.

## Second opinion

Ran `codex exec` for a plan review (before coding — caught the original "set once, never modify" design flaw and drove the reset-on-reopen decision) and a diff review (after). The diff review found no concrete bugs and flagged only the SQL-shape-vs-live-DB test gap noted above.

## Security model

No new auth surface. The API endpoint was already behind `require_session_or_service_token`; this PR only adds a readable column to an existing response. No user input flows into SQL — both writers use hard-coded string literals for the `source` value, and the CHECK constraint is the final backstop against any future bad write.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest` (1107 passed)
- [x] Migration applied successfully against dev DB; all 5 existing rows backfilled to `broker_sync`
- [x] `source` column is NOT NULL with no default (verified via `information_schema.columns`)