### PR TITLE
chore: backlog hygiene — README refresh and #162 timeout regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ Long-horizon AI-assisted investment engine for eToro.
 ## Repo structure
 
 - `app/` — services, providers, workers, and API
-- `sql/` — Postgres migrations (001–010)
+- `sql/` — Postgres migrations (001–021 and counting)
 - `docs/` — architecture, scoring model, trading policy, tax engine
 - `.claude/` — project guidance, skills, agents, and hooks
+- `frontend/` — React + Vite operator dashboard (pnpm)
 - `tests/` — pytest suite
 - `docker-compose.yml` — local Postgres
 
@@ -24,20 +25,21 @@ Backend services implemented:
 - Market data (OHLCV, quotes, features)
 - Filings and fundamentals (SEC EDGAR, Companies House, FMP)
 - News and sentiment
+- Thesis engine (#6)
 - Scoring and ranking engine
 - Portfolio manager
 - Execution guard
-
-Remaining backend:
-- Thesis engine (#6)
 - eToro order client (#10)
 - Tax ledger (#11)
 - Coverage tier management (#12)
+- REST API layer (FastAPI) and operator dashboard
+- Ops monitoring (job runs, runtime config, admin page)
+- Broker credential management with durable audit log
 
-Not yet started:
-- API layer (REST endpoints for frontend)
-- Frontend / dashboard
-- Ops monitoring and admin controls
+Currently in flight:
+
+- Copy-trading ingestion (#183 Track 1a), AUM correction (#187
+  Track 1b), browsing UX (#188 Track 1.5), discovery (#189 Track 2)
 
 ## Local setup
 
@@ -45,7 +47,7 @@ Not yet started:
 cp .env.example .env
 docker compose up -d
 uv run uvicorn app.main:app --reload
-cd frontend && npm install && npm run dev
+pnpm --dir frontend install && pnpm --dir frontend dev
 ```
 
 Open <http://localhost:5173>. On a fresh database the app drops into

--- a/tests/test_api_broker_credentials.py
+++ b/tests/test_api_broker_credentials.py
@@ -370,6 +370,27 @@ class TestValidate:
         assert body["auth_valid"] is False
         assert body["env_valid"] is False
 
+    @patch("app.api.broker_credentials.httpx.Client")
+    def test_timeout_error_handled_gracefully(self, mock_client_cls: MagicMock) -> None:
+        """Regression for #162: httpx.TimeoutException must be caught
+        and returned as a 200 with auth_valid=False, not propagated as
+        an unhandled 500. The catch at _probe_etoro's except clause is
+        httpx.HTTPError (the base class), which covers TimeoutException,
+        ReadError, ConnectError, and the rest of the transport-error
+        hierarchy. This test pins the timeout branch explicitly so a
+        future narrowing of the catch cannot silently regress it.
+        """
+        mock_http = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_http)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_http.get.side_effect = httpx.TimeoutException("read timeout")
+
+        resp = client.post("/broker-credentials/validate", json=self._BODY)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["auth_valid"] is False
+        assert body["env_valid"] is False
+
     def test_invalid_environment_rejected(self) -> None:
         body = {**self._BODY, "environment": "production"}
         resp = client.post("/broker-credentials/validate", json=body)


### PR DESCRIPTION
## Summary

Small backlog-hygiene pass that bundles two low-churn cleanups:

1. **README refresh.** The top-level README listed #6/#10/#11/#12 as "remaining backend", frontend bootstrap used `npm`, and the migration range said "001–010". None of that matches reality. Fixed:
   - Moved Thesis engine (#6), eToro order client (#10), Tax ledger (#11), Coverage tier management (#12), REST API, Ops monitoring, and Broker credential management into the implemented list.
   - Added a "Currently in flight" section for the copy-trading tracks (#183 / #187 / #188 / #189).
   - Updated migration range to "001–021 and counting" (`sql/` contains 21 migrations today).
   - Fixed the frontend bootstrap commands to use `pnpm --dir frontend` — matches `frontend/package.json` `packageManager: pnpm@9.12.0`.
   - Added `frontend/` to the repo-structure section (it was missing entirely).

2. **#162 regression test.** Issue #162 reports that `/broker-credentials/validate` could 500 on network timeouts. Empirically the catch in `app/api/broker_credentials.py::_probe_etoro` is already `httpx.HTTPError` (the superclass), which covers `TimeoutException`, `ReadError`, `ConnectError`, and the rest of the transport-error hierarchy. Verified with `issubclass(httpx.TimeoutException, httpx.HTTPError) → True`.

   The catch is over-satisfied, but the regression test for the timeout branch was missing. Added `test_timeout_error_handled_gracefully` in `tests/test_api_broker_credentials.py::TestValidate` alongside the existing `test_network_error_handled_gracefully`. It pins the behaviour so a future narrowing of the except clause cannot silently regress #162.

   **Closes #162.**

## Not in scope

- README rewording beyond the stale facts above. No tone / structure changes.
- No source code changes to `_probe_etoro`. The test pins existing correct behaviour; it is not accompanied by a fix because there is nothing to fix.
- No changes to the copy-trading tracks — those are separate PRs (#183 etc).

## Security model

No auth / authz / credentials surface touched. The new test mocks `httpx.Client` and does not exercise the real eToro surface.

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes (README is markdown, not touched by ruff format)
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 1106 passed, 1 skipped (the new test is part of this run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)