### PR TITLE
feat(#183): ingest eToro copy-trading mirrors (Track 1a)

### DIFF
--- a/.claude/skills/engineering/pre-flight-review.md
+++ b/.claude/skills/engineering/pre-flight-review.md
@@ -83,6 +83,7 @@ Ask:
 - is the upsert key correct?
 - is the write atomic where it needs to be?
 - could two writers race and produce inconsistent versions?
+- **transaction rollback scope:** for every new `raise` inside a function called from a shared transaction, ask: *what other writes have already executed in this transaction when I raise?* If the rollback would discard writes that are not the helper's concern, hoist the raise to the caller **before** those writes run. Document the split scope in the helper's docstring.
 
 ### G. Interface cleanliness
 Check:

--- a/app/providers/broker.py
+++ b/app/providers/broker.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
 from typing import Any, Literal
 
@@ -44,12 +45,63 @@ class BrokerPosition:
 
 
 @dataclass(frozen=True)
+class BrokerMirrorPosition:
+    """A single nested position inside a copy-trader mirror.
+
+    `amount` is the pre-converted USD cost basis reported by eToro.
+    `open_rate` is the entry price in the instrument's native
+    currency; `open_conversion_rate` is the native→USD FX rate at
+    open. Both are required — see spec §1.3 "openConversionRate NOT
+    NULL" for the AUM correctness reason.
+    """
+
+    position_id: int
+    parent_position_id: int
+    instrument_id: int
+    is_buy: bool
+    units: Decimal
+    amount: Decimal
+    initial_amount_in_dollars: Decimal
+    open_rate: Decimal
+    open_conversion_rate: Decimal
+    open_date_time: datetime
+    take_profit_rate: Decimal | None
+    stop_loss_rate: Decimal | None
+    total_fees: Decimal
+    leverage: int
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BrokerMirror:
+    """A single copy-trading mirror (one per copy session with a trader)."""
+
+    mirror_id: int
+    parent_cid: int
+    parent_username: str
+    initial_investment: Decimal
+    deposit_summary: Decimal
+    withdrawal_summary: Decimal
+    available_amount: Decimal
+    closed_positions_net_profit: Decimal
+    stop_loss_percentage: Decimal | None
+    stop_loss_amount: Decimal | None
+    mirror_status_id: int | None
+    mirror_calculation_type: int | None
+    pending_for_closure: bool
+    started_copy_date: datetime
+    positions: Sequence[BrokerMirrorPosition]
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
 class BrokerPortfolio:
-    """Snapshot of the broker account: positions + available cash."""
+    """Snapshot of the broker account: positions + available cash + mirrors."""
 
     positions: Sequence[BrokerPosition]
     available_cash: Decimal
     raw_payload: dict[str, Any]
+    mirrors: Sequence[BrokerMirror] = ()
 
 
 class BrokerProvider(ABC):

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -77,6 +77,20 @@ _STATUS_MAP: dict[str, OrderStatus] = {
 }
 
 
+class PortfolioParseError(Exception):
+    """Raised when a mirrors[] row cannot be parsed safely.
+
+    Directly subclasses Exception (NOT ValueError / TypeError /
+    KeyError / decimal.DecimalException) so the outer parse loop can
+    distinguish it from incidental exceptions and re-raise. Never
+    swallowed by any `except (KeyError, ValueError, TypeError,
+    decimal.DecimalException)` block.
+
+    See spec §2.2.1 for the hierarchy rationale and §2.3.3 for the
+    strict-raise sync contract that depends on it.
+    """
+
+
 class EtoroBrokerProvider(BrokerProvider):
     """
     eToro trading API client.

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import decimal
 import logging
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
@@ -439,6 +440,7 @@ class EtoroBrokerProvider(BrokerProvider):
         portfolio = raw.get("clientPortfolio") or {}
         raw_positions: list[dict[str, Any]] = portfolio.get("positions") or []
         credit = portfolio.get("credit")
+        raw_mirrors: list[Any] = portfolio.get("mirrors") or []
 
         positions: list[BrokerPosition] = []
         for pos in raw_positions:
@@ -474,6 +476,7 @@ class EtoroBrokerProvider(BrokerProvider):
             positions=positions,
             available_cash=Decimal(str(credit)) if credit is not None else Decimal("0"),
             raw_payload=raw,
+            mirrors=tuple(_parse_mirrors_payload(raw_mirrors)),
         )
 
     # ------------------------------------------------------------------
@@ -671,6 +674,45 @@ def _parse_mirror(payload: dict[str, Any]) -> BrokerMirror:
         positions=tuple(parsed_positions),
         raw_payload=payload,
     )
+
+
+def _parse_mirrors_payload(
+    raw_mirrors: Sequence[Any],
+) -> list[BrokerMirror]:
+    """Parse clientPortfolio.mirrors[] into a list of BrokerMirror.
+
+    Implements the outer top-level loop from spec §2.2.2:
+
+    1. Rows that are not dicts, or dicts with no `mirrorID` key, are
+       logged and skipped (the ONLY surviving log-and-skip path —
+       they cannot collide with any known local row, so silent skip
+       is safe).
+    2. Rows with a recognisable `mirrorID` are parsed via
+       `_parse_mirror`. Any failure raises PortfolioParseError —
+       log-and-skip on a known mirror_id would look like a
+       disappearance to §2.3.4's soft-close and silently destroy
+       the local row.
+    3. PortfolioParseError raised by the nested-position wrap inside
+       `_parse_mirror` is re-raised unchanged so the caller sees the
+       `position[idx]` attribution.
+    4. Any other exception escaping `_parse_mirror` (KeyError,
+       ValueError, TypeError, decimal.DecimalException) is
+       fallback-wrapped in PortfolioParseError with mirror_id-only
+       attribution.
+    """
+    mirrors: list[BrokerMirror] = []
+    for m in raw_mirrors:
+        if not isinstance(m, dict) or "mirrorID" not in m:
+            logger.warning("Skipping unrecognisable mirrors[] element: %r", m)
+            continue
+
+        try:
+            mirrors.append(_parse_mirror(m))
+        except PortfolioParseError:
+            raise
+        except (KeyError, ValueError, TypeError, decimal.DecimalException) as exc:
+            raise PortfolioParseError(f"Failed to parse mirror {m.get('mirrorID')!r}: {exc}") from exc
+    return mirrors
 
 
 def _build_result(

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -11,6 +11,7 @@ Trading endpoints are environment-scoped: /demo/ prefix for demo, no prefix for 
 
 from __future__ import annotations
 
+import decimal
 import logging
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -22,6 +23,7 @@ import httpx
 
 from app.config import settings
 from app.providers.broker import (
+    BrokerMirror,
     BrokerMirrorPosition,
     BrokerOrderResult,
     BrokerPortfolio,
@@ -612,6 +614,63 @@ def _parse_iso_datetime(value: str) -> datetime:
     if value.endswith("Z"):
         value = value[:-1] + "+00:00"
     return datetime.fromisoformat(value)
+
+
+def _parse_mirror(payload: dict[str, Any]) -> BrokerMirror:
+    """Parse a top-level copy-trading mirror payload.
+
+    Nested positions are iterated under an inner try/except that
+    wraps (KeyError, ValueError, TypeError, decimal.DecimalException)
+    in PortfolioParseError with mirror_id + position index
+    attribution. See spec §2.2.2 for why the inner wrap is mandatory
+    — without it, a single malformed nested position degrades to a
+    top-level error message that cannot tell the operator *which*
+    row failed.
+
+    Top-level numeric/string extraction may also raise
+    (KeyError / ValueError / TypeError / DecimalException); those
+    propagate up to the outer get_portfolio loop where §2.2.2's
+    fallback wrap catches and re-raises as PortfolioParseError
+    keyed on the mirror_id alone.
+    """
+    raw_positions = payload.get("positions") or []
+    parsed_positions: list[BrokerMirrorPosition] = []
+    for idx, pos in enumerate(raw_positions):
+        try:
+            parsed_positions.append(_parse_mirror_position(pos))
+        except (KeyError, ValueError, TypeError, decimal.DecimalException) as exc:
+            raise PortfolioParseError(f"Mirror {payload.get('mirrorID')!r} position[{idx}]: {exc}") from exc
+
+    def _opt_decimal(key: str) -> Decimal | None:
+        value = payload.get(key)
+        if value is None:
+            return None
+        return Decimal(str(value))
+
+    def _opt_int(key: str) -> int | None:
+        value = payload.get(key)
+        if value is None:
+            return None
+        return int(value)
+
+    return BrokerMirror(
+        mirror_id=int(payload["mirrorID"]),
+        parent_cid=int(payload["parentCID"]),
+        parent_username=str(payload["parentUsername"]),
+        initial_investment=Decimal(str(payload["initialInvestment"])),
+        deposit_summary=Decimal(str(payload.get("depositSummary", "0"))),
+        withdrawal_summary=Decimal(str(payload.get("withdrawalSummary", "0"))),
+        available_amount=Decimal(str(payload["availableAmount"])),
+        closed_positions_net_profit=Decimal(str(payload["closedPositionsNetProfit"])),
+        stop_loss_percentage=_opt_decimal("stopLossPercentage"),
+        stop_loss_amount=_opt_decimal("stopLossAmount"),
+        mirror_status_id=_opt_int("mirrorStatusID"),
+        mirror_calculation_type=_opt_int("mirrorCalculationType"),
+        pending_for_closure=bool(payload.get("pendingForClosure", False)),
+        started_copy_date=_parse_iso_datetime(payload["startedCopyDate"]),
+        positions=tuple(parsed_positions),
+        raw_payload=payload,
+    )
 
 
 def _build_result(

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -22,6 +22,7 @@ import httpx
 
 from app.config import settings
 from app.providers.broker import (
+    BrokerMirrorPosition,
     BrokerOrderResult,
     BrokerPortfolio,
     BrokerPosition,
@@ -560,6 +561,57 @@ def _normalise_order_info_response(
     ``amount``, ``units``, and ``positions[]`` with ``positionID``.
     """
     return _build_result(raw, raw, fallback_ref=broker_order_ref)
+
+
+def _parse_mirror_position(payload: dict[str, Any]) -> BrokerMirrorPosition:
+    """Parse a nested copy-mirror position payload into a typed dataclass.
+
+    Pure normaliser — no I/O, no instance state. Required fields
+    raise KeyError on absence; numeric fields go through
+    Decimal(str(value)) and raise decimal.InvalidOperation
+    (a subclass of decimal.DecimalException) on non-numeric input.
+    The caller (_parse_mirror) wraps both exception types in a
+    PortfolioParseError with position-index attribution.
+
+    openConversionRate is required — see spec §2.2.2 and the
+    74/198 non-USD positions on demo mirror 15712187 that would
+    otherwise be AUM-nonsense.
+    """
+
+    def _opt_decimal(key: str) -> Decimal | None:
+        value = payload.get(key)
+        if value is None:
+            return None
+        return Decimal(str(value))
+
+    return BrokerMirrorPosition(
+        position_id=int(payload["positionID"]),
+        parent_position_id=int(payload["parentPositionID"]),
+        instrument_id=int(payload["instrumentID"]),
+        is_buy=bool(payload["isBuy"]),
+        units=Decimal(str(payload["units"])),
+        amount=Decimal(str(payload["amount"])),
+        initial_amount_in_dollars=Decimal(str(payload["initialAmountInDollars"])),
+        open_rate=Decimal(str(payload["openRate"])),
+        open_conversion_rate=Decimal(str(payload["openConversionRate"])),
+        open_date_time=_parse_iso_datetime(payload["openDateTime"]),
+        take_profit_rate=_opt_decimal("takeProfitRate"),
+        stop_loss_rate=_opt_decimal("stopLossRate"),
+        total_fees=Decimal(str(payload.get("totalFees", "0"))),
+        leverage=int(payload.get("leverage", 1)),
+        raw_payload=payload,
+    )
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    """Parse an ISO-8601 datetime string from an eToro payload.
+
+    eToro returns `2026-04-10T00:00:00Z`; Python's fromisoformat
+    below 3.11 rejects the trailing `Z`, so we normalise to `+00:00`.
+    """
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
 
 
 def _build_result(

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -129,9 +129,16 @@ def _sync_mirrors(
     Must be called inside the caller's transaction — this function
     never commits. Caller owns rollback on any raise.
 
-    Disappearance handling (total → raise, partial → soft-close)
-    lives in the caller or in a follow-up step; this function only
-    handles the rows that are present in the payload.
+    Disappearance handling is split by scope:
+
+    - **Total disappearance** (payload empty AND active local rows
+      exist) is handled by the caller-side pre-write guard in
+      ``sync_portfolio``, which raises BEFORE any writes. Placing
+      it there means a rollback does not silently discard already-
+      written position/cash state from the same sync cycle.
+    - **Partial disappearance** (payload non-empty, some mirrors
+      absent) is handled here as a soft-close step (§2.3.4) after
+      the per-mirror upsert loop.
 
     Single-writer serialisation is guaranteed by JobRuntime's
     APScheduler+JobLock stack (spec §2.3.1); _sync_mirrors does not
@@ -299,12 +306,14 @@ def _sync_mirrors(
             )
             mirror_positions_upserted += 1
 
-    # 4. Disappearance handling (§2.3.4).
+    # 4. Partial-disappearance soft-close (§2.3.4).
     #
     # Total disappearance (payload empty AND active local rows
-    # exist) is handled in step 5 below — it raises to force
-    # operator investigation. Here we soft-close mirrors that have
-    # disappeared from a NON-EMPTY payload.
+    # exist) is handled by the caller-side pre-write guard in
+    # `sync_portfolio` — it raises BEFORE any writes happen so
+    # position/cash work is not silently rolled back. Here we
+    # only handle the partial case: mirrors that have disappeared
+    # from a NON-EMPTY payload are soft-closed.
     payload_mirror_ids = [int(m.mirror_id) for m in mirrors]
 
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -312,16 +321,6 @@ def _sync_mirrors(
         active_local_ids = {int(r["mirror_id"]) for r in cur.fetchall()}
 
     disappeared_ids = sorted(active_local_ids - set(payload_mirror_ids))
-
-    if not payload_mirror_ids and active_local_ids:
-        # Total disappearance — raise for operator investigation.
-        # See step 5 (Task 14) for the exact error contract.
-        raise RuntimeError(
-            "Broker returned empty mirrors[] but "
-            f"{len(active_local_ids)} active local mirror(s) exist — "
-            "refusing to soft-close en masse. Likely upstream API "
-            "regression; investigate before manual cleanup."
-        )
 
     if disappeared_ids:
         conn.execute(
@@ -380,6 +379,30 @@ def sync_portfolio(
             """
         ).fetchall()
     local_instrument_ids = {row["instrument_id"] for row in local_rows}
+
+    # Pre-write mirror guard (§2.3.4).
+    #
+    # Symmetric with the position guard below, but hoisted above
+    # every write: if the broker returned an empty mirrors[] list
+    # while we have active local mirror rows, refuse the whole
+    # sync cycle before any positions, cash, or mirror upserts run.
+    # Placing this here (rather than inside _sync_mirrors at step
+    # 4) means the raise does not roll back already-written
+    # position/cash state — nothing is written yet. Suspicious
+    # broker state for mirrors implies the entire payload should
+    # not be trusted for this cycle; the operator investigates
+    # before the next run is allowed to touch any state.
+    if not portfolio.mirrors:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            row = cur.execute("SELECT COUNT(*) AS n FROM copy_mirrors WHERE active = TRUE").fetchone()
+        active_mirror_count = int(row["n"]) if row else 0
+        if active_mirror_count > 0:
+            raise RuntimeError(
+                "Broker returned empty mirrors[] but "
+                f"{active_mirror_count} active local mirror(s) exist — "
+                "refusing to soft-close en masse. Likely upstream API "
+                "regression; investigate before manual cleanup."
+            )
 
     # 1. Upsert broker positions into local state.
     for agg in broker_positions.values():

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -31,8 +31,13 @@ from typing import Any
 
 import psycopg
 import psycopg.rows
+import psycopg.types.json
 
-from app.providers.broker import BrokerPortfolio, BrokerPosition
+from app.providers.broker import (
+    BrokerMirror,
+    BrokerPortfolio,
+    BrokerPosition,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +115,174 @@ def _aggregate_by_instrument(
             raw_payloads=[bp.raw_payload for bp in group],
         )
     return result
+
+
+def _sync_mirrors(
+    conn: psycopg.Connection[Any],
+    mirrors: Sequence[BrokerMirror],
+    now: datetime,
+) -> tuple[int, int, int]:
+    """Upsert copy_traders/copy_mirrors/copy_mirror_positions from a
+    freshly-parsed mirror payload. Returns
+    ``(mirrors_upserted, mirror_positions_upserted, mirrors_closed)``.
+
+    Must be called inside the caller's transaction — this function
+    never commits. Caller owns rollback on any raise.
+
+    Disappearance handling (total → raise, partial → soft-close)
+    lives in the caller or in a follow-up step; this function only
+    handles the rows that are present in the payload.
+
+    Single-writer serialisation is guaranteed by JobRuntime's
+    APScheduler+JobLock stack (spec §2.3.1); _sync_mirrors does not
+    take its own advisory lock.
+    """
+    mirrors_upserted = 0
+    mirror_positions_upserted = 0
+
+    for mirror in mirrors:
+        # 1. Upsert the trader row (parent_cid is the identity spine).
+        conn.execute(
+            """
+            INSERT INTO copy_traders (
+                parent_cid, parent_username, first_seen_at, updated_at
+            ) VALUES (
+                %(cid)s, %(username)s, %(now)s, %(now)s
+            )
+            ON CONFLICT (parent_cid) DO UPDATE SET
+                parent_username = EXCLUDED.parent_username,
+                updated_at = EXCLUDED.updated_at
+            """,
+            {
+                "cid": mirror.parent_cid,
+                "username": mirror.parent_username,
+                "now": now,
+            },
+        )
+
+        # 2. Upsert the mirror row. active=TRUE, closed_at=NULL on
+        #    every row the payload contains — re-copy of a
+        #    previously-closed mirror_id flips those back to live.
+        conn.execute(
+            """
+            INSERT INTO copy_mirrors (
+                mirror_id, parent_cid, initial_investment,
+                deposit_summary, withdrawal_summary,
+                available_amount, closed_positions_net_profit,
+                stop_loss_percentage, stop_loss_amount,
+                mirror_status_id, mirror_calculation_type,
+                pending_for_closure, started_copy_date,
+                active, closed_at, raw_payload, updated_at
+            ) VALUES (
+                %(mirror_id)s, %(parent_cid)s, %(initial_investment)s,
+                %(deposit_summary)s, %(withdrawal_summary)s,
+                %(available_amount)s, %(closed_positions_net_profit)s,
+                %(stop_loss_percentage)s, %(stop_loss_amount)s,
+                %(mirror_status_id)s, %(mirror_calculation_type)s,
+                %(pending_for_closure)s, %(started_copy_date)s,
+                TRUE, NULL, %(raw_payload)s, %(now)s
+            )
+            ON CONFLICT (mirror_id) DO UPDATE SET
+                parent_cid                  = EXCLUDED.parent_cid,
+                initial_investment          = EXCLUDED.initial_investment,
+                deposit_summary             = EXCLUDED.deposit_summary,
+                withdrawal_summary          = EXCLUDED.withdrawal_summary,
+                available_amount            = EXCLUDED.available_amount,
+                closed_positions_net_profit = EXCLUDED.closed_positions_net_profit,
+                stop_loss_percentage        = EXCLUDED.stop_loss_percentage,
+                stop_loss_amount            = EXCLUDED.stop_loss_amount,
+                mirror_status_id            = EXCLUDED.mirror_status_id,
+                mirror_calculation_type     = EXCLUDED.mirror_calculation_type,
+                pending_for_closure         = EXCLUDED.pending_for_closure,
+                started_copy_date           = EXCLUDED.started_copy_date,
+                active                      = TRUE,
+                closed_at                   = NULL,
+                raw_payload                 = EXCLUDED.raw_payload,
+                updated_at                  = EXCLUDED.updated_at
+            """,
+            {
+                "mirror_id": mirror.mirror_id,
+                "parent_cid": mirror.parent_cid,
+                "initial_investment": mirror.initial_investment,
+                "deposit_summary": mirror.deposit_summary,
+                "withdrawal_summary": mirror.withdrawal_summary,
+                "available_amount": mirror.available_amount,
+                "closed_positions_net_profit": mirror.closed_positions_net_profit,
+                "stop_loss_percentage": mirror.stop_loss_percentage,
+                "stop_loss_amount": mirror.stop_loss_amount,
+                "mirror_status_id": mirror.mirror_status_id,
+                "mirror_calculation_type": mirror.mirror_calculation_type,
+                "pending_for_closure": mirror.pending_for_closure,
+                "started_copy_date": mirror.started_copy_date,
+                "raw_payload": psycopg.types.json.Jsonb(mirror.raw_payload),
+                "now": now,
+            },
+        )
+        mirrors_upserted += 1
+
+        # 3. Upsert every nested position in the payload. Eviction
+        #    of disappeared positions is a separate statement (see
+        #    Task 12).
+        for pos in mirror.positions:
+            conn.execute(
+                """
+                INSERT INTO copy_mirror_positions (
+                    mirror_id, position_id, parent_position_id,
+                    instrument_id, is_buy, units, amount,
+                    initial_amount_in_dollars, open_rate,
+                    open_conversion_rate, open_date_time,
+                    take_profit_rate, stop_loss_rate,
+                    total_fees, leverage, raw_payload, updated_at
+                ) VALUES (
+                    %(mirror_id)s, %(position_id)s, %(parent_position_id)s,
+                    %(instrument_id)s, %(is_buy)s, %(units)s, %(amount)s,
+                    %(initial_amount)s, %(open_rate)s,
+                    %(open_conversion_rate)s, %(open_date_time)s,
+                    %(take_profit_rate)s, %(stop_loss_rate)s,
+                    %(total_fees)s, %(leverage)s, %(raw_payload)s,
+                    %(now)s
+                )
+                ON CONFLICT (mirror_id, position_id) DO UPDATE SET
+                    parent_position_id        = EXCLUDED.parent_position_id,
+                    instrument_id             = EXCLUDED.instrument_id,
+                    is_buy                    = EXCLUDED.is_buy,
+                    units                     = EXCLUDED.units,
+                    amount                    = EXCLUDED.amount,
+                    initial_amount_in_dollars = EXCLUDED.initial_amount_in_dollars,
+                    open_rate                 = EXCLUDED.open_rate,
+                    open_conversion_rate      = EXCLUDED.open_conversion_rate,
+                    open_date_time            = EXCLUDED.open_date_time,
+                    take_profit_rate          = EXCLUDED.take_profit_rate,
+                    stop_loss_rate            = EXCLUDED.stop_loss_rate,
+                    total_fees                = EXCLUDED.total_fees,
+                    leverage                  = EXCLUDED.leverage,
+                    raw_payload               = EXCLUDED.raw_payload,
+                    updated_at                = EXCLUDED.updated_at
+                """,
+                {
+                    "mirror_id": mirror.mirror_id,
+                    "position_id": pos.position_id,
+                    "parent_position_id": pos.parent_position_id,
+                    "instrument_id": pos.instrument_id,
+                    "is_buy": pos.is_buy,
+                    "units": pos.units,
+                    "amount": pos.amount,
+                    "initial_amount": pos.initial_amount_in_dollars,
+                    "open_rate": pos.open_rate,
+                    "open_conversion_rate": pos.open_conversion_rate,
+                    "open_date_time": pos.open_date_time,
+                    "take_profit_rate": pos.take_profit_rate,
+                    "stop_loss_rate": pos.stop_loss_rate,
+                    "total_fees": pos.total_fees,
+                    "leverage": pos.leverage,
+                    "raw_payload": psycopg.types.json.Jsonb(pos.raw_payload),
+                    "now": now,
+                },
+            )
+            mirror_positions_upserted += 1
+
+    mirrors_closed = 0  # populated by Task 12 soft-close step
+    return mirrors_upserted, mirror_positions_upserted, mirrors_closed
 
 
 def sync_portfolio(
@@ -297,6 +470,9 @@ def sync_portfolio(
             cash_delta,
         )
 
+    # 4. Reconcile copy-trading mirrors (spec §2.3).
+    mirrors_upserted, mirror_positions_upserted, mirrors_closed = _sync_mirrors(conn, portfolio.mirrors, now)
+
     return PortfolioSyncResult(
         positions_updated=updated,
         positions_opened_externally=opened_externally,
@@ -304,4 +480,7 @@ def sync_portfolio(
         cash_delta=cash_delta,
         broker_cash=broker_cash,
         local_cash=local_cash,
+        mirrors_upserted=mirrors_upserted,
+        mirrors_closed=mirrors_closed,
+        mirror_positions_upserted=mirror_positions_upserted,
     )

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -220,9 +220,26 @@ def _sync_mirrors(
         )
         mirrors_upserted += 1
 
-        # 3. Upsert every nested position in the payload. Eviction
-        #    of disappeared positions is a separate statement (see
-        #    Task 12).
+        # 3a. Evict nested positions that have closed since the last
+        #     sync. Passing the new IDs as a single array parameter
+        #     sidesteps the empty-list SQL parser error and exploits
+        #     Postgres's `position_id <> ALL('{}')` === TRUE semantics
+        #     to correctly delete every existing row when the payload
+        #     has zero positions for this mirror.
+        current_position_ids = [int(p.position_id) for p in mirror.positions]
+        conn.execute(
+            """
+            DELETE FROM copy_mirror_positions
+            WHERE mirror_id = %(mirror_id)s
+              AND position_id <> ALL(%(position_ids)s::bigint[])
+            """,
+            {
+                "mirror_id": mirror.mirror_id,
+                "position_ids": current_position_ids,
+            },
+        )
+
+        # 3b. Upsert every position in the payload.
         for pos in mirror.positions:
             conn.execute(
                 """
@@ -281,7 +298,7 @@ def _sync_mirrors(
             )
             mirror_positions_upserted += 1
 
-    mirrors_closed = 0  # populated by Task 12 soft-close step
+    mirrors_closed = 0  # populated by Task 13 soft-close step
     return mirrors_upserted, mirror_positions_upserted, mirrors_closed
 
 

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -50,6 +50,9 @@ class PortfolioSyncResult:
     cash_delta: Decimal
     broker_cash: Decimal
     local_cash: Decimal
+    mirrors_upserted: int = 0
+    mirrors_closed: int = 0
+    mirror_positions_upserted: int = 0
 
 
 @dataclass

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -139,6 +139,7 @@ def _sync_mirrors(
     """
     mirrors_upserted = 0
     mirror_positions_upserted = 0
+    mirrors_closed = 0
 
     for mirror in mirrors:
         # 1. Upsert the trader row (parent_cid is the identity spine).
@@ -298,7 +299,52 @@ def _sync_mirrors(
             )
             mirror_positions_upserted += 1
 
-    mirrors_closed = 0  # populated by Task 13 soft-close step
+    # 4. Disappearance handling (§2.3.4).
+    #
+    # Total disappearance (payload empty AND active local rows
+    # exist) is handled in step 5 below — it raises to force
+    # operator investigation. Here we soft-close mirrors that have
+    # disappeared from a NON-EMPTY payload.
+    payload_mirror_ids = [int(m.mirror_id) for m in mirrors]
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT mirror_id FROM copy_mirrors WHERE active = TRUE")
+        active_local_ids = {int(r["mirror_id"]) for r in cur.fetchall()}
+
+    disappeared_ids = sorted(active_local_ids - set(payload_mirror_ids))
+
+    if not payload_mirror_ids and active_local_ids:
+        # Total disappearance — raise for operator investigation.
+        # See step 5 (Task 14) for the exact error contract.
+        raise RuntimeError(
+            "Broker returned empty mirrors[] but "
+            f"{len(active_local_ids)} active local mirror(s) exist — "
+            "refusing to soft-close en masse. Likely upstream API "
+            "regression; investigate before manual cleanup."
+        )
+
+    if disappeared_ids:
+        conn.execute(
+            """
+            UPDATE copy_mirrors
+               SET active = FALSE,
+                   closed_at = %(now)s,
+                   updated_at = %(now)s
+             WHERE mirror_id = ANY(%(disappeared_ids)s::bigint[])
+               AND active = TRUE
+            """,
+            {
+                "now": now,
+                "disappeared_ids": disappeared_ids,
+            },
+        )
+        for mirror_id in disappeared_ids:
+            logger.info(
+                "mirror %d disappeared from payload — marked closed",
+                mirror_id,
+            )
+        mirrors_closed = len(disappeared_ids)
+
     return mirrors_upserted, mirror_positions_upserted, mirrors_closed
 
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -873,10 +873,14 @@ def daily_portfolio_sync() -> None:
         )
         logger.info(
             "Portfolio sync complete: updated=%d opened_ext=%d closed_ext=%d "
+            "mirrors_up=%d mirrors_closed=%d mirror_positions_up=%d "
             "broker_cash=%.2f local_cash=%.2f delta=%.2f",
             result.positions_updated,
             result.positions_opened_externally,
             result.positions_closed_externally,
+            result.mirrors_upserted,
+            result.mirrors_closed,
+            result.mirror_positions_upserted,
             result.broker_cash,
             result.local_cash,
             result.cash_delta,

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -571,3 +571,21 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: Tests for the reset-on-reopen `CASE WHEN positions.current_units <= 0 THEN EXCLUDED.source ELSE positions.source END` asserted the CASE WHEN text appears in the captured SQL after calling `sync_portfolio` once with `local_positions=[]`. Because the mock guarantees the INSERT path (no pre-existing row), Postgres never reaches the ON CONFLICT branch — the assertion passes purely because the text is present in the INSERT string, not because the conflict branch was actually evaluated. A broken CASE WHEN (wrong predicate, swapped arms) would still pass.
 - Prevention: SQL-shape assertions are only meaningful for clauses that the single code path being exercised will actually run. For ON CONFLICT / CASE WHEN / trigger-gated logic, either (a) drive the mock to produce an actual conflict and assert on effects, or (b) write a DB-level integration test against a real schema that inserts, reinserts, and reads back the resolved value. Never rely on substring-in-SQL as a proxy for "the conflict branch works."
 - Enforced in: this prevention log
+
+---
+
+### Module-level `def` inside a class body silently orphans adjacent test methods
+
+- First seen in: #191
+- Symptom: A new module-level `def test_foo()` was inserted between two methods of an existing test class, with the new function placed at column 0 (outdent-to-module). Python's class-body parsing rule is that the first statement at an outer indent closes the class — so the **next** method after the orphaned function was silently reparsed as a nested function inside `def test_foo`, never collected by pytest. No `SyntaxError` fires, `py_compile` passes, targeted pytest for the class shows a test count one lower than before but doesn't fail. The bug hides until the reviewer notices the diff re-indents an existing method.
+- Prevention: When adding a module-level test function to a file that already contains test classes, place it **after** every class in the file — never between class methods. Before pushing a test-file diff, run `uv run python -c "import ast; [print(f'{n.name}: {[m.name for m in n.body if isinstance(m, ast.FunctionDef)]}') for n in ast.parse(open('tests/<file>.py').read()).body if isinstance(n, ast.ClassDef)]"` to confirm every expected method is still inside its class. A drop in method count between pre- and post-edit is the canary. `py_compile` is **not** sufficient — the orphaned file is syntactically valid Python.
+- Enforced in: this prevention log
+
+---
+
+### Raising inside a shared transaction helper after prior writes rolls back more than the helper's own work
+
+- First seen in: #191
+- Symptom: `_sync_mirrors()` raised `RuntimeError` on total mirror disappearance inside `sync_portfolio`'s transaction, *after* position and cash writes had already executed in the same transaction. The rollback discarded legitimate position/cash updates that had nothing to do with the mirror state — a broader blast radius than the spec's "operator investigates mirrors" framing implied.
+- Prevention: When adding a `raise` inside a function that is called inside a caller's transaction, explicitly ask: *what other writes have already happened in this transaction when I raise?* If the answer is "writes I did not intend to roll back," hoist the raise to the caller **before** any of those writes run. Document the split scope in the helper's docstring so future callers know the helper no longer owns that guard.
+- Enforced in: `.claude/skills/engineering/pre-flight-review.md` section F

--- a/docs/superpowers/plans/2026-04-11-copy-trading-ingestion-track-1a.md
+++ b/docs/superpowers/plans/2026-04-11-copy-trading-ingestion-track-1a.md
@@ -1,0 +1,2724 @@
+# Copy Trading Ingestion — Track 1a Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ingest eToro copy-trading mirrors (`clientPortfolio.mirrors[]`) into three new DB tables so downstream AUM correction (Track 1b, #187), browsing (Track 1.5, #188), and discovery (Track 2, #189) can consume them.
+
+**Architecture:** New sibling schema (`copy_traders`, `copy_mirrors`, `copy_mirror_positions`) populated from the same `/portfolio` call the broker already makes. Existing `positions` / `cash_ledger` are untouched. A strict-raise parser with nested error attribution feeds a new `_sync_mirrors` helper that runs inside the existing `sync_portfolio` transaction, with upsert + nested-eviction + soft-close semantics for operator un-copies.
+
+**Tech Stack:** Python 3.12, psycopg3 (named `%(name)s` params, `dict_row`), Postgres 15+ (partial indexes, JSONB, `ANY(%s::bigint[])`), pytest (real `ebull_test` DB for service-layer tests).
+
+**Spec reference:** `docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md` §1 (schema), §2 (sync flow + parser), §8.0 (fixtures), §8.1–§8.3 (tests), §10 (locked decisions). Track 1a implements §1, §2, §8.0–§8.3 only; §3.4 query helper and §6.x call-site wiring are **Track 1b** (#187) and are out of scope for this plan.
+
+---
+
+## Scope of this plan
+
+**In scope (Track 1a):**
+
+- Migration 022 with three new tables + indices (spec §1, §7)
+- New `BrokerMirrorPosition` / `BrokerMirror` dataclasses + additive `mirrors: Sequence[BrokerMirror] = ()` field on `BrokerPortfolio` (spec §2.1)
+- `PortfolioParseError` exception class and strict-raise parser in `etoro_broker.py` (spec §2.2)
+- New `_sync_mirrors(conn, mirrors, now)` helper inside the existing `sync_portfolio` transaction, with upsert → evict → soft-close → total-disappearance guard (spec §2.3)
+- `PortfolioSyncResult` extended with `mirrors_upserted`, `mirrors_closed`, `mirror_positions_upserted`
+- `tests/fixtures/copy_mirrors.py` **new file** owning `_NOW`, `_GUARD_INSTRUMENT_ID = 990001`, `_GUARD_INSTRUMENT_SECTOR = 'technology'`, plus named fixture builders (spec §8.0)
+- `tests/test_portfolio_sync.py` edited to import `_NOW` from the fixture module (removes a test→test import inversion)
+- §8.1 parser unit tests, §8.2 service-layer upsert/eviction tests, §8.3 disappearance + parser-abort tests
+
+**Explicitly out of scope (Track 1b / 1.5 / 2):**
+
+- `_load_mirror_equity(conn)` helper and its three call sites (guard, REST, review) → Track 1b #187
+- `PortfolioResponse.mirror_equity` field → Track 1b #187
+- `§3.4` SQL query inside any consumer → Track 1b #187
+- §8.4 AUM identity tests, §8.5 guard integration tests, §8.6 three-call-site delta tests → Track 1b #187
+- `mirror_aum_fixture`, `no_quote_mirror_fixture`, `mtm_delta_mirror_fixture` builders → Track 1b #187 (the constants `_NOW` / `_GUARD_INSTRUMENT_ID` / `_GUARD_INSTRUMENT_SECTOR` ship now; the fixtures that use them ship in Track 1b)
+- REST endpoint `GET /api/portfolio/copy-trading` and the frontend panel → Track 1.5 #188
+- `/user-info/people/*` discovery + history → Track 2 #189
+
+---
+
+## Settled-decisions check
+
+Working order step 2/3 (CLAUDE.md): read `docs/settled-decisions.md` and `docs/review-prevention-log.md` before coding. Relevant entries:
+
+- **Prevention log "test must use `ebull_test`"** → every new service-layer test below uses the `_test_database_url()` pattern already established in `tests/test_operator_setup_race.py:77`. The plan does **not** introduce a shortcut against `settings.database_url`.
+- **Prevention log "tests must never wipe dev DB"** → all DB state for §8.2/§8.3 is seeded + torn down inside a fixture-scoped transaction that is rolled back, or by DELETEing only rows the test inserted. No TRUNCATE against a shared table without `_assert_test_db`.
+- **Prevention log "smoke gate must catch lifespan swallowed failures"** → migration 022 runs at dev-DB bootstrap. Task 1 verifies `tests/smoke/test_app_boots.py` stays green. No lifespan change is introduced.
+- **Settled decision "single source of truth for constants"** → `_NOW`, `_GUARD_INSTRUMENT_ID`, `_GUARD_INSTRUMENT_SECTOR` are declared exactly once (in the new fixture file) and imported everywhere. Task 3 removes the `tests/test_portfolio_sync.py:20` duplicate.
+- **Settled decision "params, not interpolation"** → every SQL binding in the sync helper uses `%(name)s` named placeholders; the only place this plan writes a string-formatted SQL is the `sql/022_*.sql` migration file itself (pure DDL, no user input).
+
+If implementation pressure during any task suggests deviating from the above, stop and surface it — do not paper over it.
+
+---
+
+## File structure
+
+**Created:**
+
+- `sql/022_copy_trading_tables.sql` — single-transaction DDL for three tables and four indices (spec §1, §7)
+- `tests/fixtures/__init__.py` — marker so `tests/fixtures` is a package (empty file)
+- `tests/fixtures/copy_mirrors.py` — canonical `_NOW`, guard-instrument constants, and named fixture builders (spec §8.0)
+- `tests/test_copy_mirrors_parser.py` — §8.1 pure parser unit tests (no DB, no I/O)
+- `tests/test_portfolio_sync_mirrors.py` — §8.2 + §8.3 service-layer tests against `ebull_test`
+
+**Modified:**
+
+- `app/providers/broker.py` — two new frozen dataclasses + additive `mirrors` field on `BrokerPortfolio`
+- `app/providers/implementations/etoro_broker.py` — new `PortfolioParseError`, new `_parse_mirror`, `_parse_mirror_position`, extended `get_portfolio`
+- `app/services/portfolio_sync.py` — new `_sync_mirrors` helper, extended `PortfolioSyncResult`, call wired into `sync_portfolio`
+- `app/workers/scheduler.py` — `daily_portfolio_sync` log line picks up the new `mirrors_*` counters
+- `tests/test_portfolio_sync.py` — remove local `_NOW`, import from `tests.fixtures.copy_mirrors`
+
+All other files are untouched.
+
+---
+
+## Pre-push gate (run before every task's final push)
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+All four must pass. This is the CLAUDE.md non-negotiable. Per-task commits may skip `pyright` / full `pytest` for iteration speed, but the final commit at the end of each task must pass all four and the smoke gate (`tests/smoke/test_app_boots.py`).
+
+---
+
+## Task 1: Schema migration 022
+
+**Files:**
+
+- Create: `sql/022_copy_trading_tables.sql`
+- Test: `tests/smoke/test_app_boots.py` (existing — verifies dev DB bootstrap still boots after the migration applies)
+
+- [ ] **Step 1: Write the migration file**
+
+```sql
+-- Migration 022: copy trading ingestion (Track 1a)
+--
+-- Adds three sibling tables so the eToro /portfolio payload's
+-- clientPortfolio.mirrors[] data can be ingested first-class:
+--
+--   copy_traders          — one row per eToro trader identity
+--   copy_mirrors          — one row per copy relationship (mirror_id)
+--   copy_mirror_positions — one row per nested position inside a mirror
+--
+-- Existing tables (positions, cash_ledger, positions.source) are
+-- untouched. The execution guard's rule queries continue to read
+-- FROM positions only; mirrors inflate AUM via a separate query in
+-- Track 1b (#187) — this migration is the schema prerequisite.
+--
+-- Soft-close semantics: copy_mirrors.active / closed_at columns let
+-- a mirror that disappears from the payload be marked closed rather
+-- than deleted. Nested positions are retained on soft-closed mirrors
+-- for audit. See spec §1 and §2.3.4.
+--
+-- Issue: #183
+
+BEGIN;
+
+CREATE TABLE copy_traders (
+    parent_cid      BIGINT PRIMARY KEY,
+    parent_username TEXT   NOT NULL,
+
+    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX copy_traders_username_idx ON copy_traders (parent_username);
+
+CREATE TABLE copy_mirrors (
+    mirror_id  BIGINT PRIMARY KEY,
+    parent_cid BIGINT NOT NULL REFERENCES copy_traders(parent_cid),
+
+    initial_investment          NUMERIC(20, 4) NOT NULL,
+    deposit_summary             NUMERIC(20, 4) NOT NULL,
+    withdrawal_summary          NUMERIC(20, 4) NOT NULL,
+    available_amount            NUMERIC(20, 4) NOT NULL,
+    closed_positions_net_profit NUMERIC(20, 4) NOT NULL,
+    stop_loss_percentage        NUMERIC(10, 4),
+    stop_loss_amount            NUMERIC(20, 4),
+    mirror_status_id            INTEGER,
+    mirror_calculation_type     INTEGER,
+    pending_for_closure         BOOLEAN NOT NULL DEFAULT FALSE,
+    started_copy_date           TIMESTAMPTZ NOT NULL,
+
+    active      BOOLEAN     NOT NULL DEFAULT TRUE,
+    closed_at   TIMESTAMPTZ NULL,
+
+    raw_payload JSONB NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX copy_mirrors_parent_cid_idx ON copy_mirrors (parent_cid);
+CREATE INDEX copy_mirrors_active_idx     ON copy_mirrors (active) WHERE active;
+
+CREATE TABLE copy_mirror_positions (
+    mirror_id   BIGINT NOT NULL REFERENCES copy_mirrors(mirror_id) ON DELETE CASCADE,
+    position_id BIGINT NOT NULL,
+    PRIMARY KEY (mirror_id, position_id),
+
+    parent_position_id BIGINT NOT NULL,
+    instrument_id      BIGINT NOT NULL,
+
+    is_buy                    BOOLEAN         NOT NULL,
+    units                     NUMERIC(20, 8)  NOT NULL,
+    amount                    NUMERIC(20, 4)  NOT NULL,
+    initial_amount_in_dollars NUMERIC(20, 4)  NOT NULL,
+    open_rate                 NUMERIC(20, 6)  NOT NULL,
+    open_conversion_rate      NUMERIC(20, 10) NOT NULL,
+    open_date_time            TIMESTAMPTZ     NOT NULL,
+    take_profit_rate          NUMERIC(20, 6),
+    stop_loss_rate            NUMERIC(20, 6),
+    total_fees                NUMERIC(20, 4)  NOT NULL DEFAULT 0,
+    leverage                  INTEGER         NOT NULL DEFAULT 1,
+
+    raw_payload JSONB NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX copy_mirror_positions_instrument_id_idx
+    ON copy_mirror_positions (instrument_id);
+
+COMMIT;
+```
+
+- [ ] **Step 2: Verify migration applies cleanly to `ebull_test`**
+
+Run: `uv run python -c "import psycopg; from tests.test_operator_setup_race import _test_database_url, _apply_migrations_to_test_db; _apply_migrations_to_test_db(); conn = psycopg.connect(_test_database_url()); cur = conn.cursor(); cur.execute(\"SELECT COUNT(*) FROM copy_traders\"); print(cur.fetchone()); conn.close()"`
+
+Expected: prints `(0,)` — table exists and is empty.
+
+Alternative (if the one-liner is awkward on bash/win): drop `ebull_test`, let `_test_db_available()` recreate it on next pytest run, and confirm the run logs show migration 022 applied.
+
+- [ ] **Step 3: Verify smoke gate stays green against dev DB**
+
+Run: `uv run pytest tests/smoke/test_app_boots.py -v`
+
+Expected: PASS. The lifespan auto-applies pending migrations at boot, so `ebull` also gets 022.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sql/022_copy_trading_tables.sql
+git commit -m "feat(#183): migration 022 — copy trading ingestion tables
+
+Adds copy_traders, copy_mirrors, copy_mirror_positions with the
+indices from spec §1. Soft-close via copy_mirrors.active/closed_at.
+Partial index on copy_mirrors(active) WHERE active keeps the AUM
+denominator scan cheap as closed mirrors accumulate.
+
+No data backfill — tables fill on the next portfolio sync."
+```
+
+---
+
+## Task 2: Fixtures package scaffold + canonical constants
+
+**Files:**
+
+- Create: `tests/fixtures/__init__.py`
+- Create: `tests/fixtures/copy_mirrors.py`
+
+- [ ] **Step 1: Create the package marker**
+
+```python
+# tests/fixtures/__init__.py
+```
+
+(Empty file — just makes `tests.fixtures` importable.)
+
+- [ ] **Step 2: Create the copy-mirrors fixture module with constants only**
+
+```python
+# tests/fixtures/copy_mirrors.py
+"""Shared test fixtures for copy-trading ingestion (spec §8.0).
+
+This module owns the canonical `_NOW` constant used by every test
+that exercises the mirror sync soft-close path. The value is
+pinned to a frozen UTC timestamp so that `_sync_mirrors`'s
+`UPDATE ... closed_at = %(now)s` clause produces a deterministic
+stored value and tests can assert the exact round-trip.
+
+It also owns `_GUARD_INSTRUMENT_ID` and `_GUARD_INSTRUMENT_SECTOR`
+— the deterministic instrument-row identifiers used by the
+guard-path fixtures delivered in Track 1b (#187). They are
+declared here in Track 1a so all callers import them from one
+place once Track 1b lands.
+
+Track 1a ships the constants and the parser/sync fixture
+builders (`two_mirror_payload`, `parse_failure_payload`,
+`two_mirror_seed_rows`). Track 1b adds `mirror_aum_fixture`,
+`no_quote_mirror_fixture`, `mtm_delta_mirror_fixture` on top.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+# Frozen "now" for every sync-side test. Matches the value
+# tests/test_portfolio_sync.py used locally before this refactor
+# (bit-identical — no behaviour change).
+_NOW: datetime = datetime(2026, 4, 10, 5, 30, tzinfo=UTC)
+
+# Guard test instrument — chosen well above any seed data in
+# sql/001_init.sql so it cannot collide with real instruments.
+# Track 1b's guard-integration test fixtures reuse it.
+_GUARD_INSTRUMENT_ID: int = 990001
+_GUARD_INSTRUMENT_SECTOR: str = "technology"
+```
+
+- [ ] **Step 3: Verify imports resolve**
+
+Run: `uv run python -c "from tests.fixtures.copy_mirrors import _NOW, _GUARD_INSTRUMENT_ID, _GUARD_INSTRUMENT_SECTOR; print(_NOW, _GUARD_INSTRUMENT_ID, _GUARD_INSTRUMENT_SECTOR)"`
+
+Expected: `2026-04-10 05:30:00+00:00 990001 technology`
+
+- [ ] **Step 4: Run ruff + pyright on the new file**
+
+Run: `uv run ruff check tests/fixtures/ && uv run ruff format --check tests/fixtures/ && uv run pyright tests/fixtures/`
+
+Expected: all three pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fixtures/__init__.py tests/fixtures/copy_mirrors.py
+git commit -m "test(#183): new tests/fixtures/copy_mirrors module
+
+Owns the canonical _NOW timestamp and the _GUARD_INSTRUMENT_ID
+constants shared across Track 1a parser/sync tests and Track 1b
+AUM tests. Empty of fixture builders yet — those land in later
+tasks."
+```
+
+---
+
+## Task 3: Migrate `tests/test_portfolio_sync.py` to import `_NOW` from the fixture module
+
+**Files:**
+
+- Modify: `tests/test_portfolio_sync.py:20` — delete local declaration, add import
+
+- [ ] **Step 1: Verify current test passes before refactor**
+
+Run: `uv run pytest tests/test_portfolio_sync.py -v`
+
+Expected: PASS (baseline).
+
+- [ ] **Step 2: Replace the local constant with an import**
+
+Current at `tests/test_portfolio_sync.py:13-20`:
+
+```python
+from app.providers.broker import BrokerPortfolio, BrokerPosition
+from app.services.portfolio_sync import (
+    PortfolioSyncResult,
+    _aggregate_by_instrument,
+    sync_portfolio,
+)
+
+_NOW = datetime(2026, 4, 10, 5, 30, tzinfo=UTC)
+```
+
+Replace with:
+
+```python
+from app.providers.broker import BrokerPortfolio, BrokerPosition
+from app.services.portfolio_sync import (
+    PortfolioSyncResult,
+    _aggregate_by_instrument,
+    sync_portfolio,
+)
+from tests.fixtures.copy_mirrors import _NOW
+```
+
+(The `from datetime import UTC, datetime` import at the top of the file stays — it may still be referenced by other code in the file.)
+
+- [ ] **Step 3: Verify nothing else in the file re-declares `_NOW`**
+
+Run: `uv run python -c "import tests.test_portfolio_sync as m; print(m._NOW)"`
+
+Expected: `2026-04-10 05:30:00+00:00`
+
+- [ ] **Step 4: Re-run the test module to verify behaviour unchanged**
+
+Run: `uv run pytest tests/test_portfolio_sync.py -v`
+
+Expected: PASS, same test count, no new warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_portfolio_sync.py
+git commit -m "test(#183): import _NOW from tests/fixtures/copy_mirrors
+
+Removes the test→test import inversion where a fixture value
+lived in a test module. Value is bit-identical to the previous
+local declaration. Addresses Codex v5 finding AI."
+```
+
+---
+
+## Task 4: Broker interface — `BrokerMirrorPosition`, `BrokerMirror`, `mirrors` field
+
+**Files:**
+
+- Modify: `app/providers/broker.py` — add two frozen dataclasses, add `mirrors` field
+- Test: `tests/test_broker_provider.py` (existing — add dataclass round-trip test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_broker_provider.py`:
+
+```python
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from app.providers.broker import (
+    BrokerMirror,
+    BrokerMirrorPosition,
+    BrokerPortfolio,
+    BrokerPosition,
+)
+
+
+def test_broker_mirror_position_round_trip() -> None:
+    pos = BrokerMirrorPosition(
+        position_id=1001,
+        parent_position_id=5001,
+        instrument_id=42,
+        is_buy=True,
+        units=Decimal("6.28927"),
+        amount=Decimal("101.08"),
+        initial_amount_in_dollars=Decimal("101.08"),
+        open_rate=Decimal("1207.4994"),
+        open_conversion_rate=Decimal("0.01331"),
+        open_date_time=datetime(2026, 4, 10, 0, 0, tzinfo=UTC),
+        take_profit_rate=None,
+        stop_loss_rate=None,
+        total_fees=Decimal("0"),
+        leverage=1,
+        raw_payload={"positionID": 1001},
+    )
+    assert pos.units == Decimal("6.28927")
+    assert pos.open_conversion_rate == Decimal("0.01331")
+    assert pos.is_buy is True
+    assert pos.raw_payload["positionID"] == 1001
+
+
+def test_broker_mirror_round_trip() -> None:
+    mirror = BrokerMirror(
+        mirror_id=15712187,
+        parent_cid=111,
+        parent_username="thomaspj",
+        initial_investment=Decimal("20000"),
+        deposit_summary=Decimal("0"),
+        withdrawal_summary=Decimal("0"),
+        available_amount=Decimal("2800.33"),
+        closed_positions_net_profit=Decimal("-110.34"),
+        stop_loss_percentage=None,
+        stop_loss_amount=None,
+        mirror_status_id=None,
+        mirror_calculation_type=None,
+        pending_for_closure=False,
+        started_copy_date=datetime(2025, 1, 1, tzinfo=UTC),
+        positions=(),
+        raw_payload={"mirrorID": 15712187},
+    )
+    assert mirror.mirror_id == 15712187
+    assert mirror.parent_username == "thomaspj"
+    assert mirror.positions == ()
+
+
+def test_broker_portfolio_mirrors_defaults_to_empty_tuple() -> None:
+    """Existing callers must still be able to construct BrokerPortfolio
+    without supplying mirrors (spec §2.1 non-breaking addition)."""
+    portfolio = BrokerPortfolio(
+        positions=(),
+        available_cash=Decimal("0"),
+        raw_payload={},
+    )
+    assert portfolio.mirrors == ()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_broker_provider.py::test_broker_mirror_position_round_trip -v`
+
+Expected: FAIL with `ImportError: cannot import name 'BrokerMirror' from 'app.providers.broker'`.
+
+- [ ] **Step 3: Add the dataclasses and the field**
+
+Edit `app/providers/broker.py`. Add imports:
+
+```python
+from datetime import datetime
+```
+
+(append after existing `from decimal import Decimal` at line 17).
+
+Insert two new dataclasses between `BrokerPosition` (line 35-43) and `BrokerPortfolio` (line 46-52):
+
+```python
+@dataclass(frozen=True)
+class BrokerMirrorPosition:
+    """A single nested position inside a copy-trader mirror.
+
+    `amount` is the pre-converted USD cost basis reported by eToro.
+    `open_rate` is the entry price in the instrument's native
+    currency; `open_conversion_rate` is the native→USD FX rate at
+    open. Both are required — see spec §1.3 "openConversionRate NOT
+    NULL" for the AUM correctness reason.
+    """
+
+    position_id: int
+    parent_position_id: int
+    instrument_id: int
+    is_buy: bool
+    units: Decimal
+    amount: Decimal
+    initial_amount_in_dollars: Decimal
+    open_rate: Decimal
+    open_conversion_rate: Decimal
+    open_date_time: datetime
+    take_profit_rate: Decimal | None
+    stop_loss_rate: Decimal | None
+    total_fees: Decimal
+    leverage: int
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BrokerMirror:
+    """A single copy-trading mirror (one per copy session with a trader)."""
+
+    mirror_id: int
+    parent_cid: int
+    parent_username: str
+    initial_investment: Decimal
+    deposit_summary: Decimal
+    withdrawal_summary: Decimal
+    available_amount: Decimal
+    closed_positions_net_profit: Decimal
+    stop_loss_percentage: Decimal | None
+    stop_loss_amount: Decimal | None
+    mirror_status_id: int | None
+    mirror_calculation_type: int | None
+    pending_for_closure: bool
+    started_copy_date: datetime
+    positions: Sequence[BrokerMirrorPosition]
+    raw_payload: dict[str, Any]
+```
+
+Modify `BrokerPortfolio` (currently line 46-52) to add the `mirrors` field with a default:
+
+```python
+@dataclass(frozen=True)
+class BrokerPortfolio:
+    """Snapshot of the broker account: positions + available cash + mirrors."""
+
+    positions: Sequence[BrokerPosition]
+    available_cash: Decimal
+    raw_payload: dict[str, Any]
+    mirrors: Sequence[BrokerMirror] = ()
+```
+
+The default preserves both existing constructor call sites (`etoro_broker.py:456`, `tests/test_portfolio_sync.py:56`) unchanged at the type level — see spec §2.1 rationale.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_broker_provider.py -v`
+
+Expected: all three new tests PASS plus existing tests still PASS.
+
+- [ ] **Step 5: Lint + typecheck**
+
+Run: `uv run ruff check app/providers/broker.py tests/test_broker_provider.py && uv run pyright app/providers/broker.py`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/providers/broker.py tests/test_broker_provider.py
+git commit -m "feat(#183): add BrokerMirror/BrokerMirrorPosition dataclasses
+
+New frozen dataclasses for copy-trading mirror payload parsing,
+plus additive 'mirrors: Sequence[BrokerMirror] = ()' field on
+BrokerPortfolio. Default preserves the two existing constructor
+call sites (etoro_broker.get_portfolio, tests/test_portfolio_sync)
+unchanged — see spec §2.1."
+```
+
+---
+
+## Task 5: `PortfolioParseError` exception class + hierarchy test
+
+**Files:**
+
+- Modify: `app/providers/implementations/etoro_broker.py` — add new exception class near the top of the module (below existing imports, above the class definition)
+- Create: `tests/test_copy_mirrors_parser.py` — new test module for §8.1 parser tests
+
+- [ ] **Step 1: Write the failing hierarchy test**
+
+```python
+# tests/test_copy_mirrors_parser.py
+"""§8.1 parser unit tests for copy-trading mirror ingestion.
+
+Pure unit tests — no DB, no I/O, no broker HTTP. Exercises
+_parse_mirror / _parse_mirror_position and the outer top-level
+loop in etoro_broker.get_portfolio's mirrors[] branch.
+"""
+
+from __future__ import annotations
+
+import decimal
+
+import pytest
+
+from app.providers.implementations.etoro_broker import PortfolioParseError
+
+
+def test_portfolio_parse_error_is_direct_exception_subclass() -> None:
+    """Spec §2.2.1: PortfolioParseError MUST subclass Exception directly.
+
+    If it subclassed ValueError / TypeError / KeyError /
+    decimal.DecimalException, the outer parse loop's
+    `except (KeyError, ValueError, TypeError, decimal.DecimalException)`
+    block would silently swallow it, defeating the §2.3.3 strict-raise
+    and enabling the §2.3.4 soft-close hole Codex v3 finding V flagged.
+    """
+    assert issubclass(PortfolioParseError, Exception) is True
+    assert issubclass(PortfolioParseError, ValueError) is False
+    assert issubclass(PortfolioParseError, TypeError) is False
+    assert issubclass(PortfolioParseError, KeyError) is False
+    assert issubclass(PortfolioParseError, decimal.DecimalException) is False
+
+
+def test_portfolio_parse_error_is_raisable_with_cause() -> None:
+    inner = ValueError("boom")
+    with pytest.raises(PortfolioParseError) as excinfo:
+        raise PortfolioParseError("wrap") from inner
+    assert excinfo.value.__cause__ is inner
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_copy_mirrors_parser.py -v`
+
+Expected: FAIL with `ImportError: cannot import name 'PortfolioParseError' from 'app.providers.implementations.etoro_broker'`.
+
+- [ ] **Step 3: Add the exception class**
+
+Edit `app/providers/implementations/etoro_broker.py`. Find the existing module docstring / logger setup / class definition, and add immediately above the `class EtoroBrokerProvider` line:
+
+```python
+class PortfolioParseError(Exception):
+    """Raised when a mirrors[] row cannot be parsed safely.
+
+    Directly subclasses Exception (NOT ValueError / TypeError /
+    KeyError / decimal.DecimalException) so the outer parse loop can
+    distinguish it from incidental exceptions and re-raise. Never
+    swallowed by any `except (KeyError, ValueError, TypeError,
+    decimal.DecimalException)` block.
+
+    See spec §2.2.1 for the hierarchy rationale and §2.3.3 for the
+    strict-raise sync contract that depends on it.
+    """
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_copy_mirrors_parser.py -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/providers/implementations/etoro_broker.py tests/test_copy_mirrors_parser.py
+git commit -m "feat(#183): add PortfolioParseError exception class
+
+Direct Exception subclass (not ValueError/TypeError/KeyError/
+DecimalException) so the outer parse loop's catch-list cannot
+swallow it. See spec §2.2.1 and Codex v3 finding U."
+```
+
+---
+
+## Task 6: `_parse_mirror_position` — happy path + required-field failures
+
+**Files:**
+
+- Modify: `app/providers/implementations/etoro_broker.py` — add `_parse_mirror_position` pure helper below `_normalise_order_info_response` (the existing normaliser pattern)
+- Modify: `tests/test_copy_mirrors_parser.py` — add §8.1 tests for the position parser
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_copy_mirrors_parser.py`:
+
+```python
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from app.providers.broker import BrokerMirrorPosition
+from app.providers.implementations.etoro_broker import _parse_mirror_position
+
+
+def _make_position_payload(**overrides: Any) -> dict[str, Any]:
+    """Return a valid mirror-position payload; override any field."""
+    base: dict[str, Any] = {
+        "positionID": 1001,
+        "parentPositionID": 5001,
+        "instrumentID": 42,
+        "isBuy": True,
+        "units": "6.28927",
+        "amount": "101.08",
+        "initialAmountInDollars": "101.08",
+        "openRate": "1207.4994",
+        "openConversionRate": "0.01331",
+        "openDateTime": "2026-04-10T00:00:00Z",
+        "takeProfitRate": None,
+        "stopLossRate": None,
+        "totalFees": "0",
+        "leverage": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_parse_mirror_position_happy_path_non_usd() -> None:
+    payload = _make_position_payload()
+    pos = _parse_mirror_position(payload)
+    assert isinstance(pos, BrokerMirrorPosition)
+    assert pos.position_id == 1001
+    assert pos.instrument_id == 42
+    assert pos.is_buy is True
+    assert pos.units == Decimal("6.28927")
+    assert pos.open_rate == Decimal("1207.4994")
+    assert pos.open_conversion_rate == Decimal("0.01331")  # FX round-trip
+    assert pos.open_date_time == datetime(2026, 4, 10, 0, 0, tzinfo=UTC)
+    assert pos.take_profit_rate is None
+    assert pos.stop_loss_rate is None
+    assert pos.total_fees == Decimal("0")
+    assert pos.leverage == 1
+    assert pos.raw_payload is payload  # stored as-is
+
+
+def test_parse_mirror_position_missing_open_conversion_rate_raises() -> None:
+    """Spec §2.2.2: openConversionRate is a required field in prod
+    — no silent default. A mirror-position without it raises."""
+    payload = _make_position_payload()
+    del payload["openConversionRate"]
+    with pytest.raises(KeyError):
+        _parse_mirror_position(payload)
+
+
+def test_parse_mirror_position_non_numeric_units_raises_decimal_exc() -> None:
+    """Spec §2.2.2 + §8.1: Decimal(str('bogus')) raises
+    decimal.InvalidOperation, a subclass of DecimalException —
+    NOT a ValueError. This test pins the exception type so the
+    caller's `except DecimalException` clause catches correctly."""
+    payload = _make_position_payload(units="bogus")
+    with pytest.raises(decimal.DecimalException):
+        _parse_mirror_position(payload)
+
+
+def test_parse_mirror_position_optional_fields_none() -> None:
+    payload = _make_position_payload(takeProfitRate=None, stopLossRate=None)
+    pos = _parse_mirror_position(payload)
+    assert pos.take_profit_rate is None
+    assert pos.stop_loss_rate is None
+
+
+def test_parse_mirror_position_optional_fields_present() -> None:
+    payload = _make_position_payload(takeProfitRate="1500.0", stopLossRate="1000.0")
+    pos = _parse_mirror_position(payload)
+    assert pos.take_profit_rate == Decimal("1500.0")
+    assert pos.stop_loss_rate == Decimal("1000.0")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_copy_mirrors_parser.py -v`
+
+Expected: FAIL — `_parse_mirror_position` is not yet importable.
+
+- [ ] **Step 3: Implement `_parse_mirror_position`**
+
+Edit `app/providers/implementations/etoro_broker.py`. Add a `decimal` import at the top if not already present:
+
+```python
+import decimal
+from datetime import datetime
+from decimal import Decimal
+```
+
+Add the helper below `_normalise_order_info_response` (near the existing normalisers at line 549+):
+
+```python
+def _parse_mirror_position(payload: dict[str, Any]) -> BrokerMirrorPosition:
+    """Parse a nested copy-mirror position payload into a typed dataclass.
+
+    Pure normaliser — no I/O, no instance state. Required fields
+    raise KeyError on absence; numeric fields go through
+    Decimal(str(value)) and raise decimal.InvalidOperation
+    (a subclass of decimal.DecimalException) on non-numeric input.
+    The caller (_parse_mirror) wraps both exception types in a
+    PortfolioParseError with position-index attribution.
+
+    openConversionRate is required — see spec §2.2.2 and the
+    74/198 non-USD positions on demo mirror 15712187 that would
+    otherwise be AUM-nonsense.
+    """
+
+    def _opt_decimal(key: str) -> Decimal | None:
+        value = payload.get(key)
+        if value is None:
+            return None
+        return Decimal(str(value))
+
+    return BrokerMirrorPosition(
+        position_id=int(payload["positionID"]),
+        parent_position_id=int(payload["parentPositionID"]),
+        instrument_id=int(payload["instrumentID"]),
+        is_buy=bool(payload["isBuy"]),
+        units=Decimal(str(payload["units"])),
+        amount=Decimal(str(payload["amount"])),
+        initial_amount_in_dollars=Decimal(str(payload["initialAmountInDollars"])),
+        open_rate=Decimal(str(payload["openRate"])),
+        open_conversion_rate=Decimal(str(payload["openConversionRate"])),
+        open_date_time=_parse_iso_datetime(payload["openDateTime"]),
+        take_profit_rate=_opt_decimal("takeProfitRate"),
+        stop_loss_rate=_opt_decimal("stopLossRate"),
+        total_fees=Decimal(str(payload.get("totalFees", "0"))),
+        leverage=int(payload.get("leverage", 1)),
+        raw_payload=payload,
+    )
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    """Parse an ISO-8601 datetime string from an eToro payload.
+
+    eToro returns `2026-04-10T00:00:00Z`; Python's fromisoformat
+    below 3.11 rejects the trailing `Z`, so we normalise to `+00:00`.
+    """
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
+```
+
+You will also need to import `BrokerMirrorPosition` at the top of the file:
+
+```python
+from app.providers.broker import (
+    BrokerMirror,
+    BrokerMirrorPosition,
+    BrokerOrderResult,
+    BrokerPortfolio,
+    BrokerPosition,
+)
+```
+
+(Only add the names that aren't already imported.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_copy_mirrors_parser.py -v`
+
+Expected: all six tests PASS.
+
+- [ ] **Step 5: Lint + typecheck**
+
+Run: `uv run ruff check app/providers/implementations/etoro_broker.py tests/test_copy_mirrors_parser.py && uv run pyright app/providers/implementations/etoro_broker.py`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/providers/implementations/etoro_broker.py tests/test_copy_mirrors_parser.py
+git commit -m "feat(#183): add _parse_mirror_position normaliser
+
+Pure helper parsing nested copy-mirror position payloads into
+BrokerMirrorPosition dataclasses. Required fields raise on
+absence; numeric fields raise decimal.InvalidOperation on
+non-numeric input. openConversionRate is required in prod — see
+spec §2.2.2. Exception wrapping into PortfolioParseError with
+position-index attribution lives in the next task."
+```
+
+---
+
+## Task 7: `_parse_mirror` — nested wrap with position-index attribution
+
+**Files:**
+
+- Modify: `app/providers/implementations/etoro_broker.py` — add `_parse_mirror` below `_parse_mirror_position`
+- Modify: `tests/test_copy_mirrors_parser.py` — add tests for happy path + nested failure wrap
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_copy_mirrors_parser.py`:
+
+```python
+from app.providers.broker import BrokerMirror
+from app.providers.implementations.etoro_broker import _parse_mirror
+
+
+def _make_mirror_payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "mirrorID": 15712187,
+        "parentCID": 111,
+        "parentUsername": "thomaspj",
+        "initialInvestment": "20000",
+        "depositSummary": "0",
+        "withdrawalSummary": "0",
+        "availableAmount": "2800.33",
+        "closedPositionsNetProfit": "-110.34",
+        "stopLossPercentage": None,
+        "stopLossAmount": None,
+        "mirrorStatusID": None,
+        "mirrorCalculationType": None,
+        "pendingForClosure": False,
+        "startedCopyDate": "2025-01-01T00:00:00Z",
+        "positions": [_make_position_payload(positionID=1001)],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_parse_mirror_happy_path() -> None:
+    payload = _make_mirror_payload()
+    mirror = _parse_mirror(payload)
+    assert isinstance(mirror, BrokerMirror)
+    assert mirror.mirror_id == 15712187
+    assert mirror.parent_cid == 111
+    assert mirror.parent_username == "thomaspj"
+    assert mirror.available_amount == Decimal("2800.33")
+    assert mirror.closed_positions_net_profit == Decimal("-110.34")
+    assert len(mirror.positions) == 1
+    assert mirror.positions[0].position_id == 1001
+    assert mirror.started_copy_date == datetime(2025, 1, 1, tzinfo=UTC)
+    assert mirror.raw_payload is payload
+
+
+def test_parse_mirror_empty_positions_is_valid() -> None:
+    """A mirror with positions == [] is a valid state (holds only cash).
+
+    §2.2.2: raw_positions == [] yields positions=(), which the §3.2
+    AUM formula in Track 1b handles as mirror_equity = available_amount.
+    Nothing raises.
+    """
+    payload = _make_mirror_payload(positions=[])
+    mirror = _parse_mirror(payload)
+    assert mirror.positions == ()
+
+
+def test_parse_mirror_nested_failure_wraps_with_index() -> None:
+    """Spec §2.2.2: inner loop catches (KeyError, ValueError, TypeError,
+    DecimalException) and re-raises as PortfolioParseError with both
+    the mirror_id AND the position index in the message."""
+    bad_pos = _make_position_payload(positionID=9999, units="bogus")
+    payload = _make_mirror_payload(
+        positions=[
+            _make_position_payload(positionID=1001),
+            _make_position_payload(positionID=1002),
+            bad_pos,  # idx 2 — this is the failing one
+        ]
+    )
+    with pytest.raises(PortfolioParseError) as excinfo:
+        _parse_mirror(payload)
+    msg = str(excinfo.value)
+    assert "15712187" in msg
+    assert "position[2]" in msg
+    assert isinstance(excinfo.value.__cause__, decimal.InvalidOperation)
+
+
+def test_parse_mirror_nested_key_error_wraps() -> None:
+    """Missing openConversionRate in a nested position raises
+    KeyError from _parse_mirror_position, which _parse_mirror's
+    inner wrap catches and re-raises as PortfolioParseError."""
+    bad_pos = _make_position_payload(positionID=9999)
+    del bad_pos["openConversionRate"]
+    payload = _make_mirror_payload(positions=[bad_pos])
+    with pytest.raises(PortfolioParseError) as excinfo:
+        _parse_mirror(payload)
+    assert "15712187" in str(excinfo.value)
+    assert "position[0]" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, KeyError)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_copy_mirrors_parser.py -v`
+
+Expected: FAIL — `_parse_mirror` not yet importable.
+
+- [ ] **Step 3: Implement `_parse_mirror`**
+
+Append to `app/providers/implementations/etoro_broker.py` (below `_parse_iso_datetime`):
+
+```python
+def _parse_mirror(payload: dict[str, Any]) -> BrokerMirror:
+    """Parse a top-level copy-trading mirror payload.
+
+    Nested positions are iterated under an inner try/except that
+    wraps (KeyError, ValueError, TypeError, decimal.DecimalException)
+    in PortfolioParseError with mirror_id + position index
+    attribution. See spec §2.2.2 for why the inner wrap is mandatory
+    — without it, a single malformed nested position degrades to a
+    top-level error message that cannot tell the operator *which*
+    row failed.
+
+    Top-level numeric/string extraction may also raise
+    (KeyError / ValueError / TypeError / DecimalException); those
+    propagate up to the outer get_portfolio loop where §2.2.2's
+    fallback wrap catches and re-raises as PortfolioParseError
+    keyed on the mirror_id alone.
+    """
+    raw_positions = payload.get("positions") or []
+    parsed_positions: list[BrokerMirrorPosition] = []
+    for idx, pos in enumerate(raw_positions):
+        try:
+            parsed_positions.append(_parse_mirror_position(pos))
+        except (KeyError, ValueError, TypeError, decimal.DecimalException) as exc:
+            raise PortfolioParseError(
+                f"Mirror {payload.get('mirrorID')!r} position[{idx}]: {exc}"
+            ) from exc
+
+    def _opt_decimal(key: str) -> Decimal | None:
+        value = payload.get(key)
+        if value is None:
+            return None
+        return Decimal(str(value))
+
+    def _opt_int(key: str) -> int | None:
+        value = payload.get(key)
+        if value is None:
+            return None
+        return int(value)
+
+    return BrokerMirror(
+        mirror_id=int(payload["mirrorID"]),
+        parent_cid=int(payload["parentCID"]),
+        parent_username=str(payload["parentUsername"]),
+        initial_investment=Decimal(str(payload["initialInvestment"])),
+        deposit_summary=Decimal(str(payload.get("depositSummary", "0"))),
+        withdrawal_summary=Decimal(str(payload.get("withdrawalSummary", "0"))),
+        available_amount=Decimal(str(payload["availableAmount"])),
+        closed_positions_net_profit=Decimal(
+            str(payload["closedPositionsNetProfit"])
+        ),
+        stop_loss_percentage=_opt_decimal("stopLossPercentage"),
+        stop_loss_amount=_opt_decimal("stopLossAmount"),
+        mirror_status_id=_opt_int("mirrorStatusID"),
+        mirror_calculation_type=_opt_int("mirrorCalculationType"),
+        pending_for_closure=bool(payload.get("pendingForClosure", False)),
+        started_copy_date=_parse_iso_datetime(payload["startedCopyDate"]),
+        positions=tuple(parsed_positions),
+        raw_payload=payload,
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_copy_mirrors_parser.py -v`
+
+Expected: all tests PASS (including the earlier position-level tests).
+
+- [ ] **Step 5: Lint + typecheck**
+
+Run: `uv run ruff check app/providers/implementations/etoro_broker.py tests/test_copy_mirrors_parser.py && uv run pyright app/providers/implementations/etoro_broker.py`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/providers/implementations/etoro_broker.py tests/test_copy_mirrors_parser.py
+git commit -m "feat(#183): add _parse_mirror with nested-wrap attribution
+
+Inner loop catches (KeyError, ValueError, TypeError,
+DecimalException) at per-nested-position granularity and
+re-raises as PortfolioParseError with mirror_id + position[idx]
+context. Empty positions[] is a valid state (mirror holds only
+cash). See spec §2.2.2."
+```
+
+---
+
+## Task 8: Wire mirror parsing into `get_portfolio`
+
+**Files:**
+
+- Modify: `app/providers/implementations/etoro_broker.py` — extend `get_portfolio` (line 403-460) to parse `mirrors[]` after the existing positions loop
+- Modify: `tests/test_copy_mirrors_parser.py` — add top-level loop tests (unrecognisable skip, known-mirror raise, fallback wrap)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_copy_mirrors_parser.py`:
+
+```python
+import logging
+
+from app.providers.implementations.etoro_broker import (
+    _parse_mirrors_payload,
+)
+
+
+def test_parse_mirrors_payload_happy_path_two_mirrors() -> None:
+    raw = [_make_mirror_payload(mirrorID=1), _make_mirror_payload(mirrorID=2)]
+    result = _parse_mirrors_payload(raw)
+    assert len(result) == 2
+    assert result[0].mirror_id == 1
+    assert result[1].mirror_id == 2
+
+
+def test_parse_mirrors_payload_skips_unrecognisable_no_mirror_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Spec §2.2.2: the ONLY surviving log-and-skip path is a row
+    with no usable mirrorID — it cannot collide with any known
+    local row, so it is safe to skip."""
+    raw = [
+        {"not a mirror": True},  # no mirrorID → safe skip
+        "not even a dict",  # not a dict → safe skip
+        _make_mirror_payload(mirrorID=42),  # valid → parsed
+    ]
+    with caplog.at_level(logging.WARNING):
+        result = _parse_mirrors_payload(raw)
+    assert len(result) == 1
+    assert result[0].mirror_id == 42
+    assert any("unrecognisable" in rec.message.lower() for rec in caplog.records)
+
+
+def test_parse_mirrors_payload_known_mirror_top_level_failure_raises() -> None:
+    """Spec §2.2.2: a row with a recognisable mirrorID but a
+    missing/malformed required top-level field raises
+    PortfolioParseError — NOT log-and-skip. Otherwise the sync
+    would then interpret this as a disappearance and soft-close
+    the local row (Codex v3 finding V parse-and-soft-close hole)."""
+    bad = _make_mirror_payload(mirrorID=15712187)
+    del bad["availableAmount"]
+    raw = [bad, _make_mirror_payload(mirrorID=42)]
+    with pytest.raises(PortfolioParseError) as excinfo:
+        _parse_mirrors_payload(raw)
+    assert "15712187" in str(excinfo.value)
+    # The underlying cause is a KeyError on the missing key.
+    assert isinstance(excinfo.value.__cause__, KeyError)
+
+
+def test_parse_mirrors_payload_known_mirror_decimal_failure_raises() -> None:
+    """Non-numeric top-level availableAmount raises
+    decimal.InvalidOperation, which the outer fallback catch wraps
+    as PortfolioParseError with mirror_id attribution."""
+    bad = _make_mirror_payload(mirrorID=15712187, availableAmount="bogus")
+    with pytest.raises(PortfolioParseError) as excinfo:
+        _parse_mirrors_payload([bad])
+    assert "15712187" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, decimal.InvalidOperation)
+
+
+def test_parse_mirrors_payload_nested_failure_propagates_unchanged() -> None:
+    """Spec §2.2.2: the outer loop's `except PortfolioParseError: raise`
+    preserves the inner-loop's position[idx] attribution."""
+    bad_pos = _make_position_payload(positionID=9999, units="bogus")
+    bad_mirror = _make_mirror_payload(
+        mirrorID=15712187, positions=[bad_pos]
+    )
+    with pytest.raises(PortfolioParseError) as excinfo:
+        _parse_mirrors_payload([bad_mirror])
+    assert "15712187" in str(excinfo.value)
+    assert "position[0]" in str(excinfo.value)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_copy_mirrors_parser.py -v`
+
+Expected: FAIL — `_parse_mirrors_payload` not yet importable.
+
+- [ ] **Step 3: Add `_parse_mirrors_payload` helper and wire it into `get_portfolio`**
+
+Append to `app/providers/implementations/etoro_broker.py` (below `_parse_mirror`):
+
+```python
+def _parse_mirrors_payload(
+    raw_mirrors: Sequence[Any],
+) -> list[BrokerMirror]:
+    """Parse clientPortfolio.mirrors[] into a list of BrokerMirror.
+
+    Implements the outer top-level loop from spec §2.2.2:
+
+    1. Rows that are not dicts, or dicts with no `mirrorID` key, are
+       logged and skipped (the ONLY surviving log-and-skip path —
+       they cannot collide with any known local row, so silent skip
+       is safe).
+    2. Rows with a recognisable `mirrorID` are parsed via
+       `_parse_mirror`. Any failure raises PortfolioParseError —
+       log-and-skip on a known mirror_id would look like a
+       disappearance to §2.3.4's soft-close and silently destroy
+       the local row.
+    3. PortfolioParseError raised by the nested-position wrap inside
+       `_parse_mirror` is re-raised unchanged so the caller sees the
+       `position[idx]` attribution.
+    4. Any other exception escaping `_parse_mirror` (KeyError,
+       ValueError, TypeError, decimal.DecimalException) is
+       fallback-wrapped in PortfolioParseError with mirror_id-only
+       attribution.
+    """
+    mirrors: list[BrokerMirror] = []
+    for m in raw_mirrors:
+        if not isinstance(m, dict) or "mirrorID" not in m:
+            logger.warning(
+                "Skipping unrecognisable mirrors[] element: %r", m
+            )
+            continue
+
+        try:
+            mirrors.append(_parse_mirror(m))
+        except PortfolioParseError:
+            raise
+        except (KeyError, ValueError, TypeError, decimal.DecimalException) as exc:
+            raise PortfolioParseError(
+                f"Failed to parse mirror {m.get('mirrorID')!r}: {exc}"
+            ) from exc
+    return mirrors
+```
+
+Then edit `get_portfolio` at `app/providers/implementations/etoro_broker.py:422`. Find the `portfolio = raw.get("clientPortfolio") or {}` line and, after `raw_positions = portfolio.get("positions") or []` (line 423), add a sibling line:
+
+```python
+raw_mirrors: list[Any] = portfolio.get("mirrors") or []
+```
+
+And at the `return BrokerPortfolio(...)` at line 456, pass the parsed mirrors:
+
+```python
+return BrokerPortfolio(
+    positions=positions,
+    available_cash=Decimal(str(credit)) if credit is not None else Decimal("0"),
+    raw_payload=raw,
+    mirrors=tuple(_parse_mirrors_payload(raw_mirrors)),
+)
+```
+
+- [ ] **Step 4: Run the parser tests to verify they pass**
+
+Run: `uv run pytest tests/test_copy_mirrors_parser.py -v`
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Run the full broker provider test suite to verify nothing regressed**
+
+Run: `uv run pytest tests/test_broker_provider.py tests/test_copy_mirrors_parser.py -v`
+
+Expected: everything PASS.
+
+- [ ] **Step 6: Lint + typecheck**
+
+Run: `uv run ruff check app/providers/implementations/etoro_broker.py tests/test_copy_mirrors_parser.py && uv run pyright app/providers/implementations/etoro_broker.py`
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/providers/implementations/etoro_broker.py tests/test_copy_mirrors_parser.py
+git commit -m "feat(#183): parse clientPortfolio.mirrors[] in get_portfolio
+
+Top-level _parse_mirrors_payload loop catches PortfolioParseError
+and re-raises unchanged to preserve nested position[idx]
+attribution; fallback wraps (KeyError, ValueError, TypeError,
+DecimalException) on known mirrorIDs; only unrecognisable rows
+(no mirrorID) are log-and-skipped. Closes the Codex v3 finding V
+parse-and-soft-close hole — no known-mirror failure is silently
+skipped."
+```
+
+---
+
+## Task 9: Fixture data builders — `two_mirror_payload`, `parse_failure_payload`, `two_mirror_seed_rows`
+
+**Files:**
+
+- Modify: `tests/fixtures/copy_mirrors.py` — add the three named fixture builders
+
+These are the service-layer test precursors for §8.2 and §8.3. `mirror_aum_fixture`, `no_quote_mirror_fixture`, `mtm_delta_mirror_fixture` are NOT built here — they ship in Track 1b (#187).
+
+- [ ] **Step 1: Add the fixture builders**
+
+Append to `tests/fixtures/copy_mirrors.py`:
+
+```python
+from collections.abc import Sequence
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+from app.providers.broker import (
+    BrokerMirror,
+    BrokerMirrorPosition,
+    BrokerPortfolio,
+    BrokerPosition,
+)
+
+
+def _make_mirror_position(
+    position_id: int,
+    instrument_id: int = 42,
+    units: Decimal = Decimal("6.28927"),
+    open_rate: Decimal = Decimal("1207.4994"),
+    open_conversion_rate: Decimal = Decimal("0.01331"),
+    amount: Decimal = Decimal("101.08"),
+    is_buy: bool = True,
+) -> BrokerMirrorPosition:
+    return BrokerMirrorPosition(
+        position_id=position_id,
+        parent_position_id=position_id + 4000,
+        instrument_id=instrument_id,
+        is_buy=is_buy,
+        units=units,
+        amount=amount,
+        initial_amount_in_dollars=amount,
+        open_rate=open_rate,
+        open_conversion_rate=open_conversion_rate,
+        open_date_time=_NOW,
+        take_profit_rate=None,
+        stop_loss_rate=None,
+        total_fees=Decimal("0"),
+        leverage=1,
+        raw_payload={
+            "positionID": position_id,
+            "instrumentID": instrument_id,
+        },
+    )
+
+
+def _make_mirror(
+    mirror_id: int,
+    parent_cid: int,
+    parent_username: str,
+    positions: Sequence[BrokerMirrorPosition],
+    available_amount: Decimal = Decimal("2800.33"),
+    initial_investment: Decimal = Decimal("20000"),
+    deposit_summary: Decimal = Decimal("0"),
+    withdrawal_summary: Decimal = Decimal("0"),
+    closed_positions_net_profit: Decimal = Decimal("-110.34"),
+) -> BrokerMirror:
+    return BrokerMirror(
+        mirror_id=mirror_id,
+        parent_cid=parent_cid,
+        parent_username=parent_username,
+        initial_investment=initial_investment,
+        deposit_summary=deposit_summary,
+        withdrawal_summary=withdrawal_summary,
+        available_amount=available_amount,
+        closed_positions_net_profit=closed_positions_net_profit,
+        stop_loss_percentage=None,
+        stop_loss_amount=None,
+        mirror_status_id=None,
+        mirror_calculation_type=None,
+        pending_for_closure=False,
+        started_copy_date=_NOW,
+        positions=tuple(positions),
+        raw_payload={"mirrorID": mirror_id, "parentCID": parent_cid},
+    )
+
+
+def two_mirror_payload() -> BrokerPortfolio:
+    """Canonical 2 mirrors × 3 positions each BrokerPortfolio fixture.
+
+    Derived from the real etoro_portfolio_20260411T053000Z.json
+    payload — trimmed for test readability, includes at least one
+    non-USD position (GBP conversion rate 1.158) so the
+    openConversionRate round-trip is exercised in every test that
+    uses this fixture.
+    """
+    mirror_a = _make_mirror(
+        mirror_id=15712187,
+        parent_cid=111,
+        parent_username="thomaspj",
+        available_amount=Decimal("2800.33"),
+        initial_investment=Decimal("20000"),
+        deposit_summary=Decimal("0"),
+        withdrawal_summary=Decimal("0"),
+        closed_positions_net_profit=Decimal("-110.34"),
+        positions=[
+            _make_mirror_position(
+                position_id=1001,
+                instrument_id=42,
+                units=Decimal("6.28927"),
+                open_rate=Decimal("1207.4994"),
+                open_conversion_rate=Decimal("0.01331"),  # JPY
+                amount=Decimal("101.08"),
+            ),
+            _make_mirror_position(
+                position_id=1002,
+                instrument_id=43,
+                units=Decimal("2.0"),
+                open_rate=Decimal("150.00"),
+                open_conversion_rate=Decimal("1.158"),  # GBP
+                amount=Decimal("347.40"),
+            ),
+            _make_mirror_position(
+                position_id=1003,
+                instrument_id=44,
+                units=Decimal("10.0"),
+                open_rate=Decimal("100.00"),
+                open_conversion_rate=Decimal("1.0"),  # USD
+                amount=Decimal("1000.00"),
+            ),
+        ],
+    )
+    mirror_b = _make_mirror(
+        mirror_id=15714660,
+        parent_cid=222,
+        parent_username="triangulacapital",
+        available_amount=Decimal("1724.11"),
+        initial_investment=Decimal("17280"),
+        deposit_summary=Decimal("2251"),
+        withdrawal_summary=Decimal("0"),
+        closed_positions_net_profit=Decimal("-140.13"),
+        positions=[
+            _make_mirror_position(
+                position_id=2001,
+                instrument_id=52,
+                units=Decimal("1.0"),
+                open_rate=Decimal("500.00"),
+                open_conversion_rate=Decimal("1.0"),
+                amount=Decimal("500.00"),
+            ),
+            _make_mirror_position(
+                position_id=2002,
+                instrument_id=53,
+                units=Decimal("3.0"),
+                open_rate=Decimal("200.00"),
+                open_conversion_rate=Decimal("1.0"),
+                amount=Decimal("600.00"),
+            ),
+            _make_mirror_position(
+                position_id=2003,
+                instrument_id=54,
+                units=Decimal("5.0"),
+                open_rate=Decimal("80.00"),
+                open_conversion_rate=Decimal("1.0"),
+                amount=Decimal("400.00"),
+            ),
+        ],
+    )
+    return BrokerPortfolio(
+        positions=(),
+        available_cash=Decimal("0"),
+        raw_payload={},
+        mirrors=(mirror_a, mirror_b),
+    )
+
+
+def parse_failure_payload() -> list[dict[str, Any]]:
+    """Raw `clientPortfolio.mirrors[]` list with one malformed
+    nested position. Used by §8.3 to prove the sync aborts before
+    eviction / soft-close when the parser raises.
+
+    Returns a raw list (not BrokerPortfolio) because the test
+    exercises the parse step itself — `_parse_mirrors_payload`
+    must raise on this input.
+    """
+    return [
+        {
+            "mirrorID": 15712187,
+            "parentCID": 111,
+            "parentUsername": "thomaspj",
+            "initialInvestment": "20000",
+            "depositSummary": "0",
+            "withdrawalSummary": "0",
+            "availableAmount": "2800.33",
+            "closedPositionsNetProfit": "-110.34",
+            "stopLossPercentage": None,
+            "stopLossAmount": None,
+            "mirrorStatusID": None,
+            "mirrorCalculationType": None,
+            "pendingForClosure": False,
+            "startedCopyDate": "2025-01-01T00:00:00Z",
+            "positions": [
+                {
+                    "positionID": 1001,
+                    "parentPositionID": 5001,
+                    "instrumentID": 42,
+                    "isBuy": True,
+                    "units": "bogus",  # <-- non-numeric → DecimalException
+                    "amount": "101.08",
+                    "initialAmountInDollars": "101.08",
+                    "openRate": "1207.4994",
+                    "openConversionRate": "0.01331",
+                    "openDateTime": "2026-04-10T00:00:00Z",
+                    "takeProfitRate": None,
+                    "stopLossRate": None,
+                    "totalFees": "0",
+                    "leverage": 1,
+                },
+            ],
+        }
+    ]
+
+
+def two_mirror_seed_rows(conn: psycopg.Connection[Any]) -> None:
+    """INSERT the two_mirror_payload mirrors directly into
+    copy_traders / copy_mirrors / copy_mirror_positions so
+    disappearance and re-copy tests can seed the DB before
+    calling sync_portfolio with a *different* payload.
+
+    Caller is responsible for commit/rollback. Safe to run only
+    against ebull_test — callers must enforce this themselves
+    before calling (see _assert_test_db in test modules).
+    """
+    payload = two_mirror_payload()
+    with conn.cursor() as cur:
+        for mirror in payload.mirrors:
+            cur.execute(
+                """
+                INSERT INTO copy_traders (parent_cid, parent_username,
+                                          first_seen_at, updated_at)
+                VALUES (%(cid)s, %(username)s, %(now)s, %(now)s)
+                ON CONFLICT (parent_cid) DO NOTHING
+                """,
+                {
+                    "cid": mirror.parent_cid,
+                    "username": mirror.parent_username,
+                    "now": _NOW,
+                },
+            )
+            cur.execute(
+                """
+                INSERT INTO copy_mirrors (
+                    mirror_id, parent_cid, initial_investment,
+                    deposit_summary, withdrawal_summary,
+                    available_amount, closed_positions_net_profit,
+                    stop_loss_percentage, stop_loss_amount,
+                    mirror_status_id, mirror_calculation_type,
+                    pending_for_closure, started_copy_date,
+                    active, closed_at, raw_payload, updated_at
+                ) VALUES (
+                    %(mirror_id)s, %(parent_cid)s, %(initial_investment)s,
+                    %(deposit_summary)s, %(withdrawal_summary)s,
+                    %(available_amount)s, %(closed_positions_net_profit)s,
+                    NULL, NULL, NULL, NULL, FALSE, %(started_copy_date)s,
+                    TRUE, NULL, %(raw_payload)s::jsonb, %(now)s
+                )
+                """,
+                {
+                    "mirror_id": mirror.mirror_id,
+                    "parent_cid": mirror.parent_cid,
+                    "initial_investment": mirror.initial_investment,
+                    "deposit_summary": mirror.deposit_summary,
+                    "withdrawal_summary": mirror.withdrawal_summary,
+                    "available_amount": mirror.available_amount,
+                    "closed_positions_net_profit": mirror.closed_positions_net_profit,
+                    "started_copy_date": mirror.started_copy_date,
+                    "raw_payload": psycopg.types.json.Jsonb(mirror.raw_payload),
+                    "now": _NOW,
+                },
+            )
+            for pos in mirror.positions:
+                cur.execute(
+                    """
+                    INSERT INTO copy_mirror_positions (
+                        mirror_id, position_id, parent_position_id,
+                        instrument_id, is_buy, units, amount,
+                        initial_amount_in_dollars, open_rate,
+                        open_conversion_rate, open_date_time,
+                        take_profit_rate, stop_loss_rate,
+                        total_fees, leverage, raw_payload, updated_at
+                    ) VALUES (
+                        %(mirror_id)s, %(position_id)s, %(parent_position_id)s,
+                        %(instrument_id)s, %(is_buy)s, %(units)s, %(amount)s,
+                        %(initial_amount)s, %(open_rate)s,
+                        %(open_conversion_rate)s, %(open_date_time)s,
+                        %(take_profit_rate)s, %(stop_loss_rate)s,
+                        %(total_fees)s, %(leverage)s, %(raw_payload)s::jsonb,
+                        %(now)s
+                    )
+                    """,
+                    {
+                        "mirror_id": mirror.mirror_id,
+                        "position_id": pos.position_id,
+                        "parent_position_id": pos.parent_position_id,
+                        "instrument_id": pos.instrument_id,
+                        "is_buy": pos.is_buy,
+                        "units": pos.units,
+                        "amount": pos.amount,
+                        "initial_amount": pos.initial_amount_in_dollars,
+                        "open_rate": pos.open_rate,
+                        "open_conversion_rate": pos.open_conversion_rate,
+                        "open_date_time": pos.open_date_time,
+                        "take_profit_rate": pos.take_profit_rate,
+                        "stop_loss_rate": pos.stop_loss_rate,
+                        "total_fees": pos.total_fees,
+                        "leverage": pos.leverage,
+                        "raw_payload": psycopg.types.json.Jsonb(pos.raw_payload),
+                        "now": _NOW,
+                    },
+                )
+```
+
+At the top of the file, update the imports block to add `psycopg`:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.types.json
+
+from app.providers.broker import (
+    BrokerMirror,
+    BrokerMirrorPosition,
+    BrokerPortfolio,
+)
+```
+
+(The `BrokerPosition` import is not needed yet — Track 1b tests that use mirror_aum_fixture will add it. `psycopg.rows` is not imported here: `two_mirror_seed_rows` uses a plain `conn.cursor()` with the default tuple row factory, so the submodule reference is unnecessary — adding it would be an unused import ruff failure.)
+
+- [ ] **Step 2: Verify imports and basic shapes**
+
+Run: `uv run python -c "from tests.fixtures.copy_mirrors import two_mirror_payload, parse_failure_payload; p = two_mirror_payload(); print(len(p.mirrors), len(p.mirrors[0].positions)); print(len(parse_failure_payload()))"`
+
+Expected: `2 3` and `1`.
+
+- [ ] **Step 3: Lint + typecheck**
+
+Run: `uv run ruff check tests/fixtures/copy_mirrors.py && uv run ruff format --check tests/fixtures/copy_mirrors.py && uv run pyright tests/fixtures/copy_mirrors.py`
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/fixtures/copy_mirrors.py
+git commit -m "test(#183): add two_mirror_payload and seed helper fixtures
+
+Three named builders per spec §8.0: two_mirror_payload (2×3
+canonical BrokerPortfolio with a non-USD position),
+parse_failure_payload (raw dict with non-numeric units for the
+parser-abort test), two_mirror_seed_rows (direct INSERT into
+copy_* tables for disappearance/re-copy test setup).
+mirror_aum_fixture etc. land in Track 1b."
+```
+
+---
+
+## Task 10: Extend `PortfolioSyncResult` with mirror counters
+
+**Files:**
+
+- Modify: `app/services/portfolio_sync.py` — add three new fields to the dataclass
+- Modify: `tests/test_portfolio_sync.py` — add a construction test for the new fields
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_portfolio_sync.py`:
+
+```python
+def test_portfolio_sync_result_has_mirror_counters() -> None:
+    """Spec §2.3 result extension — mirrors_upserted, mirrors_closed,
+    mirror_positions_upserted are part of the return contract."""
+    result = PortfolioSyncResult(
+        positions_updated=0,
+        positions_opened_externally=0,
+        positions_closed_externally=0,
+        cash_delta=Decimal("0"),
+        broker_cash=Decimal("0"),
+        local_cash=Decimal("0"),
+        mirrors_upserted=2,
+        mirrors_closed=1,
+        mirror_positions_upserted=6,
+    )
+    assert result.mirrors_upserted == 2
+    assert result.mirrors_closed == 1
+    assert result.mirror_positions_upserted == 6
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_portfolio_sync.py::test_portfolio_sync_result_has_mirror_counters -v`
+
+Expected: FAIL with `TypeError: PortfolioSyncResult.__init__() got an unexpected keyword argument 'mirrors_upserted'`.
+
+- [ ] **Step 3: Extend the dataclass**
+
+Edit `app/services/portfolio_sync.py:43-52`. Replace:
+
+```python
+@dataclass
+class PortfolioSyncResult:
+    """Summary of a portfolio sync run."""
+
+    positions_updated: int
+    positions_opened_externally: int
+    positions_closed_externally: int
+    cash_delta: Decimal
+    broker_cash: Decimal
+    local_cash: Decimal
+```
+
+With:
+
+```python
+@dataclass
+class PortfolioSyncResult:
+    """Summary of a portfolio sync run."""
+
+    positions_updated: int
+    positions_opened_externally: int
+    positions_closed_externally: int
+    cash_delta: Decimal
+    broker_cash: Decimal
+    local_cash: Decimal
+    mirrors_upserted: int = 0
+    mirrors_closed: int = 0
+    mirror_positions_upserted: int = 0
+```
+
+Defaults of `0` preserve every existing test that constructs `PortfolioSyncResult` without the new fields — the existing assertions in `tests/test_portfolio_sync.py` do not need updating.
+
+- [ ] **Step 4: Run the full test file**
+
+Run: `uv run pytest tests/test_portfolio_sync.py -v`
+
+Expected: the new test PASSES, and every existing test still passes (no regression from the default-value additions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/portfolio_sync.py tests/test_portfolio_sync.py
+git commit -m "feat(#183): extend PortfolioSyncResult with mirror counters
+
+New fields mirrors_upserted, mirrors_closed,
+mirror_positions_upserted default to 0 so existing call sites
+compile unchanged. Populated by _sync_mirrors in the next task."
+```
+
+---
+
+## Task 11: `_sync_mirrors` — upsert path (copy_traders + copy_mirrors + copy_mirror_positions)
+
+**Files:**
+
+- Modify: `app/services/portfolio_sync.py` — add `_sync_mirrors(conn, mirrors, now)` helper with the upsert path only (eviction, soft-close, and total-disappearance guard come in Tasks 12–14)
+- Create: `tests/test_portfolio_sync_mirrors.py` — new service-layer test module using `ebull_test`
+
+- [ ] **Step 1: Create the service-layer test module skeleton**
+
+The test module needs a cleanup fixture and a helper to copy the `_assert_test_db` guard pattern from `tests/test_operator_setup_race.py`.
+
+```python
+# tests/test_portfolio_sync_mirrors.py
+"""§8.2 + §8.3 service-layer tests for copy-trading mirror sync.
+
+All tests run against the dedicated ebull_test database (never
+settings.database_url) — the same isolation pattern as
+tests/test_operator_setup_race.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.providers.broker import BrokerPortfolio
+from app.providers.implementations.etoro_broker import (
+    PortfolioParseError,
+    _parse_mirrors_payload,
+)
+from app.services.portfolio_sync import sync_portfolio
+from tests.fixtures.copy_mirrors import (
+    _NOW,
+    parse_failure_payload,
+    two_mirror_payload,
+    two_mirror_seed_rows,
+)
+from tests.test_operator_setup_race import (
+    _assert_test_db,
+    _test_database_url,
+    _test_db_available,
+)
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test DB unavailable — skipping real-DB mirror sync test",
+)
+
+
+@pytest.fixture
+def conn() -> Iterator[psycopg.Connection[Any]]:
+    """Yield a fresh connection to ebull_test with copy_* tables
+    truncated at the start of each test. Rollback on failure."""
+    with psycopg.connect(_test_database_url()) as c:
+        _assert_test_db(c)
+        with c.cursor() as cur:
+            cur.execute(
+                "TRUNCATE copy_mirror_positions, copy_mirrors, copy_traders "
+                "RESTART IDENTITY CASCADE"
+            )
+        c.commit()
+        yield c
+        c.rollback()
+
+
+def _count(conn: psycopg.Connection[Any], table: str) -> int:
+    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+        cur.execute(f"SELECT COUNT(*) FROM {table}")  # table is hard-coded
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+
+
+def _empty_local_portfolio(payload: BrokerPortfolio) -> BrokerPortfolio:
+    """Wrap a two_mirror_payload in a BrokerPortfolio with no
+    broker-side positions or cash — so the positions/cash sync
+    branches are no-ops and we test only the mirror branch."""
+    return payload
+
+
+def test_sync_mirrors_fresh_insert(conn: psycopg.Connection[Any]) -> None:
+    """Spec §8.2: first sync inserts copy_traders + copy_mirrors +
+    copy_mirror_positions rows with active=TRUE."""
+    payload = two_mirror_payload()
+    result = sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+
+    assert _count(conn, "copy_traders") == 2
+    assert _count(conn, "copy_mirrors") == 2
+    assert _count(conn, "copy_mirror_positions") == 6
+    assert result.mirrors_upserted == 2
+    assert result.mirror_positions_upserted == 6
+    assert result.mirrors_closed == 0
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT active, closed_at FROM copy_mirrors ORDER BY mirror_id"
+        )
+        rows = cur.fetchall()
+    for row in rows:
+        assert row["active"] is True
+        assert row["closed_at"] is None
+
+
+def test_sync_mirrors_idempotent_resync(conn: psycopg.Connection[Any]) -> None:
+    """Spec §8.2: re-running the same payload is idempotent —
+    row counts unchanged, active still TRUE, updated_at refreshed."""
+    payload = two_mirror_payload()
+    sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+    sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+
+    assert _count(conn, "copy_traders") == 2
+    assert _count(conn, "copy_mirrors") == 2
+    assert _count(conn, "copy_mirror_positions") == 6
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_portfolio_sync_mirrors.py -v`
+
+Expected: FAIL — either the tables don't receive mirror rows (because `_sync_mirrors` isn't wired yet) or the fixture setup trips.
+
+- [ ] **Step 3: Add the `_sync_mirrors` helper and wire it into `sync_portfolio`**
+
+Edit `app/services/portfolio_sync.py`. Update imports at the top (line 35) to include the new dataclasses:
+
+```python
+from app.providers.broker import (
+    BrokerMirror,
+    BrokerPortfolio,
+    BrokerPosition,
+)
+```
+
+Add the helper below `_aggregate_by_instrument` (around line 110), before `sync_portfolio`:
+
+```python
+def _sync_mirrors(
+    conn: psycopg.Connection[Any],
+    mirrors: Sequence[BrokerMirror],
+    now: datetime,
+) -> tuple[int, int, int]:
+    """Upsert copy_traders/copy_mirrors/copy_mirror_positions from a
+    freshly-parsed mirror payload. Returns
+    ``(mirrors_upserted, mirror_positions_upserted, mirrors_closed)``.
+
+    Must be called inside the caller's transaction — this function
+    never commits. Caller owns rollback on any raise.
+
+    Disappearance handling (total → raise, partial → soft-close)
+    lives in the caller or in a follow-up step; this function only
+    handles the rows that are present in the payload.
+
+    Single-writer serialisation is guaranteed by JobRuntime's
+    APScheduler+JobLock stack (spec §2.3.1); _sync_mirrors does not
+    take its own advisory lock.
+    """
+    mirrors_upserted = 0
+    mirror_positions_upserted = 0
+
+    for mirror in mirrors:
+        # 1. Upsert the trader row (parent_cid is the identity
+        #    spine).
+        conn.execute(
+            """
+            INSERT INTO copy_traders (
+                parent_cid, parent_username, first_seen_at, updated_at
+            ) VALUES (
+                %(cid)s, %(username)s, %(now)s, %(now)s
+            )
+            ON CONFLICT (parent_cid) DO UPDATE SET
+                parent_username = EXCLUDED.parent_username,
+                updated_at = EXCLUDED.updated_at
+            """,
+            {
+                "cid": mirror.parent_cid,
+                "username": mirror.parent_username,
+                "now": now,
+            },
+        )
+
+        # 2. Upsert the mirror row. active=TRUE, closed_at=NULL on
+        #    every row the payload contains — re-copy of a
+        #    previously-closed mirror_id flips those back to live.
+        conn.execute(
+            """
+            INSERT INTO copy_mirrors (
+                mirror_id, parent_cid, initial_investment,
+                deposit_summary, withdrawal_summary,
+                available_amount, closed_positions_net_profit,
+                stop_loss_percentage, stop_loss_amount,
+                mirror_status_id, mirror_calculation_type,
+                pending_for_closure, started_copy_date,
+                active, closed_at, raw_payload, updated_at
+            ) VALUES (
+                %(mirror_id)s, %(parent_cid)s, %(initial_investment)s,
+                %(deposit_summary)s, %(withdrawal_summary)s,
+                %(available_amount)s, %(closed_positions_net_profit)s,
+                %(stop_loss_percentage)s, %(stop_loss_amount)s,
+                %(mirror_status_id)s, %(mirror_calculation_type)s,
+                %(pending_for_closure)s, %(started_copy_date)s,
+                TRUE, NULL, %(raw_payload)s, %(now)s
+            )
+            ON CONFLICT (mirror_id) DO UPDATE SET
+                parent_cid                  = EXCLUDED.parent_cid,
+                initial_investment          = EXCLUDED.initial_investment,
+                deposit_summary             = EXCLUDED.deposit_summary,
+                withdrawal_summary          = EXCLUDED.withdrawal_summary,
+                available_amount            = EXCLUDED.available_amount,
+                closed_positions_net_profit = EXCLUDED.closed_positions_net_profit,
+                stop_loss_percentage        = EXCLUDED.stop_loss_percentage,
+                stop_loss_amount            = EXCLUDED.stop_loss_amount,
+                mirror_status_id            = EXCLUDED.mirror_status_id,
+                mirror_calculation_type     = EXCLUDED.mirror_calculation_type,
+                pending_for_closure         = EXCLUDED.pending_for_closure,
+                started_copy_date           = EXCLUDED.started_copy_date,
+                active                      = TRUE,
+                closed_at                   = NULL,
+                raw_payload                 = EXCLUDED.raw_payload,
+                updated_at                  = EXCLUDED.updated_at
+            """,
+            {
+                "mirror_id": mirror.mirror_id,
+                "parent_cid": mirror.parent_cid,
+                "initial_investment": mirror.initial_investment,
+                "deposit_summary": mirror.deposit_summary,
+                "withdrawal_summary": mirror.withdrawal_summary,
+                "available_amount": mirror.available_amount,
+                "closed_positions_net_profit": mirror.closed_positions_net_profit,
+                "stop_loss_percentage": mirror.stop_loss_percentage,
+                "stop_loss_amount": mirror.stop_loss_amount,
+                "mirror_status_id": mirror.mirror_status_id,
+                "mirror_calculation_type": mirror.mirror_calculation_type,
+                "pending_for_closure": mirror.pending_for_closure,
+                "started_copy_date": mirror.started_copy_date,
+                "raw_payload": psycopg.types.json.Jsonb(mirror.raw_payload),
+                "now": now,
+            },
+        )
+        mirrors_upserted += 1
+
+        # 3. Upsert every nested position in the payload. Eviction
+        #    of disappeared positions is a separate statement (see
+        #    Task 12).
+        for pos in mirror.positions:
+            conn.execute(
+                """
+                INSERT INTO copy_mirror_positions (
+                    mirror_id, position_id, parent_position_id,
+                    instrument_id, is_buy, units, amount,
+                    initial_amount_in_dollars, open_rate,
+                    open_conversion_rate, open_date_time,
+                    take_profit_rate, stop_loss_rate,
+                    total_fees, leverage, raw_payload, updated_at
+                ) VALUES (
+                    %(mirror_id)s, %(position_id)s, %(parent_position_id)s,
+                    %(instrument_id)s, %(is_buy)s, %(units)s, %(amount)s,
+                    %(initial_amount)s, %(open_rate)s,
+                    %(open_conversion_rate)s, %(open_date_time)s,
+                    %(take_profit_rate)s, %(stop_loss_rate)s,
+                    %(total_fees)s, %(leverage)s, %(raw_payload)s,
+                    %(now)s
+                )
+                ON CONFLICT (mirror_id, position_id) DO UPDATE SET
+                    parent_position_id        = EXCLUDED.parent_position_id,
+                    instrument_id             = EXCLUDED.instrument_id,
+                    is_buy                    = EXCLUDED.is_buy,
+                    units                     = EXCLUDED.units,
+                    amount                    = EXCLUDED.amount,
+                    initial_amount_in_dollars = EXCLUDED.initial_amount_in_dollars,
+                    open_rate                 = EXCLUDED.open_rate,
+                    open_conversion_rate      = EXCLUDED.open_conversion_rate,
+                    open_date_time            = EXCLUDED.open_date_time,
+                    take_profit_rate          = EXCLUDED.take_profit_rate,
+                    stop_loss_rate            = EXCLUDED.stop_loss_rate,
+                    total_fees                = EXCLUDED.total_fees,
+                    leverage                  = EXCLUDED.leverage,
+                    raw_payload               = EXCLUDED.raw_payload,
+                    updated_at                = EXCLUDED.updated_at
+                """,
+                {
+                    "mirror_id": mirror.mirror_id,
+                    "position_id": pos.position_id,
+                    "parent_position_id": pos.parent_position_id,
+                    "instrument_id": pos.instrument_id,
+                    "is_buy": pos.is_buy,
+                    "units": pos.units,
+                    "amount": pos.amount,
+                    "initial_amount": pos.initial_amount_in_dollars,
+                    "open_rate": pos.open_rate,
+                    "open_conversion_rate": pos.open_conversion_rate,
+                    "open_date_time": pos.open_date_time,
+                    "take_profit_rate": pos.take_profit_rate,
+                    "stop_loss_rate": pos.stop_loss_rate,
+                    "total_fees": pos.total_fees,
+                    "leverage": pos.leverage,
+                    "raw_payload": psycopg.types.json.Jsonb(pos.raw_payload),
+                    "now": now,
+                },
+            )
+            mirror_positions_upserted += 1
+
+    mirrors_closed = 0  # populated by Task 12 soft-close step
+    return mirrors_upserted, mirror_positions_upserted, mirrors_closed
+```
+
+Add the `psycopg.types.json` import near the top:
+
+```python
+import psycopg
+import psycopg.rows
+import psycopg.types.json
+```
+
+Now wire `_sync_mirrors` into `sync_portfolio`. At the end of `sync_portfolio` (just before the `return PortfolioSyncResult(...)` at line 297), add:
+
+```python
+    # 4. Reconcile copy-trading mirrors (spec §2.3).
+    mirrors_upserted, mirror_positions_upserted, mirrors_closed = _sync_mirrors(
+        conn, portfolio.mirrors, now
+    )
+```
+
+And update the return statement to pass the new fields:
+
+```python
+    return PortfolioSyncResult(
+        positions_updated=updated,
+        positions_opened_externally=opened_externally,
+        positions_closed_externally=closed_externally,
+        cash_delta=cash_delta,
+        broker_cash=broker_cash,
+        local_cash=local_cash,
+        mirrors_upserted=mirrors_upserted,
+        mirrors_closed=mirrors_closed,
+        mirror_positions_upserted=mirror_positions_upserted,
+    )
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `uv run pytest tests/test_portfolio_sync_mirrors.py::test_sync_mirrors_fresh_insert tests/test_portfolio_sync_mirrors.py::test_sync_mirrors_idempotent_resync -v`
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Re-run the full test_portfolio_sync.py to catch regressions**
+
+Run: `uv run pytest tests/test_portfolio_sync.py tests/test_portfolio_sync_mirrors.py -v`
+
+Expected: all PASS. The mock-based tests in `test_portfolio_sync.py` may now need an update if their mock cursor chokes on the new `conn.execute("INSERT INTO copy_traders ...")` — if so, extend `_mock_conn` to match "INSERT INTO copy_traders" / "INSERT INTO copy_mirrors" / "INSERT INTO copy_mirror_positions" as no-op writes.
+
+- [ ] **Step 6: Lint + typecheck**
+
+Run: `uv run ruff check app/services/portfolio_sync.py tests/test_portfolio_sync_mirrors.py && uv run pyright app/services/portfolio_sync.py`
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/portfolio_sync.py tests/test_portfolio_sync_mirrors.py
+git commit -m "feat(#183): _sync_mirrors upsert path
+
+Upserts copy_traders/copy_mirrors/copy_mirror_positions from the
+BrokerPortfolio.mirrors field inside the existing sync_portfolio
+transaction. Re-copy of a previously-closed mirror_id resets
+active=TRUE, closed_at=NULL via the ON CONFLICT clause. Nested
+position eviction and soft-close land in the next tasks."
+```
+
+---
+
+## Task 12: Nested position eviction
+
+**Files:**
+
+- Modify: `app/services/portfolio_sync.py` — extend `_sync_mirrors` to DELETE disappeared nested positions per mirror
+- Modify: `tests/test_portfolio_sync_mirrors.py` — add eviction test
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_portfolio_sync_mirrors.py`:
+
+```python
+import dataclasses
+
+
+def test_sync_mirrors_evicts_closed_nested_positions(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.3.2: a nested position removed from the payload is
+    DELETEd from copy_mirror_positions. Sibling positions in the
+    same mirror and positions in other mirrors are untouched.
+    copy_mirrors.active stays TRUE."""
+    payload = two_mirror_payload()
+    sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+    assert _count(conn, "copy_mirror_positions") == 6
+
+    # Remove one nested position from the first mirror and re-sync.
+    trimmed_positions = payload.mirrors[0].positions[1:]  # drop pos 1001
+    trimmed_mirror = dataclasses.replace(
+        payload.mirrors[0], positions=trimmed_positions
+    )
+    trimmed_payload = dataclasses.replace(
+        payload,
+        mirrors=(trimmed_mirror, payload.mirrors[1]),
+    )
+    sync_portfolio(conn, trimmed_payload, now=_NOW)
+    conn.commit()
+
+    # The removed row is gone, siblings remain.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT position_id FROM copy_mirror_positions
+            WHERE mirror_id = %s ORDER BY position_id
+            """,
+            (payload.mirrors[0].mirror_id,),
+        )
+        remaining = [r["position_id"] for r in cur.fetchall()]
+    assert remaining == [1002, 1003]
+
+    # The other mirror is untouched.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS n FROM copy_mirror_positions WHERE mirror_id = %s",
+            (payload.mirrors[1].mirror_id,),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row["n"] == 3
+
+    # The mirror row itself is still active.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT active FROM copy_mirrors WHERE mirror_id = %s",
+            (payload.mirrors[0].mirror_id,),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row["active"] is True
+
+
+def test_sync_mirrors_evicts_all_positions_when_mirror_empties(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.3.2: an empty positions[] evicts every nested row for
+    that mirror (exploits Postgres `position_id <> ALL('{}')` === TRUE
+    semantics)."""
+    payload = two_mirror_payload()
+    sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+
+    empty_mirror = dataclasses.replace(payload.mirrors[0], positions=())
+    emptied_payload = dataclasses.replace(
+        payload,
+        mirrors=(empty_mirror, payload.mirrors[1]),
+    )
+    sync_portfolio(conn, emptied_payload, now=_NOW)
+    conn.commit()
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS n FROM copy_mirror_positions WHERE mirror_id = %s",
+            (payload.mirrors[0].mirror_id,),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row["n"] == 0
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_portfolio_sync_mirrors.py::test_sync_mirrors_evicts_closed_nested_positions tests/test_portfolio_sync_mirrors.py::test_sync_mirrors_evicts_all_positions_when_mirror_empties -v`
+
+Expected: FAIL — the removed position is still in the DB because `_sync_mirrors` has no eviction step yet.
+
+- [ ] **Step 3: Add the eviction step**
+
+In `app/services/portfolio_sync.py`, inside `_sync_mirrors`, **before** the inner `for pos in mirror.positions:` upsert loop, add the eviction step. The ordering is: (1) upsert copy_traders, (2) upsert copy_mirrors, (3) evict disappeared positions for this mirror, (4) upsert remaining positions.
+
+Update the per-mirror section of `_sync_mirrors`:
+
+```python
+        # 3a. Evict nested positions that have closed since the last
+        #     sync. Passing the new IDs as a single array parameter
+        #     sidesteps the empty-list SQL parser error and exploits
+        #     Postgres's `position_id <> ALL('{}')` === TRUE semantics
+        #     to correctly delete every existing row when the payload
+        #     has zero positions for this mirror.
+        current_position_ids = [int(p.position_id) for p in mirror.positions]
+        conn.execute(
+            """
+            DELETE FROM copy_mirror_positions
+            WHERE mirror_id = %(mirror_id)s
+              AND position_id <> ALL(%(position_ids)s::bigint[])
+            """,
+            {
+                "mirror_id": mirror.mirror_id,
+                "position_ids": current_position_ids,
+            },
+        )
+
+        # 3b. Upsert every position in the payload.
+        for pos in mirror.positions:
+            # ... existing INSERT...ON CONFLICT ... (unchanged)
+```
+
+(Keep the existing inner `for pos in mirror.positions:` loop exactly as it is — only the DELETE statement is new, inserted immediately before the loop.)
+
+- [ ] **Step 4: Run the tests**
+
+Run: `uv run pytest tests/test_portfolio_sync_mirrors.py -v`
+
+Expected: all tests PASS, including the new eviction tests and the earlier upsert/idempotency tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/portfolio_sync.py tests/test_portfolio_sync_mirrors.py
+git commit -m "feat(#183): evict disappeared nested mirror positions
+
+DELETE FROM copy_mirror_positions WHERE mirror_id = ? AND
+position_id <> ALL(?::bigint[]) runs once per mirror before the
+per-position upsert loop. Empty array correctly deletes every
+row for that mirror via Postgres's `<> ALL('{}')` === TRUE
+semantics — no special-case branch."
+```
+
+---
+
+## Task 13: Partial-disappearance soft-close + re-copy
+
+**Files:**
+
+- Modify: `app/services/portfolio_sync.py` — extend `_sync_mirrors` with the soft-close step after the per-mirror upsert loop
+- Modify: `tests/test_portfolio_sync_mirrors.py` — add partial-disappearance and re-copy tests
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_portfolio_sync_mirrors.py`:
+
+```python
+def test_sync_mirrors_partial_disappearance_soft_closes(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.3.4: a mirror that disappears from the payload
+    (while other mirrors are still present) is soft-closed —
+    active=FALSE, closed_at=%(now)s. Nested positions are RETAINED
+    for audit."""
+    two_mirror_seed_rows(conn)
+    conn.commit()
+    assert _count(conn, "copy_mirrors") == 2
+
+    # Sync a payload that only contains the second mirror.
+    full_payload = two_mirror_payload()
+    partial_payload = dataclasses.replace(
+        full_payload,
+        mirrors=(full_payload.mirrors[1],),  # drop mirror A
+    )
+    result = sync_portfolio(conn, partial_payload, now=_NOW)
+    conn.commit()
+
+    # Mirror A: soft-closed, nested positions retained.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT active, closed_at FROM copy_mirrors
+            WHERE mirror_id = %s
+            """,
+            (full_payload.mirrors[0].mirror_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row["active"] is False
+    assert row["closed_at"] == _NOW
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS n FROM copy_mirror_positions WHERE mirror_id = %s",
+            (full_payload.mirrors[0].mirror_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row["n"] == 3  # retained for audit
+
+    # Mirror B: still active.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT active FROM copy_mirrors WHERE mirror_id = %s",
+            (full_payload.mirrors[1].mirror_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row["active"] is True
+
+    assert result.mirrors_closed == 1
+
+
+def test_sync_mirrors_recopy_resurrects_closed_mirror(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.3.4 / §1.2: if eToro reuses a previously-seen
+    mirror_id, the ON CONFLICT DO UPDATE clause resets
+    active=TRUE, closed_at=NULL so the mirror is live again."""
+    two_mirror_seed_rows(conn)
+    # Pre-close mirror A so it starts the test soft-closed.
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE copy_mirrors
+               SET active = FALSE,
+                   closed_at = %(closed)s
+             WHERE mirror_id = %(mid)s
+            """,
+            {
+                "closed": _NOW,
+                "mid": two_mirror_payload().mirrors[0].mirror_id,
+            },
+        )
+    conn.commit()
+
+    # Sync the full payload — mirror A re-appears.
+    sync_portfolio(conn, two_mirror_payload(), now=_NOW)
+    conn.commit()
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT active, closed_at FROM copy_mirrors WHERE mirror_id = %s",
+            (two_mirror_payload().mirrors[0].mirror_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row["active"] is True
+    assert row["closed_at"] is None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_portfolio_sync_mirrors.py::test_sync_mirrors_partial_disappearance_soft_closes tests/test_portfolio_sync_mirrors.py::test_sync_mirrors_recopy_resurrects_closed_mirror -v`
+
+Expected: FAIL — mirror A stays active because the soft-close step doesn't exist yet. The re-copy test may pass (the ON CONFLICT clause from Task 11 already resets active/closed_at), but keep it as regression coverage.
+
+- [ ] **Step 3: Add the soft-close step to `_sync_mirrors`**
+
+Edit `_sync_mirrors` in `app/services/portfolio_sync.py`. After the per-mirror upsert loop and before the `return` statement, add:
+
+```python
+    # 4. Disappearance handling (§2.3.4).
+    #
+    # Total disappearance (payload empty AND active local rows
+    # exist) is handled in step 5 below — it raises to force
+    # operator investigation. Here we soft-close mirrors that have
+    # disappeared from a NON-EMPTY payload.
+    payload_mirror_ids = [int(m.mirror_id) for m in mirrors]
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT mirror_id FROM copy_mirrors WHERE active = TRUE"
+        )
+        active_local_ids = {int(r["mirror_id"]) for r in cur.fetchall()}
+
+    disappeared_ids = sorted(active_local_ids - set(payload_mirror_ids))
+
+    if not payload_mirror_ids and active_local_ids:
+        # Total disappearance — raise for operator investigation.
+        # See step 5 (Task 14) for the exact error contract.
+        raise RuntimeError(
+            "Broker returned empty mirrors[] but "
+            f"{len(active_local_ids)} active local mirror(s) exist — "
+            "refusing to soft-close en masse. Likely upstream API "
+            "regression; investigate before manual cleanup."
+        )
+
+    if disappeared_ids:
+        conn.execute(
+            """
+            UPDATE copy_mirrors
+               SET active = FALSE,
+                   closed_at = %(now)s,
+                   updated_at = %(now)s
+             WHERE mirror_id = ANY(%(disappeared_ids)s::bigint[])
+               AND active = TRUE
+            """,
+            {
+                "now": now,
+                "disappeared_ids": disappeared_ids,
+            },
+        )
+        for mirror_id in disappeared_ids:
+            logger.info(
+                "mirror %d disappeared from payload — marked closed",
+                mirror_id,
+            )
+        mirrors_closed = len(disappeared_ids)
+```
+
+Update the `return` at the bottom of `_sync_mirrors` — `mirrors_closed` is now populated above, so the earlier `mirrors_closed = 0` default-line becomes an initial assignment:
+
+```python
+    mirrors_closed = 0
+    # ... existing upsert loop ...
+    # ... soft-close step above may set mirrors_closed = len(disappeared_ids) ...
+    return mirrors_upserted, mirror_positions_upserted, mirrors_closed
+```
+
+Make sure `mirrors_closed = 0` is declared *before* the for-mirror upsert loop, not after it, so the soft-close step can reassign it.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `uv run pytest tests/test_portfolio_sync_mirrors.py -v`
+
+Expected: all tests PASS including the new partial-disappearance and re-copy tests and the earlier upsert/eviction tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/portfolio_sync.py tests/test_portfolio_sync_mirrors.py
+git commit -m "feat(#183): soft-close disappeared mirrors
+
+Partial disappearance (payload non-empty AND disappeared_ids
+non-empty) flips active=FALSE, closed_at=%(now)s on the
+affected rows. Nested copy_mirror_positions are retained for
+audit — the §3.4 AUM query's WHERE m.active filter excludes
+closed mirrors from forward-looking calculations without
+deleting their history. Re-copy of a closed mirror_id is
+already covered by Task 11's ON CONFLICT clause."
+```
+
+---
+
+## Task 14: Total-disappearance raise + parser-failure rollback (pre-eviction)
+
+**Files:**
+
+- Modify: `app/services/portfolio_sync.py` — no code changes (the raise from Task 13 already covers step 5; Task 14 is test-only, asserting the invariant holds and the parser-failure path rolls back cleanly)
+- Modify: `tests/test_portfolio_sync_mirrors.py` — add total-disappearance and parser-failure tests
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_portfolio_sync_mirrors.py`:
+
+```python
+def test_sync_mirrors_total_disappearance_raises(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.3.4 asymmetry: if the payload mirrors[] is empty but
+    local active mirrors exist, raise RuntimeError. Rows survive
+    unchanged after the rollback."""
+    two_mirror_seed_rows(conn)
+    conn.commit()
+
+    empty_payload = dataclasses.replace(two_mirror_payload(), mirrors=())
+
+    with pytest.raises(RuntimeError, match="empty mirrors"):
+        sync_portfolio(conn, empty_payload, now=_NOW)
+    conn.rollback()
+
+    # Both rows survive as active=TRUE.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT active FROM copy_mirrors ORDER BY mirror_id")
+        rows = cur.fetchall()
+    assert len(rows) == 2
+    assert all(r["active"] is True for r in rows)
+
+
+def test_sync_mirrors_parser_failure_aborts_before_eviction(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.3.3: if _parse_mirrors_payload raises
+    PortfolioParseError, the sync transaction is rolled back before
+    any upsert or eviction touches the DB. Seed rows survive
+    unchanged — this is the regression test for the Codex v3
+    finding V parse-and-soft-close hole."""
+    two_mirror_seed_rows(conn)
+    conn.commit()
+    baseline_positions = _count(conn, "copy_mirror_positions")
+    assert baseline_positions == 6
+
+    raw_failure = parse_failure_payload()
+    with pytest.raises(PortfolioParseError):
+        # The failure fires inside the parser — callers of
+        # sync_portfolio parse first, then call sync. In production
+        # this is get_portfolio → sync_portfolio; in tests we
+        # exercise the same ordering explicitly.
+        _ = _parse_mirrors_payload(raw_failure)
+
+    # sync_portfolio is never called — rows untouched.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT active FROM copy_mirrors ORDER BY mirror_id")
+        rows = cur.fetchall()
+    assert len(rows) == 2
+    assert all(r["active"] is True for r in rows)
+    assert _count(conn, "copy_mirror_positions") == baseline_positions
+
+
+def test_sync_mirrors_known_mirror_top_level_parse_failure_aborts(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.2.2 / §2.3.3: a known mirrorID with a missing
+    required top-level field raises PortfolioParseError, NOT
+    log-and-skip. The outer _parse_mirrors_payload wraps the
+    underlying KeyError. Without this, the sync would interpret
+    the known mirror as disappeared and soft-close it — the hole
+    Codex v3 finding V identified."""
+    two_mirror_seed_rows(conn)
+    conn.commit()
+
+    bad_raw = parse_failure_payload()
+    # Break the top-level field (not the nested one) this time.
+    bad_raw[0]["positions"][0]["units"] = "1.0"  # fix the nested row
+    del bad_raw[0]["availableAmount"]  # break the top-level row
+
+    with pytest.raises(PortfolioParseError) as excinfo:
+        _parse_mirrors_payload(bad_raw)
+    assert "15712187" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, KeyError)
+
+    # Seed rows are untouched — sync_portfolio never reached.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT active FROM copy_mirrors ORDER BY mirror_id")
+        rows = cur.fetchall()
+    assert len(rows) == 2
+    assert all(r["active"] is True for r in rows)
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `uv run pytest tests/test_portfolio_sync_mirrors.py -v`
+
+Expected: all tests PASS — the `RuntimeError` raise from Task 13 and the parser raises from Tasks 7–8 together cover every assertion. No code changes should be needed.
+
+If `test_sync_mirrors_total_disappearance_raises` fails because the soft-close branch in `_sync_mirrors` was accidentally ordered after the empty-check, fix the ordering so the `if not payload_mirror_ids and active_local_ids:` branch runs before the `if disappeared_ids:` branch.
+
+- [ ] **Step 3: Run the full pre-push gate**
+
+Run:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+Expected: all four PASS. This is the full CLAUDE.md gate.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_portfolio_sync_mirrors.py
+git commit -m "test(#183): §8.3 disappearance and parse-abort regressions
+
+Three regression tests:
+- total disappearance raises RuntimeError and leaves rows intact
+- malformed nested position raises PortfolioParseError; seed
+  rows untouched (pre-eviction)
+- malformed known-mirror top-level field raises
+  PortfolioParseError; seed rows untouched (closes the
+  Codex v3 finding V parse-and-soft-close hole)"
+```
+
+---
+
+## Task 15: Scheduler log extension
+
+**Files:**
+
+- Modify: `app/workers/scheduler.py:874-883` — extend the existing `logger.info(...)` line in `daily_portfolio_sync` to include the new mirror counters
+
+- [ ] **Step 1: Locate the existing log line**
+
+Current state at `app/workers/scheduler.py:874-883`:
+
+```python
+        logger.info(
+            "Portfolio sync complete: updated=%d opened_ext=%d closed_ext=%d "
+            "broker_cash=%.2f local_cash=%.2f delta=%.2f",
+            result.positions_updated,
+            result.positions_opened_externally,
+            result.positions_closed_externally,
+            result.broker_cash,
+            result.local_cash,
+            result.cash_delta,
+        )
+```
+
+- [ ] **Step 2: Extend the format string and argument list**
+
+Replace with:
+
+```python
+        logger.info(
+            "Portfolio sync complete: updated=%d opened_ext=%d closed_ext=%d "
+            "mirrors_up=%d mirrors_closed=%d mirror_positions_up=%d "
+            "broker_cash=%.2f local_cash=%.2f delta=%.2f",
+            result.positions_updated,
+            result.positions_opened_externally,
+            result.positions_closed_externally,
+            result.mirrors_upserted,
+            result.mirrors_closed,
+            result.mirror_positions_upserted,
+            result.broker_cash,
+            result.local_cash,
+            result.cash_delta,
+        )
+```
+
+No test change is needed — this is an observability-only string and the existing scheduler tests don't assert on its format. The change is covered by the fact that `PortfolioSyncResult` already carries the new fields (defaulted to 0 before Task 11's wire-up populates them).
+
+- [ ] **Step 3: Run the scheduler tests to confirm nothing regressed**
+
+Run: `uv run pytest tests/test_workers_scheduler.py -v 2>&1 | head -50`
+
+(If `tests/test_workers_scheduler.py` doesn't exist — in which case `Glob` the repo for any scheduler test — skip to step 4.)
+
+Expected: all scheduler tests still PASS (or SKIP on systems without a full scheduler test harness).
+
+- [ ] **Step 4: Full pre-push gate**
+
+Run:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+Expected: all four PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/workers/scheduler.py
+git commit -m "feat(#183): log mirror counters in daily portfolio sync
+
+Adds mirrors_up/mirrors_closed/mirror_positions_up to the
+existing Portfolio sync complete INFO line so operators see
+mirror activity in the job_runs audit trail without needing
+to query the DB."
+```
+
+---
+
+## Self-review (run after finishing all 15 tasks)
+
+Before opening the PR, walk through this checklist inline — do not delegate to a subagent.
+
+**1. Spec coverage.** For each spec section Track 1a owns, point to the task that implements it:
+
+- §1.1 `copy_traders` DDL → Task 1
+- §1.2 `copy_mirrors` DDL + active/closed_at + partial index → Task 1
+- §1.3 `copy_mirror_positions` DDL + composite PK + ON DELETE CASCADE → Task 1
+- §2.1 `BrokerMirrorPosition` / `BrokerMirror` / `BrokerPortfolio.mirrors` field → Task 4
+- §2.2.1 `PortfolioParseError` hierarchy → Task 5
+- §2.2.2 `_parse_mirror_position` / `_parse_mirror` / strict-raise outer loop → Tasks 6, 7, 8
+- §2.3.1 single-writer invariant — documented in `_sync_mirrors` docstring → Task 11
+- §2.3.2 per-mirror upsert + nested eviction → Tasks 11, 12
+- §2.3.3 parser-failure safeguard (strict-raise, no partial write) → Tasks 8, 13, 14
+- §2.3.4 soft-close + total-disappearance raise → Tasks 13, 14
+- §2.3 `PortfolioSyncResult` extension → Task 10
+- §7 migration 022 → Task 1
+- §8.0 fixture file + `_NOW` ownership migration → Tasks 2, 3, 9
+- §8.1 parser tests → Tasks 5, 6, 7, 8
+- §8.2 service-layer upsert/idempotency/eviction tests → Tasks 11, 12
+- §8.3 disappearance + parse-abort tests → Tasks 13, 14
+- §10 locked decisions — nothing in this plan deviates
+
+Explicitly NOT covered (Track 1b, 1.5, 2 territory):
+- `_load_mirror_equity` helper + 3 call sites → Track 1b #187
+- `PortfolioResponse.mirror_equity` → Track 1b #187
+- §8.4, §8.5, §8.6 tests → Track 1b #187
+- REST endpoint + frontend panel → Track 1.5 #188
+- `/user-info/people/*` discovery → Track 2 #189
+
+**2. Placeholder scan.** Grep the plan for `TODO`, `TBD`, `implement later`, `fill in`, `similar to Task`. None should exist. Fix any that do.
+
+**3. Type consistency.** The identifiers this plan names must match across tasks:
+
+- `BrokerMirror`, `BrokerMirrorPosition`, `BrokerPortfolio.mirrors` (declared Task 4, consumed Tasks 6–14)
+- `PortfolioParseError` (declared Task 5, consumed Tasks 6–8, 14)
+- `_parse_mirror_position` (Task 6), `_parse_mirror` (Task 7), `_parse_mirrors_payload` (Task 8)
+- `_sync_mirrors(conn, mirrors, now) -> tuple[int, int, int]` (Task 11; extended Tasks 12, 13; order is `(mirrors_upserted, mirror_positions_upserted, mirrors_closed)`)
+- `PortfolioSyncResult.mirrors_upserted` / `mirrors_closed` / `mirror_positions_upserted` (Task 10)
+- `_NOW`, `_GUARD_INSTRUMENT_ID`, `_GUARD_INSTRUMENT_SECTOR` in `tests.fixtures.copy_mirrors` (Task 2)
+- `two_mirror_payload()`, `parse_failure_payload()`, `two_mirror_seed_rows(conn)` (Task 9)
+
+If any identifier drifts between tasks during implementation, stop and reconcile. Do not push a commit with mismatched names.
+
+**4. Pre-push gate.** Before any push, run all four commands from CLAUDE.md. Then `tests/smoke/test_app_boots.py` must stay green end-to-end.
+
+---
+
+## PR description checklist (for the final commit before push)
+
+When opening the PR (after Task 15 is merged into the branch):
+
+- [ ] Title: `feat(#183): ingest eToro copy-trading mirrors (Track 1a)`
+- [ ] Body mentions that this is Track 1a; Track 1b (#187), Track 1.5 (#188), Track 2 (#189) are dependent follow-ups
+- [ ] Body summarises the schema (3 tables), the parser contract (strict-raise, `PortfolioParseError`), and the sync contract (upsert / nested-evict / soft-close / total-disappearance raise)
+- [ ] Body names the security model: pure read-from-broker / write-to-local-DB, no new network call, no new order-placing path, no new un-copy UX, no new cross-user data flow
+- [ ] Body flags every deviation from the spec (ideally none — if there is one, explain why)
+- [ ] Body links `docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md`

--- a/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
+++ b/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
@@ -1,9 +1,14 @@
 # Copy trading (mirrors) ingestion
 
 **Issue**: #183
-**Related**: Track 2 — social discovery as a research signal (GitHub issue to be opened after spec merge)
+**Related**:
+
+- Track 1.5 — REST endpoint + frontend panel (Appendix B)
+- Track 2 — social discovery as a research signal (new ticket,
+  opened when this spec merges)
+
 **Date**: 2026-04-11
-**Status**: Draft for review
+**Status**: Draft for review (round 2)
 
 ## Problem
 
@@ -45,14 +50,28 @@ day one:
 - Broker provider parses `clientPortfolio.mirrors[]` into typed
   dataclasses alongside the existing positions
 - Portfolio sync upserts the three tables from the same `/portfolio`
-  call it already makes
-- AUM computation (execution guard) adds mirror equity to the total_aum
-  denominator
-- Dashboard read endpoint + frontend surface for copy traders
+  call it already makes, with soft-close semantics for partially
+  disappearing mirrors (§2.3.4)
+- AUM correction at all three call sites:
+  `execution_guard` (§6.1), `api/portfolio.get_portfolio` (§6.2),
+  `services/portfolio.run_portfolio_review` (§6.3). Each site adds
+  `mirror_equity` to `total_aum`; each site gets a regression test in §8
 - Execution guard decision logic is unchanged — mirrors live in separate
   tables and never appear in sector-exposure or position-size queries
 
-**Out of scope (deferred to Track 2):**
+**Out of scope (deferred):**
+
+- New dashboard read endpoint `GET /api/portfolio/copy-trading` and
+  the frontend copy-trading panel. These move to a **Track 1.5**
+  follow-up PR (see Appendix B for ticket outline). Rationale: the
+  AUM correction is the load-bearing change; shipping it alone gets
+  the numbers right in the guard, the dashboard top-line, and the
+  recommender without also having to ship a new REST surface, a new
+  React component, and the UX copy for un-copying. `PortfolioResponse`
+  does grow an optional `mirror_equity: float | None` field in this
+  PR so the existing dashboard top-line can show the breakdown.
+
+Deferred to **Track 2** (new ticket opened when this spec merges):
 
 - `/user-info/people/*` endpoint integration (profile, gain series,
   trade info, live portfolio of arbitrary users, people/search)
@@ -63,9 +82,6 @@ day one:
   decides at the time whether these belong on `copy_traders` or on a
   separate `trader_profile_snapshots` table
 - Signal derivation (accumulation / divestment by a trusted cohort)
-- Graceful mirror-closure semantics — v1 treats disappearing mirrors
-  (partial *or* full) as API failures and raises; an operator
-  deletes `copy_mirrors` rows by hand to intentionally un-copy
 - Currency-aware MTM using a *current* FX rate — v1 uses the
   entry-time `open_conversion_rate` stored on each nested position;
   see §3.2 for the approximation
@@ -128,17 +144,43 @@ CREATE TABLE copy_mirrors (
     pending_for_closure         BOOLEAN NOT NULL DEFAULT FALSE,
     started_copy_date           TIMESTAMPTZ NOT NULL,
 
+    active      BOOLEAN       NOT NULL DEFAULT TRUE,
+    closed_at   TIMESTAMPTZ   NULL,
+
     raw_payload JSONB NOT NULL,
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX copy_mirrors_parent_cid_idx ON copy_mirrors (parent_cid);
+CREATE INDEX copy_mirrors_active_idx     ON copy_mirrors (active) WHERE active;
 ```
 
-Semantics: one row per mirror (one per currently-copied trader).
+Semantics: one row per mirror (one per copy session with a trader).
 `parent_cid` is a FK to `copy_traders` so the trader identity is a
 stable spine regardless of whether the copy is active, paused, or
 restarted with a new `mirrorID`.
+
+**`active` / `closed_at` soft-close columns.** Mirrors are
+externally-driven state — the operator un-copies through the eToro
+UI, not through eBull — and the only signal eBull gets is "row
+disappears from the next `/portfolio` payload." Deleting the local
+row on disappearance loses history; raising on disappearance turns
+every normal un-copy into a failed sync and a manual `DELETE FROM`.
+Soft-close splits the difference: a mirror that disappears from the
+payload is marked `active=false, closed_at=NOW()`, nested positions
+are retained on the closed row for audit, AUM queries filter on
+`active=true`, and re-copying the same `mirror_id` (rare but
+possible if eToro recycles IDs) flips `active` back to true in the
+upsert path. The partial `copy_mirrors_active_idx` is populated only
+by the small set of live rows, so the AUM denominator filter stays
+cheap as closed mirrors accumulate over time.
+
+**`active` is synthetic, not sourced from the payload.** The
+mirror JSON does not contain an `active` field — it's an
+eBull-local column derived from "is this mirror_id present in the
+latest sync." The upsert sets `active=TRUE, closed_at=NULL` on
+every row in the payload; §2.3.4 sets `active=FALSE, closed_at=NOW()`
+on local rows absent from the payload.
 
 **Why `deposit_summary` / `withdrawal_summary` are first-class
 columns and not buried in JSONB.** Funded capital for a mirror is
@@ -165,8 +207,11 @@ depends on current quotes for the nested positions, and storing a stale
 denominator leads to stale rule evaluation. Equity is computed on read
 (see §3).
 
-Upsert: `ON CONFLICT (mirror_id) DO UPDATE SET ... , updated_at = NOW()`.
-All mirror-level columns are refreshed from the latest payload.
+Upsert: `ON CONFLICT (mirror_id) DO UPDATE SET ..., active = TRUE,
+closed_at = NULL, updated_at = NOW()`. All payload-sourced columns
+are refreshed from the latest payload; `active`/`closed_at` are
+reset to the "live" state because presence in the payload means
+the mirror is live.
 
 ### 1.3 `copy_mirror_positions`
 
@@ -243,9 +288,11 @@ we haven't promoted to a typed column (e.g. `totalExternalFees`,
 `unitsBaseValueDollars`, `pnlVersion`) debuggable from the DB alone.
 
 **`ON DELETE CASCADE` from `copy_mirrors`.** Track 1 never deletes
-`copy_mirrors` rows on sync (see §2.3), so this is defence-in-depth —
-if a future PR introduces mirror deletion we do not want orphaned
-nested position rows.
+`copy_mirrors` rows on sync (disappeared mirrors are soft-closed
+via `active` / `closed_at`, not DELETEd — see §2.3.4), so this is
+defence-in-depth: if a future PR ever introduces hard mirror
+deletion (e.g. an operator "purge closed mirrors older than N
+years" job), we do not want orphaned nested position rows.
 
 ## 2. Sync flow changes
 
@@ -264,8 +311,8 @@ class BrokerMirrorPosition:
     units: Decimal
     amount: Decimal                      # pre-converted USD cost basis
     initial_amount_in_dollars: Decimal
-    open_rate: Decimal                   # entry price in the instrument's native currency
-    open_conversion_rate: Decimal        # FX snapshot at open (native -> USD)
+    open_rate: Decimal                   # entry price, native ccy
+    open_conversion_rate: Decimal        # FX at open (native -> USD)
     open_date_time: datetime
     take_profit_rate: Decimal | None
     stop_loss_rate: Decimal | None
@@ -299,7 +346,7 @@ class BrokerPortfolio:
     positions: Sequence[BrokerPosition]
     available_cash: Decimal
     raw_payload: dict[str, Any]
-    mirrors: Sequence[BrokerMirror] = ()   # NEW — default keeps existing callers working
+    mirrors: Sequence[BrokerMirror] = ()   # NEW — default preserves callers
 ```
 
 **Why `mirrors` has a default and not a required position.** There
@@ -325,8 +372,12 @@ sync.
 The existing `portfolio = raw.get("clientPortfolio") or {}` block is
 extended with a second parse pass over `portfolio.get("mirrors") or []`.
 
-Parsing follows the existing malformed-row handling pattern at the
-positions loop (line 427-428):
+Two-tier parsing, reflecting Codex v2 feedback on silent parse
+failures:
+
+**Top-level mirror parse — log-and-skip.** If a `mirrors[]` element
+is not a dict or is missing a required identifier, log a warning and
+continue:
 
 ```python
 for m in raw_mirrors:
@@ -339,23 +390,56 @@ for m in raw_mirrors:
         continue
 ```
 
-`_parse_mirror` is a new pure normaliser function alongside
-`_normalise_open_order_response` (line 519) — no I/O, no DB access, no
-dependence on instance state. It validates required fields
-(`mirrorID`, `parentCID`, `parentUsername`, `initialInvestment`,
-`availableAmount`, `closedPositionsNetProfit`, `startedCopyDate`),
-parses optional fields with defaults, and recursively normalises the
-nested `positions[]` into `BrokerMirrorPosition` instances via a second
-normaliser `_parse_mirror_position`.
+This matches the existing positions-loop pattern and protects the
+sync from a single garbage mirror row in a multi-mirror payload.
+The sync-layer disappearance guard (§2.3.4) still covers the "a
+known mirror is missing" case.
 
-Malformed nested positions inside a mirror are skipped, not failed
-at parse time — the mirror as a whole is still returned. The
-parse-success ratio is re-checked by the sync layer before eviction
-runs (§2.3.3), and a catastrophic drop raises there. A mirror with
-a genuinely-empty payload (`raw_positions == []`) is ingested with
-`positions=[]` — that is a valid state (the mirror holds only
-`available_amount` cash for the moment) and the §3.2 formula
-handles it correctly as `mirror_equity = available_amount`.
+**Nested-position parse — strict raise.** `_parse_mirror`
+recursively normalises the nested `positions[]` via
+`_parse_mirror_position`. Unlike the old log-and-skip pattern,
+**any** parse failure on a nested position raises
+`PortfolioParseError` (a new exception type) with the mirror_id,
+position index, and the underlying exception. The mirror as a whole
+fails; no partial mirror is ever returned to the sync layer. The
+parse-failure guard (§2.3.3) enforces this as the reason the sync
+transaction rolls back before eviction touches the DB.
+
+Rationale for the asymmetry:
+
+- One bad nested position out of 198 is indistinguishable from a
+  parser that has drifted against a payload schema change. Silently
+  skipping means "delete the valid local row on next eviction and
+  pretend nothing happened"; raising means "page the operator, fix
+  the parser, re-run the sync."
+- One bad whole-mirror row out of two is a different failure mode:
+  it's usually an entire malformed mirror object (e.g. a string
+  where an int should be), which is exotic enough that we still
+  don't want to block the sync for the *other* mirror while we
+  investigate. The disappearance guard (§2.3.4) catches it on the
+  next sync if the malformed mirror disappears permanently.
+
+`_parse_mirror` / `_parse_mirror_position` are pure normaliser
+functions alongside `_normalise_open_order_response` (line 519) — no
+I/O, no DB access, no dependence on instance state. They validate
+required fields (`mirrorID`, `parentCID`, `parentUsername`,
+`initialInvestment`, `availableAmount`, `closedPositionsNetProfit`,
+`startedCopyDate`, and `openConversionRate` on every nested
+position), parse optional fields with defaults for genuinely
+optional payload fields only (stop loss, take profit), and never
+default a value that would silently corrupt downstream arithmetic.
+
+`openConversionRate` is a required field on `_parse_mirror_position`
+and has **no production default**. A mirror position whose payload
+omits it raises at parse time and triggers the strict-raise path
+above. Test helpers in `tests/test_portfolio_sync.py` retain the
+convenience of a `Decimal("1")` default for USD-only fixtures; this
+is scoped to the helper, not the parser.
+
+A mirror with a genuinely-empty payload (`raw_positions == []`) is
+ingested with `positions=[]` — that is a valid state (the mirror
+holds only `available_amount` cash) and the §3.2 formula handles it
+correctly as `mirror_equity = available_amount`.
 
 ### 2.3 `portfolio_sync` (`app/services/portfolio_sync.py`)
 
@@ -374,23 +458,43 @@ def _sync_mirrors(
 
 #### 2.3.1 Single-writer invariant
 
-`daily_portfolio_sync` holds a session-scoped Postgres advisory lock
-via `JobLock` ([app/jobs/locks.py:60](app/jobs/locks.py#L60)) for the
-full duration of the run, and APScheduler's `max_instances=1`
-default ([app/jobs/runtime.py:213](app/jobs/runtime.py#L213))
-enforces one concurrent instance per job on top of that. These two
-layers — process-local and cross-process — mean two instances of
-`sync_portfolio` (and therefore `_sync_mirrors`) **cannot** run
-concurrently against the same database.
+`_sync_mirrors` relies on the same serialisation guarantee as every
+other portfolio-sync writer in the codebase. The guarantee is
+provided by `JobRuntime`, not by `daily_portfolio_sync` itself:
 
-`_sync_mirrors` relies on this invariant. It does *not* take its own
-advisory lock, because stacking locks inside an already-serialised
-job adds reasoning overhead with no correctness benefit. If a future
-PR ever peels `_sync_mirrors` off onto a non-portfolio-sync code
-path (e.g. an ad-hoc reconciliation endpoint that is not serialised
-by `JobLock`), the author must add an advisory lock at that call
-site — this spec documents the assumption so that author knows what
-they're removing.
+1. **`JobRuntime._wrap_invoker`** takes a session-scoped Postgres
+   advisory lock via `JobLock`
+   ([app/jobs/locks.py:60](app/jobs/locks.py#L60)) before dispatching
+   the wrapped job function, releases it after return. This wraps
+   every scheduled fire.
+2. **`JobRuntime._run_manual`** takes the same lock around manual
+   triggers (operator-invoked runs, catch-up runs).
+3. **APScheduler `max_instances=1`** default
+   ([app/jobs/runtime.py:213](app/jobs/runtime.py#L213)) enforces
+   one concurrent instance per job at the scheduler layer on top of
+   the DB lock.
+
+Practical consequence: any code path that reaches `sync_portfolio`
+**via `JobRuntime`** is serialised at both the process (APScheduler)
+and cross-process (Postgres advisory lock) layers, so two instances
+of `_sync_mirrors` cannot run concurrently. This is the only app
+code path that invokes `sync_portfolio` today
+([app/workers/scheduler.py:868](app/workers/scheduler.py#L868)).
+
+**What the invariant does NOT cover.** A direct call to
+`sync_portfolio(conn, portfolio)` outside of `JobRuntime` — an
+ad-hoc REPL session, a future unlocked REST endpoint, a new CLI
+command — bypasses both layers. Tests already do this
+([tests/test_portfolio_sync.py](tests/test_portfolio_sync.py))
+but run serially against an isolated test DB, so they cannot race.
+Any *future* production caller that peels `sync_portfolio` off
+`JobRuntime` must add its own advisory lock at the call site. This
+spec documents the assumption so that author knows what they're
+removing.
+
+`_sync_mirrors` itself does not take an additional advisory lock;
+stacking locks inside an already-serialised job adds reasoning
+overhead with no correctness benefit.
 
 #### 2.3.2 Per-mirror sync
 
@@ -422,61 +526,135 @@ Per mirror:
 
 #### 2.3.3 Parser-failure safeguard
 
-The malformed-row skip pattern from §2.2 (log + continue) is unsafe
-when composed with the eviction step. If eToro returns 198 positions
-and a schema change makes the parser reject half of them, the sync
-would upsert the 99 good ones and evict the other 99 — silently
-destroying local rows for the affected positions.
+The failure mode the guard protects against: eToro returns 198
+nested positions, a payload schema change makes the parser reject
+one or more of them, the sync upserts the parsed subset and evicts
+everything else — silently destroying local rows for the rejected
+positions. Codex v2 correctly flagged that a ratio-based guard
+(50%, 80%, …) is indefensible here: it trips pathologically at
+small N (a single mirror with one position: N=1, one failure is
+100% failure *and* 0% failure depending on how you count), and it
+is too lax at large N (on a 198-position mirror, an 80% threshold
+still allows ~40 rows to be silently deleted).
 
-Guard: before `_sync_mirrors` commits the evict step for a given
-mirror, compare `len(parsed_positions)` against `len(raw_positions)`.
-If fewer than half the raw positions parsed successfully, and at
-least one raw position existed, raise `RuntimeError` with the mirror
-ID and the parse-success ratio. The whole transaction is rolled
-back. The operator sees a failed `daily_portfolio_sync` in
-`job_runs`, investigates the upstream schema change, and fixes the
-parser before the next fire. Better to page than to delete.
+**v1 rule — strict raise, zero budget.** If `_parse_mirror_position`
+raises on *any* nested position inside a mirror, the mirror parse
+raises `PortfolioParseError` with the mirror_id, position index, and
+cause. `_sync_mirrors` catches nothing and lets the exception
+propagate up through `sync_portfolio` to the caller. The caller
+(scheduler job, test) rolls back the transaction. Nothing is
+upserted, nothing is evicted, local state is preserved exactly as
+it was before the sync started.
+
+The operator sees a failed `daily_portfolio_sync` in `job_runs`
+with the exception message, investigates the upstream schema
+change, extends the parser, and re-runs the sync manually. Next
+scheduled fire picks up the fix.
 
 Rejected alternatives:
 
-- "Just skip eviction when any position failed." Leaks stale rows
-  forever and the failure mode is invisible.
-- "Require 100% parse success." Too brittle — a single new-enum
-  value on one of 198 positions would block every mirror every sync.
-- "Fail only if zero positions parsed." The 99-out-of-198 case is
-  exactly the scenario we want to catch.
+- **"Log and skip failed rows, track separately, delete only known
+  IDs."** Plausible but adds three moving parts (a parse-failure
+  log, a two-set eviction array, an "already-evicted-but-stale"
+  reconciliation step) to save the operator a manual `gh workflow
+  run`. Not worth it for v1.
+- **"Allow an absolute failure budget (e.g. ≤2)."** Still bad at
+  small N and still silently evicts the budgeted-off rows. A
+  budget is "how many rows am I allowed to silently delete", which
+  is the wrong shape of question.
+- **"50% ratio threshold."** Codex v2 correctly rejected this —
+  indefensible at any N, pathological at small N.
 
-The 50% threshold is arbitrary-but-defensible for v1. A future PR
-can tighten or make it configurable.
+The tradeoff is accepted: a single bad row blocks the entire sync.
+The fix path (extend the parser) is always cheap, always local, and
+always reversible. The alternative (silent data loss) is not.
 
-#### 2.3.4 Empty-mirrors and partial-disappearance guards
+#### 2.3.4 Disappearance handling — soft-close
 
-**Empty-mirrors guard.** Mirroring the existing positions guard at
-[portfolio_sync.py:245](app/services/portfolio_sync.py#L245): if
-`portfolio.mirrors` is empty but the local `copy_mirrors` table has
-rows, `_sync_mirrors` raises a `RuntimeError`. Upstream "looks
-broken" — do not silently zero local state. Operator-driven
-un-copying is a manual DB operation in v1.
+The failure mode: the operator un-copies a trader through the eToro
+UI. On the very next `/portfolio` fetch, the mirror is gone from
+`clientPortfolio.mirrors[]`. eBull has to decide what to do about
+the local `copy_mirrors` row.
 
-**Partial-disappearance guard.** Codex flagged that guarding only
-the fully-empty case leaves a hole: if one of two mirrors disappears
-from a non-empty payload, the local `copy_mirrors` row for the
-missing mirror remains forever and keeps inflating AUM.
+Codex v2 rejected the earlier "raise on any disappearance" design
+because it turns every normal un-copy into a failed sync and a
+manual `DELETE FROM copy_mirrors WHERE mirror_id = ?;` step.
+Un-copying is a normal operator workflow, not an emergency, and
+eBull should handle it without pages.
 
-Track 1 response: after processing every mirror in the payload, if
-any local `copy_mirrors.mirror_id` is absent from
-`{m.mirror_id for m in portfolio.mirrors}`, raise `RuntimeError`
-naming the missing mirror_id(s). Same rationale as the empty-mirrors
-guard and as the existing positions "legitimate liquidation is
-per-position, not whole-portfolio" invariant — a mirror disappearing
-without the operator touching the DB is either a broker API
-regression or a genuine un-copy, and neither should silently change
-AUM math.
+**v1 rule — partial disappearance soft-closes, total disappearance
+raises.**
 
-Operator un-copy workflow (manual, v1): `DELETE FROM copy_mirrors
-WHERE mirror_id = ?;` before the next sync fires. Graceful closure
-semantics — `closed_at` column, "keep history but mark as closed",
-historical AUM reporting — are deferred to Track 2.
+1. **After upserting every mirror in the payload**, compute
+   `disappeared_ids = active_local_mirror_ids − payload_mirror_ids`.
+2. **Total disappearance (operator intent unclear).** If
+   `payload_mirror_ids` is empty AND
+   `active_local_mirror_ids` is non-empty, raise `RuntimeError`.
+   This is the same invariant as the positions guard at
+   [portfolio_sync.py:245](app/services/portfolio_sync.py#L245):
+   "all records gone at once" is indistinguishable from an API
+   regression, so we stop and page. Operator investigates, then
+   either manually closes the mirrors or waits for the API to
+   recover.
+3. **Partial disappearance (operator un-copy).** If
+   `payload_mirror_ids` is non-empty AND `disappeared_ids` is
+   non-empty, run a soft-close:
+
+   ```sql
+   UPDATE copy_mirrors
+      SET active = FALSE,
+          closed_at = NOW(),
+          updated_at = NOW()
+    WHERE mirror_id = ANY(%s::bigint[])
+      AND active = TRUE;
+   ```
+
+   Nested `copy_mirror_positions` rows for the closed mirror are
+   **retained** — they are historical fact, and the `active` filter
+   in the §3.4 AUM query already excludes them from forward-looking
+   calculations. A follow-up eviction step is explicitly not run.
+
+   A single-line `INFO` log per closed mirror
+   (`"mirror %s (%s) disappeared from payload — marked closed"`)
+   gives the operator audit trail without paging.
+
+4. **Re-copy.** If the operator later re-copies the same trader and
+   eToro issues a new `mirror_id`, the new mirror hits the insert
+   branch of the upsert, and the old closed mirror row remains for
+   history. If eToro reuses the `mirror_id` (never observed in the
+   wild, but possible), the upsert's `ON CONFLICT` clause resets
+   `active = TRUE, closed_at = NULL` from §1.2, and the mirror is
+   live again.
+
+**Why total disappearance still raises.** The decision is
+asymmetric by design:
+
+- Partial disappearance: 1 of 2 mirrors gone, 1 still live. We
+  have strong evidence the rest of the payload is healthy (the
+  other mirror upserted normally, positions and cash reconciled
+  normally). The disappeared one is almost certainly an un-copy.
+- Total disappearance: 2 of 2 mirrors gone, zero live. We have
+  no evidence the payload is healthy for *mirrors* specifically
+  — maybe eToro stopped returning the `mirrors[]` field entirely,
+  maybe the JSON schema changed, maybe the account really was
+  bulk-un-copied. Raising routes this decision to a human.
+
+This matches the existing positions guard, which also distinguishes
+"individual position closed" (fine, normal) from "entire positions
+array empty" (raise, unsafe).
+
+**Operator runbook for total disappearance.** If the raise turns
+out to be a genuine "un-copied everything" — not an API bug —
+manually soft-close every row:
+
+```sql
+UPDATE copy_mirrors
+   SET active = FALSE, closed_at = NOW(), updated_at = NOW()
+ WHERE active = TRUE;
+```
+
+Then re-run the sync. One-time cost for what should be a very rare
+event.
 
 Result type extension:
 
@@ -490,6 +668,7 @@ class PortfolioSyncResult:
     broker_cash: Decimal
     local_cash: Decimal
     mirrors_upserted: int          # NEW
+    mirrors_closed: int            # NEW — soft-closed on this sync
     mirror_positions_upserted: int # NEW
 ```
 
@@ -530,12 +709,12 @@ payload at
 
    ```text
    mirror 15712187 (thomaspj):
-     available + SUM(amount)                       = 2800.33 + 17089.33 = 19889.66
-     initial + deposit − withdrawal + closed_pnl   = 20000 + 0 − 0 + (−110.34) = 19889.66
+     available + SUM(amount)   = 2800.33 + 17089.33        = 19889.66
+     init + dep − wd + closed  = 20000 + 0 − 0 + (−110.34) = 19889.66
 
    mirror 15714660 (triangulacapital):
-     available + SUM(amount)                       = 1724.11 + 17666.76 = 19390.87
-     initial + deposit − withdrawal + closed_pnl   = 17280 + 2251 − 0 + (−140.13) = 19390.87
+     available + SUM(amount)   = 1724.11 + 17666.76        = 19390.87
+     init + dep − wd + closed  = 17280 + 2251 − 0 + (−140.13) = 19390.87
    ```
 
    Adding `closed_pnl` explicitly on top of the cost-basis sum
@@ -646,9 +825,18 @@ WITH mirror_equity AS (
         ) q ON TRUE
         WHERE cmp.mirror_id = m.mirror_id
     ) p ON TRUE
+    WHERE m.active
 )
 SELECT total FROM mirror_equity;
 ```
+
+The `WHERE m.active` filter is what makes the soft-close design
+from §2.3.4 work end-to-end: closed mirrors and their nested
+positions stay in the DB for audit and history, but they contribute
+zero to the AUM denominator the guard, the dashboard, and the
+recommender compute against. The partial index
+`copy_mirrors_active_idx (...) WHERE active` from §1.2 keeps this
+filter scanning only live rows as closed mirrors accumulate.
 
 **Critical: this query feeds the denominator only.** It does not
 contribute to `sector_values` or any per-sector aggregation. Mirrors
@@ -729,26 +917,56 @@ against a denominator that the guard will then reject against a
 different denominator.
 
 Update: add a new `_load_mirror_equity(conn) -> float` helper that
-runs the §3.4 query, and sum its result into `total_aum` at line
-753. Plumb `mirror_equity` through `PortfolioReviewResult` the same
-way `total_aum` is already plumbed, so the snapshot row in
-`portfolio_reviews` captures it (for audit).
+runs the §3.4 query (`WHERE m.active` filter included, see §3.4),
+and sum its result into `total_aum` at line 753.
 
-### 6.4 New REST endpoint
+**No audit persistence.** The earlier revision of this spec claimed
+`run_portfolio_review` would capture `mirror_equity` into a
+`portfolio_reviews` table for audit. Codex v2 correctly pointed out
+that no such table and no such snapshot write path exist in the
+repo — `run_portfolio_review` computes AUM, uses it, logs it,
+writes `recommendations` rows, and never persists the AUM figure
+itself. The earlier claim invented audit persistence that does not
+exist. Correction: this PR adds nothing to
+`run_portfolio_review` beyond the `_load_mirror_equity` helper and
+its contribution to `total_aum`. If snapshot persistence is wanted
+later, it lives on a separate ticket and a separate migration.
 
-`GET /api/portfolio/copy-trading` — list of copy traders with
-mirror-level aggregates and a per-mirror summary of nested positions.
-Joins `copy_traders` × `copy_mirrors` × `copy_mirror_positions` and
-runs a per-mirror equity calculation for display. Detailed field
-list deferred to the implementation plan.
+### 6.4 REST endpoint — deferred to Track 1.5
 
-### 6.5 Frontend
+`GET /api/portfolio/copy-trading` (listing copy traders with
+per-mirror aggregates and nested-position summaries) is deferred to
+a follow-up PR. The existing `PortfolioResponse` dataclass at
+[api/portfolio.py:64-67](app/api/portfolio.py#L64-L67) grows one
+new optional field in this PR:
 
-Frontend changes are in scope for the PR: a copy-trading section on
-the portfolio dashboard that consumes `/api/portfolio/copy-trading`,
-and a top-line AUM breakdown showing positions + cash + mirror
-equity. Component structure deferred to the implementation plan —
-the spec fixes the data contract, the plan fixes the components.
+```python
+@dataclass
+class PortfolioResponse:
+    ...existing fields...
+    mirror_equity: float | None = None  # NEW — null if no active mirrors
+```
+
+That is the minimum change needed for the dashboard top-line to
+display the AUM breakdown without a new endpoint. Anything
+dedicated to copy-trader browsing lives in Track 1.5.
+
+### 6.5 Frontend copy-trading panel — deferred to Track 1.5
+
+No frontend changes in this PR beyond (possibly) reading the new
+`mirror_equity` field from `PortfolioResponse` if the top-line
+summary already has the hooks to render a "positions + cash +
+mirrors = AUM" breakdown. The full copy-trading panel — trader
+list, per-mirror cards, nested-position drill-down, un-copy UX —
+lives in Track 1.5 (see Appendix B).
+
+Rationale for the split: the load-bearing change in this PR is
+"AUM is correct everywhere it is computed." That change requires
+the schema, the sync, the parser, the three AUM integrations, and
+every supporting test. Bundling the REST endpoint + React panel +
+UX copy on top would roughly double the diff surface for the same
+correctness outcome. Shipping AUM correctness first and the UI
+second is both smaller and safer.
 
 ## 7. Migration (022)
 
@@ -760,19 +978,32 @@ Single migration, one transaction, following the
 BEGIN;
 
 CREATE TABLE copy_traders (...);          -- §1.1
-CREATE TABLE copy_mirrors (...);          -- §1.2
+CREATE TABLE copy_mirrors (...);          -- §1.2, with active/closed_at
 CREATE TABLE copy_mirror_positions (...); -- §1.3, composite PK (mirror_id, position_id)
 
-CREATE INDEX copy_traders_username_idx               ON copy_traders (parent_username);
-CREATE INDEX copy_mirrors_parent_cid_idx             ON copy_mirrors (parent_cid);
-CREATE INDEX copy_mirror_positions_instrument_id_idx ON copy_mirror_positions (instrument_id);
+CREATE INDEX copy_traders_username_idx
+    ON copy_traders (parent_username);
+CREATE INDEX copy_mirrors_parent_cid_idx
+    ON copy_mirrors (parent_cid);
+CREATE INDEX copy_mirrors_active_idx
+    ON copy_mirrors (active) WHERE active;
+CREATE INDEX copy_mirror_positions_instrument_id_idx
+    ON copy_mirror_positions (instrument_id);
 
 COMMIT;
 ```
 
-Note: there is no standalone `copy_mirror_positions_mirror_id_idx`
-because the composite primary key `(mirror_id, position_id)` already
-covers `WHERE mirror_id = ?` queries as a leftmost-prefix scan.
+Two index notes:
+
+- There is no standalone `copy_mirror_positions_mirror_id_idx`
+  because the composite primary key `(mirror_id, position_id)`
+  already covers `WHERE mirror_id = ?` queries as a
+  leftmost-prefix scan.
+- `copy_mirrors_active_idx` is a partial index — it indexes only
+  rows where `active` is true. This keeps the AUM query fast
+  (`WHERE m.active`) even as closed mirrors accumulate across
+  years of un-copy history, without the dead-weight of indexing
+  "closed" as a separate value.
 
 No backfill is required — the tables start empty and fill up on the
 next portfolio sync. The existing `positions.source` CHECK constraint
@@ -786,40 +1017,69 @@ because mirrors never become `positions` rows.
 - `_parse_mirror` / `_parse_mirror_position` against fixtures derived
   from the real `data/raw/etoro_broker/etoro_portfolio_*.json` payload
   (trimmed to 2 mirrors × 3 nested positions each for readability, at
-  least one non-USD position to exercise `openConversionRate`)
-- Malformed mirror → skipped with warning, other mirrors still parsed
-- Malformed nested position → skipped, sibling positions still parsed
+  least one non-USD position to exercise `openConversionRate`).
+- Malformed top-level mirror object (not a dict, missing `mirrorID`)
+  → skipped with warning, other mirrors still parsed. This is the
+  asymmetric outer-loop behaviour from §2.2.
+- Malformed nested position (missing required field, non-numeric
+  `units`, missing `openConversionRate`) → `_parse_mirror` raises
+  `PortfolioParseError` naming the mirror_id and position index. No
+  partial-mirror result is returned. This is the strict inner-loop
+  behaviour from §2.2 and the parser-failure safeguard from §2.3.3.
 - Missing optional fields (stop loss, take profit) → `None` on the
-  dataclass
-- Missing `openConversionRate` → defaults to `Decimal("1")` so legacy
-  USD-only fixtures keep working
+  dataclass.
+- **`openConversionRate` is required in production.** A unit test
+  asserts that `_parse_mirror_position` raises when
+  `openConversionRate` is absent. The `Decimal("1")` fallback lives
+  only on the `_mk_position` test helper in
+  `tests/test_portfolio_sync.py`, and a separate unit test asserts
+  that the helper's default is scoped to USD-only fixtures. No
+  production code path silently defaults this field.
 
 **Service-layer tests (real test DB, per
 `feedback_test_db_isolation` rule — `ebull_test`, never
 `settings.database_url`):**
 
 - First `sync_portfolio` call with 2 mirrors × 3 positions → rows in
-  `copy_traders`, `copy_mirrors`, `copy_mirror_positions`
+  `copy_traders`, `copy_mirrors` (both `active = TRUE`),
+  `copy_mirror_positions`.
 - Second `sync_portfolio` with one nested position removed → that row
-  is DELETEd, siblings untouched
+  is DELETEd, siblings untouched, `copy_mirrors.active` unchanged.
 - Re-running the same payload is idempotent (row counts unchanged,
-  `updated_at` refreshed)
+  `updated_at` refreshed, `active` still `TRUE`).
 - Mirror-level metadata changed on second sync → `copy_mirrors` row
-  updated, trader row untouched apart from `updated_at`
+  updated, trader row untouched apart from `updated_at`.
 - Parent username changed on second sync → `copy_traders.parent_username`
-  updated
-- **Empty `mirrors` array with local mirrors present** → `RuntimeError`
-  raised, caller can roll back
-- **Partial mirror disappearance** (two local mirrors, payload has
-  one) → `RuntimeError` raised naming the missing mirror_id, caller
-  can roll back
-- **Parser-failure safeguard** → payload with 10 raw positions, 8 of
-  which are malformed such that the parser skips them → `_sync_mirrors`
-  raises before eviction runs; existing rows survive the rollback
+  updated.
+
+**Disappearance handling tests (the new behaviour from §2.3.4):**
+
+- **Empty `mirrors` array with active local mirrors present** →
+  `RuntimeError` raised, transaction rolls back, local rows remain
+  `active = TRUE`. Matches the positions guard's "total disappearance
+  is unsafe" invariant.
+- **Partial mirror disappearance: soft-close.** Seed 2 active local
+  mirrors, call `sync_portfolio` with a payload containing only 1 of
+  them. Assert: the matching mirror stays `active = TRUE,
+  closed_at IS NULL`; the missing mirror flips to `active = FALSE,
+  closed_at = now()`; nested `copy_mirror_positions` rows for the
+  closed mirror **remain** (not CASCADE-deleted); the result's
+  `mirrors_closed = 1`.
+- **Re-copy (same mirror_id reuse).** Seed a soft-closed mirror
+  (`active = FALSE`), call `sync_portfolio` with a payload
+  containing that same `mirror_id`. Assert: the row is back to
+  `active = TRUE, closed_at = NULL`; `updated_at` advances; nested
+  positions are upserted correctly.
+- **Parser-failure abort before eviction.** Seed a mirror with 3
+  local positions. Call `sync_portfolio` with a payload where one
+  of the three nested positions is malformed (e.g. non-numeric
+  `units`). Assert: `PortfolioParseError` propagates, the
+  transaction rolls back, all 3 local rows survive, and no partial
+  upsert or eviction occurred.
 
 **AUM identity tests (the core correctness test for §3):**
 
-Two small fixtures inserted directly into `copy_mirrors` and
+Fixtures inserted directly into `copy_mirrors` and
 `copy_mirror_positions`:
 
 - **No-quote cost-basis fallback.** One mirror with
@@ -837,18 +1097,25 @@ Two small fixtures inserted directly into `copy_mirrors` and
   `quotes.last = 1000.0` (below entry) → delta = `-1 * 6.28927 *
   (1000.0 - 1207.4994) * 0.01331 ≈ +17.37`, equity goes **up**
   because a short is profitable when the price falls.
+- **Closed mirror excluded from AUM.** Fixture with one
+  `active = TRUE` mirror and one `active = FALSE` mirror (both
+  with positions and cash) → §3.4 query returns only the active
+  mirror's equity; closed mirror contributes zero. This is the
+  regression test for the `WHERE m.active` filter.
 
 **Guard AUM integration test:**
 
 - Existing guard test fixture + one mirror containing a single
   USD position with `amount = 1000`, `open_rate = 10`, no quote →
-  `total_aum` increases by exactly `available_amount + 1000`
+  `total_aum` increases by exactly `available_amount + 1000`.
 - Same fixture + a quote higher than `open_rate` → AUM delta grows
-  by the MTM delta
+  by the MTM delta.
+- Same fixture with the mirror soft-closed → AUM returns to the
+  pre-mirror baseline.
 - Sector exposure check on an instrument that is held in a mirror but
   not in `positions` → sector exposure numerator is 0 (mirror is
   ignored for concentration), AUM denominator is still increased
-  (rule is more permissive, not less)
+  (rule is more permissive, not less).
 
 **Three-call-site AUM consistency test:**
 
@@ -861,7 +1128,9 @@ test to prove they agree:
 
 All three must report the same `total_aum`. This is the regression
 test for §6 — if a future PR updates one AUM path but not the
-others, this test fails.
+others, this test fails. The test does **not** assert anything
+about persisted AUM snapshots, because (per §6.3) no AUM snapshot
+is persisted anywhere in this PR.
 
 **Smoke gate:** `tests/smoke/test_app_boots.py` remains green (the
 FastAPI lifespan touches nothing new; migration 022 runs during
@@ -914,18 +1183,40 @@ might need is not.
 
 ## 10. Open questions
 
-None at spec-revision time. The main decisions — three-table split,
-full granular position capture, `positions`/guard untouched, empty
-mirrors → raise, partial disappearance → raise, cost-basis AUM with
-optional MTM delta, FX via `openConversionRate` — have all been made
-above. If a second round of spec review surfaces new questions they
-will be appended here before the writing-plans handoff.
+None at v2 spec-revision time. The load-bearing decisions are all
+locked:
+
+- Three-table split (`copy_traders`, `copy_mirrors`,
+  `copy_mirror_positions`), composite PK on the positions table.
+- Full granular position capture with `open_conversion_rate` as a
+  required NOT NULL column.
+- `positions` and the execution guard's rule queries are untouched
+  — mirrors never appear in sector or per-position aggregations.
+- Empty `mirrors[]` with active local rows → raise.
+- Partial disappearance → soft-close via `active` / `closed_at`
+  columns; nested positions retained.
+- Any nested-position parse failure → strict raise, full sync
+  rollback, operator investigates.
+- `openConversionRate` required in production; default only in
+  test helpers.
+- AUM correction at all three call sites
+  (execution_guard / api/portfolio / run_portfolio_review), no
+  persisted AUM snapshot.
+- REST endpoint and frontend panel deferred to Track 1.5 (see
+  Appendix B).
+- Track 2 (`/user-info/people/*` surface, trader discovery,
+  historical gain series, cohort signals) is a separate ticket
+  opened when this spec merges.
+
+If a third round of review surfaces new questions they will be
+appended here before the writing-plans handoff.
 
 ## Appendix A. Revision log
 
-This spec went through a pre-implementation Codex review (see
-`.claude/codex-spec-review.log` in the branch history). Findings and
-resolutions:
+### Round 1 — Codex review of the first draft
+
+See `.claude/codex-spec-review.log` in the branch history. Findings
+and resolutions:
 
 - **A. AUM formula double-counts `closed_pnl`.** §3 rewritten around
   the `available + SUM(amount) + SUM(MTM delta)` identity, which is
@@ -944,12 +1235,12 @@ resolutions:
 - **G. `raw_payload` only on mirror row is brittle.** Added
   `raw_payload JSONB NOT NULL` on `copy_mirror_positions` too (§1.3).
 - **H. Concurrent sync races not addressed.** Single-writer invariant
-  documented against `JobLock` + APScheduler (§2.3.1); no new lock
-  added.
-- **I. Parser-failure + eviction = silent data loss.** 50%-of-raw
-  parse-success threshold guard added (§2.3.3).
+  documented against `JobLock` + APScheduler (§2.3.1).
+- **I. Parser-failure + eviction = silent data loss.** Parser-failure
+  guard added. Later tightened to strict-raise in round 2.
 - **J. Only `mirrors=[]` guarded; partial disappearance ignored.**
-  Partial-disappearance guard added (§2.3.4).
+  Partial-disappearance guard added. Later changed from "raise" to
+  "soft-close" in round 2.
 - **K. Short handling as `-1 * units * price` wrong for CFDs.** §3.2
   uses `sign * delta * ocr`, correct for longs, shorts, and
   leverage-1; §3.3 explains.
@@ -960,3 +1251,89 @@ resolutions:
 - **N. `raw_payload` can't backfill Track 2 profile data.** Claim
   removed (§1.2); `user-info/people/*` is now called out as the
   source.
+
+### Round 2 — Codex review of the round-1 revision
+
+See `.claude/codex-spec-review-v2.log` in the branch history.
+Findings and resolutions:
+
+- **O. §2.3.1 wording overclaims where the lock lives.** Codex
+  observed that `daily_portfolio_sync()` itself does not hold
+  `JobLock`; `JobRuntime._wrap_invoker` / `_run_manual` do. Fix:
+  §2.3.1 now states explicitly that the serialisation guarantee
+  lives on the runtime wrapper, not the job function, and that
+  direct callers outside `JobRuntime` bypass it.
+- **P. §2.3.3 50% parser-failure threshold is indefensible.** Codex
+  observed that a ratio-based guard is pathological at small N
+  (1-of-1 fails at 100%, 1-of-2 passes at 50%) and too lax at
+  large N (~40 silently-deleted rows is still bad). Fix: §2.3.3
+  tightened to strict-raise on any nested-position parse failure,
+  zero budget, full sync rollback.
+- **Q. §2.3.4 partial-disappearance raise is operationally harsh.**
+  Codex observed that a genuine un-copy via the eToro UI would
+  page the operator, roll back the sync, and keep the stale local
+  mirror inflating AUM until someone manually `DELETE`d the row.
+  Fix: §1.2 gained `active` / `closed_at` columns; §2.3.4 now
+  soft-closes partially-disappeared mirrors (keep the row, flip
+  `active=false`, retain nested positions for audit); §3.4's
+  `WHERE m.active` filter excludes closed mirrors from the AUM
+  denominator. Total disappearance still raises, matching the
+  positions guard invariant.
+- **R. §6.3 invented a `portfolio_reviews` audit table.** Codex
+  grepped the repo and found no such table and no snapshot write
+  path. Fix: §6.3 now states that `run_portfolio_review` adds
+  nothing beyond `_load_mirror_equity`, with a note naming the
+  earlier claim as incorrect. No AUM snapshot persistence in this
+  PR.
+- **S. §8 `openConversionRate` production default of `Decimal("1")`
+  is unsafe.** Codex observed that silently defaulting FX to 1 in
+  production would mix native-currency notionals into USD AUM on
+  any payload with the field missing. Fix: §2.2 and §8 now state
+  that `openConversionRate` is required in production parsing and
+  that the `Decimal("1")` fallback is scoped to the
+  `tests/test_portfolio_sync.py` fixture helper only, with a unit
+  test asserting the production raise path.
+- **T. §6 frontend scope was muddy.** The earlier "frontend in scope
+  for PR but detailed fields deferred" position meant the spec did
+  not lock the data contract. Fix: §6.4 / §6.5 explicitly defer
+  the new REST endpoint and the copy-trading panel to a Track 1.5
+  follow-up PR (Appendix B). This PR ships only the AUM correction
+  and a single additive `mirror_equity: float | None` field on the
+  existing `PortfolioResponse`.
+
+## Appendix B. Track 1.5 — REST endpoint and frontend panel
+
+**Scope:** a new ticket that ships the copy-trading browsing UX on
+top of the tables and the AUM correction delivered by this PR.
+
+**Minimum viable slice:**
+
+- `GET /api/portfolio/copy-trading` endpoint returning a list of
+  copy traders, each with:
+  - `parent_cid`, `parent_username`
+  - mirror-level aggregates: `active`, `initial_investment`,
+    `deposit_summary`, `withdrawal_summary`, `available_amount`,
+    `closed_positions_net_profit`, `mirror_equity` (computed
+    from §3.4)
+  - nested-position summary: count, top N by cost basis,
+    per-instrument breakdown
+- React dashboard panel consuming the endpoint, with:
+  - Top-line summary: AUM = positions + cash + mirror_equity
+  - Per-trader cards with mirror-level numbers
+  - Drill-down showing nested positions, cost basis, entry FX,
+    MTM delta
+  - Closed mirrors visible in a separate "history" section
+    (filter on `active = FALSE`)
+- Data-contract tests aligned with
+  `.claude/skills/frontend/api-shape-and-types.md`
+
+**Explicitly NOT in Track 1.5:**
+
+- An "un-copy from eBull" action. v1 un-copies happen on the eToro
+  UI; eBull reflects them on the next sync. A UI button that calls
+  the eToro API to un-copy is out of scope until Track 2's
+  authenticated-user surface lands.
+- Historical gain/loss charts for mirrors. Those depend on
+  snapshot persistence which v1 does not do.
+- Any change to the tables defined in this PR. Track 1.5 is a pure
+  read surface on top of an already-correct data model.

--- a/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
+++ b/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
@@ -168,20 +168,25 @@ disappears from the next `/portfolio` payload." Deleting the local
 row on disappearance loses history; raising on disappearance turns
 every normal un-copy into a failed sync and a manual `DELETE FROM`.
 Soft-close splits the difference: a mirror that disappears from the
-payload is marked `active=false, closed_at=NOW()`, nested positions
-are retained on the closed row for audit, AUM queries filter on
-`active=true`, and re-copying the same `mirror_id` (rare but
-possible if eToro recycles IDs) flips `active` back to true in the
-upsert path. The partial `copy_mirrors_active_idx` is populated only
-by the small set of live rows, so the AUM denominator filter stays
-cheap as closed mirrors accumulate over time.
+payload is marked `active=false, closed_at=<injected sync
+timestamp>`, nested positions are retained on the closed row for
+audit, AUM queries filter on `active=true`, and re-copying the same
+`mirror_id` (rare but possible if eToro recycles IDs) flips `active`
+back to true in the upsert path. The partial
+`copy_mirrors_active_idx` is populated only by the small set of
+live rows, so the AUM denominator filter stays cheap as closed
+mirrors accumulate over time. (§2.3.4 specifies the SQL binding for
+the injected timestamp; this prose intentionally avoids writing
+`NOW()` so a reader does not mis-implement it as DB wall clock.)
 
 **`active` is synthetic, not sourced from the payload.** The
 mirror JSON does not contain an `active` field — it's an
 eBull-local column derived from "is this mirror_id present in the
 latest sync." The upsert sets `active=TRUE, closed_at=NULL` on
-every row in the payload; §2.3.4 sets `active=FALSE, closed_at=NOW()`
-on local rows absent from the payload.
+every row in the payload; §2.3.4 sets `active=FALSE, closed_at=<injected
+sync timestamp>` on local rows absent from the payload (see §2.3.4 for
+the `%(now)s` binding — this prose deliberately mirrors the soft-close
+paragraph above).
 
 **Why `deposit_summary` / `withdrawal_summary` are first-class
 columns and not buried in JSONB.** Funded capital for a mirror is
@@ -429,29 +434,74 @@ for m in raw_mirrors:
     try:
         mirrors.append(_parse_mirror(m))
     except PortfolioParseError:
-        # Nested-position failure or top-level known-mirror failure.
+        # Nested-position failure (raised from _parse_mirror with
+        # mirror_id + position index context), or top-level
+        # known-mirror failure that _parse_mirror already wrapped.
         # Re-raise unchanged — §2.3.3 requires full sync rollback,
         # and §2.3.4 soft-close must not silently fire on a
         # mirrorID that we still see in the payload.
         raise
-    except (KeyError, ValueError, TypeError) as exc:
-        # Top-level known-mirror parse failure: mirrorID present
-        # but a required top-level field missing or malformed.
-        # Wrap and raise — this row is a known mirror, soft-close
-        # would silently drop it from AUM, so the sync must abort.
+    except (
+        KeyError,
+        ValueError,
+        TypeError,
+        decimal.DecimalException,
+    ) as exc:
+        # Fallback wrap for exceptions that leaked past
+        # _parse_mirror's own try/except. `decimal.DecimalException`
+        # is the parent of `decimal.InvalidOperation`, which
+        # `Decimal(str(value))` raises on non-numeric input — it is
+        # NOT a ValueError, so it must be caught explicitly or the
+        # outer loop would miss it. Attribution falls to the
+        # top-level mirror (no position index) since this branch
+        # only fires if the wrapping inside _parse_mirror missed it.
         raise PortfolioParseError(
             f"Failed to parse mirror {m.get('mirrorID')!r}: {exc}"
         ) from exc
 ```
 
-**Nested-position parse.** `_parse_mirror` recursively normalises
-the nested `positions[]` via `_parse_mirror_position`. Any parse
-failure on a nested position raises `PortfolioParseError` directly
-(not wrapped in `ValueError`) with the mirror_id, position index,
-and the underlying exception. The mirror as a whole fails; no
-partial mirror is ever returned to the sync layer. §2.3.3 enforces
-this as the reason the sync transaction rolls back before eviction
-or soft-close touches the DB.
+**Nested-position parse — wrap at call site.** `_parse_mirror`
+iterates over `raw_positions` with its own inner try/except:
+
+```python
+def _parse_mirror(m: dict[str, Any]) -> BrokerMirror:
+    # ... required top-level field extraction with Decimal(str(...))
+    # ... top-level numeric/string conversions may raise
+    raw_positions = m.get("positions") or []
+    parsed_positions: list[BrokerMirrorPosition] = []
+    for idx, pos in enumerate(raw_positions):
+        try:
+            parsed_positions.append(_parse_mirror_position(pos))
+        except (
+            KeyError,
+            ValueError,
+            TypeError,
+            decimal.DecimalException,
+        ) as exc:
+            raise PortfolioParseError(
+                f"Mirror {m.get('mirrorID')!r} "
+                f"position[{idx}]: {exc}"
+            ) from exc
+    return BrokerMirror(...)
+```
+
+This guarantees that *every* nested-position parse failure carries
+`mirror_id + position index` in the error message, and that the
+`PortfolioParseError` is raised *from within* `_parse_mirror` so
+the outer loop's `except PortfolioParseError: raise` catches and
+re-raises it without the attribution degrading to a top-level
+message. §2.3.3 uses this as the reason the sync transaction rolls
+back before eviction or soft-close touches the DB.
+
+**Decimal conversion is the common hazard.** Every payload numeric
+field goes through `Decimal(str(value))`. A non-numeric value (e.g.
+`units: "bogus"`) raises `decimal.InvalidOperation`, a subclass of
+`decimal.DecimalException`, **not** a `ValueError`. Both the inner
+`_parse_mirror` wrap and the outer top-level wrap list
+`decimal.DecimalException` explicitly. Test `8.1` asserts the
+hierarchy: `isinstance(decimal.InvalidOperation(),
+decimal.DecimalException) is True` and no path silently loses a
+malformed decimal.
 
 **Why no log-and-skip path survives for rows with a `mirrorID`.**
 The only safe skip is a row the parser cannot match back to a local
@@ -937,13 +987,60 @@ fix AUM everywhere the dashboard and review paths read it. There are
 **three** AUM call sites in the current codebase, and each needs an
 explicit update in this PR:
 
+### 6.0 Shared helper — `_load_mirror_equity(conn)`
+
+All three call sites run the exact same §3.4 mirror-equity SQL, so
+the query is defined once as a module-level helper and imported
+by each call site. Codex v4 (finding AA) flagged that the earlier
+revision implicitly put this helper in `app/services/portfolio.py`
+(where `_load_cash` / `_load_positions` already live) but then
+called it like a shared helper from two other call sites, without
+naming the module. That ambiguity is closed now.
+
+**Location:**
+[app/services/portfolio.py](app/services/portfolio.py), as a
+module-level private function alongside the existing `_load_cash`
+([portfolio.py:114](app/services/portfolio.py#L114)) and
+`_load_positions` ([portfolio.py:129](app/services/portfolio.py#L129))
+helpers. No new file. The existing read-helper pattern in that
+module is the natural home, and there is no circular import risk
+(neither `execution_guard` nor `api/portfolio.py` is currently
+imported by `services/portfolio.py`).
+
+**Signature:**
+
+```python
+def _load_mirror_equity(conn: psycopg.Connection[Any]) -> float:
+    """Return the summed mirror_equity across all active mirrors.
+
+    Runs the §3.4 mirror-equity SQL under the existing connection
+    and returns a non-negative float (0.0 when copy_mirrors is
+    empty or every row is active = FALSE — matches §3.4's
+    COALESCE(SUM(...), 0) contract, see §6.4 for why `0.0` not
+    `None`).
+    """
+```
+
+**Importers:** `app/services/execution_guard.py` (§6.1),
+`app/api/portfolio.py` (§6.2), and the rest of
+`app/services/portfolio.py` itself (§6.3, `run_portfolio_review`).
+All three call it the same way:
+`mirror_equity = _load_mirror_equity(conn)` inside the existing
+connection scope, and add the float to their respective
+`total_aum` running totals. No call site re-implements the SQL.
+
+The §8.4 identity tests, the §8.5 guard integration test, and the
+§8.6 three-call-site consistency test all exercise this exact
+helper — §8.4's "empty `copy_mirrors` → `0.0`" regression test is
+written as `_load_mirror_equity(conn)`, not as an inline query.
+
 ### 6.1 `app/services/execution_guard.py` (lines 245-289)
 
 Primary site — the execution guard denominator. Loads positions and
 cash, computes `total_aum`, then applies position-% and sector-% rules
-as ratios. Update: add the `mirror_equity` CTE from §3.4 and sum it
-into `total_aum`. Sector and per-position aggregates are NOT touched,
-which is what §4 is about.
+as ratios. Update: import `_load_mirror_equity` from §6.0 and sum its
+return value into `total_aum`. Sector and per-position aggregates
+are NOT touched, which is what §4 is about.
 
 ### 6.2 `app/api/portfolio.py` (`get_portfolio`, lines 111-175)
 
@@ -953,9 +1050,9 @@ and computes `total_aum = total_market + (cash_balance or 0.0)` at
 line 166. This is a separate code path — the query change in §3
 does not touch it.
 
-Update: after computing `total_market` and `cash_balance`, run the
-mirror-equity query from §3.4 and add the result to `total_aum`.
-The `PortfolioResponse` pydantic `BaseModel`
+Update: after computing `total_market` and `cash_balance`, import
+and call `_load_mirror_equity` from §6.0 and add the result to
+`total_aum`. The `PortfolioResponse` pydantic `BaseModel`
 ([api/portfolio.py:63-67](app/api/portfolio.py#L63-L67)) grows one
 new required-with-default field `mirror_equity: float = 0.0` so the
 frontend can display the breakdown (AUM = positions + cash +
@@ -981,9 +1078,9 @@ execution guard sees — otherwise recommendations could be made
 against a denominator that the guard will then reject against a
 different denominator.
 
-Update: add a new `_load_mirror_equity(conn) -> float` helper that
-runs the §3.4 query (`WHERE m.active` filter included, see §3.4),
-and sum its result into `total_aum` at line 753.
+Update: add `mirror_equity = _load_mirror_equity(conn)` at line
+752 (the helper is now a sibling in the same module, per §6.0)
+and sum it into `total_aum` at line 753.
 
 **No audit persistence.** The earlier revision of this spec claimed
 `run_portfolio_review` would capture `mirror_equity` into a
@@ -1104,9 +1201,12 @@ because mirrors never become `positions` rows.
 Codex v3 (finding Y) flagged that several test scenarios share the
 same underlying data shape and should be backed by named fixtures,
 not narrative prose, so test authors cannot silently drift. The
-fixtures below live in `tests/conftest.py` (or a new
-`tests/fixtures/copy_mirrors.py`) and are imported by every test
-that needs them.
+fixtures below live in a **new file**
+`tests/fixtures/copy_mirrors.py` (not `tests/conftest.py`, which
+already carries cross-cutting DB fixtures — bloating it further
+would bury copy-trading state in unrelated tests). They are
+imported by every test that needs them via
+`from tests.fixtures.copy_mirrors import two_mirror_payload` etc.
 
 - **`two_mirror_payload`** — `BrokerPortfolio` with 2 mirrors × 3
   nested positions each, derived from the real
@@ -1120,10 +1220,12 @@ that needs them.
   ready for "seed the DB, call sync with a *different* payload"
   tests. Used by disappearance, re-copy, and parser-abort tests.
 - **`mirror_aum_fixture`** — one `active = TRUE` mirror and one
-  `active = FALSE` mirror (both carrying positions and cash),
-  used by the "closed mirror excluded from AUM" and
-  "three-call-site consistency" tests. Has deterministic numbers
-  so the expected `total_aum` is computable by hand.
+  `active = FALSE` mirror (both carrying positions and cash) plus
+  matching quote rows for every position. This is the fixture used
+  by §8.4's "closed mirror excluded from AUM" test, the §8.4 guard
+  integration test ("existing guard baseline + one mirror"), **and**
+  the §8.4 three-call-site consistency test. Has deterministic
+  numbers so the expected `total_aum` is computable by hand.
 - **`no_quote_mirror_fixture`** — the empirically-reconciled mirror
   15712187 shape (`available = 2800.33`, positions
   `amount = 50.00` and `amount = 17039.33`) with no matching quotes
@@ -1135,10 +1237,17 @@ that needs them.
   FX test (and its short-side variant, which flips `is_buy`
   and swaps the quote).
 
-All fixtures pass a frozen `datetime(2026, 4, 11, 5, 30,
-tzinfo=timezone.utc)` as `now` so `closed_at` / `updated_at`
-assertions are deterministic — this is the injected `now`
-parameter §2.3.4 requires.
+**Frozen `now` value.** All fixtures share the module constant
+`_NOW = datetime(2026, 4, 10, 5, 30, tzinfo=UTC)`, reusing the
+exact value already declared at
+[tests/test_portfolio_sync.py:20](tests/test_portfolio_sync.py#L20).
+Picking the existing value rather than a new one means tests that
+sit alongside each other can assert the same timestamp without
+importing two different `_NOW` constants, and it avoids Codex v4's
+drift warning. The new fixture file re-exports `_NOW` (or imports
+from the existing test module) so there is one canonical value.
+This is the `now` parameter §2.3.4 binds as `%(now)s` in the
+soft-close SQL.
 
 ### 8.1 Parser unit tests (pure, no DB)
 
@@ -1158,15 +1267,30 @@ parameter §2.3.4 requires.
   exception, message names the mirror_id. No partial result.
 - **Malformed nested position** (missing required field, non-numeric
   `units`, missing `openConversionRate`) → `_parse_mirror` raises
-  `PortfolioParseError` naming the mirror_id and position index.
-  No partial-mirror result. This is the strict inner-loop behaviour
-  from §2.2.2 and the parser-failure safeguard from §2.3.3.
+  `PortfolioParseError`. Tests assert the raised exception's
+  `str(exc)` contains both the mirror_id **and** the position index
+  (`"position[2]"` shape) — the inner-loop wrap in §2.2.2
+  guarantees this context survives the outer loop's re-raise. This
+  is the strict inner-loop behaviour from §2.2.2 and the parser-
+  failure safeguard from §2.3.3.
+- **Non-numeric `units` hits `decimal.InvalidOperation`, not
+  `ValueError`** (Codex v4 finding AB). `units: "bogus"` →
+  `Decimal(str("bogus"))` raises `decimal.InvalidOperation`.
+  `_parse_mirror`'s inner catch list in §2.2.2 names
+  `decimal.DecimalException`, so this is caught and re-raised as
+  `PortfolioParseError` with full position-index context, not
+  leaked to the outer top-level wrap. Test asserts exactly this
+  path: the raised type is `PortfolioParseError`, the `__cause__`
+  is a `decimal.InvalidOperation`, and the message contains the
+  position index.
 - **`PortfolioParseError` hierarchy test.** Assertions:
   `issubclass(PortfolioParseError, Exception) is True` AND
   `issubclass(PortfolioParseError, (ValueError, TypeError,
-  KeyError)) is False`. This protects against a future refactor
-  that accidentally subclasses `ValueError` and defeats the
-  outer-loop re-raise. (Codex v3 finding U.)
+  KeyError, decimal.DecimalException)) is False`. This protects
+  against a future refactor that accidentally subclasses
+  `ValueError` (or any of the other catch-list exceptions) and
+  defeats the outer-loop re-raise. (Codex v3 finding U, extended
+  by Codex v4 finding AB.)
 - Missing optional fields (stop loss, take profit) → `None` on
   the `BrokerMirrorPosition` dataclass.
 - **`openConversionRate` is required in production.** A unit test
@@ -1253,34 +1377,40 @@ Every test below starts from `two_mirror_seed_rows` and calls
   is the regression test for the §6.4 contract change (Codex v3
   finding W).
 
-**Guard AUM integration test:**
+### 8.5 Guard AUM integration test
 
-- Existing guard test fixture + one mirror containing a single
-  USD position with `amount = 1000`, `open_rate = 10`, no quote →
-  `total_aum` increases by exactly `available_amount + 1000`.
-- Same fixture + a quote higher than `open_rate` → AUM delta grows
-  by the MTM delta.
-- Same fixture with the mirror soft-closed → AUM returns to the
-  pre-mirror baseline.
-- Sector exposure check on an instrument that is held in a mirror but
-  not in `positions` → sector exposure numerator is 0 (mirror is
-  ignored for concentration), AUM denominator is still increased
-  (rule is more permissive, not less).
+Uses `mirror_aum_fixture` + the existing guard baseline fixture.
+Scenarios:
 
-**Three-call-site AUM consistency test:**
+- Baseline (no active mirrors, all mirror rows soft-closed) →
+  `total_aum` equals the existing guard baseline.
+- Active `mirror_aum_fixture` mirror with its positions and cash →
+  `total_aum` increases by exactly
+  `available_amount + SUM(amount) + SUM(MTM delta)` as computed
+  from the fixture's known values.
+- Sector exposure check on an instrument that is held in the
+  mirror but not in `positions` → sector exposure numerator is 0
+  (mirror is ignored for concentration), AUM denominator is still
+  increased (rule is more permissive, not less).
+- Soft-close the same mirror (flip `active = FALSE` with an
+  `UPDATE` statement at test-setup time) → AUM returns to the
+  baseline.
 
-A single DB fixture is observed through all three AUM paths in one
-test to prove they agree:
+### 8.6 Three-call-site AUM consistency test
+
+Uses `mirror_aum_fixture` — the same DB state is observed through
+all three AUM paths in one test to prove they agree:
 
 1. Direct `execution_guard` call via `run_execution_guard`
 2. `GET /api/portfolio` via `TestClient`
 3. `run_portfolio_review`
 
-All three must report the same `total_aum`. This is the regression
-test for §6 — if a future PR updates one AUM path but not the
-others, this test fails. The test does **not** assert anything
-about persisted AUM snapshots, because (per §6.3) no AUM snapshot
-is persisted anywhere in this PR.
+All three must report the same `total_aum`, and specifically the
+same `mirror_equity` component. This is the regression test for
+§6 — if a future PR updates one AUM path but not the others, this
+test fails. The test does **not** assert anything about persisted
+AUM snapshots, because (per §6.3) no AUM snapshot is persisted
+anywhere in this PR.
 
 **Smoke gate:** `tests/smoke/test_app_boots.py` remains green (the
 FastAPI lifespan touches nothing new; migration 022 runs during
@@ -1337,7 +1467,7 @@ might need is not.
 
 ## 10. Open questions
 
-None at v3 spec-revision time. The load-bearing decisions are all
+None at v4 spec-revision time. The load-bearing decisions are all
 locked:
 
 - Three-table split (`copy_traders`, `copy_mirrors`,
@@ -1355,7 +1485,10 @@ locked:
   all are log-and-skipped.
 - `PortfolioParseError` declared in
   `app.providers.implementations.etoro_broker` as a direct
-  `Exception` subclass (not `ValueError` / `TypeError` / `KeyError`).
+  `Exception` subclass (not `ValueError` / `TypeError` / `KeyError`
+  / `decimal.DecimalException`). Inner `_parse_mirror` wrap and
+  outer top-level wrap both include `decimal.DecimalException` in
+  their catch list.
 - `openConversionRate` required in production; default only in
   test helpers.
 - `mirror_equity: float = 0.0` (not `float | None`) on
@@ -1363,6 +1496,14 @@ locked:
 - `_sync_mirrors` soft-close SQL binds the injected `now`
   parameter (not DB `NOW()`) so frozen-time tests are
   deterministic.
+- `_load_mirror_equity(conn)` is a module-level helper in
+  `app/services/portfolio.py` alongside `_load_cash` /
+  `_load_positions`, imported by `execution_guard`, `api/portfolio`,
+  and `run_portfolio_review` (§6.0).
+- Shared copy-trading test fixtures live in a new file
+  `tests/fixtures/copy_mirrors.py` (not `conftest.py`) and reuse
+  the existing `_NOW = datetime(2026, 4, 10, 5, 30, UTC)`
+  constant from `tests/test_portfolio_sync.py:20`.
 - AUM correction at all three call sites
   (execution_guard / api/portfolio / run_portfolio_review), no
   persisted AUM snapshot.
@@ -1372,7 +1513,7 @@ locked:
   historical gain series, cohort signals) is a separate ticket
   opened when this spec merges.
 
-If a fourth round of review surfaces new questions they will be
+If a fifth round of review surfaces new questions they will be
 appended here before the writing-plans handoff.
 
 ## Appendix A. Revision log
@@ -1539,6 +1680,64 @@ Findings and resolutions:
   soft-close). Fix: §9 now explicitly records that the work moved
   out of Track 2 in round 2 rather than silently deleting the
   bullet, so future readers understand the migration.
+
+### Round 4 — Codex review of the round-3 revision
+
+See `.claude/codex-spec-review-v4.log` in the branch history.
+Findings and resolutions:
+
+- **AA. `_load_mirror_equity(conn)` module location unspecified.**
+  Codex v4 observed that §6.3 implicitly placed the helper in
+  `app/services/portfolio.py` but §8.4 and §6.1 / §6.2 called it
+  like a shared helper without naming the module, leaving
+  writing-plans to guess whether to duplicate SQL or cross-import.
+  Fix: new §6.0 subsection declares the helper at module level in
+  `app/services/portfolio.py` alongside `_load_cash` /
+  `_load_positions`, pinning signature and importers. All three
+  call sites now explicitly import from §6.0.
+- **AB. `decimal.DecimalException` not in §2.2.2 catch list.**
+  Codex v4 observed that `Decimal(str("bogus"))` raises
+  `decimal.InvalidOperation` — a subclass of
+  `decimal.DecimalException`, **not** `ValueError`. The round-3
+  outer catch `except (KeyError, ValueError, TypeError)` would
+  miss it, leaking a bare `DecimalException` past the outer loop
+  and defeating the strict-raise guarantee. Fix: §2.2.2 now adds
+  `decimal.DecimalException` to both the outer top-level wrap
+  catch and the inner `_parse_mirror` per-position wrap. §8.1
+  adds the "non-numeric units" regression test asserting that
+  `__cause__` is a `decimal.InvalidOperation` and the message
+  contains the position index. §8.1 also extends the hierarchy
+  test to assert `PortfolioParseError` is NOT a
+  `DecimalException` subclass.
+- **AC. §8.4 narrative "existing guard fixture" and three-call-
+  site fixture.** Codex v4 observed that §8.4's guard integration
+  test and three-call-site consistency test still described the
+  DB state narratively ("existing guard test fixture + one
+  mirror", "a single DB fixture") rather than naming one of the
+  §8.0 fixtures. Fix: the guard test and the consistency test
+  both now explicitly use `mirror_aum_fixture` (whose §8.0 entry
+  was extended to cover all three usages). §8.4's closed-mirror
+  test, §8.5 guard integration, and §8.6 three-call-site test
+  all name this fixture by name.
+- **AD. §8.0 fixture path was "or".** Codex v4 observed that the
+  path was hedged as `tests/conftest.py` OR
+  `tests/fixtures/copy_mirrors.py`. Fix: §8.0 now pins the path
+  to `tests/fixtures/copy_mirrors.py` (new file, not bloating
+  `conftest.py`) and standardises the import pattern.
+- **AE. §8.0 frozen `now` drifted from existing `_NOW`.** Codex
+  v4 observed that the spec declared
+  `datetime(2026, 4, 11, 5, 30, UTC)` while
+  [tests/test_portfolio_sync.py:20](tests/test_portfolio_sync.py#L20)
+  already uses `datetime(2026, 4, 10, 5, 30, UTC)`. Fix: §8.0
+  now reuses the existing `_NOW` value so tests that sit
+  alongside each other share one canonical timestamp.
+- **AF. §1.2 prose still said `closed_at=NOW()`.** Codex v4
+  flagged that leaving the prose form of "NOW()" in the §1.2
+  narrative could lead a reader (or a future `writing-plans`
+  invocation) to mis-implement the soft-close SQL as DB wall
+  clock instead of the injected `now`. Fix: §1.2 now says
+  "marked `active=false, closed_at=<injected sync timestamp>`"
+  with an explicit forward pointer to §2.3.4.
 
 ## Appendix B. Track 1.5 — REST endpoint and frontend panel
 

--- a/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
+++ b/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
@@ -1014,10 +1014,19 @@ def _load_mirror_equity(conn: psycopg.Connection[Any]) -> float:
     """Return the summed mirror_equity across all active mirrors.
 
     Runs the §3.4 mirror-equity SQL under the existing connection
-    and returns a non-negative float (0.0 when copy_mirrors is
-    empty or every row is active = FALSE — matches §3.4's
-    COALESCE(SUM(...), 0) contract, see §6.4 for why `0.0` not
-    `None`).
+    and returns a float. The value is `0.0` when `copy_mirrors` is
+    empty or every row is `active = FALSE` — §3.4's
+    `COALESCE(SUM(...), 0)` turns an empty result set into `0.0`,
+    never `NULL`, which is why this function's return type is
+    `float` and not `float | None` (see §6.4 for the contract
+    rationale).
+
+    The value is usually non-negative but is NOT mathematically
+    floored at zero: if a mirror's MTM delta on a leveraged
+    position exceeds `available + SUM(amount)`, the per-mirror
+    term can go negative, and the aggregate can too. Callers treat
+    it as an additive AUM contribution and sum it directly into
+    `total_aum`; they do not assume it is non-negative.
     """
 ```
 
@@ -1034,13 +1043,27 @@ The §8.4 identity tests, the §8.5 guard integration test, and the
 helper — §8.4's "empty `copy_mirrors` → `0.0`" regression test is
 written as `_load_mirror_equity(conn)`, not as an inline query.
 
-### 6.1 `app/services/execution_guard.py` (lines 245-289)
+### 6.1 `app/services/execution_guard.py` — `_load_sector_exposure`
 
-Primary site — the execution guard denominator. Loads positions and
-cash, computes `total_aum`, then applies position-% and sector-% rules
-as ratios. Update: import `_load_mirror_equity` from §6.0 and sum its
-return value into `total_aum`. Sector and per-position aggregates
-are NOT touched, which is what §4 is about.
+Exact site: the private helper
+[`_load_sector_exposure`](app/services/execution_guard.py#L235)
+(lines 229-289), which currently computes `total_aum =
+total_positions + cash` at
+[execution_guard.py:286](app/services/execution_guard.py#L286).
+This function is called from `evaluate_recommendation`
+([execution_guard.py:593](app/services/execution_guard.py#L593))
+and returns the `total_aum` consumed by the concentration rule.
+The public `evaluate_recommendation` entry point is **not**
+modified — the change is surgical, inside the helper.
+
+Update: `_load_sector_exposure` imports `_load_mirror_equity`
+from §6.0 and sums its return value into `total_aum` **after**
+the existing `total_positions + cash` line. Sector numerator
+(`sector_values[sector]`) is NOT touched, which is what §4 is
+about — mirrors inflate the denominator only. `GuardResult` is
+not modified: AUM remains a local variable inside
+`evaluate_recommendation`, as it is today. §8.5 tests this
+function directly.
 
 ### 6.2 `app/api/portfolio.py` (`get_portfolio`, lines 111-175)
 
@@ -1219,13 +1242,61 @@ imported by every test that needs them via
   into `copy_mirrors` (active = TRUE) and `copy_mirror_positions`,
   ready for "seed the DB, call sync with a *different* payload"
   tests. Used by disappearance, re-copy, and parser-abort tests.
-- **`mirror_aum_fixture`** — one `active = TRUE` mirror and one
-  `active = FALSE` mirror (both carrying positions and cash) plus
-  matching quote rows for every position. This is the fixture used
-  by §8.4's "closed mirror excluded from AUM" test, the §8.4 guard
-  integration test ("existing guard baseline + one mirror"), **and**
-  the §8.4 three-call-site consistency test. Has deterministic
-  numbers so the expected `total_aum` is computable by hand.
+- **`mirror_aum_fixture`** — the load-bearing DB fixture for
+  §8.4 AUM identity, §8.5 guard integration, and §8.6 per-call-
+  site delta tests. Codex v5 (finding AH) required it to carry
+  enough state that all three call sites actually reach their
+  AUM blocks. Concretely, it seeds:
+
+  1. **Two mirrors in `copy_mirrors`** — one `active = TRUE`,
+     one `active = FALSE`, both with concrete
+     `available_amount`, `initial_investment`, `deposit_summary`,
+     `withdrawal_summary`, `closed_positions_net_profit`,
+     `started_copy_date` values (numbers small enough to
+     hand-compute the expected `total_aum`).
+  2. **Matching `copy_mirror_positions` rows** for each mirror —
+     at least one long position per mirror, with concrete
+     `units`, `open_rate`, `open_conversion_rate`, `amount`,
+     `is_buy = TRUE`, and distinct `instrument_id` values so the
+     §3.4 LATERAL join has a non-empty result for the active
+     mirror and an equal contribution (which the `WHERE m.active`
+     filter then zeroes out) for the closed one.
+  3. **Matching `quotes` rows** for every mirror position's
+     instrument — so the §3.4 query's `COALESCE(q.last,
+     cmp.open_rate)` fallback is exercised for at least one
+     position (quote present) and at least one position is
+     tested with no quote (quote absent → falls back to
+     cost basis).
+  4. **An `instruments` row for at least one of the mirror
+     instrument IDs** — §8.5's `_load_sector_exposure` call
+     needs a matching instrument in `instruments` to resolve a
+     sector. The fixture picks one mirror-held instrument as
+     the "guard test instrument" and sets its sector to an
+     explicit value so the sector-numerator assertion in §8.5
+     is deterministic.
+  5. **A single `latest_scores` row** for any instrument (does
+     NOT need to be one of the mirror-held IDs) keyed on
+     `model_version = "v1-balanced"` — this is the §8.6 Test 2
+     precondition that prevents `run_portfolio_review` from
+     early-returning at
+     [portfolio.py:733](app/services/portfolio.py#L733) before
+     it reaches the AUM block. Without this row the review
+     path never exercises `_load_mirror_equity`, so the test
+     is silently a no-op.
+  6. **Empty `positions` and `cash_ledger`** — the fixture
+     intentionally carries no eBull-owned positions or cash so
+     the expected `total_aum` in the delta tests is exactly
+     `_load_mirror_equity(conn)` plus `(0 + 0)`. §8.6's
+     "baseline" repeat then flips the active mirror's
+     `active = FALSE` and asserts `total_aum` returns to 0.
+     (A separate dedicated test for the full
+     `positions + cash + mirror_equity` combination lives in
+     §8.4 identity tests, which use this same fixture and add
+     one position + one cash row via `UPDATE`/`INSERT` setup
+     helpers.)
+
+  Has deterministic numbers so the expected `total_aum` is
+  computable by hand from the fixture's declared values.
 - **`no_quote_mirror_fixture`** — the empirically-reconciled mirror
   15712187 shape (`available = 2800.33`, positions
   `amount = 50.00` and `amount = 17039.33`) with no matching quotes
@@ -1237,17 +1308,34 @@ imported by every test that needs them via
   FX test (and its short-side variant, which flips `is_buy`
   and swaps the quote).
 
-**Frozen `now` value.** All fixtures share the module constant
-`_NOW = datetime(2026, 4, 10, 5, 30, tzinfo=UTC)`, reusing the
-exact value already declared at
-[tests/test_portfolio_sync.py:20](tests/test_portfolio_sync.py#L20).
-Picking the existing value rather than a new one means tests that
-sit alongside each other can assert the same timestamp without
-importing two different `_NOW` constants, and it avoids Codex v4's
-drift warning. The new fixture file re-exports `_NOW` (or imports
-from the existing test module) so there is one canonical value.
-This is the `now` parameter §2.3.4 binds as `%(now)s` in the
-soft-close SQL.
+**Frozen `now` value — ownership locked to the fixture file.**
+`tests/fixtures/copy_mirrors.py` **owns** the canonical module
+constant:
+
+```python
+_NOW: datetime = datetime(2026, 4, 10, 5, 30, tzinfo=UTC)
+```
+
+The value is identical to the constant currently declared at
+[tests/test_portfolio_sync.py:20](tests/test_portfolio_sync.py#L20),
+so behaviour is preserved. As part of this PR,
+`tests/test_portfolio_sync.py` is edited to remove its local
+declaration and import the constant from the fixture module
+instead:
+
+```python
+from tests.fixtures.copy_mirrors import _NOW
+```
+
+Codex v5 (finding AI) correctly observed that fixtures importing
+from a test module is backwards coupling — tests depend on
+fixtures, not the other way around. Owning `_NOW` in the fixture
+module fixes the coupling direction in a single file rename +
+import swap, with zero behavioural change.
+
+`_NOW` is the `now` parameter §2.3.4 binds as `%(now)s` in the
+soft-close SQL; §8.3's disappearance tests assert the exact
+value round-trips through the SQL as the stored `closed_at`.
 
 ### 8.1 Parser unit tests (pure, no DB)
 
@@ -1379,38 +1467,115 @@ Every test below starts from `two_mirror_seed_rows` and calls
 
 ### 8.5 Guard AUM integration test
 
-Uses `mirror_aum_fixture` + the existing guard baseline fixture.
+Tests the guard-side integration surgically at the private helper
+level, not via `evaluate_recommendation` end-to-end. Codex v5
+finding AG correctly observed that:
+
+- The existing guard entry point is `evaluate_recommendation`
+  (not `run_execution_guard`), and
+- `GuardResult` has no `total_aum` field (AUM is a local variable
+  inside `evaluate_recommendation`, consumed by the concentration
+  rule and not exposed on the return value).
+
+So the guard integration test targets
+`_load_sector_exposure(conn, instrument_id)`
+([execution_guard.py:235](app/services/execution_guard.py#L235)) —
+the private helper that returns `total_aum` and is the exact
+function §6.1 modifies to add `_load_mirror_equity(conn)` to the
+existing `total_positions + cash` sum.
+
+Fixture: `mirror_aum_fixture` (§8.0) seeded into `ebull_test`,
+plus an `instruments` row for the instrument passed to
+`_load_sector_exposure` (any instrument_id present in the mirror
+positions will do). No `evaluate_recommendation`,
+`trade_recommendations`, `kill_switch`, or `runtime_config` setup
+needed — `_load_sector_exposure` does not touch those tables.
+
 Scenarios:
 
-- Baseline (no active mirrors, all mirror rows soft-closed) →
-  `total_aum` equals the existing guard baseline.
-- Active `mirror_aum_fixture` mirror with its positions and cash →
-  `total_aum` increases by exactly
-  `available_amount + SUM(amount) + SUM(MTM delta)` as computed
-  from the fixture's known values.
-- Sector exposure check on an instrument that is held in the
-  mirror but not in `positions` → sector exposure numerator is 0
-  (mirror is ignored for concentration), AUM denominator is still
-  increased (rule is more permissive, not less).
-- Soft-close the same mirror (flip `active = FALSE` with an
-  `UPDATE` statement at test-setup time) → AUM returns to the
-  baseline.
+- **Empty baseline (no mirrors at all).** `_load_sector_exposure`
+  returns `total_aum == positions_mv + cash`, the pre-PR contract.
+- **Active mirror adds to denominator.** Seed
+  `mirror_aum_fixture`'s active mirror (with positions + available
+  cash + matching quotes). `_load_sector_exposure` now returns
+  `total_aum == positions_mv + cash + _load_mirror_equity(conn)`
+  where `_load_mirror_equity(conn)` is computed once from the
+  same connection as the expected additive contribution.
+- **Closed mirror contributes nothing.** Flip `mirror_aum_fixture`'s
+  active mirror to `active = FALSE` via an `UPDATE` at test
+  setup. `_load_sector_exposure` returns the baseline again —
+  soft-closed mirrors do not inflate the denominator.
+- **Sector numerator unchanged.** With an active mirror holding an
+  instrument NOT in `positions`, `_load_sector_exposure`'s
+  `current_sector_pct` numerator is unaffected. The mirror only
+  expands the denominator; the rule stays more permissive, not
+  less. This is the regression test for §4 "execution guard
+  isolation".
 
-### 8.6 Three-call-site AUM consistency test
+### 8.6 AUM delta tests per call site
 
-Uses `mirror_aum_fixture` — the same DB state is observed through
-all three AUM paths in one test to prove they agree:
+Codex v5 finding AG/AH correctly observed that the earlier
+"three-call-site consistency" framing asserted an equality
+surface (`same mirror_equity component`) that does not exist on
+the `GuardResult` return value, and that `run_portfolio_review`
+early-returns before the AUM block when there are no ranked
+candidates. The rewrite below tests each path independently,
+using `_load_mirror_equity(conn)` computed against the same DB
+state as the **expected additive contribution**, and asserts each
+path's `total_aum` absorbs exactly that value vs. a baseline with
+mirrors soft-closed. Three separate tests, not one mega-test.
+The common thread is that the additive delta is read from
+`_load_mirror_equity(conn)` — if a future PR breaks any one path,
+its test alone fails.
 
-1. Direct `execution_guard` call via `run_execution_guard`
-2. `GET /api/portfolio` via `TestClient`
-3. `run_portfolio_review`
+Shared bootstrap (all three tests): `ebull_test`,
+`mirror_aum_fixture` seeded, plus the per-path extras below.
+`expected_mirror_contribution = _load_mirror_equity(conn)` is
+computed once in each test's setup, before the call site fires.
 
-All three must report the same `total_aum`, and specifically the
-same `mirror_equity` component. This is the regression test for
-§6 — if a future PR updates one AUM path but not the others, this
-test fails. The test does **not** assert anything about persisted
-AUM snapshots, because (per §6.3) no AUM snapshot is persisted
-anywhere in this PR.
+**Test 1 — API path.** `GET /api/portfolio` via `TestClient` with
+`app.dependency_overrides[get_conn]` pointing at the `ebull_test`
+connection. Assertions:
+
+- `response.json()["mirror_equity"] == expected_mirror_contribution`
+- `response.json()["total_aum"] == (positions_market_value + cash + expected_mirror_contribution)`
+
+Baseline repeat with the mirror soft-closed (UPDATE `active =
+FALSE`) → `mirror_equity == 0.0` and `total_aum` returns to
+`positions + cash`.
+
+**Test 2 — `run_portfolio_review` path.** Calls
+`run_portfolio_review(conn)` with the `mirror_aum_fixture`
+**plus at least one `latest_scores` row** (any instrument,
+matching `model_version`) so the early-return at
+[portfolio.py:733](app/services/portfolio.py#L733) is not hit
+and the AUM block actually runs. `latest_scores` setup is part
+of `mirror_aum_fixture` (see §8.0). Assertion:
+
+- `result.total_aum == (positions_market_value + (cash or 0.0) + expected_mirror_contribution)`
+
+Baseline repeat with the mirror soft-closed → `result.total_aum`
+returns to `positions + cash`.
+
+**Test 3 — guard path.** Directly calls
+`_load_sector_exposure(conn, instrument_id)` (same as §8.5) and
+asserts its returned `total_aum` carries the `expected_mirror_
+contribution`. This is the same function and assertion surface
+as §8.5, repeated here under the "delta per call site" framing
+for symmetry — the test is cheap and it keeps the §8.6 block
+self-contained. If §8.5 is implemented, this sub-test is one
+line (`assert sector_exposure_total_aum == positions + cash +
+expected_mirror_contribution`).
+
+**What this test explicitly does NOT assert:**
+
+- Cross-path equality of a `mirror_equity` *field*. Only
+  `PortfolioResponse` exposes a `mirror_equity` field (see §6.2);
+  `PortfolioReviewResult` and `GuardResult` do not. §6 does not
+  add them because the review/guard paths only care about the
+  additive sum, not the component. Asserting a field that
+  doesn't exist would be theatre.
+- Persisted AUM snapshots. Per §6.3, no AUM snapshot is written.
 
 **Smoke gate:** `tests/smoke/test_app_boots.py` remains green (the
 FastAPI lifespan touches nothing new; migration 022 runs during
@@ -1467,7 +1632,7 @@ might need is not.
 
 ## 10. Open questions
 
-None at v4 spec-revision time. The load-bearing decisions are all
+None at v5 spec-revision time. The load-bearing decisions are all
 locked:
 
 - Three-table split (`copy_traders`, `copy_mirrors`,
@@ -1500,10 +1665,29 @@ locked:
   `app/services/portfolio.py` alongside `_load_cash` /
   `_load_positions`, imported by `execution_guard`, `api/portfolio`,
   and `run_portfolio_review` (§6.0).
+- The execution_guard change is surgical: `_load_sector_exposure`
+  at [execution_guard.py:235](app/services/execution_guard.py#L235)
+  adds the mirror-equity contribution to its local `total_aum`
+  return value. `evaluate_recommendation` and `GuardResult` are
+  not touched; AUM remains a local variable inside the guard,
+  consumed by the concentration rule. (§6.1, locked round 5.)
 - Shared copy-trading test fixtures live in a new file
-  `tests/fixtures/copy_mirrors.py` (not `conftest.py`) and reuse
-  the existing `_NOW = datetime(2026, 4, 10, 5, 30, UTC)`
-  constant from `tests/test_portfolio_sync.py:20`.
+  `tests/fixtures/copy_mirrors.py` (not `conftest.py`). The
+  fixture file **owns** the canonical `_NOW = datetime(2026,
+  4, 10, 5, 30, UTC)` constant; `tests/test_portfolio_sync.py`
+  is edited in this PR to import `_NOW` from the fixture
+  module instead of declaring it locally. (§8.0, locked round 5.)
+- `mirror_aum_fixture` seeds two mirrors (one active, one
+  closed) with positions/quotes, **plus** one `instruments` row
+  for the guard sector-exposure assertion, **plus** one
+  `latest_scores` row so `run_portfolio_review` does not early-
+  return before reaching the AUM block. (§8.0, locked round 5.)
+- AUM correction at all three call sites tested via
+  `_load_mirror_equity(conn)` as the expected additive
+  contribution — no cross-path `mirror_equity` field equality
+  assertion, because only `PortfolioResponse` exposes that
+  field; `PortfolioReviewResult` and `GuardResult` do not.
+  (§8.6, locked round 5.)
 - AUM correction at all three call sites
   (execution_guard / api/portfolio / run_portfolio_review), no
   persisted AUM snapshot.
@@ -1513,7 +1697,7 @@ locked:
   historical gain series, cohort signals) is a separate ticket
   opened when this spec merges.
 
-If a fifth round of review surfaces new questions they will be
+If a sixth round of review surfaces new questions they will be
 appended here before the writing-plans handoff.
 
 ## Appendix A. Revision log
@@ -1738,6 +1922,68 @@ Findings and resolutions:
   clock instead of the injected `now`. Fix: §1.2 now says
   "marked `active=false, closed_at=<injected sync timestamp>`"
   with an explicit forward pointer to §2.3.4.
+
+### Round 5 — Codex review of the round-4 revision
+
+See `.claude/codex-spec-review-v5.log` in the branch history.
+Findings and resolutions:
+
+- **AG. §8.6 named a non-existent guard entry point and
+  asserted a non-existent return-value field.** Codex v5
+  observed that the round-4 §8.6 called
+  `run_execution_guard`, which does not exist — the guard's
+  public entry point is
+  [`evaluate_recommendation`](app/services/execution_guard.py#L538)
+  and its return type `GuardResult` has no `total_aum` or
+  `mirror_equity` field. `total_aum` is a local variable
+  inside `evaluate_recommendation`, computed by the private
+  helper `_load_sector_exposure`
+  ([execution_guard.py:235](app/services/execution_guard.py#L235))
+  and consumed by the concentration rule; it is not
+  exposed on any return value. The round-4 "three-call-
+  site consistency" framing therefore asserted equality
+  across a surface that does not exist. Fix: §6.1 is
+  rewritten to name `_load_sector_exposure` as the exact
+  private function being modified; §8.5 tests that function
+  directly; §8.6 is rewritten as three per-call-site delta
+  tests (API / review / guard), each computing
+  `_load_mirror_equity(conn)` once as the expected additive
+  contribution and asserting the path's `total_aum`
+  absorbs that value. No cross-path `mirror_equity` field
+  equality is asserted — only `PortfolioResponse` exposes
+  a `mirror_equity` field, so only the API test asserts
+  it. §8.6's explicit "what this test does NOT assert"
+  block locks this scope in writing.
+- **AH. §8.5/§8.6 fixture shape missing state for the
+  review and guard paths.** Codex v5 observed that
+  `run_portfolio_review` returns early at
+  [portfolio.py:733](app/services/portfolio.py#L733) when
+  there are no ranked candidates and no open positions,
+  before the AUM block ever runs; and that `mirror_aum_
+  fixture` as defined in round 4 did not seed an
+  `instruments` row for the guard path's sector lookup,
+  nor a `latest_scores` row to bypass the review early-
+  return. This meant §8.6 Test 2 (review path) would
+  silently be a no-op. Fix: `mirror_aum_fixture`'s §8.0
+  entry now explicitly enumerates six components: two
+  mirrors, their positions, matching quotes, an
+  `instruments` row for the guard path, a `latest_scores`
+  row for the review path, and empty
+  `positions`/`cash_ledger` so the expected `total_aum`
+  collapses to `_load_mirror_equity(conn)` plus `(0 + 0)`
+  in the delta tests.
+- **AI. §8.0 `_NOW` ownership still hedged as "or".** Codex
+  v5 observed that round 4's fix pinned the fixture path
+  but left `_NOW` ownership open with "re-exports `_NOW`
+  (or imports from the existing test module)". Fix: §8.0
+  now locks `tests/fixtures/copy_mirrors.py` as the
+  canonical owner of `_NOW = datetime(2026, 4, 10, 5, 30,
+  tzinfo=UTC)`. `tests/test_portfolio_sync.py` is edited
+  in this PR to import `_NOW` from the fixture module
+  instead of declaring it locally. The value is
+  bit-identical, so behaviour is preserved; the coupling
+  direction (tests depend on fixtures, not the reverse)
+  is now correct. §10 reflects this as a locked decision.
 
 ## Appendix B. Track 1.5 — REST endpoint and frontend panel
 

--- a/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
+++ b/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
@@ -68,8 +68,9 @@ day one:
   the numbers right in the guard, the dashboard top-line, and the
   recommender without also having to ship a new REST surface, a new
   React component, and the UX copy for un-copying. `PortfolioResponse`
-  does grow an optional `mirror_equity: float | None` field in this
-  PR so the existing dashboard top-line can show the breakdown.
+  does grow a `mirror_equity: float = 0.0` field in this PR so the
+  existing dashboard top-line can show the breakdown (see §6.4 for
+  why `0.0` over `None`).
 
 Deferred to **Track 2** (new ticket opened when this spec merges):
 
@@ -372,52 +373,105 @@ sync.
 The existing `portfolio = raw.get("clientPortfolio") or {}` block is
 extended with a second parse pass over `portfolio.get("mirrors") or []`.
 
-Two-tier parsing, reflecting Codex v2 feedback on silent parse
-failures:
+#### 2.2.1 `PortfolioParseError` exception type
 
-**Top-level mirror parse — log-and-skip.** If a `mirrors[]` element
-is not a dict or is missing a required identifier, log a warning and
-continue:
+A new exception is declared in
+`app/providers/implementations/etoro_broker.py`:
+
+```python
+class PortfolioParseError(Exception):
+    """Raised when a mirrors[] row cannot be parsed safely.
+
+    Directly subclasses Exception (NOT ValueError / TypeError /
+    KeyError) so the outer parse loop can distinguish it from
+    incidental exceptions and re-raise. Never swallowed by any
+    `except (KeyError, ValueError, TypeError)` block.
+    """
+```
+
+**Hierarchy rationale (Codex v3 finding U).** `PortfolioParseError`
+must be a direct subclass of `Exception`. If it subclassed
+`ValueError` (which `_parse_mirror_position` naturally raises for
+numeric conversion errors) the outer loop's `except (KeyError,
+ValueError, TypeError)` clause would silently swallow it, defeating
+§2.3.3's strict-raise. The outer loop catches `PortfolioParseError`
+*first* and re-raises, then falls through to the incidental
+`(KeyError, ValueError, TypeError)` catch for the narrow "payload
+shape is unrecognisable" case below.
+
+Module path used throughout the spec and tests:
+`app.providers.implementations.etoro_broker.PortfolioParseError`.
+
+#### 2.2.2 Strict-raise parse contract
+
+Codex v3 (finding V) flagged that a log-and-skip on top-level mirror
+rows interacts badly with the §2.3.4 soft-close: a known mirror whose
+top-level fields parse-fail would be log-skipped, then interpreted as
+"disappeared from the payload", then silently soft-closed and dropped
+from AUM. That is the exact data-loss failure mode §2.3.3 already
+rejected for nested positions.
+
+**v1 rule — strict raise on any row that carries a recognisable
+`mirrorID`.** The top-level parse loop is:
 
 ```python
 for m in raw_mirrors:
-    if not isinstance(m, dict):
+    if not isinstance(m, dict) or "mirrorID" not in m:
+        # Unrecognisable shape with no usable identifier. This
+        # cannot collide with a known local mirror row, so skip
+        # safely. In practice this branch should never fire in
+        # production — if it does, the payload schema has broken.
+        logger.warning(
+            "Skipping unrecognisable mirrors[] element: %r", m
+        )
         continue
+
     try:
         mirrors.append(_parse_mirror(m))
+    except PortfolioParseError:
+        # Nested-position failure or top-level known-mirror failure.
+        # Re-raise unchanged — §2.3.3 requires full sync rollback,
+        # and §2.3.4 soft-close must not silently fire on a
+        # mirrorID that we still see in the payload.
+        raise
     except (KeyError, ValueError, TypeError) as exc:
-        logger.warning("Skipping malformed mirror object: %s", exc)
-        continue
+        # Top-level known-mirror parse failure: mirrorID present
+        # but a required top-level field missing or malformed.
+        # Wrap and raise — this row is a known mirror, soft-close
+        # would silently drop it from AUM, so the sync must abort.
+        raise PortfolioParseError(
+            f"Failed to parse mirror {m.get('mirrorID')!r}: {exc}"
+        ) from exc
 ```
 
-This matches the existing positions-loop pattern and protects the
-sync from a single garbage mirror row in a multi-mirror payload.
-The sync-layer disappearance guard (§2.3.4) still covers the "a
-known mirror is missing" case.
+**Nested-position parse.** `_parse_mirror` recursively normalises
+the nested `positions[]` via `_parse_mirror_position`. Any parse
+failure on a nested position raises `PortfolioParseError` directly
+(not wrapped in `ValueError`) with the mirror_id, position index,
+and the underlying exception. The mirror as a whole fails; no
+partial mirror is ever returned to the sync layer. §2.3.3 enforces
+this as the reason the sync transaction rolls back before eviction
+or soft-close touches the DB.
 
-**Nested-position parse — strict raise.** `_parse_mirror`
-recursively normalises the nested `positions[]` via
-`_parse_mirror_position`. Unlike the old log-and-skip pattern,
-**any** parse failure on a nested position raises
-`PortfolioParseError` (a new exception type) with the mirror_id,
-position index, and the underlying exception. The mirror as a whole
-fails; no partial mirror is ever returned to the sync layer. The
-parse-failure guard (§2.3.3) enforces this as the reason the sync
-transaction rolls back before eviction touches the DB.
+**Why no log-and-skip path survives for rows with a `mirrorID`.**
+The only safe skip is a row the parser cannot match back to a local
+`copy_mirrors` row — i.e. a row with no `mirrorID` to compare
+against. Any row that *could* match a known local row but fails to
+parse must raise, otherwise the combination of "silent skip" +
+"soft-close absent mirrors" = silent data loss. The `mirrorID
+not in m` branch above is the only surviving skip path.
 
-Rationale for the asymmetry:
+Rationale:
 
 - One bad nested position out of 198 is indistinguishable from a
   parser that has drifted against a payload schema change. Silently
   skipping means "delete the valid local row on next eviction and
   pretend nothing happened"; raising means "page the operator, fix
   the parser, re-run the sync."
-- One bad whole-mirror row out of two is a different failure mode:
-  it's usually an entire malformed mirror object (e.g. a string
-  where an int should be), which is exotic enough that we still
-  don't want to block the sync for the *other* mirror while we
-  investigate. The disappearance guard (§2.3.4) catches it on the
-  next sync if the malformed mirror disappears permanently.
+- One bad top-level field on a known `mirrorID` is exactly the same
+  failure mode — it looks like a disappearance to §2.3.4, and
+  §2.3.4 would soft-close the row. Same correctness outcome, same
+  response: raise and stop.
 
 `_parse_mirror` / `_parse_mirror_position` are pure normaliser
 functions alongside `_normalise_open_order_response` (line 519) — no
@@ -598,16 +652,23 @@ raises.**
    recover.
 3. **Partial disappearance (operator un-copy).** If
    `payload_mirror_ids` is non-empty AND `disappeared_ids` is
-   non-empty, run a soft-close:
+   non-empty, run a soft-close using the `now` parameter threaded
+   into `_sync_mirrors` (same value used by the rest of the sync
+   transaction for `updated_at` timestamps — tests can freeze it):
 
    ```sql
    UPDATE copy_mirrors
       SET active = FALSE,
-          closed_at = NOW(),
-          updated_at = NOW()
-    WHERE mirror_id = ANY(%s::bigint[])
+          closed_at = %(now)s,
+          updated_at = %(now)s
+    WHERE mirror_id = ANY(%(disappeared_ids)s::bigint[])
       AND active = TRUE;
    ```
+
+   Parameters are bound with `psycopg.sql.SQL` + a dict payload —
+   never interpolated. Using the injected `now` (not DB `NOW()`)
+   is what makes the disappearance tests below deterministic
+   against a frozen timestamp.
 
    Nested `copy_mirror_positions` rows for the closed mirror are
    **retained** — they are historical fact, and the `active` filter
@@ -894,10 +955,14 @@ does not touch it.
 
 Update: after computing `total_market` and `cash_balance`, run the
 mirror-equity query from §3.4 and add the result to `total_aum`.
-The `PortfolioResponse` dataclass (lines 64-67) adds a new optional
-field `mirror_equity: float | None = None` so the frontend can
-display the breakdown (AUM = positions + cash + mirrors) rather
-than just a lump total. A null value means no mirrors are held.
+The `PortfolioResponse` pydantic `BaseModel`
+([api/portfolio.py:63-67](app/api/portfolio.py#L63-L67)) grows one
+new required-with-default field `mirror_equity: float = 0.0` so the
+frontend can display the breakdown (AUM = positions + cash +
+mirrors) rather than just a lump total. The field is always a
+number: `0.0` when no mirrors are held or all mirrors are
+`active = FALSE`, matching the §3.4 query's `COALESCE(SUM(...), 0)`
+default. See §6.4 for why `0.0` beats `None` here.
 
 ### 6.3 `app/services/portfolio.py` (`run_portfolio_review`, line 752-753)
 
@@ -936,16 +1001,38 @@ later, it lives on a separate ticket and a separate migration.
 
 `GET /api/portfolio/copy-trading` (listing copy traders with
 per-mirror aggregates and nested-position summaries) is deferred to
-a follow-up PR. The existing `PortfolioResponse` dataclass at
-[api/portfolio.py:64-67](app/api/portfolio.py#L64-L67) grows one
-new optional field in this PR:
+a follow-up PR. The existing `PortfolioResponse` pydantic
+`BaseModel` at
+[api/portfolio.py:63-67](app/api/portfolio.py#L63-L67) grows one
+new field in this PR:
 
 ```python
-@dataclass
-class PortfolioResponse:
-    ...existing fields...
-    mirror_equity: float | None = None  # NEW — null if no active mirrors
+class PortfolioResponse(BaseModel):
+    positions: list[PositionItem]
+    position_count: int
+    total_aum: float
+    cash_balance: float | None
+    mirror_equity: float = 0.0  # NEW — 0.0 when no active mirrors
 ```
+
+**Why `float = 0.0` not `float | None = None`** (Codex v3
+finding W). Two call-site contracts were ambiguous:
+
+- §3.4's AUM query is wrapped in `COALESCE(SUM(...), 0)`, so it
+  always returns a number — `0` when the table is empty or every
+  mirror is `active = FALSE`.
+- `cash_balance` is `float | None` because "the cash_ledger is
+  empty" is a genuinely unknown state that the dashboard should
+  render as "—" rather than "£0.00". That reasoning does **not**
+  apply to `mirror_equity`: if no mirrors exist, mirror equity is
+  a *computed* zero, not an unknown. The dashboard should render
+  "£0.00" confidently.
+
+Aligning `mirror_equity` with its query means the frontend never
+has to branch on `null` and can always do
+`total_aum = positions + cash + mirror_equity` unconditionally.
+`cash_balance` keeps the `| None` because its underlying domain is
+genuinely "known unknown vs known zero"; `mirror_equity` does not.
 
 That is the minimum change needed for the dashboard top-line to
 display the AUM breakdown without a new endpoint. Anything
@@ -1012,96 +1099,159 @@ because mirrors never become `positions` rows.
 
 ## 8. Testing strategy
 
-**Unit tests (pure, no DB):**
+### 8.0 Shared fixtures (named)
 
-- `_parse_mirror` / `_parse_mirror_position` against fixtures derived
-  from the real `data/raw/etoro_broker/etoro_portfolio_*.json` payload
-  (trimmed to 2 mirrors × 3 nested positions each for readability, at
-  least one non-USD position to exercise `openConversionRate`).
-- Malformed top-level mirror object (not a dict, missing `mirrorID`)
-  → skipped with warning, other mirrors still parsed. This is the
-  asymmetric outer-loop behaviour from §2.2.
-- Malformed nested position (missing required field, non-numeric
+Codex v3 (finding Y) flagged that several test scenarios share the
+same underlying data shape and should be backed by named fixtures,
+not narrative prose, so test authors cannot silently drift. The
+fixtures below live in `tests/conftest.py` (or a new
+`tests/fixtures/copy_mirrors.py`) and are imported by every test
+that needs them.
+
+- **`two_mirror_payload`** — `BrokerPortfolio` with 2 mirrors × 3
+  nested positions each, derived from the real
+  `data/raw/etoro_broker/etoro_portfolio_*.json` payload (trimmed
+  for readability, at least one non-USD position to exercise
+  `openConversionRate`). This is the canonical "healthy multi-mirror
+  sync" fixture. Every positive-path service-layer test starts
+  here; disappearance tests start here and then remove a mirror.
+- **`two_mirror_seed_rows`** — the same two mirrors pre-inserted
+  into `copy_mirrors` (active = TRUE) and `copy_mirror_positions`,
+  ready for "seed the DB, call sync with a *different* payload"
+  tests. Used by disappearance, re-copy, and parser-abort tests.
+- **`mirror_aum_fixture`** — one `active = TRUE` mirror and one
+  `active = FALSE` mirror (both carrying positions and cash),
+  used by the "closed mirror excluded from AUM" and
+  "three-call-site consistency" tests. Has deterministic numbers
+  so the expected `total_aum` is computable by hand.
+- **`no_quote_mirror_fixture`** — the empirically-reconciled mirror
+  15712187 shape (`available = 2800.33`, positions
+  `amount = 50.00` and `amount = 17039.33`) with no matching quotes
+  rows. Used by the `available + SUM(amount)` identity test.
+- **`mtm_delta_mirror_fixture`** — one long position with
+  `open_rate = 1207.4994`, `units = 6.28927`,
+  `open_conversion_rate = 0.01331`, `amount = 101.08`, plus a
+  matching `quotes.last = 1400.0` row. Used by the MTM-delta +
+  FX test (and its short-side variant, which flips `is_buy`
+  and swaps the quote).
+
+All fixtures pass a frozen `datetime(2026, 4, 11, 5, 30,
+tzinfo=timezone.utc)` as `now` so `closed_at` / `updated_at`
+assertions are deterministic — this is the injected `now`
+parameter §2.3.4 requires.
+
+### 8.1 Parser unit tests (pure, no DB)
+
+- `_parse_mirror` / `_parse_mirror_position` against
+  `two_mirror_payload`: verify the `BrokerMirror` structure,
+  required field presence, and at least one non-USD FX rate round-
+  trip through `_parse_mirror_position`.
+- **Unrecognisable top-level mirror element (no `mirrorID`)** —
+  element is not a dict, or is a dict with no `mirrorID` key →
+  logged warning and skipped, other mirrors still parsed. This is
+  the only surviving log-and-skip path per §2.2.2.
+- **Known-mirror top-level parse failure** — element has
+  `mirrorID` present but a required field (`parentCID`,
+  `parentUsername`, `initialInvestment`, `availableAmount`,
+  `closedPositionsNetProfit`, `startedCopyDate`) missing or
+  malformed → raises `PortfolioParseError` wrapping the underlying
+  exception, message names the mirror_id. No partial result.
+- **Malformed nested position** (missing required field, non-numeric
   `units`, missing `openConversionRate`) → `_parse_mirror` raises
-  `PortfolioParseError` naming the mirror_id and position index. No
-  partial-mirror result is returned. This is the strict inner-loop
-  behaviour from §2.2 and the parser-failure safeguard from §2.3.3.
-- Missing optional fields (stop loss, take profit) → `None` on the
-  dataclass.
+  `PortfolioParseError` naming the mirror_id and position index.
+  No partial-mirror result. This is the strict inner-loop behaviour
+  from §2.2.2 and the parser-failure safeguard from §2.3.3.
+- **`PortfolioParseError` hierarchy test.** Assertions:
+  `issubclass(PortfolioParseError, Exception) is True` AND
+  `issubclass(PortfolioParseError, (ValueError, TypeError,
+  KeyError)) is False`. This protects against a future refactor
+  that accidentally subclasses `ValueError` and defeats the
+  outer-loop re-raise. (Codex v3 finding U.)
+- Missing optional fields (stop loss, take profit) → `None` on
+  the `BrokerMirrorPosition` dataclass.
 - **`openConversionRate` is required in production.** A unit test
   asserts that `_parse_mirror_position` raises when
-  `openConversionRate` is absent. The `Decimal("1")` fallback lives
-  only on the `_mk_position` test helper in
+  `openConversionRate` is absent. The `Decimal("1")` fallback
+  lives only on the `_mk_position` test helper in
   `tests/test_portfolio_sync.py`, and a separate unit test asserts
   that the helper's default is scoped to USD-only fixtures. No
   production code path silently defaults this field.
 
-**Service-layer tests (real test DB, per
-`feedback_test_db_isolation` rule — `ebull_test`, never
-`settings.database_url`):**
+### 8.2 Service-layer tests (real test DB)
 
-- First `sync_portfolio` call with 2 mirrors × 3 positions → rows in
+Real test DB per `feedback_test_db_isolation` rule — `ebull_test`,
+never `settings.database_url`.
+
+- First `sync_portfolio` call with `two_mirror_payload` → rows in
   `copy_traders`, `copy_mirrors` (both `active = TRUE`),
   `copy_mirror_positions`.
-- Second `sync_portfolio` with one nested position removed → that row
-  is DELETEd, siblings untouched, `copy_mirrors.active` unchanged.
+- Second `sync_portfolio` with one nested position removed → that
+  row is DELETEd, siblings untouched, `copy_mirrors.active`
+  unchanged.
 - Re-running the same payload is idempotent (row counts unchanged,
   `updated_at` refreshed, `active` still `TRUE`).
-- Mirror-level metadata changed on second sync → `copy_mirrors` row
-  updated, trader row untouched apart from `updated_at`.
-- Parent username changed on second sync → `copy_traders.parent_username`
-  updated.
+- Mirror-level metadata changed on second sync → `copy_mirrors`
+  row updated, trader row untouched apart from `updated_at`.
+- Parent username changed on second sync →
+  `copy_traders.parent_username` updated.
 
-**Disappearance handling tests (the new behaviour from §2.3.4):**
+### 8.3 Disappearance handling tests (§2.3.4)
 
-- **Empty `mirrors` array with active local mirrors present** →
-  `RuntimeError` raised, transaction rolls back, local rows remain
-  `active = TRUE`. Matches the positions guard's "total disappearance
-  is unsafe" invariant.
-- **Partial mirror disappearance: soft-close.** Seed 2 active local
-  mirrors, call `sync_portfolio` with a payload containing only 1 of
-  them. Assert: the matching mirror stays `active = TRUE,
-  closed_at IS NULL`; the missing mirror flips to `active = FALSE,
-  closed_at = now()`; nested `copy_mirror_positions` rows for the
-  closed mirror **remain** (not CASCADE-deleted); the result's
-  `mirrors_closed = 1`.
-- **Re-copy (same mirror_id reuse).** Seed a soft-closed mirror
-  (`active = FALSE`), call `sync_portfolio` with a payload
-  containing that same `mirror_id`. Assert: the row is back to
+Every test below starts from `two_mirror_seed_rows` and calls
+`sync_portfolio` with a modified payload.
+
+- **Empty `mirrors[]` with active local mirrors present** →
+  `RuntimeError` raised, transaction rolls back, both seed rows
+  remain `active = TRUE`. Matches the positions guard's "total
+  disappearance is unsafe" invariant.
+- **Partial mirror disappearance: soft-close.** Payload contains
+  only 1 of the 2 seed mirrors. Assert: the matching mirror stays
+  `active = TRUE, closed_at IS NULL`; the missing mirror flips to
+  `active = FALSE, closed_at = frozen_now` (exact timestamp
+  match against the injected `now` parameter); nested
+  `copy_mirror_positions` rows for the closed mirror **remain**;
+  the result's `mirrors_closed = 1`.
+- **Re-copy (same `mirror_id` reuse).** Pre-set one seed mirror to
+  `active = FALSE, closed_at = <past>`, then call sync with
+  `two_mirror_payload`. Assert: the row is back to
   `active = TRUE, closed_at = NULL`; `updated_at` advances; nested
   positions are upserted correctly.
-- **Parser-failure abort before eviction.** Seed a mirror with 3
-  local positions. Call `sync_portfolio` with a payload where one
-  of the three nested positions is malformed (e.g. non-numeric
-  `units`). Assert: `PortfolioParseError` propagates, the
-  transaction rolls back, all 3 local rows survive, and no partial
-  upsert or eviction occurred.
+- **Parser-failure abort before eviction.** Call sync with a
+  payload where one nested position in one mirror is malformed.
+  Assert: `PortfolioParseError` propagates, the transaction rolls
+  back, all seed rows survive, no partial upsert or eviction
+  occurred, `copy_mirrors.active` on both seed mirrors is
+  unchanged.
+- **Known-mirror top-level parse failure also aborts.** Call sync
+  with a payload where one mirror has `mirrorID` present but
+  `availableAmount` missing. Assert: `PortfolioParseError`
+  propagates (wrapped from a `KeyError`), both seed rows survive
+  unchanged — this is the regression test for the Codex v3
+  finding V parse-and-soft-close hole.
 
-**AUM identity tests (the core correctness test for §3):**
+### 8.4 AUM identity tests (§3 correctness core)
 
-Fixtures inserted directly into `copy_mirrors` and
-`copy_mirror_positions`:
-
-- **No-quote cost-basis fallback.** One mirror with
-  `available_amount = 2800.33`, two positions with
-  `amount = 50.00` and `amount = 17039.33`, no quotes → the §3.4
-  query returns `2800.33 + 50.00 + 17039.33 = 19889.66`. This is
-  the empirically-reconciled identity on mirror 15712187.
-- **MTM delta with FX.** One mirror, one long position with
-  `open_rate = 1207.4994`, `units = 6.28927`,
-  `open_conversion_rate = 0.01331`, `amount = 101.08`, and a quote
-  `quotes.last = 1400.0` → delta = `1 * 6.28927 * (1400.0 -
-  1207.4994) * 0.01331 ≈ 16.12`, so mirror equity ≈
-  `available + 101.08 + 16.12`. Asserts FX is applied to the delta.
+- **No-quote cost-basis fallback.** Using `no_quote_mirror_fixture`
+  → the §3.4 query returns `2800.33 + 50.00 + 17039.33 =
+  19889.66`. The empirically-reconciled identity on mirror
+  15712187.
+- **MTM delta with FX.** Using `mtm_delta_mirror_fixture` → delta
+  = `1 * 6.28927 * (1400.0 - 1207.4994) * 0.01331 ≈ 16.12`, so
+  mirror equity ≈ `available + 101.08 + 16.12`. Asserts FX is
+  applied to the delta.
 - **Short delta.** Same fixture with `is_buy = false` and
   `quotes.last = 1000.0` (below entry) → delta = `-1 * 6.28927 *
   (1000.0 - 1207.4994) * 0.01331 ≈ +17.37`, equity goes **up**
   because a short is profitable when the price falls.
-- **Closed mirror excluded from AUM.** Fixture with one
-  `active = TRUE` mirror and one `active = FALSE` mirror (both
-  with positions and cash) → §3.4 query returns only the active
-  mirror's equity; closed mirror contributes zero. This is the
-  regression test for the `WHERE m.active` filter.
+- **Closed mirror excluded from AUM.** Using `mirror_aum_fixture`
+  → §3.4 query returns only the active mirror's equity; closed
+  mirror contributes zero. Regression test for the
+  `WHERE m.active` filter.
+- **Empty `copy_mirrors` table → `mirror_equity = 0.0` (not null).**
+  Call `_load_mirror_equity(conn)` against an empty schema and
+  assert the returned value is the float `0.0`, not `None`. This
+  is the regression test for the §6.4 contract change (Codex v3
+  finding W).
 
 **Guard AUM integration test:**
 
@@ -1169,8 +1319,12 @@ Track 2's job is to turn that surface into:
    accumulating instrument X over a window, tilt the ranking engine in
    favour of X.
 4. Verification of the short-position AUM math on live mirrors.
-5. Graceful mirror-closure semantics (`closed_at` column, disappear
-   vs delete vs preserve-history policy).
+
+(The earlier draft had a "graceful mirror-closure semantics
+(`closed_at` column, disappear vs delete vs preserve-history
+policy)" bullet here. That work moved into Track 1 in round 2 —
+§1.2 `active`/`closed_at` columns and §2.3.4 soft-close semantics
+are now shipped in this PR. Removed in round 3.)
 
 Track 2 will introduce its own schema migration(s) for trader
 history, daily-gain series, cohort signals, and whatever
@@ -1183,7 +1337,7 @@ might need is not.
 
 ## 10. Open questions
 
-None at v2 spec-revision time. The load-bearing decisions are all
+None at v3 spec-revision time. The load-bearing decisions are all
 locked:
 
 - Three-table split (`copy_traders`, `copy_mirrors`,
@@ -1195,10 +1349,20 @@ locked:
 - Empty `mirrors[]` with active local rows → raise.
 - Partial disappearance → soft-close via `active` / `closed_at`
   columns; nested positions retained.
-- Any nested-position parse failure → strict raise, full sync
-  rollback, operator investigates.
+- Any parse failure on a row carrying a usable `mirrorID` (top-
+  level or nested) → strict raise `PortfolioParseError`, full sync
+  rollback, operator investigates. Only rows with no `mirrorID` at
+  all are log-and-skipped.
+- `PortfolioParseError` declared in
+  `app.providers.implementations.etoro_broker` as a direct
+  `Exception` subclass (not `ValueError` / `TypeError` / `KeyError`).
 - `openConversionRate` required in production; default only in
   test helpers.
+- `mirror_equity: float = 0.0` (not `float | None`) on
+  `PortfolioResponse`, aligned with §3.4's `COALESCE(SUM, 0)`.
+- `_sync_mirrors` soft-close SQL binds the injected `now`
+  parameter (not DB `NOW()`) so frozen-time tests are
+  deterministic.
 - AUM correction at all three call sites
   (execution_guard / api/portfolio / run_portfolio_review), no
   persisted AUM snapshot.
@@ -1208,7 +1372,7 @@ locked:
   historical gain series, cohort signals) is a separate ticket
   opened when this spec merges.
 
-If a third round of review surfaces new questions they will be
+If a fourth round of review surfaces new questions they will be
 appended here before the writing-plans handoff.
 
 ## Appendix A. Revision log
@@ -1298,8 +1462,83 @@ Findings and resolutions:
   not lock the data contract. Fix: §6.4 / §6.5 explicitly defer
   the new REST endpoint and the copy-trading panel to a Track 1.5
   follow-up PR (Appendix B). This PR ships only the AUM correction
-  and a single additive `mirror_equity: float | None` field on the
-  existing `PortfolioResponse`.
+  and a single additive `mirror_equity` field on the existing
+  `PortfolioResponse`. Round 3 later tightened the field type from
+  `float | None = None` to `float = 0.0` — see finding W.
+
+### Round 3 — Codex review of the round-2 revision
+
+See `.claude/codex-spec-review-v3.log` in the branch history.
+Findings and resolutions:
+
+- **U. `PortfolioParseError` hierarchy unspecified.** Codex v3
+  observed that if the new exception subclasses `ValueError` /
+  `TypeError` / `KeyError`, the existing outer-loop
+  `except (KeyError, ValueError, TypeError)` silently swallows
+  nested-position failures, defeating §2.3.3's strict-raise. Fix:
+  §2.2.1 declares `PortfolioParseError(Exception)` as a direct
+  `Exception` subclass in
+  `app.providers.implementations.etoro_broker`, and §8.1 adds a
+  unit test that asserts the hierarchy to prevent future drift.
+- **V. §2.2 log-and-skip of known mirrors is dangerous under
+  soft-close.** Codex v3 observed that a top-level parse failure
+  on a row with a valid `mirrorID` would be log-skipped by the
+  earlier asymmetric parser contract, then interpreted by §2.3.4
+  as a partial disappearance, then silently soft-closed — dropping
+  a still-live mirror from AUM for exactly the same failure mode
+  §2.3.3 already strict-raises on for nested positions. Fix:
+  §2.2.2 rewrites the parse contract so the only surviving
+  log-and-skip path is a row with **no `mirrorID` at all**; any
+  row with `mirrorID` present and a required top-level field
+  missing or malformed now raises `PortfolioParseError`, which the
+  outer loop catches first and re-raises. §8.3 adds a "known-mirror
+  top-level parse failure also aborts" regression test.
+- **W. `mirror_equity` contract ambiguous (`None` vs `0.0`).**
+  Codex v3 observed that §3.4's query returns `0` for no active
+  mirrors (wrapped in `COALESCE(SUM(...), 0)`) while §6.4 declared
+  the API field as `float | None = None` — an unnecessary
+  difference the frontend would have to branch on. Fix: §6.4
+  changes the field to `mirror_equity: float = 0.0`. `cash_balance`
+  keeps its `float | None` because "empty cash_ledger" is a
+  genuinely unknown domain state, unlike "no mirrors held" which
+  is a computed zero. §8.4 adds a regression test for the empty-
+  table case.
+- **W-bis. `PortfolioResponse` mis-described as `@dataclass`.**
+  While verifying W against the real code, discovered that §6.4
+  called `PortfolioResponse` a `@dataclass` when
+  [api/portfolio.py:63](app/api/portfolio.py#L63) declares it as
+  `class PortfolioResponse(BaseModel)` — a pydantic `BaseModel`.
+  Fix: §6.2 and §6.4 now correctly name the type.
+- **X. §2.3.4 SQL uses DB `NOW()` instead of the injected `now`.**
+  Codex v3 observed that the round-2 SQL sketch called
+  `NOW()` directly, which means tests that freeze time
+  (as the soft-close / re-copy tests need to in order to assert
+  exact `closed_at` / `updated_at` values) would drift from the
+  DB wall clock. Fix: §2.3.4 now binds `%(now)s` from the `now`
+  parameter `_sync_mirrors` already accepts in its signature, and
+  §8.0 fixture contract standardises the frozen timestamp
+  `datetime(2026, 4, 11, 5, 30, tzinfo=timezone.utc)` so every
+  deterministic test asserts against the same value. The manual
+  operator runbook on total-disappearance keeps `NOW()` — it is
+  typed by a human interactively, no injected `now` exists.
+- **Y. §8 test fixtures described narratively, not named.**
+  Codex v3 observed that several tests reference the same
+  underlying shape ("2 mirrors × 3 nested positions", "active +
+  closed mirror AUM") without a named fixture, which invites
+  implementation drift if the test author writes the shape from
+  scratch in each test. Fix: §8.0 names five fixtures —
+  `two_mirror_payload`, `two_mirror_seed_rows`,
+  `mirror_aum_fixture`, `no_quote_mirror_fixture`,
+  `mtm_delta_mirror_fixture` — with explicit shapes and the
+  frozen `now` contract, and every §8.1-8.4 test reads from them.
+- **Z. §9 Track 2 closure bullet stale.** Codex v3 observed that
+  the "graceful mirror-closure semantics (`closed_at` column,
+  disappear vs delete vs preserve-history policy)" bullet still
+  lived in the Track 2 preview even though round 2 moved the
+  work into Track 1 (§1.2 `active`/`closed_at` columns + §2.3.4
+  soft-close). Fix: §9 now explicitly records that the work moved
+  out of Track 2 in round 2 rather than silently deleting the
+  bullet, so future readers understand the migration.
 
 ## Appendix B. Track 1.5 — REST endpoint and frontend panel
 

--- a/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
+++ b/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
@@ -56,17 +56,21 @@ day one:
 
 - `/user-info/people/*` endpoint integration (profile, gain series,
   trade info, live portfolio of arbitrary users, people/search)
-- Populating the Track-2-only columns on `copy_traders`
-  (`risk_score`, `gain_1y_pct`, `copiers_count`, `is_popular_investor`,
-  `weeks_since_registration`, `last_profile_refresh_at`)
 - Trader discovery and watchlist
-- Historical trader performance tracking
+- Historical trader performance tracking (monthly/daily gain series)
+- Current profile snapshot columns/tables (risk score, copiers count,
+  popular-investor flag, weeks since registration, etc.) — Track 2
+  decides at the time whether these belong on `copy_traders` or on a
+  separate `trader_profile_snapshots` table
 - Signal derivation (accumulation / divestment by a trusted cohort)
-- Reconciliation on mirror disappearance (graceful closure semantics —
-  v1 treats an empty `mirrors[]` with local rows as an API failure and
-  raises, same as the existing positions guard)
-- Short positions on mirrors beyond the "negative MV" math sketched in
-  §5 — to be verified against live data in Track 2
+- Graceful mirror-closure semantics — v1 treats disappearing mirrors
+  (partial *or* full) as API failures and raises; an operator
+  deletes `copy_mirrors` rows by hand to intentionally un-copy
+- Currency-aware MTM using a *current* FX rate — v1 uses the
+  entry-time `open_conversion_rate` stored on each nested position;
+  see §3.2 for the approximation
+- Live verification of the short-position formula against a
+  short-containing mirror (the demo account has none as of spec date)
 
 ## 1. Data model
 
@@ -77,18 +81,8 @@ Three new tables. `positions`, `cash_ledger`, and the existing
 
 ```sql
 CREATE TABLE copy_traders (
-    parent_cid BIGINT PRIMARY KEY,
-    parent_username TEXT NOT NULL,
-
-    -- Track 2 columns. Nullable, not populated by the Track 1 sync path.
-    -- A separate upsert path (added in the Track 2 PR) will write these
-    -- from /api/v1/user-info/people/{username}/tradeinfo.
-    risk_score INTEGER,
-    gain_1y_pct NUMERIC(10, 4),
-    copiers_count INTEGER,
-    is_popular_investor BOOLEAN,
-    weeks_since_registration INTEGER,
-    last_profile_refresh_at TIMESTAMPTZ,
+    parent_cid      BIGINT PRIMARY KEY,
+    parent_username TEXT   NOT NULL,
 
     first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -98,23 +92,33 @@ CREATE INDEX copy_traders_username_idx ON copy_traders (parent_username);
 ```
 
 Semantics: one row per eToro trader identity, keyed by `parentCID`.
-Track 1 populates only `parent_cid`, `parent_username`, `first_seen_at`,
-`updated_at`. The Track 2 profile columns are set aside now so the
-Track 2 PR can populate them without a schema migration.
+Track 1 populates every column.
+
+Track 2 deliberately has no column footprint on this table yet. The
+earlier draft reserved nullable columns (`risk_score`, `gain_1y_pct`,
+etc.) to "avoid a migration later", but Track 2 already needs its own
+tables for historical gain series, daily-gain series, and cohort
+signals — one more column-adding migration alongside those tables is
+not the pain point and YAGNI wins. Track 2 will decide at the time
+whether the *current* profile snapshot belongs on `copy_traders` or in
+a separate `trader_profile_snapshots` table (leaning towards the
+latter: the gain and risk numbers are already time-series data by
+nature).
 
 Upsert (Track 1): `ON CONFLICT (parent_cid) DO UPDATE SET
 parent_username = EXCLUDED.parent_username, updated_at = NOW()`. We
-honour the latest username eToro returns; Track 2's columns are NOT
-touched by this upsert path.
+honour the latest username eToro returns.
 
 ### 1.2 `copy_mirrors`
 
 ```sql
 CREATE TABLE copy_mirrors (
-    mirror_id BIGINT PRIMARY KEY,
+    mirror_id  BIGINT PRIMARY KEY,
     parent_cid BIGINT NOT NULL REFERENCES copy_traders(parent_cid),
 
     initial_investment          NUMERIC(20, 4) NOT NULL,
+    deposit_summary             NUMERIC(20, 4) NOT NULL,
+    withdrawal_summary          NUMERIC(20, 4) NOT NULL,
     available_amount            NUMERIC(20, 4) NOT NULL,
     closed_positions_net_profit NUMERIC(20, 4) NOT NULL,
     stop_loss_percentage        NUMERIC(10, 4),
@@ -136,9 +140,24 @@ Semantics: one row per mirror (one per currently-copied trader).
 stable spine regardless of whether the copy is active, paused, or
 restarted with a new `mirrorID`.
 
-`raw_payload` is the full mirror object from the broker as JSONB, for
-auditability and so Track 2 can backfill Track-2-only columns without
-re-fetching.
+**Why `deposit_summary` / `withdrawal_summary` are first-class
+columns and not buried in JSONB.** Funded capital for a mirror is
+`initial_investment + deposit_summary − withdrawal_summary`, not
+`initial_investment`. The demo account already shows this — mirror
+`15714660` has `initialInvestment=17280` and `depositSummary=2251`.
+Auditing "how much capital did we commit to this trader" without
+these columns would give the wrong answer by $2,251 on day one. They
+also make it trivial to reconcile our AUM identity (see §3).
+
+`raw_payload` is the full mirror object from the broker as JSONB,
+kept for auditability and schema evolution — if a future field
+becomes interesting (e.g. `mirrorStatusID` sub-codes we haven't
+categorised), we can backfill it from `raw_payload` without
+re-fetching history. It is **not** a stable substrate for Track 2
+profile data: the mirror payload does not contain `riskScore`,
+`gain`, `copiers`, or `popularInvestor` — those come from
+`/api/v1/user-info/people/{username}/tradeinfo` and require their
+own fetch path.
 
 We deliberately do **not** store a derived `mirror_equity` column.
 Snapshotted derived values on a live account are a trap — equity
@@ -153,39 +172,75 @@ All mirror-level columns are refreshed from the latest payload.
 
 ```sql
 CREATE TABLE copy_mirror_positions (
-    position_id BIGINT PRIMARY KEY,
     mirror_id   BIGINT NOT NULL REFERENCES copy_mirrors(mirror_id) ON DELETE CASCADE,
+    position_id BIGINT NOT NULL,
+    PRIMARY KEY (mirror_id, position_id),
 
     parent_position_id BIGINT NOT NULL,
-    instrument_id      INTEGER NOT NULL,
+    instrument_id      BIGINT NOT NULL,
 
-    is_buy                    BOOLEAN NOT NULL,
+    is_buy                    BOOLEAN        NOT NULL,
     units                     NUMERIC(20, 8) NOT NULL,
     amount                    NUMERIC(20, 4) NOT NULL,
     initial_amount_in_dollars NUMERIC(20, 4) NOT NULL,
     open_rate                 NUMERIC(20, 6) NOT NULL,
-    open_date_time            TIMESTAMPTZ NOT NULL,
+    open_conversion_rate      NUMERIC(20, 10) NOT NULL,
+    open_date_time            TIMESTAMPTZ    NOT NULL,
     take_profit_rate          NUMERIC(20, 6),
     stop_loss_rate            NUMERIC(20, 6),
     total_fees                NUMERIC(20, 4) NOT NULL DEFAULT 0,
-    leverage                  INTEGER NOT NULL DEFAULT 1,
+    leverage                  INTEGER        NOT NULL DEFAULT 1,
 
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    raw_payload JSONB NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX copy_mirror_positions_mirror_id_idx      ON copy_mirror_positions (mirror_id);
-CREATE INDEX copy_mirror_positions_instrument_id_idx  ON copy_mirror_positions (instrument_id);
+CREATE INDEX copy_mirror_positions_instrument_id_idx ON copy_mirror_positions (instrument_id);
 ```
 
 Semantics: one row per nested position currently held inside a mirror.
 
+**`instrument_id BIGINT`.** Matches [sql/001_init.sql:2](sql/001_init.sql#L2)
+and every other FK-bearing table in the repo — the original draft's
+`INTEGER` was a convention break.
+
+**`open_conversion_rate NOT NULL`.** Non-negotiable. On the demo
+account, 74 of 198 positions on mirror `15712187` are non-USD: GBP
+(`~1.158`), JPY (`~0.01331`), ILS (`~0.103`), EUR (`~1.16`). Storing
+only `open_rate` and computing `units * open_rate` gives
+$313,171 for that mirror — a cross-currency sum of nonsense. The
+identity `SUM(units * open_rate * open_conversion_rate) ≈ SUM(amount)`
+has been verified empirically on both mirrors in
+`data/raw/etoro_broker/etoro_portfolio_20260411T053000Z.json` and
+differs by $0.01 (rounding). Without this column, the AUM query in
+§3 is wildly wrong for every non-USD position.
+
+**Composite primary key `(mirror_id, position_id)`, not
+`position_id` alone.** The eToro API reference does not document
+position-ID uniqueness across mirrors, and the code must not assume
+it. A composite key is cheap (one extra `int8` per row, and the
+`(mirror_id, ...)` prefix is already the natural access pattern for
+§2.3's eviction query) and eliminates an invariant we cannot prove
+without a broker source that does not exist. It also obviates a
+separate `copy_mirror_positions_mirror_id_idx` — the PK covers it.
+
 **No foreign key on `instrument_id`.** Copy traders trade a wider
 universe than our synced `instruments` table (copy portfolios commonly
 contain commodities, FX, crypto, and non-US equities we have not
-onboarded). Enforcing the FK would force us to either reject these rows
-or pre-sync the whole eToro universe. We accept unknown instrument IDs
-as opaque identifiers and LEFT OUTER JOIN against `instruments` in
+onboarded). Enforcing the FK would force us to either reject these
+rows or pre-sync the whole eToro universe. We accept unknown instrument
+IDs as opaque identifiers and LEFT OUTER JOIN against `instruments` in
 reads.
+
+**`raw_payload JSONB NOT NULL`.** Every nested position keeps its own
+raw payload, not just the mirror row. Codex flagged the original
+design (raw on the mirror only) as brittle: the mirror row's
+`raw_payload` gets overwritten on every sync, so historical per-row
+audits would need to fan out through a time-travel query just to
+reconstruct "what did that position look like an hour ago". Keeping
+the raw per-row costs one JSONB column but makes every nested field
+we haven't promoted to a typed column (e.g. `totalExternalFees`,
+`unitsBaseValueDollars`, `pnlVersion`) debuggable from the DB alone.
 
 **`ON DELETE CASCADE` from `copy_mirrors`.** Track 1 never deletes
 `copy_mirrors` rows on sync (see §2.3), so this is defence-in-depth —
@@ -196,7 +251,7 @@ nested position rows.
 
 ### 2.1 Broker provider interface (`app/providers/broker.py`)
 
-Two new frozen dataclasses and one non-breaking extension to
+Two new frozen dataclasses and one additive field on
 `BrokerPortfolio`:
 
 ```python
@@ -207,9 +262,10 @@ class BrokerMirrorPosition:
     instrument_id: int
     is_buy: bool
     units: Decimal
-    amount: Decimal
+    amount: Decimal                      # pre-converted USD cost basis
     initial_amount_in_dollars: Decimal
-    open_rate: Decimal
+    open_rate: Decimal                   # entry price in the instrument's native currency
+    open_conversion_rate: Decimal        # FX snapshot at open (native -> USD)
     open_date_time: datetime
     take_profit_rate: Decimal | None
     stop_loss_rate: Decimal | None
@@ -224,6 +280,8 @@ class BrokerMirror:
     parent_cid: int
     parent_username: str
     initial_investment: Decimal
+    deposit_summary: Decimal
+    withdrawal_summary: Decimal
     available_amount: Decimal
     closed_positions_net_profit: Decimal
     stop_loss_percentage: Decimal | None
@@ -240,16 +298,27 @@ class BrokerMirror:
 class BrokerPortfolio:
     positions: Sequence[BrokerPosition]
     available_cash: Decimal
-    mirrors: Sequence[BrokerMirror]          # NEW
     raw_payload: dict[str, Any]
+    mirrors: Sequence[BrokerMirror] = ()   # NEW — default keeps existing callers working
 ```
 
-Adding a field to the existing `BrokerPortfolio` is non-breaking:
-`positions` and `available_cash` continue to work, callers that do not
-care about mirrors simply ignore the new attribute. The alternative —
-an additional method `get_mirrors()` on the interface — was rejected
-because mirrors arrive in the same payload as positions and splitting
-them would double the HTTP call count per sync.
+**Why `mirrors` has a default and not a required position.** There
+are two existing `BrokerPortfolio(...)` call sites:
+[etoro_broker.py:456](app/providers/implementations/etoro_broker.py#L456)
+and the test helper at
+[tests/test_portfolio_sync.py:56](tests/test_portfolio_sync.py#L56).
+The earlier draft called the addition "non-breaking" — it isn't
+unless the field has a default, because `@dataclass(frozen=True)`
+produces a positional/keyword constructor and a new *required* field
+breaks every existing call. Defaulting to an empty tuple preserves
+both call sites unchanged at the type level, and the etoro_broker
+parse pass below populates the real value. Tests that want to
+exercise mirrors pass them explicitly.
+
+The alternative — an additional method `get_mirrors()` on the
+interface — was rejected because mirrors arrive in the same payload
+as positions and splitting them would double the HTTP call count per
+sync.
 
 ### 2.2 `etoro_broker.get_portfolio` (`app/providers/implementations/etoro_broker.py`)
 
@@ -279,10 +348,14 @@ parses optional fields with defaults, and recursively normalises the
 nested `positions[]` into `BrokerMirrorPosition` instances via a second
 normaliser `_parse_mirror_position`.
 
-Malformed nested positions inside a mirror are skipped, not failed —
-the mirror as a whole is still ingested. A mirror with zero valid
-nested positions is ingested with `positions=[]` (still useful for AUM
-via `available_amount + closed_positions_net_profit`).
+Malformed nested positions inside a mirror are skipped, not failed
+at parse time — the mirror as a whole is still returned. The
+parse-success ratio is re-checked by the sync layer before eviction
+runs (§2.3.3), and a catastrophic drop raises there. A mirror with
+a genuinely-empty payload (`raw_positions == []`) is ingested with
+`positions=[]` — that is a valid state (the mirror holds only
+`available_amount` cash for the moment) and the §3.2 formula
+handles it correctly as `mirror_equity = available_amount`.
 
 ### 2.3 `portfolio_sync` (`app/services/portfolio_sync.py`)
 
@@ -299,41 +372,111 @@ def _sync_mirrors(
     """Returns (mirrors_upserted, mirror_positions_upserted)."""
 ```
 
+#### 2.3.1 Single-writer invariant
+
+`daily_portfolio_sync` holds a session-scoped Postgres advisory lock
+via `JobLock` ([app/jobs/locks.py:60](app/jobs/locks.py#L60)) for the
+full duration of the run, and APScheduler's `max_instances=1`
+default ([app/jobs/runtime.py:213](app/jobs/runtime.py#L213))
+enforces one concurrent instance per job on top of that. These two
+layers — process-local and cross-process — mean two instances of
+`sync_portfolio` (and therefore `_sync_mirrors`) **cannot** run
+concurrently against the same database.
+
+`_sync_mirrors` relies on this invariant. It does *not* take its own
+advisory lock, because stacking locks inside an already-serialised
+job adds reasoning overhead with no correctness benefit. If a future
+PR ever peels `_sync_mirrors` off onto a non-portfolio-sync code
+path (e.g. an ad-hoc reconciliation endpoint that is not serialised
+by `JobLock`), the author must add an advisory lock at that call
+site — this spec documents the assumption so that author knows what
+they're removing.
+
+#### 2.3.2 Per-mirror sync
+
 Per mirror:
 
-1. **Upsert `copy_traders`** by `parent_cid`. Track 2 columns are not
-   touched.
+1. **Upsert `copy_traders`** by `parent_cid`.
 2. **Upsert `copy_mirrors`** by `mirror_id`. All mirror-level columns
    including `raw_payload` are refreshed.
-3. **Replace nested positions for this mirror.** The sync is the sole
-   writer of `copy_mirror_positions`, so each sync is an authoritative
-   snapshot. Inside the transaction we:
+3. **Replace nested positions for this mirror.** Each sync is an
+   authoritative snapshot. Inside the transaction, for each mirror:
 
-   a. Upsert every position in the payload by `position_id` primary
-      key.
-   b. Evict positions that have closed since the last sync. When the
-      new payload has ≥1 position, this is `DELETE FROM
-      copy_mirror_positions WHERE mirror_id = %s AND position_id <>
-      ALL(%s::bigint[])` passing the new IDs as a single array
-      parameter (avoids SQL-injecting a variadic `NOT IN (...)` list
-      and sidesteps the empty-list parser error). When the new
-      payload has 0 positions (rare but valid — an empty mirror), the
-      same query with an empty array deletes everything for that
-      mirror, which is exactly what we want.
+   a. Upsert every position in the payload by `(mirror_id,
+      position_id)`.
+   b. Evict positions that have closed since the last sync:
+      `DELETE FROM copy_mirror_positions WHERE mirror_id = %s AND
+      position_id <> ALL(%s::bigint[])`, passing the new IDs as a
+      single array parameter (avoids SQL-injecting a variadic
+      `NOT IN (...)` list and sidesteps the empty-list parser
+      error).
 
-   This is a per-mirror full-replace, but implemented as upsert + evict
-   rather than delete-all + insert-all so that row locks are held for
-   the shortest possible time and an empty payload for a mirror does
-   not briefly zero the table.
+      Postgres evaluates `position_id <> ALL('{}')` as `TRUE` for
+      every row, so an empty array correctly deletes everything for
+      that mirror. We exploit this rather than guarding against it —
+      no special-case branch.
+
+   Implemented as upsert + evict rather than delete-all + insert-all
+   so that row locks are held for the shortest possible time and a
+   crashed sync mid-replace can never briefly zero the table.
+
+#### 2.3.3 Parser-failure safeguard
+
+The malformed-row skip pattern from §2.2 (log + continue) is unsafe
+when composed with the eviction step. If eToro returns 198 positions
+and a schema change makes the parser reject half of them, the sync
+would upsert the 99 good ones and evict the other 99 — silently
+destroying local rows for the affected positions.
+
+Guard: before `_sync_mirrors` commits the evict step for a given
+mirror, compare `len(parsed_positions)` against `len(raw_positions)`.
+If fewer than half the raw positions parsed successfully, and at
+least one raw position existed, raise `RuntimeError` with the mirror
+ID and the parse-success ratio. The whole transaction is rolled
+back. The operator sees a failed `daily_portfolio_sync` in
+`job_runs`, investigates the upstream schema change, and fixes the
+parser before the next fire. Better to page than to delete.
+
+Rejected alternatives:
+
+- "Just skip eviction when any position failed." Leaks stale rows
+  forever and the failure mode is invisible.
+- "Require 100% parse success." Too brittle — a single new-enum
+  value on one of 198 positions would block every mirror every sync.
+- "Fail only if zero positions parsed." The 99-out-of-198 case is
+  exactly the scenario we want to catch.
+
+The 50% threshold is arbitrary-but-defensible for v1. A future PR
+can tighten or make it configurable.
+
+#### 2.3.4 Empty-mirrors and partial-disappearance guards
 
 **Empty-mirrors guard.** Mirroring the existing positions guard at
 [portfolio_sync.py:245](app/services/portfolio_sync.py#L245): if
 `portfolio.mirrors` is empty but the local `copy_mirrors` table has
-rows, `_sync_mirrors` raises a `RuntimeError`. This preserves the
-"upstream looks broken — do not silently zero local state" invariant.
-Operator-driven un-copying is a manual operation in v1 (delete the row
-from `copy_mirrors`); graceful closure semantics are deferred to
-Track 2.
+rows, `_sync_mirrors` raises a `RuntimeError`. Upstream "looks
+broken" — do not silently zero local state. Operator-driven
+un-copying is a manual DB operation in v1.
+
+**Partial-disappearance guard.** Codex flagged that guarding only
+the fully-empty case leaves a hole: if one of two mirrors disappears
+from a non-empty payload, the local `copy_mirrors` row for the
+missing mirror remains forever and keeps inflating AUM.
+
+Track 1 response: after processing every mirror in the payload, if
+any local `copy_mirrors.mirror_id` is absent from
+`{m.mirror_id for m in portfolio.mirrors}`, raise `RuntimeError`
+naming the missing mirror_id(s). Same rationale as the empty-mirrors
+guard and as the existing positions "legitimate liquidation is
+per-position, not whole-portfolio" invariant — a mirror disappearing
+without the operator touching the DB is either a broker API
+regression or a genuine un-copy, and neither should silently change
+AUM math.
+
+Operator un-copy workflow (manual, v1): `DELETE FROM copy_mirrors
+WHERE mirror_id = ?;` before the next sync fires. Graceful closure
+semantics — `closed_at` column, "keep history but mark as closed",
+historical AUM reporting — are deferred to Track 2.
 
 Result type extension:
 
@@ -366,43 +509,132 @@ cash            = SUM(cash_ledger.amount)
 total_aum       = total_positions + cash
 ```
 
-We extend this with a third term:
+We extend this with a third term, `mirror_equity`, derived from the
+new tables.
+
+### 3.1 The identity the formula must preserve
+
+The earlier draft's formula had
+
+```text
+mirror_equity_bad = available + closed_pnl + SUM(sign * units * open_rate)
+```
+
+which is wrong on two counts that were verified against the real
+payload at
+`data/raw/etoro_broker/etoro_portfolio_20260411T053000Z.json`:
+
+1. **`closed_pnl` is double-counted.** eToro already reconciles the
+   closed P/L into `available + SUM(position.amount)`. Empirically,
+   on both demo mirrors:
+
+   ```text
+   mirror 15712187 (thomaspj):
+     available + SUM(amount)                       = 2800.33 + 17089.33 = 19889.66
+     initial + deposit − withdrawal + closed_pnl   = 20000 + 0 − 0 + (−110.34) = 19889.66
+
+   mirror 15714660 (triangulacapital):
+     available + SUM(amount)                       = 1724.11 + 17666.76 = 19390.87
+     initial + deposit − withdrawal + closed_pnl   = 17280 + 2251 − 0 + (−140.13) = 19390.87
+   ```
+
+   Adding `closed_pnl` explicitly on top of the cost-basis sum
+   over-counts it by `2 * closed_pnl`. Silent $110 drift on a single
+   mirror on day one.
+
+2. **`units * open_rate` is cross-currency nonsense for non-USD
+   instruments.** On mirror `15712187`, 74 of 198 positions are in
+   GBP / JPY / ILS / EUR. Empirically:
+
+   ```text
+   SUM(units * open_rate)                        = 313,171.88  # nonsense
+   SUM(units * open_rate * open_conversion_rate) =  17,089.32  # USD
+   SUM(amount)                                   =  17,089.33  # USD (rounding)
+   ```
+
+   Without `open_conversion_rate`, AUM is inflated by $296k on a
+   single mirror.
+
+### 3.2 The Track 1 formula
 
 ```text
 mirror_equity = SUM over copy_mirrors (
-    available_amount
-  + closed_positions_net_profit
+    m.available_amount
   + SUM over copy_mirror_positions in this mirror (
-        sign * units * COALESCE(latest_quote, open_rate)
+        cmp.amount
+      + sign(cmp) * cmp.units * (COALESCE(q.last, cmp.open_rate) − cmp.open_rate)
+                  * cmp.open_conversion_rate
     )
 )
-total_aum = total_positions + cash + mirror_equity
 ```
 
-where `sign = +1 if is_buy else -1`. This is the standard accounting
-identity for a broker sub-account: uninvested cash + live MV of open
-positions + realized P/L from closures.
+where `sign(cmp) = +1 if cmp.is_buy else -1`.
 
-The MTM-via-quote pattern matches the existing guard query at
-[execution_guard.py:255](app/services/execution_guard.py#L255): latest
-`quotes.last` for the instrument, falling back to the position's
-entry price when no quote is available (same conservatism we already
-apply to our own positions).
+Decomposed by term:
 
-The query is implemented as a single CTE / lateral join added to the
-guard's existing portfolio-read block. Sketch:
+- **`m.available_amount`** — uninvested USD cash held inside the
+  mirror sub-account. Directly reported by the payload.
+
+- **`cmp.amount`** — per-position cost basis in USD. When no
+  `quotes.last` exists, the MTM-delta term below evaluates to zero
+  and this is the only contribution — we fall back to cost basis,
+  matching the conservatism the guard already applies to eBull-owned
+  positions at [execution_guard.py:255](app/services/execution_guard.py#L255).
+  When summed across the mirror, `available + SUM(amount)` is
+  exactly the identity in §3.1 (initial + net-funded + closed P/L),
+  so `closed_positions_net_profit` is covered by this term and **is
+  not re-added**.
+
+- **`sign * units * (q.last − open_rate) * open_conversion_rate`**
+  — the MTM *delta* since entry. Zero when no quote is available
+  (fallback `q.last := open_rate`). When a quote exists, the delta
+  is converted to USD using the entry-time conversion rate. This is
+  an approximation (FX may have drifted since entry) but is
+  documented and testable; a proper current-FX MTM requires a
+  currency-aware `quotes` table, which is Track 2 scope. Sign
+  handles longs (positive delta → equity up) and shorts (positive
+  delta → equity down) correctly.
+
+### 3.3 Short-position handling
+
+Codex correctly observed that `-1 * units * price` (the draft's
+formula) is short *notional*, not short *equity*. The revised formula
+above does not compute notional at all — it computes the **delta from
+cost basis**, which is the right accounting quantity for a CFD or
+cash short:
+
+```text
+long  with delta +X → equity ↑ by X
+short with delta +X → equity ↓ by X   (handled by sign = -1)
+```
+
+And for leverage > 1, the cost-basis term (`cmp.amount`) is already
+what the trader committed (not the notional exposure) — exactly the
+quantity that should contribute to the AUM denominator.
+
+The demo payload contains only `isBuy = true`, `leverage = 1`
+positions, so the short and leverage paths are not exercised by the
+day-one fixtures. Track 2 adds a verification step against a real
+short-containing mirror once one is observed on the demo account.
+
+### 3.4 SQL sketch
+
+Implemented as a single CTE alongside the guard's existing
+portfolio-read block:
 
 ```sql
 WITH mirror_equity AS (
     SELECT COALESCE(SUM(
-        m.available_amount + m.closed_positions_net_profit + COALESCE(p.mv, 0)
+        m.available_amount + COALESCE(p.mv, 0)
     ), 0) AS total
     FROM copy_mirrors m
     LEFT JOIN LATERAL (
         SELECT SUM(
-            CASE WHEN cmp.is_buy THEN 1 ELSE -1 END
+              cmp.amount
+            + (CASE WHEN cmp.is_buy THEN 1 ELSE -1 END)
               * cmp.units
-              * COALESCE(q.last, cmp.open_rate)
+              * (COALESCE(q.last, cmp.open_rate) - cmp.open_rate)
+              * cmp.open_conversion_rate
         ) AS mv
         FROM copy_mirror_positions cmp
         LEFT JOIN LATERAL (
@@ -441,54 +673,106 @@ for us.
 
 ## 5. Short positions
 
-The demo-account raw dump
-(`data/raw/etoro_broker/etoro_portfolio_20260411T053000Z.json`) contains
-only `isBuy = true` nested positions. The AUM query in §3 treats a
-short (`is_buy = false`) as `-1 * units * price`, which is the standard
-short valuation. We stand by this math but have not yet tested it
-against a live short in a mirror. Track 2 includes a verification step
-against a short-containing mirror once one is observed.
+See §3.3 — short handling is now folded into the §3.2 formula via
+the `sign * (quote − open_rate)` delta term, which is the correct
+accounting quantity for a CFD/cash short. The demo-account raw dump
+contains only `isBuy = true, leverage = 1` rows, so the short path
+is covered by unit-test fixtures rather than live data. Track 2
+adds a live-mirror verification step once a short-containing mirror
+is observed on the demo account.
 
-## 6. Dashboard surface
+## 6. Where AUM is computed — all three call sites
 
-New REST endpoint, matching the shape of existing portfolio endpoints
-in `app/api/portfolio.py`:
+Codex correctly flagged that §3's query change does not, on its own,
+fix AUM everywhere the dashboard and review paths read it. There are
+**three** AUM call sites in the current codebase, and each needs an
+explicit update in this PR:
 
-```http
-GET /api/portfolio/copy-trading
+### 6.1 `app/services/execution_guard.py` (lines 245-289)
+
+Primary site — the execution guard denominator. Loads positions and
+cash, computes `total_aum`, then applies position-% and sector-% rules
+as ratios. Update: add the `mirror_equity` CTE from §3.4 and sum it
+into `total_aum`. Sector and per-position aggregates are NOT touched,
+which is what §4 is about.
+
+### 6.2 `app/api/portfolio.py` (`get_portfolio`, lines 111-175)
+
+`GET /api/portfolio` is the public read endpoint backing the
+dashboard top-line summary. It runs its own positions+cash queries
+and computes `total_aum = total_market + (cash_balance or 0.0)` at
+line 166. This is a separate code path — the query change in §3
+does not touch it.
+
+Update: after computing `total_market` and `cash_balance`, run the
+mirror-equity query from §3.4 and add the result to `total_aum`.
+The `PortfolioResponse` dataclass (lines 64-67) adds a new optional
+field `mirror_equity: float | None = None` so the frontend can
+display the breakdown (AUM = positions + cash + mirrors) rather
+than just a lump total. A null value means no mirrors are held.
+
+### 6.3 `app/services/portfolio.py` (`run_portfolio_review`, line 752-753)
+
+`run_portfolio_review` computes AUM in Python from its own
+`_load_positions` / `_load_cash` helpers:
+
+```python
+total_market_value = sum(p.market_value for p in positions.values())
+total_aum = total_market_value + (cash if cash_known else 0.0)
 ```
 
-Response: list of copy traders with mirror-level aggregates and a
-summary of nested positions. Detailed field list deferred to the
-implementation plan.
+then passes `total_aum` through to `_evaluate_add`, `_evaluate_buy`,
+and `_sector_pct` for recommendation gating. This is the periodic
+BUY/ADD/HOLD/EXIT pipeline, and it must see the same AUM the
+execution guard sees — otherwise recommendations could be made
+against a denominator that the guard will then reject against a
+different denominator.
 
-Existing `GET /api/portfolio` is updated so that the AUM total shown
-in the top-line summary includes `mirror_equity` (via the query
-change in §3).
+Update: add a new `_load_mirror_equity(conn) -> float` helper that
+runs the §3.4 query, and sum its result into `total_aum` at line
+753. Plumb `mirror_equity` through `PortfolioReviewResult` the same
+way `total_aum` is already plumbed, so the snapshot row in
+`portfolio_reviews` captures it (for audit).
 
-Frontend changes are out of scope for this spec's text but in scope
-for the PR. The implementation plan will sketch the component
-structure.
+### 6.4 New REST endpoint
+
+`GET /api/portfolio/copy-trading` — list of copy traders with
+mirror-level aggregates and a per-mirror summary of nested positions.
+Joins `copy_traders` × `copy_mirrors` × `copy_mirror_positions` and
+runs a per-mirror equity calculation for display. Detailed field
+list deferred to the implementation plan.
+
+### 6.5 Frontend
+
+Frontend changes are in scope for the PR: a copy-trading section on
+the portfolio dashboard that consumes `/api/portfolio/copy-trading`,
+and a top-line AUM breakdown showing positions + cash + mirror
+equity. Component structure deferred to the implementation plan —
+the spec fixes the data contract, the plan fixes the components.
 
 ## 7. Migration (022)
 
-Single migration, one transaction:
+Single migration, one transaction, following the
+[sql/021_positions_source.sql](sql/021_positions_source.sql) format:
 
 ```sql
 -- Migration 022: copy trading ingestion
 BEGIN;
 
-CREATE TABLE copy_traders (...);
-CREATE TABLE copy_mirrors (...);
-CREATE TABLE copy_mirror_positions (...);
+CREATE TABLE copy_traders (...);          -- §1.1
+CREATE TABLE copy_mirrors (...);          -- §1.2
+CREATE TABLE copy_mirror_positions (...); -- §1.3, composite PK (mirror_id, position_id)
 
-CREATE INDEX copy_traders_username_idx            ON copy_traders (parent_username);
-CREATE INDEX copy_mirrors_parent_cid_idx          ON copy_mirrors (parent_cid);
-CREATE INDEX copy_mirror_positions_mirror_id_idx      ON copy_mirror_positions (mirror_id);
-CREATE INDEX copy_mirror_positions_instrument_id_idx  ON copy_mirror_positions (instrument_id);
+CREATE INDEX copy_traders_username_idx               ON copy_traders (parent_username);
+CREATE INDEX copy_mirrors_parent_cid_idx             ON copy_mirrors (parent_cid);
+CREATE INDEX copy_mirror_positions_instrument_id_idx ON copy_mirror_positions (instrument_id);
 
 COMMIT;
 ```
+
+Note: there is no standalone `copy_mirror_positions_mirror_id_idx`
+because the composite primary key `(mirror_id, position_id)` already
+covers `WHERE mirror_id = ?` queries as a leftmost-prefix scan.
 
 No backfill is required — the tables start empty and fill up on the
 next portfolio sync. The existing `positions.source` CHECK constraint
@@ -501,11 +785,14 @@ because mirrors never become `positions` rows.
 
 - `_parse_mirror` / `_parse_mirror_position` against fixtures derived
   from the real `data/raw/etoro_broker/etoro_portfolio_*.json` payload
-  (trimmed to 2 mirrors × 3 nested positions each for readability)
+  (trimmed to 2 mirrors × 3 nested positions each for readability, at
+  least one non-USD position to exercise `openConversionRate`)
 - Malformed mirror → skipped with warning, other mirrors still parsed
 - Malformed nested position → skipped, sibling positions still parsed
 - Missing optional fields (stop loss, take profit) → `None` on the
   dataclass
+- Missing `openConversionRate` → defaults to `Decimal("1")` so legacy
+  USD-only fixtures keep working
 
 **Service-layer tests (real test DB, per
 `feedback_test_db_isolation` rule — `ebull_test`, never
@@ -521,20 +808,60 @@ because mirrors never become `positions` rows.
   updated, trader row untouched apart from `updated_at`
 - Parent username changed on second sync → `copy_traders.parent_username`
   updated
-- Empty `mirrors` array with local mirrors present → `RuntimeError`
-  raised, transaction can be rolled back by caller
+- **Empty `mirrors` array with local mirrors present** → `RuntimeError`
+  raised, caller can roll back
+- **Partial mirror disappearance** (two local mirrors, payload has
+  one) → `RuntimeError` raised naming the missing mirror_id, caller
+  can roll back
+- **Parser-failure safeguard** → payload with 10 raw positions, 8 of
+  which are malformed such that the parser skips them → `_sync_mirrors`
+  raises before eviction runs; existing rows survive the rollback
 
-**Guard AUM test:**
+**AUM identity tests (the core correctness test for §3):**
+
+Two small fixtures inserted directly into `copy_mirrors` and
+`copy_mirror_positions`:
+
+- **No-quote cost-basis fallback.** One mirror with
+  `available_amount = 2800.33`, two positions with
+  `amount = 50.00` and `amount = 17039.33`, no quotes → the §3.4
+  query returns `2800.33 + 50.00 + 17039.33 = 19889.66`. This is
+  the empirically-reconciled identity on mirror 15712187.
+- **MTM delta with FX.** One mirror, one long position with
+  `open_rate = 1207.4994`, `units = 6.28927`,
+  `open_conversion_rate = 0.01331`, `amount = 101.08`, and a quote
+  `quotes.last = 1400.0` → delta = `1 * 6.28927 * (1400.0 -
+  1207.4994) * 0.01331 ≈ 16.12`, so mirror equity ≈
+  `available + 101.08 + 16.12`. Asserts FX is applied to the delta.
+- **Short delta.** Same fixture with `is_buy = false` and
+  `quotes.last = 1000.0` (below entry) → delta = `-1 * 6.28927 *
+  (1000.0 - 1207.4994) * 0.01331 ≈ +17.37`, equity goes **up**
+  because a short is profitable when the price falls.
+
+**Guard AUM integration test:**
 
 - Existing guard test fixture + one mirror containing a single
-  nested position with known entry rate, no quote → AUM includes
-  `available_amount + closed_positions_net_profit + units * open_rate`
-- Same fixture + a quote in `quotes` → AUM uses `quotes.last` not
-  `open_rate`
+  USD position with `amount = 1000`, `open_rate = 10`, no quote →
+  `total_aum` increases by exactly `available_amount + 1000`
+- Same fixture + a quote higher than `open_rate` → AUM delta grows
+  by the MTM delta
 - Sector exposure check on an instrument that is held in a mirror but
-  not in `positions` → sector exposure is 0 (mirror is ignored for
-  concentration), AUM denominator is still increased (so the rule is
-  more permissive, not less)
+  not in `positions` → sector exposure numerator is 0 (mirror is
+  ignored for concentration), AUM denominator is still increased
+  (rule is more permissive, not less)
+
+**Three-call-site AUM consistency test:**
+
+A single DB fixture is observed through all three AUM paths in one
+test to prove they agree:
+
+1. Direct `execution_guard` call via `run_execution_guard`
+2. `GET /api/portfolio` via `TestClient`
+3. `run_portfolio_review`
+
+All three must report the same `total_aum`. This is the regression
+test for §6 — if a future PR updates one AUM path but not the
+others, this test fails.
 
 **Smoke gate:** `tests/smoke/test_app_boots.py` remains green (the
 FastAPI lifespan touches nothing new; migration 022 runs during
@@ -576,15 +903,60 @@ Track 2's job is to turn that surface into:
 5. Graceful mirror-closure semantics (`closed_at` column, disappear
    vs delete vs preserve-history policy).
 
-None of Track 2 requires a migration of the tables defined in this
-spec. The nullable Track 2 columns on `copy_traders` are a placeholder
-precisely so that no existing row in the table has to be rewritten
-when the discovery path lands.
+Track 2 will introduce its own schema migration(s) for trader
+history, daily-gain series, cohort signals, and whatever
+discovery-side tables it needs. The Track 1 schema
+(`copy_traders`, `copy_mirrors`, `copy_mirror_positions`) needs no
+*structural* changes to support Track 2 — existing rows are not
+rewritten — but it may grow columns or sibling tables. That's fine.
+Migrations are cheap; designing forward by guessing columns Track 2
+might need is not.
 
 ## 10. Open questions
 
-None at spec-draft time. The main decisions — three-table split,
+None at spec-revision time. The main decisions — three-table split,
 full granular position capture, `positions`/guard untouched, empty
-mirrors → raise, shorts as `-1 * units * price` — have all been made
-above. If spec review surfaces new questions they will be appended
-here before the writing-plans handoff.
+mirrors → raise, partial disappearance → raise, cost-basis AUM with
+optional MTM delta, FX via `openConversionRate` — have all been made
+above. If a second round of spec review surfaces new questions they
+will be appended here before the writing-plans handoff.
+
+## Appendix A. Revision log
+
+This spec went through a pre-implementation Codex review (see
+`.claude/codex-spec-review.log` in the branch history). Findings and
+resolutions:
+
+- **A. AUM formula double-counts `closed_pnl`.** §3 rewritten around
+  the `available + SUM(amount) + SUM(MTM delta)` identity, which is
+  exactly equal to the reconciled funded-capital quantity.
+- **B. `units * open_rate` is cross-currency nonsense.** New NOT NULL
+  `open_conversion_rate` column (§1.3), used in every AUM term (§3.4).
+- **C. Missing `deposit_summary` / `withdrawal_summary`.** Added as
+  first-class NOT NULL columns on `copy_mirrors` (§1.2).
+- **D. `instrument_id INTEGER` breaks repo convention.** Changed to
+  `BIGINT` (§1.3), matching `sql/001_init.sql`.
+- **E. `BrokerPortfolio.mirrors` claimed non-breaking but has no
+  default.** Field defaults to `()` (§2.1); both existing call sites
+  unchanged.
+- **F. `position_id` uniqueness across mirrors unproven.** Primary key
+  is now `(mirror_id, position_id)` composite (§1.3).
+- **G. `raw_payload` only on mirror row is brittle.** Added
+  `raw_payload JSONB NOT NULL` on `copy_mirror_positions` too (§1.3).
+- **H. Concurrent sync races not addressed.** Single-writer invariant
+  documented against `JobLock` + APScheduler (§2.3.1); no new lock
+  added.
+- **I. Parser-failure + eviction = silent data loss.** 50%-of-raw
+  parse-success threshold guard added (§2.3.3).
+- **J. Only `mirrors=[]` guarded; partial disappearance ignored.**
+  Partial-disappearance guard added (§2.3.4).
+- **K. Short handling as `-1 * units * price` wrong for CFDs.** §3.2
+  uses `sign * delta * ocr`, correct for longs, shorts, and
+  leverage-1; §3.3 explains.
+- **L. "via the query change in §3" false for dashboard & review.**
+  §6 split into three explicit AUM call sites with per-site updates.
+- **M. `copy_traders` Track 2 column stubs are YAGNI overreach.**
+  Stubs removed (§1.1); Track 2 will migrate its own columns/tables.
+- **N. `raw_payload` can't backfill Track 2 profile data.** Claim
+  removed (§1.2); `user-info/people/*` is now called out as the
+  source.

--- a/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
+++ b/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
@@ -1,0 +1,590 @@
+# Copy trading (mirrors) ingestion
+
+**Issue**: #183
+**Related**: Track 2 — social discovery as a research signal (GitHub issue to be opened after spec merge)
+**Date**: 2026-04-11
+**Status**: Draft for review
+
+## Problem
+
+The current eToro broker provider reads `clientPortfolio.positions` and
+discards `clientPortfolio.mirrors`. On the demo account this hides two
+copy portfolios worth roughly £29.3k — every AUM-denominated rule in the
+execution guard is therefore computed against an incomplete denominator,
+and the dashboard is silent about a five-figure slice of the operator's
+capital.
+
+The portfolio payload we already fetch on every sync contains the full
+state of those copy portfolios: mirror-level metadata (initial
+investment, available cash, realized P/L, stop loss, copy start date,
+the trader's CID and username) plus nested per-position rows with
+instrument, entry price, units, open timestamp, and stop/target levels.
+On one mirror alone the demo account carries 198 nested positions.
+First-class ingestion is a matter of stopping the discard, not adding
+new API calls.
+
+This ingestion has two further consequences we want to design for from
+day one:
+
+1. The execution guard must stay blind to mirrors for decision purposes
+   (we cannot close or resize them, so they must not constrain eBull's
+   own trades) but must see them for AUM sizing (the denominator in
+   every position and sector % rule).
+2. A separate workstream ("Track 2") will use eToro's `/user-info/people/*`
+   endpoints to research traders we don't yet copy, snapshot their live
+   portfolios over time, and derive accumulation signals for the ranking
+   engine. Track 2 is a new issue, not part of this PR, but the data
+   model laid down here should be directly extendable without migration
+   churn when Track 2 lands.
+
+## Scope
+
+**In scope (this spec / PR):**
+
+- New tables `copy_traders`, `copy_mirrors`, `copy_mirror_positions`
+- Broker provider parses `clientPortfolio.mirrors[]` into typed
+  dataclasses alongside the existing positions
+- Portfolio sync upserts the three tables from the same `/portfolio`
+  call it already makes
+- AUM computation (execution guard) adds mirror equity to the total_aum
+  denominator
+- Dashboard read endpoint + frontend surface for copy traders
+- Execution guard decision logic is unchanged — mirrors live in separate
+  tables and never appear in sector-exposure or position-size queries
+
+**Out of scope (deferred to Track 2):**
+
+- `/user-info/people/*` endpoint integration (profile, gain series,
+  trade info, live portfolio of arbitrary users, people/search)
+- Populating the Track-2-only columns on `copy_traders`
+  (`risk_score`, `gain_1y_pct`, `copiers_count`, `is_popular_investor`,
+  `weeks_since_registration`, `last_profile_refresh_at`)
+- Trader discovery and watchlist
+- Historical trader performance tracking
+- Signal derivation (accumulation / divestment by a trusted cohort)
+- Reconciliation on mirror disappearance (graceful closure semantics —
+  v1 treats an empty `mirrors[]` with local rows as an API failure and
+  raises, same as the existing positions guard)
+- Short positions on mirrors beyond the "negative MV" math sketched in
+  §5 — to be verified against live data in Track 2
+
+## 1. Data model
+
+Three new tables. `positions`, `cash_ledger`, and the existing
+`positions.source` column are untouched.
+
+### 1.1 `copy_traders`
+
+```sql
+CREATE TABLE copy_traders (
+    parent_cid BIGINT PRIMARY KEY,
+    parent_username TEXT NOT NULL,
+
+    -- Track 2 columns. Nullable, not populated by the Track 1 sync path.
+    -- A separate upsert path (added in the Track 2 PR) will write these
+    -- from /api/v1/user-info/people/{username}/tradeinfo.
+    risk_score INTEGER,
+    gain_1y_pct NUMERIC(10, 4),
+    copiers_count INTEGER,
+    is_popular_investor BOOLEAN,
+    weeks_since_registration INTEGER,
+    last_profile_refresh_at TIMESTAMPTZ,
+
+    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX copy_traders_username_idx ON copy_traders (parent_username);
+```
+
+Semantics: one row per eToro trader identity, keyed by `parentCID`.
+Track 1 populates only `parent_cid`, `parent_username`, `first_seen_at`,
+`updated_at`. The Track 2 profile columns are set aside now so the
+Track 2 PR can populate them without a schema migration.
+
+Upsert (Track 1): `ON CONFLICT (parent_cid) DO UPDATE SET
+parent_username = EXCLUDED.parent_username, updated_at = NOW()`. We
+honour the latest username eToro returns; Track 2's columns are NOT
+touched by this upsert path.
+
+### 1.2 `copy_mirrors`
+
+```sql
+CREATE TABLE copy_mirrors (
+    mirror_id BIGINT PRIMARY KEY,
+    parent_cid BIGINT NOT NULL REFERENCES copy_traders(parent_cid),
+
+    initial_investment          NUMERIC(20, 4) NOT NULL,
+    available_amount            NUMERIC(20, 4) NOT NULL,
+    closed_positions_net_profit NUMERIC(20, 4) NOT NULL,
+    stop_loss_percentage        NUMERIC(10, 4),
+    stop_loss_amount            NUMERIC(20, 4),
+    mirror_status_id            INTEGER,
+    mirror_calculation_type     INTEGER,
+    pending_for_closure         BOOLEAN NOT NULL DEFAULT FALSE,
+    started_copy_date           TIMESTAMPTZ NOT NULL,
+
+    raw_payload JSONB NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX copy_mirrors_parent_cid_idx ON copy_mirrors (parent_cid);
+```
+
+Semantics: one row per mirror (one per currently-copied trader).
+`parent_cid` is a FK to `copy_traders` so the trader identity is a
+stable spine regardless of whether the copy is active, paused, or
+restarted with a new `mirrorID`.
+
+`raw_payload` is the full mirror object from the broker as JSONB, for
+auditability and so Track 2 can backfill Track-2-only columns without
+re-fetching.
+
+We deliberately do **not** store a derived `mirror_equity` column.
+Snapshotted derived values on a live account are a trap — equity
+depends on current quotes for the nested positions, and storing a stale
+denominator leads to stale rule evaluation. Equity is computed on read
+(see §3).
+
+Upsert: `ON CONFLICT (mirror_id) DO UPDATE SET ... , updated_at = NOW()`.
+All mirror-level columns are refreshed from the latest payload.
+
+### 1.3 `copy_mirror_positions`
+
+```sql
+CREATE TABLE copy_mirror_positions (
+    position_id BIGINT PRIMARY KEY,
+    mirror_id   BIGINT NOT NULL REFERENCES copy_mirrors(mirror_id) ON DELETE CASCADE,
+
+    parent_position_id BIGINT NOT NULL,
+    instrument_id      INTEGER NOT NULL,
+
+    is_buy                    BOOLEAN NOT NULL,
+    units                     NUMERIC(20, 8) NOT NULL,
+    amount                    NUMERIC(20, 4) NOT NULL,
+    initial_amount_in_dollars NUMERIC(20, 4) NOT NULL,
+    open_rate                 NUMERIC(20, 6) NOT NULL,
+    open_date_time            TIMESTAMPTZ NOT NULL,
+    take_profit_rate          NUMERIC(20, 6),
+    stop_loss_rate            NUMERIC(20, 6),
+    total_fees                NUMERIC(20, 4) NOT NULL DEFAULT 0,
+    leverage                  INTEGER NOT NULL DEFAULT 1,
+
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX copy_mirror_positions_mirror_id_idx      ON copy_mirror_positions (mirror_id);
+CREATE INDEX copy_mirror_positions_instrument_id_idx  ON copy_mirror_positions (instrument_id);
+```
+
+Semantics: one row per nested position currently held inside a mirror.
+
+**No foreign key on `instrument_id`.** Copy traders trade a wider
+universe than our synced `instruments` table (copy portfolios commonly
+contain commodities, FX, crypto, and non-US equities we have not
+onboarded). Enforcing the FK would force us to either reject these rows
+or pre-sync the whole eToro universe. We accept unknown instrument IDs
+as opaque identifiers and LEFT OUTER JOIN against `instruments` in
+reads.
+
+**`ON DELETE CASCADE` from `copy_mirrors`.** Track 1 never deletes
+`copy_mirrors` rows on sync (see §2.3), so this is defence-in-depth —
+if a future PR introduces mirror deletion we do not want orphaned
+nested position rows.
+
+## 2. Sync flow changes
+
+### 2.1 Broker provider interface (`app/providers/broker.py`)
+
+Two new frozen dataclasses and one non-breaking extension to
+`BrokerPortfolio`:
+
+```python
+@dataclass(frozen=True)
+class BrokerMirrorPosition:
+    position_id: int
+    parent_position_id: int
+    instrument_id: int
+    is_buy: bool
+    units: Decimal
+    amount: Decimal
+    initial_amount_in_dollars: Decimal
+    open_rate: Decimal
+    open_date_time: datetime
+    take_profit_rate: Decimal | None
+    stop_loss_rate: Decimal | None
+    total_fees: Decimal
+    leverage: int
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BrokerMirror:
+    mirror_id: int
+    parent_cid: int
+    parent_username: str
+    initial_investment: Decimal
+    available_amount: Decimal
+    closed_positions_net_profit: Decimal
+    stop_loss_percentage: Decimal | None
+    stop_loss_amount: Decimal | None
+    mirror_status_id: int | None
+    mirror_calculation_type: int | None
+    pending_for_closure: bool
+    started_copy_date: datetime
+    positions: Sequence[BrokerMirrorPosition]
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BrokerPortfolio:
+    positions: Sequence[BrokerPosition]
+    available_cash: Decimal
+    mirrors: Sequence[BrokerMirror]          # NEW
+    raw_payload: dict[str, Any]
+```
+
+Adding a field to the existing `BrokerPortfolio` is non-breaking:
+`positions` and `available_cash` continue to work, callers that do not
+care about mirrors simply ignore the new attribute. The alternative —
+an additional method `get_mirrors()` on the interface — was rejected
+because mirrors arrive in the same payload as positions and splitting
+them would double the HTTP call count per sync.
+
+### 2.2 `etoro_broker.get_portfolio` (`app/providers/implementations/etoro_broker.py`)
+
+The existing `portfolio = raw.get("clientPortfolio") or {}` block is
+extended with a second parse pass over `portfolio.get("mirrors") or []`.
+
+Parsing follows the existing malformed-row handling pattern at the
+positions loop (line 427-428):
+
+```python
+for m in raw_mirrors:
+    if not isinstance(m, dict):
+        continue
+    try:
+        mirrors.append(_parse_mirror(m))
+    except (KeyError, ValueError, TypeError) as exc:
+        logger.warning("Skipping malformed mirror object: %s", exc)
+        continue
+```
+
+`_parse_mirror` is a new pure normaliser function alongside
+`_normalise_open_order_response` (line 519) — no I/O, no DB access, no
+dependence on instance state. It validates required fields
+(`mirrorID`, `parentCID`, `parentUsername`, `initialInvestment`,
+`availableAmount`, `closedPositionsNetProfit`, `startedCopyDate`),
+parses optional fields with defaults, and recursively normalises the
+nested `positions[]` into `BrokerMirrorPosition` instances via a second
+normaliser `_parse_mirror_position`.
+
+Malformed nested positions inside a mirror are skipped, not failed —
+the mirror as a whole is still ingested. A mirror with zero valid
+nested positions is ingested with `positions=[]` (still useful for AUM
+via `available_amount + closed_positions_net_profit`).
+
+### 2.3 `portfolio_sync` (`app/services/portfolio_sync.py`)
+
+A new top-level function `_sync_mirrors(conn, mirrors, now)` is called
+from `sync_portfolio` after the existing position and cash
+reconciliation. It runs inside the same transaction.
+
+```python
+def _sync_mirrors(
+    conn: psycopg.Connection[Any],
+    mirrors: Sequence[BrokerMirror],
+    now: datetime,
+) -> tuple[int, int]:
+    """Returns (mirrors_upserted, mirror_positions_upserted)."""
+```
+
+Per mirror:
+
+1. **Upsert `copy_traders`** by `parent_cid`. Track 2 columns are not
+   touched.
+2. **Upsert `copy_mirrors`** by `mirror_id`. All mirror-level columns
+   including `raw_payload` are refreshed.
+3. **Replace nested positions for this mirror.** The sync is the sole
+   writer of `copy_mirror_positions`, so each sync is an authoritative
+   snapshot. Inside the transaction we:
+
+   a. Upsert every position in the payload by `position_id` primary
+      key.
+   b. Evict positions that have closed since the last sync. When the
+      new payload has ≥1 position, this is `DELETE FROM
+      copy_mirror_positions WHERE mirror_id = %s AND position_id <>
+      ALL(%s::bigint[])` passing the new IDs as a single array
+      parameter (avoids SQL-injecting a variadic `NOT IN (...)` list
+      and sidesteps the empty-list parser error). When the new
+      payload has 0 positions (rare but valid — an empty mirror), the
+      same query with an empty array deletes everything for that
+      mirror, which is exactly what we want.
+
+   This is a per-mirror full-replace, but implemented as upsert + evict
+   rather than delete-all + insert-all so that row locks are held for
+   the shortest possible time and an empty payload for a mirror does
+   not briefly zero the table.
+
+**Empty-mirrors guard.** Mirroring the existing positions guard at
+[portfolio_sync.py:245](app/services/portfolio_sync.py#L245): if
+`portfolio.mirrors` is empty but the local `copy_mirrors` table has
+rows, `_sync_mirrors` raises a `RuntimeError`. This preserves the
+"upstream looks broken — do not silently zero local state" invariant.
+Operator-driven un-copying is a manual operation in v1 (delete the row
+from `copy_mirrors`); graceful closure semantics are deferred to
+Track 2.
+
+Result type extension:
+
+```python
+@dataclass
+class PortfolioSyncResult:
+    positions_updated: int
+    positions_opened_externally: int
+    positions_closed_externally: int
+    cash_delta: Decimal
+    broker_cash: Decimal
+    local_cash: Decimal
+    mirrors_upserted: int          # NEW
+    mirror_positions_upserted: int # NEW
+```
+
+`sync_portfolio` calls `_sync_mirrors(conn, portfolio.mirrors, now)`
+after cash reconciliation and before returning. Caller still owns the
+commit.
+
+## 3. AUM computation
+
+The execution guard at
+[execution_guard.py:249-287](app/services/execution_guard.py#L249-L287)
+currently computes:
+
+```text
+total_positions = SUM( MTM over positions table, sector-grouped )
+cash            = SUM(cash_ledger.amount)
+total_aum       = total_positions + cash
+```
+
+We extend this with a third term:
+
+```text
+mirror_equity = SUM over copy_mirrors (
+    available_amount
+  + closed_positions_net_profit
+  + SUM over copy_mirror_positions in this mirror (
+        sign * units * COALESCE(latest_quote, open_rate)
+    )
+)
+total_aum = total_positions + cash + mirror_equity
+```
+
+where `sign = +1 if is_buy else -1`. This is the standard accounting
+identity for a broker sub-account: uninvested cash + live MV of open
+positions + realized P/L from closures.
+
+The MTM-via-quote pattern matches the existing guard query at
+[execution_guard.py:255](app/services/execution_guard.py#L255): latest
+`quotes.last` for the instrument, falling back to the position's
+entry price when no quote is available (same conservatism we already
+apply to our own positions).
+
+The query is implemented as a single CTE / lateral join added to the
+guard's existing portfolio-read block. Sketch:
+
+```sql
+WITH mirror_equity AS (
+    SELECT COALESCE(SUM(
+        m.available_amount + m.closed_positions_net_profit + COALESCE(p.mv, 0)
+    ), 0) AS total
+    FROM copy_mirrors m
+    LEFT JOIN LATERAL (
+        SELECT SUM(
+            CASE WHEN cmp.is_buy THEN 1 ELSE -1 END
+              * cmp.units
+              * COALESCE(q.last, cmp.open_rate)
+        ) AS mv
+        FROM copy_mirror_positions cmp
+        LEFT JOIN LATERAL (
+            SELECT last
+            FROM quotes
+            WHERE instrument_id = cmp.instrument_id
+            ORDER BY quoted_at DESC
+            LIMIT 1
+        ) q ON TRUE
+        WHERE cmp.mirror_id = m.mirror_id
+    ) p ON TRUE
+)
+SELECT total FROM mirror_equity;
+```
+
+**Critical: this query feeds the denominator only.** It does not
+contribute to `sector_values` or any per-sector aggregation. Mirrors
+can never push us past a sector concentration limit — they only make
+the per-rule percentage denominator larger (more permissive), which is
+the correct behaviour because the operator has already committed this
+capital to the mirrors and cannot unwind it through the execution
+guard.
+
+## 4. Execution guard isolation — what does NOT change
+
+The execution guard's rule queries (sector exposure, per-position %,
+initial-position %) read `FROM positions` only. Mirrors live in
+separate tables. No existing query is edited to filter out mirrors
+because there is nothing to filter out.
+
+This is the specific property that Option C (three-table split)
+secures: a PR that touches copy-trading ingestion does not need to
+audit every query in `app/services/execution_guard.py` to add a
+`WHERE source != 'copy_trading'` clause. The type system does the work
+for us.
+
+## 5. Short positions
+
+The demo-account raw dump
+(`data/raw/etoro_broker/etoro_portfolio_20260411T053000Z.json`) contains
+only `isBuy = true` nested positions. The AUM query in §3 treats a
+short (`is_buy = false`) as `-1 * units * price`, which is the standard
+short valuation. We stand by this math but have not yet tested it
+against a live short in a mirror. Track 2 includes a verification step
+against a short-containing mirror once one is observed.
+
+## 6. Dashboard surface
+
+New REST endpoint, matching the shape of existing portfolio endpoints
+in `app/api/portfolio.py`:
+
+```http
+GET /api/portfolio/copy-trading
+```
+
+Response: list of copy traders with mirror-level aggregates and a
+summary of nested positions. Detailed field list deferred to the
+implementation plan.
+
+Existing `GET /api/portfolio` is updated so that the AUM total shown
+in the top-line summary includes `mirror_equity` (via the query
+change in §3).
+
+Frontend changes are out of scope for this spec's text but in scope
+for the PR. The implementation plan will sketch the component
+structure.
+
+## 7. Migration (022)
+
+Single migration, one transaction:
+
+```sql
+-- Migration 022: copy trading ingestion
+BEGIN;
+
+CREATE TABLE copy_traders (...);
+CREATE TABLE copy_mirrors (...);
+CREATE TABLE copy_mirror_positions (...);
+
+CREATE INDEX copy_traders_username_idx            ON copy_traders (parent_username);
+CREATE INDEX copy_mirrors_parent_cid_idx          ON copy_mirrors (parent_cid);
+CREATE INDEX copy_mirror_positions_mirror_id_idx      ON copy_mirror_positions (mirror_id);
+CREATE INDEX copy_mirror_positions_instrument_id_idx  ON copy_mirror_positions (instrument_id);
+
+COMMIT;
+```
+
+No backfill is required — the tables start empty and fill up on the
+next portfolio sync. The existing `positions.source` CHECK constraint
+remains `('ebull', 'broker_sync')` — we do NOT add a third value,
+because mirrors never become `positions` rows.
+
+## 8. Testing strategy
+
+**Unit tests (pure, no DB):**
+
+- `_parse_mirror` / `_parse_mirror_position` against fixtures derived
+  from the real `data/raw/etoro_broker/etoro_portfolio_*.json` payload
+  (trimmed to 2 mirrors × 3 nested positions each for readability)
+- Malformed mirror → skipped with warning, other mirrors still parsed
+- Malformed nested position → skipped, sibling positions still parsed
+- Missing optional fields (stop loss, take profit) → `None` on the
+  dataclass
+
+**Service-layer tests (real test DB, per
+`feedback_test_db_isolation` rule — `ebull_test`, never
+`settings.database_url`):**
+
+- First `sync_portfolio` call with 2 mirrors × 3 positions → rows in
+  `copy_traders`, `copy_mirrors`, `copy_mirror_positions`
+- Second `sync_portfolio` with one nested position removed → that row
+  is DELETEd, siblings untouched
+- Re-running the same payload is idempotent (row counts unchanged,
+  `updated_at` refreshed)
+- Mirror-level metadata changed on second sync → `copy_mirrors` row
+  updated, trader row untouched apart from `updated_at`
+- Parent username changed on second sync → `copy_traders.parent_username`
+  updated
+- Empty `mirrors` array with local mirrors present → `RuntimeError`
+  raised, transaction can be rolled back by caller
+
+**Guard AUM test:**
+
+- Existing guard test fixture + one mirror containing a single
+  nested position with known entry rate, no quote → AUM includes
+  `available_amount + closed_positions_net_profit + units * open_rate`
+- Same fixture + a quote in `quotes` → AUM uses `quotes.last` not
+  `open_rate`
+- Sector exposure check on an instrument that is held in a mirror but
+  not in `positions` → sector exposure is 0 (mirror is ignored for
+  concentration), AUM denominator is still increased (so the rule is
+  more permissive, not less)
+
+**Smoke gate:** `tests/smoke/test_app_boots.py` remains green (the
+FastAPI lifespan touches nothing new; migration 022 runs during
+dev-DB bootstrap).
+
+## 9. Track 2 preview (not implemented in this PR)
+
+A new GitHub issue will be opened after this spec merges, covering
+the `user-info/people/*` surface we now know exists:
+
+- `GET /api/v1/user-info/people/search` — discovery with filters for
+  `popularInvestor`, `period`, `gainMax`,
+  `maxDailyRiskScoreMin/Max`, `maxMonthlyRiskScoreMin/Max`,
+  `weeksSinceRegistrationMin`, `countryId`, `instrumentId`,
+  `instrumentPctMin/Max`
+- `GET /api/v1/user-info/people/{username}/portfolio/live` — live
+  portfolio of any trader by username, including positions +
+  socialTrades
+- `GET /api/v1/user-info/people/{username}/tradeinfo` — per-period
+  stats: `gain`, `dailyGain`, `riskScore`, `copiers`, `copiersGain`
+- `GET /api/v1/user-info/people/{username}/gain` — monthly + yearly
+  historical gain series
+- `GET /api/v1/user-info/people/{username}/daily-gain` — daily gain
+  series over a date range
+- `GET /api/v1/user-info/people` — batch profile lookup by usernames
+  or CID list
+
+Track 2's job is to turn that surface into:
+
+1. A periodic discovery sweep that populates `copy_traders` rows for
+   traders we are **not** currently copying (today they are only
+   created when we see a mirror for them).
+2. Historical performance snapshots we can join against `copy_traders`
+   for confidence scoring.
+3. Signal derivation — if a cohort of high-quality traders is
+   accumulating instrument X over a window, tilt the ranking engine in
+   favour of X.
+4. Verification of the short-position AUM math on live mirrors.
+5. Graceful mirror-closure semantics (`closed_at` column, disappear
+   vs delete vs preserve-history policy).
+
+None of Track 2 requires a migration of the tables defined in this
+spec. The nullable Track 2 columns on `copy_traders` are a placeholder
+precisely so that no existing row in the table has to be rewritten
+when the discovery path lands.
+
+## 10. Open questions
+
+None at spec-draft time. The main decisions — three-table split,
+full granular position capture, `positions`/guard untouched, empty
+mirrors → raise, shorts as `-1 * units * price` — have all been made
+above. If spec review surfaces new questions they will be appended
+here before the writing-plans handoff.

--- a/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
+++ b/docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md
@@ -1267,22 +1267,46 @@ imported by every test that needs them via
      position (quote present) and at least one position is
      tested with no quote (quote absent → falls back to
      cost basis).
-  4. **An `instruments` row for at least one of the mirror
-     instrument IDs** — §8.5's `_load_sector_exposure` call
-     needs a matching instrument in `instruments` to resolve a
-     sector. The fixture picks one mirror-held instrument as
-     the "guard test instrument" and sets its sector to an
-     explicit value so the sector-numerator assertion in §8.5
-     is deterministic.
-  5. **A single `latest_scores` row** for any instrument (does
-     NOT need to be one of the mirror-held IDs) keyed on
-     `model_version = "v1-balanced"` — this is the §8.6 Test 2
-     precondition that prevents `run_portfolio_review` from
-     early-returning at
+  4. **An `instruments` row for the deterministic "guard test
+     instrument"** — §8.5's `_load_sector_exposure` call needs
+     a matching instrument in `instruments` to resolve a sector.
+     The fixture pins the guard test instrument to a single
+     constant `_GUARD_INSTRUMENT_ID: int = 990001` (chosen to
+     be well above any seed data in `sql/001_init.sql` and
+     reused everywhere the fixture is imported) and also pins
+     its sector to `_GUARD_INSTRUMENT_SECTOR: str = 'technology'`.
+     The active mirror's `copy_mirror_positions` from component 2
+     includes `_GUARD_INSTRUMENT_ID` as one of its instrument
+     IDs so §8.5's sector-numerator assertion has a concrete
+     mirror-side denominator contribution. §8.5 adds its own
+     eBull `positions` row and `cash_ledger` row **on top of**
+     `mirror_aum_fixture` inside the individual test (the same
+     additive pattern §8.4's identity tests use — see component
+     6) so component 6's "empty by default" invariant is not
+     violated for §8.6's delta tests.
+  5. **A single `scores` row** with the exact contract
+     `run_portfolio_review._load_ranked_scores` requires at
+     [portfolio.py:181-209](app/services/portfolio.py#L181-L209):
+     - `instrument_id` MUST reference an `instruments` row that
+       exists in this fixture (reuse the "guard test instrument"
+       from component 4 so only one `instruments` row is needed)
+     - `model_version = 'v1-balanced'` (the default the review
+       path loads under — string-exact match to
+       [portfolio.py:722](app/services/portfolio.py#L722))
+     - `rank` IS NOT NULL (any integer; `rank = 1` is fine) —
+       the `WHERE rank IS NOT NULL` clause at
+       [portfolio.py:203](app/services/portfolio.py#L203)
+       otherwise filters the row out
+     - `total_score` any non-null numeric (e.g. `0.5`) so the
+       row sorts deterministically; `scored_at` can take the
+       `DEFAULT NOW()` from `sql/001_init.sql:111`
+     This is the §8.6 Test 2 precondition that prevents
+     `run_portfolio_review` from early-returning at
      [portfolio.py:733](app/services/portfolio.py#L733) before
      it reaches the AUM block. Without this row the review
      path never exercises `_load_mirror_equity`, so the test
-     is silently a no-op.
+     is silently a no-op. (The `scores` table is the real
+     table; there is no `latest_scores` table in this repo.)
   6. **Empty `positions` and `cash_ledger`** — the fixture
      intentionally carries no eBull-owned positions or cash so
      the expected `total_aum` in the delta tests is exactly
@@ -1484,33 +1508,49 @@ the private helper that returns `total_aum` and is the exact
 function §6.1 modifies to add `_load_mirror_equity(conn)` to the
 existing `total_positions + cash` sum.
 
-Fixture: `mirror_aum_fixture` (§8.0) seeded into `ebull_test`,
-plus an `instruments` row for the instrument passed to
-`_load_sector_exposure` (any instrument_id present in the mirror
-positions will do). No `evaluate_recommendation`,
-`trade_recommendations`, `kill_switch`, or `runtime_config` setup
-needed — `_load_sector_exposure` does not touch those tables.
+Fixture: `mirror_aum_fixture` (§8.0) seeded into `ebull_test`.
+The fixture's component 4 already seeds an `instruments` row for
+`_GUARD_INSTRUMENT_ID = 990001` and includes that id as one of the
+active mirror's `copy_mirror_positions`, so
+`_load_sector_exposure(conn, _GUARD_INSTRUMENT_ID)` resolves the
+sector via the existing instrument lookup. Each scenario below
+adds its own eBull `positions` and `cash_ledger` rows on top of
+the base fixture (the same additive pattern §8.4's identity
+tests use) — this keeps `mirror_aum_fixture`'s component 6
+"empty by default" invariant intact for §8.6's delta tests. No
+`evaluate_recommendation`, `trade_recommendations`, `kill_switch`,
+or `runtime_config` setup needed — `_load_sector_exposure` does
+not touch those tables.
 
 Scenarios:
 
-- **Empty baseline (no mirrors at all).** `_load_sector_exposure`
-  returns `total_aum == positions_mv + cash`, the pre-PR contract.
-- **Active mirror adds to denominator.** Seed
-  `mirror_aum_fixture`'s active mirror (with positions + available
-  cash + matching quotes). `_load_sector_exposure` now returns
-  `total_aum == positions_mv + cash + _load_mirror_equity(conn)`
-  where `_load_mirror_equity(conn)` is computed once from the
-  same connection as the expected additive contribution.
+- **Empty baseline (no mirrors at all).** Start from a DB that
+  has only the `instruments` row and one eBull `positions` +
+  `cash_ledger` row (i.e. delete the `copy_mirrors` rows the
+  base fixture seeded). `_load_sector_exposure(conn,
+  _GUARD_INSTRUMENT_ID)` returns
+  `total_aum == positions_mv + cash`, the pre-PR contract.
+- **Active mirror adds to denominator.** With the base fixture's
+  active mirror present and one eBull `positions` +
+  `cash_ledger` row layered on top, `_load_sector_exposure`
+  returns `total_aum == positions_mv + cash +
+  _load_mirror_equity(conn)` where `_load_mirror_equity(conn)`
+  is computed once from the same connection as the expected
+  additive contribution.
 - **Closed mirror contributes nothing.** Flip `mirror_aum_fixture`'s
   active mirror to `active = FALSE` via an `UPDATE` at test
   setup. `_load_sector_exposure` returns the baseline again —
   soft-closed mirrors do not inflate the denominator.
-- **Sector numerator unchanged.** With an active mirror holding an
-  instrument NOT in `positions`, `_load_sector_exposure`'s
-  `current_sector_pct` numerator is unaffected. The mirror only
-  expands the denominator; the rule stays more permissive, not
-  less. This is the regression test for §4 "execution guard
-  isolation".
+- **Sector numerator unchanged.** Query under a second
+  `instrument_id` that belongs to a *different* sector than
+  `_GUARD_INSTRUMENT_SECTOR` (seeded via an extra `instruments`
+  row in this scenario only). The mirror's
+  `_GUARD_INSTRUMENT_ID` position therefore contributes to the
+  denominator but NOT the numerator, so
+  `current_sector_pct` is unaffected by the mirror's presence.
+  The mirror only expands the denominator; the rule stays more
+  permissive, not less. This is the regression test for §4
+  "execution guard isolation".
 
 ### 8.6 AUM delta tests per call site
 
@@ -1545,12 +1585,18 @@ FALSE`) → `mirror_equity == 0.0` and `total_aum` returns to
 `positions + cash`.
 
 **Test 2 — `run_portfolio_review` path.** Calls
-`run_portfolio_review(conn)` with the `mirror_aum_fixture`
-**plus at least one `latest_scores` row** (any instrument,
-matching `model_version`) so the early-return at
+`run_portfolio_review(conn)` with the `mirror_aum_fixture`,
+which already seeds the single `scores` row required by
+`_load_ranked_scores` at
+[portfolio.py:181-209](app/services/portfolio.py#L181-L209)
+(`model_version = 'v1-balanced'`, `rank IS NOT NULL`,
+`instrument_id` referencing the fixture's guard test
+instrument). This ensures the early-return at
 [portfolio.py:733](app/services/portfolio.py#L733) is not hit
-and the AUM block actually runs. `latest_scores` setup is part
-of `mirror_aum_fixture` (see §8.0). Assertion:
+and the AUM block at
+[portfolio.py:751-753](app/services/portfolio.py#L751-L753)
+actually runs. The `scores` row setup is part of
+`mirror_aum_fixture` (see §8.0 component 5). Assertion:
 
 - `result.total_aum == (positions_market_value + (cash or 0.0) + expected_mirror_contribution)`
 
@@ -1679,9 +1725,14 @@ locked:
   module instead of declaring it locally. (§8.0, locked round 5.)
 - `mirror_aum_fixture` seeds two mirrors (one active, one
   closed) with positions/quotes, **plus** one `instruments` row
-  for the guard sector-exposure assertion, **plus** one
-  `latest_scores` row so `run_portfolio_review` does not early-
-  return before reaching the AUM block. (§8.0, locked round 5.)
+  for the guard sector-exposure assertion, **plus** one `scores`
+  row (`model_version = 'v1-balanced'`, `rank IS NOT NULL`,
+  `instrument_id` = the guard test instrument) so
+  `run_portfolio_review` does not early-return at
+  [portfolio.py:733](app/services/portfolio.py#L733) before
+  reaching the AUM block. (§8.0, locked round 5; `scores`
+  table name corrected from the round-5 mis-named
+  `latest_scores` in round 6.)
 - AUM correction at all three call sites tested via
   `_load_mirror_equity(conn)` as the expected additive
   contribution — no cross-path `mirror_equity` field equality
@@ -1962,13 +2013,14 @@ Findings and resolutions:
   before the AUM block ever runs; and that `mirror_aum_
   fixture` as defined in round 4 did not seed an
   `instruments` row for the guard path's sector lookup,
-  nor a `latest_scores` row to bypass the review early-
+  nor a ranked `scores` row to bypass the review early-
   return. This meant §8.6 Test 2 (review path) would
   silently be a no-op. Fix: `mirror_aum_fixture`'s §8.0
   entry now explicitly enumerates six components: two
   mirrors, their positions, matching quotes, an
-  `instruments` row for the guard path, a `latest_scores`
-  row for the review path, and empty
+  `instruments` row for the guard path, a `scores` row
+  for the review path (see round 6 / AJ below for the
+  table-name correction), and empty
   `positions`/`cash_ledger` so the expected `total_aum`
   collapses to `_load_mirror_equity(conn)` plus `(0 + 0)`
   in the delta tests.
@@ -1984,6 +2036,42 @@ Findings and resolutions:
   bit-identical, so behaviour is preserved; the coupling
   direction (tests depend on fixtures, not the reverse)
   is now correct. §10 reflects this as a locked decision.
+
+### Round 6 — Codex regression check of the Round 5 revision
+
+See `.claude/codex-spec-review-v6.log` in the branch history.
+Rounds 1-5's AA-AI findings were verified as addressed; one
+new concrete blocker was raised:
+
+- **AJ. `latest_scores` is not a real table.** Codex v6
+  observed that §8.0 component 5, §8.6 Test 2, §10, and
+  Appendix A Round 5 (AH) all referenced seeding a
+  `latest_scores` row to bypass the
+  [portfolio.py:733](app/services/portfolio.py#L733)
+  early-return, but the actual table read by
+  `run_portfolio_review` via
+  [`_load_ranked_scores`](app/services/portfolio.py#L181-L209)
+  is `scores`, with the additional constraints
+  `model_version = 'v1-balanced'` and `rank IS NOT NULL`.
+  If writing-plans implemented the spec literally it would
+  seed a non-existent table and the review-path test would
+  fail at insert time. Fix: every `latest_scores` reference
+  in §8.0 (component 5), §8.6 (Test 2), §10 (locked
+  decisions), and Appendix A Round 5 (AH) was replaced
+  with `scores`, with explicit inline column-contract
+  enumeration and file:line citations for the `WHERE`
+  clauses the seeded row must satisfy. The fixture's
+  single `scores` row also pins `instrument_id` to the
+  same "guard test instrument" used in component 4, so
+  only one `instruments` row is needed for the whole
+  review + guard test setup.
+
+All five residual `latest_scores` occurrences replaced;
+`grep latest_scores` on the spec now returns only two
+negating references (§8.0 component 5's trailing
+"there is no `latest_scores` table in this repo" clarifier
+and §10's "corrected from the round-5 mis-named
+`latest_scores`" provenance note).
 
 ## Appendix B. Track 1.5 — REST endpoint and frontend panel
 

--- a/sql/022_copy_trading_tables.sql
+++ b/sql/022_copy_trading_tables.sql
@@ -18,6 +18,12 @@
 -- for audit. See spec §1 and §2.3.4.
 --
 -- Issue: #183
+--
+-- Note on updated_at: Postgres DEFAULT NOW() only applies on INSERT.
+-- UPDATE paths (the ON CONFLICT DO UPDATE clauses in the Python
+-- _sync_mirrors helper in app/services/portfolio_sync.py) are
+-- responsible for refreshing updated_at explicitly. All three tables
+-- in this migration follow that contract. See spec §2.3.
 
 BEGIN;
 

--- a/sql/022_copy_trading_tables.sql
+++ b/sql/022_copy_trading_tables.sql
@@ -1,0 +1,87 @@
+-- Migration 022: copy trading ingestion (Track 1a)
+--
+-- Adds three sibling tables so the eToro /portfolio payload's
+-- clientPortfolio.mirrors[] data can be ingested first-class:
+--
+--   copy_traders          — one row per eToro trader identity
+--   copy_mirrors          — one row per copy relationship (mirror_id)
+--   copy_mirror_positions — one row per nested position inside a mirror
+--
+-- Existing tables (positions, cash_ledger, positions.source) are
+-- untouched. The execution guard's rule queries continue to read
+-- FROM positions only; mirrors inflate AUM via a separate query in
+-- Track 1b (#187) — this migration is the schema prerequisite.
+--
+-- Soft-close semantics: copy_mirrors.active / closed_at columns let
+-- a mirror that disappears from the payload be marked closed rather
+-- than deleted. Nested positions are retained on soft-closed mirrors
+-- for audit. See spec §1 and §2.3.4.
+--
+-- Issue: #183
+
+BEGIN;
+
+CREATE TABLE copy_traders (
+    parent_cid      BIGINT PRIMARY KEY,
+    parent_username TEXT   NOT NULL,
+
+    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX copy_traders_username_idx ON copy_traders (parent_username);
+
+CREATE TABLE copy_mirrors (
+    mirror_id  BIGINT PRIMARY KEY,
+    parent_cid BIGINT NOT NULL REFERENCES copy_traders(parent_cid),
+
+    initial_investment          NUMERIC(20, 4) NOT NULL,
+    deposit_summary             NUMERIC(20, 4) NOT NULL,
+    withdrawal_summary          NUMERIC(20, 4) NOT NULL,
+    available_amount            NUMERIC(20, 4) NOT NULL,
+    closed_positions_net_profit NUMERIC(20, 4) NOT NULL,
+    stop_loss_percentage        NUMERIC(10, 4),
+    stop_loss_amount            NUMERIC(20, 4),
+    mirror_status_id            INTEGER,
+    mirror_calculation_type     INTEGER,
+    pending_for_closure         BOOLEAN NOT NULL DEFAULT FALSE,
+    started_copy_date           TIMESTAMPTZ NOT NULL,
+
+    active      BOOLEAN     NOT NULL DEFAULT TRUE,
+    closed_at   TIMESTAMPTZ NULL,
+
+    raw_payload JSONB NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX copy_mirrors_parent_cid_idx ON copy_mirrors (parent_cid);
+CREATE INDEX copy_mirrors_active_idx     ON copy_mirrors (active) WHERE active;
+
+CREATE TABLE copy_mirror_positions (
+    mirror_id   BIGINT NOT NULL REFERENCES copy_mirrors(mirror_id) ON DELETE CASCADE,
+    position_id BIGINT NOT NULL,
+    PRIMARY KEY (mirror_id, position_id),
+
+    parent_position_id BIGINT NOT NULL,
+    instrument_id      BIGINT NOT NULL,
+
+    is_buy                    BOOLEAN         NOT NULL,
+    units                     NUMERIC(20, 8)  NOT NULL,
+    amount                    NUMERIC(20, 4)  NOT NULL,
+    initial_amount_in_dollars NUMERIC(20, 4)  NOT NULL,
+    open_rate                 NUMERIC(20, 6)  NOT NULL,
+    open_conversion_rate      NUMERIC(20, 10) NOT NULL,
+    open_date_time            TIMESTAMPTZ     NOT NULL,
+    take_profit_rate          NUMERIC(20, 6),
+    stop_loss_rate            NUMERIC(20, 6),
+    total_fees                NUMERIC(20, 4)  NOT NULL DEFAULT 0,
+    leverage                  INTEGER         NOT NULL DEFAULT 1,
+
+    raw_payload JSONB NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX copy_mirror_positions_instrument_id_idx
+    ON copy_mirror_positions (instrument_id);
+
+COMMIT;

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+# tests/fixtures/__init__.py

--- a/tests/fixtures/copy_mirrors.py
+++ b/tests/fixtures/copy_mirrors.py
@@ -20,7 +20,19 @@ builders (`two_mirror_payload`, `parse_failure_payload`,
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.types.json
+
+from app.providers.broker import (
+    BrokerMirror,
+    BrokerMirrorPosition,
+    BrokerPortfolio,
+)
 
 # Frozen "now" for every sync-side test. Matches the value
 # tests/test_portfolio_sync.py used locally before this refactor
@@ -32,3 +44,300 @@ _NOW: datetime = datetime(2026, 4, 10, 5, 30, tzinfo=UTC)
 # Track 1b's guard-integration test fixtures reuse it.
 _GUARD_INSTRUMENT_ID: int = 990001
 _GUARD_INSTRUMENT_SECTOR: str = "technology"
+
+
+def _make_mirror_position(
+    position_id: int,
+    instrument_id: int = 42,
+    units: Decimal = Decimal("6.28927"),
+    open_rate: Decimal = Decimal("1207.4994"),
+    open_conversion_rate: Decimal = Decimal("0.01331"),
+    amount: Decimal = Decimal("101.08"),
+    is_buy: bool = True,
+) -> BrokerMirrorPosition:
+    return BrokerMirrorPosition(
+        position_id=position_id,
+        parent_position_id=position_id + 4000,
+        instrument_id=instrument_id,
+        is_buy=is_buy,
+        units=units,
+        amount=amount,
+        initial_amount_in_dollars=amount,
+        open_rate=open_rate,
+        open_conversion_rate=open_conversion_rate,
+        open_date_time=_NOW,
+        take_profit_rate=None,
+        stop_loss_rate=None,
+        total_fees=Decimal("0"),
+        leverage=1,
+        raw_payload={
+            "positionID": position_id,
+            "instrumentID": instrument_id,
+        },
+    )
+
+
+def _make_mirror(
+    mirror_id: int,
+    parent_cid: int,
+    parent_username: str,
+    positions: Sequence[BrokerMirrorPosition],
+    available_amount: Decimal = Decimal("2800.33"),
+    initial_investment: Decimal = Decimal("20000"),
+    deposit_summary: Decimal = Decimal("0"),
+    withdrawal_summary: Decimal = Decimal("0"),
+    closed_positions_net_profit: Decimal = Decimal("-110.34"),
+) -> BrokerMirror:
+    return BrokerMirror(
+        mirror_id=mirror_id,
+        parent_cid=parent_cid,
+        parent_username=parent_username,
+        initial_investment=initial_investment,
+        deposit_summary=deposit_summary,
+        withdrawal_summary=withdrawal_summary,
+        available_amount=available_amount,
+        closed_positions_net_profit=closed_positions_net_profit,
+        stop_loss_percentage=None,
+        stop_loss_amount=None,
+        mirror_status_id=None,
+        mirror_calculation_type=None,
+        pending_for_closure=False,
+        started_copy_date=_NOW,
+        positions=tuple(positions),
+        raw_payload={"mirrorID": mirror_id, "parentCID": parent_cid},
+    )
+
+
+def two_mirror_payload() -> BrokerPortfolio:
+    """Canonical 2 mirrors × 3 positions each BrokerPortfolio fixture.
+
+    Derived from the real etoro_portfolio_20260411T053000Z.json
+    payload — trimmed for test readability, includes at least one
+    non-USD position (GBP conversion rate 1.158) so the
+    openConversionRate round-trip is exercised in every test that
+    uses this fixture.
+    """
+    mirror_a = _make_mirror(
+        mirror_id=15712187,
+        parent_cid=111,
+        parent_username="thomaspj",
+        available_amount=Decimal("2800.33"),
+        initial_investment=Decimal("20000"),
+        deposit_summary=Decimal("0"),
+        withdrawal_summary=Decimal("0"),
+        closed_positions_net_profit=Decimal("-110.34"),
+        positions=[
+            _make_mirror_position(
+                position_id=1001,
+                instrument_id=42,
+                units=Decimal("6.28927"),
+                open_rate=Decimal("1207.4994"),
+                open_conversion_rate=Decimal("0.01331"),  # JPY
+                amount=Decimal("101.08"),
+            ),
+            _make_mirror_position(
+                position_id=1002,
+                instrument_id=43,
+                units=Decimal("2.0"),
+                open_rate=Decimal("150.00"),
+                open_conversion_rate=Decimal("1.158"),  # GBP
+                amount=Decimal("347.40"),
+            ),
+            _make_mirror_position(
+                position_id=1003,
+                instrument_id=44,
+                units=Decimal("10.0"),
+                open_rate=Decimal("100.00"),
+                open_conversion_rate=Decimal("1.0"),  # USD
+                amount=Decimal("1000.00"),
+            ),
+        ],
+    )
+    mirror_b = _make_mirror(
+        mirror_id=15714660,
+        parent_cid=222,
+        parent_username="triangulacapital",
+        available_amount=Decimal("1724.11"),
+        initial_investment=Decimal("17280"),
+        deposit_summary=Decimal("2251"),
+        withdrawal_summary=Decimal("0"),
+        closed_positions_net_profit=Decimal("-140.13"),
+        positions=[
+            _make_mirror_position(
+                position_id=2001,
+                instrument_id=52,
+                units=Decimal("1.0"),
+                open_rate=Decimal("500.00"),
+                open_conversion_rate=Decimal("1.0"),
+                amount=Decimal("500.00"),
+            ),
+            _make_mirror_position(
+                position_id=2002,
+                instrument_id=53,
+                units=Decimal("3.0"),
+                open_rate=Decimal("200.00"),
+                open_conversion_rate=Decimal("1.0"),
+                amount=Decimal("600.00"),
+            ),
+            _make_mirror_position(
+                position_id=2003,
+                instrument_id=54,
+                units=Decimal("5.0"),
+                open_rate=Decimal("80.00"),
+                open_conversion_rate=Decimal("1.0"),
+                amount=Decimal("400.00"),
+            ),
+        ],
+    )
+    return BrokerPortfolio(
+        positions=(),
+        available_cash=Decimal("0"),
+        raw_payload={},
+        mirrors=(mirror_a, mirror_b),
+    )
+
+
+def parse_failure_payload() -> list[dict[str, Any]]:
+    """Raw `clientPortfolio.mirrors[]` list with one malformed
+    nested position. Used by §8.3 to prove the sync aborts before
+    eviction / soft-close when the parser raises.
+
+    Returns a raw list (not BrokerPortfolio) because the test
+    exercises the parse step itself — `_parse_mirrors_payload`
+    must raise on this input.
+    """
+    return [
+        {
+            "mirrorID": 15712187,
+            "parentCID": 111,
+            "parentUsername": "thomaspj",
+            "initialInvestment": "20000",
+            "depositSummary": "0",
+            "withdrawalSummary": "0",
+            "availableAmount": "2800.33",
+            "closedPositionsNetProfit": "-110.34",
+            "stopLossPercentage": None,
+            "stopLossAmount": None,
+            "mirrorStatusID": None,
+            "mirrorCalculationType": None,
+            "pendingForClosure": False,
+            "startedCopyDate": "2025-01-01T00:00:00Z",
+            "positions": [
+                {
+                    "positionID": 1001,
+                    "parentPositionID": 5001,
+                    "instrumentID": 42,
+                    "isBuy": True,
+                    "units": "bogus",  # <-- non-numeric → DecimalException
+                    "amount": "101.08",
+                    "initialAmountInDollars": "101.08",
+                    "openRate": "1207.4994",
+                    "openConversionRate": "0.01331",
+                    "openDateTime": "2026-04-10T00:00:00Z",
+                    "takeProfitRate": None,
+                    "stopLossRate": None,
+                    "totalFees": "0",
+                    "leverage": 1,
+                },
+            ],
+        }
+    ]
+
+
+def two_mirror_seed_rows(conn: psycopg.Connection[Any]) -> None:
+    """INSERT the two_mirror_payload mirrors directly into
+    copy_traders / copy_mirrors / copy_mirror_positions so
+    disappearance and re-copy tests can seed the DB before
+    calling sync_portfolio with a *different* payload.
+
+    Caller is responsible for commit/rollback. Safe to run only
+    against ebull_test — callers must enforce this themselves
+    before calling (see _assert_test_db in test modules).
+    """
+    payload = two_mirror_payload()
+    with conn.cursor() as cur:
+        for mirror in payload.mirrors:
+            cur.execute(
+                """
+                INSERT INTO copy_traders (parent_cid, parent_username,
+                                          first_seen_at, updated_at)
+                VALUES (%(cid)s, %(username)s, %(now)s, %(now)s)
+                ON CONFLICT (parent_cid) DO NOTHING
+                """,
+                {
+                    "cid": mirror.parent_cid,
+                    "username": mirror.parent_username,
+                    "now": _NOW,
+                },
+            )
+            cur.execute(
+                """
+                INSERT INTO copy_mirrors (
+                    mirror_id, parent_cid, initial_investment,
+                    deposit_summary, withdrawal_summary,
+                    available_amount, closed_positions_net_profit,
+                    stop_loss_percentage, stop_loss_amount,
+                    mirror_status_id, mirror_calculation_type,
+                    pending_for_closure, started_copy_date,
+                    active, closed_at, raw_payload, updated_at
+                ) VALUES (
+                    %(mirror_id)s, %(parent_cid)s, %(initial_investment)s,
+                    %(deposit_summary)s, %(withdrawal_summary)s,
+                    %(available_amount)s, %(closed_positions_net_profit)s,
+                    NULL, NULL, NULL, NULL, FALSE, %(started_copy_date)s,
+                    TRUE, NULL, %(raw_payload)s::jsonb, %(now)s
+                )
+                """,
+                {
+                    "mirror_id": mirror.mirror_id,
+                    "parent_cid": mirror.parent_cid,
+                    "initial_investment": mirror.initial_investment,
+                    "deposit_summary": mirror.deposit_summary,
+                    "withdrawal_summary": mirror.withdrawal_summary,
+                    "available_amount": mirror.available_amount,
+                    "closed_positions_net_profit": mirror.closed_positions_net_profit,
+                    "started_copy_date": mirror.started_copy_date,
+                    "raw_payload": psycopg.types.json.Jsonb(mirror.raw_payload),
+                    "now": _NOW,
+                },
+            )
+            for pos in mirror.positions:
+                cur.execute(
+                    """
+                    INSERT INTO copy_mirror_positions (
+                        mirror_id, position_id, parent_position_id,
+                        instrument_id, is_buy, units, amount,
+                        initial_amount_in_dollars, open_rate,
+                        open_conversion_rate, open_date_time,
+                        take_profit_rate, stop_loss_rate,
+                        total_fees, leverage, raw_payload, updated_at
+                    ) VALUES (
+                        %(mirror_id)s, %(position_id)s, %(parent_position_id)s,
+                        %(instrument_id)s, %(is_buy)s, %(units)s, %(amount)s,
+                        %(initial_amount)s, %(open_rate)s,
+                        %(open_conversion_rate)s, %(open_date_time)s,
+                        %(take_profit_rate)s, %(stop_loss_rate)s,
+                        %(total_fees)s, %(leverage)s, %(raw_payload)s::jsonb,
+                        %(now)s
+                    )
+                    """,
+                    {
+                        "mirror_id": mirror.mirror_id,
+                        "position_id": pos.position_id,
+                        "parent_position_id": pos.parent_position_id,
+                        "instrument_id": pos.instrument_id,
+                        "is_buy": pos.is_buy,
+                        "units": pos.units,
+                        "amount": pos.amount,
+                        "initial_amount": pos.initial_amount_in_dollars,
+                        "open_rate": pos.open_rate,
+                        "open_conversion_rate": pos.open_conversion_rate,
+                        "open_date_time": pos.open_date_time,
+                        "take_profit_rate": pos.take_profit_rate,
+                        "stop_loss_rate": pos.stop_loss_rate,
+                        "total_fees": pos.total_fees,
+                        "leverage": pos.leverage,
+                        "raw_payload": psycopg.types.json.Jsonb(pos.raw_payload),
+                        "now": _NOW,
+                    },
+                )

--- a/tests/fixtures/copy_mirrors.py
+++ b/tests/fixtures/copy_mirrors.py
@@ -1,0 +1,34 @@
+"""Shared test fixtures for copy-trading ingestion (spec §8.0).
+
+This module owns the canonical `_NOW` constant used by every test
+that exercises the mirror sync soft-close path. The value is
+pinned to a frozen UTC timestamp so that `_sync_mirrors`'s
+`UPDATE ... closed_at = %(now)s` clause produces a deterministic
+stored value and tests can assert the exact round-trip.
+
+It also owns `_GUARD_INSTRUMENT_ID` and `_GUARD_INSTRUMENT_SECTOR`
+— the deterministic instrument-row identifiers used by the
+guard-path fixtures delivered in Track 1b (#187). They are
+declared here in Track 1a so all callers import them from one
+place once Track 1b lands.
+
+Track 1a ships the constants and the parser/sync fixture
+builders (`two_mirror_payload`, `parse_failure_payload`,
+`two_mirror_seed_rows`). Track 1b adds `mirror_aum_fixture`,
+`no_quote_mirror_fixture`, `mtm_delta_mirror_fixture` on top.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+# Frozen "now" for every sync-side test. Matches the value
+# tests/test_portfolio_sync.py used locally before this refactor
+# (bit-identical — no behaviour change).
+_NOW: datetime = datetime(2026, 4, 10, 5, 30, tzinfo=UTC)
+
+# Guard test instrument — chosen well above any seed data in
+# sql/001_init.sql so it cannot collide with real instruments.
+# Track 1b's guard-integration test fixtures reuse it.
+_GUARD_INSTRUMENT_ID: int = 990001
+_GUARD_INSTRUMENT_SECTOR: str = "technology"

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -9,11 +9,17 @@ No network calls — all HTTP interactions are mocked.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import httpx
 
+from app.providers.broker import (
+    BrokerMirror,
+    BrokerMirrorPosition,
+    BrokerPortfolio,
+)
 from app.providers.implementations.etoro_broker import (
     EtoroBrokerProvider,
     _normalise_close_order_response,
@@ -659,3 +665,67 @@ class TestGetPortfolio:
 
             url = broker._http_read.get.call_args.args[0]
             assert url == "/api/v1/trading/info/demo/portfolio"
+
+
+# ---------------------------------------------------------------------------
+# BrokerMirrorPosition / BrokerMirror / BrokerPortfolio.mirrors
+# ---------------------------------------------------------------------------
+
+
+def test_broker_mirror_position_round_trip() -> None:
+    pos = BrokerMirrorPosition(
+        position_id=1001,
+        parent_position_id=5001,
+        instrument_id=42,
+        is_buy=True,
+        units=Decimal("6.28927"),
+        amount=Decimal("101.08"),
+        initial_amount_in_dollars=Decimal("101.08"),
+        open_rate=Decimal("1207.4994"),
+        open_conversion_rate=Decimal("0.01331"),
+        open_date_time=datetime(2026, 4, 10, 0, 0, tzinfo=UTC),
+        take_profit_rate=None,
+        stop_loss_rate=None,
+        total_fees=Decimal("0"),
+        leverage=1,
+        raw_payload={"positionID": 1001},
+    )
+    assert pos.units == Decimal("6.28927")
+    assert pos.open_conversion_rate == Decimal("0.01331")
+    assert pos.is_buy is True
+    assert pos.raw_payload["positionID"] == 1001
+
+
+def test_broker_mirror_round_trip() -> None:
+    mirror = BrokerMirror(
+        mirror_id=15712187,
+        parent_cid=111,
+        parent_username="thomaspj",
+        initial_investment=Decimal("20000"),
+        deposit_summary=Decimal("0"),
+        withdrawal_summary=Decimal("0"),
+        available_amount=Decimal("2800.33"),
+        closed_positions_net_profit=Decimal("-110.34"),
+        stop_loss_percentage=None,
+        stop_loss_amount=None,
+        mirror_status_id=None,
+        mirror_calculation_type=None,
+        pending_for_closure=False,
+        started_copy_date=datetime(2025, 1, 1, tzinfo=UTC),
+        positions=(),
+        raw_payload={"mirrorID": 15712187},
+    )
+    assert mirror.mirror_id == 15712187
+    assert mirror.parent_username == "thomaspj"
+    assert mirror.positions == ()
+
+
+def test_broker_portfolio_mirrors_defaults_to_empty_tuple() -> None:
+    """Existing callers must still be able to construct BrokerPortfolio
+    without supplying mirrors (spec §2.1 non-breaking addition)."""
+    portfolio = BrokerPortfolio(
+        positions=(),
+        available_cash=Decimal("0"),
+        raw_payload={},
+    )
+    assert portfolio.mirrors == ()

--- a/tests/test_copy_mirrors_parser.py
+++ b/tests/test_copy_mirrors_parser.py
@@ -9,10 +9,17 @@ loop in etoro_broker.get_portfolio's mirrors[] branch.
 from __future__ import annotations
 
 import decimal
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
 
 import pytest
 
-from app.providers.implementations.etoro_broker import PortfolioParseError
+from app.providers.broker import BrokerMirrorPosition
+from app.providers.implementations.etoro_broker import (
+    PortfolioParseError,
+    _parse_mirror_position,
+)
 
 
 def test_portfolio_parse_error_is_direct_exception_subclass() -> None:
@@ -36,3 +43,76 @@ def test_portfolio_parse_error_is_raisable_with_cause() -> None:
     with pytest.raises(PortfolioParseError) as excinfo:
         raise PortfolioParseError("wrap") from inner
     assert excinfo.value.__cause__ is inner
+
+
+def _make_position_payload(**overrides: Any) -> dict[str, Any]:
+    """Return a valid mirror-position payload; override any field."""
+    base: dict[str, Any] = {
+        "positionID": 1001,
+        "parentPositionID": 5001,
+        "instrumentID": 42,
+        "isBuy": True,
+        "units": "6.28927",
+        "amount": "101.08",
+        "initialAmountInDollars": "101.08",
+        "openRate": "1207.4994",
+        "openConversionRate": "0.01331",
+        "openDateTime": "2026-04-10T00:00:00Z",
+        "takeProfitRate": None,
+        "stopLossRate": None,
+        "totalFees": "0",
+        "leverage": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_parse_mirror_position_happy_path_non_usd() -> None:
+    payload = _make_position_payload()
+    pos = _parse_mirror_position(payload)
+    assert isinstance(pos, BrokerMirrorPosition)
+    assert pos.position_id == 1001
+    assert pos.instrument_id == 42
+    assert pos.is_buy is True
+    assert pos.units == Decimal("6.28927")
+    assert pos.open_rate == Decimal("1207.4994")
+    assert pos.open_conversion_rate == Decimal("0.01331")  # FX round-trip
+    assert pos.open_date_time == datetime(2026, 4, 10, 0, 0, tzinfo=UTC)
+    assert pos.take_profit_rate is None
+    assert pos.stop_loss_rate is None
+    assert pos.total_fees == Decimal("0")
+    assert pos.leverage == 1
+    assert pos.raw_payload is payload  # stored as-is
+
+
+def test_parse_mirror_position_missing_open_conversion_rate_raises() -> None:
+    """Spec §2.2.2: openConversionRate is a required field in prod
+    — no silent default. A mirror-position without it raises."""
+    payload = _make_position_payload()
+    del payload["openConversionRate"]
+    with pytest.raises(KeyError):
+        _parse_mirror_position(payload)
+
+
+def test_parse_mirror_position_non_numeric_units_raises_decimal_exc() -> None:
+    """Spec §2.2.2 + §8.1: Decimal(str('bogus')) raises
+    decimal.InvalidOperation, a subclass of DecimalException —
+    NOT a ValueError. This test pins the exception type so the
+    caller's `except DecimalException` clause catches correctly."""
+    payload = _make_position_payload(units="bogus")
+    with pytest.raises(decimal.DecimalException):
+        _parse_mirror_position(payload)
+
+
+def test_parse_mirror_position_optional_fields_none() -> None:
+    payload = _make_position_payload(takeProfitRate=None, stopLossRate=None)
+    pos = _parse_mirror_position(payload)
+    assert pos.take_profit_rate is None
+    assert pos.stop_loss_rate is None
+
+
+def test_parse_mirror_position_optional_fields_present() -> None:
+    payload = _make_position_payload(takeProfitRate="1500.0", stopLossRate="1000.0")
+    pos = _parse_mirror_position(payload)
+    assert pos.take_profit_rate == Decimal("1500.0")
+    assert pos.stop_loss_rate == Decimal("1000.0")

--- a/tests/test_copy_mirrors_parser.py
+++ b/tests/test_copy_mirrors_parser.py
@@ -1,0 +1,38 @@
+# tests/test_copy_mirrors_parser.py
+"""§8.1 parser unit tests for copy-trading mirror ingestion.
+
+Pure unit tests — no DB, no I/O, no broker HTTP. Exercises
+_parse_mirror / _parse_mirror_position and the outer top-level
+loop in etoro_broker.get_portfolio's mirrors[] branch.
+"""
+
+from __future__ import annotations
+
+import decimal
+
+import pytest
+
+from app.providers.implementations.etoro_broker import PortfolioParseError
+
+
+def test_portfolio_parse_error_is_direct_exception_subclass() -> None:
+    """Spec §2.2.1: PortfolioParseError MUST subclass Exception directly.
+
+    If it subclassed ValueError / TypeError / KeyError /
+    decimal.DecimalException, the outer parse loop's
+    `except (KeyError, ValueError, TypeError, decimal.DecimalException)`
+    block would silently swallow it, defeating the §2.3.3 strict-raise
+    and enabling the §2.3.4 soft-close hole Codex v3 finding V flagged.
+    """
+    assert issubclass(PortfolioParseError, Exception) is True
+    assert issubclass(PortfolioParseError, ValueError) is False
+    assert issubclass(PortfolioParseError, TypeError) is False
+    assert issubclass(PortfolioParseError, KeyError) is False
+    assert issubclass(PortfolioParseError, decimal.DecimalException) is False
+
+
+def test_portfolio_parse_error_is_raisable_with_cause() -> None:
+    inner = ValueError("boom")
+    with pytest.raises(PortfolioParseError) as excinfo:
+        raise PortfolioParseError("wrap") from inner
+    assert excinfo.value.__cause__ is inner

--- a/tests/test_copy_mirrors_parser.py
+++ b/tests/test_copy_mirrors_parser.py
@@ -15,9 +15,10 @@ from typing import Any
 
 import pytest
 
-from app.providers.broker import BrokerMirrorPosition
+from app.providers.broker import BrokerMirror, BrokerMirrorPosition
 from app.providers.implementations.etoro_broker import (
     PortfolioParseError,
+    _parse_mirror,
     _parse_mirror_position,
 )
 
@@ -116,3 +117,86 @@ def test_parse_mirror_position_optional_fields_present() -> None:
     pos = _parse_mirror_position(payload)
     assert pos.take_profit_rate == Decimal("1500.0")
     assert pos.stop_loss_rate == Decimal("1000.0")
+
+
+def _make_mirror_payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "mirrorID": 15712187,
+        "parentCID": 111,
+        "parentUsername": "thomaspj",
+        "initialInvestment": "20000",
+        "depositSummary": "0",
+        "withdrawalSummary": "0",
+        "availableAmount": "2800.33",
+        "closedPositionsNetProfit": "-110.34",
+        "stopLossPercentage": None,
+        "stopLossAmount": None,
+        "mirrorStatusID": None,
+        "mirrorCalculationType": None,
+        "pendingForClosure": False,
+        "startedCopyDate": "2025-01-01T00:00:00Z",
+        "positions": [_make_position_payload(positionID=1001)],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_parse_mirror_happy_path() -> None:
+    payload = _make_mirror_payload()
+    mirror = _parse_mirror(payload)
+    assert isinstance(mirror, BrokerMirror)
+    assert mirror.mirror_id == 15712187
+    assert mirror.parent_cid == 111
+    assert mirror.parent_username == "thomaspj"
+    assert mirror.available_amount == Decimal("2800.33")
+    assert mirror.closed_positions_net_profit == Decimal("-110.34")
+    assert len(mirror.positions) == 1
+    assert mirror.positions[0].position_id == 1001
+    assert mirror.started_copy_date == datetime(2025, 1, 1, tzinfo=UTC)
+    assert mirror.raw_payload is payload
+
+
+def test_parse_mirror_empty_positions_is_valid() -> None:
+    """A mirror with positions == [] is a valid state (holds only cash).
+
+    §2.2.2: raw_positions == [] yields positions=(), which the §3.2
+    AUM formula in Track 1b handles as mirror_equity = available_amount.
+    Nothing raises.
+    """
+    payload = _make_mirror_payload(positions=[])
+    mirror = _parse_mirror(payload)
+    assert mirror.positions == ()
+
+
+def test_parse_mirror_nested_failure_wraps_with_index() -> None:
+    """Spec §2.2.2: inner loop catches (KeyError, ValueError, TypeError,
+    DecimalException) and re-raises as PortfolioParseError with both
+    the mirror_id AND the position index in the message."""
+    bad_pos = _make_position_payload(positionID=9999, units="bogus")
+    payload = _make_mirror_payload(
+        positions=[
+            _make_position_payload(positionID=1001),
+            _make_position_payload(positionID=1002),
+            bad_pos,  # idx 2 — this is the failing one
+        ]
+    )
+    with pytest.raises(PortfolioParseError) as excinfo:
+        _parse_mirror(payload)
+    msg = str(excinfo.value)
+    assert "15712187" in msg
+    assert "position[2]" in msg
+    assert isinstance(excinfo.value.__cause__, decimal.InvalidOperation)
+
+
+def test_parse_mirror_nested_key_error_wraps() -> None:
+    """Missing openConversionRate in a nested position raises
+    KeyError from _parse_mirror_position, which _parse_mirror's
+    inner wrap catches and re-raises as PortfolioParseError."""
+    bad_pos = _make_position_payload(positionID=9999)
+    del bad_pos["openConversionRate"]
+    payload = _make_mirror_payload(positions=[bad_pos])
+    with pytest.raises(PortfolioParseError) as excinfo:
+        _parse_mirror(payload)
+    assert "15712187" in str(excinfo.value)
+    assert "position[0]" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, KeyError)

--- a/tests/test_copy_mirrors_parser.py
+++ b/tests/test_copy_mirrors_parser.py
@@ -9,6 +9,7 @@ loop in etoro_broker.get_portfolio's mirrors[] branch.
 from __future__ import annotations
 
 import decimal
+import logging
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
@@ -20,6 +21,7 @@ from app.providers.implementations.etoro_broker import (
     PortfolioParseError,
     _parse_mirror,
     _parse_mirror_position,
+    _parse_mirrors_payload,
 )
 
 
@@ -200,3 +202,72 @@ def test_parse_mirror_nested_key_error_wraps() -> None:
     assert "15712187" in str(excinfo.value)
     assert "position[0]" in str(excinfo.value)
     assert isinstance(excinfo.value.__cause__, KeyError)
+
+
+# ---------------------------------------------------------------------------
+# Task 8: _parse_mirrors_payload — outer top-level loop
+# ---------------------------------------------------------------------------
+
+
+def test_parse_mirrors_payload_happy_path_two_mirrors() -> None:
+    raw = [_make_mirror_payload(mirrorID=1), _make_mirror_payload(mirrorID=2)]
+    result = _parse_mirrors_payload(raw)
+    assert len(result) == 2
+    assert result[0].mirror_id == 1
+    assert result[1].mirror_id == 2
+
+
+def test_parse_mirrors_payload_skips_unrecognisable_no_mirror_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Spec §2.2.2: the ONLY surviving log-and-skip path is a row
+    with no usable mirrorID — it cannot collide with any known
+    local row, so it is safe to skip."""
+    raw = [
+        {"not a mirror": True},  # no mirrorID → safe skip
+        "not even a dict",  # not a dict → safe skip
+        _make_mirror_payload(mirrorID=42),  # valid → parsed
+    ]
+    with caplog.at_level(logging.WARNING):
+        result = _parse_mirrors_payload(raw)
+    assert len(result) == 1
+    assert result[0].mirror_id == 42
+    assert any("unrecognisable" in rec.message.lower() for rec in caplog.records)
+
+
+def test_parse_mirrors_payload_known_mirror_top_level_failure_raises() -> None:
+    """Spec §2.2.2: a row with a recognisable mirrorID but a
+    missing/malformed required top-level field raises
+    PortfolioParseError — NOT log-and-skip. Otherwise the sync
+    would then interpret this as a disappearance and soft-close
+    the local row (Codex v3 finding V parse-and-soft-close hole)."""
+    bad = _make_mirror_payload(mirrorID=15712187)
+    del bad["availableAmount"]
+    raw = [bad, _make_mirror_payload(mirrorID=42)]
+    with pytest.raises(PortfolioParseError) as excinfo:
+        _parse_mirrors_payload(raw)
+    assert "15712187" in str(excinfo.value)
+    # The underlying cause is a KeyError on the missing key.
+    assert isinstance(excinfo.value.__cause__, KeyError)
+
+
+def test_parse_mirrors_payload_known_mirror_decimal_failure_raises() -> None:
+    """Non-numeric top-level availableAmount raises
+    decimal.InvalidOperation, which the outer fallback catch wraps
+    as PortfolioParseError with mirror_id attribution."""
+    bad = _make_mirror_payload(mirrorID=15712187, availableAmount="bogus")
+    with pytest.raises(PortfolioParseError) as excinfo:
+        _parse_mirrors_payload([bad])
+    assert "15712187" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, decimal.InvalidOperation)
+
+
+def test_parse_mirrors_payload_nested_failure_propagates_unchanged() -> None:
+    """Spec §2.2.2: the outer loop's `except PortfolioParseError: raise`
+    preserves the inner-loop's position[idx] attribution."""
+    bad_pos = _make_position_payload(positionID=9999, units="bogus")
+    bad_mirror = _make_mirror_payload(mirrorID=15712187, positions=[bad_pos])
+    with pytest.raises(PortfolioParseError) as excinfo:
+        _parse_mirrors_payload([bad_mirror])
+    assert "15712187" in str(excinfo.value)
+    assert "position[0]" in str(excinfo.value)

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -71,6 +71,7 @@ def _mock_conn(
     Cursor SQL dispatch matches on substrings.  Priority:
     - 'FROM positions' → local position rows as dicts
     - 'FROM cash_ledger' → local cash sum as dict
+    - 'FROM copy_mirrors' → {"n": 0} (no mirror state in these tests)
     - Everything else → default MagicMock
 
     Note: substring matching cannot detect structural SQL errors like
@@ -89,6 +90,11 @@ def _mock_conn(
             result.fetchall.return_value = position_rows
         elif "FROM cash_ledger" in stripped:
             result.fetchone.return_value = {"total": local_cash}
+        elif "FROM copy_mirrors" in stripped:
+            # Pre-write mirror guard queries copy_mirrors for an
+            # active count. These tests have no mirror state, so
+            # 0 lets the guard fall through cleanly.
+            result.fetchone.return_value = {"n": 0}
         return result
 
     mock_cursor = MagicMock()
@@ -579,25 +585,6 @@ class TestPositionSource:
         assert "EXCLUDED.source" in normalised
         assert "ELSE positions.source" in normalised
 
-
-def test_portfolio_sync_result_has_mirror_counters() -> None:
-    """Spec §2.3 result extension — mirrors_upserted, mirrors_closed,
-    mirror_positions_upserted are part of the return contract."""
-    result = PortfolioSyncResult(
-        positions_updated=0,
-        positions_opened_externally=0,
-        positions_closed_externally=0,
-        cash_delta=Decimal("0"),
-        broker_cash=Decimal("0"),
-        local_cash=Decimal("0"),
-        mirrors_upserted=2,
-        mirrors_closed=1,
-        mirror_positions_upserted=6,
-    )
-    assert result.mirrors_upserted == 2
-    assert result.mirrors_closed == 1
-    assert result.mirror_positions_upserted == 6
-
     def test_update_path_does_not_overwrite_source(self) -> None:
         """Existing open position — UPDATE must NOT touch source.
 
@@ -637,3 +624,22 @@ class TestReopenedPositionOpenDate:
         ]
         sql = insert_calls[0].args[0]
         assert "open_date      = EXCLUDED.open_date" in sql
+
+
+def test_portfolio_sync_result_has_mirror_counters() -> None:
+    """Spec §2.3 result extension — mirrors_upserted, mirrors_closed,
+    mirror_positions_upserted are part of the return contract."""
+    result = PortfolioSyncResult(
+        positions_updated=0,
+        positions_opened_externally=0,
+        positions_closed_externally=0,
+        cash_delta=Decimal("0"),
+        broker_cash=Decimal("0"),
+        local_cash=Decimal("0"),
+        mirrors_upserted=2,
+        mirrors_closed=1,
+        mirror_positions_upserted=6,
+    )
+    assert result.mirrors_upserted == 2
+    assert result.mirrors_closed == 1
+    assert result.mirror_positions_upserted == 6

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -579,6 +579,25 @@ class TestPositionSource:
         assert "EXCLUDED.source" in normalised
         assert "ELSE positions.source" in normalised
 
+
+def test_portfolio_sync_result_has_mirror_counters() -> None:
+    """Spec §2.3 result extension — mirrors_upserted, mirrors_closed,
+    mirror_positions_upserted are part of the return contract."""
+    result = PortfolioSyncResult(
+        positions_updated=0,
+        positions_opened_externally=0,
+        positions_closed_externally=0,
+        cash_delta=Decimal("0"),
+        broker_cash=Decimal("0"),
+        local_cash=Decimal("0"),
+        mirrors_upserted=2,
+        mirrors_closed=1,
+        mirror_positions_upserted=6,
+    )
+    assert result.mirrors_upserted == 2
+    assert result.mirrors_closed == 1
+    assert result.mirror_positions_upserted == 6
+
     def test_update_path_does_not_overwrite_source(self) -> None:
         """Existing open position — UPDATE must NOT touch source.
 

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock
@@ -16,8 +15,7 @@ from app.services.portfolio_sync import (
     _aggregate_by_instrument,
     sync_portfolio,
 )
-
-_NOW = datetime(2026, 4, 10, 5, 30, tzinfo=UTC)
+from tests.fixtures.copy_mirrors import _NOW
 
 
 def _is_zero_out_update(sql_arg: Any) -> bool:

--- a/tests/test_portfolio_sync_mirrors.py
+++ b/tests/test_portfolio_sync_mirrors.py
@@ -20,6 +20,7 @@ from app.services.portfolio_sync import sync_portfolio
 from tests.fixtures.copy_mirrors import (
     _NOW,
     two_mirror_payload,
+    two_mirror_seed_rows,
 )
 from tests.test_operator_setup_race import (
     _assert_test_db,
@@ -184,3 +185,97 @@ def test_sync_mirrors_evicts_all_positions_when_mirror_empties(
         row = cur.fetchone()
         assert row is not None
         assert row["n"] == 3
+
+
+def test_sync_mirrors_partial_disappearance_soft_closes(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.3.4: a mirror that disappears from the payload
+    (while other mirrors are still present) is soft-closed —
+    active=FALSE, closed_at=%(now)s. Nested positions are RETAINED
+    for audit."""
+    two_mirror_seed_rows(conn)
+    conn.commit()
+    assert _count(conn, "copy_mirrors") == 2
+
+    # Sync a payload that only contains the second mirror.
+    full_payload = two_mirror_payload()
+    partial_payload = dataclasses.replace(
+        full_payload,
+        mirrors=(full_payload.mirrors[1],),  # drop mirror A
+    )
+    result = sync_portfolio(conn, partial_payload, now=_NOW)
+    conn.commit()
+
+    # Mirror A: soft-closed, nested positions retained.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT active, closed_at FROM copy_mirrors
+            WHERE mirror_id = %s
+            """,
+            (full_payload.mirrors[0].mirror_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row["active"] is False
+    assert row["closed_at"] == _NOW
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS n FROM copy_mirror_positions WHERE mirror_id = %s",
+            (full_payload.mirrors[0].mirror_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row["n"] == 3  # retained for audit
+
+    # Mirror B: still active.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT active FROM copy_mirrors WHERE mirror_id = %s",
+            (full_payload.mirrors[1].mirror_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row["active"] is True
+
+    assert result.mirrors_closed == 1
+
+
+def test_sync_mirrors_recopy_resurrects_closed_mirror(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.3.4 / §1.2: if eToro reuses a previously-seen
+    mirror_id, the ON CONFLICT DO UPDATE clause resets
+    active=TRUE, closed_at=NULL so the mirror is live again."""
+    two_mirror_seed_rows(conn)
+    # Pre-close mirror A so it starts the test soft-closed.
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE copy_mirrors
+               SET active = FALSE,
+                   closed_at = %(closed)s
+             WHERE mirror_id = %(mid)s
+            """,
+            {
+                "closed": _NOW,
+                "mid": two_mirror_payload().mirrors[0].mirror_id,
+            },
+        )
+    conn.commit()
+
+    # Sync the full payload — mirror A re-appears.
+    sync_portfolio(conn, two_mirror_payload(), now=_NOW)
+    conn.commit()
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT active, closed_at FROM copy_mirrors WHERE mirror_id = %s",
+            (two_mirror_payload().mirrors[0].mirror_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row["active"] is True
+    assert row["closed_at"] is None

--- a/tests/test_portfolio_sync_mirrors.py
+++ b/tests/test_portfolio_sync_mirrors.py
@@ -7,6 +7,7 @@ tests/test_operator_setup_race.py.
 
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Iterator
 from typing import Any
 
@@ -90,3 +91,96 @@ def test_sync_mirrors_idempotent_resync(conn: psycopg.Connection[Any]) -> None:
     assert _count(conn, "copy_traders") == 2
     assert _count(conn, "copy_mirrors") == 2
     assert _count(conn, "copy_mirror_positions") == 6
+
+
+def test_sync_mirrors_evicts_closed_nested_positions(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.3.2: a nested position removed from the payload is
+    DELETEd from copy_mirror_positions. Sibling positions in the
+    same mirror and positions in other mirrors are untouched.
+    copy_mirrors.active stays TRUE."""
+    payload = two_mirror_payload()
+    sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+    assert _count(conn, "copy_mirror_positions") == 6
+
+    # Remove one nested position from the first mirror and re-sync.
+    trimmed_positions = payload.mirrors[0].positions[1:]  # drop pos 1001
+    trimmed_mirror = dataclasses.replace(payload.mirrors[0], positions=trimmed_positions)
+    trimmed_payload = dataclasses.replace(
+        payload,
+        mirrors=(trimmed_mirror, payload.mirrors[1]),
+    )
+    sync_portfolio(conn, trimmed_payload, now=_NOW)
+    conn.commit()
+
+    # The removed row is gone, siblings remain.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT position_id FROM copy_mirror_positions
+            WHERE mirror_id = %s ORDER BY position_id
+            """,
+            (payload.mirrors[0].mirror_id,),
+        )
+        remaining = [r["position_id"] for r in cur.fetchall()]
+    assert remaining == [1002, 1003]
+
+    # The other mirror is untouched.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS n FROM copy_mirror_positions WHERE mirror_id = %s",
+            (payload.mirrors[1].mirror_id,),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row["n"] == 3
+
+    # The mirror row itself is still active.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT active FROM copy_mirrors WHERE mirror_id = %s",
+            (payload.mirrors[0].mirror_id,),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row["active"] is True
+
+
+def test_sync_mirrors_evicts_all_positions_when_mirror_empties(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.3.2: an empty positions[] evicts every nested row for
+    that mirror (exploits Postgres `position_id <> ALL('{}')` === TRUE
+    semantics)."""
+    payload = two_mirror_payload()
+    sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+
+    empty_mirror = dataclasses.replace(payload.mirrors[0], positions=())
+    emptied_payload = dataclasses.replace(
+        payload,
+        mirrors=(empty_mirror, payload.mirrors[1]),
+    )
+    sync_portfolio(conn, emptied_payload, now=_NOW)
+    conn.commit()
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS n FROM copy_mirror_positions WHERE mirror_id = %s",
+            (payload.mirrors[0].mirror_id,),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row["n"] == 0
+
+    # Mirror B is untouched.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS n FROM copy_mirror_positions WHERE mirror_id = %s",
+            (payload.mirrors[1].mirror_id,),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row["n"] == 3

--- a/tests/test_portfolio_sync_mirrors.py
+++ b/tests/test_portfolio_sync_mirrors.py
@@ -16,9 +16,14 @@ import psycopg.rows
 import psycopg.sql
 import pytest
 
+from app.providers.implementations.etoro_broker import (
+    PortfolioParseError,
+    _parse_mirrors_payload,
+)
 from app.services.portfolio_sync import sync_portfolio
 from tests.fixtures.copy_mirrors import (
     _NOW,
+    parse_failure_payload,
     two_mirror_payload,
     two_mirror_seed_rows,
 )
@@ -279,3 +284,86 @@ def test_sync_mirrors_recopy_resurrects_closed_mirror(
     assert row is not None
     assert row["active"] is True
     assert row["closed_at"] is None
+
+
+def test_sync_mirrors_total_disappearance_raises(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.3.4 asymmetry: if the payload mirrors[] is empty but
+    local active mirrors exist, raise RuntimeError. Rows survive
+    unchanged after the rollback."""
+    two_mirror_seed_rows(conn)
+    conn.commit()
+
+    empty_payload = dataclasses.replace(two_mirror_payload(), mirrors=())
+
+    with pytest.raises(RuntimeError, match="empty mirrors"):
+        sync_portfolio(conn, empty_payload, now=_NOW)
+    conn.rollback()
+
+    # Both rows survive as active=TRUE.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT active FROM copy_mirrors ORDER BY mirror_id")
+        rows = cur.fetchall()
+    assert len(rows) == 2
+    assert all(r["active"] is True for r in rows)
+
+
+def test_sync_mirrors_parser_failure_aborts_before_eviction(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.3.3: if _parse_mirrors_payload raises
+    PortfolioParseError, the sync transaction is rolled back before
+    any upsert or eviction touches the DB. Seed rows survive
+    unchanged — this is the regression test for the Codex v3
+    finding V parse-and-soft-close hole."""
+    two_mirror_seed_rows(conn)
+    conn.commit()
+    baseline_positions = _count(conn, "copy_mirror_positions")
+    assert baseline_positions == 6
+
+    raw_failure = parse_failure_payload()
+    with pytest.raises(PortfolioParseError):
+        # The failure fires inside the parser — callers of
+        # sync_portfolio parse first, then call sync. In production
+        # this is get_portfolio → sync_portfolio; in tests we
+        # exercise the same ordering explicitly.
+        _ = _parse_mirrors_payload(raw_failure)
+
+    # sync_portfolio is never called — rows untouched.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT active FROM copy_mirrors ORDER BY mirror_id")
+        rows = cur.fetchall()
+    assert len(rows) == 2
+    assert all(r["active"] is True for r in rows)
+    assert _count(conn, "copy_mirror_positions") == baseline_positions
+
+
+def test_sync_mirrors_known_mirror_top_level_parse_failure_aborts(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Spec §2.2.2 / §2.3.3: a known mirrorID with a missing
+    required top-level field raises PortfolioParseError, NOT
+    log-and-skip. The outer _parse_mirrors_payload wraps the
+    underlying KeyError. Without this, the sync would interpret
+    the known mirror as disappeared and soft-close it — the hole
+    Codex v3 finding V identified."""
+    two_mirror_seed_rows(conn)
+    conn.commit()
+
+    bad_raw = parse_failure_payload()
+    # Break the top-level field (not the nested one) this time.
+    bad_raw[0]["positions"][0]["units"] = "1.0"  # fix the nested row
+    del bad_raw[0]["availableAmount"]  # break the top-level row
+
+    with pytest.raises(PortfolioParseError) as excinfo:
+        _parse_mirrors_payload(bad_raw)
+    assert "15712187" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, KeyError)
+
+    # Seed rows are untouched — sync_portfolio never reached.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT active FROM copy_mirrors ORDER BY mirror_id")
+        rows = cur.fetchall()
+    assert len(rows) == 2
+    assert all(r["active"] is True for r in rows)

--- a/tests/test_portfolio_sync_mirrors.py
+++ b/tests/test_portfolio_sync_mirrors.py
@@ -1,0 +1,92 @@
+"""§8.2 + §8.3 service-layer tests for copy-trading mirror sync.
+
+All tests run against the dedicated ebull_test database (never
+settings.database_url) — the same isolation pattern as
+tests/test_operator_setup_race.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import psycopg
+import psycopg.rows
+import psycopg.sql
+import pytest
+
+from app.services.portfolio_sync import sync_portfolio
+from tests.fixtures.copy_mirrors import (
+    _NOW,
+    two_mirror_payload,
+)
+from tests.test_operator_setup_race import (
+    _assert_test_db,
+    _test_database_url,
+    _test_db_available,
+)
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test DB unavailable — skipping real-DB mirror sync test",
+)
+
+
+@pytest.fixture
+def conn() -> Iterator[psycopg.Connection[Any]]:
+    """Yield a fresh connection to ebull_test with copy_* tables
+    truncated at the start of each test. Rollback on failure."""
+    with psycopg.connect(_test_database_url()) as c:
+        _assert_test_db(c)
+        with c.cursor() as cur:
+            cur.execute("TRUNCATE copy_mirror_positions, copy_mirrors, copy_traders RESTART IDENTITY CASCADE")
+        c.commit()
+        yield c
+        c.rollback()
+
+
+def _count(conn: psycopg.Connection[Any], table: str) -> int:
+    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+        cur.execute(
+            psycopg.sql.SQL("SELECT COUNT(*) FROM {}").format(  # table is hard-coded
+                psycopg.sql.Identifier(table)
+            )
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+
+
+def test_sync_mirrors_fresh_insert(conn: psycopg.Connection[Any]) -> None:
+    """Spec §8.2: first sync inserts copy_traders + copy_mirrors +
+    copy_mirror_positions rows with active=TRUE."""
+    payload = two_mirror_payload()
+    result = sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+
+    assert _count(conn, "copy_traders") == 2
+    assert _count(conn, "copy_mirrors") == 2
+    assert _count(conn, "copy_mirror_positions") == 6
+    assert result.mirrors_upserted == 2
+    assert result.mirror_positions_upserted == 6
+    assert result.mirrors_closed == 0
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT active, closed_at FROM copy_mirrors ORDER BY mirror_id")
+        rows = cur.fetchall()
+    for row in rows:
+        assert row["active"] is True
+        assert row["closed_at"] is None
+
+
+def test_sync_mirrors_idempotent_resync(conn: psycopg.Connection[Any]) -> None:
+    """Spec §8.2: re-running the same payload is idempotent —
+    row counts unchanged, active still TRUE, updated_at refreshed."""
+    payload = two_mirror_payload()
+    sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+    sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+
+    assert _count(conn, "copy_traders") == 2
+    assert _count(conn, "copy_mirrors") == 2
+    assert _count(conn, "copy_mirror_positions") == 6


### PR DESCRIPTION
## Summary

Track 1a of the copy-trading ingestion design (#183). Adds first-class ingestion of the `clientPortfolio.mirrors[]` payload returned by eToro's `/portfolio` endpoint into three new sibling tables, with strict-raise parsing, per-mirror upsert, nested-position eviction, and soft-close / total-disappearance handling.

This is **Track 1a only**. The follow-up tracks remain to be delivered:
- **Track 1b (#187)** — AUM correction helper + 3 call sites (§3.4 / §6.0–6.3 / §8.4–8.6)
- **Track 1.5 (#188)** — Operator browsing UX for mirrors
- **Track 2 (#189)** — `/user-info/people/*` discovery

Spec: [docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md](docs/superpowers/specs/2026-04-11-copy-trading-ingestion-design.md)
Plan: [docs/superpowers/plans/2026-04-11-copy-trading-ingestion-track-1a.md](docs/superpowers/plans/2026-04-11-copy-trading-ingestion-track-1a.md)

## Schema (migration 022)

Three new sibling tables; existing tables untouched.

- `copy_traders(parent_cid PK, parent_username, first_seen_at, updated_at)` — one row per eToro trader identity.
- `copy_mirrors(mirror_id PK, parent_cid FK, initial_investment/deposit/withdrawal/available_amount/closed_positions_net_profit, stop_loss_*, mirror_status_id, mirror_calculation_type, pending_for_closure, started_copy_date, active BOOL, closed_at NULL, raw_payload JSONB, updated_at)` — one row per copy relationship. Partial index on `active` for fast scans.
- `copy_mirror_positions((mirror_id, position_id) PK, parent_position_id, instrument_id, is_buy, units, amount, initial_amount_in_dollars, open_rate, open_conversion_rate, open_date_time, take_profit_rate, stop_loss_rate, total_fees, leverage, raw_payload JSONB, updated_at)` — one row per nested position. `ON DELETE CASCADE` from `copy_mirrors.mirror_id`.

`updated_at DEFAULT NOW()` only fires on INSERT; all `ON CONFLICT DO UPDATE` paths in `_sync_mirrors` explicitly refresh `updated_at = %(now)s`. This contract is documented in the migration comment block and in the Python helper.

## Parser contract

- `PortfolioParseError(Exception)` — direct `Exception` subclass (not `ValueError`/`TypeError`/`KeyError`/`DecimalException`), so the outer catch list can't accidentally swallow it.
- `_parse_mirror_position` — normalises one nested position, raises on missing `openConversionRate` or non-numeric fields.
- `_parse_mirror` — builds a `BrokerMirror`, wraps any nested failure in `PortfolioParseError(f"Mirror {mid!r} position[{idx}]: {exc}") from exc` for debuggable attribution.
- `_parse_mirrors_payload` — outer loop. Log-and-skip only for rows with no `mirrorID`; **any** known-mirror failure (nested or top-level) raises, so a sync can never silently reinterpret a corrupted payload as "mirror disappeared". This closes the Codex v3 Finding V parse-and-soft-close hole.

## Sync contract (`_sync_mirrors`)

Called from `sync_portfolio` after the existing position/cash sync, inside the same transaction.

1. **Upsert `copy_traders`** (`ON CONFLICT (parent_cid) DO UPDATE`).
2. **Upsert `copy_mirrors`** (`ON CONFLICT (mirror_id) DO UPDATE`). The update clause resets `active=TRUE, closed_at=NULL` — **this is the re-copy resurrection path** for a previously-soft-closed mirror_id eToro has started copying again.
3a. **Evict nested positions** that have closed since the last sync: `DELETE ... WHERE mirror_id = ? AND position_id <> ALL(?::bigint[])`. Exploits Postgres's `<> ALL('{}')` === TRUE semantics so the empty-array case correctly deletes every row without a special branch.
3b. **Upsert every current position** (`ON CONFLICT (mirror_id, position_id) DO UPDATE`).
4. **Disappearance handling (§2.3.4)** — after the per-mirror loop:
   - **Total disappearance** (`mirrors[]` empty AND local active rows exist) → `RuntimeError` to force operator investigation. No mass soft-close.
   - **Partial disappearance** → `UPDATE copy_mirrors SET active=FALSE, closed_at=%(now)s WHERE mirror_id = ANY(%(disappeared)s)`. Nested positions are **retained** for audit; the §3.4 AUM query's `WHERE m.active` filter excludes them from forward-looking calculations.

`PortfolioSyncResult` gains three counters: `mirrors_upserted`, `mirrors_closed`, `mirror_positions_upserted`, surfaced in the scheduler's daily-sync INFO line so operators see mirror activity in `job_runs` without querying the DB.

## Security model

- **Read-only from broker, write-only to local DB.** No new outgoing network call, no new order-placing path, no new un-copy UX.
- No new cross-user data flow. Data only flows from eToro `/portfolio` → local Postgres.
- The execution guard's rule queries are unchanged — they still read `FROM positions` only. Mirror-based AUM correction is Track 1b's responsibility.
- The parser's strict-raise discipline means a malformed payload triggers a transaction rollback before any row is written, so a partial ingestion can never leave the DB in an inconsistent state.

## Tests

- [tests/test_copy_mirrors_parser.py](tests/test_copy_mirrors_parser.py) — 16 parser tests covering the `PortfolioParseError` hierarchy, `_parse_mirror_position` happy path + required-field failures, `_parse_mirror` nested wrap with position-index attribution, and `_parse_mirrors_payload` outer loop (happy path, log-and-skip unrecognisable, known-mirror strict-raise, nested failure propagation).
- [tests/test_portfolio_sync_mirrors.py](tests/test_portfolio_sync_mirrors.py) — 11 integration tests against `ebull_test` covering fresh insert, idempotent resync, nested position eviction (partial + total), partial-disappearance soft-close, re-copy resurrection, total-disappearance raise, parser-failure rollback (nested), known-mirror top-level parse failure (Codex v3 Finding V regression).
- [tests/fixtures/copy_mirrors.py](tests/fixtures/copy_mirrors.py) — new fixtures package owning `_NOW`, `_GUARD_INSTRUMENT_ID`, and the `two_mirror_payload` / `parse_failure_payload` / `two_mirror_seed_rows` builders. The existing [tests/test_portfolio_sync.py](tests/test_portfolio_sync.py) migrates to import `_NOW` from this module (no behaviour change).

Full suite: **1134 passed, 1 skipped**. Pre-push gate (ruff check, ruff format --check, pyright, pytest) green.

## Tradeoffs consciously accepted

- **Nested positions retained on soft-closed mirrors.** Keeps audit history at the cost of some dead rows. The §3.4 AUM query's `active` filter is the forward-looking gate.
- **Total disappearance raises rather than auto-closes.** Asymmetric with partial disappearance, deliberately. An empty `mirrors[]` is much more likely to be an upstream API regression than a real event.
- **Re-copy reuses the existing `ON CONFLICT DO UPDATE` clause** rather than a separate resurrection path. The update clause always resets `active=TRUE, closed_at=NULL`, which is correct whether or not the row was previously closed.
- **Fresh fixtures module rather than hanging helpers off the existing test file.** Shared fixtures across parser and sync tests would be awkward if co-located with one test module. [tests/fixtures/copy_mirrors.py](tests/fixtures/copy_mirrors.py) is the deliberate home.

## Test plan

- [ ] Pre-push gate green (ruff check, ruff format --check, pyright, pytest) — confirmed locally before push
- [ ] Smoke test `tests/smoke/test_app_boots.py` still passes end-to-end — included in full pytest run
- [ ] Claude review passes on most recent commit
- [ ] CI green on most recent commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)