### PR TITLE
feat(#215): portfolio valuation fallback + independent FX source

### DIFF
--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -64,6 +64,7 @@ class PositionItem(BaseModel):
     cost_basis: float
     market_value: float
     unrealized_pnl: float
+    valuation_source: str  # "quote", "daily_close", or "cost_basis"
     source: PositionSource
     updated_at: datetime
 
@@ -108,15 +109,23 @@ def _parse_position(
     current_units = float(row["current_units"])  # type: ignore[arg-type]
     native_currency: str = str(row.get("currency") or "USD")  # fallback for un-enriched
 
-    # Mark-to-market: use quote last price when available, else fall back to cost_basis.
+    # Mark-to-market hierarchy: quote.last → price_daily.close → cost_basis.
+    # valuation_source tells the dashboard which tier produced the value.
     last_price = parse_optional_float(row, "last")
+    daily_close = parse_optional_float(row, "daily_close")
+
     if last_price is not None:
         market_value = current_units * last_price
         unrealized_pnl = market_value - cost_basis
+        valuation_source = "quote"
+    elif daily_close is not None:
+        market_value = current_units * daily_close
+        unrealized_pnl = market_value - cost_basis
+        valuation_source = "daily_close"
     else:
-        # No quote — fall back to cost_basis; no P&L signal.
         market_value = cost_basis
         unrealized_pnl = 0.0
+        valuation_source = "cost_basis"
 
     # Convert monetary values to display currency.
     if native_currency != display_currency:
@@ -148,6 +157,7 @@ def _parse_position(
         cost_basis=cost_basis,
         market_value=market_value,
         unrealized_pnl=unrealized_pnl,
+        valuation_source=valuation_source,
         source=row["source"],  # type: ignore[arg-type]
         updated_at=row["updated_at"],  # type: ignore[arg-type]
     )
@@ -236,14 +246,25 @@ def get_portfolio(
     # Zero-unit positions are excluded: fully liquidated positions should not
     # appear in the portfolio view or inflate AUM.
     # i.currency: the instrument's native currency for FX conversion.
+    # LEFT JOIN quotes (1:1 by PK) and latest price_daily (DISTINCT ON
+    # avoids fan-out — one row per instrument, most recent date).
     positions_sql = """
         SELECT p.instrument_id, i.symbol, i.company_name, i.currency,
                p.open_date, p.avg_cost, p.current_units, p.cost_basis,
                p.source, p.updated_at,
-               q.last
+               q.last,
+               pd.close AS daily_close
         FROM positions p
         JOIN instruments i USING (instrument_id)
         LEFT JOIN quotes q USING (instrument_id)
+        LEFT JOIN LATERAL (
+            SELECT close
+            FROM price_daily
+            WHERE instrument_id = p.instrument_id
+              AND close IS NOT NULL
+            ORDER BY price_date DESC
+            LIMIT 1
+        ) pd ON true
         WHERE p.current_units > 0
         ORDER BY p.cost_basis DESC, p.instrument_id ASC
     """

--- a/app/providers/implementations/frankfurter.py
+++ b/app/providers/implementations/frankfurter.py
@@ -1,0 +1,59 @@
+"""
+Frankfurter FX rate provider.
+
+Fetches ECB reference exchange rates from the Frankfurter API
+(https://frankfurter.dev/). No API key required.
+
+ECB publishes rates daily around 16:00 CET on working days.
+Rates are informational reference rates — suitable for display
+currency conversion, not for trade execution pricing.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.frankfurter.dev"
+_TIMEOUT_S = 15.0
+
+
+def fetch_latest_rates(
+    base: str,
+    targets: list[str],
+) -> dict[tuple[str, str], Decimal]:
+    """Fetch latest ECB rates for base → each target currency.
+
+    Returns a dict keyed by (from_currency, to_currency) → rate.
+    Rate semantics: 1 unit of ``base`` = ``rate`` units of ``target``.
+
+    Raises on network/HTTP errors — caller should handle.
+    """
+    if not targets:
+        return {}
+
+    # Frankfurter API: GET /v1/latest?base=USD&symbols=GBP,EUR
+    symbols = ",".join(targets)
+    with httpx.Client(timeout=_TIMEOUT_S) as client:
+        response = client.get(
+            f"{_BASE_URL}/v1/latest",
+            params={"base": base, "symbols": symbols},
+        )
+        response.raise_for_status()
+
+    data = response.json()
+    raw_rates: dict[str, object] = data.get("rates", {})
+
+    result: dict[tuple[str, str], Decimal] = {}
+    for ccy, value in raw_rates.items():
+        if value is not None:
+            try:
+                result[(base, ccy)] = Decimal(str(value))
+            except Exception:
+                logger.warning("Failed to parse Frankfurter rate %s→%s: %s", base, ccy, value)
+
+    return result

--- a/app/providers/implementations/frankfurter.py
+++ b/app/providers/implementations/frankfurter.py
@@ -25,16 +25,20 @@ _TIMEOUT_S = 15.0
 def fetch_latest_rates(
     base: str,
     targets: list[str],
-) -> dict[tuple[str, str], Decimal]:
+) -> tuple[dict[tuple[str, str], Decimal], str | None]:
     """Fetch latest ECB rates for base → each target currency.
 
-    Returns a dict keyed by (from_currency, to_currency) → rate.
+    Returns ``(rates, ecb_date)`` where *rates* is keyed by
+    ``(from_currency, to_currency) → rate`` and *ecb_date* is the ISO
+    date string from the API response (e.g. ``"2026-04-11"``).  On
+    weekends/holidays the date reflects the last ECB publication day.
+
     Rate semantics: 1 unit of ``base`` = ``rate`` units of ``target``.
 
     Raises on network/HTTP errors — caller should handle.
     """
     if not targets:
-        return {}
+        return {}, None
 
     # Frankfurter API: GET /v1/latest?base=USD&symbols=GBP,EUR
     symbols = ",".join(targets)
@@ -46,6 +50,7 @@ def fetch_latest_rates(
         response.raise_for_status()
 
     data = response.json()
+    ecb_date: str | None = data.get("date")
     raw_rates: dict[str, object] = data.get("rates", {})
 
     result: dict[tuple[str, str], Decimal] = {}
@@ -56,4 +61,4 @@ def fetch_latest_rates(
             except Exception:
                 logger.warning("Failed to parse Frankfurter rate %s→%s: %s", base, ccy, value)
 
-    return result
+    return result, ecb_date

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1242,7 +1242,14 @@ def fx_rates_refresh() -> None:
         # Fetch USD → every other supported currency.
         targets = sorted(c for c in SUPPORTED_CURRENCIES if c != "USD")
         try:
-            ecb_rates = fetch_latest_rates("USD", targets)
+            ecb_rates, ecb_date = fetch_latest_rates("USD", targets)
+            # Use the ECB publication date for quoted_at so freshness
+            # checks reflect when the rate was actually set, not when
+            # we fetched it (matters on weekends/holidays).
+            if ecb_date is not None:
+                ecb_quoted_at = datetime.fromisoformat(ecb_date).replace(tzinfo=UTC)
+            else:
+                ecb_quoted_at = datetime.now(UTC)
             with psycopg.connect(settings.database_url) as conn:
                 with conn.transaction():
                     for (from_ccy, to_ccy), rate in ecb_rates.items():
@@ -1251,10 +1258,15 @@ def fx_rates_refresh() -> None:
                             from_currency=from_ccy,
                             to_currency=to_ccy,
                             rate=rate,
-                            quoted_at=datetime.now(UTC),
+                            quoted_at=ecb_quoted_at,
                         )
                         fx_rows_written += 1
-            logger.info("fx_rates_refresh: Frankfurter ECB rates written: %d pairs", fx_rows_written)
+                conn.commit()
+            logger.info(
+                "fx_rates_refresh: Frankfurter ECB rates written: %d pairs (date=%s)",
+                fx_rows_written,
+                ecb_date,
+            )
         except Exception:
             logger.warning("fx_rates_refresh: Frankfurter fetch failed, continuing with eToro fallback", exc_info=True)
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1361,6 +1361,7 @@ def fx_rates_refresh() -> None:
                                     q.instrument_id,
                                     exc_info=True,
                                 )
+                        conn.commit()
                     else:
                         logger.info("fx_rates_refresh: no covered instruments for eToro quotes")
             except Exception:

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -254,9 +254,10 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_FX_RATES_REFRESH,
-        description="Refresh live FX rates from eToro conversion rates.",
+        description="Refresh live FX rates (Frankfurter primary, eToro secondary).",
         cadence=Cadence.hourly(minute=0),
-        prerequisite=_has_coverage_tier12,
+        # No prerequisite: Frankfurter FX is independent of instrument coverage.
+        # The eToro quote refresh inside the job self-guards on coverage.
     ),
     ScheduledJob(
         name=JOB_DAILY_RESEARCH_REFRESH,
@@ -451,6 +452,26 @@ def _load_etoro_credentials(job_name: str) -> tuple[str, str] | None:
         logger.error("%s: %s, skipping", job_name, exc)
         return None
     return (api_key, user_key)
+
+
+def _promote_held_to_tier1(conn: psycopg.Connection[Any]) -> int:
+    """Promote instruments with open positions to coverage Tier 1.
+
+    Returns the number of instruments promoted. Idempotent — instruments
+    already at Tier 1 are untouched. Must be called inside an open
+    transaction (the caller commits).
+    """
+    result = conn.execute(
+        """
+        UPDATE coverage
+        SET coverage_tier = 1
+        WHERE instrument_id IN (
+            SELECT instrument_id FROM positions WHERE current_units > 0
+        )
+          AND coverage_tier != 1
+        """
+    )
+    return result.rowcount
 
 
 def nightly_universe_sync() -> None:
@@ -902,7 +923,15 @@ def daily_portfolio_sync() -> None:
 
         with psycopg.connect(settings.database_url) as conn:
             result = sync_portfolio(conn, portfolio)
+
+            # Auto-promote held instruments to Tier 1 so market data,
+            # FX rates, and downstream jobs fire for them. Without this,
+            # newly synced positions stay at Tier 3 and all jobs skip.
+            promoted = _promote_held_to_tier1(conn)
             conn.commit()
+
+        if promoted:
+            logger.info("Portfolio sync: auto-promoted %d held instruments to Tier 1", promoted)
 
         tracker.row_count = (
             result.positions_updated + result.positions_opened_externally + result.positions_closed_externally
@@ -1185,128 +1214,147 @@ def weekly_coverage_review() -> None:
 
 
 def fx_rates_refresh() -> None:
-    """Refresh live FX rates and quotes from eToro conversion rates.
+    """Refresh live FX rates and quotes.
 
-    The eToro rates endpoint returns ``conversionRateAsk``/``conversionRateBid``
-    on every quote response. These represent the instrument's native currency →
-    account currency (USD) conversion rate. This job:
+    Two-source strategy:
 
-    1. Batch-fetches quotes for all covered Tier 1/2 instruments.
-    2. Extracts unique currency → USD conversion rates from the response.
-    3. Upserts each rate pair into ``live_fx_rates`` for display-currency
-       conversion.
-    4. Also upserts the quotes themselves into the ``quotes`` table so
-       quote freshness stays hourly (candle refresh runs daily at 22:00).
+    1. **Frankfurter (primary FX):** Fetch ECB reference rates for all
+       supported display currencies. No API key, no coverage prerequisite.
+       Runs unconditionally.
 
-    Runs hourly at :00. Requires Tier 1/2 coverage rows.
+    2. **eToro quotes (secondary):** Batch-fetch quotes for covered Tier 1/2
+       instruments. Extracts eToro-specific conversion rates as a supplement,
+       and upserts quotes for hourly freshness. Skips gracefully if eToro
+       credentials are missing or the rates endpoint fails.
+
+    Runs hourly at :00.
     """
+    from app.providers.implementations.frankfurter import fetch_latest_rates
     from app.services.fx import upsert_live_fx_rate
     from app.services.market_data import compute_spread_pct
-
-    creds = _load_etoro_credentials("fx_rates_refresh")
-    if creds is None:
-        return
-
-    api_key, user_key = creds
+    from app.services.runtime_config import SUPPORTED_CURRENCIES
 
     with _tracked_job(JOB_FX_RATES_REFRESH) as tracker:
-        with (
-            EtoroMarketDataProvider(api_key=api_key, user_key=user_key, env=settings.etoro_env) as provider,
-            psycopg.connect(settings.database_url) as conn,
-        ):
-            rows = conn.execute(
-                """
-                SELECT i.instrument_id, i.symbol, i.currency
-                FROM instruments i
-                JOIN coverage c ON c.instrument_id = i.instrument_id
-                WHERE i.is_tradable = TRUE
-                  AND c.coverage_tier IN (1, 2)
-                ORDER BY i.symbol
-                """
-            ).fetchall()
+        fx_rows_written = 0
+        quotes_updated = 0
 
-            if not rows:
-                logger.info("fx_rates_refresh: no covered instruments found, skipping")
-                tracker.row_count = 0
-                return
-
-            instrument_ids = [row[0] for row in rows]
-            currency_map: dict[int, str | None] = {row[0]: row[2] for row in rows}
-
-            quotes = provider.get_quotes(instrument_ids)
-
-            # --- Extract FX rates from conversion_rate fields ---
-            # Group by currency to get the latest rate per unique pair.
-            # eToro conversion rates are instrument_ccy → USD.
-            fx_pairs: dict[str, tuple[Decimal, datetime]] = {}  # ccy → (rate, ts)
-            for q in quotes:
-                if q.conversion_rate is None:
-                    continue
-                ccy = currency_map.get(q.instrument_id)
-                if ccy is None or ccy == "USD":
-                    continue
-                # Keep the most recent timestamp per currency.
-                existing = fx_pairs.get(ccy)
-                if existing is None or q.timestamp > existing[1]:
-                    fx_pairs[ccy] = (q.conversion_rate, q.timestamp)
-
-            fx_rows_written = 0
-            with conn.transaction():
-                for ccy, (rate, ts) in fx_pairs.items():
-                    # Store the direct pair: ccy → USD
-                    upsert_live_fx_rate(
-                        conn,
-                        from_currency=ccy,
-                        to_currency="USD",
-                        rate=rate,
-                        quoted_at=ts,
-                    )
-                    fx_rows_written += 1
-
-            # --- Upsert quotes for hourly freshness ---
-            max_spread_pct = Decimal("1.0")
-            quotes_updated = 0
-            for q in quotes:
-                try:
-                    spread_pct = compute_spread_pct(q.bid, q.ask)
-                    spread_flag = spread_pct is not None and spread_pct > max_spread_pct
-                    with conn.transaction():
-                        conn.execute(
-                            """
-                            INSERT INTO quotes (
-                                instrument_id, quoted_at, bid, ask, last, spread_pct, spread_flag
-                            )
-                            VALUES (
-                                %(instrument_id)s, %(quoted_at)s, %(bid)s, %(ask)s,
-                                %(last)s, %(spread_pct)s, %(spread_flag)s
-                            )
-                            ON CONFLICT (instrument_id) DO UPDATE SET
-                                quoted_at   = EXCLUDED.quoted_at,
-                                bid         = EXCLUDED.bid,
-                                ask         = EXCLUDED.ask,
-                                last        = EXCLUDED.last,
-                                spread_pct  = EXCLUDED.spread_pct,
-                                spread_flag = EXCLUDED.spread_flag
-                            """,
-                            {
-                                "instrument_id": q.instrument_id,
-                                "quoted_at": q.timestamp,
-                                "bid": q.bid,
-                                "ask": q.ask,
-                                "last": q.last,
-                                "spread_pct": spread_pct,
-                                "spread_flag": spread_flag,
-                            },
+        # --- Phase 1: Frankfurter ECB rates (always runs) ---
+        # Fetch USD → every other supported currency.
+        targets = sorted(c for c in SUPPORTED_CURRENCIES if c != "USD")
+        try:
+            ecb_rates = fetch_latest_rates("USD", targets)
+            with psycopg.connect(settings.database_url) as conn:
+                with conn.transaction():
+                    for (from_ccy, to_ccy), rate in ecb_rates.items():
+                        upsert_live_fx_rate(
+                            conn,
+                            from_currency=from_ccy,
+                            to_currency=to_ccy,
+                            rate=rate,
+                            quoted_at=datetime.now(UTC),
                         )
-                        quotes_updated += 1
-                except Exception:
-                    logger.warning(
-                        "fx_rates_refresh: failed to upsert quote for instrument %d",
-                        q.instrument_id,
-                        exc_info=True,
-                    )
+                        fx_rows_written += 1
+            logger.info("fx_rates_refresh: Frankfurter ECB rates written: %d pairs", fx_rows_written)
+        except Exception:
+            logger.warning("fx_rates_refresh: Frankfurter fetch failed, continuing with eToro fallback", exc_info=True)
 
-            tracker.row_count = fx_rows_written + quotes_updated
+        # --- Phase 2: eToro quotes + conversion rates (best-effort) ---
+        creds = _load_etoro_credentials("fx_rates_refresh")
+        if creds is not None:
+            api_key, user_key = creds
+            try:
+                with (
+                    EtoroMarketDataProvider(api_key=api_key, user_key=user_key, env=settings.etoro_env) as provider,
+                    psycopg.connect(settings.database_url) as conn,
+                ):
+                    rows = conn.execute(
+                        """
+                        SELECT i.instrument_id, i.symbol, i.currency
+                        FROM instruments i
+                        JOIN coverage c ON c.instrument_id = i.instrument_id
+                        WHERE i.is_tradable = TRUE
+                          AND c.coverage_tier IN (1, 2)
+                        ORDER BY i.symbol
+                        """
+                    ).fetchall()
+
+                    if rows:
+                        instrument_ids = [row[0] for row in rows]
+                        currency_map: dict[int, str | None] = {row[0]: row[2] for row in rows}
+
+                        quotes = provider.get_quotes(instrument_ids)
+
+                        # Extract eToro-specific conversion rates as a supplement.
+                        fx_pairs: dict[str, tuple[Decimal, datetime]] = {}
+                        for q in quotes:
+                            if q.conversion_rate is None:
+                                continue
+                            ccy = currency_map.get(q.instrument_id)
+                            if ccy is None or ccy == "USD":
+                                continue
+                            existing = fx_pairs.get(ccy)
+                            if existing is None or q.timestamp > existing[1]:
+                                fx_pairs[ccy] = (q.conversion_rate, q.timestamp)
+
+                        with conn.transaction():
+                            for ccy, (rate, ts) in fx_pairs.items():
+                                upsert_live_fx_rate(
+                                    conn,
+                                    from_currency=ccy,
+                                    to_currency="USD",
+                                    rate=rate,
+                                    quoted_at=ts,
+                                )
+                                fx_rows_written += 1
+
+                        # Upsert quotes for hourly freshness.
+                        max_spread_pct = Decimal("1.0")
+                        for q in quotes:
+                            try:
+                                spread_pct = compute_spread_pct(q.bid, q.ask)
+                                spread_flag = spread_pct is not None and spread_pct > max_spread_pct
+                                with conn.transaction():
+                                    conn.execute(
+                                        """
+                                        INSERT INTO quotes (
+                                            instrument_id, quoted_at, bid, ask, last,
+                                            spread_pct, spread_flag
+                                        )
+                                        VALUES (
+                                            %(instrument_id)s, %(quoted_at)s, %(bid)s, %(ask)s,
+                                            %(last)s, %(spread_pct)s, %(spread_flag)s
+                                        )
+                                        ON CONFLICT (instrument_id) DO UPDATE SET
+                                            quoted_at   = EXCLUDED.quoted_at,
+                                            bid         = EXCLUDED.bid,
+                                            ask         = EXCLUDED.ask,
+                                            last        = EXCLUDED.last,
+                                            spread_pct  = EXCLUDED.spread_pct,
+                                            spread_flag = EXCLUDED.spread_flag
+                                        """,
+                                        {
+                                            "instrument_id": q.instrument_id,
+                                            "quoted_at": q.timestamp,
+                                            "bid": q.bid,
+                                            "ask": q.ask,
+                                            "last": q.last,
+                                            "spread_pct": spread_pct,
+                                            "spread_flag": spread_flag,
+                                        },
+                                    )
+                                    quotes_updated += 1
+                            except Exception:
+                                logger.warning(
+                                    "fx_rates_refresh: failed to upsert quote for instrument %d",
+                                    q.instrument_id,
+                                    exc_info=True,
+                                )
+                    else:
+                        logger.info("fx_rates_refresh: no covered instruments for eToro quotes")
+            except Exception:
+                logger.warning("fx_rates_refresh: eToro quote fetch failed", exc_info=True)
+
+        tracker.row_count = fx_rows_written + quotes_updated
 
     logger.info(
         "fx_rates_refresh complete: fx_pairs=%d quotes=%d",

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1318,6 +1318,7 @@ def fx_rates_refresh() -> None:
                                     quoted_at=ts,
                                 )
                                 fx_rows_written += 1
+                        conn.commit()
 
                         # Upsert quotes for hourly freshness.
                         max_spread_pct = Decimal("1.0")

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -619,6 +619,24 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 
 ---
 
+### `conn.transaction()` without `conn.commit()` silently rolls back in psycopg v3
+
+- First seen in: #216 (Frankfurter ECB rates never persisted)
+- Symptom: `fx_rates_refresh` Phase 1 opened `psycopg.connect()`, wrote FX rates inside `conn.transaction()`, but never called `conn.commit()`. In psycopg v3, `conn.transaction()` creates a savepoint — it does NOT commit the outer implicit transaction. When the `with psycopg.connect()` context exits, the connection closes and PostgreSQL rolls back the uncommitted transaction. Every hourly run wrote rates successfully but silently discarded them.
+- Prevention: Any `psycopg.connect()` block that writes data must include an explicit `conn.commit()` after the `conn.transaction()` savepoint exits. Pre-push check: `grep -Pzo 'with psycopg\.connect.*\n(?:.*\n)*?.*conn\.transaction' app/` — every match must have a corresponding `conn.commit()` before the connection's `with` block ends. This is the inverse of the "Mid-transaction `conn.commit()` in service functions" entry: service functions that *accept* a connection must NOT commit; code that *owns* the connection MUST commit.
+- Enforced in: `docs/review-prevention-log.md`; `app/workers/scheduler.py` (fx_rates_refresh)
+
+---
+
+### External API timestamps must derive from the API response, not `datetime.now()`
+
+- First seen in: #216 (Frankfurter `quoted_at` used `datetime.now(UTC)`)
+- Symptom: `fx_rates_refresh` used `datetime.now(UTC)` as the `quoted_at` timestamp for ECB rates, but the Frankfurter API returns a `date` field reflecting the actual ECB publication date. On weekends/holidays this would record today's timestamp against a rate that was 1–3 days stale, misleading any freshness check on `live_fx_rates`.
+- Prevention: When writing timestamps that represent "when was this data produced", always use the timestamp from the external source's response. `datetime.now()` is only appropriate for "when did we fetch this" — and even then, prefer the source's own timestamp. Pre-push check: `grep -n "datetime.now" app/workers/scheduler.py` — every hit must be justified in a comment or use a provider-supplied timestamp instead.
+- Enforced in: `docs/review-prevention-log.md`; `app/providers/implementations/frankfurter.py` (returns `ecb_date`); `app/workers/scheduler.py` (fx_rates_refresh)
+
+---
+
 ### Quote write ownership must be exclusive to one job
 
 - First seen in: #211 (daily_candle_refresh shadowed hourly quotes)

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -201,6 +201,8 @@ export interface PositionItem {
   cost_basis: number;
   market_value: number;
   unrealized_pnl: number;
+  valuation_source: "quote" | "daily_close" | "cost_basis";
+  source: string;
   updated_at: string;
 }
 

--- a/frontend/src/pages/InstrumentDetailPage.test.tsx
+++ b/frontend/src/pages/InstrumentDetailPage.test.tsx
@@ -405,6 +405,8 @@ describe("InstrumentDetailPage — position", () => {
           cost_basis: 1850,
           market_value: 1910,
           unrealized_pnl: 60,
+          valuation_source: "quote" as const,
+          source: "broker_sync",
           updated_at: "2024-06-01T00:00:00Z",
         },
       ],

--- a/tests/test_frankfurter.py
+++ b/tests/test_frankfurter.py
@@ -13,11 +13,12 @@ from app.providers.implementations.frankfurter import fetch_latest_rates
 
 class TestFetchLatestRates:
     def test_empty_targets_returns_empty(self) -> None:
-        result = fetch_latest_rates("USD", [])
-        assert result == {}
+        rates, ecb_date = fetch_latest_rates("USD", [])
+        assert rates == {}
+        assert ecb_date is None
 
     @patch("app.providers.implementations.frankfurter.httpx.Client")
-    def test_parses_rates(self, mock_client_cls: MagicMock) -> None:
+    def test_parses_rates_and_date(self, mock_client_cls: MagicMock) -> None:
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "base": "USD",
@@ -31,12 +32,13 @@ class TestFetchLatestRates:
         mock_client.__exit__ = MagicMock(return_value=False)
         mock_client_cls.return_value = mock_client
 
-        result = fetch_latest_rates("USD", ["GBP", "EUR"])
+        rates, ecb_date = fetch_latest_rates("USD", ["GBP", "EUR"])
 
-        assert ("USD", "GBP") in result
-        assert ("USD", "EUR") in result
-        assert result[("USD", "GBP")] == Decimal("0.7812")
-        assert result[("USD", "EUR")] == Decimal("0.9234")
+        assert ("USD", "GBP") in rates
+        assert ("USD", "EUR") in rates
+        assert rates[("USD", "GBP")] == Decimal("0.7812")
+        assert rates[("USD", "EUR")] == Decimal("0.9234")
+        assert ecb_date == "2026-04-13"
 
     @patch("app.providers.implementations.frankfurter.httpx.Client")
     def test_http_error_propagates(self, mock_client_cls: MagicMock) -> None:
@@ -66,8 +68,8 @@ class TestFetchLatestRates:
         mock_client.__exit__ = MagicMock(return_value=False)
         mock_client_cls.return_value = mock_client
 
-        result = fetch_latest_rates("USD", ["GBP", "EUR"])
+        rates, _ecb_date = fetch_latest_rates("USD", ["GBP", "EUR"])
 
         # GBP should still be parsed (Decimal("not_a_number") actually raises)
         # but EUR should succeed
-        assert ("USD", "EUR") in result
+        assert ("USD", "EUR") in rates

--- a/tests/test_frankfurter.py
+++ b/tests/test_frankfurter.py
@@ -1,0 +1,73 @@
+"""Tests for app.providers.implementations.frankfurter."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app.providers.implementations.frankfurter import fetch_latest_rates
+
+
+class TestFetchLatestRates:
+    def test_empty_targets_returns_empty(self) -> None:
+        result = fetch_latest_rates("USD", [])
+        assert result == {}
+
+    @patch("app.providers.implementations.frankfurter.httpx.Client")
+    def test_parses_rates(self, mock_client_cls: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "base": "USD",
+            "date": "2026-04-13",
+            "rates": {"GBP": 0.7812, "EUR": 0.9234},
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result = fetch_latest_rates("USD", ["GBP", "EUR"])
+
+        assert ("USD", "GBP") in result
+        assert ("USD", "EUR") in result
+        assert result[("USD", "GBP")] == Decimal("0.7812")
+        assert result[("USD", "EUR")] == Decimal("0.9234")
+
+    @patch("app.providers.implementations.frankfurter.httpx.Client")
+    def test_http_error_propagates(self, mock_client_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=MagicMock()
+        )
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(httpx.HTTPStatusError):
+            fetch_latest_rates("USD", ["GBP"])
+
+    @patch("app.providers.implementations.frankfurter.httpx.Client")
+    def test_skips_unparseable_rate(self, mock_client_cls: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "rates": {"GBP": "not_a_number", "EUR": 0.92},
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result = fetch_latest_rates("USD", ["GBP", "EUR"])
+
+        # GBP should still be parsed (Decimal("not_a_number") actually raises)
+        # but EUR should succeed
+        assert ("USD", "EUR") in result

--- a/tests/test_portfolio_valuation.py
+++ b/tests/test_portfolio_valuation.py
@@ -1,0 +1,99 @@
+"""Tests for portfolio valuation hierarchy: quote → daily_close → cost_basis."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from app.api.portfolio import _parse_position
+
+
+def _row(
+    *,
+    instrument_id: int = 1,
+    symbol: str = "AAPL",
+    company_name: str = "Apple Inc.",
+    currency: str = "USD",
+    open_date: date | None = date(2024, 1, 1),
+    avg_cost: float = 150.0,
+    current_units: float = 10.0,
+    cost_basis: float = 1500.0,
+    source: str = "broker_sync",
+    updated_at: datetime = datetime(2026, 4, 13, 12, 0, tzinfo=UTC),
+    last: float | None = None,
+    daily_close: float | None = None,
+) -> dict[str, object]:
+    return {
+        "instrument_id": instrument_id,
+        "symbol": symbol,
+        "company_name": company_name,
+        "currency": currency,
+        "open_date": open_date,
+        "avg_cost": avg_cost,
+        "current_units": current_units,
+        "cost_basis": cost_basis,
+        "source": source,
+        "updated_at": updated_at,
+        "last": last,
+        "daily_close": daily_close,
+    }
+
+
+class TestValuationHierarchy:
+    """Verify the three-tier pricing fallback: quote → daily_close → cost_basis."""
+
+    def test_quote_is_primary(self) -> None:
+        """When quote.last exists, use it regardless of daily_close."""
+        row = _row(current_units=10.0, cost_basis=1500.0, last=160.0, daily_close=155.0)
+        rates: dict[tuple[str, str], Decimal] = {}
+        pos = _parse_position(row, "USD", rates)
+
+        assert pos.valuation_source == "quote"
+        assert pos.market_value == 10.0 * 160.0
+        assert pos.unrealized_pnl == (10.0 * 160.0) - 1500.0
+
+    def test_daily_close_is_secondary(self) -> None:
+        """When no quote but daily_close exists, use daily_close."""
+        row = _row(current_units=10.0, cost_basis=1500.0, last=None, daily_close=155.0)
+        rates: dict[tuple[str, str], Decimal] = {}
+        pos = _parse_position(row, "USD", rates)
+
+        assert pos.valuation_source == "daily_close"
+        assert pos.market_value == 10.0 * 155.0
+        assert pos.unrealized_pnl == (10.0 * 155.0) - 1500.0
+
+    def test_cost_basis_is_fallback(self) -> None:
+        """When neither quote nor daily_close exists, fall back to cost_basis."""
+        row = _row(current_units=10.0, cost_basis=1500.0, last=None, daily_close=None)
+        rates: dict[tuple[str, str], Decimal] = {}
+        pos = _parse_position(row, "USD", rates)
+
+        assert pos.valuation_source == "cost_basis"
+        assert pos.market_value == 1500.0
+        assert pos.unrealized_pnl == 0.0
+
+    def test_fx_conversion_applied_to_daily_close(self) -> None:
+        """Daily close values are converted to display currency."""
+        row = _row(currency="USD", current_units=10.0, cost_basis=1500.0, daily_close=155.0)
+        rates = {("USD", "GBP"): Decimal("0.78")}
+        pos = _parse_position(row, "GBP", rates)
+
+        assert pos.valuation_source == "daily_close"
+        # market_value = 10 * 155 * 0.78 = 1209.0
+        expected_mv = float(Decimal("1550.0") * Decimal("0.78"))
+        assert abs(pos.market_value - expected_mv) < 0.01
+
+    def test_zero_last_price_is_not_none(self) -> None:
+        """A quote.last of 0.0 is a valid price, not a missing value.
+
+        This matters for instruments that can trade at very low prices.
+        parse_optional_float returns 0.0 for zero values, so the quote
+        path should be chosen.
+        """
+        row = _row(current_units=100.0, cost_basis=500.0, last=0.0, daily_close=5.0)
+        rates: dict[tuple[str, str], Decimal] = {}
+        pos = _parse_position(row, "USD", rates)
+
+        # parse_optional_float returns 0.0 for a zero value, which is not None
+        assert pos.valuation_source == "quote"
+        assert pos.market_value == 0.0

--- a/tests/test_promote_held.py
+++ b/tests/test_promote_held.py
@@ -1,0 +1,34 @@
+"""Tests for _promote_held_to_tier1 in scheduler."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.workers.scheduler import _promote_held_to_tier1
+
+
+class TestPromoteHeldToTier1:
+    def test_promotes_held_instruments(self) -> None:
+        conn = MagicMock()
+        result = MagicMock()
+        result.rowcount = 3
+        conn.execute.return_value = result
+
+        promoted = _promote_held_to_tier1(conn)
+
+        assert promoted == 3
+        sql = conn.execute.call_args[0][0]
+        assert "UPDATE coverage" in sql
+        assert "coverage_tier = 1" in sql
+        assert "current_units > 0" in sql
+        assert "coverage_tier != 1" in sql
+
+    def test_zero_when_all_already_tier1(self) -> None:
+        conn = MagicMock()
+        result = MagicMock()
+        result.rowcount = 0
+        conn.execute.return_value = result
+
+        promoted = _promote_held_to_tier1(conn)
+
+        assert promoted == 0


### PR DESCRIPTION
## Summary

Unblocks the dashboard when the eToro rates endpoint is down (returning 500 for 3+ days).

- **Portfolio valuation hierarchy**: `quote.last` → `price_daily.close` → `cost_basis`. Adds `valuation_source` field so the frontend knows when it's showing degraded data. Uses `LATERAL` subquery for latest daily close (no fan-out risk).
- **Frankfurter FX provider**: Fetches ECB reference rates (USD→GBP, USD→EUR) independently of eToro. No API key, daily granularity, backed by central bank data. `fx_rates_refresh` no longer requires Tier 1/2 coverage to run.
- **Auto-promote held positions**: `daily_portfolio_sync` promotes instruments with open positions to Tier 1 coverage, breaking the chicken-and-egg where positions exist but all market data jobs skip on Tier 3.
- **Batch resilience** (fixes #212): eToro quote batch fetch wrapped in try/except so failures don't escape the job tracker.

## Security model

- Candle-derived pricing (`daily_close`) is **display-only** — it never satisfies `execution_guard` spread/liquidity checks. The `quotes` table is not written with synthetic data.
- Frankfurter provider is a thin HTTP adapter with no DB access or domain logic.
- FX rates are for display currency conversion only (not trade execution).
- No new auth surfaces. No new user input paths.

## Conscious trade-offs

- Frankfurter is a third-party dependency (no API key, but still an external service). ECB rates update daily ~16:00 CET. Acceptable for demo-first stage.
- `_promote_held_to_tier1` bypasses the normal coverage review promotion path (score thresholds). This is intentional: held instruments must have market data regardless of scoring state.
- The `LATERAL` subquery adds a correlated scan per position row. With 5 positions this is negligible; at scale, an index on `(instrument_id, price_date DESC)` already exists on `price_daily`.

## Files changed

| File | What changed |
|------|-------------|
| `app/providers/implementations/frankfurter.py` | New: thin adapter for Frankfurter ECB rates API |
| `app/workers/scheduler.py` | Rewritten `fx_rates_refresh` (two-source), added `_promote_held_to_tier1`, removed coverage prerequisite from FX job |
| `app/api/portfolio.py` | Three-tier valuation hierarchy, `valuation_source` field, LATERAL JOIN for daily close |
| `frontend/src/api/types.ts` | Added `valuation_source` and `source` to `PositionItem` |
| `frontend/src/pages/InstrumentDetailPage.test.tsx` | Test fixture updated for new fields |
| `tests/test_frankfurter.py` | New: Frankfurter provider tests |
| `tests/test_portfolio_valuation.py` | New: valuation hierarchy tests (quote/daily_close/cost_basis) |
| `tests/test_promote_held.py` | New: auto-promote logic tests |

## Test plan

- [x] `uv run ruff check .` — pass
- [x] `uv run ruff format --check .` — pass
- [x] `uv run pyright` — pass
- [x] `uv run pytest` — 1209 passed
- [x] `pnpm --dir frontend typecheck` — pass
- [x] `pnpm --dir frontend test` — 148 passed

Closes #215. Closes #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)