### PR TITLE
feat: add current_price to portfolio position response

### DIFF
--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -137,6 +137,8 @@ def _parse_position(
             market_value = float(convert(Decimal(str(market_value)), native_currency, display_currency, rates))
             cost_basis = float(convert(Decimal(str(cost_basis)), native_currency, display_currency, rates))
             unrealized_pnl = float(convert(Decimal(str(unrealized_pnl)), native_currency, display_currency, rates))
+            if current_price is not None:
+                current_price = float(convert(Decimal(str(current_price)), native_currency, display_currency, rates))
         except FxRateNotFound:
             logger.warning(
                 "FX rate %s→%s not found; skipping conversion for position",
@@ -145,17 +147,11 @@ def _parse_position(
             )
 
     avg_cost = parse_optional_float(row, "avg_cost")
-    if native_currency != display_currency:
-        if avg_cost is not None:
-            try:
-                avg_cost = float(convert(Decimal(str(avg_cost)), native_currency, display_currency, rates))
-            except FxRateNotFound:
-                pass  # warning already logged above
-        if current_price is not None:
-            try:
-                current_price = float(convert(Decimal(str(current_price)), native_currency, display_currency, rates))
-            except FxRateNotFound:
-                pass
+    if avg_cost is not None and native_currency != display_currency:
+        try:
+            avg_cost = float(convert(Decimal(str(avg_cost)), native_currency, display_currency, rates))
+        except FxRateNotFound:
+            pass  # warning already logged above
 
     return PositionItem(
         instrument_id=row["instrument_id"],  # type: ignore[arg-type]

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -60,6 +60,7 @@ class PositionItem(BaseModel):
     company_name: str
     open_date: date | None
     avg_cost: float | None
+    current_price: float | None
     current_units: float
     cost_basis: float
     market_value: float
@@ -115,14 +116,17 @@ def _parse_position(
     daily_close = parse_optional_float(row, "daily_close")
 
     if last_price is not None:
+        current_price: float | None = last_price
         market_value = current_units * last_price
         unrealized_pnl = market_value - cost_basis
         valuation_source = "quote"
     elif daily_close is not None:
+        current_price = daily_close
         market_value = current_units * daily_close
         unrealized_pnl = market_value - cost_basis
         valuation_source = "daily_close"
     else:
+        current_price = None
         market_value = cost_basis
         unrealized_pnl = 0.0
         valuation_source = "cost_basis"
@@ -141,11 +145,17 @@ def _parse_position(
             )
 
     avg_cost = parse_optional_float(row, "avg_cost")
-    if avg_cost is not None and native_currency != display_currency:
-        try:
-            avg_cost = float(convert(Decimal(str(avg_cost)), native_currency, display_currency, rates))
-        except FxRateNotFound:
-            pass  # warning already logged above
+    if native_currency != display_currency:
+        if avg_cost is not None:
+            try:
+                avg_cost = float(convert(Decimal(str(avg_cost)), native_currency, display_currency, rates))
+            except FxRateNotFound:
+                pass  # warning already logged above
+        if current_price is not None:
+            try:
+                current_price = float(convert(Decimal(str(current_price)), native_currency, display_currency, rates))
+            except FxRateNotFound:
+                pass
 
     return PositionItem(
         instrument_id=row["instrument_id"],  # type: ignore[arg-type]
@@ -153,6 +163,7 @@ def _parse_position(
         company_name=row["company_name"],  # type: ignore[arg-type]
         open_date=row["open_date"],  # type: ignore[arg-type]
         avg_cost=avg_cost,
+        current_price=current_price,
         current_units=current_units,
         cost_basis=cost_basis,
         market_value=market_value,

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -131,7 +131,9 @@ def _parse_position(
         unrealized_pnl = 0.0
         valuation_source = "cost_basis"
 
-    # Convert monetary values to display currency.
+    # Convert all monetary values to display currency in a single block
+    # so they either all convert or all stay in native currency.
+    avg_cost = parse_optional_float(row, "avg_cost")
     if native_currency != display_currency:
         try:
             market_value = float(convert(Decimal(str(market_value)), native_currency, display_currency, rates))
@@ -139,19 +141,14 @@ def _parse_position(
             unrealized_pnl = float(convert(Decimal(str(unrealized_pnl)), native_currency, display_currency, rates))
             if current_price is not None:
                 current_price = float(convert(Decimal(str(current_price)), native_currency, display_currency, rates))
+            if avg_cost is not None:
+                avg_cost = float(convert(Decimal(str(avg_cost)), native_currency, display_currency, rates))
         except FxRateNotFound:
             logger.warning(
                 "FX rate %s→%s not found; skipping conversion for position",
                 native_currency,
                 display_currency,
             )
-
-    avg_cost = parse_optional_float(row, "avg_cost")
-    if avg_cost is not None and native_currency != display_currency:
-        try:
-            avg_cost = float(convert(Decimal(str(avg_cost)), native_currency, display_currency, rates))
-        except FxRateNotFound:
-            pass  # warning already logged above
 
     return PositionItem(
         instrument_id=row["instrument_id"],  # type: ignore[arg-type]

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -197,6 +197,7 @@ export interface PositionItem {
   company_name: string;
   open_date: string | null;
   avg_cost: number | null;
+  current_price: number | null;
   current_units: number;
   cost_basis: number;
   market_value: number;

--- a/frontend/src/pages/InstrumentDetailPage.test.tsx
+++ b/frontend/src/pages/InstrumentDetailPage.test.tsx
@@ -401,6 +401,7 @@ describe("InstrumentDetailPage — position", () => {
           company_name: "Apple Inc.",
           open_date: "2024-03-01",
           avg_cost: 185,
+          current_price: 191,
           current_units: 10,
           cost_basis: 1850,
           market_value: 1910,

--- a/tests/test_portfolio_valuation.py
+++ b/tests/test_portfolio_valuation.py
@@ -49,6 +49,7 @@ class TestValuationHierarchy:
         pos = _parse_position(row, "USD", rates)
 
         assert pos.valuation_source == "quote"
+        assert pos.current_price == 160.0
         assert pos.market_value == 10.0 * 160.0
         assert pos.unrealized_pnl == (10.0 * 160.0) - 1500.0
 
@@ -59,6 +60,7 @@ class TestValuationHierarchy:
         pos = _parse_position(row, "USD", rates)
 
         assert pos.valuation_source == "daily_close"
+        assert pos.current_price == 155.0
         assert pos.market_value == 10.0 * 155.0
         assert pos.unrealized_pnl == (10.0 * 155.0) - 1500.0
 
@@ -69,6 +71,7 @@ class TestValuationHierarchy:
         pos = _parse_position(row, "USD", rates)
 
         assert pos.valuation_source == "cost_basis"
+        assert pos.current_price is None
         assert pos.market_value == 1500.0
         assert pos.unrealized_pnl == 0.0
 
@@ -79,6 +82,9 @@ class TestValuationHierarchy:
         pos = _parse_position(row, "GBP", rates)
 
         assert pos.valuation_source == "daily_close"
+        # current_price = 155 * 0.78 = 120.9
+        expected_price = float(Decimal("155.0") * Decimal("0.78"))
+        assert abs(pos.current_price - expected_price) < 0.01  # type: ignore[operator]
         # market_value = 10 * 155 * 0.78 = 1209.0
         expected_mv = float(Decimal("1550.0") * Decimal("0.78"))
         assert abs(pos.market_value - expected_mv) < 0.01


### PR DESCRIPTION
## Summary
- Add `current_price` field to `PositionItem` — the per-unit price used for valuation
- Value comes from the same three-tier hierarchy: `quote.last` → `daily_close` → `null` (cost_basis fallback has no price signal)
- Converted to display currency alongside `avg_cost` and `market_value`
- Lets the dashboard show the current price directly instead of requiring mental division of `market_value / current_units`

## Security model
No change — read-only field derived from existing data. No new DB queries, no new external calls.

## Test plan
- [x] Backend: `test_portfolio_valuation.py` asserts `current_price` for all three tiers + FX conversion
- [x] Frontend: `InstrumentDetailPage.test.tsx` fixture updated with `current_price`
- [x] All 1209 backend tests pass, 148 frontend tests pass
- [x] Lint, format, typecheck all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)