### PR TITLE
feat: show current price column in positions table

### DIFF
--- a/frontend/src/components/dashboard/PositionsTable.tsx
+++ b/frontend/src/components/dashboard/PositionsTable.tsx
@@ -38,6 +38,7 @@ export function PositionsTable({ positions }: { positions: PositionItem[] }) {
             <Th>Company</Th>
             <Th align="right">Units</Th>
             <Th align="right">Avg cost</Th>
+            <Th align="right">Price</Th>
             <Th align="right">Market value</Th>
             <Th align="right">Unrealized P&L</Th>
           </tr>
@@ -61,6 +62,9 @@ export function PositionsTable({ positions }: { positions: PositionItem[] }) {
                 </Td>
                 <Td align="right">{formatNumber(p.current_units)}</Td>
                 <Td align="right">{formatMoney(p.avg_cost, currency)}</Td>
+                <Td align="right">
+                  {p.current_price != null ? formatMoney(p.current_price, currency) : "—"}
+                </Td>
                 <Td align="right">{formatMoney(p.market_value, currency)}</Td>
                 <Td align="right">
                   <span className={positive ? "text-emerald-600" : "text-red-600"}>


### PR DESCRIPTION
## Summary

- Adds a **Price** column to the portfolio positions table, between Avg cost and Market value
- Renders `current_price` from the portfolio API (added in #217) using `formatMoney`
- Shows an em-dash (—) when no price signal exists (`valuation_source = "cost_basis"`)

## Why

The operator had to mentally divide market_value by units to figure out
the current price. The API already exposes the field — this just surfaces
it in the UI.

## Security model

No new API calls. No new data flows. Read-only rendering of an existing
field from `PortfolioResponse.positions[].current_price`.

## Test plan

- [x] `pnpm --dir frontend typecheck` — passes
- [x] `pnpm --dir frontend test` — 148/148 pass
- [ ] Visual check: positions table shows Price column with formatted values
- [ ] Visual check: positions with `valuation_source = "cost_basis"` show — in Price column

🤖 Generated with [Claude Code](https://claude.com/claude-code)