### PR TITLE
feat(#188): copy-trading browsing UX — endpoint and frontend page

### DIFF
--- a/app/api/copy_trading.py
+++ b/app/api/copy_trading.py
@@ -1,0 +1,314 @@
+"""Copy-trading browsing endpoint (Track 1.5 — issue #188).
+
+Read-only surface over the copy_traders, copy_mirrors, and
+copy_mirror_positions tables delivered by Track 1a (#183).
+
+Returns per-trader cards with mirror-level aggregates and nested
+position breakdowns, all converted to the operator's display currency.
+
+No writes. No schema changes.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.api._helpers import parse_optional_float
+from app.api.auth import require_session_or_service_token
+from app.db import get_conn
+from app.services.fx import FxRateNotFound, convert, load_live_fx_rates_with_metadata
+from app.services.runtime_config import get_runtime_config
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/portfolio/copy-trading",
+    tags=["portfolio"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class MirrorPositionItem(BaseModel):
+    position_id: int
+    instrument_id: int
+    symbol: str | None
+    company_name: str | None
+    is_buy: bool
+    units: float
+    amount: float
+    open_rate: float
+    open_conversion_rate: float
+    open_date_time: datetime
+    current_price: float | None
+    market_value: float
+    unrealized_pnl: float
+
+
+class MirrorSummary(BaseModel):
+    mirror_id: int
+    active: bool
+    initial_investment: float
+    deposit_summary: float
+    withdrawal_summary: float
+    available_amount: float
+    closed_positions_net_profit: float
+    mirror_equity: float
+    position_count: int
+    positions: list[MirrorPositionItem]
+    started_copy_date: datetime
+    closed_at: datetime | None
+
+
+class CopyTraderSummary(BaseModel):
+    parent_cid: int
+    parent_username: str
+    mirrors: list[MirrorSummary]
+    total_equity: float
+
+
+class CopyTradingResponse(BaseModel):
+    traders: list[CopyTraderSummary]
+    total_mirror_equity: float
+    display_currency: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_position_mtm(
+    row: dict[str, Any],
+    display_currency: str,
+    rates: dict[tuple[str, str], Decimal],
+) -> MirrorPositionItem:
+    """Build a MirrorPositionItem with mark-to-market from a joined row.
+
+    Price hierarchy: quote.last → price_daily.close → open_rate (fallback).
+    All monetary values are in USD natively (eToro copy-trading positions).
+    Convert to display_currency at the end.
+    """
+    units = float(row["units"])
+    amount = float(row["amount"])
+    open_rate = float(row["open_rate"])
+    open_conv = float(row["open_conversion_rate"])
+    is_buy = row["is_buy"]
+    direction = 1.0 if is_buy else -1.0
+
+    # Price hierarchy for the instrument's native currency price
+    quote_last = parse_optional_float(row, "quote_last")
+    daily_close = parse_optional_float(row, "daily_close")
+
+    if quote_last is not None:
+        native_price = quote_last
+    elif daily_close is not None:
+        native_price = daily_close
+    else:
+        native_price = open_rate  # fallback — P&L will be zero
+
+    # P&L in USD: direction * units * (current - entry) * fx_at_open
+    pnl_usd = direction * units * (native_price - open_rate) * open_conv
+    market_value_usd = amount + pnl_usd
+
+    # current_price in display terms: native_price converted, but only
+    # if we have a real price signal (not the open_rate fallback)
+    if quote_last is not None or daily_close is not None:
+        current_price_usd: float | None = native_price * open_conv
+    else:
+        current_price_usd = None
+
+    # Convert USD → display_currency
+    if "USD" != display_currency:
+        try:
+            market_value = float(convert(Decimal(str(market_value_usd)), "USD", display_currency, rates))
+            pnl = float(convert(Decimal(str(pnl_usd)), "USD", display_currency, rates))
+            if current_price_usd is not None:
+                current_price: float | None = float(
+                    convert(Decimal(str(current_price_usd)), "USD", display_currency, rates)
+                )
+            else:
+                current_price = None
+            amount_display = float(convert(Decimal(str(amount)), "USD", display_currency, rates))
+        except FxRateNotFound:
+            logger.warning("FX rate USD→%s not found; skipping conversion", display_currency)
+            market_value = market_value_usd
+            pnl = pnl_usd
+            current_price = current_price_usd
+            amount_display = amount
+    else:
+        market_value = market_value_usd
+        pnl = pnl_usd
+        current_price = current_price_usd
+        amount_display = amount
+
+    return MirrorPositionItem(
+        position_id=row["position_id"],
+        instrument_id=row["instrument_id"],
+        symbol=row.get("symbol"),
+        company_name=row.get("company_name"),
+        is_buy=is_buy,
+        units=units,
+        amount=amount_display,
+        open_rate=open_rate,
+        open_conversion_rate=open_conv,
+        open_date_time=row["open_date_time"],
+        current_price=current_price,
+        market_value=market_value,
+        unrealized_pnl=pnl,
+    )
+
+
+def _convert_usd(
+    value: float,
+    display_currency: str,
+    rates: dict[tuple[str, str], Decimal],
+) -> float:
+    """Convert a USD value to display_currency, returning original on failure."""
+    if display_currency == "USD":
+        return value
+    try:
+        return float(convert(Decimal(str(value)), "USD", display_currency, rates))
+    except FxRateNotFound:
+        return value
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=CopyTradingResponse)
+def get_copy_trading(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> CopyTradingResponse:
+    """Per-trader copy-trading overview with nested position breakdowns.
+
+    Returns all copy traders (active mirrors first, then closed), with
+    per-mirror equity computed from the same three-tier pricing hierarchy
+    as the main portfolio endpoint.
+
+    All monetary values are converted to the operator's display currency.
+    """
+    config = get_runtime_config(conn)
+    display_currency = config.display_currency
+    rates_meta = load_live_fx_rates_with_metadata(conn)
+    rates: dict[tuple[str, str], Decimal] = {k: v["rate"] for k, v in rates_meta.items()}
+
+    # -- Query 1: traders + mirrors ----------------------------------------
+    mirrors_sql = """
+        SELECT ct.parent_cid, ct.parent_username,
+               cm.mirror_id, cm.active,
+               cm.initial_investment, cm.deposit_summary,
+               cm.withdrawal_summary, cm.available_amount,
+               cm.closed_positions_net_profit,
+               cm.started_copy_date, cm.closed_at
+        FROM copy_traders ct
+        JOIN copy_mirrors cm USING (parent_cid)
+        ORDER BY cm.active DESC, ct.parent_username, cm.mirror_id
+    """
+
+    # -- Query 2: all positions with instrument + pricing info -------------
+    # One query across all mirrors avoids N+1.  Instrument join is LEFT
+    # because mirrors may hold instruments outside the eBull universe.
+    positions_sql = """
+        SELECT cmp.mirror_id, cmp.position_id, cmp.instrument_id,
+               i.symbol, i.company_name,
+               cmp.is_buy, cmp.units, cmp.amount,
+               cmp.open_rate, cmp.open_conversion_rate,
+               cmp.open_date_time,
+               q.last AS quote_last,
+               pd.close AS daily_close
+        FROM copy_mirror_positions cmp
+        LEFT JOIN instruments i ON i.instrument_id = cmp.instrument_id
+        LEFT JOIN quotes q ON q.instrument_id = cmp.instrument_id
+        LEFT JOIN LATERAL (
+            SELECT close
+            FROM price_daily
+            WHERE instrument_id = cmp.instrument_id
+              AND close IS NOT NULL
+            ORDER BY price_date DESC
+            LIMIT 1
+        ) pd ON TRUE
+        ORDER BY cmp.mirror_id, cmp.amount DESC
+    """
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(mirrors_sql)
+        mirror_rows = cur.fetchall()
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(positions_sql)
+        position_rows = cur.fetchall()
+
+    # -- Group positions by mirror_id --------------------------------------
+    positions_by_mirror: dict[int, list[dict[str, Any]]] = {}
+    for row in position_rows:
+        mid = row["mirror_id"]
+        positions_by_mirror.setdefault(mid, []).append(row)
+
+    # -- Assemble per-trader summaries -------------------------------------
+    traders_map: dict[int, CopyTraderSummary] = {}
+
+    for mr in mirror_rows:
+        parent_cid: int = mr["parent_cid"]
+        mirror_id: int = mr["mirror_id"]
+
+        # Build position items for this mirror
+        raw_positions = positions_by_mirror.get(mirror_id, [])
+        position_items = [_compute_position_mtm(p, display_currency, rates) for p in raw_positions]
+
+        # Per-mirror equity = available_amount + sum(position market values)
+        available_usd = float(mr["available_amount"])
+        positions_mv_display = sum(p.market_value for p in position_items)
+        available_display = _convert_usd(available_usd, display_currency, rates)
+        mirror_equity = available_display + positions_mv_display
+
+        mirror_summary = MirrorSummary(
+            mirror_id=mirror_id,
+            active=mr["active"],
+            initial_investment=_convert_usd(float(mr["initial_investment"]), display_currency, rates),
+            deposit_summary=_convert_usd(float(mr["deposit_summary"]), display_currency, rates),
+            withdrawal_summary=_convert_usd(float(mr["withdrawal_summary"]), display_currency, rates),
+            available_amount=available_display,
+            closed_positions_net_profit=_convert_usd(float(mr["closed_positions_net_profit"]), display_currency, rates),
+            mirror_equity=mirror_equity,
+            position_count=len(position_items),
+            positions=position_items,
+            started_copy_date=mr["started_copy_date"],
+            closed_at=mr["closed_at"],
+        )
+
+        if parent_cid not in traders_map:
+            traders_map[parent_cid] = CopyTraderSummary(
+                parent_cid=parent_cid,
+                parent_username=mr["parent_username"],
+                mirrors=[],
+                total_equity=0.0,
+            )
+        traders_map[parent_cid].mirrors.append(mirror_summary)
+
+    # Compute per-trader total equity
+    traders = list(traders_map.values())
+    for trader in traders:
+        trader.total_equity = sum(m.mirror_equity for m in trader.mirrors)
+
+    total_mirror_equity = sum(t.total_equity for t in traders)
+
+    return CopyTradingResponse(
+        traders=traders,
+        total_mirror_equity=total_mirror_equity,
+        display_currency=display_currency,
+    )

--- a/app/api/copy_trading.py
+++ b/app/api/copy_trading.py
@@ -12,6 +12,7 @@ No writes. No schema changes.
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from datetime import datetime
 from decimal import Decimal
 from typing import Any
@@ -182,6 +183,7 @@ def _convert_usd(
     try:
         return float(convert(Decimal(str(value)), "USD", display_currency, rates))
     except FxRateNotFound:
+        logger.warning("FX rate USD→%s not found; returning unconverted value", display_currency)
         return value
 
 
@@ -254,10 +256,9 @@ def get_copy_trading(
         position_rows = cur.fetchall()
 
     # -- Group positions by mirror_id --------------------------------------
-    positions_by_mirror: dict[int, list[dict[str, Any]]] = {}
+    positions_by_mirror: dict[int, list[dict[str, Any]]] = defaultdict(list)
     for row in position_rows:
-        mid = row["mirror_id"]
-        positions_by_mirror.setdefault(mid, []).append(row)
+        positions_by_mirror[row["mirror_id"]].append(row)
 
     # -- Assemble per-trader summaries -------------------------------------
     traders_map: dict[int, CopyTraderSummary] = {}

--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ from app.api.auth_setup import router as auth_setup_router
 from app.api.broker_credentials import router as broker_credentials_router
 from app.api.config import KillSwitchRequest, KillSwitchResponse, post_kill_switch
 from app.api.config import router as config_router
+from app.api.copy_trading import router as copy_trading_router
 from app.api.filings import router as filings_router
 from app.api.instruments import router as instruments_router
 from app.api.jobs import router as jobs_router
@@ -119,6 +120,7 @@ app.include_router(operators_router)
 app.include_router(audit_router)
 app.include_router(broker_credentials_router)
 app.include_router(config_router)
+app.include_router(copy_trading_router)
 app.include_router(filings_router)
 app.include_router(instruments_router)
 app.include_router(jobs_router)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { LoginPage } from "@/pages/LoginPage";
 import { SetupPage } from "@/pages/SetupPage";
 import { RecoverPage } from "@/pages/RecoverPage";
 import { OperatorsPage } from "@/pages/OperatorsPage";
+import { CopyTradingPage } from "@/pages/CopyTradingPage";
 import { InstrumentsPage } from "@/pages/InstrumentsPage";
 
 export function App() {
@@ -36,6 +37,7 @@ export function App() {
           <Route path="rankings" element={<RankingsPage />} />
           <Route path="instruments" element={<InstrumentsPage />} />
           <Route path="instruments/:instrumentId" element={<InstrumentDetailPage />} />
+          <Route path="copy-trading" element={<CopyTradingPage />} />
           <Route path="recommendations" element={<RecommendationsPage />} />
           <Route path="admin" element={<AdminPage />} />
           <Route path="operators" element={<OperatorsPage />} />

--- a/frontend/src/api/copyTrading.ts
+++ b/frontend/src/api/copyTrading.ts
@@ -1,0 +1,6 @@
+import { apiFetch } from "@/api/client";
+import type { CopyTradingResponse } from "@/api/types";
+
+export function fetchCopyTrading(): Promise<CopyTradingResponse> {
+  return apiFetch<CopyTradingResponse>("/portfolio/copy-trading");
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -455,3 +455,51 @@ export interface NewsListResponse {
   offset: number;
   limit: number;
 }
+
+// ---------------------------------------------------------------------------
+// /portfolio/copy-trading (app/api/copy_trading.py)
+// ---------------------------------------------------------------------------
+
+export interface MirrorPositionItem {
+  position_id: number;
+  instrument_id: number;
+  symbol: string | null;
+  company_name: string | null;
+  is_buy: boolean;
+  units: number;
+  amount: number;
+  open_rate: number;
+  open_conversion_rate: number;
+  open_date_time: string;
+  current_price: number | null;
+  market_value: number;
+  unrealized_pnl: number;
+}
+
+export interface MirrorSummary {
+  mirror_id: number;
+  active: boolean;
+  initial_investment: number;
+  deposit_summary: number;
+  withdrawal_summary: number;
+  available_amount: number;
+  closed_positions_net_profit: number;
+  mirror_equity: number;
+  position_count: number;
+  positions: MirrorPositionItem[];
+  started_copy_date: string;
+  closed_at: string | null;
+}
+
+export interface CopyTraderSummary {
+  parent_cid: number;
+  parent_username: string;
+  mirrors: MirrorSummary[];
+  total_equity: number;
+}
+
+export interface CopyTradingResponse {
+  traders: CopyTraderSummary[];
+  total_mirror_equity: number;
+  display_currency: string;
+}

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ const NAV_ITEMS: { to: string; label: string; end?: boolean }[] = [
   { to: "/", label: "Dashboard", end: true },
   { to: "/instruments", label: "Instruments" },
   { to: "/rankings", label: "Rankings" },
+  { to: "/copy-trading", label: "Copy Trading" },
   { to: "/recommendations", label: "Recommendations" },
   { to: "/admin", label: "Admin" },
   { to: "/operators", label: "Operators" },

--- a/frontend/src/pages/CopyTradingPage.test.tsx
+++ b/frontend/src/pages/CopyTradingPage.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * Tests for CopyTradingPage (#188).
+ *
+ * Scope:
+ *   - Empty state when no traders
+ *   - Renders trader cards with equity and P&L
+ *   - Expanding a card shows nested positions
+ *   - Closed mirrors appear in a separate section
+ *   - Error state renders retry button
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { CopyTradingPage } from "@/pages/CopyTradingPage";
+import { fetchCopyTrading } from "@/api/copyTrading";
+import type { CopyTradingResponse } from "@/api/types";
+
+vi.mock("@/api/copyTrading", () => ({
+  fetchCopyTrading: vi.fn(),
+}));
+
+const mockedFetch = vi.mocked(fetchCopyTrading);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const emptyResponse: CopyTradingResponse = {
+  traders: [],
+  total_mirror_equity: 0,
+  display_currency: "GBP",
+};
+
+function makeResponse(overrides: Partial<CopyTradingResponse> = {}): CopyTradingResponse {
+  return {
+    traders: [
+      {
+        parent_cid: 123,
+        parent_username: "thomaspj",
+        mirrors: [
+          {
+            mirror_id: 1001,
+            active: true,
+            initial_investment: 15000,
+            deposit_summary: 0,
+            withdrawal_summary: 0,
+            available_amount: 1000,
+            closed_positions_net_profit: 200,
+            mirror_equity: 14500,
+            position_count: 2,
+            positions: [
+              {
+                position_id: 5001,
+                instrument_id: 42,
+                symbol: "AAPL",
+                company_name: "Apple Inc.",
+                is_buy: true,
+                units: 10,
+                amount: 7000,
+                open_rate: 150.0,
+                open_conversion_rate: 1.0,
+                open_date_time: "2026-03-01T12:00:00Z",
+                current_price: 160.0,
+                market_value: 7500,
+                unrealized_pnl: 500,
+              },
+              {
+                position_id: 5002,
+                instrument_id: 99,
+                symbol: "TSLA",
+                company_name: "Tesla Inc.",
+                is_buy: true,
+                units: 5,
+                amount: 6000,
+                open_rate: 200.0,
+                open_conversion_rate: 1.0,
+                open_date_time: "2026-03-15T12:00:00Z",
+                current_price: null,
+                market_value: 6000,
+                unrealized_pnl: 0,
+              },
+            ],
+            started_copy_date: "2026-01-15T10:00:00Z",
+            closed_at: null,
+          },
+        ],
+        total_equity: 14500,
+      },
+    ],
+    total_mirror_equity: 14500,
+    display_currency: "GBP",
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/copy-trading"]}>
+      <Routes>
+        <Route path="/copy-trading" element={<CopyTradingPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockedFetch.mockResolvedValue(makeResponse());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CopyTradingPage — empty state", () => {
+  it("shows empty state when no traders", async () => {
+    mockedFetch.mockResolvedValueOnce(emptyResponse);
+    renderPage();
+    expect(await screen.findByText("No copy traders")).toBeInTheDocument();
+  });
+});
+
+describe("CopyTradingPage — trader cards", () => {
+  it("renders trader username and position count", async () => {
+    renderPage();
+    expect(await screen.findByText("thomaspj")).toBeInTheDocument();
+    expect(screen.getByText(/2 positions/)).toBeInTheDocument();
+  });
+
+  it("shows mirror equity in summary", async () => {
+    renderPage();
+    await screen.findByText("thomaspj");
+    expect(screen.getByText("Mirror equity")).toBeInTheDocument();
+  });
+
+  it("shows copied traders count", async () => {
+    renderPage();
+    await screen.findByText("thomaspj");
+    expect(screen.getByText("Copied traders")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+});
+
+describe("CopyTradingPage — drill-down", () => {
+  it("expands to show positions on click", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const card = await screen.findByText("thomaspj");
+
+    // Positions not visible before expansion
+    expect(screen.queryByText("AAPL")).toBeNull();
+
+    // Click to expand
+    await user.click(card);
+
+    // Positions now visible
+    expect(screen.getByText("AAPL")).toBeInTheDocument();
+    expect(screen.getByText("TSLA")).toBeInTheDocument();
+  });
+
+  it("shows LONG pill for buy positions", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByText("thomaspj"));
+
+    const longs = screen.getAllByText("LONG");
+    expect(longs.length).toBe(2);
+  });
+
+  it("shows — for positions without current price", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByText("thomaspj"));
+
+    // TSLA has current_price: null, should show em-dash
+    const rows = screen.getAllByRole("row");
+    // Find the TSLA row
+    const tslaRow = rows.find((r) => within(r).queryByText("TSLA") !== null)!;
+    expect(within(tslaRow).getByText("—")).toBeInTheDocument();
+  });
+});
+
+describe("CopyTradingPage — closed mirrors", () => {
+  it("renders closed mirrors in a separate section", async () => {
+    mockedFetch.mockResolvedValueOnce(
+      makeResponse({
+        traders: [
+          {
+            parent_cid: 456,
+            parent_username: "closedtrader",
+            mirrors: [
+              {
+                mirror_id: 2001,
+                active: false,
+                initial_investment: 5000,
+                deposit_summary: 0,
+                withdrawal_summary: 0,
+                available_amount: 0,
+                closed_positions_net_profit: -200,
+                mirror_equity: 4800,
+                position_count: 0,
+                positions: [],
+                started_copy_date: "2025-06-01T10:00:00Z",
+                closed_at: "2026-01-01T10:00:00Z",
+              },
+            ],
+            total_equity: 4800,
+          },
+        ],
+      }),
+    );
+    renderPage();
+    expect(await screen.findByText("Closed mirrors")).toBeInTheDocument();
+    expect(screen.getByText("closedtrader")).toBeInTheDocument();
+  });
+
+  it("does not show closed section when all mirrors are active", async () => {
+    renderPage();
+    await screen.findByText("thomaspj");
+    expect(screen.queryByText("Closed mirrors")).toBeNull();
+  });
+});
+
+describe("CopyTradingPage — error state", () => {
+  it("shows retry button on fetch failure", async () => {
+    mockedFetch.mockRejectedValueOnce(new Error("network error"));
+    renderPage();
+    expect(await screen.findByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -1,0 +1,311 @@
+import { useState } from "react";
+import { fetchCopyTrading } from "@/api/copyTrading";
+import { useAsync } from "@/lib/useAsync";
+import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
+import { formatMoney, formatNumber, formatDateTime } from "@/lib/format";
+import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import type { CopyTraderSummary, MirrorSummary, MirrorPositionItem } from "@/api/types";
+
+/**
+ * Copy-trading browsing page (#188 — Track 1.5).
+ *
+ * Shows per-trader cards with mirror-level aggregates and an expandable
+ * nested-position drill-down. Closed mirrors are shown in a separate
+ * history section at the bottom.
+ */
+export function CopyTradingPage() {
+  const currency = useDisplayCurrency();
+  // useAsync captures fn via a ref — fresh arrow per render is fine.
+  const ct = useAsync(fetchCopyTrading, []);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold text-slate-800">Copy Trading</h1>
+
+      {ct.error !== null ? (
+        <div className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+          <SectionError onRetry={ct.refetch} />
+        </div>
+      ) : ct.loading ? (
+        <SectionSkeleton rows={6} />
+      ) : ct.data === null ? (
+        <SectionSkeleton rows={6} />
+      ) : ct.data.traders.length === 0 ? (
+        <EmptyState
+          title="No copy traders"
+          description="Mirror positions will appear here once a copy-trading relationship is synced from eToro."
+        />
+      ) : (
+        <>
+          <MirrorEquitySummary
+            totalMirrorEquity={ct.data.total_mirror_equity}
+            currency={currency}
+            traderCount={ct.data.traders.length}
+          />
+          <ActiveTraders traders={ct.data.traders} currency={currency} />
+          <ClosedMirrors traders={ct.data.traders} currency={currency} />
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+function MirrorEquitySummary({
+  totalMirrorEquity,
+  currency,
+  traderCount,
+}: {
+  totalMirrorEquity: number;
+  currency: string;
+  traderCount: number;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+      <StatCard label="Mirror equity" value={formatMoney(totalMirrorEquity, currency)} />
+      <StatCard label="Copied traders" value={String(traderCount)} />
+    </div>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</div>
+      <div className="mt-1 text-lg font-semibold text-slate-800">{value}</div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Active traders
+// ---------------------------------------------------------------------------
+
+function ActiveTraders({
+  traders,
+  currency,
+}: {
+  traders: CopyTraderSummary[];
+  currency: string;
+}) {
+  const activeMirrors = traders.flatMap((t) =>
+    t.mirrors.filter((m) => m.active).map((m) => ({ trader: t, mirror: m })),
+  );
+
+  if (activeMirrors.length === 0) return null;
+
+  return (
+    <Section title="Active mirrors">
+      <div className="space-y-4">
+        {activeMirrors.map(({ trader, mirror }) => (
+          <TraderMirrorCard
+            key={mirror.mirror_id}
+            trader={trader}
+            mirror={mirror}
+            currency={currency}
+          />
+        ))}
+      </div>
+    </Section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Trader card
+// ---------------------------------------------------------------------------
+
+function TraderMirrorCard({
+  trader,
+  mirror,
+  currency,
+}: {
+  trader: CopyTraderSummary;
+  mirror: MirrorSummary;
+  currency: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const funded = mirror.initial_investment + mirror.deposit_summary - mirror.withdrawal_summary;
+  const pnl = mirror.mirror_equity - funded;
+
+  return (
+    <div className="rounded-md border border-slate-200 bg-white">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-slate-50"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <div>
+          <span className="text-sm font-semibold text-slate-800">{trader.parent_username}</span>
+          <span className="ml-2 text-xs text-slate-500">
+            {mirror.position_count} position{mirror.position_count !== 1 ? "s" : ""}
+          </span>
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="text-right">
+            <div className="text-xs text-slate-500">Equity</div>
+            <div className="text-sm font-medium tabular-nums text-slate-800">
+              {formatMoney(mirror.mirror_equity, currency)}
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-xs text-slate-500">P&L</div>
+            <div
+              className={`text-sm font-medium tabular-nums ${pnl >= 0 ? "text-emerald-600" : "text-red-600"}`}
+            >
+              {formatMoney(pnl, currency)}
+            </div>
+          </div>
+          <span className="text-slate-400">{expanded ? "▲" : "▼"}</span>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-slate-100 px-4 py-3">
+          <MirrorStats mirror={mirror} currency={currency} />
+          <MirrorPositionsTable positions={mirror.positions} currency={currency} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MirrorStats({ mirror, currency }: { mirror: MirrorSummary; currency: string }) {
+  return (
+    <div className="mb-3 grid grid-cols-2 gap-x-6 gap-y-1 text-xs sm:grid-cols-4">
+      <LabelValue label="Initial investment" value={formatMoney(mirror.initial_investment, currency)} />
+      <LabelValue label="Deposits" value={formatMoney(mirror.deposit_summary, currency)} />
+      <LabelValue label="Withdrawals" value={formatMoney(mirror.withdrawal_summary, currency)} />
+      <LabelValue label="Available cash" value={formatMoney(mirror.available_amount, currency)} />
+      <LabelValue label="Closed P&L" value={formatMoney(mirror.closed_positions_net_profit, currency)} />
+      <LabelValue label="Copying since" value={formatDateTime(mirror.started_copy_date)} />
+    </div>
+  );
+}
+
+function LabelValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <span className="text-slate-500">{label}: </span>
+      <span className="font-medium tabular-nums text-slate-700">{value}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mirror positions table
+// ---------------------------------------------------------------------------
+
+function MirrorPositionsTable({
+  positions,
+  currency,
+}: {
+  positions: MirrorPositionItem[];
+  currency: string;
+}) {
+  if (positions.length === 0) {
+    return <p className="text-xs text-slate-500">No open positions in this mirror.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead className="text-xs uppercase text-slate-500">
+          <tr>
+            <th className="px-2 py-2 text-left">Symbol</th>
+            <th className="px-2 py-2 text-left">Side</th>
+            <th className="px-2 py-2 text-right">Units</th>
+            <th className="px-2 py-2 text-right">Entry</th>
+            <th className="px-2 py-2 text-right">Price</th>
+            <th className="px-2 py-2 text-right">Value</th>
+            <th className="px-2 py-2 text-right">P&L</th>
+          </tr>
+        </thead>
+        <tbody>
+          {positions.map((p) => (
+            <MirrorPositionRow key={p.position_id} position={p} currency={currency} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function MirrorPositionRow({
+  position,
+  currency,
+}: {
+  position: MirrorPositionItem;
+  currency: string;
+}) {
+  return (
+    <tr className="border-t border-slate-100">
+      <td className="px-2 py-2 text-left">
+        <span className="font-medium text-slate-800">
+          {position.symbol ?? `#${position.instrument_id}`}
+        </span>
+        {position.company_name ? (
+          <span className="ml-1 text-xs text-slate-500">{position.company_name}</span>
+        ) : null}
+      </td>
+      <td className="px-2 py-2 text-left">
+        <span
+          className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-medium ${
+            position.is_buy
+              ? "bg-emerald-50 text-emerald-700"
+              : "bg-red-50 text-red-700"
+          }`}
+        >
+          {position.is_buy ? "LONG" : "SHORT"}
+        </span>
+      </td>
+      <td className="px-2 py-2 text-right tabular-nums">{formatNumber(position.units)}</td>
+      <td className="px-2 py-2 text-right tabular-nums">{formatNumber(position.open_rate, 2)}</td>
+      <td className="px-2 py-2 text-right tabular-nums">
+        {position.current_price != null ? formatMoney(position.current_price, currency) : "—"}
+      </td>
+      <td className="px-2 py-2 text-right tabular-nums">{formatMoney(position.market_value, currency)}</td>
+      <td className="px-2 py-2 text-right tabular-nums">
+        <span className={position.unrealized_pnl >= 0 ? "text-emerald-600" : "text-red-600"}>
+          {formatMoney(position.unrealized_pnl, currency)}
+        </span>
+      </td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Closed mirrors
+// ---------------------------------------------------------------------------
+
+function ClosedMirrors({
+  traders,
+  currency,
+}: {
+  traders: CopyTraderSummary[];
+  currency: string;
+}) {
+  const closedMirrors = traders.flatMap((t) =>
+    t.mirrors.filter((m) => !m.active).map((m) => ({ trader: t, mirror: m })),
+  );
+
+  if (closedMirrors.length === 0) return null;
+
+  return (
+    <Section title="Closed mirrors">
+      <div className="space-y-4">
+        {closedMirrors.map(({ trader, mirror }) => (
+          <TraderMirrorCard
+            key={mirror.mirror_id}
+            trader={trader}
+            mirror={mirror}
+            currency={currency}
+          />
+        ))}
+      </div>
+    </Section>
+  );
+}

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -27,9 +27,7 @@ export function CopyTradingPage() {
         <div className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
           <SectionError onRetry={ct.refetch} />
         </div>
-      ) : ct.loading ? (
-        <SectionSkeleton rows={6} />
-      ) : ct.data === null ? (
+      ) : ct.loading || ct.data === null ? (
         <SectionSkeleton rows={6} />
       ) : ct.data.traders.length === 0 ? (
         <EmptyState

--- a/tests/test_copy_trading_mtm.py
+++ b/tests/test_copy_trading_mtm.py
@@ -1,0 +1,145 @@
+"""Tests for copy-trading position mark-to-market computation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from app.api.copy_trading import _compute_position_mtm
+
+
+def _pos_row(
+    *,
+    mirror_id: int = 1,
+    position_id: int = 100,
+    instrument_id: int = 42,
+    symbol: str | None = "AAPL",
+    company_name: str | None = "Apple Inc.",
+    is_buy: bool = True,
+    units: float = 10.0,
+    amount: float = 1500.0,
+    open_rate: float = 150.0,
+    open_conversion_rate: float = 1.0,
+    open_date_time: datetime = datetime(2026, 4, 1, 12, 0, tzinfo=UTC),
+    quote_last: float | None = None,
+    daily_close: float | None = None,
+) -> dict[str, object]:
+    return {
+        "mirror_id": mirror_id,
+        "position_id": position_id,
+        "instrument_id": instrument_id,
+        "symbol": symbol,
+        "company_name": company_name,
+        "is_buy": is_buy,
+        "units": units,
+        "amount": amount,
+        "open_rate": open_rate,
+        "open_conversion_rate": open_conversion_rate,
+        "open_date_time": open_date_time,
+        "quote_last": quote_last,
+        "daily_close": daily_close,
+    }
+
+
+class TestPriceHierarchy:
+    """Verify the three-tier pricing: quote → daily_close → open_rate."""
+
+    def test_quote_is_primary(self) -> None:
+        row = _pos_row(units=10, amount=1500, open_rate=150.0, quote_last=160.0, daily_close=155.0)
+        rates: dict[tuple[str, str], Decimal] = {}
+        pos = _compute_position_mtm(row, "USD", rates)
+
+        assert pos.current_price is not None
+        assert abs(pos.current_price - 160.0) < 0.01
+        # P&L = 1 * 10 * (160 - 150) * 1.0 = 100
+        assert abs(pos.unrealized_pnl - 100.0) < 0.01
+        # market_value = 1500 + 100 = 1600
+        assert abs(pos.market_value - 1600.0) < 0.01
+
+    def test_daily_close_is_secondary(self) -> None:
+        row = _pos_row(units=10, amount=1500, open_rate=150.0, quote_last=None, daily_close=155.0)
+        rates: dict[tuple[str, str], Decimal] = {}
+        pos = _compute_position_mtm(row, "USD", rates)
+
+        assert pos.current_price is not None
+        assert abs(pos.current_price - 155.0) < 0.01
+        # P&L = 1 * 10 * (155 - 150) * 1.0 = 50
+        assert abs(pos.unrealized_pnl - 50.0) < 0.01
+        assert abs(pos.market_value - 1550.0) < 0.01
+
+    def test_open_rate_is_fallback(self) -> None:
+        row = _pos_row(units=10, amount=1500, open_rate=150.0, quote_last=None, daily_close=None)
+        rates: dict[tuple[str, str], Decimal] = {}
+        pos = _compute_position_mtm(row, "USD", rates)
+
+        # No price signal — current_price is None, P&L is zero
+        assert pos.current_price is None
+        assert pos.unrealized_pnl == 0.0
+        assert pos.market_value == 1500.0
+
+
+class TestFxConversion:
+    """Verify USD → display_currency conversion."""
+
+    def test_converts_to_gbp(self) -> None:
+        row = _pos_row(units=10, amount=1500, open_rate=150.0, daily_close=160.0)
+        rates = {("USD", "GBP"): Decimal("0.75")}
+        pos = _compute_position_mtm(row, "GBP", rates)
+
+        # P&L in USD = 10 * (160-150) * 1.0 = 100
+        # MV in USD = 1500 + 100 = 1600
+        # MV in GBP = 1600 * 0.75 = 1200
+        assert abs(pos.market_value - 1200.0) < 0.01
+        assert abs(pos.unrealized_pnl - 75.0) < 0.01
+        assert pos.current_price is not None
+        # current_price = 160 * 1.0 (open_conversion_rate) * 0.75 = 120
+        assert abs(pos.current_price - 120.0) < 0.01
+
+    def test_no_conversion_when_display_is_usd(self) -> None:
+        row = _pos_row(units=10, amount=1500, open_rate=150.0, daily_close=160.0)
+        rates: dict[tuple[str, str], Decimal] = {}
+        pos = _compute_position_mtm(row, "USD", rates)
+
+        assert abs(pos.market_value - 1600.0) < 0.01
+
+
+class TestShortPositions:
+    """Verify short (is_buy=False) MTM direction."""
+
+    def test_short_position_gains_on_price_drop(self) -> None:
+        row = _pos_row(is_buy=False, units=10, amount=1500, open_rate=150.0, daily_close=140.0)
+        rates: dict[tuple[str, str], Decimal] = {}
+        pos = _compute_position_mtm(row, "USD", rates)
+
+        # P&L = -1 * 10 * (140 - 150) * 1.0 = 100 (gain)
+        assert abs(pos.unrealized_pnl - 100.0) < 0.01
+        assert abs(pos.market_value - 1600.0) < 0.01
+
+    def test_short_position_loses_on_price_rise(self) -> None:
+        row = _pos_row(is_buy=False, units=10, amount=1500, open_rate=150.0, daily_close=160.0)
+        rates: dict[tuple[str, str], Decimal] = {}
+        pos = _compute_position_mtm(row, "USD", rates)
+
+        # P&L = -1 * 10 * (160 - 150) * 1.0 = -100 (loss)
+        assert abs(pos.unrealized_pnl - (-100.0)) < 0.01
+        assert abs(pos.market_value - 1400.0) < 0.01
+
+
+class TestOpenConversionRate:
+    """Verify open_conversion_rate is applied correctly for non-USD instruments."""
+
+    def test_non_usd_instrument(self) -> None:
+        # GBP-denominated instrument: open_rate in GBP, conversion 1.25 (GBP→USD)
+        row = _pos_row(
+            units=100,
+            amount=12500,
+            open_rate=100.0,
+            open_conversion_rate=1.25,
+            daily_close=110.0,
+        )
+        rates: dict[tuple[str, str], Decimal] = {}
+        pos = _compute_position_mtm(row, "USD", rates)
+
+        # P&L = 1 * 100 * (110 - 100) * 1.25 = 1250
+        assert abs(pos.unrealized_pnl - 1250.0) < 0.01
+        assert abs(pos.market_value - 13750.0) < 0.01


### PR DESCRIPTION
## Summary

- Adds `GET /portfolio/copy-trading` endpoint returning per-trader cards with mirror-level aggregates and nested position breakdowns
- Adds a new **Copy Trading** page at `/copy-trading` with expandable trader cards, position drill-down, and closed mirrors history
- All monetary values converted to display currency via the same three-tier pricing hierarchy (quote → daily_close → open_rate) as the main portfolio endpoint
- No schema changes — pure read surface over #183 tables

## What changed

### Backend (`app/api/copy_trading.py`)
- New `CopyTradingResponse` model with `CopyTraderSummary`, `MirrorSummary`, and `MirrorPositionItem`
- Two-query approach: one for all traders+mirrors, one for all positions (avoids N+1)
- Per-position MTM: `P&L = direction × units × (current_price - open_rate) × open_conversion_rate`
- FX conversion: all USD values converted atomically to display currency
- Registered on `prefix="/portfolio/copy-trading"`, session-auth-gated

### Frontend
- `CopyTradingPage` with summary cards, expandable `TraderMirrorCard` components, and `MirrorPositionsTable`
- LONG/SHORT pills, P&L colouring (emerald/red), em-dash for missing prices
- Closed mirrors section (separate from active)
- Route added to `App.tsx`, nav link added to `Sidebar.tsx`
- Types added to `types.ts`, thin fetcher in `copyTrading.ts`

## Security model

Read-only endpoint. Same auth gate as `GET /portfolio` (`require_session_or_service_token`). No new data flows — reads existing `copy_traders`, `copy_mirrors`, `copy_mirror_positions` tables. No user input interpolated into queries.

## Settled decisions preserved

- **AUM basis**: uses mark-to-market (quote → daily_close) with cost_basis fallback
- **Provider boundary**: no provider logic in the API layer; FX conversion uses existing `app/services/fx`

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 1217 passed, 1 skipped
- [x] `pnpm --dir frontend typecheck` — passes
- [x] `pnpm --dir frontend test` — 158 passed
- [ ] Visual: Copy Trading page renders per-trader cards with correct equity/P&L
- [ ] Visual: Expanding a card shows nested positions with prices
- [ ] Visual: Closed mirrors appear in separate section

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)