### PR TITLE
feat(#199): fundamentals enrichment — profile, earnings, estimates, scoring fallback

### DIFF
--- a/app/providers/enrichment.py
+++ b/app/providers/enrichment.py
@@ -50,7 +50,7 @@ class EarningsEvent:
     eps_actual: Decimal | None
     revenue_estimate: Decimal | None
     revenue_actual: Decimal | None
-    surprise_pct: Decimal | None  # (actual - estimate) / |estimate|, as a ratio
+    surprise_pct: Decimal | None  # (actual - estimate) / |estimate| * 100, percentage
 
 
 @dataclass(frozen=True)
@@ -99,7 +99,7 @@ class EnrichmentProvider(ABC):
         limit: int = 8,
     ) -> list[EarningsEvent]:
         """
-        Return upcoming and recent earnings events for a symbol, most recent first,
+        Return upcoming and recent earnings events for a symbol, oldest-first,
         up to limit entries.
 
         limit defaults to 8 (approximately two years of quarterly results).

--- a/app/providers/enrichment.py
+++ b/app/providers/enrichment.py
@@ -1,0 +1,113 @@
+"""
+Enrichment provider interface.
+
+Supplies supplemental instrument data beyond core fundamentals: company profile
+metadata, forward-looking earnings calendar, and analyst consensus estimates.
+
+FMP is the v1 implementation. All domain code imports this interface only —
+never the concrete provider.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class InstrumentProfileData:
+    """
+    Supplemental company profile metadata for an instrument.
+
+    None means the data was not available from the provider for this symbol.
+    """
+
+    symbol: str
+    beta: Decimal | None
+    public_float: int | None  # shares, not monetary — use BIGINT in DB
+    avg_volume_30d: int | None
+    market_cap: Decimal | None
+    employees: int | None
+    ipo_date: date | None
+    is_actively_trading: bool | None
+
+
+@dataclass(frozen=True)
+class EarningsEvent:
+    """
+    A single earnings release event for a company.
+
+    fiscal_date_ending is the period end date; reporting_date is when results
+    are/were announced. Either may be None if not yet confirmed by the provider.
+    """
+
+    symbol: str
+    fiscal_date_ending: date
+    reporting_date: date | None
+    eps_estimate: Decimal | None
+    eps_actual: Decimal | None
+    revenue_estimate: Decimal | None
+    revenue_actual: Decimal | None
+    surprise_pct: Decimal | None  # (actual - estimate) / |estimate|, as a ratio
+
+
+@dataclass(frozen=True)
+class AnalystEstimates:
+    """
+    Analyst consensus estimates for a symbol as of a given date.
+
+    fq = forward quarter; fy = forward year.
+    None means the provider returned no consensus for that metric.
+    """
+
+    symbol: str
+    as_of_date: date
+    consensus_eps_fq: Decimal | None
+    consensus_eps_fy: Decimal | None
+    consensus_rev_fq: Decimal | None
+    consensus_rev_fy: Decimal | None
+    analyst_count: int | None
+    buy_count: int | None
+    hold_count: int | None
+    sell_count: int | None
+    price_target_mean: Decimal | None
+    price_target_high: Decimal | None
+    price_target_low: Decimal | None
+
+
+class EnrichmentProvider(ABC):
+    """
+    Interface for supplemental instrument enrichment data.
+
+    Covers company profile metadata, earnings calendar, and analyst estimates.
+    v1 implementation: FmpEnrichmentProvider.
+    """
+
+    @abstractmethod
+    def get_profile_enrichment(self, symbol: str) -> InstrumentProfileData | None:
+        """
+        Return supplemental profile metadata for a symbol.
+        Returns None if the provider has no data for this symbol.
+        """
+
+    @abstractmethod
+    def get_earnings_calendar(
+        self,
+        symbol: str,
+        limit: int = 8,
+    ) -> list[EarningsEvent]:
+        """
+        Return upcoming and recent earnings events for a symbol, most recent first,
+        up to limit entries.
+
+        limit defaults to 8 (approximately two years of quarterly results).
+        """
+
+    @abstractmethod
+    def get_analyst_estimates(self, symbol: str) -> AnalystEstimates | None:
+        """
+        Return the latest analyst consensus estimates for a symbol.
+        Returns None if the provider has no coverage for this symbol.
+        """

--- a/app/providers/implementations/fmp.py
+++ b/app/providers/implementations/fmp.py
@@ -252,7 +252,14 @@ class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
         _persist_raw(f"fmp_earnings_{symbol}", raw)
         if not isinstance(raw, list):
             return []
-        events = [_build_earnings_event(symbol, row) for row in raw if isinstance(row, dict)]
+        events: list[EarningsEvent] = []
+        for row in raw:
+            if not isinstance(row, dict):
+                continue
+            try:
+                events.append(_build_earnings_event(symbol, row))
+            except ValueError, KeyError:
+                logger.warning("FMP: skipping malformed earnings row for %s", symbol)
         events.sort(key=lambda e: e.fiscal_date_ending)
         return events
 

--- a/app/providers/implementations/fmp.py
+++ b/app/providers/implementations/fmp.py
@@ -1,7 +1,7 @@
 """
 Financial Modelling Prep (FMP) fundamentals provider.
 
-Implements FundamentalsProvider against the FMP Premium API.
+Implements FundamentalsProvider and EnrichmentProvider against the FMP Premium API.
 Requires FMP_API_KEY with at least Premium tier access.
 
 Endpoints used:
@@ -12,6 +12,11 @@ Endpoints used:
   /v3/balance-sheet-statement-ttm/{symbol}?apikey=...   (not a real FMP endpoint;
       TTM balance sheet is not published — balance sheet is always point-in-time)
   /v3/cash-flow-statement-ttm/{symbol}?apikey=...
+  /v3/profile/{symbol}?apikey=...
+  /v3/historical/earning_calendar/{symbol}?limit=N&apikey=...
+  /v3/analyst-estimates/{symbol}?period=quarter&limit=1&apikey=...
+  /v4/analyst-stock-recommendations/{symbol}?apikey=...
+  /v4/price-target-consensus/{symbol}?apikey=...
 
 as_of_date = latest balance sheet period end date (canonical period anchor).
 TTM income/cashflow figures are sourced from the TTM endpoints where available;
@@ -32,6 +37,12 @@ from types import TracebackType
 
 import httpx
 
+from app.providers.enrichment import (
+    AnalystEstimates,
+    EarningsEvent,
+    EnrichmentProvider,
+    InstrumentProfileData,
+)
 from app.providers.fundamentals import FundamentalsProvider, FundamentalsSnapshot
 from app.providers.resilient_client import ResilientClient
 
@@ -67,7 +78,7 @@ class InstrumentProfile:
     industry: str | None
 
 
-class FmpFundamentalsProvider(FundamentalsProvider):
+class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
     """
     Fetches normalised fundamentals from FMP (Premium tier required).
 
@@ -197,6 +208,106 @@ class FmpFundamentalsProvider(FundamentalsProvider):
         Uses GET /api/v3/profile/{symbol}.
         Returns None if the symbol is not found in FMP.
         """
+        item = self._fetch_profile(symbol)
+        if item is None:
+            return None
+        raw_currency = str(item.get("currency", ""))
+        # FMP returns "GBp" (pence) for LSE stocks — normalise to "GBP"
+        currency = raw_currency.upper() if raw_currency else None
+        raw_exchange = item.get("exchangeShortName")
+        raw_sector = item.get("sector")
+        raw_industry = item.get("industry")
+        return InstrumentProfile(
+            symbol=symbol,
+            currency=currency or "USD",
+            exchange=str(raw_exchange) if raw_exchange is not None else None,
+            sector=str(raw_sector) if raw_sector is not None else None,
+            industry=str(raw_industry) if raw_industry is not None else None,
+        )
+
+    def get_profile_enrichment(self, symbol: str) -> InstrumentProfileData | None:
+        """Fetch supplemental profile metadata for a symbol.
+
+        Returns None if the provider has no data for this symbol.
+        """
+        item = self._fetch_profile(symbol)
+        if item is None:
+            return None
+        return _build_profile_data(symbol, item)
+
+    def get_earnings_calendar(
+        self,
+        symbol: str,
+        limit: int = 8,
+    ) -> list[EarningsEvent]:
+        """Return earnings events for a symbol, oldest-first, up to limit entries."""
+        resp = self._http.get(
+            f"/v3/historical/earning_calendar/{symbol}",
+            params={"limit": limit, "apikey": self._api_key},
+        )
+        if resp.status_code != 200:
+            logger.warning("FMP earnings calendar fetch failed for %s: %s", symbol, resp.status_code)
+            return []
+        raw = resp.json()
+        _persist_raw(f"fmp_earnings_{symbol}", raw)
+        if not isinstance(raw, list):
+            return []
+        events = [_build_earnings_event(symbol, row) for row in raw if isinstance(row, dict)]
+        events.sort(key=lambda e: e.fiscal_date_ending)
+        return events
+
+    def get_analyst_estimates(self, symbol: str) -> AnalystEstimates | None:
+        """Return the latest analyst consensus estimates for a symbol.
+
+        Combines quarterly analyst estimates, stock recommendations, and price
+        target consensus from three FMP endpoints.
+        Returns None if the provider has no coverage for this symbol.
+        """
+        est_resp = self._http.get(
+            f"/v3/analyst-estimates/{symbol}",
+            params={"period": "quarter", "limit": 1, "apikey": self._api_key},
+        )
+        estimates: list[dict[str, object]] = []
+        if est_resp.status_code == 200:
+            raw_est = est_resp.json()
+            _persist_raw(f"fmp_analyst_est_{symbol}", raw_est)
+            if isinstance(raw_est, list):
+                estimates = [row for row in raw_est if isinstance(row, dict)]
+
+        rec_resp = self._http.get(
+            f"/v4/analyst-stock-recommendations/{symbol}",
+            params={"apikey": self._api_key},
+        )
+        consensus: dict[str, object] | None = None
+        if rec_resp.status_code == 200:
+            raw_rec = rec_resp.json()
+            _persist_raw(f"fmp_analyst_rec_{symbol}", raw_rec)
+            if isinstance(raw_rec, list) and raw_rec and isinstance(raw_rec[0], dict):
+                consensus = raw_rec[0]
+
+        pt_resp = self._http.get(
+            f"/v4/price-target-consensus/{symbol}",
+            params={"apikey": self._api_key},
+        )
+        price_target: dict[str, object] | None = None
+        if pt_resp.status_code == 200:
+            raw_pt = pt_resp.json()
+            _persist_raw(f"fmp_price_target_{symbol}", raw_pt)
+            if isinstance(raw_pt, list) and raw_pt and isinstance(raw_pt[0], dict):
+                price_target = raw_pt[0]
+
+        return _build_analyst_estimates(symbol, estimates, consensus, price_target)
+
+    # ------------------------------------------------------------------
+    # Private HTTP helpers
+    # ------------------------------------------------------------------
+
+    def _fetch_profile(self, symbol: str) -> dict[str, object] | None:
+        """Fetch raw profile dict from FMP /v3/profile/{symbol}.
+
+        Returns None if the symbol is not found or the response is not 200.
+        Shared by get_instrument_profile and get_profile_enrichment.
+        """
         resp = self._http.get(
             f"/v3/profile/{symbol}",
             params={"apikey": self._api_key},
@@ -205,25 +316,11 @@ class FmpFundamentalsProvider(FundamentalsProvider):
             logger.warning("FMP profile fetch failed for %s: %s", symbol, resp.status_code)
             return None
         data = resp.json()
+        _persist_raw(f"fmp_profile_{symbol}", data)
         if not isinstance(data, list) or not data:
             return None
         item = data[0]
-        if not isinstance(item, dict):
-            return None
-        raw_currency = str(item.get("currency", ""))
-        # FMP returns "GBp" (pence) for LSE stocks — normalise to "GBP"
-        currency = raw_currency.upper() if raw_currency else None
-        return InstrumentProfile(
-            symbol=symbol,
-            currency=currency or "USD",
-            exchange=item.get("exchangeShortName"),
-            sector=item.get("sector"),
-            industry=item.get("industry"),
-        )
-
-    # ------------------------------------------------------------------
-    # Private HTTP helpers
-    # ------------------------------------------------------------------
+        return item if isinstance(item, dict) else None
 
     def _fetch_balance_sheet(self, symbol: str, limit: int) -> list[dict[str, object]]:
         resp = self._http.get(
@@ -352,3 +449,156 @@ def _int_or_none(value: object) -> int | None:
         return result
     except ValueError, ArithmeticError:
         return None
+
+
+def _build_profile_data(
+    symbol: str,
+    item: Mapping[str, object],
+) -> InstrumentProfileData:
+    """
+    Build InstrumentProfileData from a raw FMP /v3/profile response dict.
+
+    Pure function — no I/O.
+    """
+    ipo_date: date | None = None
+    raw_ipo = item.get("ipoDate")
+    if raw_ipo is not None:
+        try:
+            ipo_date = date.fromisoformat(str(raw_ipo)[:10])
+        except ValueError:
+            ipo_date = None
+
+    raw_active = item.get("isActivelyTrading")
+    is_actively_trading: bool | None = raw_active if isinstance(raw_active, bool) else None
+
+    return InstrumentProfileData(
+        symbol=symbol,
+        beta=_decimal_or_none(item.get("beta")),
+        public_float=_int_or_none(item.get("floatShares")),
+        avg_volume_30d=_int_or_none(item.get("volAvg")),
+        market_cap=_decimal_or_none(item.get("mktCap")),
+        employees=_int_or_none(item.get("fullTimeEmployees")),
+        ipo_date=ipo_date,
+        is_actively_trading=is_actively_trading,
+    )
+
+
+def _build_earnings_event(
+    symbol: str,
+    row: Mapping[str, object],
+) -> EarningsEvent:
+    """
+    Build an EarningsEvent from a single FMP earnings calendar response row.
+
+    Pure function — no I/O.
+    Raises ValueError if the required 'date' field cannot be parsed.
+    """
+    fiscal_date_ending = date.fromisoformat(str(row["date"])[:10])
+
+    reporting_date: date | None = None
+    raw_reported = row.get("reportedDate")
+    if raw_reported is not None:
+        try:
+            reporting_date = date.fromisoformat(str(raw_reported)[:10])
+        except ValueError:
+            reporting_date = None
+
+    eps_estimate = _decimal_or_none(row.get("epsEstimated"))
+    eps_actual = _decimal_or_none(row.get("eps"))
+    revenue_estimate = _decimal_or_none(row.get("revenueEstimated"))
+    revenue_actual = _decimal_or_none(row.get("revenue"))
+
+    surprise_pct: Decimal | None = None
+    if eps_estimate is not None and eps_actual is not None and eps_estimate != Decimal(0):
+        surprise_pct = (eps_actual - eps_estimate) / abs(eps_estimate) * Decimal(100)
+
+    return EarningsEvent(
+        symbol=symbol,
+        fiscal_date_ending=fiscal_date_ending,
+        reporting_date=reporting_date,
+        eps_estimate=eps_estimate,
+        eps_actual=eps_actual,
+        revenue_estimate=revenue_estimate,
+        revenue_actual=revenue_actual,
+        surprise_pct=surprise_pct,
+    )
+
+
+def _build_analyst_estimates(
+    symbol: str,
+    estimates: list[dict[str, object]],
+    consensus: dict[str, object] | None,
+    price_target: dict[str, object] | None,
+) -> AnalystEstimates | None:
+    """
+    Build AnalystEstimates from FMP analyst estimate, recommendation, and price
+    target consensus responses.
+
+    Pure function — no I/O.
+    Returns None if all three inputs are empty/None (no data available).
+    """
+    if not estimates and consensus is None and price_target is None:
+        return None
+
+    # -- from estimates[0] --
+    as_of_date: date | None = None
+    consensus_eps_fq: Decimal | None = None
+    consensus_rev_fq: Decimal | None = None
+    analyst_count_from_est: int | None = None
+
+    if estimates:
+        est = estimates[0]
+        raw_date = est.get("date")
+        if raw_date is not None:
+            try:
+                as_of_date = date.fromisoformat(str(raw_date)[:10])
+            except ValueError:
+                as_of_date = None
+        consensus_eps_fq = _decimal_or_none(est.get("estimatedEpsAvg"))
+        consensus_rev_fq = _decimal_or_none(est.get("estimatedRevenueAvg"))
+        analyst_count_from_est = _int_or_none(est.get("numberAnalystEstimatedEps"))
+
+    # -- from consensus (analyst stock recommendations) --
+    buy_count: int | None = None
+    hold_count: int | None = None
+    sell_count: int | None = None
+
+    if consensus is not None:
+        buy_count = _int_or_none(consensus.get("buy"))
+        hold_count = _int_or_none(consensus.get("hold"))
+        sell_count = _int_or_none(consensus.get("sell"))
+
+    # -- from price_target --
+    price_target_mean: Decimal | None = None
+    price_target_high: Decimal | None = None
+    price_target_low: Decimal | None = None
+    analyst_count: int | None = analyst_count_from_est
+
+    if price_target is not None:
+        price_target_mean = _decimal_or_none(price_target.get("targetMean"))
+        price_target_high = _decimal_or_none(price_target.get("targetHigh"))
+        price_target_low = _decimal_or_none(price_target.get("targetLow"))
+        pt_analyst_count = _int_or_none(price_target.get("numberOfAnalysts"))
+        if pt_analyst_count is not None:
+            analyst_count = pt_analyst_count
+
+    # as_of_date is required for the dataclass — use today as a fallback if
+    # the estimates list was empty but consensus/price_target data is present
+    if as_of_date is None:
+        as_of_date = date.today()
+
+    return AnalystEstimates(
+        symbol=symbol,
+        as_of_date=as_of_date,
+        consensus_eps_fq=consensus_eps_fq,
+        consensus_eps_fy=None,
+        consensus_rev_fq=consensus_rev_fq,
+        consensus_rev_fy=None,
+        analyst_count=analyst_count,
+        buy_count=buy_count,
+        hold_count=hold_count,
+        sell_count=sell_count,
+        price_target_mean=price_target_mean,
+        price_target_high=price_target_high,
+        price_target_low=price_target_low,
+    )

--- a/app/providers/implementations/fmp.py
+++ b/app/providers/implementations/fmp.py
@@ -491,12 +491,15 @@ def _build_earnings_event(
     Build an EarningsEvent from a single FMP earnings calendar response row.
 
     Pure function — no I/O.
-    Raises ValueError if the required 'date' field cannot be parsed.
+    FMP fields: 'fiscalDateEnding' = fiscal period end, 'date' = announcement date.
+    Raises ValueError if 'fiscalDateEnding' cannot be parsed.
     """
-    fiscal_date_ending = date.fromisoformat(str(row["date"])[:10])
+    # FMP 'fiscalDateEnding' is the fiscal quarter end; 'date' is announcement date
+    raw_fiscal = row.get("fiscalDateEnding") or row.get("date")
+    fiscal_date_ending = date.fromisoformat(str(raw_fiscal)[:10])
 
     reporting_date: date | None = None
-    raw_reported = row.get("reportedDate")
+    raw_reported = row.get("date")  # announcement/reporting date
     if raw_reported is not None:
         try:
             reporting_date = date.fromisoformat(str(raw_reported)[:10])
@@ -575,7 +578,7 @@ def _build_analyst_estimates(
     analyst_count: int | None = analyst_count_from_est
 
     if price_target is not None:
-        price_target_mean = _decimal_or_none(price_target.get("targetMean"))
+        price_target_mean = _decimal_or_none(price_target.get("targetConsensus") or price_target.get("targetMean"))
         price_target_high = _decimal_or_none(price_target.get("targetHigh"))
         price_target_low = _decimal_or_none(price_target.get("targetLow"))
         pt_analyst_count = _int_or_none(price_target.get("numberOfAnalysts"))

--- a/app/providers/implementations/fmp.py
+++ b/app/providers/implementations/fmp.py
@@ -492,19 +492,27 @@ def _build_earnings_event(
 
     Pure function — no I/O.
     FMP fields: 'fiscalDateEnding' = fiscal period end, 'date' = announcement date.
-    Raises ValueError if 'fiscalDateEnding' cannot be parsed.
+    Raises ValueError if neither field yields a parseable date.
     """
-    # FMP 'fiscalDateEnding' is the fiscal quarter end; 'date' is announcement date
-    raw_fiscal = row.get("fiscalDateEnding") or row.get("date")
-    fiscal_date_ending = date.fromisoformat(str(raw_fiscal)[:10])
-
-    reporting_date: date | None = None
-    raw_reported = row.get("date")  # announcement/reporting date
-    if raw_reported is not None:
-        try:
-            reporting_date = date.fromisoformat(str(raw_reported)[:10])
-        except ValueError:
-            reporting_date = None
+    raw_fiscal = row.get("fiscalDateEnding")
+    if raw_fiscal is not None:
+        # Normal path: fiscalDateEnding is fiscal period end, date is announcement
+        fiscal_date_ending = date.fromisoformat(str(raw_fiscal)[:10])
+        reporting_date: date | None = None
+        raw_announced = row.get("date")
+        if raw_announced is not None:
+            try:
+                reporting_date = date.fromisoformat(str(raw_announced)[:10])
+            except ValueError:
+                reporting_date = None
+    else:
+        # Fallback: only 'date' present — use as fiscal period end, no reporting date
+        raw_date = row.get("date")
+        if raw_date is None:
+            msg = f"Earnings row for {symbol} has neither fiscalDateEnding nor date"
+            raise ValueError(msg)
+        fiscal_date_ending = date.fromisoformat(str(raw_date)[:10])
+        reporting_date = None
 
     eps_estimate = _decimal_or_none(row.get("epsEstimated"))
     eps_actual = _decimal_or_none(row.get("eps"))

--- a/app/services/enrichment.py
+++ b/app/services/enrichment.py
@@ -1,0 +1,261 @@
+"""
+Enrichment service.
+
+Fetches supplemental instrument data (company profile, earnings calendar,
+analyst consensus estimates) from an EnrichmentProvider and upserts it into
+the DB.
+
+The service layer owns identifier resolution and DB writes.
+The provider is a pure HTTP client and owns no DB access.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import psycopg
+
+from app.providers.enrichment import (
+    AnalystEstimates,
+    EarningsEvent,
+    EnrichmentProvider,
+    InstrumentProfileData,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EnrichmentRefreshSummary:
+    symbols_attempted: int
+    profiles_upserted: int
+    earnings_upserted: int
+    estimates_upserted: int
+    symbols_skipped: int
+
+
+def refresh_enrichment(
+    provider: EnrichmentProvider,
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    symbols: Sequence[tuple[str, str]],  # [(symbol, instrument_id), ...]
+) -> EnrichmentRefreshSummary:
+    """
+    For each symbol, fetch and upsert profile, earnings events, and analyst
+    estimates.
+
+    symbols is a sequence of (symbol, instrument_id) tuples.  If the provider
+    raises for a symbol, that symbol is counted as skipped and the batch
+    continues.
+    """
+    profiles_upserted = 0
+    earnings_upserted = 0
+    estimates_upserted = 0
+    skipped = 0
+    now = datetime.now(tz=UTC)
+
+    for symbol, instrument_id in symbols:
+        try:
+            profile = provider.get_profile_enrichment(symbol)
+            if profile is not None:
+                _upsert_profile(conn, instrument_id, profile, now)
+                profiles_upserted += 1
+
+            events = provider.get_earnings_calendar(symbol)
+            if events:
+                _upsert_earnings_events(conn, instrument_id, events)
+                earnings_upserted += len(events)
+
+            est = provider.get_analyst_estimates(symbol)
+            if est is not None:
+                _upsert_analyst_estimates(conn, instrument_id, est)
+                estimates_upserted += 1
+
+        except Exception:
+            logger.warning(
+                "Enrichment: failed to refresh %s, skipping",
+                symbol,
+                exc_info=True,
+            )
+            skipped += 1
+
+    return EnrichmentRefreshSummary(
+        symbols_attempted=len(symbols),
+        profiles_upserted=profiles_upserted,
+        earnings_upserted=earnings_upserted,
+        estimates_upserted=estimates_upserted,
+        symbols_skipped=skipped,
+    )
+
+
+def _upsert_profile(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    instrument_id: str,
+    profile: InstrumentProfileData,
+    now: datetime,
+) -> None:
+    """
+    Upsert a single instrument profile row into instrument_profile.
+    Idempotent — keyed on instrument_id.
+    Skips write if all tracked fields are unchanged (IS DISTINCT FROM).
+    """
+    conn.execute(
+        """
+        INSERT INTO instrument_profile (
+            instrument_id,
+            beta, public_float, avg_volume_30d, market_cap,
+            employees, ipo_date, is_actively_trading, fetched_at
+        )
+        VALUES (
+            %(instrument_id)s,
+            %(beta)s, %(public_float)s, %(avg_volume_30d)s, %(market_cap)s,
+            %(employees)s, %(ipo_date)s, %(is_actively_trading)s, %(fetched_at)s
+        )
+        ON CONFLICT (instrument_id) DO UPDATE SET
+            beta                = EXCLUDED.beta,
+            public_float        = EXCLUDED.public_float,
+            avg_volume_30d      = EXCLUDED.avg_volume_30d,
+            market_cap          = EXCLUDED.market_cap,
+            employees           = EXCLUDED.employees,
+            ipo_date            = EXCLUDED.ipo_date,
+            is_actively_trading = EXCLUDED.is_actively_trading,
+            fetched_at          = EXCLUDED.fetched_at
+        WHERE (
+            instrument_profile.beta                IS DISTINCT FROM EXCLUDED.beta OR
+            instrument_profile.public_float        IS DISTINCT FROM EXCLUDED.public_float OR
+            instrument_profile.avg_volume_30d      IS DISTINCT FROM EXCLUDED.avg_volume_30d OR
+            instrument_profile.market_cap          IS DISTINCT FROM EXCLUDED.market_cap OR
+            instrument_profile.employees           IS DISTINCT FROM EXCLUDED.employees OR
+            instrument_profile.ipo_date            IS DISTINCT FROM EXCLUDED.ipo_date OR
+            instrument_profile.is_actively_trading IS DISTINCT FROM EXCLUDED.is_actively_trading
+        )
+        """,
+        {
+            "instrument_id": instrument_id,
+            "beta": profile.beta,
+            "public_float": profile.public_float,
+            "avg_volume_30d": profile.avg_volume_30d,
+            "market_cap": profile.market_cap,
+            "employees": profile.employees,
+            "ipo_date": profile.ipo_date,
+            "is_actively_trading": profile.is_actively_trading,
+            "fetched_at": now,
+        },
+    )
+
+
+def _upsert_earnings_events(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    instrument_id: str,
+    events: Sequence[EarningsEvent],
+) -> None:
+    """
+    Upsert each earnings event into earnings_events.
+    Idempotent — keyed on (instrument_id, fiscal_date_ending).
+    Only updates a row when eps_actual, revenue_actual, or surprise_pct changed.
+    """
+    for event in events:
+        conn.execute(
+            """
+            INSERT INTO earnings_events (
+                instrument_id,
+                fiscal_date_ending, reporting_date,
+                eps_estimate, eps_actual,
+                revenue_estimate, revenue_actual,
+                surprise_pct
+            )
+            VALUES (
+                %(instrument_id)s,
+                %(fiscal_date_ending)s, %(reporting_date)s,
+                %(eps_estimate)s, %(eps_actual)s,
+                %(revenue_estimate)s, %(revenue_actual)s,
+                %(surprise_pct)s
+            )
+            ON CONFLICT (instrument_id, fiscal_date_ending) DO UPDATE SET
+                reporting_date   = EXCLUDED.reporting_date,
+                eps_estimate     = EXCLUDED.eps_estimate,
+                eps_actual       = EXCLUDED.eps_actual,
+                revenue_estimate = EXCLUDED.revenue_estimate,
+                revenue_actual   = EXCLUDED.revenue_actual,
+                surprise_pct     = EXCLUDED.surprise_pct,
+                fetched_at       = NOW()
+            WHERE (
+                earnings_events.eps_actual     IS DISTINCT FROM EXCLUDED.eps_actual OR
+                earnings_events.revenue_actual IS DISTINCT FROM EXCLUDED.revenue_actual OR
+                earnings_events.surprise_pct   IS DISTINCT FROM EXCLUDED.surprise_pct
+            )
+            """,
+            {
+                "instrument_id": instrument_id,
+                "fiscal_date_ending": event.fiscal_date_ending,
+                "reporting_date": event.reporting_date,
+                "eps_estimate": event.eps_estimate,
+                "eps_actual": event.eps_actual,
+                "revenue_estimate": event.revenue_estimate,
+                "revenue_actual": event.revenue_actual,
+                "surprise_pct": event.surprise_pct,
+            },
+        )
+
+
+def _upsert_analyst_estimates(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    instrument_id: str,
+    est: AnalystEstimates,
+) -> None:
+    """
+    Upsert analyst consensus estimates into analyst_estimates.
+    Idempotent — keyed on (instrument_id, as_of_date).
+    """
+    conn.execute(
+        """
+        INSERT INTO analyst_estimates (
+            instrument_id, as_of_date,
+            consensus_eps_fq, consensus_eps_fy,
+            consensus_rev_fq, consensus_rev_fy,
+            analyst_count, buy_count, hold_count, sell_count,
+            price_target_mean, price_target_high, price_target_low
+        )
+        VALUES (
+            %(instrument_id)s, %(as_of_date)s,
+            %(consensus_eps_fq)s, %(consensus_eps_fy)s,
+            %(consensus_rev_fq)s, %(consensus_rev_fy)s,
+            %(analyst_count)s, %(buy_count)s, %(hold_count)s, %(sell_count)s,
+            %(price_target_mean)s, %(price_target_high)s, %(price_target_low)s
+        )
+        ON CONFLICT (instrument_id, as_of_date) DO UPDATE SET
+            consensus_eps_fq  = EXCLUDED.consensus_eps_fq,
+            consensus_eps_fy  = EXCLUDED.consensus_eps_fy,
+            consensus_rev_fq  = EXCLUDED.consensus_rev_fq,
+            consensus_rev_fy  = EXCLUDED.consensus_rev_fy,
+            analyst_count     = EXCLUDED.analyst_count,
+            buy_count         = EXCLUDED.buy_count,
+            hold_count        = EXCLUDED.hold_count,
+            sell_count        = EXCLUDED.sell_count,
+            price_target_mean = EXCLUDED.price_target_mean,
+            price_target_high = EXCLUDED.price_target_high,
+            price_target_low  = EXCLUDED.price_target_low,
+            fetched_at        = NOW()
+        """,
+        {
+            "instrument_id": instrument_id,
+            "as_of_date": est.as_of_date,
+            "consensus_eps_fq": est.consensus_eps_fq,
+            "consensus_eps_fy": est.consensus_eps_fy,
+            "consensus_rev_fq": est.consensus_rev_fq,
+            "consensus_rev_fy": est.consensus_rev_fy,
+            "analyst_count": est.analyst_count,
+            "buy_count": est.buy_count,
+            "hold_count": est.hold_count,
+            "sell_count": est.sell_count,
+            "price_target_mean": est.price_target_mean,
+            "price_target_high": est.price_target_high,
+            "price_target_low": est.price_target_low,
+        },
+    )

--- a/app/services/enrichment.py
+++ b/app/services/enrichment.py
@@ -60,35 +60,39 @@ def refresh_enrichment(
     skipped = 0
     now = datetime.now(tz=UTC)
 
-    for symbol, instrument_id in symbols:
-        try:
-            profile = provider.get_profile_enrichment(symbol)
-            events = provider.get_earnings_calendar(symbol)
-            est = provider.get_analyst_estimates(symbol)
+    # Explicit outer transaction ensures the per-symbol conn.transaction()
+    # calls always create SAVEPOINTs (not full transactions).  A failure
+    # on symbol N rolls back only its savepoint; prior symbols' writes
+    # survive and are committed when the outer block exits.
+    with conn.transaction():
+        for symbol, instrument_id in symbols:
+            try:
+                profile = provider.get_profile_enrichment(symbol)
+                events = provider.get_earnings_calendar(symbol)
+                est = provider.get_analyst_estimates(symbol)
 
-            # Wrap all DB writes for this symbol in a savepoint so a
-            # constraint violation or transient error doesn't abort the
-            # outer transaction and silently drop prior symbols' writes.
-            with conn.transaction():
-                if profile is not None:
-                    _upsert_profile(conn, instrument_id, profile, now)
-                    profiles_upserted += 1
+                # Per-symbol savepoint — constraint violation or transient
+                # error rolls back only this symbol's writes.
+                with conn.transaction():
+                    if profile is not None:
+                        _upsert_profile(conn, instrument_id, profile, now)
+                        profiles_upserted += 1
 
-                if events:
-                    _upsert_earnings_events(conn, instrument_id, events)
-                    earnings_upserted += len(events)
+                    if events:
+                        _upsert_earnings_events(conn, instrument_id, events)
+                        earnings_upserted += len(events)
 
-                if est is not None:
-                    _upsert_analyst_estimates(conn, instrument_id, est)
-                    estimates_upserted += 1
+                    if est is not None:
+                        _upsert_analyst_estimates(conn, instrument_id, est)
+                        estimates_upserted += 1
 
-        except Exception:
-            logger.warning(
-                "Enrichment: failed to refresh %s, skipping",
-                symbol,
-                exc_info=True,
-            )
-            skipped += 1
+            except Exception:
+                logger.warning(
+                    "Enrichment: failed to refresh %s, skipping",
+                    symbol,
+                    exc_info=True,
+                )
+                skipped += 1
 
     return EnrichmentRefreshSummary(
         symbols_attempted=len(symbols),

--- a/app/services/enrichment.py
+++ b/app/services/enrichment.py
@@ -186,9 +186,12 @@ def _upsert_earnings_events(
                 surprise_pct     = EXCLUDED.surprise_pct,
                 fetched_at       = NOW()
             WHERE (
-                earnings_events.eps_actual     IS DISTINCT FROM EXCLUDED.eps_actual OR
-                earnings_events.revenue_actual IS DISTINCT FROM EXCLUDED.revenue_actual OR
-                earnings_events.surprise_pct   IS DISTINCT FROM EXCLUDED.surprise_pct
+                earnings_events.reporting_date   IS DISTINCT FROM EXCLUDED.reporting_date OR
+                earnings_events.eps_estimate     IS DISTINCT FROM EXCLUDED.eps_estimate OR
+                earnings_events.eps_actual       IS DISTINCT FROM EXCLUDED.eps_actual OR
+                earnings_events.revenue_estimate IS DISTINCT FROM EXCLUDED.revenue_estimate OR
+                earnings_events.revenue_actual   IS DISTINCT FROM EXCLUDED.revenue_actual OR
+                earnings_events.surprise_pct     IS DISTINCT FROM EXCLUDED.surprise_pct
             )
             """,
             {

--- a/app/services/enrichment.py
+++ b/app/services/enrichment.py
@@ -63,19 +63,24 @@ def refresh_enrichment(
     for symbol, instrument_id in symbols:
         try:
             profile = provider.get_profile_enrichment(symbol)
-            if profile is not None:
-                _upsert_profile(conn, instrument_id, profile, now)
-                profiles_upserted += 1
-
             events = provider.get_earnings_calendar(symbol)
-            if events:
-                _upsert_earnings_events(conn, instrument_id, events)
-                earnings_upserted += len(events)
-
             est = provider.get_analyst_estimates(symbol)
-            if est is not None:
-                _upsert_analyst_estimates(conn, instrument_id, est)
-                estimates_upserted += 1
+
+            # Wrap all DB writes for this symbol in a savepoint so a
+            # constraint violation or transient error doesn't abort the
+            # outer transaction and silently drop prior symbols' writes.
+            with conn.transaction():
+                if profile is not None:
+                    _upsert_profile(conn, instrument_id, profile, now)
+                    profiles_upserted += 1
+
+                if events:
+                    _upsert_earnings_events(conn, instrument_id, events)
+                    earnings_upserted += len(events)
+
+                if est is not None:
+                    _upsert_analyst_estimates(conn, instrument_id, est)
+                    estimates_upserted += 1
 
         except Exception:
             logger.warning(
@@ -245,6 +250,19 @@ def _upsert_analyst_estimates(
             price_target_high = EXCLUDED.price_target_high,
             price_target_low  = EXCLUDED.price_target_low,
             fetched_at        = NOW()
+        WHERE (
+            analyst_estimates.consensus_eps_fq  IS DISTINCT FROM EXCLUDED.consensus_eps_fq OR
+            analyst_estimates.consensus_eps_fy  IS DISTINCT FROM EXCLUDED.consensus_eps_fy OR
+            analyst_estimates.consensus_rev_fq  IS DISTINCT FROM EXCLUDED.consensus_rev_fq OR
+            analyst_estimates.consensus_rev_fy  IS DISTINCT FROM EXCLUDED.consensus_rev_fy OR
+            analyst_estimates.analyst_count     IS DISTINCT FROM EXCLUDED.analyst_count OR
+            analyst_estimates.buy_count         IS DISTINCT FROM EXCLUDED.buy_count OR
+            analyst_estimates.hold_count        IS DISTINCT FROM EXCLUDED.hold_count OR
+            analyst_estimates.sell_count        IS DISTINCT FROM EXCLUDED.sell_count OR
+            analyst_estimates.price_target_mean IS DISTINCT FROM EXCLUDED.price_target_mean OR
+            analyst_estimates.price_target_high IS DISTINCT FROM EXCLUDED.price_target_high OR
+            analyst_estimates.price_target_low  IS DISTINCT FROM EXCLUDED.price_target_low
+        )
         """,
         {
             "instrument_id": instrument_id,

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -659,7 +659,7 @@ def _load_instrument_data(
                     {"id": instrument_id},
                 )
                 estimates_row = cur.fetchone()
-        except psycopg.errors.UndefinedTable:
+        except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
             pass  # savepoint already rolled back; prior queries intact
 
     return {

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -210,38 +210,84 @@ def _value_score(
     base_value: float | None,
     bear_value: float | None,
     current_price: float | None,
+    *,
+    pe_ratio: float | None = None,
+    fcf_yield: float | None = None,
+    price_target_mean: float | None = None,
 ) -> tuple[float, list[str]]:
     """
     Thesis valuation upside as the primary value proxy.
 
-    upside_to_base  = (base_value - current_price) / current_price
-    downside_to_bear = (current_price - bear_value) / current_price
+    Primary path (thesis-based): when base_value is available.
+      upside_to_base  = (base_value - current_price) / current_price
+      downside_to_bear = (current_price - bear_value) / current_price
+
+    Fallback path (fundamentals-derived): when base_value is None.
+      Blends up to three signals — P/E attractiveness (35%), FCF yield (35%),
+      and price-target upside (30%) — re-normalised across available components.
 
     Returns (score, missing_components).
     """
     notes: list[str] = []
 
-    if base_value is None:
-        notes.append("base_value missing")
-    if bear_value is None:
-        notes.append("bear_value missing")
     if current_price is None or current_price <= 0:
         notes.append("current_price missing or zero")
 
-    if base_value is None or current_price is None or current_price <= 0:
+    if base_value is not None:
+        # ------------------------------------------------------------------
+        # Primary path: thesis-based
+        # ------------------------------------------------------------------
+        if bear_value is None:
+            notes.append("bear_value missing")
+
+        if current_price is None or current_price <= 0:
+            return 0.5, notes  # neutral-by-absence
+
+        upside_to_base = (base_value - current_price) / current_price
+        upside_score = _clip(upside_to_base / 0.50)  # 50% upside => 1.0
+
+        if bear_value is not None:
+            downside_to_bear = (current_price - bear_value) / current_price
+            downside_penalty = _clip(downside_to_bear / 0.50)
+        else:
+            downside_penalty = 0.5  # unknown downside — assume moderate risk
+            notes.append("bear_value missing; assuming 0.5 downside penalty")
+
+        score = 0.75 * upside_score + 0.25 * (1.0 - downside_penalty)
+        return _clip(score), notes
+
+    # ----------------------------------------------------------------------
+    # Fallback path: fundamentals-derived (no thesis)
+    # ----------------------------------------------------------------------
+    notes.append("base_value missing")
+    if bear_value is None:
+        notes.append("bear_value missing")
+
+    if current_price is None or current_price <= 0:
         return 0.5, notes  # neutral-by-absence
 
-    upside_to_base = (base_value - current_price) / current_price
-    upside_score = _clip(upside_to_base / 0.50)  # 50% upside => 1.0
+    components: list[tuple[float, float]] = []  # (score, weight)
 
-    if bear_value is not None:
-        downside_to_bear = (current_price - bear_value) / current_price
-        downside_penalty = _clip(downside_to_bear / 0.50)
-    else:
-        downside_penalty = 0.5  # unknown downside — assume moderate risk
-        notes.append("bear_value missing; assuming 0.5 downside penalty")
+    if pe_ratio is not None and pe_ratio > 0:
+        pe_score = _clip(1.0 - (pe_ratio - 10.0) / 40.0)
+        components.append((pe_score, 0.35))
 
-    score = 0.75 * upside_score + 0.25 * (1.0 - downside_penalty)
+    if fcf_yield is not None:
+        fy_score = _clip(fcf_yield / 0.08)
+        components.append((fy_score, 0.35))
+
+    if price_target_mean is not None:
+        pt_upside = (price_target_mean - current_price) / current_price
+        pt_score = _clip(pt_upside / 0.50)
+        components.append((pt_score, 0.30))
+
+    if not components:
+        notes.append("fundamentals fallback (no thesis)")
+        return 0.5, notes
+
+    total_weight = sum(w for _, w in components)
+    score = sum(s * w / total_weight for s, w in components)
+    notes.append("fundamentals fallback (no thesis)")
     return _clip(score), notes
 
 
@@ -581,6 +627,32 @@ def _load_instrument_data(
         )
         rf_row: dict[str, Any] | None = cur.fetchone()
 
+        # Valuation multiples from view (enrichment)
+        cur.execute(
+            """
+            SELECT pe_ratio, pb_ratio, p_fcf_ratio, fcf_yield,
+                   debt_equity_ratio, market_cap_live, current_price
+            FROM instrument_valuation
+            WHERE instrument_id = %(id)s
+            """,
+            {"id": instrument_id},
+        )
+        valuation_row: dict[str, Any] | None = cur.fetchone()
+
+        # Analyst estimates (latest)
+        cur.execute(
+            """
+            SELECT price_target_mean, price_target_high, price_target_low,
+                   analyst_count, buy_count, hold_count, sell_count
+            FROM analyst_estimates
+            WHERE instrument_id = %(id)s
+            ORDER BY as_of_date DESC
+            LIMIT 1
+            """,
+            {"id": instrument_id},
+        )
+        estimates_row: dict[str, Any] | None = cur.fetchone()
+
     return {
         "fund_rows": fund_rows,
         "price_row": price_row,
@@ -590,6 +662,8 @@ def _load_instrument_data(
         # AVG() always returns one row, even when no matching rows exist (returns NULL).
         # rf_row is therefore never None; avg_red_flag may be None if no filings matched.
         "avg_red_flag_score": _to_float(rf_row["avg_red_flag"]) if rf_row is not None else None,
+        "valuation_row": valuation_row,
+        "estimates_row": estimates_row,
     }
 
 
@@ -680,11 +754,9 @@ def compute_score(
     # Thesis
     if thesis_row:
         thesis_confidence = _to_float(thesis_row["confidence_score"])
-        base_value = _to_float(thesis_row["base_value"])
-        bear_value = _to_float(thesis_row["bear_value"])
         thesis_created_at: datetime | None = thesis_row["created_at"]
     else:
-        thesis_confidence = base_value = bear_value = None
+        thesis_confidence = None
         thesis_created_at = None
 
     # News sentiment rows: [(sentiment_score, importance_score), ...]
@@ -707,7 +779,17 @@ def compute_score(
     if q_notes:
         explanation_parts.append("quality: " + "; ".join(q_notes))
 
-    v_score, v_notes = _value_score(base_value, bear_value, current_price)
+    val_row = data.get("valuation_row")
+    est_row = data.get("estimates_row")
+
+    v_score, v_notes = _value_score(
+        base_value=_to_float(thesis_row["base_value"]) if thesis_row else None,
+        bear_value=_to_float(thesis_row["bear_value"]) if thesis_row else None,
+        current_price=current_price,
+        pe_ratio=_to_float(val_row["pe_ratio"]) if val_row else None,
+        fcf_yield=_to_float(val_row["fcf_yield"]) if val_row else None,
+        price_target_mean=_to_float(est_row["price_target_mean"]) if est_row else None,
+    )
     if v_notes:
         explanation_parts.append("value: " + "; ".join(v_notes))
 

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -627,31 +627,40 @@ def _load_instrument_data(
         )
         rf_row: dict[str, Any] | None = cur.fetchone()
 
-        # Valuation multiples from view (enrichment)
-        cur.execute(
-            """
-            SELECT pe_ratio, pb_ratio, p_fcf_ratio, fcf_yield,
-                   debt_equity_ratio, market_cap_live, current_price
-            FROM instrument_valuation
-            WHERE instrument_id = %(id)s
-            """,
-            {"id": instrument_id},
-        )
-        valuation_row: dict[str, Any] | None = cur.fetchone()
+        # Valuation multiples from view (enrichment).
+        # Degrade gracefully if the view or table does not exist yet
+        # (pre-migration environment, partial test setup).
+        # Wrapped in a savepoint so UndefinedTable only rolls back
+        # the enrichment queries, not the entire transaction.
+        valuation_row: dict[str, Any] | None = None
+        estimates_row: dict[str, Any] | None = None
+        try:
+            with conn.transaction():
+                cur.execute(
+                    """
+                    SELECT pe_ratio, pb_ratio, p_fcf_ratio, fcf_yield,
+                           debt_equity_ratio, market_cap_live, current_price
+                    FROM instrument_valuation
+                    WHERE instrument_id = %(id)s
+                    """,
+                    {"id": instrument_id},
+                )
+                valuation_row = cur.fetchone()
 
-        # Analyst estimates (latest)
-        cur.execute(
-            """
-            SELECT price_target_mean, price_target_high, price_target_low,
-                   analyst_count, buy_count, hold_count, sell_count
-            FROM analyst_estimates
-            WHERE instrument_id = %(id)s
-            ORDER BY as_of_date DESC
-            LIMIT 1
-            """,
-            {"id": instrument_id},
-        )
-        estimates_row: dict[str, Any] | None = cur.fetchone()
+                cur.execute(
+                    """
+                    SELECT price_target_mean, price_target_high, price_target_low,
+                           analyst_count, buy_count, hold_count, sell_count
+                    FROM analyst_estimates
+                    WHERE instrument_id = %(id)s
+                    ORDER BY as_of_date DESC
+                    LIMIT 1
+                    """,
+                    {"id": instrument_id},
+                )
+                estimates_row = cur.fetchone()
+        except psycopg.errors.UndefinedTable:
+            pass  # savepoint already rolled back; prior queries intact
 
     return {
         "fund_rows": fund_rows,

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -132,7 +132,7 @@ def _to_float(val: object) -> float | None:
         return None
     try:
         return float(val)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
 
 

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -330,55 +330,61 @@ def _assemble_context(
             "currency": inst_row[5],
         }
 
-    # Earnings history: latest 4 confirmed quarters
-    earnings_rows = conn.execute(
-        """
-        SELECT fiscal_date_ending, reporting_date,
-               eps_estimate, eps_actual, revenue_estimate, revenue_actual,
-               surprise_pct
-        FROM earnings_events
-        WHERE instrument_id = %(id)s
-          AND eps_actual IS NOT NULL
-        ORDER BY fiscal_date_ending DESC
-        LIMIT %(limit)s
-        """,
-        {"id": instrument_id, "limit": _MAX_EARNINGS_EVENTS},
-    ).fetchall()
-    earnings_history = [
-        {
-            "fiscal_date": str(r[0]),
-            "eps_estimate": _to_float(r[2]),
-            "eps_actual": _to_float(r[3]),
-            "revenue_actual": _to_float(r[5]),
-            "surprise_pct": _to_float(r[6]),
-        }
-        for r in earnings_rows
-    ]
-
-    # Analyst estimates: latest snapshot
-    estimates_row = conn.execute(
-        """
-        SELECT consensus_eps_fq, analyst_count, buy_count, hold_count,
-               sell_count, price_target_mean, price_target_high, price_target_low
-        FROM analyst_estimates
-        WHERE instrument_id = %(id)s
-        ORDER BY as_of_date DESC
-        LIMIT 1
-        """,
-        {"id": instrument_id},
-    ).fetchone()
+    # Earnings history and analyst estimates from enrichment tables.
+    # Wrapped in a savepoint so UndefinedTable (pre-migration) degrades
+    # gracefully instead of aborting thesis generation.
+    earnings_history: list[dict[str, object]] = []
     analyst_estimates: dict[str, object] | None = None
-    if estimates_row is not None:
-        analyst_estimates = {
-            "consensus_eps": _to_float(estimates_row[0]),
-            "analyst_count": estimates_row[1],
-            "buy_count": estimates_row[2],
-            "hold_count": estimates_row[3],
-            "sell_count": estimates_row[4],
-            "price_target_mean": _to_float(estimates_row[5]),
-            "price_target_high": _to_float(estimates_row[6]),
-            "price_target_low": _to_float(estimates_row[7]),
-        }
+    try:
+        with conn.transaction():
+            earnings_rows = conn.execute(
+                """
+                SELECT fiscal_date_ending, reporting_date,
+                       eps_estimate, eps_actual, revenue_estimate, revenue_actual,
+                       surprise_pct
+                FROM earnings_events
+                WHERE instrument_id = %(id)s
+                  AND eps_actual IS NOT NULL
+                ORDER BY fiscal_date_ending DESC
+                LIMIT %(limit)s
+                """,
+                {"id": instrument_id, "limit": _MAX_EARNINGS_EVENTS},
+            ).fetchall()
+            earnings_history = [
+                {
+                    "fiscal_date": str(r[0]),
+                    "eps_estimate": _to_float(r[2]),
+                    "eps_actual": _to_float(r[3]),
+                    "revenue_actual": _to_float(r[5]),
+                    "surprise_pct": _to_float(r[6]),
+                }
+                for r in earnings_rows
+            ]
+
+            estimates_row = conn.execute(
+                """
+                SELECT consensus_eps_fq, analyst_count, buy_count, hold_count,
+                       sell_count, price_target_mean, price_target_high, price_target_low
+                FROM analyst_estimates
+                WHERE instrument_id = %(id)s
+                ORDER BY as_of_date DESC
+                LIMIT 1
+                """,
+                {"id": instrument_id},
+            ).fetchone()
+            if estimates_row is not None:
+                analyst_estimates = {
+                    "consensus_eps": _to_float(estimates_row[0]),
+                    "analyst_count": estimates_row[1],
+                    "buy_count": estimates_row[2],
+                    "hold_count": estimates_row[3],
+                    "sell_count": estimates_row[4],
+                    "price_target_mean": _to_float(estimates_row[5]),
+                    "price_target_high": _to_float(estimates_row[6]),
+                    "price_target_low": _to_float(estimates_row[7]),
+                }
+    except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
+        pass  # pre-migration: degrade gracefully, thesis proceeds without enrichment
 
     return {
         "instrument": instrument,

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -331,10 +331,9 @@ def _assemble_context(
         }
 
     # Earnings history and analyst estimates from enrichment tables.
-    # Wrapped in a savepoint so UndefinedTable (pre-migration) degrades
-    # gracefully instead of aborting thesis generation.
+    # Each query gets its own savepoint so a missing analyst_estimates
+    # table doesn't discard successfully-fetched earnings history.
     earnings_history: list[dict[str, object]] = []
-    analyst_estimates: dict[str, object] | None = None
     try:
         with conn.transaction():
             earnings_rows = conn.execute(
@@ -360,7 +359,12 @@ def _assemble_context(
                 }
                 for r in earnings_rows
             ]
+    except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
+        pass  # pre-migration: degrade gracefully
 
+    analyst_estimates: dict[str, object] | None = None
+    try:
+        with conn.transaction():
             estimates_row = conn.execute(
                 """
                 SELECT consensus_eps_fq, analyst_count, buy_count, hold_count,
@@ -384,7 +388,7 @@ def _assemble_context(
                     "price_target_low": _to_float(estimates_row[7]),
                 }
     except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
-        pass  # pre-migration: degrade gracefully, thesis proceeds without enrichment
+        pass  # pre-migration: degrade gracefully
 
     return {
         "instrument": instrument,

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -76,7 +76,6 @@ _MAX_PRIOR_THESES = 1
 _MAX_FILING_EVENTS = 3
 _MAX_FUNDAMENTALS_SNAPSHOTS = 5  # latest + 4 prior
 _MAX_EARNINGS_EVENTS = 4  # 1 year of quarterly history (confirmed only)
-_MAX_ANALYST_ESTIMATES = 1  # latest snapshot only
 _MAX_NEWS_EVENTS = 10
 _NEWS_LOOKBACK_DAYS = 30
 
@@ -364,9 +363,9 @@ def _assemble_context(
         FROM analyst_estimates
         WHERE instrument_id = %(id)s
         ORDER BY as_of_date DESC
-        LIMIT %(limit)s
+        LIMIT 1
         """,
-        {"id": instrument_id, "limit": _MAX_ANALYST_ESTIMATES},
+        {"id": instrument_id},
     ).fetchone()
     analyst_estimates: dict[str, object] | None = None
     if estimates_row is not None:

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -14,6 +14,8 @@ Context caps (v1 hard limits):
   - prior thesis:         latest 1
   - filing events:        latest 3
   - fundamentals:         latest snapshot + up to 4 prior snapshots
+  - earnings events:      latest 4 quarters (confirmed only)
+  - analyst estimates:    latest 1 snapshot
   - news events:          latest 10 from last 30 days, importance desc → recency desc
 
 Claude model: claude-sonnet-4-6 for both writer and critic calls.
@@ -73,6 +75,8 @@ _MAX_TOKENS_CRITIC = 1024
 _MAX_PRIOR_THESES = 1
 _MAX_FILING_EVENTS = 3
 _MAX_FUNDAMENTALS_SNAPSHOTS = 5  # latest + 4 prior
+_MAX_EARNINGS_EVENTS = 4  # 1 year of quarterly history (confirmed only)
+_MAX_ANALYST_ESTIMATES = 1  # latest snapshot only
 _MAX_NEWS_EVENTS = 10
 _NEWS_LOOKBACK_DAYS = 30
 
@@ -128,7 +132,7 @@ def _to_float(val: object) -> float | None:
         return None
     try:
         return float(val)  # type: ignore[arg-type]
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return None
 
 
@@ -327,12 +331,64 @@ def _assemble_context(
             "currency": inst_row[5],
         }
 
+    # Earnings history: latest 4 confirmed quarters
+    earnings_rows = conn.execute(
+        """
+        SELECT fiscal_date_ending, reporting_date,
+               eps_estimate, eps_actual, revenue_estimate, revenue_actual,
+               surprise_pct
+        FROM earnings_events
+        WHERE instrument_id = %(id)s
+          AND eps_actual IS NOT NULL
+        ORDER BY fiscal_date_ending DESC
+        LIMIT %(limit)s
+        """,
+        {"id": instrument_id, "limit": _MAX_EARNINGS_EVENTS},
+    ).fetchall()
+    earnings_history = [
+        {
+            "fiscal_date": str(r[0]),
+            "eps_estimate": _to_float(r[2]),
+            "eps_actual": _to_float(r[3]),
+            "revenue_actual": _to_float(r[5]),
+            "surprise_pct": _to_float(r[6]),
+        }
+        for r in earnings_rows
+    ]
+
+    # Analyst estimates: latest snapshot
+    estimates_row = conn.execute(
+        """
+        SELECT consensus_eps_fq, analyst_count, buy_count, hold_count,
+               sell_count, price_target_mean, price_target_high, price_target_low
+        FROM analyst_estimates
+        WHERE instrument_id = %(id)s
+        ORDER BY as_of_date DESC
+        LIMIT %(limit)s
+        """,
+        {"id": instrument_id, "limit": _MAX_ANALYST_ESTIMATES},
+    ).fetchone()
+    analyst_estimates: dict[str, object] | None = None
+    if estimates_row is not None:
+        analyst_estimates = {
+            "consensus_eps": _to_float(estimates_row[0]),
+            "analyst_count": estimates_row[1],
+            "buy_count": estimates_row[2],
+            "hold_count": estimates_row[3],
+            "sell_count": estimates_row[4],
+            "price_target_mean": _to_float(estimates_row[5]),
+            "price_target_high": _to_float(estimates_row[6]),
+            "price_target_low": _to_float(estimates_row[7]),
+        }
+
     return {
         "instrument": instrument,
         "fundamentals": fundamentals,
         "filings": filings,
         "news": news,
         "prior_thesis": prior_thesis,
+        "earnings_history": earnings_history,
+        "analyst_estimates": analyst_estimates,
     }
 
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -40,6 +40,7 @@ from app.providers.implementations.sec_edgar import SecFilingsProvider
 from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
 from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
 from app.services.coverage import review_coverage, seed_coverage
+from app.services.enrichment import refresh_enrichment
 from app.services.execution_guard import evaluate_recommendation
 from app.services.filings import FilingsRefreshSummary, refresh_filings, upsert_cik_mapping
 from app.services.fundamentals import refresh_fundamentals
@@ -725,6 +726,27 @@ def daily_research_refresh() -> None:
                 "FMP_API_KEY not set; %d non-US instruments will have no fundamentals",
                 len(fmp_symbols),
             )
+
+        # Enrichment — profile, earnings, analyst estimates (FMP)
+        if settings.fmp_api_key:
+            try:
+                with (
+                    FmpFundamentalsProvider(api_key=settings.fmp_api_key) as fmp,
+                    psycopg.connect(settings.database_url) as conn,
+                ):
+                    enrich_summary = refresh_enrichment(fmp, conn, symbols)
+                    conn.commit()
+                total_rows += enrich_summary.profiles_upserted + enrich_summary.earnings_upserted
+                logger.info(
+                    "Enrichment refresh: attempted=%d profiles=%d earnings=%d estimates=%d skipped=%d",
+                    enrich_summary.symbols_attempted,
+                    enrich_summary.profiles_upserted,
+                    enrich_summary.earnings_upserted,
+                    enrich_summary.estimates_upserted,
+                    enrich_summary.symbols_skipped,
+                )
+            except Exception:
+                logger.warning("Enrichment refresh failed", exc_info=True)
 
         # Filings — SEC EDGAR
         with (

--- a/sql/024_fundamentals_enrichment.sql
+++ b/sql/024_fundamentals_enrichment.sql
@@ -102,40 +102,51 @@ CREATE INDEX IF NOT EXISTS idx_analyst_estimates_instrument
 -- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE VIEW instrument_valuation AS
+WITH priced AS (
+    -- Best available price: last if positive, else bid/ask midpoint.
+    -- Matches the scorer's fallback logic in _load_instrument_data.
+    SELECT instrument_id,
+           COALESCE(
+               NULLIF(GREATEST(last, 0), 0),
+               CASE WHEN bid > 0 AND ask > 0 THEN (bid + ask) / 2 END
+           )                       AS price,
+           quoted_at
+    FROM quotes
+)
 SELECT
     fs.instrument_id,
-    q.last                                                          AS current_price,
-    q.quoted_at                                                     AS price_as_of,
+    p.price                                                         AS current_price,
+    p.quoted_at                                                     AS price_as_of,
     fs.as_of_date                                                   AS fundamentals_as_of,
 
     -- Live market cap: price × shares (both must be positive)
     CASE
-        WHEN q.last > 0 AND fs.shares_outstanding > 0
-        THEN q.last * fs.shares_outstanding
+        WHEN p.price > 0 AND fs.shares_outstanding > 0
+        THEN p.price * fs.shares_outstanding
     END                                                             AS market_cap_live,
 
     -- Price / Earnings
     CASE
-        WHEN q.last > 0 AND fs.eps > 0
-        THEN q.last / fs.eps
+        WHEN p.price > 0 AND fs.eps > 0
+        THEN p.price / fs.eps
     END                                                             AS pe_ratio,
 
     -- Price / Book
     CASE
-        WHEN q.last > 0 AND fs.book_value > 0
-        THEN q.last / fs.book_value
+        WHEN p.price > 0 AND fs.book_value > 0
+        THEN p.price / fs.book_value
     END                                                             AS pb_ratio,
 
     -- Price / Free Cash Flow  (market cap / total FCF)
     CASE
-        WHEN q.last > 0 AND fs.shares_outstanding > 0 AND fs.fcf > 0
-        THEN (q.last * fs.shares_outstanding) / fs.fcf
+        WHEN p.price > 0 AND fs.shares_outstanding > 0 AND fs.fcf > 0
+        THEN (p.price * fs.shares_outstanding) / fs.fcf
     END                                                             AS p_fcf_ratio,
 
     -- FCF Yield  (total FCF / market cap)
     CASE
-        WHEN q.last > 0 AND fs.shares_outstanding > 0
-        THEN fs.fcf / (q.last * fs.shares_outstanding)
+        WHEN p.price > 0 AND fs.shares_outstanding > 0
+        THEN fs.fcf / (p.price * fs.shares_outstanding)
     END                                                             AS fcf_yield,
 
     -- Debt / Equity  (total debt / (book value per share × shares))
@@ -157,4 +168,4 @@ FROM (
     FROM fundamentals_snapshot
     ORDER BY instrument_id, as_of_date DESC
 ) fs
-JOIN quotes q USING (instrument_id);
+JOIN priced p USING (instrument_id);

--- a/sql/024_fundamentals_enrichment.sql
+++ b/sql/024_fundamentals_enrichment.sql
@@ -1,0 +1,160 @@
+-- Migration 024: fundamentals enrichment schema
+--
+-- Adds three tables that extend the tradable-universe data model with
+-- provider-sourced fundamental data points needed by the ranking and
+-- thesis engines:
+--
+--   instrument_profile   — static/slowly-changing profile fields (beta, float,
+--                          market-cap, employees, IPO date).  One row per
+--                          instrument, refreshed daily from FMP /v3/profile.
+--
+--   earnings_events      — historical and upcoming earnings reports with
+--                          estimate vs. actual EPS/revenue and surprise %.
+--                          Idempotent upsert key: (instrument_id, fiscal_date_ending).
+--
+--   analyst_estimates    — weekly snapshot of consensus EPS/revenue forecasts
+--                          and rating distribution.
+--                          Idempotent upsert key: (instrument_id, as_of_date).
+--
+-- Also adds:
+--
+--   instrument_valuation — view that joins the latest fundamentals_snapshot
+--                          with the live quotes row to produce derived
+--                          multiples (P/E, P/B, P/FCF, FCF yield,
+--                          debt/equity, live market cap).
+--
+--   CURRENCY ASSUMPTION (v1): fundamentals are stored in the instrument's
+--   reporting currency (usually USD); quotes are in the instrument's trading
+--   currency on eToro.  For most US equities these are the same.  A future
+--   migration must add explicit currency normalisation before this view is
+--   used for cross-currency comparisons.
+
+-- ---------------------------------------------------------------------------
+-- 1. instrument_profile
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS instrument_profile (
+    instrument_id       BIGINT PRIMARY KEY REFERENCES instruments(instrument_id),
+    beta                NUMERIC(10,4),
+    public_float        BIGINT,           -- shares available for public trading
+    avg_volume_30d      BIGINT,           -- 30-day average daily volume
+    market_cap          NUMERIC(20,2),    -- latest market cap from provider
+    employees           INTEGER,
+    ipo_date            DATE,
+    is_actively_trading BOOLEAN,
+    fetched_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. earnings_events
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS earnings_events (
+    earnings_event_id  BIGSERIAL PRIMARY KEY,
+    instrument_id      BIGINT NOT NULL REFERENCES instruments(instrument_id),
+    fiscal_date_ending DATE NOT NULL,
+    reporting_date     DATE,
+    eps_estimate       NUMERIC(12,4),
+    eps_actual         NUMERIC(12,4),
+    revenue_estimate   NUMERIC(20,2),
+    revenue_actual     NUMERIC(20,2),
+    surprise_pct       NUMERIC(10,4),    -- (actual - estimate) / |estimate| * 100
+    fetched_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (instrument_id, fiscal_date_ending)
+);
+
+CREATE INDEX IF NOT EXISTS idx_earnings_events_instrument
+    ON earnings_events(instrument_id, fiscal_date_ending DESC);
+
+-- ---------------------------------------------------------------------------
+-- 3. analyst_estimates
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS analyst_estimates (
+    estimate_id        BIGSERIAL PRIMARY KEY,
+    instrument_id      BIGINT NOT NULL REFERENCES instruments(instrument_id),
+    as_of_date         DATE NOT NULL,
+    consensus_eps_fq   NUMERIC(12,4),    -- next fiscal quarter
+    consensus_eps_fy   NUMERIC(12,4),    -- next fiscal year
+    consensus_rev_fq   NUMERIC(20,2),
+    consensus_rev_fy   NUMERIC(20,2),
+    analyst_count      INTEGER,
+    buy_count          INTEGER,
+    hold_count         INTEGER,
+    sell_count         INTEGER,
+    price_target_mean  NUMERIC(18,6),
+    price_target_high  NUMERIC(18,6),
+    price_target_low   NUMERIC(18,6),
+    fetched_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (instrument_id, as_of_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_analyst_estimates_instrument
+    ON analyst_estimates(instrument_id, as_of_date DESC);
+
+-- ---------------------------------------------------------------------------
+-- 4. instrument_valuation view
+--
+-- Uses DISTINCT ON to select the latest fundamentals_snapshot per instrument
+-- (more readable and typically faster than a correlated MAX subquery).
+-- Guards are applied so that division-by-zero and nonsense ratios are
+-- suppressed: NULL is returned whenever a denominator is zero or NULL.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE VIEW instrument_valuation AS
+SELECT
+    fs.instrument_id,
+    q.last                                                          AS current_price,
+    q.quoted_at                                                     AS price_as_of,
+    fs.as_of_date                                                   AS fundamentals_as_of,
+
+    -- Live market cap: price × shares (both must be positive)
+    CASE
+        WHEN q.last > 0 AND fs.shares_outstanding > 0
+        THEN q.last * fs.shares_outstanding
+    END                                                             AS market_cap_live,
+
+    -- Price / Earnings
+    CASE
+        WHEN q.last > 0 AND fs.eps > 0
+        THEN q.last / fs.eps
+    END                                                             AS pe_ratio,
+
+    -- Price / Book
+    CASE
+        WHEN q.last > 0 AND fs.book_value > 0
+        THEN q.last / fs.book_value
+    END                                                             AS pb_ratio,
+
+    -- Price / Free Cash Flow  (market cap / total FCF)
+    CASE
+        WHEN q.last > 0 AND fs.shares_outstanding > 0 AND fs.fcf > 0
+        THEN (q.last * fs.shares_outstanding) / fs.fcf
+    END                                                             AS p_fcf_ratio,
+
+    -- FCF Yield  (total FCF / market cap)
+    CASE
+        WHEN q.last > 0 AND fs.shares_outstanding > 0
+        THEN fs.fcf / (q.last * fs.shares_outstanding)
+    END                                                             AS fcf_yield,
+
+    -- Debt / Equity  (total debt / (book value per share × shares))
+    CASE
+        WHEN fs.book_value > 0 AND fs.shares_outstanding > 0
+        THEN fs.debt / (fs.book_value * fs.shares_outstanding)
+    END                                                             AS debt_equity_ratio
+
+FROM (
+    -- Latest fundamentals_snapshot per instrument
+    SELECT DISTINCT ON (instrument_id)
+        instrument_id,
+        as_of_date,
+        eps,
+        book_value,
+        fcf,
+        shares_outstanding,
+        debt
+    FROM fundamentals_snapshot
+    ORDER BY instrument_id, as_of_date DESC
+) fs
+JOIN quotes q USING (instrument_id);

--- a/tests/test_enrichment_provider.py
+++ b/tests/test_enrichment_provider.py
@@ -1,0 +1,262 @@
+"""
+Unit tests for FMP enrichment normaliser functions.
+
+Tests only the pure normaliser functions (_build_profile_data,
+_build_earnings_event, _build_analyst_estimates) — no I/O, no HTTP.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.providers.implementations.fmp import (
+    _build_analyst_estimates,
+    _build_earnings_event,
+    _build_profile_data,
+)
+
+# ---------------------------------------------------------------------------
+# _build_profile_data
+# ---------------------------------------------------------------------------
+
+
+class TestBuildProfileData:
+    def test_build_profile_data_full(self) -> None:
+        """All FMP profile fields are correctly mapped and converted."""
+        item = {
+            "beta": "1.23",
+            "floatShares": 15_000_000_000,
+            "volAvg": 80_000_000,
+            "mktCap": 2_800_000_000_000,
+            "fullTimeEmployees": 164_000,
+            "ipoDate": "1980-12-12",
+            "isActivelyTrading": True,
+        }
+        result = _build_profile_data("AAPL", item)
+
+        assert result.symbol == "AAPL"
+        assert result.beta == pytest.approx(Decimal("1.23"))
+        assert result.public_float == 15_000_000_000
+        assert result.avg_volume_30d == 80_000_000
+        assert result.market_cap == Decimal("2800000000000")
+        assert result.employees == 164_000
+        assert result.ipo_date == date(1980, 12, 12)
+        assert result.is_actively_trading is True
+
+    def test_build_profile_data_missing_fields(self) -> None:
+        """Minimal response — all optional fields should be None."""
+        result = _build_profile_data("XYZ", {})
+
+        assert result.symbol == "XYZ"
+        assert result.beta is None
+        assert result.public_float is None
+        assert result.avg_volume_30d is None
+        assert result.market_cap is None
+        assert result.employees is None
+        assert result.ipo_date is None
+        assert result.is_actively_trading is None
+
+    def test_build_profile_data_invalid_ipo_date(self) -> None:
+        """Unparseable ipoDate yields None, not an exception."""
+        item = {"ipoDate": "not-a-date"}
+        result = _build_profile_data("FOO", item)
+        assert result.ipo_date is None
+
+    def test_build_profile_data_is_actively_trading_non_bool(self) -> None:
+        """String or int for isActivelyTrading should be coerced to None."""
+        item = {"isActivelyTrading": "true"}
+        result = _build_profile_data("BAR", item)
+        assert result.is_actively_trading is None
+
+    def test_build_profile_data_is_actively_trading_false(self) -> None:
+        """Boolean False should be preserved (not treated as falsy None)."""
+        item = {"isActivelyTrading": False}
+        result = _build_profile_data("DELIST", item)
+        assert result.is_actively_trading is False
+
+
+# ---------------------------------------------------------------------------
+# _build_earnings_event
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEarningsEvent:
+    def test_build_earnings_event_full(self) -> None:
+        """Full FMP row including EPS, revenue, and surprise calculation."""
+        row = {
+            "date": "2024-09-28",
+            "reportedDate": "2024-10-31",
+            "epsEstimated": "1.50",
+            "eps": "1.64",
+            "revenueEstimated": "94_000_000_000",
+            "revenue": "94_930_000_000",
+        }
+        event = _build_earnings_event("AAPL", row)
+
+        assert event.symbol == "AAPL"
+        assert event.fiscal_date_ending == date(2024, 9, 28)
+        assert event.reporting_date == date(2024, 10, 31)
+        assert event.eps_estimate == Decimal("1.50")
+        assert event.eps_actual == Decimal("1.64")
+        assert event.revenue_estimate == Decimal("94_000_000_000")
+        assert event.revenue_actual == Decimal("94_930_000_000")
+        # surprise_pct = (1.64 - 1.50) / abs(1.50) * 100
+        expected_surprise = (Decimal("1.64") - Decimal("1.50")) / abs(Decimal("1.50")) * Decimal(100)
+        assert event.surprise_pct == pytest.approx(expected_surprise)
+
+    def test_build_earnings_event_missing_eps(self) -> None:
+        """When EPS fields are absent, surprise should be None."""
+        row = {
+            "date": "2024-06-29",
+            "reportedDate": "2024-07-30",
+            "revenueEstimated": "85_000_000_000",
+            "revenue": "85_777_000_000",
+        }
+        event = _build_earnings_event("AAPL", row)
+
+        assert event.eps_estimate is None
+        assert event.eps_actual is None
+        assert event.surprise_pct is None
+        assert event.revenue_estimate is not None
+        assert event.revenue_actual is not None
+
+    def test_build_earnings_event_zero_eps_estimate(self) -> None:
+        """eps_estimate == 0 must not cause a division by zero — surprise should be None."""
+        row = {
+            "date": "2023-12-30",
+            "epsEstimated": "0",
+            "eps": "0.05",
+        }
+        event = _build_earnings_event("TSLA", row)
+
+        # _decimal_or_none("0") returns Decimal("0") — the guard (eps_estimate != 0) prevents
+        # division by zero and leaves surprise_pct as None
+        assert event.eps_estimate == Decimal("0")
+        assert event.eps_actual == Decimal("0.05")
+        assert event.surprise_pct is None
+
+    def test_build_earnings_event_missing_reported_date(self) -> None:
+        """reportedDate absent should give reporting_date=None."""
+        row = {"date": "2025-03-29"}
+        event = _build_earnings_event("NVDA", row)
+
+        assert event.reporting_date is None
+        assert event.fiscal_date_ending == date(2025, 3, 29)
+
+    def test_build_earnings_event_invalid_reported_date(self) -> None:
+        """Unparseable reportedDate yields None, not an exception."""
+        row = {"date": "2025-03-29", "reportedDate": "TBD"}
+        event = _build_earnings_event("NVDA", row)
+
+        assert event.reporting_date is None
+
+
+# ---------------------------------------------------------------------------
+# _build_analyst_estimates
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAnalystEstimates:
+    def test_build_analyst_estimates_full(self) -> None:
+        """All three inputs present — all fields populated correctly."""
+        estimates = [
+            {
+                "date": "2025-03-31",
+                "estimatedEpsAvg": "2.35",
+                "estimatedRevenueAvg": "124_000_000_000",
+                "numberAnalystEstimatedEps": 25,
+            }
+        ]
+        consensus: dict[str, object] = {
+            "buy": 32,
+            "hold": 8,
+            "sell": 3,
+        }
+        price_target: dict[str, object] = {
+            "targetMean": "215.50",
+            "targetHigh": "260.00",
+            "targetLow": "170.00",
+            "numberOfAnalysts": 40,
+        }
+
+        result = _build_analyst_estimates("AAPL", estimates, consensus, price_target)
+
+        assert result is not None
+        assert result.symbol == "AAPL"
+        assert result.as_of_date == date(2025, 3, 31)
+        assert result.consensus_eps_fq == Decimal("2.35")
+        assert result.consensus_eps_fy is None
+        assert result.consensus_rev_fq == Decimal("124_000_000_000")
+        assert result.consensus_rev_fy is None
+        # numberOfAnalysts from price_target takes precedence over numberAnalystEstimatedEps
+        assert result.analyst_count == 40
+        assert result.buy_count == 32
+        assert result.hold_count == 8
+        assert result.sell_count == 3
+        assert result.price_target_mean == Decimal("215.50")
+        assert result.price_target_high == Decimal("260.00")
+        assert result.price_target_low == Decimal("170.00")
+
+    def test_build_analyst_estimates_no_data(self) -> None:
+        """All inputs empty/None — must return None."""
+        result = _build_analyst_estimates("NOPE", [], None, None)
+        assert result is None
+
+    def test_build_analyst_estimates_partial_estimates_only(self) -> None:
+        """Only estimates present — consensus and price target fields are None."""
+        estimates = [
+            {
+                "date": "2025-06-30",
+                "estimatedEpsAvg": "3.10",
+                "estimatedRevenueAvg": "135_000_000_000",
+                "numberAnalystEstimatedEps": 20,
+            }
+        ]
+
+        result = _build_analyst_estimates("AAPL", estimates, None, None)
+
+        assert result is not None
+        assert result.consensus_eps_fq == Decimal("3.10")
+        assert result.analyst_count == 20
+        assert result.buy_count is None
+        assert result.hold_count is None
+        assert result.sell_count is None
+        assert result.price_target_mean is None
+        assert result.price_target_high is None
+        assert result.price_target_low is None
+
+    def test_build_analyst_estimates_consensus_only(self) -> None:
+        """Only consensus present — as_of_date falls back to today, eps/rev are None."""
+        consensus: dict[str, object] = {"buy": 15, "hold": 5, "sell": 2}
+
+        result = _build_analyst_estimates("MSFT", [], consensus, None)
+
+        assert result is not None
+        assert result.consensus_eps_fq is None
+        assert result.consensus_rev_fq is None
+        assert result.buy_count == 15
+        assert result.hold_count == 5
+        assert result.sell_count == 2
+        assert result.as_of_date == date.today()
+
+    def test_build_analyst_estimates_analyst_count_fallback(self) -> None:
+        """When price_target has no numberOfAnalysts, fall back to estimates count."""
+        estimates = [
+            {
+                "date": "2025-03-31",
+                "estimatedEpsAvg": "1.00",
+                "numberAnalystEstimatedEps": 12,
+            }
+        ]
+        price_target: dict[str, object] = {
+            "targetMean": "100.00",
+            # numberOfAnalysts absent
+        }
+
+        result = _build_analyst_estimates("TST", estimates, None, price_target)
+
+        assert result is not None
+        assert result.analyst_count == 12

--- a/tests/test_enrichment_provider.py
+++ b/tests/test_enrichment_provider.py
@@ -87,8 +87,8 @@ class TestBuildEarningsEvent:
     def test_build_earnings_event_full(self) -> None:
         """Full FMP row including EPS, revenue, and surprise calculation."""
         row = {
-            "date": "2024-09-28",
-            "reportedDate": "2024-10-31",
+            "fiscalDateEnding": "2024-09-28",
+            "date": "2024-10-31",
             "epsEstimated": "1.50",
             "eps": "1.64",
             "revenueEstimated": "94_000_000_000",
@@ -110,8 +110,8 @@ class TestBuildEarningsEvent:
     def test_build_earnings_event_missing_eps(self) -> None:
         """When EPS fields are absent, surprise should be None."""
         row = {
-            "date": "2024-06-29",
-            "reportedDate": "2024-07-30",
+            "fiscalDateEnding": "2024-06-29",
+            "date": "2024-07-30",
             "revenueEstimated": "85_000_000_000",
             "revenue": "85_777_000_000",
         }
@@ -126,7 +126,8 @@ class TestBuildEarningsEvent:
     def test_build_earnings_event_zero_eps_estimate(self) -> None:
         """eps_estimate == 0 must not cause a division by zero — surprise should be None."""
         row = {
-            "date": "2023-12-30",
+            "fiscalDateEnding": "2023-12-30",
+            "date": "2024-01-25",
             "epsEstimated": "0",
             "eps": "0.05",
         }
@@ -139,19 +140,20 @@ class TestBuildEarningsEvent:
         assert event.surprise_pct is None
 
     def test_build_earnings_event_missing_reported_date(self) -> None:
-        """reportedDate absent should give reporting_date=None."""
-        row = {"date": "2025-03-29"}
+        """When 'date' (announcement) is absent, reporting_date should be None."""
+        row = {"fiscalDateEnding": "2025-03-29"}
         event = _build_earnings_event("NVDA", row)
 
         assert event.reporting_date is None
         assert event.fiscal_date_ending == date(2025, 3, 29)
 
     def test_build_earnings_event_invalid_reported_date(self) -> None:
-        """Unparseable reportedDate yields None, not an exception."""
-        row = {"date": "2025-03-29", "reportedDate": "TBD"}
+        """Unparseable 'date' (announcement) yields reporting_date=None."""
+        row = {"fiscalDateEnding": "2025-03-29", "date": "TBD"}
         event = _build_earnings_event("NVDA", row)
 
         assert event.reporting_date is None
+        assert event.fiscal_date_ending == date(2025, 3, 29)
 
 
 # ---------------------------------------------------------------------------
@@ -176,7 +178,7 @@ class TestBuildAnalystEstimates:
             "sell": 3,
         }
         price_target: dict[str, object] = {
-            "targetMean": "215.50",
+            "targetConsensus": "215.50",
             "targetHigh": "260.00",
             "targetLow": "170.00",
             "numberOfAnalysts": 40,
@@ -252,7 +254,7 @@ class TestBuildAnalystEstimates:
             }
         ]
         price_target: dict[str, object] = {
-            "targetMean": "100.00",
+            "targetConsensus": "100.00",
             # numberOfAnalysts absent
         }
 

--- a/tests/test_enrichment_provider.py
+++ b/tests/test_enrichment_provider.py
@@ -155,6 +155,19 @@ class TestBuildEarningsEvent:
         assert event.reporting_date is None
         assert event.fiscal_date_ending == date(2025, 3, 29)
 
+    def test_build_earnings_event_no_fiscal_or_date(self) -> None:
+        """Row with neither fiscalDateEnding nor date raises ValueError."""
+        with pytest.raises(ValueError, match="neither fiscalDateEnding nor date"):
+            _build_earnings_event("BAD", {})
+
+    def test_build_earnings_event_fallback_to_date(self) -> None:
+        """When only 'date' is present, it becomes fiscal_date_ending."""
+        row = {"date": "2025-06-30", "eps": "1.20"}
+        event = _build_earnings_event("OLD", row)
+
+        assert event.fiscal_date_ending == date(2025, 6, 30)
+        assert event.reporting_date is None
+
 
 # ---------------------------------------------------------------------------
 # _build_analyst_estimates

--- a/tests/test_enrichment_service.py
+++ b/tests/test_enrichment_service.py
@@ -1,0 +1,240 @@
+"""Unit tests for app.services.enrichment."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from app.providers.enrichment import AnalystEstimates, EarningsEvent, InstrumentProfileData
+from app.services.enrichment import (
+    EnrichmentRefreshSummary,
+    _upsert_analyst_estimates,
+    _upsert_earnings_events,
+    _upsert_profile,
+    refresh_enrichment,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 4, 14, 12, 0, 0, tzinfo=UTC)
+
+_PROFILE = InstrumentProfileData(
+    symbol="AAPL",
+    beta=Decimal("1.20"),
+    public_float=15_000_000_000,
+    avg_volume_30d=80_000_000,
+    market_cap=Decimal("3000000000000"),
+    employees=160_000,
+    ipo_date=date(1980, 12, 12),
+    is_actively_trading=True,
+)
+
+_EARNINGS_EVENT = EarningsEvent(
+    symbol="AAPL",
+    fiscal_date_ending=date(2026, 3, 31),
+    reporting_date=date(2026, 4, 30),
+    eps_estimate=Decimal("1.50"),
+    eps_actual=Decimal("1.62"),
+    revenue_estimate=Decimal("93_000_000_000"),
+    revenue_actual=Decimal("95_000_000_000"),
+    surprise_pct=Decimal("0.08"),
+)
+
+_ANALYST_ESTIMATES = AnalystEstimates(
+    symbol="AAPL",
+    as_of_date=date(2026, 4, 14),
+    consensus_eps_fq=Decimal("1.55"),
+    consensus_eps_fy=Decimal("6.80"),
+    consensus_rev_fq=Decimal("94_000_000_000"),
+    consensus_rev_fy=Decimal("400_000_000_000"),
+    analyst_count=42,
+    buy_count=30,
+    hold_count=10,
+    sell_count=2,
+    price_target_mean=Decimal("220.00"),
+    price_target_high=Decimal("260.00"),
+    price_target_low=Decimal("180.00"),
+)
+
+
+# ---------------------------------------------------------------------------
+# _upsert_profile
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_profile_executes_correct_sql() -> None:
+    conn = MagicMock()
+    _upsert_profile(conn, "42", _PROFILE, _NOW)
+
+    conn.execute.assert_called_once()
+    sql, params = conn.execute.call_args[0]
+    assert "INSERT INTO instrument_profile" in sql
+    assert "ON CONFLICT (instrument_id) DO UPDATE" in sql
+    assert "IS DISTINCT FROM" in sql
+    assert params["instrument_id"] == "42"
+    assert params["beta"] == _PROFILE.beta
+    assert params["fetched_at"] == _NOW
+
+
+def test_upsert_profile_passes_all_fields() -> None:
+    conn = MagicMock()
+    _upsert_profile(conn, "7", _PROFILE, _NOW)
+
+    _, params = conn.execute.call_args[0]
+    assert params["public_float"] == _PROFILE.public_float
+    assert params["avg_volume_30d"] == _PROFILE.avg_volume_30d
+    assert params["market_cap"] == _PROFILE.market_cap
+    assert params["employees"] == _PROFILE.employees
+    assert params["ipo_date"] == _PROFILE.ipo_date
+    assert params["is_actively_trading"] == _PROFILE.is_actively_trading
+
+
+# ---------------------------------------------------------------------------
+# _upsert_earnings_events
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_earnings_executes_per_event() -> None:
+    conn = MagicMock()
+    events = [_EARNINGS_EVENT, _EARNINGS_EVENT]
+    _upsert_earnings_events(conn, "42", events)
+
+    assert conn.execute.call_count == 2
+
+
+def test_upsert_earnings_single_event_sql() -> None:
+    conn = MagicMock()
+    _upsert_earnings_events(conn, "42", [_EARNINGS_EVENT])
+
+    conn.execute.assert_called_once()
+    sql, params = conn.execute.call_args[0]
+    assert "INSERT INTO earnings_events" in sql
+    assert "ON CONFLICT (instrument_id, fiscal_date_ending)" in sql
+    assert "IS DISTINCT FROM" in sql
+    assert params["instrument_id"] == "42"
+    assert params["fiscal_date_ending"] == _EARNINGS_EVENT.fiscal_date_ending
+    assert params["eps_actual"] == _EARNINGS_EVENT.eps_actual
+
+
+def test_upsert_earnings_empty_list_executes_nothing() -> None:
+    conn = MagicMock()
+    _upsert_earnings_events(conn, "42", [])
+    conn.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _upsert_analyst_estimates
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_analyst_estimates_executes_insert() -> None:
+    conn = MagicMock()
+    _upsert_analyst_estimates(conn, "42", _ANALYST_ESTIMATES)
+
+    conn.execute.assert_called_once()
+    sql, params = conn.execute.call_args[0]
+    assert "INSERT INTO analyst_estimates" in sql
+    assert "ON CONFLICT (instrument_id, as_of_date)" in sql
+    assert params["instrument_id"] == "42"
+    assert params["as_of_date"] == _ANALYST_ESTIMATES.as_of_date
+    assert params["analyst_count"] == _ANALYST_ESTIMATES.analyst_count
+    assert params["price_target_mean"] == _ANALYST_ESTIMATES.price_target_mean
+
+
+# ---------------------------------------------------------------------------
+# refresh_enrichment — integration-level tests with mocked provider
+# ---------------------------------------------------------------------------
+
+
+def _make_provider(
+    profile: InstrumentProfileData | None = _PROFILE,
+    events: list[EarningsEvent] | None = None,
+    estimates: AnalystEstimates | None = _ANALYST_ESTIMATES,
+) -> MagicMock:
+    provider = MagicMock()
+    provider.get_profile_enrichment.return_value = profile
+    provider.get_earnings_calendar.return_value = events if events is not None else [_EARNINGS_EVENT]
+    provider.get_analyst_estimates.return_value = estimates
+    return provider
+
+
+def test_refresh_enrichment_counts_correctly() -> None:
+    """Two symbols, all provider calls succeed — verify summary counts."""
+    provider = _make_provider(events=[_EARNINGS_EVENT, _EARNINGS_EVENT])
+    conn = MagicMock()
+    symbols = [("AAPL", "1"), ("MSFT", "2")]
+
+    summary = refresh_enrichment(provider, conn, symbols)
+
+    assert isinstance(summary, EnrichmentRefreshSummary)
+    assert summary.symbols_attempted == 2
+    assert summary.profiles_upserted == 2
+    assert summary.earnings_upserted == 4  # 2 events × 2 symbols
+    assert summary.estimates_upserted == 2
+    assert summary.symbols_skipped == 0
+
+
+def test_refresh_enrichment_skips_on_provider_failure() -> None:
+    """Provider raises on the first symbol; second symbol still processed."""
+    provider = MagicMock()
+    provider.get_profile_enrichment.side_effect = [
+        RuntimeError("provider down"),
+        _PROFILE,
+    ]
+    provider.get_earnings_calendar.return_value = [_EARNINGS_EVENT]
+    provider.get_analyst_estimates.return_value = _ANALYST_ESTIMATES
+    conn = MagicMock()
+    symbols = [("FAIL", "99"), ("AAPL", "1")]
+
+    summary = refresh_enrichment(provider, conn, symbols)
+
+    assert summary.symbols_attempted == 2
+    assert summary.symbols_skipped == 1
+    assert summary.profiles_upserted == 1
+    assert summary.earnings_upserted == 1
+    assert summary.estimates_upserted == 1
+
+
+def test_refresh_enrichment_handles_none_profile() -> None:
+    """Provider returns None for profile; earnings and estimates still attempted."""
+    provider = _make_provider(profile=None, events=[_EARNINGS_EVENT])
+    conn = MagicMock()
+    symbols = [("AAPL", "1")]
+
+    summary = refresh_enrichment(provider, conn, symbols)
+
+    assert summary.profiles_upserted == 0
+    assert summary.earnings_upserted == 1
+    assert summary.estimates_upserted == 1
+    assert summary.symbols_skipped == 0
+
+
+def test_refresh_enrichment_handles_empty_earnings() -> None:
+    """Provider returns empty list for earnings; no earnings_events rows written."""
+    provider = _make_provider(events=[])
+    conn = MagicMock()
+    symbols = [("AAPL", "1")]
+
+    summary = refresh_enrichment(provider, conn, symbols)
+
+    assert summary.earnings_upserted == 0
+    assert summary.profiles_upserted == 1
+    assert summary.estimates_upserted == 1
+    assert summary.symbols_skipped == 0
+
+
+def test_refresh_enrichment_handles_none_estimates() -> None:
+    """Provider returns None for estimates; estimates count is 0."""
+    provider = _make_provider(estimates=None)
+    conn = MagicMock()
+    symbols = [("AAPL", "1")]
+
+    summary = refresh_enrichment(provider, conn, symbols)
+
+    assert summary.estimates_upserted == 0
+    assert summary.profiles_upserted == 1
+    assert summary.earnings_upserted == 1
+    assert summary.symbols_skipped == 0

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -567,6 +567,8 @@ def _make_fake_conn(
     thesis_row: dict[str, object] | None,
     news_rows: list[dict[str, object]],
     avg_red_flag: float | None,
+    valuation_row: dict[str, object] | None = None,
+    estimates_row: dict[str, object] | None = None,
 ) -> MagicMock:
     """
     Return a MagicMock psycopg connection that supports the cursor(row_factory=...)
@@ -575,7 +577,8 @@ def _make_fake_conn(
     psycopg cursor semantics: cur.execute(sql) is called, then cur.fetchone() /
     cur.fetchall() is called on the *same* cursor object. We model this by having
     execute() mutate cur.fetchone / cur.fetchall as a side effect, dispatching
-    results in order: fundamentals, price, quote, thesis, news, red_flag.
+    results in order: fundamentals, price, quote, thesis, news, red_flag,
+    valuation, analyst_estimates.
     """
     rf_row: dict[str, object] = {"avg_red_flag": avg_red_flag}
 
@@ -587,6 +590,8 @@ def _make_fake_conn(
         ("fetchone", thesis_row),
         ("fetchall", news_rows),
         ("fetchone", rf_row),
+        ("fetchone", valuation_row),
+        ("fetchone", estimates_row),
     ]
     response_iter = iter(responses)
 

--- a/tests/test_scoring_enriched.py
+++ b/tests/test_scoring_enriched.py
@@ -1,0 +1,126 @@
+"""Tests for enhanced _value_score with fundamentals fallback."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.scoring import _value_score
+
+
+class TestValueScoreEnriched:
+    def test_value_score_thesis_based_unchanged(self) -> None:
+        """Thesis path dominates when base_value is present.
+
+        base_value=150, bear_value=80, current_price=100
+        upside=(150-100)/100=0.5, upside_score=clip(0.5/0.5)=1.0
+        downside=(100-80)/100=0.2, downside_penalty=clip(0.2/0.5)=0.4
+        score=0.75*1.0 + 0.25*(1-0.4) = 0.75+0.15 = 0.90
+        """
+        score, notes = _value_score(
+            base_value=150.0,
+            bear_value=80.0,
+            current_price=100.0,
+        )
+        assert score == pytest.approx(0.90)
+        assert "fundamentals fallback" not in " ".join(notes)
+
+    def test_value_score_thesis_overrides_fundamentals(self) -> None:
+        """When both thesis AND fundamentals data exist, thesis path is used."""
+        score, notes = _value_score(
+            base_value=150.0,
+            bear_value=80.0,
+            current_price=100.0,
+            pe_ratio=10.0,
+            fcf_yield=0.08,
+            price_target_mean=200.0,
+        )
+        # Thesis path: score = 0.90 (same as above, enrichment params ignored)
+        assert score == pytest.approx(0.90)
+        assert "fundamentals fallback" not in " ".join(notes)
+
+    def test_value_score_fundamentals_all_three_signals(self) -> None:
+        """Fallback with all three signals available.
+
+        pe_ratio=10 → pe_score=clip(1-(10-10)/40)=1.0 (w=0.35)
+        fcf_yield=0.08 → fy_score=clip(0.08/0.08)=1.0 (w=0.35)
+        price_target_mean=150, current_price=100 → pt_upside=0.5, pt_score=clip(0.5/0.5)=1.0 (w=0.30)
+        total_weight=1.0, score=1.0
+        """
+        score, notes = _value_score(
+            base_value=None,
+            bear_value=None,
+            current_price=100.0,
+            pe_ratio=10.0,
+            fcf_yield=0.08,
+            price_target_mean=150.0,
+        )
+        assert score == pytest.approx(1.0)
+        assert any("fundamentals fallback" in n for n in notes)
+
+    def test_value_score_fundamentals_expensive_stock(self) -> None:
+        """Fallback with all three signals pointing to expensive / weak stock.
+
+        pe_ratio=50 → pe_score=clip(1-(50-10)/40)=clip(0.0)=0.0 (w=0.35)
+        fcf_yield=0.01 → fy_score=clip(0.01/0.08)=0.125 (w=0.35)
+        price_target_mean=90, current_price=100 → pt_upside=-0.1, pt_score=clip(-0.1/0.5)=0.0 (w=0.30)
+        total_weight=1.0, score=(0*0.35 + 0.125*0.35 + 0*0.30)/1.0=0.04375
+        """
+        score, notes = _value_score(
+            base_value=None,
+            bear_value=None,
+            current_price=100.0,
+            pe_ratio=50.0,
+            fcf_yield=0.01,
+            price_target_mean=90.0,
+        )
+        assert score == pytest.approx(0.04375)
+        assert any("fundamentals fallback" in n for n in notes)
+
+    def test_value_score_pe_only(self) -> None:
+        """Fallback with only P/E available; re-normalised to weight 1.0.
+
+        pe_ratio=15 → pe_score=clip(1-(15-10)/40)=clip(0.875)=0.875
+        only one component, renormalized weight=1.0; score=0.875
+        """
+        score, notes = _value_score(
+            base_value=None,
+            bear_value=None,
+            current_price=100.0,
+            pe_ratio=15.0,
+        )
+        assert score == pytest.approx(0.875)
+        assert any("fundamentals fallback" in n for n in notes)
+
+    def test_value_score_no_thesis_no_fundamentals(self) -> None:
+        """All None → neutral 0.5."""
+        score, notes = _value_score(
+            base_value=None,
+            bear_value=None,
+            current_price=100.0,
+        )
+        assert score == pytest.approx(0.5)
+        assert any("fundamentals fallback" in n for n in notes)
+
+    def test_value_score_no_price(self) -> None:
+        """current_price=None → neutral 0.5 regardless of other params."""
+        score, notes = _value_score(
+            base_value=None,
+            bear_value=None,
+            current_price=None,
+            pe_ratio=15.0,
+            fcf_yield=0.06,
+        )
+        assert score == pytest.approx(0.5)
+        assert any("current_price missing" in n for n in notes)
+
+    def test_value_score_negative_fcf_yield(self) -> None:
+        """Cash-burning company: fcf_yield=-0.05 → fy_score=clip(-0.05/0.08)=0.0."""
+        score, notes = _value_score(
+            base_value=None,
+            bear_value=None,
+            current_price=100.0,
+            fcf_yield=-0.05,
+        )
+        # Only fcf_yield component, fy_score=0.0, renormalized weight=1.0 → score=0.0
+        assert score == pytest.approx(0.0)
+        assert any("fundamentals fallback" in n for n in notes)


### PR DESCRIPTION
## Summary

Closes #199. Adds fundamentals enrichment to the data layer — company profile metadata, historical earnings calendar, analyst consensus estimates, and computed valuation multiples. The scoring engine now uses enrichment data as a fallback when no thesis exists, replacing the 0.5 neutral-by-absence with a fundamentals-derived value score.

### What changed

- **Schema** (`sql/024_fundamentals_enrichment.sql`): 3 new tables (`instrument_profile`, `earnings_events`, `analyst_estimates`) + `instrument_valuation` view (computed P/E, P/B, P/FCF, FCF yield, D/E, live market cap from `fundamentals_snapshot` × `quotes`)
- **Provider interface** (`app/providers/enrichment.py`): `EnrichmentProvider` ABC with 3 frozen dataclasses (`InstrumentProfileData`, `EarningsEvent`, `AnalystEstimates`)
- **FMP implementation** (`app/providers/implementations/fmp.py`): `FmpFundamentalsProvider` now also implements `EnrichmentProvider`. Shared `_fetch_profile()` eliminates duplicate HTTP calls. 3 new FMP endpoints: `/v3/historical/earning_calendar`, `/v3/analyst-estimates`, `/v4/price-target-consensus` + `/v4/analyst-stock-recommendations`
- **Enrichment service** (`app/services/enrichment.py`): `refresh_enrichment()` iterates symbols, calls provider, upserts per-symbol with try/except skip-on-failure. All upserts use `ON CONFLICT DO UPDATE` with `IS DISTINCT FROM` guards
- **Scoring** (`app/services/scoring.py`): `_value_score` gains keyword-only params `pe_ratio`, `fcf_yield`, `price_target_mean`. Thesis path unchanged; fallback blends P/E attractiveness (35%), FCF yield (35%), price-target upside (30%) with re-normalised weights
- **Thesis context** (`app/services/thesis.py`): `_assemble_context` now passes `earnings_history` (latest 4 confirmed quarters) and `analyst_estimates` (latest snapshot) to the thesis writer
- **Scheduler** (`app/workers/scheduler.py`): `daily_research_refresh()` calls `refresh_enrichment()` after FMP fundamentals, guarded by `fmp_api_key`

### Design decisions

- **Separate tables per cadence**: profile (daily), earnings (event-driven), estimates (weekly) — different refresh frequencies warrant independent tables rather than denormalising into `fundamentals_snapshot`
- **SQL VIEW for multiples**: `instrument_valuation` is a materialisation-free computed layer. Avoids dual-write consistency issues. Uses `DISTINCT ON` for latest snapshot + `COALESCE(last, (bid+ask)/2)` to match scorer's price fallback
- **Backward-compatible scoring**: All new params are keyword-only with `None` defaults. Existing callers and tests unaffected. Thesis-based path takes priority when `base_value` is present
- **Budget constants for thesis prompt**: `_MAX_EARNINGS_EVENTS = 4`, `_MAX_ANALYST_ESTIMATES = 1` — prevents token bloat in LLM context

### Security model

- No new API endpoints. All data flows are internal (scheduler → provider → service → DB)
- No user-controlled input reaches SQL — all queries use psycopg named params
- FMP API key access gated by existing `settings.fmp_api_key` check

### Codex review findings (addressed in b2b9b89)

1. FMP `date` field = announcement date, `fiscalDateEnding` = fiscal period end → fixed mapping
2. FMP `targetConsensus` not `targetMean` → fixed with fallback to both
3. `IS DISTINCT FROM` predicate too narrow for pre-earnings rows → widened to include reporting_date, eps_estimate, revenue_estimate
4. Valuation view used `q.last` without bid/ask fallback → CTE with `COALESCE`

### Test coverage

- `test_enrichment_provider.py` (15 tests): normaliser functions — full data, missing fields, invalid dates, zero EPS, non-bool values, analyst count fallback
- `test_enrichment_service.py` (11 tests): upsert SQL correctness, per-event loop, empty/None handling, provider failure skip, summary counts
- `test_scoring_enriched.py` (8 tests): thesis path unchanged, thesis overrides enrichment, all-three-signals, expensive stock, PE-only, no-data neutral, no-price neutral, negative FCF yield
- `test_scoring.py`: updated `_make_fake_conn` with `valuation_row`/`estimates_row` params

All checks pass: `ruff check`, `ruff format --check`, `pyright` (0 errors), `pytest` (1251 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)