### PR TITLE
feat(#200): technical analysis engine — TA-enhanced momentum scoring

### DIFF
--- a/app/api/scores.py
+++ b/app/api/scores.py
@@ -34,7 +34,7 @@ MAX_PAGE_LIMIT = 200
 
 Stance = Literal["buy", "hold", "watch", "avoid"]
 
-_DEFAULT_MODEL_VERSION = "v1-balanced"
+_DEFAULT_MODEL_VERSION = "v1.1-balanced"
 
 # ---------------------------------------------------------------------------
 # Response models

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -5,6 +5,8 @@ Ingests daily OHLCV candles and current quotes for covered instruments,
 computes rolling return and volatility features, and flags wide spreads.
 """
 
+from __future__ import annotations
+
 import logging
 import math
 from dataclasses import dataclass
@@ -14,6 +16,7 @@ from decimal import Decimal
 import psycopg
 
 from app.providers.market_data import MarketDataProvider, OHLCVBar, Quote
+from app.services.technical_analysis import OHLCVRow, compute_indicators
 
 logger = logging.getLogger(__name__)
 
@@ -270,15 +273,70 @@ def _compute_and_store_features(
     returns = _compute_rolling_returns(prices)
     volatility = _compute_volatility_30d(prices)
 
+    # --- TA indicators (full OHLCV needed, not just close) ---
+    ohlcv_rows = conn.execute(
+        """
+        SELECT open, high, low, close, volume
+        FROM price_daily
+        WHERE instrument_id = %(instrument_id)s
+          AND close IS NOT NULL
+        ORDER BY price_date DESC
+        LIMIT 400
+        """,
+        {"instrument_id": instrument_id},
+    ).fetchall()
+
+    _TA_COLUMNS = [
+        "sma_20",
+        "sma_50",
+        "sma_200",
+        "ema_12",
+        "ema_26",
+        "macd_line",
+        "macd_signal",
+        "macd_histogram",
+        "rsi_14",
+        "stoch_k",
+        "stoch_d",
+        "bb_upper",
+        "bb_lower",
+        "atr_14",
+    ]
+    ta_params: dict[str, Decimal | None] = {k: None for k in _TA_COLUMNS}
+
+    if ohlcv_rows:
+        bars: list[OHLCVRow] = [
+            OHLCVRow(open=r[0], high=r[1], low=r[2], close=r[3], volume=r[4]) for r in reversed(ohlcv_rows)
+        ]
+        ta_result = compute_indicators(bars)
+        if ta_result is not None:
+            for k, v in ta_result.items():
+                if k in ta_params and isinstance(v, float):
+                    ta_params[k] = Decimal(str(round(v, 6)))
+
     conn.execute(
         """
         UPDATE price_daily SET
-            return_1w     = %(return_1w)s,
-            return_1m     = %(return_1m)s,
-            return_3m     = %(return_3m)s,
-            return_6m     = %(return_6m)s,
-            return_1y     = %(return_1y)s,
-            volatility_30d = %(volatility_30d)s
+            return_1w      = %(return_1w)s,
+            return_1m      = %(return_1m)s,
+            return_3m      = %(return_3m)s,
+            return_6m      = %(return_6m)s,
+            return_1y      = %(return_1y)s,
+            volatility_30d = %(volatility_30d)s,
+            sma_20         = %(sma_20)s,
+            sma_50         = %(sma_50)s,
+            sma_200        = %(sma_200)s,
+            ema_12         = %(ema_12)s,
+            ema_26         = %(ema_26)s,
+            macd_line      = %(macd_line)s,
+            macd_signal    = %(macd_signal)s,
+            macd_histogram = %(macd_histogram)s,
+            rsi_14         = %(rsi_14)s,
+            stoch_k        = %(stoch_k)s,
+            stoch_d        = %(stoch_d)s,
+            bb_upper       = %(bb_upper)s,
+            bb_lower       = %(bb_lower)s,
+            atr_14         = %(atr_14)s
         WHERE instrument_id = %(instrument_id)s
           AND price_date = %(price_date)s
         """,
@@ -291,6 +349,7 @@ def _compute_and_store_features(
             "return_6m": returns.get("return_6m"),
             "return_1y": returns.get("return_1y"),
             "volatility_30d": volatility,
+            **ta_params,
         },
     )
     return 1

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -274,11 +274,16 @@ def _compute_and_store_features(
     volatility = _compute_volatility_30d(prices)
 
     # --- TA indicators (full OHLCV needed, not just close) ---
+    # Require all four price columns non-null; the schema permits partial
+    # rows (close-only) which would crash float() in stochastic/ATR.
     ohlcv_rows = conn.execute(
         """
         SELECT open, high, low, close, volume
         FROM price_daily
         WHERE instrument_id = %(instrument_id)s
+          AND open IS NOT NULL
+          AND high IS NOT NULL
+          AND low IS NOT NULL
           AND close IS NOT NULL
         ORDER BY price_date DESC
         LIMIT 400

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -323,7 +323,7 @@ def _compute_and_store_features(
             ta_result = compute_indicators(bars)
             if ta_result is not None:
                 for k, v in ta_result.items():
-                    if k in ta_params and isinstance(v, float):
+                    if k in ta_params and isinstance(v, float) and math.isfinite(v):
                         ta_params[k] = Decimal(str(round(v, 6)))
 
     conn.execute(

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -276,9 +276,12 @@ def _compute_and_store_features(
     # --- TA indicators (full OHLCV needed, not just close) ---
     # Require all four price columns non-null; the schema permits partial
     # rows (close-only) which would crash float() in stochastic/ATR.
+    # Include price_date so we can verify the latest complete OHLCV bar
+    # matches the row we're updating — avoids writing stale TA values
+    # when the newest candle has close but incomplete OHLC.
     ohlcv_rows = conn.execute(
         """
-        SELECT open, high, low, close, volume
+        SELECT price_date, open, high, low, close, volume
         FROM price_daily
         WHERE instrument_id = %(instrument_id)s
           AND open IS NOT NULL
@@ -310,14 +313,18 @@ def _compute_and_store_features(
     ta_params: dict[str, Decimal | None] = {k: None for k in _TA_COLUMNS}
 
     if ohlcv_rows:
-        bars: list[OHLCVRow] = [
-            OHLCVRow(open=r[0], high=r[1], low=r[2], close=r[3], volume=r[4]) for r in reversed(ohlcv_rows)
-        ]
-        ta_result = compute_indicators(bars)
-        if ta_result is not None:
-            for k, v in ta_result.items():
-                if k in ta_params and isinstance(v, float):
-                    ta_params[k] = Decimal(str(round(v, 6)))
+        # Only compute TA if the latest complete OHLCV bar matches the row
+        # we're updating; otherwise the indicators would be stale-by-one-day.
+        ohlcv_latest_date: date = ohlcv_rows[0][0]  # newest first
+        if ohlcv_latest_date == latest_date:
+            bars: list[OHLCVRow] = [
+                OHLCVRow(open=r[1], high=r[2], low=r[3], close=r[4], volume=r[5]) for r in reversed(ohlcv_rows)
+            ]
+            ta_result = compute_indicators(bars)
+            if ta_result is not None:
+                for k, v in ta_result.items():
+                    if k in ta_params and isinstance(v, float):
+                        ta_params[k] = Decimal(str(round(v, 6)))
 
     conn.execute(
         """

--- a/app/services/portfolio.py
+++ b/app/services/portfolio.py
@@ -858,7 +858,7 @@ def _should_persist_hold(
 
 def run_portfolio_review(
     conn: psycopg.Connection[Any],
-    model_version: str = "v1-balanced",
+    model_version: str = "v1.1-balanced",
 ) -> PortfolioReviewResult:
     """
     Evaluate the Tier 1 ranked candidate list against current portfolio state

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -23,7 +23,7 @@ Versioning contract:
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -296,7 +296,7 @@ def _momentum_score(
     return_3m: float | None,
     return_6m: float | None,
     *,
-    ta_indicators: dict[str, float | None] | None = None,
+    ta_indicators: Mapping[str, float | None] | None = None,
 ) -> tuple[float, list[str]]:
     """
     Blended momentum score combining return-based signals with TA indicators.

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -954,9 +954,11 @@ def compute_score(
     if v_notes:
         explanation_parts.append("value: " + "; ".join(v_notes))
 
-    # Build TA indicators dict for momentum score
+    # Build TA indicators dict for momentum score.
+    # Only v1.1+ models use TA-enhanced momentum; v1 models preserve
+    # the original return-only formula for score history compatibility.
     ta_indicators: dict[str, float | None] | None = None
-    if price_row is not None:
+    if price_row is not None and model_version.startswith("v1.1"):
         ta_keys = [
             "sma_200",
             "macd_histogram",

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -34,10 +34,14 @@ from psycopg.types.json import Jsonb
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_MODEL_VERSION = "v1-balanced"
+_DEFAULT_MODEL_VERSION = "v1.1-balanced"
 
 # ---------------------------------------------------------------------------
 # Weight modes  (must sum to 1.0)
+#
+# v1   — return-only momentum (3 return windows, no TA)
+# v1.1 — TA-enhanced momentum (returns + trend/quality/volatility subcomponents)
+#         Same family weights as v1; the difference is inside _momentum_score.
 # ---------------------------------------------------------------------------
 
 _WEIGHT_MODES: dict[str, dict[str, float]] = {
@@ -58,6 +62,30 @@ _WEIGHT_MODES: dict[str, dict[str, float]] = {
         "turnaround": 0.05,
     },
     "v1-speculative": {
+        "turnaround": 0.30,
+        "value": 0.25,
+        "momentum": 0.15,
+        "confidence": 0.15,
+        "sentiment": 0.10,
+        "quality": 0.05,
+    },
+    "v1.1-balanced": {
+        "quality": 0.25,
+        "value": 0.25,
+        "turnaround": 0.20,
+        "confidence": 0.15,
+        "momentum": 0.10,
+        "sentiment": 0.05,
+    },
+    "v1.1-conservative": {
+        "quality": 0.35,
+        "value": 0.25,
+        "confidence": 0.20,
+        "momentum": 0.10,
+        "sentiment": 0.05,
+        "turnaround": 0.05,
+    },
+    "v1.1-speculative": {
         "turnaround": 0.30,
         "value": 0.25,
         "momentum": 0.15,

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -410,7 +410,7 @@ def _momentum_score(
 
     rsi_val = ta_indicators.get("rsi_14")
     if rsi_val is not None:
-        # RSI sweet spot: 50-65 (healthy uptrend momentum).
+        # RSI ramp: 30→50 is recovery, 50→70 is healthy uptrend.
         # Oversold (<30) and overbought (>70) are warning zones.
         if rsi_val < 30:
             rsi_score = rsi_val / 60.0
@@ -447,6 +447,9 @@ def _momentum_score(
     if bb_upper is not None and bb_lower is not None and current_close is not None:
         bb_width = bb_upper - bb_lower
         if bb_width > 0:
+            # Position within band measures trend strength (high = strong
+            # uptrend), intentionally opposite to RSI/stoch overbought
+            # treatment which measures exhaustion risk.
             vol_parts.append((_clip((current_close - bb_lower) / bb_width), 0.60))
         else:
             vol_parts.append((0.5, 0.60))

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -295,40 +295,161 @@ def _momentum_score(
     return_1m: float | None,
     return_3m: float | None,
     return_6m: float | None,
+    *,
+    ta_indicators: dict[str, float | None] | None = None,
 ) -> tuple[float, list[str]]:
     """
-    Blended return score.  3m return is dominant (50% weight).
+    Blended momentum score combining return-based signals with TA indicators.
 
-    Returns (score, missing_components).
+    When ta_indicators is None or empty, falls back to pure return scoring
+    (backward compatible).
+
+    TA blending (when available):
+      Return-based:      40%
+      Trend confirmation: 25% (price vs SMA200, MACD histogram)
+      Momentum quality:  20% (RSI regime, Stochastic position)
+      Volatility regime: 15% (Bollinger position, ATR context)
+
+    Returns (score, notes_about_missing_components).
     """
     notes: list[str] = []
-    components: list[tuple[float, float]] = []  # (score, weight)
+
+    # --- Return-based component (original logic) ---
+    return_components: list[tuple[float, float]] = []
 
     if return_1m is not None:
         s1m = _clip((return_1m + 0.10) / 0.30)
-        components.append((s1m, 0.20))
+        return_components.append((s1m, 0.20))
     else:
         notes.append("return_1m missing")
 
     if return_3m is not None:
         s3m = _clip((return_3m + 0.15) / 0.45)
-        components.append((s3m, 0.50))
+        return_components.append((s3m, 0.50))
     else:
         notes.append("return_3m missing")
 
     if return_6m is not None:
         s6m = _clip((return_6m + 0.20) / 0.60)
-        components.append((s6m, 0.30))
+        return_components.append((s6m, 0.30))
     else:
         notes.append("return_6m missing")
 
-    if not components:
-        return 0.5, notes  # no momentum data — neutral-by-absence
+    if not return_components:
+        return_score: float | None = None
+    else:
+        total_w = sum(w for _, w in return_components)
+        return_score = sum(s * w / total_w for s, w in return_components)
 
-    # Re-normalise weights across available components
-    total_weight = sum(w for _, w in components)
-    score = sum(s * w / total_weight for s, w in components)
-    return _clip(score), notes
+    # --- If no TA data, fall back to return-only scoring ---
+    if not ta_indicators or not any(
+        ta_indicators.get(k) is not None
+        for k in ("sma_200", "macd_histogram", "rsi_14", "stoch_k", "bb_upper", "atr_14")
+    ):
+        if return_score is None:
+            return 0.5, notes
+        return _clip(return_score), notes
+
+    current_close = ta_indicators.get("current_close")
+
+    # --- Trend confirmation (25%): SMA200 + MACD histogram ---
+    trend_parts: list[tuple[float, float]] = []
+
+    sma_200 = ta_indicators.get("sma_200")
+    if sma_200 is not None and current_close is not None and sma_200 != 0:
+        pct_from_sma = (current_close - sma_200) / sma_200
+        trend_parts.append((_clip(0.5 + pct_from_sma * 2.5), 0.60))
+    else:
+        notes.append("TA: sma_200 unavailable")
+
+    macd_hist = ta_indicators.get("macd_histogram")
+    if macd_hist is not None:
+        trend_parts.append((_clip(0.5 + macd_hist / 10.0), 0.40))
+    else:
+        notes.append("TA: macd_histogram unavailable")
+
+    trend_score: float | None = None
+    if trend_parts:
+        tw = sum(w for _, w in trend_parts)
+        trend_score = sum(s * w / tw for s, w in trend_parts)
+
+    # --- Momentum quality (20%): RSI + Stochastic ---
+    mq_parts: list[tuple[float, float]] = []
+
+    rsi_val = ta_indicators.get("rsi_14")
+    if rsi_val is not None:
+        # RSI sweet spot: 50-65 (healthy uptrend momentum).
+        # Oversold (<30) and overbought (>70) are warning zones.
+        if rsi_val < 30:
+            rsi_score = rsi_val / 60.0
+        elif rsi_val <= 70:
+            rsi_score = 0.5 + (rsi_val - 30) / 80.0
+        else:
+            rsi_score = max(0.0, 1.0 - (rsi_val - 70) / 30.0)
+        mq_parts.append((_clip(rsi_score), 0.60))
+    else:
+        notes.append("TA: rsi_14 unavailable")
+
+    stoch_k = ta_indicators.get("stoch_k")
+    if stoch_k is not None:
+        if stoch_k < 20:
+            stoch_score = stoch_k / 40.0
+        elif stoch_k <= 80:
+            stoch_score = 0.5 + (stoch_k - 20) / 120.0
+        else:
+            stoch_score = max(0.0, 1.0 - (stoch_k - 80) / 20.0)
+        mq_parts.append((_clip(stoch_score), 0.40))
+    else:
+        notes.append("TA: stoch_k unavailable")
+
+    mq_score: float | None = None
+    if mq_parts:
+        mw = sum(w for _, w in mq_parts)
+        mq_score = sum(s * w / mw for s, w in mq_parts)
+
+    # --- Volatility regime (15%): Bollinger position + ATR ---
+    vol_parts: list[tuple[float, float]] = []
+
+    bb_upper = ta_indicators.get("bb_upper")
+    bb_lower = ta_indicators.get("bb_lower")
+    if bb_upper is not None and bb_lower is not None and current_close is not None:
+        bb_width = bb_upper - bb_lower
+        if bb_width > 0:
+            vol_parts.append((_clip((current_close - bb_lower) / bb_width), 0.60))
+        else:
+            vol_parts.append((0.5, 0.60))
+    else:
+        notes.append("TA: bollinger unavailable")
+
+    atr_val = ta_indicators.get("atr_14")
+    if atr_val is not None and current_close is not None and current_close > 0:
+        atr_pct = atr_val / current_close
+        vol_parts.append((_clip(1.0 - atr_pct * 10.0), 0.40))
+    else:
+        notes.append("TA: atr_14 unavailable")
+
+    vol_score: float | None = None
+    if vol_parts:
+        vw = sum(w for _, w in vol_parts)
+        vol_score = sum(s * w / vw for s, w in vol_parts)
+
+    # --- Final blend ---
+    final_parts: list[tuple[float, float]] = []
+    if return_score is not None:
+        final_parts.append((return_score, 0.40))
+    if trend_score is not None:
+        final_parts.append((trend_score, 0.25))
+    if mq_score is not None:
+        final_parts.append((mq_score, 0.20))
+    if vol_score is not None:
+        final_parts.append((vol_score, 0.15))
+
+    if not final_parts:
+        return 0.5, notes
+
+    total_w = sum(w for _, w in final_parts)
+    blended = sum(s * w / total_w for s, w in final_parts)
+    return _clip(blended), notes
 
 
 def _sentiment_score(
@@ -555,7 +676,10 @@ def _load_instrument_data(
         # Latest price features
         cur.execute(
             """
-            SELECT return_1m, return_3m, return_6m, close
+            SELECT return_1m, return_3m, return_6m, close,
+                   sma_200, macd_histogram, rsi_14,
+                   stoch_k, stoch_d,
+                   bb_upper, bb_lower, atr_14
             FROM price_daily
             WHERE instrument_id = %(id)s
               AND close IS NOT NULL
@@ -802,7 +926,30 @@ def compute_score(
     if v_notes:
         explanation_parts.append("value: " + "; ".join(v_notes))
 
-    m_score, m_notes = _momentum_score(return_1m, return_3m, return_6m)
+    # Build TA indicators dict for momentum score
+    ta_indicators: dict[str, float | None] | None = None
+    if price_row is not None:
+        ta_keys = [
+            "sma_200",
+            "macd_histogram",
+            "rsi_14",
+            "stoch_k",
+            "stoch_d",
+            "bb_upper",
+            "bb_lower",
+            "atr_14",
+        ]
+        ta_raw = {k: _to_float(price_row.get(k)) for k in ta_keys}
+        if any(v is not None for v in ta_raw.values()):
+            ta_indicators = ta_raw
+            ta_indicators["current_close"] = current_price
+
+    m_score, m_notes = _momentum_score(
+        return_1m,
+        return_3m,
+        return_6m,
+        ta_indicators=ta_indicators,
+    )
     if m_notes:
         explanation_parts.append("momentum: " + "; ".join(m_notes))
 

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -391,8 +391,12 @@ def _momentum_score(
         notes.append("TA: sma_200 unavailable")
 
     macd_hist = ta_indicators.get("macd_histogram")
-    if macd_hist is not None:
-        trend_parts.append((_clip(0.5 + macd_hist / 10.0), 0.40))
+    if macd_hist is not None and current_close is not None and current_close != 0:
+        # Normalise histogram to percentage of price so signal is
+        # comparable across price levels.  Scale factor 20 maps a ±2.5 %
+        # histogram to the 0-1 clip range (moderate signal ≈ 0.7/0.3).
+        macd_pct = macd_hist / current_close
+        trend_parts.append((_clip(0.5 + macd_pct * 20.0), 0.40))
     else:
         notes.append("TA: macd_histogram unavailable")
 

--- a/app/services/technical_analysis.py
+++ b/app/services/technical_analysis.py
@@ -1,0 +1,313 @@
+"""
+Pure technical analysis computation module.
+
+All functions are pure — no DB, no I/O.  They take OHLCV data
+(oldest-first) and return indicator values as floats.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from decimal import Decimal
+from typing import TypedDict
+
+
+class OHLCVRow(TypedDict):
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: int | None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _ema_series(closes: Sequence[Decimal], period: int) -> list[float] | None:
+    """Full EMA series from index (period-1) onward.
+
+    Seed is the SMA of the first *period* values.
+    Returns None if len(closes) < period.
+    """
+    if len(closes) < period:
+        return None
+
+    seed = float(sum(closes[:period])) / period
+    mult = 2.0 / (period + 1)
+    result = [seed]
+    for i in range(period, len(closes)):
+        val = float(closes[i]) * mult + result[-1] * (1.0 - mult)
+        result.append(val)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Individual indicators
+# ---------------------------------------------------------------------------
+
+
+def sma(closes: Sequence[Decimal], period: int) -> float | None:
+    """Simple moving average of the last *period* closes.
+
+    Returns None if insufficient data.
+    """
+    if len(closes) < period:
+        return None
+    return float(sum(closes[-period:])) / period
+
+
+def ema(closes: Sequence[Decimal], period: int) -> float | None:
+    """Exponential moving average.
+
+    Seed = SMA of first *period* values.  Multiplier = 2 / (period + 1).
+    Returns None if insufficient data.
+    """
+    series = _ema_series(closes, period)
+    if series is None:
+        return None
+    return series[-1]
+
+
+def rsi(closes: Sequence[Decimal], period: int = 14) -> float | None:
+    """Relative Strength Index with Wilder smoothing.
+
+    Requires at least period + 1 data points.
+    """
+    if len(closes) < period + 1:
+        return None
+
+    deltas = [float(closes[i] - closes[i - 1]) for i in range(1, len(closes))]
+
+    # Initial averages over the first *period* deltas
+    gains = [d if d > 0 else 0.0 for d in deltas[:period]]
+    losses = [-d if d < 0 else 0.0 for d in deltas[:period]]
+
+    avg_gain = sum(gains) / period
+    avg_loss = sum(losses) / period
+
+    # Wilder smoothing for remaining deltas
+    for d in deltas[period:]:
+        avg_gain = (avg_gain * (period - 1) + (d if d > 0 else 0.0)) / period
+        avg_loss = (avg_loss * (period - 1) + (-d if d < 0 else 0.0)) / period
+
+    if avg_gain == 0.0 and avg_loss == 0.0:
+        return 50.0
+    if avg_loss == 0.0:
+        return 100.0
+
+    rs = avg_gain / avg_loss
+    return 100.0 - 100.0 / (1.0 + rs)
+
+
+def macd(
+    closes: Sequence[Decimal],
+    fast: int = 12,
+    slow: int = 26,
+    signal_period: int = 9,
+) -> tuple[float, float, float] | None:
+    """MACD line, signal line, and histogram.
+
+    Returns (line, signal, histogram) or None if insufficient data.
+    Needs at least slow + signal_period - 1 data points.
+    """
+    if len(closes) < slow + signal_period - 1:
+        return None
+
+    fast_series = _ema_series(closes, fast)
+    slow_series = _ema_series(closes, slow)
+    if fast_series is None or slow_series is None:
+        return None
+
+    # Align: fast_series starts at index (fast-1), slow at (slow-1).
+    # MACD line series starts where both are available — aligned to
+    # the slow series start.
+    offset = slow - fast  # how many extra fast values before slow starts
+    macd_series = [fast_series[offset + i] - slow_series[i] for i in range(len(slow_series))]
+
+    if len(macd_series) < signal_period:
+        return None
+
+    # Signal = EMA of the MACD line series
+    macd_decimals = [Decimal(str(v)) for v in macd_series]
+    signal_series = _ema_series(macd_decimals, signal_period)
+    if signal_series is None:
+        return None
+
+    line = macd_series[-1]
+    signal_val = signal_series[-1]
+    histogram = line - signal_val
+    return (line, signal_val, histogram)
+
+
+def bollinger_bands(
+    closes: Sequence[Decimal],
+    period: int = 20,
+    num_std: float = 2.0,
+) -> tuple[float, float] | None:
+    """Bollinger Bands (upper, lower).
+
+    Uses population standard deviation (ddof=0).
+    Returns None if insufficient data.
+    """
+    if len(closes) < period:
+        return None
+
+    window = [float(c) for c in closes[-period:]]
+    mean = sum(window) / period
+    variance = sum((x - mean) ** 2 for x in window) / period
+    std = math.sqrt(variance)
+    return (mean + num_std * std, mean - num_std * std)
+
+
+def atr(bars: Sequence[OHLCVRow], period: int = 14) -> float | None:
+    """Average True Range with Wilder smoothing.
+
+    True Range = max(high - low, |high - prev_close|, |low - prev_close|).
+    Needs period + 1 bars (first bar establishes prev_close).
+    """
+    if len(bars) < period + 1:
+        return None
+
+    # Compute true ranges (first bar is anchor only)
+    trs: list[float] = []
+    for i in range(1, len(bars)):
+        high = float(bars[i]["high"])
+        low = float(bars[i]["low"])
+        prev_close = float(bars[i - 1]["close"])
+        tr = max(high - low, abs(high - prev_close), abs(low - prev_close))
+        trs.append(tr)
+
+    # Initial ATR = SMA of first *period* TRs
+    atr_val = sum(trs[:period]) / period
+
+    # Wilder smoothing for remaining
+    for tr in trs[period:]:
+        atr_val = (atr_val * (period - 1) + tr) / period
+
+    return atr_val
+
+
+def stochastic(
+    bars: Sequence[OHLCVRow],
+    k_period: int = 14,
+    d_period: int = 3,
+) -> tuple[float, float] | None:
+    """Stochastic oscillator (%K, %D).
+
+    %K = (close - lowest_low) / (highest_high - lowest_low) * 100.
+    %D = SMA(d_period) of %K values.
+    Needs k_period + d_period - 1 bars.
+    """
+    required = k_period + d_period - 1
+    if len(bars) < required:
+        return None
+
+    # Compute %K for each window of k_period bars, producing d_period values
+    k_values: list[float] = []
+    for end_idx in range(len(bars) - d_period + 1, len(bars) + 1):
+        start_idx = end_idx - k_period
+        window = bars[start_idx:end_idx]
+        highest = max(float(b["high"]) for b in window)
+        lowest = min(float(b["low"]) for b in window)
+        close = float(window[-1]["close"])
+
+        if highest == lowest:
+            k_values.append(50.0)
+        else:
+            k_values.append((close - lowest) / (highest - lowest) * 100.0)
+
+    pct_k = k_values[-1]
+    pct_d = sum(k_values[-d_period:]) / d_period
+    return (pct_k, pct_d)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def compute_indicators(
+    bars: Sequence[OHLCVRow],
+) -> dict[str, float | str | None] | None:
+    """Compute all technical indicators from OHLCV bars.
+
+    Returns a dict keyed by price_daily column names, plus derived
+    cross-signals (price_vs_sma200, trend_sma_cross).
+    Returns None for empty bars.
+    """
+    if not bars:
+        return None
+
+    closes = [b["close"] for b in bars]
+
+    # Individual indicators
+    sma_20 = sma(closes, 20)
+    sma_50 = sma(closes, 50)
+    sma_200 = sma(closes, 200)
+    ema_12 = ema(closes, 12)
+    ema_26 = ema(closes, 26)
+
+    macd_result = macd(closes)
+    macd_line: float | None = None
+    macd_signal: float | None = None
+    macd_histogram: float | None = None
+    if macd_result is not None:
+        macd_line, macd_signal, macd_histogram = macd_result
+
+    rsi_14 = rsi(closes, 14)
+
+    stoch_result = stochastic(bars)
+    stoch_k: float | None = None
+    stoch_d: float | None = None
+    if stoch_result is not None:
+        stoch_k, stoch_d = stoch_result
+
+    bb_result = bollinger_bands(closes)
+    bb_upper: float | None = None
+    bb_lower: float | None = None
+    if bb_result is not None:
+        bb_upper, bb_lower = bb_result
+
+    atr_14 = atr(bars, 14)
+
+    # Derived cross-signals (not stored in DB)
+    latest_close = float(closes[-1])
+
+    price_vs_sma200: str | None
+    if sma_200 is not None:
+        price_vs_sma200 = "above" if latest_close > sma_200 else "below"
+    else:
+        price_vs_sma200 = None
+
+    trend_sma_cross: str
+    if sma_50 is not None and sma_200 is not None:
+        if sma_50 > sma_200:
+            trend_sma_cross = "golden"
+        elif sma_50 < sma_200:
+            trend_sma_cross = "death"
+        else:
+            trend_sma_cross = "none"
+    else:
+        trend_sma_cross = "none"
+
+    return {
+        "sma_20": sma_20,
+        "sma_50": sma_50,
+        "sma_200": sma_200,
+        "ema_12": ema_12,
+        "ema_26": ema_26,
+        "macd_line": macd_line,
+        "macd_signal": macd_signal,
+        "macd_histogram": macd_histogram,
+        "rsi_14": rsi_14,
+        "stoch_k": stoch_k,
+        "stoch_d": stoch_d,
+        "bb_upper": bb_upper,
+        "bb_lower": bb_lower,
+        "atr_14": atr_14,
+        "price_vs_sma200": price_vs_sma200,
+        "trend_sma_cross": trend_sma_cross,
+    }

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -979,7 +979,7 @@ def morning_candidate_review() -> None:
     Re-score, rank, and generate trade recommendations for Tier 1 candidates.
 
     Steps (run sequentially on the same connection for each phase):
-      1. Score all eligible Tier 1 instruments (v1-balanced).
+      1. Score all eligible Tier 1 instruments (default model version).
       2. Run portfolio review to produce BUY/ADD/HOLD/EXIT recommendations.
 
     Each phase opens its own connection so a failure in recommendations

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -184,7 +184,7 @@ Use capped context in v1:
 
 ### Model versioning
 - `model_version` includes the scoring mode
-- default scoring mode is `v1-balanced`
+- default scoring mode is `v1.1-balanced` (v1.1 = TA-enhanced momentum)
 
 ### Rank delta comparison
 - compare rank delta only against the most recent prior run using the same model version / mode

--- a/sql/025_technical_analysis_columns.sql
+++ b/sql/025_technical_analysis_columns.sql
@@ -1,0 +1,34 @@
+-- Migration 025: add technical analysis indicator columns to price_daily
+--
+-- These columns store the latest-only computed TA values for each instrument.
+-- Values are recomputed on every daily candle refresh (tail end of
+-- _compute_and_store_features). Only the most recent price_date row per
+-- instrument carries values; historical rows remain NULL.
+--
+-- Formula variants pinned for auditability:
+--   RSI: Wilder smoothing (alpha = 1/period)
+--   ATR: Wilder smoothing
+--   EMA: seeded with SMA of first `period` values
+--   Bollinger: population stddev (ddof=0)
+--   Stochastic %K: (close - low14) / (high14 - low14) * 100
+--   Stochastic %D: SMA(3) of %K
+
+-- Trend indicators
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS sma_20 NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS sma_50 NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS sma_200 NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS ema_12 NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS ema_26 NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS macd_line NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS macd_signal NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS macd_histogram NUMERIC(18,6);
+
+-- Momentum indicators
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS rsi_14 NUMERIC(10,4);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS stoch_k NUMERIC(10,4);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS stoch_d NUMERIC(10,4);
+
+-- Volatility indicators
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS bb_upper NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS bb_lower NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS atr_14 NUMERIC(18,6);

--- a/tests/fixtures/copy_mirrors.py
+++ b/tests/fixtures/copy_mirrors.py
@@ -358,7 +358,7 @@ def mirror_aum_fixture(conn: psycopg.Connection[Any]) -> None:
          such that the MTM delta is non-zero but hand-computable).
       4. An instruments row for _GUARD_INSTRUMENT_ID with
          sector=_GUARD_INSTRUMENT_SECTOR.
-      5. A scores row with model_version='v1-balanced', rank=1,
+      5. A scores row with model_version='v1.1-balanced', rank=1,
          total_score=0.5, instrument_id=_GUARD_INSTRUMENT_ID —
          required by run_portfolio_review's _load_ranked_scores
          WHERE rank IS NOT NULL clause (portfolio.py:203).
@@ -539,7 +539,7 @@ def mirror_aum_fixture(conn: psycopg.Connection[Any]) -> None:
             """
             INSERT INTO scores (instrument_id, model_version,
                                 total_score, rank, scored_at)
-            VALUES (%(iid)s, 'v1-balanced', 0.5, 1, %(now)s)
+            VALUES (%(iid)s, 'v1.1-balanced', 0.5, 1, %(now)s)
             """,
             {"iid": _GUARD_INSTRUMENT_ID, "now": _NOW},
         )

--- a/tests/test_api_scores.py
+++ b/tests/test_api_scores.py
@@ -48,7 +48,7 @@ def _make_ranking_row(
     confidence_score: float | None = 0.85,
     penalties_json: list[dict[str, object]] | None = None,
     explanation: str | None = "Strong quality + value",
-    model_version: str = "v1-balanced",
+    model_version: str = "v1.1-balanced",
     scored_at: datetime = _NOW,
 ) -> dict[str, Any]:
     """Build a dict matching the joined scores+instruments+coverage query shape."""
@@ -89,7 +89,7 @@ def _make_history_row(
     explanation: str | None = "Strong quality + value",
     rank: int | None = 1,
     rank_delta: int | None = -2,
-    model_version: str = "v1-balanced",
+    model_version: str = "v1.1-balanced",
 ) -> dict[str, Any]:
     return {
         "scored_at": scored_at,
@@ -185,7 +185,7 @@ class TestListRankings:
         assert body["total"] == 1
         assert body["offset"] == 0
         assert body["limit"] == 50
-        assert body["model_version"] == "v1-balanced"
+        assert body["model_version"] == "v1.1-balanced"
         assert body["scored_at"] is not None
         assert len(body["items"]) == 1
 

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -668,10 +668,15 @@ def _generate_price_rows(n: int) -> list[tuple[date, Decimal]]:
     return [(date.fromordinal(base.toordinal() + i), Decimal(str(100 + i * 0.5))) for i in range(n)]
 
 
-def _generate_ohlcv_rows(n: int) -> list[tuple[Decimal, Decimal, Decimal, Decimal, int]]:
-    """Generate n OHLCV tuples (open, high, low, close, volume)."""
+def _generate_ohlcv_rows(n: int) -> list[tuple[date, Decimal, Decimal, Decimal, Decimal, int]]:
+    """Generate n OHLCV tuples (price_date, open, high, low, close, volume).
+
+    Dates match _generate_price_rows so the TA date-alignment check passes.
+    """
+    base = date(2025, 1, 1)
     return [
         (
+            date.fromordinal(base.toordinal() + i),  # price_date
             Decimal(str(100 + i * 0.5)),  # open
             Decimal(str(101 + i * 0.5)),  # high
             Decimal(str(99 + i * 0.5)),  # low

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -4,6 +4,8 @@ Unit tests for market data normalisation, feature computation, and spread checks
 No network calls, no database — all tests use in-memory fixtures.
 """
 
+from __future__ import annotations
+
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
@@ -23,6 +25,7 @@ from app.providers.market_data import OHLCVBar, Quote
 from app.services.market_data import (
     DEFAULT_MAX_SPREAD_PCT,
     _candles_are_fresh,
+    _compute_and_store_features,
     _compute_rolling_returns,
     _compute_volatility_30d,
     _most_recent_trading_day,
@@ -609,3 +612,182 @@ class TestCandleFreshness:
 
     def test_same_day_weekday(self) -> None:
         assert _candles_are_fresh_standalone(date(2026, 4, 13), date(2026, 4, 13))
+
+
+# ---------------------------------------------------------------------------
+# TA integration in _compute_and_store_features
+# ---------------------------------------------------------------------------
+
+_TA_COLUMN_NAMES = [
+    "sma_20",
+    "sma_50",
+    "sma_200",
+    "ema_12",
+    "ema_26",
+    "macd_line",
+    "macd_signal",
+    "macd_histogram",
+    "rsi_14",
+    "stoch_k",
+    "stoch_d",
+    "bb_upper",
+    "bb_lower",
+    "atr_14",
+]
+
+
+def _make_mock_execute(results_queue: list[list[tuple[object, ...]]]) -> object:
+    """Return a side_effect callable that pops from a pre-built results queue.
+
+    Each call to conn.execute() returns a MagicMock whose .fetchall()
+    yields the next list from the queue.  Calls beyond the queue length
+    return empty results (for the UPDATE).
+    """
+    queue = list(results_queue)
+    idx = [0]
+
+    def _side_effect(*args: object, **kwargs: object) -> MagicMock:
+        mock = MagicMock()
+        if idx[0] < len(queue):
+            mock.fetchall.return_value = queue[idx[0]]
+            mock.fetchone.return_value = queue[idx[0]][0] if queue[idx[0]] else None
+        else:
+            mock.fetchall.return_value = []
+            mock.fetchone.return_value = None
+        idx[0] += 1
+        return mock
+
+    return _side_effect
+
+
+def _generate_price_rows(n: int) -> list[tuple[date, Decimal]]:
+    """Generate n rows of (price_date, close) with a gentle uptrend."""
+    base = date(2025, 1, 1)
+    return [(date.fromordinal(base.toordinal() + i), Decimal(str(100 + i * 0.5))) for i in range(n)]
+
+
+def _generate_ohlcv_rows(n: int) -> list[tuple[Decimal, Decimal, Decimal, Decimal, int]]:
+    """Generate n OHLCV tuples (open, high, low, close, volume)."""
+    return [
+        (
+            Decimal(str(100 + i * 0.5)),  # open
+            Decimal(str(101 + i * 0.5)),  # high
+            Decimal(str(99 + i * 0.5)),  # low
+            Decimal(str(100 + i * 0.5)),  # close
+            1000000,  # volume
+        )
+        for i in range(n)
+    ]
+
+
+class TestComputeAndStoreFeaturesTA:
+    """Tests for TA indicator integration in _compute_and_store_features."""
+
+    def test_ta_columns_in_update_sql(self) -> None:
+        """With 250+ rows, the UPDATE SQL contains all TA columns and params."""
+        n = 250
+        price_rows = _generate_price_rows(n)
+        # DB returns newest-first; function reverses internally
+        close_rows = list(reversed(price_rows))
+        ohlcv_rows = list(reversed(_generate_ohlcv_rows(n)))
+
+        conn = MagicMock()
+        conn.execute.side_effect = _make_mock_execute([close_rows, ohlcv_rows])
+
+        result = _compute_and_store_features(conn, instrument_id=42)
+        assert result == 1
+
+        # The third conn.execute call is the UPDATE
+        assert conn.execute.call_count == 3
+        update_call = conn.execute.call_args_list[2]
+        sql = update_call[0][0]
+        params = update_call[0][1]
+
+        # Verify every TA column appears in both the SQL and params dict
+        for col in _TA_COLUMN_NAMES:
+            assert f"%({col})s" in sql, f"Missing placeholder for {col}"
+            assert col in params, f"Missing param key for {col}"
+
+        # With 250 bars, at least RSI and SMA-20 should be non-None
+        assert params["rsi_14"] is not None
+        assert params["sma_20"] is not None
+        # Values should be Decimal (not float)
+        assert isinstance(params["rsi_14"], Decimal)
+        assert isinstance(params["sma_20"], Decimal)
+
+    def test_ta_none_with_insufficient_data(self) -> None:
+        """With only 10 rows, long-window indicators (sma_200) are None."""
+        n = 10
+        price_rows = _generate_price_rows(n)
+        close_rows = list(reversed(price_rows))
+        ohlcv_rows = list(reversed(_generate_ohlcv_rows(n)))
+
+        conn = MagicMock()
+        conn.execute.side_effect = _make_mock_execute([close_rows, ohlcv_rows])
+
+        result = _compute_and_store_features(conn, instrument_id=42)
+        assert result == 1
+
+        update_call = conn.execute.call_args_list[2]
+        params = update_call[0][1]
+
+        # sma_200 needs 200 bars — with 10 rows it must be None
+        assert params["sma_200"] is None
+        # sma_50 needs 50 bars — with 10 rows it must be None
+        assert params["sma_50"] is None
+        # All TA keys must still be present (even if None)
+        for col in _TA_COLUMN_NAMES:
+            assert col in params
+
+    def test_ta_skipped_when_no_rows(self) -> None:
+        """When there are no price rows, function returns 0 with no crash."""
+        conn = MagicMock()
+        conn.execute.side_effect = _make_mock_execute([[]])
+
+        result = _compute_and_store_features(conn, instrument_id=42)
+        assert result == 0
+        # Only the initial close-prices SELECT was executed; no OHLCV or UPDATE
+        assert conn.execute.call_count == 1
+
+    def test_ta_values_are_rounded_decimals(self) -> None:
+        """TA float values are converted to Decimal with 6dp precision."""
+        n = 250
+        price_rows = _generate_price_rows(n)
+        close_rows = list(reversed(price_rows))
+        ohlcv_rows = list(reversed(_generate_ohlcv_rows(n)))
+
+        conn = MagicMock()
+        conn.execute.side_effect = _make_mock_execute([close_rows, ohlcv_rows])
+
+        _compute_and_store_features(conn, instrument_id=42)
+
+        update_call = conn.execute.call_args_list[2]
+        params = update_call[0][1]
+
+        for col in _TA_COLUMN_NAMES:
+            val = params[col]
+            if val is not None:
+                assert isinstance(val, Decimal), f"{col} should be Decimal, got {type(val)}"
+                # Verify at most 6 decimal places
+                _, _, exponent = val.as_tuple()
+                assert isinstance(exponent, int)
+                assert abs(exponent) <= 6, f"{col} has more than 6dp: {val}"
+
+    def test_string_indicators_excluded_from_ta_params(self) -> None:
+        """compute_indicators returns price_vs_sma200 and trend_sma_cross as
+        strings — these must NOT appear in the numeric ta_params dict."""
+        n = 250
+        price_rows = _generate_price_rows(n)
+        close_rows = list(reversed(price_rows))
+        ohlcv_rows = list(reversed(_generate_ohlcv_rows(n)))
+
+        conn = MagicMock()
+        conn.execute.side_effect = _make_mock_execute([close_rows, ohlcv_rows])
+
+        _compute_and_store_features(conn, instrument_id=42)
+
+        update_call = conn.execute.call_args_list[2]
+        params = update_call[0][1]
+
+        assert "price_vs_sma200" not in params
+        assert "trend_sma_cross" not in params

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -780,6 +780,34 @@ class TestComputeAndStoreFeaturesTA:
                 assert isinstance(exponent, int)
                 assert abs(exponent) <= 6, f"{col} has more than 6dp: {val}"
 
+    def test_ta_skipped_when_dates_misaligned(self) -> None:
+        """When latest OHLCV date != latest close date, all TA params are None.
+
+        This tests the stale-TA guard: if the latest candle has close but
+        incomplete OHLC, the OHLCV query returns the prior complete bar,
+        creating a date mismatch that should suppress TA computation.
+        """
+        n = 250
+        price_rows = _generate_price_rows(n)
+        close_rows = list(reversed(price_rows))
+
+        # OHLCV rows end one day earlier than close rows — simulates a
+        # partial candle where close is set but OHLC is still NULL.
+        ohlcv_rows = list(reversed(_generate_ohlcv_rows(n - 1)))
+
+        conn = MagicMock()
+        conn.execute.side_effect = _make_mock_execute([close_rows, ohlcv_rows])
+
+        result = _compute_and_store_features(conn, instrument_id=42)
+        assert result == 1
+
+        update_call = conn.execute.call_args_list[2]
+        params = update_call[0][1]
+
+        # Every TA column must be None due to date mismatch
+        for col in _TA_COLUMN_NAMES:
+            assert params[col] is None, f"{col} should be None when dates misalign"
+
     def test_string_indicators_excluded_from_ta_params(self) -> None:
         """compute_indicators returns price_vs_sma200 and trend_sma_cross as
         strings — these must NOT appear in the numeric ta_params dict."""

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -6,8 +6,10 @@ No network calls, no database — all tests use in-memory fixtures.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import UTC, date, datetime
 from decimal import Decimal
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -636,7 +638,7 @@ _TA_COLUMN_NAMES = [
 ]
 
 
-def _make_mock_execute(results_queue: list[list[tuple[object, ...]]]) -> object:
+def _make_mock_execute(results_queue: Sequence[Sequence[Any]]) -> object:
     """Return a side_effect callable that pops from a pre-built results queue.
 
     Each call to conn.execute() returns a MagicMock whose .fetchall()

--- a/tests/test_portfolio_review_mirror_equity.py
+++ b/tests/test_portfolio_review_mirror_equity.py
@@ -88,7 +88,7 @@ def test_run_portfolio_review_total_aum_includes_mirror_equity(
     # emitted. The two log messages are disjoint by construction,
     # so this pins the execution path directly.
     full_path_log = next(
-        (r for r in caplog.records if "ranked=1 model=v1-balanced" in r.getMessage()),
+        (r for r in caplog.records if "ranked=1 model=v1.1-balanced" in r.getMessage()),
         None,
     )
     assert full_path_log is not None, (

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -314,6 +314,28 @@ class TestEnhancedMomentumScore:
         assert score > 0.5  # bullish TA should push above neutral
         assert score <= 1.0
 
+    def test_zero_close_guards_division(self) -> None:
+        """current_close = 0 should not cause ZeroDivisionError.
+
+        MACD and ATR sub-components divide by current_close; the guards
+        must suppress them gracefully and emit unavailable notes.
+        """
+        ta = {
+            "sma_200": 90.0,
+            "macd_histogram": 2.0,
+            "rsi_14": 55.0,
+            "stoch_k": 50.0,
+            "stoch_d": 50.0,
+            "bb_upper": 120.0,
+            "bb_lower": 80.0,
+            "atr_14": 3.0,
+            "current_close": 0.0,
+        }
+        score, notes = _momentum_score(0.10, 0.20, 0.30, ta_indicators=ta)
+        assert 0.0 <= score <= 1.0
+        # MACD should be suppressed (division by zero guard)
+        assert any("macd_histogram" in n for n in notes)
+
 
 # ---------------------------------------------------------------------------
 # _sentiment_score

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -208,6 +208,114 @@ class TestMomentumScore:
 
 
 # ---------------------------------------------------------------------------
+# _momentum_score with TA indicators
+# ---------------------------------------------------------------------------
+
+
+class TestEnhancedMomentumScore:
+    """Tests for _momentum_score with TA inputs."""
+
+    def test_backward_compatible_no_ta(self) -> None:
+        """When ta_indicators is not passed, matches original behavior."""
+        score_old, _ = _momentum_score(0.10, 0.20, 0.30)
+        score_new, _ = _momentum_score(0.10, 0.20, 0.30, ta_indicators=None)
+        assert score_new == _approx(score_old)
+
+    def test_strong_bullish_ta_boosts(self) -> None:
+        """Bullish TA (above SMA200, positive MACD, healthy RSI) with positive returns."""
+        ta = {
+            "sma_200": 90.0,
+            "macd_histogram": 2.5,
+            "rsi_14": 60.0,
+            "stoch_k": 70.0,
+            "stoch_d": 65.0,
+            "bb_upper": 120.0,
+            "bb_lower": 80.0,
+            "atr_14": 3.0,
+            "current_close": 110.0,
+        }
+        score, notes = _momentum_score(0.10, 0.20, 0.30, ta_indicators=ta)
+        assert score > 0.7
+        # No "unavailable" notes for provided indicators
+        assert not any("unavailable" in n for n in notes)
+
+    def test_bearish_ta_drags_down(self) -> None:
+        """Bearish TA (below SMA200, negative MACD, overbought RSI) drags score below pure returns."""
+        ta = {
+            "sma_200": 130.0,
+            "macd_histogram": -3.0,
+            "rsi_14": 82.0,
+            "stoch_k": 90.0,
+            "stoch_d": 85.0,
+            "bb_upper": 115.0,
+            "bb_lower": 105.0,
+            "atr_14": 6.0,
+            "current_close": 100.0,
+        }
+        score_no_ta, _ = _momentum_score(0.10, 0.20, 0.30)
+        score_with_ta, _ = _momentum_score(0.10, 0.20, 0.30, ta_indicators=ta)
+        assert score_with_ta < score_no_ta
+
+    def test_partial_ta_uses_available(self) -> None:
+        """When some TA values are None, available ones still contribute."""
+        ta = {
+            "sma_200": None,
+            "macd_histogram": 1.5,
+            "rsi_14": 55.0,
+            "stoch_k": None,
+            "stoch_d": None,
+            "bb_upper": None,
+            "bb_lower": None,
+            "atr_14": None,
+            "current_close": 100.0,
+        }
+        score, notes = _momentum_score(0.10, 0.20, 0.30, ta_indicators=ta)
+        assert 0.0 <= score <= 1.0
+        assert any("sma_200" in n for n in notes)
+
+    def test_all_missing_returns_and_no_ta_neutral(self) -> None:
+        """No returns + no TA = neutral 0.5."""
+        score, notes = _momentum_score(None, None, None, ta_indicators=None)
+        assert score == _approx(0.5)
+        assert len(notes) == 3  # 3 missing return notes
+
+    def test_rsi_overbought_penalty(self) -> None:
+        """RSI > 70 should reduce momentum quality score."""
+        ta_healthy = {
+            "sma_200": 90.0,
+            "macd_histogram": 1.0,
+            "rsi_14": 55.0,
+            "stoch_k": 50.0,
+            "stoch_d": 50.0,
+            "bb_upper": 120.0,
+            "bb_lower": 80.0,
+            "atr_14": 2.0,
+            "current_close": 100.0,
+        }
+        ta_overbought = {**ta_healthy, "rsi_14": 85.0}
+        score_healthy, _ = _momentum_score(0.10, 0.20, 0.30, ta_indicators=ta_healthy)
+        score_overbought, _ = _momentum_score(0.10, 0.20, 0.30, ta_indicators=ta_overbought)
+        assert score_overbought < score_healthy
+
+    def test_ta_with_no_returns_still_produces_score(self) -> None:
+        """When all returns are None but TA is available, TA alone drives the score."""
+        ta = {
+            "sma_200": 90.0,
+            "macd_histogram": 2.0,
+            "rsi_14": 60.0,
+            "stoch_k": 65.0,
+            "stoch_d": 60.0,
+            "bb_upper": 120.0,
+            "bb_lower": 80.0,
+            "atr_14": 2.5,
+            "current_close": 110.0,
+        }
+        score, notes = _momentum_score(None, None, None, ta_indicators=ta)
+        assert score > 0.5  # bullish TA should push above neutral
+        assert score <= 1.0
+
+
+# ---------------------------------------------------------------------------
 # _sentiment_score
 # ---------------------------------------------------------------------------
 

--- a/tests/test_technical_analysis.py
+++ b/tests/test_technical_analysis.py
@@ -1,0 +1,337 @@
+"""Tests for the pure TA computation module."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from decimal import Decimal
+
+import pytest
+
+from app.services.technical_analysis import (
+    OHLCVRow,
+    atr,
+    bollinger_bands,
+    compute_indicators,
+    ema,
+    macd,
+    rsi,
+    sma,
+    stochastic,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_closes(values: list[float]) -> list[Decimal]:
+    return [Decimal(str(v)) for v in values]
+
+
+def _make_ohlcv(
+    values: Sequence[tuple[float, float, float, float]],
+) -> list[OHLCVRow]:
+    return [
+        OHLCVRow(
+            open=Decimal(str(op)),
+            high=Decimal(str(hi)),
+            low=Decimal(str(lo)),
+            close=Decimal(str(cl)),
+            volume=None,
+        )
+        for op, hi, lo, cl in values
+    ]
+
+
+# ===================================================================
+# SMA
+# ===================================================================
+
+
+class TestSMA:
+    def test_sma_20_exact(self) -> None:
+        closes = _make_closes([float(i) for i in range(1, 21)])
+        result = sma(closes, 20)
+        assert result == pytest.approx(10.5, rel=1e-4)
+
+    def test_sma_longer_series(self) -> None:
+        closes = _make_closes([1, 2, 3, 4, 5])
+        result = sma(closes, 3)
+        assert result == pytest.approx(4.0, rel=1e-4)
+
+    def test_sma_insufficient_data(self) -> None:
+        closes = _make_closes([1, 2])
+        assert sma(closes, 3) is None
+
+
+# ===================================================================
+# EMA
+# ===================================================================
+
+
+class TestEMA:
+    def test_ema_seeded_with_sma(self) -> None:
+        # EMA(3) of [1,2,3,4,5]:
+        # seed = SMA(1,2,3) = 2.0
+        # mult = 2/(3+1) = 0.5
+        # EMA_4 = 4*0.5 + 2.0*0.5 = 3.0
+        # EMA_5 = 5*0.5 + 3.0*0.5 = 4.0
+        closes = _make_closes([1, 2, 3, 4, 5])
+        result = ema(closes, 3)
+        assert result == pytest.approx(4.0, rel=1e-4)
+
+    def test_ema_12_matches_reference(self) -> None:
+        closes = _make_closes([float(i) for i in range(1, 21)])
+        result = ema(closes, 12)
+        assert result is not None
+        assert result > 13.0
+
+    def test_ema_insufficient_data(self) -> None:
+        closes = _make_closes([1, 2])
+        assert ema(closes, 3) is None
+
+
+# ===================================================================
+# RSI
+# ===================================================================
+
+
+class TestRSI:
+    def test_rsi_all_gains(self) -> None:
+        closes = _make_closes([float(i) for i in range(1, 20)])
+        result = rsi(closes, 14)
+        assert result is not None
+        assert result > 95
+
+    def test_rsi_all_losses(self) -> None:
+        closes = _make_closes([float(i) for i in range(20, 1, -1)])
+        result = rsi(closes, 14)
+        assert result is not None
+        assert result < 5
+
+    def test_rsi_flat_market(self) -> None:
+        closes = _make_closes([100.0] * 20)
+        result = rsi(closes, 14)
+        assert result == 50.0
+
+    def test_rsi_insufficient_data(self) -> None:
+        closes = _make_closes([1, 2, 3])
+        assert rsi(closes, 14) is None
+
+    def test_rsi_known_value(self) -> None:
+        # Alternating +1/-0.5 from 100, 29 values
+        vals: list[float] = [100.0]
+        for i in range(28):
+            if i % 2 == 0:
+                vals.append(vals[-1] + 1.0)
+            else:
+                vals.append(vals[-1] - 0.5)
+        closes = _make_closes(vals)
+        result = rsi(closes, 14)
+        assert result is not None
+        assert 55 <= result <= 75
+
+
+# ===================================================================
+# MACD
+# ===================================================================
+
+
+class TestMACD:
+    def test_macd_components(self) -> None:
+        closes = _make_closes([float(i) for i in range(1, 51)])
+        result = macd(closes)
+        assert result is not None
+        line, signal, histogram = result
+        assert line > 0
+        assert histogram == pytest.approx(line - signal, rel=1e-4)
+
+    def test_macd_insufficient_data(self) -> None:
+        closes = _make_closes([float(i) for i in range(1, 34)])
+        assert macd(closes) is None
+
+    def test_macd_flat_market(self) -> None:
+        closes = _make_closes([50.0] * 50)
+        result = macd(closes)
+        assert result is not None
+        line, signal, histogram = result
+        assert line == pytest.approx(0.0, abs=1e-6)
+        assert signal == pytest.approx(0.0, abs=1e-6)
+        assert histogram == pytest.approx(0.0, abs=1e-6)
+
+
+# ===================================================================
+# Bollinger Bands
+# ===================================================================
+
+
+class TestBollingerBands:
+    def test_bollinger_flat_market(self) -> None:
+        closes = _make_closes([100.0] * 20)
+        result = bollinger_bands(closes)
+        assert result is not None
+        upper, lower = result
+        assert upper == pytest.approx(100.0, abs=1e-6)
+        assert lower == pytest.approx(100.0, abs=1e-6)
+
+    def test_bollinger_known_spread(self) -> None:
+        closes = _make_closes([float(i) for i in range(1, 21)])
+        result = bollinger_bands(closes)
+        assert result is not None
+        upper, lower = result
+        mean = 10.5
+        # Population stddev of 1..20
+        variance = sum((i - mean) ** 2 for i in range(1, 21)) / 20
+        std = variance**0.5
+        assert upper == pytest.approx(mean + 2 * std, rel=1e-4)
+        assert lower == pytest.approx(mean - 2 * std, rel=1e-4)
+
+    def test_bollinger_insufficient_data(self) -> None:
+        closes = _make_closes([1, 2, 3])
+        assert bollinger_bands(closes) is None
+
+
+# ===================================================================
+# ATR
+# ===================================================================
+
+
+class TestATR:
+    def test_atr_known_value(self) -> None:
+        # Constant range bars: high=105, low=95, close=100
+        # Need period+1 = 15 bars for period=14
+        bars = _make_ohlcv([(100, 105, 95, 100)] * 15)
+        result = atr(bars, 14)
+        assert result is not None
+        assert result == pytest.approx(10.0, rel=1e-4)
+
+    def test_atr_with_gaps(self) -> None:
+        # 14 constant bars then one with gap
+        base_bars = [(100, 105, 95, 100)] * 14
+        # Gap bar: prev_close=100, high=115, low=108
+        # TR = max(115-108, |115-100|, |108-100|) = max(7, 15, 8) = 15
+        gap_bar = (110, 115, 108, 112)
+        bars = _make_ohlcv(base_bars + [gap_bar])
+        result = atr(bars, 14)
+        assert result is not None
+        # Initial ATR (first 14 TRs, indices 1-14) = SMA of 13 * 10 + 15 / 14
+        # Bars: index 0 is anchor. Bars 1..13 have TR=10 each (13 bars).
+        # Bar 14 (gap bar) has TR=15. That's 14 TRs total.
+        # Initial ATR = (13*10 + 15)/14 = 145/14 ≈ 10.357
+        assert result == pytest.approx(145 / 14, rel=1e-4)
+
+    def test_atr_insufficient_data(self) -> None:
+        bars = _make_ohlcv([(100, 105, 95, 100)] * 5)
+        assert atr(bars, 14) is None
+
+
+# ===================================================================
+# Stochastic
+# ===================================================================
+
+
+class TestStochastic:
+    def test_stochastic_at_high(self) -> None:
+        # Close at the top of range for all bars
+        bars = _make_ohlcv([(100, 110, 90, 110)] * 16)
+        result = stochastic(bars)
+        assert result is not None
+        k, d = result
+        assert k == pytest.approx(100.0, abs=1e-6)
+        assert d == pytest.approx(100.0, abs=1e-6)
+
+    def test_stochastic_at_low(self) -> None:
+        # Close at the bottom of range for all bars
+        bars = _make_ohlcv([(100, 110, 90, 90)] * 16)
+        result = stochastic(bars)
+        assert result is not None
+        k, d = result
+        assert k == pytest.approx(0.0, abs=1e-6)
+        assert d == pytest.approx(0.0, abs=1e-6)
+
+    def test_stochastic_midpoint(self) -> None:
+        # Close at the midpoint of range
+        bars = _make_ohlcv([(100, 110, 90, 100)] * 16)
+        result = stochastic(bars)
+        assert result is not None
+        k, _d = result
+        assert k == pytest.approx(50.0, abs=1e-6)
+
+    def test_stochastic_insufficient_data(self) -> None:
+        bars = _make_ohlcv([(100, 110, 90, 100)] * 5)
+        assert stochastic(bars) is None
+
+
+# ===================================================================
+# compute_indicators (orchestrator)
+# ===================================================================
+
+
+class TestComputeIndicators:
+    def _make_ascending_bars(self, n: int) -> list[OHLCVRow]:
+        """Create n ascending bars with realistic OHLCV shape."""
+        return [
+            OHLCVRow(
+                open=Decimal(str(100 + i)),
+                high=Decimal(str(105 + i)),
+                low=Decimal(str(95 + i)),
+                close=Decimal(str(102 + i)),
+                volume=1000,
+            )
+            for i in range(n)
+        ]
+
+    def test_full_dataset_returns_all_indicators(self) -> None:
+        bars = self._make_ascending_bars(250)
+        result = compute_indicators(bars)
+        assert result is not None
+        stored_keys = [
+            "sma_20",
+            "sma_50",
+            "sma_200",
+            "ema_12",
+            "ema_26",
+            "macd_line",
+            "macd_signal",
+            "macd_histogram",
+            "rsi_14",
+            "stoch_k",
+            "stoch_d",
+            "bb_upper",
+            "bb_lower",
+            "atr_14",
+        ]
+        for key in stored_keys:
+            assert key in result, f"Missing key: {key}"
+            assert result[key] is not None, f"Key {key} is None"
+
+    def test_insufficient_history_returns_none_for_long_indicators(self) -> None:
+        bars = self._make_ascending_bars(30)
+        result = compute_indicators(bars)
+        assert result is not None
+        assert result["sma_200"] is None
+        assert result["sma_20"] is not None
+
+    def test_empty_bars_returns_none(self) -> None:
+        assert compute_indicators([]) is None
+
+    def test_price_above_sma200(self) -> None:
+        # Ascending bars — latest close well above SMA(200)
+        bars = self._make_ascending_bars(250)
+        result = compute_indicators(bars)
+        assert result is not None
+        assert result["price_vs_sma200"] == "above"
+
+    def test_trend_sma_cross_golden(self) -> None:
+        # Ascending data: SMA(50) > SMA(200) → golden cross
+        bars = self._make_ascending_bars(250)
+        result = compute_indicators(bars)
+        assert result is not None
+        assert result["trend_sma_cross"] == "golden"
+
+    def test_trend_sma_cross_none_when_insufficient(self) -> None:
+        # Not enough data for SMA(200) → cross signal should be "none"
+        bars = self._make_ascending_bars(100)
+        result = compute_indicators(bars)
+        assert result is not None
+        assert result["trend_sma_cross"] == "none"


### PR DESCRIPTION
Closes #200

## What changed

Adds a pure-Python technical analysis engine that computes 14 indicators from existing OHLCV data in `price_daily` and folds them into the existing `momentum_score` family as v1.1. No new score family, no new weight modes, no new dependencies.

**Files (14 changed, +1265/-32):**

| Layer | Files | Purpose |
|-------|-------|---------|
| Schema | `sql/025_technical_analysis_columns.sql` | 14 new NUMERIC columns on `price_daily` |
| Computation | `app/services/technical_analysis.py` (new, 313 lines) | Pure functions: SMA, EMA, RSI, MACD, Bollinger, ATR, Stochastic |
| Integration | `app/services/market_data.py` | TA computed at tail of `_compute_and_store_features()` |
| Scoring | `app/services/scoring.py` | Enhanced `_momentum_score()` blends returns (40%) + trend (25%) + momentum quality (20%) + volatility regime (15%) |
| Version bump | `app/api/scores.py`, `app/services/portfolio.py`, `app/workers/scheduler.py`, `docs/settled-decisions.md` | Default model version → `v1.1-balanced` |
| Tests | `tests/test_technical_analysis.py` (30 tests), `tests/test_scoring.py` (+9 tests), `tests/test_market_data.py` (+6 tests) | Indicator formulas, scoring integration, edge cases |
| Test fixtures | `tests/test_api_scores.py`, `tests/test_portfolio_review_mirror_equity.py`, `tests/fixtures/copy_mirrors.py` | Updated for v1.1-balanced default |

## Why

Issue #200: the existing `momentum_score` used only 1m/3m/6m returns — no trend confirmation, no overbought/oversold detection, no volatility regime assessment. With 400 days of OHLCV already in `price_daily`, TA indicators are the natural enrichment.

Folding into the existing momentum family (not a new `ta_score`) avoids double-counting momentum, avoids weight mode migration, and avoids API/persistence changes.

## Schema / migration impact

- **Migration 025**: 14 `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements on `price_daily`
- All columns are nullable NUMERIC; no backfill required
- Existing rows remain NULL until next candle refresh
- No schema version change required for API consumers

## Invariants checked

- **No new dependencies**: pure Python using `math` and `decimal` stdlib only
- **Parameterised SQL**: all queries use `%(name)s` placeholders
- **Idempotent writes**: UPDATE is keyed on `(instrument_id, price_date)` — re-running writes same values
- **Version isolation**: v1 models (`v1-balanced` etc.) preserve the original return-only momentum formula; TA gated on `model_version.startswith("v1.1")`
- **Stale TA guard**: indicators only written when latest complete OHLCV bar date matches the target price_daily row — prevents stale-by-one-day writes when latest candle has incomplete OHLC
- **NaN guard**: `math.isfinite(v)` check before `Decimal()` conversion prevents non-finite TA values from crashing Postgres NUMERIC columns
- **OHLC completeness filter**: `AND open IS NOT NULL AND high IS NOT NULL AND low IS NOT NULL` on the OHLCV query — schema permits partial rows

## Failure paths considered

- **Insufficient history** (< 200 bars): long-window indicators return None → scoring falls back to available subcomponents with re-weighted proportions
- **All TA None**: momentum score degrades to return-only formula (backward compatible with v1)
- **Partial OHLC candle**: stale TA guard suppresses computation; all TA params written as NULL
- **Zero/negative close price**: division guards in MACD normalisation and ATR percentage prevent ZeroDivisionError
- **Non-finite TA output**: `math.isfinite()` guard converts to None before DB write
- **Empty price_daily**: function returns 0 early, no UPDATE executed

## Tests added

- **30 indicator formula tests** (`test_technical_analysis.py`): each indicator verified against hand-computed reference values with specific tolerances. Covers SMA, EMA, RSI (Wilder smoothing, insufficient data, all gains/losses), MACD (histogram, signal), Bollinger (bands, population stddev), ATR (Wilder, insufficient), Stochastic (%K/%D, boundary, zero range), and the `compute_indicators` orchestrator (sufficient data, insufficient, empty, partial OHLC).
- **9 enhanced momentum tests** (`test_scoring.py`): backward compatibility (no TA = same as v1), bullish TA boost, bearish TA drag, partial TA, neutral fallback, RSI overbought penalty, TA-only scoring, and zero-close division guard.
- **6 market data integration tests** (`test_market_data.py`): TA columns in UPDATE SQL, insufficient data, no rows, Decimal precision, string indicators excluded, stale-TA date-mismatch guard.

## Conscious tradeoffs

- **Latest-only storage**: only the most recent price_daily row per instrument carries TA values. Historical TA is not persisted — recomputed from raw candles if needed. Avoids backfill complexity and storage cost.
- **No separate scheduler job**: TA runs at the tail of `_compute_and_store_features()` in the daily candle refresh. Eliminates race conditions but couples TA freshness to candle refresh cadence.
- **`startswith("v1.1")` gate**: will match v1.10+ when those arrive. Acceptable for now; refactor to explicit set when v1.2 is introduced.
- **`_TA_COLUMNS` list defined in market_data.py and test file**: not extracted to a shared constant yet. Worth doing when a 15th indicator is added.
- **`stoch_d` loaded but unused in scoring**: kept in the data path for future crossover signal work (#202).
- **Bollinger position direction**: measures trend strength (high = strong uptrend), intentionally opposite to RSI/stoch overbought treatment. Documented in code comment.

## Formula variants pinned (auditability)

| Indicator | Variant | Detail |
|-----------|---------|--------|
| RSI | Wilder smoothing | α = 1/period |
| ATR | Wilder smoothing | α = 1/period |
| EMA | SMA-seeded | first `period` values averaged as seed |
| Bollinger | Population stddev | ddof=0 |
| Stochastic %K | Raw | (close - low14) / (high14 - low14) × 100 |
| Stochastic %D | SMA(3) of %K | |
| MACD | 12/26/9 | normalised by current_close for scoring |

## Tech debt opened

None — all Codex findings addressed in this PR.

## Security model

No new API endpoints, no new user input paths, no authentication changes. All SQL is parameterised. TA computation is pure (no I/O, no network, no DB access).