### PR TITLE
feat(#202): entry timing service — TA-informed SL/TP and defer logic

### DIFF
--- a/app/services/entry_timing.py
+++ b/app/services/entry_timing.py
@@ -318,18 +318,20 @@ def evaluate_entry_conditions(
     sma_200_f = float(sma_200_raw) if sma_200_raw is not None else None
     atr_dec = Decimal(str(atr_raw)) if atr_raw is not None else None
 
-    # Evaluate each condition
+    # Evaluate each condition independently.  RSI and MACD handle NULL
+    # inputs as neutral.  Bollinger and trend need a close price, so they
+    # are neutral when close is NULL.  This preserves the distinction
+    # between "no price row" (ta is None, caught above) and "price row
+    # with NULL indicators" in the condition log.
     conditions: list[tuple[str, bool]] = []
-
+    conditions.append(_eval_rsi(rsi_f))
+    conditions.append(_eval_macd(macd_f))
     if close_f is not None:
-        conditions.append(_eval_rsi(rsi_f))
-        conditions.append(_eval_macd(macd_f))
         conditions.append(_eval_bollinger(close_f, bb_upper_f, bb_lower_f))
         conditions.append(_eval_trend(close_f, sma_200_f))
     else:
-        # No close price at all — can't evaluate anything. Pass through
-        # (don't block on missing data).
-        conditions.append(("no close price available (neutral)", True))
+        conditions.append(("bollinger: close NULL (neutral)", True))
+        conditions.append(("trend: close NULL (neutral)", True))
 
     # Count unfavorable conditions
     unfavorable = [desc for desc, ok in conditions if not ok]

--- a/app/services/entry_timing.py
+++ b/app/services/entry_timing.py
@@ -49,7 +49,10 @@ RSI_OVERBOUGHT = 75.0
 # band range (upper - lower), consider overextended and defer.
 BB_OVEREXTENDED_PCT = 0.95
 
-TimingVerdict = Literal["pass", "defer", "skip", "error"]
+# Verdicts returned by evaluate_entry_conditions.  The DB CHECK
+# constraint also permits 'error' (written by the scheduler for
+# error-deferred recs), but the service itself never produces it.
+TimingVerdict = Literal["pass", "defer", "skip"]
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/entry_timing.py
+++ b/app/services/entry_timing.py
@@ -1,0 +1,383 @@
+"""Entry timing service — TA-informed entry condition evaluation.
+
+Sits between the portfolio manager (which decides WHAT to trade) and
+the execution guard (which checks hard rules).  For BUY/ADD
+recommendations, evaluates whether current TA conditions support
+entering now vs. deferring to the next cycle.
+
+EXIT recommendations always pass through — the timing layer must
+never add gates that block protective exits (settled decision).
+
+Key design choices:
+  - NULL TA indicators are neutral/pass — never block on missing data.
+  - ATR-based stop-loss with a 5% floor to prevent negative/too-tight SL.
+  - Take-profit from thesis base_value, guarded against stale/below-entry values.
+  - Pure service module: reads DB, returns a result. No side effects.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+import psycopg.rows
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# ATR multiplier for stop-loss: entry_price - ATR_SL_MULTIPLIER * ATR(14)
+ATR_SL_MULTIPLIER = Decimal("2.0")
+
+# Floor: SL cannot be more than this fraction below entry price.
+# Prevents negative/absurdly wide SL on volatile low-price stocks.
+SL_FLOOR_PCT = Decimal("0.05")  # 5% below entry
+
+# Minimum SL distance: SL must be at least this fraction below entry.
+# Prevents being stopped out by normal spread noise on low-volatility stocks.
+SL_MIN_DISTANCE_PCT = Decimal("0.02")  # 2% below entry
+
+# RSI threshold: above this = overbought, defer entry.
+RSI_OVERBOUGHT = 75.0
+
+# Bollinger band proximity: if price is within this fraction of the upper
+# band range (upper - lower), consider overextended and defer.
+BB_OVEREXTENDED_PCT = 0.95
+
+TimingVerdict = Literal["pass", "defer", "skip"]
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EntryEvaluation:
+    """Result of evaluating entry timing conditions for a recommendation."""
+
+    verdict: TimingVerdict
+    stop_loss_rate: Decimal | None
+    take_profit_rate: Decimal | None
+    rationale: str
+    condition_details: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# DB loaders
+# ---------------------------------------------------------------------------
+
+
+def _load_recommendation_with_thesis(
+    conn: psycopg.Connection[Any],
+    recommendation_id: int,
+) -> dict[str, Any] | None:
+    """Load recommendation joined with the latest thesis for the instrument.
+
+    Returns None if the recommendation doesn't exist.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT tr.recommendation_id, tr.instrument_id, tr.action,
+                   tr.target_entry, tr.suggested_size_pct, tr.status,
+                   t.base_value, t.buy_zone_low, t.buy_zone_high,
+                   t.confidence_score
+            FROM trade_recommendations tr
+            LEFT JOIN LATERAL (
+                SELECT base_value, buy_zone_low, buy_zone_high, confidence_score
+                FROM theses
+                WHERE instrument_id = tr.instrument_id
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) t ON TRUE
+            WHERE tr.recommendation_id = %(rid)s
+            """,
+            {"rid": recommendation_id},
+        )
+        return cur.fetchone()
+
+
+def _load_latest_ta(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> dict[str, Any] | None:
+    """Load the latest price_daily row with TA indicators.
+
+    Returns None if no TA data exists for this instrument.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT close, sma_200, rsi_14, macd_histogram,
+                   bb_upper, bb_lower, atr_14
+            FROM price_daily
+            WHERE instrument_id = %(iid)s
+              AND close IS NOT NULL
+            ORDER BY price_date DESC
+            LIMIT 1
+            """,
+            {"iid": instrument_id},
+        )
+        return cur.fetchone()
+
+
+# ---------------------------------------------------------------------------
+# Condition evaluators
+# ---------------------------------------------------------------------------
+
+
+def _eval_rsi(rsi_14: float | None) -> tuple[str, bool]:
+    """Evaluate RSI condition.
+
+    Returns (description, is_favorable).
+    NULL RSI = neutral/pass (never block on missing data).
+    """
+    if rsi_14 is None:
+        return ("rsi: NULL (neutral)", True)
+    if rsi_14 > RSI_OVERBOUGHT:
+        return (f"rsi: {rsi_14:.1f} > {RSI_OVERBOUGHT} (overbought, defer)", False)
+    return (f"rsi: {rsi_14:.1f} (ok)", True)
+
+
+def _eval_macd(macd_histogram: float | None) -> tuple[str, bool]:
+    """Evaluate MACD histogram condition.
+
+    Positive histogram = momentum is favorable.
+    Negative = momentum weakening, defer.
+    NULL = neutral/pass.
+    """
+    if macd_histogram is None:
+        return ("macd: NULL (neutral)", True)
+    if macd_histogram >= 0:
+        return (f"macd_hist: {macd_histogram:.4f} >= 0 (favorable)", True)
+    return (f"macd_hist: {macd_histogram:.4f} < 0 (weak momentum, defer)", False)
+
+
+def _eval_bollinger(
+    close: float,
+    bb_upper: float | None,
+    bb_lower: float | None,
+) -> tuple[str, bool]:
+    """Evaluate Bollinger band position.
+
+    Price near upper band = overextended, defer.
+    NULL bands = neutral/pass.
+    """
+    if bb_upper is None or bb_lower is None:
+        return ("bollinger: NULL (neutral)", True)
+    band_width = bb_upper - bb_lower
+    if band_width <= 0:
+        return ("bollinger: zero-width band (neutral)", True)
+    # Position within band: 0 = lower, 1 = upper
+    position = (close - bb_lower) / band_width
+    if position >= BB_OVEREXTENDED_PCT:
+        return (f"bollinger: position={position:.2f} >= {BB_OVEREXTENDED_PCT} (overextended, defer)", False)
+    return (f"bollinger: position={position:.2f} (ok)", True)
+
+
+def _eval_trend(close: float, sma_200: float | None) -> tuple[str, bool]:
+    """Evaluate trend confirmation via SMA-200.
+
+    Price above SMA-200 = favorable.
+    Price below = unfavorable but not a hard defer (informational).
+    NULL SMA-200 = neutral/pass.
+    """
+    if sma_200 is None:
+        return ("trend: SMA-200 NULL (neutral)", True)
+    if close >= sma_200:
+        return (f"trend: close={close:.2f} >= SMA-200={sma_200:.2f} (favorable)", True)
+    return (f"trend: close={close:.2f} < SMA-200={sma_200:.2f} (below trend)", True)
+
+
+# ---------------------------------------------------------------------------
+# SL/TP computation
+# ---------------------------------------------------------------------------
+
+
+def _compute_stop_loss(
+    entry_price: Decimal,
+    atr_14: Decimal | None,
+) -> Decimal:
+    """Compute ATR-based stop-loss with floor and minimum distance clamps.
+
+    Formula: entry_price - ATR_SL_MULTIPLIER * ATR(14)
+    Floor:   max(ATR-derived, entry_price * (1 - SL_FLOOR_PCT))
+    Minimum: min(result, entry_price * (1 - SL_MIN_DISTANCE_PCT))
+
+    Units: entry_price is USD, ATR is USD price-range. Result is USD.
+
+    If ATR is NULL, uses the floor (5% below entry) as default.
+    """
+    floor_sl = entry_price * (Decimal("1") - SL_FLOOR_PCT)
+    min_distance_sl = entry_price * (Decimal("1") - SL_MIN_DISTANCE_PCT)
+
+    if atr_14 is None or atr_14 <= 0:
+        # No ATR data: use the floor as a reasonable default
+        return floor_sl
+
+    # ATR-derived SL
+    atr_sl = entry_price - ATR_SL_MULTIPLIER * atr_14
+
+    # Clamp: not below floor (prevents negative/absurdly wide SL)
+    sl = max(atr_sl, floor_sl)
+
+    # Clamp: at least SL_MIN_DISTANCE_PCT below entry (prevents too-tight SL)
+    sl = min(sl, min_distance_sl)
+
+    return sl
+
+
+def _compute_take_profit(
+    entry_price: Decimal,
+    base_value: Decimal | None,
+) -> Decimal | None:
+    """Compute take-profit from thesis base_value (target price).
+
+    Returns None if base_value is missing or at/below entry price.
+    A TP at or below entry would trigger immediately — nonsensical.
+    """
+    if base_value is None:
+        return None
+    if base_value <= entry_price:
+        # base_value at/below current entry — don't set a TP that
+        # would trigger immediately. The portfolio manager already
+        # handles valuation-target-achieved as an EXIT condition.
+        return None
+    return base_value
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def evaluate_entry_conditions(
+    conn: psycopg.Connection[Any],
+    recommendation_id: int,
+) -> EntryEvaluation:
+    """Evaluate TA-based entry timing for a single recommendation.
+
+    For BUY/ADD: checks RSI, MACD, Bollinger, trend; computes SL/TP.
+    For EXIT: always returns pass (never defers protective exits).
+    For HOLD: returns skip (no timing evaluation needed).
+    """
+    rec = _load_recommendation_with_thesis(conn, recommendation_id)
+    if rec is None:
+        return EntryEvaluation(
+            verdict="skip",
+            stop_loss_rate=None,
+            take_profit_rate=None,
+            rationale=f"recommendation_id={recommendation_id} not found",
+        )
+
+    action = str(rec["action"])
+    instrument_id = int(rec["instrument_id"])
+
+    # EXIT recs always pass — never defer protective exits (settled decision).
+    if action == "EXIT":
+        return EntryEvaluation(
+            verdict="skip",
+            stop_loss_rate=None,
+            take_profit_rate=None,
+            rationale="EXIT recommendation: timing evaluation skipped (always pass through)",
+        )
+
+    # HOLD recs don't need timing evaluation.
+    if action == "HOLD":
+        return EntryEvaluation(
+            verdict="skip",
+            stop_loss_rate=None,
+            take_profit_rate=None,
+            rationale="HOLD recommendation: no timing evaluation needed",
+        )
+
+    # --- BUY/ADD: evaluate TA conditions ---
+    ta = _load_latest_ta(conn, instrument_id)
+
+    # Extract TA values, guarding every nullable field before float() cast.
+    # Prevention log: float(None) crash in nullable columns (#73).
+    close_raw = ta["close"] if ta is not None else None
+    rsi_raw = ta["rsi_14"] if ta is not None else None
+    macd_hist_raw = ta["macd_histogram"] if ta is not None else None
+    bb_upper_raw = ta["bb_upper"] if ta is not None else None
+    bb_lower_raw = ta["bb_lower"] if ta is not None else None
+    sma_200_raw = ta["sma_200"] if ta is not None else None
+    atr_raw = ta["atr_14"] if ta is not None else None
+
+    close_f = float(close_raw) if close_raw is not None else None
+    rsi_f = float(rsi_raw) if rsi_raw is not None else None
+    macd_f = float(macd_hist_raw) if macd_hist_raw is not None else None
+    bb_upper_f = float(bb_upper_raw) if bb_upper_raw is not None else None
+    bb_lower_f = float(bb_lower_raw) if bb_lower_raw is not None else None
+    sma_200_f = float(sma_200_raw) if sma_200_raw is not None else None
+    atr_dec = Decimal(str(atr_raw)) if atr_raw is not None else None
+
+    # Evaluate each condition
+    conditions: list[tuple[str, bool]] = []
+
+    if close_f is not None:
+        conditions.append(_eval_rsi(rsi_f))
+        conditions.append(_eval_macd(macd_f))
+        conditions.append(_eval_bollinger(close_f, bb_upper_f, bb_lower_f))
+        conditions.append(_eval_trend(close_f, sma_200_f))
+    else:
+        # No close price at all — can't evaluate anything. Pass through
+        # (don't block on missing data).
+        conditions.append(("no close price available (neutral)", True))
+
+    # Count unfavorable conditions
+    unfavorable = [desc for desc, ok in conditions if not ok]
+    all_details = {f"cond_{i}": desc for i, (desc, _ok) in enumerate(conditions)}
+
+    # Compute SL/TP regardless of verdict (auditable even on defers).
+    # entry_price = target_entry from recommendation (buy zone midpoint, USD).
+    entry_price_raw = rec["target_entry"]
+    entry_price = Decimal(str(entry_price_raw)) if entry_price_raw is not None else None
+
+    base_value_raw = rec["base_value"]
+    base_value = Decimal(str(base_value_raw)) if base_value_raw is not None else None
+
+    sl: Decimal | None = None
+    tp: Decimal | None = None
+
+    if entry_price is not None and entry_price > 0:
+        sl = _compute_stop_loss(entry_price, atr_dec)
+        tp = _compute_take_profit(entry_price, base_value)
+
+    # Verdict: defer if any condition is unfavorable.
+    # Entry timing is conservative — one red flag is enough to defer.
+    if unfavorable:
+        rationale_parts = [f"DEFER ({len(unfavorable)} unfavorable): "] + unfavorable
+        if sl is not None:
+            rationale_parts.append(f"SL={sl:.6f}")
+        if tp is not None:
+            rationale_parts.append(f"TP={tp:.6f}")
+        return EntryEvaluation(
+            verdict="defer",
+            stop_loss_rate=sl,
+            take_profit_rate=tp,
+            rationale="; ".join(rationale_parts),
+            condition_details=all_details,
+        )
+
+    # All conditions favorable — pass.
+    rationale_parts = ["PASS (all conditions favorable)"]
+    for desc, _ in conditions:
+        rationale_parts.append(desc)
+    if sl is not None:
+        rationale_parts.append(f"SL={sl:.6f}")
+    if tp is not None:
+        rationale_parts.append(f"TP={tp:.6f}")
+    return EntryEvaluation(
+        verdict="pass",
+        stop_loss_rate=sl,
+        take_profit_rate=tp,
+        rationale="; ".join(rationale_parts),
+        condition_details=all_details,
+    )

--- a/app/services/entry_timing.py
+++ b/app/services/entry_timing.py
@@ -49,7 +49,7 @@ RSI_OVERBOUGHT = 75.0
 # band range (upper - lower), consider overextended and defer.
 BB_OVEREXTENDED_PCT = 0.95
 
-TimingVerdict = Literal["pass", "defer", "skip"]
+TimingVerdict = Literal["pass", "defer", "skip", "error"]
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -32,7 +32,7 @@ import psycopg
 import psycopg.rows
 from psycopg.types.json import Jsonb
 
-from app.providers.broker import BrokerOrderResult, BrokerProvider
+from app.providers.broker import BrokerOrderResult, BrokerProvider, OrderParams
 from app.services.runtime_config import get_runtime_config
 
 logger = logging.getLogger(__name__)
@@ -83,7 +83,8 @@ def _load_approved_recommendation(
         cur.execute(
             """
             SELECT recommendation_id, instrument_id, action,
-                   target_entry, suggested_size_pct, model_version, status
+                   target_entry, suggested_size_pct, model_version, status,
+                   stop_loss_rate, take_profit_rate
             FROM trade_recommendations
             WHERE recommendation_id = %(rid)s
             """,
@@ -186,6 +187,7 @@ def _synthetic_fill(
     quote_price: Decimal | None,
     requested_amount: Decimal | None,
     requested_units: Decimal | None,
+    params: OrderParams | None = None,
 ) -> BrokerOrderResult:
     """
     Build a synthetic BrokerOrderResult for demo mode.
@@ -203,21 +205,30 @@ def _synthetic_fill(
     else:
         units = Decimal("0")
 
+    payload: dict[str, Any] = {
+        "demo": True,
+        "instrument_id": instrument_id,
+        "action": action,
+        "price": str(price),
+        "units": str(units),
+        "note": "synthetic fill — no real API call"
+        + ("" if quote_price is not None else "; no quote available, price=0"),
+    }
+    # Record intended SL/TP in raw_payload for audit completeness
+    # (demo mode has no broker to enforce these, but they should be visible).
+    if params is not None:
+        if params.stop_loss_rate is not None:
+            payload["stop_loss_rate"] = str(params.stop_loss_rate)
+        if params.take_profit_rate is not None:
+            payload["take_profit_rate"] = str(params.take_profit_rate)
+
     return BrokerOrderResult(
         broker_order_ref=f"DEMO-{instrument_id}-{action}",
         status="filled",
         filled_price=price,
         filled_units=units,
         fees=Decimal("0"),
-        raw_payload={
-            "demo": True,
-            "instrument_id": instrument_id,
-            "action": action,
-            "price": str(price),
-            "units": str(units),
-            "note": "synthetic fill — no real API call"
-            + ("" if quote_price is not None else "; no quote available, price=0"),
-        },
+        raw_payload=payload,
     )
 
 
@@ -523,6 +534,18 @@ def execute_order(
         if cash is not None and cash > 0:
             requested_amount = cash * Decimal(str(rec["suggested_size_pct"]))
 
+    # --- Step 2b: build OrderParams from recommendation SL/TP ---
+    # SL/TP are set by the entry timing service (Phase 2) for BUY/ADD recs.
+    # For EXIT recs, both are NULL — no SL/TP on a close-position order.
+    order_params: OrderParams | None = None
+    sl_raw = rec.get("stop_loss_rate")
+    tp_raw = rec.get("take_profit_rate")
+    if sl_raw is not None or tp_raw is not None:
+        order_params = OrderParams(
+            stop_loss_rate=Decimal(str(sl_raw)) if sl_raw is not None else None,
+            take_profit_rate=Decimal(str(tp_raw)) if tp_raw is not None else None,
+        )
+
     # --- Step 3: call broker or demo mode ---
     # Read live-mode flag from runtime_config (DB-backed source of truth).
     # Any RuntimeConfigCorrupt propagates: we will NOT default to demo mode
@@ -559,6 +582,7 @@ def execute_order(
                 action=action,
                 amount=requested_amount,
                 units=requested_units,
+                params=order_params,
             )
     else:
         quote_price = _load_latest_quote_price(conn, instrument_id)
@@ -568,6 +592,7 @@ def execute_order(
             quote_price=quote_price,
             requested_amount=requested_amount,
             requested_units=requested_units,
+            params=order_params,
         )
         logger.info(
             "demo mode: instrument_id=%d action=%s price=%s units=%s",

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -535,15 +535,22 @@ def execute_order(
             requested_amount = cash * Decimal(str(rec["suggested_size_pct"]))
 
     # --- Step 2b: build OrderParams from recommendation SL/TP ---
-    # SL/TP are set by the entry timing service (Phase 2) for BUY/ADD recs.
+    # SL/TP are set by the entry timing service (Phase 0) for BUY/ADD recs.
     # For EXIT recs, both are NULL — no SL/TP on a close-position order.
+    # Explicit key access: crash loudly if columns are missing from the query
+    # (would indicate a code bug, not a data issue).
     order_params: OrderParams | None = None
-    sl_raw = rec.get("stop_loss_rate")
-    tp_raw = rec.get("take_profit_rate")
+    sl_raw = rec["stop_loss_rate"]
+    tp_raw = rec["take_profit_rate"]
     if sl_raw is not None or tp_raw is not None:
         order_params = OrderParams(
             stop_loss_rate=Decimal(str(sl_raw)) if sl_raw is not None else None,
             take_profit_rate=Decimal(str(tp_raw)) if tp_raw is not None else None,
+        )
+    if action in ("BUY", "ADD") and order_params is None:
+        logger.warning(
+            "execute_order: BUY/ADD rec=%d has no SL/TP — timing may not have run",
+            recommendation_id,
         )
 
     # --- Step 3: call broker or demo mode ---

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1203,8 +1203,12 @@ def execute_approved_orders() -> None:
                                     update_params,
                                 )
 
-                        # Counter increment AFTER transaction commit (reached
-                        # only if both writes succeeded).
+                        # Commit the transaction (savepoint released above,
+                        # but the outer implicit txn needs an explicit commit).
+                        conn.commit()
+
+                        # Counter increment AFTER commit (reached only if
+                        # both writes succeeded).
                         if new_status is not None:
                             timing_deferred += 1
                         else:

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -31,6 +31,7 @@ import anthropic
 import psycopg
 import psycopg.rows
 import psycopg.sql
+from psycopg.types.json import Jsonb
 
 from app.config import settings
 from app.providers.implementations.companies_house import CompaniesHouseFilingsProvider
@@ -1063,76 +1064,104 @@ def execute_approved_orders() -> None:
         # --- Phase 0: entry timing — evaluate TA conditions for BUY/ADD ---
         # Inline timing check (not a separate scheduled job) guarantees
         # ordering: timing → guard → execute. Eliminates scheduler race.
-        with psycopg.connect(settings.database_url) as conn:
-            timing_candidates = conn.execute(
-                """
-                SELECT recommendation_id, action
-                FROM trade_recommendations
-                WHERE status = 'proposed'
-                ORDER BY recommendation_id
-                """,
-            ).fetchall()
-
         timing_passed = 0
         timing_deferred = 0
         timing_skipped = 0
+        timing_candidates: list[tuple[Any, ...]] = []
+
+        try:
+            with psycopg.connect(settings.database_url) as conn:
+                timing_candidates = conn.execute(
+                    """
+                    SELECT recommendation_id, action, instrument_id
+                    FROM trade_recommendations
+                    WHERE status = 'proposed'
+                    ORDER BY recommendation_id
+                    """,
+                ).fetchall()
+        except Exception:
+            # DB failure fetching timing candidates must not kill Phase 1/2.
+            logger.error(
+                "execute_approved_orders: timing candidate fetch failed",
+                exc_info=True,
+            )
+
         for row in timing_candidates:
-            rec_id, action = row[0], row[1]
-            # EXIT/HOLD recs skip timing evaluation entirely.
+            rec_id, action, instrument_id = row[0], row[1], row[2]
+            # EXIT/HOLD recs skip timing — never gate protective exits
+            # (settled decision). The inner evaluate_entry_conditions also
+            # handles this, but skipping here avoids opening a per-rec DB
+            # connection for actions that are guaranteed to be skipped.
             if action in ("EXIT", "HOLD"):
                 timing_skipped += 1
                 continue
             try:
                 with psycopg.connect(settings.database_url) as conn:
                     evaluation = evaluate_entry_conditions(conn, rec_id)
-                    if evaluation.verdict == "defer":
+
+                    pass_fail = "DEFER" if evaluation.verdict == "defer" else "PASS"
+                    new_status = "timing_deferred" if evaluation.verdict == "defer" else None
+
+                    if evaluation.verdict in ("pass", "defer"):
+                        # Write decision_audit row for the timing decision.
                         conn.execute(
                             """
-                            UPDATE trade_recommendations
-                            SET status = 'timing_deferred',
-                                stop_loss_rate = %(sl)s,
-                                take_profit_rate = %(tp)s,
-                                timing_verdict = %(verdict)s,
-                                timing_rationale = %(rationale)s
-                            WHERE recommendation_id = %(rid)s
+                            INSERT INTO decision_audit
+                                (decision_time, instrument_id, recommendation_id,
+                                 stage, pass_fail, explanation, evidence_json)
+                            VALUES
+                                (NOW(), %(iid)s, %(rid)s,
+                                 'entry_timing', %(pf)s, %(expl)s, %(ev)s)
                             """,
                             {
-                                "sl": evaluation.stop_loss_rate,
-                                "tp": evaluation.take_profit_rate,
-                                "verdict": evaluation.verdict,
-                                "rationale": evaluation.rationale,
+                                "iid": instrument_id,
                                 "rid": rec_id,
+                                "pf": pass_fail,
+                                "expl": evaluation.rationale,
+                                "ev": Jsonb(evaluation.condition_details),
                             },
                         )
+
+                        # Update recommendation with SL/TP and timing verdict.
+                        update_params: dict[str, Any] = {
+                            "sl": evaluation.stop_loss_rate,
+                            "tp": evaluation.take_profit_rate,
+                            "verdict": evaluation.verdict,
+                            "rationale": evaluation.rationale,
+                            "rid": rec_id,
+                        }
+                        if new_status is not None:
+                            conn.execute(
+                                """
+                                UPDATE trade_recommendations
+                                SET status = 'timing_deferred',
+                                    stop_loss_rate = %(sl)s,
+                                    take_profit_rate = %(tp)s,
+                                    timing_verdict = %(verdict)s,
+                                    timing_rationale = %(rationale)s
+                                WHERE recommendation_id = %(rid)s
+                                """,
+                                update_params,
+                            )
+                            timing_deferred += 1
+                        else:
+                            conn.execute(
+                                """
+                                UPDATE trade_recommendations
+                                SET stop_loss_rate = %(sl)s,
+                                    take_profit_rate = %(tp)s,
+                                    timing_verdict = %(verdict)s,
+                                    timing_rationale = %(rationale)s
+                                WHERE recommendation_id = %(rid)s
+                                """,
+                                update_params,
+                            )
+                            timing_passed += 1
                         conn.commit()
-                        timing_deferred += 1
+
                         logger.info(
-                            "execute_approved_orders: timing DEFER rec=%d rationale=%s",
-                            rec_id,
-                            evaluation.rationale,
-                        )
-                    elif evaluation.verdict == "pass":
-                        conn.execute(
-                            """
-                            UPDATE trade_recommendations
-                            SET stop_loss_rate = %(sl)s,
-                                take_profit_rate = %(tp)s,
-                                timing_verdict = %(verdict)s,
-                                timing_rationale = %(rationale)s
-                            WHERE recommendation_id = %(rid)s
-                            """,
-                            {
-                                "sl": evaluation.stop_loss_rate,
-                                "tp": evaluation.take_profit_rate,
-                                "verdict": evaluation.verdict,
-                                "rationale": evaluation.rationale,
-                                "rid": rec_id,
-                            },
-                        )
-                        conn.commit()
-                        timing_passed += 1
-                        logger.info(
-                            "execute_approved_orders: timing PASS rec=%d rationale=%s",
+                            "execute_approved_orders: timing %s rec=%d rationale=%s",
+                            pass_fail,
                             rec_id,
                             evaluation.rationale,
                         )
@@ -1141,14 +1170,46 @@ def execute_approved_orders() -> None:
                         # but handle gracefully.
                         timing_skipped += 1
             except Exception:
-                # Don't let a timing failure block the entire run.
-                # Leave the rec as 'proposed' — the guard can still evaluate it.
-                timing_skipped += 1
+                # Timing failure must not let an uninspected BUY/ADD rec
+                # reach the guard without SL/TP. Mark as timing_deferred
+                # so Phase 1 excludes it.
                 logger.error(
-                    "execute_approved_orders: timing evaluation failed for rec=%d",
+                    "execute_approved_orders: timing evaluation failed for rec=%d, deferring",
                     rec_id,
                     exc_info=True,
                 )
+                try:
+                    with psycopg.connect(settings.database_url) as err_conn:
+                        err_conn.execute(
+                            """
+                            INSERT INTO decision_audit
+                                (decision_time, instrument_id, recommendation_id,
+                                 stage, pass_fail, explanation)
+                            VALUES
+                                (NOW(), %(iid)s, %(rid)s,
+                                 'entry_timing', 'FAIL',
+                                 'timing evaluation raised an exception; deferred to prevent SL/TP-absent execution')
+                            """,
+                            {"iid": instrument_id, "rid": rec_id},
+                        )
+                        err_conn.execute(
+                            """
+                            UPDATE trade_recommendations
+                            SET status = 'timing_deferred',
+                                timing_verdict = 'defer',
+                                timing_rationale = 'timing evaluation failed — deferred as safety fallback'
+                            WHERE recommendation_id = %(rid)s
+                            """,
+                            {"rid": rec_id},
+                        )
+                        err_conn.commit()
+                except Exception:
+                    logger.error(
+                        "execute_approved_orders: failed to defer rec=%d after timing error",
+                        rec_id,
+                        exc_info=True,
+                    )
+                timing_deferred += 1
 
         logger.info(
             "execute_approved_orders: timing phase — candidates=%d passed=%d deferred=%d skipped=%d",

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -41,6 +41,7 @@ from app.providers.implementations.sec_fundamentals import SecFundamentalsProvid
 from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
 from app.services.coverage import review_coverage, seed_coverage
 from app.services.enrichment import refresh_enrichment
+from app.services.entry_timing import evaluate_entry_conditions
 from app.services.execution_guard import evaluate_recommendation
 from app.services.filings import FilingsRefreshSummary, refresh_filings, upsert_cik_mapping
 from app.services.fundamentals import refresh_fundamentals
@@ -1034,11 +1035,17 @@ def morning_candidate_review() -> None:
 def execute_approved_orders() -> None:
     """Guard and execute actionable trade recommendations.
 
-    Two phases, run sequentially:
+    Three phases, run sequentially:
 
-    Phase 1 — Guard: query all ``proposed`` recommendations. For each,
-    call ``evaluate_recommendation`` to run the execution guard.  PASS
-    transitions the recommendation to ``approved``; FAIL transitions to
+    Phase 0 — Entry timing: evaluate TA conditions for BUY/ADD recs.
+    If conditions are unfavorable, set status='timing_deferred' and
+    write SL/TP + rationale.  If favorable, write SL/TP and leave as
+    'proposed'.  EXIT/HOLD recs are untouched.  Inline (not a separate
+    scheduled job) to guarantee ordering and eliminate scheduler race.
+
+    Phase 1 — Guard: query all remaining ``proposed`` recommendations.
+    For each, call ``evaluate_recommendation`` to run the execution
+    guard.  PASS transitions to ``approved``; FAIL transitions to
     ``rejected``.
 
     Phase 2 — Execute: query all ``approved`` recommendations (includes
@@ -1053,7 +1060,106 @@ def execute_approved_orders() -> None:
     from app.providers.implementations.etoro_broker import EtoroBrokerProvider
 
     with _tracked_job(JOB_EXECUTE_APPROVED_ORDERS) as tracker:
+        # --- Phase 0: entry timing — evaluate TA conditions for BUY/ADD ---
+        # Inline timing check (not a separate scheduled job) guarantees
+        # ordering: timing → guard → execute. Eliminates scheduler race.
+        with psycopg.connect(settings.database_url) as conn:
+            timing_candidates = conn.execute(
+                """
+                SELECT recommendation_id, action
+                FROM trade_recommendations
+                WHERE status = 'proposed'
+                ORDER BY recommendation_id
+                """,
+            ).fetchall()
+
+        timing_passed = 0
+        timing_deferred = 0
+        timing_skipped = 0
+        for row in timing_candidates:
+            rec_id, action = row[0], row[1]
+            # EXIT/HOLD recs skip timing evaluation entirely.
+            if action in ("EXIT", "HOLD"):
+                timing_skipped += 1
+                continue
+            try:
+                with psycopg.connect(settings.database_url) as conn:
+                    evaluation = evaluate_entry_conditions(conn, rec_id)
+                    if evaluation.verdict == "defer":
+                        conn.execute(
+                            """
+                            UPDATE trade_recommendations
+                            SET status = 'timing_deferred',
+                                stop_loss_rate = %(sl)s,
+                                take_profit_rate = %(tp)s,
+                                timing_verdict = %(verdict)s,
+                                timing_rationale = %(rationale)s
+                            WHERE recommendation_id = %(rid)s
+                            """,
+                            {
+                                "sl": evaluation.stop_loss_rate,
+                                "tp": evaluation.take_profit_rate,
+                                "verdict": evaluation.verdict,
+                                "rationale": evaluation.rationale,
+                                "rid": rec_id,
+                            },
+                        )
+                        conn.commit()
+                        timing_deferred += 1
+                        logger.info(
+                            "execute_approved_orders: timing DEFER rec=%d rationale=%s",
+                            rec_id,
+                            evaluation.rationale,
+                        )
+                    elif evaluation.verdict == "pass":
+                        conn.execute(
+                            """
+                            UPDATE trade_recommendations
+                            SET stop_loss_rate = %(sl)s,
+                                take_profit_rate = %(tp)s,
+                                timing_verdict = %(verdict)s,
+                                timing_rationale = %(rationale)s
+                            WHERE recommendation_id = %(rid)s
+                            """,
+                            {
+                                "sl": evaluation.stop_loss_rate,
+                                "tp": evaluation.take_profit_rate,
+                                "verdict": evaluation.verdict,
+                                "rationale": evaluation.rationale,
+                                "rid": rec_id,
+                            },
+                        )
+                        conn.commit()
+                        timing_passed += 1
+                        logger.info(
+                            "execute_approved_orders: timing PASS rec=%d rationale=%s",
+                            rec_id,
+                            evaluation.rationale,
+                        )
+                    else:
+                        # verdict == "skip" — should not happen for BUY/ADD
+                        # but handle gracefully.
+                        timing_skipped += 1
+            except Exception:
+                # Don't let a timing failure block the entire run.
+                # Leave the rec as 'proposed' — the guard can still evaluate it.
+                timing_skipped += 1
+                logger.error(
+                    "execute_approved_orders: timing evaluation failed for rec=%d",
+                    rec_id,
+                    exc_info=True,
+                )
+
+        logger.info(
+            "execute_approved_orders: timing phase — candidates=%d passed=%d deferred=%d skipped=%d",
+            len(timing_candidates),
+            timing_passed,
+            timing_deferred,
+            timing_skipped,
+        )
+
         # --- Phase 1: guard proposed recommendations ---
+        # Re-query proposed recs (timing_deferred ones are now excluded).
         with psycopg.connect(settings.database_url) as conn:
             proposed = conn.execute(
                 """
@@ -1188,15 +1294,22 @@ def execute_approved_orders() -> None:
                         exc_info=True,
                     )
 
-            tracker.row_count = guarded + rejected + executed + pending + failed
+            tracker.row_count = (
+                timing_passed + timing_deferred + timing_skipped + guarded + rejected + executed + pending + failed
+            )
 
         finally:
             if broker_ctx is not None:
                 broker_ctx.__exit__(None, None, None)
 
     logger.info(
-        "execute_approved_orders complete: proposed=%d guarded=%d rejected=%d "
-        "approved=%d executed=%d pending=%d failed=%d",
+        "execute_approved_orders complete: "
+        "timing(passed=%d deferred=%d skipped=%d) "
+        "guard(proposed=%d approved=%d rejected=%d) "
+        "exec(approved=%d executed=%d pending=%d failed=%d)",
+        timing_passed,
+        timing_deferred,
+        timing_skipped,
         len(proposed),
         guarded,
         rejected,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1149,61 +1149,66 @@ def execute_approved_orders() -> None:
                     new_status = "timing_deferred" if evaluation.verdict == "defer" else None
 
                     if evaluation.verdict in ("pass", "defer"):
-                        # Write decision_audit row for the timing decision.
-                        conn.execute(
-                            """
-                            INSERT INTO decision_audit
-                                (decision_time, instrument_id, recommendation_id,
-                                 stage, pass_fail, explanation, evidence_json)
-                            VALUES
-                                (NOW(), %(iid)s, %(rid)s,
-                                 'entry_timing', %(pf)s, %(expl)s, %(ev)s)
-                            """,
-                            {
-                                "iid": instrument_id,
-                                "rid": rec_id,
-                                "pf": pass_fail,
-                                "expl": evaluation.rationale,
-                                "ev": Jsonb(evaluation.condition_details),
-                            },
-                        )
-
-                        # Update recommendation with SL/TP and timing verdict.
-                        update_params: dict[str, Any] = {
-                            "sl": evaluation.stop_loss_rate,
-                            "tp": evaluation.take_profit_rate,
-                            "verdict": evaluation.verdict,
-                            "rationale": evaluation.rationale,
-                            "rid": rec_id,
-                        }
-                        if new_status is not None:
+                        # Atomic: audit row + rec update in one transaction.
+                        # If either statement fails, both roll back and the
+                        # outer except catches it → _timing_error_defer.
+                        with conn.transaction():
                             conn.execute(
                                 """
-                                UPDATE trade_recommendations
-                                SET status = 'timing_deferred',
-                                    stop_loss_rate = %(sl)s,
-                                    take_profit_rate = %(tp)s,
-                                    timing_verdict = %(verdict)s,
-                                    timing_rationale = %(rationale)s
-                                WHERE recommendation_id = %(rid)s
+                                INSERT INTO decision_audit
+                                    (decision_time, instrument_id, recommendation_id,
+                                     stage, pass_fail, explanation, evidence_json)
+                                VALUES
+                                    (NOW(), %(iid)s, %(rid)s,
+                                     'entry_timing', %(pf)s, %(expl)s, %(ev)s)
                                 """,
-                                update_params,
+                                {
+                                    "iid": instrument_id,
+                                    "rid": rec_id,
+                                    "pf": pass_fail,
+                                    "expl": evaluation.rationale,
+                                    "ev": Jsonb(evaluation.condition_details),
+                                },
                             )
+                            update_params: dict[str, Any] = {
+                                "sl": evaluation.stop_loss_rate,
+                                "tp": evaluation.take_profit_rate,
+                                "verdict": evaluation.verdict,
+                                "rationale": evaluation.rationale,
+                                "rid": rec_id,
+                            }
+                            if new_status is not None:
+                                conn.execute(
+                                    """
+                                    UPDATE trade_recommendations
+                                    SET status = 'timing_deferred',
+                                        stop_loss_rate = %(sl)s,
+                                        take_profit_rate = %(tp)s,
+                                        timing_verdict = %(verdict)s,
+                                        timing_rationale = %(rationale)s
+                                    WHERE recommendation_id = %(rid)s
+                                    """,
+                                    update_params,
+                                )
+                            else:
+                                conn.execute(
+                                    """
+                                    UPDATE trade_recommendations
+                                    SET stop_loss_rate = %(sl)s,
+                                        take_profit_rate = %(tp)s,
+                                        timing_verdict = %(verdict)s,
+                                        timing_rationale = %(rationale)s
+                                    WHERE recommendation_id = %(rid)s
+                                    """,
+                                    update_params,
+                                )
+
+                        # Counter increment AFTER transaction commit (reached
+                        # only if both writes succeeded).
+                        if new_status is not None:
                             timing_deferred += 1
                         else:
-                            conn.execute(
-                                """
-                                UPDATE trade_recommendations
-                                SET stop_loss_rate = %(sl)s,
-                                    take_profit_rate = %(tp)s,
-                                    timing_verdict = %(verdict)s,
-                                    timing_rationale = %(rationale)s
-                                WHERE recommendation_id = %(rid)s
-                                """,
-                                update_params,
-                            )
                             timing_passed += 1
-                        conn.commit()
 
                         logger.info(
                             "execute_approved_orders: timing %s rec=%d rationale=%s",
@@ -1223,6 +1228,14 @@ def execute_approved_orders() -> None:
                         if skip_ok:
                             timing_deferred += 1
                         else:
+                            # Defer failed — rec stays proposed. Log at
+                            # CRITICAL: this is the last safety path before
+                            # the execution guard (which is the final gate).
+                            logger.critical(
+                                "execute_approved_orders: rec=%d could not be deferred after skip verdict; "
+                                "rec remains proposed — execution guard is the final safety net",
+                                rec_id,
+                            )
                             timing_skipped += 1
             except Exception:
                 # Timing failure must not let an uninspected BUY/ADD rec

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1033,6 +1033,52 @@ def morning_candidate_review() -> None:
     )
 
 
+def _timing_error_defer(
+    rec_id: int,
+    instrument_id: int,
+    explanation: str,
+) -> bool:
+    """Atomically defer a rec that could not be timing-evaluated.
+
+    Writes a decision_audit row + sets status='timing_deferred' with
+    timing_verdict='error' in one transaction.  Returns True if the
+    commit succeeded, False if the fallback itself failed (rec left as
+    'proposed' — logged by caller).
+    """
+    try:
+        with psycopg.connect(settings.database_url) as conn:
+            conn.execute(
+                """
+                INSERT INTO decision_audit
+                    (decision_time, instrument_id, recommendation_id,
+                     stage, pass_fail, explanation)
+                VALUES
+                    (NOW(), %(iid)s, %(rid)s,
+                     'entry_timing', 'FAIL', %(expl)s)
+                """,
+                {"iid": instrument_id, "rid": rec_id, "expl": explanation},
+            )
+            conn.execute(
+                """
+                UPDATE trade_recommendations
+                SET status = 'timing_deferred',
+                    timing_verdict = 'error',
+                    timing_rationale = %(rationale)s
+                WHERE recommendation_id = %(rid)s
+                """,
+                {"rid": rec_id, "rationale": explanation},
+            )
+            conn.commit()
+        return True
+    except Exception:
+        logger.error(
+            "execute_approved_orders: failed to defer rec=%d after timing error",
+            rec_id,
+            exc_info=True,
+        )
+        return False
+
+
 def execute_approved_orders() -> None:
     """Guard and execute actionable trade recommendations.
 
@@ -1166,9 +1212,15 @@ def execute_approved_orders() -> None:
                             evaluation.rationale,
                         )
                     else:
-                        # verdict == "skip" — should not happen for BUY/ADD
-                        # but handle gracefully.
-                        timing_skipped += 1
+                        # verdict == "skip" for a BUY/ADD rec — should not
+                        # happen, but must not let an uninspected rec reach
+                        # the guard. Defer it as a safety measure.
+                        _timing_error_defer(
+                            rec_id,
+                            instrument_id,
+                            "evaluate_entry_conditions returned 'skip' for BUY/ADD rec — deferred as safety fallback",
+                        )
+                        timing_deferred += 1
             except Exception:
                 # Timing failure must not let an uninspected BUY/ADD rec
                 # reach the guard without SL/TP. Mark as timing_deferred
@@ -1178,38 +1230,15 @@ def execute_approved_orders() -> None:
                     rec_id,
                     exc_info=True,
                 )
-                try:
-                    with psycopg.connect(settings.database_url) as err_conn:
-                        err_conn.execute(
-                            """
-                            INSERT INTO decision_audit
-                                (decision_time, instrument_id, recommendation_id,
-                                 stage, pass_fail, explanation)
-                            VALUES
-                                (NOW(), %(iid)s, %(rid)s,
-                                 'entry_timing', 'FAIL',
-                                 'timing evaluation raised an exception; deferred to prevent SL/TP-absent execution')
-                            """,
-                            {"iid": instrument_id, "rid": rec_id},
-                        )
-                        err_conn.execute(
-                            """
-                            UPDATE trade_recommendations
-                            SET status = 'timing_deferred',
-                                timing_verdict = 'defer',
-                                timing_rationale = 'timing evaluation failed — deferred as safety fallback'
-                            WHERE recommendation_id = %(rid)s
-                            """,
-                            {"rid": rec_id},
-                        )
-                        err_conn.commit()
-                except Exception:
-                    logger.error(
-                        "execute_approved_orders: failed to defer rec=%d after timing error",
-                        rec_id,
-                        exc_info=True,
-                    )
-                timing_deferred += 1
+                deferred_ok = _timing_error_defer(
+                    rec_id,
+                    instrument_id,
+                    "timing evaluation raised an exception; deferred to prevent SL/TP-absent execution",
+                )
+                if deferred_ok:
+                    timing_deferred += 1
+                else:
+                    timing_skipped += 1
 
         logger.info(
             "execute_approved_orders: timing phase — candidates=%d passed=%d deferred=%d skipped=%d",

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1215,12 +1215,15 @@ def execute_approved_orders() -> None:
                         # verdict == "skip" for a BUY/ADD rec — should not
                         # happen, but must not let an uninspected rec reach
                         # the guard. Defer it as a safety measure.
-                        _timing_error_defer(
+                        skip_ok = _timing_error_defer(
                             rec_id,
                             instrument_id,
                             "evaluate_entry_conditions returned 'skip' for BUY/ADD rec — deferred as safety fallback",
                         )
-                        timing_deferred += 1
+                        if skip_ok:
+                            timing_deferred += 1
+                        else:
+                            timing_skipped += 1
             except Exception:
                 # Timing failure must not let an uninspected BUY/ADD rec
                 # reach the guard without SL/TP. Mark as timing_deferred

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -643,3 +643,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `daily_candle_refresh` called `refresh_market_data` which upserted quotes, overwriting fresher hourly values from `fx_rates_refresh` with stale end-of-day data whenever the daily job ran after the hourly one.
 - Prevention: When adding a new scheduled job that writes to a table, grep for all other jobs that also write to that table. If ownership is split, add `skip_*` flags so only one job is responsible. `daily_candle_refresh` must pass `skip_quotes=True`. Check: `grep -rn "_upsert_quote\|INSERT INTO quotes" app/` — only `fx_rates_refresh` and `refresh_market_data(skip_quotes=False)` should write quotes.
 - Enforced in: `app/workers/scheduler.py` (`skip_quotes=True` in daily_candle_refresh); `app/services/market_data.py` (`skip_quotes` parameter)
+
+---
+
+### `conn.transaction()` savepoint release does not commit the outer transaction
+
+- First seen in: #231
+- Symptom: `with conn.transaction():` on a `psycopg.connect()`-opened connection (autocommit=False) creates a savepoint. The savepoint is released when the block exits, but the outer implicit transaction is not committed. If `conn.commit()` is omitted after the block, writes are silently rolled back when the connection closes.
+- Prevention: After any `with conn.transaction():` block on a non-autocommit connection, verify that `conn.commit()` is called before the connection closes. Alternatively, avoid `conn.transaction()` and use a plain `conn.commit()` when savepoint semantics are not needed. Grep `with conn\.transaction\(\):` and verify each is followed by `conn.commit()` within the same `with psycopg.connect(...)` scope.
+- Enforced in: this prevention log

--- a/sql/026_entry_timing_columns.sql
+++ b/sql/026_entry_timing_columns.sql
@@ -26,11 +26,10 @@ ALTER TABLE trade_recommendations
 -- Constrain timing_verdict to known values.  NULL is allowed for
 -- pre-migration rows.  'error' marks recs where timing evaluation
 -- raised an exception and the rec was deferred as a safety fallback.
-DO $$
-BEGIN
-    ALTER TABLE trade_recommendations
-        ADD CONSTRAINT chk_timing_verdict
-        CHECK (timing_verdict IN ('pass', 'defer', 'skip', 'error'));
-EXCEPTION
-    WHEN duplicate_object THEN NULL;
-END $$;
+-- DROP + ADD so the constraint always reflects the current allowed set.
+ALTER TABLE trade_recommendations
+    DROP CONSTRAINT IF EXISTS chk_timing_verdict;
+
+ALTER TABLE trade_recommendations
+    ADD CONSTRAINT chk_timing_verdict
+    CHECK (timing_verdict IN ('pass', 'defer', 'skip', 'error'));

--- a/sql/026_entry_timing_columns.sql
+++ b/sql/026_entry_timing_columns.sql
@@ -22,3 +22,14 @@ ALTER TABLE trade_recommendations
     ADD COLUMN IF NOT EXISTS take_profit_rate  NUMERIC(18,6),
     ADD COLUMN IF NOT EXISTS timing_verdict    TEXT,
     ADD COLUMN IF NOT EXISTS timing_rationale  TEXT;
+
+-- Constrain timing_verdict to known values.  NULL is allowed for
+-- pre-migration rows.
+DO $$
+BEGIN
+    ALTER TABLE trade_recommendations
+        ADD CONSTRAINT chk_timing_verdict
+        CHECK (timing_verdict IN ('pass', 'defer', 'skip'));
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;

--- a/sql/026_entry_timing_columns.sql
+++ b/sql/026_entry_timing_columns.sql
@@ -1,0 +1,24 @@
+-- Migration 026: add entry timing columns to trade_recommendations
+--
+-- stop_loss_rate: ATR-based stop-loss price computed by the entry timing
+--   service. Passed through to the broker as OrderParams.stop_loss_rate.
+--   NULL for EXIT recs and for recs created before this migration.
+--
+-- take_profit_rate: thesis base_value (target price) at recommendation time.
+--   Passed through to the broker as OrderParams.take_profit_rate.
+--   NULL for EXIT recs and for recs created before this migration.
+--
+-- timing_verdict: outcome of the entry timing evaluation.
+--   'pass' = conditions favorable, proceed to guard.
+--   'defer' = conditions unfavorable, skip this cycle.
+--   'skip' = not evaluated (EXIT recs, or pre-migration recs).
+--   NULL for recs created before this migration.
+--
+-- timing_rationale: human-readable explanation of the timing verdict.
+--   Records which conditions passed/failed and the computed SL/TP values.
+
+ALTER TABLE trade_recommendations
+    ADD COLUMN IF NOT EXISTS stop_loss_rate    NUMERIC(18,6),
+    ADD COLUMN IF NOT EXISTS take_profit_rate  NUMERIC(18,6),
+    ADD COLUMN IF NOT EXISTS timing_verdict    TEXT,
+    ADD COLUMN IF NOT EXISTS timing_rationale  TEXT;

--- a/sql/026_entry_timing_columns.sql
+++ b/sql/026_entry_timing_columns.sql
@@ -26,10 +26,14 @@ ALTER TABLE trade_recommendations
 -- Constrain timing_verdict to known values.  NULL is allowed for
 -- pre-migration rows.  'error' marks recs where timing evaluation
 -- raised an exception and the rec was deferred as a safety fallback.
--- DROP + ADD so the constraint always reflects the current allowed set.
-ALTER TABLE trade_recommendations
-    DROP CONSTRAINT IF EXISTS chk_timing_verdict;
-
-ALTER TABLE trade_recommendations
-    ADD CONSTRAINT chk_timing_verdict
-    CHECK (timing_verdict IN ('pass', 'defer', 'skip', 'error'));
+-- Wrapped in DO $$ to be idempotent: drops any prior version of the
+-- constraint first, then adds the current one.  Both DDL statements
+-- are transactional in PostgreSQL, so partial failure is safe.
+DO $$
+BEGIN
+    ALTER TABLE trade_recommendations
+        DROP CONSTRAINT IF EXISTS chk_timing_verdict;
+    ALTER TABLE trade_recommendations
+        ADD CONSTRAINT chk_timing_verdict
+        CHECK (timing_verdict IN ('pass', 'defer', 'skip', 'error'));
+END $$;

--- a/sql/026_entry_timing_columns.sql
+++ b/sql/026_entry_timing_columns.sql
@@ -24,12 +24,13 @@ ALTER TABLE trade_recommendations
     ADD COLUMN IF NOT EXISTS timing_rationale  TEXT;
 
 -- Constrain timing_verdict to known values.  NULL is allowed for
--- pre-migration rows.
+-- pre-migration rows.  'error' marks recs where timing evaluation
+-- raised an exception and the rec was deferred as a safety fallback.
 DO $$
 BEGIN
     ALTER TABLE trade_recommendations
         ADD CONSTRAINT chk_timing_verdict
-        CHECK (timing_verdict IN ('pass', 'defer', 'skip'));
+        CHECK (timing_verdict IN ('pass', 'defer', 'skip', 'error'));
 EXCEPTION
     WHEN duplicate_object THEN NULL;
 END $$;

--- a/tests/test_entry_timing.py
+++ b/tests/test_entry_timing.py
@@ -1,0 +1,355 @@
+"""Tests for app.services.entry_timing — TA-informed entry condition evaluation.
+
+Structure:
+  - TestConditionEvaluators — individual TA condition checks
+  - TestStopLossComputation — ATR-based SL with floor/ceiling clamps
+  - TestTakeProfitComputation — base_value TP guard
+  - TestEvaluateEntryConditions — full evaluate_entry_conditions with mocked DB
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+from app.services.entry_timing import (
+    RSI_OVERBOUGHT,
+    _compute_stop_loss,
+    _compute_take_profit,
+    _eval_bollinger,
+    _eval_macd,
+    _eval_rsi,
+    _eval_trend,
+    evaluate_entry_conditions,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cursor(rows: list[dict[str, Any]]) -> MagicMock:
+    cur = MagicMock()
+    cur.fetchall.return_value = rows
+    cur.fetchone.return_value = rows[0] if rows else None
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    return cur
+
+
+def _make_conn(cursor_sequence: list[MagicMock]) -> MagicMock:
+    conn = MagicMock()
+    conn.cursor.side_effect = cursor_sequence
+    conn.execute.return_value = MagicMock()
+    return conn
+
+
+def _rec_row(
+    recommendation_id: int = 1,
+    instrument_id: int = 42,
+    action: str = "BUY",
+    target_entry: float | None = 150.0,
+    status: str = "proposed",
+    base_value: float | None = 200.0,
+    buy_zone_low: float | None = 140.0,
+    buy_zone_high: float | None = 160.0,
+    confidence_score: float | None = 0.8,
+    suggested_size_pct: float | None = 0.05,
+) -> dict[str, Any]:
+    return {
+        "recommendation_id": recommendation_id,
+        "instrument_id": instrument_id,
+        "action": action,
+        "target_entry": target_entry,
+        "suggested_size_pct": suggested_size_pct,
+        "status": status,
+        "base_value": base_value,
+        "buy_zone_low": buy_zone_low,
+        "buy_zone_high": buy_zone_high,
+        "confidence_score": confidence_score,
+    }
+
+
+def _ta_row(
+    close: float = 155.0,
+    sma_200: float | None = 145.0,
+    rsi_14: float | None = 55.0,
+    macd_histogram: float | None = 0.5,
+    bb_upper: float | None = 165.0,
+    bb_lower: float | None = 135.0,
+    atr_14: float | None = 3.5,
+) -> dict[str, Any]:
+    return {
+        "close": close,
+        "sma_200": sma_200,
+        "rsi_14": rsi_14,
+        "macd_histogram": macd_histogram,
+        "bb_upper": bb_upper,
+        "bb_lower": bb_lower,
+        "atr_14": atr_14,
+    }
+
+
+# ---------------------------------------------------------------------------
+# TestConditionEvaluators
+# ---------------------------------------------------------------------------
+
+
+class TestConditionEvaluators:
+    """Individual TA condition checks."""
+
+    def test_rsi_null_is_neutral(self) -> None:
+        desc, ok = _eval_rsi(None)
+        assert ok is True
+        assert "neutral" in desc
+
+    def test_rsi_below_threshold_is_ok(self) -> None:
+        desc, ok = _eval_rsi(50.0)
+        assert ok is True
+        assert "ok" in desc
+
+    def test_rsi_at_threshold_is_ok(self) -> None:
+        desc, ok = _eval_rsi(RSI_OVERBOUGHT)
+        assert ok is True
+
+    def test_rsi_above_threshold_defers(self) -> None:
+        desc, ok = _eval_rsi(80.0)
+        assert ok is False
+        assert "overbought" in desc
+
+    def test_macd_null_is_neutral(self) -> None:
+        desc, ok = _eval_macd(None)
+        assert ok is True
+        assert "neutral" in desc
+
+    def test_macd_positive_is_favorable(self) -> None:
+        desc, ok = _eval_macd(0.5)
+        assert ok is True
+        assert "favorable" in desc
+
+    def test_macd_zero_is_favorable(self) -> None:
+        desc, ok = _eval_macd(0.0)
+        assert ok is True
+
+    def test_macd_negative_defers(self) -> None:
+        desc, ok = _eval_macd(-0.5)
+        assert ok is False
+        assert "weak momentum" in desc
+
+    def test_bollinger_null_is_neutral(self) -> None:
+        desc, ok = _eval_bollinger(155.0, None, None)
+        assert ok is True
+        assert "neutral" in desc
+
+    def test_bollinger_within_band_is_ok(self) -> None:
+        desc, ok = _eval_bollinger(150.0, bb_upper=165.0, bb_lower=135.0)
+        assert ok is True
+        assert "ok" in desc
+
+    def test_bollinger_near_upper_defers(self) -> None:
+        # position = (164 - 135) / (165 - 135) = 0.966 > 0.95
+        desc, ok = _eval_bollinger(164.0, bb_upper=165.0, bb_lower=135.0)
+        assert ok is False
+        assert "overextended" in desc
+
+    def test_bollinger_zero_width_is_neutral(self) -> None:
+        desc, ok = _eval_bollinger(150.0, bb_upper=150.0, bb_lower=150.0)
+        assert ok is True
+        assert "neutral" in desc
+
+    def test_trend_null_sma_is_neutral(self) -> None:
+        desc, ok = _eval_trend(155.0, None)
+        assert ok is True
+        assert "neutral" in desc
+
+    def test_trend_above_sma_favorable(self) -> None:
+        desc, ok = _eval_trend(155.0, 145.0)
+        assert ok is True
+        assert "favorable" in desc
+
+    def test_trend_below_sma_still_passes(self) -> None:
+        # Below SMA-200 is informational, not a hard defer.
+        desc, ok = _eval_trend(140.0, 145.0)
+        assert ok is True
+        assert "below trend" in desc
+
+
+# ---------------------------------------------------------------------------
+# TestStopLossComputation
+# ---------------------------------------------------------------------------
+
+
+class TestStopLossComputation:
+    """ATR-based SL with floor and minimum distance clamps."""
+
+    def test_normal_atr_stop_loss(self) -> None:
+        # entry=150, ATR=3.5 => SL = 150 - 2*3.5 = 143
+        # Floor = 150 * 0.95 = 142.5 => max(143, 142.5) = 143
+        # MinDist = 150 * 0.98 = 147 => min(143, 147) = 143
+        sl = _compute_stop_loss(Decimal("150"), Decimal("3.5"))
+        assert sl == Decimal("143.0")
+
+    def test_low_price_high_atr_uses_floor(self) -> None:
+        # entry=3, ATR=2 => SL = 3 - 2*2 = -1
+        # Floor = 3 * 0.95 = 2.85 => max(-1, 2.85) = 2.85
+        # MinDist = 3 * 0.98 = 2.94 => min(2.85, 2.94) = 2.85
+        sl = _compute_stop_loss(Decimal("3"), Decimal("2"))
+        assert sl == Decimal("2.85")
+
+    def test_low_volatility_uses_min_distance(self) -> None:
+        # entry=150, ATR=0.5 => SL = 150 - 2*0.5 = 149
+        # Floor = 150 * 0.95 = 142.5 => max(149, 142.5) = 149
+        # MinDist = 150 * 0.98 = 147 => min(149, 147) = 147
+        sl = _compute_stop_loss(Decimal("150"), Decimal("0.5"))
+        assert sl == Decimal("147.0")
+
+    def test_null_atr_uses_floor(self) -> None:
+        sl = _compute_stop_loss(Decimal("100"), None)
+        assert sl == Decimal("95.0")  # 100 * 0.95
+
+    def test_zero_atr_uses_floor(self) -> None:
+        sl = _compute_stop_loss(Decimal("100"), Decimal("0"))
+        assert sl == Decimal("95.0")
+
+    def test_sl_always_positive(self) -> None:
+        # Even with extreme ATR, floor prevents negative SL.
+        sl = _compute_stop_loss(Decimal("1"), Decimal("100"))
+        assert sl > 0
+
+
+# ---------------------------------------------------------------------------
+# TestTakeProfitComputation
+# ---------------------------------------------------------------------------
+
+
+class TestTakeProfitComputation:
+    """Take-profit from thesis base_value."""
+
+    def test_base_value_above_entry(self) -> None:
+        tp = _compute_take_profit(Decimal("150"), Decimal("200"))
+        assert tp == Decimal("200")
+
+    def test_base_value_at_entry_returns_none(self) -> None:
+        tp = _compute_take_profit(Decimal("150"), Decimal("150"))
+        assert tp is None
+
+    def test_base_value_below_entry_returns_none(self) -> None:
+        tp = _compute_take_profit(Decimal("150"), Decimal("100"))
+        assert tp is None
+
+    def test_null_base_value_returns_none(self) -> None:
+        tp = _compute_take_profit(Decimal("150"), None)
+        assert tp is None
+
+
+# ---------------------------------------------------------------------------
+# TestEvaluateEntryConditions
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateEntryConditions:
+    """Full evaluate_entry_conditions with mocked DB."""
+
+    def test_exit_rec_always_skips(self) -> None:
+        rec = _rec_row(action="EXIT")
+        conn = _make_conn([_make_cursor([rec])])
+        result = evaluate_entry_conditions(conn, 1)
+        assert result.verdict == "skip"
+        assert result.stop_loss_rate is None
+
+    def test_hold_rec_always_skips(self) -> None:
+        rec = _rec_row(action="HOLD")
+        conn = _make_conn([_make_cursor([rec])])
+        result = evaluate_entry_conditions(conn, 1)
+        assert result.verdict == "skip"
+
+    def test_missing_rec_returns_skip(self) -> None:
+        conn = _make_conn([_make_cursor([])])
+        result = evaluate_entry_conditions(conn, 999)
+        assert result.verdict == "skip"
+        assert "not found" in result.rationale
+
+    def test_all_favorable_passes(self) -> None:
+        rec = _rec_row()
+        ta = _ta_row()
+        conn = _make_conn([_make_cursor([rec]), _make_cursor([ta])])
+        result = evaluate_entry_conditions(conn, 1)
+        assert result.verdict == "pass"
+        assert result.stop_loss_rate is not None
+        assert result.take_profit_rate == Decimal("200")
+
+    def test_overbought_rsi_defers(self) -> None:
+        rec = _rec_row()
+        ta = _ta_row(rsi_14=80.0)
+        conn = _make_conn([_make_cursor([rec]), _make_cursor([ta])])
+        result = evaluate_entry_conditions(conn, 1)
+        assert result.verdict == "defer"
+        assert "overbought" in result.rationale
+
+    def test_negative_macd_defers(self) -> None:
+        rec = _rec_row()
+        ta = _ta_row(macd_histogram=-1.0)
+        conn = _make_conn([_make_cursor([rec]), _make_cursor([ta])])
+        result = evaluate_entry_conditions(conn, 1)
+        assert result.verdict == "defer"
+        assert "weak momentum" in result.rationale
+
+    def test_overextended_bollinger_defers(self) -> None:
+        rec = _rec_row()
+        ta = _ta_row(close=164.5, bb_upper=165.0, bb_lower=135.0)
+        conn = _make_conn([_make_cursor([rec]), _make_cursor([ta])])
+        result = evaluate_entry_conditions(conn, 1)
+        assert result.verdict == "defer"
+        assert "overextended" in result.rationale
+
+    def test_all_null_ta_passes(self) -> None:
+        """NULL indicators are neutral — should pass, not block."""
+        rec = _rec_row()
+        ta = _ta_row(
+            sma_200=None,
+            rsi_14=None,
+            macd_histogram=None,
+            bb_upper=None,
+            bb_lower=None,
+            atr_14=None,
+        )
+        conn = _make_conn([_make_cursor([rec]), _make_cursor([ta])])
+        result = evaluate_entry_conditions(conn, 1)
+        assert result.verdict == "pass"
+
+    def test_no_ta_row_passes(self) -> None:
+        """No price_daily TA row at all — pass through (don't block on missing data)."""
+        rec = _rec_row()
+        conn = _make_conn([_make_cursor([rec]), _make_cursor([])])
+        result = evaluate_entry_conditions(conn, 1)
+        assert result.verdict == "pass"
+
+    def test_null_target_entry_no_sl_tp(self) -> None:
+        """If target_entry is NULL, SL/TP should be None."""
+        rec = _rec_row(target_entry=None)
+        ta = _ta_row()
+        conn = _make_conn([_make_cursor([rec]), _make_cursor([ta])])
+        result = evaluate_entry_conditions(conn, 1)
+        assert result.stop_loss_rate is None
+        assert result.take_profit_rate is None
+
+    def test_base_value_below_entry_no_tp(self) -> None:
+        """If base_value <= entry, TP should be None (guard against immediate trigger)."""
+        rec = _rec_row(target_entry=200.0, base_value=180.0)
+        ta = _ta_row()
+        conn = _make_conn([_make_cursor([rec]), _make_cursor([ta])])
+        result = evaluate_entry_conditions(conn, 1)
+        assert result.take_profit_rate is None
+        # SL should still be computed.
+        assert result.stop_loss_rate is not None
+
+    def test_sl_tp_computed_even_on_defer(self) -> None:
+        """SL/TP should be computed and included even when verdict is defer (audit trail)."""
+        rec = _rec_row()
+        ta = _ta_row(rsi_14=80.0)  # trigger defer
+        conn = _make_conn([_make_cursor([rec]), _make_cursor([ta])])
+        result = evaluate_entry_conditions(conn, 1)
+        assert result.verdict == "defer"
+        assert result.stop_loss_rate is not None
+        assert "SL=" in result.rationale

--- a/tests/test_execute_approved_orders.py
+++ b/tests/test_execute_approved_orders.py
@@ -1,7 +1,8 @@
 """Tests for the execute_approved_orders scheduled job.
 
-The job orchestrates two existing services — execution_guard and order_client —
-so tests mock both services and verify the orchestration logic:
+The job orchestrates three phases — entry_timing, execution_guard, order_client —
+so tests mock all three services and verify the orchestration logic:
+- Phase 0: entry timing evaluates TA conditions for BUY/ADD recs
 - Phase 1: proposed recommendations are guarded (PASS → approved, FAIL → rejected)
 - Phase 2: approved recommendations are executed
 - Isolation: one failure does not block others
@@ -9,6 +10,14 @@ so tests mock both services and verify the orchestration logic:
 Mock approach: patch ``_tracked_job`` with a no-op context manager so
 the job tracking infrastructure (which also uses psycopg.connect) does
 not interfere with the connection mocking for the business logic.
+
+Connection order (Phase 0 → Phase 1 → Phase 2):
+  0. timing_conn    — SELECT proposed recs for timing evaluation
+  0a. per-rec conn  — one per BUY/ADD candidate (evaluate + UPDATE)
+  1. proposed_conn  — SELECT remaining proposed recs for guard
+  1a. per-rec conn  — one per proposed rec (guard + UPDATE)
+  2. approved_conn  — SELECT approved recs for execution
+  2a. per-rec conn  — one per approved rec (execute_order)
 """
 
 from __future__ import annotations
@@ -106,12 +115,14 @@ class TestGuardPhase:
         _creds: MagicMock,
     ) -> None:
         """Two proposed recs: one PASS, one FAIL."""
+        timing_conn = _mock_conn_with_rows([])  # Phase 0: no timing candidates
         proposed_conn = _mock_conn_with_rows([(1,), (2,)])
         guard_conn1 = _mock_conn_with_rows([])
         guard_conn2 = _mock_conn_with_rows([])
         approved_conn = _mock_conn_with_rows([])
 
         mock_connect.side_effect = [
+            timing_conn,
             proposed_conn,
             guard_conn1,
             guard_conn2,
@@ -137,12 +148,14 @@ class TestGuardPhase:
         _creds: MagicMock,
     ) -> None:
         """If guard raises for rec 1, rec 2 is still guarded."""
+        timing_conn = _mock_conn_with_rows([])  # Phase 0: no timing candidates
         proposed_conn = _mock_conn_with_rows([(1,), (2,)])
         guard_conn1 = _mock_conn_with_rows([])
         guard_conn2 = _mock_conn_with_rows([])
         approved_conn = _mock_conn_with_rows([])
 
         mock_connect.side_effect = [
+            timing_conn,
             proposed_conn,
             guard_conn1,
             guard_conn2,
@@ -176,12 +189,14 @@ class TestExecutePhase:
         _creds: MagicMock,
     ) -> None:
         """One proposed rec passes guard, then is executed."""
+        timing_conn = _mock_conn_with_rows([])  # Phase 0: no timing candidates
         proposed_conn = _mock_conn_with_rows([(1,)])
         guard_conn = _mock_conn_with_rows([])
         approved_conn = _mock_conn_with_rows([(1, 100)])
         exec_conn = _mock_conn_with_rows([])
 
         mock_connect.side_effect = [
+            timing_conn,
             proposed_conn,
             guard_conn,
             approved_conn,
@@ -210,12 +225,14 @@ class TestExecutePhase:
         _creds: MagicMock,
     ) -> None:
         """If execution raises for rec 1, rec 2 is still executed."""
+        timing_conn = _mock_conn_with_rows([])  # Phase 0: no timing candidates
         proposed_conn = _mock_conn_with_rows([])
         approved_conn = _mock_conn_with_rows([(1, 100), (2, 200)])
         exec_conn1 = _mock_conn_with_rows([])
         exec_conn2 = _mock_conn_with_rows([])
 
         mock_connect.side_effect = [
+            timing_conn,
             proposed_conn,
             approved_conn,
             exec_conn1,
@@ -243,11 +260,12 @@ class TestExecutePhase:
         _creds: MagicMock,
     ) -> None:
         """A non-filled outcome is logged as failed."""
+        timing_conn = _mock_conn_with_rows([])  # Phase 0: no timing candidates
         proposed_conn = _mock_conn_with_rows([])
         approved_conn = _mock_conn_with_rows([(1, 100)])
         exec_conn = _mock_conn_with_rows([])
 
-        mock_connect.side_effect = [proposed_conn, approved_conn, exec_conn]
+        mock_connect.side_effect = [timing_conn, proposed_conn, approved_conn, exec_conn]
         mock_exec.return_value = _exec_failed(1, 500)
 
         from app.workers.scheduler import execute_approved_orders
@@ -273,10 +291,11 @@ class TestNoWork:
         _creds: MagicMock,
     ) -> None:
         """No proposed or approved recs → guard and execute never called."""
+        timing_conn = _mock_conn_with_rows([])  # Phase 0: no timing candidates
         proposed_conn = _mock_conn_with_rows([])
         approved_conn = _mock_conn_with_rows([])
 
-        mock_connect.side_effect = [proposed_conn, approved_conn]
+        mock_connect.side_effect = [timing_conn, proposed_conn, approved_conn]
 
         from app.workers.scheduler import execute_approved_orders
 

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -121,6 +121,8 @@ def _rec_cursor(
     suggested_size_pct: float | None = 0.05,
     model_version: str | None = "v1-balanced",
     status: str = "approved",
+    stop_loss_rate: float | None = None,
+    take_profit_rate: float | None = None,
 ) -> MagicMock:
     return _make_cursor(
         [
@@ -132,6 +134,8 @@ def _rec_cursor(
                 "suggested_size_pct": suggested_size_pct,
                 "model_version": model_version,
                 "status": status,
+                "stop_loss_rate": stop_loss_rate,
+                "take_profit_rate": take_profit_rate,
             }
         ]
     )


### PR DESCRIPTION
Closes #202

## What changed

Adds Phase 0 (entry timing) to the `execute_approved_orders` pipeline, sitting between recommendation generation and the execution guard. For BUY/ADD recommendations, the entry timing service evaluates TA conditions and computes stop-loss / take-profit levels before the guard runs.

**New files:**
- `app/services/entry_timing.py` — pure service: evaluates RSI, MACD, Bollinger band position, and SMA-200 trend; computes ATR-based stop-loss (with floor + minimum-distance clamps) and thesis-based take-profit
- `sql/026_entry_timing_columns.sql` — adds `stop_loss_rate`, `take_profit_rate`, `timing_verdict`, `timing_rationale` to `trade_recommendations`
- `tests/test_entry_timing.py` — 37 tests covering condition evaluators, SL/TP math, and full integration

**Modified files:**
- `app/workers/scheduler.py` — adds Phase 0 (timing → guard → execute) inline in `execute_approved_orders`; unfavorable conditions set `status='timing_deferred'`, favorable write SL/TP and leave as `proposed`
- `app/services/order_client.py` — reads SL/TP from recommendation, builds `OrderParams`, passes through to broker (live) and demo mode (recorded in `raw_payload` for audit)
- `tests/test_execute_approved_orders.py` — all 8 orchestration tests updated for the new Phase 0 connection
- `tests/test_order_client.py` — test helpers updated with `stop_loss_rate` / `take_profit_rate` fields

## Why

Issue #202 requires that every position opened has a defined exit strategy at time of entry. The system must use TA signals to time entries (don't buy at resistance, wait for a better price) and set SL/TP on every order. This is the first deliverable: the timing evaluation and SL/TP computation. Ongoing position management (trailing stops, thesis-refresh-driven adjustments) is follow-up work.

Phase 0 is inline in the scheduler (not a separate job) to guarantee ordering and eliminate race conditions between timing evaluation and guard evaluation.

## Schema / migration impact

- Migration 026: `ALTER TABLE trade_recommendations ADD COLUMN IF NOT EXISTS` for 4 new nullable columns
- All columns are nullable — backwards-compatible with existing rows (pre-migration recs get NULL)
- No data backfill needed

## Invariants checked

- **EXIT recs never blocked:** entry timing returns `skip` for EXIT/HOLD (settled decision preserved)
- **NULL TA indicators are neutral:** missing data never blocks — only unfavorable signals defer
- **SL floor + minimum distance:** ATR-based SL clamped to prevent negative/absurdly-wide values (floor = 5% below entry) and too-tight values (min distance = 2% below entry)
- **TP guard:** base_value at or below entry produces no TP (prevents immediate trigger)
- **Audit completeness:** SL/TP computed and persisted even on defer verdicts
- **No external I/O in transactions:** entry_timing is pure reads; scheduler commits after each UPDATE
- **Parameterized SQL throughout:** no f-string interpolation

## Failure paths considered

- Recommendation not found → skip verdict
- No TA data at all (empty price_daily) → pass through (don't block on missing data)
- All TA indicators NULL → neutral, pass through
- NULL target_entry → no SL/TP computed (both None)
- base_value at/below entry → TP set to None (guard against immediate trigger)
- Extreme ATR (negative SL) → floor clamp prevents
- Very low ATR (SL too close) → minimum distance clamp widens
- Timing evaluation exception → caught per-candidate, rec stays proposed for guard

## Tests added

**Condition evaluators (17 tests):** RSI null/below/at/above threshold; MACD null/positive/zero/negative; Bollinger null/within-band/near-upper/zero-width; trend null/above/below SMA-200

**SL computation (6 tests):** normal ATR, low-price high-ATR (floor), low-volatility (min distance), null ATR, zero ATR, always-positive guarantee

**TP computation (4 tests):** above entry, at entry, below entry, null base_value

**Full integration (10 tests):** EXIT skips, HOLD skips, missing rec skips, all-favorable passes, overbought defers, negative MACD defers, overextended Bollinger defers, all-null TA passes, no TA row passes, null target_entry, base_value below entry, SL/TP computed on defer

**Scheduler orchestration (8 tests):** all updated with Phase 0 timing connection; guard phase, execute phase, isolation, edge cases all still covered

## Conscious tradeoffs

- **Conservative defer:** one unfavorable TA condition is enough to defer. This favors patience over execution speed, matching the long-horizon posture.
- **No buy-zone check in timing:** issue #202 mentions buy_zone_low/high but the timing service focuses on TA signals. Buy-zone gating is a portfolio manager concern and can be added as a follow-up.
- **No trailing stops yet:** this PR sets SL/TP at entry. Ongoing adjustment (trailing stops, thesis-refresh-driven SL/TP revision) is follow-up work per the issue scope.
- **Per-candidate connection in Phase 0:** each timing evaluation opens its own DB connection rather than sharing one. Consistent with Phase 1/2 patterns and avoids mid-transaction complexity.

## Tech debt opened

None — follow-up work (trailing stops, ongoing SL/TP management, buy-zone integration) is tracked in the parent issue #198 workstream.