### PR TITLE
feat(#203): budget and capital management service

### DIFF
--- a/app/api/budget.py
+++ b/app/api/budget.py
@@ -1,0 +1,255 @@
+"""Budget API endpoints (issue #203).
+
+Endpoints:
+  - GET   /budget              — compute and return full budget state snapshot
+  - GET   /budget/events       — paginated list of capital events
+  - POST  /budget/events       — record an operator capital injection or withdrawal
+  - GET   /budget/config       — current budget config (cash_buffer_pct, cgt_scenario)
+  - PATCH /budget/config       — partial update of budget config
+
+All endpoints require operator auth.
+
+Fail-closed posture:
+  - Missing ``budget_config`` singleton row → 503 (configuration corrupt).
+    Never auto-recreated and never substituted with default values.
+
+Commit ownership:
+  - POST /budget/events and PATCH /budget/config must commit explicitly.
+    The service functions (record_capital_event, update_budget_config) do
+    not commit — the API handler owns the commit boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field, model_validator
+
+from app.api.auth import require_session_or_service_token
+from app.db import get_conn
+from app.services.budget import (
+    BudgetConfigCorrupt,
+    compute_budget_state,
+    get_budget_config,
+    list_capital_events,
+    record_capital_event,
+    update_budget_config,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/budget",
+    tags=["budget"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class BudgetStateResponse(BaseModel):
+    cash_balance: float | None
+    deployed_capital: float
+    mirror_equity: float
+    working_budget: float | None
+    estimated_tax_gbp: float
+    estimated_tax_usd: float
+    gbp_usd_rate: float | None
+    cash_buffer_reserve: float
+    available_for_deployment: float | None
+    cash_buffer_pct: float
+    cgt_scenario: str
+    tax_year: str
+
+
+class CapitalEventResponse(BaseModel):
+    event_id: int
+    event_time: datetime
+    event_type: str
+    amount: float
+    currency: str
+    source: str
+    note: str | None
+    created_by: str | None
+
+
+class BudgetConfigResponse(BaseModel):
+    cash_buffer_pct: float
+    cgt_scenario: str
+    updated_at: datetime
+    updated_by: str
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+
+class CreateCapitalEventRequest(BaseModel):
+    event_type: Literal["injection", "withdrawal"]
+    amount: float = Field(gt=0)
+    currency: str = "USD"
+    note: str | None = None
+
+
+class UpdateBudgetConfigRequest(BaseModel):
+    cash_buffer_pct: float | None = Field(default=None, ge=0, le=0.50)
+    cgt_scenario: Literal["basic", "higher"] | None = None
+    updated_by: str
+    reason: str
+
+    @model_validator(mode="after")
+    def _at_least_one_field(self) -> UpdateBudgetConfigRequest:
+        if self.cash_buffer_pct is None and self.cgt_scenario is None:
+            raise ValueError("at least one of cash_buffer_pct or cgt_scenario must be provided")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=BudgetStateResponse)
+def get_budget(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> BudgetStateResponse:
+    """Compute and return a full budget state snapshot."""
+    try:
+        state = compute_budget_state(conn)
+    except BudgetConfigCorrupt:
+        logger.exception("budget config corrupt — cannot compute budget state")
+        raise HTTPException(status_code=503, detail="budget configuration unavailable")
+
+    return BudgetStateResponse(
+        cash_balance=float(state.cash_balance) if state.cash_balance is not None else None,
+        deployed_capital=float(state.deployed_capital),
+        mirror_equity=float(state.mirror_equity),
+        working_budget=float(state.working_budget) if state.working_budget is not None else None,
+        estimated_tax_gbp=float(state.estimated_tax_gbp),
+        estimated_tax_usd=float(state.estimated_tax_usd),
+        gbp_usd_rate=float(state.gbp_usd_rate) if state.gbp_usd_rate is not None else None,
+        cash_buffer_reserve=float(state.cash_buffer_reserve),
+        available_for_deployment=(
+            float(state.available_for_deployment) if state.available_for_deployment is not None else None
+        ),
+        cash_buffer_pct=float(state.cash_buffer_pct),
+        cgt_scenario=state.cgt_scenario,
+        tax_year=state.tax_year,
+    )
+
+
+@router.get("/events", response_model=list[CapitalEventResponse])
+def get_capital_events(
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> list[CapitalEventResponse]:
+    """Return a paginated list of capital events ordered by event_time descending."""
+    events = list_capital_events(conn, limit=limit, offset=offset)
+    return [
+        CapitalEventResponse(
+            event_id=e.event_id,
+            event_time=e.event_time,
+            event_type=e.event_type,
+            amount=float(e.amount),
+            currency=e.currency,
+            source=e.source,
+            note=e.note,
+            created_by=e.created_by,
+        )
+        for e in events
+    ]
+
+
+@router.post("/events", response_model=CapitalEventResponse, status_code=201)
+def create_capital_event(
+    body: CreateCapitalEventRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> CapitalEventResponse:
+    """Record an operator capital injection or withdrawal."""
+    event = record_capital_event(
+        conn,
+        event_type=body.event_type,
+        amount=Decimal(str(body.amount)),
+        currency=body.currency,
+        note=body.note,
+        created_by="operator",
+        source="operator",
+    )
+    conn.commit()
+    return CapitalEventResponse(
+        event_id=event.event_id,
+        event_time=event.event_time,
+        event_type=event.event_type,
+        amount=float(event.amount),
+        currency=event.currency,
+        source=event.source,
+        note=event.note,
+        created_by=event.created_by,
+    )
+
+
+@router.get("/config", response_model=BudgetConfigResponse)
+def get_budget_config_endpoint(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> BudgetConfigResponse:
+    """Return the current budget configuration."""
+    try:
+        config = get_budget_config(conn)
+    except BudgetConfigCorrupt:
+        logger.exception("budget config corrupt — cannot load budget config")
+        raise HTTPException(status_code=503, detail="budget configuration unavailable")
+
+    return BudgetConfigResponse(
+        cash_buffer_pct=float(config.cash_buffer_pct),
+        cgt_scenario=config.cgt_scenario,
+        updated_at=config.updated_at,
+        updated_by=config.updated_by,
+        reason=config.reason,
+    )
+
+
+@router.patch("/config", response_model=BudgetConfigResponse)
+def patch_budget_config(
+    body: UpdateBudgetConfigRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> BudgetConfigResponse:
+    """Partial update of budget configuration.
+
+    Only fields provided as non-None are changed.  Both ``updated_by`` and
+    ``reason`` are required for every mutation so the audit trail always
+    carries attribution.
+    """
+    cash_buffer_decimal = Decimal(str(body.cash_buffer_pct)) if body.cash_buffer_pct is not None else None
+    try:
+        config = update_budget_config(
+            conn,
+            cash_buffer_pct=cash_buffer_decimal,
+            cgt_scenario=body.cgt_scenario,
+            updated_by=body.updated_by,
+            reason=body.reason,
+        )
+    except BudgetConfigCorrupt:
+        logger.exception("budget config corrupt — cannot update budget config")
+        raise HTTPException(status_code=503, detail="budget configuration unavailable")
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    conn.commit()
+    return BudgetConfigResponse(
+        cash_buffer_pct=float(config.cash_buffer_pct),
+        cgt_scenario=config.cgt_scenario,
+        updated_at=config.updated_at,
+        updated_by=config.updated_by,
+        reason=config.reason,
+    )

--- a/app/api/budget.py
+++ b/app/api/budget.py
@@ -97,7 +97,7 @@ class BudgetConfigResponse(BaseModel):
 class CreateCapitalEventRequest(BaseModel):
     event_type: Literal["injection", "withdrawal"]
     amount: float = Field(gt=0)
-    currency: str = "USD"
+    currency: Literal["USD", "GBP"] = "USD"
     note: str | None = None
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ from app.api.auth_bootstrap import router as auth_bootstrap_router
 from app.api.auth_session import router as auth_session_router
 from app.api.auth_setup import router as auth_setup_router
 from app.api.broker_credentials import router as broker_credentials_router
+from app.api.budget import router as budget_router
 from app.api.config import KillSwitchRequest, KillSwitchResponse, post_kill_switch
 from app.api.config import router as config_router
 from app.api.copy_trading import router as copy_trading_router
@@ -119,6 +120,7 @@ app.include_router(auth_bootstrap_router)
 app.include_router(auth_session_router)
 app.include_router(operators_router)
 app.include_router(audit_router)
+app.include_router(budget_router)
 app.include_router(broker_credentials_router)
 app.include_router(config_router)
 app.include_router(copy_trading_router)

--- a/app/services/budget.py
+++ b/app/services/budget.py
@@ -22,13 +22,15 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any, Literal
 
 import psycopg
 import psycopg.rows
 from psycopg import sql
+
+from app.services.tax_ledger import ANNUAL_EXEMPT
 
 logger = logging.getLogger(__name__)
 
@@ -361,3 +363,225 @@ def list_capital_events(
         )
         for r in rows
     ]
+
+
+# ---------------------------------------------------------------------------
+# Budget state computation
+# ---------------------------------------------------------------------------
+
+
+def _current_uk_tax_year() -> str:
+    """Return the current UK tax year as ``"YYYY/YY"``.
+
+    The UK tax year runs 6 April to 5 April.
+    E.g. on 2026-04-15 the tax year is ``"2026/27"`` (past 6 April);
+    on 2025-04-05 the tax year is ``"2024/25"`` (on or before 5 April).
+    """
+    now = datetime.now(tz=UTC)
+    # Tax year starts on 6 April. Dates up to and including 5 April
+    # belong to the tax year that started the previous calendar year.
+    if now.month < 4 or (now.month == 4 and now.day <= 5):
+        start_year = now.year - 1
+    else:
+        start_year = now.year
+    end_year_short = str(start_year + 1)[-2:]
+    return f"{start_year}/{end_year_short}"
+
+
+def _load_cash_balance(conn: psycopg.Connection[Any]) -> Decimal | None:
+    """Load total cash balance from ``cash_ledger``.
+
+    Aggregate always returns one row; the column is NULL when the table
+    is empty (prevention: dead-code None-guard on aggregate fetchone).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT SUM(amount) AS balance FROM cash_ledger")
+        row = cur.fetchone()
+
+    # prevention: aggregate fetchone always returns a row; None-check is
+    # on the column value, not the row itself.
+    if row is None or row["balance"] is None:
+        return None
+    return Decimal(str(row["balance"]))
+
+
+def _load_deployed_capital(conn: psycopg.Connection[Any]) -> Decimal:
+    """Load total deployed capital from open positions.
+
+    CRITICAL: ``WHERE current_units > 0`` — prevention log says
+    zero-unit positions inflate AUM via cost_basis fallback.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT COALESCE(SUM(cost_basis), 0) AS deployed
+            FROM positions
+            WHERE current_units > 0
+            """
+        )
+        row = cur.fetchone()
+
+    # Aggregate with COALESCE always returns a non-None value.
+    if row is None:
+        return _ZERO  # defensive; should never happen
+    return Decimal(str(row["deployed"]))
+
+
+def _load_mirror_equity(conn: psycopg.Connection[Any]) -> Decimal:
+    """Load total equity held in active copy mirrors.
+
+    Mirror equity = active mirrors' available_amount + their positions'
+    current_value.  Returns ``Decimal("0")`` if no mirrors exist.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT COALESCE(
+                (SELECT SUM(cm.available_amount)
+                 FROM copy_mirrors cm
+                 WHERE cm.status = 'active')
+                +
+                (SELECT COALESCE(SUM(cmp.current_value), 0)
+                 FROM copy_mirror_positions cmp
+                 JOIN copy_mirrors cm2 ON cm2.mirror_id = cmp.mirror_id
+                 WHERE cm2.status = 'active'),
+                0
+            ) AS mirror_equity
+            """
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        return _ZERO  # defensive; should never happen
+    return Decimal(str(row["mirror_equity"]))
+
+
+def _load_tax_estimates(
+    conn: psycopg.Connection[Any],
+    tax_year: str,
+) -> tuple[Decimal, Decimal]:
+    """Return ``(basic_estimate_gbp, higher_estimate_gbp)`` for ``tax_year``.
+
+    Reads ``disposal_matches`` and applies current-year CGT rates
+    (basic=18%, higher=24%) after the annual exempt amount.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT
+                COALESCE(SUM(CASE WHEN gain_or_loss_gbp > 0
+                                  THEN gain_or_loss_gbp ELSE 0 END), 0) AS total_gains,
+                COALESCE(SUM(gain_or_loss_gbp), 0) AS net_gain
+            FROM disposal_matches
+            WHERE tax_year = %(ty)s
+            """,
+            {"ty": tax_year},
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        return (_ZERO, _ZERO)  # defensive
+
+    total_gains = Decimal(str(row["total_gains"]))
+    net_gain = Decimal(str(row["net_gain"]))
+
+    taxable_net = max(net_gain - ANNUAL_EXEMPT, _ZERO)
+    if total_gains <= _ZERO or taxable_net <= _ZERO:
+        return (_ZERO, _ZERO)
+
+    basic_rate = Decimal("0.18")
+    higher_rate = Decimal("0.24")
+
+    # scale = proportion of total gains that is taxable after exempt amount
+    # units: taxable_net (GBP) / total_gains (GBP) = dimensionless ratio
+    scale = taxable_net / total_gains
+    _TWO_DP = Decimal("0.01")
+    basic_est = (total_gains * basic_rate * scale).quantize(_TWO_DP)
+    higher_est = (total_gains * higher_rate * scale).quantize(_TWO_DP)
+    return (basic_est, higher_est)
+
+
+def _load_gbp_usd_rate(conn: psycopg.Connection[Any]) -> Decimal | None:
+    """Load the GBP -> USD exchange rate from ``live_fx_rates``.
+
+    Returns None if no rate is found.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT rate
+            FROM live_fx_rates
+            WHERE from_currency = 'GBP' AND to_currency = 'USD'
+            """
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        return None
+    return Decimal(str(row["rate"]))
+
+
+def compute_budget_state(conn: psycopg.Connection[Any]) -> BudgetState:
+    """Compute a full budget state snapshot from current DB state.
+
+    Reads from budget_config, cash_ledger, positions, copy_mirrors,
+    copy_mirror_positions, disposal_matches, and live_fx_rates.
+    """
+    config = get_budget_config(conn)
+    tax_year = _current_uk_tax_year()
+
+    cash_balance = _load_cash_balance(conn)
+    deployed_capital = _load_deployed_capital(conn)
+    mirror_equity = _load_mirror_equity(conn)
+
+    # working_budget = cash + deployed + mirrors (None if cash is unknown)
+    if cash_balance is not None:
+        working_budget = cash_balance + deployed_capital + mirror_equity
+    else:
+        working_budget = None
+
+    # Tax estimates
+    basic_est, higher_est = _load_tax_estimates(conn, tax_year)
+    if config.cgt_scenario == "basic":
+        estimated_tax_gbp = basic_est
+    else:
+        estimated_tax_gbp = higher_est
+
+    # FX conversion
+    gbp_usd_rate = _load_gbp_usd_rate(conn)
+    if gbp_usd_rate is not None:
+        estimated_tax_usd = estimated_tax_gbp * gbp_usd_rate
+    else:
+        if estimated_tax_gbp > _ZERO:
+            logger.warning(
+                "No GBP->USD rate available; using 0 for tax_usd (tax_gbp=%s)",
+                estimated_tax_gbp,
+            )
+        estimated_tax_usd = _ZERO
+
+    # Cash buffer reserve
+    if working_budget is not None:
+        cash_buffer_reserve = working_budget * config.cash_buffer_pct
+    else:
+        cash_buffer_reserve = _ZERO
+
+    # Available for deployment
+    if cash_balance is not None:
+        available_for_deployment = cash_balance - estimated_tax_usd - cash_buffer_reserve
+    else:
+        available_for_deployment = None
+
+    return BudgetState(
+        cash_balance=cash_balance,
+        deployed_capital=deployed_capital,
+        mirror_equity=mirror_equity,
+        working_budget=working_budget,
+        estimated_tax_gbp=estimated_tax_gbp,
+        estimated_tax_usd=estimated_tax_usd,
+        gbp_usd_rate=gbp_usd_rate,
+        cash_buffer_reserve=cash_buffer_reserve,
+        available_for_deployment=available_for_deployment,
+        cash_buffer_pct=config.cash_buffer_pct,
+        cgt_scenario=config.cgt_scenario,
+        tax_year=tax_year,
+    )

--- a/app/services/budget.py
+++ b/app/services/budget.py
@@ -437,7 +437,7 @@ def _load_mirror_equity(conn: psycopg.Connection[Any]) -> Decimal:
         cur.execute(
             """
             SELECT COALESCE(
-                (SELECT SUM(cm.available_amount)
+                (SELECT COALESCE(SUM(cm.available_amount), 0)
                  FROM copy_mirrors cm
                  WHERE cm.status = 'active')
                 +
@@ -492,12 +492,9 @@ def _load_tax_estimates(
     basic_rate = Decimal("0.18")
     higher_rate = Decimal("0.24")
 
-    # scale = proportion of total gains that is taxable after exempt amount
-    # units: taxable_net (GBP) / total_gains (GBP) = dimensionless ratio
-    scale = taxable_net / total_gains
     _TWO_DP = Decimal("0.01")
-    basic_est = (total_gains * basic_rate * scale).quantize(_TWO_DP)
-    higher_est = (total_gains * higher_rate * scale).quantize(_TWO_DP)
+    basic_est = (taxable_net * basic_rate).quantize(_TWO_DP)
+    higher_est = (taxable_net * higher_rate).quantize(_TWO_DP)
     return (basic_est, higher_est)
 
 
@@ -559,7 +556,10 @@ def compute_budget_state(conn: psycopg.Connection[Any]) -> BudgetState:
             )
         estimated_tax_usd = _ZERO
 
-    # Cash buffer reserve
+    # Cash buffer reserve — intentionally % of total AUM (working_budget),
+    # not % of cash_balance.  Using cash as the base would create a feedback
+    # loop: deploying more cash shrinks the buffer, enabling even more
+    # deployment.  AUM-based reserve scales with portfolio size.
     if working_budget is not None:
         cash_buffer_reserve = working_budget * config.cash_buffer_pct
     else:

--- a/app/services/budget.py
+++ b/app/services/budget.py
@@ -1,0 +1,363 @@
+"""
+Budget service — types, config, and capital events.
+
+Pure service module that computes budget state on the fly from DB rows.
+No caching, no singletons in memory — every call reads current state.
+
+Capital events (``capital_events`` table):
+  ``amount`` is always positive; ``event_type`` carries the directional
+  semantics (injection = cash in, withdrawal = cash out, tax_provision =
+  reserved for CGT, tax_release = released back from CGT reserve).
+
+Budget config (``budget_config`` table):
+  Singleton row (``id = TRUE``, same pattern as ``runtime_config``) holding
+  operator-level preferences: ``cash_buffer_pct`` and ``cgt_scenario``.
+  Every mutation writes one ``budget_config_audit`` row per changed field
+  inside the same transaction as the UPDATE.
+
+Issue: #203
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+import psycopg.rows
+from psycopg import sql
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+CapitalEventType = Literal["injection", "withdrawal", "tax_provision", "tax_release"]
+CapitalEventSource = Literal["operator", "system", "broker_sync"]
+CgtScenario = Literal["basic", "higher"]
+
+_ZERO = Decimal("0")
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class BudgetConfigCorrupt(RuntimeError):
+    """Raised when the budget_config singleton row is missing.
+
+    Callers on safety-critical paths must catch this and fail closed —
+    never default to permissive budget assumptions.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BudgetConfig:
+    cash_buffer_pct: Decimal
+    cgt_scenario: str
+    updated_at: datetime
+    updated_by: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class BudgetState:
+    cash_balance: Decimal | None
+    deployed_capital: Decimal
+    mirror_equity: Decimal
+    working_budget: Decimal | None
+    estimated_tax_gbp: Decimal
+    estimated_tax_usd: Decimal
+    gbp_usd_rate: Decimal | None
+    cash_buffer_reserve: Decimal
+    available_for_deployment: Decimal | None
+    cash_buffer_pct: Decimal
+    cgt_scenario: str
+    tax_year: str
+
+
+@dataclass(frozen=True)
+class CapitalEvent:
+    event_id: int
+    event_time: datetime
+    event_type: str
+    amount: Decimal
+    currency: str
+    source: str
+    note: str | None
+    created_by: str | None
+
+
+# ---------------------------------------------------------------------------
+# Budget config queries
+# ---------------------------------------------------------------------------
+
+
+def get_budget_config(conn: psycopg.Connection[Any]) -> BudgetConfig:
+    """Load the singleton budget_config row.
+
+    Raises BudgetConfigCorrupt if the row is missing — every caller on a
+    safety-critical path must treat this as fail-closed.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT cash_buffer_pct,
+                   cgt_scenario,
+                   updated_at,
+                   updated_by,
+                   reason
+            FROM budget_config
+            WHERE id = TRUE
+            """
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        raise BudgetConfigCorrupt("budget_config singleton row missing — configuration corrupt")
+
+    return BudgetConfig(
+        cash_buffer_pct=Decimal(str(row["cash_buffer_pct"])),
+        cgt_scenario=str(row["cgt_scenario"]),
+        updated_at=row["updated_at"],
+        updated_by=str(row["updated_by"]),
+        reason=str(row["reason"]),
+    )
+
+
+def update_budget_config(
+    conn: psycopg.Connection[Any],
+    *,
+    cash_buffer_pct: Decimal | None = None,
+    cgt_scenario: str | None = None,
+    updated_by: str,
+    reason: str,
+) -> BudgetConfig:
+    """Atomically update the budget_config singleton.
+
+    Only fields passed as non-None are changed (partial update semantics).
+    Writes one audit row per changed field, in the same transaction as the
+    UPDATE.  The pre-update row is read inside the transaction so the audit
+    ``old_value`` cannot race a concurrent writer.
+
+    This function accepts a caller connection.  It must NOT call
+    ``conn.commit()`` — only uses ``conn.transaction()`` for savepoints.
+    The caller owns the commit.
+
+    Raises ValueError if no fields are provided or if provided values
+    match the current row (no-op patch).
+    Raises BudgetConfigCorrupt if the singleton row is missing.
+    """
+    if cash_buffer_pct is None and cgt_scenario is None:
+        raise ValueError("at least one of cash_buffer_pct or cgt_scenario must be provided")
+
+    # prevention: audit reads outside the write transaction
+    # prevention: read-then-write cap enforcement outside transaction
+    # All reads + UPDATE + audit writes happen inside one conn.transaction() block.
+    with conn.transaction():
+        # Read current values inside the transaction.
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT cash_buffer_pct,
+                       cgt_scenario,
+                       updated_at,
+                       updated_by,
+                       reason
+                FROM budget_config
+                WHERE id = TRUE
+                FOR UPDATE
+                """
+            )
+            current = cur.fetchone()
+
+        if current is None:
+            raise BudgetConfigCorrupt("budget_config singleton row missing — cannot update; configuration corrupt")
+
+        old_buffer = Decimal(str(current["cash_buffer_pct"]))
+        old_scenario = str(current["cgt_scenario"])
+
+        # Track which fields actually changed.
+        changes: dict[str, tuple[str, str]] = {}
+        if cash_buffer_pct is not None and cash_buffer_pct != old_buffer:
+            changes["cash_buffer_pct"] = (str(old_buffer), str(cash_buffer_pct))
+        if cgt_scenario is not None and cgt_scenario != old_scenario:
+            changes["cgt_scenario"] = (old_scenario, cgt_scenario)
+
+        if not changes:
+            raise ValueError("no fields changed")
+
+        # Build dynamic SET clause using psycopg.sql for type-safe composition.
+        # Column names come from a fixed set in code (never user input).
+        set_parts: list[sql.Composable] = []
+        params: dict[str, Any] = {
+            "by": updated_by,
+            "reason": reason,
+        }
+        if "cash_buffer_pct" in changes:
+            set_parts.append(sql.SQL("cash_buffer_pct = {buffer}").format(buffer=sql.Placeholder("buffer")))
+            params["buffer"] = cash_buffer_pct
+        if "cgt_scenario" in changes:
+            set_parts.append(sql.SQL("cgt_scenario = {scenario}").format(scenario=sql.Placeholder("scenario")))
+            params["scenario"] = cgt_scenario
+
+        set_parts.append(sql.SQL("updated_at = NOW()"))
+        set_parts.append(sql.SQL("updated_by = {by}").format(by=sql.Placeholder("by")))
+        set_parts.append(sql.SQL("reason = {reason}").format(reason=sql.Placeholder("reason")))
+
+        query = sql.SQL(
+            "UPDATE budget_config SET {sets} WHERE id = TRUE"
+            " RETURNING cash_buffer_pct, cgt_scenario, updated_at, updated_by, reason"
+        ).format(sets=sql.SQL(", ").join(set_parts))
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as upd_cur:
+            result = upd_cur.execute(query, params)
+            # prevention: single-row UPDATE silent no-op on missing row
+            if result.rowcount == 0:
+                raise BudgetConfigCorrupt("budget_config UPDATE affected 0 rows — singleton vanished")
+            updated_row = upd_cur.fetchone()
+
+        if updated_row is None:
+            raise RuntimeError("RETURNING produced no row despite rowcount > 0")
+
+        # Write one audit row per changed field.
+        for field, (old_val, new_val) in changes.items():
+            conn.execute(
+                """
+                INSERT INTO budget_config_audit
+                    (changed_at, changed_by, field, old_value, new_value, reason)
+                VALUES
+                    (NOW(), %(by)s, %(field)s, %(old)s, %(new)s, %(reason)s)
+                """,
+                {
+                    "by": updated_by,
+                    "field": field,
+                    "old": old_val,
+                    "new": new_val,
+                    "reason": reason,
+                },
+            )
+
+    logger.info(
+        "budget_config updated by=%s reason=%s changes=%s",
+        updated_by,
+        reason,
+        list(changes.keys()),
+    )
+
+    return BudgetConfig(
+        cash_buffer_pct=Decimal(str(updated_row["cash_buffer_pct"])),
+        cgt_scenario=str(updated_row["cgt_scenario"]),
+        updated_at=updated_row["updated_at"],
+        updated_by=str(updated_row["updated_by"]),
+        reason=str(updated_row["reason"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Capital event queries
+# ---------------------------------------------------------------------------
+
+
+def record_capital_event(
+    conn: psycopg.Connection[Any],
+    *,
+    event_type: CapitalEventType,
+    amount: Decimal,
+    currency: str,
+    source: CapitalEventSource,
+    note: str | None,
+    created_by: str | None,
+) -> CapitalEvent:
+    """Insert a capital event and return the persisted row.
+
+    ``amount`` must be positive — the sign is carried by ``event_type``.
+
+    Raises ValueError if amount <= 0.
+    Raises RuntimeError if RETURNING produces no row (invariant violation).
+    """
+    if amount <= _ZERO:
+        raise ValueError("amount must be positive")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            INSERT INTO capital_events
+                (event_type, amount, currency, source, note, created_by)
+            VALUES
+                (%(type)s, %(amount)s, %(currency)s, %(source)s, %(note)s, %(by)s)
+            RETURNING event_id, event_time, event_type, amount, currency,
+                      source, note, created_by
+            """,
+            {
+                "type": event_type,
+                "amount": amount,
+                "currency": currency,
+                "source": source,
+                "note": note,
+                "by": created_by,
+            },
+        )
+        row = cur.fetchone()
+
+    # prevention: assert as runtime guard
+    if row is None:
+        raise RuntimeError("INSERT INTO capital_events RETURNING produced no row")
+
+    return CapitalEvent(
+        event_id=int(row["event_id"]),
+        event_time=row["event_time"],
+        event_type=str(row["event_type"]),
+        amount=Decimal(str(row["amount"])),
+        currency=str(row["currency"]),
+        source=str(row["source"]),
+        note=row["note"],
+        created_by=row["created_by"],
+    )
+
+
+def list_capital_events(
+    conn: psycopg.Connection[Any],
+    *,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[CapitalEvent]:
+    """Return capital events ordered by event_time descending.
+
+    Supports pagination via limit/offset.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT event_id, event_time, event_type, amount, currency,
+                   source, note, created_by
+            FROM capital_events
+            ORDER BY event_time DESC
+            LIMIT %(limit)s OFFSET %(offset)s
+            """,
+            {"limit": limit, "offset": offset},
+        )
+        rows = cur.fetchall()
+
+    return [
+        CapitalEvent(
+            event_id=int(r["event_id"]),
+            event_time=r["event_time"],
+            event_type=str(r["event_type"]),
+            amount=Decimal(str(r["amount"])),
+            currency=str(r["currency"]),
+            source=str(r["source"]),
+            note=r["note"],
+            created_by=r["created_by"],
+        )
+        for r in rows
+    ]

--- a/app/services/execution_guard.py
+++ b/app/services/execution_guard.py
@@ -25,7 +25,7 @@ Rule application by action:
     - no_thesis             — no thesis row exists
     - spread_wide           — quotes.spread_flag is TRUE
     - spread_unavailable    — no quotes row or spread_flag is NULL
-    - cash_unknown          — cash_ledger is empty (cannot verify affordability)
+    - budget_available      — budget exhausted or unknown (accounts for tax + buffer)
     - concentration_breach  — post-action sector exposure would exceed 25% AUM
 
   EXIT:
@@ -48,6 +48,7 @@ import psycopg
 import psycopg.rows
 from psycopg.types.json import Jsonb
 
+from app.services.budget import BudgetConfigCorrupt, BudgetState, compute_budget_state
 from app.services.portfolio import _load_mirror_equity
 from app.services.runtime_config import RuntimeConfigCorrupt, get_runtime_config
 
@@ -88,7 +89,7 @@ RuleName = Literal[
     "no_thesis",
     "spread_wide",
     "spread_unavailable",
-    "cash_unknown",
+    "budget_available",
     "instrument_missing",
     "sector_missing",
     "concentration_breach",
@@ -410,20 +411,34 @@ def _check_spread(quote: dict[str, Any] | None) -> RuleResult:
     return RuleResult(rule="spread_wide", passed=True)
 
 
-def _check_cash(cash: float | None) -> RuleResult:
-    if cash is None:
+def _check_budget(budget: BudgetState) -> RuleResult:
+    """Check budget availability for BUY/ADD orders.
+
+    Replaces the raw cash > 0 check with budget-aware logic that accounts
+    for tax provisions and cash buffer reserve.
+    """
+    if budget.available_for_deployment is None:
         return RuleResult(
-            rule="cash_unknown",
+            rule="budget_available",
             passed=False,
-            detail="cash_ledger is empty; cannot verify affordability",
+            detail="cash_ledger is empty; cannot verify budget availability",
         )
-    if cash <= 0:
+    if budget.available_for_deployment <= 0:
         return RuleResult(
-            rule="cash_unknown",
+            rule="budget_available",
             passed=False,
-            detail=f"cash_balance={cash}; no buying power",
+            detail=(
+                f"budget exhausted: available_for_deployment="
+                f"{budget.available_for_deployment:.2f} "
+                f"(cash={budget.cash_balance}, tax_reserved={budget.estimated_tax_usd:.2f}, "
+                f"buffer={budget.cash_buffer_reserve:.2f})"
+            ),
         )
-    return RuleResult(rule="cash_unknown", passed=True)
+    return RuleResult(
+        rule="budget_available",
+        passed=True,
+        detail=f"budget ok: available_for_deployment={budget.available_for_deployment:.2f}",
+    )
 
 
 def _check_concentration(
@@ -558,7 +573,7 @@ def evaluate_recommendation(
     Steps:
       1. Load the recommendation row.
       2. Load all required state from DB (kill switch, coverage, thesis,
-         quote, cash, sector exposure).
+         quote, budget state, sector exposure).
       3. Evaluate rules in order; collect results.
       4. Write audit row + update recommendation status atomically.
       5. Return GuardResult.
@@ -588,7 +603,7 @@ def evaluate_recommendation(
     coverage: dict[str, Any] | None = None
     thesis: dict[str, Any] | None = None
     quote: dict[str, Any] | None = None
-    cash: float | None = None
+    budget: BudgetState | None = None
     instrument_found: bool = True
     sector: str | None = None
     current_sector_pct: float = 0.0
@@ -598,7 +613,13 @@ def evaluate_recommendation(
         coverage = _load_coverage(conn, instrument_id)
         thesis = _load_latest_thesis(conn, instrument_id)
         quote = _load_quote(conn, instrument_id)
-        cash = _load_cash(conn)
+        # Budget-aware cash check: replaces raw _load_cash(conn).
+        # compute_budget_state reads budget_config, cash_ledger, positions,
+        # copy_mirrors, disposal_matches, and live_fx_rates.
+        try:
+            budget = compute_budget_state(conn)
+        except BudgetConfigCorrupt:
+            budget = None
         instrument_found, sector, current_sector_pct, total_aum = _load_sector_exposure(conn, instrument_id)
 
     # --- Step 3: evaluate rules ---
@@ -633,7 +654,16 @@ def evaluate_recommendation(
         if coverage is not None:
             rule_results.append(_check_thesis_freshness(thesis, coverage, now))
         rule_results.append(_check_spread(quote))
-        rule_results.append(_check_cash(cash))
+        if budget is None:
+            rule_results.append(
+                RuleResult(
+                    rule="budget_available",
+                    passed=False,
+                    detail="budget_config singleton row missing — cannot verify budget",
+                )
+            )
+        else:
+            rule_results.append(_check_budget(budget))
         rule_results.append(_check_concentration(instrument_found, sector, current_sector_pct, total_aum))
 
     # --- Step 4: derive verdict ---

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -652,3 +652,22 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `with conn.transaction():` on a `psycopg.connect()`-opened connection (autocommit=False) creates a savepoint. The savepoint is released when the block exits, but the outer implicit transaction is not committed. If `conn.commit()` is omitted after the block, writes are silently rolled back when the connection closes.
 - Prevention: After any `with conn.transaction():` block on a non-autocommit connection, verify that `conn.commit()` is called before the connection closes. Alternatively, avoid `conn.transaction()` and use a plain `conn.commit()` when savepoint semantics are not needed. Grep `with conn\.transaction\(\):` and verify each is followed by `conn.commit()` within the same `with psycopg.connect(...)` scope.
 - Enforced in: this prevention log
+
+
+---
+
+### psycopg3 cursors are independent — mock cursor sequences are not
+
+- First seen in: #232 (review BLOCKING 2)
+- Symptom: Reviewer flagged a "cursor desync" when `BudgetConfigCorrupt` is raised mid-sequence in `compute_budget_state`, claiming it corrupts the cursor position for `_load_sector_exposure`. In production, each `conn.cursor()` creates an independent server cursor — there is no shared iterator to desync. The issue exists only in the test mock pattern where `conn.cursor` returns cursors via `side_effect` from a list.
+- Prevention: When a test helper builds a cursor sequence (`_buy_cursors`, `_exit_cursors`, etc.) and includes an exception path that consumes fewer cursors than the happy path, the helper must emit the correct number of cursors for each path. See `_budget_cursors_list(budget_corrupt=True)` which returns 1 cursor instead of 6. Always count the cursors consumed by each branch.
+- Enforced in: `tests/test_execution_guard.py` (`_budget_cursors_list` with `budget_corrupt` parameter)
+
+---
+
+### New TEXT columns in migrations need CHECK constraints or Literal types
+
+- First seen in: #232 (review WARNING 1)
+- Symptom: `capital_events.currency` was a free-text TEXT column with no CHECK constraint. While SQL injection is blocked by parameterized queries, arbitrary strings persisting in domain columns violate the enum-style semantics.
+- Prevention: Before merge, `grep 'TEXT NOT NULL' sql/0*.sql` on new migrations and confirm each user-supplied column has either a CHECK constraint or an enum type. On the API model side, use `Literal["a", "b"]` instead of `str` for columns with constrained values.
+- Enforced in: `sql/027_budget_capital.sql` (`chk_capital_events_currency`); `app/api/budget.py` (`Literal["USD", "GBP"]`)

--- a/sql/027_budget_capital.sql
+++ b/sql/027_budget_capital.sql
@@ -38,6 +38,12 @@ BEGIN
         CHECK (amount > 0);
 
     ALTER TABLE capital_events
+        DROP CONSTRAINT IF EXISTS chk_capital_events_currency;
+    ALTER TABLE capital_events
+        ADD CONSTRAINT chk_capital_events_currency
+        CHECK (currency IN ('USD', 'GBP'));
+
+    ALTER TABLE capital_events
         DROP CONSTRAINT IF EXISTS chk_capital_events_source;
     ALTER TABLE capital_events
         ADD CONSTRAINT chk_capital_events_source

--- a/sql/027_budget_capital.sql
+++ b/sql/027_budget_capital.sql
@@ -1,0 +1,100 @@
+-- Migration 027: budget and capital management tables
+--
+-- capital_events: operator-facing ledger for cash injections, withdrawals,
+--   and system-managed tax provisions/releases.  amount is always positive;
+--   event_type carries the directional semantics.
+--
+-- budget_config: singleton row (same pattern as runtime_config) holding
+--   operator-level budget preferences: cash buffer percentage and the CGT
+--   scenario used for tax provisioning.
+--
+-- budget_config_audit: per-field audit trail for every mutation of
+--   budget_config, mirroring runtime_config_audit.
+
+CREATE TABLE IF NOT EXISTS capital_events (
+    event_id    BIGSERIAL    PRIMARY KEY,
+    event_time  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    event_type  TEXT         NOT NULL,
+    amount      NUMERIC(18,6) NOT NULL,
+    currency    TEXT         NOT NULL DEFAULT 'USD',
+    source      TEXT         NOT NULL DEFAULT 'operator',
+    note        TEXT,
+    created_by  TEXT
+);
+
+-- Idempotent CHECK constraints for capital_events.
+DO $$
+BEGIN
+    ALTER TABLE capital_events
+        DROP CONSTRAINT IF EXISTS chk_capital_events_event_type;
+    ALTER TABLE capital_events
+        ADD CONSTRAINT chk_capital_events_event_type
+        CHECK (event_type IN ('injection', 'withdrawal', 'tax_provision', 'tax_release'));
+
+    ALTER TABLE capital_events
+        DROP CONSTRAINT IF EXISTS chk_capital_events_amount;
+    ALTER TABLE capital_events
+        ADD CONSTRAINT chk_capital_events_amount
+        CHECK (amount > 0);
+
+    ALTER TABLE capital_events
+        DROP CONSTRAINT IF EXISTS chk_capital_events_source;
+    ALTER TABLE capital_events
+        ADD CONSTRAINT chk_capital_events_source
+        CHECK (source IN ('operator', 'system', 'broker_sync'));
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_capital_events_event_time
+    ON capital_events (event_time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_capital_events_event_type
+    ON capital_events (event_type, event_time DESC);
+
+-- Singleton budget config.  id BOOLEAN PRIMARY KEY DEFAULT TRUE + CHECK id = TRUE
+-- enforces at most one row, matching the runtime_config pattern.
+CREATE TABLE IF NOT EXISTS budget_config (
+    id               BOOLEAN      PRIMARY KEY DEFAULT TRUE,
+    cash_buffer_pct  NUMERIC(5,4) NOT NULL DEFAULT 0.05,
+    cgt_scenario     TEXT         NOT NULL DEFAULT 'higher',
+    updated_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_by       TEXT         NOT NULL DEFAULT 'system',
+    reason           TEXT         NOT NULL DEFAULT 'initial seed',
+    CONSTRAINT budget_config_single_row CHECK (id = TRUE)
+);
+
+-- Idempotent CHECK constraints for budget_config.
+DO $$
+BEGIN
+    ALTER TABLE budget_config
+        DROP CONSTRAINT IF EXISTS chk_budget_config_cash_buffer_pct;
+    ALTER TABLE budget_config
+        ADD CONSTRAINT chk_budget_config_cash_buffer_pct
+        CHECK (cash_buffer_pct >= 0 AND cash_buffer_pct <= 0.50);
+
+    ALTER TABLE budget_config
+        DROP CONSTRAINT IF EXISTS chk_budget_config_cgt_scenario;
+    ALTER TABLE budget_config
+        ADD CONSTRAINT chk_budget_config_cgt_scenario
+        CHECK (cgt_scenario IN ('basic', 'higher'));
+END $$;
+
+-- Seed singleton row with safe defaults.
+INSERT INTO budget_config (id)
+VALUES (TRUE)
+ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS budget_config_audit (
+    audit_id    BIGSERIAL    PRIMARY KEY,
+    changed_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    changed_by  TEXT         NOT NULL,
+    field       TEXT         NOT NULL,
+    old_value   TEXT,
+    new_value   TEXT,
+    reason      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_budget_config_audit_changed_at
+    ON budget_config_audit (changed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_budget_config_audit_field
+    ON budget_config_audit (field, changed_at DESC);

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -13,6 +13,7 @@ Mock DB approach mirrors test_runtime_config.py.
 
 from __future__ import annotations
 
+import unittest.mock
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
@@ -23,7 +24,10 @@ import pytest
 from app.services.budget import (
     BudgetConfig,
     BudgetConfigCorrupt,
+    BudgetState,
     CapitalEvent,
+    _current_uk_tax_year,
+    compute_budget_state,
     get_budget_config,
     list_capital_events,
     record_capital_event,
@@ -402,3 +406,220 @@ class TestListCapitalEvents:
         events = list_capital_events(conn)
         assert events[0].amount == Decimal("1234.567890")
         assert isinstance(events[0].amount, Decimal)
+
+
+# ---------------------------------------------------------------------------
+# TestComputeBudgetState
+# ---------------------------------------------------------------------------
+
+
+def _budget_config_row(
+    buffer: str = "0.0500",
+    scenario: str = "higher",
+) -> dict[str, Any]:
+    return {
+        "cash_buffer_pct": Decimal(buffer),
+        "cgt_scenario": scenario,
+        "updated_at": _NOW,
+        "updated_by": "seed",
+        "reason": "initial seed",
+    }
+
+
+def _budget_conn(
+    config_row: dict[str, Any] | None = None,
+    cash_balance: Decimal | None = Decimal("10000"),
+    deployed: Decimal = Decimal("5000"),
+    mirror_equity: Decimal = Decimal("2000"),
+    total_gains: Decimal = Decimal("3500"),
+    net_gain: Decimal = Decimal("3500"),
+    gbp_usd_rate: Decimal | None = Decimal("1.25"),
+) -> MagicMock:
+    """Build a mock connection for compute_budget_state.
+
+    Cursor order:
+      0: budget_config (get_budget_config)
+      1: cash_balance (_load_cash_balance)
+      2: deployed_capital (_load_deployed_capital)
+      3: mirror_equity (_load_mirror_equity)
+      4: tax estimates (_load_tax_estimates)
+      5: gbp_usd rate (_load_gbp_usd_rate)
+    """
+    if config_row is None:
+        config_row = _budget_config_row()
+
+    cur_config = _make_cursor(single=config_row)
+    cur_cash = _make_cursor(single={"balance": cash_balance})
+    cur_deployed = _make_cursor(single={"deployed": deployed})
+    cur_mirrors = _make_cursor(single={"mirror_equity": mirror_equity})
+    cur_tax = _make_cursor(
+        single={"total_gains": total_gains, "net_gain": net_gain},
+    )
+    if gbp_usd_rate is not None:
+        cur_fx = _make_cursor(single={"rate": gbp_usd_rate})
+    else:
+        # Simulate no row found — fetchone returns None
+        cur_fx = _make_cursor()
+        cur_fx.fetchone.return_value = None
+
+    return _make_conn([cur_config, cur_cash, cur_deployed, cur_mirrors, cur_tax, cur_fx])
+
+
+class TestComputeBudgetState:
+    def test_full_budget_computation(self) -> None:
+        """Full happy path: cash=10000, deployed=5000, mirrors=2000,
+        higher CGT with gains=3500 net=3500 → taxable=500 → est=120 GBP,
+        rate=1.25 → tax_usd=150, buffer=5% of 17000=850,
+        available=10000-150-850=9000.
+        """
+        conn = _budget_conn()
+        with unittest.mock.patch(
+            "app.services.budget._current_uk_tax_year",
+            return_value="2025/26",
+        ):
+            state = compute_budget_state(conn)
+
+        assert isinstance(state, BudgetState)
+        assert state.cash_balance == Decimal("10000")
+        assert state.deployed_capital == Decimal("5000")
+        assert state.mirror_equity == Decimal("2000")
+        assert state.working_budget == Decimal("17000")
+
+        # Tax: total_gains=3500, net_gain=3500, ANNUAL_EXEMPT=3000
+        # taxable_net = 3500 - 3000 = 500
+        # scale = 500 / 3500
+        # higher_est = 3500 * 0.24 * (500/3500) = 120.00 (quantized)
+        assert state.estimated_tax_gbp == Decimal("120.00")
+        # tax_usd = 120.00 * 1.25 = 150.0000
+        assert state.estimated_tax_usd == Decimal("150.0000")
+        assert state.gbp_usd_rate == Decimal("1.25")
+
+        # buffer = 17000 * 0.05 = 850.00
+        assert state.cash_buffer_reserve == Decimal("850.0000")
+
+        # available = 10000 - 150.0000 - 850.0000 = 9000.0000
+        assert state.available_for_deployment == Decimal("9000.0000")
+        assert state.cash_buffer_pct == Decimal("0.0500")
+        assert state.cgt_scenario == "higher"
+        assert state.tax_year == "2025/26"
+
+    def test_unknown_cash_returns_none_available(self) -> None:
+        """When cash_ledger SUM is NULL, cash_balance=None,
+        working_budget=None, available=None.
+        """
+        conn = _budget_conn(cash_balance=None)
+        with unittest.mock.patch(
+            "app.services.budget._current_uk_tax_year",
+            return_value="2025/26",
+        ):
+            state = compute_budget_state(conn)
+
+        assert state.cash_balance is None
+        assert state.working_budget is None
+        assert state.available_for_deployment is None
+        assert state.cash_buffer_reserve == Decimal("0")
+
+    def test_no_fx_rate_uses_zero_tax(self) -> None:
+        """When GBP->USD rate is None, tax_usd=0 and a warning is logged."""
+        conn = _budget_conn(gbp_usd_rate=None)
+        with (
+            unittest.mock.patch(
+                "app.services.budget._current_uk_tax_year",
+                return_value="2025/26",
+            ),
+            unittest.mock.patch("app.services.budget.logger") as mock_logger,
+        ):
+            state = compute_budget_state(conn)
+
+        assert state.gbp_usd_rate is None
+        assert state.estimated_tax_usd == Decimal("0")
+        assert state.estimated_tax_gbp > Decimal("0")
+        mock_logger.warning.assert_called_once()
+
+    def test_negative_available_when_over_reserved(self) -> None:
+        """When tax + buffer > cash, available is negative."""
+        # cash=100, deployed=50000, mirrors=0, gains=50000, net=50000
+        # working_budget = 100 + 50000 + 0 = 50100
+        # taxable_net = 50000 - 3000 = 47000
+        # scale = 47000 / 50000
+        # higher_est = 50000 * 0.24 * (47000/50000) = 11280
+        # tax_usd = 11280 * 1.25 = 14100
+        # buffer = 50100 * 0.05 = 2505
+        # available = 100 - 14100 - 2505 = -16505
+        conn = _budget_conn(
+            cash_balance=Decimal("100"),
+            deployed=Decimal("50000"),
+            mirror_equity=Decimal("0"),
+            total_gains=Decimal("50000"),
+            net_gain=Decimal("50000"),
+        )
+        with unittest.mock.patch(
+            "app.services.budget._current_uk_tax_year",
+            return_value="2025/26",
+        ):
+            state = compute_budget_state(conn)
+
+        assert state.available_for_deployment is not None
+        assert state.available_for_deployment < Decimal("0")
+
+    def test_basic_cgt_scenario_uses_basic_estimate(self) -> None:
+        """When cgt_scenario='basic', the basic rate (18%) is used."""
+        conn = _budget_conn(
+            config_row=_budget_config_row(scenario="basic"),
+        )
+        with unittest.mock.patch(
+            "app.services.budget._current_uk_tax_year",
+            return_value="2025/26",
+        ):
+            state = compute_budget_state(conn)
+
+        assert state.cgt_scenario == "basic"
+        # basic_est = 3500 * 0.18 * (500/3500) = 90.00 (quantized)
+        assert state.estimated_tax_gbp == Decimal("90.00")
+
+
+class TestCurrentUkTaxYear:
+    def test_mid_april_returns_current_start_year(self) -> None:
+        """2026-04-15 is past 6 April → in the 2026/27 tax year."""
+        with unittest.mock.patch(
+            "app.services.budget.datetime",
+        ) as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 4, 15, tzinfo=UTC)
+            result = _current_uk_tax_year()
+        assert result == "2026/27"
+
+    def test_april_5_belongs_to_previous_year(self) -> None:
+        """2025-04-05 is still in the 2024/25 tax year."""
+        with unittest.mock.patch(
+            "app.services.budget.datetime",
+        ) as mock_dt:
+            mock_dt.now.return_value = datetime(2025, 4, 5, tzinfo=UTC)
+            result = _current_uk_tax_year()
+        assert result == "2024/25"
+
+    def test_april_6_starts_new_year(self) -> None:
+        """2025-04-06 is in the 2025/26 tax year."""
+        with unittest.mock.patch(
+            "app.services.budget.datetime",
+        ) as mock_dt:
+            mock_dt.now.return_value = datetime(2025, 4, 6, tzinfo=UTC)
+            result = _current_uk_tax_year()
+        assert result == "2025/26"
+
+    def test_january_belongs_to_previous_start_year(self) -> None:
+        """2026-01-15 is in the 2025/26 tax year."""
+        with unittest.mock.patch(
+            "app.services.budget.datetime",
+        ) as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 15, tzinfo=UTC)
+            result = _current_uk_tax_year()
+        assert result == "2025/26"
+
+    def test_century_boundary_format(self) -> None:
+        """2099-12-31 should produce '2099/00'."""
+        with unittest.mock.patch(
+            "app.services.budget.datetime",
+        ) as mock_dt:
+            mock_dt.now.return_value = datetime(2099, 12, 31, tzinfo=UTC)
+            result = _current_uk_tax_year()
+        assert result == "2099/00"

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -487,8 +487,7 @@ class TestComputeBudgetState:
 
         # Tax: total_gains=3500, net_gain=3500, ANNUAL_EXEMPT=3000
         # taxable_net = 3500 - 3000 = 500
-        # scale = 500 / 3500
-        # higher_est = 3500 * 0.24 * (500/3500) = 120.00 (quantized)
+        # higher_est = 500 * 0.24 = 120.00
         assert state.estimated_tax_gbp == Decimal("120.00")
         # tax_usd = 120.00 * 1.25 = 150.0000
         assert state.estimated_tax_usd == Decimal("150.0000")
@@ -541,8 +540,7 @@ class TestComputeBudgetState:
         # cash=100, deployed=50000, mirrors=0, gains=50000, net=50000
         # working_budget = 100 + 50000 + 0 = 50100
         # taxable_net = 50000 - 3000 = 47000
-        # scale = 47000 / 50000
-        # higher_est = 50000 * 0.24 * (47000/50000) = 11280
+        # higher_est = 47000 * 0.24 = 11280
         # tax_usd = 11280 * 1.25 = 14100
         # buffer = 50100 * 0.05 = 2505
         # available = 100 - 14100 - 2505 = -16505
@@ -574,7 +572,7 @@ class TestComputeBudgetState:
             state = compute_budget_state(conn)
 
         assert state.cgt_scenario == "basic"
-        # basic_est = 3500 * 0.18 * (500/3500) = 90.00 (quantized)
+        # basic_est = 500 * 0.18 = 90.00
         assert state.estimated_tax_gbp == Decimal("90.00")
 
 

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,404 @@
+"""
+Tests for app.services.budget.
+
+Covers:
+  - get_budget_config: happy path, missing row -> BudgetConfigCorrupt
+  - update_budget_config: updates config and writes audit, raises on missing
+    singleton, raises when no fields provided, raises when no fields changed
+  - record_capital_event: inserts event and returns it, rejects non-positive amount
+  - list_capital_events: returns events ordered by time, returns empty list
+
+Mock DB approach mirrors test_runtime_config.py.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.budget import (
+    BudgetConfig,
+    BudgetConfigCorrupt,
+    CapitalEvent,
+    get_budget_config,
+    list_capital_events,
+    record_capital_event,
+    update_budget_config,
+)
+
+_NOW = datetime(2026, 4, 15, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_cursor(
+    rows: list[dict[str, Any]] | None = None,
+    single: dict[str, Any] | None = None,
+) -> MagicMock:
+    cur = MagicMock()
+    if single is not None:
+        cur.execute.return_value.fetchone.return_value = single
+        cur.fetchone.return_value = single
+    if rows is not None:
+        cur.execute.return_value.fetchall.return_value = rows
+        cur.fetchall.return_value = rows
+        cur.fetchone.return_value = rows[0] if rows else None
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    return cur
+
+
+def _make_conn(cursors: list[MagicMock]) -> MagicMock:
+    conn = MagicMock()
+    cursor_iter = iter(cursors)
+    conn.cursor.side_effect = lambda **kwargs: next(cursor_iter)
+    conn.execute.return_value = MagicMock(rowcount=1)
+    tx = MagicMock()
+    tx.__enter__ = MagicMock(return_value=tx)
+    tx.__exit__ = MagicMock(return_value=False)
+    conn.transaction.return_value = tx
+    return conn
+
+
+def _config_row(
+    buffer: str = "0.0500",
+    scenario: str = "higher",
+) -> dict[str, Any]:
+    return {
+        "cash_buffer_pct": Decimal(buffer),
+        "cgt_scenario": scenario,
+        "updated_at": _NOW,
+        "updated_by": "seed",
+        "reason": "initial seed",
+    }
+
+
+def _event_row(
+    event_id: int = 1,
+    event_type: str = "injection",
+    amount: str = "5000.00",
+    currency: str = "USD",
+    source: str = "operator",
+    note: str | None = "first deposit",
+    created_by: str | None = "operator",
+) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "event_time": _NOW,
+        "event_type": event_type,
+        "amount": Decimal(amount),
+        "currency": currency,
+        "source": source,
+        "note": note,
+        "created_by": created_by,
+    }
+
+
+# ---------------------------------------------------------------------------
+# TestGetBudgetConfig
+# ---------------------------------------------------------------------------
+
+
+class TestGetBudgetConfig:
+    def test_returns_config_from_db(self) -> None:
+        conn = _make_conn([_make_cursor(rows=[_config_row()])])
+        cfg = get_budget_config(conn)
+        assert isinstance(cfg, BudgetConfig)
+        assert cfg.cash_buffer_pct == Decimal("0.0500")
+        assert cfg.cgt_scenario == "higher"
+        assert cfg.updated_by == "seed"
+        assert cfg.reason == "initial seed"
+        assert cfg.updated_at == _NOW
+
+    def test_missing_row_raises_budget_config_corrupt(self) -> None:
+        conn = _make_conn([_make_cursor(rows=[])])
+        with pytest.raises(BudgetConfigCorrupt, match="missing"):
+            get_budget_config(conn)
+
+    def test_decimal_conversion_avoids_float_precision_loss(self) -> None:
+        row = _config_row(buffer="0.1234")
+        conn = _make_conn([_make_cursor(rows=[row])])
+        cfg = get_budget_config(conn)
+        assert cfg.cash_buffer_pct == Decimal("0.1234")
+        assert isinstance(cfg.cash_buffer_pct, Decimal)
+
+
+# ---------------------------------------------------------------------------
+# TestUpdateBudgetConfig
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateBudgetConfig:
+    def test_raises_when_no_fields_provided(self) -> None:
+        conn = _make_conn([])
+        with pytest.raises(ValueError, match="at least one"):
+            update_budget_config(conn, updated_by="op", reason="r")
+
+    def test_raises_when_singleton_missing(self) -> None:
+        conn = _make_conn([_make_cursor(rows=[])])
+        with pytest.raises(BudgetConfigCorrupt, match="cannot update"):
+            update_budget_config(
+                conn,
+                cash_buffer_pct=Decimal("0.10"),
+                updated_by="op",
+                reason="raise buffer",
+            )
+
+    def test_raises_when_no_fields_changed(self) -> None:
+        conn = _make_conn([_make_cursor(rows=[_config_row()])])
+        with pytest.raises(ValueError, match="no fields changed"):
+            update_budget_config(
+                conn,
+                cash_buffer_pct=Decimal("0.0500"),
+                updated_by="op",
+                reason="noop",
+            )
+
+    def test_updates_cash_buffer_and_writes_audit(self) -> None:
+        # Cursor 1: SELECT FOR UPDATE, Cursor 2: UPDATE RETURNING
+        returning_row = {
+            **_config_row(buffer="0.1000"),
+            "updated_by": "op",
+            "reason": "raise buffer",
+        }
+        cur_select = _make_cursor(rows=[_config_row(buffer="0.0500")])
+        cur_update = _make_cursor(rows=[returning_row])
+        # Make the execute return value have rowcount
+        cur_update.execute.return_value = MagicMock(rowcount=1)
+
+        conn = _make_conn([cur_select, cur_update])
+        cfg = update_budget_config(
+            conn,
+            cash_buffer_pct=Decimal("0.1000"),
+            updated_by="op",
+            reason="raise buffer",
+        )
+
+        assert cfg.cash_buffer_pct == Decimal("0.1000")
+        assert cfg.cgt_scenario == "higher"
+        assert cfg.updated_by == "op"
+
+        # One audit row for cash_buffer_pct
+        assert conn.execute.call_count == 1
+        sql, params = conn.execute.call_args[0]
+        assert "budget_config_audit" in sql
+        assert params["field"] == "cash_buffer_pct"
+        assert params["old"] == "0.0500"
+        assert params["new"] == "0.1000"
+
+    def test_updates_cgt_scenario_and_writes_audit(self) -> None:
+        returning_row = {
+            **_config_row(scenario="basic"),
+            "updated_by": "op",
+            "reason": "switch to basic rate",
+        }
+        cur_select = _make_cursor(rows=[_config_row(scenario="higher")])
+        cur_update = _make_cursor(rows=[returning_row])
+        cur_update.execute.return_value = MagicMock(rowcount=1)
+
+        conn = _make_conn([cur_select, cur_update])
+        cfg = update_budget_config(
+            conn,
+            cgt_scenario="basic",
+            updated_by="op",
+            reason="switch to basic rate",
+        )
+
+        assert cfg.cgt_scenario == "basic"
+        assert conn.execute.call_count == 1
+        sql, params = conn.execute.call_args[0]
+        assert params["field"] == "cgt_scenario"
+        assert params["old"] == "higher"
+        assert params["new"] == "basic"
+
+    def test_updates_both_fields_writes_two_audit_rows(self) -> None:
+        returning_row = {
+            **_config_row(buffer="0.1000", scenario="basic"),
+            "updated_by": "op",
+            "reason": "full change",
+        }
+        cur_select = _make_cursor(rows=[_config_row(buffer="0.0500", scenario="higher")])
+        cur_update = _make_cursor(rows=[returning_row])
+        cur_update.execute.return_value = MagicMock(rowcount=1)
+
+        conn = _make_conn([cur_select, cur_update])
+        cfg = update_budget_config(
+            conn,
+            cash_buffer_pct=Decimal("0.1000"),
+            cgt_scenario="basic",
+            updated_by="op",
+            reason="full change",
+        )
+
+        assert cfg.cash_buffer_pct == Decimal("0.1000")
+        assert cfg.cgt_scenario == "basic"
+
+        # Two audit rows (one per changed field)
+        assert conn.execute.call_count == 2
+        fields = {call[0][1]["field"] for call in conn.execute.call_args_list}
+        assert fields == {"cash_buffer_pct", "cgt_scenario"}
+
+    def test_atomic_via_transaction(self) -> None:
+        returning_row = {**_config_row(buffer="0.1000"), "updated_by": "op", "reason": "r"}
+        cur_select = _make_cursor(rows=[_config_row(buffer="0.0500")])
+        cur_update = _make_cursor(rows=[returning_row])
+        cur_update.execute.return_value = MagicMock(rowcount=1)
+
+        conn = _make_conn([cur_select, cur_update])
+        update_budget_config(
+            conn,
+            cash_buffer_pct=Decimal("0.1000"),
+            updated_by="op",
+            reason="r",
+        )
+
+        conn.transaction.assert_called_once()
+
+    def test_raises_corrupt_when_update_affects_zero_rows(self) -> None:
+        cur_select = _make_cursor(rows=[_config_row()])
+        cur_update = MagicMock()
+        cur_update.__enter__ = MagicMock(return_value=cur_update)
+        cur_update.__exit__ = MagicMock(return_value=False)
+        cur_update.execute.return_value = MagicMock(rowcount=0)
+
+        conn = _make_conn([cur_select, cur_update])
+        with pytest.raises(BudgetConfigCorrupt, match="0 rows"):
+            update_budget_config(
+                conn,
+                cgt_scenario="basic",
+                updated_by="op",
+                reason="vanished",
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestRecordCapitalEvent
+# ---------------------------------------------------------------------------
+
+
+class TestRecordCapitalEvent:
+    def test_inserts_event_and_returns_dataclass(self) -> None:
+        row = _event_row()
+        conn = _make_conn([_make_cursor(rows=[row])])
+        event = record_capital_event(
+            conn,
+            event_type="injection",
+            amount=Decimal("5000.00"),
+            currency="USD",
+            source="operator",
+            note="first deposit",
+            created_by="operator",
+        )
+
+        assert isinstance(event, CapitalEvent)
+        assert event.event_id == 1
+        assert event.event_type == "injection"
+        assert event.amount == Decimal("5000.00")
+        assert event.currency == "USD"
+        assert event.source == "operator"
+        assert event.note == "first deposit"
+        assert event.created_by == "operator"
+        assert event.event_time == _NOW
+
+    def test_rejects_zero_amount(self) -> None:
+        conn = _make_conn([])
+        with pytest.raises(ValueError, match="amount must be positive"):
+            record_capital_event(
+                conn,
+                event_type="injection",
+                amount=Decimal("0"),
+                currency="USD",
+                source="operator",
+                note=None,
+                created_by="op",
+            )
+
+    def test_rejects_negative_amount(self) -> None:
+        conn = _make_conn([])
+        with pytest.raises(ValueError, match="amount must be positive"):
+            record_capital_event(
+                conn,
+                event_type="withdrawal",
+                amount=Decimal("-100"),
+                currency="USD",
+                source="operator",
+                note=None,
+                created_by="op",
+            )
+
+    def test_handles_null_note_and_created_by(self) -> None:
+        row = _event_row(note=None, created_by=None)
+        conn = _make_conn([_make_cursor(rows=[row])])
+        event = record_capital_event(
+            conn,
+            event_type="tax_provision",
+            amount=Decimal("100.00"),
+            currency="GBP",
+            source="system",
+            note=None,
+            created_by=None,
+        )
+        assert event.note is None
+        assert event.created_by is None
+
+    def test_raises_runtime_error_when_returning_produces_none(self) -> None:
+        cur = _make_cursor(rows=[])
+        # Override fetchone to return None (simulating RETURNING producing nothing)
+        cur.fetchone.return_value = None
+        conn = _make_conn([cur])
+        with pytest.raises(RuntimeError, match="RETURNING produced no row"):
+            record_capital_event(
+                conn,
+                event_type="injection",
+                amount=Decimal("100"),
+                currency="USD",
+                source="operator",
+                note=None,
+                created_by="op",
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestListCapitalEvents
+# ---------------------------------------------------------------------------
+
+
+class TestListCapitalEvents:
+    def test_returns_events_ordered_by_time(self) -> None:
+        rows = [
+            _event_row(event_id=2, amount="3000.00", note="second"),
+            _event_row(event_id=1, amount="5000.00", note="first"),
+        ]
+        conn = _make_conn([_make_cursor(rows=rows)])
+        events = list_capital_events(conn)
+
+        assert len(events) == 2
+        assert events[0].event_id == 2
+        assert events[1].event_id == 1
+        assert all(isinstance(e, CapitalEvent) for e in events)
+
+    def test_returns_empty_list_when_no_events(self) -> None:
+        conn = _make_conn([_make_cursor(rows=[])])
+        events = list_capital_events(conn)
+        assert events == []
+
+    def test_passes_limit_and_offset_to_query(self) -> None:
+        cur = _make_cursor(rows=[])
+        conn = _make_conn([cur])
+        list_capital_events(conn, limit=10, offset=20)
+
+        # Verify the cursor received limit and offset in the params dict.
+        sql, params = cur.execute.call_args[0]
+        assert "LIMIT" in sql
+        assert "OFFSET" in sql
+        assert params["limit"] == 10
+        assert params["offset"] == 20
+
+    def test_decimal_conversion_on_returned_events(self) -> None:
+        row = _event_row(amount="1234.567890")
+        conn = _make_conn([_make_cursor(rows=[row])])
+        events = list_capital_events(conn)
+        assert events[0].amount == Decimal("1234.567890")
+        assert isinstance(events[0].amount, Decimal)

--- a/tests/test_execution_guard.py
+++ b/tests/test_execution_guard.py
@@ -7,7 +7,7 @@ Structure:
   - TestCheckCoverage          — _check_coverage
   - TestCheckThesisFreshness   — _check_thesis_freshness
   - TestCheckSpread            — _check_spread
-  - TestCheckCash              — _check_cash
+  - TestCheckBudget            — _check_budget
   - TestCheckConcentration     — _check_concentration
   - TestBuildExplanation       — _build_explanation
   - TestEvaluateRecommendation — end-to-end via evaluate_recommendation with mock DB
@@ -19,40 +19,44 @@ Mock DB approach mirrors test_portfolio.py:
   - conn.execute() is a no-op mock (for UPDATE and INSERT without RETURNING)
   - conn.transaction() is a no-op context manager
 
-Cursor call order inside evaluate_recommendation:
+Cursor call order inside evaluate_recommendation (BUY):
   1. _load_recommendation          — fetchone
   2. _load_kill_switch             — fetchone
   3. get_runtime_config            — fetchone (runtime_config singleton)
   4. _load_coverage                — fetchone
   5. _load_latest_thesis           — fetchone
   6. _load_quote                   — fetchone
-  7. _load_cash                    — fetchone
-  8. _load_sector_exposure         — 4 cursors: instruments, positions,
+  7-12. compute_budget_state       — 6 cursors:
+         budget_config, cash_balance, deployed_capital,
+         mirror_equity, tax_estimates, gbp_usd_rate
+  13. _load_sector_exposure        — 4 cursors: instruments, positions,
                                      cash_ledger, mirror_equity
                                      (the mirror_equity cursor is consumed
                                      by _load_mirror_equity, wired into
                                      total_aum by Track 1b / #187).
-  9. _write_audit                  — 1 cursor (INSERT RETURNING decision_id)
-     + conn.execute (UPDATE status)
+  14. _write_audit                 — 1 cursor (INSERT RETURNING decision_id)
+      + conn.execute (UPDATE status)
 
-Note: for EXIT actions, cursors 4-8 (coverage through sector_exposure) are
+Note: for EXIT actions, cursors 4-14 (coverage through sector_exposure) are
 skipped, so the sequence is shorter.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.services.budget import BudgetState
 from app.services.execution_guard import (
     GuardResult,
     RuleResult,
     _build_explanation,
     _check_auto_trading,
-    _check_cash,
+    _check_budget,
     _check_concentration,
     _check_coverage,
     _check_kill_switch,
@@ -159,8 +163,38 @@ def _quote_cursor(spread_flag: bool | None = False) -> MagicMock:
     return _make_cursor([{"spread_flag": spread_flag}])
 
 
-def _cash_ledger_cursor(balance: float | None = 10_000.0) -> MagicMock:
-    return _make_cursor([{"balance": balance}])
+def _budget_config_cursor() -> MagicMock:
+    return _make_cursor(
+        [
+            {
+                "cash_buffer_pct": Decimal("0.0500"),
+                "cgt_scenario": "higher",
+                "updated_at": _NOW,
+                "updated_by": "system",
+                "reason": "initial seed",
+            }
+        ]
+    )
+
+
+def _budget_cash_cursor(balance: float | None = 10_000.0) -> MagicMock:
+    return _make_cursor([{"balance": Decimal(str(balance)) if balance is not None else None}])
+
+
+def _budget_deployed_cursor(deployed: float = 0.0) -> MagicMock:
+    return _make_cursor([{"deployed": Decimal(str(deployed))}])
+
+
+def _budget_mirror_cursor(equity: float = 0.0) -> MagicMock:
+    return _make_cursor([{"mirror_equity": Decimal(str(equity))}])
+
+
+def _budget_tax_cursor() -> MagicMock:
+    return _make_cursor([{"total_gains": Decimal("0"), "net_gain": Decimal("0")}])
+
+
+def _budget_fx_cursor(rate: float = 1.27) -> MagicMock:
+    return _make_cursor([{"rate": Decimal(str(rate))}])
 
 
 def _sector_cursors(
@@ -197,6 +231,30 @@ def _audit_cursor(decision_id: int = 99) -> MagicMock:
     return _make_cursor([{"decision_id": decision_id}])
 
 
+def _budget_cursors_list(
+    *,
+    cash_balance: float | None = 10_000.0,
+    budget_corrupt: bool = False,
+) -> list[MagicMock]:
+    """Return the cursor sequence consumed by compute_budget_state.
+
+    When budget_corrupt=True, budget_config returns no rows which
+    triggers BudgetConfigCorrupt.  Otherwise 6 cursors are returned:
+    budget_config, cash_balance, deployed_capital, mirror_equity,
+    tax_estimates, gbp_usd_rate.
+    """
+    if budget_corrupt:
+        return [_make_cursor([])]  # empty budget_config -> BudgetConfigCorrupt
+    return [
+        _budget_config_cursor(),
+        _budget_cash_cursor(balance=cash_balance),
+        _budget_deployed_cursor(),
+        _budget_mirror_cursor(),
+        _budget_tax_cursor(),
+        _budget_fx_cursor(),
+    ]
+
+
 def _buy_cursors(
     *,
     ks_active: bool = False,
@@ -208,6 +266,7 @@ def _buy_cursors(
     thesis_age_days: int = 3,
     spread_flag: bool | None = False,
     cash_balance: float | None = 10_000.0,
+    budget_corrupt: bool = False,
     sector: str | None = "Technology",
     sector_mv: float = 0.0,
     total_positions: float = 0.0,
@@ -228,7 +287,7 @@ def _buy_cursors(
         _coverage_cursor(tier=coverage_tier, frequency=coverage_frequency),
         _thesis_cursor(age_days=thesis_age_days),
         _quote_cursor(spread_flag=spread_flag),
-        _cash_ledger_cursor(balance=cash_balance),
+        *_budget_cursors_list(cash_balance=cash_balance, budget_corrupt=budget_corrupt),
         *_sector_cursors(
             sector=sector,
             sector_market_value=sector_mv,
@@ -424,30 +483,50 @@ class TestCheckSpread:
 
 
 # ---------------------------------------------------------------------------
-# TestCheckCash
+# TestCheckBudget
 # ---------------------------------------------------------------------------
 
 
-class TestCheckCash:
-    def test_none_cash_fails(self) -> None:
-        result = _check_cash(None)
-        assert result.passed is False
-        assert result.rule == "cash_unknown"
+class TestCheckBudget:
+    def _budget(
+        self,
+        available: Decimal | None = Decimal("9250"),
+        cash: Decimal | None = Decimal("10000"),
+    ) -> BudgetState:
+        return BudgetState(
+            cash_balance=cash,
+            deployed_capital=Decimal("5000"),
+            mirror_equity=Decimal("0"),
+            working_budget=Decimal("15000") if cash is not None else None,
+            estimated_tax_gbp=Decimal("0"),
+            estimated_tax_usd=Decimal("0"),
+            gbp_usd_rate=Decimal("1.27"),
+            cash_buffer_reserve=Decimal("750"),
+            available_for_deployment=available,
+            cash_buffer_pct=Decimal("0.05"),
+            cgt_scenario="higher",
+            tax_year="2025/26",
+        )
 
-    def test_zero_cash_fails(self) -> None:
-        # Zero means no buying power — block BUY/ADD
-        result = _check_cash(0.0)
-        assert result.passed is False
-        assert result.rule == "cash_unknown"
-
-    def test_negative_cash_fails(self) -> None:
-        result = _check_cash(-1.0)
-        assert result.passed is False
-        assert result.rule == "cash_unknown"
-
-    def test_positive_cash_passes(self) -> None:
-        result = _check_cash(5_000.0)
+    def test_positive_available_passes(self) -> None:
+        result = _check_budget(self._budget(available=Decimal("9250")))
         assert result.passed is True
+        assert result.rule == "budget_available"
+
+    def test_none_available_fails(self) -> None:
+        result = _check_budget(self._budget(available=None, cash=None))
+        assert result.passed is False
+        assert result.rule == "budget_available"
+
+    def test_zero_available_fails(self) -> None:
+        result = _check_budget(self._budget(available=Decimal("0")))
+        assert result.passed is False
+        assert result.rule == "budget_available"
+
+    def test_negative_available_fails(self) -> None:
+        result = _check_budget(self._budget(available=Decimal("-7450")))
+        assert result.passed is False
+        assert "budget exhausted" in result.detail
 
 
 # ---------------------------------------------------------------------------
@@ -502,11 +581,11 @@ class TestBuildExplanation:
     def test_single_failure_named(self) -> None:
         results = [
             RuleResult(rule="kill_switch", passed=True),
-            RuleResult(rule="cash_unknown", passed=False, detail="ledger empty"),
+            RuleResult(rule="budget_available", passed=False, detail="ledger empty"),
         ]
         explanation = _build_explanation(results)
         assert "FAIL" in explanation
-        assert "cash_unknown" in explanation
+        assert "budget_available" in explanation
         assert "ledger empty" in explanation
 
     def test_multiple_failures_all_listed(self) -> None:
@@ -663,21 +742,27 @@ class TestEvaluateRecommendation:
         result = self._eval(_exit_cursors())
         assert result.verdict == "PASS"
 
-    # --- Cash ---
+    # --- Budget ---
 
-    def test_cash_unknown_fails_buy(self) -> None:
+    def test_budget_unavailable_fails_buy(self) -> None:
         cursors = _buy_cursors(cash_balance=None)
         result = self._eval(cursors)
         assert result.verdict == "FAIL"
-        assert "cash_unknown" in result.failed_rules
+        assert "budget_available" in result.failed_rules
 
-    def test_zero_cash_fails_buy(self) -> None:
+    def test_zero_cash_budget_exhausted_fails_buy(self) -> None:
         cursors = _buy_cursors(cash_balance=0.0)
         result = self._eval(cursors)
         assert result.verdict == "FAIL"
-        assert "cash_unknown" in result.failed_rules
+        assert "budget_available" in result.failed_rules
 
-    def test_cash_unknown_does_not_fail_exit(self) -> None:
+    def test_budget_config_corrupt_fails_buy(self) -> None:
+        cursors = _buy_cursors(budget_corrupt=True)
+        result = self._eval(cursors)
+        assert result.verdict == "FAIL"
+        assert "budget_available" in result.failed_rules
+
+    def test_budget_does_not_fail_exit(self) -> None:
         result = self._eval(_exit_cursors())
         assert result.verdict == "PASS"
 


### PR DESCRIPTION
## Summary

Adds a working-budget concept to eBull — the system now tracks how much capital is truly available for deployment, accounting for estimated tax liability and a configurable cash buffer reserve.

**Closes #203**

## What changed

### Schema (migration 027)
- `capital_events` — ledger for operator deposits, withdrawals, and system tax provisions. Amount is always positive; `event_type` carries directional semantics. CHECK constraints on event_type, source, and amount > 0.
- `budget_config` — singleton (same pattern as `runtime_config`) with `cash_buffer_pct` (default 5%) and `cgt_scenario` (basic/higher rate, default higher). Seeded with safe defaults.
- `budget_config_audit` — per-field audit trail for config changes.

### Service (`app/services/budget.py`)
Pure service module computing budget state on the fly from 5+ existing tables:
- `compute_budget_state(conn)` reads `budget_config`, `cash_ledger`, `positions`, `copy_mirrors`, `disposal_matches`, and `live_fx_rates`
- **Core formula:** `available_for_deployment = cash_balance - estimated_tax_usd - cash_buffer_reserve`
- Tax estimates use current-year CGT rates (18% basic, 24% higher) after annual exempt amount (£3,000), converted GBP→USD via `live_fx_rates`
- `record_capital_event()` / `list_capital_events()` for operator deposits/withdrawals
- `get_budget_config()` / `update_budget_config()` with per-field audit trail in same transaction

### API (`app/api/budget.py`)
Five endpoints, all requiring operator auth:
- `GET /budget` — full budget state snapshot
- `GET /budget/events` — paginated capital event history
- `POST /budget/events` — record injection/withdrawal (201)
- `GET /budget/config` — current budget config
- `PATCH /budget/config` — partial update with audit

### Execution guard integration
- Replaced raw `_check_cash(cash > 0)` with `_check_budget(available_for_deployment > 0)`
- BUY/ADD now fail when budget is exhausted (tax + buffer reserves exceed cash)
- `BudgetConfigCorrupt` → fail closed (explicit FAIL rule, not silent pass)
- Rule name changed: `cash_unknown` → `budget_available`
- `_load_cash` preserved — still used by `_load_sector_exposure` for AUM

## Security model

- All budget endpoints protected by `require_session_or_service_token`
- Only `injection` and `withdrawal` are operator-creatable via API; `tax_provision` and `tax_release` are system-only (enforced by Pydantic `Literal`)
- BudgetConfigCorrupt always maps to fixed-phrase 503 detail — no exception text leakage
- Budget config audit in same transaction as UPDATE (prevention: audit reads outside transaction)
- `amount > 0` DB constraint + service-level validation — no negative-amount injection possible

## Conscious tradeoffs

1. **No auto-detection of capital changes during broker sync** — deferred to follow-up PR. For now, operator manually records deposits/withdrawals via API. The budget computation still works correctly with raw cash from `cash_ledger`.
2. **Order client sizing unchanged** — still uses raw cash × `suggested_size_pct`. The execution guard is the enforcement point. Follow-up will size from `available_for_deployment`.
3. **Simplified tax estimates** — uses current-year flat CGT rates rather than per-disposal weighted rates from `tax_year_summary()`. Sufficient for budget estimates; tax ledger remains authoritative.
4. **No FX rate → zero tax provision** — if GBP→USD rate is missing, tax provision is treated as 0 with a warning log. This avoids blocking all trades on missing FX data. Conservative in the wrong direction but prevents total paralysis.
5. **Budget state computed on every read** — no caching/snapshots. Fresh state is correct; stale state is dangerous. Dashboard queries are infrequent enough that this is fine.

## Settled decisions preserved

| Decision | How preserved |
|----------|--------------|
| Cash semantics (positive=inflow, negative=outflow) | Budget reads `SUM(cash_ledger.amount)` unchanged |
| Unknown cash blocks execution | `available_for_deployment=None` → guard FAIL |
| AUM basis (MTM first, cost basis fallback) | Deployed capital uses existing positions table |
| Guard auditability | Budget rule detail carries full snapshot |
| Guard re-check | Budget computed fresh inside guard |

## Prevention log entries addressed

- Audit reads outside transaction → `update_budget_config` reads+writes in one `conn.transaction()`
- Zero-unit position inflates AUM → `WHERE current_units > 0`
- Single-row UPDATE no-op → `rowcount == 0` check
- Mid-transaction commit → service never calls `conn.commit()`
- Dead-code None-guard → aggregate None-check on column, not row

## Test plan

- [ ] 30 budget service tests (types, config, events, compute_budget_state, tax year)
- [ ] 71 execution guard tests (including 4 new budget-aware tests)
- [ ] 8 execute_approved_orders tests (unchanged, verify no regression)
- [ ] Smoke test passes (app boots with migration 027)
- [ ] Full suite: 1406 passed, 1 skipped
- [ ] Lint, format, typecheck all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)