### PR TITLE
fix(#210): mirror equity — DRY budget.py, 3-tier pricing, smoke test, sync sanity check

### DIFF
--- a/app/services/budget.py
+++ b/app/services/budget.py
@@ -30,6 +30,7 @@ import psycopg
 import psycopg.rows
 from psycopg import sql
 
+from app.services.portfolio import _load_mirror_equity
 from app.services.tax_ledger import ANNUAL_EXEMPT
 
 logger = logging.getLogger(__name__)
@@ -427,35 +428,6 @@ def _load_deployed_capital(conn: psycopg.Connection[Any]) -> Decimal:
     return Decimal(str(row["deployed"]))
 
 
-def _load_mirror_equity(conn: psycopg.Connection[Any]) -> Decimal:
-    """Load total equity held in active copy mirrors.
-
-    Mirror equity = active mirrors' available_amount + their positions'
-    current_value.  Returns ``Decimal("0")`` if no mirrors exist.
-    """
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            """
-            SELECT COALESCE(
-                (SELECT COALESCE(SUM(cm.available_amount), 0)
-                 FROM copy_mirrors cm
-                 WHERE cm.status = 'active')
-                +
-                (SELECT COALESCE(SUM(cmp.current_value), 0)
-                 FROM copy_mirror_positions cmp
-                 JOIN copy_mirrors cm2 ON cm2.mirror_id = cmp.mirror_id
-                 WHERE cm2.status = 'active'),
-                0
-            ) AS mirror_equity
-            """
-        )
-        row = cur.fetchone()
-
-    if row is None:
-        return _ZERO  # defensive; should never happen
-    return Decimal(str(row["mirror_equity"]))
-
-
 def _load_tax_estimates(
     conn: psycopg.Connection[Any],
     tax_year: str,
@@ -529,7 +501,7 @@ def compute_budget_state(conn: psycopg.Connection[Any]) -> BudgetState:
 
     cash_balance = _load_cash_balance(conn)
     deployed_capital = _load_deployed_capital(conn)
-    mirror_equity = _load_mirror_equity(conn)
+    mirror_equity = Decimal(str(_load_mirror_equity(conn)))
 
     # working_budget = cash + deployed + mirrors (None if cash is unknown)
     if cash_balance is not None:

--- a/app/services/portfolio.py
+++ b/app/services/portfolio.py
@@ -296,6 +296,11 @@ def _load_mirror_equity(conn: psycopg.Connection[Any]) -> float:
     the aggregate could go negative too. Callers sum this
     directly into `total_aum` without assuming positivity.
 
+    Pricing uses the same 3-tier hierarchy as `load_mirror_breakdowns`:
+    live quote → most-recent daily close → position open rate.
+    This ensures budget state and dashboard AUM agree when quotes
+    are absent but `price_daily` has data.
+
     This helper does NOT open its own transaction; it reads
     under the caller's scope, matching `_load_cash` /
     `_load_positions`.
@@ -311,7 +316,7 @@ def _load_mirror_equity(conn: psycopg.Connection[Any]) -> float:
                       cmp.amount
                     + (CASE WHEN cmp.is_buy THEN 1 ELSE -1 END)
                       * cmp.units
-                      * (COALESCE(q.last, cmp.open_rate) - cmp.open_rate)
+                      * (COALESCE(q.last, pd.close, cmp.open_rate) - cmp.open_rate)
                       * cmp.open_conversion_rate
                 ) AS mv
                 FROM copy_mirror_positions cmp
@@ -322,6 +327,14 @@ def _load_mirror_equity(conn: psycopg.Connection[Any]) -> float:
                     ORDER BY quoted_at DESC
                     LIMIT 1
                 ) q ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT close
+                    FROM price_daily
+                    WHERE instrument_id = cmp.instrument_id
+                      AND close IS NOT NULL
+                    ORDER BY price_date DESC
+                    LIMIT 1
+                ) pd ON TRUE
                 WHERE cmp.mirror_id = m.mirror_id
             ) p ON TRUE
             WHERE m.active

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -474,6 +474,48 @@ def _sync_mirrors(
     return mirrors_upserted, mirror_positions_upserted, mirrors_closed
 
 
+def _validate_mirror_equity(conn: psycopg.Connection[Any]) -> None:
+    """Log a warning if any mirror's equity looks inconsistent.
+
+    For each active mirror, compare:
+      funded = initial_investment + deposit_summary - withdrawal_summary
+      equity = available_amount + sum(position amounts)
+
+    If equity > 2× funded for any mirror, something is likely wrong
+    (double-counting, stale data, or missing quote coverage).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("""
+            SELECT m.mirror_id, m.available_amount,
+                   m.initial_investment + m.deposit_summary
+                     - m.withdrawal_summary AS funded,
+                   COALESCE(p.total_amount, 0) AS positions_total
+            FROM copy_mirrors m
+            LEFT JOIN (
+                SELECT mirror_id, SUM(amount) AS total_amount
+                FROM copy_mirror_positions
+                GROUP BY mirror_id
+            ) p USING (mirror_id)
+            WHERE m.active
+        """)
+        rows = cur.fetchall()
+
+    for r in rows:
+        equity = float(r["available_amount"]) + float(r["positions_total"])
+        funded = float(r["funded"])
+        if funded > 0 and equity > 2 * funded:
+            logger.warning(
+                "Mirror %s equity (%.2f) > 2× funded (%.2f) — "
+                "possible double-count in available_amount; "
+                "equity=available(%.2f)+positions(%.2f)",
+                r["mirror_id"],
+                equity,
+                funded,
+                float(r["available_amount"]),
+                float(r["positions_total"]),
+            )
+
+
 def sync_portfolio(
     conn: psycopg.Connection[Any],
     portfolio: BrokerPortfolio,
@@ -694,6 +736,8 @@ def sync_portfolio(
 
     # 4. Reconcile copy-trading mirrors (spec §2.3).
     mirrors_upserted, mirror_positions_upserted, mirrors_closed = _sync_mirrors(conn, portfolio.mirrors, now)
+
+    _validate_mirror_equity(conn)
 
     return PortfolioSyncResult(
         positions_updated=updated,

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -501,18 +501,20 @@ def _validate_mirror_equity(conn: psycopg.Connection[Any]) -> None:
         rows = cur.fetchall()
 
     for r in rows:
-        equity = float(r["available_amount"]) + float(r["positions_total"])
-        funded = float(r["funded"])
+        available = Decimal(str(r["available_amount"]))
+        positions = Decimal(str(r["positions_total"]))
+        funded = Decimal(str(r["funded"]))
+        equity = available + positions
         if funded > 0 and equity > 2 * funded:
             logger.warning(
-                "Mirror %s equity (%.2f) > 2× funded (%.2f) — "
+                "Mirror %s equity (%s) > 2× funded (%s) — "
                 "possible double-count in available_amount; "
-                "equity=available(%.2f)+positions(%.2f)",
+                "equity=available(%s)+positions(%s)",
                 r["mirror_id"],
                 equity,
                 funded,
-                float(r["available_amount"]),
-                float(r["positions_total"]),
+                available,
+                positions,
             )
 
 

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -671,3 +671,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `capital_events.currency` was a free-text TEXT column with no CHECK constraint. While SQL injection is blocked by parameterized queries, arbitrary strings persisting in domain columns violate the enum-style semantics.
 - Prevention: Before merge, `grep 'TEXT NOT NULL' sql/0*.sql` on new migrations and confirm each user-supplied column has either a CHECK constraint or an enum type. On the API model side, use `Literal["a", "b"]` instead of `str` for columns with constrained values.
 - Enforced in: `sql/027_budget_capital.sql` (`chk_capital_events_currency`); `app/api/budget.py` (`Literal["USD", "GBP"]`)
+
+---
+
+### Dependency override save/restore must not gate on `value is not None`
+
+- First seen in: #234 (review BLOCKING 2)
+- Symptom: Smoke test saved a `dependency_overrides` entry with `pop(key, None)`, then only restored it when `saved is not None`. If the override was explicitly set to `None` (a valid FastAPI override value), the restore was skipped, permanently deleting the entry for subsequent tests.
+- Prevention: When saving and restoring `app.dependency_overrides` entries, track presence separately (`had_key = key in overrides`) and restore unconditionally when the key was present. Do not use the value itself as a presence sentinel.
+- Enforced in: `tests/smoke/test_app_boots.py` (`had_get_conn` / `saved_get_conn` pattern)

--- a/tests/smoke/test_app_boots.py
+++ b/tests/smoke/test_app_boots.py
@@ -135,6 +135,20 @@ def test_app_lifespan_boots_and_state_is_coherent() -> None:
         if hasattr(app.state, flag):
             delattr(app.state, flag)
 
+    # Other test modules register mock dependency_overrides at import
+    # time (the ``setdefault(get_conn, _fallback_conn)`` pattern used
+    # by every test_api_*.py file).  When pytest collects those modules
+    # before this smoke test, the mock replaces the real ``get_conn``
+    # dependency — and endpoint requests inside the TestClient hit the
+    # mock's empty result iterator instead of the real DB.  Remove the
+    # ``get_conn`` override for the duration of this test so endpoint
+    # requests use the real connection pool opened by the lifespan.
+    # The auth no-op override (installed by conftest.py) must remain.
+    from app.db import get_conn
+
+    had_get_conn = get_conn in app.dependency_overrides
+    saved_get_conn = app.dependency_overrides.pop(get_conn, None)
+
     try:
         with TestClient(app) as client:
             # Lifespan must have populated every flag the rest of the
@@ -192,6 +206,11 @@ def test_app_lifespan_boots_and_state_is_coherent() -> None:
         # test had not run. On the failure path (lifespan crashed
         # mid-startup) restoration is the whole point: subsequent
         # tests should not inherit a half-deleted state.
+        # Restore the get_conn override so subsequent tests that rely on
+        # the module-level ``setdefault`` pattern still see their mock.
+        if had_get_conn and saved_get_conn is not None:
+            app.dependency_overrides[get_conn] = saved_get_conn
+
         for flag, value in snapshot.items():
             if value is _SENTINEL:
                 if hasattr(app.state, flag):

--- a/tests/smoke/test_app_boots.py
+++ b/tests/smoke/test_app_boots.py
@@ -171,6 +171,17 @@ def test_app_lifespan_boots_and_state_is_coherent() -> None:
             # came up but the app object itself is broken.
             resp = client.get("/health")
             assert resp.status_code == 200, resp.text
+
+            # /budget exercises the full SQL path in compute_budget_state
+            # against the real schema. This catches column-name mismatches
+            # (e.g. referencing cm.status or cmp.current_value when the
+            # actual columns have different names) that mock-based unit
+            # tests silently miss because they never run real SQL.
+            # budget_config is seeded by migration 027 so the singleton
+            # row is always present on a migrated dev DB.
+            resp = client.get("/budget")
+            assert resp.status_code == 200, resp.text
+            assert "available_for_deployment" in resp.json()
     finally:
         # Restore the snapshot regardless of how the body exited.
         # On the success path TestClient's exit hook has already run

--- a/tests/smoke/test_app_boots.py
+++ b/tests/smoke/test_app_boots.py
@@ -208,8 +208,8 @@ def test_app_lifespan_boots_and_state_is_coherent() -> None:
         # tests should not inherit a half-deleted state.
         # Restore the get_conn override so subsequent tests that rely on
         # the module-level ``setdefault`` pattern still see their mock.
-        if had_get_conn and saved_get_conn is not None:
-            app.dependency_overrides[get_conn] = saved_get_conn
+        if had_get_conn:
+            app.dependency_overrides[get_conn] = saved_get_conn  # type: ignore[assignment]
 
         for flag, value in snapshot.items():
             if value is _SENTINEL:

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -430,20 +430,24 @@ def _budget_conn(
     config_row: dict[str, Any] | None = None,
     cash_balance: Decimal | None = Decimal("10000"),
     deployed: Decimal = Decimal("5000"),
-    mirror_equity: Decimal = Decimal("2000"),
+    mirror_equity: float = 2000.0,
     total_gains: Decimal = Decimal("3500"),
     net_gain: Decimal = Decimal("3500"),
     gbp_usd_rate: Decimal | None = Decimal("1.25"),
-) -> MagicMock:
+) -> tuple[MagicMock, float]:
     """Build a mock connection for compute_budget_state.
 
-    Cursor order:
+    _load_mirror_equity is now imported from portfolio.py and must be patched
+    by callers via ``unittest.mock.patch("app.services.budget._load_mirror_equity")``.
+    This helper returns (conn, mirror_equity_float) so callers can supply the
+    patch return_value.
+
+    Cursor order (5 cursors — mirror_equity consumed by patched function):
       0: budget_config (get_budget_config)
       1: cash_balance (_load_cash_balance)
       2: deployed_capital (_load_deployed_capital)
-      3: mirror_equity (_load_mirror_equity)
-      4: tax estimates (_load_tax_estimates)
-      5: gbp_usd rate (_load_gbp_usd_rate)
+      3: tax estimates (_load_tax_estimates)
+      4: gbp_usd rate (_load_gbp_usd_rate)
     """
     if config_row is None:
         config_row = _budget_config_row()
@@ -451,7 +455,6 @@ def _budget_conn(
     cur_config = _make_cursor(single=config_row)
     cur_cash = _make_cursor(single={"balance": cash_balance})
     cur_deployed = _make_cursor(single={"deployed": deployed})
-    cur_mirrors = _make_cursor(single={"mirror_equity": mirror_equity})
     cur_tax = _make_cursor(
         single={"total_gains": total_gains, "net_gain": net_gain},
     )
@@ -462,7 +465,7 @@ def _budget_conn(
         cur_fx = _make_cursor()
         cur_fx.fetchone.return_value = None
 
-    return _make_conn([cur_config, cur_cash, cur_deployed, cur_mirrors, cur_tax, cur_fx])
+    return _make_conn([cur_config, cur_cash, cur_deployed, cur_tax, cur_fx]), mirror_equity
 
 
 class TestComputeBudgetState:
@@ -472,10 +475,16 @@ class TestComputeBudgetState:
         rate=1.25 → tax_usd=150, buffer=5% of 17000=850,
         available=10000-150-850=9000.
         """
-        conn = _budget_conn()
-        with unittest.mock.patch(
-            "app.services.budget._current_uk_tax_year",
-            return_value="2025/26",
+        conn, mirror_val = _budget_conn()
+        with (
+            unittest.mock.patch(
+                "app.services.budget._current_uk_tax_year",
+                return_value="2025/26",
+            ),
+            unittest.mock.patch(
+                "app.services.budget._load_mirror_equity",
+                return_value=mirror_val,
+            ),
         ):
             state = compute_budget_state(conn)
 
@@ -506,10 +515,16 @@ class TestComputeBudgetState:
         """When cash_ledger SUM is NULL, cash_balance=None,
         working_budget=None, available=None.
         """
-        conn = _budget_conn(cash_balance=None)
-        with unittest.mock.patch(
-            "app.services.budget._current_uk_tax_year",
-            return_value="2025/26",
+        conn, mirror_val = _budget_conn(cash_balance=None)
+        with (
+            unittest.mock.patch(
+                "app.services.budget._current_uk_tax_year",
+                return_value="2025/26",
+            ),
+            unittest.mock.patch(
+                "app.services.budget._load_mirror_equity",
+                return_value=mirror_val,
+            ),
         ):
             state = compute_budget_state(conn)
 
@@ -520,11 +535,15 @@ class TestComputeBudgetState:
 
     def test_no_fx_rate_uses_zero_tax(self) -> None:
         """When GBP->USD rate is None, tax_usd=0 and a warning is logged."""
-        conn = _budget_conn(gbp_usd_rate=None)
+        conn, mirror_val = _budget_conn(gbp_usd_rate=None)
         with (
             unittest.mock.patch(
                 "app.services.budget._current_uk_tax_year",
                 return_value="2025/26",
+            ),
+            unittest.mock.patch(
+                "app.services.budget._load_mirror_equity",
+                return_value=mirror_val,
             ),
             unittest.mock.patch("app.services.budget.logger") as mock_logger,
         ):
@@ -544,16 +563,22 @@ class TestComputeBudgetState:
         # tax_usd = 11280 * 1.25 = 14100
         # buffer = 50100 * 0.05 = 2505
         # available = 100 - 14100 - 2505 = -16505
-        conn = _budget_conn(
+        conn, mirror_val = _budget_conn(
             cash_balance=Decimal("100"),
             deployed=Decimal("50000"),
-            mirror_equity=Decimal("0"),
+            mirror_equity=0.0,
             total_gains=Decimal("50000"),
             net_gain=Decimal("50000"),
         )
-        with unittest.mock.patch(
-            "app.services.budget._current_uk_tax_year",
-            return_value="2025/26",
+        with (
+            unittest.mock.patch(
+                "app.services.budget._current_uk_tax_year",
+                return_value="2025/26",
+            ),
+            unittest.mock.patch(
+                "app.services.budget._load_mirror_equity",
+                return_value=mirror_val,
+            ),
         ):
             state = compute_budget_state(conn)
 
@@ -562,12 +587,18 @@ class TestComputeBudgetState:
 
     def test_basic_cgt_scenario_uses_basic_estimate(self) -> None:
         """When cgt_scenario='basic', the basic rate (18%) is used."""
-        conn = _budget_conn(
+        conn, mirror_val = _budget_conn(
             config_row=_budget_config_row(scenario="basic"),
         )
-        with unittest.mock.patch(
-            "app.services.budget._current_uk_tax_year",
-            return_value="2025/26",
+        with (
+            unittest.mock.patch(
+                "app.services.budget._current_uk_tax_year",
+                return_value="2025/26",
+            ),
+            unittest.mock.patch(
+                "app.services.budget._load_mirror_equity",
+                return_value=mirror_val,
+            ),
         ):
             state = compute_budget_state(conn)
 

--- a/tests/test_execution_guard.py
+++ b/tests/test_execution_guard.py
@@ -186,7 +186,7 @@ def _budget_deployed_cursor(deployed: float = 0.0) -> MagicMock:
 
 
 def _budget_mirror_cursor(equity: float = 0.0) -> MagicMock:
-    return _make_cursor([{"mirror_equity": Decimal(str(equity))}])
+    return _make_cursor([{"total": equity}])
 
 
 def _budget_tax_cursor() -> MagicMock:
@@ -240,8 +240,15 @@ def _budget_cursors_list(
 
     When budget_corrupt=True, budget_config returns no rows which
     triggers BudgetConfigCorrupt.  Otherwise 6 cursors are returned:
-    budget_config, cash_balance, deployed_capital, mirror_equity,
-    tax_estimates, gbp_usd_rate.
+      0: budget_config (get_budget_config)
+      1: cash_balance (_load_cash_balance)
+      2: deployed_capital (_load_deployed_capital)
+      3: mirror_equity (consumed by portfolio._load_mirror_equity call-through)
+      4: tax_estimates (_load_tax_estimates)
+      5: gbp_usd_rate (_load_gbp_usd_rate)
+
+    Note: test_budget.py patches _load_mirror_equity directly (5 cursors),
+    so its _budget_conn() helper omits cursor 3.
     """
     if budget_corrupt:
         return [_make_cursor([])]  # empty budget_config -> BudgetConfigCorrupt

--- a/tests/test_execution_guard.py
+++ b/tests/test_execution_guard.py
@@ -186,7 +186,7 @@ def _budget_deployed_cursor(deployed: float = 0.0) -> MagicMock:
 
 
 def _budget_mirror_cursor(equity: float = 0.0) -> MagicMock:
-    return _make_cursor([{"total": equity}])
+    return _make_cursor([{"total": Decimal(str(equity))}])
 
 
 def _budget_tax_cursor() -> MagicMock:

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -14,6 +14,7 @@ from app.services.portfolio_sync import (
     PortfolioSyncResult,
     _aggregate_by_instrument,
     _upsert_broker_positions,
+    _validate_mirror_equity,
     sync_portfolio,
 )
 from tests.fixtures.copy_mirrors import _NOW
@@ -896,3 +897,74 @@ class TestBrokerPositionsInSyncPortfolio:
         assert result.positions_updated == 1
         assert result.broker_positions_upserted == 0
         assert result.broker_positions_deleted == 0
+
+
+# ---------------------------------------------------------------------------
+# _validate_mirror_equity — sanity check after sync
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMirrorEquity:
+    """Tests for the post-sync mirror equity sanity check."""
+
+    @staticmethod
+    def _make_conn(rows: list[dict[str, Any]]) -> MagicMock:
+        cur = MagicMock()
+        cur.fetchall.return_value = rows
+        cur.__enter__ = MagicMock(return_value=cur)
+        cur.__exit__ = MagicMock(return_value=False)
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        return conn
+
+    def test_warns_on_overstatement(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When equity > 2× funded, a warning is logged."""
+        import logging
+
+        rows = [
+            {
+                "mirror_id": 42,
+                "available_amount": 5000.0,
+                "funded": 1000.0,
+                "positions_total": 3000.0,
+            },
+        ]
+        conn = self._make_conn(rows)
+        with caplog.at_level(logging.WARNING):
+            _validate_mirror_equity(conn)
+        assert "possible double-count" in caplog.text
+        assert "42" in caplog.text
+
+    def test_no_warning_when_equity_is_normal(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When equity is within 2× funded, no warning is logged."""
+        import logging
+
+        rows = [
+            {
+                "mirror_id": 1,
+                "available_amount": 300.0,
+                "funded": 1000.0,
+                "positions_total": 700.0,
+            },
+        ]
+        conn = self._make_conn(rows)
+        with caplog.at_level(logging.WARNING):
+            _validate_mirror_equity(conn)
+        assert "possible double-count" not in caplog.text
+
+    def test_skips_zero_funded(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Zero-funded mirrors should not trigger false positives."""
+        import logging
+
+        rows = [
+            {
+                "mirror_id": 99,
+                "available_amount": 100.0,
+                "funded": 0.0,
+                "positions_total": 0.0,
+            },
+        ]
+        conn = self._make_conn(rows)
+        with caplog.at_level(logging.WARNING):
+            _validate_mirror_equity(conn)
+        assert "possible double-count" not in caplog.text

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -924,9 +924,9 @@ class TestValidateMirrorEquity:
         rows = [
             {
                 "mirror_id": 42,
-                "available_amount": 5000.0,
-                "funded": 1000.0,
-                "positions_total": 3000.0,
+                "available_amount": Decimal("5000"),
+                "funded": Decimal("1000"),
+                "positions_total": Decimal("3000"),
             },
         ]
         conn = self._make_conn(rows)
@@ -942,9 +942,9 @@ class TestValidateMirrorEquity:
         rows = [
             {
                 "mirror_id": 1,
-                "available_amount": 300.0,
-                "funded": 1000.0,
-                "positions_total": 700.0,
+                "available_amount": Decimal("300"),
+                "funded": Decimal("1000"),
+                "positions_total": Decimal("700"),
             },
         ]
         conn = self._make_conn(rows)
@@ -959,9 +959,9 @@ class TestValidateMirrorEquity:
         rows = [
             {
                 "mirror_id": 99,
-                "available_amount": 100.0,
-                "funded": 0.0,
-                "positions_total": 0.0,
+                "available_amount": Decimal("100"),
+                "funded": Decimal("0"),
+                "positions_total": Decimal("0"),
             },
         ]
         conn = self._make_conn(rows)


### PR DESCRIPTION
## What changed

Closes #210. Five commits addressing the mirror equity overstatement investigation:

1. **`app/services/budget.py`** — Removed broken `_load_mirror_equity()` that referenced non-existent columns (`cm.status`, `cmp.current_value`). Budget now imports the canonical version from `portfolio.py` and wraps the `float` return in `Decimal(str(...))`.

2. **`app/services/portfolio.py`** — Added `price_daily` as a middle tier in `_load_mirror_equity`'s pricing fallback: `COALESCE(q.last, pd.close, cmp.open_rate)`. This aligns with `load_mirror_breakdowns` so budget state and dashboard AUM agree when quotes are absent but daily close data exists.

3. **`tests/smoke/test_app_boots.py`** — Added `GET /budget` assertion to the smoke test (catches column-name mismatches that mock tests miss). Fixed a test-ordering bug where module-level `setdefault(get_conn, _fallback_conn)` overrides from `test_api_*.py` files leaked into the smoke test, replacing the real DB connection with an exhausted mock iterator (`StopIteration`).

4. **`app/services/portfolio_sync.py`** — Added `_validate_mirror_equity()` called after `_sync_mirrors`. Logs a warning when any mirror's computed equity exceeds 2× its funded capital, catching likely double-counting at sync time.

5. **`tests/test_budget.py`, `tests/test_execution_guard.py`, `tests/test_portfolio_sync.py`** — Updated mock cursor sequences (6→5 cursors in budget tests, since mirror equity is now patched rather than cursor-fed). Added 3 tests for the new validation function.

## Why

The operator dashboard showed AUM ~£27k higher than eToro's actual total value. Investigation (5 diagnostic SQL queries against dev DB) found the mirror data is **not corrupt** — equity/funded ratios are 99.3–99.7%. The overstatement root cause is #209 (missing quotes): the `quotes` table has 0 rows and `price_daily` covers only 5 direct-position instruments, so all 385 mirror positions fall back to cost basis (`open_rate`), which hides unrealized losses.

This PR fixes **code-level bugs** found during the investigation (broken column references, inconsistent pricing tiers) and adds **observability** (smoke test, sync sanity check). The actual AUM correction will resolve when #209 delivers real-time quotes for mirror instruments.

## Schema / migration impact

None.

## Invariants checked

- `_load_mirror_equity` single source of truth in `portfolio.py` — budget and dashboard use the same function
- 3-tier pricing hierarchy (`quote → price_daily → open_rate`) consistent across `_load_mirror_equity` and `load_mirror_breakdowns`
- Smoke test clears only the `get_conn` override, preserving the auth no-op from conftest
- `_validate_mirror_equity` is read-only (no writes), safe to add to the sync path
- No external I/O inside transactions

## Failure paths considered

- Empty `copy_mirrors` table → `COALESCE(SUM(...), 0)` returns 0, validation loop skips
- Zero-funded mirrors → `funded > 0` guard prevents false-positive warnings
- Missing `price_daily` rows → COALESCE falls through to `open_rate` (cost basis)
- Smoke test `get_conn` not in overrides → `pop(..., None)` is a no-op; restore skipped

## Tests added

- `TestValidateMirrorEquity::test_warns_on_overstatement` — equity > 2× funded triggers warning log
- `TestValidateMirrorEquity::test_no_warning_when_equity_is_normal` — normal equity produces no warning
- `TestValidateMirrorEquity::test_skips_zero_funded` — zero-funded mirrors don't trigger false positives
- Smoke test: `GET /budget` returns 200 with `available_for_deployment` in body
- All 5 existing budget tests updated to patch `_load_mirror_equity` directly

## Conscious tradeoffs

- The sanity check uses `SUM(amount)` (cost basis) not MTM — it's a cheap heuristic for detecting >2× overstatement, not a precision tool. MTM-based checks would duplicate the equity calculation.
- Did not fix the 12 test modules' `setdefault(get_conn, _fallback_conn)` pattern globally — each module independently owns its mock setup. The smoke test pops the override locally instead.

## Tech debt opened

None — #209 is already tracked and covers the root cause (missing quotes).