### PR TITLE
fix(#209): stale MTM — inline instrumentIds URL, add quote-staleness warning

### DIFF
--- a/app/providers/implementations/etoro.py
+++ b/app/providers/implementations/etoro.py
@@ -161,9 +161,11 @@ class EtoroMarketDataProvider(MarketDataProvider):
             chunk = instrument_ids[i : i + _RATES_BATCH_SIZE]
             ids_param = ",".join(str(id_) for id_ in chunk)
             try:
+                # Build the query string inline instead of via params={}
+                # so the comma in "1181,1699" is not percent-encoded.
+                # httpx encodes commas as %2C which eToro rejects with 500.
                 response = self._http.get(
-                    "/api/v1/market-data/instruments/rates",
-                    params={"instrumentIds": ids_param},
+                    f"/api/v1/market-data/instruments/rates?instrumentIds={ids_param}",
                     headers=self._request_headers(),
                 )
                 response.raise_for_status()

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1608,6 +1608,13 @@ def fx_rates_refresh() -> None:
                                     exc_info=True,
                                 )
                         conn.commit()
+
+                        if quotes_updated == 0:
+                            logger.warning(
+                                "fx_rates_refresh: 0 quotes written for %d covered instruments"
+                                " — quote staleness will degrade mark-to-market valuations",
+                                len(instrument_ids),
+                            )
                     else:
                         logger.info("fx_rates_refresh: no covered instruments for eToro quotes")
             except Exception:

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -368,11 +368,11 @@ class TestGetQuotesChunking:
             assert provider._http.get.call_count == 2
             # First call: 50 IDs inlined in URL
             first_url = provider._http.get.call_args_list[0].args[0]
-            first_ids = first_url.split("instrumentIds=")[1]
+            first_ids = first_url.split("instrumentIds=")[1].split("&")[0]
             assert len(first_ids.split(",")) == 50
             # Second call: 1 ID
             second_url = provider._http.get.call_args_list[1].args[0]
-            second_ids = second_url.split("instrumentIds=")[1]
+            second_ids = second_url.split("instrumentIds=")[1].split("&")[0]
             assert len(second_ids.split(",")) == 1
 
     @patch("app.providers.implementations.etoro._persist_raw")

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -332,7 +332,7 @@ class TestGetQuotesChunking:
 
     @patch("app.providers.implementations.etoro._persist_raw")
     def test_single_batch_params(self, _mock_persist: MagicMock) -> None:
-        """instrumentIds param is comma-separated ints."""
+        """instrumentIds are inlined in the URL with raw commas (not percent-encoded)."""
         from app.providers.implementations.etoro import EtoroMarketDataProvider
 
         mock_resp = MagicMock()
@@ -346,8 +346,8 @@ class TestGetQuotesChunking:
             provider.get_quotes([1001, 1002, 1003])
 
             provider._http.get.assert_called_once()
-            call_kwargs = provider._http.get.call_args
-            assert call_kwargs.kwargs["params"]["instrumentIds"] == "1001,1002,1003"
+            url_arg = provider._http.get.call_args.args[0]
+            assert "instrumentIds=1001,1002,1003" in url_arg
 
     @patch("app.providers.implementations.etoro._persist_raw")
     def test_chunking_at_51_ids(self, _mock_persist: MagicMock) -> None:
@@ -366,12 +366,14 @@ class TestGetQuotesChunking:
             provider.get_quotes(ids)
 
             assert provider._http.get.call_count == 2
-            # First call: 50 IDs
-            first_params = provider._http.get.call_args_list[0].kwargs["params"]["instrumentIds"]
-            assert len(first_params.split(",")) == 50
+            # First call: 50 IDs inlined in URL
+            first_url = provider._http.get.call_args_list[0].args[0]
+            first_ids = first_url.split("instrumentIds=")[1]
+            assert len(first_ids.split(",")) == 50
             # Second call: 1 ID
-            second_params = provider._http.get.call_args_list[1].kwargs["params"]["instrumentIds"]
-            assert len(second_params.split(",")) == 1
+            second_url = provider._http.get.call_args_list[1].args[0]
+            second_ids = second_url.split("instrumentIds=")[1]
+            assert len(second_ids.split(",")) == 1
 
     @patch("app.providers.implementations.etoro._persist_raw")
     def test_failed_chunk_does_not_poison_others(self, _mock_persist: MagicMock) -> None:


### PR DESCRIPTION
## What changed

Two commits on `fix/209-stale-mtm-missing-quotes`:

1. **`app/providers/implementations/etoro.py`** — Changed the rates endpoint call from `params={"instrumentIds": ids_param}` to an inline URL query string (`f"...?instrumentIds={ids_param}"`). httpx percent-encodes commas as `%2C` in the `params` dict; eToro's API rejects `%2C` with a 500. Raw commas in the URL work.

2. **`app/workers/scheduler.py`** — Added a WARNING log when `quotes_updated == 0` but covered Tier 1/2 instruments exist. Previously the job reported `success` with `row_count=2` (only ECB FX pairs), giving the operator no signal that the entire quote pipeline was silently failing.

3. **`tests/test_market_data.py`** — Updated `test_single_batch_params` and `test_chunking_at_51_ids` to assert on URL content instead of the now-removed `params` dict.

## Why

Issue #209: the `fx_rates_refresh` job was producing 0 quotes for all Tier 1/2 instruments. Root cause: httpx percent-encodes commas in query parameter values (`instrumentIds=1181%2C1699`), and eToro rejects that with HTTP 500.

Downstream impact: with 0 quotes in the `quotes` table, the `COALESCE(q.last, pd.close, cmp.open_rate)` pricing hierarchy in portfolio valuation fell through to `open_rate` (cost basis), hiding unrealised P&L movements and degrading mark-to-market accuracy.

Verified fix live: all 5 Tier 1 instruments (BBBY, GME, IEP, QQQ, VOO) now return real bid/ask/last prices from the eToro rates endpoint.

## Schema / migration impact

None.

## Invariants checked

- **Provider stays thin:** URL construction fix only — no domain logic added to the provider.
- **Batch chunking preserved:** 50-ID chunks still work; tests verify 50+1 split.
- **Partial failure tolerance preserved:** Failed chunks still log and continue; surviving chunks still return quotes.
- **`ids_param` is safe for URL interpolation:** Built from `str(int)` values joined with commas — no user-controlled input.

## Failure paths considered

- **Empty instrument list:** `get_quotes([])` returns `[]` immediately (existing guard, unchanged).
- **Single-chunk failure:** Logged, skipped, remaining chunks proceed (existing behaviour, unchanged).
- **Zero quotes despite covered instruments:** Now surfaces a WARNING log naming the MTM impact.
- **No eToro credentials:** Phase 2 skips gracefully (existing behaviour, unchanged).

## Tests added

- `test_single_batch_params`: Verifies `instrumentIds=1001,1002,1003` appears in the URL with raw commas (not in a `params` dict).
- `test_chunking_at_51_ids`: Verifies the 50-ID chunk boundary produces two calls with correct ID counts extracted from the URL.

Both tests updated from the prior `params` dict assertions to URL string assertions.

## Conscious tradeoffs

- **No dashboard-level staleness indicator:** Issue #209 mentions a "data freshness indicator on the dashboard when quotes are older than a threshold." That's a frontend feature — out of scope for this fix PR. The WARNING log provides operator visibility via the existing log pipeline.
- **`tracker.row_count` still combines FX + quotes:** The combined count is accurate (it's a count of rows written). The zero-quote case now has a separate WARNING log, so the operator can distinguish "2 FX pairs, 0 quotes" from "2 FX pairs, 5 quotes" without changing the tracker semantics.

## Tech debt opened

None.

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)