### PR TITLE
feat(#233): budget dashboard UI — overview panel, config controls, deployment card

### DIFF
--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -680,3 +680,21 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: Smoke test saved a `dependency_overrides` entry with `pop(key, None)`, then only restored it when `saved is not None`. If the override was explicitly set to `None` (a valid FastAPI override value), the restore was skipped, permanently deleting the entry for subsequent tests.
 - Prevention: When saving and restoring `app.dependency_overrides` entries, track presence separately (`had_key = key in overrides`) and restore unconditionally when the key was present. Do not use the value itself as a presence sentinel.
 - Enforced in: `tests/smoke/test_app_boots.py` (`had_get_conn` / `saved_get_conn` pattern)
+
+---
+
+### Loose `string` on API response fields that mirror backend `Literal` types
+
+- First seen in: #236 (review WARNING 3)
+- Symptom: `types.ts` used `string` for `cgt_scenario`, `event_type`, `currency`, and `source` fields instead of literal unions. This erodes exhaustiveness checks — callers that destructure the response lose compile-time validation of discriminated values.
+- Prevention: When adding a new interface to `types.ts`, if the backend Pydantic model uses `Literal["a", "b"]` for a field, use the matching union type in the TS interface. Grep `types.ts` for bare `string` on fields that correspond to constrained columns.
+- Enforced in: `frontend/src/api/types.ts` (`BudgetStateResponse`, `CapitalEventResponse`, `BudgetConfigResponse`)
+
+---
+
+### Infinity/out-of-range numeric inputs bypass `Number.isNaN` guards
+
+- First seen in: #236 (review WARNING 4)
+- Symptom: `"1e308"` → `Number("1e308")` → `Infinity`; `Infinity` is not `NaN`, so `Number.isNaN(Infinity)` returns `false`, passing the guard and sending `amount: Infinity` to the backend.
+- Prevention: Use `Number.isFinite(v)` instead of `!Number.isNaN(v)` for numeric input validation before API submission. `isFinite` rejects both `NaN` and `±Infinity`.
+- Enforced in: `frontend/src/components/settings/BudgetConfigSection.tsx` (event amount guard)

--- a/frontend/src/api/budget.ts
+++ b/frontend/src/api/budget.ts
@@ -1,0 +1,49 @@
+import { apiFetch } from "@/api/client";
+import type {
+  BudgetConfigResponse,
+  BudgetStateResponse,
+  CapitalEventResponse,
+} from "@/api/types";
+
+export function fetchBudget(): Promise<BudgetStateResponse> {
+  return apiFetch<BudgetStateResponse>("/budget");
+}
+
+export function fetchBudgetConfig(): Promise<BudgetConfigResponse> {
+  return apiFetch<BudgetConfigResponse>("/budget/config");
+}
+
+export function fetchCapitalEvents(
+  limit = 50,
+  offset = 0,
+): Promise<CapitalEventResponse[]> {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    offset: String(offset),
+  });
+  return apiFetch<CapitalEventResponse[]>(`/budget/events?${params}`);
+}
+
+export function createCapitalEvent(body: {
+  event_type: "injection" | "withdrawal";
+  amount: number;
+  currency?: "USD" | "GBP";
+  note?: string;
+}): Promise<CapitalEventResponse> {
+  return apiFetch<CapitalEventResponse>("/budget/events", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function updateBudgetConfig(body: {
+  cash_buffer_pct?: number;
+  cgt_scenario?: "basic" | "higher";
+  updated_by: string;
+  reason: string;
+}): Promise<BudgetConfigResponse> {
+  return apiFetch<BudgetConfigResponse>("/budget/config", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -571,3 +571,41 @@ export interface MirrorDetailResponse {
   mirror: MirrorSummary;
   display_currency: string;
 }
+
+// ---------------------------------------------------------------------------
+// Budget (mirrors app/api/budget.py)
+// ---------------------------------------------------------------------------
+
+export interface BudgetStateResponse {
+  cash_balance: number | null;
+  deployed_capital: number;
+  mirror_equity: number;
+  working_budget: number | null;
+  estimated_tax_gbp: number;
+  estimated_tax_usd: number;
+  gbp_usd_rate: number | null;
+  cash_buffer_reserve: number;
+  available_for_deployment: number | null;
+  cash_buffer_pct: number;
+  cgt_scenario: string;
+  tax_year: string;
+}
+
+export interface CapitalEventResponse {
+  event_id: number;
+  event_time: string;
+  event_type: string;
+  amount: number;
+  currency: string;
+  source: string;
+  note: string | null;
+  created_by: string | null;
+}
+
+export interface BudgetConfigResponse {
+  cash_buffer_pct: number;
+  cgt_scenario: string;
+  updated_at: string;
+  updated_by: string;
+  reason: string;
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -587,24 +587,24 @@ export interface BudgetStateResponse {
   cash_buffer_reserve: number;
   available_for_deployment: number | null;
   cash_buffer_pct: number;
-  cgt_scenario: string;
+  cgt_scenario: "basic" | "higher";
   tax_year: string;
 }
 
 export interface CapitalEventResponse {
   event_id: number;
   event_time: string;
-  event_type: string;
+  event_type: "injection" | "withdrawal" | "tax_provision" | "tax_release";
   amount: number;
-  currency: string;
-  source: string;
+  currency: "USD" | "GBP";
+  source: "operator" | "system" | "broker_sync";
   note: string | null;
   created_by: string | null;
 }
 
 export interface BudgetConfigResponse {
   cash_buffer_pct: number;
-  cgt_scenario: string;
+  cgt_scenario: "basic" | "higher";
   updated_at: string;
   updated_by: string;
   reason: string;

--- a/frontend/src/components/dashboard/BudgetOverviewPanel.tsx
+++ b/frontend/src/components/dashboard/BudgetOverviewPanel.tsx
@@ -1,0 +1,76 @@
+import type { BudgetStateResponse } from "@/api/types";
+import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
+import { formatMoney, formatPct } from "@/lib/format";
+import { SectionSkeleton } from "@/components/dashboard/Section";
+
+/**
+ * Read-only budget overview for the Dashboard sidebar.
+ *
+ * Shows working budget breakdown, cash buffer, tax provision, and tax year.
+ * Fetched via an independent `useAsync(fetchBudget)` in DashboardPage —
+ * loading / error / data states are handled per the async-data-loading skill.
+ */
+export function BudgetOverviewPanel({
+  budget,
+  loading,
+  hasError,
+  onRetry,
+}: {
+  budget: BudgetStateResponse | null;
+  loading: boolean;
+  hasError: boolean;
+  onRetry: () => void;
+}) {
+  const currency = useDisplayCurrency();
+
+  if (hasError) {
+    return (
+      <div
+        role="alert"
+        className="flex items-center justify-between rounded border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-700"
+      >
+        <span>/budget failed to load.</span>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded border border-red-300 bg-white px-2 py-0.5 text-[10px] font-medium text-red-700 hover:bg-red-100"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (loading || budget === null) {
+    return <SectionSkeleton rows={5} />;
+  }
+
+  return (
+    <div className="space-y-3">
+      <dl className="space-y-2 text-sm">
+        <Row label="Working budget" value={formatMoney(budget.working_budget, currency)} />
+        <Row label="Cash balance" value={formatMoney(budget.cash_balance, currency)} />
+        <Row label="Deployed capital" value={formatMoney(budget.deployed_capital, currency)} />
+        <Row label="Mirror equity" value={formatMoney(budget.mirror_equity, currency)} />
+        <Row
+          label={`Cash buffer (${formatPct(budget.cash_buffer_pct)})`}
+          value={formatMoney(budget.cash_buffer_reserve, currency)}
+        />
+        <Row
+          label={`Tax provision (${budget.cgt_scenario})`}
+          value={`${formatMoney(budget.estimated_tax_gbp, "GBP")} / ${formatMoney(budget.estimated_tax_usd, "USD")}`}
+        />
+        <Row label="Tax year" value={budget.tax_year} />
+      </dl>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-4">
+      <dt className="text-slate-500">{label}</dt>
+      <dd className="shrink-0 text-right tabular-nums text-slate-700">{value}</dd>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/SummaryCards.tsx
+++ b/frontend/src/components/dashboard/SummaryCards.tsx
@@ -19,9 +19,11 @@ import { SectionSkeleton } from "@/components/dashboard/Section";
 export function SummaryCards({
   data,
   budgetData,
+  budgetError,
 }: {
   data: PortfolioResponse | null;
   budgetData: BudgetStateResponse | null;
+  budgetError?: boolean;
 }) {
   const currency = useDisplayCurrency();
   if (data === null) {
@@ -64,19 +66,25 @@ export function SummaryCards({
         hint={pnlFraction === null ? undefined : formatPct(pnlFraction)}
         tone={totalPnl >= 0 ? "positive" : "negative"}
       />
-      <DeploymentCard budget={budgetData} currency={currency} />
+      <DeploymentCard budget={budgetData} budgetError={budgetError} currency={currency} />
     </div>
   );
 }
 
 function DeploymentCard({
   budget,
+  budgetError,
   currency,
 }: {
   budget: BudgetStateResponse | null;
+  budgetError?: boolean;
   currency: string;
 }) {
   if (budget === null) {
+    // Distinguish "still loading" (skeleton) from "failed" (dash + hint).
+    if (budgetError) {
+      return <Card label="Available for deployment" value="—" hint="Budget unavailable" />;
+    }
     return (
       <div className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
         <SectionSkeleton rows={2} />

--- a/frontend/src/components/dashboard/SummaryCards.tsx
+++ b/frontend/src/components/dashboard/SummaryCards.tsx
@@ -1,4 +1,4 @@
-import type { PortfolioResponse } from "@/api/types";
+import type { BudgetStateResponse, PortfolioResponse } from "@/api/types";
 import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
 import { formatMoney, formatPct, pnlPct } from "@/lib/format";
 import { SectionSkeleton } from "@/components/dashboard/Section";
@@ -16,12 +16,18 @@ import { SectionSkeleton } from "@/components/dashboard/Section";
  * sum-of-cost-basis (capital-weighted), not an average of per-position
  * percentages.
  */
-export function SummaryCards({ data }: { data: PortfolioResponse | null }) {
+export function SummaryCards({
+  data,
+  budgetData,
+}: {
+  data: PortfolioResponse | null;
+  budgetData: BudgetStateResponse | null;
+}) {
   const currency = useDisplayCurrency();
   if (data === null) {
     return (
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        {[0, 1, 2].map((i) => (
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {[0, 1, 2, 3].map((i) => (
           <div key={i} className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
             <SectionSkeleton rows={2} />
           </div>
@@ -45,7 +51,7 @@ export function SummaryCards({ data }: { data: PortfolioResponse | null }) {
   const pnlFraction = pnlPct(totalPnl, totalCost);
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
       <Card label="Total AUM" value={formatMoney(data.total_aum, currency)} />
       <Card
         label="Cash balance"
@@ -58,7 +64,48 @@ export function SummaryCards({ data }: { data: PortfolioResponse | null }) {
         hint={pnlFraction === null ? undefined : formatPct(pnlFraction)}
         tone={totalPnl >= 0 ? "positive" : "negative"}
       />
+      <DeploymentCard budget={budgetData} currency={currency} />
     </div>
+  );
+}
+
+function DeploymentCard({
+  budget,
+  currency,
+}: {
+  budget: BudgetStateResponse | null;
+  currency: string;
+}) {
+  if (budget === null) {
+    return (
+      <div className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+        <SectionSkeleton rows={2} />
+      </div>
+    );
+  }
+
+  const available = budget.available_for_deployment;
+  const isNull = available === null;
+  const isLow =
+    !isNull &&
+    budget.working_budget !== null &&
+    budget.working_budget > 0 &&
+    available / budget.working_budget < 0.05;
+  const isNegative = !isNull && available < 0;
+
+  const tone: "positive" | "negative" | undefined = isNull
+    ? undefined
+    : isNegative || isLow
+      ? "negative"
+      : "positive";
+
+  return (
+    <Card
+      label="Available for deployment"
+      value={isNull ? "—" : formatMoney(available, currency)}
+      hint={isNull ? "Cash unknown" : isLow ? "Low deployment capital" : undefined}
+      tone={tone}
+    />
   );
 }
 

--- a/frontend/src/components/settings/BudgetConfigSection.test.tsx
+++ b/frontend/src/components/settings/BudgetConfigSection.test.tsx
@@ -1,0 +1,357 @@
+/**
+ * Tests for BudgetConfigSection (#233).
+ *
+ * Scope:
+ *   - Config controls display correct values after fraction → percentage
+ *     conversion (backend stores 0.05, input shows 5)
+ *   - Save button disabled when no field changed or reason is empty
+ *   - Save sends only changed fields, converting percentage back to fraction
+ *   - Save error surfaces the alert banner
+ *   - Capital event form validation and submission
+ *   - Capital events history table renders rows
+ *   - Empty-state for no capital events
+ *
+ * The API client is mocked at the module boundary.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { BudgetConfigSection } from "@/components/settings/BudgetConfigSection";
+import {
+  createCapitalEvent,
+  fetchBudgetConfig,
+  fetchCapitalEvents,
+  updateBudgetConfig,
+} from "@/api/budget";
+import type {
+  BudgetConfigResponse,
+  CapitalEventResponse,
+} from "@/api/types";
+
+vi.mock("@/api/budget", () => ({
+  fetchBudgetConfig: vi.fn(),
+  fetchCapitalEvents: vi.fn(),
+  updateBudgetConfig: vi.fn(),
+  createCapitalEvent: vi.fn(),
+}));
+
+const mockedFetchConfig = vi.mocked(fetchBudgetConfig);
+const mockedFetchEvents = vi.mocked(fetchCapitalEvents);
+const mockedUpdateConfig = vi.mocked(updateBudgetConfig);
+const mockedCreateEvent = vi.mocked(createCapitalEvent);
+
+function configResponse(
+  overrides: Partial<BudgetConfigResponse> = {},
+): BudgetConfigResponse {
+  return {
+    cash_buffer_pct: 0.05,
+    cgt_scenario: "higher",
+    updated_at: "2026-04-15T10:00:00Z",
+    updated_by: "system",
+    reason: "initial seed",
+    ...overrides,
+  };
+}
+
+function eventResponse(
+  overrides: Partial<CapitalEventResponse> = {},
+): CapitalEventResponse {
+  return {
+    event_id: 1,
+    event_time: "2026-04-15T10:00:00Z",
+    event_type: "injection",
+    amount: 5000,
+    currency: "USD",
+    source: "operator",
+    note: null,
+    created_by: "operator",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockedFetchConfig.mockReset();
+  mockedFetchEvents.mockReset();
+  mockedUpdateConfig.mockReset();
+  mockedCreateEvent.mockReset();
+  mockedFetchConfig.mockResolvedValue(configResponse());
+  mockedFetchEvents.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Config controls — display
+// ---------------------------------------------------------------------------
+
+describe("BudgetConfigSection — config display", () => {
+  it("converts fraction to percentage for the buffer input (0.05 → 5)", async () => {
+    render(<BudgetConfigSection />);
+    const input = await screen.findByLabelText("Cash buffer %");
+    expect(input).toHaveValue(5);
+  });
+
+  it("displays the CGT scenario from the server", async () => {
+    render(<BudgetConfigSection />);
+    const select = await screen.findByLabelText("CGT scenario");
+    expect(select).toHaveValue("higher");
+  });
+
+  it("shows section heading", async () => {
+    render(<BudgetConfigSection />);
+    expect(
+      await screen.findByText("Budget Configuration"),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config controls — save button state
+// ---------------------------------------------------------------------------
+
+describe("BudgetConfigSection — save button", () => {
+  it("is disabled when no field has been changed", async () => {
+    render(<BudgetConfigSection />);
+    // Wait for config to load and form to appear
+    await screen.findByLabelText("Cash buffer %");
+    const btn = screen.getByRole("button", { name: "Save config" });
+    expect(btn).toBeDisabled();
+  });
+
+  it("is disabled when reason is empty even if a field changed", async () => {
+    const user = userEvent.setup();
+    render(<BudgetConfigSection />);
+    const input = await screen.findByLabelText("Cash buffer %");
+    await user.clear(input);
+    await user.type(input, "10");
+    const btn = screen.getByRole("button", { name: "Save config" });
+    expect(btn).toBeDisabled();
+  });
+
+  it("is enabled when a field changed AND reason is provided", async () => {
+    const user = userEvent.setup();
+    render(<BudgetConfigSection />);
+    const input = await screen.findByLabelText("Cash buffer %");
+    await user.clear(input);
+    await user.type(input, "10");
+    await user.type(
+      screen.getByPlaceholderText("Why are you changing this?"),
+      "test reason",
+    );
+    const btn = screen.getByRole("button", { name: "Save config" });
+    expect(btn).toBeEnabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config controls — save behaviour
+// ---------------------------------------------------------------------------
+
+describe("BudgetConfigSection — save", () => {
+  it("converts percentage back to fraction when saving (10 → 0.10)", async () => {
+    mockedUpdateConfig.mockResolvedValueOnce(
+      configResponse({ cash_buffer_pct: 0.1 }),
+    );
+    const user = userEvent.setup();
+    render(<BudgetConfigSection />);
+
+    const input = await screen.findByLabelText("Cash buffer %");
+    await user.clear(input);
+    await user.type(input, "10");
+    await user.type(
+      screen.getByPlaceholderText("Why are you changing this?"),
+      "increasing buffer",
+    );
+    await user.click(screen.getByRole("button", { name: "Save config" }));
+
+    await waitFor(() => {
+      expect(mockedUpdateConfig).toHaveBeenCalledOnce();
+    });
+    expect(mockedUpdateConfig).toHaveBeenCalledWith({
+      cash_buffer_pct: 0.1,
+      cgt_scenario: undefined,
+      updated_by: "operator",
+      reason: "increasing buffer",
+    });
+  });
+
+  it("sends only changed fields (scenario changed, buffer unchanged)", async () => {
+    mockedUpdateConfig.mockResolvedValueOnce(
+      configResponse({ cgt_scenario: "basic" }),
+    );
+    const user = userEvent.setup();
+    render(<BudgetConfigSection />);
+
+    await screen.findByLabelText("Cash buffer %");
+    await user.selectOptions(screen.getByLabelText("CGT scenario"), "basic");
+    await user.type(
+      screen.getByPlaceholderText("Why are you changing this?"),
+      "switching scenario",
+    );
+    await user.click(screen.getByRole("button", { name: "Save config" }));
+
+    await waitFor(() => {
+      expect(mockedUpdateConfig).toHaveBeenCalledOnce();
+    });
+    expect(mockedUpdateConfig).toHaveBeenCalledWith({
+      cash_buffer_pct: undefined,
+      cgt_scenario: "basic",
+      updated_by: "operator",
+      reason: "switching scenario",
+    });
+  });
+
+  it("shows success message after save", async () => {
+    mockedUpdateConfig.mockResolvedValueOnce(
+      configResponse({ cash_buffer_pct: 0.1 }),
+    );
+    const user = userEvent.setup();
+    render(<BudgetConfigSection />);
+
+    const input = await screen.findByLabelText("Cash buffer %");
+    await user.clear(input);
+    await user.type(input, "10");
+    await user.type(
+      screen.getByPlaceholderText("Why are you changing this?"),
+      "test",
+    );
+    await user.click(screen.getByRole("button", { name: "Save config" }));
+
+    expect(
+      await screen.findByText("Budget config updated."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error alert when save fails", async () => {
+    mockedUpdateConfig.mockRejectedValueOnce(new Error("network error"));
+    const user = userEvent.setup();
+    render(<BudgetConfigSection />);
+
+    const input = await screen.findByLabelText("Cash buffer %");
+    await user.clear(input);
+    await user.type(input, "10");
+    await user.type(
+      screen.getByPlaceholderText("Why are you changing this?"),
+      "test",
+    );
+    await user.click(screen.getByRole("button", { name: "Save config" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /Failed to save budget config/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capital event form
+// ---------------------------------------------------------------------------
+
+describe("BudgetConfigSection — capital event form", () => {
+  it("Record event button is disabled when amount is empty", async () => {
+    render(<BudgetConfigSection />);
+    await screen.findByLabelText("Cash buffer %");
+    const btn = screen.getByRole("button", { name: "Record event" });
+    expect(btn).toBeDisabled();
+  });
+
+  it("submits a capital event with the correct payload", async () => {
+    mockedCreateEvent.mockResolvedValueOnce(
+      eventResponse({ amount: 1000, currency: "GBP", note: "test deposit" }),
+    );
+    const user = userEvent.setup();
+    render(<BudgetConfigSection />);
+
+    await screen.findByLabelText("Cash buffer %");
+    await user.type(screen.getByLabelText("Amount"), "1000");
+    await user.selectOptions(screen.getByLabelText("Currency"), "GBP");
+    await user.type(screen.getByLabelText("Note (optional)"), "test deposit");
+    await user.click(screen.getByRole("button", { name: "Record event" }));
+
+    await waitFor(() => {
+      expect(mockedCreateEvent).toHaveBeenCalledOnce();
+    });
+    expect(mockedCreateEvent).toHaveBeenCalledWith({
+      event_type: "injection",
+      amount: 1000,
+      currency: "GBP",
+      note: "test deposit",
+    });
+  });
+
+  it("shows success message after recording an event", async () => {
+    mockedCreateEvent.mockResolvedValueOnce(eventResponse());
+    const user = userEvent.setup();
+    render(<BudgetConfigSection />);
+
+    await screen.findByLabelText("Cash buffer %");
+    await user.type(screen.getByLabelText("Amount"), "500");
+    await user.click(screen.getByRole("button", { name: "Record event" }));
+
+    expect(
+      await screen.findByText("Capital event recorded."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error alert when event creation fails", async () => {
+    mockedCreateEvent.mockRejectedValueOnce(new Error("server error"));
+    const user = userEvent.setup();
+    render(<BudgetConfigSection />);
+
+    await screen.findByLabelText("Cash buffer %");
+    await user.type(screen.getByLabelText("Amount"), "500");
+    await user.click(screen.getByRole("button", { name: "Record event" }));
+
+    const alerts = await screen.findAllByRole("alert");
+    const eventAlert = alerts.find((a) =>
+      a.textContent?.includes("Failed to record capital event"),
+    );
+    expect(eventAlert).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capital events history
+// ---------------------------------------------------------------------------
+
+describe("BudgetConfigSection — events history", () => {
+  it("shows empty state when no events exist", async () => {
+    render(<BudgetConfigSection />);
+    expect(
+      await screen.findByText("No capital events recorded yet."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders event rows in the history table", async () => {
+    mockedFetchEvents.mockResolvedValueOnce([
+      eventResponse({
+        event_id: 1,
+        event_type: "injection",
+        amount: 5000,
+        currency: "USD",
+        note: "initial deposit",
+      }),
+      eventResponse({
+        event_id: 2,
+        event_type: "withdrawal",
+        amount: 1000,
+        currency: "GBP",
+        note: null,
+      }),
+    ]);
+    render(<BudgetConfigSection />);
+
+    // Wait for the table to render — "injection" and "withdrawal" also
+    // appear in the form's Type dropdown, so use getAllByText and check
+    // that the table added at least one extra occurrence.
+    expect(await screen.findByText("initial deposit")).toBeInTheDocument();
+    // "injection" appears in the dropdown option + table row = 2+
+    expect(screen.getAllByText("injection").length).toBeGreaterThanOrEqual(2);
+    // "withdrawal" appears in the dropdown option + table row = 2+
+    expect(screen.getAllByText("withdrawal").length).toBeGreaterThanOrEqual(2);
+    // Null note renders as dash
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/frontend/src/components/settings/BudgetConfigSection.tsx
+++ b/frontend/src/components/settings/BudgetConfigSection.tsx
@@ -26,9 +26,15 @@ export function BudgetConfigSection() {
   const [configSuccess, setConfigSuccess] = useState(false);
   const [configError, setConfigError] = useState(false);
 
-  // Derive displayed values: local override > server value > default
-  const displayedBufferPct =
-    cashBufferPct ?? config.data?.cash_buffer_pct ?? 10;
+  // Derive displayed values: local override > server value > default.
+  // Backend stores cash_buffer_pct as a fraction (0.05 = 5%); the input
+  // operates on a percentage scale so we multiply by 100 for display and
+  // divide by 100 when sending.
+  const serverBufferPct =
+    config.data?.cash_buffer_pct != null
+      ? Math.round(config.data.cash_buffer_pct * 100)
+      : null;
+  const displayedBufferPct = cashBufferPct ?? serverBufferPct ?? 5;
   const displayedCgtScenario =
     cgtScenario ??
     (config.data?.cgt_scenario === "higher" ? "higher" : "basic");
@@ -39,9 +45,15 @@ export function BudgetConfigSection() {
     setConfigError(false);
     setConfigSuccess(false);
     try {
+      // Only send fields that actually changed — the backend rejects
+      // no-op patches with 422 "no fields changed".
+      const bufferChanged = cashBufferPct !== null;
+      const scenarioChanged = cgtScenario !== null;
+
       await updateBudgetConfig({
-        cash_buffer_pct: displayedBufferPct,
-        cgt_scenario: displayedCgtScenario,
+        // Convert percentage (display) back to fraction (API).
+        cash_buffer_pct: bufferChanged ? displayedBufferPct / 100 : undefined,
+        cgt_scenario: scenarioChanged ? displayedCgtScenario : undefined,
         updated_by: "operator",
         reason: configReason,
       });
@@ -101,6 +113,7 @@ export function BudgetConfigSection() {
   }
 
   const configReasonMissing = configReason.trim().length === 0;
+  const configNothingChanged = cashBufferPct === null && cgtScenario === null;
   const eventAmountInvalid =
     eventAmount === "" || Number.isNaN(Number(eventAmount)) || Number(eventAmount) <= 0;
 
@@ -178,7 +191,7 @@ export function BudgetConfigSection() {
 
               <button
                 type="submit"
-                disabled={configSaving || configReasonMissing}
+                disabled={configSaving || configReasonMissing || configNothingChanged}
                 className="rounded bg-slate-800 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {configSaving ? "Saving..." : "Save config"}

--- a/frontend/src/components/settings/BudgetConfigSection.tsx
+++ b/frontend/src/components/settings/BudgetConfigSection.tsx
@@ -154,7 +154,7 @@ export function BudgetConfigSection() {
                     step={1}
                     value={displayedBufferPct}
                     onChange={(e) => {
-                      const val = Number(e.target.value);
+                      const val = Math.min(50, Math.max(0, Number(e.target.value)));
                       setCashBufferPct(val === serverBufferPct ? null : val);
                     }}
                     disabled={configSaving}

--- a/frontend/src/components/settings/BudgetConfigSection.tsx
+++ b/frontend/src/components/settings/BudgetConfigSection.tsx
@@ -1,0 +1,353 @@
+import { useState } from "react";
+import type { FormEvent } from "react";
+import {
+  createCapitalEvent,
+  fetchBudgetConfig,
+  fetchCapitalEvents,
+  updateBudgetConfig,
+} from "@/api/budget";
+import type { CapitalEventResponse } from "@/api/types";
+import { SectionSkeleton, SectionError } from "@/components/dashboard/Section";
+import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
+import { formatDateTime, formatMoney } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+export function BudgetConfigSection() {
+  const displayCurrency = useDisplayCurrency();
+
+  // ---- Config state ----
+  const config = useAsync(fetchBudgetConfig, []);
+  const [cashBufferPct, setCashBufferPct] = useState<number | null>(null);
+  const [cgtScenario, setCgtScenario] = useState<"basic" | "higher" | null>(
+    null,
+  );
+  const [configReason, setConfigReason] = useState("");
+  const [configSaving, setConfigSaving] = useState(false);
+  const [configSuccess, setConfigSuccess] = useState(false);
+  const [configError, setConfigError] = useState(false);
+
+  // Derive displayed values: local override > server value > default
+  const displayedBufferPct =
+    cashBufferPct ?? config.data?.cash_buffer_pct ?? 10;
+  const displayedCgtScenario =
+    cgtScenario ??
+    (config.data?.cgt_scenario === "higher" ? "higher" : "basic");
+
+  async function handleConfigSave(e: FormEvent) {
+    e.preventDefault();
+    setConfigSaving(true);
+    setConfigError(false);
+    setConfigSuccess(false);
+    try {
+      await updateBudgetConfig({
+        cash_buffer_pct: displayedBufferPct,
+        cgt_scenario: displayedCgtScenario,
+        updated_by: "operator",
+        reason: configReason,
+      });
+      config.refetch();
+      setCashBufferPct(null);
+      setCgtScenario(null);
+      setConfigReason("");
+      setConfigSuccess(true);
+    } catch (err: unknown) {
+      console.error("Failed to update budget config", err);
+      setConfigError(true);
+    } finally {
+      setConfigSaving(false);
+    }
+  }
+
+  // ---- Capital event form state ----
+  const [eventType, setEventType] = useState<"injection" | "withdrawal">(
+    "injection",
+  );
+  const [eventAmount, setEventAmount] = useState("");
+  const [eventCurrency, setEventCurrency] = useState<"USD" | "GBP">("USD");
+  const [eventNote, setEventNote] = useState("");
+  const [eventSaving, setEventSaving] = useState(false);
+  const [eventSuccess, setEventSuccess] = useState(false);
+  const [eventError, setEventError] = useState(false);
+
+  // ---- Capital events history ----
+  const events = useAsync(() => fetchCapitalEvents(20, 0), []);
+
+  async function handleEventSubmit(e: FormEvent) {
+    e.preventDefault();
+    const parsed = Number(eventAmount);
+    if (Number.isNaN(parsed) || parsed <= 0) return;
+    setEventSaving(true);
+    setEventError(false);
+    setEventSuccess(false);
+    try {
+      await createCapitalEvent({
+        event_type: eventType,
+        amount: parsed,
+        currency: eventCurrency,
+        note: eventNote.trim() || undefined,
+      });
+      events.refetch();
+      setEventType("injection");
+      setEventAmount("");
+      setEventCurrency("USD");
+      setEventNote("");
+      setEventSuccess(true);
+    } catch (err: unknown) {
+      console.error("Failed to create capital event", err);
+      setEventError(true);
+    } finally {
+      setEventSaving(false);
+    }
+  }
+
+  const configReasonMissing = configReason.trim().length === 0;
+  const eventAmountInvalid =
+    eventAmount === "" || Number.isNaN(Number(eventAmount)) || Number(eventAmount) <= 0;
+
+  return (
+    <section className="rounded-md border border-slate-200 bg-white shadow-sm">
+      <header className="border-b border-slate-100 px-4 py-3">
+        <h2 className="text-sm font-semibold text-slate-700">
+          Budget Configuration
+        </h2>
+      </header>
+
+      <div className="space-y-6 p-4">
+        {/* ---- Sub-section 1: Config Controls ---- */}
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Config Controls
+          </h3>
+
+          {config.loading ? (
+            <div className="mt-2">
+              <SectionSkeleton rows={3} />
+            </div>
+          ) : config.error ? (
+            <div className="mt-2">
+              <SectionError onRetry={config.refetch} />
+            </div>
+          ) : (
+            <form onSubmit={(e) => void handleConfigSave(e)} className="mt-3 space-y-3">
+              <div className="flex flex-wrap items-end gap-4">
+                <label className="block">
+                  <span className="text-xs text-slate-500">
+                    Cash buffer %
+                  </span>
+                  <input
+                    type="number"
+                    min={0}
+                    max={50}
+                    step={1}
+                    value={displayedBufferPct}
+                    onChange={(e) => setCashBufferPct(Number(e.target.value))}
+                    disabled={configSaving}
+                    className="mt-1 block w-24 rounded border border-slate-300 px-2 py-1.5 text-sm"
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="text-xs text-slate-500">CGT scenario</span>
+                  <select
+                    value={displayedCgtScenario}
+                    onChange={(e) =>
+                      setCgtScenario(e.target.value as "basic" | "higher")
+                    }
+                    disabled={configSaving}
+                    className="mt-1 block rounded border border-slate-300 px-2 py-1.5 text-sm"
+                  >
+                    <option value="basic">basic</option>
+                    <option value="higher">higher</option>
+                  </select>
+                </label>
+              </div>
+
+              <label className="block">
+                <span className="text-xs text-slate-500">
+                  Reason (required)
+                </span>
+                <input
+                  type="text"
+                  value={configReason}
+                  onChange={(e) => setConfigReason(e.target.value)}
+                  disabled={configSaving}
+                  placeholder="Why are you changing this?"
+                  className="mt-1 block w-full max-w-md rounded border border-slate-300 px-2 py-1.5 text-sm"
+                />
+              </label>
+
+              <button
+                type="submit"
+                disabled={configSaving || configReasonMissing}
+                className="rounded bg-slate-800 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {configSaving ? "Saving..." : "Save config"}
+              </button>
+
+              {configSuccess && (
+                <p className="rounded bg-emerald-50 px-2 py-1.5 text-xs text-emerald-700">
+                  Budget config updated.
+                </p>
+              )}
+              {configError && (
+                <p
+                  role="alert"
+                  className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700"
+                >
+                  Failed to save budget config. Check the browser console for
+                  details.
+                </p>
+              )}
+            </form>
+          )}
+        </div>
+
+        {/* ---- Sub-section 2: Capital Event Form ---- */}
+        <div className="border-t border-slate-100 pt-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Record Capital Event
+          </h3>
+
+          <form
+            onSubmit={(e) => void handleEventSubmit(e)}
+            className="mt-3 space-y-3"
+          >
+            <div className="flex flex-wrap items-end gap-4">
+              <label className="block">
+                <span className="text-xs text-slate-500">Type</span>
+                <select
+                  value={eventType}
+                  onChange={(e) =>
+                    setEventType(
+                      e.target.value as "injection" | "withdrawal",
+                    )
+                  }
+                  disabled={eventSaving}
+                  className="mt-1 block rounded border border-slate-300 px-2 py-1.5 text-sm"
+                >
+                  <option value="injection">injection</option>
+                  <option value="withdrawal">withdrawal</option>
+                </select>
+              </label>
+
+              <label className="block">
+                <span className="text-xs text-slate-500">Amount</span>
+                <input
+                  type="number"
+                  min={0}
+                  step="any"
+                  value={eventAmount}
+                  onChange={(e) => setEventAmount(e.target.value)}
+                  disabled={eventSaving}
+                  placeholder="0.00"
+                  className="mt-1 block w-32 rounded border border-slate-300 px-2 py-1.5 text-sm"
+                />
+              </label>
+
+              <label className="block">
+                <span className="text-xs text-slate-500">Currency</span>
+                <select
+                  value={eventCurrency}
+                  onChange={(e) =>
+                    setEventCurrency(e.target.value as "USD" | "GBP")
+                  }
+                  disabled={eventSaving}
+                  className="mt-1 block rounded border border-slate-300 px-2 py-1.5 text-sm"
+                >
+                  <option value="USD">USD</option>
+                  <option value="GBP">GBP</option>
+                </select>
+              </label>
+            </div>
+
+            <label className="block">
+              <span className="text-xs text-slate-500">Note (optional)</span>
+              <textarea
+                value={eventNote}
+                onChange={(e) => setEventNote(e.target.value)}
+                disabled={eventSaving}
+                rows={2}
+                className="mt-1 block w-full max-w-md rounded border border-slate-300 px-2 py-1.5 text-sm"
+              />
+            </label>
+
+            <button
+              type="submit"
+              disabled={eventSaving || eventAmountInvalid}
+              className="rounded bg-slate-800 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {eventSaving ? "Submitting..." : "Record event"}
+            </button>
+
+            {eventSuccess && (
+              <p className="rounded bg-emerald-50 px-2 py-1.5 text-xs text-emerald-700">
+                Capital event recorded.
+              </p>
+            )}
+            {eventError && (
+              <p
+                role="alert"
+                className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700"
+              >
+                Failed to record capital event. Check the browser console for
+                details.
+              </p>
+            )}
+          </form>
+        </div>
+
+        {/* ---- Sub-section 3: Capital Events History ---- */}
+        <div className="border-t border-slate-100 pt-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Capital Events History
+          </h3>
+
+          <div className="mt-3">
+            {events.loading ? (
+              <SectionSkeleton rows={3} />
+            ) : events.error ? (
+              <SectionError onRetry={events.refetch} />
+            ) : events.data && events.data.length > 0 ? (
+              <div className="overflow-x-auto">
+                <table className="w-full text-left text-sm">
+                  <thead>
+                    <tr>
+                      <th className="py-1.5 text-xs text-slate-500">Time</th>
+                      <th className="py-1.5 text-xs text-slate-500">Type</th>
+                      <th className="py-1.5 text-xs text-slate-500">Amount</th>
+                      <th className="py-1.5 text-xs text-slate-500">
+                        Currency
+                      </th>
+                      <th className="py-1.5 text-xs text-slate-500">Note</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {events.data.map((ev: CapitalEventResponse) => (
+                      <tr key={ev.event_id}>
+                        <td className="py-1.5">
+                          {formatDateTime(ev.event_time)}
+                        </td>
+                        <td className="py-1.5">{ev.event_type}</td>
+                        <td className="py-1.5">
+                          {formatMoney(ev.amount, ev.currency || displayCurrency)}
+                        </td>
+                        <td className="py-1.5">{ev.currency}</td>
+                        <td className="py-1.5 text-slate-500">
+                          {ev.note ?? "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="text-sm text-slate-500">
+                No capital events recorded yet.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/settings/BudgetConfigSection.tsx
+++ b/frontend/src/components/settings/BudgetConfigSection.tsx
@@ -8,13 +8,10 @@ import {
 } from "@/api/budget";
 import type { CapitalEventResponse } from "@/api/types";
 import { SectionSkeleton, SectionError } from "@/components/dashboard/Section";
-import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
 import { formatDateTime, formatMoney } from "@/lib/format";
 import { useAsync } from "@/lib/useAsync";
 
 export function BudgetConfigSection() {
-  const displayCurrency = useDisplayCurrency();
-
   // ---- Config state ----
   const config = useAsync(fetchBudgetConfig, []);
   const [cashBufferPct, setCashBufferPct] = useState<number | null>(null);
@@ -57,11 +54,13 @@ export function BudgetConfigSection() {
         updated_by: "operator",
         reason: configReason,
       });
-      config.refetch();
       setCashBufferPct(null);
       setCgtScenario(null);
       setConfigReason("");
       setConfigSuccess(true);
+      // Refetch after local state resets so the re-render from refetch
+      // completion sees null overrides → uses new server values cleanly.
+      config.refetch();
     } catch (err: unknown) {
       console.error("Failed to update budget config", err);
       setConfigError(true);
@@ -87,7 +86,7 @@ export function BudgetConfigSection() {
   async function handleEventSubmit(e: FormEvent) {
     e.preventDefault();
     const parsed = Number(eventAmount);
-    if (Number.isNaN(parsed) || parsed <= 0) return;
+    if (!Number.isFinite(parsed) || parsed <= 0) return;
     setEventSaving(true);
     setEventError(false);
     setEventSuccess(false);
@@ -114,8 +113,9 @@ export function BudgetConfigSection() {
 
   const configReasonMissing = configReason.trim().length === 0;
   const configNothingChanged = cashBufferPct === null && cgtScenario === null;
+  const parsedEventAmount = Number(eventAmount);
   const eventAmountInvalid =
-    eventAmount === "" || Number.isNaN(Number(eventAmount)) || Number(eventAmount) <= 0;
+    eventAmount === "" || !Number.isFinite(parsedEventAmount) || parsedEventAmount <= 0;
 
   return (
     <section className="rounded-md border border-slate-200 bg-white shadow-sm">
@@ -153,7 +153,10 @@ export function BudgetConfigSection() {
                     max={50}
                     step={1}
                     value={displayedBufferPct}
-                    onChange={(e) => setCashBufferPct(Number(e.target.value))}
+                    onChange={(e) => {
+                      const val = Number(e.target.value);
+                      setCashBufferPct(val === serverBufferPct ? null : val);
+                    }}
                     disabled={configSaving}
                     className="mt-1 block w-24 rounded border border-slate-300 px-2 py-1.5 text-sm"
                   />
@@ -163,9 +166,14 @@ export function BudgetConfigSection() {
                   <span className="text-xs text-slate-500">CGT scenario</span>
                   <select
                     value={displayedCgtScenario}
-                    onChange={(e) =>
-                      setCgtScenario(e.target.value as "basic" | "higher")
-                    }
+                    onChange={(e) => {
+                      const val = e.target.value as "basic" | "higher";
+                      const serverScenario =
+                        config.data?.cgt_scenario === "higher"
+                          ? "higher"
+                          : "basic";
+                      setCgtScenario(val === serverScenario ? null : val);
+                    }}
                     disabled={configSaving}
                     className="mt-1 block rounded border border-slate-300 px-2 py-1.5 text-sm"
                   >
@@ -342,7 +350,7 @@ export function BudgetConfigSection() {
                         </td>
                         <td className="py-1.5">{ev.event_type}</td>
                         <td className="py-1.5">
-                          {formatMoney(ev.amount, ev.currency || displayCurrency)}
+                          {formatMoney(ev.amount, ev.currency)}
                         </td>
                         <td className="py-1.5">{ev.currency}</td>
                         <td className="py-1.5 text-slate-500">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -9,6 +9,7 @@ import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/S
 import { SummaryCards } from "@/components/dashboard/SummaryCards";
 import { PositionsTable } from "@/components/dashboard/PositionsTable";
 import { RecentRecommendations } from "@/components/dashboard/RecentRecommendations";
+import { BudgetOverviewPanel } from "@/components/dashboard/BudgetOverviewPanel";
 import { SystemStatusPanel } from "@/components/dashboard/SystemStatusPanel";
 import { BootstrapProgress, isBootstrapping } from "@/components/dashboard/BootstrapProgress";
 
@@ -89,24 +90,35 @@ export function DashboardPage() {
           )}
         </div>
 
-        <Section title="System status">
-          {/* No combined loading gate: each endpoint's loading / error /
-              data state must drive its own render branch so a slow or
-              retrying endpoint cannot hide the already-resolved side.
-              See docs/review-prevention-log.md "Duplicate error widgets…"
-              and the related round-3 PR-#89 finding on shared loading
-              gates. */}
-          <SystemStatusPanel
-            system={system.error !== null ? null : system.data}
-            config={config.error !== null ? null : config.data}
-            systemLoading={system.loading}
-            configLoading={config.loading}
-            systemError={system.error !== null}
-            configError={config.error !== null}
-            onRetrySystem={system.refetch}
-            onRetryConfig={config.refetch}
-          />
-        </Section>
+        <div className="space-y-6">
+          <Section title="System status">
+            {/* No combined loading gate: each endpoint's loading / error /
+                data state must drive its own render branch so a slow or
+                retrying endpoint cannot hide the already-resolved side.
+                See docs/review-prevention-log.md "Duplicate error widgets…"
+                and the related round-3 PR-#89 finding on shared loading
+                gates. */}
+            <SystemStatusPanel
+              system={system.error !== null ? null : system.data}
+              config={config.error !== null ? null : config.data}
+              systemLoading={system.loading}
+              configLoading={config.loading}
+              systemError={system.error !== null}
+              configError={config.error !== null}
+              onRetrySystem={system.refetch}
+              onRetryConfig={config.refetch}
+            />
+          </Section>
+
+          <Section title="Budget">
+            <BudgetOverviewPanel
+              budget={budget.error !== null ? null : budget.data}
+              loading={budget.loading}
+              hasError={budget.error !== null}
+              onRetry={budget.refetch}
+            />
+          </Section>
+        </div>
       </div>
 
       <Section title="Recent recommendations">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,3 +1,4 @@
+import { fetchBudget } from "@/api/budget";
 import { fetchPortfolio } from "@/api/portfolio";
 import { fetchRecommendations } from "@/api/recommendations";
 import { fetchSystemStatus } from "@/api/system";
@@ -34,12 +35,14 @@ export function DashboardPage() {
   );
   const system = useAsync(fetchSystemStatus, []);
   const config = useAsync(fetchConfig, []);
+  const budget = useAsync(fetchBudget, []);
 
   const allFailed =
     portfolio.error !== null &&
     recs.error !== null &&
     system.error !== null &&
-    config.error !== null;
+    config.error !== null &&
+    budget.error !== null;
 
   return (
     <div className="space-y-6">
@@ -68,7 +71,10 @@ export function DashboardPage() {
             </div>
           ) : (
             <>
-              <SummaryCards data={portfolio.loading ? null : portfolio.data} />
+              <SummaryCards
+                data={portfolio.loading ? null : portfolio.data}
+                budgetData={budget.loading || budget.error !== null ? null : budget.data}
+              />
               <Section title="Positions">
                 {portfolio.loading ? (
                   <SectionSkeleton rows={4} />

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -75,6 +75,7 @@ export function DashboardPage() {
               <SummaryCards
                 data={portfolio.loading ? null : portfolio.data}
                 budgetData={budget.loading || budget.error !== null ? null : budget.data}
+                budgetError={budget.error !== null}
               />
               <Section title="Positions">
                 {portfolio.loading ? (

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -39,6 +39,22 @@ vi.mock("@/api/brokerCredentials", () => ({
   validateStoredCredentials: vi.fn(),
 }));
 
+// Budget API mock — prevents BudgetConfigSection from making real fetch
+// calls, which would produce extra role="alert" elements and break the
+// broker-credential test assertions that use getByRole("alert").
+vi.mock("@/api/budget", () => ({
+  fetchBudgetConfig: vi.fn().mockResolvedValue({
+    cash_buffer_pct: 0.05,
+    cgt_scenario: "higher",
+    updated_at: "2026-04-15T00:00:00Z",
+    updated_by: "system",
+    reason: "initial seed",
+  }),
+  fetchCapitalEvents: vi.fn().mockResolvedValue([]),
+  updateBudgetConfig: vi.fn(),
+  createCapitalEvent: vi.fn(),
+}));
+
 const mockedList = vi.mocked(listBrokerCredentials);
 const mockedCreate = vi.mocked(createBrokerCredential);
 const mockedRevoke = vi.mocked(revokeBrokerCredential);

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -30,6 +30,7 @@ import {
 import { runJob } from "@/api/jobs";
 import { ValidationResultDisplay } from "@/components/broker/ValidationResultDisplay";
 import { useRecoveryPhraseModal } from "@/components/security/RecoveryPhraseModal";
+import { BudgetConfigSection } from "@/components/settings/BudgetConfigSection";
 import { DisplayCurrencySection } from "@/components/settings/DisplayCurrencySection";
 import { deriveCredentialSetMode, ENVIRONMENT } from "@/lib/credentialSetMode";
 import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
@@ -48,6 +49,7 @@ export function SettingsPage(): JSX.Element {
         currentCurrency={displayCurrency}
         onChanged={() => window.location.reload()}
       />
+      <BudgetConfigSection />
       <BrokerCredentialsSection />
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #233. Adds budget visibility to the operator Dashboard and budget config controls to the Settings page.

### Dashboard changes
- **4th summary card** — "Available for Deployment" with green/red tone and "Cash unknown" / "Low deployment capital" hints
- **Budget Overview sidebar panel** — working budget breakdown (cash, deployed, mirrors), cash buffer reserve, tax provision (GBP/USD), tax year. Independent loading/error states with retry.

### Settings changes
- **Budget Config section** — cash buffer % input and CGT scenario dropdown, with reason field (required) and audit trail. Only changed fields are sent in the PATCH to avoid backend "no fields changed" rejection.
- **Capital Event form** — injection/withdrawal with amount, currency, and optional note
- **Capital Events History** — paginated table of past events

### Key design decisions
- `cash_buffer_pct` stored as fraction (0.05) in the backend, displayed as percentage (5) in the UI. Conversion happens at the component boundary: `* 100` on display, `/ 100` on save.
- Each budget data source (`fetchBudget`, `fetchBudgetConfig`, `fetchCapitalEvents`) owns its own `useAsync` lifecycle — no combined loading gates.
- `types.ts` additions mirror the backend `BudgetStateResponse`, `BudgetConfigResponse`, and `CapitalEventResponse` Pydantic models field-for-field.
- Save button disabled when nothing changed OR reason is empty, preventing no-op 422s.

### Security model
- All budget endpoints require `require_session_or_service_token` (unchanged from PR #232).
- No new auth surface — reads existing session cookie via `credentials: "include"`.
- Config mutations attributed to `"operator"` with mandatory reason for audit trail.

## Files changed

| File | What |
|------|------|
| `frontend/src/api/types.ts` | `BudgetStateResponse`, `BudgetConfigResponse`, `CapitalEventResponse` interfaces |
| `frontend/src/api/budget.ts` | 5 typed fetcher/mutator wrappers |
| `frontend/src/components/dashboard/SummaryCards.tsx` | `budgetData` prop, `DeploymentCard` component, 4-col grid |
| `frontend/src/components/dashboard/BudgetOverviewPanel.tsx` | Read-only sidebar panel |
| `frontend/src/components/settings/BudgetConfigSection.tsx` | Config controls + capital event form + events history |
| `frontend/src/pages/DashboardPage.tsx` | Wire `fetchBudget` to SummaryCards + BudgetOverviewPanel |
| `frontend/src/pages/SettingsPage.tsx` | Import and render `BudgetConfigSection` |
| `frontend/src/pages/SettingsPage.test.tsx` | Add budget API mock to prevent alert collisions |
| `frontend/src/components/settings/BudgetConfigSection.test.tsx` | 16 tests: unit conversion, save behaviour, event form, history |

## Test plan

- [x] `pnpm --dir frontend typecheck` — clean
- [x] `pnpm --dir frontend test` — 176 passed (14 files)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 1409 passed
- [ ] Manual: Dashboard shows budget panel with correct values
- [ ] Manual: Settings shows budget config with fraction→percentage conversion (DB 0.05 → input shows 5)
- [ ] Manual: Changing buffer % and saving sends correct fraction to backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>