### PR TITLE
fix(#228): order_client writes broker_positions on BUY/ADD fill

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -279,6 +279,10 @@ def _persist_order_and_fill(
                     ON CONFLICT (position_id) DO UPDATE SET
                         units = EXCLUDED.units,
                         amount = EXCLUDED.amount,
+                        open_rate = EXCLUDED.open_rate,
+                        open_conversion_rate = EXCLUDED.open_conversion_rate,
+                        total_fees = EXCLUDED.total_fees,
+                        raw_payload = EXCLUDED.raw_payload,
                         updated_at = EXCLUDED.updated_at
                     """,
                     {

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -378,6 +378,68 @@ def _update_position_buy(
     )
 
 
+def _persist_broker_position(
+    conn: psycopg.Connection[Any],
+    order_id: int,
+    instrument_id: int,
+    filled_price: Decimal,
+    filled_units: Decimal,
+    fees: Decimal,
+    order_params: OrderParams | None,
+    raw_payload: dict[str, Any],
+    now: datetime,
+) -> None:
+    """Insert a broker_positions row for an eBull-originated BUY/ADD fill.
+
+    Uses ``order_id`` as the synthetic ``position_id`` — the same convention
+    as ``app/api/orders._persist_order_and_fill``.  The row is immediately
+    visible to ``_load_position_id_for_exit`` so a subsequent EXIT
+    recommendation does not have to wait for the next broker sync cycle.
+
+    ON CONFLICT: if a broker sync backfills the same ``position_id`` before
+    this runs (unlikely but safe), update units/amount/updated_at.
+    """
+    gross = filled_price * filled_units
+    conn.execute(
+        """
+        INSERT INTO broker_positions
+            (position_id, instrument_id, is_buy, units, amount,
+             initial_amount_in_dollars, open_rate, open_conversion_rate,
+             open_date_time, stop_loss_rate, take_profit_rate,
+             is_no_stop_loss, is_no_take_profit,
+             leverage, is_tsl_enabled, total_fees,
+             source, raw_payload, updated_at)
+        VALUES
+            (%(pid)s, %(iid)s, TRUE, %(units)s, %(amount)s,
+             %(amount)s, %(price)s, 1,
+             %(now)s, %(sl)s, %(tp)s,
+             %(no_sl)s, %(no_tp)s,
+             %(leverage)s, %(tsl)s, %(fees)s,
+             'ebull', %(payload)s, %(now)s)
+        ON CONFLICT (position_id) DO UPDATE SET
+            units = EXCLUDED.units,
+            amount = EXCLUDED.amount,
+            updated_at = EXCLUDED.updated_at
+        """,
+        {
+            "pid": order_id,
+            "iid": instrument_id,
+            "units": filled_units,
+            "amount": gross,
+            "price": filled_price,
+            "now": now,
+            "sl": order_params.stop_loss_rate if order_params else None,
+            "tp": order_params.take_profit_rate if order_params else None,
+            "no_sl": order_params is None or order_params.stop_loss_rate is None,
+            "no_tp": order_params is None or order_params.take_profit_rate is None,
+            "leverage": order_params.leverage if order_params else 1,
+            "tsl": order_params.is_tsl_enabled if order_params else False,
+            "fees": fees,
+            "payload": Jsonb(raw_payload),
+        },
+    )
+
+
 def _update_position_exit(
     conn: psycopg.Connection[Any],
     instrument_id: int,
@@ -650,6 +712,17 @@ def execute_order(
                     instrument_id=instrument_id,
                     filled_price=fp,
                     filled_units=fu,
+                    now=now,
+                )
+                _persist_broker_position(
+                    conn,
+                    order_id=order_id,
+                    instrument_id=instrument_id,
+                    filled_price=fp,
+                    filled_units=fu,
+                    fees=broker_result.fees,
+                    order_params=order_params,
+                    raw_payload=broker_result.raw_payload,
                     now=now,
                 )
             elif action == "EXIT":

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -419,6 +419,10 @@ def _persist_broker_position(
         ON CONFLICT (position_id) DO UPDATE SET
             units = EXCLUDED.units,
             amount = EXCLUDED.amount,
+            open_rate = EXCLUDED.open_rate,
+            open_conversion_rate = EXCLUDED.open_conversion_rate,
+            total_fees = EXCLUDED.total_fees,
+            raw_payload = EXCLUDED.raw_payload,
             updated_at = EXCLUDED.updated_at
         """,
         {

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -698,3 +698,21 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `"1e308"` → `Number("1e308")` → `Infinity`; `Infinity` is not `NaN`, so `Number.isNaN(Infinity)` returns `false`, passing the guard and sending `amount: Infinity` to the backend.
 - Prevention: Use `Number.isFinite(v)` instead of `!Number.isNaN(v)` for numeric input validation before API submission. `isFinite` rejects both `NaN` and `±Infinity`.
 - Enforced in: `frontend/src/components/settings/BudgetConfigSection.tsx` (event amount guard)
+
+---
+
+### ON CONFLICT DO UPDATE on raw_payload tables must include raw_payload in SET clause
+
+- First seen in: #237
+- Symptom: `INSERT INTO broker_positions ... ON CONFLICT (position_id) DO UPDATE SET units, amount, updated_at` omitted `raw_payload` from the update list. If a broker sync race won the INSERT first, the subsequent eBull upsert preserved the sync's payload and silently dropped the eBull raw payload. Same pattern existed in `app/api/orders.py`.
+- Prevention: Before pushing any `ON CONFLICT DO UPDATE` on a table with a `raw_payload` column, verify the SET clause includes `raw_payload = EXCLUDED.raw_payload`. Grep `ON CONFLICT.*DO UPDATE` in files that touch `broker_positions`, `copy_mirror_positions`, or any table with `raw_payload`, and confirm each includes the column. If payload should NOT be overwritten, document why in a SQL comment.
+- Enforced in: `app/services/order_client.py`, `app/api/orders.py`
+
+---
+
+### ON CONFLICT DO UPDATE must cover all financial columns, not just units/amount
+
+- First seen in: #237
+- Symptom: `ON CONFLICT DO UPDATE SET units, amount, updated_at` omitted `total_fees`, `open_rate`, and `open_conversion_rate`. On a race, the losing writer's fee and rate values were silently discarded.
+- Prevention: Before pushing any `ON CONFLICT DO UPDATE` on a financial table (`broker_positions`, `copy_mirror_positions`), verify the SET clause covers all columns where the eBull-originated values should be authoritative — especially fees and rates. If a column should intentionally NOT be updated on conflict, add a SQL comment explaining why.
+- Enforced in: `app/services/order_client.py`, `app/api/orders.py`

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -410,9 +410,14 @@ class TestExecuteOrderDemoMode:
         bp_calls = [c for c in conn.execute.call_args_list if "broker_positions" in str(c)]
         assert len(bp_calls) == 1, f"Expected 1 broker_positions INSERT, got {len(bp_calls)}"
 
-        # Verify key params: position_id = order_id, source = 'ebull'
-        sql_str = str(bp_calls[0])
-        assert "'ebull'" in sql_str
+        # Verify params passed through execute_order (not just SQL shape)
+        params = bp_calls[0].args[1]
+        assert params["pid"] == 7  # position_id = order_id
+        assert params["iid"] == 1  # instrument_id from rec
+        assert params["sl"] == Decimal("90")
+        assert params["tp"] == Decimal("120")
+        assert params["no_sl"] is False
+        assert params["no_tp"] is False
 
     @patch("app.services.order_client._utcnow", return_value=_NOW)
     def test_demo_exit_does_not_write_broker_positions(self, _mock_now: MagicMock) -> None:
@@ -834,6 +839,8 @@ class TestPersistBrokerPosition:
         assert "INSERT INTO broker_positions" in normalised
         assert "'ebull'" in normalised
         assert "ON CONFLICT (position_id) DO UPDATE" in normalised
+        # ON CONFLICT must update raw_payload to prevent silent payload loss
+        assert "raw_payload = EXCLUDED.raw_payload" in normalised
 
         params = conn.execute.call_args_list[0].args[1]
         assert params["pid"] == 7

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -19,7 +19,7 @@ Cursor call order inside execute_order (demo BUY with suggested_size_pct):
   3. _load_latest_quote_price       — fetchone
   4. _persist_order                 — fetchone (INSERT RETURNING)
   5. _persist_fill                  — fetchone (INSERT RETURNING)
-  6. conn.execute x4                — position upsert, cash_ledger, rec status, audit
+  6. conn.execute x5                — position upsert, broker_positions, cash_ledger, rec status, audit
 
 Cursor call order inside execute_order (demo EXIT):
   1. _load_approved_recommendation  — fetchone
@@ -40,11 +40,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.providers.broker import BrokerOrderResult
+from app.providers.broker import BrokerOrderResult, OrderParams
 from app.services.order_client import (
     _load_approved_recommendation,
     _load_latest_quote_price,
     _load_position_units,
+    _persist_broker_position,
     _synthetic_fill,
     _update_position_buy,
     execute_order,
@@ -314,8 +315,8 @@ class TestExecuteOrderDemoMode:
         assert result.broker_order_ref == "DEMO-1-BUY"
         assert "order filled" in result.explanation
 
-        # conn.execute: position upsert, cash_ledger, rec status, audit = 4
-        assert conn.execute.call_count == 4
+        # conn.execute: position upsert, broker_positions, cash_ledger, rec status, audit = 5
+        assert conn.execute.call_count == 5
 
     @patch("app.services.order_client._utcnow", return_value=_NOW)
     def test_demo_exit_produces_fill(self, _mock_now: MagicMock) -> None:
@@ -386,6 +387,52 @@ class TestExecuteOrderDemoMode:
         broker.place_order.assert_not_called()
         broker.close_position.assert_not_called()
         broker.get_order_status.assert_not_called()
+
+    @patch("app.services.order_client._utcnow", return_value=_NOW)
+    def test_demo_buy_writes_broker_positions_row(self, _mock_now: MagicMock) -> None:
+        """BUY/ADD fills must INSERT into broker_positions so EXIT can resolve."""
+        cursors = [
+            _rec_cursor(action="BUY", stop_loss_rate=90.0, take_profit_rate=120.0),
+            _cash_cursor(balance=10_000.0),
+            _quote_cursor(last=100.0),
+            _order_returning_cursor(order_id=7),
+            _fill_returning_cursor(fill_id=3),
+        ]
+        conn = _make_conn(cursors)
+        result = execute_order(
+            conn,
+            recommendation_id=42,
+            decision_id=10,
+        )
+        assert result.outcome == "filled"
+
+        # Find the broker_positions INSERT among conn.execute calls
+        bp_calls = [c for c in conn.execute.call_args_list if "broker_positions" in str(c)]
+        assert len(bp_calls) == 1, f"Expected 1 broker_positions INSERT, got {len(bp_calls)}"
+
+        # Verify key params: position_id = order_id, source = 'ebull'
+        sql_str = str(bp_calls[0])
+        assert "'ebull'" in sql_str
+
+    @patch("app.services.order_client._utcnow", return_value=_NOW)
+    def test_demo_exit_does_not_write_broker_positions(self, _mock_now: MagicMock) -> None:
+        """EXIT fills must NOT insert into broker_positions (the row already exists)."""
+        cursors = [
+            _rec_cursor(action="EXIT", target_entry=None, suggested_size_pct=None),
+            _position_cursor(current_units=5.0),
+            _quote_cursor(last=200.0),
+            _order_returning_cursor(order_id=8),
+            _fill_returning_cursor(fill_id=4),
+        ]
+        conn = _make_conn(cursors)
+        result = execute_order(
+            conn,
+            recommendation_id=42,
+            decision_id=10,
+        )
+        assert result.outcome == "filled"
+        bp_calls = [c for c in conn.execute.call_args_list if "broker_positions" in str(c)]
+        assert len(bp_calls) == 0
 
     @patch("app.services.order_client._utcnow", return_value=_NOW)
     def test_demo_buy_writes_execution_audit(self, _mock_now: MagicMock) -> None:
@@ -755,3 +802,67 @@ class TestUpdatePositionBuySource:
         assert "positions.current_units <= 0" in normalised
         assert "EXCLUDED.source" in normalised
         assert "ELSE positions.source" in normalised
+
+
+# ---------------------------------------------------------------------------
+# TestPersistBrokerPosition
+# ---------------------------------------------------------------------------
+
+
+class TestPersistBrokerPosition:
+    """Verify _persist_broker_position emits the correct INSERT."""
+
+    def test_inserts_with_source_ebull_and_sl_tp(self) -> None:
+        conn = _make_conn([])
+        _persist_broker_position(
+            conn,
+            order_id=7,
+            instrument_id=42,
+            filled_price=Decimal("100"),
+            filled_units=Decimal("5"),
+            fees=Decimal("1.50"),
+            order_params=OrderParams(
+                stop_loss_rate=Decimal("90"),
+                take_profit_rate=Decimal("120"),
+            ),
+            raw_payload={"demo": True},
+            now=_NOW,
+        )
+        assert conn.execute.call_count == 1
+        sql = conn.execute.call_args_list[0].args[0]
+        normalised = re.sub(r"\s+", " ", sql)
+        assert "INSERT INTO broker_positions" in normalised
+        assert "'ebull'" in normalised
+        assert "ON CONFLICT (position_id) DO UPDATE" in normalised
+
+        params = conn.execute.call_args_list[0].args[1]
+        assert params["pid"] == 7
+        assert params["iid"] == 42
+        assert params["units"] == Decimal("5")
+        # amount = price * units = 500
+        assert params["amount"] == Decimal("500")
+        assert params["sl"] == Decimal("90")
+        assert params["tp"] == Decimal("120")
+        assert params["no_sl"] is False
+        assert params["no_tp"] is False
+
+    def test_inserts_without_order_params(self) -> None:
+        conn = _make_conn([])
+        _persist_broker_position(
+            conn,
+            order_id=8,
+            instrument_id=99,
+            filled_price=Decimal("50"),
+            filled_units=Decimal("10"),
+            fees=Decimal("0"),
+            order_params=None,
+            raw_payload={"demo": True},
+            now=_NOW,
+        )
+        params = conn.execute.call_args_list[0].args[1]
+        assert params["sl"] is None
+        assert params["tp"] is None
+        assert params["no_sl"] is True
+        assert params["no_tp"] is True
+        assert params["leverage"] == 1
+        assert params["tsl"] is False


### PR DESCRIPTION
## Summary

Closes #228.

The recommendation flow (`execute_order` in `app/services/order_client.py`) wrote to the aggregate `positions` table and `fills` on BUY/ADD, but **not** to `broker_positions`. This left a window between order placement and the next broker sync cycle where `_load_position_id_for_exit()` returned `None`, causing live EXIT recommendations to be marked `failed` despite an open local position.

## What changed

- **`app/services/order_client.py`**: Added `_persist_broker_position` helper that INSERTs into `broker_positions` with `source='ebull'`. Called inside the existing transaction block after `_update_position_buy` for BUY/ADD fills only.
  - Uses `order_id` as synthetic `position_id` — same convention as `app/api/orders._persist_order_and_fill`
  - ON CONFLICT DO UPDATE handles the (unlikely) race with broker sync backfilling the same position_id
  - Carries SL/TP from `OrderParams` when available
  - `open_conversion_rate = 1` — correct for USD-only universe; #229 tracks the non-USD fix

- **`tests/test_order_client.py`**: 4 new tests + 1 count adjustment:
  - `TestPersistBrokerPosition::test_inserts_with_source_ebull_and_sl_tp` — verifies SQL shape and param values with SL/TP
  - `TestPersistBrokerPosition::test_inserts_without_order_params` — verifies NULL SL/TP and defaults
  - `TestExecuteOrderDemoMode::test_demo_buy_writes_broker_positions_row` — integration: BUY fill emits broker_positions INSERT
  - `TestExecuteOrderDemoMode::test_demo_exit_does_not_write_broker_positions` — integration: EXIT fill does NOT write broker_positions
  - Updated `test_demo_buy_produces_fill_and_order` count: `conn.execute` 4→5

## Security model

No new endpoints or auth changes. The INSERT runs inside the same `conn.transaction()` block that already persists fills, positions, cash ledger, and audit rows. No external I/O inside the transaction.

## Tradeoffs

- **Synthetic `position_id = order_id`**: Same pattern as `orders.py`. Collision risk with real broker position IDs is tracked in #227 — not introduced here, just inherited.
- **`open_conversion_rate = 1`**: Correct for USD-only. #229 tracks the fix for non-USD instruments.
- **No migration**: `broker_positions` table already exists (024). No schema changes needed.

## Settled decisions preserved

- Provider boundary: change is in service layer, not provider
- Guard auditability: existing `decision_audit` row unchanged
- Cash semantics: existing `_record_cash_ledger` unchanged

## Prevention log entries checked

- "decision_id received but not written back" — already addressed
- "Zero-value fills persisted" — existing `fu > 0` guard runs before `_persist_broker_position`
- "Shared column vocabulary mismatch" — uses same `source = 'ebull'` literal as `orders.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)