### PR TITLE
feat(#205): autonomous operation loop — retry, monitor, pipeline

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -62,8 +62,10 @@ from app.workers.scheduler import (
     JOB_DAILY_THESIS_REFRESH,
     JOB_EXECUTE_APPROVED_ORDERS,
     JOB_FX_RATES_REFRESH,
+    JOB_MONITOR_POSITIONS,
     JOB_MORNING_CANDIDATE_REVIEW,
     JOB_NIGHTLY_UNIVERSE_SYNC,
+    JOB_RETRY_DEFERRED,
     JOB_WEEKLY_COVERAGE_REVIEW,
     SCHEDULED_JOBS,
     Cadence,
@@ -78,8 +80,10 @@ from app.workers.scheduler import (
     daily_thesis_refresh,
     execute_approved_orders,
     fx_rates_refresh,
+    monitor_positions_job,
     morning_candidate_review,
     nightly_universe_sync,
+    retry_deferred_recommendations_job,
     weekly_coverage_review,
 )
 
@@ -119,6 +123,8 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_MORNING_CANDIDATE_REVIEW: morning_candidate_review,
     JOB_WEEKLY_COVERAGE_REVIEW: weekly_coverage_review,
     JOB_DAILY_TAX_RECONCILIATION: daily_tax_reconciliation,
+    JOB_RETRY_DEFERRED: retry_deferred_recommendations_job,
+    JOB_MONITOR_POSITIONS: monitor_positions_job,
 }
 
 

--- a/app/services/deferred_retry.py
+++ b/app/services/deferred_retry.py
@@ -43,7 +43,12 @@ RETRY_EXPIRY_HOURS: int = 24
 
 @dataclass(frozen=True)
 class RetryResult:
-    """Counts from a single run of retry_deferred_recommendations()."""
+    """Counts from a single run of retry_deferred_recommendations().
+
+    ``retried`` counts all evaluation attempts, including those that
+    errored.  Invariant: retried == re_proposed + re_deferred + errors
+    (for the non-expired subset).
+    """
 
     retried: int
     re_proposed: int

--- a/app/services/deferred_retry.py
+++ b/app/services/deferred_retry.py
@@ -1,0 +1,363 @@
+"""Deferred retry service — re-evaluate timing_deferred recommendations.
+
+Sits between the scheduler's execute_approved_orders job and the
+entry_timing service.  BUY/ADD recommendations that were deferred by
+Phase 0 (TA conditions unfavorable) are retried here up to
+MAX_RETRY_ATTEMPTS times within RETRY_EXPIRY_HOURS.
+
+Design:
+  - Expire first (max retries or age) before re-evaluating.
+  - Each status transition + audit row is atomic (one transaction).
+  - Exceptions on a single rec are logged and counted; they never abort
+    the rest of the batch (data-inconsistency case, not programmer error).
+  - Pure service: caller provides the connection; no direct DB connects.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from psycopg.types.json import Jsonb
+
+from app.services.entry_timing import EntryEvaluation, evaluate_entry_conditions
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MAX_RETRY_ATTEMPTS: int = 3
+RETRY_EXPIRY_HOURS: int = 24
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RetryResult:
+    """Counts from a single run of retry_deferred_recommendations()."""
+
+    retried: int
+    re_proposed: int
+    re_deferred: int
+    expired: int
+    errors: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _expire_rec(
+    conn: psycopg.Connection[Any],
+    rec: dict[str, Any],
+    reason: str,
+) -> None:
+    """Atomically expire a rec: set status=timing_expired + write audit row.
+
+    Must be called inside a ``with conn.transaction():`` block so the caller
+    can group the commit after the context manager exits.
+    """
+    rec_id: int = rec["recommendation_id"]
+    instrument_id: int = rec["instrument_id"]
+
+    conn.execute(
+        """
+        INSERT INTO decision_audit
+            (decision_time, instrument_id, recommendation_id,
+             stage, pass_fail, explanation)
+        VALUES
+            (NOW(), %(iid)s, %(rid)s,
+             'deferred_retry', 'FAIL', %(expl)s)
+        """,
+        {"iid": instrument_id, "rid": rec_id, "expl": reason},
+    )
+    conn.execute(
+        """
+        UPDATE trade_recommendations
+        SET status = 'timing_expired',
+            timing_rationale = %(rationale)s
+        WHERE recommendation_id = %(rid)s
+        """,
+        {"rid": rec_id, "rationale": reason},
+    )
+
+
+def _write_retry_pass(
+    conn: psycopg.Connection[Any],
+    rec: dict[str, Any],
+    evaluation: EntryEvaluation,
+) -> None:
+    """Atomically transition a rec to proposed after a PASS verdict."""
+    rec_id: int = rec["recommendation_id"]
+    instrument_id: int = rec["instrument_id"]
+    new_retry_count: int = rec["timing_retry_count"] + 1
+
+    conn.execute(
+        """
+        INSERT INTO decision_audit
+            (decision_time, instrument_id, recommendation_id,
+             stage, pass_fail, explanation, evidence_json)
+        VALUES
+            (NOW(), %(iid)s, %(rid)s,
+             'deferred_retry', 'PASS', %(expl)s, %(ev)s)
+        """,
+        {
+            "iid": instrument_id,
+            "rid": rec_id,
+            "expl": evaluation.rationale,
+            "ev": Jsonb(evaluation.condition_details),
+        },
+    )
+    conn.execute(
+        """
+        UPDATE trade_recommendations
+        SET status = 'proposed',
+            stop_loss_rate = %(sl)s,
+            take_profit_rate = %(tp)s,
+            timing_verdict = %(verdict)s,
+            timing_rationale = %(rationale)s,
+            timing_retry_count = %(retry_count)s
+        WHERE recommendation_id = %(rid)s
+        """,
+        {
+            "sl": evaluation.stop_loss_rate,
+            "tp": evaluation.take_profit_rate,
+            "verdict": evaluation.verdict,
+            "rationale": evaluation.rationale,
+            "retry_count": new_retry_count,
+            "rid": rec_id,
+        },
+    )
+
+
+def _write_retry_defer(
+    conn: psycopg.Connection[Any],
+    rec: dict[str, Any],
+    evaluation: EntryEvaluation,
+) -> None:
+    """Atomically increment retry_count and stay timing_deferred."""
+    rec_id: int = rec["recommendation_id"]
+    instrument_id: int = rec["instrument_id"]
+    new_retry_count: int = rec["timing_retry_count"] + 1
+
+    conn.execute(
+        """
+        INSERT INTO decision_audit
+            (decision_time, instrument_id, recommendation_id,
+             stage, pass_fail, explanation, evidence_json)
+        VALUES
+            (NOW(), %(iid)s, %(rid)s,
+             'deferred_retry', 'DEFER', %(expl)s, %(ev)s)
+        """,
+        {
+            "iid": instrument_id,
+            "rid": rec_id,
+            "expl": evaluation.rationale,
+            "ev": Jsonb(evaluation.condition_details),
+        },
+    )
+    conn.execute(
+        """
+        UPDATE trade_recommendations
+        SET timing_retry_count = %(retry_count)s,
+            timing_verdict = %(verdict)s,
+            timing_rationale = %(rationale)s
+        WHERE recommendation_id = %(rid)s
+        """,
+        {
+            "retry_count": new_retry_count,
+            "verdict": evaluation.verdict,
+            "rationale": evaluation.rationale,
+            "rid": rec_id,
+        },
+    )
+
+
+def _increment_retry_count_only(
+    conn: psycopg.Connection[Any],
+    rec: dict[str, Any],
+) -> None:
+    """Increment retry_count without changing status (error path).
+
+    No audit row: the caller logs the exception.  The rec stays in
+    timing_deferred so the next cycle can retry it again.
+    """
+    rec_id: int = rec["recommendation_id"]
+    new_retry_count: int = rec["timing_retry_count"] + 1
+
+    conn.execute(
+        """
+        UPDATE trade_recommendations
+        SET timing_retry_count = %(retry_count)s
+        WHERE recommendation_id = %(rid)s
+        """,
+        {"retry_count": new_retry_count, "rid": rec_id},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def retry_deferred_recommendations(conn: psycopg.Connection[Any]) -> RetryResult:
+    """Re-evaluate all timing_deferred BUY/ADD recommendations.
+
+    For each deferred rec:
+    - Expire if retry count >= MAX_RETRY_ATTEMPTS or age > RETRY_EXPIRY_HOURS.
+    - Otherwise, call evaluate_entry_conditions():
+        - pass   → transition to 'proposed' (re_proposed += 1)
+        - defer  → stay 'timing_deferred', increment retry_count (re_deferred += 1)
+        - exception → increment retry_count only, log error (errors += 1)
+
+    Every status transition + decision_audit row is atomic.
+    Exceptions on individual recs are logged and counted; they never abort
+    the batch (partial results are better than a total failure).
+
+    Returns a RetryResult with per-outcome counts.
+    """
+    # Load all deferred recs in a stable order.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT recommendation_id, instrument_id, action,
+                   timing_retry_count, timing_deferred_at
+            FROM trade_recommendations
+            WHERE status = 'timing_deferred'
+              AND action IN ('BUY', 'ADD')
+            ORDER BY recommendation_id
+            """,
+        )
+        recs: list[dict[str, Any]] = cur.fetchall()
+
+    if not recs:
+        return RetryResult(retried=0, re_proposed=0, re_deferred=0, expired=0)
+
+    now = datetime.now(tz=UTC)
+    expiry_cutoff = now - timedelta(hours=RETRY_EXPIRY_HOURS)
+
+    retried = 0
+    re_proposed = 0
+    re_deferred = 0
+    expired = 0
+    errors = 0
+
+    for rec in recs:
+        rec_id: int = rec["recommendation_id"]
+        retry_count: int = rec["timing_retry_count"]
+        deferred_at: datetime | None = rec["timing_deferred_at"]
+
+        # --- Expiry check (age OR retry exhaustion) ---
+        age_expired = deferred_at is not None and deferred_at < expiry_cutoff
+        count_expired = retry_count >= MAX_RETRY_ATTEMPTS
+
+        if age_expired or count_expired:
+            if age_expired and deferred_at is not None:
+                reason = (
+                    f"deferred_retry: expired — deferred_at={deferred_at.isoformat()} "
+                    f"older than {RETRY_EXPIRY_HOURS}h cutoff"
+                )
+            else:
+                reason = (
+                    f"deferred_retry: expired — retry_count={retry_count} "
+                    f">= MAX_RETRY_ATTEMPTS={MAX_RETRY_ATTEMPTS}"
+                )
+            try:
+                with conn.transaction():
+                    _expire_rec(conn, rec, reason)
+                conn.commit()
+                expired += 1
+                logger.info("deferred_retry: expired rec=%d reason=%s", rec_id, reason)
+            except Exception:
+                logger.error(
+                    "deferred_retry: failed to expire rec=%d",
+                    rec_id,
+                    exc_info=True,
+                )
+                errors += 1
+            continue
+
+        # --- Re-evaluate TA conditions ---
+        retried += 1
+        try:
+            # I/O (evaluate_entry_conditions reads DB) happens BEFORE the
+            # transaction so the lock window is minimised (sql-correctness).
+            evaluation: EntryEvaluation = evaluate_entry_conditions(conn, rec_id)
+
+            if evaluation.verdict == "pass":
+                with conn.transaction():
+                    _write_retry_pass(conn, rec, evaluation)
+                conn.commit()
+                re_proposed += 1
+                logger.info(
+                    "deferred_retry: PASS rec=%d retry_count=%d→%d",
+                    rec_id,
+                    retry_count,
+                    retry_count + 1,
+                )
+
+            elif evaluation.verdict in ("defer", "skip"):
+                # "skip" should not happen for a BUY/ADD rec but treat it as
+                # defer rather than an error — stays deferred, retried later.
+                with conn.transaction():
+                    _write_retry_defer(conn, rec, evaluation)
+                conn.commit()
+                re_deferred += 1
+                logger.info(
+                    "deferred_retry: DEFER rec=%d retry_count=%d→%d rationale=%s",
+                    rec_id,
+                    retry_count,
+                    retry_count + 1,
+                    evaluation.rationale,
+                )
+
+            else:
+                # Defensive: unknown verdict — treat as error.
+                logger.error(
+                    "deferred_retry: unexpected verdict=%r for rec=%d",
+                    evaluation.verdict,
+                    rec_id,
+                )
+                with conn.transaction():
+                    _increment_retry_count_only(conn, rec)
+                conn.commit()
+                errors += 1
+
+        except Exception:
+            logger.error(
+                "deferred_retry: evaluation raised for rec=%d",
+                rec_id,
+                exc_info=True,
+            )
+            # Best-effort: increment retry count so the rec is not stuck
+            # at retry_count=0 forever.  If this also fails, we leave it
+            # unchanged (the next cycle will retry).
+            try:
+                with conn.transaction():
+                    _increment_retry_count_only(conn, rec)
+                conn.commit()
+            except Exception:
+                logger.error(
+                    "deferred_retry: could not increment retry_count for rec=%d",
+                    rec_id,
+                    exc_info=True,
+                )
+            errors += 1
+
+    return RetryResult(
+        retried=retried,
+        re_proposed=re_proposed,
+        re_deferred=re_deferred,
+        expired=expired,
+        errors=errors,
+    )

--- a/app/services/deferred_retry.py
+++ b/app/services/deferred_retry.py
@@ -183,18 +183,36 @@ def _write_retry_defer(
     )
 
 
-def _increment_retry_count_only(
+def _write_retry_error(
     conn: psycopg.Connection[Any],
     rec: dict[str, Any],
 ) -> None:
-    """Increment retry_count without changing status (error path).
+    """Increment retry_count and write audit row on the error path.
 
-    No audit row: the caller logs the exception.  The rec stays in
-    timing_deferred so the next cycle can retry it again.
+    The rec stays in timing_deferred so the next cycle can retry it.
+    The audit row captures that a retry attempt was consumed by an error,
+    so the trail is complete when the rec is eventually expired.
     """
     rec_id: int = rec["recommendation_id"]
+    instrument_id: int = rec["instrument_id"]
     new_retry_count: int = rec["timing_retry_count"] + 1
 
+    conn.execute(
+        """
+        INSERT INTO decision_audit
+            (decision_time, instrument_id, recommendation_id,
+             stage, pass_fail, explanation)
+        VALUES
+            (NOW(), %(iid)s, %(rid)s,
+             'deferred_retry', 'FAIL',
+             %(expl)s)
+        """,
+        {
+            "iid": instrument_id,
+            "rid": rec_id,
+            "expl": f"evaluation raised an exception (retry_count={new_retry_count})",
+        },
+    )
     conn.execute(
         """
         UPDATE trade_recommendations
@@ -328,7 +346,7 @@ def retry_deferred_recommendations(conn: psycopg.Connection[Any]) -> RetryResult
                     rec_id,
                 )
                 with conn.transaction():
-                    _increment_retry_count_only(conn, rec)
+                    _write_retry_error(conn, rec)
                 conn.commit()
                 errors += 1
 
@@ -338,16 +356,19 @@ def retry_deferred_recommendations(conn: psycopg.Connection[Any]) -> RetryResult
                 rec_id,
                 exc_info=True,
             )
-            # Best-effort: increment retry count so the rec is not stuck
-            # at retry_count=0 forever.  If this also fails, we leave it
-            # unchanged (the next cycle will retry).
+            # The exception may have left the connection in an error state
+            # (InFailedSqlTransaction). Roll back so subsequent operations
+            # on the same connection can proceed.
+            conn.rollback()
+            # Best-effort: increment retry count + write audit row so the
+            # error attempt is visible in the audit trail.
             try:
                 with conn.transaction():
-                    _increment_retry_count_only(conn, rec)
+                    _write_retry_error(conn, rec)
                 conn.commit()
             except Exception:
                 logger.error(
-                    "deferred_retry: could not increment retry_count for rec=%d",
+                    "deferred_retry: could not write error audit for rec=%d",
                     rec_id,
                     exc_info=True,
                 )

--- a/app/services/deferred_retry.py
+++ b/app/services/deferred_retry.py
@@ -280,8 +280,9 @@ def retry_deferred_recommendations(conn: psycopg.Connection[Any]) -> RetryResult
         count_expired = retry_count >= MAX_RETRY_ATTEMPTS
 
         if age_expired or count_expired:
-            if age_expired:
-                assert deferred_at is not None  # narrowed by age_expired
+            # age_expired guarantees deferred_at is not None, but pyright
+            # can't narrow through a bool variable — re-check explicitly.
+            if age_expired and deferred_at is not None:
                 reason = (
                     f"deferred_retry: expired — deferred_at={deferred_at.isoformat()} "
                     f"older than {RETRY_EXPIRY_HOURS}h cutoff"
@@ -359,7 +360,9 @@ def retry_deferred_recommendations(conn: psycopg.Connection[Any]) -> RetryResult
             )
             # The exception may have left the connection in an error state
             # (InFailedSqlTransaction). Roll back so subsequent operations
-            # on the same connection can proceed.
+            # on the same connection can proceed. This only discards the
+            # failed evaluate_entry_conditions work — prior iterations
+            # committed immediately, so no committed data is lost.
             conn.rollback()
             # Best-effort: increment retry count + write audit row so the
             # error attempt is visible in the audit trail.

--- a/app/services/deferred_retry.py
+++ b/app/services/deferred_retry.py
@@ -269,8 +269,7 @@ def retry_deferred_recommendations(conn: psycopg.Connection[Any]) -> RetryResult
                 )
             else:
                 reason = (
-                    f"deferred_retry: expired — retry_count={retry_count} "
-                    f">= MAX_RETRY_ATTEMPTS={MAX_RETRY_ATTEMPTS}"
+                    f"deferred_retry: expired — retry_count={retry_count} >= MAX_RETRY_ATTEMPTS={MAX_RETRY_ATTEMPTS}"
                 )
             try:
                 with conn.transaction():

--- a/app/services/deferred_retry.py
+++ b/app/services/deferred_retry.py
@@ -280,7 +280,8 @@ def retry_deferred_recommendations(conn: psycopg.Connection[Any]) -> RetryResult
         count_expired = retry_count >= MAX_RETRY_ATTEMPTS
 
         if age_expired or count_expired:
-            if age_expired and deferred_at is not None:
+            if age_expired:
+                assert deferred_at is not None  # narrowed by age_expired
                 reason = (
                     f"deferred_retry: expired — deferred_at={deferred_at.isoformat()} "
                     f"older than {RETRY_EXPIRY_HOURS}h cutoff"

--- a/app/services/position_monitor.py
+++ b/app/services/position_monitor.py
@@ -1,0 +1,187 @@
+"""Position monitor service — intraday SL/TP/thesis-break detection.
+
+Checks all open positions against the latest quotes and thesis data to
+surface breaches that the daily 05:30 broker sync would otherwise miss.
+
+Design choices:
+  - READ-ONLY: no state mutations, no orders placed.
+  - NULL SL/TP/red_flag = skip that check (never block on missing data).
+  - filter WHERE current_units > 0 to exclude liquidated positions.
+  - LATERAL joins for quotes/theses/broker_positions to avoid JOIN fan-out.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+import psycopg.rows
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Mirror portfolio.EXIT_RED_FLAG_THRESHOLD — exported as Decimal for
+# consistent comparison against Decimal values returned from the DB.
+EXIT_RED_FLAG_THRESHOLD = Decimal("0.80")
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+AlertType = Literal["sl_breach", "tp_breach", "thesis_break"]
+
+
+@dataclass(frozen=True)
+class MonitorAlert:
+    """A single position health alert."""
+
+    instrument_id: int
+    symbol: str
+    alert_type: AlertType
+    detail: str
+    current_bid: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class MonitorResult:
+    """Aggregate result returned by check_position_health."""
+
+    positions_checked: int
+    alerts: list[MonitorAlert] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check_position_health(conn: psycopg.Connection[Any]) -> MonitorResult:
+    """Check all open positions against latest quotes and thesis data.
+
+    For each open position:
+      - sl_breach:    bid is not None AND sl is not None AND bid < sl
+      - tp_breach:    bid is not None AND tp is not None AND bid >= tp
+      - thesis_break: red_flag is not None AND red_flag >= EXIT_RED_FLAG_THRESHOLD
+
+    Returns a MonitorResult with the count of positions checked and any alerts
+    raised. NULL SL/TP/red_flag values are silently skipped — never block on
+    missing data (prevention log: missing data on hard-rule path).
+
+    This function is read-only. It neither places orders nor mutates any state.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT
+                p.instrument_id,
+                i.symbol,
+                bp.stop_loss_rate,
+                bp.take_profit_rate,
+                q.bid,
+                t.red_flag_score
+            FROM positions p
+            JOIN instruments i USING (instrument_id)
+            -- Latest broker_positions row for this position's SL/TP.
+            -- LATERAL prevents JOIN fan-out (prevention log: JOIN fan-out inflates
+            -- aggregates — broker_positions has multiple rows per instrument).
+            LEFT JOIN LATERAL (
+                SELECT stop_loss_rate, take_profit_rate
+                FROM broker_positions
+                WHERE instrument_id = p.instrument_id
+                ORDER BY updated_at DESC
+                LIMIT 1
+            ) bp ON TRUE
+            -- Latest quote bid/ask.
+            LEFT JOIN LATERAL (
+                SELECT bid
+                FROM quotes
+                WHERE instrument_id = p.instrument_id
+                ORDER BY quoted_at DESC
+                LIMIT 1
+            ) q ON TRUE
+            -- Latest thesis red_flag_score.
+            LEFT JOIN LATERAL (
+                SELECT red_flag_score
+                FROM theses
+                WHERE instrument_id = p.instrument_id
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) t ON TRUE
+            WHERE p.current_units > 0
+            """
+        )
+        rows = cur.fetchall()
+
+    alerts: list[MonitorAlert] = []
+
+    for row in rows:
+        instrument_id: int = row["instrument_id"]
+        symbol: str = row["symbol"]
+
+        bid_raw = row["bid"]
+        sl_raw = row["stop_loss_rate"]
+        tp_raw = row["take_profit_rate"]
+        red_flag_raw = row["red_flag_score"]
+
+        bid = Decimal(str(bid_raw)) if bid_raw is not None else None
+        sl = Decimal(str(sl_raw)) if sl_raw is not None else None
+        tp = Decimal(str(tp_raw)) if tp_raw is not None else None
+        red_flag = Decimal(str(red_flag_raw)) if red_flag_raw is not None else None
+
+        # SL breach: current bid has fallen below the stop-loss rate.
+        if bid is not None and sl is not None and bid < sl:
+            alerts.append(
+                MonitorAlert(
+                    instrument_id=instrument_id,
+                    symbol=symbol,
+                    alert_type="sl_breach",
+                    detail=f"bid={bid} < stop_loss={sl}",
+                    current_bid=bid,
+                )
+            )
+
+        # TP breach: current bid has reached or exceeded the take-profit rate.
+        if bid is not None and tp is not None and bid >= tp:
+            alerts.append(
+                MonitorAlert(
+                    instrument_id=instrument_id,
+                    symbol=symbol,
+                    alert_type="tp_breach",
+                    detail=f"bid={bid} >= take_profit={tp}",
+                    current_bid=bid,
+                )
+            )
+
+        # Thesis break: red flag score at or above the exit threshold.
+        if red_flag is not None and red_flag >= EXIT_RED_FLAG_THRESHOLD:
+            alerts.append(
+                MonitorAlert(
+                    instrument_id=instrument_id,
+                    symbol=symbol,
+                    alert_type="thesis_break",
+                    detail=f"red_flag={red_flag} >= threshold={EXIT_RED_FLAG_THRESHOLD}",
+                    current_bid=bid,
+                )
+            )
+
+        if alerts:
+            logger.info(
+                "position_monitor: %d alert(s) for instrument_id=%d symbol=%s",
+                sum(1 for a in alerts if a.instrument_id == instrument_id),
+                instrument_id,
+                symbol,
+            )
+
+    logger.info(
+        "position_monitor: checked=%d alerts=%d",
+        len(rows),
+        len(alerts),
+    )
+
+    return MonitorResult(positions_checked=len(rows), alerts=alerts)

--- a/app/services/position_monitor.py
+++ b/app/services/position_monitor.py
@@ -13,7 +13,7 @@ Design choices:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, Literal
 
@@ -53,7 +53,7 @@ class MonitorResult:
     """Aggregate result returned by check_position_health."""
 
     positions_checked: int
-    alerts: list[MonitorAlert] = field(default_factory=list)
+    alerts: tuple[MonitorAlert, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -170,4 +170,4 @@ def check_position_health(conn: psycopg.Connection[Any]) -> MonitorResult:
                 )
             )
 
-    return MonitorResult(positions_checked=len(rows), alerts=alerts)
+    return MonitorResult(positions_checked=len(rows), alerts=tuple(alerts))

--- a/app/services/position_monitor.py
+++ b/app/services/position_monitor.py
@@ -170,18 +170,4 @@ def check_position_health(conn: psycopg.Connection[Any]) -> MonitorResult:
                 )
             )
 
-        if alerts:
-            logger.info(
-                "position_monitor: %d alert(s) for instrument_id=%d symbol=%s",
-                sum(1 for a in alerts if a.instrument_id == instrument_id),
-                instrument_id,
-                symbol,
-            )
-
-    logger.info(
-        "position_monitor: checked=%d alerts=%d",
-        len(rows),
-        len(alerts),
-    )
-
     return MonitorResult(positions_checked=len(rows), alerts=alerts)

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -41,6 +41,7 @@ from app.providers.implementations.sec_edgar import SecFilingsProvider
 from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
 from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
 from app.services.coverage import review_coverage, seed_coverage
+from app.services.deferred_retry import retry_deferred_recommendations
 from app.services.enrichment import refresh_enrichment
 from app.services.entry_timing import evaluate_entry_conditions
 from app.services.execution_guard import evaluate_recommendation
@@ -52,6 +53,7 @@ from app.services.ops_monitor import check_row_count_spike, record_job_finish, r
 from app.services.order_client import execute_order
 from app.services.portfolio import run_portfolio_review
 from app.services.portfolio_sync import sync_portfolio
+from app.services.position_monitor import check_position_health
 from app.services.scoring import compute_rankings
 from app.services.sentiment import ClaudeSentimentScorer
 from app.services.tax_ledger import ingest_tax_events, run_disposal_matching
@@ -176,6 +178,8 @@ JOB_DAILY_TAX_RECONCILIATION = "daily_tax_reconciliation"
 JOB_DAILY_PORTFOLIO_SYNC = "daily_portfolio_sync"
 JOB_EXECUTE_APPROVED_ORDERS = "execute_approved_orders"
 JOB_FX_RATES_REFRESH = "fx_rates_refresh"
+JOB_RETRY_DEFERRED = "retry_deferred_recommendations"
+JOB_MONITOR_POSITIONS = "monitor_positions"
 
 
 # ---------------------------------------------------------------------------
@@ -227,6 +231,29 @@ def _has_actionable_recommendations(conn: psycopg.Connection[Any]) -> Prerequisi
     ):
         return (True, "")
     return (False, "no proposed or approved recommendations")
+
+
+def _has_deferred_recommendations(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if at least one timing_deferred BUY/ADD recommendation exists."""
+    if _exists(
+        conn,
+        psycopg.sql.SQL(
+            "SELECT EXISTS(SELECT 1 FROM trade_recommendations "
+            "WHERE status = 'timing_deferred' AND action IN ('BUY', 'ADD'))"
+        ),
+    ):
+        return (True, "")
+    return (False, "no timing_deferred BUY/ADD recommendations")
+
+
+def _has_open_positions(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if at least one open position exists."""
+    if _exists(
+        conn,
+        psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM positions WHERE current_units > 0)"),
+    ):
+        return (True, "")
+    return (False, "no open positions")
 
 
 def _has_tier1_stale_theses(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
@@ -298,6 +325,20 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         prerequisite=_has_actionable_recommendations,
         # Do not fire on cold boot — order execution must only happen at
         # the scheduled time, not as a surprise catch-up hours later.
+        catch_up_on_boot=False,
+    ),
+    ScheduledJob(
+        name=JOB_RETRY_DEFERRED,
+        description="Re-evaluate timing_deferred recommendations with fresh TA data.",
+        cadence=Cadence.hourly(minute=30),
+        prerequisite=_has_deferred_recommendations,
+        catch_up_on_boot=False,
+    ),
+    ScheduledJob(
+        name=JOB_MONITOR_POSITIONS,
+        description="Check open positions for SL/TP breaches and thesis breaks.",
+        cadence=Cadence.hourly(minute=15),
+        prerequisite=_has_open_positions,
         catch_up_on_boot=False,
     ),
     ScheduledJob(
@@ -1032,6 +1073,21 @@ def morning_candidate_review() -> None:
         rec_result.total_aum,
     )
 
+    # --- Pipeline trigger: if recs were generated, run the execution pipeline ---
+    actionable_count = sum(1 for r in rec_result.recommendations if r.action in ("BUY", "ADD", "EXIT"))
+    if actionable_count > 0:
+        logger.info(
+            "morning_candidate_review: %d actionable recs → triggering execute_approved_orders",
+            actionable_count,
+        )
+        try:
+            execute_approved_orders()
+        except Exception:
+            logger.error(
+                "morning_candidate_review: pipeline trigger to execute_approved_orders failed",
+                exc_info=True,
+            )
+
 
 def _timing_error_defer(
     rec_id: int,
@@ -1063,7 +1119,8 @@ def _timing_error_defer(
                 UPDATE trade_recommendations
                 SET status = 'timing_deferred',
                     timing_verdict = 'error',
-                    timing_rationale = %(rationale)s
+                    timing_rationale = %(rationale)s,
+                    timing_deferred_at = COALESCE(timing_deferred_at, NOW())
                 WHERE recommendation_id = %(rid)s
                 """,
                 {"rid": rec_id, "rationale": explanation},
@@ -1185,7 +1242,8 @@ def execute_approved_orders() -> None:
                                         stop_loss_rate = %(sl)s,
                                         take_profit_rate = %(tp)s,
                                         timing_verdict = %(verdict)s,
-                                        timing_rationale = %(rationale)s
+                                        timing_rationale = %(rationale)s,
+                                        timing_deferred_at = COALESCE(timing_deferred_at, NOW())
                                     WHERE recommendation_id = %(rid)s
                                     """,
                                     update_params,
@@ -1428,6 +1486,92 @@ def execute_approved_orders() -> None:
         pending,
         failed,
     )
+
+
+def retry_deferred_recommendations_job() -> None:
+    """Re-evaluate timing_deferred recommendations hourly.
+
+    Checks kill switch and auto-trading flag before proceeding.
+    Deferred recs that now pass timing are transitioned to 'proposed'
+    so they enter the next execute_approved_orders cycle.
+    """
+    from app.services.ops_monitor import get_kill_switch_status
+    from app.services.runtime_config import get_runtime_config
+
+    with _tracked_job(JOB_RETRY_DEFERRED) as tracker:
+        # Safety gate: kill switch + auto-trading check
+        try:
+            with psycopg.connect(settings.database_url) as conn:
+                ks = get_kill_switch_status(conn)
+                config = get_runtime_config(conn)
+        except Exception:
+            logger.error("retry_deferred: failed to load runtime config", exc_info=True)
+            tracker.row_count = 0
+            return
+
+        if ks.get("is_active"):
+            logger.warning("retry_deferred: kill switch active, skipping")
+            tracker.row_count = 0
+            return
+
+        if not config.enable_auto_trading:
+            logger.info("retry_deferred: auto_trading disabled, skipping")
+            tracker.row_count = 0
+            return
+
+        try:
+            with psycopg.connect(settings.database_url) as conn:
+                result = retry_deferred_recommendations(conn)
+        except Exception:
+            logger.error("retry_deferred: service call failed", exc_info=True)
+            tracker.row_count = 0
+            return
+
+        tracker.row_count = result.retried + result.expired + result.errors
+        logger.info(
+            "retry_deferred: retried=%d re_proposed=%d re_deferred=%d expired=%d errors=%d",
+            result.retried,
+            result.re_proposed,
+            result.re_deferred,
+            result.expired,
+            result.errors,
+        )
+
+
+def monitor_positions_job() -> None:
+    """Hourly position health check.
+
+    Detects SL/TP breaches and thesis breaks between daily sync cycles.
+    Alerts are logged for now; future work may trigger out-of-cycle
+    EXIT recommendations or operator notifications.
+
+    Read-only — does not place orders or modify positions.
+    """
+    with _tracked_job(JOB_MONITOR_POSITIONS) as tracker:
+        try:
+            with psycopg.connect(settings.database_url) as conn:
+                result = check_position_health(conn)
+        except Exception:
+            logger.error("monitor_positions: health check failed", exc_info=True)
+            tracker.row_count = 0
+            return
+
+        tracker.row_count = result.positions_checked
+
+        if result.alerts:
+            for alert in result.alerts:
+                logger.warning(
+                    "monitor_positions: ALERT %s on %s (instrument_id=%d): %s",
+                    alert.alert_type,
+                    alert.symbol,
+                    alert.instrument_id,
+                    alert.detail,
+                )
+        else:
+            logger.info(
+                "monitor_positions: %d positions checked, no alerts",
+                result.positions_checked,
+            )
 
 
 def weekly_coverage_review() -> None:

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1074,14 +1074,29 @@ def morning_candidate_review() -> None:
     )
 
     # --- Pipeline trigger: if recs were generated, run the execution pipeline ---
+    # Gate on kill switch and auto-trading flag before invoking the execution
+    # path — the guard inside execute_approved_orders is a second line of
+    # defence, not a substitute for checking at the call site.
     actionable_count = sum(1 for r in rec_result.recommendations if r.action in ("BUY", "ADD", "EXIT"))
     if actionable_count > 0:
-        logger.info(
-            "morning_candidate_review: %d actionable recs → triggering execute_approved_orders",
-            actionable_count,
-        )
         try:
-            execute_approved_orders()
+            from app.services.ops_monitor import get_kill_switch_status
+            from app.services.runtime_config import get_runtime_config
+
+            with psycopg.connect(settings.database_url) as conn:
+                ks = get_kill_switch_status(conn)
+                config = get_runtime_config(conn)
+
+            if ks.get("is_active"):
+                logger.warning("morning_candidate_review: kill switch active, skipping pipeline trigger")
+            elif not config.enable_auto_trading:
+                logger.info("morning_candidate_review: auto_trading disabled, skipping pipeline trigger")
+            else:
+                logger.info(
+                    "morning_candidate_review: %d actionable recs → triggering execute_approved_orders",
+                    actionable_count,
+                )
+                execute_approved_orders()
         except Exception:
             logger.error(
                 "morning_candidate_review: pipeline trigger to execute_approved_orders failed",
@@ -1499,28 +1514,24 @@ def retry_deferred_recommendations_job() -> None:
     from app.services.runtime_config import get_runtime_config
 
     with _tracked_job(JOB_RETRY_DEFERRED) as tracker:
-        # Safety gate: kill switch + auto-trading check
+        # Single connection for config check + service call so the kill
+        # switch state cannot change between the gate and the work.
         try:
             with psycopg.connect(settings.database_url) as conn:
+                # Safety gate: kill switch + auto-trading check
                 ks = get_kill_switch_status(conn)
                 config = get_runtime_config(conn)
-        except Exception:
-            logger.error("retry_deferred: failed to load runtime config", exc_info=True)
-            tracker.row_count = 0
-            return
 
-        if ks.get("is_active"):
-            logger.warning("retry_deferred: kill switch active, skipping")
-            tracker.row_count = 0
-            return
+                if ks.get("is_active"):
+                    logger.warning("retry_deferred: kill switch active, skipping")
+                    tracker.row_count = 0
+                    return
 
-        if not config.enable_auto_trading:
-            logger.info("retry_deferred: auto_trading disabled, skipping")
-            tracker.row_count = 0
-            return
+                if not config.enable_auto_trading:
+                    logger.info("retry_deferred: auto_trading disabled, skipping")
+                    tracker.row_count = 0
+                    return
 
-        try:
-            with psycopg.connect(settings.database_url) as conn:
                 result = retry_deferred_recommendations(conn)
         except Exception:
             logger.error("retry_deferred: service call failed", exc_info=True)

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -716,3 +716,21 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `ON CONFLICT DO UPDATE SET units, amount, updated_at` omitted `total_fees`, `open_rate`, and `open_conversion_rate`. On a race, the losing writer's fee and rate values were silently discarded.
 - Prevention: Before pushing any `ON CONFLICT DO UPDATE` on a financial table (`broker_positions`, `copy_mirror_positions`), verify the SET clause covers all columns where the eBull-originated values should be authoritative — especially fees and rates. If a column should intentionally NOT be updated on conflict, add a SQL comment explaining why.
 - Enforced in: `app/services/order_client.py`, `app/api/orders.py`
+
+---
+
+### conn.rollback() needed after caught exception on a shared connection
+
+- First seen in: #238
+- Symptom: `evaluate_entry_conditions(conn, rec_id)` raises mid-cursor, leaving the connection in `InFailedSqlTransaction` state. Every subsequent `with conn.transaction()` on the same connection fails silently — the rest of the batch is dead.
+- Prevention: When a service function calls I/O that may raise on a **shared connection** (one used for multiple sequential operations), wrap the call in `try/except` and call `conn.rollback()` in the except path before attempting any further DB work on that connection. This clears the error state.
+- Enforced in: `app/services/deferred_retry.py` (retry_deferred_recommendations error path)
+
+---
+
+### Kill-switch + auto_trading gate at pipeline call sites
+
+- First seen in: #238
+- Symptom: `morning_candidate_review()` called `execute_approved_orders()` directly without checking the kill switch or `enable_auto_trading` flag. The guards *inside* `execute_approved_orders` would catch it, but the non-negotiable rule is that AI-generated trade actions must never reach the execution path without an explicit gate at the call site.
+- Prevention: Any code path that invokes `execute_approved_orders()` (or any future order-execution function) must check both `get_kill_switch_status(conn)["is_active"]` and `get_runtime_config(conn).enable_auto_trading` before the call. The callee's internal guard is a second line of defence, not the primary one.
+- Enforced in: `app/workers/scheduler.py` (morning_candidate_review pipeline trigger)

--- a/sql/028_autonomous_loop.sql
+++ b/sql/028_autonomous_loop.sql
@@ -20,6 +20,9 @@ ALTER TABLE trade_recommendations
 -- Add timing_expired to the status vocabulary.
 -- No existing CHECK constraint on status (001_init.sql uses bare TEXT),
 -- so we add one now for the expanded set used by the autonomous loop.
+-- Use NOT VALID to avoid a full-table scan on ADD, then VALIDATE in a
+-- separate statement so existing out-of-vocabulary rows (if any) surface
+-- as a clear error rather than rolling back the entire migration.
 -- Wrapped in DO $$ for idempotency.
 DO $$
 BEGIN
@@ -31,5 +34,11 @@ BEGIN
             'proposed', 'approved', 'rejected', 'executed',
             'execution_failed', 'timing_deferred', 'timing_expired',
             'cancelled'
-        ));
+        ))
+        NOT VALID;
 END $$;
+
+-- Validate separately — this does a sequential scan but will not hold
+-- an ACCESS EXCLUSIVE lock (only SHARE UPDATE EXCLUSIVE), and will fail
+-- cleanly if any legacy rows violate the constraint.
+ALTER TABLE trade_recommendations VALIDATE CONSTRAINT chk_recommendation_status;

--- a/sql/028_autonomous_loop.sql
+++ b/sql/028_autonomous_loop.sql
@@ -1,0 +1,35 @@
+-- Migration 028: autonomous operation loop — deferred retry tracking
+--
+-- timing_retry_count: how many times a timing_deferred rec has been
+--   re-evaluated. Starts at 0, incremented on each retry attempt.
+--   Used to cap retries (max 3 per cycle) and for observability.
+--
+-- timing_deferred_at: when the rec was first deferred. Used to expire
+--   stale deferred recs (>24h old) so they don't retry indefinitely.
+--
+-- deferred_recommendation_id: when a deferred rec expires, a new
+--   recommendation may be generated in the next morning cycle. This
+--   FK links the retry lineage for auditability.
+
+ALTER TABLE trade_recommendations
+    ADD COLUMN IF NOT EXISTS timing_retry_count      INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS timing_deferred_at       TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS deferred_recommendation_id BIGINT
+        REFERENCES trade_recommendations(recommendation_id);
+
+-- Add timing_expired to the status vocabulary.
+-- No existing CHECK constraint on status (001_init.sql uses bare TEXT),
+-- so we add one now for the expanded set used by the autonomous loop.
+-- Wrapped in DO $$ for idempotency.
+DO $$
+BEGIN
+    ALTER TABLE trade_recommendations
+        DROP CONSTRAINT IF EXISTS chk_recommendation_status;
+    ALTER TABLE trade_recommendations
+        ADD CONSTRAINT chk_recommendation_status
+        CHECK (status IN (
+            'proposed', 'approved', 'rejected', 'executed',
+            'execution_failed', 'timing_deferred', 'timing_expired',
+            'cancelled'
+        ));
+END $$;

--- a/tests/test_deferred_retry.py
+++ b/tests/test_deferred_retry.py
@@ -1,0 +1,269 @@
+"""Tests for app.services.deferred_retry.
+
+Structure:
+  - TestRetryDeferredRecommendations — full retry_deferred_recommendations
+    with mocked DB and mocked evaluate_entry_conditions.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.services.deferred_retry import (
+    MAX_RETRY_ATTEMPTS,
+    RETRY_EXPIRY_HOURS,
+    RetryResult,
+    retry_deferred_recommendations,
+)
+from app.services.entry_timing import EntryEvaluation
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PATCH_TARGET = "app.services.deferred_retry.evaluate_entry_conditions"
+
+
+def _make_cursor(rows: list[dict[str, Any]]) -> MagicMock:
+    cur = MagicMock()
+    cur.fetchall.return_value = rows
+    cur.fetchone.return_value = rows[0] if rows else None
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    return cur
+
+
+def _make_conn(cursor: MagicMock) -> MagicMock:
+    """Return a connection mock whose cursor() context manager yields ``cursor``."""
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    # transaction() must work as a context manager
+    txn_ctx = MagicMock()
+    txn_ctx.__enter__ = MagicMock(return_value=txn_ctx)
+    txn_ctx.__exit__ = MagicMock(return_value=False)
+    conn.transaction.return_value = txn_ctx
+    return conn
+
+
+def _rec(
+    recommendation_id: int = 1,
+    instrument_id: int = 42,
+    action: str = "BUY",
+    timing_retry_count: int = 0,
+    timing_deferred_at: datetime | None = None,
+) -> dict[str, Any]:
+    if timing_deferred_at is None:
+        timing_deferred_at = datetime.now(tz=UTC) - timedelta(hours=1)
+    return {
+        "recommendation_id": recommendation_id,
+        "instrument_id": instrument_id,
+        "action": action,
+        "timing_retry_count": timing_retry_count,
+        "timing_deferred_at": timing_deferred_at,
+    }
+
+
+def _pass_evaluation() -> EntryEvaluation:
+    return EntryEvaluation(
+        verdict="pass",
+        stop_loss_rate=Decimal("142.5"),
+        take_profit_rate=Decimal("200.0"),
+        rationale="PASS (all conditions favorable)",
+        condition_details={"cond_0": "rsi: 55.0 (ok)"},
+    )
+
+
+def _defer_evaluation() -> EntryEvaluation:
+    return EntryEvaluation(
+        verdict="defer",
+        stop_loss_rate=Decimal("142.5"),
+        take_profit_rate=None,
+        rationale="DEFER (1 unfavorable): rsi: 80.0 > 75.0 (overbought, defer)",
+        condition_details={"cond_0": "rsi: 80.0 > 75.0 (overbought, defer)"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRetryDeferredRecommendations:
+    """retry_deferred_recommendations with mocked DB."""
+
+    def test_no_deferred_recs_returns_zero_counts(self) -> None:
+        """Empty fetchall → RetryResult with all zeros, no DB writes."""
+        cur = _make_cursor([])
+        conn = _make_conn(cur)
+
+        result = retry_deferred_recommendations(conn)
+
+        assert result == RetryResult(retried=0, re_proposed=0, re_deferred=0, expired=0, errors=0)
+        conn.execute.assert_not_called()
+
+    def test_deferred_rec_within_retry_limit_is_re_evaluated(self) -> None:
+        """retry_count < MAX and not expired → evaluate, PASS → re_proposed=1."""
+        rec = _rec(timing_retry_count=0)
+        cur = _make_cursor([rec])
+        conn = _make_conn(cur)
+
+        with patch(_PATCH_TARGET, return_value=_pass_evaluation()) as mock_fn:
+            result = retry_deferred_recommendations(conn)
+
+        mock_fn.assert_called_once_with(conn, rec["recommendation_id"])
+        assert result.re_proposed == 1
+        assert result.retried == 1
+        assert result.re_deferred == 0
+        assert result.expired == 0
+        assert result.errors == 0
+
+    def test_deferred_rec_exceeding_retry_limit_is_expired(self) -> None:
+        """retry_count == MAX_RETRY_ATTEMPTS → expired=1, no evaluation call."""
+        rec = _rec(timing_retry_count=MAX_RETRY_ATTEMPTS)
+        cur = _make_cursor([rec])
+        conn = _make_conn(cur)
+
+        with patch(_PATCH_TARGET) as mock_fn:
+            result = retry_deferred_recommendations(conn)
+
+        mock_fn.assert_not_called()
+        assert result.expired == 1
+        assert result.retried == 0
+        assert result.errors == 0
+        # Verify the UPDATE to timing_expired was issued
+        update_calls = [str(c) for c in conn.execute.call_args_list]
+        assert any("timing_expired" in c for c in update_calls)
+
+    def test_deferred_rec_older_than_expiry_is_expired(self) -> None:
+        """deferred_at older than RETRY_EXPIRY_HOURS → expired=1, no evaluation call."""
+        old_time = datetime.now(tz=UTC) - timedelta(hours=RETRY_EXPIRY_HOURS + 1)
+        rec = _rec(timing_retry_count=0, timing_deferred_at=old_time)
+        cur = _make_cursor([rec])
+        conn = _make_conn(cur)
+
+        with patch(_PATCH_TARGET) as mock_fn:
+            result = retry_deferred_recommendations(conn)
+
+        mock_fn.assert_not_called()
+        assert result.expired == 1
+        assert result.retried == 0
+        assert result.errors == 0
+
+    def test_re_evaluation_still_unfavorable_increments_retry_count(self) -> None:
+        """eval returns defer → re_deferred=1, retry_count incremented."""
+        rec = _rec(timing_retry_count=1)
+        cur = _make_cursor([rec])
+        conn = _make_conn(cur)
+
+        with patch(_PATCH_TARGET, return_value=_defer_evaluation()):
+            result = retry_deferred_recommendations(conn)
+
+        assert result.re_deferred == 1
+        assert result.retried == 1
+        assert result.re_proposed == 0
+        assert result.expired == 0
+        assert result.errors == 0
+        # Verify retry_count was incremented (UPDATE with timing_retry_count)
+        update_calls = [str(c) for c in conn.execute.call_args_list]
+        assert any("timing_retry_count" in c for c in update_calls)
+
+    def test_evaluation_exception_increments_errors_and_retry_count(self) -> None:
+        """evaluate_entry_conditions raises → errors=1, retry_count increment attempted."""
+        rec = _rec(timing_retry_count=0)
+        cur = _make_cursor([rec])
+        conn = _make_conn(cur)
+
+        with patch(_PATCH_TARGET, side_effect=RuntimeError("TA data unavailable")):
+            result = retry_deferred_recommendations(conn)
+
+        assert result.errors == 1
+        assert result.retried == 1
+        assert result.re_proposed == 0
+        assert result.re_deferred == 0
+        # Best-effort retry_count increment: transaction() must have been called
+        conn.transaction.assert_called()
+
+    def test_multiple_recs_counted_independently(self) -> None:
+        """Two recs: one passes, one defers → re_proposed=1, re_deferred=1."""
+        rec_pass = _rec(recommendation_id=1, timing_retry_count=0)
+        rec_defer = _rec(recommendation_id=2, timing_retry_count=1)
+        cur = _make_cursor([rec_pass, rec_defer])
+        conn = _make_conn(cur)
+
+        def _dispatch(_conn: Any, rec_id: int) -> EntryEvaluation:
+            if rec_id == 1:
+                return _pass_evaluation()
+            return _defer_evaluation()
+
+        with patch(_PATCH_TARGET, side_effect=_dispatch):
+            result = retry_deferred_recommendations(conn)
+
+        assert result.re_proposed == 1
+        assert result.re_deferred == 1
+        assert result.retried == 2
+        assert result.expired == 0
+        assert result.errors == 0
+
+    def test_expiry_check_age_wins_over_retry_count(self) -> None:
+        """rec with retry_count < MAX but age > RETRY_EXPIRY_HOURS → expired (age wins)."""
+        old_time = datetime.now(tz=UTC) - timedelta(hours=RETRY_EXPIRY_HOURS + 5)
+        rec = _rec(timing_retry_count=MAX_RETRY_ATTEMPTS - 1, timing_deferred_at=old_time)
+        cur = _make_cursor([rec])
+        conn = _make_conn(cur)
+
+        with patch(_PATCH_TARGET) as mock_fn:
+            result = retry_deferred_recommendations(conn)
+
+        mock_fn.assert_not_called()
+        assert result.expired == 1
+
+    def test_audit_row_written_on_pass(self) -> None:
+        """On PASS, decision_audit INSERT includes stage=deferred_retry and pass_fail=PASS."""
+        rec = _rec(timing_retry_count=0)
+        cur = _make_cursor([rec])
+        conn = _make_conn(cur)
+
+        with patch(_PATCH_TARGET, return_value=_pass_evaluation()):
+            retry_deferred_recommendations(conn)
+
+        all_calls = [str(c) for c in conn.execute.call_args_list]
+        assert any("deferred_retry" in c for c in all_calls)
+        assert any("PASS" in c for c in all_calls)
+
+    def test_audit_row_written_on_expiry(self) -> None:
+        """On expiry, decision_audit INSERT includes pass_fail=FAIL."""
+        rec = _rec(timing_retry_count=MAX_RETRY_ATTEMPTS)
+        cur = _make_cursor([rec])
+        conn = _make_conn(cur)
+
+        with patch(_PATCH_TARGET):
+            retry_deferred_recommendations(conn)
+
+        all_calls = [str(c) for c in conn.execute.call_args_list]
+        assert any("FAIL" in c for c in all_calls)
+
+    def test_retry_result_is_frozen_dataclass(self) -> None:
+        """RetryResult must be immutable (frozen=True)."""
+        result = RetryResult(retried=1, re_proposed=1, re_deferred=0, expired=0)
+        try:
+            result.retried = 99  # type: ignore[misc]
+            raise AssertionError("Should have raised FrozenInstanceError")
+        except Exception as exc:
+            assert "cannot assign" in str(exc).lower() or "frozen" in str(exc).lower()
+
+    def test_none_timing_deferred_at_skips_age_check(self) -> None:
+        """If timing_deferred_at is None, age check is skipped — rec is re-evaluated."""
+        rec = _rec(timing_retry_count=0)
+        rec["timing_deferred_at"] = None
+        cur = _make_cursor([rec])
+        conn = _make_conn(cur)
+
+        with patch(_PATCH_TARGET, return_value=_pass_evaluation()) as mock_fn:
+            result = retry_deferred_recommendations(conn)
+
+        mock_fn.assert_called_once()
+        assert result.re_proposed == 1
+        assert result.expired == 0

--- a/tests/test_position_monitor.py
+++ b/tests/test_position_monitor.py
@@ -6,6 +6,7 @@ Structure:
 
 from __future__ import annotations
 
+import dataclasses
 from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock
@@ -213,8 +214,6 @@ class TestCheckPositionHealth:
         """MonitorResult and MonitorAlert are frozen (immutable)."""
         conn = _make_conn([_make_cursor([])])
         result = check_position_health(conn)
-        import dataclasses
-
         assert dataclasses.is_dataclass(result)
         # Frozen: assigning to a field raises FrozenInstanceError
         try:

--- a/tests/test_position_monitor.py
+++ b/tests/test_position_monitor.py
@@ -1,0 +1,233 @@
+"""Tests for app.services.position_monitor — intraday SL/TP/thesis-break detection.
+
+Structure:
+  - TestCheckPositionHealth — full check_position_health with mocked DB
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+from app.services.position_monitor import (
+    EXIT_RED_FLAG_THRESHOLD,
+    check_position_health,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cursor(rows: list[dict[str, Any]]) -> MagicMock:
+    """Build a mock cursor that returns dict rows from fetchall."""
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.fetchone.return_value = rows[0] if rows else None
+    cur.fetchall.return_value = rows
+    return cur
+
+
+def _make_conn(cursors: list[MagicMock]) -> MagicMock:
+    """Build a mock connection whose cursor() calls consume cursors in order."""
+    conn = MagicMock()
+    cursor_iter = iter(cursors)
+    conn.cursor.side_effect = lambda **kwargs: next(cursor_iter)
+    conn.execute.return_value = MagicMock()
+    return conn
+
+
+def _position_row(
+    instrument_id: int = 1,
+    symbol: str = "AAPL",
+    stop_loss_rate: float | None = 140.0,
+    take_profit_rate: float | None = 200.0,
+    bid: float | None = 160.0,
+    red_flag_score: float | None = 0.20,
+) -> dict[str, Any]:
+    """Build a synthetic position row matching the query projection."""
+    return {
+        "instrument_id": instrument_id,
+        "symbol": symbol,
+        "stop_loss_rate": stop_loss_rate,
+        "take_profit_rate": take_profit_rate,
+        "bid": bid,
+        "red_flag_score": red_flag_score,
+    }
+
+
+# ---------------------------------------------------------------------------
+# TestCheckPositionHealth
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPositionHealth:
+    """Full check_position_health with mocked DB."""
+
+    def test_no_open_positions_returns_empty(self) -> None:
+        """Empty fetchall → 0 checked, no alerts."""
+        conn = _make_conn([_make_cursor([])])
+        result = check_position_health(conn)
+        assert result.positions_checked == 0
+        assert result.alerts == []
+
+    def test_position_below_stop_loss_generates_alert(self) -> None:
+        """bid < sl → sl_breach alert."""
+        row = _position_row(bid=130.0, stop_loss_rate=140.0)
+        conn = _make_conn([_make_cursor([row])])
+        result = check_position_health(conn)
+        assert result.positions_checked == 1
+        sl_alerts = [a for a in result.alerts if a.alert_type == "sl_breach"]
+        assert len(sl_alerts) == 1
+        alert = sl_alerts[0]
+        assert alert.instrument_id == 1
+        assert alert.symbol == "AAPL"
+        assert alert.current_bid == Decimal("130.0")
+        assert "stop_loss" in alert.detail
+
+    def test_position_above_take_profit_generates_alert(self) -> None:
+        """bid >= tp → tp_breach alert."""
+        row = _position_row(bid=200.0, take_profit_rate=200.0)
+        conn = _make_conn([_make_cursor([row])])
+        result = check_position_health(conn)
+        tp_alerts = [a for a in result.alerts if a.alert_type == "tp_breach"]
+        assert len(tp_alerts) == 1
+        alert = tp_alerts[0]
+        assert alert.current_bid == Decimal("200.0")
+        assert "take_profit" in alert.detail
+
+    def test_position_strictly_above_take_profit_generates_alert(self) -> None:
+        """bid > tp (strict) also triggers tp_breach."""
+        row = _position_row(bid=210.0, take_profit_rate=200.0)
+        conn = _make_conn([_make_cursor([row])])
+        result = check_position_health(conn)
+        tp_alerts = [a for a in result.alerts if a.alert_type == "tp_breach"]
+        assert len(tp_alerts) == 1
+
+    def test_position_with_high_red_flag_generates_thesis_break_alert(self) -> None:
+        """red_flag >= 0.80 → thesis_break alert."""
+        row = _position_row(red_flag_score=0.85)
+        conn = _make_conn([_make_cursor([row])])
+        result = check_position_health(conn)
+        tb_alerts = [a for a in result.alerts if a.alert_type == "thesis_break"]
+        assert len(tb_alerts) == 1
+        alert = tb_alerts[0]
+        assert "red_flag" in alert.detail
+        assert "threshold" in alert.detail
+
+    def test_red_flag_exactly_at_threshold_generates_alert(self) -> None:
+        """red_flag == EXIT_RED_FLAG_THRESHOLD (0.80) → thesis_break (inclusive boundary)."""
+        row = _position_row(red_flag_score=float(EXIT_RED_FLAG_THRESHOLD))
+        conn = _make_conn([_make_cursor([row])])
+        result = check_position_health(conn)
+        tb_alerts = [a for a in result.alerts if a.alert_type == "thesis_break"]
+        assert len(tb_alerts) == 1
+
+    def test_red_flag_just_below_threshold_no_alert(self) -> None:
+        """red_flag < EXIT_RED_FLAG_THRESHOLD → no thesis_break alert."""
+        row = _position_row(red_flag_score=0.79)
+        conn = _make_conn([_make_cursor([row])])
+        result = check_position_health(conn)
+        tb_alerts = [a for a in result.alerts if a.alert_type == "thesis_break"]
+        assert len(tb_alerts) == 0
+
+    def test_healthy_position_generates_no_alert(self) -> None:
+        """Price in range, low red flag → no alerts."""
+        row = _position_row(
+            bid=160.0,
+            stop_loss_rate=140.0,
+            take_profit_rate=200.0,
+            red_flag_score=0.20,
+        )
+        conn = _make_conn([_make_cursor([row])])
+        result = check_position_health(conn)
+        assert result.positions_checked == 1
+        assert result.alerts == []
+
+    def test_null_sl_tp_does_not_crash(self) -> None:
+        """NULL SL/TP/red_flag → no alerts, no crash."""
+        row = _position_row(
+            stop_loss_rate=None,
+            take_profit_rate=None,
+            red_flag_score=None,
+            bid=160.0,
+        )
+        conn = _make_conn([_make_cursor([row])])
+        result = check_position_health(conn)
+        assert result.positions_checked == 1
+        assert result.alerts == []
+
+    def test_null_bid_skips_sl_and_tp_checks(self) -> None:
+        """NULL bid → sl_breach and tp_breach checks skipped; no alerts."""
+        row = _position_row(
+            bid=None,
+            stop_loss_rate=140.0,
+            take_profit_rate=200.0,
+            red_flag_score=0.10,
+        )
+        conn = _make_conn([_make_cursor([row])])
+        result = check_position_health(conn)
+        # red_flag is 0.10 < threshold so no thesis_break either
+        assert result.alerts == []
+
+    def test_multiple_positions_counted_correctly(self) -> None:
+        """Multiple positions → positions_checked equals the row count."""
+        rows = [
+            _position_row(instrument_id=1, symbol="AAPL"),
+            _position_row(instrument_id=2, symbol="TSLA"),
+            _position_row(instrument_id=3, symbol="MSFT"),
+        ]
+        conn = _make_conn([_make_cursor(rows)])
+        result = check_position_health(conn)
+        assert result.positions_checked == 3
+
+    def test_position_can_trigger_multiple_alert_types(self) -> None:
+        """A single position can generate both sl_breach and thesis_break simultaneously."""
+        row = _position_row(
+            bid=130.0,
+            stop_loss_rate=140.0,
+            take_profit_rate=200.0,
+            red_flag_score=0.90,
+        )
+        conn = _make_conn([_make_cursor([row])])
+        result = check_position_health(conn)
+        alert_types = {a.alert_type for a in result.alerts}
+        assert "sl_breach" in alert_types
+        assert "thesis_break" in alert_types
+        # bid=130 < tp=200 so no tp_breach
+        assert "tp_breach" not in alert_types
+
+    def test_alert_carries_correct_instrument_id_and_symbol(self) -> None:
+        """Alert fields match the source position row."""
+        row = _position_row(instrument_id=42, symbol="NVDA", bid=130.0, stop_loss_rate=140.0)
+        conn = _make_conn([_make_cursor([row])])
+        result = check_position_health(conn)
+        assert len(result.alerts) == 1
+        alert = result.alerts[0]
+        assert alert.instrument_id == 42
+        assert alert.symbol == "NVDA"
+
+    def test_result_is_frozen_dataclass(self) -> None:
+        """MonitorResult and MonitorAlert are frozen (immutable)."""
+        conn = _make_conn([_make_cursor([])])
+        result = check_position_health(conn)
+        import dataclasses
+
+        assert dataclasses.is_dataclass(result)
+        # Frozen: assigning to a field raises FrozenInstanceError
+        try:
+            result.positions_checked = 999  # type: ignore[misc]
+            assert False, "Expected FrozenInstanceError"
+        except Exception as e:
+            assert "FrozenInstanceError" in type(e).__name__ or "cannot assign" in str(e).lower()
+
+    def test_alert_current_bid_is_none_when_bid_null(self) -> None:
+        """When bid is NULL but red_flag triggers thesis_break, current_bid on alert is None."""
+        row = _position_row(bid=None, red_flag_score=0.90)
+        conn = _make_conn([_make_cursor([row])])
+        result = check_position_health(conn)
+        tb_alerts = [a for a in result.alerts if a.alert_type == "thesis_break"]
+        assert len(tb_alerts) == 1
+        assert tb_alerts[0].current_bid is None

--- a/tests/test_position_monitor.py
+++ b/tests/test_position_monitor.py
@@ -72,7 +72,7 @@ class TestCheckPositionHealth:
         conn = _make_conn([_make_cursor([])])
         result = check_position_health(conn)
         assert result.positions_checked == 0
-        assert result.alerts == []
+        assert result.alerts == ()
 
     def test_position_below_stop_loss_generates_alert(self) -> None:
         """bid < sl → sl_breach alert."""
@@ -145,7 +145,7 @@ class TestCheckPositionHealth:
         conn = _make_conn([_make_cursor([row])])
         result = check_position_health(conn)
         assert result.positions_checked == 1
-        assert result.alerts == []
+        assert result.alerts == ()
 
     def test_null_sl_tp_does_not_crash(self) -> None:
         """NULL SL/TP/red_flag → no alerts, no crash."""
@@ -158,7 +158,7 @@ class TestCheckPositionHealth:
         conn = _make_conn([_make_cursor([row])])
         result = check_position_health(conn)
         assert result.positions_checked == 1
-        assert result.alerts == []
+        assert result.alerts == ()
 
     def test_null_bid_skips_sl_and_tp_checks(self) -> None:
         """NULL bid → sl_breach and tp_breach checks skipped; no alerts."""
@@ -171,7 +171,7 @@ class TestCheckPositionHealth:
         conn = _make_conn([_make_cursor([row])])
         result = check_position_health(conn)
         # red_flag is 0.10 < threshold so no thesis_break either
-        assert result.alerts == []
+        assert result.alerts == ()
 
     def test_multiple_positions_counted_correctly(self) -> None:
         """Multiple positions → positions_checked equals the row count."""

--- a/tests/test_scheduler_autonomous.py
+++ b/tests/test_scheduler_autonomous.py
@@ -176,7 +176,7 @@ class TestMonitorPositionsJob:
         """monitor_positions_job must call check_position_health and set row_count."""
         from app.services.position_monitor import MonitorResult
 
-        fake_result = MonitorResult(positions_checked=3, alerts=[])
+        fake_result = MonitorResult(positions_checked=3, alerts=())
         mock_health.return_value = fake_result
 
         conn_ctx = MagicMock()
@@ -210,7 +210,7 @@ class TestMonitorPositionsJob:
             alert_type="sl_breach",
             detail="bid=100 < stop_loss=110",
         )
-        fake_result = MonitorResult(positions_checked=5, alerts=[alert])
+        fake_result = MonitorResult(positions_checked=5, alerts=(alert,))
         mock_health.return_value = fake_result
 
         conn_ctx = MagicMock()

--- a/tests/test_scheduler_autonomous.py
+++ b/tests/test_scheduler_autonomous.py
@@ -1,0 +1,271 @@
+"""Tests for the autonomous scheduler additions (Tasks 4-7).
+
+Covers:
+- retry_deferred_recommendations_job: kill switch gate, normal execution path
+- monitor_positions_job: calls check_position_health and sets row_count
+- execute_approved_orders: stamps timing_deferred_at in Phase 0 UPDATE
+- morning_candidate_review: triggers execute_approved_orders when actionable recs present
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import app.workers.scheduler as scheduler_module
+from app.workers.scheduler import (
+    monitor_positions_job,
+    retry_deferred_recommendations_job,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DB_URL_PATCH = "app.workers.scheduler.settings"
+_PSYCOPG_CONNECT_PATCH = "app.workers.scheduler.psycopg.connect"
+_RECORD_START_PATCH = "app.workers.scheduler.record_job_start"
+_RECORD_FINISH_PATCH = "app.workers.scheduler.record_job_finish"
+_SPIKE_PATCH = "app.workers.scheduler.check_row_count_spike"
+
+
+def _make_spike_mock() -> MagicMock:
+    m = MagicMock()
+    m.flagged = False
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Task 4: retry_deferred_recommendations_job
+# ---------------------------------------------------------------------------
+
+
+_GET_KS_PATCH = "app.services.ops_monitor.get_kill_switch_status"
+_GET_CONFIG_PATCH = "app.services.runtime_config.get_runtime_config"
+
+
+class TestRetryDeferredJob:
+    """Tests for retry_deferred_recommendations_job."""
+
+    @patch(_SPIKE_PATCH, return_value=MagicMock(flagged=False))
+    @patch(_RECORD_FINISH_PATCH)
+    @patch(_RECORD_START_PATCH, return_value=1)
+    @patch("app.workers.scheduler.retry_deferred_recommendations")
+    @patch(_PSYCOPG_CONNECT_PATCH)
+    def test_kill_switch_active_skips_service(
+        self,
+        mock_connect: MagicMock,
+        mock_retry_svc: MagicMock,
+        mock_start: MagicMock,
+        mock_finish: MagicMock,
+        mock_spike: MagicMock,
+    ) -> None:
+        """When kill switch is active, retry service must not be called."""
+        from app.services.runtime_config import RuntimeConfig
+
+        mock_ks = {"is_active": True, "reason": "test"}
+        mock_config = MagicMock(spec=RuntimeConfig)
+        mock_config.enable_auto_trading = True
+
+        conn_ctx = MagicMock()
+        conn_ctx.__enter__ = MagicMock(return_value=conn_ctx)
+        conn_ctx.__exit__ = MagicMock(return_value=False)
+        mock_connect.return_value = conn_ctx
+
+        with (
+            patch(_GET_KS_PATCH, return_value=mock_ks),
+            patch(_GET_CONFIG_PATCH, return_value=mock_config),
+        ):
+            retry_deferred_recommendations_job()
+
+        mock_retry_svc.assert_not_called()
+
+    @patch(_SPIKE_PATCH, return_value=MagicMock(flagged=False))
+    @patch(_RECORD_FINISH_PATCH)
+    @patch(_RECORD_START_PATCH, return_value=1)
+    @patch("app.workers.scheduler.retry_deferred_recommendations")
+    @patch(_PSYCOPG_CONNECT_PATCH)
+    def test_auto_trading_disabled_skips_service(
+        self,
+        mock_connect: MagicMock,
+        mock_retry_svc: MagicMock,
+        mock_start: MagicMock,
+        mock_finish: MagicMock,
+        mock_spike: MagicMock,
+    ) -> None:
+        """When enable_auto_trading=False, retry service must not be called."""
+        from app.services.runtime_config import RuntimeConfig
+
+        mock_ks = {"is_active": False}
+        mock_config = MagicMock(spec=RuntimeConfig)
+        mock_config.enable_auto_trading = False
+
+        conn_ctx = MagicMock()
+        conn_ctx.__enter__ = MagicMock(return_value=conn_ctx)
+        conn_ctx.__exit__ = MagicMock(return_value=False)
+        mock_connect.return_value = conn_ctx
+
+        with (
+            patch(_GET_KS_PATCH, return_value=mock_ks),
+            patch(_GET_CONFIG_PATCH, return_value=mock_config),
+        ):
+            retry_deferred_recommendations_job()
+
+        mock_retry_svc.assert_not_called()
+
+    @patch(_SPIKE_PATCH, return_value=MagicMock(flagged=False))
+    @patch(_RECORD_FINISH_PATCH)
+    @patch(_RECORD_START_PATCH, return_value=1)
+    @patch("app.workers.scheduler.retry_deferred_recommendations")
+    @patch(_PSYCOPG_CONNECT_PATCH)
+    def test_calls_retry_service_when_config_allows(
+        self,
+        mock_connect: MagicMock,
+        mock_retry_svc: MagicMock,
+        mock_start: MagicMock,
+        mock_finish: MagicMock,
+        mock_spike: MagicMock,
+    ) -> None:
+        """When kill switch off and auto_trading on, retry service is called once."""
+        from app.services.deferred_retry import RetryResult
+        from app.services.runtime_config import RuntimeConfig
+
+        mock_ks = {"is_active": False}
+        mock_config = MagicMock(spec=RuntimeConfig)
+        mock_config.enable_auto_trading = True
+
+        fake_result = RetryResult(retried=2, re_proposed=1, re_deferred=1, expired=0, errors=0)
+        mock_retry_svc.return_value = fake_result
+
+        conn_ctx = MagicMock()
+        conn_ctx.__enter__ = MagicMock(return_value=conn_ctx)
+        conn_ctx.__exit__ = MagicMock(return_value=False)
+        mock_connect.return_value = conn_ctx
+
+        with (
+            patch(_GET_KS_PATCH, return_value=mock_ks),
+            patch(_GET_CONFIG_PATCH, return_value=mock_config),
+        ):
+            retry_deferred_recommendations_job()
+
+        mock_retry_svc.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Task 5: monitor_positions_job
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorPositionsJob:
+    """Tests for monitor_positions_job."""
+
+    @patch(_SPIKE_PATCH, return_value=MagicMock(flagged=False))
+    @patch(_RECORD_FINISH_PATCH)
+    @patch(_RECORD_START_PATCH, return_value=1)
+    @patch("app.workers.scheduler.check_position_health")
+    @patch(_PSYCOPG_CONNECT_PATCH)
+    def test_calls_check_position_health(
+        self,
+        mock_connect: MagicMock,
+        mock_health: MagicMock,
+        mock_start: MagicMock,
+        mock_finish: MagicMock,
+        mock_spike: MagicMock,
+    ) -> None:
+        """monitor_positions_job must call check_position_health and set row_count."""
+        from app.services.position_monitor import MonitorResult
+
+        fake_result = MonitorResult(positions_checked=3, alerts=[])
+        mock_health.return_value = fake_result
+
+        conn_ctx = MagicMock()
+        conn_ctx.__enter__ = MagicMock(return_value=conn_ctx)
+        conn_ctx.__exit__ = MagicMock(return_value=False)
+        mock_connect.return_value = conn_ctx
+
+        monitor_positions_job()
+
+        mock_health.assert_called_once()
+
+    @patch(_SPIKE_PATCH, return_value=MagicMock(flagged=False))
+    @patch(_RECORD_FINISH_PATCH)
+    @patch(_RECORD_START_PATCH, return_value=1)
+    @patch("app.workers.scheduler.check_position_health")
+    @patch(_PSYCOPG_CONNECT_PATCH)
+    def test_row_count_equals_positions_checked(
+        self,
+        mock_connect: MagicMock,
+        mock_health: MagicMock,
+        mock_start: MagicMock,
+        mock_finish: MagicMock,
+        mock_spike: MagicMock,
+    ) -> None:
+        """tracker.row_count must equal result.positions_checked."""
+        from app.services.position_monitor import MonitorAlert, MonitorResult
+
+        alert = MonitorAlert(
+            instrument_id=1,
+            symbol="AAPL",
+            alert_type="sl_breach",
+            detail="bid=100 < stop_loss=110",
+        )
+        fake_result = MonitorResult(positions_checked=5, alerts=[alert])
+        mock_health.return_value = fake_result
+
+        conn_ctx = MagicMock()
+        conn_ctx.__enter__ = MagicMock(return_value=conn_ctx)
+        conn_ctx.__exit__ = MagicMock(return_value=False)
+        mock_connect.return_value = conn_ctx
+
+        # Capture the tracker row_count by inspecting record_job_finish call args.
+        captured_row_count: list[Any] = []
+
+        def capture_finish(conn: Any, run_id: Any, **kwargs: Any) -> None:
+            captured_row_count.append(kwargs.get("row_count"))
+
+        with patch(_RECORD_FINISH_PATCH, side_effect=capture_finish):
+            monitor_positions_job()
+
+        assert captured_row_count and captured_row_count[0] == 5
+
+
+# ---------------------------------------------------------------------------
+# Task 6: timing_deferred_at stamp — source-level assertion
+# ---------------------------------------------------------------------------
+
+
+class TestTimingDeferredAtStamp:
+    """Verify that execute_approved_orders and _timing_error_defer stamp timing_deferred_at."""
+
+    def test_timing_deferred_at_in_execute_approved_orders_source(self) -> None:
+        """Phase 0 defer UPDATE must include timing_deferred_at."""
+        source = inspect.getsource(scheduler_module.execute_approved_orders)
+        assert "timing_deferred_at" in source, (
+            "execute_approved_orders must stamp timing_deferred_at = COALESCE(timing_deferred_at, NOW()) "
+            "when deferring a rec in Phase 0"
+        )
+
+    def test_timing_deferred_at_in_timing_error_defer_source(self) -> None:
+        """_timing_error_defer UPDATE must include timing_deferred_at."""
+        source = inspect.getsource(scheduler_module._timing_error_defer)
+        assert "timing_deferred_at" in source, (
+            "_timing_error_defer must stamp timing_deferred_at = COALESCE(timing_deferred_at, NOW()) "
+            "so error-deferred recs are eligible for expiry"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task 7: Pipeline trigger — source-level assertion
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineTrigger:
+    """Verify that morning_candidate_review calls execute_approved_orders."""
+
+    def test_execute_approved_orders_called_in_morning_review_source(self) -> None:
+        """morning_candidate_review source must contain execute_approved_orders call."""
+        source = inspect.getsource(scheduler_module.morning_candidate_review)
+        assert "execute_approved_orders" in source, (
+            "morning_candidate_review must trigger execute_approved_orders when actionable recs are generated"
+        )


### PR DESCRIPTION
## What changed

Three independent subsystems layered onto the existing scheduler to close the gaps preventing autonomous end-to-end investment lifecycle operation.

### 1. Deferred recommendation retry (`app/services/deferred_retry.py`)
New hourly job re-evaluates `timing_deferred` BUY/ADD recs using fresh TA data via `evaluate_entry_conditions()`. Recs that now pass are transitioned back to `proposed` for the next guard+execute cycle. Recs that exceed the retry cap (3 attempts) or age out (24h) are expired to `timing_expired`.

### 2. Intraday position monitoring (`app/services/position_monitor.py`)
New hourly read-only job checks all open positions against latest quotes and thesis data. Detects SL breaches (bid < stop_loss), TP breaches (bid >= take_profit), and thesis breaks (red_flag >= 0.80). Alerts are logged at WARNING — no auto-EXIT yet (conscious deferral).

### 3. Pipeline trigger (`scheduler.py:morning_candidate_review`)
After `morning_candidate_review` produces actionable recs, it now directly invokes `execute_approved_orders()` as a pipeline stage. The 06:30 cron remains as a catch-all.

### 4. Deferred-at timestamp (`scheduler.py:execute_approved_orders`, `_timing_error_defer`)
Phase 0 and the error-defer helper now stamp `timing_deferred_at = COALESCE(timing_deferred_at, NOW())` so the retry service can age-expire deferred recs.

### 5. Job runtime registration (`app/jobs/runtime.py`)
Both new jobs added to `_INVOKERS` for APScheduler registration and manual triggers.

**Files touched:** `sql/028_autonomous_loop.sql`, `app/services/deferred_retry.py`, `app/services/position_monitor.py`, `app/workers/scheduler.py`, `app/jobs/runtime.py`, `tests/test_deferred_retry.py`, `tests/test_position_monitor.py`, `tests/test_scheduler_autonomous.py`

## Why

Issue #205 — the scheduler ran independent cron jobs with no awareness of each other. Three concrete gaps blocked autonomous operation:
1. `timing_deferred` recs were dead-ended (no retry mechanism)
2. SL/TP hits and thesis breaks were only detected during the daily 05:30 broker sync
3. The morning pipeline (score → recommend → execute) ran as separate cron triggers with timing gaps

## Schema / migration impact

Migration `028_autonomous_loop.sql`:
- `trade_recommendations.timing_retry_count INTEGER NOT NULL DEFAULT 0` — retry counter
- `trade_recommendations.timing_deferred_at TIMESTAMPTZ` — first deferral timestamp
- `trade_recommendations.deferred_recommendation_id BIGINT` (FK to self) — retry lineage
- CHECK constraint `chk_recommendation_status` covering full status vocabulary: proposed, approved, rejected, executed, execution_failed, timing_deferred, timing_expired, cancelled

All columns are additive (no backfill needed). DEFAULT 0 on retry_count is backwards-compatible.

## Invariants checked

- **Atomic audit + status transitions**: Every status change writes a `decision_audit` row in the same `with conn.transaction()` block (prevention log: read-then-write in same txn)
- **Kill switch gate**: `retry_deferred_recommendations_job` checks `get_kill_switch_status()` + `enable_auto_trading` before any writes
- **tracker.row_count on every exit path**: All `return` statements inside `_tracked_job` set `tracker.row_count` first (prevention log entry)
- **No I/O inside transactions**: `evaluate_entry_conditions()` called before `with conn.transaction()` in the retry service
- **COALESCE preserves original timestamp**: Re-deferral after re-proposal doesn't overwrite the original `timing_deferred_at`
- **NULL-safe comparisons**: Position monitor guards all nullable fields (SL, TP, bid, red_flag) before comparison
- **LATERAL joins prevent fan-out**: Position monitor uses `LEFT JOIN LATERAL ... LIMIT 1` for quotes, broker_positions, theses
- **`WHERE current_units > 0`**: Excludes liquidated positions (prevention log: zero-unit inflates AUM)
- **EXIT recs never deferred**: Only BUY/ADD recs are retried (settled decision: never gate protective exits)
- **catch_up_on_boot=False**: Both new jobs do not surprise-fire on restart

## Failure paths considered

- Empty deferred recs list → all-zero RetryResult, no-op
- Empty positions list → MonitorResult with 0 checked, no alerts
- NULL timing_deferred_at → age check skipped, only count-based expiry applies
- NULL SL/TP/red_flag/bid → that check skipped, no crash
- evaluate_entry_conditions raises → retry_count incremented, rec stays deferred
- expire transaction fails → logged, counted in errors, batch continues
- Pipeline trigger fails → logged at ERROR, morning review still completes
- Kill switch active → retry job skips entirely, row_count=0
- Runtime config load fails → retry job skips entirely, row_count=0

## Tests added

**`tests/test_deferred_retry.py`** (12 tests):
- No deferred recs → zero counts
- Rec within retry limit re-evaluated via evaluate_entry_conditions
- Pass verdict → re_proposed, audit row with PASS
- Defer verdict → re_deferred, retry_count incremented
- Retry count exhausted → expired
- Age expired → expired
- Multiple recs counted independently
- Audit rows written on both pass and expiry paths

**`tests/test_position_monitor.py`** (15 tests):
- No positions → empty result
- SL breach (bid < sl), TP breach (bid >= tp), thesis break (red_flag >= 0.80)
- Healthy position → no alerts
- NULL SL/TP/red_flag → no crash, no alerts
- NULL bid → SL/TP checks skipped
- Multiple alerts on single position
- Boundary conditions (exact threshold values)

**`tests/test_scheduler_autonomous.py`** (8 tests):
- Retry job checks kill switch before service call
- Retry job calls service when config allows
- Monitor job calls check_position_health
- Pipeline trigger present in morning_candidate_review
- timing_deferred_at stamp present in execute_approved_orders

## Conscious tradeoffs

- **No auto-EXIT from monitor alerts** — Monitor detects breaches and logs them; generating EXIT recs automatically requires careful design around the execution guard's re-check rule. Deferred to follow-up.
- **No event-driven research triggers** — Only the morning → execution chain is connected. Research jobs are expensive and their cadence should remain operator-controlled.
- **No operator notification** — Alerts are logged only. Slack/email/webhook requires infrastructure not yet built.
- **Retried recs wait for next execute cycle** — Re-proposed recs don't immediately enter guard+execute. The pipeline trigger from morning review or the 06:30 cron picks them up.
- **`DEFER` as pass_fail value** — Used alongside `PASS`/`FAIL` in `decision_audit`. No CHECK constraint on the column; consistent with existing scheduler Phase 0 usage (line 1148).

Closes #205