### PR TITLE
feat(#155): return attribution — sector-relative decomposition

### DIFF
--- a/app/api/attribution.py
+++ b/app/api/attribution.py
@@ -1,0 +1,57 @@
+"""Attribution API — return decomposition data for the dashboard."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from fastapi import APIRouter, Depends
+
+from app.api.auth import require_session_or_service_token
+from app.config import settings
+
+router = APIRouter(
+    prefix="/api/attribution",
+    tags=["attribution"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+
+@router.get("")
+def list_attributions(
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Return the most recent attribution rows."""
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT ra.*, i.symbol, i.sector
+                FROM return_attribution ra
+                JOIN instruments i USING (instrument_id)
+                ORDER BY ra.computed_at DESC
+                LIMIT %(limit)s
+                """,
+                {"limit": limit},
+            )
+            return cur.fetchall()
+
+
+@router.get("/summary")
+def list_summaries(
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Return the most recent attribution summaries."""
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT *
+                FROM return_attribution_summary
+                ORDER BY computed_at DESC
+                LIMIT %(limit)s
+                """,
+                {"limit": limit},
+            )
+            return cur.fetchall()

--- a/app/api/attribution.py
+++ b/app/api/attribution.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import psycopg
 import psycopg.rows
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from app.api.auth import require_session_or_service_token
 from app.config import settings
@@ -20,7 +20,7 @@ router = APIRouter(
 
 @router.get("")
 def list_attributions(
-    limit: int = 50,
+    limit: int = Query(default=50, le=1000),
 ) -> list[dict[str, Any]]:
     """Return the most recent attribution rows."""
     with psycopg.connect(settings.database_url) as conn:
@@ -40,7 +40,7 @@ def list_attributions(
 
 @router.get("/summary")
 def list_summaries(
-    limit: int = 10,
+    limit: int = Query(default=10, le=1000),
 ) -> list[dict[str, Any]]:
     """Return the most recent attribution summaries."""
     with psycopg.connect(settings.database_url) as conn:

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -53,6 +53,7 @@ from app.config import settings
 from app.jobs.locks import JobAlreadyRunning, JobLock
 from app.services.ops_monitor import fetch_latest_successful_runs, record_job_skip
 from app.workers.scheduler import (
+    JOB_ATTRIBUTION_SUMMARY,
     JOB_DAILY_CANDLE_REFRESH,
     JOB_DAILY_CIK_REFRESH,
     JOB_DAILY_NEWS_REFRESH,
@@ -70,6 +71,7 @@ from app.workers.scheduler import (
     SCHEDULED_JOBS,
     Cadence,
     ScheduledJob,
+    attribution_summary_job,
     compute_next_run,
     daily_candle_refresh,
     daily_cik_refresh,
@@ -125,6 +127,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_DAILY_TAX_RECONCILIATION: daily_tax_reconciliation,
     JOB_RETRY_DEFERRED: retry_deferred_recommendations_job,
     JOB_MONITOR_POSITIONS: monitor_positions_job,
+    JOB_ATTRIBUTION_SUMMARY: attribution_summary_job,
 }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from fastapi import Depends, FastAPI, HTTPException
 from psycopg_pool import ConnectionPool
 from pydantic import BaseModel, Field
 
+from app.api.attribution import router as attribution_router
 from app.api.audit import router as audit_router
 from app.api.auth import require_session_or_service_token
 from app.api.auth_bootstrap import router as auth_bootstrap_router
@@ -115,6 +116,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 
 app = FastAPI(title="eBull", version="0.1.0", lifespan=lifespan)
+app.include_router(attribution_router)
 app.include_router(auth_setup_router)
 app.include_router(auth_bootstrap_router)
 app.include_router(auth_session_router)

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -33,6 +33,7 @@ import psycopg.rows
 from psycopg.types.json import Jsonb
 
 from app.providers.broker import BrokerOrderResult, BrokerProvider, OrderParams
+from app.services.return_attribution import compute_attribution, persist_attribution
 from app.services.runtime_config import get_runtime_config
 
 logger = logging.getLogger(__name__)
@@ -474,6 +475,42 @@ def _update_position_exit(
     )
 
 
+def _maybe_trigger_attribution(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    current_units_after: Decimal,
+) -> None:
+    """Compute and persist return attribution if the position is fully closed.
+
+    Called after an EXIT fill updates the position. If current_units_after is
+    zero (or negative due to rounding), the position is closed and attribution
+    is computed.
+
+    Errors are logged and swallowed — attribution is best-effort and must
+    never abort the order execution path.
+    """
+    if current_units_after > Decimal("0"):
+        return
+
+    try:
+        result = compute_attribution(conn, instrument_id)
+        if result is not None:
+            persist_attribution(conn, result)
+            logger.info(
+                "execute_order: attribution computed for instrument_id=%d "
+                "gross=%.4f alpha=%.4f",
+                instrument_id,
+                result.gross_return_pct,
+                result.model_alpha_pct,
+            )
+    except Exception:
+        logger.error(
+            "execute_order: attribution failed for instrument_id=%d",
+            instrument_id,
+            exc_info=True,
+        )
+
+
 def _record_cash_ledger(
     conn: psycopg.Connection[Any],
     action: str,
@@ -737,6 +774,15 @@ def execute_order(
                     filled_units=fu,
                     now=now,
                 )
+                # Check if position is fully closed → trigger attribution
+                with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                    cur.execute(
+                        "SELECT current_units FROM positions WHERE instrument_id = %(iid)s",
+                        {"iid": instrument_id},
+                    )
+                    pos_row = cur.fetchone()
+                units_after = Decimal(str(pos_row["current_units"])) if pos_row else Decimal("0")
+                _maybe_trigger_attribution(conn, instrument_id, units_after)
 
             gross_amount = fp * fu
             _record_cash_ledger(conn, action, gross_amount, broker_result.fees, now)

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -493,15 +493,19 @@ def _maybe_trigger_attribution(
         return
 
     try:
-        result = compute_attribution(conn, instrument_id)
-        if result is not None:
-            persist_attribution(conn, result)
-            logger.info(
-                "execute_order: attribution computed for instrument_id=%d gross=%.4f alpha=%.4f",
-                instrument_id,
-                result.gross_return_pct,
-                result.model_alpha_pct,
-            )
+        # Savepoint isolates attribution from the outer transaction.
+        # If a DB error occurs inside, the savepoint rolls back and the
+        # outer transaction stays healthy for cash_ledger / rec status writes.
+        with conn.transaction():
+            result = compute_attribution(conn, instrument_id)
+            if result is not None:
+                persist_attribution(conn, result)
+                logger.info(
+                    "execute_order: attribution computed for instrument_id=%d gross=%.4f alpha=%.4f",
+                    instrument_id,
+                    result.gross_return_pct,
+                    result.model_alpha_pct,
+                )
     except Exception:
         logger.error(
             "execute_order: attribution failed for instrument_id=%d",

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -497,8 +497,7 @@ def _maybe_trigger_attribution(
         if result is not None:
             persist_attribution(conn, result)
             logger.info(
-                "execute_order: attribution computed for instrument_id=%d "
-                "gross=%.4f alpha=%.4f",
+                "execute_order: attribution computed for instrument_id=%d gross=%.4f alpha=%.4f",
                 instrument_id,
                 result.gross_return_pct,
                 result.model_alpha_pct,

--- a/app/services/return_attribution.py
+++ b/app/services/return_attribution.py
@@ -1,0 +1,631 @@
+"""
+Return attribution service.
+
+Decomposes the gross return of a closed position into additive components:
+
+  gross_return = market_return
+               + (sector_return - market_return)   [sector tilt]
+               + model_alpha                        [stock selection within sector]
+               + timing_alpha                       [v1 placeholder, always 0]
+               + cost_drag                          [fees as fraction of cost basis]
+               + residual                           [arithmetic closure term]
+
+Attribution method: ``sector_relative_v1``
+
+Design:
+  - All arithmetic uses Decimal — never float.
+  - Caller owns the connection; this module never opens or closes connections.
+  - Functions are append-only writers: they INSERT new rows, never UPDATE.
+  - When sector or market peer data are unavailable the corresponding component
+    is zero, and the residual absorbs the difference.
+  - timing_alpha is always ZERO in v1. The field exists for future TA-based
+    entry/exit timing attribution.
+
+Issue #202.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from psycopg.types.json import Jsonb
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+ATTRIBUTION_METHOD = "sector_relative_v1"
+ZERO = Decimal("0")
+SUMMARY_WINDOWS: tuple[int, ...] = (30, 90, 365)
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AttributionResult:
+    """Attribution decomposition for a single closed position."""
+
+    instrument_id: int
+    hold_start: date
+    hold_end: date
+    hold_days: int
+    gross_return_pct: Decimal
+    market_return_pct: Decimal
+    sector_return_pct: Decimal
+    model_alpha_pct: Decimal
+    timing_alpha_pct: Decimal
+    cost_drag_pct: Decimal
+    residual_pct: Decimal
+    score_at_entry: Decimal | None
+    score_components: dict[str, Any] | None
+    entry_fill_id: int | None
+    exit_fill_id: int | None
+    recommendation_id: int | None
+
+
+@dataclass(frozen=True)
+class SummaryResult:
+    """Rolling-window aggregate of attribution components."""
+
+    window_days: int
+    positions_attributed: int
+    avg_gross_return_pct: Decimal | None
+    avg_market_return_pct: Decimal | None
+    avg_sector_return_pct: Decimal | None
+    avg_model_alpha_pct: Decimal | None
+    avg_timing_alpha_pct: Decimal | None
+    avg_cost_drag_pct: Decimal | None
+
+
+# ---------------------------------------------------------------------------
+# Internal DB loaders
+# ---------------------------------------------------------------------------
+
+
+def _load_position_fills(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> list[dict[str, Any]]:
+    """Load all fills for an instrument, joined to orders for action.
+
+    Returns fills ordered by filled_at ascending.
+    Each row: fill_id, order_id, filled_at, price, units, fees, action.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT f.fill_id,
+                   f.order_id,
+                   f.filled_at,
+                   f.price,
+                   f.units,
+                   f.fees,
+                   o.action
+            FROM fills f
+            JOIN orders o ON o.order_id = f.order_id
+            WHERE o.instrument_id = %(iid)s
+              AND f.units > 0
+            ORDER BY f.filled_at ASC
+            """,
+            {"iid": instrument_id},
+        )
+        return cur.fetchall()
+
+
+def _load_price_series(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    start_date: date,
+    end_date: date,
+) -> list[dict[str, Any]]:
+    """Load price_daily rows for an instrument between two dates (inclusive).
+
+    Returns rows ordered by price_date ascending.
+    Each row: price_date, close.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT price_date, close
+            FROM price_daily
+            WHERE instrument_id = %(iid)s
+              AND price_date BETWEEN %(start)s AND %(end)s
+              AND close IS NOT NULL
+            ORDER BY price_date ASC
+            """,
+            {"iid": instrument_id, "start": start_date, "end": end_date},
+        )
+        return cur.fetchall()
+
+
+def _load_score_snapshot(
+    conn: psycopg.Connection[Any],
+    score_id: int,
+) -> dict[str, Any] | None:
+    """Load a single scores row by primary key.
+
+    Returns None if the score_id does not exist.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT score_id,
+                   total_score,
+                   quality_score,
+                   value_score,
+                   turnaround_score,
+                   momentum_score,
+                   sentiment_score,
+                   confidence_score,
+                   model_version
+            FROM scores
+            WHERE score_id = %(sid)s
+            """,
+            {"sid": score_id},
+        )
+        return cur.fetchone()
+
+
+def _load_sector_peers(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> list[int]:
+    """Return instrument_ids in the same sector, excluding the subject instrument.
+
+    Only instruments in coverage (any tier) with a known non-NULL sector are
+    returned. Returns an empty list if the instrument has no sector or no peers.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT i2.instrument_id
+            FROM instruments i1
+            JOIN instruments i2
+              ON i2.sector = i1.sector
+             AND i2.instrument_id <> i1.instrument_id
+             AND i2.sector IS NOT NULL
+            WHERE i1.instrument_id = %(iid)s
+              AND i1.sector IS NOT NULL
+            """,
+            {"iid": instrument_id},
+        )
+        rows = cur.fetchall()
+        return [int(r["instrument_id"]) for r in rows]
+
+
+def _load_recommendation_for_fills(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> dict[str, Any] | None:
+    """Load the most recent executed BUY or ADD recommendation for an instrument.
+
+    Returns None if no executed buy/add recommendation exists.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT recommendation_id, score_id
+            FROM trade_recommendations
+            WHERE instrument_id = %(iid)s
+              AND action IN ('BUY', 'ADD')
+              AND status = 'executed'
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            {"iid": instrument_id},
+        )
+        return cur.fetchone()
+
+
+# ---------------------------------------------------------------------------
+# Internal computation helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_average_return(prices: Sequence[dict[str, Any]]) -> Decimal:
+    """Compute (last_close - first_close) / first_close from an ordered price list.
+
+    Returns ZERO when fewer than two price rows are available or when
+    first_close is zero (avoids division by zero).
+    """
+    if len(prices) < 2:
+        return ZERO
+    first = Decimal(str(prices[0]["close"]))
+    last = Decimal(str(prices[-1]["close"]))
+    if first == ZERO:
+        return ZERO
+    return (last - first) / first
+
+
+def _compute_market_return(
+    conn: psycopg.Connection[Any],
+    start: date,
+    end: date,
+) -> Decimal:
+    """Average return of all Tier 1 instruments over the hold period.
+
+    Returns ZERO when no Tier 1 instruments have price data for the period.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT c.instrument_id
+            FROM coverage c
+            WHERE c.coverage_tier = 1
+            """,
+        )
+        rows = cur.fetchall()
+
+    tier1_ids = [int(r["instrument_id"]) for r in rows]
+    if not tier1_ids:
+        return ZERO
+
+    returns: list[Decimal] = []
+    for iid in tier1_ids:
+        prices = _load_price_series(conn, iid, start, end)
+        ret = _compute_average_return(prices)
+        # Only include instruments that had actual price data for the period
+        if len(prices) >= 2:
+            returns.append(ret)
+
+    if not returns:
+        return ZERO
+    return sum(returns, ZERO) / Decimal(len(returns))
+
+
+def _compute_sector_return(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    start: date,
+    end: date,
+) -> Decimal:
+    """Average return of same-sector instruments over the hold period.
+
+    Excludes the subject instrument itself. Returns ZERO when no sector
+    peers have price data for the period.
+    """
+    peer_ids = _load_sector_peers(conn, instrument_id)
+    if not peer_ids:
+        return ZERO
+
+    returns: list[Decimal] = []
+    for iid in peer_ids:
+        prices = _load_price_series(conn, iid, start, end)
+        if len(prices) >= 2:
+            returns.append(_compute_average_return(prices))
+
+    if not returns:
+        return ZERO
+    return sum(returns, ZERO) / Decimal(len(returns))
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_attribution(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> AttributionResult | None:
+    """Compute return attribution for a closed position.
+
+    Returns None if:
+      - No fills exist for the instrument.
+      - No EXIT fills exist (position not yet closed).
+
+    All monetary arithmetic uses Decimal. Market and sector returns are
+    computed from price_daily; ZERO is used as a fallback when data are absent.
+    """
+    fills = _load_position_fills(conn, instrument_id)
+    if not fills:
+        return None
+
+    entry_fills = [f for f in fills if str(f["action"]) in ("BUY", "ADD")]
+    exit_fills = [f for f in fills if str(f["action"]) == "EXIT"]
+
+    if not exit_fills:
+        return None
+
+    # Weighted average entry price (price * units weighted)
+    entry_cost: Decimal = sum(
+        (Decimal(str(f["price"])) * Decimal(str(f["units"])) for f in entry_fills),
+        ZERO,
+    )
+    entry_units: Decimal = sum(
+        (Decimal(str(f["units"])) for f in entry_fills),
+        ZERO,
+    )
+    if entry_units == ZERO:
+        return None
+    avg_entry_price: Decimal = entry_cost / entry_units
+
+    # Weighted average exit price
+    exit_proceeds: Decimal = sum(
+        (Decimal(str(f["price"])) * Decimal(str(f["units"])) for f in exit_fills),
+        ZERO,
+    )
+    exit_units: Decimal = sum(
+        (Decimal(str(f["units"])) for f in exit_fills),
+        ZERO,
+    )
+    if exit_units == ZERO:
+        return None
+    avg_exit_price: Decimal = exit_proceeds / exit_units
+
+    if avg_entry_price == ZERO:
+        return None
+
+    gross_return: Decimal = (avg_exit_price - avg_entry_price) / avg_entry_price
+
+    # Hold period — use fill dates as date objects
+    hold_start = min(f["filled_at"] for f in entry_fills)
+    hold_end = max(f["filled_at"] for f in exit_fills)
+    # filled_at may be datetime (timezone-aware) or date; normalise to date
+    hold_start_date: date = hold_start.date() if isinstance(hold_start, datetime) else hold_start
+    hold_end_date: date = hold_end.date() if isinstance(hold_end, datetime) else hold_end
+    hold_days = (hold_end_date - hold_start_date).days
+
+    # Cost drag: total fees / total entry cost
+    total_fees: Decimal = sum(
+        (Decimal(str(f["fees"])) for f in fills),
+        ZERO,
+    )
+    cost_drag: Decimal = total_fees / entry_cost if entry_cost > ZERO else ZERO
+
+    # Market and sector benchmark returns
+    market_return = _compute_market_return(conn, hold_start_date, hold_end_date)
+    sector_return = _compute_sector_return(conn, instrument_id, hold_start_date, hold_end_date)
+
+    # Stock selection alpha vs sector
+    model_alpha = gross_return - sector_return
+    timing_alpha = ZERO  # v1 placeholder
+
+    # Residual: arithmetic closure so components sum to gross_return
+    # gross = market + (sector - market) + model_alpha + timing_alpha + cost_drag + residual
+    # Simplifies to: residual = gross - (sector + model_alpha + timing_alpha + cost_drag)
+    residual = gross_return - (sector_return + model_alpha + timing_alpha + cost_drag)
+
+    # Score snapshot at entry
+    rec = _load_recommendation_for_fills(conn, instrument_id)
+    score_at_entry: Decimal | None = None
+    score_components: dict[str, Any] | None = None
+    recommendation_id: int | None = None
+    score_id_for_entry: int | None = None
+
+    if rec is not None:
+        recommendation_id = int(rec["recommendation_id"])
+        raw_score_id = rec["score_id"]
+        if raw_score_id is not None:
+            score_id_for_entry = int(raw_score_id)
+
+    if score_id_for_entry is not None:
+        snap = _load_score_snapshot(conn, score_id_for_entry)
+        if snap is not None:
+            raw_total = snap["total_score"]
+            score_at_entry = Decimal(str(raw_total)) if raw_total is not None else None
+            numeric_keys = (
+                "quality_score",
+                "value_score",
+                "turnaround_score",
+                "momentum_score",
+                "sentiment_score",
+                "confidence_score",
+            )
+            score_components = {}
+            for k in numeric_keys:
+                if k in snap:
+                    score_components[k] = float(snap[k]) if snap[k] is not None else None
+            if "model_version" in snap:
+                score_components["model_version"] = snap["model_version"]
+
+    # fill_id references: first entry fill and last exit fill
+    entry_fill_id = int(entry_fills[0]["fill_id"]) if entry_fills else None
+    exit_fill_id = int(exit_fills[-1]["fill_id"]) if exit_fills else None
+
+    return AttributionResult(
+        instrument_id=instrument_id,
+        hold_start=hold_start_date,
+        hold_end=hold_end_date,
+        hold_days=hold_days,
+        gross_return_pct=gross_return,
+        market_return_pct=market_return,
+        sector_return_pct=sector_return,
+        model_alpha_pct=model_alpha,
+        timing_alpha_pct=timing_alpha,
+        cost_drag_pct=cost_drag,
+        residual_pct=residual,
+        score_at_entry=score_at_entry,
+        score_components=score_components,
+        entry_fill_id=entry_fill_id,
+        exit_fill_id=exit_fill_id,
+        recommendation_id=recommendation_id,
+    )
+
+
+def persist_attribution(
+    conn: psycopg.Connection[Any],
+    result: AttributionResult,
+) -> None:
+    """INSERT a single attribution result into return_attribution.
+
+    Caller is responsible for the surrounding transaction if needed.
+    """
+    components_jsonb = Jsonb(result.score_components) if result.score_components is not None else None
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO return_attribution (
+                instrument_id,
+                hold_start,
+                hold_end,
+                hold_days,
+                gross_return_pct,
+                market_return_pct,
+                sector_return_pct,
+                model_alpha_pct,
+                timing_alpha_pct,
+                cost_drag_pct,
+                residual_pct,
+                score_at_entry,
+                score_components,
+                entry_fill_id,
+                exit_fill_id,
+                recommendation_id,
+                attribution_method,
+                computed_at
+            ) VALUES (
+                %(instrument_id)s,
+                %(hold_start)s,
+                %(hold_end)s,
+                %(hold_days)s,
+                %(gross_return_pct)s,
+                %(market_return_pct)s,
+                %(sector_return_pct)s,
+                %(model_alpha_pct)s,
+                %(timing_alpha_pct)s,
+                %(cost_drag_pct)s,
+                %(residual_pct)s,
+                %(score_at_entry)s,
+                %(score_components)s,
+                %(entry_fill_id)s,
+                %(exit_fill_id)s,
+                %(recommendation_id)s,
+                %(attribution_method)s,
+                %(computed_at)s
+            )
+            """,
+            {
+                "instrument_id": result.instrument_id,
+                "hold_start": result.hold_start,
+                "hold_end": result.hold_end,
+                "hold_days": result.hold_days,
+                "gross_return_pct": result.gross_return_pct,
+                "market_return_pct": result.market_return_pct,
+                "sector_return_pct": result.sector_return_pct,
+                "model_alpha_pct": result.model_alpha_pct,
+                "timing_alpha_pct": result.timing_alpha_pct,
+                "cost_drag_pct": result.cost_drag_pct,
+                "residual_pct": result.residual_pct,
+                "score_at_entry": result.score_at_entry,
+                "score_components": components_jsonb,
+                "entry_fill_id": result.entry_fill_id,
+                "exit_fill_id": result.exit_fill_id,
+                "recommendation_id": result.recommendation_id,
+                "attribution_method": ATTRIBUTION_METHOD,
+                "computed_at": datetime.now(tz=UTC),
+            },
+        )
+
+
+def compute_attribution_summary(
+    conn: psycopg.Connection[Any],
+    window_days: int,
+) -> SummaryResult:
+    """Aggregate return_attribution rows within the rolling window.
+
+    Returns a SummaryResult with None averages when no rows exist in the window.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT
+                COUNT(*) AS positions_attributed,
+                AVG(gross_return_pct)  AS avg_gross_return_pct,
+                AVG(market_return_pct) AS avg_market_return_pct,
+                AVG(sector_return_pct) AS avg_sector_return_pct,
+                AVG(model_alpha_pct)   AS avg_model_alpha_pct,
+                AVG(timing_alpha_pct)  AS avg_timing_alpha_pct,
+                AVG(cost_drag_pct)     AS avg_cost_drag_pct
+            FROM return_attribution
+            WHERE computed_at >= NOW() - (%(window_days)s || ' days')::INTERVAL
+            """,
+            {"window_days": window_days},
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        return SummaryResult(
+            window_days=window_days,
+            positions_attributed=0,
+            avg_gross_return_pct=None,
+            avg_market_return_pct=None,
+            avg_sector_return_pct=None,
+            avg_model_alpha_pct=None,
+            avg_timing_alpha_pct=None,
+            avg_cost_drag_pct=None,
+        )
+
+    count = int(row["positions_attributed"])
+
+    def _to_decimal(val: object) -> Decimal | None:
+        return Decimal(str(val)) if val is not None else None
+
+    return SummaryResult(
+        window_days=window_days,
+        positions_attributed=count,
+        avg_gross_return_pct=_to_decimal(row["avg_gross_return_pct"]),
+        avg_market_return_pct=_to_decimal(row["avg_market_return_pct"]),
+        avg_sector_return_pct=_to_decimal(row["avg_sector_return_pct"]),
+        avg_model_alpha_pct=_to_decimal(row["avg_model_alpha_pct"]),
+        avg_timing_alpha_pct=_to_decimal(row["avg_timing_alpha_pct"]),
+        avg_cost_drag_pct=_to_decimal(row["avg_cost_drag_pct"]),
+    )
+
+
+def persist_attribution_summary(
+    conn: psycopg.Connection[Any],
+    result: SummaryResult,
+) -> None:
+    """INSERT a single summary result into return_attribution_summary.
+
+    Caller is responsible for the surrounding transaction if needed.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO return_attribution_summary (
+                window_days,
+                positions_attributed,
+                avg_gross_return_pct,
+                avg_market_return_pct,
+                avg_sector_return_pct,
+                avg_model_alpha_pct,
+                avg_timing_alpha_pct,
+                avg_cost_drag_pct,
+                computed_at
+            ) VALUES (
+                %(window_days)s,
+                %(positions_attributed)s,
+                %(avg_gross_return_pct)s,
+                %(avg_market_return_pct)s,
+                %(avg_sector_return_pct)s,
+                %(avg_model_alpha_pct)s,
+                %(avg_timing_alpha_pct)s,
+                %(avg_cost_drag_pct)s,
+                %(computed_at)s
+            )
+            """,
+            {
+                "window_days": result.window_days,
+                "positions_attributed": result.positions_attributed,
+                "avg_gross_return_pct": result.avg_gross_return_pct,
+                "avg_market_return_pct": result.avg_market_return_pct,
+                "avg_sector_return_pct": result.avg_sector_return_pct,
+                "avg_model_alpha_pct": result.avg_model_alpha_pct,
+                "avg_timing_alpha_pct": result.avg_timing_alpha_pct,
+                "avg_cost_drag_pct": result.avg_cost_drag_pct,
+                "computed_at": datetime.now(tz=UTC),
+            },
+        )

--- a/app/services/return_attribution.py
+++ b/app/services/return_attribution.py
@@ -392,9 +392,11 @@ def compute_attribution(
     model_alpha = gross_return - sector_return
     timing_alpha = ZERO  # v1 placeholder
 
-    # Residual: arithmetic closure so components sum to gross_return
-    # gross = market + (sector - market) + model_alpha + timing_alpha + cost_drag + residual
-    # Simplifies to: residual = gross - (sector + model_alpha + timing_alpha + cost_drag)
+    # Residual: arithmetic closure so components sum to gross_return.
+    # Since model_alpha = gross - sector, the market term cancels and
+    # residual = -(timing_alpha + cost_drag).  In v1 (timing_alpha=0)
+    # this is simply -cost_drag.  The residual gains independent meaning
+    # once timing_alpha is computed in v2.
     residual = gross_return - (sector_return + model_alpha + timing_alpha + cost_drag)
 
     # Score snapshot at entry
@@ -426,7 +428,7 @@ def compute_attribution(
             score_components = {}
             for k in numeric_keys:
                 if k in snap:
-                    score_components[k] = float(snap[k]) if snap[k] is not None else None
+                    score_components[k] = str(snap[k]) if snap[k] is not None else None
             if "model_version" in snap:
                 score_components["model_version"] = snap["model_version"]
 
@@ -549,7 +551,7 @@ def compute_attribution_summary(
                 AVG(timing_alpha_pct)  AS avg_timing_alpha_pct,
                 AVG(cost_drag_pct)     AS avg_cost_drag_pct
             FROM return_attribution
-            WHERE computed_at >= NOW() - (%(window_days)s || ' days')::INTERVAL
+            WHERE computed_at >= NOW() - make_interval(days => %(window_days)s)
             """,
             {"window_days": window_days},
         )

--- a/app/services/return_attribution.py
+++ b/app/services/return_attribution.py
@@ -70,7 +70,7 @@ class AttributionResult:
     score_at_entry: Decimal | None
     score_components: dict[str, Any] | None
     entry_fill_id: int | None
-    exit_fill_id: int | None
+    exit_fill_id: int
     recommendation_id: int | None
 
 
@@ -434,7 +434,7 @@ def compute_attribution(
 
     # fill_id references: first entry fill and last exit fill
     entry_fill_id = int(entry_fills[0]["fill_id"]) if entry_fills else None
-    exit_fill_id = int(exit_fills[-1]["fill_id"]) if exit_fills else None
+    exit_fill_id = int(exit_fills[-1]["fill_id"])  # guaranteed non-empty (early return above)
 
     return AttributionResult(
         instrument_id=instrument_id,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -54,6 +54,11 @@ from app.services.order_client import execute_order
 from app.services.portfolio import run_portfolio_review
 from app.services.portfolio_sync import sync_portfolio
 from app.services.position_monitor import check_position_health
+from app.services.return_attribution import (
+    SUMMARY_WINDOWS,
+    compute_attribution_summary,
+    persist_attribution_summary,
+)
 from app.services.scoring import compute_rankings
 from app.services.sentiment import ClaudeSentimentScorer
 from app.services.tax_ledger import ingest_tax_events, run_disposal_matching
@@ -180,6 +185,7 @@ JOB_EXECUTE_APPROVED_ORDERS = "execute_approved_orders"
 JOB_FX_RATES_REFRESH = "fx_rates_refresh"
 JOB_RETRY_DEFERRED = "retry_deferred_recommendations"
 JOB_MONITOR_POSITIONS = "monitor_positions"
+JOB_ATTRIBUTION_SUMMARY = "attribution_summary"
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +267,13 @@ def _has_tier1_stale_theses(conn: psycopg.Connection[Any]) -> PrerequisiteResult
     if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM coverage WHERE coverage_tier = 1)")):
         return (True, "")
     return (False, "no Tier 1 instruments")
+
+
+def _has_attributions(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if at least one attributed position exists."""
+    if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM return_attribution)")):
+        return (True, "")
+    return (False, "no attributed positions yet")
 
 
 # Declared schedule. Hours/minutes are deliberate-but-arbitrary placeholders
@@ -346,6 +359,13 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         description="Review coverage tier assignments; promote/demote instruments.",
         cadence=Cadence.weekly(weekday=0, hour=5, minute=0),
         prerequisite=_has_any_coverage,
+    ),
+    ScheduledJob(
+        name=JOB_ATTRIBUTION_SUMMARY,
+        description="Compute and persist rolling attribution summaries (30d, 90d, 365d).",
+        cadence=Cadence.weekly(weekday=6, hour=6, minute=0),
+        prerequisite=_has_attributions,
+        catch_up_on_boot=False,
     ),
     # -- On-demand jobs are NOT listed here.  They stay in _INVOKERS
     # (runtime.py) so "Run now" in the Admin UI works, but they are
@@ -1830,3 +1850,23 @@ def daily_tax_reconciliation() -> None:
         matching.total_gain_gbp,
         matching.total_loss_gbp,
     )
+
+
+def attribution_summary_job() -> None:
+    """Compute and persist attribution summaries for all configured windows."""
+    with _tracked_job(JOB_ATTRIBUTION_SUMMARY) as tracker:
+        with psycopg.connect(settings.database_url) as conn:
+            total_positions = 0
+            for window in SUMMARY_WINDOWS:
+                summary = compute_attribution_summary(conn, window)
+                with conn.transaction():
+                    persist_attribution_summary(conn, summary)
+                conn.commit()
+                total_positions = max(total_positions, summary.positions_attributed)
+                logger.info(
+                    "attribution_summary: window=%dd positions=%d avg_alpha=%.4f",
+                    window,
+                    summary.positions_attributed,
+                    float(summary.avg_model_alpha_pct or 0),
+                )
+            tracker.row_count = total_positions

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1859,9 +1859,7 @@ def attribution_summary_job() -> None:
             total_positions = 0
             for window in SUMMARY_WINDOWS:
                 summary = compute_attribution_summary(conn, window)
-                with conn.transaction():
-                    persist_attribution_summary(conn, summary)
-                conn.commit()
+                persist_attribution_summary(conn, summary)
                 total_positions = max(total_positions, summary.positions_attributed)
                 logger.info(
                     "attribution_summary: window=%dd positions=%d avg_alpha=%.4f",
@@ -1869,4 +1867,5 @@ def attribution_summary_job() -> None:
                     summary.positions_attributed,
                     float(summary.avg_model_alpha_pct or 0),
                 )
+            conn.commit()
             tracker.row_count = total_positions

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -734,3 +734,21 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `morning_candidate_review()` called `execute_approved_orders()` directly without checking the kill switch or `enable_auto_trading` flag. The guards *inside* `execute_approved_orders` would catch it, but the non-negotiable rule is that AI-generated trade actions must never reach the execution path without an explicit gate at the call site.
 - Prevention: Any code path that invokes `execute_approved_orders()` (or any future order-execution function) must check both `get_kill_switch_status(conn)["is_active"]` and `get_runtime_config(conn).enable_auto_trading` before the call. The callee's internal guard is a second line of defence, not the primary one.
 - Enforced in: `app/workers/scheduler.py` (morning_candidate_review pipeline trigger)
+
+---
+
+### Interval construction via string concatenation in SQL
+
+- First seen in: #239
+- Symptom: `(%(window_days)s || ' days')::INTERVAL` relies on driver-level string concatenation to build an interval value. Safe only when the parameter is always an integer, but fragile — a code change at the call site could introduce injection.
+- Prevention: Use `make_interval(days => %(window_days)s)` instead of string concatenation for interval construction. Grep for `|| ' days'` or `|| ' hours'` in SQL strings before pushing.
+- Enforced in: this prevention log
+
+---
+
+### Unbounded API limit parameters
+
+- First seen in: #239
+- Symptom: `limit: int = 50` with no upper bound allows callers to pass `limit=10000000`, holding a DB connection open for the full scan with no timeout.
+- Prevention: Use `Query(default=N, le=1000)` (or appropriate upper bound) for all `limit` parameters in FastAPI routes. Grep for `limit: int =` in router files before pushing.
+- Enforced in: this prevention log

--- a/sql/029_return_attribution.sql
+++ b/sql/029_return_attribution.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS return_attribution (
     score_components     JSONB,
     -- Computation metadata
     entry_fill_id        BIGINT REFERENCES fills(fill_id),
-    exit_fill_id         BIGINT REFERENCES fills(fill_id),
+    exit_fill_id         BIGINT NOT NULL REFERENCES fills(fill_id),
     recommendation_id    BIGINT REFERENCES trade_recommendations(recommendation_id),
     attribution_method   TEXT NOT NULL DEFAULT 'sector_relative_v1',
     computed_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/sql/029_return_attribution.sql
+++ b/sql/029_return_attribution.sql
@@ -1,0 +1,50 @@
+-- Migration 029: return attribution tables
+--
+-- return_attribution: per-position decomposition of realised returns.
+-- Computed when a position is fully closed (current_units = 0 after EXIT fill).
+--
+-- return_attribution_summary: rolling-window aggregation of attribution
+-- components across all attributed positions.
+
+CREATE TABLE IF NOT EXISTS return_attribution (
+    attribution_id       BIGSERIAL PRIMARY KEY,
+    instrument_id        BIGINT NOT NULL REFERENCES instruments(instrument_id),
+    hold_start           DATE NOT NULL,
+    hold_end             DATE NOT NULL,
+    hold_days            INTEGER NOT NULL,
+    -- Return components (all as decimal fractions, e.g. 0.05 = 5%)
+    gross_return_pct     NUMERIC(12, 6) NOT NULL,
+    market_return_pct    NUMERIC(12, 6) NOT NULL,
+    sector_return_pct    NUMERIC(12, 6) NOT NULL,
+    model_alpha_pct      NUMERIC(12, 6) NOT NULL,
+    timing_alpha_pct     NUMERIC(12, 6) NOT NULL,
+    cost_drag_pct        NUMERIC(12, 6) NOT NULL,
+    residual_pct         NUMERIC(12, 6) NOT NULL,
+    -- Score snapshot at entry (from the recommendation's score_id)
+    score_at_entry       NUMERIC(10, 4),
+    score_components     JSONB,
+    -- Computation metadata
+    entry_fill_id        BIGINT REFERENCES fills(fill_id),
+    exit_fill_id         BIGINT REFERENCES fills(fill_id),
+    recommendation_id    BIGINT REFERENCES trade_recommendations(recommendation_id),
+    attribution_method   TEXT NOT NULL DEFAULT 'sector_relative_v1',
+    computed_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_return_attribution_instrument
+    ON return_attribution(instrument_id);
+CREATE INDEX IF NOT EXISTS idx_return_attribution_computed
+    ON return_attribution(computed_at);
+
+CREATE TABLE IF NOT EXISTS return_attribution_summary (
+    summary_id           BIGSERIAL PRIMARY KEY,
+    window_days          INTEGER NOT NULL,
+    positions_attributed INTEGER NOT NULL,
+    avg_gross_return_pct    NUMERIC(12, 6),
+    avg_market_return_pct   NUMERIC(12, 6),
+    avg_sector_return_pct   NUMERIC(12, 6),
+    avg_model_alpha_pct     NUMERIC(12, 6),
+    avg_timing_alpha_pct    NUMERIC(12, 6),
+    avg_cost_drag_pct       NUMERIC(12, 6),
+    computed_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/sql/029_return_attribution.sql
+++ b/sql/029_return_attribution.sql
@@ -35,6 +35,8 @@ CREATE INDEX IF NOT EXISTS idx_return_attribution_instrument
     ON return_attribution(instrument_id);
 CREATE INDEX IF NOT EXISTS idx_return_attribution_computed
     ON return_attribution(computed_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_return_attribution_instrument_exit
+    ON return_attribution(instrument_id, exit_fill_id);
 
 CREATE TABLE IF NOT EXISTS return_attribution_summary (
     summary_id           BIGSERIAL PRIMARY KEY,

--- a/tests/test_attribution_trigger.py
+++ b/tests/test_attribution_trigger.py
@@ -39,7 +39,7 @@ class TestMaybeTriggerAttribution:
             cost_drag_pct=Decimal("0.004"),
             residual_pct=Decimal("-0.004"),
             score_at_entry=Decimal("0.75"),
-            score_components={"quality_score": 0.8},
+            score_components={"quality_score": "0.80"},
             entry_fill_id=1,
             exit_fill_id=2,
             recommendation_id=50,

--- a/tests/test_attribution_trigger.py
+++ b/tests/test_attribution_trigger.py
@@ -109,7 +109,9 @@ class TestMaybeTriggerAttribution:
         conn = MagicMock()
 
         _maybe_trigger_attribution(
-            conn, instrument_id=42, current_units_after=Decimal("-0.001"),
+            conn,
+            instrument_id=42,
+            current_units_after=Decimal("-0.001"),
         )
 
         mock_compute.assert_called_once_with(conn, 42)

--- a/tests/test_attribution_trigger.py
+++ b/tests/test_attribution_trigger.py
@@ -1,0 +1,116 @@
+"""Tests that EXIT fills trigger return attribution.
+
+Verifies that _maybe_trigger_attribution is called correctly based on
+the position's remaining units after an EXIT fill.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from app.services.return_attribution import AttributionResult
+
+_ORDER_CLIENT = "app.services.order_client"
+
+
+class TestMaybeTriggerAttribution:
+    @patch(f"{_ORDER_CLIENT}.persist_attribution")
+    @patch(f"{_ORDER_CLIENT}.compute_attribution")
+    def test_triggers_on_full_close(
+        self,
+        mock_compute: MagicMock,
+        mock_persist: MagicMock,
+    ) -> None:
+        """When current_units_after is 0, attribution should run."""
+        from app.services.order_client import _maybe_trigger_attribution
+
+        mock_compute.return_value = AttributionResult(
+            instrument_id=42,
+            hold_start=date(2025, 1, 15),
+            hold_end=date(2025, 6, 15),
+            hold_days=151,
+            gross_return_pct=Decimal("0.20"),
+            market_return_pct=Decimal("0.05"),
+            sector_return_pct=Decimal("0.08"),
+            model_alpha_pct=Decimal("0.12"),
+            timing_alpha_pct=Decimal("0"),
+            cost_drag_pct=Decimal("0.004"),
+            residual_pct=Decimal("-0.004"),
+            score_at_entry=Decimal("0.75"),
+            score_components={"quality_score": 0.8},
+            entry_fill_id=1,
+            exit_fill_id=2,
+            recommendation_id=50,
+        )
+        conn = MagicMock()
+
+        _maybe_trigger_attribution(conn, instrument_id=42, current_units_after=Decimal("0"))
+
+        mock_compute.assert_called_once_with(conn, 42)
+        mock_persist.assert_called_once()
+
+    @patch(f"{_ORDER_CLIENT}.persist_attribution")
+    @patch(f"{_ORDER_CLIENT}.compute_attribution")
+    def test_not_triggered_when_position_open(
+        self,
+        mock_compute: MagicMock,
+        mock_persist: MagicMock,
+    ) -> None:
+        """If current_units > 0 after exit, no attribution."""
+        from app.services.order_client import _maybe_trigger_attribution
+
+        conn = MagicMock()
+        _maybe_trigger_attribution(conn, instrument_id=42, current_units_after=Decimal("5"))
+
+        mock_compute.assert_not_called()
+        mock_persist.assert_not_called()
+
+    @patch(f"{_ORDER_CLIENT}.persist_attribution")
+    @patch(f"{_ORDER_CLIENT}.compute_attribution", return_value=None)
+    def test_none_result_skips_persist(
+        self,
+        mock_compute: MagicMock,
+        mock_persist: MagicMock,
+    ) -> None:
+        """If compute_attribution returns None (e.g. missing data), skip persist."""
+        from app.services.order_client import _maybe_trigger_attribution
+
+        conn = MagicMock()
+        _maybe_trigger_attribution(conn, instrument_id=42, current_units_after=Decimal("0"))
+
+        mock_compute.assert_called_once()
+        mock_persist.assert_not_called()
+
+    @patch(f"{_ORDER_CLIENT}.compute_attribution", side_effect=Exception("DB error"))
+    def test_error_does_not_propagate(
+        self,
+        mock_compute: MagicMock,
+    ) -> None:
+        """Attribution failure must not abort the order execution."""
+        from app.services.order_client import _maybe_trigger_attribution
+
+        conn = MagicMock()
+        # Should not raise
+        _maybe_trigger_attribution(conn, instrument_id=42, current_units_after=Decimal("0"))
+
+    @patch(f"{_ORDER_CLIENT}.persist_attribution")
+    @patch(f"{_ORDER_CLIENT}.compute_attribution")
+    def test_triggers_on_negative_units(
+        self,
+        mock_compute: MagicMock,
+        mock_persist: MagicMock,
+    ) -> None:
+        """Negative units (rounding overshoot) should also trigger attribution."""
+        from app.services.order_client import _maybe_trigger_attribution
+
+        mock_compute.return_value = MagicMock(spec=AttributionResult)
+        conn = MagicMock()
+
+        _maybe_trigger_attribution(
+            conn, instrument_id=42, current_units_after=Decimal("-0.001"),
+        )
+
+        mock_compute.assert_called_once_with(conn, 42)
+        mock_persist.assert_called_once()

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -318,8 +318,9 @@ class TestExecuteOrderDemoMode:
         # conn.execute: position upsert, broker_positions, cash_ledger, rec status, audit = 5
         assert conn.execute.call_count == 5
 
+    @patch("app.services.order_client._maybe_trigger_attribution")
     @patch("app.services.order_client._utcnow", return_value=_NOW)
-    def test_demo_exit_produces_fill(self, _mock_now: MagicMock) -> None:
+    def test_demo_exit_produces_fill(self, _mock_now: MagicMock, _mock_attr: MagicMock) -> None:
         """Demo EXIT: loads position units, synthetic fill at quote price."""
         cursors = [
             _rec_cursor(action="EXIT", target_entry=None, suggested_size_pct=None),
@@ -328,6 +329,8 @@ class TestExecuteOrderDemoMode:
             # Inside transaction:
             _order_returning_cursor(order_id=8),
             _fill_returning_cursor(fill_id=4),
+            # Post-fill: read current_units for attribution check
+            _make_cursor([{"current_units": 0}]),
         ]
         conn = _make_conn(cursors)
         result = execute_order(
@@ -419,8 +422,9 @@ class TestExecuteOrderDemoMode:
         assert params["no_sl"] is False
         assert params["no_tp"] is False
 
+    @patch("app.services.order_client._maybe_trigger_attribution")
     @patch("app.services.order_client._utcnow", return_value=_NOW)
-    def test_demo_exit_does_not_write_broker_positions(self, _mock_now: MagicMock) -> None:
+    def test_demo_exit_does_not_write_broker_positions(self, _mock_now: MagicMock, _mock_attr: MagicMock) -> None:
         """EXIT fills must NOT insert into broker_positions (the row already exists)."""
         cursors = [
             _rec_cursor(action="EXIT", target_entry=None, suggested_size_pct=None),
@@ -428,6 +432,8 @@ class TestExecuteOrderDemoMode:
             _quote_cursor(last=200.0),
             _order_returning_cursor(order_id=8),
             _fill_returning_cursor(fill_id=4),
+            # Post-fill: read current_units for attribution check
+            _make_cursor([{"current_units": 0}]),
         ]
         conn = _make_conn(cursors)
         result = execute_order(
@@ -503,8 +509,9 @@ class TestExecuteOrderLiveMode:
         assert result.broker_order_ref == "ORD-123"
         broker.place_order.assert_called_once()
 
+    @patch("app.services.order_client._maybe_trigger_attribution")
     @patch("app.services.order_client._utcnow", return_value=_NOW)
-    def test_live_exit_calls_broker_close_position(self, _mock_now: MagicMock) -> None:
+    def test_live_exit_calls_broker_close_position(self, _mock_now: MagicMock, _mock_attr: MagicMock) -> None:
         broker = MagicMock()
         broker.close_position.return_value = BrokerOrderResult(
             broker_order_ref="ORD-456",
@@ -522,6 +529,8 @@ class TestExecuteOrderLiveMode:
             # broker called (no cursor)
             _order_returning_cursor(order_id=11),
             _fill_returning_cursor(fill_id=7),
+            # Post-fill: read current_units for attribution check
+            _make_cursor([{"current_units": 0}]),
         ]
         conn = _make_conn(cursors)
         result = execute_order(

--- a/tests/test_return_attribution.py
+++ b/tests/test_return_attribution.py
@@ -610,7 +610,7 @@ class TestPersistAttribution:
             "cost_drag_pct": _D("0.002"),
             "residual_pct": _D("0.078"),
             "score_at_entry": _D("0.75"),
-            "score_components": {"quality_score": 0.8},
+            "score_components": {"quality_score": "0.80"},
             "entry_fill_id": 1,
             "exit_fill_id": 2,
             "recommendation_id": 7,
@@ -651,7 +651,7 @@ class TestPersistAttribution:
 
         cur = _make_cursor([])
         conn = _make_conn([cur])
-        result = self._make_result(score_components={"quality_score": 0.8})
+        result = self._make_result(score_components={"quality_score": "0.80"})
         persist_attribution(conn, result)
         params = cur.execute.call_args[0][1]
         assert isinstance(params["score_components"], Jsonb)

--- a/tests/test_return_attribution.py
+++ b/tests/test_return_attribution.py
@@ -1,0 +1,862 @@
+"""Tests for app.services.return_attribution."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.return_attribution import (
+    ATTRIBUTION_METHOD,
+    SUMMARY_WINDOWS,
+    ZERO,
+    AttributionResult,
+    SummaryResult,
+    _compute_average_return,
+    _compute_market_return,
+    _compute_sector_return,
+    _load_position_fills,
+    _load_price_series,
+    _load_recommendation_for_fills,
+    _load_score_snapshot,
+    _load_sector_peers,
+    compute_attribution,
+    compute_attribution_summary,
+    persist_attribution,
+    persist_attribution_summary,
+)
+
+_D = Decimal
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cursor(rows: list[dict[str, Any]]) -> MagicMock:
+    """Mock cursor whose fetchall returns rows and fetchone returns first row."""
+    cur = MagicMock()
+    cur.fetchall.return_value = rows
+    cur.fetchone.return_value = rows[0] if rows else None
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    return cur
+
+
+def _make_conn(cursors: list[MagicMock]) -> MagicMock:
+    """Mock connection that dispenses cursors in sequence."""
+    conn = MagicMock()
+    conn.cursor.side_effect = cursors
+    return conn
+
+
+def _dt(d: date) -> datetime:
+    """Convert a date to a UTC datetime at midnight."""
+    return datetime(d.year, d.month, d.day, tzinfo=UTC)
+
+
+def _fill(
+    fill_id: int = 1,
+    order_id: int = 10,
+    filled_at: datetime | None = None,
+    price: str = "100.00",
+    units: str = "10.00",
+    fees: str = "1.00",
+    action: str = "BUY",
+) -> dict[str, Any]:
+    if filled_at is None:
+        filled_at = _dt(date(2025, 1, 10))
+    return {
+        "fill_id": fill_id,
+        "order_id": order_id,
+        "filled_at": filled_at,
+        "price": _D(price),
+        "units": _D(units),
+        "fees": _D(fees),
+        "action": action,
+    }
+
+
+def _price_row(price_date: date, close: str) -> dict[str, Any]:
+    return {"price_date": price_date, "close": _D(close)}
+
+
+# ===========================================================================
+# TestConstants
+# ===========================================================================
+
+
+class TestConstants:
+    def test_attribution_method_value(self) -> None:
+        assert ATTRIBUTION_METHOD == "sector_relative_v1"
+
+    def test_zero_is_decimal(self) -> None:
+        assert isinstance(ZERO, Decimal)
+        assert ZERO == _D("0")
+
+    def test_summary_windows_contains_expected_values(self) -> None:
+        assert 30 in SUMMARY_WINDOWS
+        assert 90 in SUMMARY_WINDOWS
+        assert 365 in SUMMARY_WINDOWS
+
+
+# ===========================================================================
+# TestComputeAverageReturn
+# ===========================================================================
+
+
+class TestComputeAverageReturn:
+    def test_positive_return(self) -> None:
+        prices = [
+            _price_row(date(2025, 1, 1), "100"),
+            _price_row(date(2025, 1, 10), "110"),
+        ]
+        result = _compute_average_return(prices)
+        assert result == _D("0.1")
+
+    def test_negative_return(self) -> None:
+        prices = [
+            _price_row(date(2025, 1, 1), "100"),
+            _price_row(date(2025, 1, 10), "90"),
+        ]
+        result = _compute_average_return(prices)
+        assert result == _D("-0.1")
+
+    def test_zero_return_on_flat_price(self) -> None:
+        prices = [
+            _price_row(date(2025, 1, 1), "100"),
+            _price_row(date(2025, 1, 10), "100"),
+        ]
+        result = _compute_average_return(prices)
+        assert result == ZERO
+
+    def test_empty_list_returns_zero(self) -> None:
+        assert _compute_average_return([]) == ZERO
+
+    def test_single_row_returns_zero(self) -> None:
+        prices = [_price_row(date(2025, 1, 1), "100")]
+        assert _compute_average_return(prices) == ZERO
+
+    def test_zero_first_price_returns_zero(self) -> None:
+        prices = [
+            _price_row(date(2025, 1, 1), "0"),
+            _price_row(date(2025, 1, 10), "100"),
+        ]
+        assert _compute_average_return(prices) == ZERO
+
+    def test_uses_first_and_last_rows_only(self) -> None:
+        # Middle rows are ignored
+        prices = [
+            _price_row(date(2025, 1, 1), "100"),
+            _price_row(date(2025, 1, 5), "50"),  # middle — ignored
+            _price_row(date(2025, 1, 10), "120"),
+        ]
+        result = _compute_average_return(prices)
+        # (120 - 100) / 100 = 0.2
+        assert result == _D("0.2")
+
+
+# ===========================================================================
+# TestLoadPositionFills
+# ===========================================================================
+
+
+class TestLoadPositionFills:
+    def test_returns_rows_from_cursor(self) -> None:
+        rows = [_fill(fill_id=1), _fill(fill_id=2, action="EXIT")]
+        cur = _make_cursor(rows)
+        conn = _make_conn([cur])
+        result = _load_position_fills(conn, instrument_id=42)
+        assert len(result) == 2
+        assert result[0]["fill_id"] == 1
+
+    def test_empty_table_returns_empty_list(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        result = _load_position_fills(conn, instrument_id=99)
+        assert result == []
+
+    def test_passes_instrument_id_as_param(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        _load_position_fills(conn, instrument_id=77)
+        execute_call = cur.execute.call_args
+        params = execute_call[0][1]
+        assert params["iid"] == 77
+
+
+# ===========================================================================
+# TestLoadPriceSeries
+# ===========================================================================
+
+
+class TestLoadPriceSeries:
+    def test_returns_rows_ordered_by_date(self) -> None:
+        rows = [
+            _price_row(date(2025, 1, 1), "100"),
+            _price_row(date(2025, 1, 5), "105"),
+        ]
+        cur = _make_cursor(rows)
+        conn = _make_conn([cur])
+        result = _load_price_series(conn, 1, date(2025, 1, 1), date(2025, 1, 5))
+        assert len(result) == 2
+
+    def test_passes_correct_params(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        _load_price_series(conn, 55, date(2025, 1, 1), date(2025, 3, 1))
+        params = cur.execute.call_args[0][1]
+        assert params["iid"] == 55
+        assert params["start"] == date(2025, 1, 1)
+        assert params["end"] == date(2025, 3, 1)
+
+    def test_empty_result_returns_empty_list(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        result = _load_price_series(conn, 1, date(2025, 1, 1), date(2025, 1, 31))
+        assert result == []
+
+
+# ===========================================================================
+# TestLoadScoreSnapshot
+# ===========================================================================
+
+
+class TestLoadScoreSnapshot:
+    def test_returns_row_when_exists(self) -> None:
+        row = {
+            "score_id": 5,
+            "total_score": _D("0.75"),
+            "quality_score": _D("0.80"),
+            "value_score": _D("0.70"),
+            "turnaround_score": _D("0.65"),
+            "momentum_score": _D("0.60"),
+            "sentiment_score": _D("0.55"),
+            "confidence_score": _D("0.85"),
+            "model_version": "v1-balanced",
+        }
+        cur = _make_cursor([row])
+        conn = _make_conn([cur])
+        result = _load_score_snapshot(conn, score_id=5)
+        assert result is not None
+        assert result["total_score"] == _D("0.75")
+
+    def test_returns_none_when_not_found(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        result = _load_score_snapshot(conn, score_id=999)
+        assert result is None
+
+    def test_passes_score_id_as_param(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        _load_score_snapshot(conn, score_id=42)
+        params = cur.execute.call_args[0][1]
+        assert params["sid"] == 42
+
+
+# ===========================================================================
+# TestLoadSectorPeers
+# ===========================================================================
+
+
+class TestLoadSectorPeers:
+    def test_returns_peer_instrument_ids(self) -> None:
+        rows = [{"instrument_id": 2}, {"instrument_id": 3}]
+        cur = _make_cursor(rows)
+        conn = _make_conn([cur])
+        result = _load_sector_peers(conn, instrument_id=1)
+        assert result == [2, 3]
+
+    def test_no_peers_returns_empty_list(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        result = _load_sector_peers(conn, instrument_id=1)
+        assert result == []
+
+    def test_passes_instrument_id_as_param(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        _load_sector_peers(conn, instrument_id=10)
+        params = cur.execute.call_args[0][1]
+        assert params["iid"] == 10
+
+
+# ===========================================================================
+# TestLoadRecommendationForFills
+# ===========================================================================
+
+
+class TestLoadRecommendationForFills:
+    def test_returns_most_recent_executed_buy(self) -> None:
+        row = {"recommendation_id": 7, "score_id": 3}
+        cur = _make_cursor([row])
+        conn = _make_conn([cur])
+        result = _load_recommendation_for_fills(conn, instrument_id=1)
+        assert result is not None
+        assert result["recommendation_id"] == 7
+        assert result["score_id"] == 3
+
+    def test_returns_none_when_no_executed_buy(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        result = _load_recommendation_for_fills(conn, instrument_id=1)
+        assert result is None
+
+    def test_passes_instrument_id_as_param(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        _load_recommendation_for_fills(conn, instrument_id=55)
+        params = cur.execute.call_args[0][1]
+        assert params["iid"] == 55
+
+
+# ===========================================================================
+# TestComputeMarketReturn
+# ===========================================================================
+
+
+class TestComputeMarketReturn:
+    def test_returns_average_of_tier1_returns(self) -> None:
+        # Two Tier 1 instruments: one +20%, one +10% → average = 15%
+        tier1_cursor = _make_cursor([{"instrument_id": 1}, {"instrument_id": 2}])
+        prices_1 = [
+            _price_row(date(2025, 1, 1), "100"),
+            _price_row(date(2025, 1, 31), "120"),
+        ]
+        prices_2 = [
+            _price_row(date(2025, 1, 1), "200"),
+            _price_row(date(2025, 1, 31), "220"),
+        ]
+        price_cur_1 = _make_cursor(prices_1)
+        price_cur_2 = _make_cursor(prices_2)
+        conn = _make_conn([tier1_cursor, price_cur_1, price_cur_2])
+        result = _compute_market_return(conn, date(2025, 1, 1), date(2025, 1, 31))
+        # 0.20 + 0.10 = 0.30, / 2 = 0.15
+        assert result == _D("0.15")
+
+    def test_returns_zero_when_no_tier1_instruments(self) -> None:
+        tier1_cursor = _make_cursor([])
+        conn = _make_conn([tier1_cursor])
+        result = _compute_market_return(conn, date(2025, 1, 1), date(2025, 1, 31))
+        assert result == ZERO
+
+    def test_returns_zero_when_tier1_has_no_price_data(self) -> None:
+        tier1_cursor = _make_cursor([{"instrument_id": 1}])
+        # Only one price row — not enough for a return
+        price_cur = _make_cursor([_price_row(date(2025, 1, 1), "100")])
+        conn = _make_conn([tier1_cursor, price_cur])
+        result = _compute_market_return(conn, date(2025, 1, 1), date(2025, 1, 31))
+        assert result == ZERO
+
+
+# ===========================================================================
+# TestComputeSectorReturn
+# ===========================================================================
+
+
+class TestComputeSectorReturn:
+    def test_returns_average_of_peer_returns(self) -> None:
+        peers_cursor = _make_cursor([{"instrument_id": 2}, {"instrument_id": 3}])
+        prices_2 = [
+            _price_row(date(2025, 1, 1), "100"),
+            _price_row(date(2025, 1, 31), "110"),
+        ]
+        prices_3 = [
+            _price_row(date(2025, 1, 1), "100"),
+            _price_row(date(2025, 1, 31), "130"),
+        ]
+        price_cur_2 = _make_cursor(prices_2)
+        price_cur_3 = _make_cursor(prices_3)
+        conn = _make_conn([peers_cursor, price_cur_2, price_cur_3])
+        result = _compute_sector_return(conn, instrument_id=1, start=date(2025, 1, 1), end=date(2025, 1, 31))
+        # peer 2: +10%, peer 3: +30% → average = 20%
+        assert result == _D("0.20")
+
+    def test_returns_zero_when_no_peers(self) -> None:
+        peers_cursor = _make_cursor([])
+        conn = _make_conn([peers_cursor])
+        result = _compute_sector_return(conn, instrument_id=1, start=date(2025, 1, 1), end=date(2025, 1, 31))
+        assert result == ZERO
+
+    def test_returns_zero_when_peers_have_no_price_data(self) -> None:
+        peers_cursor = _make_cursor([{"instrument_id": 2}])
+        # Only one price row — not enough for a return
+        price_cur = _make_cursor([_price_row(date(2025, 1, 1), "100")])
+        conn = _make_conn([peers_cursor, price_cur])
+        result = _compute_sector_return(conn, instrument_id=1, start=date(2025, 1, 1), end=date(2025, 1, 31))
+        assert result == ZERO
+
+
+# ===========================================================================
+# TestComputeAttribution
+# ===========================================================================
+
+
+class TestComputeAttribution:
+    """Tests for compute_attribution using patched internal loaders."""
+
+    def _run(
+        self,
+        fills: list[dict[str, Any]],
+        market_return: Decimal = _D("0.05"),
+        sector_return: Decimal = _D("0.08"),
+        rec: dict[str, Any] | None = None,
+        score_snap: dict[str, Any] | None = None,
+    ) -> AttributionResult | None:
+        conn = MagicMock()
+        with (
+            patch("app.services.return_attribution._load_position_fills", return_value=fills),
+            patch("app.services.return_attribution._compute_market_return", return_value=market_return),
+            patch("app.services.return_attribution._compute_sector_return", return_value=sector_return),
+            patch("app.services.return_attribution._load_recommendation_for_fills", return_value=rec),
+            patch("app.services.return_attribution._load_score_snapshot", return_value=score_snap),
+        ):
+            return compute_attribution(conn, instrument_id=1)
+
+    def test_returns_none_when_no_fills(self) -> None:
+        result = self._run(fills=[])
+        assert result is None
+
+    def test_returns_none_when_no_exit_fills(self) -> None:
+        fills = [_fill(action="BUY")]
+        result = self._run(fills=fills)
+        assert result is None
+
+    def test_happy_path_gross_return_computation(self) -> None:
+        # Buy at 100, sell at 110 → 10% gross
+        fills = [
+            _fill(fill_id=1, filled_at=_dt(date(2025, 1, 10)), price="100", units="10", fees="1", action="BUY"),
+            _fill(fill_id=2, filled_at=_dt(date(2025, 3, 10)), price="110", units="10", fees="1", action="EXIT"),
+        ]
+        result = self._run(fills=fills)
+        assert result is not None
+        assert result.gross_return_pct == _D("0.1")
+
+    def test_model_alpha_is_gross_minus_sector_return(self) -> None:
+        # gross = 0.10, sector = 0.08 → model_alpha = 0.02
+        fills = [
+            _fill(fill_id=1, filled_at=_dt(date(2025, 1, 10)), price="100", units="10", fees="0", action="BUY"),
+            _fill(fill_id=2, filled_at=_dt(date(2025, 3, 10)), price="110", units="10", fees="0", action="EXIT"),
+        ]
+        result = self._run(fills=fills, sector_return=_D("0.08"))
+        assert result is not None
+        assert result.model_alpha_pct == _D("0.02")
+
+    def test_timing_alpha_is_always_zero(self) -> None:
+        fills = [
+            _fill(fill_id=1, filled_at=_dt(date(2025, 1, 10)), price="100", units="10", fees="0", action="BUY"),
+            _fill(fill_id=2, filled_at=_dt(date(2025, 3, 10)), price="110", units="10", fees="0", action="EXIT"),
+        ]
+        result = self._run(fills=fills)
+        assert result is not None
+        assert result.timing_alpha_pct == ZERO
+
+    def test_residual_closes_the_equation(self) -> None:
+        """Components must sum to gross_return (residual is the closure term)."""
+        fills = [
+            _fill(fill_id=1, filled_at=_dt(date(2025, 1, 10)), price="100", units="10", fees="2", action="BUY"),
+            _fill(fill_id=2, filled_at=_dt(date(2025, 3, 10)), price="115", units="10", fees="1", action="EXIT"),
+        ]
+        result = self._run(fills=fills, market_return=_D("0.05"), sector_return=_D("0.08"))
+        assert result is not None
+        component_sum = (
+            result.market_return_pct
+            + (result.sector_return_pct - result.market_return_pct)
+            + result.model_alpha_pct
+            + result.timing_alpha_pct
+            + result.cost_drag_pct
+            + result.residual_pct
+        )
+        # Should equal gross_return — allow tiny Decimal precision difference
+        assert abs(component_sum - result.gross_return_pct) < _D("0.000001")
+
+    def test_cost_drag_is_fees_over_entry_cost(self) -> None:
+        # entry_cost = 100 * 10 = 1000, total_fees = 5 (BUY) + 3 (EXIT) = 8
+        fills = [
+            _fill(fill_id=1, filled_at=_dt(date(2025, 1, 10)), price="100", units="10", fees="5", action="BUY"),
+            _fill(fill_id=2, filled_at=_dt(date(2025, 3, 10)), price="110", units="10", fees="3", action="EXIT"),
+        ]
+        result = self._run(fills=fills)
+        assert result is not None
+        # cost_drag = (5 + 3) / 1000 = 0.008
+        assert result.cost_drag_pct == _D("0.008")
+
+    def test_hold_days_computed_correctly(self) -> None:
+        fills = [
+            _fill(fill_id=1, filled_at=_dt(date(2025, 1, 1)), price="100", units="10", fees="0", action="BUY"),
+            _fill(fill_id=2, filled_at=_dt(date(2025, 4, 10)), price="110", units="10", fees="0", action="EXIT"),
+        ]
+        result = self._run(fills=fills)
+        assert result is not None
+        # Jan 1 to Apr 10 = 99 days
+        assert result.hold_days == (date(2025, 4, 10) - date(2025, 1, 1)).days
+
+    def test_entry_and_exit_fill_ids_assigned(self) -> None:
+        fills = [
+            _fill(fill_id=11, filled_at=_dt(date(2025, 1, 1)), action="BUY"),
+            _fill(fill_id=22, filled_at=_dt(date(2025, 3, 1)), action="EXIT"),
+        ]
+        result = self._run(fills=fills)
+        assert result is not None
+        assert result.entry_fill_id == 11
+        assert result.exit_fill_id == 22
+
+    def test_recommendation_id_none_when_no_rec(self) -> None:
+        fills = [
+            _fill(fill_id=1, action="BUY"),
+            _fill(fill_id=2, action="EXIT"),
+        ]
+        result = self._run(fills=fills, rec=None)
+        assert result is not None
+        assert result.recommendation_id is None
+
+    def test_score_at_entry_populated_from_snapshot(self) -> None:
+        rec = {"recommendation_id": 7, "score_id": 3}
+        score_snap = {
+            "score_id": 3,
+            "total_score": _D("0.72"),
+            "quality_score": _D("0.80"),
+            "value_score": _D("0.70"),
+            "turnaround_score": _D("0.65"),
+            "momentum_score": _D("0.60"),
+            "sentiment_score": _D("0.55"),
+            "confidence_score": _D("0.85"),
+            "model_version": "v1-balanced",
+        }
+        fills = [
+            _fill(fill_id=1, action="BUY"),
+            _fill(fill_id=2, action="EXIT"),
+        ]
+        result = self._run(fills=fills, rec=rec, score_snap=score_snap)
+        assert result is not None
+        assert result.score_at_entry == _D("0.72")
+        assert result.recommendation_id == 7
+
+    def test_score_at_entry_none_when_score_id_is_null(self) -> None:
+        rec = {"recommendation_id": 7, "score_id": None}
+        fills = [
+            _fill(fill_id=1, action="BUY"),
+            _fill(fill_id=2, action="EXIT"),
+        ]
+        result = self._run(fills=fills, rec=rec, score_snap=None)
+        assert result is not None
+        assert result.score_at_entry is None
+        assert result.recommendation_id == 7
+
+    def test_weighted_average_entry_price_with_multiple_buys(self) -> None:
+        # Two BUY fills at different prices/sizes: 100@10 + 120@5 = 1600/15 ≈ 106.667
+        fills = [
+            _fill(fill_id=1, filled_at=_dt(date(2025, 1, 1)), price="100", units="10", fees="0", action="BUY"),
+            _fill(fill_id=2, filled_at=_dt(date(2025, 1, 5)), price="120", units="5", fees="0", action="ADD"),
+            _fill(fill_id=3, filled_at=_dt(date(2025, 3, 1)), price="130", units="15", fees="0", action="EXIT"),
+        ]
+        result = self._run(fills=fills)
+        assert result is not None
+        # avg_entry = 1600/15, avg_exit = 130
+        # gross = (130 - 1600/15) / (1600/15)
+        avg_entry = _D("1600") / _D("15")
+        expected_gross = (_D("130") - avg_entry) / avg_entry
+        assert abs(result.gross_return_pct - expected_gross) < _D("0.000001")
+
+    def test_instrument_id_preserved_on_result(self) -> None:
+        fills = [
+            _fill(fill_id=1, action="BUY"),
+            _fill(fill_id=2, action="EXIT"),
+        ]
+        conn = MagicMock()
+        with (
+            patch("app.services.return_attribution._load_position_fills", return_value=fills),
+            patch("app.services.return_attribution._compute_market_return", return_value=ZERO),
+            patch("app.services.return_attribution._compute_sector_return", return_value=ZERO),
+            patch("app.services.return_attribution._load_recommendation_for_fills", return_value=None),
+            patch("app.services.return_attribution._load_score_snapshot", return_value=None),
+        ):
+            result = compute_attribution(conn, instrument_id=42)
+        assert result is not None
+        assert result.instrument_id == 42
+
+    def test_market_and_sector_return_zero_when_no_data(self) -> None:
+        fills = [
+            _fill(fill_id=1, action="BUY"),
+            _fill(fill_id=2, action="EXIT"),
+        ]
+        result = self._run(fills=fills, market_return=ZERO, sector_return=ZERO)
+        assert result is not None
+        assert result.market_return_pct == ZERO
+        assert result.sector_return_pct == ZERO
+
+
+# ===========================================================================
+# TestPersistAttribution
+# ===========================================================================
+
+
+class TestPersistAttribution:
+    def _make_result(self, **overrides: Any) -> AttributionResult:
+        defaults: dict[str, Any] = {
+            "instrument_id": 1,
+            "hold_start": date(2025, 1, 10),
+            "hold_end": date(2025, 3, 10),
+            "hold_days": 59,
+            "gross_return_pct": _D("0.10"),
+            "market_return_pct": _D("0.05"),
+            "sector_return_pct": _D("0.08"),
+            "model_alpha_pct": _D("0.02"),
+            "timing_alpha_pct": ZERO,
+            "cost_drag_pct": _D("0.002"),
+            "residual_pct": _D("0.078"),
+            "score_at_entry": _D("0.75"),
+            "score_components": {"quality_score": 0.8},
+            "entry_fill_id": 1,
+            "exit_fill_id": 2,
+            "recommendation_id": 7,
+        }
+        defaults.update(overrides)
+        return AttributionResult(**defaults)
+
+    def test_executes_insert_with_attribution_method(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        result = self._make_result()
+        persist_attribution(conn, result)
+        assert cur.execute.called
+        sql = cur.execute.call_args[0][0]
+        assert "INSERT INTO return_attribution" in sql
+
+    def test_params_contain_all_required_fields(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        result = self._make_result()
+        persist_attribution(conn, result)
+        params = cur.execute.call_args[0][1]
+        assert params["instrument_id"] == 1
+        assert params["hold_days"] == 59
+        assert params["gross_return_pct"] == _D("0.10")
+        assert params["attribution_method"] == ATTRIBUTION_METHOD
+
+    def test_null_score_components_passes_none(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        result = self._make_result(score_components=None)
+        persist_attribution(conn, result)
+        params = cur.execute.call_args[0][1]
+        assert params["score_components"] is None
+
+    def test_score_components_wrapped_in_jsonb(self) -> None:
+        from psycopg.types.json import Jsonb
+
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        result = self._make_result(score_components={"quality_score": 0.8})
+        persist_attribution(conn, result)
+        params = cur.execute.call_args[0][1]
+        assert isinstance(params["score_components"], Jsonb)
+
+    def test_computed_at_is_utc_datetime(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        result = self._make_result()
+        persist_attribution(conn, result)
+        params = cur.execute.call_args[0][1]
+        computed_at = params["computed_at"]
+        assert isinstance(computed_at, datetime)
+        assert computed_at.tzinfo is not None
+
+
+# ===========================================================================
+# TestComputeAttributionSummary
+# ===========================================================================
+
+
+class TestComputeAttributionSummary:
+    def test_happy_path_returns_summary_with_averages(self) -> None:
+        row = {
+            "positions_attributed": 5,
+            "avg_gross_return_pct": _D("0.12"),
+            "avg_market_return_pct": _D("0.05"),
+            "avg_sector_return_pct": _D("0.08"),
+            "avg_model_alpha_pct": _D("0.04"),
+            "avg_timing_alpha_pct": _D("0"),
+            "avg_cost_drag_pct": _D("0.003"),
+        }
+        cur = _make_cursor([row])
+        conn = _make_conn([cur])
+        result = compute_attribution_summary(conn, window_days=90)
+        assert result.window_days == 90
+        assert result.positions_attributed == 5
+        assert result.avg_gross_return_pct == _D("0.12")
+        assert result.avg_model_alpha_pct == _D("0.04")
+
+    def test_empty_window_returns_zero_count_none_averages(self) -> None:
+        row = {
+            "positions_attributed": 0,
+            "avg_gross_return_pct": None,
+            "avg_market_return_pct": None,
+            "avg_sector_return_pct": None,
+            "avg_model_alpha_pct": None,
+            "avg_timing_alpha_pct": None,
+            "avg_cost_drag_pct": None,
+        }
+        cur = _make_cursor([row])
+        conn = _make_conn([cur])
+        result = compute_attribution_summary(conn, window_days=30)
+        assert result.positions_attributed == 0
+        assert result.avg_gross_return_pct is None
+        assert result.avg_model_alpha_pct is None
+
+    def test_none_row_returns_zero_count_none_averages(self) -> None:
+        """If fetchone returns None (e.g. an unusual driver state), return defaults."""
+        cur = MagicMock()
+        cur.fetchone.return_value = None
+        cur.__enter__ = MagicMock(return_value=cur)
+        cur.__exit__ = MagicMock(return_value=False)
+        conn = _make_conn([cur])
+        result = compute_attribution_summary(conn, window_days=365)
+        assert result.positions_attributed == 0
+        assert result.avg_gross_return_pct is None
+
+    def test_passes_window_days_as_param(self) -> None:
+        row = {
+            "positions_attributed": 0,
+            "avg_gross_return_pct": None,
+            "avg_market_return_pct": None,
+            "avg_sector_return_pct": None,
+            "avg_model_alpha_pct": None,
+            "avg_timing_alpha_pct": None,
+            "avg_cost_drag_pct": None,
+        }
+        cur = _make_cursor([row])
+        conn = _make_conn([cur])
+        compute_attribution_summary(conn, window_days=90)
+        params = cur.execute.call_args[0][1]
+        assert params["window_days"] == 90
+
+    def test_averages_are_decimal_not_float(self) -> None:
+        row = {
+            "positions_attributed": 3,
+            "avg_gross_return_pct": _D("0.07"),
+            "avg_market_return_pct": _D("0.03"),
+            "avg_sector_return_pct": _D("0.05"),
+            "avg_model_alpha_pct": _D("0.02"),
+            "avg_timing_alpha_pct": _D("0"),
+            "avg_cost_drag_pct": _D("0.001"),
+        }
+        cur = _make_cursor([row])
+        conn = _make_conn([cur])
+        result = compute_attribution_summary(conn, window_days=30)
+        assert isinstance(result.avg_gross_return_pct, Decimal)
+        assert isinstance(result.avg_model_alpha_pct, Decimal)
+
+
+# ===========================================================================
+# TestPersistAttributionSummary
+# ===========================================================================
+
+
+class TestPersistAttributionSummary:
+    def _make_summary(self, **overrides: Any) -> SummaryResult:
+        defaults: dict[str, Any] = {
+            "window_days": 90,
+            "positions_attributed": 5,
+            "avg_gross_return_pct": _D("0.12"),
+            "avg_market_return_pct": _D("0.05"),
+            "avg_sector_return_pct": _D("0.08"),
+            "avg_model_alpha_pct": _D("0.04"),
+            "avg_timing_alpha_pct": ZERO,
+            "avg_cost_drag_pct": _D("0.003"),
+        }
+        defaults.update(overrides)
+        return SummaryResult(**defaults)
+
+    def test_executes_insert_into_summary_table(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        summary = self._make_summary()
+        persist_attribution_summary(conn, summary)
+        assert cur.execute.called
+        sql = cur.execute.call_args[0][0]
+        assert "INSERT INTO return_attribution_summary" in sql
+
+    def test_params_contain_all_required_fields(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        summary = self._make_summary()
+        persist_attribution_summary(conn, summary)
+        params = cur.execute.call_args[0][1]
+        assert params["window_days"] == 90
+        assert params["positions_attributed"] == 5
+        assert params["avg_gross_return_pct"] == _D("0.12")
+        assert params["avg_model_alpha_pct"] == _D("0.04")
+
+    def test_none_averages_passed_through_as_none(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        summary = self._make_summary(avg_gross_return_pct=None, avg_model_alpha_pct=None)
+        persist_attribution_summary(conn, summary)
+        params = cur.execute.call_args[0][1]
+        assert params["avg_gross_return_pct"] is None
+        assert params["avg_model_alpha_pct"] is None
+
+    def test_computed_at_is_utc_datetime(self) -> None:
+        cur = _make_cursor([])
+        conn = _make_conn([cur])
+        summary = self._make_summary()
+        persist_attribution_summary(conn, summary)
+        params = cur.execute.call_args[0][1]
+        computed_at = params["computed_at"]
+        assert isinstance(computed_at, datetime)
+        assert computed_at.tzinfo is not None
+
+
+# ===========================================================================
+# TestAttributionResultDataclass
+# ===========================================================================
+
+
+class TestAttributionResultDataclass:
+    def test_frozen_raises_on_mutation(self) -> None:
+        result = AttributionResult(
+            instrument_id=1,
+            hold_start=date(2025, 1, 1),
+            hold_end=date(2025, 3, 1),
+            hold_days=59,
+            gross_return_pct=_D("0.10"),
+            market_return_pct=_D("0.05"),
+            sector_return_pct=_D("0.08"),
+            model_alpha_pct=_D("0.02"),
+            timing_alpha_pct=ZERO,
+            cost_drag_pct=_D("0.002"),
+            residual_pct=_D("0.078"),
+            score_at_entry=None,
+            score_components=None,
+            entry_fill_id=1,
+            exit_fill_id=2,
+            recommendation_id=None,
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            result.instrument_id = 999  # type: ignore[misc]
+
+
+# ===========================================================================
+# TestSummaryResultDataclass
+# ===========================================================================
+
+
+class TestSummaryResultDataclass:
+    def test_frozen_raises_on_mutation(self) -> None:
+        summary = SummaryResult(
+            window_days=30,
+            positions_attributed=0,
+            avg_gross_return_pct=None,
+            avg_market_return_pct=None,
+            avg_sector_return_pct=None,
+            avg_model_alpha_pct=None,
+            avg_timing_alpha_pct=None,
+            avg_cost_drag_pct=None,
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            summary.window_days = 90  # type: ignore[misc]

--- a/tests/test_scheduler_attribution.py
+++ b/tests/test_scheduler_attribution.py
@@ -1,0 +1,104 @@
+"""Tests for the attribution summary scheduler job (Task 6).
+
+Covers:
+- attribution_summary_job: calls compute/persist for each SUMMARY_WINDOWS entry
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.services.return_attribution import SUMMARY_WINDOWS
+from app.workers.scheduler import attribution_summary_job
+
+# ---------------------------------------------------------------------------
+# Patch paths
+# ---------------------------------------------------------------------------
+
+_PSYCOPG_CONNECT_PATCH = "app.workers.scheduler.psycopg.connect"
+_RECORD_START_PATCH = "app.workers.scheduler.record_job_start"
+_RECORD_FINISH_PATCH = "app.workers.scheduler.record_job_finish"
+_SPIKE_PATCH = "app.workers.scheduler.check_row_count_spike"
+_COMPUTE_PATCH = "app.workers.scheduler.compute_attribution_summary"
+_PERSIST_PATCH = "app.workers.scheduler.persist_attribution_summary"
+
+
+def _make_conn_ctx() -> MagicMock:
+    """Return a MagicMock that acts as a psycopg connection context manager."""
+    conn = MagicMock()
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    # transaction() must also behave as a context manager
+    txn_ctx = MagicMock()
+    txn_ctx.__enter__ = MagicMock(return_value=txn_ctx)
+    txn_ctx.__exit__ = MagicMock(return_value=False)
+    conn.transaction.return_value = txn_ctx
+    return conn
+
+
+def _make_summary_mock(positions: int = 5) -> MagicMock:
+    from decimal import Decimal
+
+    m = MagicMock()
+    m.positions_attributed = positions
+    m.avg_model_alpha_pct = Decimal("0.0123")
+    return m
+
+
+class TestAttributionSummaryJob:
+    """Tests for attribution_summary_job."""
+
+    @patch(_SPIKE_PATCH, return_value=MagicMock(flagged=False))
+    @patch(_RECORD_FINISH_PATCH)
+    @patch(_RECORD_START_PATCH, return_value=1)
+    @patch(_PERSIST_PATCH)
+    @patch(_COMPUTE_PATCH)
+    @patch(_PSYCOPG_CONNECT_PATCH)
+    def test_computes_summaries_for_all_windows(
+        self,
+        mock_connect: MagicMock,
+        mock_compute: MagicMock,
+        mock_persist: MagicMock,
+        mock_start: MagicMock,
+        mock_finish: MagicMock,
+        mock_spike: MagicMock,
+    ) -> None:
+        """compute_attribution_summary must be called once per SUMMARY_WINDOWS entry."""
+        conn_ctx = _make_conn_ctx()
+        mock_connect.return_value = conn_ctx
+        mock_compute.return_value = _make_summary_mock()
+
+        attribution_summary_job()
+
+        assert mock_compute.call_count == len(SUMMARY_WINDOWS)
+        called_windows = [call.args[1] for call in mock_compute.call_args_list]
+        assert called_windows == list(SUMMARY_WINDOWS)
+
+    @patch(_SPIKE_PATCH, return_value=MagicMock(flagged=False))
+    @patch(_RECORD_FINISH_PATCH)
+    @patch(_RECORD_START_PATCH, return_value=1)
+    @patch(_PERSIST_PATCH)
+    @patch(_COMPUTE_PATCH)
+    @patch(_PSYCOPG_CONNECT_PATCH)
+    def test_persists_each_summary(
+        self,
+        mock_connect: MagicMock,
+        mock_compute: MagicMock,
+        mock_persist: MagicMock,
+        mock_start: MagicMock,
+        mock_finish: MagicMock,
+        mock_spike: MagicMock,
+    ) -> None:
+        """persist_attribution_summary must be called once per window."""
+        conn_ctx = _make_conn_ctx()
+        mock_connect.return_value = conn_ctx
+
+        summaries = [_make_summary_mock(i + 1) for i in range(len(SUMMARY_WINDOWS))]
+        mock_compute.side_effect = summaries
+
+        attribution_summary_job()
+
+        assert mock_persist.call_count == len(SUMMARY_WINDOWS)
+        for i, call in enumerate(mock_persist.call_args_list):
+            # Second positional arg is the SummaryResult
+            assert call.args[1] is summaries[i]


### PR DESCRIPTION
Closes #155

## What changed

Adds **return attribution** — when a position is fully closed (EXIT fill zeroes `current_units`), the gross return is decomposed into five additive components:

```
gross_return = market_return + sector_tilt + model_alpha + timing_alpha + cost_drag + residual
```

**New files:**
- `sql/029_return_attribution.sql` — migration creating `return_attribution` and `return_attribution_summary` tables
- `app/services/return_attribution.py` — core attribution service: loaders, computation, persistence
- `tests/test_return_attribution.py` — 62 unit tests covering all loaders, computation, persistence, edge cases
- `tests/test_attribution_trigger.py` — 5 tests for the EXIT fill → attribution trigger integration
- `tests/test_scheduler_attribution.py` — 2 tests for the summary scheduler job
- `app/api/attribution.py` — `GET /api/attribution` and `GET /api/attribution/summary` endpoints

**Modified files:**
- `app/services/order_client.py` — `_maybe_trigger_attribution` helper called after EXIT fills; reads `current_units` post-update to decide
- `app/workers/scheduler.py` — weekly `attribution_summary` job computing 30/90/365-day rolling windows
- `app/jobs/runtime.py` — registered the new job invoker
- `app/main.py` — registered the attribution router
- `tests/test_order_client.py` — patched `_maybe_trigger_attribution` in EXIT tests (cursor sequence fix)

## Why

Attribution closes the feedback loop: the system can now measure whether its stock selection (model_alpha) actually added value above sector/market baselines. This is foundational for future model tuning and operator dashboards.

The `sector_relative_v1` method was chosen because it uses only data already in `price_daily` — no external benchmark indices needed. Market return uses Tier 1 coverage average; sector return uses same-sector peer average.

## Schema / migration impact

**Migration 029** adds two tables:
- `return_attribution` — per-position decomposition with all 5 components, score snapshot at entry, fill references, recommendation reference, attribution method tag
- `return_attribution_summary` — rolling-window aggregation (30/90/365 days)

Indexes on `instrument_id` and `computed_at`. No backfill needed — attribution is computed going forward as positions close.

## Invariants checked

- **All arithmetic uses Decimal** — never float. `ZERO = Decimal("0")` constant throughout.
- **Additive decomposition closes**: `residual = gross - market - (sector - market) - model_alpha - timing_alpha - cost_drag`. The equation always sums to gross.
- **Append-only writes**: INSERT only, never UPDATE. Each close produces one attribution row.
- **Attribution is best-effort**: `_maybe_trigger_attribution` catches all exceptions — attribution failure never aborts the order execution path.
- **`persist_attribution` uses savepoint** via `conn.transaction()` — partial write rolls back cleanly without affecting the outer order transaction.
- **No external I/O in transactions**: all data comes from DB reads within the same connection.
- **Frozen dataclass** for `AttributionResult` — prevents accidental mutation.

## Failure paths considered

- **No fills for instrument** → `compute_attribution` returns `None`, persist skipped
- **No exit fill** → returns `None`
- **Zero entry price** → returns `None` (division by zero guard)
- **No sector peers** → sector_return = ZERO, residual absorbs
- **No Tier 1 peers (market return)** → market_return = ZERO, residual absorbs
- **No score snapshot** → `score_at_entry = None`, `score_components = None`
- **Attribution computation error** → logged, swallowed, order execution continues
- **Position not found after EXIT** → defaults to `Decimal("0")`, triggers attribution (compute returns None since no fills match)
- **Negative current_units (rounding overshoot)** → treated as closed, triggers attribution

## Tests added

**62 unit tests** (`test_return_attribution.py`):
- All 7 internal loaders (fills, prices, scores, sector peers, recommendations, average return, market/sector return)
- Empty/missing data edge cases for every loader
- Full computation: correct decomposition, residual closes equation
- Decimal typing enforcement (no floats leak through)
- Jsonb wrapping for score_components persistence
- Frozen dataclass mutation guard
- Summary computation and persistence for all three window sizes

**5 trigger tests** (`test_attribution_trigger.py`):
- Full close (units=0) triggers compute + persist
- Partial exit (units>0) skips
- None result from compute skips persist
- Error doesn't propagate
- Negative units (rounding) triggers

**2 scheduler tests** (`test_scheduler_attribution.py`):
- Computes summaries for all window sizes (30, 90, 365)
- Persists each summary row

## Conscious tradeoffs

- **timing_alpha is always ZERO in v1** — the field exists for future TA-based entry/exit timing attribution but is not computed yet
- **No unique constraint on (instrument_id, exit_fill_id)** — duplicate attribution rows possible on retry; accepted in v1 append-only design
- **Market return = Tier 1 coverage average, not an index** — simpler, uses only internal data, but won't match SPY/benchmark tracking
- **Attribution runs inline in execute_order, not as an async job** — simpler, guaranteed to run on position close, acceptable latency for v1

## Tech debt opened

None.