### PR TITLE
feat(#207): reporting engine — weekly/monthly performance snapshots

### DIFF
--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -1,0 +1,81 @@
+"""Reports API — periodic performance report snapshots."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from fastapi import APIRouter, Depends, Query
+
+from app.api.auth import require_session_or_service_token
+from app.config import settings
+
+router = APIRouter(
+    prefix="/api/reports",
+    tags=["reports"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+
+@router.get("/weekly")
+def list_weekly_reports(
+    limit: int = Query(default=10, ge=1, le=100),
+) -> list[dict[str, Any]]:
+    """Return the most recent weekly report snapshots."""
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT snapshot_id, report_type, period_start, period_end,
+                       snapshot_json, computed_at
+                FROM report_snapshots
+                WHERE report_type = 'weekly'
+                ORDER BY period_start DESC
+                LIMIT %(limit)s
+                """,
+                {"limit": limit},
+            )
+            return cur.fetchall()
+
+
+@router.get("/monthly")
+def list_monthly_reports(
+    limit: int = Query(default=10, ge=1, le=100),
+) -> list[dict[str, Any]]:
+    """Return the most recent monthly report snapshots."""
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT snapshot_id, report_type, period_start, period_end,
+                       snapshot_json, computed_at
+                FROM report_snapshots
+                WHERE report_type = 'monthly'
+                ORDER BY period_start DESC
+                LIMIT %(limit)s
+                """,
+                {"limit": limit},
+            )
+            return cur.fetchall()
+
+
+@router.get("/latest")
+def get_latest_report(
+    report_type: str = Query(pattern="^(weekly|monthly)$"),
+) -> dict[str, Any] | None:
+    """Return the single most recent report of the given type."""
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT snapshot_id, report_type, period_start, period_end,
+                       snapshot_json, computed_at
+                FROM report_snapshots
+                WHERE report_type = %(report_type)s
+                ORDER BY period_start DESC
+                LIMIT 1
+                """,
+                {"report_type": report_type},
+            )
+            return cur.fetchone()

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -9,7 +9,7 @@ import psycopg.rows
 from fastapi import APIRouter, Depends, Query
 
 from app.api.auth import require_session_or_service_token
-from app.config import settings
+from app.db import get_conn
 
 router = APIRouter(
     prefix="/api/reports",
@@ -20,62 +20,62 @@ router = APIRouter(
 
 @router.get("/weekly")
 def list_weekly_reports(
+    conn: psycopg.Connection[object] = Depends(get_conn),
     limit: int = Query(default=10, ge=1, le=100),
 ) -> list[dict[str, Any]]:
     """Return the most recent weekly report snapshots."""
-    with psycopg.connect(settings.database_url) as conn:
-        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-            cur.execute(
-                """
-                SELECT snapshot_id, report_type, period_start, period_end,
-                       snapshot_json, computed_at
-                FROM report_snapshots
-                WHERE report_type = 'weekly'
-                ORDER BY period_start DESC
-                LIMIT %(limit)s
-                """,
-                {"limit": limit},
-            )
-            return cur.fetchall()
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT snapshot_id, report_type, period_start, period_end,
+                   snapshot_json, computed_at
+            FROM report_snapshots
+            WHERE report_type = 'weekly'
+            ORDER BY period_start DESC
+            LIMIT %(limit)s
+            """,
+            {"limit": limit},
+        )
+        return cur.fetchall()
 
 
 @router.get("/monthly")
 def list_monthly_reports(
+    conn: psycopg.Connection[object] = Depends(get_conn),
     limit: int = Query(default=10, ge=1, le=100),
 ) -> list[dict[str, Any]]:
     """Return the most recent monthly report snapshots."""
-    with psycopg.connect(settings.database_url) as conn:
-        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-            cur.execute(
-                """
-                SELECT snapshot_id, report_type, period_start, period_end,
-                       snapshot_json, computed_at
-                FROM report_snapshots
-                WHERE report_type = 'monthly'
-                ORDER BY period_start DESC
-                LIMIT %(limit)s
-                """,
-                {"limit": limit},
-            )
-            return cur.fetchall()
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT snapshot_id, report_type, period_start, period_end,
+                   snapshot_json, computed_at
+            FROM report_snapshots
+            WHERE report_type = 'monthly'
+            ORDER BY period_start DESC
+            LIMIT %(limit)s
+            """,
+            {"limit": limit},
+        )
+        return cur.fetchall()
 
 
 @router.get("/latest")
 def get_latest_report(
+    conn: psycopg.Connection[object] = Depends(get_conn),
     report_type: str = Query(pattern="^(weekly|monthly)$"),
 ) -> dict[str, Any] | None:
     """Return the single most recent report of the given type."""
-    with psycopg.connect(settings.database_url) as conn:
-        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-            cur.execute(
-                """
-                SELECT snapshot_id, report_type, period_start, period_end,
-                       snapshot_json, computed_at
-                FROM report_snapshots
-                WHERE report_type = %(report_type)s
-                ORDER BY period_start DESC
-                LIMIT 1
-                """,
-                {"report_type": report_type},
-            )
-            return cur.fetchone()
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT snapshot_id, report_type, period_start, period_end,
+                   snapshot_json, computed_at
+            FROM report_snapshots
+            WHERE report_type = %(report_type)s
+            ORDER BY period_start DESC
+            LIMIT 1
+            """,
+            {"report_type": report_type},
+        )
+        return cur.fetchone()

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -112,7 +112,7 @@ class JobOverviewResponse(BaseModel):
     name: str
     description: str
     cadence: str
-    cadence_kind: Literal["hourly", "daily", "weekly"]
+    cadence_kind: Literal["hourly", "daily", "weekly", "monthly"]
     next_run_time: datetime
     next_run_time_source: Literal["live", "declared"]
     last_status: Literal["running", "success", "failure", "skipped"] | None

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -164,6 +164,13 @@ def _trigger_for(cadence: Cadence) -> CronTrigger:
             minute=cadence.minute,
             timezone="UTC",
         )
+    if cadence.kind == "monthly":
+        return CronTrigger(
+            day=cadence.day,
+            hour=cadence.hour,
+            minute=cadence.minute,
+            timezone="UTC",
+        )
     raise ValueError(f"unsupported cadence kind: {cadence.kind!r}")
 
 

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -64,10 +64,12 @@ from app.workers.scheduler import (
     JOB_EXECUTE_APPROVED_ORDERS,
     JOB_FX_RATES_REFRESH,
     JOB_MONITOR_POSITIONS,
+    JOB_MONTHLY_REPORT,
     JOB_MORNING_CANDIDATE_REVIEW,
     JOB_NIGHTLY_UNIVERSE_SYNC,
     JOB_RETRY_DEFERRED,
     JOB_WEEKLY_COVERAGE_REVIEW,
+    JOB_WEEKLY_REPORT,
     SCHEDULED_JOBS,
     Cadence,
     ScheduledJob,
@@ -83,10 +85,12 @@ from app.workers.scheduler import (
     execute_approved_orders,
     fx_rates_refresh,
     monitor_positions_job,
+    monthly_report,
     morning_candidate_review,
     nightly_universe_sync,
     retry_deferred_recommendations_job,
     weekly_coverage_review,
+    weekly_report,
 )
 
 logger = logging.getLogger(__name__)
@@ -128,6 +132,8 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_RETRY_DEFERRED: retry_deferred_recommendations_job,
     JOB_MONITOR_POSITIONS: monitor_positions_job,
     JOB_ATTRIBUTION_SUMMARY: attribution_summary_job,
+    JOB_WEEKLY_REPORT: weekly_report,
+    JOB_MONTHLY_REPORT: monthly_report,
 }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ from app.api.operators import router as operators_router
 from app.api.orders import router as orders_router
 from app.api.portfolio import router as portfolio_router
 from app.api.recommendations import router as recommendations_router
+from app.api.reports import router as reports_router
 from app.api.scores import router as scores_router
 from app.api.system import router as system_router
 from app.api.theses import router as theses_router
@@ -133,6 +134,7 @@ app.include_router(news_router)
 app.include_router(orders_router)
 app.include_router(portfolio_router)
 app.include_router(recommendations_router)
+app.include_router(reports_router)
 app.include_router(scores_router)
 app.include_router(system_router)
 app.include_router(theses_router)

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -260,7 +260,263 @@ def _budget_snapshot(conn: psycopg.Connection[Any]) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Main entry point
+# Monthly-only section functions
+# ---------------------------------------------------------------------------
+
+
+def _position_pnl_breakdown(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> list[dict[str, Any]]:
+    """Per-position P&L for positions that had fill activity in the period."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT p.instrument_id,
+                   i.symbol,
+                   i.company_name,
+                   p.cost_basis,
+                   p.realized_pnl,
+                   p.unrealized_pnl,
+                   p.current_units,
+                   p.avg_cost
+            FROM positions p
+            JOIN instruments i USING (instrument_id)
+            WHERE p.instrument_id IN (
+                SELECT DISTINCT o.instrument_id
+                FROM fills f
+                JOIN orders o USING (order_id)
+                WHERE f.filled_at >= %(start)s
+                  AND f.filled_at < %(end)s::date + 1
+            )
+            ORDER BY p.realized_pnl + p.unrealized_pnl DESC
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "instrument_id": r["instrument_id"],
+            "symbol": r["symbol"],
+            "company_name": r["company_name"],
+            "cost_basis": _dec(r["cost_basis"]),
+            "realized_pnl": _dec(r["realized_pnl"]),
+            "unrealized_pnl": _dec(r["unrealized_pnl"]),
+            "current_units": _dec(r["current_units"]),
+        }
+        for r in rows
+    ]
+
+
+def _win_rate_and_holding(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> dict[str, Any]:
+    """Win rate and average holding period for positions closed in the period."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT ra.gross_return_pct, ra.hold_days
+            FROM return_attribution ra
+            WHERE ra.hold_end >= %(start)s
+              AND ra.hold_end <= %(end)s
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        rows = cur.fetchall()
+
+    total = len(rows)
+    if total == 0:
+        return {
+            "total_closed": 0,
+            "winners": 0,
+            "losers": 0,
+            "win_rate_pct": None,
+            "avg_holding_days": None,
+        }
+
+    winners = sum(1 for r in rows if r["gross_return_pct"] is not None and r["gross_return_pct"] > 0)
+    losers = total - winners
+    win_rate = f"{100 * winners / total:.2f}"
+    hold_days_vals = [float(r["hold_days"]) for r in rows if r["hold_days"] is not None]
+    avg_holding = sum(hold_days_vals) / len(hold_days_vals) if hold_days_vals else None
+    return {
+        "total_closed": total,
+        "winners": winners,
+        "losers": losers,
+        "win_rate_pct": win_rate,
+        "avg_holding_days": avg_holding,
+    }
+
+
+def _best_worst_trade(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Best and worst attributed trade closed in the period."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT ra.instrument_id,
+                   i.symbol,
+                   ra.gross_return_pct,
+                   ra.hold_days,
+                   ra.model_alpha_pct
+            FROM return_attribution ra
+            JOIN instruments i USING (instrument_id)
+            WHERE ra.hold_end >= %(start)s
+              AND ra.hold_end <= %(end)s
+            ORDER BY ra.gross_return_pct DESC
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        rows = cur.fetchall()
+
+    if not rows:
+        return None, None
+
+    def _to_dict(r: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "instrument_id": r["instrument_id"],
+            "symbol": r["symbol"],
+            "gross_return_pct": _dec(r["gross_return_pct"]),
+            "hold_days": r["hold_days"],
+            "model_alpha_pct": _dec(r["model_alpha_pct"]),
+        }
+
+    best = _to_dict(rows[0])
+    worst = _to_dict(rows[-1]) if len(rows) > 1 else _to_dict(rows[0])
+    return best, worst
+
+
+def _period_attribution(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> dict[str, Any]:
+    """Period-bounded attribution aggregated directly from return_attribution."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*) AS positions_attributed,
+                   AVG(gross_return_pct)   AS avg_gross,
+                   AVG(market_return_pct)  AS avg_market,
+                   AVG(model_alpha_pct)    AS avg_alpha
+            FROM return_attribution
+            WHERE hold_end >= %(start)s
+              AND hold_end <= %(end)s
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        return {
+            "positions_attributed": 0,
+            "avg_gross_return_pct": None,
+            "avg_market_return_pct": None,
+            "avg_model_alpha_pct": None,
+        }
+    return {
+        "positions_attributed": row["positions_attributed"],
+        "avg_gross_return_pct": _dec(row["avg_gross"]),
+        "avg_market_return_pct": _dec(row["avg_market"]),
+        "avg_model_alpha_pct": _dec(row["avg_alpha"]),
+    }
+
+
+def _thesis_accuracy(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> list[dict[str, Any]]:
+    """Thesis accuracy for closed positions, using thesis active at position open.
+
+    For each closed position, determines whether the exit price hit the bull,
+    base, or bear target from the thesis that was active when the position
+    was opened (nearest thesis by created_at before hold_start).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT ra.instrument_id,
+                   i.symbol,
+                   ra.gross_return_pct,
+                   t.base_value,
+                   t.bull_value,
+                   t.bear_value,
+                   t.stance,
+                   t.confidence_score,
+                   f_exit.price AS exit_price
+            FROM return_attribution ra
+            JOIN instruments i USING (instrument_id)
+            LEFT JOIN LATERAL (
+                SELECT base_value, bull_value, bear_value, stance, confidence_score
+                FROM theses
+                WHERE instrument_id = ra.instrument_id
+                  AND created_at <= (ra.hold_start::timestamptz)
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) t ON true
+            LEFT JOIN fills f_exit ON f_exit.fill_id = ra.exit_fill_id
+            WHERE ra.hold_end >= %(start)s
+              AND ra.hold_end <= %(end)s
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        rows = cur.fetchall()
+
+    results: list[dict[str, Any]] = []
+    for r in rows:
+        exit_price = r["exit_price"]
+        bull_value = r["bull_value"]
+        base_value = r["base_value"]
+        bear_value = r["bear_value"]
+
+        target_hit: str | None
+        if exit_price is None or bull_value is None or base_value is None or bear_value is None:
+            target_hit = None
+        elif exit_price >= bull_value:
+            target_hit = "bull"
+        elif exit_price >= base_value:
+            target_hit = "base"
+        elif exit_price <= bear_value:
+            target_hit = "bear"
+        else:
+            target_hit = "between_bear_and_base"
+
+        results.append(
+            {
+                "instrument_id": r["instrument_id"],
+                "symbol": r["symbol"],
+                "gross_return_pct": _dec(r["gross_return_pct"]),
+                "stance": r["stance"],
+                "confidence_score": _dec(r["confidence_score"]),
+                "exit_price": _dec(exit_price),
+                "base_value": _dec(base_value),
+                "bull_value": _dec(bull_value),
+                "bear_value": _dec(bear_value),
+                "target_hit": target_hit,
+            }
+        )
+    return results
+
+
+def _tax_provision_snapshot(conn: psycopg.Connection[Any]) -> dict[str, Any]:
+    """Current tax provision from the budget service."""
+    budget = compute_budget_state(conn)
+    return {
+        "estimated_tax_gbp": _dec(budget.estimated_tax_gbp),
+        "estimated_tax_usd": _dec(budget.estimated_tax_usd),
+        "tax_year": budget.tax_year,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main entry points
 # ---------------------------------------------------------------------------
 
 
@@ -298,4 +554,43 @@ def generate_weekly_report(
         "upcoming_earnings": upcoming_earnings,
         "score_changes": score_changes,
         "budget": budget,
+    }
+
+
+def generate_monthly_report(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> MonthlyReport:
+    """Generate a monthly performance report snapshot.
+
+    Reads from positions, fills, orders, instruments, return_attribution,
+    theses, and the budget service.
+
+    The caller owns the transaction; this function never calls conn.commit().
+
+    Returns a plain dict suitable for storage in report_snapshots.snapshot_json.
+    """
+    pnl = _pnl_snapshot(conn)
+    position_pnl = _position_pnl_breakdown(conn, period_start, period_end)
+    win_rate_data = _win_rate_and_holding(conn, period_start, period_end)
+    best_trade, worst_trade = _best_worst_trade(conn, period_start, period_end)
+    attribution_summary = _period_attribution(conn, period_start, period_end)
+    thesis_accuracy = _thesis_accuracy(conn, period_start, period_end)
+    tax_provision = _tax_provision_snapshot(conn)
+
+    return {
+        "report_type": "monthly",
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "generated_at": datetime.now(tz=UTC).isoformat(),
+        "pnl": pnl,
+        "position_pnl": position_pnl,
+        "win_rate": win_rate_data["win_rate_pct"],
+        "avg_holding_days": win_rate_data["avg_holding_days"],
+        "best_trade": best_trade,
+        "worst_trade": worst_trade,
+        "attribution_summary": attribution_summary,
+        "thesis_accuracy": thesis_accuracy,
+        "tax_provision": tax_provision,
     }

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -1,0 +1,301 @@
+"""
+Reporting service — weekly (and future monthly) performance report snapshots.
+
+Reads from existing tables and returns plain dicts suitable for JSONB storage
+in the report_snapshots table.
+
+All values are current-state snapshots, not true period deltas.
+Decimal values are serialised to strings for JSON compatibility.
+
+Issue: #207
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+from app.services.budget import compute_budget_state
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+WeeklyReport = dict[str, Any]
+MonthlyReport = dict[str, Any]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dec(v: Decimal | None) -> str | None:
+    """Decimal → str for JSON serialisation, preserving None."""
+    return str(v) if v is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Section functions
+# ---------------------------------------------------------------------------
+
+
+def _pnl_snapshot(conn: psycopg.Connection[Any]) -> dict[str, Any]:
+    """Current realised + unrealised P&L totals from the positions table.
+
+    This is a current-state snapshot, not a period delta.  Both realized_pnl
+    and unrealized_pnl are the running totals on open positions.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT COALESCE(SUM(realized_pnl), 0)   AS realized,
+                   COALESCE(SUM(unrealized_pnl), 0) AS unrealized
+            FROM positions
+            WHERE current_units > 0
+            """
+        )
+        row = cur.fetchone()
+
+    realized: Decimal = row["realized"] if row else Decimal("0")
+    unrealized: Decimal = row["unrealized"] if row else Decimal("0")
+    total = realized + unrealized
+    return {
+        "realized_pnl": _dec(realized),
+        "unrealized_pnl": _dec(unrealized),
+        "total_pnl": _dec(total),
+        "note": "current-state snapshot, not period delta",
+    }
+
+
+def _top_bottom_performers(
+    conn: psycopg.Connection[Any],
+    n: int = 3,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Top N and bottom N open positions by unrealized_pnl.
+
+    Returns (top_list, bottom_list).  If total open positions <= n, the bottom
+    list is empty to avoid duplicating entries that already appear in the top.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT p.instrument_id,
+                   i.symbol,
+                   i.company_name,
+                   p.unrealized_pnl,
+                   p.current_units,
+                   p.avg_cost
+            FROM positions p
+            JOIN instruments i USING (instrument_id)
+            WHERE p.current_units > 0
+            ORDER BY p.unrealized_pnl DESC
+            """
+        )
+        rows = cur.fetchall()
+
+    def _row_to_dict(r: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "instrument_id": r["instrument_id"],
+            "symbol": r["symbol"],
+            "company_name": r["company_name"],
+            "unrealized_pnl": _dec(r["unrealized_pnl"]),
+        }
+
+    total = len(rows)
+    top = [_row_to_dict(r) for r in rows[:n]]
+    # Avoid duplicates: if there are n or fewer positions, bottom is empty.
+    bottom = [_row_to_dict(r) for r in rows[max(n, total - n) :]] if total > n else []
+    return top, bottom
+
+
+def _positions_opened_closed(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """BUY and EXIT fills in the report period.
+
+    Joins recommendations via orders.recommendation_id (not through
+    decision_audit).
+    """
+
+    def _fetch(action: str) -> list[dict[str, Any]]:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT o.instrument_id,
+                       i.symbol,
+                       o.action,
+                       tr.rationale,
+                       f.price,
+                       f.units,
+                       f.filled_at
+                FROM fills f
+                JOIN orders o USING (order_id)
+                JOIN instruments i ON i.instrument_id = o.instrument_id
+                LEFT JOIN trade_recommendations tr
+                       ON tr.recommendation_id = o.recommendation_id
+                WHERE o.action = %(action)s
+                  AND f.filled_at >= %(start)s
+                  AND f.filled_at < %(end)s::date + 1
+                ORDER BY f.filled_at
+                """,
+                {"action": action, "start": period_start, "end": period_end},
+            )
+            raw = cur.fetchall()
+        return [
+            {
+                "instrument_id": r["instrument_id"],
+                "symbol": r["symbol"],
+                "action": r["action"],
+                "rationale": r["rationale"],
+                "price": _dec(r["price"]),
+                "units": _dec(r["units"]),
+                "filled_at": r["filled_at"].isoformat() if r["filled_at"] is not None else None,
+            }
+            for r in raw
+        ]
+
+    opened = _fetch("BUY")
+    closed = _fetch("EXIT")
+    return opened, closed
+
+
+def _upcoming_earnings(
+    conn: psycopg.Connection[Any],
+    lookahead_days: int = 14,
+) -> list[dict[str, Any]]:
+    """Upcoming earnings events for currently held positions."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT ee.instrument_id,
+                   i.symbol,
+                   i.company_name,
+                   ee.reporting_date,
+                   ee.eps_estimate
+            FROM earnings_events ee
+            JOIN instruments i USING (instrument_id)
+            JOIN positions p USING (instrument_id)
+            WHERE p.current_units > 0
+              AND ee.reporting_date >= CURRENT_DATE
+              AND ee.reporting_date < CURRENT_DATE + make_interval(days => %(days)s)
+            ORDER BY ee.reporting_date
+            """,
+            {"days": lookahead_days},
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "instrument_id": r["instrument_id"],
+            "symbol": r["symbol"],
+            "company_name": r["company_name"],
+            "reporting_date": r["reporting_date"].isoformat() if r["reporting_date"] is not None else None,
+            "eps_estimate": _dec(r["eps_estimate"]),
+        }
+        for r in rows
+    ]
+
+
+def _score_changes(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+    min_rank_delta: int = 5,
+) -> list[dict[str, Any]]:
+    """Significant rank movements in the report period.
+
+    Filters to rows where ABS(rank_delta) >= min_rank_delta.
+    rank and rank_delta were added to scores in migration 007.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT s.instrument_id,
+                   i.symbol,
+                   s.total_score,
+                   s.rank,
+                   s.rank_delta,
+                   s.scored_at
+            FROM scores s
+            JOIN instruments i USING (instrument_id)
+            WHERE s.scored_at >= %(start)s
+              AND s.scored_at < %(end)s::date + 1
+              AND s.rank_delta IS NOT NULL
+              AND ABS(s.rank_delta) >= %(min_delta)s
+            ORDER BY ABS(s.rank_delta) DESC
+            """,
+            {"start": period_start, "end": period_end, "min_delta": min_rank_delta},
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "instrument_id": r["instrument_id"],
+            "symbol": r["symbol"],
+            "total_score": _dec(r["total_score"]),
+            "rank": r["rank"],
+            "rank_delta": r["rank_delta"],
+            "scored_at": r["scored_at"].isoformat() if r["scored_at"] is not None else None,
+        }
+        for r in rows
+    ]
+
+
+def _budget_snapshot(conn: psycopg.Connection[Any]) -> dict[str, Any]:
+    """Current budget state via compute_budget_state."""
+    budget = compute_budget_state(conn)
+    return {
+        "cash_balance": _dec(budget.cash_balance),
+        "deployed_capital": _dec(budget.deployed_capital),
+        "estimated_tax_usd": _dec(budget.estimated_tax_usd),
+        "available_for_deployment": _dec(budget.available_for_deployment),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def generate_weekly_report(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> WeeklyReport:
+    """Generate a weekly performance report snapshot.
+
+    Reads from positions, fills, orders, instruments, trade_recommendations,
+    earnings_events, scores, and the budget service.
+
+    The caller owns the transaction; this function never calls conn.commit().
+
+    Returns a plain dict suitable for storage in report_snapshots.snapshot_json.
+    """
+    pnl = _pnl_snapshot(conn)
+    top_performers, bottom_performers = _top_bottom_performers(conn)
+    positions_opened, positions_closed = _positions_opened_closed(conn, period_start, period_end)
+    upcoming_earnings = _upcoming_earnings(conn)
+    score_changes = _score_changes(conn, period_start, period_end)
+    budget = _budget_snapshot(conn)
+
+    return {
+        "report_type": "weekly",
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "generated_at": datetime.now(tz=UTC).isoformat(),
+        "pnl": pnl,
+        "top_performers": top_performers,
+        "bottom_performers": bottom_performers,
+        "positions_opened": positions_opened,
+        "positions_closed": positions_closed,
+        "upcoming_earnings": upcoming_earnings,
+        "score_changes": score_changes,
+        "budget": budget,
+    }

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -113,7 +113,7 @@ def _top_bottom_performers(
     total = len(rows)
     top = [_row_to_dict(r) for r in rows[:n]]
     # Avoid duplicates: if there are n or fewer positions, bottom is empty.
-    bottom = [_row_to_dict(r) for r in rows[max(n, total - n) :]] if total > n else []
+    bottom = [_row_to_dict(r) for r in rows[total - n :]] if total > n else []
     return top, bottom
 
 

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -50,16 +50,17 @@ def _dec(v: Decimal | None) -> str | None:
 def _pnl_snapshot(conn: psycopg.Connection[Any]) -> dict[str, Any]:
     """Current realised + unrealised P&L totals from the positions table.
 
-    This is a current-state snapshot, not a period delta.  Both realized_pnl
-    and unrealized_pnl are the running totals on open positions.
+    This is a current-state snapshot, not a period delta.  Realized P&L spans
+    all positions (open and closed); unrealized P&L only applies to positions
+    that still hold units.
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT COALESCE(SUM(realized_pnl), 0)   AS realized,
-                   COALESCE(SUM(unrealized_pnl), 0) AS unrealized
+            SELECT COALESCE(SUM(realized_pnl), 0) AS realized,
+                   COALESCE(SUM(unrealized_pnl) FILTER (WHERE current_units > 0), 0)
+                       AS unrealized
             FROM positions
-            WHERE current_units > 0
             """
         )
         row = cur.fetchone()
@@ -458,7 +459,7 @@ def _thesis_accuracy(
                 SELECT base_value, bull_value, bear_value, stance, confidence_score
                 FROM theses
                 WHERE instrument_id = ra.instrument_id
-                  AND created_at <= (ra.hold_start::timestamptz)
+                  AND created_at < (ra.hold_start::timestamptz + interval '1 day')
                 ORDER BY created_at DESC
                 LIMIT 1
             ) t ON true

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import psycopg
 import psycopg.rows
+from psycopg.types.json import Jsonb
 
 from app.services.budget import compute_budget_state
 
@@ -513,6 +514,65 @@ def _tax_provision_snapshot(conn: psycopg.Connection[Any]) -> dict[str, Any]:
         "estimated_tax_usd": _dec(budget.estimated_tax_usd),
         "tax_year": budget.tax_year,
     }
+
+
+# ---------------------------------------------------------------------------
+# Persistence layer
+# ---------------------------------------------------------------------------
+
+
+def persist_report_snapshot(
+    conn: psycopg.Connection[Any],
+    *,
+    report_type: str,
+    period_start: date,
+    period_end: date,
+    snapshot: dict[str, Any],
+) -> None:
+    """Upsert a report snapshot into report_snapshots.
+
+    Idempotent: ON CONFLICT replaces the snapshot for the same
+    (report_type, period_start) pair. The caller owns the commit.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO report_snapshots (report_type, period_start, period_end, snapshot_json)
+            VALUES (%(report_type)s, %(period_start)s, %(period_end)s, %(snapshot)s)
+            ON CONFLICT (report_type, period_start) DO UPDATE
+            SET period_end   = EXCLUDED.period_end,
+                snapshot_json = EXCLUDED.snapshot_json,
+                computed_at  = NOW()
+            """,
+            {
+                "report_type": report_type,
+                "period_start": period_start,
+                "period_end": period_end,
+                "snapshot": Jsonb(snapshot),
+            },
+        )
+
+
+def load_report_snapshots(
+    conn: psycopg.Connection[Any],
+    *,
+    report_type: str,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Load the most recent report snapshots of a given type."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT snapshot_id, report_type, period_start, period_end,
+                   snapshot_json, computed_at
+            FROM report_snapshots
+            WHERE report_type = %(report_type)s
+            ORDER BY period_start DESC
+            LIMIT %(limit)s
+            """,
+            {"report_type": report_type, "limit": limit},
+        )
+        return cur.fetchall()
 
 
 # ---------------------------------------------------------------------------

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -297,11 +297,7 @@ def _has_positions_or_attributions(conn: psycopg.Connection[Any]) -> Prerequisit
     if _exists(
         conn,
         psycopg.sql.SQL(
-            "SELECT EXISTS("
-            "SELECT 1 FROM positions WHERE current_units > 0 "
-            "UNION ALL "
-            "SELECT 1 FROM return_attribution LIMIT 1"
-            ")"
+            "SELECT EXISTS(SELECT 1 FROM positions WHERE current_units > 0) OR EXISTS(SELECT 1 FROM return_attribution)"
         ),
     ):
         return (True, "")

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -88,7 +88,7 @@ logger = logging.getLogger(__name__)
 # next-fire-time from APScheduler; ``compute_next_run`` is retained as
 # a pure utility for catch-up-on-boot and tests.
 
-CadenceKind = Literal["hourly", "daily", "weekly"]
+CadenceKind = Literal["hourly", "daily", "weekly", "monthly"]
 
 
 @dataclass(frozen=True)
@@ -104,6 +104,7 @@ class Cadence:
     minute: int = 0
     hour: int = 0
     weekday: int = 0  # 0=Mon (matches datetime.weekday())
+    day: int = 0  # 1..28 for monthly cadence
 
     @classmethod
     def hourly(cls, *, minute: int = 0) -> Cadence:
@@ -129,6 +130,16 @@ class Cadence:
             raise ValueError(f"weekly minute must be 0..59, got {minute}")
         return cls(kind="weekly", weekday=weekday, hour=hour, minute=minute)
 
+    @classmethod
+    def monthly(cls, *, day: int, hour: int, minute: int = 0) -> Cadence:
+        if not 1 <= day <= 28:
+            raise ValueError(f"monthly day must be 1..28, got {day}")
+        if not 0 <= hour <= 23:
+            raise ValueError(f"monthly hour must be 0..23, got {hour}")
+        if not 0 <= minute <= 59:
+            raise ValueError(f"monthly minute must be 0..59, got {minute}")
+        return cls(kind="monthly", day=day, hour=hour, minute=minute)
+
     @property
     def label(self) -> str:
         """Human-readable label for API responses."""
@@ -136,8 +147,11 @@ class Cadence:
             return f"hourly at :{self.minute:02d} UTC"
         if self.kind == "daily":
             return f"daily at {self.hour:02d}:{self.minute:02d} UTC"
-        weekday_names = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
-        return f"weekly on {weekday_names[self.weekday]} at {self.hour:02d}:{self.minute:02d} UTC"
+        if self.kind == "weekly":
+            weekday_names = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+            return f"weekly on {weekday_names[self.weekday]} at {self.hour:02d}:{self.minute:02d} UTC"
+        # monthly
+        return f"monthly on day {self.day} at {self.hour:02d}:{self.minute:02d} UTC"
 
 
 PrerequisiteResult = tuple[bool, str]
@@ -402,12 +416,22 @@ def compute_next_run(cadence: Cadence, now: datetime) -> datetime:
             candidate += timedelta(days=1)
         return candidate
 
-    # weekly
-    candidate = now_utc.replace(hour=cadence.hour, minute=cadence.minute, second=0, microsecond=0)
-    days_ahead = (cadence.weekday - candidate.weekday()) % 7
-    candidate += timedelta(days=days_ahead)
+    if cadence.kind == "weekly":
+        candidate = now_utc.replace(hour=cadence.hour, minute=cadence.minute, second=0, microsecond=0)
+        days_ahead = (cadence.weekday - candidate.weekday()) % 7
+        candidate += timedelta(days=days_ahead)
+        if candidate <= now_utc:
+            candidate += timedelta(days=7)
+        return candidate
+
+    # monthly
+    candidate = now_utc.replace(day=cadence.day, hour=cadence.hour, minute=cadence.minute, second=0, microsecond=0)
     if candidate <= now_utc:
-        candidate += timedelta(days=7)
+        # Advance to next month
+        if candidate.month == 12:
+            candidate = candidate.replace(year=candidate.year + 1, month=1)
+        else:
+            candidate = candidate.replace(month=candidate.month + 1)
     return candidate
 
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -200,6 +200,8 @@ JOB_FX_RATES_REFRESH = "fx_rates_refresh"
 JOB_RETRY_DEFERRED = "retry_deferred_recommendations"
 JOB_MONITOR_POSITIONS = "monitor_positions"
 JOB_ATTRIBUTION_SUMMARY = "attribution_summary"
+JOB_WEEKLY_REPORT = "weekly_report"
+JOB_MONTHLY_REPORT = "monthly_report"
 
 
 # ---------------------------------------------------------------------------
@@ -288,6 +290,22 @@ def _has_attributions(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM return_attribution)")):
         return (True, "")
     return (False, "no attributed positions yet")
+
+
+def _has_positions_or_attributions(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if there are open positions or any attributed positions."""
+    if _exists(
+        conn,
+        psycopg.sql.SQL(
+            "SELECT EXISTS("
+            "SELECT 1 FROM positions WHERE current_units > 0 "
+            "UNION ALL "
+            "SELECT 1 FROM return_attribution LIMIT 1"
+            ")"
+        ),
+    ):
+        return (True, "")
+    return (False, "no positions or attributions to report on")
 
 
 # Declared schedule. Hours/minutes are deliberate-but-arbitrary placeholders
@@ -380,6 +398,19 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         cadence=Cadence.weekly(weekday=6, hour=6, minute=0),
         prerequisite=_has_attributions,
         catch_up_on_boot=False,
+    ),
+    # -- Reporting: generate periodic reports when there's data to report on --
+    ScheduledJob(
+        name=JOB_WEEKLY_REPORT,
+        description="Generate weekly performance report snapshot.",
+        cadence=Cadence.weekly(weekday=5, hour=7, minute=0),  # Saturday 07:00
+        prerequisite=_has_positions_or_attributions,
+    ),
+    ScheduledJob(
+        name=JOB_MONTHLY_REPORT,
+        description="Generate monthly performance report snapshot.",
+        cadence=Cadence.monthly(day=1, hour=7, minute=0),  # 1st of month 07:00
+        prerequisite=_has_positions_or_attributions,
     ),
     # -- On-demand jobs are NOT listed here.  They stay in _INVOKERS
     # (runtime.py) so "Run now" in the Admin UI works, but they are
@@ -1893,3 +1924,50 @@ def attribution_summary_job() -> None:
                 )
             conn.commit()
             tracker.row_count = total_positions
+
+
+def weekly_report() -> None:
+    """Generate and persist the weekly performance report."""
+    from app.services.reporting import generate_weekly_report, persist_report_snapshot
+
+    with _tracked_job(JOB_WEEKLY_REPORT) as tracker:
+        # Period: previous Monday through Sunday
+        today = datetime.now(tz=UTC).date()
+        # Saturday run → report covers Mon–Sun of the week just ended
+        period_end = today - timedelta(days=(today.weekday() + 1) % 7)  # last Sunday
+        period_start = period_end - timedelta(days=6)  # Monday of that week
+
+        with psycopg.connect(settings.database_url) as conn:
+            report = generate_weekly_report(conn, period_start, period_end)
+            persist_report_snapshot(
+                conn,
+                report_type="weekly",
+                period_start=period_start,
+                period_end=period_end,
+                snapshot=report,
+            )
+            conn.commit()
+        tracker.row_count = 1
+
+
+def monthly_report() -> None:
+    """Generate and persist the monthly performance report."""
+    from app.services.reporting import generate_monthly_report, persist_report_snapshot
+
+    with _tracked_job(JOB_MONTHLY_REPORT) as tracker:
+        # Period: previous full calendar month
+        today = datetime.now(tz=UTC).date()
+        period_end = today.replace(day=1) - timedelta(days=1)  # last day of prev month
+        period_start = period_end.replace(day=1)  # first day of prev month
+
+        with psycopg.connect(settings.database_url) as conn:
+            report = generate_monthly_report(conn, period_start, period_end)
+            persist_report_snapshot(
+                conn,
+                report_type="monthly",
+                period_start=period_start,
+                period_end=period_end,
+                snapshot=report,
+            )
+            conn.commit()
+        tracker.row_count = 1

--- a/docs/superpowers/plans/2026-04-14-fundamentals-enrichment.md
+++ b/docs/superpowers/plans/2026-04-14-fundamentals-enrichment.md
@@ -1,0 +1,1482 @@
+# Fundamentals Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich the fundamentals data layer with valuation multiples, instrument profile data (beta, float, volume), earnings calendar, and analyst estimates — then feed these into the scoring engine to replace neutral-by-absence defaults.
+
+**Architecture:** Three new tables (`instrument_profile`, `earnings_events`, `analyst_estimates`) store data at their natural cadence. A SQL view (`instrument_valuation`) computes derived multiples (P/E, P/B, P/FCF, FCF yield, D/E, market cap) by joining `fundamentals_snapshot` with `quotes` — no stale cached values. The FMP provider gains three new fetch methods; the service layer gains a new `refresh_enrichment` function; the scoring engine's `_value_score` gains a fundamentals-derived fallback path.
+
+**Tech Stack:** PostgreSQL 17, psycopg3, Python 3.14, httpx, pytest
+
+**Issue:** #199
+**Branch:** `feature/199-fundamentals-enrichment`
+
+---
+
+## Settled decisions that apply
+
+| Decision | How this plan preserves it |
+|---|---|
+| FMP is the normalized fundamentals provider in v1 | All new endpoints are FMP. No new provider. |
+| Providers are thin adapters; domain logic in services | FMP provider returns dataclasses; service layer owns DB writes and freshness checks. |
+| Scoring is heuristic, explicit, auditable | All new score formulas are clipped 0-1 with explicit constants. No ML, no hidden weighting. |
+| Penalties are additive in v1 | No new multiplicative penalties. |
+| `as_of_date` = financial statement period end date | `fundamentals_snapshot` is not modified — multiples view joins it with latest quote. |
+| Provider design rule: no DB lookups in providers | FMP methods return dataclasses; service resolves instrument_id. |
+
+## Prevention log entries that apply
+
+| Entry | How avoided |
+|---|---|
+| No-op ORDER BY | All new `fetchone()` queries use meaningful sort columns (e.g. `as_of_date DESC`, `fetched_at DESC`). |
+| Missing data on hard-rule path silently passes | Enrichment data is best-effort for scoring; missing data returns neutral score with logged note, never silently passes a hard rule. |
+| JOIN fan-out inflates aggregates | The valuation view uses `LATERAL ... LIMIT 1` for quotes (one row per instrument). |
+
+---
+
+## File structure
+
+### New files
+| File | Responsibility |
+|---|---|
+| `sql/025_fundamentals_enrichment.sql` | Migration: `instrument_profile`, `earnings_events`, `analyst_estimates` tables + `instrument_valuation` view |
+| `app/providers/enrichment.py` | Provider interface: `EnrichmentProvider` ABC with `get_profile`, `get_earnings_calendar`, `get_analyst_estimates` |
+| `app/services/enrichment.py` | Service: `refresh_enrichment()` — fetch + upsert profile, earnings, estimates |
+| `tests/test_enrichment_provider.py` | Unit tests for FMP enrichment normalisation (pure functions, no I/O) |
+| `tests/test_enrichment_service.py` | Unit tests for service upsert logic (mock DB) |
+| `tests/test_scoring_enriched.py` | Unit tests for enhanced `_value_score` with fundamentals fallback |
+
+### Modified files
+| File | What changes |
+|---|---|
+| `app/providers/implementations/fmp.py` | Add `get_profile_enrichment()`, `get_earnings_calendar()`, `get_analyst_estimates()` methods + normaliser functions |
+| `app/services/scoring.py` | `_value_score` gains fundamentals-derived fallback; `_load_instrument_data` fetches enrichment data |
+| `app/workers/scheduler.py` | Wire `refresh_enrichment` into `daily_research_refresh` |
+| `app/services/thesis.py` | Pass enrichment context (earnings, estimates) to Claude writer |
+
+---
+
+## Phase 1: Schema and provider interface
+
+### Task 1: Migration — new tables and valuation view
+
+**Files:**
+- Create: `sql/025_fundamentals_enrichment.sql`
+
+- [ ] **Step 1: Write the migration SQL**
+
+```sql
+-- 025_fundamentals_enrichment.sql
+-- Adds instrument_profile, earnings_events, analyst_estimates,
+-- and a computed valuation view for scoring.
+
+-- ── instrument_profile ──────────────────────────────────────────
+-- One row per instrument. Refreshed daily from FMP /v3/profile.
+-- Stores data that changes infrequently (beta, float, employees).
+CREATE TABLE IF NOT EXISTS instrument_profile (
+    instrument_id   BIGINT PRIMARY KEY REFERENCES instruments(instrument_id),
+    beta            NUMERIC(10,4),
+    public_float    BIGINT,           -- shares available for public trading
+    avg_volume_30d  BIGINT,           -- 30-day average daily volume
+    market_cap      NUMERIC(20,2),    -- latest market cap from provider
+    employees       INTEGER,
+    ipo_date        DATE,
+    is_actively_trading BOOLEAN,
+    fetched_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ── earnings_events ─────────────────────────────────────────────
+-- One row per earnings report per instrument.
+-- Keyed on (instrument_id, fiscal_date_ending) for idempotent upsert.
+CREATE TABLE IF NOT EXISTS earnings_events (
+    earnings_event_id BIGSERIAL PRIMARY KEY,
+    instrument_id     BIGINT NOT NULL REFERENCES instruments(instrument_id),
+    fiscal_date_ending DATE NOT NULL,
+    reporting_date     DATE,
+    eps_estimate       NUMERIC(12,4),
+    eps_actual         NUMERIC(12,4),
+    revenue_estimate   NUMERIC(20,2),
+    revenue_actual     NUMERIC(20,2),
+    surprise_pct       NUMERIC(10,4),   -- (actual - estimate) / |estimate| * 100
+    fetched_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (instrument_id, fiscal_date_ending)
+);
+
+CREATE INDEX IF NOT EXISTS idx_earnings_events_instrument
+    ON earnings_events(instrument_id, fiscal_date_ending DESC);
+
+-- ── analyst_estimates ───────────────────────────────────────────
+-- One row per instrument per estimate snapshot date.
+-- Refreshed weekly. Keyed on (instrument_id, as_of_date).
+CREATE TABLE IF NOT EXISTS analyst_estimates (
+    estimate_id       BIGSERIAL PRIMARY KEY,
+    instrument_id     BIGINT NOT NULL REFERENCES instruments(instrument_id),
+    as_of_date        DATE NOT NULL,
+    consensus_eps_fq  NUMERIC(12,4),    -- next fiscal quarter
+    consensus_eps_fy  NUMERIC(12,4),    -- next fiscal year
+    consensus_rev_fq  NUMERIC(20,2),
+    consensus_rev_fy  NUMERIC(20,2),
+    analyst_count     INTEGER,
+    buy_count         INTEGER,
+    hold_count        INTEGER,
+    sell_count        INTEGER,
+    price_target_mean NUMERIC(18,6),
+    price_target_high NUMERIC(18,6),
+    price_target_low  NUMERIC(18,6),
+    fetched_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (instrument_id, as_of_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_analyst_estimates_instrument
+    ON analyst_estimates(instrument_id, as_of_date DESC);
+
+-- ── instrument_valuation view ───────────────────────────────────
+-- Computed multiples from fundamentals_snapshot + quotes.
+-- Scoring engine reads this view; no stale cached values.
+CREATE OR REPLACE VIEW instrument_valuation AS
+SELECT
+    fs.instrument_id,
+    fs.as_of_date,
+    -- Market cap: price * shares_outstanding
+    q.last * fs.shares_outstanding        AS market_cap_live,
+    -- P/E ratio: price / EPS (NULL-safe: returns NULL if EPS <= 0 or NULL)
+    CASE WHEN fs.eps > 0
+         THEN q.last / fs.eps
+         ELSE NULL
+    END                                    AS pe_ratio,
+    -- P/B ratio: price / book_value_per_share
+    CASE WHEN fs.book_value > 0
+         THEN q.last / fs.book_value
+         ELSE NULL
+    END                                    AS pb_ratio,
+    -- P/FCF ratio: market_cap / FCF
+    CASE WHEN fs.fcf > 0
+         THEN (q.last * fs.shares_outstanding) / fs.fcf
+         ELSE NULL
+    END                                    AS p_fcf_ratio,
+    -- FCF yield: FCF / market_cap (inverse of P/FCF)
+    CASE WHEN q.last > 0 AND fs.shares_outstanding > 0
+         THEN fs.fcf / (q.last * fs.shares_outstanding)
+         ELSE NULL
+    END                                    AS fcf_yield,
+    -- Debt/Equity ratio: total_debt / (book_value * shares_outstanding)
+    CASE WHEN fs.book_value > 0 AND fs.shares_outstanding > 0
+         THEN fs.debt / (fs.book_value * fs.shares_outstanding)
+         ELSE NULL
+    END                                    AS debt_equity_ratio,
+    q.last                                 AS current_price,
+    q.quoted_at                            AS price_as_of
+FROM fundamentals_snapshot fs
+JOIN quotes q ON q.instrument_id = fs.instrument_id
+-- Pick latest fundamentals snapshot per instrument
+WHERE fs.as_of_date = (
+    SELECT MAX(fs2.as_of_date)
+    FROM fundamentals_snapshot fs2
+    WHERE fs2.instrument_id = fs.instrument_id
+);
+```
+
+- [ ] **Step 2: Verify migration numbering**
+
+Run: `ls sql/*.sql | tail -3`
+Expected: `024_broker_positions.sql` is the last migration. `025` is correct.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sql/025_fundamentals_enrichment.sql
+git commit -m "feat(#199): add enrichment schema — instrument_profile, earnings_events, analyst_estimates, valuation view"
+```
+
+---
+
+### Task 2: Provider interface — EnrichmentProvider ABC
+
+**Files:**
+- Create: `app/providers/enrichment.py`
+
+- [ ] **Step 1: Write the provider interface and dataclasses**
+
+```python
+"""
+Enrichment provider interface.
+
+FMP is the v1 implementation. All domain code imports this interface only —
+never the concrete provider.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class InstrumentProfileData:
+    """Profile data for a single instrument from provider."""
+
+    symbol: str
+    beta: Decimal | None
+    public_float: int | None            # shares available for public trading
+    avg_volume_30d: int | None          # 30-day average daily volume
+    market_cap: Decimal | None
+    employees: int | None
+    ipo_date: date | None
+    is_actively_trading: bool | None
+
+
+@dataclass(frozen=True)
+class EarningsEvent:
+    """Single earnings report from provider."""
+
+    symbol: str
+    fiscal_date_ending: date
+    reporting_date: date | None
+    eps_estimate: Decimal | None
+    eps_actual: Decimal | None
+    revenue_estimate: Decimal | None
+    revenue_actual: Decimal | None
+    surprise_pct: Decimal | None        # (actual - estimate) / |estimate| * 100
+
+
+@dataclass(frozen=True)
+class AnalystEstimates:
+    """Analyst consensus snapshot from provider."""
+
+    symbol: str
+    as_of_date: date
+    consensus_eps_fq: Decimal | None    # next fiscal quarter
+    consensus_eps_fy: Decimal | None    # next fiscal year
+    consensus_rev_fq: Decimal | None
+    consensus_rev_fy: Decimal | None
+    analyst_count: int | None
+    buy_count: int | None
+    hold_count: int | None
+    sell_count: int | None
+    price_target_mean: Decimal | None
+    price_target_high: Decimal | None
+    price_target_low: Decimal | None
+
+
+class EnrichmentProvider(ABC):
+    """
+    Interface for instrument enrichment data: profile, earnings, estimates.
+
+    v1 implementation: FmpFundamentalsProvider (extended).
+    """
+
+    @abstractmethod
+    def get_profile(self, symbol: str) -> InstrumentProfileData | None:
+        """Return profile data for a symbol. None if not found."""
+
+    @abstractmethod
+    def get_earnings_calendar(
+        self, symbol: str, limit: int = 8,
+    ) -> list[EarningsEvent]:
+        """Return recent earnings events oldest-first, up to limit quarters."""
+
+    @abstractmethod
+    def get_analyst_estimates(self, symbol: str) -> AnalystEstimates | None:
+        """Return latest analyst consensus snapshot. None if not found."""
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/providers/enrichment.py
+git commit -m "feat(#199): add EnrichmentProvider interface and dataclasses"
+```
+
+---
+
+### Task 3: FMP provider — implement enrichment methods
+
+**Files:**
+- Modify: `app/providers/implementations/fmp.py`
+- Test: `tests/test_enrichment_provider.py`
+
+- [ ] **Step 1: Write failing tests for FMP profile normalisation**
+
+Create `tests/test_enrichment_provider.py` with fixtures from FMP `/v3/profile` response shape:
+
+```python
+"""Unit tests for FMP enrichment normalisation — pure functions, no I/O."""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.providers.implementations.fmp import (
+    _build_profile_data,
+    _build_earnings_event,
+    _build_analyst_estimates,
+)
+
+# ── Profile fixtures ──────────────────────────────────────────
+
+FIXTURE_FMP_PROFILE = {
+    "symbol": "AAPL",
+    "beta": 1.24,
+    "volAvg": 58432100,
+    "mktCap": 2850000000000,
+    "fullTimeEmployees": "161000",
+    "ipoDate": "1980-12-12",
+    "isActivelyTrading": True,
+    "floatShares": 15400000000,
+}
+
+FIXTURE_FMP_PROFILE_MINIMAL = {
+    "symbol": "UNKNOWN",
+}
+
+
+def test_build_profile_data_full():
+    result = _build_profile_data("AAPL", FIXTURE_FMP_PROFILE)
+    assert result.symbol == "AAPL"
+    assert result.beta == Decimal("1.24")
+    assert result.public_float == 15400000000
+    assert result.avg_volume_30d == 58432100
+    assert result.market_cap == Decimal("2850000000000")
+    assert result.employees == 161000
+    assert result.ipo_date == date(1980, 12, 12)
+    assert result.is_actively_trading is True
+
+
+def test_build_profile_data_missing_fields():
+    result = _build_profile_data("UNKNOWN", FIXTURE_FMP_PROFILE_MINIMAL)
+    assert result.symbol == "UNKNOWN"
+    assert result.beta is None
+    assert result.public_float is None
+    assert result.avg_volume_30d is None
+    assert result.employees is None
+    assert result.ipo_date is None
+
+
+# ── Earnings fixtures ─────────────────────────────────────────
+
+FIXTURE_FMP_EARNINGS = {
+    "date": "2024-06-30",
+    "symbol": "AAPL",
+    "reportedDate": "2024-08-01",
+    "epsEstimated": 1.34,
+    "eps": 1.40,
+    "revenueEstimated": 84530000000,
+    "revenue": 85780000000,
+}
+
+
+def test_build_earnings_event_full():
+    result = _build_earnings_event("AAPL", FIXTURE_FMP_EARNINGS)
+    assert result.fiscal_date_ending == date(2024, 6, 30)
+    assert result.reporting_date == date(2024, 8, 1)
+    assert result.eps_estimate == Decimal("1.34")
+    assert result.eps_actual == Decimal("1.40")
+    assert result.revenue_estimate == Decimal("84530000000")
+    assert result.revenue_actual == Decimal("85780000000")
+    assert result.surprise_pct == pytest.approx(Decimal("4.4776"), rel=1e-2)
+
+
+def test_build_earnings_event_missing_eps():
+    row = {"date": "2024-03-31", "symbol": "AAPL"}
+    result = _build_earnings_event("AAPL", row)
+    assert result.fiscal_date_ending == date(2024, 3, 31)
+    assert result.eps_actual is None
+    assert result.surprise_pct is None
+
+
+# ── Analyst estimates fixtures ────────────────────────────────
+
+FIXTURE_FMP_ESTIMATES = {
+    "symbol": "AAPL",
+    "date": "2024-06-30",
+    "estimatedEpsAvg": 1.45,
+    "estimatedRevenueAvg": 90000000000,
+    "numberAnalystEstimatedEps": 32,
+}
+
+FIXTURE_FMP_CONSENSUS = {
+    "symbol": "AAPL",
+    "buy": 25,
+    "hold": 5,
+    "sell": 2,
+    "consensus": "Buy",
+}
+
+FIXTURE_FMP_PRICE_TARGET = {
+    "symbol": "AAPL",
+    "targetMean": 210.50,
+    "targetHigh": 250.00,
+    "targetLow": 180.00,
+    "numberOfAnalysts": 32,
+}
+
+
+def test_build_analyst_estimates_full():
+    result = _build_analyst_estimates(
+        "AAPL",
+        estimates=[FIXTURE_FMP_ESTIMATES],
+        consensus=FIXTURE_FMP_CONSENSUS,
+        price_target=FIXTURE_FMP_PRICE_TARGET,
+    )
+    assert result is not None
+    assert result.consensus_eps_fq == Decimal("1.45")
+    assert result.analyst_count == 32
+    assert result.buy_count == 25
+    assert result.hold_count == 5
+    assert result.sell_count == 2
+    assert result.price_target_mean == Decimal("210.50")
+
+
+def test_build_analyst_estimates_no_data():
+    result = _build_analyst_estimates("AAPL", estimates=[], consensus=None, price_target=None)
+    assert result is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_enrichment_provider.py -v`
+Expected: ImportError — `_build_profile_data` etc. do not exist yet.
+
+- [ ] **Step 3: Implement normaliser functions in fmp.py**
+
+Add to `app/providers/implementations/fmp.py` after the existing normaliser section:
+
+```python
+from app.providers.enrichment import (
+    AnalystEstimates,
+    EarningsEvent,
+    EnrichmentProvider,
+    InstrumentProfileData,
+)
+
+
+def _build_profile_data(
+    symbol: str, item: Mapping[str, object],
+) -> InstrumentProfileData:
+    """Normalise FMP /v3/profile response into InstrumentProfileData."""
+    raw_ipo = item.get("ipoDate")
+    ipo_date: date | None = None
+    if raw_ipo:
+        try:
+            ipo_date = date.fromisoformat(str(raw_ipo)[:10])
+        except ValueError:
+            pass
+
+    return InstrumentProfileData(
+        symbol=symbol,
+        beta=_decimal_or_none(item.get("beta")),
+        public_float=_int_or_none(item.get("floatShares")),
+        avg_volume_30d=_int_or_none(item.get("volAvg")),
+        market_cap=_decimal_or_none(item.get("mktCap")),
+        employees=_int_or_none(item.get("fullTimeEmployees")),
+        ipo_date=ipo_date,
+        is_actively_trading=item.get("isActivelyTrading") if isinstance(item.get("isActivelyTrading"), bool) else None,
+    )
+
+
+def _build_earnings_event(
+    symbol: str, row: Mapping[str, object],
+) -> EarningsEvent:
+    """Normalise one FMP earnings calendar row."""
+    raw_fiscal = row.get("date")
+    fiscal_date = date.fromisoformat(str(raw_fiscal)[:10]) if raw_fiscal else date.min
+
+    raw_report = row.get("reportedDate")
+    report_date: date | None = None
+    if raw_report:
+        try:
+            report_date = date.fromisoformat(str(raw_report)[:10])
+        except ValueError:
+            pass
+
+    eps_est = _decimal_or_none(row.get("epsEstimated"))
+    eps_act = _decimal_or_none(row.get("eps"))
+    rev_est = _decimal_or_none(row.get("revenueEstimated"))
+    rev_act = _decimal_or_none(row.get("revenue"))
+
+    surprise: Decimal | None = None
+    if eps_est is not None and eps_act is not None and eps_est != 0:
+        surprise = (eps_act - eps_est) / abs(eps_est) * 100
+
+    return EarningsEvent(
+        symbol=symbol,
+        fiscal_date_ending=fiscal_date,
+        reporting_date=report_date,
+        eps_estimate=eps_est,
+        eps_actual=eps_act,
+        revenue_estimate=rev_est,
+        revenue_actual=rev_act,
+        surprise_pct=surprise,
+    )
+
+
+def _build_analyst_estimates(
+    symbol: str,
+    estimates: list[dict[str, object]],
+    consensus: dict[str, object] | None,
+    price_target: dict[str, object] | None,
+) -> AnalystEstimates | None:
+    """Combine FMP analyst-estimation, consensus, and price-target data."""
+    if not estimates and consensus is None and price_target is None:
+        return None
+
+    est = estimates[0] if estimates else {}
+    raw_date = est.get("date")
+    as_of = date.fromisoformat(str(raw_date)[:10]) if raw_date else date.today()
+
+    return AnalystEstimates(
+        symbol=symbol,
+        as_of_date=as_of,
+        consensus_eps_fq=_decimal_or_none(est.get("estimatedEpsAvg")),
+        consensus_eps_fy=None,  # FMP annual endpoint is separate; defer to v2
+        consensus_rev_fq=_decimal_or_none(est.get("estimatedRevenueAvg")),
+        consensus_rev_fy=None,
+        analyst_count=_int_or_none(
+            (price_target or {}).get("numberOfAnalysts") or est.get("numberAnalystEstimatedEps")
+        ),
+        buy_count=_int_or_none((consensus or {}).get("buy")),
+        hold_count=_int_or_none((consensus or {}).get("hold")),
+        sell_count=_int_or_none((consensus or {}).get("sell")),
+        price_target_mean=_decimal_or_none((price_target or {}).get("targetMean")),
+        price_target_high=_decimal_or_none((price_target or {}).get("targetHigh")),
+        price_target_low=_decimal_or_none((price_target or {}).get("targetLow")),
+    )
+```
+
+- [ ] **Step 4: Add HTTP fetch methods and implement EnrichmentProvider on FmpFundamentalsProvider**
+
+Add to the `FmpFundamentalsProvider` class:
+
+```python
+    # ── Enrichment methods (EnrichmentProvider) ──────────────
+
+    def get_profile_enrichment(self, symbol: str) -> InstrumentProfileData | None:
+        """Fetch enrichment profile data from FMP /v3/profile."""
+        resp = self._http.get(
+            f"/v3/profile/{symbol}",
+            params={"apikey": self._api_key},
+        )
+        if resp.status_code != 200:
+            logger.warning("FMP profile enrichment failed for %s: %s", symbol, resp.status_code)
+            return None
+        data = resp.json()
+        _persist_raw(f"fmp_profile_{symbol}", data)
+        if not isinstance(data, list) or not data:
+            return None
+        return _build_profile_data(symbol, data[0])
+
+    def get_earnings_calendar(self, symbol: str, limit: int = 8) -> list[EarningsEvent]:
+        """Fetch earnings history from FMP /v3/historical/earning_calendar/{symbol}."""
+        resp = self._http.get(
+            f"/v3/historical/earning_calendar/{symbol}",
+            params={"limit": limit, "apikey": self._api_key},
+        )
+        if resp.status_code != 200:
+            logger.warning("FMP earnings calendar failed for %s: %s", symbol, resp.status_code)
+            return []
+        data = resp.json()
+        _persist_raw(f"fmp_earnings_{symbol}", data)
+        if not isinstance(data, list):
+            return []
+        events = [_build_earnings_event(symbol, row) for row in data if isinstance(row, dict)]
+        events.sort(key=lambda e: e.fiscal_date_ending)  # oldest-first
+        return events
+
+    def get_analyst_estimates(self, symbol: str) -> AnalystEstimates | None:
+        """Combine FMP analyst-estimation, consensus, and price-target endpoints."""
+        # Analyst estimates (quarterly forward)
+        est_resp = self._http.get(
+            f"/v3/analyst-estimates/{symbol}",
+            params={"period": "quarter", "limit": 1, "apikey": self._api_key},
+        )
+        estimates: list[dict[str, object]] = []
+        if est_resp.status_code == 200:
+            raw = est_resp.json()
+            _persist_raw(f"fmp_estimates_{symbol}", raw)
+            if isinstance(raw, list):
+                estimates = [r for r in raw if isinstance(r, dict)]
+
+        # Analyst consensus (buy/hold/sell)
+        con_resp = self._http.get(
+            f"/v4/analyst-stock-recommendations/{symbol}",
+            params={"apikey": self._api_key},
+        )
+        consensus: dict[str, object] | None = None
+        if con_resp.status_code == 200:
+            raw = con_resp.json()
+            _persist_raw(f"fmp_consensus_{symbol}", raw)
+            if isinstance(raw, list) and raw:
+                consensus = raw[0] if isinstance(raw[0], dict) else None
+
+        # Price targets (mean/high/low)
+        pt_resp = self._http.get(
+            f"/v4/price-target-consensus/{symbol}",
+            params={"apikey": self._api_key},
+        )
+        price_target: dict[str, object] | None = None
+        if pt_resp.status_code == 200:
+            raw = pt_resp.json()
+            _persist_raw(f"fmp_price_target_{symbol}", raw)
+            if isinstance(raw, list) and raw:
+                price_target = raw[0] if isinstance(raw[0], dict) else None
+
+        return _build_analyst_estimates(symbol, estimates, consensus, price_target)
+```
+
+Make `FmpFundamentalsProvider` also implement `EnrichmentProvider`:
+
+```python
+class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_enrichment_provider.py -v`
+Expected: All tests pass.
+
+- [ ] **Step 6: Run full check suite**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/providers/implementations/fmp.py app/providers/enrichment.py tests/test_enrichment_provider.py
+git commit -m "feat(#199): FMP enrichment provider — profile, earnings, analyst estimates"
+```
+
+---
+
+## Phase 2: Service layer
+
+### Task 4: Enrichment service — fetch and upsert
+
+**Files:**
+- Create: `app/services/enrichment.py`
+- Test: `tests/test_enrichment_service.py`
+
+- [ ] **Step 1: Write failing tests for upsert functions**
+
+Create `tests/test_enrichment_service.py`:
+
+```python
+"""Unit tests for enrichment service — mock DB, no network."""
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from app.providers.enrichment import (
+    AnalystEstimates,
+    EarningsEvent,
+    InstrumentProfileData,
+)
+from app.services.enrichment import (
+    EnrichmentRefreshSummary,
+    _upsert_analyst_estimates,
+    _upsert_earnings_events,
+    _upsert_profile,
+    refresh_enrichment,
+)
+
+_NOW = datetime(2026, 4, 14, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_profile(symbol: str = "AAPL") -> InstrumentProfileData:
+    return InstrumentProfileData(
+        symbol=symbol,
+        beta=Decimal("1.24"),
+        public_float=15400000000,
+        avg_volume_30d=58000000,
+        market_cap=Decimal("2850000000000"),
+        employees=161000,
+        ipo_date=date(1980, 12, 12),
+        is_actively_trading=True,
+    )
+
+
+def _make_earnings(symbol: str = "AAPL") -> list[EarningsEvent]:
+    return [
+        EarningsEvent(
+            symbol=symbol,
+            fiscal_date_ending=date(2024, 3, 31),
+            reporting_date=date(2024, 5, 2),
+            eps_estimate=Decimal("1.50"),
+            eps_actual=Decimal("1.53"),
+            revenue_estimate=Decimal("90000000000"),
+            revenue_actual=Decimal("90800000000"),
+            surprise_pct=Decimal("2.0"),
+        ),
+    ]
+
+
+def _make_estimates(symbol: str = "AAPL") -> AnalystEstimates:
+    return AnalystEstimates(
+        symbol=symbol,
+        as_of_date=date(2024, 6, 30),
+        consensus_eps_fq=Decimal("1.45"),
+        consensus_eps_fy=None,
+        consensus_rev_fq=Decimal("90000000000"),
+        consensus_rev_fy=None,
+        analyst_count=32,
+        buy_count=25,
+        hold_count=5,
+        sell_count=2,
+        price_target_mean=Decimal("210.50"),
+        price_target_high=Decimal("250.00"),
+        price_target_low=Decimal("180.00"),
+    )
+
+
+def test_upsert_profile_executes_insert():
+    conn = MagicMock()
+    _upsert_profile(conn, 42, _make_profile(), _NOW)
+    conn.execute.assert_called_once()
+    sql = conn.execute.call_args[0][0]
+    assert "INSERT INTO instrument_profile" in sql
+    assert "ON CONFLICT (instrument_id)" in sql
+
+
+def test_upsert_earnings_executes_insert_per_event():
+    conn = MagicMock()
+    events = _make_earnings()
+    _upsert_earnings_events(conn, 42, events)
+    assert conn.execute.call_count == len(events)
+    sql = conn.execute.call_args[0][0]
+    assert "INSERT INTO earnings_events" in sql
+
+
+def test_upsert_analyst_estimates_executes_insert():
+    conn = MagicMock()
+    _upsert_analyst_estimates(conn, 42, _make_estimates())
+    conn.execute.assert_called_once()
+    sql = conn.execute.call_args[0][0]
+    assert "INSERT INTO analyst_estimates" in sql
+    assert "ON CONFLICT (instrument_id, as_of_date)" in sql
+
+
+def test_refresh_enrichment_counts_correctly():
+    mock_provider = MagicMock()
+    mock_provider.get_profile_enrichment.return_value = _make_profile()
+    mock_provider.get_earnings_calendar.return_value = _make_earnings()
+    mock_provider.get_analyst_estimates.return_value = _make_estimates()
+    mock_conn = MagicMock()
+
+    symbols = [("AAPL", "42"), ("MSFT", "43")]
+    summary = refresh_enrichment(mock_provider, mock_conn, symbols)
+    assert summary.symbols_attempted == 2
+    assert summary.profiles_upserted == 2
+    assert summary.symbols_skipped == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_enrichment_service.py -v`
+Expected: ImportError.
+
+- [ ] **Step 3: Implement the enrichment service**
+
+Create `app/services/enrichment.py`:
+
+```python
+"""
+Enrichment service.
+
+Fetches and upserts instrument profile, earnings calendar, and analyst
+estimates from an EnrichmentProvider (FMP in v1).
+
+The service layer owns identifier resolution and DB writes.
+The provider is a pure HTTP client.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import psycopg
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from app.providers.enrichment import (
+        AnalystEstimates,
+        EarningsEvent,
+        EnrichmentProvider,
+        InstrumentProfileData,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EnrichmentRefreshSummary:
+    symbols_attempted: int
+    profiles_upserted: int
+    earnings_upserted: int
+    estimates_upserted: int
+    symbols_skipped: int
+
+
+def refresh_enrichment(
+    provider: EnrichmentProvider,
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    symbols: Sequence[tuple[str, str]],  # [(symbol, instrument_id), ...]
+) -> EnrichmentRefreshSummary:
+    """
+    For each symbol, fetch profile, earnings, and analyst estimates
+    and upsert them. Each symbol is independent — a failure on one
+    does not abort the batch.
+    """
+    profiles = 0
+    earnings = 0
+    estimates = 0
+    skipped = 0
+    now = datetime.now(UTC)
+
+    for symbol, instrument_id in symbols:
+        iid = int(instrument_id)
+        try:
+            # Profile
+            profile = provider.get_profile_enrichment(symbol)
+            if profile is not None:
+                _upsert_profile(conn, iid, profile, now)
+                profiles += 1
+
+            # Earnings
+            events = provider.get_earnings_calendar(symbol)
+            if events:
+                _upsert_earnings_events(conn, iid, events)
+                earnings += len(events)
+
+            # Analyst estimates
+            est = provider.get_analyst_estimates(symbol)
+            if est is not None:
+                _upsert_analyst_estimates(conn, iid, est)
+                estimates += 1
+
+        except Exception:
+            logger.warning("Enrichment: failed for %s, skipping", symbol, exc_info=True)
+            skipped += 1
+
+    return EnrichmentRefreshSummary(
+        symbols_attempted=len(symbols),
+        profiles_upserted=profiles,
+        earnings_upserted=earnings,
+        estimates_upserted=estimates,
+        symbols_skipped=skipped,
+    )
+
+
+def _upsert_profile(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    instrument_id: int,
+    profile: InstrumentProfileData,
+    now: datetime,
+) -> None:
+    """Upsert instrument_profile. Keyed on instrument_id (one row per instrument)."""
+    conn.execute(
+        """
+        INSERT INTO instrument_profile (
+            instrument_id, beta, public_float, avg_volume_30d,
+            market_cap, employees, ipo_date, is_actively_trading, fetched_at
+        )
+        VALUES (
+            %(instrument_id)s, %(beta)s, %(public_float)s, %(avg_volume_30d)s,
+            %(market_cap)s, %(employees)s, %(ipo_date)s, %(is_actively_trading)s,
+            %(fetched_at)s
+        )
+        ON CONFLICT (instrument_id) DO UPDATE SET
+            beta               = EXCLUDED.beta,
+            public_float       = EXCLUDED.public_float,
+            avg_volume_30d     = EXCLUDED.avg_volume_30d,
+            market_cap         = EXCLUDED.market_cap,
+            employees          = EXCLUDED.employees,
+            ipo_date           = EXCLUDED.ipo_date,
+            is_actively_trading = EXCLUDED.is_actively_trading,
+            fetched_at         = EXCLUDED.fetched_at
+        WHERE (
+            instrument_profile.beta               IS DISTINCT FROM EXCLUDED.beta               OR
+            instrument_profile.public_float       IS DISTINCT FROM EXCLUDED.public_float       OR
+            instrument_profile.avg_volume_30d     IS DISTINCT FROM EXCLUDED.avg_volume_30d     OR
+            instrument_profile.market_cap         IS DISTINCT FROM EXCLUDED.market_cap         OR
+            instrument_profile.employees          IS DISTINCT FROM EXCLUDED.employees          OR
+            instrument_profile.ipo_date           IS DISTINCT FROM EXCLUDED.ipo_date           OR
+            instrument_profile.is_actively_trading IS DISTINCT FROM EXCLUDED.is_actively_trading
+        )
+        """,
+        {
+            "instrument_id": instrument_id,
+            "beta": profile.beta,
+            "public_float": profile.public_float,
+            "avg_volume_30d": profile.avg_volume_30d,
+            "market_cap": profile.market_cap,
+            "employees": profile.employees,
+            "ipo_date": profile.ipo_date,
+            "is_actively_trading": profile.is_actively_trading,
+            "fetched_at": now,
+        },
+    )
+
+
+def _upsert_earnings_events(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    instrument_id: int,
+    events: Sequence[EarningsEvent],
+) -> None:
+    """Upsert earnings events. Keyed on (instrument_id, fiscal_date_ending)."""
+    for ev in events:
+        conn.execute(
+            """
+            INSERT INTO earnings_events (
+                instrument_id, fiscal_date_ending, reporting_date,
+                eps_estimate, eps_actual, revenue_estimate, revenue_actual,
+                surprise_pct
+            )
+            VALUES (
+                %(instrument_id)s, %(fiscal_date_ending)s, %(reporting_date)s,
+                %(eps_estimate)s, %(eps_actual)s, %(revenue_estimate)s,
+                %(revenue_actual)s, %(surprise_pct)s
+            )
+            ON CONFLICT (instrument_id, fiscal_date_ending) DO UPDATE SET
+                reporting_date   = EXCLUDED.reporting_date,
+                eps_estimate     = EXCLUDED.eps_estimate,
+                eps_actual       = EXCLUDED.eps_actual,
+                revenue_estimate = EXCLUDED.revenue_estimate,
+                revenue_actual   = EXCLUDED.revenue_actual,
+                surprise_pct     = EXCLUDED.surprise_pct,
+                fetched_at       = NOW()
+            WHERE (
+                earnings_events.eps_actual       IS DISTINCT FROM EXCLUDED.eps_actual       OR
+                earnings_events.revenue_actual   IS DISTINCT FROM EXCLUDED.revenue_actual   OR
+                earnings_events.surprise_pct     IS DISTINCT FROM EXCLUDED.surprise_pct
+            )
+            """,
+            {
+                "instrument_id": instrument_id,
+                "fiscal_date_ending": ev.fiscal_date_ending,
+                "reporting_date": ev.reporting_date,
+                "eps_estimate": ev.eps_estimate,
+                "eps_actual": ev.eps_actual,
+                "revenue_estimate": ev.revenue_estimate,
+                "revenue_actual": ev.revenue_actual,
+                "surprise_pct": ev.surprise_pct,
+            },
+        )
+
+
+def _upsert_analyst_estimates(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    instrument_id: int,
+    est: AnalystEstimates,
+) -> None:
+    """Upsert analyst estimates. Keyed on (instrument_id, as_of_date)."""
+    conn.execute(
+        """
+        INSERT INTO analyst_estimates (
+            instrument_id, as_of_date,
+            consensus_eps_fq, consensus_eps_fy,
+            consensus_rev_fq, consensus_rev_fy,
+            analyst_count, buy_count, hold_count, sell_count,
+            price_target_mean, price_target_high, price_target_low
+        )
+        VALUES (
+            %(instrument_id)s, %(as_of_date)s,
+            %(consensus_eps_fq)s, %(consensus_eps_fy)s,
+            %(consensus_rev_fq)s, %(consensus_rev_fy)s,
+            %(analyst_count)s, %(buy_count)s, %(hold_count)s, %(sell_count)s,
+            %(price_target_mean)s, %(price_target_high)s, %(price_target_low)s
+        )
+        ON CONFLICT (instrument_id, as_of_date) DO UPDATE SET
+            consensus_eps_fq  = EXCLUDED.consensus_eps_fq,
+            consensus_eps_fy  = EXCLUDED.consensus_eps_fy,
+            consensus_rev_fq  = EXCLUDED.consensus_rev_fq,
+            consensus_rev_fy  = EXCLUDED.consensus_rev_fy,
+            analyst_count     = EXCLUDED.analyst_count,
+            buy_count         = EXCLUDED.buy_count,
+            hold_count        = EXCLUDED.hold_count,
+            sell_count        = EXCLUDED.sell_count,
+            price_target_mean = EXCLUDED.price_target_mean,
+            price_target_high = EXCLUDED.price_target_high,
+            price_target_low  = EXCLUDED.price_target_low,
+            fetched_at        = NOW()
+        """,
+        {
+            "instrument_id": instrument_id,
+            "as_of_date": est.as_of_date,
+            "consensus_eps_fq": est.consensus_eps_fq,
+            "consensus_eps_fy": est.consensus_eps_fy,
+            "consensus_rev_fq": est.consensus_rev_fq,
+            "consensus_rev_fy": est.consensus_rev_fy,
+            "analyst_count": est.analyst_count,
+            "buy_count": est.buy_count,
+            "hold_count": est.hold_count,
+            "sell_count": est.sell_count,
+            "price_target_mean": est.price_target_mean,
+            "price_target_high": est.price_target_high,
+            "price_target_low": est.price_target_low,
+        },
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_enrichment_service.py -v`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/enrichment.py tests/test_enrichment_service.py
+git commit -m "feat(#199): enrichment service — profile, earnings, analyst estimates upsert"
+```
+
+---
+
+## Phase 3: Scoring engine enhancement
+
+### Task 5: Enhanced value_score with fundamentals fallback
+
+**Files:**
+- Test: `tests/test_scoring_enriched.py`
+- Modify: `app/services/scoring.py`
+
+- [ ] **Step 1: Write failing tests for enhanced _value_score**
+
+Create `tests/test_scoring_enriched.py`:
+
+```python
+"""Tests for scoring engine enrichment — fundamentals-derived value signals."""
+from __future__ import annotations
+
+import pytest
+
+from app.services.scoring import _value_score
+
+
+def _approx(v: float, rel: float = 1e-4) -> object:
+    return pytest.approx(v, rel=rel)
+
+
+# ── Thesis-based scoring still works (existing behaviour) ────
+
+def test_value_score_thesis_based_unchanged():
+    """When thesis valuation bands exist, they dominate."""
+    score, notes = _value_score(
+        base_value=150.0, bear_value=80.0, current_price=100.0,
+        pe_ratio=None, fcf_yield=None, price_target_mean=None,
+    )
+    # 50% upside => upside_score=1.0; downside=(100-80)/100=0.20 => penalty=0.40
+    # 0.75 * 1.0 + 0.25 * (1 - 0.40) = 0.75 + 0.15 = 0.90
+    assert score == _approx(0.90)
+    assert not any("fundamentals fallback" in n for n in notes)
+
+
+# ── Fundamentals fallback when thesis is missing ─────────────
+
+def test_value_score_fundamentals_fallback_cheap_stock():
+    """P/E = 10, FCF yield = 8%, price target 20% above => attractive."""
+    score, notes = _value_score(
+        base_value=None, bear_value=None, current_price=100.0,
+        pe_ratio=10.0, fcf_yield=0.08, price_target_mean=120.0,
+    )
+    assert score > 0.6
+    assert any("fundamentals fallback" in n for n in notes)
+
+
+def test_value_score_fundamentals_fallback_expensive_stock():
+    """P/E = 60, FCF yield = 0.5%, price target below current => expensive."""
+    score, notes = _value_score(
+        base_value=None, bear_value=None, current_price=100.0,
+        pe_ratio=60.0, fcf_yield=0.005, price_target_mean=85.0,
+    )
+    assert score < 0.4
+    assert any("fundamentals fallback" in n for n in notes)
+
+
+def test_value_score_no_thesis_no_fundamentals():
+    """No thesis and no enrichment data => neutral 0.5."""
+    score, notes = _value_score(
+        base_value=None, bear_value=None, current_price=100.0,
+        pe_ratio=None, fcf_yield=None, price_target_mean=None,
+    )
+    assert score == _approx(0.5)
+
+
+def test_value_score_partial_fundamentals():
+    """Only P/E available, no FCF yield or price target."""
+    score, notes = _value_score(
+        base_value=None, bear_value=None, current_price=100.0,
+        pe_ratio=15.0, fcf_yield=None, price_target_mean=None,
+    )
+    assert 0.3 < score < 0.8  # reasonable range for moderate P/E
+    assert any("fundamentals fallback" in n for n in notes)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_scoring_enriched.py -v`
+Expected: TypeError — `_value_score` does not accept enrichment params yet.
+
+- [ ] **Step 3: Modify `_value_score` to accept enrichment parameters**
+
+In `app/services/scoring.py`, update `_value_score` signature and add fundamentals fallback path:
+
+```python
+def _value_score(
+    base_value: float | None,
+    bear_value: float | None,
+    current_price: float | None,
+    *,
+    pe_ratio: float | None = None,
+    fcf_yield: float | None = None,
+    price_target_mean: float | None = None,
+) -> tuple[float, list[str]]:
+    """
+    Thesis valuation upside as the primary value proxy.
+    Falls back to fundamentals-derived signals when thesis is absent.
+    """
+    notes: list[str] = []
+
+    # ── Primary path: thesis-based valuation ──────────────────
+    if base_value is not None and current_price is not None and current_price > 0:
+        if bear_value is None:
+            notes.append("bear_value missing")
+
+        upside_to_base = (base_value - current_price) / current_price
+        upside_score = _clip(upside_to_base / 0.50)
+
+        if bear_value is not None:
+            downside_to_bear = (current_price - bear_value) / current_price
+            downside_penalty = _clip(downside_to_bear / 0.50)
+        else:
+            downside_penalty = 0.5
+            notes.append("bear_value missing; assuming 0.5 downside penalty")
+
+        score = 0.75 * upside_score + 0.25 * (1.0 - downside_penalty)
+        return _clip(score), notes
+
+    # ── Fallback path: fundamentals-derived signals ───────────
+    # Used when thesis is missing. Blends P/E attractiveness,
+    # FCF yield, and analyst price target upside.
+    components: list[tuple[float, float]] = []  # (score, weight)
+
+    if current_price is None or current_price <= 0:
+        notes.append("current_price missing or zero")
+        return 0.5, notes
+
+    if pe_ratio is not None and pe_ratio > 0:
+        # P/E score: lower is better. P/E=10 => 1.0, P/E=30 => 0.33, P/E=50+ => ~0
+        pe_score = _clip(1.0 - (pe_ratio - 10.0) / 40.0)
+        components.append((pe_score, 0.35))
+    else:
+        notes.append("pe_ratio missing or non-positive")
+
+    if fcf_yield is not None:
+        # FCF yield score: higher is better. 8% => 1.0, 0% => 0.0
+        fy_score = _clip(fcf_yield / 0.08)
+        components.append((fy_score, 0.35))
+    else:
+        notes.append("fcf_yield missing")
+
+    if price_target_mean is not None and price_target_mean > 0:
+        # Price target upside: (target - price) / price, scaled like thesis upside
+        pt_upside = (price_target_mean - current_price) / current_price
+        pt_score = _clip(pt_upside / 0.50)
+        components.append((pt_score, 0.30))
+    else:
+        notes.append("price_target_mean missing")
+
+    if not components:
+        return 0.5, notes  # neutral-by-absence
+
+    notes.append("fundamentals fallback (no thesis)")
+    total_weight = sum(w for _, w in components)
+    score = sum(s * w / total_weight for s, w in components)
+    return _clip(score), notes
+```
+
+- [ ] **Step 4: Update `_load_instrument_data` to fetch enrichment data**
+
+Add to the existing cursor block in `_load_instrument_data`:
+
+```python
+        # Valuation multiples from view (enrichment)
+        cur.execute(
+            """
+            SELECT pe_ratio, pb_ratio, p_fcf_ratio, fcf_yield,
+                   debt_equity_ratio, market_cap_live, current_price
+            FROM instrument_valuation
+            WHERE instrument_id = %(id)s
+            """,
+            {"id": instrument_id},
+        )
+        valuation_row: dict[str, Any] | None = cur.fetchone()
+
+        # Analyst estimates (latest)
+        cur.execute(
+            """
+            SELECT price_target_mean, price_target_high, price_target_low,
+                   analyst_count, buy_count, hold_count, sell_count
+            FROM analyst_estimates
+            WHERE instrument_id = %(id)s
+            ORDER BY as_of_date DESC
+            LIMIT 1
+            """,
+            {"id": instrument_id},
+        )
+        estimates_row: dict[str, Any] | None = cur.fetchone()
+```
+
+Add to the return dict:
+
+```python
+        "valuation_row": valuation_row,
+        "estimates_row": estimates_row,
+```
+
+- [ ] **Step 5: Update `compute_score` to pass enrichment data to `_value_score`**
+
+In the `compute_score` function, where `_value_score` is called, update to pass enrichment params:
+
+```python
+    val_row = data.get("valuation_row")
+    est_row = data.get("estimates_row")
+
+    value, value_notes = _value_score(
+        base_value=_to_float(thesis_row["base_value"]) if thesis_row else None,
+        bear_value=_to_float(thesis_row["bear_value"]) if thesis_row else None,
+        current_price=current_price,
+        pe_ratio=_to_float(val_row["pe_ratio"]) if val_row else None,
+        fcf_yield=_to_float(val_row["fcf_yield"]) if val_row else None,
+        price_target_mean=_to_float(est_row["price_target_mean"]) if est_row else None,
+    )
+```
+
+- [ ] **Step 6: Run all scoring tests**
+
+```bash
+uv run pytest tests/test_scoring.py tests/test_scoring_enriched.py -v
+```
+
+Expected: All pass. Existing tests should not break because the new params have defaults.
+
+- [ ] **Step 7: Run full check suite**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/services/scoring.py tests/test_scoring_enriched.py
+git commit -m "feat(#199): enhance value_score with fundamentals-derived fallback"
+```
+
+---
+
+## Phase 4: Scheduler integration
+
+### Task 6: Wire enrichment into daily_research_refresh
+
+**Files:**
+- Modify: `app/workers/scheduler.py`
+
+- [ ] **Step 1: Add enrichment call after FMP fundamentals refresh**
+
+In `daily_research_refresh()`, after the FMP fundamentals block (~line 722), add:
+
+```python
+        # Enrichment — profile, earnings, analyst estimates (FMP only)
+        if settings.fmp_api_key:
+            try:
+                with (
+                    FmpFundamentalsProvider(api_key=settings.fmp_api_key) as fmp,
+                    psycopg.connect(settings.database_url) as conn,
+                ):
+                    from app.services.enrichment import refresh_enrichment
+
+                    enrich_summary = refresh_enrichment(fmp, conn, symbols)
+                    conn.commit()
+                total_rows += enrich_summary.profiles_upserted + enrich_summary.earnings_upserted
+                logger.info(
+                    "Enrichment refresh: attempted=%d profiles=%d earnings=%d estimates=%d skipped=%d",
+                    enrich_summary.symbols_attempted,
+                    enrich_summary.profiles_upserted,
+                    enrich_summary.earnings_upserted,
+                    enrich_summary.estimates_upserted,
+                    enrich_summary.symbols_skipped,
+                )
+            except Exception:
+                logger.warning("Enrichment refresh failed", exc_info=True)
+```
+
+Note: The import should be at the top of the file, not inline. Move it to the imports section:
+
+```python
+from app.services.enrichment import refresh_enrichment
+```
+
+- [ ] **Step 2: Run smoke test**
+
+```bash
+uv run pytest tests/smoke/test_app_boots.py -v
+```
+
+Expected: App boots — the new migration and import don't break startup.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/workers/scheduler.py
+git commit -m "feat(#199): wire enrichment refresh into daily_research_refresh job"
+```
+
+---
+
+## Phase 5: Thesis context enrichment
+
+### Task 7: Pass earnings and estimates context to thesis writer
+
+**Files:**
+- Modify: `app/services/thesis.py`
+
+- [ ] **Step 1: Add earnings and estimates to _assemble_context**
+
+In `_assemble_context`, add after the fundamentals fetch block:
+
+```python
+        # Earnings history (latest 4 quarters)
+        cur.execute(
+            """
+            SELECT fiscal_date_ending, reporting_date,
+                   eps_estimate, eps_actual, revenue_estimate, revenue_actual,
+                   surprise_pct
+            FROM earnings_events
+            WHERE instrument_id = %(id)s
+              AND eps_actual IS NOT NULL
+            ORDER BY fiscal_date_ending DESC
+            LIMIT 4
+            """,
+            {"id": instrument_id},
+        )
+        earnings_rows = cur.fetchall()
+
+        # Analyst estimates (latest)
+        cur.execute(
+            """
+            SELECT consensus_eps_fq, analyst_count, buy_count, hold_count,
+                   sell_count, price_target_mean, price_target_high, price_target_low
+            FROM analyst_estimates
+            WHERE instrument_id = %(id)s
+            ORDER BY as_of_date DESC
+            LIMIT 1
+            """,
+            {"id": instrument_id},
+        )
+        estimates_row = cur.fetchone()
+```
+
+Add to the returned context dict:
+
+```python
+    "earnings_history": [
+        {
+            "fiscal_date": str(r["fiscal_date_ending"]),
+            "eps_estimate": _to_float(r["eps_estimate"]),
+            "eps_actual": _to_float(r["eps_actual"]),
+            "revenue_actual": _to_float(r["revenue_actual"]),
+            "surprise_pct": _to_float(r["surprise_pct"]),
+        }
+        for r in earnings_rows
+    ],
+    "analyst_estimates": {
+        "consensus_eps": _to_float(estimates_row["consensus_eps_fq"]),
+        "analyst_count": estimates_row["analyst_count"],
+        "buy_count": estimates_row["buy_count"],
+        "hold_count": estimates_row["hold_count"],
+        "sell_count": estimates_row["sell_count"],
+        "price_target_mean": _to_float(estimates_row["price_target_mean"]),
+        "price_target_high": _to_float(estimates_row["price_target_high"]),
+        "price_target_low": _to_float(estimates_row["price_target_low"]),
+    } if estimates_row else None,
+```
+
+- [ ] **Step 2: Run existing thesis tests**
+
+```bash
+uv run pytest tests/test_thesis.py -v
+```
+
+Expected: All pass — the new context fields are additive and don't affect existing mock setup.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/services/thesis.py
+git commit -m "feat(#199): pass earnings history and analyst estimates to thesis writer context"
+```
+
+---
+
+## Phase 6: Final checks and PR
+
+### Task 8: Pre-flight review, Codex review, push
+
+- [ ] **Step 1: Run full check suite**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+All four must pass.
+
+- [ ] **Step 2: Self-review the diff**
+
+```bash
+git diff origin/main...HEAD
+```
+
+Run through the pre-flight review checklist (`.claude/skills/engineering/pre-flight-review.md`).
+
+- [ ] **Step 3: Run Codex review**
+
+```bash
+codex.cmd review --base main
+```
+
+Evaluate suggestions critically. Fix real issues, rebut false positives.
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push -u origin feature/199-fundamentals-enrichment
+gh pr create --title "feat(#199): fundamentals enrichment — valuation multiples, earnings, analyst estimates" --body "..."
+```
+
+- [ ] **Step 5: Poll review and CI**
+
+```bash
+gh pr checks <n>
+gh pr view <n> --comments
+```
+
+Wait for Claude review + CI green. Resolve all comments per the review comment resolution contract.

--- a/docs/superpowers/plans/2026-04-14-technical-analysis-engine.md
+++ b/docs/superpowers/plans/2026-04-14-technical-analysis-engine.md
@@ -1,0 +1,1529 @@
+# Technical Analysis Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compute TA indicators from existing OHLCV data in `price_daily` and fold them into the existing `momentum_score` family to produce a richer, multi-signal momentum assessment.
+
+**Architecture:** Pure Python computation module reads 400 days of OHLCV data (already fetched by `_compute_and_store_features` in `market_data.py`), computes ~15 indicators per instrument, stores latest-only values as new columns on `price_daily`, and the scoring engine's `_momentum_score()` is enhanced with three TA subcomponents (trend confirmation 40%, momentum quality 30%, volatility regime 30%) that blend with the existing return-based score.
+
+**Tech Stack:** Python stdlib (math, decimal), psycopg3, pytest. No new dependencies.
+
+---
+
+## Settled decisions that apply
+
+- **v1 scoring is heuristic, explicit, and auditable** — TA indicators are textbook formulas with pinned variants, no ML.
+- **Penalties are additive in v1** — no change; TA enhances family score, not penalties.
+- **Each score row carries enough detail to explain how it was produced** — TA subcomponent notes flow into the existing explanation.
+- **model_version includes scoring mode, default is v1-balanced** — no model_version change since this enhances momentum, not a new family.
+- **Providers are thin adapters; domain logic lives in services** — TA computation is a pure service function.
+- **Do not add libraries casually** — pure Python, no pandas-ta.
+
+## Prevention log entries that apply
+
+- **Guard ALL required fields before casting** (`float(None)` crash risk) — TA functions must handle None OHLCV values gracefully; guard before float conversion.
+- **Shared params dict** — verify each key consumed by every query that receives it. The UPDATE for TA columns must match the params dict exactly.
+- **Product name drift** — grep for all name variants when adding TA scoring references in docs or comments.
+
+## File structure
+
+| File | Responsibility |
+|------|---------------|
+| `sql/025_technical_analysis_columns.sql` | Migration: add ~15 TA indicator columns to `price_daily` |
+| `app/services/technical_analysis.py` | Pure computation: takes list of OHLCV dicts, returns dict of latest indicator values |
+| `app/services/market_data.py` | Extended: call TA computation at tail end of `_compute_and_store_features()` |
+| `app/services/scoring.py` | Enhanced: `_momentum_score()` gains TA subcomponents |
+| `tests/test_technical_analysis.py` | Unit tests for each indicator formula against known reference values |
+| `tests/test_market_data.py` | Integration test for TA column persistence |
+| `tests/test_scoring.py` | New tests for enhanced momentum score with TA inputs |
+
+---
+
+### Task 1: Migration — add TA indicator columns to `price_daily`
+
+**Files:**
+- Create: `sql/025_technical_analysis_columns.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+```sql
+-- Migration 025: add technical analysis indicator columns to price_daily
+--
+-- These columns store the latest-only computed TA values for each instrument.
+-- Values are recomputed on every daily candle refresh (tail end of
+-- _compute_and_store_features). Only the most recent price_date row per
+-- instrument carries values; historical rows remain NULL.
+--
+-- Formula variants pinned for auditability:
+--   RSI: Wilder smoothing (EMA with alpha = 1/period)
+--   ATR: Wilder smoothing
+--   EMA: seeded with SMA of first `period` values
+--   Bollinger: population stddev (ddof=0)
+--   Stochastic %K: raw = (close - low14) / (high14 - low14) * 100
+--   Stochastic %D: SMA(3) of %K
+
+-- Trend indicators
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS sma_20 NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS sma_50 NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS sma_200 NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS ema_12 NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS ema_26 NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS macd_line NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS macd_signal NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS macd_histogram NUMERIC(18,6);
+
+-- Momentum indicators
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS rsi_14 NUMERIC(10,4);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS stoch_k NUMERIC(10,4);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS stoch_d NUMERIC(10,4);
+
+-- Volatility indicators
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS bb_upper NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS bb_lower NUMERIC(18,6);
+ALTER TABLE price_daily ADD COLUMN IF NOT EXISTS atr_14 NUMERIC(18,6);
+```
+
+- [ ] **Step 2: Verify migration runs against dev DB**
+
+Run: `psql $DATABASE_URL -f sql/025_technical_analysis_columns.sql`
+Expected: 14 `ALTER TABLE` statements succeed (or no-op if re-run).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sql/025_technical_analysis_columns.sql
+git commit -m "feat(#200): migration 025 — add TA indicator columns to price_daily"
+```
+
+---
+
+### Task 2: Pure TA computation module — SMA, EMA, RSI
+
+**Files:**
+- Create: `app/services/technical_analysis.py`
+- Create: `tests/test_technical_analysis.py`
+
+This task implements the first three indicators. Subsequent tasks add the remaining indicators to the same module.
+
+- [ ] **Step 1: Write failing tests for SMA**
+
+```python
+"""Tests for app.services.technical_analysis — pure indicator computation.
+
+Reference values computed by hand or cross-checked against TradingView.
+All functions take a list of OHLCVRow dicts (oldest-first) and return
+the indicator value for the latest bar, or None if insufficient history.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.technical_analysis import (
+    OHLCVRow,
+    compute_indicators,
+    sma,
+    ema,
+    rsi,
+)
+
+
+def _approx(value: float, rel: float = 1e-4) -> object:
+    return pytest.approx(value, rel=rel)
+
+
+def _make_closes(values: list[float]) -> list[Decimal]:
+    return [Decimal(str(v)) for v in values]
+
+
+class TestSMA:
+    def test_sma_20_exact(self) -> None:
+        """SMA(20) of 20 values = arithmetic mean."""
+        closes = _make_closes([float(i) for i in range(1, 21)])
+        result = sma(closes, 20)
+        assert result == _approx(10.5)
+
+    def test_sma_longer_series(self) -> None:
+        """SMA(3) of [1,2,3,4,5] = mean of last 3 = 4.0."""
+        closes = _make_closes([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = sma(closes, 3)
+        assert result == _approx(4.0)
+
+    def test_sma_insufficient_data(self) -> None:
+        """Returns None when fewer than `period` values."""
+        closes = _make_closes([1.0, 2.0])
+        result = sma(closes, 20)
+        assert result is None
+```
+
+- [ ] **Step 2: Write failing tests for EMA**
+
+```python
+class TestEMA:
+    def test_ema_seeded_with_sma(self) -> None:
+        """EMA(3) of [1,2,3,4,5]: seed = SMA(3) of first 3 = 2.0.
+        Then: EMA_4 = 4 * (2/4) + 2.0 * (1 - 2/4) = 2 + 1 = 3.0
+              EMA_5 = 5 * (2/4) + 3.0 * (1 - 2/4) = 2.5 + 1.5 = 4.0
+        """
+        closes = _make_closes([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = ema(closes, 3)
+        assert result == _approx(4.0)
+
+    def test_ema_12_matches_reference(self) -> None:
+        """EMA(12) with 20 data points — verify against hand-computed value."""
+        # 20 ascending values; seed = SMA(12) of first 12 = 6.5
+        closes = _make_closes([float(i) for i in range(1, 21)])
+        result = ema(closes, 12)
+        # EMA(12) multiplier = 2/(12+1) = 0.153846...
+        # Computed iteratively from seed 6.5 through values 13..20
+        assert result is not None
+        assert result > 13.0  # must track upward trend
+
+    def test_ema_insufficient_data(self) -> None:
+        closes = _make_closes([1.0, 2.0])
+        result = ema(closes, 12)
+        assert result is None
+```
+
+- [ ] **Step 3: Write failing tests for RSI**
+
+```python
+class TestRSI:
+    def test_rsi_all_gains(self) -> None:
+        """Monotonically increasing prices → RSI near 100."""
+        closes = _make_closes([float(i) for i in range(1, 30)])
+        result = rsi(closes, 14)
+        assert result is not None
+        assert result > 95.0
+
+    def test_rsi_all_losses(self) -> None:
+        """Monotonically decreasing prices → RSI near 0."""
+        closes = _make_closes([float(30 - i) for i in range(29)])
+        result = rsi(closes, 14)
+        assert result is not None
+        assert result < 5.0
+
+    def test_rsi_flat_market(self) -> None:
+        """All same price → RSI = 50 (no gains, no losses, Wilder smoothing)."""
+        closes = _make_closes([100.0] * 30)
+        result = rsi(closes, 14)
+        # With zero gains and zero losses, RSI is undefined (0/0).
+        # Convention: return 50.0 (neutral).
+        assert result == _approx(50.0)
+
+    def test_rsi_insufficient_data(self) -> None:
+        """Need at least period+1 values for one smoothing step."""
+        closes = _make_closes([1.0] * 10)
+        result = rsi(closes, 14)
+        assert result is None
+
+    def test_rsi_known_value(self) -> None:
+        """RSI(14) with a known sequence.
+        Alternating +1/-0.5 gives avg_gain=1, avg_loss=0.5 after initial window.
+        RS = 1/0.5 = 2, RSI = 100 - 100/(1+2) = 66.67.
+        """
+        # Build: start at 100, alternate +1, -0.5
+        prices = [100.0]
+        for i in range(28):
+            if i % 2 == 0:
+                prices.append(prices[-1] + 1.0)
+            else:
+                prices.append(prices[-1] - 0.5)
+        closes = _make_closes(prices)
+        result = rsi(closes, 14)
+        assert result is not None
+        # After Wilder smoothing, RSI should be in 60-70 range
+        assert 55.0 < result < 75.0
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_technical_analysis.py -v`
+Expected: ImportError (module doesn't exist yet)
+
+- [ ] **Step 5: Implement SMA, EMA, RSI in `technical_analysis.py`**
+
+```python
+"""
+Technical analysis indicator computation.
+
+Pure functions — no DB, no I/O. Each function takes a list of Decimal
+close prices (oldest-first) and returns the indicator value for the
+latest bar, or None if there is insufficient history.
+
+Formula variants (pinned for auditability):
+  - RSI: Wilder smoothing (alpha = 1/period)
+  - EMA: seeded with SMA of the first `period` values
+  - ATR: Wilder smoothing over true range
+  - Bollinger: population stddev (ddof=0)
+  - Stochastic %K: (close - low14) / (high14 - low14) * 100
+  - Stochastic %D: SMA(3) of %K
+
+All prices are assumed split-adjusted (eToro provides adjusted candles
+for US equities). If candles are corrected, TA is recomputed on the
+next refresh.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import TypedDict
+
+
+class OHLCVRow(TypedDict):
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: int | None
+
+
+def sma(closes: list[Decimal], period: int) -> float | None:
+    """Simple moving average of the last `period` closes."""
+    if len(closes) < period:
+        return None
+    window = closes[-period:]
+    return float(sum(window)) / period
+
+
+def ema(closes: list[Decimal], period: int) -> float | None:
+    """Exponential moving average, seeded with SMA of the first `period` values.
+
+    Multiplier: 2 / (period + 1).
+    """
+    if len(closes) < period:
+        return None
+    seed = float(sum(closes[:period])) / period
+    multiplier = 2.0 / (period + 1)
+    value = seed
+    for close in closes[period:]:
+        value = float(close) * multiplier + value * (1.0 - multiplier)
+    return value
+
+
+def rsi(closes: list[Decimal], period: int = 14) -> float | None:
+    """Relative Strength Index using Wilder smoothing.
+
+    Requires at least period + 1 data points.
+    Returns 50.0 for flat markets (zero gains and zero losses).
+    """
+    if len(closes) < period + 1:
+        return None
+
+    deltas = [float(closes[i]) - float(closes[i - 1]) for i in range(1, len(closes))]
+
+    # Initial average gain/loss (SMA of first `period` deltas)
+    gains = [max(d, 0.0) for d in deltas[:period]]
+    losses = [max(-d, 0.0) for d in deltas[:period]]
+    avg_gain = sum(gains) / period
+    avg_loss = sum(losses) / period
+
+    # Wilder smoothing for remaining deltas
+    for d in deltas[period:]:
+        avg_gain = (avg_gain * (period - 1) + max(d, 0.0)) / period
+        avg_loss = (avg_loss * (period - 1) + max(-d, 0.0)) / period
+
+    if avg_gain == 0.0 and avg_loss == 0.0:
+        return 50.0  # flat market — neutral by convention
+
+    if avg_loss == 0.0:
+        return 100.0
+
+    rs = avg_gain / avg_loss
+    return 100.0 - 100.0 / (1.0 + rs)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_technical_analysis.py -v`
+Expected: All SMA, EMA, RSI tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/technical_analysis.py tests/test_technical_analysis.py
+git commit -m "feat(#200): SMA, EMA, RSI indicator computation with tests"
+```
+
+---
+
+### Task 3: TA computation module — MACD, Bollinger, ATR, Stochastic
+
+**Files:**
+- Modify: `app/services/technical_analysis.py`
+- Modify: `tests/test_technical_analysis.py`
+
+- [ ] **Step 1: Write failing tests for MACD**
+
+```python
+from app.services.technical_analysis import macd, bollinger_bands, atr, stochastic
+
+
+class TestMACD:
+    def test_macd_components(self) -> None:
+        """MACD with 30 ascending values — line should be positive (fast > slow)."""
+        closes = _make_closes([float(i) for i in range(1, 31)])
+        result = macd(closes)
+        assert result is not None
+        line, signal, histogram = result
+        assert line > 0  # fast EMA > slow EMA in uptrend
+        assert histogram == _approx(line - signal)
+
+    def test_macd_insufficient_data(self) -> None:
+        """Need at least 26 + 9 - 1 = 34 values for signal line."""
+        closes = _make_closes([float(i) for i in range(1, 20)])
+        result = macd(closes)
+        assert result is None
+
+    def test_macd_flat_market(self) -> None:
+        """Flat prices → MACD line, signal, and histogram all near zero."""
+        closes = _make_closes([100.0] * 50)
+        result = macd(closes)
+        assert result is not None
+        line, signal, histogram = result
+        assert abs(line) < 0.01
+        assert abs(signal) < 0.01
+        assert abs(histogram) < 0.01
+```
+
+- [ ] **Step 2: Write failing tests for Bollinger Bands**
+
+```python
+class TestBollingerBands:
+    def test_bollinger_flat_market(self) -> None:
+        """Flat prices → upper = lower = SMA (zero stddev)."""
+        closes = _make_closes([100.0] * 25)
+        result = bollinger_bands(closes)
+        assert result is not None
+        upper, lower = result
+        assert upper == _approx(100.0)
+        assert lower == _approx(100.0)
+
+    def test_bollinger_known_spread(self) -> None:
+        """[1,2,3,...,20] — SMA(20)=10.5, pop stddev known."""
+        closes = _make_closes([float(i) for i in range(1, 21)])
+        result = bollinger_bands(closes, period=20, num_std=2.0)
+        assert result is not None
+        upper, lower = result
+        # Population stddev of 1..20 = sqrt((20^2 - 1)/12) = sqrt(399/12) ≈ 5.7663
+        import math
+        pop_std = math.sqrt(sum((i - 10.5) ** 2 for i in range(1, 21)) / 20)
+        assert upper == _approx(10.5 + 2.0 * pop_std)
+        assert lower == _approx(10.5 - 2.0 * pop_std)
+
+    def test_bollinger_insufficient_data(self) -> None:
+        closes = _make_closes([1.0] * 10)
+        result = bollinger_bands(closes, period=20)
+        assert result is None
+```
+
+- [ ] **Step 3: Write failing tests for ATR**
+
+```python
+def _make_ohlcv(
+    values: list[tuple[float, float, float, float]],
+) -> list[OHLCVRow]:
+    """Build OHLCV rows from (open, high, low, close) tuples."""
+    return [
+        OHLCVRow(
+            open=Decimal(str(o)),
+            high=Decimal(str(h)),
+            low=Decimal(str(l)),
+            close=Decimal(str(c)),
+            volume=None,
+        )
+        for o, h, l, c in values
+    ]
+
+
+class TestATR:
+    def test_atr_known_value(self) -> None:
+        """ATR(14) with constant range bars.
+        Each bar: open=100, high=105, low=95, close=100.
+        True range = max(105-95, |105-100|, |95-100|) = 10.
+        ATR should converge to 10.
+        """
+        bars = _make_ohlcv([(100.0, 105.0, 95.0, 100.0)] * 30)
+        result = atr(bars, 14)
+        assert result == _approx(10.0)
+
+    def test_atr_with_gaps(self) -> None:
+        """When prev_close is outside today's range, true range includes the gap."""
+        bars = _make_ohlcv([
+            (100.0, 105.0, 95.0, 100.0),  # TR = 10
+        ] * 14 + [
+            (110.0, 115.0, 108.0, 112.0),  # prev_close=100, TR = max(7, 15, 8) = 15
+        ])
+        result = atr(bars, 14)
+        assert result is not None
+        # After 14 bars of TR=10, one bar of TR=15
+        # Wilder: (10 * 13 + 15) / 14 = 145/14 ≈ 10.357
+        assert result == _approx(145.0 / 14.0)
+
+    def test_atr_insufficient_data(self) -> None:
+        bars = _make_ohlcv([(100.0, 105.0, 95.0, 100.0)] * 5)
+        result = atr(bars, 14)
+        assert result is None
+```
+
+- [ ] **Step 4: Write failing tests for Stochastic**
+
+```python
+class TestStochastic:
+    def test_stochastic_at_high(self) -> None:
+        """Close at the top of the 14-day range → %K = 100."""
+        # 14 bars with range 90-110, close at 110
+        bars = _make_ohlcv([(100.0, 110.0, 90.0, 110.0)] * 20)
+        result = stochastic(bars)
+        assert result is not None
+        k, d = result
+        assert k == _approx(100.0)
+        assert d == _approx(100.0)  # SMA(3) of [100, 100, 100]
+
+    def test_stochastic_at_low(self) -> None:
+        """Close at the bottom of the range → %K = 0."""
+        bars = _make_ohlcv([(100.0, 110.0, 90.0, 90.0)] * 20)
+        result = stochastic(bars)
+        assert result is not None
+        k, d = result
+        assert k == _approx(0.0)
+        assert d == _approx(0.0)
+
+    def test_stochastic_midpoint(self) -> None:
+        """Close at midpoint of 14-day range → %K = 50."""
+        bars = _make_ohlcv([(100.0, 110.0, 90.0, 100.0)] * 20)
+        result = stochastic(bars)
+        assert result is not None
+        k, d = result
+        assert k == _approx(50.0)
+
+    def test_stochastic_insufficient_data(self) -> None:
+        """Need at least 14 + 2 bars for %K(14) and %D = SMA(3)."""
+        bars = _make_ohlcv([(100.0, 110.0, 90.0, 100.0)] * 10)
+        result = stochastic(bars)
+        assert result is None
+```
+
+- [ ] **Step 5: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_technical_analysis.py::TestMACD tests/test_technical_analysis.py::TestBollingerBands tests/test_technical_analysis.py::TestATR tests/test_technical_analysis.py::TestStochastic -v`
+Expected: ImportError or AttributeError (functions not defined yet)
+
+- [ ] **Step 6: Implement MACD**
+
+Add to `app/services/technical_analysis.py`:
+
+```python
+def macd(
+    closes: list[Decimal],
+    fast: int = 12,
+    slow: int = 26,
+    signal_period: int = 9,
+) -> tuple[float, float, float] | None:
+    """MACD: (macd_line, signal_line, histogram).
+
+    macd_line = EMA(fast) - EMA(slow)
+    signal = EMA(signal_period) of macd_line series
+    histogram = macd_line - signal
+
+    Requires at least slow + signal_period - 1 data points.
+    """
+    min_required = slow + signal_period - 1
+    if len(closes) < min_required:
+        return None
+
+    # Compute full EMA series for MACD line
+    fast_ema_series = _ema_series(closes, fast)
+    slow_ema_series = _ema_series(closes, slow)
+    if fast_ema_series is None or slow_ema_series is None:
+        return None
+
+    # MACD line: align from the point where both EMAs are available
+    # slow EMA starts at index (slow - 1), fast at (fast - 1)
+    start = slow - 1  # slow EMA available from this index onward
+    macd_values = [
+        fast_ema_series[i] - slow_ema_series[i - start + (slow - 1)]
+        for i in range(start, len(closes))
+    ]
+
+    if len(macd_values) < signal_period:
+        return None
+
+    # Signal line: EMA of MACD values
+    signal_seed = sum(macd_values[:signal_period]) / signal_period
+    multiplier = 2.0 / (signal_period + 1)
+    signal_value = signal_seed
+    for v in macd_values[signal_period:]:
+        signal_value = v * multiplier + signal_value * (1.0 - multiplier)
+
+    macd_line = macd_values[-1]
+    histogram = macd_line - signal_value
+    return (macd_line, signal_value, histogram)
+```
+
+Also add the `_ema_series` helper:
+
+```python
+def _ema_series(closes: list[Decimal], period: int) -> list[float] | None:
+    """Compute the full EMA series (one value per input from index period-1 onward)."""
+    if len(closes) < period:
+        return None
+    seed = float(sum(closes[:period])) / period
+    multiplier = 2.0 / (period + 1)
+    result = [seed]
+    for close in closes[period:]:
+        result.append(float(close) * multiplier + result[-1] * (1.0 - multiplier))
+    return result
+```
+
+- [ ] **Step 7: Implement Bollinger Bands**
+
+```python
+def bollinger_bands(
+    closes: list[Decimal],
+    period: int = 20,
+    num_std: float = 2.0,
+) -> tuple[float, float] | None:
+    """Bollinger Bands: (upper, lower). Uses population stddev (ddof=0)."""
+    if len(closes) < period:
+        return None
+    window = [float(c) for c in closes[-period:]]
+    mean = sum(window) / period
+    variance = sum((x - mean) ** 2 for x in window) / period
+    std = math.sqrt(variance)
+    return (mean + num_std * std, mean - num_std * std)
+```
+
+- [ ] **Step 8: Implement ATR**
+
+```python
+def atr(bars: list[OHLCVRow], period: int = 14) -> float | None:
+    """Average True Range using Wilder smoothing.
+
+    True Range = max(high - low, |high - prev_close|, |low - prev_close|).
+    Requires at least period + 1 bars (period TRs for the initial average,
+    plus one bar to establish prev_close).
+    """
+    if len(bars) < period + 1:
+        return None
+
+    true_ranges: list[float] = []
+    for i in range(1, len(bars)):
+        high = float(bars[i]["high"])
+        low = float(bars[i]["low"])
+        prev_close = float(bars[i - 1]["close"])
+        tr = max(high - low, abs(high - prev_close), abs(low - prev_close))
+        true_ranges.append(tr)
+
+    # Initial ATR: SMA of first `period` true ranges
+    atr_value = sum(true_ranges[:period]) / period
+
+    # Wilder smoothing for remaining
+    for tr in true_ranges[period:]:
+        atr_value = (atr_value * (period - 1) + tr) / period
+
+    return atr_value
+```
+
+- [ ] **Step 9: Implement Stochastic**
+
+```python
+def stochastic(
+    bars: list[OHLCVRow],
+    k_period: int = 14,
+    d_period: int = 3,
+) -> tuple[float, float] | None:
+    """Stochastic oscillator: (%K, %D).
+
+    %K = (close - lowest_low_14) / (highest_high_14 - lowest_low_14) * 100
+    %D = SMA(d_period) of %K values
+
+    Requires at least k_period + d_period - 1 bars.
+    """
+    min_required = k_period + d_period - 1
+    if len(bars) < min_required:
+        return None
+
+    k_values: list[float] = []
+    for i in range(k_period - 1, len(bars)):
+        window = bars[i - k_period + 1 : i + 1]
+        highest = max(float(b["high"]) for b in window)
+        lowest = min(float(b["low"]) for b in window)
+        close = float(bars[i]["close"])
+        if highest == lowest:
+            k_values.append(50.0)  # flat range — neutral
+        else:
+            k_values.append((close - lowest) / (highest - lowest) * 100.0)
+
+    if len(k_values) < d_period:
+        return None
+
+    # %D = SMA of last d_period %K values
+    latest_k = k_values[-1]
+    d_value = sum(k_values[-d_period:]) / d_period
+    return (latest_k, d_value)
+```
+
+- [ ] **Step 10: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_technical_analysis.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add app/services/technical_analysis.py tests/test_technical_analysis.py
+git commit -m "feat(#200): MACD, Bollinger, ATR, Stochastic indicators with tests"
+```
+
+---
+
+### Task 4: `compute_indicators` orchestrator and cross-signal detection
+
+**Files:**
+- Modify: `app/services/technical_analysis.py`
+- Modify: `tests/test_technical_analysis.py`
+
+- [ ] **Step 1: Write failing tests for `compute_indicators`**
+
+```python
+class TestComputeIndicators:
+    def test_full_dataset_returns_all_indicators(self) -> None:
+        """With 200+ bars, all indicators should be populated."""
+        bars = _make_ohlcv([(100.0 + i * 0.5, 102.0 + i * 0.5, 98.0 + i * 0.5, 100.5 + i * 0.5) for i in range(250)])
+        result = compute_indicators(bars)
+        assert result is not None
+        # All keys present
+        for key in [
+            "sma_20", "sma_50", "sma_200",
+            "ema_12", "ema_26",
+            "macd_line", "macd_signal", "macd_histogram",
+            "rsi_14", "stoch_k", "stoch_d",
+            "bb_upper", "bb_lower", "atr_14",
+        ]:
+            assert key in result, f"Missing key: {key}"
+            assert result[key] is not None, f"None for key: {key}"
+
+    def test_insufficient_history_returns_none_for_long_indicators(self) -> None:
+        """With only 30 bars, SMA(200) should be None, but SMA(20) and RSI should work."""
+        bars = _make_ohlcv([(100.0, 105.0, 95.0, 100.0)] * 30)
+        result = compute_indicators(bars)
+        assert result is not None
+        assert result["sma_200"] is None
+        assert result["sma_50"] is None
+        assert result["sma_20"] is not None
+        assert result["rsi_14"] is not None
+
+    def test_empty_bars_returns_none(self) -> None:
+        result = compute_indicators([])
+        assert result is None
+
+    def test_golden_cross_detected(self) -> None:
+        """When SMA(50) crosses above SMA(200), golden_cross should be True."""
+        # Build a series where prices rise enough for SMA(50) > SMA(200)
+        # at the end but SMA(50) < SMA(200) one bar earlier.
+        # Use 250 bars: flat at 100 for first 200, then rise to 150.
+        bars = _make_ohlcv(
+            [(100.0, 101.0, 99.0, 100.0)] * 200
+            + [(100.0 + i, 101.0 + i, 99.0 + i, 100.0 + i) for i in range(1, 51)]
+        )
+        result = compute_indicators(bars)
+        assert result is not None
+        # At minimum, the cross-signal fields should be present
+        assert "trend_sma_cross" in result
+
+    def test_price_above_sma200(self) -> None:
+        """Close above SMA(200) → price_vs_sma200 = 'above'."""
+        bars = _make_ohlcv(
+            [(50.0, 51.0, 49.0, 50.0)] * 200
+            + [(150.0, 151.0, 149.0, 150.0)] * 50
+        )
+        result = compute_indicators(bars)
+        assert result is not None
+        assert result.get("price_vs_sma200") == "above"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_technical_analysis.py::TestComputeIndicators -v`
+Expected: FAIL (compute_indicators not implemented yet or missing keys)
+
+- [ ] **Step 3: Implement `compute_indicators`**
+
+Add to `app/services/technical_analysis.py`:
+
+```python
+def compute_indicators(bars: list[OHLCVRow]) -> dict[str, float | str | None] | None:
+    """Compute all TA indicators for the latest bar.
+
+    Returns a dict keyed by column name (matching price_daily columns),
+    or None if no bars are provided.
+
+    Cross signals (golden/death cross, price vs SMA200) are derived from
+    recent raw candles at computation time — not stored as columns.
+    """
+    if not bars:
+        return None
+
+    closes = [b["close"] for b in bars]
+
+    # Trend
+    sma_20 = sma(closes, 20)
+    sma_50 = sma(closes, 50)
+    sma_200 = sma(closes, 200)
+    ema_12 = ema(closes, 12)
+    ema_26 = ema(closes, 26)
+
+    # MACD
+    macd_result = macd(closes)
+    macd_line_val = macd_result[0] if macd_result else None
+    macd_signal_val = macd_result[1] if macd_result else None
+    macd_histogram_val = macd_result[2] if macd_result else None
+
+    # Momentum
+    rsi_14 = rsi(closes, 14)
+    stoch_result = stochastic(bars)
+    stoch_k_val = stoch_result[0] if stoch_result else None
+    stoch_d_val = stoch_result[1] if stoch_result else None
+
+    # Volatility
+    bb_result = bollinger_bands(closes, 20, 2.0)
+    bb_upper_val = bb_result[0] if bb_result else None
+    bb_lower_val = bb_result[1] if bb_result else None
+    atr_14 = atr(bars, 14)
+
+    # Cross-signal detection (derived, not stored)
+    current_close = float(closes[-1])
+
+    # Price vs SMA(200)
+    price_vs_sma200: str | None = None
+    if sma_200 is not None:
+        price_vs_sma200 = "above" if current_close > sma_200 else "below"
+
+    # Golden/death cross: SMA(50) vs SMA(200) comparison
+    # We need SMA(50) and SMA(200) for both latest and one-bar-earlier
+    trend_sma_cross: str | None = None
+    if sma_50 is not None and sma_200 is not None and len(closes) > 200:
+        prev_sma_50 = sma(closes[:-1], 50)
+        prev_sma_200 = sma(closes[:-1], 200)
+        if prev_sma_50 is not None and prev_sma_200 is not None:
+            if sma_50 > sma_200 and prev_sma_50 <= prev_sma_200:
+                trend_sma_cross = "golden"
+            elif sma_50 < sma_200 and prev_sma_50 >= prev_sma_200:
+                trend_sma_cross = "death"
+            else:
+                trend_sma_cross = "none"
+
+    return {
+        # Stored columns (match price_daily column names)
+        "sma_20": sma_20,
+        "sma_50": sma_50,
+        "sma_200": sma_200,
+        "ema_12": ema_12,
+        "ema_26": ema_26,
+        "macd_line": macd_line_val,
+        "macd_signal": macd_signal_val,
+        "macd_histogram": macd_histogram_val,
+        "rsi_14": rsi_14,
+        "stoch_k": stoch_k_val,
+        "stoch_d": stoch_d_val,
+        "bb_upper": bb_upper_val,
+        "bb_lower": bb_lower_val,
+        "atr_14": atr_14,
+        # Derived (not stored — used at scoring time)
+        "price_vs_sma200": price_vs_sma200,
+        "trend_sma_cross": trend_sma_cross,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_technical_analysis.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/technical_analysis.py tests/test_technical_analysis.py
+git commit -m "feat(#200): compute_indicators orchestrator with cross-signal detection"
+```
+
+---
+
+### Task 5: Integrate TA computation into market data refresh
+
+**Files:**
+- Modify: `app/services/market_data.py`
+- Modify: `tests/test_market_data.py` (or create if it doesn't exist)
+
+- [ ] **Step 1: Write failing test for TA column persistence**
+
+Add to `tests/test_market_data.py`:
+
+```python
+"""Test that _compute_and_store_features calls TA computation and persists results."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from app.services.market_data import _compute_and_store_features
+
+
+class TestComputeAndStoreFeaturesTA:
+    """Verify that TA indicators are computed and written to price_daily."""
+
+    def test_ta_columns_included_in_update(self) -> None:
+        """When enough OHLCV data exists, TA columns should appear in the UPDATE params."""
+        # Build 250 rows of fake OHLCV data (enough for all indicators)
+        mock_rows = [
+            (date(2025, 1, 1) + __import__("datetime").timedelta(days=i), Decimal("100.0") + Decimal(str(i * 0.1)))
+            for i in range(250)
+        ]
+        # Also need OHLCV for TA — we need to mock the second query
+        mock_ohlcv = [
+            {
+                "open": Decimal("100.0") + Decimal(str(i * 0.1)),
+                "high": Decimal("101.0") + Decimal(str(i * 0.1)),
+                "low": Decimal("99.0") + Decimal(str(i * 0.1)),
+                "close": Decimal("100.0") + Decimal(str(i * 0.1)),
+                "volume": 1000,
+            }
+            for i in range(250)
+        ]
+
+        conn = MagicMock()
+        execute_results = iter([
+            # First call: price_date + close query
+            MagicMock(fetchall=MagicMock(return_value=list(reversed(mock_rows)))),
+            # Second call: OHLCV query for TA
+            MagicMock(fetchall=MagicMock(return_value=list(reversed([
+                (r["open"], r["high"], r["low"], r["close"], r["volume"]) for r in mock_ohlcv
+            ])))),
+            # Third call: UPDATE
+            MagicMock(),
+        ])
+        conn.execute.side_effect = lambda *a, **kw: next(execute_results)
+
+        result = _compute_and_store_features(conn, instrument_id=1)
+        assert result == 1
+
+        # The UPDATE call should include TA column params
+        update_call = conn.execute.call_args_list[-1]
+        update_sql = str(update_call.args[0])
+        assert "rsi_14" in update_sql
+        assert "sma_20" in update_sql
+        assert "macd_line" in update_sql
+        assert "atr_14" in update_sql
+
+    def test_ta_graceful_with_insufficient_data(self) -> None:
+        """With only 10 rows, TA indicators should be None but returns still computed."""
+        mock_rows = [
+            (date(2025, 1, 1) + __import__("datetime").timedelta(days=i), Decimal("100.0"))
+            for i in range(10)
+        ]
+        mock_ohlcv = [
+            (Decimal("100.0"), Decimal("101.0"), Decimal("99.0"), Decimal("100.0"), 1000)
+            for _ in range(10)
+        ]
+
+        conn = MagicMock()
+        execute_results = iter([
+            MagicMock(fetchall=MagicMock(return_value=list(reversed(mock_rows)))),
+            MagicMock(fetchall=MagicMock(return_value=list(reversed(mock_ohlcv)))),
+            MagicMock(),
+        ])
+        conn.execute.side_effect = lambda *a, **kw: next(execute_results)
+
+        result = _compute_and_store_features(conn, instrument_id=1)
+        assert result == 1
+
+        update_params = conn.execute.call_args_list[-1].args[1]
+        # SMA(200) should be None with only 10 rows
+        assert update_params["sma_200"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_market_data.py::TestComputeAndStoreFeaturesTA -v`
+Expected: FAIL (UPDATE SQL doesn't include TA columns yet)
+
+- [ ] **Step 3: Extend `_compute_and_store_features` to call TA computation**
+
+Modify `app/services/market_data.py`:
+
+1. Add import at top:
+```python
+from app.services.technical_analysis import OHLCVRow, compute_indicators
+```
+
+2. Inside `_compute_and_store_features`, after the existing `rows` fetch and before the UPDATE, add a second query to fetch OHLCV data and compute TA:
+
+```python
+    # --- TA indicators (computed from full OHLCV, not just close) ---
+    ohlcv_rows = conn.execute(
+        """
+        SELECT open, high, low, close, volume
+        FROM price_daily
+        WHERE instrument_id = %(instrument_id)s
+          AND close IS NOT NULL
+        ORDER BY price_date DESC
+        LIMIT 400
+        """,
+        {"instrument_id": instrument_id},
+    ).fetchall()
+
+    ta_indicators: dict[str, float | str | None] = {}
+    if ohlcv_rows:
+        # Reverse to oldest-first for TA computation
+        bars: list[OHLCVRow] = [
+            OHLCVRow(open=r[0], high=r[1], low=r[2], close=r[3], volume=r[4])
+            for r in reversed(ohlcv_rows)
+        ]
+        result = compute_indicators(bars)
+        if result is not None:
+            # Only keep storable columns (not derived cross-signals)
+            ta_indicators = {
+                k: v for k, v in result.items()
+                if k not in ("price_vs_sma200", "trend_sma_cross")
+            }
+```
+
+3. Extend the UPDATE statement to include TA columns:
+
+```python
+    conn.execute(
+        """
+        UPDATE price_daily SET
+            return_1w      = %(return_1w)s,
+            return_1m      = %(return_1m)s,
+            return_3m      = %(return_3m)s,
+            return_6m      = %(return_6m)s,
+            return_1y      = %(return_1y)s,
+            volatility_30d = %(volatility_30d)s,
+            sma_20         = %(sma_20)s,
+            sma_50         = %(sma_50)s,
+            sma_200        = %(sma_200)s,
+            ema_12         = %(ema_12)s,
+            ema_26         = %(ema_26)s,
+            macd_line      = %(macd_line)s,
+            macd_signal    = %(macd_signal)s,
+            macd_histogram = %(macd_histogram)s,
+            rsi_14         = %(rsi_14)s,
+            stoch_k        = %(stoch_k)s,
+            stoch_d        = %(stoch_d)s,
+            bb_upper       = %(bb_upper)s,
+            bb_lower       = %(bb_lower)s,
+            atr_14         = %(atr_14)s
+        WHERE instrument_id = %(instrument_id)s
+          AND price_date = %(price_date)s
+        """,
+        {
+            "instrument_id": instrument_id,
+            "price_date": latest_date,
+            "return_1w": returns.get("return_1w"),
+            "return_1m": returns.get("return_1m"),
+            "return_3m": returns.get("return_3m"),
+            "return_6m": returns.get("return_6m"),
+            "return_1y": returns.get("return_1y"),
+            "volatility_30d": volatility,
+            **{k: (Decimal(str(round(v, 6))) if isinstance(v, float) else None) for k, v in ta_indicators.items()},
+            # Ensure all TA keys present even if compute_indicators returned None
+            **{k: None for k in [
+                "sma_20", "sma_50", "sma_200", "ema_12", "ema_26",
+                "macd_line", "macd_signal", "macd_histogram",
+                "rsi_14", "stoch_k", "stoch_d",
+                "bb_upper", "bb_lower", "atr_14",
+            ] if k not in ta_indicators},
+        },
+    )
+```
+
+Note: The `**{k: None ...}` dict is built first, then `**ta_indicators` overwrites with actual values. Reverse the merge order to get this right:
+
+```python
+    ta_params: dict[str, Decimal | None] = {
+        k: None for k in [
+            "sma_20", "sma_50", "sma_200", "ema_12", "ema_26",
+            "macd_line", "macd_signal", "macd_histogram",
+            "rsi_14", "stoch_k", "stoch_d",
+            "bb_upper", "bb_lower", "atr_14",
+        ]
+    }
+    for k, v in ta_indicators.items():
+        ta_params[k] = Decimal(str(round(v, 6))) if isinstance(v, float) else None
+
+    conn.execute(
+        """...""",
+        {
+            "instrument_id": instrument_id,
+            "price_date": latest_date,
+            "return_1w": returns.get("return_1w"),
+            "return_1m": returns.get("return_1m"),
+            "return_3m": returns.get("return_3m"),
+            "return_6m": returns.get("return_6m"),
+            "return_1y": returns.get("return_1y"),
+            "volatility_30d": volatility,
+            **ta_params,
+        },
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_market_data.py tests/test_technical_analysis.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/market_data.py tests/test_market_data.py
+git commit -m "feat(#200): integrate TA computation into daily candle refresh"
+```
+
+---
+
+### Task 6: Enhance `_momentum_score` with TA subcomponents
+
+**Files:**
+- Modify: `app/services/scoring.py`
+- Modify: `tests/test_scoring.py`
+
+The enhanced momentum score blends the existing return-based score with three new TA subcomponents:
+- **Trend confirmation (40%)**: Price vs SMA(200), MACD histogram direction
+- **Momentum quality (30%)**: RSI regime, Stochastic position
+- **Volatility regime (30%)**: Bollinger Band position, ATR relative to price
+
+When TA data is unavailable (insufficient history, pre-migration), the score falls back to pure return-based scoring — backward compatible.
+
+- [ ] **Step 1: Write failing tests for enhanced momentum score**
+
+Add to `tests/test_scoring.py`:
+
+```python
+class TestEnhancedMomentumScore:
+    """Tests for _momentum_score with TA inputs."""
+
+    def test_backward_compatible_no_ta(self) -> None:
+        """When no TA dict is passed, score matches original return-only behavior."""
+        score_old, notes_old = _momentum_score(
+            return_1m=0.10, return_3m=0.20, return_6m=0.30,
+        )
+        score_new, notes_new = _momentum_score(
+            return_1m=0.10, return_3m=0.20, return_6m=0.30,
+            ta_indicators=None,
+        )
+        assert score_new == _approx(score_old)
+
+    def test_strong_trend_confirmation_boosts_score(self) -> None:
+        """Price above SMA(200) + positive MACD + positive returns → high score."""
+        ta = {
+            "sma_200": 90.0,
+            "macd_histogram": 2.5,
+            "rsi_14": 60.0,
+            "stoch_k": 70.0,
+            "stoch_d": 65.0,
+            "bb_upper": 120.0,
+            "bb_lower": 80.0,
+            "atr_14": 3.0,
+            "current_close": 110.0,
+        }
+        score, notes = _momentum_score(
+            return_1m=0.10, return_3m=0.20, return_6m=0.30,
+            ta_indicators=ta,
+        )
+        assert score > 0.7
+        assert not any("TA" in n and "missing" in n for n in notes)
+
+    def test_bearish_ta_drags_score_down(self) -> None:
+        """Price below SMA(200) + negative MACD + overbought RSI → lower score."""
+        ta = {
+            "sma_200": 120.0,
+            "macd_histogram": -3.0,
+            "rsi_14": 80.0,  # overbought
+            "stoch_k": 90.0,
+            "stoch_d": 85.0,
+            "bb_upper": 115.0,
+            "bb_lower": 105.0,
+            "atr_14": 5.0,
+            "current_close": 100.0,
+        }
+        score_no_ta, _ = _momentum_score(
+            return_1m=0.10, return_3m=0.20, return_6m=0.30,
+        )
+        score_with_ta, _ = _momentum_score(
+            return_1m=0.10, return_3m=0.20, return_6m=0.30,
+            ta_indicators=ta,
+        )
+        # Bearish TA should pull score below pure return-based score
+        assert score_with_ta < score_no_ta
+
+    def test_partial_ta_data_uses_available(self) -> None:
+        """When some TA values are None, available ones still contribute."""
+        ta = {
+            "sma_200": None,  # insufficient history
+            "macd_histogram": 1.0,
+            "rsi_14": 55.0,
+            "stoch_k": None,
+            "stoch_d": None,
+            "bb_upper": None,
+            "bb_lower": None,
+            "atr_14": None,
+            "current_close": 100.0,
+        }
+        score, notes = _momentum_score(
+            return_1m=0.10, return_3m=0.20, return_6m=0.30,
+            ta_indicators=ta,
+        )
+        assert 0.0 <= score <= 1.0
+        # Should note missing TA components
+        assert any("sma_200" in n.lower() or "TA" in n for n in notes)
+
+    def test_all_missing_returns_and_no_ta(self) -> None:
+        """No returns + no TA = neutral 0.5."""
+        score, notes = _momentum_score(None, None, None, ta_indicators=None)
+        assert score == _approx(0.5)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_scoring.py::TestEnhancedMomentumScore -v`
+Expected: FAIL (signature doesn't accept ta_indicators yet)
+
+- [ ] **Step 3: Update `_momentum_score` signature and implement TA blending**
+
+Modify `_momentum_score` in `app/services/scoring.py`:
+
+```python
+def _momentum_score(
+    return_1m: float | None,
+    return_3m: float | None,
+    return_6m: float | None,
+    *,
+    ta_indicators: dict[str, float | None] | None = None,
+) -> tuple[float, list[str]]:
+    """
+    Blended momentum score combining return-based signals with TA indicators.
+
+    When ta_indicators is None or empty, falls back to pure return scoring
+    (backward compatible).
+
+    TA blending (when available):
+      - Return-based score: 40% weight
+      - Trend confirmation: 25% weight (price vs SMA200, MACD)
+      - Momentum quality: 20% weight (RSI regime, Stochastic)
+      - Volatility regime: 15% weight (Bollinger position, ATR context)
+
+    Returns (score, notes) where notes lists missing components.
+    """
+    notes: list[str] = []
+
+    # --- Return-based component (original logic) ---
+    return_components: list[tuple[float, float]] = []
+
+    if return_1m is not None:
+        s1m = _clip((return_1m + 0.10) / 0.30)
+        return_components.append((s1m, 0.20))
+    else:
+        notes.append("return_1m missing")
+
+    if return_3m is not None:
+        s3m = _clip((return_3m + 0.15) / 0.45)
+        return_components.append((s3m, 0.50))
+    else:
+        notes.append("return_3m missing")
+
+    if return_6m is not None:
+        s6m = _clip((return_6m + 0.20) / 0.60)
+        return_components.append((s6m, 0.30))
+    else:
+        notes.append("return_6m missing")
+
+    if not return_components:
+        return_score: float | None = None
+    else:
+        total_w = sum(w for _, w in return_components)
+        return_score = sum(s * w / total_w for s, w in return_components)
+
+    # --- If no TA data, fall back to return-only scoring ---
+    if not ta_indicators or not any(
+        ta_indicators.get(k) is not None
+        for k in ("sma_200", "macd_histogram", "rsi_14", "stoch_k", "bb_upper", "atr_14")
+    ):
+        if return_score is None:
+            return 0.5, notes
+        return _clip(return_score), notes
+
+    # --- TA subcomponents ---
+    current_close = ta_indicators.get("current_close")
+
+    # 1. Trend confirmation (SMA200 + MACD histogram)
+    trend_parts: list[tuple[float, float]] = []
+
+    sma_200 = ta_indicators.get("sma_200")
+    if sma_200 is not None and current_close is not None:
+        # Above SMA200 → bullish (0.7-1.0 based on distance)
+        # Below → bearish (0.0-0.3)
+        pct_from_sma = (current_close - sma_200) / sma_200 if sma_200 != 0 else 0
+        trend_parts.append((_clip(0.5 + pct_from_sma * 2.5), 0.60))
+    else:
+        notes.append("TA: sma_200 unavailable")
+
+    macd_hist = ta_indicators.get("macd_histogram")
+    if macd_hist is not None:
+        # Positive histogram → bullish, negative → bearish
+        # Normalise: histogram in typical range [-5, 5]
+        macd_signal = _clip(0.5 + macd_hist / 10.0)
+        trend_parts.append((macd_signal, 0.40))
+    else:
+        notes.append("TA: macd_histogram unavailable")
+
+    trend_score: float | None = None
+    if trend_parts:
+        tw = sum(w for _, w in trend_parts)
+        trend_score = sum(s * w / tw for s, w in trend_parts)
+
+    # 2. Momentum quality (RSI + Stochastic)
+    mq_parts: list[tuple[float, float]] = []
+
+    rsi_val = ta_indicators.get("rsi_14")
+    if rsi_val is not None:
+        # RSI 30-70 is healthy momentum territory.
+        # Overbought (>70) penalised, oversold (<30) penalised.
+        # Sweet spot: 50-65 → highest score.
+        if rsi_val < 30:
+            rsi_score = rsi_val / 60.0  # 0→0, 30→0.5
+        elif rsi_val <= 70:
+            rsi_score = 0.5 + (rsi_val - 30) / 80.0  # 30→0.5, 70→1.0
+        else:
+            rsi_score = max(0.0, 1.0 - (rsi_val - 70) / 30.0)  # 70→1.0, 100→0.0
+        mq_parts.append((_clip(rsi_score), 0.60))
+    else:
+        notes.append("TA: rsi_14 unavailable")
+
+    stoch_k = ta_indicators.get("stoch_k")
+    if stoch_k is not None:
+        # Similar to RSI: mid-range is good, extremes are warning
+        if stoch_k < 20:
+            stoch_score = stoch_k / 40.0
+        elif stoch_k <= 80:
+            stoch_score = 0.5 + (stoch_k - 20) / 120.0
+        else:
+            stoch_score = max(0.0, 1.0 - (stoch_k - 80) / 20.0)
+        mq_parts.append((_clip(stoch_score), 0.40))
+    else:
+        notes.append("TA: stoch_k unavailable")
+
+    mq_score: float | None = None
+    if mq_parts:
+        mw = sum(w for _, w in mq_parts)
+        mq_score = sum(s * w / mw for s, w in mq_parts)
+
+    # 3. Volatility regime (Bollinger position + ATR)
+    vol_parts: list[tuple[float, float]] = []
+
+    bb_upper = ta_indicators.get("bb_upper")
+    bb_lower = ta_indicators.get("bb_lower")
+    if bb_upper is not None and bb_lower is not None and current_close is not None:
+        bb_width = bb_upper - bb_lower
+        if bb_width > 0:
+            # Position within bands: 0 = lower, 1 = upper
+            bb_position = (current_close - bb_lower) / bb_width
+            # Mid-band is healthiest; near upper = stretched; near lower = weak
+            vol_parts.append((_clip(bb_position), 0.60))
+        else:
+            vol_parts.append((0.5, 0.60))  # flat band
+    else:
+        notes.append("TA: bollinger bands unavailable")
+
+    atr_val = ta_indicators.get("atr_14")
+    if atr_val is not None and current_close is not None and current_close > 0:
+        # ATR as % of price — low vol environment scores higher for trend-following
+        atr_pct = atr_val / current_close
+        # atr_pct typically 1-5%. Lower = calmer = better for trend continuation
+        vol_score = _clip(1.0 - atr_pct * 10.0)  # 0%→1.0, 5%→0.5, 10%→0.0
+        vol_parts.append((vol_score, 0.40))
+    else:
+        notes.append("TA: atr_14 unavailable")
+
+    vol_score_final: float | None = None
+    if vol_parts:
+        vw = sum(w for _, w in vol_parts)
+        vol_score_final = sum(s * w / vw for s, w in vol_parts)
+
+    # --- Blend all components ---
+    final_parts: list[tuple[float, float]] = []
+    if return_score is not None:
+        final_parts.append((return_score, 0.40))
+    if trend_score is not None:
+        final_parts.append((trend_score, 0.25))
+    if mq_score is not None:
+        final_parts.append((mq_score, 0.20))
+    if vol_score_final is not None:
+        final_parts.append((vol_score_final, 0.15))
+
+    if not final_parts:
+        return 0.5, notes
+
+    total_w = sum(w for _, w in final_parts)
+    blended = sum(s * w / total_w for s, w in final_parts)
+    return _clip(blended), notes
+```
+
+- [ ] **Step 4: Update the data loading to pass TA indicators to momentum score**
+
+Modify the caller of `_momentum_score` in `scoring.py`. In `_load_instrument_data`, extend the price_daily query:
+
+```python
+        # Latest price features
+        cur.execute(
+            """
+            SELECT return_1m, return_3m, return_6m, close,
+                   sma_200, macd_histogram, rsi_14,
+                   stoch_k, stoch_d,
+                   bb_upper, bb_lower, atr_14
+            FROM price_daily
+            WHERE instrument_id = %(id)s
+              AND close IS NOT NULL
+            ORDER BY price_date DESC
+            LIMIT 1
+            """,
+            {"id": instrument_id},
+        )
+        price_row: dict[str, Any] | None = cur.fetchone()
+```
+
+Then in the scoring function where `_momentum_score` is called, build the `ta_indicators` dict from `price_row`:
+
+```python
+    # Build TA indicators dict for momentum score
+    ta_indicators: dict[str, float | None] | None = None
+    if price_row is not None:
+        ta_keys = ["sma_200", "macd_histogram", "rsi_14", "stoch_k", "stoch_d", "bb_upper", "bb_lower", "atr_14"]
+        ta_raw = {k: price_row.get(k) for k in ta_keys}
+        if any(v is not None for v in ta_raw.values()):
+            ta_indicators = {k: float(v) if v is not None else None for k, v in ta_raw.items()}
+            ta_indicators["current_close"] = float(current_price) if current_price else None
+
+    momentum, momentum_notes = _momentum_score(
+        return_1m=float(price_row["return_1m"]) if price_row and price_row.get("return_1m") is not None else None,
+        return_3m=float(price_row["return_3m"]) if price_row and price_row.get("return_3m") is not None else None,
+        return_6m=float(price_row["return_6m"]) if price_row and price_row.get("return_6m") is not None else None,
+        ta_indicators=ta_indicators,
+    )
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `uv run pytest tests/test_scoring.py tests/test_technical_analysis.py tests/test_market_data.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Run full pre-push checklist**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+Expected: All four pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/scoring.py tests/test_scoring.py
+git commit -m "feat(#200): enhance momentum score with TA subcomponents (trend, momentum quality, volatility regime)"
+```
+
+---
+
+### Task 7: Smoke test — verify TA integration end-to-end
+
+**Files:**
+- Existing: `tests/smoke/test_app_boots.py` (verify no regressions)
+
+- [ ] **Step 1: Run the smoke test to ensure the app still boots**
+
+Run: `uv run pytest tests/smoke/test_app_boots.py -v`
+Expected: PASS
+
+- [ ] **Step 2: Run migration against dev DB**
+
+Run: `psql $DATABASE_URL -f sql/025_technical_analysis_columns.sql`
+Expected: All ALTER TABLE statements succeed.
+
+- [ ] **Step 3: Verify full test suite**
+
+Run: `uv run pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 4: Run pre-push checklist**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+Expected: All four pass.
+
+---
+
+### Task 8: Final review and push
+
+This task follows the branch/PR workflow from CLAUDE.md.
+
+- [ ] **Step 1: Review the full diff**
+
+Run: `git diff main --stat` and `git diff main` to review all changes.
+
+- [ ] **Step 2: Run Codex review before push**
+
+```bash
+codex.cmd review --base main
+```
+
+Address any real findings. If deferring, ask Codex to confirm.
+
+- [ ] **Step 3: Push and open PR**
+
+```bash
+git push -u origin feature/200-technical-analysis-engine
+gh pr create --title "feat(#200): technical analysis engine" --body "..."
+```
+
+- [ ] **Step 4: Poll review and CI**
+
+Poll `gh pr view <n> --comments` and `gh pr checks <n>` until review has posted on the latest commit SHA and CI is green.
+
+- [ ] **Step 5: Resolve review comments**
+
+Each comment resolved as `FIXED {sha}`, `DEFERRED #{issue}`, or `REBUTTED {reason}`.
+Each PREVENTION comment resolved as `EXTRACTED {file}`, `ALREADY_COVERED {file}`, or `REBUTTED {reason}`.
+
+- [ ] **Step 6: Codex review before merge**
+
+```bash
+codex.cmd review --base main
+```
+
+Merge only after Codex confirms + CI green on latest SHA.
+
+- [ ] **Step 7: Merge, clean up**
+
+```bash
+gh pr merge <n> --squash --delete-branch
+git branch -d feature/200-technical-analysis-engine
+```
+
+Close linked issue #200.

--- a/docs/superpowers/plans/2026-04-15-autonomous-operation-loop.md
+++ b/docs/superpowers/plans/2026-04-15-autonomous-operation-loop.md
@@ -1,0 +1,1581 @@
+# Autonomous Operation Loop — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three gaps preventing autonomous end-to-end investment lifecycle: retry deferred recommendations, monitor positions intraday, and wire pipeline awareness between scheduled jobs.
+
+**Architecture:** Three independent subsystems layered onto the existing scheduler and service modules. (1) A new hourly `retry_deferred_recommendations` job re-evaluates `timing_deferred` BUY/ADD recs using fresh TA data. (2) A new hourly `monitor_positions` job detects SL/TP hits and thesis breaks between daily syncs. (3) Pipeline triggers — post-completion hooks on existing jobs — chain outputs to downstream job invocation so the morning pipeline fires as a connected sequence rather than isolated cron jobs.
+
+**Tech Stack:** Python, psycopg3, APScheduler (existing), PostgreSQL, existing TA/entry-timing/execution-guard services.
+
+---
+
+## Settled decisions that apply
+
+- **Kill switch stops all autonomous trading immediately** — every new job must check the kill switch before any write path.
+- **Execution guard hard rules always apply** — retried recs go through the full guard, not a shortcut.
+- **EXIT recs always pass through timing** — never defer protective exits (existing settled decision preserved).
+- **Guard re-check rule** — guard must re-check constraints against current state; never trust old recommendation state.
+- **Paper trading mode must work identically to live mode** — new jobs must operate in both modes.
+- **Decision audit per guard invocation** — every guard/timing evaluation writes an audit row.
+- **enable_auto_trading is not the same as enable_live_trading** — new autonomous jobs check `enable_auto_trading`.
+
+## Prevention log entries that apply
+
+- **decision_id received but not written back to decision_audit** — every pipeline stage must write its own audit row.
+- **Early return inside `_tracked_job` without `row_count`** — all new jobs must set `tracker.row_count` on every path.
+- **Read-then-write cap enforcement outside transaction** — retry status changes must be atomic with their audit rows.
+- **ON CONFLICT DO NOTHING counter overcount** — counters gated on `rowcount > 0`.
+- **Shared column vocabulary mismatch across stages** — reuse existing `pass_fail` values (`PASS`, `FAIL`, `DEFER`).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `sql/028_autonomous_loop.sql` | Migration: add `timing_retry_count` + `timing_deferred_at` columns to `trade_recommendations`; add `deferred_recommendation_id` FK column for retry-created recs |
+| `app/services/deferred_retry.py` | Service: re-evaluate deferred recs, transition them back to `proposed` or expire them |
+| `app/services/position_monitor.py` | Service: lightweight intraday position health check (SL/TP hit detection, thesis break) |
+| `app/workers/scheduler.py` | Modified: add 2 new scheduled jobs + 2 new job functions + pipeline trigger hooks |
+| `tests/test_deferred_retry.py` | Tests for deferred retry service |
+| `tests/test_position_monitor.py` | Tests for position monitoring service |
+| `tests/test_scheduler_autonomous.py` | Tests for new scheduler jobs and pipeline triggers |
+
+---
+
+## Task 1: Migration — deferred retry tracking columns
+
+**Files:**
+- Create: `sql/028_autonomous_loop.sql`
+
+- [ ] **Step 1: Write the migration SQL**
+
+```sql
+-- Migration 028: autonomous operation loop — deferred retry tracking
+--
+-- timing_retry_count: how many times a timing_deferred rec has been
+--   re-evaluated. Starts at 0, incremented on each retry attempt.
+--   Used to cap retries (max 3 per cycle) and for observability.
+--
+-- timing_deferred_at: when the rec was first deferred. Used to expire
+--   stale deferred recs (>24h old) so they don't retry indefinitely.
+--
+-- deferred_recommendation_id: when a deferred rec expires, a new
+--   recommendation may be generated in the next morning cycle. This
+--   FK links the retry lineage for auditability.
+
+ALTER TABLE trade_recommendations
+    ADD COLUMN IF NOT EXISTS timing_retry_count      INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS timing_deferred_at       TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS deferred_recommendation_id BIGINT
+        REFERENCES trade_recommendations(recommendation_id);
+```
+
+- [ ] **Step 2: Apply migration locally**
+
+Run: `uv run python -c "import psycopg; conn = psycopg.connect('$(grep DATABASE_URL .env | cut -d= -f2-)'); conn.execute(open('sql/028_autonomous_loop.sql').read()); conn.commit(); print('OK')"`
+Expected: OK (no errors)
+
+- [ ] **Step 3: Verify columns exist**
+
+Run: `uv run python -c "import psycopg; from app.config import settings; conn = psycopg.connect(settings.database_url); cur = conn.execute(\"SELECT column_name FROM information_schema.columns WHERE table_name='trade_recommendations' AND column_name IN ('timing_retry_count','timing_deferred_at','deferred_recommendation_id')\"); print([r[0] for r in cur.fetchall()])"`
+Expected: `['timing_retry_count', 'timing_deferred_at', 'deferred_recommendation_id']`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sql/028_autonomous_loop.sql
+git commit -m "feat(#205): migration 028 — deferred retry tracking columns"
+```
+
+---
+
+## Task 2: Deferred retry service
+
+**Files:**
+- Create: `app/services/deferred_retry.py`
+- Test: `tests/test_deferred_retry.py`
+
+### Step-by-step
+
+- [ ] **Step 1: Write the failing test — retry re-evaluates a deferred rec**
+
+```python
+"""Tests for app.services.deferred_retry."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.deferred_retry import (
+    MAX_RETRY_ATTEMPTS,
+    RETRY_EXPIRY_HOURS,
+    RetryResult,
+    retry_deferred_recommendations,
+)
+
+
+def _mock_conn() -> MagicMock:
+    """Create a mock psycopg connection with cursor context manager."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value = MagicMock()
+    conn.transaction.return_value.__enter__ = MagicMock()
+    conn.transaction.return_value.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+class TestRetryDeferredRecommendations:
+    """Tests for the retry_deferred_recommendations service function."""
+
+    def test_no_deferred_recs_returns_zero_counts(self) -> None:
+        conn = _mock_conn()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        cursor.fetchall.return_value = []
+
+        result = retry_deferred_recommendations(conn)
+
+        assert result.retried == 0
+        assert result.re_proposed == 0
+        assert result.re_deferred == 0
+        assert result.expired == 0
+
+    def test_deferred_rec_within_retry_limit_is_re_evaluated(self) -> None:
+        """A deferred rec with retry_count < MAX should be re-evaluated via entry timing."""
+        conn = _mock_conn()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        now = datetime.now(UTC)
+        cursor.fetchall.return_value = [
+            {
+                "recommendation_id": 42,
+                "instrument_id": 100,
+                "action": "BUY",
+                "timing_retry_count": 0,
+                "timing_deferred_at": now - timedelta(hours=1),
+            },
+        ]
+
+        with patch("app.services.deferred_retry.evaluate_entry_conditions") as mock_eval:
+            mock_eval.return_value = MagicMock(
+                verdict="pass",
+                stop_loss_rate=Decimal("95.00"),
+                take_profit_rate=Decimal("120.00"),
+                rationale="RSI recovered, MACD positive",
+                condition_details={"rsi": 55.0},
+            )
+            result = retry_deferred_recommendations(conn)
+
+        assert result.retried == 1
+        assert result.re_proposed == 1
+        mock_eval.assert_called_once_with(conn, 42)
+
+    def test_deferred_rec_exceeding_retry_limit_is_expired(self) -> None:
+        """A rec that has been retried MAX_RETRY_ATTEMPTS times gets expired."""
+        conn = _mock_conn()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        now = datetime.now(UTC)
+        cursor.fetchall.return_value = [
+            {
+                "recommendation_id": 42,
+                "instrument_id": 100,
+                "action": "BUY",
+                "timing_retry_count": MAX_RETRY_ATTEMPTS,
+                "timing_deferred_at": now - timedelta(hours=1),
+            },
+        ]
+
+        result = retry_deferred_recommendations(conn)
+
+        assert result.expired == 1
+        assert result.retried == 0
+
+    def test_deferred_rec_older_than_expiry_is_expired(self) -> None:
+        """A rec deferred longer than RETRY_EXPIRY_HOURS gets expired."""
+        conn = _mock_conn()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        cursor.fetchall.return_value = [
+            {
+                "recommendation_id": 42,
+                "instrument_id": 100,
+                "action": "BUY",
+                "timing_retry_count": 0,
+                "timing_deferred_at": datetime.now(UTC) - timedelta(hours=RETRY_EXPIRY_HOURS + 1),
+            },
+        ]
+
+        result = retry_deferred_recommendations(conn)
+
+        assert result.expired == 1
+        assert result.retried == 0
+
+    def test_re_evaluation_still_unfavorable_increments_retry_count(self) -> None:
+        """When timing still says defer, retry_count is incremented."""
+        conn = _mock_conn()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        now = datetime.now(UTC)
+        cursor.fetchall.return_value = [
+            {
+                "recommendation_id": 42,
+                "instrument_id": 100,
+                "action": "BUY",
+                "timing_retry_count": 1,
+                "timing_deferred_at": now - timedelta(hours=2),
+            },
+        ]
+
+        with patch("app.services.deferred_retry.evaluate_entry_conditions") as mock_eval:
+            mock_eval.return_value = MagicMock(
+                verdict="defer",
+                stop_loss_rate=Decimal("95.00"),
+                take_profit_rate=None,
+                rationale="RSI still overbought",
+                condition_details={"rsi": 78.0},
+            )
+            result = retry_deferred_recommendations(conn)
+
+        assert result.re_deferred == 1
+        assert result.re_proposed == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_deferred_retry.py -v`
+Expected: FAIL (module not found)
+
+- [ ] **Step 3: Write the deferred retry service**
+
+```python
+"""Deferred recommendation retry service.
+
+Re-evaluates timing_deferred BUY/ADD recommendations using fresh TA data.
+Recs that now pass are transitioned back to 'proposed' for the next
+guard+execute cycle. Recs that exceed the retry cap or age out are
+expired to 'timing_expired'.
+
+Design choices:
+  - Reuses evaluate_entry_conditions() — same TA checks, same SL/TP compute.
+  - Each retry attempt writes a decision_audit row for auditability.
+  - Retry cap (MAX_RETRY_ATTEMPTS) and time cap (RETRY_EXPIRY_HOURS) prevent
+    infinite retry loops on persistently unfavorable instruments.
+  - timing_deferred_at is set on first deferral (by the scheduler's Phase 0),
+    not on retry — so expiry is measured from original deferral time.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from psycopg.types.json import Jsonb
+
+from app.services.entry_timing import evaluate_entry_conditions
+
+logger = logging.getLogger(__name__)
+
+# Maximum number of retry attempts before expiring a deferred rec.
+# 3 retries at hourly cadence = 3 hours of re-checks after deferral.
+MAX_RETRY_ATTEMPTS: int = 3
+
+# Hours after which a deferred rec expires regardless of retry count.
+# Prevents stale recs from lingering across trading days.
+RETRY_EXPIRY_HOURS: int = 24
+
+
+@dataclass(frozen=True)
+class RetryResult:
+    """Summary of a deferred retry run."""
+
+    retried: int
+    re_proposed: int
+    re_deferred: int
+    expired: int
+    errors: int = 0
+
+
+def retry_deferred_recommendations(conn: psycopg.Connection[Any]) -> RetryResult:
+    """Re-evaluate all timing_deferred BUY/ADD recs.
+
+    For each deferred rec:
+    1. If retry_count >= MAX or deferred_at + EXPIRY has passed → expire.
+    2. Otherwise, re-run evaluate_entry_conditions:
+       - verdict=pass → transition to 'proposed', update SL/TP.
+       - verdict=defer → increment retry_count, stay deferred.
+       - verdict=skip/error → increment retry_count, stay deferred.
+
+    Each transition writes a decision_audit row in the same transaction
+    as the status update (prevention log: read-then-write in same txn).
+
+    Returns a RetryResult summary.
+    """
+    now = datetime.now(UTC)
+    expiry_cutoff = now - timedelta(hours=RETRY_EXPIRY_HOURS)
+
+    # Load all timing_deferred recs (BUY/ADD only — EXIT/HOLD never deferred).
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT recommendation_id, instrument_id, action,
+                   timing_retry_count, timing_deferred_at
+            FROM trade_recommendations
+            WHERE status = 'timing_deferred'
+              AND action IN ('BUY', 'ADD')
+            ORDER BY recommendation_id
+            """,
+        )
+        deferred = cur.fetchall()
+
+    retried = 0
+    re_proposed = 0
+    re_deferred = 0
+    expired = 0
+    errors = 0
+
+    for rec in deferred:
+        rec_id: int = rec["recommendation_id"]
+        instrument_id: int = rec["instrument_id"]
+        retry_count: int = rec["timing_retry_count"]
+        deferred_at = rec["timing_deferred_at"]
+
+        # --- Expiry check ---
+        should_expire = (
+            retry_count >= MAX_RETRY_ATTEMPTS
+            or (deferred_at is not None and deferred_at < expiry_cutoff)
+        )
+        if should_expire:
+            with conn.transaction():
+                conn.execute(
+                    """
+                    INSERT INTO decision_audit
+                        (decision_time, instrument_id, recommendation_id,
+                         stage, pass_fail, explanation)
+                    VALUES
+                        (NOW(), %(iid)s, %(rid)s,
+                         'deferred_retry', 'FAIL',
+                         %(expl)s)
+                    """,
+                    {
+                        "iid": instrument_id,
+                        "rid": rec_id,
+                        "expl": f"expired: retry_count={retry_count}, "
+                        f"deferred_at={deferred_at}, cutoff={expiry_cutoff}",
+                    },
+                )
+                conn.execute(
+                    """
+                    UPDATE trade_recommendations
+                    SET status = 'timing_expired',
+                        timing_verdict = 'error',
+                        timing_rationale = %(rationale)s
+                    WHERE recommendation_id = %(rid)s
+                    """,
+                    {
+                        "rid": rec_id,
+                        "rationale": f"expired after {retry_count} retries "
+                        f"(max={MAX_RETRY_ATTEMPTS}, expiry={RETRY_EXPIRY_HOURS}h)",
+                    },
+                )
+            conn.commit()
+            expired += 1
+            logger.info(
+                "deferred_retry: expired rec=%d (retries=%d, deferred_at=%s)",
+                rec_id,
+                retry_count,
+                deferred_at,
+            )
+            continue
+
+        # --- Re-evaluate timing ---
+        try:
+            evaluation = evaluate_entry_conditions(conn, rec_id)
+        except Exception:
+            logger.error(
+                "deferred_retry: evaluation failed for rec=%d, incrementing retry count",
+                rec_id,
+                exc_info=True,
+            )
+            with conn.transaction():
+                conn.execute(
+                    """
+                    UPDATE trade_recommendations
+                    SET timing_retry_count = timing_retry_count + 1
+                    WHERE recommendation_id = %(rid)s
+                    """,
+                    {"rid": rec_id},
+                )
+            conn.commit()
+            errors += 1
+            continue
+
+        retried += 1
+
+        if evaluation.verdict == "pass":
+            # Conditions now favorable — transition back to proposed
+            with conn.transaction():
+                conn.execute(
+                    """
+                    INSERT INTO decision_audit
+                        (decision_time, instrument_id, recommendation_id,
+                         stage, pass_fail, explanation, evidence_json)
+                    VALUES
+                        (NOW(), %(iid)s, %(rid)s,
+                         'deferred_retry', 'PASS', %(expl)s, %(ev)s)
+                    """,
+                    {
+                        "iid": instrument_id,
+                        "rid": rec_id,
+                        "expl": evaluation.rationale,
+                        "ev": Jsonb(evaluation.condition_details),
+                    },
+                )
+                conn.execute(
+                    """
+                    UPDATE trade_recommendations
+                    SET status = 'proposed',
+                        stop_loss_rate = %(sl)s,
+                        take_profit_rate = %(tp)s,
+                        timing_verdict = %(verdict)s,
+                        timing_rationale = %(rationale)s,
+                        timing_retry_count = timing_retry_count + 1
+                    WHERE recommendation_id = %(rid)s
+                    """,
+                    {
+                        "sl": evaluation.stop_loss_rate,
+                        "tp": evaluation.take_profit_rate,
+                        "verdict": evaluation.verdict,
+                        "rationale": evaluation.rationale,
+                        "rid": rec_id,
+                    },
+                )
+            conn.commit()
+            re_proposed += 1
+            logger.info(
+                "deferred_retry: rec=%d re-proposed (verdict=pass, sl=%s, tp=%s)",
+                rec_id,
+                evaluation.stop_loss_rate,
+                evaluation.take_profit_rate,
+            )
+        else:
+            # Still unfavorable — increment retry count, stay deferred
+            with conn.transaction():
+                conn.execute(
+                    """
+                    INSERT INTO decision_audit
+                        (decision_time, instrument_id, recommendation_id,
+                         stage, pass_fail, explanation, evidence_json)
+                    VALUES
+                        (NOW(), %(iid)s, %(rid)s,
+                         'deferred_retry', 'DEFER', %(expl)s, %(ev)s)
+                    """,
+                    {
+                        "iid": instrument_id,
+                        "rid": rec_id,
+                        "expl": evaluation.rationale,
+                        "ev": Jsonb(evaluation.condition_details),
+                    },
+                )
+                conn.execute(
+                    """
+                    UPDATE trade_recommendations
+                    SET timing_retry_count = timing_retry_count + 1,
+                        stop_loss_rate = %(sl)s,
+                        take_profit_rate = %(tp)s,
+                        timing_verdict = %(verdict)s,
+                        timing_rationale = %(rationale)s
+                    WHERE recommendation_id = %(rid)s
+                    """,
+                    {
+                        "sl": evaluation.stop_loss_rate,
+                        "tp": evaluation.take_profit_rate,
+                        "verdict": evaluation.verdict,
+                        "rationale": evaluation.rationale,
+                        "rid": rec_id,
+                    },
+                )
+            conn.commit()
+            re_deferred += 1
+            logger.info(
+                "deferred_retry: rec=%d still deferred (retry_count=%d, verdict=%s)",
+                rec_id,
+                retry_count + 1,
+                evaluation.verdict,
+            )
+
+    return RetryResult(
+        retried=retried,
+        re_proposed=re_proposed,
+        re_deferred=re_deferred,
+        expired=expired,
+        errors=errors,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_deferred_retry.py -v`
+Expected: 5 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/deferred_retry.py tests/test_deferred_retry.py
+git commit -m "feat(#205): deferred retry service — re-evaluate timing_deferred recs"
+```
+
+---
+
+## Task 3: Position monitoring service
+
+**Files:**
+- Create: `app/services/position_monitor.py`
+- Test: `tests/test_position_monitor.py`
+
+### Step-by-step
+
+- [ ] **Step 1: Write the failing test — position monitor detects SL hit**
+
+```python
+"""Tests for app.services.position_monitor."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.position_monitor import (
+    MonitorAlert,
+    MonitorResult,
+    check_position_health,
+)
+
+
+def _mock_conn() -> MagicMock:
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value = MagicMock()
+    conn.transaction.return_value.__enter__ = MagicMock()
+    conn.transaction.return_value.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+class TestCheckPositionHealth:
+    """Tests for the check_position_health service function."""
+
+    def test_no_open_positions_returns_empty(self) -> None:
+        conn = _mock_conn()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        cursor.fetchall.return_value = []
+
+        result = check_position_health(conn)
+
+        assert result.positions_checked == 0
+        assert result.alerts == []
+
+    def test_position_below_stop_loss_generates_alert(self) -> None:
+        """When current price < SL rate, an alert is generated."""
+        conn = _mock_conn()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        cursor.fetchall.return_value = [
+            {
+                "instrument_id": 100,
+                "symbol": "AAPL",
+                "current_units": Decimal("10"),
+                "stop_loss_rate": Decimal("140.00"),
+                "take_profit_rate": Decimal("200.00"),
+                "latest_bid": Decimal("135.00"),
+                "latest_ask": Decimal("135.50"),
+                "red_flag_score": Decimal("0.30"),
+            },
+        ]
+
+        result = check_position_health(conn)
+
+        assert result.positions_checked == 1
+        assert len(result.alerts) == 1
+        assert result.alerts[0].alert_type == "sl_breach"
+        assert result.alerts[0].instrument_id == 100
+
+    def test_position_above_take_profit_generates_alert(self) -> None:
+        """When current price >= TP rate, an alert is generated."""
+        conn = _mock_conn()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        cursor.fetchall.return_value = [
+            {
+                "instrument_id": 100,
+                "symbol": "AAPL",
+                "current_units": Decimal("10"),
+                "stop_loss_rate": Decimal("140.00"),
+                "take_profit_rate": Decimal("200.00"),
+                "latest_bid": Decimal("205.00"),
+                "latest_ask": Decimal("205.50"),
+                "red_flag_score": Decimal("0.30"),
+            },
+        ]
+
+        result = check_position_health(conn)
+
+        assert result.positions_checked == 1
+        assert len(result.alerts) == 1
+        assert result.alerts[0].alert_type == "tp_breach"
+
+    def test_position_with_high_red_flag_generates_thesis_break_alert(self) -> None:
+        """When red_flag_score >= 0.80, a thesis_break alert is generated."""
+        conn = _mock_conn()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        cursor.fetchall.return_value = [
+            {
+                "instrument_id": 100,
+                "symbol": "AAPL",
+                "current_units": Decimal("10"),
+                "stop_loss_rate": Decimal("140.00"),
+                "take_profit_rate": Decimal("200.00"),
+                "latest_bid": Decimal("160.00"),
+                "latest_ask": Decimal("160.50"),
+                "red_flag_score": Decimal("0.85"),
+            },
+        ]
+
+        result = check_position_health(conn)
+
+        assert result.positions_checked == 1
+        assert len(result.alerts) == 1
+        assert result.alerts[0].alert_type == "thesis_break"
+
+    def test_healthy_position_generates_no_alert(self) -> None:
+        """Price within SL/TP range and low red flag → no alert."""
+        conn = _mock_conn()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        cursor.fetchall.return_value = [
+            {
+                "instrument_id": 100,
+                "symbol": "AAPL",
+                "current_units": Decimal("10"),
+                "stop_loss_rate": Decimal("140.00"),
+                "take_profit_rate": Decimal("200.00"),
+                "latest_bid": Decimal("160.00"),
+                "latest_ask": Decimal("160.50"),
+                "red_flag_score": Decimal("0.30"),
+            },
+        ]
+
+        result = check_position_health(conn)
+
+        assert result.positions_checked == 1
+        assert result.alerts == []
+
+    def test_null_sl_tp_does_not_crash(self) -> None:
+        """Positions without SL/TP (pre-migration) should not generate SL/TP alerts."""
+        conn = _mock_conn()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        cursor.fetchall.return_value = [
+            {
+                "instrument_id": 100,
+                "symbol": "AAPL",
+                "current_units": Decimal("10"),
+                "stop_loss_rate": None,
+                "take_profit_rate": None,
+                "latest_bid": Decimal("160.00"),
+                "latest_ask": Decimal("160.50"),
+                "red_flag_score": None,
+            },
+        ]
+
+        result = check_position_health(conn)
+
+        assert result.positions_checked == 1
+        assert result.alerts == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_position_monitor.py -v`
+Expected: FAIL (module not found)
+
+- [ ] **Step 3: Write the position monitoring service**
+
+```python
+"""Intraday position monitoring service.
+
+Provides lightweight position health checks between daily broker sync
+cycles. Detects:
+  - SL breaches: current bid < stop_loss_rate
+  - TP breaches: current bid >= take_profit_rate
+  - Thesis breaks: red_flag_score >= EXIT_RED_FLAG_THRESHOLD
+
+Does NOT place orders. Generates alerts that the scheduler logs and
+(in future) could trigger an out-of-cycle EXIT recommendation.
+
+Design choices:
+  - Uses latest quotes from the quotes table (refreshed hourly by
+    fx_rates_refresh). No broker API call in the monitor itself.
+  - Checks broker_positions for per-position SL/TP (most accurate).
+  - Falls back to positions table if no broker_positions data exists
+    (pre-migration positions without SL/TP).
+  - NULL SL/TP/red_flag = skip that check (never block on missing data,
+    matching entry_timing convention).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+import psycopg.rows
+
+logger = logging.getLogger(__name__)
+
+# Reuse the portfolio manager's red flag threshold (settled decision).
+EXIT_RED_FLAG_THRESHOLD = Decimal("0.80")
+
+AlertType = Literal["sl_breach", "tp_breach", "thesis_break"]
+
+
+@dataclass(frozen=True)
+class MonitorAlert:
+    """A single position health alert."""
+
+    instrument_id: int
+    symbol: str
+    alert_type: AlertType
+    detail: str
+    current_bid: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class MonitorResult:
+    """Summary of a position monitoring run."""
+
+    positions_checked: int
+    alerts: list[MonitorAlert] = field(default_factory=list)
+
+
+def check_position_health(conn: psycopg.Connection[Any]) -> MonitorResult:
+    """Check all open positions for SL/TP breaches and thesis breaks.
+
+    Queries open positions joined with latest quotes and the most recent
+    thesis red_flag_score. Returns alerts for any breaches detected.
+
+    This is a read-only operation — no state mutations.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT
+                p.instrument_id,
+                i.symbol,
+                p.current_units,
+                bp.stop_loss_rate,
+                bp.take_profit_rate,
+                q.bid AS latest_bid,
+                q.ask AS latest_ask,
+                t.red_flag_score
+            FROM positions p
+            JOIN instruments i ON i.instrument_id = p.instrument_id
+            LEFT JOIN LATERAL (
+                SELECT stop_loss_rate, take_profit_rate
+                FROM broker_positions
+                WHERE instrument_id = p.instrument_id
+                ORDER BY updated_at DESC
+                LIMIT 1
+            ) bp ON TRUE
+            LEFT JOIN LATERAL (
+                SELECT bid, ask
+                FROM quotes
+                WHERE instrument_id = p.instrument_id
+                ORDER BY quoted_at DESC
+                LIMIT 1
+            ) q ON TRUE
+            LEFT JOIN LATERAL (
+                SELECT red_flag_score
+                FROM theses
+                WHERE instrument_id = p.instrument_id
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) t ON TRUE
+            WHERE p.current_units > 0
+            ORDER BY p.instrument_id
+            """,
+        )
+        positions = cur.fetchall()
+
+    alerts: list[MonitorAlert] = []
+
+    for pos in positions:
+        instrument_id: int = pos["instrument_id"]
+        symbol: str = pos["symbol"]
+        sl = pos["stop_loss_rate"]
+        tp = pos["take_profit_rate"]
+        bid = pos["latest_bid"]
+        red_flag = pos["red_flag_score"]
+
+        # SL breach: current bid < stop_loss_rate
+        if sl is not None and bid is not None and bid < sl:
+            alerts.append(
+                MonitorAlert(
+                    instrument_id=instrument_id,
+                    symbol=symbol,
+                    alert_type="sl_breach",
+                    detail=f"bid={bid} < sl={sl}",
+                    current_bid=bid,
+                )
+            )
+
+        # TP breach: current bid >= take_profit_rate
+        if tp is not None and bid is not None and bid >= tp:
+            alerts.append(
+                MonitorAlert(
+                    instrument_id=instrument_id,
+                    symbol=symbol,
+                    alert_type="tp_breach",
+                    detail=f"bid={bid} >= tp={tp}",
+                    current_bid=bid,
+                )
+            )
+
+        # Thesis break: red_flag_score >= threshold
+        if red_flag is not None and red_flag >= EXIT_RED_FLAG_THRESHOLD:
+            alerts.append(
+                MonitorAlert(
+                    instrument_id=instrument_id,
+                    symbol=symbol,
+                    alert_type="thesis_break",
+                    detail=f"red_flag={red_flag} >= {EXIT_RED_FLAG_THRESHOLD}",
+                    current_bid=bid,
+                )
+            )
+
+    return MonitorResult(
+        positions_checked=len(positions),
+        alerts=alerts,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_position_monitor.py -v`
+Expected: 6 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/position_monitor.py tests/test_position_monitor.py
+git commit -m "feat(#205): position monitor service — intraday SL/TP/thesis break detection"
+```
+
+---
+
+## Task 4: Wire scheduler — deferred retry job
+
+**Files:**
+- Modify: `app/workers/scheduler.py` (add job constant, ScheduledJob entry, job function)
+- Test: `tests/test_scheduler_autonomous.py`
+
+### Step-by-step
+
+- [ ] **Step 1: Write the failing test — scheduler job invokes retry service**
+
+```python
+"""Tests for autonomous operation loop scheduler jobs."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestRetryDeferredRecommendationsJob:
+    """Tests for the retry_deferred_recommendations scheduler job."""
+
+    @patch("app.workers.scheduler.psycopg.connect")
+    @patch("app.workers.scheduler.retry_deferred_recommendations")
+    @patch("app.workers.scheduler.record_job_start", return_value=1)
+    @patch("app.workers.scheduler.record_job_finish")
+    @patch("app.workers.scheduler.check_row_count_spike")
+    def test_job_calls_retry_service(
+        self,
+        mock_spike: MagicMock,
+        mock_finish: MagicMock,
+        mock_start: MagicMock,
+        mock_retry: MagicMock,
+        mock_connect: MagicMock,
+    ) -> None:
+        from app.services.deferred_retry import RetryResult
+        from app.workers.scheduler import retry_deferred_recommendations_job
+
+        mock_retry.return_value = RetryResult(
+            retried=2, re_proposed=1, re_deferred=1, expired=0, errors=0
+        )
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_spike.return_value = MagicMock(flagged=False)
+
+        retry_deferred_recommendations_job()
+
+        mock_retry.assert_called_once()
+
+    @patch("app.workers.scheduler.psycopg.connect")
+    @patch("app.workers.scheduler.retry_deferred_recommendations")
+    @patch("app.workers.scheduler.record_job_start", return_value=1)
+    @patch("app.workers.scheduler.record_job_finish")
+    @patch("app.workers.scheduler.check_row_count_spike")
+    def test_job_checks_kill_switch(
+        self,
+        mock_spike: MagicMock,
+        mock_finish: MagicMock,
+        mock_start: MagicMock,
+        mock_retry: MagicMock,
+        mock_connect: MagicMock,
+    ) -> None:
+        """Job must check kill switch before proceeding."""
+        from app.workers.scheduler import retry_deferred_recommendations_job
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_spike.return_value = MagicMock(flagged=False)
+
+        # Simulate kill switch active
+        with patch("app.workers.scheduler.load_runtime_config") as mock_config:
+            mock_config.return_value = MagicMock(
+                kill_switch_active=True,
+                enable_auto_trading=True,
+            )
+            from app.services.deferred_retry import RetryResult
+
+            mock_retry.return_value = RetryResult(
+                retried=0, re_proposed=0, re_deferred=0, expired=0, errors=0
+            )
+            retry_deferred_recommendations_job()
+
+        # When kill switch is active, retry service should NOT be called
+        mock_retry.assert_not_called()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_scheduler_autonomous.py -v`
+Expected: FAIL (import error — function doesn't exist yet)
+
+- [ ] **Step 3: Add job constant, import, and ScheduledJob entry**
+
+In `app/workers/scheduler.py`, add the job name constant alongside the existing ones (around line 177):
+
+```python
+JOB_RETRY_DEFERRED = "retry_deferred_recommendations"
+```
+
+Add the import at the top (around line 46):
+
+```python
+from app.services.deferred_retry import retry_deferred_recommendations
+```
+
+Add the ScheduledJob entry in SCHEDULED_JOBS (after the `execute_approved_orders` entry, before `weekly_coverage_review`):
+
+```python
+ScheduledJob(
+    name=JOB_RETRY_DEFERRED,
+    description="Re-evaluate timing_deferred recommendations with fresh TA data.",
+    cadence=Cadence.hourly(minute=30),
+    prerequisite=_has_deferred_recommendations,
+    catch_up_on_boot=False,
+),
+```
+
+Add the prerequisite function (after `_has_actionable_recommendations`):
+
+```python
+def _has_deferred_recommendations(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if at least one timing_deferred BUY/ADD recommendation exists."""
+    if _exists(
+        conn,
+        psycopg.sql.SQL(
+            "SELECT EXISTS(SELECT 1 FROM trade_recommendations "
+            "WHERE status = 'timing_deferred' AND action IN ('BUY', 'ADD'))"
+        ),
+    ):
+        return (True, "")
+    return (False, "no timing_deferred BUY/ADD recommendations")
+```
+
+- [ ] **Step 4: Add the `load_runtime_config` import and write the job function**
+
+Import `load_runtime_config` (check existing imports first — it may already be imported).
+
+Add the job function (after `execute_approved_orders`):
+
+```python
+def retry_deferred_recommendations_job() -> None:
+    """Re-evaluate timing_deferred recommendations hourly.
+
+    Checks kill switch and auto-trading flag before proceeding.
+    Deferred recs that now pass timing are transitioned to 'proposed'
+    so they enter the next execute_approved_orders cycle.
+    """
+    from app.services.runtime_config import load_runtime_config
+
+    with _tracked_job(JOB_RETRY_DEFERRED) as tracker:
+        # Safety gate: kill switch + auto-trading check
+        try:
+            with psycopg.connect(settings.database_url) as conn:
+                config = load_runtime_config(conn)
+        except Exception:
+            logger.error("retry_deferred: failed to load runtime config", exc_info=True)
+            tracker.row_count = 0
+            return
+
+        if config.kill_switch_active:
+            logger.warning("retry_deferred: kill switch active, skipping")
+            tracker.row_count = 0
+            return
+
+        if not config.enable_auto_trading:
+            logger.info("retry_deferred: auto_trading disabled, skipping")
+            tracker.row_count = 0
+            return
+
+        try:
+            with psycopg.connect(settings.database_url) as conn:
+                result = retry_deferred_recommendations(conn)
+        except Exception:
+            logger.error("retry_deferred: service call failed", exc_info=True)
+            tracker.row_count = 0
+            return
+
+        tracker.row_count = result.retried + result.expired + result.errors
+        logger.info(
+            "retry_deferred: retried=%d re_proposed=%d re_deferred=%d expired=%d errors=%d",
+            result.retried,
+            result.re_proposed,
+            result.re_deferred,
+            result.expired,
+            result.errors,
+        )
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/test_scheduler_autonomous.py -v`
+Expected: PASSED
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/workers/scheduler.py tests/test_scheduler_autonomous.py
+git commit -m "feat(#205): retry_deferred_recommendations scheduler job — hourly deferred rec retry"
+```
+
+---
+
+## Task 5: Wire scheduler — position monitoring job
+
+**Files:**
+- Modify: `app/workers/scheduler.py` (add job constant, ScheduledJob entry, job function)
+- Modify: `tests/test_scheduler_autonomous.py` (add monitor job tests)
+
+### Step-by-step
+
+- [ ] **Step 1: Write the failing test — position monitor job**
+
+Append to `tests/test_scheduler_autonomous.py`:
+
+```python
+class TestMonitorPositionsJob:
+    """Tests for the monitor_positions scheduler job."""
+
+    @patch("app.workers.scheduler.psycopg.connect")
+    @patch("app.workers.scheduler.check_position_health")
+    @patch("app.workers.scheduler.record_job_start", return_value=1)
+    @patch("app.workers.scheduler.record_job_finish")
+    @patch("app.workers.scheduler.check_row_count_spike")
+    def test_job_calls_monitor_service(
+        self,
+        mock_spike: MagicMock,
+        mock_finish: MagicMock,
+        mock_start: MagicMock,
+        mock_monitor: MagicMock,
+        mock_connect: MagicMock,
+    ) -> None:
+        from app.services.position_monitor import MonitorResult
+        from app.workers.scheduler import monitor_positions_job
+
+        mock_monitor.return_value = MonitorResult(positions_checked=5, alerts=[])
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_spike.return_value = MagicMock(flagged=False)
+
+        monitor_positions_job()
+
+        mock_monitor.assert_called_once()
+
+    @patch("app.workers.scheduler.psycopg.connect")
+    @patch("app.workers.scheduler.check_position_health")
+    @patch("app.workers.scheduler.record_job_start", return_value=1)
+    @patch("app.workers.scheduler.record_job_finish")
+    @patch("app.workers.scheduler.check_row_count_spike")
+    def test_job_logs_alerts(
+        self,
+        mock_spike: MagicMock,
+        mock_finish: MagicMock,
+        mock_start: MagicMock,
+        mock_monitor: MagicMock,
+        mock_connect: MagicMock,
+    ) -> None:
+        from app.services.position_monitor import MonitorAlert, MonitorResult
+        from app.workers.scheduler import monitor_positions_job
+
+        mock_monitor.return_value = MonitorResult(
+            positions_checked=1,
+            alerts=[
+                MonitorAlert(
+                    instrument_id=100,
+                    symbol="AAPL",
+                    alert_type="sl_breach",
+                    detail="bid=135 < sl=140",
+                ),
+            ],
+        )
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_spike.return_value = MagicMock(flagged=False)
+
+        # Should not raise — alerts are logged, not acted upon
+        monitor_positions_job()
+
+        mock_monitor.assert_called_once()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_scheduler_autonomous.py::TestMonitorPositionsJob -v`
+Expected: FAIL (import error)
+
+- [ ] **Step 3: Add job constant and ScheduledJob entry**
+
+In `app/workers/scheduler.py`, add the job name constant:
+
+```python
+JOB_MONITOR_POSITIONS = "monitor_positions"
+```
+
+Add the import:
+
+```python
+from app.services.position_monitor import check_position_health
+```
+
+Add the ScheduledJob entry (after retry_deferred, before weekly_coverage_review):
+
+```python
+ScheduledJob(
+    name=JOB_MONITOR_POSITIONS,
+    description="Check open positions for SL/TP breaches and thesis breaks.",
+    cadence=Cadence.hourly(minute=15),
+    prerequisite=_has_open_positions,
+    catch_up_on_boot=False,
+),
+```
+
+Add the prerequisite function:
+
+```python
+def _has_open_positions(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if at least one open position exists."""
+    if _exists(
+        conn,
+        psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM positions WHERE current_units > 0)"),
+    ):
+        return (True, "")
+    return (False, "no open positions")
+```
+
+- [ ] **Step 4: Write the job function**
+
+```python
+def monitor_positions_job() -> None:
+    """Hourly position health check.
+
+    Detects SL/TP breaches and thesis breaks between daily sync cycles.
+    Alerts are logged for now; future work may trigger out-of-cycle
+    EXIT recommendations or operator notifications.
+
+    Read-only — does not place orders or modify positions.
+    """
+    with _tracked_job(JOB_MONITOR_POSITIONS) as tracker:
+        try:
+            with psycopg.connect(settings.database_url) as conn:
+                result = check_position_health(conn)
+        except Exception:
+            logger.error("monitor_positions: health check failed", exc_info=True)
+            tracker.row_count = 0
+            return
+
+        tracker.row_count = result.positions_checked
+
+        if result.alerts:
+            for alert in result.alerts:
+                logger.warning(
+                    "monitor_positions: ALERT %s on %s (instrument_id=%d): %s",
+                    alert.alert_type,
+                    alert.symbol,
+                    alert.instrument_id,
+                    alert.detail,
+                )
+        else:
+            logger.info(
+                "monitor_positions: %d positions checked, no alerts",
+                result.positions_checked,
+            )
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/test_scheduler_autonomous.py -v`
+Expected: All PASSED
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/workers/scheduler.py tests/test_scheduler_autonomous.py
+git commit -m "feat(#205): monitor_positions scheduler job — hourly intraday position health check"
+```
+
+---
+
+## Task 6: Pipeline triggers — stamp `timing_deferred_at` on first deferral
+
+**Files:**
+- Modify: `app/workers/scheduler.py` (Phase 0 in `execute_approved_orders`)
+
+### Step-by-step
+
+- [ ] **Step 1: Write the failing test — timing_deferred_at is set on deferral**
+
+Append to `tests/test_scheduler_autonomous.py`:
+
+```python
+class TestTimingDeferredAtStamp:
+    """Verify that Phase 0 stamps timing_deferred_at on first deferral."""
+
+    def test_deferred_at_column_set_in_update_sql(self) -> None:
+        """The Phase 0 defer UPDATE must include timing_deferred_at = NOW()."""
+        import inspect
+        from app.workers.scheduler import execute_approved_orders
+
+        source = inspect.getsource(execute_approved_orders)
+        # The defer path that sets status='timing_deferred' must also set
+        # timing_deferred_at. We check for it in the SQL string.
+        assert "timing_deferred_at" in source, (
+            "execute_approved_orders must stamp timing_deferred_at when deferring"
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_scheduler_autonomous.py::TestTimingDeferredAtStamp -v`
+Expected: FAIL (timing_deferred_at not in source)
+
+- [ ] **Step 3: Modify the Phase 0 defer UPDATE in `execute_approved_orders`**
+
+In `scheduler.py` around line 1181, the UPDATE that sets `status = 'timing_deferred'` needs an additional column:
+
+Change:
+```sql
+UPDATE trade_recommendations
+SET status = 'timing_deferred',
+    stop_loss_rate = %(sl)s,
+    take_profit_rate = %(tp)s,
+    timing_verdict = %(verdict)s,
+    timing_rationale = %(rationale)s
+WHERE recommendation_id = %(rid)s
+```
+
+To:
+```sql
+UPDATE trade_recommendations
+SET status = 'timing_deferred',
+    stop_loss_rate = %(sl)s,
+    take_profit_rate = %(tp)s,
+    timing_verdict = %(verdict)s,
+    timing_rationale = %(rationale)s,
+    timing_deferred_at = COALESCE(timing_deferred_at, NOW())
+WHERE recommendation_id = %(rid)s
+```
+
+Similarly update the `_timing_error_defer` helper function (around line 1062) to also stamp `timing_deferred_at`:
+
+Change:
+```sql
+UPDATE trade_recommendations
+SET status = 'timing_deferred',
+    timing_verdict = 'error',
+    timing_rationale = %(rationale)s
+WHERE recommendation_id = %(rid)s
+```
+
+To:
+```sql
+UPDATE trade_recommendations
+SET status = 'timing_deferred',
+    timing_verdict = 'error',
+    timing_rationale = %(rationale)s,
+    timing_deferred_at = COALESCE(timing_deferred_at, NOW())
+WHERE recommendation_id = %(rid)s
+```
+
+The `COALESCE` ensures that if a rec is deferred multiple times (error → re-proposed → deferred again), the original deferral timestamp is preserved.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_scheduler_autonomous.py::TestTimingDeferredAtStamp -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite to verify no regressions**
+
+Run: `uv run pytest -v`
+Expected: All PASSED
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/workers/scheduler.py tests/test_scheduler_autonomous.py
+git commit -m "feat(#205): stamp timing_deferred_at on first deferral for retry expiry tracking"
+```
+
+---
+
+## Task 7: Pipeline triggers — chain morning jobs
+
+**Files:**
+- Modify: `app/workers/scheduler.py` (add post-completion trigger hooks)
+
+### Step-by-step
+
+- [ ] **Step 1: Write the test — morning_candidate_review triggers execute_approved_orders**
+
+Append to `tests/test_scheduler_autonomous.py`:
+
+```python
+class TestPipelineTriggers:
+    """Verify that completed pipeline stages trigger downstream jobs."""
+
+    def test_morning_candidate_review_triggers_execution(self) -> None:
+        """After morning_candidate_review produces recs, it should
+        log a pipeline trigger for execute_approved_orders."""
+        import inspect
+        from app.workers.scheduler import morning_candidate_review
+
+        source = inspect.getsource(morning_candidate_review)
+        # The function must contain a trigger/invocation of execute_approved_orders
+        assert "execute_approved_orders" in source, (
+            "morning_candidate_review should trigger execute_approved_orders after producing recs"
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_scheduler_autonomous.py::TestPipelineTriggers -v`
+Expected: FAIL (`execute_approved_orders` not in `morning_candidate_review` source)
+
+- [ ] **Step 3: Add pipeline trigger to `morning_candidate_review`**
+
+At the end of `morning_candidate_review()`, after the logging of recommendations, add a direct invocation:
+
+```python
+# --- Pipeline trigger: if recs were generated, run the execution pipeline ---
+actionable_count = sum(
+    1 for r in rec_result.recommendations if r.action in ("BUY", "ADD", "EXIT")
+)
+if actionable_count > 0:
+    logger.info(
+        "morning_candidate_review: %d actionable recs → triggering execute_approved_orders",
+        actionable_count,
+    )
+    try:
+        execute_approved_orders()
+    except Exception:
+        logger.error(
+            "morning_candidate_review: pipeline trigger to execute_approved_orders failed",
+            exc_info=True,
+        )
+```
+
+This replaces the need for a separate cron trigger — when the morning review produces actionable recommendations, execution runs immediately as a pipeline stage rather than waiting for the 06:30 cron. The 06:30 cron remains as a catch-all for approved recs from other sources (e.g., manual approval via API).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_scheduler_autonomous.py::TestPipelineTriggers -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: All PASSED
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/workers/scheduler.py tests/test_scheduler_autonomous.py
+git commit -m "feat(#205): pipeline trigger — morning_candidate_review chains execute_approved_orders"
+```
+
+---
+
+## Task 8: Add `timing_expired` to status CHECK constraint
+
+**Files:**
+- Modify: `sql/028_autonomous_loop.sql`
+
+### Step-by-step
+
+- [ ] **Step 1: Check existing CHECK constraint on `trade_recommendations.status`**
+
+Search for any existing CHECK constraint on the status column. If none exists (the init schema uses bare TEXT), add one. If one exists, expand it.
+
+- [ ] **Step 2: Add the constraint update to the migration**
+
+Append to `sql/028_autonomous_loop.sql`:
+
+```sql
+-- Add timing_expired to the status vocabulary.
+-- No existing CHECK constraint on status (001_init.sql uses bare TEXT),
+-- so we add one now for the expanded set used by the autonomous loop.
+-- Wrapped in DO $$ for idempotency.
+DO $$
+BEGIN
+    ALTER TABLE trade_recommendations
+        DROP CONSTRAINT IF EXISTS chk_recommendation_status;
+    ALTER TABLE trade_recommendations
+        ADD CONSTRAINT chk_recommendation_status
+        CHECK (status IN (
+            'proposed', 'approved', 'rejected', 'executed',
+            'execution_failed', 'timing_deferred', 'timing_expired',
+            'cancelled'
+        ));
+END $$;
+```
+
+- [ ] **Step 3: Re-apply migration**
+
+Run: `uv run python -c "import psycopg; conn = psycopg.connect('$(grep DATABASE_URL .env | cut -d= -f2-)'); conn.execute(open('sql/028_autonomous_loop.sql').read()); conn.commit(); print('OK')"`
+Expected: OK
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sql/028_autonomous_loop.sql
+git commit -m "feat(#205): add timing_expired to status CHECK constraint"
+```
+
+---
+
+## Task 9: Register new jobs in runtime.py invokers
+
+**Files:**
+- Modify: `app/jobs/runtime.py` (add new jobs to `_INVOKERS` dict)
+
+### Step-by-step
+
+- [ ] **Step 1: Read current runtime.py to understand the invoker pattern**
+
+Read `app/jobs/runtime.py` to find the `_INVOKERS` dict and registration pattern.
+
+- [ ] **Step 2: Add new job invokers**
+
+Add entries for the two new jobs:
+
+```python
+JOB_RETRY_DEFERRED: retry_deferred_recommendations_job,
+JOB_MONITOR_POSITIONS: monitor_positions_job,
+```
+
+Import the necessary names from `app.workers.scheduler`.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: All PASSED
+
+- [ ] **Step 4: Run linting and type checks**
+
+Run: `uv run ruff check . && uv run ruff format --check . && uv run pyright`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/jobs/runtime.py
+git commit -m "feat(#205): register retry_deferred and monitor_positions in job runtime"
+```
+
+---
+
+## Task 10: Pre-push checks and PR
+
+- [ ] **Step 1: Run full pre-push checklist**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+All four must pass.
+
+- [ ] **Step 2: Fix any failures**
+
+Address lint, format, type, or test errors.
+
+- [ ] **Step 3: Self-review the diff**
+
+Read `.claude/skills/engineering/pre-flight-review.md` and run through the checklist against the full diff.
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push -u origin feature/205-autonomous-operation-loop
+gh pr create --title "feat(#205): autonomous operation loop" --body "..."
+```
+
+- [ ] **Step 5: Wait for review and CI, resolve comments**
+
+Poll `gh pr view <n> --comments` and `gh pr checks <n>` until review posts and CI is green.
+
+---
+
+## What this PR does NOT include (conscious deferrals)
+
+These are explicitly out of scope for this PR and should be tracked as follow-up issues:
+
+1. **Automated EXIT from position monitor alerts** — The monitor detects breaches and logs them, but does not auto-generate EXIT recommendations. This requires careful design around the execution guard's re-check rule and the operator's approval posture. Track as a follow-up issue.
+
+2. **Event-driven pipeline triggers beyond morning chain** — Only the morning_candidate_review → execute_approved_orders chain is implemented. Research → score → rank triggers are deferred because the research jobs are expensive and their cadence should remain operator-controlled.
+
+3. **Operator notification on alerts** — Position monitor alerts are logged only. Slack/email/webhook notifications require infrastructure not yet built.
+
+4. **Retry of re-proposed recs through guard+execute** — When a deferred rec is re-proposed, it waits for the next `execute_approved_orders` cycle (either the pipeline trigger from morning review or the 06:30 cron). An immediate guard+execute chain from the retry job is deferred to keep the retry job lightweight and read-mostly.

--- a/docs/superpowers/plans/2026-04-15-budget-capital-management.md
+++ b/docs/superpowers/plans/2026-04-15-budget-capital-management.md
@@ -1,0 +1,1758 @@
+# Budget and Capital Management Service — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give eBull a working-budget concept — track capital deposits/withdrawals, provision estimated tax liability, enforce a cash buffer, and expose "available for deployment" to the execution guard and dashboard.
+
+**Architecture:** Pure service module (`budget.py`) that computes budget state on the fly from existing tables (`cash_ledger`, `positions`, `disposal_matches`, `live_fx_rates`) plus two new tables (`capital_events`, `budget_config`). No materialized views, no scheduler job — budget state is computed fresh on every read. The execution guard replaces its raw `cash > 0` check with `available_for_deployment > 0`.
+
+**Tech Stack:** Python 3.12, psycopg 3, FastAPI, PostgreSQL, Pydantic, pytest
+
+---
+
+## Settled Decisions That Apply
+
+| Decision | How this plan preserves it |
+|----------|--------------------------|
+| **Cash semantics** (positive = inflow, negative = outflow) | Budget service reads `SUM(cash_ledger.amount)` unchanged; capital_events uses its own sign convention (always positive, type implies direction) to avoid confusion. |
+| **Unknown cash rule** (empty ledger blocks execution, not recs) | Budget service returns `cash_balance=None` when ledger is empty; execution guard fails closed on `None`. |
+| **AUM basis** (MTM first, cost basis fallback) | `deployed_capital` computation reuses the `WHERE current_units > 0` + LATERAL quote join pattern from `portfolio.py`. |
+| **Guard auditability** (one decision_audit row per invocation) | Budget-aware check is a new rule in the existing rule list — evidence_json captures the budget snapshot. |
+| **Guard re-check rule** (re-check current state) | Budget state is computed fresh inside the guard, never cached. |
+| **Provider boundary** (thin providers, domain in services) | Budget is a pure service module — no HTTP client, no provider. |
+
+## Prevention Log Entries That Apply
+
+| Entry | How avoided |
+|-------|------------|
+| **Audit reads outside the write transaction** | `budget_config` audit rows written in same `conn.transaction()` as the UPDATE. |
+| **Mid-transaction conn.commit() in service functions** | `budget.py` functions accept caller connections, never call `conn.commit()`. |
+| **Zero-unit position inflates AUM** | Deployed capital query includes `WHERE current_units > 0`. |
+| **Dead-code None-guard on aggregate fetchone()** | `SUM()` always returns one row; None-guard is on the column value, not the row. |
+| **Single-row UPDATE silent no-op** | Budget config UPDATE checks `rowcount == 0` and raises. |
+| **Read-then-write outside transaction** | Config update reads old values and writes audit in one `conn.transaction()`. |
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `sql/027_budget_capital.sql` | Migration: `capital_events` table, `budget_config` singleton, `budget_config_audit` |
+| `app/services/budget.py` | Pure service: `BudgetState`, `BudgetConfig`, `compute_budget_state()`, `record_capital_event()`, `list_capital_events()`, `get_budget_config()`, `update_budget_config()` |
+| `tests/test_budget.py` | Unit tests for all budget service functions |
+| `app/api/budget.py` | API endpoints: GET /budget, POST /budget/events, GET /budget/events, PATCH /budget/config |
+| `app/services/execution_guard.py` | Modify: replace `_check_cash` with budget-aware `_check_budget` |
+| `tests/test_execution_guard.py` | Modify: update cash-check tests for budget-aware logic |
+| `app/main.py` | Modify: register budget router |
+
+## Scope Boundaries
+
+**In scope (this PR):**
+- Schema: `capital_events`, `budget_config`, `budget_config_audit`
+- Service: compute budget state, record/list capital events, get/update config
+- API: four endpoints for budget state and management
+- Execution guard: budget-aware BUY/ADD cash check
+- Tests: full unit coverage
+
+**Out of scope (deferred):**
+- Auto-detection of capital changes during broker sync → follow-up PR
+- Order client sizing from `available_for_deployment` → follow-up PR (guard is the enforcement point for now)
+- Fresh capital deployment strategy (wait 1-3 days) → #205 autonomous loop
+- Dashboard UI integration → separate frontend PR
+- Scheduler budget snapshot job → not needed (computed on the fly)
+
+---
+
+## Task 1: Migration 027 — Schema
+
+**Files:**
+- Create: `sql/027_budget_capital.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Migration 027: budget and capital management tables
+--
+-- capital_events: tracks operator deposits, withdrawals, and system tax provisions.
+--   amount is always positive; event_type implies direction (injection = inflow,
+--   withdrawal = outflow, tax_provision = reserved, tax_release = un-reserved).
+--
+-- budget_config: singleton (same pattern as runtime_config) with operator-
+--   configurable budget parameters.  Seeded with sensible defaults.
+--
+-- budget_config_audit: per-field audit trail for config changes.
+
+-- A. Capital events ledger
+CREATE TABLE IF NOT EXISTS capital_events (
+    event_id    BIGSERIAL PRIMARY KEY,
+    event_time  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    event_type  TEXT NOT NULL,
+    amount      NUMERIC(18,6) NOT NULL,
+    currency    TEXT NOT NULL DEFAULT 'USD',
+    source      TEXT NOT NULL DEFAULT 'operator',
+    note        TEXT,
+    created_by  TEXT
+);
+
+DO $$
+BEGIN
+    ALTER TABLE capital_events
+        DROP CONSTRAINT IF EXISTS chk_capital_event_type;
+    ALTER TABLE capital_events
+        ADD CONSTRAINT chk_capital_event_type
+        CHECK (event_type IN ('injection', 'withdrawal', 'tax_provision', 'tax_release'));
+END $$;
+
+DO $$
+BEGIN
+    ALTER TABLE capital_events
+        DROP CONSTRAINT IF EXISTS chk_capital_event_source;
+    ALTER TABLE capital_events
+        ADD CONSTRAINT chk_capital_event_source
+        CHECK (source IN ('operator', 'system', 'broker_sync'));
+END $$;
+
+-- Positive-amount invariant
+DO $$
+BEGIN
+    ALTER TABLE capital_events
+        DROP CONSTRAINT IF EXISTS chk_capital_event_amount_positive;
+    ALTER TABLE capital_events
+        ADD CONSTRAINT chk_capital_event_amount_positive
+        CHECK (amount > 0);
+END $$;
+
+-- B. Budget config singleton
+CREATE TABLE IF NOT EXISTS budget_config (
+    id               BOOLEAN PRIMARY KEY DEFAULT TRUE,
+    cash_buffer_pct  NUMERIC(5,4) NOT NULL DEFAULT 0.05,
+    cgt_scenario     TEXT NOT NULL DEFAULT 'higher',
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by       TEXT NOT NULL DEFAULT 'system',
+    reason           TEXT NOT NULL DEFAULT 'initial seed'
+);
+
+DO $$
+BEGIN
+    ALTER TABLE budget_config
+        DROP CONSTRAINT IF EXISTS chk_cgt_scenario;
+    ALTER TABLE budget_config
+        ADD CONSTRAINT chk_cgt_scenario
+        CHECK (cgt_scenario IN ('basic', 'higher'));
+END $$;
+
+DO $$
+BEGIN
+    ALTER TABLE budget_config
+        DROP CONSTRAINT IF EXISTS chk_cash_buffer_pct_range;
+    ALTER TABLE budget_config
+        ADD CONSTRAINT chk_cash_buffer_pct_range
+        CHECK (cash_buffer_pct >= 0 AND cash_buffer_pct <= 0.50);
+END $$;
+
+-- Singleton constraint: only id=TRUE allowed
+DO $$
+BEGIN
+    ALTER TABLE budget_config
+        DROP CONSTRAINT IF EXISTS chk_budget_config_singleton;
+    ALTER TABLE budget_config
+        ADD CONSTRAINT chk_budget_config_singleton
+        CHECK (id = TRUE);
+END $$;
+
+-- Seed the singleton row
+INSERT INTO budget_config (id) VALUES (TRUE) ON CONFLICT DO NOTHING;
+
+-- C. Budget config audit
+CREATE TABLE IF NOT EXISTS budget_config_audit (
+    audit_id    BIGSERIAL PRIMARY KEY,
+    changed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    changed_by  TEXT NOT NULL,
+    field       TEXT NOT NULL,
+    old_value   TEXT,
+    new_value   TEXT,
+    reason      TEXT
+);
+```
+
+- [ ] **Step 2: Run the migration against local dev DB**
+
+Run: `psql "$DATABASE_URL" -f sql/027_budget_capital.sql`
+Expected: no errors, tables created, singleton row seeded.
+
+- [ ] **Step 3: Verify idempotency**
+
+Run: `psql "$DATABASE_URL" -f sql/027_budget_capital.sql`
+Expected: no errors on second run (IF NOT EXISTS, ON CONFLICT DO NOTHING, DROP CONSTRAINT IF EXISTS).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sql/027_budget_capital.sql
+git commit -m "feat(#203): migration 027 — capital_events and budget_config tables"
+```
+
+---
+
+## Task 2: Budget Service — Types and Config
+
+**Files:**
+- Create: `app/services/budget.py`
+
+- [ ] **Step 1: Write the failing test for BudgetConfig loading**
+
+Create `tests/test_budget.py`:
+
+```python
+"""Tests for the budget and capital management service.
+
+Mock approach: mock psycopg.Connection with controlled cursor return values.
+Pattern matches test_entry_timing.py — _make_cursor() + _make_conn().
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import psycopg.rows
+
+from app.services.budget import BudgetConfig, BudgetConfigCorrupt, get_budget_config
+
+
+def _make_cursor(rows: list[dict] | None = None, single: dict | None = None) -> MagicMock:
+    """Build a mock cursor whose fetchone/fetchall return controlled values."""
+    cur = MagicMock()
+    if single is not None:
+        cur.execute.return_value.fetchone.return_value = single
+        cur.fetchone.return_value = single
+    if rows is not None:
+        cur.execute.return_value.fetchall.return_value = rows
+        cur.fetchall.return_value = rows
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    return cur
+
+
+def _make_conn(cursors: list[MagicMock]) -> MagicMock:
+    """Build a mock connection that yields cursors in order."""
+    conn = MagicMock()
+    conn.cursor.side_effect = cursors
+    return conn
+
+
+class TestGetBudgetConfig:
+    def test_returns_config_from_db(self) -> None:
+        cur = _make_cursor(single={
+            "cash_buffer_pct": Decimal("0.05"),
+            "cgt_scenario": "higher",
+            "updated_at": "2026-04-15T00:00:00+00:00",
+            "updated_by": "operator",
+            "reason": "initial seed",
+        })
+        conn = _make_conn([cur])
+
+        config = get_budget_config(conn)
+
+        assert config.cash_buffer_pct == Decimal("0.05")
+        assert config.cgt_scenario == "higher"
+
+    def test_raises_corrupt_when_row_missing(self) -> None:
+        cur = _make_cursor(single=None)
+        conn = _make_conn([cur])
+
+        import pytest
+        with pytest.raises(BudgetConfigCorrupt):
+            get_budget_config(conn)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_budget.py::TestGetBudgetConfig -v`
+Expected: FAIL — `ImportError: cannot import name 'BudgetConfig'`
+
+- [ ] **Step 3: Write the types and get_budget_config()**
+
+Create `app/services/budget.py`:
+
+```python
+"""Budget and capital management service.
+
+Computes the working budget — how much capital is available for deployment —
+from existing tables (cash_ledger, positions, disposal_matches, live_fx_rates)
+plus two new tables (capital_events, budget_config).
+
+Key concepts:
+  - working_budget = cash_balance + deployed_capital + mirror_equity
+  - available_for_deployment = cash_balance - estimated_tax_usd - cash_buffer_reserve
+  - cash_buffer_reserve = working_budget * cash_buffer_pct
+  - estimated_tax_usd = estimated CGT (from tax_year_summary) converted via live_fx_rates
+
+Design choices:
+  - Pure service module: reads DB, returns results. No side effects except
+    explicit write functions (record_capital_event, update_budget_config).
+  - Budget state is computed fresh on every read — no caching, no snapshots.
+  - capital_events.amount is always positive; event_type implies direction.
+  - budget_config is a singleton (same pattern as runtime_config).
+
+Issue #203.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+import psycopg.rows
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CapitalEventType = Literal["injection", "withdrawal", "tax_provision", "tax_release"]
+CapitalEventSource = Literal["operator", "system", "broker_sync"]
+CgtScenario = Literal["basic", "higher"]
+
+_ZERO = Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class BudgetConfigCorrupt(RuntimeError):
+    """Raised when the budget_config singleton row is missing.
+
+    Callers must fail closed — never default to unconstrained spending.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BudgetConfig:
+    cash_buffer_pct: Decimal
+    cgt_scenario: str  # 'basic' or 'higher'
+    updated_at: datetime
+    updated_by: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class BudgetState:
+    """Snapshot of the current budget position."""
+
+    # Observed values (USD)
+    cash_balance: Decimal | None  # None = ledger empty (unknown)
+    deployed_capital: Decimal     # SUM(cost_basis) for open positions
+    mirror_equity: Decimal        # from copy-trading mirrors
+
+    # Computed (USD)
+    working_budget: Decimal | None  # cash + deployed + mirrors; None if cash unknown
+
+    # Reservations (USD)
+    estimated_tax_gbp: Decimal    # from tax_year_summary
+    estimated_tax_usd: Decimal    # converted at latest GBP→USD rate
+    gbp_usd_rate: Decimal | None  # rate used for conversion; None if unavailable
+    cash_buffer_reserve: Decimal  # working_budget * cash_buffer_pct
+
+    # Bottom line (USD)
+    available_for_deployment: Decimal | None  # cash - tax - buffer; None if cash unknown
+
+    # Config echo
+    cash_buffer_pct: Decimal
+    cgt_scenario: str
+    tax_year: str
+
+
+@dataclass(frozen=True)
+class CapitalEvent:
+    """A single capital event row."""
+
+    event_id: int
+    event_time: datetime
+    event_type: str
+    amount: Decimal
+    currency: str
+    source: str
+    note: str | None
+    created_by: str | None
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def get_budget_config(conn: psycopg.Connection[Any]) -> BudgetConfig:
+    """Load the budget_config singleton.
+
+    Raises BudgetConfigCorrupt if the row is missing.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT cash_buffer_pct, cgt_scenario,
+                   updated_at, updated_by, reason
+            FROM budget_config
+            WHERE id = TRUE
+            """
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise BudgetConfigCorrupt("budget_config singleton row missing")
+    return BudgetConfig(
+        cash_buffer_pct=Decimal(str(row["cash_buffer_pct"])),
+        cgt_scenario=str(row["cgt_scenario"]),
+        updated_at=row["updated_at"],
+        updated_by=str(row["updated_by"]),
+        reason=str(row["reason"]),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_budget.py::TestGetBudgetConfig -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/budget.py tests/test_budget.py
+git commit -m "feat(#203): budget service types, BudgetConfig, get_budget_config()"
+```
+
+---
+
+## Task 3: Budget Service — update_budget_config()
+
+**Files:**
+- Modify: `app/services/budget.py`
+- Modify: `tests/test_budget.py`
+
+- [ ] **Step 1: Write the failing test for update_budget_config**
+
+Add to `tests/test_budget.py`:
+
+```python
+from app.services.budget import update_budget_config
+
+
+class TestUpdateBudgetConfig:
+    def test_updates_config_and_writes_audit(self) -> None:
+        """PATCH cash_buffer_pct: verify UPDATE + audit INSERT."""
+        # Current config
+        config_cur = _make_cursor(single={
+            "cash_buffer_pct": Decimal("0.05"),
+            "cgt_scenario": "higher",
+        })
+        # UPDATE result
+        update_cur = MagicMock()
+        update_cur.execute.return_value.rowcount = 1
+        update_cur.__enter__ = MagicMock(return_value=update_cur)
+        update_cur.__exit__ = MagicMock(return_value=False)
+        # Audit INSERT
+        audit_cur = MagicMock()
+        audit_cur.__enter__ = MagicMock(return_value=audit_cur)
+        audit_cur.__exit__ = MagicMock(return_value=False)
+
+        conn = _make_conn([config_cur, update_cur, audit_cur])
+        # Mock transaction context manager
+        conn.transaction.return_value.__enter__ = MagicMock()
+        conn.transaction.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = update_budget_config(
+            conn,
+            cash_buffer_pct=Decimal("0.08"),
+            updated_by="operator",
+            reason="increase buffer",
+        )
+
+        assert result.cash_buffer_pct == Decimal("0.08")
+
+    def test_raises_on_missing_singleton(self) -> None:
+        """UPDATE affects 0 rows → raise."""
+        config_cur = _make_cursor(single={
+            "cash_buffer_pct": Decimal("0.05"),
+            "cgt_scenario": "higher",
+        })
+        update_cur = MagicMock()
+        update_cur.execute.return_value.rowcount = 0
+        update_cur.__enter__ = MagicMock(return_value=update_cur)
+        update_cur.__exit__ = MagicMock(return_value=False)
+
+        conn = _make_conn([config_cur, update_cur])
+        conn.transaction.return_value.__enter__ = MagicMock()
+        conn.transaction.return_value.__exit__ = MagicMock(return_value=False)
+
+        import pytest
+        with pytest.raises(BudgetConfigCorrupt):
+            update_budget_config(
+                conn,
+                cash_buffer_pct=Decimal("0.08"),
+                updated_by="operator",
+                reason="test",
+            )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_budget.py::TestUpdateBudgetConfig -v`
+Expected: FAIL — `ImportError: cannot import name 'update_budget_config'`
+
+- [ ] **Step 3: Implement update_budget_config()**
+
+Add to `app/services/budget.py`:
+
+```python
+def update_budget_config(
+    conn: psycopg.Connection[Any],
+    *,
+    cash_buffer_pct: Decimal | None = None,
+    cgt_scenario: CgtScenario | None = None,
+    updated_by: str,
+    reason: str,
+) -> BudgetConfig:
+    """Partial update of budget_config with per-field audit trail.
+
+    At least one of cash_buffer_pct or cgt_scenario must be provided.
+    Reads old values, writes UPDATE + audit rows in one transaction.
+    Returns the new config state.
+
+    Raises BudgetConfigCorrupt if the singleton row is missing.
+    Raises ValueError if no fields are provided.
+    """
+    if cash_buffer_pct is None and cgt_scenario is None:
+        raise ValueError("at least one field must be provided")
+
+    now = datetime.now(tz=UTC)
+
+    with conn.transaction():
+        # Read current values inside the transaction (prevention: audit reads
+        # outside the write transaction).
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT cash_buffer_pct, cgt_scenario FROM budget_config WHERE id = TRUE"
+            )
+            old = cur.fetchone()
+        if old is None:
+            raise BudgetConfigCorrupt("budget_config singleton row missing")
+
+        # Build SET clause for changed fields only
+        changes: dict[str, tuple[str, str]] = {}  # field -> (old, new)
+        set_parts: list[str] = []
+        params: dict[str, Any] = {"by": updated_by, "reason": reason, "now": now}
+
+        if cash_buffer_pct is not None and Decimal(str(old["cash_buffer_pct"])) != cash_buffer_pct:
+            changes["cash_buffer_pct"] = (str(old["cash_buffer_pct"]), str(cash_buffer_pct))
+            set_parts.append("cash_buffer_pct = %(new_buffer)s")
+            params["new_buffer"] = cash_buffer_pct
+
+        if cgt_scenario is not None and str(old["cgt_scenario"]) != cgt_scenario:
+            changes["cgt_scenario"] = (str(old["cgt_scenario"]), cgt_scenario)
+            set_parts.append("cgt_scenario = %(new_cgt)s")
+            params["new_cgt"] = cgt_scenario
+
+        if not changes:
+            raise ValueError("no fields changed")
+
+        set_parts.append("updated_at = %(now)s")
+        set_parts.append("updated_by = %(by)s")
+        set_parts.append("reason = %(reason)s")
+
+        with conn.cursor() as cur:
+            result = cur.execute(
+                f"UPDATE budget_config SET {', '.join(set_parts)} WHERE id = TRUE",  # noqa: S608
+                params,
+            )
+            if result.rowcount == 0:
+                raise BudgetConfigCorrupt("budget_config singleton row missing after UPDATE")
+
+        # Write audit rows — one per changed field
+        with conn.cursor() as cur:
+            for field, (old_val, new_val) in changes.items():
+                cur.execute(
+                    """
+                    INSERT INTO budget_config_audit
+                        (changed_at, changed_by, field, old_value, new_value, reason)
+                    VALUES (%(at)s, %(by)s, %(field)s, %(old)s, %(new)s, %(reason)s)
+                    """,
+                    {
+                        "at": now,
+                        "by": updated_by,
+                        "field": field,
+                        "old": old_val,
+                        "new": new_val,
+                        "reason": reason,
+                    },
+                )
+
+    return BudgetConfig(
+        cash_buffer_pct=cash_buffer_pct if cash_buffer_pct is not None else Decimal(str(old["cash_buffer_pct"])),
+        cgt_scenario=cgt_scenario if cgt_scenario is not None else str(old["cgt_scenario"]),
+        updated_at=now,
+        updated_by=updated_by,
+        reason=reason,
+    )
+```
+
+**Note on the `f"UPDATE..."` line:** The SET clause is built from a fixed set of column names (never user input). The `# noqa: S608` suppresses the Bandit warning for this safe dynamic SQL. All values use parameterised placeholders.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_budget.py::TestUpdateBudgetConfig -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/budget.py tests/test_budget.py
+git commit -m "feat(#203): update_budget_config() with per-field audit trail"
+```
+
+---
+
+## Task 4: Budget Service — Capital Events
+
+**Files:**
+- Modify: `app/services/budget.py`
+- Modify: `tests/test_budget.py`
+
+- [ ] **Step 1: Write the failing test for record_capital_event**
+
+Add to `tests/test_budget.py`:
+
+```python
+from app.services.budget import record_capital_event, list_capital_events, CapitalEvent
+
+
+class TestRecordCapitalEvent:
+    def test_inserts_event_and_returns_it(self) -> None:
+        cur = MagicMock()
+        cur.execute.return_value.fetchone.return_value = {
+            "event_id": 1,
+            "event_time": datetime(2026, 4, 15, tzinfo=UTC),
+            "event_type": "injection",
+            "amount": Decimal("10000"),
+            "currency": "USD",
+            "source": "operator",
+            "note": "initial deposit",
+            "created_by": "luke",
+        }
+        cur.__enter__ = MagicMock(return_value=cur)
+        cur.__exit__ = MagicMock(return_value=False)
+        conn = _make_conn([cur])
+
+        event = record_capital_event(
+            conn,
+            event_type="injection",
+            amount=Decimal("10000"),
+            currency="USD",
+            note="initial deposit",
+            created_by="luke",
+        )
+
+        assert event.event_id == 1
+        assert event.event_type == "injection"
+        assert event.amount == Decimal("10000")
+
+    def test_rejects_non_positive_amount(self) -> None:
+        conn = _make_conn([])
+        import pytest
+        with pytest.raises(ValueError, match="positive"):
+            record_capital_event(
+                conn,
+                event_type="injection",
+                amount=Decimal("0"),
+                created_by="test",
+            )
+
+
+class TestListCapitalEvents:
+    def test_returns_events_ordered_by_time(self) -> None:
+        cur = _make_cursor(rows=[
+            {
+                "event_id": 2,
+                "event_time": datetime(2026, 4, 15, tzinfo=UTC),
+                "event_type": "injection",
+                "amount": Decimal("5000"),
+                "currency": "USD",
+                "source": "operator",
+                "note": "top-up",
+                "created_by": "luke",
+            },
+            {
+                "event_id": 1,
+                "event_time": datetime(2026, 4, 10, tzinfo=UTC),
+                "event_type": "injection",
+                "amount": Decimal("10000"),
+                "currency": "USD",
+                "source": "operator",
+                "note": "initial",
+                "created_by": "luke",
+            },
+        ])
+        conn = _make_conn([cur])
+
+        events = list_capital_events(conn)
+
+        assert len(events) == 2
+        assert events[0].event_id == 2  # most recent first
+
+    def test_returns_empty_list_when_no_events(self) -> None:
+        cur = _make_cursor(rows=[])
+        conn = _make_conn([cur])
+
+        events = list_capital_events(conn)
+
+        assert events == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_budget.py::TestRecordCapitalEvent -v`
+Expected: FAIL — `ImportError: cannot import name 'record_capital_event'`
+
+- [ ] **Step 3: Implement record_capital_event() and list_capital_events()**
+
+Add to `app/services/budget.py`:
+
+```python
+def record_capital_event(
+    conn: psycopg.Connection[Any],
+    *,
+    event_type: CapitalEventType,
+    amount: Decimal,
+    currency: str = "USD",
+    source: CapitalEventSource = "operator",
+    note: str | None = None,
+    created_by: str,
+) -> CapitalEvent:
+    """Insert a capital event and return the created row.
+
+    amount must be positive — the event_type implies direction.
+    """
+    if amount <= 0:
+        raise ValueError("amount must be positive")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        row = cur.execute(
+            """
+            INSERT INTO capital_events
+                (event_type, amount, currency, source, note, created_by)
+            VALUES (%(type)s, %(amount)s, %(currency)s, %(source)s, %(note)s, %(by)s)
+            RETURNING event_id, event_time, event_type, amount, currency,
+                      source, note, created_by
+            """,
+            {
+                "type": event_type,
+                "amount": amount,
+                "currency": currency,
+                "source": source,
+                "note": note,
+                "by": created_by,
+            },
+        ).fetchone()
+
+    if row is None:
+        raise RuntimeError("INSERT RETURNING produced no row")
+
+    return CapitalEvent(
+        event_id=int(row["event_id"]),
+        event_time=row["event_time"],
+        event_type=str(row["event_type"]),
+        amount=Decimal(str(row["amount"])),
+        currency=str(row["currency"]),
+        source=str(row["source"]),
+        note=row["note"],
+        created_by=row["created_by"],
+    )
+
+
+def list_capital_events(
+    conn: psycopg.Connection[Any],
+    *,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[CapitalEvent]:
+    """List capital events, most recent first."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT event_id, event_time, event_type, amount, currency,
+                   source, note, created_by
+            FROM capital_events
+            ORDER BY event_time DESC
+            LIMIT %(limit)s OFFSET %(offset)s
+            """,
+            {"limit": limit, "offset": offset},
+        )
+        rows = cur.fetchall()
+
+    return [
+        CapitalEvent(
+            event_id=int(r["event_id"]),
+            event_time=r["event_time"],
+            event_type=str(r["event_type"]),
+            amount=Decimal(str(r["amount"])),
+            currency=str(r["currency"]),
+            source=str(r["source"]),
+            note=r["note"],
+            created_by=r["created_by"],
+        )
+        for r in rows
+    ]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_budget.py::TestRecordCapitalEvent tests/test_budget.py::TestListCapitalEvents -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/budget.py tests/test_budget.py
+git commit -m "feat(#203): record_capital_event() and list_capital_events()"
+```
+
+---
+
+## Task 5: Budget Service — compute_budget_state()
+
+This is the core function. It reads from five tables and returns a single `BudgetState` snapshot.
+
+**Files:**
+- Modify: `app/services/budget.py`
+- Modify: `tests/test_budget.py`
+
+- [ ] **Step 1: Write the failing tests for compute_budget_state**
+
+Add to `tests/test_budget.py`:
+
+```python
+from app.services.budget import compute_budget_state, BudgetState
+
+
+class TestComputeBudgetState:
+    """Tests for the core budget state computation.
+
+    Connection cursor sequence (one cursor per query):
+      0. budget_config
+      1. cash_balance (SUM from cash_ledger)
+      2. deployed_capital (SUM cost_basis from positions)
+      3. mirror_equity (SUM from copy_mirrors + copy_mirror_positions)
+      4. tax_year_summary (disposal_matches aggregates)
+      5. gbp_usd rate (live_fx_rates)
+    """
+
+    def _config_cursor(
+        self,
+        buffer_pct: str = "0.05",
+        cgt: str = "higher",
+    ) -> MagicMock:
+        return _make_cursor(single={
+            "cash_buffer_pct": Decimal(buffer_pct),
+            "cgt_scenario": cgt,
+            "updated_at": datetime(2026, 4, 15, tzinfo=UTC),
+            "updated_by": "system",
+            "reason": "seed",
+        })
+
+    def _cash_cursor(self, balance: str | None) -> MagicMock:
+        val = Decimal(balance) if balance is not None else None
+        return _make_cursor(single={"balance": val})
+
+    def _deployed_cursor(self, total: str = "0") -> MagicMock:
+        return _make_cursor(single={"deployed": Decimal(total)})
+
+    def _mirror_cursor(self, equity: str = "0") -> MagicMock:
+        return _make_cursor(single={"mirror_equity": Decimal(equity)})
+
+    def _tax_cursor(self, basic: str = "0", higher: str = "0") -> MagicMock:
+        return _make_cursor(single={
+            "estimated_cgt_basic": Decimal(basic),
+            "estimated_cgt_higher": Decimal(higher),
+        })
+
+    def _fx_cursor(self, rate: str | None = "1.27") -> MagicMock:
+        val = Decimal(rate) if rate is not None else None
+        return _make_cursor(single={"rate": val} if val is not None else None)
+
+    def test_full_budget_computation(self) -> None:
+        """cash=10000, deployed=5000, mirrors=2000, tax_higher_gbp=500, rate=1.27, buffer=5%"""
+        conn = _make_conn([
+            self._config_cursor(),         # 0: config
+            self._cash_cursor("10000"),     # 1: cash
+            self._deployed_cursor("5000"),  # 2: deployed
+            self._mirror_cursor("2000"),    # 3: mirrors
+            self._tax_cursor(higher="500"), # 4: tax
+            self._fx_cursor("1.27"),        # 5: fx
+        ])
+
+        state = compute_budget_state(conn)
+
+        assert state.cash_balance == Decimal("10000")
+        assert state.deployed_capital == Decimal("5000")
+        assert state.mirror_equity == Decimal("2000")
+        # working_budget = 10000 + 5000 + 2000 = 17000
+        assert state.working_budget == Decimal("17000")
+        # tax_usd = 500 * 1.27 = 635
+        assert state.estimated_tax_gbp == Decimal("500")
+        assert state.estimated_tax_usd == Decimal("635")
+        # buffer = 17000 * 0.05 = 850
+        assert state.cash_buffer_reserve == Decimal("850")
+        # available = 10000 - 635 - 850 = 8515
+        assert state.available_for_deployment == Decimal("8515")
+
+    def test_unknown_cash_returns_none_available(self) -> None:
+        """Empty cash_ledger → cash=None, available=None."""
+        conn = _make_conn([
+            self._config_cursor(),
+            self._cash_cursor(None),
+            self._deployed_cursor("5000"),
+            self._mirror_cursor("0"),
+            self._tax_cursor(),
+            self._fx_cursor(),
+        ])
+
+        state = compute_budget_state(conn)
+
+        assert state.cash_balance is None
+        assert state.working_budget is None
+        assert state.available_for_deployment is None
+
+    def test_no_fx_rate_uses_zero_tax(self) -> None:
+        """Missing GBP→USD rate → tax_usd=0, logged as warning."""
+        conn = _make_conn([
+            self._config_cursor(),
+            self._cash_cursor("10000"),
+            self._deployed_cursor("0"),
+            self._mirror_cursor("0"),
+            self._tax_cursor(higher="500"),
+            self._fx_cursor(None),
+        ])
+
+        state = compute_budget_state(conn)
+
+        assert state.gbp_usd_rate is None
+        assert state.estimated_tax_usd == Decimal("0")
+        # buffer = 10000 * 0.05 = 500
+        # available = 10000 - 0 - 500 = 9500
+        assert state.available_for_deployment == Decimal("9500")
+
+    def test_negative_available_when_over_reserved(self) -> None:
+        """Tax + buffer > cash → available is negative (no new orders)."""
+        conn = _make_conn([
+            self._config_cursor(buffer_pct="0.10"),
+            self._cash_cursor("1000"),
+            self._deployed_cursor("20000"),
+            self._mirror_cursor("0"),
+            self._tax_cursor(higher="5000"),
+            self._fx_cursor("1.27"),
+        ])
+
+        state = compute_budget_state(conn)
+
+        # working_budget = 1000 + 20000 + 0 = 21000
+        # buffer = 21000 * 0.10 = 2100
+        # tax_usd = 5000 * 1.27 = 6350
+        # available = 1000 - 6350 - 2100 = -7450
+        assert state.available_for_deployment is not None
+        assert state.available_for_deployment < 0
+
+    def test_basic_cgt_scenario_uses_basic_estimate(self) -> None:
+        """cgt_scenario='basic' reads the basic estimate, not higher."""
+        conn = _make_conn([
+            self._config_cursor(cgt="basic"),
+            self._cash_cursor("10000"),
+            self._deployed_cursor("0"),
+            self._mirror_cursor("0"),
+            self._tax_cursor(basic="300", higher="500"),
+            self._fx_cursor("1.27"),
+        ])
+
+        state = compute_budget_state(conn)
+
+        assert state.estimated_tax_gbp == Decimal("300")
+        assert state.cgt_scenario == "basic"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_budget.py::TestComputeBudgetState -v`
+Expected: FAIL — `ImportError: cannot import name 'compute_budget_state'`
+
+- [ ] **Step 3: Implement compute_budget_state()**
+
+Add to `app/services/budget.py`:
+
+```python
+def _current_uk_tax_year() -> str:
+    """Return the current UK tax year string (e.g. '2025/26').
+
+    UK tax year runs 6 April to 5 April.
+    """
+    now = datetime.now(tz=UTC)
+    year = now.year
+    month = now.month
+    day = now.day
+    if month < 4 or (month == 4 and day <= 5):
+        start_year = year - 1
+    else:
+        start_year = year
+    return f"{start_year}/{str(start_year + 1)[-2:]}"
+
+
+def _load_cash_balance(conn: psycopg.Connection[Any]) -> Decimal | None:
+    """SUM(cash_ledger.amount) or None if ledger is empty."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT SUM(amount) AS balance FROM cash_ledger")
+        row = cur.fetchone()
+    # Aggregate always returns one row; column is NULL when table is empty.
+    if row is None or row["balance"] is None:
+        return None
+    return Decimal(str(row["balance"]))
+
+
+def _load_deployed_capital(conn: psycopg.Connection[Any]) -> Decimal:
+    """SUM(cost_basis) for open positions (current_units > 0)."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT COALESCE(SUM(cost_basis), 0) AS deployed
+            FROM positions
+            WHERE current_units > 0
+            """
+        )
+        row = cur.fetchone()
+    # Aggregate always returns one row.
+    if row is None:
+        raise RuntimeError("deployed capital aggregate returned no rows")
+    return Decimal(str(row["deployed"]))
+
+
+def _load_mirror_equity(conn: psycopg.Connection[Any]) -> Decimal:
+    """Total mirror equity from copy-trading mirrors.
+
+    Mirrors that are paused or have no positions still contribute their
+    available_amount to the equity figure (funds are allocated to the mirror).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT COALESCE(
+                (SELECT SUM(cm.available_amount) FROM copy_mirrors cm
+                 WHERE cm.status = 'active')
+                +
+                (SELECT COALESCE(SUM(cmp.current_value), 0)
+                 FROM copy_mirror_positions cmp
+                 JOIN copy_mirrors cm2 ON cm2.mirror_id = cmp.mirror_id
+                 WHERE cm2.status = 'active'),
+                0
+            ) AS mirror_equity
+            """
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise RuntimeError("mirror equity aggregate returned no rows")
+    return Decimal(str(row["mirror_equity"]))
+
+
+def _load_tax_estimates(
+    conn: psycopg.Connection[Any],
+    tax_year: str,
+) -> tuple[Decimal, Decimal]:
+    """Load estimated CGT for both scenarios from disposal_matches.
+
+    Returns (basic_estimate_gbp, higher_estimate_gbp).
+    Both are zero if no disposals exist for the tax year.
+
+    This is a simplified read — it replicates the tax_year_summary logic
+    for just the CGT estimates, avoiding a circular import of tax_ledger.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT
+                COALESCE(SUM(CASE WHEN gain_or_loss_gbp > 0
+                    THEN gain_or_loss_gbp ELSE 0 END), 0) AS total_gains,
+                COALESCE(SUM(gain_or_loss_gbp), 0) AS net_gain
+            FROM disposal_matches
+            WHERE tax_year = %(ty)s
+            """,
+            {"ty": tax_year},
+        )
+        agg = cur.fetchone()
+    if agg is None:
+        raise RuntimeError("tax aggregate returned no rows")
+
+    net_gain = Decimal(str(agg["net_gain"]))
+    total_gains = Decimal(str(agg["total_gains"]))
+
+    # Apply annual exemption
+    from app.services.tax_ledger import ANNUAL_EXEMPT
+
+    taxable_net = max(net_gain - ANNUAL_EXEMPT, _ZERO)
+    if total_gains <= 0 or taxable_net <= 0:
+        return _ZERO, _ZERO
+
+    # Simplified: use current-year rates (post-Autumn-Budget)
+    # For more accurate per-disposal weighting, callers should use
+    # tax_year_summary() directly. This is sufficient for budget estimates.
+    basic_rate = Decimal("0.18")
+    higher_rate = Decimal("0.24")
+
+    scale = taxable_net / total_gains
+    basic_est = total_gains * basic_rate * scale
+    higher_est = total_gains * higher_rate * scale
+
+    return basic_est, higher_est
+
+
+def _load_gbp_usd_rate(conn: psycopg.Connection[Any]) -> Decimal | None:
+    """Latest GBP→USD rate from live_fx_rates, or None if unavailable."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT rate
+            FROM live_fx_rates
+            WHERE from_currency = 'GBP' AND to_currency = 'USD'
+            """
+        )
+        row = cur.fetchone()
+    if row is None or row["rate"] is None:
+        return None
+    return Decimal(str(row["rate"]))
+
+
+def compute_budget_state(conn: psycopg.Connection[Any]) -> BudgetState:
+    """Compute the current budget state from all source tables.
+
+    This is the core function — called by the API and execution guard.
+    Reads from: budget_config, cash_ledger, positions, copy_mirrors,
+    disposal_matches, live_fx_rates.
+
+    Returns a frozen snapshot. Never caches — always reads fresh state.
+    """
+    config = get_budget_config(conn)
+    tax_year = _current_uk_tax_year()
+
+    # 1. Cash balance
+    cash_balance = _load_cash_balance(conn)
+
+    # 2. Deployed capital (open positions)
+    deployed_capital = _load_deployed_capital(conn)
+
+    # 3. Mirror equity
+    mirror_equity = _load_mirror_equity(conn)
+
+    # 4. Working budget
+    if cash_balance is not None:
+        working_budget: Decimal | None = cash_balance + deployed_capital + mirror_equity
+    else:
+        working_budget = None
+
+    # 5. Tax provision
+    basic_tax_gbp, higher_tax_gbp = _load_tax_estimates(conn, tax_year)
+    if config.cgt_scenario == "basic":
+        estimated_tax_gbp = basic_tax_gbp
+    else:
+        estimated_tax_gbp = higher_tax_gbp
+
+    # Convert GBP tax estimate to USD
+    gbp_usd_rate = _load_gbp_usd_rate(conn)
+    if gbp_usd_rate is not None and gbp_usd_rate > 0:
+        estimated_tax_usd = estimated_tax_gbp * gbp_usd_rate
+    else:
+        # No FX rate available — cannot convert. Log warning, treat as zero
+        # to avoid blocking all trades on missing FX data.
+        if estimated_tax_gbp > 0:
+            logger.warning(
+                "No GBP→USD rate available; tax provision of %.2f GBP "
+                "cannot be converted — treating as 0 USD for budget",
+                estimated_tax_gbp,
+            )
+        estimated_tax_usd = _ZERO
+
+    # 6. Cash buffer reserve
+    if working_budget is not None:
+        cash_buffer_reserve = working_budget * config.cash_buffer_pct
+    else:
+        cash_buffer_reserve = _ZERO
+
+    # 7. Available for deployment
+    if cash_balance is not None:
+        available_for_deployment: Decimal | None = (
+            cash_balance - estimated_tax_usd - cash_buffer_reserve
+        )
+    else:
+        available_for_deployment = None
+
+    return BudgetState(
+        cash_balance=cash_balance,
+        deployed_capital=deployed_capital,
+        mirror_equity=mirror_equity,
+        working_budget=working_budget,
+        estimated_tax_gbp=estimated_tax_gbp,
+        estimated_tax_usd=estimated_tax_usd,
+        gbp_usd_rate=gbp_usd_rate,
+        cash_buffer_reserve=cash_buffer_reserve,
+        available_for_deployment=available_for_deployment,
+        cash_buffer_pct=config.cash_buffer_pct,
+        cgt_scenario=config.cgt_scenario,
+        tax_year=tax_year,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_budget.py::TestComputeBudgetState -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/budget.py tests/test_budget.py
+git commit -m "feat(#203): compute_budget_state() — core budget computation"
+```
+
+---
+
+## Task 6: API Endpoints
+
+**Files:**
+- Create: `app/api/budget.py`
+- Modify: `app/main.py` (register router)
+
+- [ ] **Step 1: Write the API router**
+
+Create `app/api/budget.py`:
+
+```python
+"""Budget and capital management API endpoints (issue #203).
+
+Endpoints:
+  - GET    /budget          — current budget state snapshot
+  - GET    /budget/events   — list capital events (paginated)
+  - POST   /budget/events   — record a capital event (injection/withdrawal)
+  - PATCH  /budget/config   — update budget configuration
+
+All endpoints require operator auth.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.api.auth import require_session_or_service_token
+from app.db import get_conn
+from app.services.budget import (
+    BudgetConfigCorrupt,
+    BudgetState,
+    CapitalEvent,
+    compute_budget_state,
+    get_budget_config,
+    list_capital_events,
+    record_capital_event,
+    update_budget_config,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/budget",
+    tags=["budget"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class BudgetStateResponse(BaseModel):
+    cash_balance: float | None
+    deployed_capital: float
+    mirror_equity: float
+    working_budget: float | None
+    estimated_tax_gbp: float
+    estimated_tax_usd: float
+    gbp_usd_rate: float | None
+    cash_buffer_reserve: float
+    available_for_deployment: float | None
+    cash_buffer_pct: float
+    cgt_scenario: str
+    tax_year: str
+
+
+class CapitalEventResponse(BaseModel):
+    event_id: int
+    event_time: datetime
+    event_type: str
+    amount: float
+    currency: str
+    source: str
+    note: str | None
+    created_by: str | None
+
+
+class BudgetConfigResponse(BaseModel):
+    cash_buffer_pct: float
+    cgt_scenario: str
+    updated_at: datetime
+    updated_by: str
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+
+class CreateCapitalEventRequest(BaseModel):
+    event_type: Literal["injection", "withdrawal"]
+    amount: float = Field(gt=0)
+    currency: str = "USD"
+    note: str | None = None
+
+
+class UpdateBudgetConfigRequest(BaseModel):
+    cash_buffer_pct: float | None = Field(default=None, ge=0, le=0.50)
+    cgt_scenario: Literal["basic", "higher"] | None = None
+    updated_by: str
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=BudgetStateResponse)
+def get_budget(conn: psycopg.Connection = Depends(get_conn)) -> BudgetStateResponse:
+    """Current budget state snapshot."""
+    try:
+        state = compute_budget_state(conn)
+    except BudgetConfigCorrupt:
+        raise HTTPException(status_code=503, detail="budget configuration unavailable")
+    return BudgetStateResponse(
+        cash_balance=float(state.cash_balance) if state.cash_balance is not None else None,
+        deployed_capital=float(state.deployed_capital),
+        mirror_equity=float(state.mirror_equity),
+        working_budget=float(state.working_budget) if state.working_budget is not None else None,
+        estimated_tax_gbp=float(state.estimated_tax_gbp),
+        estimated_tax_usd=float(state.estimated_tax_usd),
+        gbp_usd_rate=float(state.gbp_usd_rate) if state.gbp_usd_rate is not None else None,
+        cash_buffer_reserve=float(state.cash_buffer_reserve),
+        available_for_deployment=float(state.available_for_deployment) if state.available_for_deployment is not None else None,
+        cash_buffer_pct=float(state.cash_buffer_pct),
+        cgt_scenario=state.cgt_scenario,
+        tax_year=state.tax_year,
+    )
+
+
+@router.get("/events", response_model=list[CapitalEventResponse])
+def get_capital_events(
+    conn: psycopg.Connection = Depends(get_conn),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> list[CapitalEventResponse]:
+    """List capital events, most recent first."""
+    events = list_capital_events(conn, limit=limit, offset=offset)
+    return [
+        CapitalEventResponse(
+            event_id=e.event_id,
+            event_time=e.event_time,
+            event_type=e.event_type,
+            amount=float(e.amount),
+            currency=e.currency,
+            source=e.source,
+            note=e.note,
+            created_by=e.created_by,
+        )
+        for e in events
+    ]
+
+
+@router.post("/events", response_model=CapitalEventResponse, status_code=201)
+def create_capital_event(
+    body: CreateCapitalEventRequest,
+    conn: psycopg.Connection = Depends(get_conn),
+) -> CapitalEventResponse:
+    """Record a capital event (deposit or withdrawal).
+
+    Only 'injection' and 'withdrawal' are operator-creatable.
+    'tax_provision' and 'tax_release' are system-only.
+    """
+    event = record_capital_event(
+        conn,
+        event_type=body.event_type,
+        amount=Decimal(str(body.amount)),
+        currency=body.currency,
+        note=body.note,
+        created_by="operator",
+        source="operator",
+    )
+    conn.commit()
+    return CapitalEventResponse(
+        event_id=event.event_id,
+        event_time=event.event_time,
+        event_type=event.event_type,
+        amount=float(event.amount),
+        currency=event.currency,
+        source=event.source,
+        note=event.note,
+        created_by=event.created_by,
+    )
+
+
+@router.patch("/config", response_model=BudgetConfigResponse)
+def patch_budget_config(
+    body: UpdateBudgetConfigRequest,
+    conn: psycopg.Connection = Depends(get_conn),
+) -> BudgetConfigResponse:
+    """Update budget configuration."""
+    if body.cash_buffer_pct is None and body.cgt_scenario is None:
+        raise HTTPException(status_code=422, detail="at least one field must be provided")
+
+    try:
+        config = update_budget_config(
+            conn,
+            cash_buffer_pct=Decimal(str(body.cash_buffer_pct)) if body.cash_buffer_pct is not None else None,
+            cgt_scenario=body.cgt_scenario,
+            updated_by=body.updated_by,
+            reason=body.reason,
+        )
+    except BudgetConfigCorrupt:
+        raise HTTPException(status_code=503, detail="budget configuration unavailable")
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    conn.commit()
+    return BudgetConfigResponse(
+        cash_buffer_pct=float(config.cash_buffer_pct),
+        cgt_scenario=config.cgt_scenario,
+        updated_at=config.updated_at,
+        updated_by=config.updated_by,
+        reason=config.reason,
+    )
+
+
+@router.get("/config", response_model=BudgetConfigResponse)
+def get_budget_config_endpoint(
+    conn: psycopg.Connection = Depends(get_conn),
+) -> BudgetConfigResponse:
+    """Current budget configuration."""
+    try:
+        config = get_budget_config(conn)
+    except BudgetConfigCorrupt:
+        raise HTTPException(status_code=503, detail="budget configuration unavailable")
+    return BudgetConfigResponse(
+        cash_buffer_pct=float(config.cash_buffer_pct),
+        cgt_scenario=config.cgt_scenario,
+        updated_at=config.updated_at,
+        updated_by=config.updated_by,
+        reason=config.reason,
+    )
+```
+
+- [ ] **Step 2: Register the router in main.py**
+
+Add to `app/main.py` imports:
+
+```python
+from app.api.budget import router as budget_router
+```
+
+Add to the router registration block:
+
+```python
+app.include_router(budget_router)
+```
+
+- [ ] **Step 3: Run the smoke test to verify the app boots**
+
+Run: `uv run pytest tests/smoke/test_app_boots.py -v`
+Expected: PASS (migration 027 must be applied to dev DB first)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/api/budget.py app/main.py
+git commit -m "feat(#203): budget API — GET /budget, events CRUD, config PATCH"
+```
+
+---
+
+## Task 7: Execution Guard Integration
+
+Replace the raw `_check_cash` rule with a budget-aware `_check_budget` rule.
+
+**Files:**
+- Modify: `app/services/execution_guard.py`
+- Modify: `tests/test_execution_guard.py`
+
+- [ ] **Step 1: Read the current execution guard cash check**
+
+Read `app/services/execution_guard.py` around lines 215-222 (`_load_cash`) and lines 410-430 (`_check_cash` and its usage in the rule list).
+
+- [ ] **Step 2: Write the failing test for the budget-aware check**
+
+Add to `tests/test_execution_guard.py`:
+
+```python
+class TestBudgetAwareCheck:
+    """The execution guard should use available_for_deployment, not raw cash."""
+
+    @patch("app.services.execution_guard.compute_budget_state")
+    def test_passes_when_budget_available(self, mock_budget: MagicMock) -> None:
+        from app.services.budget import BudgetState
+        mock_budget.return_value = BudgetState(
+            cash_balance=Decimal("10000"),
+            deployed_capital=Decimal("5000"),
+            mirror_equity=Decimal("0"),
+            working_budget=Decimal("15000"),
+            estimated_tax_gbp=Decimal("0"),
+            estimated_tax_usd=Decimal("0"),
+            gbp_usd_rate=Decimal("1.27"),
+            cash_buffer_reserve=Decimal("750"),
+            available_for_deployment=Decimal("9250"),
+            cash_buffer_pct=Decimal("0.05"),
+            cgt_scenario="higher",
+            tax_year="2025/26",
+        )
+        from app.services.execution_guard import _check_budget
+        result = _check_budget(mock_budget.return_value)
+        assert result.passed is True
+
+    @patch("app.services.execution_guard.compute_budget_state")
+    def test_fails_when_budget_exhausted(self, mock_budget: MagicMock) -> None:
+        from app.services.budget import BudgetState
+        mock_budget.return_value = BudgetState(
+            cash_balance=Decimal("1000"),
+            deployed_capital=Decimal("20000"),
+            mirror_equity=Decimal("0"),
+            working_budget=Decimal("21000"),
+            estimated_tax_gbp=Decimal("5000"),
+            estimated_tax_usd=Decimal("6350"),
+            gbp_usd_rate=Decimal("1.27"),
+            cash_buffer_reserve=Decimal("2100"),
+            available_for_deployment=Decimal("-7450"),
+            cash_buffer_pct=Decimal("0.10"),
+            cgt_scenario="higher",
+            tax_year="2025/26",
+        )
+        from app.services.execution_guard import _check_budget
+        result = _check_budget(mock_budget.return_value)
+        assert result.passed is False
+        assert "budget" in result.detail.lower() or "available" in result.detail.lower()
+
+    @patch("app.services.execution_guard.compute_budget_state")
+    def test_fails_when_cash_unknown(self, mock_budget: MagicMock) -> None:
+        from app.services.budget import BudgetState
+        mock_budget.return_value = BudgetState(
+            cash_balance=None,
+            deployed_capital=Decimal("0"),
+            mirror_equity=Decimal("0"),
+            working_budget=None,
+            estimated_tax_gbp=Decimal("0"),
+            estimated_tax_usd=Decimal("0"),
+            gbp_usd_rate=None,
+            cash_buffer_reserve=Decimal("0"),
+            available_for_deployment=None,
+            cash_buffer_pct=Decimal("0.05"),
+            cgt_scenario="higher",
+            tax_year="2025/26",
+        )
+        from app.services.execution_guard import _check_budget
+        result = _check_budget(mock_budget.return_value)
+        assert result.passed is False
+        assert "unknown" in result.detail.lower()
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_execution_guard.py::TestBudgetAwareCheck -v`
+Expected: FAIL — `ImportError: cannot import name '_check_budget'`
+
+- [ ] **Step 4: Replace _check_cash with _check_budget in execution_guard.py**
+
+In `app/services/execution_guard.py`:
+
+1. Add import at top:
+```python
+from app.services.budget import BudgetState, compute_budget_state
+```
+
+2. Replace `_check_cash` function:
+```python
+def _check_budget(budget: BudgetState) -> RuleResult:
+    """Check budget availability for BUY/ADD orders.
+
+    Replaces the raw cash > 0 check with budget-aware logic that accounts
+    for tax provisions and cash buffer reserve.
+
+    Fail-closed: unknown cash (None) or exhausted budget (≤ 0) fails.
+    """
+    if budget.available_for_deployment is None:
+        return RuleResult(
+            rule="budget_available",
+            passed=False,
+            detail="cash_ledger is empty; cannot verify budget availability",
+        )
+    if budget.available_for_deployment <= 0:
+        return RuleResult(
+            rule="budget_available",
+            passed=False,
+            detail=(
+                f"budget exhausted: available_for_deployment="
+                f"{budget.available_for_deployment:.2f} "
+                f"(cash={budget.cash_balance}, tax_reserved={budget.estimated_tax_usd:.2f}, "
+                f"buffer={budget.cash_buffer_reserve:.2f})"
+            ),
+        )
+    return RuleResult(
+        rule="budget_available",
+        passed=True,
+        detail=(
+            f"budget ok: available_for_deployment="
+            f"{budget.available_for_deployment:.2f}"
+        ),
+    )
+```
+
+3. In `evaluate_recommendation()`, replace the cash-loading and checking:
+
+Where the guard currently does:
+```python
+cash = _load_cash(conn)
+# ... later in rule list for BUY/ADD:
+rules.append(_check_cash(cash))
+```
+
+Change to:
+```python
+budget = compute_budget_state(conn)
+# ... later in rule list for BUY/ADD:
+rules.append(_check_budget(budget))
+```
+
+4. Include the budget snapshot in `evidence_json` for auditability:
+```python
+"budget_snapshot": {
+    "cash_balance": float(budget.cash_balance) if budget.cash_balance is not None else None,
+    "available_for_deployment": float(budget.available_for_deployment) if budget.available_for_deployment is not None else None,
+    "estimated_tax_usd": float(budget.estimated_tax_usd),
+    "cash_buffer_reserve": float(budget.cash_buffer_reserve),
+    "cash_buffer_pct": float(budget.cash_buffer_pct),
+    "cgt_scenario": budget.cgt_scenario,
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_execution_guard.py -v`
+Expected: PASS (existing tests may need mock updates for the new budget call)
+
+- [ ] **Step 6: Update existing execution guard tests**
+
+Existing tests that mock `_load_cash` will need updating to either:
+- Mock `compute_budget_state` instead, or
+- Provide budget state where the old cash check was
+
+Review each test class in `tests/test_execution_guard.py` and update accordingly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/execution_guard.py tests/test_execution_guard.py
+git commit -m "feat(#203): execution guard — budget-aware cash check replaces raw cash"
+```
+
+---
+
+## Task 8: Full Check Suite
+
+**Files:** None new — verification only.
+
+- [ ] **Step 1: Run linter**
+
+Run: `uv run ruff check .`
+Expected: no errors
+
+- [ ] **Step 2: Run formatter check**
+
+Run: `uv run ruff format --check .`
+Expected: no formatting issues
+
+- [ ] **Step 3: Run type checker**
+
+Run: `uv run pyright`
+Expected: no errors
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `uv run pytest`
+Expected: all tests pass, including smoke test
+
+- [ ] **Step 5: Fix any issues found in steps 1-4**
+
+Address all lint, type, and test failures before proceeding.
+
+- [ ] **Step 6: Final commit if fixes were needed**
+
+```bash
+git add -u
+git commit -m "fix(#203): address lint/type/test issues"
+```
+
+---
+
+## Task 9: PR and Review
+
+- [ ] **Step 1: Self-review the diff**
+
+Read `.claude/skills/engineering/pre-flight-review.md` and review the full diff against it.
+
+- [ ] **Step 2: Push and open PR**
+
+```bash
+git push -u origin feature/203-budget-capital-management
+gh pr create --title "feat(#203): budget and capital management service" --body "..."
+```
+
+- [ ] **Step 3: Poll review + CI, resolve all comments, iterate until APPROVE**
+
+Follow the branch and PR workflow from CLAUDE.md:
+1. `gh pr checks <n>` — wait for CI green
+2. `gh pr view <n> --comments` — read review
+3. Address every comment (FIXED/DEFERRED/REBUTTED)
+4. Re-run checks, push follow-up
+5. Repeat until APPROVE on latest commit
+
+- [ ] **Step 4: Merge and clean up**
+
+```bash
+gh pr merge <n> --squash --delete-branch
+git checkout main && git pull
+gh issue close 203
+```

--- a/docs/superpowers/plans/2026-04-15-budget-dashboard-ui.md
+++ b/docs/superpowers/plans/2026-04-15-budget-dashboard-ui.md
@@ -1,0 +1,576 @@
+# Budget Dashboard UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface budget state on the Dashboard (summary card + sidebar panel) and add budget config controls to the Settings page, so the operator has at-a-glance visibility into available deployment capital, tax provisioning, and buffer reserves.
+
+**Architecture:** Three independent UI additions: (1) a 4th summary card on Dashboard showing `available_for_deployment`, (2) a Budget Overview panel in the Dashboard sidebar, (3) a Budget Config section on the Settings page. Each uses its own `useAsync` fetch — budget data is an independent async source that must not gate or be gated by existing Dashboard fetches (per async-data-loading skill). The backend endpoints (`GET /budget`, `GET /budget/config`, `PATCH /budget/config`, `GET /budget/events`, `POST /budget/events`) are already shipped in PR #232.
+
+**Tech Stack:** React 18, TypeScript 5, Tailwind CSS 3, Vite 5, Vitest + Testing Library
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `frontend/src/api/budget.ts` | Typed fetchers for all 5 budget endpoints |
+| Modify | `frontend/src/api/types.ts` | Add `BudgetStateResponse`, `CapitalEventResponse`, `BudgetConfigResponse`, request types |
+| Modify | `frontend/src/pages/DashboardPage.tsx` | Add `useAsync(fetchBudget)`, wire 4th card + sidebar panel |
+| Modify | `frontend/src/components/dashboard/SummaryCards.tsx` | Accept optional `budgetData` prop, render 4th card |
+| Create | `frontend/src/components/dashboard/BudgetOverviewPanel.tsx` | Sidebar panel: buffer, tax, breakdown |
+| Create | `frontend/src/components/settings/BudgetConfigSection.tsx` | Settings: buffer slider, CGT toggle, capital events form + table |
+| Modify | `frontend/src/pages/SettingsPage.tsx` | Import and render `BudgetConfigSection` |
+| Create | `frontend/src/components/settings/__tests__/BudgetConfigSection.test.tsx` | Tests for config controls |
+| Create | `frontend/src/components/dashboard/__tests__/BudgetOverviewPanel.test.tsx` | Tests for sidebar panel |
+
+---
+
+### Task 1: API types and fetchers
+
+**Files:**
+- Modify: `frontend/src/api/types.ts:574` (append after last interface)
+- Create: `frontend/src/api/budget.ts`
+
+- [ ] **Step 1: Add budget types to types.ts**
+
+Append to the end of `frontend/src/api/types.ts`. These mirror the Pydantic models in `app/api/budget.py:58-89` field-for-field:
+
+```typescript
+// ---------------------------------------------------------------------------
+// Budget (mirrors app/api/budget.py)
+// ---------------------------------------------------------------------------
+
+export interface BudgetStateResponse {
+  cash_balance: number | null;
+  deployed_capital: number;
+  mirror_equity: number;
+  working_budget: number | null;
+  estimated_tax_gbp: number;
+  estimated_tax_usd: number;
+  gbp_usd_rate: number | null;
+  cash_buffer_reserve: number;
+  available_for_deployment: number | null;
+  cash_buffer_pct: number;
+  cgt_scenario: string;
+  tax_year: string;
+}
+
+export interface CapitalEventResponse {
+  event_id: number;
+  event_time: string;
+  event_type: string;
+  amount: number;
+  currency: string;
+  source: string;
+  note: string | null;
+  created_by: string | null;
+}
+
+export interface BudgetConfigResponse {
+  cash_buffer_pct: number;
+  cgt_scenario: string;
+  updated_at: string;
+  updated_by: string;
+  reason: string;
+}
+```
+
+- [ ] **Step 2: Create budget fetchers**
+
+Create `frontend/src/api/budget.ts`:
+
+```typescript
+import { apiFetch } from "@/api/client";
+import type {
+  BudgetStateResponse,
+  BudgetConfigResponse,
+  CapitalEventResponse,
+} from "@/api/types";
+
+export function fetchBudget(): Promise<BudgetStateResponse> {
+  return apiFetch<BudgetStateResponse>("/budget");
+}
+
+export function fetchBudgetConfig(): Promise<BudgetConfigResponse> {
+  return apiFetch<BudgetConfigResponse>("/budget/config");
+}
+
+export function fetchCapitalEvents(
+  limit = 50,
+  offset = 0,
+): Promise<CapitalEventResponse[]> {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    offset: String(offset),
+  });
+  return apiFetch<CapitalEventResponse[]>(`/budget/events?${params}`);
+}
+
+export function createCapitalEvent(body: {
+  event_type: "injection" | "withdrawal";
+  amount: number;
+  currency?: "USD" | "GBP";
+  note?: string;
+}): Promise<CapitalEventResponse> {
+  return apiFetch<CapitalEventResponse>("/budget/events", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function updateBudgetConfig(body: {
+  cash_buffer_pct?: number;
+  cgt_scenario?: "basic" | "higher";
+  updated_by: string;
+  reason: string;
+}): Promise<BudgetConfigResponse> {
+  return apiFetch<BudgetConfigResponse>("/budget/config", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+```
+
+- [ ] **Step 3: Verify typecheck passes**
+
+Run: `pnpm --dir frontend typecheck`
+Expected: PASS (no new errors)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/types.ts frontend/src/api/budget.ts
+git commit -m "feat(#233): budget API types and fetchers"
+```
+
+---
+
+### Task 2: Dashboard summary card — "Available for Deployment"
+
+**Files:**
+- Modify: `frontend/src/components/dashboard/SummaryCards.tsx`
+- Modify: `frontend/src/pages/DashboardPage.tsx`
+
+- [ ] **Step 1: Add budget data prop to SummaryCards**
+
+Modify `SummaryCards.tsx` to accept an optional `budgetData` prop and render a 4th card. The grid changes from `sm:grid-cols-3` to `sm:grid-cols-2 lg:grid-cols-4` so 4 cards fit.
+
+The 4th card shows `available_for_deployment` with color coding:
+- Green when positive
+- Amber when low (< 5% of working_budget)
+- Red when negative
+- "Cash unknown" hint when `cash_balance` is null (which makes `available_for_deployment` null)
+
+```typescript
+import type { BudgetStateResponse, PortfolioResponse } from "@/api/types";
+```
+
+Update the component signature:
+```typescript
+export function SummaryCards({
+  data,
+  budgetData,
+}: {
+  data: PortfolioResponse | null;
+  budgetData: BudgetStateResponse | null;
+})
+```
+
+Loading skeleton: change from 3 to 4 skeleton cards.
+
+After the P&L card, add:
+```tsx
+<DeploymentCard budget={budgetData} currency={currency} />
+```
+
+New helper component inside the same file:
+```typescript
+function DeploymentCard({
+  budget,
+  currency,
+}: {
+  budget: BudgetStateResponse | null;
+  currency: string;
+}) {
+  if (budget === null) {
+    return (
+      <div className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+        <SectionSkeleton rows={2} />
+      </div>
+    );
+  }
+
+  const available = budget.available_for_deployment;
+  const isNull = available === null;
+  const isLow =
+    !isNull &&
+    budget.working_budget !== null &&
+    budget.working_budget > 0 &&
+    available! / budget.working_budget < 0.05;
+  const isNegative = !isNull && available! < 0;
+
+  const tone: "positive" | "negative" | undefined = isNull
+    ? undefined
+    : isNegative
+      ? "negative"
+      : isLow
+        ? "negative"
+        : "positive";
+
+  return (
+    <Card
+      label="Available for deployment"
+      value={isNull ? "—" : formatMoney(available, currency)}
+      hint={isNull ? "Cash unknown" : isLow ? "Low deployment capital" : undefined}
+      tone={tone}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: Wire budget fetch into DashboardPage**
+
+In `DashboardPage.tsx`, add the budget fetch as a new independent async source:
+
+```typescript
+import { fetchBudget } from "@/api/budget";
+```
+
+Add alongside existing fetches:
+```typescript
+const budget = useAsync(fetchBudget, []);
+```
+
+Update `allFailed` to include budget:
+```typescript
+const allFailed =
+  portfolio.error !== null &&
+  recs.error !== null &&
+  system.error !== null &&
+  config.error !== null &&
+  budget.error !== null;
+```
+
+Pass budget data to SummaryCards:
+```tsx
+<SummaryCards
+  data={portfolio.loading ? null : portfolio.data}
+  budgetData={budget.loading ? null : budget.error !== null ? null : budget.data}
+/>
+```
+
+- [ ] **Step 3: Verify typecheck and dev server**
+
+Run: `pnpm --dir frontend typecheck`
+Run: `pnpm --dir frontend dev` — check Dashboard shows 4 cards
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/dashboard/SummaryCards.tsx frontend/src/pages/DashboardPage.tsx
+git commit -m "feat(#233): 4th summary card — Available for Deployment"
+```
+
+---
+
+### Task 3: Budget Overview sidebar panel
+
+**Files:**
+- Create: `frontend/src/components/dashboard/BudgetOverviewPanel.tsx`
+- Modify: `frontend/src/pages/DashboardPage.tsx`
+
+- [ ] **Step 1: Create BudgetOverviewPanel component**
+
+Create `frontend/src/components/dashboard/BudgetOverviewPanel.tsx`:
+
+Read-only display panel for the Dashboard sidebar (below System Status). Shows:
+- Cash buffer reserve (absolute + percentage)
+- Estimated tax provision (GBP + USD with scenario label)
+- CGT scenario in use
+- Current tax year
+- Working budget breakdown (cash + deployed + mirrors)
+
+The component receives `budget: BudgetStateResponse | null`, `loading: boolean`, `hasError: boolean`, `onRetry: () => void`. It renders its own loading/error/data states per the async-data-loading skill.
+
+```typescript
+import type { BudgetStateResponse } from "@/api/types";
+import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
+import { formatMoney, formatPct } from "@/lib/format";
+import { SectionSkeleton } from "@/components/dashboard/Section";
+
+export function BudgetOverviewPanel({
+  budget,
+  loading,
+  hasError,
+  onRetry,
+}: {
+  budget: BudgetStateResponse | null;
+  loading: boolean;
+  hasError: boolean;
+  onRetry: () => void;
+}) {
+  const currency = useDisplayCurrency();
+
+  if (hasError) {
+    return (
+      <div
+        role="alert"
+        className="flex items-center justify-between rounded border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-700"
+      >
+        <span>/budget failed to load.</span>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded border border-red-300 bg-white px-2 py-0.5 text-[10px] font-medium text-red-700 hover:bg-red-100"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (loading || budget === null) {
+    return <SectionSkeleton rows={5} />;
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+        Budget overview
+      </div>
+
+      <dl className="space-y-2 text-sm">
+        <Row label="Working budget" value={formatMoney(budget.working_budget, currency)} />
+        <Row label="Cash balance" value={formatMoney(budget.cash_balance, currency)} />
+        <Row label="Deployed capital" value={formatMoney(budget.deployed_capital, currency)} />
+        <Row label="Mirror equity" value={formatMoney(budget.mirror_equity, currency)} />
+        <Row
+          label={`Cash buffer (${formatPct(budget.cash_buffer_pct)})`}
+          value={formatMoney(budget.cash_buffer_reserve, currency)}
+        />
+        <Row
+          label={`Tax provision (${budget.cgt_scenario})`}
+          value={`${formatMoney(budget.estimated_tax_gbp, "GBP")} / ${formatMoney(budget.estimated_tax_usd, "USD")}`}
+        />
+        <Row label="Tax year" value={budget.tax_year} />
+      </dl>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-4">
+      <dt className="text-slate-500">{label}</dt>
+      <dd className="shrink-0 text-right tabular-nums text-slate-700">{value}</dd>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Wire into DashboardPage sidebar**
+
+In `DashboardPage.tsx`, add below the `<Section title="System status">` block (still within the right sidebar column):
+
+```typescript
+import { BudgetOverviewPanel } from "@/components/dashboard/BudgetOverviewPanel";
+```
+
+Add a new Section after System Status in the sidebar:
+```tsx
+<Section title="Budget">
+  <BudgetOverviewPanel
+    budget={budget.error !== null ? null : budget.data}
+    loading={budget.loading}
+    hasError={budget.error !== null}
+    onRetry={budget.refetch}
+  />
+</Section>
+```
+
+The sidebar column currently holds only System Status. After this, it holds System Status + Budget. Both sections are in a `space-y-6` container. Budget uses the same `budget` async source as the 4th card — one source, one error surface (the inline error is in the panel, the card just shows skeleton/dash).
+
+- [ ] **Step 3: Verify typecheck and dev server**
+
+Run: `pnpm --dir frontend typecheck`
+Check Dashboard: sidebar shows Budget panel below System Status
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/dashboard/BudgetOverviewPanel.tsx frontend/src/pages/DashboardPage.tsx
+git commit -m "feat(#233): Budget Overview sidebar panel on Dashboard"
+```
+
+---
+
+### Task 4: Budget config controls on Settings page
+
+**Files:**
+- Create: `frontend/src/components/settings/BudgetConfigSection.tsx`
+- Modify: `frontend/src/pages/SettingsPage.tsx`
+
+- [ ] **Step 1: Create BudgetConfigSection component**
+
+Create `frontend/src/components/settings/BudgetConfigSection.tsx`:
+
+Three sub-sections:
+1. **Buffer + CGT controls**: Input for `cash_buffer_pct` (0-50%), dropdown for `cgt_scenario`, reason field, Save button. Calls `PATCH /budget/config`.
+2. **Record capital event**: Form with event_type dropdown (injection/withdrawal), amount input, currency select, note textarea, Submit button. Calls `POST /budget/events`.
+3. **Capital events history**: Table showing recent events from `GET /budget/events`.
+
+The component fetches its own data via `useAsync(fetchBudgetConfig)` and `useAsync(fetchCapitalEvents)`.
+
+```typescript
+import { useCallback, useState } from "react";
+import type { FormEvent } from "react";
+
+import {
+  createCapitalEvent,
+  fetchBudgetConfig,
+  fetchCapitalEvents,
+  updateBudgetConfig,
+} from "@/api/budget";
+import type { CapitalEventResponse } from "@/api/types";
+import { SectionSkeleton, SectionError } from "@/components/dashboard/Section";
+import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
+import { formatDateTime, formatMoney } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+export function BudgetConfigSection() {
+  const configAsync = useAsync(fetchBudgetConfig, []);
+  const eventsAsync = useAsync(() => fetchCapitalEvents(20, 0), []);
+
+  return (
+    <section className="rounded-md border border-slate-200 bg-white shadow-sm">
+      <header className="border-b border-slate-100 px-4 py-3">
+        <h2 className="text-sm font-semibold text-slate-700">Budget configuration</h2>
+      </header>
+      <div className="space-y-6 p-4">
+        {configAsync.loading ? (
+          <SectionSkeleton rows={4} />
+        ) : configAsync.error !== null ? (
+          <SectionError onRetry={configAsync.refetch} />
+        ) : configAsync.data !== null ? (
+          <ConfigControls
+            initialBufferPct={configAsync.data.cash_buffer_pct}
+            initialScenario={configAsync.data.cgt_scenario as "basic" | "higher"}
+            onSaved={configAsync.refetch}
+          />
+        ) : null}
+
+        <div className="border-t border-slate-100 pt-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Record capital event
+          </h3>
+          <CapitalEventForm onCreated={eventsAsync.refetch} />
+        </div>
+
+        <div className="border-t border-slate-100 pt-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Recent capital events
+          </h3>
+          {eventsAsync.loading ? (
+            <SectionSkeleton rows={3} />
+          ) : eventsAsync.error !== null ? (
+            <SectionError onRetry={eventsAsync.refetch} />
+          ) : eventsAsync.data !== null && eventsAsync.data.length > 0 ? (
+            <EventsTable events={eventsAsync.data} />
+          ) : (
+            <p className="mt-2 text-sm text-slate-500">No capital events recorded yet.</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+```
+
+`ConfigControls` sub-component: form with buffer pct input, CGT dropdown, reason field, save button.
+
+`CapitalEventForm` sub-component: form with event_type select, amount input, currency select, note textarea, submit button.
+
+`EventsTable` sub-component: simple table with columns: Time, Type, Amount, Currency, Source, Note.
+
+(Full implementation code for each sub-component is in the actual implementation — the plan defines their interfaces and responsibilities.)
+
+- [ ] **Step 2: Wire into SettingsPage**
+
+In `SettingsPage.tsx`, import and render between `DisplayCurrencySection` and `BrokerCredentialsSection`:
+
+```typescript
+import { BudgetConfigSection } from "@/components/settings/BudgetConfigSection";
+```
+
+```tsx
+<DisplayCurrencySection ... />
+<BudgetConfigSection />
+<BrokerCredentialsSection />
+```
+
+- [ ] **Step 3: Verify typecheck and dev server**
+
+Run: `pnpm --dir frontend typecheck`
+Check Settings page: Budget configuration section appears with controls
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/settings/BudgetConfigSection.tsx frontend/src/pages/SettingsPage.tsx
+git commit -m "feat(#233): budget config controls on Settings page"
+```
+
+---
+
+### Task 5: Tests
+
+**Files:**
+- Create: `frontend/src/components/dashboard/__tests__/BudgetOverviewPanel.test.tsx`
+- Create: `frontend/src/components/settings/__tests__/BudgetConfigSection.test.tsx`
+
+- [ ] **Step 1: Test BudgetOverviewPanel**
+
+Tests:
+- Renders skeleton when loading
+- Renders error with retry button when hasError
+- Renders all budget fields when data is provided
+- Shows "—" for null cash_balance and working_budget
+
+- [ ] **Step 2: Test BudgetConfigSection**
+
+Tests:
+- Renders loading skeleton initially
+- Renders config form with initial values after load
+- Shows error state with retry on fetch failure
+- Save button calls updateBudgetConfig with correct payload
+- Capital event form submits with correct payload
+- Events table renders rows
+
+- [ ] **Step 3: Run tests**
+
+Run: `pnpm --dir frontend test`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/dashboard/__tests__/ frontend/src/components/settings/__tests__/
+git commit -m "test(#233): budget dashboard and settings tests"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- [x] 4th summary card (Task 2)
+- [x] Budget Overview sidebar panel (Task 3)
+- [x] Budget config controls (Task 4)
+- [x] Capital event recording (Task 4)
+- [x] Capital events history (Task 4)
+- [x] API types mirror Pydantic models (Task 1)
+
+**Placeholder scan:** No TBD/TODO. Task 4 ConfigControls/CapitalEventForm/EventsTable are described by interface — full code is in implementation. This is acceptable because the sub-components follow clear patterns already established in the codebase (SettingsPage broker credentials forms).
+
+**Type consistency:** `BudgetStateResponse` field names match across Task 1 (type definition), Task 2 (card consumption), Task 3 (panel consumption). `BudgetConfigResponse` matches between Task 1 and Task 4.

--- a/docs/superpowers/plans/2026-04-15-fix-mirror-equity-overstatement.md
+++ b/docs/superpowers/plans/2026-04-15-fix-mirror-equity-overstatement.md
@@ -1,0 +1,553 @@
+# Fix Mirror Equity Overstatement — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix mirror equity calculation so AUM reflects reality — eliminate the ~£27k overstatement and fix budget.py's broken query that references non-existent schema columns.
+
+**Architecture:** Two bugs, one root cause investigation. (1) budget.py's `_load_mirror_equity()` references `cm.status` (doesn't exist; column is `cm.active BOOLEAN`) and `cmp.current_value` (doesn't exist; must compute MTM from position fields). Fix by importing portfolio.py's canonical version. (2) The dashboard shows mirror equity ~3× too high. Investigate data via diagnostic queries, then fix the root cause. (3) Align the 2-tier pricing in `_load_mirror_equity` with the 3-tier hierarchy in `load_mirror_breakdowns` for consistency.
+
+**Tech Stack:** Python, psycopg3, PostgreSQL, pytest
+
+---
+
+## Settled decisions that apply
+
+- **AUM basis** — "AUM and concentration should use mark-to-market first. If no current quote exists, fall back to cost basis." Both `_load_mirror_equity` and `load_mirror_breakdowns` must use the same MTM fallback chain.
+- **Provider boundary** — "keep providers thin, domain logic in services." Mirror equity logic stays in `portfolio.py`, not the provider.
+
+## Prevention log entries that apply
+
+- **psycopg3 cursors are independent — mock cursor sequences are not** — budget.py's mock-based tests passed despite referencing non-existent columns. The smoke test (which runs against real DB) doesn't cover `GET /budget`, so the schema mismatch was invisible.
+- **SQL-shape assertions are only meaningful for clauses the code path runs** — mocks can't validate column names. Adding smoke coverage for the budget endpoint is required.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `app/services/budget.py` | Modify | Remove broken `_load_mirror_equity`, import from portfolio.py |
+| `app/services/portfolio.py` | Modify | Add `price_daily` fallback to `_load_mirror_equity` (3-tier alignment) |
+| `app/services/portfolio_sync.py` | Modify | Add mirror equity sanity check during sync |
+| `tests/test_budget.py` | Modify | Update mock target for mirror equity |
+| `tests/test_portfolio.py` | Modify | Add test for 3-tier pricing in `_load_mirror_equity` |
+| `tests/smoke/test_app_boots.py` | Modify | Add `GET /budget` smoke assertion |
+
+---
+
+### Task 1: Diagnose the overstatement via SQL queries
+
+This task runs diagnostic queries against the dev database to identify the root cause of the ~£27k mirror equity overstatement. The queries must be run manually by the operator or via `psql`.
+
+**Files:**
+- None (diagnostic only)
+
+- [ ] **Step 1: Check active mirrors and their available_amount**
+
+```sql
+SELECT mirror_id, parent_cid, available_amount, initial_investment,
+       deposit_summary, withdrawal_summary, closed_positions_net_profit,
+       active, updated_at
+FROM copy_mirrors
+WHERE active = TRUE;
+```
+
+Expected: 2 active mirrors. Note each `available_amount` value. Compare `available_amount` against `initial_investment + deposit_summary - withdrawal_summary + closed_positions_net_profit` — if `available_amount` is close to this sum, it represents total equity, not just uninvested cash.
+
+- [ ] **Step 2: Check position counts and invested amounts per mirror**
+
+```sql
+SELECT mirror_id, COUNT(*) AS pos_count, SUM(amount) AS total_amount,
+       SUM(initial_amount_in_dollars) AS total_initial
+FROM copy_mirror_positions
+GROUP BY mirror_id
+ORDER BY mirror_id;
+```
+
+Expected: Compare `SUM(amount)` against `SUM(initial_amount_in_dollars)`. If `amount ≈ initial_amount_in_dollars`, they represent invested capital. If `amount >> initial_amount_in_dollars`, `amount` may include unrealized P&L (which would be double-counted by the MTM formula).
+
+- [ ] **Step 3: Run the mirror equity CTE manually**
+
+```sql
+WITH mirror_equity AS (
+    SELECT m.mirror_id,
+           m.available_amount,
+           COALESCE(p.mv, 0) AS positions_mv,
+           m.available_amount + COALESCE(p.mv, 0) AS per_mirror_equity
+    FROM copy_mirrors m
+    LEFT JOIN LATERAL (
+        SELECT SUM(
+              cmp.amount
+            + (CASE WHEN cmp.is_buy THEN 1 ELSE -1 END)
+              * cmp.units
+              * (COALESCE(q.last, cmp.open_rate) - cmp.open_rate)
+              * cmp.open_conversion_rate
+        ) AS mv
+        FROM copy_mirror_positions cmp
+        LEFT JOIN LATERAL (
+            SELECT last
+            FROM quotes
+            WHERE instrument_id = cmp.instrument_id
+            ORDER BY quoted_at DESC
+            LIMIT 1
+        ) q ON TRUE
+        WHERE cmp.mirror_id = m.mirror_id
+    ) p ON TRUE
+    WHERE m.active
+)
+SELECT *, SUM(per_mirror_equity) OVER () AS total_mirror_equity
+FROM mirror_equity;
+```
+
+Expected: Identify which mirror contributes most to the overstatement and whether `available_amount` or `positions_mv` is the dominant factor.
+
+- [ ] **Step 4: Cross-check against raw_payload**
+
+```sql
+SELECT mirror_id,
+       available_amount AS db_available,
+       (raw_payload->>'availableAmount')::numeric AS api_available,
+       initial_investment AS db_initial,
+       (raw_payload->>'initialInvestment')::numeric AS api_initial
+FROM copy_mirrors
+WHERE active = TRUE;
+```
+
+Expected: DB values should match raw_payload values exactly. If they diverge, the sync pipeline has a parsing bug.
+
+- [ ] **Step 5: Determine root cause and record findings**
+
+Based on the diagnostic results, the root cause will be one of:
+1. **`available_amount` includes position values** — fix: mirror equity = `available_amount` only (positions already accounted for), or adjust formula
+2. **`amount` includes unrealized P&L** — fix: use `initial_amount_in_dollars` instead of `amount` in the MTM base
+3. **Duplicate or stale data** — fix: deduplication or sync-pipeline correction
+4. **FX conversion applied incorrectly** — fix: conversion logic
+
+Record the finding in a code comment or issue comment before proceeding to Task 2.
+
+---
+
+### Task 2: Fix budget.py — DRY mirror equity with portfolio.py
+
+**Files:**
+- Modify: `app/services/budget.py:430-456` (remove broken `_load_mirror_equity`)
+- Modify: `app/services/budget.py:532` (update call site)
+- Test: `tests/test_budget.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Update the budget test to mock the portfolio.py import instead of the broken local function. In `tests/test_budget.py`, find `_budget_conn` helper and update the mock target:
+
+```python
+# In TestComputeBudgetState, the mirror_equity cursor (index 3) is consumed
+# by budget.py's local _load_mirror_equity. After the fix, budget.py imports
+# portfolio._load_mirror_equity instead, so the mock target changes.
+#
+# Replace the cursor-based mirror mock with a patch on the import:
+```
+
+The existing test `test_full_budget_computation` should still pass after the change — it mocks cursors that the broken local function consumed. After removing the local function, the cursor count changes from 6 to 5 (no mirror cursor in budget.py; it calls portfolio's version instead).
+
+First, verify the current tests pass:
+
+Run: `uv run pytest tests/test_budget.py -v`
+Expected: PASS
+
+- [ ] **Step 2: Remove broken `_load_mirror_equity` from budget.py and import from portfolio.py**
+
+In `app/services/budget.py`, remove lines 430-456 (the broken `_load_mirror_equity` function).
+
+Add import at the top of the file:
+
+```python
+from app.services.portfolio import _load_mirror_equity
+```
+
+Update `compute_budget_state` (around line 532) to convert the float return to Decimal:
+
+```python
+    mirror_equity = Decimal(str(_load_mirror_equity(conn)))
+```
+
+The line `mirror_equity = _load_mirror_equity(conn)` previously called the local broken version. Now it calls portfolio.py's correct version and wraps in Decimal.
+
+- [ ] **Step 3: Update the budget test helpers to mock the new import**
+
+In `tests/test_budget.py`, the `_budget_conn` helper builds 6 cursors:
+```
+budget_config, cash_balance, deployed_capital, mirror_equity, tax_estimates, gbp_usd_rate
+```
+
+After the fix, budget.py no longer runs its own mirror query — it calls `portfolio._load_mirror_equity(conn)`. So the cursor sequence drops to 5 (remove `cur_mirrors`), and we patch `app.services.budget._load_mirror_equity` (the imported name) instead.
+
+Update `_budget_conn`:
+
+```python
+def _budget_conn(
+    *,
+    config_row: dict[str, Any] | None = None,
+    cash_balance: Decimal | None = Decimal("10000"),
+    deployed: Decimal = Decimal("5000"),
+    total_gains: Decimal = Decimal("3500"),
+    net_gain: Decimal = Decimal("3500"),
+    gbp_usd_rate: Decimal | None = Decimal("1.25"),
+) -> MagicMock:
+    """Build a mock connection for compute_budget_state.
+
+    Cursor order (5 cursors — mirror_equity is now patched separately):
+      0: budget_config (get_budget_config)
+      1: cash balance (_load_cash_balance)
+      2: deployed capital (_load_deployed_capital)
+      3: tax estimates (_load_tax_estimates)
+      4: gbp_usd rate (_load_gbp_usd_rate)
+    """
+    if config_row is None:
+        config_row = _budget_config_row()
+
+    cur_config = _make_cursor(single=config_row)
+    cur_cash = _make_cursor(single={"balance": cash_balance})
+    cur_deployed = _make_cursor(single={"deployed": deployed})
+    cur_tax = _make_cursor(
+        single={"total_gains": total_gains, "net_gain": net_gain},
+    )
+    if gbp_usd_rate is not None:
+        cur_fx = _make_cursor(single={"rate": gbp_usd_rate})
+    else:
+        cur_fx = _make_cursor()
+        cur_fx.fetchone.return_value = None
+
+    return _make_conn([cur_config, cur_cash, cur_deployed, cur_tax, cur_fx])
+```
+
+Then wrap every `compute_budget_state(conn)` call in the test class with a patch on the mirror equity:
+
+```python
+with (
+    unittest.mock.patch(
+        "app.services.budget._current_uk_tax_year",
+        return_value="2025/26",
+    ),
+    unittest.mock.patch(
+        "app.services.budget._load_mirror_equity",
+        return_value=2000.0,
+    ),
+):
+    state = compute_budget_state(conn)
+```
+
+The `return_value=2000.0` matches the previous mock cursor value (`mirror_equity=Decimal("2000")`), but now returns float (portfolio.py's return type) — budget.py wraps it in `Decimal(str(...))`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_budget.py -v`
+Expected: All 30 tests PASS
+
+- [ ] **Step 5: Update execution guard tests**
+
+The execution guard's `_budget_cursors_list` helper in `tests/test_execution_guard.py` builds 6 cursors for `compute_budget_state`. After the change, `compute_budget_state` only opens 5 cursors (no mirror cursor). But `compute_budget_state` now calls `portfolio._load_mirror_equity(conn)` which opens its own cursor.
+
+So the total cursor count stays the same (5 budget internal + 1 from portfolio import = 6 cursors consumed from the mock `conn.cursor()` side_effect). No change needed in execution guard tests — the cursor ordering is:
+
+```
+budget_config → cash_balance → deployed_capital → mirror_equity(via portfolio) → tax_estimates → gbp_usd_rate
+```
+
+Wait — the ordering depends on where in `compute_budget_state` the `_load_mirror_equity` call sits. Let me verify. In budget.py:
+
+```python
+config = get_budget_config(conn)        # cursor 1
+cash_balance = _load_cash_balance(conn)  # cursor 2
+deployed = _load_deployed_capital(conn)  # cursor 3
+mirror_equity = Decimal(str(_load_mirror_equity(conn)))  # cursor 4 (now from portfolio)
+```
+
+So cursor 4 is now consumed by portfolio.py's `_load_mirror_equity`, which opens `conn.cursor()`. The mock side_effect still provides the mirror cursor at position 4. No test changes needed for execution guard.
+
+Run: `uv run pytest tests/test_execution_guard.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/budget.py tests/test_budget.py
+git commit -m "fix(#210): DRY mirror equity — budget.py imports portfolio.py's canonical version
+
+Removes budget.py's broken _load_mirror_equity() which referenced
+non-existent columns (cm.status, cmp.current_value). Now imports
+portfolio._load_mirror_equity() and wraps float→Decimal.
+
+Updates budget test mocks to patch the imported function instead
+of providing a cursor for the removed local query."
+```
+
+---
+
+### Task 3: Align `_load_mirror_equity` pricing to 3-tier
+
+The execution guard and budget service use `portfolio._load_mirror_equity()` which has 2-tier pricing (quote → open_rate). The dashboard uses `load_mirror_breakdowns()` which has 3-tier pricing (quote → price_daily → open_rate). This means budget state and dashboard AUM give different mirror equity values when quotes are missing but `price_daily` has data.
+
+**Files:**
+- Modify: `app/services/portfolio.py:303-330` (`_load_mirror_equity` SQL)
+- Test: `tests/test_portfolio.py`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/test_portfolio.py`, add a test that verifies `_load_mirror_equity` uses `price_daily.close` as a fallback when `quotes.last` is missing:
+
+```python
+class TestLoadMirrorEquityPricingFallback:
+    """Verify _load_mirror_equity uses 3-tier pricing: quote → price_daily → open_rate."""
+
+    def test_uses_price_daily_when_quote_missing(self) -> None:
+        """When quote.last is NULL but price_daily.close exists,
+        mirror equity should use price_daily.close for MTM."""
+        # This test runs against the mock DB — see test_portfolio.py
+        # patterns for how mirror equity is typically tested.
+        # The key assertion: with a position where close > open_rate,
+        # the mirror equity should be higher than when falling back to
+        # open_rate (which gives zero delta).
+        pass  # Implemented in the actual test step below
+```
+
+The exact test depends on the existing test patterns in `tests/test_portfolio.py`. Read the file's mirror equity tests and follow the mock pattern.
+
+Run: `uv run pytest tests/test_portfolio.py::TestLoadMirrorEquityPricingFallback -v`
+Expected: FAIL (test not yet implemented or assertion fails with 2-tier)
+
+- [ ] **Step 2: Add `price_daily` fallback to `_load_mirror_equity` SQL**
+
+In `app/services/portfolio.py`, update the `_load_mirror_equity` CTE (lines 303-330):
+
+```python
+    sql = """
+        WITH mirror_equity AS (
+            SELECT COALESCE(SUM(
+                m.available_amount + COALESCE(p.mv, 0)
+            ), 0) AS total
+            FROM copy_mirrors m
+            LEFT JOIN LATERAL (
+                SELECT SUM(
+                      cmp.amount
+                    + (CASE WHEN cmp.is_buy THEN 1 ELSE -1 END)
+                      * cmp.units
+                      * (COALESCE(q.last, pd.close, cmp.open_rate) - cmp.open_rate)
+                      * cmp.open_conversion_rate
+                ) AS mv
+                FROM copy_mirror_positions cmp
+                LEFT JOIN LATERAL (
+                    SELECT last
+                    FROM quotes
+                    WHERE instrument_id = cmp.instrument_id
+                    ORDER BY quoted_at DESC
+                    LIMIT 1
+                ) q ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT close
+                    FROM price_daily
+                    WHERE instrument_id = cmp.instrument_id
+                      AND close IS NOT NULL
+                    ORDER BY price_date DESC
+                    LIMIT 1
+                ) pd ON TRUE
+                WHERE cmp.mirror_id = m.mirror_id
+            ) p ON TRUE
+            WHERE m.active
+        )
+        SELECT total FROM mirror_equity
+    """
+```
+
+The only change is adding the `LEFT JOIN LATERAL` on `price_daily` and updating COALESCE from `COALESCE(q.last, cmp.open_rate)` to `COALESCE(q.last, pd.close, cmp.open_rate)`.
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_portfolio.py -v`
+Expected: All tests PASS (including the new 3-tier test)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/services/portfolio.py tests/test_portfolio.py
+git commit -m "fix(#210): align _load_mirror_equity to 3-tier pricing
+
+Adds price_daily.close fallback to _load_mirror_equity, matching
+the 3-tier hierarchy in load_mirror_breakdowns (quote → price_daily
+→ open_rate). Ensures budget state and dashboard AUM agree when
+quotes are missing but daily candles are available."
+```
+
+---
+
+### Task 4: Add smoke test for `GET /budget` endpoint
+
+The smoke test runs against the real dev DB. Adding `GET /budget` catches schema mismatches that mock-based unit tests cannot detect.
+
+**Files:**
+- Modify: `tests/smoke/test_app_boots.py`
+
+- [ ] **Step 1: Read the existing smoke test to understand the pattern**
+
+Read: `tests/smoke/test_app_boots.py`
+
+The existing test uses `TestClient` and asserts on HTTP status codes for various endpoints. Find the pattern and add a budget assertion.
+
+- [ ] **Step 2: Add `GET /budget` to the smoke test**
+
+Add an assertion that `GET /budget` returns 200 (budget_config singleton is seeded by migration 027):
+
+```python
+    # Budget state — exercises compute_budget_state against real schema.
+    # Catches column-name mismatches that mock-based tests cannot detect
+    # (e.g., the cm.status / cmp.current_value bug from PR #232).
+    resp = client.get("/budget", headers=auth_headers)
+    assert resp.status_code == 200, f"GET /budget returned {resp.status_code}: {resp.text}"
+    budget = resp.json()
+    assert "available_for_deployment" in budget
+```
+
+- [ ] **Step 3: Run the smoke test**
+
+Run: `uv run pytest tests/smoke/test_app_boots.py -v`
+Expected: PASS — `GET /budget` returns 200 with the real schema
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/smoke/test_app_boots.py
+git commit -m "test(#210): add GET /budget to smoke test
+
+Exercises compute_budget_state against the real dev DB schema.
+Catches column-name mismatches (cm.status, cmp.current_value)
+that mock-based unit tests cannot detect."
+```
+
+---
+
+### Task 5: Add mirror equity sanity check during sync
+
+Add a post-sync validation in `portfolio_sync.py` that logs a warning when mirror equity looks suspicious. This catches overstatements at sync time rather than waiting for the operator to notice.
+
+**Files:**
+- Modify: `app/services/portfolio_sync.py` (after `_sync_mirrors` returns)
+- Test: `tests/test_portfolio_sync.py`
+
+- [ ] **Step 1: Identify the sync call site**
+
+Read `app/services/portfolio_sync.py` and find where `_sync_mirrors` is called. The sanity check goes immediately after the sync completes.
+
+- [ ] **Step 2: Add validation logic**
+
+After `_sync_mirrors` completes, query each active mirror and validate:
+
+```python
+def _validate_mirror_equity(conn: psycopg.Connection[Any]) -> None:
+    """Log a warning if mirror equity looks inconsistent.
+
+    For each active mirror, compare:
+      funded = initial_investment + deposit_summary - withdrawal_summary
+      equity = available_amount + sum(position amounts)
+
+    If equity > 2× funded for any mirror, something is likely wrong
+    (double-counting, stale data, or semantic mismatch in available_amount).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("""
+            SELECT m.mirror_id, m.available_amount,
+                   m.initial_investment + m.deposit_summary
+                     - m.withdrawal_summary AS funded,
+                   COALESCE(p.total_amount, 0) AS positions_total
+            FROM copy_mirrors m
+            LEFT JOIN (
+                SELECT mirror_id, SUM(amount) AS total_amount
+                FROM copy_mirror_positions
+                GROUP BY mirror_id
+            ) p USING (mirror_id)
+            WHERE m.active
+        """)
+        rows = cur.fetchall()
+
+    for r in rows:
+        equity = float(r["available_amount"]) + float(r["positions_total"])
+        funded = float(r["funded"])
+        if funded > 0 and equity > 2 * funded:
+            logger.warning(
+                "Mirror %s equity (%.2f) > 2× funded (%.2f) — "
+                "possible double-count in available_amount; "
+                "equity=available(%.2f)+positions(%.2f)",
+                r["mirror_id"], equity, funded,
+                float(r["available_amount"]), float(r["positions_total"]),
+            )
+```
+
+Call this after `_sync_mirrors` returns in the main sync function.
+
+- [ ] **Step 3: Write a test for the validation**
+
+```python
+def test_validate_mirror_equity_warns_on_overstatement(caplog) -> None:
+    """When equity > 2× funded, a warning is logged."""
+    # Mock the conn to return a mirror with available_amount >> funded
+    ...
+    with caplog.at_level(logging.WARNING):
+        _validate_mirror_equity(conn)
+    assert "possible double-count" in caplog.text
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_portfolio_sync.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/portfolio_sync.py tests/test_portfolio_sync.py
+git commit -m "fix(#210): add mirror equity sanity check during sync
+
+Logs a warning when any mirror's computed equity exceeds 2× its
+funded capital, catching likely double-counting at sync time
+rather than waiting for the operator to notice AUM discrepancies."
+```
+
+---
+
+### Task 6: Fix the root cause (based on Task 1 findings)
+
+This task depends on the diagnostic results from Task 1. The fix will be one of:
+
+**If `available_amount` from eToro includes position values:**
+- In `_load_mirror_equity` and `load_mirror_breakdowns`, change the formula:
+  - FROM: `available_amount + SUM(position MTM)`
+  - TO: `available_amount` alone (positions are already included)
+  - OR: derive uninvested cash as `available_amount - SUM(initial_amount_in_dollars)` and use that
+
+**If `amount` in positions includes unrealized P&L:**
+- Change the MTM formula to use `initial_amount_in_dollars` as the cost base instead of `amount`
+- The delta `(current - open_rate) * ocr` would still represent the unrealized component
+
+**If duplicate or stale data exists:**
+- Fix the sync pipeline deduplication or the soft-close logic
+
+The exact code depends on the diagnosis. Update tests to match.
+
+- [ ] **Step 1: Implement the fix based on Task 1 findings**
+- [ ] **Step 2: Update all mirror equity calculations consistently** (portfolio.py `_load_mirror_equity`, `load_mirror_breakdowns`, and any test helpers)
+- [ ] **Step 3: Write regression test with the previously-incorrect values**
+- [ ] **Step 4: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "fix(#210): correct mirror equity root cause — [describe what changed]"
+```
+
+---
+
+## Self-review checklist
+
+1. **Spec coverage**: Task 1 covers diagnosis. Tasks 2-4 fix known code bugs. Task 5 adds observability. Task 6 fixes the root cause.
+2. **Placeholder scan**: Task 6 is intentionally contingent on Task 1 findings — it cannot be fully specified without data. All other tasks have complete code.
+3. **Type consistency**: `_load_mirror_equity` returns `float` (portfolio.py). Budget.py wraps in `Decimal(str(...))`. Execution guard uses float directly.

--- a/docs/superpowers/plans/2026-04-15-return-attribution.md
+++ b/docs/superpowers/plans/2026-04-15-return-attribution.md
@@ -1,0 +1,1599 @@
+# Return Attribution and Performance Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decompose realised returns for closed positions into attribution components (market, sector, model alpha, timing, costs) to create the feedback loop that tells us whether the scoring model generates alpha.
+
+**Architecture:** A pure service (`return_attribution.py`) computes attribution for a single closed position given its fills, the instrument's sector peers, and the scoring snapshot at entry. The service is triggered inline when `execute_order` processes an EXIT fill that zeroes out `current_units`. A scheduled summary worker aggregates attribution across all closed positions for rolling windows. An API endpoint exposes attribution data for the dashboard.
+
+**Tech Stack:** Python, psycopg3, Decimal arithmetic (no numpy/pandas — the decomposition is 5 subtractions on 2 price series)
+
+---
+
+## Settled decisions that apply
+
+- **Auditability**: persist structured evidence where it matters — attribution is the evidence layer for scoring model performance.
+- **Score auditability**: each score row carries per-family detail — we read these for the `score_components` snapshot.
+- **AUM basis**: mark-to-market first, fall back to cost basis — consistent with how we calculate returns.
+- **Provider design rule**: providers are thin adapters — attribution reads `price_daily` directly, no new provider needed.
+
+## Prevention log entries that apply
+
+- **conn.rollback() after caught exceptions on shared connections**: attribution runs inside `execute_order`'s connection — if attribution raises, the connection must be rolled back before proceeding.
+- **Kill-switch + auto_trading gate at pipeline call sites**: not directly relevant (attribution is passive/read + write, not an order action).
+
+## Scope decisions
+
+1. **No external benchmark ingestion.** Market return is computed from average `price_daily.close` returns across all Tier 1 instruments over the hold period. Sector return is computed from same-sector instruments. This uses only existing data.
+2. **Cost drag from `fills.fees`**, not `trade_cost_record` (#154 not built). When #154 lands, attribution can be enriched.
+3. **Attribution triggers on EXIT fill that zeroes out position** (not on every partial sell). Partial exits accumulate — attribution runs on full close.
+4. **Score snapshot comes from `trade_recommendations.score_id`** FK that already exists. No new column needed at entry time.
+5. **Summary worker is in-scope** — it's 3 SQL aggregates and a cron job, not a separate subsystem.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|------|---------------|
+| `sql/029_return_attribution.sql` | Migration: `return_attribution` + `return_attribution_summary` tables |
+| `app/services/return_attribution.py` | Core service: `compute_attribution(conn, instrument_id)` + `compute_attribution_summary(conn, window_days)` |
+| `app/services/order_client.py` | Modified: trigger attribution after EXIT fill zeroes position |
+| `app/workers/scheduler.py` | Modified: add `attribution_summary` scheduled job |
+| `app/jobs/runtime.py` | Modified: register new job |
+| `app/api/attribution.py` | API endpoint: GET attribution data |
+| `tests/test_return_attribution.py` | Unit tests for the attribution service |
+| `tests/test_attribution_trigger.py` | Tests for the order_client integration |
+| `tests/test_scheduler_attribution.py` | Tests for the summary job |
+
+---
+
+## Task 1: Migration — return_attribution tables
+
+**Files:**
+- Create: `sql/029_return_attribution.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Migration 029: return attribution tables
+--
+-- return_attribution: per-position decomposition of realised returns.
+-- Computed when a position is fully closed (current_units = 0 after EXIT fill).
+--
+-- return_attribution_summary: rolling-window aggregation of attribution
+-- components across all attributed positions.
+
+CREATE TABLE IF NOT EXISTS return_attribution (
+    attribution_id       BIGSERIAL PRIMARY KEY,
+    instrument_id        BIGINT NOT NULL REFERENCES instruments(instrument_id),
+    hold_start           DATE NOT NULL,
+    hold_end             DATE NOT NULL,
+    hold_days            INTEGER NOT NULL,
+    -- Return components (all as decimal fractions, e.g. 0.05 = 5%)
+    gross_return_pct     NUMERIC(12, 6) NOT NULL,
+    market_return_pct    NUMERIC(12, 6) NOT NULL,
+    sector_return_pct    NUMERIC(12, 6) NOT NULL,
+    model_alpha_pct      NUMERIC(12, 6) NOT NULL,
+    timing_alpha_pct     NUMERIC(12, 6) NOT NULL,
+    cost_drag_pct        NUMERIC(12, 6) NOT NULL,
+    residual_pct         NUMERIC(12, 6) NOT NULL,
+    -- Score snapshot at entry (from the recommendation's score_id)
+    score_at_entry       NUMERIC(10, 4),
+    score_components     JSONB,
+    -- Computation metadata
+    entry_fill_id        BIGINT REFERENCES fills(fill_id),
+    exit_fill_id         BIGINT REFERENCES fills(fill_id),
+    recommendation_id    BIGINT REFERENCES trade_recommendations(recommendation_id),
+    attribution_method   TEXT NOT NULL DEFAULT 'sector_relative_v1',
+    computed_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_return_attribution_instrument
+    ON return_attribution(instrument_id);
+CREATE INDEX IF NOT EXISTS idx_return_attribution_computed
+    ON return_attribution(computed_at);
+
+CREATE TABLE IF NOT EXISTS return_attribution_summary (
+    summary_id           BIGSERIAL PRIMARY KEY,
+    window_days          INTEGER NOT NULL,
+    positions_attributed INTEGER NOT NULL,
+    avg_gross_return_pct    NUMERIC(12, 6),
+    avg_market_return_pct   NUMERIC(12, 6),
+    avg_sector_return_pct   NUMERIC(12, 6),
+    avg_model_alpha_pct     NUMERIC(12, 6),
+    avg_timing_alpha_pct    NUMERIC(12, 6),
+    avg_cost_drag_pct       NUMERIC(12, 6),
+    computed_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+- [ ] **Step 2: Apply migration and verify**
+
+Run: `psql -f sql/029_return_attribution.sql ebull`
+Expected: no errors, tables created.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sql/029_return_attribution.sql
+git commit -m "feat(#155): migration 029 — return_attribution + summary tables"
+```
+
+---
+
+## Task 2: Attribution service — data loaders
+
+**Files:**
+- Create: `app/services/return_attribution.py`
+- Test: `tests/test_return_attribution.py`
+
+This task builds the internal data-loading helpers that the attribution computation will use. Each loads a specific piece of data from the DB.
+
+- [ ] **Step 1: Write failing tests for data loaders**
+
+```python
+"""Tests for app.services.return_attribution."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.return_attribution import (
+    _load_position_fills,
+    _load_price_series,
+    _load_score_snapshot,
+    _load_sector_peers,
+)
+
+
+def _make_conn(cursors: list[MagicMock]) -> MagicMock:
+    """Build a mock connection that returns cursors in sequence."""
+    conn = MagicMock()
+    cursor_iter = iter(cursors)
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(side_effect=lambda: next(cursor_iter))
+    ctx.__exit__ = MagicMock(return_value=False)
+    conn.cursor.return_value = ctx
+    return conn
+
+
+def _make_cursor(rows: list[dict[str, Any]]) -> MagicMock:
+    cur = MagicMock()
+    cur.fetchall.return_value = rows
+    cur.fetchone.return_value = rows[0] if rows else None
+    return cur
+
+
+class TestLoadPositionFills:
+    def test_returns_entry_and_exit_fills(self) -> None:
+        """Should return BUY fills as entries and EXIT fills as exits."""
+        fills = [
+            {
+                "fill_id": 1,
+                "action": "BUY",
+                "filled_at": datetime(2025, 1, 15, tzinfo=timezone.utc),
+                "price": Decimal("150.00"),
+                "units": Decimal("10.0"),
+                "fees": Decimal("1.50"),
+            },
+            {
+                "fill_id": 2,
+                "action": "EXIT",
+                "filled_at": datetime(2025, 6, 15, tzinfo=timezone.utc),
+                "price": Decimal("180.00"),
+                "units": Decimal("10.0"),
+                "fees": Decimal("1.80"),
+            },
+        ]
+        conn = _make_conn([_make_cursor(fills)])
+        result = _load_position_fills(conn, instrument_id=42)
+        assert len(result) == 2
+        assert result[0]["action"] == "BUY"
+        assert result[1]["action"] == "EXIT"
+
+    def test_empty_when_no_fills(self) -> None:
+        conn = _make_conn([_make_cursor([])])
+        result = _load_position_fills(conn, instrument_id=42)
+        assert result == []
+
+
+class TestLoadPriceSeries:
+    def test_returns_date_close_pairs(self) -> None:
+        rows = [
+            {"price_date": date(2025, 1, 15), "close": Decimal("150.00")},
+            {"price_date": date(2025, 6, 15), "close": Decimal("180.00")},
+        ]
+        conn = _make_conn([_make_cursor(rows)])
+        result = _load_price_series(
+            conn, instrument_id=42,
+            start_date=date(2025, 1, 15), end_date=date(2025, 6, 15),
+        )
+        assert len(result) == 2
+        assert result[0]["price_date"] == date(2025, 1, 15)
+
+
+class TestLoadScoreSnapshot:
+    def test_returns_score_components_from_score_id(self) -> None:
+        row = {
+            "total_score": Decimal("0.7500"),
+            "quality_score": Decimal("0.80"),
+            "value_score": Decimal("0.65"),
+            "turnaround_score": Decimal("0.30"),
+            "momentum_score": Decimal("0.70"),
+            "sentiment_score": Decimal("0.60"),
+            "confidence_score": Decimal("0.85"),
+            "model_version": "v1.1-balanced",
+        }
+        conn = _make_conn([_make_cursor([row])])
+        result = _load_score_snapshot(conn, score_id=100)
+        assert result is not None
+        assert result["total_score"] == Decimal("0.7500")
+
+    def test_returns_none_when_no_score(self) -> None:
+        conn = _make_conn([_make_cursor([])])
+        result = _load_score_snapshot(conn, score_id=None)
+        assert result is None
+
+
+class TestLoadSectorPeers:
+    def test_returns_instrument_ids_in_same_sector(self) -> None:
+        rows = [{"instrument_id": 10}, {"instrument_id": 20}]
+        conn = _make_conn([_make_cursor(rows)])
+        result = _load_sector_peers(conn, instrument_id=42)
+        assert result == [10, 20]
+
+    def test_excludes_self(self) -> None:
+        """The target instrument must not appear in its own peer list."""
+        rows = [{"instrument_id": 10}]
+        conn = _make_conn([_make_cursor(rows)])
+        result = _load_sector_peers(conn, instrument_id=42)
+        assert 42 not in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_return_attribution.py -v`
+Expected: ImportError — module does not exist yet.
+
+- [ ] **Step 3: Implement data loaders**
+
+```python
+"""Return attribution service — decompose realised position returns.
+
+Decomposes the gross return of a closed position into:
+  - market_return:  average return of all Tier 1 instruments over hold period
+  - sector_return:  average return of same-sector instruments over hold period
+  - model_alpha:    instrument return minus sector return (sector-relative alpha)
+  - timing_alpha:   difference between actual entry price and price at scoring time
+  - cost_drag:      total fees as fraction of cost basis
+  - residual:       gross - (market + sector_excess + timing + costs)
+
+Design:
+  - Pure service: caller provides the connection.
+  - All arithmetic uses Decimal to avoid float rounding on financial data.
+  - NULL-safe: missing data → component set to Decimal("0").
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from psycopg.types.json import Jsonb
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ATTRIBUTION_METHOD = "sector_relative_v1"
+
+ZERO = Decimal("0")
+
+# Summary windows (days)
+SUMMARY_WINDOWS: tuple[int, ...] = (30, 90, 365)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AttributionResult:
+    """Decomposed return for a single closed position."""
+
+    instrument_id: int
+    hold_start: date
+    hold_end: date
+    hold_days: int
+    gross_return_pct: Decimal
+    market_return_pct: Decimal
+    sector_return_pct: Decimal
+    model_alpha_pct: Decimal
+    timing_alpha_pct: Decimal
+    cost_drag_pct: Decimal
+    residual_pct: Decimal
+    score_at_entry: Decimal | None
+    score_components: dict[str, Any] | None
+    entry_fill_id: int | None
+    exit_fill_id: int | None
+    recommendation_id: int | None
+
+
+@dataclass(frozen=True)
+class SummaryResult:
+    """Aggregated attribution over a rolling window."""
+
+    window_days: int
+    positions_attributed: int
+    avg_gross_return_pct: Decimal | None
+    avg_market_return_pct: Decimal | None
+    avg_sector_return_pct: Decimal | None
+    avg_model_alpha_pct: Decimal | None
+    avg_timing_alpha_pct: Decimal | None
+    avg_cost_drag_pct: Decimal | None
+
+
+# ---------------------------------------------------------------------------
+# Internal data loaders
+# ---------------------------------------------------------------------------
+
+
+def _load_position_fills(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> list[dict[str, Any]]:
+    """Load all fills for an instrument, joined with order action, oldest first."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT f.fill_id, o.action, f.filled_at, f.price, f.units, f.fees
+            FROM fills f
+            JOIN orders o USING (order_id)
+            WHERE o.instrument_id = %(iid)s
+            ORDER BY f.filled_at ASC, f.fill_id ASC
+            """,
+            {"iid": instrument_id},
+        )
+        return cur.fetchall()
+
+
+def _load_price_series(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    start_date: date,
+    end_date: date,
+) -> list[dict[str, Any]]:
+    """Load daily close prices for an instrument within a date range."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT price_date, close
+            FROM price_daily
+            WHERE instrument_id = %(iid)s
+              AND price_date >= %(start)s
+              AND price_date <= %(end)s
+            ORDER BY price_date ASC
+            """,
+            {"iid": instrument_id, "start": start_date, "end": end_date},
+        )
+        return cur.fetchall()
+
+
+def _load_score_snapshot(
+    conn: psycopg.Connection[Any],
+    score_id: int | None,
+) -> dict[str, Any] | None:
+    """Load the scoring snapshot for a given score_id.
+
+    Returns None if score_id is None or the row doesn't exist.
+    """
+    if score_id is None:
+        return None
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT total_score,
+                   quality_score, value_score, turnaround_score,
+                   momentum_score, sentiment_score, confidence_score,
+                   model_version
+            FROM scores
+            WHERE score_id = %(sid)s
+            """,
+            {"sid": score_id},
+        )
+        return cur.fetchone()
+
+
+def _load_sector_peers(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> list[int]:
+    """Load Tier 1 instrument_ids in the same sector, excluding self.
+
+    Uses coverage.tier = 1 to limit to the active universe.
+    Falls back to all instruments in the same sector if coverage
+    doesn't exist for this instrument's sector.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT i2.instrument_id
+            FROM instruments i1
+            JOIN instruments i2 ON i2.sector = i1.sector
+                               AND i2.instrument_id != i1.instrument_id
+            LEFT JOIN coverage c ON c.instrument_id = i2.instrument_id
+            WHERE i1.instrument_id = %(iid)s
+              AND i2.is_tradable = TRUE
+              AND (c.tier = 1 OR c.tier IS NULL)
+            """,
+            {"iid": instrument_id},
+        )
+        return [row["instrument_id"] for row in cur.fetchall()]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_return_attribution.py -v`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/return_attribution.py tests/test_return_attribution.py
+git commit -m "feat(#155): return attribution data loaders + tests"
+```
+
+---
+
+## Task 3: Attribution service — computation logic
+
+**Files:**
+- Modify: `app/services/return_attribution.py`
+- Test: `tests/test_return_attribution.py`
+
+This task adds the core `compute_attribution` function that decomposes a position's return.
+
+- [ ] **Step 1: Write failing tests for compute_attribution**
+
+Add to `tests/test_return_attribution.py`:
+
+```python
+from app.services.return_attribution import (
+    AttributionResult,
+    compute_attribution,
+    _compute_average_return,
+)
+
+
+class TestComputeAverageReturn:
+    def test_simple_return(self) -> None:
+        """Average return from a price series is (last - first) / first."""
+        prices = [
+            {"price_date": date(2025, 1, 1), "close": Decimal("100")},
+            {"price_date": date(2025, 1, 2), "close": Decimal("110")},
+        ]
+        result = _compute_average_return(prices)
+        assert result == Decimal("0.1")  # 10%
+
+    def test_empty_series_returns_zero(self) -> None:
+        assert _compute_average_return([]) == Decimal("0")
+
+    def test_single_price_returns_zero(self) -> None:
+        prices = [{"price_date": date(2025, 1, 1), "close": Decimal("100")}]
+        assert _compute_average_return(prices) == Decimal("0")
+
+
+class TestComputeAttribution:
+    def test_full_decomposition(self) -> None:
+        """Known numbers: verify decomposition components sum correctly.
+
+        Setup:
+          - Bought at 100, sold at 120 → gross = 20%
+          - Market returned 5% over the hold period
+          - Sector returned 8% over the hold period
+          - Score existed at entry with price 98 → timing = (100-98)/98 lost
+          - Fees: 2 on buy + 2.40 on sell = 4.40 on cost 1000 → 0.44%
+        """
+        # Build mock connection with sequenced cursor returns.
+        # compute_attribution calls: _load_position_fills, _load_price_series
+        # (instrument), _load_recommendation_for_instrument,
+        # _load_score_snapshot, _load_sector_peers, then for each peer:
+        # _load_price_series(peer). Plus _load_price_series for all Tier 1
+        # (market return).
+        #
+        # For this test we mock at a higher level — patch the internal loaders.
+        pass  # Implemented in step 3 via patching
+
+    def test_no_fills_returns_none(self) -> None:
+        """If there are no fills, attribution cannot be computed."""
+        conn = _make_conn([_make_cursor([])])
+        result = compute_attribution(conn, instrument_id=42)
+        assert result is None
+
+    def test_no_exit_fill_returns_none(self) -> None:
+        """If there are only BUY fills (position still open), return None."""
+        fills = [
+            {
+                "fill_id": 1, "action": "BUY",
+                "filled_at": datetime(2025, 1, 15, tzinfo=timezone.utc),
+                "price": Decimal("150"), "units": Decimal("10"), "fees": Decimal("1"),
+            },
+        ]
+        conn = _make_conn([_make_cursor(fills)])
+        result = compute_attribution(conn, instrument_id=42)
+        assert result is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_return_attribution.py::TestComputeAttribution -v`
+Expected: ImportError for `compute_attribution`.
+
+- [ ] **Step 3: Write full decomposition test with patched loaders**
+
+Replace the `test_full_decomposition` placeholder and add patched test:
+
+```python
+from unittest.mock import patch
+
+_SVC = "app.services.return_attribution"
+
+
+class TestComputeAttribution:
+    def test_no_fills_returns_none(self) -> None:
+        """If there are no fills, attribution cannot be computed."""
+        conn = MagicMock()
+        with patch(f"{_SVC}._load_position_fills", return_value=[]):
+            result = compute_attribution(conn, instrument_id=42)
+        assert result is None
+
+    def test_no_exit_fill_returns_none(self) -> None:
+        """Position still open → no attribution."""
+        fills = [
+            {
+                "fill_id": 1, "action": "BUY",
+                "filled_at": datetime(2025, 1, 15, tzinfo=timezone.utc),
+                "price": Decimal("150"), "units": Decimal("10"), "fees": Decimal("1"),
+            },
+        ]
+        conn = MagicMock()
+        with patch(f"{_SVC}._load_position_fills", return_value=fills):
+            result = compute_attribution(conn, instrument_id=42)
+        assert result is None
+
+    @patch(f"{_SVC}._load_sector_peers", return_value=[10, 20])
+    @patch(f"{_SVC}._load_score_snapshot", return_value={
+        "total_score": Decimal("0.75"),
+        "quality_score": Decimal("0.80"), "value_score": Decimal("0.65"),
+        "turnaround_score": Decimal("0.30"), "momentum_score": Decimal("0.70"),
+        "sentiment_score": Decimal("0.60"), "confidence_score": Decimal("0.85"),
+        "model_version": "v1.1-balanced",
+    })
+    @patch(f"{_SVC}._load_recommendation_for_fills")
+    @patch(f"{_SVC}._load_price_series")
+    @patch(f"{_SVC}._load_position_fills")
+    def test_full_decomposition(
+        self,
+        mock_fills: MagicMock,
+        mock_prices: MagicMock,
+        mock_rec: MagicMock,
+        mock_score: MagicMock,
+        mock_peers: MagicMock,
+    ) -> None:
+        """Verify decomposition with known numbers."""
+        # Entry: BUY 10 units at 100 (fees=2), Exit: EXIT 10 at 120 (fees=2.40)
+        mock_fills.return_value = [
+            {"fill_id": 1, "action": "BUY",
+             "filled_at": datetime(2025, 1, 15, tzinfo=timezone.utc),
+             "price": Decimal("100"), "units": Decimal("10"), "fees": Decimal("2")},
+            {"fill_id": 2, "action": "EXIT",
+             "filled_at": datetime(2025, 6, 15, tzinfo=timezone.utc),
+             "price": Decimal("120"), "units": Decimal("10"), "fees": Decimal("2.40")},
+        ]
+
+        mock_rec.return_value = {"recommendation_id": 50, "score_id": 100}
+
+        # Price series for instrument (100 → 120)
+        instrument_prices = [
+            {"price_date": date(2025, 1, 15), "close": Decimal("100")},
+            {"price_date": date(2025, 6, 15), "close": Decimal("120")},
+        ]
+        # Price series for sector peers (avg 108 → return ~8% each)
+        peer_prices = [
+            {"price_date": date(2025, 1, 15), "close": Decimal("50")},
+            {"price_date": date(2025, 6, 15), "close": Decimal("54")},
+        ]
+        # Market prices — Tier 1 average
+        market_prices = [
+            {"price_date": date(2025, 1, 15), "close": Decimal("200")},
+            {"price_date": date(2025, 6, 15), "close": Decimal("210")},
+        ]
+
+        # _load_price_series is called for: instrument, each peer, then market
+        mock_prices.side_effect = [
+            instrument_prices,  # instrument
+            peer_prices,        # peer 10
+            peer_prices,        # peer 20
+            market_prices,      # market (all Tier 1)
+        ]
+
+        conn = MagicMock()
+        result = compute_attribution(conn, instrument_id=42)
+
+        assert result is not None
+        assert result.instrument_id == 42
+        # gross = (120-100)/100 = 0.20
+        assert result.gross_return_pct == Decimal("0.2")
+        # Check components are populated (exact values depend on implementation)
+        assert isinstance(result.model_alpha_pct, Decimal)
+        assert isinstance(result.cost_drag_pct, Decimal)
+        # cost_drag = (2 + 2.40) / (100 * 10) = 0.0044
+        assert result.cost_drag_pct == Decimal("0.0044")
+        # residual should be small (gross - sum of components)
+        assert result.score_at_entry == Decimal("0.75")
+        assert result.entry_fill_id == 1
+        assert result.exit_fill_id == 2
+
+    @patch(f"{_SVC}._load_sector_peers", return_value=[])
+    @patch(f"{_SVC}._load_score_snapshot", return_value=None)
+    @patch(f"{_SVC}._load_recommendation_for_fills", return_value=None)
+    @patch(f"{_SVC}._load_price_series", return_value=[])
+    @patch(f"{_SVC}._load_position_fills")
+    def test_no_price_data_graceful(
+        self,
+        mock_fills: MagicMock,
+        mock_prices: MagicMock,
+        mock_rec: MagicMock,
+        mock_score: MagicMock,
+        mock_peers: MagicMock,
+    ) -> None:
+        """Missing price data → components default to zero, gross from fills."""
+        mock_fills.return_value = [
+            {"fill_id": 1, "action": "BUY",
+             "filled_at": datetime(2025, 1, 15, tzinfo=timezone.utc),
+             "price": Decimal("100"), "units": Decimal("10"), "fees": Decimal("0")},
+            {"fill_id": 2, "action": "EXIT",
+             "filled_at": datetime(2025, 6, 15, tzinfo=timezone.utc),
+             "price": Decimal("120"), "units": Decimal("10"), "fees": Decimal("0")},
+        ]
+        conn = MagicMock()
+        result = compute_attribution(conn, instrument_id=42)
+        assert result is not None
+        assert result.gross_return_pct == Decimal("0.2")
+        assert result.market_return_pct == ZERO
+        assert result.sector_return_pct == ZERO
+```
+
+- [ ] **Step 4: Implement compute_attribution**
+
+Add to `app/services/return_attribution.py`:
+
+```python
+def _compute_average_return(prices: list[dict[str, Any]]) -> Decimal:
+    """Compute simple return from first to last close price.
+
+    Returns (last - first) / first as a Decimal fraction.
+    Returns Decimal("0") if fewer than 2 prices.
+    """
+    if len(prices) < 2:
+        return ZERO
+    first = Decimal(str(prices[0]["close"]))
+    last = Decimal(str(prices[-1]["close"]))
+    if first == ZERO:
+        return ZERO
+    return (last - first) / first
+
+
+def _load_recommendation_for_fills(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> dict[str, Any] | None:
+    """Load the most recent executed recommendation for an instrument.
+
+    Returns recommendation_id + score_id, or None if no executed rec exists.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT recommendation_id, score_id
+            FROM trade_recommendations
+            WHERE instrument_id = %(iid)s
+              AND status = 'executed'
+              AND action IN ('BUY', 'ADD')
+            ORDER BY recommendation_id DESC
+            LIMIT 1
+            """,
+            {"iid": instrument_id},
+        )
+        return cur.fetchone()
+
+
+def _compute_market_return(
+    conn: psycopg.Connection[Any],
+    start_date: date,
+    end_date: date,
+) -> Decimal:
+    """Compute the average return across all Tier 1 instruments (market proxy).
+
+    Loads price_daily for each Tier 1 instrument over the hold period,
+    computes each instrument's return, and averages them.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT c.instrument_id
+            FROM coverage c
+            WHERE c.tier = 1
+            """,
+        )
+        tier1_ids = [row["instrument_id"] for row in cur.fetchall()]
+
+    if not tier1_ids:
+        return ZERO
+
+    returns: list[Decimal] = []
+    for iid in tier1_ids:
+        prices = _load_price_series(conn, iid, start_date, end_date)
+        ret = _compute_average_return(prices)
+        returns.append(ret)
+
+    if not returns:
+        return ZERO
+    return sum(returns, ZERO) / Decimal(str(len(returns)))
+
+
+def _compute_sector_return(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    start_date: date,
+    end_date: date,
+) -> Decimal:
+    """Compute the average return of same-sector peers over the hold period."""
+    peer_ids = _load_sector_peers(conn, instrument_id)
+    if not peer_ids:
+        return ZERO
+
+    returns: list[Decimal] = []
+    for pid in peer_ids:
+        prices = _load_price_series(conn, pid, start_date, end_date)
+        ret = _compute_average_return(prices)
+        returns.append(ret)
+
+    if not returns:
+        return ZERO
+    return sum(returns, ZERO) / Decimal(str(len(returns)))
+
+
+def compute_attribution(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> AttributionResult | None:
+    """Compute return attribution for a closed position.
+
+    Returns None if:
+      - No fills exist for the instrument.
+      - No EXIT fill exists (position still open).
+
+    Decomposition (sector_relative_v1):
+      gross_return  = (avg_exit_price - avg_entry_price) / avg_entry_price
+      market_return = average return of all Tier 1 instruments over hold period
+      sector_return = average return of same-sector peers over hold period
+      model_alpha   = gross_return - sector_return  (sector-relative outperformance)
+      timing_alpha  = Decimal("0")  (placeholder — requires scored-price data)
+      cost_drag     = total_fees / cost_basis
+      residual      = gross - (market + (sector - market) + model_alpha + timing + cost)
+                    = gross - sector - model_alpha - timing - cost
+
+    All components are decimal fractions (0.05 = 5%).
+    """
+    fills = _load_position_fills(conn, instrument_id)
+    if not fills:
+        return None
+
+    entry_fills = [f for f in fills if f["action"] in ("BUY", "ADD")]
+    exit_fills = [f for f in fills if f["action"] == "EXIT"]
+
+    if not entry_fills or not exit_fills:
+        return None
+
+    # Weighted average entry and exit prices
+    total_entry_cost = sum(
+        Decimal(str(f["price"])) * Decimal(str(f["units"])) for f in entry_fills
+    )
+    total_entry_units = sum(Decimal(str(f["units"])) for f in entry_fills)
+
+    total_exit_proceeds = sum(
+        Decimal(str(f["price"])) * Decimal(str(f["units"])) for f in exit_fills
+    )
+    total_exit_units = sum(Decimal(str(f["units"])) for f in exit_fills)
+
+    if total_entry_units == ZERO or total_entry_cost == ZERO:
+        return None
+
+    avg_entry_price = total_entry_cost / total_entry_units
+    avg_exit_price = total_exit_proceeds / total_exit_units
+
+    # Gross return
+    gross_return = (avg_exit_price - avg_entry_price) / avg_entry_price
+
+    # Hold period
+    hold_start = entry_fills[0]["filled_at"].date()
+    hold_end = exit_fills[-1]["filled_at"].date()
+    hold_days = (hold_end - hold_start).days
+
+    # Cost drag: total fees / cost basis
+    total_fees = sum(Decimal(str(f["fees"])) for f in fills)
+    cost_drag = total_fees / total_entry_cost if total_entry_cost != ZERO else ZERO
+
+    # Market and sector returns
+    market_return = _compute_market_return(conn, hold_start, hold_end)
+    sector_return = _compute_sector_return(conn, instrument_id, hold_start, hold_end)
+
+    # Model alpha: instrument outperformance vs sector
+    model_alpha = gross_return - sector_return
+
+    # Timing alpha: placeholder for v1 (requires scored_at price vs fill price)
+    timing_alpha = ZERO
+
+    # Residual: gross - all components
+    residual = gross_return - market_return - (sector_return - market_return) - model_alpha - timing_alpha - cost_drag
+    # Simplifies to: gross - sector - model_alpha - timing - cost
+    # = gross - sector - (gross - sector) - 0 - cost
+    # = -cost
+    # Correct: residual absorbs the cost drag difference.
+    # Recompute cleanly:
+    residual = gross_return - (market_return + (sector_return - market_return) + model_alpha + timing_alpha + cost_drag)
+
+    # Score snapshot
+    rec = _load_recommendation_for_fills(conn, instrument_id)
+    score_id = rec["score_id"] if rec else None
+    rec_id = rec["recommendation_id"] if rec else None
+    score_snapshot = _load_score_snapshot(conn, score_id)
+
+    score_at_entry: Decimal | None = None
+    score_components: dict[str, Any] | None = None
+    if score_snapshot is not None:
+        score_at_entry = Decimal(str(score_snapshot["total_score"]))
+        score_components = {
+            k: float(score_snapshot[k])
+            for k in (
+                "quality_score", "value_score", "turnaround_score",
+                "momentum_score", "sentiment_score", "confidence_score",
+            )
+        }
+
+    return AttributionResult(
+        instrument_id=instrument_id,
+        hold_start=hold_start,
+        hold_end=hold_end,
+        hold_days=hold_days,
+        gross_return_pct=gross_return,
+        market_return_pct=market_return,
+        sector_return_pct=sector_return,
+        model_alpha_pct=model_alpha,
+        timing_alpha_pct=timing_alpha,
+        cost_drag_pct=cost_drag,
+        residual_pct=residual,
+        score_at_entry=score_at_entry,
+        score_components=score_components,
+        entry_fill_id=entry_fills[0]["fill_id"],
+        exit_fill_id=exit_fills[-1]["fill_id"],
+        recommendation_id=rec_id,
+    )
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/test_return_attribution.py -v`
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/return_attribution.py tests/test_return_attribution.py
+git commit -m "feat(#155): compute_attribution — return decomposition logic"
+```
+
+---
+
+## Task 4: Attribution service — persist + summary
+
+**Files:**
+- Modify: `app/services/return_attribution.py`
+- Test: `tests/test_return_attribution.py`
+
+- [ ] **Step 1: Write failing tests for persist and summary**
+
+Add to `tests/test_return_attribution.py`:
+
+```python
+from app.services.return_attribution import (
+    persist_attribution,
+    compute_attribution_summary,
+    SummaryResult,
+)
+
+
+class TestPersistAttribution:
+    def test_inserts_row(self) -> None:
+        """persist_attribution should INSERT into return_attribution."""
+        result = AttributionResult(
+            instrument_id=42,
+            hold_start=date(2025, 1, 15),
+            hold_end=date(2025, 6, 15),
+            hold_days=151,
+            gross_return_pct=Decimal("0.20"),
+            market_return_pct=Decimal("0.05"),
+            sector_return_pct=Decimal("0.08"),
+            model_alpha_pct=Decimal("0.12"),
+            timing_alpha_pct=ZERO,
+            cost_drag_pct=Decimal("0.0044"),
+            residual_pct=Decimal("-0.0044"),
+            score_at_entry=Decimal("0.75"),
+            score_components={"quality_score": 0.8},
+            entry_fill_id=1,
+            exit_fill_id=2,
+            recommendation_id=50,
+        )
+        conn = MagicMock()
+        persist_attribution(conn, result)
+        conn.execute.assert_called_once()
+        sql = conn.execute.call_args[0][0]
+        assert "INSERT INTO return_attribution" in sql
+
+
+class TestComputeAttributionSummary:
+    def test_aggregates_over_window(self) -> None:
+        """Should SELECT AVG from return_attribution within window."""
+        row = {
+            "positions_attributed": 5,
+            "avg_gross_return_pct": Decimal("0.10"),
+            "avg_market_return_pct": Decimal("0.04"),
+            "avg_sector_return_pct": Decimal("0.06"),
+            "avg_model_alpha_pct": Decimal("0.04"),
+            "avg_timing_alpha_pct": ZERO,
+            "avg_cost_drag_pct": Decimal("0.003"),
+        }
+        conn = _make_conn([_make_cursor([row])])
+        result = compute_attribution_summary(conn, window_days=90)
+        assert result.window_days == 90
+        assert result.positions_attributed == 5
+        assert result.avg_model_alpha_pct == Decimal("0.04")
+
+    def test_empty_window_returns_zeros(self) -> None:
+        row = {
+            "positions_attributed": 0,
+            "avg_gross_return_pct": None,
+            "avg_market_return_pct": None,
+            "avg_sector_return_pct": None,
+            "avg_model_alpha_pct": None,
+            "avg_timing_alpha_pct": None,
+            "avg_cost_drag_pct": None,
+        }
+        conn = _make_conn([_make_cursor([row])])
+        result = compute_attribution_summary(conn, window_days=90)
+        assert result.positions_attributed == 0
+        assert result.avg_gross_return_pct is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_return_attribution.py::TestPersistAttribution -v`
+Expected: ImportError for `persist_attribution`.
+
+- [ ] **Step 3: Implement persist_attribution and compute_attribution_summary**
+
+Add to `app/services/return_attribution.py`:
+
+```python
+def persist_attribution(
+    conn: psycopg.Connection[Any],
+    result: AttributionResult,
+) -> None:
+    """Insert an attribution row. Must be called inside a transaction."""
+    conn.execute(
+        """
+        INSERT INTO return_attribution (
+            instrument_id, hold_start, hold_end, hold_days,
+            gross_return_pct, market_return_pct, sector_return_pct,
+            model_alpha_pct, timing_alpha_pct, cost_drag_pct, residual_pct,
+            score_at_entry, score_components,
+            entry_fill_id, exit_fill_id, recommendation_id,
+            attribution_method
+        ) VALUES (
+            %(iid)s, %(start)s, %(end)s, %(days)s,
+            %(gross)s, %(market)s, %(sector)s,
+            %(alpha)s, %(timing)s, %(cost)s, %(residual)s,
+            %(score)s, %(components)s,
+            %(entry_fill)s, %(exit_fill)s, %(rec_id)s,
+            %(method)s
+        )
+        """,
+        {
+            "iid": result.instrument_id,
+            "start": result.hold_start,
+            "end": result.hold_end,
+            "days": result.hold_days,
+            "gross": result.gross_return_pct,
+            "market": result.market_return_pct,
+            "sector": result.sector_return_pct,
+            "alpha": result.model_alpha_pct,
+            "timing": result.timing_alpha_pct,
+            "cost": result.cost_drag_pct,
+            "residual": result.residual_pct,
+            "score": result.score_at_entry,
+            "components": Jsonb(result.score_components) if result.score_components else None,
+            "entry_fill": result.entry_fill_id,
+            "exit_fill": result.exit_fill_id,
+            "rec_id": result.recommendation_id,
+            "method": ATTRIBUTION_METHOD,
+        },
+    )
+
+
+def compute_attribution_summary(
+    conn: psycopg.Connection[Any],
+    window_days: int,
+) -> SummaryResult:
+    """Aggregate attribution components over a rolling window.
+
+    Reads from return_attribution where computed_at >= NOW() - window_days.
+    Returns a SummaryResult with averages (None if no rows in window).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT
+                COUNT(*)::INTEGER AS positions_attributed,
+                AVG(gross_return_pct) AS avg_gross_return_pct,
+                AVG(market_return_pct) AS avg_market_return_pct,
+                AVG(sector_return_pct) AS avg_sector_return_pct,
+                AVG(model_alpha_pct) AS avg_model_alpha_pct,
+                AVG(timing_alpha_pct) AS avg_timing_alpha_pct,
+                AVG(cost_drag_pct) AS avg_cost_drag_pct
+            FROM return_attribution
+            WHERE computed_at >= NOW() - MAKE_INTERVAL(days => %(window)s)
+            """,
+            {"window": window_days},
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        return SummaryResult(
+            window_days=window_days,
+            positions_attributed=0,
+            avg_gross_return_pct=None,
+            avg_market_return_pct=None,
+            avg_sector_return_pct=None,
+            avg_model_alpha_pct=None,
+            avg_timing_alpha_pct=None,
+            avg_cost_drag_pct=None,
+        )
+
+    return SummaryResult(
+        window_days=window_days,
+        positions_attributed=int(row["positions_attributed"]),
+        avg_gross_return_pct=row["avg_gross_return_pct"],
+        avg_market_return_pct=row["avg_market_return_pct"],
+        avg_sector_return_pct=row["avg_sector_return_pct"],
+        avg_model_alpha_pct=row["avg_model_alpha_pct"],
+        avg_timing_alpha_pct=row["avg_timing_alpha_pct"],
+        avg_cost_drag_pct=row["avg_cost_drag_pct"],
+    )
+
+
+def persist_attribution_summary(
+    conn: psycopg.Connection[Any],
+    result: SummaryResult,
+) -> None:
+    """Insert a summary row. Must be called inside a transaction."""
+    conn.execute(
+        """
+        INSERT INTO return_attribution_summary (
+            window_days, positions_attributed,
+            avg_gross_return_pct, avg_market_return_pct,
+            avg_sector_return_pct, avg_model_alpha_pct,
+            avg_timing_alpha_pct, avg_cost_drag_pct
+        ) VALUES (
+            %(window)s, %(count)s,
+            %(gross)s, %(market)s, %(sector)s,
+            %(alpha)s, %(timing)s, %(cost)s
+        )
+        """,
+        {
+            "window": result.window_days,
+            "count": result.positions_attributed,
+            "gross": result.avg_gross_return_pct,
+            "market": result.avg_market_return_pct,
+            "sector": result.avg_sector_return_pct,
+            "alpha": result.avg_model_alpha_pct,
+            "timing": result.avg_timing_alpha_pct,
+            "cost": result.avg_cost_drag_pct,
+        },
+    )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_return_attribution.py -v`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/return_attribution.py tests/test_return_attribution.py
+git commit -m "feat(#155): persist_attribution + summary aggregation"
+```
+
+---
+
+## Task 5: Trigger attribution from order_client
+
+**Files:**
+- Modify: `app/services/order_client.py`
+- Test: `tests/test_attribution_trigger.py`
+
+When `execute_order` processes an EXIT fill and the position reaches `current_units = 0`, trigger `compute_attribution` + `persist_attribution`.
+
+- [ ] **Step 1: Write failing test for the trigger**
+
+Create `tests/test_attribution_trigger.py`:
+
+```python
+"""Tests that EXIT fills trigger return attribution."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from app.services.return_attribution import AttributionResult
+
+
+_ORDER_CLIENT = "app.services.order_client"
+
+
+class TestAttributionTrigger:
+    @patch(f"{_ORDER_CLIENT}.persist_attribution")
+    @patch(f"{_ORDER_CLIENT}.compute_attribution")
+    def test_attribution_triggered_on_full_close(
+        self,
+        mock_compute: MagicMock,
+        mock_persist: MagicMock,
+    ) -> None:
+        """When an EXIT fill zeroes current_units, attribution should run."""
+        from app.services.order_client import _maybe_trigger_attribution
+
+        mock_compute.return_value = MagicMock(spec=AttributionResult)
+        conn = MagicMock()
+
+        # current_units after exit = 0 → should trigger
+        _maybe_trigger_attribution(conn, instrument_id=42, current_units_after=Decimal("0"))
+
+        mock_compute.assert_called_once_with(conn, 42)
+        mock_persist.assert_called_once()
+
+    @patch(f"{_ORDER_CLIENT}.persist_attribution")
+    @patch(f"{_ORDER_CLIENT}.compute_attribution")
+    def test_attribution_not_triggered_when_position_open(
+        self,
+        mock_compute: MagicMock,
+        mock_persist: MagicMock,
+    ) -> None:
+        """If current_units > 0 after exit, no attribution."""
+        from app.services.order_client import _maybe_trigger_attribution
+
+        conn = MagicMock()
+        _maybe_trigger_attribution(conn, instrument_id=42, current_units_after=Decimal("5"))
+
+        mock_compute.assert_not_called()
+        mock_persist.assert_not_called()
+
+    @patch(f"{_ORDER_CLIENT}.compute_attribution", return_value=None)
+    def test_attribution_none_result_no_persist(
+        self,
+        mock_compute: MagicMock,
+    ) -> None:
+        """If compute_attribution returns None (e.g. missing data), skip persist."""
+        from app.services.order_client import _maybe_trigger_attribution
+
+        conn = MagicMock()
+        _maybe_trigger_attribution(conn, instrument_id=42, current_units_after=Decimal("0"))
+
+        mock_compute.assert_called_once()
+        # persist should not have been called since compute returned None
+
+    @patch(f"{_ORDER_CLIENT}.compute_attribution", side_effect=Exception("DB error"))
+    def test_attribution_error_does_not_break_order(
+        self,
+        mock_compute: MagicMock,
+    ) -> None:
+        """Attribution failure must not abort the order execution."""
+        from app.services.order_client import _maybe_trigger_attribution
+
+        conn = MagicMock()
+        # Should not raise — attribution errors are logged and swallowed
+        _maybe_trigger_attribution(conn, instrument_id=42, current_units_after=Decimal("0"))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_attribution_trigger.py -v`
+Expected: ImportError for `_maybe_trigger_attribution`.
+
+- [ ] **Step 3: Implement the trigger in order_client.py**
+
+Add to `app/services/order_client.py` (near the other internal helpers):
+
+```python
+from app.services.return_attribution import (
+    compute_attribution,
+    persist_attribution,
+)
+
+
+def _maybe_trigger_attribution(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    current_units_after: Decimal,
+) -> None:
+    """Compute and persist return attribution if the position is fully closed.
+
+    Called after an EXIT fill updates the position. If current_units_after is
+    zero (or negative due to rounding), the position is closed and attribution
+    is computed.
+
+    Errors are logged and swallowed — attribution is best-effort and must
+    never abort the order execution path.
+    """
+    if current_units_after > Decimal("0"):
+        return
+
+    try:
+        result = compute_attribution(conn, instrument_id)
+        if result is not None:
+            persist_attribution(conn, result)
+            logger.info(
+                "execute_order: attribution computed for instrument_id=%d "
+                "gross=%.4f alpha=%.4f",
+                instrument_id,
+                result.gross_return_pct,
+                result.model_alpha_pct,
+            )
+    except Exception:
+        logger.error(
+            "execute_order: attribution failed for instrument_id=%d",
+            instrument_id,
+            exc_info=True,
+        )
+```
+
+Then call `_maybe_trigger_attribution` inside `execute_order`, after the EXIT fill updates the position. Find the section in `execute_order` that calls `UPDATE positions SET current_units = current_units - ...` for EXIT actions and add:
+
+```python
+            # After the position update, check if fully closed
+            if action == "EXIT":
+                with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                    cur.execute(
+                        "SELECT current_units FROM positions WHERE instrument_id = %(iid)s",
+                        {"iid": instrument_id},
+                    )
+                    pos_row = cur.fetchone()
+                units_after = Decimal(str(pos_row["current_units"])) if pos_row else Decimal("0")
+                _maybe_trigger_attribution(conn, instrument_id, units_after)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_attribution_trigger.py -v`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest -q`
+Expected: all tests PASS (no regressions in order_client).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/order_client.py tests/test_attribution_trigger.py
+git commit -m "feat(#155): trigger attribution on EXIT fill that closes position"
+```
+
+---
+
+## Task 6: Summary scheduler job
+
+**Files:**
+- Modify: `app/workers/scheduler.py`
+- Modify: `app/jobs/runtime.py`
+- Test: `tests/test_scheduler_attribution.py`
+
+- [ ] **Step 1: Write failing test for the summary job**
+
+Create `tests/test_scheduler_attribution.py`:
+
+```python
+"""Tests for the attribution_summary scheduler job."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+_PSYCOPG_CONNECT_PATCH = "app.workers.scheduler.psycopg.connect"
+_RECORD_START_PATCH = "app.workers.scheduler.record_job_start"
+_RECORD_FINISH_PATCH = "app.workers.scheduler.record_job_finish"
+_SPIKE_PATCH = "app.workers.scheduler.check_runtime_spike"
+
+
+class TestAttributionSummaryJob:
+    @patch(_SPIKE_PATCH, return_value=MagicMock(flagged=False))
+    @patch(_RECORD_FINISH_PATCH)
+    @patch(_RECORD_START_PATCH, return_value=1)
+    @patch("app.workers.scheduler.persist_attribution_summary")
+    @patch("app.workers.scheduler.compute_attribution_summary")
+    @patch(_PSYCOPG_CONNECT_PATCH)
+    def test_computes_and_persists_summaries(
+        self,
+        mock_connect: MagicMock,
+        mock_summary: MagicMock,
+        mock_persist: MagicMock,
+        mock_start: MagicMock,
+        mock_finish: MagicMock,
+        mock_spike: MagicMock,
+    ) -> None:
+        """Job should compute summaries for each window and persist them."""
+        from app.services.return_attribution import SummaryResult, SUMMARY_WINDOWS
+        from app.workers.scheduler import attribution_summary_job
+
+        fake_result = SummaryResult(
+            window_days=90,
+            positions_attributed=5,
+            avg_gross_return_pct=Decimal("0.10"),
+            avg_market_return_pct=Decimal("0.04"),
+            avg_sector_return_pct=Decimal("0.06"),
+            avg_model_alpha_pct=Decimal("0.04"),
+            avg_timing_alpha_pct=Decimal("0"),
+            avg_cost_drag_pct=Decimal("0.003"),
+        )
+        mock_summary.return_value = fake_result
+
+        conn_ctx = MagicMock()
+        conn_ctx.__enter__ = MagicMock(return_value=conn_ctx)
+        conn_ctx.__exit__ = MagicMock(return_value=False)
+        mock_connect.return_value = conn_ctx
+
+        attribution_summary_job()
+
+        assert mock_summary.call_count == len(SUMMARY_WINDOWS)
+        assert mock_persist.call_count == len(SUMMARY_WINDOWS)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_scheduler_attribution.py -v`
+Expected: ImportError for `attribution_summary_job`.
+
+- [ ] **Step 3: Implement the job**
+
+Add to `app/workers/scheduler.py`:
+
+```python
+# At top with other imports:
+from app.services.return_attribution import (
+    SUMMARY_WINDOWS,
+    compute_attribution_summary,
+    persist_attribution_summary,
+)
+
+# New constant with other JOB_ constants:
+JOB_ATTRIBUTION_SUMMARY = "attribution_summary"
+
+# New prerequisite (attribution needs at least one attributed position):
+def _has_attributions(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
+    exists = _exists(conn, SQL("SELECT 1 FROM return_attribution LIMIT 1"))
+    if not exists:
+        return False, "no attributed positions yet"
+    return True, ""
+
+# New ScheduledJob entry in SCHEDULED_JOBS list:
+# ScheduledJob(
+#     name=JOB_ATTRIBUTION_SUMMARY,
+#     cron_trigger=CronTrigger(day_of_week="sun", hour=6, minute=0),
+#     prerequisites=[_has_attributions],
+#     catch_up_on_boot=False,
+# ),
+
+# New job function:
+def attribution_summary_job() -> None:
+    """Compute and persist attribution summaries for all configured windows."""
+    with _tracked_job(JOB_ATTRIBUTION_SUMMARY) as tracker:
+        with psycopg.connect(settings.database_url) as conn:
+            total_positions = 0
+            for window in SUMMARY_WINDOWS:
+                summary = compute_attribution_summary(conn, window)
+                with conn.transaction():
+                    persist_attribution_summary(conn, summary)
+                conn.commit()
+                total_positions = max(total_positions, summary.positions_attributed)
+                logger.info(
+                    "attribution_summary: window=%dd positions=%d avg_alpha=%.4f",
+                    window,
+                    summary.positions_attributed,
+                    float(summary.avg_model_alpha_pct or 0),
+                )
+            tracker.row_count = total_positions
+```
+
+Add to `app/jobs/runtime.py`:
+
+```python
+from app.workers.scheduler import JOB_ATTRIBUTION_SUMMARY, attribution_summary_job
+
+# In _INVOKERS dict:
+JOB_ATTRIBUTION_SUMMARY: attribution_summary_job,
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_scheduler_attribution.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest -q`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/workers/scheduler.py app/jobs/runtime.py tests/test_scheduler_attribution.py
+git commit -m "feat(#155): weekly attribution_summary scheduler job"
+```
+
+---
+
+## Task 7: API endpoint
+
+**Files:**
+- Create: `app/api/attribution.py`
+- Modify: `app/main.py` (register router)
+
+- [ ] **Step 1: Implement the API endpoint**
+
+Create `app/api/attribution.py`:
+
+```python
+"""Attribution API — return decomposition data for the dashboard."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from fastapi import APIRouter, Depends
+
+from app.api.auth_session import require_operator
+from app.config import settings
+
+router = APIRouter(prefix="/api/attribution", tags=["attribution"])
+
+
+@router.get("")
+def list_attributions(
+    _: Any = Depends(require_operator),
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Return the most recent attribution rows."""
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT ra.*, i.symbol, i.sector
+                FROM return_attribution ra
+                JOIN instruments i USING (instrument_id)
+                ORDER BY ra.computed_at DESC
+                LIMIT %(limit)s
+                """,
+                {"limit": limit},
+            )
+            return cur.fetchall()
+
+
+@router.get("/summary")
+def list_summaries(
+    _: Any = Depends(require_operator),
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Return the most recent attribution summaries."""
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT *
+                FROM return_attribution_summary
+                ORDER BY computed_at DESC
+                LIMIT %(limit)s
+                """,
+                {"limit": limit},
+            )
+            return cur.fetchall()
+```
+
+- [ ] **Step 2: Register the router in app/main.py**
+
+Add to the router registration section:
+
+```python
+from app.api.attribution import router as attribution_router
+app.include_router(attribution_router)
+```
+
+- [ ] **Step 3: Run pre-push checks**
+
+Run:
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest -q
+```
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/api/attribution.py app/main.py
+git commit -m "feat(#155): GET /api/attribution + /api/attribution/summary endpoints"
+```
+
+---
+
+## Task 8: Pre-push checks and PR
+
+- [ ] **Step 1: Run full pre-push suite**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest -q
+```
+
+All four must pass.
+
+- [ ] **Step 2: Self-review the diff**
+
+Read `.claude/skills/engineering/pre-flight-review.md` and check:
+- No raw SQL interpolation (all parameterised)
+- Decimal arithmetic throughout (no float on financial values)
+- Attribution errors swallowed in order_client (never abort execution)
+- Migration is idempotent (`IF NOT EXISTS`)
+- Tests cover: empty state, happy path, error path, boundary conditions
+
+- [ ] **Step 3: Push and open PR**
+
+```bash
+git push -u origin feature/155-return-attribution
+gh pr create --title "feat(#155): return attribution and performance audit service" --body "..."
+```
+
+- [ ] **Step 4: Poll review and CI, resolve all comments**
+
+Follow the standard review-resolve-push cycle from CLAUDE.md.

--- a/docs/superpowers/plans/2026-04-16-reporting-engine.md
+++ b/docs/superpowers/plans/2026-04-16-reporting-engine.md
@@ -1,0 +1,1464 @@
+# Reporting Engine — Periodic Performance Reports
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build scheduled weekly and monthly performance reports that snapshot portfolio data into a queryable table, surfacing P&L, attribution, trade activity, earnings, score changes, budget status, and thesis accuracy.
+
+**Architecture:** Reports are JSONB snapshots persisted in `report_snapshots` (one row per report type + period). Each report is computed by a pure function that reads existing tables, assembles a typed dict, and stores it. Scheduler jobs fire weekly (Saturday morning) and monthly (1st of month). API endpoints expose the stored snapshots. **V1 reports are current-state snapshots** — without beginning-of-period valuation history, P&L sections report current `positions.realized_pnl` + `unrealized_pnl` totals and period-bounded trade activity, not true period-over-period deltas.
+
+**Tech Stack:** Python 3.12, psycopg v3, FastAPI, PostgreSQL, existing scheduler infrastructure (`_tracked_job`, `ScheduledJob`, `Cadence`).
+
+**Scope note:** This plan covers periodic reports only (backend). The instrument detail page from issue #207 will be a separate plan — it depends on #204 (charts) and is an independent frontend subsystem.
+
+**Codex review applied:** All blocking/high findings from Codex plan review are incorporated:
+
+- Realised P&L uses `positions.realized_pnl` (not `SUM(gross_amount - fees)` which is proceeds, not profit)
+- P&L sections are explicitly labeled as current-state snapshots
+- Monthly cadence extends `CadenceKind`, `compute_next_run()`, `_trigger_for()`, `Cadence.label`, and `_INVOKERS` in `app/jobs/runtime.py`
+- Attribution uses period-bounded `return_attribution` rows, not rolling summary
+- Thesis accuracy uses entry-time thesis (via `recommendation_id` → `score_id` → thesis at entry)
+- API limits use `ge=1, le=100`
+- Tests include JSON serialization, monthly boundary, and drift-guard coverage
+
+---
+
+## Settled decisions that apply
+
+- **Thesis versioning**: each thesis is a new row; reports query `theses` by `instrument_id` + `created_at DESC`.
+- **Scoring model style**: v1 scoring is heuristic, explicit, auditable. Reports surface `total_score` and component scores.
+- **AUM basis**: mark-to-market first, cost_basis fallback. Reports use the same logic as `get_portfolio`.
+- **Cash semantics**: `cash_ledger.amount` positive = inflow, negative = outflow.
+- **Provider boundary**: reports are service-layer, no provider calls.
+
+## Prevention log entries that apply
+
+- **Interval construction via string concatenation in SQL** — use `make_interval(days => ...)` not string concat.
+- **Unbounded API limit parameters** — use `Query(default=..., le=...)` on all list endpoints.
+- **Mid-transaction `conn.commit()` in service functions** — service functions must not commit; caller owns the transaction.
+- **`conn.transaction()` savepoint release does not commit the outer transaction** — caller commits after service returns.
+- **Dead-code None-guard on aggregate fetchone()** — aggregate queries always return one row; guard the value, not the row.
+- **Naive datetime in TIMESTAMPTZ query params** — use `datetime.now(tz=timezone.utc)`.
+
+---
+
+## File structure
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Create | `sql/030_report_snapshots.sql` | Migration: `report_snapshots` table |
+| Create | `app/services/reporting.py` | Report generation logic (weekly + monthly) |
+| Create | `app/api/reports.py` | API endpoints for report snapshots |
+| Modify | `app/workers/scheduler.py` | Add `Cadence.monthly()`, `CadenceKind`, `compute_next_run()` monthly branch, two new jobs, prerequisite |
+| Modify | `app/jobs/runtime.py` | Add `_trigger_for()` monthly branch, import + wire new jobs in `_INVOKERS` |
+| Modify | `app/main.py` | Register reports router |
+| Create | `tests/test_reporting.py` | Unit tests for report generation |
+
+---
+
+### Task 1: Migration — `report_snapshots` table
+
+**Files:**
+- Create: `sql/030_report_snapshots.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Migration 030: report snapshots
+--
+-- Stores periodic (weekly/monthly) performance report snapshots as JSONB.
+-- One row per (report_type, period_start). Idempotent rerun replaces the snapshot.
+
+CREATE TABLE IF NOT EXISTS report_snapshots (
+    snapshot_id    BIGSERIAL PRIMARY KEY,
+    report_type    TEXT NOT NULL CHECK (report_type IN ('weekly', 'monthly')),
+    period_start   DATE NOT NULL,
+    period_end     DATE NOT NULL,
+    snapshot_json  JSONB NOT NULL,
+    computed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_report_snapshots_type_period
+    ON report_snapshots(report_type, period_start);
+```
+
+- [ ] **Step 2: Verify migration applies cleanly**
+
+Run: `uv run python -c "from app.db.master_key import bootstrap; import psycopg; from app.config import settings; conn = psycopg.connect(settings.database_url); bootstrap(conn); conn.commit(); conn.close(); print('OK')"`
+Expected: OK (no errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sql/030_report_snapshots.sql
+git commit -m "feat(#207): add report_snapshots migration (030)"
+```
+
+---
+
+### Task 2: Add `Cadence.monthly()` to scheduler
+
+**Files:**
+- Modify: `app/workers/scheduler.py` (lines ~95-130, Cadence class)
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/test_reporting.py` (create the file):
+
+```python
+"""Tests for the reporting engine — weekly & monthly performance reports."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.workers.scheduler import Cadence
+
+
+class TestCadenceMonthly:
+    def test_valid_monthly_cadence(self) -> None:
+        c = Cadence.monthly(day=1, hour=6, minute=0)
+        assert c.kind == "monthly"
+        assert c.day == 1
+        assert c.hour == 6
+        assert c.minute == 0
+
+    def test_monthly_day_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match="monthly day must be 1..28"):
+            Cadence.monthly(day=29, hour=6)
+
+    def test_monthly_day_zero(self) -> None:
+        with pytest.raises(ValueError, match="monthly day must be 1..28"):
+            Cadence.monthly(day=0, hour=6)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_reporting.py::TestCadenceMonthly -v`
+Expected: FAIL — `Cadence` has no `monthly` classmethod
+
+- [ ] **Step 3: Add `day` field and `monthly` classmethod to Cadence**
+
+In `app/workers/scheduler.py`, add to the `Cadence` dataclass:
+
+```python
+# After the existing fields (kind, weekday, hour, minute):
+day: int = 0  # 1..28 for monthly cadence
+
+@classmethod
+def monthly(cls, *, day: int, hour: int, minute: int = 0) -> Cadence:
+    if not 1 <= day <= 28:
+        raise ValueError(f"monthly day must be 1..28, got {day}")
+    if not 0 <= hour <= 23:
+        raise ValueError(f"monthly hour must be 0..23, got {hour}")
+    if not 0 <= minute <= 59:
+        raise ValueError(f"monthly minute must be 0..59, got {minute}")
+    return cls(kind="monthly", day=day, hour=hour, minute=minute)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_reporting.py::TestCadenceMonthly -v`
+Expected: 3 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/workers/scheduler.py tests/test_reporting.py
+git commit -m "feat(#207): add Cadence.monthly() for report scheduling"
+```
+
+---
+
+### Task 3: Weekly report generator
+
+**Files:**
+- Create: `app/services/reporting.py`
+- Modify: `tests/test_reporting.py`
+
+The weekly report assembles:
+1. Portfolio P&L (realised + unrealised) for the week
+2. Top 3 / bottom 3 performers by unrealized P&L change
+3. Positions opened/closed this week with reasoning
+4. Upcoming earnings for held positions
+5. Score changes (significant rank movements)
+6. Budget status (deployed vs available vs tax reserve)
+
+- [ ] **Step 1: Write the failing test for `generate_weekly_report`**
+
+Add to `tests/test_reporting.py`:
+
+```python
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from app.services.reporting import generate_weekly_report, WeeklyReport
+
+_REPORTING = "app.services.reporting"
+
+
+class TestGenerateWeeklyReport:
+    def test_returns_weekly_report_structure(self) -> None:
+        """Weekly report should contain all expected sections."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Empty result sets — the structure test cares about shape, not data
+        cursor.fetchall.return_value = []
+        cursor.fetchone.return_value = {"cash_balance": None}
+
+        with patch(f"{_REPORTING}.compute_budget_state") as mock_budget:
+            mock_budget.return_value = MagicMock(
+                cash_balance=Decimal("10000"),
+                deployed_capital=Decimal("5000"),
+                estimated_tax_usd=Decimal("200"),
+                available_for_deployment=Decimal("4800"),
+            )
+            report = generate_weekly_report(
+                conn,
+                period_start=date(2026, 4, 6),
+                period_end=date(2026, 4, 12),
+            )
+
+        assert report["report_type"] == "weekly"
+        assert report["period_start"] == "2026-04-06"
+        assert report["period_end"] == "2026-04-12"
+        assert "pnl" in report
+        assert "top_performers" in report
+        assert "bottom_performers" in report
+        assert "positions_opened" in report
+        assert "positions_closed" in report
+        assert "upcoming_earnings" in report
+        assert "score_changes" in report
+        assert "budget" in report
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_reporting.py::TestGenerateWeeklyReport::test_returns_weekly_report_structure -v`
+Expected: FAIL — `app.services.reporting` does not exist
+
+- [ ] **Step 3: Implement `generate_weekly_report`**
+
+Create `app/services/reporting.py`:
+
+```python
+"""Reporting engine — periodic performance report generation.
+
+Each generate_* function reads from existing tables and returns a plain dict
+suitable for JSONB storage in report_snapshots. The caller owns the
+transaction and commit.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+from app.services.budget import compute_budget_state
+
+logger = logging.getLogger(__name__)
+
+# Type aliases for report dicts.  These are stored as JSONB so we use
+# plain dicts rather than dataclasses — no ORM overhead, easy serialisation.
+WeeklyReport = dict[str, Any]
+MonthlyReport = dict[str, Any]
+
+
+def _dec(v: Decimal | None) -> str | None:
+    """Decimal → str for JSON serialisation, preserving None."""
+    return str(v) if v is not None else None
+
+
+def _period_pnl(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> dict[str, str | None]:
+    """Compute realised + unrealised P&L delta for the period.
+
+    Realised: sum of fills.gross_amount for EXIT fills in the period.
+    Unrealised: current positions.unrealized_pnl snapshot (point-in-time).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # Realised P&L from EXIT fills in the period
+        cur.execute(
+            """
+            SELECT COALESCE(SUM(f.gross_amount - f.fees), 0) AS realised_pnl
+            FROM fills f
+            JOIN orders o USING (order_id)
+            WHERE o.action = 'EXIT'
+              AND f.filled_at >= %(start)s
+              AND f.filled_at < %(end)s::date + 1
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        row = cur.fetchone()
+        realised = row["realised_pnl"] if row else Decimal(0)
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # Current unrealised P&L snapshot
+        cur.execute(
+            "SELECT COALESCE(SUM(unrealized_pnl), 0) AS total FROM positions WHERE current_units > 0"
+        )
+        row = cur.fetchone()
+        unrealised = row["total"] if row else Decimal(0)
+
+    return {
+        "realised_pnl": _dec(realised),
+        "unrealised_pnl": _dec(unrealised),
+        "total_pnl": _dec(realised + unrealised),
+    }
+
+
+def _top_bottom_performers(
+    conn: psycopg.Connection[Any],
+    n: int = 3,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Top N and bottom N open positions by unrealized_pnl."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT p.instrument_id, i.symbol, i.company_name,
+                   p.unrealized_pnl, p.current_units, p.avg_cost
+            FROM positions p
+            JOIN instruments i USING (instrument_id)
+            WHERE p.current_units > 0
+            ORDER BY p.unrealized_pnl DESC
+            """,
+        )
+        rows = cur.fetchall()
+
+    def _fmt(r: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "instrument_id": r["instrument_id"],
+            "symbol": r["symbol"],
+            "company_name": r["company_name"],
+            "unrealized_pnl": _dec(r["unrealized_pnl"]),
+        }
+
+    top = [_fmt(r) for r in rows[:n]]
+    bottom = [_fmt(r) for r in rows[-n:]] if len(rows) > n else [_fmt(r) for r in rows[n:]]
+    # Reverse bottom so worst performer is first
+    bottom.reverse()
+    return top, bottom
+
+
+def _positions_opened_closed(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Positions opened and closed in the period, with rationale."""
+    opened: list[dict[str, Any]] = []
+    closed: list[dict[str, Any]] = []
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # BUY fills in the period — new positions
+        cur.execute(
+            """
+            SELECT o.instrument_id, i.symbol, o.action,
+                   tr.rationale, f.price, f.units, f.filled_at
+            FROM fills f
+            JOIN orders o USING (order_id)
+            JOIN instruments i ON i.instrument_id = o.instrument_id
+            LEFT JOIN trade_recommendations tr
+                ON tr.recommendation_id = (
+                    SELECT da.recommendation_id
+                    FROM decision_audit da
+                    WHERE da.instrument_id = o.instrument_id
+                      AND da.stage = 'execution_guard'
+                    ORDER BY da.decision_time DESC
+                    LIMIT 1
+                )
+            WHERE o.action = 'BUY'
+              AND f.filled_at >= %(start)s
+              AND f.filled_at < %(end)s::date + 1
+            ORDER BY f.filled_at
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        for r in cur.fetchall():
+            opened.append({
+                "symbol": r["symbol"],
+                "instrument_id": r["instrument_id"],
+                "price": _dec(r["price"]),
+                "units": _dec(r["units"]),
+                "rationale": r["rationale"],
+                "filled_at": r["filled_at"].isoformat() if r["filled_at"] else None,
+            })
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # EXIT fills in the period
+        cur.execute(
+            """
+            SELECT o.instrument_id, i.symbol, o.action,
+                   tr.rationale, f.price, f.units, f.filled_at
+            FROM fills f
+            JOIN orders o USING (order_id)
+            JOIN instruments i ON i.instrument_id = o.instrument_id
+            LEFT JOIN trade_recommendations tr
+                ON tr.recommendation_id = (
+                    SELECT da.recommendation_id
+                    FROM decision_audit da
+                    WHERE da.instrument_id = o.instrument_id
+                      AND da.stage = 'execution_guard'
+                    ORDER BY da.decision_time DESC
+                    LIMIT 1
+                )
+            WHERE o.action = 'EXIT'
+              AND f.filled_at >= %(start)s
+              AND f.filled_at < %(end)s::date + 1
+            ORDER BY f.filled_at
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        for r in cur.fetchall():
+            closed.append({
+                "symbol": r["symbol"],
+                "instrument_id": r["instrument_id"],
+                "price": _dec(r["price"]),
+                "units": _dec(r["units"]),
+                "rationale": r["rationale"],
+                "filled_at": r["filled_at"].isoformat() if r["filled_at"] else None,
+            })
+
+    return opened, closed
+
+
+def _upcoming_earnings(
+    conn: psycopg.Connection[Any],
+    lookahead_days: int = 14,
+) -> list[dict[str, Any]]:
+    """Upcoming earnings for held positions within lookahead window."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT ee.instrument_id, i.symbol, i.company_name,
+                   ee.reporting_date, ee.eps_estimate
+            FROM earnings_events ee
+            JOIN instruments i USING (instrument_id)
+            JOIN positions p USING (instrument_id)
+            WHERE p.current_units > 0
+              AND ee.reporting_date >= CURRENT_DATE
+              AND ee.reporting_date < CURRENT_DATE + make_interval(days => %(days)s)
+            ORDER BY ee.reporting_date
+            """,
+            {"days": lookahead_days},
+        )
+        return [
+            {
+                "symbol": r["symbol"],
+                "company_name": r["company_name"],
+                "instrument_id": r["instrument_id"],
+                "reporting_date": r["reporting_date"].isoformat() if r["reporting_date"] else None,
+                "eps_estimate": _dec(r["eps_estimate"]),
+            }
+            for r in cur.fetchall()
+        ]
+
+
+def _score_changes(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+    min_rank_delta: int = 5,
+) -> list[dict[str, Any]]:
+    """Instruments with significant rank movement in the period."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT s.instrument_id, i.symbol, s.total_score, s.rank,
+                   s.rank_delta, s.scored_at
+            FROM scores s
+            JOIN instruments i USING (instrument_id)
+            WHERE s.scored_at >= %(start)s
+              AND s.scored_at < %(end)s::date + 1
+              AND s.rank_delta IS NOT NULL
+              AND ABS(s.rank_delta) >= %(min_delta)s
+            ORDER BY ABS(s.rank_delta) DESC
+            """,
+            {"start": period_start, "end": period_end, "min_delta": min_rank_delta},
+        )
+        return [
+            {
+                "symbol": r["symbol"],
+                "instrument_id": r["instrument_id"],
+                "total_score": _dec(r["total_score"]),
+                "rank": r["rank"],
+                "rank_delta": r["rank_delta"],
+                "scored_at": r["scored_at"].isoformat() if r["scored_at"] else None,
+            }
+            for r in cur.fetchall()
+        ]
+
+
+def _budget_snapshot(conn: psycopg.Connection[Any]) -> dict[str, str | None]:
+    """Current budget status for report embedding."""
+    budget = compute_budget_state(conn)
+    return {
+        "cash_balance": _dec(budget.cash_balance),
+        "deployed_capital": _dec(budget.deployed_capital),
+        "estimated_tax_usd": _dec(budget.estimated_tax_usd),
+        "available_for_deployment": _dec(budget.available_for_deployment),
+    }
+
+
+def generate_weekly_report(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> WeeklyReport:
+    """Generate a weekly performance report snapshot.
+
+    Reads from existing tables and returns a plain dict for JSONB storage.
+    The caller owns the transaction and commit.
+    """
+    pnl = _period_pnl(conn, period_start, period_end)
+    top, bottom = _top_bottom_performers(conn)
+    opened, closed = _positions_opened_closed(conn, period_start, period_end)
+    earnings = _upcoming_earnings(conn)
+    scores = _score_changes(conn, period_start, period_end)
+    budget = _budget_snapshot(conn)
+
+    return {
+        "report_type": "weekly",
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "generated_at": datetime.now(tz=timezone.utc).isoformat(),
+        "pnl": pnl,
+        "top_performers": top,
+        "bottom_performers": bottom,
+        "positions_opened": opened,
+        "positions_closed": closed,
+        "upcoming_earnings": earnings,
+        "score_changes": scores,
+        "budget": budget,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_reporting.py::TestGenerateWeeklyReport -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/reporting.py tests/test_reporting.py
+git commit -m "feat(#207): weekly report generator with P&L, performers, trades, earnings, scores, budget"
+```
+
+---
+
+### Task 4: Monthly report generator
+
+**Files:**
+- Modify: `app/services/reporting.py`
+- Modify: `tests/test_reporting.py`
+
+The monthly report adds:
+1. Full P&L breakdown by position
+2. Win rate (% of closed positions that were profitable)
+3. Average holding period
+4. Best/worst trade of the month
+5. Portfolio vs benchmark (S&P 500) via return_attribution_summary
+6. Thesis accuracy review (were buy/base/bear targets hit?)
+7. Tax provision update
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_reporting.py`:
+
+```python
+from app.services.reporting import generate_monthly_report, MonthlyReport
+
+
+class TestGenerateMonthlyReport:
+    def test_returns_monthly_report_structure(self) -> None:
+        """Monthly report should contain all expected sections."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = []
+        cursor.fetchone.return_value = {"total": Decimal("0"), "cash_balance": None}
+
+        with patch(f"{_REPORTING}.compute_budget_state") as mock_budget:
+            mock_budget.return_value = MagicMock(
+                cash_balance=Decimal("10000"),
+                deployed_capital=Decimal("5000"),
+                estimated_tax_usd=Decimal("200"),
+                estimated_tax_gbp=Decimal("160"),
+                available_for_deployment=Decimal("4800"),
+                tax_year="2025/26",
+            )
+            report = generate_monthly_report(
+                conn,
+                period_start=date(2026, 3, 1),
+                period_end=date(2026, 3, 31),
+            )
+
+        assert report["report_type"] == "monthly"
+        assert report["period_start"] == "2026-03-01"
+        assert report["period_end"] == "2026-03-31"
+        assert "position_pnl" in report
+        assert "win_rate" in report
+        assert "avg_holding_days" in report
+        assert "best_trade" in report
+        assert "worst_trade" in report
+        assert "attribution_summary" in report
+        assert "thesis_accuracy" in report
+        assert "tax_provision" in report
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_reporting.py::TestGenerateMonthlyReport -v`
+Expected: FAIL — `generate_monthly_report` not defined
+
+- [ ] **Step 3: Implement `generate_monthly_report`**
+
+Add to `app/services/reporting.py`:
+
+```python
+def _position_pnl_breakdown(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> list[dict[str, Any]]:
+    """Per-position P&L for the period (positions that had any fill activity)."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT p.instrument_id, i.symbol, i.company_name,
+                   p.cost_basis, p.realized_pnl, p.unrealized_pnl,
+                   p.current_units, p.avg_cost
+            FROM positions p
+            JOIN instruments i USING (instrument_id)
+            WHERE p.instrument_id IN (
+                SELECT DISTINCT o.instrument_id
+                FROM fills f
+                JOIN orders o USING (order_id)
+                WHERE f.filled_at >= %(start)s
+                  AND f.filled_at < %(end)s::date + 1
+            )
+            ORDER BY p.realized_pnl + p.unrealized_pnl DESC
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        return [
+            {
+                "instrument_id": r["instrument_id"],
+                "symbol": r["symbol"],
+                "company_name": r["company_name"],
+                "cost_basis": _dec(r["cost_basis"]),
+                "realized_pnl": _dec(r["realized_pnl"]),
+                "unrealized_pnl": _dec(r["unrealized_pnl"]),
+                "current_units": _dec(r["current_units"]),
+            }
+            for r in cur.fetchall()
+        ]
+
+
+def _win_rate_and_holding(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> dict[str, Any]:
+    """Win rate and average holding period for positions closed in the period."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT ra.gross_return_pct, ra.hold_days
+            FROM return_attribution ra
+            WHERE ra.hold_end >= %(start)s
+              AND ra.hold_end <= %(end)s
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        rows = cur.fetchall()
+
+    if not rows:
+        return {
+            "total_closed": 0,
+            "winners": 0,
+            "losers": 0,
+            "win_rate_pct": None,
+            "avg_holding_days": None,
+        }
+
+    winners = sum(1 for r in rows if r["gross_return_pct"] > 0)
+    total = len(rows)
+    avg_days = sum(r["hold_days"] for r in rows) / total
+
+    return {
+        "total_closed": total,
+        "winners": winners,
+        "losers": total - winners,
+        "win_rate_pct": str(round(Decimal(winners) / Decimal(total) * 100, 2)),
+        "avg_holding_days": round(avg_days, 1),
+    }
+
+
+def _best_worst_trade(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Best and worst attributed trade closed in the period."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT ra.instrument_id, i.symbol, ra.gross_return_pct,
+                   ra.hold_days, ra.model_alpha_pct
+            FROM return_attribution ra
+            JOIN instruments i USING (instrument_id)
+            WHERE ra.hold_end >= %(start)s
+              AND ra.hold_end <= %(end)s
+            ORDER BY ra.gross_return_pct DESC
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        rows = cur.fetchall()
+
+    if not rows:
+        return None, None
+
+    def _fmt(r: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "symbol": r["symbol"],
+            "instrument_id": r["instrument_id"],
+            "gross_return_pct": _dec(r["gross_return_pct"]),
+            "hold_days": r["hold_days"],
+            "model_alpha_pct": _dec(r["model_alpha_pct"]),
+        }
+
+    return _fmt(rows[0]), _fmt(rows[-1])
+
+
+def _attribution_summary_snapshot(
+    conn: psycopg.Connection[Any],
+) -> list[dict[str, Any]]:
+    """Latest attribution summary per window (from return_attribution_summary)."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT ON (window_days)
+                   window_days, positions_attributed,
+                   avg_gross_return_pct, avg_market_return_pct,
+                   avg_model_alpha_pct, computed_at
+            FROM return_attribution_summary
+            ORDER BY window_days, computed_at DESC
+            """,
+        )
+        return [
+            {
+                "window_days": r["window_days"],
+                "positions_attributed": r["positions_attributed"],
+                "avg_gross_return_pct": _dec(r["avg_gross_return_pct"]),
+                "avg_market_return_pct": _dec(r["avg_market_return_pct"]),
+                "avg_model_alpha_pct": _dec(r["avg_model_alpha_pct"]),
+            }
+            for r in cur.fetchall()
+        ]
+
+
+def _thesis_accuracy(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> list[dict[str, Any]]:
+    """For closed positions in the period, check if price hit buy/base/bear targets."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT ra.instrument_id, i.symbol,
+                   ra.gross_return_pct,
+                   t.base_value, t.bull_value, t.bear_value,
+                   t.stance, t.confidence_score,
+                   f_exit.price AS exit_price
+            FROM return_attribution ra
+            JOIN instruments i USING (instrument_id)
+            LEFT JOIN LATERAL (
+                SELECT base_value, bull_value, bear_value, stance, confidence_score
+                FROM theses
+                WHERE instrument_id = ra.instrument_id
+                  AND created_at <= ra.computed_at
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) t ON true
+            LEFT JOIN fills f_exit ON f_exit.fill_id = ra.exit_fill_id
+            WHERE ra.hold_end >= %(start)s
+              AND ra.hold_end <= %(end)s
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        results = []
+        for r in cur.fetchall():
+            exit_price = r["exit_price"]
+            base = r["base_value"]
+            bull = r["bull_value"]
+            bear = r["bear_value"]
+            hit = None
+            if exit_price is not None and base is not None:
+                if bull is not None and exit_price >= bull:
+                    hit = "bull"
+                elif exit_price >= base:
+                    hit = "base"
+                elif bear is not None and exit_price <= bear:
+                    hit = "bear"
+                else:
+                    hit = "between_bear_and_base"
+
+            results.append({
+                "symbol": r["symbol"],
+                "instrument_id": r["instrument_id"],
+                "gross_return_pct": _dec(r["gross_return_pct"]),
+                "thesis_stance": r["stance"],
+                "thesis_confidence": _dec(r["confidence_score"]),
+                "target_hit": hit,
+            })
+        return results
+
+
+def _tax_provision_snapshot(conn: psycopg.Connection[Any]) -> dict[str, str | None]:
+    """Current tax provision from budget state."""
+    budget = compute_budget_state(conn)
+    return {
+        "estimated_tax_gbp": _dec(budget.estimated_tax_gbp),
+        "estimated_tax_usd": _dec(budget.estimated_tax_usd),
+        "tax_year": budget.tax_year,
+    }
+
+
+def generate_monthly_report(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> MonthlyReport:
+    """Generate a monthly performance report snapshot.
+
+    Reads from existing tables and returns a plain dict for JSONB storage.
+    The caller owns the transaction and commit.
+    """
+    pnl = _period_pnl(conn, period_start, period_end)
+    position_pnl = _position_pnl_breakdown(conn, period_start, period_end)
+    win_hold = _win_rate_and_holding(conn, period_start, period_end)
+    best, worst = _best_worst_trade(conn, period_start, period_end)
+    attribution = _attribution_summary_snapshot(conn)
+    accuracy = _thesis_accuracy(conn, period_start, period_end)
+    tax = _tax_provision_snapshot(conn)
+
+    return {
+        "report_type": "monthly",
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "generated_at": datetime.now(tz=timezone.utc).isoformat(),
+        "pnl": pnl,
+        "position_pnl": position_pnl,
+        "win_rate": win_hold,
+        "avg_holding_days": win_hold["avg_holding_days"],
+        "best_trade": best,
+        "worst_trade": worst,
+        "attribution_summary": attribution,
+        "thesis_accuracy": accuracy,
+        "tax_provision": tax,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_reporting.py::TestGenerateMonthlyReport -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/reporting.py tests/test_reporting.py
+git commit -m "feat(#207): monthly report generator with position P&L, win rate, attribution, thesis accuracy, tax"
+```
+
+---
+
+### Task 5: Persist and retrieve report snapshots
+
+**Files:**
+- Modify: `app/services/reporting.py`
+- Modify: `tests/test_reporting.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_reporting.py`:
+
+```python
+from app.services.reporting import persist_report_snapshot, load_report_snapshots
+import json
+
+
+class TestPersistReportSnapshot:
+    def test_persist_inserts_row(self) -> None:
+        """persist_report_snapshot should execute an INSERT with ON CONFLICT DO UPDATE."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        report = {
+            "report_type": "weekly",
+            "period_start": "2026-04-06",
+            "period_end": "2026-04-12",
+            "pnl": {"realised_pnl": "100", "unrealised_pnl": "200"},
+        }
+
+        persist_report_snapshot(
+            conn,
+            report_type="weekly",
+            period_start=date(2026, 4, 6),
+            period_end=date(2026, 4, 12),
+            snapshot=report,
+        )
+
+        cursor.execute.assert_called_once()
+        call_args = cursor.execute.call_args
+        sql = call_args[0][0]
+        params = call_args[0][1]
+        assert "ON CONFLICT" in sql
+        assert params["report_type"] == "weekly"
+        assert params["period_start"] == date(2026, 4, 6)
+
+
+class TestLoadReportSnapshots:
+    def test_load_returns_list(self) -> None:
+        """load_report_snapshots should query by report_type."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = []
+
+        result = load_report_snapshots(conn, report_type="weekly", limit=10)
+        assert result == []
+        cursor.execute.assert_called_once()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_reporting.py::TestPersistReportSnapshot -v`
+Expected: FAIL — `persist_report_snapshot` not defined
+
+- [ ] **Step 3: Implement persist and load functions**
+
+Add to `app/services/reporting.py`:
+
+```python
+from psycopg.types.json import Jsonb
+
+
+def persist_report_snapshot(
+    conn: psycopg.Connection[Any],
+    *,
+    report_type: str,
+    period_start: date,
+    period_end: date,
+    snapshot: dict[str, Any],
+) -> None:
+    """Upsert a report snapshot into report_snapshots.
+
+    Idempotent: ON CONFLICT replaces the snapshot for the same
+    (report_type, period_start) pair. The caller owns the commit.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO report_snapshots (report_type, period_start, period_end, snapshot_json)
+            VALUES (%(report_type)s, %(period_start)s, %(period_end)s, %(snapshot)s)
+            ON CONFLICT (report_type, period_start) DO UPDATE
+            SET period_end   = EXCLUDED.period_end,
+                snapshot_json = EXCLUDED.snapshot_json,
+                computed_at  = NOW()
+            """,
+            {
+                "report_type": report_type,
+                "period_start": period_start,
+                "period_end": period_end,
+                "snapshot": Jsonb(snapshot),
+            },
+        )
+
+
+def load_report_snapshots(
+    conn: psycopg.Connection[Any],
+    *,
+    report_type: str,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Load the most recent report snapshots of a given type."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT snapshot_id, report_type, period_start, period_end,
+                   snapshot_json, computed_at
+            FROM report_snapshots
+            WHERE report_type = %(report_type)s
+            ORDER BY period_start DESC
+            LIMIT %(limit)s
+            """,
+            {"report_type": report_type, "limit": limit},
+        )
+        return cur.fetchall()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_reporting.py::TestPersistReportSnapshot tests/test_reporting.py::TestLoadReportSnapshots -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/reporting.py tests/test_reporting.py
+git commit -m "feat(#207): persist and load report snapshots with idempotent upsert"
+```
+
+---
+
+### Task 6: Scheduler jobs — weekly and monthly report generation
+
+**Files:**
+- Modify: `app/workers/scheduler.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_reporting.py`:
+
+```python
+class TestReportSchedulerJobs:
+    def test_weekly_report_job_registered(self) -> None:
+        """weekly_report job should be in SCHEDULED_JOBS."""
+        from app.workers.scheduler import SCHEDULED_JOBS
+        names = [j.name for j in SCHEDULED_JOBS]
+        assert "weekly_report" in names
+
+    def test_monthly_report_job_registered(self) -> None:
+        """monthly_report job should be in SCHEDULED_JOBS."""
+        from app.workers.scheduler import SCHEDULED_JOBS
+        names = [j.name for j in SCHEDULED_JOBS]
+        assert "monthly_report" in names
+
+    def test_weekly_report_cadence(self) -> None:
+        """weekly_report should run Saturday morning."""
+        from app.workers.scheduler import SCHEDULED_JOBS
+        job = next(j for j in SCHEDULED_JOBS if j.name == "weekly_report")
+        assert job.cadence.kind == "weekly"
+        assert job.cadence.weekday == 5  # Saturday
+
+    def test_monthly_report_cadence(self) -> None:
+        """monthly_report should run on the 1st of each month."""
+        from app.workers.scheduler import SCHEDULED_JOBS
+        job = next(j for j in SCHEDULED_JOBS if j.name == "monthly_report")
+        assert job.cadence.kind == "monthly"
+        assert job.cadence.day == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_reporting.py::TestReportSchedulerJobs -v`
+Expected: FAIL — jobs not registered
+
+- [ ] **Step 3: Add job constants, prerequisite, and register jobs**
+
+In `app/workers/scheduler.py`:
+
+Add job constants near existing ones (~line 188):
+```python
+JOB_WEEKLY_REPORT = "weekly_report"
+JOB_MONTHLY_REPORT = "monthly_report"
+```
+
+Add prerequisite (near existing `_has_*` functions):
+```python
+def _has_positions_or_attributions(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if there are open positions or any attributed positions (something to report on)."""
+    if _exists(
+        conn,
+        psycopg.sql.SQL(
+            "SELECT EXISTS("
+            "SELECT 1 FROM positions WHERE current_units > 0 "
+            "UNION ALL "
+            "SELECT 1 FROM return_attribution LIMIT 1"
+            ")"
+        ),
+    ):
+        return (True, "")
+    return (False, "no positions or attributions to report on")
+```
+
+Add job registrations to `SCHEDULED_JOBS` list:
+```python
+ScheduledJob(
+    name=JOB_WEEKLY_REPORT,
+    description="Generate weekly performance report snapshot.",
+    cadence=Cadence.weekly(weekday=5, hour=7, minute=0),  # Saturday 07:00
+    prerequisite=_has_positions_or_attributions,
+),
+ScheduledJob(
+    name=JOB_MONTHLY_REPORT,
+    description="Generate monthly performance report snapshot.",
+    cadence=Cadence.monthly(day=1, hour=7, minute=0),  # 1st of month 07:00
+    prerequisite=_has_positions_or_attributions,
+),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_reporting.py::TestReportSchedulerJobs -v`
+Expected: 4 passed
+
+- [ ] **Step 5: Add the job invoker functions**
+
+Still in `app/workers/scheduler.py`, add the actual job functions near the bottom (before the `_INVOKERS` dict):
+
+```python
+def weekly_report() -> None:
+    """Generate and persist the weekly performance report."""
+    from app.services.reporting import generate_weekly_report, persist_report_snapshot
+
+    with _tracked_job(JOB_WEEKLY_REPORT) as tracker:
+        # Period: previous Monday through Sunday
+        today = datetime.now(tz=timezone.utc).date()
+        # Saturday run → report covers Mon–Sun of the week just ended
+        period_end = today - timedelta(days=(today.weekday() + 1) % 7)  # last Sunday
+        period_start = period_end - timedelta(days=6)  # Monday of that week
+
+        with psycopg.connect(settings.database_url) as conn:
+            report = generate_weekly_report(conn, period_start, period_end)
+            persist_report_snapshot(
+                conn,
+                report_type="weekly",
+                period_start=period_start,
+                period_end=period_end,
+                snapshot=report,
+            )
+            conn.commit()
+        tracker.row_count = 1
+
+
+def monthly_report() -> None:
+    """Generate and persist the monthly performance report."""
+    from app.services.reporting import generate_monthly_report, persist_report_snapshot
+
+    with _tracked_job(JOB_MONTHLY_REPORT) as tracker:
+        # Period: previous full calendar month
+        today = datetime.now(tz=timezone.utc).date()
+        period_end = today.replace(day=1) - timedelta(days=1)  # last day of prev month
+        period_start = period_end.replace(day=1)  # first day of prev month
+
+        with psycopg.connect(settings.database_url) as conn:
+            report = generate_monthly_report(conn, period_start, period_end)
+            persist_report_snapshot(
+                conn,
+                report_type="monthly",
+                period_start=period_start,
+                period_end=period_end,
+                snapshot=report,
+            )
+            conn.commit()
+        tracker.row_count = 1
+```
+
+Add entries to `_INVOKERS` dict:
+```python
+JOB_WEEKLY_REPORT: weekly_report,
+JOB_MONTHLY_REPORT: monthly_report,
+```
+
+- [ ] **Step 6: Run all reporting tests**
+
+Run: `uv run pytest tests/test_reporting.py -v`
+Expected: All pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/workers/scheduler.py tests/test_reporting.py
+git commit -m "feat(#207): register weekly and monthly report scheduler jobs"
+```
+
+---
+
+### Task 7: API endpoints for report snapshots
+
+**Files:**
+- Create: `app/api/reports.py`
+- Modify: `app/main.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_reporting.py`:
+
+```python
+class TestReportsAPI:
+    def test_reports_router_exists(self) -> None:
+        """The reports router should have the correct prefix."""
+        from app.api.reports import router
+        assert router.prefix == "/api/reports"
+
+    def test_list_weekly_endpoint_exists(self) -> None:
+        """GET /api/reports/weekly should be a registered route."""
+        from app.api.reports import router
+        paths = [r.path for r in router.routes]
+        assert "/weekly" in paths
+
+    def test_list_monthly_endpoint_exists(self) -> None:
+        """GET /api/reports/monthly should be a registered route."""
+        from app.api.reports import router
+        paths = [r.path for r in router.routes]
+        assert "/monthly" in paths
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_reporting.py::TestReportsAPI -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the API router**
+
+Create `app/api/reports.py`:
+
+```python
+"""Reports API — periodic performance report snapshots."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from fastapi import APIRouter, Depends, Query
+
+from app.api.auth import require_session_or_service_token
+from app.config import settings
+
+router = APIRouter(
+    prefix="/api/reports",
+    tags=["reports"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+
+@router.get("/weekly")
+def list_weekly_reports(
+    limit: int = Query(default=10, le=100),
+) -> list[dict[str, Any]]:
+    """Return the most recent weekly report snapshots."""
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT snapshot_id, report_type, period_start, period_end,
+                       snapshot_json, computed_at
+                FROM report_snapshots
+                WHERE report_type = 'weekly'
+                ORDER BY period_start DESC
+                LIMIT %(limit)s
+                """,
+                {"limit": limit},
+            )
+            return cur.fetchall()
+
+
+@router.get("/monthly")
+def list_monthly_reports(
+    limit: int = Query(default=10, le=100),
+) -> list[dict[str, Any]]:
+    """Return the most recent monthly report snapshots."""
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT snapshot_id, report_type, period_start, period_end,
+                       snapshot_json, computed_at
+                FROM report_snapshots
+                WHERE report_type = 'monthly'
+                ORDER BY period_start DESC
+                LIMIT %(limit)s
+                """,
+                {"limit": limit},
+            )
+            return cur.fetchall()
+
+
+@router.get("/latest")
+def get_latest_report(
+    report_type: str = Query(pattern="^(weekly|monthly)$"),
+) -> dict[str, Any] | None:
+    """Return the single most recent report of the given type."""
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT snapshot_id, report_type, period_start, period_end,
+                       snapshot_json, computed_at
+                FROM report_snapshots
+                WHERE report_type = %(report_type)s
+                ORDER BY period_start DESC
+                LIMIT 1
+                """,
+                {"report_type": report_type},
+            )
+            return cur.fetchone()
+```
+
+- [ ] **Step 4: Register the router in `app/main.py`**
+
+Add to the router registration block in `app/main.py`:
+
+```python
+from app.api.reports import router as reports_router
+app.include_router(reports_router)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_reporting.py::TestReportsAPI -v`
+Expected: 3 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/reports.py app/main.py tests/test_reporting.py
+git commit -m "feat(#207): reports API endpoints — weekly, monthly, latest"
+```
+
+---
+
+### Task 8: Edge case tests
+
+**Files:**
+- Modify: `tests/test_reporting.py`
+
+- [ ] **Step 1: Write edge case tests**
+
+Add to `tests/test_reporting.py`:
+
+```python
+class TestWinRateEdgeCases:
+    def test_no_closed_positions_returns_none(self) -> None:
+        """Win rate should be None when no positions closed in the period."""
+        from app.services.reporting import _win_rate_and_holding
+
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = []
+
+        result = _win_rate_and_holding(conn, date(2026, 4, 1), date(2026, 4, 30))
+        assert result["total_closed"] == 0
+        assert result["win_rate_pct"] is None
+        assert result["avg_holding_days"] is None
+
+    def test_all_winners(self) -> None:
+        """100% win rate when all positions were profitable."""
+        from app.services.reporting import _win_rate_and_holding
+
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = [
+            {"gross_return_pct": Decimal("0.10"), "hold_days": 30},
+            {"gross_return_pct": Decimal("0.05"), "hold_days": 45},
+        ]
+
+        result = _win_rate_and_holding(conn, date(2026, 4, 1), date(2026, 4, 30))
+        assert result["total_closed"] == 2
+        assert result["win_rate_pct"] == "100.00"
+        assert result["avg_holding_days"] == 37.5
+
+
+class TestBottomPerformersEdge:
+    def test_fewer_than_n_positions(self) -> None:
+        """With fewer positions than N, bottom list should not duplicate top."""
+        from app.services.reporting import _top_bottom_performers
+
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = [
+            {
+                "instrument_id": 1, "symbol": "AAPL", "company_name": "Apple",
+                "unrealized_pnl": Decimal("100"), "current_units": Decimal("5"),
+                "avg_cost": Decimal("150"),
+            },
+        ]
+
+        top, bottom = _top_bottom_performers(conn, n=3)
+        assert len(top) == 1
+        assert len(bottom) == 0  # only 1 position, goes to top, none left for bottom
+
+
+class TestDecHelper:
+    def test_none_returns_none(self) -> None:
+        from app.services.reporting import _dec
+        assert _dec(None) is None
+
+    def test_decimal_returns_string(self) -> None:
+        from app.services.reporting import _dec
+        assert _dec(Decimal("1.23")) == "1.23"
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `uv run pytest tests/test_reporting.py -v`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_reporting.py
+git commit -m "test(#207): edge case tests — win rate, performer lists, decimal helper"
+```
+
+---
+
+### Task 9: Local checks and self-review
+
+- [ ] **Step 1: Run full pre-push checklist**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+All four must pass.
+
+- [ ] **Step 2: Fix any issues found**
+
+- [ ] **Step 3: Self-review the full diff**
+
+Run: `git diff main --stat` and `git diff main` to review all changes.
+
+Check against the pre-flight review skill:
+- No security issues (parameterised queries, auth on endpoints)
+- No type mismatches (Decimal → str for JSONB, proper None handling)
+- No prevention log violations
+- No settled decision violations
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -u
+git commit -m "chore(#207): pre-push fixes from self-review"
+```

--- a/sql/030_report_snapshots.sql
+++ b/sql/030_report_snapshots.sql
@@ -1,0 +1,16 @@
+-- Migration 030: report snapshots
+--
+-- Stores periodic (weekly/monthly) performance report snapshots as JSONB.
+-- One row per (report_type, period_start). Idempotent rerun replaces the snapshot.
+
+CREATE TABLE IF NOT EXISTS report_snapshots (
+    snapshot_id    BIGSERIAL PRIMARY KEY,
+    report_type    TEXT NOT NULL CHECK (report_type IN ('weekly', 'monthly')),
+    period_start   DATE NOT NULL,
+    period_end     DATE NOT NULL,
+    snapshot_json  JSONB NOT NULL,
+    computed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_report_snapshots_type_period
+    ON report_snapshots(report_type, period_start);

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -379,7 +379,7 @@ class TestSystemJobs:
         # Each entry carries the declared cadence + computed next_run_time.
         for job in body["jobs"]:
             assert job["cadence"]
-            assert job["cadence_kind"] in ("hourly", "daily", "weekly")
+            assert job["cadence_kind"] in ("hourly", "daily", "weekly", "monthly")
             assert job["next_run_time"]
             assert job["next_run_time_source"] == "declared"
             assert job["description"]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,77 @@
+"""Tests for the reporting engine — weekly & monthly performance reports."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.workers.scheduler import Cadence, compute_next_run
+
+
+class TestCadenceMonthly:
+    def test_valid_monthly_cadence(self) -> None:
+        c = Cadence.monthly(day=1, hour=6, minute=0)
+        assert c.kind == "monthly"
+        assert c.day == 1
+        assert c.hour == 6
+        assert c.minute == 0
+
+    def test_monthly_day_out_of_range_high(self) -> None:
+        with pytest.raises(ValueError, match="monthly day must be 1..28"):
+            Cadence.monthly(day=29, hour=6)
+
+    def test_monthly_day_out_of_range_low(self) -> None:
+        with pytest.raises(ValueError, match="monthly day must be 1..28"):
+            Cadence.monthly(day=0, hour=6)
+
+    def test_monthly_label(self) -> None:
+        c = Cadence.monthly(day=15, hour=9, minute=30)
+        assert c.label == "monthly on day 15 at 09:30 UTC"
+
+
+class TestComputeNextRunMonthly:
+    def test_same_month_future(self) -> None:
+        """If the fire day hasn't passed yet this month, return this month."""
+        now = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
+        c = Cadence.monthly(day=15, hour=7, minute=0)
+        result = compute_next_run(c, now)
+        assert result == datetime(2026, 4, 15, 7, 0, 0, tzinfo=UTC)
+
+    def test_same_month_past_advances_to_next(self) -> None:
+        """If fire day already passed this month, advance to next month."""
+        now = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+        c = Cadence.monthly(day=1, hour=7, minute=0)
+        result = compute_next_run(c, now)
+        assert result == datetime(2026, 5, 1, 7, 0, 0, tzinfo=UTC)
+
+    def test_december_wraps_to_january(self) -> None:
+        """December fire that's already passed wraps to January next year."""
+        now = datetime(2026, 12, 15, 12, 0, 0, tzinfo=UTC)
+        c = Cadence.monthly(day=1, hour=7, minute=0)
+        result = compute_next_run(c, now)
+        assert result == datetime(2027, 1, 1, 7, 0, 0, tzinfo=UTC)
+
+    def test_exact_fire_time_advances(self) -> None:
+        """If now is exactly on fire time, next run is next month (strictly greater)."""
+        now = datetime(2026, 4, 1, 7, 0, 0, tzinfo=UTC)
+        c = Cadence.monthly(day=1, hour=7, minute=0)
+        result = compute_next_run(c, now)
+        assert result == datetime(2026, 5, 1, 7, 0, 0, tzinfo=UTC)
+
+    def test_february_28(self) -> None:
+        """Day 28 works in February (non-leap year)."""
+        now = datetime(2027, 2, 1, 0, 0, 0, tzinfo=UTC)
+        c = Cadence.monthly(day=28, hour=7, minute=0)
+        result = compute_next_run(c, now)
+        assert result == datetime(2027, 2, 28, 7, 0, 0, tzinfo=UTC)
+
+
+class TestTriggerForMonthly:
+    def test_monthly_trigger(self) -> None:
+        from app.jobs.runtime import _trigger_for
+
+        c = Cadence.monthly(day=1, hour=7, minute=0)
+        trigger = _trigger_for(c)
+        # CronTrigger fields — verify the trigger was created without error
+        assert trigger is not None

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -231,3 +231,47 @@ class TestLoadReportSnapshots:
         result = load_report_snapshots(conn, report_type="weekly", limit=10)
         assert result == []
         cursor.execute.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Scheduler job registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestReportSchedulerJobs:
+    def test_weekly_report_job_registered(self) -> None:
+        """weekly_report job should be in SCHEDULED_JOBS."""
+        from app.workers.scheduler import SCHEDULED_JOBS
+
+        names = [j.name for j in SCHEDULED_JOBS]
+        assert "weekly_report" in names
+
+    def test_monthly_report_job_registered(self) -> None:
+        """monthly_report job should be in SCHEDULED_JOBS."""
+        from app.workers.scheduler import SCHEDULED_JOBS
+
+        names = [j.name for j in SCHEDULED_JOBS]
+        assert "monthly_report" in names
+
+    def test_weekly_report_cadence(self) -> None:
+        """weekly_report should run Saturday morning."""
+        from app.workers.scheduler import SCHEDULED_JOBS
+
+        job = next(j for j in SCHEDULED_JOBS if j.name == "weekly_report")
+        assert job.cadence.kind == "weekly"
+        assert job.cadence.weekday == 5  # Saturday
+
+    def test_monthly_report_cadence(self) -> None:
+        """monthly_report should run on the 1st of each month."""
+        from app.workers.scheduler import SCHEDULED_JOBS
+
+        job = next(j for j in SCHEDULED_JOBS if j.name == "monthly_report")
+        assert job.cadence.kind == "monthly"
+        assert job.cadence.day == 1
+
+    def test_drift_guard_invokers_match(self) -> None:
+        """Both new jobs must have entries in _INVOKERS."""
+        from app.jobs.runtime import _INVOKERS
+
+        assert "weekly_report" in _INVOKERS
+        assert "monthly_report" in _INVOKERS

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 
 import pytest
@@ -309,3 +310,138 @@ class TestReportsAPI:
 
         paths = [r.path for r in router.routes if hasattr(r, "path")]  # type: ignore[union-attr]
         assert "/api/reports/latest" in paths
+
+
+# ---------------------------------------------------------------------------
+# Edge case tests
+# ---------------------------------------------------------------------------
+
+
+class TestWinRateEdgeCases:
+    def test_no_closed_positions_returns_none(self) -> None:
+        """Win rate should be None when no positions closed in the period."""
+        from app.services.reporting import _win_rate_and_holding
+
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = []
+
+        result = _win_rate_and_holding(conn, date(2026, 4, 1), date(2026, 4, 30))
+        assert result["total_closed"] == 0
+        assert result["win_rate_pct"] is None
+        assert result["avg_holding_days"] is None
+
+    def test_all_winners(self) -> None:
+        """100% win rate when all positions were profitable."""
+        from app.services.reporting import _win_rate_and_holding
+
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = [
+            {"gross_return_pct": Decimal("0.10"), "hold_days": 30},
+            {"gross_return_pct": Decimal("0.05"), "hold_days": 45},
+        ]
+
+        result = _win_rate_and_holding(conn, date(2026, 4, 1), date(2026, 4, 30))
+        assert result["total_closed"] == 2
+        assert result["win_rate_pct"] == "100.00"
+        assert result["avg_holding_days"] == 37.5
+
+
+class TestBottomPerformersEdge:
+    def test_fewer_than_n_positions(self) -> None:
+        """With fewer positions than N, bottom list should not duplicate top."""
+        from app.services.reporting import _top_bottom_performers
+
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = [
+            {
+                "instrument_id": 1, "symbol": "AAPL", "company_name": "Apple",
+                "unrealized_pnl": Decimal("100"), "current_units": Decimal("5"),
+                "avg_cost": Decimal("150"),
+            },
+        ]
+
+        top, bottom = _top_bottom_performers(conn, n=3)
+        assert len(top) == 1
+        assert len(bottom) == 0
+
+
+class TestDecHelper:
+    def test_none_returns_none(self) -> None:
+        from app.services.reporting import _dec
+        assert _dec(None) is None
+
+    def test_decimal_returns_string(self) -> None:
+        from app.services.reporting import _dec
+        assert _dec(Decimal("1.23")) == "1.23"
+
+
+class TestJsonSerializability:
+    """Codex-requested: verify reports can be serialized to JSON."""
+
+    def test_weekly_report_is_json_serializable(self) -> None:
+        """The weekly report dict must survive json.dumps without error."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = []
+        cursor.fetchone.return_value = {"realized": Decimal("0"), "unrealized": Decimal("0")}
+
+        with patch(f"{_REPORTING}.compute_budget_state") as mock_budget:
+            mock_budget.return_value = MagicMock(
+                cash_balance=Decimal("10000"),
+                deployed_capital=Decimal("5000"),
+                estimated_tax_usd=Decimal("200"),
+                available_for_deployment=Decimal("4800"),
+            )
+            report = generate_weekly_report(
+                conn,
+                period_start=date(2026, 4, 6),
+                period_end=date(2026, 4, 12),
+            )
+
+        # Must not raise
+        serialized = json.dumps(report)
+        assert isinstance(serialized, str)
+        assert "weekly" in serialized
+
+    def test_monthly_report_is_json_serializable(self) -> None:
+        """The monthly report dict must survive json.dumps without error."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = []
+        cursor.fetchone.return_value = {
+            "realized": Decimal("0"), "unrealized": Decimal("0"),
+            "positions_attributed": 0, "avg_gross": None,
+            "avg_market": None, "avg_alpha": None,
+        }
+
+        with patch(f"{_REPORTING}.compute_budget_state") as mock_budget:
+            mock_budget.return_value = MagicMock(
+                cash_balance=Decimal("10000"),
+                deployed_capital=Decimal("5000"),
+                estimated_tax_usd=Decimal("200"),
+                estimated_tax_gbp=Decimal("160"),
+                available_for_deployment=Decimal("4800"),
+                tax_year="2025/26",
+            )
+            report = generate_monthly_report(
+                conn,
+                period_start=date(2026, 3, 1),
+                period_end=date(2026, 3, 31),
+            )
+
+        serialized = json.dumps(report)
+        assert isinstance(serialized, str)
+        assert "monthly" in serialized

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -75,3 +75,53 @@ class TestTriggerForMonthly:
         trigger = _trigger_for(c)
         # CronTrigger fields — verify the trigger was created without error
         assert trigger is not None
+
+
+# ---------------------------------------------------------------------------
+# Weekly report generator tests
+# ---------------------------------------------------------------------------
+
+from datetime import date  # noqa: E402
+from decimal import Decimal  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+from app.services.reporting import generate_weekly_report  # noqa: E402
+
+_REPORTING = "app.services.reporting"
+
+
+class TestGenerateWeeklyReport:
+    def test_returns_weekly_report_structure(self) -> None:
+        """Weekly report should contain all expected sections."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = []
+        cursor.fetchone.return_value = {"realized": Decimal("0"), "unrealized": Decimal("0")}
+
+        with patch(f"{_REPORTING}.compute_budget_state") as mock_budget:
+            mock_budget.return_value = MagicMock(
+                cash_balance=Decimal("10000"),
+                deployed_capital=Decimal("5000"),
+                estimated_tax_usd=Decimal("200"),
+                available_for_deployment=Decimal("4800"),
+            )
+            report = generate_weekly_report(
+                conn,
+                period_start=date(2026, 4, 6),
+                period_end=date(2026, 4, 12),
+            )
+
+        assert report["report_type"] == "weekly"
+        assert report["period_start"] == "2026-04-06"
+        assert report["period_end"] == "2026-04-12"
+        assert "pnl" in report
+        assert report["pnl"]["note"] == "current-state snapshot, not period delta"
+        assert "top_performers" in report
+        assert "bottom_performers" in report
+        assert "positions_opened" in report
+        assert "positions_closed" in report
+        assert "upcoming_earnings" in report
+        assert "score_changes" in report
+        assert "budget" in report

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -177,3 +177,57 @@ class TestGenerateMonthlyReport:
         assert "attribution_summary" in report
         assert "thesis_accuracy" in report
         assert "tax_provision" in report
+
+
+# ---------------------------------------------------------------------------
+# Persistence layer tests
+# ---------------------------------------------------------------------------
+
+
+class TestPersistReportSnapshot:
+    def test_persist_executes_upsert(self) -> None:
+        """persist_report_snapshot should execute an INSERT with ON CONFLICT DO UPDATE."""
+        from app.services.reporting import persist_report_snapshot
+
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        report = {
+            "report_type": "weekly",
+            "period_start": "2026-04-06",
+            "period_end": "2026-04-12",
+            "pnl": {"realized_pnl": "100", "unrealized_pnl": "200"},
+        }
+
+        persist_report_snapshot(
+            conn,
+            report_type="weekly",
+            period_start=date(2026, 4, 6),
+            period_end=date(2026, 4, 12),
+            snapshot=report,
+        )
+
+        cursor.execute.assert_called_once()
+        sql = cursor.execute.call_args[0][0]
+        params = cursor.execute.call_args[0][1]
+        assert "ON CONFLICT" in sql
+        assert params["report_type"] == "weekly"
+        assert params["period_start"] == date(2026, 4, 6)
+
+
+class TestLoadReportSnapshots:
+    def test_load_returns_list(self) -> None:
+        """load_report_snapshots should query by report_type."""
+        from app.services.reporting import load_report_snapshots
+
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = []
+
+        result = load_report_snapshots(conn, report_type="weekly", limit=10)
+        assert result == []
+        cursor.execute.assert_called_once()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -363,8 +363,11 @@ class TestBottomPerformersEdge:
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         cursor.fetchall.return_value = [
             {
-                "instrument_id": 1, "symbol": "AAPL", "company_name": "Apple",
-                "unrealized_pnl": Decimal("100"), "current_units": Decimal("5"),
+                "instrument_id": 1,
+                "symbol": "AAPL",
+                "company_name": "Apple",
+                "unrealized_pnl": Decimal("100"),
+                "current_units": Decimal("5"),
                 "avg_cost": Decimal("150"),
             },
         ]
@@ -377,10 +380,12 @@ class TestBottomPerformersEdge:
 class TestDecHelper:
     def test_none_returns_none(self) -> None:
         from app.services.reporting import _dec
+
         assert _dec(None) is None
 
     def test_decimal_returns_string(self) -> None:
         from app.services.reporting import _dec
+
         assert _dec(Decimal("1.23")) == "1.23"
 
 
@@ -422,9 +427,12 @@ class TestJsonSerializability:
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         cursor.fetchall.return_value = []
         cursor.fetchone.return_value = {
-            "realized": Decimal("0"), "unrealized": Decimal("0"),
-            "positions_attributed": 0, "avg_gross": None,
-            "avg_market": None, "avg_alpha": None,
+            "realized": Decimal("0"),
+            "unrealized": Decimal("0"),
+            "positions_attributed": 0,
+            "avg_gross": None,
+            "avg_market": None,
+            "avg_alpha": None,
         }
 
         with patch(f"{_REPORTING}.compute_budget_state") as mock_budget:

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -275,3 +275,37 @@ class TestReportSchedulerJobs:
 
         assert "weekly_report" in _INVOKERS
         assert "monthly_report" in _INVOKERS
+
+
+# ---------------------------------------------------------------------------
+# Reports API tests
+# ---------------------------------------------------------------------------
+
+
+class TestReportsAPI:
+    def test_reports_router_exists(self) -> None:
+        """The reports router should have the correct prefix."""
+        from app.api.reports import router
+
+        assert router.prefix == "/api/reports"
+
+    def test_list_weekly_endpoint_exists(self) -> None:
+        """GET /api/reports/weekly should be a registered route."""
+        from app.api.reports import router
+
+        paths = [r.path for r in router.routes if hasattr(r, "path")]  # type: ignore[union-attr]
+        assert "/api/reports/weekly" in paths
+
+    def test_list_monthly_endpoint_exists(self) -> None:
+        """GET /api/reports/monthly should be a registered route."""
+        from app.api.reports import router
+
+        paths = [r.path for r in router.routes if hasattr(r, "path")]  # type: ignore[union-attr]
+        assert "/api/reports/monthly" in paths
+
+    def test_latest_endpoint_exists(self) -> None:
+        """GET /api/reports/latest should be a registered route."""
+        from app.api.reports import router
+
+        paths = [r.path for r in router.routes if hasattr(r, "path")]  # type: ignore[union-attr]
+        assert "/api/reports/latest" in paths

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -125,3 +125,55 @@ class TestGenerateWeeklyReport:
         assert "upcoming_earnings" in report
         assert "score_changes" in report
         assert "budget" in report
+
+
+# ---------------------------------------------------------------------------
+# Monthly report generator tests
+# ---------------------------------------------------------------------------
+
+from app.services.reporting import generate_monthly_report  # noqa: E402
+
+
+class TestGenerateMonthlyReport:
+    def test_returns_monthly_report_structure(self) -> None:
+        """Monthly report should contain all expected sections."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = []
+        cursor.fetchone.return_value = {
+            "realized": Decimal("0"),
+            "unrealized": Decimal("0"),
+            "positions_attributed": 0,
+            "avg_gross": None,
+            "avg_market": None,
+            "avg_alpha": None,
+        }
+
+        with patch(f"{_REPORTING}.compute_budget_state") as mock_budget:
+            mock_budget.return_value = MagicMock(
+                cash_balance=Decimal("10000"),
+                deployed_capital=Decimal("5000"),
+                estimated_tax_usd=Decimal("200"),
+                estimated_tax_gbp=Decimal("160"),
+                available_for_deployment=Decimal("4800"),
+                tax_year="2025/26",
+            )
+            report = generate_monthly_report(
+                conn,
+                period_start=date(2026, 3, 1),
+                period_end=date(2026, 3, 31),
+            )
+
+        assert report["report_type"] == "monthly"
+        assert report["period_start"] == "2026-03-01"
+        assert report["period_end"] == "2026-03-31"
+        assert "position_pnl" in report
+        assert "win_rate" in report
+        assert "avg_holding_days" in report
+        assert "best_trade" in report
+        assert "worst_trade" in report
+        assert "attribution_summary" in report
+        assert "thesis_accuracy" in report
+        assert "tax_provision" in report


### PR DESCRIPTION
Closes #207

## What changed

New periodic reporting subsystem that generates weekly and monthly performance
report snapshots, persists them as JSONB, and serves them via API endpoints.

**New files:**
- `sql/030_report_snapshots.sql` — migration for `report_snapshots` table (JSONB, idempotent upsert via unique index)
- `app/services/reporting.py` — report generation engine (657 lines): 12 section functions, 2 generators (weekly/monthly), persist + load helpers
- `app/api/reports.py` — 3 REST endpoints: `GET /api/reports/weekly`, `/monthly`, `/latest`
- `tests/test_reporting.py` — 30 tests across 12 test classes

**Modified files:**
- `app/workers/scheduler.py` — `Cadence.monthly()` classmethod, two new scheduled jobs (weekly Saturday 07:00, monthly 1st 07:00)
- `app/jobs/runtime.py` — monthly `CronTrigger` branch, two new invoker entries
- `app/api/system.py` — `JobOverviewResponse.cadence_kind` Literal includes `"monthly"`
- `app/main.py` — reports router registration
- `tests/test_api_system.py` — cadence kind assertion updated

## Why

Issue #207 calls for automated periodic performance reporting. This enables the
operator to review portfolio performance without manual data pulling. Reports are
**current-state snapshots** (not period deltas) because we don't yet have
beginning-of-period valuation history — this is documented in the report metadata.

Monthly reports add period-bounded return attribution, win rate/holding stats,
best/worst trades, thesis accuracy, and tax provision snapshots on top of what
the weekly report provides.

## Schema / migration impact

- **New table:** `report_snapshots` with unique index on `(report_type, period_start)`
- **No schema changes** to existing tables
- **No data backfill** — table starts empty, populated by scheduled jobs
- Idempotent: `ON CONFLICT DO UPDATE` means re-running for same period replaces cleanly

## Invariants checked

- **Idempotent upserts** — unique index on `(report_type, period_start)`, upsert replaces snapshot
- **No external I/O inside transactions** — report generation reads DB, then persists; no API calls mid-tx
- **Parameterized queries only** — all SQL uses `%(name)s` params
- **Service functions never commit** — caller owns transaction boundary
- **LATERAL joins with LIMIT 1** — thesis accuracy uses `LATERAL ... ORDER BY created_at DESC LIMIT 1` to avoid fan-out
- **Realized P&L includes closed positions** — `FILTER (WHERE current_units > 0)` only on unrealized; realized sums all positions
- **Same-day thesis inclusion** — `created_at < hold_start + interval '1 day'` includes theses created on the hold-start day

## Failure paths considered

- **Empty positions table** — COALESCE returns zeros, empty performer lists, no earnings
- **No return attribution rows** — period attribution returns empty, win rate returns `null`
- **No theses for instrument** — LATERAL join is LEFT JOIN, thesis fields null, `target_hit` = null
- **No fills for period** — opened/closed lists empty
- **No budget state** — `compute_budget_state` returns defaults
- **February scheduling** — `Cadence.monthly()` caps day at 28, validated on construction
- **December→January wrap** — `compute_next_run` handles year rollover explicitly

## Tests added

30 tests across 12 classes:
- `TestCadenceMonthly` (4) — construction, day validation, label format
- `TestComputeNextRunMonthly` (5) — same-month future, next-month wrap, December→January, exact fire, Feb 28
- `TestTriggerForMonthly` (1) — APScheduler CronTrigger creation
- `TestGenerateWeeklyReport` (1) — structure: 8 expected sections present
- `TestGenerateMonthlyReport` (1) — structure: 9 expected sections present
- `TestPersistReportSnapshot` (1) — upsert SQL verification
- `TestLoadReportSnapshots` (1) — query shape verification
- `TestReportSchedulerJobs` (5) — job registration, cadence values, drift guard
- `TestReportsAPI` (4) — router prefix, endpoint existence
- `TestWinRateEdgeCases` (2) — empty attribution, 100% win rate
- `TestBottomPerformersEdge` (1) — fewer than N positions
- `TestDecHelper` (2) — None passthrough, Decimal→str
- `TestJsonSerializability` (2) — weekly/monthly snapshots JSON-roundtrip

## Conscious tradeoffs

- **Current-state snapshots, not true period deltas** — we lack beginning-of-period valuations; reports are labeled with a `note` field documenting this. True deltas require valuation history (future work).
- **JSONB column instead of normalized tables** — report schema will evolve; JSONB gives flexibility without migrations per format change. Querying individual metrics across periods requires JSON path queries.
- **Frontend instrument detail page deferred** — plan scoped to backend; per-instrument analytics pages depend on #204 charts infrastructure.
- **No email/notification delivery** — reports are stored and served via API; push delivery is future scope.

## Tech debt opened

None — all scope items from #207 that are backend-only are covered.

## Security model

- All three API endpoints require `require_session_or_service_token` (same auth as existing endpoints)
- `report_type` query param on `/latest` is pattern-validated: `^(weekly|monthly)$`
- No user-controlled input in SQL beyond parameterized limit/type values

## Codex checkpoints

1. **Plan review** — 8 findings addressed in implementation (period-bounded attribution, entry-time thesis anchoring, realized P&L correctness, etc.)
2. **Diff review** — 2 P2 findings fixed in commit `ab67f76`: closed-position realized P&L and same-day thesis exclusion