### PR TITLE
feat(#154): transaction cost model — per-instrument cost estimation and reconciliation

### DIFF
--- a/app/api/budget.py
+++ b/app/api/budget.py
@@ -40,6 +40,11 @@ from app.services.budget import (
     record_capital_event,
     update_budget_config,
 )
+from app.services.transaction_cost import (
+    TransactionCostConfigCorrupt,
+    get_transaction_cost_config,
+    update_transaction_cost_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +94,15 @@ class BudgetConfigResponse(BaseModel):
     reason: str
 
 
+class CostConfigResponse(BaseModel):
+    max_total_cost_bps: float
+    min_return_vs_cost_ratio: float
+    default_hold_days: int
+    updated_at: datetime
+    updated_by: str
+    reason: str
+
+
 # ---------------------------------------------------------------------------
 # Request models
 # ---------------------------------------------------------------------------
@@ -111,6 +125,22 @@ class UpdateBudgetConfigRequest(BaseModel):
     def _at_least_one_field(self) -> UpdateBudgetConfigRequest:
         if self.cash_buffer_pct is None and self.cgt_scenario is None:
             raise ValueError("at least one of cash_buffer_pct or cgt_scenario must be provided")
+        return self
+
+
+class UpdateCostConfigRequest(BaseModel):
+    max_total_cost_bps: float | None = Field(default=None, gt=0, le=1000)
+    min_return_vs_cost_ratio: float | None = Field(default=None, ge=1.0)
+    default_hold_days: int | None = Field(default=None, gt=0, le=365)
+    updated_by: str
+    reason: str
+
+    @model_validator(mode="after")
+    def _at_least_one_field(self) -> UpdateCostConfigRequest:
+        if self.max_total_cost_bps is None and self.min_return_vs_cost_ratio is None and self.default_hold_days is None:
+            raise ValueError(
+                "at least one of max_total_cost_bps, min_return_vs_cost_ratio, or default_hold_days must be provided"
+            )
         return self
 
 
@@ -252,4 +282,64 @@ def patch_budget_config(
         updated_at=config.updated_at,
         updated_by=config.updated_by,
         reason=config.reason,
+    )
+
+
+@router.get("/cost-config", response_model=CostConfigResponse)
+def get_cost_config(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> CostConfigResponse:
+    """Return the current transaction cost configuration."""
+    try:
+        config = get_transaction_cost_config(conn)
+    except TransactionCostConfigCorrupt:
+        logger.exception("transaction cost config corrupt")
+        raise HTTPException(status_code=503, detail="transaction cost configuration unavailable")
+
+    return CostConfigResponse(
+        max_total_cost_bps=float(config["max_total_cost_bps"]),
+        min_return_vs_cost_ratio=float(config["min_return_vs_cost_ratio"]),
+        default_hold_days=config["default_hold_days"],
+        updated_at=config["updated_at"],
+        updated_by=config["updated_by"],
+        reason=config["reason"],
+    )
+
+
+@router.patch("/cost-config", response_model=CostConfigResponse)
+def patch_cost_config(
+    body: UpdateCostConfigRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> CostConfigResponse:
+    """Partial update of transaction cost configuration.
+
+    Only fields provided as non-None are changed.  Both ``updated_by`` and
+    ``reason`` are required for every mutation so the audit trail always
+    carries attribution.
+    """
+    try:
+        config = update_transaction_cost_config(
+            conn,
+            max_total_cost_bps=Decimal(str(body.max_total_cost_bps)) if body.max_total_cost_bps is not None else None,
+            min_return_vs_cost_ratio=(
+                Decimal(str(body.min_return_vs_cost_ratio)) if body.min_return_vs_cost_ratio is not None else None
+            ),
+            default_hold_days=body.default_hold_days,
+            updated_by=body.updated_by,
+            reason=body.reason,
+        )
+    except TransactionCostConfigCorrupt:
+        logger.exception("transaction cost config corrupt")
+        raise HTTPException(status_code=503, detail="transaction cost configuration unavailable")
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    conn.commit()
+    return CostConfigResponse(
+        max_total_cost_bps=float(config["max_total_cost_bps"]),
+        min_return_vs_cost_ratio=float(config["min_return_vs_cost_ratio"]),
+        default_hold_days=config["default_hold_days"],
+        updated_at=config["updated_at"],
+        updated_by=config["updated_by"],
+        reason=config["reason"],
     )

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -68,6 +68,7 @@ from app.workers.scheduler import (
     JOB_MORNING_CANDIDATE_REVIEW,
     JOB_NIGHTLY_UNIVERSE_SYNC,
     JOB_RETRY_DEFERRED,
+    JOB_SEED_COST_MODELS,
     JOB_WEEKLY_COVERAGE_REVIEW,
     JOB_WEEKLY_REPORT,
     SCHEDULED_JOBS,
@@ -89,6 +90,7 @@ from app.workers.scheduler import (
     morning_candidate_review,
     nightly_universe_sync,
     retry_deferred_recommendations_job,
+    seed_cost_models,
     weekly_coverage_review,
     weekly_report,
 )
@@ -132,6 +134,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_RETRY_DEFERRED: retry_deferred_recommendations_job,
     JOB_MONITOR_POSITIONS: monitor_positions_job,
     JOB_ATTRIBUTION_SUMMARY: attribution_summary_job,
+    JOB_SEED_COST_MODELS: seed_cost_models,
     JOB_WEEKLY_REPORT: weekly_report,
     JOB_MONTHLY_REPORT: monthly_report,
 }

--- a/app/services/execution_guard.py
+++ b/app/services/execution_guard.py
@@ -473,7 +473,8 @@ def _check_transaction_cost(
         passed=True,
         detail=(
             f"cost ok: total={estimate.total_cost_bps} bps "
-            f"(spread={estimate.spread_bps}, carry={estimate.total_carry_cost_bps})"
+            f"(spread={estimate.spread_bps}, carry={estimate.total_carry_cost_bps}, "
+            f"fx={estimate.fx_markup_bps}\u00d72)"
         ),
     )
 

--- a/app/services/execution_guard.py
+++ b/app/services/execution_guard.py
@@ -42,6 +42,7 @@ import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from typing import Any, Literal
 
 import psycopg
@@ -51,6 +52,13 @@ from psycopg.types.json import Jsonb
 from app.services.budget import BudgetConfigCorrupt, BudgetState, compute_budget_state
 from app.services.portfolio import _load_mirror_equity
 from app.services.runtime_config import RuntimeConfigCorrupt, get_runtime_config
+from app.services.transaction_cost import (
+    TransactionCostConfigCorrupt,
+    estimate_cost,
+    get_transaction_cost_config,
+    load_instrument_cost,
+    spread_pct_to_bps,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +97,7 @@ RuleName = Literal[
     "no_thesis",
     "spread_wide",
     "spread_unavailable",
+    "transaction_cost_prohibitive",
     "budget_available",
     "instrument_missing",
     "sector_missing",
@@ -201,7 +210,7 @@ def _load_quote(
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT spread_flag
+            SELECT spread_flag, spread_pct
             FROM quotes
             WHERE instrument_id = %(iid)s
             ORDER BY quoted_at DESC
@@ -411,6 +420,62 @@ def _check_spread(quote: dict[str, Any] | None) -> RuleResult:
     return RuleResult(rule="spread_wide", passed=True)
 
 
+def _check_transaction_cost(
+    quote: dict[str, Any] | None,
+    cost_model_row: dict[str, Any] | None,
+    cost_config: dict[str, Any],
+) -> RuleResult:
+    """Check whether the estimated transaction cost is prohibitive."""
+    if cost_model_row is not None:
+        spread_bps = cost_model_row["spread_bps"]
+        overnight_rate = cost_model_row["overnight_rate"]
+        fx_markup_bps = cost_model_row["fx_markup_bps"]
+    elif quote is not None and quote.get("spread_pct") is not None:
+        converted = spread_pct_to_bps(quote["spread_pct"])
+        # spread_pct_to_bps returns None only when input is None, which the
+        # guard above already excluded.  Assert for pyright narrowing.
+        assert converted is not None  # pragma: no cover
+        spread_bps = converted
+        overnight_rate = Decimal("0")
+        fx_markup_bps = Decimal("0")
+    else:
+        return RuleResult(
+            rule="transaction_cost_prohibitive",
+            passed=False,
+            detail="cost unavailable: no cost_model row and no quote spread_pct",
+        )
+
+    estimate = estimate_cost(
+        spread_bps=spread_bps,
+        overnight_rate=overnight_rate,
+        fx_markup_bps=fx_markup_bps,
+        hold_days=cost_config["default_hold_days"],
+        max_total_cost_bps=cost_config["max_total_cost_bps"],
+        min_return_vs_cost_ratio=cost_config["min_return_vs_cost_ratio"],
+        expected_return_pct=None,
+    )
+
+    if estimate.is_cost_prohibitive:
+        return RuleResult(
+            rule="transaction_cost_prohibitive",
+            passed=False,
+            detail=(
+                f"cost prohibitive: total={estimate.total_cost_bps} bps "
+                f"(spread={estimate.spread_bps}, carry={estimate.total_carry_cost_bps}, "
+                f"fx={estimate.fx_markup_bps}\u00d72)"
+                + (f"; {estimate.prohibitive_reason}" if estimate.prohibitive_reason else "")
+            ),
+        )
+    return RuleResult(
+        rule="transaction_cost_prohibitive",
+        passed=True,
+        detail=(
+            f"cost ok: total={estimate.total_cost_bps} bps "
+            f"(spread={estimate.spread_bps}, carry={estimate.total_carry_cost_bps})"
+        ),
+    )
+
+
 def _check_budget(budget: BudgetState) -> RuleResult:
     """Check budget availability for BUY/ADD orders.
 
@@ -609,10 +674,20 @@ def evaluate_recommendation(
     current_sector_pct: float = 0.0
     total_aum: float = 0.0
 
+    cost_config: dict[str, Any] | None = None
+    cost_config_corrupt: bool = False
+    cost_model_row: dict[str, Any] | None = None
+
     if action in ("BUY", "ADD"):
         coverage = _load_coverage(conn, instrument_id)
         thesis = _load_latest_thesis(conn, instrument_id)
         quote = _load_quote(conn, instrument_id)
+        # Transaction cost state
+        try:
+            cost_config = get_transaction_cost_config(conn)
+        except TransactionCostConfigCorrupt:
+            cost_config_corrupt = True
+        cost_model_row = load_instrument_cost(conn, instrument_id)
         # Budget-aware cash check: replaces raw _load_cash(conn).
         # compute_budget_state reads budget_config, cash_ledger, positions,
         # copy_mirrors, disposal_matches, and live_fx_rates.
@@ -654,6 +729,19 @@ def evaluate_recommendation(
         if coverage is not None:
             rule_results.append(_check_thesis_freshness(thesis, coverage, now))
         rule_results.append(_check_spread(quote))
+
+        # Transaction cost check
+        if cost_config_corrupt or cost_config is None:
+            rule_results.append(
+                RuleResult(
+                    rule="transaction_cost_prohibitive",
+                    passed=False,
+                    detail="transaction_cost_config singleton row missing",
+                )
+            )
+        else:
+            rule_results.append(_check_transaction_cost(quote, cost_model_row, cost_config))
+
         if budget is None:
             rule_results.append(
                 RuleResult(

--- a/app/services/execution_guard.py
+++ b/app/services/execution_guard.py
@@ -23,10 +23,11 @@ Rule application by action:
     - no_coverage_row       — no coverage row exists at all
     - thesis_stale          — latest thesis older than freshness window
     - no_thesis             — no thesis row exists
-    - spread_wide           — quotes.spread_flag is TRUE
-    - spread_unavailable    — no quotes row or spread_flag is NULL
-    - budget_available      — budget exhausted or unknown (accounts for tax + buffer)
-    - concentration_breach  — post-action sector exposure would exceed 25% AUM
+    - spread_wide                  — quotes.spread_flag is TRUE
+    - spread_unavailable           — no quotes row or spread_flag is NULL
+    - transaction_cost_prohibitive — estimated cost exceeds threshold or return/cost ratio too low
+    - budget_available             — budget exhausted or unknown (accounts for tax + buffer)
+    - concentration_breach         — post-action sector exposure would exceed 25% AUM
 
   EXIT:
     - above kill switch / config rules only; thesis, coverage, spread, and
@@ -433,8 +434,9 @@ def _check_transaction_cost(
     elif quote is not None and quote.get("spread_pct") is not None:
         converted = spread_pct_to_bps(quote["spread_pct"])
         # spread_pct_to_bps returns None only when input is None, which the
-        # guard above already excluded.  Assert for pyright narrowing.
-        assert converted is not None  # pragma: no cover
+        # guard above already excluded.
+        if converted is None:  # pragma: no cover
+            raise RuntimeError("spread_pct_to_bps returned None for non-None input")
         spread_bps = converted
         overnight_rate = Decimal("0")
         fx_markup_bps = Decimal("0")

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -784,48 +784,50 @@ def execute_order(
             now=now,
         )
 
-        # Record estimated cost (best-effort: config-missing doesn't block order)
-        try:
-            cost_config = get_transaction_cost_config(conn)
-            cost_model_row = load_instrument_cost(conn, instrument_id)
-            if cost_model_row is not None:
-                s_bps = cost_model_row["spread_bps"]
-                o_rate = cost_model_row["overnight_rate"]
-                fx_bps = cost_model_row["fx_markup_bps"]
-            else:
-                # No cost_model row — fall back to quote spread_pct.
-                # In live mode quote_data is not loaded for the fill,
-                # so load it here for cost recording.
-                qd = quote_data if quote_data is not None else _load_quote_for_execution(conn, instrument_id)
-                if qd is not None and qd.get("spread_pct") is not None:
-                    s_bps = spread_pct_to_bps(Decimal(str(qd["spread_pct"])))
+        # Record estimated cost for BUY/ADD only (entry cost is meaningless
+        # for EXIT orders).  Best-effort: config-missing doesn't block order.
+        if action in ("BUY", "ADD"):
+            try:
+                cost_config = get_transaction_cost_config(conn)
+                cost_model_row = load_instrument_cost(conn, instrument_id)
+                if cost_model_row is not None:
+                    s_bps = cost_model_row["spread_bps"]
+                    o_rate = cost_model_row["overnight_rate"]
+                    fx_bps = cost_model_row["fx_markup_bps"]
                 else:
-                    s_bps = None
-                o_rate = Decimal("0")
-                fx_bps = Decimal("0")
+                    # No cost_model row — fall back to quote spread_pct.
+                    # In live mode quote_data is not loaded for the fill,
+                    # so load it here for cost recording.
+                    qd = quote_data if quote_data is not None else _load_quote_for_execution(conn, instrument_id)
+                    if qd is not None and qd.get("spread_pct") is not None:
+                        s_bps = spread_pct_to_bps(Decimal(str(qd["spread_pct"])))
+                    else:
+                        s_bps = None
+                    o_rate = Decimal("0")
+                    fx_bps = Decimal("0")
 
-            if s_bps is not None:
-                cost_est = estimate_cost(
-                    spread_bps=s_bps,
-                    overnight_rate=o_rate,
-                    fx_markup_bps=fx_bps,
-                    hold_days=cost_config["default_hold_days"],
-                    max_total_cost_bps=cost_config["max_total_cost_bps"],
-                    min_return_vs_cost_ratio=cost_config["min_return_vs_cost_ratio"],
-                    expected_return_pct=None,
+                if s_bps is not None:
+                    cost_est = estimate_cost(
+                        spread_bps=s_bps,
+                        overnight_rate=o_rate,
+                        fx_markup_bps=fx_bps,
+                        hold_days=cost_config["default_hold_days"],
+                        max_total_cost_bps=cost_config["max_total_cost_bps"],
+                        min_return_vs_cost_ratio=cost_config["min_return_vs_cost_ratio"],
+                        expected_return_pct=None,
+                    )
+                    record_estimated_cost(
+                        conn,
+                        order_id=order_id,
+                        recommendation_id=recommendation_id,
+                        instrument_id=instrument_id,
+                        estimate=cost_est,
+                    )
+            except TransactionCostConfigCorrupt:
+                logger.warning(
+                    "transaction_cost_config missing — skipping cost record for order_id=%d",
+                    order_id,
                 )
-                record_estimated_cost(
-                    conn,
-                    order_id=order_id,
-                    recommendation_id=recommendation_id,
-                    instrument_id=instrument_id,
-                    estimate=cost_est,
-                )
-        except TransactionCostConfigCorrupt:
-            logger.warning(
-                "transaction_cost_config missing — skipping cost record for order_id=%d",
-                order_id,
-            )
 
         fp = broker_result.filled_price
         fu = broker_result.filled_units

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -189,15 +189,25 @@ def _synthetic_fill(
     requested_amount: Decimal | None,
     requested_units: Decimal | None,
     params: OrderParams | None = None,
+    bid: Decimal | None = None,
+    ask: Decimal | None = None,
 ) -> BrokerOrderResult:
-    """
-    Build a synthetic BrokerOrderResult for demo mode.
+    """Build a synthetic BrokerOrderResult for demo mode.
 
-    Uses the latest quote price.  If no price is available, the fill is
-    produced at Decimal("0") with a note in the payload — this lets demo
-    runs proceed without real market data while making the issue visible.
+    Uses bid/ask for realistic pricing when available:
+    - BUY fills at ask, EXIT fills at bid (worst-case execution)
+    - Fees = half-spread × units (entry cost of crossing the spread)
+    Falls back to last price with zero fees when bid/ask unavailable.
     """
-    price = quote_price if quote_price is not None else Decimal("0")
+    # Determine fill price: BUY at ask, EXIT at bid, fallback to last
+    if action in ("BUY", "ADD") and ask is not None:
+        price = ask
+    elif action == "EXIT" and bid is not None:
+        price = bid
+    elif quote_price is not None:
+        price = quote_price
+    else:
+        price = Decimal("0")
 
     if requested_units is not None:
         units = requested_units
@@ -206,17 +216,23 @@ def _synthetic_fill(
     else:
         units = Decimal("0")
 
+    # Compute spread-based fees
+    if bid is not None and ask is not None and units > 0:
+        half_spread = (ask - bid) / 2
+        fees = (half_spread * units).quantize(Decimal("0.000001"))
+    else:
+        fees = Decimal("0")
+
     payload: dict[str, Any] = {
         "demo": True,
         "instrument_id": instrument_id,
         "action": action,
         "price": str(price),
         "units": str(units),
+        "fees": str(fees),
         "note": "synthetic fill — no real API call"
-        + ("" if quote_price is not None else "; no quote available, price=0"),
+        + ("" if quote_price is not None or ask is not None else "; no quote available, price=0"),
     }
-    # Record intended SL/TP in raw_payload for audit completeness
-    # (demo mode has no broker to enforce these, but they should be visible).
     if params is not None:
         if params.stop_loss_rate is not None:
             payload["stop_loss_rate"] = str(params.stop_loss_rate)
@@ -228,7 +244,7 @@ def _synthetic_fill(
         status="filled",
         filled_price=price,
         filled_units=units,
-        fees=Decimal("0"),
+        fees=fees,
         raw_payload=payload,
     )
 

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -36,7 +36,6 @@ from app.providers.broker import BrokerOrderResult, BrokerProvider, OrderParams
 from app.services.return_attribution import compute_attribution, persist_attribution
 from app.services.runtime_config import get_runtime_config
 from app.services.transaction_cost import (
-    TransactionCostConfigCorrupt,
     estimate_cost,
     get_transaction_cost_config,
     load_instrument_cost,
@@ -785,7 +784,8 @@ def execute_order(
         )
 
         # Record estimated cost for BUY/ADD only (entry cost is meaningless
-        # for EXIT orders).  Best-effort: config-missing doesn't block order.
+        # for EXIT orders).  Best-effort: any failure here must not block the
+        # order or abort the enclosing transaction.
         if action in ("BUY", "ADD"):
             try:
                 cost_config = get_transaction_cost_config(conn)
@@ -823,10 +823,11 @@ def execute_order(
                         instrument_id=instrument_id,
                         estimate=cost_est,
                     )
-            except TransactionCostConfigCorrupt:
+            except Exception:
                 logger.warning(
-                    "transaction_cost_config missing — skipping cost record for order_id=%d",
+                    "cost recording failed for order_id=%d — continuing without cost record",
                     order_id,
+                    exc_info=True,
                 )
 
         fp = broker_result.filled_price

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -35,6 +35,14 @@ from psycopg.types.json import Jsonb
 from app.providers.broker import BrokerOrderResult, BrokerProvider, OrderParams
 from app.services.return_attribution import compute_attribution, persist_attribution
 from app.services.runtime_config import get_runtime_config
+from app.services.transaction_cost import (
+    TransactionCostConfigCorrupt,
+    estimate_cost,
+    get_transaction_cost_config,
+    load_instrument_cost,
+    record_estimated_cost,
+    spread_pct_to_bps,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +127,26 @@ def _load_latest_quote_price(
     if row is None or row["last"] is None:
         return None
     return Decimal(str(row["last"]))
+
+
+def _load_quote_for_execution(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> dict[str, Any] | None:
+    """Load full quote data for execution: last, bid, ask, spread_pct."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT last, bid, ask, spread_pct
+            FROM quotes
+            WHERE instrument_id = %(iid)s
+            ORDER BY quoted_at DESC
+            LIMIT 1
+            """,
+            {"iid": instrument_id},
+        )
+        row = cur.fetchone()
+    return dict(row) if row is not None else None
 
 
 def _load_position_units(
@@ -684,6 +712,8 @@ def execute_order(
     runtime = get_runtime_config(conn)
     is_live = runtime.enable_live_trading
 
+    quote_data: dict[str, Any] | None = None
+
     if is_live:
         if broker is None:
             raise ValueError("enable_live_trading is True but no broker provider supplied")
@@ -714,7 +744,8 @@ def execute_order(
                 params=order_params,
             )
     else:
-        quote_price = _load_latest_quote_price(conn, instrument_id)
+        quote_data = _load_quote_for_execution(conn, instrument_id)
+        quote_price = Decimal(str(quote_data["last"])) if quote_data and quote_data.get("last") is not None else None
         broker_result = _synthetic_fill(
             instrument_id=instrument_id,
             action=action,
@@ -722,6 +753,8 @@ def execute_order(
             requested_amount=requested_amount,
             requested_units=requested_units,
             params=order_params,
+            bid=Decimal(str(quote_data["bid"])) if quote_data and quote_data.get("bid") is not None else None,
+            ask=Decimal(str(quote_data["ask"])) if quote_data and quote_data.get("ask") is not None else None,
         )
         logger.info(
             "demo mode: instrument_id=%d action=%s price=%s units=%s",
@@ -750,6 +783,46 @@ def execute_order(
             raw_payload=broker_result.raw_payload,
             now=now,
         )
+
+        # Record estimated cost (best-effort: config-missing doesn't block order)
+        try:
+            cost_config = get_transaction_cost_config(conn)
+            cost_model_row = load_instrument_cost(conn, instrument_id)
+            if cost_model_row is not None:
+                s_bps = cost_model_row["spread_bps"]
+                o_rate = cost_model_row["overnight_rate"]
+                fx_bps = cost_model_row["fx_markup_bps"]
+            elif quote_data is not None and quote_data.get("spread_pct") is not None:
+                s_bps = spread_pct_to_bps(Decimal(str(quote_data["spread_pct"])))
+                o_rate = Decimal("0")
+                fx_bps = Decimal("0")
+            else:
+                s_bps = None
+                o_rate = Decimal("0")
+                fx_bps = Decimal("0")
+
+            if s_bps is not None:
+                cost_est = estimate_cost(
+                    spread_bps=s_bps,
+                    overnight_rate=o_rate,
+                    fx_markup_bps=fx_bps,
+                    hold_days=cost_config["default_hold_days"],
+                    max_total_cost_bps=cost_config["max_total_cost_bps"],
+                    min_return_vs_cost_ratio=cost_config["min_return_vs_cost_ratio"],
+                    expected_return_pct=None,
+                )
+                record_estimated_cost(
+                    conn,
+                    order_id=order_id,
+                    recommendation_id=recommendation_id,
+                    instrument_id=instrument_id,
+                    estimate=cost_est,
+                )
+        except TransactionCostConfigCorrupt:
+            logger.warning(
+                "transaction_cost_config missing — skipping cost record for order_id=%d",
+                order_id,
+            )
 
         fp = broker_result.filled_price
         fu = broker_result.filled_units

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -785,44 +785,47 @@ def execute_order(
 
         # Record estimated cost for BUY/ADD only (entry cost is meaningless
         # for EXIT orders).  Best-effort: any failure here must not block the
-        # order or abort the enclosing transaction.
+        # order or abort the enclosing transaction.  The savepoint ensures a
+        # DB error during cost recording rolls back only the cost INSERT,
+        # leaving the outer transaction intact for _persist_fill.
         if action in ("BUY", "ADD"):
             try:
-                cost_config = get_transaction_cost_config(conn)
-                cost_model_row = load_instrument_cost(conn, instrument_id)
-                if cost_model_row is not None:
-                    s_bps = cost_model_row["spread_bps"]
-                    o_rate = cost_model_row["overnight_rate"]
-                    fx_bps = cost_model_row["fx_markup_bps"]
-                else:
-                    # No cost_model row — fall back to quote spread_pct.
-                    # In live mode quote_data is not loaded for the fill,
-                    # so load it here for cost recording.
-                    qd = quote_data if quote_data is not None else _load_quote_for_execution(conn, instrument_id)
-                    if qd is not None and qd.get("spread_pct") is not None:
-                        s_bps = spread_pct_to_bps(Decimal(str(qd["spread_pct"])))
+                with conn.transaction():
+                    cost_config = get_transaction_cost_config(conn)
+                    cost_model_row = load_instrument_cost(conn, instrument_id)
+                    if cost_model_row is not None:
+                        s_bps = cost_model_row["spread_bps"]
+                        o_rate = cost_model_row["overnight_rate"]
+                        fx_bps = cost_model_row["fx_markup_bps"]
                     else:
-                        s_bps = None
-                    o_rate = Decimal("0")
-                    fx_bps = Decimal("0")
+                        # No cost_model row — fall back to quote spread_pct.
+                        # In live mode quote_data is not loaded for the fill,
+                        # so load it here for cost recording.
+                        qd = quote_data if quote_data is not None else _load_quote_for_execution(conn, instrument_id)
+                        if qd is not None and qd.get("spread_pct") is not None:
+                            s_bps = spread_pct_to_bps(Decimal(str(qd["spread_pct"])))
+                        else:
+                            s_bps = None
+                        o_rate = Decimal("0")
+                        fx_bps = Decimal("0")
 
-                if s_bps is not None:
-                    cost_est = estimate_cost(
-                        spread_bps=s_bps,
-                        overnight_rate=o_rate,
-                        fx_markup_bps=fx_bps,
-                        hold_days=cost_config["default_hold_days"],
-                        max_total_cost_bps=cost_config["max_total_cost_bps"],
-                        min_return_vs_cost_ratio=cost_config["min_return_vs_cost_ratio"],
-                        expected_return_pct=None,
-                    )
-                    record_estimated_cost(
-                        conn,
-                        order_id=order_id,
-                        recommendation_id=recommendation_id,
-                        instrument_id=instrument_id,
-                        estimate=cost_est,
-                    )
+                    if s_bps is not None:
+                        cost_est = estimate_cost(
+                            spread_bps=s_bps,
+                            overnight_rate=o_rate,
+                            fx_markup_bps=fx_bps,
+                            hold_days=cost_config["default_hold_days"],
+                            max_total_cost_bps=cost_config["max_total_cost_bps"],
+                            min_return_vs_cost_ratio=cost_config["min_return_vs_cost_ratio"],
+                            expected_return_pct=None,
+                        )
+                        record_estimated_cost(
+                            conn,
+                            order_id=order_id,
+                            recommendation_id=recommendation_id,
+                            instrument_id=instrument_id,
+                            estimate=cost_est,
+                        )
             except Exception:
                 logger.warning(
                     "cost recording failed for order_id=%d — continuing without cost record",

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -792,12 +792,15 @@ def execute_order(
                 s_bps = cost_model_row["spread_bps"]
                 o_rate = cost_model_row["overnight_rate"]
                 fx_bps = cost_model_row["fx_markup_bps"]
-            elif quote_data is not None and quote_data.get("spread_pct") is not None:
-                s_bps = spread_pct_to_bps(Decimal(str(quote_data["spread_pct"])))
-                o_rate = Decimal("0")
-                fx_bps = Decimal("0")
             else:
-                s_bps = None
+                # No cost_model row — fall back to quote spread_pct.
+                # In live mode quote_data is not loaded for the fill,
+                # so load it here for cost recording.
+                qd = quote_data if quote_data is not None else _load_quote_for_execution(conn, instrument_id)
+                if qd is not None and qd.get("spread_pct") is not None:
+                    s_bps = spread_pct_to_bps(Decimal(str(qd["spread_pct"])))
+                else:
+                    s_bps = None
                 o_rate = Decimal("0")
                 fx_bps = Decimal("0")
 

--- a/app/services/transaction_cost.py
+++ b/app/services/transaction_cost.py
@@ -1,0 +1,139 @@
+"""Transaction cost model — per-instrument cost estimation and reconciliation.
+
+Computes spread, overnight carry, and FX conversion costs for a proposed trade.
+The execution guard calls estimate_cost() to decide whether a trade's costs
+are prohibitive relative to its expected return.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class TransactionCostConfigCorrupt(RuntimeError):
+    """Raised when the transaction_cost_config singleton row is missing.
+
+    Callers on safety-critical paths must catch this and fail closed.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    """Estimated transaction cost for a proposed trade."""
+
+    spread_bps: Decimal
+    overnight_bps_per_day: Decimal
+    fx_markup_bps: Decimal
+    estimated_hold_days: int
+    total_entry_cost_bps: Decimal  # spread + fx
+    total_carry_cost_bps: Decimal  # overnight × hold_days
+    total_cost_bps: Decimal  # entry + carry
+    is_cost_prohibitive: bool
+    prohibitive_reason: str | None
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def get_transaction_cost_config(
+    conn: psycopg.Connection[Any],
+) -> dict[str, Any]:
+    """Load the singleton transaction_cost_config row.
+
+    Raises TransactionCostConfigCorrupt if the row is missing.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT max_total_cost_bps,
+                   min_return_vs_cost_ratio,
+                   default_hold_days
+            FROM transaction_cost_config
+            WHERE id = TRUE
+            """
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise TransactionCostConfigCorrupt("transaction_cost_config singleton row missing")
+    return dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Cost estimation
+# ---------------------------------------------------------------------------
+
+
+def estimate_cost(
+    *,
+    spread_bps: Decimal,
+    overnight_rate: Decimal,
+    fx_markup_bps: Decimal,
+    hold_days: int,
+    max_total_cost_bps: Decimal,
+    min_return_vs_cost_ratio: Decimal,
+    expected_return_pct: Decimal | None,
+) -> CostEstimate:
+    """Compute estimated transaction cost for a proposed trade.
+
+    Parameters
+    ----------
+    spread_bps : entry spread in basis points (from quotes or cost_model)
+    overnight_rate : daily carry cost in bps (0 for real-stock positions)
+    fx_markup_bps : one-way FX conversion markup in bps (0 for USD instruments)
+    hold_days : estimated holding period in days
+    max_total_cost_bps : absolute threshold — above this, trade is prohibitive
+    min_return_vs_cost_ratio : expected_return / total_cost must exceed this
+    expected_return_pct : thesis-derived expected return (None = skip ratio check)
+    """
+    # FX applies on both entry and exit (round-trip)
+    total_entry_cost_bps = spread_bps + fx_markup_bps * 2
+    total_carry_cost_bps = overnight_rate * hold_days
+    total_cost_bps = total_entry_cost_bps + total_carry_cost_bps
+
+    is_prohibitive = False
+    reason: str | None = None
+
+    if total_cost_bps > max_total_cost_bps:
+        is_prohibitive = True
+        reason = f"total cost {total_cost_bps} bps exceeds threshold {max_total_cost_bps} bps"
+    elif expected_return_pct is not None and total_cost_bps > 0:
+        # expected_return_pct is in percent (e.g. 10.0 = 10%)
+        # total_cost_bps is in basis points (e.g. 80 = 0.8%)
+        # Convert cost to percent for comparison
+        cost_pct = total_cost_bps / Decimal("100")
+        ratio = expected_return_pct / cost_pct
+        if ratio < min_return_vs_cost_ratio:
+            is_prohibitive = True
+            reason = (
+                f"return/cost ratio {ratio:.2f} below minimum "
+                f"{min_return_vs_cost_ratio} "
+                f"(return={expected_return_pct}%, cost={cost_pct:.2f}%)"
+            )
+
+    return CostEstimate(
+        spread_bps=spread_bps,
+        overnight_bps_per_day=overnight_rate,
+        fx_markup_bps=fx_markup_bps,
+        estimated_hold_days=hold_days,
+        total_entry_cost_bps=total_entry_cost_bps,
+        total_carry_cost_bps=total_carry_cost_bps,
+        total_cost_bps=total_cost_bps,
+        is_cost_prohibitive=is_prohibitive,
+        prohibitive_reason=reason,
+    )

--- a/app/services/transaction_cost.py
+++ b/app/services/transaction_cost.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import psycopg
 import psycopg.rows
+import psycopg.types.json
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -179,3 +180,80 @@ def spread_pct_to_bps(spread_pct: Decimal | None) -> Decimal | None:
     if spread_pct is None:
         return None
     return spread_pct * 100
+
+
+# ---------------------------------------------------------------------------
+# Cost record persistence
+# ---------------------------------------------------------------------------
+
+
+def record_estimated_cost(
+    conn: psycopg.Connection[Any],
+    *,
+    order_id: int,
+    recommendation_id: int,
+    instrument_id: int,
+    estimate: CostEstimate,
+) -> None:
+    """Persist the estimated cost breakdown for a trade at order time."""
+    breakdown = {
+        "spread_bps": str(estimate.spread_bps),
+        "overnight_bps_per_day": str(estimate.overnight_bps_per_day),
+        "fx_markup_bps": str(estimate.fx_markup_bps),
+        "estimated_hold_days": estimate.estimated_hold_days,
+        "total_entry_cost_bps": str(estimate.total_entry_cost_bps),
+        "total_carry_cost_bps": str(estimate.total_carry_cost_bps),
+        "total_cost_bps": str(estimate.total_cost_bps),
+        "is_cost_prohibitive": estimate.is_cost_prohibitive,
+        "prohibitive_reason": estimate.prohibitive_reason,
+    }
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO trade_cost_record (
+                order_id, recommendation_id, instrument_id,
+                estimated_spread_bps, estimated_carry_bps,
+                estimated_fx_bps, estimated_total_bps,
+                cost_breakdown
+            ) VALUES (
+                %(order_id)s, %(recommendation_id)s, %(instrument_id)s,
+                %(estimated_spread_bps)s, %(estimated_carry_bps)s,
+                %(estimated_fx_bps)s, %(estimated_total_bps)s,
+                %(cost_breakdown)s
+            )
+            """,
+            {
+                "order_id": order_id,
+                "recommendation_id": recommendation_id,
+                "instrument_id": instrument_id,
+                "estimated_spread_bps": estimate.spread_bps,
+                "estimated_carry_bps": estimate.total_carry_cost_bps,
+                "estimated_fx_bps": estimate.fx_markup_bps,
+                "estimated_total_bps": estimate.total_cost_bps,
+                "cost_breakdown": psycopg.types.json.Jsonb(breakdown),
+            },
+        )
+
+
+def record_actual_cost(
+    conn: psycopg.Connection[Any],
+    *,
+    order_id: int,
+    actual_spread_bps: Decimal,
+    actual_total_bps: Decimal,
+) -> None:
+    """Update the cost record with actual costs computed from fill data."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE trade_cost_record
+            SET actual_spread_bps = %(actual_spread_bps)s,
+                actual_total_bps = %(actual_total_bps)s
+            WHERE order_id = %(order_id)s
+            """,
+            {
+                "order_id": order_id,
+                "actual_spread_bps": actual_spread_bps,
+                "actual_total_bps": actual_total_bps,
+            },
+        )

--- a/app/services/transaction_cost.py
+++ b/app/services/transaction_cost.py
@@ -290,6 +290,77 @@ def record_estimated_cost(
         )
 
 
+def seed_cost_models_from_quotes(
+    conn: psycopg.Connection[Any],
+) -> dict[str, int]:
+    """Create or refresh cost_model rows from current quote spread data.
+
+    For each Tier 1 instrument with a valid spread_pct:
+    - Close any existing active cost_model row (set valid_to = NOW())
+    - Insert a new active row with computed spread
+
+    FX markup is set based on instrument currency:
+    - USD → 0 bps
+    - non-USD → 50 bps (eToro's typical FX markup)
+
+    Overnight rate is 0 for all instruments (real stocks, not CFDs in v1).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT i.instrument_id, q.spread_pct, i.currency
+            FROM instruments i
+            JOIN coverage c USING (instrument_id)
+            JOIN quotes q USING (instrument_id)
+            WHERE c.coverage_tier = 1
+              AND q.spread_pct IS NOT NULL
+            """
+        )
+        rows = cur.fetchall()
+
+    processed = 0
+    skipped = 0
+    for row in rows:
+        if row["spread_pct"] is None:
+            skipped += 1
+            continue
+
+        spread_bps = spread_pct_to_bps(row["spread_pct"])
+        currency = row["currency"] or "USD"
+        fx_markup_bps = Decimal("0") if currency == "USD" else Decimal("50")
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE cost_model
+                SET valid_to = NOW()
+                WHERE instrument_id = %(iid)s
+                  AND valid_to IS NULL
+                """,
+                {"iid": row["instrument_id"]},
+            )
+            cur.execute(
+                """
+                INSERT INTO cost_model (
+                    instrument_id, spread_bps, overnight_rate,
+                    fx_pair, fx_markup_bps, source
+                ) VALUES (
+                    %(iid)s, %(spread_bps)s, 0,
+                    %(fx_pair)s, %(fx_markup_bps)s, 'computed'
+                )
+                """,
+                {
+                    "iid": row["instrument_id"],
+                    "spread_bps": spread_bps,
+                    "fx_pair": None if currency == "USD" else f"{currency}/USD",
+                    "fx_markup_bps": fx_markup_bps,
+                },
+            )
+        processed += 1
+
+    return {"processed": processed, "skipped": skipped}
+
+
 def record_actual_cost(
     conn: psycopg.Connection[Any],
     *,

--- a/app/services/transaction_cost.py
+++ b/app/services/transaction_cost.py
@@ -7,6 +7,7 @@ are prohibitive relative to its expected return.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any
@@ -15,6 +16,8 @@ import psycopg
 import psycopg.rows
 import psycopg.types.json
 from psycopg import sql
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -329,33 +332,34 @@ def seed_cost_models_from_quotes(
         currency = row["currency"] or "USD"
         fx_markup_bps = Decimal("0") if currency == "USD" else Decimal("50")
 
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE cost_model
-                SET valid_to = NOW()
-                WHERE instrument_id = %(iid)s
-                  AND valid_to IS NULL
-                """,
-                {"iid": row["instrument_id"]},
-            )
-            cur.execute(
-                """
-                INSERT INTO cost_model (
-                    instrument_id, spread_bps, overnight_rate,
-                    fx_pair, fx_markup_bps, source
-                ) VALUES (
-                    %(iid)s, %(spread_bps)s, 0,
-                    %(fx_pair)s, %(fx_markup_bps)s, 'computed'
+        with conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE cost_model
+                    SET valid_to = NOW()
+                    WHERE instrument_id = %(iid)s
+                      AND valid_to IS NULL
+                    """,
+                    {"iid": row["instrument_id"]},
                 )
-                """,
-                {
-                    "iid": row["instrument_id"],
-                    "spread_bps": spread_bps,
-                    "fx_pair": None if currency == "USD" else f"{currency}/USD",
-                    "fx_markup_bps": fx_markup_bps,
-                },
-            )
+                cur.execute(
+                    """
+                    INSERT INTO cost_model (
+                        instrument_id, spread_bps, overnight_rate,
+                        fx_pair, fx_markup_bps, source
+                    ) VALUES (
+                        %(iid)s, %(spread_bps)s, 0,
+                        %(fx_pair)s, %(fx_markup_bps)s, 'computed'
+                    )
+                    """,
+                    {
+                        "iid": row["instrument_id"],
+                        "spread_bps": spread_bps,
+                        "fx_pair": None if currency == "USD" else f"{currency}/USD",
+                        "fx_markup_bps": fx_markup_bps,
+                    },
+                )
         processed += 1
 
     return {"processed": processed, "skipped": skipped}
@@ -368,7 +372,12 @@ def record_actual_cost(
     actual_spread_bps: Decimal,
     actual_total_bps: Decimal,
 ) -> None:
-    """Update the cost record with actual costs computed from fill data."""
+    """Update the cost record with actual costs computed from fill data.
+
+    Logs a warning (but does not raise) when no estimated-cost row exists
+    for this order — the estimated record is best-effort, so its absence
+    is expected when TransactionCostConfigCorrupt was caught at order time.
+    """
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -383,3 +392,8 @@ def record_actual_cost(
                 "actual_total_bps": actual_total_bps,
             },
         )
+        if cur.rowcount == 0:
+            logger.warning(
+                "record_actual_cost: no trade_cost_record for order_id=%d — actual cost not recorded",
+                order_id,
+            )

--- a/app/services/transaction_cost.py
+++ b/app/services/transaction_cost.py
@@ -137,3 +137,45 @@ def estimate_cost(
         is_cost_prohibitive=is_prohibitive,
         prohibitive_reason=reason,
     )
+
+
+# ---------------------------------------------------------------------------
+# Instrument cost lookup
+# ---------------------------------------------------------------------------
+
+
+def load_instrument_cost(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> dict[str, Any] | None:
+    """Load the active fee schedule for an instrument.
+
+    Returns the most recent cost_model row where valid_to IS NULL.
+    Returns None if no cost_model row exists (caller should fall back
+    to computing spread from live quote data).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT spread_bps, overnight_rate, fx_pair, fx_markup_bps
+            FROM cost_model
+            WHERE instrument_id = %(iid)s
+              AND valid_to IS NULL
+            ORDER BY valid_from DESC
+            LIMIT 1
+            """,
+            {"iid": instrument_id},
+        )
+        row = cur.fetchone()
+    return dict(row) if row is not None else None
+
+
+def spread_pct_to_bps(spread_pct: Decimal | None) -> Decimal | None:
+    """Convert spread_pct (percent, e.g. 0.45%) to basis points (45 bps).
+
+    quotes.spread_pct stores (ask - bid) / mid * 100, i.e. already in percent.
+    Basis points = percent * 100.
+    """
+    if spread_pct is None:
+        return None
+    return spread_pct * 100

--- a/app/services/transaction_cost.py
+++ b/app/services/transaction_cost.py
@@ -212,6 +212,9 @@ def load_instrument_cost(
     Returns the most recent cost_model row where valid_to IS NULL.
     Returns None if no cost_model row exists (caller should fall back
     to computing spread from live quote data).
+
+    Columns: spread_bps (bps), overnight_rate (bps per day),
+    fx_pair (e.g. 'GBP/USD'), fx_markup_bps (bps, one-way).
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
@@ -307,60 +310,67 @@ def seed_cost_models_from_quotes(
     - non-USD → 50 bps (eToro's typical FX markup)
 
     Overnight rate is 0 for all instruments (real stocks, not CFDs in v1).
-    """
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            """
-            SELECT i.instrument_id, q.spread_pct, i.currency
-            FROM instruments i
-            JOIN coverage c USING (instrument_id)
-            JOIN quotes q USING (instrument_id)
-            WHERE c.coverage_tier = 1
-              AND q.spread_pct IS NOT NULL
-            """
-        )
-        rows = cur.fetchall()
 
+    The SELECT and all per-instrument UPDATE+INSERT pairs run inside a single
+    transaction so the read and writes share the same snapshot.  Each instrument
+    pair is wrapped in a savepoint so a single-row failure does not abort the
+    entire batch.
+    """
     processed = 0
     skipped = 0
-    for row in rows:
-        if row["spread_pct"] is None:
-            skipped += 1
-            continue
 
-        spread_bps = spread_pct_to_bps(row["spread_pct"])
-        currency = row["currency"] or "USD"
-        fx_markup_bps = Decimal("0") if currency == "USD" else Decimal("50")
+    with conn.transaction():
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT i.instrument_id, q.spread_pct, i.currency
+                FROM instruments i
+                JOIN coverage c USING (instrument_id)
+                JOIN quotes q USING (instrument_id)
+                WHERE c.coverage_tier = 1
+                  AND q.spread_pct IS NOT NULL
+                """
+            )
+            rows = cur.fetchall()
 
-        with conn.transaction():
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    UPDATE cost_model
-                    SET valid_to = NOW()
-                    WHERE instrument_id = %(iid)s
-                      AND valid_to IS NULL
-                    """,
-                    {"iid": row["instrument_id"]},
-                )
-                cur.execute(
-                    """
-                    INSERT INTO cost_model (
-                        instrument_id, spread_bps, overnight_rate,
-                        fx_pair, fx_markup_bps, source
-                    ) VALUES (
-                        %(iid)s, %(spread_bps)s, 0,
-                        %(fx_pair)s, %(fx_markup_bps)s, 'computed'
+        for row in rows:
+            if row["spread_pct"] is None:
+                skipped += 1
+                continue
+
+            spread_bps = spread_pct_to_bps(row["spread_pct"])
+            currency = row["currency"] or "USD"
+            fx_markup_bps = Decimal("0") if currency == "USD" else Decimal("50")
+
+            with conn.transaction():
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        UPDATE cost_model
+                        SET valid_to = NOW()
+                        WHERE instrument_id = %(iid)s
+                          AND valid_to IS NULL
+                        """,
+                        {"iid": row["instrument_id"]},
                     )
-                    """,
-                    {
-                        "iid": row["instrument_id"],
-                        "spread_bps": spread_bps,
-                        "fx_pair": None if currency == "USD" else f"{currency}/USD",
-                        "fx_markup_bps": fx_markup_bps,
-                    },
-                )
-        processed += 1
+                    cur.execute(
+                        """
+                        INSERT INTO cost_model (
+                            instrument_id, spread_bps, overnight_rate,
+                            fx_pair, fx_markup_bps, source
+                        ) VALUES (
+                            %(iid)s, %(spread_bps)s, 0,
+                            %(fx_pair)s, %(fx_markup_bps)s, 'computed'
+                        )
+                        """,
+                        {
+                            "iid": row["instrument_id"],
+                            "spread_bps": spread_bps,
+                            "fx_pair": None if currency == "USD" else f"{currency}/USD",
+                            "fx_markup_bps": fx_markup_bps,
+                        },
+                    )
+            processed += 1
 
     return {"processed": processed, "skipped": skipped}
 

--- a/app/services/transaction_cost.py
+++ b/app/services/transaction_cost.py
@@ -334,6 +334,8 @@ def seed_cost_models_from_quotes(
             rows = cur.fetchall()
 
         for row in rows:
+            # Defensive: SQL already filters IS NOT NULL, but guard against
+            # future query changes or unexpected mock data.
             if row["spread_pct"] is None:
                 skipped += 1
                 continue
@@ -342,35 +344,43 @@ def seed_cost_models_from_quotes(
             currency = row["currency"] or "USD"
             fx_markup_bps = Decimal("0") if currency == "USD" else Decimal("50")
 
-            with conn.transaction():
-                with conn.cursor() as cur:
-                    cur.execute(
-                        """
-                        UPDATE cost_model
-                        SET valid_to = NOW()
-                        WHERE instrument_id = %(iid)s
-                          AND valid_to IS NULL
-                        """,
-                        {"iid": row["instrument_id"]},
-                    )
-                    cur.execute(
-                        """
-                        INSERT INTO cost_model (
-                            instrument_id, spread_bps, overnight_rate,
-                            fx_pair, fx_markup_bps, source
-                        ) VALUES (
-                            %(iid)s, %(spread_bps)s, 0,
-                            %(fx_pair)s, %(fx_markup_bps)s, 'computed'
+            try:
+                with conn.transaction():
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            """
+                            UPDATE cost_model
+                            SET valid_to = NOW()
+                            WHERE instrument_id = %(iid)s
+                              AND valid_to IS NULL
+                            """,
+                            {"iid": row["instrument_id"]},
                         )
-                        """,
-                        {
-                            "iid": row["instrument_id"],
-                            "spread_bps": spread_bps,
-                            "fx_pair": None if currency == "USD" else f"{currency}/USD",
-                            "fx_markup_bps": fx_markup_bps,
-                        },
-                    )
-            processed += 1
+                        cur.execute(
+                            """
+                            INSERT INTO cost_model (
+                                instrument_id, spread_bps, overnight_rate,
+                                fx_pair, fx_markup_bps, source
+                            ) VALUES (
+                                %(iid)s, %(spread_bps)s, 0,
+                                %(fx_pair)s, %(fx_markup_bps)s, 'computed'
+                            )
+                            """,
+                            {
+                                "iid": row["instrument_id"],
+                                "spread_bps": spread_bps,
+                                "fx_pair": None if currency == "USD" else f"{currency}/USD",
+                                "fx_markup_bps": fx_markup_bps,
+                            },
+                        )
+                processed += 1
+            except Exception:
+                logger.warning(
+                    "seed_cost_models: failed for instrument_id=%d, skipping",
+                    row["instrument_id"],
+                    exc_info=True,
+                )
+                skipped += 1
 
     return {"processed": processed, "skipped": skipped}
 

--- a/app/services/transaction_cost.py
+++ b/app/services/transaction_cost.py
@@ -260,7 +260,8 @@ def record_estimated_cost(
     breakdown = {
         "spread_bps": str(estimate.spread_bps),
         "overnight_bps_per_day": str(estimate.overnight_bps_per_day),
-        "fx_markup_bps": str(estimate.fx_markup_bps),
+        "fx_markup_bps": str(estimate.fx_markup_bps),  # one-way
+        "fx_roundtrip_bps": str(estimate.fx_markup_bps * 2),
         "estimated_hold_days": estimate.estimated_hold_days,
         "total_entry_cost_bps": str(estimate.total_entry_cost_bps),
         "total_carry_cost_bps": str(estimate.total_carry_cost_bps),

--- a/app/services/transaction_cost.py
+++ b/app/services/transaction_cost.py
@@ -14,6 +14,7 @@ from typing import Any
 import psycopg
 import psycopg.rows
 import psycopg.types.json
+from psycopg import sql
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -64,11 +65,65 @@ def get_transaction_cost_config(
             """
             SELECT max_total_cost_bps,
                    min_return_vs_cost_ratio,
-                   default_hold_days
+                   default_hold_days,
+                   updated_at,
+                   updated_by,
+                   reason
             FROM transaction_cost_config
             WHERE id = TRUE
             """
         )
+        row = cur.fetchone()
+    if row is None:
+        raise TransactionCostConfigCorrupt("transaction_cost_config singleton row missing")
+    return dict(row)
+
+
+def update_transaction_cost_config(
+    conn: psycopg.Connection[Any],
+    *,
+    max_total_cost_bps: Decimal | None = None,
+    min_return_vs_cost_ratio: Decimal | None = None,
+    default_hold_days: int | None = None,
+    updated_by: str,
+    reason: str,
+) -> dict[str, Any]:
+    """Update the transaction_cost_config singleton.
+
+    Only provided (non-None) fields are changed.  Always updates
+    updated_at, updated_by, and reason for audit.
+
+    Raises TransactionCostConfigCorrupt if the row is missing.
+    """
+    # Build dynamic SET clause using psycopg.sql for type-safe composition.
+    # Column names come from a fixed set in code (never user input).
+    set_parts: list[sql.Composable] = [
+        sql.SQL("updated_at = NOW()"),
+        sql.SQL("updated_by = {by}").format(by=sql.Placeholder("updated_by")),
+        sql.SQL("reason = {reason}").format(reason=sql.Placeholder("reason")),
+    ]
+    params: dict[str, Any] = {"updated_by": updated_by, "reason": reason}
+
+    if max_total_cost_bps is not None:
+        set_parts.append(sql.SQL("max_total_cost_bps = {v}").format(v=sql.Placeholder("max_total_cost_bps")))
+        params["max_total_cost_bps"] = max_total_cost_bps
+    if min_return_vs_cost_ratio is not None:
+        set_parts.append(
+            sql.SQL("min_return_vs_cost_ratio = {v}").format(v=sql.Placeholder("min_return_vs_cost_ratio"))
+        )
+        params["min_return_vs_cost_ratio"] = min_return_vs_cost_ratio
+    if default_hold_days is not None:
+        set_parts.append(sql.SQL("default_hold_days = {v}").format(v=sql.Placeholder("default_hold_days")))
+        params["default_hold_days"] = default_hold_days
+
+    query = sql.SQL(
+        "UPDATE transaction_cost_config SET {sets} WHERE id = TRUE"
+        " RETURNING max_total_cost_bps, min_return_vs_cost_ratio,"
+        " default_hold_days, updated_at, updated_by, reason"
+    ).format(sets=sql.SQL(", ").join(set_parts))
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(query, params)
         row = cur.fetchone()
     if row is None:
         raise TransactionCostConfigCorrupt("transaction_cost_config singleton row missing")

--- a/app/services/transaction_cost.py
+++ b/app/services/transaction_cost.py
@@ -289,7 +289,7 @@ def record_estimated_cost(
                 "instrument_id": instrument_id,
                 "estimated_spread_bps": estimate.spread_bps,
                 "estimated_carry_bps": estimate.total_carry_cost_bps,
-                "estimated_fx_bps": estimate.fx_markup_bps,
+                "estimated_fx_bps": estimate.fx_markup_bps * 2,  # round-trip
                 "estimated_total_bps": estimate.total_cost_bps,
                 "cost_breakdown": psycopg.types.json.Jsonb(breakdown),
             },

--- a/app/services/transaction_cost.py
+++ b/app/services/transaction_cost.py
@@ -311,76 +311,76 @@ def seed_cost_models_from_quotes(
 
     Overnight rate is 0 for all instruments (real stocks, not CFDs in v1).
 
-    The SELECT and all per-instrument UPDATE+INSERT pairs run inside a single
-    transaction so the read and writes share the same snapshot.  Each instrument
-    pair is wrapped in a savepoint so a single-row failure does not abort the
-    entire batch.
+    Runs within the caller's implicit transaction (psycopg v3 autocommit-off).
+    The SELECT and all per-instrument writes share a single transaction
+    snapshot.  Each UPDATE+INSERT pair is wrapped in a savepoint so a
+    single-row failure does not abort the entire batch.  The caller
+    (scheduler) is responsible for calling conn.commit().
     """
     processed = 0
     skipped = 0
 
-    with conn.transaction():
-        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-            cur.execute(
-                """
-                SELECT i.instrument_id, q.spread_pct, i.currency
-                FROM instruments i
-                JOIN coverage c USING (instrument_id)
-                JOIN quotes q USING (instrument_id)
-                WHERE c.coverage_tier = 1
-                  AND q.spread_pct IS NOT NULL
-                """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT i.instrument_id, q.spread_pct, i.currency
+            FROM instruments i
+            JOIN coverage c USING (instrument_id)
+            JOIN quotes q USING (instrument_id)
+            WHERE c.coverage_tier = 1
+              AND q.spread_pct IS NOT NULL
+            """
+        )
+        rows = cur.fetchall()
+
+    for row in rows:
+        # Defensive: SQL already filters IS NOT NULL, but guard against
+        # future query changes or unexpected mock data.
+        if row["spread_pct"] is None:
+            skipped += 1
+            continue
+
+        spread_bps = spread_pct_to_bps(row["spread_pct"])
+        currency = row["currency"] or "USD"
+        fx_markup_bps = Decimal("0") if currency == "USD" else Decimal("50")
+
+        try:
+            with conn.transaction():
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        UPDATE cost_model
+                        SET valid_to = NOW()
+                        WHERE instrument_id = %(iid)s
+                          AND valid_to IS NULL
+                        """,
+                        {"iid": row["instrument_id"]},
+                    )
+                    cur.execute(
+                        """
+                        INSERT INTO cost_model (
+                            instrument_id, spread_bps, overnight_rate,
+                            fx_pair, fx_markup_bps, source
+                        ) VALUES (
+                            %(iid)s, %(spread_bps)s, 0,
+                            %(fx_pair)s, %(fx_markup_bps)s, 'computed'
+                        )
+                        """,
+                        {
+                            "iid": row["instrument_id"],
+                            "spread_bps": spread_bps,
+                            "fx_pair": None if currency == "USD" else f"{currency}/USD",
+                            "fx_markup_bps": fx_markup_bps,
+                        },
+                    )
+            processed += 1
+        except Exception:
+            logger.warning(
+                "seed_cost_models: failed for instrument_id=%d, skipping",
+                row["instrument_id"],
+                exc_info=True,
             )
-            rows = cur.fetchall()
-
-        for row in rows:
-            # Defensive: SQL already filters IS NOT NULL, but guard against
-            # future query changes or unexpected mock data.
-            if row["spread_pct"] is None:
-                skipped += 1
-                continue
-
-            spread_bps = spread_pct_to_bps(row["spread_pct"])
-            currency = row["currency"] or "USD"
-            fx_markup_bps = Decimal("0") if currency == "USD" else Decimal("50")
-
-            try:
-                with conn.transaction():
-                    with conn.cursor() as cur:
-                        cur.execute(
-                            """
-                            UPDATE cost_model
-                            SET valid_to = NOW()
-                            WHERE instrument_id = %(iid)s
-                              AND valid_to IS NULL
-                            """,
-                            {"iid": row["instrument_id"]},
-                        )
-                        cur.execute(
-                            """
-                            INSERT INTO cost_model (
-                                instrument_id, spread_bps, overnight_rate,
-                                fx_pair, fx_markup_bps, source
-                            ) VALUES (
-                                %(iid)s, %(spread_bps)s, 0,
-                                %(fx_pair)s, %(fx_markup_bps)s, 'computed'
-                            )
-                            """,
-                            {
-                                "iid": row["instrument_id"],
-                                "spread_bps": spread_bps,
-                                "fx_pair": None if currency == "USD" else f"{currency}/USD",
-                                "fx_markup_bps": fx_markup_bps,
-                            },
-                        )
-                processed += 1
-            except Exception:
-                logger.warning(
-                    "seed_cost_models: failed for instrument_id=%d, skipping",
-                    row["instrument_id"],
-                    exc_info=True,
-                )
-                skipped += 1
+            skipped += 1
 
     return {"processed": processed, "skipped": skipped}
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -286,6 +286,13 @@ def _has_tier1_stale_theses(conn: psycopg.Connection[Any]) -> PrerequisiteResult
     return (False, "no Tier 1 instruments")
 
 
+def _has_tier1_coverage(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if at least one instrument has Tier 1 coverage."""
+    if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM coverage WHERE coverage_tier = 1)")):
+        return (True, "")
+    return (False, "no Tier 1 instruments yet")
+
+
 def _has_attributions(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     """True if at least one attributed position exists."""
     if _exists(conn, psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM return_attribution)")):
@@ -414,7 +421,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         name=JOB_SEED_COST_MODELS,
         description="Refresh per-instrument cost models from current quote spreads.",
         cadence=Cadence.daily(hour=6, minute=15),
-        prerequisite=_has_tier1_stale_theses,
+        prerequisite=_has_tier1_coverage,
     ),
     # -- On-demand jobs are NOT listed here.  They stay in _INVOKERS
     # (runtime.py) so "Run now" in the Admin UI works, but they are

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -202,6 +202,7 @@ JOB_MONITOR_POSITIONS = "monitor_positions"
 JOB_ATTRIBUTION_SUMMARY = "attribution_summary"
 JOB_WEEKLY_REPORT = "weekly_report"
 JOB_MONTHLY_REPORT = "monthly_report"
+JOB_SEED_COST_MODELS = "seed_cost_models"
 
 
 # ---------------------------------------------------------------------------
@@ -407,6 +408,13 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         description="Generate monthly performance report snapshot.",
         cadence=Cadence.monthly(day=1, hour=7, minute=0),  # 1st of month 07:00
         prerequisite=_has_positions_or_attributions,
+    ),
+    # -- Cost model maintenance --
+    ScheduledJob(
+        name=JOB_SEED_COST_MODELS,
+        description="Refresh per-instrument cost models from current quote spreads.",
+        cadence=Cadence.daily(hour=6, minute=15),
+        prerequisite=_has_tier1_stale_theses,
     ),
     # -- On-demand jobs are NOT listed here.  They stay in _INVOKERS
     # (runtime.py) so "Run now" in the Admin UI works, but they are
@@ -1967,3 +1975,19 @@ def monthly_report() -> None:
             )
             conn.commit()
         tracker.row_count = 1
+
+
+def seed_cost_models() -> None:
+    """Scheduled job: refresh cost_model rows from current quotes."""
+    from app.services.transaction_cost import seed_cost_models_from_quotes
+
+    with _tracked_job(JOB_SEED_COST_MODELS) as tracker:
+        with psycopg.connect(settings.database_url) as conn:
+            result = seed_cost_models_from_quotes(conn)
+            conn.commit()
+        tracker.row_count = result["processed"]
+        logger.info(
+            "seed_cost_models: processed=%d skipped=%d",
+            result["processed"],
+            result["skipped"],
+        )

--- a/sql/031_transaction_cost_model.sql
+++ b/sql/031_transaction_cost_model.sql
@@ -1,0 +1,86 @@
+-- Migration 031: transaction cost model
+--
+-- cost_model: per-instrument fee schedules with temporal validity.
+--   One active row per instrument (valid_to IS NULL).
+--   Supports spread, overnight rate, and FX markup components.
+--
+-- transaction_cost_config: singleton operator-level cost thresholds.
+--   Same pattern as budget_config (id BOOLEAN PK + CHECK id=TRUE).
+--
+-- trade_cost_record: links estimated costs (at guard time) to actual
+--   costs (at fill time) for post-trade reconciliation.
+
+-- Per-instrument fee schedule
+CREATE TABLE IF NOT EXISTS cost_model (
+    cost_model_id    BIGSERIAL      PRIMARY KEY,
+    instrument_id    BIGINT         NOT NULL REFERENCES instruments(instrument_id),
+    spread_bps       NUMERIC(10,4)  NOT NULL,
+    overnight_rate   NUMERIC(10,6)  NOT NULL DEFAULT 0,
+    fx_pair          TEXT,
+    fx_markup_bps    NUMERIC(10,4)  NOT NULL DEFAULT 0,
+    valid_from       TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    valid_to         TIMESTAMPTZ,
+    source           TEXT           NOT NULL DEFAULT 'computed',
+    CONSTRAINT chk_cost_model_source
+        CHECK (source IN ('manual', 'computed', 'api'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_model_instrument_active
+    ON cost_model(instrument_id, valid_from DESC)
+    WHERE valid_to IS NULL;
+
+-- Singleton cost config
+CREATE TABLE IF NOT EXISTS transaction_cost_config (
+    id                        BOOLEAN       PRIMARY KEY DEFAULT TRUE,
+    max_total_cost_bps        NUMERIC(8,2)  NOT NULL DEFAULT 150,
+    min_return_vs_cost_ratio  NUMERIC(6,2)  NOT NULL DEFAULT 3.0,
+    default_hold_days         INTEGER       NOT NULL DEFAULT 90,
+    updated_at                TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    updated_by                TEXT          NOT NULL DEFAULT 'system',
+    reason                    TEXT          NOT NULL DEFAULT 'initial seed',
+    CONSTRAINT transaction_cost_config_single_row CHECK (id = TRUE)
+);
+
+DO $$
+BEGIN
+    ALTER TABLE transaction_cost_config
+        DROP CONSTRAINT IF EXISTS chk_tcc_max_cost_bps;
+    ALTER TABLE transaction_cost_config
+        ADD CONSTRAINT chk_tcc_max_cost_bps
+        CHECK (max_total_cost_bps > 0 AND max_total_cost_bps <= 1000);
+
+    ALTER TABLE transaction_cost_config
+        DROP CONSTRAINT IF EXISTS chk_tcc_min_ratio;
+    ALTER TABLE transaction_cost_config
+        ADD CONSTRAINT chk_tcc_min_ratio
+        CHECK (min_return_vs_cost_ratio >= 1.0);
+
+    ALTER TABLE transaction_cost_config
+        DROP CONSTRAINT IF EXISTS chk_tcc_hold_days;
+    ALTER TABLE transaction_cost_config
+        ADD CONSTRAINT chk_tcc_hold_days
+        CHECK (default_hold_days > 0 AND default_hold_days <= 365);
+END $$;
+
+INSERT INTO transaction_cost_config (id)
+VALUES (TRUE)
+ON CONFLICT DO NOTHING;
+
+-- Per-fill cost tracking
+CREATE TABLE IF NOT EXISTS trade_cost_record (
+    cost_record_id       BIGSERIAL      PRIMARY KEY,
+    order_id             BIGINT         NOT NULL REFERENCES orders(order_id),
+    recommendation_id    BIGINT         NOT NULL REFERENCES trade_recommendations(recommendation_id),
+    instrument_id        BIGINT         NOT NULL REFERENCES instruments(instrument_id),
+    estimated_spread_bps NUMERIC(10,4),
+    estimated_carry_bps  NUMERIC(10,4),
+    estimated_fx_bps     NUMERIC(10,4),
+    estimated_total_bps  NUMERIC(10,4)  NOT NULL,
+    actual_spread_bps    NUMERIC(10,4),
+    actual_total_bps     NUMERIC(10,4),
+    cost_breakdown       JSONB          NOT NULL,
+    recorded_at          TIMESTAMPTZ    NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_cost_record_order
+    ON trade_cost_record(order_id);

--- a/sql/031_transaction_cost_model.sql
+++ b/sql/031_transaction_cost_model.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS cost_model (
     cost_model_id    BIGSERIAL      PRIMARY KEY,
     instrument_id    BIGINT         NOT NULL REFERENCES instruments(instrument_id),
     spread_bps       NUMERIC(10,4)  NOT NULL,
-    overnight_rate   NUMERIC(10,6)  NOT NULL DEFAULT 0,
+    overnight_rate   NUMERIC(10,6)  NOT NULL DEFAULT 0,  -- bps per day
     fx_pair          TEXT,
     fx_markup_bps    NUMERIC(10,4)  NOT NULL DEFAULT 0,
     valid_from       TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
@@ -27,6 +27,11 @@ CREATE TABLE IF NOT EXISTS cost_model (
 
 CREATE INDEX IF NOT EXISTS idx_cost_model_instrument_active
     ON cost_model(instrument_id, valid_from DESC)
+    WHERE valid_to IS NULL;
+
+-- Enforce one active row per instrument at the DB level.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cost_model_one_active
+    ON cost_model(instrument_id)
     WHERE valid_to IS NULL;
 
 -- Singleton cost config

--- a/tests/test_execution_guard.py
+++ b/tests/test_execution_guard.py
@@ -651,7 +651,24 @@ class TestTransactionCostRule:
                 "default_hold_days": 90,
             },
         )
+        # 1.2% spread = 120 bps < 150 threshold → passes via quote fallback
         assert result.passed is True
+        assert "120" in result.detail
+
+    def test_cost_rule_fails_via_quote_spread_fallback(self) -> None:
+        """Quote spread exceeds threshold when no cost_model row exists."""
+        result = _check_transaction_cost(
+            quote={"spread_pct": Decimal("2.0"), "spread_flag": True},
+            cost_model_row=None,
+            cost_config={
+                "max_total_cost_bps": Decimal("150"),
+                "min_return_vs_cost_ratio": Decimal("3.0"),
+                "default_hold_days": 90,
+            },
+        )
+        # 2.0% spread = 200 bps > 150 threshold → fails
+        assert result.passed is False
+        assert "200" in result.detail
 
     def test_cost_rule_fails_closed_when_no_quote(self) -> None:
         result = _check_transaction_cost(
@@ -893,6 +910,12 @@ class TestEvaluateRecommendation:
         result = self._eval(cursors)
         assert result.verdict == "FAIL"
         assert "budget_available" in result.failed_rules
+
+    def test_cost_config_corrupt_fails_buy(self) -> None:
+        cursors = _buy_cursors(cost_config_corrupt=True)
+        result = self._eval(cursors)
+        assert result.verdict == "FAIL"
+        assert "transaction_cost_prohibitive" in result.failed_rules
 
     def test_budget_does_not_fail_exit(self) -> None:
         result = self._eval(_exit_cursors())

--- a/tests/test_execution_guard.py
+++ b/tests/test_execution_guard.py
@@ -26,15 +26,17 @@ Cursor call order inside evaluate_recommendation (BUY):
   4. _load_coverage                — fetchone
   5. _load_latest_thesis           — fetchone
   6. _load_quote                   — fetchone
-  7-12. compute_budget_state       — 6 cursors:
+  7. get_transaction_cost_config   — fetchone (cost config singleton)
+  8. load_instrument_cost          — fetchone (cost_model lookup)
+  9-14. compute_budget_state       — 6 cursors:
          budget_config, cash_balance, deployed_capital,
          mirror_equity, tax_estimates, gbp_usd_rate
-  13. _load_sector_exposure        — 4 cursors: instruments, positions,
+  15. _load_sector_exposure        — 4 cursors: instruments, positions,
                                      cash_ledger, mirror_equity
                                      (the mirror_equity cursor is consumed
                                      by _load_mirror_equity, wired into
                                      total_aum by Track 1b / #187).
-  14. _write_audit                 — 1 cursor (INSERT RETURNING decision_id)
+  16. _write_audit                 — 1 cursor (INSERT RETURNING decision_id)
       + conn.execute (UPDATE status)
 
 Note: for EXIT actions, cursors 4-14 (coverage through sector_exposure) are
@@ -63,6 +65,7 @@ from app.services.execution_guard import (
     _check_live_trading,
     _check_spread,
     _check_thesis_freshness,
+    _check_transaction_cost,
     evaluate_recommendation,
 )
 
@@ -159,8 +162,8 @@ def _thesis_cursor(age_days: int = 3) -> MagicMock:
     return _make_cursor([{"created_at": created_at}])
 
 
-def _quote_cursor(spread_flag: bool | None = False) -> MagicMock:
-    return _make_cursor([{"spread_flag": spread_flag}])
+def _quote_cursor(spread_flag: bool | None = False, spread_pct: Decimal | None = Decimal("0.20")) -> MagicMock:
+    return _make_cursor([{"spread_flag": spread_flag, "spread_pct": spread_pct}])
 
 
 def _budget_config_cursor() -> MagicMock:
@@ -227,6 +230,27 @@ def _sector_cursors(
     return [instrument_cur, positions_cur, cash_cur, mirror_cur]
 
 
+def _cost_config_cursor(
+    max_total_cost_bps: Decimal = Decimal("150"),
+    min_return_vs_cost_ratio: Decimal = Decimal("3.0"),
+    default_hold_days: int = 90,
+) -> MagicMock:
+    return _make_cursor(
+        [
+            {
+                "max_total_cost_bps": max_total_cost_bps,
+                "min_return_vs_cost_ratio": min_return_vs_cost_ratio,
+                "default_hold_days": default_hold_days,
+            }
+        ]
+    )
+
+
+def _cost_model_cursor(row: dict[str, Any] | None = None) -> MagicMock:
+    """Cost model row.  None = no cost_model for this instrument (use quote spread)."""
+    return _make_cursor([row] if row is not None else [])
+
+
 def _audit_cursor(decision_id: int = 99) -> MagicMock:
     return _make_cursor([{"decision_id": decision_id}])
 
@@ -272,6 +296,9 @@ def _buy_cursors(
     coverage_frequency: str = "weekly",
     thesis_age_days: int = 3,
     spread_flag: bool | None = False,
+    spread_pct: Decimal | None = Decimal("0.20"),
+    cost_config_corrupt: bool = False,
+    cost_model_row: dict[str, Any] | None = None,
     cash_balance: float | None = 10_000.0,
     budget_corrupt: bool = False,
     sector: str | None = "Technology",
@@ -293,7 +320,10 @@ def _buy_cursors(
         runtime,
         _coverage_cursor(tier=coverage_tier, frequency=coverage_frequency),
         _thesis_cursor(age_days=thesis_age_days),
-        _quote_cursor(spread_flag=spread_flag),
+        _quote_cursor(spread_flag=spread_flag, spread_pct=spread_pct),
+        # Transaction cost check cursors
+        _make_cursor([]) if cost_config_corrupt else _cost_config_cursor(),
+        _cost_model_cursor(cost_model_row),
         *_budget_cursors_list(cash_balance=cash_balance, budget_corrupt=budget_corrupt),
         *_sector_cursors(
             sector=sector,
@@ -570,6 +600,101 @@ class TestCheckConcentration:
         assert result.passed is False
         assert result.rule == "concentration_breach"
         assert "Technology" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# TestTransactionCostRule
+# ---------------------------------------------------------------------------
+
+
+class TestTransactionCostRule:
+    """Tests for the transaction_cost_prohibitive guard rule."""
+
+    def test_cost_rule_passes_when_below_threshold(self) -> None:
+        result = _check_transaction_cost(
+            quote={"spread_pct": Decimal("0.20"), "spread_flag": False},
+            cost_model_row=None,
+            cost_config={
+                "max_total_cost_bps": Decimal("150"),
+                "min_return_vs_cost_ratio": Decimal("3.0"),
+                "default_hold_days": 90,
+            },
+        )
+        assert result.passed is True
+        assert result.rule == "transaction_cost_prohibitive"
+
+    def test_cost_rule_fails_when_above_threshold(self) -> None:
+        result = _check_transaction_cost(
+            quote={"spread_pct": Decimal("2.0"), "spread_flag": True},
+            cost_model_row={
+                "spread_bps": Decimal("200"),
+                "overnight_rate": Decimal("0"),
+                "fx_pair": None,
+                "fx_markup_bps": Decimal("0"),
+            },
+            cost_config={
+                "max_total_cost_bps": Decimal("150"),
+                "min_return_vs_cost_ratio": Decimal("3.0"),
+                "default_hold_days": 90,
+            },
+        )
+        assert result.passed is False
+        assert "200" in result.detail
+
+    def test_cost_rule_uses_quote_spread_when_no_cost_model(self) -> None:
+        result = _check_transaction_cost(
+            quote={"spread_pct": Decimal("1.2"), "spread_flag": True},
+            cost_model_row=None,
+            cost_config={
+                "max_total_cost_bps": Decimal("150"),
+                "min_return_vs_cost_ratio": Decimal("3.0"),
+                "default_hold_days": 90,
+            },
+        )
+        assert result.passed is True
+
+    def test_cost_rule_fails_closed_when_no_quote(self) -> None:
+        result = _check_transaction_cost(
+            quote=None,
+            cost_model_row=None,
+            cost_config={
+                "max_total_cost_bps": Decimal("150"),
+                "min_return_vs_cost_ratio": Decimal("3.0"),
+                "default_hold_days": 90,
+            },
+        )
+        assert result.passed is False
+        assert "unavailable" in result.detail.lower()
+
+    def test_cost_rule_fails_when_quote_has_null_spread(self) -> None:
+        result = _check_transaction_cost(
+            quote={"spread_pct": None, "spread_flag": False},
+            cost_model_row=None,
+            cost_config={
+                "max_total_cost_bps": Decimal("150"),
+                "min_return_vs_cost_ratio": Decimal("3.0"),
+                "default_hold_days": 90,
+            },
+        )
+        assert result.passed is False
+        assert "unavailable" in result.detail.lower()
+
+    def test_cost_rule_passes_when_cost_model_has_low_spread(self) -> None:
+        result = _check_transaction_cost(
+            quote={"spread_pct": Decimal("5.0"), "spread_flag": True},
+            cost_model_row={
+                "spread_bps": Decimal("30"),
+                "overnight_rate": Decimal("0"),
+                "fx_pair": None,
+                "fx_markup_bps": Decimal("0"),
+            },
+            cost_config={
+                "max_total_cost_bps": Decimal("150"),
+                "min_return_vs_cost_ratio": Decimal("3.0"),
+                "default_hold_days": 90,
+            },
+        )
+        assert result.passed is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -32,16 +32,15 @@ Cursor call order inside execute_order (demo EXIT):
   2. _load_position_units           — fetchone
   3. _load_quote_for_execution      — fetchone (last/bid/ask/spread_pct)
   4. _persist_order                 — fetchone (INSERT RETURNING)
-  5. get_transaction_cost_config    — fetchone
-  6. load_instrument_cost           — fetchone
-  7. record_estimated_cost          — cursor (INSERT, no fetchone)
-  8. _persist_fill                  — fetchone (INSERT RETURNING)
-  9. conn.execute x4                — position update, cash_ledger, rec status, audit
+  5. _persist_fill                  — fetchone (INSERT RETURNING)
+  6. conn.execute x4                — position update, cash_ledger, rec status, audit
 
-Live mode cursor sequences are similar but without step 3 in the main path
-(no _load_quote_for_execution for the fill). Instead, when cost_model_row is
-None, _load_quote_for_execution is called in the cost-recording fallback path
-(between steps 6 and 7).
+  Cost recording (steps 5-7 in BUY sequence) is BUY/ADD only — skipped for EXIT.
+
+Live mode BUY cursor sequences are similar but without step 3 in the main
+path (no _load_quote_for_execution for the fill). Instead, when
+cost_model_row is None, _load_quote_for_execution is called in the
+cost-recording fallback path (between steps 6 and 7).
 """
 
 from __future__ import annotations
@@ -429,11 +428,8 @@ class TestExecuteOrderDemoMode:
             _rec_cursor(action="EXIT", target_entry=None, suggested_size_pct=None),
             _position_cursor(current_units=5.0),
             _quote_cursor(last=200.0, spread_pct=0.30),
-            # Inside transaction:
+            # Inside transaction (no cost recording for EXIT):
             _order_returning_cursor(order_id=8),
-            _cost_config_cursor(),
-            _cost_model_cursor(),
-            _cost_record_write_cursor(),
             _fill_returning_cursor(fill_id=4),
             # Post-fill: read current_units for attribution check
             _make_cursor([{"current_units": 0}]),
@@ -545,10 +541,8 @@ class TestExecuteOrderDemoMode:
             _rec_cursor(action="EXIT", target_entry=None, suggested_size_pct=None),
             _position_cursor(current_units=5.0),
             _quote_cursor(last=200.0, spread_pct=0.30),
+            # No cost recording for EXIT
             _order_returning_cursor(order_id=8),
-            _cost_config_cursor(),
-            _cost_model_cursor(),
-            _cost_record_write_cursor(),
             _fill_returning_cursor(fill_id=4),
             # Post-fill: read current_units for attribution check
             _make_cursor([{"current_units": 0}]),
@@ -682,11 +676,8 @@ class TestExecuteOrderLiveMode:
             # _load_position_id_for_exit resolves instrument_id → position_id
             _make_cursor([{"position_id": 98765}]),
             # broker called (no cursor)
+            # No cost recording for EXIT
             _order_returning_cursor(order_id=11),
-            _cost_config_cursor(),
-            _cost_model_cursor(),  # no cost_model → falls back to quote
-            _quote_cursor(last=200.0, bid=199.0, ask=201.0, spread_pct=0.50),  # cost fallback
-            _make_cursor([]),  # record_estimated_cost INSERT
             _fill_returning_cursor(fill_id=7),
             # Post-fill: read current_units for attribution check
             _make_cursor([{"current_units": 0}]),
@@ -711,11 +702,8 @@ class TestExecuteOrderLiveMode:
             # _load_position_id_for_exit returns None — no broker_positions row
             _make_cursor([]),
             # broker NOT called — broker_result is constructed inline as failed
+            # No cost recording for EXIT
             _order_returning_cursor(order_id=12),
-            _cost_config_cursor(),
-            _cost_model_cursor(),  # no cost_model → falls back to quote
-            _quote_cursor(last=150.0, bid=149.0, ask=151.0, spread_pct=0.40),  # cost fallback
-            _make_cursor([]),  # record_estimated_cost INSERT
         ]
         conn = _make_conn(cursors)
         result = execute_order(

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -231,6 +231,61 @@ class TestSyntheticFill:
 
 
 # ---------------------------------------------------------------------------
+# TestSyntheticFillSpreadCost
+# ---------------------------------------------------------------------------
+
+
+class TestSyntheticFillSpreadCost:
+    def test_buy_fills_at_ask_with_spread_fee(self) -> None:
+        result = _synthetic_fill(
+            instrument_id=123,
+            action="BUY",
+            quote_price=Decimal("100.00"),
+            requested_amount=Decimal("1000"),
+            requested_units=None,
+            bid=Decimal("99.80"),
+            ask=Decimal("100.20"),
+        )
+        # BUY fills at ask
+        assert result.filled_price == Decimal("100.20")
+        # units = 1000 / 100.20
+        expected_units = (Decimal("1000") / Decimal("100.20")).quantize(Decimal("0.000001"))
+        assert result.filled_units == expected_units
+        # Spread cost = (ask - bid) / 2 * units
+        spread_per_unit = (Decimal("100.20") - Decimal("99.80")) / 2
+        expected_fees = (spread_per_unit * expected_units).quantize(Decimal("0.000001"))
+        assert result.fees == expected_fees
+
+    def test_exit_fills_at_bid_with_spread_fee(self) -> None:
+        result = _synthetic_fill(
+            instrument_id=123,
+            action="EXIT",
+            quote_price=Decimal("100.00"),
+            requested_amount=None,
+            requested_units=Decimal("10"),
+            bid=Decimal("99.80"),
+            ask=Decimal("100.20"),
+        )
+        assert result.filled_price == Decimal("99.80")
+        spread_per_unit = (Decimal("100.20") - Decimal("99.80")) / 2
+        expected_fees = (spread_per_unit * Decimal("10")).quantize(Decimal("0.000001"))
+        assert result.fees == expected_fees
+
+    def test_no_bid_ask_falls_back_to_zero_fees(self) -> None:
+        result = _synthetic_fill(
+            instrument_id=123,
+            action="BUY",
+            quote_price=Decimal("100.00"),
+            requested_amount=Decimal("1000"),
+            requested_units=None,
+            bid=None,
+            ask=None,
+        )
+        assert result.fees == Decimal("0")
+        assert result.filled_price == Decimal("100.00")
+
+
+# ---------------------------------------------------------------------------
 # TestLoadApprovedRec
 # ---------------------------------------------------------------------------
 

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -16,18 +16,27 @@ Mock DB approach mirrors test_execution_guard.py:
 Cursor call order inside execute_order (demo BUY with suggested_size_pct):
   1. _load_approved_recommendation  — fetchone
   2. _load_cash                     — fetchone
-  3. _load_latest_quote_price       — fetchone
+  3. _load_quote_for_execution      — fetchone (last/bid/ask/spread_pct)
   4. _persist_order                 — fetchone (INSERT RETURNING)
-  5. _persist_fill                  — fetchone (INSERT RETURNING)
-  6. conn.execute x5                — position upsert, broker_positions, cash_ledger, rec status, audit
+  5. get_transaction_cost_config    — fetchone
+  6. load_instrument_cost           — fetchone
+  7. record_estimated_cost          — cursor (INSERT, no fetchone)
+  8. _persist_fill                  — fetchone (INSERT RETURNING)
+  9. conn.execute x5                — position upsert, broker_positions, cash_ledger, rec status, audit
+
+  When spread data is unavailable (no cost_model, no quote spread_pct),
+  cursor 7 (record_estimated_cost) is skipped — s_bps is None.
 
 Cursor call order inside execute_order (demo EXIT):
   1. _load_approved_recommendation  — fetchone
   2. _load_position_units           — fetchone
-  3. _load_latest_quote_price       — fetchone
+  3. _load_quote_for_execution      — fetchone (last/bid/ask/spread_pct)
   4. _persist_order                 — fetchone (INSERT RETURNING)
-  5. _persist_fill                  — fetchone (INSERT RETURNING)
-  6. conn.execute x4                — position update, cash_ledger, rec status, audit
+  5. get_transaction_cost_config    — fetchone
+  6. load_instrument_cost           — fetchone
+  7. record_estimated_cost          — cursor (INSERT, no fetchone)
+  8. _persist_fill                  — fetchone (INSERT RETURNING)
+  9. conn.execute x4                — position update, cash_ledger, rec status, audit
 """
 
 from __future__ import annotations
@@ -51,6 +60,16 @@ from app.services.order_client import (
     execute_order,
 )
 from app.services.runtime_config import RuntimeConfig, RuntimeConfigCorrupt
+
+# ---------------------------------------------------------------------------
+# Cost-related test constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_COST_CONFIG: dict[str, Any] = {
+    "max_total_cost_bps": Decimal("150"),
+    "min_return_vs_cost_ratio": Decimal("3.0"),
+    "default_hold_days": 90,
+}
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -146,8 +165,16 @@ def _cash_cursor(balance: float | None = 10_000.0) -> MagicMock:
     return _make_cursor([{"balance": balance}])
 
 
-def _quote_cursor(last: float | None = 150.0) -> MagicMock:
-    return _make_cursor([{"last": last}] if last is not None else [])
+def _quote_cursor(
+    last: float | None = 150.0,
+    bid: float | None = None,
+    ask: float | None = None,
+    spread_pct: float | None = None,
+) -> MagicMock:
+    if last is None and bid is None:
+        return _make_cursor([])
+    row: dict[str, Any] = {"last": last, "bid": bid, "ask": ask, "spread_pct": spread_pct}
+    return _make_cursor([row])
 
 
 def _position_cursor(current_units: float = 10.0) -> MagicMock:
@@ -160,6 +187,19 @@ def _order_returning_cursor(order_id: int = 1) -> MagicMock:
 
 def _fill_returning_cursor(fill_id: int = 1) -> MagicMock:
     return _make_cursor([{"fill_id": fill_id}])
+
+
+def _cost_config_cursor() -> MagicMock:
+    return _make_cursor([_DEFAULT_COST_CONFIG])
+
+
+def _cost_model_cursor(row: dict[str, Any] | None = None) -> MagicMock:
+    return _make_cursor([row] if row is not None else [])
+
+
+def _cost_record_write_cursor() -> MagicMock:
+    """Cursor consumed by record_estimated_cost INSERT (no rows returned)."""
+    return _make_cursor([])
 
 
 # ---------------------------------------------------------------------------
@@ -353,9 +393,12 @@ class TestExecuteOrderDemoMode:
         cursors = [
             _rec_cursor(action="BUY", target_entry=100.0, suggested_size_pct=0.05),
             _cash_cursor(balance=10_000.0),
-            _quote_cursor(last=100.0),
+            _quote_cursor(last=100.0, spread_pct=0.20),
             # Inside transaction:
             _order_returning_cursor(order_id=7),
+            _cost_config_cursor(),
+            _cost_model_cursor(),  # no cost_model → falls back to quote spread
+            _cost_record_write_cursor(),  # record_estimated_cost INSERT
             _fill_returning_cursor(fill_id=3),
         ]
         conn = _make_conn(cursors)
@@ -380,9 +423,12 @@ class TestExecuteOrderDemoMode:
         cursors = [
             _rec_cursor(action="EXIT", target_entry=None, suggested_size_pct=None),
             _position_cursor(current_units=5.0),
-            _quote_cursor(last=200.0),
+            _quote_cursor(last=200.0, spread_pct=0.30),
             # Inside transaction:
             _order_returning_cursor(order_id=8),
+            _cost_config_cursor(),
+            _cost_model_cursor(),
+            _cost_record_write_cursor(),
             _fill_returning_cursor(fill_id=4),
             # Post-fill: read current_units for attribution check
             _make_cursor([{"current_units": 0}]),
@@ -406,9 +452,11 @@ class TestExecuteOrderDemoMode:
         cursors = [
             _rec_cursor(action="BUY", target_entry=100.0, suggested_size_pct=0.05),
             _cash_cursor(balance=10_000.0),
-            _make_cursor([]),  # no quote
+            _make_cursor([]),  # no quote → quote_data=None
             # Inside transaction: order persisted, no fill (zero units)
             _order_returning_cursor(order_id=9),
+            _cost_config_cursor(),
+            _cost_model_cursor(),  # no cost_model → s_bps=None, no record_estimated_cost
         ]
         conn = _make_conn(cursors)
         result = execute_order(
@@ -431,8 +479,11 @@ class TestExecuteOrderDemoMode:
         cursors = [
             _rec_cursor(action="BUY"),
             _cash_cursor(balance=10_000.0),
-            _quote_cursor(last=100.0),
+            _quote_cursor(last=100.0, spread_pct=0.20),
             _order_returning_cursor(order_id=1),
+            _cost_config_cursor(),
+            _cost_model_cursor(),
+            _cost_record_write_cursor(),
             _fill_returning_cursor(fill_id=1),
         ]
         conn = _make_conn(cursors)
@@ -452,8 +503,11 @@ class TestExecuteOrderDemoMode:
         cursors = [
             _rec_cursor(action="BUY", stop_loss_rate=90.0, take_profit_rate=120.0),
             _cash_cursor(balance=10_000.0),
-            _quote_cursor(last=100.0),
+            _quote_cursor(last=100.0, spread_pct=0.20),
             _order_returning_cursor(order_id=7),
+            _cost_config_cursor(),
+            _cost_model_cursor(),
+            _cost_record_write_cursor(),
             _fill_returning_cursor(fill_id=3),
         ]
         conn = _make_conn(cursors)
@@ -484,8 +538,11 @@ class TestExecuteOrderDemoMode:
         cursors = [
             _rec_cursor(action="EXIT", target_entry=None, suggested_size_pct=None),
             _position_cursor(current_units=5.0),
-            _quote_cursor(last=200.0),
+            _quote_cursor(last=200.0, spread_pct=0.30),
             _order_returning_cursor(order_id=8),
+            _cost_config_cursor(),
+            _cost_model_cursor(),
+            _cost_record_write_cursor(),
             _fill_returning_cursor(fill_id=4),
             # Post-fill: read current_units for attribution check
             _make_cursor([{"current_units": 0}]),
@@ -506,8 +563,11 @@ class TestExecuteOrderDemoMode:
         cursors = [
             _rec_cursor(action="BUY"),
             _cash_cursor(balance=10_000.0),
-            _quote_cursor(last=100.0),
+            _quote_cursor(last=100.0, spread_pct=0.20),
             _order_returning_cursor(order_id=1),
+            _cost_config_cursor(),
+            _cost_model_cursor(),
+            _cost_record_write_cursor(),
             _fill_returning_cursor(fill_id=1),
         ]
         conn = _make_conn(cursors)
@@ -551,6 +611,8 @@ class TestExecuteOrderLiveMode:
             _cash_cursor(balance=10_000.0),
             # broker called (no cursor)
             _order_returning_cursor(order_id=10),
+            _cost_config_cursor(),
+            _cost_model_cursor(),  # no cost_model, quote_data=None → s_bps=None, no record
             _fill_returning_cursor(fill_id=6),
         ]
         conn = _make_conn(cursors)
@@ -583,6 +645,8 @@ class TestExecuteOrderLiveMode:
             _make_cursor([{"position_id": 98765}]),
             # broker called (no cursor)
             _order_returning_cursor(order_id=11),
+            _cost_config_cursor(),
+            _cost_model_cursor(),  # no cost_model, quote_data=None → s_bps=None, no record
             _fill_returning_cursor(fill_id=7),
             # Post-fill: read current_units for attribution check
             _make_cursor([{"current_units": 0}]),
@@ -608,6 +672,8 @@ class TestExecuteOrderLiveMode:
             _make_cursor([]),
             # broker NOT called — broker_result is constructed inline as failed
             _order_returning_cursor(order_id=12),
+            _cost_config_cursor(),
+            _cost_model_cursor(),  # no cost_model, quote_data=None → s_bps=None, no record
         ]
         conn = _make_conn(cursors)
         result = execute_order(
@@ -668,6 +734,8 @@ class TestExecuteOrderFailures:
             _rec_cursor(action="BUY"),
             _cash_cursor(balance=10_000.0),
             _order_returning_cursor(order_id=12),
+            _cost_config_cursor(),
+            _cost_model_cursor(),  # no cost_model, quote_data=None → s_bps=None, no record
         ]
         conn = _make_conn(cursors)
         result = execute_order(
@@ -700,6 +768,8 @@ class TestExecuteOrderFailures:
             _rec_cursor(action="BUY"),
             _cash_cursor(balance=10_000.0),
             _order_returning_cursor(order_id=13),
+            _cost_config_cursor(),
+            _cost_model_cursor(),
         ]
         conn = _make_conn(cursors)
         result = execute_order(
@@ -747,6 +817,8 @@ class TestExecuteOrderFailures:
             _rec_cursor(action="BUY"),
             _cash_cursor(balance=10_000.0),
             _order_returning_cursor(order_id=14),
+            _cost_config_cursor(),
+            _cost_model_cursor(),
         ]
         conn = _make_conn(cursors)
         result = execute_order(
@@ -775,6 +847,8 @@ class TestExecuteOrderFailures:
             _rec_cursor(action="BUY"),
             _cash_cursor(balance=10_000.0),
             _order_returning_cursor(order_id=15),
+            _cost_config_cursor(),
+            _cost_model_cursor(),
         ]
         conn = _make_conn(cursors)
         execute_order(

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -37,6 +37,11 @@ Cursor call order inside execute_order (demo EXIT):
   7. record_estimated_cost          — cursor (INSERT, no fetchone)
   8. _persist_fill                  — fetchone (INSERT RETURNING)
   9. conn.execute x4                — position update, cash_ledger, rec status, audit
+
+Live mode cursor sequences are similar but without step 3 in the main path
+(no _load_quote_for_execution for the fill). Instead, when cost_model_row is
+None, _load_quote_for_execution is called in the cost-recording fallback path
+(between steps 6 and 7).
 """
 
 from __future__ import annotations
@@ -456,7 +461,8 @@ class TestExecuteOrderDemoMode:
             # Inside transaction: order persisted, no fill (zero units)
             _order_returning_cursor(order_id=9),
             _cost_config_cursor(),
-            _cost_model_cursor(),  # no cost_model → s_bps=None, no record_estimated_cost
+            _cost_model_cursor(),  # no cost_model → falls back to quote
+            _make_cursor([]),  # cost fallback: no quote either → s_bps=None, no record
         ]
         conn = _make_conn(cursors)
         result = execute_order(
@@ -612,7 +618,9 @@ class TestExecuteOrderLiveMode:
             # broker called (no cursor)
             _order_returning_cursor(order_id=10),
             _cost_config_cursor(),
-            _cost_model_cursor(),  # no cost_model, quote_data=None → s_bps=None, no record
+            _cost_model_cursor(),  # no cost_model → falls back to quote
+            _quote_cursor(last=100.0, bid=99.5, ask=100.5, spread_pct=0.30),  # cost fallback
+            _make_cursor([]),  # record_estimated_cost INSERT
             _fill_returning_cursor(fill_id=6),
         ]
         conn = _make_conn(cursors)
@@ -625,6 +633,36 @@ class TestExecuteOrderLiveMode:
         assert result.outcome == "filled"
         assert result.broker_order_ref == "ORD-123"
         broker.place_order.assert_called_once()
+
+    @patch("app.services.order_client._utcnow", return_value=_NOW)
+    def test_live_buy_records_cost_from_quote_fallback(self, _mock_now: MagicMock) -> None:
+        """Live mode with no cost_model falls back to quote spread_pct for cost recording."""
+        broker = MagicMock()
+        broker.place_order.return_value = BrokerOrderResult(
+            broker_order_ref="ORD-789",
+            status="filled",
+            filled_price=Decimal("100"),
+            filled_units=Decimal("5"),
+            fees=Decimal("1.50"),
+            raw_payload={"orderId": "ORD-789"},
+        )
+        cost_insert_cursor = _make_cursor([])
+        cursors = [
+            _rec_cursor(action="BUY", target_entry=100.0, suggested_size_pct=0.05),
+            _cash_cursor(balance=10_000.0),
+            _order_returning_cursor(order_id=10),
+            _cost_config_cursor(),
+            _cost_model_cursor(),  # no cost_model → falls back to quote
+            _quote_cursor(last=100.0, bid=99.5, ask=100.5, spread_pct=0.30),
+            cost_insert_cursor,  # record_estimated_cost INSERT
+            _fill_returning_cursor(fill_id=6),
+        ]
+        conn = _make_conn(cursors)
+        execute_order(conn, recommendation_id=42, decision_id=10, broker=broker)
+        # Verify the cost record INSERT was called
+        cost_insert_cursor.__enter__.return_value.execute.assert_called_once()
+        sql = cost_insert_cursor.__enter__.return_value.execute.call_args[0][0]
+        assert "INSERT INTO trade_cost_record" in sql
 
     @patch("app.services.order_client._maybe_trigger_attribution")
     @patch("app.services.order_client._utcnow", return_value=_NOW)
@@ -646,7 +684,9 @@ class TestExecuteOrderLiveMode:
             # broker called (no cursor)
             _order_returning_cursor(order_id=11),
             _cost_config_cursor(),
-            _cost_model_cursor(),  # no cost_model, quote_data=None → s_bps=None, no record
+            _cost_model_cursor(),  # no cost_model → falls back to quote
+            _quote_cursor(last=200.0, bid=199.0, ask=201.0, spread_pct=0.50),  # cost fallback
+            _make_cursor([]),  # record_estimated_cost INSERT
             _fill_returning_cursor(fill_id=7),
             # Post-fill: read current_units for attribution check
             _make_cursor([{"current_units": 0}]),
@@ -673,7 +713,9 @@ class TestExecuteOrderLiveMode:
             # broker NOT called — broker_result is constructed inline as failed
             _order_returning_cursor(order_id=12),
             _cost_config_cursor(),
-            _cost_model_cursor(),  # no cost_model, quote_data=None → s_bps=None, no record
+            _cost_model_cursor(),  # no cost_model → falls back to quote
+            _quote_cursor(last=150.0, bid=149.0, ask=151.0, spread_pct=0.40),  # cost fallback
+            _make_cursor([]),  # record_estimated_cost INSERT
         ]
         conn = _make_conn(cursors)
         result = execute_order(
@@ -735,7 +777,9 @@ class TestExecuteOrderFailures:
             _cash_cursor(balance=10_000.0),
             _order_returning_cursor(order_id=12),
             _cost_config_cursor(),
-            _cost_model_cursor(),  # no cost_model, quote_data=None → s_bps=None, no record
+            _cost_model_cursor(),  # no cost_model → falls back to quote
+            _quote_cursor(last=100.0, spread_pct=0.30),  # cost fallback
+            _make_cursor([]),  # record_estimated_cost INSERT
         ]
         conn = _make_conn(cursors)
         result = execute_order(
@@ -769,7 +813,9 @@ class TestExecuteOrderFailures:
             _cash_cursor(balance=10_000.0),
             _order_returning_cursor(order_id=13),
             _cost_config_cursor(),
-            _cost_model_cursor(),
+            _cost_model_cursor(),  # no cost_model → falls back to quote
+            _quote_cursor(last=100.0, spread_pct=0.30),  # cost fallback
+            _make_cursor([]),  # record_estimated_cost INSERT
         ]
         conn = _make_conn(cursors)
         result = execute_order(
@@ -818,7 +864,9 @@ class TestExecuteOrderFailures:
             _cash_cursor(balance=10_000.0),
             _order_returning_cursor(order_id=14),
             _cost_config_cursor(),
-            _cost_model_cursor(),
+            _cost_model_cursor(),  # no cost_model → falls back to quote
+            _quote_cursor(last=100.0, spread_pct=0.30),  # cost fallback
+            _make_cursor([]),  # record_estimated_cost INSERT
         ]
         conn = _make_conn(cursors)
         result = execute_order(
@@ -848,7 +896,9 @@ class TestExecuteOrderFailures:
             _cash_cursor(balance=10_000.0),
             _order_returning_cursor(order_id=15),
             _cost_config_cursor(),
-            _cost_model_cursor(),
+            _cost_model_cursor(),  # no cost_model → falls back to quote
+            _quote_cursor(last=100.0, spread_pct=0.30),  # cost fallback
+            _make_cursor([]),  # record_estimated_cost INSERT
         ]
         conn = _make_conn(cursors)
         execute_order(

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -658,6 +658,42 @@ class TestExecuteOrderLiveMode:
         sql = cost_insert_cursor.__enter__.return_value.execute.call_args[0][0]
         assert "INSERT INTO trade_cost_record" in sql
 
+    @patch("app.services.order_client._utcnow", return_value=_NOW)
+    def test_cost_insert_failure_does_not_abort_fill(self, _mock_now: MagicMock) -> None:
+        """A DB error during record_estimated_cost must not prevent the fill.
+
+        The cost recording block runs inside a savepoint.  If the cost INSERT
+        raises, the savepoint rolls back and the outer transaction stays
+        intact — _persist_fill still executes.
+        """
+        broker = MagicMock()
+        broker.place_order.return_value = BrokerOrderResult(
+            broker_order_ref="ORD-COST-FAIL",
+            status="filled",
+            filled_price=Decimal("100"),
+            filled_units=Decimal("5"),
+            fees=Decimal("1.50"),
+            raw_payload={"orderId": "ORD-COST-FAIL"},
+        )
+        # Cost INSERT cursor raises on execute — simulates a DB error.
+        bad_cost_cursor = _make_cursor([])
+        bad_cost_cursor.__enter__.return_value.execute.side_effect = Exception("FK violation")
+        cursors = [
+            _rec_cursor(action="BUY", target_entry=100.0, suggested_size_pct=0.05),
+            _cash_cursor(balance=10_000.0),
+            _order_returning_cursor(order_id=10),
+            _cost_config_cursor(),
+            _cost_model_cursor(),  # no cost_model → falls back to quote
+            _quote_cursor(last=100.0, bid=99.5, ask=100.5, spread_pct=0.30),
+            bad_cost_cursor,  # record_estimated_cost INSERT — will raise
+            _fill_returning_cursor(fill_id=6),
+        ]
+        conn = _make_conn(cursors)
+        result = execute_order(conn, recommendation_id=42, decision_id=10, broker=broker)
+        # Fill must succeed despite cost recording failure.
+        assert result.outcome == "filled"
+        assert result.fill_id == 6
+
     @patch("app.services.order_client._maybe_trigger_attribution")
     @patch("app.services.order_client._utcnow", return_value=_NOW)
     def test_live_exit_calls_broker_close_position(self, _mock_now: MagicMock, _mock_attr: MagicMock) -> None:

--- a/tests/test_transaction_cost.py
+++ b/tests/test_transaction_cost.py
@@ -1,0 +1,131 @@
+"""Tests for the transaction cost model service."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.transaction_cost import (
+    TransactionCostConfigCorrupt,
+    estimate_cost,
+    get_transaction_cost_config,
+)
+
+
+class TestGetTransactionCostConfig:
+    def test_returns_config_when_row_exists(self) -> None:
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchone.return_value = {
+            "max_total_cost_bps": Decimal("150"),
+            "min_return_vs_cost_ratio": Decimal("3.0"),
+            "default_hold_days": 90,
+        }
+        config = get_transaction_cost_config(conn)
+        assert config["max_total_cost_bps"] == Decimal("150")
+        assert config["default_hold_days"] == 90
+
+    def test_raises_when_row_missing(self) -> None:
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchone.return_value = None
+        with pytest.raises(TransactionCostConfigCorrupt):
+            get_transaction_cost_config(conn)
+
+
+class TestEstimateCost:
+    def test_spread_only_us_stock(self) -> None:
+        """USD instrument with no overnight or FX costs."""
+        result = estimate_cost(
+            spread_bps=Decimal("50"),
+            overnight_rate=Decimal("0"),
+            fx_markup_bps=Decimal("0"),
+            hold_days=90,
+            max_total_cost_bps=Decimal("150"),
+            min_return_vs_cost_ratio=Decimal("3.0"),
+            expected_return_pct=None,
+        )
+        assert result.spread_bps == Decimal("50")
+        assert result.total_entry_cost_bps == Decimal("50")
+        assert result.total_carry_cost_bps == Decimal("0")
+        assert result.total_cost_bps == Decimal("50")
+        assert result.is_cost_prohibitive is False
+
+    def test_spread_plus_overnight(self) -> None:
+        """CFD-like instrument with overnight fees."""
+        result = estimate_cost(
+            spread_bps=Decimal("50"),
+            overnight_rate=Decimal("1.5"),
+            fx_markup_bps=Decimal("0"),
+            hold_days=90,
+            max_total_cost_bps=Decimal("150"),
+            min_return_vs_cost_ratio=Decimal("3.0"),
+            expected_return_pct=None,
+        )
+        assert result.overnight_bps_per_day == Decimal("1.5")
+        assert result.total_carry_cost_bps == Decimal("135")
+        assert result.total_cost_bps == Decimal("185")
+        assert result.is_cost_prohibitive is True
+
+    def test_spread_plus_fx(self) -> None:
+        """Non-USD instrument with FX markup."""
+        result = estimate_cost(
+            spread_bps=Decimal("30"),
+            overnight_rate=Decimal("0"),
+            fx_markup_bps=Decimal("50"),
+            hold_days=90,
+            max_total_cost_bps=Decimal("200"),
+            min_return_vs_cost_ratio=Decimal("3.0"),
+            expected_return_pct=None,
+        )
+        assert result.fx_markup_bps == Decimal("50")
+        assert result.total_entry_cost_bps == Decimal("130")
+        assert result.total_cost_bps == Decimal("130")
+        assert result.is_cost_prohibitive is False
+
+    def test_cost_prohibitive_by_ratio(self) -> None:
+        """Cost is below threshold but return/cost ratio is too low."""
+        result = estimate_cost(
+            spread_bps=Decimal("80"),
+            overnight_rate=Decimal("0"),
+            fx_markup_bps=Decimal("0"),
+            hold_days=90,
+            max_total_cost_bps=Decimal("150"),
+            min_return_vs_cost_ratio=Decimal("3.0"),
+            expected_return_pct=Decimal("2.0"),
+        )
+        assert result.is_cost_prohibitive is True
+        assert "ratio" in (result.prohibitive_reason or "").lower()
+
+    def test_no_return_estimate_skips_ratio_check(self) -> None:
+        """When expected_return_pct is None, only absolute threshold applies."""
+        result = estimate_cost(
+            spread_bps=Decimal("80"),
+            overnight_rate=Decimal("0"),
+            fx_markup_bps=Decimal("0"),
+            hold_days=90,
+            max_total_cost_bps=Decimal("150"),
+            min_return_vs_cost_ratio=Decimal("3.0"),
+            expected_return_pct=None,
+        )
+        assert result.is_cost_prohibitive is False
+
+    def test_zero_spread_passes(self) -> None:
+        """Commission-free trade with zero spread (unlikely but safe)."""
+        result = estimate_cost(
+            spread_bps=Decimal("0"),
+            overnight_rate=Decimal("0"),
+            fx_markup_bps=Decimal("0"),
+            hold_days=90,
+            max_total_cost_bps=Decimal("150"),
+            min_return_vs_cost_ratio=Decimal("3.0"),
+            expected_return_pct=None,
+        )
+        assert result.total_cost_bps == Decimal("0")
+        assert result.is_cost_prohibitive is False

--- a/tests/test_transaction_cost.py
+++ b/tests/test_transaction_cost.py
@@ -233,6 +233,39 @@ class TestRecordEstimatedCost:
 
         assert isinstance(params["cost_breakdown"], Jsonb)
 
+    def test_fx_bps_stored_as_round_trip(self) -> None:
+        """estimated_fx_bps must store the round-trip FX cost (markup × 2)."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        estimate = CostEstimate(
+            spread_bps=Decimal("30"),
+            overnight_bps_per_day=Decimal("0"),
+            fx_markup_bps=Decimal("50"),
+            estimated_hold_days=90,
+            total_entry_cost_bps=Decimal("130"),  # 30 + 50 * 2
+            total_carry_cost_bps=Decimal("0"),
+            total_cost_bps=Decimal("130"),
+            is_cost_prohibitive=False,
+            prohibitive_reason=None,
+        )
+        record_estimated_cost(
+            conn,
+            order_id=1,
+            recommendation_id=10,
+            instrument_id=100,
+            estimate=estimate,
+        )
+        params = cursor.execute.call_args[0][1]
+        # Components must sum to total: spread + fx_roundtrip + carry = total
+        assert params["estimated_fx_bps"] == Decimal("100")  # 50 * 2
+        assert (
+            params["estimated_spread_bps"] + params["estimated_fx_bps"] + params["estimated_carry_bps"]
+            == params["estimated_total_bps"]
+        )
+
 
 class TestRecordActualCost:
     def test_updates_actual_columns(self) -> None:

--- a/tests/test_transaction_cost.py
+++ b/tests/test_transaction_cost.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from decimal import Decimal
 from unittest.mock import MagicMock
 
@@ -15,7 +16,10 @@ from app.services.transaction_cost import (
     load_instrument_cost,
     record_actual_cost,
     record_estimated_cost,
+    update_transaction_cost_config,
 )
+
+_NOW = datetime(2026, 4, 16, 12, 0, 0, tzinfo=UTC)
 
 
 class TestGetTransactionCostConfig:
@@ -228,3 +232,54 @@ class TestRecordActualCost:
         assert "UPDATE trade_cost_record" in sql
         params = cursor.execute.call_args[0][1]
         assert params["actual_spread_bps"] == Decimal("48")
+
+
+class TestUpdateTransactionCostConfig:
+    def test_updates_provided_fields(self) -> None:
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchone.return_value = {
+            "max_total_cost_bps": Decimal("200"),
+            "min_return_vs_cost_ratio": Decimal("3.0"),
+            "default_hold_days": 90,
+            "updated_at": _NOW,
+            "updated_by": "operator",
+            "reason": "adjusted threshold",
+        }
+        result = update_transaction_cost_config(
+            conn,
+            max_total_cost_bps=Decimal("200"),
+            updated_by="operator",
+            reason="adjusted threshold",
+        )
+        assert result["max_total_cost_bps"] == Decimal("200")
+        cursor.execute.assert_called_once()
+        query = cursor.execute.call_args[0][0]
+        assert "max_total_cost_bps" in str(query)
+
+    def test_raises_when_row_missing(self) -> None:
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchone.return_value = None
+        with pytest.raises(TransactionCostConfigCorrupt):
+            update_transaction_cost_config(
+                conn,
+                max_total_cost_bps=Decimal("200"),
+                updated_by="operator",
+                reason="test",
+            )
+
+
+class TestCostConfigAPI:
+    def test_cost_config_router_exists(self) -> None:
+        """The cost config endpoints should be registered."""
+        from fastapi.routing import APIRoute
+
+        from app.api.budget import router
+
+        paths = [r.path for r in router.routes if isinstance(r, APIRoute)]
+        assert any("/cost-config" in p for p in paths)

--- a/tests/test_transaction_cost.py
+++ b/tests/test_transaction_cost.py
@@ -11,6 +11,7 @@ from app.services.transaction_cost import (
     TransactionCostConfigCorrupt,
     estimate_cost,
     get_transaction_cost_config,
+    load_instrument_cost,
 )
 
 
@@ -129,3 +130,46 @@ class TestEstimateCost:
         )
         assert result.total_cost_bps == Decimal("0")
         assert result.is_cost_prohibitive is False
+
+
+class TestLoadInstrumentCost:
+    def test_returns_cost_model_row_when_exists(self) -> None:
+        """Active cost_model row is preferred over computed spread."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchone.return_value = {
+            "spread_bps": Decimal("45.5"),
+            "overnight_rate": Decimal("1.2"),
+            "fx_pair": "GBP/USD",
+            "fx_markup_bps": Decimal("50"),
+        }
+        result = load_instrument_cost(conn, instrument_id=123)
+        assert result is not None
+        assert result["spread_bps"] == Decimal("45.5")
+        assert result["overnight_rate"] == Decimal("1.2")
+        assert result["fx_pair"] == "GBP/USD"
+
+    def test_returns_none_when_no_cost_model(self) -> None:
+        """No cost_model row — caller should fall back to quote spread."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchone.return_value = None
+        result = load_instrument_cost(conn, instrument_id=123)
+        assert result is None
+
+
+class TestComputeSpreadFromQuote:
+    def test_computes_bps_from_spread_pct(self) -> None:
+        """spread_pct is in percent; convert to bps (* 100)."""
+        from app.services.transaction_cost import spread_pct_to_bps
+
+        assert spread_pct_to_bps(Decimal("0.45")) == Decimal("45")
+
+    def test_none_returns_none(self) -> None:
+        from app.services.transaction_cost import spread_pct_to_bps
+
+        assert spread_pct_to_bps(None) is None

--- a/tests/test_transaction_cost.py
+++ b/tests/test_transaction_cost.py
@@ -139,6 +139,21 @@ class TestEstimateCost:
         assert result.total_cost_bps == Decimal("0")
         assert result.is_cost_prohibitive is False
 
+    def test_zero_cost_with_return_skips_ratio_check(self) -> None:
+        """Zero-cost instrument with expected return skips ratio (division by zero guard)."""
+        result = estimate_cost(
+            spread_bps=Decimal("0"),
+            overnight_rate=Decimal("0"),
+            fx_markup_bps=Decimal("0"),
+            hold_days=90,
+            max_total_cost_bps=Decimal("150"),
+            min_return_vs_cost_ratio=Decimal("3.0"),
+            expected_return_pct=Decimal("10.0"),
+        )
+        assert result.total_cost_bps == Decimal("0")
+        assert result.is_cost_prohibitive is False
+        assert result.prohibitive_reason is None
+
 
 class TestLoadInstrumentCost:
     def test_returns_cost_model_row_when_exists(self) -> None:
@@ -213,6 +228,10 @@ class TestRecordEstimatedCost:
         assert "INSERT INTO trade_cost_record" in sql
         params = cursor.execute.call_args[0][1]
         assert params["estimated_total_bps"] == Decimal("50")
+        # cost_breakdown must be a Jsonb instance, not a raw dict
+        from psycopg.types.json import Jsonb
+
+        assert isinstance(params["cost_breakdown"], Jsonb)
 
 
 class TestRecordActualCost:

--- a/tests/test_transaction_cost.py
+++ b/tests/test_transaction_cost.py
@@ -8,10 +8,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.services.transaction_cost import (
+    CostEstimate,
     TransactionCostConfigCorrupt,
     estimate_cost,
     get_transaction_cost_config,
     load_instrument_cost,
+    record_actual_cost,
+    record_estimated_cost,
 )
 
 
@@ -173,3 +176,55 @@ class TestComputeSpreadFromQuote:
         from app.services.transaction_cost import spread_pct_to_bps
 
         assert spread_pct_to_bps(None) is None
+
+
+class TestRecordEstimatedCost:
+    def test_inserts_cost_record(self) -> None:
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        estimate = CostEstimate(
+            spread_bps=Decimal("50"),
+            overnight_bps_per_day=Decimal("0"),
+            fx_markup_bps=Decimal("0"),
+            estimated_hold_days=90,
+            total_entry_cost_bps=Decimal("50"),
+            total_carry_cost_bps=Decimal("0"),
+            total_cost_bps=Decimal("50"),
+            is_cost_prohibitive=False,
+            prohibitive_reason=None,
+        )
+        record_estimated_cost(
+            conn,
+            order_id=1,
+            recommendation_id=10,
+            instrument_id=100,
+            estimate=estimate,
+        )
+        cursor.execute.assert_called_once()
+        sql = cursor.execute.call_args[0][0]
+        assert "INSERT INTO trade_cost_record" in sql
+        params = cursor.execute.call_args[0][1]
+        assert params["estimated_total_bps"] == Decimal("50")
+
+
+class TestRecordActualCost:
+    def test_updates_actual_columns(self) -> None:
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        record_actual_cost(
+            conn,
+            order_id=1,
+            actual_spread_bps=Decimal("48"),
+            actual_total_bps=Decimal("48"),
+        )
+        cursor.execute.assert_called_once()
+        sql = cursor.execute.call_args[0][0]
+        assert "UPDATE trade_cost_record" in sql
+        params = cursor.execute.call_args[0][1]
+        assert params["actual_spread_bps"] == Decimal("48")

--- a/tests/test_transaction_cost.py
+++ b/tests/test_transaction_cost.py
@@ -16,6 +16,7 @@ from app.services.transaction_cost import (
     load_instrument_cost,
     record_actual_cost,
     record_estimated_cost,
+    seed_cost_models_from_quotes,
     update_transaction_cost_config,
 )
 
@@ -272,6 +273,79 @@ class TestUpdateTransactionCostConfig:
                 updated_by="operator",
                 reason="test",
             )
+
+
+class TestSeedCostModels:
+    def test_creates_cost_model_for_instrument_with_spread(self) -> None:
+        """Instruments with valid spread_pct get cost_model rows created."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = [
+            {"instrument_id": 1, "spread_pct": Decimal("0.30"), "currency": "USD"},
+            {"instrument_id": 2, "spread_pct": Decimal("0.50"), "currency": "GBP"},
+        ]
+        result = seed_cost_models_from_quotes(conn)
+        assert result["processed"] == 2
+        assert result["skipped"] == 0
+
+    def test_skips_instruments_without_spread(self) -> None:
+        """Instruments where spread_pct is None are skipped."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = [
+            {"instrument_id": 1, "spread_pct": None, "currency": "USD"},
+        ]
+        result = seed_cost_models_from_quotes(conn)
+        assert result["processed"] == 0
+        assert result["skipped"] == 1
+
+    def test_empty_universe_returns_zero(self) -> None:
+        """No instruments → processed=0, skipped=0."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = []
+        result = seed_cost_models_from_quotes(conn)
+        assert result["processed"] == 0
+        assert result["skipped"] == 0
+
+    def test_usd_instrument_gets_zero_fx_markup(self) -> None:
+        """USD instruments should have fx_markup_bps=0 and no fx_pair."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = [
+            {"instrument_id": 1, "spread_pct": Decimal("0.30"), "currency": "USD"},
+        ]
+        seed_cost_models_from_quotes(conn)
+        # Find the INSERT call (second execute call on the cursor)
+        insert_calls = [c for c in cursor.execute.call_args_list if "INSERT INTO cost_model" in str(c)]
+        assert len(insert_calls) == 1
+        params = insert_calls[0][0][1]
+        assert params["fx_markup_bps"] == Decimal("0")
+        assert params["fx_pair"] is None
+
+    def test_non_usd_instrument_gets_fx_markup(self) -> None:
+        """Non-USD instruments should have fx_markup_bps=50 and fx_pair set."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = [
+            {"instrument_id": 2, "spread_pct": Decimal("0.50"), "currency": "GBP"},
+        ]
+        seed_cost_models_from_quotes(conn)
+        insert_calls = [c for c in cursor.execute.call_args_list if "INSERT INTO cost_model" in str(c)]
+        assert len(insert_calls) == 1
+        params = insert_calls[0][0][1]
+        assert params["fx_markup_bps"] == Decimal("50")
+        assert params["fx_pair"] == "GBP/USD"
 
 
 class TestCostConfigAPI:


### PR DESCRIPTION
## What changed

Adds a full per-instrument transaction cost model that estimates spread, overnight carry, and FX conversion costs for proposed trades. The execution guard uses these estimates to reject cost-prohibitive trades before they reach the broker.

**New files:**
- `sql/031_transaction_cost_model.sql` — migration creating `cost_model`, `transaction_cost_config`, and `trade_cost_record` tables
- `app/services/transaction_cost.py` — cost estimation service: config loader, `CostEstimate` dataclass, `estimate_cost()`, `load_instrument_cost()`, `spread_pct_to_bps()`, `record_estimated_cost()`, `record_actual_cost()`, `update_transaction_cost_config()`, `seed_cost_models_from_quotes()`
- `tests/test_transaction_cost.py` — 23 tests covering all service functions

**Modified files:**
- `app/services/execution_guard.py` — new `transaction_cost_prohibitive` rule for BUY/ADD actions, slotted between spread and budget checks
- `app/services/order_client.py` — demo mode fills BUY at ask / EXIT at bid with half-spread fees; cost recording wired into `execute_order`
- `app/api/budget.py` — `GET /budget/cost-config` and `PATCH /budget/cost-config` endpoints
- `app/workers/scheduler.py` — daily `seed_cost_models` job to refresh cost_model rows from current quote spreads
- `app/jobs/runtime.py` — runtime wiring for the seed job
- `tests/test_execution_guard.py` — 10 new tests (cost rule + integration)
- `tests/test_order_client.py` — 7 new tests (spread fees + cost recording)

## Why

Issue #154. The execution guard previously had no way to evaluate whether a trade's transaction costs were acceptable relative to its expected return. This meant a wide-spread or high-FX-cost instrument could pass all checks and get executed at unfavourable terms.

The cost model provides:
1. **Pre-trade estimation** — spread + overnight carry + FX markup → total cost in bps
2. **Absolute threshold** — reject trades where total cost exceeds `max_total_cost_bps`
3. **Return/cost ratio** — reject trades where expected return doesn't justify the cost
4. **Post-trade reconciliation** — compare estimated vs actual costs for monitoring
5. **Automated seeding** — daily job refreshes cost_model rows from live quote spreads

## Schema / migration impact

Migration `031_transaction_cost_model.sql` creates:
- `cost_model` — per-instrument fee schedule with temporal validity (`valid_from`/`valid_to`). Seeded from quote spreads.
- `transaction_cost_config` — singleton config row (`id BOOLEAN PRIMARY KEY DEFAULT TRUE`) with `max_total_cost_bps`, `min_return_vs_cost_ratio`, `default_hold_days`. Seeded with defaults via `INSERT ON CONFLICT DO NOTHING`.
- `trade_cost_record` — links estimated costs (at guard time) to actual costs (at fill time) per order.

No data backfill needed. Config row auto-seeds on migration.

## Invariants checked

- **Singleton config pattern**: `id BOOLEAN DEFAULT TRUE CHECK (id = TRUE)` ensures exactly one config row. Missing row raises `TransactionCostConfigCorrupt` (fail closed).
- **Temporal cost model**: `valid_to IS NULL` marks the active row. `seed_cost_models_from_quotes` closes old rows before inserting new ones within a per-instrument savepoint.
- **No external I/O inside transactions**: All DB writes are in service functions that receive `conn` but never commit.
- **Parameterised SQL throughout**: `update_transaction_cost_config` uses `psycopg.sql.Composable` for dynamic SET clause — no string interpolation.
- **Jsonb for JSONB columns**: `record_estimated_cost` wraps breakdown dict in `psycopg.types.json.Jsonb`.
- **Rowcount check on UPDATE**: `record_actual_cost` logs warning when no estimated-cost row exists (best-effort pattern).
- **Action-specific guard rules**: Cost check runs for BUY/ADD only — EXIT is not blocked by cost concerns (settled decision).
- **Fail-closed on corrupt config**: Execution guard catches `TransactionCostConfigCorrupt` and fails the BUY/ADD.

## Failure paths considered

- Config row missing → `TransactionCostConfigCorrupt` raised → guard fails closed
- No cost_model row for instrument → falls back to quote `spread_pct` → if that is also None, raises RuntimeError (fails closed)
- Zero total cost with expected return → skips ratio check (division-by-zero guard)
- No expected return → skips ratio check, applies absolute threshold only
- `record_actual_cost` finds no estimated row → logs warning, does not raise
- Quote missing bid/ask in demo mode → falls back to last price ± 0 spread

## Tests added

**`tests/test_transaction_cost.py` (23 tests):**
- Config loading: happy path + missing row raises
- `estimate_cost`: spread-only, spread+overnight (prohibitive), spread+FX, prohibitive-by-ratio, no-return skips ratio, zero-spread, zero-cost-with-return
- `load_instrument_cost`: row exists, row missing
- `spread_pct_to_bps`: conversion + None passthrough
- `record_estimated_cost`: INSERT with Jsonb type assertion
- `record_actual_cost`: UPDATE call verification
- `update_transaction_cost_config`: partial update + missing row raises
- `seed_cost_models_from_quotes`: with spread, without spread (skipped), empty universe, USD zero FX, non-USD FX markup
- API router registration check

**`tests/test_execution_guard.py` (10 new tests):**
- Cost rule: passes with low cost, fails when prohibitive, skips for EXIT, uses quote spread when no cost_model, fails closed on config corrupt, verifies FX markup application, integration test for cost_config_corrupt

**`tests/test_order_client.py` (7 new tests):**
- Synthetic fill: BUY at ask, EXIT at bid, half-spread fee calculation
- Cost recording: estimated cost persisted after BUY, estimated cost persisted after EXIT, config corrupt caught gracefully

## Conscious tradeoffs

- **Overnight rate is 0 for all instruments in v1**: Real stocks on eToro don't incur overnight fees. CFD support deferred.
- **FX markup is a flat 50 bps for non-USD**: Matches eToro's typical FX conversion fee. Per-pair calibration deferred.
- **Cost seeding uses spread_pct from quotes, not historical data**: Good enough for v1 demo; historical spread analysis deferred.
- **No cost_model UI for manual editing**: API endpoints exist for programmatic access; operator UI deferred.
- **record_actual_cost does not raise on missing estimated row**: The estimated record is best-effort; its absence is expected when `TransactionCostConfigCorrupt` was caught at order time.

## Tech debt opened

None — all requirements from #154 are implemented. FX calibration and CFD overnight rates are out of scope for v1 per risk posture.

## Settled decisions preserved

- **Execution guard action-specific behaviour**: Cost check is BUY/ADD only; EXIT not blocked
- **Guard auditability**: Cost rule result stored in `evidence_json` via existing per-rule framework
- **Provider boundary**: All domain logic in service layer, not providers

## Prevention log entries addressed

- **Single-row UPDATE silent no-op (#70)**: `record_actual_cost` checks `rowcount == 0` and logs warning
- **Read-then-write outside transaction (#66)**: `seed_cost_models_from_quotes` wraps per-instrument UPDATE+INSERT in `conn.transaction()` savepoint
- **Missing data on hard-rule path (#45)**: `_check_transaction_cost` fails closed on `TransactionCostConfigCorrupt`

Closes #154