### PR TITLE
fix(#252): break scoring prerequisite bootstrap deadlock

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -246,6 +246,37 @@ def _has_scores(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     return (False, "no scores rows")
 
 
+def _has_scoreable_instruments(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if at least one tradable instrument has data to score.
+
+    Mirrors the eligibility query in compute_rankings (scoring.py) so the
+    prerequisite passes if and only if scoring would find at least one
+    instrument to score.  This replaces _has_scores for
+    morning_candidate_review to break the bootstrap deadlock where
+    scoring cannot run because no scores exist yet.
+    """
+    if _exists(
+        conn,
+        psycopg.sql.SQL(
+            """
+            SELECT EXISTS(
+                SELECT 1
+                FROM instruments i
+                JOIN coverage c ON c.instrument_id = i.instrument_id
+                WHERE i.is_tradable = TRUE
+                  AND (
+                      EXISTS (SELECT 1 FROM theses t WHERE t.instrument_id = i.instrument_id)
+                      OR EXISTS (SELECT 1 FROM fundamentals_snapshot f WHERE f.instrument_id = i.instrument_id)
+                      OR EXISTS (SELECT 1 FROM price_daily p WHERE p.instrument_id = i.instrument_id)
+                  )
+            )
+            """
+        ),
+    ):
+        return (True, "")
+    return (False, "no scoreable instruments")
+
+
 def _has_actionable_recommendations(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     """True if at least one proposed or approved recommendation exists."""
     if _exists(
@@ -365,7 +396,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         name=JOB_MORNING_CANDIDATE_REVIEW,
         description="Re-score, rank, and generate trade recommendations for Tier 1 candidates.",
         cadence=Cadence.daily(hour=6, minute=0),
-        prerequisite=_has_scores,
+        prerequisite=_has_scoreable_instruments,
     ),
     ScheduledJob(
         name=JOB_EXECUTE_APPROVED_ORDERS,

--- a/tests/test_scheduler_prerequisites.py
+++ b/tests/test_scheduler_prerequisites.py
@@ -51,7 +51,11 @@ class TestHasScoreableInstruments:
 
         cursor = conn.cursor.return_value.__enter__.return_value
         sql_arg = cursor.execute.call_args[0][0]
-        sql_text = sql_arg.as_string(conn)
+        # Access the raw template string from psycopg.sql.SQL — _obj is
+        # the underlying str.  as_string() requires a real connection so
+        # it returns a MagicMock on a mock conn (vacuous assertions).
+        sql_text = sql_arg._obj
+        assert isinstance(sql_text, str), "sql_arg._obj should be a plain string"
 
         # Must join coverage and check for at least one data source
         assert "coverage" in sql_text

--- a/tests/test_scheduler_prerequisites.py
+++ b/tests/test_scheduler_prerequisites.py
@@ -1,0 +1,61 @@
+"""Unit tests for scheduler prerequisite functions.
+
+Covers _has_scoreable_instruments which replaced _has_scores as the
+prerequisite for morning_candidate_review (fix for #252 bootstrap
+deadlock).
+
+No live database — uses a mock connection with canned query results.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.workers.scheduler import _has_scoreable_instruments
+
+
+def _mock_conn(exists_result: bool) -> MagicMock:
+    """Build a mock psycopg Connection that returns *exists_result* for
+    a ``SELECT EXISTS(...)`` query."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.execute.return_value = cursor
+    cursor.fetchone.return_value = (exists_result,)
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=False)
+    conn.cursor.return_value = cursor
+    return conn
+
+
+class TestHasScoreableInstruments:
+    """Verify _has_scoreable_instruments prerequisite logic."""
+
+    def test_passes_when_scoreable_instruments_exist(self) -> None:
+        """Fundamentals exist, scores table empty — prerequisite should pass."""
+        conn = _mock_conn(exists_result=True)
+        result, reason = _has_scoreable_instruments(conn)
+        assert result is True
+        assert reason == ""
+
+    def test_fails_when_no_scoreable_instruments(self) -> None:
+        """No instruments with any data — prerequisite should fail."""
+        conn = _mock_conn(exists_result=False)
+        result, reason = _has_scoreable_instruments(conn)
+        assert result is False
+        assert reason == "no scoreable instruments"
+
+    def test_query_checks_instruments_with_data(self) -> None:
+        """Verify the SQL checks for theses, fundamentals, or price data."""
+        conn = _mock_conn(exists_result=True)
+        _has_scoreable_instruments(conn)
+
+        cursor = conn.cursor.return_value.__enter__.return_value
+        sql_arg = cursor.execute.call_args[0][0]
+        sql_text = sql_arg.as_string(conn)
+
+        # Must join coverage and check for at least one data source
+        assert "coverage" in sql_text
+        assert "is_tradable" in sql_text
+        assert "theses" in sql_text
+        assert "fundamentals_snapshot" in sql_text
+        assert "price_daily" in sql_text


### PR DESCRIPTION
## Summary

- `morning_candidate_review` used `_has_scores` as its prerequisite, but it is the only job that creates scores — classic bootstrap deadlock
- Replaced with `_has_scoreable_instruments` which mirrors the eligibility query in `compute_rankings` (scoring.py:1129-1137)
- Prerequisite now checks: tradable instruments with coverage + at least one of thesis/fundamentals/price data
- `_has_scores` retained for potential use by other jobs

## What changed

- `app/workers/scheduler.py`: new `_has_scoreable_instruments` prerequisite function; swapped on `morning_candidate_review` (line 399)
- `tests/test_scheduler_prerequisites.py`: 3 tests covering pass/fail/SQL content verification

## Security model

No security changes. Read-only prerequisite check, no new endpoints or auth changes.

## Tradeoffs

- Kept `_has_scores` rather than deleting it — other jobs or future prereqs may need it
- SQL in prerequisite mirrors `compute_rankings` eligibility query verbatim — single source of truth would be better long-term but not worth the abstraction for two call sites

## Settled decisions preserved

- **Scoring model style**: heuristic, explicit, auditable — unchanged
- **Penalty style**: additive v1 — unchanged

## Prevention log

No entries directly applicable. SQL uses `psycopg.sql.SQL` (no string interpolation).

## Test plan

- [x] `test_passes_when_scoreable_instruments_exist` — fundamentals exist, scores table empty
- [x] `test_fails_when_no_scoreable_instruments` — no instruments with data
- [x] `test_query_checks_instruments_with_data` — SQL references all three data tables
- [x] Full suite: 1587 passed, 1 skipped
- [x] ruff check, ruff format, pyright — all clean

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)