### PR TITLE
fix(#253): include T3 bootstrap batch in candle refresh

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -757,12 +757,19 @@ def daily_candle_refresh() -> None:
                 JOIN coverage c ON c.instrument_id = i.instrument_id
                 WHERE i.is_tradable = TRUE
                   AND c.coverage_tier IN (1, 2)
-                ORDER BY i.symbol
+                ORDER BY i.symbol, i.instrument_id
                 """
             ).fetchall()
 
             # T3: bootstrap batch — instruments with fundamentals but no
             # candle data yet, capped to avoid API rate limit pressure.
+            # NOT EXISTS(price_daily) is intentional: once an instrument
+            # has any candle data it drops out of the bootstrap pool.
+            # refresh_market_data fetches ~400 candles per instrument in
+            # a single API call, so a "partial" bootstrap still gives
+            # enough data for momentum scoring.  If the API call fails
+            # entirely, no rows are inserted and the instrument retries
+            # next run.
             t3_rows = conn.execute(
                 """
                 SELECT i.instrument_id, i.symbol
@@ -778,7 +785,7 @@ def daily_candle_refresh() -> None:
                       SELECT 1 FROM price_daily p
                       WHERE p.instrument_id = i.instrument_id
                   )
-                ORDER BY i.symbol
+                ORDER BY i.symbol, i.instrument_id
                 LIMIT %(limit)s
                 """,
                 {"limit": _T3_BOOTSTRAP_BATCH_SIZE},

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -715,12 +715,27 @@ def nightly_universe_sync() -> None:
             tracker.row_count = row_count
 
 
+_T3_BOOTSTRAP_BATCH_SIZE = 200
+"""Max T3 instruments to include in candle refresh for bootstrap scoring.
+
+Prevents hitting API rate limits while giving enough T3 instruments price
+data to enable T3→T2 promotion via the scoring/coverage pipeline.
+"""
+
+
 def daily_candle_refresh() -> None:
     """
-    Refresh quotes and candles for all active Tier 1/2 instruments.
+    Refresh candles for Tier 1/2 instruments and a bootstrap subset of
+    Tier 3 instruments that have fundamentals data.
 
-    Fetches up to 400 daily candles (enough for 1y return + buffer)
-    and the current quote for each covered instrument.
+    T1/T2: all covered instruments (uncapped).
+    T3: up to _T3_BOOTSTRAP_BATCH_SIZE instruments that already have a
+    fundamentals_snapshot row, ordered by symbol for determinism.  This
+    gives T3 instruments enough price data for momentum scoring, enabling
+    T3→T2 promotion via the weekly coverage review.
+
+    Fetches up to 400 daily candles per instrument (enough for 1y return
+    + buffer).  Quotes are skipped (owned by the hourly job).
 
     Runs daily at 22:00 UTC, after US market close.
     """
@@ -734,7 +749,8 @@ def daily_candle_refresh() -> None:
             EtoroMarketDataProvider(api_key=api_key, user_key=user_key, env=settings.etoro_env) as provider,
             psycopg.connect(settings.database_url) as conn,
         ):
-            rows = conn.execute(
+            # T1/T2: all covered instruments
+            tier12_rows = conn.execute(
                 """
                 SELECT i.instrument_id, i.symbol
                 FROM instruments i
@@ -745,12 +761,43 @@ def daily_candle_refresh() -> None:
                 """
             ).fetchall()
 
-            if not rows:
+            # T3: bootstrap batch — instruments with fundamentals but no
+            # candle data yet, capped to avoid API rate limit pressure.
+            t3_rows = conn.execute(
+                """
+                SELECT i.instrument_id, i.symbol
+                FROM instruments i
+                JOIN coverage c ON c.instrument_id = i.instrument_id
+                WHERE i.is_tradable = TRUE
+                  AND c.coverage_tier = 3
+                  AND EXISTS (
+                      SELECT 1 FROM fundamentals_snapshot f
+                      WHERE f.instrument_id = i.instrument_id
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM price_daily p
+                      WHERE p.instrument_id = i.instrument_id
+                  )
+                ORDER BY i.symbol
+                LIMIT %(limit)s
+                """,
+                {"limit": _T3_BOOTSTRAP_BATCH_SIZE},
+            ).fetchall()
+
+            all_rows = tier12_rows + t3_rows
+            if not all_rows:
                 logger.info("daily_candle_refresh: no covered instruments found, skipping")
                 tracker.row_count = 0
                 return
 
-            instruments = [(row[0], row[1]) for row in rows]
+            logger.info(
+                "daily_candle_refresh: %d T1/T2 + %d T3 bootstrap = %d instruments",
+                len(tier12_rows),
+                len(t3_rows),
+                len(all_rows),
+            )
+
+            instruments = [(row[0], row[1]) for row in all_rows]
             # skip_quotes=True: quote freshness is owned by the hourly
             # fx_rates_refresh job; daily candle job must not shadow
             # those fresher values with stale end-of-day data.

--- a/tests/test_daily_candle_refresh.py
+++ b/tests/test_daily_candle_refresh.py
@@ -1,0 +1,146 @@
+"""Unit tests for daily_candle_refresh T3 bootstrap logic.
+
+Verifies that the candle refresh includes a capped batch of T3
+instruments with fundamentals data alongside the full T1/T2 set.
+
+Fix for #253 — T3 instruments were excluded from candle refresh,
+creating a bootstrap deadlock where T3 had no price data and could
+not score high enough to promote.
+
+No live database or network calls — all dependencies are mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.workers.scheduler import _T3_BOOTSTRAP_BATCH_SIZE, daily_candle_refresh
+
+
+def _make_mock_conn(
+    tier12_rows: list[tuple[int, str]],
+    t3_rows: list[tuple[int, str]],
+) -> MagicMock:
+    """Mock connection that returns tier12_rows on first execute, t3_rows
+    on second."""
+    conn = MagicMock()
+    result1 = MagicMock()
+    result1.fetchall.return_value = tier12_rows
+    result2 = MagicMock()
+    result2.fetchall.return_value = t3_rows
+    conn.execute.side_effect = [result1, result2]
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+_PATCHES = {
+    "creds": "app.workers.scheduler._load_etoro_credentials",
+    "tracked": "app.workers.scheduler._tracked_job",
+    "provider_cls": "app.workers.scheduler.EtoroMarketDataProvider",
+    "connect": "app.workers.scheduler.psycopg.connect",
+    "refresh": "app.workers.scheduler.refresh_market_data",
+}
+
+
+class TestDailyCandleRefreshT3Bootstrap:
+    """Verify T3 bootstrap instruments are included in candle refresh."""
+
+    def _run(
+        self,
+        tier12_rows: list[tuple[int, str]],
+        t3_rows: list[tuple[int, str]],
+    ) -> MagicMock:
+        """Run daily_candle_refresh with mocked dependencies.
+
+        Returns the mock for refresh_market_data so callers can inspect
+        what instruments were passed.
+        """
+        mock_conn = _make_mock_conn(tier12_rows, t3_rows)
+        mock_provider = MagicMock()
+        mock_provider.__enter__ = MagicMock(return_value=mock_provider)
+        mock_provider.__exit__ = MagicMock(return_value=False)
+
+        mock_tracker = MagicMock()
+        mock_tracker.__enter__ = MagicMock(return_value=mock_tracker)
+        mock_tracker.__exit__ = MagicMock(return_value=False)
+
+        mock_summary = MagicMock()
+        mock_summary.candle_rows_upserted = 10
+        mock_summary.instruments_refreshed = len(tier12_rows) + len(t3_rows)
+        mock_summary.features_computed = 5
+        mock_summary.quotes_updated = 0
+        mock_summary.quotes_skipped = 0
+        mock_summary.spread_flags_set = 0
+
+        with (
+            patch(_PATCHES["creds"], return_value=("key", "ukey")),
+            patch(_PATCHES["tracked"], return_value=mock_tracker),
+            patch(_PATCHES["provider_cls"], return_value=mock_provider),
+            patch(_PATCHES["connect"], return_value=mock_conn),
+            patch(_PATCHES["refresh"], return_value=mock_summary) as mock_refresh,
+        ):
+            daily_candle_refresh()
+
+        return mock_refresh
+
+    def test_t3_instruments_with_fundamentals_included(self) -> None:
+        """T3 instruments with fundamentals data are passed to refresh."""
+        tier12 = [(1, "AAPL"), (2, "MSFT")]
+        t3_bootstrap = [(100, "XYZ"), (101, "ABC")]
+
+        mock_refresh = self._run(tier12, t3_bootstrap)
+
+        mock_refresh.assert_called_once()
+        instruments = mock_refresh.call_args[0][2]
+        assert instruments == [(1, "AAPL"), (2, "MSFT"), (100, "XYZ"), (101, "ABC")]
+
+    def test_skip_quotes_true(self) -> None:
+        """Candle refresh must pass skip_quotes=True per quote ownership rule."""
+        mock_refresh = self._run([(1, "AAPL")], [])
+        assert mock_refresh.call_args[1]["skip_quotes"] is True
+
+    def test_empty_t3_batch_still_refreshes_tier12(self) -> None:
+        """When no T3 instruments qualify, only T1/T2 are refreshed."""
+        tier12 = [(1, "AAPL")]
+        mock_refresh = self._run(tier12, [])
+
+        instruments = mock_refresh.call_args[0][2]
+        assert instruments == [(1, "AAPL")]
+
+    def test_no_instruments_skips_refresh(self) -> None:
+        """When both queries return empty, refresh is not called."""
+        mock_refresh = self._run([], [])
+        mock_refresh.assert_not_called()
+
+    def test_t3_query_uses_limit_param(self) -> None:
+        """Verify the T3 query passes _T3_BOOTSTRAP_BATCH_SIZE as limit."""
+        mock_conn = _make_mock_conn([(1, "AAPL")], [(100, "XYZ")])
+        mock_provider = MagicMock()
+        mock_provider.__enter__ = MagicMock(return_value=mock_provider)
+        mock_provider.__exit__ = MagicMock(return_value=False)
+        mock_tracker = MagicMock()
+        mock_tracker.__enter__ = MagicMock(return_value=mock_tracker)
+        mock_tracker.__exit__ = MagicMock(return_value=False)
+        mock_summary = MagicMock()
+        mock_summary.candle_rows_upserted = 1
+
+        with (
+            patch(_PATCHES["creds"], return_value=("key", "ukey")),
+            patch(_PATCHES["tracked"], return_value=mock_tracker),
+            patch(_PATCHES["provider_cls"], return_value=mock_provider),
+            patch(_PATCHES["connect"], return_value=mock_conn),
+            patch(_PATCHES["refresh"], return_value=mock_summary),
+        ):
+            daily_candle_refresh()
+
+        # Second execute call is the T3 query with limit param
+        t3_call = mock_conn.execute.call_args_list[1]
+        sql_text = t3_call[0][0]
+        params = t3_call[0][1]
+        assert "LIMIT" in sql_text
+        assert params == {"limit": _T3_BOOTSTRAP_BATCH_SIZE}
+
+    def test_bootstrap_batch_size_is_200(self) -> None:
+        """Sanity check the constant value."""
+        assert _T3_BOOTSTRAP_BATCH_SIZE == 200


### PR DESCRIPTION
## Summary

- `daily_candle_refresh` was gated to T1/T2 only, starving 12,352 T3 instruments of price data
- Added a capped T3 bootstrap query: up to 200 T3 instruments with fundamentals but no existing candles
- T1/T2 instruments remain uncapped; T3 batch is appended to the same refresh run
- `NOT EXISTS(price_daily)` ensures each T3 instrument is bootstrapped once — subsequent runs skip it

## What changed

- `app/workers/scheduler.py`: new `_T3_BOOTSTRAP_BATCH_SIZE = 200` constant; `daily_candle_refresh` now runs two queries (T1/T2 + T3 bootstrap) and combines results
- `tests/test_daily_candle_refresh.py`: 6 tests covering T3 inclusion, skip_quotes, empty states, limit param, batch size constant

## Security model

No security changes. Read-only query expansion, no new endpoints or auth changes. Same `skip_quotes=True` rule preserved per quote ownership contract.

## Tradeoffs

- **200 cap**: conservative to avoid API rate pressure. Each instrument fetches ~400 candle rows. 200 T3 instruments = ~80k API-fetched candle rows per run. Can be raised later.
- **`NOT EXISTS(price_daily)` filter**: instruments with any candle data are excluded from bootstrap. This means a T3 instrument with partial data won't be re-fetched. Acceptable — even one day of candles gives the momentum family something to work with.
- **Module constant, not Settings**: batch size is an internal tuning knob, not operator-facing. Keeps config surface small per eBull principles.

## Settled decisions preserved

- **Provider design rule**: providers stay thin — `refresh_market_data` owns orchestration
- **Scoring model style**: unchanged — giving T3 price data enables scoring but doesn't change the model

## Prevention log

- **Quote write ownership** (#211): `skip_quotes=True` preserved — daily job does not shadow hourly quotes
- **Calendar-day freshness** (#168): no new freshness checks added

## Test plan

- [x] `test_t3_instruments_with_fundamentals_included` — T3 rows appended to T1/T2
- [x] `test_skip_quotes_true` — quote ownership contract preserved
- [x] `test_empty_t3_batch_still_refreshes_tier12` — T3 empty doesn't break T1/T2
- [x] `test_no_instruments_skips_refresh` — both empty → no API calls
- [x] `test_t3_query_uses_limit_param` — SQL has LIMIT with correct batch size
- [x] `test_bootstrap_batch_size_is_200` — constant value sanity
- [x] Full suite: 1593 passed, 1 skipped
- [x] ruff check, ruff format, pyright — all clean

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)