### PR TITLE
feat(#260): Phase 4 — flip ORCHESTRATOR_ENABLED + swap cron triggers

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -112,7 +112,7 @@ class JobOverviewResponse(BaseModel):
     name: str
     description: str
     cadence: str
-    cadence_kind: Literal["hourly", "daily", "weekly", "monthly"]
+    cadence_kind: Literal["every_n_minutes", "hourly", "daily", "weekly", "monthly"]
     next_run_time: datetime
     next_run_time_source: Literal["live", "declared"]
     last_status: Literal["running", "success", "failure", "skipped"] | None

--- a/app/config.py
+++ b/app/config.py
@@ -54,13 +54,14 @@ class Settings(BaseSettings):
     service_token: str | None = None
 
     # --- Sync orchestrator (issue #260) ---------------------------------
-    # Phase 1 ships orchestrator infrastructure behind this flag. When
-    # False (default), POST /sync returns 503 "sync orchestrator
-    # disabled (Phase 1)" and no orchestrator-triggered runs occur —
-    # the scheduler continues its current behaviour unchanged.
-    # Phase 4 flips this to True and removes the 12 cron triggers
-    # whose JOB_TO_LAYERS entries are non-empty.
-    orchestrator_enabled: bool = False
+    # Phase 4 (this flip): activates the orchestrator. POST /sync now
+    # returns 202 + plan; the 12 legacy cron triggers mapping to
+    # non-empty JOB_TO_LAYERS entries have been removed and replaced
+    # with two orchestrator triggers (FULL @ 03:00 UTC and
+    # HIGH_FREQUENCY @ */5min).
+    # The 13 underlying job functions stay in _INVOKERS so
+    # POST /jobs/{name}/run continues to work via the adapter.
+    orchestrator_enabled: bool = True
 
     # --- Browser session settings (issue #98) ---------------------------
     # Both timeouts are enforced server-side in get_active_session. The

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -68,6 +68,8 @@ from app.workers.scheduler import (
     JOB_MONTHLY_REPORT,
     JOB_MORNING_CANDIDATE_REVIEW,
     JOB_NIGHTLY_UNIVERSE_SYNC,
+    JOB_ORCHESTRATOR_FULL_SYNC,
+    JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
     JOB_RETRY_DEFERRED,
     JOB_SEED_COST_MODELS,
     JOB_WEEKLY_COVERAGE_REVIEW,
@@ -91,6 +93,8 @@ from app.workers.scheduler import (
     monthly_report,
     morning_candidate_review,
     nightly_universe_sync,
+    orchestrator_full_sync,
+    orchestrator_high_frequency_sync,
     retry_deferred_recommendations_job,
     seed_cost_models,
     weekly_coverage_review,
@@ -140,6 +144,8 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_SEED_COST_MODELS: seed_cost_models,
     JOB_WEEKLY_REPORT: weekly_report,
     JOB_MONTHLY_REPORT: monthly_report,
+    JOB_ORCHESTRATOR_FULL_SYNC: orchestrator_full_sync,
+    JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC: orchestrator_high_frequency_sync,
 }
 
 
@@ -163,6 +169,8 @@ def _trigger_for(cadence: Cadence) -> CronTrigger:
     so a future cadence kind that is not handled raises ``ValueError``
     rather than silently picking a wrong default.
     """
+    if cadence.kind == "every_n_minutes":
+        return CronTrigger(minute=f"*/{cadence.interval_minutes}", timezone="UTC")
     if cadence.kind == "hourly":
         return CronTrigger(minute=cadence.minute, timezone="UTC")
     if cadence.kind == "daily":

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -93,7 +93,7 @@ logger = logging.getLogger(__name__)
 # next-fire-time from APScheduler; ``compute_next_run`` is retained as
 # a pure utility for catch-up-on-boot and tests.
 
-CadenceKind = Literal["hourly", "daily", "weekly", "monthly"]
+CadenceKind = Literal["every_n_minutes", "hourly", "daily", "weekly", "monthly"]
 
 
 @dataclass(frozen=True)
@@ -110,6 +110,17 @@ class Cadence:
     hour: int = 0
     weekday: int = 0  # 0=Mon (matches datetime.weekday())
     day: int = 0  # 1..28 for monthly cadence
+    interval_minutes: int = 0  # every_n_minutes cadence (e.g. 5 for every 5 min)
+
+    @classmethod
+    def every_n_minutes(cls, *, interval: int) -> Cadence:
+        """Cron-style sub-hourly cadence — e.g. interval=5 fires at
+        :00, :05, :10, … every hour. Used by orchestrator_high_frequency_sync."""
+        if interval < 1 or interval > 30:
+            raise ValueError(f"every_n_minutes interval must be 1..30, got {interval}")
+        if 60 % interval != 0:
+            raise ValueError(f"every_n_minutes interval must divide 60 evenly, got {interval}")
+        return cls(kind="every_n_minutes", interval_minutes=interval)
 
     @classmethod
     def hourly(cls, *, minute: int = 0) -> Cadence:
@@ -148,6 +159,8 @@ class Cadence:
     @property
     def label(self) -> str:
         """Human-readable label for API responses."""
+        if self.kind == "every_n_minutes":
+            return f"every {self.interval_minutes}m"
         if self.kind == "hourly":
             return f"hourly at :{self.minute:02d} UTC"
         if self.kind == "daily":
@@ -209,6 +222,8 @@ JOB_WEEKLY_REPORT = "weekly_report"
 JOB_MONTHLY_REPORT = "monthly_report"
 JOB_SEED_COST_MODELS = "seed_cost_models"
 JOB_DAILY_FINANCIAL_FACTS = "daily_financial_facts"
+JOB_ORCHESTRATOR_FULL_SYNC = "orchestrator_full_sync"
+JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC = "orchestrator_high_frequency_sync"
 
 
 # ---------------------------------------------------------------------------
@@ -353,63 +368,31 @@ def _has_positions_or_attributions(conn: psycopg.Connection[Any]) -> Prerequisit
 # until APScheduler is wired — the values are stable enough for operator UI
 # planning but should not be treated as the live truth. See module docstring.
 SCHEDULED_JOBS: list[ScheduledJob] = [
-    # -- Always-on: data infrastructure, no prerequisites ----------------
-    # nightly_universe_sync is on-demand only (eToro's instrument list
-    # barely changes).  It stays in _INVOKERS for "Run now" in the Admin UI.
+    # -- Orchestrator triggers (Phase 4 — replaces 12 legacy cron jobs) --
+    # Single daily full-DAG sync at 03:00 UTC. The orchestrator plans
+    # which layers are stale and refreshes only those, in topological
+    # order. Replaces the 12 removed legacy entries that mapped to
+    # non-empty JOB_TO_LAYERS values (see spec §4.5). The 13th in-DAG
+    # adapter is nightly_universe_sync, which was already on-demand
+    # only before Phase 4 — it remains in _INVOKERS for the Admin UI.
     ScheduledJob(
-        name=JOB_DAILY_CIK_REFRESH,
-        description="Refresh the SEC ticker→CIK mapping in external_identifiers.",
+        name=JOB_ORCHESTRATOR_FULL_SYNC,
+        description="Orchestrator full sync — walks the DAG and refreshes stale layers.",
         cadence=Cadence.daily(hour=3, minute=0),
     ),
-    # -- Pipeline: skip when upstream data is absent ---------------------
+    # Every-5-minutes refresh of independent high-frequency layers
+    # (portfolio_sync + fx_rates). The orchestrator's partial unique
+    # index gate ensures this cannot overlap with a still-running FULL
+    # sync — the wrapper catches SyncAlreadyRunning and logs.
     ScheduledJob(
-        name=JOB_DAILY_CANDLE_REFRESH,
-        description="Fetch daily candles for all active Tier 1/2 instruments after US market close.",
-        cadence=Cadence.daily(hour=22, minute=0),
-        prerequisite=_has_coverage_tier12,
+        name=JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
+        description="Orchestrator high-frequency sync — portfolio_sync + fx_rates every 5 minutes.",
+        cadence=Cadence.every_n_minutes(interval=5),
+        catch_up_on_boot=False,
     ),
-    ScheduledJob(
-        name=JOB_FX_RATES_REFRESH,
-        description="Refresh live FX rates (Frankfurter primary, eToro secondary).",
-        cadence=Cadence.hourly(minute=0),
-        # No prerequisite: Frankfurter FX is independent of instrument coverage.
-        # The eToro quote refresh inside the job self-guards on coverage.
-    ),
-    ScheduledJob(
-        name=JOB_DAILY_RESEARCH_REFRESH,
-        description="Refresh fundamentals and filings for all tradable instruments.",
-        cadence=Cadence.daily(hour=3, minute=30),
-        prerequisite=_has_any_coverage,
-    ),
-    ScheduledJob(
-        name=JOB_DAILY_FINANCIAL_FACTS,
-        description="Fetch expanded SEC XBRL facts and normalize into financial periods.",
-        cadence=Cadence.daily(hour=3, minute=45),
-        prerequisite=_has_any_coverage,
-    ),
-    ScheduledJob(
-        name=JOB_DAILY_NEWS_REFRESH,
-        description="Fetch, deduplicate, and score news events for active Tier 1/2 instruments.",
-        cadence=Cadence.daily(hour=4, minute=0),
-        prerequisite=_has_coverage_tier12,
-    ),
-    ScheduledJob(
-        name=JOB_DAILY_THESIS_REFRESH,
-        description="Regenerate theses for stale Tier 1/2 instruments.",
-        cadence=Cadence.daily(hour=4, minute=30),
-        prerequisite=_has_coverage_tier12,
-    ),
-    ScheduledJob(
-        name=JOB_DAILY_PORTFOLIO_SYNC,
-        description="Sync positions and cash from eToro broker to local state.",
-        cadence=Cadence.daily(hour=5, minute=30),
-    ),
-    ScheduledJob(
-        name=JOB_MORNING_CANDIDATE_REVIEW,
-        description="Re-score, rank, and generate trade recommendations for Tier 1 candidates.",
-        cadence=Cadence.daily(hour=6, minute=0),
-        prerequisite=_has_scoreable_instruments,
-    ),
+    # -- Outside-DAG jobs (5 kept on their own cron triggers) ------------
+    # These have empty JOB_TO_LAYERS entries and remain independently
+    # scheduled; they do not participate in the orchestrator DAG.
     ScheduledJob(
         name=JOB_EXECUTE_APPROVED_ORDERS,
         description="Guard and execute actionable trade recommendations.",
@@ -446,26 +429,6 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         prerequisite=_has_attributions,
         catch_up_on_boot=False,
     ),
-    # -- Reporting: generate periodic reports when there's data to report on --
-    ScheduledJob(
-        name=JOB_WEEKLY_REPORT,
-        description="Generate weekly performance report snapshot.",
-        cadence=Cadence.weekly(weekday=5, hour=7, minute=0),  # Saturday 07:00
-        prerequisite=_has_positions_or_attributions,
-    ),
-    ScheduledJob(
-        name=JOB_MONTHLY_REPORT,
-        description="Generate monthly performance report snapshot.",
-        cadence=Cadence.monthly(day=1, hour=7, minute=0),  # 1st of month 07:00
-        prerequisite=_has_positions_or_attributions,
-    ),
-    # -- Cost model maintenance --
-    ScheduledJob(
-        name=JOB_SEED_COST_MODELS,
-        description="Refresh per-instrument cost models from current quote spreads.",
-        cadence=Cadence.daily(hour=6, minute=15),
-        prerequisite=_has_tier1_coverage,
-    ),
     # -- On-demand jobs are NOT listed here.  They stay in _INVOKERS
     # (runtime.py) so "Run now" in the Admin UI works, but they are
     # not registered with APScheduler and do not participate in
@@ -488,6 +451,18 @@ def compute_next_run(cadence: Cadence, now: datetime) -> datetime:
     if now.tzinfo is None:
         raise ValueError("compute_next_run requires a timezone-aware 'now'")
     now_utc = now.astimezone(UTC)
+
+    if cadence.kind == "every_n_minutes":
+        # Next slot is the smallest k*interval minute past the current hour
+        # that is strictly after now.
+        interval = cadence.interval_minutes
+        candidate = now_utc.replace(second=0, microsecond=0)
+        next_minute = ((now_utc.minute // interval) + 1) * interval
+        if next_minute >= 60:
+            candidate = candidate.replace(minute=0) + timedelta(hours=1)
+        else:
+            candidate = candidate.replace(minute=next_minute)
+        return candidate
 
     if cadence.kind == "hourly":
         candidate = now_utc.replace(minute=cadence.minute, second=0, microsecond=0)
@@ -2177,4 +2152,53 @@ def seed_cost_models() -> None:
             "seed_cost_models: processed=%d skipped=%d",
             result["processed"],
             result["skipped"],
+        )
+
+
+def orchestrator_full_sync() -> None:
+    """Scheduled job: full DAG sync via the orchestrator.
+
+    Replaces 12 legacy cron triggers removed in Phase 4. Runs
+    `run_sync(FULL, trigger='scheduled')` which plans, executes, and
+    finalizes synchronously in this worker thread. Any layer failure
+    is recorded in `sync_runs` / `sync_layer_progress`; the
+    `_safe_run_and_finalize` wrapper ensures the partial unique index
+    gate always releases, even on crash.
+    """
+    from app.services.sync_orchestrator import SyncScope, run_sync
+
+    logger.info("orchestrator_full_sync: starting")
+    result = run_sync(SyncScope.full(), trigger="scheduled")
+    logger.info(
+        "orchestrator_full_sync complete: sync_run_id=%d outcomes=%d",
+        result.sync_run_id,
+        len(result.outcomes),
+    )
+
+
+def orchestrator_high_frequency_sync() -> None:
+    """Scheduled job: refresh portfolio_sync + fx_rates every 5 minutes
+    via the orchestrator. Runs `run_sync(HIGH_FREQUENCY, trigger='scheduled')`.
+
+    The orchestrator's partial unique index gate ensures this cannot
+    overlap with a still-running FULL sync — it returns early via
+    SyncAlreadyRunning, which this wrapper catches and logs.
+    """
+    from app.services.sync_orchestrator import (
+        SyncAlreadyRunning,
+        SyncScope,
+        run_sync,
+    )
+
+    try:
+        result = run_sync(SyncScope.high_frequency(), trigger="scheduled")
+        logger.info(
+            "orchestrator_high_frequency_sync complete: sync_run_id=%d outcomes=%d",
+            result.sync_run_id,
+            len(result.outcomes),
+        )
+    except SyncAlreadyRunning as exc:
+        logger.info(
+            "orchestrator_high_frequency_sync skipped: sync %s already running",
+            exc.active_sync_run_id,
         )

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -379,7 +379,13 @@ class TestSystemJobs:
         # Each entry carries the declared cadence + computed next_run_time.
         for job in body["jobs"]:
             assert job["cadence"]
-            assert job["cadence_kind"] in ("hourly", "daily", "weekly", "monthly")
+            assert job["cadence_kind"] in (
+                "every_n_minutes",
+                "hourly",
+                "daily",
+                "weekly",
+                "monthly",
+            )
             assert job["next_run_time"]
             assert job["next_run_time_source"] == "declared"
             assert job["description"]

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -273,16 +273,28 @@ class TestGetNextRunTimes:
         assert result[JOB_ORCHESTRATOR_FULL_SYNC] is None
 
     def test_excludes_unwired_scheduled_jobs(self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch) -> None:
-        """SCHEDULED_JOBS entries not in the invoker map are excluded."""
-        from app.workers.scheduler import JOB_DAILY_CANDLE_REFRESH, JOB_ORCHESTRATOR_FULL_SYNC
+        """SCHEDULED_JOBS entries not in the invoker map are excluded.
 
-        # Wire only one of two scheduled jobs — the other should be absent.
+        Uses JOB_EXECUTE_APPROVED_ORDERS as the 'unwired' case — it IS
+        still in SCHEDULED_JOBS after Phase 4 but is deliberately NOT
+        passed to _make_runtime. A scheduled job with no invoker must
+        be excluded from get_next_run_times(), otherwise the Admin UI
+        would show a next-run time for a job that would silently 404
+        on manual trigger.
+        """
+        from app.workers.scheduler import (
+            JOB_EXECUTE_APPROVED_ORDERS,
+            JOB_ORCHESTRATOR_FULL_SYNC,
+        )
+
+        # Wire only one of the two scheduled jobs — the unwired one
+        # (execute_approved_orders) must be absent from the result.
         rt = _make_runtime({JOB_ORCHESTRATOR_FULL_SYNC: lambda: None})
         monkeypatch.setattr(rt._scheduler, "get_job", lambda _job_id: None)
 
         result = rt.get_next_run_times()
         assert JOB_ORCHESTRATOR_FULL_SYNC in result
-        assert JOB_DAILY_CANDLE_REFRESH not in result
+        assert JOB_EXECUTE_APPROVED_ORDERS not in result
 
 
 class TestProductionInvokerRegistry:

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -209,13 +209,13 @@ class TestStartWiring:
         # Wire an invoker for a name that IS in SCHEDULED_JOBS, plus
         # one that is not. start() should register the first and
         # silently ignore the second.
-        from app.workers.scheduler import JOB_DAILY_CIK_REFRESH
+        from app.workers.scheduler import JOB_ORCHESTRATOR_FULL_SYNC
 
         added: list[str] = []
 
         rt = _make_runtime(
             {
-                JOB_DAILY_CIK_REFRESH: lambda: None,
+                JOB_ORCHESTRATOR_FULL_SYNC: lambda: None,
                 "not_in_registry": lambda: None,
             }
         )
@@ -229,7 +229,7 @@ class TestStartWiring:
 
         rt.start()
 
-        assert added == [f"recurring:{JOB_DAILY_CIK_REFRESH}"]
+        assert added == [f"recurring:{JOB_ORCHESTRATOR_FULL_SYNC}"]
 
     def test_double_start_raises(self, patched_runtime: None) -> None:
         rt = _make_runtime({})
@@ -243,45 +243,45 @@ class TestGetNextRunTimes:
         self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """get_next_run_times queries APScheduler's in-memory jobs."""
-        from app.workers.scheduler import JOB_DAILY_CIK_REFRESH
+        from app.workers.scheduler import JOB_ORCHESTRATOR_FULL_SYNC
 
         fire_time = datetime(2026, 4, 11, 3, 0, 0, tzinfo=UTC)
 
         fake_aps_job = MagicMock()
         fake_aps_job.next_run_time = fire_time
 
-        rt = _make_runtime({JOB_DAILY_CIK_REFRESH: lambda: None})
+        rt = _make_runtime({JOB_ORCHESTRATOR_FULL_SYNC: lambda: None})
         monkeypatch.setattr(
             rt._scheduler,
             "get_job",
-            lambda job_id: fake_aps_job if job_id == f"recurring:{JOB_DAILY_CIK_REFRESH}" else None,
+            lambda job_id: fake_aps_job if job_id == f"recurring:{JOB_ORCHESTRATOR_FULL_SYNC}" else None,
         )
 
         result = rt.get_next_run_times()
-        assert result[JOB_DAILY_CIK_REFRESH] == fire_time
+        assert result[JOB_ORCHESTRATOR_FULL_SYNC] == fire_time
 
     def test_returns_none_for_missing_scheduler_job(
         self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """If APScheduler doesn't know about a job, return None."""
-        from app.workers.scheduler import JOB_DAILY_CIK_REFRESH
+        from app.workers.scheduler import JOB_ORCHESTRATOR_FULL_SYNC
 
-        rt = _make_runtime({JOB_DAILY_CIK_REFRESH: lambda: None})
+        rt = _make_runtime({JOB_ORCHESTRATOR_FULL_SYNC: lambda: None})
         monkeypatch.setattr(rt._scheduler, "get_job", lambda _job_id: None)
 
         result = rt.get_next_run_times()
-        assert result[JOB_DAILY_CIK_REFRESH] is None
+        assert result[JOB_ORCHESTRATOR_FULL_SYNC] is None
 
     def test_excludes_unwired_scheduled_jobs(self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch) -> None:
         """SCHEDULED_JOBS entries not in the invoker map are excluded."""
-        from app.workers.scheduler import JOB_DAILY_CANDLE_REFRESH, JOB_DAILY_CIK_REFRESH
+        from app.workers.scheduler import JOB_DAILY_CANDLE_REFRESH, JOB_ORCHESTRATOR_FULL_SYNC
 
         # Wire only one of two scheduled jobs — the other should be absent.
-        rt = _make_runtime({JOB_DAILY_CIK_REFRESH: lambda: None})
+        rt = _make_runtime({JOB_ORCHESTRATOR_FULL_SYNC: lambda: None})
         monkeypatch.setattr(rt._scheduler, "get_job", lambda _job_id: None)
 
         result = rt.get_next_run_times()
-        assert JOB_DAILY_CIK_REFRESH in result
+        assert JOB_ORCHESTRATOR_FULL_SYNC in result
         assert JOB_DAILY_CANDLE_REFRESH not in result
 
 
@@ -314,8 +314,32 @@ class TestProductionInvokerRegistry:
         registry_names = {job.name for job in SCHEDULED_JOBS}
         invoker_names = set(_INVOKERS.keys())
         on_demand = invoker_names - registry_names
-        assert on_demand == {"daily_tax_reconciliation", "nightly_universe_sync"}, (
-            f"Unexpected on-demand invokers (update this test if intentional): {sorted(on_demand)}"
+        # Phase 4: 12 former-scheduled jobs are now driven by the
+        # orchestrator_full_sync DAG walk. They stay in _INVOKERS so
+        # POST /jobs/{name}/run continues to work, but they are
+        # no longer independently scheduled.
+        expected_on_demand = {
+            # Pre-Phase-4 on-demand (unchanged):
+            "daily_tax_reconciliation",
+            "nightly_universe_sync",
+            # Phase-4 moved from SCHEDULED_JOBS to orchestrator-driven:
+            "daily_candle_refresh",
+            "daily_cik_refresh",
+            "daily_financial_facts",
+            "daily_news_refresh",
+            "daily_portfolio_sync",
+            "daily_research_refresh",
+            "daily_thesis_refresh",
+            "fx_rates_refresh",
+            "monthly_report",
+            "morning_candidate_review",
+            "seed_cost_models",
+            "weekly_report",
+        }
+        assert on_demand == expected_on_demand, (
+            f"Unexpected on-demand invokers (update this test if intentional): "
+            f"unexpected={sorted(on_demand - expected_on_demand)} "
+            f"missing={sorted(expected_on_demand - on_demand)}"
         )
 
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -239,39 +239,19 @@ class TestLoadReportSnapshots:
 # ---------------------------------------------------------------------------
 
 
-class TestReportSchedulerJobs:
-    def test_weekly_report_job_registered(self) -> None:
-        """weekly_report job should be in SCHEDULED_JOBS."""
-        from app.workers.scheduler import SCHEDULED_JOBS
+class TestReportJobsAvailability:
+    """weekly_report and monthly_report used to be scheduled directly;
+    since Phase 4 they are driven by the orchestrator full sync (via
+    JOB_TO_LAYERS → weekly_reports / monthly_reports layers). They
+    remain in _INVOKERS so POST /jobs/{name}/run continues to work."""
 
-        names = [j.name for j in SCHEDULED_JOBS]
-        assert "weekly_report" in names
+    def test_reports_available_via_orchestrator(self) -> None:
+        from app.services.sync_orchestrator.registry import JOB_TO_LAYERS
 
-    def test_monthly_report_job_registered(self) -> None:
-        """monthly_report job should be in SCHEDULED_JOBS."""
-        from app.workers.scheduler import SCHEDULED_JOBS
+        assert JOB_TO_LAYERS["weekly_report"] == ("weekly_reports",)
+        assert JOB_TO_LAYERS["monthly_report"] == ("monthly_reports",)
 
-        names = [j.name for j in SCHEDULED_JOBS]
-        assert "monthly_report" in names
-
-    def test_weekly_report_cadence(self) -> None:
-        """weekly_report should run Saturday morning."""
-        from app.workers.scheduler import SCHEDULED_JOBS
-
-        job = next(j for j in SCHEDULED_JOBS if j.name == "weekly_report")
-        assert job.cadence.kind == "weekly"
-        assert job.cadence.weekday == 5  # Saturday
-
-    def test_monthly_report_cadence(self) -> None:
-        """monthly_report should run on the 1st of each month."""
-        from app.workers.scheduler import SCHEDULED_JOBS
-
-        job = next(j for j in SCHEDULED_JOBS if j.name == "monthly_report")
-        assert job.cadence.kind == "monthly"
-        assert job.cadence.day == 1
-
-    def test_drift_guard_invokers_match(self) -> None:
-        """Both new jobs must have entries in _INVOKERS."""
+    def test_reports_still_in_invokers(self) -> None:
         from app.jobs.runtime import _INVOKERS
 
         assert "weekly_report" in _INVOKERS

--- a/tests/test_workers_scheduler_registry.py
+++ b/tests/test_workers_scheduler_registry.py
@@ -58,16 +58,36 @@ class TestRegistryShape:
 # ---------------------------------------------------------------------------
 
 
-class TestDailyCandleJob:
-    def test_daily_candle_job_registered(self) -> None:
-        names = [job.name for job in SCHEDULED_JOBS]
-        assert "daily_candle_refresh" in names
+class TestOrchestratorTriggers:
+    """Phase 4: SCHEDULED_JOBS now carries two orchestrator triggers in
+    place of the 12 legacy cron entries that mapped to non-empty
+    JOB_TO_LAYERS values. daily_candle_refresh still exists as an
+    _INVOKERS entry for POST /jobs/{name}/run, but no longer has its
+    own cron schedule."""
 
-    def test_daily_candle_job_cadence(self) -> None:
-        job = next(j for j in SCHEDULED_JOBS if j.name == "daily_candle_refresh")
+    def test_orchestrator_full_sync_registered(self) -> None:
+        names = [job.name for job in SCHEDULED_JOBS]
+        assert "orchestrator_full_sync" in names
+
+    def test_orchestrator_full_sync_cadence_daily_03_utc(self) -> None:
+        job = next(j for j in SCHEDULED_JOBS if j.name == "orchestrator_full_sync")
         assert job.cadence.kind == "daily"
-        assert job.cadence.hour == 22
+        assert job.cadence.hour == 3
         assert job.cadence.minute == 0
+
+    def test_orchestrator_high_frequency_registered_every_5min(self) -> None:
+        job = next(j for j in SCHEDULED_JOBS if j.name == "orchestrator_high_frequency_sync")
+        assert job.cadence.kind == "every_n_minutes"
+        assert job.cadence.interval_minutes == 5
+
+    def test_daily_candle_refresh_still_invokable_via_invokers(self) -> None:
+        from app.jobs.runtime import _INVOKERS
+
+        assert "daily_candle_refresh" in _INVOKERS
+
+    def test_daily_candle_refresh_no_longer_scheduled(self) -> None:
+        names = [job.name for job in SCHEDULED_JOBS]
+        assert "daily_candle_refresh" not in names
 
 
 # ---------------------------------------------------------------------------
@@ -76,6 +96,14 @@ class TestDailyCandleJob:
 
 
 class TestCadenceValidators:
+    @pytest.mark.parametrize("interval", [0, 31, 7])
+    def test_every_n_minutes_invalid_raises(self, interval: int) -> None:
+        with pytest.raises(ValueError, match="every_n_minutes"):
+            Cadence.every_n_minutes(interval=interval)
+
+    def test_every_n_minutes_label(self) -> None:
+        assert Cadence.every_n_minutes(interval=5).label == "every 5m"
+
     @pytest.mark.parametrize("minute", [-1, 60, 75])
     def test_hourly_invalid_minute_raises(self, minute: int) -> None:
         with pytest.raises(ValueError, match="hourly minute"):


### PR DESCRIPTION
## Summary
Activates the sync orchestrator. 12 legacy cron triggers removed, 2 orchestrator triggers added. POST /sync now returns 202 + plan (was 503). The 13 underlying job functions stay in \`_INVOKERS\` so POST /jobs/{name}/run continues to work via the adapter.

## SCHEDULED_JOBS delta (17 → 7)

**Removed (12):** daily_cik_refresh, daily_candle_refresh, fx_rates_refresh, daily_research_refresh, daily_financial_facts, daily_news_refresh, daily_thesis_refresh, daily_portfolio_sync, morning_candidate_review, weekly_report, monthly_report, seed_cost_models

**Added (2):**
- \`orchestrator_full_sync\` — daily @ 03:00 UTC, walks DAG, refreshes stale layers
- \`orchestrator_high_frequency_sync\` — every 5 minutes, portfolio_sync + fx_rates only

**Kept (5):** execute_approved_orders, retry_deferred_recommendations, monitor_positions, weekly_coverage_review, attribution_summary (empty JOB_TO_LAYERS entries — outside the DAG)

## New Cadence kind
\`every_n_minutes(interval=N)\` — 1..30, must divide 60. Compiles to APScheduler \`CronTrigger(minute=f"*/{N}")\`.

## Security model
- Orchestrator triggers wrap \`run_sync(FULL, trigger='scheduled')\` and \`run_sync(HIGH_FREQUENCY, ...)\`
- High-frequency wrapper catches \`SyncAlreadyRunning\` (cannot overlap full sync via the partial-unique-index gate)
- \`_safe_run_and_finalize\` wrapper guarantees terminal sync_runs status + gate release on any crash
- 13 former-scheduled invokers still accessible via \`POST /jobs/{name}/run\` (gated by \`require_session_or_service_token\`)
- Boot reaper from Phase 1 covers orphaned runs from Phase 4 onwards

## Tradeoffs
- First orchestrator_full_sync at 03:00 UTC will plan and run whichever layers are stale. On an established DB this should be a small number.
- \`catch_up_on_boot=False\` on the high-frequency trigger prevents spurious 5-min catch-ups if the app was offline for a while.
- Phase 4 is behavioural: scheduled triggers change. Observation window before Phase 3 (dashboard) is valuable.

## Test plan
- [x] \`uv run pytest\` — 1710 passed, 1 skipped
- [x] \`uv run ruff check .\` + \`ruff format --check .\` — clean
- [x] \`uv run pyright\` — 0 errors
- [ ] Manual: restart dev stack, verify \`/system/jobs\` shows 7 entries (5 legacy + 2 orchestrator)
- [ ] Manual: \`curl -X POST /sync -d '{"scope":"full"}'\` returns 202 + plan (was 503)

## Follow-ups
- Phase 2: progress callbacks on long-running layers
- Phase 3: dashboard UI replacing AdminPage jobs section
- Phase 5: remove legacy /system/jobs UI tab, mark /jobs endpoint deprecated

🤖 Generated with [Claude Code](https://claude.com/claude-code)