### PR TITLE
feat(#260): Phase 5 — consolidate AdminPage around orchestrator

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -51,7 +51,11 @@ export interface ConfigResponse {
 export type LayerStatus = "ok" | "stale" | "empty" | "error";
 export type OverallStatus = "ok" | "degraded" | "down";
 export type JobLastStatus = "running" | "success" | "failure" | "skipped" | null;
-export type CadenceKind = "hourly" | "daily" | "weekly";
+export type CadenceKind =
+  | "hourly"
+  | "daily"
+  | "weekly"
+  | "every_n_minutes";
 
 export interface LayerHealthResponse {
   layer: string;

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -100,6 +100,42 @@ function jobsResponse(): JobsListResponse {
         last_finished_at: null,
         detail: "no runs recorded",
       },
+      {
+        name: "retry_deferred_recommendations",
+        description: "Retry deferred recommendations.",
+        cadence: "hourly",
+        cadence_kind: "hourly",
+        next_run_time: "2026-04-16T02:00:00Z",
+        next_run_time_source: "declared",
+        last_status: "success",
+        last_started_at: "2026-04-16T01:00:00Z",
+        last_finished_at: "2026-04-16T01:00:05Z",
+        detail: "",
+      },
+      {
+        name: "weekly_coverage_review",
+        description: "Weekly coverage review.",
+        cadence: "weekly",
+        cadence_kind: "weekly",
+        next_run_time: "2026-04-20T08:00:00Z",
+        next_run_time_source: "declared",
+        last_status: "success",
+        last_started_at: "2026-04-13T08:00:00Z",
+        last_finished_at: "2026-04-13T08:00:20Z",
+        detail: "",
+      },
+      {
+        name: "attribution_summary",
+        description: "Portfolio attribution summary.",
+        cadence: "daily at 07:00 UTC",
+        cadence_kind: "daily",
+        next_run_time: "2026-04-17T07:00:00Z",
+        next_run_time_source: "declared",
+        last_status: "failure",
+        last_started_at: "2026-04-16T07:00:00Z",
+        last_finished_at: "2026-04-16T07:00:02Z",
+        detail: "provider timeout",
+      },
     ],
   };
 }
@@ -135,6 +171,19 @@ describe("AdminPage — background tasks table", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Run monitor_positions now" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Run retry_deferred_recommendations now",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Run weekly_coverage_review now",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Run attribution_summary now" }),
     ).toBeInTheDocument();
     // Orchestrator-owned entries filtered out.
     expect(

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -1,58 +1,99 @@
 /**
- * Tests for AdminPage scheduled-jobs surface (#13 PR B).
+ * Tests for AdminPage (#260 Phase 5).
  *
- * Scope:
- *   - jobs table renders the overview shape from /system/jobs
- *   - "Run now" button POSTs /jobs/{name}/run and surfaces success
- *   - 409 from runJob renders "Already running" without throwing
- *   - successful trigger refetches both panels (so the operator's
- *     action is reflected without a manual refresh)
- *   - recent runs table renders the row shape from /jobs/runs
+ * After Phase 5, AdminPage is composed of two sections:
+ *   1. SyncDashboard — the orchestrator's 15-layer freshness view. It
+ *      hits /sync/layers, /sync/status, /sync/runs on mount, so the
+ *      sync API is mocked here to return empty responses.
+ *   2. Background tasks — the 5 scheduled jobs outside the orchestrator
+ *      DAG. Orchestrator-owned job names are filtered out at the
+ *      component boundary.
  *
- * The API client is mocked at the module boundary; this test exercises
- * the page's state machine, not the network layer.
+ * The legacy "Recent runs" table and the full scheduled-jobs list are
+ * gone, so those assertions were removed. The API client is mocked at
+ * the module boundary; this test exercises the page's state machine,
+ * not the network layer.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { AdminPage } from "@/pages/AdminPage";
-import { fetchJobRuns, fetchJobsOverview, runJob } from "@/api/jobs";
+import { fetchJobsOverview, runJob } from "@/api/jobs";
+import {
+  fetchSyncLayers,
+  fetchSyncRuns,
+  fetchSyncStatus,
+} from "@/api/sync";
 import { ApiError } from "@/api/client";
-import type { JobsListResponse, JobRunsListResponse } from "@/api/types";
+import type { JobsListResponse } from "@/api/types";
 
 vi.mock("@/api/jobs", () => ({
   fetchJobsOverview: vi.fn(),
-  fetchJobRuns: vi.fn(),
   runJob: vi.fn(),
 }));
 
+vi.mock("@/api/sync", () => ({
+  fetchSyncLayers: vi.fn(),
+  fetchSyncStatus: vi.fn(),
+  fetchSyncRuns: vi.fn(),
+  triggerSync: vi.fn(),
+}));
+
 const mockedJobs = vi.mocked(fetchJobsOverview);
-const mockedRuns = vi.mocked(fetchJobRuns);
 const mockedRun = vi.mocked(runJob);
+const mockedLayers = vi.mocked(fetchSyncLayers);
+const mockedStatus = vi.mocked(fetchSyncStatus);
+const mockedSyncRuns = vi.mocked(fetchSyncRuns);
 
 function jobsResponse(): JobsListResponse {
+  // Mix of orchestrator-owned + background tasks. The two orchestrator
+  // entries must be filtered out by the component.
   return {
-    checked_at: "2026-04-09T01:00:00Z",
+    checked_at: "2026-04-16T01:00:00Z",
     jobs: [
       {
-        name: "nightly_universe_sync",
-        description: "Sync the eToro tradable instrument universe.",
+        name: "orchestrator_full_sync",
+        description: "Nightly orchestrator sweep.",
         cadence: "daily at 02:00 UTC",
         cadence_kind: "daily",
-        next_run_time: "2026-04-10T02:00:00Z",
+        next_run_time: "2026-04-17T02:00:00Z",
         next_run_time_source: "declared",
         last_status: "success",
-        last_started_at: "2026-04-09T02:00:00Z",
-        last_finished_at: "2026-04-09T02:00:12Z",
+        last_started_at: "2026-04-16T02:00:00Z",
+        last_finished_at: "2026-04-16T02:05:00Z",
         detail: "",
       },
       {
-        name: "daily_news_refresh",
-        description: "Fetch and score news.",
-        cadence: "daily at 04:00 UTC",
-        cadence_kind: "daily",
-        next_run_time: "2026-04-10T04:00:00Z",
+        name: "orchestrator_high_frequency_sync",
+        description: "5-min orchestrator tick.",
+        cadence: "every 5 minutes",
+        cadence_kind: "every_n_minutes",
+        next_run_time: "2026-04-16T01:05:00Z",
+        next_run_time_source: "declared",
+        last_status: "success",
+        last_started_at: "2026-04-16T01:00:00Z",
+        last_finished_at: "2026-04-16T01:00:03Z",
+        detail: "",
+      },
+      {
+        name: "execute_approved_orders",
+        description: "Execute operator-approved orders.",
+        cadence: "every 1 minutes",
+        cadence_kind: "every_n_minutes",
+        next_run_time: "2026-04-16T01:01:00Z",
+        next_run_time_source: "declared",
+        last_status: "success",
+        last_started_at: "2026-04-16T01:00:00Z",
+        last_finished_at: "2026-04-16T01:00:01Z",
+        detail: "",
+      },
+      {
+        name: "monitor_positions",
+        description: "Monitor open positions.",
+        cadence: "every 5 minutes",
+        cadence_kind: "every_n_minutes",
+        next_run_time: "2026-04-16T01:05:00Z",
         next_run_time_source: "declared",
         last_status: null,
         last_started_at: null,
@@ -63,84 +104,77 @@ function jobsResponse(): JobsListResponse {
   };
 }
 
-function runsResponse(): JobRunsListResponse {
-  return {
-    items: [
-      {
-        run_id: 42,
-        job_name: "nightly_universe_sync",
-        started_at: "2026-04-09T02:00:00Z",
-        finished_at: "2026-04-09T02:00:12Z",
-        status: "success",
-        row_count: 1234,
-        error_msg: null,
-      },
-    ],
-    count: 1,
-    limit: 50,
-    job_name: null,
-  };
-}
-
 beforeEach(() => {
   mockedJobs.mockReset();
-  mockedRuns.mockReset();
   mockedRun.mockReset();
+  mockedLayers.mockReset();
+  mockedStatus.mockReset();
+  mockedSyncRuns.mockReset();
   mockedJobs.mockResolvedValue(jobsResponse());
-  mockedRuns.mockResolvedValue(runsResponse());
+  mockedLayers.mockResolvedValue({ layers: [] });
+  mockedStatus.mockResolvedValue({
+    is_running: false,
+    current_run: null,
+    active_layer: null,
+  });
+  mockedSyncRuns.mockResolvedValue({ runs: [] });
 });
 
 afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("AdminPage — jobs table", () => {
-  it("renders one row per declared job with status + cadence", async () => {
+describe("AdminPage — background tasks table", () => {
+  it("filters out orchestrator-owned jobs and lists background tasks", async () => {
     render(<AdminPage />);
+    // Background tasks present.
     expect(
-      await screen.findByRole("button", { name: "Run nightly_universe_sync now" }),
+      await screen.findByRole("button", {
+        name: "Run execute_approved_orders now",
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Run daily_news_refresh now" }),
+      screen.getByRole("button", { name: "Run monitor_positions now" }),
     ).toBeInTheDocument();
-    expect(screen.getAllByText(/daily at \d\d:00 UTC/)).toHaveLength(2);
+    // Orchestrator-owned entries filtered out.
+    expect(
+      screen.queryByRole("button", { name: "Run orchestrator_full_sync now" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: "Run orchestrator_high_frequency_sync now",
+      }),
+    ).toBeNull();
+    // Never-run state rendered for monitor_positions.
     expect(screen.getByText("never run")).toBeInTheDocument();
-  });
-
-  it("renders recent runs from /jobs/runs", async () => {
-    render(<AdminPage />);
-    await screen.findAllByText("nightly_universe_sync");
-    // Both the jobs row and the recent-runs row include the job name.
-    // 1234 is the row_count cell, which only appears in the runs table.
-    expect(await screen.findByText("1234")).toBeInTheDocument();
   });
 });
 
 describe("AdminPage — Run now button", () => {
-  it("POSTs to runJob and refetches both panels on success", async () => {
+  it("POSTs to runJob and refetches jobs on success", async () => {
     const user = userEvent.setup();
     mockedRun.mockResolvedValueOnce(undefined);
     render(<AdminPage />);
-    await screen.findAllByText("nightly_universe_sync");
+    await screen.findByRole("button", {
+      name: "Run execute_approved_orders now",
+    });
 
     expect(mockedJobs).toHaveBeenCalledTimes(1);
-    expect(mockedRuns).toHaveBeenCalledTimes(1);
 
     await user.click(
-      screen.getByRole("button", { name: "Run nightly_universe_sync now" }),
+      screen.getByRole("button", { name: "Run execute_approved_orders now" }),
     );
 
     await waitFor(() => {
-      expect(mockedRun).toHaveBeenCalledWith("nightly_universe_sync");
+      expect(mockedRun).toHaveBeenCalledWith("execute_approved_orders");
     });
-    // Both panels refetched after a successful trigger.
     await waitFor(() => {
       expect(mockedJobs).toHaveBeenCalledTimes(2);
-      expect(mockedRuns).toHaveBeenCalledTimes(2);
     });
-    // Button shows the queued state.
     expect(
-      await screen.findByRole("button", { name: "Run nightly_universe_sync now" }),
+      await screen.findByRole("button", {
+        name: "Run execute_approved_orders now",
+      }),
     ).toHaveTextContent("Queued");
   });
 
@@ -148,35 +182,37 @@ describe("AdminPage — Run now button", () => {
     const user = userEvent.setup();
     mockedRun.mockRejectedValueOnce(new ApiError(409, "job already running"));
     render(<AdminPage />);
-    await screen.findAllByText("nightly_universe_sync");
+    await screen.findByRole("button", {
+      name: "Run execute_approved_orders now",
+    });
 
     await user.click(
-      screen.getByRole("button", { name: "Run nightly_universe_sync now" }),
+      screen.getByRole("button", { name: "Run execute_approved_orders now" }),
     );
 
     expect(
       await screen.findByRole("button", {
-        name: "Run nightly_universe_sync now",
+        name: "Run execute_approved_orders now",
       }),
     ).toHaveTextContent("Already running");
-    // No refetch on failure -- the error path leaves the panels alone.
     expect(mockedJobs).toHaveBeenCalledTimes(1);
-    expect(mockedRuns).toHaveBeenCalledTimes(1);
   });
 
   it("renders 'Unknown job' on 404", async () => {
     const user = userEvent.setup();
     mockedRun.mockRejectedValueOnce(new ApiError(404, "unknown job"));
     render(<AdminPage />);
-    await screen.findAllByText("nightly_universe_sync");
+    await screen.findByRole("button", {
+      name: "Run execute_approved_orders now",
+    });
 
     await user.click(
-      screen.getByRole("button", { name: "Run nightly_universe_sync now" }),
+      screen.getByRole("button", { name: "Run execute_approved_orders now" }),
     );
 
     expect(
       await screen.findByRole("button", {
-        name: "Run nightly_universe_sync now",
+        name: "Run execute_approved_orders now",
       }),
     ).toHaveTextContent("Unknown job");
   });

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,32 +1,31 @@
 /**
- * Admin page — scheduled jobs (#13 PR B).
+ * Admin page (issue #260 Phase 5).
  *
- * Two panels, each owning its own request lifecycle so a slow or
- * failing endpoint cannot blank the other:
+ * Two sections:
+ *   1. Sync dashboard — 15-layer freshness grid + recent sync runs +
+ *      "Sync now" button. Owned by the orchestrator.
+ *   2. Background tasks — the 5 scheduled jobs that live outside the
+ *      orchestrator DAG (execute_approved_orders, monitor_positions,
+ *      retry_deferred_recommendations, weekly_coverage_review,
+ *      attribution_summary). Retained because the operator still needs
+ *      Run-Now for them and they are not part of the data-sync flow.
  *
- *   1. Jobs table — declared schedule + computed next-run + last-run
- *      summary, sourced from GET /system/jobs. Each row carries a
- *      "Run now" button that POSTs /jobs/{name}/run; the per-row
- *      transient state (running / error / success) lives in this page,
- *      not in a global store.
- *   2. Recent runs — newest-first slice of job_runs from GET /jobs/runs.
- *      Refetched whenever a manual trigger is fired so the operator
- *      sees their action take effect without a manual refresh.
- *
- * The system-status / kill-switch / data-layer surface is intentionally
- * NOT duplicated here — it lives on the dashboard's SystemStatusPanel
- * already and PR B is scoped to the jobs surface only.
+ * The prior "Recent runs" table is removed — the Sync dashboard's
+ * recent-sync-runs table is the authoritative per-run view now, and
+ * individual job runs for the background tasks can be retrieved via
+ * the /jobs/runs API if needed (operator CLI, not UI).
  */
 
 import { useCallback, useState } from "react";
 
-import { fetchJobRuns, fetchJobsOverview, runJob } from "@/api/jobs";
-import type {
-  JobOverviewResponse,
-  JobRunResponse,
-} from "@/api/types";
+import { fetchJobsOverview, runJob } from "@/api/jobs";
+import type { JobOverviewResponse } from "@/api/types";
 import { ApiError } from "@/api/client";
-import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
 import { useAsync } from "@/lib/useAsync";
 import { formatDateTime } from "@/lib/format";
 import { SyncDashboard } from "@/pages/SyncDashboard";
@@ -44,35 +43,26 @@ const STATUS_TONE: Record<string, string> = {
   skipped: "text-slate-400",
 };
 
+// Orchestrator-owned scheduled jobs — surfaced by the Sync dashboard
+// above; not duplicated here. Every other SCHEDULED_JOBS entry is a
+// "background task" that remains outside the orchestrator DAG.
+const ORCHESTRATOR_OWNED = new Set([
+  "orchestrator_full_sync",
+  "orchestrator_high_frequency_sync",
+]);
+
 export function AdminPage() {
   const jobs = useAsync(fetchJobsOverview, []);
-  const runs = useAsync(() => fetchJobRuns(null, 50), []);
 
-  // Per-row transient state. Keyed on job name; cleared automatically
-  // when a fresh fetch resolves so a stale "queued" badge does not
-  // outlive the next refresh.
   const [rowState, setRowState] = useState<Record<string, RowState>>({});
 
-  // Depend on the stable refetch references rather than the full
-  // useAsync state objects -- ``jobs`` and ``runs`` are new objects on
-  // every render (loading/data/error transitions), but their
-  // ``refetch`` callbacks are memoised inside ``useAsync``. Closing
-  // over the state objects would recreate ``handleRun`` (and force
-  // ``JobsTable`` to re-render every row) on every async transition.
-  // Round 1 review WARNING 3.
   const refetchJobs = jobs.refetch;
-  const refetchRuns = runs.refetch;
   const handleRun = useCallback(
     async (name: string) => {
       setRowState((prev) => ({ ...prev, [name]: { kind: "running" } }));
       try {
         await runJob(name);
         setRowState((prev) => ({ ...prev, [name]: { kind: "queued" } }));
-        // Refresh both panels so the operator's action is reflected
-        // without a manual refresh. A single refresh is enough; the
-        // operator can hit the button again or reload the page if
-        // they want to see further updates.
-        refetchRuns();
         refetchJobs();
       } catch (err) {
         const message =
@@ -83,58 +73,43 @@ export function AdminPage() {
                 ? "Unknown job"
                 : `Failed (HTTP ${err.status})`
             : "Failed";
-        setRowState((prev) => ({ ...prev, [name]: { kind: "error", message } }));
+        setRowState((prev) => ({
+          ...prev,
+          [name]: { kind: "error", message },
+        }));
       }
     },
-    [refetchJobs, refetchRuns],
+    [refetchJobs],
+  );
+
+  const backgroundJobs = (jobs.data?.jobs ?? []).filter(
+    (j) => !ORCHESTRATOR_OWNED.has(j.name),
   );
 
   return (
     <div className="space-y-8">
-      {/* Phase 3: sync orchestrator dashboard (issue #260). Sits above the
-          legacy jobs table — the jobs table remains until Phase 5 removes
-          it, so operators can cross-check old behaviour vs orchestrator
-          behaviour during the cutover window. */}
       <SyncDashboard />
 
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold text-slate-800">
-          Legacy scheduled jobs
-        </h1>
-      </div>
-
-      <Section title="Jobs">
+      <Section title="Background tasks">
         {jobs.loading ? (
-          <SectionSkeleton rows={6} />
+          <SectionSkeleton rows={5} />
         ) : jobs.error !== null ? (
           <SectionError onRetry={jobs.refetch} />
         ) : (
-          <JobsTable
-            items={jobs.data?.jobs ?? []}
-            rowState={rowState}
-            onRun={handleRun}
-          />
-        )}
-      </Section>
-
-      <Section
-        title="Recent runs"
-        action={
-          <button
-            type="button"
-            onClick={runs.refetch}
-            className="rounded border border-slate-200 bg-white px-2 py-0.5 text-[10px] font-medium text-slate-600 hover:bg-slate-50"
-          >
-            Refresh
-          </button>
-        }
-      >
-        {runs.loading ? (
-          <SectionSkeleton rows={5} />
-        ) : runs.error !== null ? (
-          <SectionError onRetry={runs.refetch} />
-        ) : (
-          <RecentRunsTable items={runs.data?.items ?? []} />
+          <>
+            <p className="mb-3 text-xs text-slate-500">
+              Scheduled jobs that live outside the orchestrator DAG —
+              transaction execution, position monitoring, deferred-rec
+              retries, and periodic governance. Data-pipeline jobs
+              (candles, theses, scoring, reports, etc.) are driven by
+              the orchestrator above.
+            </p>
+            <JobsTable
+              items={backgroundJobs}
+              rowState={rowState}
+              onRun={handleRun}
+            />
+          </>
         )}
       </Section>
     </div>
@@ -151,7 +126,7 @@ function JobsTable({
   onRun: (name: string) => void;
 }) {
   if (items.length === 0) {
-    return <p className="text-sm text-slate-500">No jobs registered.</p>;
+    return <p className="text-sm text-slate-500">No background jobs registered.</p>;
   }
   return (
     <div className="overflow-x-auto">
@@ -173,15 +148,21 @@ function JobsTable({
               <tr key={job.name} className="align-top">
                 <td className="py-2 pr-4">
                   <div className="font-medium text-slate-700">{job.name}</div>
-                  <div className="text-xs text-slate-500">{job.description}</div>
+                  <div className="text-xs text-slate-500">
+                    {job.description}
+                  </div>
                 </td>
-                <td className="py-2 pr-4 text-xs text-slate-600">{job.cadence}</td>
+                <td className="py-2 pr-4 text-xs text-slate-600">
+                  {job.cadence}
+                </td>
                 <td className="py-2 pr-4 text-xs text-slate-600">
                   {formatDateTime(job.next_run_time)}
                 </td>
                 <td className="py-2 pr-4 text-xs">
                   <span
-                    className={STATUS_TONE[job.last_status ?? ""] ?? "text-slate-400"}
+                    className={
+                      STATUS_TONE[job.last_status ?? ""] ?? "text-slate-400"
+                    }
                   >
                     {job.last_status ?? "never run"}
                   </span>
@@ -239,54 +220,5 @@ function RunButton({
     >
       {label}
     </button>
-  );
-}
-
-function RecentRunsTable({ items }: { items: JobRunResponse[] }) {
-  if (items.length === 0) {
-    return <p className="text-sm text-slate-500">No runs recorded yet.</p>;
-  }
-  return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-left text-sm">
-        <thead className="text-xs uppercase tracking-wide text-slate-500">
-          <tr>
-            <th className="py-2 pr-4">Job</th>
-            <th className="py-2 pr-4">Status</th>
-            <th className="py-2 pr-4">Started</th>
-            <th className="py-2 pr-4">Finished</th>
-            <th className="py-2 pr-4">Rows</th>
-            <th className="py-2 pr-4">Error</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-slate-100">
-          {items.map((run) => (
-            <tr key={run.run_id}>
-              <td className="py-2 pr-4 font-medium text-slate-700">{run.job_name}</td>
-              <td className="py-2 pr-4 text-xs">
-                <span className={STATUS_TONE[run.status] ?? "text-slate-500"}>
-                  {run.status}
-                </span>
-              </td>
-              <td className="py-2 pr-4 text-xs text-slate-600">
-                {formatDateTime(run.started_at)}
-              </td>
-              <td className="py-2 pr-4 text-xs text-slate-600">
-                {formatDateTime(run.finished_at)}
-              </td>
-              <td className="py-2 pr-4 text-xs text-slate-600">
-                {run.row_count ?? "—"}
-              </td>
-              <td
-                className="max-w-xs truncate py-2 pr-4 text-xs text-red-600"
-                title={run.error_msg ?? undefined}
-              >
-                {run.error_msg ?? ""}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary

Phase 5 of the data-orchestrator rollout (#260). After Phases 1 + 3 + 4, `AdminPage` still carried two legacy panels that duplicated orchestrator state:
- a full **Scheduled jobs** table (12 of those jobs are now orchestrator-owned)
- a **Recent runs** panel fed from `/jobs/runs`

Both are removed. The page is now: `SyncDashboard` (Phase 3) + a narrow **Background tasks** section for the 5 scheduled jobs that live *outside* the orchestrator DAG — execution, position monitoring, deferred-rec retries, weekly governance, attribution summary.

## Changes

- `frontend/src/pages/AdminPage.tsx` — full rewrite. Filters `SCHEDULED_JOBS` by an `ORCHESTRATOR_OWNED` set (`orchestrator_full_sync`, `orchestrator_high_frequency_sync`) so only the 5 background tasks appear. Kept the existing `JobsTable` + `RunButton` internal components; dropped `RecentRunsTable` + the `runs = useAsync(() => fetchJobRuns(...))` state.
- `frontend/src/pages/AdminPage.test.tsx` — rewritten. Now mocks `@/api/sync` (since `SyncDashboard` renders inside the page and auto-polls on mount), asserts orchestrator-owned entries are filtered out, exercises Run-now / 409 / 404 paths against a background-task fixture.
- `frontend/src/api/types.ts` — `CadenceKind` extended with `"every_n_minutes"`. Phase 4 added this cadence kind on the backend (`app/workers/scheduler.py`) but the frontend type lagged; the test fixture reminded me.

## Security model

No change. AdminPage is a read/write operator surface already gated by the existing session / service-token middleware — no new endpoints, no new writes.

## Tradeoffs

- `ORCHESTRATOR_OWNED` is a frontend-side set literal mirroring the two orchestrator job names in `scheduler.py`. An operator-visible divergence is hard (the orchestrator jobs are stable contract surfaces; adding a third would show up in the background-tasks list and warrant a code review anyway) but the alternative — a server-side `is_orchestrator_owned` boolean on `JobOverviewResponse` — felt like overkill for two names.
- Kept the **Run now** affordance on background tasks. Operators still want it there (ad-hoc re-execution after a failure) and these jobs are not part of the DAG, so there is no orchestrator-side concurrency model to worry about — `JobLock` + the `409 already running` path continues to guard them.

## Test plan

- [x] `pnpm --dir frontend typecheck` — green
- [x] `pnpm --dir frontend test --run` — 179 passed, 15 files
- [x] `uv run ruff check .` / `ruff format --check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest -q` — 1711 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)