### PR TITLE
feat(#260): Phase 2 — progress callbacks on long-running layers

### DIFF
--- a/app/services/financial_facts.py
+++ b/app/services/financial_facts.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 import psycopg
 
 from app.providers.fundamentals import XbrlFact
+from app.services.sync_orchestrator.progress import report_progress
 
 if TYPE_CHECKING:
     from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
@@ -182,8 +183,9 @@ def refresh_financial_facts(
     total_upserted = 0
     total_skipped = 0
     failed = 0
+    total = len(symbols)
 
-    for symbol, instrument_id, cik in symbols:
+    for idx, (symbol, instrument_id, cik) in enumerate(symbols, start=1):
         try:
             with conn.transaction():
                 facts = provider.extract_facts(symbol, cik)
@@ -207,6 +209,9 @@ def refresh_financial_facts(
         except Exception:
             failed += 1
             logger.exception("Failed to refresh SEC facts for %s", symbol)
+        report_progress(idx, total)
+
+    report_progress(total, total, force=True)
 
     status = "success" if failed == 0 else ("partial" if total_upserted > 0 else "failed")
     _finish_ingestion_run(

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -16,6 +16,7 @@ from decimal import Decimal
 import psycopg
 
 from app.providers.market_data import MarketDataProvider, OHLCVBar, Quote
+from app.services.sync_orchestrator.progress import report_progress
 from app.services.technical_analysis import OHLCVRow, compute_indicators
 
 logger = logging.getLogger(__name__)
@@ -80,9 +81,11 @@ def refresh_market_data(
     candles_skipped = 0
 
     # --- Candles: per-instrument (with freshness skip) ---
-    for instrument_id, symbol in instruments:
+    total = len(instruments)
+    for idx, (instrument_id, symbol) in enumerate(instruments, start=1):
         if _candles_are_fresh(conn, instrument_id, today):
             candles_skipped += 1
+            report_progress(idx, total)
             continue
         try:
             with conn.transaction():
@@ -94,6 +97,11 @@ def refresh_market_data(
                     features_computed += computed
         except Exception:
             logger.warning("Failed to refresh candles for %s (id=%d), skipping", symbol, instrument_id, exc_info=True)
+        report_progress(idx, total)
+
+    # Final force-tick so items_done lands at the loop boundary even
+    # if the last increment was below the throttle threshold.
+    report_progress(total, total, force=True)
 
     if candles_skipped:
         logger.info("Candle freshness skip: %d/%d instruments already fresh", candles_skipped, len(instruments))

--- a/app/services/sync_orchestrator/adapters.py
+++ b/app/services/sync_orchestrator/adapters.py
@@ -27,6 +27,10 @@ import psycopg
 from app.config import settings
 from app.jobs.locks import JobAlreadyRunning, JobLock
 from app.services.ops_monitor import record_job_skip
+from app.services.sync_orchestrator.progress import (
+    clear_active_progress,
+    set_active_progress,
+)
 from app.services.sync_orchestrator.types import (
     PREREQ_SKIP_MARKER,
     LayerOutcome,
@@ -78,18 +82,30 @@ def _latest_job_outcome(job_name: str) -> tuple[LayerOutcome, int]:
 def _run_with_lock(
     job_name: str,
     legacy_fn: Any,
+    progress: ProgressCallback | None = None,
 ) -> tuple[LayerOutcome, int] | str:
     """Run legacy_fn() under JobLock. Returns (outcome, row_count) on
     success-or-handled-failure; returns a PREREQ_SKIP reason string on
-    JobAlreadyRunning contention."""
+    JobAlreadyRunning contention.
+
+    When ``progress`` is provided, installs it on the shared ContextVar
+    (spec §2.7) so long-running inner loops can call
+    ``sync_orchestrator.progress.report_progress`` without extra
+    plumbing. The var is cleared in ``finally`` so it never leaks
+    between layers in the same sync run.
+    """
     try:
         with JobLock(settings.database_url, job_name):
+            token = set_active_progress(progress) if progress is not None else None
             try:
                 legacy_fn()
             except Exception:
                 # _tracked_job recorded failure; re-raise so the
                 # orchestrator records FAILED for the emit.
                 raise
+            finally:
+                if token is not None:
+                    clear_active_progress(token)
             return _latest_job_outcome(job_name)
     except JobAlreadyRunning:
         with psycopg.connect(settings.database_url, autocommit=True) as conn:
@@ -132,9 +148,10 @@ def _wrap_single(
     job_name: str,
     layer_name: str,
     legacy_fn: Any,
+    progress: ProgressCallback | None = None,
 ) -> Sequence[tuple[str, RefreshResult]]:
     """Common pattern for single-emit adapters."""
-    result = _run_with_lock(job_name, legacy_fn)
+    result = _run_with_lock(job_name, legacy_fn, progress=progress)
     if isinstance(result, str):
         return _single_emit_result(layer_name, LayerOutcome.PREREQ_SKIP, 0, result)
     outcome, row_count = result
@@ -183,6 +200,7 @@ def refresh_candles(
         job_name="daily_candle_refresh",
         layer_name="candles",
         legacy_fn=daily_candle_refresh,
+        progress=progress,
     )
 
 
@@ -228,6 +246,7 @@ def refresh_thesis(
         job_name="daily_thesis_refresh",
         layer_name="thesis",
         legacy_fn=daily_thesis_refresh,
+        progress=progress,
     )
 
 
@@ -321,7 +340,7 @@ def refresh_financial_facts_and_normalization(
     financial_normalization). Atomic — both emits share one outcome."""
     from app.workers.scheduler import daily_financial_facts
 
-    result = _run_with_lock("daily_financial_facts", daily_financial_facts)
+    result = _run_with_lock("daily_financial_facts", daily_financial_facts, progress=progress)
     if isinstance(result, str):
         skip = RefreshResult(
             outcome=LayerOutcome.PREREQ_SKIP,

--- a/app/services/sync_orchestrator/progress.py
+++ b/app/services/sync_orchestrator/progress.py
@@ -1,0 +1,111 @@
+"""Progress reporting for long-running layer refreshes (spec §2.7).
+
+Legacy job functions (``daily_candle_refresh``, ``daily_financial_facts``,
+``daily_thesis_refresh``) have the signature ``() -> None`` and are also
+invoked directly by APScheduler. To avoid forking their signatures or
+plumbing an extra argument through multiple service-layer calls, the
+orchestrator stashes the active ``ProgressCallback`` in a ``ContextVar``
+before calling ``legacy_fn()`` and exposes ``report_progress`` as a
+no-op-when-unset helper the loops call at item granularity.
+
+Throttling (spec: every N items **or** every 10 seconds, whichever
+comes first) is implemented here so loop bodies stay clean. When no
+progress callback is active — e.g. APScheduler calling the legacy
+function directly, or unit tests of the service-layer function —
+``report_progress`` returns without doing any work.
+
+The ContextVar is set/cleared by the orchestrator adapter; services
+layer only imports ``report_progress``.
+"""
+
+from __future__ import annotations
+
+import time
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+
+from app.services.sync_orchestrator.types import ProgressCallback
+
+_DEFAULT_TICK_EVERY_ITEMS = 5
+_DEFAULT_TICK_EVERY_SECONDS = 10.0
+
+
+@dataclass
+class _ProgressState:
+    callback: ProgressCallback
+    last_tick_items: int
+    last_tick_time: float
+
+
+_active: ContextVar[_ProgressState | None] = ContextVar("sync_orchestrator_progress", default=None)
+
+
+def set_active_progress(callback: ProgressCallback) -> Token[_ProgressState | None]:
+    """Install ``callback`` as the active progress reporter for the
+    current context. Returns a token the caller passes to
+    ``clear_active_progress`` to restore the previous state.
+
+    Fires an immediate ``(0, None)`` tick so the UI moves from 'pending'
+    to 'running' on the first poll after the layer begins — otherwise
+    the first visible tick waits for the loop to reach the throttle
+    threshold, which may be tens of seconds on slow providers.
+    """
+    state = _ProgressState(
+        callback=callback,
+        last_tick_items=0,
+        last_tick_time=time.monotonic(),
+    )
+    token = _active.set(state)
+    try:
+        callback(0, None)
+    except Exception:
+        pass
+    return token
+
+
+def clear_active_progress(token: Token[_ProgressState | None]) -> None:
+    """Restore the previous progress state. Always called from the
+    adapter's ``finally`` to guarantee the context is clean for the
+    next layer in the same sync run."""
+    _active.reset(token)
+
+
+def report_progress(
+    items_done: int,
+    items_total: int | None,
+    *,
+    tick_every_items: int = _DEFAULT_TICK_EVERY_ITEMS,
+    tick_every_seconds: float = _DEFAULT_TICK_EVERY_SECONDS,
+    force: bool = False,
+) -> None:
+    """Tick the active progress callback.
+
+    No-op when no callback is installed (the common case outside an
+    orchestrator-driven sync). Throttled so fast loops do not hammer
+    the database: emits only when ``tick_every_items`` items have
+    elapsed since the last tick OR ``tick_every_seconds`` seconds
+    have elapsed, whichever comes first. The final-state tick (loop
+    finished) should pass ``force=True`` so the last ``items_done``
+    is always persisted even if the delta is below threshold.
+
+    Callback exceptions are caught and ignored — progress reporting
+    must never abort the underlying work.
+    """
+    state = _active.get()
+    if state is None:
+        return
+
+    now = time.monotonic()
+    items_since = items_done - state.last_tick_items
+    seconds_since = now - state.last_tick_time
+
+    if not force and items_since < tick_every_items and seconds_since < tick_every_seconds:
+        return
+
+    try:
+        state.callback(items_done, items_total)
+    except Exception:
+        return
+
+    state.last_tick_items = items_done
+    state.last_tick_time = now

--- a/app/services/sync_orchestrator/progress.py
+++ b/app/services/sync_orchestrator/progress.py
@@ -89,7 +89,12 @@ def report_progress(
     is always persisted even if the delta is below threshold.
 
     Callback exceptions are caught and ignored — progress reporting
-    must never abort the underlying work.
+    must never abort the underlying work. Throttle state is advanced
+    regardless of whether the callback succeeded, so a sustained DB
+    failure does not cause a hot-retry every iteration: the next
+    threshold is measured from the attempted tick, not the last
+    successful one. A transient blip drops one tick; the next tick
+    lands naturally when the throttle elapses again.
     """
     state = _active.get()
     if state is None:
@@ -102,10 +107,12 @@ def report_progress(
     if not force and items_since < tick_every_items and seconds_since < tick_every_seconds:
         return
 
+    # Advance throttle state BEFORE calling the callback so a raised
+    # exception cannot prevent the update — preventing a hot-retry
+    # loop on sustained DB failure.
+    state.last_tick_items = items_done
+    state.last_tick_time = now
     try:
         state.callback(items_done, items_total)
     except Exception:
         return
-
-    state.last_tick_items = items_done
-    state.last_tick_time = now

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -66,6 +66,7 @@ from app.services.return_attribution import (
 )
 from app.services.scoring import compute_rankings
 from app.services.sync_orchestrator import prereq_skip_reason
+from app.services.sync_orchestrator.progress import report_progress
 from app.services.tax_ledger import ingest_tax_events, run_disposal_matching
 from app.services.thesis import find_stale_instruments, generate_thesis
 from app.services.universe import enrich_instrument_currencies, sync_universe
@@ -1137,7 +1138,8 @@ def daily_thesis_refresh() -> None:
 
         generated = 0
         skipped = 0
-        for item in stale:
+        total = len(stale)
+        for idx, item in enumerate(stale, start=1):
             try:
                 with psycopg.connect(settings.database_url) as conn:
                     generate_thesis(
@@ -1154,7 +1156,9 @@ def daily_thesis_refresh() -> None:
                     exc_info=True,
                 )
                 skipped += 1
+            report_progress(idx, total)
 
+        report_progress(total, total, force=True)
         tracker.row_count = generated
 
     logger.info(

--- a/frontend/src/pages/SyncDashboard.test.tsx
+++ b/frontend/src/pages/SyncDashboard.test.tsx
@@ -1,15 +1,38 @@
 /**
- * Unit tests for SyncDashboard helpers.
+ * Unit tests for SyncDashboard helpers + LayerProgressBar rendering.
  *
- * Focus: parseUtc — the Safari-strict ISO-8601 parse used when
- * computing sync-run durations. Without timezone normalisation,
- * Safari parses offset-less strings as local time, which would
- * produce wrong durations for operators outside UTC.
+ * Focus:
+ *   - parseUtc — the Safari-strict ISO-8601 parse used when
+ *     computing sync-run durations. Without timezone normalisation,
+ *     Safari parses offset-less strings as local time, which would
+ *     produce wrong durations for operators outside UTC.
+ *   - LayerProgressBar — the three render shapes (starting / counter
+ *     / proportional bar) driven by the active_layer progress payload
+ *     produced by the Phase 2 ticks. We render the full SyncDashboard
+ *     with a mocked sync API so the in-card progress rendering is
+ *     exercised end-to-end.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
 
-import { parseUtc } from "./SyncDashboard";
+import { SyncDashboard, parseUtc } from "./SyncDashboard";
+import {
+  fetchSyncLayers,
+  fetchSyncRuns,
+  fetchSyncStatus,
+} from "@/api/sync";
+
+vi.mock("@/api/sync", () => ({
+  fetchSyncLayers: vi.fn(),
+  fetchSyncStatus: vi.fn(),
+  fetchSyncRuns: vi.fn(),
+  triggerSync: vi.fn(),
+}));
+
+const mockedLayers = vi.mocked(fetchSyncLayers);
+const mockedStatus = vi.mocked(fetchSyncStatus);
+const mockedRuns = vi.mocked(fetchSyncRuns);
 
 describe("parseUtc", () => {
   it("parses string with explicit +00:00 offset as UTC", () => {
@@ -31,5 +54,107 @@ describe("parseUtc", () => {
     const d = parseUtc("2026-04-16T12:30:00+02:00");
     // 12:30 at +02:00 = 10:30 UTC
     expect(d.toISOString()).toBe("2026-04-16T10:30:00.000Z");
+  });
+});
+
+function baseLayersResponse() {
+  return {
+    layers: [
+      {
+        name: "candles",
+        display_name: "Candles",
+        tier: 1 as const,
+        is_fresh: false,
+        freshness_detail: "stale: 3h since last sync",
+        last_success_at: "2026-04-16T09:00:00Z",
+        last_duration_seconds: 120,
+        last_error_category: null,
+        consecutive_failures: 0,
+        dependencies: ["universe"],
+        is_blocking: true,
+      },
+    ],
+  };
+}
+
+function runningStatus(opts: {
+  itemsDone: number | null;
+  itemsTotal: number | null;
+}) {
+  return {
+    is_running: true,
+    current_run: {
+      sync_run_id: 42,
+      scope: "full",
+      trigger: "manual",
+      started_at: "2026-04-16T12:00:00Z",
+      layers_planned: 15,
+      layers_done: 3,
+      layers_failed: 0,
+      layers_skipped: 0,
+    },
+    active_layer: {
+      name: "candles",
+      started_at: "2026-04-16T12:05:00Z",
+      items_total: opts.itemsTotal,
+      items_done: opts.itemsDone,
+    },
+  };
+}
+
+describe("LayerProgressBar", () => {
+  beforeEach(() => {
+    mockedLayers.mockReset();
+    mockedStatus.mockReset();
+    mockedRuns.mockReset();
+    mockedLayers.mockResolvedValue(baseLayersResponse());
+    mockedRuns.mockResolvedValue({ runs: [] });
+  });
+
+  it("renders 'starting…' before the first items tick lands", async () => {
+    mockedStatus.mockResolvedValue(
+      runningStatus({ itemsDone: null, itemsTotal: null }),
+    );
+    render(<SyncDashboard />);
+    expect(await screen.findByText("starting…")).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+  });
+
+  it("renders plain counter when items_total is unknown", async () => {
+    mockedStatus.mockResolvedValue(
+      runningStatus({ itemsDone: 42, itemsTotal: null }),
+    );
+    render(<SyncDashboard />);
+    expect(await screen.findByText("42 items processed")).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+  });
+
+  it("renders proportional progressbar when both sides are known", async () => {
+    mockedStatus.mockResolvedValue(
+      runningStatus({ itemsDone: 25, itemsTotal: 100 }),
+    );
+    render(<SyncDashboard />);
+    const bar = await screen.findByRole("progressbar", {
+      name: "candles progress",
+    });
+    expect(bar).toHaveAttribute("aria-valuenow", "25");
+    expect(bar).toHaveAttribute("aria-valuemin", "0");
+    expect(bar).toHaveAttribute("aria-valuemax", "100");
+    expect(screen.getByText("25 / 100")).toBeInTheDocument();
+    expect(screen.getByText("25%")).toBeInTheDocument();
+  });
+
+  it("caps visible progress at 100 if items_done overshoots items_total", async () => {
+    // Defensive: an adapter that misreports (e.g. counts both a skip
+    // and a retry against the same item) must not blow past the track.
+    mockedStatus.mockResolvedValue(
+      runningStatus({ itemsDone: 150, itemsTotal: 100 }),
+    );
+    render(<SyncDashboard />);
+    const bar = await screen.findByRole("progressbar", {
+      name: "candles progress",
+    });
+    expect(bar).toHaveAttribute("aria-valuenow", "100");
+    expect(screen.getByText("100%")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/SyncDashboard.tsx
+++ b/frontend/src/pages/SyncDashboard.tsx
@@ -229,7 +229,15 @@ export function SyncDashboard() {
                   </div>
                   <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
                     {group.map((layer) => (
-                      <LayerCard key={layer.name} layer={layer} />
+                      <LayerCard
+                        key={layer.name}
+                        layer={layer}
+                        activeProgress={
+                          status.data?.active_layer?.name === layer.name
+                            ? status.data.active_layer
+                            : null
+                        }
+                      />
                     ))}
                   </div>
                 </div>
@@ -305,9 +313,33 @@ export function SyncDashboard() {
   );
 }
 
-function LayerCard({ layer }: { layer: SyncLayer }) {
-  const border = layer.is_fresh ? "border-emerald-200" : "border-amber-200";
-  const dot = layer.is_fresh ? "bg-emerald-500" : "bg-amber-500";
+interface ActiveLayerProgress {
+  name: string;
+  started_at: string | null;
+  items_total: number | null;
+  items_done: number | null;
+}
+
+function LayerCard({
+  layer,
+  activeProgress,
+}: {
+  layer: SyncLayer;
+  activeProgress: ActiveLayerProgress | null;
+}) {
+  // "Running" wins visually over fresh/stale so the operator can see
+  // the layer that is currently moving, regardless of its prior state.
+  const isRunning = activeProgress !== null;
+  const border = isRunning
+    ? "border-sky-300"
+    : layer.is_fresh
+      ? "border-emerald-200"
+      : "border-amber-200";
+  const dot = isRunning
+    ? "bg-sky-500"
+    : layer.is_fresh
+      ? "bg-emerald-500"
+      : "bg-amber-500";
   return (
     <div
       className={`rounded border ${border} bg-white p-3 text-sm shadow-sm`}
@@ -316,7 +348,7 @@ function LayerCard({ layer }: { layer: SyncLayer }) {
         <span className="font-medium text-slate-800">{layer.display_name}</span>
         <span className="flex items-center gap-1">
           <span className="sr-only">
-            {layer.is_fresh ? "fresh" : "stale"}
+            {isRunning ? "running" : layer.is_fresh ? "fresh" : "stale"}
           </span>
           <span className={`h-2 w-2 rounded-full ${dot}`} aria-hidden />
         </span>
@@ -327,6 +359,7 @@ function LayerCard({ layer }: { layer: SyncLayer }) {
       >
         {layer.freshness_detail}
       </p>
+      {isRunning && <LayerProgressBar progress={activeProgress} />}
       <div className="mt-2 flex flex-wrap gap-2 text-xs text-slate-400">
         {layer.last_success_at && (
           <span title={layer.last_success_at}>
@@ -347,6 +380,54 @@ function LayerCard({ layer }: { layer: SyncLayer }) {
           deps: {layer.dependencies.join(", ")}
         </p>
       )}
+    </div>
+  );
+}
+
+/**
+ * Progress bar for an active layer.
+ *
+ * Renders three shapes depending on what the adapter has reported:
+ *   - "starting…" while items_done is null (the initial tick has not
+ *     landed, or the layer just installed the callback).
+ *   - "N items" as a plain counter when items_total is null (the
+ *     adapter does not know the total — e.g. non-item-oriented work).
+ *   - A proportional bar when both items_done and items_total are
+ *     known. Width is capped at 100% so an adapter that misreports
+ *     items_done > items_total never blows past the visible track.
+ */
+function LayerProgressBar({ progress }: { progress: ActiveLayerProgress }) {
+  const { items_done, items_total } = progress;
+  if (items_done === null) {
+    return <p className="mt-2 text-xs text-sky-600">starting…</p>;
+  }
+  if (items_total === null || items_total === 0) {
+    return (
+      <p className="mt-2 text-xs text-sky-600">{items_done} items processed</p>
+    );
+  }
+  const pct = Math.min(100, Math.round((items_done / items_total) * 100));
+  return (
+    <div className="mt-2">
+      <div className="flex items-center justify-between text-xs text-sky-600">
+        <span>
+          {items_done} / {items_total}
+        </span>
+        <span>{pct}%</span>
+      </div>
+      <div
+        className="mt-1 h-1.5 w-full overflow-hidden rounded bg-sky-100"
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${progress.name} progress`}
+      >
+        <div
+          className="h-full bg-sky-500 transition-[width] duration-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
     </div>
   );
 }

--- a/tests/test_sync_orchestrator_progress.py
+++ b/tests/test_sync_orchestrator_progress.py
@@ -103,13 +103,8 @@ class TestThrottle:
 
 
 class TestCallbackErrorHandling:
-    def test_callback_exception_is_swallowed_and_state_advances(self) -> None:
-        # A callback that raises must not abort the loop. The throttle
-        # state is NOT advanced on failure, so subsequent threshold
-        # checks continue to operate on the prior tick — this is
-        # intentional: if the DB is momentarily unavailable, we want
-        # to retry on the next tick rather than silently skip until
-        # the next time threshold.
+    def test_callback_exception_is_swallowed(self) -> None:
+        # A callback that raises must not abort the loop.
         cb = MagicMock(side_effect=RuntimeError("db down"))
         with patch("app.services.sync_orchestrator.progress.time.monotonic", return_value=100.0):
             token = set_active_progress(cb)
@@ -118,7 +113,25 @@ class TestCallbackErrorHandling:
 
             report_progress(5, 100)  # hits threshold, callback raises
 
-            # Callback was invoked once despite raising.
+            cb.assert_called_once_with(5, 100)
+            clear_active_progress(token)
+
+    def test_throttle_state_advances_on_exception(self) -> None:
+        # A sustained DB failure must not cause a hot-retry loop. The
+        # throttle state is advanced BEFORE the callback is invoked,
+        # so the next threshold is measured from the attempted tick,
+        # not the last successful one. Verify by firing a failing
+        # tick then immediately another below the item threshold —
+        # the second call must be throttled, not attempted.
+        cb = MagicMock(side_effect=RuntimeError("db down"))
+        with patch("app.services.sync_orchestrator.progress.time.monotonic", return_value=100.0):
+            token = set_active_progress(cb)
+            cb.reset_mock()
+            cb.side_effect = RuntimeError("db down")
+
+            report_progress(5, 100)  # threshold, callback raises, state advances
+            report_progress(6, 100)  # item delta = 1 from the advanced state, throttled
+
             cb.assert_called_once_with(5, 100)
             clear_active_progress(token)
 

--- a/tests/test_sync_orchestrator_progress.py
+++ b/tests/test_sync_orchestrator_progress.py
@@ -1,0 +1,165 @@
+"""Unit tests for app.services.sync_orchestrator.progress.
+
+Focus:
+  - ``report_progress`` is a no-op when no callback is installed
+    (the common case — APScheduler calling a legacy job directly, or
+    unit tests of the service-layer function without an orchestrator).
+  - ``set_active_progress`` fires an immediate (0, None) tick so the
+    UI can leave 'pending' on the first poll.
+  - Throttling: emits only when the item delta OR time delta exceeds
+    the threshold; ``force=True`` bypasses both.
+  - Callback exceptions are swallowed (progress reporting must never
+    abort work).
+  - The ContextVar is properly cleared by the token restore so state
+    does not leak between layers in the same sync run.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.sync_orchestrator.progress import (
+    clear_active_progress,
+    report_progress,
+    set_active_progress,
+)
+
+
+class TestNoActiveCallback:
+    def test_report_progress_is_noop_when_no_callback(self) -> None:
+        # No ContextVar set — must return without raising.
+        report_progress(5, 100)
+        report_progress(10, 100, force=True)
+
+
+class TestImmediateTickOnInstall:
+    def test_set_active_progress_fires_initial_zero_tick(self) -> None:
+        cb = MagicMock()
+        token = set_active_progress(cb)
+        try:
+            cb.assert_called_once_with(0, None)
+        finally:
+            clear_active_progress(token)
+
+    def test_swallows_exception_from_initial_tick(self) -> None:
+        cb = MagicMock(side_effect=RuntimeError("boom"))
+        # Must not raise — progress reporting must never abort the
+        # work it is instrumenting.
+        token = set_active_progress(cb)
+        clear_active_progress(token)
+
+
+class TestThrottle:
+    def test_suppresses_ticks_below_item_and_time_threshold(self) -> None:
+        cb = MagicMock()
+        with patch("app.services.sync_orchestrator.progress.time.monotonic", return_value=100.0):
+            token = set_active_progress(cb)
+            cb.reset_mock()  # drop the install-time tick
+
+            # Items delta = 2 (below default 5); time delta = 0 (below 10s).
+            report_progress(2, 100)
+            report_progress(4, 100)
+
+            assert cb.call_count == 0
+            clear_active_progress(token)
+
+    def test_emits_when_item_threshold_met(self) -> None:
+        cb = MagicMock()
+        with patch("app.services.sync_orchestrator.progress.time.monotonic", return_value=100.0):
+            token = set_active_progress(cb)
+            cb.reset_mock()
+
+            # Items delta = 5 (default threshold).
+            report_progress(5, 100)
+
+            cb.assert_called_once_with(5, 100)
+            clear_active_progress(token)
+
+    def test_emits_when_time_threshold_met(self) -> None:
+        cb = MagicMock()
+        monotonic = MagicMock(side_effect=[100.0, 115.0])  # install, then tick
+        with patch("app.services.sync_orchestrator.progress.time.monotonic", monotonic):
+            token = set_active_progress(cb)
+            cb.reset_mock()
+
+            # Items delta = 1 (below 5); time delta = 15s (above 10s).
+            report_progress(1, 100)
+
+            cb.assert_called_once_with(1, 100)
+            clear_active_progress(token)
+
+    def test_force_bypasses_throttle(self) -> None:
+        cb = MagicMock()
+        with patch("app.services.sync_orchestrator.progress.time.monotonic", return_value=100.0):
+            token = set_active_progress(cb)
+            cb.reset_mock()
+
+            report_progress(1, 100, force=True)
+
+            cb.assert_called_once_with(1, 100)
+            clear_active_progress(token)
+
+
+class TestCallbackErrorHandling:
+    def test_callback_exception_is_swallowed_and_state_advances(self) -> None:
+        # A callback that raises must not abort the loop. The throttle
+        # state is NOT advanced on failure, so subsequent threshold
+        # checks continue to operate on the prior tick — this is
+        # intentional: if the DB is momentarily unavailable, we want
+        # to retry on the next tick rather than silently skip until
+        # the next time threshold.
+        cb = MagicMock(side_effect=RuntimeError("db down"))
+        with patch("app.services.sync_orchestrator.progress.time.monotonic", return_value=100.0):
+            token = set_active_progress(cb)
+            cb.reset_mock()
+            cb.side_effect = RuntimeError("db down")
+
+            report_progress(5, 100)  # hits threshold, callback raises
+
+            # Callback was invoked once despite raising.
+            cb.assert_called_once_with(5, 100)
+            clear_active_progress(token)
+
+
+class TestContextVarIsolation:
+    def test_clear_restores_previous_state(self) -> None:
+        # After clear, a subsequent report_progress must not invoke
+        # the old callback — the var has been reset.
+        cb = MagicMock()
+        token = set_active_progress(cb)
+        cb.reset_mock()
+        clear_active_progress(token)
+
+        report_progress(100, 100, force=True)
+
+        cb.assert_not_called()
+
+    def test_nested_progress_contexts_restore_outer(self) -> None:
+        outer = MagicMock()
+        inner = MagicMock()
+
+        outer_token = set_active_progress(outer)
+        outer.reset_mock()
+
+        inner_token = set_active_progress(inner)
+        inner.reset_mock()
+
+        # Inner active: only `inner` should receive the forced tick.
+        report_progress(1, 10, force=True)
+        inner.assert_called_once_with(1, 10)
+        outer.assert_not_called()
+
+        clear_active_progress(inner_token)
+
+        # Outer restored: now `outer` receives.
+        outer.reset_mock()
+        report_progress(2, 10, force=True)
+        outer.assert_called_once_with(2, 10)
+
+        clear_active_progress(outer_token)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes out the data-orchestrator rollout (#260). Phase 1 stood up the ProgressCallback infrastructure; Phase 2 actually emits ticks from the three long-running layers (candles, financial_facts, thesis) and surfaces them as a live progress bar in SyncDashboard.

## Design — ContextVar bridge

Legacy job functions have signature `() -> None` and are also invoked directly by APScheduler. Rather than forking their signatures or threading an extra argument through several service-layer calls, the orchestrator adapter stashes the active `ProgressCallback` in a `ContextVar` before calling `legacy_fn()`. Service-layer loops import a tiny `report_progress(done, total)` helper that reads the var and ticks with throttling; when no var is set (APScheduler invocation, unit tests) it is a no-op.

Throttling matches spec §2.7 — emit every N items (default 5) OR every 10s, whichever first. `force=True` bypasses the threshold for the final loop-boundary tick so `items_done` always lands at the true total. `set_active_progress` fires an immediate `(0, None)` tick so the UI leaves 'pending' on the first poll.

## Changes

**Backend**
- `app/services/sync_orchestrator/progress.py` — new module (ContextVar, install/clear, throttled `report_progress`). Callback exceptions are swallowed: progress reporting must never abort work.
- `app/services/sync_orchestrator/adapters.py` — `_run_with_lock` / `_wrap_single` accept optional `progress`, install on the ContextVar, clear in `finally`. Only the three long-running adapters pass it through.
- `app/services/market_data.py::refresh_market_data` — per-instrument tick in the candles loop + final force tick.
- `app/services/financial_facts.py::refresh_financial_facts` — per-symbol tick + final force tick.
- `app/workers/scheduler.py::daily_thesis_refresh` — per-stale-instrument tick + final force tick.

**Frontend**
- `SyncDashboard` threads `status.data.active_layer` into the matching LayerCard.
- `LayerCard` gets a running-state border (sky-300) that beats fresh/stale so the active layer is obvious.
- New `LayerProgressBar` component — three render shapes: `starting…` / `N items processed` / proportional `<div role=\"progressbar\">` with ARIA. Width capped at 100% to defend against adapter misreporting.

**Tests**
- `tests/test_sync_orchestrator_progress.py` (new, 10 tests) — no-op without callback, initial zero tick, item-delta trigger, time-delta trigger (monotonic clock mocked), force bypass, callback exception swallowing, ContextVar isolation (clear + nested install).
- `frontend/src/pages/SyncDashboard.test.tsx` (extended, 4 new) — three render shapes + 100% cap.

## Security model

No change. No new endpoints; no new writes outside `sync_layer_progress` which was already writable by the orchestrator. Progress callback exceptions are caught so a broken DB connection during a tick cannot abort the layer work itself.

## Tradeoffs

- **ContextVar vs explicit argument.** The alternative — extending every legacy job's signature with `progress: ProgressCallback | None = None` — would be more discoverable but would force churn across 13 scheduler functions and their unit tests for value only three of them use. ContextVar keeps the blast radius tight and makes the \"no callback\" path a true no-op.
- **Throttle state advances on callback exception.** When the progress UPDATE fails (DB blip), the state advances anyway; the next item/time threshold retries. Rationale: under sustained DB failure we'd otherwise re-hit the failing callback on every tick, pouring exceptions into the log. The cost is one dropped visible tick on a transient blip — the loop's own log line still records per-item progress at INFO.
- **Progress bar overrides freshness colour while running.** A layer that was stale and is currently running shows sky-blue rather than amber. Operators care most about \"what's moving now\" during an active sync; the freshness dot returns as soon as the active_layer moves on.

## Test plan

- [x] `uv run ruff check .` / `ruff format --check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest -q` — 1721 passed, 1 skipped (+10 tests over main)
- [x] `pnpm --dir frontend typecheck` — green
- [x] `pnpm --dir frontend test --run` — 183 passed (+4 over main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)