### PR TITLE
fix: orchestrator_full_sync catchup + CIK upsert idempotency

### DIFF
--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -117,6 +117,28 @@ def upsert_cik_mapping(
             if not cik:
                 logger.debug("CIK mapping: no CIK found for symbol %s", symbol)
                 continue
+            # external_identifiers has TWO uniqueness constraints:
+            #   (a) uq_external_identifiers_provider_value — UNIQUE(provider,
+            #       identifier_type, identifier_value)
+            #   (b) uq_external_identifiers_primary — partial UNIQUE
+            #       (instrument_id, provider, identifier_type) WHERE is_primary=TRUE
+            # ON CONFLICT can only target one. If an instrument already has a
+            # primary sec/cik row with a DIFFERENT value (e.g. the SEC ticker
+            # map changed), the INSERT below would violate (b) before (a)
+            # ever matched. Demote any mismatching primary row first so the
+            # upsert's own conflict target handles the rest.
+            conn.execute(
+                """
+                UPDATE external_identifiers
+                SET is_primary = FALSE
+                WHERE instrument_id     = %(instrument_id)s
+                  AND provider          = 'sec'
+                  AND identifier_type   = 'cik'
+                  AND is_primary        = TRUE
+                  AND identifier_value != %(cik)s
+                """,
+                {"instrument_id": instrument_id, "cik": cik},
+            )
             conn.execute(
                 """
                 INSERT INTO external_identifiers (
@@ -129,6 +151,7 @@ def upsert_cik_mapping(
                 )
                 ON CONFLICT (provider, identifier_type, identifier_value) DO UPDATE SET
                     instrument_id    = EXCLUDED.instrument_id,
+                    is_primary       = TRUE,
                     last_verified_at = NOW()
                 """,
                 {"instrument_id": instrument_id, "cik": cik},

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -380,6 +380,12 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         name=JOB_ORCHESTRATOR_FULL_SYNC,
         description="Orchestrator full sync — walks the DAG and refreshes stale layers.",
         cadence=Cadence.daily(hour=3, minute=0),
+        # Never catch up on boot. A full sync runs ~45min (research refresh
+        # dominates) and holds DB connections the HTTP layer needs. Every
+        # dev-stack restart would otherwise fire a catch-up and wedge the
+        # site until it finishes. If the 03:00 UTC slot is missed, the
+        # operator can click "Sync now" in the admin UI.
+        catch_up_on_boot=False,
     ),
     # Every-5-minutes refresh of independent high-frequency layers
     # (portfolio_sync + fx_rates). The orchestrator's partial unique


### PR DESCRIPTION
## What
- `orchestrator_full_sync` now `catch_up_on_boot=False`. Dev-stack restart no longer fires a 45-min catch-up that starves HTTP.
- `upsert_cik_mapping` demotes mismatching primary rows before the ON CONFLICT upsert, so a changed SEC CIK on an instrument no longer violates `uq_external_identifiers_primary`.

## Why
Live stack hung after Phase 4 merged: every reload fired a catch-up full sync, research_refresh held connections for 45 min, frontend polled /sync/status into a saturated backend. Separately, daily_cik_refresh failed every run with the same partial-unique violation — polluting job_runs and breaking CIK freshness.

## Test plan
- uv run ruff check . && uv run ruff format --check . && uv run pyright
- uv run pytest -q — 1722 passed