### PR TITLE
feat(#269): external_data_watermarks table + service helper

### DIFF
--- a/app/services/watermarks.py
+++ b/app/services/watermarks.py
@@ -1,0 +1,142 @@
+"""External data watermark store (#269).
+
+Every incremental-fetch adapter uses the same helper to remember
+"what was the newest thing we saw last time from this provider."
+Replaces the pattern of each job rolling its own bespoke storage.
+
+Usage pattern:
+
+    from app.services.watermarks import get_watermark, set_watermark
+
+    wm = get_watermark(conn, "sec.tickers", "global")
+    headers = {}
+    if wm and wm.response_hash:
+        headers["If-Modified-Since"] = wm.watermark  # Last-Modified value
+
+    resp = http.get(url, headers=headers)
+    if resp.status_code == 304:
+        return  # nothing changed
+
+    body_hash = sha256(resp.content).hexdigest()
+    if wm and wm.response_hash == body_hash:
+        return  # identical body, provider didn't serve 304 (e.g. FMP)
+
+    # Do the work — upsert / ingest
+    ...
+
+    set_watermark(
+        conn,
+        source="sec.tickers",
+        key="global",
+        watermark=resp.headers.get("Last-Modified", ""),
+        watermark_at=parse_http_date(resp.headers.get("Last-Modified")),
+        response_hash=body_hash,
+    )
+
+The ``source`` identifier is a stable short string — one per
+"data source under a specific fetch contract." Document new sources
+in docs/superpowers/plans/2026-04-17-lightweight-etl-audit.md so
+future adapters reuse names rather than inventing variants.
+
+The ``watermark`` value is opaque to this module. Callers interpret
+it (ETag string, accession_number, ISO date) in their own domain.
+This module is pure key-value storage.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import psycopg
+
+
+@dataclass(frozen=True)
+class Watermark:
+    """Snapshot of a stored watermark row."""
+
+    source: str
+    key: str
+    watermark: str
+    watermark_at: datetime | None
+    fetched_at: datetime
+    response_hash: str | None
+
+
+def get_watermark(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    source: str,
+    key: str,
+) -> Watermark | None:
+    """Return the stored watermark row for (source, key), or None if
+    no watermark has ever been recorded.
+
+    None return is a hot-path signal to the caller: "no prior state,
+    do full backfill instead of incremental fetch." Do not treat
+    a missing row as an error.
+    """
+    row = conn.execute(
+        """
+        SELECT source, key, watermark, watermark_at, fetched_at, response_hash
+        FROM external_data_watermarks
+        WHERE source = %s AND key = %s
+        """,
+        (source, key),
+    ).fetchone()
+    if row is None:
+        return None
+    return Watermark(
+        source=row[0],
+        key=row[1],
+        watermark=row[2],
+        watermark_at=row[3],
+        fetched_at=row[4],
+        response_hash=row[5],
+    )
+
+
+def set_watermark(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    *,
+    source: str,
+    key: str,
+    watermark: str,
+    watermark_at: datetime | None = None,
+    response_hash: str | None = None,
+) -> None:
+    """Upsert the watermark row for (source, key).
+
+    Callers must invoke this inside their own transaction — the
+    watermark write and the actual data upsert must land atomically
+    so a crash mid-ingest doesn't leave the watermark ahead of the
+    data (next run would skip work that wasn't finished).
+    """
+    conn.execute(
+        """
+        INSERT INTO external_data_watermarks (
+            source, key, watermark, watermark_at, response_hash, fetched_at
+        )
+        VALUES (%s, %s, %s, %s, %s, NOW())
+        ON CONFLICT (source, key) DO UPDATE SET
+            watermark      = EXCLUDED.watermark,
+            watermark_at   = EXCLUDED.watermark_at,
+            response_hash  = EXCLUDED.response_hash,
+            fetched_at     = EXCLUDED.fetched_at
+        """,
+        (source, key, watermark, watermark_at, response_hash),
+    )
+
+
+def list_keys(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    source: str,
+) -> list[str]:
+    """Return all stored keys for ``source``. Used by adapters to
+    enumerate "entities we have a prior watermark for" — typically
+    CIKs that have been seen at least once — vs entities still
+    needing initial backfill."""
+    rows = conn.execute(
+        "SELECT key FROM external_data_watermarks WHERE source = %s ORDER BY key",
+        (source,),
+    ).fetchall()
+    return [r[0] for r in rows]

--- a/app/services/watermarks.py
+++ b/app/services/watermarks.py
@@ -49,6 +49,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 import psycopg
+from psycopg.pq import TransactionStatus
 
 
 @dataclass(frozen=True)
@@ -106,11 +107,25 @@ def set_watermark(
 ) -> None:
     """Upsert the watermark row for (source, key).
 
-    Callers must invoke this inside their own transaction — the
-    watermark write and the actual data upsert must land atomically
-    so a crash mid-ingest doesn't leave the watermark ahead of the
-    data (next run would skip work that wasn't finished).
+    Callers MUST invoke this inside their own transaction. The watermark
+    write and the actual data upsert must land atomically — a crash
+    mid-ingest that committed the watermark but not the data would
+    cause the next run to skip work that was never finished.
+
+    Enforced at runtime: raises RuntimeError if the connection is not
+    currently in an open transaction (INTRANS status). Autocommit
+    connections and idle connections both fail the check. This turns
+    a silent correctness hazard into a loud boot-time signal.
     """
+    status = conn.info.transaction_status
+    if status != TransactionStatus.INTRANS:
+        raise RuntimeError(
+            f"set_watermark must be called inside an open transaction "
+            f"(got TransactionStatus={status}). The watermark write and "
+            f"the data upsert must be atomic — otherwise a crash between "
+            f"them leaves the watermark ahead of the data. Wrap this call "
+            f"in `with conn.transaction():` along with the data write."
+        )
     conn.execute(
         """
         INSERT INTO external_data_watermarks (

--- a/app/services/watermarks.py
+++ b/app/services/watermarks.py
@@ -119,12 +119,22 @@ def set_watermark(
     """
     status = conn.info.transaction_status
     if status != TransactionStatus.INTRANS:
+        # INTRANS is the ONLY valid status. All other values fail:
+        #   IDLE     — autocommit or no transaction opened
+        #   UNKNOWN  — connection broken / closed
+        #   ACTIVE   — a command is currently executing (bug: should not reach here)
+        #   INERROR  — transaction is aborted; any write would raise
+        #              "current transaction is aborted" — surface the
+        #              true cause up front instead.
+        if status == TransactionStatus.INERROR:
+            detail = "transaction is in error state — rollback before retrying"
+        else:
+            detail = "wrap this call in `with conn.transaction():` along with the data write"
         raise RuntimeError(
             f"set_watermark must be called inside an open transaction "
             f"(got TransactionStatus={status}). The watermark write and "
             f"the data upsert must be atomic — otherwise a crash between "
-            f"them leaves the watermark ahead of the data. Wrap this call "
-            f"in `with conn.transaction():` along with the data write."
+            f"them leaves the watermark ahead of the data. {detail}."
         )
     conn.execute(
         """

--- a/docs/superpowers/plans/2026-04-17-lightweight-etl-audit.md
+++ b/docs/superpowers/plans/2026-04-17-lightweight-etl-audit.md
@@ -135,19 +135,23 @@ No provider wired. Out of scope. When wired, apply the same watermark principle 
 **Impact:** Near-real-time position updates (seconds not 5 min) AND ~3x reduction in REST polling.
 **Ticket:** #274.
 
-### `fx_rates` → `fx_rates_refresh` (Frankfurter)
+### `fx_rates` — split into live + EOD sources
 
-**Current:** Hourly poll.
-**Provider capability:** `ETag` → 304. ECB publishes ~16:00 CET on TARGET working days.
-**Recommendation:**
-- Schedule **one call per day at 16:15 CET** with `If-None-Match` holding last ETag.
-- If 304, no writes.
-- If 200, upsert with the ECB publication date as `quoted_at` (matches current pattern).
+Decision 2026-04-17: two FX sources, split by purpose, no accidental mixing.
+
+**Live stock / portfolio / P&L conversions → eToro FX instruments** (ticket #281):
+- FX pairs (GBP/USD, GBP/EUR, EUR/USD, …) are tradable instruments on eToro with their own WebSocket rate streams.
+- Subscribe via the WebSocket integration from #274.
+- Marks match what actually executes on the broker — no drift between eBull P&L and eToro statements.
+
+**Tax report conversions → Frankfurter ECB** (ticket #275):
+- ECB published central-bank reference rate — the correct source for tax filings wanting a regulatory-approved rate.
+- Fetched once per day at 16:15 CET with `If-None-Match` → 304 on no-change.
 - Skip non-TARGET days (weekends + TARGET holidays).
-- Optional: one fallback call at 17:00 CET for late-publication days (rare).
 
-**Impact:** 24 calls/day → 1-2. ~95% reduction. Eliminates the meaningless weekend polls.
-**Ticket:** #275.
+Every conversion path must be tagged at the call site with which source should feed it. No caller should ever be able to pick up the wrong one by accident — separate service modules (`fx_live.py` vs `fx_eod.py`) keep the boundary explicit.
+
+**Impact:** Live P&L becomes intraday-accurate. Frankfurter polling drops from 24/day → 1-2/day. Broker-statement reconciliation becomes trivial.
 
 ### `cost_models` / `weekly_reports` / `monthly_reports`
 

--- a/sql/034_external_data_watermarks.sql
+++ b/sql/034_external_data_watermarks.sql
@@ -30,8 +30,6 @@ CREATE TABLE IF NOT EXISTS external_data_watermarks (
     PRIMARY KEY (source, key)
 );
 
--- Index helps `SELECT key FROM external_data_watermarks WHERE source = ?`
--- scans which the incremental-fetch jobs run to enumerate "CIKs we have
--- a prior watermark for" vs "CIKs still needing initial backfill."
-CREATE INDEX IF NOT EXISTS idx_external_data_watermarks_source
-    ON external_data_watermarks(source);
+-- No separate single-column index on `source` needed: the composite PK
+-- above already creates a btree index on (source, key), which Postgres
+-- can use for leftmost-prefix lookups on `source` alone.

--- a/sql/034_external_data_watermarks.sql
+++ b/sql/034_external_data_watermarks.sql
@@ -1,0 +1,37 @@
+-- Migration 034: external_data_watermarks (issue #269)
+--
+-- A single per-source watermark store used by every incremental-fetch
+-- adapter to remember "what was the newest thing we saw last time from
+-- this provider." Replaces the pattern of each job rolling its own
+-- bespoke storage (per-row last_verified_at on domain tables, implicit
+-- "latest job_runs row" lookups, etc.).
+--
+-- The `source` column is a stable string identifier for the data source
+-- under a specific fetch contract — e.g. `sec.tickers` for the CIK
+-- mapping, `sec.submissions` for per-company filings listings,
+-- `frankfurter.latest` for the ECB rate feed. Keep this identifier
+-- documented in docs/superpowers/plans/2026-04-17-lightweight-etl-audit.md
+-- so future adapters pick the same name.
+--
+-- The `key` column is the per-entity key: CIK for per-company SEC
+-- watermarks, `global` for singleton sources (no per-entity dimension).
+--
+-- `watermark` is the opaque provider-native token — ETag string,
+-- accession_number, ISO date, etc. The caller knows how to interpret it;
+-- this table is pure key-value storage.
+
+CREATE TABLE IF NOT EXISTS external_data_watermarks (
+    source          TEXT NOT NULL,
+    key             TEXT NOT NULL,
+    watermark       TEXT NOT NULL,
+    watermark_at    TIMESTAMPTZ,
+    fetched_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    response_hash   TEXT,
+    PRIMARY KEY (source, key)
+);
+
+-- Index helps `SELECT key FROM external_data_watermarks WHERE source = ?`
+-- scans which the incremental-fetch jobs run to enumerate "CIKs we have
+-- a prior watermark for" vs "CIKs still needing initial backfill."
+CREATE INDEX IF NOT EXISTS idx_external_data_watermarks_source
+    ON external_data_watermarks(source);

--- a/tests/test_watermarks.py
+++ b/tests/test_watermarks.py
@@ -1,0 +1,122 @@
+"""Unit tests for app.services.watermarks (#269).
+
+Mocks psycopg.Connection at the service boundary — the helper does
+plain SELECT / INSERT ON CONFLICT, no driver-specific behaviour to
+exercise live. The schema itself is covered by the migration and by
+the smoke test that boots the app lifespan.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+from app.services.watermarks import Watermark, get_watermark, list_keys, set_watermark
+
+
+def _mock_conn(fetchone_return=None, fetchall_return=None):
+    """Build a MagicMock conn whose `execute().fetchone()` returns the
+    given row and whose `execute().fetchall()` returns the given list.
+
+    Each call to `execute()` returns a fresh cursor-like mock with both
+    `fetchone` and `fetchall` wired — matches the psycopg3 pattern
+    where `conn.execute(...)` returns a cursor you can immediately
+    call `fetchone()`/`fetchall()` on.
+    """
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = fetchone_return
+    cursor.fetchall.return_value = fetchall_return or []
+    conn.execute.return_value = cursor
+    return conn
+
+
+class TestGetWatermark:
+    def test_returns_none_when_row_missing(self) -> None:
+        conn = _mock_conn(fetchone_return=None)
+        result = get_watermark(conn, "sec.tickers", "global")
+        assert result is None
+
+    def test_returns_watermark_dataclass_on_hit(self) -> None:
+        now = datetime.now(UTC)
+        watermark_at = datetime(2026, 4, 15, 20, 5, 57, tzinfo=UTC)
+        conn = _mock_conn(
+            fetchone_return=(
+                "sec.tickers",
+                "global",
+                "Wed, 15 Apr 2026 20:05:57 GMT",
+                watermark_at,
+                now,
+                "abc123",
+            ),
+        )
+        result = get_watermark(conn, "sec.tickers", "global")
+        assert result == Watermark(
+            source="sec.tickers",
+            key="global",
+            watermark="Wed, 15 Apr 2026 20:05:57 GMT",
+            watermark_at=watermark_at,
+            fetched_at=now,
+            response_hash="abc123",
+        )
+
+    def test_sends_parameterised_query(self) -> None:
+        """Never interpolate source/key into the SQL — they can be
+        attacker-controlled in principle (downstream bugs could route
+        external identifiers into the source arg). Parameters only."""
+        conn = _mock_conn(fetchone_return=None)
+        get_watermark(conn, "sec.tickers", "'; DROP TABLE users --")
+        call = conn.execute.call_args
+        sql, params = call[0]
+        assert "%s" in sql
+        assert "DROP TABLE" not in sql  # never interpolated into SQL text
+        assert params == ("sec.tickers", "'; DROP TABLE users --")
+
+
+class TestSetWatermark:
+    def test_upsert_sends_all_columns(self) -> None:
+        conn = _mock_conn()
+        now = datetime(2026, 4, 17, 12, 0, 0, tzinfo=UTC)
+        set_watermark(
+            conn,
+            source="sec.submissions",
+            key="0000320193",
+            watermark="0001140361-26-013192",
+            watermark_at=now,
+            response_hash="deadbeef",
+        )
+        sql, params = conn.execute.call_args[0]
+        assert "INSERT INTO external_data_watermarks" in sql
+        assert "ON CONFLICT (source, key) DO UPDATE" in sql
+        assert params == (
+            "sec.submissions",
+            "0000320193",
+            "0001140361-26-013192",
+            now,
+            "deadbeef",
+        )
+
+    def test_defaults_watermark_at_and_hash_to_none(self) -> None:
+        conn = _mock_conn()
+        set_watermark(
+            conn,
+            source="frankfurter.latest",
+            key="global",
+            watermark='"etag-value-123"',
+        )
+        _sql, params = conn.execute.call_args[0]
+        assert params[3] is None
+        assert params[4] is None
+
+
+class TestListKeys:
+    def test_returns_sorted_keys(self) -> None:
+        conn = _mock_conn(
+            fetchall_return=[("0000320193",), ("0000789019",), ("0001018724",)],
+        )
+        keys = list_keys(conn, "sec.submissions")
+        assert keys == ["0000320193", "0000789019", "0001018724"]
+
+    def test_returns_empty_list_when_source_has_no_entries(self) -> None:
+        conn = _mock_conn(fetchall_return=[])
+        assert list_keys(conn, "sec.submissions") == []

--- a/tests/test_watermarks.py
+++ b/tests/test_watermarks.py
@@ -119,12 +119,24 @@ class TestSetWatermark:
         assert params[3] is None
         assert params[4] is None
 
-    def test_refuses_to_write_outside_a_transaction(self) -> None:
-        """Autocommit/idle connections would commit the watermark
-        immediately, potentially ahead of the data ingest — crash
-        recovery would then skip unfinished work silently. The runtime
-        check turns this correctness hazard into a loud RuntimeError."""
-        conn = _mock_conn(transaction_status=TransactionStatus.IDLE)
+    @pytest.mark.parametrize(
+        "status",
+        [
+            TransactionStatus.IDLE,
+            TransactionStatus.UNKNOWN,
+            TransactionStatus.INERROR,
+            TransactionStatus.ACTIVE,
+        ],
+    )
+    def test_refuses_to_write_outside_an_open_transaction(self, status: TransactionStatus) -> None:
+        """Every non-INTRANS status must raise BEFORE execute is called.
+        Autocommit connections report IDLE; closed/broken report UNKNOWN;
+        aborted transactions report INERROR; a command mid-flight reports
+        ACTIVE. None of them are safe targets for a watermark write —
+        committing watermark ahead of data (IDLE/UNKNOWN) or against an
+        aborted transaction (INERROR) would silently skip work on the
+        next run or produce a cryptic downstream error."""
+        conn = _mock_conn(transaction_status=status)
         with pytest.raises(RuntimeError, match="inside an open transaction"):
             set_watermark(
                 conn,
@@ -132,8 +144,15 @@ class TestSetWatermark:
                 key="0000320193",
                 watermark="acc-1",
             )
-        # Critically: execute was NEVER called — we refused before writing.
         conn.execute.assert_not_called()
+
+    def test_inerror_produces_dedicated_rollback_hint(self) -> None:
+        """INERROR is the trickiest state — PostgreSQL would reject the
+        write with 'current transaction is aborted' anyway, but the
+        helpful cause ('rollback before retrying') beats the raw error."""
+        conn = _mock_conn(transaction_status=TransactionStatus.INERROR)
+        with pytest.raises(RuntimeError, match="rollback before retrying"):
+            set_watermark(conn, source="s", key="k", watermark="v")
 
 
 class TestListKeys:

--- a/tests/test_watermarks.py
+++ b/tests/test_watermarks.py
@@ -11,23 +11,34 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
+import pytest
+from psycopg.pq import TransactionStatus
+
 from app.services.watermarks import Watermark, get_watermark, list_keys, set_watermark
 
 
-def _mock_conn(fetchone_return=None, fetchall_return=None):
+def _mock_conn(
+    fetchone_return=None,
+    fetchall_return=None,
+    transaction_status=TransactionStatus.INTRANS,
+):
     """Build a MagicMock conn whose `execute().fetchone()` returns the
     given row and whose `execute().fetchall()` returns the given list.
 
     Each call to `execute()` returns a fresh cursor-like mock with both
     `fetchone` and `fetchall` wired — matches the psycopg3 pattern
     where `conn.execute(...)` returns a cursor you can immediately
-    call `fetchone()`/`fetchall()` on.
+    call `fetchone()`/`fetchall()` on. `transaction_status` simulates
+    the `conn.info.transaction_status` check `set_watermark` uses to
+    enforce its in-transaction invariant; default is INTRANS so tests
+    that don't care about the guard behave like legitimate callers.
     """
     conn = MagicMock()
     cursor = MagicMock()
     cursor.fetchone.return_value = fetchone_return
     cursor.fetchall.return_value = fetchall_return or []
     conn.execute.return_value = cursor
+    conn.info.transaction_status = transaction_status
     return conn
 
 
@@ -107,6 +118,22 @@ class TestSetWatermark:
         _sql, params = conn.execute.call_args[0]
         assert params[3] is None
         assert params[4] is None
+
+    def test_refuses_to_write_outside_a_transaction(self) -> None:
+        """Autocommit/idle connections would commit the watermark
+        immediately, potentially ahead of the data ingest — crash
+        recovery would then skip unfinished work silently. The runtime
+        check turns this correctness hazard into a loud RuntimeError."""
+        conn = _mock_conn(transaction_status=TransactionStatus.IDLE)
+        with pytest.raises(RuntimeError, match="inside an open transaction"):
+            set_watermark(
+                conn,
+                source="sec.submissions",
+                key="0000320193",
+                watermark="acc-1",
+            )
+        # Critically: execute was NEVER called — we refused before writing.
+        conn.execute.assert_not_called()
 
 
 class TestListKeys:


### PR DESCRIPTION
## What
- sql/034 migration: \`external_data_watermarks(source, key, watermark, watermark_at, fetched_at, response_hash)\`
- \`app/services/watermarks.py\`: \`get_watermark\` / \`set_watermark\` / \`list_keys\` helpers
- 7 unit tests
- Plan doc FX section updated — keep both sources, split by purpose

## Why
Blocker for #270, #272, #275, #276. Replaces per-job bespoke watermark storage with one helper.

## Test plan
- \`uv run pytest -q\` — 1730 passed
- \`uv run ruff check .\` / \`ruff format --check .\` / \`uv run pyright\` — clean