### PR TITLE
feat(#270): SEC CIK refresh — conditional GET with watermark

### DIFF
--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -238,9 +238,13 @@ class SecFilingsProvider(FilingsProvider):
             return None
 
         resp.raise_for_status()
+        # Hash the raw bytes BEFORE decoding so body_hash always
+        # reflects exactly what arrived over the wire — independent of
+        # downstream JSON parsing or any future HTTP client swap that
+        # might mutate the content view.
+        body_hash = hashlib.sha256(resp.content).hexdigest()
         raw = resp.json()
         _persist_raw("sec_tickers", raw)
-        body_hash = hashlib.sha256(resp.content).hexdigest()
         return CikMappingResult(
             mapping=_parse_cik_mapping(raw),
             body_hash=body_hash,

--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -25,8 +25,10 @@ Provider contract:
     populate external_identifiers during daily CIK refresh.
 """
 
+import hashlib
 import json
 import logging
+from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from pathlib import Path
 from types import TracebackType
@@ -59,6 +61,25 @@ def _persist_raw(tag: str, payload: object) -> None:
 def _zero_pad_cik(cik: str | int) -> str:
     """Return a 10-digit zero-padded CIK string."""
     return str(int(cik)).zfill(10)
+
+
+@dataclass(frozen=True)
+class CikMappingResult:
+    """Result of a conditional-GET fetch of company_tickers.json.
+
+    - ``mapping`` — parsed {TICKER: zero-padded-CIK} dict.
+    - ``body_hash`` — sha256 hex of the raw response bytes. Callers
+      persist this as the watermark's ``response_hash`` so a subsequent
+      run that fetches the same body (without a 304) can still no-op
+      without reparsing.
+    - ``last_modified`` — the server's ``Last-Modified`` header value,
+      to be persisted as the watermark and sent as ``If-Modified-Since``
+      on the next run. ``None`` if the header is absent.
+    """
+
+    mapping: dict[str, str]
+    body_hash: str
+    last_modified: str | None
 
 
 class SecFilingsProvider(FilingsProvider):
@@ -176,12 +197,55 @@ class SecFilingsProvider(FilingsProvider):
         ticker → zero-padded CIK string.
 
         Called by the service layer during the daily CIK refresh job.
+        Unconditional path — retained for callers that don't care about
+        deltas. Prefer ``build_cik_mapping_conditional`` for scheduled
+        refreshes.
         """
         resp = self._http_tickers.get(_TICKERS_URL)
         resp.raise_for_status()
         raw = resp.json()
         _persist_raw("sec_tickers", raw)
         return _parse_cik_mapping(raw)
+
+    def build_cik_mapping_conditional(
+        self,
+        *,
+        if_modified_since: str | None = None,
+    ) -> CikMappingResult | None:
+        """
+        Conditional-GET variant of ``build_cik_mapping``.
+
+        Sends ``If-Modified-Since: <if_modified_since>`` when a prior
+        ``Last-Modified`` value is available. Returns:
+
+        - ``None`` when the server responds 304 Not Modified.
+        - ``CikMappingResult`` otherwise, carrying the parsed mapping,
+          the raw body hash (sha256 hex) for secondary dedup, and the
+          response ``Last-Modified`` header (may be None).
+
+        www.sec.gov honours conditional requests on this endpoint
+        (observed 2026-04-17). Per the SEC developer guidelines the
+        User-Agent must identify the caller with an email — set
+        via ``settings.sec_user_agent`` at client construction.
+        """
+        headers: dict[str, str] = {}
+        if if_modified_since:
+            headers["If-Modified-Since"] = if_modified_since
+
+        resp = self._http_tickers.get(_TICKERS_URL, headers=headers)
+        if resp.status_code == 304:
+            logger.info("SEC tickers: 304 Not Modified")
+            return None
+
+        resp.raise_for_status()
+        raw = resp.json()
+        _persist_raw("sec_tickers", raw)
+        body_hash = hashlib.sha256(resp.content).hexdigest()
+        return CikMappingResult(
+            mapping=_parse_cik_mapping(raw),
+            body_hash=body_hash,
+            last_modified=resp.headers.get("Last-Modified"),
+        )
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -70,6 +70,7 @@ from app.services.sync_orchestrator.progress import report_progress
 from app.services.tax_ledger import ingest_tax_events, run_disposal_matching
 from app.services.thesis import find_stale_instruments, generate_thesis
 from app.services.universe import enrich_instrument_currencies, sync_universe
+from app.services.watermarks import get_watermark, set_watermark
 
 logger = logging.getLogger(__name__)
 
@@ -839,23 +840,74 @@ def daily_cik_refresh() -> None:
     Refresh SEC ticker → CIK mapping and upsert into external_identifiers.
 
     Runs daily. Idempotent — safe to re-run.
+
+    Conditional-fetch path (#270): sends If-Modified-Since against the
+    prior Last-Modified watermark. When the server returns 304, skips
+    the upsert loop entirely — most days this is a zero-byte no-op.
+    On 200 with an unchanged body (defensive — SEC could serve 200
+    with identical bytes), the sha256 body-hash watermark lets us skip
+    anyway. Only when the body genuinely changed do we do the full
+    upsert and advance the watermark.
     """
+    SOURCE = "sec.tickers"
+    WATERMARK_KEY = "global"
+
     with _tracked_job(JOB_DAILY_CIK_REFRESH) as tracker:
         with (
             SecFilingsProvider(user_agent=settings.sec_user_agent) as provider,
             psycopg.connect(settings.database_url) as conn,
         ):
-            mapping = provider.build_cik_mapping()
+            prior = get_watermark(conn, SOURCE, WATERMARK_KEY)
+            if_modified_since = prior.watermark if prior else None
+
+            result = provider.build_cik_mapping_conditional(
+                if_modified_since=if_modified_since,
+            )
+
+            if result is None:
+                # 304 — nothing changed.
+                logger.info("daily_cik_refresh: 304 Not Modified, skipping upsert")
+                tracker.row_count = 0
+                return
+
+            if prior and prior.response_hash == result.body_hash:
+                # 200 with identical bytes. Advance fetched_at only.
+                logger.info("daily_cik_refresh: 200 but body hash unchanged, skipping upsert")
+                with conn.transaction():
+                    set_watermark(
+                        conn,
+                        source=SOURCE,
+                        key=WATERMARK_KEY,
+                        watermark=result.last_modified or (prior.watermark if prior else ""),
+                        response_hash=result.body_hash,
+                    )
+                tracker.row_count = 0
+                return
 
             rows = conn.execute(
                 "SELECT symbol, instrument_id::text FROM instruments WHERE is_tradable = TRUE"
             ).fetchall()
             instrument_symbols = [(row[0], row[1]) for row in rows]
 
-            upserted = upsert_cik_mapping(conn, mapping, instrument_symbols)
+            # Upsert + watermark advance must land atomically — if the
+            # watermark committed but the upserts didn't (crash), the
+            # next run would skip and the data would drift.
+            with conn.transaction():
+                upserted = upsert_cik_mapping(conn, result.mapping, instrument_symbols)
+                set_watermark(
+                    conn,
+                    source=SOURCE,
+                    key=WATERMARK_KEY,
+                    watermark=result.last_modified or "",
+                    response_hash=result.body_hash,
+                )
         tracker.row_count = upserted
 
-    logger.info("CIK refresh complete: mapping_size=%d upserted=%d", len(mapping), upserted)
+    logger.info(
+        "CIK refresh complete: mapping_size=%d upserted=%d",
+        len(result.mapping),
+        upserted,
+    )
 
 
 def daily_research_refresh() -> None:

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -852,13 +852,22 @@ def daily_cik_refresh() -> None:
     SOURCE = "sec.tickers"
     WATERMARK_KEY = "global"
 
+    # Pre-bind so any reference after the inner `with` blocks is always
+    # bound — a future refactor that moves these assignments deeper
+    # cannot produce an UnboundLocalError under an exception path.
+    upserted = 0
+    mapping_size = 0
+
     with _tracked_job(JOB_DAILY_CIK_REFRESH) as tracker:
         with (
             SecFilingsProvider(user_agent=settings.sec_user_agent) as provider,
             psycopg.connect(settings.database_url) as conn,
         ):
             prior = get_watermark(conn, SOURCE, WATERMARK_KEY)
-            if_modified_since = prior.watermark if prior else None
+            # Explicit truthy check: an empty-string watermark from a
+            # prior run where Last-Modified was absent must NOT be sent
+            # as `If-Modified-Since: ` (invalid HTTP date).
+            if_modified_since = prior.watermark if (prior and prior.watermark) else None
 
             result = provider.build_cik_mapping_conditional(
                 if_modified_since=if_modified_since,
@@ -870,6 +879,8 @@ def daily_cik_refresh() -> None:
                 tracker.row_count = 0
                 return
 
+            mapping_size = len(result.mapping)
+
             if prior and prior.response_hash == result.body_hash:
                 # 200 with identical bytes. Advance fetched_at only.
                 logger.info("daily_cik_refresh: 200 but body hash unchanged, skipping upsert")
@@ -878,7 +889,7 @@ def daily_cik_refresh() -> None:
                         conn,
                         source=SOURCE,
                         key=WATERMARK_KEY,
-                        watermark=result.last_modified or (prior.watermark if prior else ""),
+                        watermark=result.last_modified or prior.watermark,
                         response_hash=result.body_hash,
                     )
                 tracker.row_count = 0
@@ -898,6 +909,10 @@ def daily_cik_refresh() -> None:
                     conn,
                     source=SOURCE,
                     key=WATERMARK_KEY,
+                    # Empty string when Last-Modified is absent is the
+                    # "no validator available" sentinel — next run's
+                    # truthy check above will fall back to no-header.
+                    # The body_hash still works for dedup in that case.
                     watermark=result.last_modified or "",
                     response_hash=result.body_hash,
                 )
@@ -905,7 +920,7 @@ def daily_cik_refresh() -> None:
 
     logger.info(
         "CIK refresh complete: mapping_size=%d upserted=%d",
-        len(result.mapping),
+        mapping_size,
         upserted,
     )
 

--- a/tests/test_sec_cik_conditional.py
+++ b/tests/test_sec_cik_conditional.py
@@ -1,0 +1,117 @@
+"""Unit tests for SEC conditional CIK fetch (#270).
+
+Mocks the ResilientClient's response at the HTTP boundary — verifies
+that 304 → returns None, 200 → returns CikMappingResult with parsed
+mapping + body hash + Last-Modified, and that If-Modified-Since is
+forwarded in the request headers when supplied.
+
+Live-network coverage for this endpoint lives in an integration
+test harness out of scope for Phase 1 unit coverage.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.providers.implementations.sec_edgar import CikMappingResult, SecFilingsProvider
+
+
+def _mock_response(status_code: int, json_body=None, headers=None, content=b""):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    resp.content = content
+    resp.json.return_value = json_body
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+@pytest.fixture
+def provider() -> SecFilingsProvider:
+    """Build a provider with ResilientClients stubbed so we can assert
+    on the outbound HTTP call without hitting the network."""
+    p = SecFilingsProvider(user_agent="test@example.com")
+    # Both are typed as ResilientClient — MagicMock() substitute is a
+    # deliberate test-time override.
+    p._http_tickers = MagicMock()  # type: ignore[assignment]
+    p._http = MagicMock()  # type: ignore[assignment]
+    return p
+
+
+def _tickers(p: SecFilingsProvider) -> Any:
+    """Return the tickers client as Any so pyright lets us poke at
+    MagicMock's return_value / call_args directly in tests."""
+    return cast(Any, p._http_tickers)
+
+
+class TestConditional304:
+    def test_returns_none_on_304(self, provider: SecFilingsProvider) -> None:
+        _tickers(provider).get.return_value = _mock_response(304)
+
+        result = provider.build_cik_mapping_conditional(
+            if_modified_since="Wed, 15 Apr 2026 20:05:57 GMT",
+        )
+
+        assert result is None
+
+    def test_forwards_if_modified_since_header(self, provider: SecFilingsProvider) -> None:
+        _tickers(provider).get.return_value = _mock_response(304)
+
+        provider.build_cik_mapping_conditional(
+            if_modified_since="Wed, 15 Apr 2026 20:05:57 GMT",
+        )
+
+        _args, kwargs = _tickers(provider).get.call_args
+        assert kwargs["headers"] == {
+            "If-Modified-Since": "Wed, 15 Apr 2026 20:05:57 GMT",
+        }
+
+    def test_omits_header_when_no_prior_watermark(self, provider: SecFilingsProvider) -> None:
+        """First-run case: no watermark yet, no If-Modified-Since sent."""
+        _tickers(provider).get.return_value = _mock_response(
+            200,
+            json_body={"0": {"cik_str": 320193, "ticker": "AAPL", "title": "Apple"}},
+            headers={"Last-Modified": "Wed, 15 Apr 2026 20:05:57 GMT"},
+            content=b'{"0":{"cik_str":320193,"ticker":"AAPL","title":"Apple"}}',
+        )
+
+        provider.build_cik_mapping_conditional(if_modified_since=None)
+
+        _args, kwargs = _tickers(provider).get.call_args
+        assert kwargs["headers"] == {}
+
+
+class TestConditional200:
+    def test_returns_parsed_mapping_plus_metadata(self, provider: SecFilingsProvider) -> None:
+        body = b'{"0":{"cik_str":320193,"ticker":"AAPL","title":"Apple"}}'
+        _tickers(provider).get.return_value = _mock_response(
+            200,
+            json_body={"0": {"cik_str": 320193, "ticker": "AAPL", "title": "Apple"}},
+            headers={"Last-Modified": "Wed, 15 Apr 2026 20:05:57 GMT"},
+            content=body,
+        )
+
+        result = provider.build_cik_mapping_conditional()
+
+        assert isinstance(result, CikMappingResult)
+        assert result.mapping == {"AAPL": "0000320193"}
+        # body_hash is sha256(body).hexdigest(); stability matters for dedup.
+        assert (
+            result.body_hash == ("a4dc6fcecc9c2a2ddb98df0b5cdfab08fdc0f7dc16c0d9e9ed76d5e7e5f4c21a")
+            or len(result.body_hash) == 64
+        )  # loose check — hex of sha256
+        assert result.last_modified == "Wed, 15 Apr 2026 20:05:57 GMT"
+
+    def test_last_modified_none_when_header_absent(self, provider: SecFilingsProvider) -> None:
+        _tickers(provider).get.return_value = _mock_response(
+            200,
+            json_body={},
+            headers={},
+            content=b"{}",
+        )
+        result = provider.build_cik_mapping_conditional()
+        assert result is not None
+        assert result.last_modified is None

--- a/tests/test_sec_cik_conditional.py
+++ b/tests/test_sec_cik_conditional.py
@@ -98,6 +98,9 @@ class TestConditional200:
 
         assert isinstance(result, CikMappingResult)
         assert result.mapping == {"AAPL": "0000320193"}
+        # Length check defends against a future transcription error
+        # that silently changes the pinned value.
+        assert len(result.body_hash) == 64, f"sha256 hex must be 64 chars, got {len(result.body_hash)}"
         # Exact sha256 of the fixture body — pinned so a future
         # refactor that changes hashing (digest, encoding, etc.) fails
         # this test rather than silently producing a different watermark.

--- a/tests/test_sec_cik_conditional.py
+++ b/tests/test_sec_cik_conditional.py
@@ -98,11 +98,10 @@ class TestConditional200:
 
         assert isinstance(result, CikMappingResult)
         assert result.mapping == {"AAPL": "0000320193"}
-        # body_hash is sha256(body).hexdigest(); stability matters for dedup.
-        assert (
-            result.body_hash == ("a4dc6fcecc9c2a2ddb98df0b5cdfab08fdc0f7dc16c0d9e9ed76d5e7e5f4c21a")
-            or len(result.body_hash) == 64
-        )  # loose check — hex of sha256
+        # Exact sha256 of the fixture body — pinned so a future
+        # refactor that changes hashing (digest, encoding, etc.) fails
+        # this test rather than silently producing a different watermark.
+        assert result.body_hash == ("1d750f0716a1ad1927c275a3df2fd6516613ef094cd0a53ad742bc10bea4e0f9")
         assert result.last_modified == "Wed, 15 Apr 2026 20:05:57 GMT"
 
     def test_last_modified_none_when_header_absent(self, provider: SecFilingsProvider) -> None:


### PR DESCRIPTION
## What
- CikMappingResult dataclass + build_cik_mapping_conditional(if_modified_since=) on SecFilingsProvider
- daily_cik_refresh now conditional: 304 → noop, 200 w/ same hash → noop, 200 new → upsert + watermark inside one transaction
- 5 unit tests

## Why
Current job fetches ~800 KB/day unconditionally. www.sec.gov honours If-Modified-Since → 304 on this endpoint (tested 2026-04-17). ~99% of runs will now be zero-byte.

## Test plan
- \`uv run pytest -q\` — 1740 passed
- Full gate clean