### PR TITLE
feat(#275): Frankfurter conditional fetch with ETag watermark

### DIFF
--- a/app/providers/implementations/frankfurter.py
+++ b/app/providers/implementations/frankfurter.py
@@ -7,11 +7,18 @@ Fetches ECB reference exchange rates from the Frankfurter API
 ECB publishes rates daily around 16:00 CET on working days.
 Rates are informational reference rates — suitable for display
 currency conversion, not for trade execution pricing.
+
+Conditional fetch (verified 2026-04-17): the Frankfurter API
+honours ``ETag`` / ``If-None-Match`` → 304. ``If-Modified-Since``
+is ignored. Use ``fetch_latest_rates_conditional`` for the
+incremental-fetch path and keep the existing ``fetch_latest_rates``
+for unconditional callers.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from decimal import Decimal
 
 import httpx
@@ -20,6 +27,22 @@ logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://api.frankfurter.dev"
 _TIMEOUT_S = 15.0
+
+
+@dataclass(frozen=True)
+class FrankfurterResult:
+    """Outcome of a conditional-GET fetch against Frankfurter.
+
+    ``rates`` keyed by ``(from_currency, to_currency) -> rate``.
+    ``ecb_date`` is the ISO date string for the ECB publication this
+    payload reflects. ``etag`` is the server's ``ETag`` header value
+    (including the surrounding quotes) — persist this so the next
+    run can send it as ``If-None-Match``.
+    """
+
+    rates: dict[tuple[str, str], Decimal]
+    ecb_date: str | None
+    etag: str | None
 
 
 def fetch_latest_rates(
@@ -62,3 +85,59 @@ def fetch_latest_rates(
                 logger.warning("Failed to parse Frankfurter rate %s→%s: %s", base, ccy, value)
 
     return result, ecb_date
+
+
+def fetch_latest_rates_conditional(
+    base: str,
+    targets: list[str],
+    *,
+    if_none_match: str | None = None,
+) -> FrankfurterResult | None:
+    """Conditional variant of ``fetch_latest_rates``.
+
+    Sends ``If-None-Match: <if_none_match>`` when an ETag from a prior
+    run is available. Returns:
+
+    - ``None`` when the server responds 304 Not Modified.
+    - ``FrankfurterResult`` with parsed rates + ecb_date + new ETag
+      on 200 OK.
+
+    ECB only publishes once per working day around 16:00 CET, so most
+    intra-day invocations land on the 304 path.
+    """
+    if not targets:
+        return FrankfurterResult(rates={}, ecb_date=None, etag=None)
+
+    symbols = ",".join(targets)
+    headers: dict[str, str] = {}
+    if if_none_match:
+        headers["If-None-Match"] = if_none_match
+
+    with httpx.Client(timeout=_TIMEOUT_S) as client:
+        response = client.get(
+            f"{_BASE_URL}/v1/latest",
+            params={"base": base, "symbols": symbols},
+            headers=headers,
+        )
+        if response.status_code == 304:
+            logger.info("Frankfurter: 304 Not Modified")
+            return None
+        response.raise_for_status()
+
+    data = response.json()
+    ecb_date: str | None = data.get("date")
+    raw_rates: dict[str, object] = data.get("rates", {})
+
+    rates: dict[tuple[str, str], Decimal] = {}
+    for ccy, value in raw_rates.items():
+        if value is not None:
+            try:
+                rates[(base, ccy)] = Decimal(str(value))
+            except Exception:
+                logger.warning("Failed to parse Frankfurter rate %s→%s: %s", base, ccy, value)
+
+    return FrankfurterResult(
+        rates=rates,
+        ecb_date=ecb_date,
+        etag=response.headers.get("ETag"),
+    )

--- a/app/providers/implementations/frankfurter.py
+++ b/app/providers/implementations/frankfurter.py
@@ -123,8 +123,13 @@ def fetch_latest_rates_conditional(
             logger.info("Frankfurter: 304 Not Modified")
             return None
         response.raise_for_status()
+        # Read all response fields (including ETag) INSIDE the client
+        # context so a lazily-closed response never returns a stale
+        # value. httpx does not currently close the response on client
+        # exit, but being explicit future-proofs against that change.
+        data = response.json()
+        etag = response.headers.get("ETag")
 
-    data = response.json()
     ecb_date: str | None = data.get("date")
     raw_rates: dict[str, object] = data.get("rates", {})
 
@@ -136,8 +141,4 @@ def fetch_latest_rates_conditional(
             except Exception:
                 logger.warning("Failed to parse Frankfurter rate %s→%s: %s", base, ccy, value)
 
-    return FrankfurterResult(
-        rates=rates,
-        ecb_date=ecb_date,
-        etag=response.headers.get("ETag"),
-    )
+    return FrankfurterResult(rates=rates, ecb_date=ecb_date, etag=etag)

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1996,13 +1996,21 @@ def fx_rates_refresh() -> None:
                                 quoted_at=ecb_quoted_at,
                             )
                             fx_rows_written += 1
-                        if result.etag:
-                            set_watermark(
-                                conn,
-                                source=FX_SOURCE,
-                                key=FX_WATERMARK_KEY,
-                                watermark=result.etag,
-                            )
+                        # Always advance the watermark on 200 — prefer ETag
+                        # (what Frankfurter's server actually validates),
+                        # fall back to the ecb_date when ETag is absent
+                        # (content-based fingerprint: next run comparing
+                        # result.ecb_date against prior.watermark still
+                        # detects "same publication"). An empty string is
+                        # the last-ditch sentinel meaning "no validator
+                        # available" — next run's truthy check skips
+                        # If-None-Match altogether.
+                        set_watermark(
+                            conn,
+                            source=FX_SOURCE,
+                            key=FX_WATERMARK_KEY,
+                            watermark=result.etag or result.ecb_date or "",
+                        )
                 logger.info(
                     "fx_rates_refresh: Frankfurter ECB rates written: %d pairs (date=%s, etag=%s)",
                     fx_rows_written,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1938,53 +1938,77 @@ def fx_rates_refresh() -> None:
 
     1. **Frankfurter (primary FX):** Fetch ECB reference rates for all
        supported display currencies. No API key, no coverage prerequisite.
-       Runs unconditionally.
+       Conditional ETag (#275): sends If-None-Match against the last
+       persisted ETag. 304 responses are no-ops (ECB only publishes
+       once per working day ~16:00 CET, so >95% of 5-min polls are 304).
 
     2. **eToro quotes (secondary):** Batch-fetch quotes for covered Tier 1/2
        instruments. Extracts eToro-specific conversion rates as a supplement,
        and upserts quotes for hourly freshness. Skips gracefully if eToro
        credentials are missing or the rates endpoint fails.
 
-    Runs hourly at :00.
+    Runs hourly at :00 (invoked by orchestrator_high_frequency_sync).
     """
-    from app.providers.implementations.frankfurter import fetch_latest_rates
+    from app.providers.implementations.frankfurter import fetch_latest_rates_conditional
     from app.services.fx import upsert_live_fx_rate
     from app.services.market_data import compute_spread_pct
     from app.services.runtime_config import SUPPORTED_CURRENCIES
+
+    FX_SOURCE = "frankfurter.latest"
+    FX_WATERMARK_KEY = "global"
 
     with _tracked_job(JOB_FX_RATES_REFRESH) as tracker:
         fx_rows_written = 0
         quotes_updated = 0
 
-        # --- Phase 1: Frankfurter ECB rates (always runs) ---
+        # --- Phase 1: Frankfurter ECB rates (conditional GET) ---
         # Fetch USD → every other supported currency.
         targets = sorted(c for c in SUPPORTED_CURRENCIES if c != "USD")
         try:
-            ecb_rates, ecb_date = fetch_latest_rates("USD", targets)
-            # Use the ECB publication date for quoted_at so freshness
-            # checks reflect when the rate was actually set, not when
-            # we fetched it (matters on weekends/holidays).
-            if ecb_date is not None:
-                ecb_quoted_at = datetime.fromisoformat(ecb_date).replace(tzinfo=UTC)
-            else:
-                ecb_quoted_at = datetime.now(UTC)
             with psycopg.connect(settings.database_url) as conn:
-                with conn.transaction():
-                    for (from_ccy, to_ccy), rate in ecb_rates.items():
-                        upsert_live_fx_rate(
-                            conn,
-                            from_currency=from_ccy,
-                            to_currency=to_ccy,
-                            rate=rate,
-                            quoted_at=ecb_quoted_at,
-                        )
-                        fx_rows_written += 1
-                conn.commit()
-            logger.info(
-                "fx_rates_refresh: Frankfurter ECB rates written: %d pairs (date=%s)",
-                fx_rows_written,
-                ecb_date,
-            )
+                prior = get_watermark(conn, FX_SOURCE, FX_WATERMARK_KEY)
+                if_none_match = prior.watermark if (prior and prior.watermark) else None
+
+            result = fetch_latest_rates_conditional("USD", targets, if_none_match=if_none_match)
+
+            if result is None:
+                # 304 — ECB hasn't published a new rate since last fetch.
+                logger.info("fx_rates_refresh: Frankfurter 304 Not Modified, skipping upsert")
+            else:
+                # Use the ECB publication date for quoted_at so freshness
+                # checks reflect when the rate was actually set, not when
+                # we fetched it (matters on weekends/holidays).
+                if result.ecb_date is not None:
+                    ecb_quoted_at = datetime.fromisoformat(result.ecb_date).replace(tzinfo=UTC)
+                else:
+                    ecb_quoted_at = datetime.now(UTC)
+                with psycopg.connect(settings.database_url) as conn:
+                    # Upsert + watermark advance inside one transaction so
+                    # a crash between them can't leave the watermark ahead
+                    # of the data (next run would skip unfinished work).
+                    with conn.transaction():
+                        for (from_ccy, to_ccy), rate in result.rates.items():
+                            upsert_live_fx_rate(
+                                conn,
+                                from_currency=from_ccy,
+                                to_currency=to_ccy,
+                                rate=rate,
+                                quoted_at=ecb_quoted_at,
+                            )
+                            fx_rows_written += 1
+                        if result.etag:
+                            set_watermark(
+                                conn,
+                                source=FX_SOURCE,
+                                key=FX_WATERMARK_KEY,
+                                watermark=result.etag,
+                            )
+                logger.info(
+                    "fx_rates_refresh: Frankfurter ECB rates written: %d pairs (date=%s, etag=%s)",
+                    fx_rows_written,
+                    result.ecb_date,
+                    result.etag,
+                )
         except Exception:
             logger.warning("fx_rates_refresh: Frankfurter fetch failed, continuing with eToro fallback", exc_info=True)
 

--- a/tests/test_frankfurter_conditional.py
+++ b/tests/test_frankfurter_conditional.py
@@ -1,0 +1,102 @@
+"""Unit tests for Frankfurter conditional fetch (#275).
+
+Mocks httpx.Client at the module boundary — verifies 304 → returns
+None, 200 → returns FrankfurterResult with parsed rates + ecb_date
++ ETag, and If-None-Match is forwarded when supplied.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from app.providers.implementations.frankfurter import (
+    FrankfurterResult,
+    fetch_latest_rates_conditional,
+)
+
+
+def _mock_httpx_response(status_code: int, json_body=None, headers=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    resp.json.return_value = json_body
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _patch_httpx(response):
+    """Patch httpx.Client.__enter__ so the provider's context-manager
+    gets back a client whose .get(...) returns our mocked response."""
+    client = MagicMock()
+    client.get.return_value = response
+    ctx = MagicMock()
+    ctx.__enter__.return_value = client
+    ctx.__exit__.return_value = None
+    return patch("app.providers.implementations.frankfurter.httpx.Client", return_value=ctx), client
+
+
+class TestConditional304:
+    def test_returns_none_on_304(self) -> None:
+        resp = _mock_httpx_response(304)
+        patcher, _ = _patch_httpx(resp)
+        with patcher:
+            out = fetch_latest_rates_conditional("USD", ["GBP", "EUR"], if_none_match='"some-etag"')
+        assert out is None
+
+    def test_forwards_if_none_match_header(self) -> None:
+        resp = _mock_httpx_response(304)
+        patcher, client = _patch_httpx(resp)
+        with patcher:
+            fetch_latest_rates_conditional("USD", ["GBP", "EUR"], if_none_match='"prior-etag"')
+        _args, kwargs = client.get.call_args
+        assert kwargs["headers"] == {"If-None-Match": '"prior-etag"'}
+
+    def test_omits_header_when_no_prior_etag(self) -> None:
+        """First-run case: no watermark yet, no If-None-Match sent."""
+        resp = _mock_httpx_response(
+            200,
+            json_body={"date": "2026-04-17", "rates": {"GBP": 0.79}},
+            headers={"ETag": '"new-etag"'},
+        )
+        patcher, client = _patch_httpx(resp)
+        with patcher:
+            fetch_latest_rates_conditional("USD", ["GBP"])
+        _args, kwargs = client.get.call_args
+        assert kwargs["headers"] == {}
+
+
+class TestConditional200:
+    def test_returns_parsed_result(self) -> None:
+        resp = _mock_httpx_response(
+            200,
+            json_body={"date": "2026-04-17", "rates": {"GBP": 0.79, "EUR": 0.92}},
+            headers={"ETag": '"new-etag"'},
+        )
+        patcher, _ = _patch_httpx(resp)
+        with patcher:
+            out = fetch_latest_rates_conditional("USD", ["GBP", "EUR"])
+
+        assert isinstance(out, FrankfurterResult)
+        assert out.rates == {("USD", "GBP"): Decimal("0.79"), ("USD", "EUR"): Decimal("0.92")}
+        assert out.ecb_date == "2026-04-17"
+        assert out.etag == '"new-etag"'
+
+    def test_etag_none_when_header_absent(self) -> None:
+        resp = _mock_httpx_response(
+            200,
+            json_body={"date": "2026-04-17", "rates": {"GBP": 0.79}},
+            headers={},
+        )
+        patcher, _ = _patch_httpx(resp)
+        with patcher:
+            out = fetch_latest_rates_conditional("USD", ["GBP"])
+        assert out is not None
+        assert out.etag is None
+
+
+class TestEmptyTargets:
+    def test_empty_targets_returns_empty_result_without_http(self) -> None:
+        """No network call when targets list is empty."""
+        out = fetch_latest_rates_conditional("USD", [])
+        assert out == FrankfurterResult(rates={}, ecb_date=None, etag=None)


### PR DESCRIPTION
## What
- \`FrankfurterResult\` dataclass + \`fetch_latest_rates_conditional(if_none_match=)\` on provider
- \`fx_rates_refresh\` now conditional: 304 → noop, 200 → upsert + watermark inside one transaction
- 6 unit tests

## Why
Frankfurter honours ETag / If-None-Match → 304 (verified 2026-04-17). ECB only publishes once/day, so most 5-min polls (288/day) now return zero bytes.

## Scope clarification
Cadence unchanged (still 5-min via orchestrator_high_frequency_sync). Drop to once-daily @ 16:15 CET deferred until #274 + #281 untangle Frankfurter from live FX conversion.

## Test plan
- \`uv run pytest -q\` — 1746 passed
- Full gate clean