### PR TITLE
feat(#277): universe freshness window 24h → 7d

### DIFF
--- a/app/services/sync_orchestrator/freshness.py
+++ b/app/services/sync_orchestrator/freshness.py
@@ -109,7 +109,13 @@ def _current_quarter_start(today: date) -> date:
 
 
 def universe_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
-    return _fresh_by_audit(conn, "nightly_universe_sync", timedelta(hours=24))
+    # Weekly cadence (#277). eToro's /instruments endpoint has no delta
+    # filter — we pull the whole list (~15k rows) every refresh. The
+    # universe rarely changes day-to-day (new listings are rare, ticker
+    # changes rarer still), so a daily refresh was write amplification
+    # for no information gain. A 7-day window catches meaningful
+    # changes without re-pulling weekly volumes of identical rows.
+    return _fresh_by_audit(conn, "nightly_universe_sync", timedelta(days=7))
 
 
 def cik_mapping_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:

--- a/tests/test_sync_orchestrator_freshness.py
+++ b/tests/test_sync_orchestrator_freshness.py
@@ -125,7 +125,7 @@ class TestSimpleAuditOnlyPredicates:
     @pytest.mark.parametrize(
         "predicate,job_name,window",
         [
-            (universe_is_fresh, "nightly_universe_sync", timedelta(hours=24)),
+            (universe_is_fresh, "nightly_universe_sync", timedelta(days=7)),
             (cik_mapping_is_fresh, "daily_cik_refresh", timedelta(hours=24)),
             (financial_facts_is_fresh, "daily_financial_facts", timedelta(hours=24)),
             (


### PR DESCRIPTION
## What
\`universe_is_fresh\` freshness window changed from \`timedelta(hours=24)\` to \`timedelta(days=7)\`.

## Why
eToro \`/instruments\` has no delta filter — every refresh pulls the full ~15k row list. Universe changes (new listings, ticker changes) are rare at daily cadence. Daily refresh was write amplification for no information gain.

## Test plan
- \`uv run pytest -q\` — 1746 passed