### PR TITLE
feat(#271): candles two-mode fetch — backfill 400 / incremental 3

### DIFF
--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -98,7 +98,7 @@ def refresh_market_data(
             candles_skipped += 1
             report_progress(idx, total)
             continue
-        fetch_count = _candles_fetch_count(conn, instrument_id, default=lookback_days)
+        fetch_count = _candles_fetch_count(conn, instrument_id, default=lookback_days, today=today)
         try:
             with conn.transaction():
                 bars = provider.get_daily_candles(instrument_id, fetch_count)
@@ -220,25 +220,38 @@ def _candles_fetch_count(
     instrument_id: int,
     *,
     default: int,
+    today: date | None = None,
 ) -> int:
     """Decide the candlesCount for an instrument's fetch (#271).
 
-    Returns ``default`` (typically 400) for instruments with NO prior
-    candles — backfill mode. Returns ``_INCREMENTAL_FETCH_BARS`` for
-    instruments that already have history — incremental mode. The
-    upsert dedupes on (instrument_id, price_date) so overlap between
-    the incremental window and existing rows is safe.
+    Returns ``default`` (typically 400) in two cases:
+      * No prior candles at all — initial backfill mode.
+      * Prior candles exist but the most recent is older than the
+        incremental window (e.g. instrument was halted, re-added to
+        the universe after a gap, or a multi-day market closure). A
+        3-bar incremental fetch here would silently leave a history
+        gap; falling back to ``default`` closes the gap.
+
+    Returns ``_INCREMENTAL_FETCH_BARS`` when the most recent candle is
+    within the incremental window — normal daily maintenance mode.
+    The upsert dedupes on (instrument_id, price_date) so overlap is
+    safe.
     """
     row = conn.execute(
         """
-        SELECT 1 FROM price_daily
+        SELECT MAX(price_date) FROM price_daily
         WHERE instrument_id = %(instrument_id)s
-        LIMIT 1
         """,
         {"instrument_id": instrument_id},
     ).fetchone()
-    if row is None:
-        return default  # backfill
+    if row is None or row[0] is None:
+        return default  # no prior data — backfill
+    latest: date = row[0]
+    reference = today if today is not None else date.today()
+    gap_days = (reference - latest).days
+    if gap_days > _INCREMENTAL_FETCH_BARS:
+        # Gap wider than the incremental window — backfill to close it.
+        return default
     return _INCREMENTAL_FETCH_BARS
 
 

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -80,16 +80,28 @@ def refresh_market_data(
     today = date.today()
     candles_skipped = 0
 
-    # --- Candles: per-instrument (with freshness skip) ---
+    # --- Candles: per-instrument (with freshness skip + two-mode fetch) ---
+    # Two-mode fetch (#271):
+    #   * Backfill mode — instrument has NO prior candles (new to the
+    #     universe, or gap detected). Pull full `lookback_days` history
+    #     (default 400 bars).
+    #   * Incremental mode — instrument already has candle history.
+    #     Pull only INCREMENTAL_FETCH_BARS bars (yesterday + today +
+    #     correction buffer). The upsert dedupes on (instrument_id,
+    #     price_date) so overlap with existing rows is harmless.
+    # On a typical day, ~100% of Tier 1/2 instruments are in incremental
+    # mode — eToro call weight drops from 400 bars × ~500 instruments
+    # (~200k rows) to 3 × 500 (~1500 rows).
     total = len(instruments)
     for idx, (instrument_id, symbol) in enumerate(instruments, start=1):
         if _candles_are_fresh(conn, instrument_id, today):
             candles_skipped += 1
             report_progress(idx, total)
             continue
+        fetch_count = _candles_fetch_count(conn, instrument_id, default=lookback_days)
         try:
             with conn.transaction():
-                bars = provider.get_daily_candles(instrument_id, lookback_days)
+                bars = provider.get_daily_candles(instrument_id, fetch_count)
                 if bars:
                     upserted = _upsert_candles(conn, instrument_id, bars)
                     candle_rows_upserted += upserted
@@ -194,6 +206,40 @@ def _candles_are_fresh(
         return False
     latest_date: date = row[0]
     return latest_date >= _most_recent_trading_day(today)
+
+
+# Incremental fetch window in bars — yesterday + today + one
+# correction-day buffer. eToro's /candles endpoint has no date-range
+# filter, only `candlesCount`; this is the smallest count that still
+# catches the latest bar plus a one-day retrospective correction.
+_INCREMENTAL_FETCH_BARS = 3
+
+
+def _candles_fetch_count(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    instrument_id: int,
+    *,
+    default: int,
+) -> int:
+    """Decide the candlesCount for an instrument's fetch (#271).
+
+    Returns ``default`` (typically 400) for instruments with NO prior
+    candles — backfill mode. Returns ``_INCREMENTAL_FETCH_BARS`` for
+    instruments that already have history — incremental mode. The
+    upsert dedupes on (instrument_id, price_date) so overlap between
+    the incremental window and existing rows is safe.
+    """
+    row = conn.execute(
+        """
+        SELECT 1 FROM price_daily
+        WHERE instrument_id = %(instrument_id)s
+        LIMIT 1
+        """,
+        {"instrument_id": instrument_id},
+    ).fetchone()
+    if row is None:
+        return default  # backfill
+    return _INCREMENTAL_FETCH_BARS
 
 
 def _upsert_candles(

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -25,8 +25,10 @@ from app.providers.implementations.etoro import (
 )
 from app.providers.market_data import OHLCVBar, Quote
 from app.services.market_data import (
+    _INCREMENTAL_FETCH_BARS,
     DEFAULT_MAX_SPREAD_PCT,
     _candles_are_fresh,
+    _candles_fetch_count,
     _compute_and_store_features,
     _compute_rolling_returns,
     _compute_volatility_30d,
@@ -828,3 +830,28 @@ class TestComputeAndStoreFeaturesTA:
 
         assert "price_vs_sma200" not in params
         assert "trend_sma_cross" not in params
+
+
+class TestCandlesFetchCount:
+    """_candles_fetch_count (#271) — two-mode backfill vs incremental."""
+
+    def _mock_conn(self, fetchone_return):
+        """Return a MagicMock conn whose .execute().fetchone() yields the row."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = fetchone_return
+        conn.execute.return_value = cursor
+        return conn
+
+    def test_returns_default_for_instrument_with_no_prior_candles(self) -> None:
+        """Backfill mode — no price_daily rows, so we pull the full
+        lookback_days window (caller default: 400)."""
+        conn = self._mock_conn(fetchone_return=None)
+        assert _candles_fetch_count(conn, 42, default=400) == 400
+
+    def test_returns_incremental_for_instrument_with_history(self) -> None:
+        """Incremental mode — prior candles exist, pull only
+        _INCREMENTAL_FETCH_BARS (yesterday + today + correction)."""
+        conn = self._mock_conn(fetchone_return=(1,))
+        assert _candles_fetch_count(conn, 42, default=400) == _INCREMENTAL_FETCH_BARS
+        assert _INCREMENTAL_FETCH_BARS == 3  # sanity — pinning the documented value

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -843,15 +843,36 @@ class TestCandlesFetchCount:
         conn.execute.return_value = cursor
         return conn
 
-    def test_returns_default_for_instrument_with_no_prior_candles(self) -> None:
-        """Backfill mode — no price_daily rows, so we pull the full
-        lookback_days window (caller default: 400)."""
+    def test_returns_default_when_no_prior_candles(self) -> None:
+        """Initial backfill — fetchone returns None (no rows)."""
         conn = self._mock_conn(fetchone_return=None)
-        assert _candles_fetch_count(conn, 42, default=400) == 400
+        assert _candles_fetch_count(conn, 42, default=400, today=date(2026, 4, 17)) == 400
 
-    def test_returns_incremental_for_instrument_with_history(self) -> None:
-        """Incremental mode — prior candles exist, pull only
-        _INCREMENTAL_FETCH_BARS (yesterday + today + correction)."""
-        conn = self._mock_conn(fetchone_return=(1,))
-        assert _candles_fetch_count(conn, 42, default=400) == _INCREMENTAL_FETCH_BARS
-        assert _INCREMENTAL_FETCH_BARS == 3  # sanity — pinning the documented value
+    def test_returns_default_when_max_price_date_is_null(self) -> None:
+        """Defensive — SELECT MAX(...) always returns a row; NULL when
+        there are no matching rows. Treat as initial backfill."""
+        conn = self._mock_conn(fetchone_return=(None,))
+        assert _candles_fetch_count(conn, 42, default=400, today=date(2026, 4, 17)) == 400
+
+    def test_returns_incremental_when_latest_is_within_window(self) -> None:
+        """Normal daily maintenance — last candle is yesterday."""
+        conn = self._mock_conn(fetchone_return=(date(2026, 4, 16),))
+        assert _candles_fetch_count(conn, 42, default=400, today=date(2026, 4, 17)) == _INCREMENTAL_FETCH_BARS
+        assert _INCREMENTAL_FETCH_BARS == 3  # pinning documented value
+
+    def test_returns_default_when_gap_exceeds_incremental_window(self) -> None:
+        """Gap resumption — instrument was halted / re-added after a
+        multi-day closure. Last candle is 10 days ago. A 3-bar
+        incremental fetch would leave a 7-day hole; fall back to
+        full backfill instead."""
+        conn = self._mock_conn(fetchone_return=(date(2026, 4, 7),))
+        assert _candles_fetch_count(conn, 42, default=400, today=date(2026, 4, 17)) == 400
+
+    def test_returns_incremental_at_exact_window_boundary(self) -> None:
+        """Boundary — gap of exactly _INCREMENTAL_FETCH_BARS days is
+        still coverable by the incremental fetch window."""
+        today = date(2026, 4, 17)
+        latest = date(2026, 4, 14)  # 3 days ago
+        assert (today - latest).days == _INCREMENTAL_FETCH_BARS
+        conn = self._mock_conn(fetchone_return=(latest,))
+        assert _candles_fetch_count(conn, 42, default=400, today=today) == _INCREMENTAL_FETCH_BARS


### PR DESCRIPTION
## What
- \`_candles_fetch_count(conn, instrument_id, default)\` returns \`default\` (400) for instruments with no prior candles, else \`_INCREMENTAL_FETCH_BARS\` (3).
- \`refresh_market_data\` now calls this per instrument instead of hard-coding \`lookback_days\` everywhere.
- 2 unit tests.

## Why
eToro /candles has no date-range filter — candlesCount is the only knob. 400 × 500 instruments of re-transfer daily when only 1-2 new bars exist is pure waste.

## Test plan
- \`uv run pytest -q\` — 1748 passed
- Full gate clean