### PR TITLE
fix(#293): generate_thesis commits read tx before Claude calls

### DIFF
--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -688,10 +688,28 @@ def generate_thesis(
       4. Open a transaction, INSERT a new thesis row with an atomically-computed
          thesis_version, update coverage.last_reviewed_at, commit.
 
-    Returns ThesisResult. Claude calls are made outside the transaction to avoid
-    holding a connection open during network I/O.
+    Returns ThesisResult. Claude calls are made outside any DB transaction
+    to avoid holding a connection open during network I/O.
+
+    The explicit ``conn.commit()`` after ``_assemble_context`` is
+    load-bearing: on a non-autocommit connection the context SELECTs
+    open an implicit transaction that would otherwise stay open through
+    both Claude calls (2-5s each, sometimes 10s+). Holding a DB tx
+    across HTTP is the anti-pattern called out in CLAUDE.md Architecture
+    invariants; the commit closes the read tx so the connection is
+    ``idle`` (not ``idle in transaction``) while Claude runs.
+
+    **Caller contract:** do NOT wrap this call in ``with conn.transaction():``.
+    psycopg3 forbids explicit ``commit()`` inside an outer transaction
+    block; this function commits mid-flow. Callers managing their own
+    transaction must either split the call boundary around it or open a
+    dedicated connection.
     """
     context = _assemble_context(conn, instrument_id)
+    # Close the implicit read tx opened by _assemble_context SELECTs
+    # BEFORE the Claude calls below. Without this, the connection stays
+    # ``idle in transaction`` for the duration of the Claude round-trips.
+    conn.commit()
 
     # Claude calls — outside any DB transaction; these can take seconds
     writer_output = _call_writer(client, context)

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -494,9 +494,7 @@ class TestGenerateThesis:
         # Claude call. A pre-commit Claude would land at call_log[0].
         assert "commit" in call_log, "expected conn.commit() to be called"
         assert "claude" in call_log, "expected client.messages.create to be called"
-        assert call_log[0] == "commit", (
-            f"commit must be the first event; got order: {call_log}"
-        )
+        assert call_log[0] == "commit", f"commit must be the first event; got order: {call_log}"
         # Guard every Claude call, not just the first — a regression
         # that inserted _call_critic before the commit would still
         # satisfy an index-based check on the writer call alone.

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -497,7 +497,11 @@ class TestGenerateThesis:
         assert call_log[0] == "commit", (
             f"commit must be the first event; got order: {call_log}"
         )
-        assert call_log.rindex("claude") > call_log.index("commit"), (
+        # Guard every Claude call, not just the first — a regression
+        # that inserted _call_critic before the commit would still
+        # satisfy an index-based check on the writer call alone.
+        last_claude_idx = max(i for i, v in enumerate(call_log) if v == "claude")
+        assert last_claude_idx > call_log.index("commit"), (
             f"every Claude call must follow the commit; got order: {call_log}"
         )
 

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -489,11 +489,16 @@ class TestGenerateThesis:
 
         generate_thesis(instrument_id=1, conn=conn, client=client)
 
-        # First commit must precede first claude call. Both must appear.
+        # First event must be the commit. Every Claude call must come
+        # after it — guards both writer AND critic, not just the first
+        # Claude call. A pre-commit Claude would land at call_log[0].
         assert "commit" in call_log, "expected conn.commit() to be called"
         assert "claude" in call_log, "expected client.messages.create to be called"
-        assert call_log.index("commit") < call_log.index("claude"), (
-            f"commit must precede first Claude call, got order: {call_log}"
+        assert call_log[0] == "commit", (
+            f"commit must be the first event; got order: {call_log}"
+        )
+        assert call_log.rindex("claude") > call_log.index("commit"), (
+            f"every Claude call must follow the commit; got order: {call_log}"
         )
 
     def test_critic_failure_does_not_block_insert(self) -> None:

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -459,6 +459,43 @@ class TestGenerateThesis:
 
         assert result.thesis_version == 3
 
+    def test_commits_read_tx_before_claude_calls(self) -> None:
+        """Regression guard for #293: the implicit read tx opened by
+        _assemble_context's SELECTs must be committed BEFORE the Claude
+        writer/critic calls. Otherwise the connection sits
+        'idle in transaction' for 2-10s per Claude round-trip, violating
+        the CLAUDE.md 'no HTTP inside DB tx' invariant."""
+        conn = _make_conn(insert_returns_version=1)
+        client = _make_two_call_client(_VALID_WRITER, _VALID_CRITIC)
+
+        # Track the order commit vs Claude calls land on their respective
+        # mocks. A MagicMock on the parent captures every child attribute
+        # call, so recording `mock_calls` on conn and client separately
+        # gives us the interleaving we need without a manual parent mock.
+        call_log: list[str] = []
+        original_commit = conn.commit
+        original_create = client.messages.create
+
+        def tracked_commit() -> None:
+            call_log.append("commit")
+            return original_commit()
+
+        def tracked_create(*args: object, **kwargs: object) -> object:
+            call_log.append("claude")
+            return original_create(*args, **kwargs)
+
+        conn.commit = tracked_commit
+        client.messages.create = tracked_create
+
+        generate_thesis(instrument_id=1, conn=conn, client=client)
+
+        # First commit must precede first claude call. Both must appear.
+        assert "commit" in call_log, "expected conn.commit() to be called"
+        assert "claude" in call_log, "expected client.messages.create to be called"
+        assert call_log.index("commit") < call_log.index("claude"), (
+            f"commit must precede first Claude call, got order: {call_log}"
+        )
+
     def test_critic_failure_does_not_block_insert(self) -> None:
         import anthropic
 


### PR DESCRIPTION
## What
Close the implicit read transaction opened by \`_assemble_context\`'s SELECTs before \`generate_thesis\` makes Claude API calls. Prevents the connection sitting \`idle in transaction\` for 2-10s per Claude round-trip.

## Why
Issue #293. CLAUDE.md Architecture invariant: \"Holding a DB transaction across a network call is an ANTI-PATTERN in this codebase.\" \`generate_thesis\` docstring previously claimed \"Claude calls are made outside the transaction\" — true for the explicit \`with conn.transaction():\` block, false for the implicit read tx. Codex caught it during review of PR #294's master plan.

Prereq for #276 cascade work.

## Changes
- Add \`conn.commit()\` after \`_assemble_context\` returns, before \`_call_writer\`.
- Update docstring to document the load-bearing commit + caller contract (must not wrap in outer \`with conn.transaction():\`).
- New test \`test_commits_read_tx_before_claude_calls\` asserts commit ordering precedes first Claude call.

## Test plan
- [x] \`uv run pytest tests/test_thesis.py\` — 51 passed (including new test).
- [x] Full suite \`uv run pytest\` — 1786 passed.
- [x] \`uv run ruff check\` / \`ruff format --check\` / \`uv run pyright\` — all clean.
- [x] Codex reviewed: no blocking issues; caller-contract caveat incorporated into docstring.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>