### PR TITLE
feat(#292): bootstrap coverage rows for newly-added instruments

### DIFF
--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -746,3 +746,57 @@ def seed_coverage(
         seeded = result.rowcount
         logger.info("seed_coverage: seeded %d instruments at Tier 3", seeded)
         return SeedResult(seeded=seeded, already_populated=False)
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    """Outcome of ``bootstrap_missing_coverage_rows``."""
+
+    bootstrapped: int
+
+
+def bootstrap_missing_coverage_rows(
+    conn: psycopg.Connection[Any],
+) -> BootstrapResult:
+    """Insert Tier 3 coverage rows for tradable instruments that lack one.
+
+    Unlike ``seed_coverage`` which is a first-run-only bootstrap (no-ops
+    if the table is non-empty), this function targets the post-bootstrap
+    gap: newly-added tradable instruments that joined the universe
+    after the initial seed. It performs a set-difference insert keyed
+    on ``NOT EXISTS`` so existing rows are untouched and no tier is
+    ever clobbered.
+
+    Called from ``nightly_universe_sync`` after ``seed_coverage`` so
+    every tradable instrument has a coverage row going into the
+    downstream audit / thesis / scoring passes.
+
+    Opens its own ``conn.transaction()`` (savepoint when nested) so
+    the INSERT is atomic. ``ON CONFLICT DO NOTHING`` is defence-in-
+    depth; the ``NOT EXISTS`` predicate already guarantees no
+    conflict on non-concurrent callers.
+    """
+    with conn.transaction():
+        result = conn.execute(
+            """
+            INSERT INTO coverage (instrument_id, coverage_tier)
+            SELECT i.instrument_id, 3
+            FROM instruments i
+            WHERE i.is_tradable = TRUE
+              AND NOT EXISTS (
+                  SELECT 1 FROM coverage c WHERE c.instrument_id = i.instrument_id
+              )
+            ON CONFLICT DO NOTHING
+            """
+        )
+        if result.rowcount == -1:
+            raise RuntimeError(
+                "bootstrap_missing_coverage_rows INSERT INTO coverage: "
+                "server did not report a command tag (rowcount=-1)"
+            )
+        bootstrapped = result.rowcount
+        logger.info(
+            "bootstrap_missing_coverage_rows: inserted %d missing coverage rows at Tier 3",
+            bootstrapped,
+        )
+        return BootstrapResult(bootstrapped=bootstrapped)

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -709,8 +709,18 @@ def nightly_universe_sync() -> None:
             # UPDATE-based coverage audit / gate would silently no-op on
             # them. See #292.
             #
-            # bootstrap_missing_coverage_rows opens its own transaction
-            # internally, so no outer wrapper is needed here.
+            # bootstrap_missing_coverage_rows opens its own conn.transaction()
+            # which becomes a savepoint under the outer connection's
+            # implicit transaction. If a later step in nightly_universe_sync
+            # raises, the connection context manager rolls back the outer
+            # transaction — including this savepoint's inserts. That's
+            # intended: coverage bootstrap is a dependent side effect of a
+            # successful universe sync. A rolled-back bootstrap is harmless
+            # because the missing-row predicate is idempotent and the next
+            # nightly run re-inserts. The row_count contribution reflects
+            # rows staged inside the connection's transaction; it is
+            # accurate for "work attempted this run" even if the outer tx
+            # later rolls back.
             bootstrap_result = bootstrap_missing_coverage_rows(conn)
             row_count += bootstrap_result.bootstrapped
             tracker.row_count = row_count

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -40,7 +40,7 @@ from app.providers.implementations.fmp import FmpFundamentalsProvider
 from app.providers.implementations.sec_edgar import SecFilingsProvider
 from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
 from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
-from app.services.coverage import review_coverage, seed_coverage
+from app.services.coverage import bootstrap_missing_coverage_rows, review_coverage, seed_coverage
 from app.services.deferred_retry import retry_deferred_recommendations
 from app.services.enrichment import refresh_enrichment
 from app.services.entry_timing import evaluate_entry_conditions
@@ -699,6 +699,25 @@ def nightly_universe_sync() -> None:
                     "Coverage seed: seeded=%d already_populated=%s",
                     seed_result.seeded,
                     seed_result.already_populated,
+                )
+
+            # Post-bootstrap gap filler: insert Tier 3 rows for any
+            # tradable instrument that joined the universe after the
+            # initial seed and therefore has no coverage row. seed_coverage
+            # no-ops once the table is populated; without this step, such
+            # instruments would never get a coverage row and every
+            # UPDATE-based coverage audit / gate would silently no-op on
+            # them. See #292.
+            #
+            # bootstrap_missing_coverage_rows opens its own transaction
+            # internally, so no outer wrapper is needed here.
+            bootstrap_result = bootstrap_missing_coverage_rows(conn)
+            row_count += bootstrap_result.bootstrapped
+            tracker.row_count = row_count
+            if bootstrap_result.bootstrapped > 0:
+                logger.info(
+                    "Coverage bootstrap: inserted %d missing rows at Tier 3",
+                    bootstrap_result.bootstrapped,
                 )
 
             # Enrich instrument currencies from FMP for instruments that

--- a/sql/035_coverage_bootstrap_backfill.sql
+++ b/sql/035_coverage_bootstrap_backfill.sql
@@ -1,0 +1,26 @@
+-- Migration 035: backfill coverage rows for tradable instruments that
+-- joined the universe after the initial seed and therefore have no row.
+--
+-- seed_coverage is a first-run-only bootstrap: once the coverage table
+-- is non-empty, subsequent universe syncs never add rows for newly-
+-- added instruments. Over time this leaves a growing set of tradable
+-- instruments without any coverage row — invisible to every
+-- UPDATE-based coverage audit / gate because those no-op on missing
+-- rows.
+--
+-- Fix is twofold:
+--   1. nightly_universe_sync now also calls bootstrap_missing_coverage_rows
+--      to close the gap going forward (see PR for #292).
+--   2. This migration closes the backlog for any instrument that is
+--      currently tradable but has no coverage row.
+--
+-- Idempotent: NOT EXISTS + ON CONFLICT DO NOTHING. Safe to re-run.
+
+INSERT INTO coverage (instrument_id, coverage_tier)
+SELECT i.instrument_id, 3
+FROM instruments i
+WHERE i.is_tradable = TRUE
+  AND NOT EXISTS (
+      SELECT 1 FROM coverage c WHERE c.instrument_id = i.instrument_id
+  )
+ON CONFLICT DO NOTHING;

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1002,3 +1002,54 @@ class TestSeedCoverage:
         conn = self._mock_conn(coverage_count=0, inserted_rows=10)
         seed_coverage(conn)
         conn.transaction.assert_called_once()
+
+
+class TestBootstrapMissingCoverageRows:
+    """Tests for the post-bootstrap gap-filler for newly-added instruments."""
+
+    def _mock_conn(self, inserted_rows: int) -> MagicMock:
+        conn = MagicMock()
+        mock_result = MagicMock()
+        mock_result.rowcount = inserted_rows
+        conn.execute.return_value = mock_result
+        conn.transaction.return_value.__enter__ = MagicMock(return_value=None)
+        conn.transaction.return_value.__exit__ = MagicMock(return_value=False)
+        return conn
+
+    def test_inserts_missing_rows(self) -> None:
+        """Three newly-added tradable instruments without coverage rows
+        get Tier 3 entries."""
+        from app.services.coverage import bootstrap_missing_coverage_rows
+
+        conn = self._mock_conn(inserted_rows=3)
+        result = bootstrap_missing_coverage_rows(conn)
+        assert result.bootstrapped == 3
+        conn.execute.assert_called_once()
+        sql = conn.execute.call_args[0][0]
+        assert "INSERT INTO coverage" in sql
+        assert "NOT EXISTS" in sql
+        assert "is_tradable = TRUE" in sql
+
+    def test_noop_when_no_gaps(self) -> None:
+        """Every tradable instrument already has coverage → zero inserts."""
+        from app.services.coverage import bootstrap_missing_coverage_rows
+
+        conn = self._mock_conn(inserted_rows=0)
+        result = bootstrap_missing_coverage_rows(conn)
+        assert result.bootstrapped == 0
+
+    def test_runs_inside_transaction(self) -> None:
+        """Insert must be atomic — wrapped in conn.transaction()."""
+        from app.services.coverage import bootstrap_missing_coverage_rows
+
+        conn = self._mock_conn(inserted_rows=5)
+        bootstrap_missing_coverage_rows(conn)
+        conn.transaction.assert_called_once()
+
+    def test_raises_on_unknown_rowcount(self) -> None:
+        """rowcount=-1 (server did not report command tag) must raise, not return silently."""
+        from app.services.coverage import bootstrap_missing_coverage_rows
+
+        conn = self._mock_conn(inserted_rows=-1)
+        with pytest.raises(RuntimeError, match="command tag"):
+            bootstrap_missing_coverage_rows(conn)


### PR DESCRIPTION
## What
- New \`bootstrap_missing_coverage_rows\` in \`app/services/coverage.py\` — set-difference INSERT for tradable instruments lacking a \`coverage\` row. Tier 3, never clobbers existing tiers.
- \`nightly_universe_sync\` calls it after \`seed_coverage\` so newly-added instruments get coverage rows within 24h.
- Migration 035 backfills existing gaps at deploy time. Idempotent.

## Why
Issue #292. \`seed_coverage\` only runs on an empty table — once populated, every UPDATE-based audit / gate silently no-ops on instruments without a row. Prereq for #268 (filings coverage bar).

## Test plan
- [x] \`pytest tests/test_coverage.py\` — 96 passed (4 new TestBootstrapMissingCoverageRows tests).
- [x] Full suite \`uv run pytest\` — 1790 passed.
- [x] \`ruff check\` / \`ruff format --check\` / \`pyright\` — all clean.
- [x] Codex reviewed: no blocking findings; nested-tx nit addressed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>