### PR TITLE
feat(#291): execute_refresh writes filing_events from master-index (Chunk A)

### DIFF
--- a/app/services/sec_incremental.py
+++ b/app/services/sec_incremental.py
@@ -596,6 +596,15 @@ def execute_refresh(
         # Seeds + refreshes share one per-CIK body. _run_cik_upsert
         # returns the fact-row count (int >= 0) on success, or None
         # on skip / failure. Failures additionally append to `failed`.
+        #
+        # Seeds deliberately do NOT pass ``new_filings`` even if the
+        # CIK has entries in ``plan.new_filings_by_cik`` — seeds need
+        # full historical backfill (#268 Chunk E), not just this
+        # cycle's master-index hits. Writing only this week's filings
+        # for a seed would give downstream event triggers a misleading
+        # signal ("look, a filing landed") when the instrument still
+        # lacks most of its history. Chunk E owns the seed-time
+        # filing_events population.
         for cik in plan.seeds:
             done += 1
             upserted = _run_cik_upsert(

--- a/app/services/sec_incremental.py
+++ b/app/services/sec_incremental.py
@@ -86,12 +86,13 @@ class RefreshPlan:
     - ``ciks_by_day`` — ISO-date to list-of-hit-CIKs mapping used by
       the executor to decide which pending master-index writes are safe
       to commit.
-    - ``new_filings_by_cik`` — per-CIK list of master-index entries that
-      landed in this cycle. Executor upserts each into ``filing_events``
-      so downstream event-driven triggers (thesis, scoring) have a
-      timestamped signal to query. Only populated for covered CIKs with
-      non-empty master-index hits; seeds do NOT appear here (no hit
-      yet — historical backfill is #268 Chunk E territory).
+    - ``new_filings_by_cik`` — per-CIK list of master-index entries
+      that landed in this cycle. Populated for every covered CIK that
+      had at least one master-index hit in the 7-day window (including
+      seeds that happened to file this week). The executor only
+      consumes this dict on the refresh + submissions-only paths; the
+      seed path ignores it because seeds need full historical backfill
+      (#268 Chunk E), not just this week's entries.
     """
 
     seeds: list[str] = field(default_factory=list)
@@ -363,6 +364,16 @@ def _upsert_filing_from_master_index(
     try:
         filed_at = datetime.fromisoformat(entry.date_filed).replace(tzinfo=UTC)
     except ValueError:
+        # Master-index dates are always ISO; ValueError here indicates
+        # corrupt data. Log loudly so operators can investigate rather
+        # than silently substituting now().
+        logger.warning(
+            "sec_incremental: malformed date_filed %r for accession %s (cik=%s) — "
+            "falling back to now() so upsert proceeds",
+            entry.date_filed,
+            entry.accession_number,
+            entry.cik,
+        )
         filed_at = datetime.now(UTC)
     conn.execute(
         """

--- a/app/services/sec_incremental.py
+++ b/app/services/sec_incremental.py
@@ -22,9 +22,10 @@ watermark row and is placed in ``seeds`` for a full initial backfill.
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass, field
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import psycopg
@@ -85,6 +86,12 @@ class RefreshPlan:
     - ``ciks_by_day`` — ISO-date to list-of-hit-CIKs mapping used by
       the executor to decide which pending master-index writes are safe
       to commit.
+    - ``new_filings_by_cik`` — per-CIK list of master-index entries that
+      landed in this cycle. Executor upserts each into ``filing_events``
+      so downstream event-driven triggers (thesis, scoring) have a
+      timestamped signal to query. Only populated for covered CIKs with
+      non-empty master-index hits; seeds do NOT appear here (no hit
+      yet — historical backfill is #268 Chunk E territory).
     """
 
     seeds: list[str] = field(default_factory=list)
@@ -95,6 +102,7 @@ class RefreshPlan:
     submissions_only_advances: list[tuple[str, str]] = field(default_factory=list)
     pending_master_index_writes: list[tuple[str, str, str]] = field(default_factory=list)
     ciks_by_day: dict[str, list[str]] = field(default_factory=dict)
+    new_filings_by_cik: dict[str, list[MasterIndexEntry]] = field(default_factory=dict)
     # CIKs skipped during planning itself (fetch_submissions returned None
     # or filings.recent was empty). These never make it to
     # seeds/refreshes/submissions_only_advances, so the executor's
@@ -289,6 +297,10 @@ def plan_refresh(
         pending_master_index_writes=pending_master_index_writes,
         ciks_by_day=ciks_by_day_filtered,
         failed_plan_ciks=sorted(failed_plan_ciks),
+        # master_hits_by_cik has already been intersected with the
+        # covered cohort above; pass it through so the executor can
+        # upsert each hit into filing_events.
+        new_filings_by_cik=master_hits_by_cik,
     )
 
 
@@ -321,6 +333,78 @@ def _instrument_for_cik(
     return int(row[0]), str(row[1])
 
 
+def _upsert_filing_from_master_index(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    entry: MasterIndexEntry,
+    symbol: str,
+) -> None:
+    """Upsert a filing_events row from a master-index entry.
+
+    Distinct from ``filings._upsert_filing`` on the ON CONFLICT path:
+    when the row already exists, we DO NOT overwrite ``primary_document_url``
+    or ``source_url``. Master-index only carries the generic
+    ``{accession}-index.htm`` landing page, whereas the submissions-
+    based ingest (``daily_research_refresh``) stores the specific
+    primary document (e.g. ``aapl-20260330.htm``). A master-index
+    upsert arriving after the richer ingest must not downgrade the URL.
+    COALESCE preserves the existing value unless it is NULL.
+
+    ``filing_date`` and ``filing_type`` still refresh on conflict —
+    both are authoritative from either source and carry no loss-of-
+    detail risk.
+    """
+    accession_no_dashes = entry.accession_number.replace("-", "")
+    cik_int = int(entry.cik)
+    master_index_url = (
+        f"https://www.sec.gov/Archives/edgar/data/{cik_int}/{accession_no_dashes}/{entry.accession_number}-index.htm"
+    )
+    try:
+        filed_at = datetime.fromisoformat(entry.date_filed).replace(tzinfo=UTC)
+    except ValueError:
+        filed_at = datetime.now(UTC)
+    conn.execute(
+        """
+        INSERT INTO filing_events (
+            instrument_id, filing_date, filing_type,
+            provider, provider_filing_id, source_url, primary_document_url,
+            raw_payload_json
+        )
+        VALUES (
+            %(instrument_id)s, %(filing_date)s, %(filing_type)s,
+            %(provider)s, %(provider_filing_id)s, %(source_url)s, %(primary_document_url)s,
+            %(raw_payload_json)s
+        )
+        ON CONFLICT (provider, provider_filing_id) DO UPDATE SET
+            filing_date          = EXCLUDED.filing_date,
+            filing_type          = EXCLUDED.filing_type,
+            source_url           = COALESCE(filing_events.source_url, EXCLUDED.source_url),
+            primary_document_url = COALESCE(filing_events.primary_document_url, EXCLUDED.primary_document_url)
+        """,
+        {
+            "instrument_id": instrument_id,
+            "filing_date": filed_at.date(),
+            "filing_type": entry.form_type,
+            "provider": "sec",
+            "provider_filing_id": entry.accession_number,
+            "source_url": master_index_url,
+            "primary_document_url": master_index_url,
+            "raw_payload_json": json.dumps(
+                {
+                    "source": "master-index",
+                    "provider_filing_id": entry.accession_number,
+                    "symbol": symbol,
+                    "filed_at": filed_at.isoformat(),
+                    "filing_type": entry.form_type,
+                    "company_name": entry.company_name,
+                    "date_filed": entry.date_filed,
+                }
+            ),
+        },
+    )
+
+
 def _run_cik_upsert(
     conn: psycopg.Connection[tuple],
     *,
@@ -330,6 +414,7 @@ def _run_cik_upsert(
     run_id: int,
     failed: list[tuple[str, str]],
     known_top_accession: str | None = None,
+    new_filings: list[MasterIndexEntry] | None = None,
 ) -> int | None:
     """Per-CIK seed/refresh body.
 
@@ -412,6 +497,20 @@ def _run_cik_upsert(
                     ingestion_run_id=run_id,
                 )
                 facts_upserted = upserted
+            # Upsert each master-index entry for this CIK into
+            # filing_events so downstream event-driven triggers
+            # (#273 thesis, #276 cascade) have a timestamped signal.
+            # Idempotent: ON CONFLICT preserves richer URLs stored by
+            # the submissions-based ingest path. Atomic with the facts
+            # upsert and watermark writes below.
+            if new_filings:
+                for entry in new_filings:
+                    _upsert_filing_from_master_index(
+                        conn,
+                        instrument_id=instrument_id,
+                        entry=entry,
+                        symbol=symbol,
+                    )
             set_watermark(
                 conn,
                 source="sec.submissions",
@@ -511,6 +610,7 @@ def execute_refresh(
                 run_id=run_id,
                 failed=failed,
                 known_top_accession=top_accession,
+                new_filings=plan.new_filings_by_cik.get(cik),
             )
             if upserted is not None:
                 refreshed += 1
@@ -520,7 +620,35 @@ def execute_refresh(
         for cik, accession in plan.submissions_only_advances:
             done += 1
             try:
+                inst = _instrument_for_cik(conn, cik)
+                conn.commit()  # close implicit read tx from the SELECT
+                if inst is None:
+                    # Plan-drift: CIK fell out of the tradable-with-SEC
+                    # cohort between planning and execution. Record as
+                    # failed so the master-index watermark for this
+                    # day is withheld.
+                    logger.warning(
+                        "sec_incremental: submissions-only path — no tradable instrument for cik=%s (plan drift?)",
+                        cik,
+                    )
+                    failed.append((cik, "InstrumentMissing"))
+                    report_progress(done, total)
+                    continue
+                instrument_id, symbol = inst
+                new_filings = plan.new_filings_by_cik.get(cik)
                 with conn.transaction():
+                    # Upsert filing_events for each master-index entry
+                    # on this CIK so the 8-K (or similar) is visible to
+                    # downstream event-driven triggers, even though we
+                    # don't fetch companyfacts.
+                    if new_filings:
+                        for entry in new_filings:
+                            _upsert_filing_from_master_index(
+                                conn,
+                                instrument_id=instrument_id,
+                                entry=entry,
+                                symbol=symbol,
+                            )
                     set_watermark(
                         conn,
                         source="sec.submissions",

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -52,6 +52,7 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "job_runs",
     "financial_periods_raw",
     "financial_periods",
+    "filing_events",
 )
 
 

--- a/tests/test_sec_incremental_executor.py
+++ b/tests/test_sec_incremental_executor.py
@@ -577,8 +577,7 @@ def test_submissions_only_path_writes_filing_events(
     assert outcome.submissions_advanced == 1
 
     row = ebull_test_conn.execute(
-        "SELECT filing_type, provider, provider_filing_id "
-        "FROM filing_events WHERE instrument_id = 1"
+        "SELECT filing_type, provider, provider_filing_id FROM filing_events WHERE instrument_id = 1"
     ).fetchone()
     assert row is not None
     assert row[0] == "8-K"
@@ -645,15 +644,12 @@ def test_refresh_path_preserves_existing_primary_document_url(
     )
 
     row = ebull_test_conn.execute(
-        "SELECT primary_document_url FROM filing_events "
-        "WHERE provider_filing_id = '0000320193-26-000042'"
+        "SELECT primary_document_url FROM filing_events WHERE provider_filing_id = '0000320193-26-000042'"
     ).fetchone()
     assert row is not None
     # Original URL preserved — master-index upsert did NOT overwrite
     # with the generic ...-index.htm URL.
-    assert row[0].endswith("aapl-20260330.htm"), (
-        f"master-index upsert downgraded primary_document_url to: {row[0]}"
-    )
+    assert row[0].endswith("aapl-20260330.htm"), f"master-index upsert downgraded primary_document_url to: {row[0]}"
 
 
 def test_seed_path_does_not_write_filing_events(
@@ -678,7 +674,5 @@ def test_seed_path_does_not_write_filing_events(
         plan=plan,
     )
 
-    count = ebull_test_conn.execute(
-        "SELECT COUNT(*) FROM filing_events WHERE instrument_id = 1"
-    ).fetchone()
+    count = ebull_test_conn.execute("SELECT COUNT(*) FROM filing_events WHERE instrument_id = 1").fetchone()
     assert count is not None and count[0] == 0

--- a/tests/test_sec_incremental_executor.py
+++ b/tests/test_sec_incremental_executor.py
@@ -11,7 +11,7 @@ import psycopg
 import pytest
 
 from app.providers.fundamentals import XbrlFact
-from app.providers.implementations.sec_edgar import SecFilingsProvider
+from app.providers.implementations.sec_edgar import MasterIndexEntry, SecFilingsProvider
 from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
 from app.services.sec_incremental import (
     RefreshOutcome,
@@ -470,3 +470,215 @@ def test_successful_ciks_commit_master_index_watermark(
     assert master_wm is not None
     assert master_wm.watermark == "Wed, 15 Apr 2026 22:00:00 GMT"
     assert master_wm.response_hash == "abc123"
+
+
+def _mk_entry(accession: str, form: str, cik: str = "0000320193") -> MasterIndexEntry:
+    return MasterIndexEntry(
+        cik=cik,
+        company_name="TEST CORP",
+        form_type=form,
+        date_filed="2026-04-15",
+        accession_number=accession,
+    )
+
+
+def test_refresh_path_writes_filing_events(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """On the refresh path, each master-index entry for the CIK must
+    be upserted into filing_events so downstream event-driven triggers
+    see the new filing. #291 regression guard."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="TEST", cik="0000320193")
+    with ebull_test_conn.transaction():
+        set_watermark(
+            ebull_test_conn,
+            source="sec.submissions",
+            key="0000320193",
+            watermark="0000320193-25-000108",
+        )
+        set_watermark(
+            ebull_test_conn,
+            source="sec.companyfacts",
+            key="0000320193",
+            watermark="0000320193-25-000108",
+        )
+    ebull_test_conn.commit()
+
+    plan = RefreshPlan(
+        refreshes=[("0000320193", "0000320193-26-000042")],
+        new_filings_by_cik={
+            "0000320193": [
+                _mk_entry("0000320193-26-000042", "10-Q"),
+                _mk_entry("0000320193-26-000043", "8-K"),
+            ],
+        },
+    )
+    filings = StubFilingsProvider(
+        submissions_by_cik={"0000320193": _submissions_with_top("0000320193-26-000042")},
+    )
+    fundamentals = StubFundamentalsProvider(
+        facts_by_cik={"0000320193": [_sample_fact("0000320193-26-000042")]},
+    )
+
+    outcome = execute_refresh(
+        ebull_test_conn,
+        filings_provider=cast(SecFilingsProvider, filings),
+        fundamentals_provider=cast(SecFundamentalsProvider, fundamentals),
+        plan=plan,
+    )
+
+    assert outcome.refreshed == 1
+
+    rows = ebull_test_conn.execute(
+        "SELECT filing_type, provider, provider_filing_id, primary_document_url "
+        "FROM filing_events WHERE instrument_id = 1 ORDER BY provider_filing_id"
+    ).fetchall()
+    assert len(rows) == 2
+    assert rows[0][0] == "10-Q"
+    assert rows[0][1] == "sec"
+    assert rows[0][2] == "0000320193-26-000042"
+    assert rows[0][3] is not None and "edgar/data/320193" in rows[0][3]
+    assert rows[1][0] == "8-K"
+    assert rows[1][2] == "0000320193-26-000043"
+
+
+def test_submissions_only_path_writes_filing_events(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """submissions_only_advances path (8-K only, no companyfacts)
+    must still upsert the 8-K into filing_events — otherwise the
+    cascade's event predicate in #273 never sees it."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="TEST", cik="0000789019")
+    with ebull_test_conn.transaction():
+        set_watermark(
+            ebull_test_conn,
+            source="sec.submissions",
+            key="0000789019",
+            watermark="older",
+        )
+    ebull_test_conn.commit()
+
+    plan = RefreshPlan(
+        submissions_only_advances=[("0000789019", "0000789019-26-000017")],
+        new_filings_by_cik={
+            "0000789019": [_mk_entry("0000789019-26-000017", "8-K", cik="0000789019")],
+        },
+    )
+    filings = StubFilingsProvider()
+    fundamentals = StubFundamentalsProvider()
+
+    outcome = execute_refresh(
+        ebull_test_conn,
+        filings_provider=cast(SecFilingsProvider, filings),
+        fundamentals_provider=cast(SecFundamentalsProvider, fundamentals),
+        plan=plan,
+    )
+
+    assert outcome.submissions_advanced == 1
+
+    row = ebull_test_conn.execute(
+        "SELECT filing_type, provider, provider_filing_id "
+        "FROM filing_events WHERE instrument_id = 1"
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "8-K"
+    assert row[1] == "sec"
+    assert row[2] == "0000789019-26-000017"
+
+
+def test_refresh_path_preserves_existing_primary_document_url(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """When filing_events already has a row with a richer primary_document_url
+    (e.g. from the submissions-based ingest path), the master-index upsert
+    MUST NOT downgrade it to the generic index URL. #291 Codex P2."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="TEST", cik="0000320193")
+    # Pre-existing filing_events row with specific primary doc URL
+    # (simulating daily_research_refresh path).
+    ebull_test_conn.execute(
+        """
+        INSERT INTO filing_events (
+            instrument_id, filing_date, filing_type,
+            provider, provider_filing_id, source_url, primary_document_url
+        ) VALUES (
+            1, DATE '2026-04-15', '10-Q',
+            'sec', '0000320193-26-000042',
+            'https://www.sec.gov/Archives/edgar/data/320193/000032019326000042/aapl-20260330.htm',
+            'https://www.sec.gov/Archives/edgar/data/320193/000032019326000042/aapl-20260330.htm'
+        )
+        """
+    )
+    ebull_test_conn.commit()
+    with ebull_test_conn.transaction():
+        set_watermark(
+            ebull_test_conn,
+            source="sec.submissions",
+            key="0000320193",
+            watermark="0000320193-25-000108",
+        )
+        set_watermark(
+            ebull_test_conn,
+            source="sec.companyfacts",
+            key="0000320193",
+            watermark="0000320193-25-000108",
+        )
+    ebull_test_conn.commit()
+
+    plan = RefreshPlan(
+        refreshes=[("0000320193", "0000320193-26-000042")],
+        new_filings_by_cik={
+            "0000320193": [_mk_entry("0000320193-26-000042", "10-Q")],
+        },
+    )
+    filings = StubFilingsProvider(
+        submissions_by_cik={"0000320193": _submissions_with_top("0000320193-26-000042")},
+    )
+    fundamentals = StubFundamentalsProvider(
+        facts_by_cik={"0000320193": [_sample_fact("0000320193-26-000042")]},
+    )
+
+    execute_refresh(
+        ebull_test_conn,
+        filings_provider=cast(SecFilingsProvider, filings),
+        fundamentals_provider=cast(SecFundamentalsProvider, fundamentals),
+        plan=plan,
+    )
+
+    row = ebull_test_conn.execute(
+        "SELECT primary_document_url FROM filing_events "
+        "WHERE provider_filing_id = '0000320193-26-000042'"
+    ).fetchone()
+    assert row is not None
+    # Original URL preserved — master-index upsert did NOT overwrite
+    # with the generic ...-index.htm URL.
+    assert row[0].endswith("aapl-20260330.htm"), (
+        f"master-index upsert downgraded primary_document_url to: {row[0]}"
+    )
+
+
+def test_seed_path_does_not_write_filing_events(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Seeds have no master-index hit metadata (first sight) so they
+    MUST NOT write filing_events. Historical backfill is the job of
+    #268 Chunk E, not this executor."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="TEST", cik="0000320193")
+    plan = RefreshPlan(seeds=["0000320193"])
+    filings = StubFilingsProvider(
+        submissions_by_cik={"0000320193": _submissions_with_top("0000320193-26-000042")},
+    )
+    fundamentals = StubFundamentalsProvider(
+        facts_by_cik={"0000320193": [_sample_fact("0000320193-26-000042")]},
+    )
+
+    execute_refresh(
+        ebull_test_conn,
+        filings_provider=cast(SecFilingsProvider, filings),
+        fundamentals_provider=cast(SecFundamentalsProvider, fundamentals),
+        plan=plan,
+    )
+
+    count = ebull_test_conn.execute(
+        "SELECT COUNT(*) FROM filing_events WHERE instrument_id = 1"
+    ).fetchone()
+    assert count is not None and count[0] == 0


### PR DESCRIPTION
## What
Chunk A of the filings-cascade master plan (docs #294). \`sec_incremental.execute_refresh\` now upserts each master-index entry into \`filing_events\` so downstream event-driven triggers (#273 thesis, #276 cascade) have a timestamped signal within the same cycle — no longer waiting up to 24h for \`daily_research_refresh\`.

## Why
Issue #291. Prereq for #273 + #276.

## Changes
- \`RefreshPlan\` gains \`new_filings_by_cik: dict[str, list[MasterIndexEntry]]\`.
- New \`_upsert_filing_from_master_index\` in \`sec_incremental.py\` — distinct from existing \`filings._upsert_filing\` by using \`COALESCE\` in ON CONFLICT to preserve richer \`primary_document_url\` / \`source_url\` stored by submissions-based ingest. Master-index only carries the generic \`...-index.htm\` landing page; a master-index upsert arriving after the richer ingest must not downgrade the URL.
- Refresh path: upsert inside same per-CIK tx as facts + watermarks. Atomic.
- Submissions-only path: also upserts filing_events + adds plan-drift \`InstrumentMissing\` handling.
- Seeds deliberately skipped — no master-index hit metadata. Historical backfill is Chunk E (#268 stream).

## Test plan
- [x] 4 new tests in \`test_sec_incremental_executor.py\` covering refresh, submissions-only, URL preservation, seed exclusion.
- [x] Fixture \`ebull_test_db\` TRUNCATE list extended with \`filing_events\`.
- [x] \`uv run pytest\` — 1794 passed.
- [x] \`ruff check\` / \`ruff format --check\` / \`pyright\` — clean.
- [x] Codex reviewed: P2 URL-preservation finding caught + fixed + regression test added.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>