### PR TITLE
feat(#268): filings_status schema + audit v1 (Chunk D)

### DIFF
--- a/app/services/coverage_audit.py
+++ b/app/services/coverage_audit.py
@@ -222,10 +222,7 @@ def audit_all_instruments(conn: psycopg.Connection[Any]) -> AuditSummary:
                 (instrument_ids, statuses),
             )
             if result.rowcount == -1:
-                raise RuntimeError(
-                    "audit_all_instruments UPDATE: server did not report a "
-                    "command tag (rowcount=-1)"
-                )
+                raise RuntimeError("audit_all_instruments UPDATE: server did not report a command tag (rowcount=-1)")
             total_updated = result.rowcount
 
         null_anomalies = _count_null_anomalies(conn)

--- a/app/services/coverage_audit.py
+++ b/app/services/coverage_audit.py
@@ -324,7 +324,7 @@ def audit_instrument(conn: psycopg.Connection[Any], instrument_id: int) -> str:
 
         status = _classify(agg, has_sec_cik)
 
-        conn.execute(
+        result = conn.execute(
             """
             UPDATE coverage
             SET filings_status = %s,
@@ -333,5 +333,16 @@ def audit_instrument(conn: psycopg.Connection[Any], instrument_id: int) -> str:
             """,
             (status, instrument_id),
         )
+        if result.rowcount == 0:
+            # No coverage row for this instrument. Post-#292 this
+            # should never happen — universe sync + the weekly backfill
+            # together guarantee coverage rows for every tradable
+            # instrument. Raise loudly rather than return a status
+            # string that was never persisted.
+            raise RuntimeError(
+                f"audit_instrument: no coverage row for instrument_id={instrument_id}; "
+                f"classifier returned {status!r} but UPDATE matched zero rows. "
+                f"Check coverage bootstrap (#292) + universe sync wiring."
+            )
 
     return status

--- a/app/services/coverage_audit.py
+++ b/app/services/coverage_audit.py
@@ -1,0 +1,340 @@
+"""Coverage audit v1 (#268 Chunk D).
+
+Classifies every tradable instrument's ``coverage.filings_status`` so
+downstream thesis / scoring / cascade work (#273, #276) can gate on
+``filings_status = 'analysable'``.
+
+Classifier outputs (one of four; ``unknown`` is a pre-audit placeholder
+written elsewhere and ``structurally_young`` is assigned by Chunk E,
+not here):
+
+- ``analysable`` — US domestic issuer, 10-K count >= 2 in 3y AND
+  10-Q count >= 4 in 18mo. Base forms only — amendments do NOT count
+  toward history-depth thresholds.
+- ``insufficient`` — has primary SEC CIK but below the bar.
+- ``fpi`` — Foreign Private Issuer: SEC CIK, zero US base-or-amend
+  filings, at least one of {20-F, 40-F, 6-K} (base or amendment).
+- ``no_primary_sec_cik`` — no primary ``sec``/``cik`` row in
+  ``external_identifiers``. Non-US, crypto, ETFs, etc.
+
+Windows are computed in SQL via ``COUNT(*) FILTER (WHERE ...)`` so the
+Python classifier receives exact per-window counts. ``INTERVAL '18
+months'`` is calendar-correct — no ``timedelta(days=548)`` drift.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AuditCounts:
+    """Per-instrument row returned by the audit aggregate."""
+
+    instrument_id: int
+    ten_k_in_3y: int
+    ten_q_in_18m: int
+    us_base_or_amend_total: int
+    fpi_total: int
+
+
+@dataclass(frozen=True)
+class AuditSummary:
+    """Run result for ``audit_all_instruments``.
+
+    ``null_anomalies`` is the count from a post-update query over
+    tradable instruments left-joined to ``coverage`` — captures both
+    missing coverage rows (Chunk B regression) AND rows whose
+    ``filings_status`` remained NULL after the bulk UPDATE. Either is
+    a data-integrity bug and is logged at WARNING.
+    """
+
+    analysable: int
+    insufficient: int
+    fpi: int
+    no_primary_sec_cik: int
+    total_updated: int
+    null_anomalies: int
+
+
+def _classify(agg: AuditCounts | None, has_sec_cik: bool) -> str:
+    """Pure classification — windows/counts pre-computed in SQL.
+
+    ``agg`` is ``None`` when the instrument has zero SEC filings in the
+    filing_events table. ``has_sec_cik`` comes from the cohort query.
+    """
+    if not has_sec_cik:
+        return "no_primary_sec_cik"
+
+    if agg is None:
+        # SEC CIK present but no SEC filings yet — typical for a
+        # newly-added cohort member before Chunk E backfills history.
+        return "insufficient"
+
+    # FPI check FIRST: SEC CIK, zero US base-or-amend filings, at
+    # least one 20-F/40-F/6-K family filing.
+    if agg.us_base_or_amend_total == 0 and agg.fpi_total > 0:
+        return "fpi"
+
+    # US history bar — base forms only. Amendments do NOT count
+    # toward distinct-period depth (a 10-K/A restates the same year,
+    # not an additional one).
+    if agg.ten_k_in_3y >= 2 and agg.ten_q_in_18m >= 4:
+        return "analysable"
+
+    return "insufficient"
+
+
+def _load_aggregates(conn: psycopg.Connection[Any]) -> dict[int, AuditCounts]:
+    """Return per-instrument SEC filing counts for the four dimensions
+    the classifier needs.
+
+    Windows computed in SQL via ``COUNT(*) FILTER`` so the Python
+    side doesn't re-derive dates. Amendments are counted toward
+    ``us_base_or_amend_total`` (for FPI detection) but NOT toward the
+    history-depth thresholds ``ten_k_in_3y`` / ``ten_q_in_18m``.
+
+    Only covered SEC CIKs (primary) are joined in, so rows for
+    instruments without a primary ``sec``/``cik`` row are naturally
+    excluded.
+    """
+    rows = conn.execute(
+        """
+        SELECT
+            fe.instrument_id,
+            COUNT(*) FILTER (
+                WHERE fe.filing_type = '10-K'
+                  AND fe.filing_date >= (CURRENT_DATE - INTERVAL '3 years')
+            ) AS ten_k_in_3y,
+            COUNT(*) FILTER (
+                WHERE fe.filing_type = '10-Q'
+                  AND fe.filing_date >= (CURRENT_DATE - INTERVAL '18 months')
+            ) AS ten_q_in_18m,
+            COUNT(*) FILTER (
+                WHERE fe.filing_type IN ('10-K','10-K/A','10-Q','10-Q/A')
+            ) AS us_base_or_amend_total,
+            COUNT(*) FILTER (
+                WHERE fe.filing_type IN ('20-F','20-F/A','40-F','40-F/A','6-K','6-K/A')
+            ) AS fpi_total
+        FROM filing_events fe
+        JOIN external_identifiers ei
+            ON ei.instrument_id = fe.instrument_id
+           AND ei.provider = 'sec'
+           AND ei.identifier_type = 'cik'
+           AND ei.is_primary = TRUE
+        WHERE fe.provider = 'sec'
+        GROUP BY fe.instrument_id
+        """
+    ).fetchall()
+
+    return {
+        int(r[0]): AuditCounts(
+            instrument_id=int(r[0]),
+            ten_k_in_3y=int(r[1]),
+            ten_q_in_18m=int(r[2]),
+            us_base_or_amend_total=int(r[3]),
+            fpi_total=int(r[4]),
+        )
+        for r in rows
+    }
+
+
+def _load_cohort(
+    conn: psycopg.Connection[Any],
+) -> list[tuple[int, bool]]:
+    """Every tradable instrument + whether it has a primary SEC CIK."""
+    rows = conn.execute(
+        """
+        SELECT
+            i.instrument_id,
+            EXISTS (
+                SELECT 1 FROM external_identifiers ei
+                WHERE ei.instrument_id = i.instrument_id
+                  AND ei.provider = 'sec'
+                  AND ei.identifier_type = 'cik'
+                  AND ei.is_primary = TRUE
+            ) AS has_sec_cik
+        FROM instruments i
+        WHERE i.is_tradable = TRUE
+        ORDER BY i.instrument_id
+        """
+    ).fetchall()
+    return [(int(r[0]), bool(r[1])) for r in rows]
+
+
+def _count_null_anomalies(conn: psycopg.Connection[Any]) -> int:
+    """Tradable instruments missing a coverage row OR with NULL filings_status."""
+    row = conn.execute(
+        """
+        SELECT COUNT(*)
+        FROM instruments i
+        LEFT JOIN coverage c ON c.instrument_id = i.instrument_id
+        WHERE i.is_tradable = TRUE
+          AND (c.instrument_id IS NULL OR c.filings_status IS NULL)
+        """
+    ).fetchone()
+    return int(row[0]) if row is not None else 0
+
+
+def audit_all_instruments(conn: psycopg.Connection[Any]) -> AuditSummary:
+    """Full-universe audit. Writes ``filings_status`` for every tradable
+    instrument via a single bulk UPDATE. Wrapped in ``conn.transaction()``
+    so a mid-flight failure rolls back the whole audit rather than
+    leaving the table in a partial state.
+
+    Does NOT touch ``filings_backfill_*`` columns (Chunk E owns those)
+    and never assigns ``structurally_young`` (Chunk E owns that too).
+    """
+    with conn.transaction():
+        aggregates = _load_aggregates(conn)
+        cohort = _load_cohort(conn)
+
+        classifications: list[tuple[int, str]] = []
+        counts = {
+            "analysable": 0,
+            "insufficient": 0,
+            "fpi": 0,
+            "no_primary_sec_cik": 0,
+        }
+        for instrument_id, has_sec_cik in cohort:
+            status = _classify(aggregates.get(instrument_id), has_sec_cik)
+            classifications.append((instrument_id, status))
+            counts[status] += 1
+
+        total_updated = 0
+        if classifications:
+            instrument_ids = [c[0] for c in classifications]
+            statuses = [c[1] for c in classifications]
+            result = conn.execute(
+                """
+                UPDATE coverage c
+                SET filings_status = v.status,
+                    filings_audit_at = NOW()
+                FROM unnest(%s::bigint[], %s::text[]) AS v(instrument_id, status)
+                WHERE c.instrument_id = v.instrument_id
+                """,
+                (instrument_ids, statuses),
+            )
+            if result.rowcount == -1:
+                raise RuntimeError(
+                    "audit_all_instruments UPDATE: server did not report a "
+                    "command tag (rowcount=-1)"
+                )
+            total_updated = result.rowcount
+
+        null_anomalies = _count_null_anomalies(conn)
+
+    if null_anomalies > 0:
+        logger.warning(
+            "coverage_audit: %d null_anomalies detected — either tradable "
+            "instruments without a coverage row (Chunk B regression) or "
+            "coverage rows whose filings_status remained NULL after UPDATE. "
+            "Investigate before the next thesis/scoring cycle.",
+            null_anomalies,
+        )
+
+    logger.info(
+        "coverage_audit: analysable=%d insufficient=%d fpi=%d no_primary_sec_cik=%d total_updated=%d",
+        counts["analysable"],
+        counts["insufficient"],
+        counts["fpi"],
+        counts["no_primary_sec_cik"],
+        total_updated,
+    )
+
+    return AuditSummary(
+        analysable=counts["analysable"],
+        insufficient=counts["insufficient"],
+        fpi=counts["fpi"],
+        no_primary_sec_cik=counts["no_primary_sec_cik"],
+        total_updated=total_updated,
+        null_anomalies=null_anomalies,
+    )
+
+
+def audit_instrument(conn: psycopg.Connection[Any], instrument_id: int) -> str:
+    """Single-instrument version of ``audit_all_instruments``.
+
+    Returns the classified status. Used by Chunk G's universe-sync
+    hook when a new instrument needs an immediate audit pass, and by
+    Chunk E's post-backfill re-audit loop.
+
+    Wrapped in a savepoint so the SELECT + UPDATE are atomic even
+    when called inside an outer transaction.
+    """
+    with conn.transaction():
+        agg_rows = conn.execute(
+            """
+            SELECT
+                COUNT(*) FILTER (
+                    WHERE fe.filing_type = '10-K'
+                      AND fe.filing_date >= (CURRENT_DATE - INTERVAL '3 years')
+                ),
+                COUNT(*) FILTER (
+                    WHERE fe.filing_type = '10-Q'
+                      AND fe.filing_date >= (CURRENT_DATE - INTERVAL '18 months')
+                ),
+                COUNT(*) FILTER (
+                    WHERE fe.filing_type IN ('10-K','10-K/A','10-Q','10-Q/A')
+                ),
+                COUNT(*) FILTER (
+                    WHERE fe.filing_type IN ('20-F','20-F/A','40-F','40-F/A','6-K','6-K/A')
+                )
+            FROM filing_events fe
+            JOIN external_identifiers ei
+                ON ei.instrument_id = fe.instrument_id
+               AND ei.provider = 'sec'
+               AND ei.identifier_type = 'cik'
+               AND ei.is_primary = TRUE
+            WHERE fe.provider = 'sec'
+              AND fe.instrument_id = %s
+            """,
+            (instrument_id,),
+        ).fetchone()
+
+        has_cik_row = conn.execute(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM external_identifiers ei
+                WHERE ei.instrument_id = %s
+                  AND ei.provider = 'sec'
+                  AND ei.identifier_type = 'cik'
+                  AND ei.is_primary = TRUE
+            )
+            """,
+            (instrument_id,),
+        ).fetchone()
+        has_sec_cik = bool(has_cik_row[0]) if has_cik_row is not None else False
+
+        agg: AuditCounts | None
+        if agg_rows is None or all(v == 0 for v in agg_rows):
+            # No SEC filings for this instrument.
+            agg = None
+        else:
+            agg = AuditCounts(
+                instrument_id=instrument_id,
+                ten_k_in_3y=int(agg_rows[0]),
+                ten_q_in_18m=int(agg_rows[1]),
+                us_base_or_amend_total=int(agg_rows[2]),
+                fpi_total=int(agg_rows[3]),
+            )
+
+        status = _classify(agg, has_sec_cik)
+
+        conn.execute(
+            """
+            UPDATE coverage
+            SET filings_status = %s,
+                filings_audit_at = NOW()
+            WHERE instrument_id = %s
+            """,
+            (status, instrument_id),
+        )
+
+    return status

--- a/app/services/coverage_audit.py
+++ b/app/services/coverage_audit.py
@@ -225,7 +225,11 @@ def audit_all_instruments(conn: psycopg.Connection[Any]) -> AuditSummary:
                 raise RuntimeError("audit_all_instruments UPDATE: server did not report a command tag (rowcount=-1)")
             total_updated = result.rowcount
 
-        null_anomalies = _count_null_anomalies(conn)
+    # Null-anomaly check runs AFTER the transaction commits so the
+    # count reflects durable state. Running it inside the `with` block
+    # would count uncommitted rows; on commit failure those counts
+    # would be stale. Post-commit makes the check unambiguous.
+    null_anomalies = _count_null_anomalies(conn)
 
     if null_anomalies > 0:
         logger.warning(

--- a/docs/superpowers/specs/2026-04-17-filings-status-schema-design.md
+++ b/docs/superpowers/specs/2026-04-17-filings-status-schema-design.md
@@ -1,0 +1,325 @@
+# Filings status schema + audit v1 — design spec (#268 Chunk D)
+
+**Parent plan:** `docs/superpowers/plans/2026-04-17-filings-cascade-master-plan.md` Chunk D
+**Depends on:** #291 (execute_refresh writes filing_events — shipped), #292 (coverage row bootstrap — shipped)
+**Precedes:** Chunks E (backfill), F (weekly job), G (universe hook), H (admin surface), J (scoring gate)
+**Date:** 2026-04-17
+
+---
+
+## Goal
+
+Add `coverage.filings_status` column + retry-tracking columns. Implement `coverage_audit.audit_all_instruments` + `audit_instrument` that classify every tradable instrument into one of four classifier outputs: `analysable`, `insufficient`, `fpi`, `no_primary_sec_cik`. Defer `structurally_young` assignment to Chunk E (backfill). `unknown` is a pre-audit placeholder written by Chunk G (universe-sync hook); the classifier itself never outputs it.
+
+## Scope
+
+**In scope**
+
+- Migration `sql/036_coverage_filings_status.sql`:
+  - `ADD COLUMN filings_status TEXT CHECK (filings_status IN ('analysable','insufficient','fpi','no_primary_sec_cik','structurally_young','unknown'))`.
+  - `ADD COLUMN filings_audit_at TIMESTAMPTZ`.
+  - `ADD COLUMN filings_backfill_attempts INTEGER NOT NULL DEFAULT 0`.
+  - `ADD COLUMN filings_backfill_last_at TIMESTAMPTZ`.
+  - `ADD COLUMN filings_backfill_reason TEXT`.
+  - `CREATE INDEX idx_coverage_filings_status ON coverage(filings_status)`.
+- New service `app/services/coverage_audit.py`:
+  - `@dataclass AuditCounts` — per-CIK row for the aggregate.
+  - `@dataclass AuditSummary` — run result: counts for the four classifier outputs `{analysable, insufficient, fpi, no_primary_sec_cik}` plus `total_updated` + `null_anomalies` (see below).
+  - `audit_all_instruments(conn) -> AuditSummary` — full-universe scan.
+  - `audit_instrument(conn, instrument_id) -> str` — single-instrument, returns the new status.
+- Unit + real-DB integration tests.
+
+**Out of scope (other chunks)**
+
+- Backfill / `structurally_young` assignment — Chunk E.
+- Weekly scheduler job — Chunk F.
+- Universe-sync `unknown` marking — Chunk G.
+- Admin UI surface — Chunk H.
+- Scoring gate on `filings_status` — Chunk J.
+
+---
+
+## Schema
+
+```sql
+-- sql/036_coverage_filings_status.sql
+
+ALTER TABLE coverage
+    ADD COLUMN filings_status TEXT
+    CHECK (filings_status IS NULL OR filings_status IN (
+        'analysable',
+        'insufficient',
+        'fpi',
+        'no_primary_sec_cik',
+        'structurally_young',
+        'unknown'
+    ));
+
+ALTER TABLE coverage ADD COLUMN filings_audit_at TIMESTAMPTZ;
+ALTER TABLE coverage ADD COLUMN filings_backfill_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE coverage ADD COLUMN filings_backfill_last_at TIMESTAMPTZ;
+ALTER TABLE coverage ADD COLUMN filings_backfill_reason TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_coverage_filings_status
+    ON coverage(filings_status);
+
+-- Chunk D audit v1 does NOT set filings_status during the migration.
+-- All existing rows keep filings_status = NULL until the weekly audit
+-- (Chunk F) runs and classifies them. NULL semantics: "not yet audited"
+-- (pre-first-audit only). After the first full audit, NULL filings_status
+-- should never occur.
+```
+
+## Status value semantics
+
+| Value | Meaning | Gate for downstream? |
+|---|---|---|
+| `analysable` | US domestic issuer; 10-K count ≥ 2 within 3y AND 10-Q count ≥ 4 within 18mo. | YES — only this passes |
+| `insufficient` | Has primary SEC CIK (US or FPI); below the form thresholds. Probably needs backfill. | NO |
+| `fpi` | Foreign Private Issuer: SEC CIK, zero 10-K/10-Q, ≥1 of {20-F, 40-F, 6-K}. | NO (v1; #279 handles UK-equivalent bar) |
+| `no_primary_sec_cik` | No primary `sec`/`cik` row in `external_identifiers`. Non-US, crypto, ETFs, etc. | NO |
+| `structurally_young` | Post-backfill status ONLY. IPO'd <18mo ago; cannot meet US-bar by calendar. NOT assigned by Chunk D audit. | NO |
+| `unknown` | Not yet audited OR universe-sync-just-added. | NO |
+| `NULL` | Pre-first-audit invariant. Post-first-audit is an error state. | NO |
+
+## `audit_all_instruments` logic
+
+```python
+def audit_all_instruments(conn: psycopg.Connection[tuple]) -> AuditSummary:
+    """Recompute filings_status for every tradable instrument.
+
+    Does not touch filings_backfill_* columns (those are Chunk E's
+    responsibility). Does not assign `structurally_young` (Chunk E
+    owns that based on SEC earliest-filing date).
+
+    Returns per-status counts for logging.
+    """
+    # 1. Single GROUP BY aggregate: counts per (instrument_id, form_type)
+    #    WITHIN the recency windows (3y for 10-K, 18mo for 10-Q).
+    #    Filter on fe.provider='sec' AND ei.provider='sec' AND
+    #    ei.identifier_type='cik' AND ei.is_primary=TRUE.
+    # 2. Cohort query: every tradable instrument + whether it has a
+    #    primary SEC CIK.
+    # 3. Classify in Python per the table above.
+    # 4. Bulk UPDATE coverage via unnest(bigint[], text[]); set filings_audit_at=NOW().
+    # 5. Return AuditSummary.
+```
+
+### SQL (aggregate query)
+
+Recency windows are applied in SQL via `COUNT(*) FILTER (WHERE ...)` so the Python classifier receives exact per-window counts per instrument. Amendments are NOT counted toward history-depth bars — they prove the issuer re-stated a prior filing, not that they have more distinct reporting periods. Amendments DO still trigger event-driven refresh (Chunk I) and populate `filing_events`, they just don't satisfy the analysability bar.
+
+```sql
+SELECT
+    fe.instrument_id,
+    COUNT(*) FILTER (
+        WHERE fe.filing_type = '10-K'
+          AND fe.filing_date >= (CURRENT_DATE - INTERVAL '3 years')
+    ) AS ten_k_in_3y,
+    COUNT(*) FILTER (
+        WHERE fe.filing_type = '10-Q'
+          AND fe.filing_date >= (CURRENT_DATE - INTERVAL '18 months')
+    ) AS ten_q_in_18m,
+    COUNT(*) FILTER (
+        WHERE fe.filing_type IN ('10-K','10-K/A','10-Q','10-Q/A')
+    ) AS us_base_or_amend_total,
+    COUNT(*) FILTER (
+        WHERE fe.filing_type IN ('20-F','20-F/A','40-F','40-F/A','6-K','6-K/A')
+    ) AS fpi_total
+FROM filing_events fe
+JOIN external_identifiers ei
+    ON ei.instrument_id = fe.instrument_id
+    AND ei.provider = 'sec'
+    AND ei.identifier_type = 'cik'
+    AND ei.is_primary = TRUE
+WHERE fe.provider = 'sec'
+GROUP BY fe.instrument_id;
+```
+
+**Key points:**
+- Windows computed in SQL via `FILTER`, not Python. Avoids `timedelta(days=548)`-style drift at month boundaries. `INTERVAL '18 months'` is calendar-correct.
+- `CURRENT_DATE` used once; all FILTERs reference the same anchor (Postgres evaluates `CURRENT_DATE` per-row but it's stable within a transaction).
+- Base forms (`10-K`, `10-Q`) count toward the history bar. Amendments (`/A`) do NOT — they re-state the same period. `us_base_or_amend_total` is used for FPI detection (presence of ANY US-form-family filing rules out FPI), not for the bar.
+- `fpi_total` aggregates 20-F/40-F/6-K families; used only if `us_base_or_amend_total = 0`.
+- Zero-row instruments (no SEC filings yet) are omitted from this query's output — the cohort query joins them in separately so they classify as `insufficient` (if SEC CIK) or `no_primary_sec_cik`.
+
+### Cohort SQL
+
+```sql
+SELECT
+    i.instrument_id,
+    CASE WHEN EXISTS (
+        SELECT 1 FROM external_identifiers ei
+        WHERE ei.instrument_id = i.instrument_id
+          AND ei.provider = 'sec'
+          AND ei.identifier_type = 'cik'
+          AND ei.is_primary = TRUE
+    ) THEN TRUE ELSE FALSE END AS has_sec_cik
+FROM instruments i
+WHERE i.is_tradable = TRUE
+ORDER BY i.instrument_id;
+```
+
+### Classification
+
+```python
+@dataclass(frozen=True)
+class _AggRow:
+    instrument_id: int
+    ten_k_in_3y: int            # base 10-K only, within 3 years
+    ten_q_in_18m: int           # base 10-Q only, within 18 months
+    us_base_or_amend_total: int # used for FPI detection (non-zero → not FPI)
+    fpi_total: int              # 20-F/40-F/6-K family (base + amendments)
+
+
+def _classify(agg: _AggRow | None, has_sec_cik: bool) -> str:
+    """Pure function — windows/counts already computed in SQL.
+
+    `agg` is None for cohort instruments with zero SEC filings in the
+    filing_events table. `has_sec_cik` comes from the cohort query.
+    """
+    if not has_sec_cik:
+        return 'no_primary_sec_cik'
+
+    if agg is None:
+        # SEC CIK present but no filings yet — likely pre-backfill.
+        return 'insufficient'
+
+    # FPI check FIRST: has SEC CIK, zero US base-or-amend filings,
+    # at least one 20-F/40-F/6-K family filing.
+    if agg.us_base_or_amend_total == 0 and agg.fpi_total > 0:
+        return 'fpi'
+
+    # US history bar: base forms only. Amendments do NOT count toward
+    # distinct-period depth — a 10-K/A re-states the same annual
+    # period, it does not prove an additional year of history.
+    if agg.ten_k_in_3y >= 2 and agg.ten_q_in_18m >= 4:
+        return 'analysable'
+
+    return 'insufficient'
+```
+
+**Why amendments don't count toward the bar:** `10-K/A` / `10-Q/A` are restatements of already-filed periods. Two `10-K`s = two years of annual history. One `10-K` plus one `10-K/A` = still one year, restated. The analysability bar measures history depth, not filing volume. Amendments still populate `filing_events`, still trigger event-driven thesis refresh (Chunk I), and still register in the audit aggregate — they just don't satisfy `ten_k_in_3y >= 2`.
+
+**Windowing is exact via SQL `FILTER`:** no `timedelta(days=N)` drift. `INTERVAL '18 months'` is calendar-correct across month-length variance.
+
+### Bulk UPDATE
+
+Use `UPDATE ... FROM unnest(%s::bigint[], %s::text[])` — native psycopg3 array adaptation, no psycopg2-era helpers. `psycopg.extras` does not exist in psycopg3; `execute_values` is psycopg2-only.
+
+```sql
+UPDATE coverage c
+SET filings_status = v.status,
+    filings_audit_at = NOW()
+FROM unnest(%s::bigint[], %s::text[]) AS v(instrument_id, status)
+WHERE c.instrument_id = v.instrument_id;
+```
+
+Python call:
+
+```python
+if not classifications:  # empty-cohort guard
+    return AuditSummary(...)  # nothing to update
+
+instrument_ids = [row[0] for row in classifications]
+statuses = [row[1] for row in classifications]
+conn.execute(sql, (instrument_ids, statuses))
+```
+
+psycopg3 adapts `list[int]` → `bigint[]` and `list[str]` → `text[]` automatically. One roundtrip. Empty-cohort case must short-circuit before the execute — `unnest('{}'::bigint[], '{}'::text[])` is legal but an early return is clearer.
+
+### AuditSummary
+
+```python
+@dataclass(frozen=True)
+class AuditSummary:
+    analysable: int
+    insufficient: int
+    fpi: int
+    no_primary_sec_cik: int
+    total_updated: int
+    null_anomalies: int  # Count from the following post-update query:
+                         #   SELECT COUNT(*) FROM instruments i
+                         #   LEFT JOIN coverage c USING (instrument_id)
+                         #   WHERE i.is_tradable = TRUE
+                         #     AND (c.instrument_id IS NULL
+                         #          OR c.filings_status IS NULL);
+                         # Captures both: tradable instruments with no
+                         # coverage row at all (Chunk B regression)
+                         # AND coverage rows whose filings_status
+                         # remained NULL (bulk UPDATE missed them,
+                         # e.g. classification path had a gap). Either
+                         # is a data-integrity bug; logged at WARNING.
+```
+
+`unknown` is NOT a classifier output. The classifier in `_classify` returns one of `{analysable, insufficient, fpi, no_primary_sec_cik}` only. `unknown` is a pre-audit placeholder value for rows created by Chunk G (universe-sync hook marks new instruments `'unknown'` so the weekly audit picks them up). Once `audit_all_instruments` has processed a row, its `filings_status` is always one of the four classifier outputs — never `'unknown'` or `NULL`. `null_anomalies > 0` indicates either a tradable instrument without a `coverage` row (Chunk B regression) OR a coverage row whose `filings_status` remained NULL after the bulk UPDATE (classifier gap). Either case is logged at WARNING.
+
+## Edge cases
+
+| Condition | Behaviour |
+|---|---|
+| Tradable instrument with no `coverage` row | Cannot happen post-#292. Audit ignores; `total_updated` reflects only matched rows. Logs a warning if the cohort size > update count. |
+| Instrument with `coverage` row but no `filing_events` | Classified per cohort rule: has_sec_cik → `insufficient`; no CIK → `no_primary_sec_cik`. |
+| `filing_events` rows with `filing_type = 'unknown'` (legacy from migration 004) | Not in the aggregate's form-type filter; silently ignored. |
+| Zero-filing instrument with SEC CIK | `insufficient` (might be a truly-young company — Chunk E upgrades to `structurally_young` if SEC confirms no historical filings exist either). |
+| Running audit twice in quick succession | Idempotent; second run is a no-op at the aggregate level, `filings_audit_at` refreshes to NOW(). |
+| Transaction scope | Entire audit body wrapped in `with conn.transaction():` so partial failures roll back. |
+
+## Non-scope / explicit deferrals
+
+- **`structurally_young`**: audit never assigns this. Chunk E's backfill service sets it when SEC's own historical submissions.json confirms the issuer has < N total filings ever.
+- **8-K gap detection**: Chunk E's job. DB-internal count is insufficient; requires comparing DB rows vs SEC's 12-month accession list.
+- **Re-classifying instruments to a higher tier on new filings**: audit is a full recompute each run; always reflects current DB state.
+- **Companies House analysability bar**: #279.
+
+## Testing
+
+### Unit tests (`tests/test_coverage_audit.py` — mock-based)
+
+- Classification rules (pure-function `_classify`):
+  - No SEC CIK → `no_primary_sec_cik`.
+  - Has SEC CIK + 2 × 10-K (recent) + 4 × 10-Q (recent) → `analysable`.
+  - Has SEC CIK + 1 × 10-K + 4 × 10-Q → `insufficient`.
+  - Has SEC CIK + 2 × 10-K + 3 × 10-Q → `insufficient`.
+  - Has SEC CIK + 0 × 10-K + 0 × 10-Q + 1 × 20-F → `fpi`.
+  - Has SEC CIK + 0 × 10-K + 0 × 10-Q + 1 × 6-K/A → `fpi`.
+  - Has SEC CIK + 1 × 10-K + 1 × 20-F → `insufficient` (mixed; not FPI).
+  - **Amendments do NOT count toward base-form thresholds.** `1 × 10-K + 1 × 10-K/A + 4 × 10-Q` → `insufficient` (amendment restates the same year; does not add distinct annual history). `1 × 10-Q + 3 × 10-Q/A + 2 × 10-K` → `insufficient` (one actual 10-Q period, not four).
+
+### Integration tests (`tests/test_coverage_audit_integration.py` — real `ebull_test` DB)
+
+- Full `audit_all_instruments` against seeded cohort with mixed instruments → verifies counts + per-instrument status + `filings_audit_at` advances.
+- Idempotent: second run returns same counts, no row status changes.
+- Single-instrument `audit_instrument`: returns the classified status + updates the row atomically.
+
+### Pre-push gates
+
+- `uv run ruff check .` + `ruff format --check`
+- `uv run pyright`
+- `uv run pytest`
+
+## Expected impact
+
+| Metric | Before | After |
+|---|---|---|
+| `coverage.filings_status` column exists | No | Yes |
+| Every tradable instrument has an explicit filings_status (after first audit) | No | Yes (except for pre-first-audit NULLs) |
+| Ability to write "only run X on analysable" queries | No | Yes |
+| 8-K gap detection | No | No (Chunk E) |
+| Historical backfill of missing filings | No | No (Chunk E) |
+
+## Settled decisions preserved
+
+- **Filing lookup rule**: SEC uses CIK, not symbol. Audit queries use `identifier_type = 'cik'`.
+- **External identifiers `is_primary = TRUE`** enforced at every query — no `is_primary = FALSE` rows counted.
+- **Fundamentals coverage semantics** unchanged — this adds a parallel filings gate.
+
+## What this spec makes explicit
+
+- `structurally_young` is a post-backfill-only status; Chunk D never assigns it.
+- `filings_status = NULL` is pre-first-audit only; post-audit NULL is an error.
+- 10-Q recency window is 18 months, 10-K is 3 years; limitation on windowed aggregate documented.
+- FPI detection requires zero base forms + at least one FPI form (base OR amendment).
+- `fe.provider = 'sec'` + `ei.is_primary = TRUE` mandatory in every audit query.
+- Single bulk UPDATE via `unnest(bigint[], text[])` — psycopg3-native, no N+1.
+- Transaction atomicity: full audit wraps one `with conn.transaction():`.

--- a/sql/036_coverage_filings_status.sql
+++ b/sql/036_coverage_filings_status.sql
@@ -1,0 +1,33 @@
+-- Migration 036: coverage.filings_status + audit/backfill tracking columns.
+--
+-- Adds the gate column that downstream thesis / scoring / cascade work
+-- (#273, #276) consults via "filings_status = 'analysable'". Classifier
+-- values are populated by app.services.coverage_audit.audit_all_instruments
+-- (Chunk D); backfill-tracking columns are consumed by Chunk E.
+--
+-- NULL filings_status is a pre-audit placeholder. Post-first-audit,
+-- every tradable instrument's coverage row MUST have one of the six
+-- CHECK values. null_anomalies counter in AuditSummary surfaces any
+-- regression.
+
+ALTER TABLE coverage
+    ADD COLUMN IF NOT EXISTS filings_status TEXT
+    CHECK (
+        filings_status IS NULL
+        OR filings_status IN (
+            'analysable',
+            'insufficient',
+            'fpi',
+            'no_primary_sec_cik',
+            'structurally_young',
+            'unknown'
+        )
+    );
+
+ALTER TABLE coverage ADD COLUMN IF NOT EXISTS filings_audit_at TIMESTAMPTZ;
+
+ALTER TABLE coverage ADD COLUMN IF NOT EXISTS filings_backfill_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE coverage ADD COLUMN IF NOT EXISTS filings_backfill_last_at TIMESTAMPTZ;
+ALTER TABLE coverage ADD COLUMN IF NOT EXISTS filings_backfill_reason TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_coverage_filings_status ON coverage(filings_status);

--- a/tests/test_coverage_audit.py
+++ b/tests/test_coverage_audit.py
@@ -1,0 +1,158 @@
+"""Unit tests for app.services.coverage_audit.
+
+Pure-function tests for the classifier use no DB. Integration tests
+against ``ebull_test`` live in a separate file.
+"""
+
+from __future__ import annotations
+
+from app.services.coverage_audit import AuditCounts, _classify
+
+
+def _counts(
+    *,
+    ten_k_in_3y: int = 0,
+    ten_q_in_18m: int = 0,
+    us_base_or_amend_total: int = 0,
+    fpi_total: int = 0,
+) -> AuditCounts:
+    return AuditCounts(
+        instrument_id=1,
+        ten_k_in_3y=ten_k_in_3y,
+        ten_q_in_18m=ten_q_in_18m,
+        us_base_or_amend_total=us_base_or_amend_total,
+        fpi_total=fpi_total,
+    )
+
+
+class TestClassify:
+    """Classifier branch coverage."""
+
+    def test_no_sec_cik_returns_no_primary_sec_cik(self) -> None:
+        assert _classify(None, has_sec_cik=False) == "no_primary_sec_cik"
+
+    def test_no_sec_cik_ignores_agg(self) -> None:
+        # Shouldn't happen in practice (agg is None when no SEC filings)
+        # but the classifier must be robust to being handed counts anyway.
+        agg = _counts(ten_k_in_3y=5, ten_q_in_18m=10, us_base_or_amend_total=15)
+        assert _classify(agg, has_sec_cik=False) == "no_primary_sec_cik"
+
+    def test_sec_cik_no_filings_returns_insufficient(self) -> None:
+        # SEC CIK present but filing_events empty — pre-backfill state.
+        assert _classify(None, has_sec_cik=True) == "insufficient"
+
+    def test_us_issuer_with_full_history_is_analysable(self) -> None:
+        agg = _counts(
+            ten_k_in_3y=2,
+            ten_q_in_18m=4,
+            us_base_or_amend_total=6,
+        )
+        assert _classify(agg, has_sec_cik=True) == "analysable"
+
+    def test_us_issuer_extra_history_is_analysable(self) -> None:
+        # More than minimum is still analysable.
+        agg = _counts(
+            ten_k_in_3y=3,
+            ten_q_in_18m=12,
+            us_base_or_amend_total=15,
+        )
+        assert _classify(agg, has_sec_cik=True) == "analysable"
+
+    def test_exactly_at_threshold_is_analysable(self) -> None:
+        # 2 and 4 are the minimums — boundary inclusive.
+        agg = _counts(
+            ten_k_in_3y=2,
+            ten_q_in_18m=4,
+            us_base_or_amend_total=6,
+        )
+        assert _classify(agg, has_sec_cik=True) == "analysable"
+
+    def test_one_below_10k_threshold_is_insufficient(self) -> None:
+        agg = _counts(
+            ten_k_in_3y=1,
+            ten_q_in_18m=4,
+            us_base_or_amend_total=5,
+        )
+        assert _classify(agg, has_sec_cik=True) == "insufficient"
+
+    def test_one_below_10q_threshold_is_insufficient(self) -> None:
+        agg = _counts(
+            ten_k_in_3y=2,
+            ten_q_in_18m=3,
+            us_base_or_amend_total=5,
+        )
+        assert _classify(agg, has_sec_cik=True) == "insufficient"
+
+    def test_fpi_has_20f_zero_us_is_fpi(self) -> None:
+        # Has SEC CIK, zero US base-or-amend, at least one 20-F.
+        agg = _counts(
+            ten_k_in_3y=0,
+            ten_q_in_18m=0,
+            us_base_or_amend_total=0,
+            fpi_total=2,  # 2 × 20-F
+        )
+        assert _classify(agg, has_sec_cik=True) == "fpi"
+
+    def test_fpi_with_6ka_amendment_only_is_fpi(self) -> None:
+        agg = _counts(us_base_or_amend_total=0, fpi_total=1)  # single 6-K/A
+        assert _classify(agg, has_sec_cik=True) == "fpi"
+
+    def test_mixed_us_and_fpi_forms_is_insufficient_not_fpi(self) -> None:
+        # One 10-K + one 20-F → not an FPI (has US base form) and
+        # doesn't meet the US bar either.
+        agg = _counts(
+            ten_k_in_3y=1,
+            us_base_or_amend_total=1,
+            fpi_total=1,
+        )
+        assert _classify(agg, has_sec_cik=True) == "insufficient"
+
+    def test_sec_cik_with_only_8k_family_is_insufficient(self) -> None:
+        # No US base forms, no FPI forms, only 8-K-ish — insufficient.
+        agg = _counts(
+            ten_k_in_3y=0,
+            ten_q_in_18m=0,
+            us_base_or_amend_total=0,
+            fpi_total=0,
+        )
+        assert _classify(agg, has_sec_cik=True) == "insufficient"
+
+
+class TestAmendmentsDoNotCountTowardBar:
+    """Regression guard for the deliberate design decision that
+    amendments re-state an existing period and therefore do NOT
+    satisfy the history-depth bar.
+
+    Amendments still populate filing_events, still trigger
+    event-driven thesis refresh (Chunk I), and still register in
+    ``us_base_or_amend_total`` for FPI detection — they just don't
+    satisfy ``ten_k_in_3y >= 2`` or ``ten_q_in_18m >= 4``.
+
+    The SQL aggregate filters on exact ``filing_type = '10-K'`` and
+    ``'10-Q'`` (no amendments) for the window counters, so the
+    AuditCounts values landing in the classifier already exclude
+    amendments from those counts. The tests below exercise the
+    AGGREGATE'S contract (what the SQL produces), not the classifier,
+    because the classifier can't tell base from amendment from its
+    inputs alone.
+    """
+
+    def test_1_10k_plus_1_10ka_does_not_satisfy_2_10k(self) -> None:
+        # SQL aggregate would produce ten_k_in_3y=1 (base only).
+        # us_base_or_amend_total=2 (base + amend). Classifier sees
+        # ten_k_in_3y=1 → insufficient.
+        agg = _counts(
+            ten_k_in_3y=1,  # only the base 10-K, amendment excluded
+            ten_q_in_18m=4,
+            us_base_or_amend_total=6,  # 1 × 10-K + 1 × 10-K/A + 4 × 10-Q
+        )
+        assert _classify(agg, has_sec_cik=True) == "insufficient"
+
+    def test_1_10q_plus_3_10qa_does_not_satisfy_4_10q(self) -> None:
+        # Only one actual 10-Q period filed — amendments re-state it.
+        agg = _counts(
+            ten_k_in_3y=2,
+            ten_q_in_18m=1,  # base only
+            us_base_or_amend_total=6,  # 2 × 10-K + 1 × 10-Q + 3 × 10-Q/A
+        )
+        assert _classify(agg, has_sec_cik=True) == "insufficient"

--- a/tests/test_coverage_audit_integration.py
+++ b/tests/test_coverage_audit_integration.py
@@ -1,0 +1,338 @@
+"""Integration tests for coverage_audit against real ebull_test DB.
+
+Verifies the SQL aggregate's window filtering + bulk UPDATE landing
+correctly per instrument.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import psycopg
+import pytest
+
+from app.services.coverage_audit import (
+    audit_all_instruments,
+    audit_instrument,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test DB unavailable",
+)
+
+
+def _seed_instrument(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    symbol: str,
+    cik: str | None = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES (%s, %s, %s, TRUE)",
+        (instrument_id, symbol, symbol),
+    )
+    conn.execute(
+        "INSERT INTO coverage (instrument_id, coverage_tier) VALUES (%s, 3)",
+        (instrument_id,),
+    )
+    if cik is not None:
+        conn.execute(
+            "INSERT INTO external_identifiers "
+            "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+            "VALUES (%s, 'sec', 'cik', %s, TRUE)",
+            (instrument_id, cik),
+        )
+    conn.commit()
+
+
+def _seed_filing(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    filing_date: date,
+    filing_type: str,
+    accession: str,
+    provider: str = "sec",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO filing_events (
+            instrument_id, filing_date, filing_type,
+            provider, provider_filing_id
+        ) VALUES (%s, %s, %s, %s, %s)
+        """,
+        (instrument_id, filing_date, filing_type, provider, accession),
+    )
+    conn.commit()
+
+
+def test_analysable_us_issuer_with_full_history(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """US issuer with 2 × 10-K in 3y + 4 × 10-Q in 18mo → analysable."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL", cik="0000320193")
+    today = date.today()
+    # 2 × 10-K in past 3 years
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=400),
+        filing_type="10-K",
+        accession="0000320193-25-000001",
+    )
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=765),
+        filing_type="10-K",
+        accession="0000320193-24-000001",
+    )
+    # 4 × 10-Q in past 18 months
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=30),
+        filing_type="10-Q",
+        accession="0000320193-26-000001",
+    )
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=120),
+        filing_type="10-Q",
+        accession="0000320193-26-000002",
+    )
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=210),
+        filing_type="10-Q",
+        accession="0000320193-26-000003",
+    )
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=300),
+        filing_type="10-Q",
+        accession="0000320193-25-000042",
+    )
+
+    summary = audit_all_instruments(ebull_test_conn)
+
+    assert summary.analysable == 1
+    assert summary.total_updated == 1
+
+    row = ebull_test_conn.execute(
+        "SELECT filings_status, filings_audit_at FROM coverage WHERE instrument_id = 1"
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "analysable"
+    assert row[1] is not None
+
+
+def test_insufficient_below_bar(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """US issuer below the bar (1 × 10-K, 3 × 10-Q) → insufficient."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="TEST", cik="0000000001")
+    today = date.today()
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=100),
+        filing_type="10-K",
+        accession="0000000001-26-000001",
+    )
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=30),
+        filing_type="10-Q",
+        accession="0000000001-26-000002",
+    )
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=120),
+        filing_type="10-Q",
+        accession="0000000001-26-000003",
+    )
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=210),
+        filing_type="10-Q",
+        accession="0000000001-26-000004",
+    )
+
+    summary = audit_all_instruments(ebull_test_conn)
+
+    assert summary.insufficient == 1
+    row = ebull_test_conn.execute("SELECT filings_status FROM coverage WHERE instrument_id = 1").fetchone()
+    assert row is not None and row[0] == "insufficient"
+
+
+def test_fpi_with_20f_only(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """SEC CIK + 1 × 20-F + zero 10-K/10-Q → fpi."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="FPI1", cik="0001234567")
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today() - timedelta(days=60),
+        filing_type="20-F",
+        accession="0001234567-26-000001",
+    )
+
+    summary = audit_all_instruments(ebull_test_conn)
+
+    assert summary.fpi == 1
+    row = ebull_test_conn.execute("SELECT filings_status FROM coverage WHERE instrument_id = 1").fetchone()
+    assert row is not None and row[0] == "fpi"
+
+
+def test_no_primary_sec_cik(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Tradable instrument with no primary SEC CIK → no_primary_sec_cik."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="UK01")  # no cik
+
+    summary = audit_all_instruments(ebull_test_conn)
+
+    assert summary.no_primary_sec_cik == 1
+    row = ebull_test_conn.execute("SELECT filings_status FROM coverage WHERE instrument_id = 1").fetchone()
+    assert row is not None and row[0] == "no_primary_sec_cik"
+
+
+def test_amendments_do_not_count_toward_bar(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """1 × 10-K + 1 × 10-K/A + 4 × 10-Q → insufficient (amendment
+    restates same year, not a distinct second annual period)."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="TEST", cik="0000000002")
+    today = date.today()
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=400),
+        filing_type="10-K",
+        accession="0000000002-26-000001",
+    )
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=350),
+        filing_type="10-K/A",
+        accession="0000000002-26-000002",
+    )
+    for i, offset in enumerate([30, 120, 210, 300], start=3):
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=1,
+            filing_date=today - timedelta(days=offset),
+            filing_type="10-Q",
+            accession=f"0000000002-26-00000{i}",
+        )
+
+    summary = audit_all_instruments(ebull_test_conn)
+
+    assert summary.insufficient == 1
+    row = ebull_test_conn.execute("SELECT filings_status FROM coverage WHERE instrument_id = 1").fetchone()
+    assert row is not None and row[0] == "insufficient"
+
+
+def test_filings_provider_filter_excludes_companies_house(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Companies House filings for a SEC-CIK instrument must NOT count
+    toward the SEC bar."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="DUAL", cik="0000000003")
+    today = date.today()
+    # CH filings would match on filing_type label but MUST NOT count.
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=30),
+        filing_type="10-K",
+        accession="CH-26-000001",
+        provider="companies_house",
+    )
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=120),
+        filing_type="10-K",
+        accession="CH-26-000002",
+        provider="companies_house",
+    )
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=today - timedelta(days=210),
+        filing_type="10-Q",
+        accession="CH-26-000003",
+        provider="companies_house",
+    )
+
+    summary = audit_all_instruments(ebull_test_conn)
+
+    # Zero SEC filings despite 3 CH rows → insufficient, not analysable.
+    assert summary.insufficient == 1
+    assert summary.analysable == 0
+
+
+def test_idempotent_rerun(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Running the audit twice produces the same counts and same final status."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="UK02")
+
+    first = audit_all_instruments(ebull_test_conn)
+    second = audit_all_instruments(ebull_test_conn)
+
+    assert first.no_primary_sec_cik == 1
+    assert second.no_primary_sec_cik == 1
+    assert first.total_updated == second.total_updated
+
+
+def test_single_instrument_audit(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """audit_instrument classifies one instrument and updates its row."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="FPI", cik="0009999999")
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today() - timedelta(days=90),
+        filing_type="40-F",
+        accession="0009999999-26-000001",
+    )
+
+    status = audit_instrument(ebull_test_conn, instrument_id=1)
+
+    assert status == "fpi"
+    row = ebull_test_conn.execute("SELECT filings_status FROM coverage WHERE instrument_id = 1").fetchone()
+    assert row is not None and row[0] == "fpi"
+
+
+def test_null_anomaly_detected(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A tradable instrument without a coverage row triggers null_anomalies."""
+    # Instrument exists + is tradable but NO coverage row.
+    ebull_test_conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (1, 'ORPHAN', 'ORPHAN', TRUE)"
+    )
+    ebull_test_conn.commit()
+
+    summary = audit_all_instruments(ebull_test_conn)
+
+    assert summary.null_anomalies >= 1

--- a/tests/test_coverage_audit_integration.py
+++ b/tests/test_coverage_audit_integration.py
@@ -86,10 +86,13 @@ def test_analysable_us_issuer_with_full_history(
         filing_type="10-K",
         accession="0000320193-25-000001",
     )
+    # Second 10-K at days=700: well inside the 3-year window
+    # (1095 days) with ~12 months of safety margin so the test
+    # doesn't become a calendar-drift time-bomb a year from now.
     _seed_filing(
         ebull_test_conn,
         instrument_id=1,
-        filing_date=today - timedelta(days=765),
+        filing_date=today - timedelta(days=700),
         filing_type="10-K",
         accession="0000320193-24-000001",
     )
@@ -336,3 +339,19 @@ def test_null_anomaly_detected(
     summary = audit_all_instruments(ebull_test_conn)
 
     assert summary.null_anomalies >= 1
+
+
+def test_audit_instrument_raises_on_missing_coverage_row(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Single-instrument audit must NOT silently succeed when the
+    coverage row is missing (a Chunk B regression). Raising loudly
+    beats returning a status string that was never persisted."""
+    # Instrument exists + tradable but NO coverage row.
+    ebull_test_conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES (42, 'NOCOV', 'NOCOV', TRUE)"
+    )
+    ebull_test_conn.commit()
+
+    with pytest.raises(RuntimeError, match="no coverage row"):
+        audit_instrument(ebull_test_conn, instrument_id=42)


### PR DESCRIPTION
## What
Chunk D of the filings-cascade master plan (#294). Ships the \`coverage.filings_status\` gate column + \`coverage_audit.audit_all_instruments\` that classifies every tradable instrument. Downstream thesis / scoring / cascade work (#273, #276) will consult \`filings_status = 'analysable'\`.

## Why
Issue #268. Spec: [docs/superpowers/specs/2026-04-17-filings-status-schema-design.md](docs/superpowers/specs/2026-04-17-filings-status-schema-design.md) (Codex-approved v3).

## Scope
- Migration 036: \`filings_status\` column (6 CHECK values) + retry-tracking columns for Chunk E.
- Service \`coverage_audit.py\`: \`audit_all_instruments\` + \`audit_instrument\`.
- Four classifier outputs only: \`analysable\`, \`insufficient\`, \`fpi\`, \`no_primary_sec_cik\`. \`structurally_young\` and \`unknown\` deliberately deferred to Chunks E and G.
- SQL FILTER-based window counting (10-K 3y, 10-Q 18mo); amendments NOT counted toward bar; \`fe.provider='sec'\` + \`ei.is_primary=TRUE\` filters enforced.
- psycopg3-native \`UPDATE ... FROM unnest(bigint[], text[])\` bulk update.
- \`null_anomalies\` counter catches missing coverage rows + NULL statuses.

## Test plan
- [x] 14 pure-function classifier branch tests (all four outputs + amendments-excluded regression).
- [x] 9 real-\`ebull_test\` integration tests covering analysable, insufficient, fpi, no-CIK, amendments, CH-provider isolation, idempotent rerun, single-instrument audit, null anomaly.
- [x] Full suite: 1817 passed.
- [x] ruff check + format + pyright clean.
- [x] Codex review: 3 rounds, 11 findings addressed; final APPROVE. Final-diff review clean.

## Not in scope (other chunks)
- Chunk E historical backfill + \`structurally_young\` assignment.
- Chunk F weekly scheduler job.
- Chunk G universe-sync hook.
- Chunk H admin UI.
- Chunk J scoring + consumer gating.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>