### PR TITLE
feat(#268): universe-sync marks new coverage rows filings_status='unknown' (Chunk G)

### DIFF
--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -771,6 +771,14 @@ def bootstrap_missing_coverage_rows(
     every tradable instrument has a coverage row going into the
     downstream audit / thesis / scoring passes.
 
+    New rows land with ``filings_status = 'unknown'`` (#268 Chunk G)
+    so the weekly coverage audit (Chunk F) picks them up on its next
+    run and classifies them into one of the four terminal outputs.
+    Without this, the audit would leave them as NULL
+    filings_status and the ``null_anomalies`` counter would flag
+    every new instrument as a data-integrity warning until the audit
+    could catch up.
+
     Opens its own ``conn.transaction()`` (savepoint when nested) so
     the INSERT is atomic. ``ON CONFLICT DO NOTHING`` is defence-in-
     depth; the ``NOT EXISTS`` predicate already guarantees no
@@ -779,8 +787,8 @@ def bootstrap_missing_coverage_rows(
     with conn.transaction():
         result = conn.execute(
             """
-            INSERT INTO coverage (instrument_id, coverage_tier)
-            SELECT i.instrument_id, 3
+            INSERT INTO coverage (instrument_id, coverage_tier, filings_status)
+            SELECT i.instrument_id, 3, 'unknown'
             FROM instruments i
             WHERE i.is_tradable = TRUE
               AND NOT EXISTS (

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1040,10 +1040,21 @@ class TestBootstrapMissingCoverageRows:
         conn = self._mock_conn(inserted_rows=2)
         bootstrap_missing_coverage_rows(conn)
         sql = conn.execute.call_args[0][0]
-        # Both the column list and the SELECT projection must carry
-        # the unknown sentinel literally.
-        assert "filings_status" in sql
-        assert "'unknown'" in sql
+        # Assert column + literal pair positionally: the INSERT
+        # column list must include filings_status AND the SELECT
+        # projection must end with 'unknown' as its last element.
+        # Checking independent substring presence would accept a
+        # SQL body that placed 'unknown' in an unrelated clause.
+        import re
+
+        assert re.search(
+            r"INSERT INTO coverage \(instrument_id,\s*coverage_tier,\s*filings_status\)",
+            sql,
+        ), "filings_status must appear in the INSERT column list"
+        assert re.search(
+            r"SELECT i\.instrument_id,\s*3,\s*'unknown'",
+            sql,
+        ), "'unknown' literal must be the third SELECT projection value"
 
     def test_noop_when_no_gaps(self) -> None:
         """Every tradable instrument already has coverage → zero inserts."""

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1030,6 +1030,21 @@ class TestBootstrapMissingCoverageRows:
         assert "NOT EXISTS" in sql
         assert "is_tradable = TRUE" in sql
 
+    def test_new_rows_marked_filings_status_unknown(self) -> None:
+        """#268 Chunk G: rows inserted by the post-bootstrap gap filler
+        must be marked filings_status='unknown' so the weekly audit
+        picks them up without the null_anomalies counter flagging them
+        as data-integrity warnings."""
+        from app.services.coverage import bootstrap_missing_coverage_rows
+
+        conn = self._mock_conn(inserted_rows=2)
+        bootstrap_missing_coverage_rows(conn)
+        sql = conn.execute.call_args[0][0]
+        # Both the column list and the SELECT projection must carry
+        # the unknown sentinel literally.
+        assert "filings_status" in sql
+        assert "'unknown'" in sql
+
     def test_noop_when_no_gaps(self) -> None:
         """Every tradable instrument already has coverage → zero inserts."""
         from app.services.coverage import bootstrap_missing_coverage_rows


### PR DESCRIPTION
## What
Chunk G of the filings-cascade master plan. \`bootstrap_missing_coverage_rows\` INSERTs now write \`filings_status='unknown'\` so the weekly coverage audit (Chunk F, pending) picks up newly-added instruments on its next run rather than leaving them as NULL.

## Why
Without the sentinel, new instruments sit at \`filings_status = NULL\` between universe-sync and the next weekly audit run. The \`null_anomalies\` counter added in Chunk D would flag every newly-added tradable instrument as a data-integrity warning — noise, not signal.

## Test plan
- [x] New \`test_new_rows_marked_filings_status_unknown\` asserts SQL literal.
- [x] 5/5 TestBootstrapMissingCoverageRows tests pass.
- [x] Full suite: 1819 passed.
- [x] Codex review: no blockers.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>