### PR TITLE
feat(#273): thesis event-driven refresh trigger (Chunk I)

### DIFF
--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -32,12 +32,14 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
 import anthropic
 import psycopg
+from psycopg import sql as psql
 from psycopg.types.json import Jsonb
 
 logger = logging.getLogger(__name__)
@@ -48,7 +50,14 @@ logger = logging.getLogger(__name__)
 
 ThesisType = Literal["compounder", "value", "turnaround", "speculative"]
 Stance = Literal["buy", "hold", "watch", "avoid"]
-StaleReason = Literal["no_thesis", "stale", "missing_frequency"]
+StaleReason = Literal[
+    "no_thesis",
+    "stale",
+    "missing_frequency",
+    "event_new_10k",
+    "event_new_10q",
+    "event_new_8k",
+]
 
 _VALID_THESIS_TYPES: frozenset[str] = frozenset({"compounder", "value", "turnaround", "speculative"})
 _VALID_STANCES: frozenset[str] = frozenset({"buy", "hold", "watch", "avoid"})
@@ -142,34 +151,110 @@ def _to_float(val: object) -> float | None:
 
 def find_stale_instruments(
     conn: psycopg.Connection[Any],
-    tier: int = 1,
+    tier: int | None = 1,
+    *,
+    instrument_ids: Sequence[int] | None = None,
 ) -> list[StaleInstrument]:
     """
-    Return instruments whose most recent thesis is absent or older than
-    their coverage.review_frequency allows.
+    Return instruments whose most recent thesis is absent, older than
+    their coverage.review_frequency allows, or superseded by a new
+    10-K / 10-Q / 8-K filing (#273 event-driven trigger).
 
-    Stale rules (evaluated in order):
+    Stale rules (evaluated in order per instrument):
       1. No thesis row exists → stale (reason: "no_thesis")
       2. review_frequency missing / unrecognised → stale (reason: "missing_frequency")
-      3. now >= latest_thesis.created_at + interval(review_frequency) → stale (reason: "stale")
+      3. filing_events row newer than latest thesis, filing_type in
+         ('10-K', '10-K/A', '10-Q', '10-Q/A', '8-K', '8-K/A') → stale
+         (reason: "event_new_{10k,10q,8k}")
+      4. now >= latest_thesis.created_at + interval(review_frequency) → stale (reason: "stale")
+
+    Every returned instrument must have ``coverage.filings_status =
+    'analysable'`` (#268 Chunk J gate). Non-analysable instruments are
+    silently excluded — thesis generation on them is wasted Claude
+    spend.
+
+    Parameters
+    ----------
+    tier
+        Coverage tier filter. Pass ``None`` to bypass tier filtering
+        entirely — typically used by the cascade (#276) in
+        combination with ``instrument_ids`` to scope to a specific
+        subset across any tier.
+    instrument_ids
+        When provided, restrict the scan to these instruments. Used by
+        the cascade to check "did the CIKs that just had filings need
+        a thesis refresh". Does not bypass the filings_status gate.
     """
-    rows = conn.execute(
-        """
+    params: dict[str, Any] = {}
+    where_clauses = [
+        "i.is_tradable = TRUE",
+        "c.filings_status = 'analysable'",
+    ]
+    if tier is not None:
+        where_clauses.append("c.coverage_tier = %(tier)s")
+        params["tier"] = tier
+    if instrument_ids is not None:
+        where_clauses.append("i.instrument_id = ANY(%(ids)s)")
+        params["ids"] = list(instrument_ids)
+
+    where_sql_str = " AND ".join(where_clauses)
+
+    # Build query as psql.SQL so pyright is happy with the strict
+    # Query type; the ``where_sql_str`` is assembled from hardcoded
+    # fragments only (no user input) so adapting it as a bare SQL
+    # literal is safe.
+    query = (
+        psql.SQL(
+            """
         SELECT
             i.instrument_id,
             i.symbol,
             c.review_frequency,
-            MAX(t.created_at) AS latest_thesis_at
+            MAX(t.created_at)                        AS latest_thesis_at,
+            -- Latest qualifying-filing created_at timestamp. Use
+            -- ``created_at`` (ingest time) not ``filing_date`` so:
+            -- (a) a filing ingested AFTER the thesis on the same
+            --     calendar day triggers a refresh,
+            -- (b) a backfilled filing with an old filing_date but a
+            --     recent created_at also triggers (thesis generated
+            --     before the backfill could not have incorporated it).
+            MAX(fe.created_at) FILTER (
+                WHERE fe.filing_type IN (
+                    '10-K','10-K/A','10-Q','10-Q/A','8-K','8-K/A'
+                )
+            )                                        AS latest_event_created_at,
+            -- Form type of the filing with the max created_at. The
+            -- subquery orders by the same column so the two aggregates
+            -- identify the same row even for same-second multi-insert.
+            (
+                SELECT fe2.filing_type
+                FROM filing_events fe2
+                WHERE fe2.instrument_id = i.instrument_id
+                  AND fe2.filing_type IN (
+                      '10-K','10-K/A','10-Q','10-Q/A','8-K','8-K/A'
+                  )
+                ORDER BY fe2.created_at DESC, fe2.filing_event_id DESC
+                LIMIT 1
+            )                                        AS latest_event_filing_type
         FROM instruments i
         JOIN coverage c ON c.instrument_id = i.instrument_id
         LEFT JOIN theses t ON t.instrument_id = i.instrument_id
-        WHERE i.is_tradable = TRUE
-          AND c.coverage_tier = %(tier)s
+        LEFT JOIN filing_events fe ON fe.instrument_id = i.instrument_id
+        WHERE """
+        )
+        # where_sql_str is assembled from hardcoded fragments above —
+        # safe to adapt as a SQL literal. Pyright's LiteralString
+        # tightening can't see the provenance; ignore here rather
+        # than restructure the branching logic.
+        + psql.SQL(where_sql_str)  # pyright: ignore[reportArgumentType]
+        + psql.SQL(
+            """
         GROUP BY i.instrument_id, i.symbol, c.review_frequency
         ORDER BY i.symbol
-        """,
-        {"tier": tier},
-    ).fetchall()
+        """
+        )
+    )
+    rows = conn.execute(query, params).fetchall()
 
     now = _utcnow()
     stale: list[StaleInstrument] = []
@@ -179,6 +264,8 @@ def find_stale_instruments(
         symbol: str = row[1]
         review_frequency: str | None = row[2]
         latest_thesis_at: datetime | None = row[3]
+        latest_event_created_at: datetime | None = row[4]
+        latest_event_filing_type: str | None = row[5]
 
         if latest_thesis_at is None:
             stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="no_thesis"))
@@ -188,11 +275,38 @@ def find_stale_instruments(
             stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="missing_frequency"))
             continue
 
+        # Event-driven refresh: any qualifying filing INGESTED
+        # (``filing_events.created_at``) after the thesis was generated
+        # triggers a fresh run regardless of the time-based cadence
+        # window. Timestamp comparison (not date) so same-day
+        # post-thesis filings still fire. Using created_at instead of
+        # filing_date also catches backfilled filings whose reported
+        # filing_date predates the thesis — the thesis couldn't have
+        # seen them, so the refresh is warranted.
+        if (
+            latest_event_created_at is not None
+            and latest_event_filing_type is not None
+            and latest_event_created_at > latest_thesis_at
+        ):
+            reason = _event_reason_for_form(latest_event_filing_type)
+            stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason=reason))
+            continue
+
         threshold = latest_thesis_at + timedelta(days=_REVIEW_FREQUENCY_DAYS[review_frequency])
         if now >= threshold:
             stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="stale"))
 
     return stale
+
+
+def _event_reason_for_form(form_type: str) -> StaleReason:
+    """Map a filing_type to its corresponding event_* StaleReason."""
+    base = form_type.split("/", 1)[0]  # strip /A suffix
+    if base == "10-K":
+        return "event_new_10k"
+    if base == "10-Q":
+        return "event_new_10q"
+    return "event_new_8k"  # 8-K, 8-K/A
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -197,12 +197,22 @@ def find_stale_instruments(
         where_clauses.append("i.instrument_id = ANY(%(ids)s)")
         params["ids"] = list(instrument_ids)
 
-    where_sql_str = " AND ".join(where_clauses)
+    # Build WHERE via structural psql.SQL composition (each clause is
+    # a literal fragment from the list above — no user input channel).
+    # Avoids ad-hoc string concatenation so a future caller that adds
+    # a user-derived clause cannot regress into injection.
+    where_block = psql.SQL(" AND ").join(
+        psql.SQL(clause)  # pyright: ignore[reportArgumentType]
+        for clause in where_clauses
+    )
 
-    # Build query as psql.SQL so pyright is happy with the strict
-    # Query type; the ``where_sql_str`` is assembled from hardcoded
-    # fragments only (no user input) so adapting it as a bare SQL
-    # literal is safe.
+    # Single LATERAL subquery drives both the timestamp AND the form
+    # type from the SAME row so they can never disagree on same-second
+    # ties. MAX-aggregate + correlated-subquery would tiebreak
+    # independently and could report "new 10-K" while the actual
+    # newest row is an 8-K (audit-trail lie). LATERAL scope + explicit
+    # ORDER BY created_at DESC, filing_event_id DESC resolves ties
+    # deterministically.
     query = (
         psql.SQL(
             """
@@ -211,45 +221,28 @@ def find_stale_instruments(
             i.symbol,
             c.review_frequency,
             MAX(t.created_at)                        AS latest_thesis_at,
-            -- Latest qualifying-filing created_at timestamp. Use
-            -- ``created_at`` (ingest time) not ``filing_date`` so:
-            -- (a) a filing ingested AFTER the thesis on the same
-            --     calendar day triggers a refresh,
-            -- (b) a backfilled filing with an old filing_date but a
-            --     recent created_at also triggers (thesis generated
-            --     before the backfill could not have incorporated it).
-            MAX(fe.created_at) FILTER (
-                WHERE fe.filing_type IN (
-                    '10-K','10-K/A','10-Q','10-Q/A','8-K','8-K/A'
-                )
-            )                                        AS latest_event_created_at,
-            -- Form type of the filing with the max created_at. The
-            -- subquery orders by the same column so the two aggregates
-            -- identify the same row even for same-second multi-insert.
-            (
-                SELECT fe2.filing_type
-                FROM filing_events fe2
-                WHERE fe2.instrument_id = i.instrument_id
-                  AND fe2.filing_type IN (
-                      '10-K','10-K/A','10-Q','10-Q/A','8-K','8-K/A'
-                  )
-                ORDER BY fe2.created_at DESC, fe2.filing_event_id DESC
-                LIMIT 1
-            )                                        AS latest_event_filing_type
+            le.created_at                            AS latest_event_created_at,
+            le.filing_type                           AS latest_event_filing_type
         FROM instruments i
         JOIN coverage c ON c.instrument_id = i.instrument_id
         LEFT JOIN theses t ON t.instrument_id = i.instrument_id
-        LEFT JOIN filing_events fe ON fe.instrument_id = i.instrument_id
+        LEFT JOIN LATERAL (
+            SELECT fe.created_at, fe.filing_type
+            FROM filing_events fe
+            WHERE fe.instrument_id = i.instrument_id
+              AND fe.filing_type IN (
+                  '10-K','10-K/A','10-Q','10-Q/A','8-K','8-K/A'
+              )
+            ORDER BY fe.created_at DESC, fe.filing_event_id DESC
+            LIMIT 1
+        ) le ON TRUE
         WHERE """
         )
-        # where_sql_str is assembled from hardcoded fragments above —
-        # safe to adapt as a SQL literal. Pyright's LiteralString
-        # tightening can't see the provenance; ignore here rather
-        # than restructure the branching logic.
-        + psql.SQL(where_sql_str)  # pyright: ignore[reportArgumentType]
+        + where_block
         + psql.SQL(
             """
-        GROUP BY i.instrument_id, i.symbol, c.review_frequency
+        GROUP BY i.instrument_id, i.symbol, c.review_frequency,
+                 le.created_at, le.filing_type
         ORDER BY i.symbol
         """
         )

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -75,9 +75,13 @@ def _make_conn(
     """
     conn = MagicMock()
 
-    def execute_side_effect(sql: str, params: dict | None = None):
+    def execute_side_effect(sql, params: dict | None = None):  # type: ignore[no-untyped-def]
+        # sql may be a str OR a psycopg.sql.SQL/Composed object.
+        # Normalise via str() so substring-based branch matching still
+        # works regardless of which shape the service uses.
         cursor = MagicMock()
-        sql_strip = " ".join(sql.split()).lower()
+        sql_str = sql if isinstance(sql, str) else str(sql)
+        sql_strip = " ".join(sql_str.split()).lower()
 
         if "insert into theses" in sql_strip:
             # Branch priority note: this check must come before any branch that
@@ -146,7 +150,9 @@ class TestToFloat:
 
 class TestFindStaleInstruments:
     def test_no_thesis_is_stale(self) -> None:
-        rows = [(1, "AAPL", "weekly", None)]
+        # (instrument_id, symbol, review_frequency, latest_thesis_at,
+        #  latest_event_filing_date, latest_event_filing_type)
+        rows = [(1, "AAPL", "weekly", None, None, None)]
         conn = _make_conn(stale_rows=rows)
         result = find_stale_instruments(conn, tier=1)
         assert len(result) == 1
@@ -154,14 +160,14 @@ class TestFindStaleInstruments:
         assert result[0].symbol == "AAPL"
 
     def test_unknown_frequency_is_stale(self) -> None:
-        rows = [(1, "AAPL", "biannual", _NOW - timedelta(days=1))]
+        rows = [(1, "AAPL", "biannual", _NOW - timedelta(days=1), None, None)]
         conn = _make_conn(stale_rows=rows)
         result = find_stale_instruments(conn, tier=1)
         assert len(result) == 1
         assert result[0].reason == "missing_frequency"
 
     def test_null_frequency_is_stale(self) -> None:
-        rows = [(1, "AAPL", None, _NOW - timedelta(days=1))]
+        rows = [(1, "AAPL", None, _NOW - timedelta(days=1), None, None)]
         conn = _make_conn(stale_rows=rows)
         result = find_stale_instruments(conn, tier=1)
         assert len(result) == 1
@@ -169,7 +175,7 @@ class TestFindStaleInstruments:
 
     def test_past_weekly_threshold_is_stale(self) -> None:
         # thesis created 8 days ago, weekly frequency → stale
-        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=8))]
+        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=8), None, None)]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -178,7 +184,7 @@ class TestFindStaleInstruments:
 
     def test_within_weekly_threshold_is_fresh(self) -> None:
         # thesis created 3 days ago, weekly frequency → fresh
-        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=3))]
+        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=3), None, None)]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -186,7 +192,7 @@ class TestFindStaleInstruments:
 
     def test_daily_threshold(self) -> None:
         # thesis created 25 hours ago, daily frequency → stale
-        rows = [(1, "MSFT", "daily", _NOW - timedelta(hours=25))]
+        rows = [(1, "MSFT", "daily", _NOW - timedelta(hours=25), None, None)]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -195,7 +201,7 @@ class TestFindStaleInstruments:
 
     def test_monthly_threshold(self) -> None:
         # thesis created 31 days ago, monthly frequency → stale
-        rows = [(1, "TSLA", "monthly", _NOW - timedelta(days=31))]
+        rows = [(1, "TSLA", "monthly", _NOW - timedelta(days=31), None, None)]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -203,9 +209,9 @@ class TestFindStaleInstruments:
 
     def test_multiple_instruments_mixed(self) -> None:
         rows = [
-            (1, "AAPL", "weekly", _NOW - timedelta(days=3)),  # fresh
-            (2, "MSFT", "weekly", _NOW - timedelta(days=8)),  # stale
-            (3, "GOOG", "weekly", None),  # no thesis
+            (1, "AAPL", "weekly", _NOW - timedelta(days=3), None, None),  # fresh
+            (2, "MSFT", "weekly", _NOW - timedelta(days=8), None, None),  # stale
+            (3, "GOOG", "weekly", None, None, None),  # no thesis
         ]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
@@ -217,7 +223,7 @@ class TestFindStaleInstruments:
 
     def test_exactly_at_threshold_is_stale(self) -> None:
         # now == created_at + 7 days exactly → stale (>= boundary)
-        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=7))]
+        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=7), None, None)]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)

--- a/tests/test_thesis_event_driven_integration.py
+++ b/tests/test_thesis_event_driven_integration.py
@@ -391,6 +391,47 @@ def test_time_based_cadence_still_triggers_stale(
     assert result[0].reason == "stale"
 
 
+def test_same_second_filings_use_tiebreak_deterministically(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """PR review BLOCKING #301 regression guard: if two filings have
+    identical created_at, the LATERAL subquery's ORDER BY
+    (created_at DESC, filing_event_id DESC) resolves tiebreaks
+    deterministically. Latest inserted (highest filing_event_id) wins.
+    Asserting the *form type* matches the tiebreaker catches the class
+    of bug where an aggregate MAX disagrees with a correlated
+    subquery's ORDER BY."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL")
+    _seed_thesis(ebull_test_conn, instrument_id=1, created_at=datetime.now(UTC) - timedelta(days=2))
+    same_ts = datetime.now(UTC)
+    # Insert 10-K first, then 8-K — same timestamp. filing_event_id
+    # is BIGSERIAL so 8-K gets the higher value and wins the tiebreak.
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today(),
+        filing_type="10-K",
+        accession="TIE-1",
+        created_at=same_ts,
+    )
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today(),
+        filing_type="8-K",
+        accession="TIE-2",
+        created_at=same_ts,
+    )
+
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+
+    # The reason must be the tiebreak-winner's form (8-K, higher id),
+    # not the aggregate-MAX-winner's form. Both timestamps are equal
+    # so without a single deterministic source of truth the reason
+    # could report 10-K while the newest row is 8-K.
+    assert result[0].reason == "event_new_8k"
+
+
 def test_event_reason_takes_precedence_over_time_based(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:

--- a/tests/test_thesis_event_driven_integration.py
+++ b/tests/test_thesis_event_driven_integration.py
@@ -145,7 +145,11 @@ def test_new_10k_since_thesis_triggers_event_reason(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
     """Thesis was fresh by cadence, but a new 10-K landed after it —
-    must surface with reason='event_new_10k'."""
+    must surface with reason='event_new_10k'.
+
+    Pins both timestamps explicitly so a Python/DB clock skew cannot
+    invert the order and produce a silent false-negative empty result.
+    """
     _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL")
     thesis_at = datetime.now(UTC) - timedelta(days=3)  # well within weekly window
     _seed_thesis(ebull_test_conn, instrument_id=1, created_at=thesis_at)
@@ -155,6 +159,7 @@ def test_new_10k_since_thesis_triggers_event_reason(
         filing_date=date.today() - timedelta(days=1),  # newer than thesis
         filing_type="10-K",
         accession="0000320193-26-000001",
+        created_at=datetime.now(UTC),  # explicit: post-thesis ingest
     )
 
     result = find_stale_instruments(ebull_test_conn, tier=1)

--- a/tests/test_thesis_event_driven_integration.py
+++ b/tests/test_thesis_event_driven_integration.py
@@ -1,0 +1,411 @@
+"""Integration tests for #273 — thesis event-driven trigger.
+
+Extends ``find_stale_instruments`` with:
+- event-based predicate: new 10-K / 10-Q / 8-K since latest thesis.
+- ``filings_status = 'analysable'`` gate.
+- optional ``tier=None`` + ``instrument_ids=[...]`` for cascade calls.
+
+Real ``ebull_test`` DB required so the SQL aggregate + LATERAL work.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+import psycopg
+import pytest
+
+from app.services.thesis import StaleInstrument, find_stale_instruments
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test DB unavailable",
+)
+
+
+def _seed_instrument(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    symbol: str,
+    tier: int = 1,
+    filings_status: str = "analysable",
+    review_frequency: str = "weekly",
+) -> None:
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES (%s, %s, %s, TRUE)",
+        (instrument_id, symbol, symbol),
+    )
+    conn.execute(
+        "INSERT INTO coverage (instrument_id, coverage_tier, review_frequency, filings_status) VALUES (%s, %s, %s, %s)",
+        (instrument_id, tier, review_frequency, filings_status),
+    )
+    conn.commit()
+
+
+def _seed_thesis(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    thesis_version: int = 1,
+    created_at: datetime | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO theses (
+            instrument_id, thesis_version, created_at,
+            thesis_type, stance, memo_markdown
+        ) VALUES (%s, %s, %s, 'compounder', 'buy', 'test memo')
+        """,
+        (instrument_id, thesis_version, created_at or datetime.now(UTC)),
+    )
+    conn.commit()
+
+
+def _seed_filing(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    filing_date: date,
+    filing_type: str,
+    accession: str,
+    created_at: datetime | None = None,
+) -> None:
+    """Insert a filing_events row.
+
+    ``created_at`` defaults to NOW() (DB default). Tests that need to
+    pin the ingest timestamp (e.g. to assert no event-trigger fires
+    when a filing was already in the DB before the thesis ran) should
+    pass this explicitly. find_stale_instruments's event trigger
+    compares ``filing_events.created_at`` vs ``theses.created_at``, not
+    filing_date.
+    """
+    if created_at is None:
+        conn.execute(
+            """
+            INSERT INTO filing_events (
+                instrument_id, filing_date, filing_type,
+                provider, provider_filing_id
+            ) VALUES (%s, %s, %s, 'sec', %s)
+            """,
+            (instrument_id, filing_date, filing_type, accession),
+        )
+    else:
+        conn.execute(
+            """
+            INSERT INTO filing_events (
+                instrument_id, filing_date, filing_type,
+                provider, provider_filing_id, created_at
+            ) VALUES (%s, %s, %s, 'sec', %s, %s)
+            """,
+            (instrument_id, filing_date, filing_type, accession, created_at),
+        )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Analysable gate
+# ---------------------------------------------------------------------------
+
+
+def test_non_analysable_excluded(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Instruments with filings_status != 'analysable' never appear,
+    regardless of thesis staleness."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="GOOD", filings_status="analysable")
+    _seed_instrument(ebull_test_conn, instrument_id=2, symbol="BAD", filings_status="insufficient")
+
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+
+    symbols = {r.symbol for r in result}
+    assert "GOOD" in symbols
+    assert "BAD" not in symbols
+
+
+def test_fpi_excluded(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """FPI instruments are excluded (v1 — UK-equivalent bar tracked in #279)."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="FPI", filings_status="fpi")
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+    assert [r.symbol for r in result] == []
+
+
+# ---------------------------------------------------------------------------
+# Event-driven trigger
+# ---------------------------------------------------------------------------
+
+
+def test_new_10k_since_thesis_triggers_event_reason(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Thesis was fresh by cadence, but a new 10-K landed after it —
+    must surface with reason='event_new_10k'."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL")
+    thesis_at = datetime.now(UTC) - timedelta(days=3)  # well within weekly window
+    _seed_thesis(ebull_test_conn, instrument_id=1, created_at=thesis_at)
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today() - timedelta(days=1),  # newer than thesis
+        filing_type="10-K",
+        accession="0000320193-26-000001",
+    )
+
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+
+    assert len(result) == 1
+    assert result[0].instrument_id == 1
+    assert result[0].reason == "event_new_10k"
+
+
+def test_new_10q_triggers_event_new_10q(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL")
+    _seed_thesis(ebull_test_conn, instrument_id=1, created_at=datetime.now(UTC) - timedelta(days=2))
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today(),
+        filing_type="10-Q",
+        accession="0000320193-26-000002",
+    )
+
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+    assert result[0].reason == "event_new_10q"
+
+
+def test_new_8k_triggers_event_new_8k(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL")
+    _seed_thesis(ebull_test_conn, instrument_id=1, created_at=datetime.now(UTC) - timedelta(days=2))
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today(),
+        filing_type="8-K",
+        accession="0000320193-26-000003",
+    )
+
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+    assert result[0].reason == "event_new_8k"
+
+
+def test_amendment_triggers_same_reason_as_base(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """10-K/A amendment should trigger event_new_10k (not a separate reason)."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL")
+    _seed_thesis(ebull_test_conn, instrument_id=1, created_at=datetime.now(UTC) - timedelta(days=2))
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today(),
+        filing_type="10-K/A",
+        accession="0000320193-26-000004",
+    )
+
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+    assert result[0].reason == "event_new_10k"
+
+
+def test_old_filing_no_event_trigger(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Filing INGESTED (``created_at``) before the thesis must NOT
+    trigger event-based staleness — the thesis had the filing
+    available as input."""
+    thesis_at = datetime.now(UTC) - timedelta(days=3)
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL")
+    # Filing ingested BEFORE the thesis ran (ingested at days=10, then
+    # thesis at days=3). find_stale must not treat this as a new event.
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today() - timedelta(days=30),
+        filing_type="10-K",
+        accession="0000320193-25-000001",
+        created_at=datetime.now(UTC) - timedelta(days=10),
+    )
+    _seed_thesis(ebull_test_conn, instrument_id=1, created_at=thesis_at)
+
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+    # Within weekly window + filing ingested pre-thesis → fresh.
+    assert result == []
+
+
+def test_same_day_post_thesis_filing_triggers(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Thesis generated at 10:00, filing ingested same day at 15:00 →
+    event trigger. Uses created_at timestamps (not filing_date). Codex
+    flagged this gap — same-day filings with identical filing_date as
+    thesis-day would've been missed under the prior date-only check."""
+    now = datetime.now(UTC)
+    thesis_at = now - timedelta(hours=5)  # today at ~10:00 if now=15:00
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL")
+    _seed_thesis(ebull_test_conn, instrument_id=1, created_at=thesis_at)
+    # Filing ingested at now (5h after thesis). Both have filing_date=today.
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today(),
+        filing_type="8-K",
+        accession="SAMEDAY-1",
+        created_at=now,
+    )
+
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+
+    assert result[0].reason == "event_new_8k"
+
+
+def test_backfilled_filing_with_old_filing_date_triggers(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A backfilled filing with a filing_date that predates the thesis
+    but a created_at that postdates it MUST trigger — the thesis
+    could not have incorporated the row because it wasn't in the DB
+    yet. Codex-flagged second case."""
+    thesis_at = datetime.now(UTC) - timedelta(days=1)
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL")
+    _seed_thesis(ebull_test_conn, instrument_id=1, created_at=thesis_at)
+    # Old filing_date but ingested just now via backfill.
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today() - timedelta(days=90),  # old filing_date
+        filing_type="10-Q",
+        accession="BACKFILLED-1",
+        created_at=datetime.now(UTC),  # but freshly ingested
+    )
+
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+
+    assert result[0].reason == "event_new_10q"
+
+
+def test_non_fundamentals_filing_ignored(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Form types outside {10-K, 10-Q, 8-K} (+ amendments) do NOT
+    trigger event-based refresh — 20-F is for #279."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL")
+    _seed_thesis(ebull_test_conn, instrument_id=1, created_at=datetime.now(UTC) - timedelta(days=2))
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today(),
+        filing_type="20-F",
+        accession="0000320193-26-000005",
+    )
+
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+    # No event trigger; thesis is fresh by cadence → empty result.
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tier + instrument_ids parameters
+# ---------------------------------------------------------------------------
+
+
+def test_tier_none_plus_instrument_ids_bypasses_tier_filter(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Cascade caller: tier=None + instrument_ids=[...] should scope to
+    those instruments across any tier."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="T3_A", tier=3)
+    _seed_thesis(ebull_test_conn, instrument_id=1, created_at=datetime.now(UTC) - timedelta(days=2))
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today(),
+        filing_type="10-Q",
+        accession="A-1",
+    )
+    _seed_instrument(ebull_test_conn, instrument_id=2, symbol="T3_B", tier=3)
+    # Instrument 2 has no thesis → also surfaces under "no_thesis".
+
+    result = find_stale_instruments(ebull_test_conn, tier=None, instrument_ids=[1, 2])
+
+    by_id = {r.instrument_id: r for r in result}
+    assert set(by_id) == {1, 2}
+    assert by_id[1].reason == "event_new_10q"
+    assert by_id[2].reason == "no_thesis"
+
+
+def test_tier_none_without_instrument_ids_scans_all_analysable(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """tier=None + no instrument_ids → every tier's analysable instruments."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="T1", tier=1)
+    _seed_instrument(ebull_test_conn, instrument_id=2, symbol="T2", tier=2)
+    _seed_instrument(ebull_test_conn, instrument_id=3, symbol="T3", tier=3)
+
+    # All three have no thesis → all stale with reason="no_thesis".
+    result = find_stale_instruments(ebull_test_conn, tier=None)
+
+    symbols = {r.symbol for r in result}
+    assert symbols == {"T1", "T2", "T3"}
+    assert all(r.reason == "no_thesis" for r in result)
+
+
+def test_instrument_ids_scopes_result(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """instrument_ids narrows the scan even if more instruments in the
+    same tier are stale."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="A")
+    _seed_instrument(ebull_test_conn, instrument_id=2, symbol="B")
+    _seed_instrument(ebull_test_conn, instrument_id=3, symbol="C")
+    # All have no thesis.
+
+    result = find_stale_instruments(ebull_test_conn, tier=1, instrument_ids=[1, 3])
+
+    ids = {r.instrument_id for r in result}
+    assert ids == {1, 3}
+
+
+# ---------------------------------------------------------------------------
+# Existing reasons still work
+# ---------------------------------------------------------------------------
+
+
+def test_time_based_cadence_still_triggers_stale(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Old thesis, no new filings → still stale via time-based rule."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL")
+    _seed_thesis(ebull_test_conn, instrument_id=1, created_at=datetime.now(UTC) - timedelta(days=30))
+
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+    assert len(result) == 1
+    assert result[0].reason == "stale"
+
+
+def test_event_reason_takes_precedence_over_time_based(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """If both event AND time-based would fire, event reason wins
+    (informative for operator dashboards)."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AAPL")
+    _seed_thesis(ebull_test_conn, instrument_id=1, created_at=datetime.now(UTC) - timedelta(days=30))
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today(),
+        filing_type="10-Q",
+        accession="E-1",
+    )
+
+    result = find_stale_instruments(ebull_test_conn, tier=1)
+    assert isinstance(result[0], StaleInstrument)
+    assert result[0].reason == "event_new_10q"  # not "stale"


### PR DESCRIPTION
## What
Extends \`find_stale_instruments\` with event-based staleness: new 10-K/10-Q/8-K (or amendment) INGESTED after the latest thesis triggers refresh regardless of time-based cadence. Adds \`filings_status='analysable'\` gate + optional cascade-scoping params (\`tier=None\`, \`instrument_ids=[...]\`).

## Why
Issue #273. Unblocks #276 (cascade service). Closes the "stale thesis on just-filed 10-Q" gap in the pre-cascade system.

## Key design decision (Codex-flagged)
Event predicate uses \`filing_events.created_at\` timestamp vs thesis \`created_at\`, NOT \`filing_date\`. This catches (a) same-day post-thesis filings, (b) backfilled filings with old filing_date but new created_at that the thesis couldn't have seen.

## Test plan
- [x] 15 new integration tests against \`ebull_test\` DB cover all paths.
- [x] Existing 51 thesis unit tests still pass (mock updated to accept psycopg.sql objects).
- [x] Full suite: 1842 passed.
- [x] ruff + pyright clean.
- [x] Codex reviewed: Medium finding on created_at vs filing_date addressed, regression tests added for both scenarios.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>