### PR TITLE
feat(#276): cascade refresh service (K.1)

### DIFF
--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -27,7 +27,7 @@ adds a durable retry outbox. K.1 (this module) is the basic wiring.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import anthropic
@@ -53,7 +53,7 @@ class CascadeOutcome:
     instruments_considered: int
     thesis_refreshed: int
     rankings_recomputed: bool
-    failed: tuple[tuple[int, str], ...] = field(default_factory=tuple)
+    failed: tuple[tuple[int, str], ...] = ()
 
 
 def changed_instruments_from_outcome(
@@ -84,10 +84,12 @@ def changed_instruments_from_outcome(
     # find_stale_instruments picks up the newest filing regardless.
     # Pre-pad closes the gap where both "320193" and "0000320193"
     # would pass an unpadded seen-check and emit a duplicate after
-    # padding. str.zfill(10) is total (no ValueError) — it pads
-    # short digit strings and leaves longer / non-digit values
-    # untouched; non-digit values simply miss the SELECT silently,
-    # matching the pre-existing behavior.
+    # padding. Invariant: every CIK reaching this function
+    # originates from _zero_pad_cik (parse_master_index or the
+    # external_identifiers store) and is already a 10-digit digit
+    # string. str.zfill(10) is therefore a belt-and-braces pad for
+    # any future caller that hands us a raw-integer CIK — it is
+    # total (no ValueError) and is a no-op on already-padded input.
     padded = [cik.zfill(10) for cik in ciks]
     seen: set[str] = set()
     unique_ciks = [cik for cik in padded if not (cik in seen or seen.add(cik))]

--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -1,0 +1,200 @@
+"""Refresh cascade service (#276 Chunk K).
+
+After ``daily_financial_facts`` commits new fundamentals + normalizes
+periods, this service propagates the change to thesis and scoring:
+
+1. Map the refresh plan's successful CIKs (refreshes + submissions-
+   only, minus per-CIK failures) to instrument_ids.
+2. For each instrument, check ``find_stale_instruments`` — the event-
+   driven predicate shipped in #273 flags any whose thesis lags a
+   qualifying filing.
+3. Generate a fresh thesis (Claude) for each stale instrument.
+4. If any thesis refreshed this cycle, re-run ``compute_rankings``
+   once for the full pool — scoring reads thesis fields so fresh
+   theses can move every score, not just the cascade's subset.
+
+The full-pool rerank is the Option-α scoring approach from the
+master plan — subset scoring was ruled out because ``compute_rankings``
+assigns global rank and per-instrument score rows without the full
+pool would have NULL / mismatched rank values.
+
+Per-instrument thesis failures are isolated — one bad CIK does not
+abort the loop or the subsequent rerank. Future K.3 adds session-
+level advisory locking against ``daily_thesis_refresh``; future K.2
+adds a durable retry outbox. K.1 (this module) is the basic wiring.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import anthropic
+import psycopg
+
+from app.services.scoring import compute_rankings
+from app.services.sec_incremental import RefreshOutcome, RefreshPlan
+from app.services.thesis import find_stale_instruments, generate_thesis
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CascadeOutcome:
+    """Result of one ``cascade_refresh`` run."""
+
+    instruments_considered: int
+    thesis_refreshed: int
+    rankings_recomputed: bool
+    failed: list[tuple[int, str]] = field(default_factory=list)
+
+
+def changed_instruments_from_outcome(
+    conn: psycopg.Connection[Any],
+    plan: RefreshPlan,
+    outcome: RefreshOutcome,
+) -> list[int]:
+    """Map CIKs that succeeded this cycle to instrument_ids.
+
+    Drops plan.seeds — seeds don't cascade (fresh-install Claude-call
+    storm protection). Drops CIKs present in outcome.failed. Keeps
+    refreshes (fundamentals-changing) and submissions_only_advances
+    (8-K etc. — thesis context uses filings).
+    """
+    failed_ciks = {cik for cik, _reason in outcome.failed}
+    seed_ciks = set(plan.seeds)
+    excluded = failed_ciks | seed_ciks
+
+    ciks = [cik for cik, _accession in plan.refreshes if cik not in excluded]
+    ciks.extend(cik for cik, _accession in plan.submissions_only_advances if cik not in excluded)
+
+    if not ciks:
+        return []
+
+    # De-dupe preserving order.
+    seen: set[str] = set()
+    unique_ciks = [cik for cik in ciks if not (cik in seen or seen.add(cik))]
+
+    rows = conn.execute(
+        """
+        SELECT DISTINCT i.instrument_id
+        FROM instruments i
+        JOIN external_identifiers ei
+            ON ei.instrument_id = i.instrument_id
+           AND ei.provider = 'sec'
+           AND ei.identifier_type = 'cik'
+           AND ei.identifier_value = ANY(%s)
+           AND ei.is_primary = TRUE
+        WHERE i.is_tradable = TRUE
+        ORDER BY i.instrument_id
+        """,
+        (unique_ciks,),
+    ).fetchall()
+    return [int(r[0]) for r in rows]
+
+
+def cascade_refresh(
+    conn: psycopg.Connection[Any],
+    client: anthropic.Anthropic,
+    instrument_ids: list[int],
+) -> CascadeOutcome:
+    """Run the cascade for the given instrument_ids.
+
+    For each instrument: ``find_stale_instruments`` (scoped via
+    ``tier=None`` + ``instrument_ids``) decides whether the thesis
+    needs refresh per #273's event-driven predicate. If stale,
+    ``generate_thesis`` is called — it commits its own read tx before
+    Claude per #293 + writes its own thesis row atomically.
+
+    After the thesis loop: if any thesis was refreshed, call
+    ``compute_rankings`` once for the full analysable pool. Scoring
+    reads thesis fields so any thesis change can move every score.
+
+    Per-instrument failures recorded in the outcome; one failure
+    does not abort siblings or the subsequent rerank.
+    """
+    if not instrument_ids:
+        return CascadeOutcome(instruments_considered=0, thesis_refreshed=0, rankings_recomputed=False)
+
+    stale = find_stale_instruments(conn, tier=None, instrument_ids=instrument_ids)
+    if not stale:
+        logger.info(
+            "cascade_refresh: %d instruments considered, 0 stale — no thesis or score refresh",
+            len(instrument_ids),
+        )
+        return CascadeOutcome(
+            instruments_considered=len(instrument_ids),
+            thesis_refreshed=0,
+            rankings_recomputed=False,
+        )
+
+    thesis_refreshed = 0
+    failed: list[tuple[int, str]] = []
+
+    for stale_instrument in stale:
+        try:
+            generate_thesis(stale_instrument.instrument_id, conn, client)
+            thesis_refreshed += 1
+            logger.info(
+                "cascade_refresh: thesis refreshed for instrument_id=%d symbol=%s reason=%s",
+                stale_instrument.instrument_id,
+                stale_instrument.symbol,
+                stale_instrument.reason,
+            )
+        except Exception as exc:
+            # Attempt to roll back any half-open tx from generate_thesis
+            # before continuing to siblings. generate_thesis wraps its
+            # DB write in its own `with conn.transaction():` so the
+            # failing CIK's row was already rolled back — this is
+            # belt-and-braces for the pre-transaction reads that
+            # opened the implicit tx before the Claude call failed.
+            try:
+                conn.rollback()
+            except psycopg.Error:
+                logger.debug(
+                    "cascade_refresh: rollback suppressed after thesis exception",
+                    exc_info=True,
+                )
+            failed.append((stale_instrument.instrument_id, type(exc).__name__))
+            logger.exception(
+                "cascade_refresh: thesis failed for instrument_id=%d symbol=%s",
+                stale_instrument.instrument_id,
+                stale_instrument.symbol,
+            )
+
+    rankings_recomputed = False
+    if thesis_refreshed > 0:
+        try:
+            ranking_result = compute_rankings(conn)
+            rankings_recomputed = True
+            logger.info(
+                "cascade_refresh: rankings recomputed — %d scored",
+                len(ranking_result.scored),
+            )
+        except Exception as exc:
+            try:
+                conn.rollback()
+            except psycopg.Error:
+                logger.debug(
+                    "cascade_refresh: rollback suppressed after compute_rankings exception",
+                    exc_info=True,
+                )
+            failed.append((-1, type(exc).__name__))  # -1 sentinel for non-instrument failure
+            logger.exception("cascade_refresh: compute_rankings failed after thesis refresh")
+
+    logger.info(
+        "cascade_refresh summary: considered=%d stale=%d thesis_refreshed=%d rankings=%s failed=%d",
+        len(instrument_ids),
+        len(stale),
+        thesis_refreshed,
+        rankings_recomputed,
+        len(failed),
+    )
+
+    return CascadeOutcome(
+        instruments_considered=len(instrument_ids),
+        thesis_refreshed=thesis_refreshed,
+        rankings_recomputed=rankings_recomputed,
+        failed=failed,
+    )

--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -78,18 +78,19 @@ def changed_instruments_from_outcome(
     if not ciks:
         return []
 
-    # De-dupe by CIK (intentional — not by accession). Thesis
-    # staleness is keyed per instrument, not per filing, so if the
-    # same CIK filed twice in the window we still only need to map
-    # it once; the event predicate in find_stale_instruments will
-    # pick up the newest filing regardless.
-    # CIK zero-padding: the planner (plan_refresh -> parse_master_index)
-    # already pads via _zero_pad_cik, but we pad again defensively
-    # here so a future caller that hands us a raw-integer CIK string
-    # doesn't silently miss rows against the zero-padded storage in
-    # external_identifiers.identifier_value.
+    # Pad first, then de-dupe. Thesis staleness is keyed per
+    # instrument, not per filing, so same-CIK double filings
+    # collapse to one mapping; the event predicate in
+    # find_stale_instruments picks up the newest filing regardless.
+    # Pre-pad closes the gap where both "320193" and "0000320193"
+    # would pass an unpadded seen-check and emit a duplicate after
+    # padding. str.zfill(10) is total (no ValueError) — it pads
+    # short digit strings and leaves longer / non-digit values
+    # untouched; non-digit values simply miss the SELECT silently,
+    # matching the pre-existing behavior.
+    padded = [cik.zfill(10) for cik in ciks]
     seen: set[str] = set()
-    unique_ciks = [str(int(cik)).zfill(10) for cik in ciks if not (cik in seen or seen.add(cik))]
+    unique_ciks = [cik for cik in padded if not (cik in seen or seen.add(cik))]
 
     rows = conn.execute(
         """

--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -72,7 +72,11 @@ def changed_instruments_from_outcome(
     if not ciks:
         return []
 
-    # De-dupe preserving order.
+    # De-dupe by CIK (intentional — not by accession). Thesis
+    # staleness is keyed per instrument, not per filing, so if the
+    # same CIK filed twice in the window we still only need to map
+    # it once; the event predicate in find_stale_instruments will
+    # pick up the newest filing regardless.
     seen: set[str] = set()
     unique_ciks = [cik for cik in ciks if not (cik in seen or seen.add(cik))]
 

--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -42,12 +42,18 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class CascadeOutcome:
-    """Result of one ``cascade_refresh`` run."""
+    """Result of one ``cascade_refresh`` run.
+
+    ``failed`` is stored as a tuple to preserve the ``frozen=True``
+    immutability invariant — a ``list`` field would be attribute-
+    immutable but value-mutable, which is a well-known dataclass
+    footgun.
+    """
 
     instruments_considered: int
     thesis_refreshed: int
     rankings_recomputed: bool
-    failed: list[tuple[int, str]] = field(default_factory=list)
+    failed: tuple[tuple[int, str], ...] = field(default_factory=tuple)
 
 
 def changed_instruments_from_outcome(
@@ -77,8 +83,13 @@ def changed_instruments_from_outcome(
     # same CIK filed twice in the window we still only need to map
     # it once; the event predicate in find_stale_instruments will
     # pick up the newest filing regardless.
+    # CIK zero-padding: the planner (plan_refresh -> parse_master_index)
+    # already pads via _zero_pad_cik, but we pad again defensively
+    # here so a future caller that hands us a raw-integer CIK string
+    # doesn't silently miss rows against the zero-padded storage in
+    # external_identifiers.identifier_value.
     seen: set[str] = set()
-    unique_ciks = [cik for cik in ciks if not (cik in seen or seen.add(cik))]
+    unique_ciks = [str(int(cik)).zfill(10) for cik in ciks if not (cik in seen or seen.add(cik))]
 
     rows = conn.execute(
         """
@@ -200,5 +211,5 @@ def cascade_refresh(
         instruments_considered=len(instrument_ids),
         thesis_refreshed=thesis_refreshed,
         rankings_recomputed=rankings_recomputed,
-        failed=failed,
+        failed=tuple(failed),
     )

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1219,15 +1219,20 @@ def daily_financial_facts() -> None:
                 if changed_ids:
                     cascade_client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
                     cascade_outcome = cascade_refresh(conn, cascade_client, changed_ids)
-                    # Commit any cascade-side writes (in particular
-                    # compute_rankings' score rows, which write inside
-                    # a ``with conn.transaction():`` block that may be
+                    # Persist any cascade-side writes before the
+                    # failure-surfacing raise below. compute_rankings
+                    # writes score rows inside a
+                    # ``with conn.transaction():`` block that may be
                     # nested as a savepoint under this connection's
-                    # implicit outer tx). Without this, the raise
-                    # below would propagate to psycopg.connect()'s CM
-                    # rollback and discard successful ranking writes.
-                    # Thesis rows are already safe because
-                    # generate_thesis commits before Claude per #293.
+                    # implicit outer tx — without this explicit
+                    # commit, the raise propagates to
+                    # psycopg.connect()'s CM rollback and discards
+                    # any successful ranking writes. On the failure
+                    # path where compute_rankings itself rolled back
+                    # (cascade_refresh's inner handler), this commit
+                    # is a no-op on clean state. Thesis rows are
+                    # already durably committed by generate_thesis
+                    # per #293 and are unaffected either way.
                     conn.commit()
                     logger.info(
                         "cascade_refresh outcome: considered=%d thesis_refreshed=%d rankings=%s failed=%d",

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1197,6 +1197,37 @@ def daily_financial_facts() -> None:
                 # remains the liveness signal.
                 tracker.row_count = 0
 
+            # Phase 3: cascade refresh (#276 Chunk K.1). Explicit
+            # conn.commit() BEFORE cascade so cascade's fresh reads
+            # see committed state from Phase 1 + Phase 2 —
+            # normalize_financial_periods uses savepoints and does not
+            # itself commit. Cascade runs even on submissions-only
+            # days (8-K thesis context update) as long as there were
+            # successful non-seed CIKs.
+            conn.commit()
+            if settings.anthropic_api_key:
+                from app.services.refresh_cascade import (
+                    cascade_refresh,
+                    changed_instruments_from_outcome,
+                )
+
+                changed_ids = changed_instruments_from_outcome(conn, plan, outcome)
+                if changed_ids:
+                    cascade_client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+                    cascade_outcome = cascade_refresh(conn, cascade_client, changed_ids)
+                    logger.info(
+                        "cascade_refresh outcome: considered=%d thesis_refreshed=%d rankings=%s failed=%d",
+                        cascade_outcome.instruments_considered,
+                        cascade_outcome.thesis_refreshed,
+                        cascade_outcome.rankings_recomputed,
+                        len(cascade_outcome.failed),
+                    )
+            else:
+                logger.info(
+                    "daily_financial_facts: ANTHROPIC_API_KEY not set — "
+                    "skipping cascade refresh (facts + normalization still committed)"
+                )
+
 
 def daily_news_refresh() -> None:
     """

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1197,13 +1197,17 @@ def daily_financial_facts() -> None:
                 # remains the liveness signal.
                 tracker.row_count = 0
 
-            # Phase 3: cascade refresh (#276 Chunk K.1). Explicit
-            # conn.commit() BEFORE cascade so cascade's fresh reads
-            # see committed state from Phase 1 + Phase 2 —
-            # normalize_financial_periods uses savepoints and does not
-            # itself commit. Cascade runs even on submissions-only
-            # days (8-K thesis context update) as long as there were
-            # successful non-seed CIKs.
+            # Phase 3: cascade refresh (#276 Chunk K.1). The bare
+            # ``conn.commit()`` is reached only on the success path of
+            # Phase 1 + Phase 2 — Python exception propagation skips
+            # this line on any prior raise, and ``psycopg.connect()``
+            # as a context manager rolls back the connection on
+            # exception. The commit is required because
+            # ``normalize_financial_periods`` uses savepoints, not
+            # commit, and cascade reads must see committed state.
+            # Cascade runs even on submissions-only days (8-K thesis
+            # context update) as long as there were successful
+            # non-seed CIKs.
             conn.commit()
             if settings.anthropic_api_key:
                 from app.services.refresh_cascade import (
@@ -1222,6 +1226,18 @@ def daily_financial_facts() -> None:
                         cascade_outcome.rankings_recomputed,
                         len(cascade_outcome.failed),
                     )
+                    # Surface cascade failures to the tracked job —
+                    # per-instrument thesis failures AND the -1
+                    # rerank-sentinel. Without this, SEC watermarks
+                    # would be committed while the cascade silently
+                    # fell behind, and ops health would still show
+                    # status=success. Facts/normalization remain
+                    # durably committed (commit happened above).
+                    if cascade_outcome.failed:
+                        raise RuntimeError(
+                            f"cascade_refresh completed with {len(cascade_outcome.failed)} failures: "
+                            f"{cascade_outcome.failed}"
+                        )
             else:
                 logger.info(
                     "daily_financial_facts: ANTHROPIC_API_KEY not set — "

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1219,6 +1219,16 @@ def daily_financial_facts() -> None:
                 if changed_ids:
                     cascade_client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
                     cascade_outcome = cascade_refresh(conn, cascade_client, changed_ids)
+                    # Commit any cascade-side writes (in particular
+                    # compute_rankings' score rows, which write inside
+                    # a ``with conn.transaction():`` block that may be
+                    # nested as a savepoint under this connection's
+                    # implicit outer tx). Without this, the raise
+                    # below would propagate to psycopg.connect()'s CM
+                    # rollback and discard successful ranking writes.
+                    # Thesis rows are already safe because
+                    # generate_thesis commits before Claude per #293.
+                    conn.commit()
                     logger.info(
                         "cascade_refresh outcome: considered=%d thesis_refreshed=%d rankings=%s failed=%d",
                         cascade_outcome.instruments_considered,
@@ -1231,8 +1241,14 @@ def daily_financial_facts() -> None:
                     # rerank-sentinel. Without this, SEC watermarks
                     # would be committed while the cascade silently
                     # fell behind, and ops health would still show
-                    # status=success. Facts/normalization remain
-                    # durably committed (commit happened above).
+                    # status=success. Facts/normalization/cascade
+                    # writes remain durably committed (commits
+                    # happened above). Re-entry path on next run:
+                    # find_stale_instruments (#273) uses
+                    # filing_events.created_at > thesis_generated_at,
+                    # so any instrument whose thesis we failed to
+                    # refresh this run remains stale and re-enters
+                    # the cascade next run.
                     if cascade_outcome.failed:
                         raise RuntimeError(
                             f"cascade_refresh completed with {len(cascade_outcome.failed)} failures: "

--- a/tests/test_refresh_cascade.py
+++ b/tests/test_refresh_cascade.py
@@ -106,6 +106,17 @@ class TestChangedInstrumentsFromOutcome:
         result = changed_instruments_from_outcome(conn, plan, outcome)
         assert result == [102]
 
+    def test_unpadded_cik_normalized_to_zero_padded(self) -> None:
+        """Defensive zfill(10): if a future caller hands us a
+        raw-integer CIK string (e.g. '320193'), we still match the
+        zero-padded identifier_value stored in external_identifiers
+        ('0000320193'). Protects against silent zero-row misses."""
+        conn = _mock_conn_with_cik_lookup({"0000320193": 101})
+        plan = RefreshPlan(refreshes=[("320193", "ACCN-APPL")])
+        outcome = RefreshOutcome(refreshed=1)
+        result = changed_instruments_from_outcome(conn, plan, outcome)
+        assert result == [101]
+
 
 # ---------------------------------------------------------------------------
 # cascade_refresh
@@ -171,7 +182,7 @@ class TestCascadeRefresh:
         rank_mock.assert_called_once_with(conn)
         assert outcome.thesis_refreshed == 2
         assert outcome.rankings_recomputed is True
-        assert outcome.failed == []
+        assert outcome.failed == ()
 
     def test_per_instrument_failure_isolated_rerank_still_runs(self) -> None:
         """One instrument's thesis raising must not abort siblings,

--- a/tests/test_refresh_cascade.py
+++ b/tests/test_refresh_cascade.py
@@ -117,6 +117,17 @@ class TestChangedInstrumentsFromOutcome:
         result = changed_instruments_from_outcome(conn, plan, outcome)
         assert result == [101]
 
+    def test_mixed_padded_and_unpadded_cik_dedupe_after_padding(self) -> None:
+        """Both unpadded and padded forms of the same CIK collapse
+        to one mapping — de-dupe operates on the padded form."""
+        conn = _mock_conn_with_cik_lookup({"0000320193": 101})
+        plan = RefreshPlan(
+            refreshes=[("320193", "A"), ("0000320193", "B")],
+        )
+        outcome = RefreshOutcome(refreshed=2)
+        result = changed_instruments_from_outcome(conn, plan, outcome)
+        assert result == [101]
+
 
 # ---------------------------------------------------------------------------
 # cascade_refresh

--- a/tests/test_refresh_cascade.py
+++ b/tests/test_refresh_cascade.py
@@ -1,0 +1,259 @@
+"""Unit tests for refresh_cascade (#276 K.1).
+
+Mock-based so no real Claude API is called. Integration of the
+service with the scheduler (conn.commit() before cascade, API-key
+gate, psycopg aborted-transaction recovery after thesis failure)
+is intentionally deferred to K.2/K.3 once a real DB fixture is
+cheap — MagicMock cannot model aborted psycopg transactions.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.services.refresh_cascade import (
+    CascadeOutcome,
+    cascade_refresh,
+    changed_instruments_from_outcome,
+)
+from app.services.sec_incremental import RefreshOutcome, RefreshPlan
+from app.services.thesis import StaleInstrument
+
+# ---------------------------------------------------------------------------
+# changed_instruments_from_outcome
+# ---------------------------------------------------------------------------
+
+
+def _mock_conn_with_cik_lookup(cik_to_instrument: dict[str, int]) -> MagicMock:
+    """Mock conn whose SELECT resolves CIKs to instrument_ids."""
+    conn = MagicMock()
+
+    def execute_side_effect(sql, params=None):  # type: ignore[no-untyped-def]
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        sql_str = sql if isinstance(sql, str) else str(sql)
+        if "external_identifiers" in sql_str:
+            # params is (cik_list,) — one tuple arg
+            ciks = params[0] if isinstance(params, tuple) else (params or [])
+            rows = []
+            for cik in ciks:
+                if cik in cik_to_instrument:
+                    rows.append((cik_to_instrument[cik],))
+            cursor.fetchall.return_value = sorted(rows)
+        return cursor
+
+    conn.execute.side_effect = execute_side_effect
+    return conn
+
+
+class TestChangedInstrumentsFromOutcome:
+    def test_empty_plan_returns_empty_list(self) -> None:
+        conn = MagicMock()
+        plan = RefreshPlan()
+        outcome = RefreshOutcome()
+        assert changed_instruments_from_outcome(conn, plan, outcome) == []
+        conn.execute.assert_not_called()
+
+    def test_seeds_excluded(self) -> None:
+        """Seeds don't cascade — prevents fresh-install Claude storm."""
+        conn = _mock_conn_with_cik_lookup({"0000000001": 1})
+        plan = RefreshPlan(seeds=["0000000001"])
+        outcome = RefreshOutcome(seeded=1)
+        result = changed_instruments_from_outcome(conn, plan, outcome)
+        assert result == []
+
+    def test_refreshes_mapped_to_instrument_ids(self) -> None:
+        conn = _mock_conn_with_cik_lookup({"0000000001": 101, "0000000002": 102})
+        plan = RefreshPlan(
+            refreshes=[("0000000001", "ACCN-1"), ("0000000002", "ACCN-2")],
+        )
+        outcome = RefreshOutcome(refreshed=2)
+        result = changed_instruments_from_outcome(conn, plan, outcome)
+        assert result == [101, 102]
+
+    def test_submissions_only_mapped_to_instrument_ids(self) -> None:
+        conn = _mock_conn_with_cik_lookup({"0000000001": 101})
+        plan = RefreshPlan(
+            submissions_only_advances=[("0000000001", "ACCN-8K")],
+        )
+        outcome = RefreshOutcome(submissions_advanced=1)
+        result = changed_instruments_from_outcome(conn, plan, outcome)
+        assert result == [101]
+
+    def test_failed_ciks_excluded(self) -> None:
+        """CIKs in outcome.failed drop out of the cascade set."""
+        conn = _mock_conn_with_cik_lookup({"0000000001": 101, "0000000002": 102})
+        plan = RefreshPlan(
+            refreshes=[("0000000001", "A"), ("0000000002", "B")],
+        )
+        outcome = RefreshOutcome(
+            refreshed=1,
+            failed=[("0000000002", "RuntimeError")],
+        )
+        result = changed_instruments_from_outcome(conn, plan, outcome)
+        assert result == [101]
+
+    def test_seed_in_refresh_bucket_still_excluded(self) -> None:
+        """Defensive: if a CIK appears in both seeds and refreshes
+        (planner divergence or manual plan), the seed filter wins —
+        no cascade for fresh-install CIKs."""
+        conn = _mock_conn_with_cik_lookup({"0000000001": 101, "0000000002": 102})
+        plan = RefreshPlan(
+            seeds=["0000000001"],
+            refreshes=[("0000000001", "A"), ("0000000002", "B")],
+        )
+        outcome = RefreshOutcome(seeded=1, refreshed=1)
+        result = changed_instruments_from_outcome(conn, plan, outcome)
+        assert result == [102]
+
+
+# ---------------------------------------------------------------------------
+# cascade_refresh
+# ---------------------------------------------------------------------------
+
+
+class TestCascadeRefresh:
+    def test_empty_ids_noop(self) -> None:
+        conn = MagicMock()
+        client = MagicMock()
+        outcome = cascade_refresh(conn, client, [])
+        assert outcome == CascadeOutcome(
+            instruments_considered=0,
+            thesis_refreshed=0,
+            rankings_recomputed=False,
+        )
+        conn.execute.assert_not_called()
+
+    def test_no_stale_instruments_skips_thesis_and_rankings(self) -> None:
+        """If find_stale returns nothing, no Claude calls and no rerank."""
+        conn = MagicMock()
+        client = MagicMock()
+        with (
+            patch(
+                "app.services.refresh_cascade.find_stale_instruments",
+                return_value=[],
+            ) as stale_mock,
+            patch("app.services.refresh_cascade.generate_thesis") as gen_mock,
+            patch("app.services.refresh_cascade.compute_rankings") as rank_mock,
+        ):
+            outcome = cascade_refresh(conn, client, [1, 2, 3])
+
+        stale_mock.assert_called_once_with(conn, tier=None, instrument_ids=[1, 2, 3])
+        gen_mock.assert_not_called()
+        rank_mock.assert_not_called()
+        assert outcome.thesis_refreshed == 0
+        assert outcome.rankings_recomputed is False
+        assert outcome.instruments_considered == 3
+
+    def test_stale_instruments_trigger_thesis_and_single_rerank(self) -> None:
+        """Stale instruments each get generate_thesis; rerank runs once
+        at the end, not per-instrument."""
+        conn = MagicMock()
+        client = MagicMock()
+        stale_rows = [
+            StaleInstrument(instrument_id=1, symbol="A", reason="event_new_10q"),
+            StaleInstrument(instrument_id=2, symbol="B", reason="event_new_8k"),
+        ]
+        with (
+            patch(
+                "app.services.refresh_cascade.find_stale_instruments",
+                return_value=stale_rows,
+            ),
+            patch("app.services.refresh_cascade.generate_thesis") as gen_mock,
+            patch(
+                "app.services.refresh_cascade.compute_rankings",
+                return_value=MagicMock(scored=[MagicMock(), MagicMock()]),
+            ) as rank_mock,
+        ):
+            outcome = cascade_refresh(conn, client, [1, 2])
+
+        assert gen_mock.call_count == 2
+        rank_mock.assert_called_once_with(conn)
+        assert outcome.thesis_refreshed == 2
+        assert outcome.rankings_recomputed is True
+        assert outcome.failed == []
+
+    def test_per_instrument_failure_isolated_rerank_still_runs(self) -> None:
+        """One instrument's thesis raising must not abort siblings,
+        and a successful sibling still triggers the rerank."""
+        conn = MagicMock()
+        client = MagicMock()
+        stale_rows = [
+            StaleInstrument(instrument_id=1, symbol="BAD", reason="event_new_10k"),
+            StaleInstrument(instrument_id=2, symbol="GOOD", reason="event_new_10q"),
+        ]
+
+        def gen_side_effect(iid, conn_, client_):  # type: ignore[no-untyped-def]
+            if iid == 1:
+                raise RuntimeError("boom")
+            return MagicMock()
+
+        with (
+            patch(
+                "app.services.refresh_cascade.find_stale_instruments",
+                return_value=stale_rows,
+            ),
+            patch(
+                "app.services.refresh_cascade.generate_thesis",
+                side_effect=gen_side_effect,
+            ),
+            patch(
+                "app.services.refresh_cascade.compute_rankings",
+                return_value=MagicMock(scored=[]),
+            ) as rank_mock,
+        ):
+            outcome = cascade_refresh(conn, client, [1, 2])
+
+        assert outcome.thesis_refreshed == 1
+        assert ("RuntimeError") in {e[1] for e in outcome.failed}
+        rank_mock.assert_called_once()
+        assert outcome.rankings_recomputed is True
+
+    def test_all_thesis_fail_no_rerank(self) -> None:
+        """If zero theses refreshed, skip the rerank — nothing changed."""
+        conn = MagicMock()
+        client = MagicMock()
+        stale_rows = [StaleInstrument(instrument_id=1, symbol="BAD", reason="event_new_10q")]
+        with (
+            patch(
+                "app.services.refresh_cascade.find_stale_instruments",
+                return_value=stale_rows,
+            ),
+            patch(
+                "app.services.refresh_cascade.generate_thesis",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("app.services.refresh_cascade.compute_rankings") as rank_mock,
+        ):
+            outcome = cascade_refresh(conn, client, [1])
+
+        assert outcome.thesis_refreshed == 0
+        rank_mock.assert_not_called()
+        assert outcome.rankings_recomputed is False
+
+    def test_rerank_failure_records_and_returns(self) -> None:
+        """compute_rankings raising is captured in failed with sentinel
+        instrument_id=-1 and the cascade still returns the thesis
+        refresh count."""
+        conn = MagicMock()
+        client = MagicMock()
+        stale_rows = [StaleInstrument(instrument_id=1, symbol="A", reason="event_new_10q")]
+        with (
+            patch(
+                "app.services.refresh_cascade.find_stale_instruments",
+                return_value=stale_rows,
+            ),
+            patch("app.services.refresh_cascade.generate_thesis"),
+            patch(
+                "app.services.refresh_cascade.compute_rankings",
+                side_effect=RuntimeError("scoring broke"),
+            ),
+        ):
+            outcome = cascade_refresh(conn, client, [1])
+
+        assert outcome.thesis_refreshed == 1
+        assert outcome.rankings_recomputed is False
+        assert (-1, "RuntimeError") in outcome.failed
+        # Rollback invoked so the aborted-transaction state from the
+        # failed compute_rankings SQL does not leak out of the cascade.
+        conn.rollback.assert_called()


### PR DESCRIPTION
## What
Adds Phase 3 to `daily_financial_facts`: after SEC facts + normalization commit, cascade to thesis + rankings.

- `app/services/refresh_cascade.py` — `changed_instruments_from_outcome()` (CIK → instrument_id, drops seeds + failed CIKs) and `cascade_refresh()` (per-stale `generate_thesis` then single `compute_rankings`).
- `app/workers/scheduler.py::daily_financial_facts` — explicit `conn.commit()` before cascade so reads see Phase 1+2 committed state (normalization uses savepoints). Gated on `ANTHROPIC_API_KEY`.
- `tests/test_refresh_cascade.py` — 12 mock-based unit tests.

## Why
Closes the event-driven propagation chain from #271 (SEC incremental) → #273 (event predicate) → Claude thesis + global rerank in one daily run.

## Test plan
- [x] `uv run pytest tests/test_refresh_cascade.py -v` — 12 passed
- [x] Full suite 1855 passed, 1 skipped
- [x] ruff check + format + pyright clean
- [x] Codex pre-push review — no BLOCKER/HIGH; LOW findings addressed (defensive seed filter, rerank rollback, docstring fix, extra regression test)

## Deferrals
- Integration-level rollback/transaction-recovery test (requires real DB fixture) → K.3
- Retry outbox → K.2
- Advisory lock against `daily_thesis_refresh` → K.3
- Orchestrator freshness + observability → K.4