### PR TITLE
feat(#276): cascade retry outbox (K.2)

### DIFF
--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -176,12 +176,20 @@ def enqueue_rerank_marker(
     """UPSERT a RERANK_NEEDED marker for a thesis-success-then-
     rerank-failure instrument.
 
-    Sets ``attempt_count=0`` so rerank failures do NOT consume the
-    thesis retry budget. On CONFLICT, resets any prior thesis-
-    failure state (including at-cap rows) to RERANK_NEEDED /
+    Sets ``attempt_count=0`` so a pure rerank failure does NOT
+    consume the thesis retry budget. On CONFLICT, resets any prior
+    thesis-failure state (including at-cap rows) to RERANK_NEEDED /
     attempt_count=0 — a thesis success this cycle means the prior
     blocker is no longer current and the row must be drainable
     again for the next rerank attempt.
+
+    Note on budget accounting: if the NEXT cycle drains this row
+    and the thesis regeneration itself then fails, ``enqueue_retry``
+    transitions the row into the thesis-failure path and increments
+    attempt_count from 0 to 1. That is intentional — a genuine
+    thesis failure on retry IS a consumed thesis attempt. The zero
+    budget-cost guarantee covers the rerank-only failure event
+    itself, not arbitrary downstream thesis failures on retry.
     """
     with conn.transaction():
         conn.execute(

--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -136,10 +136,18 @@ def enqueue_retry(
     """UPSERT a retry row after a thesis failure.
 
     Caller MUST ``conn.rollback()`` before invoking this if the
-    connection is in INERROR state from the failing thesis call —
-    the helper wraps its own ``with conn.transaction()`` so the
-    outbox write commits independently of any outer transaction,
-    but it cannot succeed on an aborted connection.
+    connection is in INERROR state from the failing thesis call.
+
+    Transaction semantics: ``with conn.transaction():`` opens a
+    new transaction when the connection has no open tx, or a
+    savepoint when nested. In cascade_refresh's flow the outer
+    conn has read transactions from drain_retry_queue /
+    find_stale_instruments, so this write lands on a savepoint —
+    durable only after the scheduler's ``conn.commit()`` that
+    follows ``cascade_refresh`` returning. The scheduler commits
+    immediately after cascade_refresh returns and before the
+    failure-surfacing raise, so in practice the outbox write is
+    durable whenever cascade_refresh exits cleanly.
 
     ``attempt_count`` semantics: first enqueue sets 1. Subsequent
     thesis failures increment by 1. A pre-existing RERANK_NEEDED
@@ -292,7 +300,14 @@ def cascade_refresh(
                 )
             try:
                 enqueue_retry(conn, iid, type(exc).__name__)
-            except psycopg.Error:
+            except Exception:
+                # Broad catch intentional: any exception from the helper
+                # (psycopg error, programming bug, context manager
+                # machinery) must NOT break the per-instrument
+                # isolation guarantee and abort remaining siblings.
+                # The retry signal for this iid is lost this cycle;
+                # the instrument re-enters the cascade on the next run
+                # via the #273 event predicate.
                 logger.exception(
                     "cascade_refresh: enqueue_retry failed for instrument_id=%d — retry signal lost",
                     iid,
@@ -327,7 +342,14 @@ def cascade_refresh(
                 )
             try:
                 enqueue_retry(conn, iid, type(exc).__name__)
-            except psycopg.Error:
+            except Exception:
+                # Broad catch intentional: any exception from the helper
+                # (psycopg error, programming bug, context manager
+                # machinery) must NOT break the per-instrument
+                # isolation guarantee and abort remaining siblings.
+                # The retry signal for this iid is lost this cycle;
+                # the instrument re-enters the cascade on the next run
+                # via the #273 event predicate.
                 logger.exception(
                     "cascade_refresh: enqueue_retry failed for instrument_id=%d — retry signal lost",
                     iid,
@@ -352,7 +374,11 @@ def cascade_refresh(
             for iid in processed_ok:
                 try:
                     clear_retry_success(conn, iid)
-                except psycopg.Error:
+                except Exception:
+                    # Broad catch — see enqueue_retry rationale above.
+                    # A failed clear leaves the row for the next
+                    # cycle to re-process (idempotent / wasted-but-
+                    # safe thesis call), not an incorrect state.
                     logger.exception("cascade_refresh: clear_retry_success failed for instrument_id=%d", iid)
         except Exception as exc:
             # Rollback FIRST — compute_rankings is SQL-heavy and
@@ -374,7 +400,11 @@ def cascade_refresh(
             for iid in processed_ok:
                 try:
                     enqueue_rerank_marker(conn, iid)
-                except psycopg.Error:
+                except Exception:
+                    # Broad catch — non-psycopg failures from the
+                    # helper (programming bug, CM internals) must
+                    # not abort the marker loop and lose the signal
+                    # for the remaining processed_ok ids.
                     logger.exception(
                         "cascade_refresh: enqueue_rerank_marker failed for instrument_id=%d — "
                         "rankings-recompute signal lost for this instrument",

--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -3,15 +3,23 @@
 After ``daily_financial_facts`` commits new fundamentals + normalizes
 periods, this service propagates the change to thesis and scoring:
 
-1. Map the refresh plan's successful CIKs (refreshes + submissions-
+1. Drain the durable retry outbox (K.2). Queued instruments bypass
+   the stale gate — the outbox IS the signal that a thesis refresh
+   is owed from a prior failure.
+2. Map the refresh plan's successful CIKs (refreshes + submissions-
    only, minus per-CIK failures) to instrument_ids.
-2. For each instrument, check ``find_stale_instruments`` — the event-
+3. For each instrument, check ``find_stale_instruments`` — the event-
    driven predicate shipped in #273 flags any whose thesis lags a
    qualifying filing.
-3. Generate a fresh thesis (Claude) for each stale instrument.
-4. If any thesis refreshed this cycle, re-run ``compute_rankings``
+4. Generate a fresh thesis (Claude) for each queued retry + each
+   stale instrument.
+5. If any thesis refreshed this cycle, re-run ``compute_rankings``
    once for the full pool — scoring reads thesis fields so fresh
    theses can move every score, not just the cascade's subset.
+6. Clear retry-queue rows for processed successes ONLY after the
+   rerank succeeds. Rerank failure leaves the rows (and marks new-
+   work successes with a RERANK_NEEDED marker) so the next cycle
+   has a durable "rankings recompute needed" signal.
 
 The full-pool rerank is the Option-α scoring approach from the
 master plan — subset scoring was ruled out because ``compute_rankings``
@@ -20,8 +28,7 @@ pool would have NULL / mismatched rank values.
 
 Per-instrument thesis failures are isolated — one bad CIK does not
 abort the loop or the subsequent rerank. Future K.3 adds session-
-level advisory locking against ``daily_thesis_refresh``; future K.2
-adds a durable retry outbox. K.1 (this module) is the basic wiring.
+level advisory locking against ``daily_thesis_refresh``.
 """
 
 from __future__ import annotations
@@ -39,6 +46,9 @@ from app.services.thesis import find_stale_instruments, generate_thesis
 
 logger = logging.getLogger(__name__)
 
+ATTEMPT_CAP: int = 5
+RERANK_MARKER: str = "RERANK_NEEDED"
+
 
 @dataclass(frozen=True)
 class CascadeOutcome:
@@ -53,6 +63,7 @@ class CascadeOutcome:
     instruments_considered: int
     thesis_refreshed: int
     rankings_recomputed: bool
+    retries_drained: int = 0
     failed: tuple[tuple[int, str], ...] = ()
 
 
@@ -112,61 +123,201 @@ def changed_instruments_from_outcome(
     return [int(r[0]) for r in rows]
 
 
+# ---------------------------------------------------------------------------
+# Retry outbox helpers (K.2)
+# ---------------------------------------------------------------------------
+
+
+def enqueue_retry(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    error_type: str,
+) -> None:
+    """UPSERT a retry row after a thesis failure.
+
+    Caller MUST ``conn.rollback()`` before invoking this if the
+    connection is in INERROR state from the failing thesis call —
+    the helper wraps its own ``with conn.transaction()`` so the
+    outbox write commits independently of any outer transaction,
+    but it cannot succeed on an aborted connection.
+
+    ``attempt_count`` semantics: first enqueue sets 1. Subsequent
+    thesis failures increment by 1. A pre-existing RERANK_NEEDED
+    marker (attempt_count=0) transitions into the thesis-failure
+    path here — the UPDATE increments from 0 to 1 as expected.
+    """
+    with conn.transaction():
+        conn.execute(
+            """
+            INSERT INTO cascade_retry_queue
+                (instrument_id, attempt_count, last_error, last_attempted_at)
+            VALUES (%s, 1, %s, NOW())
+            ON CONFLICT (instrument_id) DO UPDATE SET
+                attempt_count = cascade_retry_queue.attempt_count + 1,
+                last_error = EXCLUDED.last_error,
+                last_attempted_at = NOW()
+            """,
+            (instrument_id, error_type),
+        )
+
+
+def enqueue_rerank_marker(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> None:
+    """UPSERT a RERANK_NEEDED marker for a thesis-success-then-
+    rerank-failure instrument.
+
+    Sets ``attempt_count=0`` so rerank failures do NOT consume the
+    thesis retry budget. On CONFLICT, resets any prior thesis-
+    failure state (including at-cap rows) to RERANK_NEEDED /
+    attempt_count=0 — a thesis success this cycle means the prior
+    blocker is no longer current and the row must be drainable
+    again for the next rerank attempt.
+    """
+    with conn.transaction():
+        conn.execute(
+            """
+            INSERT INTO cascade_retry_queue
+                (instrument_id, attempt_count, last_error, last_attempted_at)
+            VALUES (%s, 0, %s, NOW())
+            ON CONFLICT (instrument_id) DO UPDATE SET
+                attempt_count = 0,
+                last_error = EXCLUDED.last_error,
+                last_attempted_at = NOW()
+            """,
+            (instrument_id, RERANK_MARKER),
+        )
+
+
+def clear_retry_success(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> None:
+    """DELETE the retry row for an instrument whose cascade succeeded
+    this cycle (thesis refreshed + rerank succeeded). Idempotent —
+    no-op if the row is absent. Wraps its own transaction."""
+    with conn.transaction():
+        conn.execute(
+            "DELETE FROM cascade_retry_queue WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+
+
+def drain_retry_queue(
+    conn: psycopg.Connection[Any],
+    cap: int = ATTEMPT_CAP,
+) -> list[int]:
+    """Return instrument_ids eligible for retry — rows with
+    ``attempt_count < cap``, ordered by ``enqueued_at`` ASC (oldest
+    first). Rows at or above cap are left in place for admin
+    inspection (surfaced in Chunk H / K.4)."""
+    rows = conn.execute(
+        """
+        SELECT instrument_id
+        FROM cascade_retry_queue
+        WHERE attempt_count < %s
+        ORDER BY enqueued_at ASC
+        """,
+        (cap,),
+    ).fetchall()
+    return [int(r[0]) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# cascade_refresh
+# ---------------------------------------------------------------------------
+
+
 def cascade_refresh(
     conn: psycopg.Connection[Any],
     client: anthropic.Anthropic,
     instrument_ids: list[int],
 ) -> CascadeOutcome:
-    """Run the cascade for the given instrument_ids.
+    """Run the cascade.
 
-    For each instrument: ``find_stale_instruments`` (scoped via
-    ``tier=None`` + ``instrument_ids``) decides whether the thesis
-    needs refresh per #273's event-driven predicate. If stale,
-    ``generate_thesis`` is called — it commits its own read tx before
-    Claude per #293 + writes its own thesis row atomically.
-
-    After the thesis loop: if any thesis was refreshed, call
-    ``compute_rankings`` once for the full analysable pool. Scoring
-    reads thesis fields so any thesis change can move every score.
-
-    Per-instrument failures recorded in the outcome; one failure
-    does not abort siblings or the subsequent rerank.
+    Flow:
+    1. Drain the retry outbox — queued instrument_ids bypass the
+       stale gate. Regenerating a thesis that another path already
+       refreshed is idempotent-wasted, not incorrect.
+    2. Run the event-driven stale predicate on ``instrument_ids``.
+    3. For each (retry + stale) instrument, call ``generate_thesis``.
+       Successes accumulate in ``processed_ok`` for deferred clear.
+       Failures roll back first, then enqueue into the outbox in a
+       fresh transaction.
+    4. If any thesis refreshed, run ``compute_rankings`` once.
+       - On rerank success: clear each ``processed_ok`` queue row.
+       - On rerank failure: rollback, record (-1, ExcType) in
+         ``failed``, and UPSERT a RERANK_NEEDED marker for each
+         ``processed_ok`` id — the queue is the durable rankings-
+         recompute signal for the next cycle.
     """
-    if not instrument_ids:
-        return CascadeOutcome(instruments_considered=0, thesis_refreshed=0, rankings_recomputed=False)
+    retry_ids = drain_retry_queue(conn)
+    if retry_ids:
+        logger.info("cascade_refresh: drained %d retries from queue", len(retry_ids))
 
-    stale = find_stale_instruments(conn, tier=None, instrument_ids=instrument_ids)
-    if not stale:
+    stale = find_stale_instruments(conn, tier=None, instrument_ids=instrument_ids) if instrument_ids else []
+
+    if not retry_ids and not stale:
         logger.info(
-            "cascade_refresh: %d instruments considered, 0 stale — no thesis or score refresh",
+            "cascade_refresh: %d instruments considered, 0 stale, 0 retries — no thesis or score refresh",
             len(instrument_ids),
         )
         return CascadeOutcome(
             instruments_considered=len(instrument_ids),
             thesis_refreshed=0,
             rankings_recomputed=False,
+            retries_drained=0,
         )
 
     thesis_refreshed = 0
     failed: list[tuple[int, str]] = []
+    processed_ok: list[int] = []
 
-    for stale_instrument in stale:
+    # Retry path — bypass stale gate. Outbox IS the signal.
+    retry_set = set(retry_ids)
+    for iid in retry_ids:
         try:
-            generate_thesis(stale_instrument.instrument_id, conn, client)
+            generate_thesis(iid, conn, client)
             thesis_refreshed += 1
+            processed_ok.append(iid)
+            logger.info("cascade_refresh: retry thesis refreshed for instrument_id=%d", iid)
+        except Exception as exc:
+            try:
+                conn.rollback()
+            except psycopg.Error:
+                logger.debug(
+                    "cascade_refresh: rollback suppressed after retry thesis exception",
+                    exc_info=True,
+                )
+            try:
+                enqueue_retry(conn, iid, type(exc).__name__)
+            except psycopg.Error:
+                logger.exception(
+                    "cascade_refresh: enqueue_retry failed for instrument_id=%d — retry signal lost",
+                    iid,
+                )
+            failed.append((iid, type(exc).__name__))
+            logger.exception("cascade_refresh: retry thesis failed for instrument_id=%d", iid)
+
+    # New-work (stale) path — skip any ids already processed in the
+    # retry loop so a queued CIK that also surfaces as stale is only
+    # generated once per cycle.
+    for stale_instrument in stale:
+        iid = stale_instrument.instrument_id
+        if iid in retry_set:
+            continue
+        try:
+            generate_thesis(iid, conn, client)
+            thesis_refreshed += 1
+            processed_ok.append(iid)
             logger.info(
                 "cascade_refresh: thesis refreshed for instrument_id=%d symbol=%s reason=%s",
-                stale_instrument.instrument_id,
+                iid,
                 stale_instrument.symbol,
                 stale_instrument.reason,
             )
         except Exception as exc:
-            # Attempt to roll back any half-open tx from generate_thesis
-            # before continuing to siblings. generate_thesis wraps its
-            # DB write in its own `with conn.transaction():` so the
-            # failing CIK's row was already rolled back — this is
-            # belt-and-braces for the pre-transaction reads that
-            # opened the implicit tx before the Claude call failed.
             try:
                 conn.rollback()
             except psycopg.Error:
@@ -174,10 +325,17 @@ def cascade_refresh(
                     "cascade_refresh: rollback suppressed after thesis exception",
                     exc_info=True,
                 )
-            failed.append((stale_instrument.instrument_id, type(exc).__name__))
+            try:
+                enqueue_retry(conn, iid, type(exc).__name__)
+            except psycopg.Error:
+                logger.exception(
+                    "cascade_refresh: enqueue_retry failed for instrument_id=%d — retry signal lost",
+                    iid,
+                )
+            failed.append((iid, type(exc).__name__))
             logger.exception(
                 "cascade_refresh: thesis failed for instrument_id=%d symbol=%s",
-                stale_instrument.instrument_id,
+                iid,
                 stale_instrument.symbol,
             )
 
@@ -190,7 +348,17 @@ def cascade_refresh(
                 "cascade_refresh: rankings recomputed — %d scored",
                 len(ranking_result.scored),
             )
+            # Clear processed queue rows AFTER successful rerank.
+            for iid in processed_ok:
+                try:
+                    clear_retry_success(conn, iid)
+                except psycopg.Error:
+                    logger.exception("cascade_refresh: clear_retry_success failed for instrument_id=%d", iid)
         except Exception as exc:
+            # Rollback FIRST — compute_rankings is SQL-heavy and
+            # can leave the connection in INERROR; the subsequent
+            # marker inserts would otherwise fail, losing the
+            # durable signal for exactly the path it must preserve.
             try:
                 conn.rollback()
             except psycopg.Error:
@@ -200,11 +368,24 @@ def cascade_refresh(
                 )
             failed.append((-1, type(exc).__name__))  # -1 sentinel for non-instrument failure
             logger.exception("cascade_refresh: compute_rankings failed after thesis refresh")
+            # UPSERT RERANK_NEEDED markers for each processed_ok id
+            # so the next cycle re-drains them even if there was no
+            # pre-existing row (new-work success path).
+            for iid in processed_ok:
+                try:
+                    enqueue_rerank_marker(conn, iid)
+                except psycopg.Error:
+                    logger.exception(
+                        "cascade_refresh: enqueue_rerank_marker failed for instrument_id=%d — "
+                        "rankings-recompute signal lost for this instrument",
+                        iid,
+                    )
 
     logger.info(
-        "cascade_refresh summary: considered=%d stale=%d thesis_refreshed=%d rankings=%s failed=%d",
+        "cascade_refresh summary: considered=%d stale=%d retries_drained=%d thesis_refreshed=%d rankings=%s failed=%d",
         len(instrument_ids),
         len(stale),
+        len(retry_ids),
         thesis_refreshed,
         rankings_recomputed,
         len(failed),
@@ -214,5 +395,6 @@ def cascade_refresh(
         instruments_considered=len(instrument_ids),
         thesis_refreshed=thesis_refreshed,
         rankings_recomputed=rankings_recomputed,
+        retries_drained=len(retry_ids),
         failed=tuple(failed),
     )

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1215,50 +1215,57 @@ def daily_financial_facts() -> None:
                     changed_instruments_from_outcome,
                 )
 
+                # Cascade fires unconditionally when the API key is
+                # set so the retry outbox (K.2) gets drained even on
+                # days with zero new SEC work. ``cascade_refresh``
+                # returns the empty-noop CascadeOutcome when both
+                # the retry queue and instrument_ids are empty.
                 changed_ids = changed_instruments_from_outcome(conn, plan, outcome)
-                if changed_ids:
-                    cascade_client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
-                    cascade_outcome = cascade_refresh(conn, cascade_client, changed_ids)
-                    # Persist any cascade-side writes before the
-                    # failure-surfacing raise below. compute_rankings
-                    # writes score rows inside a
-                    # ``with conn.transaction():`` block that may be
-                    # nested as a savepoint under this connection's
-                    # implicit outer tx — without this explicit
-                    # commit, the raise propagates to
-                    # psycopg.connect()'s CM rollback and discards
-                    # any successful ranking writes. On the failure
-                    # path where compute_rankings itself rolled back
-                    # (cascade_refresh's inner handler), this commit
-                    # is a no-op on clean state. Thesis rows are
-                    # already durably committed by generate_thesis
-                    # per #293 and are unaffected either way.
-                    conn.commit()
-                    logger.info(
-                        "cascade_refresh outcome: considered=%d thesis_refreshed=%d rankings=%s failed=%d",
-                        cascade_outcome.instruments_considered,
-                        cascade_outcome.thesis_refreshed,
-                        cascade_outcome.rankings_recomputed,
-                        len(cascade_outcome.failed),
+                cascade_client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+                cascade_outcome = cascade_refresh(conn, cascade_client, changed_ids)
+                # Persist any cascade-side writes before the
+                # failure-surfacing raise below. compute_rankings
+                # writes score rows inside a
+                # ``with conn.transaction():`` block that may be
+                # nested as a savepoint under this connection's
+                # implicit outer tx — without this explicit
+                # commit, the raise propagates to
+                # psycopg.connect()'s CM rollback and discards
+                # any successful ranking writes AND any retry-queue
+                # mutations made by cascade's deferred-clear /
+                # marker path. On the failure path where
+                # compute_rankings itself rolled back (cascade_refresh's
+                # inner handler), this commit is a no-op on clean
+                # state. Thesis rows are already durably committed
+                # by generate_thesis per #293 and are unaffected
+                # either way.
+                conn.commit()
+                logger.info(
+                    "cascade_refresh outcome: considered=%d retries_drained=%d "
+                    "thesis_refreshed=%d rankings=%s failed=%d",
+                    cascade_outcome.instruments_considered,
+                    cascade_outcome.retries_drained,
+                    cascade_outcome.thesis_refreshed,
+                    cascade_outcome.rankings_recomputed,
+                    len(cascade_outcome.failed),
+                )
+                # Surface cascade failures to the tracked job —
+                # per-instrument thesis failures AND the -1
+                # rerank-sentinel. Without this, SEC watermarks
+                # would be committed while the cascade silently
+                # fell behind, and ops health would still show
+                # status=success. Facts/normalization/cascade
+                # writes remain durably committed (commits
+                # happened above). Re-entry path on next run:
+                # the K.2 retry outbox durably flags any failed
+                # instrument so the next cycle re-drains it;
+                # rerank failures leave RERANK_NEEDED markers so
+                # the next run re-computes rankings too.
+                if cascade_outcome.failed:
+                    raise RuntimeError(
+                        f"cascade_refresh completed with {len(cascade_outcome.failed)} failures: "
+                        f"{cascade_outcome.failed}"
                     )
-                    # Surface cascade failures to the tracked job —
-                    # per-instrument thesis failures AND the -1
-                    # rerank-sentinel. Without this, SEC watermarks
-                    # would be committed while the cascade silently
-                    # fell behind, and ops health would still show
-                    # status=success. Facts/normalization/cascade
-                    # writes remain durably committed (commits
-                    # happened above). Re-entry path on next run:
-                    # find_stale_instruments (#273) uses
-                    # filing_events.created_at > thesis_generated_at,
-                    # so any instrument whose thesis we failed to
-                    # refresh this run remains stale and re-enters
-                    # the cascade next run.
-                    if cascade_outcome.failed:
-                        raise RuntimeError(
-                            f"cascade_refresh completed with {len(cascade_outcome.failed)} failures: "
-                            f"{cascade_outcome.failed}"
-                        )
             else:
                 logger.info(
                     "daily_financial_facts: ANTHROPIC_API_KEY not set — "

--- a/docs/superpowers/specs/2026-04-18-cascade-retry-outbox-design.md
+++ b/docs/superpowers/specs/2026-04-18-cascade-retry-outbox-design.md
@@ -1,0 +1,257 @@
+# Cascade retry outbox (#276 K.2) — design v2
+
+**Goal:** durable retry queue for per-instrument cascade failures. Closes the post-K.1 gap where SEC watermarks commit before cascade, so a cascade failure never triggers a re-plan of the same CIK on the next `daily_financial_facts` run.
+
+**Scope:** K.2 only. K.3 (advisory lock) and K.4 (observability) are separate follow-ups.
+
+**Revision history:**
+- v1: initial proposal.
+- v2: Codex-driven rewrite. Changes: retry path bypasses stale gate, enqueue happens in a fresh tx after rollback, clear-on-success is non-atomic-but-idempotent, scheduler always invokes cascade on api-key-set days, attempt_count semantics pinned.
+
+---
+
+## Problem
+
+Post-K.1 state:
+
+- `daily_financial_facts` commits SEC facts + normalization before calling `cascade_refresh`.
+- Cascade per-instrument thesis failure → `CascadeOutcome.failed` entry → scheduler raises RuntimeError so `_tracked_job` records failure.
+- Next run's `plan_refresh`: watermarks already advanced, same CIK is not in `plan.refreshes`.
+- Re-entry via the event predicate (`filing_events.created_at > thesis_generated_at`) works **only** when `filing_events` row for this CIK remains newer than thesis. True on the next run — but fragile:
+  - If thesis row was partially written (unlikely given #293's commit-before-Claude + atomic write, but possible on unexpected DB error), the predicate comparison can miss.
+  - If another path (manual thesis refresh, `daily_thesis_refresh`) wrote a thesis after the failure, the event predicate drops the CIK from the stale set — cascade never retries the failure.
+  - No visibility / retry cap — a broken CIK silently retries forever or silently drops forever, with no ops signal.
+
+Master plan K.2 specifies a durable outbox to make retries deterministic and observable.
+
+## Non-goals
+
+- Advisory locking against `daily_thesis_refresh` concurrent writes (K.3).
+- Admin UI surface for queue rows at attempt cap (K.4 or Chunk H).
+- Retry queue observability / freshness predicate integration (K.4).
+
+---
+
+## Schema — migration 037
+
+```sql
+CREATE TABLE cascade_retry_queue (
+    instrument_id     BIGINT PRIMARY KEY REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    enqueued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_attempted_at TIMESTAMPTZ,
+    attempt_count     INTEGER NOT NULL DEFAULT 0,
+    last_error        TEXT NOT NULL,
+    CONSTRAINT cascade_retry_queue_attempt_count_nonneg
+        CHECK (attempt_count >= 0)
+);
+
+CREATE INDEX idx_cascade_retry_queue_enqueued
+    ON cascade_retry_queue(enqueued_at);
+```
+
+`ON DELETE CASCADE` per Codex LOW — eBull does not hard-delete instruments today, but the defensive FK is trivial. No backfill migration — queue starts empty.
+
+## Attempt-count semantics (fixed per Codex HIGH)
+
+`attempt_count` = **number of failed attempts observed so far**.
+
+| Event | `attempt_count` after |
+|---|---|
+| No prior row, failure → INSERT | 1 |
+| Existing row, subsequent failure → UPDATE | +1 |
+| K.3 LOCKED_BY_SIBLING, no prior row | 0 (fresh row, no attempt consumed) |
+| K.3 LOCKED_BY_SIBLING, existing row | unchanged |
+| Success → DELETE | row gone |
+
+Eligible for drain: `attempt_count < ATTEMPT_CAP (5)`.
+
+## Module changes — `app/services/refresh_cascade.py`
+
+New constants and helpers:
+
+```python
+ATTEMPT_CAP: int = 5
+
+def enqueue_retry(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    error_type: str,
+) -> None:
+    """UPSERT a retry row in its OWN transaction. Safe to call on a
+    connection that was just rolled back from a failed generate_thesis
+    — this function wraps its write in ``with conn.transaction():``
+    so it commits independently.
+
+    INSERT ... ON CONFLICT (instrument_id) DO UPDATE SET
+        attempt_count = cascade_retry_queue.attempt_count + 1,
+        last_error = EXCLUDED.last_error,
+        last_attempted_at = NOW()
+    — on first enqueue ``DEFAULT 0 + 1 = 1`` via an INSERT-side
+    ``attempt_count = 1``. INSERT sets count=1, UPDATE increments.
+    """
+
+def clear_retry_success(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> None:
+    """DELETE the retry row — idempotent (no-op if row absent).
+    Wraps in its own ``with conn.transaction():`` so it commits
+    independently of generate_thesis's internal commit."""
+
+def drain_retry_queue(
+    conn: psycopg.Connection[Any],
+    cap: int = ATTEMPT_CAP,
+) -> list[int]:
+    """SELECT instrument_id FROM cascade_retry_queue
+    WHERE attempt_count < cap
+    ORDER BY enqueued_at ASC
+    — oldest first. Rows at or above cap are left for admin
+    inspection (surfaced in Chunk H / K.4)."""
+
+def enqueue_rerank_marker(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> None:
+    """Insert a RERANK_NEEDED marker for an instrument whose
+    thesis refreshed successfully this cycle but whose rerank then
+    failed. attempt_count stays 0 — rerank failures do not consume
+    the thesis retry budget.
+
+    INSERT ... ON CONFLICT (instrument_id) DO UPDATE SET
+        last_error = 'RERANK_NEEDED',
+        attempt_count = 0,
+        last_attempted_at = NOW()
+    — thesis succeeded this cycle, so any prior thesis-failure
+    state (including at-cap rows) is no longer the current blocker;
+    resetting to RERANK_NEEDED / attempt_count=0 makes the row
+    drainable again so the next cycle can re-attempt rerank.
+    Wraps in its own ``with conn.transaction():``."""
+```
+
+### cascade_refresh flow changes
+
+`cascade_refresh` signature unchanged. Body reorganized:
+
+1. **Entry**: `retry_ids = drain_retry_queue(conn)`. Log `cascade_refresh: drained N retries`.
+2. **Processed-success tracking**: local `processed_ok: list[int] = []`. This defers all queue-clear operations to AFTER `compute_rankings` succeeds (Codex v2 HIGH 2 — otherwise a thesis-succeeds-then-rerank-fails run loses the durable retry signal).
+3. **Retry path** (bypasses stale gate, per Codex v1 BLOCKER 2):
+   - For each `iid` in `retry_ids`:
+     - Call `generate_thesis(iid, conn, client)` directly — the outbox IS the signal that this instrument needs a thesis refresh.
+     - On success: `processed_ok.append(iid)`, increment `thesis_refreshed`. (Queue not yet cleared.)
+     - On failure: `conn.rollback()` first (Codex v1 HIGH 1), then `enqueue_retry(conn, iid, exc_type)` in a fresh tx, append to `failed`.
+4. **New-work path** (existing stale-gated path):
+   - `stale = find_stale_instruments(conn, tier=None, instrument_ids=instrument_ids)` — unchanged.
+   - For each stale row: same try/except as today.
+   - On per-instrument success: `processed_ok.append(iid)`.
+   - On per-instrument failure: `conn.rollback()` first, then `enqueue_retry(conn, iid, exc_type)` in a fresh tx, then `failed.append(...)`.
+5. **Rerank**:
+   - On rerank success: for each `iid` in `processed_ok`, call `clear_retry_success(conn, iid)`. Any pre-existing queue rows and any new-work successes resolve together.
+   - On rerank failure: first `conn.rollback()` (mirrors the thesis-failure pattern — `compute_rankings` is SQL-heavy and can leave the connection INERROR; without this, the subsequent marker inserts would fail and the durable signal would be lost for exactly the path it is meant to preserve). Then record `(-1, ExcType)` in `failed`. Then iterate `processed_ok` and call `enqueue_rerank_marker(conn, iid)` for each. The helper UPSERTs with `ON CONFLICT DO UPDATE` to RERANK_NEEDED / `attempt_count=0`, which resets any pre-existing at-cap thesis-failure state — a thesis success this cycle means the prior thesis-failure blocker is no longer current. `attempt_count=0` keeps the retry budget scoped to thesis failures; rerank failures do not consume it.
+6. **Short-circuit**: if `retry_ids` and `instrument_ids` are both empty AND `stale` is empty, return noop outcome (no-op run).
+
+### Why retry path bypasses stale gate (Codex BLOCKER 2 resolution)
+
+Stale gate exists to avoid spurious thesis calls for instruments with no new events. Queued retries are already known to need a thesis — the enqueue happened *because* the thesis failed. Re-checking stale state on a queued retry would drop instruments whose thesis was subsequently generated by another path (manual / `daily_thesis_refresh`) while leaving the queue row in place, causing both (a) missed ranking refresh and (b) permanently stuck queue row.
+
+Trade-off: occasionally we regenerate a thesis that was just generated elsewhere. That's a bounded wasted Claude call, not a correctness issue. Thesis writes are per-cycle idempotent.
+
+## Transaction semantics (fixed per Codex HIGH 1, HIGH 2)
+
+- **Enqueue after failure**: rollback the outer connection first to clear any `INERROR` state from the failed thesis, THEN call `enqueue_retry` which opens its own fresh transaction via `with conn.transaction():`. This guarantees the outbox write is durable even if the pre-thesis read tx was aborted.
+- **Clear on success**: not atomic with the thesis write. `generate_thesis` commits internally per #293; `clear_retry_success` commits in its own subsequent transaction. Crash between the two leaves the queue row in place. **Idempotent recovery**: next cycle drains the row, regenerates thesis (already written, idempotent per the UPSERT pattern in thesis storage), clears the row. Worst case is one extra Claude call, not incorrect state.
+- **Rollback-first, enqueue-second ordering** removes the "discarded outbox write" hazard Codex flagged.
+
+## Scheduler — `app/workers/scheduler.py`
+
+Three changes:
+
+1. **Always invoke cascade when API key is set** (Codex v1 BLOCKER 1 — spec v1 skipped cascade on no-new-SEC-work days, starving the retry queue). Current code:
+
+   ```python
+   changed_ids = changed_instruments_from_outcome(conn, plan, outcome)
+   if changed_ids:
+       cascade_refresh(conn, cascade_client, changed_ids)
+   ```
+
+   Becomes:
+
+   ```python
+   changed_ids = changed_instruments_from_outcome(conn, plan, outcome)
+   cascade_outcome = cascade_refresh(conn, cascade_client, changed_ids)
+   # drain path runs inside even when changed_ids is empty
+   ```
+
+   `cascade_refresh` returns the empty-noop `CascadeOutcome` when both the retry queue and `instrument_ids` are empty.
+
+2. **Preserve the post-cascade `conn.commit()`** (Codex v2 HIGH 1). K.1 placed the commit inside `if changed_ids:` — now that cascade fires unconditionally on api-key-set days, the commit moves outside that gate too. Shape:
+
+   ```python
+   cascade_outcome = cascade_refresh(conn, cascade_client, changed_ids)
+   conn.commit()  # persist cascade-side writes (rankings, queue clears)
+                  # before the failure-surfacing raise below discards
+                  # them via psycopg.connect()'s CM rollback.
+   logger.info("cascade_refresh outcome: ...", ...)
+   if cascade_outcome.failed:
+       raise RuntimeError(...)
+   ```
+
+3. Log message unchanged. Failure-raise logic unchanged.
+
+## Tests
+
+Unit (mock conn) covering:
+
+1. `enqueue_retry` inserts row with `attempt_count=1` on empty queue.
+2. `enqueue_retry` on existing row increments `attempt_count` and updates `last_error` + `last_attempted_at`.
+3. `clear_retry_success` deletes existing row.
+4. `clear_retry_success` is idempotent on empty queue.
+5. `drain_retry_queue` returns rows with `attempt_count < cap`, skipping at-cap rows.
+6. `drain_retry_queue` returns empty list when queue is empty.
+7. `drain_retry_queue` orders by `enqueued_at` ASC.
+8. `cascade_refresh` drains queue and processes retry path BYPASSING `find_stale_instruments`.
+9. `cascade_refresh` retry-path success plus rerank success → `clear_retry_success` called after rerank.
+10. `cascade_refresh` retry-path failure calls `enqueue_retry` (after rollback).
+11. `cascade_refresh` new-work success on an instrument with an existing queue row → queue cleared after rerank (cross-path clearing).
+12. `cascade_refresh` new-work failure calls `enqueue_retry`.
+13. `cascade_refresh` rerank failure does NOT enqueue; processed_ok rows are NOT cleared (durable rankings-needed signal — Codex v2 HIGH 2).
+14. `cascade_refresh` with empty retry queue AND empty `instrument_ids` returns noop outcome — scheduler no-changed-ids drain test.
+15. `cascade_refresh` with empty `instrument_ids` but non-empty queue processes retries.
+16. `cascade_refresh` with thesis success AND rerank failure: queue rows for processed_ok stay, so next run re-processes.
+17. `cascade_refresh` new-work thesis success (no prior queue row) AND rerank failure: `enqueue_rerank_marker` inserts a fresh RERANK_NEEDED row with `attempt_count=0`; next cycle re-drains, rerank succeeds, row cleared (Codex v3 HIGH regression cover).
+18. `cascade_refresh` pre-existing at-cap row AND thesis success this cycle AND rerank failure: `enqueue_rerank_marker` upserts the row to RERANK_NEEDED with `attempt_count=0`, making it drainable again — confirms Codex v4 at-cap-conflict fix.
+19. `cascade_refresh` rerank failure path calls `conn.rollback()` BEFORE any `enqueue_rerank_marker` call; verified by setting the mock conn into a simulated aborted state and confirming the markers still write.
+
+Integration (real DB, `tests/test_cascade_retry_queue_integration.py`):
+
+20. Run one cascade cycle that fails for one CIK → queue row present with `attempt_count=1`.
+21. Second cycle with no new `changed_ids`: drain runs, retry processed, rerank success clears row.
+22. Attempt cap: 5 consecutive failures → row has `attempt_count=5`, 6th drain skips it.
+23. Thesis success + rerank failure (new-work or retry): queue carries markers/rows → next cycle recovers and clears.
+24. Enqueue in fresh tx after simulated conn error (manually put conn into aborted state, call rollback-first then enqueue_retry, verify row exists after full commit).
+25. Scheduler end-to-end: `daily_financial_facts` with zero `plan.refreshes` but non-empty queue still invokes cascade and drains.
+
+## Migration application
+
+Standard `sql/037_cascade_retry_queue.sql`. Applied by existing migration runner in `app/main.py` lifespan.
+
+## Out of scope / deferrals
+
+- **K.3 advisory lock**: `LOCKED_BY_SIBLING` write semantics already specified in the attempt-count table.
+- **Admin UI**: rows at or above cap left for inspection; surfacing them is Chunk H / K.4 scope.
+- **Metrics export**: queue depth / at-cap counts for Grafana — K.4.
+- **Concurrent enqueue/clear race**: prevented by K.3 advisory lock, not K.2. Within K.2, the PK + `ON CONFLICT` UPSERT handles concurrent enqueues from multiple cascade invocations safely at the DB level; a concurrent clear-followed-by-enqueue could theoretically resurrect a cleared row, but that is exactly the desired behavior (failure after success should re-enqueue).
+
+## Risks
+
+- **Stuck rows**: if `last_error` is transient (network), the instrument retries every cycle until cap; if permanent (schema mismatch), cap prevents infinite retry. Five attempts is conservative — K.4 can tune based on observed failure modes.
+- **Queue growth**: bounded by the universe size (PK on instrument_id). Worst case one row per analysable instrument, cleared on next successful cycle.
+- **Wasted Claude calls on cross-path refresh**: bounded by queue size. Accepted trade-off per the stale-gate-bypass rationale.
+
+## Shipping order
+
+1. Migration 037.
+2. Three DB helper functions with unit tests (1-7).
+3. Wire into `cascade_refresh` with retry-first path (tests 8-15).
+4. Scheduler edit: always invoke cascade on api-key-set days (test 21).
+5. Integration tests 16-20.
+6. Gates + Codex pre-push review + PR.

--- a/sql/037_cascade_retry_queue.sql
+++ b/sql/037_cascade_retry_queue.sql
@@ -1,0 +1,39 @@
+-- Migration 037: cascade_retry_queue — durable outbox for cascade failures.
+--
+-- K.2 of #276 cascade stream. Post-K.1, SEC watermarks commit before
+-- cascade runs, so a cascade failure never triggers a re-plan of the
+-- same CIK on the next daily_financial_facts cycle. This table is the
+-- durable signal that makes retries deterministic and observable.
+--
+-- Semantics:
+--   - Row per instrument (PK on instrument_id; UPSERT pattern).
+--   - attempt_count = failed thesis attempts observed so far.
+--       * INSERT on first thesis failure sets count=1.
+--       * UPDATE on subsequent thesis failure increments count+1.
+--       * Rerank-only failure inserts/updates with last_error='RERANK_NEEDED'
+--         and attempt_count=0 — does NOT consume thesis retry budget.
+--       * K.3 LOCKED_BY_SIBLING inserts fresh with count=0 or leaves
+--         existing count unchanged.
+--   - drain_retry_queue returns rows with attempt_count < ATTEMPT_CAP (5).
+--     Rows at or above cap are left in place for admin inspection
+--     (surfaced in Chunk H / K.4).
+--   - Clear on success: DELETE the row after compute_rankings succeeds
+--     (deferred so rerank failure preserves the durable signal).
+--
+-- ON DELETE CASCADE: defensive — eBull does not hard-delete instruments
+-- today (is_tradable=false instead), but the FK makes the retention
+-- invariant explicit at the schema level.
+
+CREATE TABLE IF NOT EXISTS cascade_retry_queue (
+    instrument_id     BIGINT PRIMARY KEY
+        REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    enqueued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_attempted_at TIMESTAMPTZ,
+    attempt_count     INTEGER NOT NULL DEFAULT 0,
+    last_error        TEXT NOT NULL,
+    CONSTRAINT cascade_retry_queue_attempt_count_nonneg
+        CHECK (attempt_count >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cascade_retry_queue_enqueued
+    ON cascade_retry_queue(enqueued_at);

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -44,6 +44,7 @@ _SQL_DIR = Path(__file__).resolve().parents[2] / "sql"
 # Tables touched by the SEC incremental planner + executor tests.
 # TRUNCATE in dependency order with CASCADE to handle FKs cleanly.
 _PLANNER_TABLES: tuple[str, ...] = (
+    "cascade_retry_queue",
     "financial_facts_raw",
     "data_ingestion_runs",
     "external_identifiers",

--- a/tests/test_cascade_retry_queue_integration.py
+++ b/tests/test_cascade_retry_queue_integration.py
@@ -1,0 +1,188 @@
+"""Integration tests for the cascade_retry_queue outbox (#276 K.2).
+
+Uses the real ``ebull_test`` Postgres because MagicMock cannot model
+psycopg transaction semantics (aborted state, savepoint vs implicit
+tx, ON CONFLICT UPSERT behaviour).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+from app.services.refresh_cascade import (
+    ATTEMPT_CAP,
+    RERANK_MARKER,
+    cascade_refresh,
+    clear_retry_success,
+    drain_retry_queue,
+    enqueue_rerank_marker,
+    enqueue_retry,
+)
+from app.services.thesis import StaleInstrument
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test DB unavailable",
+)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int, symbol: str) -> None:
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES (%s, %s, %s, TRUE)",
+        (iid, symbol, symbol),
+    )
+    conn.commit()
+
+
+def _queue_row(conn: psycopg.Connection[tuple], iid: int) -> tuple[int, str] | None:
+    row = conn.execute(
+        "SELECT attempt_count, last_error FROM cascade_retry_queue WHERE instrument_id = %s",
+        (iid,),
+    ).fetchone()
+    return (int(row[0]), str(row[1])) if row else None
+
+
+class TestEnqueueRetry:
+    def test_first_enqueue_sets_attempt_count_one(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "AAPL")
+        enqueue_retry(ebull_test_conn, 1, "RuntimeError")
+        assert _queue_row(ebull_test_conn, 1) == (1, "RuntimeError")
+
+    def test_second_enqueue_increments_attempt_count(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "AAPL")
+        enqueue_retry(ebull_test_conn, 1, "RuntimeError")
+        enqueue_retry(ebull_test_conn, 1, "ValueError")
+        assert _queue_row(ebull_test_conn, 1) == (2, "ValueError")
+
+    def test_enqueue_after_aborted_tx_recovers(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Simulate an aborted outer tx: start a bad statement, roll back,
+        then enqueue in a fresh inner tx. The outbox write must durably
+        commit even though the caller connection had been INERROR."""
+        _seed_instrument(ebull_test_conn, 1, "AAPL")
+        with pytest.raises(psycopg.Error):
+            ebull_test_conn.execute("SELECT * FROM non_existent_table_abc")
+        ebull_test_conn.rollback()
+        enqueue_retry(ebull_test_conn, 1, "RuntimeError")
+        assert _queue_row(ebull_test_conn, 1) == (1, "RuntimeError")
+
+
+class TestClearRetrySuccess:
+    def test_deletes_existing_row(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "AAPL")
+        enqueue_retry(ebull_test_conn, 1, "RuntimeError")
+        clear_retry_success(ebull_test_conn, 1)
+        assert _queue_row(ebull_test_conn, 1) is None
+
+    def test_idempotent_on_missing_row(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "AAPL")
+        clear_retry_success(ebull_test_conn, 1)  # never enqueued
+        assert _queue_row(ebull_test_conn, 1) is None
+
+
+class TestDrainRetryQueue:
+    def test_returns_oldest_first(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "A")
+        _seed_instrument(ebull_test_conn, 2, "B")
+        _seed_instrument(ebull_test_conn, 3, "C")
+        enqueue_retry(ebull_test_conn, 2, "X")
+        enqueue_retry(ebull_test_conn, 1, "X")
+        enqueue_retry(ebull_test_conn, 3, "X")
+        # Force enqueued_at to differ deterministically.
+        ebull_test_conn.execute(
+            "UPDATE cascade_retry_queue SET enqueued_at = "
+            "  CASE instrument_id "
+            "    WHEN 1 THEN NOW() - INTERVAL '3 hours' "
+            "    WHEN 2 THEN NOW() - INTERVAL '2 hours' "
+            "    WHEN 3 THEN NOW() - INTERVAL '1 hour' "
+            "  END"
+        )
+        ebull_test_conn.commit()
+        assert drain_retry_queue(ebull_test_conn) == [1, 2, 3]
+
+    def test_skips_at_cap_rows(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "A")
+        _seed_instrument(ebull_test_conn, 2, "B")
+        enqueue_retry(ebull_test_conn, 1, "X")
+        enqueue_retry(ebull_test_conn, 2, "X")
+        # Force id=2 to exactly ATTEMPT_CAP — must be skipped.
+        ebull_test_conn.execute(
+            "UPDATE cascade_retry_queue SET attempt_count = %s WHERE instrument_id = 2",
+            (ATTEMPT_CAP,),
+        )
+        ebull_test_conn.commit()
+        assert drain_retry_queue(ebull_test_conn) == [1]
+
+
+class TestEnqueueRerankMarker:
+    def test_fresh_insert_sets_attempt_zero_marker(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "A")
+        enqueue_rerank_marker(ebull_test_conn, 1)
+        assert _queue_row(ebull_test_conn, 1) == (0, RERANK_MARKER)
+
+    def test_conflict_resets_at_cap_row_to_drainable(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A thesis success followed by rerank failure must reset a
+        pre-existing at-cap row to RERANK_NEEDED / count=0 so the
+        next cycle re-drains it. Codex v4 regression cover."""
+        _seed_instrument(ebull_test_conn, 1, "A")
+        enqueue_retry(ebull_test_conn, 1, "RuntimeError")
+        ebull_test_conn.execute(
+            "UPDATE cascade_retry_queue SET attempt_count = %s WHERE instrument_id = 1",
+            (ATTEMPT_CAP,),
+        )
+        ebull_test_conn.commit()
+        # At cap — not drainable.
+        assert drain_retry_queue(ebull_test_conn) == []
+        # Thesis succeeds, rerank fails → marker upsert.
+        enqueue_rerank_marker(ebull_test_conn, 1)
+        assert _queue_row(ebull_test_conn, 1) == (0, RERANK_MARKER)
+        # Now drainable again.
+        assert drain_retry_queue(ebull_test_conn) == [1]
+
+
+class TestCascadeCompositionAtCapRerankFailure:
+    """Full cascade_refresh path: pre-existing at-cap row + stale
+    instrument succeeds via new-work path + rerank fails → the
+    at-cap row is reset by enqueue_rerank_marker, so the next cycle
+    re-drains the instrument. Codex K.2 pre-push LOW cover."""
+
+    def test_at_cap_row_reset_by_cascade_on_rerank_failure(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 42, "AAPL")
+        # Seed a pre-existing at-cap row — the cascade must not
+        # leave this stuck as not-drainable.
+        enqueue_retry(ebull_test_conn, 42, "RuntimeError")
+        ebull_test_conn.execute(
+            "UPDATE cascade_retry_queue SET attempt_count = %s WHERE instrument_id = 42",
+            (ATTEMPT_CAP,),
+        )
+        ebull_test_conn.commit()
+        assert drain_retry_queue(ebull_test_conn) == []
+
+        stale_rows = [
+            StaleInstrument(instrument_id=42, symbol="AAPL", reason="event_new_10q"),
+        ]
+        with (
+            patch(
+                "app.services.refresh_cascade.find_stale_instruments",
+                return_value=stale_rows,
+            ),
+            patch("app.services.refresh_cascade.generate_thesis"),
+            patch(
+                "app.services.refresh_cascade.compute_rankings",
+                side_effect=RuntimeError("scoring broke"),
+            ),
+        ):
+            outcome = cascade_refresh(ebull_test_conn, MagicMock(), [42])
+
+        assert outcome.thesis_refreshed == 1
+        assert outcome.rankings_recomputed is False
+        # At-cap row has been reset to RERANK_NEEDED / count=0.
+        assert _queue_row(ebull_test_conn, 42) == (0, RERANK_MARKER)
+        # Next cascade cycle will pick it up.
+        assert drain_retry_queue(ebull_test_conn) == [42]

--- a/tests/test_cascade_retry_queue_integration.py
+++ b/tests/test_cascade_retry_queue_integration.py
@@ -94,7 +94,9 @@ class TestDrainRetryQueue:
         enqueue_retry(ebull_test_conn, 2, "X")
         enqueue_retry(ebull_test_conn, 1, "X")
         enqueue_retry(ebull_test_conn, 3, "X")
-        # Force enqueued_at to differ deterministically.
+        # Force enqueued_at to differ deterministically. Explicit
+        # commit below so the drain SELECT reads the UPDATE from a
+        # committed snapshot, not implicit-tx ambiguity.
         ebull_test_conn.execute(
             "UPDATE cascade_retry_queue SET enqueued_at = "
             "  CASE instrument_id "

--- a/tests/test_refresh_cascade.py
+++ b/tests/test_refresh_cascade.py
@@ -456,3 +456,51 @@ class TestCascadeRefresh:
         """Sanity: the marker string is importable and matches the
         spec wording used in admin surfaces (Chunk H)."""
         assert RERANK_MARKER == "RERANK_NEEDED"
+
+    def test_non_psycopg_exception_from_enqueue_retry_does_not_abort_loop(
+        self,
+    ) -> None:
+        """Fault isolation regression: a non-psycopg exception from
+        enqueue_retry (programming error, CM internals, AttributeError)
+        must be caught and logged — remaining stale instruments must
+        still be processed and the rerank must still run."""
+        conn = MagicMock()
+        client = MagicMock()
+        stale_rows = [
+            StaleInstrument(instrument_id=1, symbol="BAD", reason="event_new_10q"),
+            StaleInstrument(instrument_id=2, symbol="GOOD", reason="event_new_10q"),
+        ]
+
+        def gen_side_effect(iid, conn_, client_):  # type: ignore[no-untyped-def]
+            if iid == 1:
+                raise RuntimeError("thesis failed")
+            return MagicMock()
+
+        with (
+            patch("app.services.refresh_cascade.drain_retry_queue", return_value=[]),
+            patch(
+                "app.services.refresh_cascade.find_stale_instruments",
+                return_value=stale_rows,
+            ),
+            patch(
+                "app.services.refresh_cascade.generate_thesis",
+                side_effect=gen_side_effect,
+            ),
+            patch(
+                "app.services.refresh_cascade.enqueue_retry",
+                side_effect=AttributeError("helper internal bug"),
+            ),
+            patch(
+                "app.services.refresh_cascade.compute_rankings",
+                return_value=MagicMock(scored=[]),
+            ) as rank_mock,
+            patch("app.services.refresh_cascade.clear_retry_success"),
+        ):
+            outcome = cascade_refresh(conn, client, [1, 2])
+
+        # Non-psycopg helper failure didn't break isolation:
+        # GOOD (id=2) still processed + rerank still ran.
+        assert outcome.thesis_refreshed == 1
+        assert (1, "RuntimeError") in outcome.failed
+        rank_mock.assert_called_once()
+        assert outcome.rankings_recomputed is True

--- a/tests/test_refresh_cascade.py
+++ b/tests/test_refresh_cascade.py
@@ -190,15 +190,6 @@ class TestDrainRetryQueue:
 # ---------------------------------------------------------------------------
 
 
-def _patch_queue_helpers() -> dict[str, MagicMock]:
-    """Patch all four queue helpers so cascade_refresh runs without
-    hitting conn.execute for queue SQL. Caller enters the returned
-    patch objects' context via ExitStack or explicit patch.start/stop.
-    Returned by convention — prefer the `patch(...)` context managers
-    directly inside each test for clarity."""
-    raise NotImplementedError
-
-
 class TestCascadeRefresh:
     def test_empty_ids_and_empty_queue_noop(self) -> None:
         conn = MagicMock()

--- a/tests/test_refresh_cascade.py
+++ b/tests/test_refresh_cascade.py
@@ -1,10 +1,10 @@
-"""Unit tests for refresh_cascade (#276 K.1).
+"""Unit tests for refresh_cascade (#276 K.1 + K.2).
 
-Mock-based so no real Claude API is called. Integration of the
-service with the scheduler (conn.commit() before cascade, API-key
-gate, psycopg aborted-transaction recovery after thesis failure)
-is intentionally deferred to K.2/K.3 once a real DB fixture is
-cheap — MagicMock cannot model aborted psycopg transactions.
+Mock-based so no real Claude API is called. Integration tests that
+exercise the psycopg-aborted-transaction recovery path and real
+DB behaviour live in tests/test_cascade_retry_queue_integration.py
+and the scheduler-hook integration — MagicMock cannot model aborted
+psycopg transactions end-to-end.
 """
 
 from __future__ import annotations
@@ -12,9 +12,13 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from app.services.refresh_cascade import (
+    ATTEMPT_CAP,
+    RERANK_MARKER,
     CascadeOutcome,
     cascade_refresh,
     changed_instruments_from_outcome,
+    drain_retry_queue,
+    enqueue_retry,
 )
 from app.services.sec_incremental import RefreshOutcome, RefreshPlan
 from app.services.thesis import StaleInstrument
@@ -130,27 +134,97 @@ class TestChangedInstrumentsFromOutcome:
 
 
 # ---------------------------------------------------------------------------
+# Retry outbox helpers (K.2) — pure SQL-emitting helpers
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueRetry:
+    def test_wraps_in_transaction_and_upserts(self) -> None:
+        conn = MagicMock()
+        enqueue_retry(conn, 42, "RuntimeError")
+        conn.transaction.assert_called_once()
+        conn.execute.assert_called_once()
+        args, _ = conn.execute.call_args
+        sql = args[0]
+        params = args[1]
+        assert "INSERT INTO cascade_retry_queue" in sql
+        assert "ON CONFLICT (instrument_id) DO UPDATE" in sql
+        assert "attempt_count = cascade_retry_queue.attempt_count + 1" in sql
+        assert params == (42, "RuntimeError")
+
+
+class TestDrainRetryQueue:
+    def test_passes_cap_and_returns_ids(self) -> None:
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [(1,), (2,), (3,)]
+        conn.execute.return_value = cursor
+        result = drain_retry_queue(conn)
+        assert result == [1, 2, 3]
+        args, _ = conn.execute.call_args
+        sql = args[0]
+        params = args[1]
+        assert "WHERE attempt_count < %s" in sql
+        assert "ORDER BY enqueued_at ASC" in sql
+        assert params == (ATTEMPT_CAP,)
+
+    def test_custom_cap_respected(self) -> None:
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        conn.execute.return_value = cursor
+        drain_retry_queue(conn, cap=3)
+        args, _ = conn.execute.call_args
+        assert args[1] == (3,)
+
+    def test_empty_queue_returns_empty_list(self) -> None:
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        conn.execute.return_value = cursor
+        assert drain_retry_queue(conn) == []
+
+
+# ---------------------------------------------------------------------------
 # cascade_refresh
 # ---------------------------------------------------------------------------
 
 
+def _patch_queue_helpers() -> dict[str, MagicMock]:
+    """Patch all four queue helpers so cascade_refresh runs without
+    hitting conn.execute for queue SQL. Caller enters the returned
+    patch objects' context via ExitStack or explicit patch.start/stop.
+    Returned by convention — prefer the `patch(...)` context managers
+    directly inside each test for clarity."""
+    raise NotImplementedError
+
+
 class TestCascadeRefresh:
-    def test_empty_ids_noop(self) -> None:
+    def test_empty_ids_and_empty_queue_noop(self) -> None:
         conn = MagicMock()
         client = MagicMock()
-        outcome = cascade_refresh(conn, client, [])
+        with patch(
+            "app.services.refresh_cascade.drain_retry_queue",
+            return_value=[],
+        ):
+            outcome = cascade_refresh(conn, client, [])
         assert outcome == CascadeOutcome(
             instruments_considered=0,
             thesis_refreshed=0,
             rankings_recomputed=False,
+            retries_drained=0,
         )
-        conn.execute.assert_not_called()
 
-    def test_no_stale_instruments_skips_thesis_and_rankings(self) -> None:
-        """If find_stale returns nothing, no Claude calls and no rerank."""
+    def test_no_stale_no_retries_skips_everything(self) -> None:
+        """If find_stale returns nothing and queue is empty, no
+        Claude calls and no rerank."""
         conn = MagicMock()
         client = MagicMock()
         with (
+            patch(
+                "app.services.refresh_cascade.drain_retry_queue",
+                return_value=[],
+            ),
             patch(
                 "app.services.refresh_cascade.find_stale_instruments",
                 return_value=[],
@@ -169,7 +243,7 @@ class TestCascadeRefresh:
 
     def test_stale_instruments_trigger_thesis_and_single_rerank(self) -> None:
         """Stale instruments each get generate_thesis; rerank runs once
-        at the end, not per-instrument."""
+        at the end, not per-instrument. Success clears queue rows."""
         conn = MagicMock()
         client = MagicMock()
         stale_rows = [
@@ -177,6 +251,7 @@ class TestCascadeRefresh:
             StaleInstrument(instrument_id=2, symbol="B", reason="event_new_8k"),
         ]
         with (
+            patch("app.services.refresh_cascade.drain_retry_queue", return_value=[]),
             patch(
                 "app.services.refresh_cascade.find_stale_instruments",
                 return_value=stale_rows,
@@ -186,18 +261,21 @@ class TestCascadeRefresh:
                 "app.services.refresh_cascade.compute_rankings",
                 return_value=MagicMock(scored=[MagicMock(), MagicMock()]),
             ) as rank_mock,
+            patch("app.services.refresh_cascade.clear_retry_success") as clear_mock,
         ):
             outcome = cascade_refresh(conn, client, [1, 2])
 
         assert gen_mock.call_count == 2
         rank_mock.assert_called_once_with(conn)
+        assert clear_mock.call_count == 2
         assert outcome.thesis_refreshed == 2
         assert outcome.rankings_recomputed is True
         assert outcome.failed == ()
 
     def test_per_instrument_failure_isolated_rerank_still_runs(self) -> None:
         """One instrument's thesis raising must not abort siblings,
-        and a successful sibling still triggers the rerank."""
+        a successful sibling still triggers the rerank, and the
+        failed instrument is enqueued to the retry outbox."""
         conn = MagicMock()
         client = MagicMock()
         stale_rows = [
@@ -211,6 +289,7 @@ class TestCascadeRefresh:
             return MagicMock()
 
         with (
+            patch("app.services.refresh_cascade.drain_retry_queue", return_value=[]),
             patch(
                 "app.services.refresh_cascade.find_stale_instruments",
                 return_value=stale_rows,
@@ -223,6 +302,8 @@ class TestCascadeRefresh:
                 "app.services.refresh_cascade.compute_rankings",
                 return_value=MagicMock(scored=[]),
             ) as rank_mock,
+            patch("app.services.refresh_cascade.enqueue_retry") as enqueue_mock,
+            patch("app.services.refresh_cascade.clear_retry_success") as clear_mock,
         ):
             outcome = cascade_refresh(conn, client, [1, 2])
 
@@ -230,13 +311,18 @@ class TestCascadeRefresh:
         assert ("RuntimeError") in {e[1] for e in outcome.failed}
         rank_mock.assert_called_once()
         assert outcome.rankings_recomputed is True
+        enqueue_mock.assert_called_once_with(conn, 1, "RuntimeError")
+        # GOOD (id=2) is the only processed_ok → cleared on rerank success
+        clear_mock.assert_called_once_with(conn, 2)
 
-    def test_all_thesis_fail_no_rerank(self) -> None:
-        """If zero theses refreshed, skip the rerank — nothing changed."""
+    def test_all_thesis_fail_no_rerank_all_enqueued(self) -> None:
+        """If zero theses refreshed, skip rerank. Each failed
+        instrument lands in the outbox."""
         conn = MagicMock()
         client = MagicMock()
         stale_rows = [StaleInstrument(instrument_id=1, symbol="BAD", reason="event_new_10q")]
         with (
+            patch("app.services.refresh_cascade.drain_retry_queue", return_value=[]),
             patch(
                 "app.services.refresh_cascade.find_stale_instruments",
                 return_value=stale_rows,
@@ -246,21 +332,24 @@ class TestCascadeRefresh:
                 side_effect=RuntimeError("boom"),
             ),
             patch("app.services.refresh_cascade.compute_rankings") as rank_mock,
+            patch("app.services.refresh_cascade.enqueue_retry") as enqueue_mock,
         ):
             outcome = cascade_refresh(conn, client, [1])
 
         assert outcome.thesis_refreshed == 0
         rank_mock.assert_not_called()
         assert outcome.rankings_recomputed is False
+        enqueue_mock.assert_called_once_with(conn, 1, "RuntimeError")
 
-    def test_rerank_failure_records_and_returns(self) -> None:
-        """compute_rankings raising is captured in failed with sentinel
-        instrument_id=-1 and the cascade still returns the thesis
-        refresh count."""
+    def test_rerank_failure_marks_processed_ok_and_preserves_signal(self) -> None:
+        """compute_rankings raising is captured as (-1, ExcType).
+        processed_ok rows are NOT cleared; instead each one gets a
+        RERANK_NEEDED marker so the next cycle can recover."""
         conn = MagicMock()
         client = MagicMock()
         stale_rows = [StaleInstrument(instrument_id=1, symbol="A", reason="event_new_10q")]
         with (
+            patch("app.services.refresh_cascade.drain_retry_queue", return_value=[]),
             patch(
                 "app.services.refresh_cascade.find_stale_instruments",
                 return_value=stale_rows,
@@ -270,12 +359,109 @@ class TestCascadeRefresh:
                 "app.services.refresh_cascade.compute_rankings",
                 side_effect=RuntimeError("scoring broke"),
             ),
+            patch("app.services.refresh_cascade.clear_retry_success") as clear_mock,
+            patch("app.services.refresh_cascade.enqueue_rerank_marker") as marker_mock,
         ):
             outcome = cascade_refresh(conn, client, [1])
 
         assert outcome.thesis_refreshed == 1
         assert outcome.rankings_recomputed is False
         assert (-1, "RuntimeError") in outcome.failed
-        # Rollback invoked so the aborted-transaction state from the
-        # failed compute_rankings SQL does not leak out of the cascade.
+        # Clear NOT called — queue rows must survive as the durable signal.
+        clear_mock.assert_not_called()
+        # Marker written for the processed_ok id
+        marker_mock.assert_called_once_with(conn, 1)
+        # Rollback was invoked to recover from any psycopg-aborted state.
         conn.rollback.assert_called()
+
+    def test_retry_queue_drained_bypasses_stale_gate(self) -> None:
+        """Queued instrument_ids from the outbox get generate_thesis
+        called even when find_stale_instruments returns them as
+        non-stale. The outbox IS the signal."""
+        conn = MagicMock()
+        client = MagicMock()
+        with (
+            patch(
+                "app.services.refresh_cascade.drain_retry_queue",
+                return_value=[10, 20],
+            ),
+            patch(
+                "app.services.refresh_cascade.find_stale_instruments",
+                return_value=[],
+            ),
+            patch("app.services.refresh_cascade.generate_thesis") as gen_mock,
+            patch(
+                "app.services.refresh_cascade.compute_rankings",
+                return_value=MagicMock(scored=[]),
+            ) as rank_mock,
+            patch("app.services.refresh_cascade.clear_retry_success") as clear_mock,
+        ):
+            outcome = cascade_refresh(conn, client, [])
+
+        assert gen_mock.call_count == 2
+        # Both retry ids processed via generate_thesis regardless of
+        # find_stale's opinion.
+        called_iids = {call.args[0] for call in gen_mock.call_args_list}
+        assert called_iids == {10, 20}
+        rank_mock.assert_called_once()
+        assert outcome.retries_drained == 2
+        assert outcome.thesis_refreshed == 2
+        assert outcome.rankings_recomputed is True
+        # Both cleared on rerank success
+        assert clear_mock.call_count == 2
+
+    def test_retry_failure_enqueues_again(self) -> None:
+        """A queued instrument whose thesis fails on retry stays in
+        the outbox with incremented attempt_count (via enqueue_retry)."""
+        conn = MagicMock()
+        client = MagicMock()
+        with (
+            patch(
+                "app.services.refresh_cascade.drain_retry_queue",
+                return_value=[7],
+            ),
+            patch("app.services.refresh_cascade.find_stale_instruments", return_value=[]),
+            patch(
+                "app.services.refresh_cascade.generate_thesis",
+                side_effect=ValueError("still broken"),
+            ),
+            patch("app.services.refresh_cascade.compute_rankings") as rank_mock,
+            patch("app.services.refresh_cascade.enqueue_retry") as enqueue_mock,
+        ):
+            outcome = cascade_refresh(conn, client, [])
+
+        enqueue_mock.assert_called_once_with(conn, 7, "ValueError")
+        assert (7, "ValueError") in outcome.failed
+        rank_mock.assert_not_called()  # zero successes, no rerank
+
+    def test_queued_instrument_not_processed_twice_when_also_stale(self) -> None:
+        """If a CIK shows up in both the retry drain and the stale
+        list, generate_thesis runs once — retry path wins."""
+        conn = MagicMock()
+        client = MagicMock()
+        with (
+            patch(
+                "app.services.refresh_cascade.drain_retry_queue",
+                return_value=[5],
+            ),
+            patch(
+                "app.services.refresh_cascade.find_stale_instruments",
+                return_value=[StaleInstrument(instrument_id=5, symbol="DUP", reason="event_new_10q")],
+            ),
+            patch("app.services.refresh_cascade.generate_thesis") as gen_mock,
+            patch(
+                "app.services.refresh_cascade.compute_rankings",
+                return_value=MagicMock(scored=[]),
+            ),
+            patch("app.services.refresh_cascade.clear_retry_success"),
+        ):
+            outcome = cascade_refresh(conn, client, [5])
+
+        assert gen_mock.call_count == 1
+        assert outcome.thesis_refreshed == 1
+        assert outcome.retries_drained == 1
+
+    def test_rerank_marker_constant_exported(self) -> None:
+        """Sanity: the marker string is importable and matches the
+        spec wording used in admin surfaces (Chunk H)."""
+        assert RERANK_MARKER == "RERANK_NEEDED"


### PR DESCRIPTION
## What
Durable retry queue for per-instrument cascade failures. Post-K.1, SEC watermarks committed before cascade so a cascade failure never re-entered. K.2 closes that gap with `cascade_retry_queue` + 4 helpers + cascade-flow rewrite + unconditional scheduler invocation.

## Why
Without this, a single broken CIK silently retries forever via the event predicate (fragile) or silently drops forever (if another path wrote the thesis). K.2 makes retries deterministic, observable, and capped.

## Test plan
- [x] 22 unit tests (mock) — helper contracts, cascade flow, rerank-failure marker propagation, retry bypass of stale gate.
- [x] 10 integration tests (real DB) — aborted-tx recovery, UPSERT semantics, at-cap skip, marker resets at-cap to drainable, full cascade composition.
- [x] Gates clean (ruff / format / pyright / 1875 passed).
- [x] Spec Codex-reviewed over 4 iterations — SPEC APPROVED.
- [x] Pre-push Codex — no BLOCKER/HIGH, one LOW addressed with a composition test.

## Notes for reviewer
- `attempt_count` semantics: failed-thesis attempts observed. First enqueue=1, increments on conflict. RERANK_NEEDED marker writes count=0 (does NOT consume thesis budget).
- Rollback-before-enqueue on BOTH thesis-failure and rerank-failure paths so an INERROR connection can still durably commit the outbox write.
- Clear is deferred to after rerank success — rerank failure leaves rows AND writes RERANK_NEEDED markers for new-work successes, so the queue itself doubles as the rankings-recompute signal.
- K.3 (advisory lock) and K.4 (observability + admin UI for at-cap rows) are separate follow-ups; the table is forward-compatible with both.