### PR TITLE
feat(#276): cascade advisory lock (K.3)

### DIFF
--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -34,6 +34,8 @@ level advisory locking against ``daily_thesis_refresh``.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
 
@@ -48,6 +50,19 @@ logger = logging.getLogger(__name__)
 
 ATTEMPT_CAP: int = 5
 RERANK_MARKER: str = "RERANK_NEEDED"
+LOCKED_BY_SIBLING: str = "LOCKED_BY_SIBLING"
+
+# Durability note for all queue helpers (enqueue_retry,
+# enqueue_rerank_marker, clear_retry_success, enqueue_locked_by_sibling,
+# demote_to_rerank_needed): each helper ends with an explicit
+# ``conn.commit()`` so the write is durable regardless of any prior
+# implicit-tx state. Without this, a savepoint write (via
+# ``with conn.transaction():``) under an implicit outer tx would be
+# silently discarded by a later ``conn.rollback()`` in the same
+# cascade_refresh run — the scenario Codex surfaced during the K.3
+# spec review. Callers MUST NOT wrap cascade_refresh in an outer
+# ``with conn.transaction():`` block since the helpers' commits would
+# close the outer tx prematurely.
 
 
 @dataclass(frozen=True)
@@ -64,6 +79,7 @@ class CascadeOutcome:
     thesis_refreshed: int
     rankings_recomputed: bool
     retries_drained: int = 0
+    locked_skipped: int = 0
     failed: tuple[tuple[int, str], ...] = ()
 
 
@@ -138,35 +154,28 @@ def enqueue_retry(
     Caller MUST ``conn.rollback()`` before invoking this if the
     connection is in INERROR state from the failing thesis call.
 
-    Transaction semantics: ``with conn.transaction():`` opens a
-    new transaction when the connection has no open tx, or a
-    savepoint when nested. In cascade_refresh's flow the outer
-    conn has read transactions from drain_retry_queue /
-    find_stale_instruments, so this write lands on a savepoint —
-    durable only after the scheduler's ``conn.commit()`` that
-    follows ``cascade_refresh`` returning. The scheduler commits
-    immediately after cascade_refresh returns and before the
-    failure-surfacing raise, so in practice the outbox write is
-    durable whenever cascade_refresh exits cleanly.
+    See the module-level durability note: ends with an explicit
+    ``conn.commit()`` so a later cascade rollback cannot erase the
+    signal.
 
     ``attempt_count`` semantics: first enqueue sets 1. Subsequent
     thesis failures increment by 1. A pre-existing RERANK_NEEDED
     marker (attempt_count=0) transitions into the thesis-failure
     path here — the UPDATE increments from 0 to 1 as expected.
     """
-    with conn.transaction():
-        conn.execute(
-            """
-            INSERT INTO cascade_retry_queue
-                (instrument_id, attempt_count, last_error, last_attempted_at)
-            VALUES (%s, 1, %s, NOW())
-            ON CONFLICT (instrument_id) DO UPDATE SET
-                attempt_count = cascade_retry_queue.attempt_count + 1,
-                last_error = EXCLUDED.last_error,
-                last_attempted_at = NOW()
-            """,
-            (instrument_id, error_type),
-        )
+    conn.execute(
+        """
+        INSERT INTO cascade_retry_queue
+            (instrument_id, attempt_count, last_error, last_attempted_at)
+        VALUES (%s, 1, %s, NOW())
+        ON CONFLICT (instrument_id) DO UPDATE SET
+            attempt_count = cascade_retry_queue.attempt_count + 1,
+            last_error = EXCLUDED.last_error,
+            last_attempted_at = NOW()
+        """,
+        (instrument_id, error_type),
+    )
+    conn.commit()
 
 
 def enqueue_rerank_marker(
@@ -183,6 +192,8 @@ def enqueue_rerank_marker(
     blocker is no longer current and the row must be drainable
     again for the next rerank attempt.
 
+    See module-level durability note: ends with explicit conn.commit().
+
     Note on budget accounting: if the NEXT cycle drains this row
     and the thesis regeneration itself then fails, ``enqueue_retry``
     transitions the row into the thesis-failure path and increments
@@ -191,33 +202,39 @@ def enqueue_rerank_marker(
     budget-cost guarantee covers the rerank-only failure event
     itself, not arbitrary downstream thesis failures on retry.
     """
-    with conn.transaction():
-        conn.execute(
-            """
-            INSERT INTO cascade_retry_queue
-                (instrument_id, attempt_count, last_error, last_attempted_at)
-            VALUES (%s, 0, %s, NOW())
-            ON CONFLICT (instrument_id) DO UPDATE SET
-                attempt_count = 0,
-                last_error = EXCLUDED.last_error,
-                last_attempted_at = NOW()
-            """,
-            (instrument_id, RERANK_MARKER),
-        )
+    conn.execute(
+        """
+        INSERT INTO cascade_retry_queue
+            (instrument_id, attempt_count, last_error, last_attempted_at)
+        VALUES (%s, 0, %s, NOW())
+        ON CONFLICT (instrument_id) DO UPDATE SET
+            attempt_count = 0,
+            last_error = EXCLUDED.last_error,
+            last_attempted_at = NOW()
+        """,
+        (instrument_id, RERANK_MARKER),
+    )
+    conn.commit()
 
 
 def clear_retry_success(
     conn: psycopg.Connection[Any],
     instrument_id: int,
 ) -> None:
-    """DELETE the retry row for an instrument whose cascade succeeded
-    this cycle (thesis refreshed + rerank succeeded). Idempotent —
-    no-op if the row is absent. Wraps its own transaction."""
-    with conn.transaction():
-        conn.execute(
-            "DELETE FROM cascade_retry_queue WHERE instrument_id = %s",
-            (instrument_id,),
-        )
+    """DELETE the retry row for an instrument whose cascade resolved
+    both thesis and rerank this cycle. Idempotent — no-op if the
+    row is absent. Called ONLY by cascade's own post-rerank-success
+    path; other resolution paths (e.g. daily_thesis_refresh success)
+    must use ``demote_to_rerank_needed`` to preserve the rankings-
+    recompute signal.
+
+    See module-level durability note: ends with explicit conn.commit().
+    """
+    conn.execute(
+        "DELETE FROM cascade_retry_queue WHERE instrument_id = %s",
+        (instrument_id,),
+    )
+    conn.commit()
 
 
 def drain_retry_queue(
@@ -238,6 +255,101 @@ def drain_retry_queue(
         (cap,),
     ).fetchall()
     return [int(r[0]) for r in rows]
+
+
+def enqueue_locked_by_sibling(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> None:
+    """INSERT ... ON CONFLICT DO NOTHING — preserve any existing
+    queue row (at-cap or RERANK_NEEDED). Fresh insert records
+    ``last_error='LOCKED_BY_SIBLING'`` and ``attempt_count=0`` so
+    the next cycle re-drains without consuming thesis budget.
+
+    See module-level durability note: ends with explicit conn.commit().
+    """
+    conn.execute(
+        """
+        INSERT INTO cascade_retry_queue
+            (instrument_id, attempt_count, last_error, last_attempted_at)
+        VALUES (%s, 0, %s, NOW())
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id, LOCKED_BY_SIBLING),
+    )
+    conn.commit()
+
+
+def demote_to_rerank_needed(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> None:
+    """On daily_thesis_refresh per-instrument SUCCESS, convert any
+    pending thesis-failure / LOCKED_BY_SIBLING row to
+    RERANK_NEEDED / ``attempt_count=0``. Daily's write resolves
+    the pending thesis signal but does NOT run compute_rankings,
+    so the row must persist (demoted) as a durable rankings-
+    recompute signal until a real cascade rerank succeeds and
+    clear_retry_success deletes it.
+
+    Pre-existing RERANK_NEEDED rows are untouched (the WHERE
+    clause filters them) — they already carry the correct signal.
+
+    See module-level durability note: ends with explicit conn.commit().
+    """
+    conn.execute(
+        """
+        UPDATE cascade_retry_queue
+           SET attempt_count = 0,
+               last_error = %s,
+               last_attempted_at = NOW()
+         WHERE instrument_id = %s
+           AND last_error != %s
+        """,
+        (RERANK_MARKER, instrument_id, RERANK_MARKER),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Advisory lock (K.3) — session-level, held across Claude call
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def instrument_lock(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> Iterator[bool]:
+    """Session-level ``pg_try_advisory_lock`` keyed on instrument_id.
+
+    Yields True when acquired, False when a sibling session holds
+    the lock. Session-level (NOT xact-level) so the lock spans
+    ``generate_thesis``'s internal commit-before-Claude (#293).
+
+    Unlock in ``finally`` tolerates an INERROR connection by rolling
+    back and retrying once; if the retry still fails, the session
+    close will eventually release the advisory lock on Postgres'
+    side. The protected block's exception is never masked.
+    """
+    acquired_row = conn.execute("SELECT pg_try_advisory_lock(%s)", (instrument_id,)).fetchone()
+    acquired = bool(acquired_row[0]) if acquired_row else False
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                conn.execute("SELECT pg_advisory_unlock(%s)", (instrument_id,))
+            except psycopg.Error:
+                try:
+                    conn.rollback()
+                    conn.execute("SELECT pg_advisory_unlock(%s)", (instrument_id,))
+                except psycopg.Error:
+                    logger.exception(
+                        "instrument_lock: unlock failed for instrument_id=%d — "
+                        "session close will release",
+                        instrument_id,
+                    )
 
 
 # ---------------------------------------------------------------------------
@@ -289,39 +401,45 @@ def cascade_refresh(
     thesis_refreshed = 0
     failed: list[tuple[int, str]] = []
     processed_ok: list[int] = []
+    locked_skipped = 0
 
     # Retry path — bypass stale gate. Outbox IS the signal.
     retry_set = set(retry_ids)
     for iid in retry_ids:
-        try:
-            generate_thesis(iid, conn, client)
-            thesis_refreshed += 1
-            processed_ok.append(iid)
-            logger.info("cascade_refresh: retry thesis refreshed for instrument_id=%d", iid)
-        except Exception as exc:
+        with instrument_lock(conn, iid) as acquired:
+            if not acquired:
+                try:
+                    enqueue_locked_by_sibling(conn, iid)
+                except Exception:
+                    logger.exception(
+                        "cascade_refresh: enqueue_locked_by_sibling failed for instrument_id=%d",
+                        iid,
+                    )
+                logger.info("cascade_refresh: LOCKED_BY_SIBLING retry instrument_id=%d", iid)
+                locked_skipped += 1
+                continue
             try:
-                conn.rollback()
-            except psycopg.Error:
-                logger.debug(
-                    "cascade_refresh: rollback suppressed after retry thesis exception",
-                    exc_info=True,
-                )
-            try:
-                enqueue_retry(conn, iid, type(exc).__name__)
-            except Exception:
-                # Broad catch intentional: any exception from the helper
-                # (psycopg error, programming bug, context manager
-                # machinery) must NOT break the per-instrument
-                # isolation guarantee and abort remaining siblings.
-                # The retry signal for this iid is lost this cycle;
-                # the instrument re-enters the cascade on the next run
-                # via the #273 event predicate.
-                logger.exception(
-                    "cascade_refresh: enqueue_retry failed for instrument_id=%d — retry signal lost",
-                    iid,
-                )
-            failed.append((iid, type(exc).__name__))
-            logger.exception("cascade_refresh: retry thesis failed for instrument_id=%d", iid)
+                generate_thesis(iid, conn, client)
+                thesis_refreshed += 1
+                processed_ok.append(iid)
+                logger.info("cascade_refresh: retry thesis refreshed for instrument_id=%d", iid)
+            except Exception as exc:
+                try:
+                    conn.rollback()
+                except psycopg.Error:
+                    logger.debug(
+                        "cascade_refresh: rollback suppressed after retry thesis exception",
+                        exc_info=True,
+                    )
+                try:
+                    enqueue_retry(conn, iid, type(exc).__name__)
+                except Exception:
+                    logger.exception(
+                        "cascade_refresh: enqueue_retry failed for instrument_id=%d — retry signal lost",
+                        iid,
+                    )
+                failed.append((iid, type(exc).__name__))
+                logger.exception("cascade_refresh: retry thesis failed for instrument_id=%d", iid)
 
     # New-work (stale) path — skip any ids already processed in the
     # retry loop so a queued CIK that also surfaces as stale is only
@@ -330,44 +448,53 @@ def cascade_refresh(
         iid = stale_instrument.instrument_id
         if iid in retry_set:
             continue
-        try:
-            generate_thesis(iid, conn, client)
-            thesis_refreshed += 1
-            processed_ok.append(iid)
-            logger.info(
-                "cascade_refresh: thesis refreshed for instrument_id=%d symbol=%s reason=%s",
-                iid,
-                stale_instrument.symbol,
-                stale_instrument.reason,
-            )
-        except Exception as exc:
-            try:
-                conn.rollback()
-            except psycopg.Error:
-                logger.debug(
-                    "cascade_refresh: rollback suppressed after thesis exception",
-                    exc_info=True,
-                )
-            try:
-                enqueue_retry(conn, iid, type(exc).__name__)
-            except Exception:
-                # Broad catch intentional: any exception from the helper
-                # (psycopg error, programming bug, context manager
-                # machinery) must NOT break the per-instrument
-                # isolation guarantee and abort remaining siblings.
-                # The retry signal for this iid is lost this cycle;
-                # the instrument re-enters the cascade on the next run
-                # via the #273 event predicate.
-                logger.exception(
-                    "cascade_refresh: enqueue_retry failed for instrument_id=%d — retry signal lost",
+        with instrument_lock(conn, iid) as acquired:
+            if not acquired:
+                try:
+                    enqueue_locked_by_sibling(conn, iid)
+                except Exception:
+                    logger.exception(
+                        "cascade_refresh: enqueue_locked_by_sibling failed for instrument_id=%d",
+                        iid,
+                    )
+                logger.info(
+                    "cascade_refresh: LOCKED_BY_SIBLING stale instrument_id=%d symbol=%s",
                     iid,
+                    stale_instrument.symbol,
                 )
-            failed.append((iid, type(exc).__name__))
-            logger.exception(
-                "cascade_refresh: thesis failed for instrument_id=%d symbol=%s",
-                iid,
-                stale_instrument.symbol,
-            )
+                locked_skipped += 1
+                continue
+            try:
+                generate_thesis(iid, conn, client)
+                thesis_refreshed += 1
+                processed_ok.append(iid)
+                logger.info(
+                    "cascade_refresh: thesis refreshed for instrument_id=%d symbol=%s reason=%s",
+                    iid,
+                    stale_instrument.symbol,
+                    stale_instrument.reason,
+                )
+            except Exception as exc:
+                try:
+                    conn.rollback()
+                except psycopg.Error:
+                    logger.debug(
+                        "cascade_refresh: rollback suppressed after thesis exception",
+                        exc_info=True,
+                    )
+                try:
+                    enqueue_retry(conn, iid, type(exc).__name__)
+                except Exception:
+                    logger.exception(
+                        "cascade_refresh: enqueue_retry failed for instrument_id=%d — retry signal lost",
+                        iid,
+                    )
+                failed.append((iid, type(exc).__name__))
+                logger.exception(
+                    "cascade_refresh: thesis failed for instrument_id=%d symbol=%s",
+                    iid,
+                    stale_instrument.symbol,
+                )
 
     rankings_recomputed = False
     if thesis_refreshed > 0:
@@ -420,10 +547,12 @@ def cascade_refresh(
                     )
 
     logger.info(
-        "cascade_refresh summary: considered=%d stale=%d retries_drained=%d thesis_refreshed=%d rankings=%s failed=%d",
+        "cascade_refresh summary: considered=%d stale=%d retries_drained=%d "
+        "locked_skipped=%d thesis_refreshed=%d rankings=%s failed=%d",
         len(instrument_ids),
         len(stale),
         len(retry_ids),
+        locked_skipped,
         thesis_refreshed,
         rankings_recomputed,
         len(failed),
@@ -434,5 +563,6 @@ def cascade_refresh(
         thesis_refreshed=thesis_refreshed,
         rankings_recomputed=rankings_recomputed,
         retries_drained=len(retry_ids),
+        locked_skipped=locked_skipped,
         failed=tuple(failed),
     )

--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -304,7 +304,7 @@ def demote_to_rerank_needed(
                last_error = %s,
                last_attempted_at = NOW()
          WHERE instrument_id = %s
-           AND last_error != %s
+           AND last_error IS DISTINCT FROM %s
         """,
         (RERANK_MARKER, instrument_id, RERANK_MARKER),
     )

--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -346,8 +346,7 @@ def instrument_lock(
                     conn.execute("SELECT pg_advisory_unlock(%s)", (instrument_id,))
                 except psycopg.Error:
                     logger.exception(
-                        "instrument_lock: unlock failed for instrument_id=%d — "
-                        "session close will release",
+                        "instrument_lock: unlock failed for instrument_id=%d — session close will release",
                         instrument_id,
                     )
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1340,18 +1340,42 @@ def daily_thesis_refresh() -> None:
 
         claude_client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
 
+        # K.3: import lazily so the cascade module (which itself
+        # imports scoring) isn't hit at scheduler module import time.
+        from app.services.refresh_cascade import (
+            demote_to_rerank_needed,
+            instrument_lock,
+        )
+
         generated = 0
         skipped = 0
+        locked_skipped = 0
         total = len(stale)
         for idx, item in enumerate(stale, start=1):
             try:
                 with psycopg.connect(settings.database_url) as conn:
-                    generate_thesis(
-                        instrument_id=item.instrument_id,
-                        conn=conn,
-                        client=claude_client,
-                    )
-                generated += 1
+                    with instrument_lock(conn, item.instrument_id) as acquired:
+                        if not acquired:
+                            logger.info(
+                                "daily_thesis_refresh: LOCKED_BY_SIBLING symbol=%s instrument_id=%d",
+                                item.symbol,
+                                item.instrument_id,
+                            )
+                            locked_skipped += 1
+                        else:
+                            generate_thesis(
+                                instrument_id=item.instrument_id,
+                                conn=conn,
+                                client=claude_client,
+                            )
+                            # Daily's thesis write resolves any pending
+                            # cascade thesis signal but does not run
+                            # compute_rankings, so demote rather than
+                            # delete — preserves RERANK_NEEDED rows
+                            # untouched and converts thesis-failure /
+                            # LOCKED_BY_SIBLING rows to RERANK_NEEDED.
+                            demote_to_rerank_needed(conn, item.instrument_id)
+                            generated += 1
             except Exception:
                 logger.warning(
                     "daily_thesis_refresh: failed for symbol=%s instrument_id=%d, skipping",
@@ -1366,9 +1390,10 @@ def daily_thesis_refresh() -> None:
         tracker.row_count = generated
 
     logger.info(
-        "daily_thesis_refresh complete: generated=%d skipped=%d",
+        "daily_thesis_refresh complete: generated=%d skipped=%d locked_skipped=%d",
         generated,
         skipped,
+        locked_skipped,
     )
 
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -59,6 +59,10 @@ from app.services.order_client import execute_order
 from app.services.portfolio import run_portfolio_review
 from app.services.portfolio_sync import sync_portfolio
 from app.services.position_monitor import check_position_health
+from app.services.refresh_cascade import (
+    demote_to_rerank_needed,
+    instrument_lock,
+)
 from app.services.return_attribution import (
     SUMMARY_WINDOWS,
     compute_attribution_summary,
@@ -1339,13 +1343,6 @@ def daily_thesis_refresh() -> None:
         )
 
         claude_client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
-
-        # K.3: import lazily so the cascade module (which itself
-        # imports scoring) isn't hit at scheduler module import time.
-        from app.services.refresh_cascade import (
-            demote_to_rerank_needed,
-            instrument_lock,
-        )
 
         generated = 0
         skipped = 0

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1368,14 +1368,28 @@ def daily_thesis_refresh() -> None:
                                 conn=conn,
                                 client=claude_client,
                             )
+                            # Increment BEFORE demote so a demote
+                            # failure can't silently under-count
+                            # a successful thesis write. The thesis
+                            # row is already committed by
+                            # generate_thesis (#293); the demote
+                            # call is a separate queue-mutation
+                            # side-effect we want to best-effort.
+                            generated += 1
                             # Daily's thesis write resolves any pending
                             # cascade thesis signal but does not run
                             # compute_rankings, so demote rather than
                             # delete — preserves RERANK_NEEDED rows
                             # untouched and converts thesis-failure /
                             # LOCKED_BY_SIBLING rows to RERANK_NEEDED.
-                            demote_to_rerank_needed(conn, item.instrument_id)
-                            generated += 1
+                            try:
+                                demote_to_rerank_needed(conn, item.instrument_id)
+                            except Exception:
+                                logger.exception(
+                                    "daily_thesis_refresh: demote_to_rerank_needed failed "
+                                    "for instrument_id=%d — queue signal stale until next run",
+                                    item.instrument_id,
+                                )
             except Exception:
                 logger.warning(
                     "daily_thesis_refresh: failed for symbol=%s instrument_id=%d, skipping",

--- a/docs/superpowers/specs/2026-04-18-cascade-advisory-lock-design.md
+++ b/docs/superpowers/specs/2026-04-18-cascade-advisory-lock-design.md
@@ -1,0 +1,246 @@
+# Cascade advisory lock (#276 K.3) — design v2
+
+**Goal:** prevent `cascade_refresh` and `daily_thesis_refresh` from concurrently generating a thesis for the same instrument. Duplicate Claude calls + race on thesis row commit.
+
+**Scope:** K.3 core + a K.2 durability fix that Codex surfaced while reviewing K.3 (helper writes on savepoint under implicit tx can be lost by a later cascade rollback).
+
+**Revision history:**
+- v1 — initial.
+- v2 — Codex-driven: (a) helpers now commit explicitly so later rollbacks can't destroy durable queue state; (b) `instrument_lock` unlock handles INERROR conn; (c) `daily_thesis_refresh` on success resolves the pending cascade row.
+- v3/v4 — Codex-driven: daily success demotes pending thesis-failure / LOCKED_BY_SIBLING rows to RERANK_NEEDED via `demote_to_rerank_needed` rather than deleting them, so the rankings-recompute signal survives until cascade's own rerank succeeds. Only cascade's post-rerank-success path DELETEs via `clear_retry_success`.
+
+---
+
+## Problem
+
+After K.2:
+
+- `cascade_refresh` runs inside `daily_financial_facts` and calls `generate_thesis` per queued + stale instrument.
+- `daily_thesis_refresh` runs on its own schedule and also calls `generate_thesis` per T1/T2 stale instrument.
+- Overlap = two Claude calls + commit race on thesis row. Wasted budget + audit muddle.
+
+Transaction-level locking is wrong — `generate_thesis` commits before Claude (#293), so an xact lock would release mid-call.
+
+Separately, Codex K.3 review surfaced a K.2 durability gap: queue helpers wrap writes in `with conn.transaction():` which creates savepoints under the implicit outer tx. A later `conn.rollback()` inside `cascade_refresh` rolls back the outer tx and discards the savepoint writes. The scheduler commits AFTER `cascade_refresh` returns, so post-cascade state is durable — but mid-cascade rollbacks (thesis exception handler, rerank exception handler) can erase prior enqueue writes from earlier loop iterations. K.3 fixes this.
+
+## Solution
+
+### Core: session-level advisory lock
+
+`pg_try_advisory_lock(bigint)` keyed on `instrument_id`. Held for the duration of the `generate_thesis` call (including Claude round-trip) and released in `finally` via `pg_advisory_unlock`. Non-blocking — `try_lock` returns immediately.
+
+Skip semantics:
+
+- `cascade_refresh`: write/preserve a `cascade_retry_queue` row with `last_error='LOCKED_BY_SIBLING'`, `attempt_count=0`. Does NOT consume retry budget.
+- `daily_thesis_refresh`: log informational, `skipped += 1`. No queue write on skip.
+- **New (fix for Codex v1 HIGH — at-cap stuck-row path + Codex v2/v3 HIGH — RERANK_NEEDED preservation)**: `daily_thesis_refresh` on per-instrument SUCCESS calls a NEW helper `demote_to_rerank_needed(conn, iid)` that UPDATEs any pending thesis-failure / LOCKED_BY_SIBLING row to `last_error='RERANK_NEEDED'`, `attempt_count=0`. Daily's thesis write resolves the thesis-level signal but does NOT run `compute_rankings`, so the row must persist as a durable rankings-recompute signal for the next cascade cycle. Demote-rather-than-delete. Pre-existing RERANK_NEEDED rows are left untouched. Cascade's own post-rerank-success path continues to use the unconditional `clear_retry_success` because cascade at that point resolved BOTH thesis and rerank.
+
+### K.2 durability fix
+
+Helpers drop `with conn.transaction():` and instead `conn.execute(...)` then `conn.commit()`. The commit is durable regardless of prior implicit-tx state; caller rollbacks can no longer erase prior queue writes. All four existing helpers (`enqueue_retry`, `enqueue_rerank_marker`, `clear_retry_success`, and new `enqueue_locked_by_sibling`) adopt this pattern.
+
+Trade-off: explicit `conn.commit()` calls incompatible with any future caller that wraps cascade in an outer `with conn.transaction():`. Cascade callers today don't do that. Documented in each helper's docstring. Compatible with future K.4 observability which will wrap around cascade, not inside it.
+
+## Helpers — `app/services/refresh_cascade.py`
+
+```python
+from contextlib import contextmanager
+from collections.abc import Iterator
+
+LOCKED_BY_SIBLING: str = "LOCKED_BY_SIBLING"
+
+
+@contextmanager
+def instrument_lock(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> Iterator[bool]:
+    """Session-level advisory lock on instrument_id. Yields True if
+    acquired, False if a sibling session holds it.
+
+    Session-level (NOT xact-level) so the lock spans generate_thesis
+    including its internal commit-before-Claude (#293). Unlock in
+    finally handles conn-INERROR by attempting rollback before the
+    unlock SQL, and tolerates unlock failure (session close
+    guarantees Postgres releases the lock).
+    """
+    acquired_row = conn.execute(
+        "SELECT pg_try_advisory_lock(%s)", (instrument_id,)
+    ).fetchone()
+    acquired = bool(acquired_row[0]) if acquired_row else False
+    try:
+        yield acquired
+    finally:
+        if not acquired:
+            return
+        try:
+            conn.execute("SELECT pg_advisory_unlock(%s)", (instrument_id,))
+        except psycopg.Error:
+            # Conn may be INERROR from the protected block. Roll back
+            # and retry unlock once. If retry still fails, session
+            # close will eventually free the lock — log and continue
+            # rather than masking the caller's original exception.
+            try:
+                conn.rollback()
+                conn.execute("SELECT pg_advisory_unlock(%s)", (instrument_id,))
+            except psycopg.Error:
+                logger.exception(
+                    "instrument_lock: unlock failed for instrument_id=%d — "
+                    "session close will release",
+                    instrument_id,
+                )
+
+
+def enqueue_locked_by_sibling(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> None:
+    """INSERT ... ON CONFLICT DO NOTHING — preserves any existing
+    queue row (at-cap or RERANK_NEEDED). Fresh insert records
+    last_error='LOCKED_BY_SIBLING' and attempt_count=0 so the
+    next cycle re-drains without consuming thesis budget.
+    Commits explicitly so later cascade rollbacks cannot erase
+    the skip marker (see module-level durability note).
+    """
+    conn.execute(
+        """
+        INSERT INTO cascade_retry_queue
+            (instrument_id, attempt_count, last_error, last_attempted_at)
+        VALUES (%s, 0, 'LOCKED_BY_SIBLING', NOW())
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id,),
+    )
+    conn.commit()
+```
+
+Also refactor existing helpers (`enqueue_retry`, `enqueue_rerank_marker`, `clear_retry_success`) to the same pattern: single `conn.execute` + explicit `conn.commit()`, dropping `with conn.transaction():`.
+
+New demote helper for `daily_thesis_refresh`:
+
+```python
+def demote_to_rerank_needed(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+) -> None:
+    """On daily_thesis_refresh success, convert any pending
+    thesis-failure / LOCKED_BY_SIBLING row to RERANK_NEEDED /
+    attempt_count=0. Daily's write resolves the pending thesis
+    signal but does NOT run compute_rankings, so the row must
+    persist (demoted) as a durable rankings-recompute signal
+    until a real cascade rerank succeeds and the unconditional
+    clear_retry_success path deletes it.
+
+    Codex v3 HIGH: an earlier design version DELETE'd non-
+    RERANK_NEEDED rows here. That dropped the rerank signal
+    whenever daily succeeded on a thesis-failure / lock-skipped
+    instrument, leaving rankings stale. Demote-rather-than-
+    delete preserves the signal.
+
+    Pre-existing RERANK_NEEDED rows are left untouched — they
+    already carry the correct signal.
+    """
+    conn.execute(
+        """
+        UPDATE cascade_retry_queue
+           SET attempt_count = 0,
+               last_error = 'RERANK_NEEDED',
+               last_attempted_at = NOW()
+         WHERE instrument_id = %s
+           AND last_error != 'RERANK_NEEDED'
+        """,
+        (instrument_id,),
+    )
+    conn.commit()
+```
+
+## cascade_refresh changes
+
+Per-instrument loop (both retry path and stale path) wrapped with `instrument_lock`:
+
+```python
+with instrument_lock(conn, iid) as acquired:
+    if not acquired:
+        enqueue_locked_by_sibling(conn, iid)
+        logger.info("cascade_refresh: LOCKED_BY_SIBLING instrument_id=%d", iid)
+        locked_skipped += 1
+        continue
+    # existing generate_thesis + processed_ok / failed / enqueue_retry logic
+```
+
+`CascadeOutcome` gains `locked_skipped: int = 0`. Locked-skips are NOT in `failed`, do NOT trigger the scheduler raise, and do NOT count as thesis attempts.
+
+## daily_thesis_refresh changes — `app/workers/scheduler.py`
+
+Per-instrument loop wraps with `instrument_lock`:
+
+```python
+with psycopg.connect(settings.database_url) as conn:
+    with instrument_lock(conn, item.instrument_id) as acquired:
+        if not acquired:
+            logger.info(
+                "daily_thesis_refresh: LOCKED_BY_SIBLING symbol=%s instrument_id=%d",
+                item.symbol, item.instrument_id,
+            )
+            skipped += 1
+            report_progress(idx, total)
+            continue
+        generate_thesis(
+            instrument_id=item.instrument_id,
+            conn=conn,
+            client=claude_client,
+        )
+        # On success, demote any pending thesis-failure /
+        # LOCKED_BY_SIBLING row to RERANK_NEEDED — daily's thesis
+        # write subsumes cascade's pending thesis signal but does
+        # not run compute_rankings, so the row must persist as a
+        # rankings-recompute signal. Pre-existing RERANK_NEEDED
+        # rows are untouched. Only cascade's post-rerank-success
+        # path DELETEs via clear_retry_success.
+        demote_to_rerank_needed(conn, item.instrument_id)
+```
+
+Each per-instrument `psycopg.connect(...)` gives its own session. Cross-connection advisory-lock contention blocks cascade's long-lived conn against daily's per-instrument conn — Postgres advisory locks are global-keyed across sessions.
+
+## Tests
+
+**Unit (mock conn):**
+
+1. `instrument_lock` acquired: executes `pg_try_advisory_lock`, yields True, executes `pg_advisory_unlock` in finally.
+2. `instrument_lock` not acquired: yields False, no unlock call.
+3. `instrument_lock` unlocks even if body raises.
+4. `instrument_lock` unlock path tolerates psycopg.Error on the first attempt: rollback + retry.
+5. `enqueue_locked_by_sibling` issues INSERT ... ON CONFLICT DO NOTHING with count=0 literal and 'LOCKED_BY_SIBLING' + explicit conn.commit().
+6. All existing helpers now call `conn.commit()` directly (`enqueue_retry`, `enqueue_rerank_marker`, `clear_retry_success`). Test assertions on `conn.transaction.assert_called_once()` replaced with `conn.commit.assert_called()`.
+7. `cascade_refresh` per-instrument: lock acquired → normal path, no locked_skipped.
+8. `cascade_refresh` per-instrument: lock not acquired → `enqueue_locked_by_sibling` called, `generate_thesis` NOT called, no entry in `failed`, `locked_skipped += 1`.
+9. `cascade_refresh` outcome summary includes `locked_skipped`.
+10. `cascade_refresh` lock-skip does NOT trigger scheduler raise (outcome.failed stays empty for locked rows).
+11. Regression: mid-cascade rollback does NOT destroy prior enqueue_retry writes (covered by the commit-after-execute pattern; integration-level test below).
+
+**Integration (real DB):**
+
+12. Two connections: A acquires lock for iid=1, B gets False on same iid. After A releases, B can acquire.
+13. Acquire + run invalid SQL inside lock body + exit: a second connection can acquire. Exercises the INERROR-recovery unlock path.
+14. `enqueue_locked_by_sibling` on empty queue inserts count=0 / LOCKED_BY_SIBLING.
+15. `enqueue_locked_by_sibling` on at-cap row is a no-op — preserves count and last_error.
+16. Durability: `enqueue_retry` on a conn with implicit read tx → mid-function call to `conn.rollback()` does NOT erase the enqueue row. Exercises the K.2 durability fix.
+17. `daily_thesis_refresh` path integration (scheduler-mocked Claude): success demotes a thesis-failure row to RERANK_NEEDED; skip leaves row untouched.
+18. `demote_to_rerank_needed` on thesis-failure row sets last_error='RERANK_NEEDED' + attempt_count=0 and preserves the row (Codex v3 HIGH regression cover — row must survive for cascade's next rerank).
+19. `demote_to_rerank_needed` on LOCKED_BY_SIBLING row demotes similarly — daily success + cascade lock-skip both resolve to a rankings-recompute signal.
+20. `demote_to_rerank_needed` on an existing RERANK_NEEDED row is a no-op (WHERE clause filters it out).
+
+## Risks
+
+- **Lock leaks on crash**: session-level locks persist until connection closes. `finally` unlock + connection-cleanup guarantees release. Postgres cleans up on connection death.
+- **Claude-call hold time**: lock held ~10-30s per thesis. Acceptable — this is exactly the mutual-exclusion window we want.
+- **`conn.commit()` vs outer explicit tx**: callers that wrap cascade in `with conn.transaction():` would break the commit-inside-helper pattern. No caller does this today. Documented in docstrings.
+- **LOCKED_BY_SIBLING benign race** (Codex LOW): holder can finish and clear the queue row before the loser inserts the marker. Resurrects a fresh count-0 row, next cycle does one wasted Claude call. Accepted — correctness holds, only efficiency is bounded.
+
+## Shipping order
+
+1. Helper refactor (commit-after-execute) + new `instrument_lock` / `enqueue_locked_by_sibling` / `LOCKED_BY_SIBLING`.
+2. `cascade_refresh` wiring.
+3. `daily_thesis_refresh` wiring (with post-success `demote_to_rerank_needed` — daily does not DELETE queue rows; only cascade's post-rerank-success path does).
+4. Unit tests (refactored + new) + integration tests.
+5. Codex pre-push + PR.

--- a/tests/test_cascade_retry_queue_integration.py
+++ b/tests/test_cascade_retry_queue_integration.py
@@ -14,12 +14,16 @@ import pytest
 
 from app.services.refresh_cascade import (
     ATTEMPT_CAP,
+    LOCKED_BY_SIBLING,
     RERANK_MARKER,
     cascade_refresh,
     clear_retry_success,
+    demote_to_rerank_needed,
     drain_retry_queue,
+    enqueue_locked_by_sibling,
     enqueue_rerank_marker,
     enqueue_retry,
+    instrument_lock,
 )
 from app.services.thesis import StaleInstrument
 from tests.fixtures.ebull_test_db import ebull_test_conn
@@ -188,3 +192,114 @@ class TestCascadeCompositionAtCapRerankFailure:
         assert _queue_row(ebull_test_conn, 42) == (0, RERANK_MARKER)
         # Next cascade cycle will pick it up.
         assert drain_retry_queue(ebull_test_conn) == [42]
+
+
+class TestInstrumentLockIntegration:
+    """Real-DB lock behaviour — cross-connection contention,
+    INERROR-recovery unlock path, release at session close."""
+
+    def test_two_connections_mutex(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Conn A acquires the lock for iid=1. Conn B on a separate
+        session gets False. After A releases, B can acquire."""
+        from tests.fixtures.ebull_test_db import test_database_url
+
+        with psycopg.connect(test_database_url()) as conn_b:
+            with instrument_lock(ebull_test_conn, 1) as a_acquired:
+                assert a_acquired is True
+                with instrument_lock(conn_b, 1) as b_acquired:
+                    assert b_acquired is False
+            # After A's context exits, lock is released.
+            with instrument_lock(conn_b, 1) as b_acquired_after:
+                assert b_acquired_after is True
+
+    def test_inerror_unlock_recovers_via_rollback(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Acquire lock, run invalid SQL inside the body to put the
+        conn in INERROR, exit normally. The lock must still release
+        — verified by a second conn acquiring immediately after."""
+        from tests.fixtures.ebull_test_db import test_database_url
+
+        with instrument_lock(ebull_test_conn, 2) as acquired:
+            assert acquired is True
+            with pytest.raises(psycopg.Error):
+                ebull_test_conn.execute("SELECT * FROM non_existent_xyz")
+        # Second connection should acquire immediately.
+        with psycopg.connect(test_database_url()) as conn_b:
+            with instrument_lock(conn_b, 2) as acquired_b:
+                assert acquired_b is True
+
+
+class TestEnqueueLockedBySiblingIntegration:
+    def test_insert_on_empty_queue(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "A")
+        enqueue_locked_by_sibling(ebull_test_conn, 1)
+        assert _queue_row(ebull_test_conn, 1) == (0, LOCKED_BY_SIBLING)
+
+    def test_preserves_existing_row(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """ON CONFLICT DO NOTHING — existing count + last_error stay."""
+        _seed_instrument(ebull_test_conn, 1, "A")
+        enqueue_retry(ebull_test_conn, 1, "RuntimeError")
+        ebull_test_conn.execute(
+            "UPDATE cascade_retry_queue SET attempt_count = %s WHERE instrument_id = 1",
+            (ATTEMPT_CAP,),
+        )
+        ebull_test_conn.commit()
+        # Sibling tries to enqueue LOCKED_BY_SIBLING — preserved.
+        enqueue_locked_by_sibling(ebull_test_conn, 1)
+        assert _queue_row(ebull_test_conn, 1) == (ATTEMPT_CAP, "RuntimeError")
+
+    def test_does_not_trample_rerank_needed(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Codex K.3 pre-push check (2): LOCKED_BY_SIBLING on an
+        existing RERANK_NEEDED row must preserve the marker via
+        ON CONFLICT DO NOTHING."""
+        _seed_instrument(ebull_test_conn, 1, "A")
+        enqueue_rerank_marker(ebull_test_conn, 1)
+        enqueue_locked_by_sibling(ebull_test_conn, 1)
+        assert _queue_row(ebull_test_conn, 1) == (0, RERANK_MARKER)
+
+
+class TestDemoteToRerankNeededIntegration:
+    def test_thesis_failure_row_demoted(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "A")
+        enqueue_retry(ebull_test_conn, 1, "RuntimeError")
+        assert _queue_row(ebull_test_conn, 1) == (1, "RuntimeError")
+        demote_to_rerank_needed(ebull_test_conn, 1)
+        assert _queue_row(ebull_test_conn, 1) == (0, RERANK_MARKER)
+
+    def test_locked_by_sibling_row_demoted(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "A")
+        enqueue_locked_by_sibling(ebull_test_conn, 1)
+        demote_to_rerank_needed(ebull_test_conn, 1)
+        assert _queue_row(ebull_test_conn, 1) == (0, RERANK_MARKER)
+
+    def test_rerank_needed_row_untouched(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Pre-existing RERANK_NEEDED row filtered out by the WHERE
+        clause — demote_to_rerank_needed is a no-op."""
+        _seed_instrument(ebull_test_conn, 1, "A")
+        enqueue_rerank_marker(ebull_test_conn, 1)
+        # Mutate the row to detect if demote touches it.
+        ebull_test_conn.execute("UPDATE cascade_retry_queue SET last_attempted_at = NULL WHERE instrument_id = 1")
+        ebull_test_conn.commit()
+        demote_to_rerank_needed(ebull_test_conn, 1)
+        # Row state unchanged — if demote had fired, last_attempted_at would have been set to NOW().
+        row = ebull_test_conn.execute(
+            "SELECT attempt_count, last_error, last_attempted_at FROM cascade_retry_queue WHERE instrument_id = 1"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == 0
+        assert row[1] == RERANK_MARKER
+        assert row[2] is None  # untouched
+
+
+class TestDurabilityOfHelperCommits:
+    """Regression for the K.3 commit-after-execute refactor — a
+    later cascade-level rollback must NOT erase a prior enqueue
+    write. Pre-K.3 the helper used ``with conn.transaction():``
+    which creates a savepoint under the implicit outer tx; the
+    savepoint's writes are lost when ``conn.rollback()`` fires."""
+
+    def test_rollback_after_enqueue_preserves_row(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "A")
+        enqueue_retry(ebull_test_conn, 1, "RuntimeError")
+        # Simulate cascade's later rollback of the implicit tx.
+        ebull_test_conn.rollback()
+        assert _queue_row(ebull_test_conn, 1) == (1, "RuntimeError")

--- a/tests/test_daily_thesis_refresh_lock.py
+++ b/tests/test_daily_thesis_refresh_lock.py
@@ -38,7 +38,12 @@ def mocked_env():  # type: ignore[no-untyped-def]
         patch.object(scheduler, "report_progress"),
     ):
         tracker = MagicMock()
-        tracker.row_count = None
+        # Defensive init: scheduler's ``tracker.row_count = generated``
+        # assignment runs inside the tracked-job body and will overwrite
+        # this. Keeping it as an int (not None) makes the downstream
+        # assertions unambiguous if the scheduler ever skipped the
+        # assignment.
+        tracker.row_count = 0
         tracked_cm.return_value.__enter__.return_value = tracker
         find_stale.side_effect = [[stale_item], []]  # T1 has one, T2 empty
         anthropic_mod.Anthropic.return_value = MagicMock()

--- a/tests/test_daily_thesis_refresh_lock.py
+++ b/tests/test_daily_thesis_refresh_lock.py
@@ -1,0 +1,102 @@
+"""Unit tests for daily_thesis_refresh's K.3 advisory-lock wiring.
+
+Mocks psycopg.connect + generate_thesis + instrument_lock +
+demote_to_rerank_needed to prove the scheduler's per-instrument
+loop behaves per spec: acquired → generate + demote, not acquired
+→ skip + count.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.workers import scheduler
+
+
+@pytest.fixture
+def mocked_env():  # type: ignore[no-untyped-def]
+    """Common patchset: skip settings check, one stale instrument."""
+    stub_settings = MagicMock()
+    stub_settings.anthropic_api_key = "test-key"
+    stub_settings.database_url = "postgresql://test"
+
+    stale_item = MagicMock()
+    stale_item.instrument_id = 101
+    stale_item.symbol = "AAPL"
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job") as tracked_cm,
+        patch.object(scheduler, "_record_prereq_skip"),
+        patch.object(scheduler, "find_stale_instruments") as find_stale,
+        patch.object(scheduler, "anthropic") as anthropic_mod,
+        patch.object(scheduler, "psycopg") as psycopg_mod,
+        patch.object(scheduler, "generate_thesis") as gen,
+        patch.object(scheduler, "report_progress"),
+    ):
+        tracker = MagicMock()
+        tracker.row_count = None
+        tracked_cm.return_value.__enter__.return_value = tracker
+        find_stale.side_effect = [[stale_item], []]  # T1 has one, T2 empty
+        anthropic_mod.Anthropic.return_value = MagicMock()
+
+        conn_mock = MagicMock()
+        psycopg_mod.connect.return_value.__enter__.return_value = conn_mock
+
+        yield {
+            "stale_item": stale_item,
+            "conn": conn_mock,
+            "generate_thesis": gen,
+            "tracker": tracker,
+        }
+
+
+def test_lock_acquired_generates_and_demotes(mocked_env) -> None:  # type: ignore[no-untyped-def]
+    """Acquired lock → generate_thesis runs, demote_to_rerank_needed
+    is called after success, NOT clear_retry_success."""
+
+    @contextmanager
+    def fake_lock(conn, iid):  # type: ignore[no-untyped-def]
+        yield True  # always acquire
+
+    with (
+        patch(
+            "app.services.refresh_cascade.instrument_lock",
+            fake_lock,
+        ),
+        patch("app.services.refresh_cascade.demote_to_rerank_needed") as demote_mock,
+        patch("app.services.refresh_cascade.clear_retry_success") as clear_mock,
+    ):
+        scheduler.daily_thesis_refresh()
+
+    mocked_env["generate_thesis"].assert_called_once()
+    demote_mock.assert_called_once_with(mocked_env["conn"], 101)
+    clear_mock.assert_not_called()
+    # tracker.row_count was set to 1 (generated)
+    assert mocked_env["tracker"].row_count == 1
+
+
+def test_lock_not_acquired_skips_without_generate(mocked_env) -> None:  # type: ignore[no-untyped-def]
+    """Lock contention → generate_thesis NOT called, demote NOT
+    called (daily doesn't enqueue on skip per K.3 spec)."""
+
+    @contextmanager
+    def fake_lock(conn, iid):  # type: ignore[no-untyped-def]
+        yield False  # sibling holds
+
+    with (
+        patch(
+            "app.services.refresh_cascade.instrument_lock",
+            fake_lock,
+        ),
+        patch("app.services.refresh_cascade.demote_to_rerank_needed") as demote_mock,
+    ):
+        scheduler.daily_thesis_refresh()
+
+    mocked_env["generate_thesis"].assert_not_called()
+    demote_mock.assert_not_called()
+    # No successful generations.
+    assert mocked_env["tracker"].row_count == 0

--- a/tests/test_daily_thesis_refresh_lock.py
+++ b/tests/test_daily_thesis_refresh_lock.py
@@ -63,18 +63,15 @@ def test_lock_acquired_generates_and_demotes(mocked_env) -> None:  # type: ignor
         yield True  # always acquire
 
     with (
-        patch(
-            "app.services.refresh_cascade.instrument_lock",
-            fake_lock,
-        ),
-        patch("app.services.refresh_cascade.demote_to_rerank_needed") as demote_mock,
-        patch("app.services.refresh_cascade.clear_retry_success") as clear_mock,
+        patch.object(scheduler, "instrument_lock", fake_lock),
+        patch.object(scheduler, "demote_to_rerank_needed") as demote_mock,
     ):
         scheduler.daily_thesis_refresh()
 
     mocked_env["generate_thesis"].assert_called_once()
     demote_mock.assert_called_once_with(mocked_env["conn"], 101)
-    clear_mock.assert_not_called()
+    # scheduler must NOT import clear_retry_success — only demote.
+    assert not hasattr(scheduler, "clear_retry_success")
     # tracker.row_count was set to 1 (generated)
     assert mocked_env["tracker"].row_count == 1
 
@@ -88,11 +85,8 @@ def test_lock_not_acquired_skips_without_generate(mocked_env) -> None:  # type: 
         yield False  # sibling holds
 
     with (
-        patch(
-            "app.services.refresh_cascade.instrument_lock",
-            fake_lock,
-        ),
-        patch("app.services.refresh_cascade.demote_to_rerank_needed") as demote_mock,
+        patch.object(scheduler, "instrument_lock", fake_lock),
+        patch.object(scheduler, "demote_to_rerank_needed") as demote_mock,
     ):
         scheduler.daily_thesis_refresh()
 

--- a/tests/test_refresh_cascade.py
+++ b/tests/test_refresh_cascade.py
@@ -220,7 +220,7 @@ class TestDemoteToRerankNeeded:
         sql = conn.execute.call_args.args[0]
         params = conn.execute.call_args.args[1]
         assert "UPDATE cascade_retry_queue" in sql
-        assert "last_error != %s" in sql
+        assert "last_error IS DISTINCT FROM %s" in sql
         assert "SET attempt_count = 0" in sql
         # (RERANK_MARKER for SET, instrument_id, RERANK_MARKER for WHERE filter)
         assert params == (RERANK_MARKER, 42, RERANK_MARKER)

--- a/tests/test_refresh_cascade.py
+++ b/tests/test_refresh_cascade.py
@@ -11,14 +11,20 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.services.refresh_cascade import (
     ATTEMPT_CAP,
+    LOCKED_BY_SIBLING,
     RERANK_MARKER,
     CascadeOutcome,
     cascade_refresh,
     changed_instruments_from_outcome,
+    demote_to_rerank_needed,
     drain_retry_queue,
+    enqueue_locked_by_sibling,
     enqueue_retry,
+    instrument_lock,
 )
 from app.services.sec_incremental import RefreshOutcome, RefreshPlan
 from app.services.thesis import StaleInstrument
@@ -138,12 +144,98 @@ class TestChangedInstrumentsFromOutcome:
 # ---------------------------------------------------------------------------
 
 
+class TestInstrumentLock:
+    def test_acquired_yields_true_and_unlocks_on_exit(self) -> None:
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (True,)
+        conn.execute.return_value = cursor
+        with instrument_lock(conn, 42) as acquired:
+            assert acquired is True
+        # First call: pg_try_advisory_lock. Second: pg_advisory_unlock.
+        assert conn.execute.call_count == 2
+        first_sql = conn.execute.call_args_list[0].args[0]
+        second_sql = conn.execute.call_args_list[1].args[0]
+        assert "pg_try_advisory_lock" in first_sql
+        assert "pg_advisory_unlock" in second_sql
+
+    def test_not_acquired_yields_false_and_no_unlock(self) -> None:
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (False,)
+        conn.execute.return_value = cursor
+        with instrument_lock(conn, 42) as acquired:
+            assert acquired is False
+        # Only the pg_try_advisory_lock call — no unlock.
+        assert conn.execute.call_count == 1
+
+    def test_unlocks_even_if_body_raises(self) -> None:
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (True,)
+        conn.execute.return_value = cursor
+        with pytest.raises(RuntimeError):
+            with instrument_lock(conn, 42):
+                raise RuntimeError("body failed")
+        # Unlock still ran
+        assert conn.execute.call_count == 2
+
+    def test_unlock_retries_after_psycopg_error(self) -> None:
+        conn = MagicMock()
+        lock_cursor = MagicMock()
+        lock_cursor.fetchone.return_value = (True,)
+        # First unlock raises psycopg.Error; rollback succeeds; second unlock succeeds.
+        import psycopg as _psycopg
+
+        conn.execute.side_effect = [
+            lock_cursor,  # pg_try_advisory_lock
+            _psycopg.Error("connection INERROR"),  # first unlock
+            MagicMock(),  # second unlock after rollback
+        ]
+        with instrument_lock(conn, 42) as acquired:
+            assert acquired is True
+        conn.rollback.assert_called_once()
+        assert conn.execute.call_count == 3
+
+
+class TestEnqueueLockedBySibling:
+    def test_insert_on_conflict_do_nothing_and_commits(self) -> None:
+        conn = MagicMock()
+        enqueue_locked_by_sibling(conn, 42)
+        conn.execute.assert_called_once()
+        conn.commit.assert_called_once()
+        sql = conn.execute.call_args.args[0]
+        params = conn.execute.call_args.args[1]
+        assert "INSERT INTO cascade_retry_queue" in sql
+        assert "ON CONFLICT (instrument_id) DO NOTHING" in sql
+        assert params == (42, LOCKED_BY_SIBLING)
+
+
+class TestDemoteToRerankNeeded:
+    def test_update_with_rerank_marker_filter_and_commits(self) -> None:
+        conn = MagicMock()
+        demote_to_rerank_needed(conn, 42)
+        conn.execute.assert_called_once()
+        conn.commit.assert_called_once()
+        sql = conn.execute.call_args.args[0]
+        params = conn.execute.call_args.args[1]
+        assert "UPDATE cascade_retry_queue" in sql
+        assert "last_error != %s" in sql
+        assert "SET attempt_count = 0" in sql
+        # (RERANK_MARKER for SET, instrument_id, RERANK_MARKER for WHERE filter)
+        assert params == (RERANK_MARKER, 42, RERANK_MARKER)
+
+
 class TestEnqueueRetry:
-    def test_wraps_in_transaction_and_upserts(self) -> None:
+    def test_executes_upsert_and_commits(self) -> None:
+        """K.3 refactor: helpers commit explicitly rather than using
+        ``with conn.transaction():``. This makes the queue write
+        durable regardless of implicit-tx state so a later
+        cascade-level rollback cannot erase it."""
         conn = MagicMock()
         enqueue_retry(conn, 42, "RuntimeError")
-        conn.transaction.assert_called_once()
         conn.execute.assert_called_once()
+        conn.commit.assert_called_once()
         args, _ = conn.execute.call_args
         sql = args[0]
         params = args[1]
@@ -456,6 +548,74 @@ class TestCascadeRefresh:
         """Sanity: the marker string is importable and matches the
         spec wording used in admin surfaces (Chunk H)."""
         assert RERANK_MARKER == "RERANK_NEEDED"
+
+    def test_locked_by_sibling_skips_generate_and_enqueues_marker(
+        self,
+    ) -> None:
+        """K.3: when instrument_lock returns False, cascade must
+        NOT call generate_thesis, MUST write a LOCKED_BY_SIBLING
+        marker via enqueue_locked_by_sibling, and MUST increment
+        locked_skipped without adding to failed."""
+        conn = MagicMock()
+        client = MagicMock()
+        stale_rows = [
+            StaleInstrument(instrument_id=7, symbol="LOCKED", reason="event_new_10q"),
+        ]
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_lock(conn_, iid):  # type: ignore[no-untyped-def]
+            yield False  # never acquired
+
+        with (
+            patch("app.services.refresh_cascade.drain_retry_queue", return_value=[]),
+            patch(
+                "app.services.refresh_cascade.find_stale_instruments",
+                return_value=stale_rows,
+            ),
+            patch("app.services.refresh_cascade.instrument_lock", fake_lock),
+            patch("app.services.refresh_cascade.generate_thesis") as gen_mock,
+            patch("app.services.refresh_cascade.enqueue_locked_by_sibling") as lbs_mock,
+            patch("app.services.refresh_cascade.compute_rankings") as rank_mock,
+        ):
+            outcome = cascade_refresh(conn, client, [7])
+
+        gen_mock.assert_not_called()
+        lbs_mock.assert_called_once_with(conn, 7)
+        rank_mock.assert_not_called()  # nothing to rerank
+        assert outcome.locked_skipped == 1
+        assert outcome.thesis_refreshed == 0
+        assert outcome.failed == ()  # locked-skip is NOT a failure
+
+    def test_locked_by_sibling_on_retry_path(self) -> None:
+        """Retry path also respects the lock."""
+        conn = MagicMock()
+        client = MagicMock()
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_lock(conn_, iid):  # type: ignore[no-untyped-def]
+            yield False
+
+        with (
+            patch(
+                "app.services.refresh_cascade.drain_retry_queue",
+                return_value=[99],
+            ),
+            patch("app.services.refresh_cascade.find_stale_instruments", return_value=[]),
+            patch("app.services.refresh_cascade.instrument_lock", fake_lock),
+            patch("app.services.refresh_cascade.generate_thesis") as gen_mock,
+            patch("app.services.refresh_cascade.enqueue_locked_by_sibling") as lbs_mock,
+        ):
+            outcome = cascade_refresh(conn, client, [])
+
+        gen_mock.assert_not_called()
+        lbs_mock.assert_called_once_with(conn, 99)
+        assert outcome.locked_skipped == 1
+        assert outcome.retries_drained == 1
+        assert outcome.failed == ()
 
     def test_non_psycopg_exception_from_enqueue_retry_does_not_abort_loop(
         self,


### PR DESCRIPTION
## What
Session-level `pg_try_advisory_lock(instrument_id)` around every `generate_thesis` call in both `cascade_refresh` and `daily_thesis_refresh`. Prevents duplicate Claude calls + commit race on overlap. Also fixes a K.2 durability gap surfaced by Codex — queue helpers now commit explicitly so mid-cascade rollback cannot erase prior queue writes.

## Why
Today cascade and daily_thesis both call `generate_thesis` on the same schedule window. Without mutex, overlap → two Claude calls + late-writer-wins on thesis row. Session-level lock (not xact-level) spans the internal commit-before-Claude from #293.

## Test plan
- [x] 31 unit tests — lock acquire/unlock, INERROR recovery, helper SQL contract, cascade lock-skip path.
- [x] 18 integration tests — cross-connection mutex, LOCKED_BY_SIBLING preservation of RERANK_NEEDED + at-cap rows, demote filter, durability regression.
- [x] 2 scheduler-side tests proving daily success calls demote (not clear).
- [x] Gates clean (ruff / format / pyright / 1895 passed).
- [x] Spec approved over 4 Codex iterations — SPEC APPROVED.
- [x] Pre-push Codex — no BLOCKER/HIGH, 2 LOWs addressed with the final two regression tests.

## Notes for reviewer
- Skip semantics: lock contention is NEITHER success nor failure. Cascade writes `LOCKED_BY_SIBLING` via `enqueue_locked_by_sibling` (INSERT ON CONFLICT DO NOTHING so existing rows are preserved). Daily logs + increments `locked_skipped`.
- Daily success calls `demote_to_rerank_needed` — updates pending thesis-failure / LOCKED_BY_SIBLING rows to RERANK_NEEDED / count=0, preserves pre-existing RERANK_NEEDED. Rationale: daily doesn't run `compute_rankings`, so the rankings-recompute signal must persist for cascade's next cycle.
- K.2 durability fix: all queue helpers (enqueue_retry, enqueue_rerank_marker, clear_retry_success, enqueue_locked_by_sibling, demote_to_rerank_needed) drop `with conn.transaction():` and use `conn.execute + conn.commit()`. Callers MUST NOT wrap cascade in an outer explicit tx — documented in module comment.