### PR TITLE
feat(#276): cascade observability + freshness wiring (K.4)

### DIFF
--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -404,15 +404,32 @@ def cascade_refresh(
     # observable separately from daily_financial_facts' fundamentals
     # telemetry. Populated with thesis_refreshed / locked_skipped /
     # failed counts at the end of the run. The row exists across
-    # both success and failure paths; status='failure' captures the
+    # both success and failure paths; status='failed' captures the
     # raise-inducing cascade_outcome.failed case.
-    run_id = start_ingestion_run(
-        conn,
-        source=CASCADE_RUN_SOURCE,
-        endpoint=None,
-        instrument_count=len(retry_ids) + len(stale),
-    )
-    conn.commit()
+    #
+    # Guard against start_ingestion_run failures: if the INSERT
+    # itself raises (DB down, constraint drift), we log and skip
+    # the telemetry row — cascade work itself still runs. run_id
+    # stays None so the finish_ingestion_run call is skipped too,
+    # avoiding an unbound-name crash.
+    run_id: int | None = None
+    try:
+        run_id = start_ingestion_run(
+            conn,
+            source=CASCADE_RUN_SOURCE,
+            endpoint=None,
+            instrument_count=len(retry_ids) + len(stale),
+        )
+        conn.commit()
+    except Exception:
+        logger.exception("cascade_refresh: start_ingestion_run failed — continuing without telemetry row")
+        try:
+            conn.rollback()
+        except psycopg.Error:
+            logger.debug(
+                "cascade_refresh: rollback suppressed after start_ingestion_run failure",
+                exc_info=True,
+            )
 
     thesis_refreshed = 0
     failed: list[tuple[int, str]] = []
@@ -574,24 +591,26 @@ def cascade_refresh(
         len(failed),
     )
 
-    # K.4: finalize ingestion-run telemetry. status=failure when any
+    # K.4: finalize ingestion-run telemetry. status=failed when any
     # per-instrument or rerank failure occurred so the freshness
     # predicate does not treat a degraded run as a clean one.
-    try:
-        finish_ingestion_run(
-            conn,
-            run_id=run_id,
-            status="failed" if failed else "success",
-            rows_upserted=thesis_refreshed,
-            rows_skipped=locked_skipped,
-            error=(f"{len(failed)} failures: {failed}" if failed else None),
-        )
-        conn.commit()
-    except Exception:
-        logger.exception(
-            "cascade_refresh: finish_ingestion_run failed (run_id=%d) — telemetry may be stale until next cycle",
-            run_id,
-        )
+    # Skipped when start_ingestion_run earlier failed (run_id is None).
+    if run_id is not None:
+        try:
+            finish_ingestion_run(
+                conn,
+                run_id=run_id,
+                status="failed" if failed else "success",
+                rows_upserted=thesis_refreshed,
+                rows_skipped=locked_skipped,
+                error=(f"{len(failed)} failures: {failed}" if failed else None),
+            )
+            conn.commit()
+        except Exception:
+            logger.exception(
+                "cascade_refresh: finish_ingestion_run failed (run_id=%d) — telemetry may be stale until next cycle",
+                run_id,
+            )
 
     return CascadeOutcome(
         instruments_considered=len(instrument_ids),

--- a/app/services/refresh_cascade.py
+++ b/app/services/refresh_cascade.py
@@ -42,9 +42,12 @@ from typing import Any
 import anthropic
 import psycopg
 
+from app.services.financial_facts import finish_ingestion_run, start_ingestion_run
 from app.services.scoring import compute_rankings
 from app.services.sec_incremental import RefreshOutcome, RefreshPlan
 from app.services.thesis import find_stale_instruments, generate_thesis
+
+CASCADE_RUN_SOURCE: str = "cascade_refresh"
 
 logger = logging.getLogger(__name__)
 
@@ -397,6 +400,20 @@ def cascade_refresh(
             retries_drained=0,
         )
 
+    # K.4: record a data_ingestion_runs row so cascade work is
+    # observable separately from daily_financial_facts' fundamentals
+    # telemetry. Populated with thesis_refreshed / locked_skipped /
+    # failed counts at the end of the run. The row exists across
+    # both success and failure paths; status='failure' captures the
+    # raise-inducing cascade_outcome.failed case.
+    run_id = start_ingestion_run(
+        conn,
+        source=CASCADE_RUN_SOURCE,
+        endpoint=None,
+        instrument_count=len(retry_ids) + len(stale),
+    )
+    conn.commit()
+
     thesis_refreshed = 0
     failed: list[tuple[int, str]] = []
     processed_ok: list[int] = []
@@ -556,6 +573,25 @@ def cascade_refresh(
         rankings_recomputed,
         len(failed),
     )
+
+    # K.4: finalize ingestion-run telemetry. status=failure when any
+    # per-instrument or rerank failure occurred so the freshness
+    # predicate does not treat a degraded run as a clean one.
+    try:
+        finish_ingestion_run(
+            conn,
+            run_id=run_id,
+            status="failed" if failed else "success",
+            rows_upserted=thesis_refreshed,
+            rows_skipped=locked_skipped,
+            error=(f"{len(failed)} failures: {failed}" if failed else None),
+        )
+        conn.commit()
+    except Exception:
+        logger.exception(
+            "cascade_refresh: finish_ingestion_run failed (run_id=%d) — telemetry may be stale until next cycle",
+            run_id,
+        )
 
     return CascadeOutcome(
         instruments_considered=len(instrument_ids),

--- a/app/services/sync_orchestrator/freshness.py
+++ b/app/services/sync_orchestrator/freshness.py
@@ -18,7 +18,7 @@ BEFORE ordering would hide a newer failure behind an older success.
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 import psycopg
@@ -221,9 +221,13 @@ def thesis_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
         ).fetchone()
         if cascade_row is None or cascade_row[0] is None or cascade_row[1] != "success":
             return False, audit_detail
-        from datetime import UTC, datetime
-
         finished_at = cascade_row[0]
+        # data_ingestion_runs.finished_at is TIMESTAMPTZ so psycopg3
+        # returns aware datetimes. Defensive coerce in case a future
+        # adapter config strips tz — subtracting aware from naive
+        # raises TypeError at runtime.
+        if finished_at.tzinfo is None:
+            finished_at = finished_at.replace(tzinfo=UTC)
         age = datetime.now(UTC) - finished_at
         if age >= timedelta(hours=24):
             return False, f"{audit_detail}; cascade_refresh last success {_format_age(age)} ago"

--- a/app/services/sync_orchestrator/freshness.py
+++ b/app/services/sync_orchestrator/freshness.py
@@ -202,9 +202,33 @@ def news_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
 
 
 def thesis_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
+    # K.4: thesis is refreshed by TWO independent paths —
+    # daily_thesis_refresh (its own scheduled job) and cascade_refresh
+    # (runs inside daily_financial_facts). Either a recent
+    # daily_thesis_refresh job_runs row OR a recent successful
+    # cascade_refresh ingestion run is sufficient audit evidence.
     audit_fresh, audit_detail = _fresh_by_audit(conn, "daily_thesis_refresh", timedelta(hours=24))
     if not audit_fresh:
-        return False, audit_detail
+        cascade_row = conn.execute(
+            """
+            SELECT finished_at, status
+            FROM data_ingestion_runs
+            WHERE source = 'cascade_refresh'
+              AND finished_at IS NOT NULL
+            ORDER BY finished_at DESC
+            LIMIT 1
+            """
+        ).fetchone()
+        if cascade_row is None or cascade_row[0] is None or cascade_row[1] != "success":
+            return False, audit_detail
+        from datetime import UTC, datetime
+
+        finished_at = cascade_row[0]
+        age = datetime.now(UTC) - finished_at
+        if age >= timedelta(hours=24):
+            return False, f"{audit_detail}; cascade_refresh last success {_format_age(age)} ago"
+        audit_detail = f"cascade_refresh success {_format_age(age)} ago (daily_thesis_refresh stale)"
+
     from app.services.thesis import find_stale_instruments
 
     stale_t1 = find_stale_instruments(conn, tier=1)

--- a/tests/test_cascade_retry_queue_integration.py
+++ b/tests/test_cascade_retry_queue_integration.py
@@ -290,6 +290,61 @@ class TestDemoteToRerankNeededIntegration:
         assert row[2] is None  # untouched
 
 
+class TestCascadeObservabilityRun:
+    """K.4 — cascade_refresh must write its own data_ingestion_runs
+    row so sync_orchestrator/freshness.py can detect recent cascade
+    activity independently of daily_thesis_refresh."""
+
+    def test_clean_run_writes_success_row(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "A")
+        stale_rows = [StaleInstrument(instrument_id=1, symbol="A", reason="event_new_10q")]
+        with (
+            patch(
+                "app.services.refresh_cascade.find_stale_instruments",
+                return_value=stale_rows,
+            ),
+            patch("app.services.refresh_cascade.generate_thesis"),
+            patch(
+                "app.services.refresh_cascade.compute_rankings",
+                return_value=MagicMock(scored=[]),
+            ),
+        ):
+            cascade_refresh(ebull_test_conn, MagicMock(), [1])
+
+        row = ebull_test_conn.execute(
+            "SELECT source, status, rows_upserted, rows_skipped FROM data_ingestion_runs "
+            "ORDER BY ingestion_run_id DESC LIMIT 1"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "cascade_refresh"
+        assert row[1] == "success"
+        assert row[2] == 1  # thesis_refreshed
+        assert row[3] == 0  # locked_skipped
+
+    def test_failed_run_writes_failed_row_with_error(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_instrument(ebull_test_conn, 1, "A")
+        stale_rows = [StaleInstrument(instrument_id=1, symbol="A", reason="event_new_10q")]
+        with (
+            patch(
+                "app.services.refresh_cascade.find_stale_instruments",
+                return_value=stale_rows,
+            ),
+            patch("app.services.refresh_cascade.generate_thesis"),
+            patch(
+                "app.services.refresh_cascade.compute_rankings",
+                side_effect=RuntimeError("scoring broke"),
+            ),
+        ):
+            cascade_refresh(ebull_test_conn, MagicMock(), [1])
+
+        row = ebull_test_conn.execute(
+            "SELECT status, error FROM data_ingestion_runs ORDER BY ingestion_run_id DESC LIMIT 1"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "failed"
+        assert "RuntimeError" in row[1]
+
+
 class TestDurabilityOfHelperCommits:
     """Regression for the K.3 commit-after-execute refactor — a
     later cascade-level rollback must NOT erase a prior enqueue

--- a/tests/test_sync_orchestrator_freshness.py
+++ b/tests/test_sync_orchestrator_freshness.py
@@ -224,6 +224,72 @@ class TestThesisIsFresh:
         fresh, _ = thesis_is_fresh(conn)
         assert fresh is True
 
+    def test_fresh_via_cascade_when_daily_thesis_refresh_stale(self, monkeypatch) -> None:
+        """K.4: if daily_thesis_refresh is stale/absent, a recent
+        successful cascade_refresh ingestion run is sufficient
+        audit evidence. Thesis is refreshed by either path."""
+        now = datetime.now(UTC)
+        # First fetchone: job_runs row is stale (48h old success).
+        stale_audit = (
+            now - timedelta(hours=48),
+            "success",
+            None,
+            timedelta(hours=48).total_seconds(),
+        )
+        # Second fetchone: cascade_refresh run finished 2h ago, success.
+        cascade_row = (now - timedelta(hours=2), "success")
+        conn = _mock_conn_with_rows([stale_audit, cascade_row])
+        monkeypatch.setattr(
+            "app.services.thesis.find_stale_instruments",
+            lambda _conn, tier: [],
+        )
+        fresh, detail = thesis_is_fresh(conn)
+        assert fresh is True
+        assert "cascade_refresh" in detail
+
+    def test_stale_when_both_audit_and_cascade_stale(self, monkeypatch) -> None:
+        """Both signals stale → thesis layer is stale."""
+        now = datetime.now(UTC)
+        stale_audit = (
+            now - timedelta(hours=48),
+            "success",
+            None,
+            timedelta(hours=48).total_seconds(),
+        )
+        # cascade_refresh last success 30h ago (outside 24h window).
+        cascade_row = (now - timedelta(hours=30), "success")
+        conn = _mock_conn_with_rows([stale_audit, cascade_row])
+        fresh, detail = thesis_is_fresh(conn)
+        assert fresh is False
+        assert "cascade_refresh last success" in detail
+
+    def test_stale_when_daily_stale_and_no_cascade_row(self, monkeypatch) -> None:
+        """daily_thesis_refresh stale AND no cascade row at all → stale."""
+        now = datetime.now(UTC)
+        stale_audit = (
+            now - timedelta(hours=48),
+            "success",
+            None,
+            timedelta(hours=48).total_seconds(),
+        )
+        conn = _mock_conn_with_rows([stale_audit, None])
+        fresh, _ = thesis_is_fresh(conn)
+        assert fresh is False
+
+    def test_stale_when_cascade_last_run_failed(self, monkeypatch) -> None:
+        """daily stale AND cascade last run within-window but status=failed → stale."""
+        now = datetime.now(UTC)
+        stale_audit = (
+            now - timedelta(hours=48),
+            "success",
+            None,
+            timedelta(hours=48).total_seconds(),
+        )
+        cascade_row = (now - timedelta(hours=1), "failed")
+        conn = _mock_conn_with_rows([stale_audit, cascade_row])
+        fresh, _ = thesis_is_fresh(conn)
+        assert fresh is False
+
 
 class TestScoringIsFresh:
     def test_stale_when_latest_score_older_than_thesis(self) -> None:


### PR DESCRIPTION
## What
Closes the cascade stream. `cascade_refresh` now writes its own `data_ingestion_runs` row; `thesis_is_fresh` accepts a recent cascade-run as alternate audit evidence when `daily_thesis_refresh` has gone stale.

## Why
K.1-K.3 made the cascade path fully functional but it was invisible to the sync orchestrator's freshness predicates. Without this, a freshly cascaded thesis would show as stale solely because `daily_thesis_refresh` hadn't run — even though the cascade just did the same job.

## Test plan
- [x] 4 new unit tests for `thesis_is_fresh` fallback matrix.
- [x] 2 new integration tests for the `data_ingestion_runs` write (success + failed paths).
- [x] Gates clean (ruff / pyright / 1901 passed).

## Out of scope
- Per-layer cascade sync-orchestrator entry: deferred. The observability signal via `data_ingestion_runs` is enough to close the freshness gap; a dedicated sync layer is nice-to-have for Chunk H's admin UI.