### PR TITLE
feat(#268): weekly_coverage_audit scheduler job (Chunk F, audit-only)

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -72,6 +72,7 @@ from app.workers.scheduler import (
     JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
     JOB_RETRY_DEFERRED,
     JOB_SEED_COST_MODELS,
+    JOB_WEEKLY_COVERAGE_AUDIT,
     JOB_WEEKLY_COVERAGE_REVIEW,
     JOB_WEEKLY_REPORT,
     SCHEDULED_JOBS,
@@ -97,6 +98,7 @@ from app.workers.scheduler import (
     orchestrator_high_frequency_sync,
     retry_deferred_recommendations_job,
     seed_cost_models,
+    weekly_coverage_audit,
     weekly_coverage_review,
     weekly_report,
 )
@@ -136,6 +138,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_DAILY_PORTFOLIO_SYNC: daily_portfolio_sync,
     JOB_EXECUTE_APPROVED_ORDERS: execute_approved_orders,
     JOB_MORNING_CANDIDATE_REVIEW: morning_candidate_review,
+    JOB_WEEKLY_COVERAGE_AUDIT: weekly_coverage_audit,
     JOB_WEEKLY_COVERAGE_REVIEW: weekly_coverage_review,
     JOB_DAILY_TAX_RECONCILIATION: daily_tax_reconciliation,
     JOB_RETRY_DEFERRED: retry_deferred_recommendations_job,

--- a/app/services/sync_orchestrator/registry.py
+++ b/app/services/sync_orchestrator/registry.py
@@ -213,9 +213,10 @@ JOB_TO_LAYERS: dict[str, tuple[str, ...]] = {
     "weekly_report": ("weekly_reports",),
     "monthly_report": ("monthly_reports",),
     "fx_rates_refresh": ("fx_rates",),
-    # Outside-DAG (6 entries, empty tuples):
+    # Outside-DAG (7 entries, empty tuples):
     "execute_approved_orders": (),
     "weekly_coverage_review": (),
+    "weekly_coverage_audit": (),
     "retry_deferred_recommendations": (),
     "monitor_positions": (),
     "attribution_summary": (),

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -217,6 +217,7 @@ JOB_DAILY_NEWS_REFRESH = "daily_news_refresh"
 JOB_DAILY_THESIS_REFRESH = "daily_thesis_refresh"
 JOB_MORNING_CANDIDATE_REVIEW = "morning_candidate_review"
 JOB_WEEKLY_COVERAGE_REVIEW = "weekly_coverage_review"
+JOB_WEEKLY_COVERAGE_AUDIT = "weekly_coverage_audit"
 JOB_DAILY_TAX_RECONCILIATION = "daily_tax_reconciliation"
 JOB_DAILY_PORTFOLIO_SYNC = "daily_portfolio_sync"
 JOB_EXECUTE_APPROVED_ORDERS = "execute_approved_orders"
@@ -438,6 +439,16 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         name=JOB_WEEKLY_COVERAGE_REVIEW,
         description="Review coverage tier assignments; promote/demote instruments.",
         cadence=Cadence.weekly(weekday=0, hour=5, minute=0),
+        prerequisite=_has_any_coverage,
+    ),
+    ScheduledJob(
+        name=JOB_WEEKLY_COVERAGE_AUDIT,
+        description=(
+            "Re-classify every tradable instrument's coverage.filings_status "
+            "using the current filing_events set. Surfaces instruments that "
+            "drifted from analysable (insufficient, structurally_young, etc.)."
+        ),
+        cadence=Cadence.weekly(weekday=1, hour=4, minute=0),  # Tuesday 04:00 UTC
         prerequisite=_has_any_coverage,
     ),
     ScheduledJob(
@@ -2068,6 +2079,45 @@ def monitor_positions_job() -> None:
                 "monitor_positions: %d positions checked, no alerts",
                 result.positions_checked,
             )
+
+
+def weekly_coverage_audit() -> None:
+    """Re-classify every tradable instrument's ``coverage.filings_status``
+    using the current ``filing_events`` set (#268 Chunk F minimal).
+
+    Runs Tuesday 04:00 UTC. Scope is deliberately audit-only — the
+    master plan's full Chunk F includes historical backfill via
+    Chunk E's ``backfill_filings`` helper, which is not yet shipped.
+    Until E lands, this job surfaces drift (analysable → insufficient,
+    etc.) so ops can see it without auto-remediating.
+
+    Idempotent; uses the existing ``audit_all_instruments`` bulk-
+    UPDATE path which only touches rows whose status actually
+    changed.
+    """
+    with _tracked_job(JOB_WEEKLY_COVERAGE_AUDIT) as tracker:
+        from app.services.coverage_audit import audit_all_instruments
+
+        logger.info("weekly_coverage_audit: starting bulk classifier")
+        try:
+            with psycopg.connect(settings.database_url) as conn:
+                summary = audit_all_instruments(conn)
+        except Exception:
+            logger.error("weekly_coverage_audit: failed", exc_info=True)
+            raise
+
+        tracker.row_count = summary.total_updated
+
+    logger.info(
+        "weekly_coverage_audit complete: analysable=%d insufficient=%d "
+        "fpi=%d no_primary_sec_cik=%d total_updated=%d null_anomalies=%d",
+        summary.analysable,
+        summary.insufficient,
+        summary.fpi,
+        summary.no_primary_sec_cik,
+        summary.total_updated,
+        summary.null_anomalies,
+    )
 
 
 def weekly_coverage_review() -> None:

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -2107,17 +2107,21 @@ def weekly_coverage_audit() -> None:
             raise
 
         tracker.row_count = summary.total_updated
-
-    logger.info(
-        "weekly_coverage_audit complete: analysable=%d insufficient=%d "
-        "fpi=%d no_primary_sec_cik=%d total_updated=%d null_anomalies=%d",
-        summary.analysable,
-        summary.insufficient,
-        summary.fpi,
-        summary.no_primary_sec_cik,
-        summary.total_updated,
-        summary.null_anomalies,
-    )
+        # Log inside the with so ``summary`` is always bound at the
+        # point of use. Hoisting the log after the with would leak
+        # a NameError if _tracked_job.__exit__ raises (tracker
+        # write-back failure, etc.) because ``summary`` would be
+        # bound only in a now-torn-down scope.
+        logger.info(
+            "weekly_coverage_audit complete: analysable=%d insufficient=%d "
+            "fpi=%d no_primary_sec_cik=%d total_updated=%d null_anomalies=%d",
+            summary.analysable,
+            summary.insufficient,
+            summary.fpi,
+            summary.no_primary_sec_cik,
+            summary.total_updated,
+            summary.null_anomalies,
+        )
 
 
 def weekly_coverage_review() -> None:

--- a/tests/test_sync_orchestrator_registry.py
+++ b/tests/test_sync_orchestrator_registry.py
@@ -92,6 +92,7 @@ class TestJobToLayers:
         assert JOB_TO_LAYERS["monitor_positions"] == ()
         assert JOB_TO_LAYERS["retry_deferred_recommendations"] == ()
         assert JOB_TO_LAYERS["weekly_coverage_review"] == ()
+        assert JOB_TO_LAYERS["weekly_coverage_audit"] == ()
         assert JOB_TO_LAYERS["attribution_summary"] == ()
         assert JOB_TO_LAYERS["daily_tax_reconciliation"] == ()
 

--- a/tests/test_weekly_coverage_audit.py
+++ b/tests/test_weekly_coverage_audit.py
@@ -1,0 +1,77 @@
+"""Tests for the weekly_coverage_audit scheduler job (#268 Chunk F, minimal).
+
+Audit-only variant shipped before Chunk E's backfill helper — the job
+calls audit_all_instruments and logs the AuditSummary, no remediation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.services.coverage_audit import AuditSummary
+from app.workers import scheduler
+
+
+def test_weekly_coverage_audit_runs_audit_and_sets_row_count() -> None:
+    """Happy path: audit_all_instruments returns a summary; tracker.row_count
+    is set to total_updated; no raise."""
+    summary = AuditSummary(
+        analysable=42,
+        insufficient=5,
+        fpi=1,
+        no_primary_sec_cik=3,
+        total_updated=7,
+        null_anomalies=0,
+    )
+
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+
+    tracker = MagicMock()
+    tracker.row_count = None
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job") as tracked_cm,
+        patch.object(scheduler, "psycopg") as psycopg_mod,
+        patch(
+            "app.services.coverage_audit.audit_all_instruments",
+            return_value=summary,
+        ) as audit_mock,
+    ):
+        tracked_cm.return_value.__enter__.return_value = tracker
+        conn_mock = MagicMock()
+        psycopg_mod.connect.return_value.__enter__.return_value = conn_mock
+
+        scheduler.weekly_coverage_audit()
+
+    audit_mock.assert_called_once_with(conn_mock)
+    assert tracker.row_count == 7
+
+
+def test_weekly_coverage_audit_propagates_failure() -> None:
+    """audit_all_instruments raising must propagate so _tracked_job
+    records status=failure. No silent swallow."""
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+
+    tracker = MagicMock()
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job") as tracked_cm,
+        patch.object(scheduler, "psycopg") as psycopg_mod,
+        patch(
+            "app.services.coverage_audit.audit_all_instruments",
+            side_effect=RuntimeError("classifier broke"),
+        ),
+    ):
+        tracked_cm.return_value.__enter__.return_value = tracker
+        psycopg_mod.connect.return_value.__enter__.return_value = MagicMock()
+
+        try:
+            scheduler.weekly_coverage_audit()
+        except RuntimeError as exc:
+            assert "classifier broke" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError to propagate")

--- a/tests/test_weekly_coverage_audit.py
+++ b/tests/test_weekly_coverage_audit.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+# Import the module at module-level so ``patch("app.services.coverage_audit.X")``
+# has a concrete target BEFORE the lazy ``from app.services.coverage_audit import
+# audit_all_instruments`` inside ``weekly_coverage_audit`` resolves its binding.
+import app.services.coverage_audit  # noqa: F401
 from app.services.coverage_audit import AuditSummary
 from app.workers import scheduler
 


### PR DESCRIPTION
## What
New Tuesday 04:00 UTC `weekly_coverage_audit` job that runs `audit_all_instruments` and logs the per-status counts. Surfaces coverage drift without auto-remediating.

## Why
Chunk J already gates scoring/thesis on `filings_status = 'analysable'`. Without a periodic audit, an instrument that drifts (filings gap, amendment noise) stays classified as-of-last-audit and silently dropped from scoring. The weekly job closes that gap.

## Test plan
- [x] 2 new unit tests — happy path + failure propagation.
- [x] JOB_TO_LAYERS registry updated + test.
- [x] Gates clean (ruff / pyright / 1897 passed).

## Scope notes
- **Audit-only.** The full master-plan Chunk F also wraps `audit_all_instruments` with `backfill_filings` from Chunk E to auto-remediate `insufficient` / `structurally_young` rows. E is ~2 days and not yet shipped. Shipping F's surface now means weekly drift visibility, deferring remediation until E lands.
- Wired as outside-DAG (empty layer tuple) because the audit is a side-channel — it updates `coverage` in place, not a sync layer's output.