### PR TITLE
feat(#268): historical filings backfill + weekly audit extension (Chunk E + F)

### DIFF
--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -376,6 +376,25 @@ class SecFilingsProvider(FilingsProvider):
         cik_padded = _zero_pad_cik(cik)
         return self._fetch_submissions(cik_padded)
 
+    def fetch_submissions_page(self, name: str) -> dict[str, object] | None:
+        """Fetch a secondary submissions page named in
+        ``filings.files[].name`` (e.g. ``CIK0000320193-submissions-001.json``).
+
+        Used by Chunk E's pagination loop (#268). Returns the parsed
+        JSON dict or ``None`` on 404. Uses the same rate-limited HTTP
+        client as ``fetch_submissions`` so the 10 req/s SEC cap is
+        respected across the combined call pattern.
+        """
+        path = f"/submissions/{name}"
+        resp = self._http.get(path)
+        if resp.status_code == 404:
+            logger.warning("SEC: submissions page not found: %s", name)
+            return None
+        resp.raise_for_status()
+        raw = resp.json()
+        _persist_raw(f"sec_submissions_page_{name}", raw)
+        return raw  # type: ignore[return-value]
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
@@ -416,38 +435,36 @@ def _parse_cik_mapping(raw: object) -> dict[str, str]:
     return mapping
 
 
-def _normalise_filings(
-    raw: dict[str, object],
+def _normalise_submissions_block(
+    block: dict[str, object],
     cik_padded: str,
-    start_date: date | None,
-    end_date: date | None,
-    filing_types: list[str] | None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    filing_types: list[str] | None = None,
+    symbol: str | None = None,
 ) -> list[FilingSearchResult]:
+    """Pure normalisation of one submissions page (either the
+    inline ``filings.recent`` sub-dict or a ``files[]`` secondary
+    page JSON).
+
+    Both shapes carry the same parallel arrays —
+    ``{accessionNumber, filingDate, form, primaryDocument, reportDate}``
+    — so Chunk E's pagination loop (#268) can call this per page
+    without re-fetching the primary ``submissions.json``.
+
+    ``symbol`` is used to populate ``FilingSearchResult.symbol``; if
+    omitted the accession number is used as a fallback (matches the
+    pre-refactor behaviour on empty ``tickers``).
     """
-    Normalise an EDGAR submissions JSON response into FilingSearchResult list.
-
-    The submissions JSON has recent filings inline under raw["filings"]["recent"]
-    and may reference additional filing pages under raw["filings"]["files"].
-    V1 only processes the inline "recent" block.
-    """
-    filings_block = raw.get("filings")
-    if not isinstance(filings_block, dict):
-        return []
-
-    recent = filings_block.get("recent")
-    if not isinstance(recent, dict):
-        return []
-
-    accession_numbers: list[str] = recent.get("accessionNumber") or []  # type: ignore[assignment]
-    filing_dates: list[str] = recent.get("filingDate") or []  # type: ignore[assignment]
-    form_types: list[str] = recent.get("form") or []  # type: ignore[assignment]
-    primary_docs: list[str] = recent.get("primaryDocument") or []  # type: ignore[assignment]
-    report_dates: list[str | None] = recent.get("reportDate") or []  # type: ignore[assignment]
+    accession_numbers: list[str] = block.get("accessionNumber") or []  # type: ignore[assignment]
+    filing_dates: list[str] = block.get("filingDate") or []  # type: ignore[assignment]
+    form_types: list[str] = block.get("form") or []  # type: ignore[assignment]
+    primary_docs: list[str] = block.get("primaryDocument") or []  # type: ignore[assignment]
+    report_dates: list[str | None] = block.get("reportDate") or []  # type: ignore[assignment]
 
     results: list[FilingSearchResult] = []
     for i, accession in enumerate(accession_numbers):
         form = form_types[i] if i < len(form_types) else ""
-        # Skip entries with no form type rather than storing an empty string
         if not form:
             continue
         if filing_types and form not in filing_types:
@@ -483,7 +500,7 @@ def _normalise_filings(
         results.append(
             FilingSearchResult(
                 provider_filing_id=accession,
-                symbol=raw.get("tickers", [accession])[0] if isinstance(raw.get("tickers"), list) else accession,  # type: ignore[arg-type]
+                symbol=symbol if symbol else accession,
                 filed_at=filed_at,
                 filing_type=form,
                 period_of_report=period_of_report,
@@ -491,9 +508,38 @@ def _normalise_filings(
             )
         )
 
-    # Return oldest-first
+    # Oldest-first (matches pre-refactor contract).
     results.sort(key=lambda r: r.filed_at)
     return results
+
+
+def _normalise_filings(
+    raw: dict[str, object],
+    cik_padded: str,
+    start_date: date | None,
+    end_date: date | None,
+    filing_types: list[str] | None,
+) -> list[FilingSearchResult]:
+    """Normalise an EDGAR submissions JSON response into
+    ``FilingSearchResult`` list.
+
+    Extracts the inline ``filings.recent`` block and delegates to
+    ``_normalise_submissions_block``. V1 of this function only
+    processes the inline block; secondary ``filings.files[]`` pages
+    are handled by Chunk E's backfill flow (#268) via explicit
+    per-page calls to ``_normalise_submissions_block``.
+    """
+    filings_block = raw.get("filings")
+    if not isinstance(filings_block, dict):
+        return []
+
+    recent = filings_block.get("recent")
+    if not isinstance(recent, dict):
+        return []
+
+    tickers = raw.get("tickers")
+    symbol = str(tickers[0]) if isinstance(tickers, list) and tickers else None
+    return _normalise_submissions_block(recent, cik_padded, start_date, end_date, filing_types, symbol=symbol)
 
 
 def _normalise_filing_event(provider_filing_id: str, raw: dict[str, object]) -> FilingEvent:

--- a/app/services/coverage_audit.py
+++ b/app/services/coverage_audit.py
@@ -347,20 +347,22 @@ def audit_instrument(conn: psycopg.Connection[Any], instrument_id: int) -> str:
 
         # Demote-guard: preserve ``structurally_young`` on an
         # ``insufficient`` classifier output. See module docstring.
+        # Use named params so the guard's two references to ``status``
+        # can't silently desynchronise under a future refactor.
         result = conn.execute(
             """
             UPDATE coverage
             SET filings_status = CASE
                     WHEN filings_status = 'structurally_young'
-                         AND %s = 'insufficient'
+                         AND %(status)s = 'insufficient'
                     THEN filings_status
-                    ELSE %s
+                    ELSE %(status)s
                 END,
                 filings_audit_at = NOW()
-            WHERE instrument_id = %s
+            WHERE instrument_id = %(instrument_id)s
             RETURNING filings_status
             """,
-            (status, status, instrument_id),
+            {"status": status, "instrument_id": instrument_id},
         )
         row = result.fetchone()
         if row is None:

--- a/app/services/coverage_audit.py
+++ b/app/services/coverage_audit.py
@@ -20,6 +20,13 @@ not here):
 Windows are computed in SQL via ``COUNT(*) FILTER (WHERE ...)`` so the
 Python classifier receives exact per-window counts. ``INTERVAL '18
 months'`` is calendar-correct — no ``timedelta(days=548)`` drift.
+
+Chunk E demote-guard: backfill owns ``structurally_young`` (master plan
+line 165). Audit must not write ``insufficient`` over a backfill-owned
+``structurally_young`` row on demote paths — otherwise the post-backfill
+status signal is lost. Promotion to ``analysable`` / ``fpi`` is always
+allowed. Implemented via a CASE expression in the UPDATE so the guard
+applies in both the bulk and single-instrument audit paths.
 """
 
 from __future__ import annotations
@@ -211,10 +218,20 @@ def audit_all_instruments(conn: psycopg.Connection[Any]) -> AuditSummary:
         if classifications:
             instrument_ids = [c[0] for c in classifications]
             statuses = [c[1] for c in classifications]
+            # Demote-guard: preserve ``structurally_young`` on an
+            # ``insufficient`` classifier output. Chunk E owns that
+            # value — the post-backfill signal must survive until
+            # either backfill itself demotes (issuer aged out, clean
+            # EXHAUSTED run) or promotes (enough base forms now).
             result = conn.execute(
                 """
                 UPDATE coverage c
-                SET filings_status = v.status,
+                SET filings_status = CASE
+                        WHEN c.filings_status = 'structurally_young'
+                             AND v.status = 'insufficient'
+                        THEN c.filings_status
+                        ELSE v.status
+                    END,
                     filings_audit_at = NOW()
                 FROM unnest(%s::bigint[], %s::text[]) AS v(instrument_id, status)
                 WHERE c.instrument_id = v.instrument_id
@@ -328,16 +345,25 @@ def audit_instrument(conn: psycopg.Connection[Any], instrument_id: int) -> str:
 
         status = _classify(agg, has_sec_cik)
 
+        # Demote-guard: preserve ``structurally_young`` on an
+        # ``insufficient`` classifier output. See module docstring.
         result = conn.execute(
             """
             UPDATE coverage
-            SET filings_status = %s,
+            SET filings_status = CASE
+                    WHEN filings_status = 'structurally_young'
+                         AND %s = 'insufficient'
+                    THEN filings_status
+                    ELSE %s
+                END,
                 filings_audit_at = NOW()
             WHERE instrument_id = %s
+            RETURNING filings_status
             """,
-            (status, instrument_id),
+            (status, status, instrument_id),
         )
-        if result.rowcount == 0:
+        row = result.fetchone()
+        if row is None:
             # No coverage row for this instrument. Post-#292 this
             # should never happen — universe sync + the weekly backfill
             # together guarantee coverage rows for every tradable
@@ -348,5 +374,78 @@ def audit_instrument(conn: psycopg.Connection[Any], instrument_id: int) -> str:
                 f"classifier returned {status!r} but UPDATE matched zero rows. "
                 f"Check coverage bootstrap (#292) + universe sync wiring."
             )
+        # Return what the DB actually holds post-guard, not the raw
+        # classifier output — otherwise a preserved young row would
+        # report as 'insufficient' to callers (Chunk E's probe path).
+        return str(row[0])
 
-    return status
+
+def probe_status(conn: psycopg.Connection[Any], instrument_id: int) -> str:
+    """Read-only classifier probe (#268 Chunk E).
+
+    Identical aggregate + ``_classify`` logic to ``audit_instrument``,
+    but does NOT UPDATE coverage. Backfill uses this inside its
+    pagination loop so a later retryable error cannot leave a
+    premature ``'analysable'`` in coverage (Chunk E design v3 C1).
+
+    Returns the classifier output (never reads current
+    ``filings_status``). Commits after the SELECTs to close the
+    implicit transaction per the backfill durability invariant.
+    """
+    agg_rows = conn.execute(
+        """
+        SELECT
+            COUNT(*) FILTER (
+                WHERE fe.filing_type = '10-K'
+                  AND fe.filing_date >= (CURRENT_DATE - INTERVAL '3 years')
+            ),
+            COUNT(*) FILTER (
+                WHERE fe.filing_type = '10-Q'
+                  AND fe.filing_date >= (CURRENT_DATE - INTERVAL '18 months')
+            ),
+            COUNT(*) FILTER (
+                WHERE fe.filing_type IN ('10-K','10-K/A','10-Q','10-Q/A')
+            ),
+            COUNT(*) FILTER (
+                WHERE fe.filing_type IN ('20-F','20-F/A','40-F','40-F/A','6-K','6-K/A')
+            )
+        FROM filing_events fe
+        JOIN external_identifiers ei
+            ON ei.instrument_id = fe.instrument_id
+           AND ei.provider = 'sec'
+           AND ei.identifier_type = 'cik'
+           AND ei.is_primary = TRUE
+        WHERE fe.provider = 'sec'
+          AND fe.instrument_id = %s
+        """,
+        (instrument_id,),
+    ).fetchone()
+
+    has_cik_row = conn.execute(
+        """
+        SELECT EXISTS (
+            SELECT 1 FROM external_identifiers ei
+            WHERE ei.instrument_id = %s
+              AND ei.provider = 'sec'
+              AND ei.identifier_type = 'cik'
+              AND ei.is_primary = TRUE
+        )
+        """,
+        (instrument_id,),
+    ).fetchone()
+    has_sec_cik = bool(has_cik_row[0]) if has_cik_row is not None else False
+
+    agg: AuditCounts | None
+    if agg_rows is None or all(v == 0 for v in agg_rows):
+        agg = None
+    else:
+        agg = AuditCounts(
+            instrument_id=instrument_id,
+            ten_k_in_3y=int(agg_rows[0]),
+            ten_q_in_18m=int(agg_rows[1]),
+            us_base_or_amend_total=int(agg_rows[2]),
+            fpi_total=int(agg_rows[3]),
+        )
+
+    conn.commit()  # close implicit tx per backfill durability invariant.
+    return _classify(agg, has_sec_cik)

--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -23,7 +23,7 @@ from datetime import date
 
 import psycopg
 
-from app.providers.filings import FilingSearchResult, FilingsProvider
+from app.providers.filings import FilingEvent, FilingSearchResult, FilingsProvider
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +184,60 @@ def _resolve_identifier(
         },
     ).fetchone()
     return row[0] if row else None
+
+
+def _upsert_filing_event(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    instrument_id: str | int,
+    provider_name: str,
+    event: FilingEvent,
+) -> None:
+    """Upsert a ``FilingEvent`` (from ``provider.get_filing``) into
+    ``filing_events``.
+
+    Mirrors ``_upsert_filing``'s idempotent ON CONFLICT semantics and
+    payload shape but accepts the richer ``FilingEvent`` variant
+    returned by ``FilingsProvider.get_filing``. Chunk E's 8-K gap
+    fill path uses this when re-fetching a single accession (#268).
+    """
+    conn.execute(
+        """
+        INSERT INTO filing_events (
+            instrument_id, filing_date, filing_type,
+            provider, provider_filing_id, source_url, primary_document_url,
+            raw_payload_json
+        )
+        VALUES (
+            %(instrument_id)s, %(filing_date)s, %(filing_type)s,
+            %(provider)s, %(provider_filing_id)s, %(source_url)s, %(primary_document_url)s,
+            %(raw_payload_json)s
+        )
+        ON CONFLICT (provider, provider_filing_id) DO UPDATE SET
+            filing_date          = EXCLUDED.filing_date,
+            filing_type          = EXCLUDED.filing_type,
+            source_url           = EXCLUDED.source_url,
+            primary_document_url = EXCLUDED.primary_document_url
+        """,
+        {
+            "instrument_id": instrument_id,
+            "filing_date": event.filed_at.date(),
+            "filing_type": event.filing_type,
+            "provider": provider_name,
+            "provider_filing_id": event.provider_filing_id,
+            "source_url": event.primary_document_url,
+            "primary_document_url": event.primary_document_url,
+            "raw_payload_json": json.dumps(
+                {
+                    "provider_filing_id": event.provider_filing_id,
+                    "symbol": event.symbol,
+                    "filed_at": event.filed_at.isoformat(),
+                    "filing_type": event.filing_type,
+                    "period_of_report": event.period_of_report.isoformat() if event.period_of_report else None,
+                    "primary_document_url": event.primary_document_url,
+                }
+            ),
+        },
+    )
 
 
 def _upsert_filing(

--- a/app/services/filings_backfill.py
+++ b/app/services/filings_backfill.py
@@ -1,0 +1,619 @@
+"""Filings backfill (#268 Chunk E).
+
+Drives every tradable SEC-covered instrument toward a terminal
+``coverage.filings_status`` by paging SEC ``submissions.json``
+history + verifying 8-K completeness inside the 365-day window,
+with bounded retries only on recoverable failures.
+
+Design doc: ``docs/superpowers/specs/2026-04-18-chunk-e-filings-backfill-design.md``.
+
+Durability invariant: psycopg3 opens an implicit transaction on the
+first ``execute`` against an idle connection. Any ``with
+conn.transaction():`` that follows becomes a savepoint, not a durable
+top-level commit. To keep per-page upserts durable against later
+errors, this module's rule is: **before every ``with
+conn.transaction():`` mutation block, call ``conn.commit()``**. It is
+a no-op on an idle connection; on an implicit read-tx it commits
+cheaply and puts the connection back in the idle state.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from enum import StrEnum
+from typing import Any
+
+import httpx
+import psycopg
+
+from app.providers.filings import FilingNotFound, FilingSearchResult
+from app.providers.implementations.sec_edgar import (
+    SecFilingsProvider,
+    _normalise_submissions_block,
+    _zero_pad_cik,
+)
+from app.services.coverage_audit import probe_status
+from app.services.filings import _upsert_filing, _upsert_filing_event
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------
+# Outcome enum + result dataclass
+# ---------------------------------------------------------------------
+
+
+class BackfillOutcome(StrEnum):
+    """Terminal classification for one backfill pass.
+
+    Values are persisted into ``coverage.filings_backfill_reason``.
+    See design doc §BackfillOutcome for the semantics of each value.
+    """
+
+    COMPLETE_OK = "COMPLETE_OK"
+    COMPLETE_FPI = "COMPLETE_FPI"
+    STILL_INSUFFICIENT_EXHAUSTED = "STILL_INSUFFICIENT_EXHAUSTED"
+    STILL_INSUFFICIENT_STRUCTURALLY_YOUNG = "STILL_INSUFFICIENT_STRUCTURALLY_YOUNG"
+    STILL_INSUFFICIENT_HTTP_ERROR = "STILL_INSUFFICIENT_HTTP_ERROR"
+    STILL_INSUFFICIENT_PARSE_ERROR = "STILL_INSUFFICIENT_PARSE_ERROR"
+    SKIPPED_ATTEMPTS_CAP = "SKIPPED_ATTEMPTS_CAP"
+    SKIPPED_BACKOFF_WINDOW = "SKIPPED_BACKOFF_WINDOW"
+
+
+_RETRYABLE_REASONS: frozenset[str] = frozenset(
+    {
+        BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR.value,
+        BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR.value,
+    }
+)
+
+
+@dataclass(frozen=True)
+class BackfillResult:
+    instrument_id: int
+    outcome: BackfillOutcome
+    pages_fetched: int
+    filings_upserted: int
+    eight_k_gap_filled: int
+    final_status: str
+
+
+# Tunables (module-level for test override).
+ATTEMPTS_CAP: int = 3
+BACKOFF_DAYS: int = 7
+EIGHT_K_WINDOW_DAYS: int = 365
+
+
+# ---------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------
+
+
+def _is_structurally_young(conn: psycopg.Connection[Any], instrument_id: int) -> bool:
+    """True iff the instrument's earliest SEC filing is strictly
+    newer than today - 18 months (calendar-correct via SQL INTERVAL).
+
+    False when no filings exist at all — we can't prove youth
+    without an earliest filing, so classify those as EXHAUSTED,
+    not YOUNG (design doc v2-H3).
+
+    Step 3 upserts every fetched filing to ``filing_events`` before
+    step 5 calls this helper, so the DB query is the authoritative
+    union of DB + just-fetched.
+    """
+    row = conn.execute(
+        """
+        SELECT MIN(filing_date) > (CURRENT_DATE - INTERVAL '18 months')
+        FROM filing_events
+        WHERE instrument_id = %s AND provider = 'sec'
+        """,
+        (instrument_id,),
+    ).fetchone()
+    conn.commit()  # M1 invariant.
+    return bool(row[0]) if row is not None and row[0] is not None else False
+
+
+# ---------------------------------------------------------------------
+# Single coverage-write sink
+# ---------------------------------------------------------------------
+
+
+def _finalise(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    *,
+    outcome: BackfillOutcome,
+    status: str | None,
+    pages_fetched: int = 0,
+    filings_upserted: int = 0,
+    eight_k_gap_filled: int = 0,
+) -> BackfillResult:
+    """Single coverage-write path shared by all terminal outcomes.
+
+    attempts delta by outcome:
+
+    - ``COMPLETE_OK`` / ``COMPLETE_FPI``           -> set 0
+    - ``HTTP_ERROR`` / ``PARSE_ERROR``             -> += 1
+    - ``EXHAUSTED`` / ``STRUCTURALLY_YOUNG``       -> unchanged
+    - ``SKIPPED_*``                                 -> no write at all
+
+    ``status`` semantics:
+
+    - ``None`` = preserve current ``filings_status``. Used by
+      retryable errors so a correctly-classified
+      ``structurally_young`` row is not demoted on transient
+      failure (design doc v4-H2).
+    - otherwise the UPDATE writes this value into ``filings_status``.
+
+    Commits before the UPDATE (M1 invariant) and after (K.2/K.3
+    durability pattern).
+    """
+    if outcome in (
+        BackfillOutcome.SKIPPED_ATTEMPTS_CAP,
+        BackfillOutcome.SKIPPED_BACKOFF_WINDOW,
+    ):
+        # Gating path — no mutation at all.
+        return BackfillResult(
+            instrument_id=instrument_id,
+            outcome=outcome,
+            pages_fetched=0,
+            filings_upserted=0,
+            eight_k_gap_filled=0,
+            final_status="",
+        )
+
+    # attempts delta is one of three shapes — parameterising the
+    # SQL keeps the query a ``LiteralString`` (pyright strict).
+    reset_attempts = outcome in (
+        BackfillOutcome.COMPLETE_OK,
+        BackfillOutcome.COMPLETE_FPI,
+    )
+    increment_attempts = outcome in (
+        BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR,
+        BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR,
+    )
+    # EXHAUSTED / STRUCTURALLY_YOUNG leave attempts unchanged.
+
+    conn.commit()  # M1 invariant before mutation.
+    if status is not None and reset_attempts:
+        result = conn.execute(
+            """
+            UPDATE coverage
+            SET filings_status            = %s,
+                filings_backfill_attempts = 0,
+                filings_backfill_last_at  = NOW(),
+                filings_backfill_reason   = %s,
+                filings_audit_at          = NOW()
+            WHERE instrument_id = %s
+            RETURNING filings_status
+            """,
+            (status, outcome.value, instrument_id),
+        )
+    elif status is not None and increment_attempts:
+        result = conn.execute(
+            """
+            UPDATE coverage
+            SET filings_status            = %s,
+                filings_backfill_attempts = filings_backfill_attempts + 1,
+                filings_backfill_last_at  = NOW(),
+                filings_backfill_reason   = %s,
+                filings_audit_at          = NOW()
+            WHERE instrument_id = %s
+            RETURNING filings_status
+            """,
+            (status, outcome.value, instrument_id),
+        )
+    elif status is not None:
+        # EXHAUSTED / STRUCTURALLY_YOUNG.
+        result = conn.execute(
+            """
+            UPDATE coverage
+            SET filings_status            = %s,
+                filings_backfill_last_at  = NOW(),
+                filings_backfill_reason   = %s,
+                filings_audit_at          = NOW()
+            WHERE instrument_id = %s
+            RETURNING filings_status
+            """,
+            (status, outcome.value, instrument_id),
+        )
+    elif increment_attempts:
+        # status=None preservation path for HTTP/PARSE errors
+        # (design doc v4-H2 — never demote structurally_young on
+        # transient failure).
+        result = conn.execute(
+            """
+            UPDATE coverage
+            SET filings_backfill_attempts = filings_backfill_attempts + 1,
+                filings_backfill_last_at  = NOW(),
+                filings_backfill_reason   = %s
+            WHERE instrument_id = %s
+            RETURNING filings_status
+            """,
+            (outcome.value, instrument_id),
+        )
+    else:
+        # status=None and no attempts change — currently unused
+        # but keep the branch explicit for future outcomes.
+        result = conn.execute(
+            """
+            UPDATE coverage
+            SET filings_backfill_last_at = NOW(),
+                filings_backfill_reason  = %s
+            WHERE instrument_id = %s
+            RETURNING filings_status
+            """,
+            (outcome.value, instrument_id),
+        )
+    row = result.fetchone()
+    final = str(row[0]) if row is not None and row[0] is not None else ""
+    conn.commit()  # K.2/K.3 durability.
+
+    return BackfillResult(
+        instrument_id=instrument_id,
+        outcome=outcome,
+        pages_fetched=pages_fetched,
+        filings_upserted=filings_upserted,
+        eight_k_gap_filled=eight_k_gap_filled,
+        final_status=final,
+    )
+
+
+# ---------------------------------------------------------------------
+# Gating
+# ---------------------------------------------------------------------
+
+
+def _check_gating(conn: psycopg.Connection[Any], instrument_id: int) -> BackfillOutcome | None:
+    """Return a gating outcome or ``None`` to proceed.
+
+    Cap rule exempts ``structurally_young`` rows (design doc v5-H1)
+    so an aged-out young issuer can be demoted to ``insufficient``
+    once backfill completes cleanly.
+    """
+    row = conn.execute(
+        """
+        SELECT filings_backfill_attempts, filings_backfill_last_at,
+               filings_backfill_reason, filings_status
+        FROM coverage
+        WHERE instrument_id = %s
+        """,
+        (instrument_id,),
+    ).fetchone()
+    conn.commit()  # M1 invariant.
+
+    if row is None:
+        # Bootstrap invariant violation — raise loudly.
+        raise RuntimeError(f"backfill_filings: no coverage row for instrument_id={instrument_id}")
+
+    attempts = int(row[0]) if row[0] is not None else 0
+    last_at: datetime | None = row[1]
+    last_reason: str | None = row[2]
+    filings_status: str | None = row[3]
+
+    if last_at is not None:
+        # Backoff check. Use UTC-naive-aware comparison: psycopg3 returns
+        # tz-aware datetime; compare against tz-aware now.
+        cutoff = datetime.now(last_at.tzinfo) - timedelta(days=BACKOFF_DAYS)
+        if last_at > cutoff:
+            return BackfillOutcome.SKIPPED_BACKOFF_WINDOW
+
+    if attempts >= ATTEMPTS_CAP and last_reason in _RETRYABLE_REASONS and filings_status != "structurally_young":
+        return BackfillOutcome.SKIPPED_ATTEMPTS_CAP
+
+    return None
+
+
+# ---------------------------------------------------------------------
+# Main entry
+# ---------------------------------------------------------------------
+
+
+def backfill_filings(
+    conn: psycopg.Connection[Any],
+    provider: SecFilingsProvider,
+    cik: str,
+    instrument_id: int,
+) -> BackfillResult:
+    """Page SEC submissions history for ``cik`` + reconcile 8-K gaps,
+    then write one terminal ``coverage.filings_status`` row.
+
+    See ``docs/superpowers/specs/2026-04-18-chunk-e-filings-backfill-design.md``
+    for the full flow + outcome table.
+    """
+    gated = _check_gating(conn, instrument_id)
+    if gated is not None:
+        return _finalise(conn, instrument_id, outcome=gated, status=None)
+
+    cik_padded = _zero_pad_cik(cik)
+
+    # Step 2: fetch primary submissions.json.
+    try:
+        submissions = provider.fetch_submissions(cik_padded)
+    except httpx.HTTPError:
+        logger.warning(
+            "backfill_filings: HTTP error on fetch_submissions cik=%s",
+            cik_padded,
+            exc_info=True,
+        )
+        return _finalise(
+            conn,
+            instrument_id,
+            outcome=BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR,
+            status=None,
+        )
+    except json.JSONDecodeError, TypeError, KeyError:
+        logger.warning(
+            "backfill_filings: PARSE error on fetch_submissions cik=%s",
+            cik_padded,
+            exc_info=True,
+        )
+        return _finalise(
+            conn,
+            instrument_id,
+            outcome=BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR,
+            status=None,
+        )
+
+    if submissions is None:
+        # 404 — CIK valid in external_identifiers but SEC has no
+        # submissions for it. Classify retryable.
+        return _finalise(
+            conn,
+            instrument_id,
+            outcome=BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR,
+            status=None,
+        )
+
+    window_cutoff = date.today() - timedelta(days=EIGHT_K_WINDOW_DAYS)
+    pages_fetched = 0
+    filings_upserted = 0
+    eight_k_gap_filled = 0
+    seen_filings: list[FilingSearchResult] = []
+    bar_met = False
+    eight_k_window_covered = False
+
+    # Phase A: inline `recent` block.
+    try:
+        filings_outer = submissions["filings"]
+        if not isinstance(filings_outer, dict):
+            raise TypeError("filings block not a dict")
+        recent_block = filings_outer["recent"]
+        if not isinstance(recent_block, dict):
+            raise TypeError("recent block not a dict")
+        recent_results = _normalise_submissions_block(recent_block, cik_padded)
+    except KeyError, TypeError, ValueError, AttributeError:
+        logger.warning(
+            "backfill_filings: PARSE error on recent block cik=%s",
+            cik_padded,
+            exc_info=True,
+        )
+        return _finalise(
+            conn,
+            instrument_id,
+            outcome=BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR,
+            status=None,
+        )
+
+    conn.commit()  # M1 invariant before mutation block.
+    with conn.transaction():
+        for r in recent_results:
+            _upsert_filing(conn, str(instrument_id), "sec", r)
+    seen_filings.extend(recent_results)
+    pages_fetched += 1
+    filings_upserted += len(recent_results)
+
+    bar_met = probe_status(conn, instrument_id) in ("analysable", "fpi")
+    if recent_results:
+        oldest_recent = min(r.filed_at.date() for r in recent_results)
+        if oldest_recent <= window_cutoff:
+            eight_k_window_covered = True
+
+    # Phase B: files[] pagination.
+    files_meta = filings_outer.get("files") or []
+    if not isinstance(files_meta, list):
+        files_meta = []
+
+    try:
+        entries = sorted(
+            files_meta,
+            key=lambda e: date.fromisoformat(str(e["filingTo"])),
+            reverse=True,
+        )
+    except KeyError, TypeError, ValueError:
+        # Missing/malformed filingTo — fall back to reversed original
+        # order (SEC documents files[] as chronological oldest→newest).
+        entries = list(reversed(files_meta))
+
+    for entry in entries:
+        if bar_met and eight_k_window_covered:
+            break  # nothing further to fetch (design doc v4-H1)
+
+        entry_name = entry.get("name") if isinstance(entry, dict) else None
+        if not entry_name:
+            continue
+
+        try:
+            page_raw = provider.fetch_submissions_page(str(entry_name))
+        except httpx.HTTPError:
+            logger.warning(
+                "backfill_filings: HTTP error on page cik=%s name=%s",
+                cik_padded,
+                entry_name,
+                exc_info=True,
+            )
+            return _finalise(
+                conn,
+                instrument_id,
+                outcome=BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR,
+                status=None,
+                pages_fetched=pages_fetched,
+                filings_upserted=filings_upserted,
+            )
+        except json.JSONDecodeError, TypeError, KeyError:
+            # ``fetch_submissions_page`` calls ``resp.json()`` internally
+            # which can raise on malformed bytes. Classify retryable.
+            logger.warning(
+                "backfill_filings: PARSE error on page cik=%s name=%s",
+                cik_padded,
+                entry_name,
+                exc_info=True,
+            )
+            return _finalise(
+                conn,
+                instrument_id,
+                outcome=BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR,
+                status=None,
+                pages_fetched=pages_fetched,
+                filings_upserted=filings_upserted,
+            )
+        if page_raw is None:
+            # 404 on a page the primary response claimed exists — data
+            # integrity; classify retryable.
+            logger.warning(
+                "backfill_filings: 404 on page cik=%s name=%s",
+                cik_padded,
+                entry_name,
+            )
+            return _finalise(
+                conn,
+                instrument_id,
+                outcome=BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR,
+                status=None,
+                pages_fetched=pages_fetched,
+                filings_upserted=filings_upserted,
+            )
+
+        try:
+            page_results = _normalise_submissions_block(page_raw, cik_padded)
+        except KeyError, TypeError, ValueError, AttributeError:
+            logger.warning(
+                "backfill_filings: PARSE error on page cik=%s name=%s",
+                cik_padded,
+                entry_name,
+                exc_info=True,
+            )
+            return _finalise(
+                conn,
+                instrument_id,
+                outcome=BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR,
+                status=None,
+                pages_fetched=pages_fetched,
+                filings_upserted=filings_upserted,
+            )
+
+        conn.commit()  # M1 invariant.
+        with conn.transaction():
+            for r in page_results:
+                _upsert_filing(conn, str(instrument_id), "sec", r)
+        seen_filings.extend(page_results)
+        pages_fetched += 1
+        filings_upserted += len(page_results)
+
+        if not bar_met:
+            bar_met = probe_status(conn, instrument_id) in ("analysable", "fpi")
+
+        if page_results:
+            page_oldest = min(r.filed_at.date() for r in page_results)
+            if page_oldest <= window_cutoff:
+                eight_k_window_covered = True
+
+    # Step 4: 8-K gap reconciliation.
+    conn.commit()  # M1 invariant.
+    db_rows = conn.execute(
+        """
+        SELECT provider_filing_id
+        FROM filing_events
+        WHERE instrument_id = %s
+          AND provider = 'sec'
+          AND filing_type = '8-K'
+          AND filing_date >= %s
+        """,
+        (instrument_id, window_cutoff),
+    ).fetchall()
+    conn.commit()  # M1 invariant.
+    db_eight_ks = {str(r[0]) for r in db_rows}
+
+    fetched_eight_ks = {
+        r.provider_filing_id for r in seen_filings if r.filing_type == "8-K" and r.filed_at.date() >= window_cutoff
+    }
+
+    for missing_accession in sorted(fetched_eight_ks - db_eight_ks):
+        try:
+            event = provider.get_filing(missing_accession)
+        except FilingNotFound:
+            continue  # SEC deleted between pages; skip.
+        except httpx.HTTPError:
+            logger.warning(
+                "backfill_filings: HTTP error on get_filing accession=%s",
+                missing_accession,
+                exc_info=True,
+            )
+            return _finalise(
+                conn,
+                instrument_id,
+                outcome=BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR,
+                status=None,
+                pages_fetched=pages_fetched,
+                filings_upserted=filings_upserted,
+                eight_k_gap_filled=eight_k_gap_filled,
+            )
+
+        conn.commit()  # M1 invariant.
+        with conn.transaction():
+            _upsert_filing_event(conn, instrument_id, "sec", event)
+        eight_k_gap_filled += 1
+
+    # Step 5: terminal classification + single coverage write.
+    final_status = probe_status(conn, instrument_id)
+
+    if final_status == "analysable":
+        return _finalise(
+            conn,
+            instrument_id,
+            outcome=BackfillOutcome.COMPLETE_OK,
+            status="analysable",
+            pages_fetched=pages_fetched,
+            filings_upserted=filings_upserted,
+            eight_k_gap_filled=eight_k_gap_filled,
+        )
+    if final_status == "fpi":
+        return _finalise(
+            conn,
+            instrument_id,
+            outcome=BackfillOutcome.COMPLETE_FPI,
+            status="fpi",
+            pages_fetched=pages_fetched,
+            filings_upserted=filings_upserted,
+            eight_k_gap_filled=eight_k_gap_filled,
+        )
+    if final_status == "insufficient":
+        if _is_structurally_young(conn, instrument_id):
+            return _finalise(
+                conn,
+                instrument_id,
+                outcome=BackfillOutcome.STILL_INSUFFICIENT_STRUCTURALLY_YOUNG,
+                status="structurally_young",
+                pages_fetched=pages_fetched,
+                filings_upserted=filings_upserted,
+                eight_k_gap_filled=eight_k_gap_filled,
+            )
+        return _finalise(
+            conn,
+            instrument_id,
+            outcome=BackfillOutcome.STILL_INSUFFICIENT_EXHAUSTED,
+            status="insufficient",
+            pages_fetched=pages_fetched,
+            filings_upserted=filings_upserted,
+            eight_k_gap_filled=eight_k_gap_filled,
+        )
+    if final_status == "no_primary_sec_cik":
+        raise RuntimeError(
+            f"backfill_filings: unexpected no_primary_sec_cik for "
+            f"instrument_id={instrument_id}; eligibility filter should "
+            f"have excluded this row"
+        )
+    raise RuntimeError(f"backfill_filings: unknown classifier status: {final_status!r}")

--- a/app/services/filings_backfill.py
+++ b/app/services/filings_backfill.py
@@ -417,16 +417,22 @@ def backfill_filings(
     if not isinstance(files_meta, list):
         files_meta = []
 
-    try:
-        entries = sorted(
-            files_meta,
-            key=lambda e: date.fromisoformat(str(e["filingTo"])),
-            reverse=True,
-        )
-    except KeyError, TypeError, ValueError:
-        # Missing/malformed filingTo — fall back to reversed original
-        # order (SEC documents files[] as chronological oldest→newest).
-        entries = list(reversed(files_meta))
+    def _entry_filing_to(e: object) -> date:
+        """Per-entry key resolver. Returns ``date.min`` for entries
+        whose ``filingTo`` is missing/malformed so a single bad entry
+        sinks to the back of the sort rather than aborting the whole
+        ordering (pre-v4 fallback silently demoted all pages to
+        oldest-first, wasting HTTP budget on unnecessary old pages).
+        """
+        if not isinstance(e, dict):
+            return date.min
+        raw = e.get("filingTo")
+        try:
+            return date.fromisoformat(str(raw))
+        except TypeError, ValueError:
+            return date.min
+
+    entries = sorted(files_meta, key=_entry_filing_to, reverse=True)
 
     for entry in entries:
         if bar_met and eight_k_window_covered:

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -2082,45 +2082,113 @@ def monitor_positions_job() -> None:
 
 
 def weekly_coverage_audit() -> None:
-    """Re-classify every tradable instrument's ``coverage.filings_status``
-    using the current ``filing_events`` set (#268 Chunk F minimal).
+    """Classify every tradable SEC-covered instrument via the bulk
+    audit, then drive any non-terminal one toward terminal state
+    via ``backfill_filings``.
 
-    Runs Tuesday 04:00 UTC. Scope is deliberately audit-only — the
-    master plan's full Chunk F includes historical backfill via
-    Chunk E's ``backfill_filings`` helper, which is not yet shipped.
-    Until E lands, this job surfaces drift (analysable → insufficient,
-    etc.) so ops can see it without auto-remediating.
+    Eligibility for backfill: ``filings_status IN ('insufficient',
+    'unknown', 'structurally_young')``. Including ``structurally_young``
+    lets aging young issuers re-promote to ``analysable`` once they
+    have filed past the 18-month bar (master plan line 184). ``fpi``
+    and ``no_primary_sec_cik`` are terminal and not eligible.
 
-    Idempotent; uses the existing ``audit_all_instruments`` bulk-
-    UPDATE path which only touches rows whose status actually
-    changed.
+    No post-audit re-sweep: ``backfill_filings`` writes the terminal
+    ``filings_status`` for each instrument it touches. A post-audit
+    would risk publishing ``analysable`` for instruments whose 8-K
+    window was not verified by backfill (audit's bar is 10-K/10-Q
+    only), which is the exact invariant Chunk E exists to protect
+    (design v3 C1).
+
+    Runs Tuesday 04:00 UTC.
     """
     with _tracked_job(JOB_WEEKLY_COVERAGE_AUDIT) as tracker:
         from app.services.coverage_audit import audit_all_instruments
+        from app.services.filings_backfill import BackfillOutcome, backfill_filings
 
+        outcomes: dict[BackfillOutcome, int] = {o: 0 for o in BackfillOutcome}
+        eligible_count = 0
         logger.info("weekly_coverage_audit: starting bulk classifier")
         try:
             with psycopg.connect(settings.database_url) as conn:
-                summary = audit_all_instruments(conn)
+                pre_audit = audit_all_instruments(conn)
+
+                eligible_rows = conn.execute(
+                    """
+                    SELECT c.instrument_id, ei.identifier_value AS cik
+                    FROM coverage c
+                    JOIN external_identifiers ei
+                        ON ei.instrument_id = c.instrument_id
+                       AND ei.provider = 'sec'
+                       AND ei.identifier_type = 'cik'
+                       AND ei.is_primary = TRUE
+                    WHERE c.filings_status IN ('insufficient', 'unknown', 'structurally_young')
+                    """
+                ).fetchall()
+                conn.commit()  # close implicit read tx before mutation.
+                eligible_count = len(eligible_rows)
+
+                with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+                    for row in eligible_rows:
+                        iid, cik = int(row[0]), str(row[1])
+                        try:
+                            result = backfill_filings(conn, provider, cik, iid)
+                        except Exception:
+                            # K.1 round 1 gotcha — ``except psycopg.Error``
+                            # too narrow for per-instrument isolation.
+                            logger.exception(
+                                "weekly_coverage_audit: backfill raised for instrument_id=%d",
+                                iid,
+                            )
+                            # Shared connection may be in failed-tx state
+                            # after an escaped psycopg error. Roll back so
+                            # later instruments aren't poisoned.
+                            try:
+                                conn.rollback()
+                            except Exception:
+                                logger.exception(
+                                    "weekly_coverage_audit: rollback failed after "
+                                    "instrument_id=%d — later instruments may fail",
+                                    iid,
+                                )
+                            continue
+                        outcomes[result.outcome] += 1
         except Exception:
             logger.error("weekly_coverage_audit: failed", exc_info=True)
             raise
 
-        tracker.row_count = summary.total_updated
-        # Log inside the with so ``summary`` is always bound at the
-        # point of use. Hoisting the log after the with would leak
-        # a NameError if _tracked_job.__exit__ raises (tracker
-        # write-back failure, etc.) because ``summary`` would be
-        # bound only in a now-torn-down scope.
+        # Per design v5: audit row count + every non-skipped backfill that
+        # wrote coverage (includes EXHAUSTED / STRUCTURALLY_YOUNG / HTTP /
+        # PARSE, which all UPDATE the coverage row even when filings_status
+        # is preserved).
+        non_skipped_backfill_writes = sum(
+            outcomes[o]
+            for o in (
+                BackfillOutcome.COMPLETE_OK,
+                BackfillOutcome.COMPLETE_FPI,
+                BackfillOutcome.STILL_INSUFFICIENT_STRUCTURALLY_YOUNG,
+                BackfillOutcome.STILL_INSUFFICIENT_EXHAUSTED,
+                BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR,
+                BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR,
+            )
+        )
+        tracker.row_count = pre_audit.total_updated + non_skipped_backfill_writes
         logger.info(
-            "weekly_coverage_audit complete: analysable=%d insufficient=%d "
-            "fpi=%d no_primary_sec_cik=%d total_updated=%d null_anomalies=%d",
-            summary.analysable,
-            summary.insufficient,
-            summary.fpi,
-            summary.no_primary_sec_cik,
-            summary.total_updated,
-            summary.null_anomalies,
+            "weekly_coverage_audit complete: "
+            "pre_analysable=%d eligible=%d "
+            "complete_ok=%d complete_fpi=%d structurally_young=%d "
+            "exhausted=%d http_err=%d parse_err=%d "
+            "skipped_cap=%d skipped_backoff=%d null_anomalies=%d",
+            pre_audit.analysable,
+            eligible_count,
+            outcomes[BackfillOutcome.COMPLETE_OK],
+            outcomes[BackfillOutcome.COMPLETE_FPI],
+            outcomes[BackfillOutcome.STILL_INSUFFICIENT_STRUCTURALLY_YOUNG],
+            outcomes[BackfillOutcome.STILL_INSUFFICIENT_EXHAUSTED],
+            outcomes[BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR],
+            outcomes[BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR],
+            outcomes[BackfillOutcome.SKIPPED_ATTEMPTS_CAP],
+            outcomes[BackfillOutcome.SKIPPED_BACKOFF_WINDOW],
+            pre_audit.null_anomalies,
         )
 
 

--- a/docs/superpowers/specs/2026-04-18-chunk-e-filings-backfill-design.md
+++ b/docs/superpowers/specs/2026-04-18-chunk-e-filings-backfill-design.md
@@ -1,0 +1,786 @@
+# Chunk E filings backfill + F extension (#268) — design v5
+
+**Goal:** drive every tradable SEC-covered instrument to a terminal `filings_status` (`analysable`, `fpi`, `structurally_young`, or `insufficient` when exhausted) by paging SEC `submissions.json` history + verifying 8-K completeness inside the 365-day window, with bounded retries only on recoverable failures. Extend `weekly_coverage_audit` to orchestrate backfill after its classifier pass.
+
+**Scope:** Chunk E (backfill service) + Chunk F full (scheduler extension) + a minimal Chunk D extension (`audit_all_instruments` / `audit_instrument` must preserve backfill-owned `structurally_young` on demote paths — used by other call sites such as Chunk G universe-sync hooks; scheduler itself no longer runs a post-backfill audit, see v3 C1 below).
+
+**Revision history:**
+- v1 — initial.
+- v2 — Codex-driven (8 issues): retryable-audit wipe (C1), 8-K gap gated (C2), early break leaves 8-K pages unfetched (H1), clean-exhaust misclassified as HTTP_ERROR (H2), zero-filings → YOUNG (H3), FPI not terminal (H4), implicit-tx durability (M1), `files[]` fixture shape (M2).
+- v5 — Codex-driven (2 issues on v4):
+  - (v4-H1) `status=None` retryable preservation + attempts cap could freeze an aged-out `structurally_young` row forever. Scenario: row was correctly young last month; earliest filing is now >= 18mo (aged out); 3 backfill runs hit HTTP/PARSE errors before step 5; each preserves young via `status=None` and increments attempts; cap gate then skips all future runs; Chunk D demote guard also blocks audit correction. Violates master-plan line 184. **Fix:** exempt rows where `filings_status = 'structurally_young'` from the attempts cap. Backoff (7 days) still bounds blast radius. When a young row eventually completes backfill cleanly, step 5 classifier picks `EXHAUSTED` (aged out) and writes `insufficient` — demoting correctly.
+  - (v4-L1) Pseudocode used `relativedelta(months=18)` but python-dateutil is not a project dep. `timedelta(days=548)` is documented elsewhere as calendar-drift unsafe (`coverage_audit.py` line 22). **Fix:** do the 18-month boundary check in SQL via `CURRENT_DATE - INTERVAL '18 months'`. Replace `_earliest_sec_filing_date` + Python comparison with a single-query `_is_structurally_young(conn, instrument_id) -> bool` — step 3 has already upserted all fetched filings to `filing_events`, so DB state at step 5 is the authoritative union.
+- v4 — Codex-driven (3 issues on v3):
+  - (v3-H1) Metadata-first skip `if eight_k_window_covered and entry_filing_to < window_cutoff: continue` could skip pages that still carry in-window 10-K (3y window) or 10-Q (18mo window) data when `bar_met=False`. 8-K window (365d) is shorter than both base-form windows. **Fix:** remove the `continue` clause entirely. The loop terminator `if bar_met and eight_k_window_covered: break` already covers the only valid skip condition; additional per-entry skips are incorrect.
+  - (v3-H2) Retryable outcomes (`HTTP_ERROR` / `PARSE_ERROR`) wrote `filings_status='insufficient'`, demoting a correctly-classified `structurally_young` row on transient failure. After 3 attempts the row was frozen insufficient. **Fix:** retryable outcomes pass `status=None` to `_finalise`; the UPDATE omits `filings_status` and preserves current value. `EXHAUSTED` continues to write `insufficient` (an issuer whose earliest filing is now >= 18mo ago has aged out of `structurally_young` and deserves the demote).
+  - (v3-L1) 18-month boundary used `>=` in pseudocode but prose said "newer than 18 months". Exact-boundary issuers stayed young one day extra. **Fix:** use strict `>` in `_earliest_sec_filing_date` comparison.
+- v3 — Codex-driven (3 issues on v2):
+  - (v2-C1) Retryable 8-K failure could still publish `analysable`. Page-0 upserts met the 10-K/10-Q bar, in-loop `audit_instrument` probe *wrote* `analysable`, then 8-K continuation errored. `filing_events` for 10-K/10-Q stayed durable, so scheduler's post-audit re-wrote `analysable` anyway — publishing a row whose 8-K window was never verified. **Fix:** (a) replace in-loop probe with a pure read-only classifier `_probe_status` that does NOT UPDATE; (b) backfill writes coverage exactly once at step 5 (terminal write); (c) scheduler drops the post-backfill `audit_all_instruments` call — pre-audit + per-instrument terminal writes are sufficient and correct.
+  - (v2-H1) Pagination stop condition was prose-only; pseudocode still fetched every page before checking `page_oldest_date`. Old-page 404 could then burn retry budget spuriously. **Fix:** consult `files[]` metadata (`filingTo`) BEFORE calling `fetch_submissions_page`; skip older pages once the 8-K window is covered AND base-form bar is met.
+  - (v2-M1) Step 4's DB-side 8-K SELECT reopens an implicit tx, so the next `with conn.transaction():` becomes a savepoint, not a durable top-level commit. **Fix:** call `conn.commit()` after every read that isn't immediately followed by a mutating `with conn.transaction():`; commit is a no-op on an idle connection, so it's safe to invoke defensively. Document the invariant explicitly.
+
+---
+
+## Problem
+
+After Chunks D + F-minimal, `weekly_coverage_audit` classifies `coverage.filings_status` from DB state only, leaving `insufficient` rows stuck. Master plan lines 171-184 specify the backfill pass; the per-chunk spec must resolve eight concrete correctness hazards that were latent in v1 (Codex review v2).
+
+## Solution
+
+### Chunk D extension — audit must preserve backfill-owned `structurally_young`
+
+Problem: `audit_all_instruments` and `audit_instrument` classify into `{analysable, insufficient, fpi, no_primary_sec_cik}` only. Master plan line 165 + Chunk D docstring state that `structurally_young` is owned by backfill. But master plan line 191 also calls for `audit_all_instruments` to "re-run to settle" after backfill — which, as implemented today, would overwrite every `structurally_young` back to `insufficient`.
+
+Fix (small patch to `app/services/coverage_audit.py`): change the demote direction only. Promotion to `analysable`/`fpi` always wins; a classifier output of `insufficient` is NOT written over an existing `structurally_young` row.
+
+Implementation:
+
+```python
+# In audit_all_instruments bulk UPDATE:
+UPDATE coverage c
+SET filings_status = v.status,
+    filings_audit_at = NOW()
+FROM unnest(%s::bigint[], %s::text[]) AS v(instrument_id, status)
+WHERE c.instrument_id = v.instrument_id
+  AND NOT (
+      c.filings_status = 'structurally_young'
+      AND v.status = 'insufficient'
+  )
+```
+
+`audit_instrument`: same guard on its single-row UPDATE. `filings_audit_at` is still bumped on the preserved row via a second UPDATE (see below) so downstream consumers can trust the audit timestamp.
+
+```python
+# Split into two UPDATEs so preserved young rows still get audit_at bump:
+# 1) status-changing UPDATE (guarded as above)
+# 2) audit_at-only UPDATE for rows we saw but left status alone:
+UPDATE coverage c
+SET filings_audit_at = NOW()
+FROM unnest(%s::bigint[]) AS v(instrument_id)
+WHERE c.instrument_id = v.instrument_id
+```
+
+This is a narrowly scoped change: tests 4, 5, 7 in `tests/test_coverage_audit.py` need extension for the preservation case. Ship it in the same PR as Chunk E — it is the prerequisite invariant that makes Chunk F's post-backfill re-audit safe.
+
+### New service — `app/services/filings_backfill.py`
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from enum import StrEnum
+from typing import Any
+
+import psycopg
+
+from app.providers.implementations.sec_edgar import SecFilingsProvider
+
+
+class BackfillOutcome(StrEnum):
+    """Terminal classification for one backfill pass.
+
+    Values are persisted into ``coverage.filings_backfill_reason``.
+
+    Terminal success (attempts → 0):
+
+    - ``COMPLETE_OK`` — post-backfill audit returns ``analysable``.
+    - ``COMPLETE_FPI`` — post-backfill audit returns ``fpi``. FPI is
+      a terminal coverage classification; no further backfill needed.
+
+    Terminal insufficiency (attempts unchanged — no benefit from
+    retrying):
+
+    - ``STILL_INSUFFICIENT_EXHAUSTED`` — all SEC pages consumed
+      cleanly, 8-K 365-day window fully verified, earliest known
+      filing is >= 18 months ago (old-enough issuer) OR no filings
+      found at all (can't prove youth). Still below the 10-K/10-Q
+      bar. Further retries will not change this until new filings
+      arrive; weekly audit naturally re-eligibilises the row.
+    - ``STILL_INSUFFICIENT_STRUCTURALLY_YOUNG`` — all SEC pages
+      consumed cleanly, earliest known SEC filing (DB ∪ fetched)
+      is newer than 18 months before today, and at least one
+      filing exists. Issuer has not existed long enough to meet
+      the bar. Writes ``filings_status='structurally_young'``.
+
+    Retryable insufficiency (attempts + 1):
+
+    - ``STILL_INSUFFICIENT_HTTP_ERROR`` — network error / 5xx /
+      timeout / 404 on `fetch_submissions` / 404 on secondary page
+      that primary claimed exists.
+    - ``STILL_INSUFFICIENT_PARSE_ERROR`` — `json.JSONDecodeError`
+      / `TypeError` / `KeyError` while parsing a page.
+
+    Gated (no fetch performed):
+
+    - ``SKIPPED_ATTEMPTS_CAP`` — attempts >= 3 AND last_reason ∈
+      retryable-insufficiency set.
+    - ``SKIPPED_BACKOFF_WINDOW`` — last_at within past 7 days.
+    """
+
+    COMPLETE_OK = "COMPLETE_OK"
+    COMPLETE_FPI = "COMPLETE_FPI"
+    STILL_INSUFFICIENT_EXHAUSTED = "STILL_INSUFFICIENT_EXHAUSTED"
+    STILL_INSUFFICIENT_STRUCTURALLY_YOUNG = "STILL_INSUFFICIENT_STRUCTURALLY_YOUNG"
+    STILL_INSUFFICIENT_HTTP_ERROR = "STILL_INSUFFICIENT_HTTP_ERROR"
+    STILL_INSUFFICIENT_PARSE_ERROR = "STILL_INSUFFICIENT_PARSE_ERROR"
+    SKIPPED_ATTEMPTS_CAP = "SKIPPED_ATTEMPTS_CAP"
+    SKIPPED_BACKOFF_WINDOW = "SKIPPED_BACKOFF_WINDOW"
+
+
+_RETRYABLE_REASONS: frozenset[str] = frozenset({
+    BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR.value,
+    BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR.value,
+})
+
+
+@dataclass(frozen=True)
+class BackfillResult:
+    instrument_id: int
+    outcome: BackfillOutcome
+    pages_fetched: int
+    filings_upserted: int
+    eight_k_gap_filled: int
+    final_status: str  # filings_status after the backfill's own writes
+
+
+ATTEMPTS_CAP: int = 3
+BACKOFF_DAYS: int = 7
+STRUCTURAL_YOUNG_MONTHS: int = 18
+EIGHT_K_WINDOW_DAYS: int = 365
+
+
+def backfill_filings(
+    conn: psycopg.Connection[Any],
+    provider: SecFilingsProvider,
+    cik: str,
+    instrument_id: int,
+) -> BackfillResult:
+    ...
+```
+
+### Flow
+
+#### Durability invariant (v3 M1)
+
+psycopg3 opens an implicit transaction on the first `execute` against an idle connection. Any `with conn.transaction():` that follows becomes a savepoint, not a durable top-level commit. To keep per-page upserts durable against later errors, this module's rule is:
+
+**Before every `with conn.transaction():` mutation block, call `conn.commit()`.** `commit()` is a no-op on an idle connection and cheap on a read-only implicit tx. This guarantees the subsequent `with` block is top-level and commits durably on exit.
+
+Applied at: step 1 end, step 3 per-page, step 4 pre-SELECT and pre-mutation, step 5 pre-write.
+
+#### 1. Gating check
+
+```python
+row = conn.execute(
+    "SELECT filings_backfill_attempts, filings_backfill_last_at, "
+    "filings_backfill_reason, filings_status "
+    "FROM coverage WHERE instrument_id = %s",
+    (instrument_id,),
+).fetchone()
+conn.commit()  # close the implicit read tx (v3 M1 invariant).
+```
+
+Gating outcomes:
+- `last_at IS NOT NULL AND last_at > NOW() - INTERVAL '7 days'` → return `SKIPPED_BACKOFF_WINDOW`. No coverage write.
+- `attempts >= 3 AND last_reason ∈ _RETRYABLE_REASONS AND filings_status != 'structurally_young'` → return `SKIPPED_ATTEMPTS_CAP`. No coverage write.
+- Otherwise proceed.
+
+The attempts cap bites only when the last terminal reason was HTTP/PARSE AND the current status is not `structurally_young` (v5 H1 — young rows must stay eligible indefinitely so an aged-out issuer can be demoted once backfill lands cleanly). EXHAUSTED rows with last-HTTP/PARSE still get capped (no harm in waiting for manual intervention); they are distinguished from young in that audit's demote guard does NOT protect insufficient rows, so a future fix arriving in DB via daily index ingest is caught by ordinary audit. The gating read loads `filings_status` alongside attempts/last_at/reason for this check.
+
+#### 2. Fetch `submissions.json`
+
+```python
+try:
+    submissions = provider.fetch_submissions(cik)
+except httpx.HTTPError:
+    return _finalise(conn, instrument_id, BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR, ...)
+except (json.JSONDecodeError, TypeError, KeyError):
+    return _finalise(conn, instrument_id, BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR, ...)
+
+if submissions is None:
+    # 404 — CIK was valid in external_identifiers but SEC has no
+    # submissions for it. Classify as HTTP_ERROR (recoverable: CIK
+    # correction via daily refresh may fix it) rather than
+    # EXHAUSTED (which would imply "we looked and there genuinely
+    # is nothing", untrue here).
+    return _finalise(conn, instrument_id, BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR, ...)
+```
+
+#### 3. Iterate pages recent-first
+
+```python
+bar_met: bool = False
+eight_k_window_covered: bool = False
+seen_filings: list[FilingSearchResult] = []
+window_cutoff: date = date.today() - timedelta(days=EIGHT_K_WINDOW_DAYS)
+
+# -- Phase A: process the inline `recent` block first.
+try:
+    recent_block = submissions['filings']['recent']
+    recent_results = _normalise_submissions_block(recent_block, cik_padded)
+except (KeyError, TypeError, ValueError):
+    return _finalise(conn, instrument_id, BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR, ...)
+
+conn.commit()  # M1 invariant before mutation block.
+with conn.transaction():
+    for r in recent_results:
+        _upsert_filing(conn, instrument_id, 'sec', r)
+seen_filings.extend(recent_results)
+pages_fetched += 1
+filings_upserted += len(recent_results)
+
+bar_met = _probe_status(conn, instrument_id) in ('analysable', 'fpi')
+if recent_results:
+    oldest_recent = min(r.filed_at.date() for r in recent_results)
+    if oldest_recent <= window_cutoff:
+        eight_k_window_covered = True
+
+# -- Phase B: iterate `files[]` metadata. Skip entries by metadata
+# BEFORE fetching, so an old-page 404/5xx cannot turn into a
+# spurious retry-budget burn once the 8-K window is already
+# covered (v3 H1).
+files_meta = submissions.get('filings', {}).get('files') or []
+try:
+    entries = sorted(
+        files_meta,
+        key=lambda e: date.fromisoformat(e['filingTo']),
+        reverse=True,
+    )
+except (KeyError, TypeError, ValueError):
+    # Missing/malformed filingTo on at least one entry — fallback
+    # to reversed original order (SEC documents files[] as
+    # oldest→newest, so reversed == newest first).
+    entries = list(reversed(files_meta))
+
+for entry in entries:
+    if bar_met and eight_k_window_covered:
+        break  # nothing further to fetch (v4: this is the ONLY
+               # valid skip condition; per-entry skip based on
+               # filingTo alone is incorrect — 8-K window is 365d,
+               # 10-K window is 3y, 10-Q window is 18mo, so an
+               # entry older than 365d may still carry in-window
+               # base-form filings when bar_met is False).
+
+    try:
+        page_raw = provider.fetch_submissions_page(entry['name'])
+    except httpx.HTTPError:
+        return _finalise(conn, instrument_id, BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR, ...)
+    if page_raw is None:
+        # 404 on a page the primary response claimed exists — data
+        # integrity; classify retryable.
+        return _finalise(conn, instrument_id, BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR, ...)
+
+    try:
+        page_results = _normalise_submissions_block(page_raw, cik_padded)
+    except (KeyError, TypeError, ValueError):
+        return _finalise(conn, instrument_id, BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR, ...)
+
+    conn.commit()  # M1 invariant.
+    with conn.transaction():
+        for r in page_results:
+            _upsert_filing(conn, instrument_id, 'sec', r)
+    seen_filings.extend(page_results)
+    pages_fetched += 1
+    filings_upserted += len(page_results)
+
+    if not bar_met:
+        bar_met = _probe_status(conn, instrument_id) in ('analysable', 'fpi')
+
+    if page_results:
+        page_oldest = min(r.filed_at.date() for r in page_results)
+        if page_oldest <= window_cutoff:
+            eight_k_window_covered = True
+```
+
+`_probe_status(conn, instrument_id) -> str` (v3 C1) is a new read-only helper in `app/services/coverage_audit.py`: runs the same aggregate + classifier logic as `audit_instrument` but does NOT UPDATE coverage. Used wherever backfill needs to know the current classifier output without publishing it.
+
+```python
+def _probe_status(conn: psycopg.Connection[Any], instrument_id: int) -> str:
+    """Read-only classifier probe. Identical query + _classify call
+    as audit_instrument, but never writes coverage. Chunk E uses
+    this inside the pagination loop so a later retryable error
+    cannot leave a premature 'analysable' in coverage (v3 C1).
+    """
+    # Body: the SELECT + _classify portion of audit_instrument,
+    # minus the UPDATE.
+```
+
+Also: after `_probe_status`'s SELECT, `conn.commit()` is called internally before return (same M1 invariant).
+
+#### 4. 8-K gap check (always runs — v2 C2)
+
+Step 3's pagination loop already fetches pages until `eight_k_window_covered` is True. If it terminates with `eight_k_window_covered=False` (e.g., issuer has < 1 year of history total, or `files[]` is empty and `recent` didn't span the window), there are no more pages to fetch and the 365-day 8-K window is simply as complete as SEC's own record allows. Step 4 then reconciles fetched-in-window 8-Ks against DB:
+
+```python
+conn.commit()  # M1 invariant before the read below.
+db_rows = conn.execute(
+    """
+    SELECT provider_filing_id
+    FROM filing_events
+    WHERE instrument_id = %s
+      AND provider = 'sec'
+      AND filing_type = '8-K'
+      AND filing_date >= %s
+    """,
+    (instrument_id, window_cutoff),
+).fetchall()
+conn.commit()  # M1 invariant — SELECT leaves an implicit tx open.
+db_eight_ks = {r[0] for r in db_rows}
+
+fetched_eight_ks = {
+    r.provider_filing_id
+    for r in seen_filings
+    if r.filing_type == '8-K' and r.filed_at.date() >= window_cutoff
+}
+
+# Diff is normally empty — step 3 upserts cover everything we
+# fetched. Non-empty only when ON CONFLICT upsert was silently
+# blocked (e.g., row deleted mid-flight by another writer).
+# Defensive re-fetch via get_filing():
+for missing_accession in fetched_eight_ks - db_eight_ks:
+    try:
+        event = provider.get_filing(missing_accession)
+    except FilingNotFound:
+        continue  # SEC deleted between pages; skip.
+    except httpx.HTTPError:
+        return _finalise(conn, instrument_id, BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR, ...)
+
+    conn.commit()  # M1 invariant.
+    with conn.transaction():
+        _upsert_filing_event(conn, instrument_id, 'sec', event)
+    eight_k_gap_filled += 1
+```
+
+(`_upsert_filing_event` is a thin `_upsert_filing` variant that takes a `FilingEvent` rather than `FilingSearchResult`; `get_filing` returns the former. Implementing it = 10 lines, same ON CONFLICT target. Ship in same PR.)
+
+#### 5. Terminal classification + single coverage write (v3 C1)
+
+After step 4, DB reflects everything SEC knows about this CIK within the 365-day 8-K window + whatever base-form pages we paged to meet the bar. Probe once more (read-only), then write coverage exactly once via `_finalise`:
+
+```python
+final_status = _probe_status(conn, instrument_id)  # read-only
+
+if final_status == 'analysable':
+    outcome = BackfillOutcome.COMPLETE_OK
+    status_to_write = 'analysable'
+elif final_status == 'fpi':
+    outcome = BackfillOutcome.COMPLETE_FPI
+    status_to_write = 'fpi'
+elif final_status == 'insufficient':
+    # v5-L1: 18-month boundary computed in SQL for calendar-correct
+    # arithmetic (matches the existing coverage_audit.py pattern;
+    # no python-dateutil dep). Step 3's upserts have already
+    # committed every fetched filing to filing_events, so the DB
+    # MIN(filing_date) is the authoritative union of DB + seen.
+    # Strict '>' — "newer than 18 months" per spec prose; exact-
+    # boundary issuer is no longer young.
+    if _is_structurally_young(conn, instrument_id):
+        outcome = BackfillOutcome.STILL_INSUFFICIENT_STRUCTURALLY_YOUNG
+        status_to_write = 'structurally_young'  # backfill-owned write
+    else:
+        outcome = BackfillOutcome.STILL_INSUFFICIENT_EXHAUSTED
+        status_to_write = 'insufficient'
+elif final_status == 'no_primary_sec_cik':
+    # Not reachable — eligibility filter excluded this.
+    raise RuntimeError(
+        f"backfill_filings: unexpected no_primary_sec_cik for "
+        f"instrument_id={instrument_id}; eligibility filter bug?"
+    )
+else:
+    raise RuntimeError(f"unknown classifier status: {final_status!r}")
+
+return _finalise(
+    conn, instrument_id,
+    outcome=outcome,
+    status=status_to_write,
+    pages_fetched=pages_fetched,
+    filings_upserted=filings_upserted,
+    eight_k_gap_filled=eight_k_gap_filled,
+)
+```
+
+`_finalise` is the single coverage-write path (shared by gating paths + all terminal paths). Error paths (HTTP / PARSE) pass `status=None` so the current `filings_status` is preserved (v4 H2 — never demote `structurally_young` on transient failure):
+
+```python
+def _finalise(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    *,
+    outcome: BackfillOutcome,
+    status: str | None,  # None = preserve current filings_status
+    pages_fetched: int = 0,
+    filings_upserted: int = 0,
+    eight_k_gap_filled: int = 0,
+) -> BackfillResult:
+    """Single coverage-write sink. Computes attempts delta from
+    outcome, writes status (when non-None) + attempts + last_at +
+    reason in one UPDATE, commits explicitly.
+
+    attempts delta by outcome:
+    - COMPLETE_OK / COMPLETE_FPI       -> set 0
+    - HTTP_ERROR / PARSE_ERROR         -> += 1
+    - EXHAUSTED / STRUCTURALLY_YOUNG   -> unchanged
+    - SKIPPED_*                        -> no write at all
+
+    status write by outcome (v4 H2):
+    - COMPLETE_OK                      -> 'analysable'
+    - COMPLETE_FPI                     -> 'fpi'
+    - STRUCTURALLY_YOUNG               -> 'structurally_young'
+    - EXHAUSTED                        -> 'insufficient'
+    - HTTP_ERROR / PARSE_ERROR         -> None (preserve current;
+                                           must not demote a
+                                           correctly-classified
+                                           structurally_young row
+                                           on transient failure)
+    - SKIPPED_*                        -> no write at all
+    """
+    if outcome in (BackfillOutcome.SKIPPED_ATTEMPTS_CAP,
+                   BackfillOutcome.SKIPPED_BACKOFF_WINDOW):
+        # Gating path — no mutation.
+        return BackfillResult(
+            instrument_id=instrument_id,
+            outcome=outcome,
+            pages_fetched=0,
+            filings_upserted=0,
+            eight_k_gap_filled=0,
+            final_status='',
+        )
+
+    delta_sql = {
+        BackfillOutcome.COMPLETE_OK: "0",
+        BackfillOutcome.COMPLETE_FPI: "0",
+        BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR: "filings_backfill_attempts + 1",
+        BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR: "filings_backfill_attempts + 1",
+        BackfillOutcome.STILL_INSUFFICIENT_EXHAUSTED: "filings_backfill_attempts",
+        BackfillOutcome.STILL_INSUFFICIENT_STRUCTURALLY_YOUNG: "filings_backfill_attempts",
+    }[outcome]
+
+    conn.commit()  # M1 invariant.
+    if status is not None:
+        sql = f"""
+            UPDATE coverage
+            SET filings_status            = %s,
+                filings_backfill_attempts = {delta_sql},
+                filings_backfill_last_at  = NOW(),
+                filings_backfill_reason   = %s,
+                filings_audit_at          = NOW()
+            WHERE instrument_id = %s
+        """
+        conn.execute(sql, (status, outcome.value, instrument_id))
+    else:
+        # Preserve current filings_status (v4 H2).
+        sql = f"""
+            UPDATE coverage
+            SET filings_backfill_attempts = {delta_sql},
+                filings_backfill_last_at  = NOW(),
+                filings_backfill_reason   = %s
+            WHERE instrument_id = %s
+        """
+        conn.execute(sql, (outcome.value, instrument_id))
+    conn.commit()  # K.2/K.3 durability pattern.
+
+    # final_status for the caller: if we wrote status, that's it;
+    # else re-read current value for logging.
+    if status is not None:
+        final = status
+    else:
+        row = conn.execute(
+            "SELECT filings_status FROM coverage WHERE instrument_id = %s",
+            (instrument_id,),
+        ).fetchone()
+        final = str(row[0]) if row is not None else ''
+        conn.commit()  # M1.
+
+    return BackfillResult(
+        instrument_id=instrument_id,
+        outcome=outcome,
+        pages_fetched=pages_fetched,
+        filings_upserted=filings_upserted,
+        eight_k_gap_filled=eight_k_gap_filled,
+        final_status=final,
+    )
+```
+
+Every `_finalise` call site for retryable error outcomes passes `status=None`. Example: `return _finalise(conn, instrument_id, outcome=BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR, status=None, ...)`.
+
+`_is_structurally_young(conn, instrument_id)` (v5 L1) is a pure DB-side predicate — step 3's upserts have committed every fetched filing, so `filing_events` is the authoritative union:
+
+```python
+def _is_structurally_young(conn: psycopg.Connection[Any], instrument_id: int) -> bool:
+    """True iff the instrument's earliest SEC filing is strictly
+    newer than today - 18 months (calendar-correct via SQL INTERVAL).
+    False when no filings exist at all (can't prove youth — classify
+    as EXHAUSTED, not YOUNG; closes v2-H3).
+    """
+    row = conn.execute(
+        """
+        SELECT MIN(filing_date) > (CURRENT_DATE - INTERVAL '18 months')
+        FROM filing_events
+        WHERE instrument_id = %s AND provider = 'sec'
+        """,
+        (instrument_id,),
+    ).fetchone()
+    conn.commit()  # M1 invariant.
+    return bool(row[0]) if row is not None and row[0] is not None else False
+```
+
+### Provider additions — `app/providers/implementations/sec_edgar.py`
+
+1. **Extract `_normalise_submissions_block`** from the existing `_normalise_filings`:
+
+```python
+def _normalise_submissions_block(
+    block: dict[str, object],
+    cik_padded: str,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    filing_types: list[str] | None = None,
+) -> list[FilingSearchResult]:
+    """Pure normalisation of one submissions page. Both the
+    inline ``filings.recent`` dict and any ``files[]`` secondary
+    page JSON carry the same parallel-array shape —
+    ``{accessionNumber, filingDate, form, primaryDocument, reportDate}``
+    — so Chunk E's pagination loop can call this per page.
+    """
+    # body lifted unchanged from the existing "recent" block path
+    # in _normalise_filings.
+```
+
+2. **Delegate `_normalise_filings` to it**:
+
+```python
+def _normalise_filings(raw, cik_padded, start_date, end_date, filing_types):
+    recent = raw.get("filings", {}).get("recent") if isinstance(raw.get("filings"), dict) else None
+    if not isinstance(recent, dict):
+        return []
+    return _normalise_submissions_block(recent, cik_padded, start_date, end_date, filing_types)
+```
+
+3. **Add `fetch_submissions_page`** (public):
+
+```python
+def fetch_submissions_page(self, name: str) -> dict[str, object] | None:
+    """Fetch a secondary submissions page named in
+    ``filings.files[].name`` (e.g. ``CIK0000320193-submissions-001.json``).
+
+    Returns the parsed JSON dict or ``None`` on 404. Uses the same
+    rate-limited HTTP client as ``fetch_submissions`` so the 10
+    req/s SEC cap is respected across the combined call pattern.
+    """
+    path = f"/submissions/{name}"
+    resp = self._http.get(path)
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    raw = resp.json()
+    _persist_raw(f"sec_submissions_page_{name}", raw)
+    return raw  # type: ignore[return-value]
+```
+
+### Scheduler extension — `app/workers/scheduler.py::weekly_coverage_audit`
+
+Replace current audit-only body (lines 2084-2124) with:
+
+```python
+def weekly_coverage_audit() -> None:
+    """Classify every tradable SEC-covered instrument via the bulk
+    audit, then drive any non-terminal one toward terminal state
+    via ``backfill_filings``. ``backfill_filings`` writes the
+    terminal ``filings_status`` for each instrument it touches,
+    so no post-audit re-sweep is needed (v3 C1: a post-audit
+    could publish ``analysable`` for instruments whose 8-K window
+    was not verified by backfill, because audit's bar is
+    10-K/10-Q only).
+
+    Eligibility for backfill: filings_status IN
+    ('insufficient', 'unknown', 'structurally_young').
+    Including ``structurally_young`` lets aging young issuers
+    re-promote to ``analysable`` once they have filed past the
+    18-month bar (master plan line 184). ``fpi`` and
+    ``no_primary_sec_cik`` are terminal — not eligible.
+    """
+    with _tracked_job(JOB_WEEKLY_COVERAGE_AUDIT) as tracker:
+        from app.services.coverage_audit import audit_all_instruments
+        from app.services.filings_backfill import BackfillOutcome, backfill_filings
+
+        with psycopg.connect(settings.database_url) as conn:
+            pre_audit = audit_all_instruments(conn)
+
+            eligible = conn.execute(
+                """
+                SELECT c.instrument_id, ei.identifier_value AS cik
+                FROM coverage c
+                JOIN external_identifiers ei
+                    ON ei.instrument_id = c.instrument_id
+                   AND ei.provider = 'sec'
+                   AND ei.identifier_type = 'cik'
+                   AND ei.is_primary = TRUE
+                WHERE c.filings_status IN ('insufficient', 'unknown', 'structurally_young')
+                """
+            ).fetchall()
+            conn.commit()  # M1 invariant after read.
+
+            outcomes: dict[BackfillOutcome, int] = {o: 0 for o in BackfillOutcome}
+            with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+                for row in eligible:
+                    iid, cik = int(row[0]), str(row[1])
+                    try:
+                        result = backfill_filings(conn, provider, cik, iid)
+                    except Exception:
+                        # K.1 review round 1: ``except psycopg.Error``
+                        # too narrow; use bare ``Exception`` for
+                        # per-instrument isolation across siblings.
+                        logger.exception(
+                            "weekly_coverage_audit: backfill raised for instrument_id=%d",
+                            iid,
+                        )
+                        continue
+                    outcomes[result.outcome] += 1
+
+        tracker.row_count = pre_audit.total_updated + sum(
+            outcomes[o] for o in (
+                BackfillOutcome.COMPLETE_OK,
+                BackfillOutcome.COMPLETE_FPI,
+                BackfillOutcome.STILL_INSUFFICIENT_STRUCTURALLY_YOUNG,
+                BackfillOutcome.STILL_INSUFFICIENT_EXHAUSTED,
+                BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR,
+                BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR,
+            )
+        )
+        logger.info(
+            "weekly_coverage_audit complete: "
+            "pre_analysable=%d eligible=%d "
+            "complete_ok=%d complete_fpi=%d structurally_young=%d "
+            "exhausted=%d http_err=%d parse_err=%d "
+            "skipped_cap=%d skipped_backoff=%d null_anomalies=%d",
+            pre_audit.analysable,
+            len(eligible),
+            outcomes[BackfillOutcome.COMPLETE_OK],
+            outcomes[BackfillOutcome.COMPLETE_FPI],
+            outcomes[BackfillOutcome.STILL_INSUFFICIENT_STRUCTURALLY_YOUNG],
+            outcomes[BackfillOutcome.STILL_INSUFFICIENT_EXHAUSTED],
+            outcomes[BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR],
+            outcomes[BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR],
+            outcomes[BackfillOutcome.SKIPPED_ATTEMPTS_CAP],
+            outcomes[BackfillOutcome.SKIPPED_BACKOFF_WINDOW],
+            pre_audit.null_anomalies,
+        )
+```
+
+All summary values read inside the `with _tracked_job(...)` block (F review gotcha).
+
+Why no `post_audit`:
+
+- Each `backfill_filings(...)` call writes the terminal `filings_status` for the instrument it touched (COMPLETE_OK → analysable, COMPLETE_FPI → fpi, STRUCTURALLY_YOUNG → structurally_young, EXHAUSTED/HTTP_ERROR/PARSE_ERROR → leaves `insufficient`).
+- Instruments that backfill DIDN'T touch (terminal pre-audit classification: `analysable`, `fpi`, `no_primary_sec_cik`) are unchanged by the batch — `filing_events` inserts are per-instrument, no cross-instrument effects.
+- Instruments where backfill RAISED before `_finalise` retain their pre-audit classification (per-instrument isolation). No inconsistency.
+- Skipping the post-audit is precisely what closes v3 C1 (retryable-error leaks cannot promote to analysable via an audit that only checks 10-K/10-Q counts).
+
+### Migration-less change
+
+No new SQL. All required columns exist in migration 036.
+
+## Fixtures — `tests/fixtures/sec/`
+
+SEC wire shape for reference:
+
+```json
+{
+  "cik": "0000320193",
+  "filings": {
+    "recent": { "accessionNumber": [...], "filingDate": [...], "form": [...], ... },
+    "files": [
+      { "name": "CIK0000320193-submissions-001.json", "filingCount": 1000, "filingFrom": "2018-01-01", "filingTo": "2020-12-31" },
+      { "name": "CIK0000320193-submissions-002.json", "filingCount": 1000, "filingFrom": "2015-01-01", "filingTo": "2017-12-31" }
+    ]
+  }
+}
+```
+
+Individual accessions live inside each secondary page's own `{accessionNumber, filingDate, form, ...}` arrays. `files[]` itself is only page metadata.
+
+Fixture set:
+
+- `submissions_MATURE.json` — `recent` has 2 × 10-K + 4 × 10-Q + 6 × 8-K within 365d; `files: []`. Drives `COMPLETE_OK` with `pages_fetched=1`, `eight_k_gap_filled=0`.
+- `submissions_PAGED.json` — `recent` has 1 × 10-K + 2 × 10-Q, `files[]` names one older page. `submissions_PAGED-page-001.json` adds the missing 1 × 10-K + 2 × 10-Q within the 3-year / 18-month windows. Combined meets the bar. Drives `COMPLETE_OK` with `pages_fetched=2`.
+- `submissions_YOUNG.json` — earliest filing 6 months ago, 1 × 10-K + 1 × 10-Q, `files: []`. Drives `STRUCTURALLY_YOUNG`.
+- `submissions_EXHAUSTED.json` — earliest filing 5 years ago, all filings predate the 18-month window such that the 10-Q count in window is < 4. `files: []` (or all-historical pages, all fetched). Drives `STILL_INSUFFICIENT_EXHAUSTED`.
+- `submissions_FPI.json` — 3 × 20-F + 12 × 6-K spanning 3 years, zero 10-K/10-Q/10-K/A/10-Q/A. Audit classifies `fpi`. Drives `COMPLETE_FPI`.
+- `submissions_8K_GAP.json` + `submissions_8K_GAP-page-001.json` — `recent` meets base-form bar with `filingTo` on a date such that `filingFrom` is within the 365-day window (bar_met immediately, but `eight_k_window_covered=False`). Secondary page completes the 365-day 8-K coverage with 3 additional 8-Ks within window. Drives the pagination continuation path (bar met early, continues paging for 8-K window).
+- `submissions_404.json` — not used directly; test stubs `fetch_submissions` to return `None`.
+- `submissions_BAD_JSON` — test stubs `fetch_submissions` to raise `json.JSONDecodeError`.
+- `submissions_HTTP_ERROR` — test stubs to raise `httpx.HTTPError`.
+
+## Tests
+
+**Unit — `tests/test_filings_backfill.py`:**
+
+1. Gating: `attempts=3, last_reason=HTTP_ERROR` → `SKIPPED_ATTEMPTS_CAP`; no provider call, no coverage mutation.
+2. Gating: `last_at=NOW() - 3 days` → `SKIPPED_BACKOFF_WINDOW`; no provider call, no coverage mutation.
+3. Gating: `attempts=5, last_reason=STILL_INSUFFICIENT_EXHAUSTED` → proceeds (cap bites retryable-only).
+4. Gating: `attempts=3, last_reason=STILL_INSUFFICIENT_STRUCTURALLY_YOUNG` → proceeds.
+4b. Gating (v5 H1 regression): `filings_status='structurally_young', attempts=3, last_reason=STILL_INSUFFICIENT_HTTP_ERROR, last_at=NOW()-8d` → proceeds. Cap exemption for young rows lets an aged-out young issuer demote to EXHAUSTED on next clean run. Without this test, the v4-H1 freeze regression could reappear silently.
+5. `COMPLETE_OK` on page 0: `MATURE` fixture, audit returns `analysable`, `attempts → 0`, `reason=COMPLETE_OK`, `last_at` set.
+6. `COMPLETE_OK` after pagination: `PAGED` fixtures, `pages_fetched=2`, bar_met on page 1 AND 8-K window covered on page 0 (all 8-Ks in recent).
+7. `COMPLETE_FPI`: `FPI` fixture, `final_status='fpi'`, `attempts → 0`, `reason=COMPLETE_FPI`.
+8. `STRUCTURALLY_YOUNG`: `YOUNG` fixture, `filings_status='structurally_young'` written by backfill, `attempts` unchanged.
+9. `EXHAUSTED` old issuer: `EXHAUSTED` fixture, `filings_status='insufficient'` (not written over), `attempts` unchanged, `reason=STILL_INSUFFICIENT_EXHAUSTED`.
+10. `EXHAUSTED` zero filings (H3): stub `fetch_submissions` to return a valid but empty response, `seen_filings` empty, outcome = `STILL_INSUFFICIENT_EXHAUSTED` (NOT `STRUCTURALLY_YOUNG`).
+11. `HTTP_ERROR` from `fetch_submissions`: raises `httpx.HTTPError`, `attempts + 1`, `reason=STILL_INSUFFICIENT_HTTP_ERROR`.
+12. `HTTP_ERROR` from a secondary page fetch mid-pagination: partial page-0 upserts already durable (commits hold), `pages_fetched` counts the failed page only if upserts happened (0 here).
+13. `HTTP_ERROR` on `fetch_submissions` returning `None` (404): `attempts + 1`, `reason=STILL_INSUFFICIENT_HTTP_ERROR` (not EXHAUSTED).
+14. `PARSE_ERROR` from `json.JSONDecodeError`: `attempts + 1`, `reason=STILL_INSUFFICIENT_PARSE_ERROR`.
+15. `PARSE_ERROR` from `KeyError` on missing `filings.recent`: same.
+16. 8-K pagination-continuation path: `8K_GAP` fixtures — bar met on page 0, `eight_k_window_covered=False` on page 0, step 4 continues into page 1 and upserts the missing 8-Ks. `eight_k_gap_filled` reflects the upsert count; outcome = `COMPLETE_OK`.
+17. 8-K HTTP error during continuation: partial 8-K inserts durable, outcome = `STILL_INSUFFICIENT_HTTP_ERROR`.
+18. `_normalise_submissions_block` on `recent` dict: identical output to pre-refactor `_normalise_filings` (regression).
+19. `_normalise_submissions_block` on a `files[]` page dict: same fields, same output shape.
+20. Chunk D audit extension: `audit_all_instruments` on a `structurally_young` row whose classifier returns `insufficient` leaves `filings_status='structurally_young'` (preserves backfill ownership). `filings_audit_at` bumped.
+21. Chunk D audit extension: `structurally_young` row whose classifier now returns `analysable` is promoted.
+22. Chunk D audit extension: `audit_instrument` single-row path obeys the same demote-guard.
+
+**Integration — `tests/integration/test_filings_backfill_real_db.py` (uses `ebull_test` DB per memory #test_db_isolation):**
+
+23. End-to-end: seed empty `filing_events`, stub provider with `PAGED` fixtures, call `backfill_filings` → DB rows present, coverage columns updated, no other instruments' coverage touched.
+24. Idempotency: back-to-back calls within backoff window → second is `SKIPPED_BACKOFF_WINDOW`, no duplicate upserts.
+25. Per-page durability: seed fixture, inject `psycopg.Error` after page 1 upsert (via monkey-patched `_upsert_filing`), assert page-0 rows persist in DB after the raise.
+26. Chunk D audit preservation: seed `structurally_young` row, run `audit_all_instruments` with classifier aggregates that would return `insufficient` → DB row still `structurally_young`.
+
+**Integration — `tests/integration/test_weekly_coverage_audit.py` (extend existing F-minimal tests):**
+
+27. Scheduler full path: 4 instruments {`analysable` pre-seeded, `insufficient` that backfill promotes to `analysable`, `insufficient` that backfill errors on, `structurally_young` that ages into `analysable`}. Assert: eligible set includes the latter three; per-instrument error doesn't abort the batch; final log line reflects outcome counts.
+28. `fpi` path: `insufficient` instrument whose SEC history is 20-F heavy → backfill upserts 20-Fs → audit_instrument returns `fpi` → outcome `COMPLETE_FPI` → post-audit `fpi` preserved.
+29. Per-instrument isolation: one instrument raises `RuntimeError` mid-`backfill_filings` (stubbed) — other instruments in the batch still processed.
+30. `null_anomalies` counter exposed in final log line.
+
+## Risks
+
+- **Pagination exhaustion on a serial filer**: a CIK with 10+ secondary pages could trigger many HTTP calls. Mitigation: rate limiter enforces 10 rps; weekly cadence + retry backoff bound blast radius. If a pathological issuer consistently exhausts, the EXHAUSTED outcome + 7-day backoff prevents tight-loop re-attempts.
+- **`files[]` ordering field absent on some responses**: fallback to reversed (SEC documents files[] as chronological oldest→newest, so `reversed()` ≡ newest-first). Guard with `except (KeyError, ValueError)`.
+- **`eight_k_window_covered` false-negative on single-page responses**: if `recent` has zero filings older than 365d (because `filingCount` is small), `page_oldest_date > today - 365d` and the flag stays False. If `files: []` is also empty, the pagination iterator terminates with `eight_k_window_covered=False` but nothing more to fetch — safe: step 4 fetches nothing new, diff is empty, no false miss. Test 16 covers this via the `MATURE` fixture where `files: []`.
+- **Race: post-audit reclassifies mid-backfill**: if an external writer modifies `filing_events` between step 3 and step 5, the final audit could re-read a mutated state. Acceptable — only the weekly job writes coverage, and `filing_events` writes are append-only.
+- **Explicit `conn.commit()` incompatible with outer explicit tx**: scheduler today opens `psycopg.connect(settings.database_url)` and does not wrap. Documented in docstring. K.2/K.3 pattern.
+
+## Codex checkpoints
+
+Per CLAUDE.md:
+
+1. ✅ Pre-spec review v1 — 8 issues → rolled into v2.
+2. ✅ Pre-spec review v2 — 3 issues → rolled into v3.
+3. ✅ Pre-spec review v3 — 3 issues → rolled into v4.
+4. ✅ Pre-spec review v4 — 2 issues → rolled into v5.
+5. Pre-spec review v5 — run before user approval.
+6. Pre-push review — after implementation, before first `git push`.
+7. Rebuttal-only merge — if warranted.
+
+## Shipping order
+
+1. **Chunk D audit extension** — demote-guard on `audit_all_instruments` + `audit_instrument`. Unit tests 20-22. Ship first because Chunk E depends on it.
+2. **Provider refactor** — `_normalise_submissions_block` extraction + `fetch_submissions_page` addition. Unit tests 18-19.
+3. **Gating + page iteration core** — `BackfillOutcome` + `BackfillResult` + flow steps 1-3. Unit tests 1-12.
+4. **8-K gap check + pagination continuation** — step 4. Unit tests 16-17.
+5. **Outcome classifier + coverage write** — step 5. Unit tests 13-15 (EXHAUSTED branches), polish 5-9.
+6. **Integration tests** — 23-26.
+7. **Scheduler extension** — replaces F-minimal body. Integration tests 27-30.
+8. **Codex pre-push review** + PR.

--- a/tests/test_coverage_audit_integration.py
+++ b/tests/test_coverage_audit_integration.py
@@ -14,6 +14,7 @@ import pytest
 from app.services.coverage_audit import (
     audit_all_instruments,
     audit_instrument,
+    probe_status,
 )
 from tests.fixtures.ebull_test_db import ebull_test_conn
 from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
@@ -355,3 +356,170 @@ def test_audit_instrument_raises_on_missing_coverage_row(
 
     with pytest.raises(RuntimeError, match="no coverage row"):
         audit_instrument(ebull_test_conn, instrument_id=42)
+
+
+# ---------------------------------------------------------------------
+# Chunk E demote-guard (#268)
+# ---------------------------------------------------------------------
+
+
+def _force_status(conn: psycopg.Connection[tuple], instrument_id: int, status: str) -> None:
+    """Direct UPDATE bypass for test setup: sets filings_status without
+    going through the classifier. Simulates Chunk E backfill having
+    written ``structurally_young`` previously."""
+    conn.execute(
+        "UPDATE coverage SET filings_status = %s WHERE instrument_id = %s",
+        (status, instrument_id),
+    )
+    conn.commit()
+
+
+def test_audit_all_preserves_structurally_young_on_demote(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Bulk audit must not write 'insufficient' over a
+    backfill-owned 'structurally_young' row (Chunk E demote-guard).
+    """
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="YOUNG1", cik="0000000101")
+    # Classifier will output 'insufficient' (zero filings but has CIK).
+    _force_status(ebull_test_conn, instrument_id=1, status="structurally_young")
+
+    audit_all_instruments(ebull_test_conn)
+
+    row = ebull_test_conn.execute(
+        "SELECT filings_status, filings_audit_at FROM coverage WHERE instrument_id = 1"
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "structurally_young"  # preserved
+    assert row[1] is not None  # audit_at still bumped
+
+
+def test_audit_all_promotes_structurally_young_to_analysable(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Young issuer that has since filed enough base forms must
+    promote on the next audit. Demote-guard does NOT block promotion.
+    """
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="AGED1", cik="0000000102")
+    today = date.today()
+    # 2 × 10-K in 3y + 4 × 10-Q in 18mo — meets the bar.
+    for offset, kind, acc in [
+        (400, "10-K", "0000000102-24-000001"),
+        (700, "10-K", "0000000102-23-000001"),
+        (30, "10-Q", "0000000102-26-000001"),
+        (120, "10-Q", "0000000102-26-000002"),
+        (210, "10-Q", "0000000102-25-000003"),
+        (300, "10-Q", "0000000102-25-000004"),
+    ]:
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=1,
+            filing_date=today - timedelta(days=offset),
+            filing_type=kind,
+            accession=acc,
+        )
+    _force_status(ebull_test_conn, instrument_id=1, status="structurally_young")
+
+    audit_all_instruments(ebull_test_conn)
+
+    row = ebull_test_conn.execute("SELECT filings_status FROM coverage WHERE instrument_id = 1").fetchone()
+    assert row is not None
+    assert row[0] == "analysable"
+
+
+def test_audit_instrument_preserves_structurally_young_on_demote(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Single-instrument path obeys the same demote-guard."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="YOUNG2", cik="0000000103")
+    _force_status(ebull_test_conn, instrument_id=1, status="structurally_young")
+
+    returned = audit_instrument(ebull_test_conn, instrument_id=1)
+
+    assert returned == "structurally_young"
+    row = ebull_test_conn.execute("SELECT filings_status FROM coverage WHERE instrument_id = 1").fetchone()
+    assert row is not None
+    assert row[0] == "structurally_young"
+
+
+def test_audit_instrument_promotes_structurally_young_to_fpi(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Promotion from structurally_young to fpi when 20-F appears."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="FPI2", cik="0000000104")
+    _seed_filing(
+        ebull_test_conn,
+        instrument_id=1,
+        filing_date=date.today() - timedelta(days=60),
+        filing_type="20-F",
+        accession="0000000104-26-000001",
+    )
+    _force_status(ebull_test_conn, instrument_id=1, status="structurally_young")
+
+    returned = audit_instrument(ebull_test_conn, instrument_id=1)
+
+    assert returned == "fpi"
+    row = ebull_test_conn.execute("SELECT filings_status FROM coverage WHERE instrument_id = 1").fetchone()
+    assert row is not None
+    assert row[0] == "fpi"
+
+
+# ---------------------------------------------------------------------
+# probe_status (Chunk E read-only classifier)
+# ---------------------------------------------------------------------
+
+
+def test_probe_status_returns_analysable_without_writing(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """probe_status must never UPDATE coverage."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="PROBE1", cik="0000000201")
+    today = date.today()
+    for offset, kind, acc in [
+        (400, "10-K", "0000000201-24-000001"),
+        (700, "10-K", "0000000201-23-000001"),
+        (30, "10-Q", "0000000201-26-000001"),
+        (120, "10-Q", "0000000201-26-000002"),
+        (210, "10-Q", "0000000201-25-000003"),
+        (300, "10-Q", "0000000201-25-000004"),
+    ]:
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=1,
+            filing_date=today - timedelta(days=offset),
+            filing_type=kind,
+            accession=acc,
+        )
+
+    status = probe_status(ebull_test_conn, instrument_id=1)
+
+    assert status == "analysable"
+    # Coverage row must be untouched (filings_status NULL, no audit_at).
+    row = ebull_test_conn.execute(
+        "SELECT filings_status, filings_audit_at FROM coverage WHERE instrument_id = 1"
+    ).fetchone()
+    assert row is not None
+    assert row[0] is None
+    assert row[1] is None
+
+
+def test_probe_status_returns_insufficient_when_no_filings(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Probe with SEC CIK but zero filings returns 'insufficient'."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="PROBE2", cik="0000000202")
+
+    status = probe_status(ebull_test_conn, instrument_id=1)
+
+    assert status == "insufficient"
+
+
+def test_probe_status_returns_no_primary_sec_cik(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Probe without SEC CIK returns 'no_primary_sec_cik'."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="PROBE3")  # no cik
+
+    status = probe_status(ebull_test_conn, instrument_id=1)
+
+    assert status == "no_primary_sec_cik"

--- a/tests/test_filings_backfill.py
+++ b/tests/test_filings_backfill.py
@@ -1,0 +1,771 @@
+"""Tests for ``app.services.filings_backfill`` (#268 Chunk E).
+
+Uses the real ``ebull_test`` database so the coverage-row write
+semantics (gating, _finalise attempts delta, status preservation)
+are exercised against actual psycopg3 + SQL behaviour.
+
+The SEC provider is stubbed with a hand-rolled fake that implements
+``fetch_submissions``, ``fetch_submissions_page``, and ``get_filing``
+— enough surface area for every backfill path.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+import httpx
+import psycopg
+import pytest
+
+from app.providers.filings import FilingEvent, FilingNotFound
+from app.services.filings_backfill import (
+    BackfillOutcome,
+    backfill_filings,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test DB unavailable",
+)
+
+
+# ---------------------------------------------------------------------
+# Fake provider
+# ---------------------------------------------------------------------
+
+
+@dataclass
+class _FakeResponse:
+    """Slim shim for ``httpx.Response`` — only status_code / json()."""
+
+    primary: dict[str, object] | None
+    pages: dict[str, dict[str, object]]
+    filings: dict[str, FilingEvent]
+    submissions_raises: BaseException | None = None
+    page_raises: dict[str, BaseException] | None = None
+    get_filing_raises: dict[str, BaseException] | None = None
+
+
+class FakeSecProvider:
+    """Test double for SecFilingsProvider.
+
+    Only the three methods backfill_filings calls are implemented.
+    """
+
+    def __init__(self, resp: _FakeResponse) -> None:
+        self._resp = resp
+        self.fetch_submissions_calls: list[str] = []
+        self.fetch_page_calls: list[str] = []
+        self.get_filing_calls: list[str] = []
+
+    def fetch_submissions(self, cik: str) -> dict[str, object] | None:
+        self.fetch_submissions_calls.append(cik)
+        if self._resp.submissions_raises is not None:
+            raise self._resp.submissions_raises
+        return self._resp.primary
+
+    def fetch_submissions_page(self, name: str) -> dict[str, object] | None:
+        self.fetch_page_calls.append(name)
+        if self._resp.page_raises and name in self._resp.page_raises:
+            raise self._resp.page_raises[name]
+        return self._resp.pages.get(name)
+
+    def get_filing(self, provider_filing_id: str) -> FilingEvent:
+        self.get_filing_calls.append(provider_filing_id)
+        if self._resp.get_filing_raises and provider_filing_id in self._resp.get_filing_raises:
+            raise self._resp.get_filing_raises[provider_filing_id]
+        if provider_filing_id not in self._resp.filings:
+            raise FilingNotFound(provider_filing_id)
+        return self._resp.filings[provider_filing_id]
+
+
+# ---------------------------------------------------------------------
+# Helpers: seeding
+# ---------------------------------------------------------------------
+
+
+def _seed(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    cik: str,
+    symbol: str = "TEST",
+    filings_status: str | None = None,
+    attempts: int = 0,
+    last_at: datetime | None = None,
+    last_reason: str | None = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES (%s, %s, %s, TRUE)",
+        (instrument_id, symbol, symbol),
+    )
+    conn.execute(
+        """
+        INSERT INTO coverage (
+            instrument_id, coverage_tier,
+            filings_status, filings_backfill_attempts,
+            filings_backfill_last_at, filings_backfill_reason
+        ) VALUES (%s, 3, %s, %s, %s, %s)
+        """,
+        (instrument_id, filings_status, attempts, last_at, last_reason),
+    )
+    conn.execute(
+        "INSERT INTO external_identifiers "
+        "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+        "VALUES (%s, 'sec', 'cik', %s, TRUE)",
+        (instrument_id, cik),
+    )
+    conn.commit()
+
+
+def _seed_filing(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    filing_date: date,
+    filing_type: str,
+    accession: str,
+) -> None:
+    conn.execute(
+        "INSERT INTO filing_events "
+        "(instrument_id, filing_date, filing_type, provider, provider_filing_id) "
+        "VALUES (%s, %s, %s, 'sec', %s)",
+        (instrument_id, filing_date, filing_type, accession),
+    )
+    conn.commit()
+
+
+def _coverage(
+    conn: psycopg.Connection[tuple], instrument_id: int
+) -> tuple[str | None, int, datetime | None, str | None]:
+    row = conn.execute(
+        "SELECT filings_status, filings_backfill_attempts, "
+        "filings_backfill_last_at, filings_backfill_reason "
+        "FROM coverage WHERE instrument_id = %s",
+        (instrument_id,),
+    ).fetchone()
+    conn.commit()
+    assert row is not None
+    return (row[0], int(row[1]), row[2], row[3])
+
+
+def _build_submissions(
+    *,
+    recent_filings: list[tuple[str, str, date]],
+    files: list[dict[str, Any]] | None = None,
+) -> dict[str, object]:
+    """Build a primary submissions.json payload.
+
+    ``recent_filings`` is a list of ``(accession, form, filing_date)``.
+    ``files`` is the optional ``filings.files[]`` metadata list.
+    """
+    return {
+        "cik": "0000000001",
+        "filings": {
+            "recent": {
+                "accessionNumber": [f[0] for f in recent_filings],
+                "filingDate": [f[2].isoformat() for f in recent_filings],
+                "form": [f[1] for f in recent_filings],
+                "primaryDocument": [""] * len(recent_filings),
+                "reportDate": [""] * len(recent_filings),
+            },
+            "files": files or [],
+        },
+    }
+
+
+def _page(recent_filings: list[tuple[str, str, date]]) -> dict[str, object]:
+    """Build a secondary page payload (same shape as ``recent``)."""
+    return {
+        "accessionNumber": [f[0] for f in recent_filings],
+        "filingDate": [f[2].isoformat() for f in recent_filings],
+        "form": [f[1] for f in recent_filings],
+        "primaryDocument": [""] * len(recent_filings),
+        "reportDate": [""] * len(recent_filings),
+    }
+
+
+def _analysable_recent(today: date) -> list[tuple[str, str, date]]:
+    """Return 2 × 10-K + 4 × 10-Q that satisfy the analysable bar."""
+    return [
+        ("AAAA-26-000001", "10-K", today - timedelta(days=400)),
+        ("AAAA-24-000001", "10-K", today - timedelta(days=700)),
+        ("AAAA-26-000002", "10-Q", today - timedelta(days=30)),
+        ("AAAA-26-000003", "10-Q", today - timedelta(days=120)),
+        ("AAAA-25-000004", "10-Q", today - timedelta(days=210)),
+        ("AAAA-25-000005", "10-Q", today - timedelta(days=300)),
+    ]
+
+
+def _http_error() -> httpx.HTTPError:
+    return httpx.ConnectError("simulated")
+
+
+# ---------------------------------------------------------------------
+# Gating tests (1-4b)
+# ---------------------------------------------------------------------
+
+
+class TestGating:
+    def test_1_attempts_cap_with_http_error_skips(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed(
+            ebull_test_conn,
+            instrument_id=1,
+            cik="0000000001",
+            filings_status="insufficient",
+            attempts=3,
+            last_at=datetime.now(UTC) - timedelta(days=30),
+            last_reason=BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR.value,
+        )
+        provider = FakeSecProvider(_FakeResponse(primary=None, pages={}, filings={}))
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.SKIPPED_ATTEMPTS_CAP
+        assert provider.fetch_submissions_calls == []
+        # Coverage unchanged (attempts still 3, status still insufficient).
+        status, attempts, _, _ = _coverage(ebull_test_conn, 1)
+        assert status == "insufficient"
+        assert attempts == 3
+
+    def test_2_backoff_window_skips(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed(
+            ebull_test_conn,
+            instrument_id=1,
+            cik="0000000001",
+            filings_status="insufficient",
+            attempts=1,
+            last_at=datetime.now(UTC) - timedelta(days=3),
+            last_reason=BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR.value,
+        )
+        provider = FakeSecProvider(_FakeResponse(primary=None, pages={}, filings={}))
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.SKIPPED_BACKOFF_WINDOW
+        assert provider.fetch_submissions_calls == []
+
+    def test_3_cap_does_not_bite_on_exhausted_last_reason(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed(
+            ebull_test_conn,
+            instrument_id=1,
+            cik="0000000001",
+            filings_status="insufficient",
+            attempts=5,
+            last_at=datetime.now(UTC) - timedelta(days=30),
+            last_reason=BackfillOutcome.STILL_INSUFFICIENT_EXHAUSTED.value,
+        )
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=_build_submissions(recent_filings=_analysable_recent(date.today())),
+                pages={},
+                filings={},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.COMPLETE_OK
+        assert len(provider.fetch_submissions_calls) == 1
+
+    def test_4_cap_does_not_bite_on_structurally_young_last_reason(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        _seed(
+            ebull_test_conn,
+            instrument_id=1,
+            cik="0000000001",
+            filings_status="structurally_young",
+            attempts=3,
+            last_at=datetime.now(UTC) - timedelta(days=30),
+            last_reason=BackfillOutcome.STILL_INSUFFICIENT_STRUCTURALLY_YOUNG.value,
+        )
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=_build_submissions(
+                    recent_filings=[
+                        ("A-26-000001", "10-K", date.today() - timedelta(days=60)),
+                    ]
+                ),
+                pages={},
+                filings={},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        # Not gated; proceeds to a young classification.
+        assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_STRUCTURALLY_YOUNG
+
+    def test_4b_young_row_exempt_from_cap_even_with_http_error_reason(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        """v5-H1 regression: a young row must not be frozen at cap
+        when last_reason is retryable — otherwise an aged-out issuer
+        never gets its clean EXHAUSTED demote."""
+        today = date.today()
+        _seed(
+            ebull_test_conn,
+            instrument_id=1,
+            cik="0000000001",
+            filings_status="structurally_young",
+            attempts=3,
+            last_at=datetime.now(UTC) - timedelta(days=8),  # outside backoff
+            last_reason=BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR.value,
+        )
+        # Clean response, aged-out issuer (earliest filing 20 months ago).
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=_build_submissions(
+                    recent_filings=[
+                        ("A-23-000001", "10-K", today - timedelta(days=600)),  # ~20mo
+                    ]
+                ),
+                pages={},
+                filings={},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        # Not skipped; aged-out → EXHAUSTED demotes to insufficient.
+        assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_EXHAUSTED
+        status, _, _, _ = _coverage(ebull_test_conn, 1)
+        assert status == "insufficient"
+
+
+# ---------------------------------------------------------------------
+# Terminal-outcome tests (5-15)
+# ---------------------------------------------------------------------
+
+
+class TestTerminalOutcomes:
+    def test_5_complete_ok_on_page_zero(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed(ebull_test_conn, instrument_id=1, cik="0000000001", filings_status="insufficient")
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=_build_submissions(recent_filings=_analysable_recent(date.today())),
+                pages={},
+                filings={},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.COMPLETE_OK
+        assert result.pages_fetched == 1
+        assert result.filings_upserted == 6
+        status, attempts, last_at, reason = _coverage(ebull_test_conn, 1)
+        assert status == "analysable"
+        assert attempts == 0
+        assert last_at is not None
+        assert reason == BackfillOutcome.COMPLETE_OK.value
+
+    def test_6_complete_ok_with_pagination(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        today = date.today()
+        _seed(ebull_test_conn, instrument_id=1, cik="0000000001", filings_status="insufficient")
+        # Page 0: 1 × 10-K + 2 × 10-Q (below bar)
+        # Page 1: +1 × 10-K + 2 × 10-Q (meets bar)
+        primary = _build_submissions(
+            recent_filings=[
+                ("A-26-000001", "10-K", today - timedelta(days=400)),
+                ("A-26-000002", "10-Q", today - timedelta(days=30)),
+                ("A-26-000003", "10-Q", today - timedelta(days=120)),
+            ],
+            files=[
+                {
+                    "name": "page-001.json",
+                    "filingCount": 3,
+                    "filingFrom": (today - timedelta(days=730)).isoformat(),
+                    "filingTo": (today - timedelta(days=200)).isoformat(),
+                }
+            ],
+        )
+        page_001 = _page(
+            [
+                ("A-24-000001", "10-K", today - timedelta(days=700)),
+                ("A-25-000004", "10-Q", today - timedelta(days=210)),
+                ("A-25-000005", "10-Q", today - timedelta(days=300)),
+            ]
+        )
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=primary,
+                pages={"page-001.json": page_001},
+                filings={},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.COMPLETE_OK
+        assert result.pages_fetched == 2
+        assert result.filings_upserted == 6
+
+    def test_7_complete_fpi(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        today = date.today()
+        _seed(ebull_test_conn, instrument_id=1, cik="0000000001", filings_status="insufficient")
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=_build_submissions(
+                    recent_filings=[
+                        ("F-26-000001", "20-F", today - timedelta(days=100)),
+                        ("F-26-000002", "6-K", today - timedelta(days=50)),
+                    ]
+                ),
+                pages={},
+                filings={},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.COMPLETE_FPI
+        status, attempts, _, reason = _coverage(ebull_test_conn, 1)
+        assert status == "fpi"
+        assert attempts == 0
+        assert reason == BackfillOutcome.COMPLETE_FPI.value
+
+    def test_8_structurally_young(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        today = date.today()
+        _seed(
+            ebull_test_conn,
+            instrument_id=1,
+            cik="0000000001",
+            filings_status="insufficient",
+            attempts=2,
+        )
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=_build_submissions(
+                    recent_filings=[
+                        # Earliest filing 6 months ago — clearly young.
+                        ("Y-26-000001", "10-K", today - timedelta(days=180)),
+                        ("Y-26-000002", "10-Q", today - timedelta(days=90)),
+                    ]
+                ),
+                pages={},
+                filings={},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_STRUCTURALLY_YOUNG
+        status, attempts, _, reason = _coverage(ebull_test_conn, 1)
+        assert status == "structurally_young"
+        assert attempts == 2  # unchanged
+        assert reason == BackfillOutcome.STILL_INSUFFICIENT_STRUCTURALLY_YOUNG.value
+
+    def test_9_exhausted_old_issuer(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        today = date.today()
+        _seed(
+            ebull_test_conn,
+            instrument_id=1,
+            cik="0000000001",
+            filings_status="insufficient",
+            attempts=2,
+        )
+        provider = FakeSecProvider(
+            _FakeResponse(
+                # Earliest filing 5 years ago, below bar (1 × 10-K).
+                primary=_build_submissions(
+                    recent_filings=[
+                        ("E-22-000001", "10-K", today - timedelta(days=1800)),
+                    ]
+                ),
+                pages={},
+                filings={},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_EXHAUSTED
+        status, attempts, _, reason = _coverage(ebull_test_conn, 1)
+        assert status == "insufficient"
+        assert attempts == 2  # unchanged
+        assert reason == BackfillOutcome.STILL_INSUFFICIENT_EXHAUSTED.value
+
+    def test_10_exhausted_zero_filings(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed(ebull_test_conn, instrument_id=1, cik="0000000001", filings_status="insufficient")
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=_build_submissions(recent_filings=[]),
+                pages={},
+                filings={},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        # Zero filings → can't prove youth → EXHAUSTED (v2-H3).
+        assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_EXHAUSTED
+
+    def test_11_http_error_on_fetch_submissions(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed(
+            ebull_test_conn,
+            instrument_id=1,
+            cik="0000000001",
+            filings_status="insufficient",
+            attempts=1,
+        )
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=None,
+                pages={},
+                filings={},
+                submissions_raises=_http_error(),
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR
+        status, attempts, _, reason = _coverage(ebull_test_conn, 1)
+        assert status == "insufficient"  # preserved — was already insufficient
+        assert attempts == 2  # incremented
+        assert reason == BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR.value
+
+    def test_11b_http_error_preserves_structurally_young(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """v4-H2 regression: retryable error must not demote young."""
+        _seed(
+            ebull_test_conn,
+            instrument_id=1,
+            cik="0000000001",
+            filings_status="structurally_young",
+            attempts=1,
+        )
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=None,
+                pages={},
+                filings={},
+                submissions_raises=_http_error(),
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR
+        status, attempts, _, _ = _coverage(ebull_test_conn, 1)
+        assert status == "structurally_young"  # preserved
+        assert attempts == 2
+
+    def test_12_http_error_on_secondary_page(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        today = date.today()
+        _seed(ebull_test_conn, instrument_id=1, cik="0000000001", filings_status="insufficient")
+        primary = _build_submissions(
+            recent_filings=[("A-26-000001", "10-K", today - timedelta(days=30))],
+            files=[
+                {
+                    "name": "page-001.json",
+                    "filingCount": 1,
+                    "filingFrom": (today - timedelta(days=1000)).isoformat(),
+                    "filingTo": (today - timedelta(days=500)).isoformat(),
+                }
+            ],
+        )
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=primary,
+                pages={},
+                filings={},
+                page_raises={"page-001.json": _http_error()},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR
+        # Page-0 upsert should be durable.
+        row = ebull_test_conn.execute("SELECT COUNT(*) FROM filing_events WHERE instrument_id = 1").fetchone()
+        ebull_test_conn.commit()
+        assert row is not None
+        assert int(row[0]) == 1
+
+    def test_13_404_on_fetch_submissions_classifies_http_error(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        _seed(ebull_test_conn, instrument_id=1, cik="0000000001", filings_status="insufficient")
+        provider = FakeSecProvider(_FakeResponse(primary=None, pages={}, filings={}))
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR
+
+    def test_14_parse_error_json_decode(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed(ebull_test_conn, instrument_id=1, cik="0000000001", filings_status="insufficient")
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=None,
+                pages={},
+                filings={},
+                submissions_raises=json.JSONDecodeError("bad", "", 0),
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR
+
+    def test_15_parse_error_missing_recent(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed(ebull_test_conn, instrument_id=1, cik="0000000001", filings_status="insufficient")
+        # No 'filings' key → KeyError path.
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary={"cik": "0000000001"},
+                pages={},
+                filings={},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR
+
+
+# ---------------------------------------------------------------------
+# 8-K gap check (16-17)
+# ---------------------------------------------------------------------
+
+
+class TestEightKGap:
+    def test_16_defensive_gap_fill_succeeds(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Simulate a DB gap by deleting a 10-Q row between page-upsert
+        and 8-K reconciliation isn't possible; instead exercise the
+        8-K gap path by seeding a scenario where fetched 8-Ks aren't
+        in DB — the easiest trigger is to pre-delete after upsert.
+
+        Instead: test that the 8-K reconciliation query fires at all
+        and that get_filing is called for any genuine gap. We seed a
+        primary whose 8-Ks WILL be upserted in step 3; that path
+        leaves no gap, so get_filing is not called. This test
+        primarily guards the happy path (step 4 doesn't raise)."""
+        today = date.today()
+        _seed(ebull_test_conn, instrument_id=1, cik="0000000001", filings_status="insufficient")
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=_build_submissions(
+                    recent_filings=[
+                        *_analysable_recent(today),
+                        ("K-26-000100", "8-K", today - timedelta(days=10)),
+                        ("K-26-000101", "8-K", today - timedelta(days=60)),
+                    ]
+                ),
+                pages={},
+                filings={},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.COMPLETE_OK
+        assert result.eight_k_gap_filled == 0  # no gap
+        assert provider.get_filing_calls == []
+
+    def test_17_http_error_on_gap_fill_classifies_retryable(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """When step 3 leaves a genuine 8-K gap (seen_filings but
+        DB missing), get_filing is called; an HTTP error here must
+        classify as HTTP_ERROR."""
+        today = date.today()
+        _seed(ebull_test_conn, instrument_id=1, cik="0000000001", filings_status="insufficient")
+
+        # Stub _upsert_filing to drop 8-Ks so a gap exists in DB.
+        # Simpler: pre-seed filing_events with just the 10-K/10-Q
+        # filings + use fetch_submissions returning the analysable set
+        # minus the 10-K/10-Q (so upsert adds 8-Ks; no gap). Need a
+        # different approach to FORCE a gap — directly delete 8-Ks
+        # after backfill upserts them but before step 4 queries? That
+        # requires monkey-patching.
+        #
+        # Instead: use conn.execute to DELETE 8-Ks after the first
+        # upsert. We can't interleave inside backfill_filings without
+        # a monkey-patch. For this test we rely on the fact that
+        # step 4's SQL SELECT runs AFTER all upserts, so a separate
+        # connection can't race. Skip the direct-gap branch here and
+        # cover it via integration by pre-deleting.
+        #
+        # Workaround: stage the state so no 8-Ks match the DB query
+        # but seen_filings contains one via get_filing-on-gap-fill.
+        # Simulate by returning empty primary + a files[] entry
+        # whose page contains 8-Ks — but the upsert of that page
+        # writes them to DB, same no-gap outcome.
+        #
+        # Cleanest: patch _upsert_filing at module level to skip 8-Ks
+        # (simulates a silent ON CONFLICT block).
+        import app.services.filings_backfill as backfill_module
+
+        orig_upsert = backfill_module._upsert_filing
+
+        def skip_8k_upsert(conn: Any, iid: Any, provider_name: Any, result: Any) -> None:
+            if result.filing_type == "8-K":
+                return
+            orig_upsert(conn, iid, provider_name, result)
+
+        backfill_module._upsert_filing = skip_8k_upsert
+        try:
+            provider = FakeSecProvider(
+                _FakeResponse(
+                    primary=_build_submissions(
+                        recent_filings=[
+                            *_analysable_recent(today),
+                            ("K-26-000100", "8-K", today - timedelta(days=10)),
+                        ]
+                    ),
+                    pages={},
+                    filings={},
+                    get_filing_raises={"K-26-000100": _http_error()},
+                )
+            )
+
+            result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+            assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR
+            assert provider.get_filing_calls == ["K-26-000100"]
+        finally:
+            backfill_module._upsert_filing = orig_upsert
+
+
+# ---------------------------------------------------------------------
+# Normaliser regression (18-19)
+# ---------------------------------------------------------------------
+
+
+class TestNormaliserRegression:
+    def test_18_normalise_recent_block(self) -> None:
+        from app.providers.implementations.sec_edgar import _normalise_submissions_block
+
+        today = date.today()
+        block: dict[str, object] = {
+            "accessionNumber": ["A-26-000001"],
+            "filingDate": [today.isoformat()],
+            "form": ["10-K"],
+            "primaryDocument": ["main.htm"],
+            "reportDate": [""],
+        }
+
+        results = _normalise_submissions_block(block, "0000000001")
+
+        assert len(results) == 1
+        assert results[0].provider_filing_id == "A-26-000001"
+        assert results[0].filing_type == "10-K"
+
+    def test_19_normalise_page_block_same_shape(self) -> None:
+        """A files[] page carries the same arrays as `recent`."""
+        from app.providers.implementations.sec_edgar import _normalise_submissions_block
+
+        today = date.today()
+        page = _page([("A-20-000001", "10-K", today - timedelta(days=2000))])
+
+        results = _normalise_submissions_block(page, "0000000001")  # type: ignore[arg-type]
+
+        assert len(results) == 1
+        assert results[0].provider_filing_id == "A-20-000001"

--- a/tests/test_filings_backfill.py
+++ b/tests/test_filings_backfill.py
@@ -671,6 +671,45 @@ class TestEightKGap:
         assert result.eight_k_gap_filled == 0  # no gap
         assert provider.get_filing_calls == []
 
+    def test_16b_db_only_8k_is_not_treated_as_gap(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Documents the one-directional semantics of step 4:
+        the reconciliation is defensive (``fetched - db``), NOT
+        external-truth-detection (``sec_truth - our_db``). An 8-K
+        already in DB that is NOT in seen_filings must NOT trigger
+        a spurious gap-fill attempt — ground-truth completeness
+        is guaranteed by step 3's pagination loop.
+
+        PR #307 review PREVENTION item.
+        """
+        today = date.today()
+        _seed(ebull_test_conn, instrument_id=1, cik="0000000001", filings_status="insufficient")
+        # Pre-seed an 8-K directly in DB (from some prior daily-index
+        # ingest) that SEC's submissions.json response does NOT include.
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=1,
+            filing_date=today - timedelta(days=100),
+            filing_type="8-K",
+            accession="K-26-PRE-DB",
+        )
+        # Provider returns analysable filings but none of the 8-Ks
+        # the DB already has.
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=_build_submissions(recent_filings=_analysable_recent(today)),
+                pages={},
+                filings={},
+            )
+        )
+
+        result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
+        assert result.outcome == BackfillOutcome.COMPLETE_OK
+        assert result.eight_k_gap_filled == 0
+        # get_filing must NOT be called for the pre-existing DB 8-K —
+        # otherwise we'd be re-fetching filings we already have.
+        assert provider.get_filing_calls == []
+
     def test_17_http_error_on_gap_fill_classifies_retryable(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         """When step 3 leaves a genuine 8-K gap (seen_filings but
         DB missing), get_filing is called; an HTTP error here must

--- a/tests/test_weekly_coverage_audit.py
+++ b/tests/test_weekly_coverage_audit.py
@@ -1,24 +1,38 @@
-"""Tests for the weekly_coverage_audit scheduler job (#268 Chunk F, minimal).
+"""Tests for weekly_coverage_audit scheduler job (#268 Chunk E + F).
 
-Audit-only variant shipped before Chunk E's backfill helper — the job
-calls audit_all_instruments and logs the AuditSummary, no remediation.
+Full Chunk F body now: audit_all_instruments → query eligible
+instruments → per-instrument backfill_filings → log outcome counts.
+No post-backfill audit re-sweep (design v3 C1).
 """
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-# Import the module at module-level so ``patch("app.services.coverage_audit.X")``
-# has a concrete target BEFORE the lazy ``from app.services.coverage_audit import
-# audit_all_instruments`` inside ``weekly_coverage_audit`` resolves its binding.
 import app.services.coverage_audit  # noqa: F401
+import app.services.filings_backfill  # noqa: F401
 from app.services.coverage_audit import AuditSummary
+from app.services.filings_backfill import BackfillOutcome, BackfillResult
 from app.workers import scheduler
 
 
-def test_weekly_coverage_audit_runs_audit_and_sets_row_count() -> None:
-    """Happy path: audit_all_instruments returns a summary; tracker.row_count
-    is set to total_updated; no raise."""
+def _stub_backfill_result(
+    instrument_id: int,
+    outcome: BackfillOutcome = BackfillOutcome.COMPLETE_OK,
+) -> BackfillResult:
+    return BackfillResult(
+        instrument_id=instrument_id,
+        outcome=outcome,
+        pages_fetched=1,
+        filings_upserted=0,
+        eight_k_gap_filled=0,
+        final_status="analysable",
+    )
+
+
+def test_weekly_coverage_audit_runs_audit_and_backfills_eligible() -> None:
+    """Full path: audit runs, eligible set queried, each instrument
+    is backfilled, tracker.row_count reflects audit total_updated."""
     summary = AuditSummary(
         analysable=42,
         insufficient=5,
@@ -30,34 +44,102 @@ def test_weekly_coverage_audit_runs_audit_and_sets_row_count() -> None:
 
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test-agent@example.com"
 
     tracker = MagicMock()
     tracker.row_count = None
+
+    # Two eligible rows — both backfill to COMPLETE_OK.
+    eligible_rows = [(101, "0000000101"), (102, "0000000102")]
 
     with (
         patch.object(scheduler, "settings", stub_settings),
         patch.object(scheduler, "_tracked_job") as tracked_cm,
         patch.object(scheduler, "psycopg") as psycopg_mod,
+        patch.object(scheduler, "SecFilingsProvider") as provider_cls,
         patch(
             "app.services.coverage_audit.audit_all_instruments",
             return_value=summary,
         ) as audit_mock,
+        patch(
+            "app.services.filings_backfill.backfill_filings",
+            side_effect=lambda conn, provider, cik, iid: _stub_backfill_result(iid),
+        ) as backfill_mock,
     ):
         tracked_cm.return_value.__enter__.return_value = tracker
         conn_mock = MagicMock()
+        conn_mock.execute.return_value.fetchall.return_value = eligible_rows
         psycopg_mod.connect.return_value.__enter__.return_value = conn_mock
+        provider_cls.return_value.__enter__.return_value = MagicMock()
 
         scheduler.weekly_coverage_audit()
 
     audit_mock.assert_called_once_with(conn_mock)
-    assert tracker.row_count == 7
+    assert backfill_mock.call_count == 2
+    # Row count = audit.total_updated + non-skipped backfill writes
+    # (2 × COMPLETE_OK = 2). Per design v5.
+    assert tracker.row_count == 9
 
 
-def test_weekly_coverage_audit_propagates_failure() -> None:
+def test_weekly_coverage_audit_per_instrument_error_is_isolated() -> None:
+    """One backfill raising must not abort the whole batch."""
+    summary = AuditSummary(
+        analysable=0,
+        insufficient=3,
+        fpi=0,
+        no_primary_sec_cik=0,
+        total_updated=3,
+        null_anomalies=0,
+    )
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test-agent@example.com"
+
+    tracker = MagicMock()
+
+    eligible_rows = [(201, "0000000201"), (202, "0000000202"), (203, "0000000203")]
+
+    def flaky_backfill(conn: object, provider: object, cik: str, iid: int) -> BackfillResult:
+        if iid == 202:
+            raise RuntimeError("simulated provider crash")
+        return _stub_backfill_result(iid)
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job") as tracked_cm,
+        patch.object(scheduler, "psycopg") as psycopg_mod,
+        patch.object(scheduler, "SecFilingsProvider") as provider_cls,
+        patch(
+            "app.services.coverage_audit.audit_all_instruments",
+            return_value=summary,
+        ),
+        patch(
+            "app.services.filings_backfill.backfill_filings",
+            side_effect=flaky_backfill,
+        ) as backfill_mock,
+    ):
+        tracked_cm.return_value.__enter__.return_value = tracker
+        conn_mock = MagicMock()
+        conn_mock.execute.return_value.fetchall.return_value = eligible_rows
+        psycopg_mod.connect.return_value.__enter__.return_value = conn_mock
+        provider_cls.return_value.__enter__.return_value = MagicMock()
+
+        # Must not raise — the middle instrument errors but the
+        # others still get processed.
+        scheduler.weekly_coverage_audit()
+
+    assert backfill_mock.call_count == 3
+    # Rollback is called after the erroring instrument so the
+    # shared connection isn't poisoned for the next iteration.
+    conn_mock.rollback.assert_called()
+
+
+def test_weekly_coverage_audit_propagates_audit_failure() -> None:
     """audit_all_instruments raising must propagate so _tracked_job
     records status=failure. No silent swallow."""
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test-agent@example.com"
 
     tracker = MagicMock()
 


### PR DESCRIPTION
## What
New ``app/services/filings_backfill.py``: drives every tradable SEC-covered instrument toward a terminal ``coverage.filings_status`` by paging ``submissions.json`` history + verifying 8-K completeness inside the 365-day window. Replaces F-minimal audit-only body of ``weekly_coverage_audit`` with audit → backfill loop. Closes Chunk E + full F (#268).

## Why
Chunk D's audit only classifies from DB counts, leaving ``insufficient`` rows stuck forever. Chunk E backfills history via SEC ``submissions.json`` + ``files[]`` pagination; Chunk F wires it into the weekly scheduler so the eligible set gets reconciled on every cycle.

## Test plan
- [x] 21 unit tests for ``backfill_filings`` (6 terminal outcomes + 2 skipped + all error paths).
- [x] 8 integration tests for Chunk D demote-guard + read-only ``probe_status`` in ``test_coverage_audit_integration.py``.
- [x] 3 scheduler tests for the new audit → backfill loop (happy path, per-instrument isolation + rollback, propagate audit failure).
- [x] ``ruff check``, ``ruff format --check``, ``pyright``, full pytest (1932 passed, 1 skipped).

## Spec + review
Design doc: ``docs/superpowers/specs/2026-04-18-chunk-e-filings-backfill-design.md`` (v5, APPROVED). Codex iterations before sign-off: v1 (8 issues) → v2 (3) → v3 (3) → v4 (2) → v5 (0). Pre-push Codex found 3 issues (secondary-page parse uncaught, scheduler missing rollback, row_count divergence); all fixed + Codex re-reviewed as ``no blocking regressions``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)