### PR TITLE
feat: migrate 6 providers to shared raw_persistence (Plan A PR 2 of 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ data/
 # Dev server PID tracking
 .dev-pids
 .playwright-mcp/
+
+# Codex scratch dirs
+.tmp/
+tmp_pytest/
+.superpowers/

--- a/app/providers/implementations/companies_house.py
+++ b/app/providers/implementations/companies_house.py
@@ -23,36 +23,24 @@ Endpoints used:
 Raw responses are persisted before normalisation.
 """
 
-import json
 import logging
 from datetime import UTC, date, datetime
-from pathlib import Path
 from types import TracebackType
 
 import httpx
 
 from app.providers.filings import FilingEvent, FilingNotFound, FilingSearchResult, FilingsProvider
 from app.providers.resilient_client import ResilientClient
+from app.services import raw_persistence
 
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://api.company-information.service.gov.uk"
-_RAW_PAYLOAD_DIR = Path("data/raw/companies_house")
 _PAGE_SIZE = 100
 
 # Companies House rate limit: 600 req/5 min (= 2 req/s avg).
 # 0.55s interval ≈ 109/min — ~9% headroom.
 _CH_REQUEST_INTERVAL_S = 0.55
-
-
-def _persist_raw(tag: str, payload: object) -> None:
-    try:
-        _RAW_PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-        path = _RAW_PAYLOAD_DIR / f"{tag}_{ts}.json"
-        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    except Exception:
-        logger.warning("Failed to persist raw CH payload for tag=%s", tag, exc_info=True)
 
 
 class CompaniesHouseFilingsProvider(FilingsProvider):
@@ -141,7 +129,7 @@ class CompaniesHouseFilingsProvider(FilingsProvider):
             raise FilingNotFound(f"Filing not found: {provider_filing_id}")
         resp.raise_for_status()
         raw = resp.json()
-        _persist_raw(f"ch_filing_{company_number}_{transaction_id}", raw)
+        raw_persistence.persist_raw_if_new("companies_house", f"ch_filing_{company_number}_{transaction_id}", raw)
 
         return _normalise_filing_event(provider_filing_id, company_number, raw)
 
@@ -160,7 +148,7 @@ class CompaniesHouseFilingsProvider(FilingsProvider):
             return None
         resp.raise_for_status()
         raw = resp.json()
-        _persist_raw(f"ch_filings_{company_number}", raw)
+        raw_persistence.persist_raw_if_new("companies_house", f"ch_filings_{company_number}", raw)
 
         items = raw.get("items")
         if not isinstance(items, list):

--- a/app/providers/implementations/etoro.py
+++ b/app/providers/implementations/etoro.py
@@ -8,12 +8,10 @@ Auth: three-header scheme (x-api-key, x-user-key, x-request-id).
 Base URL: https://public-api.etoro.com (configurable via settings.etoro_base_url).
 """
 
-import json
 import logging
 from collections.abc import Mapping
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from pathlib import Path
 from types import TracebackType
 from uuid import uuid4
 
@@ -22,11 +20,9 @@ import httpx
 from app.config import settings
 from app.providers.market_data import InstrumentRecord, MarketDataProvider, OHLCVBar, Quote
 from app.providers.resilient_client import ResilientClient
+from app.services import raw_persistence
 
 logger = logging.getLogger(__name__)
-
-# Directory for raw payload dumps (relative to process working directory)
-_RAW_PAYLOAD_DIR = Path("data/raw/etoro")
 
 # eToro rates endpoint accepts at most 100 instrument IDs per request
 # (OpenAPI spec maxItems: 100).  We use 50 to reduce blast radius when
@@ -36,18 +32,6 @@ _RATES_BATCH_SIZE = 50
 # eToro rate limit: 60 GET requests per minute (rolling window).
 # 1.1s inter-request interval ≈ 55 req/min — ~8% headroom.
 _ETORO_READ_INTERVAL_S = 1.1
-
-
-def _persist_raw(tag: str, payload: object) -> None:
-    """Write raw API response to disk before normalisation."""
-    try:
-        _RAW_PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-        path = _RAW_PAYLOAD_DIR / f"{tag}_{ts}.json"
-        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    except Exception:
-        # Never let persistence failure block the sync
-        logger.warning("Failed to persist raw payload for tag=%s", tag, exc_info=True)
 
 
 class EtoroMarketDataProvider(MarketDataProvider):
@@ -109,7 +93,7 @@ class EtoroMarketDataProvider(MarketDataProvider):
         )
         response.raise_for_status()
         raw = response.json()
-        _persist_raw("instruments", raw)
+        raw_persistence.persist_raw_if_new("etoro", "instruments", raw)
         return _normalise_instruments(raw)
 
     # ------------------------------------------------------------------
@@ -128,7 +112,7 @@ class EtoroMarketDataProvider(MarketDataProvider):
         )
         response.raise_for_status()
         raw = response.json()
-        _persist_raw(f"candles_{instrument_id}", raw)
+        raw_persistence.persist_raw_if_new("etoro", f"candles_{instrument_id}", raw)
         return _normalise_candles(raw)
 
     # ------------------------------------------------------------------
@@ -171,7 +155,7 @@ class EtoroMarketDataProvider(MarketDataProvider):
                 response.raise_for_status()
             except httpx.HTTPStatusError as exc:
                 # Persist the error response body for diagnosis.
-                _persist_raw(f"rates_batch{batch_num}_error", exc.response.text)
+                raw_persistence.persist_raw_if_new("etoro", f"rates_batch{batch_num}_error", exc.response.text)
                 logger.warning(
                     "Rates chunk %d failed (%d IDs, status %d), skipping",
                     batch_num,
@@ -192,7 +176,7 @@ class EtoroMarketDataProvider(MarketDataProvider):
                 failed_chunks += 1
                 continue
             raw = response.json()
-            _persist_raw(f"rates_batch{batch_num}", raw)
+            raw_persistence.persist_raw_if_new("etoro", f"rates_batch{batch_num}", raw)
             all_quotes.extend(_normalise_rates(raw))
 
         if failed_chunks:

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -14,9 +14,8 @@ from __future__ import annotations
 import decimal
 import logging
 from collections.abc import Sequence
-from datetime import UTC, datetime
+from datetime import datetime
 from decimal import Decimal
-from pathlib import Path
 from types import TracebackType
 from typing import Any
 
@@ -34,28 +33,9 @@ from app.providers.broker import (
     OrderStatus,
 )
 from app.providers.resilient_client import ResilientClient
+from app.services import raw_persistence
 
 logger = logging.getLogger(__name__)
-
-_RAW_PAYLOAD_DIR = Path("data/raw/etoro_broker")
-
-
-def _persist_raw(tag: str, payload: bytes) -> None:
-    """Write raw API response bytes to disk before normalisation.
-
-    Raises ``OSError`` on disk-level failures (permission denied, disk full)
-    so the caller can decide whether to abort or continue.  Non-OS exceptions
-    are logged and swallowed.
-    """
-    try:
-        _RAW_PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-        path = _RAW_PAYLOAD_DIR / f"{tag}_{ts}.json"
-        path.write_bytes(payload)
-    except OSError:
-        raise
-    except Exception:
-        logger.warning("Failed to persist raw payload for tag=%s", tag, exc_info=True)
 
 
 # Actions the service layer is allowed to send to place_order.
@@ -421,13 +401,10 @@ class EtoroBrokerProvider(BrokerProvider):
             f"{self._info_prefix}/portfolio",
             headers=self._request_headers(),
         )
-        try:
-            _persist_raw("etoro_portfolio", response.content)
-        except OSError:
-            logger.error(
-                "Failed to persist raw portfolio payload — continuing with response",
-                exc_info=True,
-            )
+        # Best-effort raw persist. Helper swallows OSError internally
+        # (logs + returns None); sync must continue with parsed
+        # response regardless.
+        raw_persistence.persist_raw_if_new("etoro_broker", "etoro_portfolio", response.content)
         response.raise_for_status()
         raw = response.json()
 

--- a/app/providers/implementations/fmp.py
+++ b/app/providers/implementations/fmp.py
@@ -26,13 +26,11 @@ fallback and the mismatch is logged.
 Raw responses are persisted before normalisation.
 """
 
-import json
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import date
 from decimal import Decimal
-from pathlib import Path
 from types import TracebackType
 
 import httpx
@@ -45,26 +43,15 @@ from app.providers.enrichment import (
 )
 from app.providers.fundamentals import FundamentalsProvider, FundamentalsSnapshot
 from app.providers.resilient_client import ResilientClient
+from app.services import raw_persistence
 
 logger = logging.getLogger(__name__)
 
 _FMP_BASE_URL = "https://financialmodelingprep.com/api"
-_RAW_PAYLOAD_DIR = Path("data/raw/fmp")
 
 # FMP rate limit: ~250 req/min on Premium (plan-dependent).
 # 0.25s interval ≈ 240/min — ~4% headroom.
 _FMP_REQUEST_INTERVAL_S = 0.25
-
-
-def _persist_raw(tag: str, payload: object) -> None:
-    """Write raw API response to disk before normalisation."""
-    try:
-        _RAW_PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-        path = _RAW_PAYLOAD_DIR / f"{tag}_{ts}.json"
-        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    except Exception:
-        logger.warning("Failed to persist raw FMP payload for tag=%s", tag, exc_info=True)
 
 
 @dataclass(frozen=True)
@@ -249,7 +236,7 @@ class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
             logger.warning("FMP earnings calendar fetch failed for %s: %s", symbol, resp.status_code)
             return []
         raw = resp.json()
-        _persist_raw(f"fmp_earnings_{symbol}", raw)
+        raw_persistence.persist_raw_if_new("fmp", f"fmp_earnings_{symbol}", raw)
         if not isinstance(raw, list):
             return []
         events: list[EarningsEvent] = []
@@ -277,7 +264,7 @@ class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
         estimates: list[dict[str, object]] = []
         if est_resp.status_code == 200:
             raw_est = est_resp.json()
-            _persist_raw(f"fmp_analyst_est_{symbol}", raw_est)
+            raw_persistence.persist_raw_if_new("fmp", f"fmp_analyst_est_{symbol}", raw_est)
             if isinstance(raw_est, list):
                 estimates = [row for row in raw_est if isinstance(row, dict)]
 
@@ -288,7 +275,7 @@ class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
         consensus: dict[str, object] | None = None
         if rec_resp.status_code == 200:
             raw_rec = rec_resp.json()
-            _persist_raw(f"fmp_analyst_rec_{symbol}", raw_rec)
+            raw_persistence.persist_raw_if_new("fmp", f"fmp_analyst_rec_{symbol}", raw_rec)
             if isinstance(raw_rec, list) and raw_rec and isinstance(raw_rec[0], dict):
                 consensus = raw_rec[0]
 
@@ -299,7 +286,7 @@ class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
         price_target: dict[str, object] | None = None
         if pt_resp.status_code == 200:
             raw_pt = pt_resp.json()
-            _persist_raw(f"fmp_price_target_{symbol}", raw_pt)
+            raw_persistence.persist_raw_if_new("fmp", f"fmp_price_target_{symbol}", raw_pt)
             if isinstance(raw_pt, list) and raw_pt and isinstance(raw_pt[0], dict):
                 price_target = raw_pt[0]
 
@@ -323,7 +310,7 @@ class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
             logger.warning("FMP profile fetch failed for %s: %s", symbol, resp.status_code)
             return None
         data = resp.json()
-        _persist_raw(f"fmp_profile_{symbol}", data)
+        raw_persistence.persist_raw_if_new("fmp", f"fmp_profile_{symbol}", data)
         if not isinstance(data, list) or not data:
             return None
         item = data[0]
@@ -336,7 +323,7 @@ class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
         )
         resp.raise_for_status()
         raw = resp.json()
-        _persist_raw(f"fmp_bs_{symbol}", raw)
+        raw_persistence.persist_raw_if_new("fmp", f"fmp_bs_{symbol}", raw)
         return raw if isinstance(raw, list) else []
 
     def _fetch_income(self, symbol: str, limit: int) -> list[dict[str, object]]:
@@ -346,7 +333,7 @@ class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
         )
         resp.raise_for_status()
         raw = resp.json()
-        _persist_raw(f"fmp_inc_{symbol}", raw)
+        raw_persistence.persist_raw_if_new("fmp", f"fmp_inc_{symbol}", raw)
         return raw if isinstance(raw, list) else []
 
     def _fetch_cashflow(self, symbol: str, limit: int) -> list[dict[str, object]]:
@@ -356,7 +343,7 @@ class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
         )
         resp.raise_for_status()
         raw = resp.json()
-        _persist_raw(f"fmp_cf_{symbol}", raw)
+        raw_persistence.persist_raw_if_new("fmp", f"fmp_cf_{symbol}", raw)
         return raw if isinstance(raw, list) else []
 
     def _fetch_ttm_income(self, symbol: str) -> dict[str, object] | None:
@@ -366,7 +353,7 @@ class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
         )
         resp.raise_for_status()
         raw = resp.json()
-        _persist_raw(f"fmp_inc_ttm_{symbol}", raw)
+        raw_persistence.persist_raw_if_new("fmp", f"fmp_inc_ttm_{symbol}", raw)
         if isinstance(raw, list) and raw:
             return raw[0]  # type: ignore[return-value]
         return None
@@ -378,7 +365,7 @@ class FmpFundamentalsProvider(FundamentalsProvider, EnrichmentProvider):
         )
         resp.raise_for_status()
         raw = resp.json()
-        _persist_raw(f"fmp_cf_ttm_{symbol}", raw)
+        raw_persistence.persist_raw_if_new("fmp", f"fmp_cf_ttm_{symbol}", raw)
         if isinstance(raw, list) and raw:
             return raw[0]  # type: ignore[return-value]
         return None

--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -26,36 +26,24 @@ Provider contract:
 """
 
 import hashlib
-import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
-from pathlib import Path
 from types import TracebackType
 
 import httpx
 
 from app.providers.filings import FilingEvent, FilingNotFound, FilingSearchResult, FilingsProvider
 from app.providers.resilient_client import ResilientClient
+from app.services import raw_persistence
 
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://data.sec.gov"
 _TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
-_RAW_PAYLOAD_DIR = Path("data/raw/sec")
 
 # SEC rate-limit: 10 req/s. We use a conservative inter-request floor.
 _MIN_REQUEST_INTERVAL_S = 0.11
-
-
-def _persist_raw(tag: str, payload: object) -> None:
-    try:
-        _RAW_PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-        path = _RAW_PAYLOAD_DIR / f"{tag}_{ts}.json"
-        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    except Exception:
-        logger.warning("Failed to persist raw SEC payload for tag=%s", tag, exc_info=True)
 
 
 def _zero_pad_cik(cik: str | int) -> str:
@@ -261,7 +249,7 @@ class SecFilingsProvider(FilingsProvider):
             raise FilingNotFound(f"Filing not found: {provider_filing_id}")
         resp.raise_for_status()
         raw = resp.json()
-        _persist_raw(f"sec_filing_{provider_filing_id.replace('/', '_')}", raw)
+        raw_persistence.persist_raw_if_new("sec", f"sec_filing_{provider_filing_id.replace('/', '_')}", raw)
 
         return _normalise_filing_event(provider_filing_id, raw)
 
@@ -282,7 +270,7 @@ class SecFilingsProvider(FilingsProvider):
         resp = self._http_tickers.get(_TICKERS_URL)
         resp.raise_for_status()
         raw = resp.json()
-        _persist_raw("sec_tickers", raw)
+        raw_persistence.persist_raw_if_new("sec", "sec_tickers", raw)
         return _parse_cik_mapping(raw)
 
     def build_cik_mapping_conditional(
@@ -322,7 +310,7 @@ class SecFilingsProvider(FilingsProvider):
         # might mutate the content view.
         body_hash = hashlib.sha256(resp.content).hexdigest()
         raw = resp.json()
-        _persist_raw("sec_tickers", raw)
+        raw_persistence.persist_raw_if_new("sec", "sec_tickers", raw)
         return CikMappingResult(
             mapping=_parse_cik_mapping(raw),
             body_hash=body_hash,
@@ -392,7 +380,7 @@ class SecFilingsProvider(FilingsProvider):
             return None
         resp.raise_for_status()
         raw = resp.json()
-        _persist_raw(f"sec_submissions_page_{name}", raw)
+        raw_persistence.persist_raw_if_new("sec", f"sec_submissions_page_{name}", raw)
         return raw  # type: ignore[return-value]
 
     # ------------------------------------------------------------------
@@ -407,7 +395,7 @@ class SecFilingsProvider(FilingsProvider):
             return None
         resp.raise_for_status()
         raw = resp.json()
-        _persist_raw(f"sec_submissions_{cik_padded}", raw)
+        raw_persistence.persist_raw_if_new("sec", f"sec_submissions_{cik_padded}", raw)
         return raw  # type: ignore[return-value]
 
 

--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -30,11 +30,9 @@ Provider contract:
 
 from __future__ import annotations
 
-import json
 import logging
-from datetime import UTC, date, datetime
+from datetime import date
 from decimal import Decimal
-from pathlib import Path
 from types import TracebackType
 from typing import Any
 
@@ -42,11 +40,11 @@ import httpx
 
 from app.providers.fundamentals import FundamentalsProvider, FundamentalsSnapshot, XbrlFact
 from app.providers.resilient_client import ResilientClient
+from app.services import raw_persistence
 
 logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://data.sec.gov"
-_RAW_PAYLOAD_DIR = Path("data/raw/sec_fundamentals")
 
 # SEC rate-limit: 10 req/s.  Shared with the filings provider if both are
 # running, but in practice they run in separate phases of daily_research_refresh
@@ -130,16 +128,6 @@ TRACKED_CONCEPTS: dict[str, tuple[str, ...]] = {
 }
 
 _ALL_TRACKED_TAGS: frozenset[str] = frozenset(tag for tags in TRACKED_CONCEPTS.values() for tag in tags)
-
-
-def _persist_raw(tag: str, payload: object) -> None:
-    try:
-        _RAW_PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-        path = _RAW_PAYLOAD_DIR / f"{tag}_{ts}.json"
-        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    except Exception:
-        logger.warning("Failed to persist raw SEC fundamentals payload for tag=%s", tag, exc_info=True)
 
 
 def _zero_pad_cik(cik: str | int) -> str:
@@ -342,7 +330,7 @@ class SecFundamentalsProvider(FundamentalsProvider):
             return None
         # Persist raw response before raise — non-negotiable for auditability.
         raw = resp.json()
-        _persist_raw(f"sec_facts_{cik_padded}", raw)
+        raw_persistence.persist_raw_if_new("sec_fundamentals", f"sec_facts_{cik_padded}", raw)
         resp.raise_for_status()
         return raw  # type: ignore[no-any-return]
 

--- a/app/services/raw_persistence.py
+++ b/app/services/raw_persistence.py
@@ -129,6 +129,15 @@ def _canonicalise_for_hash(payload: object) -> bytes:
             return payload
         return json.dumps(parsed, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
+    # JSON scalars (None, bool, int, float) — match the original
+    # ``_persist_raw`` per-provider behaviour which used plain
+    # ``json.dumps(payload)``. Upstream APIs sometimes return bare
+    # JSON ``null`` with a 200 response; pre-migration that would
+    # persist successfully. Scalars are already deterministic so no
+    # canonicalisation beyond ``json.dumps`` is needed.
+    if payload is None or isinstance(payload, bool | int | float):
+        return json.dumps(payload).encode("utf-8")
+
     raise TypeError(f"persist_raw_if_new: unsupported payload type {type(payload).__name__}")
 
 

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -645,7 +645,7 @@ FIXTURE_FULL_PORTFOLIO_RESPONSE = {
 }
 
 
-@patch("app.providers.implementations.etoro_broker._persist_raw")
+@patch("app.providers.implementations.etoro_broker.raw_persistence.persist_raw_if_new")
 class TestGetPortfolio:
     def test_returns_positions_and_cash(self, _mock_persist: MagicMock) -> None:
         mock_resp = MagicMock()

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -322,7 +322,7 @@ class TestNormaliseRates:
 class TestGetQuotesChunking:
     """Test that get_quotes chunks IDs at 50 and builds correct params."""
 
-    @patch("app.providers.implementations.etoro._persist_raw")
+    @patch("app.providers.implementations.etoro.raw_persistence.persist_raw_if_new")
     def test_empty_list_no_http_call(self, _mock_persist: MagicMock) -> None:
         from app.providers.implementations.etoro import EtoroMarketDataProvider
 
@@ -332,7 +332,7 @@ class TestGetQuotesChunking:
             assert result == []
             provider._http.get.assert_not_called()
 
-    @patch("app.providers.implementations.etoro._persist_raw")
+    @patch("app.providers.implementations.etoro.raw_persistence.persist_raw_if_new")
     def test_single_batch_params(self, _mock_persist: MagicMock) -> None:
         """instrumentIds are inlined in the URL with raw commas (not percent-encoded)."""
         from app.providers.implementations.etoro import EtoroMarketDataProvider
@@ -351,7 +351,7 @@ class TestGetQuotesChunking:
             url_arg = provider._http.get.call_args.args[0]
             assert "instrumentIds=1001,1002,1003" in url_arg
 
-    @patch("app.providers.implementations.etoro._persist_raw")
+    @patch("app.providers.implementations.etoro.raw_persistence.persist_raw_if_new")
     def test_chunking_at_51_ids(self, _mock_persist: MagicMock) -> None:
         """51 IDs should produce exactly 2 HTTP requests (50 + 1)."""
         from app.providers.implementations.etoro import EtoroMarketDataProvider
@@ -377,7 +377,7 @@ class TestGetQuotesChunking:
             second_ids = second_url.split("instrumentIds=")[1].split("&")[0]
             assert len(second_ids.split(",")) == 1
 
-    @patch("app.providers.implementations.etoro._persist_raw")
+    @patch("app.providers.implementations.etoro.raw_persistence.persist_raw_if_new")
     def test_failed_chunk_does_not_poison_others(self, _mock_persist: MagicMock) -> None:
         """If one chunk 500s, the rest still return quotes."""
         from app.providers.implementations.etoro import EtoroMarketDataProvider
@@ -405,8 +405,10 @@ class TestGetQuotesChunking:
             # Should return the quotes from the successful chunk
             assert len(result) == 1
             assert provider._http.get.call_count == 2
-            # Error response body must be persisted for diagnosis
-            persist_calls = {call[0][0]: call[0][1] for call in _mock_persist.call_args_list}
+            # Error response body must be persisted for diagnosis.
+            # Shared helper signature: persist_raw_if_new(source, tag, payload)
+            # — tag is positional arg index 1, payload is index 2.
+            persist_calls = {call[0][1]: call[0][2] for call in _mock_persist.call_args_list}
             assert "rates_batch1_error" in persist_calls
             assert '{"error":"internal"}' in persist_calls["rates_batch1_error"]
 

--- a/tests/test_raw_persistence.py
+++ b/tests/test_raw_persistence.py
@@ -64,10 +64,19 @@ class TestCanonicalise:
         raw_json_str = '{"code":400,"error":"bad_request"}'
         assert _canonicalise_for_hash(raw_json_str) == _canonicalise_for_hash(d)
 
+    def test_scalar_json_values_accepted(self) -> None:
+        """JSON scalars (None, bool, int, float) are accepted — matches
+        original per-provider json.dumps(payload) behaviour so upstream
+        APIs returning bare JSON null don't crash the sync path."""
+        assert _canonicalise_for_hash(None) == b"null"
+        assert _canonicalise_for_hash(True) == b"true"
+        assert _canonicalise_for_hash(42) == b"42"
+        assert _canonicalise_for_hash(3.14) == b"3.14"
+
     def test_unsupported_type_raises(self) -> None:
-        """Numbers, sets, etc. are not supported payload types."""
+        """sets, custom objects, etc. are not supported."""
         with pytest.raises(TypeError, match="unsupported payload type"):
-            _canonicalise_for_hash(42)  # type: ignore[arg-type]
+            _canonicalise_for_hash({1, 2, 3})  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## What
Migrates all 6 provider modules from per-module ``_persist_raw`` to the shared ``raw_persistence.persist_raw_if_new`` helper shipped in PR #309. No new behaviour yet — PR 3 adds compaction + sweep scheduler to actually reclaim the 225 GB.

## Provider changes
All calls route through ``app.services.raw_persistence.persist_raw_if_new``:

- ``companies_house.py``: 2 call sites (``source='companies_house'``)
- ``etoro.py``: 4 call sites (instruments, candles, rates batches, error bodies)
- ``etoro_broker.py``: 1 call site; removed caller's ``try/except OSError`` since helper swallows OSError internally (semantically equivalent — both log + continue)
- ``fmp.py``: 10 call sites
- ``sec_edgar.py``: 5 call sites
- ``sec_fundamentals.py``: 1 call site (the 225 GB source)

## Test migration
- ``test_market_data.py``: 4 ``@patch`` decorators updated to new symbol path + ``call_args`` index shifted by 1 (new ``source`` arg at position 0)
- ``test_broker_provider.py``: 1 ``@patch`` decorator updated

## Codex pre-push review
2 items flagged, both addressed:
- **P1 (ruff F401)**: 3 unused imports left over from deleted ``_persist_raw`` signatures — fixed.
- **P2 (scalar payload regression)**: helper rejected ``None`` / ``bool`` / ``int`` / ``float`` which the original ``json.dumps(payload)`` accepted. Extended ``_canonicalise_for_hash`` to accept scalars (matches pre-migration behaviour); added regression test.

Also noticed Codex's sandbox left scratch dirs (``.tmp/``, ``tmp_pytest/``, ``.superpowers/``) — added to ``.gitignore`` so they can never leak into future commits.

## Test plan
- [x] ``ruff check --no-cache`` clean
- [x] ``ruff format --check`` clean
- [x] ``pyright`` clean
- [x] ``pytest`` — 1955 passed (1 new test for scalar JSON regression), 1 skipped

## Sequence
- ✅ **PR #309** (merged): shared helper + tests
- **This PR**: migrate 6 providers
- **PR 3** (next): compaction + sweep + scheduler + state table → reclaim 225 GB

🤖 Generated with [Claude Code](https://claude.com/claude-code)