### PR TITLE
feat: Chunk L — dedupe SEC filings fetch (feature flag)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -74,17 +74,17 @@ Follow this order unless the user explicitly says otherwise:
    - `fix/{issue-number}-short-description`
 2. Commit only on that branch.
 3. Push and open a PR.
-After every push, poll:
-- `gh pr view {pr_number} --comments`
-- `gh pr checks {pr_number}`
+   After every push, poll:
+   - `gh pr view {pr_number} --comments`
+   - `gh pr checks {pr_number}`
 
-Do not push again until:
-- the Claude review has posted
-- CI results are visible
-- all review comments have been read
+   Do not push again until:
+   - the Claude review has posted
+   - CI results are visible
+   - all review comments have been read
 
-Do not push a follow-up commit for CI alone without first reading the review comments on the latest commit.
-If the review has not posted yet, wait and poll again rather than continuing blindly.
+   Do not push a follow-up commit for CI alone without first reading the review comments on the latest commit.
+   If the review has not posted yet, wait and poll again rather than continuing blindly.
 4. Wait for Claude review and CI on the latest commit.
 5. Resolve every review comment explicitly.
 6. Re-run local checks before every follow-up push.

--- a/app/config.py
+++ b/app/config.py
@@ -135,5 +135,18 @@ class Settings(BaseSettings):
     # expected reclaim volume.
     raw_retention_dry_run: bool = True
 
+    # Chunk L: dedupe SEC filings fetch. When True,
+    # ``daily_research_refresh`` skips its SEC EDGAR filings fetch
+    # entirely and relies on ``daily_financial_facts``'s master-index
+    # path (``_upsert_filing_from_master_index``) to populate
+    # ``filing_events``. Static audit confirms the master-index path
+    # is strictly broader in coverage (every form type, including
+    # amendments) — the only difference is ``primary_document_url``
+    # may be the generic index page rather than the specific document.
+    # Companies House filings path is unaffected.
+    # Ship as False (default) → operator flips True → observe ~1 week
+    # → follow-up PR deletes the guarded SEC block.
+    enable_filings_fetch_dedupe: bool = False
+
 
 settings = Settings()

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1107,27 +1107,41 @@ def daily_research_refresh() -> None:
                 logger.warning("Enrichment refresh failed", exc_info=True)
 
         # Filings — SEC EDGAR
-        with (
-            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
-            psycopg.connect(settings.database_url) as conn,
-        ):
-            sec_summary = refresh_filings(
-                provider=sec,
-                provider_name="sec",
-                identifier_type="cik",
-                conn=conn,
-                instrument_ids=instrument_ids,
-                start_date=from_date,
-                end_date=to_date,
-                filing_types=["10-K", "10-Q", "8-K"],
+        # Chunk L: when ``enable_filings_fetch_dedupe`` is True, skip
+        # this call entirely. ``daily_financial_facts`` already upserts
+        # every master-index entry into ``filing_events`` via
+        # ``_upsert_filing_from_master_index`` — strictly broader
+        # coverage (all form types, including amendments) than this
+        # path's hardcoded {10-K, 10-Q, 8-K} filter. Companies House
+        # filings (below) are unaffected — CH has no analogous
+        # master-index path.
+        if settings.enable_filings_fetch_dedupe:
+            logger.info(
+                "SEC filings refresh: skipped (enable_filings_fetch_dedupe=True); "
+                "relying on daily_financial_facts master-index path for filing_events"
             )
-        total_rows += sec_summary.filings_upserted
-        logger.info(
-            "SEC filings refresh: attempted=%d upserted=%d skipped=%d",
-            sec_summary.instruments_attempted,
-            sec_summary.filings_upserted,
-            sec_summary.instruments_skipped,
-        )
+        else:
+            with (
+                SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+                psycopg.connect(settings.database_url) as conn,
+            ):
+                sec_summary = refresh_filings(
+                    provider=sec,
+                    provider_name="sec",
+                    identifier_type="cik",
+                    conn=conn,
+                    instrument_ids=instrument_ids,
+                    start_date=from_date,
+                    end_date=to_date,
+                    filing_types=["10-K", "10-Q", "8-K"],
+                )
+            total_rows += sec_summary.filings_upserted
+            logger.info(
+                "SEC filings refresh: attempted=%d upserted=%d skipped=%d",
+                sec_summary.instruments_attempted,
+                sec_summary.filings_upserted,
+                sec_summary.instruments_skipped,
+            )
 
         # Filings — Companies House
         if settings.companies_house_api_key:

--- a/tests/test_daily_research_refresh_dedupe.py
+++ b/tests/test_daily_research_refresh_dedupe.py
@@ -1,0 +1,143 @@
+"""Tests for Chunk L — SEC filings fetch dedupe feature flag.
+
+Flag default (False): daily_research_refresh runs SEC refresh_filings
+as before. Flag=True: skips the SEC filings block entirely and logs
+the reason. Companies House path unaffected either way.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.workers import scheduler
+
+
+def _stub_conn_fetchall() -> list[tuple[str, str]]:
+    """Two tradable rows so daily_research_refresh doesn't short-circuit."""
+    return [("AAPL", "1"), ("MSFT", "2")]
+
+
+def _stub_cik_rows() -> list[tuple[str, str]]:
+    return [("AAPL", "0000320193"), ("MSFT", "0000789019")]
+
+
+def _base_mocks(monkeypatch) -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Stub the global settings + _tracked_job + psycopg.connect chain.
+
+    Returns the patched SEC filings provider, refresh_filings callable,
+    and refresh_fundamentals callable so each test can assert on them.
+    """
+    tracker = MagicMock()
+    tracker.row_count = None
+    cm = MagicMock()
+    cm.__enter__.return_value = tracker
+    cm.__exit__.return_value = False
+    monkeypatch.setattr(scheduler, "_tracked_job", MagicMock(return_value=cm))
+
+    fake_conn = MagicMock()
+    # Two execute() calls in daily_research_refresh return
+    # (a) tradable rows (b) cik rows. Order matters.
+    fake_conn.execute.return_value.fetchall.side_effect = [
+        _stub_conn_fetchall(),
+        _stub_cik_rows(),
+    ]
+    conn_cm = MagicMock()
+    conn_cm.__enter__.return_value = fake_conn
+    conn_cm.__exit__.return_value = False
+    monkeypatch.setattr(
+        scheduler.psycopg,
+        "connect",
+        MagicMock(return_value=conn_cm),
+    )
+
+    # Stub provider factories — they're context managers.
+    sec_fund_cm = MagicMock()
+    sec_fund_cm.__enter__.return_value = MagicMock()
+    sec_fund_cm.__exit__.return_value = False
+    monkeypatch.setattr(scheduler, "SecFundamentalsProvider", MagicMock(return_value=sec_fund_cm))
+
+    sec_fil_cm = MagicMock()
+    sec_fil_cm.__enter__.return_value = MagicMock()
+    sec_fil_cm.__exit__.return_value = False
+    sec_fil_cls = MagicMock(return_value=sec_fil_cm)
+    monkeypatch.setattr(scheduler, "SecFilingsProvider", sec_fil_cls)
+
+    # refresh_* helpers — canned summary mocks.
+    refresh_fund_mock = MagicMock(return_value=MagicMock(symbols_attempted=2, snapshots_upserted=2, symbols_skipped=0))
+    monkeypatch.setattr(scheduler, "refresh_fundamentals", refresh_fund_mock)
+    refresh_filings_mock = MagicMock(
+        return_value=MagicMock(instruments_attempted=2, filings_upserted=5, instruments_skipped=0)
+    )
+    monkeypatch.setattr(scheduler, "refresh_filings", refresh_filings_mock)
+
+    return sec_fil_cls, refresh_filings_mock, refresh_fund_mock
+
+
+def test_flag_false_calls_sec_refresh_filings(monkeypatch) -> None:
+    """Default behaviour — flag off, SEC filings block runs."""
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test"
+    stub_settings.companies_house_api_key = None
+    stub_settings.fmp_api_key = None
+    stub_settings.enable_filings_fetch_dedupe = False
+    monkeypatch.setattr(scheduler, "settings", stub_settings)
+
+    sec_fil_cls, refresh_filings_mock, _ = _base_mocks(monkeypatch)
+
+    scheduler.daily_research_refresh()
+
+    # SEC filings provider constructed + refresh_filings called once.
+    sec_fil_cls.assert_called_once()
+    assert refresh_filings_mock.call_count == 1
+    kwargs = refresh_filings_mock.call_args.kwargs
+    assert kwargs["provider_name"] == "sec"
+
+
+def test_flag_true_skips_sec_refresh_filings(monkeypatch) -> None:
+    """Chunk L behaviour — flag on, SEC filings block skipped entirely."""
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test"
+    stub_settings.companies_house_api_key = None
+    stub_settings.fmp_api_key = None
+    stub_settings.enable_filings_fetch_dedupe = True
+    monkeypatch.setattr(scheduler, "settings", stub_settings)
+
+    sec_fil_cls, refresh_filings_mock, _ = _base_mocks(monkeypatch)
+
+    scheduler.daily_research_refresh()
+
+    # SEC filings provider NOT constructed — block skipped.
+    sec_fil_cls.assert_not_called()
+    # refresh_filings is only called for SEC path in the default tests
+    # (CH skipped via no API key); with flag=True it must not fire.
+    assert refresh_filings_mock.call_count == 0
+
+
+def test_flag_true_leaves_ch_filings_path_available(monkeypatch) -> None:
+    """Flag affects only the SEC block — Companies House path unaffected.
+    (When COMPANIES_HOUSE_API_KEY is set, CH refresh_filings still fires.)
+    """
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test"
+    stub_settings.companies_house_api_key = "ch-key"
+    stub_settings.fmp_api_key = None
+    stub_settings.enable_filings_fetch_dedupe = True
+    monkeypatch.setattr(scheduler, "settings", stub_settings)
+
+    sec_fil_cls, refresh_filings_mock, _ = _base_mocks(monkeypatch)
+
+    # CH provider stub.
+    ch_cm = MagicMock()
+    ch_cm.__enter__.return_value = MagicMock()
+    ch_cm.__exit__.return_value = False
+    monkeypatch.setattr(scheduler, "CompaniesHouseFilingsProvider", MagicMock(return_value=ch_cm))
+
+    scheduler.daily_research_refresh()
+
+    # SEC not called; CH called once.
+    sec_fil_cls.assert_not_called()
+    ch_calls = [c for c in refresh_filings_mock.call_args_list if c.kwargs.get("provider_name") == "companies_house"]
+    assert len(ch_calls) == 1


### PR DESCRIPTION
## What
Ships Chunk L from master plan line 279. ``daily_research_refresh`` gains a flag to skip its SEC EDGAR filings fetch entirely when ``ENABLE_FILINGS_FETCH_DEDUPE=true``, relying on ``daily_financial_facts``'s master-index path (``_upsert_filing_from_master_index``) for ``filing_events`` population.

Also bundles a pending CLAUDE.md markdown-indent fix from memory (steps 4-7 in Branch/PR workflow no longer collapse into step 3's paragraph).

## Static audit — Path A vs Path B
| | Path A — refresh_filings | Path B — _upsert_filing_from_master_index |
|---|---|---|
| Triggered by | ``daily_research_refresh`` | ``daily_financial_facts`` (plus sec_incremental) |
| Data source | SEC submissions.json via ``list_filings_by_identifier`` | SEC daily master-index |
| Form filter | Hardcoded ``{10-K, 10-Q, 8-K}`` | ALL forms, incl. amendments (10-K/A, 10-Q/A, 20-F, etc) |
| URL storage | Rich ``primary_document_url`` (specific doc) | Master-index landing URL (still valid) |
| ON CONFLICT | Overwrites URL | COALESCE (preserves Path A's URL when both run) |

**Path B is strictly broader.** Chunk L deletes Path A's redundant fetches; only loss is ``primary_document_url`` becomes master-index URL (a functional SEC link) for 10-K/10-Q/8-K rows not otherwise enriched.

## Rollout
1. **This PR**: flag=False (default) → no behaviour change
2. Operator flips ``ENABLE_FILINGS_FETCH_DEDUPE=true`` in env + restart worker
3. Observe ~1 week — ``filing_events`` populated via Path B only; no gap
4. Follow-up PR: delete the guarded SEC block + Path A dead code

## Test plan
- [x] 3 tests: flag off runs SEC call, flag on skips SEC, flag on preserves CH path
- [x] ``ruff check`` / ``ruff format --check`` / ``pyright`` / ``pytest`` — 1983 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)