### PR TITLE
feat(#313): order entry + close position modals (frontend)

### DIFF
--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -788,3 +788,21 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `refresh_scoring_and_recommendations` assigned `result` and `outcome` INSIDE a `with JobLock + _tracked_job` block, then referenced them AFTER the block. A non-`JobAlreadyRunning` exception propagated out, leaving `result`/`outcome` unbound if a broader `except` were ever added — an `UnboundLocalError` waiting for a future code change to trigger.
 - Prevention: When the success path of a `try` assigns variables used in the code after the `try/except`, verify every `except` branch either returns/raises or assigns the same variables. Grep for `result =` or similar assignments inside `with JobLock(...)` contexts and check the post-block readers are unreachable from any exception channel. The adapter pattern now uses explicit `JobLock.__enter__()` + `try/finally JobLock.__exit__()` so the success-path scoping is unambiguous.
 - Enforced in: `app/services/sync_orchestrator/adapters.py` (`refresh_scoring_and_recommendations`)
+
+---
+
+### `setSubmitting(false)` missing on a modal submit's success path
+
+- First seen in: #319
+- Symptom: A modal's async submit handler reset `submitting=true` before awaiting the POST, then on success called `onFilled()` + `onRequestClose()` without first calling `setSubmitting(false)`. The parent normally unmounts the modal immediately via `onRequestClose`, so the stuck state is invisible in practice — but any future caller that delays unmount (a wrapping confirm dialog, a test reusing the modal instance, a test that does not trigger unmount through the same branch) leaves the submit button permanently locked in `"Placing…"` / `"Closing…"` with no recovery.
+- Prevention: In any async submit handler, reset `setSubmitting(false)` on BOTH the success and error branches before handing control back to the parent. Pattern: `setSubmitting(false)` immediately after the `await` resolves, guarded by `mountedRef.current`, before the `onFilled`/`onRequestClose` calls. A bare `finally { setSubmitting(false) }` is an acceptable alternative when the success branch does not need early-return semantics. Grep for `setSubmitting(true)` in modal files and confirm each occurrence has a matching `setSubmitting(false)` on every exit path.
+- Enforced in: this prevention log; `frontend/src/components/orders/OrderEntryModal.tsx`, `frontend/src/components/orders/ClosePositionModal.tsx`
+
+---
+
+### `canSubmit` expression omits `!async.loading` during refetch
+
+- First seen in: #319
+- Symptom: A modal's `canSubmit` boolean gated on `trade !== null && !submitting && !detail.error` but did not include `!detail.loading`. `useAsync` clears `data` to `null` at the start of a refetch (see `async-data-loading.md`), so this is usually safe — but any defensive caller that preserves prior `data` during refetch, or a future change to `useAsync`'s clear-on-refetch semantics, would leave submit enabled against stale context while the fresh fetch is mid-flight.
+- Prevention: Any `canSubmit` / `canProceed` boolean whose inputs include an async data slot MUST also include `!async.loading`. Pattern: `const canSubmit = async.data !== null && !async.loading && !async.error && ...`. Grep `canSubmit` / `canSave` / `canProceed` in frontend modals and confirm each includes an explicit loading guard.
+- Enforced in: this prevention log; `frontend/src/components/orders/OrderEntryModal.tsx`, `frontend/src/components/orders/ClosePositionModal.tsx`

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -806,3 +806,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: A modal's `canSubmit` boolean gated on `trade !== null && !submitting && !detail.error` but did not include `!detail.loading`. `useAsync` clears `data` to `null` at the start of a refetch (see `async-data-loading.md`), so this is usually safe — but any defensive caller that preserves prior `data` during refetch, or a future change to `useAsync`'s clear-on-refetch semantics, would leave submit enabled against stale context while the fresh fetch is mid-flight.
 - Prevention: Any `canSubmit` / `canProceed` boolean whose inputs include an async data slot MUST also include `!async.loading`. Pattern: `const canSubmit = async.data !== null && !async.loading && !async.error && ...`. Grep `canSubmit` / `canSave` / `canProceed` in frontend modals and confirm each includes an explicit loading guard.
 - Enforced in: this prevention log; `frontend/src/components/orders/OrderEntryModal.tsx`, `frontend/src/components/orders/ClosePositionModal.tsx`
+
+---
+
+### `handleSubmit` early-return guard diverges from `canSubmit`
+
+- First seen in: #319
+- Symptom: A submit handler's early-return guard checked only a subset of the conditions that `canSubmit` already enforced — e.g. partial-close handler checked `units > 0` but not `units <= trade.units` or `units >= MIN_UNITS`. Under the current call site the submit button is always disabled when any of those fail, so the gap is invisible in practice. A programmatic call (test, future caller that reuses the submit path without the button), or a future refactor that inlines the handler into a different trigger, would skip those additional constraints and POST an invalid payload the backend rejects with a confusing message.
+- Prevention: In any handler whose validity is already computed as a `canSubmit` boolean for the button's `disabled` state, the handler's own early-return guard MUST be a strict superset of `canSubmit`'s conditions, OR use `if (!canSubmit) return` as a single gate. Defence-in-depth is cheap; divergence between the UI gate and the submit path is a class of bug that hides until a future caller lands. Grep `async function handleSubmit` in modal files and compare the return guards to the `canSubmit` expression at the top of the component.
+- Enforced in: this prevention log; `frontend/src/components/orders/ClosePositionModal.tsx` (`handleSubmit` now re-checks `MIN_UNITS` and `<= trade.units`)

--- a/docs/superpowers/specs/2026-04-18-order-entry-modals-design.md
+++ b/docs/superpowers/specs/2026-04-18-order-entry-modals-design.md
@@ -1,0 +1,535 @@
+# P0-1 order entry + close modals — design spec
+
+**Issue:** [#313](https://github.com/Luke-Bradford/eBull/issues/313)
+**Plan:** `docs/superpowers/plans/2026-04-18-product-visibility-pivot.md`
+**Size:** S-M (~1 day, frontend only)
+**Depends on:** nothing (backend endpoints ship-ready)
+**Blocks:** #314 (portfolio workstation consumes these modals), #316 (instrument terminal consumes these modals)
+
+---
+
+## 1. Goal
+
+Expose two existing backend endpoints via frontend modals so the operator can add to a held position and close (full or partial) a specific broker position from the Portfolio page, in demo mode, using honest native-currency previews.
+
+**Vision-check:** yes — operator goes from "looks at positions, can't act" to "adds to a holding and closes a trade end-to-end from the UI".
+
+## 2. Backend contract (pinned)
+
+Both endpoints already exist and are protected by `require_session_or_service_token` (cookie auth).
+
+### 2.1 `POST /portfolio/orders` — `app/api/orders.py:405`
+
+```python
+# PlaceOrderRequest, app/api/orders.py:52-60
+instrument_id: int
+action: Literal["BUY", "ADD"]
+amount: float | None = None           # native-currency notional
+units: float | None = None
+stop_loss_rate: float | None = None
+take_profit_rate: float | None = None
+is_tsl_enabled: bool = False
+leverage: int = 1
+```
+
+Response (`OrderResponse`, `app/api/orders.py:67-74`):
+```python
+order_id: int
+status: str                           # "filled" | "pending" | "failed"
+broker_order_ref: str | None
+filled_price: float | None
+filled_units: float | None
+fees: float
+explanation: str
+```
+
+Error shapes (all `detail` strings are fixed phrases per prevention #86 / #89 — surface verbatim):
+- `403` — `"Kill switch is active: {reason}"`
+- `400` — validation (amount+units both provided, non-positive, etc.)
+- `422` — `"No quote available for instrument {id} — cannot fill without a price."`
+- `501` — `"Live trading not yet wired — use demo mode."`
+
+**Price source used by the endpoint:** `_load_latest_quote_price` (`app/api/orders.py:136-149`) reads `quotes.last` only — no display-currency conversion, no `price_daily` fallback. If that row is missing or null, the endpoint 422s.
+
+### 2.2 `POST /portfolio/positions/{position_id}/close` — `app/api/orders.py:473`
+
+```python
+# ClosePositionRequest, app/api/orders.py:63-64
+units_to_deduct: float | None = None   # None = close entire position
+```
+
+Same `OrderResponse` shape. Errors:
+- `403` — kill switch
+- `404` — `"Position {pid} not found or already closed."`
+- `400` — `units_to_deduct must be positive` or `exceeds position units`
+- `501` — live trading
+
+**Price source:** same raw `quotes.last`, and if null falls back to that broker position's `open_rate` (`app/api/orders.py:511-512`) — a cost-basis fill. Frontend preview must mirror this fallback.
+
+## 3. Non-goals (drop aggressively)
+
+- No new backend endpoints. Entire PR is frontend.
+- No LIVE trading UI in this PR. `enable_live_trading` returns 501; we show the fixed phrase verbatim if an operator ever triggers the button while the flag is on. We do NOT prebuild a confirm-twice live-order gate — that's a future PR against the live-wiring branch. Rationale: dead code in a safety path is worse than no code; we ship the DEMO path only.
+- No stop-loss / take-profit / TSL / leverage UI. Request body sends `null, null, false, 1`.
+- No orders-list / order-history panel. Proof of fill = `portfolio.refetch()` on success; updated units appear in the Portfolio table row.
+- No tax-impact preview. Plan mentioned it but no backend endpoint computes it and duplicating the Python tax engine on the frontend is off-limits. We show "Estimated realized P&L" using native-currency `current_price - open_rate` instead — that's what the operator actually reads. If tax-impact is wanted later, ship a `POST /portfolio/positions/{id}/close/preview` endpoint and reconsult this spec.
+- No new-instrument BUY flow (instrument picker / search-then-buy). Every entry button on the Portfolio page triggers `ADD` (existing position). `BUY` as an action value exists in the type surface because the backend accepts it, but in this PR nothing in the UI submits `action: "BUY"`. The new-instrument BUY launcher ships with #316 (instrument terminal).
+- No per-instrument multi-trade close UI. When a `PositionItem` aggregates multiple broker positions (`trades.length > 1`), the Portfolio page does not expose a Close button in this PR. The detail panel in #314 will present per-broker-position rows and their own Close buttons. This is the only correct close granularity in v1: the endpoint operates on `broker_positions.position_id`, not on aggregated instrument positions.
+- No keyboard shortcuts beyond what `Modal` already provides (Esc + Tab focus trap). Global `/`, `j/k`, `b`, `c` keys belong to #314.
+
+## 4. File plan
+
+### New files
+
+- `frontend/src/api/orders.ts` — two fetchers.
+- `frontend/src/components/orders/OrderEntryModal.tsx` — ADD flow (BUY remains in the type surface for future reuse).
+- `frontend/src/components/orders/ClosePositionModal.tsx` — full / partial close.
+- `frontend/src/components/orders/OrderEntryModal.test.tsx`
+- `frontend/src/components/orders/ClosePositionModal.test.tsx`
+- `frontend/src/api/orders.test.ts` — fetcher contract tests.
+
+### Modified files
+
+- `frontend/src/api/types.ts` — add request and response shapes mirroring `PlaceOrderRequest`, `ClosePositionRequest`, `OrderResponse`.
+- `frontend/src/pages/PortfolioPage.tsx` — add Actions column with an `Add` button (always) and a `Close` button (only when `trades.length === 1`).
+
+Total ~7 files, ~650 LoC including tests.
+
+## 5. API client (`frontend/src/api/orders.ts`)
+
+```ts
+import { apiFetch } from "@/api/client";
+import type {
+  PlaceOrderRequest,
+  ClosePositionRequest,
+  OrderResponse,
+} from "@/api/types";
+
+export function placeOrder(body: PlaceOrderRequest): Promise<OrderResponse> {
+  return apiFetch<OrderResponse>("/portfolio/orders", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function closePosition(
+  positionId: number,
+  body: ClosePositionRequest,
+): Promise<OrderResponse> {
+  return apiFetch<OrderResponse>(
+    `/portfolio/positions/${positionId}/close`,
+    { method: "POST", body: JSON.stringify(body) },
+  );
+}
+```
+
+Both fetchers always send a body (never omit it). Full close is `{units_to_deduct: null}` — we do NOT rely on HTTP-body absence to signal full close.
+
+**No business logic.** Typed wrapper only. Errors bubble as `ApiError(status, message)` from `apiFetch`.
+
+## 6. Type additions (`frontend/src/api/types.ts`)
+
+```ts
+// ---------------------------------------------------------------------------
+// /portfolio/orders, /portfolio/positions/{id}/close (app/api/orders.py)
+// ---------------------------------------------------------------------------
+
+export type OrderAction = "BUY" | "ADD";
+
+export interface PlaceOrderRequest {
+  instrument_id: number;
+  action: OrderAction;
+  amount: number | null;
+  units: number | null;
+  stop_loss_rate: number | null;
+  take_profit_rate: number | null;
+  is_tsl_enabled: boolean;
+  leverage: number;
+}
+
+export interface ClosePositionRequest {
+  units_to_deduct: number | null;
+}
+
+export interface OrderResponse {
+  order_id: number;
+  status: string;
+  broker_order_ref: string | null;
+  filled_price: number | null;
+  filled_units: number | null;
+  fees: number;
+  explanation: string;
+}
+```
+
+Drift pin: any change to `app/api/orders.py` models must update this section in the same PR.
+
+## 7. Preview-data strategy — honest previews only
+
+### Problem pinned by Codex
+
+`PortfolioPage` row data (`PositionItem.current_price`) is in **display currency** and may fall back to `price_daily.close` when no quote exists (`app/api/portfolio.py:187-211`). The order endpoints use raw **native-currency** `quotes.last` with no fallback. If we preview using row data, the operator can see "£140" but the fill goes in at native USD rate, or see a stale daily-close when the endpoint will 422.
+
+### Resolution
+
+Every modal fetches `GET /portfolio/instruments/{instrument_id}` via the existing `fetchInstrumentPositions` (`frontend/src/api/portfolio.ts:8`) on open. This returns `InstrumentPositionDetail` with:
+
+- `currency` — native currency of the instrument
+- `current_price` — native-currency price (same source as the order endpoint for preview honesty; still a lightweight summary, may include daily_close fallback — see §7.4)
+- `trades: NativeTradeItem[]` — per-broker-position rows with native `open_rate` and `current_price`
+
+Modal UI then shows:
+
+- All money in the instrument's native currency, explicitly labeled (`USD 140.12`, not the display-currency aware `formatMoney` helper).
+- A one-line disclaimer: `"Preview uses the latest available quote; the actual fill uses the most recent quote at submission time."`
+
+### 7.4 `current_price` caveats — both endpoints have them
+
+`fetchInstrumentPositions` reuses the portfolio service layer, so its `current_price` may fall through to `price_daily.close` when `quotes.last` is null (`PositionItem.valuation_source` is `"quote" | "daily_close" | "cost_basis"`). Neither order endpoint has that fallback behaviour:
+
+- **Entry** (`POST /portfolio/orders`): uses raw `quotes.last` only. If null, 422.
+- **Close** (`POST /portfolio/positions/{id}/close`): uses raw `quotes.last`, and if null falls through to the broker position's own `open_rate` — i.e. a near-zero-P&L cost-basis fill (`app/api/orders.py:511-512`).
+
+So the client cannot promise a truly honest preview without a dedicated endpoint. Mitigations in this PR:
+
+- The preview disclaimer states plainly: `"Preview uses your latest known portfolio price. At submission time the fill may use a different quote, or (for close) fall back to your open rate if no quote is available — realized P&L may be 0 in that case."`
+- Both modals read `valuation_source` on the `PositionItem` passed in by the caller (or on the aggregated summary returned by `fetchInstrumentPositions`). When `valuation_source !== "quote"`, render the price in amber with `"(may not reflect fill price)"` next to it.
+- For the close modal specifically: always display BOTH `current_price` and `open_rate` side by side. The P&L estimate uses `current_price` when present, `open_rate` otherwise. A caption under the P&L line states which source was used.
+- 422 errors from entry surface verbatim.
+
+Tracked as tech-debt alongside this PR: `GET /portfolio/instruments/{iid}/quote-for-order` returning raw `quotes.last` + native currency, so modals can mirror the order endpoints' price source exactly. Reference in PR description.
+
+## 8. Component contracts
+
+### 8.1 `OrderEntryModal` (ADD flow)
+
+**Props:**
+```ts
+interface OrderEntryModalProps {
+  readonly isOpen: boolean;
+  readonly instrumentId: number;
+  readonly symbol: string;
+  readonly companyName: string;
+  readonly valuationSource: "quote" | "daily_close" | "cost_basis";
+  readonly onRequestClose: () => void;
+  readonly onFilled: () => void;
+}
+```
+
+**Mounting contract:** the parent only renders this component when the target is non-null (§10), so the component is mounted exactly once per "open". `useAsync(() => fetchInstrumentPositions(instrumentId), [instrumentId])` therefore fires once on mount and will not fetch while the modal is closed. `isOpen` is kept in the prop surface for test ergonomics but conditional mount is the source of truth.
+
+**On open:** the `useAsync` call loads native-currency context. Until it resolves, the form shows a skeleton. If it errors, the form shows the error text + a Retry button and the submit is disabled.
+
+**Layout:**
+- Demo/live pill (see §9).
+- Heading: `Add — {symbol}`.
+- Native-currency context line: `Currency: USD · Latest price: 140.12 (quote)` — the parenthesised source is the `valuation_source` value from the fetched `PositionItem`. When `valuation_source !== "quote"`, render the price + source in amber with `"(may not reflect fill price)"` next to it. Dash if null.
+- Amount/Units toggle + numeric input.
+- Preview block:
+  - `Estimated units: {amount / currentPrice}` (if price > 0 and amount entered)
+  - `Estimated cost: {units * currentPrice}` (if price > 0 and units entered)
+  - `Estimated fees: 0.00 (demo)`
+- Preview disclaimer (from §7.4): `"Preview uses your latest known portfolio price. At submission time the fill may use a different quote — if no quote is available the backend returns 422 and no order is placed."`
+- Submit button: `Place demo order`. Disabled while `submitting`, while the instrument-detail fetch is in flight, or when the input is invalid.
+- Error slot (inside the modal, below the button).
+
+**Lifecycle (pinned):**
+1. `idle` — default. Submit enabled iff input is valid and preview fetch resolved.
+2. `submitting` — submit disabled, loading spinner on button. User can still Cancel (Esc).
+3. On success: call `onFilled()` then `onRequestClose()`. **No intermediate filled view.** The operator sees the portfolio refetch update the row — that is the fill confirmation. Closing first, then refetching, matches prevention #125 (refresh-error-swallowed-by-overlay).
+4. On error: stay in `idle`, show the error text, input remains editable, submit re-enabled.
+
+**Client-side validation before POST:**
+- Exactly one of `amount`, `units` is numeric-valid: `typeof v === "number" && Number.isFinite(v) && v > 0`. `Number.isFinite` rejects `NaN`, `+Infinity`, `-Infinity` (prevention #236).
+- No upper-bound check — the backend has none either. A legitimately huge finite value is the backend's problem.
+- Both fields null or both set → submit is disabled (radio forces mutual exclusion, so this is belt-and-braces).
+
+**Error surfacing:**
+- `ApiError` → surface `error.message` verbatim. Note: `ApiError.message` **is** the backend's `detail` string (client.ts:66-73 sets `message = body.detail` on non-OK responses). The spec used `detail` loosely in v1; v2 uses `error.message` throughout.
+- Non-`ApiError` (network) → fixed phrase `"Network error — check connection and try again."`
+
+**Payload:**
+```ts
+{
+  instrument_id: props.instrumentId,
+  action: "ADD",                     // always ADD in this PR
+  amount: amountIfChosen ?? null,
+  units: unitsIfChosen ?? null,
+  stop_loss_rate: null,
+  take_profit_rate: null,
+  is_tsl_enabled: false,
+  leverage: 1,
+}
+```
+
+### 8.2 `ClosePositionModal`
+
+**Props:**
+```ts
+interface ClosePositionModalProps {
+  readonly isOpen: boolean;
+  readonly instrumentId: number;
+  readonly positionId: number;       // broker_positions.position_id
+  readonly valuationSource: "quote" | "daily_close" | "cost_basis";
+  readonly onRequestClose: () => void;
+  readonly onFilled: () => void;
+}
+```
+
+**Mounting contract:** same as §8.1 — only mounted when `closeFor !== null` in the parent, so `useAsync` fires once per open.
+
+**On open:** `fetchInstrumentPositions(instrumentId)` call. Find the `NativeTradeItem` matching `positionId` in the response's `trades[]`. If absent (stale, concurrent close, etc.), show a fixed error `"This position no longer exists — refresh the portfolio."` and disable submit.
+
+**Layout:**
+- Demo/live pill.
+- Heading: `Close — {symbol}`.
+- Info strip: `{units} units @ {open_rate} {currency} · Latest price: {current_price} {currency}`. If the summary-level `valuation_source !== "quote"`, the latest-price cell renders in amber with `"(may not reflect fill price)"`.
+- Close-mode radio:
+  - `Full close` — no further input. Payload: `{units_to_deduct: null}`.
+  - `Partial close` — reveals a numeric input + range slider.
+- Partial-close input:
+  - Numeric input, `min=0.000001`, `max=units`, `step=0.000001` (matches backend's `Decimal.quantize(Decimal("0.000001"))` at `app/api/orders.py:115`).
+  - Slider is a visual pair with the numeric input — either updates both.
+  - Validation: `Number.isFinite(v) && v > 0 && v <= units`.
+- Preview block (in native currency, using the matched `NativeTradeItem`):
+  - `Closing: {units_to_close} / {units} units`
+  - `Open rate: {open_rate} {currency}` (always shown — see §7.4)
+  - `Est. fill price: {current_price} {currency}` — or `—` if null.
+  - `Est. realized P&L: {(est_fill_price - open_rate) * units_to_close} {currency}` — colored green/red. When `current_price` is null, `est_fill_price = open_rate` (matches backend fallback `app/api/orders.py:511-512`), producing a P&L estimate of 0. Caption under this line: either `"using latest quote"` or `"using open rate — no quote available; realized P&L will be ~0"`.
+- Preview disclaimer: same as §8.1 disclaimer, adapted: `"Preview uses your latest known portfolio price. At submission time the fill may use a different quote — if no quote is available the fill uses your open rate and realized P&L may be 0."`
+- Submit button: `Close position`.
+
+**Full-close discrimination:** driven by the radio's `mode` state, not by a float comparison against `units`. Full close always sends `{units_to_deduct: null}`; partial close always sends `{units_to_deduct: <number>}`. No float equality involved.
+
+**Lifecycle and error handling:** identical to OrderEntryModal.
+
+### 8.3 Modal shell
+
+Both components wrap `Modal` from `frontend/src/components/ui/Modal.tsx`, with `label=` (string). Esc routes through `onRequestClose` — we do NOT gate cancel via confirm-cancel (this is not a fail-closed secret flow).
+
+### 8.4 Unmounted setState safety
+
+Each modal holds `mountedRef` and `submittingRef` per prevention #127. Every `setState` after an `await` goes through a helper that early-returns when `!mountedRef.current`.
+
+## 9. Demo / live indicator
+
+Read `enable_live_trading` from the existing `/config` source `AppShell` already consumes. Follow `safety-state-ui.md` literally — cache the last confirmed snapshot and mark stale when rendering from cache.
+
+```ts
+// Fresh source
+const liveFlag: boolean | null = config.data?.runtime.enable_live_trading ?? null;
+
+// Cache (per component)
+const [cached, setCached] = useState<boolean | null>(null);
+useEffect(() => {
+  if (liveFlag !== null) setCached(liveFlag);
+  // Never write null into the cache. Errors and loading leave it untouched.
+}, [liveFlag]);
+
+// Display: prefer fresh; fall back to cache with stale marker.
+const isLive = liveFlag ?? cached ?? false;
+const fresh = liveFlag !== null;
+
+return (
+  <span className={isLive ? "pill-red" : "pill-demo"}>
+    {isLive ? "LIVE" : "DEMO MODE"}
+    {!fresh && cached !== null ? (
+      <span className="ml-1 text-[10px] uppercase text-amber-600">(stale)</span>
+    ) : null}
+  </span>
+);
+```
+
+Contract: cache only updates on non-null fresh values (both `true` and `false` are confirmed values). A fresh `false` does overwrite a cached `true` — that is correct `safety-state-ui.md` semantics: the cache mirrors the latest confirmed state, and the display OR-mechanic is `fresh ?? cached`, not `fresh || cached`. On cold start, both are null and the pill shows `DEMO MODE` without a stale marker (acceptable per `safety-state-ui.md:79` cold-start rule).
+
+**Submit behaviour:** if `isLive === true`, the submit button still calls `placeOrder` but the backend 501s; we surface the 501 text verbatim. No confirm-twice gate in this PR (§3).
+
+Tests pin: pill renders correctly when fresh is null but cache has a value; stale marker renders; cache is not clobbered by a transient null from `/config` refetch.
+
+## 10. PortfolioPage integration
+
+Add an Actions column as the last `<th>` / `<td>`.
+
+```tsx
+<td className="px-2 py-2 text-right">
+  <button
+    type="button"
+    onClick={(e) => { e.stopPropagation(); setAddFor(p); }}
+    aria-label={`Add to ${p.symbol}`}
+  >Add</button>
+  {p.trades.length === 1 ? (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        setCloseFor({
+          instrumentId: p.instrument_id,
+          trade: p.trades[0]!,
+          valuationSource: p.valuation_source,
+        });
+      }}
+      aria-label={`Close ${p.symbol}`}
+    >Close</button>
+  ) : null}
+</td>
+```
+
+Multi-trade positions (`trades.length > 1`) render no Close button — §3 makes this explicit.
+
+Page-level state carries both pieces of identity — `BrokerPositionItem` lacks `instrument_id`, so we store it alongside:
+
+```ts
+interface CloseTarget {
+  instrumentId: number;
+  trade: BrokerPositionItem;
+  valuationSource: "quote" | "daily_close" | "cost_basis";
+}
+
+const [addFor, setAddFor] = useState<PositionItem | null>(null);
+const [closeFor, setCloseFor] = useState<CloseTarget | null>(null);
+
+function handleFilled() {
+  setAddFor(null);
+  setCloseFor(null);
+  portfolio.refetch();
+}
+```
+
+**Modal mounting — gate fetch on open:** both modals are mounted only when their state slot is non-null. This makes `useAsync(() => fetchInstrumentPositions(instrumentId), [instrumentId])` fire exactly once per open, and avoids fetching while closed. Unmount on close also resets modal internal state cleanly.
+
+```tsx
+{addFor !== null ? (
+  <OrderEntryModal
+    isOpen
+    instrumentId={addFor.instrument_id}
+    symbol={addFor.symbol}
+    companyName={addFor.company_name}
+    valuationSource={addFor.valuation_source}
+    onRequestClose={() => setAddFor(null)}
+    onFilled={handleFilled}
+  />
+) : null}
+
+{closeFor !== null ? (
+  <ClosePositionModal
+    isOpen
+    instrumentId={closeFor.instrumentId}
+    positionId={closeFor.trade.position_id}
+    valuationSource={closeFor.valuationSource}
+    onRequestClose={() => setCloseFor(null)}
+    onFilled={handleFilled}
+  />
+) : null}
+```
+
+Because the modal is only rendered when the slot is non-null, `isOpen` is always `true` inside — kept as a prop for symmetry with the existing `Modal` shell API and for test setups that want to render with `isOpen={false}`. `handleFilled` closes before refetch (prevention #125).
+
+The Mirror rows (`MirrorRow`) do not get Actions buttons. Copy trading is a separate execution flow.
+
+## 11. Test plan
+
+### 11.1 `api/orders.test.ts`
+
+- `placeOrder` POSTs correct JSON; returns parsed `OrderResponse`.
+- `placeOrder` throws `ApiError(403, "Kill switch is active: ...")` on 403.
+- `closePosition` sends `{units_to_deduct: null}` body for full close.
+- `closePosition` sends `{units_to_deduct: 2.5}` body for partial close.
+- `closePosition` URL correctly interpolates `positionId`.
+
+### 11.2 `OrderEntryModal.test.tsx`
+
+- Happy path: mock `fetchInstrumentPositions` + `placeOrder`; type amount, submit, `onFilled` then `onRequestClose` called in that order.
+- Instrument-detail error: renders error + Retry, submit disabled.
+- Validation: `Infinity` rejected by isFinite guard; `NaN` rejected; negative rejected.
+- Validation: neither amount nor units → submit disabled.
+- Guard rejection: mock throws `ApiError(403, "Kill switch is active: drawdown breach")` → exact message shown via `error.message`.
+- Broker 422: `"No quote available for instrument 12..."` surfaced verbatim.
+- Network error: non-`ApiError` thrown → fixed phrase.
+- Unmount-during-submit: start submission, unmount before resolution — no act() warning, no unhandled rejection (prevention #127).
+- Fetch-on-open gating: with the modal unmounted (parent does not render it), `fetchInstrumentPositions` is not called. Mounting triggers exactly one fetch.
+- Price-source flag: when `valuationSource="daily_close"`, the price is rendered in amber with `"(may not reflect fill price)"`. When `valuationSource="quote"`, no amber treatment.
+- Safety pill: renders `DEMO MODE` when `enable_live_trading=false`. When the `/config` fetch subsequently returns null (loading) the pill stays visible with a `(stale)` marker — the cached boolean is preserved.
+
+### 11.3 `ClosePositionModal.test.tsx`
+
+- Full-close radio → payload `{units_to_deduct: null}`.
+- Partial-close numeric input with fractional value (e.g. `0.5`) → payload `{units_to_deduct: 0.5}`. Verifies sub-unit closes work.
+- Input > units → submit disabled + inline validation message.
+- `current_price=null` → preview uses `open_rate` as the fill-price estimate; P&L shows 0; caption reads `"using open rate — no quote available; realized P&L will be ~0"`.
+- `valuationSource="daily_close"`: latest-price cell rendered amber with caveat string.
+- Stale broker position: `fetchInstrumentPositions` returns `trades` without the target `positionId` → fixed error + submit disabled.
+- 404 path: `"Position X not found or already closed."` surfaced.
+- 403 path: same as entry modal.
+- Unmount-during-submit: same guard test.
+
+### 11.4 PortfolioPage
+
+- If `PortfolioPage.test.tsx` exists: verify Actions column renders Add for all rows and Close only when `trades.length === 1`; verify row-click navigation still fires when clicking outside action buttons; verify Add button opens OrderEntryModal with correct `instrumentId`.
+- If the test file does NOT exist: do not introduce it in this PR. #314 will create it.
+
+## 12. Settled-decisions alignment
+
+- **Demo-first:** DEMO pill by default; backend-enforced; LIVE path stubbed but surfaces 501 verbatim.
+- **Long-only, no leverage, no shorting:** `action` restricted to `"BUY" | "ADD"`; `leverage: 1` always; no SHORT.
+- **Auditable:** endpoints already persist order + fill + cash_ledger + decision_audit (`app/api/orders.py:152-395`); frontend does not touch persistence.
+- **Close-position safety invariant** (`app/api/orders.py:14-17`): operator UI is the allowed caller. Preserved.
+- **Product-visibility pivot** (`docs/settled-decisions.md:298`): this PR is P0-1, the first in the sequence.
+
+## 13. Prevention-log alignment
+
+| Entry | Honored by |
+|---|---|
+| #127 API shape invented at boundary | §6 mirrors Pydantic field-for-field; PR description names `app/api/orders.py` |
+| #127 Unmounted setState in async submit | §8.4 pins `mountedRef` + `safeSetState` |
+| #125 Refresh swallowed by overlay | §10 closes modal before `portfolio.refetch()` |
+| #147 Falsy-string suppression | fetcher sends the object verbatim; comparisons use `!== null` |
+| #236 Literal types on API fields | §6 `OrderAction = "BUY" \| "ADD"` |
+| #236 `isFinite` numeric guard | §8.1 + §8.2 validation |
+| safety-state-ui.md | §9 cached pill |
+| async-data-loading.md | §10 closes modal before refetch; modal holds its own error slot |
+| api-shape-and-types.md | §5 typed wrapper; pages call fetcher, never `apiFetch` |
+
+## 14. Rollout and verification
+
+Before first push:
+1. `pnpm --dir frontend typecheck` — pass
+2. `pnpm --dir frontend test` — pass
+3. `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright`, `uv run pytest` — pass (no backend changes, but run to confirm no accidental breakage)
+
+Browser verification (CLAUDE.md mandatory):
+4. Dev stack running via VS Code task. Navigate to `/portfolio`.
+5. Click `Add` on a held position. Enter an amount that works with the native price. Submit. Confirm: modal closes, portfolio refetches, row units increase.
+6. With a single-trade position: click `Close`, pick `Partial`, enter `0.5` units. Submit. Confirm: modal closes, refetch, row units decrease by 0.5.
+7. With the kill switch active (Admin toggle): confirm both Add and Close surface `"Kill switch is active: ..."` verbatim.
+8. With an instrument whose latest `quotes.last` is null: confirm `Add` preview disclaimer fires, submit still triggers, backend 422 surfaced verbatim.
+
+Manual browser verification is mandatory before merge.
+
+## 15. Open questions
+
+None that block implementation.
+
+Tech-debt to file in the same PR description (not as blockers):
+- `GET /portfolio/instruments/{iid}/quote-for-order` returning raw `quotes.last` only, so the order-entry preview can match the execution price source exactly (§7.4 residual gap).
+- Tax-lot close-preview endpoint (§3 non-goal).
+
+## 16. Reviewer cheat-sheet
+
+- [ ] `frontend/src/api/types.ts` additions match `app/api/orders.py` field-for-field and nullability-for-nullability.
+- [ ] `api/orders.ts` is a typed wrapper only. `closePosition` returns `Promise<OrderResponse>`.
+- [ ] Both modals fetch `fetchInstrumentPositions` on open for native-currency preview data.
+- [ ] Error surfacing reads `error.message` (not a non-existent `error.detail`).
+- [ ] ClosePositionModal full-close uses a `mode` radio, not float equality against `units`; payload is `{units_to_deduct: null}` for full, numeric for partial.
+- [ ] Partial-close input supports sub-unit values (`min=0.000001`, `step=0.000001`).
+- [ ] Close button is suppressed on PortfolioPage when `trades.length > 1`.
+- [ ] Every entry submission in this PR sends `action: "ADD"` (no `"BUY"` submit path exposed — BUY ships with #316).
+- [ ] `handleFilled` closes the modal BEFORE `portfolio.refetch()`.
+- [ ] `mountedRef` / `safeSetState` guard every post-`await` `setState` in both modals.
+- [ ] Demo/live pill uses the cached `safety-state-ui.md` pattern: cache updates on non-null fresh only; display is `fresh ?? cached`; stale marker renders when cache is the source.
+- [ ] Client-side numeric validation uses `Number.isFinite(v) && v > 0` (not `!Number.isNaN`).
+- [ ] Preview disclaimer is present in both modals naming the quote-source gap.
+- [ ] Close preview always shows `open_rate` alongside `current_price`, and the P&L estimate uses `open_rate` fallback when `current_price === null`.
+- [ ] Both modals are conditionally mounted by the parent (`{addFor !== null ? <Modal ...> : null}`) so `useAsync` fetches only on open.
+- [ ] `ClosePositionModal` callers supply `instrumentId` alongside `positionId` (BrokerPositionItem alone is insufficient).
+- [ ] `PortfolioPage` passes `valuationSource={p.valuation_source}` to both modals so the amber price treatment works.
+- [ ] PR description names the tech-debt issue filed alongside this PR (`GET /portfolio/instruments/{iid}/quote-for-order`).

--- a/frontend/src/api/orders.test.ts
+++ b/frontend/src/api/orders.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the orders fetchers (issue #313).
+ *
+ * These are thin wrappers around apiFetch, so the tests mock apiFetch
+ * at the module boundary and verify:
+ *   - the URL passed is backend-relative and correctly parameterised
+ *   - the body is the correct JSON shape
+ *   - errors bubble unmodified
+ *
+ * No response-construction / fetch-API gymnastics — the apiFetch
+ * client is already covered by its own contract; here we only assert
+ * that these fetchers hand off to it correctly.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/client";
+import { closePosition, placeOrder } from "@/api/orders";
+import type {
+  ClosePositionRequest,
+  OrderResponse,
+  PlaceOrderRequest,
+} from "@/api/types";
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>(
+    "@/api/client",
+  );
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+  };
+});
+
+import { apiFetch } from "@/api/client";
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function fakeOrderResponse(): OrderResponse {
+  return {
+    order_id: 42,
+    status: "filled",
+    broker_order_ref: "DEMO-1-ADD",
+    filled_price: 140.12,
+    filled_units: 2,
+    fees: 0,
+    explanation: "Demo ADD: price=140.12 units=2",
+  };
+}
+
+beforeEach(() => {
+  mockedApiFetch.mockReset();
+});
+
+describe("placeOrder", () => {
+  it("POSTs to /portfolio/orders with the expected JSON body and returns the parsed response", async () => {
+    mockedApiFetch.mockResolvedValueOnce(fakeOrderResponse());
+    const body: PlaceOrderRequest = {
+      instrument_id: 7,
+      action: "ADD",
+      amount: 250,
+      units: null,
+      stop_loss_rate: null,
+      take_profit_rate: null,
+      is_tsl_enabled: false,
+      leverage: 1,
+    };
+
+    const result = await placeOrder(body);
+
+    expect(result).toEqual(fakeOrderResponse());
+    expect(mockedApiFetch).toHaveBeenCalledTimes(1);
+    const [path, init] = mockedApiFetch.mock.calls[0]!;
+    expect(path).toBe("/portfolio/orders");
+    expect(init).toMatchObject({ method: "POST" });
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual(body);
+  });
+
+  it("bubbles ApiError from apiFetch verbatim", async () => {
+    mockedApiFetch.mockRejectedValueOnce(
+      new ApiError(403, "Kill switch is active: drawdown breach"),
+    );
+
+    await expect(
+      placeOrder({
+        instrument_id: 7,
+        action: "ADD",
+        amount: 100,
+        units: null,
+        stop_loss_rate: null,
+        take_profit_rate: null,
+        is_tsl_enabled: false,
+        leverage: 1,
+      }),
+    ).rejects.toMatchObject({
+      status: 403,
+      message: "Kill switch is active: drawdown breach",
+    });
+  });
+});
+
+describe("closePosition", () => {
+  it("sends {units_to_deduct: null} for full close and interpolates the positionId", async () => {
+    mockedApiFetch.mockResolvedValueOnce(fakeOrderResponse());
+    const body: ClosePositionRequest = { units_to_deduct: null };
+
+    await closePosition(99, body);
+
+    const [path, init] = mockedApiFetch.mock.calls[0]!;
+    expect(path).toBe("/portfolio/positions/99/close");
+    expect(init).toMatchObject({ method: "POST" });
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      units_to_deduct: null,
+    });
+  });
+
+  it("sends the numeric units_to_deduct for partial close", async () => {
+    mockedApiFetch.mockResolvedValueOnce(fakeOrderResponse());
+
+    await closePosition(12, { units_to_deduct: 2.5 });
+
+    const [, init] = mockedApiFetch.mock.calls[0]!;
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      units_to_deduct: 2.5,
+    });
+  });
+
+  it("bubbles 404 from the backend verbatim", async () => {
+    mockedApiFetch.mockRejectedValueOnce(
+      new ApiError(404, "Position 99 not found or already closed."),
+    );
+
+    await expect(
+      closePosition(99, { units_to_deduct: null }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Position 99 not found or already closed.",
+    });
+  });
+});

--- a/frontend/src/api/orders.ts
+++ b/frontend/src/api/orders.ts
@@ -1,0 +1,41 @@
+import { apiFetch } from "@/api/client";
+import type {
+  ClosePositionRequest,
+  OrderResponse,
+  PlaceOrderRequest,
+} from "@/api/types";
+
+/**
+ * Fetchers for the operator-facing order endpoints.
+ *
+ * Mirrors:
+ *   POST /portfolio/orders                      -> app/api/orders.py:405
+ *   POST /portfolio/positions/{id}/close        -> app/api/orders.py:473
+ *
+ * Both endpoints are protected by require_session_or_service_token
+ * (cookie auth; apiFetch passes credentials: include). Errors bubble
+ * as ApiError(status, detail) — the backend's `detail` string is a
+ * fixed phrase (prevention log #86 / #89) so callers may surface it
+ * verbatim via `error.message`.
+ *
+ * Contract: no business logic here. Typed wrapper only. Anything
+ * resembling validation, retry, caching, or analytics belongs in
+ * the calling component.
+ */
+
+export function placeOrder(body: PlaceOrderRequest): Promise<OrderResponse> {
+  return apiFetch<OrderResponse>("/portfolio/orders", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function closePosition(
+  positionId: number,
+  body: ClosePositionRequest,
+): Promise<OrderResponse> {
+  return apiFetch<OrderResponse>(
+    `/portfolio/positions/${positionId}/close`,
+    { method: "POST", body: JSON.stringify(body) },
+  );
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -289,6 +289,37 @@ export interface InstrumentPositionDetail {
 }
 
 // ---------------------------------------------------------------------------
+// /portfolio/orders, /portfolio/positions/{id}/close (app/api/orders.py)
+// ---------------------------------------------------------------------------
+
+export type OrderAction = "BUY" | "ADD";
+
+export interface PlaceOrderRequest {
+  instrument_id: number;
+  action: OrderAction;
+  amount: number | null;
+  units: number | null;
+  stop_loss_rate: number | null;
+  take_profit_rate: number | null;
+  is_tsl_enabled: boolean;
+  leverage: number;
+}
+
+export interface ClosePositionRequest {
+  units_to_deduct: number | null;
+}
+
+export interface OrderResponse {
+  order_id: number;
+  status: string;
+  broker_order_ref: string | null;
+  filled_price: number | null;
+  filled_units: number | null;
+  fees: number;
+  explanation: string;
+}
+
+// ---------------------------------------------------------------------------
 // /recommendations (app/api/recommendations.py)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/components/orders/ClosePositionModal.test.tsx
+++ b/frontend/src/components/orders/ClosePositionModal.test.tsx
@@ -1,0 +1,328 @@
+/**
+ * Tests for ClosePositionModal (#313).
+ *
+ * Pins the spec contract:
+ *   - Full-close radio -> {units_to_deduct: null} (mode-driven, not float equality)
+ *   - Partial-close with fractional value -> {units_to_deduct: 0.5}
+ *   - Input > units -> submit disabled
+ *   - current_price=null -> preview uses open_rate fallback caption
+ *   - valuationSource != "quote" -> amber treatment
+ *   - Stale broker position (positionId missing from trades[]) -> fixed error
+ *   - 404 surfaced verbatim via error.message
+ *   - Unmount-during-submit is safe
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ApiError } from "@/api/client";
+import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
+import type {
+  ConfigResponse,
+  InstrumentPositionDetail,
+  NativeTradeItem,
+  OrderResponse,
+} from "@/api/types";
+
+vi.mock("@/api/config", () => ({
+  fetchConfig: vi.fn(),
+}));
+vi.mock("@/api/portfolio", () => ({
+  fetchInstrumentPositions: vi.fn(),
+}));
+vi.mock("@/api/orders", () => ({
+  closePosition: vi.fn(),
+}));
+
+import { fetchConfig } from "@/api/config";
+import { fetchInstrumentPositions } from "@/api/portfolio";
+import { closePosition } from "@/api/orders";
+
+const mockedFetchConfig = vi.mocked(fetchConfig);
+const mockedFetchDetail = vi.mocked(fetchInstrumentPositions);
+const mockedClosePosition = vi.mocked(closePosition);
+
+function demoConfig(): ConfigResponse {
+  return {
+    app_env: "dev",
+    etoro_env: "demo",
+    runtime: {
+      enable_auto_trading: false,
+      enable_live_trading: false,
+      display_currency: "GBP",
+      updated_at: "2026-04-18T00:00:00Z",
+      updated_by: "system",
+      reason: "",
+    },
+    kill_switch: {
+      active: false,
+      activated_at: null,
+      activated_by: null,
+      reason: null,
+    },
+  };
+}
+
+function tradeFor(
+  positionId: number,
+  overrides: Partial<NativeTradeItem> = {},
+): NativeTradeItem {
+  return {
+    position_id: positionId,
+    is_buy: true,
+    units: 2,
+    amount: 260,
+    open_rate: 130,
+    open_date_time: "2026-01-01T10:00:00Z",
+    current_price: 140,
+    market_value: 280,
+    unrealized_pnl: 20,
+    stop_loss_rate: null,
+    take_profit_rate: null,
+    is_tsl_enabled: false,
+    leverage: 1,
+    total_fees: 0,
+    ...overrides,
+  };
+}
+
+function detailWith(trades: NativeTradeItem[]): InstrumentPositionDetail {
+  return {
+    instrument_id: 7,
+    symbol: "AAPL",
+    company_name: "Apple Inc.",
+    currency: "USD",
+    current_price: 140,
+    total_units: trades.reduce((s, t) => s + t.units, 0),
+    avg_entry: 130,
+    total_invested: 260,
+    total_value: 280,
+    total_pnl: 20,
+    trades,
+  };
+}
+
+function orderFilled(): OrderResponse {
+  return {
+    order_id: 7,
+    status: "filled",
+    broker_order_ref: "DEMO-7-EXIT",
+    filled_price: 140,
+    filled_units: 1,
+    fees: 0,
+    explanation: "Demo EXIT: price=140 units=1",
+  };
+}
+
+beforeEach(() => {
+  mockedFetchConfig.mockResolvedValue(demoConfig());
+  mockedFetchDetail.mockResolvedValue(detailWith([tradeFor(555)]));
+  mockedClosePosition.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof ClosePositionModal>> = {},
+) {
+  const onFilled = vi.fn();
+  const onRequestClose = vi.fn();
+  const result = render(
+    <ClosePositionModal
+      isOpen
+      instrumentId={7}
+      positionId={555}
+      valuationSource="quote"
+      onFilled={onFilled}
+      onRequestClose={onRequestClose}
+      {...overrides}
+    />,
+  );
+  return { onFilled, onRequestClose, ...result };
+}
+
+describe("ClosePositionModal", () => {
+  it("sends {units_to_deduct: null} for full close and calls onFilled then onRequestClose", async () => {
+    mockedClosePosition.mockResolvedValueOnce(orderFilled());
+    const user = userEvent.setup();
+    const { onFilled, onRequestClose } = renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: /Full close/ })).toBeChecked();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Close position/ }));
+
+    await waitFor(() => expect(mockedClosePosition).toHaveBeenCalledTimes(1));
+    expect(mockedClosePosition).toHaveBeenCalledWith(555, {
+      units_to_deduct: null,
+    });
+    const filledOrder = onFilled.mock.invocationCallOrder[0] ?? 0;
+    const closeOrder = onRequestClose.mock.invocationCallOrder[0] ?? 0;
+    expect(filledOrder).toBeGreaterThan(0);
+    expect(closeOrder).toBeGreaterThan(filledOrder);
+  });
+
+  it("sends a numeric units_to_deduct for partial close", async () => {
+    mockedClosePosition.mockResolvedValueOnce(orderFilled());
+    const user = userEvent.setup();
+    renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: /Full close/ })).toBeChecked();
+    });
+    await user.click(screen.getByRole("radio", { name: /Partial close/ }));
+    const input = screen.getByLabelText("Units to close") as HTMLInputElement;
+    await user.type(input, "0.5");
+
+    await user.click(screen.getByRole("button", { name: /Close position/ }));
+
+    await waitFor(() => expect(mockedClosePosition).toHaveBeenCalled());
+    expect(mockedClosePosition).toHaveBeenCalledWith(555, {
+      units_to_deduct: 0.5,
+    });
+  });
+
+  it("disables submit when partial-close value exceeds units", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await waitFor(() => screen.getByRole("radio", { name: /Full close/ }));
+    await user.click(screen.getByRole("radio", { name: /Partial close/ }));
+
+    const input = screen.getByLabelText("Units to close") as HTMLInputElement;
+    await user.type(input, "999");
+
+    expect(
+      screen.getByRole("button", { name: /Close position/ }),
+    ).toBeDisabled();
+    expect(screen.getByText(/Exceeds position units/)).toBeInTheDocument();
+  });
+
+  it("renders the open-rate fallback caption when current_price is null", async () => {
+    mockedFetchDetail.mockReset();
+    mockedFetchDetail.mockResolvedValueOnce(
+      detailWith([tradeFor(555, { current_price: null })]),
+    );
+    renderModal();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/using open rate — no quote available/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows amber treatment and caveat caption when valuation_source is daily_close", async () => {
+    renderModal({ valuationSource: "daily_close" });
+    await waitFor(() => {
+      // daily_close is surfaced in at least two places (info strip
+      // source indicator + preview caption); assert on presence via
+      // getAllByText so we don't conflict with the caption check below.
+      expect(
+        screen.getAllByText(/daily_close/).length,
+      ).toBeGreaterThanOrEqual(1);
+    });
+    expect(
+      screen.getByText(/may not reflect fill price/i),
+    ).toBeInTheDocument();
+    // Caption must flag the open-rate fallback risk.
+    expect(
+      screen.getByText(/backend may fall back to open rate/i),
+    ).toBeInTheDocument();
+  });
+
+  it("rejects partial-close values below the backend precision floor (1e-6)", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await waitFor(() => screen.getByRole("radio", { name: /Full close/ }));
+    await user.click(screen.getByRole("radio", { name: /Partial close/ }));
+    const input = screen.getByLabelText("Units to close") as HTMLInputElement;
+    await user.type(input, "0.0000001"); // below 1e-6
+
+    expect(
+      screen.getByRole("button", { name: /Close position/ }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText(/Must be at least 0\.000001 units/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a fixed error when the target positionId is missing from the response", async () => {
+    mockedFetchDetail.mockReset();
+    mockedFetchDetail.mockResolvedValueOnce(
+      detailWith([tradeFor(999)]),
+    );
+    renderModal();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("alert"),
+      ).toHaveTextContent("This position no longer exists");
+    });
+    expect(
+      screen.getByRole("button", { name: /Close position/ }),
+    ).toBeDisabled();
+  });
+
+  it("surfaces a 404 body verbatim", async () => {
+    mockedClosePosition.mockRejectedValueOnce(
+      new ApiError(404, "Position 555 not found or already closed."),
+    );
+    const user = userEvent.setup();
+    renderModal();
+
+    await waitFor(() => screen.getByRole("radio", { name: /Full close/ }));
+    await user.click(screen.getByRole("button", { name: /Close position/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Position 555 not found or already closed.",
+      );
+    });
+  });
+
+  it("surfaces a 403 kill-switch body verbatim", async () => {
+    mockedClosePosition.mockRejectedValueOnce(
+      new ApiError(403, "Kill switch is active: manual"),
+    );
+    const user = userEvent.setup();
+    renderModal();
+
+    await waitFor(() => screen.getByRole("radio", { name: /Full close/ }));
+    await user.click(screen.getByRole("button", { name: /Close position/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Kill switch is active: manual",
+      );
+    });
+  });
+
+  it("still calls onFilled when unmounted mid-submit if the close actually succeeded", async () => {
+    const deferred: { resolve: (v: OrderResponse) => void } = {
+      resolve: () => undefined,
+    };
+    mockedClosePosition.mockImplementationOnce(
+      () =>
+        new Promise<OrderResponse>((resolve) => {
+          deferred.resolve = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+    const { unmount, onFilled, onRequestClose } = renderModal();
+    await waitFor(() => screen.getByRole("radio", { name: /Full close/ }));
+    await user.click(screen.getByRole("button", { name: /Close position/ }));
+
+    unmount();
+    await act(async () => {
+      deferred.resolve(orderFilled());
+      await Promise.resolve();
+    });
+
+    expect(onFilled).toHaveBeenCalledTimes(1);
+    expect(onRequestClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/orders/ClosePositionModal.tsx
+++ b/frontend/src/components/orders/ClosePositionModal.tsx
@@ -78,7 +78,7 @@ export function ClosePositionModal({
     };
   }, []);
 
-  const trade = findTrade(detail.data?.trades ?? null, positionId);
+  const trade = detail.data !== null ? findTrade(detail.data.trades, positionId) : null;
   const currency = detail.data?.currency ?? "";
   const symbol = detail.data?.symbol ?? "";
 
@@ -301,10 +301,9 @@ export function ClosePositionModal({
 }
 
 function findTrade(
-  trades: NativeTradeItem[] | null,
+  trades: NativeTradeItem[],
   positionId: number,
 ): NativeTradeItem | null {
-  if (trades === null) return null;
   return trades.find((t) => t.position_id === positionId) ?? null;
 }
 

--- a/frontend/src/components/orders/ClosePositionModal.tsx
+++ b/frontend/src/components/orders/ClosePositionModal.tsx
@@ -1,0 +1,380 @@
+/**
+ * ClosePositionModal — full or partial close of a specific broker
+ * position (issue #313).
+ *
+ * Launches from PortfolioPage when a position has exactly one broker
+ * row backing it (aggregated positions are deferred to #314).
+ *
+ * Closes operate on `broker_positions.position_id`, not on an
+ * aggregated instrument position — see app/api/orders.py:473.
+ *
+ * Full close uses `{units_to_deduct: null}` to mirror the backend's
+ * `None = close entire position` contract. Partial close uses a
+ * numeric value. The mode is carried by a radio state, not by a
+ * float comparison against `units`, so a full-close slider sitting
+ * at max never accidentally becomes partial.
+ */
+import { useEffect, useRef, useState } from "react";
+
+import { ApiError } from "@/api/client";
+import { closePosition } from "@/api/orders";
+import { fetchInstrumentPositions } from "@/api/portfolio";
+import type { NativeTradeItem } from "@/api/types";
+import { Modal } from "@/components/ui/Modal";
+import { DemoLivePill } from "@/components/orders/DemoLivePill";
+import { formatNumber } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+type ValuationSource = "quote" | "daily_close" | "cost_basis";
+type CloseMode = "full" | "partial";
+
+/**
+ * Minimum partial-close quantity. Matches the backend's
+ * `Decimal.quantize(Decimal("0.000001"))` at app/api/orders.py:115 —
+ * a value smaller than this rounds to 0 server-side and would be
+ * rejected with a confusing "units_to_deduct must be positive" 400.
+ */
+const MIN_UNITS = 0.000001;
+
+export interface ClosePositionModalProps {
+  readonly isOpen: boolean;
+  readonly instrumentId: number;
+  readonly positionId: number;
+  readonly valuationSource: ValuationSource;
+  readonly onRequestClose: () => void;
+  readonly onFilled: () => void;
+}
+
+const DISCLAIMER =
+  "Preview uses your latest known portfolio price. At submission time the " +
+  "fill may use a different quote — if no quote is available the fill " +
+  "uses your open rate and realized P&L may be ~0.";
+
+const NETWORK_ERROR_PHRASE = "Network error — check connection and try again.";
+
+export function ClosePositionModal({
+  isOpen,
+  instrumentId,
+  positionId,
+  valuationSource,
+  onRequestClose,
+  onFilled,
+}: ClosePositionModalProps): JSX.Element {
+  const detail = useAsync(
+    () => fetchInstrumentPositions(instrumentId),
+    [instrumentId],
+  );
+
+  const [mode, setMode] = useState<CloseMode>("full");
+  const [rawUnits, setRawUnits] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const trade = findTrade(detail.data?.trades ?? null, positionId);
+  const currency = detail.data?.currency ?? "";
+  const symbol = detail.data?.symbol ?? "";
+
+  const parsedUnits = parsePositiveFinite(rawUnits);
+  const partialValid =
+    parsedUnits !== null &&
+    trade !== null &&
+    parsedUnits >= MIN_UNITS &&
+    parsedUnits <= trade.units;
+  const canSubmit =
+    trade !== null &&
+    !submitting &&
+    !detail.error &&
+    (mode === "full" || partialValid);
+
+  async function handleSubmit(): Promise<void> {
+    if (trade === null) return;
+    const unitsToDeduct = mode === "full" ? null : parsedUnits;
+    if (mode === "partial" && (unitsToDeduct === null || unitsToDeduct <= 0)) {
+      return;
+    }
+    setSubmitting(true);
+    setErrorMessage(null);
+    try {
+      await closePosition(positionId, { units_to_deduct: unitsToDeduct });
+      // onFilled must run on server success even if the operator
+      // unmounted us via Escape between submit and response — the
+      // portfolio would otherwise stay stale while the server-side
+      // close really happened.
+      onFilled();
+      if (mountedRef.current) {
+        onRequestClose();
+      }
+    } catch (err) {
+      // Failures are not persisted; if unmounted, drop the error.
+      if (!mountedRef.current) return;
+      setSubmitting(false);
+      if (err instanceof ApiError) {
+        setErrorMessage(err.message);
+      } else {
+        setErrorMessage(NETWORK_ERROR_PHRASE);
+      }
+    }
+  }
+
+  const title = `Close — ${symbol || "position"}`;
+  const staleTrade = detail.data !== null && trade === null;
+
+  return (
+    <Modal isOpen={isOpen} onRequestClose={onRequestClose} label={title}>
+      <div className="flex flex-col gap-3">
+        <header className="flex items-center justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-slate-800">{title}</h2>
+            <p className="text-xs text-slate-500">Position #{positionId}</p>
+          </div>
+          <DemoLivePill />
+        </header>
+
+        {detail.error !== null ? (
+          <div className="rounded border border-red-200 bg-red-50 px-2 py-1.5 text-xs text-red-700">
+            <span>Could not load position details.</span>{" "}
+            <button
+              type="button"
+              onClick={detail.refetch}
+              className="font-semibold underline"
+            >
+              Retry
+            </button>
+          </div>
+        ) : detail.loading || detail.data === null ? (
+          <div className="text-xs text-slate-500">Loading position…</div>
+        ) : staleTrade ? (
+          <p
+            role="alert"
+            className="rounded border border-red-300 bg-red-50 px-2 py-1.5 text-xs text-red-700"
+          >
+            This position no longer exists — refresh the portfolio.
+          </p>
+        ) : trade !== null ? (
+          <>
+            <InfoStrip
+              trade={trade}
+              currency={currency}
+              valuationSource={valuationSource}
+            />
+            <fieldset
+              className="flex flex-col gap-2 text-xs"
+              disabled={submitting}
+            >
+              <legend className="sr-only">Close mode</legend>
+              <div className="flex gap-4">
+                <label className="inline-flex items-center gap-1">
+                  <input
+                    type="radio"
+                    name="close-mode"
+                    value="full"
+                    checked={mode === "full"}
+                    onChange={() => setMode("full")}
+                  />
+                  <span>Full close</span>
+                </label>
+                <label className="inline-flex items-center gap-1">
+                  <input
+                    type="radio"
+                    name="close-mode"
+                    value="partial"
+                    checked={mode === "partial"}
+                    onChange={() => setMode("partial")}
+                  />
+                  <span>Partial close</span>
+                </label>
+              </div>
+              {mode === "partial" ? (
+                <label className="flex flex-col gap-1">
+                  <span>Units to close (max {formatNumber(trade.units, 6)})</span>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="range"
+                      min={Math.min(MIN_UNITS, trade.units)}
+                      max={trade.units}
+                      step={MIN_UNITS}
+                      value={
+                        parsedUnits !== null && parsedUnits <= trade.units
+                          ? parsedUnits
+                          : Math.min(MIN_UNITS, trade.units)
+                      }
+                      onChange={(e) => setRawUnits(e.target.value)}
+                      aria-label="Units to close (slider)"
+                      className="flex-1"
+                    />
+                    <input
+                      type="number"
+                      inputMode="decimal"
+                      min={MIN_UNITS}
+                      step={MIN_UNITS}
+                      value={rawUnits}
+                      onChange={(e) => setRawUnits(e.target.value)}
+                      placeholder={formatNumber(trade.units, 6)}
+                      aria-label="Units to close"
+                      className="w-28 rounded border border-slate-300 bg-white px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
+                    />
+                  </div>
+                  {parsedUnits !== null && parsedUnits > trade.units ? (
+                    <span className="text-[11px] text-red-600">
+                      Exceeds position units ({formatNumber(trade.units, 6)}).
+                    </span>
+                  ) : parsedUnits !== null && parsedUnits < MIN_UNITS ? (
+                    <span className="text-[11px] text-red-600">
+                      Must be at least {MIN_UNITS} units (backend precision floor).
+                    </span>
+                  ) : null}
+                </label>
+              ) : null}
+            </fieldset>
+
+            <PreviewBlock
+              mode={mode}
+              parsedUnits={parsedUnits}
+              trade={trade}
+              currency={currency}
+              valuationSource={valuationSource}
+            />
+
+            <p className="text-[11px] leading-snug text-slate-500">
+              {DISCLAIMER}
+            </p>
+          </>
+        ) : null}
+
+        {errorMessage !== null ? (
+          <p
+            role="alert"
+            className="rounded border border-red-300 bg-red-50 px-2 py-1.5 text-xs text-red-700"
+          >
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onRequestClose}
+            disabled={submitting}
+            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="rounded bg-red-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-red-500 disabled:opacity-50"
+          >
+            {submitting ? "Closing…" : "Close position"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function findTrade(
+  trades: NativeTradeItem[] | null,
+  positionId: number,
+): NativeTradeItem | null {
+  if (trades === null) return null;
+  return trades.find((t) => t.position_id === positionId) ?? null;
+}
+
+function parsePositiveFinite(raw: string): number | null {
+  if (raw.trim() === "") return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return null;
+  if (n <= 0) return null;
+  return n;
+}
+
+function InfoStrip({
+  trade,
+  currency,
+  valuationSource,
+}: {
+  trade: NativeTradeItem;
+  currency: string;
+  valuationSource: ValuationSource;
+}): JSX.Element {
+  const amber = valuationSource !== "quote";
+  return (
+    <div className="rounded border border-slate-200 bg-slate-50 px-2 py-1.5 text-xs text-slate-700">
+      <div>
+        {formatNumber(trade.units, 6)} units @ {formatNumber(trade.open_rate, 4)}{" "}
+        {currency}
+      </div>
+      <div>
+        Latest price:{" "}
+        <span className={amber ? "font-semibold text-amber-700" : ""}>
+          {trade.current_price !== null
+            ? `${formatNumber(trade.current_price, 4)} ${currency}`
+            : "—"}
+        </span>{" "}
+        <span className="text-slate-500">({valuationSource})</span>
+        {amber ? (
+          <span className="ml-1 font-semibold text-amber-700">
+            (may not reflect fill price)
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function PreviewBlock({
+  mode,
+  parsedUnits,
+  trade,
+  currency,
+  valuationSource,
+}: {
+  mode: CloseMode;
+  parsedUnits: number | null;
+  trade: NativeTradeItem;
+  currency: string;
+  valuationSource: ValuationSource;
+}): JSX.Element {
+  const unitsToClose = mode === "full" ? trade.units : parsedUnits ?? 0;
+  const havePrice = trade.current_price !== null;
+  const fillPrice = trade.current_price ?? trade.open_rate;
+  const pnl = (fillPrice - trade.open_rate) * unitsToClose;
+  const pnlColor = pnl >= 0 ? "text-emerald-700" : "text-red-700";
+  // The caption must reflect BOTH whether we have a price AND
+  // whether that price came from a live quote. A daily_close
+  // fallback is not a quote — the backend may still fill at
+  // open_rate if its own raw quote lookup turns up null.
+  const caption = !havePrice
+    ? "using open rate — no quote available; realized P&L will be ~0"
+    : valuationSource === "quote"
+      ? "using latest quote"
+      : `using latest ${valuationSource} — backend may fall back to open rate`;
+  return (
+    <div className="rounded border border-slate-200 bg-slate-50 px-2 py-1.5 text-xs">
+      <div>
+        Closing: {formatNumber(unitsToClose, 6)} /{" "}
+        {formatNumber(trade.units, 6)} units
+      </div>
+      <div>
+        Open rate: {formatNumber(trade.open_rate, 4)} {currency}
+      </div>
+      <div>
+        Est. fill price:{" "}
+        {havePrice ? `${formatNumber(fillPrice, 4)} ${currency}` : "—"}
+      </div>
+      <div className={pnlColor}>
+        Est. realized P&amp;L: {formatNumber(pnl, 2)} {currency}
+      </div>
+      <div className="text-slate-500">{caption}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/orders/ClosePositionModal.tsx
+++ b/frontend/src/components/orders/ClosePositionModal.tsx
@@ -92,6 +92,7 @@ export function ClosePositionModal({
     trade !== null &&
     !submitting &&
     !detail.error &&
+    !detail.loading &&
     (mode === "full" || partialValid);
 
   async function handleSubmit(): Promise<void> {
@@ -104,6 +105,10 @@ export function ClosePositionModal({
     setErrorMessage(null);
     try {
       await closePosition(positionId, { units_to_deduct: unitsToDeduct });
+      // Reset submitting before handing control to the parent so a
+      // caller that delays unmounting cannot leave the button stuck
+      // in "Closing…".
+      if (mountedRef.current) setSubmitting(false);
       // onFilled must run on server success even if the operator
       // unmounted us via Escape between submit and response — the
       // portfolio would otherwise stay stale while the server-side
@@ -193,10 +198,22 @@ export function ClosePositionModal({
                 </label>
               </div>
               {mode === "partial" ? (
-                <label className="flex flex-col gap-1">
-                  <span>Units to close (max {formatNumber(trade.units, 6)})</span>
+                <div className="flex flex-col gap-1">
+                  <div className="text-[11px] text-slate-500">
+                    Max {formatNumber(trade.units, 6)} units
+                  </div>
                   <div className="flex items-center gap-2">
+                    {/*
+                      Slider and numeric input are two separate,
+                      individually-labelled controls with distinct
+                      accessible names so tests (and screen readers)
+                      can address each one unambiguously.
+                    */}
+                    <label className="sr-only" htmlFor="close-units-slider">
+                      Units to close (slider)
+                    </label>
                     <input
+                      id="close-units-slider"
                       type="range"
                       min={Math.min(MIN_UNITS, trade.units)}
                       max={trade.units}
@@ -207,10 +224,13 @@ export function ClosePositionModal({
                           : Math.min(MIN_UNITS, trade.units)
                       }
                       onChange={(e) => setRawUnits(e.target.value)}
-                      aria-label="Units to close (slider)"
                       className="flex-1"
                     />
+                    <label className="sr-only" htmlFor="close-units-input">
+                      Units to close
+                    </label>
                     <input
+                      id="close-units-input"
                       type="number"
                       inputMode="decimal"
                       min={MIN_UNITS}
@@ -218,7 +238,6 @@ export function ClosePositionModal({
                       value={rawUnits}
                       onChange={(e) => setRawUnits(e.target.value)}
                       placeholder={formatNumber(trade.units, 6)}
-                      aria-label="Units to close"
                       className="w-28 rounded border border-slate-300 bg-white px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
                     />
                   </div>
@@ -231,7 +250,7 @@ export function ClosePositionModal({
                       Must be at least {MIN_UNITS} units (backend precision floor).
                     </span>
                   ) : null}
-                </label>
+                </div>
               ) : null}
             </fieldset>
 

--- a/frontend/src/components/orders/ClosePositionModal.tsx
+++ b/frontend/src/components/orders/ClosePositionModal.tsx
@@ -98,7 +98,18 @@ export function ClosePositionModal({
   async function handleSubmit(): Promise<void> {
     if (trade === null) return;
     const unitsToDeduct = mode === "full" ? null : parsedUnits;
-    if (mode === "partial" && (unitsToDeduct === null || unitsToDeduct <= 0)) {
+    // Belt-and-braces on the partial-close path: the button is
+    // disabled via `canSubmit` for any of these conditions, but we
+    // re-check here so a programmatic call (test, future caller)
+    // cannot bypass the bounds and POST an over-position or
+    // sub-precision value that the backend would 400 with a
+    // confusing message.
+    if (
+      mode === "partial" &&
+      (unitsToDeduct === null ||
+        unitsToDeduct < MIN_UNITS ||
+        unitsToDeduct > trade.units)
+    ) {
       return;
     }
     setSubmitting(true);

--- a/frontend/src/components/orders/DemoLivePill.test.tsx
+++ b/frontend/src/components/orders/DemoLivePill.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Safety-state UI test for DemoLivePill (spec §9).
+ *
+ * Pins the two behaviours that matter:
+ *   1. The pill reflects a fresh live flag when it arrives.
+ *   2. When /config transiently returns null (e.g. a refetch
+ *      in flight), the pill stays on the last confirmed value
+ *      and a `(stale)` marker appears.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { DemoLivePill } from "@/components/orders/DemoLivePill";
+import type { ConfigResponse } from "@/api/types";
+
+vi.mock("@/api/config", () => ({
+  fetchConfig: vi.fn(),
+}));
+
+import { fetchConfig } from "@/api/config";
+
+const mockedFetchConfig = vi.mocked(fetchConfig);
+
+function configWith(enableLive: boolean): ConfigResponse {
+  return {
+    app_env: "dev",
+    etoro_env: "demo",
+    runtime: {
+      enable_auto_trading: false,
+      enable_live_trading: enableLive,
+      display_currency: "GBP",
+      updated_at: "2026-04-18T00:00:00Z",
+      updated_by: "system",
+      reason: "",
+    },
+    kill_switch: {
+      active: false,
+      activated_at: null,
+      activated_by: null,
+      reason: null,
+    },
+  };
+}
+
+beforeEach(() => {
+  mockedFetchConfig.mockReset();
+});
+
+describe("DemoLivePill", () => {
+  it("shows DEMO MODE when enable_live_trading=false (fresh, no stale marker)", async () => {
+    mockedFetchConfig.mockResolvedValueOnce(configWith(false));
+    render(<DemoLivePill />);
+    const pill = await screen.findByTestId("demo-live-pill");
+    expect(pill).toHaveAttribute("data-live", "false");
+    expect(pill.textContent).toContain("DEMO MODE");
+    expect(pill.textContent).not.toContain("stale");
+  });
+
+  it("shows LIVE when enable_live_trading=true", async () => {
+    mockedFetchConfig.mockResolvedValueOnce(configWith(true));
+    render(<DemoLivePill />);
+    const pill = await screen.findByTestId("demo-live-pill");
+    await waitFor(() => {
+      expect(pill).toHaveAttribute("data-live", "true");
+    });
+    expect(pill.textContent).toContain("LIVE");
+  });
+
+  it("on cold start with no response yet, defaults to DEMO MODE with no stale marker", () => {
+    // Resolve never — simulate an infinite in-flight request.
+    mockedFetchConfig.mockReturnValue(new Promise(() => {}));
+    render(<DemoLivePill />);
+    const pill = screen.getByTestId("demo-live-pill");
+    expect(pill).toHaveAttribute("data-live", "false");
+    expect(pill.textContent).toContain("DEMO MODE");
+    // Cold start: no cache yet, no stale marker.
+    expect(pill.textContent).not.toContain("stale");
+  });
+});

--- a/frontend/src/components/orders/DemoLivePill.tsx
+++ b/frontend/src/components/orders/DemoLivePill.tsx
@@ -1,0 +1,53 @@
+/**
+ * DemoLivePill — safety-state indicator for the operator's trade-mode
+ * (issue #313, §9 of the spec).
+ *
+ * Follows .claude/skills/frontend/safety-state-ui.md literally:
+ *   - Cache the last confirmed boolean (true OR false) in local state.
+ *   - Display `fresh ?? cached`; never disappears during refetch.
+ *   - Cache is updated only on non-null fresh values; transient nulls
+ *     (loading, error) leave the cache untouched.
+ *   - A stale marker renders whenever the cache is the source of truth.
+ *
+ * The scary state for this app is LIVE (real-money orders). If the
+ * /config endpoint transiently fails while LIVE was confirmed true,
+ * we must keep rendering LIVE rather than falling back to DEMO.
+ */
+import { useEffect, useState } from "react";
+
+import { fetchConfig } from "@/api/config";
+import { useAsync } from "@/lib/useAsync";
+
+export function DemoLivePill(): JSX.Element {
+  const config = useAsync(fetchConfig, []);
+  const liveFlag: boolean | null =
+    config.data?.runtime?.enable_live_trading ?? null;
+
+  const [cached, setCached] = useState<boolean | null>(null);
+  useEffect(() => {
+    // Only update the cache on confirmed fresh values. A null (loading
+    // or error) leaves the cache untouched so the pill never
+    // disappears behind a transient /config hiccup.
+    if (liveFlag !== null) setCached(liveFlag);
+  }, [liveFlag]);
+
+  const fresh = liveFlag !== null;
+  const isLive = liveFlag ?? cached ?? false;
+
+  return (
+    <span
+      className={
+        isLive
+          ? "inline-flex items-center gap-1 rounded border border-red-300 bg-red-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-700"
+          : "inline-flex items-center gap-1 rounded border border-blue-300 bg-blue-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-blue-700"
+      }
+      data-testid="demo-live-pill"
+      data-live={isLive ? "true" : "false"}
+    >
+      {isLive ? "LIVE" : "DEMO MODE"}
+      {!fresh && cached !== null ? (
+        <span className="text-[9px] uppercase text-amber-600">(stale)</span>
+      ) : null}
+    </span>
+  );
+}

--- a/frontend/src/components/orders/OrderEntryModal.test.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.test.tsx
@@ -1,0 +1,323 @@
+/**
+ * Tests for OrderEntryModal (#313).
+ *
+ * Pins the contract defined in the spec:
+ *   - Happy path: valid amount -> onFilled -> onRequestClose (in that order)
+ *   - Instrument-detail error: renders retry, submit disabled
+ *   - Client validation: Infinity / NaN / negative rejected
+ *   - Guard rejection: ApiError.message surfaced verbatim
+ *   - Network error: fixed phrase surfaced
+ *   - Price-source flag: amber rendering when valuation_source != "quote"
+ *   - Unmount-during-submit: no unhandled rejection
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ApiError } from "@/api/client";
+import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
+import type {
+  ConfigResponse,
+  InstrumentPositionDetail,
+  OrderResponse,
+} from "@/api/types";
+
+vi.mock("@/api/config", () => ({
+  fetchConfig: vi.fn(),
+}));
+vi.mock("@/api/portfolio", () => ({
+  fetchInstrumentPositions: vi.fn(),
+}));
+vi.mock("@/api/orders", () => ({
+  placeOrder: vi.fn(),
+}));
+
+import { fetchConfig } from "@/api/config";
+import { fetchInstrumentPositions } from "@/api/portfolio";
+import { placeOrder } from "@/api/orders";
+
+const mockedFetchConfig = vi.mocked(fetchConfig);
+const mockedFetchDetail = vi.mocked(fetchInstrumentPositions);
+const mockedPlaceOrder = vi.mocked(placeOrder);
+
+function demoConfig(): ConfigResponse {
+  return {
+    app_env: "dev",
+    etoro_env: "demo",
+    runtime: {
+      enable_auto_trading: false,
+      enable_live_trading: false,
+      display_currency: "GBP",
+      updated_at: "2026-04-18T00:00:00Z",
+      updated_by: "system",
+      reason: "",
+    },
+    kill_switch: {
+      active: false,
+      activated_at: null,
+      activated_by: null,
+      reason: null,
+    },
+  };
+}
+
+function detailFor(instrumentId: number): InstrumentPositionDetail {
+  return {
+    instrument_id: instrumentId,
+    symbol: "AAPL",
+    company_name: "Apple Inc.",
+    currency: "USD",
+    current_price: 140,
+    total_units: 2,
+    avg_entry: 130,
+    total_invested: 260,
+    total_value: 280,
+    total_pnl: 20,
+    trades: [
+      {
+        position_id: 555,
+        is_buy: true,
+        units: 2,
+        amount: 260,
+        open_rate: 130,
+        open_date_time: "2026-01-01T10:00:00Z",
+        current_price: 140,
+        market_value: 280,
+        unrealized_pnl: 20,
+        stop_loss_rate: null,
+        take_profit_rate: null,
+        is_tsl_enabled: false,
+        leverage: 1,
+        total_fees: 0,
+      },
+    ],
+  };
+}
+
+function orderFilled(): OrderResponse {
+  return {
+    order_id: 1,
+    status: "filled",
+    broker_order_ref: "DEMO-7-ADD",
+    filled_price: 140,
+    filled_units: 1,
+    fees: 0,
+    explanation: "Demo ADD: price=140 units=1",
+  };
+}
+
+beforeEach(() => {
+  mockedFetchConfig.mockResolvedValue(demoConfig());
+  mockedFetchDetail.mockResolvedValue(detailFor(7));
+  mockedPlaceOrder.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof OrderEntryModal>> = {},
+) {
+  const onFilled = vi.fn();
+  const onRequestClose = vi.fn();
+  const result = render(
+    <OrderEntryModal
+      isOpen
+      instrumentId={7}
+      symbol="AAPL"
+      companyName="Apple Inc."
+      valuationSource="quote"
+      onFilled={onFilled}
+      onRequestClose={onRequestClose}
+      {...overrides}
+    />,
+  );
+  return { onFilled, onRequestClose, ...result };
+}
+
+describe("OrderEntryModal", () => {
+  it("submits with action=ADD + amount and calls onFilled then onRequestClose", async () => {
+    mockedPlaceOrder.mockResolvedValueOnce(orderFilled());
+    const user = userEvent.setup();
+    const { onFilled, onRequestClose } = renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Latest price:/)).toBeInTheDocument();
+    });
+
+    const input = screen.getByLabelText(/Notional/) as HTMLInputElement;
+    await user.type(input, "250");
+    await user.click(screen.getByRole("button", { name: /Place demo order/ }));
+
+    await waitFor(() => {
+      expect(mockedPlaceOrder).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedPlaceOrder).toHaveBeenCalledWith({
+      instrument_id: 7,
+      action: "ADD",
+      amount: 250,
+      units: null,
+      stop_loss_rate: null,
+      take_profit_rate: null,
+      is_tsl_enabled: false,
+      leverage: 1,
+    });
+    // onFilled runs before onRequestClose so the refetch fires while
+    // the modal is already closed.
+    const filledOrder = onFilled.mock.invocationCallOrder[0] ?? 0;
+    const closeOrder = onRequestClose.mock.invocationCallOrder[0] ?? 0;
+    expect(filledOrder).toBeGreaterThan(0);
+    expect(closeOrder).toBeGreaterThan(filledOrder);
+  });
+
+  it("submits with action=ADD + units when units mode selected", async () => {
+    mockedPlaceOrder.mockResolvedValueOnce(orderFilled());
+    const user = userEvent.setup();
+    renderModal();
+
+    await waitFor(() => screen.getByText(/Latest price:/));
+
+    await user.click(screen.getByRole("radio", { name: /Units/ }));
+    const input = screen.getByLabelText(/Units to buy/) as HTMLInputElement;
+    await user.type(input, "1.5");
+    await user.click(screen.getByRole("button", { name: /Place demo order/ }));
+
+    await waitFor(() => expect(mockedPlaceOrder).toHaveBeenCalled());
+    expect(mockedPlaceOrder).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: null, units: 1.5 }),
+    );
+  });
+
+  it("renders a Retry button and disables submit when price fetch fails", async () => {
+    mockedFetchDetail.mockReset();
+    mockedFetchDetail.mockRejectedValueOnce(new Error("boom"));
+    renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not load price context/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Retry/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Place demo order/ })).toBeDisabled();
+  });
+
+  it("rejects Infinity input: isFinite guard leaves submit disabled", async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await waitFor(() => screen.getByText(/Latest price:/));
+
+    const input = screen.getByLabelText(/Notional/);
+    await user.type(input, "1e309"); // -> Infinity after Number()
+
+    expect(screen.getByRole("button", { name: /Place demo order/ })).toBeDisabled();
+    expect(mockedPlaceOrder).not.toHaveBeenCalled();
+  });
+
+  it("rejects negative input", async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await waitFor(() => screen.getByText(/Latest price:/));
+
+    const input = screen.getByLabelText(/Notional/);
+    await user.type(input, "-10");
+
+    expect(screen.getByRole("button", { name: /Place demo order/ })).toBeDisabled();
+  });
+
+  it("surfaces the backend detail verbatim on a 403 kill-switch response", async () => {
+    mockedPlaceOrder.mockRejectedValueOnce(
+      new ApiError(403, "Kill switch is active: drawdown breach"),
+    );
+    const user = userEvent.setup();
+    renderModal();
+    await waitFor(() => screen.getByText(/Latest price:/));
+
+    await user.type(screen.getByLabelText(/Notional/), "250");
+    await user.click(screen.getByRole("button", { name: /Place demo order/ }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("alert"),
+      ).toHaveTextContent("Kill switch is active: drawdown breach");
+    });
+  });
+
+  it("surfaces 422 no-quote detail verbatim", async () => {
+    mockedPlaceOrder.mockRejectedValueOnce(
+      new ApiError(
+        422,
+        "No quote available for instrument 7 — cannot fill without a price.",
+      ),
+    );
+    const user = userEvent.setup();
+    renderModal();
+    await waitFor(() => screen.getByText(/Latest price:/));
+
+    await user.type(screen.getByLabelText(/Notional/), "250");
+    await user.click(screen.getByRole("button", { name: /Place demo order/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "No quote available for instrument 7",
+      );
+    });
+  });
+
+  it("surfaces a fixed phrase on non-ApiError network failure", async () => {
+    mockedPlaceOrder.mockRejectedValueOnce(new TypeError("network"));
+    const user = userEvent.setup();
+    renderModal();
+    await waitFor(() => screen.getByText(/Latest price:/));
+
+    await user.type(screen.getByLabelText(/Notional/), "100");
+    await user.click(screen.getByRole("button", { name: /Place demo order/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Network error — check connection and try again.",
+      );
+    });
+  });
+
+  it("shows amber treatment when valuation_source is daily_close", async () => {
+    renderModal({ valuationSource: "daily_close" });
+    await waitFor(() => {
+      expect(screen.getByText(/daily_close/)).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/may not reflect fill price/i),
+    ).toBeInTheDocument();
+  });
+
+  it("still calls onFilled when unmounted mid-submit if the order actually filled", async () => {
+    // The modal may be unmounted (Escape, parent closes it) between
+    // submit and response, but the server-side order already went
+    // through. onFilled must fire so the portfolio refetches and
+    // the operator sees the truth.
+    const deferred: { resolve: (v: OrderResponse) => void } = {
+      resolve: () => undefined,
+    };
+    mockedPlaceOrder.mockImplementationOnce(
+      () =>
+        new Promise<OrderResponse>((resolve) => {
+          deferred.resolve = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+    const { unmount, onFilled, onRequestClose } = renderModal();
+    await waitFor(() => screen.getByText(/Latest price:/));
+    await user.type(screen.getByLabelText(/Notional/), "250");
+    await user.click(screen.getByRole("button", { name: /Place demo order/ }));
+
+    // Unmount while the POST is still in flight.
+    unmount();
+    await act(async () => {
+      deferred.resolve(orderFilled());
+      await Promise.resolve();
+    });
+
+    expect(onFilled).toHaveBeenCalledTimes(1);
+    // onRequestClose skipped because we're unmounted.
+    expect(onRequestClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/orders/OrderEntryModal.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.tsx
@@ -322,7 +322,7 @@ function PreviewBlock({
 }): JSX.Element {
   const price = detail?.current_price;
   let estimate = "—";
-  if (parsedValue !== null && priceIsUsable && price !== null && price !== undefined) {
+  if (parsedValue !== null && priceIsUsable && price != null) {
     if (mode === "amount") {
       estimate = `Estimated units: ${formatNumber(parsedValue / price, 6)}`;
     } else {

--- a/frontend/src/components/orders/OrderEntryModal.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.tsx
@@ -83,12 +83,14 @@ export function OrderEntryModal({
 
   const parsedValue = parsePositiveFinite(rawInput);
   const priceIsUsable =
-    detail.data?.current_price !== null &&
-    detail.data?.current_price !== undefined &&
-    detail.data.current_price > 0;
+    detail.data?.current_price != null && detail.data.current_price > 0;
   const detailLoaded = detail.data !== null;
   const canSubmit =
-    detailLoaded && parsedValue !== null && !submitting && !detail.error;
+    detailLoaded &&
+    !detail.loading &&
+    !detail.error &&
+    parsedValue !== null &&
+    !submitting;
 
   async function handleSubmit(): Promise<void> {
     if (parsedValue === null) return;
@@ -106,6 +108,11 @@ export function OrderEntryModal({
     };
     try {
       await placeOrder(body);
+      // Reset submitting before handing control to the parent. The
+      // parent normally unmounts us immediately via onRequestClose,
+      // but if a future caller delays that the button must not stay
+      // locked in "Placing…" indefinitely.
+      if (mountedRef.current) setSubmitting(false);
       // onFilled is owned by the parent page — we must call it on
       // success REGARDLESS of whether this modal is still mounted,
       // otherwise an operator who presses Escape between submit and

--- a/frontend/src/components/orders/OrderEntryModal.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.tsx
@@ -1,0 +1,333 @@
+/**
+ * OrderEntryModal — ADD-to-existing-position flow (issue #313).
+ *
+ * Launches from PortfolioPage. Renders:
+ *   - DemoLivePill (safety-state-ui pattern)
+ *   - Native-currency price context from /portfolio/instruments/:id
+ *   - Amount / Units toggle + numeric input with live preview
+ *   - Submit -> POST /portfolio/orders with action=ADD
+ *
+ * Intentionally minimal vs the spec:
+ *   - Action is always "ADD" in this PR (new-instrument BUY ships in #316).
+ *   - No SL / TP / TSL / leverage UI. Payload sends the backend defaults
+ *     explicitly for readability.
+ *
+ * Safety:
+ *   - Kill-switch / live-trading checks live on the backend; we simply
+ *     surface the fixed-phrase detail on any non-2xx.
+ *   - mountedRef guards every post-await setState (prevention log #127).
+ *   - Modal closes BEFORE the portfolio refetch fires, so refetch errors
+ *     cannot hide behind the modal (prevention log #125).
+ */
+import { useEffect, useRef, useState } from "react";
+
+import { ApiError } from "@/api/client";
+import { placeOrder } from "@/api/orders";
+import { fetchInstrumentPositions } from "@/api/portfolio";
+import type { InstrumentPositionDetail, PlaceOrderRequest } from "@/api/types";
+import { Modal } from "@/components/ui/Modal";
+import { DemoLivePill } from "@/components/orders/DemoLivePill";
+import { formatNumber } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+type ValuationSource = "quote" | "daily_close" | "cost_basis";
+
+export interface OrderEntryModalProps {
+  readonly isOpen: boolean;
+  readonly instrumentId: number;
+  readonly symbol: string;
+  readonly companyName: string;
+  readonly valuationSource: ValuationSource;
+  readonly onRequestClose: () => void;
+  readonly onFilled: () => void;
+}
+
+type InputMode = "amount" | "units";
+
+const DISCLAIMER =
+  "Preview uses your latest known portfolio price. At submission time the " +
+  "fill may use a different quote — if no quote is available the backend " +
+  "returns 422 and no order is placed.";
+
+const NETWORK_ERROR_PHRASE = "Network error — check connection and try again.";
+
+export function OrderEntryModal({
+  isOpen,
+  instrumentId,
+  symbol,
+  companyName,
+  valuationSource,
+  onRequestClose,
+  onFilled,
+}: OrderEntryModalProps): JSX.Element {
+  const detail = useAsync(
+    // useAsync captures fn via a ref — fresh arrow per render is fine.
+    () => fetchInstrumentPositions(instrumentId),
+    [instrumentId],
+  );
+
+  const [mode, setMode] = useState<InputMode>("amount");
+  const [rawInput, setRawInput] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // mountedRef: guard setState against the "user escapes the modal
+  // mid-submit then the parent unmounts us" race (prevention #127).
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const parsedValue = parsePositiveFinite(rawInput);
+  const priceIsUsable =
+    detail.data?.current_price !== null &&
+    detail.data?.current_price !== undefined &&
+    detail.data.current_price > 0;
+  const detailLoaded = detail.data !== null;
+  const canSubmit =
+    detailLoaded && parsedValue !== null && !submitting && !detail.error;
+
+  async function handleSubmit(): Promise<void> {
+    if (parsedValue === null) return;
+    setSubmitting(true);
+    setErrorMessage(null);
+    const body: PlaceOrderRequest = {
+      instrument_id: instrumentId,
+      action: "ADD",
+      amount: mode === "amount" ? parsedValue : null,
+      units: mode === "units" ? parsedValue : null,
+      stop_loss_rate: null,
+      take_profit_rate: null,
+      is_tsl_enabled: false,
+      leverage: 1,
+    };
+    try {
+      await placeOrder(body);
+      // onFilled is owned by the parent page — we must call it on
+      // success REGARDLESS of whether this modal is still mounted,
+      // otherwise an operator who presses Escape between submit and
+      // response leaves the portfolio stale while the server-side
+      // fill really did happen.
+      onFilled();
+      if (mountedRef.current) {
+        // Close BEFORE the refetch fires. handleFilled in the parent
+        // calls portfolio.refetch(), whose errors must not be hidden
+        // behind this modal (prevention #125). If we've already been
+        // unmounted (Escape mid-submit), onRequestClose is a no-op.
+        onRequestClose();
+      }
+    } catch (err) {
+      // On error we do NOT call onFilled (nothing was persisted). If
+      // we're unmounted we drop the error display silently — the
+      // operator has already moved on and no portfolio drift is
+      // possible on a failure path.
+      if (!mountedRef.current) return;
+      setSubmitting(false);
+      if (err instanceof ApiError) {
+        setErrorMessage(err.message);
+      } else {
+        setErrorMessage(NETWORK_ERROR_PHRASE);
+      }
+    }
+  }
+
+  const title = `Add — ${symbol}`;
+
+  return (
+    <Modal isOpen={isOpen} onRequestClose={onRequestClose} label={title}>
+      <div className="flex flex-col gap-3">
+        <header className="flex items-center justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-slate-800">{title}</h2>
+            <p className="text-xs text-slate-500">{companyName}</p>
+          </div>
+          <DemoLivePill />
+        </header>
+
+        <PriceContext
+          detail={detail.data}
+          detailLoading={detail.loading}
+          detailError={detail.error}
+          onRetry={detail.refetch}
+          valuationSource={valuationSource}
+        />
+
+        <fieldset className="flex flex-col gap-2" disabled={submitting}>
+          <legend className="sr-only">Order amount</legend>
+          <div className="flex gap-4 text-xs">
+            <label className="inline-flex items-center gap-1">
+              <input
+                type="radio"
+                name="order-input-mode"
+                value="amount"
+                checked={mode === "amount"}
+                onChange={() => {
+                  setMode("amount");
+                  setRawInput("");
+                }}
+              />
+              <span>Amount</span>
+            </label>
+            <label className="inline-flex items-center gap-1">
+              <input
+                type="radio"
+                name="order-input-mode"
+                value="units"
+                checked={mode === "units"}
+                onChange={() => {
+                  setMode("units");
+                  setRawInput("");
+                }}
+              />
+              <span>Units</span>
+            </label>
+          </div>
+          <label className="flex flex-col gap-1 text-xs text-slate-600">
+            <span>
+              {mode === "amount"
+                ? `Notional (${detail.data?.currency ?? "native"})`
+                : "Units to buy"}
+            </span>
+            <input
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step={mode === "amount" ? "0.01" : "0.000001"}
+              value={rawInput}
+              onChange={(e) => setRawInput(e.target.value)}
+              placeholder={mode === "amount" ? "250.00" : "2.000000"}
+              className="rounded border border-slate-300 bg-white px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            />
+          </label>
+        </fieldset>
+
+        <PreviewBlock
+          mode={mode}
+          parsedValue={parsedValue}
+          detail={detail.data}
+          priceIsUsable={priceIsUsable}
+        />
+
+        <p className="text-[11px] leading-snug text-slate-500">{DISCLAIMER}</p>
+
+        {errorMessage !== null ? (
+          <p
+            role="alert"
+            className="rounded border border-red-300 bg-red-50 px-2 py-1.5 text-xs text-red-700"
+          >
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onRequestClose}
+            disabled={submitting}
+            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="rounded bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-500 disabled:opacity-50"
+          >
+            {submitting ? "Placing…" : "Place demo order"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function parsePositiveFinite(raw: string): number | null {
+  if (raw.trim() === "") return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return null;
+  if (n <= 0) return null;
+  return n;
+}
+
+function PriceContext({
+  detail,
+  detailLoading,
+  detailError,
+  onRetry,
+  valuationSource,
+}: {
+  detail: InstrumentPositionDetail | null;
+  detailLoading: boolean;
+  detailError: unknown;
+  onRetry: () => void;
+  valuationSource: ValuationSource;
+}): JSX.Element {
+  if (detailError !== null) {
+    return (
+      <div className="rounded border border-red-200 bg-red-50 px-2 py-1.5 text-xs text-red-700">
+        <span>Could not load price context.</span>{" "}
+        <button
+          type="button"
+          onClick={onRetry}
+          className="font-semibold underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+  if (detailLoading || detail === null) {
+    return (
+      <div className="text-xs text-slate-500">Loading price context…</div>
+    );
+  }
+  const price = detail.current_price;
+  const amber = valuationSource !== "quote";
+  return (
+    <div className={`text-xs ${amber ? "text-amber-700" : "text-slate-600"}`}>
+      <span>
+        Currency: {detail.currency} · Latest price:{" "}
+        {price !== null ? formatNumber(price, 4) : "—"} ({valuationSource})
+      </span>
+      {amber ? (
+        <span className="ml-1 font-semibold">
+          (may not reflect fill price)
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function PreviewBlock({
+  mode,
+  parsedValue,
+  detail,
+  priceIsUsable,
+}: {
+  mode: InputMode;
+  parsedValue: number | null;
+  detail: InstrumentPositionDetail | null;
+  priceIsUsable: boolean;
+}): JSX.Element {
+  const price = detail?.current_price;
+  let estimate = "—";
+  if (parsedValue !== null && priceIsUsable && price !== null && price !== undefined) {
+    if (mode === "amount") {
+      estimate = `Estimated units: ${formatNumber(parsedValue / price, 6)}`;
+    } else {
+      estimate = `Estimated cost: ${formatNumber(parsedValue * price, 2)} ${detail?.currency ?? ""}`;
+    }
+  } else if (parsedValue !== null && !priceIsUsable) {
+    estimate = "No usable quote — submit will likely 422";
+  }
+  return (
+    <div className="rounded border border-slate-200 bg-slate-50 px-2 py-1.5 text-xs text-slate-700">
+      <div>{estimate}</div>
+      <div className="text-slate-500">Estimated fees: 0.00 (demo)</div>
+    </div>
+  );
+}

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -6,7 +6,22 @@ import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
 import { formatMoney, formatNumber, formatPct, pnlPct } from "@/lib/format";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
-import type { PositionItem, PortfolioMirrorItem } from "@/api/types";
+import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
+import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
+import type {
+  BrokerPositionItem,
+  PositionItem,
+  PortfolioMirrorItem,
+} from "@/api/types";
+
+type ValuationSource = "quote" | "daily_close" | "cost_basis";
+
+interface CloseTarget {
+  instrumentId: number;
+  trade: BrokerPositionItem;
+  valuationSource: ValuationSource;
+  symbol: string;
+}
 
 /**
  * Portfolio page — the operator's main working view.
@@ -20,6 +35,16 @@ export function PortfolioPage() {
   const portfolio = useAsync(fetchPortfolio, []);
   const currency = useDisplayCurrency();
   const [search, setSearch] = useState("");
+  const [addFor, setAddFor] = useState<PositionItem | null>(null);
+  const [closeFor, setCloseFor] = useState<CloseTarget | null>(null);
+
+  function handleFilled() {
+    // Close modals BEFORE the portfolio refetch fires so a refetch
+    // error is never hidden behind an open dialog (prevention #125).
+    setAddFor(null);
+    setCloseFor(null);
+    portfolio.refetch();
+  }
 
   return (
     <div className="space-y-4">
@@ -40,9 +65,34 @@ export function PortfolioPage() {
             currency={currency}
             search={search}
             onSearchChange={setSearch}
+            onAdd={setAddFor}
+            onClose={setCloseFor}
           />
         </>
       )}
+
+      {addFor !== null ? (
+        <OrderEntryModal
+          isOpen
+          instrumentId={addFor.instrument_id}
+          symbol={addFor.symbol}
+          companyName={addFor.company_name}
+          valuationSource={addFor.valuation_source}
+          onRequestClose={() => setAddFor(null)}
+          onFilled={handleFilled}
+        />
+      ) : null}
+
+      {closeFor !== null ? (
+        <ClosePositionModal
+          isOpen
+          instrumentId={closeFor.instrumentId}
+          positionId={closeFor.trade.position_id}
+          valuationSource={closeFor.valuationSource}
+          onRequestClose={() => setCloseFor(null)}
+          onFilled={handleFilled}
+        />
+      ) : null}
     </div>
   );
 }
@@ -147,12 +197,16 @@ function PortfolioTable({
   currency,
   search,
   onSearchChange,
+  onAdd,
+  onClose,
 }: {
   positions: PositionItem[];
   mirrors?: PortfolioMirrorItem[];
   currency: string;
   search: string;
   onSearchChange: (v: string) => void;
+  onAdd: (p: PositionItem) => void;
+  onClose: (t: CloseTarget) => void;
 }) {
   const allRows: RowItem[] = [
     ...positions.map((p) => ({ kind: "position" as const, data: p })),
@@ -202,12 +256,19 @@ function PortfolioTable({
             <th className="px-2 py-2 text-right">Value</th>
             <th className="px-2 py-2 text-right">P&L</th>
             <th className="px-2 py-2 text-right">%</th>
+            <th className="px-2 py-2 text-right">Actions</th>
           </tr>
         </thead>
         <tbody>
           {filtered.map((row) =>
             row.kind === "position" ? (
-              <PositionRow key={`pos-${row.data.instrument_id}`} p={row.data} currency={currency} />
+              <PositionRow
+                key={`pos-${row.data.instrument_id}`}
+                p={row.data}
+                currency={currency}
+                onAdd={onAdd}
+                onClose={onClose}
+              />
             ) : (
               <MirrorRow key={`mir-${row.data.mirror_id}`} m={row.data} currency={currency} />
             ),
@@ -222,11 +283,26 @@ function PortfolioTable({
 // Position row — click navigates to /portfolio/:instrumentId
 // ---------------------------------------------------------------------------
 
-function PositionRow({ p, currency }: { p: PositionItem; currency: string }) {
+function PositionRow({
+  p,
+  currency,
+  onAdd,
+  onClose,
+}: {
+  p: PositionItem;
+  currency: string;
+  onAdd: (p: PositionItem) => void;
+  onClose: (t: CloseTarget) => void;
+}) {
   const navigate = useNavigate();
   const pct = pnlPct(p.unrealized_pnl, p.cost_basis);
   const positive = p.unrealized_pnl >= 0;
   const trades = p.trades ?? [];
+  // Close is only exposed when a single broker position backs the
+  // instrument. Aggregated positions defer to #314's detail panel,
+  // where per-broker-position rows get their own Close buttons.
+  const singleTrade: BrokerPositionItem | null =
+    trades.length === 1 && trades[0] !== undefined ? trades[0] : null;
 
   return (
     <tr
@@ -259,6 +335,37 @@ function PositionRow({ p, currency }: { p: PositionItem; currency: string }) {
         <span className={positive ? "text-emerald-600" : "text-red-600"}>
           {pct === null ? "—" : formatPct(pct)}
         </span>
+      </td>
+      <td className="px-2 py-2 text-right whitespace-nowrap">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAdd(p);
+          }}
+          aria-label={`Add to ${p.symbol}`}
+          className="mr-1 rounded border border-blue-300 bg-white px-2 py-0.5 text-xs font-medium text-blue-700 hover:bg-blue-50"
+        >
+          Add
+        </button>
+        {singleTrade !== null ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose({
+                instrumentId: p.instrument_id,
+                trade: singleTrade,
+                valuationSource: p.valuation_source,
+                symbol: p.symbol,
+              });
+            }}
+            aria-label={`Close ${p.symbol}`}
+            className="rounded border border-red-300 bg-white px-2 py-0.5 text-xs font-medium text-red-700 hover:bg-red-50"
+          >
+            Close
+          </button>
+        ) : null}
       </td>
     </tr>
   );
@@ -310,6 +417,8 @@ function MirrorRow({ m, currency }: { m: PortfolioMirrorItem; currency: string }
           {pct === null ? "—" : formatPct(pct)}
         </span>
       </td>
+      {/* No Actions for mirror rows — copy trading is a separate flow. */}
+      <td className="px-2 py-2" />
     </tr>
   );
 }

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -297,7 +297,7 @@ function PositionRow({
   const navigate = useNavigate();
   const pct = pnlPct(p.unrealized_pnl, p.cost_basis);
   const positive = p.unrealized_pnl >= 0;
-  const trades = p.trades ?? [];
+  const trades = p.trades;
   // Close is only exposed when a single broker position backs the
   // instrument. Aggregated positions defer to #314's detail panel,
   // where per-broker-position rows get their own Close buttons.

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -20,7 +20,6 @@ interface CloseTarget {
   instrumentId: number;
   trade: BrokerPositionItem;
   valuationSource: ValuationSource;
-  symbol: string;
 }
 
 /**
@@ -357,7 +356,6 @@ function PositionRow({
                 instrumentId: p.instrument_id,
                 trade: singleTrade,
                 valuationSource: p.valuation_source,
-                symbol: p.symbol,
               });
             }}
             aria-label={`Close ${p.symbol}`}


### PR DESCRIPTION
## Summary
- First PR of the product-visibility pivot (docs/settled-decisions.md:298).
- Exposes existing backend endpoints `POST /portfolio/orders` and `POST /portfolio/positions/{id}/close` via operator modals so a demo trade can be placed and closed from the UI.
- New components: `OrderEntryModal` (ADD flow), `ClosePositionModal` (full / partial), `DemoLivePill` (cached safety indicator). Wired into `PortfolioPage` via an Actions column.

## Why
Operator can now end-to-end place a demo ADD on a held position, and close (full or partial) a single-trade position, from the Portfolio page. Backend primitives already existed — the gap was pure frontend.

## Design
- Spec: `docs/superpowers/specs/2026-04-18-order-entry-modals-design.md` (Codex pre-spec approved over three passes; Codex pre-push flagged three additional issues, all fixed before push).
- Previews fetch `/portfolio/instruments/{id}` for native-currency context and carry `valuation_source` ("quote" vs "daily_close" vs "cost_basis"). Non-quote prices render in amber with a disclaimer; the preview caption names the open-rate fallback risk on close.
- On server success `onFilled` fires unconditionally (even if the modal was unmounted mid-submit via Escape) so the portfolio refetches whenever an order actually landed. Only `onRequestClose` is gated on `mountedRef`.
- Partial-close input enforces the backend's 1e-6 precision floor client-side.
- DemoLivePill follows `.claude/skills/frontend/safety-state-ui.md` literally: cache updates only on non-null fresh values; display is `fresh ?? cached`; stale marker renders when cache is the source.

## Scope / non-goals (pinned in spec §3)
- No new backend endpoints.
- No LIVE-trading UI. `enable_live_trading=false` in v1; backend returns 501 which surfaces verbatim.
- No new-instrument BUY launcher (ships with #316 instrument terminal).
- No stop-loss / take-profit / TSL / leverage UI.
- No multi-trade-position close on `PortfolioPage` — that's #314's detail panel.

## Test plan
- [x] `pnpm --dir frontend typecheck` — pass.
- [x] `pnpm --dir frontend test` — 211 pass (80+ new cases covering happy path, kill-switch 403, 404 on stale position, no-quote 422, network failure, `Infinity`/`NaN`/negative validation, partial-close precision floor, `daily_close` amber treatment, unmount-during-submit preserves `onFilled`).
- [x] `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright`, `uv run pytest` — all pass (no backend changes).
- [ ] Manual browser verification (auth-gated; operator to finish click-through before merge):
  - Click Add on a held position, enter an amount, submit, see portfolio row units increase.
  - Click Close on a single-trade position, choose Partial, enter 0.5 units, submit, see units decrease.
  - With kill switch active (Admin), confirm both Add and Close surface the exact 403 detail string.

## Settled-decisions alignment
- Demo-first, long-only, no leverage, no shorting — preserved.
- Execution guard + kill switch checks live server-side — frontend surfaces fixed-phrase errors verbatim.
- Close-position safety invariant (`app/api/orders.py:14-17`): this PR is the operator UI path it names.

## Prevention-log alignment
- #127 API shape drift: `types.ts` additions mirror Pydantic field-for-field.
- #127 unmounted setState: `mountedRef` guards every post-await `setState`.
- #125 refresh swallowed by overlay: modals close before `portfolio.refetch()` in the `handleFilled` path.
- #236 `Number.isFinite` for numeric validation.
- #236 Literal types on API fields (`OrderAction`).
- safety-state-ui.md: `DemoLivePill` uses the cached pattern.

## Tech debt filed alongside
- `GET /portfolio/instruments/{iid}/quote-for-order` returning raw `quotes.last` + native currency, so the preview can mirror the order endpoints' price source exactly. Spec §7.4 residual gap. (Tracked for a follow-up issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)