### PR TITLE
feat(#314): portfolio workstation — selection, detail panel, keyboard

### DIFF
--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -815,3 +815,30 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: A submit handler's early-return guard checked only a subset of the conditions that `canSubmit` already enforced — e.g. partial-close handler checked `units > 0` but not `units <= trade.units` or `units >= MIN_UNITS`. Under the current call site the submit button is always disabled when any of those fail, so the gap is invisible in practice. A programmatic call (test, future caller that reuses the submit path without the button), or a future refactor that inlines the handler into a different trigger, would skip those additional constraints and POST an invalid payload the backend rejects with a confusing message.
 - Prevention: In any handler whose validity is already computed as a `canSubmit` boolean for the button's `disabled` state, the handler's own early-return guard MUST be a strict superset of `canSubmit`'s conditions, OR use `if (!canSubmit) return` as a single gate. Defence-in-depth is cheap; divergence between the UI gate and the submit path is a class of bug that hides until a future caller lands. Grep `async function handleSubmit` in modal files and compare the return guards to the `canSubmit` expression at the top of the component.
 - Enforced in: this prevention log; `frontend/src/components/orders/ClosePositionModal.tsx` (`handleSubmit` now re-checks `MIN_UNITS` and `<= trade.units`)
+
+---
+
+### Duplicate structurally-identical types declared in sibling files
+
+- First seen in: #321
+- Symptom: `CloseTarget` was declared in `PortfolioPage.tsx` and a sibling `CloseTargetInPanel` interface was declared in `DetailPanel.tsx` with the same fields. The code compiled because TypeScript resolves matching structural shapes, but the two types could drift — adding a field to one without the other, or changing a type, would silently break the prop wire while `tsc` stayed green (until the actual divergent field was read).
+- Prevention: When two modules need to name the same shape — e.g. a page passes a target object to a child component and the child destructures it — export the interface from one file and import it in the other. Never declare the same shape twice. Before pushing any PR that adds a new cross-component type, `grep -rn "interface <Name>" frontend/src` should return exactly one match per unique name.
+- Enforced in: this prevention log; `frontend/src/components/portfolio/DetailPanel.tsx` exports `CloseTarget`; `frontend/src/pages/PortfolioPage.tsx` imports it.
+
+---
+
+### Hint / warning state with no clear-on-next-transition
+
+- First seen in: #321
+- Symptom: A `hint` state was set when the operator pressed `c` on a multi-trade position, displaying a one-line warning. It was never cleared on any subsequent transition (selection change, successful `b`/`c`, `Esc`), so the warning persisted through unrelated actions and looked live even when it was stale.
+- Prevention: Any transient operator-facing hint / toast / warning state must have a clear path tied to every transition that could invalidate it. For a hint tied to a keyboard action, clear it in: (a) the same action's success branch, (b) the opposite action's branch, (c) any selection change, (d) the `Esc` reset. Grep `setHint` / `setWarning` / `setNotice` in any new component and verify each state setter has corresponding clear calls — one set = at least one matching clear on every relevant transition.
+- Enforced in: this prevention log; `frontend/src/pages/PortfolioPage.tsx` (`setHint(null)` now fires on row click, `Esc`, successful `b`, successful single-trade `c`, and selection changes via keyboard).
+
+---
+
+### Stale closure over derived state in window-level keyboard handlers
+
+- First seen in: #321
+- Symptom: A `useEffect` attached a `keydown` listener to `window` and read both `pageRows` and `focusedIdx` from the closure. The deps array included both, so React re-ran the effect on every change — but a rapid key sequence (`j` then `Enter` in the same microtask, a future batched update, or a test harness that flushes without a render between events) could invoke the listener with a stale `pageRows[focusedIdx]` combination from an earlier render. `setState` updater form protects the *setter*, but `setState(prev => ...)` does nothing for *reading* other state in the same handler.
+- Prevention: In any `useEffect` that attaches a listener to a shared surface (`window`, `document`, a ref target), each piece of state the listener reads without using the updater form should be carried in a ref that is written on every render (`ref.current = value` at top level of the component body). The effect body then reads `ref.current`, which always has the freshest value. Grep `window.addEventListener` in components and verify every non-setter read of state goes through a ref.
+- Enforced in: this prevention log; `frontend/src/pages/PortfolioPage.tsx` (`focusedIdxRef` + `pageRowsRef` synced on every render).

--- a/docs/superpowers/specs/2026-04-18-portfolio-workstation-design.md
+++ b/docs/superpowers/specs/2026-04-18-portfolio-workstation-design.md
@@ -1,0 +1,318 @@
+# P0-2 Portfolio workstation — design spec
+
+**Issue:** [#314](https://github.com/Luke-Bradford/eBull/issues/314)
+**Plan:** `docs/superpowers/plans/2026-04-18-product-visibility-pivot.md`
+**Size:** M (~2 days, frontend only)
+**Depends on:** #313 (shipped in #319) — reuses `OrderEntryModal`, `ClosePositionModal`, `DemoLivePill`.
+**Blocks:** #316 (instrument terminal reuses the detail panel's thesis/filing/score components).
+
+---
+
+## 1. Goal
+
+Turn `PortfolioPage` from a report (click row → navigate away → back) into a workbench: one click selects a row, the detail panel populates inline with position data + thesis + filings + score + action buttons, and keyboard navigation lets the operator move through the list without the mouse.
+
+Vision-check: yes — operator "manages their fund from this screen" without ever leaving it for the golden paths (review, Add, Close).
+
+## 2. Backend contract (all endpoints already exist)
+
+No backend changes. Detail-panel sources:
+
+- `GET /portfolio` — `fetchPortfolio()` already loaded on the page. Provides `PositionItem.trades: BrokerPositionItem[]` in DISPLAY currency. The detail panel's broker-position table reuses these rows verbatim (no extra fetch from the panel).
+- `GET /theses/{id}` — `fetchLatestThesis(instrumentId)`. Returns `ThesisDetail` with valuation fields in NATIVE currency (no currency field on the response).
+- `GET /filings/{id}` — `fetchFilings(instrumentId, offset, limit)`. `FilingItem` fields: `filing_date`, `filing_type`, `provider`, `extracted_summary`, `red_flag_score`, URLs. No `title` field.
+- `GET /rankings/history/{id}` — `fetchScoreHistory(instrumentId, limit)`.
+
+The detail panel deliberately does NOT call `GET /portfolio/instruments/{id}` — the modals from #313 already fetch that on open for native-currency preview, and having the panel duplicate the fetch on every selection change would halve the cache hit rate and confuse the spec's "panel uses display currency, modal uses native" boundary.
+
+Each call 404s if the instrument has no data. We treat 404 as an empty state, not an error (mirrors `InstrumentDetailPage.tsx:160`).
+
+### Currency contract (pinned)
+
+- Position snapshot, broker-position rows: rendered in **display currency** from `PositionItem` / `BrokerPositionItem`.
+- Score total + sub-scores: dimensionless numbers from `ScoreHistoryItem`. Rendered via `formatNumber`, never via `formatMoney`.
+- Thesis valuation fields (buy-zone low/high, bull/base/bear values): rendered as **bare numbers with no currency symbol**, with a small caption `"(in instrument's native currency)"` under the block. Rationale: `ThesisDetail` does not carry a currency field and we are not fetching `/portfolio/instruments/{id}` in the panel (see above). The full `InstrumentDetailPage` already formats these with native currency; the detail panel is a summary, the full page is the source of truth for formatting.
+
+## 3. Non-goals (drop aggressively)
+
+- **No URL-driven selection.** Selected row lives in in-memory page state for v1. Deep-linking (`?selected=42`) is a nice-to-have that adds router complexity and race conditions; deferred to a follow-up if an operator asks for it.
+- **No dual-pane for mirror rows.** Clicking a mirror row still navigates to `/copy-trading/{id}` — copy-trading is a separate execution surface with different data needs. The workstation is for directly-held positions.
+- **No inline thesis editing, no inline order-type switching, no drag-resize panels.** Thesis is read-only in the panel; for anything else the operator clicks "View Research" and drops into the full `InstrumentDetailPage`.
+- **No keyboard-shortcut help overlay.** Shortcuts are documented in the spec and a small label bar at the bottom of the detail panel. A modal cheat-sheet is deferred.
+- **No virtualized table.** Pagination handles >50 rows. Virtualization is premature until we have thousands of holdings.
+- **No column show/hide, no per-operator layout persistence.** Later PR.
+- **No news panel.** Present on `InstrumentDetailPage` but the workstation trades panel real estate for thesis + filings + score — the three signals that drive an exit decision. News stays on the drill-through page.
+- **No "close all" for aggregated positions.** If `trades.length > 1`, the detail panel now exposes per-broker-position rows each with their own `Close` button — that covers the scope that was deferred in #313. A "close every broker position for this instrument" macro button would be an unsafe one-click bulk action in a product whose `EXIT` semantics are still being hardened; skipped.
+
+## 4. Layout
+
+Split-pane on `≥lg` breakpoints (≥1024px wide), stacked on smaller screens.
+
+```
+┌───────────────────────────────────┬──────────────────────────┐
+│ SummaryBar (AUM / P&L / …)        │                          │
+├───────────────────────────────────┤                          │
+│ Search + shortcut hint            │  DetailPanel             │
+├───────────────────────────────────┤   (selectedInstrumentId) │
+│ PortfolioTable (selectable rows)  │                          │
+│                                   │                          │
+│ [Pagination controls]             │                          │
+└───────────────────────────────────┴──────────────────────────┘
+```
+
+- Left pane: 60% width at ≥lg. Full width below.
+- Right pane: 40% width at ≥lg. Stacks below the table on narrow screens.
+- DetailPanel renders a placeholder when no row is selected: `"Select a position to see its detail."`.
+
+## 5. File plan
+
+### New files
+
+- `frontend/src/components/portfolio/DetailPanel.tsx` — right-pane container, drives thesis/filings/score sections.
+- `frontend/src/components/portfolio/PositionSummary.tsx` — left-of-detail-panel, the held-position snapshot.
+- `frontend/src/components/portfolio/BrokerPositionsTable.tsx` — per-broker-position rows with individual Close buttons.
+- `frontend/src/components/portfolio/ThesisBlock.tsx` — condensed thesis block (stance, confidence, buy-zone, memo preview).
+- `frontend/src/components/portfolio/ScoreBlock.tsx` — latest score card with sub-scores.
+- `frontend/src/components/portfolio/FilingsBlock.tsx` — latest 3 filings.
+- `frontend/src/components/portfolio/DetailPanel.test.tsx`
+- `frontend/src/components/portfolio/BrokerPositionsTable.test.tsx`
+- `frontend/src/pages/PortfolioPage.test.tsx` — first test file for this page; covers table interaction, selection state, keyboard nav, pagination, modal wiring.
+
+### Modified files
+
+- `frontend/src/pages/PortfolioPage.tsx` — adopt split layout, selected-row state, keyboard handler, pagination. Drop the row-click `useNavigate` for position rows (replace with select). Mirror rows keep their navigate behaviour.
+
+### Unchanged files
+
+- `frontend/src/api/*.ts` — no new fetchers.
+- `frontend/src/api/types.ts` — no new types.
+- All existing `OrderEntryModal` / `ClosePositionModal` / `DemoLivePill` code from #313.
+
+Estimated ~9 files new + 1 modified, ~900 LoC including tests.
+
+## 6. Selected-row state + derived slices
+
+Page state:
+
+```ts
+const [selectedId, setSelectedId] = useState<number | null>(null);
+const [focusedIdx, setFocusedIdx] = useState<number>(0);
+const [search, setSearch] = useState<string>("");
+const [page, setPage] = useState<number>(1);
+const PAGE_SIZE = 50;
+```
+
+Derived, in render:
+
+```ts
+// allRows: positions + mirrors, sorted by value (unchanged from today).
+// visible: allRows filtered by search. Used for pagination + keyboard nav.
+// pageRows: visible slice for the current page.
+// totalPages: Math.max(1, Math.ceil(visible.length / PAGE_SIZE)).
+// selectedPosition: portfolio.data.positions.find(p => p.instrument_id === selectedId) ?? null
+//   — pulled from the UNFILTERED positions list so the detail panel keeps rendering
+//   when the operator narrows the search.
+```
+
+Clamp invariants enforced in effects:
+
+```ts
+// When `visible.length` changes (search, pagination), clamp focusedIdx.
+useEffect(() => {
+  if (pageRows.length === 0) return;           // keep focusedIdx unchanged; `j`/`k` are no-ops (§8)
+  setFocusedIdx((i) => Math.min(Math.max(i, 0), pageRows.length - 1));
+}, [pageRows.length]);
+
+// When the current page exceeds totalPages (e.g. search shrinks results
+// below the current page), clamp page back into range.
+useEffect(() => {
+  if (page > totalPages) setPage(totalPages);
+}, [page, totalPages]);
+```
+
+Edge cases pinned:
+
+- **Zero rows visible** (`pageRows.length === 0`): detail panel still renders for the last `selectedId`; the table renders a `"No positions match your search."` empty state; `j`/`k`/`Enter` are no-ops until rows return.
+- **Selected row filtered out**: `selectedPosition` is derived from `portfolio.data.positions` (unfiltered), so the detail panel keeps the operator's last choice visible. Clearing search brings the row back into the left pane.
+- **Page clamp**: shrinking `visible` below the current page resets the page to the last valid page; never leaves the UI showing an empty page while rows exist.
+- **Stale selection after `/portfolio` refetch**: if the operator fully closes a position, `portfolio.refetch()` (fired from `handleFilled`) drops that instrument from `portfolio.data.positions`. `selectedPosition` is derived via `find` and becomes `null`. We clear the stale `selectedId` in a `useEffect([portfolio.data])` so the detail panel collapses back to the placeholder rather than silently hiding behind `selectedId !== null` gates:
+
+```ts
+useEffect(() => {
+  if (selectedId === null) return;
+  if (portfolio.data === null) return; // still loading — do nothing
+  const stillExists = portfolio.data.positions.some(
+    (p) => p.instrument_id === selectedId,
+  );
+  if (!stillExists) setSelectedId(null);
+}, [portfolio.data, selectedId]);
+```
+
+`b` and `c` are additionally gated on `selectedPosition !== null` at the handler level so that a stale `selectedId` between a `/portfolio` refetch and the clamp effect's flush cannot open a modal with a ghost position. `Enter` is unaffected — it promotes `focusedIdx` to `selectedId` based on the currently-visible `pageRows[focusedIdx]`, which is always a real row.
+
+Mirror rows remain row-click-to-navigate (§3). They are never selectable via `selectedId` because the detail panel is for held-instrument data, not for a copy-trading summary.
+
+## 7. DetailPanel
+
+### Props
+
+```ts
+interface DetailPanelProps {
+  readonly selectedPosition: PositionItem | null;
+  readonly currency: string; // display currency for the header stats
+  readonly onAdd: (p: PositionItem) => void;
+  readonly onCloseTrade: (t: CloseTarget) => void;
+  readonly onViewResearch: (instrumentId: number) => void;
+}
+```
+
+No `isOpen` / `onRequestClose` — it's always visible in the right pane, the data inside swaps when `selectedPosition` changes.
+
+### Composition
+
+`DetailPanel` fetches via `useAsync` keyed on `selectedPosition?.instrument_id`:
+
+- `thesis = useAsync(() => fetchLatestThesis(id), [id])`
+- `filings = useAsync(() => fetchFilings(id, 0, 3), [id])`
+- `scores = useAsync(() => fetchScoreHistory(id, 5), [id])`
+
+Each block renders its own loading / error / empty state (per `async-data-loading.md` — one error surface, one retry button per source). 404s are treated as "no data yet" empty states, not errors.
+
+When `selectedPosition === null`, the panel renders only the placeholder `"Select a position to see its detail."` and skips all fetches (conditional rendering of the fetch-driving components, per the mount-on-open pattern we used in #313 modals).
+
+### Sections (top → bottom)
+
+1. **Header**: `{symbol} · {company_name}` + `Add` button + `View Research` link.
+2. **Position snapshot** (`PositionSummary`): units, avg cost, market value, P&L — in display currency, pulled from `selectedPosition` (no fetch needed).
+3. **Broker positions** (`BrokerPositionsTable`): always rendered; shows 1-N rows from `selectedPosition.trades` (display currency — same as the rest of the portfolio page). Each row has a `Close` button that fires `onCloseTrade`. This covers the aggregated-position close gap flagged during #313.
+4. **Thesis** (`ThesisBlock`): stance, confidence, buy-zone low/high, bull/base/bear values, first ~300 chars of `memo_markdown`, and a `Read full thesis →` link to `/instruments/{id}` (the research page — NOT `/portfolio/{id}`, which is the native-currency drill-through). Valuation numbers render as plain numbers with a small caption `"(in instrument's native currency)"` since `ThesisDetail` does not carry a currency field and the panel does not fetch native context (§2).
+5. **Latest score** (`ScoreBlock`): total + 5 sub-scores (quality, value, turnaround, momentum, sentiment) from the newest `ScoreHistoryItem`.
+6. **Filings** (`FilingsBlock`): latest 3 filings showing `filing_date`, `filing_type`, and a one-line excerpt from `extracted_summary` (truncated to ~80 chars with ellipsis). `FilingItem` has no title field — `extracted_summary` is the human-readable line. If `extracted_summary` is null, render `"(no summary — open filing for details)"` with a link to `source_url` or `primary_document_url`.
+
+Bottom label bar shows keyboard hints: `/ search · j/k move · Enter select · Esc clear · b Add · c Close`.
+
+## 8. Keyboard navigation
+
+### Focus + handler strategy
+
+Keyboard shortcuts must work regardless of where browser focus sits (e.g. right after the page loads, or after the operator clicks anywhere inside the table). We attach the handler to `document` via `useEffect` + `window.addEventListener("keydown", ...)`, not to the container's `onKeyDown`. Rationale: `<tr>` elements are not focusable by default and making them focusable just for keyboard routing creates a whole tab-order story we do not need for v1. A window listener is simpler, matches how `InstrumentDetailPage.test.tsx` and other existing pages dispatch keyboard events in tests, and the gate conditions below keep the handler narrowly scoped.
+
+Tests must exercise the shortcuts via `userEvent.keyboard(...)` both before any row click and after a row click, to pin that the listener does not depend on row focus.
+
+### Gate
+
+The handler fires UNLESS:
+
+1. `document.activeElement` is an `input`, `textarea`, `select`, or `[contenteditable]` — EXCEPT the `Esc` key, which is always processed (special-case) so it can blur the search box.
+2. A modal is open (`addFor !== null || closeFor !== null`).
+3. A modifier key is held (`Ctrl`, `Meta`, `Alt`) — keeps browser shortcuts like Ctrl+R untouched.
+
+Shortcuts:
+
+| Key | Action |
+|---|---|
+| `/` | Focus the search box; `preventDefault` so the `/` does not land in the input as its first character. |
+| `j` | `focusedIdx = min(focusedIdx + 1, pageRows.length - 1)`. No-op when `pageRows.length === 0`. |
+| `k` | `focusedIdx = max(focusedIdx - 1, 0)`. No-op when `pageRows.length === 0`. |
+| `Enter` | `setSelectedId(pageRows[focusedIdx].instrument_id)` (positions only; no-op on mirror rows and when the page is empty). |
+| `Esc` | If the search input is focused, blur it AND clear the search string. Otherwise `setSelectedId(null); setFocusedIdx(0)`. Processed regardless of the input-focused gate (special-case above). |
+| `b` | If `selectedPosition !== null`, open the Add modal for it. No-op otherwise (includes the stale-selection window between a `/portfolio` refetch and the clamp effect). |
+| `c` | If `selectedPosition !== null` AND `selectedPosition.trades.length === 1`, open the Close modal for that trade. If `trades.length > 1`, render a one-line hint `"Close requires a single broker position — use the detail panel."` in a non-intrusive spot (top of the table). Otherwise no-op. |
+
+Visual focus indicator: the row at `focusedIdx` renders a 2px left border and `bg-slate-100`. The row at `selectedId` renders a stronger `bg-blue-50` and a left border in blue. Both can be present simultaneously.
+
+### Interaction with the existing mouse path
+
+- Clicking a position row: sets both `selectedId` and `focusedIdx` to that row.
+- Clicking an Action button (`Add` / `Close`) inside a row: same as before — `stopPropagation` + open the modal, without changing selection (selection is only about the detail panel).
+- Clicking outside rows does NOT clear selection (Esc does).
+
+## 9. Pagination
+
+Trigger: `visible.length > 50` after search filtering.
+
+UI: simple `← Prev | Page N of M | Next →` footer under the table. `Prev` / `Next` disabled at the bounds. No jump-to-page input; no per-page size selector.
+
+`selectedId` persists across page changes (the detail panel stays populated even if the selected row is no longer visible on the current page). `focusedIdx` resets to 0 on page change.
+
+## 10. Integration with modals from #313
+
+The existing `addFor` / `closeFor` page-level state and `handleFilled` logic from #313 is preserved verbatim. New callers:
+
+- `DetailPanel.onAdd` → `setAddFor(selectedPosition)`.
+- `DetailPanel.onCloseTrade` → `setCloseFor({ instrumentId, trade, valuationSource })`.
+- Keyboard `b` / `c` → same setters, sourced from `selectedPosition` + (for `c`) its single `trades[0]`.
+
+Modals continue to mount conditionally (`{addFor !== null ? <OrderEntryModal ...> : null}`). No changes to modal component code.
+
+## 11. Test plan (`PortfolioPage.test.tsx`)
+
+First test file for this page. Covers:
+
+- **Split layout**: renders DetailPanel placeholder when nothing selected.
+- **Row click selects**: click position row → detail panel loads with `fetchLatestThesis`, `fetchFilings`, `fetchScoreHistory` called with `instrumentId`.
+- **Mirror row navigates**: click mirror row → `useNavigate` fired with `/copy-trading/{mirror_id}`; no detail-panel fetches.
+- **`/ focuses search**: keydown `/` moves focus to the search input; `/` does not appear in the input.
+- **`j/k` moves focus ring**: starting at `focusedIdx=0`, two `j` keydowns move the ring to index 2.
+- **`Enter` selects**: keydown `Enter` promotes focused row into `selectedId`.
+- **`Esc` clears**: with `selectedId=X`, Esc sets `selectedId=null` and collapses the detail panel to placeholder.
+- **`b` opens Add modal**: with `selectedId=X`, `b` keydown opens `OrderEntryModal` with the correct instrument id.
+- **`c` opens Close modal only on single-trade**: with `trades.length === 1`, `c` opens modal; with `trades.length > 1`, `c` is a no-op and a hint line renders `"Close requires a single broker position — use the detail panel."`.
+- **Modal open suppresses shortcuts**: with `addFor !== null`, pressing `b` or `c` is a no-op (the modal owns keyboard focus).
+- **Input focus suppresses shortcuts**: typing in the search box does not trigger `j/k/b/c`.
+- **Pagination**: with 51 positions, page 1 shows 50 rows, page 2 shows 1; selectedId persists across pages.
+- **Pagination clamp**: with 51 positions and `page=2`, if search filters results to 10 rows, `page` clamps back to 1 and rows render (no empty page-2 with rows available on page-1).
+- **Selected row persists when filtered out**: select row X, type a search that excludes X. Detail panel keeps rendering X's data. Clear search → X reappears in the table, still selected.
+- **Stale selection cleared after refetch**: select row X, simulate a `/portfolio` refetch whose response no longer contains X (position fully closed). `selectedId` clears, detail panel collapses to placeholder, and `b` / `c` keydowns are no-ops until a new row is selected.
+- **Keyboard works before first click**: first render → no row clicked → `j` still moves the focus ring. Confirms the window listener does not depend on any element having focus.
+- **Esc clears search when focused**: focus the search input, type "APPL", press Esc → input blurs AND search string is cleared.
+- **Detail-panel 404**: thesis fetch throws `ApiError(404, ...)` → thesis section renders empty state, not error (matches `InstrumentDetailPage` convention).
+- **Detail-panel all-errors fallback**: if thesis, filings, AND scores all fail with non-404, render each section's error independently; do NOT fire a page-level banner (per `async-data-loading.md`: top banner is reserved for "ALL sources failed", and `/portfolio` itself is still loaded).
+
+Component-level tests for `DetailPanel`, `BrokerPositionsTable`: simpler shape tests for row rendering, action wiring, empty states.
+
+## 12. Settled-decisions alignment
+
+- **Close-position safety invariant** (`app/api/orders.py:14-17`): preserved — per-broker-position Close buttons route through the existing `ClosePositionModal` → `POST /portfolio/positions/{id}/close` path. Still operator-UI-only.
+- **Demo-first** / **long-only**: unchanged — we are not adding any new execution path.
+- **Product-visibility pivot** (`docs/settled-decisions.md:298`): this PR is P0-2, the second in the sequence.
+
+## 13. Prevention-log alignment
+
+| Entry | Honored by |
+|---|---|
+| async-data-loading: one error per source | §7 each block handles own loading/error; no page-level gate spans thesis/filings/scores |
+| async-data-loading: top banner only for all-failed | `/portfolio` itself is the only source gating the page-level error; sub-section errors stay inline |
+| safety-state-ui: cache | inherited from #313's `DemoLivePill`; not re-derived here |
+| #135 positional/unscoped test selectors | page tests use `getByRole("row", { name: ... })` scoped selectors |
+| #319 `canSubmit` loading guard | inherited from #313 modals; detail-panel has no submit buttons of its own |
+
+## 14. Rollout + verification
+
+Before push:
+
+1. `pnpm --dir frontend typecheck` / `test` pass.
+2. `uv run ruff check .`, `ruff format --check`, `pyright`, `pytest` — no-ops but run.
+
+Browser verify (operator):
+
+3. Load `/portfolio`. Click a row → detail panel populates.
+4. Type `/`, type query, `Esc`, `j` / `k`, `Enter`, `b`, `c` — verify each shortcut.
+5. On a multi-trade position, use the per-broker-position table's Close button.
+6. Verify pagination appears when >50 positions exist (may need a dev-seed).
+
+## 15. Open questions
+
+None.
+
+## 16. Reviewer cheat-sheet
+
+- [ ] `PortfolioPage` keyboard handler is gated on `!input-focused && !modal-open && !modifier`; every test covers each gate.
+- [ ] Detail panel's fetches are only wired when `selectedPosition !== null` (no idle traffic on empty state).
+- [ ] Each DetailPanel source owns its own loading / error / empty state; no combined gates.
+- [ ] 404s from thesis / filings / scores render empty states, not errors.
+- [ ] `c` keyboard shortcut is a no-op on multi-trade positions with a visible hint.
+- [ ] Pagination does NOT clear `selectedId`.
+- [ ] Mirror rows are unchanged (still navigate on click, not selectable).
+- [ ] No new backend endpoints; no changes to existing modals.
+- [ ] Per-broker-position Close buttons in the detail panel preserve the `stopPropagation` discipline.

--- a/frontend/src/components/portfolio/DetailPanel.tsx
+++ b/frontend/src/components/portfolio/DetailPanel.tsx
@@ -1,0 +1,521 @@
+/**
+ * DetailPanel — right pane of the portfolio workstation (#314).
+ *
+ * Renders the operator's selected position in four blocks:
+ *   1. Header (symbol + company name, Add button, View Research link)
+ *   2. Position snapshot + per-broker-position rows with Close buttons
+ *   3. Latest thesis (stance, confidence, buy-zone, memo preview)
+ *   4. Latest score (total + 5 sub-scores) and latest 3 filings
+ *
+ * Data sources:
+ *   - Position data reuses `selectedPosition` from the already-loaded
+ *     /portfolio response (display currency).
+ *   - Thesis / filings / scores each fetched via useAsync on the
+ *     `instrument_id` change — 404s render empty states, not errors.
+ *   - Thesis valuation fields are NATIVE currency; we render them as
+ *     plain numbers with a caption since ThesisDetail has no currency
+ *     field and we deliberately do not fetch /portfolio/instruments/{id}
+ *     here (the modals already do, and doubling the fetch blurs the
+ *     panel/modal currency-boundary — see spec §2).
+ */
+import { Link } from "react-router-dom";
+
+import { ApiError } from "@/api/client";
+import { fetchFilings } from "@/api/filings";
+import { fetchScoreHistory } from "@/api/scoreHistory";
+import { fetchLatestThesis } from "@/api/theses";
+import {
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import {
+  formatDate,
+  formatMoney,
+  formatNumber,
+  formatPct,
+  pnlPct,
+} from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+import type {
+  BrokerPositionItem,
+  FilingItem,
+  PositionItem,
+  ScoreHistoryItem,
+  ThesisDetail,
+} from "@/api/types";
+
+type ValuationSource = "quote" | "daily_close" | "cost_basis";
+
+export interface CloseTargetInPanel {
+  readonly instrumentId: number;
+  readonly trade: BrokerPositionItem;
+  readonly valuationSource: ValuationSource;
+}
+
+export interface DetailPanelProps {
+  readonly selectedPosition: PositionItem | null;
+  readonly currency: string;
+  readonly onAdd: (p: PositionItem) => void;
+  readonly onCloseTrade: (t: CloseTargetInPanel) => void;
+}
+
+export function DetailPanel({
+  selectedPosition,
+  currency,
+  onAdd,
+  onCloseTrade,
+}: DetailPanelProps): JSX.Element {
+  if (selectedPosition === null) {
+    return (
+      <aside className="hidden rounded-md border border-slate-200 bg-white p-4 text-sm text-slate-500 shadow-sm lg:block">
+        Select a position to see its detail.
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="space-y-3 rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+      <Header
+        position={selectedPosition}
+        onAdd={() => onAdd(selectedPosition)}
+      />
+      <PositionSummary position={selectedPosition} currency={currency} />
+      <BrokerPositionsTable
+        position={selectedPosition}
+        currency={currency}
+        onCloseTrade={onCloseTrade}
+      />
+      <ThesisSection instrumentId={selectedPosition.instrument_id} />
+      <ScoreSection instrumentId={selectedPosition.instrument_id} />
+      <FilingsSection instrumentId={selectedPosition.instrument_id} />
+    </aside>
+  );
+}
+
+function Header({
+  position,
+  onAdd,
+}: {
+  position: PositionItem;
+  onAdd: () => void;
+}): JSX.Element {
+  return (
+    <header className="flex items-start justify-between gap-2">
+      <div>
+        <h2 className="text-base font-semibold text-slate-800">
+          {position.symbol}
+        </h2>
+        <p className="text-xs text-slate-500">{position.company_name}</p>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <button
+          type="button"
+          onClick={onAdd}
+          aria-label={`Add to ${position.symbol}`}
+          className="rounded border border-blue-300 bg-white px-2 py-0.5 text-xs font-medium text-blue-700 hover:bg-blue-50"
+        >
+          Add
+        </button>
+        <Link
+          to={`/instruments/${position.instrument_id}`}
+          className="text-xs font-medium text-blue-700 hover:underline"
+        >
+          View research →
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+function PositionSummary({
+  position,
+  currency,
+}: {
+  position: PositionItem;
+  currency: string;
+}): JSX.Element {
+  const pct = pnlPct(position.unrealized_pnl, position.cost_basis);
+  const positive = position.unrealized_pnl >= 0;
+  return (
+    <div className="grid grid-cols-2 gap-x-4 gap-y-1 rounded border border-slate-200 bg-slate-50 p-2 text-xs sm:grid-cols-4">
+      <Stat label="Units" value={formatNumber(position.current_units, 6)} />
+      <Stat
+        label="Avg cost"
+        value={position.avg_cost !== null ? formatMoney(position.avg_cost, currency) : "—"}
+      />
+      <Stat
+        label="Market value"
+        value={formatMoney(position.market_value, currency)}
+      />
+      <Stat
+        label="P&L"
+        value={
+          <>
+            <span className={positive ? "text-emerald-700" : "text-red-700"}>
+              {formatMoney(position.unrealized_pnl, currency)}
+            </span>
+            {pct !== null ? (
+              <span className="ml-1 text-[11px] text-slate-500">
+                ({formatPct(pct)})
+              </span>
+            ) : null}
+          </>
+        }
+      />
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}): JSX.Element {
+  return (
+    <div>
+      <div className="text-[10px] font-medium uppercase tracking-wider text-slate-400">
+        {label}
+      </div>
+      <div className="tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+export function BrokerPositionsTable({
+  position,
+  currency,
+  onCloseTrade,
+}: {
+  position: PositionItem;
+  currency: string;
+  onCloseTrade: (t: CloseTargetInPanel) => void;
+}): JSX.Element {
+  const trades = position.trades;
+  if (trades.length === 0) {
+    return (
+      <p className="text-xs text-slate-500">
+        No broker positions for this instrument.
+      </p>
+    );
+  }
+  return (
+    <div className="rounded border border-slate-200">
+      <table className="w-full text-xs">
+        <thead className="bg-slate-50 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+          <tr>
+            <th className="px-2 py-1 text-left">Position #</th>
+            <th className="px-2 py-1 text-right">Units</th>
+            <th className="px-2 py-1 text-right">Open rate</th>
+            <th className="px-2 py-1 text-right">P&L</th>
+            <th className="px-2 py-1 text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {trades.map((t) => (
+            <BrokerRow
+              key={t.position_id}
+              trade={t}
+              instrumentId={position.instrument_id}
+              valuationSource={position.valuation_source}
+              currency={currency}
+              onCloseTrade={onCloseTrade}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function BrokerRow({
+  trade,
+  instrumentId,
+  valuationSource,
+  currency,
+  onCloseTrade,
+}: {
+  trade: BrokerPositionItem;
+  instrumentId: number;
+  valuationSource: ValuationSource;
+  currency: string;
+  onCloseTrade: (t: CloseTargetInPanel) => void;
+}): JSX.Element {
+  const positive = trade.unrealized_pnl >= 0;
+  return (
+    <tr className="border-t border-slate-100">
+      <td className="px-2 py-1 text-left text-slate-600">{trade.position_id}</td>
+      <td className="px-2 py-1 text-right tabular-nums">
+        {formatNumber(trade.units, 6)}
+      </td>
+      <td className="px-2 py-1 text-right tabular-nums">
+        {formatMoney(trade.open_rate, currency)}
+      </td>
+      <td
+        className={`px-2 py-1 text-right tabular-nums ${
+          positive ? "text-emerald-700" : "text-red-700"
+        }`}
+      >
+        {formatMoney(trade.unrealized_pnl, currency)}
+      </td>
+      <td className="px-2 py-1 text-right">
+        <button
+          type="button"
+          onClick={() =>
+            onCloseTrade({ instrumentId, trade, valuationSource })
+          }
+          aria-label={`Close position ${trade.position_id}`}
+          className="rounded border border-red-300 bg-white px-2 py-0.5 text-[11px] font-medium text-red-700 hover:bg-red-50"
+        >
+          Close
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+function ThesisSection({ instrumentId }: { instrumentId: number }): JSX.Element {
+  const thesis = useAsync(
+    () => fetchLatestThesis(instrumentId),
+    [instrumentId],
+  );
+  return (
+    <section className="rounded border border-slate-200 p-2">
+      <h3 className="mb-1 text-xs font-semibold uppercase tracking-wider text-slate-600">
+        Latest thesis
+      </h3>
+      {thesis.loading ? (
+        <SectionSkeleton rows={3} />
+      ) : thesis.error ? (
+        isNotFound(thesis.error) ? (
+          <EmptyState
+            title="No thesis yet"
+            description="Runs will appear here after the thesis engine processes this instrument."
+          />
+        ) : (
+          <SectionError onRetry={thesis.refetch} />
+        )
+      ) : thesis.data !== null ? (
+        <ThesisBody thesis={thesis.data} instrumentId={instrumentId} />
+      ) : null}
+    </section>
+  );
+}
+
+function ThesisBody({
+  thesis,
+  instrumentId,
+}: {
+  thesis: ThesisDetail;
+  instrumentId: number;
+}): JSX.Element {
+  const preview = memoPreview(thesis.memo_markdown, 300);
+  return (
+    <div className="space-y-1 text-xs">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[11px] font-medium text-slate-700">
+          {thesis.stance}
+        </span>
+        <span className="text-slate-500">{thesis.thesis_type}</span>
+        {thesis.confidence_score !== null ? (
+          <span className="text-slate-500">
+            confidence {formatNumber(thesis.confidence_score, 2)}
+          </span>
+        ) : null}
+      </div>
+      {(thesis.buy_zone_low !== null ||
+        thesis.buy_zone_high !== null ||
+        thesis.bull_value !== null ||
+        thesis.base_value !== null ||
+        thesis.bear_value !== null) && (
+        <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-[11px] tabular-nums text-slate-600 sm:grid-cols-5">
+          <Stat
+            label="Buy low"
+            value={thesis.buy_zone_low !== null ? formatNumber(thesis.buy_zone_low, 4) : "—"}
+          />
+          <Stat
+            label="Buy high"
+            value={thesis.buy_zone_high !== null ? formatNumber(thesis.buy_zone_high, 4) : "—"}
+          />
+          <Stat
+            label="Bear"
+            value={thesis.bear_value !== null ? formatNumber(thesis.bear_value, 4) : "—"}
+          />
+          <Stat
+            label="Base"
+            value={thesis.base_value !== null ? formatNumber(thesis.base_value, 4) : "—"}
+          />
+          <Stat
+            label="Bull"
+            value={thesis.bull_value !== null ? formatNumber(thesis.bull_value, 4) : "—"}
+          />
+        </div>
+      )}
+      <p className="text-[10px] text-slate-500">
+        (valuations in instrument's native currency)
+      </p>
+      {preview !== "" ? (
+        <p className="whitespace-pre-wrap text-slate-700">{preview}</p>
+      ) : null}
+      <Link
+        to={`/instruments/${instrumentId}`}
+        className="text-[11px] font-medium text-blue-700 hover:underline"
+      >
+        Read full thesis →
+      </Link>
+    </div>
+  );
+}
+
+function ScoreSection({ instrumentId }: { instrumentId: number }): JSX.Element {
+  const scores = useAsync(
+    () => fetchScoreHistory(instrumentId, 5),
+    [instrumentId],
+  );
+  return (
+    <section className="rounded border border-slate-200 p-2">
+      <h3 className="mb-1 text-xs font-semibold uppercase tracking-wider text-slate-600">
+        Latest score
+      </h3>
+      {scores.loading ? (
+        <SectionSkeleton rows={2} />
+      ) : scores.error ? (
+        isNotFound(scores.error) ? (
+          <EmptyState
+            title="No score yet"
+            description="Scores appear once the ranking engine has run."
+          />
+        ) : (
+          <SectionError onRetry={scores.refetch} />
+        )
+      ) : scores.data !== null && scores.data.items.length > 0 ? (
+        <ScoreBody item={scores.data.items[0]!} />
+      ) : (
+        <EmptyState title="No score data" />
+      )}
+    </section>
+  );
+}
+
+function ScoreBody({ item }: { item: ScoreHistoryItem }): JSX.Element {
+  return (
+    <div className="space-y-1 text-xs">
+      <div className="flex items-center gap-3">
+        <span className="text-sm font-semibold tabular-nums text-slate-800">
+          {formatNumber(item.total_score, 2)}
+        </span>
+        {item.rank !== null ? (
+          <span className="text-[11px] text-slate-500">
+            rank #{item.rank}
+            {item.rank_delta !== null && item.rank_delta !== 0 ? (
+              <span
+                className={
+                  item.rank_delta < 0
+                    ? "ml-1 text-emerald-700"
+                    : "ml-1 text-red-700"
+                }
+              >
+                ({item.rank_delta > 0 ? "+" : ""}
+                {item.rank_delta})
+              </span>
+            ) : null}
+          </span>
+        ) : null}
+        <span className="text-[10px] text-slate-400">
+          {item.model_version}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-[11px] tabular-nums text-slate-600 sm:grid-cols-5">
+        <Stat label="Quality" value={formatNumber(item.quality_score, 2)} />
+        <Stat label="Value" value={formatNumber(item.value_score, 2)} />
+        <Stat
+          label="Turnaround"
+          value={formatNumber(item.turnaround_score, 2)}
+        />
+        <Stat label="Momentum" value={formatNumber(item.momentum_score, 2)} />
+        <Stat
+          label="Sentiment"
+          value={formatNumber(item.sentiment_score, 2)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function FilingsSection({
+  instrumentId,
+}: {
+  instrumentId: number;
+}): JSX.Element {
+  const filings = useAsync(
+    () => fetchFilings(instrumentId, 0, 3),
+    [instrumentId],
+  );
+  return (
+    <section className="rounded border border-slate-200 p-2">
+      <h3 className="mb-1 text-xs font-semibold uppercase tracking-wider text-slate-600">
+        Latest filings
+      </h3>
+      {filings.loading ? (
+        <SectionSkeleton rows={3} />
+      ) : filings.error ? (
+        isNotFound(filings.error) ? (
+          <EmptyState title="No filings recorded" />
+        ) : (
+          <SectionError onRetry={filings.refetch} />
+        )
+      ) : filings.data !== null && filings.data.items.length > 0 ? (
+        <ul className="space-y-1 text-xs">
+          {filings.data.items.map((item) => (
+            <FilingRow key={item.filing_event_id} item={item} />
+          ))}
+        </ul>
+      ) : (
+        <EmptyState title="No filing events" />
+      )}
+    </section>
+  );
+}
+
+function FilingRow({ item }: { item: FilingItem }): JSX.Element {
+  const summary =
+    item.extracted_summary !== null && item.extracted_summary.length > 0
+      ? truncate(item.extracted_summary, 80)
+      : "(no summary — open filing for details)";
+  const link = item.source_url ?? item.primary_document_url;
+  return (
+    <li className="flex flex-col border-l-2 border-slate-200 pl-2">
+      <div className="flex items-center gap-2 text-[10px] text-slate-500">
+        <span>{formatDate(item.filing_date)}</span>
+        {item.filing_type !== null ? <span>· {item.filing_type}</span> : null}
+        <span>· {item.provider}</span>
+      </div>
+      <div className="text-slate-700">{summary}</div>
+      {link !== null ? (
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[11px] text-blue-700 hover:underline"
+        >
+          Open →
+        </a>
+      ) : null}
+    </li>
+  );
+}
+
+function memoPreview(memo: string, n: number): string {
+  const trimmed = memo.trim();
+  return trimmed.length <= n ? trimmed : `${trimmed.slice(0, n)}…`;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n)}…`;
+}
+
+function isNotFound(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}

--- a/frontend/src/components/portfolio/DetailPanel.tsx
+++ b/frontend/src/components/portfolio/DetailPanel.tsx
@@ -47,7 +47,14 @@ import type {
 
 type ValuationSource = "quote" | "daily_close" | "cost_basis";
 
-export interface CloseTargetInPanel {
+/**
+ * Shared shape used by the portfolio page AND the detail panel when
+ * asking to close a specific broker position. Exported so both sides
+ * of the `onCloseTrade` wire see the same identity — avoids the
+ * latent drift of two structurally-identical-but-separately-declared
+ * types.
+ */
+export interface CloseTarget {
   readonly instrumentId: number;
   readonly trade: BrokerPositionItem;
   readonly valuationSource: ValuationSource;
@@ -57,7 +64,7 @@ export interface DetailPanelProps {
   readonly selectedPosition: PositionItem | null;
   readonly currency: string;
   readonly onAdd: (p: PositionItem) => void;
-  readonly onCloseTrade: (t: CloseTargetInPanel) => void;
+  readonly onCloseTrade: (t: CloseTarget) => void;
 }
 
 export function DetailPanel({
@@ -191,7 +198,7 @@ export function BrokerPositionsTable({
 }: {
   position: PositionItem;
   currency: string;
-  onCloseTrade: (t: CloseTargetInPanel) => void;
+  onCloseTrade: (t: CloseTarget) => void;
 }): JSX.Element {
   const trades = position.trades;
   if (trades.length === 0) {
@@ -241,7 +248,7 @@ function BrokerRow({
   instrumentId: number;
   valuationSource: ValuationSource;
   currency: string;
-  onCloseTrade: (t: CloseTargetInPanel) => void;
+  onCloseTrade: (t: CloseTarget) => void;
 }): JSX.Element {
   const positive = trade.unrealized_pnl >= 0;
   return (

--- a/frontend/src/pages/PortfolioPage.test.tsx
+++ b/frontend/src/pages/PortfolioPage.test.tsx
@@ -1,0 +1,548 @@
+/**
+ * Tests for PortfolioPage after the #314 workstation refactor.
+ *
+ * Covers the spec behaviors: row selection drives the detail panel,
+ * keyboard shortcuts work before any click, modals integrate, and
+ * edge cases (stale selection after refetch, zero rows, page clamp)
+ * all behave as the spec pins.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+import { ApiError } from "@/api/client";
+import { PortfolioPage } from "@/pages/PortfolioPage";
+import type {
+  BrokerPositionItem,
+  ConfigResponse,
+  FilingsListResponse,
+  InstrumentPositionDetail,
+  PortfolioResponse,
+  PositionItem,
+  ScoreHistoryResponse,
+  ThesisDetail,
+} from "@/api/types";
+
+vi.mock("@/api/portfolio", () => ({
+  fetchPortfolio: vi.fn(),
+  fetchInstrumentPositions: vi.fn(),
+}));
+vi.mock("@/api/config", () => ({ fetchConfig: vi.fn() }));
+vi.mock("@/api/theses", () => ({ fetchLatestThesis: vi.fn() }));
+vi.mock("@/api/filings", () => ({ fetchFilings: vi.fn() }));
+vi.mock("@/api/scoreHistory", () => ({ fetchScoreHistory: vi.fn() }));
+vi.mock("@/api/orders", () => ({ placeOrder: vi.fn(), closePosition: vi.fn() }));
+
+import { fetchPortfolio, fetchInstrumentPositions } from "@/api/portfolio";
+import { fetchConfig } from "@/api/config";
+import { fetchLatestThesis } from "@/api/theses";
+import { fetchFilings } from "@/api/filings";
+import { fetchScoreHistory } from "@/api/scoreHistory";
+import { placeOrder, closePosition } from "@/api/orders";
+
+const mockedFetchPortfolio = vi.mocked(fetchPortfolio);
+const mockedFetchInstrumentPositions = vi.mocked(fetchInstrumentPositions);
+const mockedFetchConfig = vi.mocked(fetchConfig);
+const mockedFetchThesis = vi.mocked(fetchLatestThesis);
+const mockedFetchFilings = vi.mocked(fetchFilings);
+const mockedFetchScores = vi.mocked(fetchScoreHistory);
+const mockedPlaceOrder = vi.mocked(placeOrder);
+const mockedClosePosition = vi.mocked(closePosition);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function demoConfig(): ConfigResponse {
+  return {
+    app_env: "dev",
+    etoro_env: "demo",
+    runtime: {
+      enable_auto_trading: false,
+      enable_live_trading: false,
+      display_currency: "GBP",
+      updated_at: "2026-04-18T00:00:00Z",
+      updated_by: "system",
+      reason: "",
+    },
+    kill_switch: {
+      active: false,
+      activated_at: null,
+      activated_by: null,
+      reason: null,
+    },
+  };
+}
+
+function trade(positionId: number, overrides: Partial<BrokerPositionItem> = {}): BrokerPositionItem {
+  return {
+    position_id: positionId,
+    is_buy: true,
+    units: 2,
+    amount: 260,
+    open_rate: 130,
+    open_date_time: "2026-01-01T10:00:00Z",
+    current_price: 140,
+    market_value: 280,
+    unrealized_pnl: 20,
+    stop_loss_rate: null,
+    take_profit_rate: null,
+    is_tsl_enabled: false,
+    leverage: 1,
+    total_fees: 0,
+    ...overrides,
+  };
+}
+
+function position(
+  instrumentId: number,
+  symbol: string,
+  overrides: Partial<PositionItem> = {},
+): PositionItem {
+  return {
+    instrument_id: instrumentId,
+    symbol,
+    company_name: `${symbol} Inc.`,
+    open_date: "2026-01-01",
+    avg_cost: 130,
+    current_price: 140,
+    current_units: 2,
+    cost_basis: 260,
+    market_value: 280,
+    unrealized_pnl: 20,
+    valuation_source: "quote",
+    source: "broker",
+    updated_at: "2026-04-18T00:00:00Z",
+    trades: [trade(100 + instrumentId)],
+    ...overrides,
+  };
+}
+
+function portfolioWith(positions: PositionItem[]): PortfolioResponse {
+  return {
+    positions,
+    mirrors: [],
+    position_count: positions.length,
+    total_aum: positions.reduce((s, p) => s + p.market_value, 0),
+    cash_balance: 5000,
+    mirror_equity: 0,
+    display_currency: "GBP",
+    fx_rates_used: {},
+  };
+}
+
+function emptyThesis(): ThesisDetail {
+  return {
+    thesis_id: 1,
+    instrument_id: 7,
+    thesis_version: 1,
+    thesis_type: "compounder",
+    stance: "buy",
+    confidence_score: 0.72,
+    buy_zone_low: 120,
+    buy_zone_high: 135,
+    base_value: 150,
+    bull_value: 180,
+    bear_value: 100,
+    break_conditions_json: null,
+    memo_markdown: "Compounder thesis text.",
+    critic_json: null,
+    created_at: "2026-04-18T00:00:00Z",
+  };
+}
+
+function emptyFilings(): FilingsListResponse {
+  return {
+    instrument_id: 7,
+    symbol: "AAPL",
+    items: [],
+    total: 0,
+    offset: 0,
+    limit: 3,
+  };
+}
+
+function emptyScores(): ScoreHistoryResponse {
+  return { instrument_id: 7, items: [] };
+}
+
+function emptyInstrumentDetail(): InstrumentPositionDetail {
+  return {
+    instrument_id: 7,
+    symbol: "AAPL",
+    company_name: "AAPL Inc.",
+    currency: "USD",
+    current_price: 140,
+    total_units: 2,
+    avg_entry: 130,
+    total_invested: 260,
+    total_value: 280,
+    total_pnl: 20,
+    trades: [
+      {
+        position_id: 107,
+        is_buy: true,
+        units: 2,
+        amount: 260,
+        open_rate: 130,
+        open_date_time: "2026-01-01T10:00:00Z",
+        current_price: 140,
+        market_value: 280,
+        unrealized_pnl: 20,
+        stop_loss_rate: null,
+        take_profit_rate: null,
+        is_tsl_enabled: false,
+        leverage: 1,
+        total_fees: 0,
+      },
+    ],
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/portfolio"]}>
+      <PortfolioPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockedFetchConfig.mockResolvedValue(demoConfig());
+  mockedFetchThesis.mockResolvedValue(emptyThesis());
+  mockedFetchFilings.mockResolvedValue(emptyFilings());
+  mockedFetchScores.mockResolvedValue(emptyScores());
+  mockedFetchInstrumentPositions.mockResolvedValue(emptyInstrumentDetail());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PortfolioPage — detail panel + selection", () => {
+  it("shows a placeholder in the detail panel until a row is clicked", async () => {
+    mockedFetchPortfolio.mockResolvedValue(portfolioWith([position(7, "AAPL")]));
+    renderPage();
+
+    await waitFor(() => screen.getByText(/AAPL Inc\./));
+    expect(
+      screen.getByText(/Select a position to see its detail/i),
+    ).toBeInTheDocument();
+    // Detail-panel fetches have NOT fired yet.
+    expect(mockedFetchThesis).not.toHaveBeenCalled();
+    expect(mockedFetchFilings).not.toHaveBeenCalled();
+    expect(mockedFetchScores).not.toHaveBeenCalled();
+  });
+
+  it("clicking a position row loads the detail panel and drives thesis/filings/scores", async () => {
+    mockedFetchPortfolio.mockResolvedValue(portfolioWith([position(7, "AAPL")]));
+    const user = userEvent.setup();
+    renderPage();
+
+    const row = await screen.findByTestId("position-row-7");
+    await user.click(row);
+
+    await waitFor(() => {
+      expect(mockedFetchThesis).toHaveBeenCalledWith(7);
+      expect(mockedFetchFilings).toHaveBeenCalledWith(7, 0, 3);
+      expect(mockedFetchScores).toHaveBeenCalledWith(7, 5);
+    });
+    // Placeholder gone, detail panel content present.
+    expect(
+      screen.queryByText(/Select a position to see its detail/i),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("PortfolioPage — keyboard shortcuts", () => {
+  it("j / k move the focus ring without any prior click", async () => {
+    mockedFetchPortfolio.mockResolvedValue(
+      portfolioWith([position(1, "AAA"), position(2, "BBB"), position(3, "CCC")]),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByTestId("position-row-1");
+
+    // Initially focused index 0 (AAA — sorted by value, but all equal,
+    // so array order holds). Press `j` twice → focus on index 2 (CCC).
+    await user.keyboard("jj");
+    const cccRow = screen.getByTestId("position-row-3");
+    expect(cccRow.className).toContain("border-l-slate-400");
+  });
+
+  it("/ focuses the search box without inserting a slash", async () => {
+    mockedFetchPortfolio.mockResolvedValue(portfolioWith([position(1, "AAA")]));
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByTestId("position-row-1");
+
+    await user.keyboard("/");
+    const searchInput = screen.getByLabelText("Search positions");
+    expect(searchInput).toHaveFocus();
+    expect((searchInput as HTMLInputElement).value).toBe("");
+  });
+
+  it("Enter promotes focused row to selected", async () => {
+    mockedFetchPortfolio.mockResolvedValue(
+      portfolioWith([position(1, "AAA"), position(2, "BBB")]),
+    );
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByTestId("position-row-1");
+
+    await user.keyboard("j{Enter}");
+    // Selected should be instrument 2; fetches fire for 2.
+    await waitFor(() => {
+      expect(mockedFetchThesis).toHaveBeenCalledWith(2);
+    });
+  });
+
+  it("Esc clears selection when the search box is not focused", async () => {
+    mockedFetchPortfolio.mockResolvedValue(portfolioWith([position(7, "AAPL")]));
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByTestId("position-row-7");
+
+    await user.click(screen.getByTestId("position-row-7"));
+    await waitFor(() => expect(mockedFetchThesis).toHaveBeenCalled());
+
+    await user.keyboard("{Escape}");
+    expect(
+      await screen.findByText(/Select a position to see its detail/i),
+    ).toBeInTheDocument();
+  });
+
+  it("Esc blurs and clears the search input when focused", async () => {
+    mockedFetchPortfolio.mockResolvedValue(portfolioWith([position(1, "AAA")]));
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByTestId("position-row-1");
+
+    const searchInput = screen.getByLabelText("Search positions") as HTMLInputElement;
+    await user.click(searchInput);
+    await user.type(searchInput, "APPL");
+    expect(searchInput.value).toBe("APPL");
+    await user.keyboard("{Escape}");
+    expect(searchInput).not.toHaveFocus();
+    expect(searchInput.value).toBe("");
+  });
+
+  it("b opens the Add modal for the selected position", async () => {
+    mockedFetchPortfolio.mockResolvedValue(portfolioWith([position(7, "AAPL")]));
+    mockedPlaceOrder.mockResolvedValue({
+      order_id: 1,
+      status: "filled",
+      broker_order_ref: "DEMO-7-ADD",
+      filled_price: 140,
+      filled_units: 1,
+      fees: 0,
+      explanation: "Demo ADD",
+    });
+    const user = userEvent.setup();
+    renderPage();
+    const row = await screen.findByTestId("position-row-7");
+    await user.click(row);
+    await waitFor(() => expect(mockedFetchThesis).toHaveBeenCalled());
+
+    await user.keyboard("b");
+    await waitFor(() => {
+      expect(screen.getAllByRole("heading", { name: /Add — AAPL/i }).length).toBeGreaterThan(0);
+    });
+  });
+
+  it("c opens the Close modal when the selected position has a single trade", async () => {
+    mockedFetchPortfolio.mockResolvedValue(portfolioWith([position(7, "AAPL")]));
+    const user = userEvent.setup();
+    renderPage();
+    const row = await screen.findByTestId("position-row-7");
+    await user.click(row);
+    await waitFor(() => expect(mockedFetchThesis).toHaveBeenCalled());
+
+    await user.keyboard("c");
+    await waitFor(() => {
+      // The close modal uses `Close — {symbol}` heading.
+      expect(screen.getAllByText(/Close — AAPL/i).length).toBeGreaterThan(0);
+    });
+  });
+
+  it("c on a multi-trade position renders the hint and does NOT open a modal", async () => {
+    const multi = position(7, "AAPL", {
+      trades: [trade(100), trade(101)],
+    });
+    mockedFetchPortfolio.mockResolvedValue(portfolioWith([multi]));
+    const user = userEvent.setup();
+    renderPage();
+    const row = await screen.findByTestId("position-row-7");
+    await user.click(row);
+    await waitFor(() => expect(mockedFetchThesis).toHaveBeenCalled());
+
+    await user.keyboard("c");
+    expect(
+      screen.getByText(
+        /Close requires a single broker position — use the detail panel/i,
+      ),
+    ).toBeInTheDocument();
+    // No close modal heading was rendered.
+    expect(screen.queryByText(/^Close —/)).not.toBeInTheDocument();
+  });
+
+  it("modifier keys do not trigger shortcuts (Ctrl+b is a no-op)", async () => {
+    mockedFetchPortfolio.mockResolvedValue(portfolioWith([position(7, "AAPL")]));
+    const user = userEvent.setup();
+    renderPage();
+    const row = await screen.findByTestId("position-row-7");
+    await user.click(row);
+    await waitFor(() => expect(mockedFetchThesis).toHaveBeenCalled());
+
+    await user.keyboard("{Control>}b{/Control}");
+    expect(screen.queryByText(/^Add — AAPL$/)).not.toBeInTheDocument();
+  });
+});
+
+describe("PortfolioPage — stale selection after refetch", () => {
+  it("clears selectedId when the refetch removes the instrument; b becomes a no-op", async () => {
+    mockedFetchPortfolio.mockResolvedValueOnce(
+      portfolioWith([position(7, "AAPL"), position(8, "MSFT")]),
+    );
+    const user = userEvent.setup();
+    renderPage();
+    const row = await screen.findByTestId("position-row-7");
+    await user.click(row);
+    await waitFor(() => expect(mockedFetchThesis).toHaveBeenCalledWith(7));
+
+    // Simulate a refetch that drops instrument 7 (e.g. fully closed).
+    // handleFilled is called from inside a modal on success, which
+    // triggers portfolio.refetch; we replay the same effect by swapping
+    // the next resolved value and firing refetch via a new render.
+    // Simplest: dispatch a keydown that fires refetch indirectly is not
+    // available in the public surface. So we trigger the close modal
+    // flow end-to-end: click Close, full close, resolve, let refetch
+    // pick up the new response.
+    mockedClosePosition.mockResolvedValueOnce({
+      order_id: 1,
+      status: "filled",
+      broker_order_ref: "DEMO-7-EXIT",
+      filled_price: 140,
+      filled_units: 2,
+      fees: 0,
+      explanation: "Demo EXIT",
+    });
+    mockedFetchPortfolio.mockResolvedValueOnce(
+      portfolioWith([position(8, "MSFT")]),
+    );
+
+    await user.keyboard("c");
+    await waitFor(() =>
+      expect(screen.getAllByText(/Close — AAPL/i).length).toBeGreaterThan(0),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /^Close position$/ }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/^Close — AAPL/),
+      ).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      // After refetch, the placeholder returns — selection cleared.
+      expect(
+        screen.getByText(/Select a position to see its detail/i),
+      ).toBeInTheDocument();
+    });
+
+    // Pressing `b` now is a no-op (no modal opens).
+    await user.keyboard("b");
+    expect(screen.queryByText(/^Add — /)).not.toBeInTheDocument();
+  });
+});
+
+describe("PortfolioPage — search + pagination edge cases", () => {
+  it("shows 'No positions match' when search filters to zero rows but keeps the detail panel populated", async () => {
+    mockedFetchPortfolio.mockResolvedValue(
+      portfolioWith([position(7, "AAPL"), position(8, "MSFT")]),
+    );
+    const user = userEvent.setup();
+    renderPage();
+    const row = await screen.findByTestId("position-row-7");
+    await user.click(row);
+    await waitFor(() => expect(mockedFetchThesis).toHaveBeenCalledWith(7));
+
+    const searchInput = screen.getByLabelText("Search positions");
+    await user.type(searchInput, "ZZZZ");
+
+    expect(screen.getByText(/No positions match your search/)).toBeInTheDocument();
+    // Detail panel still populated for AAPL.
+    expect(
+      screen.queryByText(/Select a position to see its detail/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("paginates when >50 positions exist", async () => {
+    const positions = Array.from({ length: 51 }, (_, i) =>
+      position(i + 1, `SYM${i + 1}`),
+    );
+    mockedFetchPortfolio.mockResolvedValue(portfolioWith(positions));
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByTestId("position-row-1");
+    // Page 1 shows 50 rows; page 2 shows 1.
+    const rowsPage1 = await screen.findAllByTestId(/^position-row-/);
+    expect(rowsPage1.length).toBe(50);
+
+    expect(screen.getByText(/Page 1 of 2/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Next →/ }));
+    await waitFor(() => {
+      expect(screen.getByText(/Page 2 of 2/)).toBeInTheDocument();
+    });
+    const rowsPage2 = screen.getAllByTestId(/^position-row-/);
+    expect(rowsPage2.length).toBe(1);
+  });
+
+  it("clamps page back when search shrinks results below the current page", async () => {
+    const positions = Array.from({ length: 51 }, (_, i) =>
+      position(i + 1, `SYM${i + 1}`),
+    );
+    mockedFetchPortfolio.mockResolvedValue(portfolioWith(positions));
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByTestId("position-row-1");
+    await user.click(screen.getByRole("button", { name: /Next →/ }));
+    await waitFor(() =>
+      expect(screen.getByText(/Page 2 of 2/)).toBeInTheDocument(),
+    );
+
+    // Type a search that matches < PAGE_SIZE rows — pagination bar
+    // disappears (no longer needed) and the remaining rows render
+    // (they would be on page 1 after the clamp; a stale page=2
+    // without the clamp would leave the list empty).
+    await user.type(screen.getByLabelText("Search positions"), "SYM50");
+    await waitFor(() => {
+      expect(screen.getByTestId("position-row-50")).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: /Next →/ })).not.toBeInTheDocument();
+  });
+});
+
+describe("PortfolioPage — detail panel error handling", () => {
+  it("thesis 404 renders empty state instead of error", async () => {
+    mockedFetchPortfolio.mockResolvedValue(portfolioWith([position(7, "AAPL")]));
+    mockedFetchThesis.mockRejectedValue(new ApiError(404, "No thesis"));
+    const user = userEvent.setup();
+    renderPage();
+    const row = await screen.findByTestId("position-row-7");
+    await user.click(row);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No thesis yet/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Failed to load/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/PortfolioPage.test.tsx
+++ b/frontend/src/pages/PortfolioPage.test.tsx
@@ -495,8 +495,11 @@ describe("PortfolioPage — search + pagination edge cases", () => {
   });
 
   it("paginates when >50 positions exist", async () => {
+    // Distinct market_values guarantee deterministic sort order so
+    // the 51st position lands deterministically on page 2 regardless
+    // of engine sort stability for equal keys.
     const positions = Array.from({ length: 51 }, (_, i) =>
-      position(i + 1, `SYM${i + 1}`),
+      position(i + 1, `SYM${i + 1}`, { market_value: 1000 - i }),
     );
     mockedFetchPortfolio.mockResolvedValue(portfolioWith(positions));
     const user = userEvent.setup();
@@ -518,7 +521,7 @@ describe("PortfolioPage — search + pagination edge cases", () => {
 
   it("clamps page back when search shrinks results below the current page", async () => {
     const positions = Array.from({ length: 51 }, (_, i) =>
-      position(i + 1, `SYM${i + 1}`),
+      position(i + 1, `SYM${i + 1}`, { market_value: 1000 - i }),
     );
     mockedFetchPortfolio.mockResolvedValue(portfolioWith(positions));
     const user = userEvent.setup();

--- a/frontend/src/pages/PortfolioPage.test.tsx
+++ b/frontend/src/pages/PortfolioPage.test.tsx
@@ -261,16 +261,22 @@ describe("PortfolioPage — detail panel + selection", () => {
 
 describe("PortfolioPage — keyboard shortcuts", () => {
   it("j / k move the focus ring without any prior click", async () => {
+    // Distinct market_values give a stable sort: AAA=300 > BBB=200 > CCC=100.
+    // Row ordering is deterministic so the focused-row assertion does
+    // not rely on engine-specific equal-key sort behaviour.
     mockedFetchPortfolio.mockResolvedValue(
-      portfolioWith([position(1, "AAA"), position(2, "BBB"), position(3, "CCC")]),
+      portfolioWith([
+        position(1, "AAA", { market_value: 300 }),
+        position(2, "BBB", { market_value: 200 }),
+        position(3, "CCC", { market_value: 100 }),
+      ]),
     );
     const user = userEvent.setup();
     renderPage();
 
     await screen.findByTestId("position-row-1");
 
-    // Initially focused index 0 (AAA — sorted by value, but all equal,
-    // so array order holds). Press `j` twice → focus on index 2 (CCC).
+    // Initial focused index 0 = AAA. Press `j` twice → focus on CCC.
     await user.keyboard("jj");
     const cccRow = screen.getByTestId("position-row-3");
     expect(cccRow.className).toContain("border-l-slate-400");
@@ -289,8 +295,12 @@ describe("PortfolioPage — keyboard shortcuts", () => {
   });
 
   it("Enter promotes focused row to selected", async () => {
+    // Distinct market_values for deterministic sort order: AAA first, BBB second.
     mockedFetchPortfolio.mockResolvedValue(
-      portfolioWith([position(1, "AAA"), position(2, "BBB")]),
+      portfolioWith([
+        position(1, "AAA", { market_value: 200 }),
+        position(2, "BBB", { market_value: 100 }),
+      ]),
     );
     const user = userEvent.setup();
     renderPage();

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { fetchPortfolio } from "@/api/portfolio";
 import { useAsync } from "@/lib/useAsync";
@@ -8,6 +8,7 @@ import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
 import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
+import { DetailPanel } from "@/components/portfolio/DetailPanel";
 import type {
   BrokerPositionItem,
   PositionItem,
@@ -22,28 +23,219 @@ interface CloseTarget {
   valuationSource: ValuationSource;
 }
 
+type RowItem =
+  | { kind: "position"; data: PositionItem }
+  | { kind: "mirror"; data: PortfolioMirrorItem };
+
+const PAGE_SIZE = 50;
+
 /**
- * Portfolio page — the operator's main working view.
+ * Portfolio page — the operator's trading workstation (#314).
  *
- * Dense, financial-tool aesthetic. Unified positions+mirrors table sorted
- * by value. Clicking a stock row navigates to /portfolio/:instrumentId
- * (native-currency detail view). Clicking a mirror row navigates to
- * /copy-trading/:mirrorId.
+ * Split layout (≥lg):
+ *   - left pane: summary bar + search + table + pagination
+ *   - right pane: DetailPanel for the currently-selected position
+ *
+ * Selection + keyboard shortcuts:
+ *   - `/` focuses search, `j`/`k` move the focus ring, `Enter` selects,
+ *     `Esc` clears selection (or blurs search), `b` opens Add modal on
+ *     the selected position, `c` opens Close modal only when the
+ *     selected position has exactly one broker trade underneath.
+ *   - Shortcuts are attached via a window listener so they work
+ *     regardless of DOM focus. Gated on: no input is focused (Esc is
+ *     exempt), no modal is open, no modifier keys.
+ *   - Clicking a mirror row still navigates to /copy-trading/:id.
  */
 export function PortfolioPage() {
   const portfolio = useAsync(fetchPortfolio, []);
   const currency = useDisplayCurrency();
+
   const [search, setSearch] = useState("");
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [focusedIdx, setFocusedIdx] = useState<number>(0);
+  const [page, setPage] = useState<number>(1);
+  const [hint, setHint] = useState<string | null>(null);
+
   const [addFor, setAddFor] = useState<PositionItem | null>(null);
   const [closeFor, setCloseFor] = useState<CloseTarget | null>(null);
 
+  const searchRef = useRef<HTMLInputElement | null>(null);
+
+  // Derived: all rows (positions + mirrors, sorted by value), then
+  // filtered by search, then sliced for the current page.
+  const allRows: RowItem[] = useMemo(() => {
+    if (portfolio.data === null) return [];
+    const positions = portfolio.data.positions.map<RowItem>((p) => ({
+      kind: "position",
+      data: p,
+    }));
+    const mirrors = portfolio.data.mirrors.map<RowItem>((m) => ({
+      kind: "mirror",
+      data: m,
+    }));
+    const combined = [...positions, ...mirrors];
+    combined.sort((a, b) => {
+      const mvA =
+        a.kind === "position" ? a.data.market_value : a.data.mirror_equity;
+      const mvB =
+        b.kind === "position" ? b.data.market_value : b.data.mirror_equity;
+      return mvB - mvA;
+    });
+    return combined;
+  }, [portfolio.data]);
+
+  const visible = useMemo(
+    () => allRows.filter((r) => matchesSearch(r, search)),
+    [allRows, search],
+  );
+  const totalPages = Math.max(1, Math.ceil(visible.length / PAGE_SIZE));
+  const pageRows = useMemo(() => {
+    const start = (page - 1) * PAGE_SIZE;
+    return visible.slice(start, start + PAGE_SIZE);
+  }, [visible, page]);
+
+  // Derive selectedPosition from the UNFILTERED positions so the
+  // detail panel keeps rendering when the operator narrows search.
+  const selectedPosition: PositionItem | null = useMemo(() => {
+    if (selectedId === null || portfolio.data === null) return null;
+    return (
+      portfolio.data.positions.find((p) => p.instrument_id === selectedId) ??
+      null
+    );
+  }, [selectedId, portfolio.data]);
+
+  // Clamp focusedIdx when pageRows.length changes.
+  useEffect(() => {
+    if (pageRows.length === 0) return;
+    setFocusedIdx((i) => Math.min(Math.max(i, 0), pageRows.length - 1));
+  }, [pageRows.length]);
+
+  // Clamp page when it exceeds totalPages after search shrinks results.
+  useEffect(() => {
+    if (page > totalPages) setPage(totalPages);
+  }, [page, totalPages]);
+
+  // Clear stale selectedId after a /portfolio refetch that drops it
+  // (e.g. a full close in ClosePositionModal). Otherwise the detail
+  // panel would collapse but `b`/`c` would still try to act on a
+  // ghost position — gated below via selectedPosition !== null.
+  useEffect(() => {
+    if (selectedId === null || portfolio.data === null) return;
+    const stillExists = portfolio.data.positions.some(
+      (p) => p.instrument_id === selectedId,
+    );
+    if (!stillExists) setSelectedId(null);
+  }, [portfolio.data, selectedId]);
+
   function handleFilled() {
-    // Close modals BEFORE the portfolio refetch fires so a refetch
-    // error is never hidden behind an open dialog (prevention #125).
     setAddFor(null);
     setCloseFor(null);
     portfolio.refetch();
   }
+
+  function handleSelectRow(row: RowItem, idxOnPage: number) {
+    if (row.kind === "position") {
+      setSelectedId(row.data.instrument_id);
+      setFocusedIdx(idxOnPage);
+    }
+    // Mirror rows intentionally do not set selection — the row itself
+    // navigates via MirrorRow's onClick.
+  }
+
+  // Window-level keyboard handler so shortcuts work before the
+  // operator has clicked anything.
+  useEffect(() => {
+    function isEditable(el: Element | null): boolean {
+      if (el === null) return false;
+      const tag = el.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT"
+      )
+        return true;
+      return (el as HTMLElement).isContentEditable === true;
+    }
+
+    function onKey(e: KeyboardEvent) {
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+      if (addFor !== null || closeFor !== null) return;
+
+      const activeEditable = isEditable(document.activeElement);
+
+      // Esc is special-cased: always processed so it can blur the
+      // search input + clear the search string.
+      if (e.key === "Escape") {
+        if (activeEditable && document.activeElement === searchRef.current) {
+          searchRef.current?.blur();
+          setSearch("");
+          e.preventDefault();
+          return;
+        }
+        setSelectedId(null);
+        setFocusedIdx(0);
+        setHint(null);
+        e.preventDefault();
+        return;
+      }
+
+      if (activeEditable) return;
+
+      if (e.key === "/") {
+        e.preventDefault();
+        searchRef.current?.focus();
+        return;
+      }
+
+      if (e.key === "j") {
+        if (pageRows.length === 0) return;
+        setFocusedIdx((i) => Math.min(i + 1, pageRows.length - 1));
+        e.preventDefault();
+        return;
+      }
+      if (e.key === "k") {
+        if (pageRows.length === 0) return;
+        setFocusedIdx((i) => Math.max(i - 1, 0));
+        e.preventDefault();
+        return;
+      }
+      if (e.key === "Enter") {
+        if (pageRows.length === 0) return;
+        const target = pageRows[focusedIdx];
+        if (target !== undefined && target.kind === "position") {
+          setSelectedId(target.data.instrument_id);
+        }
+        e.preventDefault();
+        return;
+      }
+      if (e.key === "b") {
+        if (selectedPosition === null) return;
+        setAddFor(selectedPosition);
+        e.preventDefault();
+        return;
+      }
+      if (e.key === "c") {
+        if (selectedPosition === null) return;
+        const trades = selectedPosition.trades;
+        if (trades.length === 1 && trades[0] !== undefined) {
+          setCloseFor({
+            instrumentId: selectedPosition.instrument_id,
+            trade: trades[0],
+            valuationSource: selectedPosition.valuation_source,
+          });
+        } else if (trades.length > 1) {
+          setHint(
+            "Close requires a single broker position — use the detail panel.",
+          );
+        }
+        e.preventDefault();
+        return;
+      }
+    }
+
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [addFor, closeFor, pageRows, focusedIdx, selectedPosition]);
 
   return (
     <div className="space-y-4">
@@ -56,18 +248,82 @@ export function PortfolioPage() {
       ) : portfolio.loading || portfolio.data === null ? (
         <SectionSkeleton rows={8} />
       ) : (
-        <>
-          <SummaryBar data={portfolio.data} currency={currency} />
-          <PortfolioTable
-            positions={portfolio.data.positions}
-            mirrors={portfolio.data.mirrors}
-            currency={currency}
-            search={search}
-            onSearchChange={setSearch}
-            onAdd={setAddFor}
-            onClose={setCloseFor}
-          />
-        </>
+        <div className="grid gap-4 lg:grid-cols-5">
+          <div className="space-y-3 lg:col-span-3">
+            <SummaryBar data={portfolio.data} currency={currency} />
+            {hint !== null ? (
+              <div
+                role="status"
+                className="rounded border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs text-amber-800"
+              >
+                {hint}
+              </div>
+            ) : null}
+            {allRows.length === 0 ? (
+              <EmptyState
+                title="No positions yet"
+                description="Open a position from the rankings page to see it here."
+              >
+                <Link
+                  to="/rankings"
+                  className="text-sm font-medium text-blue-600 hover:underline"
+                >
+                  Go to rankings →
+                </Link>
+              </EmptyState>
+            ) : (
+              <>
+                <PortfolioTable
+                  pageRows={pageRows}
+                  currency={currency}
+                  search={search}
+                  onSearchChange={(v) => {
+                    setSearch(v);
+                    setPage(1);
+                  }}
+                  searchRef={searchRef}
+                  focusedIdx={focusedIdx}
+                  selectedId={selectedId}
+                  onSelectRow={handleSelectRow}
+                  onAdd={setAddFor}
+                  onClose={setCloseFor}
+                />
+                {visible.length > PAGE_SIZE ? (
+                  <PaginationBar
+                    page={page}
+                    totalPages={totalPages}
+                    onPrev={() => {
+                      setPage((p) => Math.max(1, p - 1));
+                      setFocusedIdx(0);
+                    }}
+                    onNext={() => {
+                      setPage((p) => Math.min(totalPages, p + 1));
+                      setFocusedIdx(0);
+                    }}
+                  />
+                ) : null}
+                <div className="text-[10px] text-slate-400">
+                  <kbd className="rounded bg-slate-100 px-1">/</kbd> search ·{" "}
+                  <kbd className="rounded bg-slate-100 px-1">j</kbd>/
+                  <kbd className="rounded bg-slate-100 px-1">k</kbd> move ·{" "}
+                  <kbd className="rounded bg-slate-100 px-1">Enter</kbd>{" "}
+                  select · <kbd className="rounded bg-slate-100 px-1">Esc</kbd>{" "}
+                  clear · <kbd className="rounded bg-slate-100 px-1">b</kbd>{" "}
+                  Add · <kbd className="rounded bg-slate-100 px-1">c</kbd>{" "}
+                  Close
+                </div>
+              </>
+            )}
+          </div>
+          <div className="lg:col-span-2">
+            <DetailPanel
+              selectedPosition={selectedPosition}
+              currency={currency}
+              onAdd={setAddFor}
+              onCloseTrade={setCloseFor}
+            />
+          </div>
+        </div>
       )}
 
       {addFor !== null ? (
@@ -104,7 +360,12 @@ function SummaryBar({
   data,
   currency,
 }: {
-  data: { total_aum: number; cash_balance: number | null; positions: PositionItem[]; mirrors?: PortfolioMirrorItem[] };
+  data: {
+    total_aum: number;
+    cash_balance: number | null;
+    positions: PositionItem[];
+    mirrors?: PortfolioMirrorItem[];
+  };
   currency: string;
 }) {
   const mirrors = data.mirrors ?? [];
@@ -130,7 +391,9 @@ function SummaryBar({
       />
       <Stat label="Positions" value={String(posCount)} />
       <Stat label="Instruments" value={String(data.positions.length)} />
-      {mirrorCount > 0 ? <Stat label="Mirrors" value={String(mirrorCount)} /> : null}
+      {mirrorCount > 0 ? (
+        <Stat label="Mirrors" value={String(mirrorCount)} />
+      ) : null}
     </div>
   );
 }
@@ -148,10 +411,14 @@ function Stat({
 }) {
   return (
     <div className="min-w-[64px]">
-      <div className="text-[11px] font-medium uppercase tracking-wider text-slate-400">{label}</div>
+      <div className="text-[11px] font-medium uppercase tracking-wider text-slate-400">
+        {label}
+      </div>
       <div className="text-sm font-semibold text-slate-800">{value}</div>
       {hint ? (
-        <div className={`text-xs font-medium ${tone === "positive" ? "text-emerald-600" : "text-red-600"}`}>
+        <div
+          className={`text-xs font-medium ${tone === "positive" ? "text-emerald-600" : "text-red-600"}`}
+        >
           {hint}
         </div>
       ) : null}
@@ -160,12 +427,8 @@ function Stat({
 }
 
 // ---------------------------------------------------------------------------
-// Unified table — positions + mirrors, sorted by value, click to navigate
+// Table
 // ---------------------------------------------------------------------------
-
-type RowItem =
-  | { kind: "position"; data: PositionItem }
-  | { kind: "mirror"; data: PortfolioMirrorItem };
 
 function matchesSearch(row: RowItem, q: string): boolean {
   if (!q) return true;
@@ -180,141 +443,195 @@ function matchesSearch(row: RowItem, q: string): boolean {
 }
 
 const AVATAR_TONES = [
-  "bg-blue-600", "bg-emerald-600", "bg-amber-600",
-  "bg-rose-600", "bg-violet-600", "bg-cyan-600",
+  "bg-blue-600",
+  "bg-emerald-600",
+  "bg-amber-600",
+  "bg-rose-600",
+  "bg-violet-600",
+  "bg-cyan-600",
 ] as const;
 
 function avatarTone(name: string): string {
   let hash = 0;
-  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  for (let i = 0; i < name.length; i++)
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
   return AVATAR_TONES[Math.abs(hash) % AVATAR_TONES.length] ?? "bg-blue-600";
 }
 
 function PortfolioTable({
-  positions,
-  mirrors,
+  pageRows,
   currency,
   search,
   onSearchChange,
+  searchRef,
+  focusedIdx,
+  selectedId,
+  onSelectRow,
   onAdd,
   onClose,
 }: {
-  positions: PositionItem[];
-  mirrors?: PortfolioMirrorItem[];
+  pageRows: RowItem[];
   currency: string;
   search: string;
   onSearchChange: (v: string) => void;
+  searchRef: React.MutableRefObject<HTMLInputElement | null>;
+  focusedIdx: number;
+  selectedId: number | null;
+  onSelectRow: (row: RowItem, idxOnPage: number) => void;
   onAdd: (p: PositionItem) => void;
   onClose: (t: CloseTarget) => void;
 }) {
-  const allRows: RowItem[] = [
-    ...positions.map((p) => ({ kind: "position" as const, data: p })),
-    ...(mirrors ?? []).map((m) => ({ kind: "mirror" as const, data: m })),
-  ];
-  allRows.sort((a, b) => {
-    const mvA = a.kind === "position" ? a.data.market_value : a.data.mirror_equity;
-    const mvB = b.kind === "position" ? b.data.market_value : b.data.mirror_equity;
-    return mvB - mvA;
-  });
-
-  const filtered = allRows.filter((r) => matchesSearch(r, search));
-
-  if (positions.length === 0 && (mirrors ?? []).length === 0) {
-    return (
-      <EmptyState
-        title="No positions yet"
-        description="Open a position from the rankings page to see it here."
-      >
-        <Link to="/rankings" className="text-sm font-medium text-blue-600 hover:underline">
-          Go to rankings →
-        </Link>
-      </EmptyState>
-    );
-  }
-
   return (
     <div className="rounded-md border border-slate-200 bg-white shadow-sm">
       <div className="border-b border-slate-100 px-4 py-2">
         <input
+          ref={searchRef}
           type="text"
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
-          placeholder="Search positions…"
+          placeholder="Search positions…   (press / to focus)"
+          aria-label="Search positions"
           className="w-full rounded border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700 placeholder-slate-400 outline-none focus:border-blue-300 focus:ring-1 focus:ring-blue-200"
         />
       </div>
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-slate-200 bg-slate-50 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
-            <th className="px-4 py-2 text-left">Instrument</th>
-            <th className="px-2 py-2 text-right">Trades</th>
-            <th className="px-2 py-2 text-right">Units</th>
-            <th className="px-2 py-2 text-right">Avg Entry</th>
-            <th className="px-2 py-2 text-right">Price</th>
-            <th className="px-2 py-2 text-right">Invested</th>
-            <th className="px-2 py-2 text-right">Value</th>
-            <th className="px-2 py-2 text-right">P&L</th>
-            <th className="px-2 py-2 text-right">%</th>
-            <th className="px-2 py-2 text-right">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map((row) =>
-            row.kind === "position" ? (
-              <PositionRow
-                key={`pos-${row.data.instrument_id}`}
-                p={row.data}
-                currency={currency}
-                onAdd={onAdd}
-                onClose={onClose}
-              />
-            ) : (
-              <MirrorRow key={`mir-${row.data.mirror_id}`} m={row.data} currency={currency} />
-            ),
-          )}
-        </tbody>
-      </table>
+      {pageRows.length === 0 ? (
+        <div className="p-4 text-sm text-slate-500">
+          No positions match your search.
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-slate-200 bg-slate-50 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+              <th className="px-4 py-2 text-left">Instrument</th>
+              <th className="px-2 py-2 text-right">Trades</th>
+              <th className="px-2 py-2 text-right">Units</th>
+              <th className="px-2 py-2 text-right">Avg Entry</th>
+              <th className="px-2 py-2 text-right">Price</th>
+              <th className="px-2 py-2 text-right">Invested</th>
+              <th className="px-2 py-2 text-right">Value</th>
+              <th className="px-2 py-2 text-right">P&L</th>
+              <th className="px-2 py-2 text-right">%</th>
+              <th className="px-2 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pageRows.map((row, idx) =>
+              row.kind === "position" ? (
+                <PositionRow
+                  key={`pos-${row.data.instrument_id}`}
+                  p={row.data}
+                  currency={currency}
+                  focused={idx === focusedIdx}
+                  selected={row.data.instrument_id === selectedId}
+                  onSelect={() => onSelectRow(row, idx)}
+                  onAdd={onAdd}
+                  onClose={onClose}
+                />
+              ) : (
+                <MirrorRow
+                  key={`mir-${row.data.mirror_id}`}
+                  m={row.data}
+                  currency={currency}
+                  focused={idx === focusedIdx}
+                />
+              ),
+            )}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function PaginationBar({
+  page,
+  totalPages,
+  onPrev,
+  onNext,
+}: {
+  page: number;
+  totalPages: number;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs shadow-sm">
+      <button
+        type="button"
+        onClick={onPrev}
+        disabled={page <= 1}
+        className="rounded border border-slate-200 bg-white px-2 py-0.5 font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-40"
+      >
+        ← Prev
+      </button>
+      <span className="text-slate-600">
+        Page {page} of {totalPages}
+      </span>
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={page >= totalPages}
+        className="rounded border border-slate-200 bg-white px-2 py-0.5 font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-40"
+      >
+        Next →
+      </button>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Position row — click navigates to /portfolio/:instrumentId
+// Position row — click selects for the detail panel
 // ---------------------------------------------------------------------------
 
 function PositionRow({
   p,
   currency,
+  focused,
+  selected,
+  onSelect,
   onAdd,
   onClose,
 }: {
   p: PositionItem;
   currency: string;
+  focused: boolean;
+  selected: boolean;
+  onSelect: () => void;
   onAdd: (p: PositionItem) => void;
   onClose: (t: CloseTarget) => void;
 }) {
-  const navigate = useNavigate();
   const pct = pnlPct(p.unrealized_pnl, p.cost_basis);
   const positive = p.unrealized_pnl >= 0;
   const trades = p.trades;
-  // Close is only exposed when a single broker position backs the
-  // instrument. Aggregated positions defer to #314's detail panel,
-  // where per-broker-position rows get their own Close buttons.
   const singleTrade: BrokerPositionItem | null =
     trades.length === 1 && trades[0] !== undefined ? trades[0] : null;
 
+  const rowClass = [
+    "cursor-pointer border-t border-slate-100 transition-colors",
+    selected
+      ? "bg-blue-50 border-l-2 border-l-blue-500"
+      : focused
+        ? "bg-slate-100 border-l-2 border-l-slate-400"
+        : "hover:bg-slate-50/70",
+  ].join(" ");
+
   return (
     <tr
-      className="cursor-pointer border-t border-slate-100 transition-colors hover:bg-slate-50/70"
-      onClick={() => navigate(`/portfolio/${p.instrument_id}`)}
+      className={rowClass}
+      onClick={onSelect}
+      aria-selected={selected}
+      data-testid={`position-row-${p.instrument_id}`}
     >
       <td className="px-4 py-2 text-left">
         <span className="font-medium text-slate-800">{p.symbol}</span>
         <span className="ml-1.5 text-xs text-slate-500">{p.company_name}</span>
-        <span className="ml-1.5 text-[10px] text-slate-400">→</span>
       </td>
-      <td className="px-2 py-2 text-right tabular-nums text-slate-600">{trades.length || "—"}</td>
-      <td className="px-2 py-2 text-right tabular-nums">{formatNumber(p.current_units)}</td>
+      <td className="px-2 py-2 text-right tabular-nums text-slate-600">
+        {trades.length || "—"}
+      </td>
+      <td className="px-2 py-2 text-right tabular-nums">
+        {formatNumber(p.current_units)}
+      </td>
       <td className="px-2 py-2 text-right tabular-nums text-slate-500">
         {p.avg_cost != null ? formatMoney(p.avg_cost, currency) : "—"}
       </td>
@@ -324,7 +641,9 @@ function PositionRow({
       <td className="px-2 py-2 text-right tabular-nums text-slate-600">
         {formatMoney(p.cost_basis, currency)}
       </td>
-      <td className="px-2 py-2 text-right tabular-nums">{formatMoney(p.market_value, currency)}</td>
+      <td className="px-2 py-2 text-right tabular-nums">
+        {formatMoney(p.market_value, currency)}
+      </td>
       <td className="px-2 py-2 text-right tabular-nums">
         <span className={positive ? "text-emerald-600" : "text-red-600"}>
           {formatMoney(p.unrealized_pnl, currency)}
@@ -370,19 +689,29 @@ function PositionRow({
 }
 
 // ---------------------------------------------------------------------------
-// Mirror row — click navigates to /copy-trading/:mirrorId
+// Mirror row — click navigates to /copy-trading/:mirrorId (unchanged)
 // ---------------------------------------------------------------------------
 
-function MirrorRow({ m, currency }: { m: PortfolioMirrorItem; currency: string }) {
+function MirrorRow({
+  m,
+  currency,
+  focused,
+}: {
+  m: PortfolioMirrorItem;
+  currency: string;
+  focused: boolean;
+}) {
   const navigate = useNavigate();
   const pct = pnlPct(m.unrealized_pnl, m.funded);
   const positive = m.unrealized_pnl >= 0;
 
+  const rowClass = [
+    "cursor-pointer border-t border-slate-100 transition-colors",
+    focused ? "bg-slate-100 border-l-2 border-l-slate-400" : "hover:bg-slate-50/70",
+  ].join(" ");
+
   return (
-    <tr
-      className="cursor-pointer border-t border-slate-100 transition-colors hover:bg-slate-50/70"
-      onClick={() => navigate(`/copy-trading/${m.mirror_id}`)}
-    >
+    <tr className={rowClass} onClick={() => navigate(`/copy-trading/${m.mirror_id}`)}>
       <td className="px-4 py-2 text-left">
         <span className="inline-flex items-center gap-2">
           <span
@@ -390,21 +719,27 @@ function MirrorRow({ m, currency }: { m: PortfolioMirrorItem; currency: string }
           >
             {m.parent_username.charAt(0).toUpperCase()}
           </span>
-          <span className="font-medium text-slate-800">{m.parent_username}</span>
+          <span className="font-medium text-slate-800">
+            {m.parent_username}
+          </span>
           <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500">
             COPY
           </span>
           <span className="text-[10px] text-slate-400">→</span>
         </span>
       </td>
-      <td className="px-2 py-2 text-right tabular-nums text-slate-600">{m.position_count}</td>
+      <td className="px-2 py-2 text-right tabular-nums text-slate-600">
+        {m.position_count}
+      </td>
       <td className="px-2 py-2 text-right tabular-nums text-slate-300">—</td>
       <td className="px-2 py-2 text-right tabular-nums text-slate-300">—</td>
       <td className="px-2 py-2 text-right tabular-nums text-slate-300">—</td>
       <td className="px-2 py-2 text-right tabular-nums text-slate-600">
         {formatMoney(m.funded, currency)}
       </td>
-      <td className="px-2 py-2 text-right tabular-nums">{formatMoney(m.mirror_equity, currency)}</td>
+      <td className="px-2 py-2 text-right tabular-nums">
+        {formatMoney(m.mirror_equity, currency)}
+      </td>
       <td className="px-2 py-2 text-right tabular-nums">
         <span className={positive ? "text-emerald-600" : "text-red-600"}>
           {formatMoney(m.unrealized_pnl, currency)}
@@ -415,7 +750,6 @@ function MirrorRow({ m, currency }: { m: PortfolioMirrorItem; currency: string }
           {pct === null ? "—" : formatPct(pct)}
         </span>
       </td>
-      {/* No Actions for mirror rows — copy trading is a separate flow. */}
       <td className="px-2 py-2" />
     </tr>
   );

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -54,11 +54,15 @@ export function PortfolioPage() {
 
   const searchRef = useRef<HTMLInputElement | null>(null);
 
-  // Refs track the freshest focus index + page rows so the window
-  // keyboard handler (which captures closures each effect run) always
-  // reads the current values, not a snapshot from an earlier render.
+  // Refs track the freshest focus index + page rows + selected
+  // position so the window keyboard handler (which captures closures
+  // each effect run) always reads the current values, not a snapshot
+  // from an earlier render. The refs also keep the effect's deps
+  // array small — re-binding the listener every time `portfolio.data`
+  // changes is wasteful when the handler only *reads* the position.
   const focusedIdxRef = useRef(focusedIdx);
   const pageRowsRef = useRef<RowItem[]>([]);
+  const selectedPositionRef = useRef<PositionItem | null>(null);
 
   // Derived: all rows (positions + mirrors, sorted by value), then
   // filtered by search, then sliced for the current page.
@@ -93,11 +97,6 @@ export function PortfolioPage() {
     return visible.slice(start, start + PAGE_SIZE);
   }, [visible, page]);
 
-  // Keep refs aligned with the current render so the window listener
-  // never reads a stale snapshot.
-  focusedIdxRef.current = focusedIdx;
-  pageRowsRef.current = pageRows;
-
   // Derive selectedPosition from the UNFILTERED positions so the
   // detail panel keeps rendering when the operator narrows search.
   const selectedPosition: PositionItem | null = useMemo(() => {
@@ -107,6 +106,13 @@ export function PortfolioPage() {
       null
     );
   }, [selectedId, portfolio.data]);
+
+  // Keep refs aligned with the current render so the window listener
+  // never reads a stale snapshot. Must run AFTER selectedPosition is
+  // derived.
+  focusedIdxRef.current = focusedIdx;
+  pageRowsRef.current = pageRows;
+  selectedPositionRef.current = selectedPosition;
 
   // Clamp focusedIdx when pageRows.length changes.
   useEffect(() => {
@@ -220,20 +226,22 @@ export function PortfolioPage() {
         return;
       }
       if (e.key === "b") {
-        if (selectedPosition === null) return;
-        setAddFor(selectedPosition);
+        const pos = selectedPositionRef.current;
+        if (pos === null) return;
+        setAddFor(pos);
         setHint(null);
         e.preventDefault();
         return;
       }
       if (e.key === "c") {
-        if (selectedPosition === null) return;
-        const trades = selectedPosition.trades;
+        const pos = selectedPositionRef.current;
+        if (pos === null) return;
+        const trades = pos.trades;
         if (trades.length === 1 && trades[0] !== undefined) {
           setCloseFor({
-            instrumentId: selectedPosition.instrument_id,
+            instrumentId: pos.instrument_id,
             trade: trades[0],
-            valuationSource: selectedPosition.valuation_source,
+            valuationSource: pos.valuation_source,
           });
           setHint(null);
         } else if (trades.length > 1) {
@@ -248,7 +256,10 @@ export function PortfolioPage() {
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [addFor, closeFor, selectedPosition]);
+    // Modal presence flags gate the handler; everything else the
+    // handler reads is carried by refs, so the listener does not need
+    // to re-bind on per-render state changes.
+  }, [addFor, closeFor]);
 
   return (
     <div className="space-y-4">

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -9,19 +9,12 @@ import { EmptyState } from "@/components/states/EmptyState";
 import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
 import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
 import { DetailPanel } from "@/components/portfolio/DetailPanel";
+import type { CloseTarget } from "@/components/portfolio/DetailPanel";
 import type {
   BrokerPositionItem,
   PositionItem,
   PortfolioMirrorItem,
 } from "@/api/types";
-
-type ValuationSource = "quote" | "daily_close" | "cost_basis";
-
-interface CloseTarget {
-  instrumentId: number;
-  trade: BrokerPositionItem;
-  valuationSource: ValuationSource;
-}
 
 type RowItem =
   | { kind: "position"; data: PositionItem }
@@ -61,6 +54,12 @@ export function PortfolioPage() {
 
   const searchRef = useRef<HTMLInputElement | null>(null);
 
+  // Refs track the freshest focus index + page rows so the window
+  // keyboard handler (which captures closures each effect run) always
+  // reads the current values, not a snapshot from an earlier render.
+  const focusedIdxRef = useRef(focusedIdx);
+  const pageRowsRef = useRef<RowItem[]>([]);
+
   // Derived: all rows (positions + mirrors, sorted by value), then
   // filtered by search, then sliced for the current page.
   const allRows: RowItem[] = useMemo(() => {
@@ -93,6 +92,11 @@ export function PortfolioPage() {
     const start = (page - 1) * PAGE_SIZE;
     return visible.slice(start, start + PAGE_SIZE);
   }, [visible, page]);
+
+  // Keep refs aligned with the current render so the window listener
+  // never reads a stale snapshot.
+  focusedIdxRef.current = focusedIdx;
+  pageRowsRef.current = pageRows;
 
   // Derive selectedPosition from the UNFILTERED positions so the
   // detail panel keeps rendering when the operator narrows search.
@@ -137,6 +141,9 @@ export function PortfolioPage() {
     if (row.kind === "position") {
       setSelectedId(row.data.instrument_id);
       setFocusedIdx(idxOnPage);
+      // Any stale multi-trade hint becomes irrelevant once the
+      // operator picks a new row — clear it.
+      setHint(null);
     }
     // Mirror rows intentionally do not set selection — the row itself
     // navigates via MirrorRow's onClick.
@@ -188,22 +195,26 @@ export function PortfolioPage() {
       }
 
       if (e.key === "j") {
-        if (pageRows.length === 0) return;
-        setFocusedIdx((i) => Math.min(i + 1, pageRows.length - 1));
+        const rows = pageRowsRef.current;
+        if (rows.length === 0) return;
+        setFocusedIdx((i) => Math.min(i + 1, rows.length - 1));
         e.preventDefault();
         return;
       }
       if (e.key === "k") {
-        if (pageRows.length === 0) return;
+        const rows = pageRowsRef.current;
+        if (rows.length === 0) return;
         setFocusedIdx((i) => Math.max(i - 1, 0));
         e.preventDefault();
         return;
       }
       if (e.key === "Enter") {
-        if (pageRows.length === 0) return;
-        const target = pageRows[focusedIdx];
+        const rows = pageRowsRef.current;
+        if (rows.length === 0) return;
+        const target = rows[focusedIdxRef.current];
         if (target !== undefined && target.kind === "position") {
           setSelectedId(target.data.instrument_id);
+          setHint(null);
         }
         e.preventDefault();
         return;
@@ -211,6 +222,7 @@ export function PortfolioPage() {
       if (e.key === "b") {
         if (selectedPosition === null) return;
         setAddFor(selectedPosition);
+        setHint(null);
         e.preventDefault();
         return;
       }
@@ -223,6 +235,7 @@ export function PortfolioPage() {
             trade: trades[0],
             valuationSource: selectedPosition.valuation_source,
           });
+          setHint(null);
         } else if (trades.length > 1) {
           setHint(
             "Close requires a single broker position — use the detail panel.",
@@ -235,7 +248,7 @@ export function PortfolioPage() {
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [addFor, closeFor, pageRows, focusedIdx, selectedPosition]);
+  }, [addFor, closeFor, selectedPosition]);
 
   return (
     <div className="space-y-4">

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { fetchPortfolio } from "@/api/portfolio";
 import { useAsync } from "@/lib/useAsync";
@@ -108,11 +108,15 @@ export function PortfolioPage() {
   }, [selectedId, portfolio.data]);
 
   // Keep refs aligned with the current render so the window listener
-  // never reads a stale snapshot. Must run AFTER selectedPosition is
-  // derived.
-  focusedIdxRef.current = focusedIdx;
-  pageRowsRef.current = pageRows;
-  selectedPositionRef.current = selectedPosition;
+  // never reads a stale snapshot. Using useLayoutEffect (rather than
+  // assigning during render) avoids the "no side effects in render"
+  // rule so the same code is safe under React.StrictMode double-
+  // rendering and future concurrent-mode invariants.
+  useLayoutEffect(() => {
+    focusedIdxRef.current = focusedIdx;
+    pageRowsRef.current = pageRows;
+    selectedPositionRef.current = selectedPosition;
+  });
 
   // Clamp focusedIdx when pageRows.length changes.
   useEffect(() => {

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -309,8 +309,8 @@ export function PortfolioPage() {
                   focusedIdx={focusedIdx}
                   selectedId={selectedId}
                   onSelectRow={handleSelectRow}
-                  onAdd={setAddFor}
-                  onClose={setCloseFor}
+                  onAdd={(p) => setAddFor(p)}
+                  onClose={(t) => setCloseFor(t)}
                 />
                 {visible.length > PAGE_SIZE ? (
                   <PaginationBar
@@ -343,8 +343,8 @@ export function PortfolioPage() {
             <DetailPanel
               selectedPosition={selectedPosition}
               currency={currency}
-              onAdd={setAddFor}
-              onCloseTrade={setCloseFor}
+              onAdd={(p) => setAddFor(p)}
+              onCloseTrade={(t) => setCloseFor(t)}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Second PR of the product-visibility pivot. Refactors PortfolioPage from a report into a split-pane workbench.
- Row click selects a position; right-side DetailPanel renders position snapshot, per-broker-position rows with Close buttons, latest thesis, latest score, latest filings.
- Keyboard: `/` search · `j`/`k` move · `Enter` select · `Esc` clear · `b` Add · `c` Close (single-trade only, hint shown for multi-trade).
- Pagination at 50 rows/page with clamp-on-search-shrink.
- Stale-selection clamp: after a `/portfolio` refetch drops the selected instrument, `selectedId` is cleared so `b`/`c` cannot open a ghost-position modal.

## Why
Operator goes from "looks at positions and clicks through to see detail" to "one click populates the workbench; zero clicks to act". Closes the aggregated-position close gap #313 deferred — per-broker-position rows in the detail panel each carry their own Close button.

## Design
Spec: `docs/superpowers/specs/2026-04-18-portfolio-workstation-design.md` (Codex pre-spec approved over four passes; pre-push review clean).

Detail panel reuses `PositionItem` from `/portfolio` (display currency) + fetches thesis / filings / scores on selection change. Thesis valuation fields render as bare numbers with a native-currency caption since `ThesisDetail` carries no currency field and the panel deliberately does not duplicate the modal's `/portfolio/instruments/{id}` fetch.

Keyboard handler is attached at the window level so shortcuts work before any DOM element has focus, gated on: no input focused (Esc exempted), no modal open, no modifier keys.

## Test plan
- [x] `pnpm --dir frontend typecheck` pass
- [x] `pnpm --dir frontend test` 227 pass (26 new cases covering row selection, keyboard shortcuts before/after click, modal wiring, Ctrl+b ignored, multi-trade `c` hint, stale-selection-after-refetch, zero-rows empty state, 51-row pagination, clamp-after-search, thesis 404 empty state)
- [x] `uv run ruff check`, `ruff format --check`, `pyright`, `pytest` (no-ops — no backend changes)
- [ ] Manual browser verification (auth-gated; operator to finish click-through before merge):
  - Select a row → detail panel populates
  - `/`, `j`, `k`, `Enter`, `Esc`, `b`, `c` shortcuts
  - Per-broker-position Close button closes only that broker position
  - Pagination appears when >50 positions (may need dev-seed)

## Settled-decisions alignment
- Close-position safety invariant: per-broker-position Close routes through `ClosePositionModal` → `POST /portfolio/positions/{id}/close` (still operator-UI only).
- Demo-first / long-only / product-visibility pivot: all unchanged.

## Prevention-log alignment
- async-data-loading: each DetailPanel source owns its own loading / error / empty state.
- #127 / #125: modal behavior inherited from #313 (closes before refetch; mountedRef guards).
- Test selectors: `getByRole` / `getByTestId` only, no positional indices (#135).

🤖 Generated with [Claude Code](https://claude.com/claude-code)