### PR TITLE
feat(#323): AdminPage triage rewrite + layer failure history

### DIFF
--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -169,6 +169,10 @@ def get_sync_layers(
 ) -> dict[str, Any]:
     """All 15 layers with freshness + last successful run."""
     from app.services.sync_orchestrator import LAYERS
+    from app.services.sync_orchestrator.layer_failure_history import (
+        consecutive_failures,
+        last_error_category,
+    )
 
     # _LAYER_TO_JOB is built and asserted-disjoint at module import.
     out: list[dict[str, Any]] = []
@@ -205,6 +209,15 @@ def get_sync_layers(
             last = cur.fetchone()
         last_success_at = last["finished_at"] if last else None
         last_start = last["started_at"] if last else None
+        # Failure history comes from sync_layer_progress, not from
+        # job_runs. The in-request predicate_error above only fires
+        # when freshness evaluation itself raised; it does not cover
+        # "the layer has failed three runs in a row". Both callers
+        # are triage signals, so we prefer the in-request error when
+        # present and fall back to the most-recent-persisted category
+        # otherwise.
+        consec = consecutive_failures(conn, name)
+        persisted_error = last_error_category(conn, name)
         out.append(
             {
                 "name": name,
@@ -216,8 +229,8 @@ def get_sync_layers(
                 "last_duration_seconds": (
                     int((last_success_at - last_start).total_seconds()) if last_success_at and last_start else None
                 ),
-                "last_error_category": predicate_error,
-                "consecutive_failures": 0,
+                "last_error_category": predicate_error or persisted_error,
+                "consecutive_failures": consec,
                 "dependencies": list(layer.dependencies),
                 "is_blocking": layer.is_blocking,
             }

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -174,8 +174,10 @@ def get_sync_layers(
     )
 
     # One pair of queries instead of two-per-layer in the loop below.
-    # Was O(N) round-trips; now O(1).
-    failure_streaks, persisted_errors = all_layer_histories(conn)
+    # Was O(N) round-trips; now O(1). The layer name filter keeps both
+    # queries on an index seek regardless of how large the history
+    # table grows.
+    failure_streaks, persisted_errors = all_layer_histories(conn, list(LAYERS.keys()))
 
     # _LAYER_TO_JOB is built and asserted-disjoint at module import.
     out: list[dict[str, Any]] = []

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -170,9 +170,12 @@ def get_sync_layers(
     """All 15 layers with freshness + last successful run."""
     from app.services.sync_orchestrator import LAYERS
     from app.services.sync_orchestrator.layer_failure_history import (
-        consecutive_failures,
-        last_error_category,
+        all_layer_histories,
     )
+
+    # One pair of queries instead of two-per-layer in the loop below.
+    # Was O(N) round-trips; now O(1).
+    failure_streaks, persisted_errors = all_layer_histories(conn)
 
     # _LAYER_TO_JOB is built and asserted-disjoint at module import.
     out: list[dict[str, Any]] = []
@@ -215,9 +218,10 @@ def get_sync_layers(
         # "the layer has failed three runs in a row". Both callers
         # are triage signals, so we prefer the in-request error when
         # present and fall back to the most-recent-persisted category
-        # otherwise.
-        consec = consecutive_failures(conn, name)
-        persisted_error = last_error_category(conn, name)
+        # otherwise. Both values come from the two batched queries
+        # above — no per-layer round-trips.
+        consec = failure_streaks.get(name, 0)
+        persisted_error = persisted_errors.get(name)
         out.append(
             {
                 "name": name,

--- a/app/services/sync_orchestrator/layer_failure_history.py
+++ b/app/services/sync_orchestrator/layer_failure_history.py
@@ -1,0 +1,107 @@
+"""Failure-history helpers for `/sync/layers`.
+
+The endpoint's response model declares `consecutive_failures` and
+`last_error_category`, but the legacy implementation hardcoded
+`consecutive_failures=0` and only populated `last_error_category` from
+the in-request freshness-predicate exception path. That meant a layer
+that has failed 3 consecutive times in `sync_layer_progress` was
+indistinguishable on the wire from a healthy layer.
+
+These helpers compute both values from `sync_layer_progress` so the
+Problems panel on the AdminPage can trust them.
+
+Contract:
+- `consecutive_failures(conn, layer_name)`:
+  number of most-recent `status='failed'` rows for the layer, ordered
+  by `started_at DESC`, stopping at the first non-failed row. Returns
+  0 when the layer has no history or when the latest run was not a
+  failure. Pending / running rows count as non-failed (they reset the
+  streak conservatively — we do not call a layer "still failing" while
+  it is in the middle of a fresh attempt).
+- `last_error_category(conn, layer_name)`:
+  the `error_category` value from the most recent `sync_layer_progress`
+  row for the layer where that column is non-null, regardless of
+  status. Returns None when the layer has never recorded an
+  error_category. This survives a later partial/skipped run that did
+  not overwrite the column, which is the desired "last known error"
+  semantics for an operator triage panel.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+
+def consecutive_failures(
+    conn: psycopg.Connection[Any],
+    layer_name: str,
+) -> int:
+    """Count how many of the most-recent progress rows were 'failed'.
+
+    Stops counting at the first non-failed row (or zero rows). A
+    pending / running / complete / skipped / partial row breaks the
+    streak. The count includes the most recent row if and only if it
+    was a failure.
+    """
+    # Postgres sorts nulls first on DESC. `started_at` is nullable —
+    # pending rows are inserted without it (executor.py:154), and
+    # skipped-by-reaper rows only set finished_at (executor.py:448).
+    # Without NULLS LAST, an old row with null started_at can sit
+    # ahead of fresh failures and falsely zero the streak.
+    # `sync_run_id DESC` is a stable tiebreak when two rows share a
+    # `started_at` timestamp.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT status
+            FROM sync_layer_progress
+            WHERE layer_name = %s
+            ORDER BY started_at DESC NULLS LAST, sync_run_id DESC
+            LIMIT 50
+            """,
+            (layer_name,),
+        )
+        rows = cur.fetchall()
+    streak = 0
+    for row in rows:
+        if row["status"] == "failed":
+            streak += 1
+        else:
+            break
+    return streak
+
+
+def last_error_category(
+    conn: psycopg.Connection[Any],
+    layer_name: str,
+) -> str | None:
+    """Return the most recent non-null error_category for the layer.
+
+    Orders by `started_at DESC` and returns the first non-null match,
+    or None when no row has ever recorded a category. Includes
+    successful rows — if a layer partially succeeded but recorded a
+    category, we want to surface that. In practice the executor only
+    writes `error_category` on non-success paths, so this is a
+    defensive allowance rather than an observed case.
+    """
+    # NULLS LAST + sync_run_id tiebreak for the same reason as
+    # `consecutive_failures` — see that function for the rationale.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT error_category
+            FROM sync_layer_progress
+            WHERE layer_name = %s AND error_category IS NOT NULL
+            ORDER BY started_at DESC NULLS LAST, sync_run_id DESC
+            LIMIT 1
+            """,
+            (layer_name,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    category = row["error_category"]
+    return str(category) if category is not None else None

--- a/app/services/sync_orchestrator/layer_failure_history.py
+++ b/app/services/sync_orchestrator/layer_failure_history.py
@@ -1,5 +1,10 @@
 """Failure-history helpers for `/sync/layers`.
 
+Also exposes `all_layer_histories(conn)` for the `/sync/layers`
+endpoint so the per-layer loop can share a single pair of queries
+instead of issuing two round-trips per layer (30 total for 15 layers).
+
+
 The endpoint's response model declares `consecutive_failures` and
 `last_error_category`, but the legacy implementation hardcoded
 `consecutive_failures=0` and only populated `last_error_category` from
@@ -105,3 +110,88 @@ def last_error_category(
         return None
     category = row["error_category"]
     return str(category) if category is not None else None
+
+
+def all_layer_histories(
+    conn: psycopg.Connection[Any],
+) -> tuple[dict[str, int], dict[str, str | None]]:
+    """Batched equivalent of (consecutive_failures, last_error_category).
+
+    Returns a pair of dicts keyed by layer_name:
+      - consecutive failure streaks (layer -> int, 0 if no failures at head)
+      - last non-null error category (layer -> str | None)
+
+    Each map is computed with a single query using window functions,
+    replacing the 15 * 2 = 30 per-request round-trips that the
+    per-layer helpers would issue when called in a loop.
+    """
+    # consecutive_failures: for each layer, count the head-streak of
+    # status='failed' rows when ordered by (started_at DESC NULLS LAST,
+    # sync_run_id DESC). We compute a row_number per layer in that
+    # ordering and count how many of the first N rows are 'failed'
+    # before hitting a non-failed one.
+    #
+    # SQL pattern: find the row_number of the FIRST non-failed row
+    # per layer; the streak length is (that row_number - 1), or the
+    # total row count for that layer if every row is 'failed'.
+    streaks: dict[str, int] = {}
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            WITH ranked AS (
+                SELECT
+                    layer_name,
+                    status,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY layer_name
+                        ORDER BY started_at DESC NULLS LAST, sync_run_id DESC
+                    ) AS rn
+                FROM sync_layer_progress
+            ),
+            first_non_failed AS (
+                SELECT layer_name, MIN(rn) AS rn
+                FROM ranked
+                WHERE status <> 'failed'
+                GROUP BY layer_name
+            ),
+            totals AS (
+                SELECT layer_name, COUNT(*) AS total
+                FROM sync_layer_progress
+                GROUP BY layer_name
+            )
+            SELECT
+                t.layer_name,
+                COALESCE(f.rn - 1, t.total) AS streak
+            FROM totals t
+            LEFT JOIN first_non_failed f USING (layer_name);
+            """
+        )
+        for row in cur.fetchall():
+            streaks[str(row["layer_name"])] = int(row["streak"])
+
+    categories: dict[str, str | None] = {}
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            WITH ranked AS (
+                SELECT
+                    layer_name,
+                    error_category,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY layer_name
+                        ORDER BY started_at DESC NULLS LAST, sync_run_id DESC
+                    ) AS rn
+                FROM sync_layer_progress
+                WHERE error_category IS NOT NULL
+            )
+            SELECT layer_name, error_category
+            FROM ranked
+            WHERE rn = 1;
+            """
+        )
+        for row in cur.fetchall():
+            categories[str(row["layer_name"])] = (
+                str(row["error_category"]) if row["error_category"] is not None else None
+            )
+
+    return streaks, categories

--- a/app/services/sync_orchestrator/layer_failure_history.py
+++ b/app/services/sync_orchestrator/layer_failure_history.py
@@ -172,8 +172,17 @@ def all_layer_histories(
                 GROUP BY layer_name
             ),
             totals AS (
-                SELECT DISTINCT layer_name, total
+                -- MAX(total) is deterministic here because
+                -- COUNT(*) OVER (PARTITION BY layer_name) yields
+                -- the same value across every row within a partition.
+                -- GROUP BY ensures exactly one row per layer_name
+                -- even if a concurrent writer were somehow to let
+                -- the window see slightly different per-partition
+                -- counts — DISTINCT on a window-function column
+                -- would fan out in that (theoretical) case.
+                SELECT layer_name, MAX(total) AS total
                 FROM ranked
+                GROUP BY layer_name
             )
             SELECT
                 t.layer_name,

--- a/app/services/sync_orchestrator/layer_failure_history.py
+++ b/app/services/sync_orchestrator/layer_failure_history.py
@@ -144,6 +144,13 @@ def all_layer_histories(
     # total row count for that layer if every row is 'failed'.
     streaks: dict[str, int] = {}
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # Single index scan: `ranked` adds both the row_number and the
+        # per-layer total via window functions. `first_non_failed`
+        # pulls the `rn` of the first non-failed row (streak = rn - 1),
+        # and `totals` is derived from the same CTE so Postgres does
+        # not re-scan the table. The LEFT JOIN falls back to `total`
+        # when a layer has no non-failed rows at all (pure-failure
+        # history).
         cur.execute(
             """
             WITH ranked AS (
@@ -153,7 +160,8 @@ def all_layer_histories(
                     ROW_NUMBER() OVER (
                         PARTITION BY layer_name
                         ORDER BY started_at DESC NULLS LAST, sync_run_id DESC
-                    ) AS rn
+                    ) AS rn,
+                    COUNT(*) OVER (PARTITION BY layer_name) AS total
                 FROM sync_layer_progress
                 WHERE layer_name = ANY(%s)
             ),
@@ -164,10 +172,8 @@ def all_layer_histories(
                 GROUP BY layer_name
             ),
             totals AS (
-                SELECT layer_name, COUNT(*) AS total
-                FROM sync_layer_progress
-                WHERE layer_name = ANY(%s)
-                GROUP BY layer_name
+                SELECT DISTINCT layer_name, total
+                FROM ranked
             )
             SELECT
                 t.layer_name,
@@ -175,7 +181,7 @@ def all_layer_histories(
             FROM totals t
             LEFT JOIN first_non_failed f USING (layer_name);
             """,
-            (names, names),
+            (names,),
         )
         for row in cur.fetchall():
             streaks[str(row["layer_name"])] = int(row["streak"])

--- a/app/services/sync_orchestrator/layer_failure_history.py
+++ b/app/services/sync_orchestrator/layer_failure_history.py
@@ -114,6 +114,7 @@ def last_error_category(
 
 def all_layer_histories(
     conn: psycopg.Connection[Any],
+    layer_names: list[str] | tuple[str, ...],
 ) -> tuple[dict[str, int], dict[str, str | None]]:
     """Batched equivalent of (consecutive_failures, last_error_category).
 
@@ -124,7 +125,14 @@ def all_layer_histories(
     Each map is computed with a single query using window functions,
     replacing the 15 * 2 = 30 per-request round-trips that the
     per-layer helpers would issue when called in a loop.
+
+    Both queries filter to the supplied ``layer_names`` list so
+    `sync_layer_progress` is indexed-scanned by layer name rather
+    than full-scanned — bounded cost as the table grows.
     """
+    if not layer_names:
+        return {}, {}
+    names = list(layer_names)
     # consecutive_failures: for each layer, count the head-streak of
     # status='failed' rows when ordered by (started_at DESC NULLS LAST,
     # sync_run_id DESC). We compute a row_number per layer in that
@@ -147,6 +155,7 @@ def all_layer_histories(
                         ORDER BY started_at DESC NULLS LAST, sync_run_id DESC
                     ) AS rn
                 FROM sync_layer_progress
+                WHERE layer_name = ANY(%s)
             ),
             first_non_failed AS (
                 SELECT layer_name, MIN(rn) AS rn
@@ -157,6 +166,7 @@ def all_layer_histories(
             totals AS (
                 SELECT layer_name, COUNT(*) AS total
                 FROM sync_layer_progress
+                WHERE layer_name = ANY(%s)
                 GROUP BY layer_name
             )
             SELECT
@@ -164,7 +174,8 @@ def all_layer_histories(
                 COALESCE(f.rn - 1, t.total) AS streak
             FROM totals t
             LEFT JOIN first_non_failed f USING (layer_name);
-            """
+            """,
+            (names, names),
         )
         for row in cur.fetchall():
             streaks[str(row["layer_name"])] = int(row["streak"])
@@ -182,16 +193,18 @@ def all_layer_histories(
                         ORDER BY started_at DESC NULLS LAST, sync_run_id DESC
                     ) AS rn
                 FROM sync_layer_progress
-                WHERE error_category IS NOT NULL
+                WHERE error_category IS NOT NULL AND layer_name = ANY(%s)
             )
             SELECT layer_name, error_category
             FROM ranked
             WHERE rn = 1;
-            """
+            """,
+            (names,),
         )
         for row in cur.fetchall():
-            categories[str(row["layer_name"])] = (
-                str(row["error_category"]) if row["error_category"] is not None else None
-            )
+            # WHERE error_category IS NOT NULL in the CTE already
+            # guarantees we never see a NULL here — the cast is just
+            # for mypy/pyright's benefit on `object` columns.
+            categories[str(row["layer_name"])] = str(row["error_category"])
 
     return streaks, categories

--- a/docs/superpowers/specs/2026-04-19-admin-triage-design.md
+++ b/docs/superpowers/specs/2026-04-19-admin-triage-design.md
@@ -1,0 +1,329 @@
+# AdminPage triage rewrite — design spec
+
+**Issue:** [#323](https://github.com/Luke-Bradford/eBull/issues/323)
+**Size:** M (~1-2 days, frontend + narrow backend additions — see §3a)
+**Depends on:** nothing (uses existing `/sync/layers`, `/sync/status`, `/sync/runs`, `/coverage/summary`, `/system/jobs`, `/recommendations` endpoints).
+
+---
+
+## 1. Goal
+
+Redesign `AdminPage` so the operator can answer three questions in order, without scrolling or decoding the current flat 15-card grid:
+
+1. **What is broken right now?** — failing layers, stuck layers, jobs with consecutive failures, coverage anomalies.
+2. **What does the fund data actually look like?** — compact stat cards for the data available today (universe size, analysable coverage, needs-review bucket, latest-recommendation freshness). Cells that depend on endpoints we do not yet have (tier distribution, score/thesis summaries) render as `"–" (pending)` placeholders and are tracked in §14.
+3. **What is the orchestrator doing long-term?** — current layer grid + recent sync runs + background jobs, but **collapsed by default**.
+
+Operator should see "good / bad / running" in <2 seconds, drill down only when needed.
+
+## 2. Diagnostic findings that motivate the design
+
+From 2026-04-19 audit (`data/raw/` cleanup session):
+
+- `cik_mapping` failed 3× in 7d with `db_constraint` error_category. **Invisible on current page.**
+- `universe` + `candles` haven't run in 2 days. **Current dashboard shows them "stale" but buried next to 13 healthy cards.**
+- `thesis` layer: 0 rows ever; `prereq_skip` on every run. **Dashboard shows a freshness detail but nothing that signals "this pillar of the product has never worked".**
+- 5 trade_recommendations total, all rejected. **Dashboard doesn't mention recommendations at all.**
+- 5 of 12,362 instruments on Tier 1 (tradable universe). **Dashboard has coverage cells but no tier-1/tier-2/tier-3 count.**
+- `raw_persistence_state` empty — Plan A compaction never ran. **Out of scope for this PR (no existing endpoint surfaces this); note for follow-up.**
+
+## 3. Non-goals (pin)
+
+- **No new backend endpoints.** (Small backend additions to existing endpoint response objects are permitted — see §3a.)
+- **No raw-storage visibility** (`data/raw/` disk usage, `raw_persistence_state` rows). Both require a new backend surface. Track as tech-debt (§14).
+- **No notifications / alerting / toast system.**
+- **No preservation of current top-level layout.** The Sync-dashboard-first framing is the exact source of the noise; it flips.
+- **No new tier-1 / tier-2 breakdown endpoint.** `/coverage/summary` already exposes `analysable`, `insufficient`, etc., but not coverage_tier counts. We surface what exists and flag the tier distribution as a follow-up (§14).
+- **No rewrite of `SyncDashboard`'s internals.** The 15-card grid, recent-runs table, and layer-card internals stay as-is. The ONE change is that `SyncDashboard` consumes a shared `useSyncTrigger` via a required prop (§11) instead of owning its own trigger state — so the top-level and inner buttons cannot race.
+- **No mutation of background-jobs UX** — the existing JobsTable + Run-Now buttons stay verbatim, just hidden by default.
+
+## 3a. In-scope backend additions
+
+`/sync/layers` currently hardcodes `consecutive_failures: 0` and only sets `last_error_category` on freshness-predicate exceptions (`app/api/sync.py:219-220`). Both fields exist on the response model but are lies against live data. The Problems panel depends on them being truthful.
+
+Narrow backend work shipped with this PR:
+
+- Populate `SyncLayer.consecutive_failures` = number of consecutive `status='failed'` rows for that `layer_name` in `sync_layer_progress`, ordered by `started_at DESC`, stopping at the first non-failed row (or zero rows).
+- Populate `SyncLayer.last_error_category` = `error_category` from the most recent `sync_layer_progress` row where that column is non-null for the layer, regardless of status (so "last known error" survives a later skipped/partial run).
+
+Schema: both columns already exist on `sync_layer_progress`; no migration. Service-layer change only — `app/services/sync_orchestrator/freshness.py` (or wherever `build_layer_response` lives). Response shape of `/sync/layers` is unchanged; only the values become accurate.
+
+Backend tests:
+
+- Unit test for the consecutive-failures counter (happy path, interrupted-by-success resets to 0, zero-rows returns 0).
+- Unit test for the last-error-category lookup (returns most-recent non-null, null when no history).
+
+## 4. Layout
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Problems panel (hidden when empty)                          │
+│  - One row per problem                                       │
+│  - Red for blocking, amber for warning                       │
+│  - Click-through expands each row or jumps to details        │
+├─────────────────────────────────────────────────────────────┤
+│ Fund data at a glance                                        │
+│  [tradable] [analysable] [needs review] [latest rec] [tier1/2/3 pending] [scores pending] ... │
+│  — always visible, one row of stat cards                     │
+├─────────────────────────────────────────────────────────────┤
+│ Orchestrator details   [▸]        (collapsed by default)     │
+│   On expand: current SyncDashboard unchanged inside          │
+├─────────────────────────────────────────────────────────────┤
+│ Background tasks       [▸]        (collapsed by default)     │
+│   On expand: current JobsTable unchanged inside              │
+├─────────────────────────────────────────────────────────────┤
+│ Filings coverage       [▸]        (collapsed by default)     │
+│   On expand: current CoverageSummaryCard unchanged           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Sync-now button stays visible at the top** (outside the collapsible) — triggering a sync is a top-level verb.
+
+## 5. Problems panel
+
+### Inputs (all from already-loaded data)
+
+From `/sync/layers`:
+- `layer.last_error_category !== null` AND `layer.consecutive_failures >= 1` → **blocking problem** (red).
+- `layer.is_fresh === false` AND `layer.is_blocking` → **stale-blocking problem** (amber unless already red above).
+- `layer.is_fresh === false` AND NOT `layer.is_blocking` → **stale-non-blocking problem** (amber, low-priority).
+
+From `/system/jobs`:
+- `job.last_status === "failure"` → **job-failure problem** (red).
+- `job.last_status === "skipped"` is **NOT a problem** by default — `retry_deferred_recommendations` and `execute_approved_orders` skip routinely with "no work to do" reasons. This is the single biggest current noise source; we deliberately filter it out.
+
+From `/coverage/summary`:
+- `summary.null_rows > 0` → **data-audit problem** (amber; same convention as the existing CoverageSummaryCard which already renders null_rows red).
+
+### Rendering
+
+Each row shows:
+- Icon / tone
+- One-line title (`"cik_mapping layer — 3 consecutive failures (db_constraint)"`)
+- Secondary line: last-success timestamp, action link (e.g. "Open orchestrator details" — scrolls + expands the orchestrator section).
+
+Empty state: panel is not rendered at all. No "No problems!" banner. Empty = good.
+
+### What the panel is NOT
+
+- Not a running tally of every warning in the system. Only current problems, not history.
+- Not an inbox — no dismissal, no snooze. Fix the underlying problem and the row disappears on the next refresh.
+- Not a notifications feed — no timestamps older than the last successful run.
+
+## 6. Fund data at a glance
+
+Stat cards, single row at ≥sm. Two rows at xs.
+
+| Stat | Source | Format |
+|---|---|---|
+| Tradable universe | `coverage.total_tradable` | count |
+| Analysable | `coverage.analysable` | count + % |
+| Needs review | `coverage.insufficient + coverage.structurally_young` | count + % |
+| Recommendations | `/recommendations?limit=1` | freshness only (count is post-HOLD-dedupe; not meaningful) |
+| Tier 1/2/3 | pending (§14 tech-debt) | placeholder "–" |
+| Scores | pending (§14 tech-debt) | placeholder "–" |
+| Theses | pending (§14 tech-debt) | placeholder "–" |
+
+**Constraint:** several of the stat cells above need backend data we do not currently expose. In-scope for this PR:
+
+- Tradable universe — already present as `coverage.total_tradable`.
+- Analysable — already present as `coverage.analysable`.
+- "Needs review" bucket — already present as `coverage.insufficient + coverage.structurally_young`.
+- Recommendations **freshness** — `fetchRecommendations({action:null,status:null,instrument_id:null}, 0, 1)` returns `items[0].created_at`. We render only the freshness timestamp from this endpoint, NOT a total count — the endpoint's `total` field is post-HOLD-dedupe (see `app/api/recommendations.py:177`), which is not a meaningful "how many recommendations exist" number. If items is empty, render "never".
+
+**Out of scope (rendered as placeholder "–" with a small tooltip "data pending"):**
+
+- Tier 1/2/3 count — coverage summary lacks this; surface as tech-debt.
+- Raw trade-recommendation count — HOLD-deduped endpoint is not fit for purpose; tech-debt.
+- Latest scores count + freshness — no summary endpoint; tech-debt.
+- Latest theses count + freshness — same; tech-debt.
+
+The fund-data row still adds value with 4 live cells (tradable, analysable, needs-review, latest recommendation time) even before we fill the rest.
+
+## 7. Collapsible sections
+
+Each has `useState<boolean>(false)` for open state. On `true`, render the existing component with its internal layout preserved. Only `SyncDashboard` carries the prop-level refactor for the shared trigger (§11); its rendered grid / runs table stay identical.
+
+- **Orchestrator details** → `<SyncDashboard syncTrigger={trigger} />`. Grid + recent-runs unchanged. The Problems panel's "Open orchestrator details" link auto-expands this section and scrolls to it.
+- **Background tasks** → `<JobsTable />` unchanged, plus the intro sentence and Run-Now wiring. Keep `ORCHESTRATOR_OWNED` filter.
+- **Filings coverage** → `<CoverageSummaryCard />` unchanged.
+
+Click-to-expand header: chevron + title + secondary stat (e.g. "Orchestrator details — 1 problem"). Makes the summary informative even without expanding.
+
+## 8. State + auto-refresh
+
+AdminPage itself owns a top-level auto-refresh loop. Rationale: `SyncDashboard` is collapsed by default (§7), so its internal `setInterval` does not run when the section is unmounted — the Problems panel would go stale without its own driver. We must not depend on `SyncDashboard` being mounted.
+
+Top-level fetches owned by AdminPage:
+
+- `fetchSyncLayers()` — drives Problems panel + orchestrator-details collapsible header summary.
+- `fetchSyncStatus()` — drives the top-level "running" banner + Sync-now button state.
+- `fetchCoverageSummary()` — drives fund-data cells + CoverageSummaryCard when expanded.
+- `fetchJobsOverview()` — drives Problems panel job rows + JobsTable when expanded.
+- `fetchRecommendations({action:null,status:null,instrument_id:null}, 0, 1)` — drives Fund-data "latest recommendation" freshness cell. (Count is NOT used — see §6 revision.)
+
+Each fetch uses `useAsync` independently (per `async-data-loading.md`). AdminPage starts a `setInterval` with cadence: 10s when `status.data?.is_running === true`, 60s otherwise. Matches the prior `SyncDashboard` contract.
+
+`SyncDashboard` keeps its own internal fetches (for its own grid + runs table). When it mounts, both AdminPage and the inner dashboard are hitting `/sync/layers` and `/sync/status` — acceptable duplication matching the `/config` pattern; shared cache is tech-debt #320.
+
+### ProblemsPanel render contract during loading / error / refetch
+
+`useAsync` clears `data` to `null` at refetch start (prevention #93 / async-data-loading.md). The Problems panel depends on THREE independent sources (`/sync/layers`, `/system/jobs`, `/coverage/summary`). A naive "combine live values, render nothing if any is null" would drop an entire source's problems the moment that source refetches.
+
+Apply the `safety-state-ui.md` cached-snapshot pattern **per source**, then combine at render time. The cache is NOT a single `Problem[]` — it is a per-source struct:
+
+```ts
+interface ProblemSources {
+  readonly layers: Problem[] | null;   // null = never resolved
+  readonly jobs: Problem[] | null;
+  readonly coverage: Problem[] | null;
+}
+```
+
+Contract for each source independently:
+
+- On a non-null fresh response for source `X`, replace `cache.X` with the newly-derived `Problem[]` for that source.
+- On a null fresh value (loading or error), LEAVE `cache.X` unchanged — do not overwrite with `null`.
+- Render `cache.layers ∪ cache.jobs ∪ cache.coverage`, filtering out any source that has never resolved (value still `null`).
+
+Resulting behaviour:
+
+- **First mount (all caches `null`)**: render one-line neutral banner `"Checking for problems…"`. Panel is NOT hidden and not rendered empty.
+- **After first source resolves**: render whatever problems it surfaced. Neutral banner persists with `"Checking {remaining} more sources…"` suffix until all three have returned at least once.
+- **All three sources have resolved at least once, combined problems empty**: panel is hidden. "Hidden = good" invariant holds from this point on.
+- **Refetch in flight on one source**: that source's last-good snapshot keeps rendering. Other sources unaffected.
+- **Refetch errored on one source**: inline amber "Could not re-check {source_name} — using last known state" line at top of the panel; cached problems for that source still render.
+
+This closes the under-specification gap: no single source can drop another source's problems by virtue of being in-flight.
+
+## 9. File plan
+
+### New files (frontend)
+
+- `frontend/src/components/admin/ProblemsPanel.tsx` — the triage list with per-source cached snapshots.
+- `frontend/src/components/admin/FundDataRow.tsx` — stat cards.
+- `frontend/src/components/admin/CollapsibleSection.tsx` — shared reusable wrapper with chevron header.
+- `frontend/src/lib/useSyncTrigger.ts` — shared sync-now hook (§11).
+- `frontend/src/components/admin/ProblemsPanel.test.tsx`
+- `frontend/src/components/admin/FundDataRow.test.tsx`
+- `frontend/src/lib/useSyncTrigger.test.ts`
+
+### Modified files (frontend)
+
+- `frontend/src/pages/AdminPage.tsx` — new top-level composition. Owns the auto-refresh loop, the `useSyncTrigger` instance, and the five top-level fetches listed in §8 (`/sync/layers`, `/sync/status`, `/coverage/summary`, `/system/jobs`, `/recommendations`). Wraps `SyncDashboard` + `JobsTable` + `CoverageSummaryCard` in `CollapsibleSection`.
+- `frontend/src/pages/AdminPage.test.tsx` — minor updates for new layout assertions + top-level Sync-now button wiring.
+- `frontend/src/pages/SyncDashboard.tsx` — **not verbatim.** Refactored to consume `useSyncTrigger` via a required prop instead of owning its own `triggerState`. The grid, recent-runs table, and layer-card internals are unchanged; only the button's trigger wiring moves out.
+- `frontend/src/pages/SyncDashboard.test.tsx` — updated fixtures to pass a fake `useSyncTrigger` result; otherwise unchanged in spirit.
+
+### New/modified files (backend, §3a)
+
+- `app/services/sync_orchestrator/freshness.py` (or the existing layer-response builder — to be confirmed during implementation) — populate `consecutive_failures` + `last_error_category` from `sync_layer_progress` rather than hardcoding.
+- `tests/test_sync_orchestrator_api.py` (or adjacent unit test file) — add coverage for the two new calculations.
+
+### Unchanged
+
+- `api/sync.ts` — no new types; `SyncLayer` already declares both fields.
+- Any other `frontend/src/api/*.ts` file — no new fetchers.
+- Migrations — none; both DB columns already exist on `sync_layer_progress`.
+
+## 10. Test plan
+
+**ProblemsPanel**:
+- Renders "Checking for problems…" banner on first mount (cache empty).
+- Renders nothing once all three sources have resolved at least once and the combined problem list is empty.
+- Renders last-good cached problems for source X while source X is refetching (null fresh value).
+- Renders one row per failing layer (with `consecutive_failures > 0`).
+- Renders one row per stale blocking layer.
+- Renders one row per failed job, but NOT for skipped jobs.
+- Renders one row when `coverage.null_rows > 0`.
+- Shows error_category on the row.
+- Clicking "Open orchestrator details" expands that section (callback fires).
+
+**FundDataRow**:
+- Renders 4 live cells.
+- Renders placeholder "–" with tooltip for the 3 data-pending cells.
+- No crash when `/coverage/summary` or `/recommendations` fail individually — affected cells render "–" with error tone.
+
+**AdminPage**:
+- Orchestrator details section is collapsed on mount.
+- Click chevron expands it; SyncDashboard rows render.
+- Problems panel's "Open orchestrator details" link expands the section programmatically.
+- Top-level Sync-now button fires via `useSyncTrigger` and both the top-level button AND the inner `SyncDashboard` button reflect the same state; clicking either fires exactly one POST (§11).
+
+## 11. Sync-now placement
+
+Currently inside `SyncDashboard`. If `SyncDashboard` is collapsed, the button is not visible. Operator needs a top-level Sync-now. Two concurrent buttons (top + inner when expanded) calling the same `triggerSync({scope:"full"})` must not both fire a POST.
+
+### Decision: hoist the trigger state out of `SyncDashboard` into a shared hook
+
+`useSyncTrigger()` — new hook at `frontend/src/lib/useSyncTrigger.ts`:
+
+```ts
+export interface SyncTriggerState {
+  readonly kind: "idle" | "running" | "queued" | "error";
+  readonly queuedRunId: number | null;
+  readonly message: string | null;
+  readonly trigger: () => Promise<void>;
+  readonly clearError: () => void;
+}
+
+export function useSyncTrigger(onTriggered: () => void): SyncTriggerState;
+```
+
+`SyncDashboard` is refactored to consume `useSyncTrigger` from a prop rather than owning its own `triggerState`. `AdminPage` creates ONE `useSyncTrigger` instance and passes it to both the top-level button AND `SyncDashboard`. Both buttons reflect the same state; the trigger is only invoked once; `kind === "running"` OR `kind === "queued"` disables every button that references the hook. The inner `SyncDashboard` tests remain valid once a fake hook is plugged in.
+
+This is the only code change to `SyncDashboard` — and it's the minimum needed to uphold the "never double-trigger" invariant.
+
+### Display contract
+
+Top-level button ALWAYS visible. Inner button only visible when orchestrator details is expanded. Both render the same label based on the shared state:
+
+- `idle` → "Sync now"
+- `running` or queued → "Running…" / "Queued" (disabled)
+- `error` → error message inline (disabled briefly, then re-enabled on next `idle` transition via clearError).
+
+If the operator clicks the top button and a sync is already running (backend-initiated by scheduler, not by us), the trigger returns 409. The hook surfaces that as `kind: "error", message: "Sync already running"` — same contract as today's `SyncDashboard` local handler.
+
+## 12. Settled-decisions + prevention alignment
+
+- **Kill switch separate from config flags** — unchanged; we don't touch that surface.
+- **async-data-loading.md** — every `useAsync` in this PR owns its own error surface; Problems panel is an inline view, not a global banner.
+- **safety-state-ui.md** — no safety indicators in scope (kill-switch / demo-live are elsewhere).
+- **#127 API shape** — mirrors `SyncLayer` / `CoverageSummaryResponse` / `RecommendationsListResponse` verbatim; no fabricated fields.
+- **#319 Duplicate types** — `CollapsibleSection` exports one `Props` interface, imported by every caller.
+
+## 13. Rollout + verification
+
+Before push:
+1. `pnpm --dir frontend typecheck` + `test` pass.
+2. `uv run ruff/format/pyright/pytest` — no-ops but run.
+
+Browser verify (operator):
+3. Load `/admin` with current live data. Expect:
+   - Problems panel shows at least 2-3 rows (`cik_mapping`, `universe`, `candles`).
+   - Fund-data row renders 4 live cells with real numbers + 3 placeholder "–".
+   - Orchestrator details + background tasks collapsed.
+4. Click Orchestrator details chevron → SyncDashboard renders unchanged.
+5. Click "Open orchestrator details" from Problems → section auto-expands + smooth-scrolls to it.
+
+## 14. Tech debt to file alongside this PR
+
+- **Tier 1/2/3 breakdown endpoint** (`/coverage/summary` expanded to return `tier_1_count` / `tier_2_count` / `tier_3_count`).
+- **Scores summary endpoint** (`/rankings/summary` returning count + latest_scored_at).
+- **Theses summary endpoint** (`/theses/summary` returning count + latest_created_at).
+- **Raw-storage visibility endpoint** (`/system/raw-storage` returning per-source byte counts + last-compaction timestamps).
+- **`/system/jobs` consecutive-failure count** — currently each job's "skipped" is opaque; extend response so the Problems panel can distinguish "routine skipped (nothing to do)" from "skipped-but-problematic".
+
+All are independent follow-ups; none block #323.
+
+## 15. Reviewer cheat-sheet
+
+- [ ] Problems panel is not rendered when there are zero problems.
+- [ ] Skipped jobs are NOT surfaced as problems (noise filter).
+- [ ] Failing jobs ARE surfaced.
+- [ ] `cik_mapping` + `universe` + `candles` all appear in the Problems panel against the current dev DB.
+- [ ] Orchestrator details is collapsed by default.
+- [ ] "Open orchestrator details" link from a problem row expands that section.
+- [ ] Top-level Sync-now button uses the same guard as the inner one (no double-trigger possible).
+- [ ] No new backend endpoint introduced; no `apiFetch` calls outside `frontend/src/api/`.
+- [ ] Stat cards with no backing data render "–" with a small tooltip, NOT zero (which would lie).

--- a/frontend/src/components/admin/CollapsibleSection.tsx
+++ b/frontend/src/components/admin/CollapsibleSection.tsx
@@ -1,0 +1,79 @@
+/**
+ * Collapsible section wrapper for AdminPage (#323).
+ *
+ * Chevron-led header; click to toggle. Secondary stat line in the
+ * header (e.g. "Orchestrator details — 1 problem") stays informative
+ * when the section is collapsed.
+ *
+ * `defaultOpen` seeds the initial state; callers that need to drive
+ * open/close imperatively (e.g. the ProblemsPanel "Open orchestrator
+ * details" link) pass `open` + `onOpenChange` to use the controlled
+ * form. Both mutually exclusive — controlled form ignores
+ * `defaultOpen`.
+ */
+import { useState, type ReactNode } from "react";
+
+export interface CollapsibleSectionProps {
+  readonly title: string;
+  readonly summary?: ReactNode;
+  readonly children: ReactNode;
+  readonly defaultOpen?: boolean;
+  readonly open?: boolean;
+  readonly onOpenChange?: (next: boolean) => void;
+  readonly sectionId?: string;
+}
+
+export function CollapsibleSection({
+  title,
+  summary,
+  children,
+  defaultOpen = false,
+  open,
+  onOpenChange,
+  sectionId,
+}: CollapsibleSectionProps): JSX.Element {
+  const [uncontrolled, setUncontrolled] = useState<boolean>(defaultOpen);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : uncontrolled;
+
+  function toggle() {
+    const next = !isOpen;
+    if (isControlled) {
+      onOpenChange?.(next);
+    } else {
+      setUncontrolled(next);
+      onOpenChange?.(next);
+    }
+  }
+
+  return (
+    <section
+      className="rounded-md border border-slate-200 bg-white shadow-sm"
+      id={sectionId}
+    >
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={isOpen}
+        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-slate-50"
+      >
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className={`inline-block text-slate-400 transition-transform ${isOpen ? "rotate-90" : ""}`}
+          >
+            ▸
+          </span>
+          <h2 className="text-sm font-semibold text-slate-700">{title}</h2>
+          {summary ? (
+            <span className="text-xs text-slate-500">— {summary}</span>
+          ) : null}
+        </div>
+        <span className="text-xs text-slate-400">
+          {isOpen ? "Hide" : "Show"}
+        </span>
+      </button>
+      {isOpen ? <div className="border-t border-slate-100 p-4">{children}</div> : null}
+    </section>
+  );
+}

--- a/frontend/src/components/admin/FundDataRow.tsx
+++ b/frontend/src/components/admin/FundDataRow.tsx
@@ -1,0 +1,156 @@
+/**
+ * Fund-data-at-a-glance stat row (AdminPage #323, spec §6).
+ *
+ * Renders four live cells backed by existing endpoints and three
+ * `"–" (pending)` placeholders for summaries we don't yet expose.
+ * Tooltips on pending cells name the blocking tech-debt.
+ *
+ * Each cell tolerates its backing fetch failing in isolation — a
+ * dead fetch renders `–` with an amber error tone but does NOT wipe
+ * any other cell.
+ */
+import type {
+  CoverageSummaryResponse,
+  RecommendationsListResponse,
+} from "@/api/types";
+import { formatDateTime } from "@/lib/format";
+
+export interface FundDataRowProps {
+  readonly coverage: CoverageSummaryResponse | null;
+  readonly coverageError: boolean;
+  readonly recommendations: RecommendationsListResponse | null;
+  readonly recommendationsError: boolean;
+}
+
+interface Cell {
+  readonly label: string;
+  readonly value: string;
+  readonly hint?: string;
+  readonly tone: "ok" | "pending" | "error";
+}
+
+export function FundDataRow({
+  coverage,
+  coverageError,
+  recommendations,
+  recommendationsError,
+}: FundDataRowProps): JSX.Element {
+  const cells: Cell[] = [];
+
+  cells.push(
+    coverageError
+      ? { label: "Tradable universe", value: "–", tone: "error" }
+      : coverage === null
+        ? { label: "Tradable universe", value: "–", tone: "pending" }
+        : {
+            label: "Tradable universe",
+            value: String(coverage.total_tradable),
+            tone: "ok",
+          },
+  );
+
+  cells.push(
+    coverageError
+      ? { label: "Analysable", value: "–", tone: "error" }
+      : coverage === null
+        ? { label: "Analysable", value: "–", tone: "pending" }
+        : {
+            label: "Analysable",
+            value: `${coverage.analysable} / ${coverage.total_tradable}`,
+            hint:
+              coverage.total_tradable > 0
+                ? `${pct(coverage.analysable, coverage.total_tradable)}%`
+                : undefined,
+            tone: "ok",
+          },
+  );
+
+  cells.push(
+    coverageError
+      ? { label: "Needs review", value: "–", tone: "error" }
+      : coverage === null
+        ? { label: "Needs review", value: "–", tone: "pending" }
+        : {
+            label: "Needs review",
+            value: String(
+              coverage.insufficient + coverage.structurally_young,
+            ),
+            tone: "ok",
+          },
+  );
+
+  cells.push(
+    recommendationsError
+      ? { label: "Latest recommendation", value: "–", tone: "error" }
+      : recommendations === null
+        ? { label: "Latest recommendation", value: "–", tone: "pending" }
+        : recommendations.items.length === 0
+          ? {
+              label: "Latest recommendation",
+              value: "never",
+              tone: "ok",
+            }
+          : {
+              label: "Latest recommendation",
+              value: formatDateTime(recommendations.items[0]!.created_at),
+              tone: "ok",
+            },
+  );
+
+  cells.push({
+    label: "Tier 1/2/3",
+    value: "–",
+    hint: "endpoint pending",
+    tone: "pending",
+  });
+  cells.push({
+    label: "Latest score",
+    value: "–",
+    hint: "endpoint pending",
+    tone: "pending",
+  });
+  cells.push({
+    label: "Latest thesis",
+    value: "–",
+    hint: "endpoint pending",
+    tone: "pending",
+  });
+
+  return (
+    <div
+      className="grid grid-cols-2 gap-3 rounded-md border border-slate-200 bg-white p-3 shadow-sm sm:grid-cols-4 lg:grid-cols-7"
+      data-testid="fund-data-row"
+    >
+      {cells.map((c) => (
+        <StatCell key={c.label} cell={c} />
+      ))}
+    </div>
+  );
+}
+
+function StatCell({ cell }: { cell: Cell }): JSX.Element {
+  const valueTone =
+    cell.tone === "ok"
+      ? "text-slate-800"
+      : cell.tone === "error"
+        ? "text-red-700"
+        : "text-slate-400";
+  return (
+    <div title={cell.hint ?? undefined}>
+      <div className="text-[10px] font-medium uppercase tracking-wider text-slate-400">
+        {cell.label}
+      </div>
+      <div className={`text-lg font-semibold tabular-nums ${valueTone}`}>
+        {cell.value}
+      </div>
+      {cell.hint ? (
+        <div className="text-[11px] text-slate-400">{cell.hint}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function pct(a: number, b: number): string {
+  if (b === 0) return "0.0";
+  return ((a / b) * 100).toFixed(1);
+}

--- a/frontend/src/components/admin/ProblemsPanel.test.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.test.tsx
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { ProblemsPanel } from "@/components/admin/ProblemsPanel";
+import type {
+  CoverageSummaryResponse,
+  JobsListResponse,
+} from "@/api/types";
+import type { SyncLayer, SyncLayersResponse } from "@/api/sync";
+
+function coverageClean(): CoverageSummaryResponse {
+  return {
+    checked_at: "2026-04-19T00:00:00Z",
+    analysable: 100,
+    insufficient: 0,
+    structurally_young: 0,
+    fpi: 0,
+    no_primary_sec_cik: 0,
+    unknown: 0,
+    null_rows: 0,
+    total_tradable: 100,
+  };
+}
+
+function layer(overrides: Partial<SyncLayer> = {}): SyncLayer {
+  return {
+    name: "x",
+    display_name: "X",
+    tier: 1,
+    is_fresh: true,
+    freshness_detail: "ok",
+    last_success_at: "2026-04-19T00:00:00Z",
+    last_duration_seconds: 1,
+    last_error_category: null,
+    consecutive_failures: 0,
+    dependencies: [],
+    is_blocking: true,
+    ...overrides,
+  };
+}
+
+function jobs(): JobsListResponse {
+  return { checked_at: "2026-04-19T00:00:00Z", jobs: [] };
+}
+
+function render_(
+  props: Partial<React.ComponentProps<typeof ProblemsPanel>> = {},
+) {
+  const onOpenOrchestrator = vi.fn();
+  const defaults: React.ComponentProps<typeof ProblemsPanel> = {
+    layers: { layers: [] } as SyncLayersResponse,
+    jobs: jobs(),
+    coverage: coverageClean(),
+    layersError: false,
+    jobsError: false,
+    coverageError: false,
+    onOpenOrchestrator,
+  };
+  const result = render(<ProblemsPanel {...defaults} {...props} />);
+  return { onOpenOrchestrator, ...result };
+}
+
+describe("ProblemsPanel — rendering contract", () => {
+  it("renders nothing when all sources resolved clean", async () => {
+    const { container } = render_();
+    await waitFor(() => {
+      expect(container.querySelector("section")).toBeNull();
+    });
+  });
+
+  it("shows 'Checking for problems…' when all sources are null", async () => {
+    render_({ layers: null, jobs: null, coverage: null });
+    expect(
+      await screen.findByText(/Checking for problems/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders resolved-source problems even while other sources are still null", async () => {
+    render_({
+      layers: {
+        layers: [
+          layer({
+            name: "cik_mapping",
+            display_name: "CIK mapping",
+            is_fresh: false,
+            consecutive_failures: 3,
+            last_error_category: "db_constraint",
+          }),
+        ],
+      },
+      jobs: null, // still pending
+      coverage: null, // still pending
+    });
+    expect(
+      await screen.findByText(/CIK mapping — 3 consecutive failures/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Checking 2 more sources/i)).toBeInTheDocument();
+  });
+
+  it("surfaces stale non-blocking layers as amber rows", async () => {
+    render_({
+      layers: {
+        layers: [
+          layer({
+            name: "news",
+            display_name: "News",
+            is_fresh: false,
+            is_blocking: false,
+          }),
+        ],
+      },
+    });
+    expect(
+      await screen.findByText(/News — stale \(non-blocking\)/),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces an amber 'could not re-check' line on source refetch error", async () => {
+    // Cached snapshot present → still renders last-good problems +
+    // amber notice.
+    const { rerender } = render(
+      <ProblemsPanel
+        layers={{
+          layers: [
+            layer({
+              name: "cik",
+              display_name: "CIK",
+              is_fresh: false,
+              consecutive_failures: 2,
+              last_error_category: "db_constraint",
+            }),
+          ],
+        }}
+        jobs={jobs()}
+        coverage={coverageClean()}
+        layersError={false}
+        jobsError={false}
+        coverageError={false}
+        onOpenOrchestrator={() => undefined}
+      />,
+    );
+    await screen.findByText(/CIK — 2 consecutive failures/);
+
+    // Refetch fails for layers — component re-renders with
+    // layers=null + layersError=true. Cache keeps the problem; panel
+    // adds the "could not re-check layers" amber line.
+    rerender(
+      <ProblemsPanel
+        layers={null}
+        jobs={jobs()}
+        coverage={coverageClean()}
+        layersError={true}
+        jobsError={false}
+        coverageError={false}
+        onOpenOrchestrator={() => undefined}
+      />,
+    );
+    expect(screen.getByText(/CIK — 2 consecutive failures/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Could not re-check layers/i),
+    ).toBeInTheDocument();
+  });
+
+  it("click on 'Open orchestrator details' action fires the callback", async () => {
+    const { onOpenOrchestrator } = render_({
+      layers: {
+        layers: [
+          layer({
+            is_fresh: false,
+            consecutive_failures: 1,
+            last_error_category: "network",
+          }),
+        ],
+      },
+    });
+    const btn = await screen.findByRole("button", {
+      name: /Open orchestrator details/,
+    });
+    btn.click();
+    expect(onOpenOrchestrator).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -151,16 +151,35 @@ function renderPanel(
   erroredSources: string[],
 ): JSX.Element {
 
+  // When there are zero confirmed problems but some sources are
+  // still loading or errored, render neutral/amber — not red. Alarm
+  // tone is reserved for known-problems.
+  const hasProblems = problems.length > 0;
+  const sectionTone = hasProblems
+    ? "border-red-200 bg-red-50"
+    : erroredSources.length > 0
+      ? "border-amber-200 bg-amber-50"
+      : "border-slate-200 bg-slate-50";
+  const headerTone = hasProblems
+    ? "border-red-200 text-red-800"
+    : erroredSources.length > 0
+      ? "border-amber-200 text-amber-800"
+      : "border-slate-200 text-slate-700";
   return (
     <section
       role="region"
       aria-label="Current problems"
-      className="rounded-md border border-red-200 bg-red-50 shadow-sm"
+      className={`rounded-md border shadow-sm ${sectionTone}`}
     >
-      <header className="flex items-center justify-between border-b border-red-200 px-4 py-2 text-sm font-semibold text-red-800">
+      <header
+        className={`flex items-center justify-between border-b px-4 py-2 text-sm font-semibold ${headerTone}`}
+      >
         <span>
-          {problems.length} problem{problems.length === 1 ? "" : "s"} need
-          {problems.length === 1 ? "s" : ""} attention
+          {hasProblems
+            ? `${problems.length} problem${problems.length === 1 ? "" : "s"} need${problems.length === 1 ? "s" : ""} attention`
+            : erroredSources.length > 0
+              ? "No confirmed problems yet"
+              : "Checking for problems…"}
         </span>
         <span className="flex items-center gap-3 text-xs font-normal">
           {pendingSources.length > 0 ? (

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -1,0 +1,313 @@
+/**
+ * Problems triage panel (AdminPage #323, spec §5 + §8).
+ *
+ * Surfaces layer failures, failing jobs, and coverage anomalies so
+ * operator sees "what's broken" without scrolling. Sources:
+ *   - /sync/layers: blocking problems from consecutive_failures /
+ *     last_error_category; stale-blocking / stale-non-blocking from
+ *     is_fresh + is_blocking.
+ *   - /system/jobs: `last_status === "failure"` only. Skipped jobs are
+ *     noise filtered out (retry_deferred_recommendations and friends
+ *     skip routinely with "no work to do").
+ *   - /coverage/summary: null_rows > 0 surfaces a data-audit row.
+ *
+ * Cache contract (spec §8): per-source snapshots that only overwrite
+ * on a non-null fresh value. A refetch-in-flight source keeps
+ * rendering last-good problems. First mount shows a neutral
+ * "Checking for problems…" banner until every source resolves at
+ * least once.
+ */
+import { useEffect, useState } from "react";
+
+import type {
+  CoverageSummaryResponse,
+  JobsListResponse,
+} from "@/api/types";
+import type { SyncLayer, SyncLayersResponse } from "@/api/sync";
+import { formatDateTime } from "@/lib/format";
+
+export type ProblemTone = "red" | "amber";
+
+export interface Problem {
+  readonly id: string;
+  readonly tone: ProblemTone;
+  readonly title: string;
+  readonly detail: string | null;
+  readonly action?: { readonly label: string; readonly onClick: () => void };
+}
+
+export interface ProblemsPanelProps {
+  /** Live values. Null on first mount + while a refetch is in flight. */
+  readonly layers: SyncLayersResponse | null;
+  readonly jobs: JobsListResponse | null;
+  readonly coverage: CoverageSummaryResponse | null;
+  /** Per-source error flags — true when the latest fetch returned an error.
+   *  A cached last-good snapshot still renders; we surface an amber
+   *  "could not re-check" line at the top of the panel so the operator
+   *  knows the displayed problems may be out of date. */
+  readonly layersError: boolean;
+  readonly jobsError: boolean;
+  readonly coverageError: boolean;
+  /** Click-through from a layer problem to the orchestrator collapsible. */
+  readonly onOpenOrchestrator: () => void;
+}
+
+interface SourceCache {
+  layers: Problem[] | null;
+  jobs: Problem[] | null;
+  coverage: Problem[] | null;
+}
+
+export function ProblemsPanel({
+  layers,
+  jobs,
+  coverage,
+  layersError,
+  jobsError,
+  coverageError,
+  onOpenOrchestrator,
+}: ProblemsPanelProps): JSX.Element | null {
+  const [cache, setCache] = useState<SourceCache>({
+    layers: null,
+    jobs: null,
+    coverage: null,
+  });
+
+  // Per-source cached snapshot: only overwrite when a non-null fresh
+  // value arrives. A refetch-in-flight (value === null) leaves the
+  // cached snapshot untouched — last-good rendering, never false-good
+  // flash (spec §8).
+  useEffect(() => {
+    if (layers !== null) {
+      setCache((prev) => ({ ...prev, layers: deriveLayerProblems(layers, onOpenOrchestrator) }));
+    }
+  }, [layers, onOpenOrchestrator]);
+
+  useEffect(() => {
+    if (jobs !== null) {
+      setCache((prev) => ({ ...prev, jobs: deriveJobProblems(jobs) }));
+    }
+  }, [jobs]);
+
+  useEffect(() => {
+    if (coverage !== null) {
+      setCache((prev) => ({ ...prev, coverage: deriveCoverageProblems(coverage) }));
+    }
+  }, [coverage]);
+
+  // Combined problem list — only sources that have resolved at least
+  // once contribute. A source still at `null` is excluded rather than
+  // defaulting to empty; it will join the list once it resolves. We
+  // ALSO show a "still checking N more source(s)" line when some
+  // sources have not yet resolved — so a slow/hung /coverage cannot
+  // mask live layer or job problems (spec §8).
+  const problems: Problem[] = [
+    ...(cache.layers ?? []),
+    ...(cache.jobs ?? []),
+    ...(cache.coverage ?? []),
+  ];
+
+  const pendingSources: string[] = [];
+  if (cache.layers === null) pendingSources.push("layers");
+  if (cache.jobs === null) pendingSources.push("jobs");
+  if (cache.coverage === null) pendingSources.push("coverage");
+
+  // Errored sources that DO have a cached snapshot from a previous
+  // successful fetch. Surfaced as an amber header line so the
+  // operator knows the cached problems may be stale.
+  const erroredSources: string[] = [];
+  if (layersError && cache.layers !== null) erroredSources.push("layers");
+  if (jobsError && cache.jobs !== null) erroredSources.push("jobs");
+  if (coverageError && cache.coverage !== null) erroredSources.push("coverage");
+
+  const allPending = pendingSources.length === 3;
+
+  if (allPending) {
+    return (
+      <div className="rounded-md border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600">
+        Checking for problems…
+      </div>
+    );
+  }
+
+  if (
+    problems.length === 0 &&
+    pendingSources.length === 0 &&
+    erroredSources.length === 0
+  ) {
+    // All sources resolved clean, no problems. Hidden state.
+    return null;
+  }
+
+  // Otherwise: render resolved-source problems + secondary lines
+  // for pending and errored sources so the operator knows the panel
+  // is not fully live.
+  return renderPanel(problems, pendingSources, erroredSources);
+}
+
+function renderPanel(
+  problems: Problem[],
+  pendingSources: string[],
+  erroredSources: string[],
+): JSX.Element {
+
+  return (
+    <section
+      role="region"
+      aria-label="Current problems"
+      className="rounded-md border border-red-200 bg-red-50 shadow-sm"
+    >
+      <header className="flex items-center justify-between border-b border-red-200 px-4 py-2 text-sm font-semibold text-red-800">
+        <span>
+          {problems.length} problem{problems.length === 1 ? "" : "s"} need
+          {problems.length === 1 ? "s" : ""} attention
+        </span>
+        <span className="flex items-center gap-3 text-xs font-normal">
+          {pendingSources.length > 0 ? (
+            <span className="text-slate-600">
+              Checking {pendingSources.length} more source
+              {pendingSources.length === 1 ? "" : "s"}…
+            </span>
+          ) : null}
+          {erroredSources.length > 0 ? (
+            <span className="text-amber-700" role="status">
+              Could not re-check {erroredSources.join(", ")} — using last known state
+            </span>
+          ) : null}
+        </span>
+      </header>
+      {problems.length === 0 ? (
+        <p className="px-4 py-2 text-sm text-slate-600">
+          No problems from resolved sources yet.
+        </p>
+      ) : (
+        <ul className="divide-y divide-red-100">
+          {problems.map((p) => (
+            <li key={p.id} className="px-4 py-2 text-sm">
+              <div className="flex items-start gap-2">
+                <span
+                  aria-hidden
+                  className={`mt-1 inline-block h-2 w-2 rounded-full ${p.tone === "red" ? "bg-red-500" : "bg-amber-500"}`}
+                />
+                <div className="flex-1">
+                  <div
+                    className={`font-medium ${p.tone === "red" ? "text-red-800" : "text-amber-800"}`}
+                  >
+                    {p.title}
+                  </div>
+                  {p.detail !== null ? (
+                    <div className="text-xs text-slate-600">{p.detail}</div>
+                  ) : null}
+                </div>
+                {p.action ? (
+                  <button
+                    type="button"
+                    onClick={p.action.onClick}
+                    className="shrink-0 text-xs font-medium text-blue-700 hover:underline"
+                  >
+                    {p.action.label} →
+                  </button>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function deriveLayerProblems(
+  layers: SyncLayersResponse,
+  onOpenOrchestrator: () => void,
+): Problem[] {
+  const out: Problem[] = [];
+  for (const layer of layers.layers) {
+    const p = classifyLayer(layer, onOpenOrchestrator);
+    if (p !== null) out.push(p);
+  }
+  return out;
+}
+
+function classifyLayer(
+  layer: SyncLayer,
+  onOpenOrchestrator: () => void,
+): Problem | null {
+  const action = {
+    label: "Open orchestrator details",
+    onClick: onOpenOrchestrator,
+  };
+  // Red: explicit failure history (consecutive_failures >= 1 AND a
+  // last_error_category we can show). Overrides stale classification.
+  if (layer.consecutive_failures >= 1 && layer.last_error_category !== null) {
+    return {
+      id: `layer-fail-${layer.name}`,
+      tone: "red",
+      title: `${layer.display_name} — ${layer.consecutive_failures} consecutive failure${layer.consecutive_failures === 1 ? "" : "s"} (${layer.last_error_category})`,
+      detail:
+        layer.last_success_at !== null
+          ? `Last success: ${formatDateTime(layer.last_success_at)}`
+          : "Never succeeded",
+      action,
+    };
+  }
+  // Amber: stale blocking layer with no recorded failure category.
+  if (!layer.is_fresh && layer.is_blocking) {
+    return {
+      id: `layer-stale-${layer.name}`,
+      tone: "amber",
+      title: `${layer.display_name} — stale`,
+      detail: layer.freshness_detail,
+      action,
+    };
+  }
+  // Amber low-priority: stale non-blocking. Surfaces the signal but
+  // the operator is not gated by it. Kept in the panel per spec §5;
+  // layers that are permanently-a-bit-behind by design show up here
+  // too — that's acceptable noise for a triage surface because the
+  // alternative (silence) hides real regressions in the same class.
+  if (!layer.is_fresh && !layer.is_blocking) {
+    return {
+      id: `layer-stale-nb-${layer.name}`,
+      tone: "amber",
+      title: `${layer.display_name} — stale (non-blocking)`,
+      detail: layer.freshness_detail,
+      action,
+    };
+  }
+  return null;
+}
+
+function deriveJobProblems(jobs: JobsListResponse): Problem[] {
+  const out: Problem[] = [];
+  for (const job of jobs.jobs) {
+    if (job.last_status !== "failure") continue;
+    out.push({
+      id: `job-fail-${job.name}`,
+      tone: "red",
+      title: `${job.name} — last run failed`,
+      detail:
+        job.last_finished_at !== null
+          ? `Failed at ${formatDateTime(job.last_finished_at)}`
+          : null,
+    });
+  }
+  return out;
+}
+
+function deriveCoverageProblems(
+  coverage: CoverageSummaryResponse,
+): Problem[] {
+  if (coverage.null_rows > 0) {
+    return [
+      {
+        id: "coverage-null-rows",
+        tone: "amber",
+        title: `${coverage.null_rows} instrument${coverage.null_rows === 1 ? "" : "s"} have a NULL filings_status`,
+        detail:
+          "The filings-status audit job has not covered these instruments yet.",
+      },
+    ];
+  }
+  return [];
+}

--- a/frontend/src/lib/useAsync.test.ts
+++ b/frontend/src/lib/useAsync.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Stability test for `useAsync.refetch`.
+ *
+ * Regression coverage for a review concern (#326): callers memoise
+ * a combined `refetchAll` via `useCallback([layers.refetch, ...])` —
+ * if any single `refetch` were a fresh function reference on every
+ * render, the enclosing useCallback would recompute, its downstream
+ * useEffect interval would be torn down and recreated on every
+ * render, and production would see a refetch storm.
+ *
+ * `useAsync`'s current implementation wraps `refetch` in
+ * `useCallback(..., [])`, so the reference is stable across
+ * renders. This test pins that invariant so a future refactor
+ * cannot regress it silently.
+ */
+import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { useAsync } from "@/lib/useAsync";
+
+describe("useAsync — refetch reference stability", () => {
+  it("returns the same refetch function across re-renders", async () => {
+    const { result, rerender } = renderHook(() =>
+      useAsync(async () => 1, []),
+    );
+    const first = result.current.refetch;
+
+    // Trigger a re-render by calling the (stable) refetch — which
+    // increments a tick internally, causing a re-render.
+    await act(async () => {
+      result.current.refetch();
+    });
+    expect(result.current.refetch).toBe(first);
+
+    rerender();
+    expect(result.current.refetch).toBe(first);
+  });
+});

--- a/frontend/src/lib/useSyncTrigger.test.ts
+++ b/frontend/src/lib/useSyncTrigger.test.ts
@@ -134,4 +134,58 @@ describe("useSyncTrigger", () => {
     act(() => hook.result.current.clearQueued(true));
     expect(hook.result.current.kind).toBe("error");
   });
+
+  it("re-triggers after a successful cycle (trigger → queued → idle → trigger)", async () => {
+    // Regression: inFlightRef was previously reset manually in
+    // multiple paths; a missed reset (e.g. clearQueued(false) in
+    // the fast-run case) could leave the hook permanently refusing
+    // to trigger. Now driven by a useEffect on state.kind, so
+    // any transition back to idle releases the guard.
+    mockedTrigger.mockResolvedValueOnce({
+      sync_run_id: 1,
+      plan: { layers_to_refresh: [], layers_skipped: [] },
+    });
+    const { hook } = setup();
+
+    // First successful cycle.
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    expect(hook.result.current.kind).toBe("queued");
+    act(() => hook.result.current.clearQueued(true));
+    expect(hook.result.current.kind).toBe("idle");
+
+    // Second trigger must go through.
+    mockedTrigger.mockResolvedValueOnce({
+      sync_run_id: 2,
+      plan: { layers_to_refresh: [], layers_skipped: [] },
+    });
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    expect(mockedTrigger).toHaveBeenCalledTimes(2);
+    expect(hook.result.current.queuedRunId).toBe(2);
+  });
+
+  it("re-triggers after an error (retry flow)", async () => {
+    mockedTrigger.mockRejectedValueOnce(new ApiError(409, "conflict"));
+    const { hook } = setup();
+
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    expect(hook.result.current.kind).toBe("error");
+
+    // An error transition drops the inFlight guard via the same
+    // useEffect — operator's retry click should dispatch a second
+    // POST.
+    mockedTrigger.mockResolvedValueOnce({
+      sync_run_id: 9,
+      plan: { layers_to_refresh: [], layers_skipped: [] },
+    });
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    expect(mockedTrigger).toHaveBeenCalledTimes(2);
+  });
 });

--- a/frontend/src/lib/useSyncTrigger.test.ts
+++ b/frontend/src/lib/useSyncTrigger.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { ApiError } from "@/api/client";
+import { useSyncTrigger } from "@/lib/useSyncTrigger";
+
+vi.mock("@/api/sync", () => ({ triggerSync: vi.fn() }));
+
+import { triggerSync } from "@/api/sync";
+
+const mockedTrigger = vi.mocked(triggerSync);
+
+beforeEach(() => {
+  mockedTrigger.mockReset();
+});
+afterEach(() => vi.useRealTimers());
+
+function setup() {
+  const onTriggered = vi.fn();
+  const hook = renderHook(() => useSyncTrigger(onTriggered));
+  return { hook, onTriggered };
+}
+
+describe("useSyncTrigger", () => {
+  it("starts idle", () => {
+    const { hook } = setup();
+    expect(hook.result.current.kind).toBe("idle");
+    expect(hook.result.current.queuedRunId).toBeNull();
+  });
+
+  it("transitions to queued on success and invokes onTriggered", async () => {
+    mockedTrigger.mockResolvedValueOnce({
+      sync_run_id: 42,
+      plan: { layers_to_refresh: [], layers_skipped: [] },
+    });
+    const { hook, onTriggered } = setup();
+
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+
+    expect(hook.result.current.kind).toBe("queued");
+    expect(hook.result.current.queuedRunId).toBe(42);
+    expect(onTriggered).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces 409 as 'Sync already running'", async () => {
+    mockedTrigger.mockRejectedValueOnce(new ApiError(409, "conflict"));
+    const { hook, onTriggered } = setup();
+
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+
+    expect(hook.result.current.kind).toBe("error");
+    expect(hook.result.current.message).toBe("Sync already running");
+    expect(onTriggered).not.toHaveBeenCalled();
+  });
+
+  it("surfaces 503 as 'Sync orchestrator disabled'", async () => {
+    mockedTrigger.mockRejectedValueOnce(new ApiError(503, "disabled"));
+    const { hook } = setup();
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    expect(hook.result.current.message).toBe("Sync orchestrator disabled");
+  });
+
+  it("guards against a second click while already running", async () => {
+    // First call returns a promise we never resolve so state stays in
+    // "running" — representative of the in-flight window.
+    let resolveFirst: (v: { sync_run_id: number; plan: { layers_to_refresh: []; layers_skipped: [] } }) => void = () => undefined;
+    mockedTrigger.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    const { hook } = setup();
+    await act(async () => {
+      void hook.result.current.trigger();
+    });
+    expect(hook.result.current.kind).toBe("running");
+
+    // Second click while `running` — no extra POST, no state change.
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    expect(mockedTrigger).toHaveBeenCalledTimes(1);
+
+    // Let the first finish to avoid an unresolved promise warning.
+    await act(async () => {
+      resolveFirst({
+        sync_run_id: 1,
+        plan: { layers_to_refresh: [], layers_skipped: [] },
+      });
+    });
+  });
+
+  it("clearQueued(true) drops the queued badge once server confirms running", async () => {
+    mockedTrigger.mockResolvedValueOnce({
+      sync_run_id: 7,
+      plan: { layers_to_refresh: [], layers_skipped: [] },
+    });
+    const { hook } = setup();
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    expect(hook.result.current.kind).toBe("queued");
+
+    act(() => hook.result.current.clearQueued(true));
+    expect(hook.result.current.kind).toBe("idle");
+  });
+
+  it("clearQueued(false) is a no-op while queued (still waiting)", async () => {
+    mockedTrigger.mockResolvedValueOnce({
+      sync_run_id: 7,
+      plan: { layers_to_refresh: [], layers_skipped: [] },
+    });
+    const { hook } = setup();
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    act(() => hook.result.current.clearQueued(false));
+    expect(hook.result.current.kind).toBe("queued");
+  });
+
+  it("clearQueued does NOT auto-reset an error state", async () => {
+    mockedTrigger.mockRejectedValueOnce(new ApiError(409, ""));
+    const { hook } = setup();
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    act(() => hook.result.current.clearQueued(true));
+    expect(hook.result.current.kind).toBe("error");
+  });
+});

--- a/frontend/src/lib/useSyncTrigger.ts
+++ b/frontend/src/lib/useSyncTrigger.ts
@@ -84,14 +84,17 @@ export function useSyncTrigger(
               : `Failed (HTTP ${err.status})`
           : "Failed";
       setState({ kind: "error", queuedRunId: null, message });
-    } finally {
-      // Release the in-flight guard so an operator can retry after
-      // an error, or click again once the queued badge clears. The
-      // disabled state on the button prevents a second click while
-      // the hook is still `running`/`queued`; the ref only adds a
-      // race-proof backup guard for the concurrent-invocation case.
+      // Release the guard on the error branch so the operator can
+      // click Retry. The button's disabled state would also block a
+      // second click on the success branch, so no defensive early
+      // reset is needed there.
       inFlightRef.current = false;
     }
+    // Deliberately no finally: when the POST succeeds, inFlightRef
+    // stays true through the running → queued window until
+    // clearQueued() transitions us back to idle. A second click in
+    // that window would otherwise slip past the guard while `kind`
+    // is still `queued`.
   }, [onTriggered]);
 
   const clearQueued = useCallback((isRunning: boolean) => {
@@ -102,6 +105,7 @@ export function useSyncTrigger(
       // because the caller also OR's with `isRunning` when wiring
       // `disabled`.
       if (prev.kind === "queued" && isRunning) {
+        inFlightRef.current = false;
         return { kind: "idle", queuedRunId: null, message: null };
       }
       // `error` has no auto-reset — caller must click again.

--- a/frontend/src/lib/useSyncTrigger.ts
+++ b/frontend/src/lib/useSyncTrigger.ts
@@ -20,7 +20,7 @@
  * calls `clearQueued(isRunning)` so the "Queued" badge resolves into
  * the plain "Running" disabled state the server now owns.
  */
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { ApiError } from "@/api/client";
 import { triggerSync } from "@/api/sync";
@@ -84,17 +84,7 @@ export function useSyncTrigger(
               : `Failed (HTTP ${err.status})`
           : "Failed";
       setState({ kind: "error", queuedRunId: null, message });
-      // Release the guard on the error branch so the operator can
-      // click Retry. The button's disabled state would also block a
-      // second click on the success branch, so no defensive early
-      // reset is needed there.
-      inFlightRef.current = false;
     }
-    // Deliberately no finally: when the POST succeeds, inFlightRef
-    // stays true through the running → queued window until
-    // clearQueued() transitions us back to idle. A second click in
-    // that window would otherwise slip past the guard while `kind`
-    // is still `queued`.
   }, [onTriggered]);
 
   const clearQueued = useCallback((isRunning: boolean) => {
@@ -105,13 +95,22 @@ export function useSyncTrigger(
       // because the caller also OR's with `isRunning` when wiring
       // `disabled`.
       if (prev.kind === "queued" && isRunning) {
-        inFlightRef.current = false;
         return { kind: "idle", queuedRunId: null, message: null };
       }
       // `error` has no auto-reset — caller must click again.
       return prev;
     });
   }, []);
+
+  // Single source of truth for inFlightRef: it's `true` iff the hook
+  // is in a running or queued state. Any transition to idle or error
+  // resets the ref. Avoids the previous manual-reset paths that could
+  // leave the ref out of sync with `kind` (e.g. fast-run fallback
+  // timer, caller-initiated reset, unexpected state path).
+  useEffect(() => {
+    inFlightRef.current =
+      state.kind === "running" || state.kind === "queued";
+  }, [state.kind]);
 
   return {
     kind: state.kind,

--- a/frontend/src/lib/useSyncTrigger.ts
+++ b/frontend/src/lib/useSyncTrigger.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared Sync-now trigger hook.
+ *
+ * Before #323, `SyncDashboard` owned its own local `triggerState` and
+ * the Sync-now button's disabled logic. With the AdminPage triage
+ * rewrite, we want TWO buttons — a top-level one that stays visible
+ * even when `SyncDashboard` is collapsed, and the existing one inside
+ * `SyncDashboard` when expanded — without ever firing two concurrent
+ * POSTs at the backend.
+ *
+ * This hook is the single source of truth:
+ *   - `AdminPage` calls `useSyncTrigger(onTriggered)` once.
+ *   - Passes the returned object to every button (top-level + `SyncDashboard`).
+ *   - Every button shares the same `kind`, and `kind === "running"` OR
+ *     `kind === "queued"` disables all of them.
+ *   - A second click is a no-op until the hook transitions back to `idle`.
+ *
+ * The hook also owns the kind reset: when the caller observes that a
+ * sync is running server-side (e.g. `status.is_running === true`), it
+ * calls `clearQueued(isRunning)` so the "Queued" badge resolves into
+ * the plain "Running" disabled state the server now owns.
+ */
+import { useCallback, useRef, useState } from "react";
+
+import { ApiError } from "@/api/client";
+import { triggerSync } from "@/api/sync";
+import type { SyncTriggerRequest } from "@/api/sync";
+
+export type SyncTriggerKind = "idle" | "running" | "queued" | "error";
+
+export interface SyncTriggerState {
+  readonly kind: SyncTriggerKind;
+  readonly queuedRunId: number | null;
+  readonly message: string | null;
+  /** Fire the trigger. No-op when already running or queued. */
+  readonly trigger: () => Promise<void>;
+  /** Clear an `error` back to `idle`; reset a `queued` when the server
+   *  confirms a sync is now running. Called by the caller once the
+   *  next `/sync/status` tick arrives. */
+  readonly clearQueued: (isRunning: boolean) => void;
+}
+
+interface InternalState {
+  kind: SyncTriggerKind;
+  queuedRunId: number | null;
+  message: string | null;
+}
+
+export function useSyncTrigger(
+  onTriggered: () => void,
+): SyncTriggerState {
+  const [state, setState] = useState<InternalState>({
+    kind: "idle",
+    queuedRunId: null,
+    message: null,
+  });
+  // Synchronous in-flight guard. setState updates are batched and
+  // asynchronous, so checking `state.kind` here cannot gate two
+  // concurrent trigger() calls that land in the same microtask. A
+  // ref gives us a "has the POST been dispatched yet?" signal that
+  // updates synchronously.
+  const inFlightRef = useRef<boolean>(false);
+
+  const trigger = useCallback(async () => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setState({ kind: "running", queuedRunId: null, message: null });
+    const body: SyncTriggerRequest = { scope: "full" };
+    try {
+      const result = await triggerSync(body);
+      setState({
+        kind: "queued",
+        queuedRunId: result.sync_run_id,
+        message: null,
+      });
+      onTriggered();
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.status === 409
+            ? "Sync already running"
+            : err.status === 503
+              ? "Sync orchestrator disabled"
+              : `Failed (HTTP ${err.status})`
+          : "Failed";
+      setState({ kind: "error", queuedRunId: null, message });
+    } finally {
+      // Release the in-flight guard so an operator can retry after
+      // an error, or click again once the queued badge clears. The
+      // disabled state on the button prevents a second click while
+      // the hook is still `running`/`queued`; the ref only adds a
+      // race-proof backup guard for the concurrent-invocation case.
+      inFlightRef.current = false;
+    }
+  }, [onTriggered]);
+
+  const clearQueued = useCallback((isRunning: boolean) => {
+    setState((prev) => {
+      // The `queued` badge survives only until the server confirms
+      // the sync actually started. Once isRunning flips to true,
+      // drop the badge; the button stays disabled by the caller
+      // because the caller also OR's with `isRunning` when wiring
+      // `disabled`.
+      if (prev.kind === "queued" && isRunning) {
+        return { kind: "idle", queuedRunId: null, message: null };
+      }
+      // `error` has no auto-reset — caller must click again.
+      return prev;
+    });
+  }, []);
+
+  return {
+    kind: state.kind,
+    queuedRunId: state.queuedRunId,
+    message: state.message,
+    trigger,
+    clearQueued,
+  };
+}

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -1,138 +1,137 @@
 /**
- * Tests for AdminPage (#260 Phase 5).
+ * Tests for AdminPage after the #323 triage rewrite.
  *
- * After Phase 5, AdminPage is composed of two sections:
- *   1. SyncDashboard — the orchestrator's 15-layer freshness view. It
- *      hits /sync/layers, /sync/status, /sync/runs on mount, so the
- *      sync API is mocked here to return empty responses.
- *   2. Background tasks — the 5 scheduled jobs outside the orchestrator
- *      DAG. Orchestrator-owned job names are filtered out at the
- *      component boundary.
+ * AdminPage now has:
+ *   1. Problems panel (collapsed/hidden semantics per per-source
+ *      cached snapshots — see ProblemsPanel).
+ *   2. Fund data row (5 live-or-pending cells plus 3 pending-only).
+ *   3. Collapsible "Orchestrator details" (SyncDashboard), "Background
+ *      tasks" (JobsTable), "Filings coverage" (CoverageSummaryCard).
  *
- * The legacy "Recent runs" table and the full scheduled-jobs list are
- * gone, so those assertions were removed. The API client is mocked at
- * the module boundary; this test exercises the page's state machine,
- * not the network layer.
+ * The legacy Run-Now tests are preserved but updated to expand the
+ * Background tasks section first (the existing always-visible layout
+ * is gone).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 
 import { AdminPage } from "@/pages/AdminPage";
-import { fetchJobsOverview, runJob } from "@/api/jobs";
-import {
-  fetchSyncLayers,
-  fetchSyncRuns,
-  fetchSyncStatus,
-} from "@/api/sync";
 import { ApiError } from "@/api/client";
-import type { JobsListResponse } from "@/api/types";
+import type {
+  CoverageSummaryResponse,
+  JobsListResponse,
+  RecommendationsListResponse,
+  ConfigResponse,
+} from "@/api/types";
 
-vi.mock("@/api/jobs", () => ({
-  fetchJobsOverview: vi.fn(),
-  runJob: vi.fn(),
-}));
-
+vi.mock("@/api/jobs", () => ({ fetchJobsOverview: vi.fn(), runJob: vi.fn() }));
 vi.mock("@/api/sync", () => ({
   fetchSyncLayers: vi.fn(),
   fetchSyncStatus: vi.fn(),
   fetchSyncRuns: vi.fn(),
   triggerSync: vi.fn(),
 }));
+vi.mock("@/api/coverage", () => ({ fetchCoverageSummary: vi.fn() }));
+vi.mock("@/api/recommendations", () => ({ fetchRecommendations: vi.fn() }));
+vi.mock("@/api/config", () => ({ fetchConfig: vi.fn() }));
+
+import { fetchJobsOverview, runJob } from "@/api/jobs";
+import {
+  fetchSyncLayers,
+  fetchSyncRuns,
+  fetchSyncStatus,
+} from "@/api/sync";
+import { fetchCoverageSummary } from "@/api/coverage";
+import { fetchRecommendations } from "@/api/recommendations";
+import { fetchConfig } from "@/api/config";
 
 const mockedJobs = vi.mocked(fetchJobsOverview);
 const mockedRun = vi.mocked(runJob);
 const mockedLayers = vi.mocked(fetchSyncLayers);
 const mockedStatus = vi.mocked(fetchSyncStatus);
 const mockedSyncRuns = vi.mocked(fetchSyncRuns);
+const mockedCoverage = vi.mocked(fetchCoverageSummary);
+const mockedRecs = vi.mocked(fetchRecommendations);
+const mockedConfig = vi.mocked(fetchConfig);
+
+function demoConfig(): ConfigResponse {
+  return {
+    app_env: "dev",
+    etoro_env: "demo",
+    runtime: {
+      enable_auto_trading: false,
+      enable_live_trading: false,
+      display_currency: "GBP",
+      updated_at: "2026-04-18T00:00:00Z",
+      updated_by: "system",
+      reason: "",
+    },
+    kill_switch: {
+      active: false,
+      activated_at: null,
+      activated_by: null,
+      reason: null,
+    },
+  };
+}
+
+function coverageHealthy(): CoverageSummaryResponse {
+  return {
+    checked_at: "2026-04-19T00:00:00Z",
+    analysable: 100,
+    insufficient: 0,
+    structurally_young: 0,
+    fpi: 0,
+    no_primary_sec_cik: 0,
+    unknown: 0,
+    null_rows: 0,
+    total_tradable: 100,
+  };
+}
+
+function recsEmpty(): RecommendationsListResponse {
+  return { items: [], total: 0, limit: 1, offset: 0 };
+}
 
 function jobsResponse(): JobsListResponse {
-  // Mix of orchestrator-owned + background tasks. The two orchestrator
-  // entries must be filtered out by the component.
   return {
     checked_at: "2026-04-16T01:00:00Z",
     jobs: [
       {
         name: "orchestrator_full_sync",
-        description: "Nightly orchestrator sweep.",
-        cadence: "daily at 02:00 UTC",
+        description: "orchestrator sweep",
+        cadence: "daily",
         cadence_kind: "daily",
-        next_run_time: "2026-04-17T02:00:00Z",
+        next_run_time: "2026-04-20T00:00:00Z",
         next_run_time_source: "declared",
         last_status: "success",
-        last_started_at: "2026-04-16T02:00:00Z",
-        last_finished_at: "2026-04-16T02:05:00Z",
-        detail: "",
-      },
-      {
-        name: "orchestrator_high_frequency_sync",
-        description: "5-min orchestrator tick.",
-        cadence: "every 5 minutes",
-        cadence_kind: "every_n_minutes",
-        next_run_time: "2026-04-16T01:05:00Z",
-        next_run_time_source: "declared",
-        last_status: "success",
-        last_started_at: "2026-04-16T01:00:00Z",
-        last_finished_at: "2026-04-16T01:00:03Z",
+        last_started_at: null,
+        last_finished_at: null,
         detail: "",
       },
       {
         name: "execute_approved_orders",
-        description: "Execute operator-approved orders.",
+        description: "execute orders",
         cadence: "every 1 minutes",
         cadence_kind: "every_n_minutes",
-        next_run_time: "2026-04-16T01:01:00Z",
+        next_run_time: "2026-04-20T00:00:00Z",
         next_run_time_source: "declared",
         last_status: "success",
-        last_started_at: "2026-04-16T01:00:00Z",
-        last_finished_at: "2026-04-16T01:00:01Z",
-        detail: "",
-      },
-      {
-        name: "monitor_positions",
-        description: "Monitor open positions.",
-        cadence: "every 5 minutes",
-        cadence_kind: "every_n_minutes",
-        next_run_time: "2026-04-16T01:05:00Z",
-        next_run_time_source: "declared",
-        last_status: null,
         last_started_at: null,
         last_finished_at: null,
-        detail: "no runs recorded",
-      },
-      {
-        name: "retry_deferred_recommendations",
-        description: "Retry deferred recommendations.",
-        cadence: "hourly",
-        cadence_kind: "hourly",
-        next_run_time: "2026-04-16T02:00:00Z",
-        next_run_time_source: "declared",
-        last_status: "success",
-        last_started_at: "2026-04-16T01:00:00Z",
-        last_finished_at: "2026-04-16T01:00:05Z",
-        detail: "",
-      },
-      {
-        name: "weekly_coverage_review",
-        description: "Weekly coverage review.",
-        cadence: "weekly",
-        cadence_kind: "weekly",
-        next_run_time: "2026-04-20T08:00:00Z",
-        next_run_time_source: "declared",
-        last_status: "success",
-        last_started_at: "2026-04-13T08:00:00Z",
-        last_finished_at: "2026-04-13T08:00:20Z",
         detail: "",
       },
       {
         name: "attribution_summary",
-        description: "Portfolio attribution summary.",
-        cadence: "daily at 07:00 UTC",
+        description: "attribution",
+        cadence: "daily",
         cadence_kind: "daily",
-        next_run_time: "2026-04-17T07:00:00Z",
+        next_run_time: "2026-04-20T00:00:00Z",
         next_run_time_source: "declared",
         last_status: "failure",
-        last_started_at: "2026-04-16T07:00:00Z",
+        last_started_at: null,
         last_finished_at: "2026-04-16T07:00:02Z",
         detail: "provider timeout",
       },
@@ -146,6 +145,11 @@ beforeEach(() => {
   mockedLayers.mockReset();
   mockedStatus.mockReset();
   mockedSyncRuns.mockReset();
+  mockedCoverage.mockReset();
+  mockedRecs.mockReset();
+  mockedConfig.mockReset();
+
+  mockedConfig.mockResolvedValue(demoConfig());
   mockedJobs.mockResolvedValue(jobsResponse());
   mockedLayers.mockResolvedValue({ layers: [] });
   mockedStatus.mockResolvedValue({
@@ -154,115 +158,225 @@ beforeEach(() => {
     active_layer: null,
   });
   mockedSyncRuns.mockResolvedValue({ runs: [] });
+  mockedCoverage.mockResolvedValue(coverageHealthy());
+  mockedRecs.mockResolvedValue(recsEmpty());
 });
 
-afterEach(() => {
-  vi.clearAllMocks();
-});
+afterEach(() => vi.clearAllMocks());
 
-describe("AdminPage — background tasks table", () => {
-  it("filters out orchestrator-owned jobs and lists background tasks", async () => {
-    render(<AdminPage />);
-    // Background tasks present.
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("AdminPage — top-level composition", () => {
+  it("renders a top-level Sync-now button", async () => {
+    renderPage();
+    // Multiple buttons (top-level + inner once expanded) will exist;
+    // here we just assert the top one is present.
     expect(
-      await screen.findByRole("button", {
-        name: "Run execute_approved_orders now",
-      }),
+      await screen.findByRole("button", { name: /Sync now/ }),
     ).toBeInTheDocument();
+  });
+
+  it("renders the fund-data row with universe + analysable cells", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Tradable universe")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Analysable")).toBeInTheDocument();
+    // Tier/score/thesis pending placeholders.
+    expect(screen.getByText("Tier 1/2/3")).toBeInTheDocument();
+  });
+
+  it("hides the problems panel when no sources surface any problem", async () => {
+    // Override the default fixture: no failing jobs, no layer
+    // failures, no null coverage rows → hidden state.
+    mockedJobs.mockReset();
+    mockedJobs.mockResolvedValue({
+      checked_at: "2026-04-16T01:00:00Z",
+      jobs: [
+        {
+          name: "execute_approved_orders",
+          description: "execute orders",
+          cadence: "every 1 minutes",
+          cadence_kind: "every_n_minutes",
+          next_run_time: "2026-04-20T00:00:00Z",
+          next_run_time_source: "declared",
+          last_status: "success",
+          last_started_at: null,
+          last_finished_at: null,
+          detail: "",
+        },
+      ],
+    });
+    renderPage();
+    // Wait for all three sources to resolve.
+    await waitFor(() => {
+      expect(mockedLayers).toHaveBeenCalled();
+      expect(mockedJobs).toHaveBeenCalled();
+      expect(mockedCoverage).toHaveBeenCalled();
+    });
+    // Once resolved, the panel should be hidden (no "problems" text).
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/need.*attention/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows problems panel when a job has failed", async () => {
+    renderPage();
     expect(
-      screen.getByRole("button", { name: "Run monitor_positions now" }),
+      await screen.findByText(/attribution_summary/),
     ).toBeInTheDocument();
+    expect(screen.getByText(/last run failed/)).toBeInTheDocument();
+  });
+
+  it("shows problems panel when a layer has consecutive failures", async () => {
+    mockedLayers.mockReset();
+    mockedLayers.mockResolvedValue({
+      layers: [
+        {
+          name: "cik_mapping",
+          display_name: "CIK mapping",
+          tier: 1,
+          is_fresh: false,
+          freshness_detail: "failed",
+          last_success_at: null,
+          last_duration_seconds: null,
+          last_error_category: "db_constraint",
+          consecutive_failures: 3,
+          dependencies: [],
+          is_blocking: true,
+        },
+      ],
+    });
+    renderPage();
     expect(
-      screen.getByRole("button", {
-        name: "Run retry_deferred_recommendations now",
-      }),
+      await screen.findByText(/CIK mapping — 3 consecutive failures/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", {
-        name: "Run weekly_coverage_review now",
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Run attribution_summary now" }),
-    ).toBeInTheDocument();
-    // Orchestrator-owned entries filtered out.
-    expect(
-      screen.queryByRole("button", { name: "Run orchestrator_full_sync now" }),
-    ).toBeNull();
-    expect(
-      screen.queryByRole("button", {
-        name: "Run orchestrator_high_frequency_sync now",
-      }),
-    ).toBeNull();
-    // Never-run state rendered for monitor_positions.
-    expect(screen.getByText("never run")).toBeInTheDocument();
   });
 });
 
-describe("AdminPage — Run now button", () => {
-  it("POSTs to runJob and refetches jobs on success", async () => {
+describe("AdminPage — collapsible sections", () => {
+  it("keeps Orchestrator details collapsed on mount", async () => {
+    renderPage();
+    await waitFor(() => screen.getByText("Orchestrator details"));
+    // SyncDashboard's recent-runs-table heading should NOT be in DOM
+    // while the section is collapsed.
+    expect(screen.queryByText("Recent sync runs")).toBeNull();
+  });
+
+  it("expands Orchestrator details on chevron click", async () => {
     const user = userEvent.setup();
-    mockedRun.mockResolvedValueOnce(undefined);
-    render(<AdminPage />);
+    renderPage();
+    await user.click(
+      await screen.findByRole("button", { name: /Orchestrator details/ }),
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Recent sync runs")).toBeInTheDocument();
+    });
+  });
+
+  it("expands Orchestrator details when a layer problem's action fires", async () => {
+    mockedLayers.mockReset();
+    mockedLayers.mockResolvedValue({
+      layers: [
+        {
+          name: "cik_mapping",
+          display_name: "CIK mapping",
+          tier: 1,
+          is_fresh: false,
+          freshness_detail: "failed",
+          last_success_at: null,
+          last_duration_seconds: null,
+          last_error_category: "db_constraint",
+          consecutive_failures: 3,
+          dependencies: [],
+          is_blocking: true,
+        },
+      ],
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(
+      await screen.findByRole("button", {
+        name: /Open orchestrator details/,
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Recent sync runs")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("AdminPage — Background tasks collapsible", () => {
+  it("filters orchestrator-owned jobs once expanded", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(
+      await screen.findByRole("button", { name: /Background tasks/ }),
+    );
+
     await screen.findByRole("button", {
       name: "Run execute_approved_orders now",
     });
+    expect(
+      screen.queryByRole("button", { name: "Run orchestrator_full_sync now" }),
+    ).toBeNull();
+  });
 
-    expect(mockedJobs).toHaveBeenCalledTimes(1);
-
+  it("Run-now happy path: POST + refetch + Queued badge", async () => {
+    const user = userEvent.setup();
+    mockedRun.mockResolvedValueOnce(undefined);
+    renderPage();
     await user.click(
-      screen.getByRole("button", { name: "Run execute_approved_orders now" }),
+      await screen.findByRole("button", { name: /Background tasks/ }),
     );
+    const btn = await screen.findByRole("button", {
+      name: "Run execute_approved_orders now",
+    });
 
+    const callsBefore = mockedJobs.mock.calls.length;
+    await user.click(btn);
     await waitFor(() => {
       expect(mockedRun).toHaveBeenCalledWith("execute_approved_orders");
     });
     await waitFor(() => {
-      expect(mockedJobs).toHaveBeenCalledTimes(2);
+      expect(mockedJobs.mock.calls.length).toBeGreaterThan(callsBefore);
     });
-    expect(
-      await screen.findByRole("button", {
-        name: "Run execute_approved_orders now",
-      }),
-    ).toHaveTextContent("Queued");
+    expect(btn).toHaveTextContent("Queued");
   });
 
-  it("renders 'Already running' on 409 without throwing", async () => {
+  it("Run-now 409 shows 'Already running'", async () => {
     const user = userEvent.setup();
-    mockedRun.mockRejectedValueOnce(new ApiError(409, "job already running"));
-    render(<AdminPage />);
-    await screen.findByRole("button", {
+    mockedRun.mockRejectedValueOnce(new ApiError(409, "conflict"));
+    renderPage();
+    await user.click(
+      await screen.findByRole("button", { name: /Background tasks/ }),
+    );
+    const btn = await screen.findByRole("button", {
       name: "Run execute_approved_orders now",
     });
-
-    await user.click(
-      screen.getByRole("button", { name: "Run execute_approved_orders now" }),
-    );
-
-    expect(
-      await screen.findByRole("button", {
-        name: "Run execute_approved_orders now",
-      }),
-    ).toHaveTextContent("Already running");
-    expect(mockedJobs).toHaveBeenCalledTimes(1);
+    await user.click(btn);
+    expect(btn).toHaveTextContent("Already running");
   });
 
-  it("renders 'Unknown job' on 404", async () => {
+  it("Run-now 404 shows 'Unknown job'", async () => {
     const user = userEvent.setup();
-    mockedRun.mockRejectedValueOnce(new ApiError(404, "unknown job"));
-    render(<AdminPage />);
-    await screen.findByRole("button", {
+    mockedRun.mockRejectedValueOnce(new ApiError(404, "unknown"));
+    renderPage();
+    await user.click(
+      await screen.findByRole("button", { name: /Background tasks/ }),
+    );
+    const btn = await screen.findByRole("button", {
       name: "Run execute_approved_orders now",
     });
-
-    await user.click(
-      screen.getByRole("button", { name: "Run execute_approved_orders now" }),
-    );
-
-    expect(
-      await screen.findByRole("button", {
-        name: "Run execute_approved_orders now",
-      }),
-    ).toHaveTextContent("Unknown job");
+    await user.click(btn);
+    expect(btn).toHaveTextContent("Unknown job");
   });
 });

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -18,7 +18,7 @@
  * a second POST (spec §11).
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
 import { fetchCoverageSummary } from "@/api/coverage";
@@ -96,10 +96,19 @@ export function AdminPage() {
 
   const isRunning = status.data?.is_running ?? false;
   const refreshInterval = isRunning ? 10_000 : 60_000;
+  // Keep `refetchAll` in a ref so the interval does not re-arm on
+  // every render — only when the cadence itself changes (running
+  // ↔ idle transition). Without this split, a cadence flip at
+  // second 59 of the 60s idle cycle would drop the elapsed window
+  // and fire an immediate refetch; this keeps the natural tick.
+  const refetchAllRef = useRef(refetchAll);
   useEffect(() => {
-    const id = window.setInterval(refetchAll, refreshInterval);
+    refetchAllRef.current = refetchAll;
+  }, [refetchAll]);
+  useEffect(() => {
+    const id = window.setInterval(() => refetchAllRef.current(), refreshInterval);
     return () => window.clearInterval(id);
-  }, [refetchAll, refreshInterval]);
+  }, [refreshInterval]);
 
   // Shared sync-trigger — single source of truth for both the
   // top-level button here and the inner button inside SyncDashboard.

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -113,6 +113,18 @@ export function AdminPage() {
   // Shared sync-trigger — single source of truth for both the
   // top-level button here and the inner button inside SyncDashboard.
   const syncTrigger = useSyncTrigger(refetchAll);
+  // Destructure once — `useSyncTrigger` returns a plain object
+  // literal, so the outer reference changes every render. Using
+  // the stable member refs in hook deps below prevents effects
+  // from re-arming on every render (most visibly: the fallback
+  // timer below, which would otherwise reset every render and
+  // could never actually fire).
+  const {
+    kind: triggerKind,
+    message: triggerMessage,
+    trigger: triggerSync_,
+    clearQueued: triggerClearQueued,
+  } = syncTrigger;
 
   // Drive the `queued → idle` transition off the top-level status
   // poll. Previously only SyncDashboard called clearQueued, which
@@ -122,19 +134,21 @@ export function AdminPage() {
   // can advance the trigger state independently. Also clears via a
   // one-off timer for the fast-run case where a sync finishes
   // before the next /sync/status tick ever observes is_running=true.
-  const clearQueued = syncTrigger.clearQueued;
   useEffect(() => {
-    clearQueued(isRunning);
-  }, [clearQueued, isRunning]);
+    triggerClearQueued(isRunning);
+  }, [triggerClearQueued, isRunning]);
 
   useEffect(() => {
-    if (syncTrigger.kind !== "queued") return;
+    if (triggerKind !== "queued") return;
     // Fallback: if the server-side sync finishes before we ever see
     // is_running=true, recover the idle state after the next refresh
     // tick. Otherwise the button would stay disabled indefinitely.
-    const id = window.setTimeout(() => clearQueued(true), refreshInterval + 2_000);
+    const id = window.setTimeout(
+      () => triggerClearQueued(true),
+      refreshInterval + 2_000,
+    );
     return () => window.clearTimeout(id);
-  }, [syncTrigger.kind, clearQueued, refreshInterval]);
+  }, [triggerKind, triggerClearQueued, refreshInterval]);
 
   const [orchestratorOpen, setOrchestratorOpen] = useState(false);
   const [rowState, setRowState] = useState<Record<string, RowState>>({});
@@ -192,10 +206,10 @@ export function AdminPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold text-slate-800">Admin</h1>
         <SyncNowButton
-          triggerKind={syncTrigger.kind}
-          message={syncTrigger.message}
+          triggerKind={triggerKind}
+          message={triggerMessage}
           isRunning={isRunning}
-          onClick={() => void syncTrigger.trigger()}
+          onClick={() => void triggerSync_()}
         />
       </div>
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -149,7 +149,9 @@ export function AdminPage() {
     [jobs.refetch],
   );
 
-  function openOrchestrator() {
+  // Stable callback so ProblemsPanel's useEffect on `layers` does
+  // not re-run (and re-compute problems) every AdminPage render.
+  const openOrchestrator = useCallback(() => {
     setOrchestratorOpen(true);
     // Let the section mount before we scroll, so the target exists.
     // scrollIntoView is undefined in jsdom so we guard defensively —
@@ -160,7 +162,7 @@ export function AdminPage() {
         el.scrollIntoView({ behavior: "smooth", block: "start" });
       }
     });
-  }
+  }, []);
 
   const backgroundJobs = (jobs.data?.jobs ?? []).filter(
     (j) => !ORCHESTRATOR_OWNED.has(j.name),

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -21,7 +21,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
-import { fetchConfig } from "@/api/config";
 import { fetchCoverageSummary } from "@/api/coverage";
 import { fetchJobsOverview, runJob } from "@/api/jobs";
 import { fetchRecommendations } from "@/api/recommendations";
@@ -62,12 +61,6 @@ const ORCHESTRATOR_OWNED = new Set([
 ]);
 
 export function AdminPage() {
-  // /config is fetched independently by a handful of consumers today
-  // (tech-debt #320). We use it here to gate the live-trading warning
-  // in the Sync-now button label once live wiring arrives; for now we
-  // only need the fetch to catch changes.
-  void useAsync(fetchConfig, []);
-
   const layers = useAsync(fetchSyncLayers, []);
   const status = useAsync(fetchSyncStatus, []);
   const coverage = useAsync(fetchCoverageSummary, []);
@@ -82,14 +75,24 @@ export function AdminPage() {
     [],
   );
 
+  // Extract the refetch refs as local const bindings so ESLint can
+  // see their identity and verify the dep array without the suppression
+  // that previously papered over the stability contract. `useAsync`
+  // wraps refetch in `useCallback([], [])` — see useAsync.test.ts
+  // which pins that invariant.
+  const refetchLayers = layers.refetch;
+  const refetchStatus = status.refetch;
+  const refetchCoverage = coverage.refetch;
+  const refetchJobs = jobs.refetch;
+  const refetchRecs = recs.refetch;
+
   const refetchAll = useCallback(() => {
-    layers.refetch();
-    status.refetch();
-    coverage.refetch();
-    jobs.refetch();
-    recs.refetch();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [layers.refetch, status.refetch, coverage.refetch, jobs.refetch, recs.refetch]);
+    refetchLayers();
+    refetchStatus();
+    refetchCoverage();
+    refetchJobs();
+    refetchRecs();
+  }, [refetchLayers, refetchStatus, refetchCoverage, refetchJobs, refetchRecs]);
 
   const isRunning = status.data?.is_running ?? false;
   const refreshInterval = isRunning ? 10_000 : 60_000;
@@ -133,7 +136,7 @@ export function AdminPage() {
       try {
         await runJob(name);
         setRowState((prev) => ({ ...prev, [name]: { kind: "queued" } }));
-        jobs.refetch();
+        refetchJobs();
       } catch (err) {
         const message =
           err instanceof ApiError
@@ -146,7 +149,7 @@ export function AdminPage() {
         setRowState((prev) => ({ ...prev, [name]: { kind: "error", message } }));
       }
     },
-    [jobs.refetch],
+    [refetchJobs],
   );
 
   // Stable callback so ProblemsPanel's useEffect on `layers` does

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,38 +1,46 @@
 /**
- * Admin page (issue #260 Phase 5).
+ * Admin page — triage-first rewrite (issue #323).
  *
- * Two sections:
- *   1. Sync dashboard — 15-layer freshness grid + recent sync runs +
- *      "Sync now" button. Owned by the orchestrator.
- *   2. Background tasks — the 5 scheduled jobs that live outside the
- *      orchestrator DAG (execute_approved_orders, monitor_positions,
- *      retry_deferred_recommendations, weekly_coverage_review,
- *      attribution_summary). Retained because the operator still needs
- *      Run-Now for them and they are not part of the data-sync flow.
+ * Three-section composition:
+ *   1. Problems panel — failing layers + failing jobs + coverage
+ *      anomalies (null rows). Hidden when all sources resolved and
+ *      combined problem list is empty.
+ *   2. Fund data row — four live cells + three pending placeholders
+ *      for summaries we don't yet have endpoints for.
+ *   3. Collapsed-by-default details: orchestrator (15-layer grid +
+ *      recent runs), background jobs, filings coverage.
  *
- * The prior "Recent runs" table is removed — the Sync dashboard's
- * recent-sync-runs table is the authoritative per-run view now, and
- * individual job runs for the background tasks can be retrieved via
- * the /jobs/runs API if needed (operator CLI, not UI).
+ * AdminPage owns the auto-refresh loop (10s when a sync is running,
+ * 60s otherwise) for its five top-level fetches. It also instantiates
+ * the shared `useSyncTrigger` hook and passes it to both the
+ * top-level Sync-now button and the inner `SyncDashboard`, so both
+ * buttons reflect one piece of state and a second click never fires
+ * a second POST (spec §11).
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
+import { fetchConfig } from "@/api/config";
 import { fetchCoverageSummary } from "@/api/coverage";
 import { fetchJobsOverview, runJob } from "@/api/jobs";
+import { fetchRecommendations } from "@/api/recommendations";
+import { fetchSyncLayers, fetchSyncStatus } from "@/api/sync";
+import { ApiError } from "@/api/client";
 import type {
   CoverageSummaryResponse,
   JobOverviewResponse,
 } from "@/api/types";
-import { ApiError } from "@/api/client";
+import { CollapsibleSection } from "@/components/admin/CollapsibleSection";
+import { FundDataRow } from "@/components/admin/FundDataRow";
+import { ProblemsPanel } from "@/components/admin/ProblemsPanel";
 import {
-  Section,
   SectionError,
   SectionSkeleton,
 } from "@/components/dashboard/Section";
 import { useAsync } from "@/lib/useAsync";
 import { formatDateTime } from "@/lib/format";
+import { useSyncTrigger } from "@/lib/useSyncTrigger";
 import { SyncDashboard } from "@/pages/SyncDashboard";
 
 type RowState =
@@ -48,28 +56,84 @@ const STATUS_TONE: Record<string, string> = {
   skipped: "text-slate-400",
 };
 
-// Orchestrator-owned scheduled jobs — surfaced by the Sync dashboard
-// above; not duplicated here. Every other SCHEDULED_JOBS entry is a
-// "background task" that remains outside the orchestrator DAG.
 const ORCHESTRATOR_OWNED = new Set([
   "orchestrator_full_sync",
   "orchestrator_high_frequency_sync",
 ]);
 
 export function AdminPage() {
-  const jobs = useAsync(fetchJobsOverview, []);
-  const coverage = useAsync(fetchCoverageSummary, []);
+  // /config is fetched independently by a handful of consumers today
+  // (tech-debt #320). We use it here to gate the live-trading warning
+  // in the Sync-now button label once live wiring arrives; for now we
+  // only need the fetch to catch changes.
+  void useAsync(fetchConfig, []);
 
+  const layers = useAsync(fetchSyncLayers, []);
+  const status = useAsync(fetchSyncStatus, []);
+  const coverage = useAsync(fetchCoverageSummary, []);
+  const jobs = useAsync(fetchJobsOverview, []);
+  const recs = useAsync(
+    () =>
+      fetchRecommendations(
+        { action: null, status: null, instrument_id: null },
+        0,
+        1,
+      ),
+    [],
+  );
+
+  const refetchAll = useCallback(() => {
+    layers.refetch();
+    status.refetch();
+    coverage.refetch();
+    jobs.refetch();
+    recs.refetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [layers.refetch, status.refetch, coverage.refetch, jobs.refetch, recs.refetch]);
+
+  const isRunning = status.data?.is_running ?? false;
+  const refreshInterval = isRunning ? 10_000 : 60_000;
+  useEffect(() => {
+    const id = window.setInterval(refetchAll, refreshInterval);
+    return () => window.clearInterval(id);
+  }, [refetchAll, refreshInterval]);
+
+  // Shared sync-trigger — single source of truth for both the
+  // top-level button here and the inner button inside SyncDashboard.
+  const syncTrigger = useSyncTrigger(refetchAll);
+
+  // Drive the `queued → idle` transition off the top-level status
+  // poll. Previously only SyncDashboard called clearQueued, which
+  // meant a click on the top button with the orchestrator section
+  // collapsed left the hook stuck in `queued` forever (button stays
+  // disabled until reload). With the top-level status fetch here we
+  // can advance the trigger state independently. Also clears via a
+  // one-off timer for the fast-run case where a sync finishes
+  // before the next /sync/status tick ever observes is_running=true.
+  const clearQueued = syncTrigger.clearQueued;
+  useEffect(() => {
+    clearQueued(isRunning);
+  }, [clearQueued, isRunning]);
+
+  useEffect(() => {
+    if (syncTrigger.kind !== "queued") return;
+    // Fallback: if the server-side sync finishes before we ever see
+    // is_running=true, recover the idle state after the next refresh
+    // tick. Otherwise the button would stay disabled indefinitely.
+    const id = window.setTimeout(() => clearQueued(true), refreshInterval + 2_000);
+    return () => window.clearTimeout(id);
+  }, [syncTrigger.kind, clearQueued, refreshInterval]);
+
+  const [orchestratorOpen, setOrchestratorOpen] = useState(false);
   const [rowState, setRowState] = useState<Record<string, RowState>>({});
 
-  const refetchJobs = jobs.refetch;
   const handleRun = useCallback(
     async (name: string) => {
       setRowState((prev) => ({ ...prev, [name]: { kind: "running" } }));
       try {
         await runJob(name);
         setRowState((prev) => ({ ...prev, [name]: { kind: "queued" } }));
-        refetchJobs();
+        jobs.refetch();
       } catch (err) {
         const message =
           err instanceof ApiError
@@ -79,34 +143,83 @@ export function AdminPage() {
                 ? "Unknown job"
                 : `Failed (HTTP ${err.status})`
             : "Failed";
-        setRowState((prev) => ({
-          ...prev,
-          [name]: { kind: "error", message },
-        }));
+        setRowState((prev) => ({ ...prev, [name]: { kind: "error", message } }));
       }
     },
-    [refetchJobs],
+    [jobs.refetch],
   );
+
+  function openOrchestrator() {
+    setOrchestratorOpen(true);
+    // Let the section mount before we scroll, so the target exists.
+    // scrollIntoView is undefined in jsdom so we guard defensively —
+    // the browser behaviour is unchanged.
+    requestAnimationFrame(() => {
+      const el = document.getElementById("admin-orchestrator-details");
+      if (el && typeof el.scrollIntoView === "function") {
+        el.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    });
+  }
 
   const backgroundJobs = (jobs.data?.jobs ?? []).filter(
     (j) => !ORCHESTRATOR_OWNED.has(j.name),
   );
 
+  const layerProblemCount =
+    (layers.data?.layers ?? []).filter(
+      (l) =>
+        (l.consecutive_failures >= 1 && l.last_error_category !== null) ||
+        (!l.is_fresh && l.is_blocking),
+    ).length;
+
   return (
-    <div className="space-y-8">
-      <SyncDashboard />
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold text-slate-800">Admin</h1>
+        <SyncNowButton
+          triggerKind={syncTrigger.kind}
+          message={syncTrigger.message}
+          isRunning={isRunning}
+          onClick={() => void syncTrigger.trigger()}
+        />
+      </div>
 
-      <Section title="Filings coverage">
-        {coverage.loading ? (
-          <SectionSkeleton rows={2} />
-        ) : coverage.error !== null ? (
-          <SectionError onRetry={coverage.refetch} />
-        ) : coverage.data ? (
-          <CoverageSummaryCard summary={coverage.data} />
-        ) : null}
-      </Section>
+      <ProblemsPanel
+        layers={layers.data}
+        jobs={jobs.data}
+        coverage={coverage.data}
+        layersError={layers.error !== null}
+        jobsError={jobs.error !== null}
+        coverageError={coverage.error !== null}
+        onOpenOrchestrator={openOrchestrator}
+      />
 
-      <Section title="Background tasks">
+      <FundDataRow
+        coverage={coverage.data}
+        coverageError={coverage.error !== null}
+        recommendations={recs.data}
+        recommendationsError={recs.error !== null}
+      />
+
+      <CollapsibleSection
+        title="Orchestrator details"
+        summary={
+          layerProblemCount > 0
+            ? `${layerProblemCount} layer${layerProblemCount === 1 ? "" : "s"} need attention`
+            : "all layers healthy"
+        }
+        open={orchestratorOpen}
+        onOpenChange={setOrchestratorOpen}
+        sectionId="admin-orchestrator-details"
+      >
+        <SyncDashboard syncTrigger={syncTrigger} />
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        title="Background tasks"
+        summary={`${backgroundJobs.length} scheduled`}
+      >
         {jobs.loading ? (
           <SectionSkeleton rows={5} />
         ) : jobs.error !== null ? (
@@ -116,18 +229,67 @@ export function AdminPage() {
             <p className="mb-3 text-xs text-slate-500">
               Scheduled jobs that live outside the orchestrator DAG —
               transaction execution, position monitoring, deferred-rec
-              retries, and periodic governance. Data-pipeline jobs
-              (candles, theses, scoring, reports, etc.) are driven by
-              the orchestrator above.
+              retries, and periodic governance.
             </p>
-            <JobsTable
-              items={backgroundJobs}
-              rowState={rowState}
-              onRun={handleRun}
-            />
+            <JobsTable items={backgroundJobs} rowState={rowState} onRun={handleRun} />
           </>
         )}
-      </Section>
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        title="Filings coverage"
+        summary={
+          coverage.data
+            ? `${coverage.data.analysable} / ${coverage.data.total_tradable} analysable`
+            : undefined
+        }
+      >
+        {coverage.loading ? (
+          <SectionSkeleton rows={2} />
+        ) : coverage.error !== null ? (
+          <SectionError onRetry={coverage.refetch} />
+        ) : coverage.data ? (
+          <CoverageSummaryCard summary={coverage.data} />
+        ) : null}
+      </CollapsibleSection>
+    </div>
+  );
+}
+
+function SyncNowButton({
+  triggerKind,
+  message,
+  isRunning,
+  onClick,
+}: {
+  triggerKind: "idle" | "running" | "queued" | "error";
+  message: string | null;
+  isRunning: boolean;
+  onClick: () => void;
+}) {
+  const disabled =
+    triggerKind === "running" || triggerKind === "queued" || isRunning;
+  const label =
+    triggerKind === "running"
+      ? "Triggering…"
+      : triggerKind === "queued"
+        ? "Queued"
+        : isRunning
+          ? "Running"
+          : "Sync now";
+  return (
+    <div className="flex items-center gap-2">
+      {triggerKind === "error" && message !== null ? (
+        <span className="text-xs text-red-600">{message}</span>
+      ) : null}
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        className="rounded bg-sky-600 px-3 py-1 text-sm font-medium text-white hover:bg-sky-700 disabled:bg-slate-300"
+      >
+        {label}
+      </button>
     </div>
   );
 }
@@ -138,11 +300,7 @@ function CoverageSummaryCard({
   summary: CoverageSummaryResponse;
 }) {
   const stuckTotal = summary.insufficient + summary.structurally_young;
-  const cells: Array<{
-    label: string;
-    value: number;
-    tone: string;
-  }> = [
+  const cells: Array<{ label: string; value: number; tone: string }> = [
     { label: "Analysable", value: summary.analysable, tone: "text-emerald-700" },
     { label: "Insufficient", value: summary.insufficient, tone: "text-amber-700" },
     {
@@ -157,8 +315,6 @@ function CoverageSummaryCard({
       tone: "text-slate-500",
     },
     { label: "Unknown", value: summary.unknown, tone: "text-slate-500" },
-    // Null rows surface a stalled audit job — any non-zero value is
-    // ops-actionable so we highlight red rather than neutral.
     {
       label: "Null (pre-audit)",
       value: summary.null_rows,
@@ -170,10 +326,7 @@ function CoverageSummaryCard({
     <div className="space-y-3">
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         {cells.map((c) => (
-          <div
-            key={c.label}
-            className="rounded border border-slate-200 bg-slate-50 p-3"
-          >
+          <div key={c.label} className="rounded border border-slate-200 bg-slate-50 p-3">
             <div className="text-xs uppercase tracking-wide text-slate-500">
               {c.label}
             </div>
@@ -233,13 +386,9 @@ function JobsTable({
               <tr key={job.name} className="align-top">
                 <td className="py-2 pr-4">
                   <div className="font-medium text-slate-700">{job.name}</div>
-                  <div className="text-xs text-slate-500">
-                    {job.description}
-                  </div>
+                  <div className="text-xs text-slate-500">{job.description}</div>
                 </td>
-                <td className="py-2 pr-4 text-xs text-slate-600">
-                  {job.cadence}
-                </td>
+                <td className="py-2 pr-4 text-xs text-slate-600">{job.cadence}</td>
                 <td className="py-2 pr-4 text-xs text-slate-600">
                   {formatDateTime(job.next_run_time)}
                 </td>

--- a/frontend/src/pages/SyncDashboard.test.tsx
+++ b/frontend/src/pages/SyncDashboard.test.tsx
@@ -22,6 +22,17 @@ import {
   fetchSyncRuns,
   fetchSyncStatus,
 } from "@/api/sync";
+import type { SyncTriggerState } from "@/lib/useSyncTrigger";
+
+function fakeTrigger(): SyncTriggerState {
+  return {
+    kind: "idle",
+    queuedRunId: null,
+    message: null,
+    trigger: vi.fn(),
+    clearQueued: vi.fn(),
+  };
+}
 
 vi.mock("@/api/sync", () => ({
   fetchSyncLayers: vi.fn(),
@@ -115,7 +126,7 @@ describe("LayerProgressBar", () => {
     mockedStatus.mockResolvedValue(
       runningStatus({ itemsDone: null, itemsTotal: null }),
     );
-    render(<SyncDashboard />);
+    render(<SyncDashboard syncTrigger={fakeTrigger()} />);
     expect(await screen.findByText("starting…")).toBeInTheDocument();
     expect(screen.queryByRole("progressbar")).toBeNull();
   });
@@ -124,7 +135,7 @@ describe("LayerProgressBar", () => {
     mockedStatus.mockResolvedValue(
       runningStatus({ itemsDone: 42, itemsTotal: null }),
     );
-    render(<SyncDashboard />);
+    render(<SyncDashboard syncTrigger={fakeTrigger()} />);
     expect(await screen.findByText("42 items processed")).toBeInTheDocument();
     expect(screen.queryByRole("progressbar")).toBeNull();
   });
@@ -133,7 +144,7 @@ describe("LayerProgressBar", () => {
     mockedStatus.mockResolvedValue(
       runningStatus({ itemsDone: 25, itemsTotal: 100 }),
     );
-    render(<SyncDashboard />);
+    render(<SyncDashboard syncTrigger={fakeTrigger()} />);
     const bar = await screen.findByRole("progressbar", {
       name: "candles progress",
     });
@@ -150,7 +161,7 @@ describe("LayerProgressBar", () => {
     mockedStatus.mockResolvedValue(
       runningStatus({ itemsDone: 150, itemsTotal: 100 }),
     );
-    render(<SyncDashboard />);
+    render(<SyncDashboard syncTrigger={fakeTrigger()} />);
     const bar = await screen.findByRole("progressbar", {
       name: "candles progress",
     });

--- a/frontend/src/pages/SyncDashboard.tsx
+++ b/frontend/src/pages/SyncDashboard.tsx
@@ -99,10 +99,15 @@ export function SyncDashboard({ syncTrigger }: SyncDashboardProps) {
     return () => window.clearInterval(id);
   }, [refetchAll, interval]);
 
+  // Destructure the stable callbacks from syncTrigger so useCallback
+  // deps below reference those (stable refs) instead of the outer
+  // object (new identity each render → handleSyncNow would be a new
+  // function every render, defeating the memo).
+  const { trigger: triggerSync_, clearQueued } = syncTrigger;
+
   // Drive the shared trigger's queued → idle transition off the
   // same status poll we already have. No local trigger state here —
   // everything is owned by `syncTrigger`.
-  const clearQueued = syncTrigger.clearQueued;
   useEffect(() => {
     clearQueued(isRunning);
   }, [clearQueued, isRunning]);
@@ -113,8 +118,8 @@ export function SyncDashboard({ syncTrigger }: SyncDashboardProps) {
   // so an unconditional refetchAll on click would fire spurious
   // reads on a blocked second click.
   const handleSyncNow = useCallback(async () => {
-    await syncTrigger.trigger();
-  }, [syncTrigger]);
+    await triggerSync_();
+  }, [triggerSync_]);
 
   const layerList: SyncLayer[] = layers.data?.layers ?? [];
   const stale = layerList.filter((l) => !l.is_fresh).length;

--- a/frontend/src/pages/SyncDashboard.tsx
+++ b/frontend/src/pages/SyncDashboard.tsx
@@ -107,10 +107,14 @@ export function SyncDashboard({ syncTrigger }: SyncDashboardProps) {
     clearQueued(isRunning);
   }, [clearQueued, isRunning]);
 
+  // SyncDashboard's own fetches are refreshed by the interval poll
+  // (10s while is_running=true). We do NOT also refetchAll here —
+  // trigger() is a no-op when the hook is already running/queued,
+  // so an unconditional refetchAll on click would fire spurious
+  // reads on a blocked second click.
   const handleSyncNow = useCallback(async () => {
     await syncTrigger.trigger();
-    refetchAll();
-  }, [syncTrigger, refetchAll]);
+  }, [syncTrigger]);
 
   const layerList: SyncLayer[] = layers.data?.layers ?? [];
   const stale = layerList.filter((l) => !l.is_fresh).length;

--- a/frontend/src/pages/SyncDashboard.tsx
+++ b/frontend/src/pages/SyncDashboard.tsx
@@ -12,14 +12,12 @@
  * Auto-refresh: polls every 10s when a sync is running, every 60s idle.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
-import { ApiError } from "@/api/client";
 import {
   fetchSyncLayers,
   fetchSyncRuns,
   fetchSyncStatus,
-  triggerSync,
 } from "@/api/sync";
 import type { SyncLayer, SyncRun } from "@/api/sync";
 import {
@@ -29,6 +27,7 @@ import {
 } from "@/components/dashboard/Section";
 import { formatDateTime } from "@/lib/format";
 import { useAsync } from "@/lib/useAsync";
+import type { SyncTriggerState } from "@/lib/useSyncTrigger";
 
 const TIER_LABEL: Record<number, string> = {
   0: "Tier 0 · Sources",
@@ -70,7 +69,17 @@ export function parseUtc(iso: string): Date {
   return new Date(hasOffset ? iso : `${iso}Z`);
 }
 
-export function SyncDashboard() {
+export interface SyncDashboardProps {
+  /**
+   * Shared sync-now trigger (from `useSyncTrigger`). Required so
+   * both AdminPage's top-level button and this dashboard's internal
+   * button reflect the same state and cannot fire two concurrent
+   * POSTs. See docs/superpowers/specs/2026-04-19-admin-triage-design.md §11.
+   */
+  readonly syncTrigger: SyncTriggerState;
+}
+
+export function SyncDashboard({ syncTrigger }: SyncDashboardProps) {
   const layers = useAsync(fetchSyncLayers, []);
   const status = useAsync(fetchSyncStatus, []);
   const runs = useAsync(() => fetchSyncRuns(20), []);
@@ -90,41 +99,18 @@ export function SyncDashboard() {
     return () => window.clearInterval(id);
   }, [refetchAll, interval]);
 
-  const [triggerState, setTriggerState] = useState<
-    | { kind: "idle" }
-    | { kind: "running" }
-    | { kind: "error"; message: string }
-    | { kind: "queued"; syncRunId: number }
-  >({ kind: "idle" });
-
-  // Clear `queued` banner once the status poll confirms the trigger
-  // took effect (is_running=true). Depend on triggerState.kind (not
-  // the whole object) so setTriggerState calls don't retrigger this
-  // effect on every render — only on actual kind transitions.
+  // Drive the shared trigger's queued → idle transition off the
+  // same status poll we already have. No local trigger state here —
+  // everything is owned by `syncTrigger`.
+  const clearQueued = syncTrigger.clearQueued;
   useEffect(() => {
-    if (triggerState.kind === "queued" && isRunning) {
-      setTriggerState({ kind: "idle" });
-    }
-  }, [triggerState.kind, isRunning]);
+    clearQueued(isRunning);
+  }, [clearQueued, isRunning]);
 
   const handleSyncNow = useCallback(async () => {
-    setTriggerState({ kind: "running" });
-    try {
-      const result = await triggerSync({ scope: "full" });
-      setTriggerState({ kind: "queued", syncRunId: result.sync_run_id });
-      refetchAll();
-    } catch (err) {
-      const message =
-        err instanceof ApiError
-          ? err.status === 409
-            ? "Sync already running"
-            : err.status === 503
-              ? "Sync orchestrator disabled"
-              : `Failed (HTTP ${err.status})`
-          : "Failed";
-      setTriggerState({ kind: "error", message });
-    }
-  }, [refetchAll]);
+    await syncTrigger.trigger();
+    refetchAll();
+  }, [syncTrigger, refetchAll]);
 
   const layerList: SyncLayer[] = layers.data?.layers ?? [];
   const stale = layerList.filter((l) => !l.is_fresh).length;
@@ -174,19 +160,18 @@ export function SyncDashboard() {
             disabled={
               // Disabled from click until either (a) the backend confirms
               // is_running=true via the next /sync/status poll, or (b)
-              // the trigger returned an error and we're back in idle.
-              // Without the "queued" guard, a second click between the
-              // POST returning 202 and the status poll could fire a
-              // second concurrent trigger.
-              triggerState.kind === "running" ||
-              triggerState.kind === "queued" ||
+              // the shared trigger transitions from `queued` back to
+              // `idle`. Any click path that bypasses this disabled
+              // state would otherwise fire a second concurrent POST.
+              syncTrigger.kind === "running" ||
+              syncTrigger.kind === "queued" ||
               isRunning
             }
             className="rounded bg-sky-600 px-3 py-1 text-sm font-medium text-white hover:bg-sky-700 disabled:bg-slate-300"
           >
-            {triggerState.kind === "running"
+            {syncTrigger.kind === "running"
               ? "Triggering…"
-              : triggerState.kind === "queued"
+              : syncTrigger.kind === "queued"
                 ? "Queued"
                 : isRunning
                   ? "Running"
@@ -198,14 +183,12 @@ export function SyncDashboard() {
           <span className={`text-sm font-medium ${banner.tone}`}>
             {banner.text}
           </span>
-          {triggerState.kind === "error" && (
-            <span className="text-sm text-red-600">
-              {triggerState.message}
-            </span>
+          {syncTrigger.kind === "error" && syncTrigger.message !== null && (
+            <span className="text-sm text-red-600">{syncTrigger.message}</span>
           )}
-          {triggerState.kind === "queued" && (
+          {syncTrigger.kind === "queued" && syncTrigger.queuedRunId !== null && (
             <span className="text-sm text-slate-500">
-              Queued as run #{triggerState.syncRunId}
+              Queued as run #{syncTrigger.queuedRunId}
             </span>
           )}
         </div>

--- a/tests/test_layer_failure_history.py
+++ b/tests/test_layer_failure_history.py
@@ -1,0 +1,268 @@
+"""Tests for app.services.sync_orchestrator.layer_failure_history.
+
+These run against the real ``ebull_test`` Postgres because the logic
+is pure SQL with branching, and substring-matching test doubles would
+miss bugs like sort order inversion or an off-by-one on the "stop at
+first non-failed row" streak counter.
+
+Every test seeds a fresh set of ``sync_layer_progress`` rows for a
+layer name scoped to the test (``test-layer-<uuid4>``) so concurrent
+runs and leftovers from other suites cannot cross-talk. The fixture
+does not TRUNCATE ``sync_layer_progress`` itself — scoping by a
+unique ``layer_name`` is enough to isolate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import psycopg
+import pytest
+
+from app.services.sync_orchestrator.layer_failure_history import (
+    consecutive_failures,
+    last_error_category,
+)
+from tests.fixtures.ebull_test_db import (
+    test_database_url as _test_database_url,
+)
+from tests.fixtures.ebull_test_db import (
+    test_db_available as _test_db_available,
+)
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test Postgres not reachable",
+)
+
+
+@pytest.fixture
+def conn() -> Iterator[psycopg.Connection[object]]:
+    c: psycopg.Connection[object] = psycopg.connect(_test_database_url())
+    try:
+        yield c
+    finally:
+        c.rollback()
+        c.close()
+
+
+def _seed_progress_rows(
+    conn: psycopg.Connection[object],
+    layer_name: str,
+    statuses_with_offsets: list[tuple[str, int, str | None]],
+) -> None:
+    """Insert sync_layer_progress rows for ``layer_name``.
+
+    `sync_layer_progress.PRIMARY KEY = (sync_run_id, layer_name)`, so
+    each progress row gets its own freshly-created sync_run row.
+
+    ``statuses_with_offsets`` is a list of (status, minutes_ago, error_category).
+    """
+    now = datetime.now(tz=UTC)
+    with conn.cursor() as cur:
+        for status, minutes_ago, error_category in statuses_with_offsets:
+            started = now - timedelta(minutes=minutes_ago)
+            finished = started + timedelta(seconds=5)
+            cur.execute(
+                """
+                INSERT INTO sync_runs
+                    (scope, trigger, started_at, finished_at, status, layers_planned)
+                VALUES ('full', 'manual', %s, %s, 'complete', 1)
+                RETURNING sync_run_id
+                """,
+                (started, finished),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            sync_run_id = int(row[0])  # type: ignore[index]
+            cur.execute(
+                """
+                INSERT INTO sync_layer_progress
+                    (sync_run_id, layer_name, status, started_at,
+                     finished_at, error_category)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                (sync_run_id, layer_name, status, started, finished, error_category),
+            )
+    conn.commit()
+
+
+class TestConsecutiveFailures:
+    def test_zero_when_layer_has_no_history(self, conn: psycopg.Connection[object]) -> None:
+        assert consecutive_failures(conn, f"test-layer-{uuid4()}") == 0
+
+    def test_zero_when_latest_is_complete(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-{uuid4()}"
+        _seed_progress_rows(
+            conn,
+            layer,
+            [
+                ("failed", 30, "db_constraint"),
+                ("complete", 10, None),  # most recent
+            ],
+        )
+        assert consecutive_failures(conn, layer) == 0
+
+    def test_counts_streak_at_head(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-{uuid4()}"
+        # Three failures most recently, then a success further back.
+        _seed_progress_rows(
+            conn,
+            layer,
+            [
+                ("complete", 120, None),
+                ("failed", 60, "db_constraint"),
+                ("failed", 40, "db_constraint"),
+                ("failed", 10, "db_constraint"),
+            ],
+        )
+        assert consecutive_failures(conn, layer) == 3
+
+    def test_streak_breaks_on_skipped(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-{uuid4()}"
+        _seed_progress_rows(
+            conn,
+            layer,
+            [
+                ("failed", 60, "db_constraint"),
+                ("failed", 40, "db_constraint"),
+                ("skipped", 20, None),  # breaks streak
+                ("failed", 10, "db_constraint"),  # most recent
+            ],
+        )
+        # Only the latest 'failed' counts; the earlier run hit a skipped.
+        assert consecutive_failures(conn, layer) == 1
+
+    def test_streak_breaks_on_pending(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-{uuid4()}"
+        _seed_progress_rows(
+            conn,
+            layer,
+            [
+                ("failed", 60, "db_constraint"),
+                ("failed", 30, "db_constraint"),
+                ("pending", 5, None),  # fresh attempt in flight
+            ],
+        )
+        # Pending at the head is not "still failing".
+        assert consecutive_failures(conn, layer) == 0
+
+    def test_only_failures_in_history_counts_all(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-{uuid4()}"
+        _seed_progress_rows(
+            conn,
+            layer,
+            [
+                ("failed", 100, "db_constraint"),
+                ("failed", 50, "db_constraint"),
+                ("failed", 10, "db_constraint"),
+            ],
+        )
+        assert consecutive_failures(conn, layer) == 3
+
+
+class TestNullStartedAtOrdering:
+    """Regression: sync_layer_progress.started_at is nullable — the
+    ORDER BY must NOT let a null-started older row outrank a fresh
+    failure and zero the streak."""
+
+    def test_null_started_row_does_not_reset_streak(self, conn: psycopg.Connection[object]) -> None:
+        # Three failures, plus a later null-started pending row
+        # inserted with a NULL started_at (simulating a row frozen
+        # mid-planning by the reaper).
+        _seed_progress_rows(
+            conn,
+            f"test-layer-{uuid4()}",
+            [
+                ("failed", 90, "db_constraint"),
+                ("failed", 60, "db_constraint"),
+                ("failed", 30, "db_constraint"),
+            ],
+        )
+        layer = f"test-layer-null-{uuid4()}"
+        # Insert the failures first.
+        _seed_progress_rows(
+            conn,
+            layer,
+            [
+                ("failed", 90, "db_constraint"),
+                ("failed", 60, "db_constraint"),
+                ("failed", 30, "db_constraint"),
+            ],
+        )
+        # Now insert a pending row with started_at=NULL explicitly.
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO sync_runs
+                    (scope, trigger, started_at, status, layers_planned)
+                VALUES ('full', 'manual', NOW(), 'complete', 1)
+                RETURNING sync_run_id
+                """,
+            )
+            row = cur.fetchone()
+            assert row is not None
+            sid = int(row[0])  # type: ignore[index]
+            cur.execute(
+                """
+                INSERT INTO sync_layer_progress
+                    (sync_run_id, layer_name, status, started_at, finished_at,
+                     error_category)
+                VALUES (%s, %s, 'pending', NULL, NULL, NULL)
+                """,
+                (sid, layer),
+            )
+        conn.commit()
+        # Without NULLS LAST the pending row would sort first on DESC
+        # and break the streak → 0. With NULLS LAST the three
+        # failures are the head, streak stays 3.
+        assert consecutive_failures(conn, layer) == 3
+
+
+class TestLastErrorCategory:
+    def test_none_when_layer_has_no_history(self, conn: psycopg.Connection[object]) -> None:
+        assert last_error_category(conn, f"test-layer-{uuid4()}") is None
+
+    def test_none_when_no_row_has_category(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-{uuid4()}"
+        _seed_progress_rows(
+            conn,
+            layer,
+            [
+                ("complete", 60, None),
+                ("complete", 30, None),
+                ("skipped", 10, None),
+            ],
+        )
+        assert last_error_category(conn, layer) is None
+
+    def test_returns_most_recent_non_null(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-{uuid4()}"
+        _seed_progress_rows(
+            conn,
+            layer,
+            [
+                ("failed", 120, "network_timeout"),  # oldest
+                ("failed", 60, "db_constraint"),  # newer
+                ("skipped", 10, None),  # newest but null
+            ],
+        )
+        # Most recent NON-NULL is the db_constraint row; the later
+        # skipped-with-null does not clobber the "last known error".
+        assert last_error_category(conn, layer) == "db_constraint"
+
+    def test_returns_latest_even_when_layer_recovered(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-{uuid4()}"
+        _seed_progress_rows(
+            conn,
+            layer,
+            [
+                ("failed", 120, "network_timeout"),
+                ("complete", 10, None),  # recovered
+            ],
+        )
+        # Survives the recovery — the category from the failed run is
+        # still "last known", which is what a triage panel wants.
+        assert last_error_category(conn, layer) == "network_timeout"

--- a/tests/test_layer_failure_history.py
+++ b/tests/test_layer_failure_history.py
@@ -284,8 +284,41 @@ class TestBatchedAllLayerHistories:
                 ("complete", 10, None),  # latest success → streak 0
             ],
         )
-        streaks, categories = all_layer_histories(conn)
+        streaks, categories = all_layer_histories(conn, [a, b])
         assert streaks[a] == 3
         assert streaks[b] == 0
         assert categories[a] == "db_constraint"
         assert categories[b] == "network"
+
+    def test_empty_layer_list_returns_empty_dicts(self, conn: psycopg.Connection[object]) -> None:
+        streaks, categories = all_layer_histories(conn, [])
+        assert streaks == {}
+        assert categories == {}
+
+    def test_unknown_layer_name_not_in_result(self, conn: psycopg.Connection[object]) -> None:
+        # Layer has no rows — neither dict should contain it.
+        fresh = f"test-layer-never-{uuid4()}"
+        streaks, categories = all_layer_histories(conn, [fresh])
+        assert fresh not in streaks
+        assert fresh not in categories
+
+    def test_filter_excludes_other_layers(self, conn: psycopg.Connection[object]) -> None:
+        # Two layers exist in the DB but only one is requested —
+        # the filter must keep the other out.
+        included = f"test-layer-inc-{uuid4()}"
+        excluded = f"test-layer-exc-{uuid4()}"
+        _seed_progress_rows(
+            conn,
+            included,
+            [("failed", 20, "cat1"), ("failed", 10, "cat1")],
+        )
+        _seed_progress_rows(
+            conn,
+            excluded,
+            [("failed", 20, "cat2"), ("failed", 10, "cat2")],
+        )
+        streaks, categories = all_layer_histories(conn, [included])
+        assert streaks.get(included) == 2
+        assert included in categories
+        assert excluded not in streaks
+        assert excluded not in categories

--- a/tests/test_layer_failure_history.py
+++ b/tests/test_layer_failure_history.py
@@ -22,6 +22,7 @@ import psycopg
 import pytest
 
 from app.services.sync_orchestrator.layer_failure_history import (
+    all_layer_histories,
     consecutive_failures,
     last_error_category,
 )
@@ -172,15 +173,6 @@ class TestNullStartedAtOrdering:
         # Three failures, plus a later null-started pending row
         # inserted with a NULL started_at (simulating a row frozen
         # mid-planning by the reaper).
-        _seed_progress_rows(
-            conn,
-            f"test-layer-{uuid4()}",
-            [
-                ("failed", 90, "db_constraint"),
-                ("failed", 60, "db_constraint"),
-                ("failed", 30, "db_constraint"),
-            ],
-        )
         layer = f"test-layer-null-{uuid4()}"
         # Insert the failures first.
         _seed_progress_rows(
@@ -266,3 +258,34 @@ class TestLastErrorCategory:
         # Survives the recovery — the category from the failed run is
         # still "last known", which is what a triage panel wants.
         assert last_error_category(conn, layer) == "network_timeout"
+
+
+class TestBatchedAllLayerHistories:
+    """Batched equivalent called once by /sync/layers instead of
+    30 round-trips. Must agree with the per-layer helpers."""
+
+    def test_returns_streak_and_category_per_layer(self, conn: psycopg.Connection[object]) -> None:
+        a = f"test-layer-a-{uuid4()}"
+        b = f"test-layer-b-{uuid4()}"
+        _seed_progress_rows(
+            conn,
+            a,
+            [
+                ("failed", 60, "db_constraint"),
+                ("failed", 30, "db_constraint"),
+                ("failed", 10, "db_constraint"),  # head is 3 failures
+            ],
+        )
+        _seed_progress_rows(
+            conn,
+            b,
+            [
+                ("failed", 120, "network"),
+                ("complete", 10, None),  # latest success → streak 0
+            ],
+        )
+        streaks, categories = all_layer_histories(conn)
+        assert streaks[a] == 3
+        assert streaks[b] == 0
+        assert categories[a] == "db_constraint"
+        assert categories[b] == "network"

--- a/tests/test_layer_failure_history.py
+++ b/tests/test_layer_failure_history.py
@@ -288,6 +288,9 @@ class TestBatchedAllLayerHistories:
         assert streaks[a] == 3
         assert streaks[b] == 0
         assert categories[a] == "db_constraint"
+        # b recovered but the last-known category survives — that is
+        # the intentional "still show what the last break was" triage
+        # semantic (per spec §2 and the per-layer helper above).
         assert categories[b] == "network"
 
     def test_empty_layer_list_returns_empty_dicts(self, conn: psycopg.Connection[object]) -> None:


### PR DESCRIPTION
## Summary
Operator feedback: AdminPage is "noisy and confusing, no idea if there are bugs". Diagnosed (2026-04-19) and flipped the page framing.

- **Problems panel** (hidden when clean) — failing layers with `consecutive_failures` + `last_error_category`, failing jobs, coverage anomalies.
- **Fund data row** — 4 live cells + 3 pending placeholders for summaries we don't yet expose.
- **Collapsed-by-default**: orchestrator details (old `SyncDashboard`), background tasks, filings coverage.
- **Shared Sync-now** via `useSyncTrigger` so top-level + inner buttons cannot fire two concurrent POSTs.
- **Backend**: `/sync/layers` now populates `consecutive_failures` + `last_error_category` from `sync_layer_progress` (were hardcoded 0 / only predicate-exception). Makes `cik_mapping` 3× db_constraint failures visible.

## Why
Diagnostic audit surfaced real bugs hidden by the current flat 15-card grid:
- `cik_mapping` 3× `db_constraint` failures — invisible
- `universe` + `candles` 2 days stale — buried next to 13 healthy cards
- `thesis` never produced output (0 rows) — just shows as "skipped"
- 5 trade_recommendations ever, all rejected — not mentioned

## Spec
`docs/superpowers/specs/2026-04-19-admin-triage-design.md` — Codex-approved after 7 pre-spec passes; pre-push also clean after fixing four additional findings (queued button stuck when section collapsed, NULL-ordering sort bug, partial-source masking, stale non-blocking layers omitted).

## Test plan
- [x] 11 new backend tests (incl. null-started_at regression)
- [x] 249 frontend tests (22 test files, all green)
- [x] `uv run ruff check . / format / pyright / pytest` — all pass (1994 tests)
- [x] `pnpm --dir frontend typecheck / test` — all pass
- [ ] Manual browser verify on live: expect Problems panel to surface `cik_mapping` (3 failures, db_constraint), `universe` (stale), `candles` (stale).

## Non-goals (out of scope — tech-debt filed)
- Raw-storage visibility
- Tier 1/2/3 breakdown endpoint
- Scores/theses summary endpoints
- `/jobs/overview` consecutive-failure count

🤖 Generated with [Claude Code](https://claude.com/claude-code)