### PR TITLE
feat(#328): chunk 2 — DataLayer registry extension + content predicates

### DIFF
--- a/app/services/sync_orchestrator/content_predicates.py
+++ b/app/services/sync_orchestrator/content_predicates.py
@@ -20,12 +20,17 @@ def candles_content_ok(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
     from app.services.market_data import _most_recent_trading_day
 
     trading_day = _most_recent_trading_day(date.today())
+    # `i.is_tradable = TRUE` matches the filter in `daily_candle_refresh`
+    # (app/workers/scheduler.py). Without it, a delisted instrument that
+    # still carries tier 1/2 coverage would permanently fail this
+    # content check, because the refresh job never re-fetches it.
     row = conn.execute(
         """
         SELECT COUNT(*) AS missing
         FROM instruments i
         JOIN coverage c USING (instrument_id)
         WHERE c.coverage_tier IN (1, 2)
+          AND i.is_tradable = TRUE
           AND COALESCE(
               (SELECT MAX(price_date) FROM price_daily p
                WHERE p.instrument_id = i.instrument_id),

--- a/app/services/sync_orchestrator/content_predicates.py
+++ b/app/services/sync_orchestrator/content_predicates.py
@@ -1,0 +1,71 @@
+"""Per-layer content predicates (spec §4).
+
+These live independently of the audit-age check so the new state
+machine (chunk 4) can distinguish "audit is fresh but data is missing
+rows" (DEGRADED via content) from "audit is stale" (DEGRADED via age).
+The legacy `is_fresh` predicates in `freshness.py` combined both; once
+chunk 7 retires that module these are the surviving content checks.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import psycopg
+
+
+def candles_content_ok(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
+    """Every Tier 1/2 instrument must have a candle for the most recent trading day."""
+    from app.services.market_data import _most_recent_trading_day
+
+    trading_day = _most_recent_trading_day(date.today())
+    row = conn.execute(
+        """
+        SELECT COUNT(*) AS missing
+        FROM instruments i
+        JOIN coverage c USING (instrument_id)
+        WHERE c.coverage_tier IN (1, 2)
+          AND COALESCE(
+              (SELECT MAX(price_date) FROM price_daily p
+               WHERE p.instrument_id = i.instrument_id),
+              DATE '1900-01-01'
+          ) < %s
+        """,
+        (trading_day,),
+    ).fetchone()
+    missing = row[0] if row else 0
+    if missing > 0:
+        return (
+            False,
+            f"{missing} T1/T2 instruments missing candle for {trading_day.isoformat()}",
+        )
+    return True, "all T1/T2 instruments current"
+
+
+def fundamentals_content_ok(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
+    """Every tradable instrument must have a fundamentals_snapshot row in the current quarter."""
+    today = date.today()
+    quarter = (today.month - 1) // 3
+    quarter_start = date(today.year, quarter * 3 + 1, 1)
+    row = conn.execute(
+        """
+        SELECT COUNT(*) AS missing
+        FROM instruments i
+        WHERE i.is_tradable = TRUE
+          AND NOT EXISTS (
+              SELECT 1 FROM fundamentals_snapshot fs
+              WHERE fs.instrument_id = i.instrument_id
+                AND fs.as_of_date >= %s
+          )
+        """,
+        (quarter_start,),
+    ).fetchone()
+    missing = row[0] if row else 0
+    if missing > 0:
+        return (
+            False,
+            f"{missing} tradable instruments lack fundamentals snapshot "
+            f"for quarter starting {quarter_start.isoformat()}",
+        )
+    return True, "all tradable instruments have snapshot"

--- a/app/services/sync_orchestrator/registry.py
+++ b/app/services/sync_orchestrator/registry.py
@@ -66,6 +66,9 @@ class DataLayer:
     display_name: str
     tier: int
     cadence: Cadence
+    # Legacy combined audit-age + content predicate. Retained until chunk 7
+    # retires freshness.py; the new state machine (chunk 4) calls
+    # `content_predicate` + its own age check separately.
     is_fresh: Callable[[psycopg.Connection[Any]], tuple[bool, str]]
     refresh: LayerRefresh
     dependencies: tuple[str, ...] = ()
@@ -77,7 +80,7 @@ class DataLayer:
     plain_language_sla: str = ""
 
 
-_TIGHT_RETRY = RetryPolicy(max_attempts=5, backoff_seconds=(30, 60, 120, 300, 600))
+MINUTE_LAYER_RETRY = RetryPolicy(max_attempts=5, backoff_seconds=(30, 60, 120, 300, 600))
 
 LAYERS: dict[str, DataLayer] = {
     "universe": DataLayer(
@@ -194,7 +197,7 @@ LAYERS: dict[str, DataLayer] = {
         refresh=refresh_portfolio_sync,
         dependencies=(),
         is_blocking=False,
-        retry_policy=_TIGHT_RETRY,
+        retry_policy=MINUTE_LAYER_RETRY,
         plain_language_sla="Synced every 5 minutes against eToro.",
     ),
     "fx_rates": DataLayer(
@@ -206,7 +209,7 @@ LAYERS: dict[str, DataLayer] = {
         refresh=refresh_fx_rates,
         dependencies=(),
         is_blocking=False,
-        retry_policy=_TIGHT_RETRY,
+        retry_policy=MINUTE_LAYER_RETRY,
         plain_language_sla="Refreshed every 5 minutes for live valuation.",
     ),
     "cost_models": DataLayer(

--- a/app/services/sync_orchestrator/registry.py
+++ b/app/services/sync_orchestrator/registry.py
@@ -51,9 +51,9 @@ from app.services.sync_orchestrator.freshness import (
     weekly_reports_is_fresh,
 )
 from app.services.sync_orchestrator.layer_types import (
+    DEFAULT_RETRY_POLICY,
     Cadence,
     ContentPredicate,
-    DEFAULT_RETRY_POLICY,
     RetryPolicy,
     SecretRef,
 )

--- a/app/services/sync_orchestrator/registry.py
+++ b/app/services/sync_orchestrator/registry.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any
 
 import psycopg
@@ -28,6 +29,10 @@ from app.services.sync_orchestrator.adapters import (
     refresh_universe,
     refresh_weekly_reports,
 )
+from app.services.sync_orchestrator.content_predicates import (
+    candles_content_ok,
+    fundamentals_content_ok,
+)
 from app.services.sync_orchestrator.freshness import (
     candles_is_fresh,
     cik_mapping_is_fresh,
@@ -45,6 +50,13 @@ from app.services.sync_orchestrator.freshness import (
     universe_is_fresh,
     weekly_reports_is_fresh,
 )
+from app.services.sync_orchestrator.layer_types import (
+    Cadence,
+    ContentPredicate,
+    DEFAULT_RETRY_POLICY,
+    RetryPolicy,
+    SecretRef,
+)
 from app.services.sync_orchestrator.types import LayerRefresh
 
 
@@ -53,144 +65,181 @@ class DataLayer:
     name: str
     display_name: str
     tier: int
+    cadence: Cadence
     is_fresh: Callable[[psycopg.Connection[Any]], tuple[bool, str]]
     refresh: LayerRefresh
-    dependencies: tuple[str, ...]
+    dependencies: tuple[str, ...] = ()
     is_blocking: bool = True
-    cadence: str = "daily"
+    grace_multiplier: float = 1.25
+    retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY
+    secret_refs: tuple[SecretRef, ...] = ()
+    content_predicate: ContentPredicate | None = None
+    plain_language_sla: str = ""
 
+
+_TIGHT_RETRY = RetryPolicy(max_attempts=5, backoff_seconds=(30, 60, 120, 300, 600))
 
 LAYERS: dict[str, DataLayer] = {
     "universe": DataLayer(
         name="universe",
         display_name="Tradable Universe",
         tier=0,
+        cadence=Cadence(interval=timedelta(days=7)),
         is_fresh=universe_is_fresh,
         refresh=refresh_universe,
         dependencies=(),
+        plain_language_sla="Refreshed weekly — eToro instrument list.",
     ),
     "cik_mapping": DataLayer(
         name="cik_mapping",
         display_name="SEC CIK Mapping",
         tier=0,
+        cadence=Cadence(interval=timedelta(hours=24)),
         is_fresh=cik_mapping_is_fresh,
         refresh=refresh_cik_mapping,
         dependencies=("universe",),
+        plain_language_sla="Refreshed nightly from SEC company_tickers.json.",
     ),
     "candles": DataLayer(
         name="candles",
         display_name="Daily Price Candles",
         tier=1,
+        cadence=Cadence(interval=timedelta(hours=24)),
         is_fresh=candles_is_fresh,
         refresh=refresh_candles,
         dependencies=("universe",),
+        content_predicate=candles_content_ok,
+        plain_language_sla="Refreshed every trading day after market close.",
     ),
     "financial_facts": DataLayer(
         name="financial_facts",
         display_name="SEC EDGAR XBRL Facts",
         tier=1,
+        cadence=Cadence(interval=timedelta(hours=24)),
         is_fresh=financial_facts_is_fresh,
         refresh=refresh_financial_facts_and_normalization,
         dependencies=("cik_mapping",),
+        plain_language_sla="Refreshed nightly from SEC XBRL filings.",
     ),
     "financial_normalization": DataLayer(
         name="financial_normalization",
         display_name="Financial Period Normalization",
         tier=2,
+        cadence=Cadence(interval=timedelta(hours=24)),
         is_fresh=financial_normalization_is_fresh,
         refresh=refresh_financial_facts_and_normalization,
         dependencies=("financial_facts",),
+        plain_language_sla="Derived nightly from SEC XBRL facts.",
     ),
     "fundamentals": DataLayer(
         name="fundamentals",
         display_name="Fundamentals Snapshot",
         tier=1,
+        cadence=Cadence(interval=timedelta(days=90)),
         is_fresh=fundamentals_is_fresh,
         refresh=refresh_fundamentals,
         dependencies=("universe",),
-        cadence="quarterly",
+        content_predicate=fundamentals_content_ok,
+        plain_language_sla="Refreshed quarterly alongside earnings.",
     ),
     "news": DataLayer(
         name="news",
         display_name="News & Sentiment",
         tier=1,
+        cadence=Cadence(interval=timedelta(hours=4)),
         is_fresh=news_is_fresh,
         refresh=refresh_news,
         dependencies=("universe",),
         is_blocking=False,
-        cadence="4h",
+        secret_refs=(SecretRef(env_var="ANTHROPIC_API_KEY", display_name="Anthropic API key"),),
+        plain_language_sla="Refreshed every 4h — news + sentiment scoring.",
     ),
     "thesis": DataLayer(
         name="thesis",
         display_name="Investment Thesis",
         tier=2,
+        cadence=Cadence(interval=timedelta(hours=24)),
         is_fresh=thesis_is_fresh,
         refresh=refresh_thesis,
         dependencies=("fundamentals", "financial_normalization", "news"),
+        secret_refs=(SecretRef(env_var="ANTHROPIC_API_KEY", display_name="Anthropic API key"),),
+        plain_language_sla="Refreshed nightly for stale Tier 1 tickers.",
     ),
     "scoring": DataLayer(
         name="scoring",
         display_name="Ranking Scores",
         tier=3,
+        cadence=Cadence(interval=timedelta(hours=24)),
         is_fresh=scoring_is_fresh,
         refresh=refresh_scoring_and_recommendations,
         dependencies=("thesis", "candles"),
+        plain_language_sla="Refreshed every morning pre-market.",
     ),
     "recommendations": DataLayer(
         name="recommendations",
         display_name="Trade Recommendations",
         tier=3,
+        cadence=Cadence(interval=timedelta(hours=24)),
         is_fresh=recommendations_is_fresh,
         refresh=refresh_scoring_and_recommendations,
         dependencies=("scoring",),
+        plain_language_sla="Refreshed every morning after scoring.",
     ),
     "portfolio_sync": DataLayer(
         name="portfolio_sync",
         display_name="Portfolio Sync",
         tier=0,
+        cadence=Cadence(interval=timedelta(minutes=5)),
         is_fresh=portfolio_sync_is_fresh,
         refresh=refresh_portfolio_sync,
         dependencies=(),
         is_blocking=False,
-        cadence="5m",
+        retry_policy=_TIGHT_RETRY,
+        plain_language_sla="Synced every 5 minutes against eToro.",
     ),
     "fx_rates": DataLayer(
         name="fx_rates",
         display_name="FX Rates",
         tier=0,
+        cadence=Cadence(interval=timedelta(minutes=5)),
         is_fresh=fx_rates_is_fresh,
         refresh=refresh_fx_rates,
         dependencies=(),
         is_blocking=False,
-        cadence="5m",
+        retry_policy=_TIGHT_RETRY,
+        plain_language_sla="Refreshed every 5 minutes for live valuation.",
     ),
     "cost_models": DataLayer(
         name="cost_models",
         display_name="Transaction Cost Models",
         tier=2,
+        cadence=Cadence(interval=timedelta(hours=24)),
         is_fresh=cost_models_is_fresh,
         refresh=refresh_cost_models,
         dependencies=("universe",),
+        plain_language_sla="Re-seeded nightly.",
     ),
     "weekly_reports": DataLayer(
         name="weekly_reports",
         display_name="Weekly Performance Report",
         tier=3,
+        cadence=Cadence(interval=timedelta(days=7)),
         is_fresh=weekly_reports_is_fresh,
         refresh=refresh_weekly_reports,
         dependencies=(),
         is_blocking=False,
-        cadence="weekly",
+        plain_language_sla="Published every Monday morning.",
     ),
     "monthly_reports": DataLayer(
         name="monthly_reports",
         display_name="Monthly Performance Report",
         tier=3,
+        cadence=Cadence(interval=timedelta(days=31)),
         is_fresh=monthly_reports_is_fresh,
         refresh=refresh_monthly_reports,
         dependencies=(),
         is_blocking=False,
-        cadence="monthly",
+        plain_language_sla="Published on the 1st of every month.",
     ),
 }
 

--- a/tests/services/sync_orchestrator/test_content_predicates.py
+++ b/tests/services/sync_orchestrator/test_content_predicates.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+
+from app.services.sync_orchestrator.content_predicates import (
+    candles_content_ok,
+    fundamentals_content_ok,
+)
+
+
+def test_candles_content_ok_when_no_missing_rows() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = (0,)
+    ok, detail = candles_content_ok(conn)
+    assert ok is True
+    assert "current" in detail.lower() or "ok" in detail.lower()
+
+
+def test_candles_content_missing_reports_count() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = (17,)
+    ok, detail = candles_content_ok(conn)
+    assert ok is False
+    assert "17" in detail
+
+
+def test_fundamentals_content_ok_when_no_missing() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = (0,)
+    ok, _ = fundamentals_content_ok(conn)
+    assert ok is True
+
+
+def test_fundamentals_content_missing_reports_count() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = (5,)
+    ok, detail = fundamentals_content_ok(conn)
+    assert ok is False
+    assert "5" in detail

--- a/tests/services/sync_orchestrator/test_content_predicates.py
+++ b/tests/services/sync_orchestrator/test_content_predicates.py
@@ -22,6 +22,18 @@ def test_candles_content_missing_reports_count() -> None:
     assert "17" in detail
 
 
+def test_candles_content_query_filters_tradable_instruments() -> None:
+    # Pin the is_tradable filter so a future refactor cannot silently
+    # drop it — a delisted instrument with tier 1/2 coverage would
+    # otherwise make the layer permanently fail content freshness.
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = (0,)
+    candles_content_ok(conn)
+    sql = conn.execute.call_args.args[0]
+    assert "is_tradable = TRUE" in sql or "is_tradable=TRUE" in sql
+    assert "coverage_tier IN (1, 2)" in sql or "coverage_tier IN(1, 2)" in sql
+
+
 def test_fundamentals_content_ok_when_no_missing() -> None:
     conn = MagicMock()
     conn.execute.return_value.fetchone.return_value = (0,)

--- a/tests/services/sync_orchestrator/test_registry_shape.py
+++ b/tests/services/sync_orchestrator/test_registry_shape.py
@@ -1,0 +1,90 @@
+from datetime import timedelta
+
+from app.services.sync_orchestrator.content_predicates import (
+    candles_content_ok,
+    fundamentals_content_ok,
+)
+from app.services.sync_orchestrator.layer_types import (
+    Cadence,
+    DEFAULT_RETRY_POLICY,
+    RetryPolicy,
+)
+from app.services.sync_orchestrator.registry import LAYERS
+
+
+EXPECTED_CADENCES: dict[str, timedelta] = {
+    "universe": timedelta(days=7),
+    "cik_mapping": timedelta(hours=24),
+    "candles": timedelta(hours=24),
+    "financial_facts": timedelta(hours=24),
+    "financial_normalization": timedelta(hours=24),
+    "fundamentals": timedelta(days=90),
+    "news": timedelta(hours=4),
+    "thesis": timedelta(hours=24),
+    "scoring": timedelta(hours=24),
+    "recommendations": timedelta(hours=24),
+    "portfolio_sync": timedelta(minutes=5),
+    "fx_rates": timedelta(minutes=5),
+    "cost_models": timedelta(hours=24),
+    "weekly_reports": timedelta(days=7),
+    "monthly_reports": timedelta(days=31),
+}
+
+
+def test_every_layer_has_typed_cadence() -> None:
+    for name, layer in LAYERS.items():
+        assert isinstance(layer.cadence, Cadence), f"{name} cadence is not Cadence"
+
+
+def test_cadence_intervals_match_expected() -> None:
+    for name, expected in EXPECTED_CADENCES.items():
+        assert LAYERS[name].cadence.interval == expected, (
+            f"{name} cadence interval {LAYERS[name].cadence.interval} != {expected}"
+        )
+
+
+def test_minute_cadence_layers_have_tighter_retry_policy() -> None:
+    for name in ("fx_rates", "portfolio_sync"):
+        policy = LAYERS[name].retry_policy
+        assert policy.max_attempts == 5
+        assert policy.backoff_seconds == (30, 60, 120, 300, 600)
+
+
+def test_daily_layers_use_default_retry_policy() -> None:
+    for name in ("cik_mapping", "candles", "financial_facts"):
+        assert LAYERS[name].retry_policy == DEFAULT_RETRY_POLICY
+
+
+def test_every_layer_has_non_empty_plain_language_sla() -> None:
+    for name, layer in LAYERS.items():
+        assert layer.plain_language_sla, f"{name} missing plain_language_sla"
+
+
+def test_grace_multiplier_default() -> None:
+    for name, layer in LAYERS.items():
+        assert layer.grace_multiplier == 1.25
+
+
+def test_llm_layers_declare_anthropic_secret() -> None:
+    news = {s.env_var for s in LAYERS["news"].secret_refs}
+    thesis = {s.env_var for s in LAYERS["thesis"].secret_refs}
+    assert "ANTHROPIC_API_KEY" in news
+    assert "ANTHROPIC_API_KEY" in thesis
+
+
+def test_market_data_layers_declare_no_env_secrets() -> None:
+    assert LAYERS["candles"].secret_refs == ()
+    assert LAYERS["cik_mapping"].secret_refs == ()
+
+
+def test_candles_has_content_predicate() -> None:
+    assert LAYERS["candles"].content_predicate is candles_content_ok
+
+
+def test_fundamentals_has_content_predicate() -> None:
+    assert LAYERS["fundamentals"].content_predicate is fundamentals_content_ok
+
+
+def test_layers_without_content_predicate_have_none() -> None:
+    for name in ("universe", "news", "scoring", "portfolio_sync", "cik_mapping"):
+        assert LAYERS[name].content_predicate is None

--- a/tests/services/sync_orchestrator/test_registry_shape.py
+++ b/tests/services/sync_orchestrator/test_registry_shape.py
@@ -5,12 +5,10 @@ from app.services.sync_orchestrator.content_predicates import (
     fundamentals_content_ok,
 )
 from app.services.sync_orchestrator.layer_types import (
-    Cadence,
     DEFAULT_RETRY_POLICY,
-    RetryPolicy,
+    Cadence,
 )
 from app.services.sync_orchestrator.registry import LAYERS
-
 
 EXPECTED_CADENCES: dict[str, timedelta] = {
     "universe": timedelta(days=7),


### PR DESCRIPTION
## What

Chunk 2 of sub-project **A** (freshness unification, #328). Two additions:

1. **`app/services/sync_orchestrator/content_predicates.py`** — extracts the per-instrument content-audit logic from `freshness.py`'s combined \`is_fresh\` predicates into standalone callables. Two exports: \`candles_content_ok\` and \`fundamentals_content_ok\`. Behaviour byte-identical to the legacy content blocks.

2. **Extended \`DataLayer\` dataclass** (\`app/services/sync_orchestrator/registry.py\`): adds \`cadence: Cadence\` (replaces string \`cadence\`), \`grace_multiplier\`, \`retry_policy\`, \`secret_refs\`, \`content_predicate\`, \`plain_language_sla\`. All 15 layer literals rewritten to use the new fields.

Minute-cadence layers (\`fx_rates\`, \`portfolio_sync\`) share a \`MINUTE_LAYER_RETRY\` policy (5 attempts, 30s→10min backoff). All others use \`DEFAULT_RETRY_POLICY\` (3 attempts, 1m→10m→1h).

LLM layers (\`news\`, \`thesis\`) declare \`SecretRef(env_var=\"ANTHROPIC_API_KEY\")\`. The upcoming state machine will mark them \`SECRET_MISSING\` if the var is absent, clearing the old silent \`prereq_missing:\` skip.

## Why

Chunk 1 introduced the typed vocabulary. This chunk wires it into the registry so chunk 4 can consume it. \`is_fresh\` stays on every layer (legacy combined audit-age + content predicate), with a comment pointing at chunk 7 for its retirement.

## Review loops resolved

- **Code reviewer subagent** flagged two minors: \`_TIGHT_RETRY\` ambiguity → renamed \`MINUTE_LAYER_RETRY\`; \`is_fresh\` field lacked a deprecation comment → added.
- **Codex** flagged one real bug: \`candles_content_ok\` did not filter \`is_tradable = TRUE\`, while \`daily_candle_refresh\` does. A delisted instrument with tier 1/2 coverage would permanently fail the predicate. Fixed + pinned with a SQL-shape test.

## Test plan

- [x] \`uv run pytest tests/services/sync_orchestrator/\` — 32 passed (content + registry + types)
- [x] \`uv run pytest -x -q\` full suite — 2029 passed, 1 skipped
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pyright\` — 0 errors
- [x] Codex review — single finding (is_tradable) fixed pre-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)