### PR TITLE
feat(#328): chunk 6 — collapse_cascades + scope=behind + Admin Sync default

### DIFF
--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -62,7 +62,7 @@ router = APIRouter(
 
 
 class SyncRequest(BaseModel):
-    scope: Literal["full", "layer", "high_frequency", "job"] = "full"
+    scope: Literal["full", "layer", "high_frequency", "job", "behind"] = "full"
     layer: str | None = None
     job: str | None = None
 
@@ -122,6 +122,8 @@ def _scope_from(body: SyncRequest) -> SyncScope:
         return SyncScope.full()
     if body.scope == "high_frequency":
         return SyncScope.high_frequency()
+    if body.scope == "behind":
+        return SyncScope.behind()
     if body.scope == "layer":
         if not body.layer:
             raise HTTPException(status_code=422, detail="layer required when scope='layer'")

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -62,7 +62,11 @@ router = APIRouter(
 
 
 class SyncRequest(BaseModel):
-    scope: Literal["full", "layer", "high_frequency", "job", "behind"] = "full"
+    # Default `behind` — resync only layers the state machine says are
+    # DEGRADED / ACTION_NEEDED plus their non-HEALTHY upstreams. Full
+    # sync is available via explicit `scope: "full"` for rare operator
+    # overrides; the Admin UI no longer fires full by default.
+    scope: Literal["full", "layer", "high_frequency", "job", "behind"] = "behind"
     layer: str | None = None
     job: str | None = None
 

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -339,7 +339,7 @@ def get_sync_layers_v2(
     # Build once per request using the extracted pure function.
     deps_map: dict[str, tuple[str, ...]] = {n: lay.dependencies for n, lay in LAYERS.items()}
     groups = collapse_cascades(deps_map, states)
-    groups_by_root: dict[str, list[str]] = {g.root: g.affected for g in groups}
+    groups_by_root: dict[str, list[str]] = {g.root: list(g.affected) for g in groups}
 
     category_values = {c.value for c in FailureCategory}
 
@@ -406,7 +406,7 @@ def get_sync_layers_v2(
         # RUNNING / RETRYING / CASCADE_WAITING feed into system_state
         # counts + cascade_groups; no top-level bucket.
 
-    cascade_groups = [CascadeGroupModel(root=g.root, affected=g.affected) for g in groups]
+    cascade_groups = [CascadeGroupModel(root=g.root, affected=list(g.affected)) for g in groups]
 
     running_count = sum(1 for s in states.values() if s is LayerState.RUNNING)
     retrying_count = sum(1 for s in states.values() if s is LayerState.RETRYING)

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -27,6 +27,7 @@ from app.services.sync_orchestrator import (
     SyncScope,
     submit_sync,
 )
+from app.services.sync_orchestrator.cascade import ProblemGroup, collapse_cascades
 from app.services.sync_orchestrator.layer_failure_history import all_layer_histories
 from app.services.sync_orchestrator.layer_state import compute_layer_states_from_db
 from app.services.sync_orchestrator.layer_types import (
@@ -329,40 +330,12 @@ def get_sync_layers_v2(
     healthy: list[LayerSummary] = []
     disabled: list[LayerSummary] = []
 
-    # Inline cascade-grouping shim. Chunk 6 replaces this with
-    # `collapse_cascades` from cascade.py (pure function + tests).
-    # The two implementations must agree on the descendant walk.
-    # Cached to guarantee action_needed.affected_downstream and
-    # cascade_groups[].affected stay byte-identical even if the BFS
-    # ever became order-sensitive.
-    _downstream_cache: dict[str, list[str]] = {}
-    # Pre-compute reverse adjacency once (O(N+E)) so BFS becomes O(E)
-    # per root instead of O(N*depth) re-scanning the whole registry
-    # each frontier step. Small registry today; scales gracefully.
-    _reverse_deps: dict[str, list[str]] = {n: [] for n in LAYERS}
-    for _n, _layer in LAYERS.items():
-        for _dep in _layer.dependencies:
-            _reverse_deps[_dep].append(_n)
-
-    def _downstream(root: str) -> list[str]:
-        if root in _downstream_cache:
-            return _downstream_cache[root]
-        affected: list[str] = []
-        frontier = {root}
-        visited = {root}
-        while frontier:
-            next_frontier: set[str] = set()
-            for parent in frontier:
-                for child in _reverse_deps.get(parent, ()):
-                    if child in visited:
-                        continue
-                    visited.add(child)
-                    if states.get(child) is LayerState.CASCADE_WAITING:
-                        affected.append(child)
-                    next_frontier.add(child)
-            frontier = next_frontier
-        _downstream_cache[root] = affected
-        return affected
+    # Build once per request using the extracted pure function.
+    deps_map: dict[str, tuple[str, ...]] = {
+        n: lay.dependencies for n, lay in LAYERS.items()
+    }
+    groups = collapse_cascades(deps_map, states)
+    groups_by_root: dict[str, list[str]] = {g.root: g.affected for g in groups}
 
     category_values = {c.value for c in FailureCategory}
 
@@ -386,7 +359,7 @@ def get_sync_layers_v2(
                     operator_fix=remedy.operator_fix,
                     self_heal=remedy.self_heal,
                     consecutive_failures=streaks.get(name, 0),
-                    affected_downstream=_downstream(name),
+                    affected_downstream=groups_by_root.get(name, []),
                 )
             )
         elif state is LayerState.SECRET_MISSING:
@@ -429,11 +402,7 @@ def get_sync_layers_v2(
         # RUNNING / RETRYING / CASCADE_WAITING feed into system_state
         # counts + cascade_groups; no top-level bucket.
 
-    cascade_groups = [
-        CascadeGroupModel(root=name, affected=_downstream(name))
-        for name, state in states.items()
-        if state in {LayerState.ACTION_NEEDED, LayerState.SECRET_MISSING}
-    ]
+    cascade_groups = [CascadeGroupModel(root=g.root, affected=g.affected) for g in groups]
 
     running_count = sum(1 for s in states.values() if s is LayerState.RUNNING)
     retrying_count = sum(1 for s in states.values() if s is LayerState.RETRYING)

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -27,7 +27,7 @@ from app.services.sync_orchestrator import (
     SyncScope,
     submit_sync,
 )
-from app.services.sync_orchestrator.cascade import ProblemGroup, collapse_cascades
+from app.services.sync_orchestrator.cascade import collapse_cascades
 from app.services.sync_orchestrator.layer_failure_history import all_layer_histories
 from app.services.sync_orchestrator.layer_state import compute_layer_states_from_db
 from app.services.sync_orchestrator.layer_types import (
@@ -333,9 +333,7 @@ def get_sync_layers_v2(
     disabled: list[LayerSummary] = []
 
     # Build once per request using the extracted pure function.
-    deps_map: dict[str, tuple[str, ...]] = {
-        n: lay.dependencies for n, lay in LAYERS.items()
-    }
+    deps_map: dict[str, tuple[str, ...]] = {n: lay.dependencies for n, lay in LAYERS.items()}
     groups = collapse_cascades(deps_map, states)
     groups_by_root: dict[str, list[str]] = {g.root: g.affected for g in groups}
 

--- a/app/services/sync_orchestrator/cascade.py
+++ b/app/services/sync_orchestrator/cascade.py
@@ -15,7 +15,10 @@ from app.services.sync_orchestrator.layer_types import LayerState
 @dataclass(frozen=True)
 class ProblemGroup:
     root: str
-    affected: list[str]
+    # Tuple, not list: matches the frozen-dataclass contract and
+    # prevents callers from mutating shared state through a returned
+    # reference.
+    affected: tuple[str, ...]
 
 
 def collapse_cascades(
@@ -54,5 +57,5 @@ def collapse_cascades(
                         affected.append(child)
                     next_frontier.add(child)
             frontier = next_frontier
-        groups.append(ProblemGroup(root=root, affected=affected))
+        groups.append(ProblemGroup(root=root, affected=tuple(affected)))
     return groups

--- a/app/services/sync_orchestrator/cascade.py
+++ b/app/services/sync_orchestrator/cascade.py
@@ -1,0 +1,58 @@
+"""Group CASCADE_WAITING layers under their terminal-blocked root (spec §6).
+
+Pure function over a dependency map + a state map. Used by the v2 API
+endpoint to produce `cascade_groups`; replaces the inline shim in
+`app/api/sync.py`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.services.sync_orchestrator.layer_types import LayerState
+
+
+@dataclass(frozen=True)
+class ProblemGroup:
+    root: str
+    affected: list[str]
+
+
+def collapse_cascades(
+    dependencies: dict[str, tuple[str, ...]],
+    states: dict[str, LayerState],
+) -> list[ProblemGroup]:
+    """Return one ProblemGroup per ACTION_NEEDED / SECRET_MISSING layer,
+    each listing every CASCADE_WAITING descendant in the DAG.
+
+    `dependencies[name]` lists the direct upstream layer names for
+    `name`. `states[name]` is the layer's current LayerState. Layers
+    missing from either map are treated as absent.
+    """
+    # Reverse adjacency: parent -> list of children. Computed once.
+    reverse: dict[str, list[str]] = {n: [] for n in dependencies}
+    for name, deps in dependencies.items():
+        for dep in deps:
+            reverse.setdefault(dep, []).append(name)
+
+    terminal = {LayerState.ACTION_NEEDED, LayerState.SECRET_MISSING}
+    roots = [n for n, s in states.items() if s in terminal]
+
+    groups: list[ProblemGroup] = []
+    for root in roots:
+        affected: list[str] = []
+        frontier = {root}
+        visited = {root}
+        while frontier:
+            next_frontier: set[str] = set()
+            for parent in frontier:
+                for child in reverse.get(parent, ()):
+                    if child in visited:
+                        continue
+                    visited.add(child)
+                    if states.get(child) is LayerState.CASCADE_WAITING:
+                        affected.append(child)
+                    next_frontier.add(child)
+            frontier = next_frontier
+        groups.append(ProblemGroup(root=root, affected=affected))
+    return groups

--- a/app/services/sync_orchestrator/planner.py
+++ b/app/services/sync_orchestrator/planner.py
@@ -113,10 +113,7 @@ def _scope_to_candidate_jobs(
         if conn is None:
             raise ValueError("scope='behind' requires a live connection")
         states = compute_layer_states_from_db(conn)
-        target_layers = {
-            n for n, s in states.items()
-            if s in {LayerState.DEGRADED, LayerState.ACTION_NEEDED}
-        }
+        target_layers = {n for n, s in states.items() if s in {LayerState.DEGRADED, LayerState.ACTION_NEEDED}}
         if not target_layers:
             return []
         # Include any non-HEALTHY upstreams transitively, so a waiting
@@ -140,9 +137,7 @@ def _transitive_layer_closure(seed: set[str]) -> set[str]:
     return result
 
 
-def _transitive_upstreams_not_healthy(
-    seed: set[str], states: dict[str, LayerState]
-) -> set[str]:
+def _transitive_upstreams_not_healthy(seed: set[str], states: dict[str, LayerState]) -> set[str]:
     """Return all transitive upstream dependencies of seed layers that are
     not HEALTHY. Used by scope='behind' to include prerequisites that need
     refreshing before the target layers can be satisfied."""

--- a/app/services/sync_orchestrator/planner.py
+++ b/app/services/sync_orchestrator/planner.py
@@ -12,6 +12,8 @@ from typing import Any
 
 import psycopg
 
+from app.services.sync_orchestrator.layer_state import compute_layer_states_from_db
+from app.services.sync_orchestrator.layer_types import LayerState
 from app.services.sync_orchestrator.registry import JOB_TO_LAYERS, LAYERS
 from app.services.sync_orchestrator.types import (
     ExecutionPlan,
@@ -26,7 +28,7 @@ def build_execution_plan(
     scope: SyncScope,
 ) -> ExecutionPlan:
     """Build the plan for a sync run per spec §2.6."""
-    candidate_jobs = _scope_to_candidate_jobs(scope)
+    candidate_jobs = _scope_to_candidate_jobs(scope, conn=conn)
     target_job = scope.detail if scope.kind == "job" else None
 
     layers_to_refresh: list[LayerPlan] = []
@@ -65,7 +67,10 @@ def build_execution_plan(
 # ---------------------------------------------------------------------------
 
 
-def _scope_to_candidate_jobs(scope: SyncScope) -> list[str]:
+def _scope_to_candidate_jobs(
+    scope: SyncScope,
+    conn: psycopg.Connection[Any] | None = None,
+) -> list[str]:
     """Return the ordered list of legacy job names to consider for the
     given scope. Returns all in-DAG jobs (empty-tuple outside-DAG entries
     excluded). Per-scope filtering:
@@ -75,6 +80,8 @@ def _scope_to_candidate_jobs(scope: SyncScope) -> list[str]:
     - layer(name): only jobs whose emits include the named layer + jobs
       emitting any of its transitive dependencies
     - job(legacy_name): that job + jobs emitting any of its deps
+    - behind: DEGRADED + ACTION_NEEDED layers plus transitive non-HEALTHY
+      upstreams; requires a live conn
     """
     in_dag = [name for name, emits in JOB_TO_LAYERS.items() if emits]
 
@@ -102,6 +109,21 @@ def _scope_to_candidate_jobs(scope: SyncScope) -> list[str]:
         needed_layers = _transitive_layer_closure(target_emits)
         return [job for job in in_dag if any(e in needed_layers for e in JOB_TO_LAYERS[job])]
 
+    if scope.kind == "behind":
+        if conn is None:
+            raise ValueError("scope='behind' requires a live connection")
+        states = compute_layer_states_from_db(conn)
+        target_layers = {
+            n for n, s in states.items()
+            if s in {LayerState.DEGRADED, LayerState.ACTION_NEEDED}
+        }
+        if not target_layers:
+            return []
+        # Include any non-HEALTHY upstreams transitively, so a waiting
+        # layer's prerequisites get refreshed first.
+        target_layers |= _transitive_upstreams_not_healthy(target_layers, states)
+        return [job for job in in_dag if any(e in target_layers for e in JOB_TO_LAYERS[job])]
+
     raise ValueError(f"unknown scope kind: {scope.kind}")
 
 
@@ -115,6 +137,28 @@ def _transitive_layer_closure(seed: set[str]) -> set[str]:
             if dep not in result:
                 result.add(dep)
                 stack.append(dep)
+    return result
+
+
+def _transitive_upstreams_not_healthy(
+    seed: set[str], states: dict[str, LayerState]
+) -> set[str]:
+    """Return all transitive upstream dependencies of seed layers that are
+    not HEALTHY. Used by scope='behind' to include prerequisites that need
+    refreshing before the target layers can be satisfied."""
+    result: set[str] = set()
+    stack = list(seed)
+    while stack:
+        name = stack.pop()
+        if name not in LAYERS:
+            continue
+        for dep in LAYERS[name].dependencies:
+            if dep in result:
+                continue
+            if states.get(dep) is LayerState.HEALTHY:
+                continue
+            result.add(dep)
+            stack.append(dep)
     return result
 
 

--- a/app/services/sync_orchestrator/planner.py
+++ b/app/services/sync_orchestrator/planner.py
@@ -38,8 +38,11 @@ def build_execution_plan(
     # (DEGRADED / ACTION_NEEDED + non-HEALTHY upstreams). Skip the
     # legacy is_fresh re-filter so the state machine's selection is
     # authoritative — a DEGRADED layer must fire even if is_fresh
-    # says otherwise.
-    bypass_freshness_for_all = scope.kind == "behind" and scope.force
+    # says otherwise. Keys on `kind` alone (not compound with
+    # `scope.force`) so this cannot accidentally bypass freshness for
+    # an unrelated `job` scope whose `force=True` target happens to
+    # coincide with a behind candidate.
+    bypass_freshness_for_all = scope.kind == "behind"
 
     for job_name in candidate_jobs:
         emits = JOB_TO_LAYERS[job_name]

--- a/app/services/sync_orchestrator/planner.py
+++ b/app/services/sync_orchestrator/planner.py
@@ -34,13 +34,20 @@ def build_execution_plan(
     layers_to_refresh: list[LayerPlan] = []
     layers_skipped: list[LayerSkip] = []
 
+    # `behind` scope: candidates were already state-selected
+    # (DEGRADED / ACTION_NEEDED + non-HEALTHY upstreams). Skip the
+    # legacy is_fresh re-filter so the state machine's selection is
+    # authoritative — a DEGRADED layer must fire even if is_fresh
+    # says otherwise.
+    bypass_freshness_for_all = scope.kind == "behind" and scope.force
+
     for job_name in candidate_jobs:
         emits = JOB_TO_LAYERS[job_name]
         if not emits:  # outside-DAG job — should not be in candidates
             continue
 
         is_target = job_name == target_job
-        if is_target and scope.force:
+        if (is_target and scope.force) or bypass_freshness_for_all:
             include = True
             reason = f"forced by scope={scope.kind}"
         else:
@@ -150,7 +157,12 @@ def _transitive_upstreams_not_healthy(seed: set[str], states: dict[str, LayerSta
         for dep in LAYERS[name].dependencies:
             if dep in result:
                 continue
-            if states.get(dep) is LayerState.HEALTHY:
+            dep_state = states.get(dep)
+            # Skip HEALTHY (no work needed) and DISABLED (operator
+            # toggle wins — spec §3.2 rule 1). A disabled upstream
+            # leaves the target in CASCADE_WAITING by design; firing
+            # it anyway would bypass the operator's explicit off.
+            if dep_state in {LayerState.HEALTHY, LayerState.DISABLED}:
                 continue
             result.add(dep)
             stack.append(dep)

--- a/app/services/sync_orchestrator/types.py
+++ b/app/services/sync_orchestrator/types.py
@@ -125,7 +125,7 @@ SyncTrigger = Literal["manual", "scheduled", "catch_up"]
 
 @dataclass(frozen=True)
 class SyncScope:
-    kind: Literal["full", "layer", "high_frequency", "job"]
+    kind: Literal["full", "layer", "high_frequency", "job", "behind"]
     detail: str | None = None
     force: bool = False
 
@@ -144,6 +144,10 @@ class SyncScope:
     @classmethod
     def high_frequency(cls) -> SyncScope:
         return cls(kind="high_frequency")
+
+    @classmethod
+    def behind(cls) -> SyncScope:
+        return cls(kind="behind")
 
 
 @dataclass(frozen=True)

--- a/app/services/sync_orchestrator/types.py
+++ b/app/services/sync_orchestrator/types.py
@@ -147,7 +147,11 @@ class SyncScope:
 
     @classmethod
     def behind(cls) -> SyncScope:
-        return cls(kind="behind")
+        # `force=True`: target layers were already state-selected as
+        # DEGRADED / ACTION_NEEDED (and their non-HEALTHY upstreams).
+        # Legacy `is_fresh` re-filtering would drop jobs the state
+        # machine explicitly wants refreshed, so bypass it.
+        return cls(kind="behind", force=True)
 
 
 @dataclass(frozen=True)

--- a/frontend/src/api/sync.ts
+++ b/frontend/src/api/sync.ts
@@ -35,7 +35,7 @@ export type SyncStatus = "running" | "complete" | "partial" | "failed";
 
 export interface SyncRun {
   sync_run_id: number;
-  scope: "full" | "layer" | "high_frequency" | "job";
+  scope: "full" | "layer" | "high_frequency" | "job" | "behind";
   scope_detail: string | null;
   trigger: "manual" | "scheduled" | "catch_up";
   started_at: string;
@@ -71,7 +71,7 @@ export interface SyncStatusResponse {
   } | null;
 }
 
-export type SyncScopeKind = "full" | "layer" | "high_frequency" | "job";
+export type SyncScopeKind = "full" | "layer" | "high_frequency" | "job" | "behind";
 
 export interface SyncTriggerRequest {
   scope: SyncScopeKind;

--- a/frontend/src/lib/useSyncTrigger.test.ts
+++ b/frontend/src/lib/useSyncTrigger.test.ts
@@ -188,4 +188,16 @@ describe("useSyncTrigger", () => {
     });
     expect(mockedTrigger).toHaveBeenCalledTimes(2);
   });
+
+  it("POSTs with scope=behind, not full", async () => {
+    mockedTrigger.mockResolvedValueOnce({
+      sync_run_id: 1,
+      plan: { layers_to_refresh: [], layers_skipped: [] },
+    });
+    const { hook } = setup();
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    expect(mockedTrigger).toHaveBeenCalledWith({ scope: "behind" });
+  });
 });

--- a/frontend/src/lib/useSyncTrigger.ts
+++ b/frontend/src/lib/useSyncTrigger.ts
@@ -65,7 +65,7 @@ export function useSyncTrigger(
     if (inFlightRef.current) return;
     inFlightRef.current = true;
     setState({ kind: "running", queuedRunId: null, message: null });
-    const body: SyncTriggerRequest = { scope: "full" };
+    const body: SyncTriggerRequest = { scope: "behind" };
     try {
       const result = await triggerSync(body);
       setState({

--- a/sql/041_sync_runs_scope_behind.sql
+++ b/sql/041_sync_runs_scope_behind.sql
@@ -1,0 +1,9 @@
+-- 041_sync_runs_scope_behind.sql
+-- Extends sync_runs.scope CHECK to allow 'behind' (scoped resync —
+-- DEGRADED + ACTION_NEEDED layers plus their non-HEALTHY upstreams).
+
+ALTER TABLE sync_runs
+    DROP CONSTRAINT IF EXISTS sync_runs_scope_check;
+ALTER TABLE sync_runs
+    ADD CONSTRAINT sync_runs_scope_check
+    CHECK (scope IN ('full', 'layer', 'high_frequency', 'job', 'behind'));

--- a/sql/041_sync_runs_scope_behind.sql
+++ b/sql/041_sync_runs_scope_behind.sql
@@ -2,8 +2,14 @@
 -- Extends sync_runs.scope CHECK to allow 'behind' (scoped resync —
 -- DEGRADED + ACTION_NEEDED layers plus their non-HEALTHY upstreams).
 
+-- DROP without IF EXISTS so the migration fails loudly if the
+-- constraint name has drifted (e.g. a fresh-schema environment that
+-- auto-named it differently). A silent drop-and-re-add would leave
+-- the stale constraint in place on such a DB and reject 'behind'
+-- inserts post-migration. The constraint name is pinned by
+-- sql/033_sync_orchestrator.sql:15-22 which defines the table.
 ALTER TABLE sync_runs
-    DROP CONSTRAINT IF EXISTS sync_runs_scope_check;
+    DROP CONSTRAINT sync_runs_scope_check;
 ALTER TABLE sync_runs
     ADD CONSTRAINT sync_runs_scope_check
     CHECK (scope IN ('full', 'layer', 'high_frequency', 'job', 'behind'));

--- a/tests/api/test_sync_scope_behind.py
+++ b/tests/api/test_sync_scope_behind.py
@@ -56,3 +56,71 @@ def test_post_sync_behind_includes_non_healthy_upstream(clean_client: TestClient
     assert resp.status_code == 202, body
     planned = [lp["name"] for lp in body["plan"]["layers_to_refresh"]]
     assert "daily_thesis_refresh" in planned
+
+
+def test_post_sync_empty_body_defaults_to_behind(clean_client: TestClient) -> None:
+    # Regression guard: posting {} (or omitting body) uses scope=behind,
+    # not scope=full. Matches the frontend default in useSyncTrigger.
+    from app.services.sync_orchestrator import SyncScope as _Scope
+
+    with patch("app.api.sync.submit_sync") as submit:
+        submit.return_value = (43, _make_empty_plan())
+        resp = clean_client.post("/sync", json={})
+    assert resp.status_code == 202, resp.text
+    scope_arg: _Scope = submit.call_args.args[0]
+    assert scope_arg.kind == "behind"
+
+
+def test_post_sync_behind_skips_disabled_upstream(clean_client: TestClient) -> None:
+    # A DEGRADED layer whose upstream is DISABLED must NOT pull the
+    # disabled upstream into the plan — operator toggle wins over
+    # cascade refresh.
+    from app.services.sync_orchestrator.layer_types import LayerState
+    from app.services.sync_orchestrator.registry import LAYERS
+
+    states = {n: LayerState.HEALTHY for n in LAYERS}
+    # cik_mapping is an upstream of financial_facts.
+    states["financial_facts"] = LayerState.DEGRADED
+    states["cik_mapping"] = LayerState.DISABLED
+
+    with patch(
+        "app.services.sync_orchestrator.planner.compute_layer_states_from_db",
+        return_value=states,
+    ):
+        resp = clean_client.post("/sync", json={"scope": "behind"})
+    body = resp.json()
+    assert resp.status_code == 202, body
+    planned = [lp["name"] for lp in body["plan"]["layers_to_refresh"]]
+    assert "daily_cik_refresh" not in planned, body
+    assert "daily_financial_facts" in planned, body
+
+
+def test_post_sync_behind_bypasses_legacy_freshness_filter(clean_client: TestClient) -> None:
+    # Spec invariant: when the state machine says a layer is
+    # ACTION_NEEDED or DEGRADED, scope=behind must plan it even if
+    # the legacy is_fresh predicate returns True. The state machine
+    # is authoritative under scope=behind.
+    from app.services.sync_orchestrator.layer_types import LayerState
+    from app.services.sync_orchestrator.registry import LAYERS
+
+    states = {n: LayerState.HEALTHY for n in LAYERS}
+    states["thesis"] = LayerState.ACTION_NEEDED
+
+    # Patch is_fresh to always return True — if the freshness filter
+    # leaked through, the plan would be empty. force=True on the
+    # SyncScope.behind() classmethod should bypass the filter.
+    with (
+        patch(
+            "app.services.sync_orchestrator.planner.compute_layer_states_from_db",
+            return_value=states,
+        ),
+        patch(
+            "app.services.sync_orchestrator.planner._all_emits_fresh",
+            return_value=(True, "faked fresh"),
+        ),
+    ):
+        resp = clean_client.post("/sync", json={"scope": "behind"})
+    body = resp.json()
+    assert resp.status_code == 202, body
+    planned = [lp["name"] for lp in body["plan"]["layers_to_refresh"]]
+    assert "daily_thesis_refresh" in planned, body

--- a/tests/api/test_sync_scope_behind.py
+++ b/tests/api/test_sync_scope_behind.py
@@ -1,0 +1,58 @@
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+def _make_empty_plan():
+    from app.services.sync_orchestrator.types import ExecutionPlan
+
+    return ExecutionPlan(layers_to_refresh=(), layers_skipped=(), estimated_duration=None)
+
+
+def test_post_sync_behind_accepted(clean_client: TestClient) -> None:
+    # Happy path: behind scope accepted, 202 returned. submit_sync gets
+    # called with a SyncScope(kind='behind').
+    from app.services.sync_orchestrator import SyncScope as _Scope
+
+    with patch("app.api.sync.submit_sync") as submit:
+        submit.return_value = (42, _make_empty_plan())
+        resp = clean_client.post("/sync", json={"scope": "behind"})
+    assert resp.status_code == 202, resp.text
+    scope_arg: _Scope = submit.call_args.args[0]
+    assert scope_arg.kind == "behind"
+
+
+def test_post_sync_behind_with_all_healthy_returns_empty_plan(clean_client: TestClient) -> None:
+    # scope=behind when every layer is HEALTHY → empty layers_to_refresh.
+    from app.services.sync_orchestrator.layer_types import LayerState
+    from app.services.sync_orchestrator.registry import LAYERS
+
+    all_healthy = {n: LayerState.HEALTHY for n in LAYERS}
+    with patch(
+        "app.services.sync_orchestrator.planner.compute_layer_states_from_db",
+        return_value=all_healthy,
+    ):
+        resp = clean_client.post("/sync", json={"scope": "behind"})
+    assert resp.status_code == 202, resp.text
+    assert resp.json()["plan"]["layers_to_refresh"] == []
+
+
+def test_post_sync_behind_includes_non_healthy_upstream(clean_client: TestClient) -> None:
+    # thesis is ACTION_NEEDED, all its upstreams (fundamentals,
+    # financial_normalization, news) are healthy so only thesis fires.
+    # Verify the candidate job set contains daily_thesis_refresh.
+    from app.services.sync_orchestrator.layer_types import LayerState
+    from app.services.sync_orchestrator.registry import LAYERS
+
+    states = {n: LayerState.HEALTHY for n in LAYERS}
+    states["thesis"] = LayerState.ACTION_NEEDED
+    # Keep thesis's upstreams healthy so only thesis itself fires.
+    with patch(
+        "app.services.sync_orchestrator.planner.compute_layer_states_from_db",
+        return_value=states,
+    ):
+        resp = clean_client.post("/sync", json={"scope": "behind"})
+    body = resp.json()
+    assert resp.status_code == 202, body
+    planned = [lp["name"] for lp in body["plan"]["layers_to_refresh"]]
+    assert "daily_thesis_refresh" in planned

--- a/tests/services/sync_orchestrator/test_cascade.py
+++ b/tests/services/sync_orchestrator/test_cascade.py
@@ -75,4 +75,13 @@ def test_returns_frozen_problem_group() -> None:
     groups = collapse_cascades({"a": ()}, states)
     assert isinstance(groups[0], ProblemGroup)
     assert groups[0].root == "a"
-    assert groups[0].affected == []
+    assert groups[0].affected == ()
+
+
+def test_affected_is_immutable_tuple() -> None:
+    # Regression guard: the frozen-dataclass contract relies on
+    # `affected` being an immutable sequence, so callers who share
+    # the returned reference cannot corrupt other consumers.
+    states = {"a": LayerState.ACTION_NEEDED}
+    groups = collapse_cascades({"a": ()}, states)
+    assert isinstance(groups[0].affected, tuple)

--- a/tests/services/sync_orchestrator/test_cascade.py
+++ b/tests/services/sync_orchestrator/test_cascade.py
@@ -24,9 +24,15 @@ def test_single_root_collapses_transitive_downstream() -> None:
     assert len(groups) == 1
     assert groups[0].root == "universe"
     assert set(groups[0].affected) == {
-        "cik_mapping", "candles", "financial_facts",
-        "financial_normalization", "fundamentals", "news",
-        "thesis", "scoring", "recommendations",
+        "cik_mapping",
+        "candles",
+        "financial_facts",
+        "financial_normalization",
+        "fundamentals",
+        "news",
+        "thesis",
+        "scoring",
+        "recommendations",
     }
 
 

--- a/tests/services/sync_orchestrator/test_cascade.py
+++ b/tests/services/sync_orchestrator/test_cascade.py
@@ -1,0 +1,72 @@
+from app.services.sync_orchestrator.cascade import ProblemGroup, collapse_cascades
+from app.services.sync_orchestrator.layer_types import LayerState
+
+
+def _graph() -> dict[str, tuple[str, ...]]:
+    return {
+        "universe": (),
+        "cik_mapping": ("universe",),
+        "candles": ("universe",),
+        "financial_facts": ("cik_mapping",),
+        "financial_normalization": ("financial_facts",),
+        "fundamentals": ("universe",),
+        "news": ("universe",),
+        "thesis": ("fundamentals", "financial_normalization", "news"),
+        "scoring": ("thesis", "candles"),
+        "recommendations": ("scoring",),
+    }
+
+
+def test_single_root_collapses_transitive_downstream() -> None:
+    states = {name: LayerState.CASCADE_WAITING for name in _graph()}
+    states["universe"] = LayerState.ACTION_NEEDED
+    groups = collapse_cascades(_graph(), states)
+    assert len(groups) == 1
+    assert groups[0].root == "universe"
+    assert set(groups[0].affected) == {
+        "cik_mapping", "candles", "financial_facts",
+        "financial_normalization", "fundamentals", "news",
+        "thesis", "scoring", "recommendations",
+    }
+
+
+def test_multiple_roots_produce_multiple_groups() -> None:
+    states = {name: LayerState.HEALTHY for name in _graph()}
+    states["cik_mapping"] = LayerState.ACTION_NEEDED
+    states["news"] = LayerState.SECRET_MISSING
+    for name in ("financial_facts", "financial_normalization", "thesis", "scoring", "recommendations"):
+        states[name] = LayerState.CASCADE_WAITING
+    groups = collapse_cascades(_graph(), states)
+    assert {g.root for g in groups} == {"cik_mapping", "news"}
+
+
+def test_healthy_descendant_not_in_affected() -> None:
+    states = {name: LayerState.HEALTHY for name in _graph()}
+    states["cik_mapping"] = LayerState.ACTION_NEEDED
+    groups = collapse_cascades(_graph(), states)
+    assert "financial_facts" not in groups[0].affected
+
+
+def test_degraded_root_produces_no_group() -> None:
+    states = {name: LayerState.HEALTHY for name in _graph()}
+    states["cik_mapping"] = LayerState.DEGRADED
+    assert collapse_cascades(_graph(), states) == []
+
+
+def test_retrying_root_produces_no_group() -> None:
+    # RETRYING is self-healing; not a terminal cascade root.
+    states = {name: LayerState.HEALTHY for name in _graph()}
+    states["cik_mapping"] = LayerState.RETRYING
+    assert collapse_cascades(_graph(), states) == []
+
+
+def test_empty_dependency_map() -> None:
+    assert collapse_cascades({}, {}) == []
+
+
+def test_returns_frozen_problem_group() -> None:
+    states = {"a": LayerState.ACTION_NEEDED}
+    groups = collapse_cascades({"a": ()}, states)
+    assert isinstance(groups[0], ProblemGroup)
+    assert groups[0].root == "a"
+    assert groups[0].affected == []


### PR DESCRIPTION
## What

Chunk 6 of sub-project **A** (freshness unification, #328):

1. **`app/services/sync_orchestrator/cascade.py`** — pure \`collapse_cascades(dependencies, states) -> list[ProblemGroup]\` replaces the inline \`_downstream\` shim in the v2 endpoint. 7 unit tests.
2. **`sql/041_sync_runs_scope_behind.sql`** — extends \`sync_runs.scope\` CHECK to accept \`'behind'\`.
3. **`SyncScope.behind()`** classmethod (`force=True` so state-selected candidates bypass legacy \`is_fresh\` re-filter).
4. **`SyncRequest.scope` default flipped from `full` to `behind`**. Matches the new Admin UI default; full sync stays reachable via explicit \`"scope": "full"\`.
5. **Planner \`behind\` branch** — targets \`DEGRADED | ACTION_NEEDED\` layers from \`compute_layer_states_from_db\` plus transitive non-HEALTHY upstreams (excluding DISABLED). Maps back to legacy jobs.
6. **Frontend** — \`SyncScopeKind\` Literal extended with \`"behind"\`; \`useSyncTrigger.trigger()\` now sends \`{scope: "behind"}\`. New vitest.

## Review loops

**Codex pre-push (all three resolved in \`4be579d\`):**
- P2 default mismatch → backend default now \`"behind"\`.
- P2 DISABLED upstream pulled into plan → excluded alongside HEALTHY.
- P3 state-selected layers still freshness-filtered → \`SyncScope.behind()\` sets \`force=True\`; planner bypasses \`_all_emits_fresh\` for every candidate under \`behind\`.

Three regression tests added covering each fix.

## Test plan

- [x] \`uv run pytest tests/services/sync_orchestrator/test_cascade.py tests/api/test_sync_scope_behind.py\` — 13 passed
- [x] \`uv run pytest -x -q\` — 2111 passed, 1 skipped
- [x] \`uv run ruff check .\` + \`ruff format --check .\` — clean
- [x] \`uv run pyright\` — 0 errors
- [x] \`pnpm --dir frontend test useSyncTrigger\` — new test + 10 existing pass
- [x] \`pnpm --dir frontend typecheck\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)