### PR TITLE
feat(#342): chunk 0 — v2 canonical layers[] list

### DIFF
--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -109,6 +109,23 @@ class CascadeGroupModel(BaseModel):
     affected: list[str]
 
 
+class LayerEntry(BaseModel):
+    layer: str
+    display_name: str
+    state: Literal[
+        "healthy",
+        "running",
+        "retrying",
+        "degraded",
+        "action_needed",
+        "secret_missing",
+        "cascade_waiting",
+        "disabled",
+    ]
+    last_updated: datetime | None
+    plain_language_sla: str
+
+
 class SyncLayersV2Response(BaseModel):
     generated_at: datetime
     system_state: Literal["ok", "catching_up", "needs_attention"]
@@ -119,6 +136,7 @@ class SyncLayersV2Response(BaseModel):
     healthy: list[LayerSummary]
     disabled: list[LayerSummary]
     cascade_groups: list[CascadeGroupModel]
+    layers: list[LayerEntry]
 
 
 def _scope_from(body: SyncRequest) -> SyncScope:
@@ -412,6 +430,17 @@ def get_sync_layers_v2(
     retrying_count = sum(1 for s in states.values() if s is LayerState.RETRYING)
     cascade_waiting_count = sum(1 for s in states.values() if s is LayerState.CASCADE_WAITING)
 
+    layers_entries = [
+        LayerEntry(
+            layer=name,
+            display_name=LAYERS[name].display_name,
+            state=states[name].value,
+            last_updated=last_updates.get(name),
+            plain_language_sla=LAYERS[name].plain_language_sla,
+        )
+        for name in sorted(states.keys())
+    ]
+
     return SyncLayersV2Response(
         generated_at=datetime.now(UTC),
         system_state=system_state,
@@ -429,6 +458,7 @@ def get_sync_layers_v2(
         healthy=healthy,
         disabled=disabled,
         cascade_groups=cascade_groups,
+        layers=layers_entries,
     )
 
 

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -110,18 +110,17 @@ class CascadeGroupModel(BaseModel):
 
 
 class LayerEntry(BaseModel):
+    """Per-layer UI row. Canonical source for LayerHealthList in chunk 1.
+
+    `state` is typed against the `LayerState` enum directly so future
+    additions (e.g. new states) propagate to this contract at type-check
+    time — no silent drift between the enum's source of truth and a
+    hand-copied Literal.
+    """
+
     layer: str
     display_name: str
-    state: Literal[
-        "healthy",
-        "running",
-        "retrying",
-        "degraded",
-        "action_needed",
-        "secret_missing",
-        "cascade_waiting",
-        "disabled",
-    ]
+    state: LayerState
     last_updated: datetime | None
     plain_language_sla: str
 
@@ -434,7 +433,7 @@ def get_sync_layers_v2(
         LayerEntry(
             layer=name,
             display_name=LAYERS[name].display_name,
-            state=states[name].value,
+            state=states[name],
             last_updated=last_updates.get(name),
             plain_language_sla=LAYERS[name].plain_language_sla,
         )

--- a/tests/api/test_sync_layers_v2_schema.py
+++ b/tests/api/test_sync_layers_v2_schema.py
@@ -15,6 +15,7 @@ def test_v2_endpoint_returns_expected_top_level_keys(clean_client: TestClient) -
         "healthy",
         "disabled",
         "cascade_groups",
+        "layers",
     }
 
 
@@ -142,6 +143,61 @@ def test_v2_summary_never_contradicts_state(clean_client: TestClient) -> None:
         assert "All layers healthy" not in summary, body
     if state == "ok":
         assert summary == "All layers healthy", body
+
+
+def test_v2_includes_canonical_layers_field(clean_client: TestClient) -> None:
+    resp = clean_client.get("/sync/layers/v2")
+    body = resp.json()
+    assert "layers" in body
+    assert isinstance(body["layers"], list)
+
+
+def test_v2_layers_contains_every_registered_layer_once(clean_client: TestClient) -> None:
+    from app.services.sync_orchestrator.registry import LAYERS
+
+    resp = clean_client.get("/sync/layers/v2")
+    body = resp.json()
+    returned = [entry["layer"] for entry in body["layers"]]
+    assert sorted(returned) == sorted(LAYERS.keys())
+    assert len(returned) == len(set(returned)), "duplicate layer in v2.layers"
+
+
+def test_v2_layer_entry_shape(clean_client: TestClient) -> None:
+    resp = clean_client.get("/sync/layers/v2")
+    for entry in resp.json()["layers"]:
+        assert set(entry.keys()) == {
+            "layer",
+            "display_name",
+            "state",
+            "last_updated",
+            "plain_language_sla",
+        }
+        assert entry["state"] in {
+            "healthy",
+            "running",
+            "retrying",
+            "degraded",
+            "action_needed",
+            "secret_missing",
+            "cascade_waiting",
+            "disabled",
+        }
+
+
+def test_v2_layer_entry_metadata_matches_registry(clean_client: TestClient) -> None:
+    from app.services.sync_orchestrator.registry import LAYERS
+
+    resp = clean_client.get("/sync/layers/v2")
+    for entry in resp.json()["layers"]:
+        layer = LAYERS[entry["layer"]]
+        assert entry["display_name"] == layer.display_name
+        assert entry["plain_language_sla"] == layer.plain_language_sla
+
+
+def test_v2_layers_sorted_by_name(clean_client: TestClient) -> None:
+    resp = clean_client.get("/sync/layers/v2")
+    names = [entry["layer"] for entry in resp.json()["layers"]]
+    assert names == sorted(names), "v2.layers must be sorted by layer name for determinism"
 
 
 def test_v2_requires_auth() -> None:

--- a/tests/api/test_sync_layers_v2_schema.py
+++ b/tests/api/test_sync_layers_v2_schema.py
@@ -172,16 +172,9 @@ def test_v2_layer_entry_shape(clean_client: TestClient) -> None:
             "last_updated",
             "plain_language_sla",
         }
-        assert entry["state"] in {
-            "healthy",
-            "running",
-            "retrying",
-            "degraded",
-            "action_needed",
-            "secret_missing",
-            "cascade_waiting",
-            "disabled",
-        }
+        from app.services.sync_orchestrator.layer_types import LayerState
+
+        assert entry["state"] in {s.value for s in LayerState}
 
 
 def test_v2_layer_entry_metadata_matches_registry(clean_client: TestClient) -> None:


### PR DESCRIPTION
## What

Adds \`LayerEntry\` Pydantic model and \`layers: list[LayerEntry]\` field to \`/sync/layers/v2\` response. Additive. Backend-only. Unblocks A.5 chunk 1 (Admin UI swap).

## How

\`get_sync_layers_v2\` now populates \`layers\` from the \`states\` map it already computes + \`LAYERS\` registry + existing \`last_updates\` map. Zero additional DB round-trips. Output sorted by layer name for deterministic client rendering.

Each \`LayerEntry\`: \`layer\`, \`display_name\`, \`state\` (Literal of 8 LayerState values), \`last_updated: datetime | None\`, \`plain_language_sla\`.

## Test plan

- [x] \`uv run pytest tests/api/test_sync_layers_v2_schema.py\` — 13 passed (8 existing + 5 new)
  - \`test_v2_includes_canonical_layers_field\`
  - \`test_v2_layers_contains_every_registered_layer_once\`
  - \`test_v2_layer_entry_shape\`
  - \`test_v2_layer_entry_metadata_matches_registry\`
  - \`test_v2_layers_sorted_by_name\`
- [x] \`test_v2_endpoint_returns_expected_top_level_keys\` updated to include \`"layers"\` in the keyset
- [x] \`uv run pytest -x -q\` — 2128 passed, 1 skipped
- [x] \`uv run ruff check .\` + \`format --check .\` — clean
- [x] \`uv run pyright\` — 0 errors

Reviews: spec-compliance ✅, code-quality ✅ (minor observations filed as follow-up tech-debt, not blocking).

## Spec

[\`docs/superpowers/specs/2026-04-19-admin-v2-visible-and-controllable-design.md\`](https://github.com/Luke-Bradford/eBull/blob/feature/342-admin-v2-spec/docs/superpowers/specs/2026-04-19-admin-v2-visible-and-controllable-design.md) §5.4 — canonical \`layers\` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)