### PR TITLE
feat(#342): chunk 1 — Admin v2 UI swap + LayerHealthList

### DIFF
--- a/frontend/src/api/sync.ts
+++ b/frontend/src/api/sync.ts
@@ -10,6 +10,7 @@
  */
 
 import { apiFetch } from "@/api/client";
+import type { SyncLayersV2Response } from "@/api/types";
 
 export type LayerTier = 0 | 1 | 2 | 3;
 
@@ -121,4 +122,8 @@ export function triggerSync(
     method: "POST",
     body: JSON.stringify(body),
   });
+}
+
+export function fetchSyncLayersV2(): Promise<SyncLayersV2Response> {
+  return apiFetch<SyncLayersV2Response>("/sync/layers/v2");
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -685,3 +685,75 @@ export interface InsufficientListResponse {
   checked_at: string;
   rows: InsufficientRow[];
 }
+
+// ---------------------------------------------------------------------------
+// /sync/layers/v2 (app/api/sync.py — A.5 chunk 0+)
+// ---------------------------------------------------------------------------
+
+export type LayerStateStr =
+  | "healthy"
+  | "running"
+  | "retrying"
+  | "degraded"
+  | "action_needed"
+  | "secret_missing"
+  | "cascade_waiting"
+  | "disabled";
+
+export interface LayerEntry {
+  layer: string;
+  display_name: string;
+  state: LayerStateStr;
+  last_updated: string | null;
+  plain_language_sla: string;
+}
+
+export interface ActionNeededItem {
+  root_layer: string;
+  display_name: string;
+  category:
+    | "auth_expired"
+    | "rate_limited"
+    | "source_down"
+    | "schema_drift"
+    | "db_constraint"
+    | "data_gap"
+    | "upstream_waiting"
+    | "internal_error";
+  operator_message: string;
+  operator_fix: string | null;
+  self_heal: boolean;
+  consecutive_failures: number;
+  affected_downstream: string[];
+}
+
+export interface SecretMissingItem {
+  layer: string;
+  display_name: string;
+  missing_secret: string;
+  operator_fix: string;
+}
+
+export interface LayerSummaryV2 {
+  layer: string;
+  display_name: string;
+  last_updated: string | null;
+}
+
+export interface CascadeGroup {
+  root: string;
+  affected: string[];
+}
+
+export interface SyncLayersV2Response {
+  generated_at: string;
+  system_state: "ok" | "catching_up" | "needs_attention";
+  system_summary: string;
+  action_needed: ActionNeededItem[];
+  degraded: LayerSummaryV2[];
+  secret_missing: SecretMissingItem[];
+  healthy: LayerSummaryV2[];
+  disabled: LayerSummaryV2[];
+  cascade_groups: CascadeGroup[];
+  layers: LayerEntry[];
+}

--- a/frontend/src/components/admin/LayerHealthList.test.tsx
+++ b/frontend/src/components/admin/LayerHealthList.test.tsx
@@ -66,10 +66,31 @@ describe("LayerHealthList", () => {
   });
 
   it("renders relative last_updated when present", () => {
-    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
-    const layers: LayerEntry[] = [mk({ layer: "universe", last_updated: oneHourAgo })];
-    render(<LayerHealthList layers={layers} onToggle={() => {}} />);
-    expect(screen.getByText(/1h ago/i)).toBeInTheDocument();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-19T12:00:00Z"));
+    try {
+      const layers: LayerEntry[] = [
+        mk({ layer: "universe", last_updated: "2026-04-19T11:00:00Z" }),
+      ];
+      render(<LayerHealthList layers={layers} onToggle={() => {}} />);
+      expect(screen.getByText(/1h ago/i)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("renders 'just now' when last_updated is less than a minute ago", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-19T12:00:00Z"));
+    try {
+      const layers: LayerEntry[] = [
+        mk({ layer: "universe", last_updated: "2026-04-19T11:59:45Z" }),
+      ];
+      render(<LayerHealthList layers={layers} onToggle={() => {}} />);
+      expect(screen.getByText(/just now/i)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("renders 'never' when last_updated is null", () => {
@@ -108,5 +129,45 @@ describe("LayerHealthList", () => {
     fireEvent.click(screen.getByLabelText("candles actions"));
     fireEvent.click(screen.getByText(/Enable layer/));
     expect(onToggle).toHaveBeenCalledWith("candles", true);
+  });
+
+  it("closes the open menu when clicking outside", () => {
+    const onToggle = vi.fn();
+    const layers: LayerEntry[] = [mk({ layer: "candles", state: "healthy" })];
+    render(
+      <div>
+        <LayerHealthList layers={layers} onToggle={onToggle} />
+        <div data-testid="outside">outside content</div>
+      </div>
+    );
+    fireEvent.click(screen.getByLabelText("candles actions"));
+    expect(screen.getByText(/Disable layer/)).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    expect(screen.queryByText(/Disable layer/)).toBeNull();
+  });
+
+  it("closes the open menu on Escape key", () => {
+    const onToggle = vi.fn();
+    const layers: LayerEntry[] = [mk({ layer: "candles", state: "healthy" })];
+    render(<LayerHealthList layers={layers} onToggle={onToggle} />);
+    fireEvent.click(screen.getByLabelText("candles actions"));
+    expect(screen.getByText(/Disable layer/)).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByText(/Disable layer/)).toBeNull();
+  });
+
+  it("opening a second row's menu closes the first", () => {
+    const onToggle = vi.fn();
+    const layers: LayerEntry[] = [
+      mk({ layer: "candles", state: "healthy" }),
+      mk({ layer: "universe", state: "healthy" }),
+    ];
+    render(<LayerHealthList layers={layers} onToggle={onToggle} />);
+    fireEvent.click(screen.getByLabelText("candles actions"));
+    // Both "Disable layer" buttons render the same text, so count menu items.
+    expect(screen.getAllByText(/Disable layer/)).toHaveLength(1);
+    fireEvent.click(screen.getByLabelText("universe actions"));
+    // First menu is closed; second is open; total remains exactly 1 dropdown.
+    expect(screen.getAllByText(/Disable layer/)).toHaveLength(1);
   });
 });

--- a/frontend/src/components/admin/LayerHealthList.test.tsx
+++ b/frontend/src/components/admin/LayerHealthList.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { LayerEntry } from "@/api/types";
+
+import { LayerHealthList } from "./LayerHealthList";
+
+
+function mk(overrides: Partial<LayerEntry>): LayerEntry {
+  return {
+    layer: overrides.layer ?? "universe",
+    display_name: overrides.display_name ?? "Tradable Universe",
+    state: overrides.state ?? "healthy",
+    last_updated: overrides.last_updated ?? null,
+    plain_language_sla: overrides.plain_language_sla ?? "Refreshed weekly.",
+  };
+}
+
+
+describe("LayerHealthList", () => {
+  it("renders one row per layer", () => {
+    const layers: LayerEntry[] = [
+      mk({ layer: "universe", display_name: "Tradable Universe" }),
+      mk({ layer: "candles", display_name: "Daily Price Candles" }),
+    ];
+    render(<LayerHealthList layers={layers} onToggle={() => {}} />);
+    expect(screen.getByText("Tradable Universe")).toBeInTheDocument();
+    expect(screen.getByText("Daily Price Candles")).toBeInTheDocument();
+  });
+
+  it("renders healthy pill as Healthy", () => {
+    const layers: LayerEntry[] = [mk({ layer: "universe", state: "healthy" })];
+    render(<LayerHealthList layers={layers} onToggle={() => {}} />);
+    expect(screen.getByLabelText("universe state")).toHaveTextContent(/healthy/i);
+  });
+
+  it("renders disabled pill as Disabled", () => {
+    const layers: LayerEntry[] = [mk({ layer: "candles", state: "disabled" })];
+    render(<LayerHealthList layers={layers} onToggle={() => {}} />);
+    expect(screen.getByLabelText("candles state")).toHaveTextContent(/disabled/i);
+  });
+
+  it("renders action_needed pill as Needs attention", () => {
+    const layers: LayerEntry[] = [mk({ layer: "cik_mapping", state: "action_needed" })];
+    render(<LayerHealthList layers={layers} onToggle={() => {}} />);
+    expect(screen.getByLabelText("cik_mapping state")).toHaveTextContent(/needs attention/i);
+  });
+
+  it("renders secret_missing pill as Needs attention", () => {
+    const layers: LayerEntry[] = [mk({ layer: "news", state: "secret_missing" })];
+    render(<LayerHealthList layers={layers} onToggle={() => {}} />);
+    expect(screen.getByLabelText("news state")).toHaveTextContent(/needs attention/i);
+  });
+
+  it("renders running / retrying / cascade_waiting / degraded as Catching up", () => {
+    const layers: LayerEntry[] = [
+      mk({ layer: "r1", state: "running" }),
+      mk({ layer: "r2", state: "retrying" }),
+      mk({ layer: "r3", state: "cascade_waiting" }),
+      mk({ layer: "r4", state: "degraded" }),
+    ];
+    render(<LayerHealthList layers={layers} onToggle={() => {}} />);
+    for (const name of ["r1", "r2", "r3", "r4"]) {
+      expect(screen.getByLabelText(`${name} state`)).toHaveTextContent(/catching up/i);
+    }
+  });
+
+  it("renders relative last_updated when present", () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const layers: LayerEntry[] = [mk({ layer: "universe", last_updated: oneHourAgo })];
+    render(<LayerHealthList layers={layers} onToggle={() => {}} />);
+    expect(screen.getByText(/1h ago/i)).toBeInTheDocument();
+  });
+
+  it("renders 'never' when last_updated is null", () => {
+    const layers: LayerEntry[] = [mk({ layer: "universe", last_updated: null })];
+    render(<LayerHealthList layers={layers} onToggle={() => {}} />);
+    expect(screen.getByText(/never/i)).toBeInTheDocument();
+  });
+
+  it("renders SLA below the row", () => {
+    const layers: LayerEntry[] = [mk({ layer: "candles", plain_language_sla: "Refreshed after market close." })];
+    render(<LayerHealthList layers={layers} onToggle={() => {}} />);
+    expect(screen.getByText(/refreshed after market close/i)).toBeInTheDocument();
+  });
+
+  it("mounts each row with id=admin-layer-<name> for deep-linking", () => {
+    const layers: LayerEntry[] = [
+      mk({ layer: "cik_mapping", display_name: "SEC CIK Mapping" }),
+    ];
+    const { container } = render(<LayerHealthList layers={layers} onToggle={() => {}} />);
+    expect(container.querySelector("#admin-layer-cik_mapping")).not.toBeNull();
+  });
+
+  it("toggle button fires onToggle with opposite enabled state", () => {
+    const onToggle = vi.fn();
+    const layers: LayerEntry[] = [mk({ layer: "candles", state: "healthy" })];
+    render(<LayerHealthList layers={layers} onToggle={onToggle} />);
+    fireEvent.click(screen.getByLabelText("candles actions"));
+    fireEvent.click(screen.getByText(/Disable layer/));
+    expect(onToggle).toHaveBeenCalledWith("candles", false);
+  });
+
+  it("re-enables a disabled layer via the menu", () => {
+    const onToggle = vi.fn();
+    const layers: LayerEntry[] = [mk({ layer: "candles", state: "disabled" })];
+    render(<LayerHealthList layers={layers} onToggle={onToggle} />);
+    fireEvent.click(screen.getByLabelText("candles actions"));
+    fireEvent.click(screen.getByText(/Enable layer/));
+    expect(onToggle).toHaveBeenCalledWith("candles", true);
+  });
+});

--- a/frontend/src/components/admin/LayerHealthList.tsx
+++ b/frontend/src/components/admin/LayerHealthList.tsx
@@ -7,7 +7,7 @@
  * whose Enable / Disable item emits `onToggle(name, enabled)` for the
  * parent to wire to the backend endpoint (chunk 2).
  */
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { LayerEntry, LayerStateStr } from "@/api/types";
 
@@ -60,9 +60,29 @@ function relativeAgo(iso: string | null): string {
 
 export function LayerHealthList({ layers, onToggle }: LayerHealthListProps): JSX.Element {
   const [menuOpen, setMenuOpen] = useState<string | null>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    if (menuOpen === null) return;
+    const handleDown = (ev: MouseEvent) => {
+      const target = ev.target as Node | null;
+      if (listRef.current !== null && target !== null && !listRef.current.contains(target)) {
+        setMenuOpen(null);
+      }
+    };
+    const handleKey = (ev: KeyboardEvent) => {
+      if (ev.key === "Escape") setMenuOpen(null);
+    };
+    document.addEventListener("mousedown", handleDown);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleDown);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [menuOpen]);
 
   return (
-    <ul className="divide-y divide-slate-100">
+    <ul ref={listRef} className="divide-y divide-slate-100">
       {layers.map((entry) => {
         const pill = pillFor(entry.state);
         const isDisabled = entry.state === "disabled";

--- a/frontend/src/components/admin/LayerHealthList.tsx
+++ b/frontend/src/components/admin/LayerHealthList.tsx
@@ -1,0 +1,117 @@
+/**
+ * Per-layer health list for the Admin page orchestrator details.
+ *
+ * Reads `v2.layers` (canonical per-layer list added in A.5 chunk 0).
+ * Shows state pill (Healthy / Catching up / Needs attention / Disabled),
+ * relative last_updated timestamp, plain-language SLA, and a ⋯ menu
+ * whose Enable / Disable item emits `onToggle(name, enabled)` for the
+ * parent to wire to the backend endpoint (chunk 2).
+ */
+import { useState } from "react";
+
+import type { LayerEntry, LayerStateStr } from "@/api/types";
+
+
+export interface LayerHealthListProps {
+  readonly layers: readonly LayerEntry[];
+  readonly onToggle: (layer: string, enabled: boolean) => void;
+}
+
+
+type Pill = "healthy" | "catching_up" | "needs_attention" | "disabled";
+
+
+function pillFor(state: LayerStateStr): Pill {
+  if (state === "healthy") return "healthy";
+  if (state === "disabled") return "disabled";
+  if (state === "action_needed" || state === "secret_missing") return "needs_attention";
+  return "catching_up";
+}
+
+
+const PILL_LABEL: Record<Pill, string> = {
+  healthy: "Healthy",
+  catching_up: "Catching up",
+  needs_attention: "Needs attention",
+  disabled: "Disabled",
+};
+
+
+const PILL_CLASS: Record<Pill, string> = {
+  healthy: "bg-emerald-100 text-emerald-800",
+  catching_up: "bg-amber-100 text-amber-800",
+  needs_attention: "bg-red-100 text-red-800",
+  disabled: "bg-slate-200 text-slate-600",
+};
+
+
+function relativeAgo(iso: string | null): string {
+  if (iso === null) return "never";
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+
+export function LayerHealthList({ layers, onToggle }: LayerHealthListProps): JSX.Element {
+  const [menuOpen, setMenuOpen] = useState<string | null>(null);
+
+  return (
+    <ul className="divide-y divide-slate-100">
+      {layers.map((entry) => {
+        const pill = pillFor(entry.state);
+        const isDisabled = entry.state === "disabled";
+        return (
+          <li
+            key={entry.layer}
+            id={`admin-layer-${entry.layer}`}
+            className={`flex items-start justify-between py-2 ${isDisabled ? "opacity-50" : ""}`}
+          >
+            <div className="flex-1">
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-slate-800">{entry.display_name}</span>
+                <span
+                  aria-label={`${entry.layer} state`}
+                  className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${PILL_CLASS[pill]}`}
+                >
+                  {PILL_LABEL[pill]}
+                </span>
+                <span className="text-xs text-slate-500">Updated {relativeAgo(entry.last_updated)}</span>
+              </div>
+              <div className="mt-1 text-xs text-slate-600">{entry.plain_language_sla}</div>
+            </div>
+            <div className="relative ml-4">
+              <button
+                type="button"
+                aria-label={`${entry.layer} actions`}
+                onClick={() => setMenuOpen(menuOpen === entry.layer ? null : entry.layer)}
+                className="rounded border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50"
+              >
+                ⋯
+              </button>
+              {menuOpen === entry.layer ? (
+                <div className="absolute right-0 top-full z-10 mt-1 w-40 rounded border border-slate-200 bg-white shadow">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onToggle(entry.layer, isDisabled);
+                      setMenuOpen(null);
+                    }}
+                    className="block w-full px-3 py-1 text-left text-xs text-slate-700 hover:bg-slate-50"
+                  >
+                    {isDisabled ? "Enable layer" : "Disable layer"}
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/frontend/src/components/admin/ProblemsPanel.test.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.test.tsx
@@ -392,6 +392,7 @@ describe("ProblemsPanel", () => {
     // job was rendered underneath. Must say "N problem(s) need
     // attention" whenever jobs/coverage contribute.
     const jobs: JobsListResponse = {
+      checked_at: new Date().toISOString(),
       jobs: [
         {
           name: "test_job",

--- a/frontend/src/components/admin/ProblemsPanel.test.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.test.tsx
@@ -1,182 +1,281 @@
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 
-import { ProblemsPanel } from "@/components/admin/ProblemsPanel";
 import type {
   CoverageSummaryResponse,
   JobsListResponse,
+  SyncLayersV2Response,
 } from "@/api/types";
-import type { SyncLayer, SyncLayersResponse } from "@/api/sync";
 
-function coverageClean(): CoverageSummaryResponse {
+import { ProblemsPanel } from "./ProblemsPanel";
+
+
+function emptyV2(): SyncLayersV2Response {
   return {
-    checked_at: "2026-04-19T00:00:00Z",
-    analysable: 100,
+    generated_at: new Date().toISOString(),
+    system_state: "ok",
+    system_summary: "All layers healthy",
+    action_needed: [],
+    degraded: [],
+    secret_missing: [],
+    healthy: [],
+    disabled: [],
+    cascade_groups: [],
+    layers: [],
+  };
+}
+
+
+function emptyJobs(): JobsListResponse {
+  return { checked_at: new Date().toISOString(), jobs: [] };
+}
+
+
+function emptyCoverage(): CoverageSummaryResponse {
+  return {
+    checked_at: new Date().toISOString(),
+    total_tradable: 0,
+    analysable: 0,
     insufficient: 0,
     structurally_young: 0,
     fpi: 0,
     no_primary_sec_cik: 0,
     unknown: 0,
     null_rows: 0,
-    total_tradable: 100,
   };
 }
 
-function layer(overrides: Partial<SyncLayer> = {}): SyncLayer {
-  return {
-    name: "x",
-    display_name: "X",
-    tier: 1,
-    is_fresh: true,
-    freshness_detail: "ok",
-    last_success_at: "2026-04-19T00:00:00Z",
-    last_duration_seconds: 1,
-    last_error_category: null,
-    consecutive_failures: 0,
-    dependencies: [],
-    is_blocking: true,
-    ...overrides,
-  };
-}
 
-function jobs(): JobsListResponse {
-  return { checked_at: "2026-04-19T00:00:00Z", jobs: [] };
-}
-
-function render_(
-  props: Partial<React.ComponentProps<typeof ProblemsPanel>> = {},
-) {
-  const onOpenOrchestrator = vi.fn();
+function renderPanel(
+  props: Partial<React.ComponentProps<typeof ProblemsPanel>>,
+): ReturnType<typeof render> {
   const defaults: React.ComponentProps<typeof ProblemsPanel> = {
-    layers: { layers: [] } as SyncLayersResponse,
-    jobs: jobs(),
-    coverage: coverageClean(),
-    layersError: false,
+    v2: emptyV2(),
+    jobs: emptyJobs(),
+    coverage: emptyCoverage(),
+    v2Error: false,
     jobsError: false,
     coverageError: false,
-    onOpenOrchestrator,
+    onOpenOrchestrator: () => {},
   };
-  const result = render(<ProblemsPanel {...defaults} {...props} />);
-  return { onOpenOrchestrator, ...result };
+  return render(
+    <MemoryRouter>
+      <ProblemsPanel {...defaults} {...props} />
+    </MemoryRouter>,
+  );
 }
 
-describe("ProblemsPanel — rendering contract", () => {
-  it("renders nothing when all sources resolved clean", async () => {
-    const { container } = render_();
-    await waitFor(() => {
-      expect(container.querySelector("section")).toBeNull();
-    });
+
+describe("ProblemsPanel", () => {
+  it("renders nothing when all sources are clean", () => {
+    const { container } = renderPanel({});
+    expect(container).toBeEmptyDOMElement();
   });
 
-  it("shows 'Checking for problems…' when all sources are null", async () => {
-    render_({ layers: null, jobs: null, coverage: null });
-    expect(
-      await screen.findByText(/Checking for problems/i),
-    ).toBeInTheDocument();
-  });
-
-  it("renders resolved-source problems even while other sources are still null", async () => {
-    render_({
-      layers: {
-        layers: [
-          layer({
-            name: "cik_mapping",
-            display_name: "CIK mapping",
-            is_fresh: false,
-            consecutive_failures: 3,
-            last_error_category: "db_constraint",
-          }),
-        ],
+  it("renders a red row per action_needed entry", () => {
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.system_summary = "SEC CIK Mapping needs attention";
+    v2.action_needed = [
+      {
+        root_layer: "cik_mapping",
+        display_name: "SEC CIK Mapping",
+        category: "db_constraint",
+        operator_message: "Database constraint violated",
+        operator_fix: "Open orchestrator details and inspect the offending row",
+        self_heal: false,
+        consecutive_failures: 3,
+        affected_downstream: [],
       },
-      jobs: null, // still pending
-      coverage: null, // still pending
-    });
-    expect(
-      await screen.findByText(/CIK mapping — 3 consecutive failures/),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/Checking 2 more sources/i)).toBeInTheDocument();
+    ];
+    renderPanel({ v2 });
+    // header contains "SEC CIK Mapping needs attention"; row also contains "SEC CIK Mapping"
+    expect(screen.getAllByText(/SEC CIK Mapping/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/Database constraint violated/)).toBeInTheDocument();
+    expect(screen.getByText(/3 consecutive failures/)).toBeInTheDocument();
   });
 
-  it("surfaces stale non-blocking layers as amber rows", async () => {
-    render_({
-      layers: {
-        layers: [
-          layer({
-            name: "news",
-            display_name: "News",
-            is_fresh: false,
-            is_blocking: false,
-          }),
-        ],
+  it("renders secret_missing row with a Link to /settings#providers", () => {
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.secret_missing = [
+      {
+        layer: "news",
+        display_name: "News & Sentiment",
+        missing_secret: "ANTHROPIC_API_KEY",
+        operator_fix: "Set ANTHROPIC_API_KEY in Settings → Providers",
       },
-    });
-    expect(
-      await screen.findByText(/News — stale \(non-blocking\)/),
-    ).toBeInTheDocument();
+    ];
+    renderPanel({ v2 });
+    const link = screen.getByRole("link", { name: /Set ANTHROPIC_API_KEY/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/settings#providers");
   });
 
-  it("surfaces an amber 'could not re-check' line on source refetch error", async () => {
-    // Cached snapshot present → still renders last-good problems +
-    // amber notice.
+  it("renders action_needed operator_fix as Settings link when it mentions Settings", () => {
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.action_needed = [
+      {
+        root_layer: "x",
+        display_name: "Layer X",
+        category: "auth_expired",
+        operator_message: "Credential expired",
+        operator_fix: "Update the API key in Settings → Providers",
+        self_heal: false,
+        consecutive_failures: 1,
+        affected_downstream: [],
+      },
+    ];
+    renderPanel({ v2 });
+    const link = screen.getByRole("link", { name: /Update the API key/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/settings#providers");
+  });
+
+  it("renders plain text for action_needed operator_fix when no Settings mention", () => {
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.action_needed = [
+      {
+        root_layer: "x",
+        display_name: "Layer X",
+        category: "db_constraint",
+        operator_message: "DB error",
+        operator_fix: "Open orchestrator details and inspect the offending row",
+        self_heal: false,
+        consecutive_failures: 1,
+        affected_downstream: [],
+      },
+    ];
+    renderPanel({ v2 });
+    expect(screen.queryByRole("link", { name: /Open orchestrator details and inspect/i })).toBeNull();
+    expect(screen.getByText(/Open orchestrator details and inspect the offending row/)).toBeInTheDocument();
+  });
+
+  it("expands cascade waiters when +N layers is clicked", async () => {
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.action_needed = [
+      {
+        root_layer: "cik_mapping",
+        display_name: "SEC CIK Mapping",
+        category: "db_constraint",
+        operator_message: "DB error",
+        operator_fix: null,
+        self_heal: false,
+        consecutive_failures: 3,
+        affected_downstream: ["financial_facts", "thesis", "scoring"],
+      },
+    ];
+    renderPanel({ v2 });
+    screen.getByText(/\+3 layers waiting/).click();
+    expect(await screen.findByText("financial_facts")).toBeInTheDocument();
+    expect(screen.getByText("thesis")).toBeInTheDocument();
+    expect(screen.getByText("scoring")).toBeInTheDocument();
+  });
+
+  it("renders Checking skeleton when v2 is null and has no cached snapshot", () => {
+    renderPanel({ v2: null, jobs: null, coverage: null });
+    expect(screen.getByText(/Checking for problems/i)).toBeInTheDocument();
+  });
+
+  it("keeps last-good snapshot rendered when v2 briefly goes null", () => {
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.action_needed = [
+      {
+        root_layer: "x",
+        display_name: "Layer X",
+        category: "source_down",
+        operator_message: "down",
+        operator_fix: null,
+        self_heal: true,
+        consecutive_failures: 1,
+        affected_downstream: [],
+      },
+    ];
     const { rerender } = render(
-      <ProblemsPanel
-        layers={{
-          layers: [
-            layer({
-              name: "cik",
-              display_name: "CIK",
-              is_fresh: false,
-              consecutive_failures: 2,
-              last_error_category: "db_constraint",
-            }),
-          ],
-        }}
-        jobs={jobs()}
-        coverage={coverageClean()}
-        layersError={false}
-        jobsError={false}
-        coverageError={false}
-        onOpenOrchestrator={() => undefined}
-      />,
+      <MemoryRouter>
+        <ProblemsPanel
+          v2={v2}
+          jobs={emptyJobs()}
+          coverage={emptyCoverage()}
+          v2Error={false}
+          jobsError={false}
+          coverageError={false}
+          onOpenOrchestrator={() => {}}
+        />
+      </MemoryRouter>,
     );
-    await screen.findByText(/CIK — 2 consecutive failures/);
-
-    // Refetch fails for layers — component re-renders with
-    // layers=null + layersError=true. Cache keeps the problem; panel
-    // adds the "could not re-check layers" amber line.
+    expect(screen.getByText(/Layer X/)).toBeInTheDocument();
     rerender(
-      <ProblemsPanel
-        layers={null}
-        jobs={jobs()}
-        coverage={coverageClean()}
-        layersError={true}
-        jobsError={false}
-        coverageError={false}
-        onOpenOrchestrator={() => undefined}
-      />,
+      <MemoryRouter>
+        <ProblemsPanel
+          v2={null}
+          jobs={emptyJobs()}
+          coverage={emptyCoverage()}
+          v2Error={false}
+          jobsError={false}
+          coverageError={false}
+          onOpenOrchestrator={() => {}}
+        />
+      </MemoryRouter>,
     );
-    expect(screen.getByText(/CIK — 2 consecutive failures/)).toBeInTheDocument();
-    expect(
-      screen.getByText(/Could not re-check layers/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Layer X/)).toBeInTheDocument();
   });
 
-  it("click on 'Open orchestrator details' action fires the callback", async () => {
-    const { onOpenOrchestrator } = render_({
-      layers: {
-        layers: [
-          layer({
-            is_fresh: false,
-            consecutive_failures: 1,
-            last_error_category: "network",
-          }),
-        ],
+  it("calls onOpenOrchestrator with the layer name when drill-through clicked", () => {
+    const onOpen = vi.fn();
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.action_needed = [
+      {
+        root_layer: "cik_mapping",
+        display_name: "SEC CIK Mapping",
+        category: "db_constraint",
+        operator_message: "err",
+        operator_fix: null,
+        self_heal: false,
+        consecutive_failures: 1,
+        affected_downstream: [],
       },
-    });
-    const btn = await screen.findByRole("button", {
-      name: /Open orchestrator details/,
-    });
-    btn.click();
-    expect(onOpenOrchestrator).toHaveBeenCalled();
+    ];
+    renderPanel({ v2, onOpenOrchestrator: onOpen });
+    screen.getByRole("button", { name: /Open orchestrator details for cik_mapping/ }).click();
+    expect(onOpen).toHaveBeenCalledWith("cik_mapping");
+  });
+
+  it("carries over failing jobs from v1 behaviour", () => {
+    const jobs: JobsListResponse = {
+      checked_at: new Date().toISOString(),
+      jobs: [
+        {
+          name: "test_job",
+          description: "test job",
+          cadence: "daily",
+          cadence_kind: "daily",
+          next_run_time: new Date().toISOString(),
+          next_run_time_source: "declared",
+          last_status: "failure",
+          last_started_at: null,
+          last_finished_at: new Date().toISOString(),
+          detail: "",
+        },
+      ],
+    };
+    renderPanel({ jobs });
+    expect(screen.getByText(/test_job/)).toBeInTheDocument();
+    expect(screen.getByText(/last run failed/i)).toBeInTheDocument();
+  });
+
+  it("carries over coverage null_rows from v1 behaviour", () => {
+    const coverage: CoverageSummaryResponse = {
+      ...emptyCoverage(),
+      null_rows: 12,
+    };
+    renderPanel({ coverage });
+    expect(screen.getByText(/12 instrument/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/admin/ProblemsPanel.test.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.test.tsx
@@ -385,4 +385,50 @@ describe("ProblemsPanel", () => {
     expect(screen.getByRole("status")).not.toHaveTextContent(/layers/i);
     expect(screen.getByRole("status")).not.toHaveTextContent(/jobs/i);
   });
+
+  it("uses a combined-count header when carry-over rows contribute problems but v2 is clean", () => {
+    // Regression guard: previously the header text came from
+    // v2.system_summary ("All layers healthy") even when a failed
+    // job was rendered underneath. Must say "N problem(s) need
+    // attention" whenever jobs/coverage contribute.
+    const jobs: JobsListResponse = {
+      jobs: [
+        {
+          name: "test_job",
+          description: "test job",
+          cadence: "daily",
+          next_run_time: null,
+          last_status: "failure",
+          last_finished_at: new Date().toISOString(),
+        } as unknown as JobsListResponse["jobs"][number],
+      ],
+    };
+    renderPanel({ v2: emptyV2(), jobs });
+    // v2 is clean; v2.system_summary = "All layers healthy".
+    // Header MUST reflect the one failed job, not parrot the v2 summary.
+    expect(screen.queryByText(/All layers healthy/)).toBeNull();
+    expect(screen.getByText(/1 problem.*need.*attention/i)).toBeInTheDocument();
+  });
+
+  it("renders plain text for a SecretMissingItem whose operator_fix lacks Settings phrasing", () => {
+    // Regression guard: the backend has a defensive fallback
+    // operator_fix="Check layer secret configuration" for layers
+    // without declared secret_refs. That must render as plain text,
+    // not a misleading /settings#providers link.
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.secret_missing = [
+      {
+        layer: "some_layer",
+        display_name: "Some Layer",
+        missing_secret: "(unknown)",
+        operator_fix: "Check layer secret configuration",
+      },
+    ];
+    renderPanel({ v2 });
+    expect(screen.getByText(/Check layer secret configuration/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /Check layer secret configuration/i }),
+    ).toBeNull();
+  });
 });

--- a/frontend/src/components/admin/ProblemsPanel.test.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.test.tsx
@@ -278,4 +278,111 @@ describe("ProblemsPanel", () => {
     renderPanel({ coverage });
     expect(screen.getByText(/12 instrument/)).toBeInTheDocument();
   });
+
+  it("renders plain text when operator_fix mentions Settings only as context, not as a destination", () => {
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.action_needed = [
+      {
+        root_layer: "x",
+        display_name: "Layer X",
+        category: "db_constraint",
+        operator_message: "DB error",
+        operator_fix: "Nothing to do with Settings or Providers — inspect the offending row manually",
+        self_heal: false,
+        consecutive_failures: 1,
+        affected_downstream: [],
+      },
+    ];
+    renderPanel({ v2 });
+    expect(
+      screen.queryByRole("link", { name: /Nothing to do with Settings/i }),
+    ).toBeNull();
+    expect(
+      screen.getByText(/Nothing to do with Settings or Providers/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a Settings link when operator_fix says 'Update the API key in Settings'", () => {
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.action_needed = [
+      {
+        root_layer: "x",
+        display_name: "Layer X",
+        category: "auth_expired",
+        operator_message: "Credential expired",
+        operator_fix: "Update the API key in Settings",
+        self_heal: false,
+        consecutive_failures: 1,
+        affected_downstream: [],
+      },
+    ];
+    renderPanel({ v2 });
+    const link = screen.getByRole("link", { name: /Update the API key in Settings/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/settings#providers");
+  });
+
+  it("keeps last-good coverage visible when coverage errors while v2 updates", () => {
+    // Initial render: both sources succeed, coverage has 5 null rows.
+    const initialV2 = emptyV2();
+    initialV2.system_state = "ok";
+    const initialCoverage: CoverageSummaryResponse = {
+      ...emptyCoverage(),
+      null_rows: 5,
+    };
+    const { rerender } = render(
+      <MemoryRouter>
+        <ProblemsPanel
+          v2={initialV2}
+          jobs={emptyJobs()}
+          coverage={initialCoverage}
+          v2Error={false}
+          jobsError={false}
+          coverageError={false}
+          onOpenOrchestrator={() => {}}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/5 instrument/)).toBeInTheDocument();
+
+    // Simultaneous transition: v2 flips to needs_attention with a new
+    // action_needed row; coverage refetch errors (data stays as the
+    // last-good value). Assert (a) v2 update visible, (b) amber banner
+    // lists coverage only, (c) the 5 null_rows still render from cache.
+    const updatedV2 = emptyV2();
+    updatedV2.system_state = "needs_attention";
+    updatedV2.action_needed = [
+      {
+        root_layer: "cik_mapping",
+        display_name: "SEC CIK Mapping",
+        category: "db_constraint",
+        operator_message: "Database error",
+        operator_fix: null,
+        self_heal: false,
+        consecutive_failures: 2,
+        affected_downstream: [],
+      },
+    ];
+    rerender(
+      <MemoryRouter>
+        <ProblemsPanel
+          v2={updatedV2}
+          jobs={emptyJobs()}
+          coverage={initialCoverage}
+          v2Error={false}
+          jobsError={false}
+          coverageError={true}
+          onOpenOrchestrator={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/SEC CIK Mapping/)).toBeInTheDocument();
+    expect(screen.getByText(/5 instrument/)).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(/coverage/i);
+    expect(screen.getByRole("status")).not.toHaveTextContent(/layers/i);
+    expect(screen.getByRole("status")).not.toHaveTextContent(/jobs/i);
+  });
 });

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -1,127 +1,84 @@
 /**
- * Problems triage panel (AdminPage #323, spec §5 + §8).
+ * Problems triage panel — v2-backed (A.5 chunk 1).
  *
- * Surfaces layer failures, failing jobs, and coverage anomalies so
- * operator sees "what's broken" without scrolling. Sources:
- *   - /sync/layers: blocking problems from consecutive_failures /
- *     last_error_category; stale-blocking / stale-non-blocking from
- *     is_fresh + is_blocking.
- *   - /system/jobs: `last_status === "failure"` only. Skipped jobs are
- *     noise filtered out (retry_deferred_recommendations and friends
- *     skip routinely with "no work to do").
- *   - /coverage/summary: null_rows > 0 surfaces a data-audit row.
- *
- * Cache contract (spec §8): per-source snapshots that only overwrite
- * on a non-null fresh value. A refetch-in-flight source keeps
- * rendering last-good problems. First mount shows a neutral
- * "Checking for problems…" banner until every source resolves at
- * least once.
+ * Consumes `/sync/layers/v2` for layer problems (action_needed +
+ * secret_missing) while preserving the v1 jobs-failure and coverage
+ * null-row carry-over from the original ProblemsPanel. Per-source
+ * caches keep last-good snapshots across refetch-in-flight so a
+ * transient null does not blank the red banner.
  */
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 
 import type {
+  ActionNeededItem,
   CoverageSummaryResponse,
   JobsListResponse,
+  SecretMissingItem,
+  SyncLayersV2Response,
 } from "@/api/types";
-import type { SyncLayer, SyncLayersResponse } from "@/api/sync";
 import { formatDateTime } from "@/lib/format";
 
-export type ProblemTone = "red" | "amber";
-
-export interface Problem {
-  readonly id: string;
-  readonly tone: ProblemTone;
-  readonly title: string;
-  readonly detail: string | null;
-  readonly action?: { readonly label: string; readonly onClick: () => void };
-}
 
 export interface ProblemsPanelProps {
-  /** Live values. Null on first mount + while a refetch is in flight. */
-  readonly layers: SyncLayersResponse | null;
+  /** v2 payload. Null on first mount + while refetch is in flight. */
+  readonly v2: SyncLayersV2Response | null;
+  /** Jobs payload (unchanged from v1; failing jobs still surface here). */
   readonly jobs: JobsListResponse | null;
+  /** Coverage payload (unchanged from v1; null_rows still surface here). */
   readonly coverage: CoverageSummaryResponse | null;
-  /** Per-source error flags — true when the latest fetch returned an error.
-   *  A cached last-good snapshot still renders; we surface an amber
-   *  "could not re-check" line at the top of the panel so the operator
-   *  knows the displayed problems may be out of date. */
-  readonly layersError: boolean;
+  readonly v2Error: boolean;
   readonly jobsError: boolean;
   readonly coverageError: boolean;
-  /** Click-through from a layer problem to the orchestrator collapsible. */
-  readonly onOpenOrchestrator: () => void;
+  /** Called with the root layer name when the operator clicks drill-through. */
+  readonly onOpenOrchestrator: (layerName: string) => void;
 }
+
 
 interface SourceCache {
-  layers: Problem[] | null;
-  jobs: Problem[] | null;
-  coverage: Problem[] | null;
+  v2: SyncLayersV2Response | null;
+  jobs: JobsListResponse | null;
+  coverage: CoverageSummaryResponse | null;
 }
 
+
+function mentionsSettings(text: string): boolean {
+  return /settings/i.test(text) || /providers/i.test(text);
+}
+
+
 export function ProblemsPanel({
-  layers,
+  v2,
   jobs,
   coverage,
-  layersError,
+  v2Error,
   jobsError,
   coverageError,
   onOpenOrchestrator,
 }: ProblemsPanelProps): JSX.Element | null {
-  const [cache, setCache] = useState<SourceCache>({
-    layers: null,
-    jobs: null,
-    coverage: null,
-  });
-
-  // Per-source cached snapshot: only overwrite when a non-null fresh
-  // value arrives. A refetch-in-flight (value === null) leaves the
-  // cached snapshot untouched — last-good rendering, never false-good
-  // flash (spec §8).
-  useEffect(() => {
-    if (layers !== null) {
-      setCache((prev) => ({ ...prev, layers: deriveLayerProblems(layers, onOpenOrchestrator) }));
-    }
-  }, [layers, onOpenOrchestrator]);
+  const [cache, setCache] = useState<SourceCache>({ v2: null, jobs: null, coverage: null });
 
   useEffect(() => {
-    if (jobs !== null) {
-      setCache((prev) => ({ ...prev, jobs: deriveJobProblems(jobs) }));
-    }
+    if (v2 !== null) setCache((prev) => ({ ...prev, v2 }));
+  }, [v2]);
+  useEffect(() => {
+    if (jobs !== null) setCache((prev) => ({ ...prev, jobs }));
   }, [jobs]);
-
   useEffect(() => {
-    if (coverage !== null) {
-      setCache((prev) => ({ ...prev, coverage: deriveCoverageProblems(coverage) }));
-    }
+    if (coverage !== null) setCache((prev) => ({ ...prev, coverage }));
   }, [coverage]);
 
-  // Combined problem list — only sources that have resolved at least
-  // once contribute. A source still at `null` is excluded rather than
-  // defaulting to empty; it will join the list once it resolves. We
-  // ALSO show a "still checking N more source(s)" line when some
-  // sources have not yet resolved — so a slow/hung /coverage cannot
-  // mask live layer or job problems (spec §8).
-  const problems: Problem[] = [
-    ...(cache.layers ?? []),
-    ...(cache.jobs ?? []),
-    ...(cache.coverage ?? []),
-  ];
-
   const pendingSources: string[] = [];
-  if (cache.layers === null) pendingSources.push("layers");
+  if (cache.v2 === null) pendingSources.push("layers");
   if (cache.jobs === null) pendingSources.push("jobs");
   if (cache.coverage === null) pendingSources.push("coverage");
 
-  // Errored sources that DO have a cached snapshot from a previous
-  // successful fetch. Surfaced as an amber header line so the
-  // operator knows the cached problems may be stale.
   const erroredSources: string[] = [];
-  if (layersError && cache.layers !== null) erroredSources.push("layers");
+  if (v2Error && cache.v2 !== null) erroredSources.push("layers");
   if (jobsError && cache.jobs !== null) erroredSources.push("jobs");
   if (coverageError && cache.coverage !== null) erroredSources.push("coverage");
 
   const allPending = pendingSources.length === 3;
-
   if (allPending) {
     return (
       <div className="rounded-md border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600">
@@ -130,62 +87,42 @@ export function ProblemsPanel({
     );
   }
 
-  if (
-    problems.length === 0 &&
-    pendingSources.length === 0 &&
-    erroredSources.length === 0
-  ) {
-    // All sources resolved clean, no problems. Hidden state.
+  const actionNeeded = cache.v2?.action_needed ?? [];
+  const secretMissing = cache.v2?.secret_missing ?? [];
+  const failingJobs = (cache.jobs?.jobs ?? []).filter((j) => j.last_status === "failure");
+  const coverageNullRows = cache.coverage?.null_rows ?? 0;
+
+  const totalProblems = actionNeeded.length + secretMissing.length + failingJobs.length + (coverageNullRows > 0 ? 1 : 0);
+
+  if (totalProblems === 0 && pendingSources.length === 0 && erroredSources.length === 0) {
     return null;
   }
 
-  // Otherwise: render resolved-source problems + secondary lines
-  // for pending and errored sources so the operator knows the panel
-  // is not fully live.
-  return renderPanel(problems, pendingSources, erroredSources);
-}
+  const headerText =
+    cache.v2?.system_summary ??
+    (totalProblems > 0 ? `${totalProblems} problem(s) need attention` : "No confirmed problems yet");
+  const tone = totalProblems > 0 ? "red" : erroredSources.length > 0 ? "amber" : "neutral";
+  const sectionTone =
+    tone === "red"
+      ? "border-red-200 bg-red-50"
+      : tone === "amber"
+        ? "border-amber-200 bg-amber-50"
+        : "border-slate-200 bg-slate-50";
+  const headerTone =
+    tone === "red"
+      ? "border-red-200 text-red-800"
+      : tone === "amber"
+        ? "border-amber-200 text-amber-800"
+        : "border-slate-200 text-slate-700";
 
-function renderPanel(
-  problems: Problem[],
-  pendingSources: string[],
-  erroredSources: string[],
-): JSX.Element {
-
-  // When there are zero confirmed problems but some sources are
-  // still loading or errored, render neutral/amber — not red. Alarm
-  // tone is reserved for known-problems.
-  const hasProblems = problems.length > 0;
-  const sectionTone = hasProblems
-    ? "border-red-200 bg-red-50"
-    : erroredSources.length > 0
-      ? "border-amber-200 bg-amber-50"
-      : "border-slate-200 bg-slate-50";
-  const headerTone = hasProblems
-    ? "border-red-200 text-red-800"
-    : erroredSources.length > 0
-      ? "border-amber-200 text-amber-800"
-      : "border-slate-200 text-slate-700";
   return (
-    <section
-      role="region"
-      aria-label="Current problems"
-      className={`rounded-md border shadow-sm ${sectionTone}`}
-    >
-      <header
-        className={`flex items-center justify-between border-b px-4 py-2 text-sm font-semibold ${headerTone}`}
-      >
-        <span>
-          {hasProblems
-            ? `${problems.length} problem${problems.length === 1 ? "" : "s"} need${problems.length === 1 ? "s" : ""} attention`
-            : erroredSources.length > 0
-              ? "No confirmed problems yet"
-              : "Checking for problems…"}
-        </span>
+    <section role="region" aria-label="Current problems" className={`rounded-md border shadow-sm ${sectionTone}`}>
+      <header className={`flex items-center justify-between border-b px-4 py-2 text-sm font-semibold ${headerTone}`}>
+        <span>{headerText}</span>
         <span className="flex items-center gap-3 text-xs font-normal">
           {pendingSources.length > 0 ? (
             <span className="text-slate-600">
-              Checking {pendingSources.length} more source
-              {pendingSources.length === 1 ? "" : "s"}…
+              Checking {pendingSources.length} more source{pendingSources.length === 1 ? "" : "s"}…
             </span>
           ) : null}
           {erroredSources.length > 0 ? (
@@ -195,138 +132,114 @@ function renderPanel(
           ) : null}
         </span>
       </header>
-      {problems.length === 0 ? (
-        <p className="px-4 py-2 text-sm text-slate-600">
-          No problems from resolved sources yet.
-        </p>
-      ) : (
-        <ul className="divide-y divide-red-100">
-          {problems.map((p) => (
-            <li key={p.id} className="px-4 py-2 text-sm">
-              <div className="flex items-start gap-2">
-                <span
-                  aria-hidden
-                  className={`mt-1 inline-block h-2 w-2 rounded-full ${p.tone === "red" ? "bg-red-500" : "bg-amber-500"}`}
-                />
-                <div className="flex-1">
-                  <div
-                    className={`font-medium ${p.tone === "red" ? "text-red-800" : "text-amber-800"}`}
-                  >
-                    {p.title}
-                  </div>
-                  {p.detail !== null ? (
-                    <div className="text-xs text-slate-600">{p.detail}</div>
-                  ) : null}
-                </div>
-                {p.action ? (
-                  <button
-                    type="button"
-                    onClick={p.action.onClick}
-                    className="shrink-0 text-xs font-medium text-blue-700 hover:underline"
-                  >
-                    {p.action.label} →
-                  </button>
+      <ul className="divide-y divide-red-100">
+        {actionNeeded.map((item) => (
+          <ActionNeededRow key={item.root_layer} item={item} onOpen={() => onOpenOrchestrator(item.root_layer)} />
+        ))}
+        {secretMissing.map((item) => (
+          <SecretMissingRow key={item.layer} item={item} />
+        ))}
+        {failingJobs.map((job) => (
+          <li key={`job-${job.name}`} className="px-4 py-2 text-sm">
+            <div className="flex items-start gap-2">
+              <span aria-hidden className="mt-1 inline-block h-2 w-2 rounded-full bg-red-500" />
+              <div className="flex-1">
+                <div className="font-medium text-red-800">{job.name} — last run failed</div>
+                {job.last_finished_at !== null ? (
+                  <div className="text-xs text-slate-600">Failed at {formatDateTime(job.last_finished_at)}</div>
                 ) : null}
               </div>
-            </li>
-          ))}
-        </ul>
-      )}
+            </div>
+          </li>
+        ))}
+        {coverageNullRows > 0 ? (
+          <li className="px-4 py-2 text-sm">
+            <div className="flex items-start gap-2">
+              <span aria-hidden className="mt-1 inline-block h-2 w-2 rounded-full bg-amber-500" />
+              <div className="flex-1">
+                <div className="font-medium text-amber-800">
+                  {coverageNullRows} instrument{coverageNullRows === 1 ? "" : "s"} have a NULL filings_status
+                </div>
+                <div className="text-xs text-slate-600">The filings-status audit job has not covered these instruments yet.</div>
+              </div>
+            </div>
+          </li>
+        ) : null}
+      </ul>
     </section>
   );
 }
 
-function deriveLayerProblems(
-  layers: SyncLayersResponse,
-  onOpenOrchestrator: () => void,
-): Problem[] {
-  const out: Problem[] = [];
-  for (const layer of layers.layers) {
-    const p = classifyLayer(layer, onOpenOrchestrator);
-    if (p !== null) out.push(p);
-  }
-  return out;
+
+function ActionNeededRow({ item, onOpen }: { item: ActionNeededItem; onOpen: () => void }): JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+  const fix = item.operator_fix;
+  const fixAsLink = fix !== null && mentionsSettings(fix);
+  return (
+    <li className="px-4 py-2 text-sm">
+      <div className="flex items-start gap-2">
+        <span aria-hidden className="mt-1 inline-block h-2 w-2 rounded-full bg-red-500" />
+        <div className="flex-1">
+          <div className="font-medium text-red-800">
+            {item.display_name} — {item.operator_message}
+          </div>
+          {fix !== null ? (
+            <div className="text-xs text-slate-700">
+              {fixAsLink ? (
+                <Link to="/settings#providers" className="font-medium text-blue-700 hover:underline">
+                  {fix}
+                </Link>
+              ) : (
+                <span>{fix}</span>
+              )}
+            </div>
+          ) : null}
+          <div className="mt-1 text-xs text-slate-500">{item.consecutive_failures} consecutive failures</div>
+          {item.affected_downstream.length > 0 ? (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="mt-1 text-xs text-red-700 hover:underline"
+            >
+              +{item.affected_downstream.length} layers waiting
+            </button>
+          ) : null}
+          {expanded ? (
+            <ul className="mt-1 list-disc pl-5 text-xs text-slate-600">
+              {item.affected_downstream.map((name) => (
+                <li key={name}>{name}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={onOpen}
+          className="shrink-0 text-xs font-medium text-blue-700 hover:underline"
+          aria-label={`Open orchestrator details for ${item.root_layer}`}
+        >
+          Open orchestrator details →
+        </button>
+      </div>
+    </li>
+  );
 }
 
-function classifyLayer(
-  layer: SyncLayer,
-  onOpenOrchestrator: () => void,
-): Problem | null {
-  const action = {
-    label: "Open orchestrator details",
-    onClick: onOpenOrchestrator,
-  };
-  // Red: explicit failure history (consecutive_failures >= 1 AND a
-  // last_error_category we can show). Overrides stale classification.
-  if (layer.consecutive_failures >= 1 && layer.last_error_category !== null) {
-    return {
-      id: `layer-fail-${layer.name}`,
-      tone: "red",
-      title: `${layer.display_name} — ${layer.consecutive_failures} consecutive failure${layer.consecutive_failures === 1 ? "" : "s"} (${layer.last_error_category})`,
-      detail:
-        layer.last_success_at !== null
-          ? `Last success: ${formatDateTime(layer.last_success_at)}`
-          : "Never succeeded",
-      action,
-    };
-  }
-  // Amber: stale blocking layer with no recorded failure category.
-  if (!layer.is_fresh && layer.is_blocking) {
-    return {
-      id: `layer-stale-${layer.name}`,
-      tone: "amber",
-      title: `${layer.display_name} — stale`,
-      detail: layer.freshness_detail,
-      action,
-    };
-  }
-  // Amber low-priority: stale non-blocking. Surfaces the signal but
-  // the operator is not gated by it. Kept in the panel per spec §5;
-  // layers that are permanently-a-bit-behind by design show up here
-  // too — that's acceptable noise for a triage surface because the
-  // alternative (silence) hides real regressions in the same class.
-  if (!layer.is_fresh && !layer.is_blocking) {
-    return {
-      id: `layer-stale-nb-${layer.name}`,
-      tone: "amber",
-      title: `${layer.display_name} — stale (non-blocking)`,
-      detail: layer.freshness_detail,
-      action,
-    };
-  }
-  return null;
-}
 
-function deriveJobProblems(jobs: JobsListResponse): Problem[] {
-  const out: Problem[] = [];
-  for (const job of jobs.jobs) {
-    if (job.last_status !== "failure") continue;
-    out.push({
-      id: `job-fail-${job.name}`,
-      tone: "red",
-      title: `${job.name} — last run failed`,
-      detail:
-        job.last_finished_at !== null
-          ? `Failed at ${formatDateTime(job.last_finished_at)}`
-          : null,
-    });
-  }
-  return out;
-}
-
-function deriveCoverageProblems(
-  coverage: CoverageSummaryResponse,
-): Problem[] {
-  if (coverage.null_rows > 0) {
-    return [
-      {
-        id: "coverage-null-rows",
-        tone: "amber",
-        title: `${coverage.null_rows} instrument${coverage.null_rows === 1 ? "" : "s"} have a NULL filings_status`,
-        detail:
-          "The filings-status audit job has not covered these instruments yet.",
-      },
-    ];
-  }
-  return [];
+function SecretMissingRow({ item }: { item: SecretMissingItem }): JSX.Element {
+  return (
+    <li className="px-4 py-2 text-sm">
+      <div className="flex items-start gap-2">
+        <span aria-hidden className="mt-1 inline-block h-2 w-2 rounded-full bg-amber-500" />
+        <div className="flex-1">
+          <div className="font-medium text-amber-800">{item.display_name} — credential needed</div>
+          <div className="text-xs text-slate-700">
+            <Link to="/settings#providers" className="font-medium text-blue-700 hover:underline">
+              {item.operator_fix}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </li>
+  );
 }

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -43,7 +43,12 @@ interface SourceCache {
 
 
 function mentionsSettings(text: string): boolean {
-  return /settings/i.test(text) || /providers/i.test(text);
+  // Match the canonical remedy phrasings emitted by the backend REMEDIES
+  // table — e.g. "Set X in Settings → Providers", "Update the API key in
+  // Settings". Narrow enough that a remedy mentioning settings/providers
+  // in passing (e.g. "nothing to do with Settings — inspect the row
+  // manually") stays plain text rather than becoming a misleading link.
+  return /\bin\s+Settings\b/i.test(text) || /\bSettings\s*[→>]\s*Providers\b/i.test(text);
 }
 
 

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -103,9 +103,17 @@ export function ProblemsPanel({
     return null;
   }
 
+  // `system_summary` from v2 only describes layer problems. If the total
+  // problem count comes from carried-over jobs / coverage rows too, use
+  // the combined count instead — otherwise a red panel with a failed
+  // job shown underneath would be topped by "All layers healthy".
+  const v2ProblemCount = actionNeeded.length + secretMissing.length;
   const headerText =
-    cache.v2?.system_summary ??
-    (totalProblems > 0 ? `${totalProblems} problem(s) need attention` : "No confirmed problems yet");
+    totalProblems === v2ProblemCount && cache.v2?.system_summary !== undefined
+      ? cache.v2.system_summary
+      : totalProblems > 0
+        ? `${totalProblems} problem(s) need attention`
+        : "No confirmed problems yet";
   const tone = totalProblems > 0 ? "red" : erroredSources.length > 0 ? "amber" : "neutral";
   const sectionTone =
     tone === "red"
@@ -232,6 +240,12 @@ function ActionNeededRow({ item, onOpen }: { item: ActionNeededItem; onOpen: () 
 
 
 function SecretMissingRow({ item }: { item: SecretMissingItem }): JSX.Element {
+  // Most secret_missing rows have a Settings → Providers fix. The
+  // backend has a defensive fallback path ("Check layer secret
+  // configuration") for layers with no declared secret_refs — apply
+  // the same link heuristic ActionNeededRow uses so a generic fix
+  // does not get a misleading Settings link.
+  const fixAsLink = mentionsSettings(item.operator_fix);
   return (
     <li className="px-4 py-2 text-sm">
       <div className="flex items-start gap-2">
@@ -239,9 +253,13 @@ function SecretMissingRow({ item }: { item: SecretMissingItem }): JSX.Element {
         <div className="flex-1">
           <div className="font-medium text-amber-800">{item.display_name} — credential needed</div>
           <div className="text-xs text-slate-700">
-            <Link to="/settings#providers" className="font-medium text-blue-700 hover:underline">
-              {item.operator_fix}
-            </Link>
+            {fixAsLink ? (
+              <Link to="/settings#providers" className="font-medium text-blue-700 hover:underline">
+                {item.operator_fix}
+              </Link>
+            ) : (
+              <span>{item.operator_fix}</span>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -24,11 +24,13 @@ import type {
   JobsListResponse,
   RecommendationsListResponse,
   ConfigResponse,
+  SyncLayersV2Response,
 } from "@/api/types";
 
 vi.mock("@/api/jobs", () => ({ fetchJobsOverview: vi.fn(), runJob: vi.fn() }));
 vi.mock("@/api/sync", () => ({
   fetchSyncLayers: vi.fn(),
+  fetchSyncLayersV2: vi.fn(),
   fetchSyncStatus: vi.fn(),
   fetchSyncRuns: vi.fn(),
   triggerSync: vi.fn(),
@@ -40,6 +42,7 @@ vi.mock("@/api/config", () => ({ fetchConfig: vi.fn() }));
 import { fetchJobsOverview, runJob } from "@/api/jobs";
 import {
   fetchSyncLayers,
+  fetchSyncLayersV2,
   fetchSyncRuns,
   fetchSyncStatus,
 } from "@/api/sync";
@@ -50,6 +53,7 @@ import { fetchConfig } from "@/api/config";
 const mockedJobs = vi.mocked(fetchJobsOverview);
 const mockedRun = vi.mocked(runJob);
 const mockedLayers = vi.mocked(fetchSyncLayers);
+const mockedV2 = vi.mocked(fetchSyncLayersV2);
 const mockedStatus = vi.mocked(fetchSyncStatus);
 const mockedSyncRuns = vi.mocked(fetchSyncRuns);
 const mockedCoverage = vi.mocked(fetchCoverageSummary);
@@ -139,10 +143,26 @@ function jobsResponse(): JobsListResponse {
   };
 }
 
+function emptyV2(): SyncLayersV2Response {
+  return {
+    generated_at: new Date().toISOString(),
+    system_state: "ok",
+    system_summary: "All layers healthy",
+    action_needed: [],
+    degraded: [],
+    secret_missing: [],
+    healthy: [],
+    disabled: [],
+    cascade_groups: [],
+    layers: [],
+  };
+}
+
 beforeEach(() => {
   mockedJobs.mockReset();
   mockedRun.mockReset();
   mockedLayers.mockReset();
+  mockedV2.mockReset();
   mockedStatus.mockReset();
   mockedSyncRuns.mockReset();
   mockedCoverage.mockReset();
@@ -152,6 +172,7 @@ beforeEach(() => {
   mockedConfig.mockResolvedValue(demoConfig());
   mockedJobs.mockResolvedValue(jobsResponse());
   mockedLayers.mockResolvedValue({ layers: [] });
+  mockedV2.mockResolvedValue(emptyV2());
   mockedStatus.mockResolvedValue({
     is_running: false,
     current_run: null,
@@ -216,7 +237,7 @@ describe("AdminPage — top-level composition", () => {
     renderPage();
     // Wait for all three sources to resolve.
     await waitFor(() => {
-      expect(mockedLayers).toHaveBeenCalled();
+      expect(mockedV2).toHaveBeenCalled();
       expect(mockedJobs).toHaveBeenCalled();
       expect(mockedCoverage).toHaveBeenCalled();
     });
@@ -237,24 +258,22 @@ describe("AdminPage — top-level composition", () => {
   });
 
   it("shows problems panel when a layer has consecutive failures", async () => {
-    mockedLayers.mockReset();
-    mockedLayers.mockResolvedValue({
-      layers: [
-        {
-          name: "cik_mapping",
-          display_name: "CIK mapping",
-          tier: 1,
-          is_fresh: false,
-          freshness_detail: "failed",
-          last_success_at: null,
-          last_duration_seconds: null,
-          last_error_category: "db_constraint",
-          consecutive_failures: 3,
-          dependencies: [],
-          is_blocking: true,
-        },
-      ],
-    });
+    const v2WithProblem = emptyV2();
+    v2WithProblem.system_state = "needs_attention";
+    v2WithProblem.action_needed = [
+      {
+        root_layer: "cik_mapping",
+        display_name: "CIK mapping",
+        category: "db_constraint",
+        operator_message: "3 consecutive failures",
+        operator_fix: null,
+        self_heal: false,
+        consecutive_failures: 3,
+        affected_downstream: [],
+      },
+    ];
+    mockedV2.mockReset();
+    mockedV2.mockResolvedValue(v2WithProblem);
     renderPage();
     expect(
       await screen.findByText(/CIK mapping — 3 consecutive failures/),
@@ -283,29 +302,27 @@ describe("AdminPage — collapsible sections", () => {
   });
 
   it("expands Orchestrator details when a layer problem's action fires", async () => {
-    mockedLayers.mockReset();
-    mockedLayers.mockResolvedValue({
-      layers: [
-        {
-          name: "cik_mapping",
-          display_name: "CIK mapping",
-          tier: 1,
-          is_fresh: false,
-          freshness_detail: "failed",
-          last_success_at: null,
-          last_duration_seconds: null,
-          last_error_category: "db_constraint",
-          consecutive_failures: 3,
-          dependencies: [],
-          is_blocking: true,
-        },
-      ],
-    });
+    const v2WithProblem = emptyV2();
+    v2WithProblem.system_state = "needs_attention";
+    v2WithProblem.action_needed = [
+      {
+        root_layer: "cik_mapping",
+        display_name: "CIK mapping",
+        category: "db_constraint",
+        operator_message: "3 consecutive failures",
+        operator_fix: null,
+        self_heal: false,
+        consecutive_failures: 3,
+        affected_downstream: [],
+      },
+    ];
+    mockedV2.mockReset();
+    mockedV2.mockResolvedValue(v2WithProblem);
     const user = userEvent.setup();
     renderPage();
     await user.click(
       await screen.findByRole("button", {
-        name: /Open orchestrator details/,
+        name: /Open orchestrator details for cik_mapping/,
       }),
     );
     await waitFor(() => {
@@ -378,5 +395,66 @@ describe("AdminPage — Background tasks collapsible", () => {
     });
     await user.click(btn);
     expect(btn).toHaveTextContent("Unknown job");
+  });
+});
+
+describe("AdminPage v2 integration", () => {
+  it("renders ProblemsPanel hidden and LayerHealthList rows when v2 is ok", async () => {
+    const mockV2: SyncLayersV2Response = {
+      generated_at: new Date().toISOString(),
+      system_state: "ok",
+      system_summary: "All layers healthy",
+      action_needed: [],
+      degraded: [],
+      secret_missing: [],
+      healthy: [],
+      disabled: [],
+      cascade_groups: [],
+      layers: [
+        {
+          layer: "universe",
+          display_name: "Tradable Universe",
+          state: "healthy",
+          last_updated: new Date().toISOString(),
+          plain_language_sla: "Refreshed weekly.",
+        },
+        {
+          layer: "candles",
+          display_name: "Daily Price Candles",
+          state: "healthy",
+          last_updated: new Date().toISOString(),
+          plain_language_sla: "Refreshed every trading day after market close.",
+        },
+      ],
+    };
+    mockedV2.mockReset();
+    mockedV2.mockResolvedValue(mockV2);
+    // All other sources clean to ensure ProblemsPanel hides.
+    mockedJobs.mockReset();
+    mockedJobs.mockResolvedValue({
+      checked_at: new Date().toISOString(),
+      jobs: [],
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    // Wait for v2 fetch to complete.
+    await waitFor(() => {
+      expect(mockedV2).toHaveBeenCalled();
+    });
+
+    // ProblemsPanel must be hidden (no error banner text).
+    await waitFor(() => {
+      expect(screen.queryByRole("region", { name: "Current problems" })).toBeNull();
+    });
+
+    // Expand Layer health section to see LayerHealthList rows.
+    await user.click(await screen.findByRole("button", { name: /Layer health/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Tradable Universe")).toBeInTheDocument();
+      expect(screen.getByText("Daily Price Candles")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -24,7 +24,7 @@ import { Link } from "react-router-dom";
 import { fetchCoverageSummary } from "@/api/coverage";
 import { fetchJobsOverview, runJob } from "@/api/jobs";
 import { fetchRecommendations } from "@/api/recommendations";
-import { fetchSyncLayers, fetchSyncStatus } from "@/api/sync";
+import { fetchSyncLayersV2, fetchSyncStatus } from "@/api/sync";
 import { ApiError } from "@/api/client";
 import type {
   CoverageSummaryResponse,
@@ -32,6 +32,7 @@ import type {
 } from "@/api/types";
 import { CollapsibleSection } from "@/components/admin/CollapsibleSection";
 import { FundDataRow } from "@/components/admin/FundDataRow";
+import { LayerHealthList } from "@/components/admin/LayerHealthList";
 import { ProblemsPanel } from "@/components/admin/ProblemsPanel";
 import {
   SectionError,
@@ -61,7 +62,7 @@ const ORCHESTRATOR_OWNED = new Set([
 ]);
 
 export function AdminPage() {
-  const layers = useAsync(fetchSyncLayers, []);
+  const v2 = useAsync(fetchSyncLayersV2, []);
   const status = useAsync(fetchSyncStatus, []);
   const coverage = useAsync(fetchCoverageSummary, []);
   const jobs = useAsync(fetchJobsOverview, []);
@@ -80,19 +81,19 @@ export function AdminPage() {
   // that previously papered over the stability contract. `useAsync`
   // wraps refetch in `useCallback([], [])` — see useAsync.test.ts
   // which pins that invariant.
-  const refetchLayers = layers.refetch;
+  const refetchV2 = v2.refetch;
   const refetchStatus = status.refetch;
   const refetchCoverage = coverage.refetch;
   const refetchJobs = jobs.refetch;
   const refetchRecs = recs.refetch;
 
   const refetchAll = useCallback(() => {
-    refetchLayers();
+    refetchV2();
     refetchStatus();
     refetchCoverage();
     refetchJobs();
     refetchRecs();
-  }, [refetchLayers, refetchStatus, refetchCoverage, refetchJobs, refetchRecs]);
+  }, [refetchV2, refetchStatus, refetchCoverage, refetchJobs, refetchRecs]);
 
   const isRunning = status.data?.is_running ?? false;
   const refreshInterval = isRunning ? 10_000 : 60_000;
@@ -175,17 +176,20 @@ export function AdminPage() {
     [refetchJobs],
   );
 
-  // Stable callback so ProblemsPanel's useEffect on `layers` does
-  // not re-run (and re-compute problems) every AdminPage render.
-  const openOrchestrator = useCallback(() => {
+  const openOrchestratorFor = useCallback((layerName: string) => {
     setOrchestratorOpen(true);
     // Let the section mount before we scroll, so the target exists.
     // scrollIntoView is undefined in jsdom so we guard defensively —
     // the browser behaviour is unchanged.
     requestAnimationFrame(() => {
-      const el = document.getElementById("admin-orchestrator-details");
-      if (el && typeof el.scrollIntoView === "function") {
-        el.scrollIntoView({ behavior: "smooth", block: "start" });
+      const layerEl = document.getElementById(`admin-layer-${layerName}`);
+      if (layerEl && typeof layerEl.scrollIntoView === "function") {
+        layerEl.scrollIntoView({ behavior: "smooth", block: "start" });
+        return;
+      }
+      const sectionEl = document.getElementById("admin-orchestrator-details");
+      if (sectionEl && typeof sectionEl.scrollIntoView === "function") {
+        sectionEl.scrollIntoView({ behavior: "smooth", block: "start" });
       }
     });
   }, []);
@@ -194,12 +198,9 @@ export function AdminPage() {
     (j) => !ORCHESTRATOR_OWNED.has(j.name),
   );
 
-  const layerProblemCount =
-    (layers.data?.layers ?? []).filter(
-      (l) =>
-        (l.consecutive_failures >= 1 && l.last_error_category !== null) ||
-        (!l.is_fresh && l.is_blocking),
-    ).length;
+  const unhealthyLayerCount = (v2.data?.layers ?? []).filter(
+    (l) => l.state !== "healthy" && l.state !== "disabled",
+  ).length;
 
   return (
     <div className="space-y-4">
@@ -214,13 +215,13 @@ export function AdminPage() {
       </div>
 
       <ProblemsPanel
-        layers={layers.data}
+        v2={v2.data}
         jobs={jobs.data}
         coverage={coverage.data}
-        layersError={layers.error !== null}
+        v2Error={v2.error !== null}
         jobsError={jobs.error !== null}
         coverageError={coverage.error !== null}
-        onOpenOrchestrator={openOrchestrator}
+        onOpenOrchestrator={openOrchestratorFor}
       />
 
       <FundDataRow
@@ -231,12 +232,32 @@ export function AdminPage() {
       />
 
       <CollapsibleSection
-        title="Orchestrator details"
+        title="Layer health"
         summary={
-          layerProblemCount > 0
-            ? `${layerProblemCount} layer${layerProblemCount === 1 ? "" : "s"} need attention`
-            : "all layers healthy"
+          v2.data === null
+            ? undefined
+            : unhealthyLayerCount > 0
+              ? `${unhealthyLayerCount} layer${unhealthyLayerCount === 1 ? "" : "s"} catching up or need attention`
+              : "all layers healthy"
         }
+      >
+        {v2.loading ? (
+          <SectionSkeleton rows={15} />
+        ) : v2.error !== null ? (
+          <SectionError onRetry={v2.refetch} />
+        ) : v2.data ? (
+          <LayerHealthList
+            layers={v2.data.layers}
+            onToggle={() => {
+              /* wired in chunk 2 */
+            }}
+          />
+        ) : null}
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        title="Orchestrator details"
+        summary="sync history"
         open={orchestratorOpen}
         onOpenChange={setOrchestratorOpen}
         sectionId="admin-orchestrator-details"


### PR DESCRIPTION
## What

First operator-visible payoff of sub-project A (#328). Admin page + ProblemsPanel now consume \`/sync/layers/v2\` with canonical \`layers[]\` (chunk 0 added the field, merged in #344).

- **\`frontend/src/api/types.ts\`** — v2 TS types (\`LayerEntry\`, \`ActionNeededItem\`, \`SecretMissingItem\`, \`SyncLayersV2Response\`, etc.). V1 types left alone.
- **\`frontend/src/api/sync.ts\`** — new \`fetchSyncLayersV2()\` alongside v1.
- **\`frontend/src/components/admin/LayerHealthList.tsx\`** — new per-layer list with pill colours (Healthy / Catching up / Needs attention / Disabled), relative \`last_updated\`, plain-language SLA, and a ⋯ menu emitting \`onToggle(name, enabled)\` (toggle wiring lands in chunk 2).
- **\`frontend/src/components/admin/ProblemsPanel.tsx\`** — rewritten to consume v2 while preserving the v1 jobs + coverage carry-over rows. Per-source cache keeps last-good snapshots across refetch-in-flight. \`action_needed.operator_fix\` renders as \`<Link to="/settings#providers">\` when it matches canonical \"in Settings\" / \"Settings → Providers\" phrasings; stays plain text otherwise.
- **\`frontend/src/pages/AdminPage.tsx\`** — fetches v2, mounts a new \"Layer health\" collapsible above the existing (unchanged) \"Orchestrator details\" / \`SyncDashboard\` block.

\`SyncDashboard\` + \`fetchSyncLayers\` (v1) left alone — their v2 migration is tracked on sub-project C.

## Review loops

**Code-quality subagent (Important findings, all fixed \`8055dac\`):**
- Menu outside-click + Escape handling added to LayerHealthList. 3 new tests.
- \`mentionsSettings()\` tightened to canonical phrases (\`\bin Settings\b\` / \`Settings → Providers\`) so a remedy mentioning Settings in passing stays plain text. New pinning test.
- Simultaneous-source-transition test added to ProblemsPanel (v2 updates while coverage refetch errors).
- \`relativeAgo\` test now uses \`vi.useFakeTimers\` for deterministic clock.

## Test plan

- [x] \`pnpm --dir frontend test\` — 275+ tests pass
- [x] \`pnpm --dir frontend typecheck\` — 0 errors
- [x] \`uv run pytest -x -q\` — 2128 passed, 1 skipped (backend untouched)
- [x] \`uv run ruff check .\` + \`format --check .\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)