### PR TITLE
refactor(#342): chunk 3 — retire /health/data

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -11,8 +11,8 @@ Endpoints:
       * each row carries the declared cadence + computed ``next_run_time``
         plus the most recent ``job_runs`` row for that job
 
-Distinct from ``/health`` (liveness) and from the deprecated ``/health/data``
-(which served the same purpose pre-#57). The frontend admin page (#64) polls
+Distinct from ``/health`` (liveness) and from the retired ``/health/data``
+(removed in #342; served the same purpose pre-#57). The frontend admin page (#64) polls
 ``/system/status``; the scheduled-job table on the same page polls
 ``/system/jobs``.
 

--- a/app/main.py
+++ b/app/main.py
@@ -44,11 +44,9 @@ from app.security import master_key
 from app.security.secrets_crypto import set_active_key as set_broker_encryption_key
 from app.services.coverage import override_tier
 from app.services.operator_setup import ensure_startup_token, operators_empty
-from app.services.ops_monitor import get_system_health
 from app.services.sync_orchestrator.layer_state import compute_layer_states_from_db
 from app.services.sync_orchestrator.layer_types import LayerState
 from app.services.sync_orchestrator.reaper import reap_orphaned_syncs
-from app.workers.scheduler import SCHEDULED_JOBS
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -296,62 +294,6 @@ def coverage_override(
         "new_tier": change.new_tier,
         "change_type": change.change_type,
         "rationale": change.rationale,
-    }
-
-
-# ---------------------------------------------------------------------------
-# Data health
-# ---------------------------------------------------------------------------
-
-# Deprecated: superseded by GET /system/status (issue #57). The new router
-# carries the canonical operator visibility surface (per-layer freshness, job
-# health, kill switch). This route is kept temporarily so any existing
-# operator scripts continue to work; remove once the admin page (#64) ships.
-
-
-@app.get("/health/data", dependencies=[Depends(require_session_or_service_token)], deprecated=True, tags=["system"])
-def health_data(conn: psycopg.Connection[object] = Depends(get_conn)) -> dict:
-    """Deprecated alias for ``GET /system/status``.
-
-    Job names are sourced from ``SCHEDULED_JOBS`` so this endpoint cannot
-    drift from the registry — both /health/data and /system/status report on
-    the same job set.
-    """
-    try:
-        report = get_system_health(conn, job_names=[job.name for job in SCHEDULED_JOBS])
-    except Exception as exc:
-        # Fixed-string detail; full exception text goes to logger only.
-        # See review-prevention-log entry on 5xx HTTPException leaks.
-        logger.exception("/health/data: failed to build system health report")
-        raise HTTPException(status_code=503, detail="health data unavailable") from exc
-
-    return {
-        "checked_at": report.checked_at.isoformat(),
-        "kill_switch": {
-            "active": report.kill_switch_active,
-            "detail": report.kill_switch_detail,
-        },
-        "layers": [
-            {
-                "layer": lh.layer,
-                "status": lh.status,
-                "latest": lh.latest.isoformat() if lh.latest else None,
-                "max_age_seconds": lh.max_age.total_seconds() if lh.max_age else None,
-                "age_seconds": lh.age.total_seconds() if lh.age else None,
-                "detail": lh.detail,
-            }
-            for lh in report.layers
-        ],
-        "jobs": [
-            {
-                "job_name": jh.job_name,
-                "last_status": jh.last_status,
-                "last_started_at": jh.last_started_at.isoformat() if jh.last_started_at else None,
-                "last_finished_at": jh.last_finished_at.isoformat() if jh.last_finished_at else None,
-                "detail": jh.detail,
-            }
-            for jh in report.jobs
-        ],
     }
 
 

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -6,7 +6,7 @@ Responsibilities:
   - Track job executions (start, finish, success/failure, row count).
   - Detect row-count spikes (broken-source indicator).
   - Manage the kill switch (activate / deactivate).
-  - Produce a unified system health report for the health endpoint.
+  - Produce per-layer and per-job health checks consumed by /system/status.
 
 Data layers monitored:
   - universe   — instruments.last_seen_at
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -142,15 +142,6 @@ class JobHealth:
     last_started_at: datetime | None = None
     last_finished_at: datetime | None = None
     detail: str = ""
-
-
-@dataclass
-class SystemHealth:
-    checked_at: datetime
-    layers: list[LayerHealth] = field(default_factory=list)
-    jobs: list[JobHealth] = field(default_factory=list)
-    kill_switch_active: bool = False
-    kill_switch_detail: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -634,43 +625,3 @@ def get_kill_switch_status(
             "reason": "kill_switch row missing — configuration corrupt",
         }
     return dict(row)
-
-
-# ---------------------------------------------------------------------------
-# Unified system health
-# ---------------------------------------------------------------------------
-
-
-def get_system_health(
-    conn: psycopg.Connection[Any],
-    job_names: list[str] | None = None,
-) -> SystemHealth:
-    """
-    Build a full system health report: layer staleness, job health, kill switch.
-
-    job_names: list of job names to check health for.  If None, only layer
-    staleness and kill switch are included.
-    """
-    now = _utcnow()
-
-    layers = check_all_layers(conn, now=now)
-
-    jobs: list[JobHealth] = []
-    if job_names:
-        jobs = [check_job_health(conn, name) for name in job_names]
-
-    ks = get_kill_switch_status(conn)
-
-    ks_detail = ""
-    if ks["is_active"]:
-        ks_detail = "kill switch active"
-        if ks.get("reason"):
-            ks_detail += f"; reason: {ks['reason']}"
-
-    return SystemHealth(
-        checked_at=now,
-        layers=layers,
-        jobs=jobs,
-        kill_switch_active=bool(ks["is_active"]),
-        kill_switch_detail=ks_detail,
-    )

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -136,8 +136,10 @@ class TestServiceTokenPath(_AuthTestBase):
             resp = client.get(path)
             assert resp.status_code == 401, f"{path} should require auth"
 
-    def test_health_data_requires_auth(self) -> None:
-        resp = client.get("/health/data")
+    def test_protected_endpoints_require_auth(self) -> None:
+        # /health/data retired in A.5 chunk 3 (#342). /system/status is
+        # the protected canary — same auth dependency.
+        resp = client.get("/system/status")
         assert resp.status_code == 401
 
 

--- a/tests/test_api_main.py
+++ b/tests/test_api_main.py
@@ -19,7 +19,6 @@ from fastapi.testclient import TestClient
 
 from app.db import get_conn
 from app.main import app
-from app.services.ops_monitor import SystemHealth
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -58,54 +57,6 @@ def _cleanup() -> None:
 app.dependency_overrides.setdefault(get_conn, _fallback_conn)
 
 client = TestClient(app)
-
-
-# ---------------------------------------------------------------------------
-# TestHealthData — proves pooled access for an existing main.py endpoint
-# ---------------------------------------------------------------------------
-
-
-class TestHealthData:
-    """GET /health/data — system health via pooled connection."""
-
-    def teardown_method(self) -> None:
-        _cleanup()
-
-    def test_returns_health_report_via_pooled_conn(self) -> None:
-        """The endpoint receives its connection from get_conn, not raw psycopg.connect."""
-        conn = _mock_conn()
-        _setup(conn)
-
-        report = SystemHealth(checked_at=_NOW, kill_switch_active=False, kill_switch_detail="")
-
-        with patch("app.main.get_system_health", return_value=report) as mock_health:
-            resp = client.get("/health/data")
-
-        assert resp.status_code == 200
-        body = resp.json()
-        assert body["kill_switch"]["active"] is False
-        assert body["layers"] == []
-        assert body["jobs"] == []
-
-        # Verify get_system_health was called with the injected mock connection
-        mock_health.assert_called_once()
-        call_conn = mock_health.call_args[0][0]
-        assert call_conn is conn
-
-    def test_service_error_returns_503_without_leaking_internals(self) -> None:
-        conn = _mock_conn()
-        _setup(conn)
-
-        secret_marker = "secret-table-name-do-not-leak"
-        with patch("app.main.get_system_health", side_effect=RuntimeError(secret_marker)):
-            resp = client.get("/health/data")
-
-        assert resp.status_code == 503
-        # Detail must be a fixed string; full exception text goes to
-        # logger.exception only. See review-prevention-log entry on
-        # internal exception text leaking into HTTP response bodies.
-        assert resp.json()["detail"] == "health data unavailable"
-        assert secret_marker not in resp.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ops_monitor.py
+++ b/tests/test_ops_monitor.py
@@ -9,7 +9,6 @@ Structure:
   - TestCheckJobHealth      — job health status
   - TestCheckRowCountSpike  — row-count spike detection
   - TestKillSwitch          — activate / deactivate / status
-  - TestGetSystemHealth     — unified health report
 
 Mock DB approach: same cursor/connection pattern as other test files.
 """
@@ -32,7 +31,6 @@ from app.services.ops_monitor import (
     check_row_count_spike,
     deactivate_kill_switch,
     get_kill_switch_status,
-    get_system_health,
     record_job_finish,
     record_job_skip,
     record_job_start,
@@ -643,86 +641,3 @@ class TestKillSwitch:
         status = get_kill_switch_status(conn)
         assert status["is_active"] is True
         assert "corrupt" in status["reason"]
-
-
-# ---------------------------------------------------------------------------
-# TestGetSystemHealth
-# ---------------------------------------------------------------------------
-
-
-class TestGetSystemHealth:
-    """Test unified health report."""
-
-    @patch("app.services.ops_monitor._utcnow", return_value=_NOW)
-    def test_report_includes_all_layers(self, mock_now: MagicMock) -> None:
-        # 8 layer cursors (all empty) + 1 kill switch cursor
-        cursors = [_make_cursor([{"latest": None}]) for _ in range(8)]
-        cursors.append(
-            _make_cursor(
-                [
-                    {
-                        "is_active": False,
-                        "activated_at": None,
-                        "activated_by": None,
-                        "reason": None,
-                    }
-                ]
-            )
-        )
-        conn = _make_conn(cursors)
-        report = get_system_health(conn)
-        assert len(report.layers) == 8
-        assert report.kill_switch_active is False
-
-    @patch("app.services.ops_monitor._utcnow", return_value=_NOW)
-    def test_report_includes_job_health(self, mock_now: MagicMock) -> None:
-        # 8 layer cursors + 1 job health cursor + 1 kill switch cursor
-        cursors = [_make_cursor([{"latest": None}]) for _ in range(8)]
-        cursors.append(
-            _make_cursor(
-                [
-                    {
-                        "status": "success",
-                        "started_at": _NOW,
-                        "finished_at": _NOW,
-                        "error_msg": None,
-                    }
-                ]
-            )
-        )
-        cursors.append(
-            _make_cursor(
-                [
-                    {
-                        "is_active": False,
-                        "activated_at": None,
-                        "activated_by": None,
-                        "reason": None,
-                    }
-                ]
-            )
-        )
-        conn = _make_conn(cursors)
-        report = get_system_health(conn, job_names=["test_job"])
-        assert len(report.jobs) == 1
-        assert report.jobs[0].last_status == "success"
-
-    @patch("app.services.ops_monitor._utcnow", return_value=_NOW)
-    def test_kill_switch_active_in_report(self, mock_now: MagicMock) -> None:
-        cursors = [_make_cursor([{"latest": None}]) for _ in range(8)]
-        cursors.append(
-            _make_cursor(
-                [
-                    {
-                        "is_active": True,
-                        "activated_at": _NOW,
-                        "activated_by": "ops",
-                        "reason": "emergency halt",
-                    }
-                ]
-            )
-        )
-        conn = _make_conn(cursors)
-        report = get_system_health(conn)
-        assert report.kill_switch_active is True
-        assert "emergency halt" in report.kill_switch_detail


### PR DESCRIPTION
## What

Deletes the deprecated \`/health/data\` endpoint + its backing \`SystemHealth\` dataclass + \`get_system_health\` function in \`ops_monitor.py\`. No callers remain after A.5 chunk 1 (\`ProblemsPanel\` migrated to \`/sync/layers/v2\`).

Also removes:
- \`SCHEDULED_JOBS\` import from \`app/main.py\` (was only used by the deleted handler)
- \`field\` import from \`ops_monitor.py\` (was only used by \`SystemHealth\`)

Scope-limited: \`/system/status\` + \`check_all_layers\` + \`LayerName\` / \`_STALENESS_THRESHOLDS\` etc. stay alive because Dashboard's \`SystemStatusPanel\` still consumes them. Full ops_monitor retirement tracked on #340.

## Test plan

- [x] pytest -x -q — 2138 passed, 1 skipped (all green)
- [x] ruff + format + pyright — clean
- [x] test_api_auth: \`test_health_data_requires_auth\` replaced with \`test_protected_endpoints_require_auth\` using \`/system/status\`
- [x] test_ops_monitor: \`TestGetSystemHealth\` class deleted (3 tests removed)
- [x] test_api_main: \`TestHealthData\` class deleted (2 tests removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)