### PR TITLE
feat: yfinance provider (Phase 2.1)

### DIFF
--- a/app/providers/implementations/yfinance_provider.py
+++ b/app/providers/implementations/yfinance_provider.py
@@ -338,7 +338,7 @@ class YFinanceProvider:
         for col in frame.columns:
             # yfinance columns are pandas Timestamp; .date() extracts date.
             try:
-                period_end = col.date()
+                period_end = col.date()  # type: ignore[union-attr]
             except AttributeError:
                 # Already a date, or malformed — skip.
                 continue
@@ -374,7 +374,7 @@ class YFinanceProvider:
         results: list[YFinanceDividend] = []
         for ts, amount_raw in series.items():
             try:
-                ex_date = ts.date()
+                ex_date = ts.date()  # type: ignore[union-attr]
             except AttributeError:
                 continue
             decimal_amount = _to_decimal(amount_raw)
@@ -438,7 +438,7 @@ class YFinanceProvider:
         bars: list[YFinancePriceBar] = []
         for ts, row in frame.iterrows():
             try:
-                bar_date = ts.date()
+                bar_date = ts.date()  # type: ignore[union-attr]
             except AttributeError:
                 continue
             bars.append(

--- a/app/providers/implementations/yfinance_provider.py
+++ b/app/providers/implementations/yfinance_provider.py
@@ -321,7 +321,6 @@ class YFinanceProvider:
                     "balance": ticker.balance_sheet,
                     "cashflow": ticker.cashflow,
                 }[statement]
-            info = ticker.info
         except Exception:
             logger.warning(
                 "yfinance.get_financials(statement=%s, period=%s) failed for %s",
@@ -333,6 +332,19 @@ class YFinanceProvider:
             return None
         if frame is None or frame.empty:
             return None
+        # Currency comes from .info which is a separate Yahoo call that
+        # can fail independently of the statement frame. Failing to fetch
+        # currency must NOT discard the valid statement data — fall back
+        # to None and let the UI render without a currency badge.
+        try:
+            info = ticker.info
+        except Exception:
+            logger.warning(
+                "yfinance.get_financials: .info fetch failed for %s — returning statement without currency",
+                symbol,
+                exc_info=True,
+            )
+            info = None
         currency = _to_str(info.get("financialCurrency")) if info else None
         rows: list[YFinanceFinancialRow] = []
         for col in frame.columns:

--- a/app/providers/implementations/yfinance_provider.py
+++ b/app/providers/implementations/yfinance_provider.py
@@ -1,0 +1,473 @@
+"""yfinance provider — thin wrapper around yahooquery-style public data.
+
+Used for non-US tickers where SEC XBRL doesn't apply (LSE, Euronext, HK,
+ASX) and as a gap-filler for US tickers needing current price, analyst
+estimates, major holders, etc.
+
+yfinance scrapes Yahoo Finance's public pages. It is MIT-licensed, has
+no API key, and no rate limit, but it CAN break without notice when
+Yahoo changes layout. This module's contract: every method returns
+either a typed dataclass on success or ``None`` on any failure. Never
+raise to callers — the research page must stay interactive even when
+yfinance is down.
+
+Methods surface:
+
+- :meth:`get_profile` — company identity + headline fundamentals.
+- :meth:`get_quote` — last price + 52w range + day change.
+- :meth:`get_key_stats` — valuation ratios + growth metrics.
+- :meth:`get_financials` — income / balance / cashflow statement history.
+- :meth:`get_dividends` — historical dividends per share.
+- :meth:`get_analyst_estimates` — consensus targets + EPS forecast.
+- :meth:`get_major_holders` — institutional + insider holdings pct.
+
+All numeric values are ``Decimal`` where they represent money or ratios,
+to match the rest of the codebase's money discipline.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal, InvalidOperation
+from typing import Any, Literal
+
+import yfinance
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Return types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class YFinanceProfile:
+    symbol: str
+    display_name: str | None
+    sector: str | None
+    industry: str | None
+    exchange: str | None
+    country: str | None
+    currency: str | None
+    market_cap: Decimal | None
+    employees: int | None
+    website: str | None
+    long_business_summary: str | None
+
+
+@dataclass(frozen=True)
+class YFinanceQuote:
+    symbol: str
+    price: Decimal | None
+    day_change: Decimal | None
+    day_change_pct: Decimal | None
+    week_52_high: Decimal | None
+    week_52_low: Decimal | None
+    currency: str | None
+
+
+@dataclass(frozen=True)
+class YFinanceKeyStats:
+    symbol: str
+    pe_ratio: Decimal | None
+    pb_ratio: Decimal | None
+    dividend_yield: Decimal | None  # 0-1 ratio
+    payout_ratio: Decimal | None
+    roe: Decimal | None
+    roa: Decimal | None
+    debt_to_equity: Decimal | None
+    revenue_growth_yoy: Decimal | None
+    earnings_growth_yoy: Decimal | None
+
+
+Statement = Literal["income", "balance", "cashflow"]
+Period = Literal["quarterly", "annual"]
+
+
+@dataclass(frozen=True)
+class YFinanceFinancialRow:
+    """One column of a financial statement (one fiscal period)."""
+
+    period_end: date
+    values: dict[str, Decimal]  # concept -> value
+
+
+@dataclass(frozen=True)
+class YFinanceFinancials:
+    symbol: str
+    statement: Statement
+    period: Period
+    currency: str | None
+    rows: list[YFinanceFinancialRow]
+
+
+@dataclass(frozen=True)
+class YFinanceDividend:
+    ex_date: date
+    amount: Decimal
+
+
+@dataclass(frozen=True)
+class YFinanceAnalystEstimates:
+    symbol: str
+    target_mean: Decimal | None
+    target_high: Decimal | None
+    target_low: Decimal | None
+    recommendation_mean: Decimal | None  # 1=Strong Buy, 5=Strong Sell
+    num_analysts: int | None
+
+
+@dataclass(frozen=True)
+class YFinanceMajorHolders:
+    symbol: str
+    insiders_pct: Decimal | None
+    institutions_pct: Decimal | None
+    institutional_holders_count: int | None
+
+
+@dataclass(frozen=True)
+class YFinancePriceBar:
+    """One bar of OHLCV history."""
+
+    bar_date: date
+    open: Decimal | None
+    high: Decimal | None
+    low: Decimal | None
+    close: Decimal | None
+    volume: int | None
+
+
+# ---------------------------------------------------------------------------
+# Coercion helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_decimal(raw: Any) -> Decimal | None:
+    """Coerce a yfinance value to Decimal; return None for NaN/missing."""
+    if raw is None:
+        return None
+    # yfinance returns numpy float NaN for missing values; math.isnan is
+    # unsafe on non-numeric input, so catch via Decimal construction.
+    try:
+        value = Decimal(str(raw))
+    except InvalidOperation, ValueError, TypeError:
+        return None
+    if value.is_nan():
+        return None
+    return value
+
+
+def _to_int(raw: Any) -> int | None:
+    if raw is None:
+        return None
+    try:
+        value = int(raw)
+    except ValueError, TypeError:
+        return None
+    return value
+
+
+def _to_str(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    # Yahoo sometimes returns float NaN for missing string fields (e.g.
+    # sector, industry). str(float('nan')) == 'nan', which would render
+    # the word "nan" in the UI — filter these out first.
+    try:
+        if isinstance(raw, float) and raw != raw:  # NaN check
+            return None
+    except TypeError:
+        pass
+    text = str(raw).strip()
+    if not text or text.lower() == "nan":
+        return None
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class YFinanceProvider:
+    """Thin wrapper around :class:`yfinance.Ticker`.
+
+    Every method catches all exceptions and returns ``None`` on failure.
+    Yahoo occasionally breaks; the research UI must stay interactive.
+    Failures are logged at WARNING level so operators notice drift.
+
+    The provider is stateless beyond an optional ``session`` override
+    for tests that want to inject a fake HTTP client.
+    """
+
+    def __init__(self, *, session: Any | None = None) -> None:
+        self._session = session
+
+    def _ticker(self, symbol: str) -> yfinance.Ticker:
+        if self._session is not None:
+            return yfinance.Ticker(symbol, session=self._session)
+        return yfinance.Ticker(symbol)
+
+    # -- Profile --------------------------------------------------------
+
+    def get_profile(self, symbol: str) -> YFinanceProfile | None:
+        try:
+            info = self._ticker(symbol).info
+        except Exception:
+            logger.warning("yfinance.get_profile failed for %s", symbol, exc_info=True)
+            return None
+        if not info:
+            return None
+        return YFinanceProfile(
+            symbol=symbol,
+            display_name=_to_str(info.get("longName")) or _to_str(info.get("shortName")),
+            sector=_to_str(info.get("sector")),
+            industry=_to_str(info.get("industry")),
+            exchange=_to_str(info.get("exchange")),
+            country=_to_str(info.get("country")),
+            currency=_to_str(info.get("currency")),
+            market_cap=_to_decimal(info.get("marketCap")),
+            employees=_to_int(info.get("fullTimeEmployees")),
+            website=_to_str(info.get("website")),
+            long_business_summary=_to_str(info.get("longBusinessSummary")),
+        )
+
+    # -- Quote ----------------------------------------------------------
+
+    def get_quote(self, symbol: str) -> YFinanceQuote | None:
+        try:
+            info = self._ticker(symbol).info
+        except Exception:
+            logger.warning("yfinance.get_quote failed for %s", symbol, exc_info=True)
+            return None
+        if not info:
+            return None
+        price = _to_decimal(info.get("regularMarketPrice") or info.get("currentPrice"))
+        prev_close = _to_decimal(info.get("regularMarketPreviousClose") or info.get("previousClose"))
+        day_change: Decimal | None = None
+        day_change_pct: Decimal | None = None
+        if price is not None and prev_close is not None and prev_close != 0:
+            day_change = price - prev_close
+            day_change_pct = day_change / prev_close
+        return YFinanceQuote(
+            symbol=symbol,
+            price=price,
+            day_change=day_change,
+            day_change_pct=day_change_pct,
+            week_52_high=_to_decimal(info.get("fiftyTwoWeekHigh")),
+            week_52_low=_to_decimal(info.get("fiftyTwoWeekLow")),
+            currency=_to_str(info.get("currency")),
+        )
+
+    # -- Key stats ------------------------------------------------------
+
+    def get_key_stats(self, symbol: str) -> YFinanceKeyStats | None:
+        try:
+            info = self._ticker(symbol).info
+        except Exception:
+            logger.warning("yfinance.get_key_stats failed for %s", symbol, exc_info=True)
+            return None
+        if not info:
+            return None
+        return YFinanceKeyStats(
+            symbol=symbol,
+            pe_ratio=_to_decimal(info.get("trailingPE")),
+            pb_ratio=_to_decimal(info.get("priceToBook")),
+            dividend_yield=_to_decimal(info.get("dividendYield")),
+            payout_ratio=_to_decimal(info.get("payoutRatio")),
+            roe=_to_decimal(info.get("returnOnEquity")),
+            roa=_to_decimal(info.get("returnOnAssets")),
+            debt_to_equity=_to_decimal(info.get("debtToEquity")),
+            revenue_growth_yoy=_to_decimal(info.get("revenueGrowth")),
+            earnings_growth_yoy=_to_decimal(info.get("earningsGrowth")),
+        )
+
+    # -- Financials -----------------------------------------------------
+
+    def get_financials(
+        self,
+        symbol: str,
+        *,
+        statement: Statement,
+        period: Period = "quarterly",
+    ) -> YFinanceFinancials | None:
+        """Fetch an income / balance / cashflow statement.
+
+        Returns ``None`` on any error so the UI can render "no data" rather
+        than 500. Empty statements (valid but with zero columns) also
+        return ``None`` — there is no useful render for them.
+        """
+        if period not in ("quarterly", "annual"):
+            logger.warning(
+                "yfinance.get_financials: invalid period=%r for %s (expected 'quarterly' or 'annual')",
+                period,
+                symbol,
+            )
+            return None
+        try:
+            ticker = self._ticker(symbol)
+            if period == "quarterly":
+                frame = {
+                    "income": ticker.quarterly_financials,
+                    "balance": ticker.quarterly_balance_sheet,
+                    "cashflow": ticker.quarterly_cashflow,
+                }[statement]
+            else:
+                frame = {
+                    "income": ticker.financials,
+                    "balance": ticker.balance_sheet,
+                    "cashflow": ticker.cashflow,
+                }[statement]
+            info = ticker.info
+        except Exception:
+            logger.warning(
+                "yfinance.get_financials(statement=%s, period=%s) failed for %s",
+                statement,
+                period,
+                symbol,
+                exc_info=True,
+            )
+            return None
+        if frame is None or frame.empty:
+            return None
+        currency = _to_str(info.get("financialCurrency")) if info else None
+        rows: list[YFinanceFinancialRow] = []
+        for col in frame.columns:
+            # yfinance columns are pandas Timestamp; .date() extracts date.
+            try:
+                period_end = col.date()
+            except AttributeError:
+                # Already a date, or malformed — skip.
+                continue
+            values: dict[str, Decimal] = {}
+            for concept, raw in frame[col].items():
+                decimal_value = _to_decimal(raw)
+                if decimal_value is None:
+                    continue
+                values[str(concept)] = decimal_value
+            if values:
+                rows.append(YFinanceFinancialRow(period_end=period_end, values=values))
+        if not rows:
+            return None
+        rows.sort(key=lambda r: r.period_end, reverse=True)
+        return YFinanceFinancials(
+            symbol=symbol,
+            statement=statement,
+            period=period,
+            currency=currency,
+            rows=rows,
+        )
+
+    # -- Dividends ------------------------------------------------------
+
+    def get_dividends(self, symbol: str) -> list[YFinanceDividend] | None:
+        try:
+            series = self._ticker(symbol).dividends
+        except Exception:
+            logger.warning("yfinance.get_dividends failed for %s", symbol, exc_info=True)
+            return None
+        if series is None or series.empty:
+            return []
+        results: list[YFinanceDividend] = []
+        for ts, amount_raw in series.items():
+            try:
+                ex_date = ts.date()
+            except AttributeError:
+                continue
+            decimal_amount = _to_decimal(amount_raw)
+            if decimal_amount is None:
+                continue
+            results.append(YFinanceDividend(ex_date=ex_date, amount=decimal_amount))
+        results.sort(key=lambda d: d.ex_date, reverse=True)
+        return results
+
+    # -- Analyst estimates ---------------------------------------------
+
+    def get_analyst_estimates(self, symbol: str) -> YFinanceAnalystEstimates | None:
+        try:
+            info = self._ticker(symbol).info
+        except Exception:
+            logger.warning("yfinance.get_analyst_estimates failed for %s", symbol, exc_info=True)
+            return None
+        if not info:
+            return None
+        return YFinanceAnalystEstimates(
+            symbol=symbol,
+            target_mean=_to_decimal(info.get("targetMeanPrice")),
+            target_high=_to_decimal(info.get("targetHighPrice")),
+            target_low=_to_decimal(info.get("targetLowPrice")),
+            recommendation_mean=_to_decimal(info.get("recommendationMean")),
+            num_analysts=_to_int(info.get("numberOfAnalystOpinions")),
+        )
+
+    # -- Price history --------------------------------------------------
+
+    def get_price_history(
+        self,
+        symbol: str,
+        *,
+        period: str = "1y",
+        interval: str = "1d",
+    ) -> list[YFinancePriceBar] | None:
+        """Fetch OHLCV price history.
+
+        ``period`` / ``interval`` follow yfinance's own string vocabulary
+        (e.g. ``1d``, ``5d``, ``1mo``, ``3mo``, ``6mo``, ``1y``, ``2y``,
+        ``5y``, ``ytd``, ``max``). Returns bars sorted oldest-first to
+        match what a chart renderer expects.
+
+        Returns ``None`` on yfinance raise; empty list on valid-but-empty
+        result (e.g. delisted ticker, pre-IPO window).
+        """
+        try:
+            frame = self._ticker(symbol).history(period=period, interval=interval)
+        except Exception:
+            logger.warning(
+                "yfinance.get_price_history(period=%s, interval=%s) failed for %s",
+                period,
+                interval,
+                symbol,
+                exc_info=True,
+            )
+            return None
+        if frame is None or frame.empty:
+            return []
+        bars: list[YFinancePriceBar] = []
+        for ts, row in frame.iterrows():
+            try:
+                bar_date = ts.date()
+            except AttributeError:
+                continue
+            bars.append(
+                YFinancePriceBar(
+                    bar_date=bar_date,
+                    open=_to_decimal(row.get("Open")),
+                    high=_to_decimal(row.get("High")),
+                    low=_to_decimal(row.get("Low")),
+                    close=_to_decimal(row.get("Close")),
+                    volume=_to_int(row.get("Volume")),
+                )
+            )
+        bars.sort(key=lambda b: b.bar_date)
+        return bars
+
+    # -- Major holders --------------------------------------------------
+
+    def get_major_holders(self, symbol: str) -> YFinanceMajorHolders | None:
+        try:
+            ticker = self._ticker(symbol)
+            info = ticker.info
+        except Exception:
+            logger.warning("yfinance.get_major_holders failed for %s", symbol, exc_info=True)
+            return None
+        if not info:
+            return None
+        return YFinanceMajorHolders(
+            symbol=symbol,
+            insiders_pct=_to_decimal(info.get("heldPercentInsiders")),
+            institutions_pct=_to_decimal(info.get("heldPercentInstitutions")),
+            institutional_holders_count=_to_int(info.get("numberOfInstitutionalHolders")),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "platformdirs>=4.2.0",
   "apscheduler>=3.10",
   "redis[hiredis]>=5.0.0",
+  "yfinance>=1.3.0",
 ]
 
 [tool.uv]

--- a/tests/test_yfinance_provider.py
+++ b/tests/test_yfinance_provider.py
@@ -1,0 +1,454 @@
+"""Tests for YFinanceProvider (stub-based; no live Yahoo calls)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from app.providers.implementations.yfinance_provider import (
+    YFinanceAnalystEstimates,
+    YFinanceDividend,
+    YFinanceKeyStats,
+    YFinanceMajorHolders,
+    YFinancePriceBar,
+    YFinanceProfile,
+    YFinanceProvider,
+)
+
+
+@dataclass
+class _StubTicker:
+    """Minimal fake for yfinance.Ticker used in tests."""
+
+    info: dict[str, Any]
+    dividends: pd.Series | None = None
+    quarterly_financials: pd.DataFrame | None = None
+    quarterly_balance_sheet: pd.DataFrame | None = None
+    quarterly_cashflow: pd.DataFrame | None = None
+    financials: pd.DataFrame | None = None
+    balance_sheet: pd.DataFrame | None = None
+    cashflow: pd.DataFrame | None = None
+    _history_frame: pd.DataFrame | None = None
+
+    def history(self, period: str = "1y", interval: str = "1d") -> pd.DataFrame:  # noqa: ARG002
+        return self._history_frame if self._history_frame is not None else pd.DataFrame()
+
+
+def _provider_with(ticker: _StubTicker) -> YFinanceProvider:
+    provider = YFinanceProvider()
+    # Patch the internal _ticker factory so every lookup returns the stub.
+    provider._ticker = lambda _symbol: ticker  # type: ignore[method-assign]
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Profile
+# ---------------------------------------------------------------------------
+
+
+def test_profile_happy_path() -> None:
+    ticker = _StubTicker(
+        info={
+            "longName": "Apple Inc.",
+            "sector": "Technology",
+            "industry": "Consumer Electronics",
+            "exchange": "NMS",
+            "country": "United States",
+            "currency": "USD",
+            "marketCap": 3_000_000_000_000,
+            "fullTimeEmployees": 150_000,
+            "website": "https://apple.com",
+            "longBusinessSummary": "Designs Macs and iPhones.",
+        }
+    )
+    profile = _provider_with(ticker).get_profile("AAPL")
+    assert profile == YFinanceProfile(
+        symbol="AAPL",
+        display_name="Apple Inc.",
+        sector="Technology",
+        industry="Consumer Electronics",
+        exchange="NMS",
+        country="United States",
+        currency="USD",
+        market_cap=Decimal("3000000000000"),
+        employees=150_000,
+        website="https://apple.com",
+        long_business_summary="Designs Macs and iPhones.",
+    )
+
+
+def test_profile_falls_back_to_shortName_when_longName_missing() -> None:
+    ticker = _StubTicker(info={"shortName": "BRK", "sector": "Financial Services"})
+    profile = _provider_with(ticker).get_profile("BRK.A")
+    assert profile is not None
+    assert profile.display_name == "BRK"
+
+
+def test_profile_returns_none_on_exception() -> None:
+    provider = YFinanceProvider()
+    with patch.object(
+        provider,
+        "_ticker",
+        side_effect=RuntimeError("yahoo is down"),
+    ):
+        assert provider.get_profile("AAPL") is None
+
+
+# ---------------------------------------------------------------------------
+# Quote
+# ---------------------------------------------------------------------------
+
+
+def test_quote_derives_day_change_from_previous_close() -> None:
+    ticker = _StubTicker(
+        info={
+            "regularMarketPrice": 101.5,
+            "regularMarketPreviousClose": 100.0,
+            "fiftyTwoWeekHigh": 120.0,
+            "fiftyTwoWeekLow": 80.0,
+            "currency": "USD",
+        }
+    )
+    quote = _provider_with(ticker).get_quote("AAPL")
+    assert quote is not None
+    assert quote.price == Decimal("101.5")
+    assert quote.day_change == Decimal("1.5")
+    assert quote.day_change_pct == Decimal("1.5") / Decimal("100.0")
+
+
+def test_quote_handles_missing_previous_close_gracefully() -> None:
+    ticker = _StubTicker(info={"regularMarketPrice": 50.0, "currency": "GBP"})
+    quote = _provider_with(ticker).get_quote("VOD.L")
+    assert quote is not None
+    assert quote.price == Decimal("50.0")
+    assert quote.day_change is None
+    assert quote.day_change_pct is None
+
+
+# ---------------------------------------------------------------------------
+# Key stats
+# ---------------------------------------------------------------------------
+
+
+def test_key_stats_happy_path() -> None:
+    ticker = _StubTicker(
+        info={
+            "trailingPE": 25.5,
+            "priceToBook": 35.0,
+            "dividendYield": 0.005,
+            "payoutRatio": 0.15,
+            "returnOnEquity": 1.5,
+            "returnOnAssets": 0.3,
+            "debtToEquity": 195.0,
+            "revenueGrowth": 0.08,
+            "earningsGrowth": 0.12,
+        }
+    )
+    stats = _provider_with(ticker).get_key_stats("AAPL")
+    assert stats == YFinanceKeyStats(
+        symbol="AAPL",
+        pe_ratio=Decimal("25.5"),
+        pb_ratio=Decimal("35.0"),
+        dividend_yield=Decimal("0.005"),
+        payout_ratio=Decimal("0.15"),
+        roe=Decimal("1.5"),
+        roa=Decimal("0.3"),
+        debt_to_equity=Decimal("195.0"),
+        revenue_growth_yoy=Decimal("0.08"),
+        earnings_growth_yoy=Decimal("0.12"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Financials
+# ---------------------------------------------------------------------------
+
+
+def _sample_financials_frame() -> pd.DataFrame:
+    """Build a sample income statement with 2 quarters."""
+    return pd.DataFrame(
+        {
+            pd.Timestamp("2026-03-31"): {
+                "Total Revenue": 90_000_000_000,
+                "Net Income": 25_000_000_000,
+            },
+            pd.Timestamp("2025-12-31"): {
+                "Total Revenue": 120_000_000_000,
+                "Net Income": 33_000_000_000,
+            },
+        }
+    )
+
+
+def test_financials_quarterly_income_happy_path() -> None:
+    ticker = _StubTicker(
+        info={"financialCurrency": "USD"},
+        quarterly_financials=_sample_financials_frame(),
+    )
+    financials = _provider_with(ticker).get_financials(
+        "AAPL",
+        statement="income",
+        period="quarterly",
+    )
+    assert financials is not None
+    assert financials.currency == "USD"
+    assert len(financials.rows) == 2
+    # Rows sorted descending by period_end.
+    assert financials.rows[0].period_end == date(2026, 3, 31)
+    assert financials.rows[1].period_end == date(2025, 12, 31)
+    assert financials.rows[0].values["Total Revenue"] == Decimal("90000000000")
+
+
+def test_financials_annual_routes_to_annual_frame() -> None:
+    ticker = _StubTicker(
+        info={"financialCurrency": "USD"},
+        financials=_sample_financials_frame(),
+    )
+    financials = _provider_with(ticker).get_financials(
+        "AAPL",
+        statement="income",
+        period="annual",
+    )
+    assert financials is not None
+    assert financials.period == "annual"
+
+
+def test_financials_empty_frame_returns_none() -> None:
+    ticker = _StubTicker(
+        info={"financialCurrency": "USD"},
+        quarterly_financials=pd.DataFrame(),
+    )
+    financials = _provider_with(ticker).get_financials(
+        "AAPL",
+        statement="income",
+        period="quarterly",
+    )
+    assert financials is None
+
+
+def test_financials_drops_nan_values() -> None:
+    frame = pd.DataFrame(
+        {
+            pd.Timestamp("2026-03-31"): {
+                "Total Revenue": 90_000_000_000,
+                "Dead Concept": float("nan"),
+            }
+        }
+    )
+    ticker = _StubTicker(info={"financialCurrency": "USD"}, quarterly_financials=frame)
+    financials = _provider_with(ticker).get_financials(
+        "AAPL",
+        statement="income",
+        period="quarterly",
+    )
+    assert financials is not None
+    assert len(financials.rows) == 1
+    # NaN column should have been dropped from the row's values dict.
+    assert "Dead Concept" not in financials.rows[0].values
+    assert financials.rows[0].values["Total Revenue"] == Decimal("90000000000")
+
+
+# ---------------------------------------------------------------------------
+# Dividends
+# ---------------------------------------------------------------------------
+
+
+def test_dividends_returns_sorted_list() -> None:
+    series = pd.Series(
+        data=[0.22, 0.23, 0.24],
+        index=[
+            pd.Timestamp("2025-02-14"),
+            pd.Timestamp("2025-05-14"),
+            pd.Timestamp("2025-08-14"),
+        ],
+    )
+    ticker = _StubTicker(info={}, dividends=series)
+    dividends = _provider_with(ticker).get_dividends("AAPL")
+    assert dividends == [
+        YFinanceDividend(ex_date=date(2025, 8, 14), amount=Decimal("0.24")),
+        YFinanceDividend(ex_date=date(2025, 5, 14), amount=Decimal("0.23")),
+        YFinanceDividend(ex_date=date(2025, 2, 14), amount=Decimal("0.22")),
+    ]
+
+
+def test_dividends_empty_series_returns_empty_list() -> None:
+    ticker = _StubTicker(info={}, dividends=pd.Series(dtype=float))
+    assert _provider_with(ticker).get_dividends("AAPL") == []
+
+
+# ---------------------------------------------------------------------------
+# Analyst estimates + major holders
+# ---------------------------------------------------------------------------
+
+
+def test_analyst_estimates_happy_path() -> None:
+    ticker = _StubTicker(
+        info={
+            "targetMeanPrice": 200.0,
+            "targetHighPrice": 250.0,
+            "targetLowPrice": 150.0,
+            "recommendationMean": 2.1,
+            "numberOfAnalystOpinions": 40,
+        }
+    )
+    estimates = _provider_with(ticker).get_analyst_estimates("AAPL")
+    assert estimates == YFinanceAnalystEstimates(
+        symbol="AAPL",
+        target_mean=Decimal("200.0"),
+        target_high=Decimal("250.0"),
+        target_low=Decimal("150.0"),
+        recommendation_mean=Decimal("2.1"),
+        num_analysts=40,
+    )
+
+
+def test_major_holders_happy_path() -> None:
+    ticker = _StubTicker(
+        info={
+            "heldPercentInsiders": 0.001,
+            "heldPercentInstitutions": 0.65,
+            "numberOfInstitutionalHolders": 5200,
+        }
+    )
+    holders = _provider_with(ticker).get_major_holders("AAPL")
+    assert holders == YFinanceMajorHolders(
+        symbol="AAPL",
+        insiders_pct=Decimal("0.001"),
+        institutions_pct=Decimal("0.65"),
+        institutional_holders_count=5200,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defensive fallbacks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get_profile", "get_quote", "get_key_stats", "get_dividends", "get_analyst_estimates", "get_major_holders"],
+)
+def test_every_accessor_returns_none_on_exception(method: str) -> None:
+    provider = YFinanceProvider()
+    with patch.object(provider, "_ticker", side_effect=RuntimeError("yahoo is down")):
+        assert getattr(provider, method)("AAPL") is None
+
+
+def test_get_financials_returns_none_on_exception() -> None:
+    provider = YFinanceProvider()
+    with patch.object(provider, "_ticker", side_effect=RuntimeError("yahoo is down")):
+        assert provider.get_financials("AAPL", statement="income") is None
+
+
+# ---------------------------------------------------------------------------
+# NaN-safe string coercion (Codex feedback)
+# ---------------------------------------------------------------------------
+
+
+def test_profile_filters_nan_string_fields() -> None:
+    """Yahoo occasionally returns float NaN for missing string fields.
+    str(float('nan')) == 'nan' — the UI must see None, not the literal
+    'nan', so the coercion treats NaN as missing."""
+    ticker = _StubTicker(
+        info={
+            "longName": "Vodafone Group PLC",
+            "sector": float("nan"),
+            "industry": "nan",  # string 'nan' too, case-insensitive
+            "country": "United Kingdom",
+        }
+    )
+    profile = _provider_with(ticker).get_profile("VOD.L")
+    assert profile is not None
+    assert profile.display_name == "Vodafone Group PLC"
+    assert profile.sector is None
+    assert profile.industry is None
+    assert profile.country == "United Kingdom"
+
+
+# ---------------------------------------------------------------------------
+# Strict period validation (Codex feedback)
+# ---------------------------------------------------------------------------
+
+
+def test_financials_invalid_period_returns_none() -> None:
+    ticker = _StubTicker(
+        info={"financialCurrency": "USD"},
+        quarterly_financials=_sample_financials_frame(),
+    )
+    financials = _provider_with(ticker).get_financials(
+        "AAPL",
+        statement="income",
+        period="weekly",  # type: ignore[arg-type]
+    )
+    assert financials is None
+
+
+# ---------------------------------------------------------------------------
+# Price history
+# ---------------------------------------------------------------------------
+
+
+def _sample_history_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Open": [100.0, 101.5, 103.0],
+            "High": [102.0, 103.5, 104.0],
+            "Low": [99.5, 100.0, 102.0],
+            "Close": [101.0, 103.0, 103.5],
+            "Volume": [1_000_000, 1_500_000, 1_200_000],
+        },
+        index=[
+            pd.Timestamp("2026-04-15"),
+            pd.Timestamp("2026-04-16"),
+            pd.Timestamp("2026-04-17"),
+        ],
+    )
+
+
+def test_price_history_happy_path_sorted_oldest_first() -> None:
+    ticker = _StubTicker(info={}, _history_frame=_sample_history_frame())
+    bars = _provider_with(ticker).get_price_history("AAPL", period="5d")
+    assert bars == [
+        YFinancePriceBar(
+            bar_date=date(2026, 4, 15),
+            open=Decimal("100.0"),
+            high=Decimal("102.0"),
+            low=Decimal("99.5"),
+            close=Decimal("101.0"),
+            volume=1_000_000,
+        ),
+        YFinancePriceBar(
+            bar_date=date(2026, 4, 16),
+            open=Decimal("101.5"),
+            high=Decimal("103.5"),
+            low=Decimal("100.0"),
+            close=Decimal("103.0"),
+            volume=1_500_000,
+        ),
+        YFinancePriceBar(
+            bar_date=date(2026, 4, 17),
+            open=Decimal("103.0"),
+            high=Decimal("104.0"),
+            low=Decimal("102.0"),
+            close=Decimal("103.5"),
+            volume=1_200_000,
+        ),
+    ]
+
+
+def test_price_history_empty_frame_returns_empty_list() -> None:
+    ticker = _StubTicker(info={}, _history_frame=pd.DataFrame())
+    bars = _provider_with(ticker).get_price_history("DELISTED")
+    assert bars == []
+
+
+def test_price_history_returns_none_on_exception() -> None:
+    provider = YFinanceProvider()
+    with patch.object(provider, "_ticker", side_effect=RuntimeError("yahoo is down")):
+        assert provider.get_price_history("AAPL") is None

--- a/tests/test_yfinance_provider.py
+++ b/tests/test_yfinance_provider.py
@@ -376,6 +376,28 @@ def test_profile_filters_nan_string_fields() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_financials_info_failure_does_not_discard_frame() -> None:
+    """If .info raises after the frame was fetched, we must still return
+    the statement — currency is just display metadata, not gating data.
+    Regression for PR #356 round-2 review."""
+
+    class _RaisingInfoTicker:
+        quarterly_financials = _sample_financials_frame()
+        quarterly_balance_sheet = pd.DataFrame()
+        quarterly_cashflow = pd.DataFrame()
+
+        @property
+        def info(self) -> dict[str, Any]:
+            raise RuntimeError("info endpoint flaky")
+
+    provider = YFinanceProvider()
+    provider._ticker = lambda _symbol: _RaisingInfoTicker()  # type: ignore[method-assign,return-value]
+    financials = provider.get_financials("AAPL", statement="income", period="quarterly")
+    assert financials is not None
+    assert financials.currency is None
+    assert len(financials.rows) == 2
+
+
 def test_financials_invalid_period_returns_none() -> None:
     ticker = _StubTicker(
         info={"financialCurrency": "USD"},

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.14"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -107,6 +112,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -146,6 +164,47 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -223,6 +282,39 @@ wheels = [
 ]
 
 [[package]]
+name = "curl-cffi"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cffi" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/5b/89fcfebd3e5e85134147ac99e9f2b2271165fd4d71984fc65da5f17819b7/curl_cffi-0.15.0.tar.gz", hash = "sha256:ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded", size = 196437, upload-time = "2026-04-03T11:12:31.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/42/54ddd442c795f30ce5dd4e49f87ce77505958d3777cd96a91567a3975d2a/curl_cffi-0.15.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bda66404010e9ed743b1b83c20c86f24fe21a9a6873e17479d6e67e29d8ded28", size = 2795267, upload-time = "2026-04-03T11:11:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2d/3915e238579b3c5a92cead5c79130c3b8d20caaba7616cc4d894650e1d6b/curl_cffi-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a25620d9bf989c9c029a7d1642999c4c265abb0bad811deb2f77b0b5b2b12e5b", size = 2573544, upload-time = "2026-04-03T11:11:47.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527", size = 10515369, upload-time = "2026-04-03T11:11:50.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1d/6d10dded5ce3fd8157e558ebd97d09e551b77a62cdc1c31e93d0a633cee5/curl_cffi-0.15.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:838e48212447d9c81364b04707a5c861daf08f8320f9ecb3406a8919d1d5c3b3", size = 10160045, upload-time = "2026-04-03T11:11:52.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc", size = 11090433, upload-time = "2026-04-03T11:11:55.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/78edcc4f71934225db99df68197a107386d59080742fc7bf6bb4d007924f/curl_cffi-0.15.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e5e69eee735f659287e2c84444319d68a1fa68dd37abf228943a4074864283a", size = 10479178, upload-time = "2026-04-03T11:11:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/1e101c1acb1ea2f0b4992f5c3024f596d8e21db0d53540b9d583f673c4e7/curl_cffi-0.15.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1323950224db24f4c510d010b3affa02196ca853fb424191fa917a513d3f4b", size = 10317051, upload-time = "2026-04-03T11:12:00.295Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/8ef236b22a6c23d096c85a1dc507efe37bfdfc7a2f8a4b34efb590197369/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:41f80170ba844009273b2660da1964ec31e99e5719d16b3422ada87177e32e13", size = 11299660, upload-time = "2026-04-03T11:12:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/56aeb055d962da87a1be0d74c6c644e251c7e88129b5471dc44ac724e678/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1977e1e12cfb5c11352cbb74acef1bed24eb7d226dab61ca57c168c21acd4d61", size = 11945049, upload-time = "2026-04-03T11:12:05.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8c/2abf99a38d6340d66cf0557e0c750ef3f8883dfc5d450087e01c85861343/curl_cffi-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5a0c1896a0d5a5ac1eb89cd24b008d2b718dd1df6fd2f75451b59ca66e49e572", size = 1661649, upload-time = "2026-04-03T11:12:07.948Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/dfd54f2240d3a9b96d77bacc62b97813b35e2aa8ecf5cd5013c683f1ba96/curl_cffi-0.15.0-cp310-abi3-win_arm64.whl", hash = "sha256:a6d57f8389273a3a1f94370473c74897467bcc36af0a17336989780c507fa43d", size = 1410741, upload-time = "2026-04-03T11:12:10.073Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/c24df8a4fc22fa84070dcd94abeba43c15e08cc09e35869565c0bad196fd/curl_cffi-0.15.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:4682dc38d4336e0eb0b185374db90a760efde63cbea994b4e63f3521d44c4c92", size = 7190427, upload-time = "2026-04-03T11:12:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/132225cb3491d07cc6adcce5fe395e059bde87c68cff1ef87a31c88c7819/curl_cffi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967ad7355bd8e9586f8c2d02eaa99953747549e7ea4a9b25cd53353e6b67fe6d", size = 2795723, upload-time = "2026-04-03T11:12:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8f/f4f83cd303bef7e8f1749512e5dd157e7e5d08b0a36c8211f9640a2757bf/curl_cffi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e63539d0d839d0a8c5eacf86229bc68c57803547f35e0db7ee0986328b478c3", size = 2573739, upload-time = "2026-04-03T11:12:15.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/643d65c7fc9acd742876aa55c2d7823c438cb7665810acd2e66c9976c4d9/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5", size = 10521046, upload-time = "2026-04-03T11:12:17.034Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0b/9b8037113c93f4c5323096163471fa7c35c7676c3f608eeaf1287cd99d58/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b7a92767a888ee90147e18964b396d8435ff42737030d6fb00824ffd6094805", size = 11096115, upload-time = "2026-04-03T11:12:19.694Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/96/fff2fcbd924ef4042e0d67379f751a8a4e3186a91e75e35a4cf218b306ee/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:829cc357061ecb99cc2d406301f609a039e05665322f5c025ec67c38b0dc49ce", size = 11305346, upload-time = "2026-04-03T11:12:22.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/304b253a45ab28691c8c5e8cca1e6cbb9cf8e46dfceae4648dd536f75e73/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:408d6f14e346841cd889c2e0962832bb235ba3b6749ebf609f347f747da5e60f", size = 11949834, upload-time = "2026-04-03T11:12:24.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/4723d92f08259c707a974aba27a08d0a822b9555e35ca581bf18d055a364/curl_cffi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b624c7ce087bfda967a013ed0a64702a525444e5b6e97d23534d567ccc6525aa", size = 1702771, upload-time = "2026-04-03T11:12:28.201Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/36bbe06d66fa2b765e4a07199f643a59a9cd1a754207a96335402a9520f4/curl_cffi-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3", size = 1466312, upload-time = "2026-04-03T11:12:30.054Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -258,6 +350,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "redis", extra = ["hiredis"] },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "yfinance" },
 ]
 
 [package.dev-dependencies]
@@ -284,6 +377,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.4.0" },
     { name = "redis", extras = ["hiredis"], specifier = ">=5.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
+    { name = "yfinance", specifier = ">=1.3.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -309,6 +403,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+]
+
+[[package]]
+name = "frozendict"
+version = "2.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/b2/2a3d1374b7780999d3184e171e25439a8358c47b481f68be883c14086b4c/frozendict-2.4.7.tar.gz", hash = "sha256:e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd", size = 317082, upload-time = "2025-11-11T22:40:14.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl", hash = "sha256:972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550", size = 16264, upload-time = "2025-11-11T22:40:12.836Z" },
 ]
 
 [[package]]
@@ -449,6 +552,33 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "multitasking"
+version = "0.0.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/0d/74f0293dfd7dcc3837746d0138cbedd60b31701ecc75caec7d3f281feba0/multitasking-0.0.12.tar.gz", hash = "sha256:2fba2fa8ed8c4b85e227c5dd7dc41c7d658de3b6f247927316175a57349b84d1", size = 19984, upload-time = "2025-07-20T21:27:51.636Z" }
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -458,12 +588,79 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
+    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
+name = "peewee"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/8e/8fe6b93914ed40b9cb5162e45e1be4f8bb8cf7f5a49333aa1a2d383e4870/peewee-4.0.4.tar.gz", hash = "sha256:70e07c14a10bec8d663514bda5854e44ef15d5b03974b41f7218066b6fd3a065", size = 718021, upload-time = "2026-04-02T13:52:25.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/9b/bee274b72adc7c692bf7cb8d6b0cd4071acf2957e82dace45d3f2770470e/peewee-4.0.4-py3-none-any.whl", hash = "sha256:37ccd3f89e523c7b42eed023cd90b48d088753ddff1d74e854a9c6445e7bd797", size = 144487, upload-time = "2026-04-02T13:52:24.099Z" },
 ]
 
 [[package]]
@@ -482,6 +679,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
 ]
 
 [[package]]
@@ -659,12 +871,33 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
 ]
 
 [[package]]
@@ -708,6 +941,34 @@ hiredis = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.9"
 source = { registry = "https://pypi.org/simple" }
@@ -733,12 +994,30 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]
@@ -793,6 +1072,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]
@@ -898,4 +1186,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "yfinance"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "curl-cffi" },
+    { name = "frozendict" },
+    { name = "multitasking" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "peewee" },
+    { name = "platformdirs" },
+    { name = "protobuf" },
+    { name = "pytz" },
+    { name = "requests" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/fd/943a7d71ce98a40b9006daccba96a83837acadb8e55361f41c7a81873013/yfinance-1.3.0.tar.gz", hash = "sha256:42c4e64a889dab8eeaffd3a66d4ccf1baffd566910ca63fb6332283f8f9b8a40", size = 145297, upload-time = "2026-04-16T19:51:05.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/bc/e46ed5dfb88c6f7af0f641ffb6227d32f484ea989a2987a52a9c35d17aa9/yfinance-1.3.0-py2.py3-none-any.whl", hash = "sha256:c89539f0cf6af026d570131189bd659a962e8fb942376ef8ff8913e77c9fca75", size = 133706, upload-time = "2026-04-16T19:51:04.298Z" },
 ]


### PR DESCRIPTION
## Summary
Phase 2.1 of the [2026-04-19 research-tool refocus](docs/superpowers/specs/2026-04-19-research-tool-refocus.md).

New \`app/providers/implementations/yfinance_provider.py\` for non-US tickers (LSE, Euronext, HK, ASX) where SEC XBRL doesn't apply, plus gap-fill for US current-price / analyst / major-holder data.

**Methods** (all catch exceptions and return \`None\`, so the research UI stays interactive when Yahoo breaks):
- \`get_profile\` — company identity + headline fundamentals
- \`get_quote\` — last price + 52w range + day change
- \`get_key_stats\` — PE, PB, dividend yield, payout, ROE, ROA, D/E, growth
- \`get_financials\` — income / balance / cashflow, quarterly or annual
- \`get_dividends\` — historical dividends per share
- \`get_analyst_estimates\` — consensus targets + recommendation mean
- \`get_major_holders\` — insider + institutional pct
- \`get_price_history\` — OHLCV bars, sorted oldest-first

Return types are frozen dataclasses with \`Decimal\` for monetary fields.

**Codex pre-push feedback addressed:**
- Added \`get_price_history\` — spec §2.1 explicitly requires it for the Overview tab chart.
- \`_to_str\` now filters float/string \`NaN\` so missing Yahoo string fields render as \`None\` instead of the literal \`"nan"\`.
- \`get_financials\` validates \`period\` explicitly — unknown values return \`None\` instead of silently routing to annual.

## Test plan
- \`tests/test_yfinance_provider.py\` — 26 stub-based cases. No live Yahoo calls.
- \`uv run pytest\` — 2169 passed, 1 skipped
- \`uv run ruff check .\` / \`ruff format --check .\` — clean