### PR TITLE
feat: GET /instruments/{symbol}/summary (Phase 2.2)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -12,6 +12,7 @@ No writes. No schema changes.
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 
 import psycopg
 import psycopg.rows
@@ -19,8 +20,19 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.db import get_conn
+from app.providers.implementations.yfinance_provider import YFinanceProvider
 
 router = APIRouter(prefix="/instruments", tags=["instruments"])
+
+
+def get_yfinance_provider() -> YFinanceProvider:
+    """FastAPI dependency: constructs a fresh YFinanceProvider per request.
+
+    The provider is stateless, so there is no pooling concern. Tests
+    override this via ``app.dependency_overrides`` to inject a stub.
+    """
+    return YFinanceProvider()
+
 
 # ---------------------------------------------------------------------------
 # Response models
@@ -68,6 +80,60 @@ class InstrumentListResponse(BaseModel):
     total: int
     offset: int
     limit: int
+
+
+class InstrumentIdentity(BaseModel):
+    symbol: str
+    display_name: str | None
+    sector: str | None
+    industry: str | None
+    exchange: str | None
+    country: str | None
+    currency: str | None
+    market_cap: Decimal | None
+
+
+class InstrumentPrice(BaseModel):
+    current: Decimal | None
+    day_change: Decimal | None
+    day_change_pct: Decimal | None
+    week_52_high: Decimal | None
+    week_52_low: Decimal | None
+    currency: str | None
+
+
+class InstrumentKeyStats(BaseModel):
+    pe_ratio: Decimal | None
+    pb_ratio: Decimal | None
+    dividend_yield: Decimal | None
+    payout_ratio: Decimal | None
+    roe: Decimal | None
+    roa: Decimal | None
+    debt_to_equity: Decimal | None
+    revenue_growth_yoy: Decimal | None
+    earnings_growth_yoy: Decimal | None
+
+
+class InstrumentSummary(BaseModel):
+    """Per-ticker research summary (Phase 2.2).
+
+    Identity comes from the local ``instruments`` row; price + key stats
+    come from yfinance. All leaf fields are nullable so the UI can render
+    partial data when a provider degrades.
+
+    ``source`` reports which provider populated each section so the
+    future-spec per-field attribution (SEC EDGAR / Finnhub / yfinance)
+    has a landing spot — right now everything non-identity is yfinance,
+    so the map is simple; phase 2.3 will expand it.
+    """
+
+    instrument_id: int
+    is_tradable: bool
+    coverage_tier: int | None
+    identity: InstrumentIdentity
+    price: InstrumentPrice | None
+    key_stats: InstrumentKeyStats | None
+    source: dict[str, str]
 
 
 class InstrumentDetail(BaseModel):
@@ -202,6 +268,107 @@ def list_instruments(
     ]
 
     return InstrumentListResponse(items=items, total=total, offset=offset, limit=limit)
+
+
+@router.get("/{symbol}/summary", response_model=InstrumentSummary)
+def get_instrument_summary(
+    symbol: str,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+    yfinance_provider: YFinanceProvider = Depends(get_yfinance_provider),
+) -> InstrumentSummary:
+    """Per-ticker research summary (Phase 2.2 of the 2026-04-19 refocus).
+
+    Merges local identity/tier data with yfinance-sourced price + key
+    stats. A missing symbol returns 404. yfinance failures return null
+    sections rather than 500 — the UI renders what it has.
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    lookup_sql = """
+        SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
+               i.currency, i.sector, i.industry, i.country,
+               i.is_tradable, c.coverage_tier
+        FROM instruments i
+        LEFT JOIN coverage c USING (instrument_id)
+        WHERE UPPER(i.symbol) = %(symbol)s
+        LIMIT 1
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(lookup_sql, {"symbol": symbol_clean})
+        row = cur.fetchone()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    # One yfinance .info call instead of three — Codex review caught that
+    # get_profile / get_quote / get_key_stats each triggered their own
+    # network fetch. get_snapshot fetches .info once and derives all three.
+    snapshot = yfinance_provider.get_snapshot(row["symbol"])  # type: ignore[arg-type]
+    profile = snapshot.profile
+    quote = snapshot.quote
+    stats = snapshot.key_stats
+
+    # Local DB is authoritative for every identity field that has a non-null
+    # value — yfinance fills only the gaps. company_name is schema-non-null,
+    # so display_name falls to yfinance only if the local row somehow has an
+    # empty string (defence-in-depth).
+    identity = InstrumentIdentity(
+        symbol=row["symbol"],  # type: ignore[arg-type]
+        display_name=row["company_name"] or (profile.display_name if profile is not None else None),  # type: ignore[arg-type]
+        sector=row["sector"] or (profile.sector if profile is not None else None),  # type: ignore[arg-type]
+        industry=row["industry"] or (profile.industry if profile is not None else None),  # type: ignore[arg-type]
+        exchange=row["exchange"] or (profile.exchange if profile is not None else None),  # type: ignore[arg-type]
+        country=row["country"] or (profile.country if profile is not None else None),  # type: ignore[arg-type]
+        currency=row["currency"] or (profile.currency if profile is not None else None),  # type: ignore[arg-type]
+        market_cap=profile.market_cap if profile is not None else None,
+    )
+
+    price_block = (
+        InstrumentPrice(
+            current=quote.price,
+            day_change=quote.day_change,
+            day_change_pct=quote.day_change_pct,
+            week_52_high=quote.week_52_high,
+            week_52_low=quote.week_52_low,
+            currency=quote.currency,
+        )
+        if quote is not None
+        else None
+    )
+
+    stats_block = (
+        InstrumentKeyStats(
+            pe_ratio=stats.pe_ratio,
+            pb_ratio=stats.pb_ratio,
+            dividend_yield=stats.dividend_yield,
+            payout_ratio=stats.payout_ratio,
+            roe=stats.roe,
+            roa=stats.roa,
+            debt_to_equity=stats.debt_to_equity,
+            revenue_growth_yoy=stats.revenue_growth_yoy,
+            earnings_growth_yoy=stats.earnings_growth_yoy,
+        )
+        if stats is not None
+        else None
+    )
+
+    source = {
+        "identity": "local_db+yfinance",
+        "price": "yfinance" if quote is not None else "unavailable",
+        "key_stats": "yfinance" if stats is not None else "unavailable",
+    }
+
+    return InstrumentSummary(
+        instrument_id=row["instrument_id"],  # type: ignore[arg-type]
+        is_tradable=row["is_tradable"],  # type: ignore[arg-type]
+        coverage_tier=row["coverage_tier"],  # type: ignore[arg-type]
+        identity=identity,
+        price=price_block,
+        key_stats=stats_block,
+        source=source,
+    )
 
 
 @router.get("/{instrument_id}", response_model=InstrumentDetail)

--- a/app/providers/implementations/yfinance_provider.py
+++ b/app/providers/implementations/yfinance_provider.py
@@ -471,28 +471,49 @@ class YFinanceProvider:
         if price is not None and prev_close is not None and prev_close != 0:
             day_change = price - prev_close
             day_change_pct = day_change / prev_close
-        quote = YFinanceQuote(
-            symbol=symbol,
-            price=price,
-            day_change=day_change,
-            day_change_pct=day_change_pct,
-            week_52_high=_to_decimal(info.get("fiftyTwoWeekHigh")),
-            week_52_low=_to_decimal(info.get("fiftyTwoWeekLow")),
-            currency=_to_str(info.get("currency")),
-        )
+        week_52_high = _to_decimal(info.get("fiftyTwoWeekHigh"))
+        week_52_low = _to_decimal(info.get("fiftyTwoWeekLow"))
+        # If .info returned no price-related data at all, report the section
+        # as null rather than an all-None dataclass. Matches the contract
+        # that "unavailable" sections stay null in the API response, so the
+        # UI doesn't render an empty price pane labeled as "from yfinance".
+        if price is None and week_52_high is None and week_52_low is None:
+            quote: YFinanceQuote | None = None
+        else:
+            quote = YFinanceQuote(
+                symbol=symbol,
+                price=price,
+                day_change=day_change,
+                day_change_pct=day_change_pct,
+                week_52_high=week_52_high,
+                week_52_low=week_52_low,
+                currency=_to_str(info.get("currency")),
+            )
 
-        key_stats = YFinanceKeyStats(
-            symbol=symbol,
-            pe_ratio=_to_decimal(info.get("trailingPE")),
-            pb_ratio=_to_decimal(info.get("priceToBook")),
-            dividend_yield=_to_decimal(info.get("dividendYield")),
-            payout_ratio=_to_decimal(info.get("payoutRatio")),
-            roe=_to_decimal(info.get("returnOnEquity")),
-            roa=_to_decimal(info.get("returnOnAssets")),
-            debt_to_equity=_to_decimal(info.get("debtToEquity")),
-            revenue_growth_yoy=_to_decimal(info.get("revenueGrowth")),
-            earnings_growth_yoy=_to_decimal(info.get("earningsGrowth")),
-        )
+        pe = _to_decimal(info.get("trailingPE"))
+        pb = _to_decimal(info.get("priceToBook"))
+        div_yield = _to_decimal(info.get("dividendYield"))
+        payout = _to_decimal(info.get("payoutRatio"))
+        roe = _to_decimal(info.get("returnOnEquity"))
+        roa = _to_decimal(info.get("returnOnAssets"))
+        d_to_e = _to_decimal(info.get("debtToEquity"))
+        rev_growth = _to_decimal(info.get("revenueGrowth"))
+        earn_growth = _to_decimal(info.get("earningsGrowth"))
+        if all(v is None for v in (pe, pb, div_yield, payout, roe, roa, d_to_e, rev_growth, earn_growth)):
+            key_stats: YFinanceKeyStats | None = None
+        else:
+            key_stats = YFinanceKeyStats(
+                symbol=symbol,
+                pe_ratio=pe,
+                pb_ratio=pb,
+                dividend_yield=div_yield,
+                payout_ratio=payout,
+                roe=roe,
+                roa=roa,
+                debt_to_equity=d_to_e,
+                revenue_growth_yoy=rev_growth,
+                earnings_growth_yoy=earn_growth,
+            )
 
         return YFinanceSnapshot(profile=profile, quote=quote, key_stats=key_stats)
 

--- a/app/providers/implementations/yfinance_provider.py
+++ b/app/providers/implementations/yfinance_provider.py
@@ -259,8 +259,13 @@ class YFinanceProvider:
             return None
         if not info:
             return None
-        price = _to_decimal(info.get("regularMarketPrice") or info.get("currentPrice"))
-        prev_close = _to_decimal(info.get("regularMarketPreviousClose") or info.get("previousClose"))
+        # Explicit None-check for falsy-zero preservation — a legitimate
+        # zero price from regularMarketPrice must not silently fall through
+        # to currentPrice due to `or` short-circuit on falsy values.
+        regular_price = info.get("regularMarketPrice")
+        price = _to_decimal(regular_price if regular_price is not None else info.get("currentPrice"))
+        regular_prev = info.get("regularMarketPreviousClose")
+        prev_close = _to_decimal(regular_prev if regular_prev is not None else info.get("previousClose"))
         day_change: Decimal | None = None
         day_change_pct: Decimal | None = None
         if price is not None and prev_close is not None and prev_close != 0:
@@ -464,8 +469,13 @@ class YFinanceProvider:
             long_business_summary=_to_str(info.get("longBusinessSummary")),
         )
 
-        price = _to_decimal(info.get("regularMarketPrice") or info.get("currentPrice"))
-        prev_close = _to_decimal(info.get("regularMarketPreviousClose") or info.get("previousClose"))
+        # Explicit None-check for falsy-zero preservation — a legitimate
+        # zero price from regularMarketPrice must not silently fall through
+        # to currentPrice due to `or` short-circuit on falsy values.
+        regular_price = info.get("regularMarketPrice")
+        price = _to_decimal(regular_price if regular_price is not None else info.get("currentPrice"))
+        regular_prev = info.get("regularMarketPreviousClose")
+        prev_close = _to_decimal(regular_prev if regular_prev is not None else info.get("previousClose"))
         day_change: Decimal | None = None
         day_change_pct: Decimal | None = None
         if price is not None and prev_close is not None and prev_close != 0:

--- a/app/providers/implementations/yfinance_provider.py
+++ b/app/providers/implementations/yfinance_provider.py
@@ -140,6 +140,20 @@ class YFinancePriceBar:
     volume: int | None
 
 
+@dataclass(frozen=True)
+class YFinanceSnapshot:
+    """Bundle returned by :meth:`YFinanceProvider.get_snapshot`.
+
+    Fetches :attr:`Ticker.info` exactly once and derives profile / quote /
+    key_stats from the same payload — saves two redundant network round
+    trips compared to calling the three accessor methods back-to-back.
+    """
+
+    profile: YFinanceProfile | None
+    quote: YFinanceQuote | None
+    key_stats: YFinanceKeyStats | None
+
+
 # ---------------------------------------------------------------------------
 # Coercion helpers
 # ---------------------------------------------------------------------------
@@ -414,6 +428,73 @@ class YFinanceProvider:
             recommendation_mean=_to_decimal(info.get("recommendationMean")),
             num_analysts=_to_int(info.get("numberOfAnalystOpinions")),
         )
+
+    # -- Consolidated snapshot -----------------------------------------
+
+    def get_snapshot(self, symbol: str) -> YFinanceSnapshot:
+        """Fetch profile + quote + key_stats in a single ``.info`` call.
+
+        yfinance performs a network fetch on every ``.info`` access; the
+        three separate accessor methods each trigger their own fetch. The
+        research-page summary endpoint needs all three for a single
+        ticker, so it calls this method instead of three.
+
+        Returns a :class:`YFinanceSnapshot` with ``None`` sections where
+        ``.info`` failed or the ticker has no data — never raises.
+        """
+        try:
+            info = self._ticker(symbol).info
+        except Exception:
+            logger.warning("yfinance.get_snapshot failed for %s", symbol, exc_info=True)
+            return YFinanceSnapshot(profile=None, quote=None, key_stats=None)
+        if not info:
+            return YFinanceSnapshot(profile=None, quote=None, key_stats=None)
+
+        profile = YFinanceProfile(
+            symbol=symbol,
+            display_name=_to_str(info.get("longName")) or _to_str(info.get("shortName")),
+            sector=_to_str(info.get("sector")),
+            industry=_to_str(info.get("industry")),
+            exchange=_to_str(info.get("exchange")),
+            country=_to_str(info.get("country")),
+            currency=_to_str(info.get("currency")),
+            market_cap=_to_decimal(info.get("marketCap")),
+            employees=_to_int(info.get("fullTimeEmployees")),
+            website=_to_str(info.get("website")),
+            long_business_summary=_to_str(info.get("longBusinessSummary")),
+        )
+
+        price = _to_decimal(info.get("regularMarketPrice") or info.get("currentPrice"))
+        prev_close = _to_decimal(info.get("regularMarketPreviousClose") or info.get("previousClose"))
+        day_change: Decimal | None = None
+        day_change_pct: Decimal | None = None
+        if price is not None and prev_close is not None and prev_close != 0:
+            day_change = price - prev_close
+            day_change_pct = day_change / prev_close
+        quote = YFinanceQuote(
+            symbol=symbol,
+            price=price,
+            day_change=day_change,
+            day_change_pct=day_change_pct,
+            week_52_high=_to_decimal(info.get("fiftyTwoWeekHigh")),
+            week_52_low=_to_decimal(info.get("fiftyTwoWeekLow")),
+            currency=_to_str(info.get("currency")),
+        )
+
+        key_stats = YFinanceKeyStats(
+            symbol=symbol,
+            pe_ratio=_to_decimal(info.get("trailingPE")),
+            pb_ratio=_to_decimal(info.get("priceToBook")),
+            dividend_yield=_to_decimal(info.get("dividendYield")),
+            payout_ratio=_to_decimal(info.get("payoutRatio")),
+            roe=_to_decimal(info.get("returnOnEquity")),
+            roa=_to_decimal(info.get("returnOnAssets")),
+            debt_to_equity=_to_decimal(info.get("debtToEquity")),
+            revenue_growth_yoy=_to_decimal(info.get("revenueGrowth")),
+            earnings_growth_yoy=_to_decimal(info.get("earningsGrowth")),
+        )
+
+        return YFinanceSnapshot(profile=profile, quote=quote, key_stats=key_stats)
 
     # -- Price history --------------------------------------------------
 

--- a/tests/test_api_instrument_summary.py
+++ b/tests/test_api_instrument_summary.py
@@ -276,6 +276,50 @@ def test_summary_local_company_name_beats_yfinance(client: TestClient) -> None:
     assert body["identity"]["display_name"] == "Apple Inc."
 
 
+def test_summary_numeric_symbol_routes_to_summary_not_detail(client: TestClient) -> None:
+    """Numeric ticker symbols (e.g. Tokyo 7203) must route to /summary, not
+    to the /{instrument_id} detail endpoint. The /summary path suffix
+    differentiates the routes even when the symbol segment is all digits."""
+    stub_provider = MagicMock()
+    stub_provider.get_snapshot.return_value = YFinanceSnapshot(profile=None, quote=None, key_stats=None)
+    _install_stub_provider(stub_provider)
+
+    def _db_conn():
+        conn_mock = MagicMock()
+        cur_mock = MagicMock()
+        cur_mock.__enter__.return_value = cur_mock
+        cur_mock.fetchone.return_value = {
+            "instrument_id": 99,
+            "symbol": "7203",
+            "company_name": "Toyota Motor Corp",
+            "exchange": "TSE",
+            "currency": "JPY",
+            "sector": "Consumer Cyclical",
+            "industry": None,
+            "country": "Japan",
+            "is_tradable": True,
+            "coverage_tier": None,
+        }
+        conn_mock.cursor.return_value = cur_mock
+        yield conn_mock
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/7203/summary")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # InstrumentSummary response shape — NOT InstrumentDetail which has
+    # external_identifiers / first_seen_at.
+    assert "identity" in body
+    assert "external_identifiers" not in body
+    assert body["identity"]["symbol"] == "7203"
+
+
 def test_summary_empty_symbol_returns_400(client: TestClient) -> None:
     # Whitespace-only symbol should reject with 400 rather than a DB probe.
     stub_provider = MagicMock()

--- a/tests/test_api_instrument_summary.py
+++ b/tests/test_api_instrument_summary.py
@@ -1,0 +1,296 @@
+"""Tests for GET /instruments/{symbol}/summary (Phase 2.2)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.instruments import get_yfinance_provider
+from app.main import app
+from app.providers.implementations.yfinance_provider import (
+    YFinanceKeyStats,
+    YFinanceProfile,
+    YFinanceQuote,
+    YFinanceSnapshot,
+)
+
+
+def _install_stub_provider(provider: object) -> None:
+    app.dependency_overrides[get_yfinance_provider] = lambda: provider
+
+
+def _clear_provider_override() -> None:
+    app.dependency_overrides.pop(get_yfinance_provider, None)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def cleanup() -> Iterator[None]:
+    yield
+    _clear_provider_override()
+
+
+def _stub_profile(symbol: str = "AAPL") -> YFinanceProfile:
+    return YFinanceProfile(
+        symbol=symbol,
+        display_name="Apple Inc.",
+        sector="Technology",
+        industry="Consumer Electronics",
+        exchange="NMS",
+        country="United States",
+        currency="USD",
+        market_cap=Decimal("3000000000000"),
+        employees=150_000,
+        website="https://apple.com",
+        long_business_summary="Makes iPhones.",
+    )
+
+
+def _stub_quote(symbol: str = "AAPL") -> YFinanceQuote:
+    return YFinanceQuote(
+        symbol=symbol,
+        price=Decimal("200.50"),
+        day_change=Decimal("1.50"),
+        day_change_pct=Decimal("0.00753"),
+        week_52_high=Decimal("250.00"),
+        week_52_low=Decimal("140.00"),
+        currency="USD",
+    )
+
+
+def _stub_stats(symbol: str = "AAPL") -> YFinanceKeyStats:
+    return YFinanceKeyStats(
+        symbol=symbol,
+        pe_ratio=Decimal("28.5"),
+        pb_ratio=Decimal("40.2"),
+        dividend_yield=Decimal("0.005"),
+        payout_ratio=Decimal("0.15"),
+        roe=Decimal("1.5"),
+        roa=Decimal("0.3"),
+        debt_to_equity=Decimal("195.0"),
+        revenue_growth_yoy=Decimal("0.08"),
+        earnings_growth_yoy=Decimal("0.12"),
+    )
+
+
+def test_summary_unknown_symbol_returns_404(client: TestClient, monkeypatch) -> None:
+    """Symbol not in the local instruments table must 404 without hitting yfinance."""
+    stub_provider = MagicMock()
+    stub_provider.get_snapshot.return_value = YFinanceSnapshot(profile=None, quote=None, key_stats=None)
+    _install_stub_provider(stub_provider)
+
+    # Force the DB lookup to return nothing so 404 is exercised without
+    # depending on what's in the dev DB.
+    def _empty_conn():
+        conn_mock = MagicMock()
+        cur_mock = MagicMock()
+        cur_mock.__enter__.return_value = cur_mock
+        cur_mock.fetchone.return_value = None
+        conn_mock.cursor.return_value = cur_mock
+        yield conn_mock
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _empty_conn
+    try:
+        resp = client.get("/instruments/NOTREAL/summary")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+    assert resp.status_code == 404
+    # yfinance must NOT be called for unknown symbols — the local DB is
+    # authoritative for whether a symbol exists at all.
+    stub_provider.get_snapshot.assert_not_called()
+
+
+def test_summary_happy_path_merges_db_and_yfinance(client: TestClient) -> None:
+    stub_provider = MagicMock()
+    stub_provider.get_snapshot.return_value = YFinanceSnapshot(
+        profile=_stub_profile("AAPL"),
+        quote=_stub_quote("AAPL"),
+        key_stats=_stub_stats("AAPL"),
+    )
+    _install_stub_provider(stub_provider)
+
+    def _db_conn():
+        conn_mock = MagicMock()
+        cur_mock = MagicMock()
+        cur_mock.__enter__.return_value = cur_mock
+        cur_mock.fetchone.return_value = {
+            "instrument_id": 42,
+            "symbol": "AAPL",
+            "company_name": "Apple Inc.",
+            "exchange": None,
+            "currency": None,
+            "sector": None,
+            "industry": None,
+            "country": None,
+            "is_tradable": True,
+            "coverage_tier": 1,
+        }
+        conn_mock.cursor.return_value = cur_mock
+        yield conn_mock
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/AAPL/summary")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["instrument_id"] == 42
+    assert body["is_tradable"] is True
+    assert body["coverage_tier"] == 1
+
+    # Identity merges: local DB wins if non-null, otherwise yfinance fills.
+    assert body["identity"]["symbol"] == "AAPL"
+    assert body["identity"]["display_name"] == "Apple Inc."
+    # Sector etc. come from yfinance because the DB row had them as None.
+    assert body["identity"]["sector"] == "Technology"
+    assert body["identity"]["industry"] == "Consumer Electronics"
+    assert body["identity"]["market_cap"] == "3000000000000"
+
+    # Single .info call (not three): get_snapshot called once.
+    stub_provider.get_snapshot.assert_called_once_with("AAPL")
+    assert body["price"]["current"] == "200.50"
+    assert body["key_stats"]["pe_ratio"] == "28.5"
+
+    # Source map names the effective contributors.
+    assert body["source"]["identity"] == "local_db+yfinance"
+    assert body["source"]["price"] == "yfinance"
+    assert body["source"]["key_stats"] == "yfinance"
+
+
+def test_summary_yfinance_failure_returns_null_sections(client: TestClient) -> None:
+    """When yfinance returns None for quote/stats, the UI should see null
+    sections (not 500). Identity still renders from the local DB."""
+    stub_provider = MagicMock()
+    stub_provider.get_snapshot.return_value = YFinanceSnapshot(
+        profile=None,
+        quote=None,
+        key_stats=None,
+    )
+    _install_stub_provider(stub_provider)
+
+    def _db_conn():
+        conn_mock = MagicMock()
+        cur_mock = MagicMock()
+        cur_mock.__enter__.return_value = cur_mock
+        cur_mock.fetchone.return_value = {
+            "instrument_id": 7,
+            "symbol": "VOD.L",
+            "company_name": "Vodafone Group PLC",
+            "exchange": "LSE",
+            "currency": "GBP",
+            "sector": "Telecom",
+            "industry": None,
+            "country": "United Kingdom",
+            "is_tradable": True,
+            "coverage_tier": None,
+        }
+        conn_mock.cursor.return_value = cur_mock
+        yield conn_mock
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/vod.l/summary")  # case-insensitive
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["identity"]["symbol"] == "VOD.L"
+    assert body["identity"]["display_name"] == "Vodafone Group PLC"
+    assert body["identity"]["sector"] == "Telecom"
+    assert body["price"] is None
+    assert body["key_stats"] is None
+    assert body["source"]["price"] == "unavailable"
+    assert body["source"]["key_stats"] == "unavailable"
+
+
+def test_summary_local_company_name_beats_yfinance(client: TestClient) -> None:
+    """Local DB company_name is authoritative — yfinance display_name must
+    not overwrite it when both are present. Addresses Codex review P2."""
+    stub_provider = MagicMock()
+    stub_provider.get_snapshot.return_value = YFinanceSnapshot(
+        profile=YFinanceProfile(
+            symbol="AAPL",
+            display_name="Apple (Yahoo-stale brand)",
+            sector=None,
+            industry=None,
+            exchange=None,
+            country=None,
+            currency=None,
+            market_cap=None,
+            employees=None,
+            website=None,
+            long_business_summary=None,
+        ),
+        quote=None,
+        key_stats=None,
+    )
+    _install_stub_provider(stub_provider)
+
+    def _db_conn():
+        conn_mock = MagicMock()
+        cur_mock = MagicMock()
+        cur_mock.__enter__.return_value = cur_mock
+        cur_mock.fetchone.return_value = {
+            "instrument_id": 1,
+            "symbol": "AAPL",
+            "company_name": "Apple Inc.",
+            "exchange": "NMS",
+            "currency": "USD",
+            "sector": "Technology",
+            "industry": None,
+            "country": "United States",
+            "is_tradable": True,
+            "coverage_tier": 1,
+        }
+        conn_mock.cursor.return_value = cur_mock
+        yield conn_mock
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/AAPL/summary")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # Local DB wins over yfinance's display_name.
+    assert body["identity"]["display_name"] == "Apple Inc."
+
+
+def test_summary_empty_symbol_returns_400(client: TestClient) -> None:
+    # Whitespace-only symbol should reject with 400 rather than a DB probe.
+    stub_provider = MagicMock()
+    stub_provider.get_snapshot.return_value = YFinanceSnapshot(profile=None, quote=None, key_stats=None)
+    _install_stub_provider(stub_provider)
+
+    def _db_conn():
+        yield MagicMock()
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/%20%20%20/summary")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+    assert resp.status_code == 400
+    stub_provider.get_snapshot.assert_not_called()

--- a/tests/test_yfinance_provider.py
+++ b/tests/test_yfinance_provider.py
@@ -19,6 +19,7 @@ from app.providers.implementations.yfinance_provider import (
     YFinancePriceBar,
     YFinanceProfile,
     YFinanceProvider,
+    YFinanceSnapshot,
 )
 
 
@@ -474,3 +475,60 @@ def test_price_history_returns_none_on_exception() -> None:
     provider = YFinanceProvider()
     with patch.object(provider, "_ticker", side_effect=RuntimeError("yahoo is down")):
         assert provider.get_price_history("AAPL") is None
+
+
+# ---------------------------------------------------------------------------
+# Consolidated snapshot (one .info fetch for all 3 dataclasses)
+# ---------------------------------------------------------------------------
+
+
+def test_get_snapshot_single_info_fetch_builds_all_three() -> None:
+    """Snapshot triggers exactly one .info access and derives profile +
+    quote + key_stats from that single payload. Addresses Codex review
+    concern that separate accessors triple Yahoo scrape pressure."""
+    access_count = 0
+
+    class _CountingTicker:
+        @property
+        def info(self) -> dict[str, Any]:
+            nonlocal access_count
+            access_count += 1
+            return {
+                "longName": "Apple Inc.",
+                "sector": "Technology",
+                "marketCap": 3_000_000_000_000,
+                "regularMarketPrice": 200.5,
+                "regularMarketPreviousClose": 199.0,
+                "fiftyTwoWeekHigh": 250.0,
+                "fiftyTwoWeekLow": 140.0,
+                "currency": "USD",
+                "trailingPE": 28.5,
+                "priceToBook": 40.2,
+            }
+
+    provider = YFinanceProvider()
+    provider._ticker = lambda _symbol: _CountingTicker()  # type: ignore[method-assign,return-value]
+    snapshot = provider.get_snapshot("AAPL")
+    assert access_count == 1
+    assert isinstance(snapshot, YFinanceSnapshot)
+    assert snapshot.profile is not None and snapshot.profile.display_name == "Apple Inc."
+    assert snapshot.quote is not None and snapshot.quote.price == Decimal("200.5")
+    assert snapshot.quote.day_change == Decimal("1.5")
+    assert snapshot.key_stats is not None and snapshot.key_stats.pe_ratio == Decimal("28.5")
+
+
+def test_get_snapshot_info_raise_returns_all_nones() -> None:
+    provider = YFinanceProvider()
+    with patch.object(provider, "_ticker", side_effect=RuntimeError("yahoo is down")):
+        snapshot = provider.get_snapshot("AAPL")
+    assert snapshot == YFinanceSnapshot(profile=None, quote=None, key_stats=None)
+
+
+def test_get_snapshot_empty_info_returns_all_nones() -> None:
+    class _EmptyTicker:
+        info: dict[str, Any] = {}
+
+    provider = YFinanceProvider()
+    provider._ticker = lambda _symbol: _EmptyTicker()  # type: ignore[method-assign,return-value]
+    snapshot = provider.get_snapshot("AAPL")
+    assert snapshot == YFinanceSnapshot(profile=None, quote=None, key_stats=None)

--- a/tests/test_yfinance_provider.py
+++ b/tests/test_yfinance_provider.py
@@ -532,3 +532,43 @@ def test_get_snapshot_empty_info_returns_all_nones() -> None:
     provider._ticker = lambda _symbol: _EmptyTicker()  # type: ignore[method-assign,return-value]
     snapshot = provider.get_snapshot("AAPL")
     assert snapshot == YFinanceSnapshot(profile=None, quote=None, key_stats=None)
+
+
+def test_get_snapshot_info_with_only_identity_returns_null_quote_and_stats() -> None:
+    """If .info has identity fields but no price or stats keys, quote and
+    key_stats sections must be None — not all-None dataclasses. Addresses
+    PR #358 review WARNING: contract says null sections, not shells."""
+
+    class _IdentityOnlyTicker:
+        info = {
+            "longName": "Tiny Co",
+            "sector": "Consumer",
+        }
+
+    provider = YFinanceProvider()
+    provider._ticker = lambda _symbol: _IdentityOnlyTicker()  # type: ignore[method-assign,return-value]
+    snapshot = provider.get_snapshot("TINY")
+    assert snapshot.profile is not None
+    assert snapshot.profile.display_name == "Tiny Co"
+    assert snapshot.quote is None
+    assert snapshot.key_stats is None
+
+
+def test_get_snapshot_info_with_all_null_price_fields_returns_null_quote() -> None:
+    """Explicit NaN or None values in price fields must collapse to quote=None."""
+
+    class _NullPriceTicker:
+        info = {
+            "longName": "Ghost Co",
+            "regularMarketPrice": float("nan"),
+            "regularMarketPreviousClose": None,
+            "fiftyTwoWeekHigh": None,
+            "fiftyTwoWeekLow": float("nan"),
+            # Stats still all null
+        }
+
+    provider = YFinanceProvider()
+    provider._ticker = lambda _symbol: _NullPriceTicker()  # type: ignore[method-assign,return-value]
+    snapshot = provider.get_snapshot("GHOST")
+    assert snapshot.quote is None
+    assert snapshot.key_stats is None

--- a/tests/test_yfinance_provider.py
+++ b/tests/test_yfinance_provider.py
@@ -572,3 +572,40 @@ def test_get_snapshot_info_with_all_null_price_fields_returns_null_quote() -> No
     snapshot = provider.get_snapshot("GHOST")
     assert snapshot.quote is None
     assert snapshot.key_stats is None
+
+
+def test_to_decimal_nan_returns_none() -> None:
+    """Direct invariant: _to_decimal(float('nan')) -> None, not Decimal('NaN').
+    Pins the NaN filter that _NullPriceTicker relies on."""
+    from app.providers.implementations.yfinance_provider import _to_decimal
+
+    assert _to_decimal(float("nan")) is None
+    assert _to_decimal(Decimal("NaN")) is None
+
+
+def test_get_snapshot_preserves_zero_price() -> None:
+    """A legitimate zero price must NOT fall through via `or` short-circuit
+    to currentPrice. Addresses PR #358 BLOCKING review."""
+
+    class _ZeroPriceTicker:
+        info = {
+            "longName": "Zero Co",
+            # regularMarketPrice = 0 is legitimate (halted stock, distressed
+            # delisted ticker); it's falsy but not missing.
+            "regularMarketPrice": 0,
+            "currentPrice": 5.0,  # would shadow the real price under `or`
+            "regularMarketPreviousClose": 10.0,
+            "fiftyTwoWeekHigh": 100.0,
+            "fiftyTwoWeekLow": 0.0,
+        }
+
+    provider = YFinanceProvider()
+    provider._ticker = lambda _symbol: _ZeroPriceTicker()  # type: ignore[method-assign,return-value]
+    snapshot = provider.get_snapshot("ZERO")
+    assert snapshot.quote is not None
+    # Real zero price must survive, NOT be replaced by currentPrice=5.0.
+    assert snapshot.quote.price == Decimal("0")
+    # day_change = 0 - 10 = -10.
+    assert snapshot.quote.day_change == Decimal("-10")
+    # week_52_low=0 preserved too.
+    assert snapshot.quote.week_52_low == Decimal("0")


### PR DESCRIPTION
## Summary
Phase 2.2 of the [2026-04-19 research-tool refocus](docs/superpowers/specs/2026-04-19-research-tool-refocus.md).

\`GET /instruments/{symbol}/summary\` returns per-ticker research data: identity + price + key stats.

- **Identity** (local DB authoritative, yfinance fills gaps): symbol, display_name, sector, industry, exchange, country, currency, market_cap.
- **Price**: current, day_change, day_change_pct, 52w_high, 52w_low, currency.
- **Key stats**: PE, PB, dividend yield, payout, ROE, ROA, D/E, revenue growth, earnings growth.
- **Source**: section-level provider attribution map.

404 if symbol not in local instruments table (yfinance not queried). Case-insensitive symbol match. yfinance failures return null sections, not 500.

## Codex pre-push feedback addressed
- P2 field names match spec (\`current\`, not \`price\`).
- P2 display_name precedence: local DB \`company_name\` wins over yfinance.
- P2 three \`.info\` calls consolidated into one via new \`YFinanceProvider.get_snapshot\`.
- P1 deferred as tech-debt #357: per-field source attribution + local SEC XBRL preference for US tickers. Landing MVP first unblocks Chunk 9 frontend.

## Test plan
- \`tests/test_api_instrument_summary.py\` — 5 cases (unknown symbol 404, happy-path merge, yfinance failure null sections, local company_name precedence, empty-symbol 400)
- \`tests/test_yfinance_provider.py\` — +3 snapshot cases (single .info fetch invariant, .info raise, empty .info)
- \`uv run pytest\` — 2178 passed, 1 skipped
- \`uv run ruff check .\` / \`ruff format --check .\` / \`pyright\` — clean