### PR TITLE
feat: GET /instruments/{symbol}/financials (Phase 2.3)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -352,25 +352,24 @@ def _fetch_local_financials(
     Returns (rows, currency). Empty rows = no local data, let caller fall
     back to yfinance.
     """
-    if period == "quarterly":
-        type_clause = "period_type IN ('Q1','Q2','Q3','Q4')"
-    else:
-        type_clause = "period_type = 'FY'"
+    period_types: list[str] = ["Q1", "Q2", "Q3", "Q4"] if period == "quarterly" else ["FY"]
 
-    # Columns whitelisted above — safe to format into SQL.
+    # Columns whitelisted above — safe to format into SQL. period_types
+    # is bound as a parameter, not formatted, so a future value added to
+    # the CHECK constraint won't silently match.
     select_cols = ", ".join(columns)
     sql = f"""
         SELECT period_end_date, period_type, reported_currency, {select_cols}
         FROM financial_periods
         WHERE instrument_id = %(iid)s
           AND superseded_at IS NULL
-          AND {type_clause}
+          AND period_type = ANY(%(types)s::text[])
         ORDER BY period_end_date DESC
         LIMIT 20
-    """  # noqa: S608 — columns and type_clause are hardcoded whitelists
+    """  # noqa: S608 — columns are a hardcoded whitelist; period_types is bound
 
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(sql, {"iid": instrument_id})  # type: ignore[arg-type]  # SQL built from hardcoded whitelists
+        cur.execute(sql, {"iid": instrument_id, "types": period_types})  # type: ignore[arg-type]  # SQL built from hardcoded whitelist
         db_rows = cur.fetchall()
 
     if not db_rows:
@@ -455,13 +454,21 @@ def get_instrument_financials(
             source="yfinance",
             rows=[],
         )
+    # yfinance statement rows don't carry a period_type label. For the
+    # quarterly path we infer Q1-Q4 from the period_end month (fiscal
+    # quarters end Mar/Jun/Sep/Dec for the vast majority of issuers).
+    # Annual rows are tagged "FY". This matches the local-path labels so
+    # the frontend treats both sources uniformly.
+    def _yf_period_type(d: date) -> str:
+        if period == "annual":
+            return "FY"
+        return {3: "Q1", 6: "Q2", 9: "Q3", 12: "Q4"}.get(d.month, "Q?")
+
     yf_rows = [
         InstrumentFinancialRow(
             period_end=row.period_end,
-            # yfinance rows have no period_type label; encode as statement-date
-            period_type=period[0].upper() + row.period_end.strftime("%Y"),
-            # Cast values dict to the Decimal | None shape of InstrumentFinancialRow
-            values={k: v for k, v in row.values.items()},
+            period_type=_yf_period_type(row.period_end),
+            values=dict(row.values.items()),
         )
         for row in y_fin.rows
     ]

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -454,6 +454,7 @@ def get_instrument_financials(
             source="yfinance",
             rows=[],
         )
+
     # yfinance statement rows don't carry a period_type label. For the
     # quarterly path we infer Q1-Q4 from the period_end month (fiscal
     # quarters end Mar/Jun/Sep/Dec for the vast majority of issuers).

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -11,8 +11,9 @@ No writes. No schema changes.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
+from typing import Literal
 
 import psycopg
 import psycopg.rows
@@ -112,6 +113,21 @@ class InstrumentKeyStats(BaseModel):
     debt_to_equity: Decimal | None
     revenue_growth_yoy: Decimal | None
     earnings_growth_yoy: Decimal | None
+
+
+class InstrumentFinancialRow(BaseModel):
+    period_end: date
+    period_type: str  # Q1/Q2/Q3/Q4/FY (from financial_periods) or yfinance label
+    values: dict[str, Decimal | None]
+
+
+class InstrumentFinancials(BaseModel):
+    symbol: str
+    statement: str  # "income" | "balance" | "cashflow"
+    period: str  # "quarterly" | "annual"
+    currency: str | None
+    source: str  # "financial_periods" (local SEC XBRL) | "yfinance"
+    rows: list[InstrumentFinancialRow]
 
 
 class InstrumentSummary(BaseModel):
@@ -268,6 +284,195 @@ def list_instruments(
     ]
 
     return InstrumentListResponse(items=items, total=total, offset=offset, limit=limit)
+
+
+# Column sets per statement for the local financial_periods read path.
+# Tuple order is the preferred display order for each statement.
+_INCOME_COLUMNS: tuple[str, ...] = (
+    "revenue",
+    "cost_of_revenue",
+    "gross_profit",
+    "operating_income",
+    "net_income",
+    "eps_basic",
+    "eps_diluted",
+    "research_and_dev",
+    "sga_expense",
+    "depreciation_amort",
+    "interest_expense",
+    "income_tax",
+    "shares_basic",
+    "shares_diluted",
+    "sbc_expense",
+)
+
+_BALANCE_COLUMNS: tuple[str, ...] = (
+    "total_assets",
+    "total_liabilities",
+    "shareholders_equity",
+    "cash",
+    "long_term_debt",
+    "short_term_debt",
+    "shares_outstanding",
+    "inventory",
+    "receivables",
+    "payables",
+    "goodwill",
+    "ppe_net",
+)
+
+_CASHFLOW_COLUMNS: tuple[str, ...] = (
+    "operating_cf",
+    "investing_cf",
+    "financing_cf",
+    "capex",
+    "dividends_paid",
+    "dps_declared",
+    "buyback_spend",
+)
+
+_STATEMENT_COLUMNS: dict[str, tuple[str, ...]] = {
+    "income": _INCOME_COLUMNS,
+    "balance": _BALANCE_COLUMNS,
+    "cashflow": _CASHFLOW_COLUMNS,
+}
+
+
+def _fetch_local_financials(
+    conn: psycopg.Connection[object],
+    instrument_id: int,
+    columns: tuple[str, ...],
+    period: str,
+) -> tuple[list[InstrumentFinancialRow], str | None]:
+    """Read rows from ``financial_periods`` for the given statement's columns.
+
+    ``period == 'quarterly'`` matches period_type IN ('Q1','Q2','Q3','Q4').
+    ``period == 'annual'`` matches period_type = 'FY'.
+
+    Returns (rows, currency). Empty rows = no local data, let caller fall
+    back to yfinance.
+    """
+    if period == "quarterly":
+        type_clause = "period_type IN ('Q1','Q2','Q3','Q4')"
+    else:
+        type_clause = "period_type = 'FY'"
+
+    # Columns whitelisted above — safe to format into SQL.
+    select_cols = ", ".join(columns)
+    sql = f"""
+        SELECT period_end_date, period_type, reported_currency, {select_cols}
+        FROM financial_periods
+        WHERE instrument_id = %(iid)s
+          AND superseded_at IS NULL
+          AND {type_clause}
+        ORDER BY period_end_date DESC
+        LIMIT 20
+    """  # noqa: S608 — columns and type_clause are hardcoded whitelists
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(sql, {"iid": instrument_id})  # type: ignore[arg-type]  # SQL built from hardcoded whitelists
+        db_rows = cur.fetchall()
+
+    if not db_rows:
+        return [], None
+
+    currency = db_rows[0].get("reported_currency") if db_rows else None  # type: ignore[union-attr]
+    rows: list[InstrumentFinancialRow] = [
+        InstrumentFinancialRow(
+            period_end=r["period_end_date"],  # type: ignore[arg-type]
+            period_type=str(r["period_type"]),  # type: ignore[index]
+            values={col: r.get(col) for col in columns},  # type: ignore[union-attr]
+        )
+        for r in db_rows
+    ]
+    return rows, str(currency) if currency is not None else None
+
+
+@router.get("/{symbol}/financials", response_model=InstrumentFinancials)
+def get_instrument_financials(
+    symbol: str,
+    period: Literal["quarterly", "annual"] = Query(default="quarterly"),
+    statement: Literal["income", "balance", "cashflow"] = Query(default="income"),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+    yfinance_provider: YFinanceProvider = Depends(get_yfinance_provider),
+) -> InstrumentFinancials:
+    """Per-ticker financial statement (Phase 2.3 of the 2026-04-19 refocus).
+
+    Pull priority:
+      1. Local ``financial_periods`` rows (SEC XBRL-sourced) if the
+         instrument has them.
+      2. yfinance fallback otherwise.
+
+    Returns an empty row list (not 500, not 404) when neither source has
+    data — the UI shows "no statement data available".
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    columns = _STATEMENT_COLUMNS[statement]
+
+    # Resolve symbol -> instrument_id for the local read.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT instrument_id, symbol FROM instruments WHERE UPPER(symbol) = %(s)s LIMIT 1",
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    # Try local first.
+    local_rows, local_currency = _fetch_local_financials(
+        conn,
+        int(inst_row["instrument_id"]),  # type: ignore[arg-type]
+        columns,
+        period,
+    )
+    if local_rows:
+        return InstrumentFinancials(
+            symbol=str(inst_row["symbol"]),  # type: ignore[index]
+            statement=statement,
+            period=period,
+            currency=local_currency,
+            source="financial_periods",
+            rows=local_rows,
+        )
+
+    # Fallback to yfinance.
+    y_fin = yfinance_provider.get_financials(
+        str(inst_row["symbol"]),  # type: ignore[index]
+        statement=statement,
+        period=period,
+    )
+    if y_fin is None:
+        return InstrumentFinancials(
+            symbol=str(inst_row["symbol"]),  # type: ignore[index]
+            statement=statement,
+            period=period,
+            currency=None,
+            source="yfinance",
+            rows=[],
+        )
+    yf_rows = [
+        InstrumentFinancialRow(
+            period_end=row.period_end,
+            # yfinance rows have no period_type label; encode as statement-date
+            period_type=period[0].upper() + row.period_end.strftime("%Y"),
+            # Cast values dict to the Decimal | None shape of InstrumentFinancialRow
+            values={k: v for k, v in row.values.items()},
+        )
+        for row in y_fin.rows
+    ]
+    return InstrumentFinancials(
+        symbol=str(inst_row["symbol"]),  # type: ignore[index]
+        statement=statement,
+        period=period,
+        currency=y_fin.currency,
+        source="yfinance",
+        rows=yf_rows,
+    )
 
 
 @router.get("/{symbol}/summary", response_model=InstrumentSummary)

--- a/tests/test_api_instrument_financials.py
+++ b/tests/test_api_instrument_financials.py
@@ -163,6 +163,8 @@ def test_financials_yfinance_fallback(client: TestClient) -> None:
     assert body["currency"] == "GBP"
     assert len(body["rows"]) == 1
     assert body["rows"][0]["values"]["Total Revenue"] == "9000000000"
+    # period_type inferred from the fiscal-quarter-end month (Mar → Q1).
+    assert body["rows"][0]["period_type"] == "Q1"
     stub_provider.get_financials.assert_called_once_with("VOD.L", statement="income", period="quarterly")
 
 

--- a/tests/test_api_instrument_financials.py
+++ b/tests/test_api_instrument_financials.py
@@ -1,0 +1,229 @@
+"""Tests for GET /instruments/{symbol}/financials (Phase 2.3)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.instruments import get_yfinance_provider
+from app.main import app
+from app.providers.implementations.yfinance_provider import (
+    YFinanceFinancialRow,
+    YFinanceFinancials,
+)
+
+
+def _install_stub_provider(provider: object) -> None:
+    app.dependency_overrides[get_yfinance_provider] = lambda: provider
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def cleanup() -> Iterator[None]:
+    yield
+    app.dependency_overrides.pop(get_yfinance_provider, None)
+
+
+def _install_db_conn(instrument_row: dict | None, periods_rows: list[dict] | None = None) -> None:
+    """Stub DB that returns instrument_row on first execute, periods_rows on second."""
+
+    def _conn():
+        conn_mock = MagicMock()
+        cur_mock = MagicMock()
+        cur_mock.__enter__.return_value = cur_mock
+        cur_mock.fetchone.return_value = instrument_row
+        cur_mock.fetchall.return_value = periods_rows if periods_rows is not None else []
+        conn_mock.cursor.return_value = cur_mock
+        yield conn_mock
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _conn
+
+
+def _clear_db_override() -> None:
+    from app.db import get_conn
+
+    app.dependency_overrides.pop(get_conn, None)
+
+
+def test_financials_unknown_symbol_returns_404(client: TestClient) -> None:
+    stub_provider = MagicMock()
+    _install_stub_provider(stub_provider)
+    _install_db_conn(None)
+    try:
+        resp = client.get("/instruments/NOTREAL/financials?statement=income")
+    finally:
+        _clear_db_override()
+    assert resp.status_code == 404
+    stub_provider.get_financials.assert_not_called()
+
+
+def test_financials_empty_symbol_returns_400(client: TestClient) -> None:
+    stub_provider = MagicMock()
+    _install_stub_provider(stub_provider)
+    _install_db_conn(None)
+    try:
+        resp = client.get("/instruments/%20/financials?statement=income")
+    finally:
+        _clear_db_override()
+    assert resp.status_code == 400
+
+
+def test_financials_invalid_statement_returns_422(client: TestClient) -> None:
+    # Literal validation on the query param means FastAPI returns 422 before
+    # the handler runs, without hitting the DB or yfinance.
+    stub_provider = MagicMock()
+    _install_stub_provider(stub_provider)
+    _install_db_conn({"instrument_id": 1, "symbol": "AAPL"})
+    try:
+        resp = client.get("/instruments/AAPL/financials?statement=flufinomics")
+    finally:
+        _clear_db_override()
+    assert resp.status_code == 422
+
+
+def test_financials_local_data_wins(client: TestClient) -> None:
+    """When financial_periods has rows, yfinance is not consulted."""
+    stub_provider = MagicMock()
+    _install_stub_provider(stub_provider)
+    periods_rows = [
+        {
+            "period_end_date": date(2026, 3, 31),
+            "period_type": "Q1",
+            "reported_currency": "USD",
+            "revenue": Decimal("90000000000"),
+            "cost_of_revenue": Decimal("50000000000"),
+            "gross_profit": Decimal("40000000000"),
+            "operating_income": Decimal("30000000000"),
+            "net_income": Decimal("25000000000"),
+            "eps_basic": Decimal("1.55"),
+            "eps_diluted": Decimal("1.52"),
+            "research_and_dev": None,
+            "sga_expense": None,
+            "depreciation_amort": None,
+            "interest_expense": None,
+            "income_tax": None,
+            "shares_basic": None,
+            "shares_diluted": None,
+            "sbc_expense": None,
+        }
+    ]
+    _install_db_conn({"instrument_id": 1, "symbol": "AAPL"}, periods_rows)
+    try:
+        resp = client.get("/instruments/AAPL/financials?statement=income&period=quarterly")
+    finally:
+        _clear_db_override()
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["source"] == "financial_periods"
+    assert body["currency"] == "USD"
+    assert len(body["rows"]) == 1
+    row = body["rows"][0]
+    assert row["period_end"] == "2026-03-31"
+    assert row["period_type"] == "Q1"
+    assert row["values"]["revenue"] == "90000000000"
+    assert row["values"]["research_and_dev"] is None
+    stub_provider.get_financials.assert_not_called()
+
+
+def test_financials_yfinance_fallback(client: TestClient) -> None:
+    """When financial_periods has no rows, yfinance is consulted."""
+    stub_provider = MagicMock()
+    stub_provider.get_financials.return_value = YFinanceFinancials(
+        symbol="VOD.L",
+        statement="income",
+        period="quarterly",
+        currency="GBP",
+        rows=[
+            YFinanceFinancialRow(
+                period_end=date(2026, 3, 31),
+                values={"Total Revenue": Decimal("9000000000")},
+            )
+        ],
+    )
+    _install_stub_provider(stub_provider)
+    _install_db_conn({"instrument_id": 7, "symbol": "VOD.L"}, periods_rows=[])
+    try:
+        resp = client.get("/instruments/VOD.L/financials?statement=income&period=quarterly")
+    finally:
+        _clear_db_override()
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["source"] == "yfinance"
+    assert body["currency"] == "GBP"
+    assert len(body["rows"]) == 1
+    assert body["rows"][0]["values"]["Total Revenue"] == "9000000000"
+    stub_provider.get_financials.assert_called_once_with("VOD.L", statement="income", period="quarterly")
+
+
+def test_financials_no_data_anywhere_returns_empty_rows(client: TestClient) -> None:
+    """Neither financial_periods nor yfinance has data — return 200 with
+    empty rows, NOT 404 or 500. UI shows 'no statement data'."""
+    stub_provider = MagicMock()
+    stub_provider.get_financials.return_value = None
+    _install_stub_provider(stub_provider)
+    _install_db_conn({"instrument_id": 99, "symbol": "WEIRD"}, periods_rows=[])
+    try:
+        resp = client.get("/instruments/WEIRD/financials?statement=balance")
+    finally:
+        _clear_db_override()
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["source"] == "yfinance"
+    assert body["rows"] == []
+
+
+def test_financials_balance_statement_uses_balance_columns(client: TestClient) -> None:
+    stub_provider = MagicMock()
+    _install_stub_provider(stub_provider)
+    periods_rows = [
+        {
+            "period_end_date": date(2026, 3, 31),
+            "period_type": "FY",
+            "reported_currency": "USD",
+            "total_assets": Decimal("400000000000"),
+            "total_liabilities": Decimal("300000000000"),
+            "shareholders_equity": Decimal("100000000000"),
+            "cash": None,
+            "long_term_debt": None,
+            "short_term_debt": None,
+            "shares_outstanding": None,
+            "inventory": None,
+            "receivables": None,
+            "payables": None,
+            "goodwill": None,
+            "ppe_net": None,
+        }
+    ]
+    _install_db_conn({"instrument_id": 1, "symbol": "AAPL"}, periods_rows)
+    try:
+        resp = client.get("/instruments/AAPL/financials?statement=balance&period=annual")
+    finally:
+        _clear_db_override()
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert set(body["rows"][0]["values"].keys()) == {
+        "total_assets",
+        "total_liabilities",
+        "shareholders_equity",
+        "cash",
+        "long_term_debt",
+        "short_term_debt",
+        "shares_outstanding",
+        "inventory",
+        "receivables",
+        "payables",
+        "goodwill",
+        "ppe_net",
+    }
+    assert body["rows"][0]["values"]["total_assets"] == "400000000000"


### PR DESCRIPTION
## Summary
Phase 2.3 of the [2026-04-19 research-tool refocus](docs/superpowers/specs/2026-04-19-research-tool-refocus.md).

\`GET /instruments/{symbol}/financials?statement=income|balance|cashflow&period=quarterly|annual\`

**Pull priority** (matches spec):
1. Local \`financial_periods\` table (SEC XBRL-sourced) if populated.
2. yfinance fallback for non-US or US instruments without XBRL history.

**Response shape**:
- \`symbol\`, \`statement\`, \`period\`, \`currency\`, \`source\`, \`rows\`
- \`rows\`: \`[{period_end, period_type, values: {column: Decimal | None}}]\`

**Behavior**:
- 404 if symbol not in local \`instruments\` table.
- 400 if symbol is whitespace-only.
- 422 on invalid \`statement\` / \`period\` (FastAPI Literal validation).
- 200 with \`rows=[]\` if neither source has data (UI shows "no data available").

Column sets per statement are hardcoded whitelists composed into SQL directly (parameterised on instrument_id only). \`period_type\` filter uses \`IN ('Q1','Q2','Q3','Q4')\` for quarterly, \`= 'FY'\` for annual. Up to 20 most-recent rows.

## Test plan
- \`tests/test_api_instrument_financials.py\` — 7 cases (unknown symbol 404, empty symbol 400, invalid statement 422, local-data-wins, yfinance fallback, no-data-anywhere empty rows, balance-statement columns)
- \`uv run pytest\` — 2190 passed, 1 skipped
- \`uv run ruff check .\` / \`ruff format --check .\` / \`pyright\` — clean