### PR TITLE
feat: POST /instruments/{symbol}/thesis (Phase 2.4)

### DIFF
--- a/app/api/theses.py
+++ b/app/api/theses.py
@@ -4,7 +4,8 @@ Reads from:
   - theses       (append-only versioned thesis rows per instrument)
   - instruments   (existence check for 404 on history endpoint)
 
-No writes. No schema changes.
+Writes from POST /instruments/{symbol}/thesis (Phase 2.4) via the
+existing ``generate_thesis`` service — 24h-cached per-ticker.
 
 Note: the issue (#52) mentions ``conviction_score`` but the theses table
 has ``confidence_score``.  This module uses the actual schema column name.
@@ -12,16 +13,44 @@ has ``confidence_score``.  This module uses the actual schema column name.
 
 from __future__ import annotations
 
-from datetime import datetime
+import logging
+import os
+from datetime import UTC, datetime, timedelta
 
+import anthropic
 import psycopg
 import psycopg.rows
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.db import get_conn
+from app.services.thesis import generate_thesis
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/theses", tags=["theses"])
+
+
+# Separate router for the symbol-based POST; kept under /instruments so
+# the research page can POST to a single resource prefix.
+instrument_thesis_router = APIRouter(prefix="/instruments", tags=["instruments"])
+
+
+def get_anthropic_client() -> anthropic.Anthropic:
+    """FastAPI dependency: constructs an Anthropic client per request.
+
+    Raises ``HTTPException(503)`` when ANTHROPIC_API_KEY is unset — the
+    thesis endpoint is the only caller that needs it, so failing here
+    keeps the rest of the API unaffected by missing credentials.
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise HTTPException(
+            status_code=503,
+            detail="ANTHROPIC_API_KEY not configured — thesis generation unavailable",
+        )
+    return anthropic.Anthropic(api_key=api_key)
+
 
 MAX_PAGE_LIMIT = 200
 
@@ -203,3 +232,114 @@ def get_thesis_history(
         offset=offset,
         limit=limit,
     )
+
+
+# ---------------------------------------------------------------------------
+# Symbol-keyed thesis endpoint (Phase 2.4)
+# ---------------------------------------------------------------------------
+
+
+THESIS_CACHE_WINDOW = timedelta(hours=24)
+
+
+class GenerateThesisResponse(BaseModel):
+    """Result of POST /instruments/{symbol}/thesis.
+
+    ``cached`` reports whether the returned thesis came from the 24h
+    cache (no Anthropic spend for this request) or was freshly
+    generated this call.
+    """
+
+    cached: bool
+    thesis: ThesisDetail
+
+
+@instrument_thesis_router.post("/{symbol}/thesis", response_model=GenerateThesisResponse)
+def generate_instrument_thesis(
+    symbol: str,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+    client: anthropic.Anthropic = Depends(get_anthropic_client),
+) -> GenerateThesisResponse:
+    """Generate or return the cached thesis for a ticker.
+
+    Phase 2.4 of the 2026-04-19 research-tool refocus. On-demand only —
+    no scheduled thesis refresh. Cache window is 24h per ticker: a POST
+    within 24h of the last thesis returns the cached row without
+    calling Anthropic; after 24h the endpoint regenerates.
+
+    Returns:
+      - 404 if the symbol is not in the local instruments table
+      - 503 if ANTHROPIC_API_KEY is not configured
+      - 200 with the thesis (cached or fresh)
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT instrument_id FROM instruments WHERE UPPER(symbol) = %(s)s LIMIT 1",
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+
+    # Cache check: latest thesis for this instrument within 24h.
+    latest_sql = f"""
+        SELECT {_THESIS_COLUMNS}
+        FROM theses t
+        WHERE t.instrument_id = %(iid)s
+          AND t.created_at >= %(since)s
+        ORDER BY t.created_at DESC, t.thesis_version DESC
+        LIMIT 1
+    """  # noqa: S608 — _THESIS_COLUMNS is a module-level constant
+    now = datetime.now(UTC)
+    cache_cutoff = now - THESIS_CACHE_WINDOW
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(latest_sql, {"iid": instrument_id, "since": cache_cutoff})
+        cached_row = cur.fetchone()
+
+    if cached_row is not None:
+        logger.info(
+            "POST /instruments/%s/thesis: cache hit (created_at=%s)",
+            symbol_clean,
+            cached_row["created_at"],  # type: ignore[index]
+        )
+        return GenerateThesisResponse(cached=True, thesis=_parse_thesis(cached_row))
+
+    # Cache miss — call the existing generate_thesis service. It handles
+    # its own DB transaction + Anthropic calls. We must NOT wrap this in
+    # our own transaction (see generate_thesis caller contract).
+    logger.info("POST /instruments/%s/thesis: cache miss, generating", symbol_clean)
+    try:
+        generate_thesis(instrument_id, conn, client)
+    except Exception as exc:
+        logger.exception("POST /instruments/%s/thesis: generation failed", symbol_clean)
+        raise HTTPException(
+            status_code=502,
+            detail=f"thesis generation failed: {type(exc).__name__}",
+        ) from exc
+
+    # Re-read the just-inserted thesis via the same columns shape so the
+    # response format is stable.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            f"""
+            SELECT {_THESIS_COLUMNS}
+            FROM theses t
+            WHERE t.instrument_id = %(iid)s
+            ORDER BY t.created_at DESC, t.thesis_version DESC
+            LIMIT 1
+            """,  # noqa: S608
+            {"iid": instrument_id},
+        )
+        fresh_row = cur.fetchone()
+
+    if fresh_row is None:
+        # Shouldn't happen — generate_thesis just inserted. Defensive.
+        raise HTTPException(status_code=500, detail="thesis row missing after generation")
+
+    return GenerateThesisResponse(cached=False, thesis=_parse_thesis(fresh_row))

--- a/app/main.py
+++ b/app/main.py
@@ -35,6 +35,7 @@ from app.api.reports import router as reports_router
 from app.api.scores import router as scores_router
 from app.api.sync import router as sync_router
 from app.api.system import router as system_router
+from app.api.theses import instrument_thesis_router
 from app.api.theses import router as theses_router
 from app.config import settings
 from app.db import get_conn
@@ -175,6 +176,7 @@ app.include_router(scores_router)
 app.include_router(sync_router)
 app.include_router(system_router)
 app.include_router(theses_router)
+app.include_router(instrument_thesis_router)
 
 
 @app.get("/health")

--- a/tests/test_api_instrument_thesis.py
+++ b/tests/test_api_instrument_thesis.py
@@ -1,0 +1,200 @@
+"""Tests for POST /instruments/{symbol}/thesis (Phase 2.4).
+
+Uses stub providers for Anthropic + DB so no real LLM calls happen.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.theses import get_anthropic_client
+from app.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def cleanup() -> Iterator[None]:
+    yield
+    app.dependency_overrides.pop(get_anthropic_client, None)
+
+
+def _install_anthropic_stub() -> MagicMock:
+    stub = MagicMock()
+    app.dependency_overrides[get_anthropic_client] = lambda: stub
+    return stub
+
+
+def _install_db(
+    *,
+    instrument_row: dict | None,
+    cached_thesis: dict | None = None,
+    fresh_thesis: dict | None = None,
+) -> None:
+    """Stub DB with three sequential fetchone calls:
+    1. instrument lookup
+    2. cache check (cached_thesis or None)
+    3. fresh thesis re-read after generate_thesis (if reached)
+    """
+
+    def _conn():
+        conn_mock = MagicMock()
+        cur_mock = MagicMock()
+        cur_mock.__enter__.return_value = cur_mock
+        cur_mock.fetchone.side_effect = [instrument_row, cached_thesis, fresh_thesis]
+        conn_mock.cursor.return_value = cur_mock
+        # commit is a no-op for the tests.
+        conn_mock.commit = MagicMock()
+        conn_mock.transaction = MagicMock(return_value=MagicMock(__enter__=MagicMock(), __exit__=MagicMock()))
+        yield conn_mock
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _conn
+
+
+def _clear_db() -> None:
+    from app.db import get_conn
+
+    app.dependency_overrides.pop(get_conn, None)
+
+
+def _thesis_row(**overrides) -> dict:
+    base = {
+        "thesis_id": 101,
+        "instrument_id": 42,
+        "thesis_version": 3,
+        "thesis_type": "long",
+        "stance": "buy",
+        "confidence_score": 0.72,
+        "buy_zone_low": 180.0,
+        "buy_zone_high": 195.0,
+        "base_value": 200.0,
+        "bull_value": 230.0,
+        "bear_value": 160.0,
+        "break_conditions_json": ["sales growth < 5%", "margin contraction"],
+        "memo_markdown": "# Bull case\nSolid moat.",
+        "critic_json": {"counter": "sector headwinds"},
+        "created_at": datetime.now(UTC) - timedelta(hours=2),
+    }
+    base.update(overrides)
+    return base
+
+
+def test_thesis_returns_503_when_api_key_missing(client: TestClient) -> None:
+    # Don't install anthropic stub → the real get_anthropic_client runs
+    # and reads os.environ. DB dependency still needs a stub because it
+    # resolves alongside the anthropic dependency.
+    _install_db(instrument_row=None)
+    import os
+
+    prior = os.environ.pop("ANTHROPIC_API_KEY", None)
+    try:
+        resp = client.post("/instruments/AAPL/thesis")
+    finally:
+        if prior is not None:
+            os.environ["ANTHROPIC_API_KEY"] = prior
+        _clear_db()
+    assert resp.status_code == 503
+    assert "ANTHROPIC_API_KEY" in resp.json()["detail"]
+
+
+def test_thesis_unknown_symbol_returns_404(client: TestClient) -> None:
+    _install_anthropic_stub()
+    _install_db(instrument_row=None)
+    try:
+        resp = client.post("/instruments/NOTREAL/thesis")
+    finally:
+        _clear_db()
+    assert resp.status_code == 404
+
+
+def test_thesis_empty_symbol_returns_400(client: TestClient) -> None:
+    _install_anthropic_stub()
+    _install_db(instrument_row=None)
+    try:
+        resp = client.post("/instruments/%20/thesis")
+    finally:
+        _clear_db()
+    assert resp.status_code == 400
+
+
+def test_thesis_cache_hit_returns_cached_without_llm(client: TestClient) -> None:
+    """Within 24h of the last thesis, the endpoint returns the cached row
+    without calling generate_thesis / Anthropic."""
+    _install_anthropic_stub()
+    cached = _thesis_row()
+    _install_db(
+        instrument_row={"instrument_id": 42},
+        cached_thesis=cached,
+    )
+    with patch("app.api.theses.generate_thesis") as gen_mock:
+        try:
+            resp = client.post("/instruments/AAPL/thesis")
+        finally:
+            _clear_db()
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["cached"] is True
+    assert body["thesis"]["thesis_id"] == 101
+    assert body["thesis"]["stance"] == "buy"
+    gen_mock.assert_not_called()
+
+
+def test_thesis_cache_miss_generates_and_returns_fresh(client: TestClient) -> None:
+    """No thesis within the 24h window → generate_thesis is called, the
+    fresh row is re-read and returned."""
+    _install_anthropic_stub()
+    fresh = _thesis_row(
+        thesis_id=202,
+        thesis_version=4,
+        memo_markdown="# Fresh\nUpdated thesis.",
+        created_at=datetime.now(UTC),
+    )
+    _install_db(
+        instrument_row={"instrument_id": 42},
+        cached_thesis=None,  # cache miss
+        fresh_thesis=fresh,
+    )
+    with patch("app.api.theses.generate_thesis") as gen_mock:
+        try:
+            resp = client.post("/instruments/AAPL/thesis")
+        finally:
+            _clear_db()
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["cached"] is False
+    assert body["thesis"]["thesis_id"] == 202
+    assert body["thesis"]["memo_markdown"].startswith("# Fresh")
+    gen_mock.assert_called_once()
+
+
+def test_thesis_generate_failure_returns_502(client: TestClient) -> None:
+    """When generate_thesis raises (Anthropic outage, DB transient, etc.)
+    the endpoint surfaces 502 rather than letting the 500 propagate."""
+    _install_anthropic_stub()
+    _install_db(
+        instrument_row={"instrument_id": 42},
+        cached_thesis=None,
+    )
+    with patch(
+        "app.api.theses.generate_thesis",
+        side_effect=RuntimeError("anthropic is down"),
+    ):
+        try:
+            resp = client.post("/instruments/AAPL/thesis")
+        finally:
+            _clear_db()
+
+    assert resp.status_code == 502
+    assert "thesis generation failed" in resp.json()["detail"]


### PR DESCRIPTION
## Summary
Phase 2.4 of the [2026-04-19 research-tool refocus](docs/superpowers/specs/2026-04-19-research-tool-refocus.md).

On-demand thesis generation: the UI POSTs, the endpoint wraps the existing \`generate_thesis\` service (Anthropic writer + critic calls, versioned append-only insert into \`theses\`) with a 24h per-ticker cache.

## Behavior
- **400** if symbol is whitespace-only
- **404** if symbol not in the local \`instruments\` table
- **503** if \`ANTHROPIC_API_KEY\` is unset (fails closed)
- **200** \`cached=true\` when a thesis row exists within the 24h window (no LLM spend)
- **200** \`cached=false\` when generation succeeded
- **502** when \`generate_thesis\` raises (Anthropic outage, transient DB)

New \`get_anthropic_client\` dependency — constructed per request. 503 raised inside the dependency keeps the rest of the API unaffected by missing credentials.

## Test plan
- \`tests/test_api_instrument_thesis.py\` — 6 cases (unknown symbol 404, empty 400, missing key 503, cache hit no-LLM, cache miss LLM-called, generation failure 502)
- \`uv run pytest\` — 2196 passed, 1 skipped
- \`uv run ruff check .\` / \`ruff format --check .\` / \`pyright\` — clean