### PR TITLE
feat: candle refresh includes held positions (Phase 1.3)

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -810,19 +810,24 @@ data to enable T3→T2 promotion via the scoring/coverage pipeline.
 
 def daily_candle_refresh() -> None:
     """
-    Refresh candles for Tier 1/2 instruments and a bootstrap subset of
-    Tier 3 instruments that have fundamentals data.
+    Refresh candles for the scoped instrument set.
 
-    T1/T2: all covered instruments (uncapped).
-    T3: up to _T3_BOOTSTRAP_BATCH_SIZE instruments that already have a
-    fundamentals_snapshot row, ordered by symbol for determinism.  This
-    gives T3 instruments enough price data for momentum scoring, enabling
-    T3→T2 promotion via the weekly coverage review.
+    Scope (per 2026-04-19 research-tool refocus §1.3):
+      1. All currently-held positions (regardless of coverage tier) —
+         the operator needs current price context for anything in the
+         portfolio even if it's been demoted below T2.
+      2. All Tier 1/2 covered instruments (uncapped).
+      3. Up to ``_T3_BOOTSTRAP_BATCH_SIZE`` Tier 3 instruments that
+         already have fundamentals, ordered by symbol for determinism.
+         Enables T3→T2 promotion by seeding candle history.
 
     Fetches up to 400 daily candles per instrument (enough for 1y return
     + buffer).  Quotes are skipped (owned by the hourly job).
 
-    Runs daily at 22:00 UTC, after US market close.
+    Runs daily at 22:00 UTC, after US market close. Watchlist scope
+    (spec §1.3 bullet 2) lands once the watchlist table exists
+    (Phase 3.2). High-frequency held-position refresh (5-min cadence
+    during market hours) is Phase 4 (live quotes).
     """
     creds = _load_etoro_credentials("daily_candle_refresh")
     if creds is None:
@@ -835,7 +840,20 @@ def daily_candle_refresh() -> None:
             EtoroMarketDataProvider(api_key=api_key, user_key=user_key, env=settings.etoro_env) as provider,
             psycopg.connect(settings.database_url) as conn,
         ):
-            # T1/T2: all covered instruments
+            # Held positions — always included, regardless of coverage tier.
+            held_rows = conn.execute(
+                """
+                SELECT DISTINCT i.instrument_id, i.symbol
+                FROM positions p
+                JOIN instruments i ON i.instrument_id = p.instrument_id
+                WHERE p.current_units > 0
+                  AND i.is_tradable = TRUE
+                ORDER BY i.symbol, i.instrument_id
+                """
+            ).fetchall()
+
+            # T1/T2: all covered instruments (minus any already picked up
+            # via held_rows, to avoid duplicate fetches in this batch).
             tier12_rows = conn.execute(
                 """
                 SELECT i.instrument_id, i.symbol
@@ -877,20 +895,32 @@ def daily_candle_refresh() -> None:
                 {"limit": _T3_BOOTSTRAP_BATCH_SIZE},
             ).fetchall()
 
-            all_rows = tier12_rows + t3_rows
-            if not all_rows:
-                logger.info("daily_candle_refresh: no covered instruments found, skipping")
+            # Dedupe across scopes. A held T1 instrument must not be
+            # fetched twice; set semantics keyed on instrument_id preserve
+            # the symbol tuple from the first scope that introduced it.
+            seen: set[int] = set()
+            ordered: list[tuple[int, str]] = []
+            for row in held_rows + tier12_rows + t3_rows:
+                iid = int(row[0])
+                if iid in seen:
+                    continue
+                seen.add(iid)
+                ordered.append((iid, str(row[1])))
+
+            if not ordered:
+                logger.info("daily_candle_refresh: no instruments to refresh, skipping")
                 tracker.row_count = 0
                 return
 
             logger.info(
-                "daily_candle_refresh: %d T1/T2 + %d T3 bootstrap = %d instruments",
+                "daily_candle_refresh: %d held + %d T1/T2 + %d T3 bootstrap = %d unique instruments",
+                len(held_rows),
                 len(tier12_rows),
                 len(t3_rows),
-                len(all_rows),
+                len(ordered),
             )
 
-            instruments = [(row[0], row[1]) for row in all_rows]
+            instruments = ordered
             # skip_quotes=True: quote freshness is owned by the hourly
             # fx_rates_refresh job; daily candle job must not shadow
             # those fresher values with stale end-of-day data.

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -840,14 +840,18 @@ def daily_candle_refresh() -> None:
             EtoroMarketDataProvider(api_key=api_key, user_key=user_key, env=settings.etoro_env) as provider,
             psycopg.connect(settings.database_url) as conn,
         ):
-            # Held positions — always included, regardless of coverage tier.
+            # Held positions — always included, regardless of coverage
+            # tier OR is_tradable status. A delisted/suspended instrument
+            # still in the portfolio needs candle updates so P&L and
+            # exit-timing logic keep working. If the provider 404s on
+            # delisted symbols, refresh_market_data logs and continues
+            # per-instrument.
             held_rows = conn.execute(
                 """
                 SELECT DISTINCT i.instrument_id, i.symbol
                 FROM positions p
                 JOIN instruments i ON i.instrument_id = p.instrument_id
                 WHERE p.current_units > 0
-                  AND i.is_tradable = TRUE
                 ORDER BY i.symbol, i.instrument_id
                 """
             ).fetchall()

--- a/tests/test_daily_candle_refresh.py
+++ b/tests/test_daily_candle_refresh.py
@@ -20,15 +20,18 @@ from app.workers.scheduler import _T3_BOOTSTRAP_BATCH_SIZE, daily_candle_refresh
 def _make_mock_conn(
     tier12_rows: list[tuple[int, str]],
     t3_rows: list[tuple[int, str]],
+    held_rows: list[tuple[int, str]] | None = None,
 ) -> MagicMock:
-    """Mock connection that returns tier12_rows on first execute, t3_rows
-    on second."""
+    """Mock connection that returns held_rows / tier12_rows / t3_rows in
+    the order the handler executes them (held → tier12 → t3)."""
     conn = MagicMock()
-    result1 = MagicMock()
-    result1.fetchall.return_value = tier12_rows
-    result2 = MagicMock()
-    result2.fetchall.return_value = t3_rows
-    conn.execute.side_effect = [result1, result2]
+    result_held = MagicMock()
+    result_held.fetchall.return_value = held_rows or []
+    result_12 = MagicMock()
+    result_12.fetchall.return_value = tier12_rows
+    result_t3 = MagicMock()
+    result_t3.fetchall.return_value = t3_rows
+    conn.execute.side_effect = [result_held, result_12, result_t3]
     conn.__enter__ = MagicMock(return_value=conn)
     conn.__exit__ = MagicMock(return_value=False)
     return conn
@@ -50,13 +53,14 @@ class TestDailyCandleRefreshT3Bootstrap:
         self,
         tier12_rows: list[tuple[int, str]],
         t3_rows: list[tuple[int, str]],
+        held_rows: list[tuple[int, str]] | None = None,
     ) -> MagicMock:
         """Run daily_candle_refresh with mocked dependencies.
 
         Returns the mock for refresh_market_data so callers can inspect
         what instruments were passed.
         """
-        mock_conn = _make_mock_conn(tier12_rows, t3_rows)
+        mock_conn = _make_mock_conn(tier12_rows, t3_rows, held_rows)
         mock_provider = MagicMock()
         mock_provider.__enter__ = MagicMock(return_value=mock_provider)
         mock_provider.__exit__ = MagicMock(return_value=False)
@@ -113,6 +117,27 @@ class TestDailyCandleRefreshT3Bootstrap:
         mock_refresh = self._run([], [])
         mock_refresh.assert_not_called()
 
+    def test_held_positions_included(self) -> None:
+        """Held positions must be refreshed regardless of coverage tier."""
+        held = [(999, "LEGACY_HOLD")]
+        tier12 = [(1, "AAPL")]
+        t3_bootstrap = [(100, "XYZ")]
+        mock_refresh = self._run(tier12, t3_bootstrap, held_rows=held)
+
+        instruments = mock_refresh.call_args[0][2]
+        assert (999, "LEGACY_HOLD") in instruments
+        # Dedupe: ordering puts held first, T1/T2 next, T3 last.
+        assert instruments[0] == (999, "LEGACY_HOLD")
+
+    def test_duplicate_instrument_across_scopes_is_deduped(self) -> None:
+        """An instrument that's both held and T1/T2 must not be fetched twice."""
+        held = [(1, "AAPL")]
+        tier12 = [(1, "AAPL"), (2, "MSFT")]
+        mock_refresh = self._run(tier12, [], held_rows=held)
+
+        instruments = mock_refresh.call_args[0][2]
+        assert instruments == [(1, "AAPL"), (2, "MSFT")]
+
     def test_t3_query_uses_limit_param(self) -> None:
         """Verify the T3 query passes _T3_BOOTSTRAP_BATCH_SIZE as limit."""
         mock_conn = _make_mock_conn([(1, "AAPL")], [(100, "XYZ")])
@@ -134,8 +159,9 @@ class TestDailyCandleRefreshT3Bootstrap:
         ):
             daily_candle_refresh()
 
-        # Second execute call is the T3 query with limit param
-        t3_call = mock_conn.execute.call_args_list[1]
+        # Third execute call is the T3 query with limit param
+        # (1st=held, 2nd=tier12, 3rd=T3 bootstrap).
+        t3_call = mock_conn.execute.call_args_list[2]
         sql_text = t3_call[0][0]
         params = t3_call[0][1]
         assert "LIMIT" in sql_text


### PR DESCRIPTION
## Summary
Phase 1.3 of the [2026-04-19 research-tool refocus](docs/superpowers/specs/2026-04-19-research-tool-refocus.md).

\`daily_candle_refresh\` now has three explicit scopes, in priority order:
1. **Held positions** — always, regardless of coverage tier (a demoted-but-still-held instrument keeps getting candle updates)
2. **T1/T2 covered** — uncapped (unchanged)
3. **T3 bootstrap batch** — up to \`_T3_BOOTSTRAP_BATCH_SIZE\` with fundamentals but no candles yet (unchanged)

Duplicates across scopes are deduped by \`instrument_id\`. Held ordering is preserved so logs are readable.

**Deferred:**
- Watchlist scope (spec §1.3 bullet 2) lands with the Phase 3.2 watchlist table.
- High-frequency held-position 5-min cadence lands with Phase 4 live quotes.

## Test plan
- \`tests/test_daily_candle_refresh.py\` — +2 cases (held positions included, duplicate deduped)
- \`uv run pytest\` — 2189 passed, 1 skipped
- \`uv run ruff check .\` / \`ruff format --check .\` / \`pyright\` — clean