### PR TITLE
feat: retire attribution_summary from SCHEDULED_JOBS (Phase 1.4)

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -451,13 +451,10 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         cadence=Cadence.weekly(weekday=0, hour=5, minute=0),  # Monday 05:00 UTC
         prerequisite=_has_any_coverage,
     ),
-    ScheduledJob(
-        name=JOB_ATTRIBUTION_SUMMARY,
-        description="Compute and persist rolling attribution summaries (30d, 90d, 365d).",
-        cadence=Cadence.weekly(weekday=6, hour=6, minute=0),
-        prerequisite=_has_attributions,
-        catch_up_on_boot=False,
-    ),
+    # attribution_summary retired from scheduling in Phase 1.4 of the
+    # 2026-04-19 research-tool refocus — no UI consumer today. The
+    # function body stays in scheduler.py + _INVOKERS so the operator
+    # can still manually fire it from Admin "Run now" if needed.
     ScheduledJob(
         name=JOB_RAW_DATA_RETENTION_SWEEP,
         description=(

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -343,6 +343,10 @@ class TestProductionInvokerRegistry:
             "morning_candidate_review",
             "seed_cost_models",
             "weekly_report",
+            # Phase 1.4: attribution_summary retired from SCHEDULED_JOBS
+            # (no UI consumer). Function stays in _INVOKERS for manual
+            # trigger from Admin "Run now".
+            "attribution_summary",
             # daily_cik_refresh + daily_financial_facts retired from _INVOKERS
             # in Chunk 3 of the 2026-04-19 research-tool refocus; they are
             # now called from inside fundamentals_sync.


### PR DESCRIPTION
## Summary
Phase 1.4 of the [2026-04-19 research-tool refocus](docs/superpowers/specs/2026-04-19-research-tool-refocus.md).

\`attribution_summary\` has no UI consumer today. Retired from \`SCHEDULED_JOBS\`. Function body + \`_INVOKERS\` entry remain so operators can still manually fire it from Admin 'Run now' if needed.

**Net scheduled jobs: 8 → 7.**

## Test plan
- \`uv run pytest\` — 2189 passed, 1 skipped (\`test_every_invoker_is_scheduled_or_on_demand\` updated to track the new on-demand set)
- \`uv run ruff check .\` — clean