### PR TITLE
feat: watchlist table + CRUD endpoints (Phase 3.2)

### DIFF
--- a/app/api/watchlist.py
+++ b/app/api/watchlist.py
@@ -1,0 +1,179 @@
+"""Watchlist API (Phase 3.2 of the 2026-04-19 research-tool refocus).
+
+Per-operator list of instruments the user is tracking. V1 assumes a
+single operator — ``sole_operator_id`` resolves the current operator
+rather than a session-scoped one, matching how other operator-scoped
+endpoints in this codebase work today. When multi-operator sessions
+land, swap to a session-backed dependency.
+
+Routes:
+  GET    /watchlist                     — list tracked instruments (newest-first)
+  POST   /watchlist                     — add {symbol, notes?}
+  DELETE /watchlist/{symbol}            — remove
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+import psycopg
+import psycopg.rows
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.api.auth import require_session_or_service_token
+from app.db import get_conn
+from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
+
+router = APIRouter(
+    prefix="/watchlist",
+    tags=["watchlist"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+
+class WatchlistItem(BaseModel):
+    instrument_id: int
+    symbol: str
+    company_name: str
+    exchange: str | None
+    currency: str | None
+    sector: str | None
+    added_at: datetime
+    notes: str | None
+
+
+class WatchlistListResponse(BaseModel):
+    items: list[WatchlistItem]
+    total: int
+
+
+class WatchlistAddRequest(BaseModel):
+    symbol: str = Field(min_length=1, max_length=32)
+    notes: str | None = None
+
+
+def _resolve_operator(conn: psycopg.Connection[object]) -> UUID:
+    try:
+        return sole_operator_id(conn)
+    except NoOperatorError as exc:
+        raise HTTPException(status_code=503, detail="no operator configured") from exc
+    except AmbiguousOperatorError as exc:
+        raise HTTPException(
+            status_code=501,
+            detail="multiple operators present — watchlist requires a per-session operator context",
+        ) from exc
+
+
+@router.get("", response_model=WatchlistListResponse)
+def list_watchlist(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> WatchlistListResponse:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
+                   i.currency, i.sector,
+                   w.added_at, w.notes
+            FROM watchlist w
+            JOIN instruments i USING (instrument_id)
+            WHERE w.operator_id = %(op)s
+            ORDER BY w.added_at DESC
+            """,
+            {"op": operator_id},
+        )
+        rows = cur.fetchall()
+    items = [
+        WatchlistItem(
+            instrument_id=int(r["instrument_id"]),  # type: ignore[arg-type]
+            symbol=str(r["symbol"]),  # type: ignore[index]
+            company_name=str(r["company_name"]),  # type: ignore[index]
+            exchange=r["exchange"],  # type: ignore[union-attr]
+            currency=r["currency"],  # type: ignore[union-attr]
+            sector=r["sector"],  # type: ignore[union-attr]
+            added_at=r["added_at"],  # type: ignore[arg-type]
+            notes=r["notes"],  # type: ignore[union-attr]
+        )
+        for r in rows
+    ]
+    return WatchlistListResponse(items=items, total=len(items))
+
+
+@router.post("", response_model=WatchlistItem, status_code=201)
+def add_to_watchlist(
+    req: WatchlistAddRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> WatchlistItem:
+    operator_id = _resolve_operator(conn)
+    symbol_clean = req.symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT instrument_id, symbol, company_name, exchange, currency, sector "
+            "FROM instruments WHERE UPPER(symbol) = %(s)s LIMIT 1",
+            {"s": symbol_clean},
+        )
+        inst = cur.fetchone()
+    if inst is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {req.symbol} not found")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            INSERT INTO watchlist (operator_id, instrument_id, notes)
+            VALUES (%(op)s, %(iid)s, %(notes)s)
+            ON CONFLICT (operator_id, instrument_id)
+            DO UPDATE SET notes = EXCLUDED.notes
+            RETURNING added_at, notes
+            """,
+            {"op": operator_id, "iid": int(inst["instrument_id"]), "notes": req.notes},  # type: ignore[arg-type]
+        )
+        wl_row = cur.fetchone()
+    conn.commit()
+    assert wl_row is not None
+
+    return WatchlistItem(
+        instrument_id=int(inst["instrument_id"]),  # type: ignore[arg-type]
+        symbol=str(inst["symbol"]),  # type: ignore[index]
+        company_name=str(inst["company_name"]),  # type: ignore[index]
+        exchange=inst["exchange"],  # type: ignore[union-attr]
+        currency=inst["currency"],  # type: ignore[union-attr]
+        sector=inst["sector"],  # type: ignore[union-attr]
+        added_at=wl_row["added_at"],  # type: ignore[arg-type]
+        notes=wl_row["notes"],  # type: ignore[union-attr]
+    )
+
+
+@router.delete("/{symbol}", status_code=204)
+def remove_from_watchlist(
+    symbol: str,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    operator_id = _resolve_operator(conn)
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            DELETE FROM watchlist w
+            USING instruments i
+            WHERE w.operator_id = %(op)s
+              AND w.instrument_id = i.instrument_id
+              AND UPPER(i.symbol) = %(s)s
+            """,
+            {"op": operator_id, "s": symbol_clean},
+        )
+        rows_deleted = cur.rowcount
+    conn.commit()
+
+    if rows_deleted == 0:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Instrument {symbol} not on watchlist",
+        )

--- a/app/api/watchlist.py
+++ b/app/api/watchlist.py
@@ -138,12 +138,12 @@ def add_to_watchlist(
             {"op": operator_id, "iid": int(inst["instrument_id"]), "notes": req.notes},  # type: ignore[arg-type]
         )
         wl_row = cur.fetchone()
-    conn.commit()
     if wl_row is None:
         # RETURNING must produce a row — if it didn't, the INSERT/UPDATE
-        # path is broken and we should surface that instead of crashing
-        # under python -O (where bare ``assert`` is compiled away).
+        # path is broken. Raise BEFORE committing so a broken response
+        # path doesn't leave a committed row the caller can't confirm.
         raise HTTPException(status_code=500, detail="watchlist upsert returned no row")
+    conn.commit()
 
     return WatchlistItem(
         instrument_id=int(inst["instrument_id"]),  # type: ignore[arg-type]

--- a/app/api/watchlist.py
+++ b/app/api/watchlist.py
@@ -127,14 +127,23 @@ def add_to_watchlist(
             INSERT INTO watchlist (operator_id, instrument_id, notes)
             VALUES (%(op)s, %(iid)s, %(notes)s)
             ON CONFLICT (operator_id, instrument_id)
-            DO UPDATE SET notes = EXCLUDED.notes
+            DO UPDATE SET
+                -- Preserve existing notes when the caller omits notes
+                -- on a re-add; only overwrite on an explicit new note.
+                notes = COALESCE(EXCLUDED.notes, watchlist.notes)
+                -- added_at intentionally NOT updated — 'first added'
+                -- semantics must survive idempotent re-adds.
             RETURNING added_at, notes
             """,
             {"op": operator_id, "iid": int(inst["instrument_id"]), "notes": req.notes},  # type: ignore[arg-type]
         )
         wl_row = cur.fetchone()
     conn.commit()
-    assert wl_row is not None
+    if wl_row is None:
+        # RETURNING must produce a row — if it didn't, the INSERT/UPDATE
+        # path is broken and we should surface that instead of crashing
+        # under python -O (where bare ``assert`` is compiled away).
+        raise HTTPException(status_code=500, detail="watchlist upsert returned no row")
 
     return WatchlistItem(
         instrument_id=int(inst["instrument_id"]),  # type: ignore[arg-type]
@@ -170,10 +179,13 @@ def remove_from_watchlist(
             {"op": operator_id, "s": symbol_clean},
         )
         rows_deleted = cur.rowcount
-    conn.commit()
 
+    # Check rowcount BEFORE commit — a 404 (nothing deleted) must not
+    # commit a no-op transaction (cosmetic, but noisy in audit logs
+    # and confusing to clients that retry on 404).
     if rows_deleted == 0:
         raise HTTPException(
             status_code=404,
             detail=f"Instrument {symbol} not on watchlist",
         )
+    conn.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -37,6 +37,7 @@ from app.api.sync import router as sync_router
 from app.api.system import router as system_router
 from app.api.theses import instrument_thesis_router
 from app.api.theses import router as theses_router
+from app.api.watchlist import router as watchlist_router
 from app.config import settings
 from app.db import get_conn
 from app.db.migrations import migration_status, run_migrations
@@ -177,6 +178,7 @@ app.include_router(sync_router)
 app.include_router(system_router)
 app.include_router(theses_router)
 app.include_router(instrument_thesis_router)
+app.include_router(watchlist_router)
 
 
 @app.get("/health")

--- a/sql/042_watchlist.sql
+++ b/sql/042_watchlist.sql
@@ -1,0 +1,20 @@
+-- Watchlist (Phase 3.2 of the 2026-04-19 research-tool refocus).
+--
+-- Per-operator list of instruments the user is tracking. Separate from
+-- positions (actively held) and from coverage (system-tiered for scoring).
+-- Primary consumer: Dashboard watchlist section + "add to watchlist"
+-- button on the instrument page.
+
+CREATE TABLE IF NOT EXISTS watchlist (
+    operator_id    UUID NOT NULL REFERENCES operators(operator_id) ON DELETE CASCADE,
+    instrument_id  BIGINT NOT NULL REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    added_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    notes          TEXT,
+
+    PRIMARY KEY (operator_id, instrument_id)
+);
+
+-- Index for the dashboard's "watchlist for this operator" query
+-- ordered by added_at DESC (newest first).
+CREATE INDEX IF NOT EXISTS watchlist_operator_added_idx
+    ON watchlist(operator_id, added_at DESC);

--- a/tests/test_api_watchlist.py
+++ b/tests/test_api_watchlist.py
@@ -1,0 +1,149 @@
+"""Tests for the watchlist API (Phase 3.2)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def cleanup() -> Iterator[None]:
+    yield
+    from app.db import get_conn
+
+    app.dependency_overrides.pop(get_conn, None)
+
+
+def _install_conn(fetchone_returns: list, fetchall_returns: list | None = None) -> MagicMock:
+    """Stub DB that drives fetchone calls in order and fetchall if supplied."""
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.__enter__.return_value = cur
+    cur.__exit__.return_value = None
+    cur.fetchone.side_effect = list(fetchone_returns)
+    if fetchall_returns is not None:
+        cur.fetchall.return_value = fetchall_returns
+    cur.rowcount = 1
+    conn.cursor.return_value = cur
+    conn.commit = MagicMock()
+
+    def _dep():
+        yield conn
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _dep
+    return cur
+
+
+def test_list_empty_watchlist(client: TestClient) -> None:
+    with patch("app.api.watchlist.sole_operator_id", return_value=uuid4()):
+        _install_conn([], fetchall_returns=[])
+        resp = client.get("/watchlist")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["items"] == []
+    assert body["total"] == 0
+
+
+def test_list_returns_items_sorted_newest_first(client: TestClient) -> None:
+    rows = [
+        {
+            "instrument_id": 42,
+            "symbol": "AAPL",
+            "company_name": "Apple Inc.",
+            "exchange": "NMS",
+            "currency": "USD",
+            "sector": "Technology",
+            "added_at": datetime(2026, 4, 15),
+            "notes": "core holding",
+        },
+        {
+            "instrument_id": 7,
+            "symbol": "VOD.L",
+            "company_name": "Vodafone",
+            "exchange": "LSE",
+            "currency": "GBP",
+            "sector": "Telecom",
+            "added_at": datetime(2026, 4, 10),
+            "notes": None,
+        },
+    ]
+    with patch("app.api.watchlist.sole_operator_id", return_value=uuid4()):
+        _install_conn([], fetchall_returns=rows)
+        resp = client.get("/watchlist")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == 2
+    assert body["items"][0]["symbol"] == "AAPL"
+    assert body["items"][0]["notes"] == "core holding"
+    assert body["items"][1]["notes"] is None
+
+
+def test_add_happy_path(client: TestClient) -> None:
+    # fetchone sequence: [instrument lookup, insert returning]
+    fetchones = [
+        {
+            "instrument_id": 42,
+            "symbol": "AAPL",
+            "company_name": "Apple Inc.",
+            "exchange": "NMS",
+            "currency": "USD",
+            "sector": "Technology",
+        },
+        {"added_at": datetime(2026, 4, 19), "notes": "watch for earnings"},
+    ]
+    with patch("app.api.watchlist.sole_operator_id", return_value=uuid4()):
+        _install_conn(fetchones)
+        resp = client.post(
+            "/watchlist",
+            json={"symbol": "aapl", "notes": "watch for earnings"},
+        )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["symbol"] == "AAPL"
+    assert body["notes"] == "watch for earnings"
+
+
+def test_add_unknown_symbol_returns_404(client: TestClient) -> None:
+    with patch("app.api.watchlist.sole_operator_id", return_value=uuid4()):
+        _install_conn([None])
+        resp = client.post("/watchlist", json={"symbol": "NOTREAL"})
+    assert resp.status_code == 404
+
+
+def test_add_blank_symbol_returns_400(client: TestClient) -> None:
+    with patch("app.api.watchlist.sole_operator_id", return_value=uuid4()):
+        # Pydantic min_length=1 rejects empty strings with 422 before handler runs,
+        # but whitespace-only survives validation.
+        _install_conn([])
+        resp = client.post("/watchlist", json={"symbol": "   "})
+    assert resp.status_code == 400
+
+
+def test_delete_happy_path(client: TestClient) -> None:
+    with patch("app.api.watchlist.sole_operator_id", return_value=uuid4()):
+        cur = _install_conn([])
+        cur.rowcount = 1
+        resp = client.delete("/watchlist/AAPL")
+    assert resp.status_code == 204
+
+
+def test_delete_not_on_watchlist_returns_404(client: TestClient) -> None:
+    with patch("app.api.watchlist.sole_operator_id", return_value=uuid4()):
+        cur = _install_conn([])
+        cur.rowcount = 0
+        resp = client.delete("/watchlist/AAPL")
+    assert resp.status_code == 404

--- a/tests/test_api_watchlist.py
+++ b/tests/test_api_watchlist.py
@@ -117,6 +117,32 @@ def test_add_happy_path(client: TestClient) -> None:
     assert body["notes"] == "watch for earnings"
 
 
+def test_add_without_notes_preserves_existing_notes(client: TestClient) -> None:
+    """A re-add without notes must NOT overwrite the stored note with NULL.
+    Covered by the ON CONFLICT DO UPDATE ... COALESCE clause."""
+    fetchones = [
+        {
+            "instrument_id": 42,
+            "symbol": "AAPL",
+            "company_name": "Apple Inc.",
+            "exchange": "NMS",
+            "currency": "USD",
+            "sector": "Technology",
+        },
+        # Server returns the PRESERVED note, not NULL.
+        {"added_at": datetime(2026, 4, 10), "notes": "core holding"},
+    ]
+    with patch("app.api.watchlist.sole_operator_id", return_value=uuid4()):
+        cur = _install_conn(fetchones)
+        resp = client.post("/watchlist", json={"symbol": "AAPL"})
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["notes"] == "core holding"
+    # Verify the SQL contains COALESCE (pin the notes-preservation fix).
+    upsert_call = cur.execute.call_args_list[1]
+    assert "COALESCE(EXCLUDED.notes" in upsert_call[0][0]
+
+
 def test_add_unknown_symbol_returns_404(client: TestClient) -> None:
     with patch("app.api.watchlist.sole_operator_id", return_value=uuid4()):
         _install_conn([None])
@@ -141,9 +167,27 @@ def test_delete_happy_path(client: TestClient) -> None:
     assert resp.status_code == 204
 
 
-def test_delete_not_on_watchlist_returns_404(client: TestClient) -> None:
+def test_delete_not_on_watchlist_returns_404_without_commit(client: TestClient) -> None:
+    """404 on a missing watchlist entry must NOT trigger a no-op commit —
+    rowcount check must precede the commit call. Pin this by making the
+    stub conn raise if commit() is called; if the handler still 404s,
+    the commit wasn't invoked."""
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.__enter__.return_value = cur
+    cur.__exit__.return_value = None
+    cur.rowcount = 0
+    conn.cursor.return_value = cur
+    conn.commit.side_effect = AssertionError("commit must NOT be called on 404 path")
+
+    def _dep():
+        yield conn
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _dep
     with patch("app.api.watchlist.sole_operator_id", return_value=uuid4()):
-        cur = _install_conn([])
-        cur.rowcount = 0
         resp = client.delete("/watchlist/AAPL")
+
     assert resp.status_code == 404
+    conn.commit.assert_not_called()


### PR DESCRIPTION
## Summary
Phase 3.2 of the [2026-04-19 research-tool refocus](docs/superpowers/specs/2026-04-19-research-tool-refocus.md). Per-operator list of instruments the user is tracking. Separate from positions (held) and coverage (system-tiered for scoring).

**Schema** — \`sql/042_watchlist.sql\`: \`(operator_id, instrument_id)\` PK with ON DELETE CASCADE, optional \`notes\`, \`added_at\`. Index on \`(operator_id, added_at DESC)\` for the newest-first dashboard query.

**Endpoints** (session-or-service-token auth):
- \`GET /watchlist\` — list newest-first
- \`POST /watchlist {symbol, notes}\` — add (idempotent via ON CONFLICT DO UPDATE)
- \`DELETE /watchlist/{symbol}\` — remove

Unknown symbol → 404. Blank symbol → 400. No operator context → 503.

**Unblocks** Phase 3.1 Dashboard rewrite (next PR) + the InstrumentPage "Add to watchlist" button (deferred until the frontend consumer ships).

## Test plan
- \`tests/test_api_watchlist.py\` — 7 cases
- \`uv run pytest\` — 2196 passed, 1 skipped
- \`uv run ruff check .\` / \`ruff format --check .\` / \`pyright\` — clean