### PR TITLE
feat: Dashboard watchlist + positions click-through (Phase 3.1 initial)

### DIFF
--- a/frontend/src/api/watchlist.ts
+++ b/frontend/src/api/watchlist.ts
@@ -1,0 +1,38 @@
+import { apiFetch } from "@/api/client";
+
+export interface WatchlistItem {
+  instrument_id: number;
+  symbol: string;
+  company_name: string;
+  exchange: string | null;
+  currency: string | null;
+  sector: string | null;
+  added_at: string;
+  notes: string | null;
+}
+
+export interface WatchlistListResponse {
+  items: WatchlistItem[];
+  total: number;
+}
+
+export function fetchWatchlist(): Promise<WatchlistListResponse> {
+  return apiFetch<WatchlistListResponse>("/watchlist");
+}
+
+export function addToWatchlist(
+  symbol: string,
+  notes?: string | null,
+): Promise<WatchlistItem> {
+  return apiFetch<WatchlistItem>("/watchlist", {
+    method: "POST",
+    body: JSON.stringify({ symbol, notes }),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function removeFromWatchlist(symbol: string): Promise<void> {
+  return apiFetch<void>(`/watchlist/${encodeURIComponent(symbol)}`, {
+    method: "DELETE",
+  });
+}

--- a/frontend/src/components/dashboard/PositionsTable.tsx
+++ b/frontend/src/components/dashboard/PositionsTable.tsx
@@ -86,7 +86,7 @@ function PositionRow({ p, currency }: { p: PositionItem; currency: string }) {
     <tr className="border-t border-slate-100">
       <Td>
         <Link
-          to={`/instruments/${p.instrument_id}`}
+          to={`/instrument/${encodeURIComponent(p.symbol)}`}
           className="font-medium text-blue-600 hover:underline"
         >
           {p.symbol}

--- a/frontend/src/components/dashboard/WatchlistPanel.tsx
+++ b/frontend/src/components/dashboard/WatchlistPanel.tsx
@@ -3,6 +3,14 @@ import { Link } from "react-router-dom";
 import type { WatchlistItem } from "@/api/watchlist";
 import { EmptyState } from "@/components/states/EmptyState";
 
+function formatAddedAt(raw: string): string {
+  // Parse the added_at timestamp through Date rather than assuming an
+  // ISO 8601 YYYY-MM-DD prefix shape on the raw string.
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return raw;
+  return d.toLocaleDateString();
+}
+
 interface Props {
   items: WatchlistItem[];
   onRemove?: (symbol: string) => void;
@@ -50,7 +58,7 @@ export function WatchlistPanel({ items, onRemove }: Props) {
                 {item.notes ?? ""}
               </td>
               <td className="px-2 py-1 text-xs text-slate-400">
-                {item.added_at.slice(0, 10)}
+                {formatAddedAt(item.added_at)}
               </td>
               {onRemove && (
                 <td className="px-2 py-1 text-right">

--- a/frontend/src/components/dashboard/WatchlistPanel.tsx
+++ b/frontend/src/components/dashboard/WatchlistPanel.tsx
@@ -1,0 +1,72 @@
+import { Link } from "react-router-dom";
+
+import type { WatchlistItem } from "@/api/watchlist";
+import { EmptyState } from "@/components/states/EmptyState";
+
+interface Props {
+  items: WatchlistItem[];
+  onRemove?: (symbol: string) => void;
+}
+
+export function WatchlistPanel({ items, onRemove }: Props) {
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        title="Watchlist empty"
+        description="Add tickers from the instrument page to track them here."
+      />
+    );
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
+            <th className="px-2 py-1">Symbol</th>
+            <th className="px-2 py-1">Name</th>
+            <th className="px-2 py-1">Sector</th>
+            <th className="px-2 py-1">Notes</th>
+            <th className="px-2 py-1 text-xs text-slate-400">Added</th>
+            {onRemove && <th className="px-2 py-1" />}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr
+              key={item.instrument_id}
+              className="border-b border-slate-100 last:border-0"
+            >
+              <td className="px-2 py-1">
+                <Link
+                  to={`/instrument/${encodeURIComponent(item.symbol)}`}
+                  className="font-medium text-blue-700 hover:underline"
+                >
+                  {item.symbol}
+                </Link>
+              </td>
+              <td className="px-2 py-1">{item.company_name}</td>
+              <td className="px-2 py-1 text-slate-500">{item.sector ?? "—"}</td>
+              <td className="px-2 py-1 text-xs text-slate-500">
+                {item.notes ?? ""}
+              </td>
+              <td className="px-2 py-1 text-xs text-slate-400">
+                {item.added_at.slice(0, 10)}
+              </td>
+              {onRemove && (
+                <td className="px-2 py-1 text-right">
+                  <button
+                    type="button"
+                    className="text-xs text-red-600 hover:underline"
+                    onClick={() => onRemove(item.symbol)}
+                  >
+                    Remove
+                  </button>
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { fetchPortfolio } from "@/api/portfolio";
 import { fetchRecommendations } from "@/api/recommendations";
 import { fetchSystemStatus } from "@/api/system";
 import { fetchConfig } from "@/api/config";
+import { fetchWatchlist, removeFromWatchlist } from "@/api/watchlist";
 import { useAsync } from "@/lib/useAsync";
 import { ErrorBanner } from "@/components/states/ErrorBanner";
 import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
@@ -12,6 +13,7 @@ import { RecentRecommendations } from "@/components/dashboard/RecentRecommendati
 import { BudgetOverviewPanel } from "@/components/dashboard/BudgetOverviewPanel";
 import { SystemStatusPanel } from "@/components/dashboard/SystemStatusPanel";
 import { BootstrapProgress, isBootstrapping } from "@/components/dashboard/BootstrapProgress";
+import { WatchlistPanel } from "@/components/dashboard/WatchlistPanel";
 
 /**
  * Operator dashboard (#60).
@@ -37,6 +39,16 @@ export function DashboardPage() {
   const system = useAsync(fetchSystemStatus, []);
   const config = useAsync(fetchConfig, []);
   const budget = useAsync(fetchBudget, []);
+  const watchlist = useAsync(fetchWatchlist, []);
+
+  const handleRemove = async (symbol: string) => {
+    try {
+      await removeFromWatchlist(symbol);
+      watchlist.refetch();
+    } catch {
+      // Surface via the existing error slot on next render; for now no-op.
+    }
+  };
 
   const allFailed =
     portfolio.error !== null &&
@@ -121,6 +133,19 @@ export function DashboardPage() {
           </Section>
         </div>
       </div>
+
+      <Section title={`Watchlist${watchlist.data ? ` (${watchlist.data.total})` : ""}`}>
+        {watchlist.loading ? (
+          <SectionSkeleton rows={3} />
+        ) : watchlist.error !== null ? (
+          <SectionError onRetry={watchlist.refetch} />
+        ) : (
+          <WatchlistPanel
+            items={watchlist.data?.items ?? []}
+            onRemove={handleRemove}
+          />
+        )}
+      </Section>
 
       <Section title="Recent recommendations">
         {recs.loading ? (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { fetchBudget } from "@/api/budget";
 import { fetchPortfolio } from "@/api/portfolio";
 import { fetchRecommendations } from "@/api/recommendations";
@@ -40,13 +42,20 @@ export function DashboardPage() {
   const config = useAsync(fetchConfig, []);
   const budget = useAsync(fetchBudget, []);
   const watchlist = useAsync(fetchWatchlist, []);
+  const [watchlistError, setWatchlistError] = useState<string | null>(null);
 
   const handleRemove = async (symbol: string) => {
+    setWatchlistError(null);
     try {
       await removeFromWatchlist(symbol);
       watchlist.refetch();
-    } catch {
-      // Surface via the existing error slot on next render; for now no-op.
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : `Failed to remove ${symbol}`;
+      setWatchlistError(message);
+      // Refetch anyway so the UI reflects server state (e.g. another
+      // session already removed the row).
+      watchlist.refetch();
     }
   };
 
@@ -135,6 +144,18 @@ export function DashboardPage() {
       </div>
 
       <Section title={`Watchlist${watchlist.data ? ` (${watchlist.data.total})` : ""}`}>
+        {watchlistError !== null && (
+          <div className="mb-2 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-700">
+            {watchlistError}
+            <button
+              type="button"
+              className="ml-2 underline"
+              onClick={() => setWatchlistError(null)}
+            >
+              dismiss
+            </button>
+          </div>
+        )}
         {watchlist.loading ? (
           <SectionSkeleton rows={3} />
         ) : watchlist.error !== null ? (


### PR DESCRIPTION
## Summary
Initial pass on the [Phase 3.1 Dashboard cockpit rewrite](docs/superpowers/specs/2026-04-19-research-tool-refocus.md). Builds on the watchlist table from #367.

- **Watchlist section** on the Dashboard loading \`/watchlist\`. Symbol / name / sector / notes / added-at columns. Per-row Remove button. Symbol column links to the new \`/instrument/:symbol\` research page.
- **PositionsTable symbol links** now point at \`/instrument/:symbol\` instead of \`/instruments/:instrumentId\`. Click-through unifies the cockpit path across Dashboard → Instrument.
- New \`WatchlistPanel\` component + \`api/watchlist.ts\` client.

## Out of scope (Phase 3.1 follow-up)
- Drop ops-grid / bootstrap / coverage from Dashboard → \`/ops\`
- Top movers
- News feed filtered to held
- "Run morning review" button
- Live price flicker (Phase 4)

## Test plan
- \`pnpm typecheck\` — clean
- \`pnpm test\` — 287/287 passed