### PR TITLE
fix: reports + attribution router prefix (double /api bug)

### DIFF
--- a/app/api/attribution.py
+++ b/app/api/attribution.py
@@ -12,7 +12,7 @@ from app.api.auth import require_session_or_service_token
 from app.config import settings
 
 router = APIRouter(
-    prefix="/api/attribution",
+    prefix="/attribution",
     tags=["attribution"],
     dependencies=[Depends(require_session_or_service_token)],
 )

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -12,7 +12,7 @@ from app.api.auth import require_session_or_service_token
 from app.db import get_conn
 
 router = APIRouter(
-    prefix="/api/reports",
+    prefix="/reports",
     tags=["reports"],
     dependencies=[Depends(require_session_or_service_token)],
 )

--- a/frontend/src/api/reports.ts
+++ b/frontend/src/api/reports.ts
@@ -10,10 +10,10 @@ export interface ReportSnapshot {
 }
 
 export function fetchWeeklyReports(limit = 10): Promise<ReportSnapshot[]> {
-  return apiFetch<ReportSnapshot[]>(`/api/reports/weekly?limit=${limit}`);
+  return apiFetch<ReportSnapshot[]>(`/reports/weekly?limit=${limit}`);
 }
 
 export function fetchMonthlyReports(limit = 10): Promise<ReportSnapshot[]> {
-  return apiFetch<ReportSnapshot[]>(`/api/reports/monthly?limit=${limit}`);
+  return apiFetch<ReportSnapshot[]>(`/reports/monthly?limit=${limit}`);
 }
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -265,31 +265,35 @@ class TestReportJobsAvailability:
 
 class TestReportsAPI:
     def test_reports_router_exists(self) -> None:
-        """The reports router should have the correct prefix."""
+        """The reports router should have the correct prefix.
+
+        The Vite dev proxy strips ``/api`` before forwarding to the
+        backend, so the FastAPI router prefix must NOT include ``/api``
+        — otherwise browser calls to ``/api/reports/...`` resolve to
+        ``/reports/...`` on the backend and 404. Keep this prefix
+        consistent with other routers (filings, news, instruments).
+        """
         from app.api.reports import router
 
-        assert router.prefix == "/api/reports"
+        assert router.prefix == "/reports"
 
     def test_list_weekly_endpoint_exists(self) -> None:
-        """GET /api/reports/weekly should be a registered route."""
         from app.api.reports import router
 
         paths = [r.path for r in router.routes if hasattr(r, "path")]  # type: ignore[union-attr]
-        assert "/api/reports/weekly" in paths
+        assert "/reports/weekly" in paths
 
     def test_list_monthly_endpoint_exists(self) -> None:
-        """GET /api/reports/monthly should be a registered route."""
         from app.api.reports import router
 
         paths = [r.path for r in router.routes if hasattr(r, "path")]  # type: ignore[union-attr]
-        assert "/api/reports/monthly" in paths
+        assert "/reports/monthly" in paths
 
     def test_latest_endpoint_exists(self) -> None:
-        """GET /api/reports/latest should be a registered route."""
         from app.api.reports import router
 
         paths = [r.path for r in router.routes if hasattr(r, "path")]  # type: ignore[union-attr]
-        assert "/api/reports/latest" in paths
+        assert "/reports/latest" in paths
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
User-reported: clicking Weekly or Monthly on \`/reports\` threw \`apiFetch path must not start with "/api"; got "/api/reports/weekly?limit=10"\`.

**Root cause.** Two routers declared with an \`/api/*\` prefix:
- \`app/api/reports.py\` → \`prefix="/api/reports"\`
- \`app/api/attribution.py\` → \`prefix="/api/attribution"\` (same bug, no consumer yet)

Every other router in the codebase uses a bare prefix (\`/filings\`, \`/news\`, \`/instruments\`) because the Vite dev proxy strips \`/api\` before forwarding. Browser \`/api/reports/weekly\` → backend sees \`/reports/weekly\`, which did not match the router's declared \`/api/reports\` path → 404.

**Fix.**
- Backend: both routers switched to root-relative prefixes.
- Frontend: \`api/reports.ts\` paths rewritten to \`/reports/*\`; \`apiFetch\` adds \`/api\` itself.

## Test plan
- \`tests/test_reporting.py\` — 27 passed; updated to assert new prefix with a comment explaining the proxy contract.
- \`uv run pytest\` — 2197 passed, 1 skipped.
- \`uv run ruff check .\` — clean.
- \`pnpm typecheck\` — clean.