### PR TITLE
feat(#357): summary endpoint prefers local SEC XBRL over yfinance for US tickers

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -12,7 +12,7 @@ No writes. No schema changes.
 from __future__ import annotations
 
 from datetime import date, datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Literal
 
 import psycopg
@@ -21,7 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.db import get_conn
-from app.providers.implementations.yfinance_provider import YFinanceProvider
+from app.providers.implementations.yfinance_provider import YFinanceKeyStats, YFinanceProvider
 
 router = APIRouter(prefix="/instruments", tags=["instruments"])
 
@@ -113,6 +113,9 @@ class InstrumentKeyStats(BaseModel):
     debt_to_equity: Decimal | None
     revenue_growth_yoy: Decimal | None
     earnings_growth_yoy: Decimal | None
+    # Per-field provenance map — present only when stats came from a mixed
+    # local+yfinance merge. None when the whole block is yfinance-only.
+    field_source: dict[str, str] | None = None
 
 
 class InstrumentFinancialRow(BaseModel):
@@ -483,6 +486,158 @@ def get_instrument_financials(
     )
 
 
+def _has_sec_cik(conn: psycopg.Connection[object], instrument_id: int) -> bool:
+    """True if the instrument has a primary SEC CIK — the US-ticker signal
+    that gates the local-SEC-XBRL preference path."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM external_identifiers "
+            "WHERE instrument_id = %(iid)s AND provider = 'sec' "
+            "AND identifier_type = 'cik' AND is_primary = TRUE "
+            "LIMIT 1",
+            {"iid": instrument_id},
+        )
+        return cur.fetchone() is not None
+
+
+def _fetch_local_fundamentals(
+    conn: psycopg.Connection[object],
+    instrument_id: int,
+) -> dict[str, Decimal | None]:
+    """Return the latest fundamentals_snapshot row as a dict of derivable
+    fields. Missing rows yield an empty dict — callers treat it as
+    'no local fundamentals'.
+
+    Pulls:
+      - eps (for PE ratio with current price)
+      - book_value (per-share, for PB ratio with current price)
+      - net_debt / cash / debt (for debt_to_equity with equity from
+        financial_periods)
+
+    Complemented by the latest financial_periods row (TTM-ish) for ROE,
+    ROA, revenue growth — data the snapshot table doesn't carry.
+    """
+    out: dict[str, Decimal | None] = {}
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT eps, book_value, shares_outstanding, cash, debt, net_debt, revenue_ttm
+            FROM fundamentals_snapshot
+            WHERE instrument_id = %(iid)s
+            ORDER BY as_of_date DESC
+            LIMIT 1
+            """,
+            {"iid": instrument_id},
+        )
+        snap = cur.fetchone()
+        cur.execute(
+            """
+            SELECT net_income, shareholders_equity, total_assets, total_liabilities, revenue
+            FROM financial_periods
+            WHERE instrument_id = %(iid)s
+              AND superseded_at IS NULL
+              AND period_type IN ('Q1', 'Q2', 'Q3', 'Q4', 'FY')
+            ORDER BY period_end_date DESC
+            LIMIT 1
+            """,
+            {"iid": instrument_id},
+        )
+        fp = cur.fetchone()
+    if snap is not None:
+        out["eps"] = snap.get("eps")  # type: ignore[union-attr]
+        out["book_value"] = snap.get("book_value")  # type: ignore[union-attr]
+        out["shares_outstanding"] = snap.get("shares_outstanding")  # type: ignore[union-attr]
+        out["net_debt"] = snap.get("net_debt")  # type: ignore[union-attr]
+        out["debt"] = snap.get("debt")  # type: ignore[union-attr]
+    if fp is not None:
+        out["net_income"] = fp.get("net_income")  # type: ignore[union-attr]
+        out["shareholders_equity"] = fp.get("shareholders_equity")  # type: ignore[union-attr]
+        out["total_assets"] = fp.get("total_assets")  # type: ignore[union-attr]
+        out["total_liabilities"] = fp.get("total_liabilities")  # type: ignore[union-attr]
+        out["revenue"] = fp.get("revenue")  # type: ignore[union-attr]
+    return out
+
+
+def _merge_stats_with_local(
+    yfinance_stats: YFinanceKeyStats | None,
+    local: dict[str, Decimal | None],
+    current_price: Decimal | None,
+) -> InstrumentKeyStats | None:
+    """Merge local SEC-derived stats onto a yfinance KeyStats object.
+
+    Local data wins per-field when present:
+      - pe_ratio    = current_price / eps
+      - pb_ratio    = current_price / book_value
+      - debt_to_equity = debt / shareholders_equity
+      - roe         = net_income / shareholders_equity
+      - roa         = net_income / total_assets
+
+    Fields the local snapshot can't produce (dividend yield, payout ratio,
+    revenue_growth_yoy, earnings_growth_yoy) always fall back to yfinance.
+    """
+    if yfinance_stats is None and not local:
+        return None
+
+    field_source: dict[str, str] = {}
+
+    def _pick(field: str, local_value: Decimal | None, yfinance_value: Decimal | None) -> Decimal | None:
+        if local_value is not None:
+            field_source[field] = "sec_xbrl"
+            return local_value
+        if yfinance_value is not None:
+            field_source[field] = "yfinance"
+            return yfinance_value
+        field_source[field] = "unavailable"
+        return None
+
+    def _safe_div(num: Decimal | None, denom: Decimal | None) -> Decimal | None:
+        if num is None or denom is None or denom == 0:
+            return None
+        try:
+            return num / denom
+        except ArithmeticError, InvalidOperation:
+            return None
+
+    local_pe = _safe_div(current_price, local.get("eps"))
+    local_pb = _safe_div(current_price, local.get("book_value"))
+    local_de = _safe_div(local.get("debt"), local.get("shareholders_equity"))
+    local_roe = _safe_div(local.get("net_income"), local.get("shareholders_equity"))
+    local_roa = _safe_div(local.get("net_income"), local.get("total_assets"))
+
+    return InstrumentKeyStats(
+        pe_ratio=_pick("pe_ratio", local_pe, yfinance_stats.pe_ratio if yfinance_stats else None),
+        pb_ratio=_pick("pb_ratio", local_pb, yfinance_stats.pb_ratio if yfinance_stats else None),
+        dividend_yield=_pick(
+            "dividend_yield",
+            None,
+            yfinance_stats.dividend_yield if yfinance_stats else None,
+        ),
+        payout_ratio=_pick(
+            "payout_ratio",
+            None,
+            yfinance_stats.payout_ratio if yfinance_stats else None,
+        ),
+        roe=_pick("roe", local_roe, yfinance_stats.roe if yfinance_stats else None),
+        roa=_pick("roa", local_roa, yfinance_stats.roa if yfinance_stats else None),
+        debt_to_equity=_pick(
+            "debt_to_equity",
+            local_de,
+            yfinance_stats.debt_to_equity if yfinance_stats else None,
+        ),
+        revenue_growth_yoy=_pick(
+            "revenue_growth_yoy",
+            None,
+            yfinance_stats.revenue_growth_yoy if yfinance_stats else None,
+        ),
+        earnings_growth_yoy=_pick(
+            "earnings_growth_yoy",
+            None,
+            yfinance_stats.earnings_growth_yoy if yfinance_stats else None,
+        ),
+        field_source=field_source,
+    )
+
+
 @router.get("/{symbol}/summary", response_model=InstrumentSummary)
 def get_instrument_summary(
     symbol: str,
@@ -551,8 +706,27 @@ def get_instrument_summary(
         else None
     )
 
-    stats_block = (
-        InstrumentKeyStats(
+    # Prefer local SEC XBRL fields for US tickers (#357). Local values
+    # override yfinance per-field; fields the snapshot can't compute
+    # (dividend yield, growth) fall back to yfinance cleanly.
+    instrument_id_int = int(row["instrument_id"])  # type: ignore[arg-type]
+    local_fundamentals: dict[str, Decimal | None] = {}
+    use_local_sec = _has_sec_cik(conn, instrument_id_int)
+    if use_local_sec:
+        local_fundamentals = _fetch_local_fundamentals(conn, instrument_id_int)
+
+    # Treat a dict of all-None as "no local data" — the fundamentals_snapshot
+    # table may exist with sparse rows during bootstrap.
+    has_local_values = any(v is not None for v in local_fundamentals.values())
+    if use_local_sec and has_local_values:
+        stats_block = _merge_stats_with_local(
+            stats,
+            local_fundamentals,
+            current_price=(quote.price if quote is not None else None),
+        )
+        key_stats_source = "local_sec_xbrl+yfinance"
+    elif stats is not None:
+        stats_block = InstrumentKeyStats(
             pe_ratio=stats.pe_ratio,
             pb_ratio=stats.pb_ratio,
             dividend_yield=stats.dividend_yield,
@@ -562,15 +736,17 @@ def get_instrument_summary(
             debt_to_equity=stats.debt_to_equity,
             revenue_growth_yoy=stats.revenue_growth_yoy,
             earnings_growth_yoy=stats.earnings_growth_yoy,
+            field_source=None,
         )
-        if stats is not None
-        else None
-    )
+        key_stats_source = "yfinance"
+    else:
+        stats_block = None
+        key_stats_source = "unavailable"
 
     source = {
         "identity": "local_db+yfinance",
         "price": "yfinance" if quote is not None else "unavailable",
-        "key_stats": "yfinance" if stats is not None else "unavailable",
+        "key_stats": key_stats_source,
     }
 
     return InstrumentSummary(

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -106,6 +106,16 @@ class InstrumentPrice(BaseModel):
     currency: str | None
 
 
+# Closed set of values for `InstrumentKeyStats.field_source` entries. Mirror
+# in frontend/src/api/types.ts — consumers rely on this being exhaustive.
+KeyStatsFieldSource = Literal[
+    "sec_xbrl",
+    "yfinance",
+    "unavailable",
+    "sec_xbrl_price_missing",
+]
+
+
 class InstrumentKeyStats(BaseModel):
     pe_ratio: Decimal | None
     pb_ratio: Decimal | None
@@ -116,9 +126,7 @@ class InstrumentKeyStats(BaseModel):
     debt_to_equity: Decimal | None
     revenue_growth_yoy: Decimal | None
     earnings_growth_yoy: Decimal | None
-    # Per-field provenance map — present only when stats came from a mixed
-    # local+yfinance merge. None when the whole block is yfinance-only.
-    field_source: dict[str, str] | None = None
+    field_source: dict[str, KeyStatsFieldSource] | None = None
 
 
 class InstrumentFinancialRow(BaseModel):
@@ -592,7 +600,7 @@ def _merge_stats_with_local(
     if yfinance_stats is None and not local:
         return None
 
-    field_source: dict[str, str] = {}
+    field_source: dict[str, KeyStatsFieldSource] = {}
 
     def _pick(field: str, local_value: Decimal | None, yfinance_value: Decimal | None) -> Decimal | None:
         if local_value is not None:

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -11,6 +11,7 @@ No writes. No schema changes.
 
 from __future__ import annotations
 
+import logging
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Literal
@@ -22,6 +23,8 @@ from pydantic import BaseModel
 
 from app.db import get_conn
 from app.providers.implementations.yfinance_provider import YFinanceKeyStats, YFinanceProvider
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/instruments", tags=["instruments"])
 
@@ -518,31 +521,42 @@ def _fetch_local_fundamentals(
     ROA, revenue growth — data the snapshot table doesn't carry.
     """
     out: dict[str, Decimal | None] = {}
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            """
-            SELECT eps, book_value, shares_outstanding, cash, debt, net_debt, revenue_ttm
-            FROM fundamentals_snapshot
-            WHERE instrument_id = %(iid)s
-            ORDER BY as_of_date DESC
-            LIMIT 1
-            """,
-            {"iid": instrument_id},
+    try:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT eps, book_value, shares_outstanding, cash, debt, net_debt, revenue_ttm
+                FROM fundamentals_snapshot
+                WHERE instrument_id = %(iid)s
+                ORDER BY as_of_date DESC
+                LIMIT 1
+                """,
+                {"iid": instrument_id},
+            )
+            snap = cur.fetchone()
+            cur.execute(
+                """
+                SELECT net_income, shareholders_equity, total_assets, total_liabilities, revenue
+                FROM financial_periods
+                WHERE instrument_id = %(iid)s
+                  AND superseded_at IS NULL
+                  AND period_type IN ('Q1', 'Q2', 'Q3', 'Q4', 'FY')
+                ORDER BY period_end_date DESC
+                LIMIT 1
+                """,
+                {"iid": instrument_id},
+            )
+            fp = cur.fetchone()
+    except psycopg.Error:
+        # DB errors masquerading as "no local data" would be invisible
+        # in the source map. Log the failure loudly; caller treats the
+        # empty dict as fall-through to yfinance.
+        logger.warning(
+            "_fetch_local_fundamentals: DB query failed for instrument_id=%d",
+            instrument_id,
+            exc_info=True,
         )
-        snap = cur.fetchone()
-        cur.execute(
-            """
-            SELECT net_income, shareholders_equity, total_assets, total_liabilities, revenue
-            FROM financial_periods
-            WHERE instrument_id = %(iid)s
-              AND superseded_at IS NULL
-              AND period_type IN ('Q1', 'Q2', 'Q3', 'Q4', 'FY')
-            ORDER BY period_end_date DESC
-            LIMIT 1
-            """,
-            {"iid": instrument_id},
-        )
-        fp = cur.fetchone()
+        return {}
     if snap is not None:
         out["eps"] = snap.get("eps")  # type: ignore[union-attr]
         out["book_value"] = snap.get("book_value")  # type: ignore[union-attr]
@@ -604,36 +618,55 @@ def _merge_stats_with_local(
     local_roe = _safe_div(local.get("net_income"), local.get("shareholders_equity"))
     local_roa = _safe_div(local.get("net_income"), local.get("total_assets"))
 
+    # When local EPS / book_value are present but current_price is not,
+    # pe/pb remain unresolvable — but that's "waiting on price", not
+    # "no local data". Surface that distinction in field_source so the
+    # UI can render a "price missing" hint instead of an ambiguous em-dash.
+    price_blocked_pe = local_pe is None and current_price is None and local.get("eps") is not None
+    price_blocked_pb = local_pb is None and current_price is None and local.get("book_value") is not None
+
+    pe_final = _pick("pe_ratio", local_pe, yfinance_stats.pe_ratio if yfinance_stats else None)
+    pb_final = _pick("pb_ratio", local_pb, yfinance_stats.pb_ratio if yfinance_stats else None)
+    div_final = _pick("dividend_yield", None, yfinance_stats.dividend_yield if yfinance_stats else None)
+    payout_final = _pick("payout_ratio", None, yfinance_stats.payout_ratio if yfinance_stats else None)
+    roe_final = _pick("roe", local_roe, yfinance_stats.roe if yfinance_stats else None)
+    roa_final = _pick("roa", local_roa, yfinance_stats.roa if yfinance_stats else None)
+    de_final = _pick(
+        "debt_to_equity",
+        local_de,
+        yfinance_stats.debt_to_equity if yfinance_stats else None,
+    )
+    rev_growth_final = _pick(
+        "revenue_growth_yoy",
+        None,
+        yfinance_stats.revenue_growth_yoy if yfinance_stats else None,
+    )
+    earn_growth_final = _pick(
+        "earnings_growth_yoy",
+        None,
+        yfinance_stats.earnings_growth_yoy if yfinance_stats else None,
+    )
+
+    # Rewrite field_source for pe/pb when local SEC data exists but the
+    # current price is missing — distinguishes "waiting on price" from
+    # "genuinely unavailable" so the UI can render an actionable hint.
+    # Rewrite BEFORE constructing the Pydantic model since Pydantic v2
+    # copies the dict into the field, severing post-construction mutation.
+    if price_blocked_pe and pe_final is None:
+        field_source["pe_ratio"] = "sec_xbrl_price_missing"
+    if price_blocked_pb and pb_final is None:
+        field_source["pb_ratio"] = "sec_xbrl_price_missing"
+
     return InstrumentKeyStats(
-        pe_ratio=_pick("pe_ratio", local_pe, yfinance_stats.pe_ratio if yfinance_stats else None),
-        pb_ratio=_pick("pb_ratio", local_pb, yfinance_stats.pb_ratio if yfinance_stats else None),
-        dividend_yield=_pick(
-            "dividend_yield",
-            None,
-            yfinance_stats.dividend_yield if yfinance_stats else None,
-        ),
-        payout_ratio=_pick(
-            "payout_ratio",
-            None,
-            yfinance_stats.payout_ratio if yfinance_stats else None,
-        ),
-        roe=_pick("roe", local_roe, yfinance_stats.roe if yfinance_stats else None),
-        roa=_pick("roa", local_roa, yfinance_stats.roa if yfinance_stats else None),
-        debt_to_equity=_pick(
-            "debt_to_equity",
-            local_de,
-            yfinance_stats.debt_to_equity if yfinance_stats else None,
-        ),
-        revenue_growth_yoy=_pick(
-            "revenue_growth_yoy",
-            None,
-            yfinance_stats.revenue_growth_yoy if yfinance_stats else None,
-        ),
-        earnings_growth_yoy=_pick(
-            "earnings_growth_yoy",
-            None,
-            yfinance_stats.earnings_growth_yoy if yfinance_stats else None,
-        ),
+        pe_ratio=pe_final,
+        pb_ratio=pb_final,
+        dividend_yield=div_final,
+        payout_ratio=payout_final,
+        roe=roe_final,
+        roa=roa_final,
+        debt_to_equity=de_final,
+        revenue_growth_yoy=rev_growth_final,
+        earnings_growth_yoy=earn_growth_final,
         field_source=field_source,
     )
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -212,6 +212,21 @@ export interface InstrumentPrice {
   currency: string | null;
 }
 
+// Closed set of values emitted in InstrumentKeyStats.field_source.
+// Mirrors KeyStatsFieldSource in app/api/instruments.py.
+//   - "sec_xbrl"                 → computed from local SEC XBRL data
+//   - "yfinance"                 → pulled from yfinance snapshot
+//   - "unavailable"              → field genuinely absent everywhere
+//   - "sec_xbrl_price_missing"   → local SEC inputs present but live
+//                                  quote absent, so ratio is unresolvable
+//                                  (distinct from "unavailable" so UI
+//                                  can render a "waiting on price" hint)
+export type KeyStatsFieldSource =
+  | "sec_xbrl"
+  | "yfinance"
+  | "unavailable"
+  | "sec_xbrl_price_missing";
+
 export interface InstrumentKeyStats {
   pe_ratio: string | null;
   pb_ratio: string | null;
@@ -222,7 +237,7 @@ export interface InstrumentKeyStats {
   debt_to_equity: string | null;
   revenue_growth_yoy: string | null;
   earnings_growth_yoy: string | null;
-  field_source?: Record<string, string> | null;
+  field_source?: Record<string, KeyStatsFieldSource> | null;
 }
 
 export interface InstrumentSummary {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -222,6 +222,7 @@ export interface InstrumentKeyStats {
   debt_to_equity: string | null;
   revenue_growth_yoy: string | null;
   earnings_growth_yoy: string | null;
+  field_source?: Record<string, string> | null;
 }
 
 export interface InstrumentSummary {

--- a/tests/test_api_instrument_summary.py
+++ b/tests/test_api_instrument_summary.py
@@ -51,6 +51,10 @@ def _make_cursor_sequence(fetchone_per_cursor: list[list[object]]) -> MagicMock:
 
     `fetchone_per_cursor[i]` is the list of `fetchone` return values for
     the i-th `cursor(...)` call in dispatch order (one entry per execute).
+    Always uses `side_effect`, even for single-element lists — a
+    `return_value` would silently replay the same row on an unexpected
+    second `fetchone()` call and mask a test-construction bug (Codex
+    finding on PR #370 round 2).
     """
     cursors_iter = iter(fetchone_per_cursor)
 
@@ -59,10 +63,8 @@ def _make_cursor_sequence(fetchone_per_cursor: list[list[object]]) -> MagicMock:
         cur.__enter__.return_value = cur
         cur.__exit__.return_value = None
         results = next(cursors_iter)
-        if len(results) == 1:
-            cur.fetchone.return_value = results[0]
-        else:
-            cur.fetchone.side_effect = list(results)
+        assert results, "each cursor must declare at least one fetchone result"
+        cur.fetchone.side_effect = list(results)
         return cur
 
     conn_mock = MagicMock()

--- a/tests/test_api_instrument_summary.py
+++ b/tests/test_api_instrument_summary.py
@@ -410,6 +410,72 @@ def test_summary_prefers_local_sec_xbrl_for_us_ticker(client: TestClient) -> Non
     assert fs["revenue_growth_yoy"] == "yfinance"
 
 
+def test_summary_sec_preference_reports_price_missing_when_quote_absent(
+    client: TestClient,
+) -> None:
+    """US ticker with local fundamentals but no live quote → pe/pb can't be
+    computed, but field_source distinguishes 'sec_xbrl_price_missing' from
+    'unavailable' so the UI can render an actionable 'waiting on price' hint."""
+    from decimal import Decimal
+    from unittest.mock import MagicMock
+
+    from app.db import get_conn
+
+    stub_provider = MagicMock()
+    stub_provider.get_snapshot.return_value = YFinanceSnapshot(
+        profile=_stub_profile("AAPL"),
+        quote=None,  # No live price
+        key_stats=None,  # No yfinance stats either
+    )
+    _install_stub_provider(stub_provider)
+
+    def _db_conn() -> Iterator[MagicMock]:
+        conn_mock = MagicMock()
+        cur_mock = MagicMock()
+        cur_mock.__enter__.return_value = cur_mock
+        cur_mock.__exit__.return_value = None
+        cur_mock.fetchone.side_effect = [
+            {
+                "instrument_id": 42,
+                "symbol": "AAPL",
+                "company_name": "Apple Inc.",
+                "exchange": "NMS",
+                "currency": "USD",
+                "sector": "Technology",
+                "industry": None,
+                "country": "United States",
+                "is_tradable": True,
+                "coverage_tier": 1,
+            },
+            (1,),
+            {
+                "eps": Decimal("6.50"),
+                "book_value": Decimal("4.20"),
+                "shares_outstanding": None,
+                "cash": None,
+                "debt": None,
+                "net_debt": None,
+                "revenue_ttm": None,
+            },
+            None,
+        ]
+        conn_mock.cursor.return_value = cur_mock
+        yield conn_mock
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/AAPL/summary")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200, resp.text
+    ks = resp.json()["key_stats"]
+    assert ks["pe_ratio"] is None
+    assert ks["pb_ratio"] is None
+    assert ks["field_source"]["pe_ratio"] == "sec_xbrl_price_missing"
+    assert ks["field_source"]["pb_ratio"] == "sec_xbrl_price_missing"
+
+
 def test_summary_sec_preference_missing_local_falls_through_to_yfinance(
     client: TestClient,
 ) -> None:

--- a/tests/test_api_instrument_summary.py
+++ b/tests/test_api_instrument_summary.py
@@ -320,6 +320,150 @@ def test_summary_numeric_symbol_routes_to_summary_not_detail(client: TestClient)
     assert body["identity"]["symbol"] == "7203"
 
 
+def test_summary_prefers_local_sec_xbrl_for_us_ticker(client: TestClient) -> None:
+    """#357: a US ticker (primary SEC CIK present) with local
+    fundamentals_snapshot + financial_periods data uses those values
+    over yfinance, reports key_stats source='local_sec_xbrl+yfinance',
+    and surfaces per-field provenance."""
+    from decimal import Decimal
+    from unittest.mock import MagicMock
+
+    from app.db import get_conn
+
+    stub_provider = MagicMock()
+    stub_provider.get_snapshot.return_value = YFinanceSnapshot(
+        profile=_stub_profile("AAPL"),
+        quote=_stub_quote("AAPL"),
+        key_stats=_stub_stats("AAPL"),  # yfinance has all stats
+    )
+    _install_stub_provider(stub_provider)
+
+    def _db_conn() -> Iterator[MagicMock]:
+        conn_mock = MagicMock()
+        cur_mock = MagicMock()
+        cur_mock.__enter__.return_value = cur_mock
+        cur_mock.__exit__.return_value = None
+        # Sequence: instrument lookup, has_sec_cik lookup, fundamentals_snapshot,
+        # financial_periods.
+        cur_mock.fetchone.side_effect = [
+            {
+                "instrument_id": 42,
+                "symbol": "AAPL",
+                "company_name": "Apple Inc.",
+                "exchange": "NMS",
+                "currency": "USD",
+                "sector": "Technology",
+                "industry": None,
+                "country": "United States",
+                "is_tradable": True,
+                "coverage_tier": 1,
+            },
+            (1,),  # has_sec_cik
+            {
+                "eps": Decimal("6.50"),
+                "book_value": Decimal("4.20"),
+                "shares_outstanding": Decimal("15000000000"),
+                "cash": Decimal("50000000000"),
+                "debt": Decimal("120000000000"),
+                "net_debt": Decimal("70000000000"),
+                "revenue_ttm": Decimal("400000000000"),
+            },
+            {
+                "net_income": Decimal("100000000000"),
+                "shareholders_equity": Decimal("63000000000"),
+                "total_assets": Decimal("350000000000"),
+                "total_liabilities": Decimal("287000000000"),
+                "revenue": Decimal("400000000000"),
+            },
+        ]
+        conn_mock.cursor.return_value = cur_mock
+        yield conn_mock
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/AAPL/summary")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["source"]["key_stats"] == "local_sec_xbrl+yfinance"
+
+    ks = body["key_stats"]
+    # PE = 200.50 / 6.50 ≈ 30.85 (overrides yfinance's 28.5)
+    assert Decimal(ks["pe_ratio"]) == Decimal("200.50") / Decimal("6.50")
+    # PB = 200.50 / 4.20 ≈ 47.74 (overrides yfinance's 40.2)
+    assert Decimal(ks["pb_ratio"]) == Decimal("200.50") / Decimal("4.20")
+    # debt/equity = 120B / 63B ≈ 1.904 (overrides yfinance's 195.0)
+    assert Decimal(ks["debt_to_equity"]) == Decimal("120000000000") / Decimal("63000000000")
+    # ROE = 100B / 63B ≈ 1.587
+    assert Decimal(ks["roe"]) == Decimal("100000000000") / Decimal("63000000000")
+    # Field source map reports SEC origin for computed fields,
+    # yfinance for dividend/payout/growth.
+    fs = ks["field_source"]
+    assert fs["pe_ratio"] == "sec_xbrl"
+    assert fs["pb_ratio"] == "sec_xbrl"
+    assert fs["debt_to_equity"] == "sec_xbrl"
+    assert fs["roe"] == "sec_xbrl"
+    assert fs["roa"] == "sec_xbrl"
+    assert fs["dividend_yield"] == "yfinance"
+    assert fs["revenue_growth_yoy"] == "yfinance"
+
+
+def test_summary_sec_preference_missing_local_falls_through_to_yfinance(
+    client: TestClient,
+) -> None:
+    """A US ticker (CIK present) but no local fundamentals rows — must
+    cleanly fall through to the pure-yfinance path."""
+    from unittest.mock import MagicMock
+
+    from app.db import get_conn
+
+    stub_provider = MagicMock()
+    stub_provider.get_snapshot.return_value = YFinanceSnapshot(
+        profile=_stub_profile("AAPL"),
+        quote=_stub_quote("AAPL"),
+        key_stats=_stub_stats("AAPL"),
+    )
+    _install_stub_provider(stub_provider)
+
+    def _db_conn() -> Iterator[MagicMock]:
+        conn_mock = MagicMock()
+        cur_mock = MagicMock()
+        cur_mock.__enter__.return_value = cur_mock
+        cur_mock.__exit__.return_value = None
+        cur_mock.fetchone.side_effect = [
+            {
+                "instrument_id": 42,
+                "symbol": "AAPL",
+                "company_name": "Apple Inc.",
+                "exchange": "NMS",
+                "currency": "USD",
+                "sector": "Technology",
+                "industry": None,
+                "country": "United States",
+                "is_tradable": True,
+                "coverage_tier": 1,
+            },
+            (1,),  # has_sec_cik → True
+            None,  # no fundamentals_snapshot row
+            None,  # no financial_periods row
+        ]
+        conn_mock.cursor.return_value = cur_mock
+        yield conn_mock
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/AAPL/summary")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["source"]["key_stats"] == "yfinance"
+    assert body["key_stats"]["pe_ratio"] == "28.5"  # yfinance value
+
+
 def test_summary_empty_symbol_returns_400(client: TestClient) -> None:
     # Whitespace-only symbol should reject with 400 rather than a DB probe.
     stub_provider = MagicMock()

--- a/tests/test_api_instrument_summary.py
+++ b/tests/test_api_instrument_summary.py
@@ -511,6 +511,12 @@ def test_summary_sec_preference_reports_price_missing_when_quote_absent(
     assert ks["pb_ratio"] is None
     assert ks["field_source"]["pe_ratio"] == "sec_xbrl_price_missing"
     assert ks["field_source"]["pb_ratio"] == "sec_xbrl_price_missing"
+    # Non-price fields have no supporting local data (no financial_periods
+    # row in this scenario), so they must stay "unavailable" — a regression
+    # that silently mis-attributes them to SEC would fail here.
+    assert ks["field_source"]["debt_to_equity"] == "unavailable"
+    assert ks["field_source"]["roe"] == "unavailable"
+    assert ks["field_source"]["roa"] == "unavailable"
 
 
 def test_summary_sec_preference_missing_local_falls_through_to_yfinance(

--- a/tests/test_api_instrument_summary.py
+++ b/tests/test_api_instrument_summary.py
@@ -38,6 +38,38 @@ def cleanup() -> Iterator[None]:
     _clear_provider_override()
 
 
+def _make_cursor_sequence(fetchone_per_cursor: list[list[object]]) -> MagicMock:
+    """Build a conn mock whose every `cursor(...)` call returns an isolated
+    cursor mock with its own `fetchone` sequence.
+
+    Why: endpoint helpers open distinct cursors (one without `row_factory`
+    for `_has_sec_cik`, one with `dict_row` for `_fetch_local_fundamentals`
+    that runs two queries). A single shared `cur_mock` with
+    `fetchone.side_effect = [...]` couples query order to cursor order —
+    a refactor silently desyncs the stub and the test passes with wrong
+    data. Per-call isolation prevents that.
+
+    `fetchone_per_cursor[i]` is the list of `fetchone` return values for
+    the i-th `cursor(...)` call in dispatch order (one entry per execute).
+    """
+    cursors_iter = iter(fetchone_per_cursor)
+
+    def _next_cursor(*_args: object, **_kwargs: object) -> MagicMock:
+        cur = MagicMock()
+        cur.__enter__.return_value = cur
+        cur.__exit__.return_value = None
+        results = next(cursors_iter)
+        if len(results) == 1:
+            cur.fetchone.return_value = results[0]
+        else:
+            cur.fetchone.side_effect = list(results)
+        return cur
+
+    conn_mock = MagicMock()
+    conn_mock.cursor.side_effect = _next_cursor
+    return conn_mock
+
+
 def _stub_profile(symbol: str = "AAPL") -> YFinanceProfile:
     return YFinanceProfile(
         symbol=symbol,
@@ -339,45 +371,48 @@ def test_summary_prefers_local_sec_xbrl_for_us_ticker(client: TestClient) -> Non
     _install_stub_provider(stub_provider)
 
     def _db_conn() -> Iterator[MagicMock]:
-        conn_mock = MagicMock()
-        cur_mock = MagicMock()
-        cur_mock.__enter__.return_value = cur_mock
-        cur_mock.__exit__.return_value = None
-        # Sequence: instrument lookup, has_sec_cik lookup, fundamentals_snapshot,
-        # financial_periods.
-        cur_mock.fetchone.side_effect = [
-            {
-                "instrument_id": 42,
-                "symbol": "AAPL",
-                "company_name": "Apple Inc.",
-                "exchange": "NMS",
-                "currency": "USD",
-                "sector": "Technology",
-                "industry": None,
-                "country": "United States",
-                "is_tradable": True,
-                "coverage_tier": 1,
-            },
-            (1,),  # has_sec_cik
-            {
-                "eps": Decimal("6.50"),
-                "book_value": Decimal("4.20"),
-                "shares_outstanding": Decimal("15000000000"),
-                "cash": Decimal("50000000000"),
-                "debt": Decimal("120000000000"),
-                "net_debt": Decimal("70000000000"),
-                "revenue_ttm": Decimal("400000000000"),
-            },
-            {
-                "net_income": Decimal("100000000000"),
-                "shareholders_equity": Decimal("63000000000"),
-                "total_assets": Decimal("350000000000"),
-                "total_liabilities": Decimal("287000000000"),
-                "revenue": Decimal("400000000000"),
-            },
-        ]
-        conn_mock.cursor.return_value = cur_mock
-        yield conn_mock
+        # Cursor dispatch order:
+        #   1. instrument lookup (one fetchone)
+        #   2. _has_sec_cik (one fetchone)
+        #   3. _fetch_local_fundamentals (two fetchones on one cursor:
+        #      fundamentals_snapshot then financial_periods)
+        yield _make_cursor_sequence(
+            [
+                [
+                    {
+                        "instrument_id": 42,
+                        "symbol": "AAPL",
+                        "company_name": "Apple Inc.",
+                        "exchange": "NMS",
+                        "currency": "USD",
+                        "sector": "Technology",
+                        "industry": None,
+                        "country": "United States",
+                        "is_tradable": True,
+                        "coverage_tier": 1,
+                    }
+                ],
+                [(1,)],
+                [
+                    {
+                        "eps": Decimal("6.50"),
+                        "book_value": Decimal("4.20"),
+                        "shares_outstanding": Decimal("15000000000"),
+                        "cash": Decimal("50000000000"),
+                        "debt": Decimal("120000000000"),
+                        "net_debt": Decimal("70000000000"),
+                        "revenue_ttm": Decimal("400000000000"),
+                    },
+                    {
+                        "net_income": Decimal("100000000000"),
+                        "shareholders_equity": Decimal("63000000000"),
+                        "total_assets": Decimal("350000000000"),
+                        "total_liabilities": Decimal("287000000000"),
+                        "revenue": Decimal("400000000000"),
+                    },
+                ],
+            ]
+        )
 
     app.dependency_overrides[get_conn] = _db_conn
     try:
@@ -430,37 +465,37 @@ def test_summary_sec_preference_reports_price_missing_when_quote_absent(
     _install_stub_provider(stub_provider)
 
     def _db_conn() -> Iterator[MagicMock]:
-        conn_mock = MagicMock()
-        cur_mock = MagicMock()
-        cur_mock.__enter__.return_value = cur_mock
-        cur_mock.__exit__.return_value = None
-        cur_mock.fetchone.side_effect = [
-            {
-                "instrument_id": 42,
-                "symbol": "AAPL",
-                "company_name": "Apple Inc.",
-                "exchange": "NMS",
-                "currency": "USD",
-                "sector": "Technology",
-                "industry": None,
-                "country": "United States",
-                "is_tradable": True,
-                "coverage_tier": 1,
-            },
-            (1,),
-            {
-                "eps": Decimal("6.50"),
-                "book_value": Decimal("4.20"),
-                "shares_outstanding": None,
-                "cash": None,
-                "debt": None,
-                "net_debt": None,
-                "revenue_ttm": None,
-            },
-            None,
-        ]
-        conn_mock.cursor.return_value = cur_mock
-        yield conn_mock
+        yield _make_cursor_sequence(
+            [
+                [
+                    {
+                        "instrument_id": 42,
+                        "symbol": "AAPL",
+                        "company_name": "Apple Inc.",
+                        "exchange": "NMS",
+                        "currency": "USD",
+                        "sector": "Technology",
+                        "industry": None,
+                        "country": "United States",
+                        "is_tradable": True,
+                        "coverage_tier": 1,
+                    }
+                ],
+                [(1,)],
+                [
+                    {
+                        "eps": Decimal("6.50"),
+                        "book_value": Decimal("4.20"),
+                        "shares_outstanding": None,
+                        "cash": None,
+                        "debt": None,
+                        "net_debt": None,
+                        "revenue_ttm": None,
+                    },
+                    None,
+                ],
+            ]
+        )
 
     app.dependency_overrides[get_conn] = _db_conn
     try:
@@ -494,29 +529,26 @@ def test_summary_sec_preference_missing_local_falls_through_to_yfinance(
     _install_stub_provider(stub_provider)
 
     def _db_conn() -> Iterator[MagicMock]:
-        conn_mock = MagicMock()
-        cur_mock = MagicMock()
-        cur_mock.__enter__.return_value = cur_mock
-        cur_mock.__exit__.return_value = None
-        cur_mock.fetchone.side_effect = [
-            {
-                "instrument_id": 42,
-                "symbol": "AAPL",
-                "company_name": "Apple Inc.",
-                "exchange": "NMS",
-                "currency": "USD",
-                "sector": "Technology",
-                "industry": None,
-                "country": "United States",
-                "is_tradable": True,
-                "coverage_tier": 1,
-            },
-            (1,),  # has_sec_cik → True
-            None,  # no fundamentals_snapshot row
-            None,  # no financial_periods row
-        ]
-        conn_mock.cursor.return_value = cur_mock
-        yield conn_mock
+        yield _make_cursor_sequence(
+            [
+                [
+                    {
+                        "instrument_id": 42,
+                        "symbol": "AAPL",
+                        "company_name": "Apple Inc.",
+                        "exchange": "NMS",
+                        "currency": "USD",
+                        "sector": "Technology",
+                        "industry": None,
+                        "country": "United States",
+                        "is_tradable": True,
+                        "coverage_tier": 1,
+                    }
+                ],
+                [(1,)],  # has_sec_cik → True
+                [None, None],  # no fundamentals_snapshot, no financial_periods
+            ]
+        )
 
     app.dependency_overrides[get_conn] = _db_conn
     try:


### PR DESCRIPTION
## Summary
Closes #357. \`/instruments/{symbol}/summary\` now uses local \`fundamentals_snapshot\` + \`financial_periods\` data to compute key stats for US tickers (primary SEC CIK present), falling back to yfinance per-field where the local snapshot can't compute the value.

**Fields derived locally when data is present:**
- \`pe_ratio\` = current_price / eps
- \`pb_ratio\` = current_price / book_value
- \`debt_to_equity\` = debt / shareholders_equity
- \`roe\` = net_income / shareholders_equity
- \`roa\` = net_income / total_assets

**Fields always from yfinance:** \`dividend_yield\`, \`payout_ratio\`, \`revenue_growth_yoy\`, \`earnings_growth_yoy\` — no local source today.

**Response changes:**
- \`InstrumentKeyStats\` gains optional \`field_source\` dict (per-field provenance: \`sec_xbrl\` / \`yfinance\` / \`unavailable\`). Set only on the merged path.
- \`source.key_stats\` reports \`local_sec_xbrl+yfinance\` when SEC contributed, \`yfinance\` on fallback.

Non-US tickers and US tickers without local fundamentals fall through to the pure-yfinance path unchanged.

## Test plan
- \`tests/test_api_instrument_summary.py\` — +2 cases (SEC preference happy path with sentinel arithmetic + missing-local fallback)
- \`uv run pytest\` — 2199 passed, 1 skipped
- \`uv run ruff check .\` / \`ruff format --check .\` / \`pyright\` — clean