### PR TITLE
fix(#353): surface partial XBRL/planner/cascade failures in daily_financial_facts

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1332,27 +1332,39 @@ def daily_financial_facts() -> None:
                     cascade_outcome.rankings_recomputed,
                     len(cascade_outcome.failed),
                 )
-                # Surface cascade failures to the tracked job —
-                # per-instrument thesis failures AND the -1
-                # rerank-sentinel. Without this, SEC watermarks
-                # would be committed while the cascade silently
-                # fell behind, and ops health would still show
-                # status=success. Facts/normalization/cascade
-                # writes remain durably committed (commits
-                # happened above). Re-entry path on next run:
-                # the K.2 retry outbox durably flags any failed
-                # instrument so the next cycle re-drains it;
-                # rerank failures leave RERANK_NEEDED markers so
-                # the next run re-computes rankings too.
-                if cascade_outcome.failed:
-                    raise RuntimeError(
-                        f"cascade_refresh completed with {len(cascade_outcome.failed)} failures: "
-                        f"{cascade_outcome.failed}"
-                    )
+                cascade_failures: list[tuple[int, str]] = list(cascade_outcome.failed)
             else:
                 logger.info(
                     "daily_financial_facts: ANTHROPIC_API_KEY not set — "
                     "skipping cascade refresh (facts + normalization still committed)"
+                )
+                cascade_failures = []
+
+            # Surface every partial-failure channel in a single combined raise
+            # AFTER all commits so successful CIKs' facts, rankings, and
+            # retry-queue mutations all land durably. Channels:
+            #   - outcome.failed        — per-CIK XBRL extract failures (#353)
+            #   - plan.failed_plan_ciks — planner-phase skips (transient
+            #                             submissions.json fetches that never
+            #                             reached the executor)
+            #   - cascade_failures      — per-instrument thesis failures AND
+            #                             the -1 rerank sentinel
+            # Without a combined raise, a day where 20% of CIKs fail XBRL but
+            # cascade succeeds leaves tracker status='success', phase-1
+            # failed_phases empty, and Admin health green — masking a real
+            # partial outage. Re-entry path: the K.2 retry outbox re-queues
+            # failed executor CIKs, un-advanced master-index watermarks
+            # re-plan the planner-skipped CIKs, RERANK_NEEDED markers retry
+            # rankings — so all three failure channels converge back to
+            # green without manual intervention once the upstream source
+            # recovers.
+            if outcome.failed or plan.failed_plan_ciks or cascade_failures:
+                raise RuntimeError(
+                    "daily_financial_facts: "
+                    f"xbrl_failed={len(outcome.failed)} ({outcome.failed}); "
+                    f"planner_skipped={len(plan.failed_plan_ciks)} ({plan.failed_plan_ciks}); "
+                    f"cascade_failed={len(cascade_failures)} ({cascade_failures}); "
+                    "facts/normalization/cascade writes for successful CIKs were committed"
                 )
 
 

--- a/tests/test_daily_financial_facts_partial_xbrl.py
+++ b/tests/test_daily_financial_facts_partial_xbrl.py
@@ -1,0 +1,244 @@
+"""Unit test for the partial-XBRL-failure surfacing added in #353.
+
+`execute_refresh` returns a `RefreshOutcome` whose `.failed` attribute
+lists per-CIK failures without raising. Before #353, `daily_financial_facts()`
+would merely log the failure count, so a day where 20% of SEC pulls crashed
+left the tracked job status='success' and Admin health green.
+
+The fix raises `RuntimeError` after the cascade + commits, so successful
+CIKs' facts, rankings, and retry-queue writes all land first, but the job
+itself fails and `fundamentals_sync` phase 1 sees the failure.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.fundamentals import RefreshOutcome, RefreshPlan
+
+
+def _install_tracked_job_cm(mod: object) -> MagicMock:
+    """Replace _tracked_job with a context manager yielding a tracker mock."""
+    tracker = MagicMock()
+    tracker.row_count = 0
+    tracked_cm = MagicMock()
+    tracked_cm.__enter__.return_value = tracker
+    tracked_cm.__exit__.return_value = None
+    return tracked_cm
+
+
+def test_daily_financial_facts_raises_when_outcome_has_failures() -> None:
+    """With `outcome.failed` non-empty, the job must raise so
+    fundamentals_sync phase 1 records a failure. The raise lands AFTER
+    the facts commit, so successful CIKs' writes are preserved."""
+    from app.workers import scheduler
+
+    # Plan: one seed + one refresh. Outcome: one succeeded refresh + one
+    # XBRL failure in the seed.
+    plan = RefreshPlan(
+        seeds=("0000000001",),
+        refreshes=(("0000000002", "2026-04-18"),),
+        submissions_only_advances=(),
+    )
+    outcome = RefreshOutcome(
+        seeded=0,
+        refreshed=1,
+        submissions_advanced=0,
+        failed=[("0000000001", "HTTPError")],
+    )
+
+    conn = MagicMock()
+    # Phase 2 lookup returns one instrument for the refreshed CIK.
+    conn.execute.return_value.fetchall.return_value = [(42,)]
+
+    fake_connect_cm = MagicMock()
+    fake_connect_cm.__enter__.return_value = conn
+    fake_connect_cm.__exit__.return_value = None
+
+    tracked_cm = _install_tracked_job_cm(scheduler)
+
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://stub/"
+    stub_settings.sec_user_agent = "test"
+    # No anthropic key → cascade block skipped, so the partial-failure raise
+    # is the only thing standing between success and RuntimeError.
+    stub_settings.anthropic_api_key = None
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job", return_value=tracked_cm),
+        patch.object(scheduler.psycopg, "connect", return_value=fake_connect_cm),
+        patch.object(scheduler, "SecFilingsProvider") as filings_cls,
+        patch.object(scheduler, "SecFundamentalsProvider") as fundamentals_cls,
+        patch("app.services.fundamentals.plan_refresh", return_value=plan),
+        patch("app.services.fundamentals.execute_refresh", return_value=outcome),
+        patch(
+            "app.services.fundamentals.normalize_financial_periods",
+            return_value=MagicMock(
+                instruments_processed=1,
+                periods_raw_upserted=0,
+                periods_canonical_upserted=0,
+            ),
+        ),
+    ):
+        filings_cls.return_value.__enter__.return_value = MagicMock()
+        fundamentals_cls.return_value.__enter__.return_value = MagicMock()
+
+        with pytest.raises(RuntimeError, match="xbrl_failed=1"):
+            scheduler.daily_financial_facts()
+
+    # Committed state: facts for successful CIK + normalization landed
+    # BEFORE the raise. Verify by counting commits: one after Phase 2
+    # (normalization), zero after cascade (no anthropic key).
+    assert conn.commit.call_count >= 1
+
+
+def test_daily_financial_facts_raises_when_planner_has_skipped_ciks() -> None:
+    """Planner-phase skips land in `plan.failed_plan_ciks` (separate from
+    the executor's `outcome.failed`). Without surfacing them, a day where
+    every submissions.json fetch returns None leaves the executor with
+    nothing to do — `outcome.failed` is empty but the upstream fetch is
+    broken and Admin health would still be green."""
+    from app.workers import scheduler
+
+    plan = RefreshPlan(
+        seeds=(),
+        refreshes=(),
+        submissions_only_advances=(),
+        failed_plan_ciks=["0000000009"],
+    )
+    outcome = RefreshOutcome(seeded=0, refreshed=0, submissions_advanced=0, failed=[])
+
+    conn = MagicMock()
+    fake_connect_cm = MagicMock()
+    fake_connect_cm.__enter__.return_value = conn
+    fake_connect_cm.__exit__.return_value = None
+
+    tracked_cm = _install_tracked_job_cm(scheduler)
+
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://stub/"
+    stub_settings.sec_user_agent = "test"
+    stub_settings.anthropic_api_key = None
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job", return_value=tracked_cm),
+        patch.object(scheduler.psycopg, "connect", return_value=fake_connect_cm),
+        patch.object(scheduler, "SecFilingsProvider") as filings_cls,
+        patch.object(scheduler, "SecFundamentalsProvider") as fundamentals_cls,
+        patch("app.services.fundamentals.plan_refresh", return_value=plan),
+        patch("app.services.fundamentals.execute_refresh", return_value=outcome),
+    ):
+        filings_cls.return_value.__enter__.return_value = MagicMock()
+        fundamentals_cls.return_value.__enter__.return_value = MagicMock()
+
+        with pytest.raises(RuntimeError, match="planner_skipped=1"):
+            scheduler.daily_financial_facts()
+
+
+def test_daily_financial_facts_combines_xbrl_and_cascade_failures() -> None:
+    """When both channels fail, the single combined raise names both so
+    diagnostics don't drop one signal. Previously the cascade-raise
+    fired first and masked the XBRL failure."""
+    from app.workers import scheduler
+
+    plan = RefreshPlan(
+        seeds=(),
+        refreshes=(("0000000002", "2026-04-18"),),
+        submissions_only_advances=(),
+    )
+    outcome = RefreshOutcome(
+        seeded=0,
+        refreshed=1,
+        submissions_advanced=0,
+        failed=[("0000000001", "HTTPError")],
+    )
+
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.return_value = [(42,)]
+    fake_connect_cm = MagicMock()
+    fake_connect_cm.__enter__.return_value = conn
+    fake_connect_cm.__exit__.return_value = None
+
+    tracked_cm = _install_tracked_job_cm(scheduler)
+
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://stub/"
+    stub_settings.sec_user_agent = "test"
+    stub_settings.anthropic_api_key = "sk-ant-stub"  # enable cascade
+
+    # Stub a cascade that reports one per-instrument failure.
+    cascade_outcome = MagicMock(
+        instruments_considered=1,
+        retries_drained=0,
+        thesis_refreshed=0,
+        rankings_recomputed=False,
+        failed=[(42, "RuntimeError")],
+    )
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job", return_value=tracked_cm),
+        patch.object(scheduler.psycopg, "connect", return_value=fake_connect_cm),
+        patch.object(scheduler, "SecFilingsProvider") as filings_cls,
+        patch.object(scheduler, "SecFundamentalsProvider") as fundamentals_cls,
+        patch("app.services.fundamentals.plan_refresh", return_value=plan),
+        patch("app.services.fundamentals.execute_refresh", return_value=outcome),
+        patch(
+            "app.services.fundamentals.normalize_financial_periods",
+            return_value=MagicMock(
+                instruments_processed=1,
+                periods_raw_upserted=0,
+                periods_canonical_upserted=0,
+            ),
+        ),
+        patch("app.services.refresh_cascade.cascade_refresh", return_value=cascade_outcome),
+        patch("app.services.refresh_cascade.changed_instruments_from_outcome", return_value=[42]),
+        patch("app.workers.scheduler.anthropic.Anthropic"),
+    ):
+        filings_cls.return_value.__enter__.return_value = MagicMock()
+        fundamentals_cls.return_value.__enter__.return_value = MagicMock()
+
+        with pytest.raises(RuntimeError) as excinfo:
+            scheduler.daily_financial_facts()
+        # Single raise names BOTH channels — no signal masking.
+        assert "xbrl_failed=1" in str(excinfo.value)
+        assert "cascade_failed=1" in str(excinfo.value)
+
+
+def test_daily_financial_facts_no_raise_when_outcome_clean() -> None:
+    """Clean outcome (no failures) must not raise — this is the happy
+    path and the regression guard against a too-eager raise condition."""
+    from app.workers import scheduler
+
+    plan = RefreshPlan(seeds=(), refreshes=(), submissions_only_advances=())
+    outcome = RefreshOutcome(seeded=0, refreshed=0, submissions_advanced=0, failed=[])
+
+    conn = MagicMock()
+    fake_connect_cm = MagicMock()
+    fake_connect_cm.__enter__.return_value = conn
+    fake_connect_cm.__exit__.return_value = None
+
+    tracked_cm = _install_tracked_job_cm(scheduler)
+
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://stub/"
+    stub_settings.sec_user_agent = "test"
+    stub_settings.anthropic_api_key = None
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job", return_value=tracked_cm),
+        patch.object(scheduler.psycopg, "connect", return_value=fake_connect_cm),
+        patch.object(scheduler, "SecFilingsProvider") as filings_cls,
+        patch.object(scheduler, "SecFundamentalsProvider") as fundamentals_cls,
+        patch("app.services.fundamentals.plan_refresh", return_value=plan),
+        patch("app.services.fundamentals.execute_refresh", return_value=outcome),
+    ):
+        filings_cls.return_value.__enter__.return_value = MagicMock()
+        fundamentals_cls.return_value.__enter__.return_value = MagicMock()
+
+        scheduler.daily_financial_facts()  # must not raise

--- a/tests/test_daily_financial_facts_partial_xbrl.py
+++ b/tests/test_daily_financial_facts_partial_xbrl.py
@@ -104,11 +104,12 @@ def test_daily_financial_facts_raises_when_planner_has_skipped_ciks() -> None:
     broken and Admin health would still be green."""
     from app.workers import scheduler
 
-    # Plan has no seeds / refreshes — production-code guard
-    # `if outcome.seeded + outcome.refreshed > 0 and touched_ciks:` in
-    # scheduler.daily_financial_facts() short-circuits, so
-    # `normalize_financial_periods` is never reached. No patch needed
-    # for that function here.
+    # Plan has no seeds / refreshes — production-code guard at
+    # app/workers/scheduler.py:1245
+    #   `if outcome.seeded + outcome.refreshed > 0 and touched_ciks:`
+    # short-circuits because `outcome.seeded == 0` and
+    # `outcome.refreshed == 0`, so `normalize_financial_periods` is
+    # never reached. No patch needed for that function here.
     plan = RefreshPlan(
         seeds=[],
         refreshes=[],

--- a/tests/test_daily_financial_facts_partial_xbrl.py
+++ b/tests/test_daily_financial_facts_partial_xbrl.py
@@ -38,9 +38,9 @@ def test_daily_financial_facts_raises_when_outcome_has_failures() -> None:
     # Plan: one seed + one refresh. Outcome: one succeeded refresh + one
     # XBRL failure in the seed.
     plan = RefreshPlan(
-        seeds=("0000000001",),
-        refreshes=(("0000000002", "2026-04-18"),),
-        submissions_only_advances=(),
+        seeds=["0000000001"],
+        refreshes=[("0000000002", "2026-04-18")],
+        submissions_only_advances=[],
     )
     outcome = RefreshOutcome(
         seeded=0,
@@ -104,9 +104,9 @@ def test_daily_financial_facts_raises_when_planner_has_skipped_ciks() -> None:
     from app.workers import scheduler
 
     plan = RefreshPlan(
-        seeds=(),
-        refreshes=(),
-        submissions_only_advances=(),
+        seeds=[],
+        refreshes=[],
+        submissions_only_advances=[],
         failed_plan_ciks=["0000000009"],
     )
     outcome = RefreshOutcome(seeded=0, refreshed=0, submissions_advanced=0, failed=[])
@@ -146,9 +146,9 @@ def test_daily_financial_facts_combines_xbrl_and_cascade_failures() -> None:
     from app.workers import scheduler
 
     plan = RefreshPlan(
-        seeds=(),
-        refreshes=(("0000000002", "2026-04-18"),),
-        submissions_only_advances=(),
+        seeds=[],
+        refreshes=[("0000000002", "2026-04-18")],
+        submissions_only_advances=[],
     )
     outcome = RefreshOutcome(
         seeded=0,
@@ -214,7 +214,7 @@ def test_daily_financial_facts_no_raise_when_outcome_clean() -> None:
     path and the regression guard against a too-eager raise condition."""
     from app.workers import scheduler
 
-    plan = RefreshPlan(seeds=(), refreshes=(), submissions_only_advances=())
+    plan = RefreshPlan(seeds=[], refreshes=[], submissions_only_advances=[])
     outcome = RefreshOutcome(seeded=0, refreshed=0, submissions_advanced=0, failed=[])
 
     conn = MagicMock()

--- a/tests/test_daily_financial_facts_partial_xbrl.py
+++ b/tests/test_daily_financial_facts_partial_xbrl.py
@@ -19,8 +19,9 @@ import pytest
 from app.services.fundamentals import RefreshOutcome, RefreshPlan
 
 
-def _install_tracked_job_cm(mod: object) -> MagicMock:
-    """Replace _tracked_job with a context manager yielding a tracker mock."""
+def _install_tracked_job_cm() -> MagicMock:
+    """Build a context-manager mock that yields a tracker mock. Callers
+    install it via `patch.object(scheduler, "_tracked_job", return_value=cm)`."""
     tracker = MagicMock()
     tracker.row_count = 0
     tracked_cm = MagicMock()
@@ -57,7 +58,7 @@ def test_daily_financial_facts_raises_when_outcome_has_failures() -> None:
     fake_connect_cm.__enter__.return_value = conn
     fake_connect_cm.__exit__.return_value = None
 
-    tracked_cm = _install_tracked_job_cm(scheduler)
+    tracked_cm = _install_tracked_job_cm()
 
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://stub/"
@@ -103,6 +104,11 @@ def test_daily_financial_facts_raises_when_planner_has_skipped_ciks() -> None:
     broken and Admin health would still be green."""
     from app.workers import scheduler
 
+    # Plan has no seeds / refreshes — production-code guard
+    # `if outcome.seeded + outcome.refreshed > 0 and touched_ciks:` in
+    # scheduler.daily_financial_facts() short-circuits, so
+    # `normalize_financial_periods` is never reached. No patch needed
+    # for that function here.
     plan = RefreshPlan(
         seeds=[],
         refreshes=[],
@@ -116,7 +122,7 @@ def test_daily_financial_facts_raises_when_planner_has_skipped_ciks() -> None:
     fake_connect_cm.__enter__.return_value = conn
     fake_connect_cm.__exit__.return_value = None
 
-    tracked_cm = _install_tracked_job_cm(scheduler)
+    tracked_cm = _install_tracked_job_cm()
 
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://stub/"
@@ -163,7 +169,7 @@ def test_daily_financial_facts_combines_xbrl_and_cascade_failures() -> None:
     fake_connect_cm.__enter__.return_value = conn
     fake_connect_cm.__exit__.return_value = None
 
-    tracked_cm = _install_tracked_job_cm(scheduler)
+    tracked_cm = _install_tracked_job_cm()
 
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://stub/"
@@ -222,7 +228,7 @@ def test_daily_financial_facts_no_raise_when_outcome_clean() -> None:
     fake_connect_cm.__enter__.return_value = conn
     fake_connect_cm.__exit__.return_value = None
 
-    tracked_cm = _install_tracked_job_cm(scheduler)
+    tracked_cm = _install_tracked_job_cm()
 
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://stub/"


### PR DESCRIPTION
## What
Single combined raise at the end of `daily_financial_facts()` surfaces every partial-failure channel:
- `outcome.failed` — per-CIK XBRL extract failures (#353 core)
- `plan.failed_plan_ciks` — planner-phase skips
- `cascade_outcome.failed` — thesis / rerank failures

## Why
`execute_refresh` collected per-CIK XBRL failures in `RefreshOutcome.failed` without raising. Job logged the count and returned clean — tracker `status='success'`, `fundamentals_sync` phase 1 `failed_phases` empty, Admin health green. A day where 20% of SEC pulls crashed was invisible.

Separate cascade-only raise fired BEFORE any xbrl check → cascade's message masked the xbrl signal on double-failure days (Codex P3).

## Test plan
- [x] `test_daily_financial_facts_raises_when_outcome_has_failures`
- [x] `test_daily_financial_facts_raises_when_planner_has_skipped_ciks`
- [x] `test_daily_financial_facts_combines_xbrl_and_cascade_failures`
- [x] `test_daily_financial_facts_no_raise_when_outcome_clean`
- [x] `test_fundamentals_sync_phase1_xbrl_failure_isolated` unchanged
- [x] ruff / format / pyright green
- [x] Codex pre-push review clean on combined-raise diff

Closes #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)