### PR TITLE
fix(#355): drop KeyError from backfill_filings parse-error handlers

### DIFF
--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -1588,7 +1588,13 @@ def backfill_filings(
             outcome=BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR,
             status=None,
         )
-    except json.JSONDecodeError, TypeError, KeyError:
+    except json.JSONDecodeError, TypeError:
+        # `fetch_submissions` only decodes JSON (`resp.json()`) and returns
+        # the dict — it does no dict-key access here. `KeyError` would mean
+        # a dict-access bug in the provider code that raised during decode;
+        # misclassifying that as a retryable PARSE error would hide it behind
+        # backoff. Let any `KeyError` propagate so operators see the
+        # traceback instead of silent retry (#355).
         logger.warning(
             "backfill_filings: PARSE error on fetch_submissions cik=%s",
             cik_padded,
@@ -1702,9 +1708,12 @@ def backfill_filings(
                 pages_fetched=pages_fetched,
                 filings_upserted=filings_upserted,
             )
-        except json.JSONDecodeError, TypeError, KeyError:
-            # ``fetch_submissions_page`` calls ``resp.json()`` internally
-            # which can raise on malformed bytes. Classify retryable.
+        except json.JSONDecodeError, TypeError:
+            # `fetch_submissions_page` calls `resp.json()` internally — JSON
+            # decode + basic type coercion are the only failure modes. A
+            # `KeyError` at this scope would signal a dict-access bug inside
+            # the provider, not a malformed payload; let it propagate so
+            # operators see the traceback instead of silent retry (#355).
             logger.warning(
                 "backfill_filings: PARSE error on page cik=%s name=%s",
                 cik_padded,

--- a/tests/test_filings_backfill.py
+++ b/tests/test_filings_backfill.py
@@ -631,6 +631,25 @@ class TestTerminalOutcomes:
 
         assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_PARSE_ERROR
 
+    def test_15b_keyerror_from_provider_propagates(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """#355: a `KeyError` raised by the provider's `fetch_submissions`
+        is a dict-access bug in the provider, not a malformed-payload
+        condition. It must propagate instead of being misclassified as a
+        retryable PARSE error — otherwise real programming errors hide
+        behind exponential backoff."""
+        _seed(ebull_test_conn, instrument_id=1, cik="0000000001", filings_status="insufficient")
+        provider = FakeSecProvider(
+            _FakeResponse(
+                primary=None,
+                pages={},
+                filings={},
+                submissions_raises=KeyError("filings"),
+            )
+        )
+
+        with pytest.raises(KeyError, match="filings"):
+            backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
+
 
 # ---------------------------------------------------------------------
 # 8-K gap check (16-17)


### PR DESCRIPTION
## What
Remove `KeyError` from two `except (json.JSONDecodeError, TypeError, KeyError):` clauses in [app/services/coverage.py](app/services/coverage.py) around `fetch_submissions` + `fetch_submissions_page`.

## Why
`resp.json()` never raises `KeyError` — a KeyError reaching those handlers means a dict-access bug inside the provider, not a malformed payload. Misclassifying it as retryable hides programming errors behind exponential backoff.

Verified via Codex: `httpx.Response.json()` calls `json.loads()` which can only raise `json.JSONDecodeError` / `UnicodeDecodeError`. The SEC provider's two entrypoints do no dict-key access after decode, so any KeyError there is genuinely a provider bug.

Kept KeyError on the inner `_normalise_submissions_block(...)` handlers — those DO touch dict keys and a KeyError there is a legitimate malformed-payload signal (test 15 unchanged).

## Test plan
- [x] New `test_15b_keyerror_from_provider_propagates` asserts KeyError from `fetch_submissions` propagates
- [x] Existing `test_14_parse_error_json_decode` + `test_15_parse_error_missing_recent` still pass
- [x] 23/23 tests in `test_filings_backfill.py` green
- [x] Codex pre-push review: no findings

Closes #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)