### PR TITLE
refactor(#320): shared ConfigProvider + useConfig() context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from "react-router-dom";
 import { AppShell } from "@/layout/AppShell";
 import { ErrorBoundary } from "@/components/states/ErrorBoundary";
 import { RequireAuth } from "@/components/RequireAuth";
+import { ConfigProvider } from "@/lib/ConfigContext";
 import { DisplayCurrencyProvider } from "@/lib/DisplayCurrencyContext";
 import { DashboardPage } from "@/pages/DashboardPage";
 import { RankingsPage } from "@/pages/RankingsPage";
@@ -32,9 +33,11 @@ export function App() {
         <Route
           element={
             <RequireAuth>
-              <DisplayCurrencyProvider>
-                <AppShell />
-              </DisplayCurrencyProvider>
+              <ConfigProvider>
+                <DisplayCurrencyProvider>
+                  <AppShell />
+                </DisplayCurrencyProvider>
+              </ConfigProvider>
             </RequireAuth>
           }
         >

--- a/frontend/src/components/orders/ClosePositionModal.test.tsx
+++ b/frontend/src/components/orders/ClosePositionModal.test.tsx
@@ -17,6 +17,7 @@ import userEvent from "@testing-library/user-event";
 
 import { ApiError } from "@/api/client";
 import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
+import { TestConfigProvider } from "@/lib/ConfigContext";
 import type {
   ConfigResponse,
   InstrumentPositionDetail,
@@ -24,9 +25,6 @@ import type {
   OrderResponse,
 } from "@/api/types";
 
-vi.mock("@/api/config", () => ({
-  fetchConfig: vi.fn(),
-}));
 vi.mock("@/api/portfolio", () => ({
   fetchInstrumentPositions: vi.fn(),
 }));
@@ -34,11 +32,9 @@ vi.mock("@/api/orders", () => ({
   closePosition: vi.fn(),
 }));
 
-import { fetchConfig } from "@/api/config";
 import { fetchInstrumentPositions } from "@/api/portfolio";
 import { closePosition } from "@/api/orders";
 
-const mockedFetchConfig = vi.mocked(fetchConfig);
 const mockedFetchDetail = vi.mocked(fetchInstrumentPositions);
 const mockedClosePosition = vi.mocked(closePosition);
 
@@ -115,7 +111,6 @@ function orderFilled(): OrderResponse {
 }
 
 beforeEach(() => {
-  mockedFetchConfig.mockResolvedValue(demoConfig());
   mockedFetchDetail.mockResolvedValue(detailWith([tradeFor(555)]));
   mockedClosePosition.mockReset();
 });
@@ -130,15 +125,17 @@ function renderModal(
   const onFilled = vi.fn();
   const onRequestClose = vi.fn();
   const result = render(
-    <ClosePositionModal
-      isOpen
-      instrumentId={7}
-      positionId={555}
-      valuationSource="quote"
-      onFilled={onFilled}
-      onRequestClose={onRequestClose}
-      {...overrides}
-    />,
+    <TestConfigProvider value={{ data: demoConfig(), loading: false }}>
+      <ClosePositionModal
+        isOpen
+        instrumentId={7}
+        positionId={555}
+        valuationSource="quote"
+        onFilled={onFilled}
+        onRequestClose={onRequestClose}
+        {...overrides}
+      />
+    </TestConfigProvider>,
   );
   return { onFilled, onRequestClose, ...result };
 }

--- a/frontend/src/components/orders/DemoLivePill.test.tsx
+++ b/frontend/src/components/orders/DemoLivePill.test.tsx
@@ -6,20 +6,16 @@
  *   2. When /config transiently returns null (e.g. a refetch
  *      in flight), the pill stays on the last confirmed value
  *      and a `(stale)` marker appears.
+ *
+ * Uses `TestConfigProvider` to inject config state directly — bypasses
+ * the shared ConfigProvider's `fetchConfig` call entirely (#320).
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
 
 import { DemoLivePill } from "@/components/orders/DemoLivePill";
+import { TestConfigProvider } from "@/lib/ConfigContext";
 import type { ConfigResponse } from "@/api/types";
-
-vi.mock("@/api/config", () => ({
-  fetchConfig: vi.fn(),
-}));
-
-import { fetchConfig } from "@/api/config";
-
-const mockedFetchConfig = vi.mocked(fetchConfig);
 
 function configWith(enableLive: boolean): ConfigResponse {
   return {
@@ -42,34 +38,36 @@ function configWith(enableLive: boolean): ConfigResponse {
   };
 }
 
-beforeEach(() => {
-  mockedFetchConfig.mockReset();
-});
-
 describe("DemoLivePill", () => {
-  it("shows DEMO MODE when enable_live_trading=false (fresh, no stale marker)", async () => {
-    mockedFetchConfig.mockResolvedValueOnce(configWith(false));
-    render(<DemoLivePill />);
-    const pill = await screen.findByTestId("demo-live-pill");
+  it("shows DEMO MODE when enable_live_trading=false (fresh, no stale marker)", () => {
+    render(
+      <TestConfigProvider value={{ data: configWith(false), loading: false }}>
+        <DemoLivePill />
+      </TestConfigProvider>,
+    );
+    const pill = screen.getByTestId("demo-live-pill");
     expect(pill).toHaveAttribute("data-live", "false");
     expect(pill.textContent).toContain("DEMO MODE");
     expect(pill.textContent).not.toContain("stale");
   });
 
-  it("shows LIVE when enable_live_trading=true", async () => {
-    mockedFetchConfig.mockResolvedValueOnce(configWith(true));
-    render(<DemoLivePill />);
-    const pill = await screen.findByTestId("demo-live-pill");
-    await waitFor(() => {
-      expect(pill).toHaveAttribute("data-live", "true");
-    });
+  it("shows LIVE when enable_live_trading=true", () => {
+    render(
+      <TestConfigProvider value={{ data: configWith(true), loading: false }}>
+        <DemoLivePill />
+      </TestConfigProvider>,
+    );
+    const pill = screen.getByTestId("demo-live-pill");
+    expect(pill).toHaveAttribute("data-live", "true");
     expect(pill.textContent).toContain("LIVE");
   });
 
   it("on cold start with no response yet, defaults to DEMO MODE with no stale marker", () => {
-    // Resolve never — simulate an infinite in-flight request.
-    mockedFetchConfig.mockReturnValue(new Promise(() => {}));
-    render(<DemoLivePill />);
+    render(
+      <TestConfigProvider value={{ data: null, loading: true }}>
+        <DemoLivePill />
+      </TestConfigProvider>,
+    );
     const pill = screen.getByTestId("demo-live-pill");
     expect(pill).toHaveAttribute("data-live", "false");
     expect(pill.textContent).toContain("DEMO MODE");

--- a/frontend/src/components/orders/DemoLivePill.tsx
+++ b/frontend/src/components/orders/DemoLivePill.tsx
@@ -15,11 +15,10 @@
  */
 import { useEffect, useState } from "react";
 
-import { fetchConfig } from "@/api/config";
-import { useAsync } from "@/lib/useAsync";
+import { useConfig } from "@/lib/ConfigContext";
 
 export function DemoLivePill(): JSX.Element {
-  const config = useAsync(fetchConfig, []);
+  const config = useConfig();
   const liveFlag: boolean | null =
     config.data?.runtime?.enable_live_trading ?? null;
 

--- a/frontend/src/components/orders/OrderEntryModal.test.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.test.tsx
@@ -22,9 +22,6 @@ import type {
   OrderResponse,
 } from "@/api/types";
 
-vi.mock("@/api/config", () => ({
-  fetchConfig: vi.fn(),
-}));
 vi.mock("@/api/portfolio", () => ({
   fetchInstrumentPositions: vi.fn(),
 }));
@@ -32,11 +29,10 @@ vi.mock("@/api/orders", () => ({
   placeOrder: vi.fn(),
 }));
 
-import { fetchConfig } from "@/api/config";
+import { TestConfigProvider } from "@/lib/ConfigContext";
 import { fetchInstrumentPositions } from "@/api/portfolio";
 import { placeOrder } from "@/api/orders";
 
-const mockedFetchConfig = vi.mocked(fetchConfig);
 const mockedFetchDetail = vi.mocked(fetchInstrumentPositions);
 const mockedPlaceOrder = vi.mocked(placeOrder);
 
@@ -107,7 +103,6 @@ function orderFilled(): OrderResponse {
 }
 
 beforeEach(() => {
-  mockedFetchConfig.mockResolvedValue(demoConfig());
   mockedFetchDetail.mockResolvedValue(detailFor(7));
   mockedPlaceOrder.mockReset();
 });
@@ -122,16 +117,18 @@ function renderModal(
   const onFilled = vi.fn();
   const onRequestClose = vi.fn();
   const result = render(
-    <OrderEntryModal
-      isOpen
-      instrumentId={7}
-      symbol="AAPL"
-      companyName="Apple Inc."
-      valuationSource="quote"
-      onFilled={onFilled}
-      onRequestClose={onRequestClose}
-      {...overrides}
-    />,
+    <TestConfigProvider value={{ data: demoConfig(), loading: false }}>
+      <OrderEntryModal
+        isOpen
+        instrumentId={7}
+        symbol="AAPL"
+        companyName="Apple Inc."
+        valuationSource="quote"
+        onFilled={onFilled}
+        onRequestClose={onRequestClose}
+        {...overrides}
+      />
+    </TestConfigProvider>,
   );
   return { onFilled, onRequestClose, ...result };
 }

--- a/frontend/src/lib/ConfigContext.tsx
+++ b/frontend/src/lib/ConfigContext.tsx
@@ -1,0 +1,75 @@
+/**
+ * Shared `/config` context (#320).
+ *
+ * Before this: every consumer (DisplayCurrencyContext, DashboardPage,
+ * DemoLivePill, …) ran its own `useAsync(fetchConfig)` — duplicate
+ * in-flight requests, uncoordinated loading/error state, safety-state
+ * pill on one page silently diverging from kill-switch banner on
+ * another because each held its own cache.
+ *
+ * Now: a single `ConfigProvider` at `AppShell` level fetches once and
+ * exposes the shared state via `useConfig()`. Any consumer that needs
+ * the config uses that hook; nothing else should import `fetchConfig`
+ * directly.
+ */
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+
+import { fetchConfig } from "@/api/config";
+import type { ConfigResponse } from "@/api/types";
+import { useAsync, type AsyncState } from "@/lib/useAsync";
+
+const ConfigContext = createContext<AsyncState<ConfigResponse> | null>(null);
+
+export function ConfigProvider({ children }: { children: ReactNode }): JSX.Element {
+  const state = useAsync(fetchConfig, []);
+  // Memoise so consumers that depend on `refetch` / stable identity don't
+  // re-render on every parent render. `useAsync` already returns new
+  // objects each render, but memoising the context value dedupes identity
+  // for consumers that compare references.
+  const value = useMemo(
+    () => ({
+      data: state.data,
+      error: state.error,
+      loading: state.loading,
+      refetch: state.refetch,
+    }),
+    [state.data, state.error, state.loading, state.refetch],
+  );
+  return <ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>;
+}
+
+/**
+ * Consume the shared `/config` state.
+ *
+ * Must be called inside a `<ConfigProvider>`. Throws outside one so
+ * tests that render a consumer without the provider fail loudly rather
+ * than silently seeing `data: null`.
+ */
+export function useConfig(): AsyncState<ConfigResponse> {
+  const value = useContext(ConfigContext);
+  if (value === null) {
+    throw new Error("useConfig() must be used inside a <ConfigProvider>");
+  }
+  return value;
+}
+
+/**
+ * Test-only helper that lets a test render consumers of `useConfig`
+ * without going through a real fetch. Pass a partial `AsyncState` and
+ * sensible defaults fill in the rest.
+ */
+export function TestConfigProvider({
+  value,
+  children,
+}: {
+  value: Partial<AsyncState<ConfigResponse>>;
+  children: ReactNode;
+}): JSX.Element {
+  const merged: AsyncState<ConfigResponse> = {
+    data: value.data ?? null,
+    error: value.error ?? null,
+    loading: value.loading ?? false,
+    refetch: value.refetch ?? (() => {}),
+  };
+  return <ConfigContext.Provider value={merged}>{children}</ConfigContext.Provider>;
+}

--- a/frontend/src/lib/DisplayCurrencyContext.tsx
+++ b/frontend/src/lib/DisplayCurrencyContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, type ReactNode } from "react";
-import { useAsync } from "@/lib/useAsync";
-import { fetchConfig } from "@/api/config";
+
+import { useConfig } from "@/lib/ConfigContext";
 
 interface DisplayCurrencyContextValue {
   displayCurrency: string;
@@ -15,7 +15,7 @@ export function useDisplayCurrency(): string {
 }
 
 export function DisplayCurrencyProvider({ children }: { children: ReactNode }) {
-  const { data } = useAsync(() => fetchConfig(), []);
+  const { data } = useConfig();
   const displayCurrency = data?.runtime?.display_currency ?? "GBP";
   return (
     <DisplayCurrencyContext.Provider value={{ displayCurrency }}>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -4,8 +4,8 @@ import { fetchBudget } from "@/api/budget";
 import { fetchPortfolio } from "@/api/portfolio";
 import { fetchRecommendations } from "@/api/recommendations";
 import { fetchSystemStatus } from "@/api/system";
-import { fetchConfig } from "@/api/config";
 import { fetchWatchlist, removeFromWatchlist } from "@/api/watchlist";
+import { useConfig } from "@/lib/ConfigContext";
 import { useAsync } from "@/lib/useAsync";
 import { ErrorBanner } from "@/components/states/ErrorBanner";
 import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
@@ -39,7 +39,7 @@ export function DashboardPage() {
     [],
   );
   const system = useAsync(fetchSystemStatus, []);
-  const config = useAsync(fetchConfig, []);
+  const config = useConfig();
   const budget = useAsync(fetchBudget, []);
   const watchlist = useAsync(fetchWatchlist, []);
   const [watchlistError, setWatchlistError] = useState<string | null>(null);

--- a/frontend/src/pages/PortfolioPage.test.tsx
+++ b/frontend/src/pages/PortfolioPage.test.tsx
@@ -28,14 +28,13 @@ vi.mock("@/api/portfolio", () => ({
   fetchPortfolio: vi.fn(),
   fetchInstrumentPositions: vi.fn(),
 }));
-vi.mock("@/api/config", () => ({ fetchConfig: vi.fn() }));
 vi.mock("@/api/theses", () => ({ fetchLatestThesis: vi.fn() }));
 vi.mock("@/api/filings", () => ({ fetchFilings: vi.fn() }));
 vi.mock("@/api/scoreHistory", () => ({ fetchScoreHistory: vi.fn() }));
 vi.mock("@/api/orders", () => ({ placeOrder: vi.fn(), closePosition: vi.fn() }));
 
+import { TestConfigProvider } from "@/lib/ConfigContext";
 import { fetchPortfolio, fetchInstrumentPositions } from "@/api/portfolio";
-import { fetchConfig } from "@/api/config";
 import { fetchLatestThesis } from "@/api/theses";
 import { fetchFilings } from "@/api/filings";
 import { fetchScoreHistory } from "@/api/scoreHistory";
@@ -43,7 +42,6 @@ import { placeOrder, closePosition } from "@/api/orders";
 
 const mockedFetchPortfolio = vi.mocked(fetchPortfolio);
 const mockedFetchInstrumentPositions = vi.mocked(fetchInstrumentPositions);
-const mockedFetchConfig = vi.mocked(fetchConfig);
 const mockedFetchThesis = vi.mocked(fetchLatestThesis);
 const mockedFetchFilings = vi.mocked(fetchFilings);
 const mockedFetchScores = vi.mocked(fetchScoreHistory);
@@ -202,14 +200,15 @@ function emptyInstrumentDetail(): InstrumentPositionDetail {
 
 function renderPage() {
   return render(
-    <MemoryRouter initialEntries={["/portfolio"]}>
-      <PortfolioPage />
-    </MemoryRouter>,
+    <TestConfigProvider value={{ data: demoConfig(), loading: false }}>
+      <MemoryRouter initialEntries={["/portfolio"]}>
+        <PortfolioPage />
+      </MemoryRouter>
+    </TestConfigProvider>,
   );
 }
 
 beforeEach(() => {
-  mockedFetchConfig.mockResolvedValue(demoConfig());
   mockedFetchThesis.mockResolvedValue(emptyThesis());
   mockedFetchFilings.mockResolvedValue(emptyFilings());
   mockedFetchScores.mockResolvedValue(emptyScores());


### PR DESCRIPTION
## What
Single `ConfigProvider` at AppShell level; consumers use `useConfig()` hook.

## Why
Every `/config` consumer previously ran its own `useAsync(fetchConfig)` — duplicate requests, uncoordinated loading/error state, safety-state pill on one page silently diverging from kill-switch banner on another.

## Changes
- [frontend/src/lib/ConfigContext.tsx](frontend/src/lib/ConfigContext.tsx) — new. `ConfigProvider`, `useConfig()`, `TestConfigProvider` (for tests).
- [App.tsx](frontend/src/App.tsx) — wrap `DisplayCurrencyProvider` in `ConfigProvider`.
- [DisplayCurrencyContext.tsx](frontend/src/lib/DisplayCurrencyContext.tsx), [DashboardPage.tsx](frontend/src/pages/DashboardPage.tsx), [DemoLivePill.tsx](frontend/src/components/orders/DemoLivePill.tsx) — migrate.
- Tests wrapped in `TestConfigProvider`.

## Test plan
- [x] 287/287 frontend tests pass
- [x] typecheck clean
- [x] Codex pre-push review clean
- [x] Verified `fetchConfig` only called inside `ConfigContext.tsx` for runtime code

Closes #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)