### PR TITLE
feat: Slice 0 — primary-listing flag + deterministic symbol lookup

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -425,10 +425,18 @@ def get_instrument_financials(
 
     columns = _STATEMENT_COLUMNS[statement]
 
-    # Resolve symbol -> instrument_id for the local read.
+    # Resolve symbol -> instrument_id for the local read. `symbol` is
+    # not UNIQUE across exchanges (see migration 043), so order by
+    # `is_primary_listing DESC, instrument_id ASC` to make the winner
+    # deterministic on collisions.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            "SELECT instrument_id, symbol FROM instruments WHERE UPPER(symbol) = %(s)s LIMIT 1",
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
             {"s": symbol_clean},
         )
         inst_row = cur.fetchone()
@@ -684,28 +692,53 @@ def get_instrument_summary(
     symbol: str,
     conn: psycopg.Connection[object] = Depends(get_conn),
     yfinance_provider: YFinanceProvider = Depends(get_yfinance_provider),
+    id: int | None = Query(default=None, ge=1),
 ) -> InstrumentSummary:
     """Per-ticker research summary (Phase 2.2 of the 2026-04-19 refocus).
 
     Merges local identity/tier data with yfinance-sourced price + key
     stats. A missing symbol returns 404. yfinance failures return null
     sections rather than 500 — the UI renders what it has.
+
+    `?id=<instrument_id>` override: when a symbol collides across
+    exchanges, the caller can pin a specific instrument_id. The server
+    verifies that id's symbol matches the path symbol — a mismatch is a
+    404, not a silent wrong-instrument response. See
+    docs/superpowers/specs/2026-04-20-per-stock-research-page.md §2.
     """
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:
         raise HTTPException(status_code=400, detail="symbol is required")
 
-    lookup_sql = """
-        SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
-               i.currency, i.sector, i.industry, i.country,
-               i.is_tradable, c.coverage_tier
-        FROM instruments i
-        LEFT JOIN coverage c USING (instrument_id)
-        WHERE UPPER(i.symbol) = %(symbol)s
-        LIMIT 1
-    """
+    # `symbol` is not UNIQUE across exchanges (see migration 043);
+    # ORDER BY `is_primary_listing DESC, instrument_id ASC` makes the
+    # winner deterministic when two listings share a ticker. See
+    # docs/superpowers/specs/2026-04-20-per-stock-research-page.md §2.
+    if id is not None:
+        lookup_sql = """
+            SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
+                   i.currency, i.sector, i.industry, i.country,
+                   i.is_tradable, c.coverage_tier
+            FROM instruments i
+            LEFT JOIN coverage c USING (instrument_id)
+            WHERE i.instrument_id = %(id)s AND UPPER(i.symbol) = %(symbol)s
+            LIMIT 1
+        """
+        params: dict[str, object] = {"id": id, "symbol": symbol_clean}
+    else:
+        lookup_sql = """
+            SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
+                   i.currency, i.sector, i.industry, i.country,
+                   i.is_tradable, c.coverage_tier
+            FROM instruments i
+            LEFT JOIN coverage c USING (instrument_id)
+            WHERE UPPER(i.symbol) = %(symbol)s
+            ORDER BY i.is_primary_listing DESC, i.instrument_id ASC
+            LIMIT 1
+        """
+        params = {"symbol": symbol_clean}
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(lookup_sql, {"symbol": symbol_clean})
+        cur.execute(lookup_sql, params)
         row = cur.fetchone()
 
     if row is None:

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -692,7 +692,7 @@ def get_instrument_summary(
     symbol: str,
     conn: psycopg.Connection[object] = Depends(get_conn),
     yfinance_provider: YFinanceProvider = Depends(get_yfinance_provider),
-    id: int | None = Query(default=None, ge=1),
+    instrument_id: int | None = Query(default=None, ge=1, alias="id"),
 ) -> InstrumentSummary:
     """Per-ticker research summary (Phase 2.2 of the 2026-04-19 refocus).
 
@@ -714,7 +714,9 @@ def get_instrument_summary(
     # ORDER BY `is_primary_listing DESC, instrument_id ASC` makes the
     # winner deterministic when two listings share a ticker. See
     # docs/superpowers/specs/2026-04-20-per-stock-research-page.md §2.
-    if id is not None:
+    if instrument_id is not None:
+        # instrument_id is the PK so the lookup is already unique; no
+        # ORDER BY / LIMIT needed.
         lookup_sql = """
             SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
                    i.currency, i.sector, i.industry, i.country,
@@ -722,9 +724,8 @@ def get_instrument_summary(
             FROM instruments i
             LEFT JOIN coverage c USING (instrument_id)
             WHERE i.instrument_id = %(id)s AND UPPER(i.symbol) = %(symbol)s
-            LIMIT 1
         """
-        params: dict[str, object] = {"id": id, "symbol": symbol_clean}
+        params: dict[str, object] = {"id": instrument_id, "symbol": symbol_clean}
     else:
         lookup_sql = """
             SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,

--- a/sql/043_instruments_primary_listing.sql
+++ b/sql/043_instruments_primary_listing.sql
@@ -26,13 +26,18 @@ ALTER TABLE instruments
 
 -- Demote collisions: within each (UPPER(symbol)) group, keep the row
 -- with the lowest instrument_id as primary, mark the rest secondary.
+-- Guarded with `AND i.is_primary_listing = TRUE` so a re-run of this
+-- migration does not undo an operator's manual promotion of a
+-- non-minimum instrument_id.
 UPDATE instruments AS i
 SET is_primary_listing = FALSE
-WHERE EXISTS (
+WHERE i.is_primary_listing = TRUE
+  AND EXISTS (
     SELECT 1
     FROM instruments AS j
     WHERE UPPER(j.symbol) = UPPER(i.symbol)
       AND j.instrument_id < i.instrument_id
+      AND j.is_primary_listing = TRUE
 );
 
 -- NOT adding a partial-unique index on `UPPER(symbol) WHERE

--- a/sql/043_instruments_primary_listing.sql
+++ b/sql/043_instruments_primary_listing.sql
@@ -1,0 +1,53 @@
+-- 043_instruments_primary_listing.sql
+--
+-- Slice 0 of per-stock research page spec (docs/superpowers/specs/2026-04-20-per-stock-research-page.md).
+--
+-- Problem: `instruments.symbol` is indexed but not UNIQUE. Symbol
+-- collisions across exchanges exist (e.g. `VOD` on NMS vs `VOD.L` on
+-- LSE — distinct instruments that share a ticker prefix), and the
+-- current `UPPER(symbol) = %s LIMIT 1` lookups in app/api/instruments.py
+-- pick winners nondeterministically.
+--
+-- Fix: tag one listing per symbol as the primary. The research page
+-- resolves symbol → instrument_id as:
+--   1. ORDER BY is_primary_listing DESC, instrument_id ASC LIMIT 1
+--   2. Alternate listings surfaced via a `?id=` override on the
+--      research URL (see spec §2).
+--
+-- Backfill strategy (non-destructive):
+--   - Default value TRUE; every existing row becomes is_primary_listing=TRUE.
+--   - Then demote collisions: for any symbol with >1 row, keep the
+--     lowest instrument_id as TRUE and mark the rest FALSE.
+--   - Future ingests set TRUE by default; the universe sync can
+--     explicitly flip when a new listing becomes primary.
+
+ALTER TABLE instruments
+    ADD COLUMN IF NOT EXISTS is_primary_listing BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Demote collisions: within each (UPPER(symbol)) group, keep the row
+-- with the lowest instrument_id as primary, mark the rest secondary.
+UPDATE instruments AS i
+SET is_primary_listing = FALSE
+WHERE EXISTS (
+    SELECT 1
+    FROM instruments AS j
+    WHERE UPPER(j.symbol) = UPPER(i.symbol)
+      AND j.instrument_id < i.instrument_id
+);
+
+-- NOT adding a partial-unique index on `UPPER(symbol) WHERE
+-- is_primary_listing`: `sync_universe()` upserts on `instrument_id`
+-- and has no collision-aware logic for setting `is_primary_listing`
+-- on a new row whose UPPER(symbol) already exists elsewhere. A unique
+-- constraint would abort the whole universe sync transaction on the
+-- first collision. The application-level tiebreaker in the symbol→id
+-- lookups (`ORDER BY is_primary_listing DESC, instrument_id ASC`) is
+-- sufficient for deterministic resolution; enforcing at-most-one-primary
+-- at the DB level is deferred until the ingest path learns to demote
+-- correctly. Filed as a separate tech-debt follow-up.
+-- Non-unique expression index to support the ORDER BY tiebreaker.
+-- The lookups filter on `UPPER(symbol)` so a plain `(symbol, ...)`
+-- btree would not seek; the expression leads with `UPPER(symbol)` to
+-- match the predicate.
+CREATE INDEX IF NOT EXISTS idx_instruments_symbol_primary
+    ON instruments ((UPPER(symbol)), is_primary_listing DESC, instrument_id);

--- a/tests/test_api_instrument_summary.py
+++ b/tests/test_api_instrument_summary.py
@@ -570,6 +570,80 @@ def test_summary_sec_preference_missing_local_falls_through_to_yfinance(
     assert body["key_stats"]["pe_ratio"] == "28.5"  # yfinance value
 
 
+def test_summary_id_override_pins_specific_instrument(client: TestClient) -> None:
+    """Slice 0: `?id=<instrument_id>` overrides primary-listing resolution
+    so the caller can pin a specific exchange listing when a symbol
+    collides. Verifies the id's symbol must match the path (404 on
+    mismatch)."""
+    from unittest.mock import MagicMock
+
+    from app.db import get_conn
+
+    stub_provider = MagicMock()
+    stub_provider.get_snapshot.return_value = YFinanceSnapshot(profile=None, quote=None, key_stats=None)
+    _install_stub_provider(stub_provider)
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield _make_cursor_sequence(
+            [
+                # Cursor 1: instrument lookup via ?id=.
+                [
+                    {
+                        "instrument_id": 777,  # alternate listing
+                        "symbol": "VOD",
+                        "company_name": "Vodafone Group PLC (LSE listing)",
+                        "exchange": "LSE",
+                        "currency": "GBP",
+                        "sector": "Telecom",
+                        "industry": None,
+                        "country": "United Kingdom",
+                        "is_tradable": True,
+                        "coverage_tier": 2,
+                    }
+                ],
+                # Cursor 2: _has_sec_cik probe — LSE ticker has no CIK.
+                [None],
+            ]
+        )
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/VOD/summary?id=777")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["instrument_id"] == 777
+    assert body["identity"]["exchange"] == "LSE"
+
+
+def test_summary_id_override_mismatched_symbol_returns_404(
+    client: TestClient,
+) -> None:
+    """If `?id=<n>` refers to an instrument whose symbol doesn't match
+    the path, respond 404 rather than silently returning the wrong
+    instrument."""
+    from unittest.mock import MagicMock
+
+    from app.db import get_conn
+
+    stub_provider = MagicMock()
+    stub_provider.get_snapshot.return_value = YFinanceSnapshot(profile=None, quote=None, key_stats=None)
+    _install_stub_provider(stub_provider)
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield _make_cursor_sequence([[None]])  # lookup returns no row
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/AAPL/summary?id=777")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 404
+
+
 def test_summary_empty_symbol_returns_400(client: TestClient) -> None:
     # Whitespace-only symbol should reject with 400 rather than a DB probe.
     stub_provider = MagicMock()


### PR DESCRIPTION
## What
Slice 0 of per-stock research page spec. Adds deterministic tiebreaker for symbol→instrument_id resolution and a `?id=` override on the summary endpoint.

## Why
`instruments.symbol` is indexed but not UNIQUE. Symbol collisions across exchanges exist (e.g. `VOD`/`VOD.L`). Current lookups in `app/api/instruments.py` use `LIMIT 1` without ORDER BY — nondeterministic on collisions.

## Changes
- **Migration 043**: `is_primary_listing BOOLEAN DEFAULT TRUE`; backfill demotes duplicates (lowest `instrument_id` per `UPPER(symbol)` stays primary). Expression index on `(UPPER(symbol), is_primary_listing DESC, instrument_id)` to support the tiebreaker seek.
- **Symbol lookups** in [app/api/instruments.py](app/api/instruments.py) for financials + summary now `ORDER BY is_primary_listing DESC, instrument_id ASC LIMIT 1`.
- **`?id=` override** on summary endpoint: caller pins specific instrument_id when ambiguous; server verifies id's symbol matches path (404 on mismatch).

## Not doing
- **No partial-unique index** on `UPPER(symbol) WHERE is_primary_listing`: `sync_universe()` has no collision-aware assignment for `is_primary_listing`, so a unique constraint would abort universe sync on the first duplicate-symbol ingest. Application-level tiebreaker is sufficient. Filed as follow-up tech-debt.

## Test plan
- [x] `test_summary_id_override_pins_specific_instrument`
- [x] `test_summary_id_override_mismatched_symbol_returns_404`
- [x] All 11 existing summary tests + 7 financials + 28 instruments still pass
- [x] Full `uv run pytest -q`: 2207 passed
- [x] ruff / format / pyright clean
- [x] Codex pre-push review: 3 rounds, final clean

Refs: [per-stock research spec §5 Slice 0](docs/superpowers/specs/2026-04-20-per-stock-research-page.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)