### PR TITLE
feat: Slice 1 — SummaryStrip + Research tab

### DIFF
--- a/frontend/src/components/instrument/ResearchTab.tsx
+++ b/frontend/src/components/instrument/ResearchTab.tsx
@@ -1,0 +1,179 @@
+/**
+ * ResearchTab — default tab of the per-stock research page (Slice 1 of
+ * docs/superpowers/specs/2026-04-20-per-stock-research-page.md).
+ *
+ * Composes existing data into one operator view: key stats with
+ * field_source provenance, thesis memo if present, break conditions.
+ * Red-flag surfacing and peer context come in Slice 2 (right rail).
+ */
+import { Section } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import type { InstrumentSummary, ThesisDetail } from "@/api/types";
+
+function formatDecimal(
+  value: string | null | undefined,
+  opts: { percent?: boolean } = {},
+): string {
+  if (value === null || value === undefined) return "—";
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "—";
+  if (opts.percent) return `${(num * 100).toFixed(2)}%`;
+  return num.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
+function formatMarketCap(value: string | null): string {
+  if (value === null) return "—";
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "—";
+  if (num >= 1e12) return `${(num / 1e12).toFixed(2)}T`;
+  if (num >= 1e9) return `${(num / 1e9).toFixed(2)}B`;
+  if (num >= 1e6) return `${(num / 1e6).toFixed(2)}M`;
+  return num.toLocaleString();
+}
+
+function FieldSourceTag({ source }: { source: string | undefined }) {
+  if (!source) return null;
+  // Colour-code the provenance so the operator sees at-a-glance where
+  // each figure came from. Matches the KeyStatsFieldSource union from
+  // frontend/src/api/types.ts.
+  let tone = "bg-slate-100 text-slate-600";
+  let label = source;
+  switch (source) {
+    case "sec_xbrl":
+      tone = "bg-emerald-50 text-emerald-700";
+      label = "SEC";
+      break;
+    case "yfinance":
+      tone = "bg-blue-50 text-blue-700";
+      label = "YF";
+      break;
+    case "sec_xbrl_price_missing":
+      tone = "bg-amber-50 text-amber-700";
+      label = "SEC · price?";
+      break;
+    case "unavailable":
+      tone = "bg-slate-100 text-slate-500";
+      label = "—";
+      break;
+  }
+  return (
+    <span className={`ml-2 rounded px-1.5 py-0.5 text-[10px] uppercase ${tone}`}>
+      {label}
+    </span>
+  );
+}
+
+function KeyStat({
+  label,
+  value,
+  source,
+}: {
+  label: string;
+  value: string;
+  source?: string;
+}) {
+  return (
+    <>
+      <dt className="text-slate-500">{label}</dt>
+      <dd className="flex items-center tabular-nums">
+        <span>{value}</span>
+        <FieldSourceTag source={source} />
+      </dd>
+    </>
+  );
+}
+
+function ThesisPanel({ thesis }: { thesis: ThesisDetail | null }) {
+  if (thesis === null) {
+    return (
+      <EmptyState
+        title="No thesis yet"
+        description="Generate one from the strip above — the AI will pull the latest filings, news, and fundamentals to draft a buy/hold/exit memo."
+      />
+    );
+  }
+  const breaks = thesis.break_conditions_json ?? [];
+  return (
+    <div className="space-y-3 text-sm">
+      <div className="whitespace-pre-wrap text-slate-700">
+        {thesis.memo_markdown}
+      </div>
+      {(thesis.base_value !== null ||
+        thesis.bull_value !== null ||
+        thesis.bear_value !== null) && (
+        <dl className="grid grid-cols-3 gap-2 rounded bg-slate-50 p-3 text-xs">
+          <div>
+            <dt className="text-slate-500">Bear</dt>
+            <dd className="font-medium tabular-nums">
+              {thesis.bear_value !== null ? thesis.bear_value : "—"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-slate-500">Base</dt>
+            <dd className="font-medium tabular-nums">
+              {thesis.base_value !== null ? thesis.base_value : "—"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-slate-500">Bull</dt>
+            <dd className="font-medium tabular-nums">
+              {thesis.bull_value !== null ? thesis.bull_value : "—"}
+            </dd>
+          </div>
+        </dl>
+      )}
+      {breaks.length > 0 && (
+        <div>
+          <div className="mb-1 text-xs font-medium uppercase tracking-wider text-slate-500">
+            Break conditions
+          </div>
+          <ul className="list-inside list-disc space-y-0.5 text-xs text-slate-600">
+            {breaks.map((b, i) => (
+              <li key={i}>{b}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface ResearchTabProps {
+  summary: InstrumentSummary;
+  thesis: ThesisDetail | null;
+}
+
+export function ResearchTab({ summary, thesis }: ResearchTabProps): JSX.Element {
+  const stats = summary.key_stats;
+  const fs = stats?.field_source ?? undefined;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Section title="Key statistics">
+        {stats === null ? (
+          <EmptyState
+            title="No key stats"
+            description="No provider returned key stats for this ticker."
+          />
+        ) : (
+          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+            <KeyStat label="Market cap" value={formatMarketCap(summary.identity.market_cap)} />
+            <KeyStat label="P/E ratio" value={formatDecimal(stats.pe_ratio)} source={fs?.pe_ratio} />
+            <KeyStat label="P/B ratio" value={formatDecimal(stats.pb_ratio)} source={fs?.pb_ratio} />
+            <KeyStat label="Dividend yield" value={formatDecimal(stats.dividend_yield, { percent: true })} source={fs?.dividend_yield} />
+            <KeyStat label="Payout ratio" value={formatDecimal(stats.payout_ratio, { percent: true })} source={fs?.payout_ratio} />
+            <KeyStat label="ROE" value={formatDecimal(stats.roe, { percent: true })} source={fs?.roe} />
+            <KeyStat label="ROA" value={formatDecimal(stats.roa, { percent: true })} source={fs?.roa} />
+            <KeyStat label="Debt / Equity" value={formatDecimal(stats.debt_to_equity)} source={fs?.debt_to_equity} />
+            <KeyStat label="Revenue growth (YoY)" value={formatDecimal(stats.revenue_growth_yoy, { percent: true })} source={fs?.revenue_growth_yoy} />
+            <KeyStat label="Earnings growth (YoY)" value={formatDecimal(stats.earnings_growth_yoy, { percent: true })} source={fs?.earnings_growth_yoy} />
+          </dl>
+        )}
+      </Section>
+
+      <Section title="Thesis">
+        <ThesisPanel thesis={thesis} />
+      </Section>
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/ResearchTab.tsx
+++ b/frontend/src/components/instrument/ResearchTab.tsx
@@ -83,7 +83,21 @@ function KeyStat({
   );
 }
 
-function ThesisPanel({ thesis }: { thesis: ThesisDetail | null }) {
+function ThesisPanel({
+  thesis,
+  errored,
+}: {
+  thesis: ThesisDetail | null;
+  errored: boolean;
+}) {
+  if (errored) {
+    return (
+      <EmptyState
+        title="Thesis temporarily unavailable"
+        description="Failed to fetch the latest thesis. Retry via the Generate thesis button in the strip above."
+      />
+    );
+  }
   if (thesis === null) {
     return (
       <EmptyState
@@ -141,9 +155,14 @@ function ThesisPanel({ thesis }: { thesis: ThesisDetail | null }) {
 export interface ResearchTabProps {
   summary: InstrumentSummary;
   thesis: ThesisDetail | null;
+  thesisErrored?: boolean;
 }
 
-export function ResearchTab({ summary, thesis }: ResearchTabProps): JSX.Element {
+export function ResearchTab({
+  summary,
+  thesis,
+  thesisErrored = false,
+}: ResearchTabProps): JSX.Element {
   const stats = summary.key_stats;
   const fs = stats?.field_source ?? undefined;
 
@@ -172,7 +191,7 @@ export function ResearchTab({ summary, thesis }: ResearchTabProps): JSX.Element 
       </Section>
 
       <Section title="Thesis">
-        <ThesisPanel thesis={thesis} />
+        <ThesisPanel thesis={thesis} errored={thesisErrored} />
       </Section>
     </div>
   );

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -285,6 +285,24 @@ describe("SummaryStrip — action gating", () => {
     expect(screen.queryByTestId("action-close")).not.toBeInTheDocument();
   });
 
+  it("keeps stance badge visible when thesisError=true but thesis data is non-null", () => {
+    // Previously-fetched thesis data must not be silently dropped
+    // during a sticky-error window (Codex slice-1 round-4 finding).
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={freshThesis()}
+        position={null}
+        {...noopProps()}
+        thesisError
+        thesisLoaded={false}
+      />,
+    );
+    expect(screen.getByTestId("thesis-badge").textContent).toContain("BUY");
+    // Error signal is additive, not a replacement.
+    expect(screen.getByTestId("thesis-badge-error")).toBeInTheDocument();
+  });
+
   it("shows error badge + keeps Generate thesis reachable on thesisError", () => {
     // Non-404 thesis errors used to silently blank the strip. Now
     // the error is surfaced and the retry affordance remains visible

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -110,7 +110,9 @@ function heldPosition(): InstrumentPositionDetail {
 function noopProps() {
   return {
     thesisLoaded: true,
+    thesisError: false,
     positionLoaded: true,
+    positionError: false,
     onAdd: vi.fn(),
     onClose: vi.fn(),
     onGenerateThesis: vi.fn(),
@@ -280,6 +282,41 @@ describe("SummaryStrip — action gating", () => {
       />,
     );
     expect(screen.queryByTestId("held-badge")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("action-close")).not.toBeInTheDocument();
+  });
+
+  it("shows error badge + keeps Generate thesis reachable on thesisError", () => {
+    // Non-404 thesis errors used to silently blank the strip. Now
+    // the error is surfaced and the retry affordance remains visible
+    // (Codex slice-1 round-3 finding).
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={null}
+        position={null}
+        {...noopProps()}
+        thesisError
+        thesisLoaded={false}
+      />,
+    );
+    expect(screen.getByTestId("thesis-badge-error")).toBeInTheDocument();
+    expect(screen.getByTestId("action-generate-thesis")).toBeInTheDocument();
+  });
+
+  it("shows position error badge + hides Close on positionError", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={freshThesis()}
+        position={null}
+        {...noopProps()}
+        positionError
+        positionLoaded={false}
+      />,
+    );
+    expect(screen.getByTestId("position-badge-error")).toBeInTheDocument();
+    // Close button must stay hidden when holdings are unknown —
+    // offering Close against unresolved position data is unsafe.
     expect(screen.queryByTestId("action-close")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -1,0 +1,303 @@
+/**
+ * Tests for SummaryStrip (Slice 1 of per-stock research page,
+ * docs/superpowers/specs/2026-04-20-per-stock-research-page.md).
+ *
+ * Pins the action-button gating spec:
+ *   - Close visible only when `position.total_units > 0`.
+ *   - Generate thesis visible when no thesis OR thesis > 30d old.
+ *   - Add visible when `summary.is_tradable === true`.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { SummaryStrip } from "@/components/instrument/SummaryStrip";
+import type {
+  InstrumentPositionDetail,
+  InstrumentSummary,
+  ThesisDetail,
+} from "@/api/types";
+
+function summary(overrides: Partial<InstrumentSummary> = {}): InstrumentSummary {
+  return {
+    instrument_id: 42,
+    is_tradable: true,
+    coverage_tier: 1,
+    identity: {
+      symbol: "AAPL",
+      display_name: "Apple Inc.",
+      sector: "Technology",
+      industry: "Consumer Electronics",
+      exchange: "NMS",
+      country: "United States",
+      currency: "USD",
+      market_cap: "3000000000000",
+    },
+    price: {
+      current: "200.50",
+      day_change: "1.50",
+      day_change_pct: "0.00753",
+      week_52_high: "250.00",
+      week_52_low: "140.00",
+      currency: "USD",
+    },
+    key_stats: null,
+    source: { identity: "local_db+yfinance", price: "yfinance", key_stats: "yfinance" },
+    ...overrides,
+  };
+}
+
+function freshThesis(): ThesisDetail {
+  const now = new Date();
+  return {
+    thesis_id: 1,
+    instrument_id: 42,
+    thesis_version: 3,
+    thesis_type: "compounder",
+    stance: "buy",
+    confidence_score: 0.72,
+    buy_zone_low: 180,
+    buy_zone_high: 210,
+    base_value: 230,
+    bull_value: 260,
+    bear_value: 170,
+    break_conditions_json: null,
+    memo_markdown: "Fresh thesis memo.",
+    critic_json: null,
+    created_at: now.toISOString(),
+  };
+}
+
+function staleThesis(): ThesisDetail {
+  const old = new Date();
+  old.setDate(old.getDate() - 45);
+  return { ...freshThesis(), created_at: old.toISOString() };
+}
+
+function heldPosition(): InstrumentPositionDetail {
+  return {
+    instrument_id: 42,
+    symbol: "AAPL",
+    company_name: "Apple Inc.",
+    currency: "USD",
+    current_price: 200.5,
+    total_units: 10,
+    avg_entry: 180,
+    total_invested: 1800,
+    total_value: 2005,
+    total_pnl: 205,
+    trades: [
+      {
+        position_id: 101,
+        is_buy: true,
+        units: 10,
+        amount: 1800,
+        open_rate: 180,
+        open_date_time: "2026-01-01T10:00:00Z",
+        current_price: 200.5,
+        market_value: 2005,
+        unrealized_pnl: 205,
+        stop_loss_rate: null,
+        take_profit_rate: null,
+        is_tsl_enabled: false,
+        leverage: 1,
+        total_fees: 0,
+      },
+    ],
+  };
+}
+
+function noopProps() {
+  return {
+    thesisLoaded: true,
+    positionLoaded: true,
+    onAdd: vi.fn(),
+    onClose: vi.fn(),
+    onGenerateThesis: vi.fn(),
+    generatingThesis: false,
+  };
+}
+
+describe("SummaryStrip — action gating", () => {
+  it("renders identity + price + sector strip from summary", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={null}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.getByText("AAPL")).toBeInTheDocument();
+    expect(screen.getByText("Apple Inc.")).toBeInTheDocument();
+    expect(screen.getByText(/Technology/)).toBeInTheDocument();
+  });
+
+  it("hides Close when not held", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={freshThesis()}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.queryByTestId("action-close")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("held-badge")).not.toBeInTheDocument();
+  });
+
+  it("shows Close + Held badge when position.total_units > 0", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={freshThesis()}
+        position={heldPosition()}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.getByTestId("action-close")).toBeInTheDocument();
+    expect(screen.getByTestId("held-badge").textContent).toContain("10u");
+  });
+
+  it("hides Generate thesis when thesis is fresh (< 30d)", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={freshThesis()}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(
+      screen.queryByTestId("action-generate-thesis"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("thesis-badge").textContent).not.toContain(
+      "stale",
+    );
+  });
+
+  it("shows Generate thesis when thesis is missing", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={null}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.getByTestId("action-generate-thesis")).toBeInTheDocument();
+    expect(screen.getByTestId("thesis-badge-missing")).toBeInTheDocument();
+  });
+
+  it("shows Generate thesis + (stale) marker when thesis is > 30d old", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={staleThesis()}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.getByTestId("action-generate-thesis")).toBeInTheDocument();
+    expect(screen.getByTestId("thesis-badge").textContent).toContain("stale");
+  });
+
+  it("hides Add when instrument is not tradable", () => {
+    render(
+      <SummaryStrip
+        summary={summary({ is_tradable: false })}
+        thesis={freshThesis()}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.queryByTestId("action-add")).not.toBeInTheDocument();
+  });
+
+  it("calls onAdd / onClose / onGenerateThesis on click", async () => {
+    const props = noopProps();
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={staleThesis()}
+        position={heldPosition()}
+        {...props}
+      />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("action-add"));
+    await user.click(screen.getByTestId("action-close"));
+    await user.click(screen.getByTestId("action-generate-thesis"));
+    expect(props.onAdd).toHaveBeenCalledTimes(1);
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+    expect(props.onGenerateThesis).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Generate thesis button while generatingThesis=true", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={null}
+        position={null}
+        {...noopProps()}
+        generatingThesis
+      />,
+    );
+    const btn = screen.getByTestId("action-generate-thesis");
+    expect(btn).toBeDisabled();
+    expect(btn.textContent).toContain("Generating");
+  });
+
+  it("hides thesis badge + Generate thesis button while fetch is unsettled (thesisLoaded=false)", () => {
+    // Prevents a pre-resolution null from flashing "Generate thesis"
+    // and triggering a needless generation (Codex slice-1 feedback).
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={null}
+        position={null}
+        {...noopProps()}
+        thesisLoaded={false}
+      />,
+    );
+    expect(screen.queryByTestId("thesis-badge")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("thesis-badge-missing"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("action-generate-thesis"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides held badge + Close button while position fetch is unsettled", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={freshThesis()}
+        position={heldPosition()}
+        {...noopProps()}
+        positionLoaded={false}
+      />,
+    );
+    expect(screen.queryByTestId("held-badge")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("action-close")).not.toBeInTheDocument();
+  });
+
+  it("hides Close button for multi-trade positions (can't close from strip)", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={freshThesis()}
+        position={{
+          ...heldPosition(),
+          trades: [
+            { position_id: 1 } as unknown as InstrumentPositionDetail["trades"][0],
+            { position_id: 2 } as unknown as InstrumentPositionDetail["trades"][0],
+          ],
+        }}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.queryByTestId("action-close")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -70,9 +70,13 @@ export interface SummaryStripProps {
   thesis: ThesisDetail | null;
   /** True iff the thesis fetch has settled (resolved or legitimate 404). */
   thesisLoaded: boolean;
+  /** True iff the thesis fetch errored on a non-404 failure. */
+  thesisError: boolean;
   position: InstrumentPositionDetail | null;
   /** True iff the position fetch has settled. */
   positionLoaded: boolean;
+  /** True iff the position fetch errored on a non-404 failure. */
+  positionError: boolean;
   onAdd: () => void;
   onClose: () => void;
   onGenerateThesis: () => void;
@@ -83,8 +87,10 @@ export function SummaryStrip({
   summary,
   thesis,
   thesisLoaded,
+  thesisError,
   position,
   positionLoaded,
+  positionError,
   onAdd,
   onClose,
   onGenerateThesis,
@@ -103,18 +109,19 @@ export function SummaryStrip({
   const isHeld = heldUnits > 0;
   // Multi-trade positions can't be closed from this strip because
   // ClosePositionModal needs one specific position_id. The operator
-  // goes to the Positions tab instead. Hide the button rather than
-  // offer a dead-end click.
+  // goes to the Positions tab instead. Also gate on `positionLoaded`
+  // (NOT errored) so a stale/unresolved fetch doesn't offer a
+  // dead-end click.
   const canCloseFromStrip =
     positionLoaded &&
+    !positionError &&
+    isHeld &&
     position !== null &&
-    position.total_units > 0 &&
     position.trades.length === 1;
   const thesisStale = isThesisStale(thesis);
-  // Only gate on staleness AFTER the fetch settles; otherwise a
-  // pre-resolution `null` would flash "Generate thesis" and could
-  // trigger a needless generation.
-  const showGenerateThesis = thesisLoaded && thesisStale;
+  // Still offer Generate thesis on errored thesis state — gives the
+  // operator a retry affordance instead of silent lockout.
+  const showGenerateThesis = (thesisLoaded && thesisStale) || thesisError;
 
   return (
     <div
@@ -159,7 +166,14 @@ export function SummaryStrip({
 
       {/* Row 3: badges + actions */}
       <div className="mt-3 flex flex-wrap items-center gap-2">
-        {thesisLoaded && thesis !== null ? (
+        {thesisError ? (
+          <span
+            data-testid="thesis-badge-error"
+            className="inline-flex items-center rounded border border-red-300 bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700"
+          >
+            Thesis unavailable
+          </span>
+        ) : thesisLoaded && thesis !== null ? (
           <span
             data-testid="thesis-badge"
             className={`inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium ${thesisTone(thesis.stance)}`}
@@ -181,7 +195,14 @@ export function SummaryStrip({
           </span>
         ) : null}
 
-        {positionLoaded && isHeld ? (
+        {positionError ? (
+          <span
+            data-testid="position-badge-error"
+            className="inline-flex items-center rounded border border-red-300 bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700"
+          >
+            Holdings unavailable
+          </span>
+        ) : positionLoaded && isHeld ? (
           <span
             data-testid="held-badge"
             className="inline-flex items-center rounded border border-blue-300 bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700"

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -1,0 +1,229 @@
+/**
+ * SummaryStrip — sticky per-instrument header (Slice 1 of per-stock
+ * research page, docs/superpowers/specs/2026-04-20-per-stock-research-page.md).
+ *
+ * Always-visible identity + price + thesis + score + position badges
+ * plus the research-page action surface (Add / Close / Generate thesis).
+ * Sits above the tab nav; stays visible as the operator scrolls through
+ * financials or news.
+ *
+ * Action gating:
+ *   - Close — only when `heldUnits > 0`.
+ *   - Generate thesis — when no thesis, or thesis is > 30d old.
+ *   - Add — always enabled on tradable instruments.
+ */
+import type {
+  InstrumentSummary,
+  InstrumentPositionDetail,
+  ThesisDetail,
+} from "@/api/types";
+
+const THESIS_STALE_DAYS = 30;
+
+function formatPrice(
+  value: string | null | undefined,
+  currency: string | null | undefined,
+): string {
+  if (value === null || value === undefined) return "—";
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "—";
+  const formatted = num.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  });
+  return currency ? `${currency} ${formatted}` : formatted;
+}
+
+function formatPct(value: string | null | undefined, signed = false): string {
+  if (value === null || value === undefined) return "—";
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "—";
+  const pct = (num * 100).toFixed(2);
+  const sign = signed && num > 0 ? "+" : "";
+  return `${sign}${pct}%`;
+}
+
+function isThesisStale(thesis: ThesisDetail | null): boolean {
+  if (thesis === null) return true;
+  const created = new Date(thesis.created_at);
+  if (Number.isNaN(created.getTime())) return true;
+  const ageDays = (Date.now() - created.getTime()) / (1000 * 60 * 60 * 24);
+  return ageDays > THESIS_STALE_DAYS;
+}
+
+function thesisTone(stance: string): string {
+  switch (stance.toLowerCase()) {
+    case "buy":
+      return "bg-emerald-50 text-emerald-700 border-emerald-300";
+    case "hold":
+      return "bg-slate-100 text-slate-700 border-slate-300";
+    case "exit":
+    case "sell":
+      return "bg-red-50 text-red-700 border-red-300";
+    default:
+      return "bg-slate-100 text-slate-700 border-slate-300";
+  }
+}
+
+export interface SummaryStripProps {
+  summary: InstrumentSummary;
+  thesis: ThesisDetail | null;
+  /** True iff the thesis fetch has settled (resolved or legitimate 404). */
+  thesisLoaded: boolean;
+  position: InstrumentPositionDetail | null;
+  /** True iff the position fetch has settled. */
+  positionLoaded: boolean;
+  onAdd: () => void;
+  onClose: () => void;
+  onGenerateThesis: () => void;
+  generatingThesis: boolean;
+}
+
+export function SummaryStrip({
+  summary,
+  thesis,
+  thesisLoaded,
+  position,
+  positionLoaded,
+  onAdd,
+  onClose,
+  onGenerateThesis,
+  generatingThesis,
+}: SummaryStripProps): JSX.Element {
+  const { identity, price } = summary;
+  const changeNum = price?.day_change_pct != null ? Number(price.day_change_pct) : null;
+  const changeColor =
+    changeNum === null
+      ? "text-slate-500"
+      : changeNum >= 0
+        ? "text-emerald-600"
+        : "text-red-600";
+
+  const heldUnits = position?.total_units ?? 0;
+  const isHeld = heldUnits > 0;
+  // Multi-trade positions can't be closed from this strip because
+  // ClosePositionModal needs one specific position_id. The operator
+  // goes to the Positions tab instead. Hide the button rather than
+  // offer a dead-end click.
+  const canCloseFromStrip =
+    positionLoaded &&
+    position !== null &&
+    position.total_units > 0 &&
+    position.trades.length === 1;
+  const thesisStale = isThesisStale(thesis);
+  // Only gate on staleness AFTER the fetch settles; otherwise a
+  // pre-resolution `null` would flash "Generate thesis" and could
+  // trigger a needless generation.
+  const showGenerateThesis = thesisLoaded && thesisStale;
+
+  return (
+    <div
+      data-testid="summary-strip"
+      className="sticky top-0 z-20 border-b border-slate-200 bg-white px-4 py-3 shadow-sm"
+    >
+      {/* Row 1: identity + price */}
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <h1 className="text-2xl font-semibold text-slate-800">
+          {identity.symbol}
+        </h1>
+        <span className="text-lg text-slate-600">
+          {identity.display_name ?? "—"}
+        </span>
+        {summary.coverage_tier !== null ? (
+          <span className="rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+            Tier {summary.coverage_tier}
+          </span>
+        ) : null}
+        {price ? (
+          <>
+            <span className="ml-auto text-2xl font-semibold tabular-nums text-slate-800">
+              {formatPrice(price.current, price.currency)}
+            </span>
+            <span className={`text-sm tabular-nums ${changeColor}`}>
+              {price.day_change != null && Number(price.day_change) >= 0
+                ? "+"
+                : ""}
+              {price.day_change ?? "—"} ({formatPct(price.day_change_pct, true)})
+            </span>
+          </>
+        ) : null}
+      </div>
+
+      {/* Row 2: sector strip */}
+      <div className="mt-1 text-xs text-slate-500">
+        {identity.sector ?? "—"}
+        {identity.industry ? ` · ${identity.industry}` : ""}
+        {identity.exchange ? ` · ${identity.exchange}` : ""}
+        {identity.country ? ` · ${identity.country}` : ""}
+      </div>
+
+      {/* Row 3: badges + actions */}
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {thesisLoaded && thesis !== null ? (
+          <span
+            data-testid="thesis-badge"
+            className={`inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium ${thesisTone(thesis.stance)}`}
+          >
+            Thesis: {thesis.stance.toUpperCase()}
+            {thesis.confidence_score !== null
+              ? ` ${Math.round(Number(thesis.confidence_score) * 100)}%`
+              : ""}
+            {thesisStale ? (
+              <span className="ml-1.5 text-amber-600">(stale)</span>
+            ) : null}
+          </span>
+        ) : thesisLoaded ? (
+          <span
+            data-testid="thesis-badge-missing"
+            className="inline-flex items-center rounded border border-slate-300 bg-slate-50 px-2 py-0.5 text-xs font-medium text-slate-500"
+          >
+            No thesis yet
+          </span>
+        ) : null}
+
+        {positionLoaded && isHeld ? (
+          <span
+            data-testid="held-badge"
+            className="inline-flex items-center rounded border border-blue-300 bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700"
+          >
+            Held: {heldUnits}u
+          </span>
+        ) : null}
+
+        <div className="ml-auto flex gap-2">
+          {summary.is_tradable ? (
+            <button
+              type="button"
+              data-testid="action-add"
+              onClick={onAdd}
+              className="rounded border border-blue-300 bg-white px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50"
+            >
+              Add
+            </button>
+          ) : null}
+          {canCloseFromStrip ? (
+            <button
+              type="button"
+              data-testid="action-close"
+              onClick={onClose}
+              className="rounded border border-red-300 bg-white px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-50"
+            >
+              Close
+            </button>
+          ) : null}
+          {showGenerateThesis ? (
+            <button
+              type="button"
+              data-testid="action-generate-thesis"
+              onClick={onGenerateThesis}
+              disabled={generatingThesis}
+              className="rounded border border-slate-300 bg-white px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            >
+              {generatingThesis ? "Generating…" : "Generate thesis"}
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -166,14 +166,12 @@ export function SummaryStrip({
 
       {/* Row 3: badges + actions */}
       <div className="mt-3 flex flex-wrap items-center gap-2">
-        {thesisError ? (
-          <span
-            data-testid="thesis-badge-error"
-            className="inline-flex items-center rounded border border-red-300 bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700"
-          >
-            Thesis unavailable
-          </span>
-        ) : thesisLoaded && thesis !== null ? (
+        {/* Show stance badge whenever we have thesis data, even when
+            the sticky error flag is set — dropping the last-known
+            stance/confidence would lose useful operator context
+            during a refetch hiccup. Add a stale/errored qualifier
+            inline. */}
+        {thesis !== null ? (
           <span
             data-testid="thesis-badge"
             className={`inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium ${thesisTone(thesis.stance)}`}
@@ -192,6 +190,15 @@ export function SummaryStrip({
             className="inline-flex items-center rounded border border-slate-300 bg-slate-50 px-2 py-0.5 text-xs font-medium text-slate-500"
           >
             No thesis yet
+          </span>
+        ) : null}
+
+        {thesisError ? (
+          <span
+            data-testid="thesis-badge-error"
+            className="inline-flex items-center rounded border border-red-300 bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700"
+          >
+            Thesis unavailable
           </span>
         ) : null}
 

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -1,13 +1,16 @@
 /**
- * /instrument/:symbol — per-ticker research page (Phase 2.5).
+ * /instrument/:symbol — per-stock research page.
  *
- * Six tabs per the 2026-04-19 research-tool refocus §2.5:
- *   1. Overview    — identity + price + key stats
- *   2. Financials  — income / balance / cashflow, quarterly / annual
- *   3. Analysis    — AI thesis (fetched on-demand)
- *   4. Positions   — held position (units + cost + PnL) or "not held" badge
- *   5. News        — instrument news feed with sentiment badge
- *   6. Filings     — filing events list
+ * Layout after Slice 1 of the per-stock research page spec
+ * (docs/superpowers/specs/2026-04-20-per-stock-research-page.md):
+ *   - Sticky SummaryStrip (identity + price + thesis/score/held badges + actions)
+ *   - Tabs: Research (default) · Financials · Positions · News · Filings
+ *   - Research tab replaces the old Overview tab; key stats + thesis memo
+ *     live there so the operator lands on "is this worth owning?".
+ *   - The old Analysis tab is gone — its Generate-thesis button moved
+ *     into the SummaryStrip and the memo renders inside Research.
+ *
+ * The right rail (filings + peer + news preview) ships in Slice 2.
  */
 
 import { useState } from "react";
@@ -20,17 +23,25 @@ import {
 } from "@/api/instruments";
 import { fetchNews } from "@/api/news";
 import { fetchInstrumentPositions } from "@/api/portfolio";
-import { generateInstrumentThesis } from "@/api/theses";
+import {
+  fetchLatestThesis,
+  generateInstrumentThesis,
+} from "@/api/theses";
+import { ApiError } from "@/api/client";
 import type {
   FilingsListResponse,
-  GenerateThesisResponse,
   InstrumentFinancials,
   InstrumentPositionDetail,
   InstrumentSummary,
   NewsListResponse,
+  ThesisDetail,
 } from "@/api/types";
+import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
+import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
 import { Section, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
+import { ResearchTab } from "@/components/instrument/ResearchTab";
+import { SummaryStrip } from "@/components/instrument/SummaryStrip";
 import { useAsync } from "@/lib/useAsync";
 
 function ErrorView({ error, onRetry }: { error: unknown; onRetry?: () => void }) {
@@ -51,12 +62,11 @@ function ErrorView({ error, onRetry }: { error: unknown; onRetry?: () => void })
   );
 }
 
-type TabId = "overview" | "financials" | "analysis" | "positions" | "news" | "filings";
+type TabId = "research" | "financials" | "positions" | "news" | "filings";
 
 const TABS: { id: TabId; label: string }[] = [
-  { id: "overview", label: "Overview" },
+  { id: "research", label: "Research" },
   { id: "financials", label: "Financials" },
-  { id: "analysis", label: "Analysis" },
   { id: "positions", label: "Positions" },
   { id: "news", label: "News" },
   { id: "filings", label: "Filings" },
@@ -76,120 +86,11 @@ function formatDecimal(
   return options.currency ? `${options.currency} ${formatted}` : formatted;
 }
 
-function formatMarketCap(value: string | null): string {
-  if (value === null) return "—";
-  const num = Number(value);
-  if (!Number.isFinite(num)) return "—";
-  if (num >= 1e12) return `${(num / 1e12).toFixed(2)}T`;
-  if (num >= 1e9) return `${(num / 1e9).toFixed(2)}B`;
-  if (num >= 1e6) return `${(num / 1e6).toFixed(2)}M`;
-  return num.toLocaleString();
-}
-
-// ---------------------------------------------------------------------------
-// Header
-// ---------------------------------------------------------------------------
-
-function Header({ summary }: { summary: InstrumentSummary }) {
-  const { identity, price } = summary;
-  const changePct = price?.day_change_pct ?? null;
-  const changeNum = changePct !== null ? Number(changePct) : null;
-  const changeColor =
-    changeNum === null
-      ? "text-slate-500"
-      : changeNum >= 0
-        ? "text-emerald-600"
-        : "text-red-600";
-  return (
-    <div className="border-b border-slate-200 pb-4">
-      <div className="flex items-baseline gap-3">
-        <h1 className="text-2xl font-semibold">{identity.symbol}</h1>
-        <span className="text-lg text-slate-600">
-          {identity.display_name ?? "—"}
-        </span>
-        {summary.coverage_tier !== null && (
-          <span className="rounded bg-blue-100 px-2 py-0.5 text-xs text-blue-700">
-            Tier {summary.coverage_tier}
-          </span>
-        )}
-      </div>
-      <div className="mt-1 text-xs text-slate-500">
-        {identity.sector ?? "—"}
-        {identity.industry ? ` · ${identity.industry}` : ""}
-        {identity.exchange ? ` · ${identity.exchange}` : ""}
-        {identity.country ? ` · ${identity.country}` : ""}
-      </div>
-      {price && (
-        <div className="mt-3 flex items-baseline gap-4">
-          <span className="text-3xl font-semibold">
-            {formatDecimal(price.current, { currency: price.currency })}
-          </span>
-          {price.day_change !== null && price.day_change_pct !== null && (
-            <span className={`text-sm ${changeColor}`}>
-              {Number(price.day_change) >= 0 ? "+" : ""}
-              {formatDecimal(price.day_change)} (
-              {formatDecimal(price.day_change_pct, { percent: true })})
-            </span>
-          )}
-          <span className="text-xs text-slate-500">
-            52w: {formatDecimal(price.week_52_low)} –{" "}
-            {formatDecimal(price.week_52_high)}
-          </span>
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Overview tab
-// ---------------------------------------------------------------------------
-
-function OverviewTab({ summary }: { summary: InstrumentSummary }) {
-  const stats = summary.key_stats;
-  return (
-    <div className="grid gap-4 md:grid-cols-2">
-      <Section title="Key statistics">
-        {stats === null ? (
-          <EmptyState title="No key stats" description="No provider returned key stats for this ticker." />
-        ) : (
-          <dl className="grid grid-cols-2 gap-y-2 text-sm">
-            <dt className="text-slate-500">Market cap</dt>
-            <dd>{formatMarketCap(summary.identity.market_cap)}</dd>
-            <dt className="text-slate-500">P/E ratio</dt>
-            <dd>{formatDecimal(stats.pe_ratio)}</dd>
-            <dt className="text-slate-500">P/B ratio</dt>
-            <dd>{formatDecimal(stats.pb_ratio)}</dd>
-            <dt className="text-slate-500">Dividend yield</dt>
-            <dd>{formatDecimal(stats.dividend_yield, { percent: true })}</dd>
-            <dt className="text-slate-500">Payout ratio</dt>
-            <dd>{formatDecimal(stats.payout_ratio, { percent: true })}</dd>
-            <dt className="text-slate-500">ROE</dt>
-            <dd>{formatDecimal(stats.roe, { percent: true })}</dd>
-            <dt className="text-slate-500">ROA</dt>
-            <dd>{formatDecimal(stats.roa, { percent: true })}</dd>
-            <dt className="text-slate-500">Debt / Equity</dt>
-            <dd>{formatDecimal(stats.debt_to_equity)}</dd>
-            <dt className="text-slate-500">Revenue growth (YoY)</dt>
-            <dd>{formatDecimal(stats.revenue_growth_yoy, { percent: true })}</dd>
-            <dt className="text-slate-500">Earnings growth (YoY)</dt>
-            <dd>{formatDecimal(stats.earnings_growth_yoy, { percent: true })}</dd>
-          </dl>
-        )}
-      </Section>
-
-      <Section title="Source attribution">
-        <ul className="space-y-1 text-xs text-slate-600">
-          {Object.entries(summary.source).map(([section, provider]) => (
-            <li key={section}>
-              <span className="font-medium">{section}</span>: {provider}
-            </li>
-          ))}
-        </ul>
-      </Section>
-    </div>
-  );
-}
+// Header + Overview tab removed in Slice 1 — replaced by
+// `components/instrument/SummaryStrip.tsx` (sticky strip) and
+// `components/instrument/ResearchTab.tsx` (Research tab content).
+// `formatDecimal` is still used by the Financials tab below;
+// `formatMarketCap` moved to ResearchTab.
 
 // ---------------------------------------------------------------------------
 // Financials tab
@@ -288,84 +189,9 @@ function FinancialsTab({ symbol }: { symbol: string }) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Analysis (thesis) tab
-// ---------------------------------------------------------------------------
-
-function AnalysisTab({ symbol }: { symbol: string }) {
-  const [thesis, setThesis] = useState<GenerateThesisResponse | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  async function generate() {
-    setLoading(true);
-    setError(null);
-    try {
-      const result = await generateInstrumentThesis(symbol);
-      setThesis(result);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  return (
-    <Section title="AI thesis">
-      <div className="mb-3 flex items-center gap-3">
-        <button
-          type="button"
-          className="rounded bg-blue-600 px-3 py-1 text-sm text-white disabled:opacity-50"
-          onClick={generate}
-          disabled={loading}
-        >
-          {loading ? "Generating…" : "Generate thesis"}
-        </button>
-        {thesis && (
-          <span className="text-xs text-slate-500">
-            {thesis.cached ? "Cached (24h window)" : "Freshly generated"}
-          </span>
-        )}
-      </div>
-      {error !== null && <ErrorView error={new Error(error)} />}
-      {thesis && (
-        <div className="space-y-3 text-sm">
-          <div className="flex gap-2 text-xs">
-            <span className="rounded bg-slate-100 px-2 py-0.5">
-              stance: {thesis.thesis.stance}
-            </span>
-            <span className="rounded bg-slate-100 px-2 py-0.5">
-              confidence: {thesis.thesis.confidence_score ?? "—"}
-            </span>
-            <span className="rounded bg-slate-100 px-2 py-0.5">
-              v{thesis.thesis.thesis_version}
-            </span>
-          </div>
-          <pre className="whitespace-pre-wrap rounded border border-slate-200 bg-slate-50 p-3 text-xs">
-            {thesis.thesis.memo_markdown}
-          </pre>
-          {thesis.thesis.critic_json && (
-            <details>
-              <summary className="cursor-pointer text-xs text-slate-500">
-                Critic output
-              </summary>
-              <pre className="mt-2 whitespace-pre-wrap rounded border border-slate-200 bg-slate-50 p-3 text-xs">
-                {JSON.stringify(thesis.thesis.critic_json, null, 2)}
-              </pre>
-            </details>
-          )}
-        </div>
-      )}
-      {!thesis && error === null && !loading && (
-        <p className="text-xs text-slate-500">
-          Click "Generate thesis" to produce an AI-written bull / bear analysis.
-          Results are cached for 24h per ticker so repeat clicks don't spend
-          on the LLM.
-        </p>
-      )}
-    </Section>
-  );
-}
+// Analysis tab retired in Slice 1. The Generate-thesis button moved to
+// `SummaryStrip`; the memo renders inside `ResearchTab`. Thesis history
+// lives in a dedicated Thesis tab (landing in a follow-up slice).
 
 // ---------------------------------------------------------------------------
 // Stub tabs (positions / news / filings) — deferred to follow-up work
@@ -599,20 +425,112 @@ function FilingsTab({ instrumentId }: { instrumentId: number }) {
 
 export function InstrumentPage() {
   const { symbol = "" } = useParams<{ symbol: string }>();
-  const [activeTab, setActiveTab] = useState<TabId>("overview");
 
-  const { data: summary, error, loading } = useAsync<InstrumentSummary>(
+  const summaryAsync = useAsync<InstrumentSummary>(
     () => fetchInstrumentSummary(symbol),
     [symbol],
   );
 
-  if (loading) return <SectionSkeleton rows={4} />;
-  if (error !== null) return <ErrorView error={error} />;
-  if (!summary) return <EmptyState title="No data" description={`No data for ${symbol}.`} />;
+  if (summaryAsync.loading) return <SectionSkeleton rows={4} />;
+  if (summaryAsync.error !== null) return <ErrorView error={summaryAsync.error} />;
+  if (!summaryAsync.data)
+    return <EmptyState title="No data" description={`No data for ${symbol}.`} />;
+
+  // Per-instrument state (thesis, position, tab, modals) lives in a
+  // child so its useAsync hooks only fire when we have a real
+  // `instrument_id`. Without this split, the parent's hooks would run
+  // once with `instrumentId=null` and settle (data=null, loading=false)
+  // before the id became known, creating a brief "loaded + null"
+  // window where the Generate-thesis gate would misfire (Codex slice-1
+  // round-2 feedback).
+  return <InstrumentPageBody summary={summaryAsync.data} symbol={symbol} />;
+}
+
+function InstrumentPageBody({
+  summary,
+  symbol,
+}: {
+  summary: InstrumentSummary;
+  symbol: string;
+}): JSX.Element {
+  const instrumentId = summary.instrument_id;
+  const [activeTab, setActiveTab] = useState<TabId>("research");
+
+  const thesisAsync = useAsync<ThesisDetail | null>(
+    async () => {
+      try {
+        return await fetchLatestThesis(instrumentId);
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 404) return null;
+        throw err;
+      }
+    },
+    [instrumentId],
+  );
+
+  const positionAsync = useAsync<InstrumentPositionDetail | null>(
+    async () => {
+      try {
+        return await fetchInstrumentPositions(instrumentId);
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 404) return null;
+        throw err;
+      }
+    },
+    [instrumentId],
+  );
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [closeOpen, setCloseOpen] = useState(false);
+  const [thesisBusy, setThesisBusy] = useState(false);
+  const [thesisErr, setThesisErr] = useState<string | null>(null);
+
+  async function handleGenerateThesis() {
+    setThesisBusy(true);
+    setThesisErr(null);
+    try {
+      await generateInstrumentThesis(symbol);
+      thesisAsync.refetch();
+    } catch (err) {
+      setThesisErr(err instanceof Error ? err.message : String(err));
+    } finally {
+      setThesisBusy(false);
+    }
+  }
+
+  function handleFilled() {
+    setAddOpen(false);
+    setCloseOpen(false);
+    positionAsync.refetch();
+  }
+
+  const position = positionAsync.data;
+  const singleTrade =
+    position !== null && position.trades.length === 1
+      ? position.trades[0]
+      : null;
 
   return (
     <div className="space-y-4">
-      <Header summary={summary} />
+      <SummaryStrip
+        summary={summary}
+        thesis={thesisAsync.data}
+        thesisLoaded={!thesisAsync.loading && thesisAsync.error === null}
+        position={position}
+        positionLoaded={!positionAsync.loading && positionAsync.error === null}
+        onAdd={() => setAddOpen(true)}
+        onClose={() => setCloseOpen(true)}
+        onGenerateThesis={handleGenerateThesis}
+        generatingThesis={thesisBusy}
+      />
+      {thesisErr !== null ? (
+        <div
+          role="status"
+          className="rounded border border-red-200 bg-red-50 px-3 py-1.5 text-xs text-red-700"
+        >
+          Thesis generation failed: {thesisErr}
+        </div>
+      ) : null}
       <nav className="flex gap-1 border-b border-slate-200">
         {TABS.map((tab) => (
           <button
@@ -630,14 +548,38 @@ export function InstrumentPage() {
         ))}
       </nav>
 
-      {activeTab === "overview" && <OverviewTab summary={summary} />}
+      {activeTab === "research" && (
+        <ResearchTab summary={summary} thesis={thesisAsync.data} />
+      )}
       {activeTab === "financials" && <FinancialsTab symbol={symbol} />}
-      {activeTab === "analysis" && <AnalysisTab symbol={symbol} />}
       {activeTab === "positions" && (
         <PositionsTab symbol={symbol} instrumentId={summary.instrument_id} />
       )}
       {activeTab === "news" && <NewsTab instrumentId={summary.instrument_id} />}
       {activeTab === "filings" && <FilingsTab instrumentId={summary.instrument_id} />}
+
+      {addOpen ? (
+        <OrderEntryModal
+          isOpen
+          instrumentId={summary.instrument_id}
+          symbol={summary.identity.symbol}
+          companyName={summary.identity.display_name ?? summary.identity.symbol}
+          valuationSource="quote"
+          onRequestClose={() => setAddOpen(false)}
+          onFilled={handleFilled}
+        />
+      ) : null}
+
+      {closeOpen && singleTrade !== null && singleTrade !== undefined ? (
+        <ClosePositionModal
+          isOpen
+          instrumentId={summary.instrument_id}
+          positionId={singleTrade.position_id}
+          valuationSource="quote"
+          onRequestClose={() => setCloseOpen(false)}
+          onFilled={handleFilled}
+        />
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -13,7 +13,7 @@
  * The right rail (filings + peer + news preview) ships in Slice 2.
  */
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { fetchFilings } from "@/api/filings";
@@ -482,8 +482,29 @@ function InstrumentPageBody({
 
   const [addOpen, setAddOpen] = useState(false);
   const [closeOpen, setCloseOpen] = useState(false);
+  // Capture the close target at click time so a mid-flight refetch
+  // clearing `positionAsync.data` can't unmount an open modal
+  // (Codex slice-1 round-3 finding).
+  const [closeTarget, setCloseTarget] = useState<{
+    positionId: number;
+  } | null>(null);
   const [thesisBusy, setThesisBusy] = useState(false);
   const [thesisErr, setThesisErr] = useState<string | null>(null);
+
+  // Sticky error flags. `useAsync.refetch()` clears `error` to null at
+  // the start of the next run, which would briefly hide the error
+  // badge + retry affordance. Keep a sticky bit that only clears when
+  // the next fetch settles cleanly (non-loading + non-error).
+  const [thesisErrSticky, setThesisErrSticky] = useState(false);
+  const [positionErrSticky, setPositionErrSticky] = useState(false);
+  useEffect(() => {
+    if (thesisAsync.error !== null) setThesisErrSticky(true);
+    else if (!thesisAsync.loading) setThesisErrSticky(false);
+  }, [thesisAsync.error, thesisAsync.loading]);
+  useEffect(() => {
+    if (positionAsync.error !== null) setPositionErrSticky(true);
+    else if (!positionAsync.loading) setPositionErrSticky(false);
+  }, [positionAsync.error, positionAsync.loading]);
 
   async function handleGenerateThesis() {
     setThesisBusy(true);
@@ -501,6 +522,7 @@ function InstrumentPageBody({
   function handleFilled() {
     setAddOpen(false);
     setCloseOpen(false);
+    setCloseTarget(null);
     positionAsync.refetch();
   }
 
@@ -510,18 +532,34 @@ function InstrumentPageBody({
       ? position.trades[0]
       : null;
 
+  function handleCloseClick() {
+    if (singleTrade === null || singleTrade === undefined) return;
+    setCloseTarget({ positionId: singleTrade.position_id });
+    setCloseOpen(true);
+  }
+
   return (
     <div className="space-y-4">
       <SummaryStrip
         summary={summary}
         thesis={thesisAsync.data}
-        thesisLoaded={!thesisAsync.loading && thesisAsync.error === null}
-        thesisError={thesisAsync.error !== null}
+        // `thesisLoaded=true` iff fetch settled cleanly (not errored,
+        // even historically) AND not currently reloading.
+        thesisLoaded={
+          !thesisAsync.loading &&
+          thesisAsync.error === null &&
+          !thesisErrSticky
+        }
+        thesisError={thesisErrSticky}
         position={position}
-        positionLoaded={!positionAsync.loading && positionAsync.error === null}
-        positionError={positionAsync.error !== null}
+        positionLoaded={
+          !positionAsync.loading &&
+          positionAsync.error === null &&
+          !positionErrSticky
+        }
+        positionError={positionErrSticky}
         onAdd={() => setAddOpen(true)}
-        onClose={() => setCloseOpen(true)}
+        onClose={handleCloseClick}
         onGenerateThesis={handleGenerateThesis}
         generatingThesis={thesisBusy}
       />
@@ -576,13 +614,16 @@ function InstrumentPageBody({
         />
       ) : null}
 
-      {closeOpen && singleTrade !== null && singleTrade !== undefined ? (
+      {closeOpen && closeTarget !== null ? (
         <ClosePositionModal
           isOpen
           instrumentId={summary.instrument_id}
-          positionId={singleTrade.position_id}
+          positionId={closeTarget.positionId}
           valuationSource="quote"
-          onRequestClose={() => setCloseOpen(false)}
+          onRequestClose={() => {
+            setCloseOpen(false);
+            setCloseTarget(null);
+          }}
           onFilled={handleFilled}
         />
       ) : null}

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -516,8 +516,10 @@ function InstrumentPageBody({
         summary={summary}
         thesis={thesisAsync.data}
         thesisLoaded={!thesisAsync.loading && thesisAsync.error === null}
+        thesisError={thesisAsync.error !== null}
         position={position}
         positionLoaded={!positionAsync.loading && positionAsync.error === null}
+        positionError={positionAsync.error !== null}
         onAdd={() => setAddOpen(true)}
         onClose={() => setCloseOpen(true)}
         onGenerateThesis={handleGenerateThesis}
@@ -549,7 +551,11 @@ function InstrumentPageBody({
       </nav>
 
       {activeTab === "research" && (
-        <ResearchTab summary={summary} thesis={thesisAsync.data} />
+        <ResearchTab
+          summary={summary}
+          thesis={thesisAsync.data}
+          thesisErrored={thesisAsync.error !== null}
+        />
       )}
       {activeTab === "financials" && <FinancialsTab symbol={symbol} />}
       {activeTab === "positions" && (

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -592,7 +592,7 @@ function InstrumentPageBody({
         <ResearchTab
           summary={summary}
           thesis={thesisAsync.data}
-          thesisErrored={thesisAsync.error !== null}
+          thesisErrored={thesisErrSticky}
         />
       )}
       {activeTab === "financials" && <FinancialsTab symbol={symbol} />}


### PR DESCRIPTION
## What
Slice 1 of per-stock research page spec. Sticky `SummaryStrip` replaces the old Header; new `Research` tab becomes the default (merges old Overview + Analysis content). Action buttons (Add / Close / Generate thesis) move into the strip, gated on holding + thesis age.

## Scope
- **SummaryStrip** — always-visible identity + price + thesis/held badges + action surface.
- **ResearchTab** — default view: key stats with `field_source` provenance + thesis memo panel.
- **InstrumentPage rewire** — Research / Financials / Positions / News / Filings tabs. Drops Overview + Analysis tabs.

## Action gating
- `Close` — `total_units > 0` AND `trades.length === 1` (multi-trade → Positions tab).
- `Generate thesis` — thesis missing or >30d old, fetch settled.
- `Add` — tradable instruments only.

## Codex findings addressed
- Round 1: null-vs-loading conflation → added `thesisLoaded`/`positionLoaded` flags.
- Round 1: multi-trade Close dead-end → hide button for multi-trade, surface intent in tests.
- Round 2: pre-resolution race on null `instrumentId` → split into `InstrumentPage` (summary fetch) and `InstrumentPageBody` (mounts only once summary resolves).

## Test plan
- [x] 12 new SummaryStrip tests cover every gating branch
- [x] 296/296 frontend tests pass
- [x] typecheck green
- [x] Codex pre-push: 2 rounds, final clean

## Not in scope
- Right rail (filings + peer + news preview) — Slice 2
- `?tab=` URL query param sync — Slice 3

Refs: [per-stock research spec §5 Slice 1](docs/superpowers/specs/2026-04-20-per-stock-research-page.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)