### PR TITLE
feat: Slice 2 — right rail (filings + peer + news)

### DIFF
--- a/frontend/src/api/rankings.ts
+++ b/frontend/src/api/rankings.ts
@@ -26,9 +26,10 @@ export const RANKINGS_PAGE_LIMIT = 200;
 
 export async function fetchRankings(
   query: RankingsQuery,
+  limit: number = RANKINGS_PAGE_LIMIT,
 ): Promise<RankingsListResponse> {
   const params = new URLSearchParams();
-  params.set("limit", String(RANKINGS_PAGE_LIMIT));
+  params.set("limit", String(limit));
   if (query.coverage_tier !== null) {
     params.set("coverage_tier", String(query.coverage_tier));
   }

--- a/frontend/src/components/instrument/RightRail.test.tsx
+++ b/frontend/src/components/instrument/RightRail.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * Tests for RightRail (Slice 2 of per-stock research page,
+ * docs/superpowers/specs/2026-04-20-per-stock-research-page.md).
+ *
+ * Pins the rules the spec actually cares about:
+ *   - All three section headers render.
+ *   - Recent filings rows show `filing_type` + date + a link when the
+ *     primary document URL is present.
+ *   - Peer snapshot short-circuits when sector is null (no pointless
+ *     rankings fetch).
+ *   - Peer snapshot filters the current instrument out + links peers
+ *     to `/instrument/:symbol`.
+ *   - `fetchRankings` receives the sector + limit=6 contract.
+ *
+ * Explicitly NOT covered here: null-URL filing fallback + sentiment
+ * tone palette. Those are presentation details; the spec ships their
+ * correctness via code review, not behavioural tests.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { RightRail } from "@/components/instrument/RightRail";
+import type {
+  FilingsListResponse,
+  NewsListResponse,
+  RankingsListResponse,
+} from "@/api/types";
+
+vi.mock("@/api/filings", () => ({ fetchFilings: vi.fn() }));
+vi.mock("@/api/news", () => ({ fetchNews: vi.fn() }));
+vi.mock("@/api/rankings", () => ({
+  fetchRankings: vi.fn(),
+  RANKINGS_PAGE_LIMIT: 200,
+}));
+
+import { fetchFilings } from "@/api/filings";
+import { fetchNews } from "@/api/news";
+import { fetchRankings } from "@/api/rankings";
+
+const mockedFilings = vi.mocked(fetchFilings);
+const mockedNews = vi.mocked(fetchNews);
+const mockedRankings = vi.mocked(fetchRankings);
+
+function filingsEmpty(instrumentId: number): FilingsListResponse {
+  return {
+    instrument_id: instrumentId,
+    symbol: null,
+    items: [],
+    total: 0,
+    offset: 0,
+    limit: 3,
+  };
+}
+
+function filingsWith(instrumentId: number): FilingsListResponse {
+  return {
+    instrument_id: instrumentId,
+    symbol: "AAPL",
+    items: [
+      {
+        filing_event_id: 1,
+        instrument_id: instrumentId,
+        filing_date: "2026-04-18",
+        filing_type: "10-Q",
+        provider: "sec",
+        source_url: null,
+        primary_document_url: "https://sec.gov/10q",
+        extracted_summary: null,
+        red_flag_score: null,
+        created_at: "2026-04-18T12:00:00Z",
+      },
+    ],
+    total: 1,
+    offset: 0,
+    limit: 3,
+  };
+}
+
+function newsEmpty(instrumentId: number): NewsListResponse {
+  return {
+    instrument_id: instrumentId,
+    symbol: null,
+    items: [],
+    total: 0,
+    offset: 0,
+    limit: 3,
+  };
+}
+
+function rankingsEmpty(): RankingsListResponse {
+  return {
+    items: [],
+    total: 0,
+    offset: 0,
+    limit: 6,
+    model_version: "v1",
+    scored_at: null,
+  };
+}
+
+function rankingsWith(currentSymbol: string): RankingsListResponse {
+  return {
+    items: [
+      {
+        instrument_id: 1,
+        symbol: currentSymbol, // the current instrument appears in its own sector list
+        company_name: `${currentSymbol} Inc.`,
+        sector: "Technology",
+        coverage_tier: 1,
+        rank: 1,
+        rank_delta: null,
+        total_score: 9.1,
+        raw_total: null,
+        quality_score: null,
+        value_score: null,
+        turnaround_score: null,
+        momentum_score: null,
+        sentiment_score: null,
+        confidence_score: null,
+        penalties_json: null,
+        explanation: null,
+        model_version: "v1",
+        scored_at: "2026-04-18T00:00:00Z",
+      },
+      {
+        instrument_id: 2,
+        symbol: "MSFT",
+        company_name: "Microsoft Corp.",
+        sector: "Technology",
+        coverage_tier: 1,
+        rank: 2,
+        rank_delta: null,
+        total_score: 8.4,
+        raw_total: null,
+        quality_score: null,
+        value_score: null,
+        turnaround_score: null,
+        momentum_score: null,
+        sentiment_score: null,
+        confidence_score: null,
+        penalties_json: null,
+        explanation: null,
+        model_version: "v1",
+        scored_at: "2026-04-18T00:00:00Z",
+      },
+    ],
+    total: 2,
+    offset: 0,
+    limit: 6,
+    model_version: "v1",
+    scored_at: "2026-04-18T00:00:00Z",
+  };
+}
+
+beforeEach(() => {
+  mockedFilings.mockReset();
+  mockedNews.mockReset();
+  mockedRankings.mockReset();
+  mockedFilings.mockResolvedValue(filingsEmpty(42));
+  mockedNews.mockResolvedValue(newsEmpty(42));
+  mockedRankings.mockResolvedValue(rankingsEmpty());
+});
+
+function renderRail(props: {
+  instrumentId?: number;
+  sector?: string | null;
+  currentSymbol?: string;
+} = {}) {
+  const {
+    instrumentId = 42,
+    sector = "Technology",
+    currentSymbol = "AAPL",
+  } = props;
+  return render(
+    <MemoryRouter>
+      <RightRail
+        instrumentId={instrumentId}
+        sector={sector}
+        currentSymbol={currentSymbol}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("RightRail", () => {
+  it("renders all three section headers", async () => {
+    renderRail();
+    expect(
+      await screen.findByText(/Recent filings/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Peer snapshot/i)).toBeInTheDocument();
+    expect(screen.getByText(/Recent news/i)).toBeInTheDocument();
+  });
+
+  it("renders filing rows when data arrives", async () => {
+    mockedFilings.mockResolvedValue(filingsWith(42));
+    renderRail();
+    await waitFor(() => {
+      expect(screen.getByText("10-Q")).toBeInTheDocument();
+    });
+    const link = screen.getByText(/open →/);
+    expect(link.getAttribute("href")).toBe("https://sec.gov/10q");
+  });
+
+  it("short-circuits peer fetch when sector is null", async () => {
+    renderRail({ sector: null });
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Sector unknown — no peer set available/i),
+      ).toBeInTheDocument();
+    });
+    expect(mockedRankings).not.toHaveBeenCalled();
+  });
+
+  it("filters the current instrument out of peer list + links peers to /instrument/:symbol", async () => {
+    mockedRankings.mockResolvedValue(rankingsWith("AAPL"));
+    renderRail({ currentSymbol: "AAPL" });
+
+    await waitFor(() => {
+      expect(screen.getByText("MSFT")).toBeInTheDocument();
+    });
+    // AAPL (the current instrument) must not appear in the peer list.
+    expect(screen.queryByText(/^AAPL$/)).not.toBeInTheDocument();
+
+    const msftLink = screen
+      .getByText("MSFT")
+      .closest("a") as HTMLAnchorElement;
+    expect(msftLink.getAttribute("href")).toBe("/instrument/MSFT");
+  });
+
+  it("renders 'No other ranked peers' when filtering leaves the peer list empty", async () => {
+    // Rankings return only the current instrument — filter removes it,
+    // leaving zero peers. Narrow fixture: one-row rankings containing
+    // just "AAPL".
+    mockedRankings.mockResolvedValue({
+      items: [
+        {
+          instrument_id: 1,
+          symbol: "AAPL",
+          company_name: "Apple Inc.",
+          sector: "Technology",
+          coverage_tier: 1,
+          rank: 1,
+          rank_delta: null,
+          total_score: 9.1,
+          raw_total: null,
+          quality_score: null,
+          value_score: null,
+          turnaround_score: null,
+          momentum_score: null,
+          sentiment_score: null,
+          confidence_score: null,
+          penalties_json: null,
+          explanation: null,
+          model_version: "v1",
+          scored_at: "2026-04-18T00:00:00Z",
+        },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 6,
+      model_version: "v1",
+      scored_at: "2026-04-18T00:00:00Z",
+    });
+    renderRail({ currentSymbol: "AAPL" });
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No other ranked peers in this sector/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("passes sector + limit=6 to fetchRankings", async () => {
+    mockedRankings.mockResolvedValue(rankingsEmpty());
+    renderRail({ sector: "Healthcare" });
+    await waitFor(() => {
+      expect(mockedRankings).toHaveBeenCalledTimes(1);
+    });
+    const [query, limit] = mockedRankings.mock.calls[0]!;
+    expect(query).toMatchObject({ sector: "Healthcare" });
+    expect(limit).toBe(6);
+  });
+});

--- a/frontend/src/components/instrument/RightRail.test.tsx
+++ b/frontend/src/components/instrument/RightRail.test.tsx
@@ -220,8 +220,12 @@ describe("RightRail", () => {
     await waitFor(() => {
       expect(screen.getByText("MSFT")).toBeInTheDocument();
     });
-    // AAPL (the current instrument) must not appear in the peer list.
-    expect(screen.queryByText(/^AAPL$/)).not.toBeInTheDocument();
+    // AAPL (the current instrument) must not appear as a peer link.
+    // Scoping via the link href avoids false positives against any
+    // future heading / breadcrumb that also renders "AAPL" text.
+    expect(
+      screen.queryByRole("link", { name: /^AAPL$/ }),
+    ).not.toBeInTheDocument();
 
     const msftLink = screen
       .getByText("MSFT")

--- a/frontend/src/components/instrument/RightRail.tsx
+++ b/frontend/src/components/instrument/RightRail.tsx
@@ -39,7 +39,16 @@ export function RightRail({
   return (
     <aside className="space-y-4">
       <RecentFilings instrumentId={instrumentId} />
-      <PeerSnapshot sector={sector} currentSymbol={currentSymbol} />
+      {/* `key={sector}` forces a full remount when the sector changes
+          so `useAsync` re-initialises with `loading=true, data=null`
+          on the first render for the new sector — otherwise one frame
+          would show the prior sector's peers under the new sector's
+          heading (Codex slice-2 round-2 stale-data finding). */}
+      <PeerSnapshot
+        key={sector ?? "__no_sector__"}
+        sector={sector}
+        currentSymbol={currentSymbol}
+      />
       <RecentNews instrumentId={instrumentId} />
     </aside>
   );

--- a/frontend/src/components/instrument/RightRail.tsx
+++ b/frontend/src/components/instrument/RightRail.tsx
@@ -130,20 +130,26 @@ function PeerSnapshot({
     );
   }
 
-  const peers: RankingItem[] = (data?.items ?? [])
-    .filter((r) => r.symbol !== currentSymbol)
-    .slice(0, 5);
+  // Gate the derivation on `data !== null` rather than `?? []` so
+  // empty state only flashes when we've actually fetched an empty
+  // ranking set, not during a sector-change transition where
+  // `useAsync`'s effect hasn't flipped loading=true yet (Codex
+  // slice-2 round-1 caveat).
+  const peers: RankingItem[] | null =
+    data === null
+      ? null
+      : data.items.filter((r) => r.symbol !== currentSymbol).slice(0, 5);
 
   return (
     <Section title={`Peer snapshot · ${sector}`}>
       {loading && <SectionSkeleton rows={3} />}
       {error !== null && <SectionError onRetry={refetch} />}
-      {!loading && error === null && peers.length === 0 && (
+      {!loading && error === null && peers !== null && peers.length === 0 && (
         <div className="text-xs text-slate-500">
           No other ranked peers in this sector.
         </div>
       )}
-      {!loading && error === null && peers.length > 0 && (
+      {!loading && error === null && peers !== null && peers.length > 0 && (
         <ul className="space-y-1.5 text-xs">
           {peers.map((p) => (
             <li

--- a/frontend/src/components/instrument/RightRail.tsx
+++ b/frontend/src/components/instrument/RightRail.tsx
@@ -1,0 +1,239 @@
+/**
+ * RightRail — peripheral-vision column of the per-stock research page
+ * (Slice 2 of docs/superpowers/specs/2026-04-20-per-stock-research-page.md).
+ *
+ * Three stacked sections, always visible regardless of which tab the
+ * operator is on:
+ *   1. Recent filings (last 3) — link out to filings tab + documents
+ *   2. Peer snapshot (top 5 ranked within same sector) — clickable
+ *      rows drill into each peer's research page
+ *   3. Recent news (last 3) — headline + sentiment badge
+ *
+ * Each section fetches independently so one failing endpoint does not
+ * blank the others (per `frontend/async-data-loading.md`).
+ */
+import { Link } from "react-router-dom";
+
+import { fetchFilings } from "@/api/filings";
+import { fetchNews } from "@/api/news";
+import { fetchRankings } from "@/api/rankings";
+import type {
+  FilingItem,
+  NewsItem,
+  RankingItem,
+} from "@/api/types";
+import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { useAsync } from "@/lib/useAsync";
+
+export interface RightRailProps {
+  instrumentId: number;
+  sector: string | null;
+  currentSymbol: string;
+}
+
+export function RightRail({
+  instrumentId,
+  sector,
+  currentSymbol,
+}: RightRailProps): JSX.Element {
+  return (
+    <aside className="space-y-4">
+      <RecentFilings instrumentId={instrumentId} />
+      <PeerSnapshot sector={sector} currentSymbol={currentSymbol} />
+      <RecentNews instrumentId={instrumentId} />
+    </aside>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recent filings
+// ---------------------------------------------------------------------------
+
+function RecentFilings({ instrumentId }: { instrumentId: number }) {
+  const { data, error, loading, refetch } = useAsync(
+    () => fetchFilings(instrumentId, 0, 3),
+    [instrumentId],
+  );
+  return (
+    <Section title="Recent filings">
+      {loading && <SectionSkeleton rows={3} />}
+      {error !== null && <SectionError onRetry={refetch} />}
+      {!loading && error === null && (data?.items.length ?? 0) === 0 && (
+        <div className="text-xs text-slate-500">No filings ingested yet.</div>
+      )}
+      {!loading && error === null && (data?.items.length ?? 0) > 0 && (
+        <ul className="space-y-1.5 text-xs">
+          {(data?.items ?? []).map((f) => (
+            <FilingRow key={f.filing_event_id} f={f} />
+          ))}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+function FilingRow({ f }: { f: FilingItem }) {
+  const link = f.primary_document_url ?? f.source_url;
+  return (
+    <li className="flex items-baseline justify-between gap-2">
+      <span className="flex items-baseline gap-2 truncate">
+        <span className="inline-block min-w-[40px] rounded bg-slate-100 px-1 py-0.5 text-center text-[10px] font-semibold uppercase text-slate-600">
+          {f.filing_type ?? "—"}
+        </span>
+        <span className="truncate text-slate-700">{f.filing_date}</span>
+      </span>
+      {link ? (
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 text-[10px] text-blue-700 hover:underline"
+        >
+          open →
+        </a>
+      ) : null}
+    </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Peer snapshot
+// ---------------------------------------------------------------------------
+
+function PeerSnapshot({
+  sector,
+  currentSymbol,
+}: {
+  sector: string | null;
+  currentSymbol: string;
+}) {
+  // `sector=null` short-circuits the fetch to avoid a pointless 200-row
+  // rankings call on unknown-sector instruments.
+  const { data, error, loading, refetch } = useAsync(
+    async () => {
+      if (sector === null) return null;
+      return await fetchRankings(
+        { coverage_tier: null, sector, stance: null },
+        6, // top 5 + room to filter out the current instrument
+      );
+    },
+    [sector],
+  );
+
+  if (sector === null) {
+    return (
+      <Section title="Peer snapshot">
+        <div className="text-xs text-slate-500">
+          Sector unknown — no peer set available.
+        </div>
+      </Section>
+    );
+  }
+
+  const peers: RankingItem[] = (data?.items ?? [])
+    .filter((r) => r.symbol !== currentSymbol)
+    .slice(0, 5);
+
+  return (
+    <Section title={`Peer snapshot · ${sector}`}>
+      {loading && <SectionSkeleton rows={3} />}
+      {error !== null && <SectionError onRetry={refetch} />}
+      {!loading && error === null && peers.length === 0 && (
+        <div className="text-xs text-slate-500">
+          No other ranked peers in this sector.
+        </div>
+      )}
+      {!loading && error === null && peers.length > 0 && (
+        <ul className="space-y-1.5 text-xs">
+          {peers.map((p) => (
+            <li
+              key={p.instrument_id}
+              className="flex items-baseline justify-between gap-2"
+            >
+              <Link
+                to={`/instrument/${encodeURIComponent(p.symbol)}`}
+                className="flex items-baseline gap-2 truncate text-blue-700 hover:underline"
+              >
+                <span className="inline-block min-w-[32px] rounded bg-slate-100 px-1 py-0.5 text-center text-[10px] font-semibold tabular-nums text-slate-600">
+                  #{p.rank ?? "—"}
+                </span>
+                <span className="truncate font-medium">{p.symbol}</span>
+              </Link>
+              <span className="shrink-0 tabular-nums text-slate-500">
+                {p.total_score !== null ? p.total_score.toFixed(1) : "—"}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recent news
+// ---------------------------------------------------------------------------
+
+function RecentNews({ instrumentId }: { instrumentId: number }) {
+  const { data, error, loading, refetch } = useAsync(
+    () => fetchNews(instrumentId, 0, 3),
+    [instrumentId],
+  );
+  return (
+    <Section title="Recent news">
+      {loading && <SectionSkeleton rows={3} />}
+      {error !== null && <SectionError onRetry={refetch} />}
+      {!loading && error === null && (data?.items.length ?? 0) === 0 && (
+        <div className="text-xs text-slate-500">No news ingested yet.</div>
+      )}
+      {!loading && error === null && (data?.items.length ?? 0) > 0 && (
+        <ul className="space-y-2 text-xs">
+          {(data?.items ?? []).map((n) => (
+            <NewsRow key={n.news_event_id} n={n} />
+          ))}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+function sentimentTone(score: number | null): string {
+  if (score === null) return "bg-slate-100 text-slate-500";
+  if (score >= 0.3) return "bg-emerald-50 text-emerald-700";
+  if (score <= -0.3) return "bg-red-50 text-red-700";
+  return "bg-slate-100 text-slate-600";
+}
+
+function NewsRow({ n }: { n: NewsItem }) {
+  const tone = sentimentTone(n.sentiment_score);
+  return (
+    <li>
+      <div className="flex items-baseline justify-between gap-2">
+        {n.url ? (
+          <a
+            href={n.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="line-clamp-2 text-slate-700 hover:text-blue-700 hover:underline"
+          >
+            {n.headline}
+          </a>
+        ) : (
+          <span className="line-clamp-2 text-slate-700">{n.headline}</span>
+        )}
+        {n.sentiment_score !== null ? (
+          <span
+            className={`shrink-0 rounded px-1 py-0.5 text-[9px] font-semibold tabular-nums uppercase ${tone}`}
+          >
+            {n.sentiment_score > 0 ? "+" : ""}
+            {n.sentiment_score.toFixed(2)}
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-0.5 flex gap-2 text-[10px] text-slate-500">
+        <span>{new Date(n.event_time).toLocaleDateString()}</span>
+        {n.source ? <span>· {n.source}</span> : null}
+      </div>
+    </li>
+  );
+}

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -41,6 +41,7 @@ import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
 import { Section, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { ResearchTab } from "@/components/instrument/ResearchTab";
+import { RightRail } from "@/components/instrument/RightRail";
 import { SummaryStrip } from "@/components/instrument/SummaryStrip";
 import { useAsync } from "@/lib/useAsync";
 
@@ -571,36 +572,52 @@ function InstrumentPageBody({
           Thesis generation failed: {thesisErr}
         </div>
       ) : null}
-      <nav className="flex gap-1 border-b border-slate-200">
-        {TABS.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            className={`px-3 py-2 text-sm ${
-              activeTab === tab.id
-                ? "border-b-2 border-blue-600 font-medium text-blue-700"
-                : "text-slate-500 hover:text-slate-700"
-            }`}
-            onClick={() => setActiveTab(tab.id)}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </nav>
+      {/* 8/12 + 4/12 split: tab content left, right rail right. Right
+          rail is persistent across tab changes per the spec — filings
+          / peer / news are always in the operator's peripheral view. */}
+      <div className="grid gap-4 lg:grid-cols-12">
+        <div className="space-y-4 lg:col-span-8">
+          <nav className="flex gap-1 border-b border-slate-200">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                className={`px-3 py-2 text-sm ${
+                  activeTab === tab.id
+                    ? "border-b-2 border-blue-600 font-medium text-blue-700"
+                    : "text-slate-500 hover:text-slate-700"
+                }`}
+                onClick={() => setActiveTab(tab.id)}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </nav>
 
-      {activeTab === "research" && (
-        <ResearchTab
-          summary={summary}
-          thesis={thesisAsync.data}
-          thesisErrored={thesisErrSticky}
-        />
-      )}
-      {activeTab === "financials" && <FinancialsTab symbol={symbol} />}
-      {activeTab === "positions" && (
-        <PositionsTab symbol={symbol} instrumentId={summary.instrument_id} />
-      )}
-      {activeTab === "news" && <NewsTab instrumentId={summary.instrument_id} />}
-      {activeTab === "filings" && <FilingsTab instrumentId={summary.instrument_id} />}
+          {activeTab === "research" && (
+            <ResearchTab
+              summary={summary}
+              thesis={thesisAsync.data}
+              thesisErrored={thesisErrSticky}
+            />
+          )}
+          {activeTab === "financials" && <FinancialsTab symbol={symbol} />}
+          {activeTab === "positions" && (
+            <PositionsTab symbol={symbol} instrumentId={summary.instrument_id} />
+          )}
+          {activeTab === "news" && <NewsTab instrumentId={summary.instrument_id} />}
+          {activeTab === "filings" && (
+            <FilingsTab instrumentId={summary.instrument_id} />
+          )}
+        </div>
+        <div className="lg:col-span-4">
+          <RightRail
+            instrumentId={summary.instrument_id}
+            sector={summary.identity.sector}
+            currentSymbol={summary.identity.symbol}
+          />
+        </div>
+      </div>
 
       {addOpen ? (
         <OrderEntryModal


### PR DESCRIPTION
## What
Persistent right rail on the research page. Three stacked sections:
1. Recent filings (last 3)
2. Peer snapshot (top 5 ranked peers in same sector, excluding current)
3. Recent news (last 3)

## Layout
InstrumentPage content splits 8/12 (tabs) + 4/12 (rail) on `lg` breakpoint. Rail persists across tab changes — peripheral vision per spec.

## Endpoints
No backend change. `fetchRankings` now takes an optional `limit` (default 200); rail passes `limit=6` so after filtering the current instrument we still have 5 peers.

## Test plan
- [x] 6 RightRail tests (section headers, filing link, sector=null, current filter, empty-peer fallback, fetchRankings contract)
- [x] typecheck green
- [x] 305 frontend tests pass
- [x] Codex reviewed, test-coverage overstatement corrected in same commit

## Not in scope
- URL tab sync (`?tab=positions`) — Slice 3
- Reports page per-contributor drill-in — Slice 4

Refs: [per-stock research spec §5 Slice 2](docs/superpowers/specs/2026-04-20-per-stock-research-page.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)