### PR TITLE
feat: Slice 3 — consolidate drill-in routes + ?tab= URL sync

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import { ConfigProvider } from "@/lib/ConfigContext";
 import { DisplayCurrencyProvider } from "@/lib/DisplayCurrencyContext";
 import { DashboardPage } from "@/pages/DashboardPage";
 import { RankingsPage } from "@/pages/RankingsPage";
-import { InstrumentDetailPage } from "@/pages/InstrumentDetailPage";
+import { InstrumentDetailRedirect } from "@/pages/InstrumentDetailRedirect";
 import { InstrumentPage } from "@/pages/InstrumentPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { RecommendationsPage } from "@/pages/RecommendationsPage";
@@ -21,7 +21,6 @@ import { OperatorsPage } from "@/pages/OperatorsPage";
 import { CopyTradingPage } from "@/pages/CopyTradingPage";
 import { InstrumentsPage } from "@/pages/InstrumentsPage";
 import { PortfolioPage } from "@/pages/PortfolioPage";
-import { PositionDetailPage } from "@/pages/PositionDetailPage";
 
 export function App() {
   return (
@@ -43,10 +42,20 @@ export function App() {
         >
           <Route index element={<DashboardPage />} />
           <Route path="portfolio" element={<PortfolioPage />} />
-          <Route path="portfolio/:instrumentId" element={<PositionDetailPage />} />
+          {/* Legacy per-instrument routes redirect to the canonical
+              `/instrument/:symbol` research page. Slice 3 of the
+              per-stock research spec — shims stay for one release so
+              operator bookmarks migrate; Slice 5 deletes them. */}
+          <Route
+            path="portfolio/:instrumentId"
+            element={<InstrumentDetailRedirect search="?tab=positions" />}
+          />
           <Route path="rankings" element={<RankingsPage />} />
           <Route path="instruments" element={<InstrumentsPage />} />
-          <Route path="instruments/:instrumentId" element={<InstrumentDetailPage />} />
+          <Route
+            path="instruments/:instrumentId"
+            element={<InstrumentDetailRedirect />}
+          />
           <Route path="instrument/:symbol" element={<InstrumentPage />} />
           <Route path="copy-trading/:mirrorId" element={<CopyTradingPage />} />
           <Route path="recommendations" element={<RecommendationsPage />} />

--- a/frontend/src/components/dashboard/RecentRecommendations.tsx
+++ b/frontend/src/components/dashboard/RecentRecommendations.tsx
@@ -36,7 +36,7 @@ export function RecentRecommendations({ items }: { items: RecommendationListItem
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <Link
-                to={`/instruments/${r.instrument_id}`}
+                to={`/instrument/${encodeURIComponent(r.symbol)}`}
                 className="font-medium text-blue-600 hover:underline"
               >
                 {r.symbol}

--- a/frontend/src/components/rankings/RankingsTable.tsx
+++ b/frontend/src/components/rankings/RankingsTable.tsx
@@ -200,7 +200,7 @@ function RankingRow({ item }: { item: RankingItem }) {
       </td>
       <td className="px-2 py-2">
         <Link
-          to={`/instruments/${item.instrument_id}`}
+          to={`/instrument/${encodeURIComponent(item.symbol)}`}
           className="font-medium text-blue-600 hover:underline"
         >
           {item.symbol}

--- a/frontend/src/components/recommendations/AuditTrail.tsx
+++ b/frontend/src/components/recommendations/AuditTrail.tsx
@@ -93,7 +93,7 @@ function AuditRow({ item }: { item: AuditListItem }) {
         <td className="px-2 py-2">
           {item.instrument_id !== null && item.symbol ? (
             <Link
-              to={`/instruments/${item.instrument_id}`}
+              to={`/instrument/${encodeURIComponent(item.symbol)}`}
               className="font-medium text-blue-600 hover:underline"
               onClick={(e) => e.stopPropagation()}
             >

--- a/frontend/src/components/recommendations/RecommendationsTable.tsx
+++ b/frontend/src/components/recommendations/RecommendationsTable.tsx
@@ -95,7 +95,7 @@ function RecommendationRow({ item }: { item: RecommendationListItem }) {
       >
         <td className="px-2 py-2">
           <Link
-            to={`/instruments/${item.instrument_id}`}
+            to={`/instrument/${encodeURIComponent(item.symbol)}`}
             className="font-medium text-blue-600 hover:underline"
             onClick={(e) => e.stopPropagation()}
           >

--- a/frontend/src/pages/InstrumentDetailRedirect.tsx
+++ b/frontend/src/pages/InstrumentDetailRedirect.tsx
@@ -1,0 +1,74 @@
+/**
+ * Route shim at `/instruments/:instrumentId` (Slice 3 of per-stock
+ * research page spec).
+ *
+ * Fetches the instrument's symbol by id, then `Navigate`s to the
+ * canonical `/instrument/:symbol` research page. Keeps legacy
+ * bookmarks warm for one release after the old InstrumentDetailPage
+ * retires; delete in Slice 5 once operator bookmarks have migrated.
+ */
+import { Navigate, useParams } from "react-router-dom";
+
+import { ApiError } from "@/api/client";
+import { fetchInstrumentDetail } from "@/api/instruments";
+import { SectionSkeleton } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+
+export interface InstrumentDetailRedirectProps {
+  /** Query string appended to the target path, e.g. `?tab=positions`. */
+  search?: string;
+}
+
+export function InstrumentDetailRedirect({
+  search = "",
+}: InstrumentDetailRedirectProps): JSX.Element {
+  const { instrumentId } = useParams<{ instrumentId: string }>();
+  const parsedId = instrumentId ? Number(instrumentId) : NaN;
+
+  const { data, error, loading } = useAsync(
+    async () => {
+      if (!Number.isFinite(parsedId)) return null;
+      try {
+        return await fetchInstrumentDetail(parsedId);
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 404) return null;
+        throw err;
+      }
+    },
+    [parsedId],
+  );
+
+  if (!Number.isFinite(parsedId)) {
+    return (
+      <EmptyState
+        title="Invalid instrument id"
+        description={`"${instrumentId}" is not a valid id.`}
+      />
+    );
+  }
+  if (loading) return <SectionSkeleton rows={2} />;
+  if (error !== null) {
+    return (
+      <EmptyState
+        title="Failed to resolve instrument"
+        description="Retry from the /instrument/:symbol URL directly."
+      />
+    );
+  }
+  if (data === null) {
+    return (
+      <EmptyState
+        title="Instrument not found"
+        description={`No instrument with id ${parsedId}.`}
+      />
+    );
+  }
+  const qs = search.startsWith("?") || search === "" ? search : `?${search}`;
+  return (
+    <Navigate
+      to={`/instrument/${encodeURIComponent(data.symbol)}${qs}`}
+      replace
+    />
+  );
+}

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -13,8 +13,8 @@
  * The right rail (filings + peer + news preview) ships in Slice 2.
  */
 
-import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useCallback, useEffect, useState } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
 
 import { fetchFilings } from "@/api/filings";
 import {
@@ -455,7 +455,28 @@ function InstrumentPageBody({
   symbol: string;
 }): JSX.Element {
   const instrumentId = summary.instrument_id;
-  const [activeTab, setActiveTab] = useState<TabId>("research");
+
+  // Tab state lives in the URL so dashboard/portfolio drill-ins can
+  // preselect the Positions tab via `?tab=positions` (Slice 3 of
+  // per-stock research spec). `replace: true` on the setter so
+  // tab-switching doesn't spam browser history.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabParam = searchParams.get("tab");
+  const activeTab: TabId = TABS.some((t) => t.id === tabParam)
+    ? (tabParam as TabId)
+    : "research";
+  const setActiveTab = useCallback(
+    (next: TabId) => {
+      const params = new URLSearchParams(searchParams);
+      if (next === "research") {
+        params.delete("tab");
+      } else {
+        params.set("tab", next);
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
 
   const thesisAsync = useAsync<ThesisDetail | null>(
     async () => {

--- a/frontend/src/pages/InstrumentsPage.test.tsx
+++ b/frontend/src/pages/InstrumentsPage.test.tsx
@@ -154,7 +154,7 @@ describe("InstrumentsPage — data rendering", () => {
       expect(screen.getByText("AAPL")).toBeInTheDocument();
     });
     const link = screen.getByText("AAPL").closest("a");
-    expect(link).toHaveAttribute("href", "/instruments/1");
+    expect(link).toHaveAttribute("href", "/instrument/AAPL");
   });
 });
 

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -5,7 +5,7 @@
  * coverage-tier filters, and server-side pagination. Columns are sortable
  * client-side within the current page (server-side sort is symbol ASC).
  *
- * Each instrument row links to /instruments/:id (detail page, #62).
+ * Each instrument row links to /instrument/:symbol (research page).
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -394,7 +394,7 @@ function InstrumentsTable({
             <tr key={item.instrument_id} className="align-top hover:bg-slate-50">
               <td className="py-2 pr-4">
                 <Link
-                  to={`/instruments/${item.instrument_id}`}
+                  to={`/instrument/${encodeURIComponent(item.symbol)}`}
                   className="text-blue-600 hover:underline"
                 >
                   <span className="font-medium">{item.symbol}</span>

--- a/frontend/src/pages/PortfolioPage.test.tsx
+++ b/frontend/src/pages/PortfolioPage.test.tsx
@@ -2,7 +2,7 @@
  * Tests for PortfolioPage after the #324 unified drill-in revert.
  *
  * Behaviour pinned:
- *   - Position row click → navigates to /portfolio/:instrumentId.
+ *   - Position row click → navigates to /instrument/:symbol?tab=positions.
  *   - Mirror row click   → navigates to /copy-trading/:mirrorId.
  *   - Row Add / Close buttons open modals without drilling.
  *   - Keyboard: `/` focuses search, `j`/`k` moves focus ring, Enter drills
@@ -147,7 +147,12 @@ function portfolioWith(
 // the current URL after a navigation without needing a real router.
 function LocationProbe() {
   const loc = useLocation();
-  return <div data-testid="location">{loc.pathname}</div>;
+  return (
+    <>
+      <div data-testid="location">{loc.pathname}</div>
+      <div data-testid="location-search">{loc.search}</div>
+    </>
+  );
 }
 
 function renderPage() {
@@ -164,7 +169,7 @@ function renderPage() {
               </>
             }
           />
-          <Route path="/portfolio/:id" element={<LocationProbe />} />
+          <Route path="/instrument/:symbol" element={<LocationProbe />} />
           <Route path="/copy-trading/:id" element={<LocationProbe />} />
         </Routes>
       </MemoryRouter>
@@ -216,7 +221,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("PortfolioPage — unified drill-in", () => {
-  it("position row click navigates to /portfolio/:instrumentId", async () => {
+  it("position row click navigates to /instrument/:symbol (tab=positions via query)", async () => {
     mockedFetchPortfolio.mockResolvedValue(portfolioWith([position(7, "AAPL")]));
     const user = userEvent.setup();
     renderPage();
@@ -225,7 +230,10 @@ describe("PortfolioPage — unified drill-in", () => {
     await user.click(row);
 
     await waitFor(() => {
-      expect(screen.getByTestId("location").textContent).toBe("/portfolio/7");
+      expect(screen.getByTestId("location").textContent).toBe("/instrument/AAPL");
+      expect(screen.getByTestId("location-search").textContent).toBe(
+        "?tab=positions",
+      );
     });
   });
 
@@ -306,14 +314,14 @@ describe("PortfolioPage — keyboard", () => {
     expect(input.value).toBe("");
   });
 
-  it("Enter drills the focused row to /portfolio/:id", async () => {
+  it("Enter drills the focused row to /instrument/:symbol", async () => {
     const user = userEvent.setup();
     renderPage();
     await screen.findByTestId("position-row-1");
 
     await user.keyboard("j{Enter}"); // focus second row (BBB → id 2), drill
     await waitFor(() => {
-      expect(screen.getByTestId("location").textContent).toBe("/portfolio/2");
+      expect(screen.getByTestId("location").textContent).toBe("/instrument/BBB");
     });
   });
 

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -37,7 +37,7 @@ const PAGE_SIZE = 50;
  * Portfolio page — unified drill-in for positions + mirrors (#324).
  *
  * Revert of the #314 workstation split. Both row types behave the same:
- *   - Position row click → /portfolio/:instrumentId
+ *   - Position row click → /instrument/:symbol?tab=positions
  *   - Mirror row click   → /copy-trading/:mirrorId
  * No right-side detail pane; the per-row Add / Close buttons still open
  * their modals inline so the #313 action surface is preserved.
@@ -132,7 +132,12 @@ export function PortfolioPage() {
   const drillInto = useCallback(
     (row: RowItem) => {
       if (row.kind === "position") {
-        navigate(`/portfolio/${row.data.instrument_id}`);
+        // Position rows drill into the research page's Positions tab
+        // (per-stock research spec §4) — the operator lands on the
+        // canonical research view with their position pre-selected.
+        navigate(
+          `/instrument/${encodeURIComponent(row.data.symbol)}?tab=positions`,
+        );
       } else {
         navigate(`/copy-trading/${row.data.mirror_id}`);
       }


### PR DESCRIPTION
## What
Every per-instrument link in the app now drills to the canonical `/instrument/:symbol` research page. Dashboard/portfolio position clicks land on the Positions tab via `?tab=positions`.

## Link migrations
- `RankingsTable`, `RecentRecommendations`, `AuditTrail`, `RecommendationsTable`, `InstrumentsPage` — all rewired.
- `PortfolioPage` position row click → `/instrument/:symbol?tab=positions` (mirror rows unchanged).

## URL-driven tab state
`InstrumentPage` reads `?tab=` via `useSearchParams`. Tab switches `replace` the query (no history spam). Clearing to research drops the param for clean URLs.

## Route shims
`InstrumentDetailRedirect` fetches the instrument by id and redirects to `/instrument/:symbol`. Wired at:
- `/instruments/:instrumentId`
- `/portfolio/:instrumentId` (appends `?tab=positions`)

Orphaned `InstrumentDetailPage` / `PositionDetailPage` stay on disk for one release; Slice 5 deletes them.

## Test plan
- [x] Tests updated (InstrumentsPage, PortfolioPage)
- [x] LocationProbe extended to expose search string
- [x] 305 frontend tests pass
- [x] typecheck green
- [x] Codex pre-push clean

## Not in scope
- Reports per-contributor drill — Slice 4
- Admin coverage migration + delete orphans — Slice 5

Refs: [per-stock research spec §5 Slice 3](docs/superpowers/specs/2026-04-20-per-stock-research-page.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)