### PR TITLE
feat: Slice 4 — Reports per-contributor drill-in

### DIFF
--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -585,6 +585,17 @@ def _load_prior_snapshot(
     # possible under test mocks) degrades to "no prior snapshot"
     # rather than raising KeyError.
     snapshot_json = row.get("snapshot_json")
+    # psycopg3 with the default JSONB adapter returns a dict. Some
+    # driver configurations or downstream adapters return the raw
+    # JSON string — decode it so a valid prior snapshot isn't
+    # silently dropped (Codex slice-4 round-2 note).
+    if isinstance(snapshot_json, str):
+        import json
+
+        try:
+            snapshot_json = json.loads(snapshot_json)
+        except json.JSONDecodeError:
+            return None
     return snapshot_json if isinstance(snapshot_json, dict) else None
 
 
@@ -616,7 +627,10 @@ def _compute_contributors(
         return {"contributors": [], "drags": []}
 
     prior_by_id = {p["instrument_id"]: p for p in prior}
-    deltas: list[dict[str, Any]] = []
+    # Keep the raw Decimal delta alongside the serialised string so
+    # sort + filter never round-trip through `Decimal(str)` re-parsing
+    # (Codex slice-4 round-2 note).
+    entries: list[tuple[Decimal, dict[str, Any]]] = []
     for curr in current:
         iid = curr["instrument_id"]
         prior_row = prior_by_id.get(iid)
@@ -627,24 +641,27 @@ def _compute_contributors(
             continue
         prior_cost = Decimal(prior_row["cost_basis"] or "0") if prior_row is not None else Decimal("0")
         pnl_pct: Decimal | None = delta / prior_cost if prior_cost > 0 else None
-        deltas.append(
-            {
-                "instrument_id": iid,
-                "symbol": curr["symbol"],
-                "pnl_delta": _dec(delta),
-                "pnl_pct": _dec(pnl_pct),
-            }
+        entries.append(
+            (
+                delta,
+                {
+                    "instrument_id": iid,
+                    "symbol": curr["symbol"],
+                    "pnl_delta": _dec(delta),
+                    "pnl_pct": _dec(pnl_pct),
+                },
+            )
         )
 
-    # Sort by signed delta: contributors are the top gainers, drags
-    # are the most-negative losers. Using Decimal for correctness on
-    # the delta comparison.
-    deltas.sort(key=lambda r: Decimal(r["pnl_delta"] or "0"), reverse=True)
-    contributors = [r for r in deltas if Decimal(r["pnl_delta"] or "0") > 0][:top_n]
-    drags = [r for r in deltas if Decimal(r["pnl_delta"] or "0") < 0][-top_n:]
-    # `drags` is ascending (most negative last after [::-1] below); the
-    # UI expects "most dragging first", so reverse here.
-    drags = list(reversed(drags))
+    # Contributors: positive deltas, descending (biggest gainer first).
+    # Drags: negative deltas, ascending (most-negative first). Both
+    # sort on the raw Decimal and slice from the head so the ordering
+    # intent is unambiguous and doesn't depend on which end of the
+    # combined list we slice from.
+    positives = sorted((e for e in entries if e[0] > 0), key=lambda e: e[0], reverse=True)
+    negatives = sorted((e for e in entries if e[0] < 0), key=lambda e: e[0])
+    contributors = [row for _, row in positives[:top_n]]
+    drags = [row for _, row in negatives[:top_n]]
     return {"contributors": contributors, "drags": drags}
 
 
@@ -734,11 +751,7 @@ def generate_weekly_report(
     # `_compute_contributors` degrades to empty lists. Passing `[]`
     # here would treat every current holding as a brand-new
     # contributor. Codex slice-4 finding.
-    prior_positions = (
-        prior.get("positions")
-        if isinstance(prior, dict) and "positions" in prior
-        else None
-    )
+    prior_positions = prior.get("positions") if isinstance(prior, dict) and "positions" in prior else None
     period_contribution = _compute_contributors(positions_now, prior_positions)
 
     return {
@@ -793,11 +806,7 @@ def generate_monthly_report(
     # `_compute_contributors` degrades to empty lists. Passing `[]`
     # here would treat every current holding as a brand-new
     # contributor. Codex slice-4 finding.
-    prior_positions = (
-        prior.get("positions")
-        if isinstance(prior, dict) and "positions" in prior
-        else None
-    )
+    prior_positions = prior.get("positions") if isinstance(prior, dict) and "positions" in prior else None
     period_contribution = _compute_contributors(positions_now, prior_positions)
 
     return {

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -522,6 +522,132 @@ def _tax_provision_snapshot(conn: psycopg.Connection[Any]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def _positions_snapshot(conn: psycopg.Connection[Any]) -> list[dict[str, Any]]:
+    """Per-instrument open-position P&L at snapshot time.
+
+    Stored on each `report_snapshots.snapshot_json["positions"]` so the
+    next snapshot can diff against it to surface period contributors
+    (Slice 4 of the per-stock research page spec).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT p.instrument_id,
+                   i.symbol,
+                   i.company_name,
+                   p.unrealized_pnl,
+                   p.cost_basis
+            FROM positions p
+            JOIN instruments i USING (instrument_id)
+            WHERE p.current_units > 0
+            ORDER BY p.instrument_id
+            """
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "instrument_id": r["instrument_id"],
+            "symbol": r["symbol"],
+            "company_name": r["company_name"],
+            "unrealized_pnl": _dec(r["unrealized_pnl"]),
+            "cost_basis": _dec(r["cost_basis"]),
+        }
+        for r in rows
+    ]
+
+
+def _load_prior_snapshot(
+    conn: psycopg.Connection[Any],
+    *,
+    report_type: str,
+    period_start: date,
+) -> dict[str, Any] | None:
+    """Return the `snapshot_json` of the most recent snapshot of the
+    given `report_type` whose `period_start` is strictly BEFORE the
+    supplied `period_start`, or None if there isn't one.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT snapshot_json
+            FROM report_snapshots
+            WHERE report_type = %(report_type)s
+              AND period_start < %(period_start)s
+            ORDER BY period_start DESC
+            LIMIT 1
+            """,
+            {"report_type": report_type, "period_start": period_start},
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    # `.get` rather than `[]` so a row shape missing the column (only
+    # possible under test mocks) degrades to "no prior snapshot"
+    # rather than raising KeyError.
+    snapshot_json = row.get("snapshot_json")
+    return snapshot_json if isinstance(snapshot_json, dict) else None
+
+
+def _compute_contributors(
+    current: list[dict[str, Any]],
+    prior: list[dict[str, Any]] | None,
+    *,
+    top_n: int = 5,
+) -> dict[str, list[dict[str, Any]]]:
+    """Diff per-instrument unrealised P&L between two position snapshots.
+
+    Returns `{contributors: [...top_n gainers...], drags: [...top_n losers...]}`
+    where each row is `{instrument_id, symbol, pnl_delta, pnl_pct}`.
+
+    - `pnl_delta` = current unrealized_pnl - prior unrealized_pnl (Decimal → str).
+    - `pnl_pct`   = pnl_delta / prior_cost_basis (None if no prior row or
+      prior cost_basis is zero — avoids div/0 and the misleading "∞%"
+      for a brand-new position).
+    - New positions (in `current`, absent from `prior`) surface with
+      their full unrealized_pnl as the delta and `pnl_pct = null`.
+    - Closed positions (in `prior`, absent from `current`) are NOT
+      reported here — their contribution lives in the realised-P&L
+      aggregate, which the existing `pnl` section already covers.
+    - When `prior is None` (first snapshot, or backfilled historical
+      snapshots with no `positions` key), both lists are empty so the
+      UI gracefully degrades.
+    """
+    if prior is None:
+        return {"contributors": [], "drags": []}
+
+    prior_by_id = {p["instrument_id"]: p for p in prior}
+    deltas: list[dict[str, Any]] = []
+    for curr in current:
+        iid = curr["instrument_id"]
+        prior_row = prior_by_id.get(iid)
+        curr_pnl = Decimal(curr["unrealized_pnl"] or "0")
+        prior_pnl = Decimal(prior_row["unrealized_pnl"] or "0") if prior_row is not None else Decimal("0")
+        delta = curr_pnl - prior_pnl
+        if delta == 0:
+            continue
+        prior_cost = Decimal(prior_row["cost_basis"] or "0") if prior_row is not None else Decimal("0")
+        pnl_pct: Decimal | None = delta / prior_cost if prior_cost > 0 else None
+        deltas.append(
+            {
+                "instrument_id": iid,
+                "symbol": curr["symbol"],
+                "pnl_delta": _dec(delta),
+                "pnl_pct": _dec(pnl_pct),
+            }
+        )
+
+    # Sort by signed delta: contributors are the top gainers, drags
+    # are the most-negative losers. Using Decimal for correctness on
+    # the delta comparison.
+    deltas.sort(key=lambda r: Decimal(r["pnl_delta"] or "0"), reverse=True)
+    contributors = [r for r in deltas if Decimal(r["pnl_delta"] or "0") > 0][:top_n]
+    drags = [r for r in deltas if Decimal(r["pnl_delta"] or "0") < 0][-top_n:]
+    # `drags` is ascending (most negative last after [::-1] below); the
+    # UI expects "most dragging first", so reverse here.
+    drags = list(reversed(drags))
+    return {"contributors": contributors, "drags": drags}
+
+
 def persist_report_snapshot(
     conn: psycopg.Connection[Any],
     *,
@@ -601,6 +727,19 @@ def generate_weekly_report(
     upcoming_earnings = _upcoming_earnings(conn)
     score_changes = _score_changes(conn, period_start, period_end)
     budget = _budget_snapshot(conn)
+    positions_now = _positions_snapshot(conn)
+    prior = _load_prior_snapshot(conn, report_type="weekly", period_start=period_start)
+    # When `prior` is absent OR lacks the `positions` key (pre-feature
+    # snapshots from before Slice 4), pass `None` so
+    # `_compute_contributors` degrades to empty lists. Passing `[]`
+    # here would treat every current holding as a brand-new
+    # contributor. Codex slice-4 finding.
+    prior_positions = (
+        prior.get("positions")
+        if isinstance(prior, dict) and "positions" in prior
+        else None
+    )
+    period_contribution = _compute_contributors(positions_now, prior_positions)
 
     return {
         "report_type": "weekly",
@@ -615,6 +754,14 @@ def generate_weekly_report(
         "upcoming_earnings": upcoming_earnings,
         "score_changes": score_changes,
         "budget": budget,
+        # Per-instrument position snapshot so the *next* weekly
+        # snapshot can compute period contribution against it.
+        "positions": positions_now,
+        # Contributors + drags computed against the prior snapshot.
+        # Slice 4 of per-stock research page spec. Empty arrays when
+        # there is no prior snapshot yet (fresh install or backfilled
+        # historicals with no `positions` key).
+        "period_contribution": period_contribution,
     }
 
 
@@ -639,6 +786,19 @@ def generate_monthly_report(
     attribution_summary = _period_attribution(conn, period_start, period_end)
     thesis_accuracy = _thesis_accuracy(conn, period_start, period_end)
     tax_provision = _tax_provision_snapshot(conn)
+    positions_now = _positions_snapshot(conn)
+    prior = _load_prior_snapshot(conn, report_type="monthly", period_start=period_start)
+    # When `prior` is absent OR lacks the `positions` key (pre-feature
+    # snapshots from before Slice 4), pass `None` so
+    # `_compute_contributors` degrades to empty lists. Passing `[]`
+    # here would treat every current holding as a brand-new
+    # contributor. Codex slice-4 finding.
+    prior_positions = (
+        prior.get("positions")
+        if isinstance(prior, dict) and "positions" in prior
+        else None
+    )
+    period_contribution = _compute_contributors(positions_now, prior_positions)
 
     return {
         "report_type": "monthly",
@@ -654,4 +814,6 @@ def generate_monthly_report(
         "attribution_summary": attribution_summary,
         "thesis_accuracy": thesis_accuracy,
         "tax_provision": tax_provision,
+        "positions": positions_now,
+        "period_contribution": period_contribution,
     }

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -12,6 +12,7 @@ Issue: #207
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, date, datetime
 from decimal import Decimal
@@ -590,8 +591,6 @@ def _load_prior_snapshot(
     # JSON string — decode it so a valid prior snapshot isn't
     # silently dropped (Codex slice-4 round-2 note).
     if isinstance(snapshot_json, str):
-        import json
-
         try:
             snapshot_json = json.loads(snapshot_json)
         except json.JSONDecodeError:

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -8,12 +8,40 @@
  */
 
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 
 import { fetchMonthlyReports, fetchWeeklyReports } from "@/api/reports";
 import type { ReportSnapshot } from "@/api/reports";
 import { Section, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
+
+interface ContributorRow {
+  instrument_id: number;
+  symbol: string;
+  pnl_delta: string | null;
+  pnl_pct: string | null;
+}
+
+function formatSignedPnl(raw: string | null | undefined): string {
+  if (raw === null || raw === undefined) return "—";
+  const num = Number(raw);
+  if (!Number.isFinite(num)) return "—";
+  const sign = num > 0 ? "+" : "";
+  return `${sign}${num.toLocaleString(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  })}`;
+}
+
+function formatSignedPct(raw: string | null | undefined): string {
+  if (raw === null || raw === undefined) return "—";
+  const num = Number(raw);
+  if (!Number.isFinite(num)) return "—";
+  const sign = num > 0 ? "+" : "";
+  return `${sign}${(num * 100).toFixed(2)}%`;
+}
 
 type TabId = "weekly" | "monthly";
 
@@ -79,6 +107,15 @@ function ReportDetail({ report }: { report: ReportSnapshot }) {
   const thesisAccuracy = json["thesis_accuracy"] as
     | Record<string, unknown>
     | undefined;
+  // Slice 4 of per-stock research page spec: top contributors /
+  // drags vs the prior snapshot, each row linking to the research
+  // page so the Reports view becomes an entry point into per-stock
+  // analysis rather than a terminal JSON dump.
+  const periodContribution = json["period_contribution"] as
+    | { contributors?: ContributorRow[]; drags?: ContributorRow[] }
+    | undefined;
+  const contributors = periodContribution?.contributors ?? [];
+  const drags = periodContribution?.drags ?? [];
 
   return (
     <div className="space-y-4">
@@ -120,6 +157,28 @@ function ReportDetail({ report }: { report: ReportSnapshot }) {
             <dt className="text-slate-500">Avg holding (days)</dt>
             <dd>{avgHoldingDays !== undefined ? String(avgHoldingDays) : "—"}</dd>
           </dl>
+        </div>
+      )}
+
+      {(contributors.length > 0 || drags.length > 0) && (
+        <div>
+          <h3 className="mb-1 text-xs font-medium uppercase tracking-wide text-slate-500">
+            Period contribution (vs prior snapshot)
+          </h3>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <div className="mb-1 text-[11px] font-semibold uppercase text-emerald-700">
+                Top contributors
+              </div>
+              <ContributorList rows={contributors} tone="positive" />
+            </div>
+            <div>
+              <div className="mb-1 text-[11px] font-semibold uppercase text-red-700">
+                Top drags
+              </div>
+              <ContributorList rows={drags} tone="negative" />
+            </div>
+          </div>
         </div>
       )}
 
@@ -212,6 +271,44 @@ function ReportDetail({ report }: { report: ReportSnapshot }) {
         </pre>
       </details>
     </div>
+  );
+}
+
+function ContributorList({
+  rows,
+  tone,
+}: {
+  rows: ContributorRow[];
+  tone: "positive" | "negative";
+}): JSX.Element {
+  if (rows.length === 0) {
+    return <div className="text-xs text-slate-500">—</div>;
+  }
+  const toneClass = tone === "positive" ? "text-emerald-600" : "text-red-600";
+  return (
+    <ul className="space-y-1 text-sm">
+      {rows.map((r) => (
+        <li
+          key={r.instrument_id}
+          className="flex items-baseline justify-between gap-3"
+        >
+          <Link
+            to={`/instrument/${encodeURIComponent(r.symbol)}`}
+            className="font-medium text-blue-700 hover:underline"
+          >
+            {r.symbol}
+          </Link>
+          <span className={`tabular-nums ${toneClass}`}>
+            {formatSignedPnl(r.pnl_delta)}
+            {r.pnl_pct !== null ? (
+              <span className="ml-2 text-xs">
+                ({formatSignedPct(r.pnl_pct)})
+              </span>
+            ) : null}
+          </span>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -558,7 +558,16 @@ class TestComputeContributors:
 
     def test_top_n_caps_each_list(self) -> None:
         """Only top_n contributors + top_n drags surface — keeps the
-        UI list short and the operator focused on biggest movers."""
+        UI list short and the operator focused on biggest movers.
+
+        Fixture uses i=1..10 so no zero-delta row silently drops
+        (i=0 would produce pnl=0 and be omitted, giving fragile
+        "passes by accident" coverage — Codex round-2 note).
+        Even i → positive delta (+i*10); odd i → negative (-i*10).
+        Positives: [+20, +40, +60, +80, +100] — top 3 = S10, S8, S6.
+        Negatives: [-10, -30, -50, -70, -90] — top 3 = S9, S7, S5
+        (most-negative first).
+        """
         prior = [
             {
                 "instrument_id": i,
@@ -566,22 +575,21 @@ class TestComputeContributors:
                 "unrealized_pnl": "0",
                 "cost_basis": "100",
             }
-            for i in range(10)
+            for i in range(1, 11)
         ]
         current = [
             {
                 "instrument_id": i,
                 "symbol": f"S{i}",
-                # Even i: positive delta (i * 10). Odd i: negative (-i * 10).
                 "unrealized_pnl": str((i if i % 2 == 0 else -i) * 10),
                 "cost_basis": "100",
             }
-            for i in range(10)
+            for i in range(1, 11)
         ]
         result = _compute_contributors(current, prior, top_n=3)
         assert len(result["contributors"]) == 3
         assert len(result["drags"]) == 3
-        # Contributors sorted by delta descending — biggest gainer first.
-        assert result["contributors"][0]["symbol"] == "S8"
-        # Drags: most negative first after reversal.
-        assert result["drags"][0]["symbol"] == "S9"
+        # Contributors sorted descending by delta — biggest gainer first.
+        assert [r["symbol"] for r in result["contributors"]] == ["S10", "S8", "S6"]
+        # Drags sorted ascending by delta — most-negative first.
+        assert [r["symbol"] for r in result["drags"]] == ["S9", "S7", "S5"]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 
@@ -437,3 +438,150 @@ class TestJsonSerializability:
         serialized = json.dumps(report)
         assert isinstance(serialized, str)
         assert "monthly" in serialized
+
+
+# ---------------------------------------------------------------------------
+# Contributors computation (Slice 4 of per-stock research page spec)
+# ---------------------------------------------------------------------------
+
+from app.services.reporting import _compute_contributors  # noqa: E402
+
+
+class TestComputeContributors:
+    def test_no_prior_snapshot_returns_empty_lists(self) -> None:
+        """First snapshot or backfilled historical (no `positions`) must
+        degrade gracefully — empty contributors + drags, not None."""
+        current = [
+            {
+                "instrument_id": 1,
+                "symbol": "AAPL",
+                "unrealized_pnl": "100",
+                "cost_basis": "1000",
+            }
+        ]
+        result = _compute_contributors(current, None)
+        assert result == {"contributors": [], "drags": []}
+
+    def test_computes_positive_and_negative_deltas(self) -> None:
+        prior = [
+            {
+                "instrument_id": 1,
+                "symbol": "AAPL",
+                "unrealized_pnl": "50",
+                "cost_basis": "1000",
+            },
+            {
+                "instrument_id": 2,
+                "symbol": "MSFT",
+                "unrealized_pnl": "80",
+                "cost_basis": "2000",
+            },
+        ]
+        current = [
+            {
+                "instrument_id": 1,
+                "symbol": "AAPL",
+                "unrealized_pnl": "150",  # +100 gainer
+                "cost_basis": "1000",
+            },
+            {
+                "instrument_id": 2,
+                "symbol": "MSFT",
+                "unrealized_pnl": "20",  # -60 drag
+                "cost_basis": "2000",
+            },
+        ]
+        result = _compute_contributors(current, prior)
+        assert len(result["contributors"]) == 1
+        assert result["contributors"][0]["symbol"] == "AAPL"
+        assert result["contributors"][0]["pnl_delta"] == "100"
+        # pct = 100 / 1000 = 0.1
+        assert result["contributors"][0]["pnl_pct"] == "0.1"
+
+        assert len(result["drags"]) == 1
+        assert result["drags"][0]["symbol"] == "MSFT"
+        assert result["drags"][0]["pnl_delta"] == "-60"
+
+    def test_new_position_with_zero_prior_cost_gets_null_pct(self) -> None:
+        """Fresh position (not in prior snapshot) surfaces with full
+        current P&L as delta but null pct — prevents misleading '∞%'."""
+        current = [
+            {
+                "instrument_id": 99,
+                "symbol": "NEW",
+                "unrealized_pnl": "50",
+                "cost_basis": "500",
+            }
+        ]
+        prior: list[dict[str, Any]] = []
+        result = _compute_contributors(current, prior)
+        assert result["contributors"][0]["symbol"] == "NEW"
+        assert result["contributors"][0]["pnl_delta"] == "50"
+        assert result["contributors"][0]["pnl_pct"] is None
+
+    def test_unchanged_position_not_in_either_list(self) -> None:
+        """Zero delta means the position didn't contribute — omit."""
+        prior = [
+            {
+                "instrument_id": 1,
+                "symbol": "FLAT",
+                "unrealized_pnl": "42",
+                "cost_basis": "100",
+            }
+        ]
+        current = [
+            {
+                "instrument_id": 1,
+                "symbol": "FLAT",
+                "unrealized_pnl": "42",
+                "cost_basis": "100",
+            }
+        ]
+        result = _compute_contributors(current, prior)
+        assert result == {"contributors": [], "drags": []}
+
+    def test_legacy_prior_without_positions_key_degrades_to_empty(self) -> None:
+        """Pre-feature snapshots (backfilled without the `positions`
+        key) must NOT be interpreted as 'prior had zero positions' —
+        that would label every current holding as a fresh contributor.
+        Passing None signals 'no comparison possible' cleanly."""
+        current = [
+            {
+                "instrument_id": 1,
+                "symbol": "AAPL",
+                "unrealized_pnl": "100",
+                "cost_basis": "1000",
+            }
+        ]
+        result = _compute_contributors(current, None)
+        assert result == {"contributors": [], "drags": []}
+
+    def test_top_n_caps_each_list(self) -> None:
+        """Only top_n contributors + top_n drags surface — keeps the
+        UI list short and the operator focused on biggest movers."""
+        prior = [
+            {
+                "instrument_id": i,
+                "symbol": f"S{i}",
+                "unrealized_pnl": "0",
+                "cost_basis": "100",
+            }
+            for i in range(10)
+        ]
+        current = [
+            {
+                "instrument_id": i,
+                "symbol": f"S{i}",
+                # Even i: positive delta (i * 10). Odd i: negative (-i * 10).
+                "unrealized_pnl": str((i if i % 2 == 0 else -i) * 10),
+                "cost_basis": "100",
+            }
+            for i in range(10)
+        ]
+        result = _compute_contributors(current, prior, top_n=3)
+        assert len(result["contributors"]) == 3
+        assert len(result["drags"]) == 3
+        # Contributors sorted by delta descending — biggest gainer first.
+        assert result["contributors"][0]["symbol"] == "S8"
+        # Drags: most negative first after reversal.
+        assert result["drags"][0]["symbol"] == "S9"


### PR DESCRIPTION
## What
Each weekly + monthly snapshot gains `positions` (per-instrument P&L at snapshot time) and `period_contribution` (top contributors + top drags vs the prior snapshot). ReportsPage renders both lists with `/instrument/:symbol` links.

## Why
Current `report_snapshots` stored aggregate P&L only — no way to see which stocks drove the delta. Operator clicking through the Reports page lands in raw JSON with no onward navigation. Slice 4 makes Reports a gateway into per-stock research.

## Graceful degradation
- First snapshot ever: no prior → empty contributors/drags.
- Pre-feature snapshots (no `positions` key): caller passes `None` (not `[]`) so every current holding isn't wrongly labelled as a new contributor. Codex caught this in round 1.

## Test plan
- [x] 6 new unit tests on `_compute_contributors` (null prior, legacy prior, deltas, new-position null pct, zero-delta omit, top_n cap)
- [x] Existing weekly + monthly structure tests still pass
- [x] Full pytest: 2212 passed
- [x] Frontend typecheck green
- [x] Codex pre-push review 2 rounds, final clean

## Not in scope
- Chart visualisation of contributor deltas — future polish
- Admin coverage migration + delete orphans — Slice 5

Refs: [per-stock research spec §5 Slice 4](docs/superpowers/specs/2026-04-20-per-stock-research-page.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)