### PR TITLE
feat: Slice 6 — copy-trader exposure panel

### DIFF
--- a/frontend/src/components/instrument/RightRail.test.tsx
+++ b/frontend/src/components/instrument/RightRail.test.tsx
@@ -22,6 +22,7 @@ import { MemoryRouter } from "react-router-dom";
 
 import { RightRail } from "@/components/instrument/RightRail";
 import type {
+  CopyTradingResponse,
   FilingsListResponse,
   NewsListResponse,
   RankingsListResponse,
@@ -33,14 +34,17 @@ vi.mock("@/api/rankings", () => ({
   fetchRankings: vi.fn(),
   RANKINGS_PAGE_LIMIT: 200,
 }));
+vi.mock("@/api/copyTrading", () => ({ fetchCopyTrading: vi.fn() }));
 
 import { fetchFilings } from "@/api/filings";
 import { fetchNews } from "@/api/news";
 import { fetchRankings } from "@/api/rankings";
+import { fetchCopyTrading } from "@/api/copyTrading";
 
 const mockedFilings = vi.mocked(fetchFilings);
 const mockedNews = vi.mocked(fetchNews);
 const mockedRankings = vi.mocked(fetchRankings);
+const mockedCopyTrading = vi.mocked(fetchCopyTrading);
 
 function filingsEmpty(instrumentId: number): FilingsListResponse {
   return {
@@ -153,13 +157,23 @@ function rankingsWith(currentSymbol: string): RankingsListResponse {
   };
 }
 
+function copyTradingEmpty(): CopyTradingResponse {
+  return {
+    traders: [],
+    total_mirror_equity: 0,
+    display_currency: "GBP",
+  };
+}
+
 beforeEach(() => {
   mockedFilings.mockReset();
   mockedNews.mockReset();
   mockedRankings.mockReset();
+  mockedCopyTrading.mockReset();
   mockedFilings.mockResolvedValue(filingsEmpty(42));
   mockedNews.mockResolvedValue(newsEmpty(42));
   mockedRankings.mockResolvedValue(rankingsEmpty());
+  mockedCopyTrading.mockResolvedValue(copyTradingEmpty());
 });
 
 function renderRail(props: {
@@ -284,5 +298,189 @@ describe("RightRail", () => {
     const [query, limit] = mockedRankings.mock.calls[0]!;
     expect(query).toMatchObject({ sector: "Healthcare" });
     expect(limit).toBe(6);
+  });
+});
+
+describe("RightRail — copy-trader exposure (Slice 6)", () => {
+  it("hides exposure section when no copy traders hold the instrument", async () => {
+    renderRail();
+    // Wait for the copy-trading fetch to settle before asserting
+    // absence — otherwise the section's loading-skeleton would still
+    // be in the DOM and the assertion would falsely pass on a
+    // later render.
+    await waitFor(() => {
+      expect(mockedCopyTrading).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Copy-trader exposure/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("lists each mirror holding the instrument + links to /copy-trading/:mirror_id", async () => {
+    mockedCopyTrading.mockResolvedValue({
+      traders: [
+        {
+          parent_cid: 1,
+          parent_username: "@gurutrader",
+          total_equity: 10000,
+          mirrors: [
+            {
+              mirror_id: 42,
+              active: true,
+              initial_investment: 5000,
+              deposit_summary: 5000,
+              withdrawal_summary: 0,
+              available_amount: 200,
+              closed_positions_net_profit: 0,
+              mirror_equity: 5500,
+              position_count: 3,
+              positions: [
+                {
+                  position_id: 1,
+                  instrument_id: 42,
+                  symbol: "AAPL",
+                  company_name: "Apple Inc.",
+                  is_buy: true,
+                  units: 4,
+                  amount: 800,
+                  open_rate: 200,
+                  open_conversion_rate: 1.0,
+                  open_date_time: "2026-03-01T10:00:00Z",
+                  current_price: 210,
+                  market_value: 840,
+                  unrealized_pnl: 40,
+                },
+              ],
+              started_copy_date: "2026-02-01",
+              closed_at: null,
+            },
+          ],
+        },
+      ],
+      total_mirror_equity: 5500,
+      display_currency: "GBP",
+    });
+    renderRail({ instrumentId: 42 });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Copy-trader exposure/i)).toBeInTheDocument();
+    });
+    const link = screen.getByText("@gurutrader").closest("a") as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/copy-trading/42");
+  });
+
+  it("filters mirrors that don't hold the current instrument", async () => {
+    mockedCopyTrading.mockResolvedValue({
+      traders: [
+        {
+          parent_cid: 1,
+          parent_username: "@other",
+          total_equity: 1000,
+          mirrors: [
+            {
+              mirror_id: 99,
+              active: true,
+              initial_investment: 500,
+              deposit_summary: 500,
+              withdrawal_summary: 0,
+              available_amount: 0,
+              closed_positions_net_profit: 0,
+              mirror_equity: 500,
+              position_count: 1,
+              positions: [
+                {
+                  position_id: 7,
+                  instrument_id: 999, // different instrument
+                  symbol: "TSLA",
+                  company_name: "Tesla",
+                  is_buy: true,
+                  units: 1,
+                  amount: 100,
+                  open_rate: 100,
+                  open_conversion_rate: 1.0,
+                  open_date_time: "2026-03-01T10:00:00Z",
+                  current_price: 100,
+                  market_value: 100,
+                  unrealized_pnl: 0,
+                },
+              ],
+              started_copy_date: "2026-02-01",
+              closed_at: null,
+            },
+          ],
+        },
+      ],
+      total_mirror_equity: 500,
+      display_currency: "GBP",
+    });
+    renderRail({ instrumentId: 42 });
+
+    await waitFor(() => {
+      expect(mockedCopyTrading).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      // @other holds TSLA, not AAPL — exposure section stays hidden.
+      expect(
+        screen.queryByText(/Copy-trader exposure/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("ignores closed mirrors even when they retain the position", async () => {
+    mockedCopyTrading.mockResolvedValue({
+      traders: [
+        {
+          parent_cid: 1,
+          parent_username: "@closedone",
+          total_equity: 0,
+          mirrors: [
+            {
+              mirror_id: 77,
+              active: false, // closed — must not contribute
+              initial_investment: 500,
+              deposit_summary: 500,
+              withdrawal_summary: 500,
+              available_amount: 0,
+              closed_positions_net_profit: 0,
+              mirror_equity: 0,
+              position_count: 1,
+              positions: [
+                {
+                  position_id: 42,
+                  instrument_id: 42,
+                  symbol: "AAPL",
+                  company_name: "Apple",
+                  is_buy: true,
+                  units: 1,
+                  amount: 200,
+                  open_rate: 200,
+                  open_conversion_rate: 1.0,
+                  open_date_time: "2026-01-01T10:00:00Z",
+                  current_price: 210,
+                  market_value: 210,
+                  unrealized_pnl: 10,
+                },
+              ],
+              started_copy_date: "2025-11-01",
+              closed_at: "2026-02-01",
+            },
+          ],
+        },
+      ],
+      total_mirror_equity: 0,
+      display_currency: "GBP",
+    });
+    renderRail({ instrumentId: 42 });
+
+    await waitFor(() => {
+      expect(mockedCopyTrading).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Copy-trader exposure/i),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/instrument/RightRail.tsx
+++ b/frontend/src/components/instrument/RightRail.tsx
@@ -268,13 +268,16 @@ function CopyExposure({ instrumentId }: { instrumentId: number }) {
     () => fetchCopyTrading(),
     [],
   );
-  // Hide the section entirely on loading/error/no-exposure so the rail
-  // doesn't nag about empty state when no copy traders hold the
-  // instrument. The mirrors endpoint is already exercised on
-  // /copy-trading surfaces; we opt for silent-when-empty here.
+  // Silent-when-empty: if no active copy-trader holds the
+  // instrument we render nothing so the rail isn't padded with an
+  // empty state on the common case (operator with no mirrors, or
+  // mirrors holding other stocks).
+  //
+  // Loading + error DO render so the operator (a) sees the fetch is
+  // in flight rather than a silent gap, and (b) can retry on a
+  // transient failure. The "hidden" condition is specifically the
+  // resolved-empty path below.
   if (loading) {
-    // Still render a skeleton on cold start so a slow fetch isn't a
-    // jarring content-shift when it resolves.
     return (
       <Section title="Copy-trader exposure">
         <SectionSkeleton rows={1} />

--- a/frontend/src/components/instrument/RightRail.tsx
+++ b/frontend/src/components/instrument/RightRail.tsx
@@ -1,23 +1,25 @@
 /**
- * RightRail — peripheral-vision column of the per-stock research page
- * (Slice 2 of docs/superpowers/specs/2026-04-20-per-stock-research-page.md).
+ * RightRail — peripheral-vision column of the per-stock research page.
+ * Slices 2 + 6 of docs/superpowers/specs/2026-04-20-per-stock-research-page.md.
  *
- * Three stacked sections, always visible regardless of which tab the
- * operator is on:
+ * Sections (independent fetches; one failure does not blank others):
  *   1. Recent filings (last 3) — link out to filings tab + documents
  *   2. Peer snapshot (top 5 ranked within same sector) — clickable
  *      rows drill into each peer's research page
- *   3. Recent news (last 3) — headline + sentiment badge
- *
- * Each section fetches independently so one failing endpoint does not
- * blank the others (per `frontend/async-data-loading.md`).
+ *   3. Copy-trader exposure (Slice 6) — parent traders the operator
+ *      mirrors who hold this instrument. Hidden when there's no
+ *      exposure. Placeholder scaffold; deeper design deferred to a
+ *      follow-up spec if scope grows.
+ *   4. Recent news (last 3) — headline + sentiment badge
  */
 import { Link } from "react-router-dom";
 
+import { fetchCopyTrading } from "@/api/copyTrading";
 import { fetchFilings } from "@/api/filings";
 import { fetchNews } from "@/api/news";
 import { fetchRankings } from "@/api/rankings";
 import type {
+  CopyTraderSummary,
   FilingItem,
   NewsItem,
   RankingItem,
@@ -49,6 +51,7 @@ export function RightRail({
         sector={sector}
         currentSymbol={currentSymbol}
       />
+      <CopyExposure instrumentId={instrumentId} />
       <RecentNews instrumentId={instrumentId} />
     </aside>
   );
@@ -217,6 +220,102 @@ function sentimentTone(score: number | null): string {
   if (score >= 0.3) return "bg-emerald-50 text-emerald-700";
   if (score <= -0.3) return "bg-red-50 text-red-700";
   return "bg-slate-100 text-slate-600";
+}
+
+// ---------------------------------------------------------------------------
+// Copy-trader exposure (Slice 6)
+// ---------------------------------------------------------------------------
+
+interface MirrorHolding {
+  mirrorId: number;
+  parentUsername: string;
+  units: number;
+  marketValue: number;
+}
+
+/** Aggregate `CopyTradingResponse` into one row per mirror holding
+ *  the instrument. Filters on `active === true` so closed mirrors
+ *  (which can retain historical positions in the response) don't
+ *  surface stale exposure. If a parent-trader has multiple active
+ *  mirrors both holding it, each mirror surfaces as its own row —
+ *  the operator cares about mirror-level actions (pause / stop),
+ *  not parent-level aggregation. */
+function extractHoldings(
+  traders: CopyTraderSummary[],
+  instrumentId: number,
+): MirrorHolding[] {
+  const out: MirrorHolding[] = [];
+  for (const trader of traders) {
+    for (const mirror of trader.mirrors) {
+      if (!mirror.active) continue;
+      const match = mirror.positions.filter(
+        (p) => p.instrument_id === instrumentId,
+      );
+      if (match.length === 0) continue;
+      out.push({
+        mirrorId: mirror.mirror_id,
+        parentUsername: trader.parent_username,
+        units: match.reduce((s, p) => s + p.units, 0),
+        marketValue: match.reduce((s, p) => s + p.market_value, 0),
+      });
+    }
+  }
+  return out;
+}
+
+function CopyExposure({ instrumentId }: { instrumentId: number }) {
+  const { data, error, loading, refetch } = useAsync(
+    () => fetchCopyTrading(),
+    [],
+  );
+  // Hide the section entirely on loading/error/no-exposure so the rail
+  // doesn't nag about empty state when no copy traders hold the
+  // instrument. The mirrors endpoint is already exercised on
+  // /copy-trading surfaces; we opt for silent-when-empty here.
+  if (loading) {
+    // Still render a skeleton on cold start so a slow fetch isn't a
+    // jarring content-shift when it resolves.
+    return (
+      <Section title="Copy-trader exposure">
+        <SectionSkeleton rows={1} />
+      </Section>
+    );
+  }
+  if (error !== null) {
+    return (
+      <Section title="Copy-trader exposure">
+        <SectionError onRetry={refetch} />
+      </Section>
+    );
+  }
+  const holdings = data ? extractHoldings(data.traders, instrumentId) : [];
+  if (holdings.length === 0) return null;
+
+  return (
+    <Section title={`Copy-trader exposure · ${holdings.length}`}>
+      <ul className="space-y-1.5 text-xs">
+        {holdings.map((h) => (
+          <li
+            key={h.mirrorId}
+            className="flex items-baseline justify-between gap-2"
+          >
+            <Link
+              to={`/copy-trading/${h.mirrorId}`}
+              className="truncate font-medium text-blue-700 hover:underline"
+            >
+              {h.parentUsername}
+            </Link>
+            <span className="shrink-0 tabular-nums text-slate-500">
+              {h.units.toLocaleString(undefined, {
+                maximumFractionDigits: 2,
+              })}
+              u
+            </span>
+          </li>
+        ))}
+      </ul>
+    </Section>
+  );
 }
 
 function NewsRow({ n }: { n: NewsItem }) {


### PR DESCRIPTION
## What
Final slice of per-stock research spec. Adds `CopyExposure` section to `RightRail` showing which active copy-trader mirrors hold the current instrument.

## Scope
- Reuses existing `/portfolio/copy-trading` endpoint — no backend change.
- Filters: `mirror.active === true` + `instrument_id` match.
- Hidden when no exposure (silent when empty).
- Each row → `/copy-trading/:mirror_id` for pause/stop actions.

## Test plan
- [x] 4 new cases: hidden-when-empty, lists mirrors, filters other instruments, ignores closed mirrors
- [x] 10/10 RightRail tests pass
- [x] 289 frontend tests pass
- [x] typecheck green
- [x] Codex reviewed; all findings addressed in same commit

Closes out spec §5 Slice 6 — full per-stock research page consolidation now shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)