### PR TITLE
feat(#316): Slice A — /instruments/:symbol/candles endpoint

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -581,23 +581,31 @@ def get_instrument_candles(
         raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
 
     days = _CANDLE_RANGE_DAYS[range_]
-    params: dict[str, object] = {"iid": inst_row["instrument_id"]}
-    if days is None:
-        where = "WHERE instrument_id = %(iid)s"
-    else:
-        where = "WHERE instrument_id = %(iid)s AND price_date >= CURRENT_DATE - make_interval(days => %(days)s)"
-        params["days"] = days
-
+    # Two fixed queries rather than f-string-composing a WHERE clause,
+    # so there's no structural-injection footgun if the range-token
+    # set grows later. `max` omits the date filter entirely.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            f"""
-            SELECT price_date, open, high, low, close, volume
-            FROM price_daily
-            {where}
-            ORDER BY price_date ASC
-            """,
-            params,
-        )
+        if days is None:
+            cur.execute(
+                """
+                SELECT price_date, open, high, low, close, volume
+                FROM price_daily
+                WHERE instrument_id = %(iid)s
+                ORDER BY price_date ASC
+                """,
+                {"iid": inst_row["instrument_id"]},
+            )
+        else:
+            cur.execute(
+                """
+                SELECT price_date, open, high, low, close, volume
+                FROM price_daily
+                WHERE instrument_id = %(iid)s
+                  AND price_date >= CURRENT_DATE - make_interval(days => %(days)s)
+                ORDER BY price_date ASC
+                """,
+                {"iid": inst_row["instrument_id"], "days": days},
+            )
         rows = cur.fetchall()
 
     bars = [

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -19,7 +19,7 @@ from typing import Literal
 import psycopg
 import psycopg.rows
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.db import get_conn
 from app.providers.implementations.yfinance_provider import YFinanceKeyStats, YFinanceProvider
@@ -142,6 +142,30 @@ class InstrumentFinancials(BaseModel):
     currency: str | None
     source: str  # "financial_periods" (local SEC XBRL) | "yfinance"
     rows: list[InstrumentFinancialRow]
+
+
+class CandleBar(BaseModel):
+    """One daily OHLCV bar — the minimal shape a chart library needs."""
+
+    date: date
+    open: Decimal | None
+    high: Decimal | None
+    low: Decimal | None
+    close: Decimal | None
+    volume: Decimal | None
+
+
+class InstrumentCandles(BaseModel):
+    # Allow `range` as the wire name without shadowing the Python
+    # builtin at the attribute level.
+    model_config = ConfigDict(populate_by_name=True)
+
+    symbol: str
+    # Range token the caller asked for; echoed so the client can cache
+    # by range key. `days` is the resolved lookback the server applied.
+    range_: Literal["1w", "1m", "3m", "6m", "1y", "5y", "max"] = Field(..., alias="range", serialization_alias="range")
+    days: int | None  # None when range="max"
+    rows: list[CandleBar]
 
 
 class InstrumentSummary(BaseModel):
@@ -502,6 +526,96 @@ def get_instrument_financials(
         currency=y_fin.currency,
         source="yfinance",
         rows=yf_rows,
+    )
+
+
+_CANDLE_RANGE_DAYS: dict[str, int | None] = {
+    "1w": 7,
+    "1m": 30,
+    "3m": 90,
+    "6m": 180,
+    "1y": 365,
+    "5y": 365 * 5,
+    "max": None,
+}
+
+
+@router.get("/{symbol}/candles", response_model=InstrumentCandles)
+def get_instrument_candles(
+    symbol: str,
+    range_: Literal["1w", "1m", "3m", "6m", "1y", "5y", "max"] = Query(default="1m", alias="range"),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> InstrumentCandles:
+    """Daily OHLCV bars for `symbol` over the requested lookback.
+
+    Reads from `price_daily` (populated by the market-data refresh
+    job). No provider fallback here — if we don't have local bars,
+    return an empty row list and let the chart render an empty state.
+    A 404 is reserved for an unknown symbol.
+
+    Range resolution is the server's responsibility: the caller passes
+    a range token (`1m`, `1y`, ...) and the server maps it to a day
+    lookback. `max` returns every stored bar.
+
+    Bars are returned oldest-first so chart libraries can feed the
+    array directly without re-sorting.
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    # Symbol → instrument_id (primary-listing tiebreaker, see #357).
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    days = _CANDLE_RANGE_DAYS[range_]
+    params: dict[str, object] = {"iid": inst_row["instrument_id"]}
+    if days is None:
+        where = "WHERE instrument_id = %(iid)s"
+    else:
+        where = "WHERE instrument_id = %(iid)s AND price_date >= CURRENT_DATE - make_interval(days => %(days)s)"
+        params["days"] = days
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            f"""
+            SELECT price_date, open, high, low, close, volume
+            FROM price_daily
+            {where}
+            ORDER BY price_date ASC
+            """,
+            params,
+        )
+        rows = cur.fetchall()
+
+    bars = [
+        CandleBar(
+            date=r["price_date"],  # type: ignore[arg-type]
+            open=r["open"],  # type: ignore[arg-type]
+            high=r["high"],  # type: ignore[arg-type]
+            low=r["low"],  # type: ignore[arg-type]
+            close=r["close"],  # type: ignore[arg-type]
+            volume=r["volume"],  # type: ignore[arg-type]
+        )
+        for r in rows
+    ]
+    return InstrumentCandles(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        range_=range_,
+        days=days,
+        rows=bars,
     )
 
 

--- a/tests/test_api_instrument_candles.py
+++ b/tests/test_api_instrument_candles.py
@@ -17,28 +17,49 @@ def client() -> TestClient:
     return TestClient(app)
 
 
-def _make_cursor_sequence(fetchone_per_cursor: list[list[object]]) -> MagicMock:
-    """Per-cursor fetchone isolation: each `cursor(...)` call gets its
-    own mock with its own `fetchone`/`fetchall` queue.
+class FetchOne:
+    """Cursor fixture: returns `row` from `fetchone`. `fetchall` returns []."""
+
+    __slots__ = ("row",)
+
+    def __init__(self, row: object) -> None:
+        self.row = row
+
+
+class FetchAll:
+    """Cursor fixture: returns `rows` from `fetchall`. `fetchone` returns None."""
+
+    __slots__ = ("rows",)
+
+    def __init__(self, rows: list[object]) -> None:
+        self.rows = rows
+
+
+def _make_cursor_sequence(
+    per_cursor: list[FetchOne | FetchAll],
+) -> MagicMock:
+    """Per-cursor isolation: each `cursor(...)` call returns a fresh
+    mock whose `fetchone`/`fetchall` behaviour is determined by an
+    explicit FetchOne / FetchAll tag (avoids the len-based heuristic
+    that the Codex slice-A round-2 review flagged as fragile).
 
     The candles endpoint opens two cursors:
-      1. Symbol → instrument_id lookup (`fetchone`).
-      2. Candle fetch (`fetchall`).
+      1. Symbol → instrument_id lookup (FetchOne).
+      2. Candle row fetch (FetchAll).
     """
-    cursors = iter(fetchone_per_cursor)
+    cursors = iter(per_cursor)
 
     def _next_cursor(*_args: object, **_kwargs: object) -> MagicMock:
         cur = MagicMock()
         cur.__enter__.return_value = cur
         cur.__exit__.return_value = None
-        results = next(cursors)
-        if len(results) == 1:
-            cur.fetchone.return_value = results[0]
+        spec = next(cursors)
+        if isinstance(spec, FetchOne):
+            cur.fetchone.return_value = spec.row
             cur.fetchall.return_value = []
         else:
-            # First entry = fetchone; rest = fetchall rows.
-            cur.fetchone.return_value = results[0]
-            cur.fetchall.return_value = list(results[1:])
+            cur.fetchone.return_value = None
+            cur.fetchall.return_value = list(spec.rows)
         return cur
 
     conn = MagicMock()
@@ -51,7 +72,7 @@ def test_candles_unknown_symbol_returns_404(client: TestClient) -> None:
     from app.db import get_conn
 
     def _db_conn() -> Iterator[MagicMock]:
-        yield _make_cursor_sequence([[None]])
+        yield _make_cursor_sequence([FetchOne(None)])
 
     app.dependency_overrides[get_conn] = _db_conn
     try:
@@ -83,28 +104,27 @@ def test_candles_happy_path_returns_ohlcv_rows(client: TestClient) -> None:
     def _db_conn() -> Iterator[MagicMock]:
         yield _make_cursor_sequence(
             [
-                # Cursor 1: instrument lookup.
-                [{"instrument_id": 42, "symbol": "AAPL"}],
-                # Cursor 2: fetchone (unused on fetchall path) + rows.
-                [
-                    None,
-                    {
-                        "price_date": date(2026, 4, 10),
-                        "open": Decimal("180.00"),
-                        "high": Decimal("182.50"),
-                        "low": Decimal("179.80"),
-                        "close": Decimal("181.25"),
-                        "volume": Decimal("1000000"),
-                    },
-                    {
-                        "price_date": date(2026, 4, 11),
-                        "open": Decimal("181.25"),
-                        "high": Decimal("183.00"),
-                        "low": Decimal("180.75"),
-                        "close": Decimal("182.60"),
-                        "volume": Decimal("950000"),
-                    },
-                ],
+                FetchOne({"instrument_id": 42, "symbol": "AAPL"}),
+                FetchAll(
+                    [
+                        {
+                            "price_date": date(2026, 4, 10),
+                            "open": Decimal("180.00"),
+                            "high": Decimal("182.50"),
+                            "low": Decimal("179.80"),
+                            "close": Decimal("181.25"),
+                            "volume": Decimal("1000000"),
+                        },
+                        {
+                            "price_date": date(2026, 4, 11),
+                            "open": Decimal("181.25"),
+                            "high": Decimal("183.00"),
+                            "low": Decimal("180.75"),
+                            "close": Decimal("182.60"),
+                            "volume": Decimal("950000"),
+                        },
+                    ]
+                ),
             ]
         )
 
@@ -132,8 +152,8 @@ def test_candles_max_range_has_null_days(client: TestClient) -> None:
     def _db_conn() -> Iterator[MagicMock]:
         yield _make_cursor_sequence(
             [
-                [{"instrument_id": 42, "symbol": "AAPL"}],
-                [None],  # No candle rows for this edge case.
+                FetchOne({"instrument_id": 42, "symbol": "AAPL"}),
+                FetchAll([]),
             ]
         )
 
@@ -172,8 +192,8 @@ def test_candles_default_range_is_1m(client: TestClient) -> None:
     def _db_conn() -> Iterator[MagicMock]:
         yield _make_cursor_sequence(
             [
-                [{"instrument_id": 42, "symbol": "AAPL"}],
-                [None],
+                FetchOne({"instrument_id": 42, "symbol": "AAPL"}),
+                FetchAll([]),
             ]
         )
 

--- a/tests/test_api_instrument_candles.py
+++ b/tests/test_api_instrument_candles.py
@@ -1,0 +1,188 @@
+"""Tests for GET /instruments/{symbol}/candles (Slice A of #316)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _make_cursor_sequence(fetchone_per_cursor: list[list[object]]) -> MagicMock:
+    """Per-cursor fetchone isolation: each `cursor(...)` call gets its
+    own mock with its own `fetchone`/`fetchall` queue.
+
+    The candles endpoint opens two cursors:
+      1. Symbol → instrument_id lookup (`fetchone`).
+      2. Candle fetch (`fetchall`).
+    """
+    cursors = iter(fetchone_per_cursor)
+
+    def _next_cursor(*_args: object, **_kwargs: object) -> MagicMock:
+        cur = MagicMock()
+        cur.__enter__.return_value = cur
+        cur.__exit__.return_value = None
+        results = next(cursors)
+        if len(results) == 1:
+            cur.fetchone.return_value = results[0]
+            cur.fetchall.return_value = []
+        else:
+            # First entry = fetchone; rest = fetchall rows.
+            cur.fetchone.return_value = results[0]
+            cur.fetchall.return_value = list(results[1:])
+        return cur
+
+    conn = MagicMock()
+    conn.cursor.side_effect = _next_cursor
+    return conn
+
+
+def test_candles_unknown_symbol_returns_404(client: TestClient) -> None:
+    """No instrument row → 404 before the price_daily fetch ever runs."""
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield _make_cursor_sequence([[None]])
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/NOTREAL/candles?range=1m")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+    assert resp.status_code == 404
+
+
+def test_candles_empty_symbol_returns_400(client: TestClient) -> None:
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield MagicMock()
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/%20%20/candles?range=1m")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+    assert resp.status_code == 400
+
+
+def test_candles_happy_path_returns_ohlcv_rows(client: TestClient) -> None:
+    from datetime import date
+
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield _make_cursor_sequence(
+            [
+                # Cursor 1: instrument lookup.
+                [{"instrument_id": 42, "symbol": "AAPL"}],
+                # Cursor 2: fetchone (unused on fetchall path) + rows.
+                [
+                    None,
+                    {
+                        "price_date": date(2026, 4, 10),
+                        "open": Decimal("180.00"),
+                        "high": Decimal("182.50"),
+                        "low": Decimal("179.80"),
+                        "close": Decimal("181.25"),
+                        "volume": Decimal("1000000"),
+                    },
+                    {
+                        "price_date": date(2026, 4, 11),
+                        "open": Decimal("181.25"),
+                        "high": Decimal("183.00"),
+                        "low": Decimal("180.75"),
+                        "close": Decimal("182.60"),
+                        "volume": Decimal("950000"),
+                    },
+                ],
+            ]
+        )
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/AAPL/candles?range=1m")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["symbol"] == "AAPL"
+    assert body["range"] == "1m"
+    assert body["days"] == 30
+    assert len(body["rows"]) == 2
+    # Rows are returned in date-ascending order.
+    assert body["rows"][0]["date"] == "2026-04-10"
+    assert body["rows"][1]["date"] == "2026-04-11"
+    assert body["rows"][0]["close"] == "181.25"
+
+
+def test_candles_max_range_has_null_days(client: TestClient) -> None:
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield _make_cursor_sequence(
+            [
+                [{"instrument_id": 42, "symbol": "AAPL"}],
+                [None],  # No candle rows for this edge case.
+            ]
+        )
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/AAPL/candles?range=max")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["range"] == "max"
+    assert body["days"] is None
+    assert body["rows"] == []
+
+
+def test_candles_invalid_range_token_returns_422(client: TestClient) -> None:
+    """FastAPI's Literal validation rejects unrecognised range tokens —
+    ensures callers can't silently request a wrong lookback."""
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield MagicMock()
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/AAPL/candles?range=banana")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+    assert resp.status_code == 422
+
+
+def test_candles_default_range_is_1m(client: TestClient) -> None:
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield _make_cursor_sequence(
+            [
+                [{"instrument_id": 42, "symbol": "AAPL"}],
+                [None],
+            ]
+        )
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/AAPL/candles")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["range"] == "1m"
+    assert resp.json()["days"] == 30


### PR DESCRIPTION
## What
New endpoint serving OHLCV bars from `price_daily`. Shape:
```json
{
  "symbol": "AAPL",
  "range": "1m",
  "days": 30,
  "rows": [{"date": "2026-04-10", "open": "180.00", "high": "182.50", "low": "179.80", "close": "181.25", "volume": "1000000"}]
}
```

Range tokens: `1w` / `1m` / `3m` / `6m` / `1y` / `5y` / `max`. Server resolves to a day lookback (`days: null` for `max`).

## Why
Kick off #316 (Instrument terminal). Most of that issue's scope shipped via the per-stock research page; the missing piece is the chart. Slice A = backend; Slice B = frontend `PriceChart` component + Chart tab.

## Scope
- Primary-listing tiebreaker on symbol → instrument_id lookup (consistent with Slice 0 of the research spec).
- No provider fallback: empty `price_daily` → `rows: []`, not 500. 404 reserved for unknown symbol.
- Bars oldest-first so chart libs can consume directly.

## Test plan
- [x] 6 tests: unknown symbol → 404, empty symbol → 400, happy path, `range=max` → `days: null`, invalid range → 422, default range = `1m`
- [x] ruff / format clean
- [x] Codex pre-push review clean

Refs #316 (Instrument terminal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)