### PR TITLE
feat(#316): Slice B — PriceChart + Research tab integration

### DIFF
--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -1,5 +1,7 @@
 import { apiFetch } from "@/api/client";
 import type {
+  CandleRange,
+  InstrumentCandles,
   InstrumentDetail,
   InstrumentFinancials,
   InstrumentListResponse,
@@ -61,5 +63,15 @@ export function fetchInstrumentFinancials(
   });
   return apiFetch<InstrumentFinancials>(
     `/instruments/${encodeURIComponent(symbol)}/financials?${params.toString()}`,
+  );
+}
+
+export function fetchInstrumentCandles(
+  symbol: string,
+  range: CandleRange,
+): Promise<InstrumentCandles> {
+  const params = new URLSearchParams({ range });
+  return apiFetch<InstrumentCandles>(
+    `/instruments/${encodeURIComponent(symbol)}/candles?${params.toString()}`,
   );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -250,6 +250,33 @@ export interface InstrumentSummary {
   source: Record<string, string>;
 }
 
+// #316 Slice A — daily OHLCV bars
+export type CandleRange =
+  | "1w"
+  | "1m"
+  | "3m"
+  | "6m"
+  | "1y"
+  | "5y"
+  | "max";
+
+export interface CandleBar {
+  date: string;
+  open: string | null;
+  high: string | null;
+  low: string | null;
+  close: string | null;
+  volume: string | null;
+}
+
+export interface InstrumentCandles {
+  symbol: string;
+  range: CandleRange;
+  /** Resolved lookback in days; null when range="max". */
+  days: number | null;
+  rows: CandleBar[];
+}
+
 // Phase 2.3 — financials
 export interface InstrumentFinancialRow {
   period_end: string;

--- a/frontend/src/components/instrument/PriceChart.test.tsx
+++ b/frontend/src/components/instrument/PriceChart.test.tsx
@@ -122,15 +122,17 @@ describe("PriceChart — data states", () => {
     expect(screen.queryByText(/No price data/i)).not.toBeInTheDocument();
   });
 
-  it("propagates fetch errors via SectionError", async () => {
+  it("propagates fetch errors via SectionError + shows a retry button", async () => {
     mockedFetch.mockRejectedValue(new Error("network down"));
     render(<MemoryRouter><PriceChart symbol="AAPL" /></MemoryRouter>);
     await waitFor(() => {
-      // SectionError renders "Failed to load" by convention elsewhere
-      // in the codebase; we just check the chart didn't render.
+      // Retry button is the operator's recovery affordance; presence
+      // guards against a future refactor silently swallowing the
+      // error (Codex slice-B round-2 test-hygiene finding).
       expect(
-        screen.queryByTestId("price-chart-AAPL"),
-      ).not.toBeInTheDocument();
+        screen.getByRole("button", { name: /retry/i }),
+      ).toBeInTheDocument();
     });
+    expect(screen.queryByTestId("price-chart-AAPL")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/instrument/PriceChart.test.tsx
+++ b/frontend/src/components/instrument/PriceChart.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Tests for PriceChart (Slice B of #316).
+ *
+ * Pin the contract that matters for operators:
+ *   - All 7 range buttons render + switching triggers a re-fetch.
+ *   - Empty data → "No price data" empty state, no SVG.
+ *   - One bar is not enough to draw a line (need ≥2) — same empty state.
+ *   - SVG renders when data is ≥2 rows.
+ *   - Loading / error states.
+ *
+ * The visual geometry (path d="..." exact values) is intentionally
+ * NOT asserted — those are render-details that churn freely. We
+ * check structural presence (price path element, volume bars) only.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+import { PriceChart } from "@/components/instrument/PriceChart";
+import type { InstrumentCandles } from "@/api/types";
+
+vi.mock("@/api/instruments", () => ({
+  fetchInstrumentCandles: vi.fn(),
+}));
+
+import { fetchInstrumentCandles } from "@/api/instruments";
+
+const mockedFetch = vi.mocked(fetchInstrumentCandles);
+
+function candles(rows: InstrumentCandles["rows"]): InstrumentCandles {
+  return {
+    symbol: "AAPL",
+    range: "1m",
+    days: 30,
+    rows,
+  };
+}
+
+beforeEach(() => {
+  mockedFetch.mockReset();
+});
+
+describe("PriceChart — range picker", () => {
+  it("renders all seven range buttons", async () => {
+    mockedFetch.mockResolvedValue(candles([]));
+    render(<MemoryRouter><PriceChart symbol="AAPL" /></MemoryRouter>);
+    for (const r of ["1w", "1m", "3m", "6m", "1y", "5y", "max"]) {
+      expect(screen.getByTestId(`chart-range-${r}`)).toBeInTheDocument();
+    }
+  });
+
+  it("clicking a range button refetches with the new range", async () => {
+    mockedFetch.mockResolvedValue(candles([]));
+    const user = userEvent.setup();
+    render(<MemoryRouter><PriceChart symbol="AAPL" /></MemoryRouter>);
+
+    await waitFor(() => {
+      expect(mockedFetch).toHaveBeenCalledWith("AAPL", "1m");
+    });
+    await user.click(screen.getByTestId("chart-range-1y"));
+    await waitFor(() => {
+      expect(mockedFetch).toHaveBeenLastCalledWith("AAPL", "1y");
+    });
+  });
+});
+
+describe("PriceChart — data states", () => {
+  it("renders 'No price data' when rows is empty", async () => {
+    mockedFetch.mockResolvedValue(candles([]));
+    render(<MemoryRouter><PriceChart symbol="AAPL" /></MemoryRouter>);
+    await waitFor(() => {
+      expect(screen.getByText(/No price data/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("price-chart-AAPL")).not.toBeInTheDocument();
+  });
+
+  it("renders empty state when only one valid close (can't draw a line)", async () => {
+    mockedFetch.mockResolvedValue(
+      candles([
+        {
+          date: "2026-04-10",
+          open: "100",
+          high: "102",
+          low: "99",
+          close: "101",
+          volume: "1000",
+        },
+      ]),
+    );
+    render(<MemoryRouter><PriceChart symbol="AAPL" /></MemoryRouter>);
+    await waitFor(() => {
+      expect(screen.getByText(/No price data/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders the SVG chart when there are ≥2 rows with close", async () => {
+    mockedFetch.mockResolvedValue(
+      candles([
+        {
+          date: "2026-04-10",
+          open: "100",
+          high: "102",
+          low: "99",
+          close: "101",
+          volume: "1000",
+        },
+        {
+          date: "2026-04-11",
+          open: "101",
+          high: "104",
+          low: "100",
+          close: "103",
+          volume: "1500",
+        },
+      ]),
+    );
+    render(<MemoryRouter><PriceChart symbol="AAPL" /></MemoryRouter>);
+    await waitFor(() => {
+      expect(screen.getByTestId("price-chart-AAPL")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/No price data/i)).not.toBeInTheDocument();
+  });
+
+  it("propagates fetch errors via SectionError", async () => {
+    mockedFetch.mockRejectedValue(new Error("network down"));
+    render(<MemoryRouter><PriceChart symbol="AAPL" /></MemoryRouter>);
+    await waitFor(() => {
+      // SectionError renders "Failed to load" by convention elsewhere
+      // in the codebase; we just check the chart didn't render.
+      expect(
+        screen.queryByTestId("price-chart-AAPL"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/instrument/PriceChart.test.tsx
+++ b/frontend/src/components/instrument/PriceChart.test.tsx
@@ -122,6 +122,43 @@ describe("PriceChart — data states", () => {
     expect(screen.queryByText(/No price data/i)).not.toBeInTheDocument();
   });
 
+  it("hides the stale chart while a new-range fetch is in flight", async () => {
+    // Resolve returns a response whose `range !== requested range` —
+    // simulates the one-frame window after a range click but before
+    // useAsync's effect clears data. Chart must NOT render because
+    // `data.range` no longer matches the component's `range`.
+    mockedFetch.mockResolvedValue({
+      ...candles([
+        {
+          date: "2026-04-10",
+          open: "100",
+          high: "102",
+          low: "99",
+          close: "101",
+          volume: "1000",
+        },
+        {
+          date: "2026-04-11",
+          open: "101",
+          high: "104",
+          low: "100",
+          close: "103",
+          volume: "1500",
+        },
+      ]),
+      range: "5y", // mismatch: component defaults to 1m
+      days: 1825,
+    });
+    render(<MemoryRouter><PriceChart symbol="AAPL" /></MemoryRouter>);
+    await waitFor(() => {
+      expect(mockedFetch).toHaveBeenCalled();
+    });
+    // Data arrived for a different range; chart stays hidden because
+    // data.range !== component range. Skeleton remains visible.
+    expect(screen.queryByTestId("price-chart-AAPL")).not.toBeInTheDocument();
+    expect(screen.queryByText(/No price data/i)).not.toBeInTheDocument();
+  });
+
   it("propagates fetch errors via SectionError + shows a retry button", async () => {
     mockedFetch.mockRejectedValue(new Error("network down"));
     render(<MemoryRouter><PriceChart symbol="AAPL" /></MemoryRouter>);

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -184,9 +184,17 @@ export function PriceChart({
     [symbol, range],
   );
 
+  // Between a range click and useAsync's effect firing, React renders
+  // one frame with `loading=false` and the prior range's `data` still
+  // in state. Gate chart rendering on `data.range === range` so the
+  // old chart doesn't flash under the new range label (Codex slice-B
+  // round-2 finding).
+  const dataMatchesRange = data?.range === range;
+  const effectivelyLoading = loading || !dataMatchesRange;
+
   const geom = useMemo<ChartGeometry | null>(
-    () => (data ? geometry(data.rows) : null),
-    [data],
+    () => (dataMatchesRange && data ? geometry(data.rows) : null),
+    [data, dataMatchesRange],
   );
 
   return (
@@ -223,16 +231,22 @@ export function PriceChart({
         ) : null}
       </div>
 
-      {loading ? <SectionSkeleton rows={6} /> : null}
+      {effectivelyLoading && error === null ? (
+        <SectionSkeleton rows={6} />
+      ) : null}
       {error !== null ? <SectionError onRetry={refetch} /> : null}
-      {!loading && error === null && geom === null ? (
+      {/* Empty state fires ONLY when a fetch for the current range has
+          settled with zero valid rows. `dataMatchesRange` ensures we
+          don't mis-label "no data yet" as "no data at all" during a
+          range-switch transition. */}
+      {!effectivelyLoading && error === null && dataMatchesRange && geom === null ? (
         <EmptyState
           title="No price data"
           description="No candles in the local price_daily store for this range. Widen the range or wait for the next market-data refresh."
         />
       ) : null}
 
-      {geom !== null ? (
+      {geom !== null && dataMatchesRange ? (
         <ChartSvg
           geom={geom}
           onHover={setHoverIdx}

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -1,0 +1,354 @@
+/**
+ * PriceChart — hand-rolled SVG line chart of daily close + volume bars
+ * (Slice B of #316 Instrument terminal).
+ *
+ * Scope trade-off: a real candlestick chart needs a library
+ * (lightweight-charts, recharts) — we deliberately ship zero-deps
+ * here per CLAUDE.md "Do not add libraries casually". Close price is
+ * the single most operator-relevant number for long-horizon
+ * investment decisions; OHLC / volume detail can be a follow-up if
+ * an operator flow actually needs them.
+ *
+ * Layout:
+ *   ┌────────────────────────────────────────┐
+ *   │  price line + hover tooltip            │ 70%
+ *   │                                        │
+ *   ├────────────────────────────────────────┤
+ *   │  volume bars                           │ 30%
+ *   └────────────────────────────────────────┘
+ *
+ * Range picker sits above the chart — 1w · 1m · 3m · 6m · 1y · 5y · max.
+ * Selection is URL-synced via `?chart=<range>` so the operator's last
+ * selection survives tab switches within the research page.
+ */
+import { useCallback, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import { fetchInstrumentCandles } from "@/api/instruments";
+import type { CandleBar, CandleRange, InstrumentCandles } from "@/api/types";
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+
+const RANGES: { id: CandleRange; label: string }[] = [
+  { id: "1w", label: "1W" },
+  { id: "1m", label: "1M" },
+  { id: "3m", label: "3M" },
+  { id: "6m", label: "6M" },
+  { id: "1y", label: "1Y" },
+  { id: "5y", label: "5Y" },
+  { id: "max", label: "MAX" },
+];
+
+// Plot area dimensions — uses viewBox + SVG scale to fluid-fit the
+// parent container (responsive via preserveAspectRatio below).
+const W = 800;
+const PRICE_H = 240;
+const VOL_H = 60;
+const PAD_LEFT = 56;
+const PAD_RIGHT = 12;
+const PAD_TOP = 12;
+const PAD_BOTTOM = 20;
+
+interface PricePoint {
+  x: number;
+  y: number;
+  close: number;
+  date: string;
+}
+
+interface VolumeBar {
+  x: number;
+  h: number;
+  up: boolean;
+}
+
+interface ChartGeometry {
+  path: string;
+  points: PricePoint[];
+  volume: VolumeBar[];
+  volBarW: number;
+  priceMin: number;
+  priceMax: number;
+  firstDate: string | null;
+  lastDate: string | null;
+}
+
+function parseNum(v: string | null | undefined): number | null {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function geometry(rows: CandleBar[]): ChartGeometry | null {
+  const clean = rows.filter((r) => parseNum(r.close) !== null);
+  if (clean.length < 2) return null;
+
+  const closes = clean.map((r) => parseNum(r.close) ?? 0);
+  const priceMin = Math.min(...closes);
+  const priceMax = Math.max(...closes);
+  const priceRange = priceMax - priceMin || 1;
+
+  const volumes = clean.map((r) => parseNum(r.volume) ?? 0);
+  const volMax = Math.max(...volumes, 1);
+
+  const plotW = W - PAD_LEFT - PAD_RIGHT;
+  const plotH = PRICE_H - PAD_TOP - PAD_BOTTOM;
+  const step = plotW / (clean.length - 1);
+
+  const points: PricePoint[] = clean.map((r, i) => {
+    const c = parseNum(r.close) ?? 0;
+    return {
+      x: PAD_LEFT + i * step,
+      y: PAD_TOP + plotH - ((c - priceMin) / priceRange) * plotH,
+      close: c,
+      date: r.date,
+    };
+  });
+
+  const path = points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(2)},${p.y.toFixed(2)}`)
+    .join(" ");
+
+  // Width and position share the same derivation so bars render
+  // consistently regardless of `n`. Cap at 12px so a 2-point series
+  // doesn't produce a wall-to-wall bar that leaks off the chart.
+  const volBarW = Math.max(1, Math.min(step * 0.8, 12));
+  const volume: VolumeBar[] = clean.map((r, i) => {
+    const v = parseNum(r.volume) ?? 0;
+    const h = (v / volMax) * VOL_H;
+    const prev = i > 0 ? (parseNum(clean[i - 1]!.close) ?? 0) : 0;
+    const curr = parseNum(r.close) ?? 0;
+    return {
+      x: PAD_LEFT + i * step - volBarW / 2,
+      h,
+      up: curr >= prev,
+    };
+  });
+
+  return {
+    path,
+    points,
+    volume,
+    volBarW,
+    priceMin,
+    priceMax,
+    firstDate: clean[0]?.date ?? null,
+    lastDate: clean[clean.length - 1]?.date ?? null,
+  };
+}
+
+export interface PriceChartProps {
+  symbol: string;
+  initialRange?: CandleRange;
+}
+
+const VALID_RANGES: readonly CandleRange[] = [
+  "1w",
+  "1m",
+  "3m",
+  "6m",
+  "1y",
+  "5y",
+  "max",
+];
+
+export function PriceChart({
+  symbol,
+  initialRange = "1m",
+}: PriceChartProps): JSX.Element {
+  // URL-sync so the operator's range choice survives tab switches
+  // inside the research page (and lives in shareable links). `replace`
+  // on change so range-toggles don't spam browser history.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawChart = searchParams.get("chart");
+  const range: CandleRange = VALID_RANGES.includes(rawChart as CandleRange)
+    ? (rawChart as CandleRange)
+    : initialRange;
+  const setRange = useCallback(
+    (next: CandleRange) => {
+      const params = new URLSearchParams(searchParams);
+      if (next === initialRange) {
+        params.delete("chart");
+      } else {
+        params.set("chart", next);
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams, initialRange],
+  );
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+
+  const { data, error, loading, refetch } = useAsync<InstrumentCandles>(
+    () => fetchInstrumentCandles(symbol, range),
+    [symbol, range],
+  );
+
+  const geom = useMemo<ChartGeometry | null>(
+    () => (data ? geometry(data.rows) : null),
+    [data],
+  );
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex gap-1">
+          {RANGES.map((r) => (
+            <button
+              key={r.id}
+              type="button"
+              onClick={() => setRange(r.id)}
+              className={`rounded px-2 py-0.5 text-xs font-medium ${
+                r.id === range
+                  ? "bg-slate-800 text-white"
+                  : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+              }`}
+              data-testid={`chart-range-${r.id}`}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+        {geom && hoverIdx !== null && geom.points[hoverIdx] ? (
+          <div className="text-xs tabular-nums text-slate-600">
+            <span className="text-slate-400">
+              {geom.points[hoverIdx]!.date}
+            </span>
+            <span className="ml-2 font-medium">
+              {geom.points[hoverIdx]!.close.toLocaleString(undefined, {
+                maximumFractionDigits: 2,
+              })}
+            </span>
+          </div>
+        ) : null}
+      </div>
+
+      {loading ? <SectionSkeleton rows={6} /> : null}
+      {error !== null ? <SectionError onRetry={refetch} /> : null}
+      {!loading && error === null && geom === null ? (
+        <EmptyState
+          title="No price data"
+          description="No candles in the local price_daily store for this range. Widen the range or wait for the next market-data refresh."
+        />
+      ) : null}
+
+      {geom !== null ? (
+        <ChartSvg
+          geom={geom}
+          onHover={setHoverIdx}
+          data-testid={`price-chart-${symbol}`}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function ChartSvg({
+  geom,
+  onHover,
+  "data-testid": testId,
+}: {
+  geom: ChartGeometry;
+  onHover: (idx: number | null) => void;
+  "data-testid": string;
+}): JSX.Element {
+  const totalH = PRICE_H + VOL_H + 8;
+  const hoverIdx = (evt: React.MouseEvent<SVGSVGElement>): number => {
+    const svg = evt.currentTarget;
+    const rect = svg.getBoundingClientRect();
+    const x = ((evt.clientX - rect.left) / rect.width) * W;
+    // Nearest-x lookup. Points are evenly spaced so a linear search
+    // over the array length is fine for the MVP; if ranges >1y start
+    // feeling slow we can bisect.
+    let best = 0;
+    let bestDx = Infinity;
+    for (let i = 0; i < geom.points.length; i++) {
+      const dx = Math.abs(geom.points[i]!.x - x);
+      if (dx < bestDx) {
+        best = i;
+        bestDx = dx;
+      }
+    }
+    return best;
+  };
+
+  return (
+    <svg
+      data-testid={testId}
+      viewBox={`0 0 ${W} ${totalH}`}
+      preserveAspectRatio="none"
+      className="w-full"
+      style={{ maxHeight: `${PRICE_H + VOL_H + 24}px` }}
+      onMouseMove={(e) => onHover(hoverIdx(e))}
+      onMouseLeave={() => onHover(null)}
+    >
+      {/* Y-axis ticks — 4 evenly-spaced price labels */}
+      {[0, 0.25, 0.5, 0.75, 1].map((frac) => {
+        const price = geom.priceMax - frac * (geom.priceMax - geom.priceMin);
+        const y = PAD_TOP + frac * (PRICE_H - PAD_TOP - PAD_BOTTOM);
+        return (
+          <g key={frac}>
+            <line
+              x1={PAD_LEFT}
+              x2={W - PAD_RIGHT}
+              y1={y}
+              y2={y}
+              stroke="#e2e8f0"
+              strokeWidth={1}
+              strokeDasharray="2 2"
+            />
+            <text
+              x={PAD_LEFT - 6}
+              y={y + 3}
+              textAnchor="end"
+              className="fill-slate-400"
+              style={{ fontSize: "10px" }}
+            >
+              {price.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* Price line */}
+      <path d={geom.path} fill="none" stroke="#2563eb" strokeWidth={1.5} />
+
+      {/* Volume bars in the bottom strip */}
+      {geom.volume.map((v, i) => (
+        <rect
+          key={i}
+          x={v.x}
+          y={PRICE_H + 8 + (VOL_H - v.h)}
+          width={geom.volBarW}
+          height={v.h}
+          fill={v.up ? "#10b981" : "#ef4444"}
+          opacity={0.5}
+        />
+      ))}
+
+      {/* Period boundary labels */}
+      {geom.firstDate ? (
+        <text
+          x={PAD_LEFT}
+          y={PRICE_H + VOL_H + 6}
+          textAnchor="start"
+          className="fill-slate-400"
+          style={{ fontSize: "10px" }}
+        >
+          {geom.firstDate}
+        </text>
+      ) : null}
+      {geom.lastDate ? (
+        <text
+          x={W - PAD_RIGHT}
+          y={PRICE_H + VOL_H + 6}
+          textAnchor="end"
+          className="fill-slate-400"
+          style={{ fontSize: "10px" }}
+        >
+          {geom.lastDate}
+        </text>
+      ) : null}
+    </svg>
+  );
+}

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -84,13 +84,17 @@ function geometry(rows: CandleBar[]): ChartGeometry | null {
   const clean = rows.filter((r) => parseNum(r.close) !== null);
   if (clean.length < 2) return null;
 
+  // Reduce rather than spread Math.min/max — spread can blow the
+  // call-stack on very large arrays. Our MAX range tops out around
+  // 5y*252 trading days ≈ 1260 bars, comfortably under any runtime's
+  // arg-count limit today, but reduce is portable and costs nothing.
   const closes = clean.map((r) => parseNum(r.close) ?? 0);
-  const priceMin = Math.min(...closes);
-  const priceMax = Math.max(...closes);
+  const priceMin = closes.reduce((a, b) => (a < b ? a : b), closes[0] ?? 0);
+  const priceMax = closes.reduce((a, b) => (a > b ? a : b), closes[0] ?? 0);
   const priceRange = priceMax - priceMin || 1;
 
   const volumes = clean.map((r) => parseNum(r.volume) ?? 0);
-  const volMax = Math.max(...volumes, 1);
+  const volMax = volumes.reduce((a, b) => (a > b ? a : b), 1);
 
   const plotW = W - PAD_LEFT - PAD_RIGHT;
   const plotH = PRICE_H - PAD_TOP - PAD_BOTTOM;

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -253,13 +253,15 @@ function ChartSvg({
   "data-testid": string;
 }): JSX.Element {
   const totalH = PRICE_H + VOL_H + 8;
-  const hoverIdx = (evt: React.MouseEvent<SVGSVGElement>): number => {
+  const findNearestIdx = (evt: React.MouseEvent<SVGSVGElement>): number => {
     const svg = evt.currentTarget;
     const rect = svg.getBoundingClientRect();
+    // Container aspect-ratio is pinned to the viewBox below, so the
+    // svg element's width ↔ viewBox.width mapping is uniform and this
+    // linear rescale is correct (would need getScreenCTM otherwise).
     const x = ((evt.clientX - rect.left) / rect.width) * W;
-    // Nearest-x lookup. Points are evenly spaced so a linear search
-    // over the array length is fine for the MVP; if ranges >1y start
-    // feeling slow we can bisect.
+    // Nearest-x lookup. Points are evenly spaced so linear search is
+    // fine for the MVP; bisect later if large ranges feel slow.
     let best = 0;
     let bestDx = Infinity;
     for (let i = 0; i < geom.points.length; i++) {
@@ -276,10 +278,18 @@ function ChartSvg({
     <svg
       data-testid={testId}
       viewBox={`0 0 ${W} ${totalH}`}
-      preserveAspectRatio="none"
+      // `xMidYMid meet` + container aspectRatio pinned to viewBox
+      // ensures uniform scaling — no stretched line slopes or
+      // tall-looking volume bars on narrow screens (Codex slice-B
+      // round-2 finding). `maxHeight` still caps the chart on very
+      // wide viewports.
+      preserveAspectRatio="xMidYMid meet"
       className="w-full"
-      style={{ maxHeight: `${PRICE_H + VOL_H + 24}px` }}
-      onMouseMove={(e) => onHover(hoverIdx(e))}
+      style={{
+        aspectRatio: `${W} / ${totalH}`,
+        maxHeight: `${PRICE_H + VOL_H + 24}px`,
+      }}
+      onMouseMove={(e) => onHover(findNearestIdx(e))}
       onMouseLeave={() => onHover(null)}
     >
       {/* Y-axis ticks — 4 evenly-spaced price labels */}

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -40,6 +40,7 @@ import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
 import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
 import { Section, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
+import { PriceChart } from "@/components/instrument/PriceChart";
 import { ResearchTab } from "@/components/instrument/ResearchTab";
 import { RightRail } from "@/components/instrument/RightRail";
 import { SummaryStrip } from "@/components/instrument/SummaryStrip";
@@ -616,11 +617,19 @@ function InstrumentPageBody({
           </nav>
 
           {activeTab === "research" && (
-            <ResearchTab
-              summary={summary}
-              thesis={thesisAsync.data}
-              thesisErrored={thesisErrSticky}
-            />
+            <div className="space-y-4">
+              {/* Chart sits at the top of Research — the operator
+                  lands on the tab and sees price context before
+                  drilling into thesis + stats. Slice B of #316. */}
+              <div className="rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+                <PriceChart symbol={symbol} />
+              </div>
+              <ResearchTab
+                summary={summary}
+                thesis={thesisAsync.data}
+                thesisErrored={thesisErrSticky}
+              />
+            </div>
           )}
           {activeTab === "financials" && <FinancialsTab symbol={symbol} />}
           {activeTab === "positions" && (


### PR DESCRIPTION
## What
Hand-rolled SVG line chart component consuming Slice A's `/instruments/:symbol/candles` endpoint. Rendered above the Research tab content so the operator sees price context immediately on the research landing.

## Why
Last missing piece of #316 Instrument terminal. Every other piece (identity + actions + thesis + stats + filings + news + peers + copy-trader exposure) shipped via the per-stock research page slices. Chart closes the loop.

## Scope (intentional)
**Zero new dependencies**: hand-rolled SVG per CLAUDE.md "Do not add libraries casually". Close-price line + volume bars is enough for long-horizon operator decisions; if operator flows later need real candlesticks / studies / drawing tools we revisit with a library adoption in its own PR.

- Range picker: 1W / 1M / 3M / 6M / 1Y / 5Y / MAX.
- Range URL-synced via `?chart=<range>` so tab switches preserve it.
- Close line (blue) + volume bars (emerald up / red down) with hover tooltip.
- Empty-state + retry-error-state + loading-skeleton.

## Test plan
- [x] 6 PriceChart tests: range picker, fetch-on-range-change, empty / single-row / multi-row states, error handling
- [x] typecheck green
- [x] 296 frontend tests pass
- [x] Codex 2 rounds, all findings fixed in-commit

## Follow-ups
- Operator integration test covering tab-away / tab-back `?chart=` preservation (end-to-end — out of scope here)
- Candlestick renderer (requires dep) — defer until operator flow needs OHLC

Refs #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)