### PR TITLE
feat(#204): portfolio value-over-time chart

### DIFF
--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -931,6 +931,12 @@ def get_value_history(
                 SUM(cl.amount) AS balance
             FROM dates d
             JOIN cash_ledger cl ON cl.event_time::date <= d.d
+            -- Filter NULL-currency rows at the SQL level so they
+            -- don't collapse into a single (date, NULL) group that
+            -- undercounts the data-quality signal. The Python loop
+            -- keeps a defence-in-depth guard in case this filter
+            -- ever gets dropped.
+            WHERE cl.currency IS NOT NULL
             GROUP BY d.d, cl.currency
             """,
             {"days": days},

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -26,7 +26,7 @@ import logging
 from collections import defaultdict
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, Literal
 
 import psycopg
 import psycopg.rows
@@ -769,4 +769,204 @@ def get_rolling_pnl(
     return RollingPnlResponse(
         display_currency=display_currency,
         periods=periods,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Portfolio value history (#204)
+# ---------------------------------------------------------------------------
+
+# Range → days-back. `max` bounded to 5y (1825d) to keep the daily
+# loop cheap; operators needing decade-scale history can follow up.
+_VALUE_HISTORY_RANGES: dict[str, int] = {
+    "1m": 30,
+    "3m": 90,
+    "6m": 180,
+    "1y": 365,
+    "5y": 1825,
+    "max": 1825,
+}
+
+
+class ValueHistoryPoint(BaseModel):
+    date: date
+    value: float
+
+
+ValueHistoryRange = Literal["1m", "3m", "6m", "1y", "5y", "max"]
+
+
+class ValueHistoryResponse(BaseModel):
+    display_currency: str
+    range: ValueHistoryRange
+    days: int
+    # Today's FX rates applied to every historical date. A multi-
+    # currency portfolio's past values are therefore approximate — a
+    # proper historical-FX series lives in `fx_rates` (tax ledger)
+    # but only covers dates with tax events. Callers that care about
+    # historical-FX accuracy should treat this chart as directional,
+    # not forensic.
+    fx_mode: str = "live"
+    # Count of native-currency rows we had to drop because the live
+    # FX snapshot didn't have that pair. Lets the FE distinguish
+    # "truly no history" from "all-skipped due to missing FX".
+    fx_skipped: int = 0
+    points: list[ValueHistoryPoint]
+
+
+@router.get("/value-history", response_model=ValueHistoryResponse)
+def get_value_history(
+    range: ValueHistoryRange = "1y",  # noqa: A002 — URL param
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> ValueHistoryResponse:
+    """Daily portfolio total value (positions + cash) over a rolling window.
+
+    Value at day D is reconstructed as:
+        sum over each instrument:
+            signed_units_at_D * close_at_D_or_prior   (converted to display ccy)
+        plus sum over each currency:
+            net_cash_ledger_at_D                       (converted to display ccy)
+
+    Signed units replay the fills ledger by order action (BUY/ADD add,
+    SELL/EXIT subtract). If a position had no `price_daily` close on
+    or before D (e.g. new listing with stale local store), that bar
+    is skipped for that day — conservatively under-states value
+    rather than inventing a zero.
+
+    FX conversion uses the **live** snapshot only (`live_fx_rates`).
+    Historical daily FX is only populated on tax-event dates today, so
+    reusing it would leave coverage gaps worse than the current
+    approximation. Flagged via `fx_mode` in the response.
+    """
+    days = _VALUE_HISTORY_RANGES[range]
+
+    runtime = get_runtime_config(conn)
+    display_currency = runtime.display_currency
+    rates_meta = load_live_fx_rates_with_metadata(conn)
+    rates: dict[tuple[str, str], Decimal] = {k: v["rate"] for k, v in rates_meta.items()}
+
+    # 1. Pull signed position-value points per (date, instrument).
+    #    Uses a correlated subquery for close-at-or-before so the query
+    #    self-contained — no separate price lookup loop in Python.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            WITH dates AS (
+                SELECT generate_series(
+                    CURRENT_DATE - make_interval(days => %(days)s::int),
+                    CURRENT_DATE,
+                    '1 day'::interval
+                )::date AS d
+            ),
+            fills_signed AS (
+                SELECT
+                    f.filled_at::date AS fill_date,
+                    o.instrument_id,
+                    CASE WHEN o.action IN ('BUY', 'ADD') THEN f.units ELSE -f.units END AS units
+                FROM fills f
+                JOIN orders o ON o.order_id = f.order_id
+            ),
+            units_per_day AS (
+                SELECT
+                    d.d,
+                    fs.instrument_id,
+                    SUM(fs.units) AS units_at_date
+                FROM dates d
+                JOIN fills_signed fs ON fs.fill_date <= d.d
+                GROUP BY d.d, fs.instrument_id
+                HAVING SUM(fs.units) > 0
+            )
+            SELECT
+                u.d AS point_date,
+                u.instrument_id,
+                i.currency AS native_currency,
+                u.units_at_date,
+                (
+                    SELECT close FROM price_daily
+                    WHERE instrument_id = u.instrument_id
+                      AND price_date <= u.d
+                      AND close IS NOT NULL
+                    ORDER BY price_date DESC
+                    LIMIT 1
+                ) AS close_at_date
+            FROM units_per_day u
+            JOIN instruments i USING (instrument_id)
+            """,
+            {"days": days},
+        )
+        position_rows = cur.fetchall()
+
+    # 2. Pull daily cumulative cash balance per currency.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            WITH dates AS (
+                SELECT generate_series(
+                    CURRENT_DATE - make_interval(days => %(days)s::int),
+                    CURRENT_DATE,
+                    '1 day'::interval
+                )::date AS d
+            )
+            SELECT
+                d.d AS point_date,
+                cl.currency,
+                SUM(cl.amount) AS balance
+            FROM dates d
+            JOIN cash_ledger cl ON cl.event_time::date <= d.d
+            GROUP BY d.d, cl.currency
+            """,
+            {"days": days},
+        )
+        cash_rows = cur.fetchall()
+
+    # 3. Aggregate into one value per day in display currency.
+    per_day: dict[date, Decimal] = defaultdict(lambda: Decimal("0"))
+    fx_skipped = 0
+
+    for row in position_rows:
+        close = row["close_at_date"]
+        if close is None:
+            continue  # no close on or before this date → skip, not zero
+        units = Decimal(str(row["units_at_date"]))
+        native_ccy = str(row["native_currency"] or display_currency)
+        value_native = close * units
+        if native_ccy != display_currency:
+            try:
+                value_native = convert(value_native, native_ccy, display_currency, rates)
+            except FxRateNotFound:
+                fx_skipped += 1
+                logger.warning(
+                    "value-history: FX %s→%s missing; skipping instrument_id=%s on %s",
+                    native_ccy,
+                    display_currency,
+                    row["instrument_id"],
+                    row["point_date"],
+                )
+                continue
+        per_day[row["point_date"]] += value_native
+
+    for row in cash_rows:
+        balance = Decimal(str(row["balance"]))
+        native_ccy = str(row["currency"] or display_currency)
+        if native_ccy != display_currency:
+            try:
+                balance = convert(balance, native_ccy, display_currency, rates)
+            except FxRateNotFound:
+                fx_skipped += 1
+                logger.warning(
+                    "value-history: FX %s→%s missing for cash on %s",
+                    native_ccy,
+                    display_currency,
+                    row["point_date"],
+                )
+                continue
+        per_day[row["point_date"]] += balance
+
+    points = [ValueHistoryPoint(date=d, value=float(v)) for d, v in sorted(per_day.items())]
+    return ValueHistoryResponse(
+        display_currency=display_currency,
+        range=range,
+        days=days,
+        fx_skipped=fx_skipped,
+        points=points,
     )

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -776,8 +776,10 @@ def get_rolling_pnl(
 # Portfolio value history (#204)
 # ---------------------------------------------------------------------------
 
-# Range → days-back. `max` bounded to 5y (1825d) to keep the daily
-# loop cheap; operators needing decade-scale history can follow up.
+# Range → days-back. `max` is intentionally capped at 5y (1825 days,
+# same as the "5y" row) to keep the daily generate_series loop cheap;
+# decade-scale history would need either materialised snapshots or an
+# expression index on fills.filled_at::date / cash_ledger.event_time::date.
 _VALUE_HISTORY_RANGES: dict[str, int] = {
     "1m": 30,
     "3m": 90,
@@ -807,9 +809,10 @@ class ValueHistoryResponse(BaseModel):
     # historical-FX accuracy should treat this chart as directional,
     # not forensic.
     fx_mode: str = "live"
-    # Count of native-currency rows we had to drop because the live
-    # FX snapshot didn't have that pair. Lets the FE distinguish
-    # "truly no history" from "all-skipped due to missing FX".
+    # Distinct FX pairs we had to drop because the live snapshot didn't
+    # have them. Lets the FE distinguish "truly no history" from
+    # "all-skipped due to missing FX", without inflating the count by
+    # (instruments × days).
     fx_skipped: int = 0
     points: list[ValueHistoryPoint]
 
@@ -935,8 +938,14 @@ def get_value_history(
         cash_rows = cur.fetchall()
 
     # 3. Aggregate into one value per day in display currency.
+    # cash_ledger semantics: every INSERT site (orders.py, order_client.py,
+    # portfolio_sync.py) writes a *delta* row, never an absolute snapshot.
+    # SUM(amount) is therefore the running balance — correct per-call-site
+    # invariant, not a coincidence of the test fixtures.
     per_day: dict[date, Decimal] = defaultdict(lambda: Decimal("0"))
-    fx_skipped = 0
+    # Track missing FX as a set of (from, to) pairs so the operator-
+    # facing count reflects distinct gaps, not N * days of duplicates.
+    fx_missing_pairs: set[tuple[str, str]] = set()
 
     for row in position_rows:
         close_raw = row["close_at_date"]
@@ -964,7 +973,7 @@ def get_value_history(
             try:
                 value_native = convert(value_native, native_ccy, display_currency, rates)
             except FxRateNotFound:
-                fx_skipped += 1
+                fx_missing_pairs.add((native_ccy, display_currency))
                 logger.warning(
                     "value-history: FX %s→%s missing; skipping instrument_id=%s on %s",
                     native_ccy,
@@ -991,7 +1000,7 @@ def get_value_history(
             try:
                 balance = convert(balance, native_ccy, display_currency, rates)
             except FxRateNotFound:
-                fx_skipped += 1
+                fx_missing_pairs.add((native_ccy, display_currency))
                 logger.warning(
                     "value-history: FX %s→%s missing for cash on %s",
                     native_ccy,
@@ -1006,6 +1015,6 @@ def get_value_history(
         display_currency=display_currency,
         range=range,
         days=days,
-        fx_skipped=fx_skipped,
+        fx_skipped=len(fx_missing_pairs),
         points=points,
     )

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -867,16 +867,16 @@ def get_value_history(
                 ) AS start_date
                 """
             )
-            row = cur.fetchone()
-            start_date: date = row["start_date"] if row else date.today()
         else:
             cur.execute(
                 "SELECT (CURRENT_DATE - make_interval(days => %(days)s::int))::date AS start_date",
                 {"days": days},
             )
-            row = cur.fetchone()
-            assert row is not None  # CURRENT_DATE always returns one row
-            start_date = row["start_date"]
+        # A SELECT without FROM always returns exactly one row in
+        # Postgres; the `or` fallback keeps a driver-level anomaly
+        # from raising an AssertionError in a live request path.
+        row = cur.fetchone()
+        start_date: date = row["start_date"] if row else date.today()
 
     # 1. Pull signed position-value points per (date, instrument).
     #    Uses a correlated subquery for close-at-or-before so the query

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -848,30 +848,45 @@ def get_value_history(
     rates_meta = load_live_fx_rates_with_metadata(conn)
     rates: dict[tuple[str, str], Decimal] = {k: v["rate"] for k, v in rates_meta.items()}
 
+    # Resolve the start date in Python so both ledger queries below
+    # use the same literal, not duplicated CTEs — a prior iteration
+    # had `max` diverge from `5y` because the bound was computed in
+    # two places. For range=max, pull the earliest ledger row; fall
+    # back to CURRENT_DATE so an empty ledger produces a single-point
+    # series rather than failing.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        if days is None:
+            cur.execute(
+                """
+                SELECT COALESCE(
+                    LEAST(
+                        (SELECT MIN(filled_at::date) FROM fills),
+                        (SELECT MIN(event_time::date) FROM cash_ledger)
+                    ),
+                    CURRENT_DATE
+                ) AS start_date
+                """
+            )
+            row = cur.fetchone()
+            start_date: date = row["start_date"] if row else date.today()
+        else:
+            cur.execute(
+                "SELECT (CURRENT_DATE - make_interval(days => %(days)s::int))::date AS start_date",
+                {"days": days},
+            )
+            row = cur.fetchone()
+            assert row is not None  # CURRENT_DATE always returns one row
+            start_date = row["start_date"]
+
     # 1. Pull signed position-value points per (date, instrument).
     #    Uses a correlated subquery for close-at-or-before so the query
-    #    self-contained — no separate price lookup loop in Python.
-    #    When `days` is NULL (range=max), start from the earliest row
-    #    in fills / cash_ledger so the chart covers real history
-    #    rather than duplicating the 5Y window.
+    #    is self-contained — no separate price lookup loop in Python.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            WITH bounds AS (
-                SELECT CASE
-                    WHEN %(days)s::int IS NULL THEN COALESCE(
-                        LEAST(
-                            (SELECT MIN(filled_at::date) FROM fills),
-                            (SELECT MIN(event_time::date) FROM cash_ledger)
-                        ),
-                        CURRENT_DATE
-                    )
-                    ELSE CURRENT_DATE - make_interval(days => %(days)s::int)
-                END AS start_date
-            ),
-            dates AS (
+            WITH dates AS (
                 SELECT generate_series(
-                    (SELECT start_date FROM bounds),
+                    %(start)s::date,
                     CURRENT_DATE,
                     '1 day'::interval
                 )::date AS d
@@ -925,30 +940,17 @@ def get_value_history(
             FROM units_per_day u
             JOIN instruments i USING (instrument_id)
             """,
-            {"days": days},
+            {"start": start_date},
         )
         position_rows = cur.fetchall()
 
-    # 2. Pull daily cumulative cash balance per currency. Same
-    #    NULL-days = earliest-row bounding as the positions query.
+    # 2. Pull daily cumulative cash balance per currency.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            WITH bounds AS (
-                SELECT CASE
-                    WHEN %(days)s::int IS NULL THEN COALESCE(
-                        LEAST(
-                            (SELECT MIN(filled_at::date) FROM fills),
-                            (SELECT MIN(event_time::date) FROM cash_ledger)
-                        ),
-                        CURRENT_DATE
-                    )
-                    ELSE CURRENT_DATE - make_interval(days => %(days)s::int)
-                END AS start_date
-            ),
-            dates AS (
+            WITH dates AS (
                 SELECT generate_series(
-                    (SELECT start_date FROM bounds),
+                    %(start)s::date,
                     CURRENT_DATE,
                     '1 day'::interval
                 )::date AS d
@@ -967,7 +969,7 @@ def get_value_history(
             WHERE cl.currency IS NOT NULL
             GROUP BY d.d, cl.currency
             """,
-            {"days": days},
+            {"start": start_date},
         )
         cash_rows = cur.fetchall()
 

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -859,12 +859,21 @@ def get_value_history(
                 )::date AS d
             ),
             fills_signed AS (
+                -- Explicit whitelist rather than default-to-negative so
+                -- a future action code (e.g. a corporate-action type)
+                -- can't silently flip the NAV sign. Unknown actions
+                -- fall through to NULL and are dropped by the SUM.
                 SELECT
                     f.filled_at::date AS fill_date,
                     o.instrument_id,
-                    CASE WHEN o.action IN ('BUY', 'ADD') THEN f.units ELSE -f.units END AS units
+                    CASE
+                        WHEN o.action IN ('BUY', 'ADD') THEN f.units
+                        WHEN o.action IN ('SELL', 'EXIT') THEN -f.units
+                        ELSE NULL
+                    END AS units
                 FROM fills f
                 JOIN orders o ON o.order_id = f.order_id
+                WHERE o.action IN ('BUY', 'ADD', 'SELL', 'EXIT')
             ),
             units_per_day AS (
                 -- Long-only invariant (CLAUDE.md, eBull non-negotiables
@@ -968,7 +977,16 @@ def get_value_history(
 
     for row in cash_rows:
         balance = Decimal(str(row["balance"]))
-        native_ccy = str(row["currency"] or display_currency)
+        raw_ccy = row["currency"]
+        if raw_ccy is None:
+            # Mirrors the positions-loop guard: cash without a currency
+            # is a data-quality bug, not a display-currency balance.
+            logger.warning(
+                "value-history: cash_ledger row has NULL currency on %s; skipping",
+                row["point_date"],
+            )
+            continue
+        native_ccy = str(raw_ccy)
         if native_ccy != display_currency:
             try:
                 balance = convert(balance, native_ccy, display_currency, rates)

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -776,17 +776,17 @@ def get_rolling_pnl(
 # Portfolio value history (#204)
 # ---------------------------------------------------------------------------
 
-# Range → days-back. `max` is intentionally capped at 5y (1825 days,
-# same as the "5y" row) to keep the daily generate_series loop cheap;
-# decade-scale history would need either materialised snapshots or an
-# expression index on fills.filled_at::date / cash_ledger.event_time::date.
-_VALUE_HISTORY_RANGES: dict[str, int] = {
+# Range → days-back. None on "max" means "from the earliest row in
+# fills/cash_ledger to today" (parallels the candles API `max`). The
+# generate_series loop stays bounded by real data; a fund with 10y of
+# trades gets 10y of points, not 5y of truncation.
+_VALUE_HISTORY_RANGES: dict[str, int | None] = {
     "1m": 30,
     "3m": 90,
     "6m": 180,
     "1y": 365,
     "5y": 1825,
-    "max": 1825,
+    "max": None,
 }
 
 
@@ -851,12 +851,27 @@ def get_value_history(
     # 1. Pull signed position-value points per (date, instrument).
     #    Uses a correlated subquery for close-at-or-before so the query
     #    self-contained — no separate price lookup loop in Python.
+    #    When `days` is NULL (range=max), start from the earliest row
+    #    in fills / cash_ledger so the chart covers real history
+    #    rather than duplicating the 5Y window.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            WITH dates AS (
+            WITH bounds AS (
+                SELECT CASE
+                    WHEN %(days)s::int IS NULL THEN COALESCE(
+                        LEAST(
+                            (SELECT MIN(filled_at::date) FROM fills),
+                            (SELECT MIN(event_time::date) FROM cash_ledger)
+                        ),
+                        CURRENT_DATE
+                    )
+                    ELSE CURRENT_DATE - make_interval(days => %(days)s::int)
+                END AS start_date
+            ),
+            dates AS (
                 SELECT generate_series(
-                    CURRENT_DATE - make_interval(days => %(days)s::int),
+                    (SELECT start_date FROM bounds),
                     CURRENT_DATE,
                     '1 day'::interval
                 )::date AS d
@@ -914,13 +929,26 @@ def get_value_history(
         )
         position_rows = cur.fetchall()
 
-    # 2. Pull daily cumulative cash balance per currency.
+    # 2. Pull daily cumulative cash balance per currency. Same
+    #    NULL-days = earliest-row bounding as the positions query.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            WITH dates AS (
+            WITH bounds AS (
+                SELECT CASE
+                    WHEN %(days)s::int IS NULL THEN COALESCE(
+                        LEAST(
+                            (SELECT MIN(filled_at::date) FROM fills),
+                            (SELECT MIN(event_time::date) FROM cash_ledger)
+                        ),
+                        CURRENT_DATE
+                    )
+                    ELSE CURRENT_DATE - make_interval(days => %(days)s::int)
+                END AS start_date
+            ),
+            dates AS (
                 SELECT generate_series(
-                    CURRENT_DATE - make_interval(days => %(days)s::int),
+                    (SELECT start_date FROM bounds),
                     CURRENT_DATE,
                     '1 day'::interval
                 )::date AS d
@@ -1017,10 +1045,20 @@ def get_value_history(
         per_day[row["point_date"]] += balance
 
     points = [ValueHistoryPoint(date=d, value=float(v)) for d, v in sorted(per_day.items())]
+
+    # For `max` the actual lookback depends on the earliest ledger
+    # row, not the input bucket — surface the effective span so the
+    # operator / charting code can label the axis correctly without
+    # needing to subtract the first point's date client-side.
+    if days is None:
+        effective_days = (points[-1].date - points[0].date).days if len(points) >= 2 else 0
+    else:
+        effective_days = days
+
     return ValueHistoryResponse(
         display_currency=display_currency,
         range=range,
-        days=days,
+        days=effective_days,
         fx_skipped=len(fx_missing_pairs),
         points=points,
     )

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -867,6 +867,12 @@ def get_value_history(
                 JOIN orders o ON o.order_id = f.order_id
             ),
             units_per_day AS (
+                -- Long-only invariant (CLAUDE.md, eBull non-negotiables
+                -- "Long only in v1. No shorting."). We intentionally
+                -- drop zero and negative net-units: zero = fully
+                -- closed (contributes nothing), negative = should
+                -- not exist in this product and is treated as
+                -- corrupt data rather than silently priced.
                 SELECT
                     d.d,
                     fs.instrument_id,
@@ -924,11 +930,26 @@ def get_value_history(
     fx_skipped = 0
 
     for row in position_rows:
-        close = row["close_at_date"]
-        if close is None:
+        close_raw = row["close_at_date"]
+        if close_raw is None:
             continue  # no close on or before this date → skip, not zero
+        # psycopg3 returns NUMERIC as Decimal in practice, but wrap
+        # defensively so we never mix Decimal with a float if a driver
+        # or column-type change ever slips in.
+        close = Decimal(str(close_raw))
         units = Decimal(str(row["units_at_date"]))
-        native_ccy = str(row["native_currency"] or display_currency)
+        raw_ccy = row["native_currency"]
+        if raw_ccy is None:
+            # Instrument missing a currency is a data-quality bug, not
+            # a display-currency position. Log and skip so we don't
+            # silently attribute foreign value to display-ccy NAV.
+            logger.warning(
+                "value-history: instrument_id=%s has NULL currency; skipping on %s",
+                row["instrument_id"],
+                row["point_date"],
+            )
+            continue
+        native_ccy = str(raw_ccy)
         value_native = close * units
         if native_ccy != display_currency:
             try:

--- a/frontend/src/api/portfolio.ts
+++ b/frontend/src/api/portfolio.ts
@@ -3,6 +3,8 @@ import type {
   InstrumentPositionDetail,
   PortfolioResponse,
   RollingPnlResponse,
+  ValueHistoryRange,
+  ValueHistoryResponse,
 } from "@/api/types";
 
 export function fetchPortfolio(): Promise<PortfolioResponse> {
@@ -15,4 +17,12 @@ export function fetchInstrumentPositions(instrumentId: number): Promise<Instrume
 
 export function fetchRollingPnl(): Promise<RollingPnlResponse> {
   return apiFetch<RollingPnlResponse>("/portfolio/rolling-pnl");
+}
+
+export function fetchValueHistory(
+  range: ValueHistoryRange,
+): Promise<ValueHistoryResponse> {
+  return apiFetch<ValueHistoryResponse>(
+    `/portfolio/value-history?range=${encodeURIComponent(range)}`,
+  );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -371,6 +371,23 @@ export interface RollingPnlResponse {
   periods: RollingPnlPeriod[];
 }
 
+// /portfolio/value-history — #204 portfolio NAV over time
+export type ValueHistoryRange = "1m" | "3m" | "6m" | "1y" | "5y" | "max";
+
+export interface ValueHistoryPoint {
+  date: string; // YYYY-MM-DD
+  value: number;
+}
+
+export interface ValueHistoryResponse {
+  display_currency: string;
+  range: ValueHistoryRange;
+  days: number;
+  fx_mode: string; // "live" in v1 — flags whether historical FX was used
+  fx_skipped: number; // rows dropped due to missing live FX pair
+  points: ValueHistoryPoint[];
+}
+
 // /portfolio/instruments/:instrumentId — native currency drill-through
 export interface NativeTradeItem {
   position_id: number;

--- a/frontend/src/components/dashboard/PortfolioValueChart.test.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueChart.test.tsx
@@ -135,10 +135,10 @@ describe("PortfolioValueChart", () => {
   });
 
   it("surfaces an 'FX rates missing' empty state when fx_skipped > 0", async () => {
-    // All-skipped is indistinguishable from "no data" without fx_skipped;
-    // the counter lets the operator know why their mixed-currency
-    // portfolio is rendering empty (Codex round-1 finding).
-    mocked.mockResolvedValue(resp([], { fx_skipped: 4 }));
+    // All-skipped is indistinguishable from "no data" without
+    // fx_skipped; the pair-count lets the operator know why their
+    // mixed-currency portfolio is rendering empty.
+    mocked.mockResolvedValue(resp([], { fx_skipped: 2 }));
     render(
       <MemoryRouter>
         <PortfolioValueChart />
@@ -147,7 +147,7 @@ describe("PortfolioValueChart", () => {
     await waitFor(() => {
       expect(screen.getByText(/FX rates missing/i)).toBeInTheDocument();
     });
-    expect(screen.getByText(/4 native-currency rows/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 currency pair/i)).toBeInTheDocument();
   });
 
   it("calls chart.remove() on unmount so Canvas is released", async () => {

--- a/frontend/src/components/dashboard/PortfolioValueChart.test.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueChart.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Tests for PortfolioValueChart (#204). lightweight-charts is mocked
+ * wholesale because jsdom can't paint Canvas — we pin the component's
+ * contract (range picker, empty/error branches, series data shape)
+ * not the library's rendering.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+const libState = vi.hoisted(() => ({
+  setData: vi.fn(),
+  fitContent: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("lightweight-charts", () => {
+  const series = { setData: libState.setData };
+  const chart = {
+    addSeries: vi.fn(() => series),
+    priceScale: vi.fn(() => ({ applyOptions: vi.fn() })),
+    timeScale: vi.fn(() => ({ fitContent: libState.fitContent })),
+    subscribeCrosshairMove: vi.fn(),
+    remove: libState.remove,
+  };
+  return {
+    createChart: vi.fn(() => chart),
+    AreaSeries: "__area__",
+  };
+});
+
+import { PortfolioValueChart } from "@/components/dashboard/PortfolioValueChart";
+import type { ValueHistoryResponse } from "@/api/types";
+
+vi.mock("@/api/portfolio", () => ({ fetchValueHistory: vi.fn() }));
+
+import { fetchValueHistory } from "@/api/portfolio";
+
+const mocked = vi.mocked(fetchValueHistory);
+
+function resp(
+  points: ValueHistoryResponse["points"],
+  overrides: Partial<ValueHistoryResponse> = {},
+): ValueHistoryResponse {
+  return {
+    display_currency: "GBP",
+    range: "1y",
+    days: 365,
+    fx_mode: "live",
+    fx_skipped: 0,
+    points,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mocked.mockReset();
+  libState.setData.mockClear();
+  libState.fitContent.mockClear();
+  libState.remove.mockClear();
+});
+
+describe("PortfolioValueChart", () => {
+  it("renders all six range buttons + an fx_mode caption on live", async () => {
+    mocked.mockResolvedValue(resp([]));
+    render(
+      <MemoryRouter>
+        <PortfolioValueChart />
+      </MemoryRouter>,
+    );
+    for (const r of ["1m", "3m", "6m", "1y", "5y", "max"]) {
+      expect(screen.getByTestId(`value-range-${r}`)).toBeInTheDocument();
+    }
+    // fx_mode caption only renders once data has loaded and reports "live".
+    await waitFor(() => {
+      expect(
+        screen.getByText(/historical converted at today's FX/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("clicking a range refetches with the new range", async () => {
+    mocked.mockResolvedValue(resp([]));
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <PortfolioValueChart />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(mocked).toHaveBeenCalledWith("1y");
+    });
+    await user.click(screen.getByTestId("value-range-3m"));
+    await waitFor(() => {
+      expect(mocked).toHaveBeenLastCalledWith("3m");
+    });
+  });
+
+  it("mounts chart + pushes ≥2 points to setData", async () => {
+    mocked.mockResolvedValue(
+      resp([
+        { date: "2026-04-18", value: 1000 },
+        { date: "2026-04-19", value: 1100 },
+      ]),
+    );
+    render(
+      <MemoryRouter>
+        <PortfolioValueChart />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("portfolio-value-chart")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(libState.setData).toHaveBeenCalled();
+    });
+    const call = libState.setData.mock.calls[0]?.[0] as Array<{ value: number }>;
+    expect(call).toHaveLength(2);
+    expect(call[0]?.value).toBe(1000);
+    expect(call[1]?.value).toBe(1100);
+  });
+
+  it("renders empty state when fewer than two valid points", async () => {
+    mocked.mockResolvedValue(resp([{ date: "2026-04-19", value: 1000 }]));
+    render(
+      <MemoryRouter>
+        <PortfolioValueChart />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/No history yet/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("portfolio-value-chart")).not.toBeInTheDocument();
+  });
+
+  it("surfaces an 'FX rates missing' empty state when fx_skipped > 0", async () => {
+    // All-skipped is indistinguishable from "no data" without fx_skipped;
+    // the counter lets the operator know why their mixed-currency
+    // portfolio is rendering empty (Codex round-1 finding).
+    mocked.mockResolvedValue(resp([], { fx_skipped: 4 }));
+    render(
+      <MemoryRouter>
+        <PortfolioValueChart />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/FX rates missing/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/4 native-currency rows/i)).toBeInTheDocument();
+  });
+
+  it("calls chart.remove() on unmount so Canvas is released", async () => {
+    mocked.mockResolvedValue(
+      resp([
+        { date: "2026-04-18", value: 1000 },
+        { date: "2026-04-19", value: 1100 },
+      ]),
+    );
+    render(
+      <MemoryRouter>
+        <PortfolioValueChart />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("portfolio-value-chart")).toBeInTheDocument();
+    });
+    cleanup();
+    expect(libState.remove).toHaveBeenCalled();
+  });
+
+  it("silent-hides on fetch error — no blanking of the rest of the dashboard", async () => {
+    mocked.mockRejectedValue(new Error("offline"));
+    const { container } = render(
+      <MemoryRouter>
+        <PortfolioValueChart />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(mocked).toHaveBeenCalled();
+    });
+    // Whole widget renders null on error — no range buttons, no chart.
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid^="value-range-"]')).toBeNull();
+    });
+    expect(
+      container.querySelector('[data-testid="portfolio-value-chart"]'),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/components/dashboard/PortfolioValueChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueChart.tsx
@@ -1,0 +1,259 @@
+/**
+ * PortfolioValueChart — total portfolio value (positions + cash) over
+ * time, rendered with lightweight-charts as a single-line area series.
+ * Lives on the dashboard under SummaryCards / RollingPnlStrip (#204).
+ *
+ * Data from GET /portfolio/value-history. The endpoint uses the
+ * **live** FX snapshot for all historical conversions — documented
+ * via `fx_mode` in the response and surfaced as a muted caption here
+ * so an operator with a mixed-currency portfolio understands the
+ * approximation.
+ *
+ * Silent-on-error: if the fetch fails, the whole widget hides. A
+ * broken chart shouldn't blank the rest of the dashboard.
+ */
+import { useEffect, useRef, useState, useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  AreaSeries,
+  createChart,
+  type IChartApi,
+  type ISeriesApi,
+  type Time,
+  type UTCTimestamp,
+} from "lightweight-charts";
+
+import { fetchValueHistory } from "@/api/portfolio";
+import type { ValueHistoryPoint, ValueHistoryRange } from "@/api/types";
+import { SectionSkeleton } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { formatMoney } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+const RANGES: { id: ValueHistoryRange; label: string }[] = [
+  { id: "1m", label: "1M" },
+  { id: "3m", label: "3M" },
+  { id: "6m", label: "6M" },
+  { id: "1y", label: "1Y" },
+  { id: "5y", label: "5Y" },
+  { id: "max", label: "MAX" },
+];
+
+const VALID_RANGES: readonly ValueHistoryRange[] = [
+  "1m",
+  "3m",
+  "6m",
+  "1y",
+  "5y",
+  "max",
+];
+
+/** Same format as PriceChart — UTC-midnight epoch seconds; null on any
+ * unparseable input so we drop bad rows rather than poison the time
+ * scale with NaN. */
+function dateToTime(date: string): UTCTimestamp | null {
+  const parts = date.split("-");
+  if (parts.length !== 3) return null;
+  const y = Number(parts[0]);
+  const m = Number(parts[1]);
+  const d = Number(parts[2]);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return null;
+  const ts = Date.UTC(y, m - 1, d);
+  if (!Number.isFinite(ts)) return null;
+  return (ts / 1000) as UTCTimestamp;
+}
+
+interface HoverState {
+  date: string;
+  value: number;
+}
+
+export function PortfolioValueChart(): JSX.Element | null {
+  // `?value=` URL-sync so the dashboard operator's range choice sticks
+  // across navigation — distinct from the per-instrument `?chart=` key
+  // so both can coexist if we ever merge these pages.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawRange = searchParams.get("value");
+  const range: ValueHistoryRange = VALID_RANGES.includes(
+    rawRange as ValueHistoryRange,
+  )
+    ? (rawRange as ValueHistoryRange)
+    : "1y";
+
+  const setRange = useCallback(
+    (next: ValueHistoryRange) => {
+      const params = new URLSearchParams(searchParams);
+      if (next === "1y") {
+        params.delete("value");
+      } else {
+        params.set("value", next);
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const { data, error, loading } = useAsync(
+    () => fetchValueHistory(range),
+    [range],
+  );
+
+  const dataMatchesRange = data?.range === range;
+  const effectivelyLoading = loading || !dataMatchesRange;
+
+  const points = dataMatchesRange && data ? data.points : null;
+  const hasData =
+    points !== null && points.filter((p) => dateToTime(p.date) !== null).length >= 2;
+
+  if (error !== null) {
+    // Silent-on-error: dashboard already has SummaryCards + rolling pills.
+    return null;
+  }
+
+  return (
+    <div className="rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div className="flex items-baseline gap-2">
+          <h2 className="text-sm font-medium text-slate-700">Portfolio value</h2>
+          {data?.fx_mode === "live" ? (
+            <span className="text-[10px] text-slate-400">
+              historical converted at today's FX
+            </span>
+          ) : null}
+        </div>
+        <div className="flex gap-1">
+          {RANGES.map((r) => (
+            <button
+              key={r.id}
+              type="button"
+              onClick={() => setRange(r.id)}
+              className={`rounded px-2 py-0.5 text-xs font-medium ${
+                r.id === range
+                  ? "bg-slate-800 text-white"
+                  : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+              }`}
+              data-testid={`value-range-${r.id}`}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {effectivelyLoading ? <SectionSkeleton rows={5} /> : null}
+      {!effectivelyLoading && !hasData ? (
+        <EmptyState
+          title={data !== null && data.fx_skipped > 0 ? "FX rates missing" : "No history yet"}
+          description={
+            data !== null && data.fx_skipped > 0
+              ? `${data.fx_skipped} native-currency rows were dropped because today's FX snapshot doesn't cover them. Wait for the FX refresh job to repopulate and retry.`
+              : "Not enough daily valuations to plot a line. Try a wider range, or wait for more trading days to accrue."
+          }
+        />
+      ) : null}
+      {hasData && points !== null && data !== null ? (
+        <ValueCanvas points={points} currency={data.display_currency} />
+      ) : null}
+    </div>
+  );
+}
+
+function ValueCanvas({
+  points,
+  currency,
+}: {
+  points: ValueHistoryPoint[];
+  currency: string;
+}): JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const seriesRef = useRef<ISeriesApi<"Area"> | null>(null);
+  const [hover, setHover] = useState<HoverState | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (container === null) return;
+
+    const chart = createChart(container, {
+      autoSize: true,
+      layout: {
+        background: { color: "#ffffff" },
+        textColor: "#64748b",
+        fontSize: 11,
+      },
+      grid: {
+        vertLines: { color: "#f1f5f9" },
+        horzLines: { color: "#f1f5f9" },
+      },
+      rightPriceScale: { borderColor: "#e2e8f0" },
+      timeScale: { borderColor: "#e2e8f0" },
+      crosshair: {
+        vertLine: { width: 1, color: "#94a3b8", style: 3 },
+        horzLine: { width: 1, color: "#94a3b8", style: 3 },
+      },
+    });
+
+    const series = chart.addSeries(AreaSeries, {
+      lineColor: "#2563eb",
+      topColor: "rgba(37,99,235,0.25)",
+      bottomColor: "rgba(37,99,235,0.02)",
+      lineWidth: 2,
+    });
+
+    chart.subscribeCrosshairMove((param) => {
+      const sp = seriesRef.current;
+      if (!param.time || !sp || typeof param.time !== "number") {
+        setHover(null);
+        return;
+      }
+      const pt = param.seriesData.get(sp);
+      if (!pt || typeof pt !== "object" || !("value" in pt)) {
+        setHover(null);
+        return;
+      }
+      const date = new Date(param.time * 1000).toISOString().slice(0, 10);
+      setHover({ date, value: (pt as { value: number }).value });
+    });
+
+    chartRef.current = chart;
+    seriesRef.current = series;
+
+    return () => {
+      chart.remove();
+      chartRef.current = null;
+      seriesRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const series = seriesRef.current;
+    const chart = chartRef.current;
+    if (!series || !chart) return;
+
+    const clean = points.flatMap((p) => {
+      const time = dateToTime(p.date);
+      if (time === null) return [];
+      return [{ time: time as Time, value: p.value }];
+    });
+    series.setData(clean);
+    chart.timeScale().fitContent();
+  }, [points]);
+
+  return (
+    <div className="relative mt-2">
+      {hover !== null ? (
+        <div className="absolute right-2 top-2 z-10 rounded bg-white/90 px-2 py-1 text-xs tabular-nums shadow-sm">
+          <span className="text-slate-400">{hover.date}</span>
+          <span className="ml-2 font-medium text-slate-700">
+            {formatMoney(hover.value, currency)}
+          </span>
+        </div>
+      ) : null}
+      <div
+        ref={containerRef}
+        data-testid="portfolio-value-chart"
+        className="h-[220px] w-full"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/PortfolioValueChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueChart.tsx
@@ -195,6 +195,12 @@ function ValueCanvas({
       lineWidth: 2,
     });
 
+    // Assign refs BEFORE subscribing so the callback can never fire
+    // against a null seriesRef in the same effect tick (latent-but-
+    // practically-unreachable race the bot flagged).
+    chartRef.current = chart;
+    seriesRef.current = series;
+
     chart.subscribeCrosshairMove((param) => {
       const sp = seriesRef.current;
       if (!param.time || !sp || typeof param.time !== "number") {
@@ -209,9 +215,6 @@ function ValueCanvas({
       const date = new Date(param.time * 1000).toISOString().slice(0, 10);
       setHover({ date, value: (pt as { value: number }).value });
     });
-
-    chartRef.current = chart;
-    seriesRef.current = series;
 
     return () => {
       chart.remove();

--- a/frontend/src/components/dashboard/PortfolioValueChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueChart.tsx
@@ -39,14 +39,13 @@ const RANGES: { id: ValueHistoryRange; label: string }[] = [
   { id: "max", label: "MAX" },
 ];
 
-const VALID_RANGES: readonly ValueHistoryRange[] = [
-  "1m",
-  "3m",
-  "6m",
-  "1y",
-  "5y",
-  "max",
-];
+// Derived rather than maintained separately — keeps the URL-parse
+// whitelist in lock-step with what's rendered.
+const VALID_RANGES: readonly string[] = RANGES.map((r) => r.id);
+
+function isValidRange(v: string | null): v is ValueHistoryRange {
+  return v !== null && VALID_RANGES.includes(v);
+}
 
 /** Same format as PriceChart — UTC-midnight epoch seconds; null on any
  * unparseable input so we drop bad rows rather than poison the time
@@ -74,11 +73,7 @@ export function PortfolioValueChart(): JSX.Element | null {
   // so both can coexist if we ever merge these pages.
   const [searchParams, setSearchParams] = useSearchParams();
   const rawRange = searchParams.get("value");
-  const range: ValueHistoryRange = VALID_RANGES.includes(
-    rawRange as ValueHistoryRange,
-  )
-    ? (rawRange as ValueHistoryRange)
-    : "1y";
+  const range: ValueHistoryRange = isValidRange(rawRange) ? rawRange : "1y";
 
   const setRange = useCallback(
     (next: ValueHistoryRange) => {
@@ -146,7 +141,7 @@ export function PortfolioValueChart(): JSX.Element | null {
           title={data !== null && data.fx_skipped > 0 ? "FX rates missing" : "No history yet"}
           description={
             data !== null && data.fx_skipped > 0
-              ? `${data.fx_skipped} native-currency rows were dropped because today's FX snapshot doesn't cover them. Wait for the FX refresh job to repopulate and retry.`
+              ? `${data.fx_skipped} currency pair(s) missing from today's FX snapshot — all rows in those pairs were dropped. Wait for the FX refresh job to repopulate and retry.`
               : "Not enough daily valuations to plot a line. Try a wider range, or wait for more trading days to accrue."
           }
         />

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -9,6 +9,7 @@ import { useConfig } from "@/lib/ConfigContext";
 import { useAsync } from "@/lib/useAsync";
 import { ErrorBanner } from "@/components/states/ErrorBanner";
 import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { PortfolioValueChart } from "@/components/dashboard/PortfolioValueChart";
 import { RollingPnlStrip } from "@/components/dashboard/RollingPnlStrip";
 import { SummaryCards } from "@/components/dashboard/SummaryCards";
 import { PositionsTable } from "@/components/dashboard/PositionsTable";
@@ -116,6 +117,11 @@ export function DashboardPage() {
               movement. Hidden on error so a failed rolling fetch
               doesn't blank the rest of the page. */}
           <RollingPnlStrip />
+          {/* Portfolio value over time (positions + cash). Mounted
+              under the pills so the operator sees the cockpit row
+              (totals → short-horizon delta → long-horizon trajectory)
+              before scrolling into the action queue. */}
+          <PortfolioValueChart />
           <Section title="Positions">
             {portfolio.loading ? (
               <SectionSkeleton rows={4} />

--- a/tests/test_api_portfolio_value_history.py
+++ b/tests/test_api_portfolio_value_history.py
@@ -37,7 +37,7 @@ def _make_conn(
     `fetchall_per_cursor` holds rows for cursors 2 and 3; the first
     cursor's fetchone uses `start_date_row` or a sane default that
     predates every fixture in this file."""
-    cursor_1 = {"fetchone": start_date_row or _DEFAULT_START}
+    start_row = start_date_row or _DEFAULT_START
     fetchalls = iter(fetchall_per_cursor)
     cursor_idx = [0]
 
@@ -46,7 +46,7 @@ def _make_conn(
         cur.__enter__.return_value = cur
         cur.__exit__.return_value = None
         if cursor_idx[0] == 0:
-            cur.fetchone.return_value = cursor_1["fetchone"]
+            cur.fetchone.return_value = start_row
         else:
             cur.fetchall.return_value = next(fetchalls)
         cursor_idx[0] += 1

--- a/tests/test_api_portfolio_value_history.py
+++ b/tests/test_api_portfolio_value_history.py
@@ -285,6 +285,63 @@ def test_value_history_fx_skipped_counts_distinct_pairs_not_rows(
     assert body["fx_skipped"] == 1  # one pair (USD→GBP), not three rows
 
 
+def test_value_history_max_reports_effective_days_from_point_span(
+    client: TestClient,
+) -> None:
+    """range=max sends NULL days to SQL (letting the query start from
+    the earliest ledger row); the endpoint should report the actual
+    span from first to last point as `days`, not a hard-coded ceiling.
+    Pins that `max` is no longer a silent duplicate of `5y`."""
+    from app.db import get_conn
+
+    def _conn() -> Iterator[MagicMock]:
+        yield _make_conn(
+            [
+                # Three dates roughly ~2 years apart — exercises the
+                # span-computation branch.
+                [
+                    {
+                        "point_date": date(2024, 4, 20),
+                        "instrument_id": 1,
+                        "native_currency": "GBP",
+                        "units_at_date": Decimal("10"),
+                        "close_at_date": Decimal("100"),
+                    },
+                    {
+                        "point_date": date(2026, 4, 20),
+                        "instrument_id": 1,
+                        "native_currency": "GBP",
+                        "units_at_date": Decimal("10"),
+                        "close_at_date": Decimal("110"),
+                    },
+                ],
+                [],
+            ]
+        )
+
+    app.dependency_overrides[get_conn] = _conn
+    try:
+        with (
+            patch(
+                "app.api.portfolio.get_runtime_config",
+                return_value=_runtime_stub("GBP"),
+            ),
+            patch(
+                "app.api.portfolio.load_live_fx_rates_with_metadata",
+                return_value={},
+            ),
+        ):
+            resp = client.get("/portfolio/value-history?range=max")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    body = resp.json()
+    assert body["range"] == "max"
+    # 2024-04-20 → 2026-04-20 = ~730 days (with leap year).
+    assert body["days"] in (730, 731)
+    assert [p["date"] for p in body["points"]] == ["2024-04-20", "2026-04-20"]
+
+
 def test_value_history_fx_missing_skips_cash_event(client: TestClient) -> None:
     """Cash in a currency with no live FX rate is logged-and-skipped,
     not a 500. Keeps the endpoint resilient to partial FX coverage."""

--- a/tests/test_api_portfolio_value_history.py
+++ b/tests/test_api_portfolio_value_history.py
@@ -1,0 +1,266 @@
+"""Tests for GET /portfolio/value-history (#204)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _make_conn(fetchall_per_cursor: list[list[dict[str, object]]]) -> MagicMock:
+    """Conn with one cursor per `conn.cursor()` call, each pre-loaded
+    with `fetchall_per_cursor[i]` as rows. The value-history endpoint
+    opens TWO cursors (positions + cash) in sequence."""
+    cursors = iter(fetchall_per_cursor)
+
+    def _next(*_a: object, **_k: object) -> MagicMock:
+        cur = MagicMock()
+        cur.__enter__.return_value = cur
+        cur.__exit__.return_value = None
+        cur.fetchall.return_value = next(cursors)
+        return cur
+
+    conn = MagicMock()
+    conn.cursor.side_effect = _next
+    return conn
+
+
+def _runtime_stub(currency: str = "GBP") -> MagicMock:
+    rt = MagicMock()
+    rt.display_currency = currency
+    return rt
+
+
+def test_value_history_sums_positions_and_cash_per_day(client: TestClient) -> None:
+    """Two dates × (one GBP position + one cash event) — values sum
+    per date in display currency."""
+    from app.db import get_conn
+
+    def _conn() -> Iterator[MagicMock]:
+        yield _make_conn(
+            [
+                # positions: units=10 @ close=100 on d1, 10 @ 110 on d2
+                [
+                    {
+                        "point_date": date(2026, 4, 19),
+                        "instrument_id": 1,
+                        "native_currency": "GBP",
+                        "units_at_date": Decimal("10"),
+                        "close_at_date": Decimal("100"),
+                    },
+                    {
+                        "point_date": date(2026, 4, 20),
+                        "instrument_id": 1,
+                        "native_currency": "GBP",
+                        "units_at_date": Decimal("10"),
+                        "close_at_date": Decimal("110"),
+                    },
+                ],
+                # cash: £500 cumulative on both dates
+                [
+                    {"point_date": date(2026, 4, 19), "currency": "GBP", "balance": Decimal("500")},
+                    {"point_date": date(2026, 4, 20), "currency": "GBP", "balance": Decimal("500")},
+                ],
+            ]
+        )
+
+    app.dependency_overrides[get_conn] = _conn
+    try:
+        with (
+            patch(
+                "app.api.portfolio.get_runtime_config",
+                return_value=_runtime_stub("GBP"),
+            ),
+            patch(
+                "app.api.portfolio.load_live_fx_rates_with_metadata",
+                return_value={},
+            ),
+        ):
+            resp = client.get("/portfolio/value-history?range=1m")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["display_currency"] == "GBP"
+    assert body["range"] == "1m"
+    assert body["fx_mode"] == "live"
+    # Day 1: 10×100 + 500 = 1500.  Day 2: 10×110 + 500 = 1600.
+    assert body["points"] == [
+        {"date": "2026-04-19", "value": 1500.0},
+        {"date": "2026-04-20", "value": 1600.0},
+    ]
+
+
+def test_value_history_fx_converts_native_positions(client: TestClient) -> None:
+    """USD position → display currency GBP at the live rate. Covers the
+    FX path for both positions and cash."""
+    from app.db import get_conn
+
+    def _conn() -> Iterator[MagicMock]:
+        yield _make_conn(
+            [
+                # 100 USD worth of position on a single day
+                [
+                    {
+                        "point_date": date(2026, 4, 20),
+                        "instrument_id": 1,
+                        "native_currency": "USD",
+                        "units_at_date": Decimal("1"),
+                        "close_at_date": Decimal("100"),
+                    },
+                ],
+                # $200 cash on the same day
+                [
+                    {"point_date": date(2026, 4, 20), "currency": "USD", "balance": Decimal("200")},
+                ],
+            ]
+        )
+
+    app.dependency_overrides[get_conn] = _conn
+    try:
+        with (
+            patch(
+                "app.api.portfolio.get_runtime_config",
+                return_value=_runtime_stub("GBP"),
+            ),
+            patch(
+                "app.api.portfolio.load_live_fx_rates_with_metadata",
+                return_value={
+                    ("USD", "GBP"): {
+                        "rate": Decimal("0.80"),
+                        "quoted_at": "2026-04-21T00:00:00Z",
+                    }
+                },
+            ),
+        ):
+            resp = client.get("/portfolio/value-history?range=1m")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    body = resp.json()
+    # 100 USD × 0.80 = 80 GBP; 200 USD × 0.80 = 160 GBP; sum = 240.
+    assert body["points"] == [{"date": "2026-04-20", "value": 240.0}]
+
+
+def test_value_history_skips_position_days_without_prior_close(client: TestClient) -> None:
+    """If `close_at_date` is NULL (no price on or before), that position
+    contributes nothing rather than being treated as worth zero."""
+    from app.db import get_conn
+
+    def _conn() -> Iterator[MagicMock]:
+        yield _make_conn(
+            [
+                # Day 1 has no close_at_date; day 2 has one
+                [
+                    {
+                        "point_date": date(2026, 4, 19),
+                        "instrument_id": 1,
+                        "native_currency": "GBP",
+                        "units_at_date": Decimal("10"),
+                        "close_at_date": None,
+                    },
+                    {
+                        "point_date": date(2026, 4, 20),
+                        "instrument_id": 1,
+                        "native_currency": "GBP",
+                        "units_at_date": Decimal("10"),
+                        "close_at_date": Decimal("100"),
+                    },
+                ],
+                # No cash rows
+                [],
+            ]
+        )
+
+    app.dependency_overrides[get_conn] = _conn
+    try:
+        with (
+            patch(
+                "app.api.portfolio.get_runtime_config",
+                return_value=_runtime_stub("GBP"),
+            ),
+            patch(
+                "app.api.portfolio.load_live_fx_rates_with_metadata",
+                return_value={},
+            ),
+        ):
+            resp = client.get("/portfolio/value-history?range=1m")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    body = resp.json()
+    # Day 1 skipped entirely because no close — not an artifact zero,
+    # not present in the series.
+    assert body["points"] == [{"date": "2026-04-20", "value": 1000.0}]
+
+
+def test_value_history_rejects_unknown_range(client: TestClient) -> None:
+    """Unknown range → FastAPI 422 from the `Literal` param validator.
+    Pins that we don't silently default to '1y' on unexpected input.
+    Overrides get_conn with a noop since dep resolution runs alongside
+    param validation in FastAPI."""
+    from app.db import get_conn
+
+    def _conn() -> Iterator[MagicMock]:
+        yield MagicMock()
+
+    app.dependency_overrides[get_conn] = _conn
+    try:
+        resp = client.get("/portfolio/value-history?range=2y")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+    assert resp.status_code == 422
+
+
+def test_value_history_fx_missing_skips_cash_event(client: TestClient) -> None:
+    """Cash in a currency with no live FX rate is logged-and-skipped,
+    not a 500. Keeps the endpoint resilient to partial FX coverage."""
+    from app.db import get_conn
+
+    def _conn() -> Iterator[MagicMock]:
+        yield _make_conn(
+            [
+                # No positions
+                [],
+                # Cash in EUR; no EUR→GBP rate loaded
+                [
+                    {"point_date": date(2026, 4, 20), "currency": "EUR", "balance": Decimal("100")},
+                ],
+            ]
+        )
+
+    app.dependency_overrides[get_conn] = _conn
+    try:
+        with (
+            patch(
+                "app.api.portfolio.get_runtime_config",
+                return_value=_runtime_stub("GBP"),
+            ),
+            patch(
+                "app.api.portfolio.load_live_fx_rates_with_metadata",
+                return_value={},
+            ),
+        ):
+            resp = client.get("/portfolio/value-history?range=1m")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    # Request succeeds; EUR cash skipped; no points emitted for that
+    # day, but fx_skipped counts the drop so the FE can distinguish
+    # "empty series due to missing FX" from "truly no history".
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["points"] == []
+    assert body["fx_skipped"] == 1

--- a/tests/test_api_portfolio_value_history.py
+++ b/tests/test_api_portfolio_value_history.py
@@ -18,17 +18,38 @@ def client() -> TestClient:
     return TestClient(app)
 
 
-def _make_conn(fetchall_per_cursor: list[list[dict[str, object]]]) -> MagicMock:
-    """Conn with one cursor per `conn.cursor()` call, each pre-loaded
-    with `fetchall_per_cursor[i]` as rows. The value-history endpoint
-    opens TWO cursors (positions + cash) in sequence."""
-    cursors = iter(fetchall_per_cursor)
+_DEFAULT_START = {"start_date": date(2020, 1, 1)}
+
+
+def _make_conn(
+    fetchall_per_cursor: list[list[dict[str, object]]],
+    *,
+    start_date_row: dict[str, object] | None = None,
+) -> MagicMock:
+    """Conn with one cursor per `conn.cursor()` call.
+
+    The value-history endpoint opens three cursors in sequence:
+        1. start-date resolution (`cur.fetchone()` returns a dict
+           with `start_date`)
+        2. positions query (`cur.fetchall()` returns position rows)
+        3. cash query (`cur.fetchall()` returns cash rows)
+
+    `fetchall_per_cursor` holds rows for cursors 2 and 3; the first
+    cursor's fetchone uses `start_date_row` or a sane default that
+    predates every fixture in this file."""
+    cursor_1 = {"fetchone": start_date_row or _DEFAULT_START}
+    fetchalls = iter(fetchall_per_cursor)
+    cursor_idx = [0]
 
     def _next(*_a: object, **_k: object) -> MagicMock:
         cur = MagicMock()
         cur.__enter__.return_value = cur
         cur.__exit__.return_value = None
-        cur.fetchall.return_value = next(cursors)
+        if cursor_idx[0] == 0:
+            cur.fetchone.return_value = cursor_1["fetchone"]
+        else:
+            cur.fetchall.return_value = next(fetchalls)
+        cursor_idx[0] += 1
         return cur
 
     conn = MagicMock()
@@ -285,6 +306,44 @@ def test_value_history_fx_skipped_counts_distinct_pairs_not_rows(
     assert body["fx_skipped"] == 1  # one pair (USD→GBP), not three rows
 
 
+def test_value_history_max_empty_ledger_returns_days_zero(
+    client: TestClient,
+) -> None:
+    """range=max on an empty ledger → start_date defaults to today,
+    generate_series produces a single row, nothing to price → empty
+    points + days=0. Pins the contract so FE can trust days=0 ==
+    'no history', not 'couldn't compute'."""
+    from app.db import get_conn
+
+    def _conn() -> Iterator[MagicMock]:
+        # Custom start_date_row: the COALESCE in the start-date query
+        # produces CURRENT_DATE when both ledgers are empty.
+        yield _make_conn(
+            [[], []],
+            start_date_row={"start_date": date(2026, 4, 21)},
+        )
+
+    app.dependency_overrides[get_conn] = _conn
+    try:
+        with (
+            patch(
+                "app.api.portfolio.get_runtime_config",
+                return_value=_runtime_stub("GBP"),
+            ),
+            patch(
+                "app.api.portfolio.load_live_fx_rates_with_metadata",
+                return_value={},
+            ),
+        ):
+            resp = client.get("/portfolio/value-history?range=max")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    body = resp.json()
+    assert body["points"] == []
+    assert body["days"] == 0
+
+
 def test_value_history_max_reports_effective_days_from_point_span(
     client: TestClient,
 ) -> None:
@@ -337,8 +396,9 @@ def test_value_history_max_reports_effective_days_from_point_span(
 
     body = resp.json()
     assert body["range"] == "max"
-    # 2024-04-20 → 2026-04-20 = ~730 days (with leap year).
-    assert body["days"] in (730, 731)
+    # Exact span from first to last point — kept computed, not hard-
+    # coded, so a future schema/semantics change surfaces here.
+    assert body["days"] == (date(2026, 4, 20) - date(2024, 4, 20)).days
     assert [p["date"] for p in body["points"]] == ["2024-04-20", "2026-04-20"]
 
 

--- a/tests/test_api_portfolio_value_history.py
+++ b/tests/test_api_portfolio_value_history.py
@@ -224,6 +224,67 @@ def test_value_history_rejects_unknown_range(client: TestClient) -> None:
     assert resp.status_code == 422
 
 
+def test_value_history_fx_skipped_counts_distinct_pairs_not_rows(
+    client: TestClient,
+) -> None:
+    """A single missing pair dropping many rows must surface as
+    fx_skipped=1, not len(rows) — keeps the operator-facing count
+    interpretable when a gap spans an entire series."""
+    from app.db import get_conn
+
+    def _conn() -> Iterator[MagicMock]:
+        yield _make_conn(
+            [
+                # 3 days × same USD instrument → 3 rows, all dropping on
+                # the same USD→GBP pair.
+                [
+                    {
+                        "point_date": date(2026, 4, 18),
+                        "instrument_id": 1,
+                        "native_currency": "USD",
+                        "units_at_date": Decimal("1"),
+                        "close_at_date": Decimal("100"),
+                    },
+                    {
+                        "point_date": date(2026, 4, 19),
+                        "instrument_id": 1,
+                        "native_currency": "USD",
+                        "units_at_date": Decimal("1"),
+                        "close_at_date": Decimal("100"),
+                    },
+                    {
+                        "point_date": date(2026, 4, 20),
+                        "instrument_id": 1,
+                        "native_currency": "USD",
+                        "units_at_date": Decimal("1"),
+                        "close_at_date": Decimal("100"),
+                    },
+                ],
+                # No cash rows
+                [],
+            ]
+        )
+
+    app.dependency_overrides[get_conn] = _conn
+    try:
+        with (
+            patch(
+                "app.api.portfolio.get_runtime_config",
+                return_value=_runtime_stub("GBP"),
+            ),
+            patch(
+                "app.api.portfolio.load_live_fx_rates_with_metadata",
+                return_value={},
+            ),
+        ):
+            resp = client.get("/portfolio/value-history?range=1m")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    body = resp.json()
+    assert body["fx_skipped"] == 1  # one pair (USD→GBP), not three rows
+
+
 def test_value_history_fx_missing_skips_cash_event(client: TestClient) -> None:
     """Cash in a currency with no live FX rate is logged-and-skipped,
     not a 500. Keeps the endpoint resilient to partial FX coverage."""
@@ -257,9 +318,10 @@ def test_value_history_fx_missing_skips_cash_event(client: TestClient) -> None:
     finally:
         app.dependency_overrides.pop(get_conn, None)
 
-    # Request succeeds; EUR cash skipped; no points emitted for that
-    # day, but fx_skipped counts the drop so the FE can distinguish
-    # "empty series due to missing FX" from "truly no history".
+    # Request succeeds; EUR cash skipped; no points emitted. fx_skipped
+    # counts distinct pairs (one: EUR→GBP), not the number of rows
+    # dropped — a 365-day gap on one pair must read as "1 pair missing"
+    # not "365 rows missing" for the FE copy to stay meaningful.
     assert resp.status_code == 200
     body = resp.json()
     assert body["points"] == []


### PR DESCRIPTION
## Summary
- New endpoint: \`GET /portfolio/value-history?range=1m|3m|6m|1y|5y|max\` returning daily NAV = \`sum(signed_units × price_daily.close) + cash_ledger\` converted to display currency via live FX.
- Literal-typed range param — FastAPI returns 422 on unknown input before the DB dep runs.
- New component: \`PortfolioValueChart\` using lightweight-charts area series, URL-synced via \`?value=\`, mounts on the dashboard under \`RollingPnlStrip\`.
- \`fx_skipped\` counter in the response surfaces the difference between "no data" and "all-skipped due to missing FX" — Codex round-1 finding fixed before first push.

## Scope limits (documented in code + \`fx_mode\` field)
- **Historical FX**: today's live rate applied to all past dates. \`sql/013\` \`fx_rates\` is populated only on tax-event dates — too sparse for a daily series. Separate ticket needed.
- **No mirror equity**: only directly-held positions + cash. Mirror equity has no historical trace.
- **SQL scaling**: the \`dates × fills\` / \`dates × cash_ledger\` inequality joins scan the ledgers per day. Acceptable at MVP ledger size; will need indexes (probably expression indexes on \`filled_at::date\` and \`event_time::date\`) before large accounts touch this. Deferring to follow-up.

## Test plan
- [x] \`uv run pytest tests/test_api_portfolio_value_history.py tests/smoke/test_app_boots.py\` — 6 pass
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm exec vitest run src/components/dashboard/PortfolioValueChart.test.tsx\` — 7 tests pass (incl. fx_skipped empty state + chart.remove() on unmount)
- [ ] Hit dashboard, flip ranges, confirm area-chart renders + hover tooltip shows value in display currency
- [ ] Provoke an FX miss (disable an FX pair, or use a portfolio with a currency not in \`live_fx_rates\`) → confirm "FX rates missing" empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)