### PR TITLE
feat(#315): Phase 3 — guard-rejection alerts strip

### DIFF
--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -74,12 +74,60 @@ def _resolve_operator(conn: psycopg.Connection[object]) -> UUID:
 def get_guard_rejections(
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> GuardRejectionsResponse:
-    _operator_id = _resolve_operator(conn)  # used in Task 3 query
-    # Implementation in Task 3.
+    operator_id = _resolve_operator(conn)
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # 1. Read operator's cursor.
+        cur.execute(
+            "SELECT alerts_last_seen_decision_id FROM operators WHERE operator_id = %(op)s",
+            {"op": operator_id},
+        )
+        op_row = cur.fetchone()
+        last_seen: int | None = op_row["alerts_last_seen_decision_id"] if op_row else None
+
+        # 2. Count unseen in-window rows (uncapped).
+        cur.execute(
+            """
+            SELECT COUNT(*) AS unseen_count
+            FROM decision_audit
+            WHERE pass_fail = 'FAIL'
+              AND stage = 'execution_guard'
+              AND decision_time >= now() - INTERVAL '7 days'
+              AND (%(last_id)s IS NULL OR decision_id > %(last_id)s)
+            """,
+            {"last_id": last_seen},
+        )
+        count_row = cur.fetchone()
+        unseen_count: int = int(count_row["unseen_count"]) if count_row else 0
+
+        # 3. Fetch the list (capped at 500). Ordering is by decision_id DESC
+        # (the PK sequence), not decision_time DESC — decision_time is app-supplied
+        # via _utcnow() and can be clock-skewed, which would break the invariant
+        # that rejections[0].decision_id === MAX(decision_id).
+        cur.execute(
+            """
+            SELECT
+                da.decision_id,
+                da.decision_time,
+                da.instrument_id,
+                i.symbol,
+                tr.action,
+                da.explanation
+            FROM decision_audit da
+            LEFT JOIN instruments i ON i.instrument_id = da.instrument_id
+            LEFT JOIN trade_recommendations tr ON tr.recommendation_id = da.recommendation_id
+            WHERE da.pass_fail = 'FAIL'
+              AND da.stage = 'execution_guard'
+              AND da.decision_time >= now() - INTERVAL '7 days'
+            ORDER BY da.decision_id DESC
+            LIMIT 500
+            """
+        )
+        rows = cur.fetchall()
+
     return GuardRejectionsResponse(
-        alerts_last_seen_decision_id=None,
-        unseen_count=0,
-        rejections=[],
+        alerts_last_seen_decision_id=last_seen,
+        unseen_count=unseen_count,
+        rejections=[GuardRejection.model_validate(r) for r in rows],
     )
 
 

--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -137,8 +137,32 @@ def mark_seen(
     body: MarkSeenRequest,
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> None:
-    _operator_id = _resolve_operator(conn)  # used in Task 4 UPDATE
-    # Implementation in Task 4.
+    operator_id = _resolve_operator(conn)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE operators
+            SET alerts_last_seen_decision_id = GREATEST(
+                COALESCE(alerts_last_seen_decision_id, 0),
+                LEAST(
+                    %(seen_through_decision_id)s,
+                    COALESCE((
+                        SELECT MAX(decision_id)
+                        FROM decision_audit
+                        WHERE pass_fail = 'FAIL'
+                          AND stage = 'execution_guard'
+                          AND decision_time >= now() - INTERVAL '7 days'
+                    ), 0)
+                )
+            )
+            WHERE operator_id = %(op)s
+            """,
+            {
+                "seen_through_decision_id": body.seen_through_decision_id,
+                "op": operator_id,
+            },
+        )
+    conn.commit()
 
 
 @router.post("/dismiss-all", status_code=status.HTTP_204_NO_CONTENT)

--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -97,7 +97,8 @@ def get_guard_rejections(
             {"last_id": last_seen},
         )
         count_row = cur.fetchone()
-        unseen_count: int = int(count_row["unseen_count"]) if count_row else 0
+        assert count_row is not None, "COUNT(*) always returns a row"
+        unseen_count: int = int(count_row["unseen_count"])
 
         # 3. Fetch the list (capped at 500). Ordering is by decision_id DESC
         # (the PK sequence), not decision_time DESC — decision_time is app-supplied

--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -169,5 +169,25 @@ def mark_seen(
 def dismiss_all(
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> None:
-    _operator_id = _resolve_operator(conn)  # used in Task 5 UPDATE
-    # Implementation in Task 5.
+    operator_id = _resolve_operator(conn)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE operators AS op
+            SET alerts_last_seen_decision_id = GREATEST(
+                COALESCE(op.alerts_last_seen_decision_id, 0),
+                m.max_id
+            )
+            FROM (
+                SELECT MAX(decision_id) AS max_id
+                FROM decision_audit
+                WHERE pass_fail = 'FAIL'
+                  AND stage = 'execution_guard'
+                  AND decision_time >= now() - INTERVAL '7 days'
+            ) AS m
+            WHERE op.operator_id = %(op)s
+              AND m.max_id IS NOT NULL
+            """,
+            {"op": operator_id},
+        )
+    conn.commit()

--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -74,7 +74,7 @@ def _resolve_operator(conn: psycopg.Connection[object]) -> UUID:
 def get_guard_rejections(
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> GuardRejectionsResponse:
-    _resolve_operator(conn)
+    _operator_id = _resolve_operator(conn)  # used in Task 3 query
     # Implementation in Task 3.
     return GuardRejectionsResponse(
         alerts_last_seen_decision_id=None,
@@ -88,7 +88,7 @@ def mark_seen(
     body: MarkSeenRequest,
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> None:
-    _resolve_operator(conn)
+    _operator_id = _resolve_operator(conn)  # used in Task 4 UPDATE
     # Implementation in Task 4.
 
 
@@ -96,5 +96,5 @@ def mark_seen(
 def dismiss_all(
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> None:
-    _resolve_operator(conn)
+    _operator_id = _resolve_operator(conn)  # used in Task 5 UPDATE
     # Implementation in Task 5.

--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -1,0 +1,100 @@
+"""Alerts API (#315 Phase 3).
+
+Guard-rejection alerts strip. Scope is intentionally narrow — this is
+the execution-guard read surface only. Thesis breaches (#394) and
+filings-status drops (#395) are deferred; #396 wires them into the
+same strip once their event persistence lands.
+
+Cursor model: operators.alerts_last_seen_decision_id (BIGINT). See
+``docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md``
+for why a decision_id cursor rather than decision_time.
+
+Routes:
+  GET  /alerts/guard-rejections   — 7-day window, 500-row cap, ORDER BY decision_id DESC
+  POST /alerts/seen               — body {seen_through_decision_id}, monotonic GREATEST + LEAST clamp
+  POST /alerts/dismiss-all        — no body, atomic MAX-in-window advance, no-op on empty window
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+import psycopg
+import psycopg.rows
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from app.api.auth import require_session_or_service_token
+from app.db import get_conn
+from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
+
+router = APIRouter(
+    prefix="/alerts",
+    tags=["alerts"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+GuardAction = Literal["BUY", "ADD", "HOLD", "EXIT"]
+
+
+class GuardRejection(BaseModel):
+    decision_id: int
+    decision_time: datetime
+    instrument_id: int | None
+    symbol: str | None
+    action: GuardAction | None
+    explanation: str
+
+
+class GuardRejectionsResponse(BaseModel):
+    alerts_last_seen_decision_id: int | None
+    unseen_count: int
+    rejections: list[GuardRejection]
+
+
+class MarkSeenRequest(BaseModel):
+    seen_through_decision_id: int = Field(gt=0)
+
+
+def _resolve_operator(conn: psycopg.Connection[object]) -> UUID:
+    try:
+        return sole_operator_id(conn)
+    except NoOperatorError as exc:
+        raise HTTPException(status_code=503, detail="no operator configured") from exc
+    except AmbiguousOperatorError as exc:
+        raise HTTPException(
+            status_code=501,
+            detail="multiple operators present — alerts require a per-session operator context",
+        ) from exc
+
+
+@router.get("/guard-rejections", response_model=GuardRejectionsResponse)
+def get_guard_rejections(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> GuardRejectionsResponse:
+    _resolve_operator(conn)
+    # Implementation in Task 3.
+    return GuardRejectionsResponse(
+        alerts_last_seen_decision_id=None,
+        unseen_count=0,
+        rejections=[],
+    )
+
+
+@router.post("/seen", status_code=status.HTTP_204_NO_CONTENT)
+def mark_seen(
+    body: MarkSeenRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    _resolve_operator(conn)
+    # Implementation in Task 4.
+
+
+@router.post("/dismiss-all", status_code=status.HTTP_204_NO_CONTENT)
+def dismiss_all(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    _resolve_operator(conn)
+    # Implementation in Task 5.

--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -92,7 +92,7 @@ def get_guard_rejections(
             WHERE pass_fail = 'FAIL'
               AND stage = 'execution_guard'
               AND decision_time >= now() - INTERVAL '7 days'
-              AND (%(last_id)s IS NULL OR decision_id > %(last_id)s)
+              AND (%(last_id)s::BIGINT IS NULL OR decision_id > %(last_id)s::BIGINT)
             """,
             {"last_id": last_seen},
         )

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse
 from psycopg_pool import ConnectionPool
 from pydantic import BaseModel, Field
 
+from app.api.alerts import router as alerts_router
 from app.api.attribution import router as attribution_router
 from app.api.audit import router as audit_router
 from app.api.auth import require_session_or_service_token
@@ -154,6 +155,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 
 app = FastAPI(title="eBull", version="0.1.0", lifespan=lifespan)
+app.include_router(alerts_router)
 app.include_router(attribution_router)
 app.include_router(auth_setup_router)
 app.include_router(auth_bootstrap_router)

--- a/docs/superpowers/plans/2026-04-21-alerts-strip-guard-rejections.md
+++ b/docs/superpowers/plans/2026-04-21-alerts-strip-guard-rejections.md
@@ -1,0 +1,2022 @@
+# Alerts strip — guard rejections (#315 Phase 3) implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship #315 Phase 3: a guard-rejection alerts strip on the operator dashboard with a decision_id-cursor ack model, normal "Mark all read" and overflow "Dismiss all" paths.
+
+**Architecture:** One migration (`sql/044_operators_alerts_seen.sql`); one new FastAPI router (`app/api/alerts.py`) exposing `GET /alerts/guard-rejections`, `POST /alerts/seen`, `POST /alerts/dismiss-all`; one new React component (`frontend/src/components/dashboard/AlertsStrip.tsx`) wired into `DashboardPage.tsx` between `RollingPnlStrip` and `PortfolioValueChart`. Cursor is `operators.alerts_last_seen_decision_id BIGINT` — keyed off `decision_audit.decision_id` (BIGSERIAL) rather than timestamps to avoid clock-skew ordering holes and tie races.
+
+**Tech Stack:** Python 3.13, FastAPI, psycopg3, Pydantic v2, pytest, TypeScript, React 19, Vite, vitest, Tailwind, React Router v7.
+
+**Spec:** [docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md](../specs/2026-04-21-alerts-strip-guard-rejections.md)
+
+---
+
+## File structure
+
+**Create:**
+
+- `sql/044_operators_alerts_seen.sql` — migration: `operators.alerts_last_seen_decision_id BIGINT` column + partial index on `decision_audit (decision_time DESC) WHERE pass_fail='FAIL' AND stage='execution_guard'`.
+- `app/api/alerts.py` — FastAPI router with three endpoints, Pydantic response models, operator-scoped auth via `sole_operator_id`.
+- `tests/test_api_alerts.py` — backend tests: operator-resolution 503/501 (×2 endpoints), GET empty/row-shape/null-action/HOLD/SQL-shape/unseen-count-shape, POST /seen validation/monotonic/clamp/SQL-shape/503/501, POST /dismiss-all happy/scope/noop/503/501, plus four ebull_test integration tests (clock-skew ordering, clamp-to-MAX, empty-window no-op, non-guard exclusion).
+- `frontend/src/api/alerts.ts` — `fetchGuardRejections`, `markAlertsSeen`, `dismissAllAlerts`.
+- `frontend/src/components/dashboard/AlertsStrip.tsx` — strip component.
+- `frontend/src/components/dashboard/AlertsStrip.test.tsx` — 11 component tests.
+
+**Modify:**
+
+- `app/main.py` — register `alerts_router` in the alphabetised `include_router` block.
+- `frontend/src/api/types.ts` — add `GuardRejectionAction`, `GuardRejection`, `GuardRejectionsResponse` types.
+- `frontend/src/lib/format.ts` — add `formatRelativeTime(iso: string | null | undefined): string` helper.
+- `frontend/src/pages/DashboardPage.tsx` — mount `<AlertsStrip />` between `<RollingPnlStrip />` and `<PortfolioValueChart />`. Rationale: operator's reading flow is totals → short-horizon delta → **alerts requiring action** → long-horizon trajectory → positions. Alerts belong above the narrative chart because they are the "needs me now" surface. The component owns its own `useAsync(fetchGuardRejections)` for render-surface isolation (matches `RollingPnlStrip`); no page-level fetch is added.
+
+All work lands on `feature/315-phase3-alerts-strip`. The spec commit is already on that branch.
+
+---
+
+## Task 1: Migration 044 — schema
+
+**Files:**
+
+- Create: `sql/044_operators_alerts_seen.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Migration 044: operator-scoped alert acknowledgement + guard-rejection read index
+--
+-- 1. operators.alerts_last_seen_decision_id — NULL = never acknowledged (all in-window rows unseen).
+--    Integer cursor keyed off decision_audit.decision_id (BIGSERIAL, unique).
+--    Timestamp-based cursor was rejected: decision_time is TIMESTAMPTZ (microsecond resolution,
+--    NOT unique under load), which leaves a tie-break race where a row inserted between GET
+--    and POST at the same decision_time as rejections[0] would be silently acked. decision_id
+--    is monotonic for the guard stage (single-threaded scheduler invocations; no concurrent
+--    writers), so a strict > comparison fully closes the race.
+-- 2. Partial index on decision_audit supports the dashboard GET scan.
+--    Narrowed to stage='execution_guard' + pass_fail='FAIL' because
+--    (a) the /alerts endpoint filters on both, (b) other stages write to
+--    decision_audit (e.g. order_execution, deferred_retry) and must not
+--    be indexed as guard rejections.
+
+ALTER TABLE operators
+    ADD COLUMN IF NOT EXISTS alerts_last_seen_decision_id BIGINT;
+
+CREATE INDEX IF NOT EXISTS idx_decision_audit_guard_failed_recent
+    ON decision_audit (decision_time DESC)
+    WHERE pass_fail = 'FAIL' AND stage = 'execution_guard';
+```
+
+- [ ] **Step 2: Apply the migration against the dev DB**
+
+Run: `psql "$DATABASE_URL" -f sql/044_operators_alerts_seen.sql`
+Expected: two `ALTER/CREATE` notices; exit code 0. Re-running is a no-op (both `IF NOT EXISTS`).
+
+- [ ] **Step 3: Verify the column and index exist**
+
+Run:
+
+```bash
+psql "$DATABASE_URL" -c "\d operators" | grep alerts_last_seen_decision_id
+psql "$DATABASE_URL" -c "\d decision_audit" | grep idx_decision_audit_guard_failed_recent
+```
+
+Expected: each grep returns one line.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sql/044_operators_alerts_seen.sql
+git commit -m "feat(#315): migration 044 — alerts_last_seen_decision_id + guard-failed index"
+```
+
+---
+
+## Task 2: Pydantic models and router skeleton
+
+**Files:**
+
+- Create: `app/api/alerts.py`
+- Modify: `app/main.py`
+
+- [ ] **Step 1: Write the failing test — router is mounted and returns 503 when no operator exists**
+
+Create `tests/test_api_alerts.py`:
+
+```python
+"""Tests for the alerts API (#315 Phase 3)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.operators import AmbiguousOperatorError, NoOperatorError
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def cleanup() -> Iterator[None]:
+    yield
+    from app.db import get_conn
+
+    app.dependency_overrides.pop(get_conn, None)
+
+
+def _install_conn(
+    fetchone_returns: list[object] | None = None,
+    fetchall_returns: list[object] | None = None,
+    rowcount: int = 1,
+) -> MagicMock:
+    """Stub DB whose cursor feeds fetchone/fetchall in the order supplied."""
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.__enter__.return_value = cur
+    cur.__exit__.return_value = None
+    if fetchone_returns is not None:
+        cur.fetchone.side_effect = list(fetchone_returns)
+    if fetchall_returns is not None:
+        cur.fetchall.return_value = fetchall_returns
+    cur.rowcount = rowcount
+    conn.cursor.return_value = cur
+    conn.commit = MagicMock()
+
+    def _dep() -> Iterator[MagicMock]:
+        yield conn
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _dep
+    return cur
+
+
+def test_get_returns_503_when_no_operator(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", side_effect=NoOperatorError()):
+        _install_conn()
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.status_code == 503
+
+
+def test_get_returns_501_when_multiple_operators(client: TestClient) -> None:
+    with patch(
+        "app.api.alerts.sole_operator_id",
+        side_effect=AmbiguousOperatorError(),
+    ):
+        _install_conn()
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.status_code == 501
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `uv run pytest tests/test_api_alerts.py -v`
+Expected: two tests collected, both FAIL (either 404 because the router isn't mounted, or ImportError on `app.api.alerts`).
+
+- [ ] **Step 3: Write the router skeleton**
+
+Create `app/api/alerts.py`:
+
+```python
+"""Alerts API (#315 Phase 3).
+
+Guard-rejection alerts strip. Scope is intentionally narrow — this is
+the execution-guard read surface only. Thesis breaches (#394) and
+filings-status drops (#395) are deferred; #396 wires them into the
+same strip once their event persistence lands.
+
+Cursor model: operators.alerts_last_seen_decision_id (BIGINT). See
+``docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md``
+for why a decision_id cursor rather than decision_time.
+
+Routes:
+  GET  /alerts/guard-rejections   — 7-day window, 500-row cap, ORDER BY decision_id DESC
+  POST /alerts/seen               — body {seen_through_decision_id}, monotonic GREATEST + LEAST clamp
+  POST /alerts/dismiss-all        — no body, atomic MAX-in-window advance, no-op on empty window
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+import psycopg
+import psycopg.rows
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from app.api.auth import require_session_or_service_token
+from app.db import get_conn
+from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
+
+router = APIRouter(
+    prefix="/alerts",
+    tags=["alerts"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+GuardAction = Literal["BUY", "ADD", "HOLD", "EXIT"]
+
+
+class GuardRejection(BaseModel):
+    decision_id: int
+    decision_time: datetime
+    instrument_id: int | None
+    symbol: str | None
+    action: GuardAction | None
+    explanation: str
+
+
+class GuardRejectionsResponse(BaseModel):
+    alerts_last_seen_decision_id: int | None
+    unseen_count: int
+    rejections: list[GuardRejection]
+
+
+class MarkSeenRequest(BaseModel):
+    seen_through_decision_id: int = Field(gt=0)
+
+
+def _resolve_operator(conn: psycopg.Connection[object]) -> UUID:
+    try:
+        return sole_operator_id(conn)
+    except NoOperatorError as exc:
+        raise HTTPException(status_code=503, detail="no operator configured") from exc
+    except AmbiguousOperatorError as exc:
+        raise HTTPException(
+            status_code=501,
+            detail="multiple operators present — alerts require a per-session operator context",
+        ) from exc
+
+
+@router.get("/guard-rejections", response_model=GuardRejectionsResponse)
+def get_guard_rejections(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> GuardRejectionsResponse:
+    _resolve_operator(conn)
+    # Implementation in Task 3.
+    return GuardRejectionsResponse(
+        alerts_last_seen_decision_id=None,
+        unseen_count=0,
+        rejections=[],
+    )
+
+
+@router.post("/seen", status_code=status.HTTP_204_NO_CONTENT)
+def mark_seen(
+    body: MarkSeenRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    _resolve_operator(conn)
+    # Implementation in Task 4.
+
+
+@router.post("/dismiss-all", status_code=status.HTTP_204_NO_CONTENT)
+def dismiss_all(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    _resolve_operator(conn)
+    # Implementation in Task 5.
+```
+
+- [ ] **Step 4: Register the router**
+
+Edit `app/main.py`. Find the alphabetised import block (line ~14) and insert:
+
+```python
+from app.api.alerts import router as alerts_router
+```
+
+Find the `include_router` block (line ~157) and insert in alphabetical order (before `attribution_router`):
+
+```python
+app.include_router(alerts_router)
+```
+
+- [ ] **Step 5: Run the tests and verify they pass**
+
+Run: `uv run pytest tests/test_api_alerts.py -v`
+Expected: both tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/alerts.py app/main.py tests/test_api_alerts.py
+git commit -m "feat(#315): alerts router skeleton + 503/501 operator-resolution tests"
+```
+
+---
+
+## Task 3: `GET /alerts/guard-rejections` — tests + implementation
+
+**Files:**
+
+- Modify: `tests/test_api_alerts.py`
+- Modify: `app/api/alerts.py`
+
+- [ ] **Step 1: Add failing tests — empty state, row shape, unseen_count anchor, ordering**
+
+Append to `tests/test_api_alerts.py`:
+
+```python
+_OP_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+def _rejection_row(
+    *,
+    decision_id: int,
+    decision_time: datetime | None = None,
+    instrument_id: int | None = 42,
+    symbol: str | None = "AAPL",
+    action: str | None = "BUY",
+    explanation: str = "FAIL — cash_available: need £200, have £50",
+) -> dict[str, object]:
+    return {
+        "decision_id": decision_id,
+        "decision_time": decision_time or datetime(2026, 4, 21, tzinfo=timezone.utc),
+        "instrument_id": instrument_id,
+        "symbol": symbol,
+        "action": action,
+        "explanation": explanation,
+    }
+
+
+def test_get_empty_state(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        # fetchone #1 = operator's alerts_last_seen_decision_id (NULL)
+        # fetchone #2 = unseen_count (0)
+        _install_conn(
+            fetchone_returns=[{"alerts_last_seen_decision_id": None}, {"unseen_count": 0}],
+            fetchall_returns=[],
+        )
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {
+        "alerts_last_seen_decision_id": None,
+        "unseen_count": 0,
+        "rejections": [],
+    }
+
+
+def test_get_returns_row_shape_and_unseen_count(client: TestClient) -> None:
+    rows = [
+        _rejection_row(decision_id=501, action="BUY"),
+        _rejection_row(decision_id=500, action="ADD", symbol="MSFT", instrument_id=43),
+    ]
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_decision_id": 499},
+                {"unseen_count": 2},
+            ],
+            fetchall_returns=rows,
+        )
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["alerts_last_seen_decision_id"] == 499
+    assert body["unseen_count"] == 2
+    assert len(body["rejections"]) == 2
+    assert body["rejections"][0]["decision_id"] == 501
+    assert body["rejections"][0]["symbol"] == "AAPL"
+    assert body["rejections"][0]["action"] == "BUY"
+
+
+def test_get_null_instrument_and_action_serialise(client: TestClient) -> None:
+    rows = [
+        _rejection_row(decision_id=1, instrument_id=None, symbol=None, action=None),
+    ]
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_decision_id": None},
+                {"unseen_count": 1},
+            ],
+            fetchall_returns=rows,
+        )
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.status_code == 200
+    row = resp.json()["rejections"][0]
+    assert row["instrument_id"] is None
+    assert row["symbol"] is None
+    assert row["action"] is None
+
+
+def test_get_hold_action_round_trip(client: TestClient) -> None:
+    rows = [_rejection_row(decision_id=7, action="HOLD")]
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_decision_id": None},
+                {"unseen_count": 1},
+            ],
+            fetchall_returns=rows,
+        )
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.json()["rejections"][0]["action"] == "HOLD"
+
+
+def test_get_sql_shape_pins_window_and_scope_and_cap(client: TestClient) -> None:
+    """Pin SQL-shape invariants that the contract depends on:
+      - 7-day window filter (INTERVAL '7 days')
+      - pass_fail = 'FAIL' (uppercase) + stage = 'execution_guard'
+      - ORDER BY decision_id DESC (NOT decision_time DESC)
+      - LIMIT 500
+    """
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_decision_id": None},
+                {"unseen_count": 0},
+            ],
+            fetchall_returns=[],
+        )
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.status_code == 200
+    list_sql = next(
+        c.args[0]
+        for c in cur.execute.call_args_list
+        if "FROM decision_audit da" in c.args[0]
+    )
+    assert "pass_fail = 'FAIL'" in list_sql
+    assert "stage = 'execution_guard'" in list_sql
+    assert "INTERVAL '7 days'" in list_sql
+    assert "ORDER BY da.decision_id DESC" in list_sql
+    assert "LIMIT 500" in list_sql
+
+
+def test_get_unseen_count_query_uses_strict_gt_on_decision_id(client: TestClient) -> None:
+    """unseen_count query uses strict `decision_id > last_id` (race-safety)."""
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_decision_id": 100},
+                {"unseen_count": 3},
+            ],
+            fetchall_returns=[],
+        )
+        client.get("/alerts/guard-rejections")
+    count_sql = next(
+        c.args[0]
+        for c in cur.execute.call_args_list
+        if "SELECT COUNT(*)" in c.args[0]
+    )
+    # Strict `>` ties are structurally impossible on a unique PK.
+    assert "decision_id > %(last_id)s" in count_sql
+    # Filter matches list query so counts and rows agree.
+    assert "pass_fail = 'FAIL'" in count_sql
+    assert "stage = 'execution_guard'" in count_sql
+    assert "INTERVAL '7 days'" in count_sql
+    # NULL last-seen path counts everything in window.
+    assert "%(last_id)s IS NULL" in count_sql
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `uv run pytest tests/test_api_alerts.py -v`
+Expected: the four new tests FAIL (the stub returns an empty list and `unseen_count=0`; only `test_get_empty_state` passes by coincidence — the others fail because `rejections` is empty and fields don't match). `test_get_null_instrument_and_action_serialise` may pass if it also sees an empty list. That's OK — you still need the real query.
+
+- [ ] **Step 3: Implement the GET endpoint**
+
+In `app/api/alerts.py`, replace the `get_guard_rejections` body with:
+
+```python
+@router.get("/guard-rejections", response_model=GuardRejectionsResponse)
+def get_guard_rejections(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> GuardRejectionsResponse:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # 1. Read operator's cursor.
+        cur.execute(
+            "SELECT alerts_last_seen_decision_id FROM operators WHERE operator_id = %(op)s",
+            {"op": operator_id},
+        )
+        op_row = cur.fetchone()
+        last_seen: int | None = op_row["alerts_last_seen_decision_id"] if op_row else None
+
+        # 2. Count unseen in-window rows (uncapped).
+        cur.execute(
+            """
+            SELECT COUNT(*) AS unseen_count
+            FROM decision_audit
+            WHERE pass_fail = 'FAIL'
+              AND stage = 'execution_guard'
+              AND decision_time >= now() - INTERVAL '7 days'
+              AND (%(last_id)s IS NULL OR decision_id > %(last_id)s)
+            """,
+            {"last_id": last_seen},
+        )
+        count_row = cur.fetchone()
+        unseen_count: int = int(count_row["unseen_count"]) if count_row else 0
+
+        # 3. Fetch the list (capped at 500). Ordering is by decision_id DESC
+        # (the PK sequence), not decision_time DESC — decision_time is app-supplied
+        # via _utcnow() and can be clock-skewed, which would break the invariant
+        # that rejections[0].decision_id === MAX(decision_id).
+        cur.execute(
+            """
+            SELECT
+                da.decision_id,
+                da.decision_time,
+                da.instrument_id,
+                i.symbol,
+                tr.action,
+                da.explanation
+            FROM decision_audit da
+            LEFT JOIN instruments i ON i.instrument_id = da.instrument_id
+            LEFT JOIN trade_recommendations tr ON tr.recommendation_id = da.recommendation_id
+            WHERE da.pass_fail = 'FAIL'
+              AND da.stage = 'execution_guard'
+              AND da.decision_time >= now() - INTERVAL '7 days'
+            ORDER BY da.decision_id DESC
+            LIMIT 500
+            """
+        )
+        rows = cur.fetchall()
+
+    return GuardRejectionsResponse(
+        alerts_last_seen_decision_id=last_seen,
+        unseen_count=unseen_count,
+        rejections=[GuardRejection.model_validate(r) for r in rows],
+    )
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `uv run pytest tests/test_api_alerts.py -v`
+Expected: all seven tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/alerts.py tests/test_api_alerts.py
+git commit -m "feat(#315): GET /alerts/guard-rejections — 7d window, 500 cap, decision_id ordering"
+```
+
+---
+
+## Task 4: `POST /alerts/seen` — tests + implementation
+
+**Files:**
+
+- Modify: `tests/test_api_alerts.py`
+- Modify: `app/api/alerts.py`
+
+- [ ] **Step 1: Add failing tests — validation, monotonic, clamp**
+
+Append to `tests/test_api_alerts.py`:
+
+```python
+def test_post_seen_rejects_missing_field(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn()
+        resp = client.post("/alerts/seen", json={})
+    assert resp.status_code == 422
+
+
+def test_post_seen_rejects_non_integer(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn()
+        resp = client.post("/alerts/seen", json={"seen_through_decision_id": "abc"})
+    assert resp.status_code == 422
+
+
+def test_post_seen_rejects_non_positive(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn()
+        resp = client.post("/alerts/seen", json={"seen_through_decision_id": 0})
+    assert resp.status_code == 422
+
+
+def test_post_seen_writes_update(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(rowcount=1)
+        resp = client.post("/alerts/seen", json={"seen_through_decision_id": 1234})
+    assert resp.status_code == 204
+    # One UPDATE call was issued with the posted value.
+    calls = cur.execute.call_args_list
+    assert any("UPDATE operators" in c.args[0] for c in calls)
+    params = [c.args[1] for c in calls if "UPDATE operators" in c.args[0]][0]
+    assert params["seen_through_decision_id"] == 1234
+    assert params["op"] == _OP_ID
+
+
+def test_post_seen_sql_shape_pins_greatest_and_least_and_scope(client: TestClient) -> None:
+    """SQL must be: GREATEST(COALESCE(current, 0), LEAST(posted, MAX-in-window-or-0))
+    with MAX subselect filtered to FAIL + execution_guard + 7-day window."""
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(rowcount=1)
+        resp = client.post("/alerts/seen", json={"seen_through_decision_id": 99999})
+    assert resp.status_code == 204
+    sql = next(c.args[0] for c in cur.execute.call_args_list if "UPDATE operators" in c.args[0])
+    assert "GREATEST" in sql
+    assert "LEAST" in sql
+    assert "SELECT MAX(decision_id)" in sql
+    assert "pass_fail = 'FAIL'" in sql
+    assert "stage = 'execution_guard'" in sql
+    assert "INTERVAL '7 days'" in sql
+
+
+def test_post_seen_returns_503_when_no_operator(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", side_effect=NoOperatorError()):
+        _install_conn()
+        resp = client.post("/alerts/seen", json={"seen_through_decision_id": 1})
+    assert resp.status_code == 503
+
+
+def test_post_seen_returns_501_when_multiple_operators(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", side_effect=AmbiguousOperatorError()):
+        _install_conn()
+        resp = client.post("/alerts/seen", json={"seen_through_decision_id": 1})
+    assert resp.status_code == 501
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `uv run pytest tests/test_api_alerts.py -v -k post_seen`
+Expected: the validation tests pass (Pydantic handles those). `test_post_seen_writes_update` FAILS because the stub endpoint doesn't execute an UPDATE.
+
+- [ ] **Step 3: Implement the endpoint**
+
+In `app/api/alerts.py`, replace the `mark_seen` body with:
+
+```python
+@router.post("/seen", status_code=status.HTTP_204_NO_CONTENT)
+def mark_seen(
+    body: MarkSeenRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE operators
+            SET alerts_last_seen_decision_id = GREATEST(
+                COALESCE(alerts_last_seen_decision_id, 0),
+                LEAST(
+                    %(seen_through_decision_id)s,
+                    COALESCE((
+                        SELECT MAX(decision_id)
+                        FROM decision_audit
+                        WHERE pass_fail = 'FAIL'
+                          AND stage = 'execution_guard'
+                          AND decision_time >= now() - INTERVAL '7 days'
+                    ), 0)
+                )
+            )
+            WHERE operator_id = %(op)s
+            """,
+            {
+                "seen_through_decision_id": body.seen_through_decision_id,
+                "op": operator_id,
+            },
+        )
+    conn.commit()
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `uv run pytest tests/test_api_alerts.py -v`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/alerts.py tests/test_api_alerts.py
+git commit -m "feat(#315): POST /alerts/seen — monotonic GREATEST + LEAST clamp to in-window MAX"
+```
+
+---
+
+## Task 5: `POST /alerts/dismiss-all` — tests + implementation
+
+**Files:**
+
+- Modify: `tests/test_api_alerts.py`
+- Modify: `app/api/alerts.py`
+
+- [ ] **Step 1: Add failing tests — happy path, empty window no-op, non-guard excluded**
+
+Append to `tests/test_api_alerts.py`:
+
+```python
+def test_post_dismiss_all_issues_update(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(rowcount=1)
+        resp = client.post("/alerts/dismiss-all")
+    assert resp.status_code == 204
+    calls = cur.execute.call_args_list
+    assert any(
+        "UPDATE operators" in c.args[0] and "SELECT MAX(decision_id)" in c.args[0]
+        for c in calls
+    )
+
+
+def test_post_dismiss_all_filters_scope_to_guard_fails_in_window(client: TestClient) -> None:
+    # Inspect the SQL shape — scope is execution_guard + FAIL + 7-day window.
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(rowcount=1)
+        resp = client.post("/alerts/dismiss-all")
+    assert resp.status_code == 204
+    update_sql = next(
+        c.args[0] for c in cur.execute.call_args_list if "UPDATE operators" in c.args[0]
+    )
+    assert "pass_fail = 'FAIL'" in update_sql
+    assert "stage = 'execution_guard'" in update_sql
+    assert "INTERVAL '7 days'" in update_sql
+    assert "m.max_id IS NOT NULL" in update_sql
+
+
+def test_post_dismiss_all_is_noop_on_zero_rowcount(client: TestClient) -> None:
+    # rowcount=0 mimics the empty-window case (WHERE m.max_id IS NOT NULL excludes the row).
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(rowcount=0)
+        resp = client.post("/alerts/dismiss-all")
+    assert resp.status_code == 204  # No-op still returns 204.
+
+
+def test_post_dismiss_all_returns_503_when_no_operator(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", side_effect=NoOperatorError()):
+        _install_conn()
+        resp = client.post("/alerts/dismiss-all")
+    assert resp.status_code == 503
+
+
+def test_post_dismiss_all_returns_501_when_multiple_operators(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", side_effect=AmbiguousOperatorError()):
+        _install_conn()
+        resp = client.post("/alerts/dismiss-all")
+    assert resp.status_code == 501
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `uv run pytest tests/test_api_alerts.py -v -k dismiss_all`
+Expected: all three FAIL — the stub doesn't issue any UPDATE.
+
+- [ ] **Step 3: Implement the endpoint**
+
+In `app/api/alerts.py`, replace the `dismiss_all` body with:
+
+```python
+@router.post("/dismiss-all", status_code=status.HTTP_204_NO_CONTENT)
+def dismiss_all(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE operators AS op
+            SET alerts_last_seen_decision_id = GREATEST(
+                COALESCE(op.alerts_last_seen_decision_id, 0),
+                m.max_id
+            )
+            FROM (
+                SELECT MAX(decision_id) AS max_id
+                FROM decision_audit
+                WHERE pass_fail = 'FAIL'
+                  AND stage = 'execution_guard'
+                  AND decision_time >= now() - INTERVAL '7 days'
+            ) AS m
+            WHERE op.operator_id = %(op)s
+              AND m.max_id IS NOT NULL
+            """,
+            {"op": operator_id},
+        )
+    conn.commit()
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `uv run pytest tests/test_api_alerts.py -v`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/alerts.py tests/test_api_alerts.py
+git commit -m "feat(#315): POST /alerts/dismiss-all — atomic MAX advance, no-op on empty window"
+```
+
+---
+
+## Task 6: Backend integration tests against real `ebull_test`
+
+The mock-cursor tests above verify contract and SQL shape. This task adds integration tests that hit the real `ebull_test` DB using the existing `ebull_test_conn` fixture at [tests/fixtures/ebull_test_db.py](../../tests/fixtures/ebull_test_db.py). Four scenarios only — ordering under simulated clock skew, clamp-to-MAX, dismiss-all empty-window no-op, non-guard exclusion.
+
+**Files:**
+
+- Modify: `tests/test_api_alerts.py`
+- Modify: `tests/fixtures/ebull_test_db.py` — extend `_PLANNER_TABLES` (or add a new tuple) to include `operators`, `decision_audit`, `trade_recommendations`, `instruments` so they are TRUNCATEd between tests.
+
+- [ ] **Step 1: Extend the TRUNCATE list**
+
+Read `tests/fixtures/ebull_test_db.py:45-57`. The existing `_PLANNER_TABLES` tuple already includes `instruments`. Append the two new tables needed here:
+
+```python
+_PLANNER_TABLES: tuple[str, ...] = (
+    "cascade_retry_queue",
+    "financial_facts_raw",
+    "data_ingestion_runs",
+    "external_identifiers",
+    "external_data_watermarks",
+    "instruments",
+    "job_runs",
+    "financial_periods_raw",
+    "financial_periods",
+    "filing_events",
+    "decision_audit",          # new — #315 Phase 3 alerts
+    "trade_recommendations",   # new — #315 Phase 3 alerts (FK parent of decision_audit)
+    "operators",               # new — #315 Phase 3 alerts (cursor column)
+)
+```
+
+Dependency order matters: `decision_audit` → `trade_recommendations` (FK via recommendation_id) → `instruments`. TRUNCATE with CASCADE handles the rest. Keep `operators` last in the group since nothing FKs into it from the rows above.
+
+- [ ] **Step 2: Add integration tests**
+
+Append to `tests/test_api_alerts.py`. `import psycopg` is already in the top-level imports (added in Task 2's scaffold). Do NOT re-import mid-file — ruff `E402` forbids that.
+
+```python
+# --- Integration tests (real ebull_test DB) ----------------------------------
+
+from tests.fixtures.ebull_test_db import ebull_test_conn, test_db_available  # noqa: F401,E402
+
+_INT_OP_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _seed_operator(conn: psycopg.Connection[object]) -> None:
+    """Insert a known operator row so sole_operator_id resolves and the
+    UPDATE in /alerts/seen / /dismiss-all has a target row. `username`
+    and `password_hash` are NOT NULL per sql/016_operators_sessions.sql;
+    use dummy values — these rows are created for the alerts tests only
+    and never authenticate."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO operators (operator_id, username, password_hash)
+            VALUES (%s, 'alerts_test_op', 'x')
+            ON CONFLICT DO NOTHING
+            """,
+            (_INT_OP_ID,),
+        )
+    conn.commit()
+
+
+def _bind_test_client(conn: psycopg.Connection[object]) -> TestClient:
+    """Bind TestClient's get_conn dep to the ebull_test connection + patch
+    the operator resolver to return the seeded operator id. Returns a
+    client whose requests run against ebull_test."""
+    def _dep() -> Iterator[psycopg.Connection[object]]:
+        yield conn
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _dep
+    return TestClient(app)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_get_orders_by_decision_id_under_clock_skew(
+    ebull_test_conn: psycopg.Connection[object],
+) -> None:
+    """Row B gets a later decision_time but an earlier decision_id.
+    GET must still put the row with the higher decision_id first."""
+    _seed_operator(ebull_test_conn)
+
+    with ebull_test_conn.cursor() as cur:
+        # instruments.instrument_id is BIGINT PRIMARY KEY with no default
+        # (sql/001_init.sql), so the caller supplies the id explicitly.
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (1, 'ZZZ', 'Test', 'USD', TRUE)"
+        )
+        iid = 1
+
+        # Insert Row B first (gets lower decision_id) with the LATER decision_time.
+        cur.execute(
+            "INSERT INTO decision_audit "
+            "(decision_time, instrument_id, stage, pass_fail, explanation) "
+            "VALUES (now(), %s, 'execution_guard', 'FAIL', 'B-later-time') "
+            "RETURNING decision_id",
+            (iid,),
+        )
+        id_b = cur.fetchone()[0]
+
+        # Insert Row A second (gets HIGHER decision_id) with the EARLIER decision_time.
+        cur.execute(
+            "INSERT INTO decision_audit "
+            "(decision_time, instrument_id, stage, pass_fail, explanation) "
+            "VALUES (now() - INTERVAL '1 hour', %s, 'execution_guard', 'FAIL', 'A-earlier-time') "
+            "RETURNING decision_id",
+            (iid,),
+        )
+        id_a = cur.fetchone()[0]
+    ebull_test_conn.commit()
+
+    assert id_a > id_b  # sanity check on the natural PK ordering
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/guard-rejections")
+        assert resp.status_code == 200
+        rejections = resp.json()["rejections"]
+        assert rejections[0]["decision_id"] == id_a
+        assert rejections[1]["decision_id"] == id_b
+    finally:
+        app.dependency_overrides.pop("app.db.get_conn", None)
+        from app.db import get_conn
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_post_seen_clamps_to_in_window_max(
+    ebull_test_conn: psycopg.Connection[object],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO decision_audit "
+            "(decision_time, stage, pass_fail, explanation) "
+            "VALUES (now(), 'execution_guard', 'FAIL', 'in-window') RETURNING decision_id"
+        )
+        max_in_window = cur.fetchone()[0]
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/seen",
+                json={"seen_through_decision_id": max_in_window + 99999},
+            )
+        assert resp.status_code == 204
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_decision_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            stored = cur.fetchone()[0]
+        assert stored == max_in_window
+    finally:
+        from app.db import get_conn
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_dismiss_all_empty_window_stays_null(
+    ebull_test_conn: psycopg.Connection[object],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    # No guard rows in window; cursor NULL; POST dismiss-all; cursor stays NULL.
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post("/alerts/dismiss-all")
+        assert resp.status_code == 204
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_decision_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone()[0] is None
+    finally:
+        from app.db import get_conn
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_non_guard_stage_excluded_from_list_and_dismiss(
+    ebull_test_conn: psycopg.Connection[object],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO decision_audit "
+            "(decision_time, stage, pass_fail, explanation) "
+            "VALUES (now(), 'order_execution', 'FAIL', 'not a guard') RETURNING decision_id"
+        )
+        id_non_guard = cur.fetchone()[0]
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/guard-rejections")
+        ids = [r["decision_id"] for r in resp.json()["rejections"]]
+        assert id_non_guard not in ids
+
+        # dismiss-all MAX subselect is NULL (no guard rows) → no-op.
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post("/alerts/dismiss-all")
+        assert resp.status_code == 204
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_decision_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone()[0] is None
+    finally:
+        from app.db import get_conn
+        app.dependency_overrides.pop(get_conn, None)
+```
+
+Notes on the integration pattern:
+
+- `ebull_test_conn` is imported from `tests/fixtures/ebull_test_db.py`; no new fixture is invented.
+- Ordering under clock skew is exercised by inserting rows in the order that makes the natural BIGSERIAL sequence produce the needed id layout — **never** by hand-setting `decision_id`. Row B first (lower id, later time), Row A second (higher id, earlier time).
+- Operator is seeded before each test because `sole_operator_id` is still patched for the integration tests (the fixture TRUNCATEs operators between tests, so seeding is required each time). The patch stays — test DB's operator table is empty and seeding one known row is simpler than running bootstrap.
+- `TestClient` is rebound to the `ebull_test` connection via `app.dependency_overrides[get_conn]`; the `finally` block clears it even on test failure.
+- `@pytest.mark.skipif("not test_db_available()")` skips gracefully when the test DB is unreachable (CI may not have it available).
+
+- [ ] **Step 3: Run the integration tests**
+
+Run: `uv run pytest tests/test_api_alerts.py -v`
+Expected: all integration tests PASS if `ebull_test` is reachable; otherwise SKIPPED (not failed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_api_alerts.py tests/fixtures/ebull_test_db.py
+git commit -m "test(#315): integration tests for alerts API against ebull_test (ordering, clamp, dismiss-all scope)"
+```
+
+---
+
+## Task 7: Frontend types + API client
+
+**Files:**
+
+- Modify: `frontend/src/api/types.ts`
+- Create: `frontend/src/api/alerts.ts`
+
+- [ ] **Step 1: Add types**
+
+In `frontend/src/api/types.ts`, append:
+
+```ts
+// #315 Phase 3 — alerts strip
+export type GuardRejectionAction = "BUY" | "ADD" | "HOLD" | "EXIT";
+
+export interface GuardRejection {
+  decision_id: number;
+  decision_time: string;  // ISO TIMESTAMPTZ
+  instrument_id: number | null;
+  symbol: string | null;
+  action: GuardRejectionAction | null;
+  explanation: string;
+}
+
+export interface GuardRejectionsResponse {
+  alerts_last_seen_decision_id: number | null;
+  unseen_count: number;
+  rejections: GuardRejection[];
+}
+```
+
+- [ ] **Step 2: Create the API client**
+
+Create `frontend/src/api/alerts.ts`:
+
+```ts
+import { apiFetch } from "@/api/client";
+import type { GuardRejectionsResponse } from "@/api/types";
+
+export function fetchGuardRejections(): Promise<GuardRejectionsResponse> {
+  return apiFetch<GuardRejectionsResponse>("/alerts/guard-rejections");
+}
+
+export function markAlertsSeen(seenThroughDecisionId: number): Promise<void> {
+  return apiFetch<void>("/alerts/seen", {
+    method: "POST",
+    body: JSON.stringify({ seen_through_decision_id: seenThroughDecisionId }),
+  });
+}
+
+export function dismissAllAlerts(): Promise<void> {
+  return apiFetch<void>("/alerts/dismiss-all", { method: "POST" });
+}
+```
+
+- [ ] **Step 3: Verify apiFetch signature**
+
+Run: `grep -n "export function apiFetch\|export async function apiFetch" frontend/src/api/client.ts`
+
+Confirm the second argument accepts `method` and `body`. If the existing signature differs (e.g. takes a separate `init` object shape), adjust the calls above to match. Do not change `apiFetch` itself.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm --dir frontend typecheck`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/types.ts frontend/src/api/alerts.ts
+git commit -m "feat(#315): frontend types + API client for alerts strip"
+```
+
+---
+
+## Task 8: `formatRelativeTime` helper
+
+**Files:**
+
+- Modify: `frontend/src/lib/format.ts`
+- Create: `frontend/src/lib/format.test.ts` (or append if it exists)
+
+- [ ] **Step 1: Check if a test file exists**
+
+Run: `ls frontend/src/lib/format.test.ts 2>/dev/null || echo "no test file"`
+
+If the file does not exist, create it with the standard header. If it exists, append the new tests.
+
+- [ ] **Step 2: Write failing tests**
+
+Create or append to `frontend/src/lib/format.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { formatRelativeTime } from "@/lib/format";
+
+describe("formatRelativeTime", () => {
+  const NOW = new Date("2026-04-21T12:00:00Z");
+
+  it("renders '—' for null / undefined / empty string", () => {
+    expect(formatRelativeTime(null)).toBe("—");
+    expect(formatRelativeTime(undefined)).toBe("—");
+    expect(formatRelativeTime("")).toBe("—");
+  });
+
+  it("renders 'just now' for <60s delta", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatRelativeTime("2026-04-21T11:59:30Z")).toBe("just now");
+    vi.useRealTimers();
+  });
+
+  it("renders minutes for <1h delta", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatRelativeTime("2026-04-21T11:55:00Z")).toBe("5m ago");
+    vi.useRealTimers();
+  });
+
+  it("renders hours for <1d delta", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatRelativeTime("2026-04-21T09:00:00Z")).toBe("3h ago");
+    vi.useRealTimers();
+  });
+
+  it("renders days for <7d delta", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatRelativeTime("2026-04-19T12:00:00Z")).toBe("2d ago");
+    vi.useRealTimers();
+  });
+
+  it("falls back to formatDate for >=7d delta", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const result = formatRelativeTime("2026-04-10T12:00:00Z");
+    expect(result).toMatch(/2026/);
+    vi.useRealTimers();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify failure**
+
+Run: `pnpm --dir frontend test -- format.test.ts`
+Expected: all six tests FAIL with "formatRelativeTime is not exported".
+
+- [ ] **Step 4: Implement the helper**
+
+In `frontend/src/lib/format.ts`, append:
+
+```ts
+/** Relative-time formatter for strip rows. Uses local system clock.
+ *  <60s → "just now", <1h → "Nm ago", <1d → "Nh ago", <7d → "Nd ago",
+ *  else → formatDate fallback. */
+export function formatRelativeTime(iso: string | null | undefined): string {
+  if (iso === null || iso === undefined || iso === "") return "—";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "—";
+  const deltaS = Math.floor((Date.now() - then) / 1000);
+  if (deltaS < 60) return "just now";
+  if (deltaS < 3600) return `${Math.floor(deltaS / 60)}m ago`;
+  if (deltaS < 86400) return `${Math.floor(deltaS / 3600)}h ago`;
+  if (deltaS < 604800) return `${Math.floor(deltaS / 86400)}d ago`;
+  return formatDate(iso);
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `pnpm --dir frontend test -- format.test.ts`
+Expected: all six PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/lib/format.ts frontend/src/lib/format.test.ts
+git commit -m "feat(#315): formatRelativeTime helper"
+```
+
+---
+
+## Task 9: `AlertsStrip` — hidden-when-empty, silent-on-error, row rendering
+
+Build the component incrementally: first the empty / error states + row rendering, then the normal-path "Mark all read" (Task 10), then the overflow-path "Dismiss all" (Task 11).
+
+**Files:**
+
+- Create: `frontend/src/components/dashboard/AlertsStrip.test.tsx`
+- Create: `frontend/src/components/dashboard/AlertsStrip.tsx`
+
+- [ ] **Step 1: Write failing tests — empty, error, row shape, instrument link, unseen borders**
+
+Create `frontend/src/components/dashboard/AlertsStrip.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { AlertsStrip } from "@/components/dashboard/AlertsStrip";
+import type { GuardRejectionsResponse } from "@/api/types";
+
+vi.mock("@/api/alerts", () => ({
+  fetchGuardRejections: vi.fn(),
+  markAlertsSeen: vi.fn(),
+  dismissAllAlerts: vi.fn(),
+}));
+
+import * as alertsApi from "@/api/alerts";
+
+const baseRow = {
+  decision_id: 501,
+  decision_time: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+  instrument_id: 42,
+  symbol: "AAPL",
+  action: "BUY" as const,
+  explanation: "FAIL — cash_available: need £200, have £50",
+};
+
+function stubFetch(data: GuardRejectionsResponse | null) {
+  (alertsApi.fetchGuardRejections as unknown as vi.Mock).mockResolvedValue(data ?? {});
+}
+
+function stubFetchError() {
+  (alertsApi.fetchGuardRejections as unknown as vi.Mock).mockRejectedValue(new Error("boom"));
+}
+
+function renderStrip() {
+  return render(
+    <MemoryRouter>
+      <AlertsStrip />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AlertsStrip", () => {
+  it("renders nothing when rejections list is empty", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 0,
+      rejections: [],
+    });
+    const { container } = renderStrip();
+    await vi.waitFor(() => {
+      expect(alertsApi.fetchGuardRejections).toHaveBeenCalled();
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing on fetch error (silent-on-error)", async () => {
+    stubFetchError();
+    const { container } = renderStrip();
+    await vi.waitFor(() => {
+      expect(alertsApi.fetchGuardRejections).toHaveBeenCalled();
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders row symbol / action / explanation", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 1,
+      rejections: [baseRow],
+    });
+    renderStrip();
+    expect(await screen.findByText("AAPL")).toBeInTheDocument();
+    expect(screen.getByText("BUY")).toBeInTheDocument();
+    expect(
+      screen.getByText(/cash_available: need £200/),
+    ).toBeInTheDocument();
+  });
+
+  it("wraps row in a Link when instrument_id is non-null", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 1,
+      rejections: [baseRow],
+    });
+    renderStrip();
+    const link = await screen.findByRole("link");
+    expect(link.getAttribute("href")).toBe("/instruments/42");
+  });
+
+  it("renders plain row (no link) when instrument_id is null", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 1,
+      rejections: [{ ...baseRow, instrument_id: null, symbol: null }],
+    });
+    renderStrip();
+    await screen.findByText(/cash_available/);
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("applies amber border for unseen rows, slate for seen", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: 500,
+      unseen_count: 1,
+      rejections: [
+        { ...baseRow, decision_id: 501 },  // unseen (501 > 500)
+        { ...baseRow, decision_id: 499 },  // seen (499 <= 500)
+      ],
+    });
+    renderStrip();
+    const rows = await screen.findAllByTestId("alerts-row");
+    expect(rows[0].className).toMatch(/border-amber/);
+    expect(rows[1].className).toMatch(/border-slate/);
+  });
+
+  it("shows unseen_count pill when unseen_count > 0", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 3,
+      rejections: [baseRow],
+    });
+    renderStrip();
+    expect(await screen.findByText(/3 new/)).toBeInTheDocument();
+  });
+
+  it("omits unseen_count pill when unseen_count === 0", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: 999,
+      unseen_count: 0,
+      rejections: [baseRow],  // still shown, just all seen
+    });
+    renderStrip();
+    await screen.findByText("AAPL");
+    expect(screen.queryByText(/new$/)).toBeNull();
+  });
+
+  it("truncates explanation visually but preserves full text in title", async () => {
+    const long = "FAIL — cash_available: need £200; thesis_stale: 14 days old; spread_wide: 0.12%";
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 1,
+      rejections: [{ ...baseRow, explanation: long }],
+    });
+    renderStrip();
+    const node = await screen.findByText(long);
+    expect(node.getAttribute("title")).toBe(long);
+    expect(node.className).toMatch(/truncate/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --dir frontend test -- AlertsStrip.test.tsx`
+Expected: all eight FAIL (module cannot be imported).
+
+- [ ] **Step 3: Implement the component**
+
+Create `frontend/src/components/dashboard/AlertsStrip.tsx`:
+
+```tsx
+/**
+ * AlertsStrip — guard-rejection alerts on the operator dashboard (#315 Phase 3).
+ *
+ * Sits between RollingPnlStrip and PortfolioValueChart. Hidden when empty;
+ * silent on fetch error (matches the RollingPnlStrip pattern — a failing
+ * /alerts must not blank the dashboard).
+ *
+ * Cursor is decision_id (not decision_time) — see spec
+ * docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md for why.
+ */
+import { Link } from "react-router-dom";
+
+import {
+  fetchGuardRejections,
+  markAlertsSeen,
+  dismissAllAlerts,
+} from "@/api/alerts";
+import type { GuardRejection } from "@/api/types";
+import { formatRelativeTime } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+function isUnseen(
+  row: GuardRejection,
+  lastSeen: number | null,
+): boolean {
+  return lastSeen === null || row.decision_id > lastSeen;
+}
+
+function RowView({
+  row,
+  lastSeen,
+}: {
+  row: GuardRejection;
+  lastSeen: number | null;
+}) {
+  const unseen = isUnseen(row, lastSeen);
+  const border = unseen
+    ? "border-l-4 border-amber-400"
+    : "border-l-4 border-slate-200";
+  const content = (
+    <div
+      data-testid="alerts-row"
+      className={`flex items-center gap-3 px-3 py-2 text-sm ${border} bg-white`}
+    >
+      <span className="w-16 font-semibold tabular-nums">{row.symbol ?? "—"}</span>
+      <span className="w-12 text-xs uppercase text-slate-500">{row.action ?? "—"}</span>
+      <span
+        className="flex-1 truncate text-slate-700"
+        title={row.explanation}
+      >
+        {row.explanation}
+      </span>
+      <span className="w-20 text-right text-xs text-slate-400">
+        {formatRelativeTime(row.decision_time)}
+      </span>
+    </div>
+  );
+  if (row.instrument_id !== null) {
+    return (
+      <Link to={`/instruments/${row.instrument_id}`} className="block hover:bg-slate-50">
+        {content}
+      </Link>
+    );
+  }
+  return content;
+}
+
+export function AlertsStrip(): JSX.Element | null {
+  const { data, error } = useAsync(fetchGuardRejections, []);
+
+  if (error !== null || data === null) return null;
+  if (data.rejections.length === 0) return null;
+
+  const lastSeen = data.alerts_last_seen_decision_id;
+
+  return (
+    <section className="rounded-md border border-slate-200 bg-white shadow-sm">
+      <header className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-slate-700">Guard rejections</h2>
+          {data.unseen_count > 0 ? (
+            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+              {data.unseen_count} new
+            </span>
+          ) : null}
+        </div>
+        {/* Action buttons land in Tasks 10 and 11 */}
+      </header>
+      <div className="max-h-96 overflow-y-auto divide-y divide-slate-100">
+        {data.rejections.map((row) => (
+          <RowView key={row.decision_id} row={row} lastSeen={lastSeen} />
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --dir frontend test -- AlertsStrip.test.tsx`
+Expected: all eight PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/dashboard/AlertsStrip.tsx frontend/src/components/dashboard/AlertsStrip.test.tsx
+git commit -m "feat(#315): AlertsStrip base — row rendering, hidden on empty, silent on error"
+```
+
+---
+
+## Task 10: Normal-path "Mark all read" button
+
+**Files:**
+
+- Modify: `frontend/src/components/dashboard/AlertsStrip.test.tsx`
+- Modify: `frontend/src/components/dashboard/AlertsStrip.tsx`
+
+- [ ] **Step 1: Add failing tests — button render, click behaviour, cap-positive branch**
+
+Append to `AlertsStrip.test.tsx`:
+
+```tsx
+import userEvent from "@testing-library/user-event";
+
+describe("AlertsStrip — Mark all read (normal path)", () => {
+  it("renders 'Mark all read' when unseen_count > 0 and <= rejections.length", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: 499,
+      unseen_count: 2,
+      rejections: [
+        { ...baseRow, decision_id: 501 },
+        { ...baseRow, decision_id: 500 },
+      ],
+    });
+    renderStrip();
+    expect(await screen.findByRole("button", { name: /mark all read/i })).toBeInTheDocument();
+  });
+
+  it("hides 'Mark all read' when unseen_count === 0 (all rows already seen)", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: 999,
+      unseen_count: 0,
+      rejections: [{ ...baseRow, decision_id: 500 }],  // seen (500 < 999)
+    });
+    renderStrip();
+    await screen.findByText("AAPL");
+    expect(screen.queryByRole("button", { name: /mark all read/i })).toBeNull();
+  });
+
+  it("stays visible at the 500-row cap when unseen_count === rejections.length === 500", async () => {
+    const rejections = Array.from({ length: 500 }, (_, i) => ({
+      ...baseRow,
+      decision_id: 500 - i,
+    }));
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 500,
+      rejections,
+    });
+    renderStrip();
+    expect(await screen.findByRole("button", { name: /mark all read/i })).toBeInTheDocument();
+  });
+
+  it("click posts rejections[0].decision_id and refetches", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: 499,
+      unseen_count: 2,
+      rejections: [
+        { ...baseRow, decision_id: 501 },
+        { ...baseRow, decision_id: 500 },
+      ],
+    });
+    (alertsApi.markAlertsSeen as unknown as vi.Mock).mockResolvedValue(undefined);
+    renderStrip();
+
+    const btn = await screen.findByRole("button", { name: /mark all read/i });
+    await userEvent.click(btn);
+
+    expect(alertsApi.markAlertsSeen).toHaveBeenCalledWith(501);  // MAX(decision_id) in payload
+    // Refetch was triggered (second fetch call).
+    await vi.waitFor(() => {
+      expect((alertsApi.fetchGuardRejections as unknown as vi.Mock).mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --dir frontend test -- AlertsStrip.test.tsx`
+Expected: the three new tests FAIL — no button is rendered.
+
+- [ ] **Step 3: Implement the button**
+
+In `AlertsStrip.tsx`, replace the current header/component body to add the button + `refetch`:
+
+```tsx
+export function AlertsStrip(): JSX.Element | null {
+  const { data, error, refetch } = useAsync(fetchGuardRejections, []);
+
+  if (error !== null || data === null) return null;
+  if (data.rejections.length === 0) return null;
+
+  const lastSeen = data.alerts_last_seen_decision_id;
+  const normalAck =
+    data.unseen_count > 0 && data.unseen_count <= data.rejections.length;
+
+  async function onMarkAllRead() {
+    // rejections is non-empty here (strip is hidden otherwise),
+    // and is ordered decision_id DESC on the server so index 0 is MAX.
+    const seenThroughDecisionId = data!.rejections[0].decision_id;
+    await markAlertsSeen(seenThroughDecisionId);
+    refetch();
+  }
+
+  return (
+    <section className="rounded-md border border-slate-200 bg-white shadow-sm">
+      <header className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-slate-700">Guard rejections</h2>
+          {data.unseen_count > 0 ? (
+            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+              {data.unseen_count} new
+            </span>
+          ) : null}
+        </div>
+        {normalAck ? (
+          <button
+            type="button"
+            onClick={onMarkAllRead}
+            className="rounded border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Mark all read
+          </button>
+        ) : null}
+      </header>
+      <div className="max-h-96 overflow-y-auto divide-y divide-slate-100">
+        {data.rejections.map((row) => (
+          <RowView key={row.decision_id} row={row} lastSeen={lastSeen} />
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --dir frontend test -- AlertsStrip.test.tsx`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/dashboard/AlertsStrip.tsx frontend/src/components/dashboard/AlertsStrip.test.tsx
+git commit -m "feat(#315): AlertsStrip — normal-path Mark all read"
+```
+
+---
+
+## Task 11: Overflow-path "Dismiss all" button + confirm dialog
+
+**Files:**
+
+- Modify: `frontend/src/components/dashboard/AlertsStrip.test.tsx`
+- Modify: `frontend/src/components/dashboard/AlertsStrip.tsx`
+
+- [ ] **Step 1: Add failing tests — render, confirm, cancel, `/recommendations` link**
+
+Append to `AlertsStrip.test.tsx`:
+
+```tsx
+describe("AlertsStrip — Dismiss all (overflow path)", () => {
+  function overflowStub() {
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 600,
+      rejections: Array.from({ length: 500 }, (_, i) => ({
+        ...baseRow,
+        decision_id: 600 - i,
+      })),
+    });
+  }
+
+  it("renders 'Dismiss all (600) as acknowledged' and a /recommendations link when unseen_count > rejections.length", async () => {
+    overflowStub();
+    renderStrip();
+    expect(
+      await screen.findByRole("button", { name: /dismiss all \(600\)/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /mark all read/i })).toBeNull();
+    const recLink = screen.getByRole("link", { name: /recommendations/i });
+    expect(recLink.getAttribute("href")).toBe("/recommendations");
+  });
+
+  it("confirm dialog: confirm calls dismissAllAlerts + refetch", async () => {
+    overflowStub();
+    (alertsApi.dismissAllAlerts as unknown as vi.Mock).mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderStrip();
+
+    const btn = await screen.findByRole("button", { name: /dismiss all \(600\)/i });
+    await userEvent.click(btn);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(alertsApi.dismissAllAlerts).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect((alertsApi.fetchGuardRejections as unknown as vi.Mock).mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+    confirmSpy.mockRestore();
+  });
+
+  it("confirm dialog: cancel does NOT call dismissAllAlerts or refetch", async () => {
+    overflowStub();
+    (alertsApi.dismissAllAlerts as unknown as vi.Mock).mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    renderStrip();
+
+    const fetchCallsBefore = (alertsApi.fetchGuardRejections as unknown as vi.Mock).mock.calls.length;
+    const btn = await screen.findByRole("button", { name: /dismiss all \(600\)/i });
+    await userEvent.click(btn);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(alertsApi.dismissAllAlerts).not.toHaveBeenCalled();
+    expect((alertsApi.fetchGuardRejections as unknown as vi.Mock).mock.calls.length).toBe(fetchCallsBefore);
+    confirmSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --dir frontend test -- AlertsStrip.test.tsx`
+Expected: the three new tests FAIL.
+
+- [ ] **Step 3: Implement the overflow branch**
+
+In `AlertsStrip.tsx`, extend the header action area. Replace the `{normalAck ? ... : null}` block with:
+
+```tsx
+        {normalAck ? (
+          <button
+            type="button"
+            onClick={onMarkAllRead}
+            className="rounded border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Mark all read
+          </button>
+        ) : null}
+        {overflowAck ? (
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onDismissAll}
+              className="rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 hover:bg-amber-100"
+            >
+              Dismiss all ({data.unseen_count}) as acknowledged
+            </button>
+            <Link
+              to="/recommendations"
+              className="text-xs text-slate-500 underline hover:text-slate-700"
+            >
+              Triage at /recommendations
+            </Link>
+          </div>
+        ) : null}
+```
+
+Add `overflowAck` + `onDismissAll` above the return:
+
+```tsx
+  const overflowAck = data.unseen_count > data.rejections.length;
+
+  async function onDismissAll() {
+    const hiddenCount = data!.unseen_count - data!.rejections.length;
+    const msg = `Dismiss all ${data!.unseen_count} unseen rejections? ${hiddenCount} are not shown above. Review them at /recommendations before dismissing if they might matter.`;
+    if (!window.confirm(msg)) return;
+    await dismissAllAlerts();
+    refetch();
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --dir frontend test -- AlertsStrip.test.tsx`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/dashboard/AlertsStrip.tsx frontend/src/components/dashboard/AlertsStrip.test.tsx
+git commit -m "feat(#315): AlertsStrip — overflow-path Dismiss all + confirm dialog"
+```
+
+---
+
+## Task 12: Wire into `DashboardPage`
+
+**Files:**
+
+- Modify: `frontend/src/pages/DashboardPage.tsx`
+
+- [ ] **Step 1: Read the current layout**
+
+Run: `grep -n "RollingPnlStrip\|PortfolioValueChart\|PositionsTable" frontend/src/pages/DashboardPage.tsx`
+
+Current order is `RollingPnlStrip` → `PortfolioValueChart` → `<Section title="Positions">`. `<AlertsStrip />` goes **between `RollingPnlStrip` and `PortfolioValueChart`** — operator reads totals → short-horizon delta → alerts → long-horizon trajectory → positions.
+
+- [ ] **Step 2: Add the import**
+
+In `frontend/src/pages/DashboardPage.tsx`, next to the other dashboard-component imports:
+
+```ts
+import { AlertsStrip } from "@/components/dashboard/AlertsStrip";
+```
+
+- [ ] **Step 3: Mount the component**
+
+In the JSX, insert between `<RollingPnlStrip />` and `<PortfolioValueChart />`:
+
+```tsx
+<RollingPnlStrip />
+{/* Needs-action surface — guard rejections since last visit.
+    Hidden when empty, silent on error. Sits above the narrative
+    chart so action-required signal precedes trajectory context. */}
+<AlertsStrip />
+<PortfolioValueChart />
+```
+
+- [ ] **Step 4: Update the layout comment**
+
+At the top of `DashboardPage`, locate the ASCII-art layout comment and insert the strip between the rolling-P&L pills and the value chart:
+
+```text
+Layout:
+  ┌ SummaryCards (AUM · Cash · P&L · Deployment) ┐
+  │ RollingPnlStrip (1d · 1w · 1m)               │
+  │ AlertsStrip (guard rejections)               │
+  │ PortfolioValueChart                          │
+  │                                              │
+  │ Positions                                    │
+  │ Needs action (proposed recs)                 │
+  │ Watchlist                                    │
+  └──────────────────────────────────────────────┘
+```
+
+- [ ] **Step 5: Typecheck + build the frontend**
+
+Run:
+
+```bash
+pnpm --dir frontend typecheck
+pnpm --dir frontend build
+```
+
+Expected: both green.
+
+- [ ] **Step 6: Smoke test in the running dev stack**
+
+Per `feedback_keep_stack_running.md`: do NOT stop/restart the VS Code-managed backend/frontend tasks. They're already running. Just open the dashboard in the browser.
+
+Visual check:
+
+- No alerts in DB → strip is not rendered (dashboard looks unchanged).
+- One FAIL guard row in DB → strip appears between rolling-P&L and Positions with one row; clicking "Mark all read" clears the amber border on next render.
+- Exit the test rows via `DELETE FROM decision_audit WHERE stage='execution_guard' AND pass_fail='FAIL' AND explanation LIKE 'TEST%'` once done.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/DashboardPage.tsx
+git commit -m "feat(#315): wire AlertsStrip into DashboardPage between RollingPnlStrip and PortfolioValueChart"
+```
+
+---
+
+## Task 13: Pre-push gates + Codex review
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full backend gate**
+
+Run:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+All four must pass. `uv run pytest` includes the smoke test (`tests/smoke/test_app_boots.py`) that boots the app via `TestClient`. The new `alerts_router` must register cleanly there.
+
+- [ ] **Step 2: Full frontend gate**
+
+Run:
+
+```bash
+pnpm --dir frontend typecheck
+pnpm --dir frontend test
+```
+
+Both must pass.
+
+- [ ] **Step 3: Self-review the diff**
+
+Run: `git diff main...HEAD -- ':!docs/superpowers'`
+
+Read the full diff. Apply the pre-flight review skill — read as an adversary. Check the spec's 22 backend + 11 frontend test cases all have matching assertions. Check the SQL matches the spec literally (casing, LEAST/GREATEST, m.max_id IS NOT NULL).
+
+- [ ] **Step 4: Codex pre-push review (CLAUDE.md checkpoint 2)**
+
+Run:
+
+```bash
+codex.cmd exec "Review the branch feature/315-phase3-alerts-strip before first push. Diff is the full implementation of docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md. Focus on correctness of the SQL queries (ordering, LEAST/GREATEST, NULL handling), ack race-safety, and React state flow around refetch. Reply terse." < /dev/null
+```
+
+Address any real findings before pushing. Report unresolved points as `REBUTTED {reason}` in the commit body.
+
+- [ ] **Step 5: Push + open PR**
+
+```bash
+git push -u origin feature/315-phase3-alerts-strip
+gh pr create --title "feat(#315): Phase 3 — guard-rejection alerts strip" --body "$(cat <<'EOF'
+## What
+Alerts strip for execution-guard rejections on the operator dashboard. Closes the final phase of #315.
+
+## Why
+Operator needs a "since last visit" view of guard rejections without leaving the dashboard. Scope limited to guard rejections because thesis breaches (#394) and filings-status drops (#395) each need their own event-persistence design.
+
+## Test plan
+- [x] Backend unit tests: operator-resolution 503/501 (GET + both POSTs), GET shape + SQL-shape pin + null-action + HOLD + unseen-count SQL shape, POST /seen validation + SQL-shape (GREATEST/LEAST/MAX scope), POST /dismiss-all happy + scope + empty-window noop
+- [x] Integration tests vs ebull_test: clock-skew ordering (decision_id wins), POST /seen clamps to in-window MAX, dismiss-all empty-window no-op, non-guard stage excluded
+- [x] Frontend tests: empty/error hidden, row shape, instrument link vs plain, amber/slate borders, unseen pill, title-truncation, Mark all read (normal + cap-positive + unseen=0 hides), Dismiss all (overflow render + confirm + cancel)
+- [x] Smoke test (`tests/smoke/test_app_boots.py`) green with new router
+- [x] Dashboard smoke-tested against dev DB
+- [x] Codex pre-spec (10 rounds) + pre-push reviews clean
+
+## Follow-ups filed on merge
+- #394 position-alert event persistence
+- #395 coverage status transition log
+- #396 wire #394 + #395 into the strip
+
+Spec: docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Poll review + CI**
+
+Per `feedback_post_push_cycle.md`: immediately start polling `gh pr view <n> --comments` and `gh pr checks <n>`. Resolve every comment as `FIXED {sha}` / `DEFERRED #{id}` / `REBUTTED {reason}`. Each follow-up push resets the review — keep polling until APPROVE on the most recent commit + CI green.
+
+- [ ] **Step 7: On merge**
+
+1. File #394, #395, #396 with the follow-up scope from the spec.
+2. Close #315.
+3. Delete local + remote branch.
+
+---
+
+## Self-review checklist
+
+**1. Spec coverage:**
+
+- Schema migration → Task 1 ✓
+- Router + operator-resolution errors → Task 2 ✓
+- GET /alerts/guard-rejections (7d window, 500 cap, decision_id ordering, unseen_count) → Task 3 ✓
+- POST /alerts/seen (validation, LEAST clamp, monotonic GREATEST) → Task 4 ✓
+- POST /alerts/dismiss-all (atomic MAX, WHERE m.max_id IS NOT NULL) → Task 5 ✓
+- Race-safety + ordering-by-decision_id integration tests → Task 6 ✓
+- Frontend types + API client → Task 7 ✓
+- formatRelativeTime helper → Task 8 ✓
+- AlertsStrip empty / error / rows / link / border → Task 9 ✓
+- AlertsStrip Mark all read (normal + cap-positive branch) → Task 10 ✓
+- AlertsStrip Dismiss all (overflow + confirm/cancel) → Task 11 ✓
+- DashboardPage wire-up → Task 12 ✓
+- Pre-push gates + Codex + PR + follow-up tickets → Task 13 ✓
+
+**2. Placeholder scan:** No TBD/TODO/"similar to", no "add error handling" hand-waves, every code step shows actual code.
+
+**3. Type consistency:**
+
+- `seenThroughDecisionId` param name matches across `alerts.ts`, test assertions, and the POST body shape `{seen_through_decision_id}`.
+- `GuardRejectionAction` Literal matches backend `Literal["BUY", "ADD", "HOLD", "EXIT"]` exactly.
+- `alerts_last_seen_decision_id` column/field name matches across migration, backend queries, response envelope, frontend types.
+- `onMarkAllRead` and `onDismissAll` are both defined in Task 10/11 before use in Task 11's JSX diff.
+- `decision_id` typed as `number` in TS and `int` in Pydantic throughout.
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-21-alerts-strip-guard-rejections.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md
+++ b/docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md
@@ -1,0 +1,393 @@
+# Alerts strip — guard rejections (#315 Phase 3)
+
+**Date:** 2026-04-21
+**Issue:** #315 (P1-3 Dashboard as command center), final phase
+**Plan:** [docs/superpowers/plans/2026-04-18-product-visibility-pivot.md](../plans/2026-04-18-product-visibility-pivot.md) line 49
+**Prior phases merged:** PR #387 (Phase 1 — demote admin + Needs action), PR #388 (Phase 2 — rolling P&L pills)
+
+---
+
+## Context
+
+Plan scope for #315 names three alert sources: **thesis breaches**, **filings-status drops from analysable**, **execution guard rejections since last visit**. Current state differs per source:
+
+| Source | Current state | Persistence |
+|---|---|---|
+| Guard rejections | `decision_audit` written on every guard invocation ([app/services/execution_guard.py:587](../../app/services/execution_guard.py) `_write_audit`, rows since migration `sql/010_execution_guard.sql`) | Full history with `decision_time`, `pass_fail`, `explanation`, `evidence_json`, `recommendation_id` |
+| Thesis breaches | `position_monitor.check_position_health` ([app/services/position_monitor.py:64](../../app/services/position_monitor.py)) runs hourly via `monitor_positions_job` ([app/workers/scheduler.py:2128](../../app/workers/scheduler.py)); results **only logged** | No DB rows |
+| Filings-status drops | `coverage.filings_status` current-label column ([sql/036_coverage_filings_status.sql](../../sql/036_coverage_filings_status.sql)); `filings_audit_at` timestamp | No transition log |
+
+Phase 3 ships **guard rejections only**. Thesis + filings require separate event-persistence work each smelling like its own ticket.
+
+## Follow-ups (filed at merge)
+
+- **#394** — position-alert event persistence: `position_alerts` table, `position_monitor` writer, dedupe policy, retention
+- **#395** — coverage status transition log: `coverage_status_events` table, audit-path writer, retention
+- **#396** — extend alerts strip to position + filings events (type-union addition on top of this PR's component)
+
+Closing #315 is conditional on this PR landing. Follow-ups rejoin backlog under the product-visibility-pivot plan.
+
+---
+
+## Scope
+
+**In:**
+- Schema: `operators.alerts_last_seen_decision_id BIGINT NULL`; partial index on `decision_audit (decision_time DESC) WHERE pass_fail = 'FAIL' AND stage = 'execution_guard'`.
+- Backend: `GET /alerts/guard-rejections` (7-day window, 500-row cap), `POST /alerts/seen` (normal-path ack via `seen_through_decision_id`), `POST /alerts/dismiss-all` (overflow-path ack, advances cursor to MAX in window).
+- Frontend: `frontend/src/api/alerts.ts`, `frontend/src/components/dashboard/AlertsStrip.tsx`, wired into `DashboardPage.tsx` between `RollingPnlStrip` and Positions.
+- Tests: backend API tests; frontend component tests.
+
+**Out (explicit non-assertions):**
+- Position alerts — deferred to #394.
+- Filings-status drops — deferred to #395.
+- Strip wiring for #394/#395 — deferred to #396.
+- Dismissing individual rows (only "mark all read").
+- Email / push / external notifications.
+- Per-operator alert preferences or filters.
+- Historical archive UI beyond the 7-day window.
+- Changes to `decision_audit` schema or guard write path.
+
+---
+
+## Schema
+
+New migration `sql/044_operators_alerts_seen.sql`:
+
+```sql
+-- Migration 044: operator-scoped alert acknowledgement + guard-rejection read index
+--
+-- 1. operators.alerts_last_seen_decision_id — NULL = never acknowledged (all in-window rows unseen).
+--    Integer cursor keyed off decision_audit.decision_id (BIGSERIAL, unique).
+--    Timestamp-based cursor was rejected: decision_time is TIMESTAMPTZ (microsecond resolution,
+--    NOT unique under load), which leaves a tie-break race where a row inserted between GET
+--    and POST at the same decision_time as rejections[0] would be silently acked. decision_id
+--    is monotonic for the guard stage (single-threaded scheduler invocations; no concurrent
+--    writers), so a strict > comparison fully closes the race.
+-- 2. Partial index on decision_audit supports the dashboard GET scan.
+--    Narrowed to stage='execution_guard' + pass_fail='FAIL' because
+--    (a) the /alerts endpoint filters on both, (b) other stages write to
+--    decision_audit (e.g. order_execution, deferred_retry) and must not
+--    be indexed as guard rejections.
+
+ALTER TABLE operators
+    ADD COLUMN IF NOT EXISTS alerts_last_seen_decision_id BIGINT;
+
+CREATE INDEX IF NOT EXISTS idx_decision_audit_guard_failed_recent
+    ON decision_audit (decision_time DESC)
+    WHERE pass_fail = 'FAIL' AND stage = 'execution_guard';
+```
+
+Existing `pass_fail` convention (see [app/services/execution_guard.py:87](../../app/services/execution_guard.py) `Verdict = Literal["PASS", "FAIL"]`): uppercase. `stage` written via the `STAGE: str = "execution_guard"` constant at [app/services/execution_guard.py:70](../../app/services/execution_guard.py). `decision_id` is `BIGSERIAL PRIMARY KEY` on `decision_audit` (see [sql/001_init.sql](../../sql/001_init.sql) L195).
+
+No backfill. No data migration.
+
+---
+
+## Backend
+
+### `GET /alerts/guard-rejections`
+
+**Module:** new file `app/api/alerts.py`. Router registered in [app/main.py](../../app/main.py) alongside existing `/alerts` consumers (none today — path is free, verified via grep).
+
+**Auth:** `dependencies=[Depends(require_session_or_service_token)]` + `sole_operator_id(conn)` — matches [app/api/watchlist.py:32](../../app/api/watchlist.py).
+
+**Operator-resolution errors** (propagated from `sole_operator_id`):
+- `NoOperatorError` → HTTP 503 (installation incomplete)
+- `AmbiguousOperatorError` → HTTP 501 (unsupported multi-operator state)
+
+Same shape as existing watchlist / portfolio routes; do not invent new codes.
+
+**Query:**
+
+```sql
+SELECT
+    da.decision_id,
+    da.decision_time,
+    da.instrument_id,
+    i.symbol,
+    tr.action,
+    da.explanation
+FROM decision_audit da
+LEFT JOIN instruments i ON i.instrument_id = da.instrument_id
+LEFT JOIN trade_recommendations tr ON tr.recommendation_id = da.recommendation_id
+WHERE da.pass_fail = 'FAIL'
+  AND da.stage = 'execution_guard'
+  AND da.decision_time >= now() - INTERVAL '7 days'
+ORDER BY da.decision_id DESC
+LIMIT 500;
+```
+
+Ordering is by `decision_id DESC` (the unique BIGSERIAL PK), **not** `decision_time DESC`. Guard audit rows use an app-supplied timestamp from `_utcnow()` ([app/services/execution_guard.py:609](../../app/services/execution_guard.py)), not DB `now()` — so a clock-skewed host could insert a row with a later `decision_id` but an earlier `decision_time`. Ordering on `decision_time` would push that row below older-`decision_id` rows and break the `rejections[0].decision_id === MAX(decision_id)` invariant the ack cursor depends on. `decision_time` is retained as the 7-day window filter (still monotonic-enough across a multi-day window that occasional backskew doesn't matter for filtering) and as the row-display timestamp, but not as a sort key.
+
+**Why LIMIT 500, not 50**: the button text is "Mark all read", and `seen_through_decision_id` clears every row with `decision_id <= seen_through_decision_id`. If `unseen_count` exceeds what the operator saw, clicking the button would silently acknowledge rows the client never rendered. 500 is large enough to cover any plausible 7-day guard-rejection count (≈70/day is extreme) while still being a bounded scan over the partial index. **The frontend renders every row in the payload** (scrollable container, no client-side slice) so `rejections.length` == "rows the operator actually saw". **Safety rule**: the "Mark all read" button is hidden when `unseen_count > rejections.length` — only true when total unseen exceeds 500, i.e., the true overflow case. See the overflow-exit path under the frontend section.
+
+`pass_fail` / `stage` values match guard writer exactly (see Schema section — prevention: shared column vocabulary mismatch across stages). `now()` is DB-side (prevention: `datetime.now(UTC)` vs DB `now()` in freshness windows). Interval literal inlined — no string concatenation (prevention: interval construction via SQL string concatenation).
+
+**`unseen_count` query** (separate; reflects true 7-day window count even when list is capped at 500):
+
+```sql
+SELECT COUNT(*) AS unseen_count
+FROM decision_audit
+WHERE pass_fail = 'FAIL'
+  AND stage = 'execution_guard'
+  AND decision_time >= now() - INTERVAL '7 days'
+  AND (%(last_id)s IS NULL OR decision_id > %(last_id)s);
+```
+
+`%(last_id)s` is the operator's current `alerts_last_seen_decision_id`. `decision_id > …` is strict — a row at the same `decision_id` cannot exist (primary key is unique), so ties are structurally impossible, closing the race documented in the Schema rationale.
+
+**Response envelope:**
+
+```json
+{
+  "alerts_last_seen_decision_id": 1200,
+  "unseen_count": 3,
+  "rejections": [
+    {
+      "decision_id": 1234,
+      "decision_time": "2026-04-21T09:30:00+00:00",
+      "instrument_id": 42,
+      "symbol": "AAPL",
+      "action": "BUY",
+      "explanation": "FAIL — cash_available: need £200, have £50"
+    }
+  ]
+}
+```
+
+**Nullability:** `instrument_id`, `symbol`, `action` all nullable (audit rows can be written without linked recommendation per [sql/010_execution_guard.sql](../../sql/010_execution_guard.sql) schema note).
+
+**`action` type:** `Literal["BUY", "ADD", "HOLD", "EXIT"] | None`. Canonical action set from [app/api/recommendations.py:43](../../app/api/recommendations.py) and [app/services/portfolio.py:73](../../app/services/portfolio.py). Mirror on the frontend `Literal` union (prevention: Loose `string` on API response fields mirroring backend `Literal`). `HOLD` rows are included if guard-evaluated — Phase 3 does not pre-filter by action; operator can see the full failure set.
+
+### `POST /alerts/seen` (normal path)
+
+**Body:** `{ "seen_through_decision_id": 1234 }` (integer; matches `decision_audit.decision_id`).
+
+**Semantics:** the `max(decision_id)` of the rejections in the preceding GET response. Client sends `rejections[0].decision_id`. The GET query orders by `decision_id DESC` (primary BIGSERIAL sequence), not `decision_time DESC`, so index 0 is deterministically MAX regardless of any app-side clock skew that might have produced a smaller `decision_time` for a larger `decision_id`. A row inserted between GET and POST has `decision_id > rejections[0].decision_id`, so the strict `>` comparison in the unseen query leaves it unseen (race-safe).
+
+The "Mark all read" button is only rendered when `unseen_count > 0 && unseen_count <= rejections.length` (see Frontend section); if there are zero rejections, the strip itself is hidden, so the frontend never POSTs an empty body.
+
+**Server-side validation + clamp:**
+
+- `seen_through_decision_id` is a required positive integer; missing → 422, non-integer/non-positive → 422.
+- Clamp to current in-window guard MAX — a buggy or malicious client posting a huge `decision_id` must not permanently advance the cursor past unseen future rows. The `LEAST(...)` in the UPDATE bounds the ack to rows that actually exist in the current 7-day guard-failure window.
+
+**Write:**
+
+```sql
+UPDATE operators
+SET alerts_last_seen_decision_id = GREATEST(
+    COALESCE(alerts_last_seen_decision_id, 0),
+    LEAST(
+        %(seen_through_decision_id)s,
+        COALESCE((
+            SELECT MAX(decision_id)
+            FROM decision_audit
+            WHERE pass_fail = 'FAIL'
+              AND stage = 'execution_guard'
+              AND decision_time >= now() - INTERVAL '7 days'
+        ), 0)
+    )
+)
+WHERE operator_id = %(op)s;
+```
+
+Monotonic — never rewinds (`COALESCE(..., 0)` ensures `GREATEST` works when current value is NULL). Clamped by `LEAST` so a client cannot advance the cursor past the real data. A client replaying an older ack cannot regress the cursor.
+
+**Response:** 204 No Content.
+
+### `POST /alerts/dismiss-all` (overflow path)
+
+**Body:** empty (no parameters).
+
+**Semantics:** explicit operator acknowledgement that they are dismissing every in-window guard rejection — including rows the frontend never received (only possible when `unseen_count > 500`). Server atomically advances the cursor to the current `MAX(decision_id)` for guard-stage rows in the 7-day window.
+
+**Write:**
+
+```sql
+UPDATE operators AS op
+SET alerts_last_seen_decision_id = GREATEST(
+    COALESCE(op.alerts_last_seen_decision_id, 0),
+    m.max_id
+)
+FROM (
+    SELECT MAX(decision_id) AS max_id
+    FROM decision_audit
+    WHERE pass_fail = 'FAIL'
+      AND stage = 'execution_guard'
+      AND decision_time >= now() - INTERVAL '7 days'
+) AS m
+WHERE op.operator_id = %(op)s
+  AND m.max_id IS NOT NULL;
+```
+
+No-op on empty window (no guard rows in 7-day window → `m.max_id IS NULL` → UPDATE matches zero rows → cursor unchanged). Atomic — a guard row inserted between the subselect and the UPDATE commit gets a larger `decision_id` and stays unseen on next GET, preserving race safety on the overflow path as well.
+
+**Response:** 204 No Content.
+
+### Error semantics
+
+- Guard-rejections GET failing should **not** 500 the dashboard; the frontend renders null on error (silent-on-error policy for strips, prevention: Frontend async render-surface isolation). Backend still returns proper 500 on internal errors — silent-on-error is a **frontend** concession, not a backend contract.
+- `GET /alerts/guard-rejections` must complete in <200ms on typical load. Partial index keeps the 7-day scan cheap.
+
+---
+
+## Frontend
+
+### `frontend/src/api/alerts.ts`
+
+```ts
+export type GuardRejectionAction = "BUY" | "ADD" | "HOLD" | "EXIT";
+
+export interface GuardRejection {
+  decision_id: number;
+  decision_time: string;
+  instrument_id: number | null;
+  symbol: string | null;
+  action: GuardRejectionAction | null;
+  explanation: string;
+}
+
+export interface GuardRejectionsResponse {
+  alerts_last_seen_decision_id: number | null;
+  unseen_count: number;
+  rejections: GuardRejection[];
+}
+
+export async function fetchGuardRejections(): Promise<GuardRejectionsResponse>;
+export async function markAlertsSeen(seenThroughDecisionId: number): Promise<void>;
+export async function dismissAllAlerts(): Promise<void>;
+```
+
+Uses existing `apiFetch` helper — matches `frontend/src/api/portfolio.ts` shape.
+
+### `frontend/src/components/dashboard/AlertsStrip.tsx`
+
+**Render rules:**
+
+1. `rejections.length === 0` → component returns `null`. Do not reserve dashboard space for zero signal.
+2. Fetch error → component returns `null` (silent-on-error; matches `RollingPnlStrip` pattern from PR #388).
+3. Header: `"Guard rejections"` + pill `"{unseen_count} new"` when `unseen_count > 0`. Right side: either "Mark all read" (normal path) or "Dismiss all ({unseen_count}) as acknowledged" (overflow path) — see below.
+4. Body renders **every row in the payload** (up to 500) in a scrollable container (CSS `max-height: 24rem; overflow-y: auto;`). No client-side slice — `rejections.length` equals "rows the operator actually saw".
+5. Row per rejection:
+   - Amber left border if `decision_id > alerts_last_seen_decision_id` (or `alerts_last_seen_decision_id === null`); slate otherwise.
+   - Columns: symbol · action · truncated `explanation` (title attribute = full) · relative time (`formatRelativeTime`).
+   - Row wraps in a React Router Link to `/instruments/{instrument_id}` when `instrument_id != null`; plain row div otherwise.
+
+**Normal path — "Mark all read":**
+
+```ts
+await markAlertsSeen(rejections[0].decision_id);  // newest decision_id in payload
+refetch();
+```
+
+`decision_id` is a unique BIGSERIAL — the strict `>` comparison on the server closes the tie-break race that a timestamp-only cursor would leave.
+
+**Overflow path — "Dismiss all ({unseen_count}) as acknowledged":**
+
+Triggered when `unseen_count > rejections.length` (total unseen exceeds the 500-row payload). The normal "Mark all read" button would ack rows the operator never rendered; that's the bug the safety rule blocks. To avoid a dead-end (the overflow previously pointed at read-only `/recommendations`, leaving the badge stuck until rows aged out), the button swaps label and intent: operator explicitly acknowledges all in-window rejections, including the `unseen_count - rejections.length` that could not be rendered.
+
+Behaviour:
+
+- Button opens a confirm dialog: "Dismiss all {unseen_count} unseen rejections? {unseen_count - rejections.length} are not shown above. Review them at /recommendations before dismissing if they might matter."
+- Confirm → `POST /alerts/dismiss-all` (no body); server atomically advances the cursor to the current MAX(decision_id) in the 7-day guard-failure window. No client-side timestamp is sent.
+- Cancel → no-op, badge stays.
+- Link to `/recommendations` shown beside the button for full triage ([frontend/src/pages/RecommendationsPage.tsx](../../frontend/src/pages/RecommendationsPage.tsx) route wired at [frontend/src/App.tsx](../../frontend/src/App.tsx)).
+
+**Render rule for the header actions:**
+
+```ts
+const normalAck = unseenCount > 0 && unseenCount <= rejections.length;
+const overflowAck = unseenCount > rejections.length;
+// Exactly one of normalAck / overflowAck is ever true when unseenCount > 0.
+```
+
+### Wire into `DashboardPage.tsx`
+
+New `useAsync(fetchGuardRejections, [])` hook. Rendered between `RollingPnlStrip` and the Positions section ([frontend/src/pages/DashboardPage.tsx](../../frontend/src/pages/DashboardPage.tsx) layout comment already documents the strip order).
+
+No page-level error coupling — strip is self-isolating per rule 2 above.
+
+---
+
+## Tests
+
+### Backend (`tests/test_api_alerts.py`)
+
+Fixtures: minimum schema (operators, instruments, trade_recommendations, decision_audit). Test DB isolation via `ebull_test` (prevention: tests must never wipe dev DB).
+
+1. **Empty state** — no rows → `{ rejections: [], unseen_count: 0, alerts_last_seen_decision_id: null }`.
+2. **7-day window inclusion** — insert rows at `now() - interval '6 days'` and `now() - interval '8 days'`; only the 6-day row returned.
+3. **500-row cap** — insert 510 failed rows within window, `alerts_last_seen_decision_id = NULL`; `rejections.length === 500`, `unseen_count === 510` (count query reflects true total, not the LIMIT). Frontend-side: this is the condition that triggers the overflow branch.
+4. **pass_fail excludes `'PASS'`** — insert mixed; only `FAIL` rows returned.
+5. **`unseen_count` anchor** — `alerts_last_seen_decision_id` set to mid-window value; rows with smaller `decision_id` → not counted, larger → counted.
+6. **`unseen_count` NULL last-seen** — all in-window rows counted.
+7. **POST /alerts/seen monotonic** — current = 1000, POST `seen_through_decision_id = 500` → column unchanged (GREATEST keeps 1000).
+8. **POST /alerts/seen first time** — NULL current, POST `1000` → set to 1000.
+9. **POST /alerts/seen missing field** — body `{}` → 422.
+10. **POST /alerts/seen non-integer** — body `{"seen_through_decision_id": "abc"}` → 422.
+11. **POST /alerts/seen clamped to MAX-in-window** — window MAX = 200; cursor NULL; POST `seen_through_decision_id = 99999` → column set to 200 (clamped by `LEAST`). Prevents buggy client from blinding operator to future alerts.
+12. **POST /alerts/seen race safety** — insert row `R_new` with `decision_id = 101`; operator posts `seen_through_decision_id = 100`; after POST, `unseen_count === 1` (R_new `decision_id = 101 > 100` still unseen — strict `>` comparison).
+13. **GET ordering by decision_id not decision_time** — insert two FAIL rows where `decision_id = 50` has `decision_time = now()` and `decision_id = 51` has `decision_time = now() - '1 minute'` (simulates app-side clock skew); `rejections[0].decision_id === 51` (ordering is `decision_id DESC`, which puts the later-PK row first even though its `decision_time` is earlier).
+14. **POST /alerts/dismiss-all advances to MAX** — insert rows with `decision_id` 100, 200, 300 within window; cursor NULL; POST dismiss-all → column set to 300.
+15. **POST /alerts/dismiss-all monotonic** — current = 500, MAX-in-window = 300; POST → column unchanged at 500 (GREATEST keeps 500; never rewinds).
+16. **POST /alerts/dismiss-all race safety** — start with cursor NULL; insert guard rows 100 and 200; POST dismiss-all; then insert row 201 → next GET shows unseen_count === 1 (row 201 arrived after the atomic MAX subselect).
+17. **POST /alerts/dismiss-all empty window** — no rows in window; cursor NULL; POST → column stays NULL (SQL UPDATE is no-op because `m.max_id IS NULL` excludes the row from matching).
+18. **POST /alerts/dismiss-all empty window with existing cursor** — cursor = 500, no rows in window; POST → column unchanged at 500.
+19. **Non-guard stage excluded** — insert FAIL row with `stage = 'order_execution'` → excluded from `/alerts/guard-rejections` and from `/alerts/dismiss-all` MAX scope.
+20. **Missing instrument_id / recommendation_id** — row still renders with nulls for `symbol`, `action`.
+21. **HOLD action round-trip** — row with `action = 'HOLD'` serialises through API without coercion.
+22. **`sole_operator_id` errors** — no operator → 503; multiple operators → 501 (both endpoints).
+
+### Frontend (`AlertsStrip.test.tsx`)
+
+1. Zero rejections → component renders nothing (`expect(container).toBeEmptyDOMElement()`).
+2. Fetch error → component renders nothing (silent-on-error).
+3. Overflow render — when `unseen_count > rejections.length` → "Mark all read" hidden, "Dismiss all ({unseen_count}) as acknowledged" rendered with confirm dialog + `/recommendations` link shown beside it.
+4. Overflow confirm behaviour — click "Dismiss all" → confirm dialog opens; confirm → `dismissAllAlerts` called (no body), then `refetch` triggered. Assert the POST actually fires, not just that the button exists.
+5. Overflow cancel behaviour — click "Dismiss all" → confirm dialog opens; cancel → `dismissAllAlerts` NOT called, `refetch` NOT triggered, badge state unchanged.
+6. When `rejections.length === 500` and `unseen_count === 500` (all unseen, none beyond payload) → "Mark all read" button stays visible (normal path). Pins the safety rule's positive branch at the cap.
+7. Unseen rows: amber border class present; seen rows: slate class present.
+8. "Mark all read" → `markAlertsSeen` called with `rejections[0].decision_id` (newest decision_id in payload); `refetch` triggered.
+9. `instrument_id !== null` → row is a `<Link>`; `instrument_id === null` → plain row.
+10. `unseen_count === 0` → no "Mark all read" button, no "N new" pill.
+11. Explanation truncates with title attribute preserving full text.
+
+Reuse existing `useAsync` test harness and `MemoryRouter` pattern from `frontend/src/components/dashboard/RollingPnlStrip.test.tsx`.
+
+---
+
+## Prevention entries consulted
+
+| Entry | How applied |
+|---|---|
+| `datetime.now(UTC)` vs DB `now()` in freshness windows | Both endpoints use DB `now()` |
+| Unbounded API limit parameters | 7-day window + 500-row hard cap hardcoded server-side; frontend renders every row in the payload (no client-side slice) so `rejections.length` == "rows operator saw" |
+| Interval construction via string concatenation in SQL | `INTERVAL '7 days'` literal; no concatenation |
+| Loose `string` on API response fields that mirror backend `Literal` | `action` typed as `Literal` union both sides |
+| Frontend async render-surface isolation | Strip silent-on-error; does not couple to page banner |
+| API response shapes invented at the type boundary | Envelope + row shapes defined in backend + frontend + tests |
+| Naive datetime in TIMESTAMPTZ query params | N/A — cursor is BIGINT `decision_id`, not a timestamp, so no naive-datetime parse path exists |
+| Unbounded enum filters accept nonsense values silently | No filter params accepted on GET (fixed window) |
+
+## Settled decisions consulted
+
+| Decision | How applied |
+|---|---|
+| Guard auditability — one decision_audit row per guard invocation | This is the read side of that contract |
+| Product-visibility pivot — prioritise operator visibility over infra work | Closes final phase of #315 |
+
+---
+
+## Definition of done
+
+1. Migration applied cleanly against dev DB.
+2. Both endpoints return shapes documented above; tests pass.
+3. Dashboard renders strip between `RollingPnlStrip` and Positions when rejections exist.
+4. "Mark all read" refetches strip; `unseen_count` reflects only rejections written after the POST (races are honoured — rows that arrived between GET and POST remain unseen per race-safety contract).
+5. Strip hidden when rejections are empty.
+6. `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright`, `uv run pytest` all pass.
+7. `pnpm --dir frontend typecheck`, `pnpm --dir frontend test` all pass.
+8. Codex pre-spec pass complete (this document); Codex pre-push pass before first `git push`.
+9. PR description self-contained per `feedback_pr_description_brevity.md`.
+10. On merge: #394, #395, #396 filed; #315 closed.

--- a/frontend/src/api/alerts.ts
+++ b/frontend/src/api/alerts.ts
@@ -1,0 +1,35 @@
+import { apiFetch } from "@/api/client";
+import type { GuardRejectionsResponse } from "@/api/types";
+
+/**
+ * Fetchers for the alerts endpoints.
+ *
+ * Mirrors:
+ *   GET /alerts/guard-rejections              -> app/api/alerts.py
+ *   POST /alerts/seen                         -> app/api/alerts.py
+ *   POST /alerts/dismiss-all                  -> app/api/alerts.py
+ *
+ * All endpoints are protected by require_session_or_service_token
+ * (cookie auth; apiFetch passes credentials: include). Errors bubble
+ * as ApiError(status, detail) — the backend's `detail` string is a
+ * fixed phrase so callers may surface it verbatim via `error.message`.
+ *
+ * Contract: no business logic here. Typed wrapper only. Anything
+ * resembling validation, retry, caching, or analytics belongs in
+ * the calling component.
+ */
+
+export function fetchGuardRejections(): Promise<GuardRejectionsResponse> {
+  return apiFetch<GuardRejectionsResponse>("/alerts/guard-rejections");
+}
+
+export function markAlertsSeen(seenThroughDecisionId: number): Promise<void> {
+  return apiFetch<void>("/alerts/seen", {
+    method: "POST",
+    body: JSON.stringify({ seen_through_decision_id: seenThroughDecisionId }),
+  });
+}
+
+export function dismissAllAlerts(): Promise<void> {
+  return apiFetch<void>("/alerts/dismiss-all", { method: "POST" });
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -906,3 +906,24 @@ export interface LayerEnabledResponse {
   is_enabled: boolean;
   warning: string | null;
 }
+
+// ---------------------------------------------------------------------------
+// #315 Phase 3 — alerts strip (app/api/alerts.py)
+// ---------------------------------------------------------------------------
+
+export type GuardRejectionAction = "BUY" | "ADD" | "HOLD" | "EXIT";
+
+export interface GuardRejection {
+  decision_id: number;
+  decision_time: string;  // ISO TIMESTAMPTZ
+  instrument_id: number | null;
+  symbol: string | null;
+  action: GuardRejectionAction | null;
+  explanation: string;
+}
+
+export interface GuardRejectionsResponse {
+  alerts_last_seen_decision_id: number | null;
+  unseen_count: number;
+  rejections: GuardRejection[];
+}

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { AlertsStrip } from "@/components/dashboard/AlertsStrip";
+import type { GuardRejectionsResponse } from "@/api/types";
+
+vi.mock("@/api/alerts", () => ({
+  fetchGuardRejections: vi.fn(),
+  markAlertsSeen: vi.fn(),
+  dismissAllAlerts: vi.fn(),
+}));
+
+import * as alertsApi from "@/api/alerts";
+
+const baseRow = {
+  decision_id: 501,
+  decision_time: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+  instrument_id: 42,
+  symbol: "AAPL",
+  action: "BUY" as const,
+  explanation: "FAIL — cash_available: need £200, have £50",
+};
+
+const mockedFetch = vi.mocked(alertsApi.fetchGuardRejections);
+
+function stubFetch(data: GuardRejectionsResponse | null) {
+  mockedFetch.mockResolvedValue(data ?? ({} as GuardRejectionsResponse));
+}
+
+function stubFetchError() {
+  mockedFetch.mockRejectedValue(new Error("boom"));
+}
+
+function renderStrip() {
+  return render(
+    <MemoryRouter>
+      <AlertsStrip />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AlertsStrip", () => {
+  it("renders nothing when rejections list is empty", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 0,
+      rejections: [],
+    });
+    const { container } = renderStrip();
+    await vi.waitFor(() => {
+      expect(alertsApi.fetchGuardRejections).toHaveBeenCalled();
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing on fetch error (silent-on-error)", async () => {
+    stubFetchError();
+    const { container } = renderStrip();
+    await vi.waitFor(() => {
+      expect(alertsApi.fetchGuardRejections).toHaveBeenCalled();
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders row symbol / action / explanation", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 1,
+      rejections: [baseRow],
+    });
+    renderStrip();
+    expect(await screen.findByText("AAPL")).toBeInTheDocument();
+    expect(screen.getByText("BUY")).toBeInTheDocument();
+    expect(
+      screen.getByText(/cash_available: need £200/),
+    ).toBeInTheDocument();
+  });
+
+  it("wraps row in a Link when instrument_id is non-null", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 1,
+      rejections: [baseRow],
+    });
+    renderStrip();
+    const link = await screen.findByRole("link");
+    expect(link.getAttribute("href")).toBe("/instruments/42");
+  });
+
+  it("renders plain row (no link) when instrument_id is null", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 1,
+      rejections: [{ ...baseRow, instrument_id: null, symbol: null }],
+    });
+    renderStrip();
+    await screen.findByText(/cash_available/);
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("applies amber border for unseen rows, slate for seen", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: 500,
+      unseen_count: 1,
+      rejections: [
+        { ...baseRow, decision_id: 501 },  // unseen (501 > 500)
+        { ...baseRow, decision_id: 499 },  // seen (499 <= 500)
+      ],
+    });
+    renderStrip();
+    const rows = await screen.findAllByTestId("alerts-row");
+    expect(rows[0]!.className).toMatch(/border-amber/);
+    expect(rows[1]!.className).toMatch(/border-slate/);
+  });
+
+  it("shows unseen_count pill when unseen_count > 0", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 3,
+      rejections: [baseRow],
+    });
+    renderStrip();
+    expect(await screen.findByText(/3 new/)).toBeInTheDocument();
+  });
+
+  it("omits unseen_count pill when unseen_count === 0", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: 999,
+      unseen_count: 0,
+      rejections: [baseRow],  // still shown, just all seen
+    });
+    renderStrip();
+    await screen.findByText("AAPL");
+    expect(screen.queryByText(/new$/)).toBeNull();
+  });
+
+  it("truncates explanation visually but preserves full text in title", async () => {
+    const long = "FAIL — cash_available: need £200; thesis_stale: 14 days old; spread_wide: 0.12%";
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 1,
+      rejections: [{ ...baseRow, explanation: long }],
+    });
+    renderStrip();
+    const node = await screen.findByText(long);
+    expect(node.getAttribute("title")).toBe(long);
+    expect(node.className).toMatch(/truncate/);
+  });
+});

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -214,3 +214,60 @@ describe("AlertsStrip — Mark all read (normal path)", () => {
     });
   });
 });
+
+describe("AlertsStrip — Dismiss all (overflow path)", () => {
+  function overflowStub() {
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 600,
+      rejections: Array.from({ length: 500 }, (_, i) => ({
+        ...baseRow,
+        decision_id: 600 - i,
+      })),
+    });
+  }
+
+  it("renders 'Dismiss all (600) as acknowledged' and a /recommendations link when unseen_count > rejections.length", async () => {
+    overflowStub();
+    renderStrip();
+    expect(
+      await screen.findByRole("button", { name: /dismiss all \(600\)/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /mark all read/i })).toBeNull();
+    const recLink = screen.getByRole("link", { name: /recommendations/i });
+    expect(recLink.getAttribute("href")).toBe("/recommendations");
+  });
+
+  it("confirm dialog: confirm calls dismissAllAlerts + refetch", async () => {
+    overflowStub();
+    vi.mocked(alertsApi.dismissAllAlerts).mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderStrip();
+
+    const btn = await screen.findByRole("button", { name: /dismiss all \(600\)/i });
+    await userEvent.click(btn);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(alertsApi.dismissAllAlerts).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+    confirmSpy.mockRestore();
+  });
+
+  it("confirm dialog: cancel does NOT call dismissAllAlerts or refetch", async () => {
+    overflowStub();
+    vi.mocked(alertsApi.dismissAllAlerts).mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    renderStrip();
+
+    const fetchCallsBefore = vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length;
+    const btn = await screen.findByRole("button", { name: /dismiss all \(600\)/i });
+    await userEvent.click(btn);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(alertsApi.dismissAllAlerts).not.toHaveBeenCalled();
+    expect(vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length).toBe(fetchCallsBefore);
+    confirmSpy.mockRestore();
+  });
+});

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -213,6 +213,29 @@ describe("AlertsStrip — Mark all read (normal path)", () => {
       expect(vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length).toBeGreaterThanOrEqual(2);
     });
   });
+
+  it("swallows markAlertsSeen rejection silently and still refetches", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: 499,
+      unseen_count: 1,
+      rejections: [{ ...baseRow, decision_id: 501 }],
+    });
+    vi.mocked(alertsApi.markAlertsSeen).mockRejectedValue(new Error("boom"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    renderStrip();
+
+    const btn = await screen.findByRole("button", { name: /mark all read/i });
+    await userEvent.click(btn);
+
+    await vi.waitFor(() => {
+      expect(errSpy).toHaveBeenCalled();
+    });
+    // Refetch fires even after a failed ack.
+    await vi.waitFor(() => {
+      expect(vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+    errSpy.mockRestore();
+  });
 });
 
 describe("AlertsStrip — Dismiss all (overflow path)", () => {
@@ -269,5 +292,25 @@ describe("AlertsStrip — Dismiss all (overflow path)", () => {
     expect(alertsApi.dismissAllAlerts).not.toHaveBeenCalled();
     expect(vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length).toBe(fetchCallsBefore);
     confirmSpy.mockRestore();
+  });
+
+  it("swallows dismissAllAlerts rejection silently and still refetches", async () => {
+    overflowStub();
+    vi.mocked(alertsApi.dismissAllAlerts).mockRejectedValue(new Error("boom"));
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    renderStrip();
+
+    const btn = await screen.findByRole("button", { name: /dismiss all \(600\)/i });
+    await userEvent.click(btn);
+
+    await vi.waitFor(() => {
+      expect(errSpy).toHaveBeenCalled();
+    });
+    await vi.waitFor(() => {
+      expect(vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+    confirmSpy.mockRestore();
+    errSpy.mockRestore();
   });
 });

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -24,8 +24,8 @@ const baseRow = {
 
 const mockedFetch = vi.mocked(alertsApi.fetchGuardRejections);
 
-function stubFetch(data: GuardRejectionsResponse | null) {
-  mockedFetch.mockResolvedValue(data ?? ({} as GuardRejectionsResponse));
+function stubFetch(data: GuardRejectionsResponse) {
+  mockedFetch.mockResolvedValue(data);
 }
 
 function stubFetchError() {

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
@@ -150,5 +151,66 @@ describe("AlertsStrip", () => {
     const node = await screen.findByText(long);
     expect(node.getAttribute("title")).toBe(long);
     expect(node.className).toMatch(/truncate/);
+  });
+});
+
+describe("AlertsStrip — Mark all read (normal path)", () => {
+  it("renders 'Mark all read' when unseen_count > 0 and <= rejections.length", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: 499,
+      unseen_count: 2,
+      rejections: [
+        { ...baseRow, decision_id: 501 },
+        { ...baseRow, decision_id: 500 },
+      ],
+    });
+    renderStrip();
+    expect(await screen.findByRole("button", { name: /mark all read/i })).toBeInTheDocument();
+  });
+
+  it("hides 'Mark all read' when unseen_count === 0 (all rows already seen)", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: 999,
+      unseen_count: 0,
+      rejections: [{ ...baseRow, decision_id: 500 }],  // seen (500 < 999)
+    });
+    renderStrip();
+    await screen.findByText("AAPL");
+    expect(screen.queryByRole("button", { name: /mark all read/i })).toBeNull();
+  });
+
+  it("stays visible at the 500-row cap when unseen_count === rejections.length === 500", async () => {
+    const rejections = Array.from({ length: 500 }, (_, i) => ({
+      ...baseRow,
+      decision_id: 500 - i,
+    }));
+    stubFetch({
+      alerts_last_seen_decision_id: null,
+      unseen_count: 500,
+      rejections,
+    });
+    renderStrip();
+    expect(await screen.findByRole("button", { name: /mark all read/i })).toBeInTheDocument();
+  });
+
+  it("click posts rejections[0].decision_id and refetches", async () => {
+    stubFetch({
+      alerts_last_seen_decision_id: 499,
+      unseen_count: 2,
+      rejections: [
+        { ...baseRow, decision_id: 501 },
+        { ...baseRow, decision_id: 500 },
+      ],
+    });
+    vi.mocked(alertsApi.markAlertsSeen).mockResolvedValue(undefined);
+    renderStrip();
+
+    const btn = await screen.findByRole("button", { name: /mark all read/i });
+    await userEvent.click(btn);
+
+    expect(alertsApi.markAlertsSeen).toHaveBeenCalledWith(501);  // MAX(decision_id) in payload
+    await vi.waitFor(() => {
+      expect(vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
   });
 });

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -1,0 +1,93 @@
+/**
+ * AlertsStrip — guard-rejection alerts on the operator dashboard (#315 Phase 3).
+ *
+ * Sits between RollingPnlStrip and PortfolioValueChart. Hidden when empty;
+ * silent on fetch error (matches the RollingPnlStrip pattern — a failing
+ * /alerts must not blank the dashboard).
+ *
+ * Cursor is decision_id (not decision_time) — see spec
+ * docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md for why.
+ */
+import { Link } from "react-router-dom";
+
+import { fetchGuardRejections } from "@/api/alerts";
+// markAlertsSeen and dismissAllAlerts are added in Tasks 10 and 11.
+import type { GuardRejection } from "@/api/types";
+import { formatRelativeTime } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+function isUnseen(
+  row: GuardRejection,
+  lastSeen: number | null,
+): boolean {
+  return lastSeen === null || row.decision_id > lastSeen;
+}
+
+function RowView({
+  row,
+  lastSeen,
+}: {
+  row: GuardRejection;
+  lastSeen: number | null;
+}) {
+  const unseen = isUnseen(row, lastSeen);
+  const border = unseen
+    ? "border-l-4 border-amber-400"
+    : "border-l-4 border-slate-200";
+  const content = (
+    <div
+      data-testid="alerts-row"
+      className={`flex items-center gap-3 px-3 py-2 text-sm ${border} bg-white`}
+    >
+      <span className="w-16 font-semibold tabular-nums">{row.symbol ?? "—"}</span>
+      <span className="w-12 text-xs uppercase text-slate-500">{row.action ?? "—"}</span>
+      <span
+        className="flex-1 truncate text-slate-700"
+        title={row.explanation}
+      >
+        {row.explanation}
+      </span>
+      <span className="w-20 text-right text-xs text-slate-400">
+        {formatRelativeTime(row.decision_time)}
+      </span>
+    </div>
+  );
+  if (row.instrument_id !== null) {
+    return (
+      <Link to={`/instruments/${row.instrument_id}`} className="block hover:bg-slate-50">
+        {content}
+      </Link>
+    );
+  }
+  return content;
+}
+
+export function AlertsStrip(): JSX.Element | null {
+  const { data, error } = useAsync(fetchGuardRejections, []);
+
+  if (error !== null || data === null) return null;
+  if (data.rejections.length === 0) return null;
+
+  const lastSeen = data.alerts_last_seen_decision_id;
+
+  return (
+    <section className="rounded-md border border-slate-200 bg-white shadow-sm">
+      <header className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-slate-700">Guard rejections</h2>
+          {data.unseen_count > 0 ? (
+            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+              {data.unseen_count} new
+            </span>
+          ) : null}
+        </div>
+        {/* Action buttons land in Tasks 10 and 11 */}
+      </header>
+      <div className="max-h-96 overflow-y-auto divide-y divide-slate-100">
+        {data.rejections.map((row) => (
+          <RowView key={row.decision_id} row={row} lastSeen={lastSeen} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -10,8 +10,7 @@
  */
 import { Link } from "react-router-dom";
 
-import { fetchGuardRejections, markAlertsSeen } from "@/api/alerts";
-// dismissAllAlerts is added in Task 11.
+import { dismissAllAlerts, fetchGuardRejections, markAlertsSeen } from "@/api/alerts";
 import type { GuardRejection } from "@/api/types";
 import { formatRelativeTime } from "@/lib/format";
 import { useAsync } from "@/lib/useAsync";
@@ -72,12 +71,21 @@ export function AlertsStrip(): JSX.Element | null {
   const lastSeen = data.alerts_last_seen_decision_id;
   const normalAck =
     data.unseen_count > 0 && data.unseen_count <= data.rejections.length;
+  const overflowAck = data.unseen_count > data.rejections.length;
 
   async function onMarkAllRead() {
     // rejections is non-empty here (strip is hidden otherwise),
     // and is ordered decision_id DESC on the server so index 0 is MAX.
     const seenThroughDecisionId = data!.rejections[0]!.decision_id;
     await markAlertsSeen(seenThroughDecisionId);
+    refetch();
+  }
+
+  async function onDismissAll() {
+    const hiddenCount = data!.unseen_count - data!.rejections.length;
+    const msg = `Dismiss all ${data!.unseen_count} unseen rejections? ${hiddenCount} are not shown above. Review them at /recommendations before dismissing if they might matter.`;
+    if (!window.confirm(msg)) return;
+    await dismissAllAlerts();
     refetch();
   }
 
@@ -100,6 +108,23 @@ export function AlertsStrip(): JSX.Element | null {
           >
             Mark all read
           </button>
+        ) : null}
+        {overflowAck ? (
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onDismissAll}
+              className="rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 hover:bg-amber-100"
+            >
+              Dismiss all ({data.unseen_count}) as acknowledged
+            </button>
+            <Link
+              to="/recommendations"
+              className="text-xs text-slate-500 underline hover:text-slate-700"
+            >
+              Triage at /recommendations
+            </Link>
+          </div>
         ) : null}
       </header>
       <div

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -37,6 +37,7 @@ function RowView({
   const content = (
     <div
       data-testid="alerts-row"
+      role="listitem"
       className={`flex items-center gap-3 px-3 py-2 text-sm ${border} bg-white`}
     >
       <span className="w-16 font-semibold tabular-nums">{row.symbol ?? "—"}</span>
@@ -71,10 +72,18 @@ export function AlertsStrip(): JSX.Element | null {
   const lastSeen = data.alerts_last_seen_decision_id;
 
   return (
-    <section className="rounded-md border border-slate-200 bg-white shadow-sm">
+    <section
+      className="rounded-md border border-slate-200 bg-white shadow-sm"
+      aria-labelledby="alerts-strip-heading"
+    >
       <header className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
         <div className="flex items-center gap-2">
-          <h2 className="text-sm font-semibold text-slate-700">Guard rejections</h2>
+          <h2
+            id="alerts-strip-heading"
+            className="text-sm font-semibold text-slate-700"
+          >
+            Guard rejections
+          </h2>
           {data.unseen_count > 0 ? (
             <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
               {data.unseen_count} new
@@ -83,7 +92,11 @@ export function AlertsStrip(): JSX.Element | null {
         </div>
         {/* Action buttons land in Tasks 10 and 11 */}
       </header>
-      <div className="max-h-96 overflow-y-auto divide-y divide-slate-100">
+      <div
+        className="max-h-96 overflow-y-auto divide-y divide-slate-100"
+        role="list"
+        tabIndex={0}
+      >
         {data.rejections.map((row) => (
           <RowView key={row.decision_id} row={row} lastSeen={lastSeen} />
         ))}

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -10,8 +10,8 @@
  */
 import { Link } from "react-router-dom";
 
-import { fetchGuardRejections } from "@/api/alerts";
-// markAlertsSeen and dismissAllAlerts are added in Tasks 10 and 11.
+import { fetchGuardRejections, markAlertsSeen } from "@/api/alerts";
+// dismissAllAlerts is added in Task 11.
 import type { GuardRejection } from "@/api/types";
 import { formatRelativeTime } from "@/lib/format";
 import { useAsync } from "@/lib/useAsync";
@@ -64,38 +64,48 @@ function RowView({
 }
 
 export function AlertsStrip(): JSX.Element | null {
-  const { data, error } = useAsync(fetchGuardRejections, []);
+  const { data, error, refetch } = useAsync(fetchGuardRejections, []);
 
   if (error !== null || data === null) return null;
   if (data.rejections.length === 0) return null;
 
   const lastSeen = data.alerts_last_seen_decision_id;
+  const normalAck =
+    data.unseen_count > 0 && data.unseen_count <= data.rejections.length;
+
+  async function onMarkAllRead() {
+    // rejections is non-empty here (strip is hidden otherwise),
+    // and is ordered decision_id DESC on the server so index 0 is MAX.
+    const seenThroughDecisionId = data!.rejections[0]!.decision_id;
+    await markAlertsSeen(seenThroughDecisionId);
+    refetch();
+  }
 
   return (
-    <section
-      className="rounded-md border border-slate-200 bg-white shadow-sm"
-      aria-labelledby="alerts-strip-heading"
-    >
+    <section aria-labelledby="alerts-strip-heading" className="rounded-md border border-slate-200 bg-white shadow-sm">
       <header className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
         <div className="flex items-center gap-2">
-          <h2
-            id="alerts-strip-heading"
-            className="text-sm font-semibold text-slate-700"
-          >
-            Guard rejections
-          </h2>
+          <h2 id="alerts-strip-heading" className="text-sm font-semibold text-slate-700">Guard rejections</h2>
           {data.unseen_count > 0 ? (
             <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
               {data.unseen_count} new
             </span>
           ) : null}
         </div>
-        {/* Action buttons land in Tasks 10 and 11 */}
+        {normalAck ? (
+          <button
+            type="button"
+            onClick={onMarkAllRead}
+            className="rounded border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Mark all read
+          </button>
+        ) : null}
       </header>
       <div
-        className="max-h-96 overflow-y-auto divide-y divide-slate-100"
-        role="list"
         tabIndex={0}
+        role="list"
+        className="max-h-96 overflow-y-auto divide-y divide-slate-100"
       >
         {data.rejections.map((row) => (
           <RowView key={row.decision_id} row={row} lastSeen={lastSeen} />

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -130,6 +130,7 @@ export function AlertsStrip(): JSX.Element | null {
       <div
         tabIndex={0}
         role="list"
+        aria-labelledby="alerts-strip-heading"
         className="max-h-96 overflow-y-auto divide-y divide-slate-100"
       >
         {data.rejections.map((row) => (

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -77,7 +77,13 @@ export function AlertsStrip(): JSX.Element | null {
     // rejections is non-empty here (strip is hidden otherwise),
     // and is ordered decision_id DESC on the server so index 0 is MAX.
     const seenThroughDecisionId = data!.rejections[0]!.decision_id;
-    await markAlertsSeen(seenThroughDecisionId);
+    try {
+      await markAlertsSeen(seenThroughDecisionId);
+    } catch (err) {
+      // Silent-on-error matches the rest of the strip; log for debugging.
+      // Server ack is idempotent (GREATEST monotonic) so a future retry is safe.
+      console.error("[AlertsStrip] markAlertsSeen failed", err);
+    }
     refetch();
   }
 
@@ -85,7 +91,11 @@ export function AlertsStrip(): JSX.Element | null {
     const hiddenCount = data!.unseen_count - data!.rejections.length;
     const msg = `Dismiss all ${data!.unseen_count} unseen rejections? ${hiddenCount} are not shown above. Review them at /recommendations before dismissing if they might matter.`;
     if (!window.confirm(msg)) return;
-    await dismissAllAlerts();
+    try {
+      await dismissAllAlerts();
+    } catch (err) {
+      console.error("[AlertsStrip] dismissAllAlerts failed", err);
+    }
     refetch();
   }
 

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatRelativeTime } from "@/lib/format";
+
+describe("formatRelativeTime", () => {
+  const NOW = new Date("2026-04-21T12:00:00Z");
+
+  it("renders '—' for null / undefined / empty string", () => {
+    expect(formatRelativeTime(null)).toBe("—");
+    expect(formatRelativeTime(undefined)).toBe("—");
+    expect(formatRelativeTime("")).toBe("—");
+  });
+
+  it("renders 'just now' for <60s delta", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatRelativeTime("2026-04-21T11:59:30Z")).toBe("just now");
+    vi.useRealTimers();
+  });
+
+  it("renders minutes for <1h delta", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatRelativeTime("2026-04-21T11:55:00Z")).toBe("5m ago");
+    vi.useRealTimers();
+  });
+
+  it("renders hours for <1d delta", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatRelativeTime("2026-04-21T09:00:00Z")).toBe("3h ago");
+    vi.useRealTimers();
+  });
+
+  it("renders days for <7d delta", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatRelativeTime("2026-04-19T12:00:00Z")).toBe("2d ago");
+    vi.useRealTimers();
+  });
+
+  it("falls back to formatDate for >=7d delta", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const result = formatRelativeTime("2026-04-10T12:00:00Z");
+    expect(result).toMatch(/2026/);
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -94,3 +94,18 @@ export function pnlPct(unrealized: number, costBasis: number): number | null {
   if (costBasis === 0) return null;
   return unrealized / costBasis;
 }
+
+/** Relative-time formatter for strip rows. Uses local system clock.
+ *  <60s → "just now", <1h → "Nm ago", <1d → "Nh ago", <7d → "Nd ago",
+ *  else → formatDate fallback. */
+export function formatRelativeTime(iso: string | null | undefined): string {
+  if (iso === null || iso === undefined || iso === "") return "—";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "—";
+  const deltaS = Math.floor((Date.now() - then) / 1000);
+  if (deltaS < 60) return "just now";
+  if (deltaS < 3600) return `${Math.floor(deltaS / 60)}m ago`;
+  if (deltaS < 86400) return `${Math.floor(deltaS / 3600)}h ago`;
+  if (deltaS < 604800) return `${Math.floor(deltaS / 86400)}d ago`;
+  return formatDate(iso);
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -8,6 +8,7 @@ import { fetchWatchlist, removeFromWatchlist } from "@/api/watchlist";
 import { useConfig } from "@/lib/ConfigContext";
 import { useAsync } from "@/lib/useAsync";
 import { ErrorBanner } from "@/components/states/ErrorBanner";
+import { AlertsStrip } from "@/components/dashboard/AlertsStrip";
 import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { PortfolioValueChart } from "@/components/dashboard/PortfolioValueChart";
 import { RollingPnlStrip } from "@/components/dashboard/RollingPnlStrip";
@@ -32,9 +33,11 @@ import { WatchlistPanel } from "@/components/dashboard/WatchlistPanel";
  *
  * Layout:
  *   ┌ SummaryCards (AUM · Cash · P&L · Deployment) ┐
+ *   │ RollingPnlStrip (1d · 1w · 1m)               │
+ *   │ AlertsStrip (guard rejections)               │
+ *   │ PortfolioValueChart                          │
  *   │                                              │
  *   │ Positions                                    │
- *   │                                              │
  *   │ Needs action (proposed recs)                 │
  *   │                                              │
  *   │ Watchlist                                    │
@@ -117,6 +120,10 @@ export function DashboardPage() {
               movement. Hidden on error so a failed rolling fetch
               doesn't blank the rest of the page. */}
           <RollingPnlStrip />
+          {/* Needs-action surface — guard rejections since last visit.
+              Hidden when empty, silent on error. Sits above the narrative
+              chart so action-required signal precedes trajectory context. */}
+          <AlertsStrip />
           {/* Portfolio value over time (positions + cash). Mounted
               under the pills so the operator sees the cockpit row
               (totals → short-horizon delta → long-horizon trajectory)

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -32,16 +32,21 @@ import { WatchlistPanel } from "@/components/dashboard/WatchlistPanel";
  * every data source failed.
  *
  * Layout:
- *   ┌ SummaryCards (AUM · Cash · P&L · Deployment) ┐
- *   │ RollingPnlStrip (1d · 1w · 1m)               │
- *   │ AlertsStrip (guard rejections)               │
- *   │ PortfolioValueChart                          │
- *   │                                              │
- *   │ Positions                                    │
+ *   ┌ SummaryCards (AUM · Cash · P&L · Deployment) ┐  ← portfolio-gated
+ *   │ RollingPnlStrip (1d · 1w · 1m)               │  ← portfolio-gated
+ *   │ PortfolioValueChart                          │  ← portfolio-gated
+ *   │ Positions                                    │  ← portfolio-gated
+ *   │──────────────────────────────────────────────│
+ *   │ AlertsStrip (guard rejections)               │  ← self-isolating, always mounted
  *   │ Needs action (proposed recs)                 │
  *   │                                              │
  *   │ Watchlist                                    │
  *   └──────────────────────────────────────────────┘
+ *
+ * Note: AlertsStrip is intentionally outside the portfolio-gated block so
+ * a /portfolio failure never suppresses guard-rejection alerts. RollingPnlStrip
+ * and PortfolioValueChart remain portfolio-gated (pre-existing behaviour from
+ * Phase 2); their isolation is tracked as tech-debt.
  */
 export function DashboardPage() {
   const portfolio = useAsync(fetchPortfolio, []);
@@ -120,10 +125,6 @@ export function DashboardPage() {
               movement. Hidden on error so a failed rolling fetch
               doesn't blank the rest of the page. */}
           <RollingPnlStrip />
-          {/* Needs-action surface — guard rejections since last visit.
-              Hidden when empty, silent on error. Sits above the narrative
-              chart so action-required signal precedes trajectory context. */}
-          <AlertsStrip />
           {/* Portfolio value over time (positions + cash). Mounted
               under the pills so the operator sees the cockpit row
               (totals → short-horizon delta → long-horizon trajectory)
@@ -141,6 +142,12 @@ export function DashboardPage() {
           </Section>
         </>
       )}
+
+      {/* Needs-action surface — guard rejections since last visit.
+          Self-isolating: handles its own loading/error/empty states.
+          Mounted outside the portfolio-gated branch so a failed
+          /portfolio fetch never suppresses guard-rejection alerts. */}
+      <AlertsStrip />
 
       <Section
         title={`Needs action${recs.data ? ` · ${recs.data.total}` : ""}`}

--- a/sql/044_operators_alerts_seen.sql
+++ b/sql/044_operators_alerts_seen.sql
@@ -1,0 +1,21 @@
+-- Migration 044: operator-scoped alert acknowledgement + guard-rejection read index
+--
+-- 1. operators.alerts_last_seen_decision_id — NULL = never acknowledged (all in-window rows unseen).
+--    Integer cursor keyed off decision_audit.decision_id (BIGSERIAL, unique).
+--    Timestamp-based cursor was rejected: decision_time is TIMESTAMPTZ (microsecond resolution,
+--    NOT unique under load), which leaves a tie-break race where a row inserted between GET
+--    and POST at the same decision_time as rejections[0] would be silently acked. decision_id
+--    is monotonic for the guard stage (single-threaded scheduler invocations; no concurrent
+--    writers), so a strict > comparison fully closes the race.
+-- 2. Partial index on decision_audit supports the dashboard GET scan.
+--    Narrowed to stage='execution_guard' + pass_fail='FAIL' because
+--    (a) the /alerts endpoint filters on both, (b) other stages write to
+--    decision_audit (e.g. order_execution, deferred_retry) and must not
+--    be indexed as guard rejections.
+
+ALTER TABLE operators
+    ADD COLUMN IF NOT EXISTS alerts_last_seen_decision_id BIGINT;
+
+CREATE INDEX IF NOT EXISTS idx_decision_audit_guard_failed_recent
+    ON decision_audit (decision_time DESC)
+    WHERE pass_fail = 'FAIL' AND stage = 'execution_guard';

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from app.api.auth import require_session_or_service_token
 from app.main import app
+from tests.fixtures.ebull_test_db import ebull_test_conn as ebull_test_conn  # noqa: F401
 
 
 def _noop_auth() -> None:  # pragma: no cover - trivial override

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -54,6 +54,9 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "financial_periods_raw",
     "financial_periods",
     "filing_events",
+    "decision_audit",  # #315 Phase 3 alerts
+    "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)
+    "operators",  # #315 Phase 3 alerts (cursor column)
 )
 
 

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -35,7 +35,8 @@ def _install_conn(
     """Stub DB whose cursor feeds fetchone/fetchall in the order supplied.
 
     Returns the MagicMock cursor so tests can assert on ``cur.execute.call_args_list``
-    for SQL-shape pinning.
+    for SQL-shape pinning. Access the parent connection via ``cur._parent_conn`` to
+    assert on commit for regression guards.
 
     Call ordering by endpoint:
       GET /alerts/guard-rejections — 2x fetchone, 1x fetchall:
@@ -59,6 +60,7 @@ def _install_conn(
     cur.rowcount = rowcount
     conn.cursor.return_value = cur
     conn.commit = MagicMock()
+    cur._parent_conn = conn  # exposed so tests can assert on commit
 
     def _dep() -> Iterator[MagicMock]:
         yield conn
@@ -263,6 +265,8 @@ def test_post_seen_writes_update(client: TestClient) -> None:
     params = [c.args[1] for c in calls if "UPDATE operators" in c.args[0]][0]
     assert params["seen_through_decision_id"] == 1234
     assert params["op"] == _OP_ID
+    # Regression guard: conn.commit() must fire or the UPDATE never persists.
+    cur._parent_conn.commit.assert_called_once()
 
 
 def test_post_seen_sql_shape_pins_greatest_and_least_and_scope(client: TestClient) -> None:

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -297,3 +297,53 @@ def test_post_seen_returns_501_when_multiple_operators(client: TestClient) -> No
         _install_conn()
         resp = client.post("/alerts/seen", json={"seen_through_decision_id": 1})
     assert resp.status_code == 501
+
+
+def test_post_dismiss_all_issues_update(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(rowcount=1)
+        resp = client.post("/alerts/dismiss-all")
+    assert resp.status_code == 204
+    calls = cur.execute.call_args_list
+    assert any(
+        "UPDATE operators" in c.args[0] and "SELECT MAX(decision_id)" in c.args[0]
+        for c in calls
+    )
+    cur._parent_conn.commit.assert_called_once()
+
+
+def test_post_dismiss_all_filters_scope_to_guard_fails_in_window(client: TestClient) -> None:
+    # Inspect the SQL shape — scope is execution_guard + FAIL + 7-day window.
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(rowcount=1)
+        resp = client.post("/alerts/dismiss-all")
+    assert resp.status_code == 204
+    update_sql = next(
+        c.args[0] for c in cur.execute.call_args_list if "UPDATE operators" in c.args[0]
+    )
+    assert "pass_fail = 'FAIL'" in update_sql
+    assert "stage = 'execution_guard'" in update_sql
+    assert "INTERVAL '7 days'" in update_sql
+    assert "m.max_id IS NOT NULL" in update_sql
+
+
+def test_post_dismiss_all_is_noop_on_zero_rowcount(client: TestClient) -> None:
+    # rowcount=0 mimics the empty-window case (WHERE m.max_id IS NOT NULL excludes the row).
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(rowcount=0)
+        resp = client.post("/alerts/dismiss-all")
+    assert resp.status_code == 204  # No-op still returns 204.
+
+
+def test_post_dismiss_all_returns_503_when_no_operator(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", side_effect=NoOperatorError()):
+        _install_conn()
+        resp = client.post("/alerts/dismiss-all")
+    assert resp.status_code == 503
+
+
+def test_post_dismiss_all_returns_501_when_multiple_operators(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", side_effect=AmbiguousOperatorError()):
+        _install_conn()
+        resp = client.post("/alerts/dismiss-all")
+    assert resp.status_code == 501

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -1,0 +1,72 @@
+"""Tests for the alerts API (#315 Phase 3)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.operators import AmbiguousOperatorError, NoOperatorError
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def cleanup() -> Iterator[None]:
+    yield
+    from app.db import get_conn
+
+    app.dependency_overrides.pop(get_conn, None)
+
+
+def _install_conn(
+    fetchone_returns: list[object] | None = None,
+    fetchall_returns: list[object] | None = None,
+    rowcount: int = 1,
+) -> MagicMock:
+    """Stub DB whose cursor feeds fetchone/fetchall in the order supplied."""
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.__enter__.return_value = cur
+    cur.__exit__.return_value = None
+    if fetchone_returns is not None:
+        cur.fetchone.side_effect = list(fetchone_returns)
+    if fetchall_returns is not None:
+        cur.fetchall.return_value = fetchall_returns
+    cur.rowcount = rowcount
+    conn.cursor.return_value = cur
+    conn.commit = MagicMock()
+
+    def _dep() -> Iterator[MagicMock]:
+        yield conn
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _dep
+    return cur
+
+
+def test_get_returns_503_when_no_operator(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", side_effect=NoOperatorError()):
+        _install_conn()
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.status_code == 503
+
+
+def test_get_returns_501_when_multiple_operators(client: TestClient) -> None:
+    with patch(
+        "app.api.alerts.sole_operator_id",
+        side_effect=AmbiguousOperatorError(),
+    ):
+        _install_conn()
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.status_code == 501

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -325,6 +325,8 @@ def test_post_dismiss_all_filters_scope_to_guard_fails_in_window(client: TestCli
     assert "stage = 'execution_guard'" in update_sql
     assert "INTERVAL '7 days'" in update_sql
     assert "m.max_id IS NOT NULL" in update_sql
+    assert "GREATEST" in update_sql
+    assert "COALESCE" in update_sql
 
 
 def test_post_dismiss_all_is_noop_on_zero_rowcount(client: TestClient) -> None:

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -32,7 +32,22 @@ def _install_conn(
     fetchall_returns: Sequence[object] | None = None,
     rowcount: int = 1,
 ) -> MagicMock:
-    """Stub DB whose cursor feeds fetchone/fetchall in the order supplied."""
+    """Stub DB whose cursor feeds fetchone/fetchall in the order supplied.
+
+    Returns the MagicMock cursor so tests can assert on ``cur.execute.call_args_list``
+    for SQL-shape pinning.
+
+    Call ordering by endpoint:
+      GET /alerts/guard-rejections — 2x fetchone, 1x fetchall:
+        fetchone[0] → {"alerts_last_seen_decision_id": int | None}
+        fetchone[1] → {"unseen_count": int}
+        fetchall    → list[rejection-row dicts]
+      POST /alerts/seen — no fetchone/fetchall; only cur.execute for the UPDATE.
+      POST /alerts/dismiss-all — no fetchone/fetchall; only cur.execute for the UPDATE.
+
+    Any test that doesn't supply the right number of fetchone entries will get a
+    MagicMock back from the exhausted side_effect, which serialises to garbage.
+    """
     conn = MagicMock()
     cur = MagicMock()
     cur.__enter__.return_value = cur

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
+import psycopg
 import pytest
 from fastapi.testclient import TestClient
 
@@ -224,13 +225,14 @@ def test_get_unseen_count_query_uses_strict_gt_on_decision_id(client: TestClient
         client.get("/alerts/guard-rejections")
     count_sql = next(c.args[0] for c in cur.execute.call_args_list if "SELECT COUNT(*)" in c.args[0])
     # Strict `>` ties are structurally impossible on a unique PK.
-    assert "decision_id > %(last_id)s" in count_sql
+    # BIGINT cast avoids AmbiguousParameter when last_id is NULL on real psycopg.
+    assert "decision_id > %(last_id)s::BIGINT" in count_sql
     # Filter matches list query so counts and rows agree.
     assert "pass_fail = 'FAIL'" in count_sql
     assert "stage = 'execution_guard'" in count_sql
     assert "INTERVAL '7 days'" in count_sql
     # NULL last-seen path counts everything in window.
-    assert "%(last_id)s IS NULL" in count_sql
+    assert "%(last_id)s::BIGINT IS NULL" in count_sql
 
 
 def test_post_seen_rejects_missing_field(client: TestClient) -> None:
@@ -305,10 +307,7 @@ def test_post_dismiss_all_issues_update(client: TestClient) -> None:
         resp = client.post("/alerts/dismiss-all")
     assert resp.status_code == 204
     calls = cur.execute.call_args_list
-    assert any(
-        "UPDATE operators" in c.args[0] and "SELECT MAX(decision_id)" in c.args[0]
-        for c in calls
-    )
+    assert any("UPDATE operators" in c.args[0] and "SELECT MAX(decision_id)" in c.args[0] for c in calls)
     cur._parent_conn.commit.assert_called_once()
 
 
@@ -318,9 +317,7 @@ def test_post_dismiss_all_filters_scope_to_guard_fails_in_window(client: TestCli
         cur = _install_conn(rowcount=1)
         resp = client.post("/alerts/dismiss-all")
     assert resp.status_code == 204
-    update_sql = next(
-        c.args[0] for c in cur.execute.call_args_list if "UPDATE operators" in c.args[0]
-    )
+    update_sql = next(c.args[0] for c in cur.execute.call_args_list if "UPDATE operators" in c.args[0])
     assert "pass_fail = 'FAIL'" in update_sql
     assert "stage = 'execution_guard'" in update_sql
     assert "INTERVAL '7 days'" in update_sql
@@ -349,3 +346,206 @@ def test_post_dismiss_all_returns_501_when_multiple_operators(client: TestClient
         _install_conn()
         resp = client.post("/alerts/dismiss-all")
     assert resp.status_code == 501
+
+
+# --- Integration tests (real ebull_test DB) ----------------------------------
+
+from tests.fixtures.ebull_test_db import test_db_available  # noqa: E402,F401
+
+_INT_OP_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _seed_operator(conn: psycopg.Connection[tuple]) -> None:
+    """Insert a known operator row so sole_operator_id resolves and the
+    UPDATE in /alerts/seen / /dismiss-all has a target row. `username`
+    and `password_hash` are NOT NULL per sql/016_operators_sessions.sql;
+    use dummy values — these rows are created for the alerts tests only
+    and never authenticate."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO operators (operator_id, username, password_hash)
+            VALUES (%s, 'alerts_test_op', 'x')
+            ON CONFLICT DO NOTHING
+            """,
+            (_INT_OP_ID,),
+        )
+    conn.commit()
+
+
+def _bind_test_client(conn: psycopg.Connection[tuple]) -> TestClient:
+    """Bind TestClient's get_conn dep to the ebull_test connection + patch
+    the operator resolver to return the seeded operator id. Returns a
+    client whose requests run against ebull_test."""
+
+    def _dep() -> Iterator[psycopg.Connection[tuple]]:
+        yield conn
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _dep
+    return TestClient(app)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_get_orders_by_decision_id_under_clock_skew(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Row B gets a later decision_time but an earlier decision_id.
+    GET must still put the row with the higher decision_id first."""
+    _seed_operator(ebull_test_conn)
+
+    with ebull_test_conn.cursor() as cur:
+        # instruments.instrument_id is BIGINT PRIMARY KEY with no default
+        # (sql/001_init.sql), so the caller supplies the id explicitly.
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (1, 'ZZZ', 'Test', 'USD', TRUE)"
+        )
+        iid = 1
+
+        # Insert Row B first (gets lower decision_id) with the LATER decision_time.
+        cur.execute(
+            "INSERT INTO decision_audit "
+            "(decision_time, instrument_id, stage, pass_fail, explanation) "
+            "VALUES (now(), %s, 'execution_guard', 'FAIL', 'B-later-time') "
+            "RETURNING decision_id",
+            (iid,),
+        )
+        row_b = cur.fetchone()
+        assert row_b is not None
+        id_b = row_b[0]
+
+        # Insert Row A second (gets HIGHER decision_id) with the EARLIER decision_time.
+        cur.execute(
+            "INSERT INTO decision_audit "
+            "(decision_time, instrument_id, stage, pass_fail, explanation) "
+            "VALUES (now() - INTERVAL '1 hour', %s, 'execution_guard', 'FAIL', 'A-earlier-time') "
+            "RETURNING decision_id",
+            (iid,),
+        )
+        row_a = cur.fetchone()
+        assert row_a is not None
+        id_a = row_a[0]
+    ebull_test_conn.commit()
+
+    assert id_a > id_b  # sanity check on the natural PK ordering
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/guard-rejections")
+        assert resp.status_code == 200
+        rejections = resp.json()["rejections"]
+        assert rejections[0]["decision_id"] == id_a
+        assert rejections[1]["decision_id"] == id_b
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_post_seen_clamps_to_in_window_max(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO decision_audit "
+            "(decision_time, stage, pass_fail, explanation) "
+            "VALUES (now(), 'execution_guard', 'FAIL', 'in-window') RETURNING decision_id"
+        )
+        max_in_window_row = cur.fetchone()
+        assert max_in_window_row is not None
+        max_in_window = max_in_window_row[0]
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/seen",
+                json={"seen_through_decision_id": max_in_window + 99999},
+            )
+        assert resp.status_code == 204
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_decision_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            stored_row = cur.fetchone()
+            assert stored_row is not None
+            stored = stored_row[0]
+        assert stored == max_in_window
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_dismiss_all_empty_window_stays_null(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    # No guard rows in window; cursor NULL; POST dismiss-all; cursor stays NULL.
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post("/alerts/dismiss-all")
+        assert resp.status_code == 204
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_decision_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            dismiss_row = cur.fetchone()
+            assert dismiss_row is not None
+            assert dismiss_row[0] is None
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_non_guard_stage_excluded_from_list_and_dismiss(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO decision_audit "
+            "(decision_time, stage, pass_fail, explanation) "
+            "VALUES (now(), 'order_execution', 'FAIL', 'not a guard') RETURNING decision_id"
+        )
+        non_guard_row = cur.fetchone()
+        assert non_guard_row is not None
+        id_non_guard = non_guard_row[0]
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/guard-rejections")
+        ids = [r["decision_id"] for r in resp.json()["rejections"]]
+        assert id_non_guard not in ids
+
+        # dismiss-all MAX subselect is NULL (no guard rows) → no-op.
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post("/alerts/dismiss-all")
+        assert resp.status_code == 204
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_decision_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            non_guard_dismiss_row = cur.fetchone()
+            assert non_guard_dismiss_row is not None
+            assert non_guard_dismiss_row[0] is None
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -3,11 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
-from uuid import UUID
 
-import psycopg
 import pytest
 from fastapi.testclient import TestClient
 

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -229,3 +229,67 @@ def test_get_unseen_count_query_uses_strict_gt_on_decision_id(client: TestClient
     assert "INTERVAL '7 days'" in count_sql
     # NULL last-seen path counts everything in window.
     assert "%(last_id)s IS NULL" in count_sql
+
+
+def test_post_seen_rejects_missing_field(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn()
+        resp = client.post("/alerts/seen", json={})
+    assert resp.status_code == 422
+
+
+def test_post_seen_rejects_non_integer(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn()
+        resp = client.post("/alerts/seen", json={"seen_through_decision_id": "abc"})
+    assert resp.status_code == 422
+
+
+def test_post_seen_rejects_non_positive(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn()
+        resp = client.post("/alerts/seen", json={"seen_through_decision_id": 0})
+    assert resp.status_code == 422
+
+
+def test_post_seen_writes_update(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(rowcount=1)
+        resp = client.post("/alerts/seen", json={"seen_through_decision_id": 1234})
+    assert resp.status_code == 204
+    # One UPDATE call was issued with the posted value.
+    calls = cur.execute.call_args_list
+    assert any("UPDATE operators" in c.args[0] for c in calls)
+    params = [c.args[1] for c in calls if "UPDATE operators" in c.args[0]][0]
+    assert params["seen_through_decision_id"] == 1234
+    assert params["op"] == _OP_ID
+
+
+def test_post_seen_sql_shape_pins_greatest_and_least_and_scope(client: TestClient) -> None:
+    """SQL must be: GREATEST(COALESCE(current, 0), LEAST(posted, MAX-in-window-or-0))
+    with MAX subselect filtered to FAIL + execution_guard + 7-day window."""
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(rowcount=1)
+        resp = client.post("/alerts/seen", json={"seen_through_decision_id": 99999})
+    assert resp.status_code == 204
+    sql = next(c.args[0] for c in cur.execute.call_args_list if "UPDATE operators" in c.args[0])
+    assert "GREATEST" in sql
+    assert "LEAST" in sql
+    assert "SELECT MAX(decision_id)" in sql
+    assert "pass_fail = 'FAIL'" in sql
+    assert "stage = 'execution_guard'" in sql
+    assert "INTERVAL '7 days'" in sql
+
+
+def test_post_seen_returns_503_when_no_operator(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", side_effect=NoOperatorError()):
+        _install_conn()
+        resp = client.post("/alerts/seen", json={"seen_through_decision_id": 1})
+    assert resp.status_code == 503
+
+
+def test_post_seen_returns_501_when_multiple_operators(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", side_effect=AmbiguousOperatorError()):
+        _install_conn()
+        resp = client.post("/alerts/seen", json={"seen_through_decision_id": 1})
+    assert resp.status_code == 501

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 import pytest
 from fastapi.testclient import TestClient
@@ -26,8 +28,8 @@ def cleanup() -> Iterator[None]:
 
 
 def _install_conn(
-    fetchone_returns: list[object] | None = None,
-    fetchall_returns: list[object] | None = None,
+    fetchone_returns: Sequence[object] | None = None,
+    fetchall_returns: Sequence[object] | None = None,
     rowcount: int = 1,
 ) -> MagicMock:
     """Stub DB whose cursor feeds fetchone/fetchall in the order supplied."""
@@ -67,3 +69,148 @@ def test_get_returns_501_when_multiple_operators(client: TestClient) -> None:
         _install_conn()
         resp = client.get("/alerts/guard-rejections")
     assert resp.status_code == 501
+
+
+_OP_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+def _rejection_row(
+    *,
+    decision_id: int,
+    decision_time: datetime | None = None,
+    instrument_id: int | None = 42,
+    symbol: str | None = "AAPL",
+    action: str | None = "BUY",
+    explanation: str = "FAIL — cash_available: need £200, have £50",
+) -> dict[str, object]:
+    return {
+        "decision_id": decision_id,
+        "decision_time": decision_time or datetime(2026, 4, 21, tzinfo=UTC),
+        "instrument_id": instrument_id,
+        "symbol": symbol,
+        "action": action,
+        "explanation": explanation,
+    }
+
+
+def test_get_empty_state(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        # fetchone #1 = operator's alerts_last_seen_decision_id (NULL)
+        # fetchone #2 = unseen_count (0)
+        _install_conn(
+            fetchone_returns=[{"alerts_last_seen_decision_id": None}, {"unseen_count": 0}],
+            fetchall_returns=[],
+        )
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {
+        "alerts_last_seen_decision_id": None,
+        "unseen_count": 0,
+        "rejections": [],
+    }
+
+
+def test_get_returns_row_shape_and_unseen_count(client: TestClient) -> None:
+    rows = [
+        _rejection_row(decision_id=501, action="BUY"),
+        _rejection_row(decision_id=500, action="ADD", symbol="MSFT", instrument_id=43),
+    ]
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_decision_id": 499},
+                {"unseen_count": 2},
+            ],
+            fetchall_returns=rows,
+        )
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["alerts_last_seen_decision_id"] == 499
+    assert body["unseen_count"] == 2
+    assert len(body["rejections"]) == 2
+    assert body["rejections"][0]["decision_id"] == 501
+    assert body["rejections"][0]["symbol"] == "AAPL"
+    assert body["rejections"][0]["action"] == "BUY"
+
+
+def test_get_null_instrument_and_action_serialise(client: TestClient) -> None:
+    rows = [
+        _rejection_row(decision_id=1, instrument_id=None, symbol=None, action=None),
+    ]
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_decision_id": None},
+                {"unseen_count": 1},
+            ],
+            fetchall_returns=rows,
+        )
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.status_code == 200
+    row = resp.json()["rejections"][0]
+    assert row["instrument_id"] is None
+    assert row["symbol"] is None
+    assert row["action"] is None
+
+
+def test_get_hold_action_round_trip(client: TestClient) -> None:
+    rows = [_rejection_row(decision_id=7, action="HOLD")]
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_decision_id": None},
+                {"unseen_count": 1},
+            ],
+            fetchall_returns=rows,
+        )
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.json()["rejections"][0]["action"] == "HOLD"
+
+
+def test_get_sql_shape_pins_window_and_scope_and_cap(client: TestClient) -> None:
+    """Pin SQL-shape invariants that the contract depends on:
+    - 7-day window filter (INTERVAL '7 days')
+    - pass_fail = 'FAIL' (uppercase) + stage = 'execution_guard'
+    - ORDER BY decision_id DESC (NOT decision_time DESC)
+    - LIMIT 500
+    """
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_decision_id": None},
+                {"unseen_count": 0},
+            ],
+            fetchall_returns=[],
+        )
+        resp = client.get("/alerts/guard-rejections")
+    assert resp.status_code == 200
+    list_sql = next(c.args[0] for c in cur.execute.call_args_list if "FROM decision_audit da" in c.args[0])
+    assert "pass_fail = 'FAIL'" in list_sql
+    assert "stage = 'execution_guard'" in list_sql
+    assert "INTERVAL '7 days'" in list_sql
+    assert "ORDER BY da.decision_id DESC" in list_sql
+    assert "LIMIT 500" in list_sql
+
+
+def test_get_unseen_count_query_uses_strict_gt_on_decision_id(client: TestClient) -> None:
+    """unseen_count query uses strict `decision_id > last_id` (race-safety)."""
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_decision_id": 100},
+                {"unseen_count": 3},
+            ],
+            fetchall_returns=[],
+        )
+        client.get("/alerts/guard-rejections")
+    count_sql = next(c.args[0] for c in cur.execute.call_args_list if "SELECT COUNT(*)" in c.args[0])
+    # Strict `>` ties are structurally impossible on a unique PK.
+    assert "decision_id > %(last_id)s" in count_sql
+    # Filter matches list query so counts and rows agree.
+    assert "pass_fail = 'FAIL'" in count_sql
+    assert "stage = 'execution_guard'" in count_sql
+    assert "INTERVAL '7 days'" in count_sql
+    # NULL last-seen path counts everything in window.
+    assert "%(last_id)s IS NULL" in count_sql


### PR DESCRIPTION
## What
Alerts strip for execution-guard rejections on the operator dashboard. Closes the final phase of #315 (P1-3 dashboard command-center pivot).

## Why
Operator needs a "since last visit" view of guard rejections without leaving the dashboard. Scope limited to guard rejections because thesis breaches (#394) and filings-status drops (#395) each need their own event-persistence design (plan-review decision; follow-ups to file on merge).

## Test plan
- [x] Backend unit tests (20): operator-resolution 503/501 (3 endpoints), GET shape + SQL-shape pins + null-action + HOLD, POST /seen validation + clamp + commit-regression, POST /dismiss-all scope + noop + commit-regression
- [x] Integration tests vs `ebull_test` (4): clock-skew ordering (`decision_id` beats `decision_time`), POST /seen clamps to in-window MAX, dismiss-all empty-window no-op, non-guard stage excluded
- [x] Frontend tests (16): empty/error hidden, row shape, instrument link vs plain, amber/slate borders, unseen pill, title-truncation, Mark all read (normal + cap-positive + unseen=0 hides + click-posts-max-id), Dismiss all (overflow render + confirm + cancel)
- [x] Smoke test (`tests/smoke/test_app_boots.py`) green with new router
- [x] Codex pre-spec (10 rounds) + pre-plan (3 rounds) + pre-push reviews clean (blocker + a11y finding fixed)
- [x] All pre-push gates green: `ruff check`, `ruff format --check`, `pyright`, `pytest` (2256 passed, 1 skipped), frontend `typecheck`, frontend `test` (336 passed)

## Follow-ups to file on merge
- #394 position-alert event persistence (enables thesis breach signal)
- #395 coverage status transition log (enables filings-status drop signal)
- #396 wire #394 + #395 into the existing strip (type-union addition)
- Tech-debt: pre-existing isolation bug — `RollingPnlStrip` and `PortfolioValueChart` mount inside the portfolio-error gate in DashboardPage, so a /portfolio failure blanks them despite their own silent-on-error. `AlertsStrip` is now decoupled per Codex pre-push; the other two need the same treatment.

Spec: `docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md`
Plan: `docs/superpowers/plans/2026-04-21-alerts-strip-guard-rejections.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)