### PR TITLE
feat(#396): position-alert event persistence

### DIFF
--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -18,6 +18,7 @@ Routes:
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 from typing import Literal
 from uuid import UUID
 
@@ -56,6 +57,30 @@ class GuardRejectionsResponse(BaseModel):
 
 class MarkSeenRequest(BaseModel):
     seen_through_decision_id: int = Field(gt=0)
+
+
+AlertType = Literal["sl_breach", "tp_breach", "thesis_break"]
+
+
+class PositionAlert(BaseModel):
+    alert_id: int
+    alert_type: AlertType
+    instrument_id: int
+    symbol: str
+    opened_at: datetime
+    resolved_at: datetime | None
+    detail: str
+    current_bid: Decimal | None
+
+
+class PositionAlertsResponse(BaseModel):
+    alerts_last_seen_position_alert_id: int | None
+    unseen_count: int
+    alerts: list[PositionAlert]
+
+
+class PositionAlertsMarkSeenRequest(BaseModel):
+    seen_through_position_alert_id: int = Field(gt=0)
 
 
 def _resolve_operator(conn: psycopg.Connection[object]) -> UUID:
@@ -191,3 +216,62 @@ def dismiss_all(
             {"op": operator_id},
         )
     conn.commit()
+
+
+@router.get("/position-alerts", response_model=PositionAlertsResponse)
+def get_position_alerts(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> PositionAlertsResponse:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # 1. Read operator's cursor.
+        cur.execute(
+            "SELECT alerts_last_seen_position_alert_id FROM operators WHERE operator_id = %(op)s",
+            {"op": operator_id},
+        )
+        op_row = cur.fetchone()
+        last_seen: int | None = op_row["alerts_last_seen_position_alert_id"] if op_row else None
+
+        # 2. Count unseen in-window rows (uncapped).
+        cur.execute(
+            """
+            SELECT COUNT(*) AS unseen_count
+            FROM position_alerts
+            WHERE opened_at >= now() - INTERVAL '7 days'
+              AND (%(last_id)s::BIGINT IS NULL OR alert_id > %(last_id)s::BIGINT)
+            """,
+            {"last_id": last_seen},
+        )
+        count_row = cur.fetchone()
+        assert count_row is not None, "COUNT(*) always returns a row"
+        unseen_count: int = int(count_row["unseen_count"])
+
+        # 3. Fetch the list (capped at 500). ORDER BY alert_id DESC —
+        # BIGSERIAL PK is the race-safe ordering (clock-skew irrelevant;
+        # single-threaded writer guarantees monotonicity). Matches #394
+        # rationale for decision_id.
+        cur.execute(
+            """
+            SELECT
+                pa.alert_id,
+                pa.alert_type,
+                pa.instrument_id,
+                i.symbol,
+                pa.opened_at,
+                pa.resolved_at,
+                pa.detail,
+                pa.current_bid
+            FROM position_alerts pa
+            JOIN instruments i ON i.instrument_id = pa.instrument_id
+            WHERE pa.opened_at >= now() - INTERVAL '7 days'
+            ORDER BY pa.alert_id DESC
+            LIMIT 500
+            """
+        )
+        rows = cur.fetchall()
+
+    return PositionAlertsResponse(
+        alerts_last_seen_position_alert_id=last_seen,
+        unseen_count=unseen_count,
+        alerts=[PositionAlert.model_validate(r) for r in rows],
+    )

--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -218,6 +218,38 @@ def dismiss_all(
     conn.commit()
 
 
+@router.post("/position-alerts/seen", status_code=status.HTTP_204_NO_CONTENT)
+def mark_position_alerts_seen(
+    body: PositionAlertsMarkSeenRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor() as cur:
+        # The m.max_id IS NOT NULL guard makes this a no-op on an empty
+        # window — without it, LEAST(client_posted, NULL) would short-circuit
+        # to NULL and GREATEST(COALESCE(cursor, 0), NULL) would itself be NULL
+        # (PostgreSQL GREATEST ignores NULL arguments), but the simpler reading
+        # is: we never want to materialise a cursor value when no rows exist.
+        cur.execute(
+            """
+            UPDATE operators AS op
+            SET alerts_last_seen_position_alert_id = GREATEST(
+                COALESCE(op.alerts_last_seen_position_alert_id, 0),
+                LEAST(%(seen_through)s, m.max_id)
+            )
+            FROM (
+                SELECT MAX(alert_id) AS max_id
+                FROM position_alerts
+                WHERE opened_at >= now() - INTERVAL '7 days'
+            ) AS m
+            WHERE op.operator_id = %(op)s
+              AND m.max_id IS NOT NULL
+            """,
+            {"seen_through": body.seen_through_position_alert_id, "op": operator_id},
+        )
+    conn.commit()
+
+
 @router.get("/position-alerts", response_model=PositionAlertsResponse)
 def get_position_alerts(
     conn: psycopg.Connection[object] = Depends(get_conn),

--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -235,7 +235,7 @@ def mark_position_alerts_seen(
             UPDATE operators AS op
             SET alerts_last_seen_position_alert_id = GREATEST(
                 COALESCE(op.alerts_last_seen_position_alert_id, 0),
-                LEAST(%(seen_through)s, m.max_id)
+                LEAST(%(seen_through_position_alert_id)s, m.max_id)
             )
             FROM (
                 SELECT MAX(alert_id) AS max_id
@@ -245,7 +245,10 @@ def mark_position_alerts_seen(
             WHERE op.operator_id = %(op)s
               AND m.max_id IS NOT NULL
             """,
-            {"seen_through": body.seen_through_position_alert_id, "op": operator_id},
+            {
+                "seen_through_position_alert_id": body.seen_through_position_alert_id,
+                "op": operator_id,
+            },
         )
     conn.commit()
 

--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -1,18 +1,30 @@
-"""Alerts API (#315 Phase 3).
+"""Alerts API — dashboard strip read + cursor endpoints.
 
-Guard-rejection alerts strip. Scope is intentionally narrow — this is
-the execution-guard read surface only. Thesis breaches (#394) and
-filings-status drops (#395) are deferred; #396 wires them into the
-same strip once their event persistence lands.
+Provides two independent alert feeds sharing the same dashboard strip shape:
 
-Cursor model: operators.alerts_last_seen_decision_id (BIGINT). See
-``docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md``
-for why a decision_id cursor rather than decision_time.
+1. Execution-guard rejections (#315 Phase 3 / PR #394):
+   - GET  /alerts/guard-rejections
+   - POST /alerts/seen               (body: {seen_through_decision_id})
+   - POST /alerts/dismiss-all
 
-Routes:
-  GET  /alerts/guard-rejections   — 7-day window, 500-row cap, ORDER BY decision_id DESC
-  POST /alerts/seen               — body {seen_through_decision_id}, monotonic GREATEST + LEAST clamp
-  POST /alerts/dismiss-all        — no body, atomic MAX-in-window advance, no-op on empty window
+2. Position alerts (SL/TP/thesis breach episodes, #396):
+   - GET  /alerts/position-alerts
+   - POST /alerts/position-alerts/seen          (body: {seen_through_position_alert_id})
+   - POST /alerts/position-alerts/dismiss-all
+
+Each feed maintains its own BIGSERIAL cursor column on ``operators`` and a
+7-day window. Cursor semantics are identical across feeds: strict ``>``
+comparison, GREATEST+COALESCE monotonicity, LEAST clamp on /seen, MAX
+advance on /dismiss-all, and ``m.max_id IS NOT NULL`` empty-window guard.
+See specs at ``docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md``
+(guard) and ``docs/superpowers/specs/2026-04-21-position-alert-persistence.md``
+(position).
+
+Known divergence between the two /seen endpoints: guard `/alerts/seen`
+writes ``0`` as the cursor on an empty window + NULL cursor (see #395
+tech-debt). Position `/alerts/position-alerts/seen` does not — it uses
+the same ``m.max_id IS NOT NULL`` guard as dismiss-all to preserve
+``NULL = never acknowledged``.
 """
 
 from __future__ import annotations
@@ -249,6 +261,32 @@ def mark_position_alerts_seen(
                 "seen_through_position_alert_id": body.seen_through_position_alert_id,
                 "op": operator_id,
             },
+        )
+    conn.commit()
+
+
+@router.post("/position-alerts/dismiss-all", status_code=status.HTTP_204_NO_CONTENT)
+def dismiss_all_position_alerts(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE operators AS op
+            SET alerts_last_seen_position_alert_id = GREATEST(
+                COALESCE(op.alerts_last_seen_position_alert_id, 0),
+                m.max_id
+            )
+            FROM (
+                SELECT MAX(alert_id) AS max_id
+                FROM position_alerts
+                WHERE opened_at >= now() - INTERVAL '7 days'
+            ) AS m
+            WHERE op.operator_id = %(op)s
+              AND m.max_id IS NOT NULL
+            """,
+            {"op": operator_id},
         )
     conn.commit()
 

--- a/app/services/position_monitor.py
+++ b/app/services/position_monitor.py
@@ -56,6 +56,15 @@ class MonitorResult:
     alerts: tuple[MonitorAlert, ...] = ()
 
 
+@dataclass(frozen=True)
+class PersistStats:
+    """Aggregate stats from one persist_position_alerts invocation."""
+
+    opened: int
+    resolved: int
+    unchanged: int
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -171,3 +180,84 @@ def check_position_health(conn: psycopg.Connection[Any]) -> MonitorResult:
             )
 
     return MonitorResult(positions_checked=len(rows), alerts=tuple(alerts))
+
+
+def persist_position_alerts(
+    conn: psycopg.Connection[Any],
+    result: MonitorResult,
+) -> PersistStats:
+    """Reconcile open breach episodes against the current MonitorResult.
+
+    Contract: for each (instrument_id, alert_type) pair:
+      - current breach AND no open episode    -> INSERT new row
+      - current breach AND open episode       -> no-op (still breaching)
+      - no current breach AND open episode    -> UPDATE resolved_at = now()
+      - no current breach AND no open episode -> no-op
+
+    Runs inside a single ``conn.transaction()`` block — caller MUST NOT
+    hold an outer transaction, because psycopg v3 treats nested
+    ``conn.transaction()`` as a savepoint and the outer commit path is
+    the caller's responsibility. ``monitor_positions_job`` opens a
+    fresh connection, invokes ``check_position_health`` (read-only, no
+    BEGIN), then calls this writer — the ``conn.transaction()`` block
+    here IS the outer transaction and commits on clean exit.
+
+    Concurrency: the INSERT path tolerates partial-unique-index
+    conflicts via ``ON CONFLICT DO NOTHING``. The resolve path runs
+    ``WHERE resolved_at IS NULL`` so a row resolved by a concurrent
+    writer between the diff read and the UPDATE is a silent no-op.
+    Both guards are defensive — the scheduler serialises
+    ``monitor_positions_job`` via ``max_instances=1`` + per-job
+    ``threading.Lock`` (app/jobs/runtime.py:224,243).
+    """
+    current: dict[tuple[int, str], MonitorAlert] = {(a.instrument_id, a.alert_type): a for a in result.alerts}
+
+    with conn.transaction():
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT instrument_id, alert_type FROM position_alerts WHERE resolved_at IS NULL")
+            open_pairs: set[tuple[int, str]] = {
+                (int(row["instrument_id"]), str(row["alert_type"])) for row in cur.fetchall()
+            }
+
+            to_open = set(current.keys()) - open_pairs
+            to_resolve = open_pairs - set(current.keys())
+            unchanged = len(open_pairs & set(current.keys()))
+
+            opened = 0
+            for key in to_open:
+                alert = current[key]
+                cur.execute(
+                    """
+                    INSERT INTO position_alerts
+                        (instrument_id, alert_type, detail, current_bid)
+                    VALUES (%(instrument_id)s, %(alert_type)s, %(detail)s, %(current_bid)s)
+                    ON CONFLICT (instrument_id, alert_type) WHERE resolved_at IS NULL
+                    DO NOTHING
+                    """,
+                    {
+                        "instrument_id": alert.instrument_id,
+                        "alert_type": alert.alert_type,
+                        "detail": alert.detail,
+                        "current_bid": alert.current_bid,
+                    },
+                )
+                # rowcount == 1 on insert, 0 on ON CONFLICT DO NOTHING (race backstop).
+                if cur.rowcount == 1:
+                    opened += 1
+
+            resolved = 0
+            for instrument_id, alert_type in to_resolve:
+                cur.execute(
+                    """
+                    UPDATE position_alerts
+                    SET resolved_at = now()
+                    WHERE instrument_id = %(instrument_id)s
+                      AND alert_type = %(alert_type)s
+                      AND resolved_at IS NULL
+                    """,
+                    {"instrument_id": instrument_id, "alert_type": alert_type},
+                )
+                if cur.rowcount == 1:
+                    resolved += 1
+
+    return PersistStats(opened=opened, resolved=resolved, unchanged=unchanged)

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -58,7 +58,6 @@ from app.services.order_client import execute_order
 from app.services.portfolio import run_portfolio_review
 from app.services.portfolio_sync import sync_portfolio
 from app.services.position_monitor import (
-    PersistStats,
     check_position_health,
     persist_position_alerts,
 )
@@ -2142,28 +2141,23 @@ def monitor_positions_job() -> None:
     ``persist_position_alerts``.
     """
     with _tracked_job(JOB_MONITOR_POSITIONS) as tracker:
-        try:
-            with psycopg.connect(settings.database_url, autocommit=True) as conn:
-                result = check_position_health(conn)
-                # Writer has its own inner try/except so that a persist
-                # failure does NOT clobber the job's row_count with 0 —
-                # check_position_health succeeded, the tracked count reflects
-                # what was checked (spec: writer failure must preserve
-                # tracker.row_count = result.positions_checked).
-                try:
-                    stats = persist_position_alerts(conn, result)
-                except Exception:
-                    logger.error(
-                        "monitor_positions: persist_position_alerts failed",
-                        exc_info=True,
-                    )
-                    stats = PersistStats(opened=0, resolved=0, unchanged=0)
-        except Exception:
-            logger.error("monitor_positions: health check failed", exc_info=True)
-            tracker.row_count = 0
-            return
-
-        tracker.row_count = result.positions_checked
+        # Connection lifecycle: one autocommit connection shared by
+        # check_position_health (read-only) and persist_position_alerts
+        # (owns its own conn.transaction()). autocommit=True is required so
+        # the writer's transaction block is the outer transaction (not a
+        # savepoint) — see prevention log entry "conn.transaction() savepoint
+        # release does not commit the outer transaction".
+        with psycopg.connect(settings.database_url, autocommit=True) as conn:
+            result = check_position_health(conn)
+            # Report row_count BEFORE the risky persist call so that if the
+            # writer raises, _tracked_job still records the count of
+            # positions we actually checked alongside the failure row. The
+            # exception is NOT swallowed here: it propagates out of the
+            # `with _tracked_job(...)` block, which marks the job as
+            # failure in job_runs (prevention: silent success on partial
+            # failure hides broken alert ingestion from ops dashboards).
+            tracker.row_count = result.positions_checked
+            stats = persist_position_alerts(conn, result)
 
         if result.alerts:
             for alert in result.alerts:

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -57,7 +57,11 @@ from app.services.ops_monitor import (
 from app.services.order_client import execute_order
 from app.services.portfolio import run_portfolio_review
 from app.services.portfolio_sync import sync_portfolio
-from app.services.position_monitor import check_position_health
+from app.services.position_monitor import (
+    PersistStats,
+    check_position_health,
+    persist_position_alerts,
+)
 from app.services.refresh_cascade import (
     demote_to_rerank_needed,
     instrument_lock,
@@ -2129,15 +2133,31 @@ def monitor_positions_job() -> None:
     """Hourly position health check.
 
     Detects SL/TP breaches and thesis breaks between daily sync cycles.
-    Alerts are logged for now; future work may trigger out-of-cycle
-    EXIT recommendations or operator notifications.
+    Writes one row per breach ONSET to ``position_alerts`` (#396);
+    existing open episodes are resolved when the breach clears. Alerts
+    also logged for operator visibility via journalctl.
 
-    Read-only — does not place orders or modify positions.
+    Read-only with respect to orders — does not place orders or modify
+    positions. Writes only to ``position_alerts`` via
+    ``persist_position_alerts``.
     """
     with _tracked_job(JOB_MONITOR_POSITIONS) as tracker:
         try:
-            with psycopg.connect(settings.database_url) as conn:
+            with psycopg.connect(settings.database_url, autocommit=True) as conn:
                 result = check_position_health(conn)
+                # Writer has its own inner try/except so that a persist
+                # failure does NOT clobber the job's row_count with 0 —
+                # check_position_health succeeded, the tracked count reflects
+                # what was checked (spec: writer failure must preserve
+                # tracker.row_count = result.positions_checked).
+                try:
+                    stats = persist_position_alerts(conn, result)
+                except Exception:
+                    logger.error(
+                        "monitor_positions: persist_position_alerts failed",
+                        exc_info=True,
+                    )
+                    stats = PersistStats(opened=0, resolved=0, unchanged=0)
         except Exception:
             logger.error("monitor_positions: health check failed", exc_info=True)
             tracker.row_count = 0
@@ -2154,11 +2174,14 @@ def monitor_positions_job() -> None:
                     alert.instrument_id,
                     alert.detail,
                 )
-        else:
-            logger.info(
-                "monitor_positions: %d positions checked, no alerts",
-                result.positions_checked,
-            )
+
+        logger.info(
+            "monitor_positions: %d checked, episodes: +%d opened / -%d resolved / %d unchanged",
+            result.positions_checked,
+            stats.opened,
+            stats.resolved,
+            stats.unchanged,
+        )
 
 
 def fundamentals_sync() -> None:

--- a/docs/superpowers/plans/2026-04-22-position-alert-persistence.md
+++ b/docs/superpowers/plans/2026-04-22-position-alert-persistence.md
@@ -1,0 +1,1957 @@
+# Position-alert event persistence — Implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist `position_monitor.check_position_health` breach events to a new `position_alerts` episode table, exposing the data via `GET /alerts/position-alerts`, `POST /alerts/position-alerts/seen`, `POST /alerts/position-alerts/dismiss-all` so #399 can render thesis/SL/TP breaches in the dashboard alerts strip.
+
+**Architecture:** Episode model — one row per breach onset, `resolved_at` flipped when the breach clears. Partial unique index on `(instrument_id, alert_type) WHERE resolved_at IS NULL` enforces at-most-one-open-episode per pair. Writer runs inside `monitor_positions_job` on the hourly tick, single-threaded per `app/jobs/runtime.py:224,243` (`max_instances=1` + `threading.Lock`). Read API mirrors #394's guard-rejection shape: 7-day window, 500-row LIMIT, BIGSERIAL `alert_id` cursor with strict `>` comparison.
+
+**Tech Stack:** Python 3.12, FastAPI, Pydantic v2, psycopg 3, PostgreSQL, pytest.
+
+**Branch:** `feature/396-position-alert-persistence` (per CLAUDE.md Branch and PR workflow).
+
+**Spec:** [`docs/superpowers/specs/2026-04-21-position-alert-persistence.md`](../specs/2026-04-21-position-alert-persistence.md).
+
+---
+
+## File Structure
+
+### New files
+
+- `sql/045_position_alerts.sql` — migration creating `position_alerts` table, partial unique index, query index, and `operators.alerts_last_seen_position_alert_id` column.
+- (No new Python files — writer lives in existing `app/services/position_monitor.py`; API lives in existing `app/api/alerts.py`.)
+
+### Modified files
+
+- `app/services/position_monitor.py` — add `PersistStats` dataclass + `persist_position_alerts(conn, result)` function.
+- `app/workers/scheduler.py:2128-2161` — call `persist_position_alerts` after `check_position_health`; adjust log line.
+- `app/api/alerts.py` — add `PositionAlert`, `PositionAlertsResponse`, `PositionAlertsMarkSeenRequest` Pydantic models; add three new endpoints.
+- `frontend/src/api/types.ts` — (no change in this PR; typed models live on backend; frontend extension is #399 scope).
+- `tests/test_position_monitor.py` — add `TestPersistPositionAlerts` class with 10 unit tests against `ebull_test_conn`.
+- `tests/test_api_alerts.py` — add 22 new test methods covering the three new endpoints.
+- `tests/fixtures/ebull_test_db.py:46-60` — add `position_alerts` to `_PLANNER_TABLES` so the per-test TRUNCATE sweeps it.
+
+---
+
+## Task 1 — Migration + test fixture
+
+**Files:**
+- Create: `sql/045_position_alerts.sql`
+- Modify: `tests/fixtures/ebull_test_db.py:46-60`
+
+- [ ] **Step 1: Write the migration**
+
+Create `sql/045_position_alerts.sql` with exact content:
+
+```sql
+-- Migration 045: position-alert episode persistence + operator read cursor
+--
+-- 1. position_alerts — one row per breach EPISODE (not per hourly evaluation).
+--    opened_at = onset detection time. resolved_at = clearance detection time
+--    (NULL while still breaching). alert_id is BIGSERIAL for strict-> cursor
+--    semantics mirroring operators.alerts_last_seen_decision_id (#394 rationale).
+-- 2. Partial unique index enforces at-most-one-open-episode per (instrument_id,
+--    alert_type). The writer's INSERT path relies on this as the concurrency
+--    backstop. Single-threaded scheduler (app/jobs/runtime.py max_instances=1
+--    + per-job threading.Lock) makes overlap effectively impossible; this
+--    constraint is the defensive second layer.
+-- 3. idx_position_alerts_recent on alert_id DESC supports the strip scan in
+--    GET /alerts/position-alerts (ORDER BY alert_id DESC + LIMIT 500).
+--    No WHERE predicate: partial-index predicates must be IMMUTABLE in
+--    PostgreSQL, and now()-based predicates use a STABLE function which
+--    would be rejected.
+-- 4. operators.alerts_last_seen_position_alert_id — parallel cursor to the
+--    existing alerts_last_seen_decision_id column. NULL = never acknowledged.
+
+CREATE TABLE IF NOT EXISTS position_alerts (
+    alert_id      BIGSERIAL    PRIMARY KEY,
+    instrument_id BIGINT       NOT NULL REFERENCES instruments(instrument_id),
+    alert_type    TEXT         NOT NULL
+                               CHECK (alert_type IN ('sl_breach', 'tp_breach', 'thesis_break')),
+    opened_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    resolved_at   TIMESTAMPTZ  NULL,
+    detail        TEXT         NOT NULL,
+    current_bid   NUMERIC      NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_position_alerts_open
+    ON position_alerts (instrument_id, alert_type)
+    WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_position_alerts_recent
+    ON position_alerts (alert_id DESC);
+
+ALTER TABLE operators
+    ADD COLUMN IF NOT EXISTS alerts_last_seen_position_alert_id BIGINT;
+```
+
+- [ ] **Step 2: Add `position_alerts` to test TRUNCATE list**
+
+In `tests/fixtures/ebull_test_db.py`, modify `_PLANNER_TABLES`:
+
+```python
+_PLANNER_TABLES: tuple[str, ...] = (
+    "cascade_retry_queue",
+    "financial_facts_raw",
+    "data_ingestion_runs",
+    "external_identifiers",
+    "external_data_watermarks",
+    "position_alerts",  # #396 position-alert episodes
+    "instruments",
+    "job_runs",
+    "financial_periods_raw",
+    "financial_periods",
+    "filing_events",
+    "decision_audit",  # #315 Phase 3 alerts
+    "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)
+    "operators",  # #315 Phase 3 alerts (cursor column)
+)
+```
+
+`position_alerts` must come BEFORE `instruments` because `position_alerts.instrument_id` references `instruments(instrument_id)` and TRUNCATE CASCADE order ensures the referencing table is cleared first (belt-and-braces — `CASCADE` handles it anyway).
+
+- [ ] **Step 3: Apply migration to dev and test DBs + verify**
+
+```bash
+uv run python -c "from app.db.migrations import run_migrations; run_migrations()"
+```
+
+Expected output: one line logging `045_position_alerts.sql applied` (exact format may differ — look for the filename).
+
+Verify the table exists in dev DB:
+
+```bash
+uv run python -c "import psycopg; from app.config import settings; \
+  c = psycopg.connect(settings.database_url); \
+  cur = c.cursor(); \
+  cur.execute(\"SELECT column_name, data_type FROM information_schema.columns WHERE table_name='position_alerts' ORDER BY ordinal_position\"); \
+  print(list(cur))"
+```
+
+Expected: 7 rows — `alert_id bigint`, `instrument_id bigint`, `alert_type text`, `opened_at timestamp with time zone`, `resolved_at timestamp with time zone`, `detail text`, `current_bid numeric`.
+
+Verify `operators.alerts_last_seen_position_alert_id`:
+
+```bash
+uv run python -c "import psycopg; from app.config import settings; \
+  c = psycopg.connect(settings.database_url); \
+  cur = c.cursor(); \
+  cur.execute(\"SELECT column_name FROM information_schema.columns WHERE table_name='operators' AND column_name='alerts_last_seen_position_alert_id'\"); \
+  print(cur.fetchall())"
+```
+
+Expected: `[('alerts_last_seen_position_alert_id',)]`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sql/045_position_alerts.sql tests/fixtures/ebull_test_db.py
+git commit -m "feat(#396): position_alerts episode table + operator cursor column"
+```
+
+---
+
+## Task 2 — Writer: `PersistStats` + `persist_position_alerts`
+
+**Files:**
+- Modify: `app/services/position_monitor.py` (add new dataclass + function)
+- Test: `tests/test_position_monitor.py` (add `TestPersistPositionAlerts` class)
+
+All writer tests use the real `ebull_test_conn` fixture (episode diff logic exercises atomic transactions, partial-unique-index conflicts, and real DB round-trips — mocked cursors can't pin those).
+
+- [ ] **Step 1: Write failing test for empty + empty no-op**
+
+Append to `tests/test_position_monitor.py`:
+
+```python
+import psycopg
+import pytest
+
+from app.services.position_monitor import (
+    MonitorAlert,
+    MonitorResult,
+    PersistStats,
+    persist_position_alerts,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn, test_db_available  # noqa: F401
+
+
+_next_instrument_id = 0
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, symbol: str = "AAPL") -> int:
+    """Insert a tradable instrument, return instrument_id.
+
+    ``instruments.instrument_id`` is a BIGINT PRIMARY KEY with NO default
+    (sql/001_init.sql:2), so the caller supplies the id. ``symbol`` and
+    ``company_name`` are NOT NULL (sql/001_init.sql:3-4) — no fixture-neutral
+    defaults. Prevention: ``INSERT INTO instruments fixtures must supply
+    is_tradable``; we supply it explicitly even though it has a default.
+    """
+    global _next_instrument_id
+    _next_instrument_id += 1
+    iid = _next_instrument_id
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (iid, symbol, f"{symbol} Inc."),
+        )
+    conn.commit()
+    return iid
+
+
+@pytest.mark.skipif("not test_db_available()")
+class TestPersistPositionAlerts:
+    """Writer diff-logic tests against real ebull_test DB."""
+
+    def test_empty_and_empty_is_noop(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        result = MonitorResult(positions_checked=0, alerts=())
+        stats = persist_position_alerts(ebull_test_conn, result)
+        assert stats == PersistStats(opened=0, resolved=0, unchanged=0)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM position_alerts")
+            assert cur.fetchone() == (0,)
+```
+
+Run:
+
+```bash
+uv run pytest tests/test_position_monitor.py::TestPersistPositionAlerts::test_empty_and_empty_is_noop -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'PersistStats'` or `cannot import name 'persist_position_alerts'`.
+
+- [ ] **Step 2: Add `PersistStats` dataclass to `position_monitor.py`**
+
+Add after the existing `MonitorResult` dataclass in `app/services/position_monitor.py`:
+
+```python
+@dataclass(frozen=True)
+class PersistStats:
+    """Aggregate stats from one persist_position_alerts invocation."""
+
+    opened: int
+    resolved: int
+    unchanged: int
+```
+
+- [ ] **Step 3: Add the writer function**
+
+Append to `app/services/position_monitor.py`:
+
+```python
+def persist_position_alerts(
+    conn: psycopg.Connection[Any],
+    result: MonitorResult,
+) -> PersistStats:
+    """Reconcile open breach episodes against the current MonitorResult.
+
+    Contract: for each (instrument_id, alert_type) pair:
+      - current breach AND no open episode    -> INSERT new row
+      - current breach AND open episode       -> no-op (still breaching)
+      - no current breach AND open episode    -> UPDATE resolved_at = now()
+      - no current breach AND no open episode -> no-op
+
+    Runs inside a single ``conn.transaction()`` block — caller MUST NOT
+    hold an outer transaction, because psycopg v3 treats nested
+    ``conn.transaction()`` as a savepoint and the outer commit path is
+    the caller's responsibility. ``monitor_positions_job`` opens a
+    fresh connection, invokes ``check_position_health`` (read-only, no
+    BEGIN), then calls this writer — the ``conn.transaction()`` block
+    here IS the outer transaction and commits on clean exit.
+
+    Concurrency: the INSERT path tolerates partial-unique-index
+    conflicts via ``ON CONFLICT DO NOTHING``. The resolve path runs
+    ``WHERE resolved_at IS NULL`` so a row resolved by a concurrent
+    writer between the diff read and the UPDATE is a silent no-op.
+    Both guards are defensive — the scheduler serialises
+    ``monitor_positions_job`` via ``max_instances=1`` + per-job
+    ``threading.Lock`` (app/jobs/runtime.py:224,243).
+    """
+    current: dict[tuple[int, str], MonitorAlert] = {
+        (a.instrument_id, a.alert_type): a for a in result.alerts
+    }
+
+    with conn.transaction():
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT instrument_id, alert_type FROM position_alerts WHERE resolved_at IS NULL"
+            )
+            open_pairs: set[tuple[int, str]] = {
+                (int(row["instrument_id"]), str(row["alert_type"])) for row in cur.fetchall()
+            }
+
+            to_open = set(current.keys()) - open_pairs
+            to_resolve = open_pairs - set(current.keys())
+            unchanged = len(open_pairs & set(current.keys()))
+
+            opened = 0
+            for key in to_open:
+                alert = current[key]
+                cur.execute(
+                    """
+                    INSERT INTO position_alerts
+                        (instrument_id, alert_type, detail, current_bid)
+                    VALUES (%(instrument_id)s, %(alert_type)s, %(detail)s, %(current_bid)s)
+                    ON CONFLICT (instrument_id, alert_type) WHERE resolved_at IS NULL
+                    DO NOTHING
+                    """,
+                    {
+                        "instrument_id": alert.instrument_id,
+                        "alert_type": alert.alert_type,
+                        "detail": alert.detail,
+                        "current_bid": alert.current_bid,
+                    },
+                )
+                # rowcount == 1 on insert, 0 on ON CONFLICT DO NOTHING (race backstop).
+                if cur.rowcount == 1:
+                    opened += 1
+
+            resolved = 0
+            for instrument_id, alert_type in to_resolve:
+                cur.execute(
+                    """
+                    UPDATE position_alerts
+                    SET resolved_at = now()
+                    WHERE instrument_id = %(instrument_id)s
+                      AND alert_type = %(alert_type)s
+                      AND resolved_at IS NULL
+                    """,
+                    {"instrument_id": instrument_id, "alert_type": alert_type},
+                )
+                if cur.rowcount == 1:
+                    resolved += 1
+
+    return PersistStats(opened=opened, resolved=resolved, unchanged=unchanged)
+```
+
+- [ ] **Step 4: Run empty-state test**
+
+```bash
+uv run pytest tests/test_position_monitor.py::TestPersistPositionAlerts::test_empty_and_empty_is_noop -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add the remaining 9 unit tests**
+
+Append each method inside `TestPersistPositionAlerts`:
+
+```python
+    def test_new_breach_opens_episode(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        alert = MonitorAlert(
+            instrument_id=iid,
+            symbol="AAPL",
+            alert_type="sl_breach",
+            detail="bid=130 < sl=140",
+            current_bid=Decimal("130"),
+        )
+        stats = persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,))
+        )
+        assert stats == PersistStats(opened=1, resolved=0, unchanged=0)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alert_type, detail, current_bid, resolved_at "
+                "FROM position_alerts WHERE instrument_id = %s",
+                (iid,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "sl_breach"
+        assert rows[0][1] == "bid=130 < sl=140"
+        assert rows[0][2] == Decimal("130")
+        assert rows[0][3] is None
+
+    def test_still_breaching_is_noop(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        alert = MonitorAlert(
+            instrument_id=iid,
+            symbol="AAPL",
+            alert_type="sl_breach",
+            detail="bid=130 < sl=140",
+            current_bid=Decimal("130"),
+        )
+        # First run: opens the episode.
+        persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,))
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alert_id, opened_at FROM position_alerts WHERE instrument_id = %s",
+                (iid,),
+            )
+            first = cur.fetchone()
+        assert first is not None
+
+        # Second run: same breach still present.
+        stats = persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,))
+        )
+        assert stats == PersistStats(opened=0, resolved=0, unchanged=1)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alert_id, opened_at FROM position_alerts WHERE instrument_id = %s",
+                (iid,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        # alert_id and opened_at unchanged — no new row, no UPDATE on existing.
+        assert rows[0][0] == first[0]
+        assert rows[0][1] == first[1]
+
+    def test_clearance_resolves_episode(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        alert = MonitorAlert(
+            instrument_id=iid,
+            symbol="AAPL",
+            alert_type="sl_breach",
+            detail="bid=130 < sl=140",
+            current_bid=Decimal("130"),
+        )
+        persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,))
+        )
+        stats = persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=1, alerts=())
+        )
+        assert stats == PersistStats(opened=0, resolved=1, unchanged=0)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT resolved_at FROM position_alerts WHERE instrument_id = %s",
+                (iid,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] is not None
+
+    def test_re_breach_after_clearance_opens_new_episode(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        alert = MonitorAlert(
+            instrument_id=iid,
+            symbol="AAPL",
+            alert_type="sl_breach",
+            detail="bid=130 < sl=140",
+            current_bid=Decimal("130"),
+        )
+        persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,))
+        )
+        persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=1, alerts=())
+        )
+        stats = persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,))
+        )
+        assert stats == PersistStats(opened=1, resolved=0, unchanged=0)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT resolved_at FROM position_alerts "
+                "WHERE instrument_id = %s ORDER BY alert_id",
+                (iid,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 2
+        assert rows[0][0] is not None  # first episode resolved
+        assert rows[1][0] is None  # second episode still open
+
+    def test_mixed_across_alert_types(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        sl = MonitorAlert(instrument_id=iid, symbol="AAPL", alert_type="sl_breach",
+                          detail="sl", current_bid=Decimal("100"))
+        tp = MonitorAlert(instrument_id=iid, symbol="AAPL", alert_type="tp_breach",
+                          detail="tp", current_bid=Decimal("250"))
+        thesis = MonitorAlert(instrument_id=iid, symbol="AAPL", alert_type="thesis_break",
+                              detail="red=0.9", current_bid=None)
+        # Seed: open sl_breach.
+        persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=1, alerts=(sl,))
+        )
+        # Current: tp + thesis (sl no longer breaching).
+        stats = persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=1, alerts=(tp, thesis))
+        )
+        assert stats == PersistStats(opened=2, resolved=1, unchanged=0)
+
+    def test_mixed_across_instruments(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid_a = _seed_instrument(ebull_test_conn, symbol="AAPL")
+        iid_b = _seed_instrument(ebull_test_conn, symbol="MSFT")
+        iid_c = _seed_instrument(ebull_test_conn, symbol="GOOG")
+        sl_a = MonitorAlert(iid_a, "AAPL", "sl_breach", "a", Decimal("100"))
+        sl_b = MonitorAlert(iid_b, "MSFT", "sl_breach", "b", Decimal("100"))
+        sl_c = MonitorAlert(iid_c, "GOOG", "sl_breach", "c", Decimal("100"))
+        persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=2, alerts=(sl_a, sl_b))
+        )
+        stats = persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=2, alerts=(sl_a, sl_c))
+        )
+        # A: unchanged (still breaching). B: resolved. C: opened.
+        assert stats == PersistStats(opened=1, resolved=1, unchanged=1)
+
+    def test_partial_unique_index_blocks_duplicate_open_pair(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        """Direct DB-level test: two open rows for same (instrument, type) fail.
+
+        The writer's ``ON CONFLICT DO NOTHING`` is the defensive-second-layer
+        concurrency backstop; its correctness depends on the partial unique
+        index itself rejecting duplicates. Hitting the ON CONFLICT path from
+        inside the writer diff is impossible (the diff reads the existing row
+        and puts it in ``unchanged``), so we pin the index constraint
+        directly. If this constraint ever regressed, the writer's backstop
+        would silently allow duplicates.
+        """
+        iid = _seed_instrument(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO position_alerts "
+                "(instrument_id, alert_type, detail) "
+                "VALUES (%s, 'sl_breach', 'first')",
+                (iid,),
+            )
+            with pytest.raises(psycopg.errors.UniqueViolation):
+                cur.execute(
+                    "INSERT INTO position_alerts "
+                    "(instrument_id, alert_type, detail) "
+                    "VALUES (%s, 'sl_breach', 'second')",
+                    (iid,),
+                )
+
+    def test_partial_unique_index_allows_reopen_after_resolve(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        """Partial index WHERE resolved_at IS NULL — a resolved row does not
+        block a new open row for the same (instrument, type)."""
+        iid = _seed_instrument(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO position_alerts "
+                "(instrument_id, alert_type, detail, resolved_at) "
+                "VALUES (%s, 'sl_breach', 'first', now())",
+                (iid,),
+            )
+            # No exception — resolved row is not counted by the partial index.
+            cur.execute(
+                "INSERT INTO position_alerts "
+                "(instrument_id, alert_type, detail) "
+                "VALUES (%s, 'sl_breach', 'second-open')",
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM position_alerts WHERE instrument_id = %s",
+                (iid,),
+            )
+            assert cur.fetchone() == (2,)
+
+    def test_all_three_alert_types_for_same_instrument(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        sl = MonitorAlert(iid, "AAPL", "sl_breach", "s", Decimal("100"))
+        tp = MonitorAlert(iid, "AAPL", "tp_breach", "t", Decimal("250"))
+        th = MonitorAlert(iid, "AAPL", "thesis_break", "r", None)
+        stats = persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=1, alerts=(sl, tp, th))
+        )
+        assert stats == PersistStats(opened=3, resolved=0, unchanged=0)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alert_type FROM position_alerts WHERE instrument_id = %s ORDER BY alert_type",
+                (iid,),
+            )
+            types = [row[0] for row in cur.fetchall()]
+        assert types == ["sl_breach", "thesis_break", "tp_breach"]
+
+    def test_current_bid_null_passes_through(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        alert = MonitorAlert(iid, "AAPL", "thesis_break", "red=0.9", None)
+        persist_position_alerts(
+            ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,))
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT current_bid FROM position_alerts WHERE instrument_id = %s", (iid,)
+            )
+            row = cur.fetchone()
+        assert row == (None,)
+```
+
+- [ ] **Step 6: Run all persist tests**
+
+```bash
+uv run pytest tests/test_position_monitor.py::TestPersistPositionAlerts -v
+```
+
+Expected: 10 PASS. If `ebull_test` is unreachable, all 10 SKIP — fix your DB connection before proceeding.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/position_monitor.py tests/test_position_monitor.py
+git commit -m "feat(#396): persist_position_alerts episode writer + 10 unit tests"
+```
+
+---
+
+## Task 3 — Scheduler wiring
+
+**Files:**
+- Modify: `app/workers/scheduler.py:2128-2161`
+
+- [ ] **Step 1: Update `monitor_positions_job` to call the writer**
+
+Replace the function body between `with _tracked_job(JOB_MONITOR_POSITIONS) as tracker:` and the `def fundamentals_sync()` sentinel:
+
+```python
+def monitor_positions_job() -> None:
+    """Hourly position health check.
+
+    Detects SL/TP breaches and thesis breaks between daily sync cycles.
+    Writes one row per breach ONSET to ``position_alerts`` (#396);
+    existing open episodes are resolved when the breach clears. Alerts
+    also logged for operator visibility via journalctl.
+
+    Read-only with respect to orders — does not place orders or modify
+    positions. Writes only to ``position_alerts`` via
+    ``persist_position_alerts``.
+    """
+    with _tracked_job(JOB_MONITOR_POSITIONS) as tracker:
+        try:
+            with psycopg.connect(settings.database_url) as conn:
+                result = check_position_health(conn)
+                # Writer has its own inner try/except so that a persist
+                # failure does NOT clobber the job's row_count with 0 —
+                # check_position_health succeeded, the tracked count reflects
+                # what was checked (spec: writer failure must preserve
+                # tracker.row_count = result.positions_checked).
+                try:
+                    stats = persist_position_alerts(conn, result)
+                except Exception:
+                    logger.error(
+                        "monitor_positions: persist_position_alerts failed",
+                        exc_info=True,
+                    )
+                    stats = PersistStats(opened=0, resolved=0, unchanged=0)
+        except Exception:
+            logger.error("monitor_positions: health check failed", exc_info=True)
+            tracker.row_count = 0
+            return
+
+        tracker.row_count = result.positions_checked
+
+        if result.alerts:
+            for alert in result.alerts:
+                logger.warning(
+                    "monitor_positions: ALERT %s on %s (instrument_id=%d): %s",
+                    alert.alert_type,
+                    alert.symbol,
+                    alert.instrument_id,
+                    alert.detail,
+                )
+
+        logger.info(
+            "monitor_positions: %d checked, episodes: +%d opened / -%d resolved / %d unchanged",
+            result.positions_checked,
+            stats.opened,
+            stats.resolved,
+            stats.unchanged,
+        )
+```
+
+Update the import on line 60:
+
+```python
+from app.services.position_monitor import (
+    PersistStats,
+    check_position_health,
+    persist_position_alerts,
+)
+```
+
+- [ ] **Step 2: Verify scheduler smoke-tests still pass**
+
+```bash
+uv run pytest tests/test_scheduler_autonomous.py -v -k monitor
+```
+
+Expected: all existing `monitor_positions` tests PASS (they mock `check_position_health` — if any assertion breaks on the new import or call shape, the mock needs a `persist_position_alerts` patch).
+
+If a test fails because `persist_position_alerts` is called with a MagicMock connection, patch the writer too:
+
+```python
+with patch("app.workers.scheduler.persist_position_alerts") as mock_persist:
+    mock_persist.return_value = PersistStats(0, 0, 0)
+    monitor_positions_job()
+```
+
+Update affected tests accordingly.
+
+- [ ] **Step 3: Run the app smoke test**
+
+```bash
+uv run pytest tests/smoke/test_app_boots.py -v
+```
+
+Expected: PASS — the app must still boot with the scheduler changes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/workers/scheduler.py tests/test_scheduler_autonomous.py
+git commit -m "feat(#396): wire persist_position_alerts into monitor_positions_job"
+```
+
+---
+
+## Task 4 — GET /alerts/position-alerts
+
+**Files:**
+- Modify: `app/api/alerts.py`
+- Test: `tests/test_api_alerts.py`
+
+- [ ] **Step 1: Write the failing test — empty state**
+
+Integration tests follow the existing module-level pattern in `tests/test_api_alerts.py`: each test is a free function decorated with `@pytest.mark.skipif("not test_db_available()")`, takes `ebull_test_conn` as a fixture, and uses the module helpers `_seed_operator`, `_bind_test_client`, and `_INT_OP_ID` already defined at [`tests/test_api_alerts.py:355-387`](../../tests/test_api_alerts.py). Auth is globally disabled via [`tests/conftest.py:22`](../../tests/conftest.py) overriding `require_session_or_service_token` — tests do not pass auth headers.
+
+Append to `tests/test_api_alerts.py` **after** the existing `test_integration_*` block (end of file):
+
+```python
+# --- #396 position-alert integration tests ----------------------------------
+
+_PA_INSTRUMENT_ID_COUNTER = 1000  # module-scoped unique IDs to avoid PK clashes
+
+
+def _seed_alert_instrument(
+    conn: psycopg.Connection[tuple], *, symbol: str = "AAPL"
+) -> int:
+    """Insert one instrument row with a unique BIGINT PK; return the id.
+
+    Isolated from the guard-rejection tests' ``iid = 1`` so a single
+    ``ebull_test_conn`` fixture can host multiple instruments without PK
+    clash after TRUNCATE resets (BIGSERIAL on other tables resets, but
+    instruments uses caller-supplied PK).
+    """
+    global _PA_INSTRUMENT_ID_COUNTER
+    _PA_INSTRUMENT_ID_COUNTER += 1
+    iid = _PA_INSTRUMENT_ID_COUNTER
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (iid, symbol, f"{symbol} Inc."),
+        )
+    conn.commit()
+    return iid
+
+
+def _seed_position_alert(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    alert_type: str = "sl_breach",
+    opened_at_offset: str = "-1 hour",
+    resolved_at_offset: str | None = None,
+    detail: str = "breach",
+    current_bid: Decimal | None = Decimal("100"),
+) -> int:
+    """Insert one position_alerts row with controlled offsets; return alert_id.
+
+    ``opened_at_offset`` / ``resolved_at_offset`` are SQL interval
+    literals (``'-1 hour'``, ``'-6 days'``). Whitespace / format is
+    re-used verbatim in an f-string inside the INSERT — do not accept
+    user input here, only test-controlled constants (prevention:
+    f-string SQL composition for column / table identifiers).
+    """
+    resolved_sql = (
+        f"now() + INTERVAL '{resolved_at_offset}'" if resolved_at_offset else "NULL"
+    )
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            INSERT INTO position_alerts
+                (instrument_id, alert_type, opened_at, resolved_at, detail, current_bid)
+            VALUES (
+                %s, %s,
+                now() + INTERVAL '{opened_at_offset}',
+                {resolved_sql},
+                %s, %s
+            )
+            RETURNING alert_id
+            """,
+            (instrument_id, alert_type, detail, current_bid),
+        )
+        row = cur.fetchone()
+        assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_empty_state(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "alerts_last_seen_position_alert_id": None,
+            "unseen_count": 0,
+            "alerts": [],
+        }
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+```
+
+Add `from decimal import Decimal` to the file's imports if not already present.
+
+Run:
+
+```bash
+uv run pytest tests/test_api_alerts.py::test_integration_position_alerts_get_empty_state -v
+```
+
+Expected: FAIL with 404 (endpoint not registered).
+
+- [ ] **Step 2: Add Pydantic models to `app/api/alerts.py`**
+
+Append after the existing `MarkSeenRequest` class:
+
+```python
+AlertType = Literal["sl_breach", "tp_breach", "thesis_break"]
+
+
+class PositionAlert(BaseModel):
+    alert_id: int
+    alert_type: AlertType
+    instrument_id: int
+    symbol: str
+    opened_at: datetime
+    resolved_at: datetime | None
+    detail: str
+    current_bid: Decimal | None
+
+
+class PositionAlertsResponse(BaseModel):
+    alerts_last_seen_position_alert_id: int | None
+    unseen_count: int
+    alerts: list[PositionAlert]
+
+
+class PositionAlertsMarkSeenRequest(BaseModel):
+    seen_through_position_alert_id: int = Field(gt=0)
+```
+
+Add to top-of-file imports:
+
+```python
+from decimal import Decimal
+```
+
+- [ ] **Step 3: Implement `GET /alerts/position-alerts`**
+
+Append to `app/api/alerts.py`:
+
+```python
+@router.get("/position-alerts", response_model=PositionAlertsResponse)
+def get_position_alerts(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> PositionAlertsResponse:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # 1. Read operator's cursor.
+        cur.execute(
+            "SELECT alerts_last_seen_position_alert_id FROM operators WHERE operator_id = %(op)s",
+            {"op": operator_id},
+        )
+        op_row = cur.fetchone()
+        last_seen: int | None = (
+            op_row["alerts_last_seen_position_alert_id"] if op_row else None
+        )
+
+        # 2. Count unseen in-window rows (uncapped).
+        cur.execute(
+            """
+            SELECT COUNT(*) AS unseen_count
+            FROM position_alerts
+            WHERE opened_at >= now() - INTERVAL '7 days'
+              AND (%(last_id)s::BIGINT IS NULL OR alert_id > %(last_id)s::BIGINT)
+            """,
+            {"last_id": last_seen},
+        )
+        count_row = cur.fetchone()
+        assert count_row is not None, "COUNT(*) always returns a row"
+        unseen_count: int = int(count_row["unseen_count"])
+
+        # 3. Fetch the list (capped at 500). ORDER BY alert_id DESC —
+        # BIGSERIAL PK is the race-safe ordering (clock-skew irrelevant;
+        # single-threaded writer guarantees monotonicity). Matches #394
+        # rationale for decision_id.
+        cur.execute(
+            """
+            SELECT
+                pa.alert_id,
+                pa.alert_type,
+                pa.instrument_id,
+                i.symbol,
+                pa.opened_at,
+                pa.resolved_at,
+                pa.detail,
+                pa.current_bid
+            FROM position_alerts pa
+            JOIN instruments i ON i.instrument_id = pa.instrument_id
+            WHERE pa.opened_at >= now() - INTERVAL '7 days'
+            ORDER BY pa.alert_id DESC
+            LIMIT 500
+            """
+        )
+        rows = cur.fetchall()
+
+    return PositionAlertsResponse(
+        alerts_last_seen_position_alert_id=last_seen,
+        unseen_count=unseen_count,
+        alerts=[PositionAlert.model_validate(r) for r in rows],
+    )
+```
+
+- [ ] **Step 4: Run empty-state test**
+
+```bash
+uv run pytest tests/test_api_alerts.py::TestPositionAlertsEndpoints::test_get_empty_state_returns_zero_count_and_null_cursor -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add the remaining GET tests**
+
+Append to `tests/test_api_alerts.py`. Each test is a module-level function; each wraps the request block in `try / finally` to pop the `get_conn` override.
+
+```python
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_includes_rows_within_window(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(ebull_test_conn, instrument_id=iid, opened_at_offset="-6 days")
+    _seed_position_alert(
+        ebull_test_conn, instrument_id=iid, opened_at_offset="-8 days",
+        alert_type="tp_breach",
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert len(body["alerts"]) == 1
+        assert body["alerts"][0]["alert_type"] == "sl_breach"
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_caps_at_500(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    # Seed 510 RESOLVED rows — partial unique index only fires on unresolved
+    # rows, so resolved_at=now() exempts each insert from the open-pair
+    # constraint. All share the same (instrument_id, alert_type) key.
+    with ebull_test_conn.cursor() as cur:
+        for _ in range(510):
+            cur.execute(
+                "INSERT INTO position_alerts "
+                "(instrument_id, alert_type, opened_at, resolved_at, detail) "
+                "VALUES (%s, 'sl_breach', now() - INTERVAL '1 hour', now(), 'x')",
+                (iid,),
+            )
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert len(body["alerts"]) == 500
+        assert body["unseen_count"] == 510
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_unseen_count_respects_cursor(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    a1 = _seed_position_alert(ebull_test_conn, instrument_id=iid,
+                              alert_type="sl_breach", resolved_at_offset="-30 min")
+    _seed_position_alert(ebull_test_conn, instrument_id=iid,
+                         alert_type="tp_breach", resolved_at_offset="-20 min")
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "UPDATE operators SET alerts_last_seen_position_alert_id = %s "
+            "WHERE operator_id = %s",
+            (a1, _INT_OP_ID),
+        )
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert body["unseen_count"] == 1
+        assert body["alerts_last_seen_position_alert_id"] == a1
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_includes_resolved_within_window(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(
+        ebull_test_conn, instrument_id=iid,
+        opened_at_offset="-6 days", resolved_at_offset="-2 hours",
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert len(body["alerts"]) == 1
+        assert body["alerts"][0]["resolved_at"] is not None
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_excludes_old_opened_even_if_unresolved(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(
+        ebull_test_conn, instrument_id=iid,
+        opened_at_offset="-9 days", resolved_at_offset=None,
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert body["alerts"] == []
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_orders_by_alert_id_not_opened_at(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Later alert_id but earlier opened_at must rank higher."""
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    a1 = _seed_position_alert(
+        ebull_test_conn, instrument_id=iid, alert_type="sl_breach",
+        opened_at_offset="-10 min", resolved_at_offset="-5 min",
+    )
+    a2 = _seed_position_alert(
+        ebull_test_conn, instrument_id=iid, alert_type="tp_breach",
+        opened_at_offset="-1 hour", resolved_at_offset="-30 min",
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        # a2 has the later alert_id (inserted second) despite earlier opened_at.
+        assert body["alerts"][0]["alert_id"] == a2
+        assert body["alerts"][1]["alert_id"] == a1
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+```
+
+- [ ] **Step 6: Run all GET tests**
+
+```bash
+uv run pytest tests/test_api_alerts.py -v -k "test_integration_position_alerts_get"
+```
+
+Expected: all 7 PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/api/alerts.py tests/test_api_alerts.py
+git commit -m "feat(#396): GET /alerts/position-alerts + 7 api tests"
+```
+
+---
+
+## Task 5 — POST /alerts/position-alerts/seen
+
+**Files:**
+- Modify: `app/api/alerts.py`
+- Test: `tests/test_api_alerts.py`
+
+- [ ] **Step 1: Write failing test for monotonic UPDATE**
+
+Append to `tests/test_api_alerts.py`:
+
+```python
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_monotonic(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(
+        ebull_test_conn, instrument_id=iid,
+        opened_at_offset="-1 hour", resolved_at_offset=None,
+    )
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "UPDATE operators SET alerts_last_seen_position_alert_id = 1000 "
+            "WHERE operator_id = %s",
+            (_INT_OP_ID,),
+        )
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": 500},
+            )
+        assert resp.status_code == 204
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators "
+                "WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (1000,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+```
+
+Run:
+
+```bash
+uv run pytest tests/test_api_alerts.py::test_integration_position_alerts_seen_monotonic -v
+```
+
+Expected: FAIL with 404.
+
+- [ ] **Step 2: Implement `POST /alerts/position-alerts/seen`**
+
+Append to `app/api/alerts.py`:
+
+```python
+@router.post("/position-alerts/seen", status_code=status.HTTP_204_NO_CONTENT)
+def mark_position_alerts_seen(
+    body: PositionAlertsMarkSeenRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor() as cur:
+        # The m.max_id IS NOT NULL guard makes this a no-op on an empty
+        # window — without it, LEAST(client_posted, NULL) would short-circuit
+        # to NULL and GREATEST(COALESCE(cursor, 0), NULL) would itself be NULL
+        # (PostgreSQL GREATEST ignores NULL arguments), but the simpler reading
+        # is: we never want to materialise a cursor value when no rows exist.
+        cur.execute(
+            """
+            UPDATE operators AS op
+            SET alerts_last_seen_position_alert_id = GREATEST(
+                COALESCE(op.alerts_last_seen_position_alert_id, 0),
+                LEAST(%(seen_through)s, m.max_id)
+            )
+            FROM (
+                SELECT MAX(alert_id) AS max_id
+                FROM position_alerts
+                WHERE opened_at >= now() - INTERVAL '7 days'
+            ) AS m
+            WHERE op.operator_id = %(op)s
+              AND m.max_id IS NOT NULL
+            """,
+            {"seen_through": body.seen_through_position_alert_id, "op": operator_id},
+        )
+    conn.commit()
+```
+
+- [ ] **Step 3: Run test**
+
+```bash
+uv run pytest tests/test_api_alerts.py::TestPositionAlertsEndpoints::test_post_seen_monotonic_never_rewinds -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Add remaining `/seen` tests**
+
+Append to `tests/test_api_alerts.py`:
+
+```python
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_first_time(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    a1 = _seed_position_alert(
+        ebull_test_conn, instrument_id=iid, opened_at_offset="-1 hour"
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": a1},
+            )
+        assert resp.status_code == 204
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators "
+                "WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (a1,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_missing_field_422(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post("/alerts/position-alerts/seen", json={})
+        assert resp.status_code == 422
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_non_integer_422(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Spec case 12 — non-integer body field rejected."""
+    _seed_operator(ebull_test_conn)
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": "abc"},
+            )
+        assert resp.status_code == 422
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_non_positive_422(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": 0},
+            )
+        assert resp.status_code == 422
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_clamped_to_in_window_max(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    a1 = _seed_position_alert(
+        ebull_test_conn, instrument_id=iid, opened_at_offset="-1 hour"
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": 99_999},
+            )
+        assert resp.status_code == 204
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators "
+                "WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (a1,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_empty_window_noop(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": 500},
+            )
+        assert resp.status_code == 204
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators "
+                "WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            # Cursor stays NULL — no 0 written. Divergence from #394 /alerts/seen
+            # (which does write 0 on the same edge; tracked separately).
+            assert cur.fetchone() == (None,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_race_strict_greater(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    a_old = _seed_position_alert(
+        ebull_test_conn, instrument_id=iid, alert_type="sl_breach",
+        opened_at_offset="-1 hour", resolved_at_offset="-30 min",
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": a_old},
+            )
+        # Row arrives AFTER the POST — larger alert_id, must remain unseen.
+        _seed_position_alert(
+            ebull_test_conn, instrument_id=iid, alert_type="tp_breach",
+            opened_at_offset="-5 min",
+        )
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert body["unseen_count"] == 1
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+```
+
+- [ ] **Step 5: Run all /seen tests**
+
+```bash
+uv run pytest tests/test_api_alerts.py -v -k "test_integration_position_alerts_seen"
+```
+
+Expected: 7 PASS (monotonic, first-time, missing-field-422, non-integer-422, non-positive-422, clamped, empty-window-noop, race). That is 8 — verify count matches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/alerts.py tests/test_api_alerts.py
+git commit -m "feat(#396): POST /alerts/position-alerts/seen + 6 api tests"
+```
+
+---
+
+## Task 6 — POST /alerts/position-alerts/dismiss-all
+
+**Files:**
+- Modify: `app/api/alerts.py`
+- Test: `tests/test_api_alerts.py`
+
+- [ ] **Step 1: Write failing test for MAX advance**
+
+Append to `tests/test_api_alerts.py`:
+
+```python
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_dismiss_all_advances_to_max(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(
+        ebull_test_conn, instrument_id=iid, alert_type="sl_breach",
+        opened_at_offset="-3 hours", resolved_at_offset="-2 hours",
+    )
+    _seed_position_alert(
+        ebull_test_conn, instrument_id=iid, alert_type="tp_breach",
+        opened_at_offset="-2 hours", resolved_at_offset="-1 hour",
+    )
+    a3 = _seed_position_alert(
+        ebull_test_conn, instrument_id=iid, alert_type="thesis_break",
+        opened_at_offset="-30 min",
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post("/alerts/position-alerts/dismiss-all")
+        assert resp.status_code == 204
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators "
+                "WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (a3,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+```
+
+Run:
+
+```bash
+uv run pytest tests/test_api_alerts.py::test_integration_position_alerts_dismiss_all_advances_to_max -v
+```
+
+Expected: FAIL with 404.
+
+- [ ] **Step 2: Implement `POST /alerts/position-alerts/dismiss-all`**
+
+Append to `app/api/alerts.py`:
+
+```python
+@router.post("/position-alerts/dismiss-all", status_code=status.HTTP_204_NO_CONTENT)
+def dismiss_all_position_alerts(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE operators AS op
+            SET alerts_last_seen_position_alert_id = GREATEST(
+                COALESCE(op.alerts_last_seen_position_alert_id, 0),
+                m.max_id
+            )
+            FROM (
+                SELECT MAX(alert_id) AS max_id
+                FROM position_alerts
+                WHERE opened_at >= now() - INTERVAL '7 days'
+            ) AS m
+            WHERE op.operator_id = %(op)s
+              AND m.max_id IS NOT NULL
+            """,
+            {"op": operator_id},
+        )
+    conn.commit()
+```
+
+- [ ] **Step 3: Run the advance test**
+
+```bash
+uv run pytest tests/test_api_alerts.py::TestPositionAlertsEndpoints::test_post_dismiss_all_advances_cursor_to_max -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Add remaining /dismiss-all tests**
+
+Append to `tests/test_api_alerts.py`:
+
+```python
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_dismiss_all_monotonic(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(
+        ebull_test_conn, instrument_id=iid,
+        opened_at_offset="-1 hour", resolved_at_offset="-30 min",
+    )
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "UPDATE operators SET alerts_last_seen_position_alert_id = 500 "
+            "WHERE operator_id = %s",
+            (_INT_OP_ID,),
+        )
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post("/alerts/position-alerts/dismiss-all")
+        assert resp.status_code == 204
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators "
+                "WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (500,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_dismiss_all_empty_window_null_cursor(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post("/alerts/position-alerts/dismiss-all")
+        assert resp.status_code == 204
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators "
+                "WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (None,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_dismiss_all_empty_window_existing_cursor(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "UPDATE operators SET alerts_last_seen_position_alert_id = 500 "
+            "WHERE operator_id = %s",
+            (_INT_OP_ID,),
+        )
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            client.post("/alerts/position-alerts/dismiss-all")
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators "
+                "WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (500,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_dismiss_all_race_later_row_unseen(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(
+        ebull_test_conn, instrument_id=iid, alert_type="sl_breach",
+        opened_at_offset="-2 hours", resolved_at_offset="-1 hour",
+    )
+    _seed_position_alert(
+        ebull_test_conn, instrument_id=iid, alert_type="tp_breach",
+        opened_at_offset="-1 hour", resolved_at_offset="-30 min",
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            client.post("/alerts/position-alerts/dismiss-all")
+        _seed_position_alert(
+            ebull_test_conn, instrument_id=iid, alert_type="thesis_break",
+            opened_at_offset="-5 min",
+        )
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert body["unseen_count"] == 1
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+```
+
+- [ ] **Step 5: Add cross-cutting tests (cursor isolation both directions, 503/501, alert_type round-trip)**
+
+Append to `tests/test_api_alerts.py`:
+
+```python
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_cursor_isolated_from_guard_direction_1(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """POST /alerts/position-alerts/seen must not touch the guard cursor."""
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    a1 = _seed_position_alert(
+        ebull_test_conn, instrument_id=iid, opened_at_offset="-1 hour"
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": a1},
+            )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_decision_id, alerts_last_seen_position_alert_id "
+                "FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            guard_cursor, pos_cursor = cur.fetchone()
+        assert guard_cursor is None  # untouched
+        assert pos_cursor == a1
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_cursor_isolated_from_guard_direction_2(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """POST /alerts/seen (guard) must not touch the position cursor."""
+    _seed_operator(ebull_test_conn)
+    # Seed one guard rejection so the /alerts/seen UPDATE is not a no-op.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO decision_audit "
+            "(decision_time, stage, pass_fail, explanation) "
+            "VALUES (now(), 'execution_guard', 'FAIL', 'guard-row') "
+            "RETURNING decision_id"
+        )
+        row = cur.fetchone()
+        assert row is not None
+        did = row[0]
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            client.post(
+                "/alerts/seen",
+                json={"seen_through_decision_id": did},
+            )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_decision_id, alerts_last_seen_position_alert_id "
+                "FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            guard_cursor, pos_cursor = cur.fetchone()
+        assert guard_cursor == did
+        assert pos_cursor is None  # untouched
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_no_operator_returns_503(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Do NOT seed an operator AND do NOT patch sole_operator_id — the
+    real resolver must raise NoOperatorError and the API must map to 503.
+    """
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        # No patch — exercise the real operator resolver path.
+        assert client.get("/alerts/position-alerts").status_code == 503
+        assert client.post(
+            "/alerts/position-alerts/seen",
+            json={"seen_through_position_alert_id": 1},
+        ).status_code == 503
+        assert client.post(
+            "/alerts/position-alerts/dismiss-all"
+        ).status_code == 503
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_multiple_operators_returns_501(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Seed two operators, do NOT patch sole_operator_id — real resolver
+    raises AmbiguousOperatorError → 501."""
+    _seed_operator(ebull_test_conn)
+    second_id = UUID("22222222-2222-2222-2222-222222222222")
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO operators (operator_id, username, password_hash) "
+            "VALUES (%s, 'alerts_test_op2', 'x') ON CONFLICT DO NOTHING",
+            (second_id,),
+        )
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        assert client.get("/alerts/position-alerts").status_code == 501
+        assert client.post(
+            "/alerts/position-alerts/seen",
+            json={"seen_through_position_alert_id": 1},
+        ).status_code == 501
+        assert client.post(
+            "/alerts/position-alerts/dismiss-all"
+        ).status_code == 501
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_alert_type_round_trip_all_three(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    offsets = {"sl_breach": "-3 hours", "tp_breach": "-2 hours", "thesis_break": "-1 hour"}
+    for t, offset in offsets.items():
+        _seed_position_alert(
+            ebull_test_conn, instrument_id=iid,
+            alert_type=t, opened_at_offset=offset,
+        )
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        types = {row["alert_type"] for row in body["alerts"]}
+        assert types == {"sl_breach", "tp_breach", "thesis_break"}
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+```
+
+- [ ] **Step 6: Run all position-alert endpoint tests**
+
+```bash
+uv run pytest tests/test_api_alerts.py -v -k "test_integration_position_alerts"
+```
+
+Expected: 23 PASS.
+
+Test inventory:
+- GET: empty_state, includes_rows_within_window, caps_at_500, unseen_count_respects_cursor, includes_resolved_within_window, excludes_old_opened_even_if_unresolved, orders_by_alert_id_not_opened_at (**7 tests**)
+- POST /seen: monotonic, first_time, missing_field_422, non_integer_422, non_positive_422, clamped_to_in_window_max, empty_window_noop, race_strict_greater (**8 tests**)
+- POST /dismiss-all: advances_to_max, monotonic, empty_window_null_cursor, empty_window_existing_cursor, race_later_row_unseen (**5 tests**)
+- Cross-cutting: cursor_isolated_from_guard_direction_1, cursor_isolated_from_guard_direction_2, no_operator_returns_503, multiple_operators_returns_501, alert_type_round_trip_all_three (**5 tests**) → wait, 2+1+1+1 = 5 cross-cutting; total 7+8+5+5 = 25.
+
+Reconcile: spec enumerates 22 API tests. Plan adds more because spec counts the two directions of cursor isolation as one line; plan splits into two. Accept the over-coverage.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/api/alerts.py tests/test_api_alerts.py
+git commit -m "feat(#396): POST /alerts/position-alerts/dismiss-all + cross-cutting tests"
+```
+
+---
+
+## Task 7 — Gates + Codex pre-push review + PR
+
+- [ ] **Step 1: Run full pre-push gate locally**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+All four must pass. If any fails, fix root cause — do NOT skip or xfail.
+
+Smoke test must be in the last `pytest` run — `tests/smoke/test_app_boots.py` is the gate that catches lifespan-only failures per CLAUDE.md `feedback_smoke_gate_swallowed_failures` memory.
+
+- [ ] **Step 2: Run Codex pre-push review**
+
+```bash
+codex.cmd exec review
+```
+
+Address every finding: FIXED / DEFERRED / REBUTTED. No findings left silent. Fix any real issue in the diff before pushing.
+
+- [ ] **Step 3: Re-run gates after Codex fixes (if any)**
+
+```bash
+uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Push branch + open PR**
+
+PR body is written to a temp file first so the `gh` invocation works in both bash and PowerShell (no heredoc dependency). Use an absolute path so the command is CWD-independent.
+
+Write `/tmp/pr_396_body.md` (or platform-equivalent temp path) with this content:
+
+```markdown
+## What
+Persist SL/TP/thesis breaches from hourly `position_monitor.check_position_health` to a new `position_alerts` episode table. Expose via `GET /alerts/position-alerts`, `POST /alerts/position-alerts/seen`, `POST /alerts/position-alerts/dismiss-all` — mirrors #394's guard-rejection shape so #399 can union all three feeds.
+
+## Why
+Closes #396. Today `monitor_positions_job` logs breaches to stderr only; no DB rows, no strip, no "since last visit" semantics. Episode model (one row per breach onset, `resolved_at` on clearance) matches eBull's append-with-intent convention for recommendations — no spam on still-breaching evaluations.
+
+## Test plan
+- [x] Unit (11): `persist_position_alerts` diff logic against `ebull_test` — empty/empty, new-breach, still-breaching, clearance, re-break, mixed types, mixed instruments, partial-unique-index blocks duplicate open pair, partial-unique-index allows reopen after resolve, all-three-types, NULL current_bid
+- [x] API (25): GET empty/window/cap/cursor/resolved-in-window/out-of-window/ordering (7); /seen monotonic/first-time/missing-field-422/non-integer-422/non-positive-422/clamp/empty-window-noop/race (8); /dismiss-all advance/monotonic/empty-window-null/empty-window-existing/race (5); cross-cutting cursor-isolation-both-directions/503/501/alert_type-round-trip (5)
+- [x] Smoke (`tests/smoke/test_app_boots.py`) green
+- [x] Codex pre-spec + pre-plan + pre-push reviews clean
+- [x] All gates green: `ruff check`, `ruff format --check`, `pyright`, `pytest`
+
+Spec: `docs/superpowers/specs/2026-04-21-position-alert-persistence.md`
+Plan: `docs/superpowers/plans/2026-04-22-position-alert-persistence.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Then push and create the PR:
+
+```bash
+git push -u origin feature/396-position-alert-persistence
+gh pr create \
+  --title "feat(#396): position-alert event persistence" \
+  --body-file /tmp/pr_396_body.md
+```
+
+On PowerShell / Windows, substitute the temp path (e.g. `$env:TEMP\pr_396_body.md`).
+
+- [ ] **Step 5: Start polling review + CI immediately**
+
+Per `feedback_post_push_cycle.md`: do NOT wait for user prompt. Start polling.
+
+```bash
+gh pr view <PR_NUMBER> --comments
+gh pr checks <PR_NUMBER>
+```
+
+Repeat until both Claude review bot has posted AND CI is green on latest commit. Resolve every comment with FIXED / DEFERRED / REBUTTED. Re-run all gates between follow-up pushes.
+
+- [ ] **Step 6: Merge when APPROVE on latest commit + CI green**
+
+Check Codex if the latest review round is rebuttal-only (per CLAUDE.md decision tree). Merge only when:
+- APPROVE on the MOST RECENT commit, OR
+- Latest round is all rebuttals, Codex independently agrees rebuttals are sound
+
+On merge:
+- Delete local + remote branch
+- Close #396
+- #397 and #399 remain open (#399 now has one of two preconditions met)
+
+---
+
+## Self-review checks (author, pre-Codex)
+
+- **Spec coverage** — every section of `docs/superpowers/specs/2026-04-21-position-alert-persistence.md` is represented:
+  - Schema → Task 1
+  - Scheduler serialization rebuttal → documented in migration comment + writer docstring
+  - Writer (`persist_position_alerts`) → Task 2
+  - Scheduler wiring → Task 3
+  - GET /alerts/position-alerts → Task 4
+  - POST /alerts/position-alerts/seen → Task 5
+  - POST /alerts/position-alerts/dismiss-all → Task 6
+  - GET snapshot consistency deferral → noted in Task 4 comment (references #395)
+  - All 25 API tests + 11 unit tests → Tasks 2, 4, 5, 6 (spec enumerated 22 + 10; plan splits a few tests into direction-pairs and adds one partial-index-allows-reopen unit test for full coverage of the DB-level invariant)
+
+- **Type consistency** — `AlertType = Literal["sl_breach", "tp_breach", "thesis_break"]` defined once in `app/api/alerts.py`; `position_monitor.AlertType` mirrors it exactly; DB CHECK constraint in migration matches; Pydantic `PositionAlert.alert_type` uses the type alias.
+
+- **No placeholders** — every step has concrete code or exact command + expected output. No "TBD" or "similar to above" references.

--- a/docs/superpowers/specs/2026-04-21-position-alert-persistence.md
+++ b/docs/superpowers/specs/2026-04-21-position-alert-persistence.md
@@ -1,0 +1,433 @@
+# Position-alert event persistence (#396)
+
+**Date:** 2026-04-21
+**Issue:** [#396](https://github.com/Luke-Bradford/eBull/issues/396) — position-alert event persistence (enables thesis/SL/TP strip row)
+**Parent plan:** [docs/superpowers/plans/2026-04-18-product-visibility-pivot.md](../plans/2026-04-18-product-visibility-pivot.md)
+**Predecessor:** PR #394 (guard-rejection alerts strip) — established the cursor, window, and response-envelope patterns this spec mirrors.
+**Peer:** #397 (coverage-status transition log) — independent, runs in parallel; both feed the strip extension in #399.
+
+---
+
+## Context
+
+[`position_monitor.check_position_health`](../../app/services/position_monitor.py) runs hourly from [`monitor_positions_job`](../../app/workers/scheduler.py) (`JOB_MONITOR_POSITIONS`). It evaluates every open position for three breach types — `sl_breach`, `tp_breach`, `thesis_break` — and returns a `MonitorResult` tuple that is currently **only logged to stderr**. No DB rows, no history, no "since last visit" semantics.
+
+The dashboard alerts strip shipped in #394 displays guard rejections with a seven-day window and a BIGSERIAL cursor on [`operators.alerts_last_seen_decision_id`](../../sql/044_operators_alerts_seen.sql). This spec defines the parallel persistence and read-path layer for position alerts so #399 can render them in the same strip.
+
+Scope intentionally matches #394's surface — same window, same clamp-and-greatest cursor semantics, same 500-row cap, same silent-on-error frontend contract. Divergences are called out where the episode model requires them.
+
+---
+
+## Scope
+
+**In:**
+- New migration `sql/045_position_alerts.sql`: `position_alerts` table + partial unique index + partial query index + new operator cursor column.
+- Writer: new function `persist_position_alerts(conn, result)` in `app/services/position_monitor.py`, invoked from `monitor_positions_job` after `check_position_health`.
+- Read API: `GET /alerts/position-alerts`, `POST /alerts/position-alerts/seen`, `POST /alerts/position-alerts/dismiss-all` — added to `app/api/alerts.py` alongside the existing guard-rejection endpoints.
+- Tests: unit tests for `persist_position_alerts` diff logic; API tests mirroring `tests/test_api_alerts.py`; smoke-test pass of the writer via scheduler invocation.
+
+**Out (explicit non-assertions):**
+- Frontend integration into `AlertsStrip.tsx` — deferred to #399.
+- Retention pruning job — 7-day strip window is enforced at read time; row purging is deferred until volume forces it.
+- Per-operator alert preferences or mute lists.
+- New breach types beyond the three already emitted by `check_position_health`.
+- Changes to `check_position_health` return shape or breach logic.
+- Changes to `monitor_positions_job` scheduling or job-tracking surface.
+- Operator actions on alerts beyond cursor ack (no "create EXIT from alert", no dismiss-one).
+- Unified cross-source alerts endpoint (a design-decision for #399).
+
+---
+
+## Design decisions (resolved in brainstorm)
+
+| Decision | Choice | Why |
+|---|---|---|
+| Dedupe policy | **Transition-only episodes** — one row per breach onset, `resolved_at` flipped when the breach clears. | Matches `recommendation persistence — do not spam identical HOLD rows every run` from settled-decisions. Hourly still-breaching evaluations stay silent; operator isn't paged repeatedly for the same signal. |
+| Retention window | **7 days** (same as guard rejections). | Strip mental model is single: "last 7 days of things that needed you". Transition-only keeps volume tiny either way. |
+| Cursor shape | **New column `alerts_last_seen_position_alert_id BIGINT`** on `operators`, parallel to existing guard cursor. | Mirrors #394 exactly; avoids the `decision_time`-race #394 already solved; #399 unions three independent feeds each with its own BIGSERIAL cursor. |
+| Transition detection | **Episode diff with `resolved_at`.** At-most-one-open-row-per-(instrument, alert_type) invariant enforced by partial unique index. Insert on current-breach-with-no-open-episode; UPDATE `resolved_at = now()` on no-current-breach-with-open-episode; no-op on the other two combinations. | Single atomic transaction; partial unique index blocks concurrent-writer races; crash-safe (process restart re-derives state from DB). |
+| Strip visibility | **Open episodes AND resolved episodes within the 7-day window**, ordered by `alert_id DESC`. | Matches guard-rejection mental model (shows historical FAILs, not just "currently failing"). Transition-only bounds volume. |
+| Cursor target | **Insert row `alert_id` only.** Resolve updates are not tracked by the cursor. | Ack means "I've seen the onset of this breach". A resolve annotation on a row the operator already ack'd is not a new event; showing the resolved-at timestamp on a historically-seen row is expected, not a surprise. |
+
+---
+
+## Schema
+
+New migration `sql/045_position_alerts.sql`:
+
+```sql
+-- Migration 045: position-alert episode persistence + operator read cursor
+--
+-- 1. position_alerts — one row per breach EPISODE (not per hourly evaluation).
+--    opened_at = onset detection time. resolved_at = clearance detection time
+--    (NULL while still breaching). alert_id is BIGSERIAL for strict-> cursor
+--    semantics mirroring operators.alerts_last_seen_decision_id (#394 rationale).
+-- 2. Partial unique index enforces at-most-one-open-episode per (instrument_id,
+--    alert_type). The writer's INSERT path relies on this as the concurrency
+--    backstop — without it, two overlapping monitor_positions_job invocations
+--    could both observe "no open episode" and double-insert. Single-threaded
+--    scheduler makes overlap unlikely; the constraint is the safety net.
+-- 3. idx_position_alerts_recent on alert_id DESC supports the strip scan in
+--    GET /alerts/position-alerts (ORDER BY alert_id DESC + LIMIT 500).
+--    No WHERE predicate: partial-index predicates must be IMMUTABLE in
+--    PostgreSQL, and now()-based predicates use a STABLE function which
+--    would be rejected. Transition-only writes keep the table small enough
+--    that a full index on alert_id DESC is cheap.
+-- 4. operators.alerts_last_seen_position_alert_id — parallel cursor to the
+--    existing alerts_last_seen_decision_id column. NULL = never acknowledged.
+
+CREATE TABLE IF NOT EXISTS position_alerts (
+    alert_id      BIGSERIAL    PRIMARY KEY,
+    instrument_id BIGINT       NOT NULL REFERENCES instruments(instrument_id),
+    alert_type    TEXT         NOT NULL
+                               CHECK (alert_type IN ('sl_breach', 'tp_breach', 'thesis_break')),
+    opened_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    resolved_at   TIMESTAMPTZ  NULL,
+    detail        TEXT         NOT NULL,
+    current_bid   NUMERIC      NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_position_alerts_open
+    ON position_alerts (instrument_id, alert_type)
+    WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_position_alerts_recent
+    ON position_alerts (alert_id DESC);
+
+ALTER TABLE operators
+    ADD COLUMN IF NOT EXISTS alerts_last_seen_position_alert_id BIGINT;
+```
+
+### Scheduler serialization (cursor-race + resolves-race rebuttal)
+
+Both the `alert_id` cursor semantics and the writer's read-then-diff-then-write flow depend on **single-threaded writer** invariants. Those invariants are guaranteed by the existing job runtime:
+
+- [`app/jobs/runtime.py:224`](../../app/jobs/runtime.py) — `self._inflight: dict[str, threading.Lock] = {name: threading.Lock() for name in self._invokers}` — per-job in-process lock.
+- [`app/jobs/runtime.py:243`](../../app/jobs/runtime.py) — APScheduler `max_instances=1` per job — scheduler-level overlap prevention.
+- Comment at [`app/jobs/runtime.py:237-244`](../../app/jobs/runtime.py) names the intent explicitly: "advisory lock is the source of truth for serialisation; this is a defensive second layer".
+
+Under this model:
+
+1. **BIGSERIAL commit-order race** (Codex #2 — sequence allocated pre-commit, so concurrent writers can commit out-of-order and leave lower `alert_id` rows to commit *after* the cursor has advanced past them): cannot occur. Only one `monitor_positions_job` invocation runs at a time; sequence values are allocated and committed in the same serial order. This mirrors the rationale from [`sql/044_operators_alerts_seen.sql`](../../sql/044_operators_alerts_seen.sql) comment L7-9 for `decision_id`: "decision_id is monotonic for the guard stage (single-threaded scheduler invocations; no concurrent writers), so a strict `>` comparison fully closes the race".
+2. **Writer resolves race** (Codex #3 — stale run reads an open episode, decides "no longer breaching", UPDATEs `resolved_at` while a fresher run would have kept it open): cannot occur. Only one invocation of `persist_position_alerts` is running at a time. If a future reader needs parallelism here, add `pg_try_advisory_xact_lock(<position_monitor_lock_key>)` at the top of the writer's transaction and bail on `false`.
+
+If and when the scheduler model changes (autoscaled workers, multi-process deployment), both invariants must be re-validated. Add a pointer to this paragraph from any future multi-worker spec.
+
+Notes:
+- `alert_type` CHECK mirrors [`position_monitor.AlertType`](../../app/services/position_monitor.py) `Literal["sl_breach", "tp_breach", "thesis_break"]` exactly. Prevention: `New TEXT columns in migrations need CHECK constraints or Literal types`.
+- `opened_at` defaults to DB `now()` on INSERT — writer does not pass an app-side timestamp. Prevention: `datetime.now(UTC)` vs DB `now()` in freshness windows.
+- `resolved_at` is UPDATE-only; writer never inserts a row with `resolved_at` already populated.
+- No `ON DELETE CASCADE` from `instruments` — prevention: `ON DELETE CASCADE on *_audit / *_log tables destroys forensic history`. Manual purge is the retention path.
+- Partial index `WHERE opened_at >= now() - INTERVAL '7 days'` uses an immutable-at-definition interval; the predicate is evaluated at index maintenance time per row, so aged-out rows fall out of the index automatically. This matches the pattern from #394's `idx_decision_audit_guard_failed_recent`.
+- No backfill. Pre-existing logged breaches stay unrecorded; the writer starts fresh on the first scheduler tick after migration.
+
+---
+
+## Writer: `persist_position_alerts`
+
+New function in [`app/services/position_monitor.py`](../../app/services/position_monitor.py), called from `monitor_positions_job` immediately after `check_position_health`:
+
+```python
+def persist_position_alerts(
+    conn: psycopg.Connection[Any],
+    result: MonitorResult,
+) -> PersistStats:
+    """Reconcile open breach episodes against the current MonitorResult.
+
+    Contract: for each (instrument_id, alert_type) pair:
+      - current breach AND no open episode   -> INSERT new row
+      - current breach AND open episode      -> no-op (still breaching)
+      - no current breach AND open episode   -> UPDATE resolved_at = now()
+      - no current breach AND no open episode -> no-op
+
+    All four branches execute inside a single conn.transaction() block.
+    Returns PersistStats(opened, resolved, unchanged) for the scheduler log line.
+    """
+```
+
+Return type:
+
+```python
+@dataclass(frozen=True)
+class PersistStats:
+    opened: int       # new episodes inserted
+    resolved: int     # existing episodes closed
+    unchanged: int    # still-open episodes left alone
+```
+
+Algorithm (inside one `with conn.transaction():` block — prevention: `Read-then-write cap enforcement outside transaction`, `conn.transaction() without conn.commit() silently rolls back in psycopg v3`):
+
+1. **Read current open episodes.**
+   ```sql
+   SELECT instrument_id, alert_type
+   FROM position_alerts
+   WHERE resolved_at IS NULL;
+   ```
+   Returned set: `OPEN = { (instrument_id, alert_type) -> row is open }`.
+
+2. **Build current-breach set from `result.alerts`:**
+   `CURRENT = { (a.instrument_id, a.alert_type): a for a in result.alerts }`. Invariant: `check_position_health` emits at most one alert per (instrument, alert_type) per invocation (see loop at [`app/services/position_monitor.py:123-171`](../../app/services/position_monitor.py) — each `if` branch pushes one alert per row, rows are per-instrument).
+
+3. **Diff:**
+   - `TO_OPEN = CURRENT.keys() - OPEN` — breaches without an open episode.
+   - `TO_RESOLVE = OPEN - CURRENT.keys()` — open episodes whose breach has cleared.
+   - Intersection → no-op.
+
+4. **INSERT for each `(instrument_id, alert_type)` in `TO_OPEN`:**
+   ```sql
+   INSERT INTO position_alerts (instrument_id, alert_type, detail, current_bid)
+   VALUES (%(instrument_id)s, %(alert_type)s, %(detail)s, %(current_bid)s)
+   ON CONFLICT (instrument_id, alert_type) WHERE resolved_at IS NULL DO NOTHING;
+   ```
+   `detail` and `current_bid` come from the corresponding `MonitorAlert`. `opened_at` defaults to DB `now()` — not supplied by writer. `ON CONFLICT ... DO NOTHING` is belt-and-braces against concurrent writer races; primary correctness comes from the partial unique index.
+
+5. **UPDATE for each `(instrument_id, alert_type)` in `TO_RESOLVE`:**
+   ```sql
+   UPDATE position_alerts
+   SET resolved_at = now()
+   WHERE instrument_id = %(instrument_id)s
+     AND alert_type = %(alert_type)s
+     AND resolved_at IS NULL;
+   ```
+   Scoped with `resolved_at IS NULL` guard so a row resolved between step 1 and step 5 isn't touched (prevention: `Single-row UPDATE silent no-op on missing row` — here the no-op is correct, not a bug).
+
+6. **Commit** via the `conn.transaction()` context manager exiting cleanly. Counts accumulated into `PersistStats` before return.
+
+**Scheduler integration** — [`app/workers/scheduler.py`](../../app/workers/scheduler.py) `monitor_positions_job`:
+
+```python
+with psycopg.connect(settings.database_url) as conn:
+    result = check_position_health(conn)
+    stats = persist_position_alerts(conn, result)
+
+# existing stderr logging preserved; add one stats line:
+logger.info(
+    "monitor_positions: %d checked, episodes: +%d opened / -%d resolved / %d unchanged",
+    result.positions_checked, stats.opened, stats.resolved, stats.unchanged,
+)
+```
+
+`persist_position_alerts` must not raise on empty `result.alerts` (idempotent no-op when both `CURRENT` and `TO_RESOLVE` are empty AND `OPEN` is empty). Exception escalation: writer failure **must** keep `tracker.row_count = result.positions_checked` — the tracked-job surface already records the check count separately from alert persistence. An exception from the writer rolls back the transaction and propagates out; the existing `except Exception` in `monitor_positions_job` already handles this path (prevention: `Early return inside context-managed tracking without row_count`).
+
+**Connection ownership** — `check_position_health` and `persist_position_alerts` share the same connection opened by the scheduler. `persist_position_alerts` must **not** call `conn.commit()` itself when the caller is managing the transaction (prevention: `Mid-transaction conn.commit() in service functions that accept a caller's connection`). The `with conn.transaction()` context inside `persist_position_alerts` creates a savepoint-like block that commits on exit *only if no outer transaction is active*; since `psycopg.connect(...)` enters autocommit-off and `check_position_health` runs a read with no BEGIN, the `conn.transaction()` block inside the writer IS the outer transaction. Document this in the function docstring so a future caller wrapping it in their own transaction doesn't double-commit.
+
+---
+
+## Read API
+
+All three endpoints added to the existing [`app/api/alerts.py`](../../app/api/alerts.py) router under the same `/alerts` prefix. Auth and operator-resolution mirror the existing guard-rejection endpoints exactly (`require_session_or_service_token` + `sole_operator_id`, 503/501 mapping for `NoOperatorError` / `AmbiguousOperatorError`).
+
+### `GET /alerts/position-alerts`
+
+**Response:**
+
+```python
+class PositionAlert(BaseModel):
+    alert_id: int
+    alert_type: Literal["sl_breach", "tp_breach", "thesis_break"]
+    instrument_id: int
+    symbol: str
+    opened_at: datetime
+    resolved_at: datetime | None
+    detail: str
+    current_bid: Decimal | None
+
+class PositionAlertsResponse(BaseModel):
+    alerts_last_seen_position_alert_id: int | None
+    unseen_count: int
+    alerts: list[PositionAlert]
+```
+
+`instrument_id` and `symbol` are NOT nullable — `position_alerts.instrument_id` has a NOT NULL FK and is always resolvable. Divergence from the guard-rejection response where nullability is required. `alert_type` is a closed `Literal` union — prevention: `Loose 'string' on API response fields that mirror backend Literal types`.
+
+**List query:**
+
+```sql
+SELECT
+    pa.alert_id,
+    pa.alert_type,
+    pa.instrument_id,
+    i.symbol,
+    pa.opened_at,
+    pa.resolved_at,
+    pa.detail,
+    pa.current_bid
+FROM position_alerts pa
+JOIN instruments i ON i.instrument_id = pa.instrument_id
+WHERE pa.opened_at >= now() - INTERVAL '7 days'
+ORDER BY pa.alert_id DESC
+LIMIT 500;
+```
+
+- Inline `INTERVAL '7 days'` literal — prevention: `Interval construction via string concatenation in SQL`.
+- Window filter on `opened_at`, not `resolved_at`. An episode that opened six days ago and resolved two hours ago is still in-window; an episode that opened nine days ago and is still unresolved falls OUT of window (edge case — accepted: if a breach has been open nine days, the strip isn't the right surface, the position page is).
+- `JOIN instruments` is INNER because FK is NOT NULL — no LEFT JOIN indirection. Prevention: `JOIN fan-out inflates aggregates` N/A because `instruments.instrument_id` is unique.
+- `ORDER BY alert_id DESC` is the stable PK sequence; the `rejections[0].alert_id === MAX(alert_id)` invariant the cursor depends on holds without clock-skew concerns (unlike `decision_time` in #394).
+- `LIMIT 500` matches #394's cap. Prevention: `Unbounded API limit parameters`.
+
+**`unseen_count` query** (separate; reflects true in-window unseen count regardless of the 500-row cap):
+
+```sql
+SELECT COUNT(*) AS unseen_count
+FROM position_alerts
+WHERE opened_at >= now() - INTERVAL '7 days'
+  AND (%(last_id)s::BIGINT IS NULL OR alert_id > %(last_id)s::BIGINT);
+```
+
+Strict `>` — ties are structurally impossible because `alert_id` is a unique BIGSERIAL. Prevention: `Shared cursor across unrelated queries` — the two queries share a dict cursor but no `%(last_id)s` placeholder is reused across them with different semantics; each query gets its own `.execute()` with a fresh params dict.
+
+### `POST /alerts/position-alerts/seen`
+
+**Body:**
+
+```python
+class PositionAlertsMarkSeenRequest(BaseModel):
+    seen_through_position_alert_id: int = Field(gt=0)
+```
+
+**Write:**
+
+```sql
+UPDATE operators AS op
+SET alerts_last_seen_position_alert_id = GREATEST(
+    COALESCE(op.alerts_last_seen_position_alert_id, 0),
+    LEAST(%(seen_through_position_alert_id)s, m.max_id)
+)
+FROM (
+    SELECT MAX(alert_id) AS max_id
+    FROM position_alerts
+    WHERE opened_at >= now() - INTERVAL '7 days'
+) AS m
+WHERE op.operator_id = %(op)s
+  AND m.max_id IS NOT NULL;
+```
+
+`LEAST` clamp bounds ack to the current in-window MAX — prevents a buggy or malicious client from advancing the cursor past future un-arrived rows. `GREATEST` + `COALESCE(..., 0)` preserves monotonicity (never rewinds; handles NULL-initial). The `AND m.max_id IS NOT NULL` guard makes the UPDATE a no-op when the window is empty — without it, the subselect would return NULL → `LEAST(client, NULL) = NULL` OR (depending on COALESCE positioning) `GREATEST(0, 0) = 0` writes `0` as a fake cursor. Empty window + client POST should leave cursor unchanged (divergence from #394's `/alerts/seen` — that endpoint writes `0` on the same edge; tracked as a separate consistency fix, not in scope for this PR). Response: `204 No Content`.
+
+### `POST /alerts/position-alerts/dismiss-all`
+
+**Body:** empty.
+
+**Write:**
+
+```sql
+UPDATE operators AS op
+SET alerts_last_seen_position_alert_id = GREATEST(
+    COALESCE(op.alerts_last_seen_position_alert_id, 0),
+    m.max_id
+)
+FROM (
+    SELECT MAX(alert_id) AS max_id
+    FROM position_alerts
+    WHERE opened_at >= now() - INTERVAL '7 days'
+) AS m
+WHERE op.operator_id = %(op)s
+  AND m.max_id IS NOT NULL;
+```
+
+Empty-window no-op (when no rows in window, `m.max_id IS NULL` excludes the UPDATE target row → cursor unchanged). Atomic — a row inserted between the subselect and the UPDATE commit has a larger `alert_id` and stays unseen on next GET. Response: `204 No Content`.
+
+### GET snapshot consistency (deferred)
+
+The GET handler runs three separate statements (cursor read, count, list) against the same `psycopg.Connection` without wrapping them in a single REPEATABLE READ snapshot. Under `READ COMMITTED`, an insert committed between statements can make `unseen_count`, `alerts_last_seen_position_alert_id`, and the returned `alerts` list reflect different moments in time. The practical symptom is a one-refresh stale count or a "newer than the cursor but missing from the list" row — which self-heals on the next GET.
+
+This is a known tech-debt shared with #394's `/alerts/guard-rejections` and is tracked against [#395](https://github.com/Luke-Bradford/eBull/issues/395) (tech-debt: dashboard reads — snapshot consistency on multi-query handlers). Deferred for consistency with the existing pattern; fixing it here without fixing #394's identical handler would leave the repo half-converted. When #395 is picked up, both handlers get the REPEATABLE READ wrapper in one pass.
+
+### Error semantics
+
+- Endpoint failures should not 500 the dashboard; the frontend renders null on error (#399 extends the existing silent-on-error policy to the new data source). Backend still returns real 500s on internal errors.
+- Partial index + 7-day window keeps GET latency <200ms.
+
+---
+
+## Tests
+
+### Unit: `persist_position_alerts` (`tests/test_position_monitor.py`, extending existing file)
+
+Fixtures use the `ebull_test` test DB (prevention: `Tests must never wipe the dev DB`).
+
+1. **Empty + empty** — no open episodes in DB, no current alerts → `PersistStats(0, 0, 0)`; zero rows after.
+2. **New breach → opens episode** — no open episodes, `result.alerts = [sl_breach on instrument A]` → one INSERT; `PersistStats(1, 0, 0)`; table row has `resolved_at IS NULL`, `opened_at` set by DB, `detail` copied from alert.
+3. **Still breaching → no-op** — one open episode for A/sl_breach, same alert in `result.alerts` → `PersistStats(0, 0, 1)`; row count unchanged; `opened_at` unchanged; no new row.
+4. **Clearance → resolves episode** — one open episode for A/sl_breach, `result.alerts = []` → `PersistStats(0, 1, 0)`; row's `resolved_at` populated with DB `now()`; no new rows.
+5. **Re-breach after clearance → new episode** — one resolved episode exists (prior `resolved_at` populated); `result.alerts = [sl_breach on A]` → `PersistStats(1, 0, 0)`; two rows in table, one with `resolved_at` set, one with `resolved_at IS NULL`.
+6. **Mixed across alert types** — A has open `sl_breach`; `result.alerts = [tp_breach on A, thesis_break on B]` → `PersistStats(2, 1, 0)` (two opens, one resolve because A's sl_breach is no longer current).
+7. **Mixed across instruments** — A has open sl_breach; B has open sl_breach; `result.alerts = [sl_breach on A, sl_breach on C]` → `PersistStats(1, 1, 1)`.
+8. **ON CONFLICT guard** — simulate a racing second writer by pre-inserting an open row for A/sl_breach inside the same connection; call `persist_position_alerts` with the same alert → no duplicate row (ON CONFLICT DO NOTHING); `PersistStats.opened == 0`, `unchanged == 1`. Note: this test asserts the index/constraint safety net, not normal-path correctness.
+9. **All three alert types for same instrument** — `result.alerts = [sl_breach, tp_breach, thesis_break all on A]`, no open episodes → three INSERTs; three open rows after (partial unique index is keyed on `(instrument_id, alert_type)` — three types are three distinct keys).
+10. **`current_bid` NULL passes through** — `result.alerts = [thesis_break with current_bid=None]` (thesis-break path doesn't require a bid) → INSERT succeeds with NULL bid column.
+
+### API: `tests/test_api_alerts.py` (extending existing file)
+
+1. **Empty state** — no rows → `{ alerts: [], unseen_count: 0, alerts_last_seen_position_alert_id: null }`.
+2. **Seven-day window inclusion** — insert rows at `now() - interval '6 days'` (opened_at) and `now() - interval '8 days'` (opened_at); only the 6-day row returned.
+3. **500-row cap** — insert 510 open rows within window, cursor NULL → `alerts.length === 500`, `unseen_count === 510`.
+4. **`unseen_count` anchor** — cursor set mid-window, verify strict `>` count.
+5. **`unseen_count` NULL cursor** — all in-window rows counted.
+6. **Resolved episodes included** — insert a row with `opened_at` at 6 days ago AND `resolved_at` at 2 hours ago; it appears in GET response with `resolved_at` populated.
+7. **Out-of-window by opened_at** — insert row with `opened_at = now() - '9 days'` and `resolved_at = NULL` → excluded (window is keyed on `opened_at`, deliberate).
+8. **Ordering** — insert rows with `alert_id` 50 and 51 where row 50 has `opened_at = now()` and row 51 has `opened_at = now() - '1 minute'` → `alerts[0].alert_id === 51` (ORDER BY `alert_id DESC`, not `opened_at`).
+9. **POST /seen monotonic** — cursor = 1000, POST `seen_through_position_alert_id = 500` → unchanged.
+10. **POST /seen first time** — cursor NULL, POST 1000 → set to 1000.
+11. **POST /seen missing field → 422**.
+12. **POST /seen non-integer → 422**.
+13. **POST /seen clamped to in-window MAX** — window MAX = 200, cursor NULL, POST 99999 → cursor set to 200.
+14. **POST /seen race safety** — insert row 101; POST `seen_through_position_alert_id = 100`; next GET shows `unseen_count === 1`.
+15. **POST /dismiss-all advances to MAX** — rows 100/200/300 in window, cursor NULL → POST → cursor 300.
+16. **POST /dismiss-all monotonic** — cursor = 500, MAX-in-window = 300 → unchanged at 500.
+17. **POST /dismiss-all race safety** — cursor NULL, rows 100 and 200 present, POST dismiss-all, THEN insert row 201 → next GET `unseen_count === 1`.
+18. **POST /dismiss-all empty window** — no rows, cursor NULL → unchanged at NULL.
+19. **POST /dismiss-all empty window with cursor** — cursor = 500, no rows in window → unchanged at 500.
+20. **`sole_operator_id` errors** — no operator → 503, multiple operators → 501, on all three endpoints.
+21. **Alert-type round-trip** — each of the three literal values round-trips through the API without coercion.
+22. **Operator cursor isolated from guard cursor** — POST /alerts/seen (guard path) does not touch `alerts_last_seen_position_alert_id`; POST /alerts/position-alerts/seen does not touch `alerts_last_seen_decision_id`. Pin this explicitly — two cursors on the same row are easy to cross-wire.
+
+### Smoke
+
+`tests/smoke/test_app_boots.py` already boots the full app via `TestClient` against dev DB. No change needed — new endpoints come up alongside the existing `/alerts/*` router, router registration is additive.
+
+---
+
+## Prevention entries consulted
+
+| Entry | How applied |
+|---|---|
+| `datetime.now(UTC)` vs DB `now()` in freshness windows | All timestamps (`opened_at`, `resolved_at`, window filter, cursor MAX subselect) use DB `now()`. |
+| Interval construction via string concatenation in SQL | `INTERVAL '7 days'` literal everywhere; no concatenation. |
+| Shared column vocabulary mismatch across stages | `alert_type` values match `position_monitor.AlertType` Literal exactly; CHECK constraint pins the vocabulary in the DB. |
+| Loose `string` on API response fields that mirror backend `Literal` | Pydantic model uses `Literal["sl_breach", "tp_breach", "thesis_break"]`. |
+| New TEXT columns in migrations need CHECK constraints or Literal types | `alert_type` has CHECK; Pydantic Literal mirrors. |
+| Unbounded API limit parameters | 500-row cap hardcoded server-side. |
+| JOIN fan-out inflates aggregates | INNER JOIN on unique FK; no aggregate queries at risk. |
+| `conn.transaction()` without `conn.commit()` silently rolls back in psycopg v3 | Writer uses `with conn.transaction()` ; outer scheduler connection is not in an existing transaction; the block IS the outer transaction and commits on clean exit. Documented in function docstring. |
+| Mid-transaction `conn.commit()` in service functions that accept a caller's connection | Writer never calls `conn.commit()` directly; caller manages or the `with conn.transaction()` block handles it. |
+| Read-then-write cap enforcement outside transaction | Diff read + insert/update in one `with conn.transaction()` block. |
+| Shared cursor across unrelated queries | Each query gets its own `.execute()` with a fresh params dict. |
+| Single-row UPDATE silent no-op on missing row | UPDATE on resolve path includes `resolved_at IS NULL` guard; silent no-op IS correct behaviour if row was resolved between read and UPDATE. |
+| ON CONFLICT DO NOTHING counter overcount | Writer uses partial-index ON CONFLICT DO NOTHING + counts from the SQL RETURNING or `rowcount`; tests pin that conflict path yields `opened=0`. |
+| ON DELETE CASCADE on `*_audit` / `*_log` tables destroys forensic history | `position_alerts.instrument_id` FK has no ON DELETE CASCADE. |
+| Naive datetime in TIMESTAMPTZ query params | Cursor is BIGINT `alert_id`; no timestamp query params. |
+| Early return inside context-managed tracking without `row_count` | `monitor_positions_job` integration keeps `tracker.row_count = result.positions_checked` on the error path and success path. |
+| Unbounded enum filters accept nonsense values silently | GET takes no enum filter params (fixed window, no user-controlled filters). |
+| Frontend async render-surface isolation | Out of scope (deferred to #399), but backend honours its side of the contract by returning proper error codes, not silent empty lists. |
+
+## Settled decisions consulted
+
+| Decision | How applied |
+|---|---|
+| Auditability — persist structured evidence where it matters | Breach episodes now have DB history, not just stderr. |
+| Recommendation persistence is append-oriented, do not spam identical HOLD rows | Transition-only episode model is the parallel rule for alert persistence. |
+| Product-visibility pivot — prioritise operator visibility over infra work | This spec is a direct descendant of the #315 strip work; position alerts are the single-biggest missing signal from the dashboard. |
+
+---
+
+## Definition of done
+
+1. Migration `sql/045_position_alerts.sql` applied cleanly against `ebull` and `ebull_test`.
+2. `persist_position_alerts` writer plus scheduler integration land in one PR with unit tests and API tests.
+3. `GET /alerts/position-alerts`, `POST /alerts/position-alerts/seen`, `POST /alerts/position-alerts/dismiss-all` all return the shapes and semantics documented above.
+4. `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright`, `uv run pytest` all pass.
+5. `tests/smoke/test_app_boots.py` passes (no frontend changes — no frontend test suite delta required).
+6. Codex pre-spec review complete (this document); Codex pre-plan review before first task dispatch; Codex pre-push review before the first `git push`.
+7. PR description follows `feedback_pr_description_brevity.md` — title `feat(#396): position-alert event persistence`; body: What / Why / Test plan bullets only.
+8. On merge: close #396. #397 and #399 remain open; #399 now has one of its two preconditions met.

--- a/sql/045_position_alerts.sql
+++ b/sql/045_position_alerts.sql
@@ -1,0 +1,39 @@
+-- Migration 045: position-alert episode persistence + operator read cursor
+--
+-- 1. position_alerts — one row per breach EPISODE (not per hourly evaluation).
+--    opened_at = onset detection time. resolved_at = clearance detection time
+--    (NULL while still breaching). alert_id is BIGSERIAL for strict-> cursor
+--    semantics mirroring operators.alerts_last_seen_decision_id (#394 rationale).
+-- 2. Partial unique index enforces at-most-one-open-episode per (instrument_id,
+--    alert_type). The writer's INSERT path relies on this as the concurrency
+--    backstop. Single-threaded scheduler (app/jobs/runtime.py max_instances=1
+--    + per-job threading.Lock) makes overlap effectively impossible; this
+--    constraint is the defensive second layer.
+-- 3. idx_position_alerts_recent on alert_id DESC supports the strip scan in
+--    GET /alerts/position-alerts (ORDER BY alert_id DESC + LIMIT 500).
+--    No WHERE predicate: partial-index predicates must be IMMUTABLE in
+--    PostgreSQL, and now()-based predicates use a STABLE function which
+--    would be rejected.
+-- 4. operators.alerts_last_seen_position_alert_id — parallel cursor to the
+--    existing alerts_last_seen_decision_id column. NULL = never acknowledged.
+
+CREATE TABLE IF NOT EXISTS position_alerts (
+    alert_id      BIGSERIAL    PRIMARY KEY,
+    instrument_id BIGINT       NOT NULL REFERENCES instruments(instrument_id),
+    alert_type    TEXT         NOT NULL
+                               CHECK (alert_type IN ('sl_breach', 'tp_breach', 'thesis_break')),
+    opened_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    resolved_at   TIMESTAMPTZ  NULL,
+    detail        TEXT         NOT NULL,
+    current_bid   NUMERIC      NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_position_alerts_open
+    ON position_alerts (instrument_id, alert_type)
+    WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_position_alerts_recent
+    ON position_alerts (alert_id DESC);
+
+ALTER TABLE operators
+    ADD COLUMN IF NOT EXISTS alerts_last_seen_position_alert_id BIGINT;

--- a/sql/046_position_alerts_opened_at_index.sql
+++ b/sql/046_position_alerts_opened_at_index.sql
@@ -1,0 +1,17 @@
+-- Migration 046: btree index on position_alerts.opened_at
+--
+-- Codex pre-push review P2: GET /alerts/position-alerts, POST
+-- /alerts/position-alerts/seen, and POST /alerts/position-alerts/dismiss-all
+-- all filter on `opened_at >= now() - INTERVAL '7 days'`. Migration 045
+-- only added an index on `alert_id DESC`, so once position_alerts
+-- accumulates history (no pruning job in scope for #396) the time-window
+-- predicate degrades to a full-table scan.
+--
+-- Plain btree on opened_at (no partial predicate) because partial-index
+-- predicates must be IMMUTABLE — now()-based predicates use a STABLE
+-- function and would be rejected. A full btree stays small while row
+-- volume is low (transition-only episode model) and supports both the
+-- 7-day window scan and ORDER BY opened_at if future queries need it.
+
+CREATE INDEX IF NOT EXISTS idx_position_alerts_opened_at
+    ON position_alerts (opened_at DESC);

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -49,6 +49,7 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "data_ingestion_runs",
     "external_identifiers",
     "external_data_watermarks",
+    "position_alerts",  # #396 position-alert episodes
     "instruments",
     "job_runs",
     "financial_periods_raw",

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -1030,3 +1030,332 @@ def test_integration_position_alerts_seen_race_strict_greater(
         from app.db import get_conn
 
         app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_dismiss_all_advances_to_max(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        alert_type="sl_breach",
+        opened_at_offset="-3 hours",
+        resolved_at_offset="-2 hours",
+    )
+    _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        alert_type="tp_breach",
+        opened_at_offset="-2 hours",
+        resolved_at_offset="-1 hour",
+    )
+    a3 = _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        alert_type="thesis_break",
+        opened_at_offset="-30 min",
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post("/alerts/position-alerts/dismiss-all")
+        assert resp.status_code == 204
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (a3,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_dismiss_all_monotonic(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        opened_at_offset="-1 hour",
+        resolved_at_offset="-30 min",
+    )
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "UPDATE operators SET alerts_last_seen_position_alert_id = 500 WHERE operator_id = %s",
+            (_INT_OP_ID,),
+        )
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post("/alerts/position-alerts/dismiss-all")
+        assert resp.status_code == 204
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (500,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_dismiss_all_empty_window_null_cursor(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post("/alerts/position-alerts/dismiss-all")
+        assert resp.status_code == 204
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (None,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_dismiss_all_empty_window_existing_cursor(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "UPDATE operators SET alerts_last_seen_position_alert_id = 500 WHERE operator_id = %s",
+            (_INT_OP_ID,),
+        )
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            client.post("/alerts/position-alerts/dismiss-all")
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (500,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_dismiss_all_race_later_row_unseen(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        alert_type="sl_breach",
+        opened_at_offset="-2 hours",
+        resolved_at_offset="-1 hour",
+    )
+    _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        alert_type="tp_breach",
+        opened_at_offset="-1 hour",
+        resolved_at_offset="-30 min",
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            client.post("/alerts/position-alerts/dismiss-all")
+        _seed_position_alert(
+            ebull_test_conn,
+            instrument_id=iid,
+            alert_type="thesis_break",
+            opened_at_offset="-5 min",
+        )
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert body["unseen_count"] == 1
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_cursor_isolated_from_guard_direction_1(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """POST /alerts/position-alerts/seen must not touch the guard cursor."""
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    a1 = _seed_position_alert(ebull_test_conn, instrument_id=iid, opened_at_offset="-1 hour")
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": a1},
+            )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_decision_id, alerts_last_seen_position_alert_id "
+                "FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            guard_cursor, pos_cursor = row
+        assert guard_cursor is None
+        assert pos_cursor == a1
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_cursor_isolated_from_guard_direction_2(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """POST /alerts/seen (guard) must not touch the position cursor."""
+    _seed_operator(ebull_test_conn)
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO decision_audit "
+            "(decision_time, stage, pass_fail, explanation) "
+            "VALUES (now(), 'execution_guard', 'FAIL', 'guard-row') "
+            "RETURNING decision_id"
+        )
+        row = cur.fetchone()
+        assert row is not None
+        did = row[0]
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            client.post(
+                "/alerts/seen",
+                json={"seen_through_decision_id": did},
+            )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_decision_id, alerts_last_seen_position_alert_id "
+                "FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            guard_cursor, pos_cursor = row
+        assert guard_cursor == did
+        assert pos_cursor is None
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_no_operator_returns_503(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Do NOT seed an operator AND do NOT patch sole_operator_id — the
+    real resolver must raise NoOperatorError and the API must map to 503.
+    """
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        assert client.get("/alerts/position-alerts").status_code == 503
+        assert (
+            client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": 1},
+            ).status_code
+            == 503
+        )
+        assert client.post("/alerts/position-alerts/dismiss-all").status_code == 503
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_multiple_operators_returns_501(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Seed two operators, do NOT patch sole_operator_id — real resolver
+    raises AmbiguousOperatorError -> 501."""
+    _seed_operator(ebull_test_conn)
+    second_id = UUID("22222222-2222-2222-2222-222222222222")
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO operators (operator_id, username, password_hash) "
+            "VALUES (%s, 'alerts_test_op2', 'x') ON CONFLICT DO NOTHING",
+            (second_id,),
+        )
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        assert client.get("/alerts/position-alerts").status_code == 501
+        assert (
+            client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": 1},
+            ).status_code
+            == 501
+        )
+        assert client.post("/alerts/position-alerts/dismiss-all").status_code == 501
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_alert_type_round_trip_all_three(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    offsets = {"sl_breach": "-3 hours", "tp_breach": "-2 hours", "thesis_break": "-1 hour"}
+    for t, offset in offsets.items():
+        _seed_position_alert(
+            ebull_test_conn,
+            instrument_id=iid,
+            alert_type=t,
+            opened_at_offset=offset,
+        )
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        types = {row["alert_type"] for row in body["alerts"]}
+        assert types == {"sl_breach", "tp_breach", "thesis_break"}
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -814,3 +814,219 @@ def test_integration_position_alerts_get_orders_by_alert_id_not_opened_at(
         from app.db import get_conn
 
         app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_monotonic(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        opened_at_offset="-1 hour",
+        resolved_at_offset=None,
+    )
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "UPDATE operators SET alerts_last_seen_position_alert_id = 1000 WHERE operator_id = %s",
+            (_INT_OP_ID,),
+        )
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": 500},
+            )
+        assert resp.status_code == 204
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (1000,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_first_time(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    a1 = _seed_position_alert(ebull_test_conn, instrument_id=iid, opened_at_offset="-1 hour")
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": a1},
+            )
+        assert resp.status_code == 204
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (a1,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_missing_field_422(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post("/alerts/position-alerts/seen", json={})
+        assert resp.status_code == 422
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_non_integer_422(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Spec case 12 — non-integer body field rejected."""
+    _seed_operator(ebull_test_conn)
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": "abc"},
+            )
+        assert resp.status_code == 422
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_non_positive_422(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": 0},
+            )
+        assert resp.status_code == 422
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_clamped_to_in_window_max(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    a1 = _seed_position_alert(ebull_test_conn, instrument_id=iid, opened_at_offset="-1 hour")
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": 99_999},
+            )
+        assert resp.status_code == 204
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            assert cur.fetchone() == (a1,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_empty_window_noop(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": 500},
+            )
+        assert resp.status_code == 204
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alerts_last_seen_position_alert_id FROM operators WHERE operator_id = %s",
+                (_INT_OP_ID,),
+            )
+            # Cursor stays NULL — no 0 written. Divergence from #394 /alerts/seen
+            # (which does write 0 on the same edge; tracked separately).
+            assert cur.fetchone() == (None,)
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_seen_race_strict_greater(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    a_old = _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        alert_type="sl_breach",
+        opened_at_offset="-1 hour",
+        resolved_at_offset="-30 min",
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            client.post(
+                "/alerts/position-alerts/seen",
+                json={"seen_through_position_alert_id": a_old},
+            )
+        # Row arrives AFTER the POST — larger alert_id, must remain unseen.
+        _seed_position_alert(
+            ebull_test_conn,
+            instrument_id=iid,
+            alert_type="tp_breach",
+            opened_at_offset="-5 min",
+        )
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert body["unseen_count"] == 1
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -657,6 +657,9 @@ def test_integration_position_alerts_get_includes_rows_within_window(
         body = resp.json()
         assert len(body["alerts"]) == 1
         assert body["alerts"][0]["alert_type"] == "sl_breach"
+        # Pins spec test 5: NULL cursor counts all in-window rows.
+        assert body["unseen_count"] == 1
+        assert body["alerts_last_seen_position_alert_id"] is None
     finally:
         from app.db import get_conn
 

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -1149,7 +1149,8 @@ def test_integration_position_alerts_dismiss_all_empty_window_existing_cursor(
     client = _bind_test_client(ebull_test_conn)
     try:
         with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
-            client.post("/alerts/position-alerts/dismiss-all")
+            resp = client.post("/alerts/position-alerts/dismiss-all")
+        assert resp.status_code == 204
         with ebull_test_conn.cursor() as cur:
             cur.execute(
                 "SELECT alerts_last_seen_position_alert_id FROM operators WHERE operator_id = %s",

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 from datetime import UTC, datetime
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
@@ -545,6 +546,267 @@ def test_integration_non_guard_stage_excluded_from_list_and_dismiss(
             non_guard_dismiss_row = cur.fetchone()
             assert non_guard_dismiss_row is not None
             assert non_guard_dismiss_row[0] is None
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+# --- #396 position-alert integration tests ----------------------------------
+
+_PA_INSTRUMENT_ID_COUNTER = 1000  # module-scoped unique IDs to avoid PK clashes
+
+
+def _seed_alert_instrument(conn: psycopg.Connection[tuple], *, symbol: str = "AAPL") -> int:
+    """Insert one instrument row with a unique BIGINT PK; return the id.
+
+    Isolated from the guard-rejection tests' ``iid = 1`` so a single
+    ``ebull_test_conn`` fixture can host multiple instruments without PK
+    clash after TRUNCATE resets (BIGSERIAL on other tables resets, but
+    instruments uses caller-supplied PK).
+    """
+    global _PA_INSTRUMENT_ID_COUNTER
+    _PA_INSTRUMENT_ID_COUNTER += 1
+    iid = _PA_INSTRUMENT_ID_COUNTER
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (iid, symbol, f"{symbol} Inc."),
+        )
+    conn.commit()
+    return iid
+
+
+def _seed_position_alert(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    alert_type: str = "sl_breach",
+    opened_at_offset: str = "-1 hour",
+    resolved_at_offset: str | None = None,
+    detail: str = "breach",
+    current_bid: Decimal | None = Decimal("100"),
+) -> int:
+    """Insert one position_alerts row with controlled offsets; return alert_id.
+
+    ``opened_at_offset`` / ``resolved_at_offset`` are SQL interval
+    literals (``'-1 hour'``, ``'-6 days'``). Whitespace / format is
+    re-used verbatim in an f-string inside the INSERT — do not accept
+    user input here, only test-controlled constants (prevention:
+    f-string SQL composition for column / table identifiers).
+    """
+    resolved_sql = f"now() + INTERVAL '{resolved_at_offset}'" if resolved_at_offset else "NULL"
+    sql = f"""
+            INSERT INTO position_alerts
+                (instrument_id, alert_type, opened_at, resolved_at, detail, current_bid)
+            VALUES (
+                %s, %s,
+                now() + INTERVAL '{opened_at_offset}',
+                {resolved_sql},
+                %s, %s
+            )
+            RETURNING alert_id
+            """
+    with conn.cursor() as cur:
+        cur.execute(sql, (instrument_id, alert_type, detail, current_bid))  # type: ignore[call-overload]
+        row = cur.fetchone()
+        assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_empty_state(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "alerts_last_seen_position_alert_id": None,
+            "unseen_count": 0,
+            "alerts": [],
+        }
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_includes_rows_within_window(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(ebull_test_conn, instrument_id=iid, opened_at_offset="-6 days")
+    _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        opened_at_offset="-8 days",
+        alert_type="tp_breach",
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert len(body["alerts"]) == 1
+        assert body["alerts"][0]["alert_type"] == "sl_breach"
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_caps_at_500(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    with ebull_test_conn.cursor() as cur:
+        for _ in range(510):
+            cur.execute(
+                "INSERT INTO position_alerts "
+                "(instrument_id, alert_type, opened_at, resolved_at, detail) "
+                "VALUES (%s, 'sl_breach', now() - INTERVAL '1 hour', now(), 'x')",
+                (iid,),
+            )
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert len(body["alerts"]) == 500
+        assert body["unseen_count"] == 510
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_unseen_count_respects_cursor(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    a1 = _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        alert_type="sl_breach",
+        resolved_at_offset="-30 min",
+    )
+    _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        alert_type="tp_breach",
+        resolved_at_offset="-20 min",
+    )
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "UPDATE operators SET alerts_last_seen_position_alert_id = %s WHERE operator_id = %s",
+            (a1, _INT_OP_ID),
+        )
+    ebull_test_conn.commit()
+
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert body["unseen_count"] == 1
+        assert body["alerts_last_seen_position_alert_id"] == a1
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_includes_resolved_within_window(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        opened_at_offset="-6 days",
+        resolved_at_offset="-2 hours",
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert len(body["alerts"]) == 1
+        assert body["alerts"][0]["resolved_at"] is not None
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_excludes_old_opened_even_if_unresolved(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        opened_at_offset="-9 days",
+        resolved_at_offset=None,
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert body["alerts"] == []
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.skipif("not test_db_available()")
+def test_integration_position_alerts_get_orders_by_alert_id_not_opened_at(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Later alert_id but earlier opened_at must rank higher."""
+    _seed_operator(ebull_test_conn)
+    iid = _seed_alert_instrument(ebull_test_conn)
+    a1 = _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        alert_type="sl_breach",
+        opened_at_offset="-10 min",
+        resolved_at_offset="-5 min",
+    )
+    a2 = _seed_position_alert(
+        ebull_test_conn,
+        instrument_id=iid,
+        alert_type="tp_breach",
+        opened_at_offset="-1 hour",
+        resolved_at_offset="-30 min",
+    )
+    client = _bind_test_client(ebull_test_conn)
+    try:
+        with patch("app.api.alerts.sole_operator_id", return_value=_INT_OP_ID):
+            resp = client.get("/alerts/position-alerts")
+        body = resp.json()
+        assert body["alerts"][0]["alert_id"] == a2
+        assert body["alerts"][1]["alert_id"] == a1
     finally:
         from app.db import get_conn
 

--- a/tests/test_position_monitor.py
+++ b/tests/test_position_monitor.py
@@ -2,6 +2,7 @@
 
 Structure:
   - TestCheckPositionHealth — full check_position_health with mocked DB
+  - TestPersistPositionAlerts — writer diff-logic tests against real ebull_test DB
 """
 
 from __future__ import annotations
@@ -11,10 +12,21 @@ from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock
 
+import psycopg
+import pytest
+
 from app.services.position_monitor import (
     EXIT_RED_FLAG_THRESHOLD,
+    MonitorAlert,
+    MonitorResult,
+    PersistStats,
     check_position_health,
+    persist_position_alerts,
 )
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -230,3 +242,240 @@ class TestCheckPositionHealth:
         tb_alerts = [a for a in result.alerts if a.alert_type == "thesis_break"]
         assert len(tb_alerts) == 1
         assert tb_alerts[0].current_bid is None
+
+
+# ---------------------------------------------------------------------------
+# TestPersistPositionAlerts
+# ---------------------------------------------------------------------------
+
+_next_instrument_id = 0
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, symbol: str = "AAPL") -> int:
+    """Insert a tradable instrument, return instrument_id.
+
+    ``instruments.instrument_id`` is a BIGINT PRIMARY KEY with NO default
+    (sql/001_init.sql:2), so the caller supplies the id. ``symbol`` and
+    ``company_name`` are NOT NULL (sql/001_init.sql:3-4) — no fixture-neutral
+    defaults. Prevention: ``INSERT INTO instruments fixtures must supply
+    is_tradable``; we supply it explicitly even though it has a default.
+    """
+    global _next_instrument_id
+    _next_instrument_id += 1
+    iid = _next_instrument_id
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (iid, symbol, f"{symbol} Inc."),
+        )
+    conn.commit()
+    return iid
+
+
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestPersistPositionAlerts:
+    """Writer diff-logic tests against real ebull_test DB."""
+
+    def test_empty_and_empty_is_noop(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        result = MonitorResult(positions_checked=0, alerts=())
+        stats = persist_position_alerts(ebull_test_conn, result)
+        assert stats == PersistStats(opened=0, resolved=0, unchanged=0)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM position_alerts")
+            assert cur.fetchone() == (0,)
+
+    def test_new_breach_opens_episode(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        alert = MonitorAlert(
+            instrument_id=iid,
+            symbol="AAPL",
+            alert_type="sl_breach",
+            detail="bid=130 < sl=140",
+            current_bid=Decimal("130"),
+        )
+        stats = persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,)))
+        assert stats == PersistStats(opened=1, resolved=0, unchanged=0)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alert_type, detail, current_bid, resolved_at FROM position_alerts WHERE instrument_id = %s",
+                (iid,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "sl_breach"
+        assert rows[0][1] == "bid=130 < sl=140"
+        assert rows[0][2] == Decimal("130")
+        assert rows[0][3] is None
+
+    def test_still_breaching_is_noop(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        alert = MonitorAlert(
+            instrument_id=iid,
+            symbol="AAPL",
+            alert_type="sl_breach",
+            detail="bid=130 < sl=140",
+            current_bid=Decimal("130"),
+        )
+        persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,)))
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alert_id, opened_at FROM position_alerts WHERE instrument_id = %s",
+                (iid,),
+            )
+            first = cur.fetchone()
+        assert first is not None
+
+        stats = persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,)))
+        assert stats == PersistStats(opened=0, resolved=0, unchanged=1)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alert_id, opened_at FROM position_alerts WHERE instrument_id = %s",
+                (iid,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == first[0]
+        assert rows[0][1] == first[1]
+
+    def test_clearance_resolves_episode(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        alert = MonitorAlert(
+            instrument_id=iid,
+            symbol="AAPL",
+            alert_type="sl_breach",
+            detail="bid=130 < sl=140",
+            current_bid=Decimal("130"),
+        )
+        persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,)))
+        stats = persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=1, alerts=()))
+        assert stats == PersistStats(opened=0, resolved=1, unchanged=0)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT resolved_at FROM position_alerts WHERE instrument_id = %s",
+                (iid,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] is not None
+
+    def test_re_breach_after_clearance_opens_new_episode(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        alert = MonitorAlert(
+            instrument_id=iid,
+            symbol="AAPL",
+            alert_type="sl_breach",
+            detail="bid=130 < sl=140",
+            current_bid=Decimal("130"),
+        )
+        persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,)))
+        persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=1, alerts=()))
+        stats = persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,)))
+        assert stats == PersistStats(opened=1, resolved=0, unchanged=0)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT resolved_at FROM position_alerts WHERE instrument_id = %s ORDER BY alert_id",
+                (iid,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 2
+        assert rows[0][0] is not None
+        assert rows[1][0] is None
+
+    def test_mixed_across_alert_types(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        sl = MonitorAlert(
+            instrument_id=iid, symbol="AAPL", alert_type="sl_breach", detail="sl", current_bid=Decimal("100")
+        )
+        tp = MonitorAlert(
+            instrument_id=iid, symbol="AAPL", alert_type="tp_breach", detail="tp", current_bid=Decimal("250")
+        )
+        thesis = MonitorAlert(
+            instrument_id=iid, symbol="AAPL", alert_type="thesis_break", detail="red=0.9", current_bid=None
+        )
+        persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=1, alerts=(sl,)))
+        stats = persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=1, alerts=(tp, thesis)))
+        assert stats == PersistStats(opened=2, resolved=1, unchanged=0)
+
+    def test_mixed_across_instruments(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid_a = _seed_instrument(ebull_test_conn, symbol="AAPL")
+        iid_b = _seed_instrument(ebull_test_conn, symbol="MSFT")
+        iid_c = _seed_instrument(ebull_test_conn, symbol="GOOG")
+        sl_a = MonitorAlert(iid_a, "AAPL", "sl_breach", "a", Decimal("100"))
+        sl_b = MonitorAlert(iid_b, "MSFT", "sl_breach", "b", Decimal("100"))
+        sl_c = MonitorAlert(iid_c, "GOOG", "sl_breach", "c", Decimal("100"))
+        persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=2, alerts=(sl_a, sl_b)))
+        stats = persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=2, alerts=(sl_a, sl_c)))
+        assert stats == PersistStats(opened=1, resolved=1, unchanged=1)
+
+    def test_partial_unique_index_blocks_duplicate_open_pair(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Direct DB-level test: two open rows for same (instrument, type) fail."""
+        iid = _seed_instrument(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO position_alerts (instrument_id, alert_type, detail) VALUES (%s, 'sl_breach', 'first')",
+                (iid,),
+            )
+            with pytest.raises(psycopg.errors.UniqueViolation):
+                cur.execute(
+                    "INSERT INTO position_alerts "
+                    "(instrument_id, alert_type, detail) "
+                    "VALUES (%s, 'sl_breach', 'second')",
+                    (iid,),
+                )
+
+    def test_partial_unique_index_allows_reopen_after_resolve(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Partial index WHERE resolved_at IS NULL — a resolved row does not
+        block a new open row for the same (instrument, type)."""
+        iid = _seed_instrument(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO position_alerts "
+                "(instrument_id, alert_type, detail, resolved_at) "
+                "VALUES (%s, 'sl_breach', 'first', now())",
+                (iid,),
+            )
+            cur.execute(
+                "INSERT INTO position_alerts "
+                "(instrument_id, alert_type, detail) "
+                "VALUES (%s, 'sl_breach', 'second-open')",
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM position_alerts WHERE instrument_id = %s",
+                (iid,),
+            )
+            assert cur.fetchone() == (2,)
+
+    def test_all_three_alert_types_for_same_instrument(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        sl = MonitorAlert(iid, "AAPL", "sl_breach", "s", Decimal("100"))
+        tp = MonitorAlert(iid, "AAPL", "tp_breach", "t", Decimal("250"))
+        th = MonitorAlert(iid, "AAPL", "thesis_break", "r", None)
+        stats = persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=1, alerts=(sl, tp, th)))
+        assert stats == PersistStats(opened=3, resolved=0, unchanged=0)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT alert_type FROM position_alerts WHERE instrument_id = %s ORDER BY alert_type",
+                (iid,),
+            )
+            types = [row[0] for row in cur.fetchall()]
+        assert types == ["sl_breach", "thesis_break", "tp_breach"]
+
+    def test_current_bid_null_passes_through(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        alert = MonitorAlert(iid, "AAPL", "thesis_break", "red=0.9", None)
+        persist_position_alerts(ebull_test_conn, MonitorResult(positions_checked=1, alerts=(alert,)))
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT current_bid FROM position_alerts WHERE instrument_id = %s", (iid,))
+            row = cur.fetchone()
+        assert row == (None,)

--- a/tests/test_position_monitor.py
+++ b/tests/test_position_monitor.py
@@ -414,20 +414,28 @@ class TestPersistPositionAlerts:
         assert stats == PersistStats(opened=1, resolved=1, unchanged=1)
 
     def test_partial_unique_index_blocks_duplicate_open_pair(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
-        """Direct DB-level test: two open rows for same (instrument, type) fail."""
+        """Direct DB-level test: two open rows for same (instrument, type) fail.
+
+        Wraps both INSERTs in a ``conn.transaction()`` savepoint so the
+        UniqueViolation is absorbed cleanly — without it, the connection's
+        implicit transaction remains in an aborted state after the second
+        INSERT fails, which would leak into any subsequent statement on
+        the same connection (brittle under future test-code additions).
+        """
         iid = _seed_instrument(ebull_test_conn)
-        with ebull_test_conn.cursor() as cur:
-            cur.execute(
-                "INSERT INTO position_alerts (instrument_id, alert_type, detail) VALUES (%s, 'sl_breach', 'first')",
-                (iid,),
-            )
-            with pytest.raises(psycopg.errors.UniqueViolation):
-                cur.execute(
-                    "INSERT INTO position_alerts "
-                    "(instrument_id, alert_type, detail) "
-                    "VALUES (%s, 'sl_breach', 'second')",
-                    (iid,),
-                )
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            with ebull_test_conn.transaction():
+                with ebull_test_conn.cursor() as cur:
+                    cur.execute(
+                        "INSERT INTO position_alerts (instrument_id, alert_type, detail) VALUES (%s, 'sl_breach', 'first')",
+                        (iid,),
+                    )
+                    cur.execute(
+                        "INSERT INTO position_alerts "
+                        "(instrument_id, alert_type, detail) "
+                        "VALUES (%s, 'sl_breach', 'second')",
+                        (iid,),
+                    )
 
     def test_partial_unique_index_allows_reopen_after_resolve(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         """Partial index WHERE resolved_at IS NULL — a resolved row does not

--- a/tests/test_position_monitor.py
+++ b/tests/test_position_monitor.py
@@ -427,7 +427,9 @@ class TestPersistPositionAlerts:
             with ebull_test_conn.transaction():
                 with ebull_test_conn.cursor() as cur:
                     cur.execute(
-                        "INSERT INTO position_alerts (instrument_id, alert_type, detail) VALUES (%s, 'sl_breach', 'first')",
+                        "INSERT INTO position_alerts "
+                        "(instrument_id, alert_type, detail) "
+                        "VALUES (%s, 'sl_breach', 'first')",
                         (iid,),
                     )
                     cur.execute(

--- a/tests/test_scheduler_autonomous.py
+++ b/tests/test_scheduler_autonomous.py
@@ -235,6 +235,54 @@ class TestMonitorPositionsJob:
 
         assert captured_row_count and captured_row_count[0] == 5
 
+    @patch(_SPIKE_PATCH, return_value=MagicMock(flagged=False))
+    @patch(_RECORD_FINISH_PATCH)
+    @patch(_RECORD_START_PATCH, return_value=1)
+    @patch("app.workers.scheduler.persist_position_alerts")
+    @patch("app.workers.scheduler.check_position_health")
+    @patch(_PSYCOPG_CONNECT_PATCH)
+    def test_persist_failure_preserves_row_count(
+        self,
+        mock_connect: MagicMock,
+        mock_health: MagicMock,
+        mock_persist: MagicMock,
+        mock_start: MagicMock,
+        mock_finish: MagicMock,
+        mock_spike: MagicMock,
+    ) -> None:
+        """Writer failure must NOT clobber row_count with 0.
+
+        Contract (spec §persist_position_alerts integration): when
+        check_position_health succeeds but persist_position_alerts raises,
+        the tracked row_count must still equal result.positions_checked —
+        the check side-effect DID happen, so the tracker reflects it.
+        """
+        from app.services.position_monitor import MonitorResult
+
+        fake_result = MonitorResult(positions_checked=7, alerts=())
+        mock_health.return_value = fake_result
+        mock_persist.side_effect = RuntimeError("simulated persist failure")
+
+        conn_ctx = MagicMock()
+        conn_ctx.__enter__ = MagicMock(return_value=conn_ctx)
+        conn_ctx.__exit__ = MagicMock(return_value=False)
+        mock_connect.return_value = conn_ctx
+
+        captured_row_count: list[Any] = []
+
+        def capture_finish(conn: Any, run_id: Any, **kwargs: Any) -> None:
+            captured_row_count.append(kwargs.get("row_count"))
+
+        with patch(_RECORD_FINISH_PATCH, side_effect=capture_finish):
+            monitor_positions_job()
+
+        # Writer raised, but the check succeeded with 7 positions — the
+        # inner except swallows the writer exception and falls through to
+        # the unconditional tracker.row_count = result.positions_checked
+        # assignment after the outer try/except.
+        assert captured_row_count and captured_row_count[0] == 7
+        mock_persist.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # Task 6: timing_deferred_at stamp — source-level assertion

--- a/tests/test_scheduler_autonomous.py
+++ b/tests/test_scheduler_autonomous.py
@@ -163,21 +163,24 @@ class TestMonitorPositionsJob:
     @patch(_SPIKE_PATCH, return_value=MagicMock(flagged=False))
     @patch(_RECORD_FINISH_PATCH)
     @patch(_RECORD_START_PATCH, return_value=1)
+    @patch("app.workers.scheduler.persist_position_alerts")
     @patch("app.workers.scheduler.check_position_health")
     @patch(_PSYCOPG_CONNECT_PATCH)
     def test_calls_check_position_health(
         self,
         mock_connect: MagicMock,
         mock_health: MagicMock,
+        mock_persist: MagicMock,
         mock_start: MagicMock,
         mock_finish: MagicMock,
         mock_spike: MagicMock,
     ) -> None:
         """monitor_positions_job must call check_position_health and set row_count."""
-        from app.services.position_monitor import MonitorResult
+        from app.services.position_monitor import MonitorResult, PersistStats
 
         fake_result = MonitorResult(positions_checked=3, alerts=())
         mock_health.return_value = fake_result
+        mock_persist.return_value = PersistStats(opened=0, resolved=0, unchanged=0)
 
         conn_ctx = MagicMock()
         conn_ctx.__enter__ = MagicMock(return_value=conn_ctx)
@@ -191,18 +194,20 @@ class TestMonitorPositionsJob:
     @patch(_SPIKE_PATCH, return_value=MagicMock(flagged=False))
     @patch(_RECORD_FINISH_PATCH)
     @patch(_RECORD_START_PATCH, return_value=1)
+    @patch("app.workers.scheduler.persist_position_alerts")
     @patch("app.workers.scheduler.check_position_health")
     @patch(_PSYCOPG_CONNECT_PATCH)
     def test_row_count_equals_positions_checked(
         self,
         mock_connect: MagicMock,
         mock_health: MagicMock,
+        mock_persist: MagicMock,
         mock_start: MagicMock,
         mock_finish: MagicMock,
         mock_spike: MagicMock,
     ) -> None:
         """tracker.row_count must equal result.positions_checked."""
-        from app.services.position_monitor import MonitorAlert, MonitorResult
+        from app.services.position_monitor import MonitorAlert, MonitorResult, PersistStats
 
         alert = MonitorAlert(
             instrument_id=1,
@@ -212,6 +217,7 @@ class TestMonitorPositionsJob:
         )
         fake_result = MonitorResult(positions_checked=5, alerts=(alert,))
         mock_health.return_value = fake_result
+        mock_persist.return_value = PersistStats(opened=0, resolved=0, unchanged=0)
 
         conn_ctx = MagicMock()
         conn_ctx.__enter__ = MagicMock(return_value=conn_ctx)

--- a/tests/test_scheduler_autonomous.py
+++ b/tests/test_scheduler_autonomous.py
@@ -13,6 +13,8 @@ import inspect
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import app.workers.scheduler as scheduler_module
 from app.workers.scheduler import (
     monitor_positions_job,
@@ -241,7 +243,7 @@ class TestMonitorPositionsJob:
     @patch("app.workers.scheduler.persist_position_alerts")
     @patch("app.workers.scheduler.check_position_health")
     @patch(_PSYCOPG_CONNECT_PATCH)
-    def test_persist_failure_preserves_row_count(
+    def test_persist_failure_marks_job_failure(
         self,
         mock_connect: MagicMock,
         mock_health: MagicMock,
@@ -250,12 +252,16 @@ class TestMonitorPositionsJob:
         mock_finish: MagicMock,
         mock_spike: MagicMock,
     ) -> None:
-        """Writer failure must NOT clobber row_count with 0.
+        """Writer failure must propagate out of _tracked_job and record a
+        FAILURE row in job_runs.
 
-        Contract (spec §persist_position_alerts integration): when
-        check_position_health succeeds but persist_position_alerts raises,
-        the tracked row_count must still equal result.positions_checked —
-        the check side-effect DID happen, so the tracker reflects it.
+        Contract (Codex pre-push review, P1): silently swallowing a persist
+        exception and returning `success` hides broken alert ingestion from
+        ops health surfaces. `persist_position_alerts` is called AFTER
+        ``tracker.row_count`` is set, so the pre-raise row_count is still
+        observable via the tracker (not through ``record_job_finish(status=
+        "success")``); `_tracked_job`'s exception handler records a failure
+        row with the exception message and error category.
         """
         from app.services.position_monitor import MonitorResult
 
@@ -268,20 +274,29 @@ class TestMonitorPositionsJob:
         conn_ctx.__exit__ = MagicMock(return_value=False)
         mock_connect.return_value = conn_ctx
 
-        captured_row_count: list[Any] = []
+        captured_calls: list[dict[str, Any]] = []
 
         def capture_finish(conn: Any, run_id: Any, **kwargs: Any) -> None:
-            captured_row_count.append(kwargs.get("row_count"))
+            captured_calls.append(kwargs)
 
         with patch(_RECORD_FINISH_PATCH, side_effect=capture_finish):
-            monitor_positions_job()
+            # _tracked_job re-raises the exception after recording the
+            # failure row (app/workers/scheduler.py:_tracked_job line ~588:
+            # `raise`). The scheduler call site (APScheduler or manual
+            # trigger) handles that raise at the edge; the contract this
+            # test pins is that record_job_finish receives status="failure"
+            # and the exception is NOT swallowed.
+            with pytest.raises(RuntimeError, match="simulated persist failure"):
+                monitor_positions_job()
 
-        # Writer raised, but the check succeeded with 7 positions — the
-        # inner except swallows the writer exception and falls through to
-        # the unconditional tracker.row_count = result.positions_checked
-        # assignment after the outer try/except.
-        assert captured_row_count and captured_row_count[0] == 7
         mock_persist.assert_called_once()
+        # _tracked_job calls record_job_finish(status="failure", ...) on
+        # exception — NOT status="success" with row_count. The health check
+        # did run (mock_health called once), so ops can still correlate the
+        # failure with the hourly tick via run_id.
+        assert mock_health.call_count == 1
+        assert captured_calls, "record_job_finish must be called on failure"
+        assert captured_calls[0].get("status") == "failure"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Persist SL/TP/thesis breaches from hourly `position_monitor.check_position_health` to a new `position_alerts` episode table. Expose via `GET /alerts/position-alerts`, `POST /alerts/position-alerts/seen`, `POST /alerts/position-alerts/dismiss-all` — mirrors #394's guard-rejection shape so #399 can union all three feeds into the dashboard strip.

## Why
Closes #396. Today `monitor_positions_job` logs breaches to stderr only; no DB rows, no strip, no "since last visit" semantics. Episode model (one row per breach onset, `resolved_at` on clearance) matches eBull's append-with-intent convention for recommendations — no spam on still-breaching evaluations.

## Test plan
- [x] Unit (11): `persist_position_alerts` diff logic against `ebull_test` — empty/empty, new-breach, still-breaching, clearance, re-break, mixed types, mixed instruments, partial-unique-index blocks duplicate open pair, partial-unique-index allows reopen after resolve, all-three-types, NULL current_bid
- [x] Scheduler (3): calls check_position_health, row_count == positions_checked, persist failure marks job failure (pre-raise row_count set, exception propagates to _tracked_job)
- [x] API (25): GET empty/window/cap/cursor/resolved-in-window/out-of-window/ordering (7); /seen monotonic/first-time/missing-field-422/non-integer-422/non-positive-422/clamp/empty-window-noop/race (8); /dismiss-all advance/monotonic/empty-window-null/empty-window-existing/race (5); cross-cutting cursor-isolation-both-directions/503/501/alert_type-round-trip (5)
- [x] Smoke (`tests/smoke/test_app_boots.py`) green
- [x] Codex pre-spec + pre-plan + pre-push reviews addressed (5 spec findings + 6 plan findings + 2 pre-push findings all resolved)
- [x] All gates green: `ruff check`, `ruff format --check`, `pyright`, `pytest` (2293 passed, 1 skipped)

Spec: `docs/superpowers/specs/2026-04-21-position-alert-persistence.md`
Plan: `docs/superpowers/plans/2026-04-22-position-alert-persistence.md`

Migrations: `sql/045_position_alerts.sql` (table + partial unique index + alert_id index + operator cursor column), `sql/046_position_alerts_opened_at_index.sql` (opened_at index for 7-day window scans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
