### PR TITLE
feat(#399): unified AlertsStrip — guard + position + coverage

### DIFF
--- a/docs/superpowers/plans/2026-04-22-alerts-strip-unified.md
+++ b/docs/superpowers/plans/2026-04-22-alerts-strip-unified.md
@@ -1,0 +1,1133 @@
+# AlertsStrip Unified Feed Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `AlertsStrip` from guard-rejections-only to a unified feed that also renders position alerts (#401) and coverage-status drops (#402), with per-feed overflow math, per-kind cursor semantics, and fan-out POSTs for mark-all-read / dismiss-all.
+
+**Architecture:** Frontend-only. Three parallel GETs via existing `/alerts/*` endpoints, client-side merge into a timestamp-sorted discriminated-union list, per-feed `FeedState<T>` for explicit partial-failure handling, `Promise.allSettled` fan-out POSTs skipping errored feeds.
+
+**Tech Stack:** React + TypeScript + Vite, vitest + @testing-library/react, Tailwind CSS.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-alerts-strip-unified.md`
+
+**Ticket:** #399. Branch `feature/399-alerts-strip-unified` created; spec committed on it.
+
+---
+
+## File Structure
+
+| Path | Responsibility | Action |
+| --- | --- | --- |
+| `frontend/src/api/types.ts` | Backend-payload type definitions | Modify (add 4 interfaces + 1 union) |
+| `frontend/src/api/alerts.ts` | Alert endpoint fetcher/mutation wrappers | Modify (add 6 functions) |
+| `frontend/src/components/dashboard/AlertsStrip.tsx` | Dashboard unified-alerts component | Rewrite (preserves public export; internal refactor) |
+| `frontend/src/components/dashboard/AlertsStrip.test.tsx` | Component tests | Extend (update existing + add new test groups) |
+
+No backend code. No migrations.
+
+---
+
+## Task 1: API types
+
+**Files:**
+
+- Modify: `frontend/src/api/types.ts` — append 5 new type declarations below existing `GuardRejection*` block.
+
+- [ ] **Step 1: Read existing GuardRejection block to confirm style**
+
+Run: `grep -n "GuardRejection" frontend/src/api/types.ts`
+
+Confirm `GuardRejection`, `GuardRejectionAction`, `GuardRejectionsResponse` all exist.
+
+- [ ] **Step 2: Append new types**
+
+Add to end of `frontend/src/api/types.ts`:
+
+```ts
+// --- #396/#401 position alerts ----------------------------------------------
+
+export type PositionAlertType = "sl_breach" | "tp_breach" | "thesis_break";
+
+export interface PositionAlert {
+  alert_id: number;
+  alert_type: PositionAlertType;
+  instrument_id: number;
+  symbol: string;
+  opened_at: string;
+  resolved_at: string | null;
+  detail: string;
+  current_bid: string | null; // Decimal serialized as string by pydantic
+}
+
+export interface PositionAlertsResponse {
+  alerts_last_seen_position_alert_id: number | null;
+  unseen_count: number;
+  alerts: PositionAlert[];
+}
+
+// --- #397/#402 coverage status drops ----------------------------------------
+
+export interface CoverageStatusDrop {
+  event_id: number;
+  instrument_id: number;
+  symbol: string;
+  changed_at: string;
+  old_status: string;
+  new_status: string | null;
+}
+
+export interface CoverageStatusDropsResponse {
+  alerts_last_seen_coverage_event_id: number | null;
+  unseen_count: number;
+  drops: CoverageStatusDrop[];
+}
+```
+
+- [ ] **Step 3: Typecheck — expect pass**
+
+Run: `pnpm --dir frontend typecheck`
+Expected: PASS (types are standalone, no usage sites yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/types.ts
+git commit -m "feat(#399): types — position alerts + coverage status drops"
+```
+
+---
+
+## Task 2: API client functions
+
+**Files:**
+
+- Modify: `frontend/src/api/alerts.ts` — append 6 new functions after existing `dismissAllAlerts`.
+
+- [ ] **Step 1: Read existing structure**
+
+Run: `cat frontend/src/api/alerts.ts`
+
+Confirm existing fns: `fetchGuardRejections`, `markAlertsSeen`, `dismissAllAlerts`. Note imports (`apiFetch`, type imports).
+
+- [ ] **Step 2: Update imports at top of file**
+
+Change the existing `import type` line to:
+
+```ts
+import type {
+  CoverageStatusDropsResponse,
+  GuardRejectionsResponse,
+  PositionAlertsResponse,
+} from "@/api/types";
+```
+
+- [ ] **Step 3: Append fetchers below `dismissAllAlerts`**
+
+```ts
+// --- #396/#401 position-alert endpoints -------------------------------------
+
+export function fetchPositionAlerts(): Promise<PositionAlertsResponse> {
+  return apiFetch<PositionAlertsResponse>("/alerts/position-alerts");
+}
+
+export function markPositionAlertsSeen(
+  seenThroughPositionAlertId: number,
+): Promise<void> {
+  return apiFetch<void>("/alerts/position-alerts/seen", {
+    method: "POST",
+    body: JSON.stringify({
+      seen_through_position_alert_id: seenThroughPositionAlertId,
+    }),
+  });
+}
+
+export function dismissAllPositionAlerts(): Promise<void> {
+  return apiFetch<void>("/alerts/position-alerts/dismiss-all", {
+    method: "POST",
+  });
+}
+
+// --- #397/#402 coverage-status-drops endpoints ------------------------------
+
+export function fetchCoverageStatusDrops(): Promise<CoverageStatusDropsResponse> {
+  return apiFetch<CoverageStatusDropsResponse>("/alerts/coverage-status-drops");
+}
+
+export function markCoverageStatusDropsSeen(
+  seenThroughEventId: number,
+): Promise<void> {
+  return apiFetch<void>("/alerts/coverage-status-drops/seen", {
+    method: "POST",
+    body: JSON.stringify({ seen_through_event_id: seenThroughEventId }),
+  });
+}
+
+export function dismissAllCoverageStatusDrops(): Promise<void> {
+  return apiFetch<void>("/alerts/coverage-status-drops/dismiss-all", {
+    method: "POST",
+  });
+}
+```
+
+- [ ] **Step 4: Typecheck — expect pass**
+
+Run: `pnpm --dir frontend typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/alerts.ts
+git commit -m "feat(#399): API client fns — position alerts + coverage status drops"
+```
+
+---
+
+## Task 3: AlertsStrip refactor — test suite (red)
+
+**Files:**
+
+- Modify: `frontend/src/components/dashboard/AlertsStrip.test.tsx` — rewrite top-level setup + adapt existing tests + add new test groups.
+
+The test rewrite comes first (red). Next task implements the component to pass.
+
+- [ ] **Step 1: Rewrite mock block**
+
+Replace the existing `vi.mock("@/api/alerts", ...)` call at the top with:
+
+```ts
+vi.mock("@/api/alerts", () => ({
+  fetchGuardRejections: vi.fn(),
+  markAlertsSeen: vi.fn(),
+  dismissAllAlerts: vi.fn(),
+  fetchPositionAlerts: vi.fn(),
+  markPositionAlertsSeen: vi.fn(),
+  dismissAllPositionAlerts: vi.fn(),
+  fetchCoverageStatusDrops: vi.fn(),
+  markCoverageStatusDropsSeen: vi.fn(),
+  dismissAllCoverageStatusDrops: vi.fn(),
+}));
+```
+
+- [ ] **Step 2: Replace stub helpers with three-feed stubs**
+
+Remove the existing `mockedFetch` / `stubFetch` / `stubFetchError` helpers and replace with:
+
+```ts
+import type {
+  CoverageStatusDrop,
+  CoverageStatusDropsResponse,
+  GuardRejection,
+  GuardRejectionsResponse,
+  PositionAlert,
+  PositionAlertsResponse,
+} from "@/api/types";
+
+const mockedGuardFetch = vi.mocked(alertsApi.fetchGuardRejections);
+const mockedPositionFetch = vi.mocked(alertsApi.fetchPositionAlerts);
+const mockedCoverageFetch = vi.mocked(alertsApi.fetchCoverageStatusDrops);
+
+const mockedMarkGuard = vi.mocked(alertsApi.markAlertsSeen);
+const mockedMarkPosition = vi.mocked(alertsApi.markPositionAlertsSeen);
+const mockedMarkCoverage = vi.mocked(alertsApi.markCoverageStatusDropsSeen);
+
+const mockedDismissGuard = vi.mocked(alertsApi.dismissAllAlerts);
+const mockedDismissPosition = vi.mocked(alertsApi.dismissAllPositionAlerts);
+const mockedDismissCoverage = vi.mocked(alertsApi.dismissAllCoverageStatusDrops);
+
+const EMPTY_GUARD: GuardRejectionsResponse = {
+  alerts_last_seen_decision_id: null,
+  unseen_count: 0,
+  rejections: [],
+};
+const EMPTY_POSITION: PositionAlertsResponse = {
+  alerts_last_seen_position_alert_id: null,
+  unseen_count: 0,
+  alerts: [],
+};
+const EMPTY_COVERAGE: CoverageStatusDropsResponse = {
+  alerts_last_seen_coverage_event_id: null,
+  unseen_count: 0,
+  drops: [],
+};
+
+function stubAll(
+  overrides: {
+    guard?: Partial<GuardRejectionsResponse> | Error;
+    position?: Partial<PositionAlertsResponse> | Error;
+    coverage?: Partial<CoverageStatusDropsResponse> | Error;
+  } = {},
+) {
+  if (overrides.guard instanceof Error) {
+    mockedGuardFetch.mockRejectedValue(overrides.guard);
+  } else {
+    mockedGuardFetch.mockResolvedValue({ ...EMPTY_GUARD, ...overrides.guard });
+  }
+  if (overrides.position instanceof Error) {
+    mockedPositionFetch.mockRejectedValue(overrides.position);
+  } else {
+    mockedPositionFetch.mockResolvedValue({ ...EMPTY_POSITION, ...overrides.position });
+  }
+  if (overrides.coverage instanceof Error) {
+    mockedCoverageFetch.mockRejectedValue(overrides.coverage);
+  } else {
+    mockedCoverageFetch.mockResolvedValue({ ...EMPTY_COVERAGE, ...overrides.coverage });
+  }
+}
+
+function makeGuard(overrides: Partial<GuardRejection> = {}): GuardRejection {
+  return {
+    decision_id: 501,
+    decision_time: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    instrument_id: 42,
+    symbol: "AAPL",
+    action: "BUY",
+    explanation: "FAIL — cash_available",
+    ...overrides,
+  };
+}
+
+function makePosition(overrides: Partial<PositionAlert> = {}): PositionAlert {
+  return {
+    alert_id: 701,
+    alert_type: "sl_breach",
+    instrument_id: 43,
+    symbol: "MSFT",
+    opened_at: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    resolved_at: null,
+    detail: "bid=320 < sl=330",
+    current_bid: "320",
+    ...overrides,
+  };
+}
+
+function makeCoverage(overrides: Partial<CoverageStatusDrop> = {}): CoverageStatusDrop {
+  return {
+    event_id: 301,
+    instrument_id: 44,
+    symbol: "TSLA",
+    changed_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+    old_status: "analysable",
+    new_status: "insufficient",
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 3: Update the existing `renders nothing when rejections list is empty` and `renders nothing on fetch error` tests to use `stubAll`**
+
+Replace:
+
+```ts
+it("renders nothing when all feeds are empty", async () => {
+  stubAll();
+  const { container } = renderStrip();
+  await vi.waitFor(() => {
+    expect(alertsApi.fetchGuardRejections).toHaveBeenCalled();
+    expect(alertsApi.fetchPositionAlerts).toHaveBeenCalled();
+    expect(alertsApi.fetchCoverageStatusDrops).toHaveBeenCalled();
+  });
+  expect(container).toBeEmptyDOMElement();
+});
+
+it("renders nothing when all feeds error (silent-on-error)", async () => {
+  stubAll({
+    guard: new Error("boom"),
+    position: new Error("boom"),
+    coverage: new Error("boom"),
+  });
+  const { container } = renderStrip();
+  await vi.waitFor(() => {
+    expect(alertsApi.fetchGuardRejections).toHaveBeenCalled();
+  });
+  expect(container).toBeEmptyDOMElement();
+});
+```
+
+- [ ] **Step 4: Adapt remaining existing guard-only tests**
+
+For each existing `it("renders row symbol / action / explanation", ...)` etc., wrap the stub in `stubAll({ guard: { rejections: [baseRow], unseen_count: 1 } })`. Keep the same assertions — behaviour for a guard-only feed must not change.
+
+- [ ] **Step 5: Add new test — merge across three kinds, DESC by ts**
+
+```ts
+it("merges three feeds into a single list DESC by timestamp", async () => {
+  const coverage = makeCoverage({
+    changed_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+  });
+  const guard = makeGuard({
+    decision_time: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+  });
+  const position = makePosition({
+    opened_at: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
+  });
+  stubAll({
+    guard: { rejections: [guard], unseen_count: 1 },
+    position: { alerts: [position], unseen_count: 1 },
+    coverage: { drops: [coverage], unseen_count: 1 },
+  });
+  renderStrip();
+  const rows = await screen.findAllByTestId("alerts-row");
+  expect(rows).toHaveLength(3);
+  // DESC by timestamp: guard (5m) → position (15m) → coverage (30m)
+  expect(rows[0]!.textContent).toContain(guard.symbol);
+  expect(rows[1]!.textContent).toContain(position.symbol);
+  expect(rows[2]!.textContent).toContain(coverage.symbol);
+});
+```
+
+- [ ] **Step 6: Add test — per-kind pill badges rendered**
+
+```ts
+it("renders kind pill badge for each row type", async () => {
+  stubAll({
+    guard: { rejections: [makeGuard()], unseen_count: 1 },
+    position: { alerts: [makePosition()], unseen_count: 1 },
+    coverage: { drops: [makeCoverage()], unseen_count: 1 },
+  });
+  renderStrip();
+  expect(await screen.findByText("GUARD")).toBeInTheDocument();
+  expect(screen.getByText("POSITION")).toBeInTheDocument();
+  expect(screen.getByText("COVERAGE")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 7: Add test — click-through routes by instrument_id**
+
+```ts
+it("links rows with non-null instrument_id to /instruments/<id>", async () => {
+  stubAll({
+    guard: { rejections: [makeGuard({ instrument_id: 42 })], unseen_count: 1 },
+    position: { alerts: [makePosition({ instrument_id: 43 })], unseen_count: 1 },
+    coverage: { drops: [makeCoverage({ instrument_id: 44 })], unseen_count: 1 },
+  });
+  renderStrip();
+  await screen.findAllByTestId("alerts-row");
+  const links = screen
+    .getAllByRole("link")
+    .map((l) => l.getAttribute("href"));
+  expect(links).toEqual(
+    expect.arrayContaining(["/instruments/42", "/instruments/43", "/instruments/44"]),
+  );
+});
+
+it("renders guard row with null instrument_id inline (no link)", async () => {
+  stubAll({
+    guard: {
+      rejections: [makeGuard({ instrument_id: null, symbol: null })],
+      unseen_count: 1,
+    },
+  });
+  renderStrip();
+  const row = await screen.findByTestId("alerts-row");
+  expect(row.closest("a")).toBeNull();
+});
+```
+
+- [ ] **Step 8: Add test — hide when any feed still loading**
+
+```ts
+it("renders null while any feed is still loading (no flash)", () => {
+  mockedGuardFetch.mockResolvedValue(EMPTY_GUARD);
+  mockedPositionFetch.mockImplementation(() => new Promise(() => {})); // never resolves
+  mockedCoverageFetch.mockResolvedValue(EMPTY_COVERAGE);
+  const { container } = renderStrip();
+  // No await — strip must render nothing at first paint.
+  expect(container).toBeEmptyDOMElement();
+});
+```
+
+- [ ] **Step 9: Add test — partial error renders the ok feeds**
+
+```ts
+it("renders ok feeds when one feed errored", async () => {
+  stubAll({
+    guard: new Error("boom"),
+    position: { alerts: [makePosition({ symbol: "MSFT" })], unseen_count: 1 },
+    coverage: { drops: [makeCoverage({ symbol: "TSLA" })], unseen_count: 1 },
+  });
+  renderStrip();
+  expect(await screen.findByText("MSFT")).toBeInTheDocument();
+  expect(screen.getByText("TSLA")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 10: Add test — unseen badge sums across feeds**
+
+```ts
+it("header badge is sum of per-feed unseen_count", async () => {
+  stubAll({
+    guard: { rejections: [makeGuard()], unseen_count: 3 },
+    position: { alerts: [makePosition()], unseen_count: 2 },
+    coverage: { drops: [makeCoverage()], unseen_count: 1 },
+  });
+  renderStrip();
+  expect(await screen.findByText("6 new")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 11: Add test — per-feed overflow surfaces Dismiss-all**
+
+```ts
+it("shows Dismiss-all when any feed has unseen > rendered (per-feed overflow)", async () => {
+  // guard renders 1 row, unseen_count=2 → per-feed overflow.
+  stubAll({
+    guard: { rejections: [makeGuard()], unseen_count: 2 },
+  });
+  renderStrip();
+  expect(await screen.findByRole("button", { name: /Dismiss all/i })).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /Mark all read/i })).toBeNull();
+});
+
+it("shows Mark-all-read when all feeds have unseen == rendered (no overflow)", async () => {
+  stubAll({
+    guard: { rejections: [makeGuard()], unseen_count: 1 },
+    position: { alerts: [makePosition()], unseen_count: 1 },
+  });
+  renderStrip();
+  expect(await screen.findByRole("button", { name: /Mark all read/i })).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /Dismiss all/i })).toBeNull();
+});
+```
+
+- [ ] **Step 12: Add test — mark-all-read fan-out with per-kind MAX ids**
+
+```ts
+it("Mark-all-read fans out to each non-empty feed with its MAX id", async () => {
+  const g = makeGuard({ decision_id: 510 });
+  const p = makePosition({ alert_id: 710 });
+  // coverage empty → no POST expected
+  stubAll({
+    guard: { rejections: [g], unseen_count: 1 },
+    position: { alerts: [p], unseen_count: 1 },
+  });
+  mockedMarkGuard.mockResolvedValue(undefined);
+  mockedMarkPosition.mockResolvedValue(undefined);
+  renderStrip();
+  const btn = await screen.findByRole("button", { name: /Mark all read/i });
+  await userEvent.click(btn);
+  await vi.waitFor(() => {
+    expect(mockedMarkGuard).toHaveBeenCalledWith(510);
+    expect(mockedMarkPosition).toHaveBeenCalledWith(710);
+    expect(mockedMarkCoverage).not.toHaveBeenCalled();
+  });
+});
+
+it("Mark-all-read tolerates a single POST failure and still calls others", async () => {
+  stubAll({
+    guard: { rejections: [makeGuard({ decision_id: 510 })], unseen_count: 1 },
+    position: { alerts: [makePosition({ alert_id: 710 })], unseen_count: 1 },
+  });
+  mockedMarkGuard.mockRejectedValue(new Error("guard seen boom"));
+  mockedMarkPosition.mockResolvedValue(undefined);
+  const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  renderStrip();
+  await userEvent.click(await screen.findByRole("button", { name: /Mark all read/i }));
+  await vi.waitFor(() => {
+    expect(mockedMarkGuard).toHaveBeenCalled();
+    expect(mockedMarkPosition).toHaveBeenCalled();
+  });
+  expect(consoleSpy).toHaveBeenCalled();
+  consoleSpy.mockRestore();
+});
+```
+
+- [ ] **Step 13: Add test — dismiss-all skips errored feeds**
+
+```ts
+it("Dismiss-all skips POST for any errored feed", async () => {
+  // guard errored, position has overflow.
+  stubAll({
+    guard: new Error("boom"),
+    position: { alerts: [makePosition()], unseen_count: 5 }, // overflow 5 > 1
+  });
+  mockedDismissPosition.mockResolvedValue(undefined);
+  // Simulate operator confirming the dialog.
+  const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+  renderStrip();
+  const btn = await screen.findByRole("button", { name: /Dismiss all/i });
+  await userEvent.click(btn);
+  await vi.waitFor(() => {
+    expect(mockedDismissPosition).toHaveBeenCalled();
+  });
+  expect(mockedDismissGuard).not.toHaveBeenCalled();
+  expect(mockedDismissCoverage).toHaveBeenCalled(); // coverage was ok + empty, but still ok → called
+  confirmSpy.mockRestore();
+});
+
+it("Dismiss-all no-op when operator cancels confirm", async () => {
+  stubAll({
+    guard: { rejections: [makeGuard()], unseen_count: 5 },
+  });
+  const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+  renderStrip();
+  await userEvent.click(await screen.findByRole("button", { name: /Dismiss all/i }));
+  expect(mockedDismissGuard).not.toHaveBeenCalled();
+  confirmSpy.mockRestore();
+});
+```
+
+- [ ] **Step 14: Run test file — expect all new tests to FAIL**
+
+Run: `pnpm --dir frontend test -- AlertsStrip`
+
+Expected: every new test fails (component still only knows about guard). Some existing tests may still pass if they happen to not break on the new mocks.
+
+- [ ] **Step 15: Commit the red test suite**
+
+```bash
+git add frontend/src/components/dashboard/AlertsStrip.test.tsx
+git commit -m "test(#399): red suite for unified AlertsStrip"
+```
+
+---
+
+## Task 4: AlertsStrip refactor — implementation (green)
+
+**Files:**
+
+- Modify: `frontend/src/components/dashboard/AlertsStrip.tsx` — full rewrite of internals. Public export `AlertsStrip` preserved.
+
+- [ ] **Step 1: Replace the entire file contents with the refactored implementation**
+
+```tsx
+/**
+ * AlertsStrip — unified dashboard alert feed (#399).
+ *
+ * Renders three independent alert streams in a single timestamp-sorted list:
+ *
+ *   1. Guard rejections (#394)
+ *   2. Position alerts — SL/TP/thesis breach episodes (#401)
+ *   3. Coverage status drops from 'analysable' (#402)
+ *
+ * Each feed keeps its own BIGSERIAL cursor column on `operators`. Partial
+ * failure is tolerated: one feed GET erroring does not hide the others; one
+ * POST failing does not block the siblings (Promise.allSettled).
+ *
+ * Overflow math is per-feed — each backend query caps at LIMIT 500 so
+ * global `totalUnseen > merged.length` would conflate feed-A hidden rows
+ * with feed-B seen padding. See spec
+ * docs/superpowers/specs/2026-04-22-alerts-strip-unified.md for rationale.
+ */
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import {
+  dismissAllAlerts,
+  dismissAllCoverageStatusDrops,
+  dismissAllPositionAlerts,
+  fetchCoverageStatusDrops,
+  fetchGuardRejections,
+  fetchPositionAlerts,
+  markAlertsSeen,
+  markCoverageStatusDropsSeen,
+  markPositionAlertsSeen,
+} from "@/api/alerts";
+import type {
+  CoverageStatusDrop,
+  CoverageStatusDropsResponse,
+  GuardRejection,
+  GuardRejectionsResponse,
+  PositionAlert,
+  PositionAlertsResponse,
+} from "@/api/types";
+import { formatRelativeTime } from "@/lib/format";
+
+type FeedState<T> =
+  | { status: "loading" }
+  | { status: "ok"; data: T }
+  | { status: "err" };
+
+type AlertRow =
+  | { kind: "guard";    ts: string; sortKey: number; row: GuardRejection }
+  | { kind: "position"; ts: string; sortKey: number; row: PositionAlert }
+  | { kind: "coverage"; ts: string; sortKey: number; row: CoverageStatusDrop };
+
+type Cursors = {
+  guard: number | null;
+  position: number | null;
+  coverage: number | null;
+};
+
+function buildRows(
+  guard: FeedState<GuardRejectionsResponse>,
+  position: FeedState<PositionAlertsResponse>,
+  coverage: FeedState<CoverageStatusDropsResponse>,
+): AlertRow[] {
+  const rows: AlertRow[] = [];
+  if (guard.status === "ok") {
+    for (const r of guard.data.rejections) {
+      rows.push({ kind: "guard", ts: r.decision_time, sortKey: Date.parse(r.decision_time), row: r });
+    }
+  }
+  if (position.status === "ok") {
+    for (const r of position.data.alerts) {
+      rows.push({ kind: "position", ts: r.opened_at, sortKey: Date.parse(r.opened_at), row: r });
+    }
+  }
+  if (coverage.status === "ok") {
+    for (const r of coverage.data.drops) {
+      rows.push({ kind: "coverage", ts: r.changed_at, sortKey: Date.parse(r.changed_at), row: r });
+    }
+  }
+  rows.sort((a, b) => b.sortKey - a.sortKey);
+  return rows;
+}
+
+function isUnseen(r: AlertRow, c: Cursors): boolean {
+  switch (r.kind) {
+    case "guard":    return c.guard    === null || r.row.decision_id > c.guard;
+    case "position": return c.position === null || r.row.alert_id    > c.position;
+    case "coverage": return c.coverage === null || r.row.event_id    > c.coverage;
+  }
+}
+
+function renderedCount(
+  guard: FeedState<GuardRejectionsResponse>,
+  position: FeedState<PositionAlertsResponse>,
+  coverage: FeedState<CoverageStatusDropsResponse>,
+): { guard: number; position: number; coverage: number } {
+  return {
+    guard: guard.status === "ok" ? guard.data.rejections.length : 0,
+    position: position.status === "ok" ? position.data.alerts.length : 0,
+    coverage: coverage.status === "ok" ? coverage.data.drops.length : 0,
+  };
+}
+
+function unseenCount(
+  guard: FeedState<GuardRejectionsResponse>,
+  position: FeedState<PositionAlertsResponse>,
+  coverage: FeedState<CoverageStatusDropsResponse>,
+): { guard: number; position: number; coverage: number } {
+  return {
+    guard: guard.status === "ok" ? guard.data.unseen_count : 0,
+    position: position.status === "ok" ? position.data.unseen_count : 0,
+    coverage: coverage.status === "ok" ? coverage.data.unseen_count : 0,
+  };
+}
+
+function KindPill({ kind }: { kind: AlertRow["kind"] }) {
+  const style = {
+    guard:    "bg-amber-100 text-amber-800",
+    position: "bg-red-100 text-red-800",
+    coverage: "bg-slate-100 text-slate-700",
+  }[kind];
+  const label = { guard: "GUARD", position: "POSITION", coverage: "COVERAGE" }[kind];
+  return (
+    <span className={`w-16 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold uppercase ${style}`}>
+      {label}
+    </span>
+  );
+}
+
+function RowShell({
+  kind,
+  unseen,
+  instrumentId,
+  children,
+}: {
+  kind: AlertRow["kind"];
+  unseen: boolean;
+  instrumentId: number | null;
+  children: React.ReactNode;
+}) {
+  const border = unseen ? "border-l-4 border-amber-400" : "border-l-4 border-slate-200";
+  const content = (
+    <div
+      data-testid="alerts-row"
+      role="listitem"
+      className={`flex items-center gap-3 px-3 py-2 text-sm ${border} bg-white`}
+    >
+      <KindPill kind={kind} />
+      {children}
+    </div>
+  );
+  if (instrumentId !== null) {
+    return (
+      <Link to={`/instruments/${instrumentId}`} className="block hover:bg-slate-50">
+        {content}
+      </Link>
+    );
+  }
+  return content;
+}
+
+function GuardRow({ row, unseen }: { row: GuardRejection; unseen: boolean }) {
+  return (
+    <RowShell kind="guard" unseen={unseen} instrumentId={row.instrument_id}>
+      <span className="w-16 font-semibold tabular-nums">{row.symbol ?? "—"}</span>
+      <span className="w-16 text-xs uppercase text-slate-500">{row.action ?? "—"}</span>
+      <span className="flex-1 truncate text-slate-700" title={row.explanation}>
+        {row.explanation}
+      </span>
+      <span className="w-20 text-right text-xs text-slate-400">
+        {formatRelativeTime(row.decision_time)}
+      </span>
+    </RowShell>
+  );
+}
+
+function PositionRow({ row, unseen }: { row: PositionAlert; unseen: boolean }) {
+  const alertLabel = {
+    sl_breach:    "SL",
+    tp_breach:    "TP",
+    thesis_break: "THESIS",
+  }[row.alert_type];
+  return (
+    <RowShell kind="position" unseen={unseen} instrumentId={row.instrument_id}>
+      <span className="w-16 font-semibold tabular-nums">{row.symbol}</span>
+      <span className="w-16 text-xs uppercase text-slate-500">{alertLabel}</span>
+      <span className="flex-1 truncate text-slate-700" title={row.detail}>
+        {row.detail}
+      </span>
+      <span className="w-20 text-right text-xs text-slate-400">
+        {formatRelativeTime(row.opened_at)}
+      </span>
+    </RowShell>
+  );
+}
+
+function CoverageRow({ row, unseen }: { row: CoverageStatusDrop; unseen: boolean }) {
+  const transition = `${row.old_status} → ${row.new_status ?? "—"}`;
+  return (
+    <RowShell kind="coverage" unseen={unseen} instrumentId={row.instrument_id}>
+      <span className="w-16 font-semibold tabular-nums">{row.symbol}</span>
+      <span
+        className="flex-1 truncate text-slate-700"
+        title={transition}
+      >
+        {transition}
+      </span>
+      <span className="w-20 text-right text-xs text-slate-400">
+        {formatRelativeTime(row.changed_at)}
+      </span>
+    </RowShell>
+  );
+}
+
+function RowView({ row, cursors }: { row: AlertRow; cursors: Cursors }) {
+  const unseen = isUnseen(row, cursors);
+  switch (row.kind) {
+    case "guard":    return <GuardRow    row={row.row} unseen={unseen} />;
+    case "position": return <PositionRow row={row.row} unseen={unseen} />;
+    case "coverage": return <CoverageRow row={row.row} unseen={unseen} />;
+  }
+}
+
+export function AlertsStrip(): JSX.Element | null {
+  const [guard, setGuard] = useState<FeedState<GuardRejectionsResponse>>({ status: "loading" });
+  const [position, setPosition] = useState<FeedState<PositionAlertsResponse>>({ status: "loading" });
+  const [coverage, setCoverage] = useState<FeedState<CoverageStatusDropsResponse>>({ status: "loading" });
+  const [refetchKey, setRefetchKey] = useState(0);
+
+  useEffect(() => {
+    setGuard({ status: "loading" });
+    setPosition({ status: "loading" });
+    setCoverage({ status: "loading" });
+    fetchGuardRejections()
+      .then((d) => setGuard({ status: "ok", data: d }))
+      .catch((err) => {
+        console.error("[AlertsStrip] fetchGuardRejections failed", err);
+        setGuard({ status: "err" });
+      });
+    fetchPositionAlerts()
+      .then((d) => setPosition({ status: "ok", data: d }))
+      .catch((err) => {
+        console.error("[AlertsStrip] fetchPositionAlerts failed", err);
+        setPosition({ status: "err" });
+      });
+    fetchCoverageStatusDrops()
+      .then((d) => setCoverage({ status: "ok", data: d }))
+      .catch((err) => {
+        console.error("[AlertsStrip] fetchCoverageStatusDrops failed", err);
+        setCoverage({ status: "err" });
+      });
+  }, [refetchKey]);
+
+  const refetch = () => setRefetchKey((k) => k + 1);
+
+  // Hide while any feed still loading — no flash of empty strip.
+  if (guard.status === "loading" || position.status === "loading" || coverage.status === "loading") {
+    return null;
+  }
+  // Hide when all three errored.
+  if (guard.status === "err" && position.status === "err" && coverage.status === "err") {
+    return null;
+  }
+
+  const merged = buildRows(guard, position, coverage);
+
+  // Hide when all ok-feeds are empty.
+  if (merged.length === 0) {
+    return null;
+  }
+
+  const unseen = unseenCount(guard, position, coverage);
+  const rendered = renderedCount(guard, position, coverage);
+  const totalUnseen = unseen.guard + unseen.position + unseen.coverage;
+
+  const guardOverflow    = unseen.guard    > rendered.guard;
+  const positionOverflow = unseen.position > rendered.position;
+  const coverageOverflow = unseen.coverage > rendered.coverage;
+  const anyOverflow = guardOverflow || positionOverflow || coverageOverflow;
+
+  const overflowAck = anyOverflow;
+  const normalAck = totalUnseen > 0 && !anyOverflow;
+
+  const cursors: Cursors = {
+    guard: guard.status === "ok" ? guard.data.alerts_last_seen_decision_id : null,
+    position: position.status === "ok" ? position.data.alerts_last_seen_position_alert_id : null,
+    coverage: coverage.status === "ok" ? coverage.data.alerts_last_seen_coverage_event_id : null,
+  };
+
+  async function onMarkAllRead() {
+    const guardMax    = Math.max(0, ...merged.filter((r) => r.kind === "guard").map((r) => (r.row as GuardRejection).decision_id));
+    const positionMax = Math.max(0, ...merged.filter((r) => r.kind === "position").map((r) => (r.row as PositionAlert).alert_id));
+    const coverageMax = Math.max(0, ...merged.filter((r) => r.kind === "coverage").map((r) => (r.row as CoverageStatusDrop).event_id));
+
+    const promises: Promise<void>[] = [];
+    if (guardMax > 0)    promises.push(markAlertsSeen(guardMax));
+    if (positionMax > 0) promises.push(markPositionAlertsSeen(positionMax));
+    if (coverageMax > 0) promises.push(markCoverageStatusDropsSeen(coverageMax));
+
+    const results = await Promise.allSettled(promises);
+    for (const r of results) {
+      if (r.status === "rejected") {
+        console.error("[AlertsStrip] mark-all-read partial failure", r.reason);
+      }
+    }
+    refetch();
+  }
+
+  async function onDismissAll() {
+    const hiddenCount =
+      Math.max(0, unseen.guard    - rendered.guard)    +
+      Math.max(0, unseen.position - rendered.position) +
+      Math.max(0, unseen.coverage - rendered.coverage);
+    const msg = `Dismiss all ${totalUnseen} unseen alerts? ${hiddenCount} are not shown above. Review them at /recommendations before dismissing if they might matter.`;
+    if (!window.confirm(msg)) return;
+
+    const promises: Promise<void>[] = [];
+    if (guard.status === "ok")    promises.push(dismissAllAlerts());
+    if (position.status === "ok") promises.push(dismissAllPositionAlerts());
+    if (coverage.status === "ok") promises.push(dismissAllCoverageStatusDrops());
+
+    const results = await Promise.allSettled(promises);
+    for (const r of results) {
+      if (r.status === "rejected") {
+        console.error("[AlertsStrip] dismiss-all partial failure", r.reason);
+      }
+    }
+    refetch();
+  }
+
+  return (
+    <section
+      aria-labelledby="alerts-strip-heading"
+      className="rounded-md border border-slate-200 bg-white shadow-sm"
+    >
+      <header className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <h2 id="alerts-strip-heading" className="text-sm font-semibold text-slate-700">
+            Alerts
+          </h2>
+          {totalUnseen > 0 ? (
+            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+              {totalUnseen} new
+            </span>
+          ) : null}
+        </div>
+        {normalAck ? (
+          <button
+            type="button"
+            onClick={onMarkAllRead}
+            className="rounded border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Mark all read
+          </button>
+        ) : null}
+        {overflowAck ? (
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onDismissAll}
+              className="rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 hover:bg-amber-100"
+            >
+              Dismiss all ({totalUnseen}) as acknowledged
+            </button>
+            <Link
+              to="/recommendations"
+              className="text-xs text-slate-500 underline hover:text-slate-700"
+            >
+              Triage at /recommendations
+            </Link>
+          </div>
+        ) : null}
+      </header>
+      <div
+        tabIndex={0}
+        role="list"
+        aria-labelledby="alerts-strip-heading"
+        className="max-h-96 overflow-y-auto divide-y divide-slate-100"
+      >
+        {merged.map((row) => (
+          <RowView key={`${row.kind}-${rowId(row)}`} row={row} cursors={cursors} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function rowId(row: AlertRow): number {
+  switch (row.kind) {
+    case "guard":    return row.row.decision_id;
+    case "position": return row.row.alert_id;
+    case "coverage": return row.row.event_id;
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck — expect pass**
+
+Run: `pnpm --dir frontend typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Run the AlertsStrip tests — expect all pass**
+
+Run: `pnpm --dir frontend test -- AlertsStrip`
+Expected: all PASS.
+
+- [ ] **Step 4: If any test fails, read the failure, fix the relevant code region, re-run.**
+
+Common pitfalls:
+- Timestamp-sort: if a test fails on ordering, confirm the generated timestamps are actually in the order the test expects. Check that `Date.parse` handles the ISO string from `new Date(...).toISOString()`.
+- Dismiss-all-skips-errored-feeds: confirm the `if (guard.status === "ok")` gate is present. An `err` feed must NOT have its POST issued.
+- Mark-all-read MAX: if a feed's merged slice is empty, `Math.max(0, ...[])` returns 0 and the POST is skipped. Check the `if (guardMax > 0)` gate.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/dashboard/AlertsStrip.tsx
+git commit -m "feat(#399): unified AlertsStrip — guard + position + coverage feeds"
+```
+
+---
+
+## Task 5: Pre-push gates + Codex checkpoint 2 + push + PR
+
+**Files:** (none; gate + review + publish)
+
+- [ ] **Step 1: Run all backend gates**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+All four must pass. If any fail, fix + re-stage + new commit. Do NOT amend.
+
+- [ ] **Step 2: Run frontend gates**
+
+```bash
+pnpm --dir frontend typecheck
+pnpm --dir frontend test
+```
+
+Both must pass.
+
+- [ ] **Step 3: Smoke gate — app still boots**
+
+Run: `uv run pytest tests/smoke/test_app_boots.py -v`
+Expected: PASS. (Frontend-only PR but smoke check costs nothing.)
+
+- [ ] **Step 4: Manual browser check (if dev stack running)**
+
+If the dev stack is running via VS Code tasks (per memory `feedback_keep_stack_running.md`): open `http://localhost:5173/` (or the configured dev port), navigate to dashboard, confirm strip renders three feeds without console errors. Do not start or restart stack automatically.
+
+If stack is not running, skip — document in PR body as "component tests verify behaviour; manual browser check deferred to reviewer".
+
+- [ ] **Step 5: Codex checkpoint 2 — diff review before push**
+
+```bash
+git diff main...HEAD > /tmp/pr399_diff.txt
+codex.cmd exec "Checkpoint 2 diff review for PR #399 (unified AlertsStrip). Diff at /tmp/pr399_diff.txt. Spec at d:/Repos/eBull/docs/superpowers/specs/2026-04-22-alerts-strip-unified.md. Plan at d:/Repos/eBull/docs/superpowers/plans/2026-04-22-alerts-strip-unified.md.
+
+Focus: per-feed overflow math correctness, dismiss-all skipping errored feeds, click-through route matches /instruments/:instrumentId (not symbol), discriminated-union exhaustiveness, Promise.allSettled partial-failure handling, test coverage gaps. Reply terse."
+```
+
+Fix any real findings before pushing.
+
+- [ ] **Step 6: Push + open PR**
+
+```bash
+git push -u origin feature/399-alerts-strip-unified
+gh pr create --title "feat(#399): unified AlertsStrip — guard + position + coverage" --body "$(cat <<'EOF'
+## What
+
+- `AlertsStrip` renders guard rejections + position alerts + coverage status drops in one timestamp-sorted DESC list.
+- Three parallel GETs to existing `/alerts/*` endpoints; client-side merge into discriminated-union rows with per-kind pill badges.
+- Unified header (`Alerts`, total-new badge) with fan-out `Promise.allSettled` POSTs for mark-all-read and dismiss-all.
+- Per-feed overflow math (each backend feed caps at 500 independently).
+- Dismiss-all skips POSTs to errored feeds — never ack invisible alerts.
+- New API client fns + types for position + coverage.
+
+## Why
+
+Closes #399. Backend pieces shipped in #394 (guard), #401 (position), #402 (coverage) — this wires them into the dashboard.
+
+## Test plan
+
+- Vitest suite covers: merge ordering, per-kind rendering, click-through via instrument_id, hide policy (loading / all-err / all-empty / partial-err), unseen totals, per-feed overflow triggering dismiss-all, mark-all-read fan-out with MAX ids + partial-failure, dismiss-all skipping errored feeds + confirm-cancel.
+- Backend gates + smoke gate green.
+
+## Called out
+
+- Partial-failure is silent — matches existing silent-on-error pattern. Cursors are monotonic GREATEST so subsequent action retries are safe.
+- Click-through uses `/instruments/:instrumentId` (existing legacy-id shim route) — same as current guard row pattern.
+- Timestamp sort is presentation only — each feed's 500-row cap is backend-ordered by PK DESC (race-safe). Client merge preserves cursor math per-kind.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Start polling review + CI immediately**
+
+Per memory `feedback_post_push_cycle.md`: the loop is not optional. Start polling without asking:
+
+```bash
+gh pr checks --watch
+gh pr view --comments
+```
+
+Resolve every comment as FIXED / DEFERRED / REBUTTED per the review comment resolution contract. Re-run Task 5 Steps 1–3 before every follow-up push. Merge only after APPROVE on the most recent commit + CI green (or Codex-agreed rebuttal-only round per `feedback_merge_rules`).
+
+---
+
+## Self-review
+
+**1. Spec coverage:**
+
+- Types (PositionAlert, PositionAlertsResponse, CoverageStatusDrop, CoverageStatusDropsResponse) → Task 1.
+- API client fns (6) → Task 2.
+- Component refactor: parallel loader, discriminated union, merge, per-kind pills, per-feed overflow, fan-out actions, dismiss-all skips errored feeds, click-through via instrument_id → Task 4.
+- Test coverage for merge, per-kind, click-through, hide policy, unseen totals, overflow, mark-all-read fan-out, dismiss-all errored-feed skip → Task 3.
+- Pre-push gates + Codex ckpt 2 + PR → Task 5.
+
+All spec sections covered.
+
+**2. Placeholder scan:** no "TBD", "TODO", "implement later". Every code step shows the full diff.
+
+**3. Type consistency:**
+
+- `FeedState<T>` shape stable across Task 3 + Task 4.
+- `AlertRow` discriminator `kind: "guard" | "position" | "coverage"` consistent in loader, renderer, action fan-out.
+- Cursor property names match pydantic backend shape: `alerts_last_seen_decision_id`, `alerts_last_seen_position_alert_id`, `alerts_last_seen_coverage_event_id`.
+- API fn names `markPositionAlertsSeen(seenThroughPositionAlertId)` / `markCoverageStatusDropsSeen(seenThroughEventId)` match the backend request-body field names.
+
+**4. Known risks:**
+
+- Test in Task 3 Step 13 asserts `mockedDismissCoverage` is called for an `ok + empty` coverage feed. This is correct — the dismiss endpoint is safe to POST against an empty window (backend `m.max_id IS NOT NULL` guard no-ops). Clarified in the existing backend specs.
+- `userEvent` v14 handles the async click + state transition — no extra `act()` wrapping needed.

--- a/docs/superpowers/specs/2026-04-22-alerts-strip-unified.md
+++ b/docs/superpowers/specs/2026-04-22-alerts-strip-unified.md
@@ -1,0 +1,405 @@
+# AlertsStrip unified feed — design spec
+
+**Ticket:** #399
+**Depends on:** #394 (merged — guard-rejection strip), #396 / #401 (merged — position-alert event persistence), #397 / #402 (merged — coverage status transition log).
+
+## Problem
+
+`AlertsStrip` today shows only guard rejections. With `/alerts/position-alerts` (#401) and `/alerts/coverage-status-drops` (#402) now live, the dashboard needs to render all three feeds in one unified strip so operator sees everything needing attention in one place.
+
+## Decisions (brainstorm 2026-04-22)
+
+| # | Decision | Reason |
+| --- | --- | --- |
+| 1 | **Three parallel fetches + client-side merge.** No new backend endpoint. | Existing per-type cursor semantics stay untouched. Parallel fetches over HTTP/2 ≈ one RTT. YAGNI on a unified backend endpoint that would duplicate cursor-read logic server-side. |
+| 2 | **Single timestamp-sorted list (DESC).** No grouping or priority tiers. | Matches operator's mental model of "what's new". Type identity preserved via per-kind badge + click-through. Grouping forces a layer to parse every render. Priority is subjective — a guard BUY block can be as urgent as a position SL breach. |
+| 3 | **Unified header + fan-out POSTs with Promise.allSettled.** One badge, one button set; on action issue 3 parallel POSTs to each feed's `/seen` or `/dismiss-all`. | Single-feed UX preserved. Idempotent GREATEST cursors tolerate partial failure — next action round covers any missed one. |
+| 4 | **Hide strip on all-empty or all-error; partial-ok renders what it has.** Loading in any feed → render null (no flash). | Matches today's silent-on-error pattern. Partial degrade beats "hide everything when one feed dies". |
+| 5 | **Per-feed overflow; not global.** Each feed's server query is independently LIMIT 500 — so per-feed `unseen_count > rendered-rows-of-that-kind` is the only correct overflow signal. Global `totalUnseen > merged.length` conflates feed-A hidden rows with feed-B seen padding. | Codex ckpt 1 finding: global math lets seen rows from feed B mask hidden unseen rows from feed A, so `"Mark all read"` could falsely appear and acknowledge invisible rows. |
+| 6 | **`dismiss-all` fan-out skips errored feeds.** If a feed's GET failed, operator does not know that feed's unseen state; dismissing it would ack invisible alerts. | Codex ckpt 1 finding. Fix: only POST `/dismiss-all` to feeds with `status === "ok"`. Mark-all-read already naturally skips via max-id = 0 for missing feeds. |
+| 7 | **Timestamp sort is presentation only.** Each backend feed is PK-ordered (monotonic) so each feed's own 500-row cap is race-safe (`app/api/alerts.py:165-168`, `347-350`, `408-410`). Client re-sort by `ts` DESC just interleaves three PK-ordered slices. Cursor math (per-kind PK compare) is unaffected. | Codex ckpt 1 finding. Documenting explicitly so future devs don't assume client sort preserves the backend ordering invariant. |
+
+## Architecture
+
+Frontend-only. Three parallel fetches to existing endpoints, client-side merge into one timestamp-sorted list with discriminated-union rows.
+
+### Surfaces
+
+1. `frontend/src/api/types.ts` — add types mirroring backend pydantic shapes for position + coverage.
+2. `frontend/src/api/alerts.ts` — add 6 fetcher fns.
+3. `frontend/src/components/dashboard/AlertsStrip.tsx` — refactor to render discriminated union.
+4. `frontend/src/components/dashboard/AlertsStrip.test.tsx` — extend with merge + per-kind + fan-out + partial-failure tests.
+
+No new backend code. No migrations.
+
+## Types
+
+```ts
+// frontend/src/api/types.ts additions
+
+export type PositionAlertType = "sl_breach" | "tp_breach" | "thesis_break";
+
+export interface PositionAlert {
+  alert_id: number;
+  alert_type: PositionAlertType;
+  instrument_id: number;
+  symbol: string;
+  opened_at: string;
+  resolved_at: string | null;
+  detail: string;
+  current_bid: string | null; // Decimal serialized as string
+}
+
+export interface PositionAlertsResponse {
+  alerts_last_seen_position_alert_id: number | null;
+  unseen_count: number;
+  alerts: PositionAlert[];
+}
+
+export interface CoverageStatusDrop {
+  event_id: number;
+  instrument_id: number;
+  symbol: string;
+  changed_at: string;
+  old_status: string;
+  new_status: string | null;
+}
+
+export interface CoverageStatusDropsResponse {
+  alerts_last_seen_coverage_event_id: number | null;
+  unseen_count: number;
+  drops: CoverageStatusDrop[];
+}
+```
+
+### Discriminated union (component-local)
+
+```ts
+// frontend/src/components/dashboard/AlertsStrip.tsx
+
+type AlertRow =
+  | { kind: "guard";    ts: string; sortKey: number; row: GuardRejection }
+  | { kind: "position"; ts: string; sortKey: number; row: PositionAlert }
+  | { kind: "coverage"; ts: string; sortKey: number; row: CoverageStatusDrop };
+```
+
+- `ts` sources: `decision_time` / `opened_at` / `changed_at`.
+- `sortKey` = `Date.parse(ts)` — cached so merge sort doesn't re-parse per compare.
+- `row` preserves raw backend payload for type-specific rendering.
+
+## API client
+
+```ts
+// frontend/src/api/alerts.ts additions
+
+export function fetchPositionAlerts(): Promise<PositionAlertsResponse> {
+  return apiFetch<PositionAlertsResponse>("/alerts/position-alerts");
+}
+
+export function markPositionAlertsSeen(seenThroughPositionAlertId: number): Promise<void> {
+  return apiFetch<void>("/alerts/position-alerts/seen", {
+    method: "POST",
+    body: JSON.stringify({ seen_through_position_alert_id: seenThroughPositionAlertId }),
+  });
+}
+
+export function dismissAllPositionAlerts(): Promise<void> {
+  return apiFetch<void>("/alerts/position-alerts/dismiss-all", { method: "POST" });
+}
+
+export function fetchCoverageStatusDrops(): Promise<CoverageStatusDropsResponse> {
+  return apiFetch<CoverageStatusDropsResponse>("/alerts/coverage-status-drops");
+}
+
+export function markCoverageStatusDropsSeen(seenThroughEventId: number): Promise<void> {
+  return apiFetch<void>("/alerts/coverage-status-drops/seen", {
+    method: "POST",
+    body: JSON.stringify({ seen_through_event_id: seenThroughEventId }),
+  });
+}
+
+export function dismissAllCoverageStatusDrops(): Promise<void> {
+  return apiFetch<void>("/alerts/coverage-status-drops/dismiss-all", { method: "POST" });
+}
+```
+
+## Component
+
+### Loader
+
+Three parallel states; use per-feed `FeedState` discriminated union rather than `useAsync` (single-promise).
+
+```ts
+type FeedState<T> = { status: "loading" } | { status: "ok"; data: T } | { status: "err" };
+```
+
+`useEffect` on a `refetchKey` fires all three in parallel; each resolves its own state. Partial failure is explicit; no single-promise error throws away successful feeds.
+
+### Hide policy
+
+- **Any** feed still `loading` → render `null` (no flash of empty strip).
+- **All three** `err` → render `null`.
+- **All three** `ok` with empty `rejections`/`alerts`/`drops` → render `null`.
+- Otherwise render the strip using whatever `ok` feeds exist. Errored feed silently absent; logged via `console.error` per existing silent-on-error pattern.
+
+### Merge + unseen
+
+```ts
+function buildRows(
+  guard: FeedState<GuardRejectionsResponse>,
+  position: FeedState<PositionAlertsResponse>,
+  coverage: FeedState<CoverageStatusDropsResponse>,
+): AlertRow[] {
+  const rows: AlertRow[] = [];
+  if (guard.status === "ok") {
+    for (const r of guard.data.rejections) {
+      rows.push({ kind: "guard", ts: r.decision_time, sortKey: Date.parse(r.decision_time), row: r });
+    }
+  }
+  if (position.status === "ok") {
+    for (const r of position.data.alerts) {
+      rows.push({ kind: "position", ts: r.opened_at, sortKey: Date.parse(r.opened_at), row: r });
+    }
+  }
+  if (coverage.status === "ok") {
+    for (const r of coverage.data.drops) {
+      rows.push({ kind: "coverage", ts: r.changed_at, sortKey: Date.parse(r.changed_at), row: r });
+    }
+  }
+  rows.sort((a, b) => b.sortKey - a.sortKey);
+  return rows;
+}
+
+type Cursors = { guard: number | null; position: number | null; coverage: number | null };
+
+function isUnseen(r: AlertRow, c: Cursors): boolean {
+  switch (r.kind) {
+    case "guard":    return c.guard    === null || r.row.decision_id > c.guard;
+    case "position": return c.position === null || r.row.alert_id    > c.position;
+    case "coverage": return c.coverage === null || r.row.event_id    > c.coverage;
+  }
+}
+```
+
+### Totals + overflow
+
+**Per-feed overflow is the only correct signal.** Each backend feed independently caps at LIMIT 500. A global `totalUnseenCount > merged.length` conflates "feed-A has hidden unseen rows" with "feed-B's seen rows padding merged.length" → would falsely surface "Mark all read" while unseen rows of feed A are invisible.
+
+```ts
+function renderedCount(feed: FeedState<{ rejections?: unknown[]; alerts?: unknown[]; drops?: unknown[] }>): number {
+  if (feed.status !== "ok") return 0;
+  return feed.data.rejections?.length ?? feed.data.alerts?.length ?? feed.data.drops?.length ?? 0;
+}
+
+function unseenCount(feed: FeedState<{ unseen_count: number }>): number {
+  return feed.status === "ok" ? feed.data.unseen_count : 0;
+}
+
+const guardOverflow    = unseenCount(guard)    > renderedCount(guard);
+const positionOverflow = unseenCount(position) > renderedCount(position);
+const coverageOverflow = unseenCount(coverage) > renderedCount(coverage);
+
+const anyOverflow   = guardOverflow || positionOverflow || coverageOverflow;
+const totalUnseen   = unseenCount(guard) + unseenCount(position) + unseenCount(coverage);
+
+const overflowAck = anyOverflow;
+const normalAck   = totalUnseen > 0 && !anyOverflow;
+```
+
+Header badge shows `totalUnseen` when > 0. Errored feeds contribute 0 to `totalUnseen` (silent-on-error).
+
+### Row variants
+
+```tsx
+function RowView({ row, unseen }: { row: AlertRow; unseen: boolean }) {
+  switch (row.kind) {
+    case "guard":    return <GuardRow    row={row.row} unseen={unseen} />;
+    case "position": return <PositionRow row={row.row} unseen={unseen} />;
+    case "coverage": return <CoverageRow row={row.row} unseen={unseen} />;
+  }
+}
+```
+
+Each variant renders identical columns: `[kind-pill] [symbol] [detail-column-A] [detail-column-B] [ts]`.
+
+| Kind | Pill colour / label | Column A | Column B |
+| --- | --- | --- | --- |
+| guard | amber / `GUARD` | action (BUY/ADD/HOLD/EXIT) | explanation |
+| position | red / `POSITION` | alert_type (SL/TP/THESIS) | detail |
+| coverage | slate / `COVERAGE` | old → new status | — |
+
+`unseen` toggles left-border colour (amber if unseen, slate if seen) — existing guard pattern extended.
+
+### Click-through
+
+All three variants wrap their row in `<Link to={`/instruments/${instrument_id}`}>` when `instrument_id` is non-null — matches existing guard `RowView` pattern (`AlertsStrip.tsx:55-61`). Route `/instruments/:instrumentId` is the legacy-id shim in `frontend/src/App.tsx`; passing an `instrument_id` (BIGINT) is the supported shape. Using symbol would route through the wrong path and fail parse in `InstrumentDetailRedirect`.
+
+- Guard: `instrument_id` nullable — inline fallback when null.
+- Position: `instrument_id` NOT NULL per backend (`app/api/alerts.py:84`). Always a link.
+- Coverage: `instrument_id` NOT NULL per backend (`app/api/alerts.py:106`). Always a link.
+
+No position-tab / research-tab deep-link in this PR — deferred.
+
+### Actions
+
+#### Mark all read
+
+```ts
+async function onMarkAllRead() {
+  const guardMax = Math.max(0, ...merged.filter(r => r.kind === "guard").map(r => r.row.decision_id));
+  const positionMax = Math.max(0, ...merged.filter(r => r.kind === "position").map(r => r.row.alert_id));
+  const coverageMax = Math.max(0, ...merged.filter(r => r.kind === "coverage").map(r => r.row.event_id));
+
+  const promises: Promise<void>[] = [];
+  if (guardMax > 0)    promises.push(markAlertsSeen(guardMax));
+  if (positionMax > 0) promises.push(markPositionAlertsSeen(positionMax));
+  if (coverageMax > 0) promises.push(markCoverageStatusDropsSeen(coverageMax));
+
+  const results = await Promise.allSettled(promises);
+  for (const r of results) {
+    if (r.status === "rejected") console.error("[AlertsStrip] mark-all-read partial failure", r.reason);
+  }
+  refetch();
+}
+```
+
+#### Dismiss all
+
+Skips POSTs to errored feeds — operator does not see an errored feed's state, must not ack invisible alerts.
+
+```ts
+async function onDismissAll() {
+  // Hidden count = sum of per-feed (unseen - rendered); errored feeds contribute 0.
+  const hiddenCount =
+    Math.max(0, unseenCount(guard)    - renderedCount(guard)) +
+    Math.max(0, unseenCount(position) - renderedCount(position)) +
+    Math.max(0, unseenCount(coverage) - renderedCount(coverage));
+
+  const msg = `Dismiss all ${totalUnseen} unseen alerts? ${hiddenCount} are not shown above. Review them at /recommendations before dismissing if they might matter.`;
+  if (!window.confirm(msg)) return;
+
+  const promises: Promise<void>[] = [];
+  if (guard.status === "ok")    promises.push(dismissAllAlerts());
+  if (position.status === "ok") promises.push(dismissAllPositionAlerts());
+  if (coverage.status === "ok") promises.push(dismissAllCoverageStatusDrops());
+
+  const results = await Promise.allSettled(promises);
+  for (const r of results) {
+    if (r.status === "rejected") console.error("[AlertsStrip] dismiss-all partial failure", r.reason);
+  }
+  refetch();
+}
+```
+
+Mark-all-read naturally skips an errored feed because its `merged.filter(r=>r.kind===K)` returns empty → max = 0 → POST skipped (same mechanism as "feed has no visible rows").
+
+### Header
+
+- Heading text: **"Alerts"** (not "Guard rejections").
+- Total-new badge: `{totalUnseenCount} new` when > 0.
+- `normalAck` → "Mark all read" button.
+- `overflowAck` → "Dismiss all ({totalUnseenCount}) as acknowledged" + `/recommendations` triage link (existing pattern).
+
+## Edge cases
+
+| Case | Behaviour |
+| --- | --- |
+| All three feeds return empty | Strip hidden. |
+| One feed errors, others return rows | Strip shows the other two feeds' rows. Errored feed silently absent. `console.error` logged. |
+| Any feed still loading | Strip renders null (no flash). |
+| Null symbol on a row | Guard: inline (no link). Position + coverage: always have `symbol` per backend SELECT JOIN — won't happen; defensive treat as inline. |
+| Total unseen > merged rows (overflow) | "Dismiss all" button shown with full count + hidden-count warning. |
+| Mark-all-read with one feed errored | Max-id for that feed is 0; no POST issued for it. Other feeds' POSTs fire normally. |
+| Mark-all-read POST fails | `Promise.allSettled` handles it; other POSTs succeed; `refetch()` still runs; subsequent action via GREATEST idempotency recovers. |
+| All three `unseen_count === 0` | Strip still renders (there are seen rows to display), but no badge + no ack buttons. |
+| Dismiss-all confirm rejected | No POSTs issued; state unchanged. |
+| One feed errored, operator clicks Dismiss-all | POST skipped for that feed. Other two `/dismiss-all` POSTs fire. Errored feed's unseen state untouched. |
+| One feed has per-feed overflow, others don't | Dismiss-all button shown (`anyOverflow === true`). Mark-all-read hidden. Avoids falsely appearing to have acknowledged hidden rows. |
+
+## Testing
+
+Extend `frontend/src/components/dashboard/AlertsStrip.test.tsx`. Mock all three fetchers via `vi.mock("@/api/alerts")`. Update existing guard-only tests to also return empty position + coverage responses.
+
+### Test groups
+
+**Merge + ordering**
+- All three populated, mixed timestamps → rendered DESC by ts across kinds.
+- Two feeds ok, one ok-empty → only the non-empty feeds' rows appear, DESC by ts.
+
+**Per-kind rendering**
+- Guard row: amber pill, action, explanation.
+- Position row: red pill, alert_type, detail.
+- Coverage row: slate pill, `old_status → new_status`.
+
+**Click-through**
+- Each kind with symbol wraps in `<Link to="/instruments/${symbol}">`.
+- Guard with null symbol renders inline.
+
+**Hide/show**
+- Any feed still loading → null.
+- All three empty + ok → null.
+- All three errored → null.
+- Two errored + one ok with rows → strip renders the one feed.
+
+**Unseen totals + per-kind cursor**
+- Sum of `unseen_count` = header badge.
+- Row unseen iff its id > its kind's cursor.
+
+**Mark-all-read fan-out**
+- All three non-empty → 3 POSTs with each kind's merged-slice MAX id.
+- One feed empty in merged → no POST for that kind.
+- One POST rejects → other two still fire; `console.error` logged; `refetch` called.
+
+**Dismiss-all fan-out**
+- Confirm text names total unseen + hidden-count.
+- 3 POSTs fan out on confirm, skipping if window.confirm rejected.
+- Partial rejection logged; refetch runs.
+
+**Overflow trigger (per-feed)**
+- Only feed A has `unseen > rendered` → Dismiss-all visible; Mark-all-read hidden.
+- All three under cap, `totalUnseen > 0` → Mark-all-read visible; Dismiss-all hidden.
+- Feed A errored + B has overflow → Dismiss-all visible; POSTs fan-out skips A.
+
+No Playwright / end-to-end tests in this PR — component tests + existing pre-push gates cover the behaviour.
+
+## Pre-push checklist
+
+Per CLAUDE.md:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+pnpm --dir frontend typecheck
+pnpm --dir frontend test
+```
+
+Python gates included even though this PR is frontend-only — type annotations in test payloads (via pydantic schema drift checks) would regress silently otherwise. Frontend typecheck + vitest are the primary gates here.
+
+## PR description skeleton
+
+Title: `feat(#399): unified AlertsStrip — guard + position + coverage`
+
+Body:
+
+> **What**
+>
+> - `AlertsStrip` renders guard rejections + position alerts + coverage-status drops in one timestamp-sorted list.
+> - Three parallel fetches + client merge; per-kind badge + cursor; unified header with fan-out `Promise.allSettled` actions.
+> - New API client fns for position + coverage endpoints; types mirror backend pydantic shapes.
+>
+> **Why**
+>
+> - Closes #399. Backend pieces shipped in #394 (guard), #401 (position), #402 (coverage) — this wires them into the dashboard.
+>
+> **Test plan**
+>
+> - Vitest: merge ordering, per-kind render, click-through, hide policy, unseen counts, mark-all-read + dismiss-all fan-out, partial-failure tolerance, overflow.
+> - Manual: load the dashboard with all three feeds populated; confirm ordering, ack flow, and silent partial-failure.
+>
+> **Called out**
+>
+> - Partial-failure silent on any single feed POST/GET — matches existing silent-on-error pattern. Cursors recover via GREATEST on next action.
+> - No new backend routes. No migrations.
+> - Position/coverage click-through resolves to `/instruments/<symbol>` only (no tab deep-link) — deferred.

--- a/frontend/src/api/alerts.ts
+++ b/frontend/src/api/alerts.ts
@@ -1,5 +1,9 @@
 import { apiFetch } from "@/api/client";
-import type { GuardRejectionsResponse } from "@/api/types";
+import type {
+  CoverageStatusDropsResponse,
+  GuardRejectionsResponse,
+  PositionAlertsResponse,
+} from "@/api/types";
 
 /**
  * Fetchers for the alerts endpoints.
@@ -32,4 +36,48 @@ export function markAlertsSeen(seenThroughDecisionId: number): Promise<void> {
 
 export function dismissAllAlerts(): Promise<void> {
   return apiFetch<void>("/alerts/dismiss-all", { method: "POST" });
+}
+
+// --- #396/#401 position-alert endpoints -------------------------------------
+
+export function fetchPositionAlerts(): Promise<PositionAlertsResponse> {
+  return apiFetch<PositionAlertsResponse>("/alerts/position-alerts");
+}
+
+export function markPositionAlertsSeen(
+  seenThroughPositionAlertId: number,
+): Promise<void> {
+  return apiFetch<void>("/alerts/position-alerts/seen", {
+    method: "POST",
+    body: JSON.stringify({
+      seen_through_position_alert_id: seenThroughPositionAlertId,
+    }),
+  });
+}
+
+export function dismissAllPositionAlerts(): Promise<void> {
+  return apiFetch<void>("/alerts/position-alerts/dismiss-all", {
+    method: "POST",
+  });
+}
+
+// --- #397/#402 coverage-status-drops endpoints ------------------------------
+
+export function fetchCoverageStatusDrops(): Promise<CoverageStatusDropsResponse> {
+  return apiFetch<CoverageStatusDropsResponse>("/alerts/coverage-status-drops");
+}
+
+export function markCoverageStatusDropsSeen(
+  seenThroughEventId: number,
+): Promise<void> {
+  return apiFetch<void>("/alerts/coverage-status-drops/seen", {
+    method: "POST",
+    body: JSON.stringify({ seen_through_event_id: seenThroughEventId }),
+  });
+}
+
+export function dismissAllCoverageStatusDrops(): Promise<void> {
+  return apiFetch<void>("/alerts/coverage-status-drops/dismiss-all", {
+    method: "POST",
+  });
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -927,3 +927,45 @@ export interface GuardRejectionsResponse {
   unseen_count: number;
   rejections: GuardRejection[];
 }
+
+// ---------------------------------------------------------------------------
+// #396/#401 position alerts (app/api/alerts.py)
+// ---------------------------------------------------------------------------
+
+export type PositionAlertType = "sl_breach" | "tp_breach" | "thesis_break";
+
+export interface PositionAlert {
+  alert_id: number;
+  alert_type: PositionAlertType;
+  instrument_id: number;
+  symbol: string;
+  opened_at: string;
+  resolved_at: string | null;
+  detail: string;
+  current_bid: string | null; // Decimal serialized as string by pydantic
+}
+
+export interface PositionAlertsResponse {
+  alerts_last_seen_position_alert_id: number | null;
+  unseen_count: number;
+  alerts: PositionAlert[];
+}
+
+// ---------------------------------------------------------------------------
+// #397/#402 coverage status drops (app/api/alerts.py)
+// ---------------------------------------------------------------------------
+
+export interface CoverageStatusDrop {
+  event_id: number;
+  instrument_id: number;
+  symbol: string;
+  changed_at: string;
+  old_status: string;
+  new_status: string | null;
+}
+
+export interface CoverageStatusDropsResponse {
+  alerts_last_seen_coverage_event_id: number | null;
+  unseen_count: number;
+  drops: CoverageStatusDrop[];
+}

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -4,33 +4,117 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { AlertsStrip } from "@/components/dashboard/AlertsStrip";
-import type { GuardRejectionsResponse } from "@/api/types";
+import type {
+  CoverageStatusDrop,
+  CoverageStatusDropsResponse,
+  GuardRejection,
+  GuardRejectionsResponse,
+  PositionAlert,
+  PositionAlertsResponse,
+} from "@/api/types";
 
 vi.mock("@/api/alerts", () => ({
   fetchGuardRejections: vi.fn(),
   markAlertsSeen: vi.fn(),
   dismissAllAlerts: vi.fn(),
+  fetchPositionAlerts: vi.fn(),
+  markPositionAlertsSeen: vi.fn(),
+  dismissAllPositionAlerts: vi.fn(),
+  fetchCoverageStatusDrops: vi.fn(),
+  markCoverageStatusDropsSeen: vi.fn(),
+  dismissAllCoverageStatusDrops: vi.fn(),
 }));
 
 import * as alertsApi from "@/api/alerts";
 
-const baseRow = {
-  decision_id: 501,
-  decision_time: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
-  instrument_id: 42,
-  symbol: "AAPL",
-  action: "BUY" as const,
-  explanation: "FAIL — cash_available: need £200, have £50",
+const mockedGuardFetch = vi.mocked(alertsApi.fetchGuardRejections);
+const mockedPositionFetch = vi.mocked(alertsApi.fetchPositionAlerts);
+const mockedCoverageFetch = vi.mocked(alertsApi.fetchCoverageStatusDrops);
+
+const mockedMarkGuard = vi.mocked(alertsApi.markAlertsSeen);
+const mockedMarkPosition = vi.mocked(alertsApi.markPositionAlertsSeen);
+const mockedMarkCoverage = vi.mocked(alertsApi.markCoverageStatusDropsSeen);
+
+const mockedDismissGuard = vi.mocked(alertsApi.dismissAllAlerts);
+const mockedDismissPosition = vi.mocked(alertsApi.dismissAllPositionAlerts);
+const mockedDismissCoverage = vi.mocked(alertsApi.dismissAllCoverageStatusDrops);
+
+const EMPTY_GUARD: GuardRejectionsResponse = {
+  alerts_last_seen_decision_id: null,
+  unseen_count: 0,
+  rejections: [],
+};
+const EMPTY_POSITION: PositionAlertsResponse = {
+  alerts_last_seen_position_alert_id: null,
+  unseen_count: 0,
+  alerts: [],
+};
+const EMPTY_COVERAGE: CoverageStatusDropsResponse = {
+  alerts_last_seen_coverage_event_id: null,
+  unseen_count: 0,
+  drops: [],
 };
 
-const mockedFetch = vi.mocked(alertsApi.fetchGuardRejections);
-
-function stubFetch(data: GuardRejectionsResponse) {
-  mockedFetch.mockResolvedValue(data);
+function stubAll(
+  overrides: {
+    guard?: Partial<GuardRejectionsResponse> | Error;
+    position?: Partial<PositionAlertsResponse> | Error;
+    coverage?: Partial<CoverageStatusDropsResponse> | Error;
+  } = {},
+) {
+  if (overrides.guard instanceof Error) {
+    mockedGuardFetch.mockRejectedValue(overrides.guard);
+  } else {
+    mockedGuardFetch.mockResolvedValue({ ...EMPTY_GUARD, ...overrides.guard });
+  }
+  if (overrides.position instanceof Error) {
+    mockedPositionFetch.mockRejectedValue(overrides.position);
+  } else {
+    mockedPositionFetch.mockResolvedValue({ ...EMPTY_POSITION, ...overrides.position });
+  }
+  if (overrides.coverage instanceof Error) {
+    mockedCoverageFetch.mockRejectedValue(overrides.coverage);
+  } else {
+    mockedCoverageFetch.mockResolvedValue({ ...EMPTY_COVERAGE, ...overrides.coverage });
+  }
 }
 
-function stubFetchError() {
-  mockedFetch.mockRejectedValue(new Error("boom"));
+function makeGuard(overrides: Partial<GuardRejection> = {}): GuardRejection {
+  return {
+    decision_id: 501,
+    decision_time: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    instrument_id: 42,
+    symbol: "AAPL",
+    action: "BUY",
+    explanation: "FAIL — cash_available: need £200, have £50",
+    ...overrides,
+  };
+}
+
+function makePosition(overrides: Partial<PositionAlert> = {}): PositionAlert {
+  return {
+    alert_id: 701,
+    alert_type: "sl_breach",
+    instrument_id: 43,
+    symbol: "MSFT",
+    opened_at: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    resolved_at: null,
+    detail: "bid=320 < sl=330",
+    current_bid: "320",
+    ...overrides,
+  };
+}
+
+function makeCoverage(overrides: Partial<CoverageStatusDrop> = {}): CoverageStatusDrop {
+  return {
+    event_id: 301,
+    instrument_id: 44,
+    symbol: "TSLA",
+    changed_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+    old_status: "analysable",
+    new_status: "insufficient",
+    ...overrides,
+  };
 }
 
 function renderStrip() {
@@ -45,73 +129,187 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("AlertsStrip", () => {
-  it("renders nothing when rejections list is empty", async () => {
-    stubFetch({
-      alerts_last_seen_decision_id: null,
-      unseen_count: 0,
-      rejections: [],
-    });
+// ---------------------------------------------------------------------------
+// Basic rendering + hide policy
+// ---------------------------------------------------------------------------
+
+describe("AlertsStrip — basic rendering", () => {
+  it("renders nothing when all feeds are empty", async () => {
+    stubAll();
     const { container } = renderStrip();
     await vi.waitFor(() => {
-      expect(alertsApi.fetchGuardRejections).toHaveBeenCalled();
+      expect(mockedGuardFetch).toHaveBeenCalled();
+      expect(mockedPositionFetch).toHaveBeenCalled();
+      expect(mockedCoverageFetch).toHaveBeenCalled();
     });
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("renders nothing on fetch error (silent-on-error)", async () => {
-    stubFetchError();
+  it("renders nothing when all feeds error (silent-on-error)", async () => {
+    stubAll({
+      guard: new Error("boom"),
+      position: new Error("boom"),
+      coverage: new Error("boom"),
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { container } = renderStrip();
     await vi.waitFor(() => {
-      expect(alertsApi.fetchGuardRejections).toHaveBeenCalled();
+      expect(mockedGuardFetch).toHaveBeenCalled();
     });
+    expect(container).toBeEmptyDOMElement();
+    errSpy.mockRestore();
+  });
+
+  it("renders nothing while any feed is still loading (no flash)", () => {
+    mockedGuardFetch.mockResolvedValue(EMPTY_GUARD);
+    mockedPositionFetch.mockImplementation(() => new Promise(() => {})); // never resolves
+    mockedCoverageFetch.mockResolvedValue(EMPTY_COVERAGE);
+    const { container } = renderStrip();
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("renders row symbol / action / explanation", async () => {
-    stubFetch({
-      alerts_last_seen_decision_id: null,
-      unseen_count: 1,
-      rejections: [baseRow],
+  it("renders ok feeds when one feed errored", async () => {
+    stubAll({
+      guard: new Error("boom"),
+      position: { alerts: [makePosition({ symbol: "MSFT" })], unseen_count: 1 },
+      coverage: { drops: [makeCoverage({ symbol: "TSLA" })], unseen_count: 1 },
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    renderStrip();
+    expect(await screen.findByText("MSFT")).toBeInTheDocument();
+    expect(screen.getByText("TSLA")).toBeInTheDocument();
+    errSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Merge + ordering
+// ---------------------------------------------------------------------------
+
+describe("AlertsStrip — merge + ordering", () => {
+  it("merges three feeds into a single list DESC by timestamp", async () => {
+    const coverage = makeCoverage({
+      symbol: "TSLA",
+      changed_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+    });
+    const guard = makeGuard({
+      symbol: "AAPL",
+      decision_time: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    });
+    const position = makePosition({
+      symbol: "MSFT",
+      opened_at: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
+    });
+    stubAll({
+      guard: { rejections: [guard], unseen_count: 1 },
+      position: { alerts: [position], unseen_count: 1 },
+      coverage: { drops: [coverage], unseen_count: 1 },
+    });
+    renderStrip();
+    const rows = await screen.findAllByTestId("alerts-row");
+    expect(rows).toHaveLength(3);
+    expect(rows[0]!.textContent).toContain("AAPL"); // 5 min ago (newest)
+    expect(rows[1]!.textContent).toContain("MSFT"); // 15 min ago
+    expect(rows[2]!.textContent).toContain("TSLA"); // 30 min ago
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-kind rendering + click-through
+// ---------------------------------------------------------------------------
+
+describe("AlertsStrip — per-kind rendering", () => {
+  it("renders kind pill badge for each row type", async () => {
+    stubAll({
+      guard: { rejections: [makeGuard()], unseen_count: 1 },
+      position: { alerts: [makePosition()], unseen_count: 1 },
+      coverage: { drops: [makeCoverage()], unseen_count: 1 },
+    });
+    renderStrip();
+    expect(await screen.findByText("GUARD")).toBeInTheDocument();
+    expect(screen.getByText("POSITION")).toBeInTheDocument();
+    expect(screen.getByText("COVERAGE")).toBeInTheDocument();
+  });
+
+  it("links rows with non-null instrument_id to /instruments/<id>", async () => {
+    stubAll({
+      guard: { rejections: [makeGuard({ instrument_id: 42 })], unseen_count: 1 },
+      position: { alerts: [makePosition({ instrument_id: 43 })], unseen_count: 1 },
+      coverage: { drops: [makeCoverage({ instrument_id: 44 })], unseen_count: 1 },
+    });
+    renderStrip();
+    await screen.findAllByTestId("alerts-row");
+    const links = screen
+      .getAllByRole("link")
+      .map((l) => l.getAttribute("href"));
+    expect(links).toEqual(
+      expect.arrayContaining(["/instruments/42", "/instruments/43", "/instruments/44"]),
+    );
+  });
+
+  it("renders guard row with null instrument_id inline (no link)", async () => {
+    stubAll({
+      guard: {
+        rejections: [makeGuard({ instrument_id: null, symbol: null })],
+        unseen_count: 1,
+      },
+    });
+    renderStrip();
+    const row = await screen.findByTestId("alerts-row");
+    expect(row.closest("a")).toBeNull();
+  });
+
+  it("guard row shows symbol / action / explanation", async () => {
+    stubAll({
+      guard: { rejections: [makeGuard()], unseen_count: 1 },
     });
     renderStrip();
     expect(await screen.findByText("AAPL")).toBeInTheDocument();
     expect(screen.getByText("BUY")).toBeInTheDocument();
-    expect(
-      screen.getByText(/cash_available: need £200/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/cash_available: need £200/)).toBeInTheDocument();
   });
 
-  it("wraps row in a Link when instrument_id is non-null", async () => {
-    stubFetch({
-      alerts_last_seen_decision_id: null,
-      unseen_count: 1,
-      rejections: [baseRow],
+  it("position row shows symbol / alert_type label / detail", async () => {
+    stubAll({
+      position: {
+        alerts: [makePosition({ alert_type: "sl_breach", detail: "bid=320 < sl=330" })],
+        unseen_count: 1,
+      },
     });
     renderStrip();
-    const link = await screen.findByRole("link");
-    expect(link.getAttribute("href")).toBe("/instruments/42");
+    expect(await screen.findByText("MSFT")).toBeInTheDocument();
+    expect(screen.getByText("SL")).toBeInTheDocument();
+    expect(screen.getByText("bid=320 < sl=330")).toBeInTheDocument();
   });
 
-  it("renders plain row (no link) when instrument_id is null", async () => {
-    stubFetch({
-      alerts_last_seen_decision_id: null,
-      unseen_count: 1,
-      rejections: [{ ...baseRow, instrument_id: null, symbol: null }],
+  it("coverage row shows symbol and old → new transition", async () => {
+    stubAll({
+      coverage: {
+        drops: [makeCoverage({ old_status: "analysable", new_status: "insufficient" })],
+        unseen_count: 1,
+      },
     });
     renderStrip();
-    await screen.findByText(/cash_available/);
-    expect(screen.queryByRole("link")).toBeNull();
+    expect(await screen.findByText("TSLA")).toBeInTheDocument();
+    expect(screen.getByText("analysable → insufficient")).toBeInTheDocument();
   });
+});
 
-  it("applies amber border for unseen rows, slate for seen", async () => {
-    stubFetch({
-      alerts_last_seen_decision_id: 500,
-      unseen_count: 1,
-      rejections: [
-        { ...baseRow, decision_id: 501 },  // unseen (501 > 500)
-        { ...baseRow, decision_id: 499 },  // seen (499 <= 500)
-      ],
+// ---------------------------------------------------------------------------
+// Unseen cursor math (per-kind)
+// ---------------------------------------------------------------------------
+
+describe("AlertsStrip — per-kind unseen cursor", () => {
+  it("applies amber border for unseen guard rows and slate for seen", async () => {
+    stubAll({
+      guard: {
+        alerts_last_seen_decision_id: 500,
+        unseen_count: 1,
+        rejections: [
+          makeGuard({ decision_id: 501 }), // unseen
+          makeGuard({ decision_id: 499 }), // seen
+        ],
+      },
     });
     renderStrip();
     const rows = await screen.findAllByTestId("alerts-row");
@@ -119,197 +317,200 @@ describe("AlertsStrip", () => {
     expect(rows[1]!.className).toMatch(/border-slate/);
   });
 
-  it("shows unseen_count pill when unseen_count > 0", async () => {
-    stubFetch({
-      alerts_last_seen_decision_id: null,
-      unseen_count: 3,
-      rejections: [baseRow],
+  it("per-kind cursor: position cursor only affects position rows", async () => {
+    stubAll({
+      position: {
+        alerts_last_seen_position_alert_id: 700,
+        unseen_count: 1,
+        alerts: [
+          makePosition({ alert_id: 701 }), // unseen (701 > 700)
+        ],
+      },
+      coverage: {
+        alerts_last_seen_coverage_event_id: null,
+        unseen_count: 1,
+        drops: [makeCoverage({ event_id: 301 })], // unseen (cursor null)
+      },
     });
     renderStrip();
-    expect(await screen.findByText(/3 new/)).toBeInTheDocument();
-  });
-
-  it("omits unseen_count pill when unseen_count === 0", async () => {
-    stubFetch({
-      alerts_last_seen_decision_id: 999,
-      unseen_count: 0,
-      rejections: [baseRow],  // still shown, just all seen
-    });
-    renderStrip();
-    await screen.findByText("AAPL");
-    expect(screen.queryByText(/new$/)).toBeNull();
-  });
-
-  it("truncates explanation visually but preserves full text in title", async () => {
-    const long = "FAIL — cash_available: need £200; thesis_stale: 14 days old; spread_wide: 0.12%";
-    stubFetch({
-      alerts_last_seen_decision_id: null,
-      unseen_count: 1,
-      rejections: [{ ...baseRow, explanation: long }],
-    });
-    renderStrip();
-    const node = await screen.findByText(long);
-    expect(node.getAttribute("title")).toBe(long);
-    expect(node.className).toMatch(/truncate/);
+    const rows = await screen.findAllByTestId("alerts-row");
+    for (const r of rows) {
+      expect(r.className).toMatch(/border-amber/);
+    }
   });
 });
 
-describe("AlertsStrip — Mark all read (normal path)", () => {
-  it("renders 'Mark all read' when unseen_count > 0 and <= rejections.length", async () => {
-    stubFetch({
-      alerts_last_seen_decision_id: 499,
-      unseen_count: 2,
-      rejections: [
-        { ...baseRow, decision_id: 501 },
-        { ...baseRow, decision_id: 500 },
-      ],
+// ---------------------------------------------------------------------------
+// Header badge + totals
+// ---------------------------------------------------------------------------
+
+describe("AlertsStrip — header totals", () => {
+  it("header badge is sum of per-feed unseen_count", async () => {
+    stubAll({
+      guard: { rejections: [makeGuard()], unseen_count: 3 },
+      position: { alerts: [makePosition()], unseen_count: 2 },
+      coverage: { drops: [makeCoverage()], unseen_count: 1 },
     });
     renderStrip();
-    expect(await screen.findByRole("button", { name: /mark all read/i })).toBeInTheDocument();
+    expect(await screen.findByText("6 new")).toBeInTheDocument();
   });
 
-  it("hides 'Mark all read' when unseen_count === 0 (all rows already seen)", async () => {
-    stubFetch({
-      alerts_last_seen_decision_id: 999,
-      unseen_count: 0,
-      rejections: [{ ...baseRow, decision_id: 500 }],  // seen (500 < 999)
+  it("omits badge when no unseen across any feed", async () => {
+    stubAll({
+      guard: {
+        alerts_last_seen_decision_id: 999,
+        unseen_count: 0,
+        rejections: [makeGuard({ decision_id: 500 })],
+      },
     });
     renderStrip();
     await screen.findByText("AAPL");
-    expect(screen.queryByRole("button", { name: /mark all read/i })).toBeNull();
+    expect(screen.queryByText(/\bnew\b/)).toBeNull();
   });
 
-  it("stays visible at the 500-row cap when unseen_count === rejections.length === 500", async () => {
-    const rejections = Array.from({ length: 500 }, (_, i) => ({
-      ...baseRow,
-      decision_id: 500 - i,
-    }));
-    stubFetch({
-      alerts_last_seen_decision_id: null,
-      unseen_count: 500,
-      rejections,
+  it("heading text is 'Alerts'", async () => {
+    stubAll({
+      guard: { rejections: [makeGuard()], unseen_count: 1 },
     });
     renderStrip();
-    expect(await screen.findByRole("button", { name: /mark all read/i })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Alerts" })).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-feed overflow + ack-button gating
+// ---------------------------------------------------------------------------
+
+describe("AlertsStrip — per-feed overflow", () => {
+  it("shows Dismiss-all when any feed has unseen > rendered (per-feed overflow)", async () => {
+    stubAll({
+      guard: { rejections: [makeGuard()], unseen_count: 2 }, // overflow (2 > 1)
+    });
+    renderStrip();
+    expect(await screen.findByRole("button", { name: /Dismiss all/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Mark all read/i })).toBeNull();
   });
 
-  it("click posts rejections[0].decision_id and refetches", async () => {
-    stubFetch({
-      alerts_last_seen_decision_id: 499,
-      unseen_count: 2,
-      rejections: [
-        { ...baseRow, decision_id: 501 },
-        { ...baseRow, decision_id: 500 },
-      ],
+  it("shows Mark-all-read when no feed overflows and totalUnseen > 0", async () => {
+    stubAll({
+      guard: { rejections: [makeGuard()], unseen_count: 1 },
+      position: { alerts: [makePosition()], unseen_count: 1 },
     });
-    vi.mocked(alertsApi.markAlertsSeen).mockResolvedValue(undefined);
     renderStrip();
+    expect(await screen.findByRole("button", { name: /Mark all read/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Dismiss all/i })).toBeNull();
+  });
 
-    const btn = await screen.findByRole("button", { name: /mark all read/i });
+  it("hides both buttons when totalUnseen === 0", async () => {
+    stubAll({
+      guard: {
+        alerts_last_seen_decision_id: 999,
+        unseen_count: 0,
+        rejections: [makeGuard({ decision_id: 500 })],
+      },
+    });
+    renderStrip();
+    await screen.findByText("AAPL");
+    expect(screen.queryByRole("button", { name: /Mark all read/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Dismiss all/i })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mark-all-read fan-out
+// ---------------------------------------------------------------------------
+
+describe("AlertsStrip — Mark all read", () => {
+  it("fans out to each non-empty feed with its MAX id", async () => {
+    stubAll({
+      guard: { rejections: [makeGuard({ decision_id: 510 })], unseen_count: 1 },
+      position: { alerts: [makePosition({ alert_id: 710 })], unseen_count: 1 },
+    });
+    mockedMarkGuard.mockResolvedValue(undefined);
+    mockedMarkPosition.mockResolvedValue(undefined);
+    renderStrip();
+    const btn = await screen.findByRole("button", { name: /Mark all read/i });
     await userEvent.click(btn);
-
-    expect(alertsApi.markAlertsSeen).toHaveBeenCalledWith(501);  // MAX(decision_id) in payload
     await vi.waitFor(() => {
-      expect(vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(mockedMarkGuard).toHaveBeenCalledWith(510);
+      expect(mockedMarkPosition).toHaveBeenCalledWith(710);
     });
+    expect(mockedMarkCoverage).not.toHaveBeenCalled();
   });
 
-  it("swallows markAlertsSeen rejection silently and still refetches", async () => {
-    stubFetch({
-      alerts_last_seen_decision_id: 499,
-      unseen_count: 1,
-      rejections: [{ ...baseRow, decision_id: 501 }],
+  it("tolerates a single POST failure and still calls others", async () => {
+    stubAll({
+      guard: { rejections: [makeGuard({ decision_id: 510 })], unseen_count: 1 },
+      position: { alerts: [makePosition({ alert_id: 710 })], unseen_count: 1 },
     });
-    vi.mocked(alertsApi.markAlertsSeen).mockRejectedValue(new Error("boom"));
+    mockedMarkGuard.mockRejectedValue(new Error("guard seen boom"));
+    mockedMarkPosition.mockResolvedValue(undefined);
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    renderStrip();
+    await userEvent.click(await screen.findByRole("button", { name: /Mark all read/i }));
+    await vi.waitFor(() => {
+      expect(mockedMarkGuard).toHaveBeenCalled();
+      expect(mockedMarkPosition).toHaveBeenCalled();
+    });
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dismiss-all fan-out
+// ---------------------------------------------------------------------------
+
+describe("AlertsStrip — Dismiss all", () => {
+  it("skips POST for any errored feed and fans out to ok feeds", async () => {
+    stubAll({
+      guard: new Error("boom"),
+      position: { alerts: [makePosition()], unseen_count: 5 }, // overflow (5 > 1)
+    });
+    mockedDismissPosition.mockResolvedValue(undefined);
+    mockedDismissCoverage.mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     renderStrip();
-
-    const btn = await screen.findByRole("button", { name: /mark all read/i });
+    const btn = await screen.findByRole("button", { name: /Dismiss all/i });
     await userEvent.click(btn);
-
     await vi.waitFor(() => {
-      expect(errSpy).toHaveBeenCalled();
+      expect(mockedDismissPosition).toHaveBeenCalled();
     });
-    // Refetch fires even after a failed ack.
-    await vi.waitFor(() => {
-      expect(vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length).toBeGreaterThanOrEqual(2);
-    });
+    expect(mockedDismissGuard).not.toHaveBeenCalled();
+    expect(mockedDismissCoverage).toHaveBeenCalled();
+    confirmSpy.mockRestore();
     errSpy.mockRestore();
   });
-});
 
-describe("AlertsStrip — Dismiss all (overflow path)", () => {
-  function overflowStub() {
-    stubFetch({
-      alerts_last_seen_decision_id: null,
-      unseen_count: 600,
-      rejections: Array.from({ length: 500 }, (_, i) => ({
-        ...baseRow,
-        decision_id: 600 - i,
-      })),
+  it("no-op when operator cancels confirm", async () => {
+    stubAll({
+      guard: { rejections: [makeGuard()], unseen_count: 5 },
     });
-  }
-
-  it("renders 'Dismiss all (600) as acknowledged' and a /recommendations link when unseen_count > rejections.length", async () => {
-    overflowStub();
-    renderStrip();
-    expect(
-      await screen.findByRole("button", { name: /dismiss all \(600\)/i }),
-    ).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /mark all read/i })).toBeNull();
-    const recLink = screen.getByRole("link", { name: /recommendations/i });
-    expect(recLink.getAttribute("href")).toBe("/recommendations");
-  });
-
-  it("confirm dialog: confirm calls dismissAllAlerts + refetch", async () => {
-    overflowStub();
-    vi.mocked(alertsApi.dismissAllAlerts).mockResolvedValue(undefined);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    renderStrip();
-
-    const btn = await screen.findByRole("button", { name: /dismiss all \(600\)/i });
-    await userEvent.click(btn);
-
-    expect(confirmSpy).toHaveBeenCalled();
-    expect(alertsApi.dismissAllAlerts).toHaveBeenCalled();
-    await vi.waitFor(() => {
-      expect(vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length).toBeGreaterThanOrEqual(2);
-    });
-    confirmSpy.mockRestore();
-  });
-
-  it("confirm dialog: cancel does NOT call dismissAllAlerts or refetch", async () => {
-    overflowStub();
-    vi.mocked(alertsApi.dismissAllAlerts).mockResolvedValue(undefined);
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
     renderStrip();
-
-    const fetchCallsBefore = vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length;
-    const btn = await screen.findByRole("button", { name: /dismiss all \(600\)/i });
-    await userEvent.click(btn);
-
-    expect(confirmSpy).toHaveBeenCalled();
-    expect(alertsApi.dismissAllAlerts).not.toHaveBeenCalled();
-    expect(vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length).toBe(fetchCallsBefore);
+    await userEvent.click(await screen.findByRole("button", { name: /Dismiss all/i }));
+    expect(mockedDismissGuard).not.toHaveBeenCalled();
     confirmSpy.mockRestore();
   });
 
-  it("swallows dismissAllAlerts rejection silently and still refetches", async () => {
-    overflowStub();
-    vi.mocked(alertsApi.dismissAllAlerts).mockRejectedValue(new Error("boom"));
+  it("tolerates a single dismiss POST failure silently", async () => {
+    stubAll({
+      guard: { rejections: [makeGuard()], unseen_count: 5 },
+      position: { alerts: [makePosition()], unseen_count: 1 },
+    });
+    mockedDismissGuard.mockRejectedValue(new Error("guard dismiss boom"));
+    mockedDismissPosition.mockResolvedValue(undefined);
+    mockedDismissCoverage.mockResolvedValue(undefined);
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     renderStrip();
-
-    const btn = await screen.findByRole("button", { name: /dismiss all \(600\)/i });
-    await userEvent.click(btn);
-
+    await userEvent.click(await screen.findByRole("button", { name: /Dismiss all/i }));
     await vi.waitFor(() => {
-      expect(errSpy).toHaveBeenCalled();
+      expect(mockedDismissGuard).toHaveBeenCalled();
+      expect(mockedDismissPosition).toHaveBeenCalled();
     });
-    await vi.waitFor(() => {
-      expect(vi.mocked(alertsApi.fetchGuardRejections).mock.calls.length).toBeGreaterThanOrEqual(2);
-    });
+    expect(errSpy).toHaveBeenCalled();
     confirmSpy.mockRestore();
     errSpy.mockRestore();
   });

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -1,35 +1,139 @@
 /**
- * AlertsStrip — guard-rejection alerts on the operator dashboard (#315 Phase 3).
+ * AlertsStrip — unified dashboard alert feed (#399).
  *
- * Sits between RollingPnlStrip and PortfolioValueChart. Hidden when empty;
- * silent on fetch error (matches the RollingPnlStrip pattern — a failing
- * /alerts must not blank the dashboard).
+ * Renders three independent alert streams in a single timestamp-sorted list:
  *
- * Cursor is decision_id (not decision_time) — see spec
- * docs/superpowers/specs/2026-04-21-alerts-strip-guard-rejections.md for why.
+ *   1. Guard rejections (#394)
+ *   2. Position alerts — SL/TP/thesis breach episodes (#401)
+ *   3. Coverage status drops from 'analysable' (#402)
+ *
+ * Each feed keeps its own BIGSERIAL cursor column on `operators`. Partial
+ * failure is tolerated: one feed GET erroring does not hide the others; one
+ * POST failing does not block the siblings (Promise.allSettled).
+ *
+ * Overflow math is per-feed — each backend query caps at LIMIT 500 so
+ * global `totalUnseen > merged.length` would conflate feed-A hidden rows
+ * with feed-B seen padding. See spec
+ * docs/superpowers/specs/2026-04-22-alerts-strip-unified.md for rationale.
  */
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
-import { dismissAllAlerts, fetchGuardRejections, markAlertsSeen } from "@/api/alerts";
-import type { GuardRejection } from "@/api/types";
+import {
+  dismissAllAlerts,
+  dismissAllCoverageStatusDrops,
+  dismissAllPositionAlerts,
+  fetchCoverageStatusDrops,
+  fetchGuardRejections,
+  fetchPositionAlerts,
+  markAlertsSeen,
+  markCoverageStatusDropsSeen,
+  markPositionAlertsSeen,
+} from "@/api/alerts";
+import type {
+  CoverageStatusDrop,
+  CoverageStatusDropsResponse,
+  GuardRejection,
+  GuardRejectionsResponse,
+  PositionAlert,
+  PositionAlertsResponse,
+} from "@/api/types";
 import { formatRelativeTime } from "@/lib/format";
-import { useAsync } from "@/lib/useAsync";
 
-function isUnseen(
-  row: GuardRejection,
-  lastSeen: number | null,
-): boolean {
-  return lastSeen === null || row.decision_id > lastSeen;
+type FeedState<T> =
+  | { status: "loading" }
+  | { status: "ok"; data: T }
+  | { status: "err" };
+
+type AlertRow =
+  | { kind: "guard"; ts: string; sortKey: number; row: GuardRejection }
+  | { kind: "position"; ts: string; sortKey: number; row: PositionAlert }
+  | { kind: "coverage"; ts: string; sortKey: number; row: CoverageStatusDrop };
+
+type Cursors = {
+  guard: number | null;
+  position: number | null;
+  coverage: number | null;
+};
+
+function buildRows(
+  guard: FeedState<GuardRejectionsResponse>,
+  position: FeedState<PositionAlertsResponse>,
+  coverage: FeedState<CoverageStatusDropsResponse>,
+): AlertRow[] {
+  const rows: AlertRow[] = [];
+  if (guard.status === "ok") {
+    for (const r of guard.data.rejections) {
+      rows.push({
+        kind: "guard",
+        ts: r.decision_time,
+        sortKey: Date.parse(r.decision_time),
+        row: r,
+      });
+    }
+  }
+  if (position.status === "ok") {
+    for (const r of position.data.alerts) {
+      rows.push({
+        kind: "position",
+        ts: r.opened_at,
+        sortKey: Date.parse(r.opened_at),
+        row: r,
+      });
+    }
+  }
+  if (coverage.status === "ok") {
+    for (const r of coverage.data.drops) {
+      rows.push({
+        kind: "coverage",
+        ts: r.changed_at,
+        sortKey: Date.parse(r.changed_at),
+        row: r,
+      });
+    }
+  }
+  rows.sort((a, b) => b.sortKey - a.sortKey);
+  return rows;
 }
 
-function RowView({
-  row,
-  lastSeen,
+function isUnseen(r: AlertRow, c: Cursors): boolean {
+  switch (r.kind) {
+    case "guard":
+      return c.guard === null || r.row.decision_id > c.guard;
+    case "position":
+      return c.position === null || r.row.alert_id > c.position;
+    case "coverage":
+      return c.coverage === null || r.row.event_id > c.coverage;
+  }
+}
+
+function KindPill({ kind }: { kind: AlertRow["kind"] }) {
+  const style = {
+    guard: "bg-amber-100 text-amber-800",
+    position: "bg-red-100 text-red-800",
+    coverage: "bg-slate-100 text-slate-700",
+  }[kind];
+  const label = { guard: "GUARD", position: "POSITION", coverage: "COVERAGE" }[kind];
+  return (
+    <span
+      className={`w-20 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold uppercase ${style}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function RowShell({
+  kind,
+  unseen,
+  instrumentId,
+  children,
 }: {
-  row: GuardRejection;
-  lastSeen: number | null;
+  kind: AlertRow["kind"];
+  unseen: boolean;
+  instrumentId: number | null;
+  children: React.ReactNode;
 }) {
-  const unseen = isUnseen(row, lastSeen);
   const border = unseen
     ? "border-l-4 border-amber-400"
     : "border-l-4 border-slate-200";
@@ -39,22 +143,13 @@ function RowView({
       role="listitem"
       className={`flex items-center gap-3 px-3 py-2 text-sm ${border} bg-white`}
     >
-      <span className="w-16 font-semibold tabular-nums">{row.symbol ?? "—"}</span>
-      <span className="w-12 text-xs uppercase text-slate-500">{row.action ?? "—"}</span>
-      <span
-        className="flex-1 truncate text-slate-700"
-        title={row.explanation}
-      >
-        {row.explanation}
-      </span>
-      <span className="w-20 text-right text-xs text-slate-400">
-        {formatRelativeTime(row.decision_time)}
-      </span>
+      <KindPill kind={kind} />
+      {children}
     </div>
   );
-  if (row.instrument_id !== null) {
+  if (instrumentId !== null) {
     return (
-      <Link to={`/instruments/${row.instrument_id}`} className="block hover:bg-slate-50">
+      <Link to={`/instruments/${instrumentId}`} className="block hover:bg-slate-50">
         {content}
       </Link>
     );
@@ -62,51 +157,258 @@ function RowView({
   return content;
 }
 
+function GuardRow({ row, unseen }: { row: GuardRejection; unseen: boolean }) {
+  return (
+    <RowShell kind="guard" unseen={unseen} instrumentId={row.instrument_id}>
+      <span className="w-16 font-semibold tabular-nums">{row.symbol ?? "—"}</span>
+      <span className="w-16 text-xs uppercase text-slate-500">{row.action ?? "—"}</span>
+      <span className="flex-1 truncate text-slate-700" title={row.explanation}>
+        {row.explanation}
+      </span>
+      <span className="w-20 text-right text-xs text-slate-400">
+        {formatRelativeTime(row.decision_time)}
+      </span>
+    </RowShell>
+  );
+}
+
+function PositionRow({ row, unseen }: { row: PositionAlert; unseen: boolean }) {
+  const alertLabel = {
+    sl_breach: "SL",
+    tp_breach: "TP",
+    thesis_break: "THESIS",
+  }[row.alert_type];
+  return (
+    <RowShell kind="position" unseen={unseen} instrumentId={row.instrument_id}>
+      <span className="w-16 font-semibold tabular-nums">{row.symbol}</span>
+      <span className="w-16 text-xs uppercase text-slate-500">{alertLabel}</span>
+      <span className="flex-1 truncate text-slate-700" title={row.detail}>
+        {row.detail}
+      </span>
+      <span className="w-20 text-right text-xs text-slate-400">
+        {formatRelativeTime(row.opened_at)}
+      </span>
+    </RowShell>
+  );
+}
+
+function CoverageRow({ row, unseen }: { row: CoverageStatusDrop; unseen: boolean }) {
+  const transition = `${row.old_status} → ${row.new_status ?? "—"}`;
+  return (
+    <RowShell kind="coverage" unseen={unseen} instrumentId={row.instrument_id}>
+      <span className="w-16 font-semibold tabular-nums">{row.symbol}</span>
+      <span className="flex-1 truncate text-slate-700" title={transition}>
+        {transition}
+      </span>
+      <span className="w-20 text-right text-xs text-slate-400">
+        {formatRelativeTime(row.changed_at)}
+      </span>
+    </RowShell>
+  );
+}
+
+function RowView({ row, cursors }: { row: AlertRow; cursors: Cursors }) {
+  const unseen = isUnseen(row, cursors);
+  switch (row.kind) {
+    case "guard":
+      return <GuardRow row={row.row} unseen={unseen} />;
+    case "position":
+      return <PositionRow row={row.row} unseen={unseen} />;
+    case "coverage":
+      return <CoverageRow row={row.row} unseen={unseen} />;
+  }
+}
+
+function rowId(row: AlertRow): number {
+  switch (row.kind) {
+    case "guard":
+      return row.row.decision_id;
+    case "position":
+      return row.row.alert_id;
+    case "coverage":
+      return row.row.event_id;
+  }
+}
+
 export function AlertsStrip(): JSX.Element | null {
-  const { data, error, refetch } = useAsync(fetchGuardRejections, []);
+  const [guard, setGuard] = useState<FeedState<GuardRejectionsResponse>>({
+    status: "loading",
+  });
+  const [position, setPosition] = useState<FeedState<PositionAlertsResponse>>({
+    status: "loading",
+  });
+  const [coverage, setCoverage] = useState<FeedState<CoverageStatusDropsResponse>>({
+    status: "loading",
+  });
+  const [refetchKey, setRefetchKey] = useState(0);
 
-  if (error !== null || data === null) return null;
-  if (data.rejections.length === 0) return null;
+  useEffect(() => {
+    let cancelled = false;
+    setGuard({ status: "loading" });
+    setPosition({ status: "loading" });
+    setCoverage({ status: "loading" });
 
-  const lastSeen = data.alerts_last_seen_decision_id;
-  const normalAck =
-    data.unseen_count > 0 && data.unseen_count <= data.rejections.length;
-  const overflowAck = data.unseen_count > data.rejections.length;
+    fetchGuardRejections()
+      .then((d) => {
+        if (!cancelled) setGuard({ status: "ok", data: d });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("[AlertsStrip] fetchGuardRejections failed", err);
+          setGuard({ status: "err" });
+        }
+      });
+    fetchPositionAlerts()
+      .then((d) => {
+        if (!cancelled) setPosition({ status: "ok", data: d });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("[AlertsStrip] fetchPositionAlerts failed", err);
+          setPosition({ status: "err" });
+        }
+      });
+    fetchCoverageStatusDrops()
+      .then((d) => {
+        if (!cancelled) setCoverage({ status: "ok", data: d });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("[AlertsStrip] fetchCoverageStatusDrops failed", err);
+          setCoverage({ status: "err" });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refetchKey]);
+
+  const refetch = () => setRefetchKey((k) => k + 1);
+
+  if (
+    guard.status === "loading" ||
+    position.status === "loading" ||
+    coverage.status === "loading"
+  ) {
+    return null;
+  }
+  if (
+    guard.status === "err" &&
+    position.status === "err" &&
+    coverage.status === "err"
+  ) {
+    return null;
+  }
+
+  const merged = buildRows(guard, position, coverage);
+
+  if (merged.length === 0) {
+    return null;
+  }
+
+  const unseenGuard = guard.status === "ok" ? guard.data.unseen_count : 0;
+  const unseenPosition = position.status === "ok" ? position.data.unseen_count : 0;
+  const unseenCoverage = coverage.status === "ok" ? coverage.data.unseen_count : 0;
+
+  const renderedGuard = guard.status === "ok" ? guard.data.rejections.length : 0;
+  const renderedPosition = position.status === "ok" ? position.data.alerts.length : 0;
+  const renderedCoverage = coverage.status === "ok" ? coverage.data.drops.length : 0;
+
+  const totalUnseen = unseenGuard + unseenPosition + unseenCoverage;
+
+  const anyOverflow =
+    unseenGuard > renderedGuard ||
+    unseenPosition > renderedPosition ||
+    unseenCoverage > renderedCoverage;
+
+  const overflowAck = anyOverflow;
+  const normalAck = totalUnseen > 0 && !anyOverflow;
+
+  const cursors: Cursors = {
+    guard: guard.status === "ok" ? guard.data.alerts_last_seen_decision_id : null,
+    position:
+      position.status === "ok"
+        ? position.data.alerts_last_seen_position_alert_id
+        : null,
+    coverage:
+      coverage.status === "ok"
+        ? coverage.data.alerts_last_seen_coverage_event_id
+        : null,
+  };
 
   async function onMarkAllRead() {
-    // rejections is non-empty here (strip is hidden otherwise),
-    // and is ordered decision_id DESC on the server so index 0 is MAX.
-    const seenThroughDecisionId = data!.rejections[0]!.decision_id;
-    try {
-      await markAlertsSeen(seenThroughDecisionId);
-    } catch (err) {
-      // Silent-on-error matches the rest of the strip; log for debugging.
-      // Server ack is idempotent (GREATEST monotonic) so a future retry is safe.
-      console.error("[AlertsStrip] markAlertsSeen failed", err);
+    const guardMax = Math.max(
+      0,
+      ...merged
+        .filter((r): r is Extract<AlertRow, { kind: "guard" }> => r.kind === "guard")
+        .map((r) => r.row.decision_id),
+    );
+    const positionMax = Math.max(
+      0,
+      ...merged
+        .filter((r): r is Extract<AlertRow, { kind: "position" }> => r.kind === "position")
+        .map((r) => r.row.alert_id),
+    );
+    const coverageMax = Math.max(
+      0,
+      ...merged
+        .filter((r): r is Extract<AlertRow, { kind: "coverage" }> => r.kind === "coverage")
+        .map((r) => r.row.event_id),
+    );
+
+    const promises: Promise<void>[] = [];
+    if (guardMax > 0) promises.push(markAlertsSeen(guardMax));
+    if (positionMax > 0) promises.push(markPositionAlertsSeen(positionMax));
+    if (coverageMax > 0) promises.push(markCoverageStatusDropsSeen(coverageMax));
+
+    const results = await Promise.allSettled(promises);
+    for (const r of results) {
+      if (r.status === "rejected") {
+        console.error("[AlertsStrip] mark-all-read partial failure", r.reason);
+      }
     }
     refetch();
   }
 
   async function onDismissAll() {
-    const hiddenCount = data!.unseen_count - data!.rejections.length;
-    const msg = `Dismiss all ${data!.unseen_count} unseen rejections? ${hiddenCount} are not shown above. Review them at /recommendations before dismissing if they might matter.`;
+    const hiddenCount =
+      Math.max(0, unseenGuard - renderedGuard) +
+      Math.max(0, unseenPosition - renderedPosition) +
+      Math.max(0, unseenCoverage - renderedCoverage);
+    const msg = `Dismiss all ${totalUnseen} unseen alerts? ${hiddenCount} are not shown above. Review them at /recommendations before dismissing if they might matter.`;
     if (!window.confirm(msg)) return;
-    try {
-      await dismissAllAlerts();
-    } catch (err) {
-      console.error("[AlertsStrip] dismissAllAlerts failed", err);
+
+    const promises: Promise<void>[] = [];
+    if (guard.status === "ok") promises.push(dismissAllAlerts());
+    if (position.status === "ok") promises.push(dismissAllPositionAlerts());
+    if (coverage.status === "ok") promises.push(dismissAllCoverageStatusDrops());
+
+    const results = await Promise.allSettled(promises);
+    for (const r of results) {
+      if (r.status === "rejected") {
+        console.error("[AlertsStrip] dismiss-all partial failure", r.reason);
+      }
     }
     refetch();
   }
 
   return (
-    <section aria-labelledby="alerts-strip-heading" className="rounded-md border border-slate-200 bg-white shadow-sm">
+    <section
+      aria-labelledby="alerts-strip-heading"
+      className="rounded-md border border-slate-200 bg-white shadow-sm"
+    >
       <header className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
         <div className="flex items-center gap-2">
-          <h2 id="alerts-strip-heading" className="text-sm font-semibold text-slate-700">Guard rejections</h2>
-          {data.unseen_count > 0 ? (
+          <h2
+            id="alerts-strip-heading"
+            className="text-sm font-semibold text-slate-700"
+          >
+            Alerts
+          </h2>
+          {totalUnseen > 0 ? (
             <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
-              {data.unseen_count} new
+              {totalUnseen} new
             </span>
           ) : null}
         </div>
@@ -126,7 +428,7 @@ export function AlertsStrip(): JSX.Element | null {
               onClick={onDismissAll}
               className="rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 hover:bg-amber-100"
             >
-              Dismiss all ({data.unseen_count}) as acknowledged
+              Dismiss all ({totalUnseen}) as acknowledged
             </button>
             <Link
               to="/recommendations"
@@ -143,8 +445,8 @@ export function AlertsStrip(): JSX.Element | null {
         aria-labelledby="alerts-strip-heading"
         className="max-h-96 overflow-y-auto divide-y divide-slate-100"
       >
-        {data.rejections.map((row) => (
-          <RowView key={row.decision_id} row={row} lastSeen={lastSeen} />
+        {merged.map((row) => (
+          <RowView key={`${row.kind}-${rowId(row)}`} row={row} cursors={cursors} />
         ))}
       </div>
     </section>


### PR DESCRIPTION
## What

- `AlertsStrip` renders guard rejections + position alerts + coverage status drops in one timestamp-sorted DESC list.
- Three parallel GETs to existing `/alerts/*` endpoints; client-side merge into discriminated-union rows with per-kind pill badges.
- Unified header (`Alerts`, total-new badge) with fan-out `Promise.allSettled` POSTs for mark-all-read and dismiss-all.
- Per-feed overflow math (each backend feed caps at 500 independently).
- Dismiss-all skips POSTs to errored feeds — never ack invisible alerts.
- New API client fns + types for position + coverage.

## Why

Closes #399. Backend pieces shipped in #394 (guard), #401 (position), #402 (coverage) — this wires them into the dashboard.

## Test plan

- Vitest: merge ordering, per-kind rendering, click-through via instrument_id, hide policy (loading / all-err / all-empty / partial-err), unseen totals, per-feed overflow triggering dismiss-all, mark-all-read fan-out with MAX ids + partial-failure, dismiss-all skipping errored feeds + confirm-cancel.
- Backend gates + smoke gate green (full pytest 2325 passed).

## Called out

- Partial-failure is silent — matches existing silent-on-error pattern. Cursors are monotonic GREATEST so subsequent action retries are safe.
- Click-through uses `/instruments/:instrumentId` (existing legacy-id shim route) — same as current guard row pattern.
- Timestamp sort is presentation only — each feed's 500-row cap is backend-ordered by PK DESC (race-safe). Client merge preserves cursor math per-kind.
- Codex checkpoint 2: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)