### PR TITLE
fix(#327): frontend test speedup — vitest cap + SetupPage reducer + script split

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -179,10 +179,12 @@ If the PR touches `frontend/`, also run:
 
 ```bash
 pnpm --dir frontend typecheck
-pnpm --dir frontend test
+pnpm --dir frontend test:unit
 ```
 
 Both must pass.
+
+`test:unit` excludes `src/pages/SetupPage.test.tsx` (heavy integration). CI runs the full `test` script on push — integration tests still gate merge. Run `pnpm --dir frontend test` locally when explicitly debugging integration coverage.
 
 ## Required engineering skills
 

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -860,3 +860,20 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `classify_exception` used `isinstance(exc, (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout))` to route transport-layer failures to `SOURCE_DOWN`. The tuple missed siblings in the same `httpx.TransportError` hierarchy (`WriteTimeout`, `PoolTimeout`, `RemoteProtocolError`, `NetworkError`), which silently fell through to `INTERNAL_ERROR` and lost the self-heal signal for DB-or-network transient infrastructure.
 - Prevention: When routing on an exception hierarchy, prefer the closest common base class (`httpx.TransportError`, `psycopg.errors.IntegrityError`) to a hand-enumerated tuple of leaf types. Hand-enumerated tuples go stale as the library adds sibling subclasses; base-class dispatch is closed under inheritance. Exception: when the classifier needs to branch *within* a hierarchy (e.g. different HTTPStatusError codes), keep the narrower check but make the branch explicit. When adding a new route, grep the library's `errors.py` or public API to list all leaves — if they share a parent, use the parent.
 - Enforced in: this prevention log; `app/services/sync_orchestrator/exception_classifier.py` (now checks `httpx.TransportError` + `psycopg.errors.IntegrityError` base classes).
+
+---
+
+### Wrapper-lambda defeating useCallback memoisation
+
+- First seen in: #405 (#327 frontend subset).
+- Symptom: `SetupPage.tsx` passed `onComplete: () => completeWizard()` to `useSetupWizard`. Because `completeWizard`'s identity changes whenever `wizard.state.pendingOperator` changes, the inline arrow creates a new `onComplete` reference every render. The hook's `skipBroker`/`completeWizard` dispatchers list `onComplete` in useCallback deps and re-create on every state tick — defeating the memoisation entirely.
+- Prevention: When passing a callback to a hook option, never wrap it in an inline arrow if the inner function's identity can change. Use the ref-and-stable-wrapper pattern:
+  ```tsx
+  const completeRef = useRef<() => void>(() => {});
+  const onComplete = useCallback(() => completeRef.current(), []);
+  const wizard = useHook({ onComplete });
+  const completeWizard = useCallback(…);
+  useEffect(() => { completeRef.current = completeWizard; }, [completeWizard]);
+  ```
+  This lets the option identity stay fixed while the real implementation rebinds freely. Before pushing any hook-wiring change, check whether the options passed to custom hooks are memoised — an inline `() => foo()` is a red flag whenever `foo` has non-trivial deps.
+- Enforced in: this prevention log; `frontend/src/pages/SetupPage.tsx` (`completeRef` + stable `onComplete` pattern).

--- a/docs/superpowers/plans/2026-04-22-frontend-test-speedup.md
+++ b/docs/superpowers/plans/2026-04-22-frontend-test-speedup.md
@@ -1,0 +1,1224 @@
+# Frontend Test Speedup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the frontend items from #327 — extract `useSetupWizard` hook + pure `wizardReducer` from `SetupPage.tsx`, trim `SetupPage.test.tsx` from ~12 tests to 6 integration tests, pin vitest `forks` pool with `maxForks: 2`, add `test:unit`/`test:integration` script split, update CLAUDE.md pre-push.
+
+**Architecture:** Reducer owns wizard state machine (step + submit/error/validation flags + credRows). Derived mode (`create`/`repair`/`complete`) stays a pure selector over `credRows`. Hook wraps reducer with fetch dispatchers, takes `onComplete` callback (no `"done"` state — completion is side effect). Pure `classifyBrokerSaveError` maps `ApiError` status → fixed string. Component consumes hook + owns form-field `useState`.
+
+**Tech Stack:** React + TypeScript + Vite + Vitest ^2.1.8 + @testing-library/react.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-frontend-test-speedup.md`
+
+**Ticket:** #327 (frontend subset). Branch `fix/327b-frontend-test-speedup` exists; spec committed.
+
+---
+
+## File Structure
+
+| Path | Responsibility | Action |
+| --- | --- | --- |
+| `frontend/src/pages/setupErrorMessages.ts` | Shared `GENERIC_ERROR` constant | Create |
+| `frontend/src/pages/useSetupWizard.ts` | `wizardReducer` + `useSetupWizard` hook + `classifyBrokerSaveError` | Create |
+| `frontend/src/pages/useSetupWizard.test.ts` | Reducer unit tests + hook integration tests + classifier tests | Create |
+| `frontend/src/pages/SetupPage.tsx` | Consume hook; keep form-field `useState`; drop 13-state constellation | Modify |
+| `frontend/src/pages/SetupPage.test.tsx` | Trim to 6 integration tests | Modify |
+| `frontend/vitest.config.ts` | Pin forks pool + `maxForks: 2` | Modify |
+| `frontend/package.json` | Add `test:unit`, `test:integration` scripts | Modify |
+| `.claude/CLAUDE.md` | Pre-push block points to `test:unit` | Modify |
+
+---
+
+## Task 1: vitest config pin + script split
+
+Smallest change; ships independently. Unlocks speed for subsequent tasks.
+
+- [ ] **Step 1: Edit `frontend/vitest.config.ts`**
+
+Replace the existing `test` block with:
+
+```ts
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import viteConfig from "./vite.config";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: "jsdom",
+      globals: false,
+      setupFiles: ["./src/test/setup.ts"],
+      css: false,
+      include: ["src/**/*.{test,spec}.{ts,tsx}"],
+      // Pin pool + cap concurrency. Vitest v2 defaults to forks already;
+      // pinning makes the choice explicit so a future edit doesn't silently
+      // switch back to threads (where #399 hit a tinypool crash).
+      pool: "forks",
+      poolOptions: { forks: { maxForks: 2 } },
+    },
+  }),
+);
+```
+
+- [ ] **Step 2: Edit `frontend/package.json` scripts block**
+
+Replace:
+
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+With:
+
+```json
+"test": "vitest run",
+"test:unit": "vitest run --exclude src/pages/SetupPage.test.tsx",
+"test:integration": "vitest run src/pages/SetupPage.test.tsx",
+"test:watch": "vitest"
+```
+
+- [ ] **Step 3: Verify existing tests still green**
+
+```bash
+pnpm --dir frontend test
+```
+
+Expected: all current tests PASS (behaviour unchanged; pool pinning is a no-op on v2.1.8).
+
+- [ ] **Step 4: Verify `test:unit` excludes correctly**
+
+```bash
+pnpm --dir frontend test:unit
+```
+
+Expected: no tests from `src/pages/SetupPage.test.tsx` in the output. Faster total run.
+
+- [ ] **Step 5: Verify `test:integration` runs just SetupPage**
+
+```bash
+pnpm --dir frontend test:integration
+```
+
+Expected: only SetupPage tests. Handful of tests, focused run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/vitest.config.ts frontend/package.json
+git commit -m "build(#327): pin vitest forks pool + maxForks:2 + unit/integration script split"
+```
+
+---
+
+## Task 2: `setupErrorMessages.ts` (shared constant)
+
+Trivial extraction. Unblocks both hook + component + tests importing from a stable location.
+
+- [ ] **Step 1: Create the file**
+
+Create `frontend/src/pages/setupErrorMessages.ts`:
+
+```ts
+/**
+ * Shared error-message constants for the operator setup wizard.
+ *
+ * GENERIC_ERROR is the single string every operator-setup fetch failure
+ * maps to. Used by SetupPage.tsx + useSetupWizard.ts to preserve the
+ * #98 non-leaky-error contract: an unauthenticated attacker must not
+ * be able to distinguish failure modes of the /auth/setup endpoint.
+ */
+export const GENERIC_ERROR = "Setup unavailable or invalid token.";
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+pnpm --dir frontend typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/setupErrorMessages.ts
+git commit -m "refactor(#327): extract GENERIC_ERROR constant to setupErrorMessages module"
+```
+
+---
+
+## Task 3: `useSetupWizard.ts` — reducer + hook + classifier (TDD)
+
+TDD: reducer unit tests first (red), then reducer body, then classifier, then hook. Hook tests use `renderHook`.
+
+**Files:**
+
+- Create: `frontend/src/pages/useSetupWizard.ts`
+- Create: `frontend/src/pages/useSetupWizard.test.ts`
+
+- [ ] **Step 1: Write the reducer + classifier test file**
+
+Create `frontend/src/pages/useSetupWizard.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { ApiError } from "@/api/client";
+import type { BrokerCredentialView } from "@/api/brokerCredentials";
+import type { Operator } from "@/api/auth";
+import type { ValidateCredentialResponse } from "@/api/brokerCredentials";
+import { GENERIC_ERROR } from "@/pages/setupErrorMessages";
+
+import {
+  classifyBrokerSaveError,
+  initialWizardState,
+  wizardReducer,
+  type WizardState,
+} from "@/pages/useSetupWizard";
+
+const OP: Operator = { operator_id: "op-1", username: "test", display_name: "Test" };
+const ROW_API: BrokerCredentialView = {
+  credential_id: "c-1",
+  operator_id: "op-1",
+  provider: "etoro",
+  label: "api_key",
+  environment: "demo",
+  created_at: "2026-04-22T00:00:00Z",
+  revoked_at: null,
+};
+const ROW_USER: BrokerCredentialView = { ...ROW_API, credential_id: "c-2", label: "user_key" };
+const VAL_OK: ValidateCredentialResponse = { ok: true, detail: "fine" };
+
+describe("wizardReducer — OPERATOR", () => {
+  it("OPERATOR_SUBMIT_START: sets submitting, clears error", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, operatorError: "prev" },
+      { type: "OPERATOR_SUBMIT_START" },
+    );
+    expect(s.operatorSubmitting).toBe(true);
+    expect(s.operatorError).toBeNull();
+  });
+
+  it("OPERATOR_SUBMIT_SUCCESS: advances step to broker, stores operator", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, operatorSubmitting: true },
+      { type: "OPERATOR_SUBMIT_SUCCESS", operator: OP },
+    );
+    expect(s.step).toBe("broker");
+    expect(s.pendingOperator).toEqual(OP);
+    expect(s.operatorSubmitting).toBe(false);
+    expect(s.operatorError).toBeNull();
+  });
+
+  it("OPERATOR_SUBMIT_ERROR: sets error to GENERIC_ERROR exactly (no payload)", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, operatorSubmitting: true },
+      { type: "OPERATOR_SUBMIT_ERROR" },
+    );
+    expect(s.operatorError).toBe(GENERIC_ERROR);
+    expect(s.operatorSubmitting).toBe(false);
+    expect(s.step).toBe("operator");
+  });
+});
+
+describe("wizardReducer — BROKER creds load", () => {
+  it("BROKER_CREDS_LOAD_START: sets loading, clears prior error", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, credRowsError: "old" },
+      { type: "BROKER_CREDS_LOAD_START" },
+    );
+    expect(s.credRowsLoading).toBe(true);
+    expect(s.credRowsError).toBeNull();
+  });
+
+  it("BROKER_CREDS_LOAD_SUCCESS: stores rows, clears loading", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, credRowsLoading: true },
+      { type: "BROKER_CREDS_LOAD_SUCCESS", rows: [ROW_API] },
+    );
+    expect(s.credRows).toEqual([ROW_API]);
+    expect(s.credRowsLoading).toBe(false);
+  });
+
+  it("BROKER_CREDS_LOAD_ERROR: forces credRows=null for create-mode fallback", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, credRows: [ROW_API] },
+      { type: "BROKER_CREDS_LOAD_ERROR", error: "network" },
+    );
+    expect(s.credRows).toBeNull();
+    expect(s.credRowsError).toBe("network");
+    expect(s.credRowsLoading).toBe(false);
+  });
+});
+
+describe("wizardReducer — BROKER submit", () => {
+  it("BROKER_SUBMIT_START: sets submitting, clears prior error", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, brokerError: "old" },
+      { type: "BROKER_SUBMIT_START" },
+    );
+    expect(s.brokerSubmitting).toBe(true);
+    expect(s.brokerError).toBeNull();
+  });
+
+  it("BROKER_SUBMIT_SUCCESS: stores refreshed rows, clears submitting", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, brokerSubmitting: true },
+      { type: "BROKER_SUBMIT_SUCCESS", rows: [ROW_API, ROW_USER] },
+    );
+    expect(s.credRows).toEqual([ROW_API, ROW_USER]);
+    expect(s.brokerSubmitting).toBe(false);
+    expect(s.brokerError).toBeNull();
+  });
+
+  it("BROKER_SUBMIT_ERROR: stores error + rows for repair-mode derivation", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, brokerSubmitting: true },
+      { type: "BROKER_SUBMIT_ERROR", error: "Invalid API key or user key value.", rows: [ROW_API] },
+    );
+    expect(s.brokerError).toBe("Invalid API key or user key value.");
+    expect(s.credRows).toEqual([ROW_API]);
+    expect(s.brokerSubmitting).toBe(false);
+    expect(s.step).toBe("operator"); // no step advance
+  });
+
+  it("BROKER_SUBMIT_ERROR with rows=null leaves credRows=null (create-mode fallback)", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, brokerSubmitting: true },
+      { type: "BROKER_SUBMIT_ERROR", error: "Could not save credential.", rows: null },
+    );
+    expect(s.credRows).toBeNull();
+  });
+});
+
+describe("wizardReducer — VALIDATION", () => {
+  it("VALIDATION_START: clears BOTH prior validation result AND validationError", () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      validation: VAL_OK,
+      validationError: "old",
+    };
+    const s = wizardReducer(seeded, { type: "VALIDATION_START" });
+    expect(s.validating).toBe(true);
+    expect(s.validation).toBeNull();
+    expect(s.validationError).toBeNull();
+  });
+
+  it("VALIDATION_SUCCESS: stores result", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, validating: true },
+      { type: "VALIDATION_SUCCESS", result: VAL_OK },
+    );
+    expect(s.validation).toEqual(VAL_OK);
+    expect(s.validating).toBe(false);
+  });
+
+  it("VALIDATION_ERROR: stores error", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, validating: true },
+      { type: "VALIDATION_ERROR", error: "Could not reach the validation endpoint." },
+    );
+    expect(s.validationError).toBe("Could not reach the validation endpoint.");
+    expect(s.validating).toBe(false);
+  });
+});
+
+describe("classifyBrokerSaveError", () => {
+  it("409 ApiError → fixed 'A credential with that label already exists...'", () => {
+    expect(classifyBrokerSaveError(new ApiError(409, "conflict"))).toBe(
+      "A credential with that label already exists. Revoke it from Settings to replace.",
+    );
+  });
+  it("400 ApiError → 'Invalid API key or user key value.'", () => {
+    expect(classifyBrokerSaveError(new ApiError(400, "bad"))).toBe(
+      "Invalid API key or user key value.",
+    );
+  });
+  it("other ApiError → 'Could not save credential.'", () => {
+    expect(classifyBrokerSaveError(new ApiError(500, "boom"))).toBe("Could not save credential.");
+  });
+  it("non-ApiError → 'Could not save credential.'", () => {
+    expect(classifyBrokerSaveError(new Error("random"))).toBe("Could not save credential.");
+  });
+  it("non-Error → 'Could not save credential.'", () => {
+    expect(classifyBrokerSaveError("plain string")).toBe("Could not save credential.");
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect all FAIL (module missing)**
+
+```bash
+pnpm --dir frontend exec vitest run src/pages/useSetupWizard.test.ts
+```
+
+Expected: all tests FAIL with import errors (`useSetupWizard` module not found).
+
+- [ ] **Step 3: Create `useSetupWizard.ts` with reducer + classifier**
+
+Create `frontend/src/pages/useSetupWizard.ts`:
+
+```ts
+/**
+ * useSetupWizard — state machine + fetch dispatchers for SetupPage.
+ *
+ * Reducer covers wizard-step transitions and fetch-status flags. Form-field
+ * inputs (username, password, apiKey, userKey, setupToken) stay as
+ * component-level `useState` in SetupPage.tsx — field churn does not belong
+ * in the state machine.
+ *
+ * Wizard step is "operator" | "broker" only. Completion is a side effect
+ * (markAuthenticated + navigate) driven by the component via the
+ * `onComplete` callback option — there is no "done" state.
+ *
+ * Derived broker-mode (create/repair/complete) is a pure selector over
+ * state.credRows: callers invoke deriveCredentialSetMode(state.credRows)
+ * from @/lib/credentialSetMode. Never a reducer field.
+ */
+import { useCallback, useReducer } from "react";
+
+import type { Operator } from "@/api/auth";
+import { postSetup } from "@/api/auth";
+import type { BrokerCredentialView, ValidateCredentialResponse } from "@/api/brokerCredentials";
+import {
+  createBrokerCredential,
+  listBrokerCredentials,
+  validateBrokerCredential,
+} from "@/api/brokerCredentials";
+import { ApiError } from "@/api/client";
+import { runJob } from "@/api/jobs";
+import { deriveCredentialSetMode, ENVIRONMENT } from "@/lib/credentialSetMode";
+import { GENERIC_ERROR } from "@/pages/setupErrorMessages";
+
+// ---------------------------------------------------------------------------
+// State + actions
+// ---------------------------------------------------------------------------
+
+export type WizardStep = "operator" | "broker";
+
+export type WizardState = {
+  step: WizardStep;
+  pendingOperator: Operator | null;
+  operatorSubmitting: boolean;
+  operatorError: string | null;
+  credRows: BrokerCredentialView[] | null;
+  credRowsLoading: boolean;
+  credRowsError: string | null;
+  brokerSubmitting: boolean;
+  brokerError: string | null;
+  validating: boolean;
+  validation: ValidateCredentialResponse | null;
+  validationError: string | null;
+};
+
+export const initialWizardState: WizardState = {
+  step: "operator",
+  pendingOperator: null,
+  operatorSubmitting: false,
+  operatorError: null,
+  credRows: null,
+  credRowsLoading: false,
+  credRowsError: null,
+  brokerSubmitting: false,
+  brokerError: null,
+  validating: false,
+  validation: null,
+  validationError: null,
+};
+
+export type WizardAction =
+  | { type: "OPERATOR_SUBMIT_START" }
+  | { type: "OPERATOR_SUBMIT_SUCCESS"; operator: Operator }
+  | { type: "OPERATOR_SUBMIT_ERROR" }
+  | { type: "BROKER_CREDS_LOAD_START" }
+  | { type: "BROKER_CREDS_LOAD_SUCCESS"; rows: BrokerCredentialView[] }
+  | { type: "BROKER_CREDS_LOAD_ERROR"; error: string }
+  | { type: "BROKER_SUBMIT_START" }
+  | { type: "BROKER_SUBMIT_SUCCESS"; rows: BrokerCredentialView[] }
+  | { type: "BROKER_SUBMIT_ERROR"; error: string; rows: BrokerCredentialView[] | null }
+  | { type: "VALIDATION_START" }
+  | { type: "VALIDATION_SUCCESS"; result: ValidateCredentialResponse }
+  | { type: "VALIDATION_ERROR"; error: string };
+
+export function wizardReducer(state: WizardState, action: WizardAction): WizardState {
+  switch (action.type) {
+    case "OPERATOR_SUBMIT_START":
+      return { ...state, operatorSubmitting: true, operatorError: null };
+    case "OPERATOR_SUBMIT_SUCCESS":
+      return {
+        ...state,
+        step: "broker",
+        pendingOperator: action.operator,
+        operatorSubmitting: false,
+        operatorError: null,
+      };
+    case "OPERATOR_SUBMIT_ERROR":
+      // #98 non-leaky contract: never propagate err.message into state.
+      return { ...state, operatorSubmitting: false, operatorError: GENERIC_ERROR };
+    case "BROKER_CREDS_LOAD_START":
+      return { ...state, credRowsLoading: true, credRowsError: null };
+    case "BROKER_CREDS_LOAD_SUCCESS":
+      return { ...state, credRowsLoading: false, credRows: action.rows };
+    case "BROKER_CREDS_LOAD_ERROR":
+      // credRows=null → deriveCredentialSetMode returns 'create'.
+      return { ...state, credRowsLoading: false, credRowsError: action.error, credRows: null };
+    case "BROKER_SUBMIT_START":
+      return { ...state, brokerSubmitting: true, brokerError: null };
+    case "BROKER_SUBMIT_SUCCESS":
+      return {
+        ...state,
+        brokerSubmitting: false,
+        brokerError: null,
+        credRows: action.rows,
+      };
+    case "BROKER_SUBMIT_ERROR":
+      return {
+        ...state,
+        brokerSubmitting: false,
+        brokerError: action.error,
+        credRows: action.rows,
+      };
+    case "VALIDATION_START":
+      return { ...state, validating: true, validation: null, validationError: null };
+    case "VALIDATION_SUCCESS":
+      return { ...state, validating: false, validation: action.result, validationError: null };
+    case "VALIDATION_ERROR":
+      return { ...state, validating: false, validationError: action.error };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error classifier (pure; unit-tested)
+// ---------------------------------------------------------------------------
+
+export function classifyBrokerSaveError(err: unknown): string {
+  if (err instanceof ApiError && err.status === 409) {
+    return "A credential with that label already exists. Revoke it from Settings to replace.";
+  }
+  if (err instanceof ApiError && err.status === 400) {
+    return "Invalid API key or user key value.";
+  }
+  return "Could not save credential.";
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseSetupWizardOptions {
+  onComplete: () => void;
+}
+
+export interface OperatorSubmitForm {
+  username: string;
+  password: string;
+  setupToken: string;  // already trimmed by caller; empty string = omit
+}
+
+export interface BrokerSubmitForm {
+  apiKey: string;
+  userKey: string;
+}
+
+export type BrokerSubmitResult =
+  | { ok: true; recoveryPhrase: readonly string[] | null }
+  | { ok: false };
+
+export function useSetupWizard({ onComplete }: UseSetupWizardOptions) {
+  const [state, dispatch] = useReducer(wizardReducer, initialWizardState);
+
+  const loadCredentials = useCallback(async (): Promise<void> => {
+    dispatch({ type: "BROKER_CREDS_LOAD_START" });
+    try {
+      const rows = await listBrokerCredentials();
+      dispatch({ type: "BROKER_CREDS_LOAD_SUCCESS", rows });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to load credentials";
+      dispatch({ type: "BROKER_CREDS_LOAD_ERROR", error: msg });
+    }
+  }, []);
+
+  const submitOperator = useCallback(async (form: OperatorSubmitForm): Promise<boolean> => {
+    dispatch({ type: "OPERATOR_SUBMIT_START" });
+    try {
+      const { operator } = await postSetup(
+        form.username,
+        form.password,
+        form.setupToken.trim() === "" ? null : form.setupToken.trim(),
+      );
+      dispatch({ type: "OPERATOR_SUBMIT_SUCCESS", operator });
+      return true;
+    } catch {
+      // #98: never leak err.message. Reducer sets GENERIC_ERROR unconditionally.
+      dispatch({ type: "OPERATOR_SUBMIT_ERROR" });
+      return false;
+    }
+  }, []);
+
+  const submitBroker = useCallback(
+    async (form: BrokerSubmitForm): Promise<BrokerSubmitResult> => {
+      // Snapshot mode before save so we can decide whether to fire the
+      // first-run universe-sync bootstrap (only on first-time create).
+      const derived = deriveCredentialSetMode(state.credRows);
+      const mode = derived.mode;
+      const missingLabel = derived.missingLabel;
+      const wasCreate = mode === "create";
+
+      dispatch({ type: "BROKER_SUBMIT_START" });
+      try {
+        let phrase: readonly string[] | null = null;
+
+        // Save api_key if needed (Create OR Repair with api_key missing).
+        if (mode === "create" || (mode === "repair" && missingLabel === "api_key")) {
+          const response = await createBrokerCredential({
+            provider: "etoro",
+            label: "api_key",
+            environment: ENVIRONMENT,
+            secret: form.apiKey,
+          });
+          if (response.recovery_phrase != null && response.recovery_phrase.length > 0) {
+            phrase = response.recovery_phrase;
+          }
+        }
+
+        // Save user_key if needed (Create OR Repair with user_key missing).
+        if (mode === "create" || (mode === "repair" && missingLabel === "user_key")) {
+          await createBrokerCredential({
+            provider: "etoro",
+            label: "user_key",
+            environment: ENVIRONMENT,
+            secret: form.userKey,
+          });
+        }
+
+        const rows = await listBrokerCredentials();
+        dispatch({ type: "BROKER_SUBMIT_SUCCESS", rows });
+
+        // First-run bootstrap: fire-and-forget universe sync, only on
+        // first-time create (not Repair). Matches SetupPage.tsx:213-219.
+        if (wasCreate) {
+          void runJob("nightly_universe_sync").catch(() => {});
+        }
+
+        return { ok: true, recoveryPhrase: phrase };
+      } catch (err) {
+        const msg = classifyBrokerSaveError(err);
+        let rows: BrokerCredentialView[] | null = null;
+        try {
+          rows = await listBrokerCredentials();
+        } catch {
+          // swallow — deriveCredentialSetMode(null) falls back to 'create'
+        }
+        dispatch({ type: "BROKER_SUBMIT_ERROR", error: msg, rows });
+        return { ok: false };
+      }
+    },
+    [state.credRows],
+  );
+
+  const skipBroker = useCallback((): void => {
+    onComplete();
+  }, [onComplete]);
+
+  const completeWizard = useCallback((): void => {
+    onComplete();
+  }, [onComplete]);
+
+  const validateCredentials = useCallback(async (form: BrokerSubmitForm): Promise<void> => {
+    dispatch({ type: "VALIDATION_START" });
+    try {
+      const result = await validateBrokerCredential({
+        api_key: form.apiKey,
+        user_key: form.userKey,
+        environment: ENVIRONMENT,
+      });
+      dispatch({ type: "VALIDATION_SUCCESS", result });
+    } catch {
+      dispatch({
+        type: "VALIDATION_ERROR",
+        error: "Could not reach the validation endpoint.",
+      });
+    }
+  }, []);
+
+  return {
+    state,
+    loadCredentials,
+    submitOperator,
+    submitBroker,
+    skipBroker,
+    completeWizard,
+    validateCredentials,
+  };
+}
+```
+
+- [ ] **Step 4: Run — expect reducer + classifier tests PASS**
+
+```bash
+pnpm --dir frontend exec vitest run src/pages/useSetupWizard.test.ts
+```
+
+Expected: all reducer + classifier tests PASS.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+pnpm --dir frontend typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/useSetupWizard.ts frontend/src/pages/useSetupWizard.test.ts
+git commit -m "feat(#327): extract useSetupWizard hook + wizardReducer + classifyBrokerSaveError"
+```
+
+---
+
+## Task 4: Hook-level tests (`renderHook`)
+
+Append to `useSetupWizard.test.ts`. Cover the #98 GENERIC_ERROR contract + first-time-create runJob firing + partial-failure credRows fallback.
+
+- [ ] **Step 1: Append hook tests**
+
+Add to end of `frontend/src/pages/useSetupWizard.test.ts`:
+
+```ts
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+vi.mock("@/api/auth");
+vi.mock("@/api/brokerCredentials");
+vi.mock("@/api/jobs");
+
+describe("useSetupWizard (hook)", () => {
+  const onComplete = vi.fn();
+
+  it("submitOperator maps any fetch failure to GENERIC_ERROR (not err.message)", async () => {
+    const { postSetup } = await import("@/api/auth");
+    vi.mocked(postSetup).mockRejectedValue(new Error("Leaky backend detail"));
+
+    const { result } = renderHook(() => useSetupWizard({ onComplete }));
+    await act(async () => {
+      await result.current.submitOperator({ username: "u", password: "p", setupToken: "" });
+    });
+    expect(result.current.state.operatorError).toBe(GENERIC_ERROR);
+    expect(result.current.state.operatorError).not.toContain("Leaky backend detail");
+    expect(result.current.state.step).toBe("operator");
+  });
+
+  it("submitBroker in create-mode fires runJob(nightly_universe_sync) fire-and-forget", async () => {
+    const { createBrokerCredential, listBrokerCredentials } = await import("@/api/brokerCredentials");
+    const { runJob } = await import("@/api/jobs");
+    vi.mocked(createBrokerCredential).mockResolvedValue({
+      credential: ROW_API,
+      recovery_phrase: null,
+    });
+    vi.mocked(listBrokerCredentials).mockResolvedValue([ROW_API, ROW_USER]);
+    vi.mocked(runJob).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useSetupWizard({ onComplete }));
+    // state.credRows === null → mode === 'create' → wasCreate=true
+    await act(async () => {
+      await result.current.submitBroker({ apiKey: "a", userKey: "u" });
+    });
+    expect(runJob).toHaveBeenCalledWith("nightly_universe_sync");
+  });
+
+  it("submitBroker in repair-mode does NOT fire runJob", async () => {
+    const { createBrokerCredential, listBrokerCredentials } = await import("@/api/brokerCredentials");
+    const { runJob } = await import("@/api/jobs");
+    vi.mocked(createBrokerCredential).mockResolvedValue({
+      credential: ROW_USER,
+      recovery_phrase: null,
+    });
+    vi.mocked(listBrokerCredentials).mockResolvedValue([ROW_API, ROW_USER]);
+    vi.mocked(runJob).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useSetupWizard({ onComplete }));
+    // Seed credRows with api_key present → mode='repair', missingLabel='user_key'
+    await act(async () => {
+      await result.current.loadCredentials();
+    });
+    // Mock now returns the post-save list with BOTH keys for the next call.
+    vi.mocked(listBrokerCredentials).mockResolvedValue([ROW_API, ROW_USER]);
+    // Actually: we need credRows = [ROW_API] only. Override:
+    vi.mocked(listBrokerCredentials).mockResolvedValueOnce([ROW_API]);
+    await act(async () => {
+      await result.current.loadCredentials();
+    });
+    expect(result.current.state.credRows).toEqual([ROW_API]);
+
+    vi.mocked(listBrokerCredentials).mockResolvedValue([ROW_API, ROW_USER]);
+    await act(async () => {
+      await result.current.submitBroker({ apiKey: "a", userKey: "u" });
+    });
+    expect(runJob).not.toHaveBeenCalled();
+  });
+
+  it("submitBroker failure + listBrokerCredentials also failing leaves credRows=null", async () => {
+    const { createBrokerCredential, listBrokerCredentials } = await import("@/api/brokerCredentials");
+    vi.mocked(createBrokerCredential).mockRejectedValue(new ApiError(500, "boom"));
+    vi.mocked(listBrokerCredentials).mockRejectedValue(new Error("list boom"));
+
+    const { result } = renderHook(() => useSetupWizard({ onComplete }));
+    await act(async () => {
+      await result.current.submitBroker({ apiKey: "a", userKey: "u" });
+    });
+    expect(result.current.state.brokerError).toBe("Could not save credential.");
+    expect(result.current.state.credRows).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+pnpm --dir frontend exec vitest run src/pages/useSetupWizard.test.ts
+```
+
+Expected: all reducer + classifier + hook tests PASS (total ~20-25 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/useSetupWizard.test.ts
+git commit -m "test(#327): useSetupWizard hook integration tests — GENERIC_ERROR + runJob + partial-failure"
+```
+
+---
+
+## Task 5: Refactor `SetupPage.tsx` to consume the hook
+
+Preserve every user-visible behaviour. Component keeps form-field `useState`; hook owns wizard state.
+
+- [ ] **Step 1: Read the current `SetupPage.tsx` + identify preserved behaviours**
+
+```bash
+cat frontend/src/pages/SetupPage.tsx | head -250
+```
+
+Behaviours to preserve:
+- Phrase modal shown AFTER both credential saves durable (not mid-save).
+- `completeWizard()` runs `markAuthenticated(pendingOperator)` + `navigate("/", { replace: true })`.
+- Clear stale validation result when brokerApiKey / brokerUserKey / mode changes (existing `useEffect` at lines 117-120).
+- useEffect on mount that loads credentials when step transitions to "broker".
+
+- [ ] **Step 2: Replace the `SetupPage` body**
+
+Modify `frontend/src/pages/SetupPage.tsx`. Delete the 13 `useState` declarations + `refreshCredentials` callback + `completeWizard` function + `handleOperatorSubmit` + `handleTestConnection` + `handleBrokerSubmit` + `handleSkipBroker` functions. Replace with hook consumption.
+
+Keep:
+- `const GENERIC_ERROR` — change to `import { GENERIC_ERROR } from "@/pages/setupErrorMessages"`.
+- Form-field `useState` (username, password, setupToken, brokerApiKey, brokerUserKey) — stay local.
+- Phrase modal hook (`useRecoveryPhraseModal`).
+- Session + navigation `useEffect`.
+- Stale-validation clear `useEffect` (rewrite to watch `[brokerApiKey, brokerUserKey, mode]` — mode derived from `state.credRows`).
+
+New component body:
+
+```tsx
+import { useCallback, useEffect, useState } from "react";
+import type { FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useRecoveryPhraseModal } from "@/components/security/RecoveryPhraseModal";
+import { deriveCredentialSetMode } from "@/lib/credentialSetMode";
+import { useSession } from "@/lib/session";
+import { GENERIC_ERROR } from "@/pages/setupErrorMessages";
+import { useSetupWizard } from "@/pages/useSetupWizard";
+
+// ... existing imports for SetupLayout, ValidationSummary, etc.
+
+const MIN_PASSWORD_LEN = 12;
+const MIN_SECRET_LEN = 4;
+
+export function SetupPage(): JSX.Element {
+  const { status, markAuthenticated } = useSession();
+  const navigate = useNavigate();
+
+  const completeWizard = useCallback(() => {
+    if (wizard.state.pendingOperator !== null) {
+      markAuthenticated(wizard.state.pendingOperator);
+    }
+    navigate("/", { replace: true });
+    // NB: wizard is declared below; this callback is defined after useSetupWizard
+    //     in the actual file order (see Step 3 for complete block).
+  }, [markAuthenticated, navigate]);  // wizard.state read via closure
+
+  const wizard = useSetupWizard({ onComplete: completeWizard });
+
+  // Step-1 form state.
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [setupToken, setSetupToken] = useState("");
+
+  // Step-2 form state.
+  const [brokerApiKey, setBrokerApiKey] = useState("");
+  const [brokerUserKey, setBrokerUserKey] = useState("");
+
+  const derived = deriveCredentialSetMode(wizard.state.credRows);
+  const mode = derived.mode;
+  const missingLabel = derived.missingLabel;
+
+  // ... rest of SetupPage — use wizard.state.* for error/submitting/etc.,
+  //     call wizard.submitOperator / wizard.submitBroker / wizard.skipBroker /
+  //     wizard.validateCredentials / wizard.loadCredentials.
+}
+```
+
+Note the forward-reference issue: `completeWizard` needs `wizard.state.pendingOperator`, but `wizard` is initialized with `completeWizard` as a dep. Resolve by using a ref or restructuring:
+
+```tsx
+// Use ref so completeWizard can read the latest pendingOperator
+// without re-binding the callback (which would re-init the hook).
+const pendingOperatorRef = useRef<Operator | null>(null);
+
+const completeWizard = useCallback(() => {
+  if (pendingOperatorRef.current !== null) {
+    markAuthenticated(pendingOperatorRef.current);
+  }
+  navigate("/", { replace: true });
+}, [markAuthenticated, navigate]);
+
+const wizard = useSetupWizard({ onComplete: completeWizard });
+
+// Sync ref whenever the hook's state advances.
+useEffect(() => {
+  pendingOperatorRef.current = wizard.state.pendingOperator;
+}, [wizard.state.pendingOperator]);
+```
+
+Add `import { useRef } from "react"` at the top.
+
+- [ ] **Step 3: Write the full refactored `SetupPage.tsx`**
+
+The new file is 250-300 lines (down from 450). Structure:
+
+```tsx
+// imports
+// constants (MIN_PASSWORD_LEN, MIN_SECRET_LEN)
+// SetupPage() {
+//   session + navigate
+//   pendingOperatorRef + completeWizard callback (via ref to avoid dep cycle)
+//   wizard = useSetupWizard({ onComplete: completeWizard })
+//   form-field state (username, password, setupToken, brokerApiKey, brokerUserKey)
+//   derived = deriveCredentialSetMode(wizard.state.credRows)
+//   phraseModal = useRecoveryPhraseModal({ onClose: completeWizard })
+//   session-redirect useEffect
+//   load-creds-on-step-broker useEffect
+//   stale-validation-clear useEffect (watch brokerApiKey, brokerUserKey, mode)
+//   handleOperatorSubmit: wraps wizard.submitOperator
+//   handleTestConnection: wraps wizard.validateCredentials
+//   handleBrokerSubmit: wraps wizard.submitBroker, opens modal or completes
+//   handleSkipBroker: confirm-dialog gate, then wizard.skipBroker()
+//   render — same JSX, read from wizard.state.* and form-field state
+// }
+```
+
+Complete refactored body (follows the structure above, preserves exact JSX + behaviours; reads state from `wizard.state.*` instead of local `useState`s). Exact line-by-line diff is long but mechanical.
+
+Key behavioural mappings:
+
+| Before (local state) | After (hook) |
+| --- | --- |
+| `step` | `wizard.state.step` |
+| `pendingOperator` | `wizard.state.pendingOperator` |
+| `submitting` | `wizard.state.operatorSubmitting` |
+| `error` | `wizard.state.operatorError` |
+| `brokerSubmitting` | `wizard.state.brokerSubmitting` |
+| `brokerError` | `wizard.state.brokerError` |
+| `credRows` | `wizard.state.credRows` |
+| `validating` | `wizard.state.validating` |
+| `validationResult` | `wizard.state.validation` |
+| `validationError` | `wizard.state.validationError` |
+| `setError(GENERIC_ERROR)` (in catch) | `wizard.submitOperator(...)` — reducer does it |
+| `refreshCredentials()` | `wizard.loadCredentials()` |
+| `completeWizard()` in submit success | `wizard.submitBroker(...)` success path returns `recoveryPhrase`; if null, call `completeWizard()` ourselves; if non-null, open modal (modal's onClose fires completeWizard). |
+
+`handleBrokerSubmit`:
+
+```tsx
+async function handleBrokerSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+  e.preventDefault();
+  const result = await wizard.submitBroker({ apiKey: brokerApiKey, userKey: brokerUserKey });
+  if (!result.ok) return;
+  setBrokerApiKey("");
+  setBrokerUserKey("");
+  if (result.recoveryPhrase !== null) {
+    phraseModal.open(result.recoveryPhrase);
+    return;
+  }
+  completeWizard();
+}
+```
+
+`handleSkipBroker` keeps its confirm-dialog gate if the current file has one; if it's just `completeWizard()`, replace with `wizard.skipBroker()`.
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+pnpm --dir frontend typecheck
+```
+
+Expected: PASS. Fix any type errors from prop drift.
+
+- [ ] **Step 5: Run existing SetupPage tests — expect most to PASS (some will fail until Task 6 trim)**
+
+```bash
+pnpm --dir frontend exec vitest run src/pages/SetupPage.test.tsx
+```
+
+Expected: the 6 tests we're keeping should PASS (the refactor preserves every user-visible behaviour). The ~9 tests we're dropping may still be in the file — they may pass or fail depending on what they asserted. That's fine; Task 6 trims them.
+
+Note: if any kept test fails, read the failure + fix the refactor. The refactor must preserve behaviour exactly. Common pitfalls:
+- `markAuthenticated` called twice (once from completeWizard, once from phraseModal.onClose) — must fire exactly once. The ref pattern keeps a single call.
+- `wizard.state.credRows` being null on first render → mode='create' → render branch consistent.
+
+- [ ] **Step 6: Full frontend suite**
+
+```bash
+pnpm --dir frontend test
+```
+
+Expected: full suite green. If any test outside SetupPage.test.tsx fails, the refactor drifted — fix before proceeding.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/SetupPage.tsx
+git commit -m "refactor(#327): SetupPage consumes useSetupWizard hook"
+```
+
+---
+
+## Task 6: Trim `SetupPage.test.tsx` to 6 integration tests
+
+Keep: happy-path save, happy-path skip, confirm-cancel, phrase-modal, repair-mode, already-complete. Drop the other ~6.
+
+- [ ] **Step 1: Read current test file**
+
+```bash
+cat frontend/src/pages/SetupPage.test.tsx
+```
+
+Identify the ~12 tests. Decide which are kept.
+
+Keep (6):
+1. `"Skip for now" completes the wizard with no broker call` (happy-path skip).
+2. `creates both api_key and user_key rows on save` (happy-path save — include the universe-sync-fires assertion from the bootstrap-trigger cluster).
+3. `routes Cancel through confirm-cancel gate, then 'Close anyway' completes wizard` (confirm-cancel).
+4. `opens the phrase modal when the first create response carries a recovery_phrase` + `completes the wizard after the operator passes the challenge` — merge into one test that covers the full phrase-modal branch.
+5. `enters Repair mode and keeps Skip available when second save fails` (repair-mode; adjust assertions to the new hook shape).
+6. A new test: `already-complete branch renders Continue + clicking it completes wizard` (add if not present; uses seeded `listBrokerCredentials` response with both api_key + user_key).
+
+Drop (6-7):
+- `surfaces the generic error and stays on step 1 when /auth/setup fails` (covered by hook test).
+- `advances to step 2 on success WITHOUT calling markAuthenticated yet` (covered by happy-path save).
+- `fires nightly_universe_sync after both credentials are saved` → merged into happy-path save.
+- `does not fire universe sync when operator skips credentials` → merged into happy-path skip.
+- `swallows universe sync errors silently` → covered by hook test (fire-and-forget pattern).
+- `completes wizard with NO phrase modal when response has no recovery_phrase` → covered by happy-path save (default mock has no phrase).
+
+- [ ] **Step 2: Rewrite `SetupPage.test.tsx`**
+
+New file has 6 top-level `it(...)` blocks grouped by `describe("SetupPage — integration")`. Shared mock setup at the top. Each test uses `render(<SetupPage />)` + `fireEvent` / `userEvent`. Mocks are the same fetchers the hook uses (`postSetup`, `createBrokerCredential`, `listBrokerCredentials`, `validateBrokerCredential`, `runJob`). The component's `completeWizard` still fires `markAuthenticated` + `navigate`, so tests assert against those mocks.
+
+Exact rewrite is mechanical — preserve fixture helpers, update mock-import list to include `runJob` + `listBrokerCredentials`. Hard-code the 6 tests per the list above; delete the rest. File size drops from ~412 lines to ~200.
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm --dir frontend test:integration
+```
+
+Expected: 6 tests PASS.
+
+- [ ] **Step 4: Full frontend suite**
+
+```bash
+pnpm --dir frontend test
+```
+
+Expected: full suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/SetupPage.test.tsx
+git commit -m "test(#327): trim SetupPage.test.tsx to 6 integration tests"
+```
+
+---
+
+## Task 7: CLAUDE.md pre-push block update
+
+- [ ] **Step 1: Read current pre-push block**
+
+```bash
+grep -n "pnpm --dir frontend" .claude/CLAUDE.md
+```
+
+Find the block with `pnpm --dir frontend typecheck` + `pnpm --dir frontend test`.
+
+- [ ] **Step 2: Edit**
+
+Replace `pnpm --dir frontend test` with `pnpm --dir frontend test:unit` inside the `If the PR touches frontend/, also run:` block. Add a note below:
+
+```markdown
+If the PR touches `frontend/`, also run:
+
+```bash
+pnpm --dir frontend typecheck
+pnpm --dir frontend test:unit
+```
+
+Both must pass.
+
+**Note:** `test:unit` excludes heavy integration tests under `src/pages/SetupPage.test.tsx`. CI runs the full `test` script on push — integration tests still gate merge. Run `pnpm --dir frontend test` locally when explicitly debugging integration coverage.
+```
+
+- [ ] **Step 3: Verify**
+
+Render the file in a markdown preview (or just eyeball the diff). Confirm the code-fence + note structure match surrounding sections.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/CLAUDE.md
+git commit -m "docs(#327): CLAUDE.md pre-push points to test:unit (CI still runs full test)"
+```
+
+---
+
+## Task 8: Pre-push gates + Codex checkpoint 2 + push + PR
+
+- [ ] **Step 1: Backend gates**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+All four must pass. (Backend unchanged by this PR; must still be green.)
+
+- [ ] **Step 2: Frontend gates**
+
+```bash
+pnpm --dir frontend typecheck
+pnpm --dir frontend test
+```
+
+Both must pass.
+
+- [ ] **Step 3: Pre-push fast path sanity**
+
+```bash
+pnpm --dir frontend test:unit
+```
+
+Expected: fewer tests than `test`; green; noticeably faster.
+
+- [ ] **Step 4: Codex checkpoint 2 — diff review**
+
+```bash
+git diff main...HEAD > /tmp/pr327b_diff.txt
+codex.cmd exec "Checkpoint 2 diff review for PR (#327 frontend subset). Diff at /tmp/pr327b_diff.txt. Spec at d:/Repos/eBull/docs/superpowers/specs/2026-04-22-frontend-test-speedup.md.
+
+Focus: useSetupWizard hook preserves SetupPage.tsx behavioural contracts (GENERIC_ERROR mapping, fixed broker-save error strings, runJob fire-and-forget on first-time create only, credRows=null fallback on list error, phrase-modal-before-complete ordering). SetupPage.tsx refactor preserves JSX + ref-based completeWizard pattern (no duplicate markAuthenticated). Integration test trim preserves all user-visible coverage. Reply terse."
+```
+
+Fix any blocking findings before pushing.
+
+- [ ] **Step 5: Push + open PR**
+
+```bash
+git push -u origin fix/327b-frontend-test-speedup
+gh pr create --title "fix(#327): frontend test speedup — vitest cap + SetupPage reducer + script split" --body "$(cat <<'EOF'
+## What
+
+- `vitest.config.ts` — pin `pool: "forks"` + `maxForks: 2`. v2 defaults to forks already; pinning prevents silent regression + the cap halves sustained CPU.
+- New `frontend/src/pages/setupErrorMessages.ts` — shared `GENERIC_ERROR` constant.
+- New `frontend/src/pages/useSetupWizard.ts` — pure `wizardReducer`, `classifyBrokerSaveError` helper, `useSetupWizard` hook. Extracts wizard state machine from `SetupPage.tsx`.
+- New `frontend/src/pages/useSetupWizard.test.ts` — reducer unit tests + classifier unit tests + `renderHook` integration tests.
+- `SetupPage.tsx` consumes the hook; keeps form-field `useState` local; `completeWizard` uses a ref to avoid dep-cycle on the hook's `onComplete` option.
+- `SetupPage.test.tsx` trimmed to 6 integration tests (happy-path save, happy-path skip, confirm-cancel, phrase-modal, repair-mode, already-complete).
+- `package.json` — `test:unit` / `test:integration` / `test` script split.
+- `.claude/CLAUDE.md` pre-push block points to `test:unit`; CI still runs full `test`.
+
+## Why
+
+Closes frontend items from #327. SetupPage had ~12 tests at 1000-1500ms each because every transition did full render + fetch mock. Pure reducer covers state transitions at <50ms total; hook-level `renderHook` covers fetch wiring; 6 kept integration tests cover irreducible multi-step UX.
+
+Backend pytest-xdist from #327 deferred to follow-up (needs `ebull_test` audit).
+
+## Test plan
+
+- Reducer + classifier unit tests: ~20 PASS <500ms.
+- Hook integration tests: 4 PASS.
+- SetupPage integration tests: 6 PASS.
+- Full suite green (frontend + backend).
+- Local `test:unit` noticeably faster than `test` (excludes heavy file).
+
+## Called out
+
+- #98 non-leaky-error contract preserved: `OPERATOR_SUBMIT_ERROR` carries no payload; reducer hard-codes `GENERIC_ERROR`.
+- Derived broker-mode stays a pure selector over `credRows` — not a reducer field.
+- `completeWizard` uses `pendingOperatorRef` to avoid re-binding the hook's `onComplete` on every state change.
+- CI runs full `test`; pre-push local runs `test:unit`.
+- pytest-xdist deferred per prior Codex ckpt 1 finding on #404 predecessor (`ebull_test` audit + collection-bootstrap idempotency).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Poll review + CI**
+
+```bash
+gh pr checks --watch
+gh pr view --comments
+```
+
+Resolve every comment as FIXED / DEFERRED / REBUTTED. Merge after APPROVE on latest commit + CI green.
+
+---
+
+## Self-review
+
+**1. Spec coverage:**
+
+- Vitest pin + cap → Task 1.
+- Script split → Task 1.
+- `setupErrorMessages.ts` → Task 2.
+- Reducer + hook + classifier + unit tests → Task 3.
+- Hook integration tests (`renderHook`) → Task 4.
+- SetupPage refactor to consume hook → Task 5.
+- Integration test trim to 6 → Task 6.
+- CLAUDE.md pre-push update → Task 7.
+- Gates + Codex + PR → Task 8.
+
+All spec sections covered.
+
+**2. Placeholder scan:** no "TBD", "TODO", "implement later". Code steps show concrete diffs; test steps show concrete test bodies.
+
+**3. Type consistency:**
+
+- `WizardStep = "operator" | "broker"` — no `"done"` — consistent everywhere.
+- `OperatorSubmitForm`, `BrokerSubmitForm`, `BrokerSubmitResult` shapes stable across hook sig + SetupPage consumer + tests.
+- `classifyBrokerSaveError` signature: `(unknown) → string`. Matches test + hook.
+- `onComplete: () => void` callback shape consistent.
+- `deriveCredentialSetMode(state.credRows)` — pure selector, matches `@/lib/credentialSetMode`.
+- `pendingOperatorRef.current` pattern avoids re-binding `onComplete` on every state change.
+
+**4. Known risks:**
+
+- Task 5 refactor is the largest change (~300 lines modified). The ref-based `completeWizard` pattern needs care to avoid double-firing `markAuthenticated` — covered by the existing test `'Close anyway' completes wizard` which asserts call count.
+- Vitest v2.1.8 supports `maxForks` per docs but any prior config override in inherited `vite.config.ts` could conflict. Task 1 step 3 runs full suite to catch any issue.

--- a/docs/superpowers/specs/2026-04-22-frontend-test-speedup.md
+++ b/docs/superpowers/specs/2026-04-22-frontend-test-speedup.md
@@ -1,0 +1,576 @@
+# Frontend test speedup — design spec
+
+**Ticket:** #327 (remaining frontend subset — vitest cap, SetupPage refactor, test-script split. Backend pytest-xdist deferred to separate PR with DB-race audit.)
+
+## Problem
+
+From #327 ticket body:
+
+> Frontend is the CPU hog (parallel jsdom workers pin every core). SetupPage wizard tests alone are 9+ tests at 1000–1500ms each. Operator reports fan spin during runs.
+
+Plus an observed reliability issue: default vitest threads pool crashed with `Maximum call stack size exceeded` during #399 execution. Forks pool avoids it.
+
+## Decisions (v3 — after Codex ckpt 1 round 2)
+
+Codex round 1 surfaced 5 issues; v2 addressed them but round 2 found 3 more SetupPage-code mismatches. This v3 matches the live state machine exactly.
+
+| # | Decision | Reason |
+| --- | --- | --- |
+| 1 | **Pin `pool: "forks"` + `maxForks: 2` in `vitest.config.ts`.** | Vitest v2 already defaults to forks per v2.1.8 migration guide; the real change is the worker cap + making the pool choice explicit so a future `vitest.config.ts` edit doesn't silently switch back to threads (where #399 hit the crash). |
+| 2 | **Extract `useSetupWizard` hook + pure `wizardReducer` from `SetupPage.tsx`.** Reducer covers wizard state machine + `credRows`; form-field inputs stay as component-level `useState`. Derived broker-mode (`create` / `repair` / `complete`) comes from `deriveCredentialSetMode(credRows)` — NOT a reducer field. | State-machine transitions are what reducer tests can cover cheaply. Form-field churn doesn't belong in the state machine. `deriveCredentialSetMode` is already a pure function in `frontend/src/lib/credentialSetMode.ts`; keeping it as a selector over `credRows` preserves the single-source-of-truth pattern. |
+| 3 | **Hook method dispatchers preserve existing UX/security contracts exactly.** Setup-operator error path dispatches `GENERIC_ERROR` (constant) — never `err.message`. Preserves #98 non-leaky error contract. | Codex finding 3: my v1 sample hook drifted from `SetupPage.tsx:59,141` — setup fetch errors must ALL map to `"Setup unavailable or invalid token."` so auth failure modes are not distinguishable to an unauthenticated attacker. |
+| 4 | **Keep 6 integration tests** (down from ~12): happy-path save, happy-path skip, confirm-cancel, phrase-modal, repair-mode, already-complete. | Codex finding 1 + 2: repair-mode + already-complete are distinct behaviours; happy-path save + skip are distinct paths (skip has no broker call). Integration tests cover fetch wiring + multi-step UX that reducer tests cannot. |
+| 5 | **Hook-level integration test covers the GENERIC_ERROR contract** via `renderHook(useSetupWizard).submitOperator()` against a mocked rejecting fetch. | Codex finding 3: this is the #98 contract; cannot drop it. `renderHook` is cheap — no full SetupPage render, just the hook. |
+| 6 | **Script split: `test` (both) / `test:unit` (exclude SetupPage.test.tsx) / `test:integration` (SetupPage only).** | Ticket §3. Pre-push local runs `test:unit`; CI runs `test` (full). |
+| 7 | **Update `.claude/CLAUDE.md` pre-push block.** `pnpm --dir frontend test` → `pnpm --dir frontend test:unit`. | Fast local loop without losing CI coverage. |
+| 8 | **Backend pytest-xdist deferred.** | Codex ckpt 1 on #404 flagged that many tests touch `ebull_test` without the `ebull_test_conn` fixture + collection-bootstrap races under multi-worker xdist. Needs its own audit PR. |
+
+## Architecture
+
+Frontend-only PR. Seven surfaces touched:
+
+| Path | Responsibility | Action |
+| --- | --- | --- |
+| `frontend/vitest.config.ts` | Vitest config | Modify (pin pool + `maxForks: 2`) |
+| `frontend/package.json` | Test scripts | Modify (add `test:unit`, `test:integration`) |
+| `frontend/src/pages/useSetupWizard.ts` | New — `wizardReducer` + `useSetupWizard` hook | Create |
+| `frontend/src/pages/useSetupWizard.test.ts` | New — reducer unit tests + hook-integration tests | Create |
+| `frontend/src/pages/SetupPage.tsx` | Consume hook; drop the 13-`useState` constellation | Modify |
+| `frontend/src/pages/SetupPage.test.tsx` | Trim to 6 integration tests | Modify |
+| `.claude/CLAUDE.md` | Pre-push block points to `test:unit` | Modify |
+
+## `useSetupWizard` — reducer + hook (v2)
+
+### State
+
+```ts
+// frontend/src/pages/useSetupWizard.ts
+import { useReducer, useCallback } from "react";
+// imports: Operator, BrokerCredentialView, ValidateCredentialResponse types + api fns
+
+// Matches SetupPage.tsx: no "done" step. Completion is a side effect
+// (markAuthenticated + navigate("/") ) driven by the component via the
+// hook's onComplete callback, not a reducer state.
+export type WizardStep = "operator" | "broker";
+
+export type WizardState = {
+  step: WizardStep;
+  pendingOperator: Operator | null;
+  operatorSubmitting: boolean;
+  operatorError: string | null;
+  // Step-2 fetch + submit state
+  credRows: BrokerCredentialView[] | null;
+  credRowsLoading: boolean;
+  credRowsError: string | null;
+  brokerSubmitting: boolean;
+  brokerError: string | null;
+  // Validation state
+  validating: boolean;
+  validation: ValidateCredentialResponse | null;
+  validationError: string | null;
+};
+
+export const initialWizardState: WizardState = {
+  step: "operator",
+  pendingOperator: null,
+  operatorSubmitting: false,
+  operatorError: null,
+  credRows: null,
+  credRowsLoading: false,
+  credRowsError: null,
+  brokerSubmitting: false,
+  brokerError: null,
+  validating: false,
+  validation: null,
+  validationError: null,
+};
+```
+
+Note: **derived broker-mode (`create` / `repair` / `complete`) is NOT a reducer field.** Components + tests call `deriveCredentialSetMode(state.credRows)` — the existing pure function — to get the mode. Single source of truth stays `credRows`.
+
+### Actions
+
+```ts
+export type WizardAction =
+  | { type: "OPERATOR_SUBMIT_START" }
+  | { type: "OPERATOR_SUBMIT_SUCCESS"; operator: Operator }
+  | { type: "OPERATOR_SUBMIT_ERROR" }               // no payload — always GENERIC_ERROR
+  | { type: "BROKER_CREDS_LOAD_START" }
+  | { type: "BROKER_CREDS_LOAD_SUCCESS"; rows: BrokerCredentialView[] }
+  | { type: "BROKER_CREDS_LOAD_ERROR"; error: string }   // also sets credRows=null so deriveCredentialSetMode() falls back to 'create'
+  | { type: "BROKER_SUBMIT_START" }
+  | { type: "BROKER_SUBMIT_SUCCESS"; rows: BrokerCredentialView[] }  // carries refreshed rows
+  | { type: "BROKER_SUBMIT_ERROR"; error: string; rows: BrokerCredentialView[] | null }  // error already classified to fixed string by classifyBrokerSaveError()
+  | { type: "VALIDATION_START" }
+  | { type: "VALIDATION_SUCCESS"; result: ValidateCredentialResponse }
+  | { type: "VALIDATION_ERROR"; error: string };
+
+// NOTE: no BROKER_SKIP or WIZARD_COMPLETE actions. Both are side effects
+// (component invokes onComplete callback → markAuthenticated + navigate).
+// Matches SetupPage.tsx completeWizard() at lines 122-127.
+```
+
+Key design points:
+
+- `OPERATOR_SUBMIT_ERROR` carries no payload. Reducer unconditionally sets `operatorError = GENERIC_ERROR`. Preserves the #98 non-leaky contract — no error message can leak from an action into state.
+- `BROKER_SUBMIT_ERROR.error` is already a fixed classified string ("A credential with that label already exists..." / "Invalid API key or user key value." / "Could not save credential."). Classification happens in the pure helper `classifyBrokerSaveError(err)` inside `useSetupWizard.ts`. The helper is unit-tested independently; the reducer just stores whatever string the hook passes.
+- `BROKER_SUBMIT_ERROR` carries `rows` so the component's next render has the re-fetched credential state to derive `repair` mode. Pairs with `listBrokerCredentials()` inside the hook's `submitBroker` catch block.
+- `BROKER_SUBMIT_SUCCESS` also carries `rows` — refreshed post-save so the UI can flip to `complete` mode immediately.
+- `BROKER_CREDS_LOAD_ERROR` also sets `credRows: null` so `deriveCredentialSetMode(null)` returns `create` mode — matches the fallback at `SetupPage.tsx:97`.
+- `VALIDATION_START` clears both `validation` AND `validationError` — matches `SetupPage.tsx:160-162` which clears result before the request.
+
+### Reducer
+
+```ts
+import { GENERIC_ERROR } from "@/pages/setupErrorMessages"; // move constant to shared module
+
+export function wizardReducer(state: WizardState, action: WizardAction): WizardState {
+  switch (action.type) {
+    case "OPERATOR_SUBMIT_START":
+      return { ...state, operatorSubmitting: true, operatorError: null };
+    case "OPERATOR_SUBMIT_SUCCESS":
+      return {
+        ...state,
+        step: "broker",
+        pendingOperator: action.operator,
+        operatorSubmitting: false,
+        operatorError: null,
+      };
+    case "OPERATOR_SUBMIT_ERROR":
+      return { ...state, operatorSubmitting: false, operatorError: GENERIC_ERROR };
+    case "BROKER_CREDS_LOAD_START":
+      return { ...state, credRowsLoading: true, credRowsError: null };
+    case "BROKER_CREDS_LOAD_SUCCESS":
+      return { ...state, credRowsLoading: false, credRows: action.rows };
+    case "BROKER_CREDS_LOAD_ERROR":
+      // credRows=null → deriveCredentialSetMode returns 'create'. Matches
+      // the current SetupPage fallback when list-creds fetch fails.
+      return { ...state, credRowsLoading: false, credRowsError: action.error, credRows: null };
+    case "BROKER_SUBMIT_START":
+      return { ...state, brokerSubmitting: true, brokerError: null };
+    case "BROKER_SUBMIT_SUCCESS":
+      return {
+        ...state,
+        brokerSubmitting: false,
+        brokerError: null,
+        credRows: action.rows,
+      };
+    case "BROKER_SUBMIT_ERROR":
+      return {
+        ...state,
+        brokerSubmitting: false,
+        brokerError: action.error,
+        credRows: action.rows,
+      };
+    case "VALIDATION_START":
+      // Clear prior result too — matches SetupPage.tsx:160-162 where
+      // both setValidationResult(null) and setValidationError(null) fire
+      // before the request.
+      return { ...state, validating: true, validation: null, validationError: null };
+    case "VALIDATION_SUCCESS":
+      return { ...state, validating: false, validation: action.result, validationError: null };
+    case "VALIDATION_ERROR":
+      return { ...state, validating: false, validationError: action.error };
+  }
+}
+```
+
+### Broker save error classifier (pure helper)
+
+```ts
+// frontend/src/pages/useSetupWizard.ts
+import { ApiError } from "@/api/client";
+
+export function classifyBrokerSaveError(err: unknown): string {
+  if (err instanceof ApiError && err.status === 409) {
+    return "A credential with that label already exists. Revoke it from Settings to replace.";
+  }
+  if (err instanceof ApiError && err.status === 400) {
+    return "Invalid API key or user key value.";
+  }
+  return "Could not save credential.";
+}
+```
+
+Unit-tested independently (fast, no mocks). Matches the mapping in `SetupPage.tsx:229-236`.
+
+### Hook
+
+```ts
+export interface UseSetupWizardOptions {
+  onComplete: () => void;   // markAuthenticated + navigate side effect
+}
+
+export function useSetupWizard({ onComplete }: UseSetupWizardOptions) {
+  const [state, dispatch] = useReducer(wizardReducer, initialWizardState);
+
+  const loadCredentials = useCallback(async (): Promise<void> => {
+    dispatch({ type: "BROKER_CREDS_LOAD_START" });
+    try {
+      const rows = await listBrokerCredentials();
+      dispatch({ type: "BROKER_CREDS_LOAD_SUCCESS", rows });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to load credentials";
+      dispatch({ type: "BROKER_CREDS_LOAD_ERROR", error: msg });
+    }
+  }, []);
+
+  const submitOperator = useCallback(async (form: OperatorForm): Promise<boolean> => {
+    dispatch({ type: "OPERATOR_SUBMIT_START" });
+    try {
+      const { operator } = await postSetup(form.username, form.password, form.setupToken);
+      dispatch({ type: "OPERATOR_SUBMIT_SUCCESS", operator });
+      return true;
+    } catch {
+      // #98: never leak err.message. Reducer sets GENERIC_ERROR unconditionally.
+      dispatch({ type: "OPERATOR_SUBMIT_ERROR" });
+      return false;
+    }
+  }, []);
+
+  // Submit one broker credential. Returns an object describing what to do
+  // next. Mirrors SetupPage.tsx's inner handleSaveOne / handleBrokerSubmit
+  // split. Only called by the component's top-level submit handler.
+  const submitBroker = useCallback(
+    async (form: BrokerForm): Promise<{ ok: true; recoveryPhrase: readonly string[] | null } | { ok: false }> => {
+      // Snapshot the pre-save mode for the "only fire universe sync on
+      // first-time create" branch below.
+      const wasCreate = deriveCredentialSetMode(state.credRows).mode === "create";
+
+      dispatch({ type: "BROKER_SUBMIT_START" });
+      try {
+        const result = await saveBrokerCredentials(form);  // may return recovery_phrase on first save
+        const rows = await listBrokerCredentials();
+        dispatch({ type: "BROKER_SUBMIT_SUCCESS", rows });
+
+        // First-run bootstrap (matches SetupPage.tsx:213-219). Fire-and-forget.
+        if (wasCreate) {
+          void runJob("nightly_universe_sync").catch(() => {});
+        }
+        return { ok: true, recoveryPhrase: result.recovery_phrase ?? null };
+      } catch (err) {
+        const msg = classifyBrokerSaveError(err);
+        let rows: BrokerCredentialView[] | null = null;
+        try {
+          rows = await listBrokerCredentials();
+        } catch {
+          // swallow — deriveCredentialSetMode(null) falls back to 'create'
+        }
+        dispatch({ type: "BROKER_SUBMIT_ERROR", error: msg, rows });
+        return { ok: false };
+      }
+    },
+    [state.credRows],
+  );
+
+  // Side-effect callbacks — no state mutation; caller invokes onComplete.
+  const skipBroker = useCallback(() => onComplete(), [onComplete]);
+  const completeWizard = useCallback(() => onComplete(), [onComplete]);
+
+  const validateCredentials = useCallback(async (form: BrokerForm): Promise<void> => {
+    dispatch({ type: "VALIDATION_START" });
+    try {
+      const result = await validateBrokerCredential({
+        api_key: form.apiKey,
+        user_key: form.userKey,
+        environment: ENVIRONMENT,
+      });
+      dispatch({ type: "VALIDATION_SUCCESS", result });
+    } catch {
+      dispatch({ type: "VALIDATION_ERROR", error: "Could not reach the validation endpoint." });
+    }
+  }, []);
+
+  return {
+    state,
+    loadCredentials,
+    submitOperator,
+    submitBroker,
+    skipBroker,
+    completeWizard,
+    validateCredentials,
+  };
+}
+```
+
+`onComplete` is the component-side side-effect bundle (`markAuthenticated + navigate`). The hook never mutates navigation state; it just invokes the callback. That keeps the hook DOM-free + testable via `renderHook` with a mock `onComplete`.
+
+## GENERIC_ERROR extraction
+
+Current `SetupPage.tsx:59` has `const GENERIC_ERROR = "Setup unavailable or invalid token."` as a module-local constant. Move to a new `frontend/src/pages/setupErrorMessages.ts` so both the component AND the hook import it from the same place:
+
+```ts
+// frontend/src/pages/setupErrorMessages.ts
+export const GENERIC_ERROR = "Setup unavailable or invalid token.";
+```
+
+## Unit tests — `useSetupWizard.test.ts`
+
+### Reducer pure tests (~17)
+
+```ts
+import { describe, expect, it } from "vitest";
+import { GENERIC_ERROR } from "@/pages/setupErrorMessages";
+import { initialWizardState, wizardReducer } from "@/pages/useSetupWizard";
+
+describe("wizardReducer", () => {
+  // --- OPERATOR transitions ---
+  it("OPERATOR_SUBMIT_START: sets submitting, clears error", () => { /* ... */ });
+  it("OPERATOR_SUBMIT_SUCCESS: advances step to broker, stores operator, clears submitting", () => { /* ... */ });
+  it("OPERATOR_SUBMIT_ERROR: sets error to GENERIC_ERROR exactly", () => {
+    const s = wizardReducer(initialWizardState, { type: "OPERATOR_SUBMIT_START" });
+    const after = wizardReducer(s, { type: "OPERATOR_SUBMIT_ERROR" });
+    expect(after.operatorError).toBe(GENERIC_ERROR);
+    expect(after.operatorSubmitting).toBe(false);
+    expect(after.step).toBe("operator");
+  });
+
+  // --- BROKER CREDS LOAD transitions ---
+  it("BROKER_CREDS_LOAD_START: sets loading, clears error", () => { /* ... */ });
+  it("BROKER_CREDS_LOAD_SUCCESS: stores rows, clears loading", () => { /* ... */ });
+  it("BROKER_CREDS_LOAD_ERROR: stores error, clears loading", () => { /* ... */ });
+
+  // --- BROKER SUBMIT transitions ---
+  it("BROKER_SUBMIT_START: sets submitting, clears error", () => { /* ... */ });
+  it("BROKER_SUBMIT_SUCCESS: stores refreshed rows, clears submitting", () => { /* ... */ });
+  it("BROKER_SUBMIT_ERROR: stores rows (for repair-mode derivation) + error", () => { /* ... */ });
+  it("BROKER_SUBMIT_ERROR with rows=null: repair-mode derivation falls back to create", () => {
+    // Integration with deriveCredentialSetMode: rows=null → mode='create'
+    // Documenting the invariant here so a future reducer change can't break it silently.
+    const s = wizardReducer(initialWizardState, {
+      type: "BROKER_SUBMIT_ERROR",
+      error: "boom",
+      rows: null,
+    });
+    expect(s.credRows).toBeNull();
+    expect(s.brokerError).toBe("boom");
+  });
+
+  // --- VALIDATION ---
+  it("VALIDATION_START: sets validating, clears BOTH prior validation AND validationError", () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      validation: { ok: true, detail: "old" } as ValidateCredentialResponse,
+      validationError: "old err",
+    };
+    const s = wizardReducer(seeded, { type: "VALIDATION_START" });
+    expect(s.validating).toBe(true);
+    expect(s.validation).toBeNull();
+    expect(s.validationError).toBeNull();
+  });
+  it("VALIDATION_SUCCESS: stores result", () => { /* ... */ });
+  it("VALIDATION_ERROR: stores error", () => { /* ... */ });
+
+  // --- Invariants ---
+  it("OPERATOR_SUBMIT_ERROR does not advance step", () => { /* ... */ });
+  it("BROKER_SUBMIT_ERROR does not advance step", () => { /* ... */ });
+  it("BROKER_CREDS_LOAD_ERROR forces credRows=null for create-mode fallback", () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      credRows: [{ provider: "etoro", label: "api_key" }] as BrokerCredentialView[],
+    };
+    const s = wizardReducer(seeded, { type: "BROKER_CREDS_LOAD_ERROR", error: "network" });
+    expect(s.credRows).toBeNull();
+  });
+});
+
+describe("classifyBrokerSaveError", () => {
+  it("409 ApiError: maps to 'A credential with that label already exists...'", () => {
+    expect(classifyBrokerSaveError(new ApiError(409, "conflict"))).toBe(
+      "A credential with that label already exists. Revoke it from Settings to replace.",
+    );
+  });
+  it("400 ApiError: maps to 'Invalid API key or user key value.'", () => {
+    expect(classifyBrokerSaveError(new ApiError(400, "bad"))).toBe("Invalid API key or user key value.");
+  });
+  it("other ApiError: maps to 'Could not save credential.'", () => {
+    expect(classifyBrokerSaveError(new ApiError(500, "boom"))).toBe("Could not save credential.");
+  });
+  it("non-ApiError: maps to 'Could not save credential.'", () => {
+    expect(classifyBrokerSaveError(new Error("random"))).toBe("Could not save credential.");
+  });
+});
+```
+
+### Hook-level integration tests (~4) — `renderHook`, no DOM
+
+```ts
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GENERIC_ERROR } from "@/pages/setupErrorMessages";
+import { useSetupWizard } from "@/pages/useSetupWizard";
+
+vi.mock("@/api/auth");
+vi.mock("@/api/brokerCredentials");
+vi.mock("@/api/jobs");
+
+describe("useSetupWizard (hook)", () => {
+  const onComplete = vi.fn();
+
+  it("submitOperator maps any fetch failure to GENERIC_ERROR (not err.message)", async () => {
+    const { postSetup } = await import("@/api/auth");
+    vi.mocked(postSetup).mockRejectedValue(new Error("Leaky detail"));
+
+    const { result } = renderHook(() => useSetupWizard({ onComplete }));
+    await act(async () => {
+      await result.current.submitOperator({ username: "x", password: "y", setupToken: "z" });
+    });
+    expect(result.current.state.operatorError).toBe(GENERIC_ERROR);
+    expect(result.current.state.operatorError).not.toContain("Leaky detail");
+  });
+
+  it("submitBroker success on create mode fires runJob(nightly_universe_sync) fire-and-forget", async () => {
+    // Seed state with no credRows → mode='create' → wasCreate=true
+    // Assert runJob called; assert dispatcher still returns ok:true even if
+    // runJob rejects asynchronously.
+    /* ... */
+  });
+
+  it("submitBroker success on repair mode does NOT fire runJob", async () => {
+    // Seed credRows with just api_key → mode='repair' → wasCreate=false
+    /* ... */
+  });
+
+  it("submitBroker failure re-fetches credentials; list fetch also failing leaves credRows=null", async () => { /* ... */ });
+});
+```
+
+## Integration tests — `SetupPage.test.tsx` trim (v2: 6 kept)
+
+Codex finding 1 + 2: the original "3 tests" scope lost repair-mode, already-complete, and save-vs-skip distinction coverage. Keep 6:
+
+1. **Happy path save** — submit operator → step 2 render with loaded credRows → submit both credentials → `markAuthenticated` + `navigate` side effects + `nightly_universe_sync` runJob fires.
+2. **Happy path skip** — submit operator → step 2 render → click Skip → `markAuthenticated` fires, NO broker POST, NO universe-sync call.
+3. **Confirm-cancel gate** — Cancel during broker step → confirm dialog → "Close anyway" fires `markAuthenticated`.
+4. **Phrase-modal branch** — first save returns `recovery_phrase` → modal opens → operator passes challenge → `markAuthenticated` fires.
+5. **Repair mode** — first save partial-fails → `credRows` refreshed → UI shows `repair` label + "finish" CTA → second save succeeds → `markAuthenticated` fires.
+6. **Already-complete branch** — step 2 opens with existing active credRows (both api_key + user_key) → UI shows `complete` label + Continue button → click Continue → `markAuthenticated` fires.
+
+**Dropped** (covered by reducer or folded into happy-path):
+- `surfaces the generic error and stays on step 1 when /auth/setup fails` → hook-integration `submitOperator maps any fetch failure to GENERIC_ERROR` test covers the security contract more precisely.
+- `advances to step 2 on success WITHOUT calling markAuthenticated yet` → asserted in happy-path save/skip via mock-call-order.
+- `creates both api_key and user_key rows on save` → covered by happy-path save (both POSTs asserted).
+- `completes wizard with NO phrase modal when response has no recovery_phrase` → covered by happy-path save (default mock has no recovery_phrase).
+
+## Vitest config change
+
+```ts
+// frontend/vitest.config.ts
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: "jsdom",
+      globals: false,
+      setupFiles: ["./src/test/setup.ts"],
+      css: false,
+      include: ["src/**/*.{test,spec}.{ts,tsx}"],
+      // Pin pool + cap concurrency. Vitest v2 defaults to forks already;
+      // pinning makes the choice explicit so a future edit doesn't silently
+      // switch back to threads (where #399 hit a tinypool crash).
+      pool: "forks",
+      poolOptions: { forks: { maxForks: 2 } },
+    },
+  }),
+);
+```
+
+## Script split
+
+```json
+"scripts": {
+  "dev": "vite",
+  "build": "tsc -b && vite build",
+  "typecheck": "tsc -b --noEmit",
+  "preview": "vite preview",
+  "test": "vitest run",
+  "test:unit": "vitest run --exclude src/pages/SetupPage.test.tsx",
+  "test:integration": "vitest run src/pages/SetupPage.test.tsx",
+  "test:watch": "vitest"
+}
+```
+
+## CLAUDE.md pre-push block
+
+Change:
+
+```bash
+pnpm --dir frontend typecheck
+pnpm --dir frontend test
+```
+
+To:
+
+```bash
+pnpm --dir frontend typecheck
+pnpm --dir frontend test:unit
+```
+
+Add callout below the block:
+
+> **Note:** Pre-push runs `test:unit` (excludes `src/pages/SetupPage.test.tsx`). CI runs the full `test` script on push — integration tests still gate merge.
+
+## Edge cases
+
+| Case | Behaviour |
+| --- | --- |
+| Developer runs `pnpm --dir frontend test` | Full suite including SetupPage integration. Matches CI. |
+| Developer runs `pnpm --dir frontend test:unit` | Excludes SetupPage.test.tsx. Fast local iteration. |
+| CI | Runs `pnpm --dir frontend test` unchanged. |
+| Hook-integration tests | Use `renderHook` — no DOM render cost. Sub-50ms each. |
+| `BROKER_SUBMIT_ERROR` with `listBrokerCredentials` also failing | Hook catches the list error + dispatches `rows: null`. Reducer stores `credRows: null`. `deriveCredentialSetMode(null)` returns `create` mode — safe fallback; user can retry. Documented in reducer test. |
+| Pre-push local run | ~2-4s (only unit + hook-integration) vs. the current full-suite cost. Full integration still runs in CI + on merge. |
+
+## Verification
+
+- `pnpm --dir frontend test src/pages/useSetupWizard.test.ts` → ~20 tests PASS, <500ms.
+- `pnpm --dir frontend test:integration` → 6 tests PASS.
+- `pnpm --dir frontend test` → full suite PASS.
+- `pnpm --dir frontend test:unit` → excludes SetupPage integration file.
+- `pnpm --dir frontend typecheck` → green.
+- Backend gates (unchanged by this PR) still green.
+
+## Rollback
+
+Revert the commit — reducer + hook + error-messages module deleted, SetupPage restored. Vitest config + package.json + CLAUDE.md revert cleanly.
+
+## Follow-up (not in this PR)
+
+- Backend pytest-xdist (needs `ebull_test` audit + collection-bootstrap idempotency — Codex ckpt 1 on #404 predecessor).
+- Additional integration tests under `*.integration.test.tsx` convention if the integration set grows.
+
+## PR description skeleton
+
+Title: `fix(#327): frontend test speedup — vitest cap + SetupPage reducer + script split`
+
+Body:
+
+> **What**
+>
+> - `vitest.config.ts` — pin `pool: "forks"` + `maxForks: 2`. Vitest v2 defaults to forks already; pinning prevents silent regression + the cap halves sustained CPU.
+> - New `frontend/src/pages/setupErrorMessages.ts` — shared `GENERIC_ERROR` constant.
+> - New `frontend/src/pages/useSetupWizard.ts` — pure `wizardReducer` + thin `useSetupWizard` hook. Extracts wizard state machine from `SetupPage.tsx`.
+> - New `frontend/src/pages/useSetupWizard.test.ts` — ~17 reducer unit tests + ~3 `renderHook` integration tests.
+> - `SetupPage.test.tsx` trimmed from ~12 tests to 6 (happy-path save, happy-path skip, confirm-cancel, phrase-modal, repair-mode, already-complete).
+> - `package.json` — `test:unit` / `test:integration` / `test` script split.
+> - `.claude/CLAUDE.md` — pre-push block points to `test:unit`; CI still runs full `test`.
+>
+> **Why**
+>
+> Closes frontend items from #327. SetupPage previously had ~12 tests at 1000-1500ms each because every transition did a full render + fetch mock dance. Pure reducer covers transition logic at <50ms total; hook-level `renderHook` covers fetch wiring; 6 kept integration tests cover irreducible multi-step UX (repair-mode, already-complete, phrase-modal, confirm-cancel gate, save/skip divergence).
+>
+> Vitest v2 already defaults to forks, so the pool change is pinning + cap. Backend pytest-xdist from #327 deferred to follow-up (needs `ebull_test` audit).
+>
+> **Test plan**
+>
+> - Reducer unit tests: ~17 PASS <500ms.
+> - Hook-integration tests: 3 PASS.
+> - Integration tests: 6 PASS.
+> - Full suite green (frontend + backend).
+>
+> **Called out**
+>
+> - #98 non-leaky-error contract preserved: `OPERATOR_SUBMIT_ERROR` action carries no payload; reducer sets `operatorError = GENERIC_ERROR` unconditionally. Hook-integration test asserts the contract explicitly.
+> - Derived broker-mode (`create` / `repair` / `complete`) stays a pure selector over `credRows` — not a reducer field. Single source of truth.
+> - CI change: none. CI runs full `test`; pre-push local runs `test:unit`.
+> - pytest-xdist deferred per prior Codex ckpt 1 finding on #404 predecessor.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,8 @@
     "typecheck": "tsc -b --noEmit",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:unit": "vitest run --exclude src/pages/SetupPage.test.tsx",
+    "test:integration": "vitest run src/pages/SetupPage.test.tsx",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/frontend/src/pages/SetupPage.test.tsx
+++ b/frontend/src/pages/SetupPage.test.tsx
@@ -1,15 +1,26 @@
 /**
  * Tests for SetupPage 2-step wizard (#122 / ADR-0003 Ticket 2c,
- * updated #139 PR D for two-key credential model).
+ * updated #139 PR D for two-key credential model, trimmed #327 for
+ * state-machine extraction into useSetupWizard).
  *
- * Scope:
- *   - Step 1 creates the operator (unchanged from #122).
- *   - Step 2 shows two-key form (API key + User key), no label field.
- *   - Two sequential createBrokerCredential calls on save.
- *   - "Skip for now" completes the wizard with no broker call.
- *   - Recovery phrase modal flow (first-save lazy-gen).
- *   - Partial-save recovery (first key saved, second failed → Repair).
- *   - markAuthenticated called exactly once, at wizard completion.
+ * Scope (integration-level — multi-step UX that reducer unit tests
+ * cannot cover):
+ *   1. Happy-path save — both credential POSTs + markAuthenticated +
+ *      nightly_universe_sync fire.
+ *   2. Happy-path skip — Skip completes wizard, no broker POST, no
+ *      universe-sync call.
+ *   3. Phrase modal — recovery_phrase response opens modal, operator
+ *      passes challenge, markAuthenticated fires.
+ *   4. Confirm-cancel gate — Cancel during phrase modal routes through
+ *      confirm dialog, "Close anyway" completes wizard.
+ *   5. Repair mode — first save partial-fails, UI re-derives to repair
+ *      mode with only the missing-key field, Skip still available.
+ *   6. Already-complete branch — step 2 opens with both credRows
+ *      present, UI shows Continue button, click completes wizard.
+ *
+ * Reducer + hook-level behaviour (GENERIC_ERROR mapping, classifier
+ * fixed strings, runJob fire-and-forget swallowing, credRows fallback
+ * on list error) is covered by useSetupWizard.test.ts.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
@@ -25,7 +36,6 @@ import {
 } from "@/api/brokerCredentials";
 import { postSetup } from "@/api/auth";
 import type { Operator } from "@/api/auth";
-import { ApiError } from "@/api/client";
 import { runJob } from "@/api/jobs";
 import { useSession } from "@/lib/session";
 
@@ -90,6 +100,10 @@ function makeRow(overrides: Partial<BrokerCredentialView> = {}): BrokerCredentia
 
 function apiKeyRow(): BrokerCredentialView {
   return makeRow({ id: "aaaa-1111", label: "api_key", last_four: "aaaa" });
+}
+
+function userKeyRow(): BrokerCredentialView {
+  return makeRow({ id: "bbbb-2222", label: "user_key", last_four: "bbbb" });
 }
 
 function withPhrase(): CreateBrokerCredentialResponse {
@@ -159,63 +173,11 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-// ---------------------------------------------------------------------------
-// Step 1 (operator) — unchanged from #122
-// ---------------------------------------------------------------------------
-
-describe("SetupPage — step 1 (operator)", () => {
-  it("surfaces the generic error and stays on step 1 when /auth/setup fails", async () => {
-    mockedPostSetup.mockRejectedValueOnce(new ApiError(404, "nope"));
-    render(<SetupPage />);
-    await completeStep1();
-    expect(
-      await screen.findByText(/Setup unavailable or invalid token/i),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Create operator/i })).toBeInTheDocument();
-    expect(markAuthenticatedMock).not.toHaveBeenCalled();
-    expect(navigateMock).not.toHaveBeenCalled();
-  });
-
-  it("advances to step 2 on success WITHOUT calling markAuthenticated yet", async () => {
-    mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
-    render(<SetupPage />);
-    await completeStep1();
-    expect(
-      await screen.findByRole("button", { name: /Save credentials/i }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Skip for now/i })).toBeInTheDocument();
-    // Two-key fields visible.
-    expect(screen.getByLabelText("API key")).toBeInTheDocument();
-    expect(screen.getByLabelText("User key")).toBeInTheDocument();
-    expect(markAuthenticatedMock).not.toHaveBeenCalled();
-    expect(navigateMock).not.toHaveBeenCalled();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Step 2 (broker, optional) — updated for two-key model
-// ---------------------------------------------------------------------------
-
-describe("SetupPage — step 2 (broker, optional)", () => {
-  it("'Skip for now' completes the wizard with no broker call", async () => {
-    const user = userEvent.setup();
-    mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
-    render(<SetupPage />);
-    await completeStep1();
-    await screen.findByRole("button", { name: /Skip for now/i });
-
-    await user.click(screen.getByRole("button", { name: /Skip for now/i }));
-
-    expect(mockedCreate).not.toHaveBeenCalled();
-    expect(markAuthenticatedMock).toHaveBeenCalledTimes(1);
-    expect(markAuthenticatedMock).toHaveBeenCalledWith(OPERATOR);
-    expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
-  });
-
-  it("creates both api_key and user_key rows on save", async () => {
+describe("SetupPage — integration", () => {
+  it("happy-path save: creates both credentials, fires universe-sync, completes wizard", async () => {
     mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
     mockedCreate
-      .mockResolvedValueOnce(withoutPhrase())  // api_key
+      .mockResolvedValueOnce(withoutPhrase()) // api_key
       .mockResolvedValueOnce(withoutPhrase()); // user_key
 
     render(<SetupPage />);
@@ -237,16 +199,38 @@ describe("SetupPage — step 2 (broker, optional)", () => {
       environment: "demo",
       secret: "test-user-key",
     });
-    // Wizard completes after both saves.
-    expect(markAuthenticatedMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mockedRunJob).toHaveBeenCalledWith("nightly_universe_sync");
+    });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await waitFor(() => {
+      expect(markAuthenticatedMock).toHaveBeenCalledTimes(1);
+    });
+    expect(markAuthenticatedMock).toHaveBeenCalledWith(OPERATOR);
     expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
   });
 
-  it("opens the phrase modal when the first create response carries a recovery_phrase", async () => {
+  it("happy-path skip: no broker POST, no universe-sync, wizard completes", async () => {
+    const user = userEvent.setup();
+    mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
+    render(<SetupPage />);
+    await completeStep1();
+    await screen.findByRole("button", { name: /Skip for now/i });
+
+    await user.click(screen.getByRole("button", { name: /Skip for now/i }));
+
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(mockedRunJob).not.toHaveBeenCalled();
+    expect(markAuthenticatedMock).toHaveBeenCalledTimes(1);
+    expect(markAuthenticatedMock).toHaveBeenCalledWith(OPERATOR);
+    expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
+  });
+
+  it("phrase-modal branch: recovery_phrase opens modal, passing challenge completes wizard", async () => {
     mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
     mockedCreate
-      .mockResolvedValueOnce(withPhrase())     // api_key (triggers phrase)
-      .mockResolvedValueOnce(withoutPhrase()); // user_key
+      .mockResolvedValueOnce(withPhrase())
+      .mockResolvedValueOnce(withoutPhrase());
 
     render(<SetupPage />);
     await completeStep1();
@@ -256,23 +240,8 @@ describe("SetupPage — step 2 (broker, optional)", () => {
       name: "Recovery phrase confirmation",
     });
     expect(dialog).toBeInTheDocument();
-    // Both credentials saved before modal opens.
     expect(mockedCreate).toHaveBeenCalledTimes(2);
-    // Wizard NOT yet complete.
     expect(markAuthenticatedMock).not.toHaveBeenCalled();
-    expect(navigateMock).not.toHaveBeenCalled();
-  });
-
-  it("completes the wizard after the operator passes the challenge", async () => {
-    mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
-    mockedCreate
-      .mockResolvedValueOnce(withPhrase())
-      .mockResolvedValueOnce(withoutPhrase());
-
-    render(<SetupPage />);
-    await completeStep1();
-    await fillStep2("test-api-key", "test-user-key");
-    await screen.findByRole("dialog");
 
     await advancePastWrittenDownGate();
     await answerChallengeCorrectly();
@@ -284,7 +253,7 @@ describe("SetupPage — step 2 (broker, optional)", () => {
     expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
   });
 
-  it("routes Cancel through confirm-cancel gate, then 'Close anyway' completes wizard", async () => {
+  it("confirm-cancel gate: Cancel during phrase modal → 'Close anyway' completes wizard", async () => {
     const user = userEvent.setup();
     mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
     mockedCreate
@@ -309,104 +278,50 @@ describe("SetupPage — step 2 (broker, optional)", () => {
     expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
   });
 
-  it("enters Repair mode and keeps Skip available when second save fails", async () => {
+  it("repair-mode: partial save failure re-derives UI to show only missing key, Skip stays available", async () => {
     mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
     mockedCreate
-      .mockResolvedValueOnce(withoutPhrase())  // api_key succeeds
-      .mockRejectedValueOnce(new Error("boom")); // user_key fails
-    // Mount fetch on step-2 entry returns empty (fresh setup), then
-    // post-error refresh returns the saved api_key.
+      .mockResolvedValueOnce(withoutPhrase())
+      .mockRejectedValueOnce(new Error("boom"));
     mockedList
-      .mockResolvedValueOnce([])           // mount fetch
-      .mockResolvedValueOnce([apiKeyRow()]); // post-error refresh
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([apiKeyRow()]);
 
     render(<SetupPage />);
     await completeStep1();
     await fillStep2("test-api-key", "test-user-key");
 
-    // Error surfaced.
     expect(await screen.findByText(/Could not save credential/i)).toBeInTheDocument();
-    // Re-derived to Repair mode.
     await waitFor(() => {
       expect(screen.queryByLabelText("API key")).toBeNull();
     });
     expect(screen.getByLabelText("User key")).toBeInTheDocument();
-    // Skip still available.
     expect(screen.getByRole("button", { name: /Skip for now/i })).toBeEnabled();
-    // Wizard NOT yet complete.
     expect(markAuthenticatedMock).not.toHaveBeenCalled();
   });
-});
 
-// ---------------------------------------------------------------------------
-// Edge case 2 (ADR-0003 §5 row 3)
-// ---------------------------------------------------------------------------
-
-describe("SetupPage — edge case 2", () => {
-  it("completes wizard with NO phrase modal when response has no recovery_phrase", async () => {
-    mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
-    mockedCreate
-      .mockResolvedValueOnce(withoutPhrase())
-      .mockResolvedValueOnce(withoutPhrase());
-
-    render(<SetupPage />);
-    await completeStep1();
-    await fillStep2("test-api-key", "test-user-key");
-
-    await waitFor(() => {
-      expect(markAuthenticatedMock).toHaveBeenCalledTimes(1);
-    });
-    expect(screen.queryByRole("dialog")).toBeNull();
-    expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// First-run bootstrap trigger (#145)
-// ---------------------------------------------------------------------------
-
-describe("SetupPage — first-run bootstrap trigger", () => {
-  it("fires nightly_universe_sync after both credentials are saved", async () => {
-    mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
-    mockedCreate
-      .mockResolvedValueOnce(withoutPhrase())
-      .mockResolvedValueOnce(withoutPhrase());
-
-    render(<SetupPage />);
-    await completeStep1();
-    await fillStep2("test-api-key", "test-user-key");
-
-    await waitFor(() => {
-      expect(mockedRunJob).toHaveBeenCalledWith("nightly_universe_sync");
-    });
-  });
-
-  it("does not fire universe sync when operator skips credentials", async () => {
+  it("already-complete branch: step 2 opens with both credentials present, Continue completes wizard", async () => {
     const user = userEvent.setup();
     mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
-    render(<SetupPage />);
-    await completeStep1();
-    await screen.findByRole("button", { name: /Skip for now/i });
-
-    await user.click(screen.getByRole("button", { name: /Skip for now/i }));
-
-    expect(mockedRunJob).not.toHaveBeenCalled();
-  });
-
-  it("swallows universe sync errors silently", async () => {
-    mockedPostSetup.mockResolvedValueOnce({ operator: OPERATOR });
-    mockedCreate
-      .mockResolvedValueOnce(withoutPhrase())
-      .mockResolvedValueOnce(withoutPhrase());
-    mockedRunJob.mockRejectedValueOnce(new Error("409 already running"));
+    mockedList.mockResolvedValueOnce([apiKeyRow(), userKeyRow()]);
 
     render(<SetupPage />);
     await completeStep1();
-    await fillStep2("test-api-key", "test-user-key");
 
-    // Wizard still completes despite runJob failure.
+    expect(await screen.findByText(/Credentials configured/i)).toBeInTheDocument();
+    const continueBtn = screen.getByRole("button", { name: /Continue/i });
+    expect(continueBtn).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Save credentials/i })).toBeNull();
+    expect(screen.queryByLabelText("API key")).toBeNull();
+    expect(markAuthenticatedMock).not.toHaveBeenCalled();
+
+    await user.click(continueBtn);
     await waitFor(() => {
       expect(markAuthenticatedMock).toHaveBeenCalledTimes(1);
     });
+    expect(markAuthenticatedMock).toHaveBeenCalledWith(OPERATOR);
+    expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(mockedRunJob).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -5,9 +5,11 @@
  *   Original single-step setup form (#106 / Ticket G). Captures the
  *   first operator's username, password, and (if running in non-loopback
  *   bootstrap-token mode) the one-shot setup token printed to the
- *   server log. POST /auth/setup. Generic-404 mapping is preserved --
+ *   server log. POST /auth/setup. Generic-error mapping is preserved --
  *   every non-2xx surfaces the same fixed string so the page never
- *   leaks which input was wrong.
+ *   leaks which input was wrong (#98). See useSetupWizard.ts — the
+ *   OPERATOR_SUBMIT_ERROR action carries no payload; the reducer
+ *   hard-codes GENERIC_ERROR unconditionally.
  *
  * Step 2: Broker credential (optional)  -- ADR-0003 Ticket 2c (#122)
  *   Updated in #139 PR D for two-key credential model. The operator
@@ -23,7 +25,9 @@
  *
  *   Credential-set mode detection mirrors SettingsPage: after a partial
  *   save failure, the form re-derives mode from the credential list and
- *   shows only the missing key's field.
+ *   shows only the missing key's field. See useSetupWizard.ts —
+ *   submitBroker re-fetches credRows on save failure for repair-mode
+ *   derivation.
  *
  * markAuthenticated discipline (#122):
  *   In the single-step incarnation we called markAuthenticated AND
@@ -34,97 +38,97 @@
  *   step 2. The cookie is already set by /auth/setup itself, so the
  *   broker-credential POST in step 2 still authenticates correctly
  *   even with the in-memory React flag deferred.
+ *
+ * State management (#327):
+ *   Wizard state machine lives in useSetupWizard (step + submit/error/
+ *   validation flags + credRows). Form-field inputs (username, password,
+ *   setupToken, brokerApiKey, brokerUserKey) stay as component-local
+ *   useState — field churn doesn't belong in the state machine. Derived
+ *   broker-mode (create/repair/complete) stays a pure selector over
+ *   state.credRows via deriveCredentialSetMode.
  */
 
 import { useCallback, useEffect, useState } from "react";
 import type { FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { ApiError } from "@/api/client";
-import { postSetup } from "@/api/auth";
-import type { Operator } from "@/api/auth";
-import {
-  type BrokerCredentialView,
-  type ValidateCredentialResponse,
-  createBrokerCredential,
-  listBrokerCredentials,
-  validateBrokerCredential,
-} from "@/api/brokerCredentials";
-import { runJob } from "@/api/jobs";
 import { ValidationResultDisplay } from "@/components/broker/ValidationResultDisplay";
 import { useRecoveryPhraseModal } from "@/components/security/RecoveryPhraseModal";
-import { deriveCredentialSetMode, ENVIRONMENT } from "@/lib/credentialSetMode";
+import { deriveCredentialSetMode } from "@/lib/credentialSetMode";
 import { useSession } from "@/lib/session";
+import { GENERIC_ERROR } from "@/pages/setupErrorMessages";
+import { useSetupWizard } from "@/pages/useSetupWizard";
 
-const GENERIC_ERROR = "Setup unavailable or invalid token.";
 const MIN_PASSWORD_LEN = 12;
 const MIN_SECRET_LEN = 4;
 
-type WizardStep = "operator" | "broker";
+// Re-export so tests that import GENERIC_ERROR via this module keep working.
+export { GENERIC_ERROR };
 
 export function SetupPage(): JSX.Element {
   const { status, markAuthenticated } = useSession();
   const navigate = useNavigate();
 
-  const [step, setStep] = useState<WizardStep>("operator");
-  const [pendingOperator, setPendingOperator] = useState<Operator | null>(null);
-
-  // Step 1 form state.
+  // Form-field state (stays local per #327 design — field churn doesn't
+  // belong in the wizard state machine).
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [setupToken, setSetupToken] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // Step 2 form state — two-key model.
   const [brokerApiKey, setBrokerApiKey] = useState("");
   const [brokerUserKey, setBrokerUserKey] = useState("");
-  const [brokerSubmitting, setBrokerSubmitting] = useState(false);
-  const [brokerError, setBrokerError] = useState<string | null>(null);
 
-  // Credential-set mode detection for partial-save recovery.
-  const [credRows, setCredRows] = useState<BrokerCredentialView[] | null>(null);
-  const derived = deriveCredentialSetMode(credRows);
+  // `wizard` is declared AFTER completeWizard (below) because
+  // useSetupWizard takes onComplete as an option. completeWizard needs
+  // `wizard.state.pendingOperator` though, which creates a chicken-and-egg.
+  // Solution: declare completeWizard after the hook and pass a wrapper via
+  // a stable closure over a `wizardRef` pattern. But TypeScript ordering
+  // prevents forward-referencing a const. Simpler: make completeWizard a
+  // useCallback whose deps include wizard.state.pendingOperator, and
+  // declare wizard BEFORE completeWizard with a stub onComplete — then
+  // replace it via a ref. That's ugly.
+  //
+  // Cleanest: separate pendingOperator tracking into a local state that
+  // mirrors wizard state, or use a ref. We use a small closure-stable
+  // completeWizard that reads wizard.state inline, declared after the
+  // hook. The hook's onComplete option needs a stable callback — we wrap
+  // it via useCallback([markAuthenticated, navigate]) since the
+  // state-read happens inside the function body each call.
+
+  const wizard = useSetupWizard({
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    onComplete: () => completeWizard(),
+  });
+
+  const completeWizard = useCallback((): void => {
+    if (wizard.state.pendingOperator !== null) {
+      markAuthenticated(wizard.state.pendingOperator);
+    }
+    navigate("/", { replace: true });
+  }, [markAuthenticated, navigate, wizard.state.pendingOperator]);
+
+  const derived = deriveCredentialSetMode(wizard.state.credRows);
   const mode = derived.mode;
   const missingLabel = derived.missingLabel;
 
-  // Validation state.
-  const [validating, setValidating] = useState(false);
-  const [validationResult, setValidationResult] =
-    useState<ValidateCredentialResponse | null>(null);
-  const [validationError, setValidationError] = useState<string | null>(null);
-
-  const refreshCredentials = useCallback(async (): Promise<void> => {
-    try {
-      const data = await listBrokerCredentials();
-      setCredRows(data);
-    } catch {
-      // On the setup page, failure to list credentials is non-fatal —
-      // the operator can still enter both keys (Create mode).
-      setCredRows(null);
-    }
-  }, []);
-
-  // Fetch existing credentials when entering step 2 so that
-  // partial-save state from a prior session is correctly detected.
+  // Fetch existing credentials when entering step 2 so partial-save
+  // state from a prior session is correctly detected.
   useEffect(() => {
-    if (step === "broker") {
-      void refreshCredentials();
+    if (wizard.state.step === "broker") {
+      void wizard.loadCredentials();
     }
-  }, [step, refreshCredentials]);
+    // loadCredentials is useCallback([]) so identity is stable; include
+    // it anyway for lint cleanliness.
+  }, [wizard.state.step, wizard.loadCredentials]);
 
   // Clear stale validation result when inputs change or mode transitions.
+  // The reducer's VALIDATION_START also clears these, but this effect
+  // handles the case where the operator edits inputs without clicking
+  // Test connection.
   useEffect(() => {
-    setValidationResult(null);
-    setValidationError(null);
+    // No-op: validation auto-clears on VALIDATION_START dispatch. We
+    // don't need a separate effect since the reducer owns that state.
+    // Kept as an empty useEffect to mark the design intent visible.
   }, [brokerApiKey, brokerUserKey, mode]);
-
-  function completeWizard(): void {
-    if (pendingOperator !== null) {
-      markAuthenticated(pendingOperator);
-    }
-    navigate("/", { replace: true });
-  }
 
   const phraseModal = useRecoveryPhraseModal({
     onClose: completeWizard,
@@ -140,106 +144,24 @@ export function SetupPage(): JSX.Element {
 
   async function handleOperatorSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault();
-    setError(null);
-    setSubmitting(true);
-    try {
-      const { operator } = await postSetup(
-        username,
-        password,
-        setupToken.trim() === "" ? null : setupToken.trim(),
-      );
-      setPendingOperator(operator);
-      setStep("broker");
-    } catch {
-      setError(GENERIC_ERROR);
-    } finally {
-      setSubmitting(false);
-    }
+    await wizard.submitOperator({ username, password, setupToken });
   }
 
   async function handleTestConnection(): Promise<void> {
-    setValidationResult(null);
-    setValidationError(null);
-    setValidating(true);
-    try {
-      const result = await validateBrokerCredential({
-        api_key: brokerApiKey,
-        user_key: brokerUserKey,
-        environment: ENVIRONMENT,
-      });
-      setValidationResult(result);
-    } catch {
-      setValidationError("Could not reach the validation endpoint.");
-    } finally {
-      setValidating(false);
-    }
+    await wizard.validateCredentials({ apiKey: brokerApiKey, userKey: brokerUserKey });
   }
 
   async function handleBrokerSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault();
-    setBrokerError(null);
-    setBrokerSubmitting(true);
-    // Capture mode before save so we can detect first-time creation.
-    const wasCreate = mode === "create";
-    try {
-      let phrase: readonly string[] | null = null;
-
-      // Save api_key if needed (Create mode or Repair with api_key missing).
-      if (mode === "create" || (mode === "repair" && missingLabel === "api_key")) {
-        const response = await createBrokerCredential({
-          provider: "etoro",
-          label: "api_key",
-          environment: ENVIRONMENT,
-          secret: brokerApiKey,
-        });
-        if (response.recovery_phrase != null && response.recovery_phrase.length > 0) {
-          phrase = response.recovery_phrase;
-        }
-      }
-
-      // Save user_key if needed (Create mode or Repair with user_key missing).
-      if (mode === "create" || (mode === "repair" && missingLabel === "user_key")) {
-        await createBrokerCredential({
-          provider: "etoro",
-          label: "user_key",
-          environment: ENVIRONMENT,
-          secret: brokerUserKey,
-        });
-      }
-
-      setBrokerApiKey("");
-      setBrokerUserKey("");
-
-      // First-run bootstrap: kick off the universe sync so the pipeline
-      // starts populating data.  Only on first-time create (not Repair).
-      // Fire-and-forget — errors are swallowed because the operator can
-      // always trigger this manually from Admin.
-      if (wasCreate) {
-        runJob("nightly_universe_sync").catch(() => {});
-      }
-
-      // If the first save triggered a recovery phrase, show the modal
-      // now that both credentials are durable.
-      if (phrase !== null) {
-        phraseModal.open(phrase);
-        return;
-      }
-
-      completeWizard();
-    } catch (err: unknown) {
-      if (err instanceof ApiError && err.status === 409) {
-        setBrokerError("A credential with that label already exists. Revoke it from Settings to replace.");
-      } else if (err instanceof ApiError && err.status === 400) {
-        setBrokerError("Invalid API key or user key value.");
-      } else {
-        setBrokerError("Could not save credential.");
-      }
-      // Re-derive mode from the refreshed list in case the first call
-      // succeeded but the second failed (partial state).
-      await refreshCredentials();
-    } finally {
-      setBrokerSubmitting(false);
+    const result = await wizard.submitBroker({ apiKey: brokerApiKey, userKey: brokerUserKey });
+    if (!result.ok) return;
+    setBrokerApiKey("");
+    setBrokerUserKey("");
+    if (result.recoveryPhrase !== null) {
+      phraseModal.open(result.recoveryPhrase);
+      return;
     }
+    completeWizard();
   }
 
   function handleSkipBroker(): void {
@@ -254,9 +176,19 @@ export function SetupPage(): JSX.Element {
     );
   }
 
+  const submitting = wizard.state.operatorSubmitting;
+  const error = wizard.state.operatorError;
+  const brokerSubmitting = wizard.state.brokerSubmitting;
+  const brokerError = wizard.state.brokerError;
+  const validating = wizard.state.validating;
+  const validationResult = wizard.state.validation;
+  const validationError = wizard.state.validationError;
+  const step = wizard.state.step;
+
   const showApiKeyField = mode === "create" || (mode === "repair" && missingLabel === "api_key");
   const showUserKeyField = mode === "create" || (mode === "repair" && missingLabel === "user_key");
-  const canTestConnection = mode === "create" && brokerApiKey.length >= MIN_SECRET_LEN && brokerUserKey.length >= MIN_SECRET_LEN;
+  const canTestConnection =
+    mode === "create" && brokerApiKey.length >= MIN_SECRET_LEN && brokerUserKey.length >= MIN_SECRET_LEN;
   const canSave =
     !brokerSubmitting &&
     (showApiKeyField ? brokerApiKey.length >= MIN_SECRET_LEN : true) &&

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -48,7 +48,7 @@
  *   state.credRows via deriveCredentialSetMode.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -77,27 +77,18 @@ export function SetupPage(): JSX.Element {
   const [brokerApiKey, setBrokerApiKey] = useState("");
   const [brokerUserKey, setBrokerUserKey] = useState("");
 
-  // `wizard` is declared AFTER completeWizard (below) because
-  // useSetupWizard takes onComplete as an option. completeWizard needs
-  // `wizard.state.pendingOperator` though, which creates a chicken-and-egg.
-  // Solution: declare completeWizard after the hook and pass a wrapper via
-  // a stable closure over a `wizardRef` pattern. But TypeScript ordering
-  // prevents forward-referencing a const. Simpler: make completeWizard a
-  // useCallback whose deps include wizard.state.pendingOperator, and
-  // declare wizard BEFORE completeWizard with a stub onComplete — then
-  // replace it via a ref. That's ugly.
+  // Stable-identity `onComplete` for useSetupWizard. The hook memoises
+  // skipBroker/completeWizard against `onComplete` identity, so a new
+  // inline arrow each render would re-create those dispatchers on
+  // every wizard state tick — defeats the hook's own useCallback.
   //
-  // Cleanest: separate pendingOperator tracking into a local state that
-  // mirrors wizard state, or use a ref. We use a small closure-stable
-  // completeWizard that reads wizard.state inline, declared after the
-  // hook. The hook's onComplete option needs a stable callback — we wrap
-  // it via useCallback([markAuthenticated, navigate]) since the
-  // state-read happens inside the function body each call.
-
-  const wizard = useSetupWizard({
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    onComplete: () => completeWizard(),
-  });
+  // Fix: wrap a ref. `onComplete` reads `completeRef.current` (stable
+  // identity via useCallback([])). The ref is updated via useEffect
+  // whenever the real `completeWizard` identity changes, so `pendingOperator`
+  // is always fresh at call time.
+  const completeRef = useRef<() => void>(() => {});
+  const onComplete = useCallback(() => completeRef.current(), []);
+  const wizard = useSetupWizard({ onComplete });
 
   const completeWizard = useCallback((): void => {
     if (wizard.state.pendingOperator !== null) {
@@ -105,6 +96,12 @@ export function SetupPage(): JSX.Element {
     }
     navigate("/", { replace: true });
   }, [markAuthenticated, navigate, wizard.state.pendingOperator]);
+
+  // Keep the ref pointing at the latest completeWizard closure so the
+  // stable `onComplete` reads a fresh pendingOperator on each invocation.
+  useEffect(() => {
+    completeRef.current = completeWizard;
+  }, [completeWizard]);
 
   const derived = deriveCredentialSetMode(wizard.state.credRows);
   const mode = derived.mode;

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -121,13 +121,15 @@ export function SetupPage(): JSX.Element {
   }, [wizard.state.step, wizard.loadCredentials]);
 
   // Clear stale validation result when inputs change or mode transitions.
-  // The reducer's VALIDATION_START also clears these, but this effect
-  // handles the case where the operator edits inputs without clicking
-  // Test connection.
+  // VALIDATION_START only fires on explicit Test-connection click, so
+  // typing into either key field without clicking Test would otherwise
+  // leave prior pass/fail banner on screen against stale values. This
+  // effect dispatches VALIDATION_CLEAR-equivalent via the hook's helper.
   useEffect(() => {
-    // No-op: validation auto-clears on VALIDATION_START dispatch. We
-    // don't need a separate effect since the reducer owns that state.
-    // Kept as an empty useEffect to mark the design intent visible.
+    if (wizard.state.validation !== null || wizard.state.validationError !== null) {
+      wizard.clearValidation();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [brokerApiKey, brokerUserKey, mode]);
 
   const phraseModal = useRecoveryPhraseModal({

--- a/frontend/src/pages/setupErrorMessages.ts
+++ b/frontend/src/pages/setupErrorMessages.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared error-message constants for the operator setup wizard.
+ *
+ * GENERIC_ERROR is the single string every operator-setup fetch failure
+ * maps to. Used by SetupPage.tsx + useSetupWizard.ts to preserve the
+ * #98 non-leaky-error contract: an unauthenticated attacker must not
+ * be able to distinguish failure modes of the /auth/setup endpoint.
+ */
+export const GENERIC_ERROR = "Setup unavailable or invalid token.";

--- a/frontend/src/pages/useSetupWizard.test.ts
+++ b/frontend/src/pages/useSetupWizard.test.ts
@@ -181,6 +181,19 @@ describe("wizardReducer — VALIDATION", () => {
     expect(s.validationError).toBe("Could not reach the validation endpoint.");
     expect(s.validating).toBe(false);
   });
+
+  it("VALIDATION_CLEAR: clears prior result + error, leaves validating flag alone", () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      validating: true,
+      validation: VAL_OK,
+      validationError: "old",
+    };
+    const s = wizardReducer(seeded, { type: "VALIDATION_CLEAR" });
+    expect(s.validation).toBeNull();
+    expect(s.validationError).toBeNull();
+    expect(s.validating).toBe(true); // unchanged
+  });
 });
 
 describe("classifyBrokerSaveError", () => {

--- a/frontend/src/pages/useSetupWizard.test.ts
+++ b/frontend/src/pages/useSetupWizard.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+
+import type { Operator } from "@/api/auth";
+import type {
+  BrokerCredentialView,
+  ValidateCredentialResponse,
+} from "@/api/brokerCredentials";
+import { ApiError } from "@/api/client";
+import { GENERIC_ERROR } from "@/pages/setupErrorMessages";
+import {
+  classifyBrokerSaveError,
+  initialWizardState,
+  wizardReducer,
+  type WizardState,
+} from "@/pages/useSetupWizard";
+
+const OP: Operator = { id: "op-1", username: "test" };
+const ROW_API: BrokerCredentialView = {
+  id: "c-1",
+  provider: "etoro",
+  label: "api_key",
+  environment: "demo",
+  last_four: "abcd",
+  created_at: "2026-04-22T00:00:00Z",
+  last_used_at: null,
+  revoked_at: null,
+};
+const ROW_USER: BrokerCredentialView = { ...ROW_API, id: "c-2", label: "user_key" };
+const VAL_OK: ValidateCredentialResponse = {
+  auth_valid: true,
+  identity: null,
+  environment: "demo",
+  env_valid: true,
+  env_check: "ok",
+  note: "fine",
+};
+
+describe("wizardReducer — OPERATOR", () => {
+  it("OPERATOR_SUBMIT_START: sets submitting, clears error", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, operatorError: "prev" },
+      { type: "OPERATOR_SUBMIT_START" },
+    );
+    expect(s.operatorSubmitting).toBe(true);
+    expect(s.operatorError).toBeNull();
+  });
+
+  it("OPERATOR_SUBMIT_SUCCESS: advances step to broker, stores operator", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, operatorSubmitting: true },
+      { type: "OPERATOR_SUBMIT_SUCCESS", operator: OP },
+    );
+    expect(s.step).toBe("broker");
+    expect(s.pendingOperator).toEqual(OP);
+    expect(s.operatorSubmitting).toBe(false);
+    expect(s.operatorError).toBeNull();
+  });
+
+  it("OPERATOR_SUBMIT_ERROR: sets error to GENERIC_ERROR exactly (no payload)", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, operatorSubmitting: true },
+      { type: "OPERATOR_SUBMIT_ERROR" },
+    );
+    expect(s.operatorError).toBe(GENERIC_ERROR);
+    expect(s.operatorSubmitting).toBe(false);
+    expect(s.step).toBe("operator");
+  });
+});
+
+describe("wizardReducer — BROKER creds load", () => {
+  it("BROKER_CREDS_LOAD_START: sets loading, clears prior error", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, credRowsError: "old" },
+      { type: "BROKER_CREDS_LOAD_START" },
+    );
+    expect(s.credRowsLoading).toBe(true);
+    expect(s.credRowsError).toBeNull();
+  });
+
+  it("BROKER_CREDS_LOAD_SUCCESS: stores rows, clears loading", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, credRowsLoading: true },
+      { type: "BROKER_CREDS_LOAD_SUCCESS", rows: [ROW_API] },
+    );
+    expect(s.credRows).toEqual([ROW_API]);
+    expect(s.credRowsLoading).toBe(false);
+  });
+
+  it("BROKER_CREDS_LOAD_ERROR: forces credRows=null for create-mode fallback", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, credRows: [ROW_API] },
+      { type: "BROKER_CREDS_LOAD_ERROR", error: "network" },
+    );
+    expect(s.credRows).toBeNull();
+    expect(s.credRowsError).toBe("network");
+    expect(s.credRowsLoading).toBe(false);
+  });
+});
+
+describe("wizardReducer — BROKER submit", () => {
+  it("BROKER_SUBMIT_START: sets submitting, clears prior error", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, brokerError: "old" },
+      { type: "BROKER_SUBMIT_START" },
+    );
+    expect(s.brokerSubmitting).toBe(true);
+    expect(s.brokerError).toBeNull();
+  });
+
+  it("BROKER_SUBMIT_SUCCESS: stores refreshed rows, clears submitting", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, brokerSubmitting: true },
+      { type: "BROKER_SUBMIT_SUCCESS", rows: [ROW_API, ROW_USER] },
+    );
+    expect(s.credRows).toEqual([ROW_API, ROW_USER]);
+    expect(s.brokerSubmitting).toBe(false);
+    expect(s.brokerError).toBeNull();
+  });
+
+  it("BROKER_SUBMIT_ERROR: stores error + rows for repair-mode derivation", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, brokerSubmitting: true },
+      {
+        type: "BROKER_SUBMIT_ERROR",
+        error: "Invalid API key or user key value.",
+        rows: [ROW_API],
+      },
+    );
+    expect(s.brokerError).toBe("Invalid API key or user key value.");
+    expect(s.credRows).toEqual([ROW_API]);
+    expect(s.brokerSubmitting).toBe(false);
+    expect(s.step).toBe("operator"); // no step advance
+  });
+
+  it("BROKER_SUBMIT_ERROR with rows=null leaves credRows=null (create-mode fallback)", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, brokerSubmitting: true },
+      {
+        type: "BROKER_SUBMIT_ERROR",
+        error: "Could not save credential.",
+        rows: null,
+      },
+    );
+    expect(s.credRows).toBeNull();
+  });
+});
+
+describe("wizardReducer — VALIDATION", () => {
+  it("VALIDATION_START: clears BOTH prior validation result AND validationError", () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      validation: VAL_OK,
+      validationError: "old",
+    };
+    const s = wizardReducer(seeded, { type: "VALIDATION_START" });
+    expect(s.validating).toBe(true);
+    expect(s.validation).toBeNull();
+    expect(s.validationError).toBeNull();
+  });
+
+  it("VALIDATION_SUCCESS: stores result", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, validating: true },
+      { type: "VALIDATION_SUCCESS", result: VAL_OK },
+    );
+    expect(s.validation).toEqual(VAL_OK);
+    expect(s.validating).toBe(false);
+  });
+
+  it("VALIDATION_ERROR: stores error", () => {
+    const s = wizardReducer(
+      { ...initialWizardState, validating: true },
+      { type: "VALIDATION_ERROR", error: "Could not reach the validation endpoint." },
+    );
+    expect(s.validationError).toBe("Could not reach the validation endpoint.");
+    expect(s.validating).toBe(false);
+  });
+});
+
+describe("classifyBrokerSaveError", () => {
+  it("409 ApiError → fixed 'A credential with that label already exists...'", () => {
+    expect(classifyBrokerSaveError(new ApiError(409, "conflict"))).toBe(
+      "A credential with that label already exists. Revoke it from Settings to replace.",
+    );
+  });
+  it("400 ApiError → 'Invalid API key or user key value.'", () => {
+    expect(classifyBrokerSaveError(new ApiError(400, "bad"))).toBe(
+      "Invalid API key or user key value.",
+    );
+  });
+  it("other ApiError → 'Could not save credential.'", () => {
+    expect(classifyBrokerSaveError(new ApiError(500, "boom"))).toBe(
+      "Could not save credential.",
+    );
+  });
+  it("non-ApiError Error → 'Could not save credential.'", () => {
+    expect(classifyBrokerSaveError(new Error("random"))).toBe("Could not save credential.");
+  });
+  it("non-Error value → 'Could not save credential.'", () => {
+    expect(classifyBrokerSaveError("plain string")).toBe("Could not save credential.");
+  });
+});

--- a/frontend/src/pages/useSetupWizard.test.ts
+++ b/frontend/src/pages/useSetupWizard.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Operator } from "@/api/auth";
 import type {
@@ -10,9 +11,14 @@ import { GENERIC_ERROR } from "@/pages/setupErrorMessages";
 import {
   classifyBrokerSaveError,
   initialWizardState,
+  useSetupWizard,
   wizardReducer,
   type WizardState,
 } from "@/pages/useSetupWizard";
+
+vi.mock("@/api/auth");
+vi.mock("@/api/brokerCredentials");
+vi.mock("@/api/jobs");
 
 const OP: Operator = { id: "op-1", username: "test" };
 const ROW_API: BrokerCredentialView = {
@@ -198,5 +204,121 @@ describe("classifyBrokerSaveError", () => {
   });
   it("non-Error value → 'Could not save credential.'", () => {
     expect(classifyBrokerSaveError("plain string")).toBe("Could not save credential.");
+  });
+});
+
+describe("useSetupWizard (hook)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("submitOperator maps any fetch failure to GENERIC_ERROR (not err.message)", async () => {
+    const { postSetup } = await import("@/api/auth");
+    vi.mocked(postSetup).mockRejectedValue(new Error("Leaky backend detail"));
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useSetupWizard({ onComplete }));
+    await act(async () => {
+      await result.current.submitOperator({ username: "u", password: "p", setupToken: "" });
+    });
+    expect(result.current.state.operatorError).toBe(GENERIC_ERROR);
+    expect(result.current.state.operatorError).not.toContain("Leaky backend detail");
+    expect(result.current.state.step).toBe("operator");
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("submitOperator success advances step to broker + stores operator", async () => {
+    const { postSetup } = await import("@/api/auth");
+    vi.mocked(postSetup).mockResolvedValue({ operator: OP });
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useSetupWizard({ onComplete }));
+    await act(async () => {
+      await result.current.submitOperator({ username: "u", password: "p", setupToken: "" });
+    });
+    expect(result.current.state.step).toBe("broker");
+    expect(result.current.state.pendingOperator).toEqual(OP);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("submitBroker in create-mode fires runJob(nightly_universe_sync) fire-and-forget", async () => {
+    const { createBrokerCredential, listBrokerCredentials } = await import(
+      "@/api/brokerCredentials"
+    );
+    const { runJob } = await import("@/api/jobs");
+    vi.mocked(createBrokerCredential).mockResolvedValue({
+      credential: ROW_API,
+      recovery_phrase: null,
+    });
+    vi.mocked(listBrokerCredentials).mockResolvedValue([ROW_API, ROW_USER]);
+    vi.mocked(runJob).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useSetupWizard({ onComplete: vi.fn() }));
+    // state.credRows === null → mode === 'create' → wasCreate=true
+    await act(async () => {
+      await result.current.submitBroker({ apiKey: "a", userKey: "u" });
+    });
+    expect(runJob).toHaveBeenCalledWith("nightly_universe_sync");
+    expect(result.current.state.brokerError).toBeNull();
+  });
+
+  it("submitBroker in repair-mode does NOT fire runJob", async () => {
+    const { createBrokerCredential, listBrokerCredentials } = await import(
+      "@/api/brokerCredentials"
+    );
+    const { runJob } = await import("@/api/jobs");
+    vi.mocked(createBrokerCredential).mockResolvedValue({
+      credential: ROW_USER,
+      recovery_phrase: null,
+    });
+    // Seed hook with credRows = [ROW_API] → mode='repair', missingLabel='user_key'
+    vi.mocked(listBrokerCredentials).mockResolvedValueOnce([ROW_API]);
+
+    const { result } = renderHook(() => useSetupWizard({ onComplete: vi.fn() }));
+    await act(async () => {
+      await result.current.loadCredentials();
+    });
+    expect(result.current.state.credRows).toEqual([ROW_API]);
+
+    // Subsequent list call (post-save) returns both rows.
+    vi.mocked(listBrokerCredentials).mockResolvedValue([ROW_API, ROW_USER]);
+    await act(async () => {
+      await result.current.submitBroker({ apiKey: "a", userKey: "u" });
+    });
+    expect(runJob).not.toHaveBeenCalled();
+  });
+
+  it("submitBroker failure with listBrokerCredentials also failing leaves credRows=null", async () => {
+    const { createBrokerCredential, listBrokerCredentials } = await import(
+      "@/api/brokerCredentials"
+    );
+    vi.mocked(createBrokerCredential).mockRejectedValue(new ApiError(500, "boom"));
+    vi.mocked(listBrokerCredentials).mockRejectedValue(new Error("list boom"));
+
+    const { result } = renderHook(() => useSetupWizard({ onComplete: vi.fn() }));
+    await act(async () => {
+      await result.current.submitBroker({ apiKey: "a", userKey: "u" });
+    });
+    expect(result.current.state.brokerError).toBe("Could not save credential.");
+    expect(result.current.state.credRows).toBeNull();
+  });
+
+  it("skipBroker invokes onComplete without dispatching state transitions", async () => {
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useSetupWizard({ onComplete }));
+    act(() => {
+      result.current.skipBroker();
+    });
+    expect(onComplete).toHaveBeenCalledOnce();
+    expect(result.current.state.step).toBe("operator");
+  });
+
+  it("completeWizard invokes onComplete without dispatching state transitions", async () => {
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useSetupWizard({ onComplete }));
+    act(() => {
+      result.current.completeWizard();
+    });
+    expect(onComplete).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/pages/useSetupWizard.ts
+++ b/frontend/src/pages/useSetupWizard.ts
@@ -1,0 +1,306 @@
+/**
+ * useSetupWizard — state machine + fetch dispatchers for SetupPage.
+ *
+ * Reducer covers wizard-step transitions and fetch-status flags. Form-field
+ * inputs (username, password, apiKey, userKey, setupToken) stay as
+ * component-level `useState` in SetupPage.tsx — field churn does not belong
+ * in the state machine.
+ *
+ * Wizard step is "operator" | "broker" only. Completion is a side effect
+ * (markAuthenticated + navigate) driven by the component via the
+ * `onComplete` callback option — there is no "done" state.
+ *
+ * Derived broker-mode (create/repair/complete) is a pure selector over
+ * state.credRows: callers invoke deriveCredentialSetMode(state.credRows)
+ * from @/lib/credentialSetMode. Never a reducer field.
+ */
+import { useCallback, useReducer } from "react";
+
+import type { Operator } from "@/api/auth";
+import { postSetup } from "@/api/auth";
+import type {
+  BrokerCredentialView,
+  ValidateCredentialResponse,
+} from "@/api/brokerCredentials";
+import {
+  createBrokerCredential,
+  listBrokerCredentials,
+  validateBrokerCredential,
+} from "@/api/brokerCredentials";
+import { ApiError } from "@/api/client";
+import { runJob } from "@/api/jobs";
+import { deriveCredentialSetMode, ENVIRONMENT } from "@/lib/credentialSetMode";
+import { GENERIC_ERROR } from "@/pages/setupErrorMessages";
+
+// ---------------------------------------------------------------------------
+// State + actions
+// ---------------------------------------------------------------------------
+
+export type WizardStep = "operator" | "broker";
+
+export type WizardState = {
+  step: WizardStep;
+  pendingOperator: Operator | null;
+  operatorSubmitting: boolean;
+  operatorError: string | null;
+  credRows: BrokerCredentialView[] | null;
+  credRowsLoading: boolean;
+  credRowsError: string | null;
+  brokerSubmitting: boolean;
+  brokerError: string | null;
+  validating: boolean;
+  validation: ValidateCredentialResponse | null;
+  validationError: string | null;
+};
+
+export const initialWizardState: WizardState = {
+  step: "operator",
+  pendingOperator: null,
+  operatorSubmitting: false,
+  operatorError: null,
+  credRows: null,
+  credRowsLoading: false,
+  credRowsError: null,
+  brokerSubmitting: false,
+  brokerError: null,
+  validating: false,
+  validation: null,
+  validationError: null,
+};
+
+export type WizardAction =
+  | { type: "OPERATOR_SUBMIT_START" }
+  | { type: "OPERATOR_SUBMIT_SUCCESS"; operator: Operator }
+  | { type: "OPERATOR_SUBMIT_ERROR" }
+  | { type: "BROKER_CREDS_LOAD_START" }
+  | { type: "BROKER_CREDS_LOAD_SUCCESS"; rows: BrokerCredentialView[] }
+  | { type: "BROKER_CREDS_LOAD_ERROR"; error: string }
+  | { type: "BROKER_SUBMIT_START" }
+  | { type: "BROKER_SUBMIT_SUCCESS"; rows: BrokerCredentialView[] }
+  | { type: "BROKER_SUBMIT_ERROR"; error: string; rows: BrokerCredentialView[] | null }
+  | { type: "VALIDATION_START" }
+  | { type: "VALIDATION_SUCCESS"; result: ValidateCredentialResponse }
+  | { type: "VALIDATION_ERROR"; error: string };
+
+export function wizardReducer(state: WizardState, action: WizardAction): WizardState {
+  switch (action.type) {
+    case "OPERATOR_SUBMIT_START":
+      return { ...state, operatorSubmitting: true, operatorError: null };
+    case "OPERATOR_SUBMIT_SUCCESS":
+      return {
+        ...state,
+        step: "broker",
+        pendingOperator: action.operator,
+        operatorSubmitting: false,
+        operatorError: null,
+      };
+    case "OPERATOR_SUBMIT_ERROR":
+      // #98 non-leaky contract: never propagate err.message into state.
+      return { ...state, operatorSubmitting: false, operatorError: GENERIC_ERROR };
+    case "BROKER_CREDS_LOAD_START":
+      return { ...state, credRowsLoading: true, credRowsError: null };
+    case "BROKER_CREDS_LOAD_SUCCESS":
+      return { ...state, credRowsLoading: false, credRows: action.rows };
+    case "BROKER_CREDS_LOAD_ERROR":
+      // credRows=null → deriveCredentialSetMode returns 'create'.
+      return {
+        ...state,
+        credRowsLoading: false,
+        credRowsError: action.error,
+        credRows: null,
+      };
+    case "BROKER_SUBMIT_START":
+      return { ...state, brokerSubmitting: true, brokerError: null };
+    case "BROKER_SUBMIT_SUCCESS":
+      return {
+        ...state,
+        brokerSubmitting: false,
+        brokerError: null,
+        credRows: action.rows,
+      };
+    case "BROKER_SUBMIT_ERROR":
+      return {
+        ...state,
+        brokerSubmitting: false,
+        brokerError: action.error,
+        credRows: action.rows,
+      };
+    case "VALIDATION_START":
+      return { ...state, validating: true, validation: null, validationError: null };
+    case "VALIDATION_SUCCESS":
+      return {
+        ...state,
+        validating: false,
+        validation: action.result,
+        validationError: null,
+      };
+    case "VALIDATION_ERROR":
+      return { ...state, validating: false, validationError: action.error };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error classifier (pure; unit-tested)
+// ---------------------------------------------------------------------------
+
+export function classifyBrokerSaveError(err: unknown): string {
+  if (err instanceof ApiError && err.status === 409) {
+    return "A credential with that label already exists. Revoke it from Settings to replace.";
+  }
+  if (err instanceof ApiError && err.status === 400) {
+    return "Invalid API key or user key value.";
+  }
+  return "Could not save credential.";
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseSetupWizardOptions {
+  onComplete: () => void;
+}
+
+export interface OperatorSubmitForm {
+  username: string;
+  password: string;
+  setupToken: string; // raw input; hook trims + coerces empty → null
+}
+
+export interface BrokerSubmitForm {
+  apiKey: string;
+  userKey: string;
+}
+
+export type BrokerSubmitResult =
+  | { ok: true; recoveryPhrase: readonly string[] | null }
+  | { ok: false };
+
+export function useSetupWizard({ onComplete }: UseSetupWizardOptions) {
+  const [state, dispatch] = useReducer(wizardReducer, initialWizardState);
+
+  const loadCredentials = useCallback(async (): Promise<void> => {
+    dispatch({ type: "BROKER_CREDS_LOAD_START" });
+    try {
+      const rows = await listBrokerCredentials();
+      dispatch({ type: "BROKER_CREDS_LOAD_SUCCESS", rows });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to load credentials";
+      dispatch({ type: "BROKER_CREDS_LOAD_ERROR", error: msg });
+    }
+  }, []);
+
+  const submitOperator = useCallback(async (form: OperatorSubmitForm): Promise<boolean> => {
+    dispatch({ type: "OPERATOR_SUBMIT_START" });
+    try {
+      const trimmed = form.setupToken.trim();
+      const { operator } = await postSetup(
+        form.username,
+        form.password,
+        trimmed === "" ? null : trimmed,
+      );
+      dispatch({ type: "OPERATOR_SUBMIT_SUCCESS", operator });
+      return true;
+    } catch {
+      // #98: never leak err.message. Reducer sets GENERIC_ERROR unconditionally.
+      dispatch({ type: "OPERATOR_SUBMIT_ERROR" });
+      return false;
+    }
+  }, []);
+
+  const submitBroker = useCallback(
+    async (form: BrokerSubmitForm): Promise<BrokerSubmitResult> => {
+      // Snapshot mode before save so we can decide whether to fire the
+      // first-run universe-sync bootstrap (only on first-time create).
+      const derived = deriveCredentialSetMode(state.credRows);
+      const mode = derived.mode;
+      const missingLabel = derived.missingLabel;
+      const wasCreate = mode === "create";
+
+      dispatch({ type: "BROKER_SUBMIT_START" });
+      try {
+        let phrase: readonly string[] | null = null;
+
+        // Save api_key if needed (Create OR Repair with api_key missing).
+        if (mode === "create" || (mode === "repair" && missingLabel === "api_key")) {
+          const response = await createBrokerCredential({
+            provider: "etoro",
+            label: "api_key",
+            environment: ENVIRONMENT,
+            secret: form.apiKey,
+          });
+          if (response.recovery_phrase != null && response.recovery_phrase.length > 0) {
+            phrase = response.recovery_phrase;
+          }
+        }
+
+        // Save user_key if needed (Create OR Repair with user_key missing).
+        if (mode === "create" || (mode === "repair" && missingLabel === "user_key")) {
+          await createBrokerCredential({
+            provider: "etoro",
+            label: "user_key",
+            environment: ENVIRONMENT,
+            secret: form.userKey,
+          });
+        }
+
+        const rows = await listBrokerCredentials();
+        dispatch({ type: "BROKER_SUBMIT_SUCCESS", rows });
+
+        // First-run bootstrap: fire-and-forget universe sync, only on
+        // first-time create (not Repair). Matches SetupPage.tsx:213-219.
+        if (wasCreate) {
+          void runJob("nightly_universe_sync").catch(() => {});
+        }
+
+        return { ok: true, recoveryPhrase: phrase };
+      } catch (err) {
+        const msg = classifyBrokerSaveError(err);
+        let rows: BrokerCredentialView[] | null = null;
+        try {
+          rows = await listBrokerCredentials();
+        } catch {
+          // swallow — deriveCredentialSetMode(null) falls back to 'create'
+        }
+        dispatch({ type: "BROKER_SUBMIT_ERROR", error: msg, rows });
+        return { ok: false };
+      }
+    },
+    [state.credRows],
+  );
+
+  const skipBroker = useCallback((): void => {
+    onComplete();
+  }, [onComplete]);
+
+  const completeWizard = useCallback((): void => {
+    onComplete();
+  }, [onComplete]);
+
+  const validateCredentials = useCallback(async (form: BrokerSubmitForm): Promise<void> => {
+    dispatch({ type: "VALIDATION_START" });
+    try {
+      const result = await validateBrokerCredential({
+        api_key: form.apiKey,
+        user_key: form.userKey,
+        environment: ENVIRONMENT,
+      });
+      dispatch({ type: "VALIDATION_SUCCESS", result });
+    } catch {
+      dispatch({
+        type: "VALIDATION_ERROR",
+        error: "Could not reach the validation endpoint.",
+      });
+    }
+  }, []);
+
+  return {
+    state,
+    loadCredentials,
+    submitOperator,
+    submitBroker,
+    skipBroker,
+    completeWizard,
+    validateCredentials,
+  };
+}

--- a/frontend/src/pages/useSetupWizard.ts
+++ b/frontend/src/pages/useSetupWizard.ts
@@ -80,7 +80,8 @@ export type WizardAction =
   | { type: "BROKER_SUBMIT_ERROR"; error: string; rows: BrokerCredentialView[] | null }
   | { type: "VALIDATION_START" }
   | { type: "VALIDATION_SUCCESS"; result: ValidateCredentialResponse }
-  | { type: "VALIDATION_ERROR"; error: string };
+  | { type: "VALIDATION_ERROR"; error: string }
+  | { type: "VALIDATION_CLEAR" };
 
 export function wizardReducer(state: WizardState, action: WizardAction): WizardState {
   switch (action.type) {
@@ -136,6 +137,11 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
       };
     case "VALIDATION_ERROR":
       return { ...state, validating: false, validationError: action.error };
+    case "VALIDATION_CLEAR":
+      // Clears prior result/error without touching `validating` — used
+      // when inputs change so the operator doesn't see a stale pass/fail
+      // banner against new values.
+      return { ...state, validation: null, validationError: null };
   }
 }
 
@@ -244,7 +250,17 @@ export function useSetupWizard({ onComplete }: UseSetupWizardOptions) {
           });
         }
 
-        const rows = await listBrokerCredentials();
+        // Refresh credRows post-save. Failure here must NOT flip the
+        // wizard into the error path — the saves already succeeded and
+        // retrying would 409 on the rows that are already persisted.
+        // Keep credRows at whatever pre-save state we had; the next
+        // step-2 mount (if any) will re-fetch.
+        let rows: BrokerCredentialView[] = state.credRows ?? [];
+        try {
+          rows = await listBrokerCredentials();
+        } catch {
+          // swallow — post-save read is best-effort
+        }
         dispatch({ type: "BROKER_SUBMIT_SUCCESS", rows });
 
         // First-run bootstrap: fire-and-forget universe sync, only on
@@ -277,6 +293,10 @@ export function useSetupWizard({ onComplete }: UseSetupWizardOptions) {
     onComplete();
   }, [onComplete]);
 
+  const clearValidation = useCallback((): void => {
+    dispatch({ type: "VALIDATION_CLEAR" });
+  }, []);
+
   const validateCredentials = useCallback(async (form: BrokerSubmitForm): Promise<void> => {
     dispatch({ type: "VALIDATION_START" });
     try {
@@ -302,5 +322,6 @@ export function useSetupWizard({ onComplete }: UseSetupWizardOptions) {
     skipBroker,
     completeWizard,
     validateCredentials,
+    clearValidation,
   };
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -29,6 +29,11 @@ export default mergeConfig(
       setupFiles: ["./src/test/setup.ts"],
       css: false,
       include: ["src/**/*.{test,spec}.{ts,tsx}"],
+      // Pin pool + cap concurrency. Vitest v2 defaults to forks already;
+      // pinning makes the choice explicit so a future edit doesn't silently
+      // switch back to threads (where #399 hit a tinypool crash).
+      pool: "forks",
+      poolOptions: { forks: { minForks: 1, maxForks: 2 } },
     },
   }),
 );


### PR DESCRIPTION
## What

- `vitest.config.ts` — pin `pool: "forks"` + `minForks: 1, maxForks: 2`. Vitest v2 defaults to forks already; pinning prevents silent regression + cap halves sustained CPU (+ avoids tinypool threads crash observed in #399).
- New `frontend/src/pages/setupErrorMessages.ts` — shared `GENERIC_ERROR` constant.
- New `frontend/src/pages/useSetupWizard.ts` — pure `wizardReducer`, `classifyBrokerSaveError` helper, `useSetupWizard` hook. Extracts wizard state machine from `SetupPage.tsx`.
- New `frontend/src/pages/useSetupWizard.test.ts` — 19 reducer unit tests + 5 classifier unit tests + 7 `renderHook` integration tests.
- `SetupPage.tsx` consumes the hook; keeps form-field `useState` local.
- `SetupPage.test.tsx` trimmed from 12 tests to 6 integration tests (happy-path save, happy-path skip, confirm-cancel, phrase-modal, repair-mode, already-complete).
- `package.json` — `test:unit` / `test:integration` / `test` script split.
- `.claude/CLAUDE.md` pre-push block points to `test:unit`; CI still runs full `test`.

## Why

Closes frontend items from #327. SetupPage had 12 tests at 500-1700ms each. Pure reducer covers state transitions at <20ms total; hook-level `renderHook` covers fetch wiring; 6 kept integration tests cover irreducible multi-step UX.

Backend pytest-xdist from #327 deferred to follow-up (needs `ebull_test` audit + collection-bootstrap idempotency per Codex ckpt 1 on #404 predecessor).

## Test plan

- Reducer + classifier unit tests: 25 PASS <20ms.
- Hook integration tests: 7 PASS (includes GENERIC_ERROR non-leak contract + runJob fire-and-forget).
- SetupPage integration tests: 6 PASS in ~6s (was 12 tests in ~12s).
- Full frontend: 364 tests PASS.
- Full backend: 2328 tests PASS.
- `test:unit` runs faster than `test` (excludes heavy integration file).

## Called out

- #98 non-leaky-error contract preserved: `OPERATOR_SUBMIT_ERROR` carries no payload; reducer hard-codes `GENERIC_ERROR`.
- Derived broker-mode stays a pure selector over `credRows` — not a reducer field.
- Codex ckpt 2 caught two regressions, both fixed before push:
  1. Post-save `listBrokerCredentials` refresh failure was flipping the wizard into the error path even though saves succeeded (would 409 on retry). Fixed — refresh is best-effort; success dispatched either way.
  2. Validation-reset useEffect was a no-op after refactor — typing after Test-connection left stale banner. Fixed — added `VALIDATION_CLEAR` action + `hook.clearValidation()` + useEffect.
- CI runs full `test`; pre-push local runs `test:unit`.
- pytest-xdist deferred — needs audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)