### PR TITLE
fix: tech-debt quick wins — #248 loopback compose + #250 migration-prefix test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,12 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-ebull}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    # Bind to loopback by default (#248). Without the 127.0.0.1 prefix,
+    # Docker publishes on 0.0.0.0 and a LAN-reachable host would expose
+    # a default-password Postgres. Override via ``POSTGRES_BIND`` if
+    # multi-host access is genuinely required.
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "${POSTGRES_BIND:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
 
@@ -16,8 +20,11 @@ services:
     image: redis:7-alpine
     container_name: ebull-redis
     restart: unless-stopped
+    # Bind to loopback by default (#248). Redis has no auth configured;
+    # a 0.0.0.0 publish would hand an unauthenticated cache to anything
+    # on the LAN. Override via ``REDIS_BIND`` if needed.
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      - "${REDIS_BIND:-127.0.0.1}:${REDIS_PORT:-6379}:6379"
 
 volumes:
   pgdata:

--- a/tests/test_migration_prefixes_unique.py
+++ b/tests/test_migration_prefixes_unique.py
@@ -1,0 +1,75 @@
+"""Migration-prefix hygiene (#250).
+
+Every ``sql/NNN_*.sql`` migration must have a unique ``NNN_`` prefix so
+human-authored ordering references stay unambiguous. One historical
+collision (``024_broker_positions.sql`` + ``024_fundamentals_enrichment.sql``)
+pre-dates the rule; it is pinned in the allow-list below so renaming an
+already-applied migration doesn't break deployed ``schema_migrations``
+tracking. Any NEW duplicate must be caught at test time.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+# Historical collisions — intentionally preserved because renaming would
+# desync ``schema_migrations`` rows on deployed DBs. Every entry is the
+# three-digit prefix (as str) followed by the set of filenames that share
+# it. ADD to this list ONLY after an explicit discussion; the default
+# contract is "new migrations MUST be unique".
+_GRANDFATHERED_DUPLICATES: dict[str, set[str]] = {
+    "024": {"024_broker_positions.sql", "024_fundamentals_enrichment.sql"},
+}
+
+_SQL_DIR = Path(__file__).resolve().parent.parent / "sql"
+_PREFIX_RE = re.compile(r"^(\d{3})_[a-zA-Z0-9_]+\.sql$")
+
+
+def test_migration_numeric_prefixes_are_unique_or_grandfathered() -> None:
+    """Every sql/NNN_*.sql prefix is either unique or on the grandfathered list."""
+    files = sorted(p.name for p in _SQL_DIR.glob("*.sql"))
+    assert files, "sql/ directory is empty — test precondition violated"
+
+    prefix_to_files: dict[str, list[str]] = {}
+    for name in files:
+        match = _PREFIX_RE.match(name)
+        assert match is not None, (
+            f"Migration {name!r} does not match the NNN_<snake>.sql naming contract. "
+            f"Fix the filename before merging."
+        )
+        prefix = match.group(1)
+        prefix_to_files.setdefault(prefix, []).append(name)
+
+    # Collisions → either grandfathered exactly, or a new bug.
+    for prefix, names in prefix_to_files.items():
+        if len(names) == 1:
+            continue
+        expected = _GRANDFATHERED_DUPLICATES.get(prefix)
+        assert expected is not None, (
+            f"New duplicate migration prefix {prefix!r}: {names}. "
+            f"Rename one file before merging OR — if you have an explicit "
+            f"reason + discussion log — add {prefix!r} to "
+            f"_GRANDFATHERED_DUPLICATES with the exact set."
+        )
+        assert set(names) == expected, (
+            f"Grandfathered prefix {prefix!r} expected files {sorted(expected)} "
+            f"but found {sorted(names)}. If a grandfathered migration was "
+            f"renamed or a new file added under the same prefix, update "
+            f"_GRANDFATHERED_DUPLICATES explicitly."
+        )
+
+
+def test_no_accidental_prefix_regression() -> None:
+    """Smoke: all prefixes are strictly 3-digit. A 2- or 4-digit prefix
+    would silently sort wrong under lexicographic ordering."""
+    files = sorted(p.name for p in _SQL_DIR.glob("*.sql"))
+    prefixes = [f.split("_", 1)[0] for f in files]
+    widths = Counter(len(p) for p in prefixes)
+    # Allow exactly width=3; anything else is a regression.
+    assert list(widths.keys()) == [3], (
+        f"Migration prefix widths drifted from 3-digit: {widths}. "
+        f"Lexicographic sort would order '10_foo.sql' before '2_foo.sql' "
+        f"under mixed widths."
+    )

--- a/tests/test_migration_prefixes_unique.py
+++ b/tests/test_migration_prefixes_unique.py
@@ -62,9 +62,16 @@ def test_migration_numeric_prefixes_are_unique_or_grandfathered() -> None:
 
 def test_no_accidental_prefix_regression() -> None:
     """Smoke: all prefixes are strictly 3-digit. A 2- or 4-digit prefix
-    would silently sort wrong under lexicographic ordering."""
+    would silently sort wrong under lexicographic ordering.
+
+    Files that don't match ``_PREFIX_RE`` (e.g. a hypothetical
+    ``init.sql``) are handled by
+    ``test_migration_numeric_prefixes_are_unique_or_grandfathered`` —
+    this test only polices the width of files that ARE prefixed, so
+    non-prefix failures surface with the correct error message there.
+    """
     files = sorted(p.name for p in _SQL_DIR.glob("*.sql"))
-    prefixes = [f.split("_", 1)[0] for f in files]
+    prefixes = [m.group(1) for f in files if (m := _PREFIX_RE.match(f))]
     widths = Counter(len(p) for p in prefixes)
     # Allow exactly width=3; anything else is a regression.
     assert list(widths.keys()) == [3], (

--- a/tests/test_migration_prefixes_unique.py
+++ b/tests/test_migration_prefixes_unique.py
@@ -36,8 +36,7 @@ def test_migration_numeric_prefixes_are_unique_or_grandfathered() -> None:
     for name in files:
         match = _PREFIX_RE.match(name)
         assert match is not None, (
-            f"Migration {name!r} does not match the NNN_<snake>.sql naming contract. "
-            f"Fix the filename before merging."
+            f"Migration {name!r} does not match the NNN_<snake>.sql naming contract. Fix the filename before merging."
         )
         prefix = match.group(1)
         prefix_to_files.setdefault(prefix, []).append(name)


### PR DESCRIPTION
## What

Two small tech-debt tickets, one PR.

### #248 — bind docker-compose Postgres + Redis to loopback by default

`docker-compose.yml` now publishes with `127.0.0.1` as the default bind address via `POSTGRES_BIND` / `REDIS_BIND` env overrides. Without this, Docker publishes on `0.0.0.0` and a LAN-reachable host would expose a default-password Postgres + unauthenticated Redis.

### #250 — enforce unique migration numeric prefixes

New `tests/test_migration_prefixes_unique.py` catches duplicate `NNN_` prefixes at test time. Historical `024_` collision grandfathered in an explicit allow-list (renaming already-applied migrations would desync `schema_migrations` tracking on deployed DBs). Also guards against mixed prefix widths.

## Also in this session (not this PR)

- **#25** already fixed on main (line 529 of `sec_edgar.py` has the `isinstance(tickers, list) and tickers` guard). Closed.
- **#41** closed as rebutted after Codex ckpt 2: ticket premise (silent abort on ValueError) no longer holds — `_tracked_job` re-raises now. Fail-fast is correct at that call site.

## Test plan

- Full backend suite: 2332 passed.
- New migration-prefix tests: 2 PASS.
- `docker compose config` still parses (verified).

## Called out

- No behaviour change for operators using default compose setup on localhost.
- `POSTGRES_BIND` / `REDIS_BIND` env-var documented in the compose comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)