### PR TITLE
fix: tech-debt quick wins — #46 single cash snapshot + #42 pending_sector_pct accumulator

### DIFF
--- a/app/services/execution_guard.py
+++ b/app/services/execution_guard.py
@@ -237,6 +237,7 @@ def _load_cash(conn: psycopg.Connection[Any]) -> float | None:
 def _load_sector_exposure(
     conn: psycopg.Connection[Any],
     instrument_id: int,
+    cash: float,
 ) -> tuple[bool, str | None, float, float]:
     """
     Return (instrument_found, sector, current_sector_pct, total_aum).
@@ -246,13 +247,19 @@ def _load_sector_exposure(
     current_sector_pct is the fraction of AUM currently in the same sector as
     instrument_id (excluding the instrument itself, since it is unowned for BUY).
     total_aum = SUM(position mark-to-market, **excluding the queried
-    instrument**) + cash + active mirror equity. The positions SELECT at
+    instrument**) + ``cash`` + active mirror equity. The positions SELECT at
     line ~269 filters `p.instrument_id != %(iid)s` (added in c006ae6 as a
     bug fix for #9 — without this, ADD actions on an already-held position
     would double-count the existing holding). This exclusion therefore
     applies to the whole total_aum figure the caller sees, not just to the
     sector numerator. Returns 0.0 when unknown. Mirrors expand the
     denominator only — the sector numerator is untouched (spec §4, #187).
+
+    ``cash`` is passed in by the caller (from the single ``compute_budget_state``
+    read) rather than re-queried here — prevents the #46 snapshot drift
+    where ``compute_budget_state`` and this function read ``cash_ledger``
+    independently within the same guard invocation and could observe
+    different totals if a row is inserted between them.
     """
     # Instrument sector
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -297,12 +304,8 @@ def _load_sector_exposure(
         sector_values[r["sector"]] = mv
         total_positions += mv
 
-    # Cash
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute("SELECT SUM(amount) AS balance FROM cash_ledger")
-        row = cur.fetchone()
-    cash = float(row["balance"]) if row is not None and row["balance"] is not None else 0.0
-
+    # Cash is passed in by the caller — read once per evaluate_recommendation
+    # invocation via compute_budget_state rather than re-queried here (#46).
     mirror_equity = _load_mirror_equity(conn)
     total_aum = total_positions + cash + mirror_equity
     current_sector_pct = (sector_values.get(sector, 0.0) / total_aum) if total_aum > 0 else 0.0
@@ -716,12 +719,21 @@ def evaluate_recommendation(
         cost_model_row = load_instrument_cost(conn, instrument_id)
         # Budget-aware cash check: replaces raw _load_cash(conn).
         # compute_budget_state reads budget_config, cash_ledger, positions,
-        # copy_mirrors, disposal_matches, and live_fx_rates.
+        # copy_mirrors, disposal_matches, and live_fx_rates. We then hand
+        # the resolved cash figure to _load_sector_exposure so both checks
+        # share a single cash_ledger snapshot (#46).
         try:
             budget = compute_budget_state(conn)
         except BudgetConfigCorrupt:
             budget = None
-        instrument_found, sector, current_sector_pct, total_aum = _load_sector_exposure(conn, instrument_id)
+        cash_for_aum = (
+            float(budget.cash_balance)
+            if budget is not None and budget.cash_balance is not None
+            else 0.0
+        )
+        instrument_found, sector, current_sector_pct, total_aum = _load_sector_exposure(
+            conn, instrument_id, cash_for_aum
+        )
 
     # --- Step 3: evaluate rules ---
     rule_results: list[RuleResult] = []

--- a/app/services/execution_guard.py
+++ b/app/services/execution_guard.py
@@ -722,15 +722,21 @@ def evaluate_recommendation(
         # copy_mirrors, disposal_matches, and live_fx_rates. We then hand
         # the resolved cash figure to _load_sector_exposure so both checks
         # share a single cash_ledger snapshot (#46).
+        #
+        # If budget_config is corrupt we still need a real cash figure for
+        # the concentration check — falling back to 0.0 would report a
+        # spurious concentration_breach alongside the real budget_available
+        # failure and muddy the audit trail. Read cash_ledger directly in
+        # that one path.
         try:
             budget = compute_budget_state(conn)
         except BudgetConfigCorrupt:
             budget = None
-        cash_for_aum = (
-            float(budget.cash_balance)
-            if budget is not None and budget.cash_balance is not None
-            else 0.0
-        )
+        if budget is not None and budget.cash_balance is not None:
+            cash_for_aum = float(budget.cash_balance)
+        else:
+            fallback_cash = _load_cash(conn)
+            cash_for_aum = fallback_cash if fallback_cash is not None else 0.0
         instrument_found, sector, current_sector_pct, total_aum = _load_sector_exposure(
             conn, instrument_id, cash_for_aum
         )

--- a/app/services/portfolio.py
+++ b/app/services/portfolio.py
@@ -630,6 +630,7 @@ def _evaluate_add(
     prev_score_total: float | None,
     total_aum: float,
     positions: dict[int, PositionState],
+    pending_sector_pct: dict[str, float],
 ) -> tuple[bool, str]:
     """
     Return (should_add, reason).
@@ -640,6 +641,15 @@ def _evaluate_add(
       - no thesis break (max_red_flag below threshold)
       - conviction improved: confidence_score delta >= 0.05 OR score delta >= 0.05
       - sector concentration passes after proposed add
+
+    ``pending_sector_pct`` is the accumulator that _evaluate_buy
+    maintains for approved-so-far BUYs in the current review pass. In
+    today's run_portfolio_review order (ADDs before any BUY accumulation)
+    the caller passes ``{}`` and the accumulator is effectively unused;
+    the parameter exists so the invariant does not depend on evaluation
+    order (#42). If a future refactor interleaves BUYs + ADDs, the
+    sector-breach check here already sees in-flight BUYs without
+    further changes.
     """
     if total_aum <= 0:
         return False, ""
@@ -678,9 +688,16 @@ def _evaluate_add(
         return False, ""
 
     # Sector check: would adding breach the cap?
+    #
+    # Includes held positions (_sector_pct) AND any in-flight BUYs from
+    # this same review pass (pending_sector_pct). Today the caller passes
+    # pending={} because BUYs run after ADDs, but carrying the accumulator
+    # in the signature means the invariant stops relying on caller order.
     headroom = MAX_FULL_POSITION_PCT - current_pct
     add_pct = min(headroom, MAX_INITIAL_POSITION_PCT)
-    sector_after = _sector_pct(positions, pos.sector, total_aum) + add_pct
+    held_sector_pct = _sector_pct(positions, pos.sector, total_aum)
+    pending_pct = pending_sector_pct.get(pos.sector, 0.0) if pos.sector is not None else 0.0
+    sector_after = held_sector_pct + pending_pct + add_pct
     if pos.sector is not None and sector_after > MAX_SECTOR_EXPOSURE_PCT:
         return (
             False,
@@ -1003,7 +1020,15 @@ def run_portfolio_review(
         # 2. ADD (only if ranked and has a score)
         if latest_score is not None:
             prev_score_total = prev_scores.get(iid)
-            should_add, add_reason = _evaluate_add(pos, details, latest_score, prev_score_total, total_aum, positions)
+            should_add, add_reason = _evaluate_add(
+                pos,
+                details,
+                latest_score,
+                prev_score_total,
+                total_aum,
+                positions,
+                pending_sector_pct={},  # ADDs currently evaluated before BUY accumulator is touched (#42)
+            )
             if should_add:
                 current_pct = pos.market_value / total_aum if total_aum > 0 else 0.0
                 add_target = min(current_pct + MAX_INITIAL_POSITION_PCT, MAX_FULL_POSITION_PCT)

--- a/tests/test_execution_guard.py
+++ b/tests/test_execution_guard.py
@@ -204,7 +204,6 @@ def _sector_cursors(
     sector: str | None = "Technology",
     sector_market_value: float = 0.0,
     total_positions: float = 0.0,
-    cash: float = 50_000.0,
     instrument_missing: bool = False,
     mirror_equity: float = 0.0,
 ) -> list[MagicMock]:
@@ -212,11 +211,10 @@ def _sector_cursors(
 
     When instrument_missing=True the instruments cursor returns no rows and
     _load_sector_exposure returns early — only 1 cursor is consumed.
-    Otherwise 4 cursors are returned (instruments, positions, cash_ledger,
-    mirror_equity). The mirror_equity cursor is consumed by
-    `_load_mirror_equity`, wired into `total_aum` by Track 1b (#187).
-    Existing mock-driven tests default it to 0.0 so the pre-PR behaviour
-    is preserved bit-identically.
+    Otherwise 3 cursors are returned (instruments, positions, mirror_equity).
+    The cash_ledger cursor was removed in #46 — cash is now a parameter
+    passed by the caller (evaluate_recommendation reads it once via
+    compute_budget_state and hands the snapshot to _load_sector_exposure).
     """
     if instrument_missing:
         return [_make_cursor([])]
@@ -225,9 +223,8 @@ def _sector_cursors(
         positions_cur = _make_cursor([{"sector": sector, "market_value": sector_market_value}])
     else:
         positions_cur = _make_cursor([])
-    cash_cur = _make_cursor([{"balance": cash}])
     mirror_cur = _make_cursor([{"total": mirror_equity}])
-    return [instrument_cur, positions_cur, cash_cur, mirror_cur]
+    return [instrument_cur, positions_cur, mirror_cur]
 
 
 def _cost_config_cursor(
@@ -304,7 +301,6 @@ def _buy_cursors(
     sector: str | None = "Technology",
     sector_mv: float = 0.0,
     total_positions: float = 0.0,
-    cash_for_sector: float = 50_000.0,
     instrument_missing: bool = False,
     decision_id: int = 99,
 ) -> list[MagicMock]:
@@ -329,7 +325,6 @@ def _buy_cursors(
             sector=sector,
             sector_market_value=sector_mv,
             total_positions=total_positions,
-            cash=cash_for_sector,
             instrument_missing=instrument_missing,
         ),
         _audit_cursor(decision_id=decision_id),
@@ -930,7 +925,7 @@ class TestEvaluateRecommendation:
         cursors = _buy_cursors(
             sector="Technology",
             sector_mv=10_500.0,
-            cash_for_sector=39_500.0,
+            cash_balance=39_500.0,
         )
         result = self._eval(cursors)
         assert result.verdict == "FAIL"
@@ -942,7 +937,7 @@ class TestEvaluateRecommendation:
         cursors = _buy_cursors(
             sector="Technology",
             sector_mv=10_000.0,
-            cash_for_sector=40_000.0,
+            cash_balance=40_000.0,
         )
         result = self._eval(cursors)
         assert result.verdict == "PASS"

--- a/tests/test_execution_guard.py
+++ b/tests/test_execution_guard.py
@@ -256,6 +256,7 @@ def _budget_cursors_list(
     *,
     cash_balance: float | None = 10_000.0,
     budget_corrupt: bool = False,
+    fallback_cash: float | None = 10_000.0,
 ) -> list[MagicMock]:
     """Return the cursor sequence consumed by compute_budget_state.
 
@@ -268,12 +269,21 @@ def _budget_cursors_list(
       4: tax_estimates (_load_tax_estimates)
       5: gbp_usd_rate (_load_gbp_usd_rate)
 
+    #46: when the budget path cannot supply cash (corrupt budget OR
+    ``cash_balance=None``), execution_guard falls back to ``_load_cash``
+    to avoid zeroing out the sector-concentration denominator. An extra
+    cash_ledger cursor is appended in those cases; the ``fallback_cash``
+    arg controls what ``_load_cash`` returns.
+
     Note: test_budget.py patches _load_mirror_equity directly (5 cursors),
     so its _budget_conn() helper omits cursor 3.
     """
     if budget_corrupt:
-        return [_make_cursor([])]  # empty budget_config -> BudgetConfigCorrupt
-    return [
+        return [
+            _make_cursor([]),  # empty budget_config -> BudgetConfigCorrupt
+            _make_cursor([{"balance": fallback_cash}]),  # execution_guard fallback _load_cash
+        ]
+    cursors = [
         _budget_config_cursor(),
         _budget_cash_cursor(balance=cash_balance),
         _budget_deployed_cursor(),
@@ -281,6 +291,11 @@ def _budget_cursors_list(
         _budget_tax_cursor(),
         _budget_fx_cursor(),
     ]
+    # cash_balance=None means compute_budget_state returns cash_balance=None,
+    # triggering the execution_guard fallback _load_cash read.
+    if cash_balance is None:
+        cursors.append(_make_cursor([{"balance": fallback_cash}]))
+    return cursors
 
 
 def _buy_cursors(

--- a/tests/test_execution_guard_mirror_aum.py
+++ b/tests/test_execution_guard_mirror_aum.py
@@ -155,7 +155,7 @@ def test_empty_baseline_no_mirrors(
     )
     conn.commit()
 
-    found, sector, pct, total_aum = _load_sector_exposure(conn, _GUARD_INSTRUMENT_ID)
+    found, sector, pct, total_aum = _load_sector_exposure(conn, _GUARD_INSTRUMENT_ID, cash=100.0)
     assert found is True
     assert sector == _GUARD_INSTRUMENT_SECTOR
     assert total_aum == pytest.approx(250.0 + 100.0, abs=1e-6)
@@ -182,7 +182,7 @@ def test_active_mirror_adds_to_denominator(
     expected_mirror = _load_mirror_equity(conn)
     assert expected_mirror == pytest.approx(1550.0, abs=1e-6)
 
-    found, sector, pct, total_aum = _load_sector_exposure(conn, _GUARD_INSTRUMENT_ID)
+    found, sector, pct, total_aum = _load_sector_exposure(conn, _GUARD_INSTRUMENT_ID, cash=100.0)
     assert found is True
     assert sector == _GUARD_INSTRUMENT_SECTOR
     assert total_aum == pytest.approx(250.0 + 100.0 + 1550.0, abs=1e-6)
@@ -208,7 +208,7 @@ def test_closed_mirror_contributes_nothing(
     )
     conn.commit()
 
-    found, _, _, total_aum = _load_sector_exposure(conn, _GUARD_INSTRUMENT_ID)
+    found, _, _, total_aum = _load_sector_exposure(conn, _GUARD_INSTRUMENT_ID, cash=100.0)
     assert found is True
     assert total_aum == pytest.approx(250.0 + 100.0, abs=1e-6)
 
@@ -239,7 +239,7 @@ def test_sector_numerator_unchanged_by_mirror(
     # cover only the 770001 position (which the query itself
     # excludes via instrument_id != iid, so numerator = 0).
     # The denominator still includes the mirror.
-    found_hc, sector_hc, pct_hc, aum_hc = _load_sector_exposure(conn, 770001)
+    found_hc, sector_hc, pct_hc, aum_hc = _load_sector_exposure(conn, 770001, cash=100.0)
     assert found_hc is True
     assert sector_hc == "healthcare"
     # Expected: the sole healthcare position is the iid being
@@ -272,12 +272,12 @@ def test_guard_delta_matches_mirror_equity(
     conn.commit()
 
     expected_mirror_contribution = _load_mirror_equity(conn)
-    _, _, _, with_mirror = _load_sector_exposure(conn, _GUARD_INSTRUMENT_ID)
+    _, _, _, with_mirror = _load_sector_exposure(conn, _GUARD_INSTRUMENT_ID, cash=100.0)
 
     with conn.cursor() as cur:
         cur.execute("UPDATE copy_mirrors SET active = FALSE")
     conn.commit()
 
-    _, _, _, without_mirror = _load_sector_exposure(conn, _GUARD_INSTRUMENT_ID)
+    _, _, _, without_mirror = _load_sector_exposure(conn, _GUARD_INSTRUMENT_ID, cash=100.0)
 
     assert (with_mirror - without_mirror) == pytest.approx(expected_mirror_contribution, abs=1e-6)

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -180,6 +180,7 @@ class TestEvaluateAdd:
             prev_score_total,
             total_aum=10_000.0,
             positions=self._base_positions(pos),
+            pending_sector_pct={},
         )
         assert should_add is True
         assert "score improved" in reason
@@ -199,6 +200,7 @@ class TestEvaluateAdd:
             prev_score_total,
             total_aum=10_000.0,
             positions=self._base_positions(pos),
+            pending_sector_pct={},
         )
         assert should_add is True
         assert "confidence improved" in reason
@@ -218,6 +220,7 @@ class TestEvaluateAdd:
             prev_score_total,
             total_aum=10_000.0,
             positions=self._base_positions(pos),
+            pending_sector_pct={},
         )
         assert should_add is False
 
@@ -236,6 +239,7 @@ class TestEvaluateAdd:
             prev_score_total=0.60,
             total_aum=10_000.0,
             positions=self._base_positions(pos),
+            pending_sector_pct={},
         )
         assert should_add is False
 
@@ -253,6 +257,7 @@ class TestEvaluateAdd:
             prev_score_total=0.60,
             total_aum=10_000.0,
             positions=self._base_positions(pos),
+            pending_sector_pct={},
         )
         assert should_add is False
 
@@ -271,6 +276,7 @@ class TestEvaluateAdd:
             prev_score_total=0.60,
             total_aum=10_000.0,
             positions=self._base_positions(pos),
+            pending_sector_pct={},
         )
         assert should_add is False
 
@@ -291,9 +297,40 @@ class TestEvaluateAdd:
             prev_score_total=0.60,
             total_aum=10_000.0,
             positions={1: pos1, 2: pos2},
+            pending_sector_pct={},
         )
         # Technology = (2000+400)/10000 = 24%; add_pct = min(10%-4%, 5%) = 5%
         # sector_after = 24% + 5% = 29% > 25% cap
+        assert should_add is False
+        assert "sector" in reason.lower()
+
+
+    def test_pending_sector_pct_accumulator_pushes_add_over_cap(self) -> None:
+        """#42: even if held-sector-only math stays under the cap, a large
+        in-flight pending BUY allocation in the same sector should block
+        the ADD. Documents the invariant that the signature now enforces.
+        """
+        # pos1: Technology 8% (below full-size 10% → ADD eligible)
+        # pos2: Technology 12% (other holding).  held_sector_pct = 20%.
+        # add_pct = min(10% - 8%, 5%) = 2%. sector_after without pending
+        # = 20% + 2% = 22% (passes). With pending 5% BUY in Technology,
+        # sector_after = 20% + 5% + 2% = 27% > 25% cap.
+        pos1 = _pos(instrument_id=1, symbol="A", sector="Technology", market_value=800.0)
+        pos2 = _pos(instrument_id=2, symbol="B", sector="Technology", market_value=1_200.0)
+        details: dict[str, Any] = {
+            "thesis": _thesis(stance="buy"),
+            "prev_thesis_confidence": 0.60,
+        }
+        latest_score = _score(total_score=0.80, confidence_score=0.80)
+        should_add, reason = _evaluate_add(
+            pos1,
+            details,
+            latest_score,
+            prev_score_total=0.60,
+            total_aum=10_000.0,
+            positions={1: pos1, 2: pos2},
+            pending_sector_pct={"Technology": 0.05},
+        )
         assert should_add is False
         assert "sector" in reason.lower()
 

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -304,7 +304,6 @@ class TestEvaluateAdd:
         assert should_add is False
         assert "sector" in reason.lower()
 
-
     def test_pending_sector_pct_accumulator_pushes_add_over_cap(self) -> None:
         """#42: even if held-sector-only math stays under the cap, a large
         in-flight pending BUY allocation in the same sector should block


### PR DESCRIPTION
## What

Two contained tech-debt tickets.

### #46 — execution guard cash_ledger single-snapshot

`_load_sector_exposure` previously re-read `cash_ledger` after `compute_budget_state` had already read it — two reads, one invocation, potential for divergent totals if a row inserted between them. Now takes `cash` as a parameter: `evaluate_recommendation` passes `budget.cash_balance` when budget is healthy, falls back to `_load_cash` when the budget config is corrupt or returns `cash_balance=None`. Either way, exactly one cash_ledger read per invocation.

Codex ckpt 2 caught that the naive `cash_for_aum = 0.0` fallback zeroed the concentration denominator on budget-corrupt paths and produced a spurious `concentration_breach` alongside the real `budget_available` failure — fixed by the `_load_cash` fallback.

### #42 — `_evaluate_add` takes `pending_sector_pct`

Sector-breach check in `_evaluate_add` now sees held positions + in-flight BUYs + the proposed add. Current call site passes `{}` because ADDs run before any BUY accumulation; the parameter absorbs the invisible ordering dependency into the signature so a future refactor that interleaves BUYs + ADDs stays correct. One new test exercises the accumulator path.

## Test plan

- 84 guard tests pass (mock cursor sequence updated — dropped the cash cursor from `_sector_cursors`, added a fallback cash cursor in `_budget_cursors_list` for corrupt/null-cash paths).
- 39 portfolio tests pass including new `test_pending_sector_pct_accumulator_pushes_add_over_cap`.
- Full suite: 2331 passed.

## Called out

- Behaviour change on healthy paths: none. Behaviour change on corrupt-budget paths: concentration check now uses real cash instead of 0 — audit trail cleaner, no false-positive `concentration_breach` on top of `budget_available` failure.
- ADD evaluation semantics: currently unchanged (caller passes `{}`). Guard-rail only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)