### PR TITLE
fix(sec): tolerate 403 before publish cutoff + bump lookback 7→30

### DIFF
--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -28,14 +28,23 @@ Provider contract:
 import hashlib
 import logging
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, time
 from types import TracebackType
+from zoneinfo import ZoneInfo
 
 import httpx
 
 from app.providers.filings import FilingEvent, FilingNotFound, FilingSearchResult, FilingsProvider
 from app.providers.resilient_client import ResilientClient
 from app.services import raw_persistence
+
+_ET = ZoneInfo("America/New_York")
+
+# SEC publishes the daily master-index ~22:00 ET on the same business
+# day. Before that moment a 403 on the current day is the "not yet
+# published" signal. After it, a 403 means SEC is actively blocking us
+# (UA/rate-limit/WAF) and must surface.
+_MASTER_INDEX_PUBLISH_HOUR_ET = 22
 
 logger = logging.getLogger(__name__)
 
@@ -331,8 +340,18 @@ class SecFilingsProvider(FilingsProvider):
         body bytes + sha256 hash + Last-Modified header for the caller
         to persist in the watermark row.
 
+        SEC's Archives host serves 403 (not 404) for files that do not
+        yet exist — current-day files are only published after the
+        Eastern-time business day closes (~22:00 ET). To distinguish
+        "not yet published" from a genuine access block, a 403 is
+        tolerated only when ``target_date`` is still within its
+        publish window: future-dated, or same-day-ET before the
+        22:00-ET publish cutoff. A 403 on a past date, or on the
+        current ET day after the publish cutoff, raises — that's
+        SEC refusing us (UA/rate-limit/etc.), not awaiting publication.
+
         Rate-limited alongside the other SEC clients via the shared
-        timestamp list, so a burst of 7 calls respects the 10 rps cap.
+        timestamp list, so a burst of N calls respects the 10 rps cap.
         """
         quarter = (target_date.month - 1) // 3 + 1
         url = (
@@ -346,6 +365,21 @@ class SecFilingsProvider(FilingsProvider):
         resp = self._http_tickers.get(url, headers=headers)
         if resp.status_code in (304, 404):
             return None
+        if resp.status_code == 403:
+            now_et = datetime.now(_ET)
+            publish_due = datetime.combine(
+                target_date,
+                time(_MASTER_INDEX_PUBLISH_HOUR_ET, 0),
+                tzinfo=_ET,
+            )
+            if now_et < publish_due:
+                logger.info(
+                    "SEC master-index: 403 on %s treated as not-yet-published (now_et=%s publish_due=%s)",
+                    target_date.isoformat(),
+                    now_et.isoformat(timespec="minutes"),
+                    publish_due.isoformat(timespec="minutes"),
+                )
+                return None
         resp.raise_for_status()
         body_hash = hashlib.sha256(resp.content).hexdigest()
         return MasterIndexFetchResult(

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -1102,7 +1102,16 @@ def normalize_financial_periods(
 # ============================================================================
 
 
-LOOKBACK_DAYS = 7
+# 30-day rolling window covers typical outage / offline scenarios
+# (weekend + holiday + a few days of developer laptop being off)
+# without explicit backfill. Each day has its own watermark keyed by
+# ISO date, so once a day's master-index has been committed the next
+# run gets a 304 and pays only the conditional-GET round-trip. A
+# 30-call burst at the 10 rps SEC cap is bounded at ~3s.
+#
+# Gaps longer than this window need a one-shot submissions.json
+# backfill for covered CIKs — tracked as tech debt.
+LOOKBACK_DAYS = 30
 
 # 6-K (foreign-private-issuer interim reports) is deliberately
 # excluded — typically lacks structured XBRL, so refreshing

--- a/tests/test_sec_provider_master_index.py
+++ b/tests/test_sec_provider_master_index.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import httpx
+import pytest
 
+from app.providers.implementations import sec_edgar as sec_edgar_mod
 from app.providers.implementations.sec_edgar import (
     MasterIndexFetchResult,
     SecFilingsProvider,
@@ -117,3 +120,77 @@ def test_fetch_url_uses_correct_quarter_for_date() -> None:
     captured.clear()
     provider.fetch_master_index(date(2026, 12, 31), if_modified_since=None)
     assert "/2026/QTR4/master.20261231.idx" in captured["url"]
+
+
+def _pin_now_et(monkeypatch: pytest.MonkeyPatch, iso_instant: str) -> None:
+    """Freeze datetime.now(_ET) inside sec_edgar to return iso_instant (ET-local)."""
+    frozen = datetime.fromisoformat(iso_instant).replace(tzinfo=ZoneInfo("America/New_York"))
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return frozen.astimezone(tz) if tz else frozen.replace(tzinfo=None)
+
+    monkeypatch.setattr(sec_edgar_mod, "datetime", _FrozenDatetime)
+
+
+def test_fetch_returns_none_on_403_for_today_before_publish_cutoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    # SEC returns 403 (not 404) for current-day master.idx before the
+    # ~22:00-ET publish cutoff. Provider treats this as "not yet
+    # available" rather than raising.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403)
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    _pin_now_et(monkeypatch, "2026-04-23T12:00:00")  # mid-day ET, before 22:00 publish
+
+    result = provider.fetch_master_index(date(2026, 4, 23), if_modified_since=None)
+    assert result is None
+
+
+def test_fetch_raises_on_403_for_today_after_publish_cutoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    # After 22:00 ET the current-day file should exist. A 403 at that
+    # point is SEC actively refusing us — must raise so ops notice.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403)
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    _pin_now_et(monkeypatch, "2026-04-23T23:00:00")  # 23:00 ET, past 22:00 publish
+
+    with pytest.raises(httpx.HTTPStatusError):
+        provider.fetch_master_index(date(2026, 4, 23), if_modified_since=None)
+
+
+def test_fetch_returns_none_on_403_for_future_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Future-dated 403s tolerated — callers may iterate a lookback
+    # window whose endpoints straddle midnight across timezones.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403)
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    _pin_now_et(monkeypatch, "2026-04-23T12:00:00")
+
+    result = provider.fetch_master_index(date(2026, 4, 24), if_modified_since=None)
+    assert result is None
+
+
+def test_fetch_raises_on_403_for_past_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Past-dated 403 is not a publish-window race — it indicates SEC
+    # is actively blocking us (UA / rate limit / WAF). Must raise so
+    # the scheduler surfaces the incident.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403)
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    _pin_now_et(monkeypatch, "2026-04-23T12:00:00")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        provider.fetch_master_index(date(2026, 4, 20), if_modified_since=None)


### PR DESCRIPTION
## What
- [app/providers/implementations/sec_edgar.py](app/providers/implementations/sec_edgar.py): `fetch_master_index` now returns `None` on 403 only when `now_et < target_date 22:00 ET` (publish window). Past-dated 403 or same-day 403 after the 22:00-ET cutoff still raises.
- [app/services/fundamentals.py](app/services/fundamentals.py): `LOOKBACK_DAYS` 7 → 30 so multi-week offline windows auto-catch-up via the existing per-day watermarked planner.
- [tests/test_sec_provider_master_index.py](tests/test_sec_provider_master_index.py): added 4 tests covering each branch of the 403 gate (pre-cutoff today, post-cutoff today, future, past).

## Why
On startup the scheduler's `fundamentals_sync` catch-up ran `daily_financial_facts`, which called `fetch_master_index(today)` at 11:00 UTC. SEC serves 403 (not 404) for current-day files before the ~22:00-ET publish — the provider raised `HTTPStatusError`, failing phase 1 of `fundamentals_sync`.

7-day lookback meant a box offline >7 days silently lost master-index-driven CIK refreshes for the gap (per-CIK watermarks exist but without a master-index hit the refresh path is skipped). 30 days covers typical outage scenarios without adding a manual backfill path.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest` (2335 passed, 1 skipped)
- [x] Codex review: clean after tightening gate from `>= today_et` to `publish_due` boundary

## Follow-up
- Tech-debt issue: boxed-off > 30 days — one-shot submissions.json backfill for stale-watermark covered CIKs (to be filed).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>