### PR TITLE
fix(sec): tolerate 403 on weekend master-index dates

### DIFF
--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -341,14 +341,18 @@ class SecFilingsProvider(FilingsProvider):
         to persist in the watermark row.
 
         SEC's Archives host serves 403 (not 404) for files that do not
-        yet exist — current-day files are only published after the
-        Eastern-time business day closes (~22:00 ET). To distinguish
-        "not yet published" from a genuine access block, a 403 is
-        tolerated only when ``target_date`` is still within its
-        publish window: future-dated, or same-day-ET before the
-        22:00-ET publish cutoff. A 403 on a past date, or on the
-        current ET day after the publish cutoff, raises — that's
-        SEC refusing us (UA/rate-limit/etc.), not awaiting publication.
+        yet exist. Two tolerated 403 classes:
+          1. Weekend (Sat/Sun) target_date — SEC never publishes on
+             weekends, and observed behaviour shows 403 rather than 404.
+          2. Not-yet-published — current-day before the ~22:00-ET
+             publish cutoff, or future-dated.
+        Any other 403 (past weekday, or current weekday after the
+        publish cutoff) raises — that's SEC refusing us
+        (UA/rate-limit/etc.), not awaiting publication.
+
+        US federal holidays also yield 403/404 on SEC side but are not
+        enumerated here — a same-day retry on the next business day
+        catches them via the per-day watermark path.
 
         Rate-limited alongside the other SEC clients via the shared
         timestamp list, so a burst of N calls respects the 10 rps cap.
@@ -366,6 +370,19 @@ class SecFilingsProvider(FilingsProvider):
         if resp.status_code in (304, 404):
             return None
         if resp.status_code == 403:
+            # SEC is inconsistent about 404 vs 403 for non-existent files.
+            # Two tolerated classes:
+            #   1. Weekend: file never publishes on Sat/Sun, ever.
+            #   2. Not-yet-published: current-day before the ~22:00-ET
+            #      publish cutoff.
+            # Anything else is a real block (UA/rate-limit/WAF) and must
+            # surface.
+            if target_date.weekday() >= 5:  # 5=Sat, 6=Sun
+                logger.info(
+                    "SEC master-index: 403 on %s treated as weekend (no publish)",
+                    target_date.isoformat(),
+                )
+                return None
             now_et = datetime.now(_ET)
             publish_due = datetime.combine(
                 target_date,

--- a/tests/test_sec_provider_master_index.py
+++ b/tests/test_sec_provider_master_index.py
@@ -180,10 +180,10 @@ def test_fetch_returns_none_on_403_for_future_date(monkeypatch: pytest.MonkeyPat
     assert result is None
 
 
-def test_fetch_raises_on_403_for_past_date(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Past-dated 403 is not a publish-window race — it indicates SEC
-    # is actively blocking us (UA / rate limit / WAF). Must raise so
-    # the scheduler surfaces the incident.
+def test_fetch_raises_on_403_for_past_weekday(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Past-dated 403 on a weekday is not a publish-window race — it
+    # indicates SEC is actively blocking us (UA / rate limit / WAF).
+    # Must raise so the scheduler surfaces the incident.
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(403)
 
@@ -192,5 +192,24 @@ def test_fetch_raises_on_403_for_past_date(monkeypatch: pytest.MonkeyPatch) -> N
 
     _pin_now_et(monkeypatch, "2026-04-23T12:00:00")
 
+    # 2026-04-20 is a Monday — past weekday, no publish-window excuse.
     with pytest.raises(httpx.HTTPStatusError):
         provider.fetch_master_index(date(2026, 4, 20), if_modified_since=None)
+
+
+def test_fetch_returns_none_on_403_for_weekend(monkeypatch: pytest.MonkeyPatch) -> None:
+    # SEC does not publish the daily master-index on weekends and has
+    # been observed to serve 403 (not just 404) for those dates. The
+    # gate must tolerate it so the 30-day lookback does not trip on
+    # every Saturday / Sunday in the window.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403)
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    _pin_now_et(monkeypatch, "2026-04-23T12:00:00")
+
+    # 2026-04-18 is Saturday, 2026-04-19 is Sunday.
+    assert provider.fetch_master_index(date(2026, 4, 18), if_modified_since=None) is None
+    assert provider.fetch_master_index(date(2026, 4, 19), if_modified_since=None) is None


### PR DESCRIPTION
## What
[app/providers/implementations/sec_edgar.py](app/providers/implementations/sec_edgar.py): `fetch_master_index` treats 403 as `None` when `target_date.weekday() >= 5` (Sat/Sun), in addition to the existing publish-cutoff gate from #409.

## Why
Dev-machine startup after #409 merged still tripped on SEC's 2026-04-19 (Sunday):

```
GET .../master.20260419.idx "HTTP/1.1 403 Forbidden"
ERROR fundamentals_sync phase 1 (XBRL + normalization) failed
httpx.HTTPStatusError: Client error '403 Forbidden'
```

SEC is inconsistent about 404 vs 403 for non-existent daily-index files. The 30-day lookback now straddles weekends, so any Saturday/Sunday that SEC chooses to serve 403 for instead of 404 breaks the catch-up. Weekend is a structural non-publish window (no ambiguity with "maybe a real block"), so safe to tolerate unconditionally.

Past-weekday 403 and same-day post-22:00-ET 403 still raise — real UA/rate-limit/WAF block signals preserved.

Holiday dates are not specially handled — a weekday US federal holiday that returns 403 will still raise. Rare; picked up on next-business-day run once SEC serves 404/200.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest` (2336 passed, 1 skipped)
- [x] New test: `test_fetch_returns_none_on_403_for_weekend` (Sat + Sun)
- [x] Codex review clean — confirmed weekend branch evaluates before publish-window, past-weekday still raises

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>