### PR TITLE
fix(sql): reconcile financial_facts_raw identity to COALESCE(period_start)

### DIFF
--- a/sql/048_financial_facts_raw_identity_constraint.sql
+++ b/sql/048_financial_facts_raw_identity_constraint.sql
@@ -1,0 +1,54 @@
+-- Reconcile financial_facts_raw identity constraint with app ON CONFLICT.
+--
+-- Background
+-- ----------
+-- Migration 032 intended `uq_facts_raw_identity`, an expression UNIQUE
+-- index over (instrument_id, concept, unit, COALESCE(period_start, '0001-01-01'::date),
+-- period_end, accession_number). Some dev databases ended up with an
+-- auto-named plain UNIQUE table constraint over
+-- (instrument_id, concept, unit, period_end, accession_number) — five
+-- columns, no period_start, no COALESCE. Schema drift, not a mismatch
+-- the migration runner can detect (migrations are identified by
+-- filename, not by resulting DDL).
+--
+-- The app's ON CONFLICT clause in upsert_facts_for_instrument names
+-- the 6-col COALESCE identity. Against the 5-col plain UNIQUE that
+-- exists on the drifted DB, PostgreSQL raises:
+--     psycopg.errors.InvalidColumnReference:
+--         there is no unique or exclusion constraint matching
+--         the ON CONFLICT specification
+-- Every per-CIK XBRL upsert fails with that error.
+--
+-- Fix
+-- ---
+-- Drop the stale 5-col constraint (if present) and ensure the 6-col
+-- COALESCE expression index exists. Both operations are idempotent:
+-- on DBs where 032 created the correct index, the DROP is a no-op and
+-- the CREATE is a no-op.
+--
+-- Safety
+-- ------
+-- The new identity is STRICTER than the old on every row that has a
+-- non-null period_start (identical constraint semantics), and allows
+-- distinct period_start values per (instr, concept, unit, period_end,
+-- accession) tuple — which is the intended SEC XBRL data model (a
+-- single filing may carry multiple period lengths ending on the same
+-- date for the same concept).
+--
+-- A duplicate-key scan at authoring time showed 0 collisions under the
+-- new identity on a 10M-row production-like DB, so replacing the
+-- constraint does not require a backfill.
+
+-- Drop the drifted auto-named UNIQUE constraint if it exists.
+-- The name matches PostgreSQL's default pattern for inline UNIQUE(...)
+-- clauses: <table>_<col1>_<col2>_..._key (truncated to 63 chars).
+ALTER TABLE financial_facts_raw
+    DROP CONSTRAINT IF EXISTS financial_facts_raw_instrument_id_concept_unit_period_end_a_key;
+
+-- Ensure the intended 6-col COALESCE expression UNIQUE index exists.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_facts_raw_identity
+    ON financial_facts_raw(
+        instrument_id, concept, unit,
+        COALESCE(period_start, '0001-01-01'::date),
+        period_end, accession_number
+    );


### PR DESCRIPTION
## What
New migration [sql/048_financial_facts_raw_identity_constraint.sql](sql/048_financial_facts_raw_identity_constraint.sql):
1. Drops drifted auto-named 5-col UNIQUE constraint \`financial_facts_raw_instrument_id_concept_unit_period_end_a_key\` (if present).
2. Ensures the intended 6-col COALESCE expression UNIQUE index \`uq_facts_raw_identity\` exists.

Both operations are idempotent — clean DBs that received migration 032 correctly are unaffected.

## Why
Dev log spammed on every per-CIK upsert:

\`\`\`
psycopg.errors.InvalidColumnReference: there is no unique or exclusion constraint matching the ON CONFLICT specification
  File ".../app/services/fundamentals.py", line 318, in upsert_facts_for_instrument
\`\`\`

[app/services/fundamentals.py:333-337](app/services/fundamentals.py#L333-L337) targets the 6-col COALESCE identity in \`ON CONFLICT\`. Some DBs ended up with a drifted plain 5-col UNIQUE constraint (no \`period_start\`, no \`COALESCE\`), so PG couldn't match the conflict spec to any constraint and raised.

Migration file 032 has no git history of an earlier version that would have produced the auto-named constraint, so this is pure DB drift (pre-migration hand-created schema or an out-of-band edit). Fix-forward with a new migration rather than editing an already-applied one.

## Safety
Duplicate-key scan on local 10M-row DB returned 0 collisions under the new 6-col identity. The new identity is STRICTER than the old on every row with a non-null \`period_start\`, and correctly permits distinct \`period_start\` values per \`(instrument_id, concept, unit, period_end, accession_number)\` — which is the SEC XBRL data model (a single filing may carry multiple period lengths ending on the same date for the same concept). No backfill / dedupe needed.

Only one app writer touches this table — [upsert_facts_for_instrument](app/services/fundamentals.py#L300). All other \`financial_facts_raw\` usage is read-only.

## Test plan
- [x] \`uv run ruff check .\`
- [x] \`uv run ruff format --check .\`
- [x] \`uv run pyright\`
- [x] \`uv run pytest\` (2336 passed, 1 skipped)
- [x] Applied migration locally; indexes now show \`uq_facts_raw_identity\` with the COALESCE expression
- [x] Codex review clean — idempotence safe on clean DBs, no other conflict path affected

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>