### PR TITLE
fix(scheduler): disable catch_up_on_boot for fundamentals_sync

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -453,6 +453,13 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         ),
         cadence=Cadence.weekly(weekday=0, hour=5, minute=0),  # Monday 05:00 UTC
         prerequisite=_has_any_coverage,
+        # Never catch up on boot. The job pulls SEC EDGAR data for every
+        # covered CIK (tens of minutes, holds DB-pool workers and hits
+        # SEC's 10 rps cap). Every dev-stack restart would otherwise
+        # fire a catch-up and make the site unresponsive until it
+        # finishes. Weekly cadence also means a missed Monday is not
+        # time-critical — operator can click "Run now" in the admin UI.
+        catch_up_on_boot=False,
     ),
     # attribution_summary retired from scheduling in Phase 1.4 of the
     # 2026-04-19 research-tool refocus — no UI consumer today. The


### PR DESCRIPTION
## What
[app/workers/scheduler.py:444-456](app/workers/scheduler.py#L444-L456) — set \`catch_up_on_boot=False\` on \`JOB_FUNDAMENTALS_SYNC\`.

## Why
\`fundamentals_sync\` is weekly (Monday 05:00 UTC) and pulls SEC EDGAR data for every covered CIK. Tens of minutes per run, holds DB-pool workers, throttled at SEC's 10 rps cap.

\`ScheduledJob.catch_up_on_boot\` defaults to \`True\` ([scheduler.py:205](app/workers/scheduler.py#L205)). While \`fundamentals_sync\` has never had a successful run (blocked by the \`ON CONFLICT\` schema drift fixed in #412), \`_catch_up()\` treats \`last_success=None\` as overdue on every boot → fires immediately. Result: dev-stack restart → site unresponsive until the multi-minute job completes.

Matches the same rationale already documented for \`orchestrator_full_sync\` and \`raw_data_retention_sweep\`: heavy work, non-time-critical cadence, operator triggers via Admin UI "Run now" if a slot is missed.

## Test plan
- [x] \`uv run ruff check .\`
- [x] \`uv run ruff format --check .\`
- [x] \`uv run pyright\`
- [x] \`uv run pytest\` (2336 passed, 1 skipped)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>