### PR TITLE
feat(#415): admin problems drill-through + 409-as-conflict UX

### DIFF
--- a/docs/superpowers/specs/2026-04-23-admin-problems-drillthrough.md
+++ b/docs/superpowers/specs/2026-04-23-admin-problems-drillthrough.md
@@ -1,0 +1,122 @@
+# Admin problems panel — drill-through + clear-when hints + 409 UX fix
+
+Issue: #415
+Branch: `feature/415-admin-problems-drillthrough`
+Date: 2026-04-23
+
+## Scope (locked)
+
+### In scope
+
+1. Differentiate **409 "sync already running"** from real errors in `useSyncTrigger.ts`. New kind `"conflict"`. Render as amber info pill (not red). In the 409 branch, also call `onTriggered()` so the caller's status poll fires immediately — the amber "conflict" pill resolves into the grey "Running" disabled state within one poll cycle instead of waiting up to 60 s for the idle-cadence tick.
+2. `ProblemsPanel.tsx` — for every alert row, render:
+
+   - a **"Clears when …"** line (static text keyed to alert type), and
+   - a **drill-through** for job failures (new).
+
+3. New page `AdminJobDetailPage` at route `/admin/jobs/:name` using existing `GET /jobs/runs?job_name=<name>`. Table of latest 50 runs, newest first. Only rows with `status === 'failure'` and non-null `error_msg` are expandable; success/skipped/running rows are non-interactive (no misleading blank expansions).
+4. Route wiring in `App.tsx` + nav from `ProblemsPanel` failing-job row. Job names are passed through `encodeURIComponent` both when building the link and when calling the API, decoded with `decodeURIComponent` for display.
+5. Tests: `ProblemsPanel.test.tsx` updates (clearsWhen + drill href), new `AdminJobDetailPage.test.tsx`, `useSyncTrigger.test.ts` conflict-vs-error split.
+
+### Out of scope (deferred → follow-up tickets)
+
+- Ack / snooze state on alerts. Filed as follow-up after this PR merges.
+- Coverage null-filings-status drill page (needs a new list endpoint; route table currently has only `/admin/coverage/insufficient`).
+- Structured per-job log endpoint (`/admin/jobs/<name>/logs`) — requires log tagging rework.
+- `monitor_positions` `red_flag_score` SQL bug — separate ticket (fix at source, not UI).
+
+### Not touched (explicit non-goals)
+
+- Alert engine re-architecture. No changes to v2 `action_needed` / `secret_missing` shape.
+- No backend endpoint additions (`/jobs/runs` already serves the detail page).
+
+## File-by-file plan
+
+### Backend
+
+None. `GET /jobs/runs?job_name=<name>&limit=50` already returns the full shape needed ([app/api/jobs.py:141-214](app/api/jobs.py#L141-L214)). `fetchJobRuns(jobName?, limit?)` already exists at [frontend/src/api/jobs.ts:23-35](frontend/src/api/jobs.ts#L23-L35) and returns a `JobRunsListResponse` (with `.items`, `.count`, `.limit`, `.job_name`) — reuse it directly.
+
+### Frontend
+
+#### `frontend/src/lib/useSyncTrigger.ts`
+
+- Extend `SyncTriggerKind` with `"conflict"`.
+- In the `catch` block, `err.status === 409` → `setState({ kind: "conflict", queuedRunId: null, message: "Another sync is already running" })`, then call `onTriggered()` so the caller's status polling fires immediately. Non-409 unchanged.
+- `inFlightRef` effect: conflict is **not** in-flight — include it alongside `error` and `idle` in the "reset ref" branch so a retry click is not blocked.
+- `clearQueued`: no-op branch for `"conflict"` (user must click again after reading, same as `"error"`).
+
+#### `frontend/src/pages/AdminPage.tsx`
+
+- `SyncNowButton` `triggerKind` prop type: include `"conflict"`.
+- Render: `triggerKind === "conflict"` → amber info pill `text-amber-700 bg-amber-50` inline text. Button stays re-clickable (not disabled by `conflict`) — user can retry when orchestrator finishes.
+- Error styling (`text-red-600`) reserved for `"error"` only.
+
+#### `frontend/src/pages/SyncDashboard.tsx`
+
+- Same branch addition at [SyncDashboard.tsx:195](frontend/src/pages/SyncDashboard.tsx#L195): amber text for conflict, red text for error.
+
+#### `frontend/src/components/admin/ProblemsPanel.tsx`
+
+- Extend every `<li>` with a `clearsWhen` line rendered in `text-xs text-slate-600`:
+
+  - `ActionNeededRow` → `"Clears when the next run of <root_layer> succeeds"`
+  - `SecretMissingRow` → `"Clears when the credential is supplied in Settings → Providers"`
+  - failing-job row → `"Clears when the next run of <job.name> succeeds"`
+  - coverage-null row → `"Clears after the fundamentals/coverage audit tags these instruments. If the count is not falling, the audit job is stuck — check its last run."` — phrased so the operator gets the *actionable* condition, not just the symptom restated.
+
+- Failing-job row: wrap the name in a `<Link to={/admin/jobs/${encodeURIComponent(job.name)}}>` with a "View runs →" affordance matching `ActionNeededRow`'s "Open orchestrator details →" style.
+- No new props. No plumbing changes.
+
+#### `frontend/src/pages/AdminJobDetailPage.tsx` (new)
+
+- Route: `/admin/jobs/:name`. Read `:name` via `useParams()` — React Router 6 already URL-decodes path params, so do **not** call `decodeURIComponent` again (avoids double-decode on names containing `%`). Use the value as-is for both display and API call.
+- Fetch: `fetchJobRuns(name, 50)` (existing helper; it re-encodes via `URLSearchParams` internally).
+- States: loading, error, empty, list. Follow `.claude/skills/frontend/loading-error-empty-states.md`.
+- Table columns: Started at, Finished at, Status pill, Duration (finished − started, or "—" if running), Row count.
+- Expansion policy: only rows with `status === 'failure'` AND `error_msg !== null` are clickable/expandable. Expanded content is `<pre class="whitespace-pre-wrap">` of `error_msg`. Other rows render as plain non-interactive rows. This prevents the "every row clickable but most expand to blank" failure mode.
+- Empty state copy: `"No recent runs for this job. If you arrived from an old bookmark, the job may have been renamed."` + "Back to Admin" link. Deliberately does not distinguish unknown-job from known-job-no-history — the endpoint cannot tell us which, and conflating the two in a neutral message is honest.
+- Back link to `/admin`.
+- Breadcrumb: `Admin / Jobs / <name>`. Match existing inline-link convention (no new shared breadcrumb component — none exists).
+
+#### `frontend/src/App.tsx`
+
+- Add `<Route path="admin/jobs/:name" element={<AdminJobDetailPage />} />` inside the authenticated block, alongside `admin`, before the `*` catch-all.
+
+### Tests
+
+#### `frontend/src/lib/useSyncTrigger.test.ts`
+
+- Update: 409 → `kind === "conflict"`, `message === "Another sync is already running"`, `onTriggered` was called exactly once (confirms immediate reconcile).
+- Keep existing 503 / non-409 assertions unchanged (`kind === "error"`, `onTriggered` not called).
+
+#### `frontend/src/components/admin/ProblemsPanel.test.tsx`
+
+- Assert `clearsWhen` text is rendered for each of the four row types.
+- Assert failing-job row has an anchor with `href="/admin/jobs/<encoded-name>"`.
+- Smoke-test a job name containing `/` to confirm encoding: e.g. `"etl/fundamentals_sync"` → `href="/admin/jobs/etl%2Ffundamentals_sync"`.
+
+#### `frontend/src/pages/AdminJobDetailPage.test.tsx` (new)
+
+- Loading state → skeleton visible.
+- Error state → friendly error + retry.
+- Empty state → "No recent runs …" copy + Back link.
+- Populated state → rows ordered newest-first, status pill colour matches status, failure row expands to show `error_msg`, success row is not interactive.
+- URL-encoded route param (e.g. `/admin/jobs/etl%2Ffundamentals_sync`) → component uses the router-decoded value as-is (assert `fetchJobRuns` is called with `"etl/fundamentals_sync"`, not double-decoded or re-encoded).
+
+## Definition of done
+
+- `ruff check . && ruff format --check . && pyright && pytest` all green (backend unaffected but run per CLAUDE.md).
+- `pnpm --dir frontend typecheck && pnpm --dir frontend test:unit` green.
+- Tests written first, failing before implementation (TDD per `.claude/skills/engineering/test-quality.md`).
+- PR description: What / Why / Test plan bullets only (per `feedback_pr_description_brevity`).
+
+## Settled-decisions check
+
+- Product-visibility pivot (2026-04-18) — passes: operator-facing admin UX directly improves the "I can manage my fund" surface. When the fund surface shows a problem, drill-through is what the operator needs next.
+- No infra / orchestrator re-architecture. No provider changes.
+
+## Review-prevention-log check
+
+- No `_tracked_job` edits (PREREQ_SKIP rule N/A).
+- No new SQL. Endpoint reuse.
+- Frontend-only changes + one new route. No async/lifecycle edits beyond the hook kind rename.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { InstrumentPage } from "@/pages/InstrumentPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { RecommendationsPage } from "@/pages/RecommendationsPage";
 import { AdminPage } from "@/pages/AdminPage";
+import { AdminJobDetailPage } from "@/pages/AdminJobDetailPage";
 import { CoverageInsufficientPage } from "@/pages/CoverageInsufficientPage";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { NotFoundPage } from "@/pages/NotFoundPage";
@@ -63,6 +64,7 @@ export function App() {
           <Route path="recommendations" element={<RecommendationsPage />} />
           <Route path="reports" element={<ReportsPage />} />
           <Route path="admin" element={<AdminPage />} />
+          <Route path="admin/jobs/:name" element={<AdminJobDetailPage />} />
           <Route
             path="admin/coverage/insufficient"
             element={<CoverageInsufficientPage />}

--- a/frontend/src/components/admin/ProblemsPanel.test.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.test.tsx
@@ -266,8 +266,127 @@ describe("ProblemsPanel", () => {
       ],
     };
     renderPanel({ jobs });
-    expect(screen.getByText(/test_job/)).toBeInTheDocument();
-    expect(screen.getByText(/last run failed/i)).toBeInTheDocument();
+    // `test_job` now appears in both the alert title and the
+    // "Clears when the next run of test_job succeeds." line — use a
+    // non-greedy matcher scoped to the title row.
+    expect(screen.getByText(/test_job — last run failed/i)).toBeInTheDocument();
+  });
+
+  it("renders a drill-through link to /admin/jobs/<name> for a failing job", () => {
+    const jobs: JobsListResponse = {
+      checked_at: new Date().toISOString(),
+      jobs: [
+        {
+          name: "fundamentals_sync",
+          description: "",
+          cadence: "weekly",
+          cadence_kind: "weekly",
+          next_run_time: new Date().toISOString(),
+          next_run_time_source: "declared",
+          last_status: "failure",
+          last_started_at: null,
+          last_finished_at: new Date().toISOString(),
+          detail: "",
+        },
+      ],
+    };
+    renderPanel({ jobs });
+    const link = screen.getByRole("link", {
+      name: /View runs for fundamentals_sync/i,
+    });
+    expect(link).toHaveAttribute("href", "/admin/jobs/fundamentals_sync");
+  });
+
+  it("URL-encodes job names containing special characters in the drill link", () => {
+    // Defensive: job_name is a plain string in the DB; if an operator
+    // ever names a job with `/`, space, or `?`, the drill link must
+    // stay unambiguous. encodeURIComponent at link-construction time.
+    const jobs: JobsListResponse = {
+      checked_at: new Date().toISOString(),
+      jobs: [
+        {
+          name: "etl/fundamentals_sync",
+          description: "",
+          cadence: "weekly",
+          cadence_kind: "weekly",
+          next_run_time: new Date().toISOString(),
+          next_run_time_source: "declared",
+          last_status: "failure",
+          last_started_at: null,
+          last_finished_at: new Date().toISOString(),
+          detail: "",
+        },
+      ],
+    };
+    renderPanel({ jobs });
+    const link = screen.getByRole("link", {
+      name: /View runs for etl\/fundamentals_sync/i,
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "/admin/jobs/etl%2Ffundamentals_sync",
+    );
+  });
+
+  it("renders a 'Clears when' hint on each alert type", () => {
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.action_needed = [
+      {
+        root_layer: "cik_mapping",
+        display_name: "SEC CIK Mapping",
+        category: "db_constraint",
+        operator_message: "DB error",
+        operator_fix: null,
+        self_heal: false,
+        consecutive_failures: 2,
+        affected_downstream: [],
+      },
+    ];
+    v2.secret_missing = [
+      {
+        layer: "news",
+        display_name: "News & Sentiment",
+        missing_secret: "ANTHROPIC_API_KEY",
+        operator_fix: "Set ANTHROPIC_API_KEY in Settings → Providers",
+      },
+    ];
+    const jobs: JobsListResponse = {
+      checked_at: new Date().toISOString(),
+      jobs: [
+        {
+          name: "fundamentals_sync",
+          description: "",
+          cadence: "weekly",
+          cadence_kind: "weekly",
+          next_run_time: new Date().toISOString(),
+          next_run_time_source: "declared",
+          last_status: "failure",
+          last_started_at: null,
+          last_finished_at: new Date().toISOString(),
+          detail: "",
+        },
+      ],
+    };
+    const coverage: CoverageSummaryResponse = {
+      ...emptyCoverage(),
+      null_rows: 7,
+    };
+    renderPanel({ v2, jobs, coverage });
+    expect(
+      screen.getByText(/Clears when the next run of cik_mapping succeeds/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Clears when the credential is supplied/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Clears when the next run of fundamentals_sync succeeds/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Clears after the fundamentals\/coverage audit/i),
+    ).toBeInTheDocument();
   });
 
   it("carries over coverage null_rows from v1 behaviour", () => {
@@ -398,7 +517,8 @@ describe("ProblemsPanel", () => {
           name: "test_job",
           description: "test job",
           cadence: "daily",
-          next_run_time: null,
+          next_run_time: new Date().toISOString(),
+          next_run_time_source: "declared",
           last_status: "failure",
           last_finished_at: new Date().toISOString(),
         } as unknown as JobsListResponse["jobs"][number],

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -161,7 +161,17 @@ export function ProblemsPanel({
                 {job.last_finished_at !== null ? (
                   <div className="text-xs text-slate-600">Failed at {formatDateTime(job.last_finished_at)}</div>
                 ) : null}
+                <div className="text-xs text-slate-600">
+                  Clears when the next run of {job.name} succeeds.
+                </div>
               </div>
+              <Link
+                to={`/admin/jobs/${encodeURIComponent(job.name)}`}
+                className="shrink-0 text-xs font-medium text-blue-700 hover:underline"
+                aria-label={`View runs for ${job.name}`}
+              >
+                View runs →
+              </Link>
             </div>
           </li>
         ))}
@@ -174,6 +184,11 @@ export function ProblemsPanel({
                   {coverageNullRows} instrument{coverageNullRows === 1 ? "" : "s"} have a NULL filings_status
                 </div>
                 <div className="text-xs text-slate-600">The filings-status audit job has not covered these instruments yet.</div>
+                <div className="text-xs text-slate-600">
+                  Clears after the fundamentals/coverage audit tags these
+                  instruments. If the count is not falling, the audit job
+                  is stuck — check its last run.
+                </div>
               </div>
             </div>
           </li>
@@ -208,6 +223,9 @@ function ActionNeededRow({ item, onOpen }: { item: ActionNeededItem; onOpen: () 
             </div>
           ) : null}
           <div className="mt-1 text-xs text-slate-500">{item.consecutive_failures} consecutive failures</div>
+          <div className="text-xs text-slate-600">
+            Clears when the next run of {item.root_layer} succeeds.
+          </div>
           {item.affected_downstream.length > 0 ? (
             <button
               type="button"
@@ -260,6 +278,9 @@ function SecretMissingRow({ item }: { item: SecretMissingItem }): JSX.Element {
             ) : (
               <span>{item.operator_fix}</span>
             )}
+          </div>
+          <div className="text-xs text-slate-600">
+            Clears when the credential is supplied in Settings → Providers.
           </div>
         </div>
       </div>

--- a/frontend/src/lib/useSyncTrigger.test.ts
+++ b/frontend/src/lib/useSyncTrigger.test.ts
@@ -44,7 +44,12 @@ describe("useSyncTrigger", () => {
     expect(onTriggered).toHaveBeenCalledTimes(1);
   });
 
-  it("surfaces 409 as 'Sync already running'", async () => {
+  it("surfaces 409 as conflict (not error) and calls onTriggered for immediate reconcile", async () => {
+    // A 409 means the orchestrator is already running a sync. The UI
+    // should render an amber informational pill (not a red error), AND
+    // the caller's status poll must fire right away so the "conflict"
+    // resolves into the grey "Running" disabled state within one poll
+    // cycle instead of waiting up to 60s for the idle-cadence tick.
     mockedTrigger.mockRejectedValueOnce(new ApiError(409, "conflict"));
     const { hook, onTriggered } = setup();
 
@@ -52,18 +57,20 @@ describe("useSyncTrigger", () => {
       await hook.result.current.trigger();
     });
 
-    expect(hook.result.current.kind).toBe("error");
-    expect(hook.result.current.message).toBe("Sync already running");
-    expect(onTriggered).not.toHaveBeenCalled();
+    expect(hook.result.current.kind).toBe("conflict");
+    expect(hook.result.current.message).toBe("Another sync is already running");
+    expect(onTriggered).toHaveBeenCalledTimes(1);
   });
 
-  it("surfaces 503 as 'Sync orchestrator disabled'", async () => {
+  it("surfaces 503 as error (orchestrator disabled) — not a conflict", async () => {
     mockedTrigger.mockRejectedValueOnce(new ApiError(503, "disabled"));
-    const { hook } = setup();
+    const { hook, onTriggered } = setup();
     await act(async () => {
       await hook.result.current.trigger();
     });
+    expect(hook.result.current.kind).toBe("error");
     expect(hook.result.current.message).toBe("Sync orchestrator disabled");
+    expect(onTriggered).not.toHaveBeenCalled();
   });
 
   it("guards against a second click while already running", async () => {
@@ -125,8 +132,36 @@ describe("useSyncTrigger", () => {
     expect(hook.result.current.kind).toBe("queued");
   });
 
-  it("clearQueued does NOT auto-reset an error state", async () => {
+  it("clearQueued(true) collapses a conflict to idle once the server confirms a sync is running", async () => {
+    // 409 means "someone else is already running a sync" — the amber
+    // pill has done its job. As soon as /sync/status reports
+    // is_running=true, the pill must collapse so the caller's normal
+    // "Running" grey state (driven by `isRunning`) takes over. Without
+    // this, the pill would persist past the end of the server-side
+    // sync and mislead the operator.
     mockedTrigger.mockRejectedValueOnce(new ApiError(409, ""));
+    const { hook } = setup();
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    expect(hook.result.current.kind).toBe("conflict");
+
+    act(() => hook.result.current.clearQueued(true));
+    expect(hook.result.current.kind).toBe("idle");
+  });
+
+  it("clearQueued(false) keeps a conflict state (server not yet confirmed running)", async () => {
+    mockedTrigger.mockRejectedValueOnce(new ApiError(409, ""));
+    const { hook } = setup();
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    act(() => hook.result.current.clearQueued(false));
+    expect(hook.result.current.kind).toBe("conflict");
+  });
+
+  it("clearQueued does NOT auto-reset a 503 error state", async () => {
+    mockedTrigger.mockRejectedValueOnce(new ApiError(503, "disabled"));
     const { hook } = setup();
     await act(async () => {
       await hook.result.current.trigger();
@@ -167,8 +202,30 @@ describe("useSyncTrigger", () => {
     expect(hook.result.current.queuedRunId).toBe(2);
   });
 
-  it("re-triggers after an error (retry flow)", async () => {
+  it("re-triggers after a conflict (retry flow)", async () => {
+    // 409 lands in `conflict`. The inFlight guard must still release
+    // so the operator's retry click dispatches a second POST once the
+    // orchestrator sync finishes.
     mockedTrigger.mockRejectedValueOnce(new ApiError(409, "conflict"));
+    const { hook } = setup();
+
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    expect(hook.result.current.kind).toBe("conflict");
+
+    mockedTrigger.mockResolvedValueOnce({
+      sync_run_id: 9,
+      plan: { layers_to_refresh: [], layers_skipped: [] },
+    });
+    await act(async () => {
+      await hook.result.current.trigger();
+    });
+    expect(mockedTrigger).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-triggers after a 503 error (retry flow)", async () => {
+    mockedTrigger.mockRejectedValueOnce(new ApiError(503, "disabled"));
     const { hook } = setup();
 
     await act(async () => {
@@ -176,9 +233,6 @@ describe("useSyncTrigger", () => {
     });
     expect(hook.result.current.kind).toBe("error");
 
-    // An error transition drops the inFlight guard via the same
-    // useEffect — operator's retry click should dispatch a second
-    // POST.
     mockedTrigger.mockResolvedValueOnce({
       sync_run_id: 9,
       plan: { layers_to_refresh: [], layers_skipped: [] },

--- a/frontend/src/lib/useSyncTrigger.ts
+++ b/frontend/src/lib/useSyncTrigger.ts
@@ -26,7 +26,12 @@ import { ApiError } from "@/api/client";
 import { triggerSync } from "@/api/sync";
 import type { SyncTriggerRequest } from "@/api/sync";
 
-export type SyncTriggerKind = "idle" | "running" | "queued" | "error";
+export type SyncTriggerKind =
+  | "idle"
+  | "running"
+  | "queued"
+  | "conflict"
+  | "error";
 
 export interface SyncTriggerState {
   readonly kind: SyncTriggerKind;
@@ -75,13 +80,28 @@ export function useSyncTrigger(
       });
       onTriggered();
     } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        // 409 means an orchestrator sync is already running. The
+        // operator's click was not a failure — the system is already
+        // doing the work. Render as an amber informational pill
+        // (handled by consumers) instead of a red error, and fire the
+        // caller's status poll immediately so the "conflict" amber
+        // resolves into the grey "Running" disabled state within one
+        // poll cycle instead of up to the next idle-cadence tick
+        // (currently 60s).
+        setState({
+          kind: "conflict",
+          queuedRunId: null,
+          message: "Another sync is already running",
+        });
+        onTriggered();
+        return;
+      }
       const message =
         err instanceof ApiError
-          ? err.status === 409
-            ? "Sync already running"
-            : err.status === 503
-              ? "Sync orchestrator disabled"
-              : `Failed (HTTP ${err.status})`
+          ? err.status === 503
+            ? "Sync orchestrator disabled"
+            : `Failed (HTTP ${err.status})`
           : "Failed";
       setState({ kind: "error", queuedRunId: null, message });
     }
@@ -97,6 +117,15 @@ export function useSyncTrigger(
       if (prev.kind === "queued" && isRunning) {
         return { kind: "idle", queuedRunId: null, message: null };
       }
+      // `conflict` collapses to `idle` as soon as the caller's status
+      // poll confirms a sync is running — the amber "Another sync is
+      // already running" pill has done its job; from that point the
+      // normal grey "Running" state (driven by `isRunning`) carries
+      // the UX. Otherwise the pill would persist past the end of the
+      // server-side sync and mislead the operator.
+      if (prev.kind === "conflict" && isRunning) {
+        return { kind: "idle", queuedRunId: null, message: null };
+      }
       // `error` has no auto-reset — caller must click again.
       return prev;
     });
@@ -108,6 +137,10 @@ export function useSyncTrigger(
   // leave the ref out of sync with `kind` (e.g. fast-run fallback
   // timer, caller-initiated reset, unexpected state path).
   useEffect(() => {
+    // `conflict` is a terminal state (the POST failed with 409) — the
+    // guard must release so a retry click after the server-side sync
+    // finishes can dispatch a new POST. Same logic as `error` and
+    // `idle`.
     inFlightRef.current =
       state.kind === "running" || state.kind === "queued";
   }, [state.kind]);

--- a/frontend/src/pages/AdminJobDetailPage.test.tsx
+++ b/frontend/src/pages/AdminJobDetailPage.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Tests for AdminJobDetailPage (#415 drill-through).
+ *
+ * Scope:
+ *   - Loading state renders skeleton
+ *   - Error state renders retry button
+ *   - Empty state renders neutral "No recent runs" copy + Back link
+ *   - Populated list renders rows newest-first
+ *   - Only failure rows with non-null error_msg are expandable
+ *   - Successful rows are not interactive
+ *   - Component passes the router-decoded :name straight to fetchJobRuns
+ *     (no double decode; no re-encode) — the helper re-encodes internally.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { AdminJobDetailPage } from "@/pages/AdminJobDetailPage";
+import { fetchJobRuns } from "@/api/jobs";
+import type { JobRunResponse, JobRunsListResponse } from "@/api/types";
+
+vi.mock("@/api/jobs", () => ({ fetchJobRuns: vi.fn() }));
+
+const mockedFetch = vi.mocked(fetchJobRuns);
+
+function makeRun(overrides: Partial<JobRunResponse> = {}): JobRunResponse {
+  return {
+    run_id: 1,
+    job_name: "fundamentals_sync",
+    started_at: "2026-04-22T10:00:00Z",
+    finished_at: "2026-04-22T10:01:30Z",
+    status: "success",
+    row_count: 100,
+    error_msg: null,
+    ...overrides,
+  };
+}
+
+function makeList(items: JobRunResponse[]): JobRunsListResponse {
+  return {
+    items,
+    count: items.length,
+    limit: 50,
+    job_name: "fundamentals_sync",
+  };
+}
+
+function renderPage(routeParam: string = "fundamentals_sync") {
+  return render(
+    <MemoryRouter initialEntries={[`/admin/jobs/${routeParam}`]}>
+      <Routes>
+        <Route path="/admin/jobs/:name" element={<AdminJobDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockedFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AdminJobDetailPage", () => {
+  it("renders a loading skeleton while the first fetch is in-flight", () => {
+    mockedFetch.mockReturnValue(new Promise(() => {})); // never resolves
+    renderPage();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("renders an error + retry when the fetch fails", async () => {
+    mockedFetch.mockRejectedValueOnce(new Error("boom"));
+    renderPage();
+    expect(await screen.findByRole("alert")).toHaveTextContent(/Failed to load/i);
+    expect(
+      screen.getByRole("button", { name: /Retry/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a neutral 'No recent runs' message with the header Back link when list is empty", async () => {
+    mockedFetch.mockResolvedValueOnce(makeList([]));
+    renderPage();
+    expect(
+      await screen.findByText(/No recent runs for this job/i),
+    ).toBeInTheDocument();
+    // Header back link (every state carries it).
+    expect(
+      screen.getByRole("link", { name: /Back to Admin/i }),
+    ).toHaveAttribute("href", "/admin");
+  });
+
+  it("renders runs in the exact order delivered by the backend (newest-first)", async () => {
+    // Backend returns ORDER BY started_at DESC. Pin the order on the
+    // Started timestamps each row rendered so a regression that
+    // reverses / re-sorts the list is caught (the raw length check
+    // would pass either way).
+    mockedFetch.mockResolvedValueOnce(
+      makeList([
+        makeRun({ run_id: 3, started_at: "2026-04-22T12:00:00Z", finished_at: null, status: "running", row_count: null }),
+        makeRun({ run_id: 2, started_at: "2026-04-22T11:00:00Z", status: "success" }),
+        makeRun({ run_id: 1, started_at: "2026-04-22T10:00:00Z", status: "success" }),
+      ]),
+    );
+    renderPage();
+    const rows = await screen.findAllByRole("row");
+    // header + 3 data rows.
+    expect(rows).toHaveLength(4);
+    // Row 0 is the <th> header. Data rows expose the raw ISO
+    // timestamp via data-started-at so the assertion does not depend
+    // on the host timezone (formatDateTime localizes; DST would make
+    // a locale-text assertion flaky in CI).
+    const dataRows = rows.slice(1);
+    const startedAt = dataRows.map((r) =>
+      r.getAttribute("data-started-at"),
+    );
+    expect(startedAt).toEqual([
+      "2026-04-22T12:00:00Z",
+      "2026-04-22T11:00:00Z",
+      "2026-04-22T10:00:00Z",
+    ]);
+  });
+
+  it("expands a failed run to show its error_msg", async () => {
+    mockedFetch.mockResolvedValueOnce(
+      makeList([
+        makeRun({
+          run_id: 42,
+          status: "failure",
+          finished_at: "2026-04-22T10:05:00Z",
+          error_msg: "psycopg.errors.UndefinedColumn: column \"red_flag_score\" does not exist",
+          row_count: null,
+        }),
+      ]),
+    );
+    renderPage();
+    // Failure row is clickable.
+    const expand = await screen.findByRole("button", {
+      name: /Show error for run 42/i,
+    });
+    await userEvent.click(expand);
+    expect(
+      screen.getByText(/column "red_flag_score" does not exist/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render an expand affordance on successful runs", async () => {
+    mockedFetch.mockResolvedValueOnce(
+      makeList([
+        makeRun({ run_id: 7, status: "success", error_msg: null }),
+      ]),
+    );
+    renderPage();
+    // Wait for the status cell to confirm the row has rendered, then
+    // assert no expand button exists for this run.
+    await screen.findByText("success");
+    expect(
+      screen.queryByRole("button", { name: /Show error for run 7/i }),
+    ).toBeNull();
+  });
+
+  it("does not render an expand affordance on a failure with a null error_msg", async () => {
+    // Spec-critical edge: only (failure AND error_msg !== null) is
+    // expandable. A failure row with no captured error would otherwise
+    // expand to an empty <pre>, which the spec explicitly rejects.
+    mockedFetch.mockResolvedValueOnce(
+      makeList([
+        makeRun({
+          run_id: 8,
+          status: "failure",
+          finished_at: "2026-04-22T10:05:00Z",
+          error_msg: null,
+          row_count: null,
+        }),
+      ]),
+    );
+    renderPage();
+    await screen.findByText("failure");
+    expect(
+      screen.queryByRole("button", { name: /Show error for run 8/i }),
+    ).toBeNull();
+  });
+
+  it("passes the router-decoded :name through to fetchJobRuns without re-encoding or double-decoding", async () => {
+    // React Router 6 already URL-decodes path params. If the page also
+    // decoded, "etl%2Ffundamentals_sync" → "etl/fundamentals_sync"
+    // the first time (by router), and a second decode would leave it
+    // as-is (harmless here) but a name containing "%" itself would
+    // corrupt (e.g. "%25" → "%"). The defence is: do nothing.
+    mockedFetch.mockResolvedValueOnce(makeList([]));
+    renderPage(encodeURIComponent("etl/fundamentals_sync"));
+    // The assertion the implementation must satisfy: the decoded name
+    // reaches fetchJobRuns verbatim. fetchJobRuns re-encodes internally
+    // when building the URLSearchParams.
+    await screen.findByText(/No recent runs/i);
+    expect(mockedFetch).toHaveBeenCalledWith("etl/fundamentals_sync", 50);
+  });
+});

--- a/frontend/src/pages/AdminJobDetailPage.tsx
+++ b/frontend/src/pages/AdminJobDetailPage.tsx
@@ -1,0 +1,178 @@
+/**
+ * Admin job detail — run history + drill-through (issue #415).
+ *
+ * Surfaces the most recent 50 rows of `job_runs` for a single job so
+ * the operator can see *why* a red "last run failed" alert is on the
+ * admin page. Failure rows expand to show `error_msg` verbatim; other
+ * statuses are non-interactive (no clickable row that expands to
+ * nothing).
+ *
+ * The `:name` path param is read straight from `useParams()` — React
+ * Router 6 already URL-decodes path params, so a second decode would
+ * corrupt names containing `%`. `fetchJobRuns` re-encodes internally
+ * when building the query string.
+ */
+
+import { useCallback, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { fetchJobRuns } from "@/api/jobs";
+import type { JobRunResponse } from "@/api/types";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
+import { useAsync } from "@/lib/useAsync";
+import { formatDateTime } from "@/lib/format";
+
+const STATUS_TONE: Record<JobRunResponse["status"], string> = {
+  success: "text-emerald-700",
+  failure: "text-red-700",
+  running: "text-sky-700",
+  skipped: "text-slate-500",
+};
+
+export function AdminJobDetailPage() {
+  const params = useParams<{ name: string }>();
+  const name = params.name ?? "";
+
+  const list = useAsync(
+    useCallback(() => fetchJobRuns(name, 50), [name]),
+    [name],
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-xs text-slate-500">Admin / Jobs</div>
+          <h1 className="text-xl font-semibold text-slate-800">{name}</h1>
+        </div>
+        <Link to="/admin" className="text-xs text-blue-700 hover:underline">
+          ← Back to Admin
+        </Link>
+      </div>
+
+      <Section title="Recent runs">
+        {list.loading ? (
+          <SectionSkeleton rows={5} />
+        ) : list.error !== null ? (
+          <SectionError onRetry={list.refetch} />
+        ) : list.data && list.data.items.length === 0 ? (
+          <EmptyState />
+        ) : list.data ? (
+          <RunsTable rows={list.data.items} />
+        ) : null}
+      </Section>
+    </div>
+  );
+}
+
+function EmptyState() {
+  // Intentionally neutral about "renamed" vs "no history" — the
+  // endpoint returns 200 + empty items for both, and conflating them
+  // honestly is less misleading than inventing a distinction. The
+  // header already carries the back link, so this component does not
+  // duplicate it.
+  return (
+    <div className="space-y-2 text-sm text-slate-600">
+      <p>No recent runs for this job.</p>
+      <p className="text-xs text-slate-500">
+        If you arrived from an old bookmark, the job may have been renamed.
+      </p>
+    </div>
+  );
+}
+
+function RunsTable({ rows }: { rows: JobRunResponse[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead className="text-xs uppercase tracking-wide text-slate-500">
+          <tr>
+            <th className="py-2 pr-4">Started</th>
+            <th className="py-2 pr-4">Finished</th>
+            <th className="py-2 pr-4">Status</th>
+            <th className="py-2 pr-4">Duration</th>
+            <th className="py-2 pr-4 text-right">Rows</th>
+            {/* Sixth column carries the per-row expand button on
+                failure rows. Declared here so the header and body row
+                column counts match (5 vs 6 would skew alignment and
+                flag the table as malformed by semantic-HTML linters). */}
+            <th className="py-2 pr-2 text-right">
+              <span className="sr-only">Actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {rows.map((row) => (
+            <RunRow key={row.run_id} row={row} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RunRow({ row }: { row: JobRunResponse }) {
+  const [expanded, setExpanded] = useState(false);
+  const expandable = row.status === "failure" && row.error_msg !== null;
+  const duration = formatDuration(row.started_at, row.finished_at);
+  return (
+    <>
+      <tr className="align-top" data-started-at={row.started_at}>
+        <td className="py-2 pr-4 text-xs text-slate-600">
+          {formatDateTime(row.started_at)}
+        </td>
+        <td className="py-2 pr-4 text-xs text-slate-600">
+          {row.finished_at !== null ? formatDateTime(row.finished_at) : "—"}
+        </td>
+        <td className={`py-2 pr-4 text-xs font-medium ${STATUS_TONE[row.status]}`}>
+          {row.status}
+        </td>
+        <td className="py-2 pr-4 text-xs text-slate-500">{duration}</td>
+        <td className="py-2 pr-4 text-right text-xs text-slate-700">
+          {row.row_count ?? "—"}
+        </td>
+        <td className="py-2 pr-2 text-right">
+          {expandable ? (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              aria-label={
+                expanded
+                  ? `Hide error for run ${row.run_id}`
+                  : `Show error for run ${row.run_id}`
+              }
+              className="text-xs font-medium text-red-700 hover:underline"
+            >
+              {expanded ? "Hide" : "Show error"}
+            </button>
+          ) : null}
+        </td>
+      </tr>
+      {expandable && expanded ? (
+        <tr>
+          <td colSpan={6} className="bg-slate-50 px-4 py-3">
+            <pre className="whitespace-pre-wrap text-xs text-slate-800">
+              {row.error_msg}
+            </pre>
+          </td>
+        </tr>
+      ) : null}
+    </>
+  );
+}
+
+function formatDuration(startedAt: string, finishedAt: string | null): string {
+  if (finishedAt === null) return "—";
+  const startMs = Date.parse(startedAt);
+  const endMs = Date.parse(finishedAt);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return "—";
+  const seconds = Math.max(0, Math.round((endMs - startMs) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  const rem = seconds % 60;
+  return `${mins}m ${rem}s`;
+}

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -257,10 +257,14 @@ describe("AdminPage — top-level composition", () => {
 
   it("shows problems panel when a job has failed", async () => {
     renderPage();
+    // The alert title `attribution_summary — last run failed` is the
+    // only place where that exact phrase appears (the "Clears when the
+    // next run of attribution_summary succeeds." line introduced in
+    // #415 contains `attribution_summary` too, so a bare regex matches
+    // twice — scope to the combined phrase).
     expect(
-      await screen.findByText(/attribution_summary/),
+      await screen.findByText(/attribution_summary — last run failed/),
     ).toBeInTheDocument();
-    expect(screen.getByText(/last run failed/)).toBeInTheDocument();
   });
 
   it("shows problems panel when a layer has consecutive failures", async () => {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -140,10 +140,12 @@ export function AdminPage() {
   }, [triggerClearQueued, isRunning]);
 
   useEffect(() => {
-    if (triggerKind !== "queued") return;
+    if (triggerKind !== "queued" && triggerKind !== "conflict") return;
     // Fallback: if the server-side sync finishes before we ever see
     // is_running=true, recover the idle state after the next refresh
-    // tick. Otherwise the button would stay disabled indefinitely.
+    // tick. Otherwise the button would stay disabled indefinitely in
+    // the queued case, or the amber "Another sync is already running"
+    // pill would stick indefinitely in the conflict case.
     const id = window.setTimeout(
       () => triggerClearQueued(true),
       refreshInterval + 2_000,
@@ -337,7 +339,7 @@ function SyncNowButton({
   isRunning,
   onClick,
 }: {
-  triggerKind: "idle" | "running" | "queued" | "error";
+  triggerKind: "idle" | "running" | "queued" | "conflict" | "error";
   message: string | null;
   isRunning: boolean;
   onClick: () => void;
@@ -356,6 +358,13 @@ function SyncNowButton({
     <div className="flex items-center gap-2">
       {triggerKind === "error" && message !== null ? (
         <span className="text-xs text-red-600">{message}</span>
+      ) : triggerKind === "conflict" && message !== null ? (
+        <span
+          className="rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs text-amber-800"
+          role="status"
+        >
+          {message}
+        </span>
       ) : null}
       <button
         type="button"

--- a/frontend/src/pages/SyncDashboard.tsx
+++ b/frontend/src/pages/SyncDashboard.tsx
@@ -195,6 +195,14 @@ export function SyncDashboard({ syncTrigger }: SyncDashboardProps) {
           {syncTrigger.kind === "error" && syncTrigger.message !== null && (
             <span className="text-sm text-red-600">{syncTrigger.message}</span>
           )}
+          {syncTrigger.kind === "conflict" && syncTrigger.message !== null && (
+            <span
+              className="rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-sm text-amber-800"
+              role="status"
+            >
+              {syncTrigger.message}
+            </span>
+          )}
           {syncTrigger.kind === "queued" && syncTrigger.queuedRunId !== null && (
             <span className="text-sm text-slate-500">
               Queued as run #{syncTrigger.queuedRunId}


### PR DESCRIPTION
## What

- ProblemsPanel: "Clears when …" hint on every alert row + drill-through link to `/admin/jobs/<name>` for failing-job alerts.
- New `AdminJobDetailPage` at `/admin/jobs/:name` — latest 50 `job_runs`, only failure rows with non-null `error_msg` are expandable.
- `useSyncTrigger`: 409 → new `conflict` kind rendered as amber info pill (not red error); fires `onTriggered()` immediately + fallback timer in AdminPage covers fast-finish server syncs.

## Why

Closes #415. Operator saw sticky red banners with no way to drill in, and 409 "sync already running" was painted as a failure. Three gaps: no job-level drill-through, no clearing-condition hints, 409 miscoded as error.

## Test plan

- [x] `pnpm typecheck` + `pnpm test:unit` (372 passed)
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest` (2336 passed)
- [x] Codex review: spec (3 rounds) + diff (3 rounds) — clean
- [x] Spec: `docs/superpowers/specs/2026-04-23-admin-problems-drillthrough.md`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>