### PR TITLE
research(#414): fundamentals ingest-shape bench + ADR 0004

### DIFF
--- a/docs/adr/0004-fundamentals-ingest-shape.md
+++ b/docs/adr/0004-fundamentals-ingest-shape.md
@@ -1,0 +1,104 @@
+# ADR 0004 — Fundamentals ingest shape (phase A)
+
+Issue: #414 investigation phase A (root-cause path for site-freeze during `fundamentals_sync`).
+Status: **Proposed** — measurement only. Implementation PR is separate.
+Date: 2026-04-23
+
+## Context
+
+`fundamentals_sync` has been the lever that takes the operator UI down on every restart while seeding. Four stabiliser PRs shipped (#409, #411, #412, #413) without touching the underlying shape — #413 just disables `catch_up_on_boot` so restarts stop re-firing the heavy job.
+
+Two signals motivated this investigation:
+
+1. 4,582 of 5,134 covered US CIKs have no `sec.submissions` watermark. Steady-state ingest cannot progress past seeding.
+2. While `fundamentals_sync` runs, operator HTTP latency spikes into tens of seconds.
+
+Issue #414 enumerated four candidate architectures (E1 batched same-process, E2 `ProcessPoolExecutor`, E3 standalone worker, E4 out-of-process script) and explicitly gated architecture selection on first closing **investigation A: is the freeze GIL contention, transaction-lock contention, or something else?**
+
+This ADR records what the DB-path benchmark *can* conclude and what it *cannot*, and picks a v1 shape accordingly.
+
+## What the bench measures
+
+`scripts/bench_fundamentals_upsert.py` runs against the isolated `ebull_test` Postgres and times three shapes of the per-CIK upsert against a synthetic 10,000-fact payload:
+
+- **A — row-loop** (current prod shape at [app/services/fundamentals.py:300-374](../../app/services/fundamentals.py#L300-L374)).
+- **B — `executemany(page_size=1000)`** — same SQL, batched round trips.
+- **C — COPY STDIN into a TEMP staging table, then one `INSERT … SELECT … ON CONFLICT`**.
+
+Three scenarios per shape:
+
+- `seed` — empty index, all INSERTs hit new rows.
+- `re-upsert no-op` — same payload re-upserted; the `WHERE IS DISTINCT FROM` filter short-circuits, so no row is rewritten. Models the watermark-unchanged steady-state path.
+- `restatement` — same identity tuple, mutated `val`; the DO UPDATE path actually rewrites rows. Models a filing restatement.
+
+## What the bench does **not** measure
+
+All of these remain open after this ADR and must be checked again once the shape change ships:
+
+- **Concurrent HTTP latency.** The bench is single-threaded. It cannot prove that a faster DB path eliminates the operator-UI freeze; it only proves the DB path gets cheaper. If residual freeze persists after shipping the shape change, parser-CPU / GIL contention becomes the suspect.
+- **GIL pressure from XBRL parsing.** The bench uses pre-generated synthetic facts and does no parsing work.
+- **Lock-wait behaviour.** `pg_stat_activity` / `pg_locks` is not sampled during the bench. It cannot say whether the current freeze is caused by a reader waiting on the ingest's write transaction or by round-trip-starved async handlers.
+- **Absolute production wall-clock.** The bench starts from an empty `financial_facts_raw` table; production carries millions of rows (the repo's own comments on [sql/048_financial_facts_raw_identity_constraint.sql:38-39](../../sql/048_financial_facts_raw_identity_constraint.sql#L38-L39) reference a 10M-row working set). B-tree insert cost is O(log N), so absolute per-CIK durations on a large existing index will be higher than the numbers below. **Only the *ratio* between shapes should be taken as signal**; the absolute wall-clock on a cold test DB is not a production predictor.
+
+## Numbers (10,000 facts, ebull_test, bench run 2026-04-23)
+
+| Shape                              | seed (s) | no-op (s) | restatement (s) | facts/s (seed) |
+|------------------------------------|---------:|----------:|----------------:|---------------:|
+| A — row-loop (current prod)        |    5.08  |     4.64  |          7.36   |          1,967 |
+| B — executemany(1000)              |    0.28  |     0.25  |          0.29   |         35,613 |
+| C — COPY → temp → INSERT … SELECT  |    0.16  |     0.06  |          0.19   |         60,993 |
+
+Ratios vs current prod (higher = faster):
+
+| Shape | seed | no-op | restatement |
+|-------|-----:|------:|------------:|
+| B     | 18×  | 18×   | 25×         |
+| C     | 31×  | 75×   | 39×         |
+
+The ratio is remarkably consistent across scenarios: batching collapses round-trip overhead by ~18× regardless of whether the underlying work is INSERT-new, no-op skip, or actual rewrite.
+
+## What the numbers do and don't justify
+
+They **do** justify:
+
+- A meaningful DB-path optimisation exists. Shape B shrinks the per-CIK transaction duration by ~18× on this bench. If production per-CIK duration tracks the same ratio, seed-time transactions drop from multi-second to sub-second, which directly reduces the window during which any operator request could block on lock contention against `financial_facts_raw`.
+- Shape B is the smallest possible fix: same SQL, same ON CONFLICT clause, same WHERE filter — only the call shape changes.
+
+They **do not** justify:
+
+- Rejecting E2 (`ProcessPoolExecutor`) / E3 (standalone worker) / E4 (OS scheduler) outright. Those architectures exist to isolate GIL pressure, which this bench does not characterise. They remain on the table as follow-ups if B does not land the freeze.
+- Claiming the freeze is "solved" once B ships. B is a necessary fix for the DB path regardless of what else is causing the freeze; it may not be sufficient.
+
+## Decision
+
+**v1: pick Shape B within E1 (same-process, batched upsert).**
+
+Rationale:
+
+- **Smallest diff that addresses the measured issue.** Same SQL, same identity index, same ON CONFLICT clause — one function body changes.
+- **No new concurrency model.** Avoids the operational complexity jump of E2/E3/E4 until we can show they are actually needed.
+- **Observable outcome.** After B ships, the implementation PR must add per-CIK timing at the `_run_cik_upsert` boundary (log-line or a new small column on `data_ingestion_runs`-like side table — `data_ingestion_runs` today is per provider batch, not per CIK). With that in place, the residual freeze question (GIL vs lock) becomes answerable in-prod by comparing per-CIK transaction wall-clock against operator-UI latency during an active seed.
+
+Shape C is **deferred to v2** — the additional 4–8× lift from COPY + INSERT SELECT is worth considering once B is in, but the TEMP-staging indirection adds complexity and a pyright-visible schema drift risk. Re-evaluate after B has run in prod for a cycle.
+
+E2 / E3 / E4 are **deferred, not rejected.** Each remains an option if B does not visibly reduce operator-UI latency during a seed run. The decision between them will need the in-prod probe that this bench deliberately does not attempt.
+
+## Open questions carried into the implementation PR
+
+The implementation PR for Shape B must answer:
+
+1. **Does the production per-CIK transaction drop below 1 s in practice?** The current `data_ingestion_runs` table records per provider batch (not per CIK), so the implementation PR must add per-CIK timing instrumentation (log-line at the `_run_cik_upsert` boundary, or a small addition to the ingest-run observability surface). Without that, we cannot answer this question.
+2. **Does operator-UI latency stop spiking during `fundamentals_sync`?** Compare p95 on `/health`, `/login`, and `/admin/jobs` while a seed is in flight — before and after.
+3. **If (1) is yes and (2) is no** → GIL / parser is the suspect; revisit E2/E3. This is the piece the current bench deliberately does not attempt to settle.
+
+## What this ADR does not change
+
+This ADR is measurement only. Nothing in `app/` is touched. The only artefact is:
+
+- `scripts/bench_fundamentals_upsert.py` — re-runnable benchmark against the isolated `ebull_test` DB (guarded — never touches the dev DB).
+
+## Related
+
+- Parent issue: #414.
+- Unblocked follow-ups: #410 (submissions.json backfill), #414 B (cadence), #414 D (seed cap), #414 F (runtime toggles), #414 G (observability).
+- Settled-decisions check — product-visibility pivot (2026-04-18): the current ingest shape is *hurting* operator visibility (freeze-induced UI outage), so the stabiliser track remains in scope.

--- a/scripts/bench_fundamentals_upsert.py
+++ b/scripts/bench_fundamentals_upsert.py
@@ -1,0 +1,461 @@
+"""Benchmark three shapes of `financial_facts_raw` upsert.
+
+Issue: #414 investigation phase A.
+
+Goal: quantify the DB-write cost of each candidate upsert shape
+against the current row-by-row shape at
+`app/services/fundamentals.py:300-374`. Three shapes are benchmarked
+against a representative single-10-K payload (~10_000 synthetic facts)
+under three scenarios:
+
+    seed             — empty index, every fact is a new INSERT.
+    re-upsert no-op  — same payload re-run; the WHERE IS DISTINCT FROM
+                       filter short-circuits, no row is rewritten.
+    restatement      — same identity tuple, mutated ``val`` field; the
+                       DO UPDATE path actually rewrites rows.
+
+Shapes under test:
+
+    A. row-by-row (current production shape).
+    B. executemany(page_size=1000) — same SQL, batched.
+    C. COPY STDIN into a TEMP staging table, then one
+       INSERT … SELECT … ON CONFLICT against `financial_facts_raw`.
+
+Runs against the isolated `ebull_test` Postgres, NEVER the dev DB.
+Reuses the same guard as `tests/fixtures/ebull_test_db.py`. Safe to
+re-run — each invocation TRUNCATEs the planner tables it writes to.
+
+Usage:
+    uv run python scripts/bench_fundamentals_upsert.py [--facts N]
+
+The script is measurement-only — it does not change any production
+code path. The numbers it produces feed the ADR at
+`docs/adr/0004-fundamentals-ingest-shape.md`.
+
+Scope limits (do NOT extrapolate beyond these):
+- Single-CIK, single-threaded, isolated DB.
+- No concurrent HTTP load, no parser CPU, no OS-level lock-wait
+  measurement.  The bench quantifies the DB write path only — it
+  cannot by itself decide whether residual site-freeze comes from the
+  Python XBRL parser (GIL) or transaction-lock contention.  Those
+  need a separate in-process probe after the shape change ships.
+- The starting table is ~0 rows; production carries millions.  B-tree
+  insert cost is O(log N), so absolute seed durations on a large
+  existing index will be higher than the numbers printed here.  The
+  *ratio* between shapes is still useful; the absolute wall-clock is
+  not a production prediction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+
+from app.providers.fundamentals import XbrlFact
+from app.services.fundamentals import upsert_facts_for_instrument
+from tests.fixtures.ebull_test_db import (
+    apply_migrations_to_test_db,
+    ensure_test_db_exists,
+    test_database_url,
+)
+
+# ---------------------------------------------------------------------------
+# Guard — refuse to run against anything except ebull_test
+# ---------------------------------------------------------------------------
+
+
+def _assert_test_db(conn: psycopg.Connection[tuple]) -> None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT current_database()")
+        row = cur.fetchone()
+    if row is None or row[0] != "ebull_test":
+        raise RuntimeError(f"refusing to run bench against database {row!r}; expected 'ebull_test'")
+
+
+# ---------------------------------------------------------------------------
+# Synthetic payload
+# ---------------------------------------------------------------------------
+
+
+_UNITS = ("USD", "USD/shares", "shares", "pure")
+
+
+def _generate_facts(count: int) -> list[XbrlFact]:
+    """Produce ``count`` unique XBRL facts that hit every branch of the
+    production identity tuple.
+
+    Each fact is unique under the `financial_facts_raw` unique index
+    ``(instrument_id, concept, unit, COALESCE(period_start), period_end,
+    accession_number)``. The generator deliberately varies:
+
+    - ``unit`` across four real-world XBRL units (USD, USD/shares,
+      shares, pure), so the bench exercises the ``unit`` column of the
+      index rather than measuring a single-unit hot path.
+    - ``period_start`` — roughly 1 in 5 facts use ``None`` to model
+      **instant** XBRL facts (balance-sheet items), which go through
+      the ``COALESCE(period_start, '0001-01-01'::date)`` branch of the
+      unique index. The other 4/5 are duration facts with real
+      period_start / period_end ranges.
+    - ``period_end`` across multiple fiscal period ends so index
+      locality spans pages, not a single hot page.
+    - ``accession_number`` across multiple filings, since the real
+      index is per-filing.
+
+    Re-upsert-no-op scenario: running the same list twice exercises
+    the ``ON CONFLICT … DO UPDATE … WHERE IS DISTINCT FROM`` short-
+    circuit (zero field changes), which is the idempotent no-op path
+    the scheduler hits every time a CIK's watermark is unchanged.
+
+    Restatement scenario (covered elsewhere in this module): the
+    harness builds a second list with the same identity tuple and a
+    mutated ``val`` to drive the DO UPDATE write path.
+    """
+    facts: list[XbrlFact] = []
+    # ~200 concepts × multiple periods × multiple units gives a
+    # realistic mixture for a 10-K-sized 10k-fact payload.
+    concepts = 200
+    for i in range(count):
+        concept_id = i % concepts
+        period_id = i // concepts
+        # Instant facts (balance-sheet) get NULL period_start roughly
+        # 1-in-5 — matches the production mix.
+        is_instant = (i % 5) == 0
+        period_end = date(2023, 3 * (period_id % 4 + 1) % 12 or 12, 28)
+        period_start = None if is_instant else date(2023, 1, 1)
+        facts.append(
+            XbrlFact(
+                concept=f"us-gaap:Concept{concept_id:04d}",
+                taxonomy="us-gaap",
+                unit=_UNITS[i % len(_UNITS)],
+                period_start=period_start,
+                period_end=period_end,
+                val=Decimal(f"{100.0 + i}"),
+                frame=f"CY2023Q{(period_id % 4) + 1}",
+                accession_number=f"0000000000-24-{period_id:06d}",
+                form_type="10-K",
+                filed_date=date(2024, 3, 15),
+                fiscal_year=2023,
+                fiscal_period="FY",
+                decimals="-3",
+            )
+        )
+    return facts
+
+
+# ---------------------------------------------------------------------------
+# Shape B — executemany(page_size=1000)
+# ---------------------------------------------------------------------------
+
+
+def upsert_facts_executemany(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    facts: Sequence[XbrlFact],
+    ingestion_run_id: int,
+    page_size: int = 1000,
+) -> None:
+    if not facts:
+        return
+    rows = [
+        {
+            "instrument_id": instrument_id,
+            "taxonomy": f.taxonomy,
+            "concept": f.concept,
+            "unit": f.unit,
+            "period_start": f.period_start,
+            "period_end": f.period_end,
+            "val": f.val,
+            "frame": f.frame,
+            "accession_number": f.accession_number,
+            "form_type": f.form_type,
+            "filed_date": f.filed_date,
+            "fiscal_year": f.fiscal_year,
+            "fiscal_period": f.fiscal_period,
+            "decimals": f.decimals,
+            "ingestion_run_id": ingestion_run_id,
+        }
+        for f in facts
+    ]
+    sql = """
+        INSERT INTO financial_facts_raw (
+            instrument_id, taxonomy, concept, unit,
+            period_start, period_end, val, frame,
+            accession_number, form_type, filed_date,
+            fiscal_year, fiscal_period, decimals,
+            ingestion_run_id
+        ) VALUES (
+            %(instrument_id)s, %(taxonomy)s, %(concept)s, %(unit)s,
+            %(period_start)s, %(period_end)s, %(val)s, %(frame)s,
+            %(accession_number)s, %(form_type)s, %(filed_date)s,
+            %(fiscal_year)s, %(fiscal_period)s, %(decimals)s,
+            %(ingestion_run_id)s
+        )
+        ON CONFLICT (
+            instrument_id, concept, unit,
+            COALESCE(period_start, '0001-01-01'::date),
+            period_end, accession_number
+        )
+        DO UPDATE SET
+            val = EXCLUDED.val,
+            frame = EXCLUDED.frame,
+            form_type = EXCLUDED.form_type,
+            filed_date = EXCLUDED.filed_date,
+            fiscal_year = EXCLUDED.fiscal_year,
+            fiscal_period = EXCLUDED.fiscal_period,
+            decimals = EXCLUDED.decimals,
+            ingestion_run_id = EXCLUDED.ingestion_run_id,
+            fetched_at = NOW()
+        WHERE financial_facts_raw.val IS DISTINCT FROM EXCLUDED.val
+           OR financial_facts_raw.frame IS DISTINCT FROM EXCLUDED.frame
+    """
+    with conn.cursor() as cur:
+        for start in range(0, len(rows), page_size):
+            cur.executemany(sql, rows[start : start + page_size])
+
+
+# ---------------------------------------------------------------------------
+# Shape C — COPY STDIN → temp staging → INSERT SELECT ON CONFLICT
+# ---------------------------------------------------------------------------
+
+
+def upsert_facts_copy(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    facts: Sequence[XbrlFact],
+    ingestion_run_id: int,
+) -> None:
+    if not facts:
+        return
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TEMP TABLE IF NOT EXISTS _stg_facts (
+                instrument_id BIGINT, taxonomy TEXT, concept TEXT, unit TEXT,
+                period_start DATE, period_end DATE, val NUMERIC(30,6), frame TEXT,
+                accession_number TEXT, form_type TEXT, filed_date DATE,
+                fiscal_year INT, fiscal_period TEXT, decimals TEXT,
+                ingestion_run_id BIGINT
+            ) ON COMMIT DROP
+            """
+        )
+        with cur.copy(
+            """
+            COPY _stg_facts (
+                instrument_id, taxonomy, concept, unit,
+                period_start, period_end, val, frame,
+                accession_number, form_type, filed_date,
+                fiscal_year, fiscal_period, decimals, ingestion_run_id
+            ) FROM STDIN
+            """
+        ) as copy:
+            for f in facts:
+                copy.write_row(
+                    (
+                        instrument_id,
+                        f.taxonomy,
+                        f.concept,
+                        f.unit,
+                        f.period_start,
+                        f.period_end,
+                        f.val,
+                        f.frame,
+                        f.accession_number,
+                        f.form_type,
+                        f.filed_date,
+                        f.fiscal_year,
+                        f.fiscal_period,
+                        f.decimals,
+                        ingestion_run_id,
+                    )
+                )
+        cur.execute(
+            """
+            INSERT INTO financial_facts_raw (
+                instrument_id, taxonomy, concept, unit,
+                period_start, period_end, val, frame,
+                accession_number, form_type, filed_date,
+                fiscal_year, fiscal_period, decimals, ingestion_run_id
+            )
+            SELECT instrument_id, taxonomy, concept, unit,
+                   period_start, period_end, val, frame,
+                   accession_number, form_type, filed_date,
+                   fiscal_year, fiscal_period, decimals, ingestion_run_id
+            FROM _stg_facts
+            ON CONFLICT (
+                instrument_id, concept, unit,
+                COALESCE(period_start, '0001-01-01'::date),
+                period_end, accession_number
+            )
+            DO UPDATE SET
+                val = EXCLUDED.val,
+                frame = EXCLUDED.frame,
+                form_type = EXCLUDED.form_type,
+                filed_date = EXCLUDED.filed_date,
+                fiscal_year = EXCLUDED.fiscal_year,
+                fiscal_period = EXCLUDED.fiscal_period,
+                decimals = EXCLUDED.decimals,
+                ingestion_run_id = EXCLUDED.ingestion_run_id,
+                fetched_at = NOW()
+            WHERE financial_facts_raw.val IS DISTINCT FROM EXCLUDED.val
+               OR financial_facts_raw.frame IS DISTINCT FROM EXCLUDED.frame
+            """
+        )
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchResult:
+    shape: str
+    scenario: str  # "seed" | "re-upsert no-op" | "restatement"
+    facts: int
+    seconds: float
+    facts_per_sec: float
+
+
+_BENCH_INSTRUMENT_ID = 999_999_999
+
+
+def _reset_and_seed(conn: psycopg.Connection[tuple]) -> tuple[int, int]:
+    _assert_test_db(conn)
+    with conn.cursor() as cur:
+        # TRUNCATE facts + runs; keep instruments row stable across
+        # shape iterations so FKs remain valid. CASCADE ensures the
+        # dependent financial_facts_raw rows are removed each run.
+        cur.execute("TRUNCATE financial_facts_raw, data_ingestion_runs RESTART IDENTITY CASCADE")
+        cur.execute(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable)
+            VALUES (%s, 'BENCH', 'Bench Inc.', 'TEST', true)
+            ON CONFLICT (instrument_id) DO NOTHING
+            """,
+            (_BENCH_INSTRUMENT_ID,),
+        )
+        cur.execute(
+            """
+            INSERT INTO data_ingestion_runs (source, endpoint, instrument_count, status)
+            VALUES ('bench', 'bench', 1, 'running')
+            RETURNING ingestion_run_id
+            """
+        )
+        row = cur.fetchone()
+        assert row is not None
+        ingestion_run_id = row[0]
+    conn.commit()
+    return _BENCH_INSTRUMENT_ID, ingestion_run_id
+
+
+def _time(fn: Callable[[], None]) -> float:
+    start = time.perf_counter()
+    fn()
+    return time.perf_counter() - start
+
+
+def bench(facts_count: int) -> list[BenchResult]:
+    ensure_test_db_exists()
+    apply_migrations_to_test_db()
+    results: list[BenchResult] = []
+    facts = _generate_facts(facts_count)
+
+    shapes: list[tuple[str, Callable[..., object]]] = [
+        ("A: row-loop (current prod)", upsert_facts_for_instrument),
+        ("B: executemany(1000)", upsert_facts_executemany),
+        ("C: COPY -> INSERT SELECT", upsert_facts_copy),
+    ]
+
+    # A second fact list with mutated ``val`` fields — same identity
+    # tuple, different value — models a filing restatement, which
+    # exercises the DO UPDATE write path (the WHERE IS DISTINCT FROM
+    # filter passes and Postgres actually rewrites the row).
+    facts_restated = [
+        XbrlFact(
+            concept=f.concept,
+            taxonomy=f.taxonomy,
+            unit=f.unit,
+            period_start=f.period_start,
+            period_end=f.period_end,
+            val=f.val + Decimal("1"),
+            frame=f.frame,
+            accession_number=f.accession_number,
+            form_type=f.form_type,
+            filed_date=f.filed_date,
+            fiscal_year=f.fiscal_year,
+            fiscal_period=f.fiscal_period,
+            decimals=f.decimals,
+        )
+        for f in facts
+    ]
+
+    for shape, fn in shapes:
+        with psycopg.connect(test_database_url()) as conn:
+            instrument_id, ingestion_run_id = _reset_and_seed(conn)
+
+            def _invoke(
+                payload: Sequence[XbrlFact],
+                f: Callable[..., object] = fn,
+            ) -> None:
+                # Default-arg capture pins the current loop iteration's
+                # ``fn`` into the closure so the transaction block below
+                # cannot silently call a later iteration's function.
+                with conn.transaction():
+                    f(
+                        conn,
+                        instrument_id=instrument_id,
+                        facts=payload,
+                        ingestion_run_id=ingestion_run_id,
+                    )
+
+            scenarios: list[tuple[str, Callable[[], None]]] = [
+                ("seed", lambda: _invoke(facts)),
+                ("re-upsert no-op", lambda: _invoke(facts)),
+                ("restatement", lambda: _invoke(facts_restated)),
+            ]
+            for scenario, action in scenarios:
+                seconds = _time(action)
+                results.append(
+                    BenchResult(
+                        shape=shape,
+                        scenario=scenario,
+                        facts=facts_count,
+                        seconds=seconds,
+                        facts_per_sec=facts_count / seconds if seconds > 0 else float("inf"),
+                    )
+                )
+
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--facts", type=int, default=10_000)
+    args = parser.parse_args()
+
+    results = bench(args.facts)
+
+    # Render a text table — easy to paste into the ADR.
+    width_shape = max(len(r.shape) for r in results) + 2
+    buf = io.StringIO()
+    buf.write(f"Benchmark: {args.facts:,} synthetic XBRL facts, one CIK\n")
+    buf.write("=" * 80 + "\n")
+    buf.write(f"{'shape'.ljust(width_shape)} {'scenario':<14} {'seconds':>10} {'facts/sec':>12}\n")
+    buf.write("-" * 80 + "\n")
+    for r in results:
+        buf.write(f"{r.shape.ljust(width_shape)} {r.scenario:<14} {r.seconds:>10.3f} {r.facts_per_sec:>12.1f}\n")
+    buf.write("=" * 80 + "\n")
+    print(buf.getvalue())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

- ADR 0004 — picks Shape B (`executemany(page_size=1000)`) as the v1 fix for the per-CIK upsert in `app/services/fundamentals.py`. Defers (not rejects) E2/E3/E4 until post-ship observability answers GIL-vs-lock.
- `scripts/bench_fundamentals_upsert.py` — re-runnable bench against the isolated `ebull_test` DB. Three shapes × three scenarios (seed / re-upsert no-op / restatement).

## Why

#414 investigation phase A. Four stabiliser PRs (#409, #411, #412, #413) didn't touch the freeze-prone shape. This PR is measurement only and unlocks the implementation PR.

## Numbers (10k synthetic facts, ebull_test)

| Shape | seed | no-op | restatement |
|-------|-----:|------:|------------:|
| A (row-loop, current) | 5.08s | 4.64s | 7.36s |
| B (executemany 1000)  | 0.28s | 0.25s | 0.29s |
| C (COPY → INSERT)     | 0.16s | 0.06s | 0.19s |

B is ~18× faster, C is ~31-75×. ADR picks B as the smallest diff; C deferred to v2.

## Scope limits (explicit in ADR)

- DB-path only. Not concurrent HTTP, not parser-GIL, not lock-wait.
- Bench starts near-empty; production has millions of rows. Only ratios carry to prod, not absolute wall-clock.

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pyright` — clean
- [x] `uv run pytest` — 2336 passed
- [x] Bench runs end-to-end against `ebull_test`
- [x] Codex review: spec-shape + bench + ADR (3 rounds) — clean

## Follow-ups

- Implementation PR for Shape B (swap in `upsert_facts_for_instrument` + unit test with wall-clock budget).
- Observability ticket: add per-CIK timing at `_run_cik_upsert` boundary (today `data_ingestion_runs` is per-batch, not per-CIK).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>