### PR TITLE
fix(#414): batch financial_facts_raw upsert via executemany + per-CIK timing

### DIFF
--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -297,6 +298,48 @@ def finish_ingestion_run(
     )
 
 
+_UPSERT_FACT_SQL = """
+INSERT INTO financial_facts_raw (
+    instrument_id, taxonomy, concept, unit,
+    period_start, period_end, val, frame,
+    accession_number, form_type, filed_date,
+    fiscal_year, fiscal_period, decimals,
+    ingestion_run_id
+) VALUES (
+    %(instrument_id)s, %(taxonomy)s, %(concept)s, %(unit)s,
+    %(period_start)s, %(period_end)s, %(val)s, %(frame)s,
+    %(accession_number)s, %(form_type)s, %(filed_date)s,
+    %(fiscal_year)s, %(fiscal_period)s, %(decimals)s,
+    %(ingestion_run_id)s
+)
+ON CONFLICT (
+    instrument_id, concept, unit,
+    COALESCE(period_start, '0001-01-01'::date),
+    period_end, accession_number
+)
+DO UPDATE SET
+    val = EXCLUDED.val,
+    frame = EXCLUDED.frame,
+    form_type = EXCLUDED.form_type,
+    filed_date = EXCLUDED.filed_date,
+    fiscal_year = EXCLUDED.fiscal_year,
+    fiscal_period = EXCLUDED.fiscal_period,
+    decimals = EXCLUDED.decimals,
+    ingestion_run_id = EXCLUDED.ingestion_run_id,
+    fetched_at = NOW()
+WHERE financial_facts_raw.val IS DISTINCT FROM EXCLUDED.val
+   OR financial_facts_raw.frame IS DISTINCT FROM EXCLUDED.frame
+"""
+
+
+# Batch size for executemany. A 10-K carries ~10k facts; a chunk of
+# 1000 keeps each round trip well under Postgres's default
+# max_parameter size (65k params ÷ 15 columns ≈ 4300 rows) while
+# being large enough to amortise per-round-trip latency. The ADR
+# 0004 bench showed this shape ~18× faster than the prior row-loop.
+_UPSERT_PAGE_SIZE = 1000
+
+
 def upsert_facts_for_instrument(
     conn: psycopg.Connection[tuple],
     *,
@@ -304,73 +347,69 @@ def upsert_facts_for_instrument(
     facts: Sequence[XbrlFact],
     ingestion_run_id: int,
 ) -> tuple[int, int]:
-    """Upsert XBRL facts into financial_facts_raw.
+    """Upsert XBRL facts into ``financial_facts_raw``.
 
-    Returns (upserted_count, skipped_count).
-    Uses ON CONFLICT DO UPDATE so restatements overwrite prior values.
+    Returns ``(upserted_count, skipped_count)``. "Upserted" means the
+    row was either INSERTed fresh or UPDATEd in place because the WHERE
+    guard on ``IS DISTINCT FROM`` matched a change; "skipped" means the
+    ON CONFLICT fired but the WHERE filter short-circuited because the
+    value was unchanged (idempotent re-upsert).
+
+    Uses ``cur.executemany`` with a 1000-row page size — the DB path
+    from ADR 0004. Same SQL as the previous row-loop shape; only the
+    call shape changed, so the identity index, ON CONFLICT semantics,
+    and `IS DISTINCT FROM` filter are unchanged.
+
+    Connection-level rowcount after ``executemany`` aggregates across
+    all parameter sets (psycopg3 contract), so ``upserted`` is
+    ``sum(cur.rowcount)`` per chunk and ``skipped`` is
+    ``len(facts) − upserted``.
     """
     if not facts:
         return 0, 0
 
-    upserted = 0
-    skipped = 0
-    for fact in facts:
-        cur = conn.execute(
-            """
-            INSERT INTO financial_facts_raw (
-                instrument_id, taxonomy, concept, unit,
-                period_start, period_end, val, frame,
-                accession_number, form_type, filed_date,
-                fiscal_year, fiscal_period, decimals,
-                ingestion_run_id
-            ) VALUES (
-                %(instrument_id)s, %(taxonomy)s, %(concept)s, %(unit)s,
-                %(period_start)s, %(period_end)s, %(val)s, %(frame)s,
-                %(accession_number)s, %(form_type)s, %(filed_date)s,
-                %(fiscal_year)s, %(fiscal_period)s, %(decimals)s,
-                %(ingestion_run_id)s
-            )
-            ON CONFLICT (
-                instrument_id, concept, unit,
-                COALESCE(period_start, '0001-01-01'::date),
-                period_end, accession_number
-            )
-            DO UPDATE SET
-                val = EXCLUDED.val,
-                frame = EXCLUDED.frame,
-                form_type = EXCLUDED.form_type,
-                filed_date = EXCLUDED.filed_date,
-                fiscal_year = EXCLUDED.fiscal_year,
-                fiscal_period = EXCLUDED.fiscal_period,
-                decimals = EXCLUDED.decimals,
-                ingestion_run_id = EXCLUDED.ingestion_run_id,
-                fetched_at = NOW()
-            WHERE financial_facts_raw.val IS DISTINCT FROM EXCLUDED.val
-               OR financial_facts_raw.frame IS DISTINCT FROM EXCLUDED.frame
-            """,
-            {
-                "instrument_id": instrument_id,
-                "taxonomy": fact.taxonomy,
-                "concept": fact.concept,
-                "unit": fact.unit,
-                "period_start": fact.period_start,
-                "period_end": fact.period_end,
-                "val": fact.val,
-                "frame": fact.frame,
-                "accession_number": fact.accession_number,
-                "form_type": fact.form_type,
-                "filed_date": fact.filed_date,
-                "fiscal_year": fact.fiscal_year,
-                "fiscal_period": fact.fiscal_period,
-                "decimals": fact.decimals,
-                "ingestion_run_id": ingestion_run_id,
-            },
-        )
-        if cur.rowcount > 0:
-            upserted += 1
-        else:
-            skipped += 1
+    rows: list[dict[str, object]] = [
+        {
+            "instrument_id": instrument_id,
+            "taxonomy": fact.taxonomy,
+            "concept": fact.concept,
+            "unit": fact.unit,
+            "period_start": fact.period_start,
+            "period_end": fact.period_end,
+            "val": fact.val,
+            "frame": fact.frame,
+            "accession_number": fact.accession_number,
+            "form_type": fact.form_type,
+            "filed_date": fact.filed_date,
+            "fiscal_year": fact.fiscal_year,
+            "fiscal_period": fact.fiscal_period,
+            "decimals": fact.decimals,
+            "ingestion_run_id": ingestion_run_id,
+        }
+        for fact in facts
+    ]
 
+    upserted = 0
+    with conn.cursor() as cur:
+        for start in range(0, len(rows), _UPSERT_PAGE_SIZE):
+            chunk = rows[start : start + _UPSERT_PAGE_SIZE]
+            cur.executemany(_UPSERT_FACT_SQL, chunk)
+            # rowcount == -1 means the driver/pool adapter did not
+            # report a command tag. That breaks the upserted/skipped
+            # accounting contract — treating it as zero would
+            # silently mis-count every fact as "skipped" and
+            # contaminate downstream metrics. Fail loudly so the
+            # caller surfaces it as a per-CIK failure (the watermark
+            # then stays at its previous value and the next run
+            # retries) rather than drifting silently.
+            if cur.rowcount < 0:
+                raise RuntimeError(
+                    "upsert_facts_for_instrument: driver returned rowcount=-1 "
+                    "after executemany; unable to account for upsert/skip counts"
+                )
+            upserted += cur.rowcount
+
+    skipped = len(rows) - upserted
     return upserted, skipped
 
 
@@ -1506,7 +1545,20 @@ def _run_cik_upsert(
     All writes for one CIK happen inside one ``with conn.transaction()``
     block so on exception the facts upsert AND both watermark writes
     roll back together — watermarks never drift ahead of data.
+
+    Emits a single ``fundamentals.cik_timing`` log line per invocation
+    (success OR failure) carrying wall-clock seconds, facts_upserted,
+    and seed-vs-refresh mode. This is the observability signal required
+    by issue #418 — per-CIK timing isolates whether the Shape-B DB-path
+    fix (ADR 0004) landed in production. ``data_ingestion_runs`` today
+    is per provider batch, not per CIK, so log parsing is the smallest
+    surface that answers the question without a schema change.
     """
+    started = time.perf_counter()
+    mode = "refresh" if known_top_accession is not None else "seed"
+    facts_upserted = 0
+    outcome = "unknown"
+
     try:
         inst = _instrument_for_cik(conn, cik)
         if inst is None:
@@ -1520,6 +1572,7 @@ def _run_cik_upsert(
                 cik,
             )
             failed.append((cik, "InstrumentMissing"))
+            outcome = "skip_instrument_missing"
             return None
         instrument_id, symbol = inst
         # Close the implicit read transaction opened by _instrument_for_cik
@@ -1546,6 +1599,7 @@ def _run_cik_upsert(
                     cik,
                 )
                 failed.append((cik, "SubmissionsMissing"))
+                outcome = "skip_submissions_missing"
                 return None
             top_accession = _top_accession_from_submissions(submissions)
             if top_accession is None:
@@ -1557,10 +1611,11 @@ def _run_cik_upsert(
                     cik,
                 )
                 failed.append((cik, "EmptyFilingsRecent"))
+                outcome = "skip_empty_filings"
                 return None
 
         facts = fundamentals_provider.extract_facts(symbol, cik)
-        facts_upserted = 0
+        upserted_in_tx = 0
 
         with conn.transaction():
             if facts:
@@ -1570,7 +1625,7 @@ def _run_cik_upsert(
                     facts=facts,
                     ingestion_run_id=run_id,
                 )
-                facts_upserted = upserted
+                upserted_in_tx = upserted
             # Upsert each master-index entry for this CIK into
             # filing_events so downstream event-driven triggers
             # (#273 thesis, #276 cascade) have a timestamped signal.
@@ -1598,6 +1653,13 @@ def _run_cik_upsert(
                 watermark=top_accession,
             )
         conn.commit()
+        # Only credit facts_upserted *after* the watermark writes and
+        # the commit have succeeded — if any step inside the
+        # transaction block raises, Postgres rolls back the fact
+        # upserts with it and the timing log must report 0 (not the
+        # count that was never actually committed).
+        facts_upserted = upserted_in_tx
+        outcome = "success"
         return facts_upserted
     except Exception as exc:
         # ``with conn.transaction()`` already rolled back on exception;
@@ -1610,7 +1672,23 @@ def _run_cik_upsert(
             logger.debug("rollback suppressed after executor exception", exc_info=True)
         failed.append((cik, type(exc).__name__))
         logger.exception("sec_incremental per-CIK upsert failed for cik=%s", cik)
+        outcome = f"error_{type(exc).__name__}"
         return None
+    finally:
+        # Structured per-CIK timing log — required by #418 so
+        # production ratios can be validated against the ADR 0004 bench
+        # (Shape B was ~18x faster on the DB-path bench). Emits on
+        # every exit path (success, skip, exception). Log keys are
+        # machine-parseable; the full "alert on regression" surface
+        # ships with #418's observability work.
+        logger.info(
+            "fundamentals.cik_timing cik=%s mode=%s outcome=%s facts_upserted=%d seconds=%.3f",
+            cik,
+            mode,
+            outcome,
+            facts_upserted,
+            time.perf_counter() - started,
+        )
 
 
 def execute_refresh(

--- a/tests/test_financial_facts_service.py
+++ b/tests/test_financial_facts_service.py
@@ -112,21 +112,19 @@ class TestUpsertFacts:
 
     def test_batches_large_payload_via_executemany(self) -> None:
         # 2500 facts must split into three chunks at page_size=1000.
-        # Each chunk reports rowcount = chunk_size (all INSERTed).
+        # ``set_rowcount`` side-effect refreshes ``cur.rowcount`` to
+        # the chunk length on every call, so the cumulative upsert
+        # count equals the total facts.
         conn = MagicMock()
         cur = MagicMock()
-        rowcounts = iter([1000, 1000, 500])
 
         def set_rowcount(_sql: object, params: list[object]) -> None:
             cur.rowcount = len(params)
 
         cur.executemany.side_effect = set_rowcount
-        cur.rowcount = next(rowcounts)  # pre-set for first .rowcount read
         conn.cursor.return_value.__enter__.return_value = cur
         facts = [_make_fact(accession_number=f"acc-{i:05d}") for i in range(2500)]
         upserted, skipped = upsert_facts_for_instrument(conn, instrument_id=1, facts=facts, ingestion_run_id=42)
-        # Three executemany calls; each one sets rowcount to its chunk
-        # length. Aggregate == total facts.
         assert cur.executemany.call_count == 3
         chunk_sizes = [len(call.args[1]) for call in cur.executemany.call_args_list]
         assert chunk_sizes == [1000, 1000, 500]

--- a/tests/test_financial_facts_service.py
+++ b/tests/test_financial_facts_service.py
@@ -67,29 +67,81 @@ class TestFinishIngestionRun:
         assert "status" in sql
 
 
+def _mock_conn_with_rowcount(rowcount: int) -> tuple[MagicMock, MagicMock]:
+    """Return ``(conn, cur)`` where ``conn.cursor()`` yields a cursor
+    whose ``executemany`` sets ``rowcount`` to the provided value.
+
+    The ADR 0004 shape calls ``conn.cursor()`` as a context manager,
+    then ``cur.executemany(sql, chunk)``, then reads ``cur.rowcount``.
+    The test double models that path so unit tests do not need a real
+    Postgres.
+    """
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.rowcount = rowcount
+    conn.cursor.return_value.__enter__.return_value = cur
+    return conn, cur
+
+
 class TestUpsertFacts:
     def test_upserts_single_fact(self) -> None:
-        conn = MagicMock()
-        cursor = MagicMock()
-        cursor.rowcount = 1
-        conn.execute.return_value = cursor
+        conn, cur = _mock_conn_with_rowcount(1)
         facts = [_make_fact()]
         upserted, skipped = upsert_facts_for_instrument(conn, instrument_id=1, facts=facts, ingestion_run_id=42)
         assert upserted == 1
         assert skipped == 0
+        cur.executemany.assert_called_once()
 
     def test_handles_empty_facts(self) -> None:
         conn = MagicMock()
         upserted, skipped = upsert_facts_for_instrument(conn, instrument_id=1, facts=[], ingestion_run_id=42)
         assert upserted == 0
         assert skipped == 0
+        # Empty facts must short-circuit before opening a cursor —
+        # avoids a wasted round-trip on instruments with no XBRL facts.
+        conn.cursor.assert_not_called()
 
     def test_counts_skipped_when_unchanged(self) -> None:
-        conn = MagicMock()
-        cursor = MagicMock()
-        cursor.rowcount = 0  # ON CONFLICT skipped because data unchanged
-        conn.execute.return_value = cursor
+        # ``IS DISTINCT FROM`` filter matches zero rows — all facts are
+        # idempotent no-ops. rowcount=0 across the whole chunk.
+        conn, _ = _mock_conn_with_rowcount(0)
         facts = [_make_fact()]
         upserted, skipped = upsert_facts_for_instrument(conn, instrument_id=1, facts=facts, ingestion_run_id=42)
         assert upserted == 0
         assert skipped == 1
+
+    def test_batches_large_payload_via_executemany(self) -> None:
+        # 2500 facts must split into three chunks at page_size=1000.
+        # Each chunk reports rowcount = chunk_size (all INSERTed).
+        conn = MagicMock()
+        cur = MagicMock()
+        rowcounts = iter([1000, 1000, 500])
+
+        def set_rowcount(_sql: object, params: list[object]) -> None:
+            cur.rowcount = len(params)
+
+        cur.executemany.side_effect = set_rowcount
+        cur.rowcount = next(rowcounts)  # pre-set for first .rowcount read
+        conn.cursor.return_value.__enter__.return_value = cur
+        facts = [_make_fact(accession_number=f"acc-{i:05d}") for i in range(2500)]
+        upserted, skipped = upsert_facts_for_instrument(conn, instrument_id=1, facts=facts, ingestion_run_id=42)
+        # Three executemany calls; each one sets rowcount to its chunk
+        # length. Aggregate == total facts.
+        assert cur.executemany.call_count == 3
+        chunk_sizes = [len(call.args[1]) for call in cur.executemany.call_args_list]
+        assert chunk_sizes == [1000, 1000, 500]
+        assert upserted == 2500
+        assert skipped == 0
+
+    def test_negative_rowcount_raises(self) -> None:
+        # rowcount == -1 means the driver did not report a command
+        # tag. Silently treating that as "all rows were skipped"
+        # would contaminate upserted/skipped accounting. The contract
+        # is to raise so the caller rolls back and the watermark
+        # stays at its previous value (the next run retries).
+        import pytest
+
+        conn, _ = _mock_conn_with_rowcount(-1)
+        facts = [_make_fact()]
+        with pytest.raises(RuntimeError, match="rowcount=-1"):
+            upsert_facts_for_instrument(conn, instrument_id=1, facts=facts, ingestion_run_id=42)

--- a/tests/test_fundamentals_upsert_integration.py
+++ b/tests/test_fundamentals_upsert_integration.py
@@ -1,0 +1,241 @@
+"""Integration tests for ``upsert_facts_for_instrument`` — ADR 0004.
+
+Exercises the real Postgres identity index via ``ebull_test`` so the
+Shape B (``executemany``) implementation is verified end-to-end:
+
+- Identity branch with non-null ``period_start`` (duration fact).
+- Identity branch with NULL ``period_start`` (instant / balance-sheet
+  fact) — goes through ``COALESCE(period_start, '0001-01-01'::date)``.
+- ``ON CONFLICT DO UPDATE WHERE IS DISTINCT FROM`` short-circuit for
+  an unchanged re-upsert (idempotent path).
+- Restatement — same identity tuple, mutated ``val`` — actually
+  rewrites the row and increments ``upserted``.
+
+These are the branches the bench [`scripts/bench_fundamentals_upsert.py`](../scripts/bench_fundamentals_upsert.py)
+exercises against synthetic data; this test confirms the production
+code path behaves the same against the real index.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.providers.fundamentals import XbrlFact
+from app.services.fundamentals import (
+    start_ingestion_run,
+    upsert_facts_for_instrument,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 (fixture re-export)
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test DB unavailable",
+)
+
+
+_INSTRUMENT_ID = 1001
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple]) -> None:
+    # Idempotent: the ``ebull_test_conn`` fixture truncates
+    # ``instruments`` between tests, but an ON CONFLICT guard makes the
+    # seed safe to re-run when the bench or another script has left a
+    # stale ``TEST`` row behind.
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (%s, 'TEST', 'Test Inc.', TRUE) "
+        "ON CONFLICT (instrument_id) DO NOTHING",
+        (_INSTRUMENT_ID,),
+    )
+    conn.commit()
+
+
+def _duration_fact(accession: str, val: Decimal) -> XbrlFact:
+    """Revenue-like fact with a non-null period_start."""
+    return XbrlFact(
+        concept="Revenues",
+        taxonomy="us-gaap",
+        unit="USD",
+        period_start=date(2023, 1, 1),
+        period_end=date(2023, 12, 31),
+        val=val,
+        frame="CY2023",
+        accession_number=accession,
+        form_type="10-K",
+        filed_date=date(2024, 3, 15),
+        fiscal_year=2023,
+        fiscal_period="FY",
+        decimals="-3",
+    )
+
+
+def _instant_fact(accession: str, val: Decimal) -> XbrlFact:
+    """Balance-sheet-like fact with a NULL period_start."""
+    return XbrlFact(
+        concept="CashAndCashEquivalentsAtCarryingValue",
+        taxonomy="us-gaap",
+        unit="USD",
+        period_start=None,
+        period_end=date(2023, 12, 31),
+        val=val,
+        frame=None,
+        accession_number=accession,
+        form_type="10-K",
+        filed_date=date(2024, 3, 15),
+        fiscal_year=2023,
+        fiscal_period="FY",
+        decimals="-3",
+    )
+
+
+def test_seed_inserts_both_instant_and_duration_facts(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_instrument(ebull_test_conn)
+    run_id = start_ingestion_run(
+        ebull_test_conn,
+        source="sec_edgar",
+        endpoint="/test",
+        instrument_count=1,
+    )
+    ebull_test_conn.commit()
+
+    facts = [
+        _duration_fact("acc-1", Decimal("100")),
+        _instant_fact("acc-1", Decimal("50")),
+    ]
+    upserted, skipped = upsert_facts_for_instrument(
+        ebull_test_conn,
+        instrument_id=_INSTRUMENT_ID,
+        facts=facts,
+        ingestion_run_id=run_id,
+    )
+    ebull_test_conn.commit()
+
+    assert upserted == 2
+    assert skipped == 0
+
+    row = ebull_test_conn.execute(
+        "SELECT COUNT(*) FROM financial_facts_raw WHERE instrument_id = %s",
+        (_INSTRUMENT_ID,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == 2
+
+
+def test_reupsert_unchanged_is_noop(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_instrument(ebull_test_conn)
+    run_id = start_ingestion_run(
+        ebull_test_conn,
+        source="sec_edgar",
+        endpoint="/test",
+        instrument_count=1,
+    )
+    ebull_test_conn.commit()
+
+    facts = [_duration_fact("acc-1", Decimal("100"))]
+    upsert_facts_for_instrument(
+        ebull_test_conn,
+        instrument_id=_INSTRUMENT_ID,
+        facts=facts,
+        ingestion_run_id=run_id,
+    )
+    ebull_test_conn.commit()
+
+    # Re-upsert identical payload — the WHERE IS DISTINCT FROM filter
+    # must short-circuit every row.
+    upserted, skipped = upsert_facts_for_instrument(
+        ebull_test_conn,
+        instrument_id=_INSTRUMENT_ID,
+        facts=facts,
+        ingestion_run_id=run_id,
+    )
+    ebull_test_conn.commit()
+
+    assert upserted == 0
+    assert skipped == 1
+
+
+def test_restatement_rewrites_row(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_instrument(ebull_test_conn)
+    run_id = start_ingestion_run(
+        ebull_test_conn,
+        source="sec_edgar",
+        endpoint="/test",
+        instrument_count=1,
+    )
+    ebull_test_conn.commit()
+
+    upsert_facts_for_instrument(
+        ebull_test_conn,
+        instrument_id=_INSTRUMENT_ID,
+        facts=[_duration_fact("acc-1", Decimal("100"))],
+        ingestion_run_id=run_id,
+    )
+    ebull_test_conn.commit()
+
+    # Same identity tuple, mutated val — DO UPDATE WHERE matches.
+    upserted, skipped = upsert_facts_for_instrument(
+        ebull_test_conn,
+        instrument_id=_INSTRUMENT_ID,
+        facts=[_duration_fact("acc-1", Decimal("200"))],
+        ingestion_run_id=run_id,
+    )
+    ebull_test_conn.commit()
+
+    assert upserted == 1
+    assert skipped == 0
+
+    row = ebull_test_conn.execute(
+        "SELECT val FROM financial_facts_raw WHERE instrument_id = %s",
+        (_INSTRUMENT_ID,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == Decimal("200.000000")
+
+
+def test_batches_across_chunk_boundary(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    # Feed more than one chunk's worth of facts so the executemany
+    # page_size (1000) is crossed at least once. Verifies aggregated
+    # rowcount across chunks is correct against a real DB — the mock
+    # tests cover the split path; this covers the real driver contract.
+    _seed_instrument(ebull_test_conn)
+    run_id = start_ingestion_run(
+        ebull_test_conn,
+        source="sec_edgar",
+        endpoint="/test",
+        instrument_count=1,
+    )
+    ebull_test_conn.commit()
+
+    facts = [_duration_fact(f"acc-{i:05d}", Decimal(f"{100 + i}")) for i in range(1500)]
+    upserted, skipped = upsert_facts_for_instrument(
+        ebull_test_conn,
+        instrument_id=_INSTRUMENT_ID,
+        facts=facts,
+        ingestion_run_id=run_id,
+    )
+    ebull_test_conn.commit()
+
+    assert upserted == 1500
+    assert skipped == 0
+
+    row = ebull_test_conn.execute(
+        "SELECT COUNT(*) FROM financial_facts_raw WHERE instrument_id = %s",
+        (_INSTRUMENT_ID,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == 1500

--- a/tests/test_sec_incremental_executor.py
+++ b/tests/test_sec_incremental_executor.py
@@ -676,3 +676,127 @@ def test_seed_path_does_not_write_filing_events(
 
     count = ebull_test_conn.execute("SELECT COUNT(*) FROM filing_events WHERE instrument_id = 1").fetchone()
     assert count is not None and count[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-CIK timing log (issue #418 observability signal)
+# ---------------------------------------------------------------------------
+#
+# The per-CIK ``fundamentals.cik_timing`` log line is the signal #418
+# uses to validate the ADR 0004 Shape B fix landed in production. The
+# tests below pin its invariants:
+#
+# - Emits exactly once per CIK on the success path, carrying
+#   ``outcome=success`` and the committed facts_upserted count.
+# - Emits exactly once on the exception path, carrying
+#   ``outcome=error_<ExceptionName>`` and ``facts_upserted=0`` — the
+#   transaction rolled back, so no facts were actually committed
+#   even if the upsert call completed before the later step raised.
+# - Emits exactly once on early skip paths, carrying an explicit
+#   ``outcome=skip_*`` tag.
+
+
+def _timing_lines(caplog_records: list[object]) -> list[str]:
+    return [
+        r.getMessage()  # type: ignore[attr-defined]
+        for r in caplog_records
+        if r.getMessage().startswith("fundamentals.cik_timing ")  # type: ignore[attr-defined]
+    ]
+
+
+def test_timing_log_emitted_on_success(
+    ebull_test_conn: psycopg.Connection[tuple],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="TEST", cik="0000320193")
+    plan = RefreshPlan(seeds=["0000320193"])
+    filings = StubFilingsProvider(
+        submissions_by_cik={"0000320193": _submissions_with_top("0000320193-26-000042")},
+    )
+    fundamentals = StubFundamentalsProvider(
+        facts_by_cik={"0000320193": [_sample_fact("0000320193-26-000042")]},
+    )
+
+    with caplog.at_level("INFO", logger="app.services.fundamentals"):
+        execute_refresh(
+            ebull_test_conn,
+            filings_provider=cast(SecFilingsProvider, filings),
+            fundamentals_provider=cast(SecFundamentalsProvider, fundamentals),
+            plan=plan,
+        )
+
+    lines = _timing_lines(caplog.records)
+    assert len(lines) == 1
+    line = lines[0]
+    assert "cik=0000320193" in line
+    assert "mode=seed" in line
+    assert "outcome=success" in line
+    assert "facts_upserted=1" in line
+
+
+def test_timing_log_emitted_on_exception_reports_zero_facts(
+    ebull_test_conn: psycopg.Connection[tuple],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # ``fail_on`` causes the fundamentals provider to raise during
+    # extract_facts, which is before the upsert runs — but the timing
+    # log must still emit exactly once, with outcome=error_RuntimeError
+    # and facts_upserted=0 (nothing was committed).
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="TEST", cik="0000320193")
+    with ebull_test_conn.transaction():
+        set_watermark(
+            ebull_test_conn,
+            source="sec.submissions",
+            key="0000320193",
+            watermark="0000320193-25-000108",
+        )
+    ebull_test_conn.commit()
+
+    plan = RefreshPlan(refreshes=[("0000320193", "0000320193-26-000042")])
+    filings = StubFilingsProvider(
+        submissions_by_cik={"0000320193": _submissions_with_top("0000320193-26-000042")},
+    )
+    fundamentals = StubFundamentalsProvider(fail_on={"0000320193"})
+
+    with caplog.at_level("INFO", logger="app.services.fundamentals"):
+        execute_refresh(
+            ebull_test_conn,
+            filings_provider=cast(SecFilingsProvider, filings),
+            fundamentals_provider=cast(SecFundamentalsProvider, fundamentals),
+            plan=plan,
+        )
+
+    lines = _timing_lines(caplog.records)
+    assert len(lines) == 1
+    line = lines[0]
+    assert "cik=0000320193" in line
+    assert "mode=refresh" in line
+    assert "outcome=error_RuntimeError" in line
+    assert "facts_upserted=0" in line
+
+
+def test_timing_log_emitted_on_instrument_missing_skip(
+    ebull_test_conn: psycopg.Connection[tuple],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Plan-time drift: the CIK was in the plan but no instrument
+    # resolves for it. _run_cik_upsert hits the InstrumentMissing
+    # early return; the timing log must still emit once.
+    plan = RefreshPlan(seeds=["0000999999"])
+    filings = StubFilingsProvider()
+    fundamentals = StubFundamentalsProvider()
+
+    with caplog.at_level("INFO", logger="app.services.fundamentals"):
+        execute_refresh(
+            ebull_test_conn,
+            filings_provider=cast(SecFilingsProvider, filings),
+            fundamentals_provider=cast(SecFundamentalsProvider, fundamentals),
+            plan=plan,
+        )
+
+    lines = _timing_lines(caplog.records)
+    assert len(lines) == 1
+    line = lines[0]
+    assert "cik=0000999999" in line
+    assert "outcome=skip_instrument_missing" in line
+    assert "facts_upserted=0" in line

--- a/tests/test_sec_incremental_executor.py
+++ b/tests/test_sec_incremental_executor.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal
+from logging import LogRecord
 from typing import cast
 
 import psycopg
@@ -696,11 +698,11 @@ def test_seed_path_does_not_write_filing_events(
 #   ``outcome=skip_*`` tag.
 
 
-def _timing_lines(caplog_records: list[object]) -> list[str]:
+def _timing_lines(caplog_records: Sequence[LogRecord]) -> list[str]:
     return [
-        r.getMessage()  # type: ignore[attr-defined]
+        r.getMessage()
         for r in caplog_records
-        if r.getMessage().startswith("fundamentals.cik_timing ")  # type: ignore[attr-defined]
+        if r.getMessage().startswith("fundamentals.cik_timing ")
     ]
 
 

--- a/tests/test_sec_incremental_executor.py
+++ b/tests/test_sec_incremental_executor.py
@@ -699,11 +699,7 @@ def test_seed_path_does_not_write_filing_events(
 
 
 def _timing_lines(caplog_records: Sequence[LogRecord]) -> list[str]:
-    return [
-        r.getMessage()
-        for r in caplog_records
-        if r.getMessage().startswith("fundamentals.cik_timing ")
-    ]
+    return [r.getMessage() for r in caplog_records if r.getMessage().startswith("fundamentals.cik_timing ")]
 
 
 def test_timing_log_emitted_on_success(


### PR DESCRIPTION
## What

- Rewrite \`upsert_facts_for_instrument\` from row-loop to \`cur.executemany\` at page_size=1000 (ADR 0004 Shape B). Same SQL, same ON CONFLICT, same IS DISTINCT FROM filter.
- Add \`fundamentals.cik_timing\` structured log at \`_run_cik_upsert\` boundary for issue #418. Emits on every exit path (success / skip / exception).
- \`rowcount=-1\` now raises a RuntimeError instead of silently reporting all rows as skipped.

## Why

ADR 0004 (merged as #417) picked Shape B based on DB-path bench showing 17-25× speedup over the current row-loop. Closes the implementation half of #414. Per-CIK timing signal unblocks in-prod validation once this deploys.

## Test plan

- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\` clean
- [x] \`uv run pytest -q\` 2345 passed
- [x] New tests:
  - unit: executemany chunk-boundary split, rowcount=-1 raise path
  - integration (ebull_test): NULL period_start identity branch, re-upsert no-op, restatement rewrite, cross-chunk aggregation
  - timing log emitted once with correct outcome on success/exception/skip
- [x] Codex review (2 rounds) — clean

## Follow-ups

- #418 — surface per-CIK p50/p95 timing in admin UI.
- #410 — submissions.json backfill for stale watermark CIKs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>