### PR TITLE
fix(#410): SEC offline-catch-up via submissions.json backfill for stale-watermark CIKs

### DIFF
--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -1148,9 +1148,20 @@ def normalize_financial_periods(
 # run gets a 304 and pays only the conditional-GET round-trip. A
 # 30-call burst at the 10 rps SEC cap is bounded at ~3s.
 #
-# Gaps longer than this window need a one-shot submissions.json
-# backfill for covered CIKs — tracked as tech debt.
+# Gaps longer than this window are handled by the stale-watermark
+# submissions.json backfill path (issue #410) — see
+# ``_stale_submission_ciks`` below.
 LOOKBACK_DAYS = 30
+
+
+# Per-run cap on the submissions.json backfill for stale-watermark
+# CIKs (#410). This is a rare-path branch; in steady state zero CIKs
+# are stale and the extra SQL query is a bounded no-op. After a long
+# outage many CIKs may qualify — the cap bounds blast radius so a
+# single run cannot burn the SEC rate budget on backfill alone. At
+# 10 rps the SEC cap is 36,000 calls/hour, so 200 is generous without
+# being reckless.
+SUBMISSIONS_STALE_BACKFILL_CAP = 200
 
 # 6-K (foreign-private-issuer interim reports) is deliberately
 # excluded — typically lacks structured XBRL, so refreshing
@@ -1250,6 +1261,58 @@ def _load_covered_us_ciks(conn: psycopg.Connection[tuple]) -> list[str]:
 
 def _lookback_dates(today: date) -> list[date]:
     return [today - timedelta(days=i) for i in range(LOOKBACK_DAYS)]
+
+
+def _stale_submission_ciks(
+    conn: psycopg.Connection[tuple],
+    *,
+    covered: list[str],
+    today: date,
+    exclude: set[str],
+    limit: int,
+) -> list[str]:
+    """Covered CIKs whose ``sec.submissions`` watermark has not been
+    refreshed in the last ``LOOKBACK_DAYS`` days.
+
+    Steady-state (short outage, at most a few days) returns an empty
+    list — every active CIK's watermark was touched on the last run.
+    After a long outage — longer than ``LOOKBACK_DAYS`` — CIKs that
+    filed during the gap are silently skipped by the master-index
+    window because their filings fall outside the planner's lookback.
+    Those CIKs are rescued here: the backfill path fetches
+    ``submissions.json`` unconditionally and diffs the top accession
+    against the stored watermark, enqueuing any new filings for a
+    refresh.
+
+    - ``covered`` is the list of covered US CIKs, already loaded by
+      the caller.  Passed in so we do not re-query the cohort.
+    - ``exclude`` is the set of CIKs already queued as a seed or
+      refresh this run — they do not need a second backfill pass.
+    - ``limit`` bounds the number of CIKs returned per run.  Returns
+      the oldest-watermark CIKs first so a long-outage backfill
+      progresses steadily rather than rotating through the same
+      hundred CIKs forever.
+    """
+    if not covered or limit <= 0:
+        return []
+    cutoff = today - timedelta(days=LOOKBACK_DAYS)
+    # Parameterise the IN clause via a single ARRAY param to avoid
+    # fan-out over N placeholders and to stay safe against CIK lists
+    # that grow to thousands of entries.
+    rows = conn.execute(
+        """
+        SELECT key
+        FROM external_data_watermarks
+        WHERE source = 'sec.submissions'
+          AND fetched_at < %s
+          AND key = ANY(%s)
+          AND NOT (key = ANY(%s))
+        ORDER BY fetched_at ASC
+        LIMIT %s
+        """,
+        (cutoff, covered, list(exclude), limit),
+    ).fetchall()
+    return [str(r[0]) for r in rows]
 
 
 def _top_accession_from_submissions(
@@ -1392,6 +1455,82 @@ def plan_refresh(
             refreshes.append((cik, top_accession))
         else:
             submissions_only.append((cik, top_accession))
+
+    # --- Stale-watermark backfill (#410) ------------------------------
+    # Covered CIKs whose sec.submissions watermark is older than
+    # LOOKBACK_DAYS AND that did not hit the master-index this window
+    # would otherwise be silently skipped — they filed during a gap
+    # longer than the window. Rescue them by fetching submissions.json
+    # unconditionally and comparing top_accession against the stored
+    # watermark. Rare-path branch: in steady state this SQL returns
+    # zero rows and the extra work is bounded.
+    #
+    # Exclude every CIK the main loop already inspected — ``seeds``
+    # covers CIKs with no watermark, and ``master_hits_by_cik`` covers
+    # CIKs that went through the main-loop submissions.json lookup
+    # (whether that produced a refresh, a submissions-only advance, a
+    # failed-plan flag, or the "accession unchanged" no-op). Either
+    # way, the main loop has already fetched submissions.json for them
+    # this run; the backfill path must not double-fetch.
+    already_handled = set(seeds) | set(master_hits_by_cik.keys())
+    stale_ciks = _stale_submission_ciks(
+        conn,
+        covered=covered,
+        today=today,
+        exclude=already_handled,
+        limit=SUBMISSIONS_STALE_BACKFILL_CAP,
+    )
+    if stale_ciks:
+        logger.info(
+            "plan_refresh: stale-watermark backfill for %d CIK(s) (cap=%d)",
+            len(stale_ciks),
+            SUBMISSIONS_STALE_BACKFILL_CAP,
+        )
+    for cik in stale_ciks:
+        wm = get_watermark(conn, "sec.submissions", cik)
+        if wm is None:
+            # Belt-and-braces: _stale_submission_ciks guarantees this
+            # CIK has a watermark row; a concurrent delete between the
+            # SELECT and this lookup would fall here. Treat as seed so
+            # the executor runs a full backfill.
+            seeds.append(cik)
+            continue
+        submissions = provider.fetch_submissions(cik)
+        if submissions is None:
+            # Transient. Same invariant as the main loop: withhold the
+            # master-index watermark by flagging this CIK so the next
+            # run retries.
+            logger.warning(
+                "plan_refresh: backfill fetch_submissions returned None for cik=%s — will retry next run",
+                cik,
+            )
+            failed_plan_ciks.append(cik)
+            continue
+        top_accession = _top_accession_from_submissions(submissions)
+        if top_accession is None:
+            logger.warning(
+                "plan_refresh: backfill submissions.json for cik=%s has empty filings.recent",
+                cik,
+            )
+            failed_plan_ciks.append(cik)
+            continue
+        if top_accession == wm.watermark:
+            # No new filings since the last watermark — this CIK has
+            # genuinely been idle during the outage. Advance
+            # ``fetched_at`` so the ``ORDER BY fetched_at ASC LIMIT``
+            # cap can make forward progress: without this, the same
+            # oldest-fetched CIKs would monopolise the cap on every
+            # run and newer stale CIKs would starve indefinitely. The
+            # UPDATE is idempotent and touches a single row.
+            conn.execute(
+                "UPDATE external_data_watermarks SET fetched_at = NOW() WHERE source = 'sec.submissions' AND key = %s",
+                (cik,),
+            )
+            continue
+        # A new filing arrived during the outage. Enqueue as refresh —
+        # the executor will fetch companyfacts and advance both
+        # watermarks atomically.
+        refreshes.append((cik, top_accession))
 
     return RefreshPlan(
         seeds=sorted(seeds),

--- a/tests/test_sec_incremental_planner.py
+++ b/tests/test_sec_incremental_planner.py
@@ -367,3 +367,328 @@ def test_body_hash_match_skips_parse(
     # Body-hash match → no parse → no entries → no refresh/submissions-only.
     assert plan.refreshes == []
     assert plan.submissions_only_advances == []
+
+
+# ---------------------------------------------------------------------------
+# Stale-watermark submissions.json backfill (#410)
+# ---------------------------------------------------------------------------
+
+
+def _set_submissions_watermark(
+    conn: psycopg.Connection[tuple],
+    *,
+    cik: str,
+    watermark: str,
+    fetched_at: date,
+) -> None:
+    """Seed a ``sec.submissions`` watermark row whose ``fetched_at``
+    is arbitrarily old. ``set_watermark`` always stamps NOW(), so
+    tests that need an antique ``fetched_at`` have to UPDATE directly.
+    """
+    with conn.transaction():
+        set_watermark(
+            conn,
+            source="sec.submissions",
+            key=cik,
+            watermark=watermark,
+        )
+        conn.execute(
+            "UPDATE external_data_watermarks SET fetched_at = %s WHERE source = 'sec.submissions' AND key = %s",
+            (fetched_at, cik),
+        )
+
+
+def test_stale_watermark_with_new_accession_enqueues_refresh(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A CIK whose sec.submissions watermark is older than
+    LOOKBACK_DAYS AND that did NOT hit the master-index window must
+    be rescued via submissions.json and enqueued as a refresh when a
+    new top accession is returned.
+    """
+    today = date(2026, 4, 15)
+    _seed_us_cohort(ebull_test_conn, ["0000000001"])
+    # Watermark fetched 90 days ago — well outside LOOKBACK_DAYS.
+    _set_submissions_watermark(
+        ebull_test_conn,
+        cik="0000000001",
+        watermark="old-accession-000042",
+        fetched_at=today - timedelta(days=90),
+    )
+
+    # No master-index bodies on any window day — the main loop skips
+    # this CIK. The backfill path must still pick it up.
+    provider = StubFilingsProvider(
+        master_bodies={},
+        submissions_by_cik={
+            "0000000001": {
+                "filings": {
+                    "recent": {
+                        "accessionNumber": ["new-accession-000099"],
+                        "form": ["10-K"],
+                        "acceptedDate": ["2026-03-01T16:05:00.000Z"],
+                    }
+                }
+            }
+        },
+    )
+    plan = plan_refresh(
+        ebull_test_conn,
+        cast(SecFilingsProvider, provider),
+        today=today,
+    )
+
+    assert plan.refreshes == [("0000000001", "new-accession-000099")]
+
+
+def test_stale_watermark_with_unchanged_accession_refreshes_fetched_at(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Stale watermark + submissions top accession unchanged → the
+    CIK was genuinely idle during the outage. Do not enqueue work,
+    BUT the planner must advance ``fetched_at`` so the next run's
+    backfill cap can make forward progress. Without this the oldest-
+    idle CIKs would monopolise the cap forever and newer stale CIKs
+    would starve (regression caught by codex).
+    """
+    today = date(2026, 4, 15)
+    _seed_us_cohort(ebull_test_conn, ["0000000001"])
+    _set_submissions_watermark(
+        ebull_test_conn,
+        cik="0000000001",
+        watermark="same-accession-000042",
+        fetched_at=today - timedelta(days=90),
+    )
+
+    provider = StubFilingsProvider(
+        master_bodies={},
+        submissions_by_cik={
+            "0000000001": {
+                "filings": {
+                    "recent": {
+                        "accessionNumber": ["same-accession-000042"],
+                        "form": ["10-K"],
+                        "acceptedDate": ["2026-03-01T16:05:00.000Z"],
+                    }
+                }
+            }
+        },
+    )
+    plan = plan_refresh(
+        ebull_test_conn,
+        cast(SecFilingsProvider, provider),
+        today=today,
+    )
+
+    assert plan.refreshes == []
+    assert plan.submissions_only_advances == []
+
+    # fetched_at must have been advanced past the stale cutoff so
+    # the next run's _stale_submission_ciks query no longer picks
+    # this CIK.
+    row = ebull_test_conn.execute(
+        "SELECT fetched_at FROM external_data_watermarks WHERE source = 'sec.submissions' AND key = %s",
+        ("0000000001",),
+    ).fetchone()
+    assert row is not None
+    # NOW() on the planner side is strictly after today - 90 days,
+    # and must now be inside the LOOKBACK_DAYS window.
+    fetched_at = row[0]
+    assert (today - fetched_at.date()).days < LOOKBACK_DAYS
+
+
+def test_fresh_watermark_is_not_a_backfill_candidate(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Steady-state regression guard: a CIK whose watermark was
+    touched inside LOOKBACK_DAYS must NOT trigger the backfill fetch,
+    even if it did not hit the master-index this window.
+    """
+    today = date(2026, 4, 15)
+    _seed_us_cohort(ebull_test_conn, ["0000000001"])
+    _set_submissions_watermark(
+        ebull_test_conn,
+        cik="0000000001",
+        watermark="fresh-accession-000042",
+        fetched_at=today - timedelta(days=5),
+    )
+
+    provider = StubFilingsProvider(master_bodies={}, submissions_by_cik={})
+    plan = plan_refresh(
+        ebull_test_conn,
+        cast(SecFilingsProvider, provider),
+        today=today,
+    )
+
+    assert plan.refreshes == []
+    # If the backfill path had run, it would have called
+    # fetch_submissions and raised a KeyError on the empty map.
+    # Reaching this assertion proves it did not run.
+
+
+def test_stale_watermark_already_queued_as_refresh_is_not_double_processed(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """CIK that hits the master-index window AND has a stale watermark
+    must only appear once (via the main loop), not twice (main loop +
+    backfill path).
+    """
+    today = date(2026, 4, 15)
+    master_day = today - timedelta(days=3)
+    _seed_us_cohort(ebull_test_conn, ["0000000001"])
+    _set_submissions_watermark(
+        ebull_test_conn,
+        cik="0000000001",
+        watermark="old-accession-000042",
+        fetched_at=today - timedelta(days=90),
+    )
+
+    master_body = (
+        b"Description:           Master Index of EDGAR Dissemination Feed\n"
+        b"Last Data Received:    April 15, 2026\n"
+        b"Comments:              webmaster@sec.gov\n"
+        b"Anonymous FTP:         ftp://ftp.sec.gov/edgar/\n"
+        b"\n"
+        b" \n"
+        b"CIK|Company Name|Form Type|Date Filed|Filename\n"
+        b"--------------------------------------------------------------------------------\n"
+        b"1|Test Co|10-K|2026-04-12|edgar/data/1/new-accession-000099.txt\n"
+    )
+    provider = StubFilingsProvider(
+        master_bodies={master_day: master_body},
+        submissions_by_cik={
+            "0000000001": {
+                "filings": {
+                    "recent": {
+                        "accessionNumber": ["new-accession-000099"],
+                        "form": ["10-K"],
+                        "acceptedDate": ["2026-04-12T16:05:00.000Z"],
+                    }
+                }
+            }
+        },
+    )
+    plan = plan_refresh(
+        ebull_test_conn,
+        cast(SecFilingsProvider, provider),
+        today=today,
+    )
+
+    # Exactly one refresh entry for the CIK — no duplicate from the
+    # backfill loop.
+    assert plan.refreshes == [("0000000001", "new-accession-000099")]
+
+
+def test_main_loop_no_op_cik_is_excluded_from_backfill(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Regression guard: a stale-watermark CIK that hit the
+    master-index this run and resolved to the main-loop ``accession
+    unchanged`` no-op must NOT be re-fetched by the backfill path.
+    That would burn backfill cap on a CIK whose submissions.json the
+    main loop already resolved this run, and (on a slow provider)
+    double the SEC rate-limit spend.
+    """
+    today = date(2026, 4, 15)
+    master_day = today - timedelta(days=3)
+    _seed_us_cohort(ebull_test_conn, ["0000000001"])
+    _set_submissions_watermark(
+        ebull_test_conn,
+        cik="0000000001",
+        watermark="same-accession-000042",
+        fetched_at=today - timedelta(days=90),
+    )
+
+    master_body = (
+        b"CIK|Company Name|Form Type|Date Filed|Filename\n"
+        b"--------------------------------------------------------------------------------\n"
+        b"1|Test Co|10-K|2026-04-12|edgar/data/1/same-accession-000042.txt\n"
+    )
+    # Count submissions fetches so we can assert the backfill path
+    # does NOT re-fetch.
+    fetch_count = {"n": 0}
+
+    class CountingStub(StubFilingsProvider):
+        def fetch_submissions(self, cik: str) -> dict[str, object] | None:
+            fetch_count["n"] += 1
+            return super().fetch_submissions(cik)
+
+    provider = CountingStub(
+        master_bodies={master_day: master_body},
+        submissions_by_cik={
+            "0000000001": {
+                "filings": {
+                    "recent": {
+                        "accessionNumber": ["same-accession-000042"],
+                        "form": ["10-K"],
+                        "acceptedDate": ["2026-04-12T16:05:00.000Z"],
+                    }
+                }
+            }
+        },
+    )
+    plan_refresh(
+        ebull_test_conn,
+        cast(SecFilingsProvider, provider),
+        today=today,
+    )
+
+    # Exactly one fetch_submissions call — the main loop's. If the
+    # backfill path also fetched, the counter would be 2.
+    assert fetch_count["n"] == 1
+
+
+def test_backfill_cap_bounds_blast_radius(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """When many CIKs are stale (long outage), the per-run cap must
+    limit how many submissions.json calls happen in one run.
+    """
+    from app.services import fundamentals as fundamentals_module
+
+    today = date(2026, 4, 15)
+    # 5 stale CIKs, cap=2 → backfill enqueues at most 2.
+    ciks = [f"{i:010d}" for i in range(1, 6)]
+    _seed_us_cohort(ebull_test_conn, ciks)
+    for i, cik in enumerate(ciks):
+        _set_submissions_watermark(
+            ebull_test_conn,
+            cik=cik,
+            watermark=f"old-{i:03d}",
+            fetched_at=today - timedelta(days=90 + i),
+        )
+
+    provider = StubFilingsProvider(
+        master_bodies={},
+        submissions_by_cik={
+            cik: {
+                "filings": {
+                    "recent": {
+                        "accessionNumber": [f"new-{i:03d}"],
+                        "form": ["10-K"],
+                        "acceptedDate": ["2026-03-01T16:05:00.000Z"],
+                    }
+                }
+            }
+            for i, cik in enumerate(ciks)
+        },
+    )
+
+    original_cap = fundamentals_module.SUBMISSIONS_STALE_BACKFILL_CAP
+    fundamentals_module.SUBMISSIONS_STALE_BACKFILL_CAP = 2
+    try:
+        plan = plan_refresh(
+            ebull_test_conn,
+            cast(SecFilingsProvider, provider),
+            today=today,
+        )
+    finally:
+        fundamentals_module.SUBMISSIONS_STALE_BACKFILL_CAP = original_cap
+
+    # Exactly two entries, and they are the two oldest watermarks —
+    # seeded at -94 days (0000000005) and -93 days (0000000004).
+    # plan.refreshes is alphabetically sorted by the planner, so we
+    # assert membership rather than order.
+    assert len(plan.refreshes) == 2
+    chosen_ciks = {cik for cik, _ in plan.refreshes}
+    assert chosen_ciks == {"0000000005", "0000000004"}


### PR DESCRIPTION
## What

\`plan_refresh\` now rescues covered CIKs whose \`sec.submissions\` watermark \`fetched_at\` is older than \`LOOKBACK_DAYS\` AND that did not hit the master-index window. An unconditional \`submissions.json\` fetch diffs the top accession against the stored watermark; new accession → enqueue refresh; unchanged → re-stamp \`fetched_at\` so the per-run cap can progress.

## Why

Fixes the silent-skip described in #410: after outages > 30 days, CIKs that filed during the gap were permanently skipped by the main loop because their filings fell outside the master-index window.

## Scope

- Rare-path branch — steady-state returns zero rows from the cohort SQL.
- \`SUBMISSIONS_STALE_BACKFILL_CAP=200\` bounds per-run fetches.
- Dedup excludes \`seeds\` + every CIK that reached the main-loop submissions.json lookup (\`master_hits_by_cik\` keys). No double-fetch.
- \`ORDER BY fetched_at ASC\` with the re-stamp on no-op means the cap converges — no starvation.

## Test plan

- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\` clean
- [x] \`uv run pytest -q\` 2351 passed
- [x] New planner tests (ebull_test):
  - new accession → refresh enqueued
  - unchanged accession → fetched_at advances
  - fresh watermark → backfill skipped
  - main-loop no-op → excluded from backfill
  - already-queued → no duplicate
  - cap respected, oldest-first ordering
- [x] Codex review (2 rounds) — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>