### PR TITLE
fix(#414): daily cadence + SEC dedupe flag + operator ingest pause

### DIFF
--- a/.claude/skills/engineering/test-quality.md
+++ b/.claude/skills/engineering/test-quality.md
@@ -79,6 +79,23 @@ assert rec.rationale == _hold_rationale(score_row, quote_is_fallback=False)
 
 If a function both writes to the DB and returns a result object, there must be a test verifying the returned object matches what was written. Silent divergence between in-memory and persisted state is a real bug class.
 
+## Integration-marker discipline
+
+Any test that uses the `clean_client` fixture (or any fixture that touches a real DB) MUST be decorated with `@pytest.mark.integration`. Unit-only CI passes deselect integration tests by marker; an unmarked integration test will either be silently skipped or error during fixture setup.
+
+```python
+# Wrong — silently runs against whichever DB mode CI picked
+def test_post_ingest_enabled_unknown_key_404(clean_client: TestClient) -> None:
+    ...
+
+# Correct
+@pytest.mark.integration
+def test_post_ingest_enabled_unknown_key_404(clean_client: TestClient) -> None:
+    ...
+```
+
+Self-check before pushing: `grep -n "def test_.*\(clean_client" tests/` and assert each match is preceded by `@pytest.mark.integration`.
+
 ## Test naming
 
 Method names describe the scenario and expected outcome:

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -508,6 +508,56 @@ def post_layer_enabled(
     )
 
 
+# ---------------------------------------------------------------------------
+# Non-orchestrator ingest toggles (#414)
+# ---------------------------------------------------------------------------
+
+# Ingest keys the operator can pause/resume at runtime without a restart.
+# Distinct from ``LAYERS`` because these gate scheduled *jobs*, not
+# orchestrator layers — ``fundamentals_sync`` has no layer emit and is not
+# in ``JOB_TO_LAYERS``. Stored in the same ``layer_enabled`` table for
+# operational convenience; absent row counts as enabled.
+INGEST_TOGGLES: dict[str, str] = {
+    "fundamentals_ingest": "Fundamentals ingest (fundamentals_sync)",
+}
+
+
+class IngestToggleResponse(BaseModel):
+    key: str
+    display_name: str
+    is_enabled: bool
+
+
+@router.post("/ingest/{key}/enabled", response_model=IngestToggleResponse)
+def post_ingest_enabled(
+    key: str,
+    body: LayerEnabledRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> IngestToggleResponse:
+    """Pause or resume a scheduled ingest job without restarting the
+    server (#414 design goal F).
+
+    Flip ``fundamentals_ingest`` to False to skip the daily
+    ``fundamentals_sync`` run (used during demos, or when SEC rate-
+    limits us). The job still runs at its cron time, logs the skip,
+    and records a zero-row ``job_runs`` entry — so the admin UI
+    shows the operator-initiated pause explicitly rather than silent
+    staleness.
+    """
+    if key not in INGEST_TOGGLES:
+        raise HTTPException(
+            status_code=404,
+            detail=f"unknown ingest key: {key}; allowed: {sorted(INGEST_TOGGLES)}",
+        )
+    set_layer_enabled(conn, key, enabled=body.enabled)
+    conn.commit()
+    return IngestToggleResponse(
+        key=key,
+        display_name=INGEST_TOGGLES[key],
+        is_enabled=body.enabled,
+    )
+
+
 def _system_summary(
     *,
     action_needed: list[ActionNeededItem],

--- a/app/config.py
+++ b/app/config.py
@@ -148,5 +148,19 @@ class Settings(BaseSettings):
     # → follow-up PR deletes the guarded SEC block.
     enable_filings_fetch_dedupe: bool = False
 
+    # When True, ``daily_research_refresh`` skips its SEC XBRL
+    # ``refresh_fundamentals`` call and ``fundamentals_sync`` phase 1b
+    # owns ``fundamentals_snapshot`` refresh for CIK-mapped tradable
+    # instruments. Collapses the dual SEC ``companyfacts`` fetch path
+    # identified in issue #414 so only one scheduled job hits
+    # ``data.sec.gov/api/xbrl/companyfacts/…`` each day. FMP fallback,
+    # FMP enrichment (profile / earnings / estimates), and Companies
+    # House filings all continue to run in ``daily_research_refresh``
+    # regardless of this flag.
+    # Ship as False (default) → operator flips True → observe ~1 day
+    # → follow-up PR deletes the guarded SEC-fundamentals block in
+    # ``daily_research_refresh``.
+    enable_sec_fundamentals_dedupe: bool = False
+
 
 settings = Settings()

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -444,21 +444,26 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ScheduledJob(
         name=JOB_FUNDAMENTALS_SYNC,
         description=(
-            "Weekly fundamentals research refresh: re-classify every "
+            "Daily fundamentals research refresh: re-classify every "
             "tradable instrument's coverage.filings_status, backfill "
             "eligible instruments via SEC EDGAR, then re-evaluate "
             "coverage tier promote/demote rules. Collapses the previous "
             "weekly_coverage_audit + weekly_coverage_review pair into a "
-            "single job per the 2026-04-19 research-tool refocus."
+            "single job per the 2026-04-19 research-tool refocus. "
+            "Cadence 02:30 UTC lands ~30 min after SEC's nightly XBRL "
+            "publish window (~22:00 ET / 02:00 UTC) so new filings are "
+            "picked up the same night rather than up to seven days "
+            "later (#414)."
         ),
-        cadence=Cadence.weekly(weekday=0, hour=5, minute=0),  # Monday 05:00 UTC
+        cadence=Cadence.daily(hour=2, minute=30),
         prerequisite=_has_any_coverage,
         # Never catch up on boot. The job pulls SEC EDGAR data for every
         # covered CIK (tens of minutes, holds DB-pool workers and hits
         # SEC's 10 rps cap). Every dev-stack restart would otherwise
         # fire a catch-up and make the site unresponsive until it
-        # finishes. Weekly cadence also means a missed Monday is not
-        # time-critical — operator can click "Run now" in the admin UI.
+        # finishes. A missed 02:30 run rolls forward to the next day —
+        # the incremental watermark design (#420) picks up skipped
+        # filings on the following run.
         catch_up_on_boot=False,
     ),
     # attribution_summary retired from scheduling in Phase 1.4 of the
@@ -1094,8 +1099,19 @@ def daily_research_refresh() -> None:
         total_rows = 0
 
         # Fundamentals — SEC XBRL (primary, free, US equities)
+        # Chunk #414: when ``enable_sec_fundamentals_dedupe`` is True,
+        # skip this call entirely. ``fundamentals_sync`` phase 1b already
+        # refreshes ``fundamentals_snapshot`` for every CIK-mapped
+        # tradable instrument daily at 02:30 UTC — same data, one HTTP
+        # path. Keeps FMP (non-US) + enrichment + CH filings below
+        # unchanged.
         sec_symbols = [(sym, iid) for sym, iid in symbols if sym.upper() in cik_map]
-        if sec_symbols:
+        if settings.enable_sec_fundamentals_dedupe:
+            logger.info(
+                "SEC fundamentals refresh: skipped (enable_sec_fundamentals_dedupe=True); "
+                "relying on fundamentals_sync phase 1b for fundamentals_snapshot"
+            )
+        elif sec_symbols:
             with (
                 SecFundamentalsProvider(user_agent=settings.sec_user_agent) as sec_fund,
                 psycopg.connect(settings.database_url) as conn,
@@ -2186,11 +2202,14 @@ def monitor_positions_job() -> None:
 
 
 def fundamentals_sync() -> None:
-    """Weekly fundamentals research refresh.
+    """Daily fundamentals research refresh.
 
     Per the 2026-04-19 research-tool refocus
     (docs/superpowers/specs/2026-04-19-research-tool-refocus.md §1.1), this
-    job owns the SEC research data pipeline end-to-end. Runs Monday 05:00 UTC.
+    job owns the SEC research data pipeline end-to-end. Runs daily at
+    02:30 UTC (#414 — landed just after the SEC nightly XBRL publish
+    window so newly-submitted 10-K/10-Q/8-K filings are ingested the
+    same night rather than up to seven days later).
 
     Four phases, in order:
 
@@ -2215,6 +2234,53 @@ def fundamentals_sync() -> None:
     fails. Phase 3 is isolated too — a transient review error leaves
     phase-2 writes committed and the job succeeded.
     """
+    # Operator pause switch (#414 design goal F). Operator flips
+    # ``layer_enabled[fundamentals_ingest]`` to False via the admin UI /
+    # SQL to pause ingest during a demo or when SEC is rate-limiting us,
+    # without restarting the server. Default behaviour is enabled — an
+    # absent row counts as enabled, so first-time deploys are not gated
+    # by a missing migration.
+    #
+    # Checked BEFORE entering ``_tracked_job`` and written as a
+    # ``status='skipped'`` row via ``record_job_skip`` so the admin UI
+    # can distinguish an operator-initiated pause from a regular
+    # zero-row success (same pattern as ``_write_prereq_skip_row``).
+    from app.services.layer_enabled import is_layer_enabled
+
+    # Fail-open posture: if the gate read itself errors (DB unavailable,
+    # table missing on a first-boot), fall through to ``_tracked_job`` so
+    # the run still lands a job_runs row — either success or a real
+    # failure from the body — rather than vanishing silently. Mirrors
+    # the runtime's prerequisite-check policy in
+    # ``app/jobs/runtime.py``.
+    ingest_paused = False
+    try:
+        with psycopg.connect(settings.database_url, autocommit=True) as gate_conn:
+            if not is_layer_enabled(gate_conn, "fundamentals_ingest"):
+                ingest_paused = True
+                logger.info(
+                    "fundamentals_sync: skipped (layer_enabled[fundamentals_ingest]=False); "
+                    "operator paused ingest — flip to True via the admin UI to resume"
+                )
+                try:
+                    record_job_skip(
+                        gate_conn,
+                        JOB_FUNDAMENTALS_SYNC,
+                        "paused by operator: layer_enabled[fundamentals_ingest]=False",
+                    )
+                except Exception:
+                    logger.error(
+                        "fundamentals_sync: failed to write operator-pause skip row",
+                        exc_info=True,
+                    )
+    except Exception:
+        logger.error(
+            "fundamentals_sync: operator-pause gate read failed — falling open and running job",
+            exc_info=True,
+        )
+    if ingest_paused:
+        return
+
     with _tracked_job(JOB_FUNDAMENTALS_SYNC) as tracker:
         from app.services.coverage import BackfillOutcome, audit_all_instruments, backfill_filings
 
@@ -2254,6 +2320,67 @@ def fundamentals_sync() -> None:
                 exc_info=True,
             )
             failed_phases.append("phase 1 (XBRL + normalization)")
+
+        # --- Phase 1b: SEC fundamentals snapshot refresh -----------------
+        # Collapses the dual SEC ``companyfacts`` fetch path identified
+        # in issue #414. Only runs when the operator has flipped
+        # ``enable_sec_fundamentals_dedupe=True`` in settings — the
+        # matching gate in ``daily_research_refresh`` skips its own SEC
+        # section when the flag is on, so exactly one job per day hits
+        # ``data.sec.gov/api/xbrl/companyfacts/…``.
+        #
+        # Isolated like phase 0/1: a transient snapshot failure must not
+        # block audit/review. Coverage reads ``fundamentals_snapshot`` so
+        # stale rows still beat a missed audit.
+        phase1b_rows = 0
+        if settings.enable_sec_fundamentals_dedupe:
+            try:
+                with psycopg.connect(settings.database_url) as conn:
+                    # ``ei.is_primary = TRUE`` matches the phase-2 audit
+                    # query. Without it, an instrument with a demoted
+                    # historical SEC CIK row would appear twice in the
+                    # result and the cik_map dict would non-deterministically
+                    # pick whichever row came last — critical now that
+                    # this query is the sole SEC snapshot driver under
+                    # the dedupe flag.
+                    cik_rows = conn.execute(
+                        """
+                        SELECT i.symbol, i.instrument_id::text, ei.identifier_value
+                        FROM instruments i
+                        JOIN external_identifiers ei
+                            ON ei.instrument_id = i.instrument_id
+                           AND ei.provider = 'sec'
+                           AND ei.identifier_type = 'cik'
+                           AND ei.is_primary = TRUE
+                        WHERE i.is_tradable = TRUE
+                        """
+                    ).fetchall()
+                    conn.commit()
+                if cik_rows:
+                    sec_symbols = [(str(row[0]), str(row[1])) for row in cik_rows]
+                    cik_map = {str(row[0]).upper(): str(row[2]) for row in cik_rows}
+                    with (
+                        SecFundamentalsProvider(user_agent=settings.sec_user_agent) as sec_fund,
+                        psycopg.connect(settings.database_url) as conn,
+                    ):
+                        sec_fund.set_cik_cache(cik_map)
+                        snap_summary = refresh_fundamentals(sec_fund, conn, sec_symbols)
+                    phase1b_rows = snap_summary.snapshots_upserted
+                    logger.info(
+                        "fundamentals_sync phase 1b (SEC snapshot) complete: attempted=%d upserted=%d skipped=%d",
+                        snap_summary.symbols_attempted,
+                        snap_summary.snapshots_upserted,
+                        snap_summary.symbols_skipped,
+                    )
+                else:
+                    logger.info("fundamentals_sync phase 1b (SEC snapshot) skipped: no CIK-mapped tradable instruments")
+            except Exception:
+                logger.error(
+                    "fundamentals_sync phase 1b (SEC snapshot) failed — "
+                    "continuing to audit/review on last-known snapshot",
+                    exc_info=True,
+                )
+                failed_phases.append("phase 1b (SEC snapshot)")
 
         # --- Phase 2: coverage audit + eligibility-gated backfill --------
         outcomes: dict[BackfillOutcome, int] = {o: 0 for o in BackfillOutcome}
@@ -2349,7 +2476,11 @@ def fundamentals_sync() -> None:
             logger.error("fundamentals_sync phase 3 (review) failed", exc_info=True)
             failed_phases.append("phase 3 (review)")
 
-        tracker.row_count = audit_rows + review_rows
+        # Phase 1b snapshots are counted separately from phase-2/3 rows
+        # so the row-count contract (tracker = rows written / audit-
+        # consistent) still holds when this job becomes the sole SEC
+        # companyfacts writer under #414.
+        tracker.row_count = audit_rows + review_rows + phase1b_rows
 
         # Raise at the end so all phases ran first, but the outer
         # _tracked_job marks the job failed and the health surfaces

--- a/tests/api/test_sync_ingest_toggle_endpoint.py
+++ b/tests/api/test_sync_ingest_toggle_endpoint.py
@@ -31,6 +31,7 @@ def test_post_ingest_enabled_happy_path(clean_client: TestClient) -> None:
         clean_client.post("/sync/ingest/fundamentals_ingest/enabled", json={"enabled": True})
 
 
+@pytest.mark.integration
 def test_post_ingest_enabled_unknown_key_404(clean_client: TestClient) -> None:
     resp = clean_client.post("/sync/ingest/not_a_real_key/enabled", json={"enabled": False})
     assert resp.status_code == 404

--- a/tests/api/test_sync_ingest_toggle_endpoint.py
+++ b/tests/api/test_sync_ingest_toggle_endpoint.py
@@ -1,0 +1,52 @@
+"""Tests for the ingest-toggle endpoint (#414 design goal F).
+
+Operator pause/resume for scheduled jobs that are not orchestrator
+layers. Uses the same ``layer_enabled`` table underneath — absent row
+counts as enabled, POST False flips to disabled, POST True restores.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.integration
+def test_post_ingest_enabled_happy_path(clean_client: TestClient) -> None:
+    try:
+        resp = clean_client.post("/sync/ingest/fundamentals_ingest/enabled", json={"enabled": False})
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["key"] == "fundamentals_ingest"
+        assert body["is_enabled"] is False
+        assert "fundamentals" in body["display_name"].lower()
+
+        resp2 = clean_client.post("/sync/ingest/fundamentals_ingest/enabled", json={"enabled": True})
+        assert resp2.status_code == 200
+        assert resp2.json()["is_enabled"] is True
+    finally:
+        clean_client.post("/sync/ingest/fundamentals_ingest/enabled", json={"enabled": True})
+
+
+def test_post_ingest_enabled_unknown_key_404(clean_client: TestClient) -> None:
+    resp = clean_client.post("/sync/ingest/not_a_real_key/enabled", json={"enabled": False})
+    assert resp.status_code == 404
+    assert "unknown ingest key" in resp.json()["detail"]
+
+
+def test_post_ingest_enabled_requires_auth() -> None:
+    from app.api.sync import router as sync_router
+    from app.db import get_conn
+
+    def _mock_conn():  # type: ignore[return]
+        yield MagicMock()
+
+    bare = FastAPI()
+    bare.include_router(sync_router)
+    bare.dependency_overrides[get_conn] = _mock_conn
+    with TestClient(bare) as client:
+        resp = client.post("/sync/ingest/fundamentals_ingest/enabled", json={"enabled": False})
+    assert resp.status_code in {401, 403}, resp.text

--- a/tests/test_daily_research_refresh_dedupe.py
+++ b/tests/test_daily_research_refresh_dedupe.py
@@ -81,6 +81,7 @@ def test_flag_false_calls_sec_refresh_filings(monkeypatch) -> None:
     stub_settings.companies_house_api_key = None
     stub_settings.fmp_api_key = None
     stub_settings.enable_filings_fetch_dedupe = False
+    stub_settings.enable_sec_fundamentals_dedupe = False
     monkeypatch.setattr(scheduler, "settings", stub_settings)
 
     sec_fil_cls, refresh_filings_mock, _ = _base_mocks(monkeypatch)
@@ -102,6 +103,7 @@ def test_flag_true_skips_sec_refresh_filings(monkeypatch) -> None:
     stub_settings.companies_house_api_key = None
     stub_settings.fmp_api_key = None
     stub_settings.enable_filings_fetch_dedupe = True
+    stub_settings.enable_sec_fundamentals_dedupe = False
     monkeypatch.setattr(scheduler, "settings", stub_settings)
 
     sec_fil_cls, refresh_filings_mock, _ = _base_mocks(monkeypatch)
@@ -125,6 +127,7 @@ def test_flag_true_leaves_ch_filings_path_available(monkeypatch) -> None:
     stub_settings.companies_house_api_key = "ch-key"
     stub_settings.fmp_api_key = None
     stub_settings.enable_filings_fetch_dedupe = True
+    stub_settings.enable_sec_fundamentals_dedupe = False
     monkeypatch.setattr(scheduler, "settings", stub_settings)
 
     sec_fil_cls, refresh_filings_mock, _ = _base_mocks(monkeypatch)
@@ -141,3 +144,112 @@ def test_flag_true_leaves_ch_filings_path_available(monkeypatch) -> None:
     sec_fil_cls.assert_not_called()
     ch_calls = [c for c in refresh_filings_mock.call_args_list if c.kwargs.get("provider_name") == "companies_house"]
     assert len(ch_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# enable_sec_fundamentals_dedupe (#414) — SEC XBRL fundamentals block
+# ---------------------------------------------------------------------------
+
+
+def test_sec_fundamentals_flag_false_calls_refresh_fundamentals(monkeypatch) -> None:
+    """Default behaviour — ``enable_sec_fundamentals_dedupe=False``,
+    daily_research_refresh runs the SEC XBRL ``refresh_fundamentals``
+    block as before. This is the pre-#414 path until the operator flips
+    the flag."""
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test"
+    stub_settings.companies_house_api_key = None
+    stub_settings.fmp_api_key = None
+    stub_settings.enable_filings_fetch_dedupe = True  # irrelevant to this test
+    stub_settings.enable_sec_fundamentals_dedupe = False
+    monkeypatch.setattr(scheduler, "settings", stub_settings)
+
+    _, _, refresh_fund_mock = _base_mocks(monkeypatch)
+
+    scheduler.daily_research_refresh()
+
+    # refresh_fundamentals fires once for the SEC-fundamentals block
+    # (no FMP fallback because fmp_api_key is unset and all symbols
+    # have CIKs, so fmp_symbols is empty).
+    assert refresh_fund_mock.call_count == 1
+
+
+def test_sec_fundamentals_flag_true_skips_refresh_fundamentals(monkeypatch) -> None:
+    """#414 behaviour — flag on, SEC XBRL ``refresh_fundamentals`` block
+    skipped. ``fundamentals_sync`` phase 1b is now the single path that
+    hits ``data.sec.gov/api/xbrl/companyfacts/…``. FMP fallback and
+    enrichment paths are untouched."""
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test"
+    stub_settings.companies_house_api_key = None
+    stub_settings.fmp_api_key = None
+    stub_settings.enable_filings_fetch_dedupe = True
+    stub_settings.enable_sec_fundamentals_dedupe = True
+    monkeypatch.setattr(scheduler, "settings", stub_settings)
+
+    _, _, refresh_fund_mock = _base_mocks(monkeypatch)
+
+    scheduler.daily_research_refresh()
+
+    # No SEC XBRL path AND no FMP path (fmp_api_key unset), so
+    # refresh_fundamentals is never called.
+    refresh_fund_mock.assert_not_called()
+
+
+def test_sec_fundamentals_flag_true_preserves_fmp_path(monkeypatch) -> None:
+    """Flag affects only the SEC XBRL block — FMP fallback for non-US
+    tickers still fires when FMP_API_KEY is set."""
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test"
+    stub_settings.companies_house_api_key = None
+    stub_settings.fmp_api_key = "fmp-key"
+    stub_settings.enable_filings_fetch_dedupe = True
+    stub_settings.enable_sec_fundamentals_dedupe = True
+    monkeypatch.setattr(scheduler, "settings", stub_settings)
+
+    # Override cik_rows to empty — all symbols become FMP fallback.
+    tracker = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = tracker
+    cm.__exit__.return_value = False
+    monkeypatch.setattr(scheduler, "_tracked_job", MagicMock(return_value=cm))
+
+    fake_conn = MagicMock()
+    fake_conn.execute.return_value.fetchall.side_effect = [
+        [("FOO", "1"), ("BAR", "2")],  # tradable rows (non-US)
+        [],  # cik rows empty → all go to FMP
+    ]
+    conn_cm = MagicMock()
+    conn_cm.__enter__.return_value = fake_conn
+    conn_cm.__exit__.return_value = False
+    monkeypatch.setattr(scheduler.psycopg, "connect", MagicMock(return_value=conn_cm))
+
+    fmp_cm = MagicMock()
+    fmp_cm.__enter__.return_value = MagicMock()
+    fmp_cm.__exit__.return_value = False
+    monkeypatch.setattr(scheduler, "FmpFundamentalsProvider", MagicMock(return_value=fmp_cm))
+    monkeypatch.setattr(scheduler, "SecFundamentalsProvider", MagicMock())
+
+    refresh_fund_mock = MagicMock(return_value=MagicMock(symbols_attempted=2, snapshots_upserted=2, symbols_skipped=0))
+    monkeypatch.setattr(scheduler, "refresh_fundamentals", refresh_fund_mock)
+    monkeypatch.setattr(
+        scheduler,
+        "refresh_enrichment",
+        MagicMock(
+            return_value=MagicMock(
+                symbols_attempted=2,
+                profiles_upserted=0,
+                earnings_upserted=0,
+                estimates_upserted=0,
+                symbols_skipped=0,
+            )
+        ),
+    )
+
+    scheduler.daily_research_refresh()
+
+    # FMP fallback fires once — no SEC XBRL block.
+    assert refresh_fund_mock.call_count == 1

--- a/tests/test_fundamentals_sync.py
+++ b/tests/test_fundamentals_sync.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import psycopg
 import pytest
 
 from app.services.coverage import AuditSummary, BackfillOutcome, BackfillResult, ReviewResult
@@ -17,20 +18,26 @@ from app.workers import scheduler
 
 
 def _stub_two_connect_ctxes(psycopg_mod: MagicMock, phase1_conn: MagicMock, phase2_conn: MagicMock) -> None:
-    """Wire psycopg.connect to return two distinct ``with``-context-manager
-    connections in sequence (phase 1 then phase 2).
+    """Wire psycopg.connect to return the ingest-gate connection plus two
+    distinct phase connections in sequence (gate → phase 2 audit → phase
+    3 review).
 
-    fundamentals_sync calls ``psycopg.connect(...)`` twice — once per phase —
-    and a shared MagicMock would alias both calls to the same connection,
-    hiding any test that a phase uses the wrong one.
+    fundamentals_sync opens ``psycopg.connect(...)`` once up-front for
+    the layer_enabled[fundamentals_ingest] gate (#414) and then once per
+    audit/review phase. A shared MagicMock would alias all three calls
+    to the same connection, hiding any test that a phase uses the wrong
+    one.
     """
+    gate_cm = MagicMock()
+    gate_cm.__enter__.return_value = MagicMock()
+    gate_cm.__exit__.return_value = None
     cm1 = MagicMock()
     cm1.__enter__.return_value = phase1_conn
     cm1.__exit__.return_value = None
     cm2 = MagicMock()
     cm2.__enter__.return_value = phase2_conn
     cm2.__exit__.return_value = None
-    psycopg_mod.connect.side_effect = [cm1, cm2]
+    psycopg_mod.connect.side_effect = [gate_cm, cm1, cm2]
 
 
 def _stub_backfill_result(
@@ -73,6 +80,10 @@ def test_fundamentals_sync_runs_audit_backfill_then_review() -> None:
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://test"
     stub_settings.sec_user_agent = "test-agent@example.com"
+    # Phase 1b (SEC snapshot dedupe under #414) is default-off. Must set
+    # explicitly because MagicMock attribute access otherwise returns a
+    # truthy MagicMock and fires phase 1b with an unstubbed connection.
+    stub_settings.enable_sec_fundamentals_dedupe = False
 
     tracker = MagicMock()
     tracker.row_count = None
@@ -132,6 +143,10 @@ def test_fundamentals_sync_per_instrument_error_is_isolated() -> None:
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://test"
     stub_settings.sec_user_agent = "test-agent@example.com"
+    # Phase 1b (SEC snapshot dedupe under #414) is default-off. Must set
+    # explicitly because MagicMock attribute access otherwise returns a
+    # truthy MagicMock and fires phase 1b with an unstubbed connection.
+    stub_settings.enable_sec_fundamentals_dedupe = False
 
     tracker = MagicMock()
 
@@ -187,6 +202,10 @@ def test_fundamentals_sync_propagates_audit_failure_and_skips_review() -> None:
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://test"
     stub_settings.sec_user_agent = "test-agent@example.com"
+    # Phase 1b (SEC snapshot dedupe under #414) is default-off. Must set
+    # explicitly because MagicMock attribute access otherwise returns a
+    # truthy MagicMock and fires phase 1b with an unstubbed connection.
+    stub_settings.enable_sec_fundamentals_dedupe = False
 
     tracker = MagicMock()
 
@@ -205,12 +224,15 @@ def test_fundamentals_sync_propagates_audit_failure_and_skips_review() -> None:
         ),
     ):
         tracked_cm.return_value.__enter__.return_value = tracker
-        # Only one connect() fires: audit raises before the eligible-rows
-        # query and before phase 2.
+        # Gate connect + phase-2 connect: audit raises before the
+        # eligible-rows query and before phase 3.
+        gate_cm = MagicMock()
+        gate_cm.__enter__.return_value = MagicMock()
+        gate_cm.__exit__.return_value = None
         cm1 = MagicMock()
         cm1.__enter__.return_value = phase1_conn
         cm1.__exit__.return_value = None
-        psycopg_mod.connect.side_effect = [cm1]
+        psycopg_mod.connect.side_effect = [gate_cm, cm1]
 
         try:
             scheduler.fundamentals_sync()
@@ -223,7 +245,8 @@ def test_fundamentals_sync_propagates_audit_failure_and_skips_review() -> None:
     # Phases 0 + 1 still fire before the audit raises.
     cik_mock.assert_called_once()
     facts_mock.assert_called_once()
-    assert psycopg_mod.connect.call_count == 1
+    # Gate connect + phase-2 audit connect = 2; phase-3 never opens.
+    assert psycopg_mod.connect.call_count == 2
 
 
 def test_fundamentals_sync_phase2_failure_preserves_phase1_success() -> None:
@@ -244,6 +267,10 @@ def test_fundamentals_sync_phase2_failure_preserves_phase1_success() -> None:
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://test"
     stub_settings.sec_user_agent = "test-agent@example.com"
+    # Phase 1b (SEC snapshot dedupe under #414) is default-off. Must set
+    # explicitly because MagicMock attribute access otherwise returns a
+    # truthy MagicMock and fires phase 1b with an unstubbed connection.
+    stub_settings.enable_sec_fundamentals_dedupe = False
 
     tracker = MagicMock()
     tracker.row_count = None
@@ -312,6 +339,10 @@ def test_fundamentals_sync_phase0_cik_failure_isolated() -> None:
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://test"
     stub_settings.sec_user_agent = "test-agent@example.com"
+    # Phase 1b (SEC snapshot dedupe under #414) is default-off. Must set
+    # explicitly because MagicMock attribute access otherwise returns a
+    # truthy MagicMock and fires phase 1b with an unstubbed connection.
+    stub_settings.enable_sec_fundamentals_dedupe = False
 
     tracker = MagicMock()
 
@@ -366,6 +397,10 @@ def test_fundamentals_sync_phase1_xbrl_failure_isolated() -> None:
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://test"
     stub_settings.sec_user_agent = "test-agent@example.com"
+    # Phase 1b (SEC snapshot dedupe under #414) is default-off. Must set
+    # explicitly because MagicMock attribute access otherwise returns a
+    # truthy MagicMock and fires phase 1b with an unstubbed connection.
+    stub_settings.enable_sec_fundamentals_dedupe = False
 
     tracker = MagicMock()
 
@@ -399,3 +434,481 @@ def test_fundamentals_sync_phase1_xbrl_failure_isolated() -> None:
     facts_mock.assert_called_once()
     audit_mock.assert_called_once_with(audit_conn)
     review_mock.assert_called_once_with(review_conn)
+
+
+def test_fundamentals_sync_phase1b_runs_when_dedupe_enabled() -> None:
+    """Phase 1b (SEC fundamentals snapshot refresh under #414) fires
+    between phase 1 (financial facts) and phase 2 (audit) when the
+    operator flips ``enable_sec_fundamentals_dedupe=True``.
+
+    The happy path pulls CIK-mapped tradable instruments, opens a
+    SecFundamentalsProvider, and calls
+    ``refresh_fundamentals(sec_fund, conn, symbols)``. Phase 1b is
+    isolated from phase 2/3 — a snapshot failure must not block the
+    audit.
+    """
+    from app.services.fundamentals import FundamentalsRefreshSummary
+
+    summary = AuditSummary(
+        analysable=0,
+        insufficient=0,
+        fpi=0,
+        no_primary_sec_cik=0,
+        total_updated=0,
+        null_anomalies=0,
+    )
+    review = _stub_review_result()
+
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test-agent@example.com"
+    stub_settings.enable_sec_fundamentals_dedupe = True
+
+    tracker = MagicMock()
+
+    # Four connect() contexts: phase 1b cik query, phase 1b snapshot
+    # refresh, phase 2 audit, phase 3 review.
+    cik_conn = MagicMock()
+    cik_conn.execute.return_value.fetchall.return_value = [
+        ("AAPL", "1", "0000320193"),
+        ("MSFT", "2", "0000789019"),
+    ]
+    snapshot_conn = MagicMock()
+    audit_conn = MagicMock()
+    audit_conn.execute.return_value.fetchall.return_value = []
+    review_conn = MagicMock()
+
+    def _ctx(c: MagicMock) -> MagicMock:
+        cm = MagicMock()
+        cm.__enter__.return_value = c
+        cm.__exit__.return_value = None
+        return cm
+
+    refresh_summary = FundamentalsRefreshSummary(symbols_attempted=2, snapshots_upserted=2, symbols_skipped=0)
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job") as tracked_cm,
+        patch.object(scheduler, "psycopg") as psycopg_mod,
+        patch.object(scheduler, "SecFilingsProvider") as filings_cls,
+        patch.object(scheduler, "SecFundamentalsProvider") as fund_cls,
+        patch.object(scheduler, "refresh_fundamentals", return_value=refresh_summary) as refresh_mock,
+        patch.object(scheduler, "review_coverage", return_value=review),
+        patch.object(scheduler, "daily_cik_refresh"),
+        patch.object(scheduler, "daily_financial_facts"),
+        patch(
+            "app.services.coverage.audit_all_instruments",
+            return_value=summary,
+        ),
+    ):
+        tracked_cm.return_value.__enter__.return_value = tracker
+        psycopg_mod.connect.side_effect = [
+            _ctx(MagicMock()),  # ingest gate
+            _ctx(cik_conn),
+            _ctx(snapshot_conn),
+            _ctx(audit_conn),
+            _ctx(review_conn),
+        ]
+        filings_cls.return_value.__enter__.return_value = MagicMock()
+        fund_cls.return_value.__enter__.return_value = MagicMock()
+
+        scheduler.fundamentals_sync()
+
+    refresh_mock.assert_called_once()
+    args, _ = refresh_mock.call_args
+    assert args[1] is snapshot_conn
+    assert args[2] == [("AAPL", "1"), ("MSFT", "2")]
+
+
+def test_fundamentals_sync_short_circuits_when_ingest_disabled() -> None:
+    """Operator pause (#414 design goal F). When
+    ``layer_enabled[fundamentals_ingest]=False`` the whole job short-
+    circuits before ``_tracked_job`` opens — no CIK refresh, no XBRL
+    fetch, no audit/review — and ``record_job_skip`` writes a
+    ``status='skipped'`` ``job_runs`` row so the admin UI can
+    distinguish the operator-initiated pause from a zero-row success.
+    """
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test-agent@example.com"
+    stub_settings.enable_sec_fundamentals_dedupe = False
+
+    gate_conn = MagicMock()
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job") as tracked_cm,
+        patch.object(scheduler, "psycopg") as psycopg_mod,
+        patch.object(scheduler, "daily_cik_refresh") as cik_mock,
+        patch.object(scheduler, "daily_financial_facts") as facts_mock,
+        patch.object(scheduler, "review_coverage") as review_mock,
+        patch.object(scheduler, "record_job_skip") as skip_mock,
+        patch("app.services.layer_enabled.is_layer_enabled", return_value=False) as gate_mock,
+    ):
+        cm = MagicMock()
+        cm.__enter__.return_value = gate_conn
+        cm.__exit__.return_value = None
+        psycopg_mod.connect.side_effect = [cm]
+
+        scheduler.fundamentals_sync()
+
+    # Gate queried once on the autocommit connection; tracked_job never
+    # opened (pause is surfaced as 'skipped', not zero-row success).
+    gate_mock.assert_called_once_with(gate_conn, "fundamentals_ingest")
+    tracked_cm.assert_not_called()
+    skip_mock.assert_called_once()
+    skip_args = skip_mock.call_args
+    assert skip_args.args[0] is gate_conn
+    assert skip_args.args[1] == "fundamentals_sync"
+    assert "paused by operator" in skip_args.args[2]
+    cik_mock.assert_not_called()
+    facts_mock.assert_not_called()
+    review_mock.assert_not_called()
+    # Connection opened with autocommit=True so record_job_skip's
+    # explicit transaction block issues a real BEGIN/COMMIT.
+    _, kwargs = psycopg_mod.connect.call_args
+    assert kwargs.get("autocommit") is True
+
+
+def test_fundamentals_sync_gate_read_failure_falls_open() -> None:
+    """Fail-open posture on gate-read failures. If
+    ``psycopg.connect`` or ``is_layer_enabled`` raises (DB unavailable,
+    ``layer_enabled`` table missing on first boot) we MUST fall through
+    to ``_tracked_job`` so the run still writes a job_runs row — either
+    the body succeeds or a real failure lands. Silently vanishing
+    would regress the runtime's prerequisite-check posture.
+    """
+    summary = AuditSummary(
+        analysable=0,
+        insufficient=0,
+        fpi=0,
+        no_primary_sec_cik=0,
+        total_updated=0,
+        null_anomalies=0,
+    )
+    review = _stub_review_result()
+
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test-agent@example.com"
+    stub_settings.enable_sec_fundamentals_dedupe = False
+
+    tracker = MagicMock()
+
+    audit_conn = MagicMock()
+    audit_conn.execute.return_value.fetchall.return_value = []
+    review_conn = MagicMock()
+
+    def _ctx(c: MagicMock) -> MagicMock:
+        cm = MagicMock()
+        cm.__enter__.return_value = c
+        cm.__exit__.return_value = None
+        return cm
+
+    # First connect() (the gate) raises — every subsequent connect() returns
+    # a usable context so the body runs normally.
+    connect_calls: list[object] = []
+
+    def _connect(*args: object, **kwargs: object) -> MagicMock:
+        connect_calls.append((args, kwargs))
+        if len(connect_calls) == 1:
+            raise psycopg.OperationalError("gate db unreachable")
+        return _ctx(audit_conn) if len(connect_calls) == 2 else _ctx(review_conn)
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job") as tracked_cm,
+        patch.object(scheduler, "psycopg") as psycopg_mod,
+        patch.object(scheduler, "SecFilingsProvider") as filings_cls,
+        patch.object(scheduler, "review_coverage", return_value=review) as review_mock,
+        patch.object(scheduler, "record_job_skip") as skip_mock,
+        patch.object(scheduler, "daily_cik_refresh") as cik_mock,
+        patch.object(scheduler, "daily_financial_facts") as facts_mock,
+        patch(
+            "app.services.coverage.audit_all_instruments",
+            return_value=summary,
+        ) as audit_mock,
+    ):
+        tracked_cm.return_value.__enter__.return_value = tracker
+        psycopg_mod.connect.side_effect = _connect
+        filings_cls.return_value.__enter__.return_value = MagicMock()
+
+        scheduler.fundamentals_sync()
+
+    # Gate raised -> body ran: record_job_skip NOT called, tracked_job
+    # opened, audit + review both fired.
+    skip_mock.assert_not_called()
+    tracked_cm.assert_called_once()
+    cik_mock.assert_called_once()
+    facts_mock.assert_called_once()
+    audit_mock.assert_called_once_with(audit_conn)
+    review_mock.assert_called_once_with(review_conn)
+
+
+def test_fundamentals_sync_phase1b_query_filters_primary_cik() -> None:
+    """Phase 1b CIK query must restrict to ``ei.is_primary = TRUE`` so
+    a symbol with a demoted historical SEC CIK row cannot appear twice
+    and non-deterministically pick the wrong CIK via dict-overwrite.
+    Matches the phase-2 audit query's filter, and is critical now that
+    phase 1b is the sole SEC companyfacts writer when the dedupe flag
+    is flipped on."""
+    summary = AuditSummary(
+        analysable=0,
+        insufficient=0,
+        fpi=0,
+        no_primary_sec_cik=0,
+        total_updated=0,
+        null_anomalies=0,
+    )
+    review = _stub_review_result()
+
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test-agent@example.com"
+    stub_settings.enable_sec_fundamentals_dedupe = True
+
+    tracker = MagicMock()
+
+    cik_cursor = MagicMock()
+    cik_cursor.fetchall.return_value = []
+    cik_conn = MagicMock()
+    cik_conn.execute.return_value = cik_cursor
+    audit_conn = MagicMock()
+    audit_conn.execute.return_value.fetchall.return_value = []
+    review_conn = MagicMock()
+
+    def _ctx(c: MagicMock) -> MagicMock:
+        cm = MagicMock()
+        cm.__enter__.return_value = c
+        cm.__exit__.return_value = None
+        return cm
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job") as tracked_cm,
+        patch.object(scheduler, "psycopg") as psycopg_mod,
+        patch.object(scheduler, "SecFilingsProvider") as filings_cls,
+        patch.object(scheduler, "review_coverage", return_value=review),
+        patch.object(scheduler, "daily_cik_refresh"),
+        patch.object(scheduler, "daily_financial_facts"),
+        patch(
+            "app.services.coverage.audit_all_instruments",
+            return_value=summary,
+        ),
+    ):
+        tracked_cm.return_value.__enter__.return_value = tracker
+        psycopg_mod.connect.side_effect = [
+            _ctx(MagicMock()),  # ingest gate
+            _ctx(cik_conn),
+            _ctx(audit_conn),
+            _ctx(review_conn),
+        ]
+        filings_cls.return_value.__enter__.return_value = MagicMock()
+
+        scheduler.fundamentals_sync()
+
+    # Assert phase 1b SQL restricts to is_primary = TRUE.
+    query = cik_conn.execute.call_args.args[0]
+    normalised = " ".join(query.split()).lower()
+    assert "ei.is_primary = true" in normalised
+    assert "ei.identifier_type = 'cik'" in normalised
+
+
+def test_fundamentals_sync_phase1b_row_count_contributes_to_tracker() -> None:
+    """Row-count contract: once the dedupe flag flips, phase 1b
+    snapshots are the bulk write path. ``tracker.row_count`` must
+    include the snapshots_upserted count so a successful snapshot-only
+    run (no audit/review changes) does not report as zero-row work.
+    """
+    from app.services.fundamentals import FundamentalsRefreshSummary
+
+    summary = AuditSummary(
+        analysable=0,
+        insufficient=0,
+        fpi=0,
+        no_primary_sec_cik=0,
+        total_updated=0,
+        null_anomalies=0,
+    )
+    review = _stub_review_result()
+
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test-agent@example.com"
+    stub_settings.enable_sec_fundamentals_dedupe = True
+
+    tracker = MagicMock()
+    tracker.row_count = None
+
+    cik_conn = MagicMock()
+    cik_conn.execute.return_value.fetchall.return_value = [
+        ("AAPL", "1", "0000320193"),
+    ]
+    snapshot_conn = MagicMock()
+    audit_conn = MagicMock()
+    audit_conn.execute.return_value.fetchall.return_value = []
+    review_conn = MagicMock()
+
+    def _ctx(c: MagicMock) -> MagicMock:
+        cm = MagicMock()
+        cm.__enter__.return_value = c
+        cm.__exit__.return_value = None
+        return cm
+
+    refresh_summary = FundamentalsRefreshSummary(symbols_attempted=1, snapshots_upserted=37, symbols_skipped=0)
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job") as tracked_cm,
+        patch.object(scheduler, "psycopg") as psycopg_mod,
+        patch.object(scheduler, "SecFilingsProvider") as filings_cls,
+        patch.object(scheduler, "SecFundamentalsProvider") as fund_cls,
+        patch.object(scheduler, "refresh_fundamentals", return_value=refresh_summary),
+        patch.object(scheduler, "review_coverage", return_value=review),
+        patch.object(scheduler, "daily_cik_refresh"),
+        patch.object(scheduler, "daily_financial_facts"),
+        patch(
+            "app.services.coverage.audit_all_instruments",
+            return_value=summary,
+        ),
+    ):
+        tracked_cm.return_value.__enter__.return_value = tracker
+        psycopg_mod.connect.side_effect = [
+            _ctx(MagicMock()),  # ingest gate
+            _ctx(cik_conn),
+            _ctx(snapshot_conn),
+            _ctx(audit_conn),
+            _ctx(review_conn),
+        ]
+        filings_cls.return_value.__enter__.return_value = MagicMock()
+        fund_cls.return_value.__enter__.return_value = MagicMock()
+
+        scheduler.fundamentals_sync()
+
+    # audit.total_updated (0) + review (0) + phase1b snapshots (37).
+    assert tracker.row_count == 37
+
+
+def test_fundamentals_sync_phase1b_failure_surfaces_at_end() -> None:
+    """Phase 1b snapshot refresh is isolated from phase 2/3 — a
+    transient failure must not block the audit or review, but must
+    still surface as a job-level failure at the end so health dashboards
+    see the outage. Mirrors the phase 0/1 isolation-with-surfacing
+    contract."""
+    from app.services.fundamentals import FundamentalsRefreshSummary  # noqa: F401
+
+    summary = AuditSummary(
+        analysable=0,
+        insufficient=0,
+        fpi=0,
+        no_primary_sec_cik=0,
+        total_updated=0,
+        null_anomalies=0,
+    )
+    review = _stub_review_result()
+
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test-agent@example.com"
+    stub_settings.enable_sec_fundamentals_dedupe = True
+
+    tracker = MagicMock()
+
+    cik_conn = MagicMock()
+    cik_conn.execute.return_value.fetchall.return_value = [("AAPL", "1", "0000320193")]
+    audit_conn = MagicMock()
+    audit_conn.execute.return_value.fetchall.return_value = []
+    review_conn = MagicMock()
+
+    def _ctx(c: MagicMock) -> MagicMock:
+        cm = MagicMock()
+        cm.__enter__.return_value = c
+        cm.__exit__.return_value = None
+        return cm
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job") as tracked_cm,
+        patch.object(scheduler, "psycopg") as psycopg_mod,
+        patch.object(scheduler, "SecFilingsProvider") as filings_cls,
+        patch.object(scheduler, "SecFundamentalsProvider") as fund_cls,
+        patch.object(
+            scheduler,
+            "refresh_fundamentals",
+            side_effect=RuntimeError("sec companyfacts 502"),
+        ),
+        patch.object(scheduler, "review_coverage", return_value=review) as review_mock,
+        patch.object(scheduler, "daily_cik_refresh"),
+        patch.object(scheduler, "daily_financial_facts"),
+        patch(
+            "app.services.coverage.audit_all_instruments",
+            return_value=summary,
+        ) as audit_mock,
+    ):
+        tracked_cm.return_value.__enter__.return_value = tracker
+        psycopg_mod.connect.side_effect = [
+            _ctx(MagicMock()),  # ingest gate
+            _ctx(cik_conn),
+            _ctx(MagicMock()),  # phase 1b snapshot conn (refresh raises)
+            _ctx(audit_conn),
+            _ctx(review_conn),
+        ]
+        filings_cls.return_value.__enter__.return_value = MagicMock()
+        fund_cls.return_value.__enter__.return_value = MagicMock()
+
+        with pytest.raises(RuntimeError, match="phase 1b"):
+            scheduler.fundamentals_sync()
+
+    # Phase 2/3 still ran despite the phase-1b failure.
+    audit_mock.assert_called_once_with(audit_conn)
+    review_mock.assert_called_once_with(review_conn)
+
+
+def test_fundamentals_sync_phase1b_skipped_when_dedupe_disabled() -> None:
+    """When ``enable_sec_fundamentals_dedupe=False`` (default), phase 1b
+    must not run — ``daily_research_refresh`` still owns the SEC
+    snapshot path until the operator flips the flag."""
+    summary = AuditSummary(
+        analysable=0,
+        insufficient=0,
+        fpi=0,
+        no_primary_sec_cik=0,
+        total_updated=0,
+        null_anomalies=0,
+    )
+    review = _stub_review_result()
+
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test-agent@example.com"
+    stub_settings.enable_sec_fundamentals_dedupe = False
+
+    tracker = MagicMock()
+
+    audit_conn = MagicMock()
+    audit_conn.execute.return_value.fetchall.return_value = []
+    review_conn = MagicMock()
+
+    with (
+        patch.object(scheduler, "settings", stub_settings),
+        patch.object(scheduler, "_tracked_job") as tracked_cm,
+        patch.object(scheduler, "psycopg") as psycopg_mod,
+        patch.object(scheduler, "SecFilingsProvider") as filings_cls,
+        patch.object(scheduler, "SecFundamentalsProvider") as fund_cls,
+        patch.object(scheduler, "refresh_fundamentals") as refresh_mock,
+        patch.object(scheduler, "review_coverage", return_value=review),
+        patch.object(scheduler, "daily_cik_refresh"),
+        patch.object(scheduler, "daily_financial_facts"),
+        patch(
+            "app.services.coverage.audit_all_instruments",
+            return_value=summary,
+        ),
+    ):
+        tracked_cm.return_value.__enter__.return_value = tracker
+        _stub_two_connect_ctxes(psycopg_mod, audit_conn, review_conn)
+        filings_cls.return_value.__enter__.return_value = MagicMock()
+
+        scheduler.fundamentals_sync()
+
+    refresh_mock.assert_not_called()
+    fund_cls.assert_not_called()

--- a/tests/test_workers_scheduler_registry.py
+++ b/tests/test_workers_scheduler_registry.py
@@ -107,6 +107,27 @@ class TestOrchestratorTriggers:
         assert "daily_candle_refresh" not in names
 
 
+class TestFundamentalsSyncCadence:
+    """fundamentals_sync cadence moved weekly→daily 02:30 UTC under #414.
+
+    SEC publishes the nightly XBRL update around 22:00 ET (02:00 UTC).
+    The previous Monday 05:00 UTC window missed the natural incremental
+    and amplified seed lag (a missed Monday meant week-long staleness).
+    Daily 02:30 UTC lands ~30 min after the publish window so new
+    filings ingest the same night.
+    """
+
+    def test_fundamentals_sync_is_daily_02_30(self) -> None:
+        job = next(j for j in SCHEDULED_JOBS if j.name == "fundamentals_sync")
+        assert job.cadence.kind == "daily"
+        assert job.cadence.hour == 2
+        assert job.cadence.minute == 30
+
+    def test_fundamentals_sync_does_not_catch_up_on_boot(self) -> None:
+        job = next(j for j in SCHEDULED_JOBS if j.name == "fundamentals_sync")
+        assert job.catch_up_on_boot is False
+
+
 # ---------------------------------------------------------------------------
 # Cadence validators
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Three backend changes for the #414 fundamentals ingest redesign:

1. `fundamentals_sync` cadence weekly Mon 05:00 UTC → daily 02:30 UTC.
2. `enable_sec_fundamentals_dedupe` flag (default False) collapses the dual SEC companyfacts fetch path — `daily_research_refresh` skips its SEC XBRL block, `fundamentals_sync` owns a new phase 1b that refreshes `fundamentals_snapshot` for primary CIK-mapped tradables.
3. Operator pause via `layer_enabled[fundamentals_ingest]` — writes `status='skipped'` row via `record_job_skip` before `_tracked_job`. Fail-open on gate read errors. New endpoint `POST /sync/ingest/{key}/enabled`.

## Why
- Daily cadence lands ~30 min after SEC's nightly XBRL publish (~02:00 UTC) — catches filings same night instead of up to seven days later.
- Dual-path SEC companyfacts fetches (fundamentals_sync + daily_research_refresh) double-hit SEC per covered CIK; flag collapses to one.
- No runtime mechanism existed to pause ingest during a demo or when SEC rate-limits us without restarting the server.

## Test plan
- [x] `uv run pytest` — 2366 passed, 1 skipped
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pyright` — clean
- [x] Codex second-opinion review (two rounds) — silent-drift + fail-closed findings addressed:
  - Pause path surfaces as `status='skipped'` not zero-row success.
  - Phase 1b snapshot rows flow into `tracker.row_count`.
  - Gate read failure falls open so runs still produce a `job_runs` row.
  - Phase 1b query filters `ei.is_primary = TRUE` matching phase 2.

## Scope boundary
Per-source toggles (`sec_edgar_enabled`, `sec_master_index_enabled`) and `max_unseeded_ciks_per_run` cap listed in #414 are deferred to a follow-up tech-debt ticket so this PR stays reviewable. Admin UI surfacing of seed progress + per-CIK timing (#418) is a separate branch.

## Settled decisions + prevention log
- Matches the existing feature-flag precedent (`enable_filings_fetch_dedupe`): default off, operator flips on, follow-up PR deletes guarded block.
- Pause pattern mirrors `_write_prereq_skip_row` — skip written on autocommit connection BEFORE `_tracked_job` opens to avoid duplicate rows.
- No settled decision affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)