### PR TITLE
feat(#418): per-CIK timing persistence + seed-progress admin API

### DIFF
--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -21,6 +21,10 @@ from pydantic import BaseModel
 from app.api.auth import require_session_or_service_token
 from app.config import settings
 from app.db import get_conn
+from app.services.fundamentals_observability import (
+    get_cik_timing_summary,
+    get_seed_progress,
+)
 from app.services.layer_enabled import set_layer_enabled
 from app.services.sync_orchestrator import (
     ExecutionPlan,
@@ -555,6 +559,146 @@ def post_ingest_enabled(
         key=key,
         display_name=INGEST_TOGGLES[key],
         is_enabled=body.enabled,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SEC ingest observability (#414 design goal G, #418)
+# ---------------------------------------------------------------------------
+
+
+class CikTimingModeModel(BaseModel):
+    mode: Literal["seed", "refresh"]
+    count: int
+    p50_seconds: float | None
+    p95_seconds: float | None
+    max_seconds: float | None
+    facts_upserted_total: int
+
+
+class SlowCikModel(BaseModel):
+    cik: str
+    mode: Literal["seed", "refresh"]
+    seconds: float
+    facts_upserted: int
+    outcome: str
+    finished_at: datetime
+
+
+class CikTimingSummaryResponse(BaseModel):
+    ingestion_run_id: int | None
+    run_source: str | None
+    run_started_at: datetime | None
+    run_finished_at: datetime | None
+    run_status: str | None
+    modes: list[CikTimingModeModel]
+    slowest: list[SlowCikModel]
+
+
+@router.get("/ingest/cik_timing/latest", response_model=CikTimingSummaryResponse)
+def get_cik_timing_latest(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> CikTimingSummaryResponse:
+    """Return p50/p95 per-CIK timing for the most recent SEC XBRL
+    ingest run (#418 acceptance: validate ADR 0004 Shape-B bench
+    ratios against production without tailing logs).
+
+    If no timing rows exist yet (pre-#418 deploy or empty table), every
+    field except an empty-list ``modes``/``slowest`` is null — the UI
+    renders "no data yet" rather than a 500.
+    """
+    summary = get_cik_timing_summary(conn)
+    return CikTimingSummaryResponse(
+        ingestion_run_id=summary.ingestion_run_id,
+        run_source=summary.run_source,
+        run_started_at=summary.run_started_at,
+        run_finished_at=summary.run_finished_at,
+        run_status=summary.run_status,
+        modes=[
+            CikTimingModeModel(
+                mode=m.mode,
+                count=m.count,
+                p50_seconds=m.p50_seconds,
+                p95_seconds=m.p95_seconds,
+                max_seconds=m.max_seconds,
+                facts_upserted_total=m.facts_upserted_total,
+            )
+            for m in summary.modes
+        ],
+        slowest=[
+            SlowCikModel(
+                cik=s.cik,
+                mode=s.mode,
+                seconds=s.seconds,
+                facts_upserted=s.facts_upserted,
+                outcome=s.outcome,
+                finished_at=s.finished_at,
+            )
+            for s in summary.slowest
+        ],
+    )
+
+
+class SeedSourceModel(BaseModel):
+    source: str
+    key_description: str
+    seeded: int
+    total: int
+
+
+class LatestIngestionRunModel(BaseModel):
+    ingestion_run_id: int
+    source: str
+    started_at: datetime
+    finished_at: datetime | None
+    status: str
+    rows_upserted: int
+    rows_skipped: int
+
+
+class SeedProgressResponse(BaseModel):
+    sources: list[SeedSourceModel]
+    latest_run: LatestIngestionRunModel | None
+    ingest_paused: bool
+
+
+@router.get("/ingest/seed_progress", response_model=SeedProgressResponse)
+def get_seed_progress_endpoint(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> SeedProgressResponse:
+    """Return seed progress ratios + latest-run state + pause flag for
+    the admin UI (#414 design goal G).
+
+    ``sources[].total`` is the count of CIK-mapped tradable
+    instruments; ``seeded`` is the number of that set with a committed
+    watermark. Ratio is the operator's "N of 5,134" seed-progress
+    number.
+    """
+    summary = get_seed_progress(conn)
+    return SeedProgressResponse(
+        sources=[
+            SeedSourceModel(
+                source=s.source,
+                key_description=s.key_description,
+                seeded=s.seeded,
+                total=s.total,
+            )
+            for s in summary.sources
+        ],
+        latest_run=(
+            LatestIngestionRunModel(
+                ingestion_run_id=summary.latest_run.ingestion_run_id,
+                source=summary.latest_run.source,
+                started_at=summary.latest_run.started_at,
+                finished_at=summary.latest_run.finished_at,
+                status=summary.latest_run.status,
+                rows_upserted=summary.latest_run.rows_upserted,
+                rows_skipped=summary.latest_run.rows_skipped,
+            )
+            if summary.latest_run is not None
+            else None
+        ),
+        ingest_paused=summary.ingest_paused,
     )
 
 

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -1818,15 +1818,101 @@ def _run_cik_upsert(
         # production ratios can be validated against the ADR 0004 bench
         # (Shape B was ~18x faster on the DB-path bench). Emits on
         # every exit path (success, skip, exception). Log keys are
-        # machine-parseable; the full "alert on regression" surface
-        # ships with #418's observability work.
+        # machine-parseable so grep-based alerting still works even if
+        # the persist path below fails.
+        finished_ts = time.perf_counter()
+        elapsed = finished_ts - started
         logger.info(
             "fundamentals.cik_timing cik=%s mode=%s outcome=%s facts_upserted=%d seconds=%.3f",
             cik,
             mode,
             outcome,
             facts_upserted,
-            time.perf_counter() - started,
+            elapsed,
+        )
+        # Persist the timing row (#418 acceptance: p50/p95 per-CIK
+        # timing surfaced in the admin UI without tailing logs). Writes
+        # on the caller's connection inside its own transaction block;
+        # by this point both the exception path and the success path
+        # have called commit/rollback, so the connection is in a clean
+        # state. Skip-path exits (no run body) pass ``run_id=None``
+        # into a NULL FK; the DDL allows NULL + ON DELETE SET NULL for
+        # safe ``data_ingestion_runs`` pruning.
+        try:
+            # Close any outstanding implicit read transaction (e.g.
+            # the one opened by ``_instrument_for_cik`` on the
+            # skip-path early returns) so ``conn.transaction()`` in
+            # ``persist_cik_timing`` opens a real BEGIN/COMMIT pair
+            # rather than nesting a savepoint that the caller's
+            # later ``conn.rollback()`` would drop. Safe — by this
+            # point the per-CIK success/error branches have already
+            # committed or rolled back their own work, and a
+            # rollback on a clean session is a no-op.
+            try:
+                conn.rollback()
+            except psycopg.Error:
+                logger.debug("pre-timing rollback suppressed", exc_info=True)
+            persist_cik_timing(
+                conn,
+                cik=cik,
+                ingestion_run_id=run_id,
+                mode=mode,
+                outcome=outcome,
+                facts_upserted=facts_upserted,
+                seconds=elapsed,
+                started_at=_utc_from_perf(started),
+                finished_at=_utc_from_perf(finished_ts),
+            )
+        except Exception:
+            logger.warning("fundamentals.cik_timing persist failed", exc_info=True)
+
+
+def _utc_from_perf(perf: float) -> datetime:
+    """Convert ``time.perf_counter`` timestamp to a wall-clock UTC
+    datetime by anchoring on ``datetime.now(tz=UTC)`` minus the
+    perf-counter delta. Used only for the cik_upsert_timing audit row
+    — elapsed seconds remain the source of truth for duration.
+    """
+    return datetime.now(tz=UTC) - timedelta(seconds=time.perf_counter() - perf)
+
+
+def persist_cik_timing(
+    conn: psycopg.Connection[tuple],
+    *,
+    cik: str,
+    ingestion_run_id: int | None,
+    mode: str,
+    outcome: str,
+    facts_upserted: int,
+    seconds: float,
+    started_at: datetime,
+    finished_at: datetime,
+) -> None:
+    """Insert one ``cik_upsert_timing`` row on the caller-supplied
+    connection. Uses its own transaction block so the write commits
+    independently of whatever the surrounding logic does next.
+    """
+    with conn.transaction():
+        conn.execute(
+            """
+            INSERT INTO cik_upsert_timing (
+                ingestion_run_id, cik, mode, outcome,
+                facts_upserted, seconds, started_at, finished_at
+            ) VALUES (
+                %(run_id)s, %(cik)s, %(mode)s, %(outcome)s,
+                %(facts)s, %(seconds)s, %(started)s, %(finished)s
+            )
+            """,
+            {
+                "run_id": ingestion_run_id,
+                "cik": cik,
+                "mode": mode,
+                "outcome": outcome,
+                "facts": facts_upserted,
+                "seconds": round(seconds, 3),
+                "started": started_at,
+                "finished": finished_at,
+            },
         )
 
 

--- a/app/services/fundamentals_observability.py
+++ b/app/services/fundamentals_observability.py
@@ -1,0 +1,298 @@
+"""Admin-UI observability helpers for the SEC fundamentals ingest
+pipeline (#414, #418).
+
+Two surfaces:
+
+- ``get_cik_timing_summary(conn)`` — p50/p95/count per mode
+  (seed/refresh) for the most recent ingestion run, plus the top-5
+  slowest CIKs. Answers "did the ADR 0004 Shape-B bench ratios hold
+  in prod?" without tailing logs.
+- ``get_seed_progress(conn)`` — submissions/master-index seed ratios
+  (N of M CIKs watermarked), latest run state, operator pause flag.
+  Answers "how far through the seed are we, ETA, and is ingest paused?"
+
+Both are read-only helpers that accept an externally-managed
+connection so the caller (the HTTP handler) controls transaction
+boundaries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal
+
+import psycopg
+
+TimingMode = Literal["seed", "refresh"]
+
+
+@dataclass(frozen=True)
+class CikTimingPercentiles:
+    mode: TimingMode
+    count: int
+    p50_seconds: float | None
+    p95_seconds: float | None
+    max_seconds: float | None
+    facts_upserted_total: int
+
+
+@dataclass(frozen=True)
+class SlowCikEntry:
+    cik: str
+    mode: TimingMode
+    seconds: float
+    facts_upserted: int
+    outcome: str
+    finished_at: datetime
+
+
+@dataclass(frozen=True)
+class CikTimingSummary:
+    ingestion_run_id: int | None
+    run_source: str | None
+    run_started_at: datetime | None
+    run_finished_at: datetime | None
+    run_status: str | None
+    modes: list[CikTimingPercentiles]
+    slowest: list[SlowCikEntry]
+
+
+def get_cik_timing_summary(conn: psycopg.Connection[Any]) -> CikTimingSummary:
+    """Return timing percentiles for the most recent ingestion run.
+
+    If no timing rows exist yet (pre-#418 deploy or empty table),
+    returns an empty summary with ``ingestion_run_id=None`` — the
+    caller renders "no data yet" rather than a 500.
+    """
+    latest = conn.execute(
+        """
+        SELECT ingestion_run_id
+        FROM cik_upsert_timing
+        WHERE ingestion_run_id IS NOT NULL
+        ORDER BY ingestion_run_id DESC
+        LIMIT 1
+        """
+    ).fetchone()
+
+    if latest is None:
+        return CikTimingSummary(
+            ingestion_run_id=None,
+            run_source=None,
+            run_started_at=None,
+            run_finished_at=None,
+            run_status=None,
+            modes=[],
+            slowest=[],
+        )
+
+    run_id = int(latest[0])
+
+    run_row = conn.execute(
+        """
+        SELECT source, started_at, finished_at, status
+        FROM data_ingestion_runs
+        WHERE ingestion_run_id = %s
+        """,
+        (run_id,),
+    ).fetchone()
+
+    # percentile_cont returns DOUBLE PRECISION; cast the NUMERIC(10,3)
+    # ``seconds`` column to float on the Python side so the JSON
+    # response is a plain number, not a Decimal.
+    rows = conn.execute(
+        """
+        SELECT mode,
+               COUNT(*)                                                AS n,
+               percentile_cont(0.5)  WITHIN GROUP (ORDER BY seconds)   AS p50,
+               percentile_cont(0.95) WITHIN GROUP (ORDER BY seconds)   AS p95,
+               MAX(seconds)                                            AS mx,
+               SUM(facts_upserted)                                     AS total_facts
+        FROM cik_upsert_timing
+        WHERE ingestion_run_id = %s
+        GROUP BY mode
+        ORDER BY mode
+        """,
+        (run_id,),
+    ).fetchall()
+
+    modes: list[CikTimingPercentiles] = []
+    for r in rows:
+        mode_str = str(r[0])
+        if mode_str not in ("seed", "refresh"):
+            continue
+        modes.append(
+            CikTimingPercentiles(
+                mode=mode_str,  # type: ignore[arg-type]
+                count=int(r[1]),
+                p50_seconds=float(r[2]) if r[2] is not None else None,
+                p95_seconds=float(r[3]) if r[3] is not None else None,
+                max_seconds=float(r[4]) if r[4] is not None else None,
+                facts_upserted_total=int(r[5] or 0),
+            )
+        )
+
+    slow_rows = conn.execute(
+        """
+        SELECT cik, mode, seconds, facts_upserted, outcome, finished_at
+        FROM cik_upsert_timing
+        WHERE ingestion_run_id = %s
+        ORDER BY seconds DESC
+        LIMIT 5
+        """,
+        (run_id,),
+    ).fetchall()
+
+    slowest: list[SlowCikEntry] = []
+    for r in slow_rows:
+        mode_str = str(r[1])
+        if mode_str not in ("seed", "refresh"):
+            continue
+        slowest.append(
+            SlowCikEntry(
+                cik=str(r[0]),
+                mode=mode_str,  # type: ignore[arg-type]
+                seconds=float(r[2]),
+                facts_upserted=int(r[3]),
+                outcome=str(r[4]),
+                finished_at=r[5],
+            )
+        )
+
+    return CikTimingSummary(
+        ingestion_run_id=run_id,
+        run_source=str(run_row[0]) if run_row else None,
+        run_started_at=run_row[1] if run_row else None,
+        run_finished_at=run_row[2] if run_row else None,
+        run_status=str(run_row[3]) if run_row else None,
+        modes=modes,
+        slowest=slowest,
+    )
+
+
+@dataclass(frozen=True)
+class SeedSourceProgress:
+    source: str
+    key_description: str
+    seeded: int
+    total: int
+
+
+@dataclass(frozen=True)
+class LatestIngestionRun:
+    ingestion_run_id: int
+    source: str
+    started_at: datetime
+    finished_at: datetime | None
+    status: str
+    rows_upserted: int
+    rows_skipped: int
+
+
+@dataclass(frozen=True)
+class SeedProgressSummary:
+    sources: list[SeedSourceProgress]
+    latest_run: LatestIngestionRun | None
+    ingest_paused: bool
+
+
+# Bound the total-CIK count to the universe of tradable instruments
+# that have a primary SEC CIK mapping. Matches the phase-2/phase-1b
+# audit query so the denominator cannot silently drift between the
+# scheduler and the admin UI.
+_TOTAL_CIKS_SQL = """
+    SELECT COUNT(*)
+    FROM instruments i
+    JOIN external_identifiers ei
+        ON ei.instrument_id = i.instrument_id
+       AND ei.provider = 'sec'
+       AND ei.identifier_type = 'cik'
+       AND ei.is_primary = TRUE
+    WHERE i.is_tradable = TRUE
+"""
+
+
+def get_seed_progress(conn: psycopg.Connection[Any]) -> SeedProgressSummary:
+    """Return seed progress ratios + latest run state + pause flag.
+
+    ``total`` is the count of CIK-mapped tradable instruments. A
+    per-source watermark exists once that CIK has been successfully
+    ingested, so ``seeded / total`` is the literal seed-progress
+    ratio the operator expects.
+    """
+    total_row = conn.execute(_TOTAL_CIKS_SQL).fetchone()
+    total = int(total_row[0]) if total_row is not None else 0
+
+    # Two watermark keys drive SEC XBRL ingest: sec.submissions
+    # (per-CIK top-accession) and sec.master-index (per-day crawl).
+    # Only sec.submissions is per-CIK — master-index is per-day, so
+    # reporting it as a seed ratio would be misleading. We surface
+    # sec.submissions as the canonical progress bar.
+    #
+    # ``seeded`` must be scoped to the SAME cohort as ``total``
+    # (primary SEC-mapped tradable instruments). Counting every
+    # sec.submissions watermark would over-report completion when a
+    # previously-seeded CIK falls out of the tradable universe —
+    # worst case, seeded > total and the progress bar exceeds 100%.
+    seeded_row = conn.execute(
+        """
+        SELECT COUNT(*)
+        FROM external_data_watermarks w
+        JOIN external_identifiers ei
+            ON ei.provider = 'sec'
+           AND ei.identifier_type = 'cik'
+           AND ei.is_primary = TRUE
+           AND ei.identifier_value = w.key
+        JOIN instruments i
+            ON i.instrument_id = ei.instrument_id
+           AND i.is_tradable = TRUE
+        WHERE w.source = 'sec.submissions'
+        """
+    ).fetchone()
+    seeded_submissions = int(seeded_row[0]) if seeded_row is not None else 0
+
+    sources = [
+        SeedSourceProgress(
+            source="sec.submissions",
+            key_description="SEC submissions.json (per-CIK top accession)",
+            seeded=seeded_submissions,
+            total=total,
+        ),
+    ]
+
+    latest_row = conn.execute(
+        """
+        SELECT ingestion_run_id, source, started_at, finished_at, status,
+               COALESCE(rows_upserted, 0), COALESCE(rows_skipped, 0)
+        FROM data_ingestion_runs
+        WHERE source = 'sec_edgar'
+        ORDER BY ingestion_run_id DESC
+        LIMIT 1
+        """
+    ).fetchone()
+
+    latest_run: LatestIngestionRun | None = None
+    if latest_row is not None:
+        latest_run = LatestIngestionRun(
+            ingestion_run_id=int(latest_row[0]),
+            source=str(latest_row[1]),
+            started_at=latest_row[2],
+            finished_at=latest_row[3],
+            status=str(latest_row[4]),
+            rows_upserted=int(latest_row[5]),
+            rows_skipped=int(latest_row[6]),
+        )
+
+    # Reuse the existing layer_enabled table — ``fundamentals_ingest``
+    # is the runtime toggle landed in #421. Absent row counts as
+    # enabled; False means the operator paused the scheduled job.
+    paused_row = conn.execute(
+        "SELECT is_enabled FROM layer_enabled WHERE layer_name = 'fundamentals_ingest'"
+    ).fetchone()
+    ingest_paused = paused_row is not None and not bool(paused_row[0])
+
+    return SeedProgressSummary(
+        sources=sources,
+        latest_run=latest_run,
+        ingest_paused=ingest_paused,
+    )

--- a/sql/049_cik_upsert_timing.sql
+++ b/sql/049_cik_upsert_timing.sql
@@ -1,0 +1,43 @@
+-- 049_cik_upsert_timing.sql
+--
+-- Per-CIK transaction timing instrumentation for SEC XBRL ingest
+-- (#418, under the #414 fundamentals ingest redesign).
+--
+-- ADR 0004 (merged in #417) settled on `executemany(page_size=1000)`
+-- for the per-CIK upsert shape. The ADR notes the DB-path bench alone
+-- cannot settle whether residual operator-UI latency during a seed
+-- comes from GIL contention, lock contention, or both. Answering that
+-- in-prod requires per-CIK timing — today `data_ingestion_runs` is per
+-- provider batch (one row per seed/refresh round), so a "CIK X took
+-- 4.7s" signal has to be parsed out of log lines.
+--
+-- This table stores one row per `_run_cik_upsert` invocation.
+-- Populated inside the existing `finally` block in
+-- ``app/services/fundamentals.py`` alongside the
+-- `fundamentals.cik_timing` log emit so the log and the row are always
+-- in sync. Parent ingestion_run_id is NULL for skip-path exits (the
+-- upsert never entered the run body, so the run has no claim on this
+-- row).
+
+CREATE TABLE IF NOT EXISTS cik_upsert_timing (
+    timing_id            BIGSERIAL PRIMARY KEY,
+    ingestion_run_id     BIGINT REFERENCES data_ingestion_runs(ingestion_run_id) ON DELETE SET NULL,
+    cik                  TEXT NOT NULL,
+    mode                 TEXT NOT NULL CHECK (mode IN ('seed', 'refresh')),
+    outcome              TEXT NOT NULL,
+    facts_upserted       INTEGER NOT NULL DEFAULT 0,
+    seconds              NUMERIC(10, 3) NOT NULL,
+    started_at           TIMESTAMPTZ NOT NULL,
+    finished_at          TIMESTAMPTZ NOT NULL
+);
+
+-- Latest-run lookup: GET /sync/ingest/cik_timing/latest returns p50/p95
+-- for every row that shares the newest ingestion_run_id. Index on
+-- (ingestion_run_id DESC, seconds) keeps that query a single index scan.
+CREATE INDEX IF NOT EXISTS cik_upsert_timing_run_desc_idx
+    ON cik_upsert_timing (ingestion_run_id DESC NULLS LAST, seconds);
+
+-- Regression alerting: cross-run comparison ("this CIK is 10x slower
+-- than last seed") joins on cik + ingestion_run_id. Supports both.
+CREATE INDEX IF NOT EXISTS cik_upsert_timing_cik_finished_idx
+    ON cik_upsert_timing (cik, finished_at DESC);

--- a/tests/api/test_sync_ingest_observability_endpoints.py
+++ b/tests/api/test_sync_ingest_observability_endpoints.py
@@ -1,0 +1,152 @@
+"""Tests for /sync/ingest/cik_timing/latest + /sync/ingest/seed_progress.
+
+End-to-end service logic is covered in
+``tests/test_fundamentals_observability.py`` against the isolated
+``ebull_test`` database. These tests verify only the HTTP plumbing —
+response shape, status codes, auth — by stubbing the service
+functions, so they can run against any Postgres (including CI's) and
+cannot touch the dev DB.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.services.fundamentals_observability import (
+    CikTimingPercentiles,
+    CikTimingSummary,
+    LatestIngestionRun,
+    SeedProgressSummary,
+    SeedSourceProgress,
+    SlowCikEntry,
+)
+
+
+@pytest.mark.integration
+def test_cik_timing_latest_empty_returns_null_run_id(clean_client: TestClient) -> None:
+    empty = CikTimingSummary(
+        ingestion_run_id=None,
+        run_source=None,
+        run_started_at=None,
+        run_finished_at=None,
+        run_status=None,
+        modes=[],
+        slowest=[],
+    )
+    with patch("app.api.sync.get_cik_timing_summary", return_value=empty):
+        resp = clean_client.get("/sync/ingest/cik_timing/latest")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ingestion_run_id"] is None
+    assert body["modes"] == []
+    assert body["slowest"] == []
+
+
+@pytest.mark.integration
+def test_cik_timing_latest_returns_populated_summary(clean_client: TestClient) -> None:
+    now = datetime.now(tz=UTC)
+    populated = CikTimingSummary(
+        ingestion_run_id=42,
+        run_source="sec_edgar",
+        run_started_at=now,
+        run_finished_at=now,
+        run_status="success",
+        modes=[
+            CikTimingPercentiles(
+                mode="seed",
+                count=3,
+                p50_seconds=1.5,
+                p95_seconds=4.6,
+                max_seconds=4.8,
+                facts_upserted_total=300,
+            ),
+        ],
+        slowest=[
+            SlowCikEntry(
+                cik="0000000003",
+                mode="seed",
+                seconds=4.8,
+                facts_upserted=100,
+                outcome="success",
+                finished_at=now,
+            ),
+        ],
+    )
+    with patch("app.api.sync.get_cik_timing_summary", return_value=populated):
+        resp = clean_client.get("/sync/ingest/cik_timing/latest")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ingestion_run_id"] == 42
+    assert body["modes"][0]["mode"] == "seed"
+    assert body["modes"][0]["count"] == 3
+    assert body["modes"][0]["p50_seconds"] == pytest.approx(1.5)
+    assert body["slowest"][0]["cik"] == "0000000003"
+
+
+@pytest.mark.integration
+def test_seed_progress_returns_paused_flag(clean_client: TestClient) -> None:
+    now = datetime.now(tz=UTC)
+    summary = SeedProgressSummary(
+        sources=[
+            SeedSourceProgress(
+                source="sec.submissions",
+                key_description="SEC submissions.json",
+                seeded=3_691,
+                total=5_134,
+            ),
+        ],
+        latest_run=LatestIngestionRun(
+            ingestion_run_id=7,
+            source="sec_edgar",
+            started_at=now,
+            finished_at=now,
+            status="success",
+            rows_upserted=10_000,
+            rows_skipped=0,
+        ),
+        ingest_paused=True,
+    )
+    with patch("app.api.sync.get_seed_progress", return_value=summary):
+        resp = clean_client.get("/sync/ingest/seed_progress")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ingest_paused"] is True
+    assert body["sources"][0]["source"] == "sec.submissions"
+    assert body["sources"][0]["seeded"] == 3_691
+    assert body["sources"][0]["total"] == 5_134
+    assert body["latest_run"]["ingestion_run_id"] == 7
+
+
+def test_cik_timing_latest_requires_auth() -> None:
+    from app.api.sync import router as sync_router
+    from app.db import get_conn
+
+    def _mock_conn():  # type: ignore[return]
+        yield MagicMock()
+
+    bare = FastAPI()
+    bare.include_router(sync_router)
+    bare.dependency_overrides[get_conn] = _mock_conn
+    with TestClient(bare) as client:
+        resp = client.get("/sync/ingest/cik_timing/latest")
+    assert resp.status_code in {401, 403}, resp.text
+
+
+def test_seed_progress_requires_auth() -> None:
+    from app.api.sync import router as sync_router
+    from app.db import get_conn
+
+    def _mock_conn():  # type: ignore[return]
+        yield MagicMock()
+
+    bare = FastAPI()
+    bare.include_router(sync_router)
+    bare.dependency_overrides[get_conn] = _mock_conn
+    with TestClient(bare) as client:
+        resp = client.get("/sync/ingest/seed_progress")
+    assert resp.status_code in {401, 403}, resp.text

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -45,8 +45,15 @@ _SQL_DIR = Path(__file__).resolve().parents[2] / "sql"
 # TRUNCATE in dependency order with CASCADE to handle FKs cleanly.
 _PLANNER_TABLES: tuple[str, ...] = (
     "cascade_retry_queue",
+    "cik_upsert_timing",  # #418 per-CIK timing audit (FK → data_ingestion_runs)
     "financial_facts_raw",
     "data_ingestion_runs",
+    # layer_enabled is the home of the #414 fundamentals_ingest pause
+    # flag and is written by several observability/planner tests. Keep
+    # it in the planner truncation set so a failed test cannot leak
+    # a disabled state across the next function-scoped run and
+    # silently make subsequent "not paused" assertions trip.
+    "layer_enabled",
     "external_identifiers",
     "external_data_watermarks",
     "coverage_status_events",  # #397 transition log (child of coverage)

--- a/tests/test_fundamentals_observability.py
+++ b/tests/test_fundamentals_observability.py
@@ -1,0 +1,219 @@
+"""Tests for the SEC fundamentals observability service (#414, #418).
+
+Uses the isolated ``ebull_test`` database via the shared
+``ebull_test_conn`` fixture — destructive writes against the dev DB
+are rejected by ``tests/smoke/test_no_settings_url_in_destructive_paths.py``
+and by the ``_assert_test_db`` backstop in the fixture module.
+``percentile_cont`` is a real Postgres aggregate, so a mocked cursor
+would only test SQL string shape and miss actual execution.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import psycopg
+import pytest
+
+from app.services.fundamentals_observability import (
+    get_cik_timing_summary,
+    get_seed_progress,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _test_db_available(),
+        reason="ebull_test DB unavailable",
+    ),
+]
+
+
+def _insert_run(conn: psycopg.Connection[tuple], *, status: str = "success") -> int:
+    row = conn.execute(
+        """
+        INSERT INTO data_ingestion_runs (source, endpoint, instrument_count, status)
+        VALUES ('sec_edgar', '/api/xbrl/companyfacts', 1, %s)
+        RETURNING ingestion_run_id
+        """,
+        (status,),
+    ).fetchone()
+    assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+def _insert_timing(
+    conn: psycopg.Connection[tuple],
+    *,
+    run_id: int | None,
+    cik: str,
+    mode: str,
+    seconds: float,
+    facts: int = 0,
+    outcome: str = "success",
+) -> None:
+    now = datetime.now(tz=UTC)
+    conn.execute(
+        """
+        INSERT INTO cik_upsert_timing (
+            ingestion_run_id, cik, mode, outcome,
+            facts_upserted, seconds, started_at, finished_at
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            run_id,
+            cik,
+            mode,
+            outcome,
+            facts,
+            seconds,
+            now - timedelta(seconds=seconds),
+            now,
+        ),
+    )
+
+
+class TestCikTimingSummary:
+    def test_empty_table_returns_null_run_id(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        summary = get_cik_timing_summary(ebull_test_conn)
+        assert summary.ingestion_run_id is None
+        assert summary.modes == []
+        assert summary.slowest == []
+
+    def test_returns_percentiles_for_latest_run_only(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        older_run = _insert_run(ebull_test_conn)
+        newer_run = _insert_run(ebull_test_conn)
+
+        with ebull_test_conn.transaction():
+            _insert_timing(ebull_test_conn, run_id=older_run, cik="1", mode="seed", seconds=99.0)
+            for i, s in enumerate([0.5, 1.0, 1.5, 2.0, 9.0]):
+                _insert_timing(
+                    ebull_test_conn,
+                    run_id=newer_run,
+                    cik=f"{i}",
+                    mode="seed",
+                    seconds=s,
+                    facts=10,
+                )
+
+        summary = get_cik_timing_summary(ebull_test_conn)
+
+        assert summary.ingestion_run_id == newer_run
+        assert len(summary.modes) == 1
+        seed = summary.modes[0]
+        assert seed.mode == "seed"
+        assert seed.count == 5
+        # p50 of [0.5, 1.0, 1.5, 2.0, 9.0] = 1.5
+        assert seed.p50_seconds == pytest.approx(1.5)
+        # p95 of same = 7.6 (interpolated)
+        assert seed.p95_seconds == pytest.approx(7.6, rel=0.01)
+        assert seed.max_seconds == pytest.approx(9.0)
+        assert seed.facts_upserted_total == 50
+
+    def test_slowest_capped_at_five(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        run = _insert_run(ebull_test_conn)
+        with ebull_test_conn.transaction():
+            for i in range(12):
+                _insert_timing(
+                    ebull_test_conn,
+                    run_id=run,
+                    cik=f"{i:04d}",
+                    mode="seed",
+                    seconds=float(i),
+                )
+
+        summary = get_cik_timing_summary(ebull_test_conn)
+        assert len(summary.slowest) == 5
+        # Descending by seconds.
+        assert summary.slowest[0].seconds == pytest.approx(11.0)
+        assert summary.slowest[-1].seconds == pytest.approx(7.0)
+
+    def test_mode_split_produces_two_rows(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        run = _insert_run(ebull_test_conn)
+        with ebull_test_conn.transaction():
+            _insert_timing(ebull_test_conn, run_id=run, cik="1", mode="seed", seconds=5.0)
+            _insert_timing(ebull_test_conn, run_id=run, cik="2", mode="refresh", seconds=0.1)
+
+        summary = get_cik_timing_summary(ebull_test_conn)
+        modes = {m.mode: m for m in summary.modes}
+        assert set(modes.keys()) == {"seed", "refresh"}
+        assert modes["seed"].count == 1
+        assert modes["refresh"].count == 1
+
+
+class TestSeedProgress:
+    def test_returns_zero_seeded_when_no_watermarks(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        summary = get_seed_progress(ebull_test_conn)
+        sources = {s.source: s for s in summary.sources}
+        assert "sec.submissions" in sources
+        assert sources["sec.submissions"].seeded == 0
+        # Universe is truncated by the fixture → total == 0 here. Just
+        # assert the contract: total is a non-negative int.
+        assert sources["sec.submissions"].total >= 0
+        assert summary.ingest_paused is False
+
+    def test_ingest_paused_flag_tracks_layer_enabled_row(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        with ebull_test_conn.transaction():
+            ebull_test_conn.execute(
+                """
+                INSERT INTO layer_enabled (layer_name, is_enabled, updated_at)
+                VALUES ('fundamentals_ingest', FALSE, now())
+                ON CONFLICT (layer_name) DO UPDATE SET is_enabled = EXCLUDED.is_enabled
+                """
+            )
+        summary = get_seed_progress(ebull_test_conn)
+        assert summary.ingest_paused is True
+
+    def test_absent_layer_row_counts_as_not_paused(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        summary = get_seed_progress(ebull_test_conn)
+        assert summary.ingest_paused is False
+
+    def test_seeded_count_restricted_to_tradable_cohort(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Counter-case surfaced by Codex review: an orphan watermark
+        for a de-listed / untracked CIK must NOT count toward
+        ``seeded`` — otherwise the progress bar can exceed 100%.
+        """
+        with ebull_test_conn.transaction():
+            # Tradable CIK + watermark: should count in both numerator
+            # and denominator.
+            ebull_test_conn.execute(
+                "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+                "VALUES (1, 'FOO', 'Foo Inc', TRUE)"
+            )
+            ebull_test_conn.execute(
+                "INSERT INTO external_identifiers "
+                "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+                "VALUES (1, 'sec', 'cik', '0000000001', TRUE)"
+            )
+            ebull_test_conn.execute(
+                "INSERT INTO external_data_watermarks (source, key, watermark) "
+                "VALUES ('sec.submissions', '0000000001', 'acc-1')"
+            )
+            # Orphan watermark (CIK not in external_identifiers at all).
+            # Should count in neither.
+            ebull_test_conn.execute(
+                "INSERT INTO external_data_watermarks (source, key, watermark) "
+                "VALUES ('sec.submissions', '0000000099', 'acc-99')"
+            )
+
+        summary = get_seed_progress(ebull_test_conn)
+        src = next(s for s in summary.sources if s.source == "sec.submissions")
+        assert src.seeded == 1
+        assert src.total == 1
+        # Invariant: seeded can never exceed total.
+        assert src.seeded <= src.total
+
+    def test_latest_run_surfaces_most_recent_sec_edgar_run(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        older = _insert_run(ebull_test_conn, status="success")
+        newer = _insert_run(ebull_test_conn, status="running")
+
+        summary = get_seed_progress(ebull_test_conn)
+        assert summary.latest_run is not None
+        assert summary.latest_run.ingestion_run_id == newer
+        assert summary.latest_run.status == "running"
+        assert newer > older  # sanity

--- a/tests/test_sec_incremental_executor.py
+++ b/tests/test_sec_incremental_executor.py
@@ -798,3 +798,35 @@ def test_timing_log_emitted_on_instrument_missing_skip(
     assert "cik=0000999999" in line
     assert "outcome=skip_instrument_missing" in line
     assert "facts_upserted=0" in line
+
+
+def test_cik_upsert_timing_row_persisted(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    # Persist-path companion to the log-line tests above (#418): each
+    # _run_cik_upsert exit must write a cik_upsert_timing row so the
+    # admin UI can surface p50/p95 per-CIK without tailing logs.
+    ebull_test_conn.execute("TRUNCATE cik_upsert_timing RESTART IDENTITY CASCADE")
+    ebull_test_conn.commit()
+
+    plan = RefreshPlan(seeds=["0000999998"])
+    filings = StubFilingsProvider()
+    fundamentals = StubFundamentalsProvider()
+
+    execute_refresh(
+        ebull_test_conn,
+        filings_provider=cast(SecFilingsProvider, filings),
+        fundamentals_provider=cast(SecFundamentalsProvider, fundamentals),
+        plan=plan,
+    )
+
+    rows = ebull_test_conn.execute(
+        "SELECT cik, mode, outcome, facts_upserted, seconds FROM cik_upsert_timing ORDER BY timing_id"
+    ).fetchall()
+    assert len(rows) == 1
+    cik, mode, outcome, facts, seconds = rows[0]
+    assert cik == "0000999998"
+    assert mode == "seed"
+    assert outcome == "skip_instrument_missing"
+    assert facts == 0
+    assert float(seconds) >= 0


### PR DESCRIPTION
## What
Backend data surface for the admin UI slated for the follow-up PR. Closes half of #418 (persistence + service + API; admin UI panel = separate branch).

1. **SQL 049 `cik_upsert_timing`** — one row per `_run_cik_upsert` exit, FK-nullable so skip-path / error-path rows still persist. Indexed for latest-run percentiles and per-CIK regression alerts.
2. **Persist inside `_run_cik_upsert` finally block** — writes on caller connection inside its own transaction. Required pre-persist rollback to close the skip-path's implicit-read tx (without it, the INSERT was nested as a savepoint that `execute_refresh`'s pre-finish rollback dropped).
3. **New observability service** — `get_cik_timing_summary` (percentile_cont p50/p95/max per mode + top-5 slowest CIKs for the latest run) and `get_seed_progress` (submissions-cohort-filtered seeded vs total, latest sec_edgar run, pause flag).
4. **Two new endpoints** — `GET /sync/ingest/cik_timing/latest` and `GET /sync/ingest/seed_progress`.

## Why
- #418 acceptance: operator can see per-CIK timing during an active seed without tailing the process log. Validates the ADR 0004 Shape-B bench ratios in-prod.
- #414 design goal G: surface \`data_ingestion_runs\` progress in the admin UI so the operator can see \"seed N of 5,134, est N days\" at a glance.

## Test plan
- [x] \`uv run pytest\` — 2381 passed, 1 skipped
- [x] \`uv run ruff check .\`
- [x] \`uv run ruff format --check .\`
- [x] \`uv run pyright\`
- [x] Codex pre-push review (one round — cohort-filter + fixture-cleanup findings addressed)
- [x] Smoke gate \`tests/smoke/test_no_settings_url_in_destructive_paths.py\` — enforces no destructive writes against the dev DB
- [x] New seeded-cohort-filter regression test guarantees \`seeded <= total\` invariant

## Scope boundary
Admin UI panel (SyncDashboard seed bar + timing percentiles + ingest toggle) ships in the follow-up PR (task 5+6 frontend). Endpoints here are the data surface that PR will consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)