### PR TITLE
feat(#418): admin SeedProgressPanel — seed bar + timing + pause toggle

### DIFF
--- a/.claude/skills/frontend/async-data-loading.md
+++ b/.claude/skills/frontend/async-data-loading.md
@@ -83,6 +83,23 @@ const recs = useAsync(() => fetchRecommendations(10), []);
 
 If you need memoisation for a different reason (passing the function to a child that uses it as a dep), you're using the wrong hook.
 
+### Refetch every dependent sibling after a mutation
+
+When a mutation handler (toggle, POST, delete) completes, call `refetch()` on **every** async state whose data can be affected — not just the one whose UI contains the button. A panel that owns two `useAsync` calls (e.g. seed progress + per-CIK timing) and only refetches the obvious one leaves the sibling stale until the next poll tick (up to 60 s of idle polling in eBull's dashboard cadence).
+
+```tsx
+// WRONG — toggle changes pause state, but timing card stays stale
+await setIngestEnabled("fundamentals_ingest", seed.ingest_paused);
+seedState.refetch();
+
+// RIGHT — refetch every sibling whose data can reflect the mutation
+await setIngestEnabled("fundamentals_ingest", seed.ingest_paused);
+seedState.refetch();
+timingState.refetch();
+```
+
+Rule of thumb: if a sibling `useAsync` call reads any backend state the mutation touches (directly or transitively), include it in the refetch list. Write a test that asserts every expected `refetch` was called.
+
 ### Cancellation
 
 Every effect that resolves async data must check a `cancelled` flag before calling state setters, so a stale resolution cannot overwrite a newer one. If you write a new async hook, this is non-negotiable.

--- a/frontend/src/api/sync.ts
+++ b/frontend/src/api/sync.ts
@@ -140,3 +140,87 @@ export function setLayerEnabled(
     },
   );
 }
+
+// ---------------------------------------------------------------------------
+// SEC ingest observability (#414, #418)
+// ---------------------------------------------------------------------------
+
+export type CikTimingMode = "seed" | "refresh";
+
+export interface CikTimingModeSummary {
+  mode: CikTimingMode;
+  count: number;
+  p50_seconds: number | null;
+  p95_seconds: number | null;
+  max_seconds: number | null;
+  facts_upserted_total: number;
+}
+
+export interface SlowCikEntry {
+  cik: string;
+  mode: CikTimingMode;
+  seconds: number;
+  facts_upserted: number;
+  outcome: string;
+  finished_at: string;
+}
+
+export interface CikTimingSummaryResponse {
+  ingestion_run_id: number | null;
+  run_source: string | null;
+  run_started_at: string | null;
+  run_finished_at: string | null;
+  run_status: string | null;
+  modes: CikTimingModeSummary[];
+  slowest: SlowCikEntry[];
+}
+
+export interface SeedSource {
+  source: string;
+  key_description: string;
+  seeded: number;
+  total: number;
+}
+
+export interface LatestIngestionRun {
+  ingestion_run_id: number;
+  source: string;
+  started_at: string;
+  finished_at: string | null;
+  status: string;
+  rows_upserted: number;
+  rows_skipped: number;
+}
+
+export interface SeedProgressResponse {
+  sources: SeedSource[];
+  latest_run: LatestIngestionRun | null;
+  ingest_paused: boolean;
+}
+
+export interface IngestToggleResponse {
+  key: string;
+  display_name: string;
+  is_enabled: boolean;
+}
+
+export function fetchCikTimingLatest(): Promise<CikTimingSummaryResponse> {
+  return apiFetch<CikTimingSummaryResponse>("/sync/ingest/cik_timing/latest");
+}
+
+export function fetchSeedProgress(): Promise<SeedProgressResponse> {
+  return apiFetch<SeedProgressResponse>("/sync/ingest/seed_progress");
+}
+
+export function setIngestEnabled(
+  key: string,
+  enabled: boolean,
+): Promise<IngestToggleResponse> {
+  return apiFetch<IngestToggleResponse>(
+    `/sync/ingest/${encodeURIComponent(key)}/enabled`,
+    {
+      method: "POST",
+      body: JSON.stringify({ enabled }),
+    },
+  );
+}

--- a/frontend/src/components/admin/SeedProgressPanel.test.tsx
+++ b/frontend/src/components/admin/SeedProgressPanel.test.tsx
@@ -146,10 +146,22 @@ describe("SeedProgressPanel", () => {
     render(<SeedProgressPanel />);
 
     const button = await screen.findByRole("button", { name: /Resume ingest/i });
+
+    // Baseline fetch counts — both APIs fire once during initial mount.
+    const seedBefore = mockFetchSeedProgress.mock.calls.length;
+    const timingBefore = mockFetchTiming.mock.calls.length;
+
     await userEvent.click(button);
 
     await waitFor(() => {
       expect(mockSetEnabled).toHaveBeenCalledWith("fundamentals_ingest", true);
+    });
+    // Toggle must refetch BOTH sibling states (review #424 WARNING:
+    // timing table would otherwise stay stale for up to 60 s of idle
+    // polling after the operator toggles ingest).
+    await waitFor(() => {
+      expect(mockFetchSeedProgress.mock.calls.length).toBeGreaterThan(seedBefore);
+      expect(mockFetchTiming.mock.calls.length).toBeGreaterThan(timingBefore);
     });
   });
 

--- a/frontend/src/components/admin/SeedProgressPanel.test.tsx
+++ b/frontend/src/components/admin/SeedProgressPanel.test.tsx
@@ -1,0 +1,200 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  CikTimingSummaryResponse,
+  SeedProgressResponse,
+} from "@/api/sync";
+
+import { SeedProgressPanel } from "./SeedProgressPanel";
+
+// Mock the API module — panel pulls all data via these functions.
+vi.mock("@/api/sync", () => ({
+  fetchSeedProgress: vi.fn(),
+  fetchCikTimingLatest: vi.fn(),
+  setIngestEnabled: vi.fn(),
+}));
+
+import {
+  fetchCikTimingLatest,
+  fetchSeedProgress,
+  setIngestEnabled,
+} from "@/api/sync";
+
+const mockFetchSeedProgress = vi.mocked(fetchSeedProgress);
+const mockFetchTiming = vi.mocked(fetchCikTimingLatest);
+const mockSetEnabled = vi.mocked(setIngestEnabled);
+
+
+function buildSeedProgress(
+  overrides: Partial<SeedProgressResponse> = {},
+): SeedProgressResponse {
+  return {
+    sources: [
+      {
+        source: "sec.submissions",
+        key_description: "SEC submissions.json (per-CIK top accession)",
+        seeded: 3_691,
+        total: 5_134,
+      },
+    ],
+    latest_run: {
+      ingestion_run_id: 42,
+      source: "sec_edgar",
+      started_at: "2026-04-24T02:30:00+00:00",
+      finished_at: "2026-04-24T02:33:10+00:00",
+      status: "success",
+      rows_upserted: 150_000,
+      rows_skipped: 0,
+    },
+    ingest_paused: false,
+    ...overrides,
+  };
+}
+
+
+function buildTiming(
+  overrides: Partial<CikTimingSummaryResponse> = {},
+): CikTimingSummaryResponse {
+  return {
+    ingestion_run_id: 42,
+    run_source: "sec_edgar",
+    run_started_at: "2026-04-24T02:30:00+00:00",
+    run_finished_at: "2026-04-24T02:33:10+00:00",
+    run_status: "success",
+    modes: [
+      {
+        mode: "seed",
+        count: 120,
+        p50_seconds: 0.45,
+        p95_seconds: 1.8,
+        max_seconds: 4.8,
+        facts_upserted_total: 120_000,
+      },
+    ],
+    slowest: [
+      {
+        cik: "0000320193",
+        mode: "seed",
+        seconds: 4.8,
+        facts_upserted: 12_500,
+        outcome: "success",
+        finished_at: "2026-04-24T02:33:10+00:00",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+
+describe("SeedProgressPanel", () => {
+  it("renders the seed progress bar + latest run + timing percentiles", async () => {
+    mockFetchSeedProgress.mockResolvedValue(buildSeedProgress());
+    mockFetchTiming.mockResolvedValue(buildTiming());
+
+    render(<SeedProgressPanel />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/SEC submissions.json/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/3,691 \/ 5,134/)).toBeInTheDocument();
+    expect(screen.getByText(/71.9%/)).toBeInTheDocument();
+    expect(screen.getByText(/Latest run #42/)).toBeInTheDocument();
+    // "success" appears twice (run status + slowest-CIK outcome column);
+    // assert presence via count rather than a unique getByText.
+    expect(screen.getAllByText("success").length).toBeGreaterThanOrEqual(1);
+    // p50 0.45s rendered as "450 ms"
+    expect(screen.getByText(/450 ms/)).toBeInTheDocument();
+  });
+
+  it("surfaces the paused banner + Resume label when ingest_paused is true", async () => {
+    mockFetchSeedProgress.mockResolvedValue(
+      buildSeedProgress({ ingest_paused: true }),
+    );
+    mockFetchTiming.mockResolvedValue(buildTiming());
+
+    render(<SeedProgressPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Ingest is paused/i)).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: /Resume ingest/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls setIngestEnabled(true) when the Resume button is clicked", async () => {
+    mockFetchSeedProgress.mockResolvedValue(
+      buildSeedProgress({ ingest_paused: true }),
+    );
+    mockFetchTiming.mockResolvedValue(buildTiming());
+    mockSetEnabled.mockResolvedValue({
+      key: "fundamentals_ingest",
+      display_name: "Fundamentals ingest",
+      is_enabled: true,
+    });
+
+    render(<SeedProgressPanel />);
+
+    const button = await screen.findByRole("button", { name: /Resume ingest/i });
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockSetEnabled).toHaveBeenCalledWith("fundamentals_ingest", true);
+    });
+  });
+
+  it("calls setIngestEnabled(false) when Pause is clicked while enabled", async () => {
+    mockFetchSeedProgress.mockResolvedValue(
+      buildSeedProgress({ ingest_paused: false }),
+    );
+    mockFetchTiming.mockResolvedValue(buildTiming());
+    mockSetEnabled.mockResolvedValue({
+      key: "fundamentals_ingest",
+      display_name: "Fundamentals ingest",
+      is_enabled: false,
+    });
+
+    render(<SeedProgressPanel />);
+
+    const button = await screen.findByRole("button", { name: /Pause ingest/i });
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockSetEnabled).toHaveBeenCalledWith("fundamentals_ingest", false);
+    });
+  });
+
+  it("renders an empty-state message when no ingest run exists yet", async () => {
+    mockFetchSeedProgress.mockResolvedValue(buildSeedProgress({ latest_run: null }));
+    mockFetchTiming.mockResolvedValue(
+      buildTiming({
+        ingestion_run_id: null,
+        run_source: null,
+        run_started_at: null,
+        run_finished_at: null,
+        run_status: null,
+        modes: [],
+        slowest: [],
+      }),
+    );
+
+    render(<SeedProgressPanel />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Per-CIK timing will appear here/i),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Latest run #/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/admin/SeedProgressPanel.tsx
+++ b/frontend/src/components/admin/SeedProgressPanel.tsx
@@ -1,0 +1,301 @@
+/**
+ * SEC ingest seed progress + per-CIK timing + operator pause toggle.
+ *
+ * Backed by three endpoints from PR #423:
+ *   - GET /sync/ingest/seed_progress   — seeded / total, latest run, pause flag
+ *   - GET /sync/ingest/cik_timing/latest — p50/p95 + top-5 slowest
+ *   - POST /sync/ingest/{key}/enabled   — operator pause switch
+ *
+ * Polling cadence:
+ *   - 10s while the latest run is 'running'
+ *   - 60s otherwise (idle / success / failed)
+ *
+ * This panel is the #414 design-goal-G and #418-acceptance surface:
+ * operator can see seed progress, runtime throughput regression, and
+ * pause state at a glance without tailing logs.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  fetchCikTimingLatest,
+  fetchSeedProgress,
+  setIngestEnabled,
+} from "@/api/sync";
+import type {
+  CikTimingSummaryResponse,
+  SeedProgressResponse,
+} from "@/api/sync";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
+import { formatDateTime } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+const FUNDAMENTALS_INGEST_KEY = "fundamentals_ingest";
+
+function formatSeconds(s: number | null): string {
+  if (s === null || Number.isNaN(s)) return "—";
+  if (s < 1) return `${(s * 1000).toFixed(0)} ms`;
+  if (s < 60) return `${s.toFixed(2)} s`;
+  const mins = Math.floor(s / 60);
+  const rem = Math.round(s - mins * 60);
+  return `${mins}m ${rem}s`;
+}
+
+function formatPct(seeded: number, total: number): string {
+  if (total === 0) return "—";
+  const pct = (seeded / total) * 100;
+  return `${pct.toFixed(1)}%`;
+}
+
+export function SeedProgressPanel() {
+  const seedState = useAsync(fetchSeedProgress, []);
+  const timingState = useAsync(fetchCikTimingLatest, []);
+  const [toggleBusy, setToggleBusy] = useState(false);
+  const [toggleError, setToggleError] = useState<string | null>(null);
+
+  const latestStatus = seedState.data?.latest_run?.status ?? null;
+  const isRunning = latestStatus === "running";
+  const pollInterval = isRunning ? 10_000 : 60_000;
+
+  const refetchAll = useCallback(() => {
+    seedState.refetch();
+    timingState.refetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [seedState.refetch, timingState.refetch]);
+
+  useEffect(() => {
+    const id = window.setInterval(refetchAll, pollInterval);
+    return () => window.clearInterval(id);
+  }, [refetchAll, pollInterval]);
+
+  const seed = seedState.data;
+  const timing = timingState.data;
+
+  const handleTogglePause = useCallback(async () => {
+    if (seed === null || seedState.data === null) return;
+    setToggleBusy(true);
+    setToggleError(null);
+    try {
+      await setIngestEnabled(FUNDAMENTALS_INGEST_KEY, seedState.data.ingest_paused);
+      seedState.refetch();
+    } catch (err) {
+      setToggleError(err instanceof Error ? err.message : "Toggle failed");
+    } finally {
+      setToggleBusy(false);
+    }
+  }, [seed, seedState]);
+
+  const toggleLabel = useMemo(() => {
+    if (toggleBusy) return "Updating…";
+    return seed?.ingest_paused ? "Resume ingest" : "Pause ingest";
+  }, [toggleBusy, seed?.ingest_paused]);
+
+  return (
+    <Section
+      title="SEC ingest progress"
+      action={
+        <button
+          type="button"
+          onClick={handleTogglePause}
+          disabled={toggleBusy || seed === null}
+          className="rounded border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {toggleLabel}
+        </button>
+      }
+    >
+      {seedState.loading ? (
+        <SectionSkeleton rows={3} />
+      ) : seedState.error !== null || seed === null ? (
+        <SectionError onRetry={seedState.refetch} />
+      ) : (
+        <div className="space-y-4">
+          {toggleError !== null && (
+            <div
+              role="alert"
+              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700"
+            >
+              {toggleError}
+            </div>
+          )}
+
+          {seed.ingest_paused && (
+            <div
+              role="status"
+              className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800"
+            >
+              Ingest is paused — scheduled runs write <code>status='skipped'</code> until
+              resumed.
+            </div>
+          )}
+
+          {/* Per-source progress bars */}
+          <div className="space-y-3">
+            {seed.sources.map((src) => {
+              const pct = src.total === 0 ? 0 : Math.min(100, (src.seeded / src.total) * 100);
+              return (
+                <div key={src.source}>
+                  <div className="flex items-center justify-between text-xs text-slate-600">
+                    <span className="font-medium text-slate-700">{src.key_description}</span>
+                    <span>
+                      {src.seeded.toLocaleString()} / {src.total.toLocaleString()} ·{" "}
+                      {formatPct(src.seeded, src.total)}
+                    </span>
+                  </div>
+                  <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-slate-100">
+                    <div
+                      className="h-full rounded-full bg-sky-500 transition-all"
+                      style={{ width: `${pct}%` }}
+                      role="progressbar"
+                      aria-valuenow={Math.round(pct)}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-label={`${src.key_description} seed progress`}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Latest run card */}
+          {seed.latest_run !== null && (
+            <LatestRunRow run={seed.latest_run} />
+          )}
+
+          {/* Timing percentiles */}
+          <TimingSection timingState={timingState} data={timing} />
+        </div>
+      )}
+    </Section>
+  );
+}
+
+function LatestRunRow({
+  run,
+}: {
+  run: NonNullable<SeedProgressResponse["latest_run"]>;
+}) {
+  const tone =
+    run.status === "running"
+      ? "text-sky-600"
+      : run.status === "success"
+        ? "text-emerald-600"
+        : run.status === "partial"
+          ? "text-amber-600"
+          : "text-red-600";
+  return (
+    <div className="rounded border border-slate-200 bg-slate-50 px-3 py-2 text-xs">
+      <div className="flex items-center justify-between">
+        <span className="font-medium text-slate-700">Latest run #{run.ingestion_run_id}</span>
+        <span className={`font-semibold ${tone}`}>{run.status}</span>
+      </div>
+      <div className="mt-1 grid grid-cols-2 gap-x-4 gap-y-1 text-slate-600 sm:grid-cols-4">
+        <div>
+          <span className="text-slate-500">Started </span>
+          {formatDateTime(run.started_at)}
+        </div>
+        <div>
+          <span className="text-slate-500">Finished </span>
+          {run.finished_at ? formatDateTime(run.finished_at) : "—"}
+        </div>
+        <div>
+          <span className="text-slate-500">Rows upserted </span>
+          {run.rows_upserted.toLocaleString()}
+        </div>
+        <div>
+          <span className="text-slate-500">Rows skipped </span>
+          {run.rows_skipped.toLocaleString()}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TimingSection({
+  timingState,
+  data,
+}: {
+  timingState: ReturnType<typeof useAsync<CikTimingSummaryResponse>>;
+  data: CikTimingSummaryResponse | null;
+}) {
+  if (timingState.loading) return <SectionSkeleton rows={2} />;
+  if (timingState.error !== null) {
+    return <SectionError onRetry={timingState.refetch} />;
+  }
+  if (data === null || data.ingestion_run_id === null) {
+    return (
+      <p className="text-xs text-slate-500">
+        Per-CIK timing will appear here after the next SEC ingest run.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Per-CIK timing · run #{data.ingestion_run_id}
+        </h3>
+      </div>
+      <table className="w-full text-xs">
+        <thead className="text-left text-[11px] uppercase text-slate-500">
+          <tr>
+            <th className="py-1">Mode</th>
+            <th>Count</th>
+            <th>p50</th>
+            <th>p95</th>
+            <th>Max</th>
+            <th>Facts upserted</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {data.modes.map((m) => (
+            <tr key={m.mode}>
+              <td className="py-1 font-medium text-slate-700">{m.mode}</td>
+              <td>{m.count.toLocaleString()}</td>
+              <td>{formatSeconds(m.p50_seconds)}</td>
+              <td>{formatSeconds(m.p95_seconds)}</td>
+              <td>{formatSeconds(m.max_seconds)}</td>
+              <td>{m.facts_upserted_total.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {data.slowest.length > 0 && (
+        <details className="mt-2 text-xs">
+          <summary className="cursor-pointer text-slate-600">
+            Slowest {data.slowest.length} CIKs
+          </summary>
+          <table className="mt-2 w-full">
+            <thead className="text-left text-[11px] uppercase text-slate-500">
+              <tr>
+                <th className="py-1">CIK</th>
+                <th>Mode</th>
+                <th>Seconds</th>
+                <th>Outcome</th>
+                <th>Facts</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {data.slowest.map((s) => (
+                <tr key={`${s.cik}-${s.finished_at}`}>
+                  <td className="py-1 font-mono text-slate-700">{s.cik}</td>
+                  <td>{s.mode}</td>
+                  <td>{formatSeconds(s.seconds)}</td>
+                  <td>{s.outcome}</td>
+                  <td>{s.facts_upserted.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/SeedProgressPanel.tsx
+++ b/frontend/src/components/admin/SeedProgressPanel.tsx
@@ -76,18 +76,23 @@ export function SeedProgressPanel() {
   const timing = timingState.data;
 
   const handleTogglePause = useCallback(async () => {
-    if (seed === null || seedState.data === null) return;
+    if (seed === null) return;
     setToggleBusy(true);
     setToggleError(null);
     try {
-      await setIngestEnabled(FUNDAMENTALS_INGEST_KEY, seedState.data.ingest_paused);
+      await setIngestEnabled(FUNDAMENTALS_INGEST_KEY, seed.ingest_paused);
+      // Refetch both sibling states — the toggle does not change
+      // timing data directly, but a subsequent run under the new
+      // state will, and leaving the timing card stale for up to
+      // 60 s of idle polling is operator-confusing.
       seedState.refetch();
+      timingState.refetch();
     } catch (err) {
       setToggleError(err instanceof Error ? err.message : "Toggle failed");
     } finally {
       setToggleBusy(false);
     }
-  }, [seed, seedState]);
+  }, [seed, seedState, timingState]);
 
   const toggleLabel = useMemo(() => {
     if (toggleBusy) return "Updating…";
@@ -284,7 +289,7 @@ function TimingSection({
             </thead>
             <tbody className="divide-y divide-slate-100">
               {data.slowest.map((s) => (
-                <tr key={`${s.cik}-${s.finished_at}`}>
+                <tr key={`${s.cik}-${s.mode}-${s.finished_at}`}>
                   <td className="py-1 font-mono text-slate-700">{s.cik}</td>
                   <td>{s.mode}</td>
                   <td>{formatSeconds(s.seconds)}</td>

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -37,6 +37,22 @@ vi.mock("@/api/sync", () => ({
   fetchSyncRuns: vi.fn(),
   triggerSync: vi.fn(),
   setLayerEnabled: vi.fn(),
+  // #418 ingest observability — SeedProgressPanel mounts on AdminPage.
+  fetchSeedProgress: vi.fn().mockResolvedValue({
+    sources: [],
+    latest_run: null,
+    ingest_paused: false,
+  }),
+  fetchCikTimingLatest: vi.fn().mockResolvedValue({
+    ingestion_run_id: null,
+    run_source: null,
+    run_started_at: null,
+    run_finished_at: null,
+    run_status: null,
+    modes: [],
+    slowest: [],
+  }),
+  setIngestEnabled: vi.fn(),
 }));
 vi.mock("@/api/coverage", () => ({ fetchCoverageSummary: vi.fn() }));
 vi.mock("@/api/recommendations", () => ({ fetchRecommendations: vi.fn() }));

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -34,6 +34,7 @@ import { CollapsibleSection } from "@/components/admin/CollapsibleSection";
 import { FundDataRow } from "@/components/admin/FundDataRow";
 import { LayerHealthList } from "@/components/admin/LayerHealthList";
 import { ProblemsPanel } from "@/components/admin/ProblemsPanel";
+import { SeedProgressPanel } from "@/components/admin/SeedProgressPanel";
 import {
   SectionError,
   SectionSkeleton,
@@ -292,6 +293,8 @@ export function AdminPage() {
       >
         <SyncDashboard syncTrigger={syncTrigger} />
       </CollapsibleSection>
+
+      <SeedProgressPanel />
 
       <CollapsibleSection
         title="Background tasks"


### PR DESCRIPTION
## What
UI half of #414 design goal G / #418 acceptance. Consumes the endpoints that shipped in #423.

- New \`SeedProgressPanel\` mounted on \`AdminPage\`, immediately after \`SyncDashboard\`.
- Per-source progress bar for \`sec.submissions\` (seeded / total, %).
- Latest-run card (id, status, started, finished, rows upserted / skipped).
- Per-CIK timing table: p50 / p95 / max per mode + expandable top-5 slowest CIKs.
- **Pause / Resume ingest** button wired to \`POST /sync/ingest/fundamentals_ingest/enabled\`. Banner appears when \`ingest_paused=true\`.
- Poll 10 s while latest run is \`running\`, 60 s otherwise — mirrors \`SyncDashboard\`.

## Why
- Operator can see seed progress (N of 5,134) at a glance without tailing logs.
- Per-CIK timing percentiles validate ADR 0004 Shape-B ratios in prod.
- Runtime ingest pause surfaces as a visible banner instead of silent staleness.

## Test plan
- [x] \`pnpm test:unit\` — 377 passed (32 files), including 5 new \`SeedProgressPanel\` cases
- [x] \`pnpm typecheck\` — clean
- [x] \`uv run ruff check .\`
- [x] \`uv run ruff format --check .\`
- [x] \`uv run pyright\`
- [x] \`uv run pytest\` — 2381 passed, 1 skipped

## Scope
Frontend only — relies on the endpoints merged in #423. No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)