### PR TITLE
feat: dividend history + TTM yield + has_dividend filter from SEC XBRL

### DIFF
--- a/.claude/skills/engineering/sql-correctness.md
+++ b/.claude/skills/engineering/sql-correctness.md
@@ -61,6 +61,32 @@ Pattern: do all I/O first, then open the transaction for the writes only.
 - `IN` clauses: `= ANY(%s)` with a list, not `IN %s` with a tuple
 - Literal `%` in LIKE patterns: `%%`
 
+## Conditional JOINs in filter-aware list queries
+
+A paginated list endpoint should only JOIN tables / views its active filters actually consume. A view backing a filter (e.g. `instrument_dividend_summary` for a `has_dividend` filter) scans every row in its source — adding the JOIN unconditionally to the items query penalises every caller, including the default no-filter case.
+
+```python
+# Wrong — dividend-summary view scanned on every list call.
+items_sql = f"""
+    SELECT ... FROM instruments i
+    LEFT JOIN coverage c USING (instrument_id)
+    LEFT JOIN instrument_dividend_summary ds USING (instrument_id)
+    {where_sql}
+"""
+
+# Correct — JOIN composed only when the filter is active, matching the
+# pattern already used for the COUNT query.
+dividend_join = "LEFT JOIN instrument_dividend_summary ds USING (instrument_id)" if has_dividend is not None else ""
+items_sql = f"""
+    SELECT ... FROM instruments i
+    LEFT JOIN coverage c USING (instrument_id)
+    {dividend_join}
+    {where_sql}
+"""
+```
+
+Self-check: `grep -n "LEFT JOIN.*_summary\|LEFT JOIN.*_view" app/api/*.py` — every match inside an `items_sql =` f-string must be gated by a conditional variable, not hardcoded.
+
 ## Single-row UPDATE must verify rowcount
 
 `UPDATE ... WHERE` silently affects zero rows when the predicate matches nothing. For any UPDATE that must affect exactly one row (singleton tables, primary-key lookups), check `result.rowcount`:

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -242,6 +242,7 @@ def list_instruments(
     sector: str | None = Query(default=None),
     coverage_tier: int | None = Query(default=None, ge=1, le=3),
     exchange: str | None = Query(default=None),
+    has_dividend: bool | None = Query(default=None),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=50, ge=1, le=MAX_PAGE_LIMIT),
 ) -> InstrumentListResponse:
@@ -253,6 +254,10 @@ def list_instruments(
       - sector: exact match on instruments.sector
       - coverage_tier: exact match (1/2/3); untiered instruments excluded
       - exchange: exact match on instruments.exchange
+      - has_dividend: True matches instruments with a positive TTM dividend
+        signal (dps_declared or dividends_paid > 0 in the last four reported
+        quarters); False matches instruments with no such signal. Backed by
+        the ``instrument_dividend_summary`` view (sql/050).
 
     Ordering: symbol ASC, instrument_id ASC (deterministic tiebreak).
     """
@@ -275,6 +280,11 @@ def list_instruments(
     if exchange is not None:
         where_clauses.append("i.exchange = %(exchange)s")
         filter_params["exchange"] = exchange
+    if has_dividend is not None:
+        if has_dividend:
+            where_clauses.append("COALESCE(ds.has_dividend, FALSE) = TRUE")
+        else:
+            where_clauses.append("COALESCE(ds.has_dividend, FALSE) = FALSE")
 
     where_sql = (" WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
 
@@ -282,8 +292,14 @@ def list_instruments(
     # Only join tables that the active filters require.
     # Uses filter_params only — no limit/offset keys that the COUNT has no placeholders for.
     count_needs_coverage = coverage_tier is not None
+    count_needs_dividend = has_dividend is not None
     count_join = "LEFT JOIN coverage c USING (instrument_id)" if count_needs_coverage else ""
-    count_sql = f"SELECT COUNT(*) AS cnt FROM instruments i {count_join}{where_sql}"  # noqa: S608  — hardcoded fragments only
+    count_dividend_join = (
+        "LEFT JOIN instrument_dividend_summary ds USING (instrument_id)" if count_needs_dividend else ""
+    )
+    count_sql = (  # noqa: S608  — hardcoded fragments only
+        f"SELECT COUNT(*) AS cnt FROM instruments i {count_join} {count_dividend_join}{where_sql}"
+    )
 
     # -- Items query -------------------------------------------------------
     items_params: dict[str, object] = {**filter_params, "limit": limit, "offset": offset}
@@ -294,6 +310,7 @@ def list_instruments(
         FROM instruments i
         LEFT JOIN quotes q USING (instrument_id)
         LEFT JOIN coverage c USING (instrument_id)
+        LEFT JOIN instrument_dividend_summary ds USING (instrument_id)
         {where_sql}
         ORDER BY i.symbol, i.instrument_id
         LIMIT %(limit)s OFFSET %(offset)s"""  # noqa: S608  — hardcoded fragments only
@@ -624,6 +641,106 @@ def get_instrument_candles(
         range=range_,
         days=days,
         rows=bars,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dividend history + summary (#414 follow-up, operator ask 2026-04-24)
+# ---------------------------------------------------------------------------
+
+
+class DividendPeriodModel(BaseModel):
+    period_end_date: date
+    period_type: str
+    fiscal_year: int
+    fiscal_quarter: int | None
+    dps_declared: Decimal | None
+    dividends_paid: Decimal | None
+    reported_currency: str | None
+
+
+class DividendSummaryModel(BaseModel):
+    has_dividend: bool
+    ttm_dps: Decimal | None
+    ttm_dividends_paid: Decimal | None
+    ttm_yield_pct: Decimal | None
+    latest_dps: Decimal | None
+    latest_dividend_at: date | None
+    dividend_streak_q: int
+    dividend_currency: str | None
+
+
+class InstrumentDividends(BaseModel):
+    symbol: str
+    summary: DividendSummaryModel
+    history: list[DividendPeriodModel]
+
+
+@router.get("/{symbol}/dividends", response_model=InstrumentDividends)
+def get_instrument_dividends(
+    symbol: str,
+    limit: int = Query(default=40, ge=1, le=400),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> InstrumentDividends:
+    """Dividend history + TTM yield summary for a single instrument.
+
+    Source: SEC XBRL ``us-gaap:CommonStockDividendsPerShareDeclared`` +
+    ``us-gaap:PaymentsOfDividends``, already ingested via the daily
+    companyfacts path. Returns ``has_dividend=False`` with an empty
+    history array for instruments that have never reported a dividend
+    — the UI can render an empty state without 404 handling.
+
+    Default ``limit=40`` covers ten years of quarterly history.
+    """
+    from app.services.dividends import get_dividend_history, get_dividend_summary
+
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    summary = get_dividend_summary(conn, instrument_id=instrument_id)
+    history = get_dividend_history(conn, instrument_id=instrument_id, limit=limit)
+
+    return InstrumentDividends(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        summary=DividendSummaryModel(
+            has_dividend=summary.has_dividend,
+            ttm_dps=summary.ttm_dps,
+            ttm_dividends_paid=summary.ttm_dividends_paid,
+            ttm_yield_pct=summary.ttm_yield_pct,
+            latest_dps=summary.latest_dps,
+            latest_dividend_at=summary.latest_dividend_at,
+            dividend_streak_q=summary.dividend_streak_q,
+            dividend_currency=summary.dividend_currency,
+        ),
+        history=[
+            DividendPeriodModel(
+                period_end_date=p.period_end_date,
+                period_type=p.period_type,
+                fiscal_year=p.fiscal_year,
+                fiscal_quarter=p.fiscal_quarter,
+                dps_declared=p.dps_declared,
+                dividends_paid=p.dividends_paid,
+                reported_currency=p.reported_currency,
+            )
+            for p in history
+        ],
     )
 
 

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -302,6 +302,10 @@ def list_instruments(
     )
 
     # -- Items query -------------------------------------------------------
+    # Only join the dividend-summary view when the filter needs it. The view
+    # scans every instrument with any dividend row, and adding it to an
+    # unrelated query (e.g. a plain ``/instruments`` call) is pure overhead.
+    items_dividend_join = count_dividend_join
     items_params: dict[str, object] = {**filter_params, "limit": limit, "offset": offset}
     items_sql = f"""SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
                i.currency, i.sector, i.is_tradable,
@@ -310,7 +314,7 @@ def list_instruments(
         FROM instruments i
         LEFT JOIN quotes q USING (instrument_id)
         LEFT JOIN coverage c USING (instrument_id)
-        LEFT JOIN instrument_dividend_summary ds USING (instrument_id)
+        {items_dividend_join}
         {where_sql}
         ORDER BY i.symbol, i.instrument_id
         LIMIT %(limit)s OFFSET %(offset)s"""  # noqa: S608  — hardcoded fragments only

--- a/app/services/dividends.py
+++ b/app/services/dividends.py
@@ -1,0 +1,154 @@
+"""Dividend history + summary service.
+
+Reads from the ``dividend_history`` + ``instrument_dividend_summary``
+views (sql/050), which derive from ``financial_periods.dps_declared``
+and ``financial_periods.dividends_paid`` — both already ingested from
+SEC XBRL companyfacts (us-gaap:CommonStockDividendsPerShareDeclared,
+us-gaap:PaymentsOfDividends) on the existing daily path.
+
+Official free source. No rate-limit exposure beyond the once-daily
+companyfacts fetch we already do.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+
+@dataclass(frozen=True)
+class DividendPeriod:
+    """One fiscal period of dividend data for a single instrument."""
+
+    period_end_date: date
+    period_type: str  # Q1 / Q2 / Q3 / Q4 / FY
+    fiscal_year: int
+    fiscal_quarter: int | None
+    dps_declared: Decimal | None
+    dividends_paid: Decimal | None
+    reported_currency: str | None
+
+
+@dataclass(frozen=True)
+class DividendSummary:
+    """Roll-up across all periods for one instrument.
+
+    ``has_dividend=False`` also covers the "no rows" case — callers can
+    render an empty-state panel without branching on None.
+    """
+
+    has_dividend: bool
+    ttm_dps: Decimal | None
+    ttm_dividends_paid: Decimal | None
+    ttm_yield_pct: Decimal | None
+    latest_dps: Decimal | None
+    latest_dividend_at: date | None
+    dividend_streak_q: int
+    dividend_currency: str | None
+
+
+_EMPTY_SUMMARY = DividendSummary(
+    has_dividend=False,
+    ttm_dps=None,
+    ttm_dividends_paid=None,
+    ttm_yield_pct=None,
+    latest_dps=None,
+    latest_dividend_at=None,
+    dividend_streak_q=0,
+    dividend_currency=None,
+)
+
+
+def get_dividend_summary(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+) -> DividendSummary:
+    """Return the single-row summary for an instrument, or the
+    ``has_dividend=False`` empty shape if the instrument has never
+    reported a dividend."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT has_dividend,
+                   ttm_dps,
+                   ttm_dividends_paid,
+                   ttm_yield_pct,
+                   latest_dps,
+                   latest_dividend_at,
+                   dividend_streak_q,
+                   dividend_currency
+            FROM instrument_dividend_summary
+            WHERE instrument_id = %s
+            """,
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        return _EMPTY_SUMMARY
+
+    return DividendSummary(
+        has_dividend=bool(row["has_dividend"]),
+        ttm_dps=row["ttm_dps"],
+        ttm_dividends_paid=row["ttm_dividends_paid"],
+        ttm_yield_pct=row["ttm_yield_pct"],
+        latest_dps=row["latest_dps"],
+        latest_dividend_at=row["latest_dividend_at"],
+        dividend_streak_q=int(row["dividend_streak_q"] or 0),
+        dividend_currency=row["dividend_currency"],
+    )
+
+
+def get_dividend_history(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    limit: int = 40,
+) -> list[DividendPeriod]:
+    """Return dividend periods for an instrument, newest first.
+
+    Default ``limit=40`` = ten years of quarterly data, enough to drive
+    a per-share bar chart without paging. Caller can request a smaller
+    window for spark-line renderings; capped at 400 to prevent
+    accidental full-history reads.
+    """
+    if not 1 <= limit <= 400:
+        raise ValueError(f"limit must be 1..400, got {limit}")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT period_end_date,
+                   period_type,
+                   fiscal_year,
+                   fiscal_quarter,
+                   dps_declared,
+                   dividends_paid,
+                   reported_currency
+            FROM dividend_history
+            WHERE instrument_id = %s
+            ORDER BY period_end_date DESC
+            LIMIT %s
+            """,
+            (instrument_id, limit),
+        )
+        rows = cur.fetchall()
+
+    return [
+        DividendPeriod(
+            period_end_date=r["period_end_date"],
+            period_type=str(r["period_type"]),
+            fiscal_year=int(r["fiscal_year"]),
+            fiscal_quarter=int(r["fiscal_quarter"]) if r["fiscal_quarter"] is not None else None,
+            dps_declared=r["dps_declared"],
+            dividends_paid=r["dividends_paid"],
+            reported_currency=r["reported_currency"],
+        )
+        for r in rows
+    ]

--- a/sql/050_dividend_history_views.sql
+++ b/sql/050_dividend_history_views.sql
@@ -1,0 +1,185 @@
+-- 050_dividend_history_views.sql
+--
+-- Dividend surfacing on top of ``financial_periods`` (user ask 2026-04-24:
+-- "especially as a way we could filter on to dividend-providing businesses,
+-- understanding what the yield is, when it pays out, how much per stock was
+-- issued over time").
+--
+-- No new underlying tables — every field below is derived from data already
+-- captured under the existing ``dps_declared`` + ``dividends_paid`` TRACKED
+-- CONCEPTS in ``financial_periods``. Adds two VIEWs:
+--
+--   1. ``dividend_history``            — long, one row per dividend-paying
+--                                        period, ordered newest-first. Drives
+--                                        the instrument-page dividend chart.
+--   2. ``instrument_dividend_summary`` — wide, one row per dividend-paying
+--                                        instrument, with TTM yield + streak
+--                                        + latest-DPS shortcuts for the
+--                                        instruments-list ``has_dividend``
+--                                        filter.
+--
+-- Source-of-truth: ``financial_periods.dps_declared`` (per-share cash
+-- declared, from us-gaap:CommonStockDividendsPerShareDeclared) and
+-- ``financial_periods.dividends_paid`` (aggregate cash outflow, from
+-- us-gaap:PaymentsOfDividends).
+--
+-- A row is considered "a dividend-paying period" when EITHER ``dps_declared``
+-- is strictly positive OR ``dividends_paid`` is strictly positive. A zero
+-- amount is explicitly non-paying — not just "no data" — so it must not
+-- surface as ``latest_dps`` or leak into the chart-driving history.
+--
+-- Live-row guard: every read filters ``superseded_at IS NULL`` so a
+-- restated or withdrawn period cannot leak into the has_dividend filter or
+-- the chart. Mirrors the canonical projection in sql/032 (line 218).
+--
+-- FY-vs-quarterly tie-break: an issuer sometimes reports the same
+-- period_end_date under BOTH ``period_type='FY'`` AND ``period_type='Q4'``.
+-- History surfaces quarterly rows only (FY excluded) to avoid double-counting
+-- four quarters as an extra row. The summary's ``latest_*`` resolution adds
+-- a deterministic ordering (``period_type DESC`` puts 'Q?' > 'FY') so the
+-- quarter-level figure wins when both exist for the same end date.
+
+-- ---------------------------------------------------------------------------
+-- 1. dividend_history
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE VIEW dividend_history AS
+SELECT
+    fp.instrument_id,
+    fp.period_end_date,
+    fp.period_type,
+    fp.fiscal_year,
+    fp.fiscal_quarter,
+    fp.period_start_date,
+    fp.months_covered,
+    fp.dps_declared,
+    fp.dividends_paid,
+    fp.reported_currency
+FROM financial_periods fp
+WHERE fp.superseded_at IS NULL
+  AND fp.period_type IN ('Q1', 'Q2', 'Q3', 'Q4')
+  AND (
+        (fp.dps_declared IS NOT NULL AND fp.dps_declared > 0)
+     OR (fp.dividends_paid IS NOT NULL AND fp.dividends_paid > 0)
+  );
+
+COMMENT ON VIEW dividend_history IS
+    'Per-quarter dividend record (one row per instrument per FISCAL QUARTER '
+    'where dps_declared > 0 or dividends_paid > 0). FY rows excluded to '
+    'prevent Q1+Q2+Q3+Q4 double-counting. Superseded rows filtered.';
+
+
+-- ---------------------------------------------------------------------------
+-- 2. instrument_dividend_summary
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE VIEW instrument_dividend_summary AS
+WITH recent_quarters AS (
+    -- Live rows only, quarterly granularity only. The streak walk below
+    -- needs every quarter (not only paying ones) so it can detect a
+    -- break, so this CTE does NOT pre-filter by amount.
+    SELECT fp.instrument_id,
+           fp.period_end_date,
+           fp.period_type,
+           fp.dps_declared,
+           fp.dividends_paid,
+           ROW_NUMBER() OVER (
+               PARTITION BY fp.instrument_id
+               ORDER BY fp.period_end_date DESC
+           ) AS rn
+    FROM financial_periods fp
+    WHERE fp.superseded_at IS NULL
+      AND fp.period_type IN ('Q1', 'Q2', 'Q3', 'Q4')
+),
+ttm AS (
+    SELECT instrument_id,
+           SUM(dps_declared)     FILTER (WHERE rn <= 4) AS ttm_dps,
+           SUM(dividends_paid)   FILTER (WHERE rn <= 4) AS ttm_dividends_paid,
+           COUNT(*)              FILTER (WHERE rn <= 4
+                                         AND dps_declared IS NOT NULL
+                                         AND dps_declared > 0) AS ttm_dividend_quarters
+    FROM recent_quarters
+    GROUP BY instrument_id
+),
+-- ``latest`` reports the newest DIVIDEND-PAYING quarter. Zero / NULL
+-- rows are deliberately excluded so ``latest_dps`` never surfaces a
+-- "we skipped the dividend this quarter" amount as though it were the
+-- current payout. Tie-break on period_type DESC so Q4 wins over FY
+-- when both exist for the same end date.
+latest AS (
+    SELECT DISTINCT ON (fp.instrument_id)
+           fp.instrument_id,
+           fp.dps_declared      AS latest_dps,
+           fp.period_end_date   AS latest_dividend_at,
+           fp.reported_currency AS dividend_currency
+    FROM financial_periods fp
+    WHERE fp.superseded_at IS NULL
+      AND (
+            (fp.dps_declared IS NOT NULL AND fp.dps_declared > 0)
+         OR (fp.dividends_paid IS NOT NULL AND fp.dividends_paid > 0)
+      )
+    ORDER BY fp.instrument_id,
+             fp.period_end_date DESC,
+             fp.period_type     DESC  -- Q4 > FY, Q3 > Q2 > Q1 lexically
+),
+-- Streak: walk newest-back across quarterly rows and count consecutive
+-- non-zero dps_declared periods until the first zero / NULL. When no
+-- break exists (``first_break_rn`` is NULL), every row in the window
+-- counts — otherwise it would collapse to zero and misreport an
+-- uninterrupted dividend payer as a non-payer.
+streaks AS (
+    SELECT instrument_id,
+           COUNT(*) FILTER (
+               WHERE first_break_rn IS NULL OR rn < first_break_rn
+           ) AS dividend_streak_q
+    FROM (
+        SELECT instrument_id,
+               rn,
+               MIN(CASE
+                       WHEN dps_declared IS NULL OR dps_declared = 0
+                       THEN rn
+                   END) OVER (PARTITION BY instrument_id) AS first_break_rn
+        FROM recent_quarters
+    ) s
+    GROUP BY instrument_id
+),
+-- Live price gate on yield. Quote row can be missing (non-tradable, demoted)
+-- — LEFT JOIN to surface the dividend facts even then.
+priced AS (
+    SELECT instrument_id,
+           COALESCE(
+               NULLIF(GREATEST(last, 0), 0),
+               CASE WHEN bid > 0 AND ask > 0 THEN (bid + ask) / 2 END
+           ) AS price
+    FROM quotes
+)
+SELECT
+    l.instrument_id,
+    ttm.ttm_dps,
+    ttm.ttm_dividends_paid,
+    ttm.ttm_dividend_quarters,
+    l.latest_dps,
+    l.latest_dividend_at,
+    l.dividend_currency,
+    s.dividend_streak_q,
+    -- TTM yield = ttm_dps / price, percent. NULL if either input missing.
+    CASE WHEN p.price IS NOT NULL
+              AND p.price > 0
+              AND ttm.ttm_dps IS NOT NULL
+              AND ttm.ttm_dps > 0
+         THEN (ttm.ttm_dps / p.price) * 100
+         ELSE NULL
+    END AS ttm_yield_pct,
+    (
+        (ttm.ttm_dps IS NOT NULL AND ttm.ttm_dps > 0)
+        OR (ttm.ttm_dividends_paid IS NOT NULL AND ttm.ttm_dividends_paid > 0)
+    ) AS has_dividend
+FROM latest l
+LEFT JOIN ttm ON ttm.instrument_id = l.instrument_id
+LEFT JOIN streaks s ON s.instrument_id = l.instrument_id
+LEFT JOIN priced p ON p.instrument_id = l.instrument_id;
+
+COMMENT ON VIEW instrument_dividend_summary IS
+    'One row per instrument that has ever reported a positive dividend (live '
+    'rows only, superseded filtered). Drives the instruments-list has_dividend '
+    'filter + per-instrument dividend summary card. Recomputed on demand.';

--- a/tests/api/test_instruments_dividends_endpoint.py
+++ b/tests/api/test_instruments_dividends_endpoint.py
@@ -1,0 +1,109 @@
+"""Tests for GET /instruments/{symbol}/dividends.
+
+Service-layer logic is covered by ``tests/test_dividends_service.py``
+against the real ebull_test DB. This test pins HTTP response shape,
+404 on unknown symbol, and auth — all via a mocked connection so it
+can run anywhere.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.instruments import router as instruments_router
+from app.db import get_conn
+from app.services.dividends import DividendPeriod, DividendSummary
+
+
+def _build_app(conn: MagicMock) -> FastAPI:
+    app = FastAPI()
+    app.include_router(instruments_router)
+
+    def _yield_conn():  # type: ignore[return]
+        yield conn
+
+    app.dependency_overrides[get_conn] = _yield_conn
+    # Bypass auth for shape tests.
+    from app.api.auth import require_session_or_service_token
+
+    app.dependency_overrides[require_session_or_service_token] = lambda: None
+    return app
+
+
+def _cursor_with(rows: list[dict[str, object] | None]) -> MagicMock:
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.fetchone.side_effect = rows
+    return cur
+
+
+def test_dividends_endpoint_returns_summary_and_history() -> None:
+    summary = DividendSummary(
+        has_dividend=True,
+        ttm_dps=Decimal("2.0000"),
+        ttm_dividends_paid=Decimal("200000000.0000"),
+        ttm_yield_pct=Decimal("2.00"),
+        latest_dps=Decimal("0.5000"),
+        latest_dividend_at=date(2025, 12, 28),
+        dividend_streak_q=20,
+        dividend_currency="USD",
+    )
+    history = [
+        DividendPeriod(
+            period_end_date=date(2025, 12, 28),
+            period_type="Q4",
+            fiscal_year=2025,
+            fiscal_quarter=4,
+            dps_declared=Decimal("0.5000"),
+            dividends_paid=Decimal("50000000.0000"),
+            reported_currency="USD",
+        ),
+    ]
+
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_with([{"instrument_id": 1, "symbol": "AAPL"}])
+    app = _build_app(conn)
+
+    with (
+        patch("app.services.dividends.get_dividend_summary", return_value=summary),
+        patch("app.services.dividends.get_dividend_history", return_value=history),
+        TestClient(app) as client,
+    ):
+        resp = client.get("/instruments/AAPL/dividends")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["symbol"] == "AAPL"
+    assert body["summary"]["has_dividend"] is True
+    assert body["summary"]["ttm_yield_pct"] == "2.00"
+    assert body["summary"]["dividend_streak_q"] == 20
+    assert len(body["history"]) == 1
+    assert body["history"][0]["period_type"] == "Q4"
+
+
+def test_dividends_endpoint_unknown_symbol_404() -> None:
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_with([None])
+    app = _build_app(conn)
+
+    with TestClient(app) as client:
+        resp = client.get("/instruments/__NOSUCHSYMBOL__/dividends")
+
+    assert resp.status_code == 404
+
+
+def test_dividends_endpoint_rejects_out_of_range_limit() -> None:
+    conn = MagicMock()
+    app = _build_app(conn)
+    with TestClient(app) as client:
+        resp = client.get("/instruments/AAPL/dividends", params={"limit": 0})
+    assert resp.status_code == 422
+    with TestClient(app) as client:
+        resp = client.get("/instruments/AAPL/dividends", params={"limit": 401})
+    assert resp.status_code == 422

--- a/tests/test_api_instruments.py
+++ b/tests/test_api_instruments.py
@@ -266,6 +266,28 @@ class TestListInstruments:
         first_execute_params = cur.execute.call_args_list[0][0][1]
         assert first_execute_params["exchange"] == "NASDAQ"
 
+    def test_filter_by_has_dividend_true(self) -> None:
+        row = _make_instrument_row()
+        conn = _with_conn([[{"cnt": 1}], [row]])
+        resp = client.get("/instruments", params={"has_dividend": "true"})
+
+        assert resp.status_code == 200
+        cur = conn.cursor.return_value
+        count_sql = cur.execute.call_args_list[0][0][0]
+        # has_dividend join + filter must appear in the built SQL.
+        assert "instrument_dividend_summary" in count_sql
+        assert "COALESCE(ds.has_dividend, FALSE) = TRUE" in count_sql
+
+    def test_filter_by_has_dividend_false(self) -> None:
+        row = _make_instrument_row()
+        conn = _with_conn([[{"cnt": 1}], [row]])
+        resp = client.get("/instruments", params={"has_dividend": "false"})
+
+        assert resp.status_code == 200
+        cur = conn.cursor.return_value
+        count_sql = cur.execute.call_args_list[0][0][0]
+        assert "COALESCE(ds.has_dividend, FALSE) = FALSE" in count_sql
+
     def test_pagination_offset_and_limit(self) -> None:
         row = _make_instrument_row()
         conn = _with_conn([[{"cnt": 100}], [row]])

--- a/tests/test_api_instruments.py
+++ b/tests/test_api_instruments.py
@@ -278,6 +278,20 @@ class TestListInstruments:
         assert "instrument_dividend_summary" in count_sql
         assert "COALESCE(ds.has_dividend, FALSE) = TRUE" in count_sql
 
+    def test_has_dividend_join_omitted_when_filter_absent(self) -> None:
+        """Review #426 WARNING: the dividend-summary view scan must not
+        hit every list call; only compose the JOIN when the filter is set."""
+        row = _make_instrument_row()
+        conn = _with_conn([[{"cnt": 1}], [row]])
+        resp = client.get("/instruments")
+
+        assert resp.status_code == 200
+        cur = conn.cursor.return_value
+        count_sql = cur.execute.call_args_list[0][0][0]
+        items_sql = cur.execute.call_args_list[1][0][0]
+        assert "instrument_dividend_summary" not in count_sql
+        assert "instrument_dividend_summary" not in items_sql
+
     def test_filter_by_has_dividend_false(self) -> None:
         row = _make_instrument_row()
         conn = _with_conn([[{"cnt": 1}], [row]])

--- a/tests/test_dividends_service.py
+++ b/tests/test_dividends_service.py
@@ -1,0 +1,304 @@
+"""Tests for app.services.dividends against the ebull_test DB.
+
+Views (sql/050_dividend_history_views.sql) are SQL-only, so the
+service tests run against the real schema to pin the view contract.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services.dividends import (
+    _EMPTY_SUMMARY,
+    get_dividend_history,
+    get_dividend_summary,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _test_db_available(),
+        reason="ebull_test DB unavailable",
+    ),
+]
+
+
+_NEXT_IID = [10_000]
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, symbol: str) -> int:
+    _NEXT_IID[0] += 1
+    iid = _NEXT_IID[0]
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (iid, symbol, f"{symbol} Inc."),
+        )
+    conn.commit()
+    return iid
+
+
+def _seed_quote(conn: psycopg.Connection[tuple], *, instrument_id: int, price: float) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO quotes (instrument_id, quoted_at, bid, ask, last)
+            VALUES (%s, NOW(), %s, %s, %s)
+            """,
+            (instrument_id, price - 0.01, price + 0.01, price),
+        )
+    conn.commit()
+
+
+def _seed_period(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    period_end: date,
+    period_type: str,
+    fiscal_year: int,
+    fiscal_quarter: int | None,
+    dps_declared: float | None = None,
+    dividends_paid: float | None = None,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO financial_periods (
+                instrument_id, period_end_date, period_type, fiscal_year,
+                fiscal_quarter, dps_declared, dividends_paid,
+                reported_currency, source, source_ref
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, 'USD', 'sec', 'test')
+            """,
+            (instrument_id, period_end, period_type, fiscal_year, fiscal_quarter, dps_declared, dividends_paid),
+        )
+    conn.commit()
+
+
+class TestGetDividendSummary:
+    def test_never_paid_returns_empty_shape(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="NEVR")
+        summary = get_dividend_summary(ebull_test_conn, instrument_id=iid)
+        assert summary == _EMPTY_SUMMARY
+
+    def test_ttm_sums_last_four_quarters(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="TTMQ")
+        _seed_quote(ebull_test_conn, instrument_id=iid, price=100.0)
+        # Four $0.50 quarterly dividends → TTM $2.00, yield 2.0%
+        for q, m in enumerate([3, 6, 9, 12], start=1):
+            _seed_period(
+                ebull_test_conn,
+                instrument_id=iid,
+                period_end=date(2025, m, 28),
+                period_type=f"Q{q}",
+                fiscal_year=2025,
+                fiscal_quarter=q,
+                dps_declared=0.50,
+                dividends_paid=50_000_000,
+            )
+        # Older quarter OUTSIDE the last-4 window — must not contribute.
+        _seed_period(
+            ebull_test_conn,
+            instrument_id=iid,
+            period_end=date(2024, 12, 28),
+            period_type="Q4",
+            fiscal_year=2024,
+            fiscal_quarter=4,
+            dps_declared=99.0,
+            dividends_paid=999_000_000,
+        )
+
+        summary = get_dividend_summary(ebull_test_conn, instrument_id=iid)
+        assert summary.has_dividend is True
+        assert summary.ttm_dps == Decimal("2.0000")
+        assert summary.ttm_yield_pct == Decimal("2.00000000")
+        # Streak walks the full quarterly history, not just the TTM
+        # window — 4 quarters of 2025 + the 2024-Q4 row that is outside
+        # TTM but still a non-zero paying quarter = 5 consecutive.
+        assert summary.dividend_streak_q == 5
+        assert summary.latest_dividend_at == date(2025, 12, 28)
+
+    def test_streak_breaks_on_zero_quarter(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="BRKS")
+        # Newest → oldest: $0.50, $0.50, 0 (streak break), $0.50
+        for q, m, amt in [
+            (4, 12, 0.50),
+            (3, 9, 0.50),
+            (2, 6, 0.0),
+            (1, 3, 0.50),
+        ]:
+            _seed_period(
+                ebull_test_conn,
+                instrument_id=iid,
+                period_end=date(2025, m, 28),
+                period_type=f"Q{q}",
+                fiscal_year=2025,
+                fiscal_quarter=q,
+                dps_declared=amt,
+            )
+
+        summary = get_dividend_summary(ebull_test_conn, instrument_id=iid)
+        # Streak walks newest-back: $0.50, $0.50, then 0 breaks. Streak = 2.
+        assert summary.dividend_streak_q == 2
+        # latest_dps must NOT be the zero row — pin that the resolver
+        # skips non-paying quarters (Codex review #PR_A).
+        assert summary.latest_dps == Decimal("0.5000")
+        assert summary.latest_dividend_at == date(2025, 12, 28)
+
+    def test_zero_quarter_excluded_from_history(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # dividend_history is "paying periods only" — a skipped-dividend
+        # quarter (dps=0) must not appear on the chart, even though the
+        # row is live in financial_periods.
+        iid = _seed_instrument(ebull_test_conn, symbol="ZEROH")
+        for q, m, amt in [(1, 3, 0.50), (2, 6, 0.0), (3, 9, 0.50)]:
+            _seed_period(
+                ebull_test_conn,
+                instrument_id=iid,
+                period_end=date(2025, m, 28),
+                period_type=f"Q{q}",
+                fiscal_year=2025,
+                fiscal_quarter=q,
+                dps_declared=amt,
+            )
+        history = get_dividend_history(ebull_test_conn, instrument_id=iid)
+        assert [p.period_end_date for p in history] == [date(2025, 9, 28), date(2025, 3, 28)]
+        assert all(p.dps_declared is not None and p.dps_declared > 0 for p in history)
+
+    def test_superseded_row_excluded(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # Mirrors the live-row guard used throughout sql/032 — a restated
+        # or withdrawn period cannot leak into either the has_dividend
+        # filter or the chart.
+        iid = _seed_instrument(ebull_test_conn, symbol="SUPR")
+        _seed_period(
+            ebull_test_conn,
+            instrument_id=iid,
+            period_end=date(2025, 12, 28),
+            period_type="Q4",
+            fiscal_year=2025,
+            fiscal_quarter=4,
+            dps_declared=0.50,
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "UPDATE financial_periods SET superseded_at = NOW() WHERE instrument_id = %s",
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        summary = get_dividend_summary(ebull_test_conn, instrument_id=iid)
+        assert summary.has_dividend is False
+        history = get_dividend_history(ebull_test_conn, instrument_id=iid)
+        assert history == []
+
+    def test_fy_row_does_not_duplicate_quarter_in_history(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # Some issuers report both FY and Q4 with the same period_end_date.
+        # history surfaces QUARTERLY only so the chart doesn't double-render
+        # the fiscal year's dividend (FY dps = Q1+Q2+Q3+Q4 aggregate).
+        iid = _seed_instrument(ebull_test_conn, symbol="FYMIX")
+        _seed_period(
+            ebull_test_conn,
+            instrument_id=iid,
+            period_end=date(2025, 12, 31),
+            period_type="Q4",
+            fiscal_year=2025,
+            fiscal_quarter=4,
+            dps_declared=0.25,
+        )
+        _seed_period(
+            ebull_test_conn,
+            instrument_id=iid,
+            period_end=date(2025, 12, 31),
+            period_type="FY",
+            fiscal_year=2025,
+            fiscal_quarter=None,
+            dps_declared=1.00,
+        )
+        history = get_dividend_history(ebull_test_conn, instrument_id=iid)
+        assert len(history) == 1
+        assert history[0].period_type == "Q4"
+
+        # Summary's latest resolver must tie-break Q4 over FY deterministically.
+        summary = get_dividend_summary(ebull_test_conn, instrument_id=iid)
+        assert summary.latest_dps == Decimal("0.2500")
+
+    def test_aggregate_only_payer_still_flags_has_dividend(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # Some filers publish only dividends_paid (aggregate) without a
+        # per-share figure — still a dividend payer.
+        iid = _seed_instrument(ebull_test_conn, symbol="AGGR")
+        _seed_period(
+            ebull_test_conn,
+            instrument_id=iid,
+            period_end=date(2025, 12, 28),
+            period_type="Q4",
+            fiscal_year=2025,
+            fiscal_quarter=4,
+            dps_declared=None,
+            dividends_paid=10_000_000,
+        )
+        summary = get_dividend_summary(ebull_test_conn, instrument_id=iid)
+        assert summary.has_dividend is True
+        assert summary.ttm_dps is None
+
+
+class TestGetDividendHistory:
+    def test_newest_first_ordering(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="ORDR")
+        for q, m in [(1, 3), (2, 6), (3, 9), (4, 12)]:
+            _seed_period(
+                ebull_test_conn,
+                instrument_id=iid,
+                period_end=date(2025, m, 28),
+                period_type=f"Q{q}",
+                fiscal_year=2025,
+                fiscal_quarter=q,
+                dps_declared=0.25,
+            )
+        history = get_dividend_history(ebull_test_conn, instrument_id=iid)
+        assert len(history) == 4
+        assert [p.period_end_date for p in history] == [
+            date(2025, 12, 28),
+            date(2025, 9, 28),
+            date(2025, 6, 28),
+            date(2025, 3, 28),
+        ]
+
+    def test_excludes_periods_without_dividend(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="EXCL")
+        _seed_period(
+            ebull_test_conn,
+            instrument_id=iid,
+            period_end=date(2025, 3, 28),
+            period_type="Q1",
+            fiscal_year=2025,
+            fiscal_quarter=1,
+            dps_declared=0.25,
+        )
+        # NULL dividend period — should be filtered out.
+        _seed_period(
+            ebull_test_conn,
+            instrument_id=iid,
+            period_end=date(2025, 6, 28),
+            period_type="Q2",
+            fiscal_year=2025,
+            fiscal_quarter=2,
+            dps_declared=None,
+            dividends_paid=None,
+        )
+        history = get_dividend_history(ebull_test_conn, instrument_id=iid)
+        assert len(history) == 1
+        assert history[0].period_end_date == date(2025, 3, 28)
+
+    def test_limit_out_of_range_raises(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        with pytest.raises(ValueError, match="limit must be"):
+            get_dividend_history(ebull_test_conn, instrument_id=1, limit=0)
+        with pytest.raises(ValueError, match="limit must be"):
+            get_dividend_history(ebull_test_conn, instrument_id=1, limit=401)


### PR DESCRIPTION
## What
Surface dividend facts already captured via the daily SEC companyfacts path. No new HTTP. No new ingest. SEC EDGAR is free, unlimited, 10 rps shared throttle already respected.

1. **sql/050_dividend_history_views.sql** — two VIEWs on top of \`financial_periods\`:
   - \`dividend_history\` — long, one row per paying quarter (newest-first); excludes FY rows (would double-count Q1+Q2+Q3+Q4) and superseded rows.
   - \`instrument_dividend_summary\` — one row per instrument with \`ttm_dps\` / \`ttm_yield_pct\` / \`latest_dps\` / \`dividend_streak_q\` / \`has_dividend\`.
2. **\`app/services/dividends.py\`** — \`get_dividend_summary\` + \`get_dividend_history\` wrappers.
3. **GET \`/instruments/{symbol}/dividends\`** — summary + history. Empty shape (not 404) for never-payers.
4. **GET \`/instruments?has_dividend=true|false\`** — list filter.

## Why
User ask: \"filter on dividend-providing businesses, understand what the yield is, when it pays out, how much per stock was issued over time\". All derivable from \`us-gaap:CommonStockDividendsPerShareDeclared\` + \`us-gaap:PaymentsOfDividends\`, both already in \`financial_periods\`. Zero new dependency, zero rate-limit exposure.

## Codex review (pre-push)
HIGH findings addressed before push:
- Zero-dps rows were leaking into \`latest_*\` + history. Fixed: require strictly positive amount.
- Superseded rows were leaking. Fixed: every read filters \`superseded_at IS NULL\`.
- FY + Q4 on shared \`period_end_date\` double-counted. Fixed: history is quarterly-only; summary tie-breaks Q4 > FY.

## Test plan
- [x] \`uv run pytest\` — 2401 passed, 1 skipped
- [x] \`uv run ruff check .\` + \`format --check\`
- [x] \`uv run pyright\`
- [x] 10 service tests against ebull_test pin: never-paid → empty shape; TTM sums last 4 quarters; streak walks full history; aggregate-only filers still flag has_dividend; zero quarter excluded from history; superseded row excluded; FY row does not duplicate Q4.
- [x] API tests (mocked service) pin: 200 shape; unknown symbol 404; limit out-of-range 422; filter composes correct SQL.

## Scope boundary
Frontend dividend panel (instrument page chart + list filter control) ships in a follow-up PR so this one stays backend-only and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)