### PR TITLE
fix(#325): flip raw_retention_dry_run default to False

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -130,10 +130,14 @@ class Settings(BaseSettings):
 
     # Raw-data retention sweep job (#268 follow-up Plan A).
     # When True, ``raw_data_retention_sweep`` logs counts per source
-    # but does NOT delete any files. Operator flips to False only
-    # after observing one dry-run cycle's output and confirming the
-    # expected reclaim volume.
-    raw_retention_dry_run: bool = True
+    # but does NOT delete any files. Default flipped to False under
+    # #325 after dry-run cycles confirmed the reclaim volume and
+    # nothing downstream reads from ``data/raw/`` post-ingest. Env
+    # override ``EBULL_RAW_RETENTION_DRY_RUN=true`` still available
+    # for operators who need a one-run pause (e.g. before a manual
+    # audit). See ``_RETENTION_POLICY`` in
+    # ``app/services/raw_persistence.py`` for per-source max_age.
+    raw_retention_dry_run: bool = False
 
     # Chunk L: dedupe SEC filings fetch. When True,
     # ``daily_research_refresh`` skips its SEC EDGAR filings fetch

--- a/tests/test_raw_retention.py
+++ b/tests/test_raw_retention.py
@@ -347,6 +347,22 @@ class TestSchedulerWiring:
         job = next(j for j in SCHEDULED_JOBS if j.name == JOB_RAW_DATA_RETENTION_SWEEP)
         assert job.catch_up_on_boot is False
 
+    def test_dry_run_default_is_false_under_issue_325(self) -> None:
+        """Default is no-longer-dry-run — #325 flipped 2026-04-24.
+
+        The retention sweep wrote zero deletions for weeks in dry-run
+        mode, growing ``data/raw/`` past 30 GB. Flipped to False so
+        age-sweep actually reclaims disk on the next daily run.
+        Operators can still force dry-run for one cycle via env var
+        ``EBULL_RAW_RETENTION_DRY_RUN=true``.
+        """
+        # Import Settings class directly — Settings() instantiation is
+        # bypassed so environment overrides do not influence this test.
+        from app.config import Settings
+
+        defaults = Settings.model_fields["raw_retention_dry_run"]
+        assert defaults.default is False
+
 
 # ---------------------------------------------------------------------
 # Integration: end-to-end dedup on real filesystem


### PR DESCRIPTION
## What
Default flips so the daily \`raw_data_retention_sweep\` actually deletes. ``data/raw/`` has grown past 30 GB since retention shipped in dry-run mode; audit 2026-04-24 confirmed nothing downstream reads from that directory post-ingest.

## Why
#325 was filed specifically for this flip. Dry-run was an operator-gated check that never got flipped. Per-source policy in \`_RETENTION_POLICY\` is intentional:
- \`sec\`, \`sec_fundamentals\`, \`companies_house\`: exact-hash compaction only (\`max_age_days=None\`).
- \`etoro\`: 7 days. \`etoro_broker\`: 90 days. \`fmp\`: 30 days.

Env override \`EBULL_RAW_RETENTION_DRY_RUN=true\` remains for one-shot operator pauses.

## Test plan
- [x] \`uv run pytest\` — 2403 passed, 1 skipped
- [x] \`uv run ruff check . && format --check\`
- [x] \`uv run pyright\`
- [x] New test \`test_dry_run_default_is_false_under_issue_325\` pins the default so a silent revert fails loudly.
- [x] Manual grep for ``data/raw/`` readers — empty outside retention sweep.

Closes #325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)