### PR TITLE
feat(#433): frontend dividend panel + SEC profile panel + has_dividend filter

### DIFF
--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -13,6 +13,7 @@ export interface InstrumentsQuery {
   sector: string | null;
   coverage_tier: number | null;
   exchange: string | null;
+  has_dividend: boolean | null;
   offset: number;
   limit: number;
 }
@@ -28,10 +29,93 @@ export function fetchInstruments(
   if (query.coverage_tier !== null)
     params.set("coverage_tier", String(query.coverage_tier));
   if (query.exchange !== null) params.set("exchange", query.exchange);
+  if (query.has_dividend !== null)
+    params.set("has_dividend", String(query.has_dividend));
   params.set("offset", String(query.offset));
   params.set("limit", String(query.limit));
   const qs = params.toString();
   return apiFetch<InstrumentListResponse>(`/instruments?${qs}`);
+}
+
+// ---------------------------------------------------------------------------
+// Dividend + SEC profile endpoints (#426 / #427)
+// ---------------------------------------------------------------------------
+
+export interface DividendPeriod {
+  period_end_date: string;
+  period_type: string;
+  fiscal_year: number;
+  fiscal_quarter: number | null;
+  dps_declared: string | null;
+  dividends_paid: string | null;
+  reported_currency: string | null;
+}
+
+export interface DividendSummary {
+  has_dividend: boolean;
+  ttm_dps: string | null;
+  ttm_dividends_paid: string | null;
+  ttm_yield_pct: string | null;
+  latest_dps: string | null;
+  latest_dividend_at: string | null;
+  dividend_streak_q: number;
+  dividend_currency: string | null;
+}
+
+export interface InstrumentDividends {
+  symbol: string;
+  summary: DividendSummary;
+  history: DividendPeriod[];
+}
+
+export function fetchInstrumentDividends(
+  symbol: string,
+): Promise<InstrumentDividends> {
+  return apiFetch<InstrumentDividends>(
+    `/instruments/${encodeURIComponent(symbol)}/dividends`,
+  );
+}
+
+export interface FormerName {
+  name: string;
+  from_: string | null;
+  to: string | null;
+}
+
+export interface InstrumentSecProfile {
+  symbol: string;
+  cik: string;
+  sic: string | null;
+  sic_description: string | null;
+  owner_org: string | null;
+  description: string | null;
+  website: string | null;
+  investor_website: string | null;
+  ein: string | null;
+  lei: string | null;
+  state_of_incorporation: string | null;
+  state_of_incorporation_desc: string | null;
+  fiscal_year_end: string | null;
+  category: string | null;
+  exchanges: string[];
+  former_names: FormerName[];
+  has_insider_issuer: boolean | null;
+  has_insider_owner: boolean | null;
+}
+
+/** Returns null on 404 (profile not seeded yet), rethrows other errors. */
+export async function fetchInstrumentSecProfile(
+  symbol: string,
+): Promise<InstrumentSecProfile | null> {
+  try {
+    return await apiFetch<InstrumentSecProfile>(
+      `/instruments/${encodeURIComponent(symbol)}/sec_profile`,
+    );
+  } catch (err) {
+    const { ApiError } = await import("@/api/client");
+    if (err instanceof ApiError && err.status === 404) return null;
+    throw err;
+  }
 }
 
 export function fetchInstrumentDetail(

--- a/frontend/src/components/instrument/DividendsPanel.test.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { InstrumentDividends } from "@/api/instruments";
+
+import { DividendsPanel } from "./DividendsPanel";
+
+vi.mock("@/api/instruments", () => ({
+  fetchInstrumentDividends: vi.fn(),
+}));
+
+import { fetchInstrumentDividends } from "@/api/instruments";
+const mockFetch = vi.mocked(fetchInstrumentDividends);
+
+
+function paid(): InstrumentDividends {
+  return {
+    symbol: "AAPL",
+    summary: {
+      has_dividend: true,
+      ttm_dps: "1.0000",
+      ttm_dividends_paid: "15000000000.0000",
+      ttm_yield_pct: "0.52",
+      latest_dps: "0.2500",
+      latest_dividend_at: "2025-12-28",
+      dividend_streak_q: 40,
+      dividend_currency: "USD",
+    },
+    history: [
+      {
+        period_end_date: "2025-12-28",
+        period_type: "Q4",
+        fiscal_year: 2025,
+        fiscal_quarter: 4,
+        dps_declared: "0.2500",
+        dividends_paid: "4000000000.0000",
+        reported_currency: "USD",
+      },
+      {
+        period_end_date: "2025-09-28",
+        period_type: "Q3",
+        fiscal_year: 2025,
+        fiscal_quarter: 3,
+        dps_declared: "0.2500",
+        dividends_paid: "3900000000.0000",
+        reported_currency: "USD",
+      },
+    ],
+  };
+}
+
+
+function notPaid(): InstrumentDividends {
+  return {
+    symbol: "GOOG",
+    summary: {
+      has_dividend: false,
+      ttm_dps: null,
+      ttm_dividends_paid: null,
+      ttm_yield_pct: null,
+      latest_dps: null,
+      latest_dividend_at: null,
+      dividend_streak_q: 0,
+      dividend_currency: null,
+    },
+    history: [],
+  };
+}
+
+
+afterEach(() => vi.clearAllMocks());
+
+
+describe("DividendsPanel", () => {
+  it("renders summary + per-quarter history for a paying instrument", async () => {
+    mockFetch.mockResolvedValue(paid());
+    render(<DividendsPanel symbol="AAPL" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/TTM yield/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/0.52%/)).toBeInTheDocument();
+    expect(screen.getByText(/FY2025 Q4/)).toBeInTheDocument();
+    expect(screen.getByText(/FY2025 Q3/)).toBeInTheDocument();
+    expect(screen.getByText(/Consecutive quarters/i)).toBeInTheDocument();
+    expect(screen.getByText("40")).toBeInTheDocument();
+  });
+
+  it("renders empty state when never-paid", async () => {
+    mockFetch.mockResolvedValue(notPaid());
+    render(<DividendsPanel symbol="GOOG" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No dividend history on file/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/TTM yield/i)).not.toBeInTheDocument();
+  });
+
+  it("renders error state + retry on fetch failure", async () => {
+    mockFetch.mockRejectedValue(new Error("boom"));
+    render(<DividendsPanel symbol="AAPL" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/instrument/DividendsPanel.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.tsx
@@ -1,0 +1,135 @@
+/**
+ * DividendsPanel — TTM yield + per-quarter history for the instrument
+ * page. Backed by GET /instruments/{symbol}/dividends.
+ *
+ * Never-paid instruments render an explicit empty state rather than a
+ * 404 or a zero row.
+ */
+
+import { fetchInstrumentDividends } from "@/api/instruments";
+import type { DividendPeriod, InstrumentDividends } from "@/api/instruments";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+import { useCallback } from "react";
+
+export interface DividendsPanelProps {
+  readonly symbol: string;
+}
+
+function formatDps(raw: string | null, currency: string | null): string {
+  if (raw === null) return "—";
+  const num = Number(raw);
+  if (!Number.isFinite(num)) return "—";
+  return `${currency ?? ""}${currency ? " " : ""}${num.toFixed(4).replace(/\.?0+$/, "")}`.trim();
+}
+
+function formatYieldPct(raw: string | null): string {
+  if (raw === null) return "—";
+  const num = Number(raw);
+  if (!Number.isFinite(num)) return "—";
+  return `${num.toFixed(2)}%`;
+}
+
+function HistoryBar({ period, max }: { period: DividendPeriod; max: number }) {
+  const num = period.dps_declared !== null ? Number(period.dps_declared) : 0;
+  const pct = max > 0 ? Math.min(100, (num / max) * 100) : 0;
+  const label = `FY${period.fiscal_year} ${period.period_type}`;
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span className="w-20 shrink-0 text-slate-500">{label}</span>
+      <div className="h-3 flex-1 rounded-sm bg-slate-100">
+        <div
+          className="h-full rounded-sm bg-sky-500"
+          style={{ width: `${pct}%` }}
+          role="progressbar"
+          aria-valuenow={num}
+          aria-valuemin={0}
+          aria-valuemax={max}
+          aria-label={`DPS ${num} in ${label}`}
+        />
+      </div>
+      <span className="w-16 shrink-0 text-right font-mono tabular-nums text-slate-700">
+        {formatDps(period.dps_declared, period.reported_currency)}
+      </span>
+    </div>
+  );
+}
+
+export function DividendsPanel({ symbol }: DividendsPanelProps) {
+  const state = useAsync<InstrumentDividends>(
+    useCallback(() => fetchInstrumentDividends(symbol), [symbol]),
+    [symbol],
+  );
+
+  return (
+    <Section title="Dividends">
+      {state.loading ? (
+        <SectionSkeleton rows={3} />
+      ) : state.error !== null || state.data === null ? (
+        <SectionError onRetry={state.refetch} />
+      ) : !state.data.summary.has_dividend || state.data.history.length === 0 ? (
+        <EmptyState
+          title="No dividend history on file"
+          description="This instrument has not reported a positive dividend in its SEC filings."
+        />
+      ) : (
+        <DividendsBody data={state.data} />
+      )}
+    </Section>
+  );
+}
+
+function DividendsBody({ data }: { data: InstrumentDividends }) {
+  const { summary, history } = data;
+  const max = history.reduce((acc, p) => {
+    if (p.dps_declared === null) return acc;
+    const n = Number(p.dps_declared);
+    return Number.isFinite(n) && n > acc ? n : acc;
+  }, 0);
+
+  return (
+    <div className="space-y-4">
+      {/* Summary row */}
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+        <dt className="text-slate-500">TTM yield</dt>
+        <dd className="font-semibold text-emerald-700">
+          {formatYieldPct(summary.ttm_yield_pct)}
+        </dd>
+        <dt className="text-slate-500">TTM DPS</dt>
+        <dd>{formatDps(summary.ttm_dps, summary.dividend_currency)}</dd>
+        <dt className="text-slate-500">Latest DPS</dt>
+        <dd>
+          {formatDps(summary.latest_dps, summary.dividend_currency)}
+          {summary.latest_dividend_at !== null && (
+            <span className="ml-2 text-xs text-slate-500">
+              period end {summary.latest_dividend_at}
+            </span>
+          )}
+        </dd>
+        <dt className="text-slate-500">Consecutive quarters</dt>
+        <dd>{summary.dividend_streak_q}</dd>
+      </dl>
+
+      {/* Per-quarter history */}
+      <div>
+        <div className="mb-1 text-xs font-medium uppercase tracking-wider text-slate-500">
+          Per-quarter DPS
+        </div>
+        <div className="space-y-1">
+          {history.map((p) => (
+            <HistoryBar
+              key={`${p.period_end_date}-${p.period_type}`}
+              period={p}
+              max={max}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/ResearchTab.tsx
+++ b/frontend/src/components/instrument/ResearchTab.tsx
@@ -7,6 +7,8 @@
  * Red-flag surfacing and peer context come in Slice 2 (right rail).
  */
 import { Section } from "@/components/dashboard/Section";
+import { DividendsPanel } from "@/components/instrument/DividendsPanel";
+import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
 import { EmptyState } from "@/components/states/EmptyState";
 import type { InstrumentSummary, ThesisDetail } from "@/api/types";
 
@@ -168,6 +170,9 @@ export function ResearchTab({
 
   return (
     <div className="grid gap-4 md:grid-cols-2">
+      <SecProfilePanel symbol={summary.identity.symbol} />
+      <DividendsPanel symbol={summary.identity.symbol} />
+
       <Section title="Key statistics">
         {stats === null ? (
           <EmptyState

--- a/frontend/src/components/instrument/SecProfilePanel.test.tsx
+++ b/frontend/src/components/instrument/SecProfilePanel.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { InstrumentSecProfile } from "@/api/instruments";
+
+import { SecProfilePanel } from "./SecProfilePanel";
+
+vi.mock("@/api/instruments", () => ({
+  fetchInstrumentSecProfile: vi.fn(),
+}));
+
+import { fetchInstrumentSecProfile } from "@/api/instruments";
+const mockFetch = vi.mocked(fetchInstrumentSecProfile);
+
+
+function seededProfile(): InstrumentSecProfile {
+  return {
+    symbol: "AAPL",
+    cik: "0000320193",
+    sic: "3571",
+    sic_description: "Electronic Computers",
+    owner_org: "06 Technology",
+    description: "Designs consumer electronics.",
+    website: "https://apple.com",
+    investor_website: null,
+    ein: "EIN",
+    lei: null,
+    state_of_incorporation: "CA",
+    state_of_incorporation_desc: "California",
+    fiscal_year_end: "0930",
+    category: "Large accelerated filer",
+    exchanges: ["NASDAQ"],
+    former_names: [
+      {
+        name: "APPLE COMPUTER INC",
+        from_: "1977-01-01T00:00:00.000Z",
+        to: "2007-01-09T00:00:00.000Z",
+      },
+    ],
+    has_insider_issuer: true,
+    has_insider_owner: true,
+  };
+}
+
+
+afterEach(() => vi.clearAllMocks());
+
+
+describe("SecProfilePanel", () => {
+  it("renders description + SIC + exchanges + former names + insider badge", async () => {
+    mockFetch.mockResolvedValue(seededProfile());
+    render(<SecProfilePanel symbol="AAPL" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Designs consumer electronics/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Electronic Computers/)).toBeInTheDocument();
+    expect(screen.getByText(/NASDAQ/)).toBeInTheDocument();
+    expect(screen.getByText(/Large accelerated filer/)).toBeInTheDocument();
+    expect(screen.getByText(/APPLE COMPUTER INC/)).toBeInTheDocument();
+    expect(screen.getByText(/Insider activity recorded/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sep 30/i)).toBeInTheDocument();
+  });
+
+  it("renders empty state when profile is null (404)", async () => {
+    mockFetch.mockResolvedValue(null);
+    render(<SecProfilePanel symbol="NOSEC" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No SEC profile yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders error state on non-404 fetch failure", async () => {
+    mockFetch.mockRejectedValue(new Error("500"));
+    render(<SecProfilePanel symbol="AAPL" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/instrument/SecProfilePanel.tsx
+++ b/frontend/src/components/instrument/SecProfilePanel.tsx
@@ -1,0 +1,173 @@
+/**
+ * SecProfilePanel — SEC-sourced entity metadata for the instrument
+ * page. Backed by GET /instruments/{symbol}/sec_profile (#427).
+ *
+ * Surfaces authentic business description, SIC sector, exchange
+ * listings, former names, insider-activity flags. Replaces the
+ * yfinance long_business_summary blurb as the primary description
+ * source for US-mapped tickers.
+ */
+
+import { fetchInstrumentSecProfile } from "@/api/instruments";
+import type { InstrumentSecProfile } from "@/api/instruments";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+import { useCallback } from "react";
+
+export interface SecProfilePanelProps {
+  readonly symbol: string;
+}
+
+export function SecProfilePanel({ symbol }: SecProfilePanelProps) {
+  const state = useAsync<InstrumentSecProfile | null>(
+    useCallback(() => fetchInstrumentSecProfile(symbol), [symbol]),
+    [symbol],
+  );
+
+  return (
+    <Section title="Company profile (SEC)">
+      {state.loading ? (
+        <SectionSkeleton rows={4} />
+      ) : state.error !== null ? (
+        <SectionError onRetry={state.refetch} />
+      ) : state.data === null ? (
+        <EmptyState
+          title="No SEC profile yet"
+          description="This instrument has no primary CIK mapping, or the daily SEC ingest has not yet seeded its entity row. Non-US tickers will not have one."
+        />
+      ) : (
+        <Body profile={state.data} />
+      )}
+    </Section>
+  );
+}
+
+function Body({ profile }: { profile: InstrumentSecProfile }) {
+  return (
+    <div className="space-y-3 text-sm">
+      {profile.description !== null && profile.description.length > 0 && (
+        <p className="leading-relaxed text-slate-700">{profile.description}</p>
+      )}
+
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+        {profile.sic_description !== null && (
+          <>
+            <dt className="text-slate-500">Industry (SIC)</dt>
+            <dd>
+              {profile.sic_description}
+              {profile.sic !== null && (
+                <span className="ml-1 text-xs text-slate-400">({profile.sic})</span>
+              )}
+            </dd>
+          </>
+        )}
+        {profile.owner_org !== null && (
+          <>
+            <dt className="text-slate-500">SEC sector</dt>
+            <dd>{profile.owner_org}</dd>
+          </>
+        )}
+        {profile.exchanges.length > 0 && (
+          <>
+            <dt className="text-slate-500">Exchanges</dt>
+            <dd>{profile.exchanges.join(", ")}</dd>
+          </>
+        )}
+        {profile.category !== null && (
+          <>
+            <dt className="text-slate-500">Filer category</dt>
+            <dd>{profile.category}</dd>
+          </>
+        )}
+        {profile.fiscal_year_end !== null && (
+          <>
+            <dt className="text-slate-500">Fiscal year end</dt>
+            <dd>{formatFiscalYearEnd(profile.fiscal_year_end)}</dd>
+          </>
+        )}
+        {profile.state_of_incorporation_desc !== null && (
+          <>
+            <dt className="text-slate-500">Incorporated</dt>
+            <dd>{profile.state_of_incorporation_desc}</dd>
+          </>
+        )}
+        <dt className="text-slate-500">CIK</dt>
+        <dd className="font-mono text-xs text-slate-600">{profile.cik}</dd>
+      </dl>
+
+      {profile.website !== null && (
+        <div>
+          <a
+            href={profile.website}
+            className="text-xs text-sky-600 hover:underline"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {profile.website}
+          </a>
+        </div>
+      )}
+
+      {profile.former_names.length > 0 && (
+        <div>
+          <div className="mb-1 text-xs font-medium uppercase tracking-wider text-slate-500">
+            Former names
+          </div>
+          <ul className="list-inside list-disc text-xs text-slate-600">
+            {profile.former_names.map((fn, i) => (
+              <li key={`${fn.name}-${i}`}>
+                {fn.name}
+                {fn.from_ !== null && fn.to !== null && (
+                  <span className="ml-1 text-slate-400">
+                    ({fn.from_.slice(0, 10)} → {fn.to.slice(0, 10)})
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {(profile.has_insider_issuer || profile.has_insider_owner) && (
+        <div className="text-xs text-slate-500">
+          <span className="mr-2 inline-block rounded bg-amber-100 px-1.5 py-0.5 font-medium text-amber-800">
+            Insider activity recorded
+          </span>
+          Form 4 filings on SEC EDGAR (detailed list pending #429).
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * SEC publishes fiscalYearEnd as "MMDD" (e.g. "0930" = Sept 30).
+ * Render as a month/day string; fall back to the raw value if parse
+ * fails.
+ */
+function formatFiscalYearEnd(raw: string): string {
+  if (raw.length !== 4 || !/^\d{4}$/.test(raw)) return raw;
+  const month = Number.parseInt(raw.slice(0, 2), 10);
+  const day = Number.parseInt(raw.slice(2, 4), 10);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return raw;
+  const months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+  return `${months[month - 1]} ${day}`;
+}

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -32,6 +32,7 @@ interface Filters {
   sector: string | null;
   exchange: string | null;
   coverage_tier: number | null;
+  has_dividend: boolean | null;
 }
 
 const INITIAL_FILTERS: Filters = {
@@ -39,6 +40,7 @@ const INITIAL_FILTERS: Filters = {
   sector: null,
   exchange: null,
   coverage_tier: null,
+  has_dividend: null,
 };
 
 // ---------------------------------------------------------------------------
@@ -129,6 +131,7 @@ export function InstrumentsPage() {
       sector: filters.sector,
       exchange: filters.exchange,
       coverage_tier: filters.coverage_tier,
+      has_dividend: filters.has_dividend,
       offset: page * INSTRUMENTS_PAGE_LIMIT,
       limit: INSTRUMENTS_PAGE_LIMIT,
     }),
@@ -192,8 +195,11 @@ export function InstrumentsPage() {
     : 0;
 
   const handleFilterChange = useCallback(
-    (key: keyof Omit<Filters, "search">, value: string | number | null) => {
-      setFilters((prev) => ({ ...prev, [key]: value || null }));
+    (
+      key: keyof Omit<Filters, "search">,
+      value: string | number | boolean | null,
+    ) => {
+      setFilters((prev) => ({ ...prev, [key]: value === "" ? null : value }));
       setPage(0);
     },
     [],
@@ -257,6 +263,29 @@ export function InstrumentsPage() {
             <option value="3">Tier 3</option>
           </select>
         </div>
+        <div>
+          <label
+            htmlFor="filter-has-dividend"
+            className="mb-1 block text-xs font-medium text-slate-600"
+          >
+            Dividend
+          </label>
+          <label className="flex items-center gap-2 rounded border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-700">
+            <input
+              id="filter-has-dividend"
+              type="checkbox"
+              checked={filters.has_dividend === true}
+              onChange={(e) =>
+                handleFilterChange(
+                  "has_dividend",
+                  e.target.checked ? true : null,
+                )
+              }
+              className="h-4 w-4"
+            />
+            <span>Only dividend-paying</span>
+          </label>
+        </div>
       </div>
 
       <Section title="Results">
@@ -268,7 +297,11 @@ export function InstrumentsPage() {
           <EmptyState
             title="No instruments found"
             description={
-              filters.search || filters.sector || filters.exchange || filters.coverage_tier !== null
+              filters.search ||
+              filters.sector ||
+              filters.exchange ||
+              filters.coverage_tier !== null ||
+              filters.has_dividend !== null
                 ? "Try adjusting your search or filters."
                 : "No instruments have been synced yet. Run the universe sync job from the Admin page."
             }


### PR DESCRIPTION
## What
UI half of #426 (dividends) + #427 (SEC entity metadata). Consumes endpoints that already shipped on main.

### Instrument page
- **DividendsPanel** — TTM yield + DPS, latest DPS, streak, per-quarter bar chart. Empty state for never-payers.
- **SecProfilePanel** — real business description (SEC Item 1-sourced description / ownerOrg / SIC / exchanges / former names / insider-activity badge). Replaces yfinance \`long_business_summary\` as primary on US tickers.
- Both mounted at top of ResearchTab.

### Instruments list
- **\`Only dividend-paying\`** checkbox — wires to backend \`has_dividend=true\` query param (#426).
- \`handleFilterChange\` signature widened to accept booleans.

## Test plan
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test:unit\` — 383 passed (new: 3 DividendsPanel + 3 SecProfilePanel)
- [x] \`uv run pytest\` — 2425 passed, 1 skipped
- [x] \`uv run ruff check\` + \`format --check\`
- [x] \`uv run pyright\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)