### PR TITLE
feat(#435): dilution tracker — share-count history + YoY badge

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -756,6 +756,105 @@ def get_instrument_sec_profile(
 
 
 # ---------------------------------------------------------------------------
+# Dilution + share-count history (#435)
+# ---------------------------------------------------------------------------
+
+
+class ShareCountPeriodModel(BaseModel):
+    period_end: date
+    fiscal_year: int | None
+    fiscal_period: str | None
+    shares_outstanding: Decimal | None
+    shares_issued_new: Decimal | None
+    buyback_shares: Decimal | None
+
+
+class DilutionSummaryModel(BaseModel):
+    latest_shares: Decimal | None
+    latest_as_of: date | None
+    yoy_shares: Decimal | None
+    net_dilution_pct_yoy: Decimal | None
+    ttm_shares_issued: Decimal | None
+    ttm_buyback_shares: Decimal | None
+    ttm_net_share_change: Decimal | None
+    dilution_posture: Literal["dilutive", "buyback_heavy", "stable"]
+
+
+class InstrumentDilution(BaseModel):
+    symbol: str
+    summary: DilutionSummaryModel
+    history: list[ShareCountPeriodModel]
+
+
+@router.get("/{symbol}/dilution", response_model=InstrumentDilution)
+def get_instrument_dilution(
+    symbol: str,
+    limit: int = Query(default=40, ge=1, le=200),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> InstrumentDilution:
+    """Per-period share count + TTM dilution summary (#435).
+
+    Source: SEC XBRL facts already ingested via the daily
+    ``fundamentals_sync`` path (``StockIssuedDuringPeriodSharesNewIssues``,
+    ``StockRepurchasedDuringPeriodShares``, ``CommonStockSharesOutstanding``,
+    ``dei:EntityCommonStockSharesOutstanding``). Returns the
+    ``stable`` empty shape for never-seeded / non-US tickers — UI
+    renders an empty state without 404 handling.
+
+    Default ``limit=40`` covers ten years of quarterly history.
+    """
+    from app.services.dilution import get_dilution_summary, get_share_count_history
+
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    summary = get_dilution_summary(conn, instrument_id=instrument_id)
+    history = get_share_count_history(conn, instrument_id=instrument_id, limit=limit)
+
+    return InstrumentDilution(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        summary=DilutionSummaryModel(
+            latest_shares=summary.latest_shares,
+            latest_as_of=summary.latest_as_of,
+            yoy_shares=summary.yoy_shares,
+            net_dilution_pct_yoy=summary.net_dilution_pct_yoy,
+            ttm_shares_issued=summary.ttm_shares_issued,
+            ttm_buyback_shares=summary.ttm_buyback_shares,
+            ttm_net_share_change=summary.ttm_net_share_change,
+            dilution_posture=summary.dilution_posture,
+        ),
+        history=[
+            ShareCountPeriodModel(
+                period_end=p.period_end,
+                fiscal_year=p.fiscal_year,
+                fiscal_period=p.fiscal_period,
+                shares_outstanding=p.shares_outstanding,
+                shares_issued_new=p.shares_issued_new,
+                buyback_shares=p.buyback_shares,
+            )
+            for p in history
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
 # Dividend history + summary (#414 follow-up, operator ask 2026-04-24)
 # ---------------------------------------------------------------------------
 

--- a/app/services/dilution.py
+++ b/app/services/dilution.py
@@ -1,0 +1,174 @@
+"""Share-count + dilution service (#435).
+
+Reads from views defined in sql/052 on top of facts already ingested
+by the daily ``fundamentals_sync`` path (#430 expanded TRACKED_CONCEPTS
++ added DEI extraction). Zero new HTTP.
+
+Drives:
+  - instrument-page "Share count" chart + dilution badge
+  - ranking-engine quality sub-score (net dilution YoY penalty)
+  - live market-cap derivation (shares × close) — retires part of
+    the yfinance profile path under #432.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+import psycopg.rows
+
+DilutionPosture = Literal["dilutive", "buyback_heavy", "stable"]
+
+
+@dataclass(frozen=True)
+class ShareCountPeriod:
+    period_end: date
+    fiscal_year: int | None
+    fiscal_period: str | None
+    shares_outstanding: Decimal | None
+    shares_issued_new: Decimal | None
+    buyback_shares: Decimal | None
+
+
+@dataclass(frozen=True)
+class DilutionSummary:
+    latest_shares: Decimal | None
+    latest_as_of: date | None
+    yoy_shares: Decimal | None
+    net_dilution_pct_yoy: Decimal | None
+    ttm_shares_issued: Decimal | None
+    ttm_buyback_shares: Decimal | None
+    ttm_net_share_change: Decimal | None
+    dilution_posture: DilutionPosture
+
+
+@dataclass(frozen=True)
+class ShareCountLatest:
+    latest_shares: Decimal
+    as_of_date: date
+    source_taxonomy: str  # 'dei' | 'us-gaap' | 'none'
+
+
+_EMPTY_SUMMARY = DilutionSummary(
+    latest_shares=None,
+    latest_as_of=None,
+    yoy_shares=None,
+    net_dilution_pct_yoy=None,
+    ttm_shares_issued=None,
+    ttm_buyback_shares=None,
+    ttm_net_share_change=None,
+    dilution_posture="stable",
+)
+
+
+def get_share_count_history(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    limit: int = 40,
+) -> list[ShareCountPeriod]:
+    """Newest-first per-period share count + deltas. Default 10 years
+    (40 quarters); capped at 200 to prevent runaway reads."""
+    if not 1 <= limit <= 200:
+        raise ValueError(f"limit must be 1..200, got {limit}")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT period_end, fiscal_year, fiscal_period,
+                   shares_outstanding, shares_issued_new, buyback_shares
+            FROM share_count_history
+            WHERE instrument_id = %s
+            ORDER BY period_end DESC
+            LIMIT %s
+            """,
+            (instrument_id, limit),
+        )
+        rows = cur.fetchall()
+
+    return [
+        ShareCountPeriod(
+            period_end=r["period_end"],
+            fiscal_year=int(r["fiscal_year"]) if r["fiscal_year"] is not None else None,
+            fiscal_period=r["fiscal_period"],
+            shares_outstanding=r["shares_outstanding"],
+            shares_issued_new=r["shares_issued_new"],
+            buyback_shares=r["buyback_shares"],
+        )
+        for r in rows
+    ]
+
+
+def get_dilution_summary(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+) -> DilutionSummary:
+    """Roll-up across the last year. Never-paid / pre-seed returns
+    ``_EMPTY_SUMMARY`` so callers render empty-state without None
+    branching."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT latest_shares, latest_as_of, yoy_shares,
+                   net_dilution_pct_yoy,
+                   ttm_shares_issued, ttm_buyback_shares,
+                   ttm_net_share_change, dilution_posture
+            FROM instrument_dilution_summary
+            WHERE instrument_id = %s
+            """,
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        return _EMPTY_SUMMARY
+
+    posture_raw = str(row["dilution_posture"])
+    if posture_raw not in ("dilutive", "buyback_heavy", "stable"):
+        posture: DilutionPosture = "stable"
+    else:
+        posture = posture_raw  # type: ignore[assignment]
+
+    return DilutionSummary(
+        latest_shares=row["latest_shares"],
+        latest_as_of=row["latest_as_of"],
+        yoy_shares=row["yoy_shares"],
+        net_dilution_pct_yoy=row["net_dilution_pct_yoy"],
+        ttm_shares_issued=row["ttm_shares_issued"],
+        ttm_buyback_shares=row["ttm_buyback_shares"],
+        ttm_net_share_change=row["ttm_net_share_change"],
+        dilution_posture=posture,
+    )
+
+
+def get_latest_share_count(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+) -> ShareCountLatest | None:
+    """Single point-in-time newest share count. Drives live market-cap
+    derivation (``latest_shares × latest_close``)."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT latest_shares, as_of_date, source_taxonomy
+            FROM instrument_share_count_latest
+            WHERE instrument_id = %s
+            """,
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+
+    if row is None or row["latest_shares"] is None:
+        return None
+
+    return ShareCountLatest(
+        latest_shares=row["latest_shares"],
+        as_of_date=row["as_of_date"],
+        source_taxonomy=str(row["source_taxonomy"]),
+    )

--- a/sql/052_share_count_history_views.sql
+++ b/sql/052_share_count_history_views.sql
@@ -60,11 +60,16 @@ WITH latest_fact AS (
     ORDER BY f.instrument_id, f.concept, f.period_end, f.period_start,
              f.filed_date DESC, f.accession_number DESC
 )
+-- Group strictly on (instrument_id, period_end) so a 10-K/A re-tag
+-- of the same period_end under a different fiscal_year/fiscal_period
+-- cannot produce duplicate rows. We still expose one representative
+-- fiscal_year + fiscal_period via MAX() for display convenience;
+-- downstream consumers treat them as hints, not keys.
 SELECT
     instrument_id,
     period_end,
-    fiscal_year,
-    fiscal_period,
+    MAX(fiscal_year)    AS fiscal_year,
+    MAX(fiscal_period)  AS fiscal_period,
     -- Share-count snapshots — prefer DEI (entity cover page) over
     -- us-gaap when both are present, because DEI is filed by the
     -- issuer specifically as the point-in-time authoritative count.
@@ -85,7 +90,7 @@ SELECT
     MAX(form_type)  AS latest_form_type,
     MAX(filed_date) AS latest_filed_date
 FROM latest_fact
-GROUP BY instrument_id, period_end, fiscal_year, fiscal_period;
+GROUP BY instrument_id, period_end;
 
 COMMENT ON VIEW share_count_history IS
     'Per-period share-count snapshot + issuance/buyback deltas from '
@@ -98,12 +103,15 @@ COMMENT ON VIEW share_count_history IS
 -- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE VIEW instrument_dilution_summary AS
-WITH ranked AS (
+WITH outstanding_only AS (
+    -- Rank by period_end across rows that report a point-in-time
+    -- count. This is what drives the "latest" + "year-ago" slots;
+    -- flow TTM below uses a SEPARATE ranking so flow-only periods
+    -- (filer publishes issuance without matching outstanding
+    -- snapshot) still contribute to ttm totals.
     SELECT instrument_id,
            period_end,
            shares_outstanding,
-           shares_issued_new,
-           buyback_shares,
            ROW_NUMBER() OVER (
                PARTITION BY instrument_id
                ORDER BY period_end DESC
@@ -111,10 +119,26 @@ WITH ranked AS (
     FROM share_count_history
     WHERE shares_outstanding IS NOT NULL
 ),
+flow_only AS (
+    -- Independent ranking for flow TTM. No shares_outstanding filter
+    -- so a period with only issuance / buyback facts still counts
+    -- toward ttm_shares_issued / ttm_buyback_shares.
+    SELECT instrument_id,
+           period_end,
+           shares_issued_new,
+           buyback_shares,
+           ROW_NUMBER() OVER (
+               PARTITION BY instrument_id
+               ORDER BY period_end DESC
+           ) AS rn
+    FROM share_count_history
+    WHERE shares_issued_new IS NOT NULL
+       OR buyback_shares    IS NOT NULL
+),
 current_state AS (
     SELECT instrument_id, shares_outstanding AS latest_shares,
            period_end AS latest_as_of
-    FROM ranked
+    FROM outstanding_only
     WHERE rn = 1
 ),
 -- Year-ago share count (rn=5 across quarterly series, or the oldest
@@ -122,17 +146,16 @@ current_state AS (
 year_ago AS (
     SELECT DISTINCT ON (instrument_id) instrument_id,
            shares_outstanding AS yoy_shares
-    FROM ranked
+    FROM outstanding_only
     WHERE rn BETWEEN 4 AND 6
     ORDER BY instrument_id, rn ASC
 ),
--- Trailing-4-quarter deltas. Use these when the raw snapshot approach
--- is missing (filer publishes flow but no point-in-time figure).
+-- Trailing-4-quarter deltas from the flow series.
 trailing_flow AS (
     SELECT instrument_id,
            SUM(shares_issued_new) FILTER (WHERE rn <= 4) AS ttm_shares_issued,
            SUM(buyback_shares)    FILTER (WHERE rn <= 4) AS ttm_buyback_shares
-    FROM ranked
+    FROM flow_only
     GROUP BY instrument_id
 )
 SELECT

--- a/sql/052_share_count_history_views.sql
+++ b/sql/052_share_count_history_views.sql
@@ -1,0 +1,198 @@
+-- 052_share_count_history_views.sql
+--
+-- Dilution tracker (#435). User ask 2026-04-24:
+-- "how much per stock was issued over time" + "anything to bolster the
+-- rankings with".
+--
+-- Three VIEWs on top of ``financial_facts_raw`` (already populated by
+-- #430's expanded TRACKED_CONCEPTS):
+--
+--   1. ``share_count_history``     — per-period share count + deltas
+--                                    (issued, repurchased) per instrument.
+--                                    Drives the instrument-page dilution
+--                                    chart.
+--   2. ``instrument_dilution_summary`` — one row per instrument with
+--                                    trailing-year net-dilution %, latest
+--                                    share count, and buyback-heavy /
+--                                    dilutive flag. Drives ranking engine
+--                                    quality sub-score (#432 follow-up) +
+--                                    instruments-list filter.
+--   3. ``instrument_share_count_latest`` — one row per instrument with
+--                                    the newest point-in-time share
+--                                    count (dei > us-gaap > NULL). Used
+--                                    everywhere market-cap needs a fresh
+--                                    count (retires part of yfinance
+--                                    get_profile — #432).
+--
+-- Dedupe strategy: XBRL amendments re-publish the same fact under a
+-- new accession_number, so ``financial_facts_raw`` carries multiple
+-- rows per (instrument, concept, period). ``DISTINCT ON`` newest
+-- ``filed_date`` + ``accession_number`` picks the latest restated
+-- figure.
+
+-- ---------------------------------------------------------------------------
+-- 1. share_count_history — per-quarter deltas
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE VIEW share_count_history AS
+WITH latest_fact AS (
+    -- For each (instrument, concept, period), keep only the newest
+    -- filing. Amendments (10-K/A) re-state prior periods — we want the
+    -- restated number, not the original.
+    SELECT DISTINCT ON (f.instrument_id, f.concept, f.period_end, f.period_start)
+           f.instrument_id,
+           f.concept,
+           f.period_end,
+           f.period_start,
+           f.val,
+           f.form_type,
+           f.filed_date,
+           f.fiscal_year,
+           f.fiscal_period
+    FROM financial_facts_raw f
+    WHERE f.concept IN (
+        'StockIssuedDuringPeriodSharesNewIssues',
+        'StockRepurchasedDuringPeriodShares',
+        'TreasuryStockSharesAcquired',
+        'CommonStockSharesOutstanding',
+        'EntityCommonStockSharesOutstanding'
+    )
+    ORDER BY f.instrument_id, f.concept, f.period_end, f.period_start,
+             f.filed_date DESC, f.accession_number DESC
+)
+SELECT
+    instrument_id,
+    period_end,
+    fiscal_year,
+    fiscal_period,
+    -- Share-count snapshots — prefer DEI (entity cover page) over
+    -- us-gaap when both are present, because DEI is filed by the
+    -- issuer specifically as the point-in-time authoritative count.
+    MAX(val) FILTER (WHERE concept = 'EntityCommonStockSharesOutstanding') AS shares_outstanding_dei,
+    MAX(val) FILTER (WHERE concept = 'CommonStockSharesOutstanding')         AS shares_outstanding_gaap,
+    COALESCE(
+        MAX(val) FILTER (WHERE concept = 'EntityCommonStockSharesOutstanding'),
+        MAX(val) FILTER (WHERE concept = 'CommonStockSharesOutstanding')
+    ) AS shares_outstanding,
+    -- Flow columns: period-over-period deltas. Either tag for
+    -- buybacks — issuers split across them depending on how the
+    -- treasury-stock accounting method was elected.
+    MAX(val) FILTER (WHERE concept = 'StockIssuedDuringPeriodSharesNewIssues')     AS shares_issued_new,
+    COALESCE(
+        MAX(val) FILTER (WHERE concept = 'StockRepurchasedDuringPeriodShares'),
+        MAX(val) FILTER (WHERE concept = 'TreasuryStockSharesAcquired')
+    ) AS buyback_shares,
+    MAX(form_type)  AS latest_form_type,
+    MAX(filed_date) AS latest_filed_date
+FROM latest_fact
+GROUP BY instrument_id, period_end, fiscal_year, fiscal_period;
+
+COMMENT ON VIEW share_count_history IS
+    'Per-period share-count snapshot + issuance/buyback deltas from '
+    'SEC XBRL. DEI section preferred for the point-in-time count. '
+    'Populated by the daily fundamentals_sync path; no new HTTP.';
+
+
+-- ---------------------------------------------------------------------------
+-- 2. instrument_dilution_summary
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE VIEW instrument_dilution_summary AS
+WITH ranked AS (
+    SELECT instrument_id,
+           period_end,
+           shares_outstanding,
+           shares_issued_new,
+           buyback_shares,
+           ROW_NUMBER() OVER (
+               PARTITION BY instrument_id
+               ORDER BY period_end DESC
+           ) AS rn
+    FROM share_count_history
+    WHERE shares_outstanding IS NOT NULL
+),
+current_state AS (
+    SELECT instrument_id, shares_outstanding AS latest_shares,
+           period_end AS latest_as_of
+    FROM ranked
+    WHERE rn = 1
+),
+-- Year-ago share count (rn=5 across quarterly series, or the oldest
+-- row within the last 6 periods if fewer).
+year_ago AS (
+    SELECT DISTINCT ON (instrument_id) instrument_id,
+           shares_outstanding AS yoy_shares
+    FROM ranked
+    WHERE rn BETWEEN 4 AND 6
+    ORDER BY instrument_id, rn ASC
+),
+-- Trailing-4-quarter deltas. Use these when the raw snapshot approach
+-- is missing (filer publishes flow but no point-in-time figure).
+trailing_flow AS (
+    SELECT instrument_id,
+           SUM(shares_issued_new) FILTER (WHERE rn <= 4) AS ttm_shares_issued,
+           SUM(buyback_shares)    FILTER (WHERE rn <= 4) AS ttm_buyback_shares
+    FROM ranked
+    GROUP BY instrument_id
+)
+SELECT
+    c.instrument_id,
+    c.latest_shares,
+    c.latest_as_of,
+    y.yoy_shares,
+    CASE
+        WHEN y.yoy_shares IS NOT NULL
+         AND y.yoy_shares > 0
+        THEN ((c.latest_shares - y.yoy_shares) / y.yoy_shares) * 100
+        ELSE NULL
+    END AS net_dilution_pct_yoy,
+    t.ttm_shares_issued,
+    t.ttm_buyback_shares,
+    -- Net change (positive = dilutive, negative = buyback-heavy).
+    COALESCE(t.ttm_shares_issued, 0) - COALESCE(t.ttm_buyback_shares, 0)
+        AS ttm_net_share_change,
+    -- Flag used by the ranking-engine quality sub-score follow-up.
+    -- >2% YoY dilution = penalty; buyback-heavy = reward. Threshold
+    -- mirrors portfolio.py's guard patterns (simple, deterministic).
+    CASE
+        WHEN y.yoy_shares IS NOT NULL AND y.yoy_shares > 0
+             AND (c.latest_shares - y.yoy_shares) / y.yoy_shares > 0.02
+        THEN 'dilutive'
+        WHEN y.yoy_shares IS NOT NULL AND y.yoy_shares > 0
+             AND (c.latest_shares - y.yoy_shares) / y.yoy_shares < -0.02
+        THEN 'buyback_heavy'
+        ELSE 'stable'
+    END AS dilution_posture
+FROM current_state c
+LEFT JOIN year_ago y ON y.instrument_id = c.instrument_id
+LEFT JOIN trailing_flow t ON t.instrument_id = c.instrument_id;
+
+COMMENT ON VIEW instrument_dilution_summary IS
+    'One row per instrument with trailing-year dilution signal. Drives '
+    'the ranking-engine quality sub-score and the operator-page '
+    'dilution badge. Positive net_dilution_pct_yoy = dilutive; '
+    'negative = buyback-heavy.';
+
+
+-- ---------------------------------------------------------------------------
+-- 3. instrument_share_count_latest — cheap market-cap input
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE VIEW instrument_share_count_latest AS
+SELECT DISTINCT ON (instrument_id)
+    instrument_id,
+    shares_outstanding AS latest_shares,
+    period_end         AS as_of_date,
+    CASE
+        WHEN shares_outstanding_dei IS NOT NULL THEN 'dei'
+        WHEN shares_outstanding_gaap IS NOT NULL THEN 'us-gaap'
+        ELSE 'none'
+    END AS source_taxonomy
+FROM share_count_history
+WHERE shares_outstanding IS NOT NULL
+ORDER BY instrument_id, period_end DESC;
+
+COMMENT ON VIEW instrument_share_count_latest IS
+    'Newest point-in-time share count per instrument. Drives live '
+    'market-cap derivation (shares x close) — retires a yfinance '
+    'call site under #432.';

--- a/tests/api/test_instruments_dilution_endpoint.py
+++ b/tests/api/test_instruments_dilution_endpoint.py
@@ -1,0 +1,97 @@
+"""Tests for GET /instruments/{symbol}/dilution (#435)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.instruments import router as instruments_router
+from app.db import get_conn
+from app.services.dilution import DilutionSummary, ShareCountPeriod
+
+
+def _build_app(conn: MagicMock) -> FastAPI:
+    app = FastAPI()
+    app.include_router(instruments_router)
+
+    def _yield_conn():  # type: ignore[return]
+        yield conn
+
+    app.dependency_overrides[get_conn] = _yield_conn
+    return app
+
+
+def _cursor_with(rows: list[dict[str, object] | None]) -> MagicMock:
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.fetchone.side_effect = rows
+    return cur
+
+
+def test_dilution_endpoint_returns_summary_and_history() -> None:
+    summary = DilutionSummary(
+        latest_shares=Decimal("15000000000"),
+        latest_as_of=date(2025, 12, 31),
+        yoy_shares=Decimal("15500000000"),
+        net_dilution_pct_yoy=Decimal("-3.23"),
+        ttm_shares_issued=Decimal("100000"),
+        ttm_buyback_shares=Decimal("500000000"),
+        ttm_net_share_change=Decimal("-499900000"),
+        dilution_posture="buyback_heavy",
+    )
+    history = [
+        ShareCountPeriod(
+            period_end=date(2025, 12, 31),
+            fiscal_year=2025,
+            fiscal_period="FY",
+            shares_outstanding=Decimal("15000000000"),
+            shares_issued_new=None,
+            buyback_shares=Decimal("500000000"),
+        ),
+    ]
+
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_with([{"instrument_id": 1, "symbol": "AAPL"}])
+    app = _build_app(conn)
+
+    with (
+        patch("app.services.dilution.get_dilution_summary", return_value=summary),
+        patch("app.services.dilution.get_share_count_history", return_value=history),
+        TestClient(app) as client,
+    ):
+        resp = client.get("/instruments/AAPL/dilution")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["symbol"] == "AAPL"
+    assert body["summary"]["dilution_posture"] == "buyback_heavy"
+    assert body["summary"]["net_dilution_pct_yoy"] == "-3.23"
+    assert len(body["history"]) == 1
+    assert body["history"][0]["fiscal_period"] == "FY"
+
+
+def test_dilution_endpoint_unknown_symbol_404() -> None:
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_with([None])
+    app = _build_app(conn)
+
+    with TestClient(app) as client:
+        resp = client.get("/instruments/__NOSUCH__/dilution")
+
+    assert resp.status_code == 404
+
+
+def test_dilution_endpoint_rejects_out_of_range_limit() -> None:
+    conn = MagicMock()
+    app = _build_app(conn)
+    with TestClient(app) as client:
+        resp = client.get("/instruments/AAPL/dilution", params={"limit": 0})
+    assert resp.status_code == 422
+    with TestClient(app) as client:
+        resp = client.get("/instruments/AAPL/dilution", params={"limit": 201})
+    assert resp.status_code == 422

--- a/tests/test_dilution_service.py
+++ b/tests/test_dilution_service.py
@@ -1,0 +1,228 @@
+"""Tests for app.services.dilution (#435)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services.dilution import (
+    _EMPTY_SUMMARY,
+    get_dilution_summary,
+    get_latest_share_count,
+    get_share_count_history,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _test_db_available(),
+        reason="ebull_test DB unavailable",
+    ),
+]
+
+_NEXT_IID = [30_000]
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, symbol: str) -> int:
+    _NEXT_IID[0] += 1
+    iid = _NEXT_IID[0]
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (iid, symbol, f"{symbol} Inc."),
+        )
+    conn.commit()
+    return iid
+
+
+def _seed_fact(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    concept: str,
+    period_end: date,
+    val: float,
+    taxonomy: str = "us-gaap",
+    unit: str = "shares",
+    accession: str = "test-accession-1",
+    filed_date: date | None = None,
+    form_type: str = "10-K",
+    fiscal_year: int = 2025,
+    fiscal_period: str = "FY",
+    period_start: date | None = None,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO financial_facts_raw (
+                instrument_id, taxonomy, concept, unit,
+                period_start, period_end, val, accession_number,
+                form_type, filed_date, fiscal_year, fiscal_period
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                instrument_id,
+                taxonomy,
+                concept,
+                unit,
+                period_start,
+                period_end,
+                val,
+                accession,
+                form_type,
+                filed_date or period_end,
+                fiscal_year,
+                fiscal_period,
+            ),
+        )
+    conn.commit()
+
+
+class TestShareCountHistory:
+    def test_empty_when_no_facts(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="EMPT")
+        history = get_share_count_history(ebull_test_conn, instrument_id=iid)
+        assert history == []
+
+    def test_dei_shares_preferred_over_gaap(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="DEIP")
+        _seed_fact(
+            ebull_test_conn,
+            instrument_id=iid,
+            taxonomy="dei",
+            concept="EntityCommonStockSharesOutstanding",
+            period_end=date(2025, 12, 31),
+            val=15_000_000_000,
+            accession="acc-dei",
+        )
+        _seed_fact(
+            ebull_test_conn,
+            instrument_id=iid,
+            concept="CommonStockSharesOutstanding",
+            period_end=date(2025, 12, 31),
+            val=14_500_000_000,
+            accession="acc-gaap",
+        )
+
+        history = get_share_count_history(ebull_test_conn, instrument_id=iid)
+        assert len(history) == 1
+        assert history[0].shares_outstanding == Decimal("15000000000.000000")
+
+    def test_newest_filing_wins_on_restatement(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="RSTT")
+        _seed_fact(
+            ebull_test_conn,
+            instrument_id=iid,
+            concept="CommonStockSharesOutstanding",
+            period_end=date(2025, 3, 31),
+            val=10_000_000,
+            accession="acc-orig",
+            filed_date=date(2025, 5, 1),
+            form_type="10-Q",
+        )
+        _seed_fact(
+            ebull_test_conn,
+            instrument_id=iid,
+            concept="CommonStockSharesOutstanding",
+            period_end=date(2025, 3, 31),
+            val=10_500_000,
+            accession="acc-amended",
+            filed_date=date(2025, 11, 1),
+            form_type="10-K/A",
+        )
+        history = get_share_count_history(ebull_test_conn, instrument_id=iid)
+        assert history[0].shares_outstanding == Decimal("10500000.000000")
+
+
+class TestDilutionSummary:
+    def test_empty_when_no_facts(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="NOFA")
+        summary = get_dilution_summary(ebull_test_conn, instrument_id=iid)
+        assert summary == _EMPTY_SUMMARY
+
+    def test_dilutive_flag_on_positive_yoy_change(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="DIL")
+        # Oldest period at rn=5 from newest-back perspective — make five
+        # quarterly rows so the "year-ago" lookup picks the first.
+        base = 10_000_000
+        growth = [0.05, 0.06, 0.07, 0.08, 0.10]  # ends at 10% above base
+        for q, pct in enumerate(growth):
+            # Oldest-first insertion; view orders DESC by period_end.
+            _seed_fact(
+                ebull_test_conn,
+                instrument_id=iid,
+                concept="CommonStockSharesOutstanding",
+                period_end=date(2024 + q // 4, 3 * ((q % 4) + 1), 28),
+                val=int(base * (1 + pct)),
+                accession=f"acc-q{q}",
+            )
+
+        summary = get_dilution_summary(ebull_test_conn, instrument_id=iid)
+        assert summary.latest_shares is not None
+        assert summary.dilution_posture in ("dilutive", "stable")
+
+    def test_buyback_heavy_flag_on_negative_yoy_change(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="BBK")
+        # Five quarters, newest has FEWER shares than oldest (buyback).
+        shares = [100_000_000, 99_000_000, 98_000_000, 97_000_000, 95_000_000]
+        for q, s in enumerate(shares):
+            _seed_fact(
+                ebull_test_conn,
+                instrument_id=iid,
+                concept="CommonStockSharesOutstanding",
+                period_end=date(2024, 3, 1) if q == 0 else date(2024 + q // 4, 3 * ((q % 4) + 1), 28),
+                val=s,
+                accession=f"acc-q{q}",
+            )
+        summary = get_dilution_summary(ebull_test_conn, instrument_id=iid)
+        # 95M / 100M = 5% drop → under the -2% threshold → buyback_heavy
+        assert summary.dilution_posture == "buyback_heavy"
+
+
+class TestLatestShareCount:
+    def test_returns_none_when_no_facts(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="NONE")
+        assert get_latest_share_count(ebull_test_conn, instrument_id=iid) is None
+
+    def test_reports_dei_source_when_dei_fact_present(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="DEIL")
+        _seed_fact(
+            ebull_test_conn,
+            instrument_id=iid,
+            taxonomy="dei",
+            concept="EntityCommonStockSharesOutstanding",
+            period_end=date(2025, 12, 31),
+            val=20_000_000,
+        )
+        got = get_latest_share_count(ebull_test_conn, instrument_id=iid)
+        assert got is not None
+        assert got.source_taxonomy == "dei"
+        assert got.latest_shares == Decimal("20000000.000000")
+
+    def test_falls_through_to_us_gaap_when_no_dei(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="GAAP")
+        _seed_fact(
+            ebull_test_conn,
+            instrument_id=iid,
+            concept="CommonStockSharesOutstanding",
+            period_end=date(2025, 12, 31),
+            val=5_000_000,
+        )
+        got = get_latest_share_count(ebull_test_conn, instrument_id=iid)
+        assert got is not None
+        assert got.source_taxonomy == "us-gaap"
+
+
+def test_limit_out_of_range_raises(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    with pytest.raises(ValueError, match="limit must be"):
+        get_share_count_history(ebull_test_conn, instrument_id=1, limit=0)
+    with pytest.raises(ValueError, match="limit must be"):
+        get_share_count_history(ebull_test_conn, instrument_id=1, limit=201)

--- a/tests/test_dilution_service.py
+++ b/tests/test_dilution_service.py
@@ -221,6 +221,71 @@ class TestLatestShareCount:
         assert got.source_taxonomy == "us-gaap"
 
 
+class TestFlowOnlyPeriodsCount:
+    """Review #442: TTM flow totals must include periods where the
+    filer published issuance / buyback without a matching
+    shares_outstanding snapshot. Prior version filtered those out."""
+
+    def test_flow_without_outstanding_still_counts_in_ttm(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="FLOW")
+        # One period with snapshot (anchors latest_as_of + year-ago
+        # lookup). One period with ONLY a flow fact.
+        _seed_fact(
+            ebull_test_conn,
+            instrument_id=iid,
+            concept="CommonStockSharesOutstanding",
+            period_end=date(2025, 12, 31),
+            val=10_000_000,
+        )
+        _seed_fact(
+            ebull_test_conn,
+            instrument_id=iid,
+            concept="StockIssuedDuringPeriodSharesNewIssues",
+            period_end=date(2025, 9, 30),
+            val=500_000,
+        )
+        summary = get_dilution_summary(ebull_test_conn, instrument_id=iid)
+        assert summary.ttm_shares_issued == Decimal("500000.000000")
+
+
+class TestPeriodEndGroupingDedupes:
+    """Review #442: a 10-K/A that re-tags the same period_end with a
+    different fiscal_period must not produce duplicate rows."""
+
+    def test_amendment_retag_does_not_duplicate_period_end(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="RTAG")
+        _seed_fact(
+            ebull_test_conn,
+            instrument_id=iid,
+            concept="CommonStockSharesOutstanding",
+            period_end=date(2025, 12, 31),
+            val=10_000_000,
+            accession="acc-orig",
+            filed_date=date(2026, 1, 30),
+            fiscal_year=2025,
+            fiscal_period="FY",
+        )
+        # Amendment re-tags the same period_end with different fiscal
+        # tags (rare but real — happens when filers correct their
+        # fiscal-year boundary).
+        _seed_fact(
+            ebull_test_conn,
+            instrument_id=iid,
+            concept="CommonStockSharesOutstanding",
+            period_end=date(2025, 12, 31),
+            val=10_200_000,
+            accession="acc-amend",
+            filed_date=date(2026, 3, 1),
+            fiscal_year=2026,
+            fiscal_period="Q1",
+            form_type="10-K/A",
+        )
+        history = get_share_count_history(ebull_test_conn, instrument_id=iid)
+        # Exactly one row per period_end — no duplication.
+        assert len(history) == 1
+        assert history[0].shares_outstanding == Decimal("10200000.000000")
+
+
 def test_limit_out_of_range_raises(ebull_test_conn: psycopg.Connection[tuple]) -> None:
     with pytest.raises(ValueError, match="limit must be"):
         get_share_count_history(ebull_test_conn, instrument_id=1, limit=0)


### PR DESCRIPTION
## What
Closes #435. Surfaces share-count deltas + dilution signal from SEC XBRL facts already ingested via #430. Zero new HTTP.

## Pieces
- **SQL 052** — three views on \`financial_facts_raw\`:
  - \`share_count_history\` (per-period, DEI > us-gaap, amendment-aware)
  - \`instrument_dilution_summary\` (YoY %, TTM net change, posture flag)
  - \`instrument_share_count_latest\` (retires yfinance market-cap path)
- **Service** — \`get_share_count_history\` / \`get_dilution_summary\` / \`get_latest_share_count\`
- **Endpoint** — \`GET /instruments/{symbol}/dilution\`

## Scope boundary
- Ranking engine wiring into quality sub-score = #432 follow-up
- Instrument-page dilution panel UI = future frontend PR (alongside #429 Form 4)

## Test plan
- [x] \`uv run pytest\` — 2438 passed
- [x] \`uv run ruff check\` + \`format --check\`
- [x] \`uv run pyright\`
- [x] 10 service tests vs ebull_test + 3 API shape tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)