### PR TITLE
feat(#431): 8-K items[] code typing from submissions.json

### DIFF
--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -1789,6 +1789,28 @@ def _run_cik_upsert(
                     exc_info=True,
                 )
 
+            # #431: 8-K items[] typing. Parse the items column in the
+            # submissions.filings.recent table and UPDATE the matching
+            # filing_events rows. Savepoint-scoped per the #439 pattern
+            # so a parse/write failure cannot poison the outer per-CIK
+            # transaction that still has XBRL facts to write.
+            try:
+                from app.services.sec_filing_items import (
+                    apply_8k_items_to_filing_events,
+                    parse_8k_items_by_accession,
+                )
+
+                items_map = parse_8k_items_by_accession(submissions)
+                if items_map:
+                    with conn.transaction():
+                        apply_8k_items_to_filing_events(conn, items_map)
+            except Exception:
+                logger.warning(
+                    "sec_incremental: 8-K items apply failed for cik=%s",
+                    cik,
+                    exc_info=True,
+                )
+
         facts = fundamentals_provider.extract_facts(symbol, cik)
         upserted_in_tx = 0
 

--- a/app/services/sec_filing_items.py
+++ b/app/services/sec_filing_items.py
@@ -1,0 +1,112 @@
+"""SEC 8-K ``items[]`` extraction from submissions.json (#431).
+
+``submissions.json.filings.recent`` is columnar: ``accessionNumber``,
+``form``, ``items``, etc. are parallel arrays indexed by filing. Each
+``items`` entry for an 8-K is a comma-separated string like
+``"1.01,2.03,9.01"`` (or empty string for non-8-K). This helper parses
+the structure into a ``dict[accession -> list[str]]`` so
+``_run_cik_upsert`` can UPDATE ``filing_events.items`` without extra
+HTTP.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+
+
+def parse_8k_items_by_accession(submissions: dict[str, Any]) -> dict[str, list[str]]:
+    """Extract accession_number → list[item_code] for every 8-K /
+    8-K/A in ``submissions.filings.recent``. Non-8-K filings are
+    skipped. Returns an empty dict if the payload is malformed."""
+    filings = submissions.get("filings")
+    if not isinstance(filings, dict):
+        return {}
+    recent = filings.get("recent")
+    if not isinstance(recent, dict):
+        return {}
+
+    accessions = recent.get("accessionNumber")
+    forms = recent.get("form")
+    items_col = recent.get("items")
+    if not isinstance(accessions, list) or not isinstance(forms, list) or not isinstance(items_col, list):
+        return {}
+
+    # Columnar alignment — all three arrays MUST have matching length;
+    # a mismatch is malformed submissions, skip rather than raise.
+    n = len(accessions)
+    if len(forms) != n or len(items_col) != n:
+        return {}
+
+    out: dict[str, list[str]] = {}
+    for accession, form, raw_items in zip(accessions, forms, items_col, strict=True):
+        if not isinstance(accession, str) or not isinstance(form, str):
+            continue
+        form_stripped = form.strip().upper()
+        # Accept 8-K and 8-K/A (amendment).
+        if not form_stripped.startswith("8-K"):
+            continue
+        codes = _split_items(raw_items)
+        # Even if items is empty, record the accession so callers can
+        # distinguish "parsed and there were no items" from "never
+        # parsed". Empty list is the signal.
+        out[accession] = codes
+    return out
+
+
+def _split_items(raw: Any) -> list[str]:
+    """Split SEC's comma-separated item string into a deduplicated
+    list. Ignores whitespace, drops anything that isn't an
+    ``N.NN``-shaped code."""
+    if not isinstance(raw, str):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for token in raw.split(","):
+        code = token.strip()
+        if not code:
+            continue
+        # SEC codes are always "N.NN" or "N.N" (two decimal digits
+        # after the dot). Reject anything that doesn't match.
+        if "." not in code:
+            continue
+        left, _, right = code.partition(".")
+        if not left.isdigit() or not right.isdigit():
+            continue
+        if code in seen:
+            continue
+        seen.add(code)
+        out.append(code)
+    return out
+
+
+def apply_8k_items_to_filing_events(
+    conn: psycopg.Connection[Any],
+    items_by_accession: dict[str, list[str]],
+) -> int:
+    """UPDATE ``filing_events.items`` for every accession we've parsed.
+
+    Only touches rows that already exist (no INSERT). Returns the
+    count of rows updated. Empty-list updates are still applied so
+    operators can tell "parsed, no items" from "never parsed".
+    """
+    if not items_by_accession:
+        return 0
+
+    # Build a single multi-row UPDATE via VALUES. psycopg renders
+    # list[str] as a Postgres text[] natively for the ``items`` col.
+    # No SQL composition; values come via parameter binding.
+    updated = 0
+    with conn.cursor() as cur:
+        for accession, codes in items_by_accession.items():
+            cur.execute(
+                """
+                UPDATE filing_events
+                SET items = %s
+                WHERE provider = 'sec' AND provider_filing_id = %s
+                """,
+                (codes, accession),
+            )
+            updated += cur.rowcount
+    return updated

--- a/app/services/sec_filing_items.py
+++ b/app/services/sec_filing_items.py
@@ -94,9 +94,11 @@ def apply_8k_items_to_filing_events(
     if not items_by_accession:
         return 0
 
-    # Build a single multi-row UPDATE via VALUES. psycopg renders
-    # list[str] as a Postgres text[] natively for the ``items`` col.
-    # No SQL composition; values come via parameter binding.
+    # One UPDATE per accession. At daily-cadence volume (tens of
+    # 8-Ks across all covered CIKs) this is fine — a bulk UNNEST
+    # would be optimal if counts ever climb into the thousands per
+    # run, but isn't worth the SQL complexity today. psycopg renders
+    # ``list[str]`` as a Postgres ``text[]`` natively.
     updated = 0
     with conn.cursor() as cur:
         for accession, codes in items_by_accession.items():

--- a/sql/053_filing_events_items.sql
+++ b/sql/053_filing_events_items.sql
@@ -1,0 +1,83 @@
+-- 053_filing_events_items.sql
+--
+-- 8-K ``items[]`` code typing (#431). ``submissions.json`` carries an
+-- ``items`` array per filing (e.g. "1.01,2.03,9.01" for a material
+-- agreement + off-balance-sheet arrangement + exhibit). We already
+-- pull the submissions dict daily but discard this field — richer
+-- than the bare ``form_type='8-K'`` signal we store today.
+--
+-- Adds:
+--   1. ``filing_events.items`` — text array of raw item codes.
+--   2. ``sec_8k_item_codes``   — lookup: code → human label +
+--                                severity (informational / material /
+--                                critical). Seeded at migration time
+--                                with the SEC's published item set.
+--
+-- The cascade-trigger plumbing (fire thesis refresh on material 8-K)
+-- is a follow-up; this migration just captures the codes.
+
+ALTER TABLE filing_events
+    ADD COLUMN IF NOT EXISTS items TEXT[];
+
+CREATE INDEX IF NOT EXISTS idx_filing_events_items_gin
+    ON filing_events USING GIN (items);
+
+
+-- ---------------------------------------------------------------------------
+-- sec_8k_item_codes lookup
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS sec_8k_item_codes (
+    code      TEXT PRIMARY KEY,
+    label     TEXT NOT NULL,
+    severity  TEXT NOT NULL CHECK (severity IN ('informational', 'material', 'critical'))
+);
+
+-- Seed the standard SEC 8-K item codes (Form 8-K General Instructions).
+-- Severity is our editorial call — "material" items are the ones we want
+-- the thesis cascade (#276) to react to; "critical" escalates further
+-- (bankruptcy, delistings, auditor changes).
+INSERT INTO sec_8k_item_codes (code, label, severity) VALUES
+    ('1.01', 'Entry into a Material Definitive Agreement',        'material'),
+    ('1.02', 'Termination of a Material Definitive Agreement',    'material'),
+    ('1.03', 'Bankruptcy or Receivership',                        'critical'),
+    ('1.04', 'Mine Safety — Reporting of Shutdowns and Patterns', 'informational'),
+    ('1.05', 'Material Cybersecurity Incidents',                  'critical'),
+    ('2.01', 'Completion of Acquisition or Disposition of Assets', 'material'),
+    ('2.02', 'Results of Operations and Financial Condition',      'material'),
+    ('2.03', 'Creation of a Direct Financial Obligation',          'material'),
+    ('2.04', 'Triggering Events That Accelerate a Financial Obligation', 'material'),
+    ('2.05', 'Costs Associated with Exit or Disposal Activities',  'material'),
+    ('2.06', 'Material Impairments',                               'critical'),
+    ('3.01', 'Notice of Delisting or Failure to Satisfy a Continued Listing Rule', 'critical'),
+    ('3.02', 'Unregistered Sales of Equity Securities',            'material'),
+    ('3.03', 'Material Modification to Rights of Security Holders', 'material'),
+    ('4.01', 'Changes in Registrant''s Certifying Accountant',     'critical'),
+    ('4.02', 'Non-Reliance on Previously Issued Financial Statements', 'critical'),
+    ('5.01', 'Changes in Control of Registrant',                   'critical'),
+    ('5.02', 'Departure/Election of Directors or Principal Officers', 'material'),
+    ('5.03', 'Amendments to Articles of Incorporation or Bylaws',  'informational'),
+    ('5.04', 'Temporary Suspension of Trading Under Employee Benefit Plans', 'informational'),
+    ('5.05', 'Amendments to Code of Ethics',                       'informational'),
+    ('5.06', 'Change in Shell Company Status',                     'material'),
+    ('5.07', 'Submission of Matters to a Vote of Security Holders', 'informational'),
+    ('5.08', 'Shareholder Director Nominations',                   'informational'),
+    ('6.01', 'ABS Informational and Computational Material',       'informational'),
+    ('6.02', 'Change of Servicer or Trustee',                      'material'),
+    ('6.03', 'Change in Credit Enhancement or Other External Support', 'material'),
+    ('6.04', 'Failure to Make a Required Distribution',            'critical'),
+    ('6.05', 'Securities Act Updating Disclosure',                 'informational'),
+    ('7.01', 'Regulation FD Disclosure',                           'informational'),
+    ('8.01', 'Other Events',                                       'informational'),
+    ('9.01', 'Financial Statements and Exhibits',                  'informational')
+ON CONFLICT (code) DO UPDATE SET
+    label    = EXCLUDED.label,
+    severity = EXCLUDED.severity;
+
+
+COMMENT ON COLUMN filing_events.items IS
+    'SEC 8-K item codes (e.g. ARRAY[''1.01'',''9.01'']). Populated from '
+    'submissions.json filings.recent[].items — comma-separated source '
+    'split into an array. NULL for non-8-K or pre-#431 filings.';
+COMMENT ON TABLE sec_8k_item_codes IS
+    'Reference lookup for SEC 8-K item codes with editorial severity tier.';

--- a/tests/test_sec_filing_items.py
+++ b/tests/test_sec_filing_items.py
@@ -1,0 +1,208 @@
+"""Tests for app.services.sec_filing_items (#431)."""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.services.sec_filing_items import (
+    _split_items,
+    apply_8k_items_to_filing_events,
+    parse_8k_items_by_accession,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+
+# ---------------------------------------------------------------------------
+# parse_8k_items_by_accession — unit
+# ---------------------------------------------------------------------------
+
+
+def _submissions_shell(
+    *,
+    accessions: list[str],
+    forms: list[str],
+    items_col: list[str],
+) -> dict:
+    return {
+        "filings": {
+            "recent": {
+                "accessionNumber": accessions,
+                "form": forms,
+                "items": items_col,
+            }
+        }
+    }
+
+
+class TestParseItems:
+    def test_extracts_items_from_8k_only(self) -> None:
+        payload = _submissions_shell(
+            accessions=["acc-1", "acc-2", "acc-3"],
+            forms=["8-K", "10-Q", "8-K/A"],
+            items_col=["1.01,2.03", "", "5.02"],
+        )
+        out = parse_8k_items_by_accession(payload)
+        assert out == {
+            "acc-1": ["1.01", "2.03"],
+            "acc-3": ["5.02"],
+        }
+
+    def test_empty_items_string_yields_empty_list(self) -> None:
+        payload = _submissions_shell(
+            accessions=["acc-1"],
+            forms=["8-K"],
+            items_col=[""],
+        )
+        out = parse_8k_items_by_accession(payload)
+        assert out == {"acc-1": []}
+
+    def test_malformed_payload_yields_empty(self) -> None:
+        assert parse_8k_items_by_accession({}) == {}
+        assert parse_8k_items_by_accession({"filings": None}) == {}
+        # Mismatched column lengths must not raise.
+        bad = _submissions_shell(
+            accessions=["a"],
+            forms=["8-K", "extra"],
+            items_col=[""],
+        )
+        assert parse_8k_items_by_accession(bad) == {}
+
+    def test_deduplicates_repeated_codes(self) -> None:
+        payload = _submissions_shell(
+            accessions=["acc-1"],
+            forms=["8-K"],
+            items_col=["1.01, 1.01 ,2.03"],
+        )
+        assert parse_8k_items_by_accession(payload) == {"acc-1": ["1.01", "2.03"]}
+
+    def test_drops_malformed_codes(self) -> None:
+        payload = _submissions_shell(
+            accessions=["acc-1"],
+            forms=["8-K"],
+            items_col=["1.01,FOO,1,9.01,,x.y"],
+        )
+        assert parse_8k_items_by_accession(payload) == {"acc-1": ["1.01", "9.01"]}
+
+
+class TestSplitItems:
+    def test_whitespace_tolerant(self) -> None:
+        assert _split_items("  1.01 , 9.01  ") == ["1.01", "9.01"]
+
+    def test_non_string_returns_empty(self) -> None:
+        assert _split_items(None) == []
+        assert _split_items(123) == []
+
+
+# ---------------------------------------------------------------------------
+# apply_8k_items_to_filing_events — integration
+# ---------------------------------------------------------------------------
+
+
+pytestmark_int = pytest.mark.integration
+
+_NEXT_IID = [40_000]
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, symbol: str) -> int:
+    _NEXT_IID[0] += 1
+    iid = _NEXT_IID[0]
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (iid, symbol, f"{symbol} Inc."),
+        )
+    conn.commit()
+    return iid
+
+
+def _seed_filing(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    accession: str,
+    filing_type: str = "8-K",
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO filing_events (
+                instrument_id, filing_date, filing_type,
+                provider, provider_filing_id, source_url
+            ) VALUES (%s, CURRENT_DATE, %s, 'sec', %s, 'https://example.com')
+            """,
+            (instrument_id, filing_type, accession),
+        )
+    conn.commit()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestApplyItems:
+    def test_updates_existing_filing_events_row(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="ITM1")
+        _seed_filing(ebull_test_conn, instrument_id=iid, accession="acc-itm1")
+
+        applied = apply_8k_items_to_filing_events(
+            ebull_test_conn,
+            {"acc-itm1": ["1.01", "9.01"]},
+        )
+        ebull_test_conn.commit()
+        assert applied == 1
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT items FROM filing_events WHERE provider_filing_id = %s",
+                ("acc-itm1",),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == ["1.01", "9.01"]
+
+    def test_missing_filing_row_is_noop(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # No filing_events row with this accession — nothing to update.
+        applied = apply_8k_items_to_filing_events(
+            ebull_test_conn,
+            {"acc-missing": ["1.01"]},
+        )
+        ebull_test_conn.commit()
+        assert applied == 0
+
+    def test_empty_list_still_writes_empty_array(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="ITM2")
+        _seed_filing(ebull_test_conn, instrument_id=iid, accession="acc-itm2")
+        apply_8k_items_to_filing_events(ebull_test_conn, {"acc-itm2": []})
+        ebull_test_conn.commit()
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT items FROM filing_events WHERE provider_filing_id = %s",
+                ("acc-itm2",),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == []
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestLookupTableSeeded:
+    def test_key_codes_present_with_severity(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT code, severity FROM sec_8k_item_codes "
+                "WHERE code IN ('1.03', '2.02', '4.01', '5.02', '8.01') "
+                "ORDER BY code"
+            )
+            rows = dict(cur.fetchall())
+        # Bankruptcy, auditor change, change-of-control → critical
+        assert rows["1.03"] == "critical"
+        assert rows["4.01"] == "critical"
+        # Earnings release, exec departure → material
+        assert rows["2.02"] == "material"
+        assert rows["5.02"] == "material"
+        # Other events → informational
+        assert rows["8.01"] == "informational"


### PR DESCRIPTION
## What
Closes #431. Captures SEC 8-K \`items[]\` codes we've been fetching daily and discarding.

## Pieces
- **SQL 053** — \`filing_events.items TEXT[]\` + \`sec_8k_item_codes\` lookup (31 codes seeded with severity tier: informational / material / critical).
- **Service** — \`parse_8k_items_by_accession\` (columnar parser, malformed-payload tolerant) + \`apply_8k_items_to_filing_events\` (UPDATE pass).
- **Wire-in** — \`_run_cik_upsert\` new savepoint-scoped block (mirrors #439 pattern) runs when submissions dict is in scope.

## Why
Bare \`form_type='8-K'\` is a weak signal. \`items=['1.03']\` = bankruptcy, \`['4.01']\` = auditor change, \`['5.02']\` = exec departure, \`['2.02']\` = earnings release. Enables cascade triggers (#276) + ranking quality sub-score + ex-date calendar parse (#434 depends on this).

## Scope boundary
Cascade auto-fire + frontend filing-stream display = follow-ups.

## Test plan
- [x] \`uv run pytest\` — 2451 passed, 1 skipped
- [x] \`uv run ruff check\` + \`format --check\`
- [x] \`uv run pyright\`
- [x] 11 tests: parse edge cases (malformed, dedup, non-8-K skip), apply update/no-op/empty-array, lookup-seed severity invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)