### PR TITLE
feat(#432): compute-from-XBRL market_cap — retire yfinance first call site

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -1243,6 +1243,22 @@ def get_instrument_summary(
     if use_local_sec:
         local_fundamentals = _fetch_local_fundamentals(conn, instrument_id_int)
 
+    # #432 (yfinance retire, batch 1): prefer compute-from-XBRL market
+    # cap over yfinance when SEC has a fresh share count. Runs after
+    # the existing local-fundamentals block so its cursor slot is the
+    # LAST in the sequence — keeps the test harness shape stable.
+    # Returns None for non-US / pre-seed; we then fall back to
+    # whatever yfinance provided on the identity built above.
+    try:
+        from app.services.xbrl_derived_stats import compute_market_cap
+
+        computed_cap = compute_market_cap(conn, instrument_id=instrument_id_int)
+    except Exception:
+        logger.warning("compute_market_cap failed", exc_info=True)
+        computed_cap = None
+    if computed_cap is not None:
+        identity = identity.model_copy(update={"market_cap": computed_cap.value})
+
     # Treat a dict of all-None as "no local data" — the fundamentals_snapshot
     # table may exist with sparse rows during bootstrap.
     has_local_values = any(v is not None for v in local_fundamentals.values())

--- a/app/services/xbrl_derived_stats.py
+++ b/app/services/xbrl_derived_stats.py
@@ -64,6 +64,11 @@ def compute_market_cap(
                 WHERE instrument_id = %(iid)s
             ),
             priced AS (
+                -- ``quotes`` is 1:1 current-snapshot by contract, but
+                -- pin ORDER BY + LIMIT 1 as a defensive belt so any
+                -- future migration that holds historical rows cannot
+                -- fan-out this LEFT JOIN into a non-deterministic
+                -- fetchone (review #444 BLOCKING).
                 SELECT
                     COALESCE(
                         NULLIF(GREATEST(last, 0), 0),
@@ -72,6 +77,8 @@ def compute_market_cap(
                     quoted_at::date AS price_as_of
                 FROM quotes
                 WHERE instrument_id = %(iid)s
+                ORDER BY quoted_at DESC
+                LIMIT 1
             )
             SELECT s.latest_shares, s.as_of_date, s.source_taxonomy,
                    p.price, p.price_as_of

--- a/app/services/xbrl_derived_stats.py
+++ b/app/services/xbrl_derived_stats.py
@@ -1,0 +1,105 @@
+"""Compute-from-XBRL helpers (#432) — replaces yfinance key-stats
+where SEC data + quotes can answer the same question.
+
+Each helper takes a ``psycopg.Connection`` + ``instrument_id`` and
+returns a typed ``Decimal | None``. None = insufficient data (operator
+UI falls back to yfinance cleanly).
+
+Helpers land as they retire a specific yfinance call site — see the
+ticket ladder in #432 for the per-call-site status.
+
+Shipped in this PR:
+  - compute_market_cap           (retires profile.market_cap)
+
+Queued for follow-ups:
+  - compute_pe_ttm, compute_pb, compute_roe, compute_roa,
+    compute_debt_to_equity, compute_revenue_growth_yoy,
+    compute_earnings_growth_yoy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+import psycopg.rows
+
+MarketCapSource = Literal["dei", "us-gaap", "unavailable"]
+
+
+@dataclass(frozen=True)
+class MarketCap:
+    value: Decimal
+    shares: Decimal
+    price: Decimal
+    price_as_of: date | None
+    shares_as_of: date
+    shares_source: MarketCapSource
+
+
+def compute_market_cap(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+) -> MarketCap | None:
+    """Compute live market cap from the newest SEC share count ×
+    latest quote (bid/ask midpoint, or ``last`` when available).
+
+    Returns ``None`` if either input is missing. Wires to
+    ``instrument_share_count_latest`` (sql/052, #435) for the share
+    count — that view prefers DEI over us-gaap, picks the newest
+    restated value, and exposes the source taxonomy used. Price
+    mirrors the pattern in ``instrument_dividend_summary.priced``:
+    NULLIF(GREATEST(last, 0), 0) first, then (bid+ask)/2.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            WITH shares AS (
+                SELECT latest_shares, as_of_date, source_taxonomy
+                FROM instrument_share_count_latest
+                WHERE instrument_id = %(iid)s
+            ),
+            priced AS (
+                SELECT
+                    COALESCE(
+                        NULLIF(GREATEST(last, 0), 0),
+                        CASE WHEN bid > 0 AND ask > 0 THEN (bid + ask) / 2 END
+                    ) AS price,
+                    quoted_at::date AS price_as_of
+                FROM quotes
+                WHERE instrument_id = %(iid)s
+            )
+            SELECT s.latest_shares, s.as_of_date, s.source_taxonomy,
+                   p.price, p.price_as_of
+            FROM shares s
+            LEFT JOIN priced p ON TRUE
+            """,
+            {"iid": instrument_id},
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        return None
+    shares = row["latest_shares"]
+    price = row["price"]
+    if shares is None or price is None or shares <= 0 or price <= 0:
+        return None
+
+    source_raw = str(row["source_taxonomy"])
+    if source_raw not in ("dei", "us-gaap", "unavailable"):
+        source: MarketCapSource = "unavailable"
+    else:
+        source = source_raw  # type: ignore[assignment]
+
+    return MarketCap(
+        value=Decimal(shares) * Decimal(price),
+        shares=Decimal(shares),
+        price=Decimal(price),
+        price_as_of=row["price_as_of"],
+        shares_as_of=row["as_of_date"],
+        shares_source=source,
+    )

--- a/tests/test_api_instrument_summary.py
+++ b/tests/test_api_instrument_summary.py
@@ -413,6 +413,9 @@ def test_summary_prefers_local_sec_xbrl_for_us_ticker(client: TestClient) -> Non
                         "revenue": Decimal("400000000000"),
                     },
                 ],
+                # #432 compute_market_cap cursor — None so the endpoint
+                # keeps the yfinance market_cap for this test's shape.
+                [None],
             ]
         )
 
@@ -496,6 +499,8 @@ def test_summary_sec_preference_reports_price_missing_when_quote_absent(
                     },
                     None,
                 ],
+                # #432 compute_market_cap cursor — None.
+                [None],
             ]
         )
 
@@ -602,6 +607,8 @@ def test_summary_id_override_pins_specific_instrument(client: TestClient) -> Non
                     }
                 ],
                 # Cursor 2: _has_sec_cik probe — LSE ticker has no CIK.
+                [None],
+                # Cursor 3: #432 compute_market_cap — None.
                 [None],
             ]
         )

--- a/tests/test_xbrl_derived_stats.py
+++ b/tests/test_xbrl_derived_stats.py
@@ -1,0 +1,144 @@
+"""Tests for app.services.xbrl_derived_stats (#432 — yfinance retire)."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services.xbrl_derived_stats import compute_market_cap
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _test_db_available(),
+        reason="ebull_test DB unavailable",
+    ),
+]
+
+_NEXT_IID = [50_000]
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, symbol: str) -> int:
+    _NEXT_IID[0] += 1
+    iid = _NEXT_IID[0]
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (iid, symbol, f"{symbol} Inc."),
+        )
+    conn.commit()
+    return iid
+
+
+def _seed_shares(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    val: float,
+    concept: str = "CommonStockSharesOutstanding",
+    taxonomy: str = "us-gaap",
+    period_end: date = date(2025, 12, 31),
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO financial_facts_raw (
+                instrument_id, taxonomy, concept, unit,
+                period_end, val, accession_number, form_type, filed_date,
+                fiscal_year, fiscal_period
+            ) VALUES (%s, %s, %s, 'shares', %s, %s, %s, '10-K', %s, 2025, 'FY')
+            """,
+            (
+                instrument_id,
+                taxonomy,
+                concept,
+                period_end,
+                val,
+                f"acc-{instrument_id}",
+                period_end,
+            ),
+        )
+    conn.commit()
+
+
+def _seed_quote(conn: psycopg.Connection[tuple], *, instrument_id: int, price: float) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO quotes (instrument_id, quoted_at, bid, ask, last)
+            VALUES (%s, %s, %s, %s, %s)
+            """,
+            (instrument_id, datetime.now(UTC), price - 0.1, price + 0.1, price),
+        )
+    conn.commit()
+
+
+class TestComputeMarketCap:
+    def test_dei_shares_and_last_price_yield_product(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="MC1")
+        _seed_shares(
+            ebull_test_conn,
+            instrument_id=iid,
+            val=15_000_000_000,
+            taxonomy="dei",
+            concept="EntityCommonStockSharesOutstanding",
+        )
+        _seed_quote(ebull_test_conn, instrument_id=iid, price=200)
+
+        got = compute_market_cap(ebull_test_conn, instrument_id=iid)
+        assert got is not None
+        assert got.value == Decimal("3000000000000.000000")
+        assert got.shares_source == "dei"
+
+    def test_us_gaap_fallback(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="MC2")
+        _seed_shares(ebull_test_conn, instrument_id=iid, val=5_000_000)
+        _seed_quote(ebull_test_conn, instrument_id=iid, price=50)
+
+        got = compute_market_cap(ebull_test_conn, instrument_id=iid)
+        assert got is not None
+        assert got.value == Decimal("250000000.000000")
+        assert got.shares_source == "us-gaap"
+
+    def test_no_shares_returns_none(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="MC3")
+        _seed_quote(ebull_test_conn, instrument_id=iid, price=50)
+        assert compute_market_cap(ebull_test_conn, instrument_id=iid) is None
+
+    def test_no_quote_returns_none(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="MC4")
+        _seed_shares(ebull_test_conn, instrument_id=iid, val=1_000_000)
+        assert compute_market_cap(ebull_test_conn, instrument_id=iid) is None
+
+    def test_zero_shares_returns_none(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="MC5")
+        _seed_shares(ebull_test_conn, instrument_id=iid, val=0)
+        _seed_quote(ebull_test_conn, instrument_id=iid, price=50)
+        assert compute_market_cap(ebull_test_conn, instrument_id=iid) is None
+
+    def test_falls_back_to_bid_ask_midpoint_when_last_missing(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="MC6")
+        _seed_shares(ebull_test_conn, instrument_id=iid, val=10_000_000)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO quotes (instrument_id, quoted_at, bid, ask, last)
+                VALUES (%s, NOW(), 99, 101, NULL)
+                """,
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        got = compute_market_cap(ebull_test_conn, instrument_id=iid)
+        assert got is not None
+        # (99 + 101) / 2 = 100
+        assert got.price == Decimal("100.0000000000000000000000000000")
+        assert got.value == Decimal("1000000000.00000000000000000000000000000000")


### PR DESCRIPTION
## What
First swap in the #432 yfinance-retire ladder. Introduces \`app/services/xbrl_derived_stats.py\` and wires \`compute_market_cap\` into \`/instruments/{symbol}/summary\`. SEC-computed value preferred over yfinance when a share count is available.

## Pieces
- **Service** \`xbrl_derived_stats.compute_market_cap\` — joins \`instrument_share_count_latest\` (#435) × quote (COALESCE last → bid/ask midpoint). Returns \`MarketCap\` dataclass with value, shares, price, both as-of dates + source taxonomy.
- **Endpoint** \`get_instrument_summary\` — calls the helper after existing fundamentals fetch so cursor sequence stays last-position-additive. Falls through to \`profile.market_cap\` when computed is None.

## Test plan
- [x] 6 new service tests vs ebull_test (DEI/us-gaap source, empty inputs, zero guards, bid/ask midpoint fallback)
- [x] 3 existing summary tests updated with additional cursor slot (\`[None]\`) — keeps key-stats assertions intact
- [x] \`uv run pytest\` — 2457 passed
- [x] \`uv run ruff check\` + \`format --check\` + \`pyright\`

## Ladder status (#432)
- [x] market_cap
- [ ] pe_ttm / pb / roe / roa / debt_to_equity (next PR)
- [ ] revenue_growth_yoy / earnings_growth_yoy
- [ ] employees (DEI fact ready, needs service fn + swap)
- [ ] analyst_estimates (genuine gap — ticket body lists Finnhub free as option)

🤖 Generated with [Claude Code](https://claude.com/claude-code)