### PR TITLE
feat(#436): writer-discipline regression guard — no direct raw writes

### DIFF
--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -882,7 +882,7 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 
 ### Empty-parametrize silent pass
 
-- First seen in: #445 (Claude review bot).
+- First seen in: #436 (surfaced by Claude review bot on PR #445).
 - Symptom: `tests/test_raw_persistence.py::TestProviderWriterDiscipline` used `@pytest.mark.parametrize("path", _iter_provider_files())`. When the generator resolves at collection time and returns `[]` (missing directory, wrong cwd, broken `rglob`, test run from an unexpected root), pytest skips every parametrised case silently with a green summary — the guard looks alive while checking nothing. Especially dangerous for regression-guard tests: the surface they're supposed to cover is exactly the kind of thing that rots without a loud failure.
 - Prevention: When a parametrised test's input is a dynamic glob / query / reflection, add a non-parametrised sentinel assertion that the input source returns at least the expected minimum cardinality. Name it `test_<source>_sentinel` so it runs alongside the guard and fails the file if the source degrades. Applies to any `@pytest.mark.parametrize(arg, generator())` where the generator could return empty — glob-based file scans, DB fixture enumerations, manifest reads, `pkgutil.iter_modules` walks, etc.
 - Enforced in: this prevention log; `tests/test_raw_persistence.py::test_provider_files_sentinel` pins `_iter_provider_files()` at `>= 10` entries.

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -877,3 +877,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
   ```
   This lets the option identity stay fixed while the real implementation rebinds freely. Before pushing any hook-wiring change, check whether the options passed to custom hooks are memoised — an inline `() => foo()` is a red flag whenever `foo` has non-trivial deps.
 - Enforced in: this prevention log; `frontend/src/pages/SetupPage.tsx` (`completeRef` + stable `onComplete` pattern).
+
+---
+
+### Empty-parametrize silent pass
+
+- First seen in: #445 (Claude review bot).
+- Symptom: `tests/test_raw_persistence.py::TestProviderWriterDiscipline` used `@pytest.mark.parametrize("path", _iter_provider_files())`. When the generator resolves at collection time and returns `[]` (missing directory, wrong cwd, broken `rglob`, test run from an unexpected root), pytest skips every parametrised case silently with a green summary — the guard looks alive while checking nothing. Especially dangerous for regression-guard tests: the surface they're supposed to cover is exactly the kind of thing that rots without a loud failure.
+- Prevention: When a parametrised test's input is a dynamic glob / query / reflection, add a non-parametrised sentinel assertion that the input source returns at least the expected minimum cardinality. Name it `test_<source>_sentinel` so it runs alongside the guard and fails the file if the source degrades. Applies to any `@pytest.mark.parametrize(arg, generator())` where the generator could return empty — glob-based file scans, DB fixture enumerations, manifest reads, `pkgutil.iter_modules` walks, etc.
+- Enforced in: this prevention log; `tests/test_raw_persistence.py::test_provider_files_sentinel` pins `_iter_provider_files()` at `>= 10` entries.

--- a/tests/test_raw_persistence.py
+++ b/tests/test_raw_persistence.py
@@ -10,6 +10,7 @@ polluting the real ``data/raw/`` tree.
 
 from __future__ import annotations
 
+import ast
 import os
 from pathlib import Path
 from typing import Any
@@ -168,3 +169,98 @@ class TestPersistRawIfNew:
         with pytest.raises(KeyError):
             persist_raw_if_new("nonexistent_source", "tag", {"k": "v"})
         assert not (tmp_path / "nonexistent_source").exists()
+
+
+# ---------------------------------------------------------------------
+# Writer-discipline regression guard (#436)
+# ---------------------------------------------------------------------
+
+
+_PROVIDERS_ROOT = Path(__file__).parent.parent / "app" / "providers"
+
+
+def _iter_provider_files() -> list[Path]:
+    """Every ``.py`` under ``app/providers/`` except ``__init__``.
+
+    Recurses so helper subpackages can't escape the guard by hiding
+    the forbidden call in a nested module."""
+    return sorted(p for p in _PROVIDERS_ROOT.rglob("*.py") if p.name != "__init__.py")
+
+
+# Attribute-name write shapes. The full regression surface is wider
+# (``os.write``, ``open(...).write``, ``from json import dump`` etc.)
+# so the guard also flags any bare ``write`` / ``writelines`` /
+# ``dump`` attribute call that isn't on a logger — providers have no
+# legitimate write path outside ``persist_raw_if_new``.
+_FORBIDDEN_WRITE_ATTRS = {
+    "write",
+    "writelines",
+    "write_text",
+    "write_bytes",
+    "dump",  # json.dump (qualified) + bare dump from ``from json import dump``
+}
+
+# Attribute roots that are known safe — writing to these cannot land
+# a raw payload on disk. Keeping the allow set short + specific means
+# any unexpected call site surfaces as an offender rather than being
+# silently swallowed. Extend only with explicit review.
+_SAFE_WRITE_ROOTS = {
+    "logger",
+    "log",
+    "sys",  # sys.stdout.write / sys.stderr.write (diagnostic only)
+}
+
+
+def _attribute_root_name(node: ast.AST) -> str | None:
+    """Return the leftmost Name in a ``foo.bar.baz`` attribute chain.
+
+    Used to classify ``logger.info(...).write(...)``-style chains as
+    safe (root = ``logger``) vs ``open(target).write(...)``-style
+    chains (root is a Call, returns None → treated as unsafe)."""
+    while isinstance(node, ast.Attribute):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else None
+
+
+class TestProviderWriterDiscipline:
+    """#436 — providers must route raw persistence through
+    ``persist_raw_if_new``. Any other write path is a regression
+    surface for the pre-migration double-write pattern (timestamp
+    variant + hash variant of the same payload)."""
+
+    @pytest.mark.parametrize(
+        "path",
+        _iter_provider_files(),
+        ids=lambda p: p.relative_to(_PROVIDERS_ROOT).as_posix(),
+    )
+    def test_no_direct_file_writes(self, path: Path) -> None:
+        """No provider makes a filesystem write outside the sanctioned
+        ``persist_raw_if_new`` path. Shape-independent: catches
+        ``.write``/``.writelines``/``.write_text``/``.write_bytes``/
+        ``.dump`` on any value that is not a logging sink. Widened
+        from the earlier ``{dump, write_text, write_bytes}`` set per
+        Codex checkpoint — ``open(target).write(...)`` and
+        ``handle.write(...)`` shapes were previously invisible."""
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        offenders: list[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute):
+                # Bare ``dump(obj, f)`` (``from json import dump``):
+                # also a regression surface. Flag Name-form calls to
+                # forbidden identifiers.
+                if isinstance(func, ast.Name) and func.id in _FORBIDDEN_WRITE_ATTRS:
+                    offenders.append(f"line {node.lineno}: {ast.unparse(node)[:120]}")
+                continue
+            if func.attr not in _FORBIDDEN_WRITE_ATTRS:
+                continue
+            root = _attribute_root_name(func.value)
+            if root in _SAFE_WRITE_ROOTS:
+                continue
+            offenders.append(f"line {node.lineno}: {ast.unparse(node)[:120]}")
+        assert not offenders, (
+            f"{path.name} makes a direct filesystem write — providers "
+            f"must route through persist_raw_if_new:\n  " + "\n  ".join(offenders)
+        )

--- a/tests/test_raw_persistence.py
+++ b/tests/test_raw_persistence.py
@@ -179,12 +179,36 @@ class TestPersistRawIfNew:
 _PROVIDERS_ROOT = Path(__file__).parent.parent / "app" / "providers"
 
 
+# Bumped with each real provider addition so a misconfigured test env
+# (missing directory, wrong cwd, broken glob) can't silently pass with
+# zero parametrised cases. Fails LOUD instead — review-prevention
+# entry "empty-parametrize silent pass".
+_MIN_PROVIDER_FILES = 10
+
+
 def _iter_provider_files() -> list[Path]:
     """Every ``.py`` under ``app/providers/`` except ``__init__``.
 
     Recurses so helper subpackages can't escape the guard by hiding
     the forbidden call in a nested module."""
     return sorted(p for p in _PROVIDERS_ROOT.rglob("*.py") if p.name != "__init__.py")
+
+
+def test_provider_files_sentinel() -> None:
+    """Non-parametrised safety net — proves ``_iter_provider_files``
+    resolves a non-empty set. If this test is the only one in the
+    class to run (zero parametrised cases), the guard below silently
+    passes and loses its regression value. This sentinel fails the
+    whole file if the glob returns less than the expected minimum,
+    so a missing directory / wrong cwd / broken pathing surfaces
+    immediately rather than during a real regression."""
+    files = _iter_provider_files()
+    assert len(files) >= _MIN_PROVIDER_FILES, (
+        f"_iter_provider_files() returned {len(files)} files — expected "
+        f"at least {_MIN_PROVIDER_FILES}. The writer-discipline guard "
+        f"would silently pass with zero parametrised cases. Check "
+        f"{_PROVIDERS_ROOT} exists and contains provider modules."
+    )
 
 
 # Attribute-name write shapes. The full regression surface is wider


### PR DESCRIPTION
## What
Adds a parametrised AST-walk test (`tests/test_raw_persistence.py::TestProviderWriterDiscipline`) that flags any provider file under `app/providers/**/*.py` making a direct filesystem write (`.write`/`.writelines`/`.write_text`/`.write_bytes`/`.dump`) outside a sanctioned logging sink root (`logger`/`log`/`sys`). Also catches bare `Name` calls for `from json import dump`.

## Why
Writer-side migration to `persist_raw_if_new` is already complete (0 legacy timestamp files across all `data/raw/` subtrees except 1 sec_fundamentals straggler that compaction will reclaim). Acceptance on #436 is effectively met. This ship is the regression guard so a future provider refactor can't silently re-introduce the pre-migration double-write.

## Test plan
- [x] `uv run pytest tests/test_raw_persistence.py -q` — 31 pass (+15 new parametrised cases)
- [x] `uv run pytest -q` — 2472 pass, 1 skip
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] Codex checkpoint 2 (3 rounds; residual: aliased imports `dump as X` + chained `self.logger` roots — adversarial, no current offenders)

Closes #436