### PR TITLE
feat(#434): 8-K Item 8.01 dividend calendar — parser + ingester + banner

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -880,10 +880,21 @@ class DividendSummaryModel(BaseModel):
     dividend_currency: str | None
 
 
+class UpcomingDividendModel(BaseModel):
+    source_accession: str
+    declaration_date: date | None
+    ex_date: date | None
+    record_date: date | None
+    pay_date: date | None
+    dps_declared: Decimal | None
+    currency: str
+
+
 class InstrumentDividends(BaseModel):
     symbol: str
     summary: DividendSummaryModel
     history: list[DividendPeriodModel]
+    upcoming: list[UpcomingDividendModel]
 
 
 @router.get("/{symbol}/dividends", response_model=InstrumentDividends)
@@ -902,7 +913,11 @@ def get_instrument_dividends(
 
     Default ``limit=40`` covers ten years of quarterly history.
     """
-    from app.services.dividends import get_dividend_history, get_dividend_summary
+    from app.services.dividends import (
+        get_dividend_history,
+        get_dividend_summary,
+        get_upcoming_dividends,
+    )
 
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:
@@ -926,6 +941,7 @@ def get_instrument_dividends(
     instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
     summary = get_dividend_summary(conn, instrument_id=instrument_id)
     history = get_dividend_history(conn, instrument_id=instrument_id, limit=limit)
+    upcoming = get_upcoming_dividends(conn, instrument_id=instrument_id)
 
     return InstrumentDividends(
         symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
@@ -950,6 +966,18 @@ def get_instrument_dividends(
                 reported_currency=p.reported_currency,
             )
             for p in history
+        ],
+        upcoming=[
+            UpcomingDividendModel(
+                source_accession=u.source_accession,
+                declaration_date=u.declaration_date,
+                ex_date=u.ex_date,
+                record_date=u.record_date,
+                pay_date=u.pay_date,
+                dps_declared=u.dps_declared,
+                currency=u.currency,
+            )
+            for u in upcoming
         ],
     )
 

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -70,6 +70,7 @@ from app.workers.scheduler import (
     JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
     JOB_RAW_DATA_RETENTION_SWEEP,
     JOB_RETRY_DEFERRED,
+    JOB_SEC_DIVIDEND_CALENDAR_INGEST,
     JOB_SEED_COST_MODELS,
     JOB_WEEKLY_REPORT,
     SCHEDULED_JOBS,
@@ -92,6 +93,7 @@ from app.workers.scheduler import (
     orchestrator_high_frequency_sync,
     raw_data_retention_sweep,
     retry_deferred_recommendations_job,
+    sec_dividend_calendar_ingest,
     seed_cost_models,
     weekly_report,
 )
@@ -138,6 +140,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_ORCHESTRATOR_FULL_SYNC: orchestrator_full_sync,
     JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC: orchestrator_high_frequency_sync,
     JOB_RAW_DATA_RETENTION_SWEEP: raw_data_retention_sweep,
+    JOB_SEC_DIVIDEND_CALENDAR_INGEST: sec_dividend_calendar_ingest,
 }
 
 

--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -262,6 +262,28 @@ class SecFilingsProvider(FilingsProvider):
 
         return _normalise_filing_event(provider_filing_id, raw)
 
+    def fetch_document_text(self, absolute_url: str) -> str | None:
+        """Fetch the raw text of a filing's primary document.
+
+        ``absolute_url`` is the fully-qualified ``https://www.sec.gov/
+        Archives/edgar/data/...`` URL stored in
+        ``filing_events.primary_document_url``. Returns the decoded
+        body on 2xx, ``None`` on 404 / 410 (filing withdrawn), and
+        re-raises on other HTTP errors so the caller can decide
+        whether to retry or skip.
+
+        Shares the tickers client's rate-limiter because both target
+        ``www.sec.gov`` — ``data.sec.gov`` uses a separate host that
+        counts under the same 10 req/s fair-use pool but is served
+        by ``self._http``. Using ``_http_tickers`` here keeps the
+        host-to-client mapping obvious (www.sec.gov ⇒ tickers client).
+        """
+        resp = self._http_tickers.get(absolute_url)
+        if resp.status_code in (404, 410):
+            return None
+        resp.raise_for_status()
+        return resp.text
+
     # ------------------------------------------------------------------
     # CIK mapping (for service layer to populate external_identifiers)
     # ------------------------------------------------------------------

--- a/app/services/dividend_calendar.py
+++ b/app/services/dividend_calendar.py
@@ -342,6 +342,30 @@ def ingest_dividend_events(
     fetch_errors = 0
     parse_misses = 0
 
+    # Tombstone sentinel: written on fetch-errors + parse-misses so
+    # the JOIN's 7-day TTL bounds re-fetches to weekly rather than
+    # daily. A DividendAnnouncement with every field None satisfies
+    # the partial-row TTL predicate and naturally gets revisited
+    # when the window expires (Codex PR #446 review WARNING).
+    _TOMBSTONE = DividendAnnouncement()
+
+    def _write_tombstone(instrument_id: int, accession: str) -> None:
+        try:
+            upsert_dividend_event(
+                conn,
+                instrument_id=instrument_id,
+                source_accession=accession,
+                announcement=_TOMBSTONE,
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            logger.warning(
+                "ingest_dividend_events: tombstone upsert failed accession=%s",
+                accession,
+                exc_info=True,
+            )
+
     for _filing_id, instrument_id, accession, url in candidates:
         try:
             body = fetcher.fetch_document_text(url)
@@ -353,17 +377,23 @@ def ingest_dividend_events(
                 exc_info=True,
             )
             fetch_errors += 1
+            _write_tombstone(instrument_id, accession)
             continue
         if body is None:
-            # 404 / 410 — filing withdrawn or URL moved. Not an error
-            # state; just skip and let the next pass retry if it ever
-            # comes back.
+            # 404 / 410 — filing withdrawn or URL moved. Write a
+            # tombstone so the 7-day TTL on last_parsed_at caps retry
+            # cadence at weekly rather than daily.
             fetch_errors += 1
+            _write_tombstone(instrument_id, accession)
             continue
 
         announcement = parse_dividend_announcement(body)
         if announcement is None:
+            # Non-dividend 8.01 (buyback, JV, litigation) — same
+            # tombstone treatment. The parser may improve later and
+            # weekly re-parse will pick it up.
             parse_misses += 1
+            _write_tombstone(instrument_id, accession)
             continue
 
         try:

--- a/app/services/dividend_calendar.py
+++ b/app/services/dividend_calendar.py
@@ -1,0 +1,445 @@
+"""Dividend-calendar parser + ingester for 8-K Item 8.01 (#434).
+
+SEC XBRL (``financial_periods.dps_declared``) captures per-period
+declared amounts but NOT the ex-date / record-date / pay-date
+calendar. That calendar lives only in the free-form announcement
+text of 8-Ks carrying Item 8.01 "Other Events". This module:
+
+1. Parses a single 8-K primary-document text into a
+   :class:`DividendAnnouncement` — a pure function, heavily unit-
+   tested against real Aristocrats shapes.
+2. Ingests unparsed 8.01 filings into ``dividend_events`` — pulls
+   the primary document via the SEC provider, parses, upserts.
+
+Acceptance bar (issue #434): ≥80% of Dividend Aristocrats extract
+cleanly. The parser is intentionally regex-only — LLM-based fallback
+is phase-2 if coverage proves insufficient.
+
+Shape: ``parse_dividend_announcement`` is the one public pure
+function. The DB path is :func:`ingest_dividend_events` which owns
+the filing fetch + upsert, commits per filing so a bad one doesn't
+roll back the batch.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Protocol
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+class _DocFetcher(Protocol):
+    """Minimal subset of ``SecFilingsProvider`` the ingester needs.
+
+    Narrow Protocol (not the full provider) so tests can substitute
+    a plain callable-shaped stub without implementing the full
+    provider interface."""
+
+    def fetch_document_text(self, absolute_url: str) -> str | None: ...
+
+
+# ---------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DividendAnnouncement:
+    """Structured extraction from one 8-K Item 8.01 primary document.
+
+    All date fields + the amount are individually nullable so a
+    partially-parsed announcement still yields a useful row (e.g. an
+    amount with no dates, or dates without an amount). ``None`` as
+    the parser's overall return value means "not a dividend
+    announcement" — a separate signal from "dividend announcement
+    with missing fields".
+
+    ``dps_declared`` is a string to preserve the exact decimal
+    precision that appears in the filing. Casting to Decimal happens
+    at the DB boundary via psycopg's NUMERIC adapter; string avoids
+    introducing float drift in transit.
+    """
+
+    declaration_date: date | None = None
+    ex_date: date | None = None
+    record_date: date | None = None
+    pay_date: date | None = None
+    dps_declared: str | None = None
+
+
+# ---------------------------------------------------------------------
+# HTML → text
+# ---------------------------------------------------------------------
+
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+# &nbsp; / numeric entities appear everywhere in EDGAR HTML; normalise
+# to plain spaces before the label regexes run so "\s+" buffers work.
+_NBSP_RE = re.compile(r"&nbsp;|&#160;|&#xa0;| ", re.IGNORECASE)
+
+
+def _strip_html(text: str) -> str:
+    """Collapse HTML tags + entities to a single flat whitespace
+    stream. Deliberately crude — the point is making the regexes
+    below whitespace-tolerant, not preserving semantic structure."""
+    no_nbsp = _NBSP_RE.sub(" ", text)
+    no_tags = _HTML_TAG_RE.sub(" ", no_nbsp)
+    return _WHITESPACE_RE.sub(" ", no_tags).strip()
+
+
+# ---------------------------------------------------------------------
+# Date parsing
+# ---------------------------------------------------------------------
+
+
+_MONTHS = {
+    "january": 1,
+    "february": 2,
+    "march": 3,
+    "april": 4,
+    "may": 5,
+    "june": 6,
+    "july": 7,
+    "august": 8,
+    "september": 9,
+    "october": 10,
+    "november": 11,
+    "december": 12,
+    # Three-letter abbreviations occur in press-release-style 8-Ks.
+    "jan": 1,
+    "feb": 2,
+    "mar": 3,
+    "apr": 4,
+    "jun": 6,
+    "jul": 7,
+    "aug": 8,
+    "sep": 9,
+    "sept": 9,
+    "oct": 10,
+    "nov": 11,
+    "dec": 12,
+}
+
+_MONTH_NAME_ALT = "|".join(sorted(_MONTHS.keys(), key=len, reverse=True))
+# Two shapes we accept:
+#   (a) "Month DD, YYYY" — SEC canonical press-release form
+#   (b) "MM/DD/YYYY" or "M/D/YYYY" — some smaller filers
+_DATE_RE = re.compile(
+    rf"(?:(?P<m1>{_MONTH_NAME_ALT})\s+(?P<d1>\d{{1,2}}),?\s+(?P<y1>\d{{4}}))"
+    rf"|(?:(?P<m2>\d{{1,2}})/(?P<d2>\d{{1,2}})/(?P<y2>\d{{4}}))",
+    re.IGNORECASE,
+)
+
+
+def _parse_date(raw: str | None) -> date | None:
+    """Parse a single date token (already known to match ``_DATE_RE``).
+
+    Returns ``None`` for out-of-range month/day or any parse failure
+    — the parser never raises for bad dates, since filings carry
+    typos often enough that aborting the whole announcement would
+    drop real rows."""
+    if not raw:
+        return None
+    m = _DATE_RE.search(raw)
+    if m is None:
+        return None
+    try:
+        if m.group("m1"):
+            month = _MONTHS[m.group("m1").lower()]
+            day = int(m.group("d1"))
+            year = int(m.group("y1"))
+        else:
+            month = int(m.group("m2"))
+            day = int(m.group("d2"))
+            year = int(m.group("y2"))
+        return date(year, month, day)
+    except KeyError, ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------
+# Label-oriented extraction
+# ---------------------------------------------------------------------
+
+
+# Dividend-language gate: the text MUST contain an explicit "dividend"
+# reference near a dollar-per-share shape, otherwise it's not a
+# dividend announcement (Item 8.01 also covers buybacks, litigation,
+# JV news, etc.). The regex is intentionally broad on both sides so
+# real announcements match regardless of word order.
+_DIVIDEND_CONTEXT_RE = re.compile(
+    r"dividend[\s\S]{0,120}?\$\s*\d+\.\d+[\s\S]{0,20}?per\s+share"
+    r"|\$\s*\d+\.\d+[\s\S]{0,40}?per\s+share[\s\S]{0,120}?dividend",
+    re.IGNORECASE,
+)
+
+_AMOUNT_RE = re.compile(
+    r"\$\s*(?P<amt>\d+\.\d+)\s*(?:per\s+share|a\s+share|/\s*share)",
+    re.IGNORECASE,
+)
+
+# Each calendar-date label below is anchored to a known phrase then a
+# bounded lookahead for the date. The bound is tight enough that a
+# later mention of a different date doesn't bleed across labels.
+_DECLARATION_RE = re.compile(
+    r"on\s+(?P<when>" + _DATE_RE.pattern + r")[^.]{0,160}?"
+    r"(?:board|directors)[^.]{0,60}?declared",
+    re.IGNORECASE,
+)
+_PAY_RE = re.compile(
+    r"payable\s+(?:on\s+)?(?P<when>" + _DATE_RE.pattern + r")",
+    re.IGNORECASE,
+)
+_RECORD_RE = re.compile(
+    r"(?:shareholders?|stockholders?|holders?)\s+of\s+record"
+    r"(?:\s+(?:as\s+of|on|at(?:\s+the\s+close\s+of\s+business\s+on)?))?"
+    r"\s+(?P<when>" + _DATE_RE.pattern + r")",
+    re.IGNORECASE,
+)
+_EX_RE = re.compile(
+    r"ex[-\s]?dividend\s+date[^.]{0,40}?"
+    r"(?P<when>" + _DATE_RE.pattern + r")",
+    re.IGNORECASE,
+)
+
+
+def parse_dividend_announcement(raw_text: str) -> DividendAnnouncement | None:
+    """Extract dividend calendar + amount from one 8-K Item 8.01 text.
+
+    Returns ``None`` when the document does not look like a dividend
+    announcement (no ``$N.NN per share`` + ``dividend`` co-occurring).
+
+    Returns a :class:`DividendAnnouncement` otherwise — any
+    individually-missing field is ``None``. Callers treat the return
+    as advisory: a parsed row carrying only an amount still beats
+    silently dropping a filing where the date language was in a
+    shape the regex doesn't cover yet.
+    """
+    if not raw_text:
+        return None
+    text = _strip_html(raw_text)
+    if not _DIVIDEND_CONTEXT_RE.search(text):
+        return None
+
+    amt_m = _AMOUNT_RE.search(text)
+    dps = amt_m.group("amt") if amt_m else None
+
+    declaration = _parse_date(_extract(_DECLARATION_RE, text))
+    pay = _parse_date(_extract(_PAY_RE, text))
+    record = _parse_date(_extract(_RECORD_RE, text))
+    ex = _parse_date(_extract(_EX_RE, text))
+
+    if not any((declaration, pay, record, ex, dps)):
+        # Dividend context matched but nothing we can commit — skip.
+        return None
+
+    return DividendAnnouncement(
+        declaration_date=declaration,
+        ex_date=ex,
+        record_date=record,
+        pay_date=pay,
+        dps_declared=dps,
+    )
+
+
+def _extract(pattern: re.Pattern[str], text: str) -> str | None:
+    m = pattern.search(text)
+    return m.group("when") if m else None
+
+
+# ---------------------------------------------------------------------
+# DB upsert
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    """Outcome of one ``ingest_dividend_events`` call."""
+
+    filings_scanned: int
+    rows_inserted: int
+    rows_updated: int
+    fetch_errors: int
+    parse_misses: int
+
+
+def ingest_dividend_events(
+    conn: psycopg.Connection[Any],
+    fetcher: _DocFetcher,
+    *,
+    limit: int = 500,
+) -> IngestResult:
+    """Find unprocessed 8-K Item 8.01 filings, fetch + parse + upsert.
+
+    Query shape: filings where ``provider='sec'``, ``filing_type='8-K'``,
+    ``items`` contains ``'8.01'``, ``primary_document_url IS NOT NULL``,
+    AND there is no existing ``dividend_events`` row for
+    ``(instrument_id, provider_filing_id)``. Oldest-first so a stop
+    mid-batch resumes cleanly.
+
+    Commits after each filing. A fetch failure or a parse miss on one
+    filing never rolls back siblings in the batch — per-row
+    durability over throughput since the ingester runs daily and
+    filings arrive in tens, not millions.
+
+    Returns an :class:`IngestResult` with counters; callers log it.
+    """
+    conn.commit()  # settle any open read tx (service-wide durability invariant).
+
+    # Candidate selector rules (addresses Codex #434 review):
+    #
+    # 1. Re-parse partial rows so a future regex improvement can backfill
+    #    missing dates. A row is "partial" when any of the three calendar
+    #    dates (ex/record/pay) is NULL. Upsert is idempotent so a stable
+    #    full row never produces a duplicate.
+    # 2. Gate the re-parse with a 7-day TTL (``created_at``) so stable
+    #    partial rows don't pound SEC every run.
+    # 3. Order by ``filing_date DESC`` so fresh filings always get budget
+    #    — prevents a backlog of permanent parse-misses at the oldest end
+    #    from starving newer, parseable announcements.
+    candidates: list[tuple[int, int, str, str]] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT fe.filing_event_id,
+                   fe.instrument_id,
+                   fe.provider_filing_id,
+                   fe.primary_document_url
+            FROM filing_events fe
+            LEFT JOIN dividend_events de
+              ON de.instrument_id = fe.instrument_id
+             AND de.source_accession = fe.provider_filing_id
+            WHERE fe.provider = 'sec'
+              AND fe.filing_type = '8-K'
+              AND fe.items IS NOT NULL
+              AND '8.01' = ANY(fe.items)
+              AND fe.primary_document_url IS NOT NULL
+              AND (
+                    de.id IS NULL
+                 OR (
+                        (de.ex_date IS NULL OR de.record_date IS NULL OR de.pay_date IS NULL)
+                        AND de.last_parsed_at < NOW() - INTERVAL '7 days'
+                    )
+              )
+            ORDER BY fe.filing_date DESC
+            LIMIT %s
+            """,
+            (limit,),
+        )
+        for row in cur.fetchall():
+            candidates.append((int(row[0]), int(row[1]), str(row[2]), str(row[3])))
+    conn.commit()
+
+    inserted = 0
+    updated = 0
+    fetch_errors = 0
+    parse_misses = 0
+
+    for _filing_id, instrument_id, accession, url in candidates:
+        try:
+            body = fetcher.fetch_document_text(url)
+        except Exception:
+            logger.warning(
+                "ingest_dividend_events: fetch failed accession=%s url=%s",
+                accession,
+                url,
+                exc_info=True,
+            )
+            fetch_errors += 1
+            continue
+        if body is None:
+            # 404 / 410 — filing withdrawn or URL moved. Not an error
+            # state; just skip and let the next pass retry if it ever
+            # comes back.
+            fetch_errors += 1
+            continue
+
+        announcement = parse_dividend_announcement(body)
+        if announcement is None:
+            parse_misses += 1
+            continue
+
+        try:
+            did_insert = upsert_dividend_event(
+                conn,
+                instrument_id=instrument_id,
+                source_accession=accession,
+                announcement=announcement,
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            logger.warning(
+                "ingest_dividend_events: upsert failed accession=%s",
+                accession,
+                exc_info=True,
+            )
+            continue
+
+        if did_insert:
+            inserted += 1
+        else:
+            updated += 1
+
+    return IngestResult(
+        filings_scanned=len(candidates),
+        rows_inserted=inserted,
+        rows_updated=updated,
+        fetch_errors=fetch_errors,
+        parse_misses=parse_misses,
+    )
+
+
+def upsert_dividend_event(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    source_accession: str,
+    announcement: DividendAnnouncement,
+    currency: str = "USD",
+) -> bool:
+    """Insert or update one ``dividend_events`` row.
+
+    Returns ``True`` on INSERT, ``False`` on UPDATE. Idempotency key
+    is ``(instrument_id, source_accession)`` per the migration's
+    UNIQUE constraint — re-running the ingester on the same filing
+    rewrites dates/amount if the parser now recognises shapes it
+    previously missed.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO dividend_events
+                (instrument_id, source_accession, declaration_date,
+                 ex_date, record_date, pay_date, dps_declared, currency)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (instrument_id, source_accession) DO UPDATE SET
+                declaration_date = EXCLUDED.declaration_date,
+                ex_date          = EXCLUDED.ex_date,
+                record_date      = EXCLUDED.record_date,
+                pay_date         = EXCLUDED.pay_date,
+                dps_declared     = EXCLUDED.dps_declared,
+                currency         = EXCLUDED.currency,
+                last_parsed_at   = NOW()
+            RETURNING (xmax = 0) AS inserted
+            """,
+            (
+                instrument_id,
+                source_accession,
+                announcement.declaration_date,
+                announcement.ex_date,
+                announcement.record_date,
+                announcement.pay_date,
+                announcement.dps_declared,
+                currency,
+            ),
+        )
+        row = cur.fetchone()
+        return bool(row[0]) if row else False

--- a/app/services/dividend_calendar.py
+++ b/app/services/dividend_calendar.py
@@ -344,19 +344,15 @@ def ingest_dividend_events(
 
     # Tombstone sentinel: written on fetch-errors + parse-misses so
     # the JOIN's 7-day TTL bounds re-fetches to weekly rather than
-    # daily. A DividendAnnouncement with every field None satisfies
-    # the partial-row TTL predicate and naturally gets revisited
-    # when the window expires (Codex PR #446 review WARNING).
-    _TOMBSTONE = DividendAnnouncement()
-
+    # daily. On first-time: inserts a row with all-NULL date/amount
+    # fields. On re-attempt (row already exists from a prior run
+    # that parsed partial data): ONLY bumps ``last_parsed_at`` and
+    # preserves the existing dates/amount — must not clobber
+    # previously-extracted values with NULLs when a transient fetch
+    # error hits between TTL windows (Codex PR #446 BLOCKING fix).
     def _write_tombstone(instrument_id: int, accession: str) -> None:
         try:
-            upsert_dividend_event(
-                conn,
-                instrument_id=instrument_id,
-                source_accession=accession,
-                announcement=_TOMBSTONE,
-            )
+            _upsert_tombstone(conn, instrument_id=instrument_id, source_accession=accession)
             conn.commit()
         except Exception:
             conn.rollback()
@@ -425,6 +421,36 @@ def ingest_dividend_events(
         fetch_errors=fetch_errors,
         parse_misses=parse_misses,
     )
+
+
+def _upsert_tombstone(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    source_accession: str,
+) -> None:
+    """Insert an all-NULL tombstone OR bump ``last_parsed_at`` on an
+    existing row — never overwrites non-NULL date/amount fields.
+
+    Called when the ingester records a fetch error or parse miss for
+    a filing. The idempotency contract of the partial-row TTL rule
+    (re-parse after 7 days) combined with a fetch failure between
+    TTL windows must NOT destroy the previously-parsed dates. A
+    prior run's real data wins over a later transient-failure
+    tombstone.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO dividend_events
+                (instrument_id, source_accession, declaration_date,
+                 ex_date, record_date, pay_date, dps_declared, currency)
+            VALUES (%s, %s, NULL, NULL, NULL, NULL, NULL, 'USD')
+            ON CONFLICT (instrument_id, source_accession) DO UPDATE SET
+                last_parsed_at = NOW()
+            """,
+            (instrument_id, source_accession),
+        )
 
 
 def upsert_dividend_event(

--- a/app/services/dividends.py
+++ b/app/services/dividends.py
@@ -35,6 +35,23 @@ class DividendPeriod:
 
 
 @dataclass(frozen=True)
+class UpcomingDividend:
+    """Forward-looking dividend calendar row from the 8-K parser (#434).
+
+    Drives the instrument-page "Next dividend" banner. Any individual
+    date may be ``None`` when the 8-K announcement disclosed only a
+    subset (e.g. ex-date + pay-date without a record-date)."""
+
+    source_accession: str
+    declaration_date: date | None
+    ex_date: date | None
+    record_date: date | None
+    pay_date: date | None
+    dps_declared: Decimal | None
+    currency: str
+
+
+@dataclass(frozen=True)
 class DividendSummary:
     """Roll-up across all periods for one instrument.
 
@@ -149,6 +166,87 @@ def get_dividend_history(
             dps_declared=r["dps_declared"],
             dividends_paid=r["dividends_paid"],
             reported_currency=r["reported_currency"],
+        )
+        for r in rows
+    ]
+
+
+_DECLARATION_ONLY_LOOKBACK_DAYS = 90
+
+
+def get_upcoming_dividends(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    reference_date: date | None = None,
+    limit: int = 4,
+) -> list[UpcomingDividend]:
+    """Return announced dividend events whose calendar is still
+    forward-looking on ``reference_date`` (default today).
+
+    Three shapes are included:
+
+    1. ``ex_date >= ref`` — canonical "next dividend" with a parsed
+       ex-date.
+    2. ``ex_date IS NULL AND pay_date >= ref`` — announcement parsed
+       pay-date but not ex-date.
+    3. ``ex_date IS NULL AND pay_date IS NULL AND declaration_date >=
+       ref - 90 days`` — declaration-only rows where the 8-K parse
+       recovered an amount but no calendar dates. Surfaces the
+       "Declared … (calendar TBD)" UI branch. The 90-day lookback is
+       a bounded window so a stale declaration-only row doesn't
+       linger forever when the calendar never materialises.
+
+    Past-dated rows in all three categories are excluded so the
+    banner doesn't cling to last quarter's payout.
+
+    Sorted earliest-first by COALESCE(ex_date, pay_date,
+    declaration_date) so the first element is always the "next"
+    event in whichever dimension survived the regex parse.
+    """
+    if not 1 <= limit <= 20:
+        raise ValueError(f"limit must be 1..20, got {limit}")
+    ref = reference_date or date.today()
+    decl_cutoff = date.fromordinal(ref.toordinal() - _DECLARATION_ONLY_LOOKBACK_DAYS)
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT source_accession,
+                   declaration_date,
+                   ex_date,
+                   record_date,
+                   pay_date,
+                   dps_declared,
+                   currency
+            FROM dividend_events
+            WHERE instrument_id = %s
+              AND (
+                    (ex_date IS NOT NULL AND ex_date >= %s)
+                 OR (ex_date IS NULL AND pay_date IS NOT NULL AND pay_date >= %s)
+                 OR (
+                        ex_date IS NULL
+                        AND pay_date IS NULL
+                        AND declaration_date IS NOT NULL
+                        AND declaration_date >= %s
+                    )
+              )
+            ORDER BY COALESCE(ex_date, pay_date, declaration_date) ASC
+            LIMIT %s
+            """,
+            (instrument_id, ref, ref, decl_cutoff, limit),
+        )
+        rows = cur.fetchall()
+
+    return [
+        UpcomingDividend(
+            source_accession=str(r["source_accession"]),
+            declaration_date=r["declaration_date"],
+            ex_date=r["ex_date"],
+            record_date=r["record_date"],
+            pay_date=r["pay_date"],
+            dps_declared=r["dps_declared"],
+            currency=str(r["currency"]),
         )
         for r in rows
     ]

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -237,6 +237,7 @@ JOB_RAW_DATA_RETENTION_SWEEP = "raw_data_retention_sweep"
 JOB_ORCHESTRATOR_FULL_SYNC = "orchestrator_full_sync"
 JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC = "orchestrator_high_frequency_sync"
 JOB_FUNDAMENTALS_SYNC = "fundamentals_sync"
+JOB_SEC_DIVIDEND_CALENDAR_INGEST = "sec_dividend_calendar_ingest"
 
 
 # ---------------------------------------------------------------------------
@@ -470,6 +471,19 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     # 2026-04-19 research-tool refocus — no UI consumer today. The
     # function body stays in scheduler.py + _INVOKERS so the operator
     # can still manually fire it from Admin "Run now" if needed.
+    ScheduledJob(
+        name=JOB_SEC_DIVIDEND_CALENDAR_INGEST,
+        description=(
+            "Parse 8-K Item 8.01 announcements into ``dividend_events`` "
+            "(#434). Runs 03:00 UTC — 30 min after fundamentals_sync so "
+            "newly-populated ``filing_events.items[]`` rows are visible. "
+            "Bounded to 500 filings per run; the ingester's LEFT JOIN "
+            "guard skips already-processed filings, so a backlog drains "
+            "over several runs without duplicating work."
+        ),
+        cadence=Cadence.daily(hour=3, minute=0),
+        catch_up_on_boot=False,
+    ),
     ScheduledJob(
         name=JOB_RAW_DATA_RETENTION_SWEEP,
         description=(
@@ -2987,4 +3001,38 @@ def raw_data_retention_sweep() -> None:
             total_deleted,
             total_bytes,
             dry_run,
+        )
+
+
+def sec_dividend_calendar_ingest() -> None:
+    """Parse 8-K Item 8.01 announcements into ``dividend_events`` (#434).
+
+    Scans filings where ``items`` contains ``'8.01'`` and no
+    ``dividend_events`` row exists yet, fetches the primary document
+    from SEC via :class:`SecFilingsProvider.fetch_document_text`,
+    parses the dividend calendar, and upserts one row per filing.
+
+    Bounded per run (``limit=500``) so a freshly-populated items[]
+    backlog doesn't tie up the SEC rate-limiter or the worker. The
+    ingester's LEFT JOIN guard makes re-runs idempotent — a backlog
+    drains over successive daily runs.
+    """
+    from app.providers.implementations.sec_edgar import SecFilingsProvider
+    from app.services.dividend_calendar import ingest_dividend_events
+
+    with _tracked_job(JOB_SEC_DIVIDEND_CALENDAR_INGEST) as tracker:
+        with (
+            psycopg.connect(settings.database_url) as conn,
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as provider,
+        ):
+            result = ingest_dividend_events(conn, provider)
+
+        tracker.row_count = result.rows_inserted + result.rows_updated
+        logger.info(
+            "sec_dividend_calendar_ingest complete: scanned=%d inserted=%d updated=%d fetch_errors=%d parse_misses=%d",
+            result.filings_scanned,
+            result.rows_inserted,
+            result.rows_updated,
+            result.fetch_errors,
+            result.parse_misses,
         )

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -62,10 +62,21 @@ export interface DividendSummary {
   dividend_currency: string | null;
 }
 
+export interface UpcomingDividend {
+  source_accession: string;
+  declaration_date: string | null;
+  ex_date: string | null;
+  record_date: string | null;
+  pay_date: string | null;
+  dps_declared: string | null;
+  currency: string;
+}
+
 export interface InstrumentDividends {
   symbol: string;
   summary: DividendSummary;
   history: DividendPeriod[];
+  upcoming: UpcomingDividend[];
 }
 
 export function fetchInstrumentDividends(

--- a/frontend/src/components/instrument/DividendsPanel.test.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.test.tsx
@@ -46,6 +46,7 @@ function paid(): InstrumentDividends {
         reported_currency: "USD",
       },
     ],
+    upcoming: [],
   };
 }
 
@@ -64,6 +65,7 @@ function notPaid(): InstrumentDividends {
       dividend_currency: null,
     },
     history: [],
+    upcoming: [],
   };
 }
 
@@ -103,5 +105,30 @@ describe("DividendsPanel", () => {
     await waitFor(() => {
       expect(screen.getByText(/Failed to load/i)).toBeInTheDocument();
     });
+  });
+
+  it("renders the Next dividend banner when upcoming[] has an entry", async () => {
+    const withUpcoming = paid();
+    withUpcoming.upcoming = [
+      {
+        source_accession: "0000320193-26-000001",
+        declaration_date: "2026-01-15",
+        ex_date: "2026-02-10",
+        record_date: "2026-02-11",
+        pay_date: "2026-02-20",
+        dps_declared: "0.2500",
+        currency: "USD",
+      },
+    ];
+    mockFetch.mockResolvedValue(withUpcoming);
+    render(<DividendsPanel symbol="AAPL" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Next dividend/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Ex-date/i)).toBeInTheDocument();
+    expect(screen.getByText(/2026-02-10/)).toBeInTheDocument();
+    expect(screen.getByText(/2026-02-11/)).toBeInTheDocument();
+    expect(screen.getByText(/2026-02-20/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/instrument/DividendsPanel.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.tsx
@@ -7,7 +7,11 @@
  */
 
 import { fetchInstrumentDividends } from "@/api/instruments";
-import type { DividendPeriod, InstrumentDividends } from "@/api/instruments";
+import type {
+  DividendPeriod,
+  InstrumentDividends,
+  UpcomingDividend,
+} from "@/api/instruments";
 import {
   Section,
   SectionError,
@@ -72,17 +76,77 @@ export function DividendsPanel({ symbol }: DividendsPanelProps) {
         <SectionSkeleton rows={3} />
       ) : state.error !== null || state.data === null ? (
         <SectionError onRetry={state.refetch} />
-      ) : !state.data.summary.has_dividend || state.data.history.length === 0 ? (
-        <EmptyState
-          title="No dividend history on file"
-          description="This instrument has not reported a positive dividend in its SEC filings."
-        />
       ) : (
-        <DividendsBody data={state.data} />
+        <>
+          {/* Upcoming banner renders OUTSIDE the has_dividend gate so a
+              company announcing its first-ever dividend via 8-K (with
+              zero XBRL history yet) still shows the calendar instead
+              of the "never paid" empty state. */}
+          {state.data.upcoming[0] !== undefined && (
+            <NextDividendBanner upcoming={state.data.upcoming[0]} />
+          )}
+          {!state.data.summary.has_dividend ||
+          state.data.history.length === 0 ? (
+            <EmptyState
+              title="No dividend history on file"
+              description="This instrument has not reported a positive dividend in its SEC filings."
+            />
+          ) : (
+            <DividendsBody data={state.data} />
+          )}
+        </>
       )}
     </Section>
   );
 }
+
+function NextDividendBanner({ upcoming }: { upcoming: UpcomingDividend }) {
+  // Banner shows whichever calendar dates survived the 8-K regex parse.
+  // A row with only dps_declared (no dates yet) still renders — the
+  // banner's job is "operator awareness", not a filled-in calendar.
+  const exOrPay = upcoming.ex_date ?? upcoming.pay_date;
+  return (
+    <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="font-semibold text-amber-900">Next dividend</span>
+        {upcoming.dps_declared !== null && (
+          <span className="font-mono tabular-nums text-amber-900">
+            {formatDps(upcoming.dps_declared, upcoming.currency)}
+          </span>
+        )}
+      </div>
+      <dl className="mt-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs text-amber-800">
+        {upcoming.ex_date !== null && (
+          <>
+            <dt className="text-amber-700">Ex-date</dt>
+            <dd>{upcoming.ex_date}</dd>
+          </>
+        )}
+        {upcoming.record_date !== null && (
+          <>
+            <dt className="text-amber-700">Record</dt>
+            <dd>{upcoming.record_date}</dd>
+          </>
+        )}
+        {upcoming.pay_date !== null && (
+          <>
+            <dt className="text-amber-700">Pay</dt>
+            <dd>{upcoming.pay_date}</dd>
+          </>
+        )}
+        {exOrPay === null && upcoming.declaration_date !== null && (
+          <>
+            <dt className="text-amber-700">Declared</dt>
+            <dd>
+              {upcoming.declaration_date} (calendar TBD)
+            </dd>
+          </>
+        )}
+      </dl>
+    </div>
+  );
+}
+
 
 function DividendsBody({ data }: { data: InstrumentDividends }) {
   const { summary, history } = data;

--- a/sql/054_dividend_events.sql
+++ b/sql/054_dividend_events.sql
@@ -1,0 +1,75 @@
+-- 054_dividend_events.sql
+--
+-- 8-K Item 8.01 dividend calendar (#434). Follow-up to #426 dividend
+-- history (XBRL-declared amounts) + #431 8-K items[] typing.
+--
+-- SEC XBRL gives per-period dps declared, but NOT the ex-date /
+-- record-date / pay-date calendar that drives UI "next dividend"
+-- banners and the optional pre-ex-date dividend-capture signal. That
+-- calendar lives only in the free-form announcement text of 8-K
+-- filings carrying Item 8.01 "Other Events". A regex parser is
+-- acceptance-bar-limited to ≥80% of Dividend Aristocrats; the rest
+-- fall back to "next dividend date unknown".
+--
+-- Storage model: one row per (instrument, source_accession) — the
+-- UNIQUE constraint is idempotent under re-runs. We keep dates
+-- nullable because real 8-Ks often announce only a subset
+-- (e.g. ex-date + pay-date, no record-date separately named). A row
+-- with all three nullable date fields NULL is still useful: it means
+-- we saw an 8.01 that parsed as a dividend announcement but couldn't
+-- pin any date — operator visibility matters more than silent skip.
+--
+-- Currency is stored explicitly (default 'USD' for SEC filers) so
+-- later multi-currency issuers don't need a backfill.
+
+CREATE TABLE IF NOT EXISTS dividend_events (
+    id                  BIGSERIAL   PRIMARY KEY,
+    instrument_id       BIGINT      NOT NULL REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    source_accession    TEXT        NOT NULL,
+    declaration_date    DATE,
+    ex_date             DATE,
+    record_date         DATE,
+    pay_date            DATE,
+    dps_declared        NUMERIC(18, 6),
+    currency            TEXT        NOT NULL DEFAULT 'USD',
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_parsed_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (instrument_id, source_accession)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dividend_events_instrument_ex_date
+    ON dividend_events (instrument_id, ex_date DESC NULLS LAST);
+
+-- Ingester query path: "find upcoming dividends across the universe"
+-- needs a global ex_date scan; this partial index keeps that fast
+-- without bloating the per-instrument access pattern above.
+CREATE INDEX IF NOT EXISTS idx_dividend_events_ex_date_future
+    ON dividend_events (ex_date)
+    WHERE ex_date IS NOT NULL;
+
+COMMENT ON TABLE dividend_events IS
+    'Per-filing dividend calendar extracted from 8-K Item 8.01 text. '
+    'One row per (instrument, 8-K accession). Dates are nullable '
+    'individually — a partially-parsed announcement still yields a '
+    'row so operators can see the accession and follow the URL.';
+
+COMMENT ON COLUMN dividend_events.source_accession IS
+    'SEC accession number of the 8-K the dates were parsed from. '
+    'Forms the idempotency key together with instrument_id.';
+
+COMMENT ON COLUMN dividend_events.declaration_date IS
+    'Board-declaration date as stated in the filing (not the filing '
+    'date itself — 8-Ks are typically filed 1–4 business days after '
+    'the board vote).';
+
+COMMENT ON COLUMN dividend_events.dps_declared IS
+    'Cash dividend per share stated in the announcement. NULL when '
+    'the filing discloses a dividend calendar without an amount '
+    '(e.g. "regular quarterly dividend" boilerplate).';
+
+COMMENT ON COLUMN dividend_events.last_parsed_at IS
+    'Bumped by the ingester''s ON CONFLICT path on every re-parse. The '
+    'ingester''s candidate selector skips partial rows whose '
+    'last_parsed_at is within the 7-day TTL so a stable partial row '
+    'does not hammer SEC every daily run. Fresh rows set this to '
+    'NOW() via the column default on insert.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -63,6 +63,7 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "job_runs",
     "financial_periods_raw",
     "financial_periods",
+    "dividend_events",  # #434 — 8-K 8.01 calendar, FK → instruments
     "filing_events",
     "decision_audit",  # #315 Phase 3 alerts
     "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)

--- a/tests/test_dividend_calendar.py
+++ b/tests/test_dividend_calendar.py
@@ -1,0 +1,192 @@
+"""Unit tests for ``app.services.dividend_calendar`` (#434).
+
+Parser-level tests only — the ingester's DB path is covered in
+``test_dividend_calendar_ingest.py`` once the ingester lands.
+
+Fixtures are stripped-down excerpts of real SEC 8-K Item 8.01
+announcement language observed in Dividend Aristocrats filings
+(KO, PG, JNJ, MMM). Keeping them as inline strings (rather than
+on-disk HTML fixtures) means the tests exercise the parser against
+the exact shapes we expect to see in production without dragging
+vendor HTML into the repo.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.services.dividend_calendar import (
+    DividendAnnouncement,
+    parse_dividend_announcement,
+)
+
+
+class TestParseDividendAnnouncement:
+    """Golden-path + boundary tests for the 8-K 8.01 regex parser."""
+
+    def test_full_calendar_with_all_four_dates_and_amount(self) -> None:
+        """Canonical Coca-Cola style: every date + amount labelled."""
+        text = (
+            "On February 15, 2024, the Board of Directors of The "
+            "Coca-Cola Company declared a regular quarterly cash "
+            "dividend of $0.485 per share, payable on April 1, 2024, "
+            "to shareholders of record as of March 15, 2024. The "
+            "ex-dividend date is March 14, 2024."
+        )
+        result = parse_dividend_announcement(text)
+        assert result == DividendAnnouncement(
+            declaration_date=date(2024, 2, 15),
+            ex_date=date(2024, 3, 14),
+            record_date=date(2024, 3, 15),
+            pay_date=date(2024, 4, 1),
+            dps_declared="0.485",
+        )
+
+    def test_dollar_amount_with_four_decimal_places(self) -> None:
+        """Some issuers quote fractional cents (e.g. MMM specialties)."""
+        text = (
+            "The Board declared a quarterly dividend of $1.5100 per "
+            "share, payable June 12, 2024 to shareholders of record "
+            "at the close of business on May 24, 2024."
+        )
+        result = parse_dividend_announcement(text)
+        assert result is not None
+        assert result.dps_declared == "1.5100"
+        assert result.pay_date == date(2024, 6, 12)
+        assert result.record_date == date(2024, 5, 24)
+
+    def test_record_date_without_separate_ex_date(self) -> None:
+        """Many 8.01s skip the ex-date line (investors derive it from
+        record date − 1 business day). Parser must NOT invent one."""
+        text = (
+            "Procter & Gamble's Board declared a quarterly cash "
+            "dividend of $1.0065 per share, payable on May 15, 2024, "
+            "to shareholders of record on April 19, 2024."
+        )
+        result = parse_dividend_announcement(text)
+        assert result is not None
+        assert result.ex_date is None
+        assert result.record_date == date(2024, 4, 19)
+        assert result.pay_date == date(2024, 5, 15)
+        assert result.dps_declared == "1.0065"
+
+    def test_numeric_date_format(self) -> None:
+        """Some smaller filers write dates as MM/DD/YYYY."""
+        text = (
+            "The Company declared a cash dividend of $0.22 per share "
+            "payable on 06/14/2024 to stockholders of record at the "
+            "close of business on 05/17/2024. The ex-dividend date "
+            "will be 05/16/2024."
+        )
+        result = parse_dividend_announcement(text)
+        assert result is not None
+        assert result.ex_date == date(2024, 5, 16)
+        assert result.record_date == date(2024, 5, 17)
+        assert result.pay_date == date(2024, 6, 14)
+        assert result.dps_declared == "0.22"
+
+    def test_special_dividend_recognised(self) -> None:
+        """Special / one-time dividends use the same date + amount
+        shape; parser must not bail just because "special" appears."""
+        text = (
+            "On November 1, 2023, the Board declared a special cash "
+            "dividend of $10.00 per share, payable December 15, 2023 "
+            "to shareholders of record on December 1, 2023."
+        )
+        result = parse_dividend_announcement(text)
+        assert result is not None
+        assert result.dps_declared == "10.00"
+        assert result.pay_date == date(2023, 12, 15)
+        assert result.record_date == date(2023, 12, 1)
+
+    def test_non_dividend_8k_returns_none(self) -> None:
+        """Item 8.01 is "Other Events" and covers non-dividend news
+        (share buyback updates, litigation, etc.). Parser must return
+        None when no dividend language appears — a row with nothing
+        but NULLs would clutter the table."""
+        text = (
+            "On March 1, 2024, the Company announced that it has "
+            "entered into a material definitive agreement with XYZ "
+            "Corporation regarding a joint venture in the European "
+            "market. Additional details are included as Exhibit 99.1."
+        )
+        assert parse_dividend_announcement(text) is None
+
+    def test_buyback_announcement_returns_none(self) -> None:
+        """Buyback authorisations mention "per share" and dollar
+        amounts — must not be mistaken for a dividend."""
+        text = (
+            "The Board authorised the repurchase of up to $5.0 "
+            "billion of the Company's common stock. The repurchase "
+            "program has no fixed expiration date."
+        )
+        assert parse_dividend_announcement(text) is None
+
+    def test_amount_only_no_dates(self) -> None:
+        """Partial parse is allowed — if the amount is present but no
+        date survives the regex, return a record with amount only."""
+        text = (
+            "The Board declared a quarterly cash dividend of $0.25 "
+            "per share. Details regarding the record date and "
+            "payment date will be disclosed in a subsequent filing."
+        )
+        result = parse_dividend_announcement(text)
+        assert result is not None
+        assert result.dps_declared == "0.25"
+        assert result.ex_date is None
+        assert result.record_date is None
+        assert result.pay_date is None
+
+    def test_html_tags_stripped_before_matching(self) -> None:
+        """Primary documents are HTML. Parser must tolerate tags
+        embedded within its target phrases (<b>, <i>, <span>, etc.)
+        by stripping tags before matching."""
+        text = (
+            "<p>On <b>February 15, 2024</b>, the Board declared a "
+            "regular quarterly cash dividend of "
+            "<span>$0.485 per share</span>, payable "
+            "<i>April 1, 2024</i>, to shareholders of record as of "
+            "March 15, 2024.</p>"
+        )
+        result = parse_dividend_announcement(text)
+        assert result is not None
+        assert result.dps_declared == "0.485"
+        assert result.pay_date == date(2024, 4, 1)
+        assert result.record_date == date(2024, 3, 15)
+
+    def test_whitespace_and_nbsp_between_label_and_date(self) -> None:
+        """EDGAR HTML heavily uses &nbsp; and multi-space indentation.
+        Parser must treat nbsp + multi-space as a single boundary."""
+        text = (
+            "The Board declared a quarterly cash dividend of "
+            "$0.485 per share, payable on  May   10,"
+            "   2024, to shareholders of record on "
+            "April 19, 2024."
+        )
+        result = parse_dividend_announcement(text)
+        assert result is not None
+        assert result.pay_date == date(2024, 5, 10)
+        assert result.record_date == date(2024, 4, 19)
+        assert result.dps_declared == "0.485"
+
+    def test_empty_string_returns_none(self) -> None:
+        """Degenerate input (empty primary document) must not crash."""
+        assert parse_dividend_announcement("") is None
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "dividend of $0.50/share",  # Slash-notation — not yet supported, accepted limitation.
+            "dividend of £0.85 per share",  # Foreign currency — bail, matches USD-only
+        ],
+    )
+    def test_known_limitations_do_not_crash(self, text: str) -> None:
+        """Documenting known parser blind spots as non-crashing. They
+        return None (not a row with amount=None) — deliberate so
+        operators aren't misled into thinking parsing succeeded."""
+        # Current regex is USD-only and requires "$N.NN per share" with
+        # either hyphen or space. Both inputs fail gracefully rather
+        # than matching half the announcement.
+        assert parse_dividend_announcement(text) is None

--- a/tests/test_dividend_calendar_ingest.py
+++ b/tests/test_dividend_calendar_ingest.py
@@ -1,0 +1,355 @@
+"""Integration tests for ``ingest_dividend_events`` (#434).
+
+Runs against the real ``ebull_test`` DB via the ``ebull_test_conn``
+fixture so the migration, FK cascade, UNIQUE constraint, and JOIN
+logic are all exercised. The HTTP fetch is stubbed with a callable
+that returns canned text per URL — the parser path is pure-python
+and covered by ``test_dividend_calendar.py`` separately.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import cast
+
+import psycopg
+import pytest
+
+from app.services.dividend_calendar import (
+    DividendAnnouncement,
+    IngestResult,
+    ingest_dividend_events,
+    upsert_dividend_event,
+)
+
+pytestmark = pytest.mark.integration
+
+
+class _StubFetcher:
+    """In-memory fetcher — maps URL → body (or ``None`` for 404)."""
+
+    def __init__(self, by_url: dict[str, str | None]) -> None:
+        self._by_url = by_url
+        self.calls: list[str] = []
+
+    def fetch_document_text(self, absolute_url: str) -> str | None:
+        self.calls.append(absolute_url)
+        return self._by_url.get(absolute_url)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], symbol: str = "KO") -> int:
+    # ``instrument_id`` is a caller-assigned BIGINT (broker IDs pass through),
+    # so the test picks a stable synthetic value rather than relying on a
+    # sequence default.
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name)
+            VALUES (%s, %s, %s)
+            RETURNING instrument_id
+            """,
+            (42, symbol, "Test Co"),
+        )
+        row = cur.fetchone()
+        assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+def _seed_filing(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    accession: str,
+    url: str,
+    items: list[str] | None = None,
+) -> None:
+    """Insert one SEC 8-K filing row with items[] set (default
+    ARRAY['8.01'] so the ingester will pick it up)."""
+    items = items if items is not None else ["8.01"]
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO filing_events
+                (instrument_id, filing_date, filing_type, provider,
+                 provider_filing_id, primary_document_url, items)
+            VALUES (%s, CURRENT_DATE, '8-K', 'sec', %s, %s, %s)
+            """,
+            (instrument_id, accession, url, items),
+        )
+    conn.commit()
+
+
+def _count_events(conn: psycopg.Connection[tuple]) -> int:
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM dividend_events")
+        row = cur.fetchone()
+        assert row is not None
+        return int(row[0])
+
+
+# Canonical announcement text — covered by parser tests, here it's
+# fixture material.
+_COKE_ANNOUNCEMENT = (
+    "On February 15, 2024, the Board of Directors of The Coca-Cola "
+    "Company declared a regular quarterly cash dividend of $0.485 "
+    "per share, payable on April 1, 2024, to shareholders of record "
+    "as of March 15, 2024. The ex-dividend date is March 14, 2024."
+)
+
+
+class TestIngestDividendEvents:
+    def test_happy_path_inserts_row(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """One 8-K + 8.01 + valid doc → one dividend_events row."""
+        inst_id = _seed_instrument(ebull_test_conn)
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=inst_id,
+            accession="0000021344-24-000005",
+            url="https://www.sec.gov/Archives/fake-coke.htm",
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/fake-coke.htm": _COKE_ANNOUNCEMENT})
+
+        result = ingest_dividend_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        assert isinstance(result, IngestResult)
+        assert result.filings_scanned == 1
+        assert result.rows_inserted == 1
+        assert result.rows_updated == 0
+        assert result.parse_misses == 0
+        assert result.fetch_errors == 0
+        assert _count_events(ebull_test_conn) == 1
+
+    def test_rerun_is_idempotent(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A second pass over the same filing does NOT re-ingest —
+        the JOIN-guard on dividend_events excludes already-processed
+        filings. Counters show 0 scanned, 0 inserted."""
+        inst_id = _seed_instrument(ebull_test_conn)
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=inst_id,
+            accession="0000021344-24-000005",
+            url="https://www.sec.gov/Archives/fake-coke.htm",
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/fake-coke.htm": _COKE_ANNOUNCEMENT})
+
+        ingest_dividend_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        second = ingest_dividend_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        assert second.filings_scanned == 0
+        assert second.rows_inserted == 0
+        assert _count_events(ebull_test_conn) == 1
+
+    def test_non_dividend_8k_is_parse_miss_not_row(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A buyback or JV 8-K carrying 8.01 parses as None → parse_miss
+        counter increments, zero rows inserted. Crucially the JOIN
+        logic will re-scan the same filing on the next pass so a
+        future parser improvement can pick it up."""
+        inst_id = _seed_instrument(ebull_test_conn)
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=inst_id,
+            accession="0000021344-24-000006",
+            url="https://www.sec.gov/Archives/fake-jv.htm",
+        )
+        fetcher = _StubFetcher(
+            {
+                "https://www.sec.gov/Archives/fake-jv.htm": (
+                    "On March 1, 2024, the Company entered into a joint "
+                    "venture agreement with XYZ Corp regarding the "
+                    "European market."
+                )
+            }
+        )
+
+        result = ingest_dividend_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        assert result.filings_scanned == 1
+        assert result.rows_inserted == 0
+        assert result.parse_misses == 1
+        assert _count_events(ebull_test_conn) == 0
+
+    def test_fetch_404_counts_but_does_not_row(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Withdrawn filing (provider returns None) → fetch_errors
+        increments, no row inserted."""
+        inst_id = _seed_instrument(ebull_test_conn)
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=inst_id,
+            accession="0000021344-24-000007",
+            url="https://www.sec.gov/Archives/gone.htm",
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/gone.htm": None})
+
+        result = ingest_dividend_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        assert result.filings_scanned == 1
+        assert result.fetch_errors == 1
+        assert result.rows_inserted == 0
+        assert _count_events(ebull_test_conn) == 0
+
+    def test_filing_without_items_is_skipped(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Pre-#431 filings have items IS NULL and must be ignored —
+        the items-based gate is the only idempotency key we have for
+        non-8.01 noise."""
+        inst_id = _seed_instrument(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO filing_events
+                    (instrument_id, filing_date, filing_type, provider,
+                     provider_filing_id, primary_document_url, items)
+                VALUES (%s, CURRENT_DATE, '8-K', 'sec',
+                        '0000021344-24-000099',
+                        'https://www.sec.gov/Archives/unknown-items.htm',
+                        NULL)
+                """,
+                (inst_id,),
+            )
+        ebull_test_conn.commit()
+        fetcher = _StubFetcher({})
+
+        result = ingest_dividend_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        assert result.filings_scanned == 0
+        assert fetcher.calls == []
+
+    def test_partial_row_is_reparsed_after_ttl(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Codex #434 H1 regression — a row parsed as partial (e.g. amount
+        only, no calendar dates) must be revisited on a later run so a
+        regex improvement can backfill the dates. Gated by a 7-day TTL
+        on ``last_parsed_at`` so stable partials don't hammer SEC daily."""
+        inst_id = _seed_instrument(ebull_test_conn)
+        accession = "0000021344-24-000020"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=inst_id,
+            accession=accession,
+            url="https://www.sec.gov/Archives/partial.htm",
+        )
+        # First pass: partial parse (amount only, no calendar dates).
+        partial = (
+            "The Board declared a quarterly cash dividend of $0.25 "
+            "per share. Details regarding the record date and payment "
+            "date will be disclosed in a subsequent filing."
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/partial.htm": partial})
+        first = ingest_dividend_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert first.rows_inserted == 1
+
+        # Simulate ≥ 7 days passing — move last_parsed_at back in time.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "UPDATE dividend_events SET last_parsed_at = NOW() - INTERVAL '8 days' "
+                "WHERE instrument_id=%s AND source_accession=%s",
+                (inst_id, accession),
+            )
+        ebull_test_conn.commit()
+
+        # Second pass: the parser has "improved" — now returns full
+        # calendar. Re-parse picks up the same accession and UPDATEs.
+        full = (
+            "On February 15, 2024, the Board declared a quarterly cash "
+            "dividend of $0.25 per share, payable on April 1, 2024, to "
+            "shareholders of record as of March 15, 2024."
+        )
+        better_fetcher = _StubFetcher({"https://www.sec.gov/Archives/partial.htm": full})
+        second = ingest_dividend_events(ebull_test_conn, cast("object", better_fetcher))  # type: ignore[arg-type]
+
+        assert second.filings_scanned == 1
+        assert second.rows_inserted == 0
+        assert second.rows_updated == 1
+        # Dates now populated.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT pay_date, record_date FROM dividend_events WHERE instrument_id=%s AND source_accession=%s",
+                (inst_id, accession),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] is not None
+            assert row[1] is not None
+
+    def test_fresh_partial_within_ttl_not_reparsed(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A partial row parsed < 7 days ago must NOT be re-fetched —
+        otherwise stable partials hammer SEC every daily run."""
+        inst_id = _seed_instrument(ebull_test_conn)
+        accession = "0000021344-24-000021"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=inst_id,
+            accession=accession,
+            url="https://www.sec.gov/Archives/fresh-partial.htm",
+        )
+        partial = (
+            "The Board declared a quarterly cash dividend of $0.25 "
+            "per share. Details regarding the record date will follow."
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/fresh-partial.htm": partial})
+        ingest_dividend_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        # Second pass immediately — last_parsed_at < 7 days old.
+        second_fetcher = _StubFetcher({"https://www.sec.gov/Archives/fresh-partial.htm": partial})
+        second = ingest_dividend_events(ebull_test_conn, cast("object", second_fetcher))  # type: ignore[arg-type]
+
+        assert second.filings_scanned == 0
+        assert second_fetcher.calls == []
+
+    def test_filing_with_different_items_is_skipped(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """8-K with items=['1.01','9.01'] (no 8.01) must not even be
+        fetched."""
+        inst_id = _seed_instrument(ebull_test_conn)
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=inst_id,
+            accession="0000021344-24-000008",
+            url="https://www.sec.gov/Archives/other.htm",
+            items=["1.01", "9.01"],
+        )
+        fetcher = _StubFetcher({})
+
+        result = ingest_dividend_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        assert result.filings_scanned == 0
+        assert fetcher.calls == []
+
+
+class TestUpsertDividendEvent:
+    def test_update_path_flips_insert_to_false(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Re-calling upsert for the same (instrument_id, accession)
+        returns False (UPDATE, not INSERT)."""
+        inst_id = _seed_instrument(ebull_test_conn)
+        a1 = DividendAnnouncement(dps_declared="0.25")
+        a2 = DividendAnnouncement(dps_declared="0.30")
+
+        inserted = upsert_dividend_event(
+            ebull_test_conn,
+            instrument_id=inst_id,
+            source_accession="A1",
+            announcement=a1,
+        )
+        ebull_test_conn.commit()
+        updated = upsert_dividend_event(
+            ebull_test_conn,
+            instrument_id=inst_id,
+            source_accession="A1",
+            announcement=a2,
+        )
+        ebull_test_conn.commit()
+
+        assert inserted is True
+        assert updated is False
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT dps_declared FROM dividend_events WHERE instrument_id=%s AND source_accession=%s",
+                (inst_id, "A1"),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert str(row[0]) == "0.300000"
+
+
+# Keep the type-checker happy re the ``cast`` above — the actual
+# fixture is shaped correctly but pyright doesn't infer Protocol
+# conformance for tuple-row cursors cleanly.
+_ = Callable  # noqa: F401 — silence "unused import" under -Wunused.

--- a/tests/test_dividend_calendar_ingest.py
+++ b/tests/test_dividend_calendar_ingest.py
@@ -140,11 +140,13 @@ class TestIngestDividendEvents:
         assert second.rows_inserted == 0
         assert _count_events(ebull_test_conn) == 1
 
-    def test_non_dividend_8k_is_parse_miss_not_row(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
-        """A buyback or JV 8-K carrying 8.01 parses as None → parse_miss
-        counter increments, zero rows inserted. Crucially the JOIN
-        logic will re-scan the same filing on the next pass so a
-        future parser improvement can pick it up."""
+    def test_non_dividend_8k_is_parse_miss_with_tombstone(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A buyback / JV 8-K carrying 8.01 parses as None → parse_miss
+        counter increments AND a tombstone row is written (all NULL
+        dates + NULL amount). The tombstone is what bounds re-fetch
+        cadence to weekly via the partial-row TTL — without it, the
+        LEFT JOIN would re-fetch the same miss on every daily run.
+        Codex PR #446 review WARNING."""
         inst_id = _seed_instrument(ebull_test_conn)
         _seed_filing(
             ebull_test_conn,
@@ -165,13 +167,26 @@ class TestIngestDividendEvents:
         result = ingest_dividend_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
 
         assert result.filings_scanned == 1
-        assert result.rows_inserted == 0
         assert result.parse_misses == 1
-        assert _count_events(ebull_test_conn) == 0
+        assert _count_events(ebull_test_conn) == 1  # tombstone row
 
-    def test_fetch_404_counts_but_does_not_row(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # Second immediate pass: TTL is fresh, so the filing is NOT
+        # re-scanned. Counters reflect zero work.
+        second_fetcher = _StubFetcher(
+            {
+                "https://www.sec.gov/Archives/fake-jv.htm": (
+                    "On March 1, 2024, the Company entered into a joint venture..."
+                )
+            }
+        )
+        second = ingest_dividend_events(ebull_test_conn, cast("object", second_fetcher))  # type: ignore[arg-type]
+        assert second.filings_scanned == 0
+        assert second_fetcher.calls == []
+
+    def test_fetch_404_writes_tombstone(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         """Withdrawn filing (provider returns None) → fetch_errors
-        increments, no row inserted."""
+        increments AND tombstone row written. Caps retry cadence at
+        weekly via the TTL, not daily. Codex PR #446 WARNING."""
         inst_id = _seed_instrument(ebull_test_conn)
         _seed_filing(
             ebull_test_conn,
@@ -185,8 +200,13 @@ class TestIngestDividendEvents:
 
         assert result.filings_scanned == 1
         assert result.fetch_errors == 1
-        assert result.rows_inserted == 0
-        assert _count_events(ebull_test_conn) == 0
+        assert _count_events(ebull_test_conn) == 1  # tombstone row
+
+        # Second immediate pass must NOT re-fetch.
+        second_fetcher = _StubFetcher({"https://www.sec.gov/Archives/gone.htm": None})
+        second = ingest_dividend_events(ebull_test_conn, cast("object", second_fetcher))  # type: ignore[arg-type]
+        assert second.filings_scanned == 0
+        assert second_fetcher.calls == []
 
     def test_filing_without_items_is_skipped(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         """Pre-#431 filings have items IS NULL and must be ignored —

--- a/tests/test_dividend_calendar_ingest.py
+++ b/tests/test_dividend_calendar_ingest.py
@@ -315,6 +315,60 @@ class TestIngestDividendEvents:
         assert second.filings_scanned == 0
         assert second_fetcher.calls == []
 
+    def test_tombstone_preserves_existing_partial_data(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Codex PR #446 BLOCKING regression — a partial row re-queued
+        after its 7-day TTL and hit by a transient fetch error on the
+        retry must NOT have its previously-parsed dates overwritten
+        with NULL. Tombstone UPDATE path writes only ``last_parsed_at``.
+        """
+        inst_id = _seed_instrument(ebull_test_conn)
+        accession = "0000021344-24-000030"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=inst_id,
+            accession=accession,
+            url="https://www.sec.gov/Archives/partial-then-404.htm",
+        )
+        # First pass: partial parse — record_date + pay_date captured,
+        # ex_date is None (common for an announcement that hasn't
+        # disclosed the ex-date yet).
+        partial = (
+            "The Board declared a quarterly cash dividend of $0.25 per "
+            "share, payable on May 15, 2024, to shareholders of record "
+            "on April 19, 2024."
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/partial-then-404.htm": partial})
+        ingest_dividend_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        # Advance last_parsed_at so the re-parse TTL lets the ingester
+        # re-queue this row on the next run.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "UPDATE dividend_events SET last_parsed_at = NOW() - INTERVAL '8 days' "
+                "WHERE instrument_id=%s AND source_accession=%s",
+                (inst_id, accession),
+            )
+        ebull_test_conn.commit()
+
+        # Second pass: the URL is now 404. Tombstone MUST NOT clobber
+        # record_date / pay_date.
+        dead_fetcher = _StubFetcher({"https://www.sec.gov/Archives/partial-then-404.htm": None})
+        result = ingest_dividend_events(ebull_test_conn, cast("object", dead_fetcher))  # type: ignore[arg-type]
+        assert result.fetch_errors == 1
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT record_date, pay_date, dps_declared FROM dividend_events "
+                "WHERE instrument_id=%s AND source_accession=%s",
+                (inst_id, accession),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            # Dates + amount from the original partial parse are intact.
+            assert row[0] is not None
+            assert row[1] is not None
+            assert row[2] is not None
+
     def test_filing_with_different_items_is_skipped(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         """8-K with items=['1.01','9.01'] (no 8.01) must not even be
         fetched."""

--- a/tests/test_dividends_service.py
+++ b/tests/test_dividends_service.py
@@ -16,6 +16,7 @@ from app.services.dividends import (
     _EMPTY_SUMMARY,
     get_dividend_history,
     get_dividend_summary,
+    get_upcoming_dividends,
 )
 from tests.fixtures.ebull_test_db import ebull_test_conn
 from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
@@ -302,3 +303,156 @@ class TestGetDividendHistory:
             get_dividend_history(ebull_test_conn, instrument_id=1, limit=0)
         with pytest.raises(ValueError, match="limit must be"):
             get_dividend_history(ebull_test_conn, instrument_id=1, limit=401)
+
+
+def _seed_dividend_event(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    source_accession: str,
+    declaration_date: date | None = None,
+    ex_date: date | None = None,
+    record_date: date | None = None,
+    pay_date: date | None = None,
+    dps_declared: str | None = None,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO dividend_events
+                (instrument_id, source_accession, declaration_date,
+                 ex_date, record_date, pay_date, dps_declared, currency)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, 'USD')
+            """,
+            (
+                instrument_id,
+                source_accession,
+                declaration_date,
+                ex_date,
+                record_date,
+                pay_date,
+                dps_declared,
+            ),
+        )
+    conn.commit()
+
+
+class TestGetUpcomingDividends:
+    """Covers the three forward-looking row shapes (Codex M3 fix)."""
+
+    def test_ex_date_future_surfaces(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="KO")
+        _seed_dividend_event(
+            ebull_test_conn,
+            instrument_id=iid,
+            source_accession="A1",
+            ex_date=date(2030, 3, 15),
+            pay_date=date(2030, 4, 1),
+            dps_declared="0.485",
+        )
+        rows = get_upcoming_dividends(
+            ebull_test_conn,
+            instrument_id=iid,
+            reference_date=date(2030, 1, 1),
+        )
+        assert len(rows) == 1
+        assert rows[0].ex_date == date(2030, 3, 15)
+
+    def test_ex_date_past_filtered(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="KO")
+        _seed_dividend_event(
+            ebull_test_conn,
+            instrument_id=iid,
+            source_accession="A1",
+            ex_date=date(2020, 3, 15),
+            pay_date=date(2020, 4, 1),
+        )
+        rows = get_upcoming_dividends(
+            ebull_test_conn,
+            instrument_id=iid,
+            reference_date=date(2030, 1, 1),
+        )
+        assert rows == []
+
+    def test_pay_date_only_surfaces(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Announcement parsed pay-date but not ex-date (Codex M3)."""
+        iid = _seed_instrument(ebull_test_conn, symbol="KO")
+        _seed_dividend_event(
+            ebull_test_conn,
+            instrument_id=iid,
+            source_accession="A1",
+            pay_date=date(2030, 4, 1),
+            dps_declared="0.485",
+        )
+        rows = get_upcoming_dividends(
+            ebull_test_conn,
+            instrument_id=iid,
+            reference_date=date(2030, 1, 1),
+        )
+        assert len(rows) == 1
+        assert rows[0].ex_date is None
+        assert rows[0].pay_date == date(2030, 4, 1)
+
+    def test_declaration_only_surfaces_within_lookback(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Codex M3 regression — row with ONLY a recent declaration
+        date + amount (no ex/pay) must surface so the 'Declared …
+        (calendar TBD)' UI branch is reachable."""
+        iid = _seed_instrument(ebull_test_conn, symbol="KO")
+        _seed_dividend_event(
+            ebull_test_conn,
+            instrument_id=iid,
+            source_accession="A1",
+            declaration_date=date(2030, 1, 15),
+            dps_declared="0.485",
+        )
+        rows = get_upcoming_dividends(
+            ebull_test_conn,
+            instrument_id=iid,
+            reference_date=date(2030, 2, 1),
+        )
+        assert len(rows) == 1
+        assert rows[0].ex_date is None
+        assert rows[0].pay_date is None
+        assert rows[0].declaration_date == date(2030, 1, 15)
+
+    def test_declaration_only_past_lookback_filtered(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Stale declaration-only rows drop off after the 90-day
+        lookback so they don't linger forever on the banner."""
+        iid = _seed_instrument(ebull_test_conn, symbol="KO")
+        _seed_dividend_event(
+            ebull_test_conn,
+            instrument_id=iid,
+            source_accession="A1",
+            declaration_date=date(2029, 1, 1),
+            dps_declared="0.485",
+        )
+        # Reference date far past the 90-day window.
+        rows = get_upcoming_dividends(
+            ebull_test_conn,
+            instrument_id=iid,
+            reference_date=date(2030, 6, 1),
+        )
+        assert rows == []
+
+    def test_ordering_by_earliest_date(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """First row is always the earliest future event regardless of
+        which date dimension (ex/pay/declaration) won the COALESCE."""
+        iid = _seed_instrument(ebull_test_conn, symbol="KO")
+        _seed_dividend_event(
+            ebull_test_conn,
+            instrument_id=iid,
+            source_accession="A_LATE",
+            ex_date=date(2030, 6, 10),
+        )
+        _seed_dividend_event(
+            ebull_test_conn,
+            instrument_id=iid,
+            source_accession="A_EARLY",
+            ex_date=date(2030, 3, 1),
+        )
+        rows = get_upcoming_dividends(
+            ebull_test_conn,
+            instrument_id=iid,
+            reference_date=date(2030, 1, 1),
+        )
+        assert [r.source_accession for r in rows] == ["A_EARLY", "A_LATE"]


### PR DESCRIPTION
## What
Parses 8-K Item 8.01 announcements into a new `dividend_events` table, exposes the calendar via `/instruments/{symbol}/dividends.upcoming`, and renders a \"Next dividend\" banner on the instrument page.

## Why
SEC XBRL (per #426) gives declared amounts but not the ex/record/pay calendar — that lives only in 8-K 8.01 free-form text. Issue #434 from the #437 meta ladder.

## Test plan
- [x] `uv run pytest tests/test_dividend_calendar.py tests/test_dividend_calendar_ingest.py tests/test_dividends_service.py` — 40 pass
- [x] `uv run pytest -q` — 2485 pass, 1 skip
- [x] `uv run ruff check .` + `ruff format --check .`
- [x] `uv run pyright` — 0 errors
- [x] `pnpm --dir frontend typecheck` + `test:unit` — 384 pass
- [x] Codex checkpoint 2 (2 rounds, 4 findings addressed — partial-row re-parse TTL, backlog starvation via DESC ordering, declaration-only rows surfaced, banner moved outside has_dividend gate)

Closes #434