### PR TITLE
feat(#428): 10-K Item 1 business-summary extraction

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -697,6 +697,7 @@ def get_instrument_sec_profile(
     been seeded yet (pre-first-seed or non-US ticker without a primary
     CIK).
     """
+    from app.services.business_summary import get_business_summary
     from app.services.sec_entity_profile import get_entity_profile
 
     symbol_clean = symbol.strip().upper()
@@ -718,12 +719,21 @@ def get_instrument_sec_profile(
     if inst_row is None:
         raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
 
-    profile = get_entity_profile(conn, instrument_id=int(inst_row["instrument_id"]))  # type: ignore[arg-type]
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    profile = get_entity_profile(conn, instrument_id=instrument_id)
     if profile is None:
         raise HTTPException(
             status_code=404,
             detail="no SEC profile on file for this instrument",
         )
+
+    # #428: prefer the authoritative 10-K Item 1 body over the short
+    # entity-level ``description`` from submissions.json. The
+    # submissions description is a ~1-sentence blurb SEC surfaces in
+    # their own UI; Item 1 is the multi-paragraph authoritative text
+    # investors expect on an instrument page.
+    item_1_body = get_business_summary(conn, instrument_id=instrument_id)
+    description = item_1_body if item_1_body is not None else profile.description
 
     return InstrumentSecProfile(
         symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
@@ -731,7 +741,7 @@ def get_instrument_sec_profile(
         sic=profile.sic,
         sic_description=profile.sic_description,
         owner_org=profile.owner_org,
-        description=profile.description,
+        description=description,
         website=profile.website,
         investor_website=profile.investor_website,
         ein=profile.ein,

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -70,6 +70,7 @@ from app.workers.scheduler import (
     JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
     JOB_RAW_DATA_RETENTION_SWEEP,
     JOB_RETRY_DEFERRED,
+    JOB_SEC_BUSINESS_SUMMARY_INGEST,
     JOB_SEC_DIVIDEND_CALENDAR_INGEST,
     JOB_SEED_COST_MODELS,
     JOB_WEEKLY_REPORT,
@@ -93,6 +94,7 @@ from app.workers.scheduler import (
     orchestrator_high_frequency_sync,
     raw_data_retention_sweep,
     retry_deferred_recommendations_job,
+    sec_business_summary_ingest,
     sec_dividend_calendar_ingest,
     seed_cost_models,
     weekly_report,
@@ -140,6 +142,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_ORCHESTRATOR_FULL_SYNC: orchestrator_full_sync,
     JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC: orchestrator_high_frequency_sync,
     JOB_RAW_DATA_RETENTION_SWEEP: raw_data_retention_sweep,
+    JOB_SEC_BUSINESS_SUMMARY_INGEST: sec_business_summary_ingest,
     JOB_SEC_DIVIDEND_CALENDAR_INGEST: sec_dividend_calendar_ingest,
 }
 

--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -1,0 +1,389 @@
+"""10-K Item 1 "Business" narrative extractor + ingester (#428).
+
+Replaces the Yahoo ``longBusinessSummary`` blurb with the
+authoritative multi-page description every SEC 10-K carries under
+Item 1. Free, official, bounded per issuer to ~quarterly cadence
+(10-K + 10-K/A amendments).
+
+Shape mirrors :mod:`app.services.dividend_calendar` (#434):
+
+- :func:`extract_business_section` is a pure function over raw HTML.
+- :func:`ingest_business_summaries` is the DB path, bounded per run
+  with a 7-day TTL on ``last_parsed_at`` so repeat fetches don't
+  consume SEC rate-limit budget.
+
+Acceptance bar from issue #428: instrument page shows an authentic
+10-K business description for US tickers with a 10-K on file;
+yfinance fallback only when absent.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------
+# HTML stripping — shared with dividend_calendar in spirit, duplicated
+# here so the two parsers don't couple on each other.
+# ---------------------------------------------------------------------
+
+
+_IXBRL_TAG_RE = re.compile(r"<ix:[^>]*>|</ix:[^>]*>", re.IGNORECASE)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_NBSP_RE = re.compile(r"&nbsp;|&#160;|&#xa0;| ", re.IGNORECASE)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _strip_html(raw: str) -> str:
+    """Strip HTML + iXBRL to a whitespace-collapsed plain-text stream.
+
+    iXBRL tags are stripped independently first because their
+    attribute content (``contextref``, ``unitref``, ...) otherwise
+    leaks through a naive ``<[^>]+>`` pass when the browser-tolerant
+    markup has nested/unbalanced tags that confuse the simpler
+    regex. Attribute content is never user-facing narrative."""
+    # Strip iXBRL element wrappers; the inner text survives.
+    no_ix = _IXBRL_TAG_RE.sub(" ", raw)
+    no_tags = _HTML_TAG_RE.sub(" ", no_ix)
+    no_nbsp = _NBSP_RE.sub(" ", no_tags)
+    return _WHITESPACE_RE.sub(" ", no_nbsp).strip()
+
+
+# ---------------------------------------------------------------------
+# Section extraction
+# ---------------------------------------------------------------------
+
+
+# Byte cap on the stored body. 10 KB is large enough for multi-page
+# Item 1 bodies (empirical: biggest Aristocrats 10-Ks run 6–8 KB after
+# whitespace collapse) with headroom for future "more…" expanders,
+# and small enough that TOASTing stays cheap.
+MAX_BODY_BYTES = 10 * 1024
+
+# "Item 1. Business" — case-insensitive, tolerant of extra
+# whitespace. The dot after the 1 is mandatory — 10-Ks consistently
+# use the dotted form, and a dot-less match picked up false positives
+# mid-sentence ("item 1 cause of action" etc.) in pilot runs.
+_ITEM_1_RE = re.compile(r"\bItem\s+1\.\s*Business\b", re.IGNORECASE)
+
+# "Item 1A. Risk Factors" is the universal end marker. If absent we
+# fall back to a byte-cap slice from the Item 1 position.
+_ITEM_1A_RE = re.compile(r"\bItem\s+1A\.\s*Risk\s+Factors\b", re.IGNORECASE)
+
+
+def extract_business_section(raw_html: str) -> str | None:
+    """Return the "Item 1. Business" narrative as plain text.
+
+    Returns ``None`` when the Item 1 heading is absent. Otherwise
+    returns the slice between the last Item 1 heading preceding the
+    Item 1A marker and the Item 1A marker itself. When Item 1A is
+    missing (malformed 10-K), takes a byte-bounded tail after Item 1.
+
+    The "last before 1A" choice is deliberate: 10-Ks place a
+    table-of-contents entry with the same "Item 1. Business" text
+    earlier in the document, followed by the actual narrative
+    heading. Picking the last occurrence before Item 1A skips the
+    TOC entry and lands on the real section header.
+    """
+    if not raw_html:
+        return None
+    text = _strip_html(raw_html)
+
+    matches_1 = list(_ITEM_1_RE.finditer(text))
+    if not matches_1:
+        return None
+
+    # Take the LAST Item 1A occurrence, not the first. The table of
+    # contents at the top of a 10-K lists "Item 1A. Risk Factors"
+    # once as a link target — the real heading appears again later.
+    # Using the last occurrence ensures the body region we slice
+    # actually contains the Item 1 narrative between the real Item
+    # 1 heading (also the last occurrence) and the real Item 1A
+    # heading. Same logic applies to Item 1.
+    matches_1a = list(_ITEM_1A_RE.finditer(text))
+    end = matches_1a[-1].start() if matches_1a else len(text)
+
+    # Pick the last Item 1 marker that precedes Item 1A (or EOF).
+    # Filings that have only a TOC mention fall into the first
+    # match, which is a tight slice — callers should enforce a
+    # minimum body length before storing (done in the ingester).
+    candidates = [m for m in matches_1 if m.start() < end]
+    if not candidates:
+        return None
+    start = candidates[-1].end()
+
+    body = text[start:end].strip()
+    if not body:
+        return None
+
+    # Byte-cap on plain text. UTF-8 encoding is ASCII-dominated for
+    # English 10-Ks so .encode() is cheap.
+    encoded = body.encode("utf-8")
+    if len(encoded) > MAX_BODY_BYTES:
+        # Decode-safe truncation: step back to a valid codepoint if
+        # the cap landed mid-byte-sequence.
+        truncated = encoded[:MAX_BODY_BYTES]
+        body = truncated.decode("utf-8", errors="ignore")
+
+    return body
+
+
+# ---------------------------------------------------------------------
+# DB upsert
+# ---------------------------------------------------------------------
+
+
+def upsert_business_summary(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    body: str,
+    source_accession: str,
+) -> bool:
+    """Insert or update one ``instrument_business_summary`` row.
+
+    Returns ``True`` on INSERT, ``False`` on UPDATE. The UPDATE path
+    overwrites the body + source_accession + timestamps so a later
+    10-K supersedes an older one cleanly."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO instrument_business_summary
+                (instrument_id, body, source_accession)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (instrument_id) DO UPDATE SET
+                body             = EXCLUDED.body,
+                source_accession = EXCLUDED.source_accession,
+                fetched_at       = NOW(),
+                last_parsed_at   = NOW()
+            RETURNING (xmax = 0) AS inserted
+            """,
+            (instrument_id, body, source_accession),
+        )
+        row = cur.fetchone()
+        return bool(row[0]) if row else False
+
+
+def record_parse_attempt(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    source_accession: str,
+) -> None:
+    """Stamp a parse attempt without ever overwriting a real body.
+
+    INSERT path (first-time failure): writes a tombstone row with
+    ``body = ''`` and the failing ``source_accession`` so the next
+    ingester pass sees a row with ``source_accession`` == the same
+    accession and ``last_parsed_at`` < 7 days — and skips it.
+
+    UPDATE path (prior row exists, failed retry): only bumps
+    ``last_parsed_at`` + ``source_accession``. Preserves any real
+    ``body`` from an earlier successful parse so a transient error
+    on a later 10-K can never destroy the extracted narrative
+    (Codex #434 / #446 BLOCKING pattern applied to #428).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO instrument_business_summary
+                (instrument_id, body, source_accession)
+            VALUES (%s, '', %s)
+            ON CONFLICT (instrument_id) DO UPDATE SET
+                source_accession = EXCLUDED.source_accession,
+                last_parsed_at   = NOW()
+            """,
+            (instrument_id, source_accession),
+        )
+
+
+# ---------------------------------------------------------------------
+# Reader
+# ---------------------------------------------------------------------
+
+
+def get_business_summary(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+) -> str | None:
+    """Return the stored Item 1 body, or None when no body exists.
+
+    A row with ``body = ''`` is a tombstone (the ingester tried and
+    failed to extract) — treated as "no body available" by callers
+    so the SEC-profile endpoint still falls through to the yfinance
+    description fallback. Read-only."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT body FROM instrument_business_summary WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    body = str(row[0])
+    return body if body else None
+
+
+# ---------------------------------------------------------------------
+# Ingester
+# ---------------------------------------------------------------------
+
+
+class _DocFetcher(Protocol):
+    def fetch_document_text(self, absolute_url: str) -> str | None: ...
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    """Outcome of one ``ingest_business_summaries`` call."""
+
+    filings_scanned: int
+    rows_inserted: int
+    rows_updated: int
+    fetch_errors: int
+    parse_misses: int
+
+
+# Soft minimum body length below which the extractor is treated as a
+# parse miss. Tuned to exclude TOC-only fragments ("Item 1. Business
+# ... 3") while keeping short-but-real business descriptions.
+_MIN_BODY_LEN = 120
+
+
+def ingest_business_summaries(
+    conn: psycopg.Connection[Any],
+    fetcher: _DocFetcher,
+    *,
+    limit: int = 200,
+) -> IngestResult:
+    """Scan 10-K filings, fetch primary doc, extract Item 1, upsert.
+
+    Candidate selector (shape addresses Codex #428 findings):
+
+    1. ``fe.filing_type IN ('10-K', '10-K/A')`` — amendments retain
+       their ``/A`` suffix through the SEC pipeline (see
+       ``app/services/fundamentals.py``); narrowing to plain ``'10-K'``
+       misses restated annual reports and pins ``source_accession`` to
+       a stale pre-amendment filing.
+    2. ``fe.primary_document_url IS NOT NULL`` — unparseable without.
+    3. No ``instrument_business_summary`` row, OR the stored
+       ``source_accession`` differs from this filing's accession
+       (later 10-K supersedes), OR the existing row is older than 7
+       days since last parse (TTL-gated retry).
+    4. Newest filing wins per instrument (``DISTINCT ON`` resolves to
+       the latest filing_date, tie-break on filing_event_id); the
+       outer query then sorts GLOBALLY newest-first so a backlog
+       doesn't delay fresh filings for higher instrument_ids
+       indefinitely.
+
+    Bounded per run (``limit=200``). 10-Ks are quarterly so the
+    steady-state backlog is small; a large limit protects against a
+    catch-up after a scheduler outage without starving other SEC
+    calls on the same rate-limit pool.
+    """
+    conn.commit()
+
+    candidates: list[tuple[int, str, str]] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            WITH latest_per_instrument AS (
+                SELECT DISTINCT ON (fe.instrument_id)
+                       fe.instrument_id,
+                       fe.provider_filing_id,
+                       fe.primary_document_url,
+                       fe.filing_date,
+                       fe.filing_event_id
+                FROM filing_events fe
+                WHERE fe.provider = 'sec'
+                  AND fe.filing_type IN ('10-K', '10-K/A')
+                  AND fe.primary_document_url IS NOT NULL
+                ORDER BY fe.instrument_id, fe.filing_date DESC, fe.filing_event_id DESC
+            )
+            SELECT lpi.instrument_id,
+                   lpi.provider_filing_id,
+                   lpi.primary_document_url
+            FROM latest_per_instrument lpi
+            LEFT JOIN instrument_business_summary bs
+                   ON bs.instrument_id = lpi.instrument_id
+            WHERE bs.instrument_id IS NULL
+               OR bs.source_accession <> lpi.provider_filing_id
+               OR bs.last_parsed_at < NOW() - INTERVAL '7 days'
+            ORDER BY lpi.filing_date DESC, lpi.filing_event_id DESC
+            LIMIT %s
+            """,
+            (limit,),
+        )
+        for row in cur.fetchall():
+            candidates.append((int(row[0]), str(row[1]), str(row[2])))
+    conn.commit()
+
+    inserted = 0
+    updated = 0
+    fetch_errors = 0
+    parse_misses = 0
+
+    for instrument_id, accession, url in candidates:
+        try:
+            html = fetcher.fetch_document_text(url)
+        except Exception:
+            logger.warning(
+                "ingest_business_summaries: fetch failed accession=%s url=%s",
+                accession,
+                url,
+                exc_info=True,
+            )
+            fetch_errors += 1
+            record_parse_attempt(conn, instrument_id=instrument_id, source_accession=accession)
+            conn.commit()
+            continue
+        if html is None:
+            fetch_errors += 1
+            record_parse_attempt(conn, instrument_id=instrument_id, source_accession=accession)
+            conn.commit()
+            continue
+
+        body = extract_business_section(html)
+        if body is None or len(body) < _MIN_BODY_LEN:
+            parse_misses += 1
+            record_parse_attempt(conn, instrument_id=instrument_id, source_accession=accession)
+            conn.commit()
+            continue
+
+        try:
+            did_insert = upsert_business_summary(
+                conn,
+                instrument_id=instrument_id,
+                body=body,
+                source_accession=accession,
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            logger.warning(
+                "ingest_business_summaries: upsert failed accession=%s",
+                accession,
+                exc_info=True,
+            )
+            continue
+
+        if did_insert:
+            inserted += 1
+        else:
+            updated += 1
+
+    return IngestResult(
+        filings_scanned=len(candidates),
+        rows_inserted=inserted,
+        rows_updated=updated,
+        fetch_errors=fetch_errors,
+        parse_misses=parse_misses,
+    )

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -238,6 +238,7 @@ JOB_ORCHESTRATOR_FULL_SYNC = "orchestrator_full_sync"
 JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC = "orchestrator_high_frequency_sync"
 JOB_FUNDAMENTALS_SYNC = "fundamentals_sync"
 JOB_SEC_DIVIDEND_CALENDAR_INGEST = "sec_dividend_calendar_ingest"
+JOB_SEC_BUSINESS_SUMMARY_INGEST = "sec_business_summary_ingest"
 
 
 # ---------------------------------------------------------------------------
@@ -482,6 +483,19 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "over several runs without duplicating work."
         ),
         cadence=Cadence.daily(hour=3, minute=0),
+        catch_up_on_boot=False,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_BUSINESS_SUMMARY_INGEST,
+        description=(
+            "Extract 10-K Item 1 'Business' narratives into "
+            "``instrument_business_summary`` (#428). Runs 03:15 UTC "
+            "— 45 min after fundamentals_sync so new 10-K filings are "
+            "visible. Bounded to 200 instruments per run with a 7-day "
+            "TTL on ``last_parsed_at`` so a backlog drains without "
+            "re-fetching already-parsed instruments."
+        ),
+        cadence=Cadence.daily(hour=3, minute=15),
         catch_up_on_boot=False,
     ),
     ScheduledJob(
@@ -3030,6 +3044,36 @@ def sec_dividend_calendar_ingest() -> None:
         tracker.row_count = result.rows_inserted + result.rows_updated
         logger.info(
             "sec_dividend_calendar_ingest complete: scanned=%d inserted=%d updated=%d fetch_errors=%d parse_misses=%d",
+            result.filings_scanned,
+            result.rows_inserted,
+            result.rows_updated,
+            result.fetch_errors,
+            result.parse_misses,
+        )
+
+
+def sec_business_summary_ingest() -> None:
+    """Extract 10-K Item 1 into ``instrument_business_summary`` (#428).
+
+    Same shape as :func:`sec_dividend_calendar_ingest` (#434) — scans
+    10-K filings, fetches the primary document, parses Item 1, and
+    upserts. Bounded per run (``limit=200``) with a 7-day
+    ``last_parsed_at`` TTL so steady-state daily runs don't hammer
+    SEC for already-parsed instruments.
+    """
+    from app.providers.implementations.sec_edgar import SecFilingsProvider
+    from app.services.business_summary import ingest_business_summaries
+
+    with _tracked_job(JOB_SEC_BUSINESS_SUMMARY_INGEST) as tracker:
+        with (
+            psycopg.connect(settings.database_url) as conn,
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as provider,
+        ):
+            result = ingest_business_summaries(conn, provider)
+
+        tracker.row_count = result.rows_inserted + result.rows_updated
+        logger.info(
+            "sec_business_summary_ingest complete: scanned=%d inserted=%d updated=%d fetch_errors=%d parse_misses=%d",
             result.filings_scanned,
             result.rows_inserted,
             result.rows_updated,

--- a/sql/055_instrument_business_summary.sql
+++ b/sql/055_instrument_business_summary.sql
@@ -1,0 +1,62 @@
+-- 055_instrument_business_summary.sql
+--
+-- 10-K Item 1 "Business" narrative extraction (#428). Replaces the
+-- Yahoo ``longBusinessSummary`` blurb (~150 words, scraped) with the
+-- authoritative multi-page description that every SEC 10-K carries
+-- under Item 1. Free, official, bounded per issuer to ~quarterly
+-- (10-K cadence + 10-K/A amendments).
+--
+-- Storage model: one row per instrument. The latest 10-K wins — we
+-- don't keep a history because the UI never surfaces a diff view and
+-- older descriptions are still recoverable from the source filing
+-- via ``source_accession``. A side table of snapshots is a follow-up
+-- if product ever wants an "X vs last year" panel.
+--
+-- Body capped at ~10 KB via NUMERIC column policy elsewhere — here a
+-- TEXT field lets Postgres TOAST compress transparently. A soft cap
+-- is enforced at the service layer (issue says ~4 KB first-slice
+-- for render; we store slightly more headroom so future "more..."
+-- expanders don't need a re-fetch).
+
+CREATE TABLE IF NOT EXISTS instrument_business_summary (
+    instrument_id       BIGINT      PRIMARY KEY
+                            REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    -- Empty string = tombstone sentinel: the ingester recorded an
+    -- attempt but parse missed / fetch failed. Readers treat empty
+    -- as "no body available" so the UI still falls back to yfinance.
+    body                TEXT        NOT NULL DEFAULT '',
+    source_accession    TEXT        NOT NULL,
+    fetched_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Bumped on every re-parse (mirrors dividend_events.last_parsed_at
+    -- pattern from #434). Gates the 7-day TTL so a bad parse on one
+    -- run doesn't pound SEC daily.
+    last_parsed_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_instrument_business_summary_source
+    ON instrument_business_summary (source_accession);
+
+COMMENT ON TABLE instrument_business_summary IS
+    'Parsed 10-K Item 1 "Business" description per instrument. One '
+    'row per instrument — latest 10-K wins. ``source_accession`` '
+    'points back to the originating filing for audit; the raw text '
+    'is reconstructable from the filing on demand.';
+
+COMMENT ON COLUMN instrument_business_summary.body IS
+    'Plain-text Item 1 narrative, HTML-stripped and whitespace-'
+    'collapsed. Truncated at the parser layer to ~10 KB so oversized '
+    'filings don''t bloat the row. Renderers slice to their own '
+    'display budget. Empty string means "tombstone" — the ingester '
+    'attempted this instrument but could not extract a body; readers '
+    'surface that as None and fall through to yfinance fallback.';
+
+COMMENT ON COLUMN instrument_business_summary.source_accession IS
+    'SEC accession of the 10-K the body was extracted from. Forms '
+    'the idempotency contract together with instrument_id — re-'
+    'running the ingester on the same accession is a no-op unless '
+    'the body changed.';
+
+COMMENT ON COLUMN instrument_business_summary.last_parsed_at IS
+    'Bumped on every ingester pass even when the upsert is a no-op, '
+    'so the 7-day TTL guard skips recently-parsed instruments and '
+    'keeps the SEC rate-limit budget intact.';

--- a/tests/api/test_instruments_sec_profile_endpoint.py
+++ b/tests/api/test_instruments_sec_profile_endpoint.py
@@ -61,6 +61,9 @@ def test_sec_profile_endpoint_returns_profile() -> None:
 
     with (
         patch("app.services.sec_entity_profile.get_entity_profile", return_value=_sample_profile()),
+        # #428 wired the endpoint to also read instrument_business_summary;
+        # patch the lookup so the test's mock-only conn doesn't raise.
+        patch("app.services.business_summary.get_business_summary", return_value=None),
         TestClient(app) as client,
     ):
         resp = client.get("/instruments/AAPL/sec_profile")

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -64,6 +64,7 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "financial_periods_raw",
     "financial_periods",
     "dividend_events",  # #434 — 8-K 8.01 calendar, FK → instruments
+    "instrument_business_summary",  # #428 — 10-K Item 1 body, FK → instruments
     "filing_events",
     "decision_audit",  # #315 Phase 3 alerts
     "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)

--- a/tests/test_business_summary.py
+++ b/tests/test_business_summary.py
@@ -1,0 +1,155 @@
+"""Unit tests for ``app.services.business_summary`` (#428).
+
+Fixtures model real 10-K shapes: heavy HTML, table-of-contents link
+that repeats the "Item 1" heading, iXBRL tags, and the standard
+"Item 1A. Risk Factors" boundary marker that terminates the
+business section.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.business_summary import (
+    MAX_BODY_BYTES,
+    extract_business_section,
+)
+
+
+class TestExtractBusinessSection:
+    def test_canonical_item_1_between_markers(self) -> None:
+        """Happy-path 10-K layout: table of contents lists Item 1, the
+        narrative starts later under its own heading, and
+        ``Item 1A. Risk Factors`` marks the end."""
+        html = """
+        <html><body>
+        <h2>Table of Contents</h2>
+        <p>Item 1. Business .... 3</p>
+        <p>Item 1A. Risk Factors ... 10</p>
+        <h2>Item 1. Business</h2>
+        <p>The Company is a global manufacturer of specialty
+           materials used in aerospace and automotive end markets.</p>
+        <p>We operate through four segments: Industrial, Safety,
+           Transportation, and Consumer.</p>
+        <h2>Item 1A. Risk Factors</h2>
+        <p>The following factors may affect our results.</p>
+        </body></html>
+        """
+        body = extract_business_section(html)
+        assert body is not None
+        assert "global manufacturer" in body
+        assert "four segments" in body
+        # End marker and anything after must be excluded.
+        assert "Risk Factors" not in body
+        assert "following factors" not in body
+
+    def test_toc_only_returns_none(self) -> None:
+        """A document whose only Item 1 mention is in the TOC (with no
+        body heading before Item 1A) has no extractable narrative —
+        better to return None than emit the TOC line."""
+        html = """
+        <html><body>
+        <p>Item 1. Business .... 3</p>
+        <p>Item 1A. Risk Factors ... 10</p>
+        <h2>Item 1A. Risk Factors</h2>
+        <p>Risks follow.</p>
+        </body></html>
+        """
+        # The extractor walks to the LAST occurrence of the Item 1
+        # marker before Item 1A, so when only the TOC entry exists
+        # the extracted body is the TOC line fragment. Accept: the
+        # body will be <some tiny string>; callers can enforce a
+        # minimum length (done at ingester layer). The unit contract
+        # here is "don't crash, return something deterministic".
+        body = extract_business_section(html)
+        assert body is not None
+        # Empty or single-line TOC fragment — service enforces min length.
+        assert len(body) < 100
+
+    def test_ixbrl_tags_stripped(self) -> None:
+        """Real 10-Ks are iXBRL-inline. The ``<ix:...>`` tags must
+        not leak into the stored body."""
+        html = """
+        <html><body>
+        <h2>Item 1. Business</h2>
+        <p>We reported <ix:nonfraction name="us-gaap:Revenues"
+           contextref="c1" unitref="usd">1000000</ix:nonfraction>
+           in revenue last year.</p>
+        <h2>Item 1A. Risk Factors</h2>
+        </body></html>
+        """
+        body = extract_business_section(html)
+        assert body is not None
+        assert "<ix" not in body
+        assert "nonfraction" not in body
+        assert "contextref" not in body
+        # The numeric value is inside the ix tag — it stays as text.
+        assert "1000000" in body
+
+    def test_body_truncated_to_cap(self) -> None:
+        """Body is capped at MAX_BODY_BYTES so oversized filings
+        don't bloat the row."""
+        filler = "A specialty chemicals company. " * 10000  # ~300 KB
+        html = f"<html><body><h2>Item 1. Business</h2><p>{filler}</p><h2>Item 1A. Risk Factors</h2></body></html>"
+        body = extract_business_section(html)
+        assert body is not None
+        assert len(body.encode("utf-8")) <= MAX_BODY_BYTES
+
+    def test_no_item_1_marker_returns_none(self) -> None:
+        """A document without the Item 1 heading returns None rather
+        than guessing."""
+        html = "<html><body><p>No financial disclosures.</p></body></html>"
+        assert extract_business_section(html) is None
+
+    def test_item_1_without_end_marker_takes_bounded_tail(self) -> None:
+        """If Item 1A is absent (malformed 10-K), take at most the
+        capped byte-count after the Item 1 heading so the extractor
+        doesn't swallow the entire remainder of the filing."""
+        html = (
+            "<html><body>"
+            "<h2>Item 1. Business</h2>"
+            "<p>We make things. We sell them. Customers buy them.</p>"
+            "</body></html>"
+        )
+        body = extract_business_section(html)
+        assert body is not None
+        assert "We make things" in body
+        assert len(body.encode("utf-8")) <= MAX_BODY_BYTES
+
+    def test_empty_input_returns_none(self) -> None:
+        assert extract_business_section("") is None
+
+    def test_whitespace_collapsed_to_single_space(self) -> None:
+        """Multi-line + nbsp in the source collapses to a single
+        space stream so the stored body is clean to render."""
+        html = (
+            "<html><body>"
+            "<h2>Item&nbsp;1.&nbsp;Business</h2>"
+            "<p>Line one.</p>\n\n\n<p>Line&nbsp;two.</p>"
+            "<h2>Item 1A. Risk Factors</h2>"
+            "</body></html>"
+        )
+        body = extract_business_section(html)
+        assert body is not None
+        # No doubled whitespace, no raw &nbsp; sequences.
+        assert "  " not in body
+        assert "&nbsp;" not in body
+        assert "Line one." in body
+        assert "Line two." in body
+
+    @pytest.mark.parametrize(
+        "heading",
+        [
+            "Item 1. Business",
+            "ITEM 1. BUSINESS",
+            "Item 1.    Business",
+            "Item  1.  Business",
+        ],
+    )
+    def test_case_and_whitespace_tolerant(self, heading: str) -> None:
+        """Real filings vary the exact casing + spacing in the Item 1
+        heading. Extractor matches all of them."""
+        html = f"<html><body><h2>{heading}</h2><p>We are a company.</p><h2>Item 1A. Risk Factors</h2></body></html>"
+        body = extract_business_section(html)
+        assert body is not None
+        assert "We are a company" in body

--- a/tests/test_business_summary.py
+++ b/tests/test_business_summary.py
@@ -43,10 +43,13 @@ class TestExtractBusinessSection:
         assert "Risk Factors" not in body
         assert "following factors" not in body
 
-    def test_toc_only_returns_none(self) -> None:
+    def test_toc_only_returns_short_fragment(self) -> None:
         """A document whose only Item 1 mention is in the TOC (with no
-        body heading before Item 1A) has no extractable narrative —
-        better to return None than emit the TOC line."""
+        body heading before Item 1A) yields a short TOC-line fragment.
+        The parser intentionally returns it rather than None so the
+        ingester can apply the ``_MIN_BODY_LEN`` threshold consistently
+        at one layer — short fragments fail that gate and get
+        tombstoned as parse misses."""
         html = """
         <html><body>
         <p>Item 1. Business .... 3</p>

--- a/tests/test_business_summary_ingest.py
+++ b/tests/test_business_summary_ingest.py
@@ -1,0 +1,274 @@
+"""Integration tests for ``ingest_business_summaries`` (#428)."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import psycopg
+import pytest
+
+from app.services.business_summary import (
+    get_business_summary,
+    ingest_business_summaries,
+)
+
+pytestmark = pytest.mark.integration
+
+
+class _StubFetcher:
+    def __init__(self, by_url: dict[str, str | None]) -> None:
+        self._by_url = by_url
+        self.calls: list[str] = []
+
+    def fetch_document_text(self, absolute_url: str) -> str | None:
+        self.calls.append(absolute_url)
+        return self._by_url.get(absolute_url)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], symbol: str = "MMM", iid: int = 77) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            (iid, symbol, "Test Co"),
+        )
+        row = cur.fetchone()
+        assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+def _seed_10k(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    accession: str,
+    url: str,
+    filing_date: str = "2026-02-15",
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO filing_events
+                (instrument_id, filing_date, filing_type, provider,
+                 provider_filing_id, primary_document_url)
+            VALUES (%s, %s, '10-K', 'sec', %s, %s)
+            """,
+            (instrument_id, filing_date, accession, url),
+        )
+    conn.commit()
+
+
+_ITEM_1_HTML = """
+<html><body>
+<h2>Table of Contents</h2>
+<p>Item 1. Business .... 3</p>
+<p>Item 1A. Risk Factors ... 10</p>
+<h2>Item 1. Business</h2>
+<p>The Company is a global diversified manufacturer of specialty
+   materials serving aerospace, automotive, healthcare, and
+   consumer end markets. The Company operates through four
+   reportable segments, each with its own leadership, brands, and
+   customer base. Our products are sold in over 70 countries.</p>
+<h2>Item 1A. Risk Factors</h2>
+<p>Risk factors follow.</p>
+</body></html>
+"""
+
+
+class TestIngestBusinessSummaries:
+    def test_happy_path_inserts(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="0000066740-26-000001",
+            url="https://www.sec.gov/Archives/mmm-10k.htm",
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/mmm-10k.htm": _ITEM_1_HTML})
+
+        result = ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        assert result.filings_scanned == 1
+        assert result.rows_inserted == 1
+        body = get_business_summary(ebull_test_conn, instrument_id=iid)
+        assert body is not None
+        assert "global diversified manufacturer" in body
+
+    def test_superseding_10k_replaces_body(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A newer 10-K with a different accession updates the row."""
+        iid = _seed_instrument(ebull_test_conn)
+        # Old filing first.
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="OLD-ACC",
+            url="https://www.sec.gov/Archives/old.htm",
+            filing_date="2024-02-15",
+        )
+        # New filing second — should win on DISTINCT ON ordering
+        # (filing_date DESC).
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="NEW-ACC",
+            url="https://www.sec.gov/Archives/new.htm",
+            filing_date="2026-02-15",
+        )
+        fetcher = _StubFetcher(
+            {
+                "https://www.sec.gov/Archives/new.htm": _ITEM_1_HTML,
+                "https://www.sec.gov/Archives/old.htm": "<html>old boring</html>",
+            }
+        )
+
+        result = ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.rows_inserted == 1
+        # Only the newer URL was fetched.
+        assert fetcher.calls == ["https://www.sec.gov/Archives/new.htm"]
+
+    def test_rerun_within_ttl_skipped(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="A1",
+            url="https://www.sec.gov/Archives/mmm-10k.htm",
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/mmm-10k.htm": _ITEM_1_HTML})
+        ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        second_fetcher = _StubFetcher({"https://www.sec.gov/Archives/mmm-10k.htm": _ITEM_1_HTML})
+        second = ingest_business_summaries(ebull_test_conn, cast("object", second_fetcher))  # type: ignore[arg-type]
+
+        assert second.filings_scanned == 0
+        assert second_fetcher.calls == []
+
+    def test_parse_miss_writes_tombstone_and_ttl_gates(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A 10-K whose primary doc has no extractable Item 1 writes a
+        tombstone (empty-body sentinel) and the next run skips via
+        TTL — no second-day SEC re-fetch."""
+        iid = _seed_instrument(ebull_test_conn)
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="A1",
+            url="https://www.sec.gov/Archives/empty.htm",
+        )
+        fetcher = _StubFetcher(
+            {"https://www.sec.gov/Archives/empty.htm": "<html><body><p>No disclosures.</p></body></html>"}
+        )
+        result = ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.parse_misses == 1
+        # Reader returns None for the tombstone row so the UI still
+        # falls through to yfinance.
+        assert get_business_summary(ebull_test_conn, instrument_id=iid) is None
+
+        # Second pass must NOT re-fetch.
+        second_fetcher = _StubFetcher(
+            {"https://www.sec.gov/Archives/empty.htm": "<html><body><p>No disclosures.</p></body></html>"}
+        )
+        second = ingest_business_summaries(ebull_test_conn, cast("object", second_fetcher))  # type: ignore[arg-type]
+        assert second.filings_scanned == 0
+        assert second_fetcher.calls == []
+
+    def test_10k_amendment_included(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Codex #428 H1 regression — 10-K/A amendments must be
+        considered, not just plain 10-K. Amended annual reports
+        carry the authoritative restated narrative."""
+        iid = _seed_instrument(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO filing_events
+                    (instrument_id, filing_date, filing_type, provider,
+                     provider_filing_id, primary_document_url)
+                VALUES (%s, '2026-03-01', '10-K/A', 'sec', 'A-AMEND',
+                        'https://www.sec.gov/Archives/amend.htm')
+                """,
+                (iid,),
+            )
+        ebull_test_conn.commit()
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/amend.htm": _ITEM_1_HTML})
+        result = ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.filings_scanned == 1
+        assert result.rows_inserted == 1
+
+    def test_tombstone_preserves_existing_body_on_fetch_error(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Codex #428 H2 / #446 BLOCKING pattern — a later 10-K whose
+        fetch fails must NOT overwrite the body extracted from an
+        earlier successful 10-K parse. Tombstone UPDATE path touches
+        only ``source_accession`` + ``last_parsed_at``."""
+        iid = _seed_instrument(ebull_test_conn)
+        # First pass: good 10-K, body stored.
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="GOOD-ACC",
+            url="https://www.sec.gov/Archives/good.htm",
+            filing_date="2024-02-15",
+        )
+        ingest_business_summaries(
+            ebull_test_conn,
+            cast("object", _StubFetcher({"https://www.sec.gov/Archives/good.htm": _ITEM_1_HTML})),  # type: ignore[arg-type]
+        )
+        first_body = get_business_summary(ebull_test_conn, instrument_id=iid)
+        assert first_body is not None and "global diversified" in first_body
+
+        # Second pass: newer 10-K/A arrives but fetch returns 404.
+        # Tombstone must not clobber the stored body.
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="NEW-ACC",
+            url="https://www.sec.gov/Archives/dead.htm",
+            filing_date="2026-03-15",
+        )
+        dead_fetcher = _StubFetcher({"https://www.sec.gov/Archives/dead.htm": None})
+        ingest_business_summaries(ebull_test_conn, cast("object", dead_fetcher))  # type: ignore[arg-type]
+
+        preserved = get_business_summary(ebull_test_conn, instrument_id=iid)
+        assert preserved is not None
+        assert "global diversified" in preserved
+
+    def test_first_time_fetch_error_tombstones(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A first-time attempt that fails (no prior row) must write
+        a tombstone so TTL gates re-fetch at weekly. Mirrors the
+        Codex #446 pattern for dividend_calendar."""
+        iid = _seed_instrument(ebull_test_conn)
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="A1",
+            url="https://www.sec.gov/Archives/gone.htm",
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/gone.htm": None})
+        result = ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.fetch_errors == 1
+
+        # Reader returns None (empty body = tombstone).
+        assert get_business_summary(ebull_test_conn, instrument_id=iid) is None
+
+        # Second immediate pass must NOT re-fetch.
+        second_fetcher = _StubFetcher({"https://www.sec.gov/Archives/gone.htm": None})
+        second = ingest_business_summaries(ebull_test_conn, cast("object", second_fetcher))  # type: ignore[arg-type]
+        assert second.filings_scanned == 0
+        assert second_fetcher.calls == []
+
+    def test_non_10k_skipped(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO filing_events
+                    (instrument_id, filing_date, filing_type, provider,
+                     provider_filing_id, primary_document_url)
+                VALUES (%s, CURRENT_DATE, '10-Q', 'sec', 'Q-ACC',
+                        'https://www.sec.gov/Archives/q.htm')
+                """,
+                (iid,),
+            )
+        ebull_test_conn.commit()
+        fetcher = _StubFetcher({})
+        result = ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.filings_scanned == 0
+        assert fetcher.calls == []


### PR DESCRIPTION
## What
Parses the authoritative Item 1 "Business" narrative from each SEC 10-K into a new `instrument_business_summary` table. The `/instruments/{symbol}/sec_profile` endpoint now prefers this body over the short submissions.json description.

## Why
Yahoo `longBusinessSummary` is a ~150-word scraped blurb. SEC 10-K Item 1 is multi-page, authoritative, and free. Issue #428 from the #437 meta ladder.

## Test plan
- [x] `uv run pytest tests/test_business_summary*.py` — 20 pass
- [x] `uv run pytest -q` — 2493 pass, 1 skip
- [x] `uv run ruff check .` + `ruff format --check .`
- [x] `uv run pyright` — 0 errors
- [x] Codex checkpoint 2: 3 findings addressed — 10-K/A inclusion, first-time tombstone idempotency, global newest-first ordering via CTE + filing_event_id tiebreak

**Note**: shares `SecFilingsProvider.fetch_document_text` with #446 (still pending merge). If #446 lands first this PR rebases cleanly on main. If this lands first, #446 needs a trivial rebase.

Closes #428