### PR TITLE
fix(#454): normalise XSL-rendered Form 4 URLs before fetch

### DIFF
--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -911,6 +911,28 @@ class _DocFetcher(Protocol):
     def fetch_document_text(self, absolute_url: str) -> str | None: ...
 
 
+# SEC submissions.json ``primaryDocument`` for ownership filings
+# (Forms 3/4/5) commonly points at an XSL-rendered HTML view rather
+# than the raw XML. The rendered path carries an ``xslF345X06/`` (or
+# sibling ``xslF345X05/`` / ``xslF345/``) segment before the filename;
+# the same file without that segment is the canonical XML.
+#
+#   XSL:  /Archives/edgar/data/320193/000114036126015421/xslF345X06/form4.xml  → text/html
+#   Raw:  /Archives/edgar/data/320193/000114036126015421/form4.xml             → text/xml
+#
+# Without normalisation the ingester fetches HTML, the parser sees an
+# ``<html>`` root instead of ``<ownershipDocument>``, and every filing
+# gets tombstoned (#454).
+_XSL_FORM345_PREFIX_RE = re.compile(r"/xslF345(?:X0[56])?/")
+
+
+def _canonical_form_4_url(url: str) -> str:
+    """Strip the XSL-rendering segment from a SEC Form-3/4/5 URL so
+    the fetch returns raw XML, not XSL-transformed HTML. Idempotent —
+    already-canonical URLs pass through unchanged."""
+    return _XSL_FORM345_PREFIX_RE.sub("/", url, count=1)
+
+
 @dataclass(frozen=True)
 class IngestResult:
     filings_scanned: int
@@ -964,7 +986,7 @@ def ingest_insider_transactions(
             (limit,),
         )
         for row in cur.fetchall():
-            candidates.append((int(row[0]), str(row[1]), str(row[2])))
+            candidates.append((int(row[0]), str(row[1]), _canonical_form_4_url(str(row[2]))))
     conn.commit()
 
     filings_parsed = 0

--- a/sql/058_clear_xsl_form4_tombstones.sql
+++ b/sql/058_clear_xsl_form4_tombstones.sql
@@ -1,0 +1,29 @@
+-- 058_clear_xsl_form4_tombstones.sql
+--
+-- One-off recovery for #454. Before the XSL-URL normalisation fix,
+-- every Form 4 ingest attempt fetched the XSL-rendered HTML path
+-- (``/xslF345X06/form4.xml``) instead of the raw XML. The parser
+-- rejected the HTML (root was ``<html>`` not ``<ownershipDocument>``)
+-- and the ingester wrote a tombstone for the filing. Result on dev:
+-- 500 tombstones, zero real transactions.
+--
+-- With the URL-normalisation fix in place, these filings are
+-- parseable — but the ingester's candidate selector skips accessions
+-- that already have an ``insider_filings`` row, so the tombstones
+-- lock the filings out permanently.
+--
+-- Recovery: delete every tombstone row where ``primary_document_url``
+-- contains the XSL-rendering segment. The ingester's next pass picks
+-- them up as fresh candidates and re-parses against the canonical
+-- XML URL. Real 404/410 tombstones (no XSL segment in the URL) are
+-- preserved so we don't re-fetch genuinely-dead URLs.
+--
+-- ON DELETE CASCADE on the child tables means any filers / footnotes
+-- / transactions under these accessions are also cleared — but
+-- tombstones by definition carry no child rows, so this is a no-op
+-- beyond the parent filings.
+
+DELETE FROM insider_filings
+WHERE is_tombstone = TRUE
+  AND primary_document_url IS NOT NULL
+  AND primary_document_url ~ '/xslF345(?:X0[56])?/';

--- a/tests/test_insider_transactions.py
+++ b/tests/test_insider_transactions.py
@@ -20,6 +20,7 @@ from app.services.insider_transactions import (
     ParsedFiler,
     ParsedFiling,
     ParsedTransaction,
+    _canonical_form_4_url,
     filer_role_string,
     parse_form_4_xml,
 )
@@ -547,6 +548,35 @@ class TestParseForm4Xml:
         assert isinstance(parsed, ParsedFiling)
         assert isinstance(parsed.filers[0], ParsedFiler)
         assert isinstance(parsed.transactions[0], ParsedTransaction)
+
+
+class TestCanonicalForm4Url:
+    """#454 regression — XSL-rendered HTML paths must be normalised to
+    the canonical raw-XML URL before the ingester fetches them."""
+
+    def test_strips_xslf345x06_segment(self) -> None:
+        raw = "https://www.sec.gov/Archives/edgar/data/320193/000114036126015421/xslF345X06/form4.xml"
+        assert _canonical_form_4_url(raw) == (
+            "https://www.sec.gov/Archives/edgar/data/320193/000114036126015421/form4.xml"
+        )
+
+    def test_strips_xslf345x05_segment(self) -> None:
+        raw = "https://www.sec.gov/Archives/edgar/data/320193/abc/xslF345X05/form4.xml"
+        assert _canonical_form_4_url(raw) == ("https://www.sec.gov/Archives/edgar/data/320193/abc/form4.xml")
+
+    def test_strips_xslf345_segment(self) -> None:
+        raw = "https://www.sec.gov/Archives/edgar/data/320193/abc/xslF345/ownership.xml"
+        assert _canonical_form_4_url(raw) == ("https://www.sec.gov/Archives/edgar/data/320193/abc/ownership.xml")
+
+    def test_canonical_url_passes_through_unchanged(self) -> None:
+        raw = "https://www.sec.gov/Archives/edgar/data/320193/abc/form4.xml"
+        assert _canonical_form_4_url(raw) == raw
+
+    def test_unrelated_path_segment_not_touched(self) -> None:
+        """Defensive: ``xslF345X06`` only matches as a path segment,
+        not as a substring inside another segment."""
+        raw = "https://www.sec.gov/Archives/edgar/data/xslF345X06extra/form4.xml"
+        assert _canonical_form_4_url(raw) == raw
 
 
 class TestFilerRoleString:

--- a/tests/test_insider_transactions_ingest.py
+++ b/tests/test_insider_transactions_ingest.py
@@ -573,6 +573,33 @@ class TestIngestInsiderTransactions:
         assert summary.buy_count_90d == 1
         assert summary.unique_filers_90d == 1
 
+    def test_xsl_rendered_url_normalised_before_fetch(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """#454 regression — filing_events.primary_document_url for
+        ownership filings often points at the XSL-rendered HTML path
+        (``/xslF345X06/form4.xml``). The ingester must strip that
+        segment and fetch the canonical raw XML URL instead."""
+        iid = _seed_instrument(ebull_test_conn)
+        _seed_form_4(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="XSL-1",
+            url="https://www.sec.gov/Archives/edgar/data/320193/0001/xslF345X06/form4.xml",
+            filing_date=date.today().isoformat(),
+        )
+        canonical_url = "https://www.sec.gov/Archives/edgar/data/320193/0001/form4.xml"
+        fetcher = _StubFetcher(
+            {
+                canonical_url: _FORM_4_RICH_BUY.replace("2024-06-15", date.today().isoformat()),
+            }
+        )
+
+        result = ingest_insider_transactions(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        # Fetcher must have been called with the normalised URL, not the XSL path.
+        assert fetcher.calls == [canonical_url]
+        assert result.filings_parsed == 1
+        assert result.rows_inserted == 1
+
     def test_non_form_4_skipped(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         iid = _seed_instrument(ebull_test_conn)
         _seed_form_4(


### PR DESCRIPTION
## Summary
- Fix Form 4 ingester fetching XSL-rendered HTML instead of raw XML (500 false tombstones on dev DB).
- Migration 058 clears XSL-URL tombstones so the ingester re-runs cleanly.
- Regression tests for URL normalisation + live dev-DB verification (25/25 parsed, 36 transactions).

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest tests/test_insider_transactions.py tests/test_insider_transactions_ingest.py` (47 passed)
- [x] Live: `ingest_insider_transactions` against real SEC — 25 scanned, 25 parsed, 36 rows, 0 errors