### PR TITLE
fix(#456): remove stale #429 badge + per-instrument Form 4 backfill

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -72,6 +72,7 @@ from app.workers.scheduler import (
     JOB_RETRY_DEFERRED,
     JOB_SEC_BUSINESS_SUMMARY_INGEST,
     JOB_SEC_DIVIDEND_CALENDAR_INGEST,
+    JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL,
     JOB_SEC_INSIDER_TRANSACTIONS_INGEST,
     JOB_SEED_COST_MODELS,
     JOB_WEEKLY_REPORT,
@@ -97,6 +98,7 @@ from app.workers.scheduler import (
     retry_deferred_recommendations_job,
     sec_business_summary_ingest,
     sec_dividend_calendar_ingest,
+    sec_insider_transactions_backfill,
     sec_insider_transactions_ingest,
     seed_cost_models,
     weekly_report,
@@ -147,6 +149,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_SEC_BUSINESS_SUMMARY_INGEST: sec_business_summary_ingest,
     JOB_SEC_DIVIDEND_CALENDAR_INGEST: sec_dividend_calendar_ingest,
     JOB_SEC_INSIDER_TRANSACTIONS_INGEST: sec_insider_transactions_ingest,
+    JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL: sec_insider_transactions_backfill,
 }
 
 

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -942,6 +942,60 @@ class IngestResult:
     parse_misses: int
 
 
+def ingest_insider_transactions_for_instrument(
+    conn: psycopg.Connection[Any],
+    fetcher: _DocFetcher,
+    *,
+    instrument_id: int,
+    limit: int = 500,
+) -> IngestResult:
+    """Targeted backfill for a single instrument.
+
+    The universe-wide :func:`ingest_insider_transactions` selector runs
+    newest-first across every Form 4 filing in ``filing_events`` and
+    is bounded at 500 per tick — which is fine for keeping up with
+    incoming flow but leaves an instrument with hundreds of historical
+    filings starved for days while newer filings on other tickers
+    cycle through. This variant scopes the scan to one instrument so
+    an operator (or a round-robin backfill job) can drain a specific
+    ticker's backlog in one pass.
+
+    Same contract as the universe-wide function:
+
+    - Candidate = ``provider='sec'`` + ``filing_type IN ('4', '4/A')``
+      + ``primary_document_url IS NOT NULL`` + no existing
+      ``insider_filings`` row.
+    - Tombstone on fetch error / parse miss.
+    - Caller's fetch URL runs through :func:`_canonical_form_4_url` to
+      strip XSL-rendering segments.
+    """
+    conn.commit()
+    candidates: list[tuple[int, str, str]] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT fe.instrument_id,
+                   fe.provider_filing_id,
+                   fe.primary_document_url
+            FROM filing_events fe
+            LEFT JOIN insider_filings fil ON fil.accession_number = fe.provider_filing_id
+            WHERE fe.provider = 'sec'
+              AND fe.filing_type IN ('4', '4/A')
+              AND fe.primary_document_url IS NOT NULL
+              AND fe.instrument_id = %s
+              AND fil.accession_number IS NULL
+            ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+            LIMIT %s
+            """,
+            (instrument_id, limit),
+        )
+        for row in cur.fetchall():
+            candidates.append((int(row[0]), str(row[1]), _canonical_form_4_url(str(row[2]))))
+    conn.commit()
+
+    return _process_candidates(conn, fetcher, candidates)
+
+
 def ingest_insider_transactions(
     conn: psycopg.Connection[Any],
     fetcher: _DocFetcher,
@@ -989,6 +1043,21 @@ def ingest_insider_transactions(
             candidates.append((int(row[0]), str(row[1]), _canonical_form_4_url(str(row[2]))))
     conn.commit()
 
+    return _process_candidates(conn, fetcher, candidates)
+
+
+def _process_candidates(
+    conn: psycopg.Connection[Any],
+    fetcher: _DocFetcher,
+    candidates: list[tuple[int, str, str]],
+) -> IngestResult:
+    """Shared fetch-parse-upsert loop for every ingest entry point.
+
+    Each candidate is ``(instrument_id, accession_number,
+    canonical_url)``. Fetch errors / None bodies / parse misses all
+    write a filing-level tombstone so the ingester never re-fetches
+    a dead accession. Successful parses flow through
+    :func:`upsert_filing` which refreshes every column on conflict."""
     filings_parsed = 0
     rows_inserted = 0
     fetch_errors = 0
@@ -1064,6 +1133,93 @@ def ingest_insider_transactions(
         fetch_errors=fetch_errors,
         parse_misses=parse_misses,
     )
+
+
+def ingest_insider_transactions_backfill(
+    conn: psycopg.Connection[Any],
+    fetcher: _DocFetcher,
+    *,
+    instruments_per_tick: int = 25,
+    per_instrument_limit: int = 50,
+) -> dict[str, int]:
+    """Round-robin backfill for instruments with un-ingested Form 4
+    filings. Complements :func:`ingest_insider_transactions` (which
+    runs newest-first universe-wide and can starve deep per-ticker
+    backlogs).
+
+    Strategy: pick the ``instruments_per_tick`` instruments with the
+    most un-ingested candidates, drain up to ``per_instrument_limit``
+    oldest candidates for each. "Oldest-first" because the newest-first
+    universe job already covers the recent end; this job clears the
+    historical tail.
+
+    Returns per-bucket counters so scheduler observability can pick
+    out how many instruments made progress.
+    """
+    conn.commit()
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT fe.instrument_id, COUNT(*) AS unfetched
+            FROM filing_events fe
+            LEFT JOIN insider_filings fil ON fil.accession_number = fe.provider_filing_id
+            WHERE fe.provider = 'sec'
+              AND fe.filing_type IN ('4', '4/A')
+              AND fe.primary_document_url IS NOT NULL
+              AND fil.accession_number IS NULL
+            GROUP BY fe.instrument_id
+            ORDER BY unfetched DESC
+            LIMIT %s
+            """,
+            (instruments_per_tick,),
+        )
+        targets = [(int(r[0]), int(r[1])) for r in cur.fetchall()]
+    conn.commit()
+
+    totals = {
+        "instruments_processed": 0,
+        "filings_parsed": 0,
+        "rows_inserted": 0,
+        "fetch_errors": 0,
+        "parse_misses": 0,
+    }
+
+    for instrument_id, _unfetched in targets:
+        candidates: list[tuple[int, str, str]] = []
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT fe.instrument_id,
+                       fe.provider_filing_id,
+                       fe.primary_document_url
+                FROM filing_events fe
+                LEFT JOIN insider_filings fil
+                    ON fil.accession_number = fe.provider_filing_id
+                WHERE fe.provider = 'sec'
+                  AND fe.filing_type IN ('4', '4/A')
+                  AND fe.primary_document_url IS NOT NULL
+                  AND fe.instrument_id = %s
+                  AND fil.accession_number IS NULL
+                ORDER BY fe.filing_date ASC, fe.filing_event_id ASC
+                LIMIT %s
+                """,
+                (instrument_id, per_instrument_limit),
+            )
+            for row in cur.fetchall():
+                candidates.append((int(row[0]), str(row[1]), _canonical_form_4_url(str(row[2]))))
+        conn.commit()
+
+        if not candidates:
+            continue
+        result = _process_candidates(conn, fetcher, candidates)
+        totals["instruments_processed"] += 1
+        totals["filings_parsed"] += result.filings_parsed
+        totals["rows_inserted"] += result.rows_inserted
+        totals["fetch_errors"] += result.fetch_errors
+        totals["parse_misses"] += result.parse_misses
+
+    return totals
 
 
 # ---------------------------------------------------------------------

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -240,6 +240,7 @@ JOB_FUNDAMENTALS_SYNC = "fundamentals_sync"
 JOB_SEC_DIVIDEND_CALENDAR_INGEST = "sec_dividend_calendar_ingest"
 JOB_SEC_BUSINESS_SUMMARY_INGEST = "sec_business_summary_ingest"
 JOB_SEC_INSIDER_TRANSACTIONS_INGEST = "sec_insider_transactions_ingest"
+JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL = "sec_insider_transactions_backfill"
 
 
 # ---------------------------------------------------------------------------
@@ -510,6 +511,21 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "cost nothing when nothing new has landed."
         ),
         cadence=Cadence.hourly(minute=30),
+        catch_up_on_boot=False,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL,
+        description=(
+            "Round-robin backfill of Form 4 filings for instruments "
+            "with deep historical backlogs (#456). Complements the "
+            "hourly universe-wide ingester: that job runs newest-first "
+            "across every ticker, so a specific instrument with 400+ "
+            "pending Form 4s can starve for days. This job picks the "
+            "25 instruments with the most un-ingested candidates and "
+            "clears up to 50 per instrument per run, oldest-first, so "
+            "the historical tail drains predictably."
+        ),
+        cadence=Cadence.hourly(minute=45),
         catch_up_on_boot=False,
     ),
     ScheduledJob(
@@ -3123,4 +3139,37 @@ def sec_insider_transactions_ingest() -> None:
             result.rows_inserted,
             result.fetch_errors,
             result.parse_misses,
+        )
+
+
+def sec_insider_transactions_backfill() -> None:
+    """Round-robin backfill for instruments with deep Form 4 backlogs.
+
+    The universe-wide hourly job (``sec_insider_transactions_ingest``)
+    runs newest-first and is bounded at 500 filings per tick. An
+    instrument with 400+ historical filings can sit starved for days
+    because newer filings on other tickers saturate the budget every
+    hour. This job targets the 25 instruments with the most
+    un-ingested Form 4 candidates and clears up to 50 oldest filings
+    per instrument per tick — the historical tail drains predictably
+    without contention against the newest-first job.
+    """
+    from app.providers.implementations.sec_edgar import SecFilingsProvider
+    from app.services.insider_transactions import ingest_insider_transactions_backfill
+
+    with _tracked_job(JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL) as tracker:
+        with (
+            psycopg.connect(settings.database_url) as conn,
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as provider,
+        ):
+            totals = ingest_insider_transactions_backfill(conn, provider)
+
+        tracker.row_count = totals["rows_inserted"]
+        logger.info(
+            "sec_insider_transactions_backfill: instruments=%d parsed=%d inserted=%d fetch_errors=%d parse_misses=%d",
+            totals["instruments_processed"],
+            totals["filings_parsed"],
+            totals["rows_inserted"],
+            totals["fetch_errors"],
+            totals["parse_misses"],
         )

--- a/frontend/src/components/instrument/SecProfilePanel.test.tsx
+++ b/frontend/src/components/instrument/SecProfilePanel.test.tsx
@@ -47,7 +47,7 @@ afterEach(() => vi.clearAllMocks());
 
 
 describe("SecProfilePanel", () => {
-  it("renders description + SIC + exchanges + former names + insider badge", async () => {
+  it("renders description + SIC + exchanges + former names", async () => {
     mockFetch.mockResolvedValue(seededProfile());
     render(<SecProfilePanel symbol="AAPL" />);
 
@@ -58,8 +58,11 @@ describe("SecProfilePanel", () => {
     expect(screen.getByText(/NASDAQ/)).toBeInTheDocument();
     expect(screen.getByText(/Large accelerated filer/)).toBeInTheDocument();
     expect(screen.getByText(/APPLE COMPUTER INC/)).toBeInTheDocument();
-    expect(screen.getByText(/Insider activity recorded/i)).toBeInTheDocument();
     expect(screen.getByText(/Sep 30/i)).toBeInTheDocument();
+    // Stale #429 placeholder must be gone — Form-4 activity lives in
+    // the sibling InsiderActivityPanel now.
+    expect(screen.queryByText(/Insider activity recorded/i)).toBeNull();
+    expect(screen.queryByText(/detailed list pending/i)).toBeNull();
   });
 
   it("renders empty state when profile is null (404)", async () => {

--- a/frontend/src/components/instrument/SecProfilePanel.tsx
+++ b/frontend/src/components/instrument/SecProfilePanel.tsx
@@ -3,9 +3,10 @@
  * page. Backed by GET /instruments/{symbol}/sec_profile (#427).
  *
  * Surfaces authentic business description, SIC sector, exchange
- * listings, former names, insider-activity flags. Replaces the
- * yfinance long_business_summary blurb as the primary description
- * source for US-mapped tickers.
+ * listings, former names. Replaces the yfinance long_business_summary
+ * blurb as the primary description source for US-mapped tickers.
+ * Form-4 insider activity lives in the sibling InsiderActivityPanel
+ * (backed by #429 ingestion) and is no longer summarised here.
  */
 
 import { fetchInstrumentSecProfile } from "@/api/instruments";
@@ -133,14 +134,6 @@ function Body({ profile }: { profile: InstrumentSecProfile }) {
         </div>
       )}
 
-      {(profile.has_insider_issuer || profile.has_insider_owner) && (
-        <div className="text-xs text-slate-500">
-          <span className="mr-2 inline-block rounded bg-amber-100 px-1.5 py-0.5 font-medium text-amber-800">
-            Insider activity recorded
-          </span>
-          Form 4 filings on SEC EDGAR (detailed list pending #429).
-        </div>
-      )}
     </div>
   );
 }

--- a/tests/test_insider_transactions_ingest.py
+++ b/tests/test_insider_transactions_ingest.py
@@ -31,6 +31,8 @@ import pytest
 from app.services.insider_transactions import (
     get_insider_summary,
     ingest_insider_transactions,
+    ingest_insider_transactions_backfill,
+    ingest_insider_transactions_for_instrument,
     list_insider_transactions,
 )
 
@@ -702,6 +704,96 @@ class TestListInsiderTransactions:
         # qualified ("transactionShares").
         assert "transactionShares" in row.footnotes
         assert "Weighted average price" in row.footnotes["transactionShares"]
+
+
+class TestBackfill:
+    """#456 — per-instrument and round-robin backfill paths."""
+
+    def test_per_instrument_scopes_to_target(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Ingester invoked for one instrument must not fetch filings
+        owned by other instruments."""
+        iid_a = _seed_instrument(ebull_test_conn, iid=201, symbol="AAA")
+        iid_b = _seed_instrument(ebull_test_conn, iid=202, symbol="BBB")
+        _seed_form_4(
+            ebull_test_conn,
+            instrument_id=iid_a,
+            accession="ACC-A",
+            url="https://www.sec.gov/Archives/a.xml",
+            filing_date=date.today().isoformat(),
+        )
+        _seed_form_4(
+            ebull_test_conn,
+            instrument_id=iid_b,
+            accession="ACC-B",
+            url="https://www.sec.gov/Archives/b.xml",
+            filing_date=date.today().isoformat(),
+        )
+        today_iso = date.today().isoformat()
+        fetcher = _StubFetcher(
+            {
+                "https://www.sec.gov/Archives/a.xml": _FORM_4_RICH_BUY.replace("2024-06-15", today_iso),
+                "https://www.sec.gov/Archives/b.xml": _FORM_4_RICH_BUY.replace("2024-06-15", today_iso).replace(
+                    "0001000001", "0002000002"
+                ),
+            }
+        )
+
+        result = ingest_insider_transactions_for_instrument(
+            ebull_test_conn,
+            cast("object", fetcher),
+            instrument_id=iid_a,  # type: ignore[arg-type]
+        )
+        assert result.filings_scanned == 1
+        assert fetcher.calls == ["https://www.sec.gov/Archives/a.xml"]
+
+    def test_backfill_round_robin_picks_biggest_backlogs(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Round-robin backfill targets instruments with the most
+        un-ingested candidates first, drains oldest-first per target."""
+        iid_deep = _seed_instrument(ebull_test_conn, iid=301, symbol="DEEP")
+        iid_shallow = _seed_instrument(ebull_test_conn, iid=302, symbol="SHAL")
+
+        today_iso = date.today().isoformat()
+        xml_body = _FORM_4_RICH_BUY.replace("2024-06-15", today_iso)
+        url_map: dict[str, str | None] = {}
+        # DEEP: 3 filings; SHAL: 1 filing. DEEP should drain in one pass.
+        for i in range(3):
+            acc = f"DEEP-{i:02d}"
+            url = f"https://www.sec.gov/Archives/deep-{i}.xml"
+            _seed_form_4(
+                ebull_test_conn,
+                instrument_id=iid_deep,
+                accession=acc,
+                url=url,
+                filing_date=f"2024-01-{10 + i:02d}",
+            )
+            url_map[url] = xml_body.replace("0001000001", f"09000{i:05d}")
+        _seed_form_4(
+            ebull_test_conn,
+            instrument_id=iid_shallow,
+            accession="SHAL-01",
+            url="https://www.sec.gov/Archives/shal.xml",
+            filing_date=today_iso,
+        )
+        url_map["https://www.sec.gov/Archives/shal.xml"] = xml_body
+
+        fetcher = _StubFetcher(url_map)
+        totals = ingest_insider_transactions_backfill(
+            ebull_test_conn,
+            cast("object", fetcher),  # type: ignore[arg-type]
+            instruments_per_tick=5,
+            per_instrument_limit=50,
+        )
+        assert totals["instruments_processed"] == 2
+        assert totals["filings_parsed"] == 4
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM insider_filings WHERE instrument_id = %s AND is_tombstone = FALSE",
+                (iid_deep,),
+            )
+            deep_count = cur.fetchone()
+            assert deep_count is not None
+            assert deep_count[0] == 3
 
 
 def test_fixture_imports_ok(ebull_test_conn: psycopg.Connection[tuple]) -> None:

--- a/tests/test_insider_transactions_ingest.py
+++ b/tests/test_insider_transactions_ingest.py
@@ -740,8 +740,8 @@ class TestBackfill:
 
         result = ingest_insider_transactions_for_instrument(
             ebull_test_conn,
-            cast("object", fetcher),
-            instrument_id=iid_a,  # type: ignore[arg-type]
+            cast("object", fetcher),  # type: ignore[arg-type]
+            instrument_id=iid_a,
         )
         assert result.filings_scanned == 1
         assert fetcher.calls == ["https://www.sec.gov/Archives/a.xml"]


### PR DESCRIPTION
## Summary
- SecProfilePanel no longer shows the stale 'Insider activity recorded — detailed list pending #429' placeholder; insider-activity detail lives in the InsiderActivityPanel.
- New per-instrument backfill path + round-robin scheduler job so instruments with deep historical backlogs drain predictably instead of starving.
- GME dev-DB sample: 1 → 65 real Form 4 transactions after targeted backfill.

## Test plan
- [x] uv run ruff check .
- [x] uv run ruff format --check .
- [x] uv run pyright
- [x] uv run pytest (2571 passed)
- [x] pnpm --dir frontend typecheck + test:unit
- [x] Live: ingest_insider_transactions_for_instrument on GME — 434 scanned, 51 parsed (pre-XML tail excluded), 65 transactions