### PR TITLE
fix(#458): Form 4 summary misleading — add all-codes lens + fix row-key collision

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -993,12 +993,35 @@ def get_instrument_dividends(
 
 
 class InsiderSummaryModel(BaseModel):
+    """90-day insider-activity summary with two lenses (#458).
+
+    Open-market fields (``open_market_*``) capture discretionary P/S
+    trading — the strongest sentiment signal. Total-activity fields
+    (``total_acquired_*`` / ``total_disposed_*``) capture every
+    non-derivative transaction classified by
+    ``acquired_disposed_code`` (or ``txn_code`` when SEC omitted the
+    A/D flag). Operators need both: an RSU-vest month can show zero
+    open-market buys alongside a large grant, and a summary that
+    only reports open-market activity would misleadingly imply the
+    insider disposed of shares on balance.
+    """
+
     symbol: str
+    open_market_net_shares_90d: Decimal
+    open_market_buy_count_90d: int
+    open_market_sell_count_90d: int
+    total_acquired_shares_90d: Decimal
+    total_disposed_shares_90d: Decimal
+    acquisition_count_90d: int
+    disposition_count_90d: int
+    unique_filers_90d: int
+    latest_txn_date: date | None
+    # Back-compat aliases for callers built against the pre-#458 shape.
+    # Mirror the primary open-market fields so existing consumers keep
+    # rendering. Remove after all callers migrate.
     net_shares_90d: Decimal
     buy_count_90d: int
     sell_count_90d: int
-    unique_filers_90d: int
-    latest_txn_date: date | None
 
 
 @router.get("/{symbol}/insider_summary", response_model=InsiderSummaryModel)
@@ -1006,13 +1029,12 @@ def get_instrument_insider_summary(
     symbol: str,
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> InsiderSummaryModel:
-    """Return the 90-day insider-transaction summary (#429).
+    """Return the 90-day insider-transaction summary (#429 / #458).
 
-    ``net_shares_90d`` is positive when insiders net-bought, negative
-    when they net-sold. Only non-derivative trades (open-market P/S
-    transactions) contribute — option grants / RSU vests are weaker
-    signals and excluded. Counts cover each filer once regardless of
-    how many transactions they filed.
+    Two lenses: open-market (discretionary P/S) and total-activity
+    (every non-derivative transaction classified by
+    ``acquired_disposed_code``). Only non-derivative trades
+    contribute; derivative grants / option exercises are excluded.
     """
     from app.services.insider_transactions import get_insider_summary
 
@@ -1039,11 +1061,18 @@ def get_instrument_insider_summary(
     summary = get_insider_summary(conn, instrument_id=instrument_id)
     return InsiderSummaryModel(
         symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
-        net_shares_90d=summary.net_shares_90d,
-        buy_count_90d=summary.buy_count_90d,
-        sell_count_90d=summary.sell_count_90d,
+        open_market_net_shares_90d=summary.open_market_net_shares_90d,
+        open_market_buy_count_90d=summary.open_market_buy_count_90d,
+        open_market_sell_count_90d=summary.open_market_sell_count_90d,
+        total_acquired_shares_90d=summary.total_acquired_shares_90d,
+        total_disposed_shares_90d=summary.total_disposed_shares_90d,
+        acquisition_count_90d=summary.acquisition_count_90d,
+        disposition_count_90d=summary.disposition_count_90d,
         unique_filers_90d=summary.unique_filers_90d,
         latest_txn_date=summary.latest_txn_date,
+        net_shares_90d=summary.open_market_net_shares_90d,
+        buy_count_90d=summary.open_market_buy_count_90d,
+        sell_count_90d=summary.open_market_sell_count_90d,
     )
 
 
@@ -1060,6 +1089,7 @@ class InsiderTransactionDetailModel(BaseModel):
     """
 
     accession_number: str
+    txn_row_num: int
     document_type: str
     txn_date: date
     deemed_execution_date: date | None
@@ -1141,6 +1171,7 @@ def get_instrument_insider_transactions(
         rows=[
             InsiderTransactionDetailModel(
                 accession_number=d.accession_number,
+                txn_row_num=d.txn_row_num,
                 document_type=d.document_type,
                 txn_date=d.txn_date,
                 deemed_execution_date=d.deemed_execution_date,

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -1231,16 +1231,56 @@ def ingest_insider_transactions_backfill(
 class InsiderSummary:
     """Aggregate view of recent insider activity for an instrument.
 
-    ``net_shares_90d`` is positive when insiders net-bought over the
-    window, negative when they net-sold. Only non-derivative
-    transactions contribute — options/RSU grants are weaker signals
-    and the issue explicitly wants buy/sell directionality."""
+    Two lenses, both scoped to the last 90 days of non-derivative
+    transactions:
 
-    net_shares_90d: Decimal
-    buy_count_90d: int
-    sell_count_90d: int
+    - **Open-market** (``open_market_*``) — only ``txn_code='P'``
+      (open-market buy) and ``txn_code='S'`` (open-market sale). This
+      is the discretionary-sentiment signal: the insider chose to
+      trade in public markets. Grants, exercises, tax-withholding
+      sells, and same-day sell-to-cover lots are excluded because
+      they are mechanical consequences of compensation, not
+      directional bets.
+    - **Total acquired / disposed** (``total_acquired_*`` /
+      ``total_disposed_*``) — every non-derivative transaction, split
+      by ``acquired_disposed_code`` when present and by ``txn_code``
+      otherwise. This is the full insider-holdings-change view, so a
+      panel that only shows open-market numbers doesn't accidentally
+      imply insiders are net sellers during an RSU-vest month when
+      they actually accumulated shares on balance.
+
+    Operators need both. A large grant (A) followed by a small
+    sell-to-cover (S) reads very differently from an operator
+    deliberately dumping stock into the market.
+    """
+
+    # Open-market (discretionary-sentiment) view.
+    open_market_net_shares_90d: Decimal
+    open_market_buy_count_90d: int
+    open_market_sell_count_90d: int
+    # Total-acquired / total-disposed (full-activity) view.
+    total_acquired_shares_90d: Decimal
+    total_disposed_shares_90d: Decimal
+    acquisition_count_90d: int
+    disposition_count_90d: int
+    # Cross-lens metadata.
     unique_filers_90d: int
     latest_txn_date: date | None
+
+    # Back-compat aliases so existing callers that rely on the old
+    # ``net_shares_90d`` / ``buy_count_90d`` / ``sell_count_90d``
+    # names keep working while the API + frontend migrate.
+    @property
+    def net_shares_90d(self) -> Decimal:
+        return self.open_market_net_shares_90d
+
+    @property
+    def buy_count_90d(self) -> int:
+        return self.open_market_buy_count_90d
+
+    @property
+    def sell_count_90d(self) -> int:
+        return self.open_market_sell_count_90d
 
 
 def get_insider_summary(
@@ -1262,17 +1302,54 @@ def get_insider_summary(
         cur.execute(
             """
             SELECT
+                -- Open-market (discretionary) view: only explicit
+                -- P / S codes. This is the sentiment signal.
                 COALESCE(SUM(
                     CASE
                         WHEN it.txn_code = 'P' THEN it.shares
                         WHEN it.txn_code = 'S' THEN -it.shares
                         ELSE 0
                     END
-                ), 0) AS net_shares,
-                COUNT(*) FILTER (WHERE it.txn_code = 'P') AS buys,
-                COUNT(*) FILTER (WHERE it.txn_code = 'S') AS sells,
+                ), 0)                                                 AS open_market_net,
+                COUNT(*) FILTER (WHERE it.txn_code = 'P')             AS open_market_buys,
+                COUNT(*) FILTER (WHERE it.txn_code = 'S')             AS open_market_sells,
+                -- Total-activity view: classify by acquired_disposed_code
+                -- when SEC gave us one (authoritative), else fall back
+                -- to txn_code (P/A/M/X = acquired; S/D/F/G = disposed).
+                COALESCE(SUM(
+                    CASE
+                        WHEN COALESCE(it.acquired_disposed_code,
+                                      CASE WHEN it.txn_code IN ('P','A','M','X','C','V','J') THEN 'A'
+                                           WHEN it.txn_code IN ('S','D','F','G') THEN 'D'
+                                           ELSE NULL END) = 'A'
+                        THEN it.shares
+                        ELSE 0
+                    END
+                ), 0)                                                 AS total_acquired,
+                COALESCE(SUM(
+                    CASE
+                        WHEN COALESCE(it.acquired_disposed_code,
+                                      CASE WHEN it.txn_code IN ('P','A','M','X','C','V','J') THEN 'A'
+                                           WHEN it.txn_code IN ('S','D','F','G') THEN 'D'
+                                           ELSE NULL END) = 'D'
+                        THEN it.shares
+                        ELSE 0
+                    END
+                ), 0)                                                 AS total_disposed,
+                COUNT(*) FILTER (
+                    WHERE COALESCE(it.acquired_disposed_code,
+                                   CASE WHEN it.txn_code IN ('P','A','M','X','C','V','J') THEN 'A'
+                                        WHEN it.txn_code IN ('S','D','F','G') THEN 'D'
+                                        ELSE NULL END) = 'A'
+                )                                                     AS acquisition_count,
+                COUNT(*) FILTER (
+                    WHERE COALESCE(it.acquired_disposed_code,
+                                   CASE WHEN it.txn_code IN ('P','A','M','X','C','V','J') THEN 'A'
+                                        WHEN it.txn_code IN ('S','D','F','G') THEN 'D'
+                                        ELSE NULL END) = 'D'
+                )                                                     AS disposition_count,
                 COUNT(DISTINCT COALESCE(it.filer_cik, it.filer_name)) AS filers,
-                MAX(it.txn_date) AS latest
+                MAX(it.txn_date)                                      AS latest
             FROM insider_transactions it
             INNER JOIN insider_filings f
                 ON f.accession_number = it.accession_number
@@ -1285,13 +1362,27 @@ def get_insider_summary(
         )
         row = cur.fetchone()
     if row is None:
-        return InsiderSummary(Decimal(0), 0, 0, 0, None)
+        return InsiderSummary(
+            open_market_net_shares_90d=Decimal(0),
+            open_market_buy_count_90d=0,
+            open_market_sell_count_90d=0,
+            total_acquired_shares_90d=Decimal(0),
+            total_disposed_shares_90d=Decimal(0),
+            acquisition_count_90d=0,
+            disposition_count_90d=0,
+            unique_filers_90d=0,
+            latest_txn_date=None,
+        )
     return InsiderSummary(
-        net_shares_90d=Decimal(row[0]) if row[0] is not None else Decimal(0),
-        buy_count_90d=int(row[1] or 0),
-        sell_count_90d=int(row[2] or 0),
-        unique_filers_90d=int(row[3] or 0),
-        latest_txn_date=row[4],
+        open_market_net_shares_90d=Decimal(row[0]) if row[0] is not None else Decimal(0),
+        open_market_buy_count_90d=int(row[1] or 0),
+        open_market_sell_count_90d=int(row[2] or 0),
+        total_acquired_shares_90d=Decimal(row[3]) if row[3] is not None else Decimal(0),
+        total_disposed_shares_90d=Decimal(row[4]) if row[4] is not None else Decimal(0),
+        acquisition_count_90d=int(row[5] or 0),
+        disposition_count_90d=int(row[6] or 0),
+        unique_filers_90d=int(row[7] or 0),
+        latest_txn_date=row[8],
     )
 
 
@@ -1312,6 +1403,7 @@ class InsiderTransactionDetail:
     """
 
     accession_number: str
+    txn_row_num: int
     document_type: str
     txn_date: date
     deemed_execution_date: date | None
@@ -1355,6 +1447,7 @@ def list_insider_transactions(
             """
             SELECT
                 it.accession_number,
+                it.txn_row_num,
                 f.document_type,
                 it.txn_date,
                 it.deemed_execution_date,
@@ -1409,7 +1502,7 @@ def list_insider_transactions(
     rows: list[InsiderTransactionDetail] = []
     for r in raw_rows:
         acc = str(r[0])
-        refs_raw = r[24] or []
+        refs_raw = r[25] or []
         # psycopg returns JSONB as a Python list/dict already.
         refs = refs_raw if isinstance(refs_raw, list) else json.loads(refs_raw)
         footnotes: dict[str, str] = {}
@@ -1422,29 +1515,30 @@ def list_insider_transactions(
         rows.append(
             InsiderTransactionDetail(
                 accession_number=acc,
-                document_type=str(r[1]),
-                txn_date=r[2],
-                deemed_execution_date=r[3],
-                filer_cik=r[4],
-                filer_name=str(r[5]),
-                filer_role=r[6],
-                security_title=r[7],
-                txn_code=str(r[8]),
-                acquired_disposed_code=r[9],
-                shares=r[10],
-                price=r[11],
-                post_transaction_shares=r[12],
-                direct_indirect=r[13],
-                nature_of_ownership=r[14],
-                is_derivative=bool(r[15]),
-                equity_swap_involved=r[16],
-                transaction_timeliness=r[17],
-                conversion_exercise_price=r[18],
-                exercise_date=r[19],
-                expiration_date=r[20],
-                underlying_security_title=r[21],
-                underlying_shares=r[22],
-                underlying_value=r[23],
+                txn_row_num=int(r[1]),
+                document_type=str(r[2]),
+                txn_date=r[3],
+                deemed_execution_date=r[4],
+                filer_cik=r[5],
+                filer_name=str(r[6]),
+                filer_role=r[7],
+                security_title=r[8],
+                txn_code=str(r[9]),
+                acquired_disposed_code=r[10],
+                shares=r[11],
+                price=r[12],
+                post_transaction_shares=r[13],
+                direct_indirect=r[14],
+                nature_of_ownership=r[15],
+                is_derivative=bool(r[16]),
+                equity_swap_involved=r[17],
+                transaction_timeliness=r[18],
+                conversion_exercise_price=r[19],
+                exercise_date=r[20],
+                expiration_date=r[21],
+                underlying_security_title=r[22],
+                underlying_shares=r[23],
+                underlying_value=r[24],
                 footnotes=footnotes,
             )
         )

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -135,15 +135,25 @@ export async function fetchInstrumentSecProfile(
 
 export interface InsiderSummary {
   symbol: string;
+  open_market_net_shares_90d: string;
+  open_market_buy_count_90d: number;
+  open_market_sell_count_90d: number;
+  total_acquired_shares_90d: string;
+  total_disposed_shares_90d: string;
+  acquisition_count_90d: number;
+  disposition_count_90d: number;
+  unique_filers_90d: number;
+  latest_txn_date: string | null;
+  // Back-compat aliases the API also ships so pre-#458 consumers
+  // keep working. Prefer the open_market_* fields in new code.
   net_shares_90d: string;
   buy_count_90d: number;
   sell_count_90d: number;
-  unique_filers_90d: number;
-  latest_txn_date: string | null;
 }
 
 export interface InsiderTransactionDetail {
   accession_number: string;
+  txn_row_num: number;
   document_type: string;
   txn_date: string;
   deemed_execution_date: string | null;

--- a/frontend/src/components/instrument/InsiderActivityPanel.test.tsx
+++ b/frontend/src/components/instrument/InsiderActivityPanel.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * InsiderActivityPanel rendering tests (#458).
+ *
+ * Exists primarily to pin the summary-strip rendering against the
+ * misleading-zero regression: a window with no acquisitions / no
+ * disposals must render "0", not "+0" / "-0". Also pins the
+ * two-lens label wording so a later refactor can't quietly drop the
+ * "Open-market only (discretionary P/S)" qualifier and re-regress
+ * the operator-facing clarity.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  InsiderSummary,
+  InsiderTransactionsList,
+} from "@/api/instruments";
+
+import { InsiderActivityPanel } from "./InsiderActivityPanel";
+
+vi.mock("@/api/instruments", () => ({
+  fetchInsiderSummary: vi.fn(),
+  fetchInsiderTransactions: vi.fn(),
+}));
+
+import {
+  fetchInsiderSummary,
+  fetchInsiderTransactions,
+} from "@/api/instruments";
+
+const mockSummary = vi.mocked(fetchInsiderSummary);
+const mockTransactions = vi.mocked(fetchInsiderTransactions);
+
+function makeSummary(overrides: Partial<InsiderSummary> = {}): InsiderSummary {
+  return {
+    symbol: "GME",
+    open_market_net_shares_90d: "-18331",
+    open_market_buy_count_90d: 0,
+    open_market_sell_count_90d: 3,
+    total_acquired_shares_90d: "42392",
+    total_disposed_shares_90d: "18331",
+    acquisition_count_90d: 2,
+    disposition_count_90d: 3,
+    unique_filers_90d: 2,
+    latest_txn_date: "2026-04-13",
+    net_shares_90d: "-18331",
+    buy_count_90d: 0,
+    sell_count_90d: 3,
+    ...overrides,
+  };
+}
+
+function emptyTxns(): InsiderTransactionsList {
+  return { symbol: "GME", rows: [] };
+}
+
+afterEach(() => vi.clearAllMocks());
+
+
+describe("InsiderActivityPanel — summary strip", () => {
+  it("leads with the all-codes Net change, not the open-market P/S count", async () => {
+    mockSummary.mockResolvedValue(makeSummary());
+    mockTransactions.mockResolvedValue(emptyTxns());
+
+    render(<InsiderActivityPanel symbol="GME" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Net change/i)).toBeInTheDocument();
+    });
+    // All-codes net: +42,392 - 18,331 = +24,061
+    expect(screen.getByText(/\+24,061 shares/)).toBeInTheDocument();
+    // Acquired / Disposed counters present (both values may appear
+    // more than once — open-market breakdown reuses the -18,331).
+    expect(screen.getByText(/\+42,392/)).toBeInTheDocument();
+    expect(screen.getAllByText(/-18,331/).length).toBeGreaterThanOrEqual(1);
+    // Open-market qualifier present but clearly secondary
+    expect(
+      screen.getByText(/Open-market only \(discretionary P\/S\)/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders 0 (not +0 or -0) when acquisitions or disposals are empty", async () => {
+    mockSummary.mockResolvedValue(
+      makeSummary({
+        total_acquired_shares_90d: "0",
+        total_disposed_shares_90d: "0",
+        acquisition_count_90d: 0,
+        disposition_count_90d: 0,
+        open_market_net_shares_90d: "0",
+        net_shares_90d: "0",
+      }),
+    );
+    mockTransactions.mockResolvedValue(emptyTxns());
+
+    render(<InsiderActivityPanel symbol="GME" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Net change/i)).toBeInTheDocument();
+    });
+    // No rendered "+0" or "-0" anywhere.
+    expect(screen.queryByText(/^\+0$/)).toBeNull();
+    expect(screen.queryByText(/^-0$/)).toBeNull();
+  });
+});

--- a/frontend/src/components/instrument/InsiderActivityPanel.tsx
+++ b/frontend/src/components/instrument/InsiderActivityPanel.tsx
@@ -87,23 +87,6 @@ function formatDate(raw: string | null): string {
   return raw;
 }
 
-function netSharesBadge(raw: string): { label: string; colour: string } {
-  const num = Number(raw);
-  if (!Number.isFinite(num) || num === 0) {
-    return { label: "Neutral", colour: "bg-slate-100 text-slate-700" };
-  }
-  if (num > 0) {
-    return {
-      label: `+${Math.round(num).toLocaleString("en-US")} shares`,
-      colour: "bg-emerald-100 text-emerald-800",
-    };
-  }
-  return {
-    label: `${Math.round(num).toLocaleString("en-US")} shares`,
-    colour: "bg-rose-100 text-rose-800",
-  };
-}
-
 function roleBadge(role: string | null): string {
   if (role === null || role === "") return "Insider";
   // role shape: pipe-joined — "director|officer:CEO|ten_percent_owner"
@@ -119,49 +102,143 @@ function roleBadge(role: string | null): string {
   return parts.join(" · ");
 }
 
+function formatDelta(raw: string): { label: string; colour: string } {
+  const num = Number(raw);
+  if (!Number.isFinite(num) || num === 0) {
+    return { label: "0", colour: "bg-slate-100 text-slate-700" };
+  }
+  if (num > 0) {
+    return {
+      label: `+${Math.round(num).toLocaleString("en-US")}`,
+      colour: "bg-emerald-100 text-emerald-800",
+    };
+  }
+  return {
+    label: Math.round(num).toLocaleString("en-US"),
+    colour: "bg-rose-100 text-rose-800",
+  };
+}
+
 function SummaryStrip({ summary }: { summary: InsiderSummary }) {
-  const badge = netSharesBadge(summary.net_shares_90d);
+  const openMarketBadge = formatDelta(summary.open_market_net_shares_90d);
+  const totalAcquired = Number(summary.total_acquired_shares_90d);
+  const totalDisposed = Number(summary.total_disposed_shares_90d);
+  const totalNet = Number.isFinite(totalAcquired - totalDisposed)
+    ? totalAcquired - totalDisposed
+    : 0;
+  const totalBadge = formatDelta(String(totalNet));
   return (
-    <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-5">
-      <div className="flex flex-col">
-        <span className="text-xs uppercase tracking-wide text-slate-500">
-          Net 90d
-        </span>
-        <span
-          className={`mt-1 inline-flex w-fit rounded px-2 py-0.5 text-xs font-semibold ${badge.colour}`}
-        >
-          {badge.label}
-        </span>
+    <div className="mb-4 flex flex-col gap-4">
+      {/* Lens 1: open-market discretionary activity (P/S only) */}
+      <div>
+        <div className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+          Open-market activity · 90 days
+          <span
+            className="ml-2 inline-block rounded bg-slate-50 px-1.5 py-0.5 text-[10px] font-normal normal-case tracking-normal text-slate-500"
+            title="Transactions with SEC code P (open-market purchase) or S (open-market sale). Discretionary insider sentiment only; excludes grants, RSU vests, sell-to-cover, and option exercises."
+          >
+            P / S codes only
+          </span>
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <div className="flex flex-col">
+            <span className="text-xs uppercase tracking-wide text-slate-500">
+              Net
+            </span>
+            <span
+              className={`mt-1 inline-flex w-fit rounded px-2 py-0.5 text-xs font-semibold ${openMarketBadge.colour}`}
+            >
+              {openMarketBadge.label} shares
+            </span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-xs uppercase tracking-wide text-slate-500">
+              Buys
+            </span>
+            <span className="mt-1 font-mono text-base tabular-nums text-emerald-700">
+              {summary.open_market_buy_count_90d}
+            </span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-xs uppercase tracking-wide text-slate-500">
+              Sells
+            </span>
+            <span className="mt-1 font-mono text-base tabular-nums text-rose-700">
+              {summary.open_market_sell_count_90d}
+            </span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-xs uppercase tracking-wide text-slate-500">
+              Latest trade
+            </span>
+            <span className="mt-1 font-mono text-base tabular-nums text-slate-800">
+              {formatDate(summary.latest_txn_date)}
+            </span>
+          </div>
+        </div>
       </div>
-      <div className="flex flex-col">
-        <span className="text-xs uppercase tracking-wide text-slate-500">Buys</span>
-        <span className="mt-1 font-mono text-base tabular-nums text-emerald-700">
-          {summary.buy_count_90d}
-        </span>
-      </div>
-      <div className="flex flex-col">
-        <span className="text-xs uppercase tracking-wide text-slate-500">
-          Sells
-        </span>
-        <span className="mt-1 font-mono text-base tabular-nums text-rose-700">
-          {summary.sell_count_90d}
-        </span>
-      </div>
-      <div className="flex flex-col">
-        <span className="text-xs uppercase tracking-wide text-slate-500">
-          Unique insiders
-        </span>
-        <span className="mt-1 font-mono text-base tabular-nums text-slate-800">
-          {summary.unique_filers_90d}
-        </span>
-      </div>
-      <div className="flex flex-col">
-        <span className="text-xs uppercase tracking-wide text-slate-500">
-          Latest trade
-        </span>
-        <span className="mt-1 font-mono text-base tabular-nums text-slate-800">
-          {formatDate(summary.latest_txn_date)}
-        </span>
+
+      {/* Lens 2: total acquired / disposed across all non-derivative codes */}
+      <div>
+        <div className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+          All insider activity · 90 days
+          <span
+            className="ml-2 inline-block rounded bg-slate-50 px-1.5 py-0.5 text-[10px] font-normal normal-case tracking-normal text-slate-500"
+            title="Every non-derivative transaction: grants (A), sales (S), option exercises (M), tax withholding (F), gifts (G), etc. Shows the full change in insider holdings across the window."
+          >
+            All codes
+          </span>
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+          <div className="flex flex-col">
+            <span className="text-xs uppercase tracking-wide text-slate-500">
+              Net
+            </span>
+            <span
+              className={`mt-1 inline-flex w-fit rounded px-2 py-0.5 text-xs font-semibold ${totalBadge.colour}`}
+            >
+              {totalBadge.label} shares
+            </span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-xs uppercase tracking-wide text-slate-500">
+              Acquired
+            </span>
+            <span className="mt-1 font-mono text-base tabular-nums text-emerald-700">
+              {Math.round(totalAcquired).toLocaleString("en-US")}
+            </span>
+            <span className="text-[10px] text-slate-500">
+              {summary.acquisition_count_90d} txns
+            </span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-xs uppercase tracking-wide text-slate-500">
+              Disposed
+            </span>
+            <span className="mt-1 font-mono text-base tabular-nums text-rose-700">
+              {Math.round(totalDisposed).toLocaleString("en-US")}
+            </span>
+            <span className="text-[10px] text-slate-500">
+              {summary.disposition_count_90d} txns
+            </span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-xs uppercase tracking-wide text-slate-500">
+              Unique insiders
+            </span>
+            <span className="mt-1 font-mono text-base tabular-nums text-slate-800">
+              {summary.unique_filers_90d}
+            </span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-xs uppercase tracking-wide text-slate-500">
+              Latest trade
+            </span>
+            <span className="mt-1 font-mono text-base tabular-nums text-slate-800">
+              {formatDate(summary.latest_txn_date)}
+            </span>
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -293,7 +370,11 @@ function Body({
           </thead>
           <tbody>
             {transactions.rows.map((txn) => (
-              <Row key={`${txn.accession_number}-${txn.txn_date}-${txn.filer_cik ?? txn.filer_name}`} txn={txn} />
+              // accession_number + txn_row_num is the DB UNIQUE key,
+              // so it's guaranteed stable and collision-free even for
+              // filings with multiple rows per filer-date (e.g. an
+              // RSU-vest pattern of same-day A + S).
+              <Row key={`${txn.accession_number}-${txn.txn_row_num}`} txn={txn} />
             ))}
           </tbody>
         </table>

--- a/frontend/src/components/instrument/InsiderActivityPanel.tsx
+++ b/frontend/src/components/instrument/InsiderActivityPanel.tsx
@@ -152,7 +152,8 @@ function SummaryStrip({ summary }: { summary: InsiderSummary }) {
               Acquired
             </span>
             <span className="mt-1 font-mono text-base tabular-nums text-emerald-700">
-              +{Math.round(totalAcquired).toLocaleString("en-US")}
+              {totalAcquired > 0 ? "+" : ""}
+              {Math.round(totalAcquired).toLocaleString("en-US")}
             </span>
             <span className="text-[10px] text-slate-500">
               {summary.acquisition_count_90d} txns
@@ -166,7 +167,8 @@ function SummaryStrip({ summary }: { summary: InsiderSummary }) {
               Disposed
             </span>
             <span className="mt-1 font-mono text-base tabular-nums text-rose-700">
-              -{Math.round(totalDisposed).toLocaleString("en-US")}
+              {totalDisposed > 0 ? "-" : ""}
+              {Math.round(totalDisposed).toLocaleString("en-US")}
             </span>
             <span className="text-[10px] text-slate-500">
               {summary.disposition_count_90d} txns

--- a/frontend/src/components/instrument/InsiderActivityPanel.tsx
+++ b/frontend/src/components/instrument/InsiderActivityPanel.tsx
@@ -120,82 +120,29 @@ function formatDelta(raw: string): { label: string; colour: string } {
 }
 
 function SummaryStrip({ summary }: { summary: InsiderSummary }) {
-  const openMarketBadge = formatDelta(summary.open_market_net_shares_90d);
   const totalAcquired = Number(summary.total_acquired_shares_90d);
   const totalDisposed = Number(summary.total_disposed_shares_90d);
   const totalNet = Number.isFinite(totalAcquired - totalDisposed)
     ? totalAcquired - totalDisposed
     : 0;
   const totalBadge = formatDelta(String(totalNet));
+  const openMarketNet = Number(summary.open_market_net_shares_90d);
+  const openMarketBadge = formatDelta(summary.open_market_net_shares_90d);
   return (
-    <div className="mb-4 flex flex-col gap-4">
-      {/* Lens 1: open-market discretionary activity (P/S only) */}
+    <div className="mb-4 flex flex-col gap-3">
+      {/* Primary view: full insider-holdings change across every
+          non-derivative code. This is the "did insiders end the
+          window owning more or fewer shares" signal operators
+          actually want at a glance. */}
       <div>
-        <div className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
-          Open-market activity · 90 days
-          <span
-            className="ml-2 inline-block rounded bg-slate-50 px-1.5 py-0.5 text-[10px] font-normal normal-case tracking-normal text-slate-500"
-            title="Transactions with SEC code P (open-market purchase) or S (open-market sale). Discretionary insider sentiment only; excludes grants, RSU vests, sell-to-cover, and option exercises."
-          >
-            P / S codes only
-          </span>
-        </div>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <div className="flex flex-col">
-            <span className="text-xs uppercase tracking-wide text-slate-500">
-              Net
-            </span>
-            <span
-              className={`mt-1 inline-flex w-fit rounded px-2 py-0.5 text-xs font-semibold ${openMarketBadge.colour}`}
-            >
-              {openMarketBadge.label} shares
-            </span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-xs uppercase tracking-wide text-slate-500">
-              Buys
-            </span>
-            <span className="mt-1 font-mono text-base tabular-nums text-emerald-700">
-              {summary.open_market_buy_count_90d}
-            </span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-xs uppercase tracking-wide text-slate-500">
-              Sells
-            </span>
-            <span className="mt-1 font-mono text-base tabular-nums text-rose-700">
-              {summary.open_market_sell_count_90d}
-            </span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-xs uppercase tracking-wide text-slate-500">
-              Latest trade
-            </span>
-            <span className="mt-1 font-mono text-base tabular-nums text-slate-800">
-              {formatDate(summary.latest_txn_date)}
-            </span>
-          </div>
-        </div>
-      </div>
-
-      {/* Lens 2: total acquired / disposed across all non-derivative codes */}
-      <div>
-        <div className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
-          All insider activity · 90 days
-          <span
-            className="ml-2 inline-block rounded bg-slate-50 px-1.5 py-0.5 text-[10px] font-normal normal-case tracking-normal text-slate-500"
-            title="Every non-derivative transaction: grants (A), sales (S), option exercises (M), tax withholding (F), gifts (G), etc. Shows the full change in insider holdings across the window."
-          >
-            All codes
-          </span>
-        </div>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
           <div className="flex flex-col">
             <span className="text-xs uppercase tracking-wide text-slate-500">
-              Net
+              Net change
             </span>
             <span
-              className={`mt-1 inline-flex w-fit rounded px-2 py-0.5 text-xs font-semibold ${totalBadge.colour}`}
+              className={`mt-1 inline-flex w-fit rounded px-2 py-0.5 text-sm font-semibold ${totalBadge.colour}`}
+              title="Total shares acquired minus disposed across every non-derivative Form 4 transaction in the last 90 days. Includes grants, open-market purchases, option exercises, sales, tax withholding, gifts."
             >
               {totalBadge.label} shares
             </span>
@@ -205,10 +152,13 @@ function SummaryStrip({ summary }: { summary: InsiderSummary }) {
               Acquired
             </span>
             <span className="mt-1 font-mono text-base tabular-nums text-emerald-700">
-              {Math.round(totalAcquired).toLocaleString("en-US")}
+              +{Math.round(totalAcquired).toLocaleString("en-US")}
             </span>
             <span className="text-[10px] text-slate-500">
               {summary.acquisition_count_90d} txns
+              {summary.open_market_buy_count_90d > 0 && (
+                <> · {summary.open_market_buy_count_90d} open-market</>
+              )}
             </span>
           </div>
           <div className="flex flex-col">
@@ -216,10 +166,13 @@ function SummaryStrip({ summary }: { summary: InsiderSummary }) {
               Disposed
             </span>
             <span className="mt-1 font-mono text-base tabular-nums text-rose-700">
-              {Math.round(totalDisposed).toLocaleString("en-US")}
+              -{Math.round(totalDisposed).toLocaleString("en-US")}
             </span>
             <span className="text-[10px] text-slate-500">
               {summary.disposition_count_90d} txns
+              {summary.open_market_sell_count_90d > 0 && (
+                <> · {summary.open_market_sell_count_90d} open-market</>
+              )}
             </span>
           </div>
           <div className="flex flex-col">
@@ -240,6 +193,31 @@ function SummaryStrip({ summary }: { summary: InsiderSummary }) {
           </div>
         </div>
       </div>
+
+      {/* Secondary view: discretionary (P/S) only — the sentiment
+          sub-signal, labelled clearly so a "0 buys" count next to
+          grants doesn't read as insiders not buying. */}
+      {(summary.open_market_buy_count_90d + summary.open_market_sell_count_90d > 0 ||
+        openMarketNet !== 0) && (
+        <div className="rounded bg-slate-50 px-3 py-1.5 text-xs text-slate-600">
+          <span className="font-medium text-slate-700">
+            Open-market only (discretionary P/S):
+          </span>{" "}
+          <span
+            className={`inline-flex items-center rounded px-1.5 py-0.5 font-semibold ${openMarketBadge.colour}`}
+          >
+            {openMarketBadge.label} shares
+          </span>{" "}
+          · {summary.open_market_buy_count_90d} buys ·{" "}
+          {summary.open_market_sell_count_90d} sells
+          <span
+            className="ml-1 text-slate-400"
+            title="Only SEC transaction codes P (open-market purchase) and S (open-market sale). Excludes grants, RSU vests, option exercises, tax withholding, gifts."
+          >
+            ⓘ
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/tests/test_insider_transactions_ingest.py
+++ b/tests/test_insider_transactions_ingest.py
@@ -675,7 +675,89 @@ class TestGetInsiderSummary:
             )
         ebull_test_conn.commit()
         summary = get_insider_summary(ebull_test_conn, instrument_id=iid)
-        assert summary.net_shares_90d == Decimal(0)
+        assert summary.open_market_net_shares_90d == Decimal(0)
+        assert summary.total_acquired_shares_90d == Decimal(0)
+        assert summary.total_disposed_shares_90d == Decimal(0)
+
+    def test_grant_plus_sell_to_cover_shows_both_lenses(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        """#458 regression — an RSU vest pattern (A grant + S
+        sell-to-cover) must surface both views: open-market counts
+        only the discretionary S, total-activity counts both the grant
+        (acquired) and the sell (disposed). The prior single-lens
+        summary showed NET=-shares / BUYS=0 / SELLS=1 with no hint
+        that the insider actually received a larger grant."""
+        iid = _seed_instrument(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO insider_filings (accession_number, instrument_id, document_type)
+                VALUES ('VEST-1', %s, '4')
+                """,
+                (iid,),
+            )
+            cur.execute(
+                """
+                INSERT INTO insider_transactions
+                    (instrument_id, accession_number, txn_row_num,
+                     filer_cik, filer_name, txn_date, txn_code,
+                     acquired_disposed_code, shares, is_derivative)
+                VALUES
+                    (%s, 'VEST-1', 0, 'CIK-A', 'Exec A',
+                     CURRENT_DATE, 'A', 'A', 1000, FALSE),
+                    (%s, 'VEST-1', 1, 'CIK-A', 'Exec A',
+                     CURRENT_DATE, 'S', 'D', 300, FALSE)
+                """,
+                (iid, iid),
+            )
+        ebull_test_conn.commit()
+
+        summary = get_insider_summary(ebull_test_conn, instrument_id=iid)
+        # Open-market lens: no P, one S.
+        assert summary.open_market_buy_count_90d == 0
+        assert summary.open_market_sell_count_90d == 1
+        assert summary.open_market_net_shares_90d == Decimal(-300)
+        # All-codes lens: grant and sell both captured.
+        assert summary.acquisition_count_90d == 1
+        assert summary.disposition_count_90d == 1
+        assert summary.total_acquired_shares_90d == Decimal(1000)
+        assert summary.total_disposed_shares_90d == Decimal(300)
+
+    def test_open_market_buy_still_registers_in_both_lenses(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        """A real open-market P must show up on both views."""
+        iid = _seed_instrument(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO insider_filings (accession_number, instrument_id, document_type)
+                VALUES ('OMB-1', %s, '4')
+                """,
+                (iid,),
+            )
+            cur.execute(
+                """
+                INSERT INTO insider_transactions
+                    (instrument_id, accession_number, txn_row_num,
+                     filer_cik, filer_name, txn_date, txn_code,
+                     acquired_disposed_code, shares, is_derivative)
+                VALUES (%s, 'OMB-1', 0, 'CIK-B', 'Exec B',
+                        CURRENT_DATE, 'P', 'A', 500, FALSE)
+                """,
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        summary = get_insider_summary(ebull_test_conn, instrument_id=iid)
+        assert summary.open_market_buy_count_90d == 1
+        assert summary.open_market_net_shares_90d == Decimal(500)
+        assert summary.acquisition_count_90d == 1
+        assert summary.total_acquired_shares_90d == Decimal(500)
+        # Back-compat aliases still work.
+        assert summary.buy_count_90d == 1
+        assert summary.net_shares_90d == Decimal(500)
 
 
 class TestListInsiderTransactions:

--- a/tests/test_insider_transactions_ingest.py
+++ b/tests/test_insider_transactions_ingest.py
@@ -679,9 +679,7 @@ class TestGetInsiderSummary:
         assert summary.total_acquired_shares_90d == Decimal(0)
         assert summary.total_disposed_shares_90d == Decimal(0)
 
-    def test_grant_plus_sell_to_cover_shows_both_lenses(
-        self, ebull_test_conn: psycopg.Connection[tuple]
-    ) -> None:
+    def test_grant_plus_sell_to_cover_shows_both_lenses(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         """#458 regression — an RSU vest pattern (A grant + S
         sell-to-cover) must surface both views: open-market counts
         only the discretionary S, total-activity counts both the grant
@@ -724,9 +722,7 @@ class TestGetInsiderSummary:
         assert summary.total_acquired_shares_90d == Decimal(1000)
         assert summary.total_disposed_shares_90d == Decimal(300)
 
-    def test_open_market_buy_still_registers_in_both_lenses(
-        self, ebull_test_conn: psycopg.Connection[tuple]
-    ) -> None:
+    def test_open_market_buy_still_registers_in_both_lenses(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         """A real open-market P must show up on both views."""
         iid = _seed_instrument(ebull_test_conn)
         with ebull_test_conn.cursor() as cur:


### PR DESCRIPTION
## Summary
- Summary strip now shows **Open-market (P/S)** AND **All-codes (every non-derivative txn)** so grants + sell-to-cover patterns don't read as pure insider selling.
- Detail table row key uses (accession, txn_row_num) so same-day A+S rows on one filing don't collide and silently drop from the DOM.

## Test plan
- [x] uv run ruff check . / format / pyright (all clean)
- [x] uv run pytest (2573 passed)
- [x] pnpm --dir frontend typecheck + test:unit (384 passed)
- [x] Live API on dev DB: GME returns 42,392 acquired / 18,331 disposed alongside open-market -18,331 net