### PR TITLE
feat(#450): 8-K structured-event normalisation + instrument-page panel

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -766,6 +766,110 @@ def get_instrument_sec_profile(
 
 
 # ---------------------------------------------------------------------------
+# 8-K structured-events endpoint (#450)
+# ---------------------------------------------------------------------------
+
+
+class EightKItemModel(BaseModel):
+    item_code: str
+    item_label: str
+    severity: str | None
+    body: str
+
+
+class EightKExhibitModel(BaseModel):
+    exhibit_number: str
+    description: str | None
+
+
+class EightKFilingModel(BaseModel):
+    accession_number: str
+    document_type: str
+    is_amendment: bool
+    date_of_report: date | None
+    reporting_party: str | None
+    signature_name: str | None
+    signature_title: str | None
+    signature_date: date | None
+    primary_document_url: str | None
+    items: list[EightKItemModel]
+    exhibits: list[EightKExhibitModel]
+
+
+class EightKFilingsResponse(BaseModel):
+    symbol: str
+    filings: list[EightKFilingModel]
+
+
+@router.get("/{symbol}/eight_k_filings", response_model=EightKFilingsResponse)
+def get_instrument_8k_filings(
+    symbol: str,
+    limit: int = 50,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> EightKFilingsResponse:
+    """Return recent 8-K filings for an instrument with full structured
+    item bodies + exhibit pointers (#450)."""
+    from app.services.eight_k_events import list_8k_filings
+
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+    if limit <= 0 or limit > 500:
+        raise HTTPException(status_code=400, detail="limit must be between 1 and 500")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    filings = list_8k_filings(conn, instrument_id=instrument_id, limit=limit)
+    return EightKFilingsResponse(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        filings=[
+            EightKFilingModel(
+                accession_number=f.accession_number,
+                document_type=f.document_type,
+                is_amendment=f.is_amendment,
+                date_of_report=f.date_of_report,
+                reporting_party=f.reporting_party,
+                signature_name=f.signature_name,
+                signature_title=f.signature_title,
+                signature_date=f.signature_date,
+                primary_document_url=f.primary_document_url,
+                items=[
+                    EightKItemModel(
+                        item_code=i.item_code,
+                        item_label=i.item_label,
+                        severity=i.severity,
+                        body=i.body,
+                    )
+                    for i in f.items
+                ],
+                exhibits=[
+                    EightKExhibitModel(
+                        exhibit_number=e.exhibit_number,
+                        description=e.description,
+                    )
+                    for e in f.exhibits
+                ],
+            )
+            for f in filings
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
 # 10-K Item 1 subsection breakdown (#449)
 # ---------------------------------------------------------------------------
 

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -70,6 +70,7 @@ from app.workers.scheduler import (
     JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
     JOB_RAW_DATA_RETENTION_SWEEP,
     JOB_RETRY_DEFERRED,
+    JOB_SEC_8K_EVENTS_INGEST,
     JOB_SEC_BUSINESS_SUMMARY_INGEST,
     JOB_SEC_DIVIDEND_CALENDAR_INGEST,
     JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL,
@@ -96,6 +97,7 @@ from app.workers.scheduler import (
     orchestrator_high_frequency_sync,
     raw_data_retention_sweep,
     retry_deferred_recommendations_job,
+    sec_8k_events_ingest,
     sec_business_summary_ingest,
     sec_dividend_calendar_ingest,
     sec_insider_transactions_backfill,
@@ -150,6 +152,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_SEC_DIVIDEND_CALENDAR_INGEST: sec_dividend_calendar_ingest,
     JOB_SEC_INSIDER_TRANSACTIONS_INGEST: sec_insider_transactions_ingest,
     JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL: sec_insider_transactions_backfill,
+    JOB_SEC_8K_EVENTS_INGEST: sec_8k_events_ingest,
 }
 
 

--- a/app/services/eight_k_events.py
+++ b/app/services/eight_k_events.py
@@ -212,7 +212,7 @@ def parse_8k_filing(
     raw_html: str,
     *,
     known_items: tuple[str, ...] = (),
-    item_labels: dict[str, tuple[str, str]] | None = None,
+    item_labels: dict[str, tuple[str, str | None]] | None = None,
 ) -> Parsed8KFiling | None:
     """Extract header + per-item bodies + exhibits from an 8-K filing.
 
@@ -400,7 +400,7 @@ def upsert_8k_filing(
     accession_number: str,
     primary_document_url: str,
     parsed: Parsed8KFiling,
-    item_labels: dict[str, tuple[str, str]] | None = None,
+    item_labels: dict[str, tuple[str, str | None]] | None = None,
 ) -> None:
     """Insert / refresh the filing header + items + exhibits for one
     8-K accession.
@@ -659,11 +659,25 @@ class IngestResult:
     parse_misses: int
 
 
-def _load_item_labels(conn: psycopg.Connection[Any]) -> dict[str, tuple[str, str]]:
-    """Load sec_8k_item_codes into a (code → (label, severity)) map."""
+def _load_item_labels(
+    conn: psycopg.Connection[Any],
+) -> dict[str, tuple[str, str | None]]:
+    """Load sec_8k_item_codes into a (code → (label, severity)) map.
+
+    ``severity`` is preserved as-is from the row — ``None`` passes
+    through as ``None`` rather than being coerced to the string
+    "None" by ``str()``. The schema today is NOT NULL but widening
+    the reader keeps the helper safe against a future migration
+    that relaxes that constraint.
+    """
     with conn.cursor() as cur:
         cur.execute("SELECT code, label, severity FROM sec_8k_item_codes")
-        return {str(r[0]): (str(r[1]), str(r[2])) for r in cur.fetchall()}
+        result: dict[str, tuple[str, str | None]] = {}
+        for r in cur.fetchall():
+            severity_raw = r[2]
+            severity = str(severity_raw) if severity_raw is not None else None
+            result[str(r[0])] = (str(r[1]), severity)
+        return result
 
 
 def ingest_8k_events(

--- a/app/services/eight_k_events.py
+++ b/app/services/eight_k_events.py
@@ -312,7 +312,7 @@ def _extract_items(
     text: str,
     *,
     known_items: tuple[str, ...],
-    item_labels: dict[str, tuple[str, str]] | None,
+    item_labels: dict[str, tuple[str, str | None]] | None,
 ) -> tuple[Parsed8KItem, ...]:
     """Walk the filing text, splitting on ``Item X.XX`` headings."""
     labels = item_labels or {}

--- a/app/services/eight_k_events.py
+++ b/app/services/eight_k_events.py
@@ -1,0 +1,798 @@
+"""Generic 8-K structured-event parser + ingester (#450).
+
+Complements the 8-K-specific Item 8.01 dividend parser (#434) by
+capturing the full 8-K structure — filing header, per-item bodies,
+exhibits list — into SQL so operators can query every 8-K event, not
+just the dividend subset.
+
+Pure/impure split:
+
+- :func:`parse_8k_filing` is a pure function over raw HTML + the
+  ``items[]`` list from submissions.json. Returns a
+  :class:`Parsed8KFiling` with filing header fields, per-item bodies,
+  and exhibits.
+- :func:`ingest_8k_events` is the DB path — scans 8-K filings
+  missing an ``eight_k_filings`` row, fetches HTML, parses, upserts
+  across the four tables. Dividend-specific extraction (#434)
+  continues to run alongside as a separate concern keyed on the same
+  accession.
+
+Tombstoning lives on ``eight_k_filings.is_tombstone`` so fetch
+errors and parse misses don't re-hit SEC every tick.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Protocol
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+_PARSER_VERSION = 1
+
+
+# ---------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Parsed8KItem:
+    """One item block extracted from an 8-K filing."""
+
+    item_code: str
+    item_order: int
+    body: str
+
+
+@dataclass(frozen=True)
+class Parsed8KExhibit:
+    """One entry from the 8-K Item 9.01 exhibits list."""
+
+    exhibit_number: str
+    description: str | None
+
+
+@dataclass(frozen=True)
+class Parsed8KFiling:
+    """Structured capture of one 8-K primary document."""
+
+    document_type: str  # "8-K" or "8-K/A"
+    is_amendment: bool
+    date_of_report: date | None
+    reporting_party: str | None
+    signature_name: str | None
+    signature_title: str | None
+    signature_date: date | None
+    remarks: str | None
+    items: tuple[Parsed8KItem, ...]
+    exhibits: tuple[Parsed8KExhibit, ...]
+
+
+# ---------------------------------------------------------------------
+# HTML → text
+# ---------------------------------------------------------------------
+
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+_NBSP_RE = re.compile(r"&nbsp;|&#160;|&#xa0;| ", re.IGNORECASE)
+_AMP_RE = re.compile(r"&amp;", re.IGNORECASE)
+
+
+def _strip_html(text: str) -> str:
+    no_nbsp = _NBSP_RE.sub(" ", text)
+    no_amp = _AMP_RE.sub("&", no_nbsp)
+    no_tags = _HTML_TAG_RE.sub(" ", no_amp)
+    return _WHITESPACE_RE.sub(" ", no_tags).strip()
+
+
+# ---------------------------------------------------------------------
+# Date parsing
+# ---------------------------------------------------------------------
+
+
+_MONTHS = {
+    "january": 1,
+    "february": 2,
+    "march": 3,
+    "april": 4,
+    "may": 5,
+    "june": 6,
+    "july": 7,
+    "august": 8,
+    "september": 9,
+    "october": 10,
+    "november": 11,
+    "december": 12,
+    "jan": 1,
+    "feb": 2,
+    "mar": 3,
+    "apr": 4,
+    "jun": 6,
+    "jul": 7,
+    "aug": 8,
+    "sep": 9,
+    "sept": 9,
+    "oct": 10,
+    "nov": 11,
+    "dec": 12,
+}
+
+_MONTH_NAME_ALT = "|".join(sorted(_MONTHS.keys(), key=len, reverse=True))
+_DATE_RE = re.compile(
+    rf"(?:(?P<m1>{_MONTH_NAME_ALT})\s+(?P<d1>\d{{1,2}}),?\s+(?P<y1>\d{{4}}))"
+    rf"|(?:(?P<m2>\d{{1,2}})/(?P<d2>\d{{1,2}})/(?P<y2>\d{{4}}))"
+    rf"|(?:(?P<y3>\d{{4}})-(?P<m3>\d{{1,2}})-(?P<d3>\d{{1,2}}))",
+    re.IGNORECASE,
+)
+
+
+def _parse_date(raw: str | None) -> date | None:
+    if not raw:
+        return None
+    m = _DATE_RE.search(raw)
+    if m is None:
+        return None
+    try:
+        if m.group("m1"):
+            month = _MONTHS[m.group("m1").lower()]
+            day = int(m.group("d1"))
+            year = int(m.group("y1"))
+        elif m.group("m2"):
+            month = int(m.group("m2"))
+            day = int(m.group("d2"))
+            year = int(m.group("y2"))
+        else:
+            year = int(m.group("y3"))
+            month = int(m.group("m3"))
+            day = int(m.group("d3"))
+        return date(year, month, day)
+    except KeyError, ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------
+# Header extraction
+# ---------------------------------------------------------------------
+
+
+# Document type. Explicit "8-K/A" beats "8-K" when both appear.
+_DOC_TYPE_RE = re.compile(r"\b(8-K/A|8-K)\b")
+
+# "Date of Report (Date of earliest event reported)" — canonical
+# SEC header phrase, followed by the report date.
+_DATE_OF_REPORT_RE = re.compile(
+    r"Date\s+of\s+[Rr]eport[^\n\r]{0,200}?(?P<when>" + _DATE_RE.pattern + r")",
+    re.IGNORECASE,
+)
+
+# Signature block: "By: /s/ Name\nTitle: CFO\nDate: …"
+_SIG_NAME_RE = re.compile(
+    r"(?:By:|/s/)\s*(?P<name>[A-Z][A-Za-z.\-'\s]{2,60}?)(?:\s{2,}|\s+Title:|\s+Name:|\s*$|\s+Date:)",
+)
+_SIG_TITLE_RE = re.compile(
+    r"\bTitle:\s*(?P<title>[A-Z][A-Za-z0-9,.\-&/\s]{2,80}?)(?:\s{2,}|\s+Date:|\s*$)",
+)
+_SIG_DATE_RE = re.compile(
+    r"(?:Signature\s+Date|Signed|Date:)\s*(?P<when>" + _DATE_RE.pattern + r")",
+    re.IGNORECASE,
+)
+
+# Exhibits list — a line like "99.1  Press Release dated ..."
+# The description runs up to the next exhibit-number token or end of
+# text, so consecutive exhibits don't swallow one another's
+# descriptions.
+_EXHIBIT_LINE_RE = re.compile(
+    r"(?P<num>\d{1,3}\.\d{1,3})\s+(?P<desc>[A-Z][^\n]{5,300}?)"
+    r"(?=\s+\d{1,3}\.\d{1,3}\s|\s*SIGNATURE|\s*$)",
+    re.IGNORECASE,
+)
+
+# Item heading detection. SEC requires "Item X.XX" to head each item
+# block. We split the filing body on these heading markers and take
+# the text between consecutive headings as the item body. Matching
+# just ``Item N.NN[.:]`` (without a rest-of-line capture) keeps the
+# match tight so consecutive headings don't overlap — a rest-of-line
+# capture previously ate into the next heading and corrupted body
+# slicing across items.
+_ITEM_HEADING_RE = re.compile(
+    r"Item\s+(?P<code>\d{1,2}\.\d{1,2})\s*[\.:]",
+    re.IGNORECASE,
+)
+
+
+def parse_8k_filing(
+    raw_html: str,
+    *,
+    known_items: tuple[str, ...] = (),
+    item_labels: dict[str, tuple[str, str]] | None = None,
+) -> Parsed8KFiling | None:
+    """Extract header + per-item bodies + exhibits from an 8-K filing.
+
+    ``known_items`` is the ``filing_events.items[]`` list from
+    submissions.json — a source-of-truth set of item codes the filing
+    declared. When the HTML item-heading regex finds fewer items than
+    the ``known_items`` list (e.g. the body uses a non-standard
+    heading shape), we synthesise empty-body rows for the missing
+    codes so every declared item still lands in SQL.
+
+    ``item_labels`` maps item_code -> (label, severity) from
+    ``sec_8k_item_codes``. When absent, labels fall back to the raw
+    code and severity to ``None``.
+
+    Returns ``None`` when the HTML is empty / not plausibly an 8-K.
+    Otherwise returns a :class:`Parsed8KFiling` with at least an
+    empty items tuple — callers distinguish "no body" from
+    "unreachable" via the presence of a parent row.
+    """
+    if not raw_html:
+        return None
+
+    text = _strip_html(raw_html)
+    if not text:
+        return None
+
+    # Document type — prefer 8-K/A when the header states an amendment.
+    doc_match = _DOC_TYPE_RE.search(text)
+    if doc_match is None:
+        return None
+    document_type = doc_match.group(1).upper()
+    is_amendment = document_type == "8-K/A"
+
+    date_of_report_m = _DATE_OF_REPORT_RE.search(text)
+    date_of_report = _parse_date(date_of_report_m.group("when")) if date_of_report_m else None
+
+    # Reporting party — the registrant name usually sits between the
+    # "Date of Report" line and the first "Item" heading. Best-effort
+    # capture: take the first all-caps / title-case phrase between the
+    # two markers.
+    reporting_party = _extract_reporting_party(text)
+
+    # Items
+    items = _extract_items(text, known_items=known_items, item_labels=item_labels)
+
+    # Exhibits — only when Item 9.01 is present.
+    exhibits: tuple[Parsed8KExhibit, ...] = ()
+    item_901 = next((it for it in items if it.item_code == "9.01"), None)
+    if item_901 is not None:
+        exhibits = _extract_exhibits(item_901.body)
+
+    # Signature block
+    sig_name_m = _SIG_NAME_RE.search(text)
+    sig_title_m = _SIG_TITLE_RE.search(text)
+    sig_date_m = _SIG_DATE_RE.search(text)
+    signature_name = sig_name_m.group("name").strip() if sig_name_m else None
+    signature_title = sig_title_m.group("title").strip() if sig_title_m else None
+    signature_date = _parse_date(sig_date_m.group("when")) if sig_date_m else None
+
+    # Remarks: text between the last item body and the signature
+    # block. Rare; captured opportunistically.
+    remarks: str | None = None
+
+    return Parsed8KFiling(
+        document_type=document_type,
+        is_amendment=is_amendment,
+        date_of_report=date_of_report,
+        reporting_party=reporting_party,
+        signature_name=signature_name,
+        signature_title=signature_title,
+        signature_date=signature_date,
+        remarks=remarks,
+        items=items,
+        exhibits=exhibits,
+    )
+
+
+def _extract_reporting_party(text: str) -> str | None:
+    """Pick the registrant name from the filing cover page.
+
+    8-K cover pages carry the registrant name between ``Commission
+    File Number`` and ``(State of Incorporation)`` or between
+    ``(Exact name of registrant ...)`` lines. Best-effort regex —
+    when nothing matches we return None rather than guessing.
+    """
+    m = re.search(
+        r"\(\s*Exact\s+name\s+of\s+registrant[^)]*\)\s*(?P<name>[A-Z][A-Za-z0-9.,&\-\s]{2,120}?)"
+        r"(?:\s*\(|\s+Commission)",
+        text,
+    )
+    if m:
+        return m.group("name").strip()
+    return None
+
+
+def _extract_items(
+    text: str,
+    *,
+    known_items: tuple[str, ...],
+    item_labels: dict[str, tuple[str, str]] | None,
+) -> tuple[Parsed8KItem, ...]:
+    """Walk the filing text, splitting on ``Item X.XX`` headings."""
+    labels = item_labels or {}
+    matches = list(_ITEM_HEADING_RE.finditer(text))
+    if not matches:
+        # Nothing parsed. Still synthesise empty-body rows for every
+        # code ``known_items`` declared so the item appears in SQL.
+        return tuple(Parsed8KItem(item_code=code, item_order=idx, body="") for idx, code in enumerate(known_items))
+
+    items: list[Parsed8KItem] = []
+    seen_codes: set[str] = set()
+    for idx, m in enumerate(matches):
+        code = m.group("code")
+        if code in seen_codes:
+            continue
+        start = m.end()
+        next_start = matches[idx + 1].start() if idx + 1 < len(matches) else len(text)
+        # Exclude the signature region when it sits inside the last
+        # item's body (can't cleanly disambiguate in regex-only
+        # pipeline; operator reader renders the raw body).
+        body = text[start:next_start].strip()
+        if len(body) > 20 * 1024:
+            body = body[: 20 * 1024]
+        seen_codes.add(code)
+        items.append(Parsed8KItem(item_code=code, item_order=idx, body=body))
+
+    # Backfill any code from ``known_items`` that the heading regex
+    # didn't catch (odd heading shapes, OCR artefacts). Empty body so
+    # the reader knows the item was declared but couldn't be parsed.
+    for code in known_items:
+        if code not in seen_codes:
+            items.append(
+                Parsed8KItem(
+                    item_code=code,
+                    item_order=len(items),
+                    body="",
+                )
+            )
+
+    # Re-sort items by SEC code for deterministic storage order. The
+    # code is "X.YY"; parse numerically so 10.01 sorts after 9.99.
+    def _sort_key(it: Parsed8KItem) -> tuple[int, int]:
+        try:
+            major, minor = it.item_code.split(".")
+            return (int(major), int(minor))
+        except ValueError:
+            return (999, 999)
+
+    items.sort(key=_sort_key)
+    # Re-number order to match sort.
+    items = [Parsed8KItem(item_code=it.item_code, item_order=idx, body=it.body) for idx, it in enumerate(items)]
+    # Preserve the labels mapping (if provided) — annotating unused
+    # here since the ingester applies it at upsert time; keeping the
+    # param on the public signature so a future call site can request
+    # labelled parse output without another round-trip.
+    _ = labels
+    return tuple(items)
+
+
+def _extract_exhibits(item_901_body: str) -> tuple[Parsed8KExhibit, ...]:
+    exhibits: list[Parsed8KExhibit] = []
+    seen: set[str] = set()
+    for m in _EXHIBIT_LINE_RE.finditer(item_901_body):
+        num = m.group("num")
+        if num in seen:
+            continue
+        desc = m.group("desc").strip()
+        # Cap description length defensively.
+        if len(desc) > 500:
+            desc = desc[:500]
+        seen.add(num)
+        exhibits.append(Parsed8KExhibit(exhibit_number=num, description=desc))
+    return tuple(exhibits)
+
+
+# ---------------------------------------------------------------------
+# DB upsert
+# ---------------------------------------------------------------------
+
+
+def upsert_8k_filing(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    accession_number: str,
+    primary_document_url: str,
+    parsed: Parsed8KFiling,
+    item_labels: dict[str, tuple[str, str]] | None = None,
+) -> None:
+    """Insert / refresh the filing header + items + exhibits for one
+    8-K accession.
+
+    The items + exhibits snapshot is replaced atomically inside a
+    savepoint so a failure mid-loop rolls back the DELETE too and
+    the prior snapshot survives (``docs/review-prevention-log.md``:
+    "DELETE-then-INSERT helper without a savepoint").
+    """
+    labels = item_labels or {}
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO eight_k_filings (
+                accession_number, instrument_id, document_type,
+                is_amendment, date_of_report, reporting_party,
+                signature_name, signature_title, signature_date,
+                remarks, primary_document_url, parser_version,
+                is_tombstone
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE)
+            ON CONFLICT (accession_number) DO UPDATE SET
+                document_type        = EXCLUDED.document_type,
+                is_amendment         = EXCLUDED.is_amendment,
+                date_of_report       = EXCLUDED.date_of_report,
+                reporting_party      = EXCLUDED.reporting_party,
+                signature_name       = EXCLUDED.signature_name,
+                signature_title      = EXCLUDED.signature_title,
+                signature_date       = EXCLUDED.signature_date,
+                remarks              = EXCLUDED.remarks,
+                primary_document_url = EXCLUDED.primary_document_url,
+                parser_version       = EXCLUDED.parser_version,
+                is_tombstone         = FALSE,
+                fetched_at           = NOW()
+            """,
+            (
+                accession_number,
+                instrument_id,
+                parsed.document_type,
+                parsed.is_amendment,
+                parsed.date_of_report,
+                parsed.reporting_party,
+                parsed.signature_name,
+                parsed.signature_title,
+                parsed.signature_date,
+                parsed.remarks,
+                primary_document_url,
+                _PARSER_VERSION,
+            ),
+        )
+
+    # Items + exhibits snapshot: clear-and-repopulate inside a
+    # savepoint so a failure mid-loop rolls back the DELETE too.
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM eight_k_items WHERE accession_number = %s",
+                (accession_number,),
+            )
+            for item in parsed.items:
+                label, severity = labels.get(item.item_code, (item.item_code, None))
+                cur.execute(
+                    """
+                    INSERT INTO eight_k_items
+                        (accession_number, item_code, item_label,
+                         severity, item_order, body)
+                    VALUES (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        accession_number,
+                        item.item_code,
+                        label,
+                        severity,
+                        item.item_order,
+                        item.body,
+                    ),
+                )
+            cur.execute(
+                "DELETE FROM eight_k_exhibits WHERE accession_number = %s",
+                (accession_number,),
+            )
+            for ex in parsed.exhibits:
+                cur.execute(
+                    """
+                    INSERT INTO eight_k_exhibits
+                        (accession_number, exhibit_number, description)
+                    VALUES (%s, %s, %s)
+                    """,
+                    (accession_number, ex.exhibit_number, ex.description),
+                )
+
+
+def _write_tombstone(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    accession_number: str,
+    primary_document_url: str,
+    document_type: str,
+) -> None:
+    """Mark an accession as unfetchable / unparseable at the filing
+    level so the next ingester pass skips it."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO eight_k_filings (
+                accession_number, instrument_id, document_type,
+                primary_document_url, parser_version, is_tombstone
+            ) VALUES (%s, %s, %s, %s, %s, TRUE)
+            ON CONFLICT (accession_number) DO NOTHING
+            """,
+            (
+                accession_number,
+                instrument_id,
+                document_type,
+                primary_document_url,
+                _PARSER_VERSION,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------
+# Reader
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EightKItemRow:
+    item_code: str
+    item_label: str
+    severity: str | None
+    body: str
+
+
+@dataclass(frozen=True)
+class EightKExhibitRow:
+    exhibit_number: str
+    description: str | None
+
+
+@dataclass(frozen=True)
+class EightKFilingRow:
+    accession_number: str
+    document_type: str
+    is_amendment: bool
+    date_of_report: date | None
+    reporting_party: str | None
+    signature_name: str | None
+    signature_title: str | None
+    signature_date: date | None
+    primary_document_url: str | None
+    items: tuple[EightKItemRow, ...]
+    exhibits: tuple[EightKExhibitRow, ...]
+
+
+def list_8k_filings(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    limit: int = 50,
+) -> list[EightKFilingRow]:
+    """Return recent 8-K filings for an instrument with items +
+    exhibits attached. Tombstoned filings excluded."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                f.accession_number, f.document_type, f.is_amendment,
+                f.date_of_report, f.reporting_party,
+                f.signature_name, f.signature_title, f.signature_date,
+                f.primary_document_url
+            FROM eight_k_filings f
+            WHERE f.instrument_id = %s
+              AND f.is_tombstone = FALSE
+            ORDER BY f.date_of_report DESC NULLS LAST, f.fetched_at DESC
+            LIMIT %s
+            """,
+            (instrument_id, limit),
+        )
+        raw_filings = cur.fetchall()
+        accessions = [str(r[0]) for r in raw_filings]
+
+        items_by_acc: dict[str, list[EightKItemRow]] = {a: [] for a in accessions}
+        exhibits_by_acc: dict[str, list[EightKExhibitRow]] = {a: [] for a in accessions}
+        if accessions:
+            cur.execute(
+                """
+                SELECT accession_number, item_code, item_label,
+                       severity, body
+                FROM eight_k_items
+                WHERE accession_number = ANY(%s)
+                ORDER BY accession_number, item_order
+                """,
+                (accessions,),
+            )
+            for acc, code, label, severity, body in cur.fetchall():
+                items_by_acc[str(acc)].append(
+                    EightKItemRow(
+                        item_code=str(code),
+                        item_label=str(label),
+                        severity=severity,
+                        body=str(body),
+                    )
+                )
+            cur.execute(
+                """
+                SELECT accession_number, exhibit_number, description
+                FROM eight_k_exhibits
+                WHERE accession_number = ANY(%s)
+                ORDER BY accession_number, exhibit_number
+                """,
+                (accessions,),
+            )
+            for acc, num, desc in cur.fetchall():
+                exhibits_by_acc[str(acc)].append(
+                    EightKExhibitRow(
+                        exhibit_number=str(num),
+                        description=desc,
+                    )
+                )
+    rows: list[EightKFilingRow] = []
+    for r in raw_filings:
+        acc = str(r[0])
+        rows.append(
+            EightKFilingRow(
+                accession_number=acc,
+                document_type=str(r[1]),
+                is_amendment=bool(r[2]),
+                date_of_report=r[3],
+                reporting_party=r[4],
+                signature_name=r[5],
+                signature_title=r[6],
+                signature_date=r[7],
+                primary_document_url=r[8],
+                items=tuple(items_by_acc.get(acc, [])),
+                exhibits=tuple(exhibits_by_acc.get(acc, [])),
+            )
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------
+# Ingester
+# ---------------------------------------------------------------------
+
+
+class _DocFetcher(Protocol):
+    def fetch_document_text(self, absolute_url: str) -> str | None: ...
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    filings_scanned: int
+    filings_parsed: int
+    items_inserted: int
+    fetch_errors: int
+    parse_misses: int
+
+
+def _load_item_labels(conn: psycopg.Connection[Any]) -> dict[str, tuple[str, str]]:
+    """Load sec_8k_item_codes into a (code → (label, severity)) map."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT code, label, severity FROM sec_8k_item_codes")
+        return {str(r[0]): (str(r[1]), str(r[2])) for r in cur.fetchall()}
+
+
+def ingest_8k_events(
+    conn: psycopg.Connection[Any],
+    fetcher: _DocFetcher,
+    *,
+    limit: int = 200,
+) -> IngestResult:
+    """Scan 8-K filings lacking an ``eight_k_filings`` row, fetch the
+    primary document, parse, upsert.
+
+    Candidate selector:
+
+    1. ``fe.filing_type IN ('8-K', '8-K/A')``.
+    2. ``fe.primary_document_url IS NOT NULL``.
+    3. No existing ``eight_k_filings`` row (tombstones live in the
+       same table so a failed filing isn't re-fetched every tick).
+    4. Ordered by filing_date DESC so fresh filings always get budget.
+    """
+    conn.commit()
+    labels = _load_item_labels(conn)
+
+    candidates: list[tuple[int, str, str, tuple[str, ...]]] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT fe.instrument_id,
+                   fe.provider_filing_id,
+                   fe.primary_document_url,
+                   COALESCE(fe.items, ARRAY[]::TEXT[])
+            FROM filing_events fe
+            LEFT JOIN eight_k_filings ekf
+                ON ekf.accession_number = fe.provider_filing_id
+            WHERE fe.provider = 'sec'
+              AND fe.filing_type IN ('8-K', '8-K/A')
+              AND fe.primary_document_url IS NOT NULL
+              AND ekf.accession_number IS NULL
+            ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+            LIMIT %s
+            """,
+            (limit,),
+        )
+        for row in cur.fetchall():
+            candidates.append(
+                (
+                    int(row[0]),
+                    str(row[1]),
+                    str(row[2]),
+                    tuple(str(c) for c in (row[3] or [])),
+                )
+            )
+    conn.commit()
+
+    filings_parsed = 0
+    items_inserted = 0
+    fetch_errors = 0
+    parse_misses = 0
+
+    for instrument_id, accession, url, known_items in candidates:
+        try:
+            html = fetcher.fetch_document_text(url)
+        except Exception:
+            logger.warning(
+                "ingest_8k_events: fetch failed accession=%s url=%s",
+                accession,
+                url,
+                exc_info=True,
+            )
+            fetch_errors += 1
+            _write_tombstone(
+                conn,
+                instrument_id=instrument_id,
+                accession_number=accession,
+                primary_document_url=url,
+                document_type="8-K",
+            )
+            conn.commit()
+            continue
+        if html is None:
+            fetch_errors += 1
+            _write_tombstone(
+                conn,
+                instrument_id=instrument_id,
+                accession_number=accession,
+                primary_document_url=url,
+                document_type="8-K",
+            )
+            conn.commit()
+            continue
+
+        parsed = parse_8k_filing(html, known_items=known_items, item_labels=labels)
+        if parsed is None:
+            parse_misses += 1
+            _write_tombstone(
+                conn,
+                instrument_id=instrument_id,
+                accession_number=accession,
+                primary_document_url=url,
+                document_type="8-K",
+            )
+            conn.commit()
+            continue
+
+        try:
+            upsert_8k_filing(
+                conn,
+                instrument_id=instrument_id,
+                accession_number=accession,
+                primary_document_url=url,
+                parsed=parsed,
+                item_labels=labels,
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            logger.warning(
+                "ingest_8k_events: upsert failed accession=%s",
+                accession,
+                exc_info=True,
+            )
+            continue
+
+        filings_parsed += 1
+        items_inserted += len(parsed.items)
+
+    return IngestResult(
+        filings_scanned=len(candidates),
+        filings_parsed=filings_parsed,
+        items_inserted=items_inserted,
+        fetch_errors=fetch_errors,
+        parse_misses=parse_misses,
+    )

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -241,6 +241,7 @@ JOB_SEC_DIVIDEND_CALENDAR_INGEST = "sec_dividend_calendar_ingest"
 JOB_SEC_BUSINESS_SUMMARY_INGEST = "sec_business_summary_ingest"
 JOB_SEC_INSIDER_TRANSACTIONS_INGEST = "sec_insider_transactions_ingest"
 JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL = "sec_insider_transactions_backfill"
+JOB_SEC_8K_EVENTS_INGEST = "sec_8k_events_ingest"
 
 
 # ---------------------------------------------------------------------------
@@ -511,6 +512,19 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "cost nothing when nothing new has landed."
         ),
         cadence=Cadence.hourly(minute=30),
+        catch_up_on_boot=False,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_8K_EVENTS_INGEST,
+        description=(
+            "Parse SEC 8-K filings into structured eight_k_filings + "
+            "eight_k_items + eight_k_exhibits (#450). Runs hourly; "
+            "8-K is the fastest filing flow (event within 4 business "
+            "days), so stale structured capture is low-value. Bounded "
+            "to 200 filings per run; idempotent on the filing UNIQUE "
+            "key."
+        ),
+        cadence=Cadence.hourly(minute=20),
         catch_up_on_boot=False,
     ),
     ScheduledJob(
@@ -3137,6 +3151,36 @@ def sec_insider_transactions_ingest() -> None:
             result.filings_scanned,
             result.filings_parsed,
             result.rows_inserted,
+            result.fetch_errors,
+            result.parse_misses,
+        )
+
+
+def sec_8k_events_ingest() -> None:
+    """Parse 8-K filings into structured SQL tables (#450).
+
+    Complements the Item 8.01 dividend parser (#434) by capturing
+    every 8-K's header, per-item bodies, and exhibits list. Runs
+    hourly so material 8-Ks (officer departures, acquisition
+    agreements, cybersecurity incidents) land in SQL within one
+    cycle of hitting EDGAR.
+    """
+    from app.providers.implementations.sec_edgar import SecFilingsProvider
+    from app.services.eight_k_events import ingest_8k_events
+
+    with _tracked_job(JOB_SEC_8K_EVENTS_INGEST) as tracker:
+        with (
+            psycopg.connect(settings.database_url) as conn,
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as provider,
+        ):
+            result = ingest_8k_events(conn, provider)
+
+        tracker.row_count = result.items_inserted
+        logger.info(
+            "sec_8k_events_ingest: scanned=%d parsed=%d items=%d fetch_errors=%d parse_misses=%d",
+            result.filings_scanned,
+            result.filings_parsed,
+            result.items_inserted,
             result.fetch_errors,
             result.parse_misses,
         )

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -926,3 +926,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `upsert_business_sections` issued a `DELETE FROM instrument_business_summary_sections WHERE instrument_id = %s AND source_accession = %s` followed by an INSERT loop. The caller ran the helper inside a wider `try` that logged and continued on failure; if any INSERT raised mid-loop (e.g. a UNIQUE violation on a malformed payload), the exception was caught and the caller still called `conn.commit()` on the outer unit — committing the DELETE alone. Result: a stored snapshot for the accession would silently become an empty list.
 - Prevention: Any helper that clears-then-repopulates rows inside the same connection MUST wrap the clear + repopulate in a `with conn.transaction():` savepoint so a mid-loop failure rolls back the DELETE too. Alternatively, use ON CONFLICT DO UPDATE upserts (no DELETE) when the table has a natural conflict key. At self-review: grep for `DELETE FROM ... WHERE ...` followed by an `INSERT` in the same function, and confirm the pair is atomically scoped.
 - Enforced in: this prevention log; `app/services/business_summary.py::upsert_business_sections` now uses `with conn.transaction():`. Regression pinned by `tests/test_business_summary_ingest.py::TestBusinessSectionsIngest::test_insert_failure_rolls_back_delete_atomically`.
+
+---
+
+### `str(row[N])` coerces SQL NULL to the literal string "None"
+
+- First seen in: #450 (surfaced by Claude review bot on PR #461).
+- Symptom: `_load_item_labels` used `str(r[2])` when building the `(label, severity)` lookup from `sec_8k_item_codes`. The schema today has `severity` NOT NULL, so the bug was latent — but the moment a future migration relaxes the constraint, every NULL severity would silently serialise to the literal four-character string `"None"` in the loaded dict and then propagate into `eight_k_items.severity` unnoticed.
+- Prevention: In any DB reader helper, `str(row[N])` is only safe when the underlying column is NOT NULL. Before wrapping a column with `str()` / `int()` / `bool()` / `Decimal()`, confirm the schema declares it NOT NULL. For nullable columns, use the Optional-aware pattern: `val if val is None else str(val)` (and widen the return type). At self-review: grep for `str\(r\[|str\(row\[` in service modules and audit each occurrence against the source schema.
+- Enforced in: this prevention log; `app/services/eight_k_events.py::_load_item_labels` now preserves NULL severity as Python `None`.

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -130,6 +130,52 @@ export async function fetchInstrumentSecProfile(
 }
 
 // ---------------------------------------------------------------------------
+// 8-K structured events (#450)
+// ---------------------------------------------------------------------------
+
+export interface EightKItem {
+  item_code: string;
+  item_label: string;
+  severity: string | null;
+  body: string;
+}
+
+export interface EightKExhibit {
+  exhibit_number: string;
+  description: string | null;
+}
+
+export interface EightKFiling {
+  accession_number: string;
+  document_type: string;
+  is_amendment: boolean;
+  date_of_report: string | null;
+  reporting_party: string | null;
+  signature_name: string | null;
+  signature_title: string | null;
+  signature_date: string | null;
+  primary_document_url: string | null;
+  items: EightKItem[];
+  exhibits: EightKExhibit[];
+}
+
+export interface EightKFilingsResponse {
+  symbol: string;
+  filings: EightKFiling[];
+}
+
+export function fetchEightKFilings(
+  symbol: string,
+  limit: number = 25,
+): Promise<EightKFilingsResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  return apiFetch<EightKFilingsResponse>(
+    `/instruments/${encodeURIComponent(symbol)}/eight_k_filings?${params.toString()}`,
+  );
+}
+
+
+// ---------------------------------------------------------------------------
 // 10-K Item 1 subsection breakdown (#449)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/components/instrument/EightKEventsPanel.tsx
+++ b/frontend/src/components/instrument/EightKEventsPanel.tsx
@@ -1,0 +1,182 @@
+/**
+ * EightKEventsPanel — recent 8-K filings timeline for the instrument
+ * page. Backed by GET /instruments/{symbol}/eight_k_filings (#450).
+ *
+ * Each filing renders as a timeline card with:
+ *   - Date of report + document type (8-K vs 8-K/A)
+ *   - Item chips (code + human label) coloured by severity
+ *   - Per-item body excerpt (expand to see full text)
+ *   - Exhibits list
+ *
+ * Complements the dividend-specific panel — this surfaces every
+ * material 8-K (officer departures, acquisitions, cybersecurity
+ * incidents, etc.), not just dividends.
+ */
+
+import { fetchEightKFilings } from "@/api/instruments";
+import type {
+  EightKFiling,
+  EightKFilingsResponse,
+  EightKItem,
+} from "@/api/instruments";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+import { useCallback, useState } from "react";
+
+export interface EightKEventsPanelProps {
+  readonly symbol: string;
+}
+
+function severityTone(severity: string | null): string {
+  switch (severity) {
+    case "critical":
+      return "bg-rose-100 text-rose-800";
+    case "material":
+      return "bg-amber-100 text-amber-800";
+    case "informational":
+      return "bg-slate-100 text-slate-600";
+    default:
+      return "bg-slate-100 text-slate-600";
+  }
+}
+
+function ItemBlock({ item }: { item: EightKItem }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasBody = item.body.length > 0;
+  const showToggle = item.body.length > 200;
+  return (
+    <div className="border-l-2 border-slate-200 pl-3">
+      <div className="mb-1 flex items-center gap-2">
+        <span
+          className={`rounded px-1.5 py-0.5 font-mono text-[11px] font-semibold ${severityTone(item.severity)}`}
+          title={item.severity ?? "severity unclassified"}
+        >
+          Item {item.item_code}
+        </span>
+        <span className="text-xs font-medium text-slate-700">
+          {item.item_label}
+        </span>
+        {showToggle && (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="ml-auto text-[11px] font-medium text-sky-700 hover:underline"
+          >
+            {expanded ? "Collapse" : "Expand"}
+          </button>
+        )}
+      </div>
+      {hasBody ? (
+        <div
+          className={`whitespace-pre-wrap text-xs text-slate-700 ${
+            expanded ? "" : "line-clamp-2"
+          }`}
+        >
+          {item.body}
+        </div>
+      ) : (
+        <div className="text-xs italic text-slate-500">
+          Item declared; body not parsed from this filing.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FilingCard({ filing }: { filing: EightKFiling }) {
+  const dateText = filing.date_of_report ?? "—";
+  return (
+    <div className="rounded-sm border border-slate-200 p-3">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        <span className="font-mono text-xs text-slate-800">
+          {dateText}
+        </span>
+        <span
+          className={`rounded px-1.5 py-0.5 text-[11px] font-semibold ${
+            filing.is_amendment
+              ? "bg-amber-50 text-amber-800"
+              : "bg-sky-50 text-sky-800"
+          }`}
+        >
+          {filing.document_type}
+        </span>
+        {filing.reporting_party !== null && (
+          <span className="text-xs text-slate-500">
+            {filing.reporting_party}
+          </span>
+        )}
+        <span className="ml-auto font-mono text-[10px] text-slate-400">
+          {filing.accession_number}
+        </span>
+      </div>
+      <div className="space-y-2">
+        {filing.items.map((it) => (
+          <ItemBlock key={`${filing.accession_number}-${it.item_code}`} item={it} />
+        ))}
+      </div>
+      {filing.exhibits.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1 border-t border-slate-100 pt-2 text-[11px]">
+          <span className="text-slate-500">Exhibits:</span>
+          {filing.exhibits.map((ex) => (
+            <span
+              key={`${filing.accession_number}-${ex.exhibit_number}`}
+              className="rounded bg-slate-100 px-1.5 py-0.5 text-slate-700"
+              title={ex.description ?? ""}
+            >
+              {ex.exhibit_number}
+              {ex.description !== null && (
+                <span className="text-slate-500"> · {ex.description.slice(0, 60)}</span>
+              )}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Body({ data }: { data: EightKFilingsResponse }) {
+  if (data.filings.length === 0) {
+    return (
+      <EmptyState
+        title="No 8-K events on file"
+        description="No 8-K filings have been parsed for this instrument yet. Either no 8-K is on file, or the hourly ingester has not yet picked up the latest filings."
+      />
+    );
+  }
+  return (
+    <div className="space-y-2">
+      {data.filings.map((f) => (
+        <FilingCard key={f.accession_number} filing={f} />
+      ))}
+    </div>
+  );
+}
+
+export function EightKEventsPanel({ symbol }: EightKEventsPanelProps) {
+  const state = useAsync<EightKFilingsResponse>(
+    useCallback(() => fetchEightKFilings(symbol, 25), [symbol]),
+    [symbol],
+  );
+  return (
+    <Section title="8-K events">
+      {state.loading ? (
+        <SectionSkeleton rows={4} />
+      ) : state.error !== null ? (
+        <SectionError onRetry={state.refetch} />
+      ) : state.data === null ? (
+        <EmptyState
+          title="8-K events unavailable"
+          description="Could not load 8-K filings for this instrument."
+        />
+      ) : (
+        <Body data={state.data} />
+      )}
+    </Section>
+  );
+}

--- a/frontend/src/components/instrument/ResearchTab.tsx
+++ b/frontend/src/components/instrument/ResearchTab.tsx
@@ -9,6 +9,7 @@
 import { Section } from "@/components/dashboard/Section";
 import { BusinessSectionsPanel } from "@/components/instrument/BusinessSectionsPanel";
 import { DividendsPanel } from "@/components/instrument/DividendsPanel";
+import { EightKEventsPanel } from "@/components/instrument/EightKEventsPanel";
 import { InsiderActivityPanel } from "@/components/instrument/InsiderActivityPanel";
 import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
 import { EmptyState } from "@/components/states/EmptyState";
@@ -179,6 +180,9 @@ export function ResearchTab({
       </div>
       <div className="md:col-span-2">
         <InsiderActivityPanel symbol={summary.identity.symbol} />
+      </div>
+      <div className="md:col-span-2">
+        <EightKEventsPanel symbol={summary.identity.symbol} />
       </div>
 
       <Section title="Key statistics">

--- a/sql/061_eight_k_structured_events.sql
+++ b/sql/061_eight_k_structured_events.sql
@@ -1,0 +1,160 @@
+-- 061_eight_k_structured_events.sql
+--
+-- 8-K structured-event normalisation (#450). The 054 migration added
+-- ``dividend_events`` for Item 8.01 only; every other 8-K event
+-- (Item 1.01 material agreement, 5.02 officer departure, 2.02
+-- earnings release, 1.05 cybersecurity incident, etc.) was known
+-- from ``filing_events.items`` as a bare code string but had no
+-- structured body capture. Operators couldn't query "show every
+-- executive departure in the universe last 90 days" without grep-
+-- scanning raw HTML.
+--
+-- Storage model:
+--
+--   eight_k_filings             — one row per 8-K accession
+--     └── eight_k_items         — one row per (accession, item_code)
+--                                 with the body text of that item
+--     └── eight_k_exhibits      — one row per (accession, exhibit_num)
+--                                 from the Item 9.01 exhibits list
+--     └── dividend_events       — pre-existing (054), keyed on the
+--                                 same accession for joint queries
+--
+-- Dividend parsing (054/434) still runs on the Item 8.01 body but
+-- now that body is captured in ``eight_k_items`` alongside every
+-- other item. Tombstoning lives on ``eight_k_filings.is_tombstone``
+-- so fetch failures and non-parseable filings never re-hit SEC
+-- every tick.
+
+CREATE TABLE IF NOT EXISTS eight_k_filings (
+    accession_number       TEXT        PRIMARY KEY,
+    instrument_id          BIGINT      NOT NULL
+                              REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    -- Literal ``8-K`` or ``8-K/A``. Amendments adjust an earlier
+    -- filing's content under a new accession; we store both
+    -- original and amendment rows independently.
+    document_type          TEXT        NOT NULL,
+    is_amendment           BOOLEAN     NOT NULL DEFAULT FALSE,
+    -- SEC "Date of Report" header field — the earliest event date
+    -- covered by the filing. Distinct from ``filing_events.filing_date``
+    -- (which is when the filing hit EDGAR). Often a few business days
+    -- apart.
+    date_of_report         DATE,
+    -- Reporting party = the registrant as the filing header states
+    -- it. Usually identical to ``instruments.company_name`` but can
+    -- diverge for subsidiary filings or post-rename deltas, so we
+    -- preserve the verbatim label.
+    reporting_party        TEXT,
+    -- Signature block at the foot of the filing. Tells the operator
+    -- who certified the 8-K and when (not always the same as the
+    -- filing_date).
+    signature_name         TEXT,
+    signature_title        TEXT,
+    signature_date         DATE,
+    -- Free-text remarks between Item 9.01 exhibits and the signature.
+    -- Rare but sometimes carries forward-looking-statement
+    -- disclaimers or related-party context we want visible.
+    remarks                TEXT,
+    primary_document_url   TEXT,
+    fetched_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    parser_version         INT         NOT NULL DEFAULT 1,
+    -- TRUE when the fetch returned 404/410 or the HTML failed to
+    -- produce any items. Reader queries exclude tombstones; ingester
+    -- selector skips accessions with an existing row so tombstoned
+    -- filings don't re-hit SEC every tick.
+    is_tombstone           BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_eight_k_filings_instrument
+    ON eight_k_filings (instrument_id, date_of_report DESC);
+
+CREATE INDEX IF NOT EXISTS idx_eight_k_filings_report_date
+    ON eight_k_filings (date_of_report DESC)
+    WHERE is_tombstone = FALSE AND date_of_report IS NOT NULL;
+
+COMMENT ON TABLE eight_k_filings IS
+    'One row per 8-K filing accession. Filing-level header + signature '
+    'block. Per-item bodies live in eight_k_items; exhibit references '
+    'live in eight_k_exhibits. Dividend-specific parse output (#434) '
+    'continues to live in dividend_events keyed on the same accession.';
+
+COMMENT ON COLUMN eight_k_filings.date_of_report IS
+    'SEC "Date of Report" — the event date the 8-K covers. Usually '
+    '1-4 business days before the filing_date on filing_events.';
+
+COMMENT ON COLUMN eight_k_filings.is_tombstone IS
+    'Sentinel flag for filings that fetched to 404 / 410 or parsed '
+    'to zero items. Tombstones are skipped by the ingester selector '
+    'and filtered out by reader queries. Re-parse of the same '
+    'accession under a better extractor flips this back to FALSE.';
+
+-- ---------------------------------------------------------------------
+-- eight_k_items — per-item body capture
+-- ---------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS eight_k_items (
+    id                 BIGSERIAL   PRIMARY KEY,
+    accession_number   TEXT        NOT NULL
+                           REFERENCES eight_k_filings(accession_number) ON DELETE CASCADE,
+    -- Item code matches ``sec_8k_item_codes.code`` (see migration 053).
+    -- "1.01", "5.02", "8.01", etc.
+    item_code          TEXT        NOT NULL,
+    -- Denormalised label + severity from sec_8k_item_codes for
+    -- read-path convenience. Bumped on upsert so a future lookup
+    -- edit (label/severity wording change) propagates automatically.
+    item_label         TEXT        NOT NULL,
+    severity           TEXT,
+    -- Source-order of this item within the filing. Items are listed
+    -- in ascending SEC code order (1.01, 2.02, 5.02, 8.01, 9.01) but
+    -- we store the actual source position so a renderer can walk the
+    -- filing's own layout.
+    item_order         INT         NOT NULL,
+    -- Full body text of this item (HTML-stripped, whitespace-
+    -- collapsed). Typical lengths: 200-5000 chars. Capped at 20 KB
+    -- per item so an exhibit-heavy 9.01 body can't blow the row.
+    body               TEXT        NOT NULL DEFAULT '',
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (accession_number, item_code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_eight_k_items_code
+    ON eight_k_items (item_code);
+
+CREATE INDEX IF NOT EXISTS idx_eight_k_items_severity
+    ON eight_k_items (severity)
+    WHERE severity IN ('material', 'critical');
+
+COMMENT ON TABLE eight_k_items IS
+    'Per-item structured capture of an 8-K filing. One row per '
+    '(accession, item_code). Body is the HTML-stripped item text; '
+    'empty string means the item was listed in the filing header '
+    'but had no narrative body (common for bare 9.01 exhibit '
+    'pointers).';
+
+COMMENT ON COLUMN eight_k_items.severity IS
+    'Severity tier from sec_8k_item_codes (informational / material / '
+    'critical). Denormalised here for read-path convenience.';
+
+-- ---------------------------------------------------------------------
+-- eight_k_exhibits — Item 9.01 exhibit pointers
+-- ---------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS eight_k_exhibits (
+    id                 BIGSERIAL   PRIMARY KEY,
+    accession_number   TEXT        NOT NULL
+                           REFERENCES eight_k_filings(accession_number) ON DELETE CASCADE,
+    -- SEC exhibit number: "99.1" (press release), "10.1" (material
+    -- contract), "2.1" (acquisition agreement), etc. Preserved
+    -- verbatim.
+    exhibit_number     TEXT        NOT NULL,
+    description        TEXT,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (accession_number, exhibit_number)
+);
+
+COMMENT ON TABLE eight_k_exhibits IS
+    'Exhibit pointers from Item 9.01 — SEC exhibit number + description '
+    'text. The exhibit body itself (press release HTML, material '
+    'contract PDF) lives at a different accession-relative URL and is '
+    'not captured here; the pointer is enough for the thesis engine '
+    'to link out or decide whether to fetch.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -64,6 +64,16 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "financial_periods_raw",
     "financial_periods",
     "dividend_events",  # #434 — 8-K 8.01 calendar, FK → instruments
+    # #450 8-K structured-event tables. Children → parent:
+    # items + exhibits FK into eight_k_filings; eight_k_filings FKs
+    # into instruments (so the instrument truncation below would
+    # cascade, but listing them explicitly keeps teardown deterministic
+    # when a test populates a filings-only row without touching
+    # instruments).
+    "eight_k_exhibits",
+    "eight_k_items",
+    "eight_k_filings",
+    "instrument_business_summary_sections",  # #449 — FK → instruments
     "instrument_business_summary",  # #428 — 10-K Item 1 body, FK → instruments
     # #429 Form 4 tables. Child-to-parent truncation order: transactions
     # and footnotes FK into filings; filers also FK into filings;

--- a/tests/test_eight_k_events.py
+++ b/tests/test_eight_k_events.py
@@ -1,0 +1,117 @@
+"""Unit tests for ``app.services.eight_k_events.parse_8k_filing`` (#450)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from app.services.eight_k_events import (
+    Parsed8KFiling,
+    Parsed8KItem,
+    parse_8k_filing,
+)
+
+# Minimal but realistic 8-K shape: cover page + a material agreement
+# item + a 9.01 exhibits block + a signature.
+_BASIC_8K = """
+<html><body>
+<p>UNITED STATES SECURITIES AND EXCHANGE COMMISSION</p>
+<p>Washington, D.C. 20549</p>
+<p>FORM 8-K</p>
+<p>Date of Report (Date of earliest event reported): March 15, 2026</p>
+<p>(Exact name of registrant as specified in its charter)</p>
+<p>APEX INDUSTRIES INC.</p>
+<p>(State of Incorporation: Delaware) Commission File Number 001-12345</p>
+<p>Item 1.01. Entry into a Material Definitive Agreement.</p>
+<p>On March 14, 2026, the Company entered into a credit agreement
+   with Acme Bank for a $500 million revolving credit facility.</p>
+<p>Item 9.01. Financial Statements and Exhibits.</p>
+<p>(d) Exhibits.</p>
+<p>99.1 Press Release dated March 15, 2026 announcing the credit facility</p>
+<p>10.1 Credit Agreement dated March 14, 2026</p>
+<p>SIGNATURE</p>
+<p>By: /s/ Jane Smith</p>
+<p>Title: Chief Financial Officer</p>
+<p>Date: March 16, 2026</p>
+</body></html>
+"""
+
+# 8-K/A amendment.
+_AMENDMENT_8K = """
+<html><body>
+<p>FORM 8-K/A (Amendment No. 1)</p>
+<p>Date of Report: April 1, 2026</p>
+<p>(Exact name of registrant) APEX INDUSTRIES INC.</p>
+<p>Item 5.02. Departure of Directors.</p>
+<p>On April 1, 2026, the Company announced the departure of its CFO.</p>
+<p>SIGNATURE</p>
+<p>By: /s/ John Doe</p>
+</body></html>
+"""
+
+
+class TestParse8KFiling:
+    def test_basic_8k_extracts_header_items_exhibits(self) -> None:
+        parsed = parse_8k_filing(
+            _BASIC_8K,
+            known_items=("1.01", "9.01"),
+            item_labels={
+                "1.01": ("Entry into a Material Definitive Agreement", "material"),
+                "9.01": ("Financial Statements and Exhibits", "informational"),
+            },
+        )
+        assert parsed is not None
+        assert parsed.document_type == "8-K"
+        assert parsed.is_amendment is False
+        assert parsed.date_of_report == date(2026, 3, 15)
+        assert parsed.reporting_party is not None
+        assert "APEX INDUSTRIES" in parsed.reporting_party
+        item_codes = {it.item_code for it in parsed.items}
+        assert item_codes == {"1.01", "9.01"}
+        # Item 1.01 body should contain the material-agreement text.
+        item_101 = next(it for it in parsed.items if it.item_code == "1.01")
+        assert "credit agreement" in item_101.body
+        # Exhibits list captured.
+        ex_numbers = {e.exhibit_number for e in parsed.exhibits}
+        assert "99.1" in ex_numbers
+        assert "10.1" in ex_numbers
+        # Signature block.
+        assert parsed.signature_name is not None
+        assert "Jane Smith" in parsed.signature_name
+        assert parsed.signature_title is not None
+        assert "Chief Financial Officer" in parsed.signature_title
+
+    def test_amendment_detected(self) -> None:
+        parsed = parse_8k_filing(_AMENDMENT_8K, known_items=("5.02",))
+        assert parsed is not None
+        assert parsed.document_type == "8-K/A"
+        assert parsed.is_amendment is True
+
+    def test_missing_item_from_known_list_synthesised_as_empty(self) -> None:
+        """If the HTML heading regex misses an item that ``known_items``
+        declares, a row with an empty body is still produced so the
+        declared item doesn't silently disappear."""
+        html = """
+        <html><body>
+        <p>FORM 8-K</p>
+        <p>Date of Report: April 1, 2026</p>
+        <p>(Exact name of registrant) APEX INDUSTRIES INC.</p>
+        <p>SIGNATURE By: /s/ X</p>
+        </body></html>
+        """
+        parsed = parse_8k_filing(html, known_items=("2.02",))
+        assert parsed is not None
+        codes = {it.item_code for it in parsed.items}
+        assert "2.02" in codes
+        synthesised = next(it for it in parsed.items if it.item_code == "2.02")
+        assert synthesised.body == ""
+
+    def test_non_8k_document_returns_none(self) -> None:
+        assert parse_8k_filing("<html>nothing relevant here</html>") is None
+
+    def test_empty_input_returns_none(self) -> None:
+        assert parse_8k_filing("") is None
+
+    def test_parsed_shape(self) -> None:
+        parsed = parse_8k_filing(_BASIC_8K, known_items=("1.01",))
+        assert isinstance(parsed, Parsed8KFiling)
+        assert parsed.items and isinstance(parsed.items[0], Parsed8KItem)

--- a/tests/test_eight_k_events_ingest.py
+++ b/tests/test_eight_k_events_ingest.py
@@ -1,0 +1,182 @@
+"""Integration tests for ``ingest_8k_events`` (#450)."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import psycopg
+import pytest
+
+from app.services.eight_k_events import ingest_8k_events, list_8k_filings
+
+pytestmark = pytest.mark.integration
+
+
+class _StubFetcher:
+    def __init__(self, by_url: dict[str, str | None]) -> None:
+        self._by_url = by_url
+        self.calls: list[str] = []
+
+    def fetch_document_text(self, absolute_url: str) -> str | None:
+        self.calls.append(absolute_url)
+        return self._by_url.get(absolute_url)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], symbol: str = "APEX", iid: int = 401) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            (iid, symbol, "Apex Inc."),
+        )
+        row = cur.fetchone()
+        assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+def _seed_8k(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    accession: str,
+    url: str,
+    items: list[str],
+    filing_date: str = "2026-03-15",
+    filing_type: str = "8-K",
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO filing_events
+                (instrument_id, filing_date, filing_type, provider,
+                 provider_filing_id, primary_document_url, items)
+            VALUES (%s, %s, %s, 'sec', %s, %s, %s)
+            """,
+            (instrument_id, filing_date, filing_type, accession, url, items),
+        )
+    conn.commit()
+
+
+_RICH_8K = """
+<html><body>
+<p>FORM 8-K</p>
+<p>Date of Report (Date of earliest event reported): March 15, 2026</p>
+<p>(Exact name of registrant) APEX INDUSTRIES INC.</p>
+<p>Commission File Number 001-12345</p>
+<p>Item 1.01. Entry into a Material Definitive Agreement.</p>
+<p>On March 14, 2026, the Company entered into a credit agreement
+   with Acme Bank for a $500 million revolving credit facility.</p>
+<p>Item 9.01. Financial Statements and Exhibits.</p>
+<p>99.1 Press Release dated March 15, 2026 announcing the credit facility</p>
+<p>10.1 Credit Agreement dated March 14, 2026</p>
+<p>SIGNATURE</p>
+<p>By: /s/ Jane Smith</p>
+<p>Title: Chief Financial Officer</p>
+<p>Date: March 16, 2026</p>
+</body></html>
+"""
+
+
+class TestIngest8KEvents:
+    def test_rich_filing_lands_header_items_exhibits(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        _seed_8k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="APEX-8K-1",
+            url="https://www.sec.gov/Archives/apex-8k.htm",
+            items=["1.01", "9.01"],
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/apex-8k.htm": _RICH_8K})
+
+        result = ingest_8k_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        assert result.filings_parsed == 1
+        assert result.items_inserted >= 2
+
+        filings = list_8k_filings(ebull_test_conn, instrument_id=iid)
+        assert len(filings) == 1
+        f = filings[0]
+        assert f.document_type == "8-K"
+        assert f.is_amendment is False
+        assert {it.item_code for it in f.items} == {"1.01", "9.01"}
+        # Labels + severity from sec_8k_item_codes lookup propagate.
+        item_101 = next(it for it in f.items if it.item_code == "1.01")
+        assert item_101.severity == "material"
+        assert "Material Definitive Agreement" in item_101.item_label
+        # Exhibits captured.
+        ex = {e.exhibit_number for e in f.exhibits}
+        assert "99.1" in ex
+        assert "10.1" in ex
+
+    def test_fetch_404_writes_tombstone_and_skips_next_run(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        _seed_8k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="DEAD-8K",
+            url="https://www.sec.gov/dead.htm",
+            items=["8.01"],
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/dead.htm": None})
+        ingest_8k_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT is_tombstone FROM eight_k_filings WHERE accession_number = %s",
+                ("DEAD-8K",),
+            )
+            row = cur.fetchone()
+            assert row is not None and row[0] is True
+
+        # Second pass: no re-fetch.
+        second_fetcher = _StubFetcher({"https://www.sec.gov/dead.htm": None})
+        ingest_8k_events(ebull_test_conn, cast("object", second_fetcher))  # type: ignore[arg-type]
+        assert second_fetcher.calls == []
+
+    def test_tombstone_filings_excluded_from_reader(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        _seed_8k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="REAL-8K",
+            url="https://www.sec.gov/real.htm",
+            items=["1.01"],
+        )
+        _seed_8k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="DEAD-8K-2",
+            url="https://www.sec.gov/dead2.htm",
+            items=["8.01"],
+        )
+        fetcher = _StubFetcher(
+            {
+                "https://www.sec.gov/real.htm": _RICH_8K,
+                "https://www.sec.gov/dead2.htm": None,
+            }
+        )
+        ingest_8k_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        filings = list_8k_filings(ebull_test_conn, instrument_id=iid)
+        assert len(filings) == 1
+        assert filings[0].accession_number == "REAL-8K"
+
+    def test_non_8k_skipped(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO filing_events
+                    (instrument_id, filing_date, filing_type, provider,
+                     provider_filing_id, primary_document_url)
+                VALUES (%s, CURRENT_DATE, '10-K', 'sec', 'NOT-8K',
+                        'https://www.sec.gov/10k.htm')
+                """,
+                (iid,),
+            )
+        ebull_test_conn.commit()
+        fetcher = _StubFetcher({})
+        result = ingest_8k_events(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.filings_scanned == 0
+        assert fetcher.calls == []

--- a/tests/test_eight_k_events_ingest.py
+++ b/tests/test_eight_k_events_ingest.py
@@ -22,6 +22,29 @@ class _StubFetcher:
         return self._by_url.get(absolute_url)
 
 
+def _seed_item_codes(conn: psycopg.Connection[tuple]) -> None:
+    """Ensure sec_8k_item_codes carries the codes these tests assert
+    against. Migration 053 seeds the table on first apply but the
+    teardown doesn't touch it, so the row is usually already present —
+    this fixture is defensive so a future test-db rebuild or a
+    targeted truncation can't regress into an empty lookup and make
+    severity assertions silently pass against ``None`` labels.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO sec_8k_item_codes (code, label, severity) VALUES
+                ('1.01', 'Entry into a Material Definitive Agreement', 'material'),
+                ('8.01', 'Other Events', 'informational'),
+                ('9.01', 'Financial Statements and Exhibits', 'informational')
+            ON CONFLICT (code) DO UPDATE SET
+                label    = EXCLUDED.label,
+                severity = EXCLUDED.severity
+            """
+        )
+    conn.commit()
+
+
 def _seed_instrument(conn: psycopg.Connection[tuple], symbol: str = "APEX", iid: int = 401) -> int:
     with conn.cursor() as cur:
         cur.execute(
@@ -79,6 +102,7 @@ _RICH_8K = """
 
 class TestIngest8KEvents:
     def test_rich_filing_lands_header_items_exhibits(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_item_codes(ebull_test_conn)
         iid = _seed_instrument(ebull_test_conn)
         _seed_8k(
             ebull_test_conn,


### PR DESCRIPTION
## Summary
- Every 8-K item lands as a queryable SQL row (not just Item 8.01 dividends). New eight_k_filings / eight_k_items / eight_k_exhibits tables keyed on accession.
- New instrument-page panel renders each 8-K as a timeline card with severity-coloured item chips, expandable bodies, and exhibits list.
- Hourly ingester job sec_8k_events_ingest at :20.

## Test plan
- [x] uv run ruff check / format / pyright (all clean)
- [x] uv run pytest (2592 passed)
- [x] pnpm --dir frontend typecheck + test:unit (386 passed)