### PR TITLE
feat(#452): filing_documents manifest capture (Phase A)

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -73,6 +73,7 @@ from app.workers.scheduler import (
     JOB_SEC_8K_EVENTS_INGEST,
     JOB_SEC_BUSINESS_SUMMARY_INGEST,
     JOB_SEC_DIVIDEND_CALENDAR_INGEST,
+    JOB_SEC_FILING_DOCUMENTS_INGEST,
     JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL,
     JOB_SEC_INSIDER_TRANSACTIONS_INGEST,
     JOB_SEED_COST_MODELS,
@@ -100,6 +101,7 @@ from app.workers.scheduler import (
     sec_8k_events_ingest,
     sec_business_summary_ingest,
     sec_dividend_calendar_ingest,
+    sec_filing_documents_ingest,
     sec_insider_transactions_backfill,
     sec_insider_transactions_ingest,
     seed_cost_models,
@@ -153,6 +155,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_SEC_INSIDER_TRANSACTIONS_INGEST: sec_insider_transactions_ingest,
     JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL: sec_insider_transactions_backfill,
     JOB_SEC_8K_EVENTS_INGEST: sec_8k_events_ingest,
+    JOB_SEC_FILING_DOCUMENTS_INGEST: sec_filing_documents_ingest,
 }
 
 

--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -263,11 +263,15 @@ class SecFilingsProvider(FilingsProvider):
         ``filing_documents`` service for the per-document manifest
         (#452).
 
-        **Contract**: the dict returned by this method MUST be
-        normalised into SQL (``filing_documents`` for the per-doc
-        manifest; ``filing_events`` for header fields). No disk-only
-        persistence — every structured field is captured in a
-        queryable table.
+        Provider-level JSON payload: the raw response is persisted
+        to ``data/raw/sec/sec_filing_*`` as the audit-trail contract
+        from prevention-log entries #171 / #177 requires — the
+        per-document structural capture lands in ``filing_documents``
+        via the service layer, and the raw dump is retained for
+        audit alongside it (structured JSON payloads remain on disk;
+        body text does not — see docs/review-prevention-log.md
+        "Every structured field from an upstream document lands in
+        SQL").
         """
         raw_id = provider_filing_id.replace("-", "")
         if len(raw_id) != 18:
@@ -281,6 +285,14 @@ class SecFilingsProvider(FilingsProvider):
         parsed = resp.json()
         if not isinstance(parsed, dict):
             return None
+        # Persist raw audit trail — same contract as the other
+        # provider-JSON methods in this file. The structural capture
+        # into SQL happens in the service layer (#452).
+        raw_persistence.persist_raw_if_new(
+            "sec",
+            f"sec_filing_{provider_filing_id.replace('/', '_')}",
+            parsed,
+        )
         return parsed
 
     def fetch_document_text(self, absolute_url: str) -> str | None:

--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -242,25 +242,46 @@ class SecFilingsProvider(FilingsProvider):
 
         provider_filing_id is the accession number, e.g. '0000320193-24-000001'.
         Raises FilingNotFound if the accession number cannot be resolved.
+
+        Does not persist the raw index JSON — every structured field
+        from that JSON now lands in ``filing_documents`` via the
+        ``filing_documents`` service (#452). Disk-only persistence
+        would re-introduce the "body text on disk without a matching
+        SQL table" anti-pattern (see docs/review-prevention-log.md).
         """
-        # Format: XXXXXXXXXX-YY-NNNNNN (18 chars without dashes); first 10 digits are the CIK
+        raw = self.fetch_filing_index(provider_filing_id)
+        if raw is None:
+            raise FilingNotFound(f"Filing not found: {provider_filing_id}")
+        return _normalise_filing_event(provider_filing_id, raw)
+
+    def fetch_filing_index(self, provider_filing_id: str) -> dict[str, object] | None:
+        """Fetch a filing's ``{accession}-index.json`` manifest.
+
+        Returns the parsed dict on 2xx, ``None`` on 404. Raises on
+        other HTTP errors so the caller decides retry vs skip. Used
+        by :func:`get_filing` for header metadata and by the
+        ``filing_documents`` service for the per-document manifest
+        (#452).
+
+        **Contract**: the dict returned by this method MUST be
+        normalised into SQL (``filing_documents`` for the per-doc
+        manifest; ``filing_events`` for header fields). No disk-only
+        persistence — every structured field is captured in a
+        queryable table.
+        """
         raw_id = provider_filing_id.replace("-", "")
         if len(raw_id) != 18:
             raise FilingNotFound(f"Invalid accession number format: {provider_filing_id}")
-
         cik_padded = raw_id[:10]
-        accession_no_dashes = raw_id
-
-        # Fetch the filing index JSON
-        path = f"/Archives/edgar/data/{int(cik_padded)}/{accession_no_dashes}/{accession_no_dashes}-index.json"
+        path = f"/Archives/edgar/data/{int(cik_padded)}/{raw_id}/{raw_id}-index.json"
         resp = self._http.get(path)
         if resp.status_code == 404:
-            raise FilingNotFound(f"Filing not found: {provider_filing_id}")
+            return None
         resp.raise_for_status()
-        raw = resp.json()
-        raw_persistence.persist_raw_if_new("sec", f"sec_filing_{provider_filing_id.replace('/', '_')}", raw)
-
-        return _normalise_filing_event(provider_filing_id, raw)
+        parsed = resp.json()
+        if not isinstance(parsed, dict):
+            return None
+        return parsed
 
     def fetch_document_text(self, absolute_url: str) -> str | None:
         """Fetch the raw text of a filing's primary document.

--- a/app/services/filing_documents.py
+++ b/app/services/filing_documents.py
@@ -309,10 +309,12 @@ def ingest_filing_documents(
         filings_parsed += 1
         documents_inserted += len(docs)
 
-    # Reference the parser version so future refactors can gate a
-    # re-parse by a version change. Currently unused in SQL — kept
-    # as a module constant so the import doesn't feel dead.
-    _ = _PARSER_VERSION
+    logger.info(
+        "ingest_filing_documents: parser_version=%d scanned=%d parsed=%d",
+        _PARSER_VERSION,
+        len(candidates),
+        filings_parsed,
+    )
 
     return IngestResult(
         filings_scanned=len(candidates),

--- a/app/services/filing_documents.py
+++ b/app/services/filing_documents.py
@@ -1,0 +1,373 @@
+"""SEC filing-document manifest parser + ingester (#452 Phase A).
+
+Every SEC filing has an ``{accession}-index.json`` listing every
+document in the submission — primary doc, exhibits, XBRL files,
+graphics, cover page. Migration 062 added ``filing_documents`` to
+capture the manifest as SQL rows. This module parses the index
+JSON and populates the table.
+
+Pure/impure split mirrors the other services in this family:
+
+- :func:`parse_filing_index` is a pure function over raw index JSON
+  returning a tuple of :class:`ParsedFilingDocument`.
+- :func:`ingest_filing_documents` is the DB path — walks
+  ``filing_events`` missing any ``filing_documents`` children,
+  fetches the index JSON via the provider, parses, upserts.
+
+Retires the ``data/raw/sec/sec_filing_*.json`` disk dump now that
+every structured field lands in SQL (#453 contract).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+_PARSER_VERSION = 1
+
+
+# ---------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ParsedFilingDocument:
+    """One document entry from a filing's index manifest."""
+
+    document_name: str
+    document_type: str | None
+    description: str | None
+    size_bytes: int | None
+    is_primary: bool
+    document_url: str
+
+
+# ---------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------
+
+
+def parse_filing_index(
+    raw_index: dict[str, object],
+    *,
+    accession_number: str,
+) -> tuple[ParsedFilingDocument, ...]:
+    """Walk the filing-index JSON and emit one ``ParsedFilingDocument``
+    per document entry.
+
+    SEC's index JSON shape:
+
+    .. code:: json
+
+        {
+          "cik": "320193",
+          "form": "10-K",
+          "primaryDocument": "aapl-20240930.htm",
+          "filingDate": "2024-11-01",
+          ...
+          "items": [
+            {"name": "aapl-20240930.htm", "type": "10-K",
+             "description": "10-K", "size": 1258402},
+            {"name": "ex-21.htm", "type": "EX-21",
+             "description": "Subsidiaries of the Registrant", "size": 1892},
+            ...
+          ]
+        }
+
+    The ``items`` list is the authoritative manifest. When a field is
+    absent in a row we preserve ``None`` rather than fabricating a
+    default — downstream renderers can distinguish "no description"
+    from "empty description".
+    """
+    items = raw_index.get("items")
+    if not isinstance(items, list):
+        return ()
+    cik_raw = raw_index.get("cik")
+    primary_name = raw_index.get("primaryDocument")
+    if not isinstance(primary_name, str):
+        primary_name = None
+
+    # CIK as an integer drops any leading zeroes, matching the SEC
+    # archive path shape (``/edgar/data/<int_cik>/<accession>/...``).
+    cik_int: int | None
+    try:
+        cik_int = int(str(cik_raw)) if cik_raw is not None else None
+    except TypeError, ValueError:
+        cik_int = None
+
+    acc_no_dashes = accession_number.replace("-", "")
+
+    docs: list[ParsedFilingDocument] = []
+    seen_names: set[str] = set()
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name or name in seen_names:
+            continue
+        seen_names.add(name)
+
+        doc_type_raw = entry.get("type")
+        doc_type = str(doc_type_raw) if isinstance(doc_type_raw, str) and doc_type_raw else None
+        desc_raw = entry.get("description")
+        description = str(desc_raw) if isinstance(desc_raw, str) and desc_raw else None
+        size_raw = entry.get("size")
+        size_bytes: int | None
+        try:
+            size_bytes = int(size_raw) if size_raw is not None else None
+        except TypeError, ValueError:
+            size_bytes = None
+
+        if cik_int is not None:
+            document_url = f"https://www.sec.gov/Archives/edgar/data/{cik_int}/{acc_no_dashes}/{name}"
+        else:
+            document_url = name  # best effort when CIK missing from index
+
+        docs.append(
+            ParsedFilingDocument(
+                document_name=name,
+                document_type=doc_type,
+                description=description,
+                size_bytes=size_bytes,
+                is_primary=(name == primary_name),
+                document_url=document_url,
+            )
+        )
+    return tuple(docs)
+
+
+# ---------------------------------------------------------------------
+# DB upsert
+# ---------------------------------------------------------------------
+
+
+def upsert_filing_documents(
+    conn: psycopg.Connection[Any],
+    *,
+    filing_event_id: int,
+    accession_number: str,
+    documents: tuple[ParsedFilingDocument, ...],
+) -> int:
+    """Replace the document snapshot for ``(filing_event_id)`` with
+    the parsed list.
+
+    DELETE + INSERT wrapped in a savepoint so a mid-loop INSERT
+    failure rolls back the DELETE atomically and the prior snapshot
+    survives (see docs/review-prevention-log.md "DELETE-then-INSERT
+    helper without a savepoint").
+    """
+    if not documents:
+        return 0
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM filing_documents WHERE filing_event_id = %s",
+                (filing_event_id,),
+            )
+            inserted = 0
+            for doc in documents:
+                cur.execute(
+                    """
+                    INSERT INTO filing_documents
+                        (filing_event_id, accession_number, document_name,
+                         document_type, description, size_bytes,
+                         is_primary, document_url)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        filing_event_id,
+                        accession_number,
+                        doc.document_name,
+                        doc.document_type,
+                        doc.description,
+                        doc.size_bytes,
+                        doc.is_primary,
+                        doc.document_url,
+                    ),
+                )
+                inserted += 1
+            return inserted
+
+
+# ---------------------------------------------------------------------
+# Ingester
+# ---------------------------------------------------------------------
+
+
+class _IndexFetcher(Protocol):
+    """Minimal Protocol the ingester needs from the provider.
+
+    Narrow shape so tests can substitute a dict-stub without
+    implementing the full provider interface.
+    """
+
+    def fetch_filing_index(self, provider_filing_id: str) -> dict[str, object] | None: ...
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    filings_scanned: int
+    filings_parsed: int
+    documents_inserted: int
+    fetch_errors: int
+    parse_misses: int
+
+
+def ingest_filing_documents(
+    conn: psycopg.Connection[Any],
+    fetcher: _IndexFetcher,
+    *,
+    limit: int = 500,
+) -> IngestResult:
+    """Scan ``filing_events`` for accessions missing any
+    ``filing_documents`` children, fetch the index JSON, upsert.
+
+    Candidate selector:
+
+    1. ``fe.provider = 'sec'`` — only SEC filings carry an index
+       JSON in this shape.
+    2. No existing ``filing_documents`` row for the filing_event_id.
+    3. Ordered by filing_date DESC so fresh filings always get
+       budget; historical backlog drains via the scheduler's
+       continuous tick.
+
+    Bounded per run (``limit=500``). The index JSON is small (~2 KB
+    typical) so the rate-limit cost is modest even on a large
+    backlog tick.
+    """
+    conn.commit()
+
+    candidates: list[tuple[int, str]] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT fe.filing_event_id, fe.provider_filing_id
+            FROM filing_events fe
+            LEFT JOIN filing_documents fd
+                ON fd.filing_event_id = fe.filing_event_id
+            WHERE fe.provider = 'sec'
+              AND fd.id IS NULL
+            GROUP BY fe.filing_event_id, fe.provider_filing_id, fe.filing_date
+            ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+            LIMIT %s
+            """,
+            (limit,),
+        )
+        for row in cur.fetchall():
+            candidates.append((int(row[0]), str(row[1])))
+    conn.commit()
+
+    filings_parsed = 0
+    documents_inserted = 0
+    fetch_errors = 0
+    parse_misses = 0
+
+    for filing_event_id, accession in candidates:
+        try:
+            raw = fetcher.fetch_filing_index(accession)
+        except Exception:
+            logger.warning(
+                "ingest_filing_documents: fetch failed accession=%s",
+                accession,
+                exc_info=True,
+            )
+            fetch_errors += 1
+            continue
+        if raw is None:
+            fetch_errors += 1
+            continue
+
+        docs = parse_filing_index(raw, accession_number=accession)
+        if not docs:
+            parse_misses += 1
+            continue
+
+        try:
+            upsert_filing_documents(
+                conn,
+                filing_event_id=filing_event_id,
+                accession_number=accession,
+                documents=docs,
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            logger.warning(
+                "ingest_filing_documents: upsert failed accession=%s",
+                accession,
+                exc_info=True,
+            )
+            continue
+
+        filings_parsed += 1
+        documents_inserted += len(docs)
+
+    # Reference the parser version so future refactors can gate a
+    # re-parse by a version change. Currently unused in SQL — kept
+    # as a module constant so the import doesn't feel dead.
+    _ = _PARSER_VERSION
+
+    return IngestResult(
+        filings_scanned=len(candidates),
+        filings_parsed=filings_parsed,
+        documents_inserted=documents_inserted,
+        fetch_errors=fetch_errors,
+        parse_misses=parse_misses,
+    )
+
+
+# ---------------------------------------------------------------------
+# Reader
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FilingDocumentRow:
+    document_name: str
+    document_type: str | None
+    description: str | None
+    size_bytes: int | None
+    is_primary: bool
+    document_url: str
+
+
+def list_filing_documents(
+    conn: psycopg.Connection[Any],
+    *,
+    filing_event_id: int,
+) -> tuple[FilingDocumentRow, ...]:
+    """Return the document manifest for one filing, primary first.
+
+    Empty tuple when no documents on file (either the ingester hasn't
+    touched this filing yet, or the filing carries no index JSON).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT document_name, document_type, description,
+                   size_bytes, is_primary, document_url
+            FROM filing_documents
+            WHERE filing_event_id = %s
+            ORDER BY is_primary DESC, document_name ASC
+            """,
+            (filing_event_id,),
+        )
+        rows = cur.fetchall()
+    return tuple(
+        FilingDocumentRow(
+            document_name=str(r[0]),
+            document_type=r[1],
+            description=r[2],
+            size_bytes=r[3],
+            is_primary=bool(r[4]),
+            document_url=str(r[5]),
+        )
+        for r in rows
+    )

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -242,6 +242,7 @@ JOB_SEC_BUSINESS_SUMMARY_INGEST = "sec_business_summary_ingest"
 JOB_SEC_INSIDER_TRANSACTIONS_INGEST = "sec_insider_transactions_ingest"
 JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL = "sec_insider_transactions_backfill"
 JOB_SEC_8K_EVENTS_INGEST = "sec_8k_events_ingest"
+JOB_SEC_FILING_DOCUMENTS_INGEST = "sec_filing_documents_ingest"
 
 
 # ---------------------------------------------------------------------------
@@ -512,6 +513,19 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "cost nothing when nothing new has landed."
         ),
         cadence=Cadence.hourly(minute=30),
+        catch_up_on_boot=False,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_FILING_DOCUMENTS_INGEST,
+        description=(
+            "Parse SEC filing-index JSON (``{accession}-index.json``) "
+            "into the filing_documents manifest table (#452). Captures "
+            "every document in every filing (primary + exhibits + "
+            "XBRL + graphics) as structured SQL rows so the long-tail "
+            "disk dump under data/raw/sec/sec_filing_*.json can be "
+            "retired. Bounded to 500 filings per run."
+        ),
+        cadence=Cadence.hourly(minute=35),
         catch_up_on_boot=False,
     ),
     ScheduledJob(
@@ -3151,6 +3165,35 @@ def sec_insider_transactions_ingest() -> None:
             result.filings_scanned,
             result.filings_parsed,
             result.rows_inserted,
+            result.fetch_errors,
+            result.parse_misses,
+        )
+
+
+def sec_filing_documents_ingest() -> None:
+    """Populate the filing_documents manifest table (#452).
+
+    Captures the per-document list from each SEC filing's
+    ``{accession}-index.json`` — primary doc + exhibits + XBRL +
+    graphics + cover — as structured SQL rows so the long-tail
+    ``data/raw/sec/sec_filing_*.json`` disk dump can be retired.
+    """
+    from app.providers.implementations.sec_edgar import SecFilingsProvider
+    from app.services.filing_documents import ingest_filing_documents
+
+    with _tracked_job(JOB_SEC_FILING_DOCUMENTS_INGEST) as tracker:
+        with (
+            psycopg.connect(settings.database_url) as conn,
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as provider,
+        ):
+            result = ingest_filing_documents(conn, provider)
+
+        tracker.row_count = result.documents_inserted
+        logger.info(
+            "sec_filing_documents_ingest: scanned=%d parsed=%d docs=%d fetch_errors=%d parse_misses=%d",
+            result.filings_scanned,
+            result.filings_parsed,
+            result.documents_inserted,
             result.fetch_errors,
             result.parse_misses,
         )

--- a/sql/062_filing_documents.sql
+++ b/sql/062_filing_documents.sql
@@ -1,0 +1,102 @@
+-- 062_filing_documents.sql
+--
+-- SEC filing-index document capture (#452 Phase A). Follow-up to the
+-- #448 operator directive: every structured upstream field lands in
+-- SQL, no silent drops.
+--
+-- Current state: every 8-K / 10-K / 10-Q / Form 4 / etc. filing has
+-- an ``{accession}-index.json`` at SEC EDGAR that lists every
+-- document in the submission — primary document, exhibits, XBRL
+-- instance, XBRL schema, graphics, cover-page XML, etc. The SEC
+-- index is the authoritative manifest; ``filing_events`` currently
+-- captures only the ``primary_document_url`` derived from the
+-- submissions.json listing. Everything else is in the on-disk
+-- ``data/raw/sec/sec_filing_*.json`` dump and unqueryable from SQL.
+--
+-- Storage model: one row per (filing_event_id, document_name).
+-- ``is_primary`` flags the submission's primary document
+-- (duplicated from ``filing_events.primary_document_url`` as a
+-- ``is_primary = TRUE`` row for consistency — the reader can now
+-- treat the primary document as one row of a structured list rather
+-- than a special column).
+--
+-- What this unlocks:
+--   - Query every EX-21 (subsidiary list) across the universe
+--     without re-fetching.
+--   - Find every cybersecurity-incident 8-K that attached a press
+--     release exhibit (EX-99).
+--   - Surface XBRL instance documents for the ingester without
+--     re-walking the JSON.
+--   - Retire ``data/raw/sec/sec_filing_*.json`` (~900 MB of the
+--     1.1 GB ``data/raw/sec/`` footprint).
+
+CREATE TABLE IF NOT EXISTS filing_documents (
+    id                BIGSERIAL    PRIMARY KEY,
+    filing_event_id   BIGINT       NOT NULL
+                          REFERENCES filing_events(filing_event_id) ON DELETE CASCADE,
+    -- Denormalised from the parent row for readable queries —
+    -- a join-less ``SELECT * FROM filing_documents WHERE
+    -- accession_number = '0000320193-24-000001'`` is common.
+    accession_number  TEXT         NOT NULL,
+    -- Filename inside the filing, e.g. "aapl-20240930.htm",
+    -- "ex-21.htm", "Financial_Report.xlsx". Unique within a
+    -- filing; used as the idempotency key.
+    document_name     TEXT         NOT NULL,
+    -- SEC-assigned document type classifier from the index JSON's
+    -- ``type`` field. Examples: "10-K", "EX-21", "EX-99.1",
+    -- "GRAPHIC", "XBRL INSTANCE DOCUMENT", "XBRL TAXONOMY EXTENSION
+    -- SCHEMA DOCUMENT", "COVER". NULL when the index entry omits
+    -- the ``type`` field (rare).
+    document_type     TEXT,
+    -- Human-readable description from the index JSON. Example for an
+    -- EX-99.1: "Press Release dated March 15, 2026 announcing the
+    -- credit facility". Often blank on exhibits that only carry the
+    -- canonical description in the exhibit body itself.
+    description       TEXT,
+    -- File size in bytes. Useful for (a) a "skip the 50 MB graphic
+    -- PDF" policy at fetch time, and (b) disk-retention forecasting
+    -- when we decide to fetch exhibit bodies.
+    size_bytes        BIGINT,
+    -- True for the submission's primary document (the one SEC labels
+    -- as the ``primaryDocument`` in the submissions.json listing).
+    -- Duplicated to this row so the reader can walk a single list
+    -- instead of special-casing the parent column.
+    is_primary        BOOLEAN      NOT NULL DEFAULT FALSE,
+    -- Fully-qualified URL reconstructed at ingest time from the
+    -- accession + document_name. Callers don't have to build the
+    -- URL themselves; ``document_url`` is the one thing they need
+    -- to fetch the document body.
+    document_url      TEXT         NOT NULL,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    UNIQUE (filing_event_id, document_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_filing_documents_accession
+    ON filing_documents (accession_number);
+
+-- Type-scoped index for "find every EX-21 across the universe" and
+-- other document-type sweeps. Partial because the long tail of types
+-- is small and well-clustered.
+CREATE INDEX IF NOT EXISTS idx_filing_documents_type
+    ON filing_documents (document_type)
+    WHERE document_type IS NOT NULL;
+
+COMMENT ON TABLE filing_documents IS
+    'Per-document manifest from each SEC filing''s ``{accession}-'
+    'index.json``. One row per document in the filing (primary + '
+    'exhibits + XBRL + graphics + cover). is_primary flags the '
+    'submission''s primary document. Retires the raw ``sec_filing_*'
+    '.json`` disk dump now that every field is captured here.';
+
+COMMENT ON COLUMN filing_documents.document_type IS
+    'SEC type classifier: "10-K", "EX-21", "EX-99.1", '
+    '"GRAPHIC", "XBRL INSTANCE DOCUMENT", "COVER", etc. Cross-'
+    'issuer queries rely on this to locate subsidiary lists, press-'
+    'release exhibits, or XBRL artefacts without re-scanning the '
+    'filing index JSON.';
+
+COMMENT ON COLUMN filing_documents.is_primary IS
+    'TRUE for the submission''s primary document — matches '
+    'filing_events.primary_document_url for the same accession. '
+    'Lets callers walk a single structured list without special-'
+    'casing the parent row.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -73,6 +73,7 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "eight_k_exhibits",
     "eight_k_items",
     "eight_k_filings",
+    "filing_documents",  # #452 — child of filing_events
     "instrument_business_summary_sections",  # #449 — FK → instruments
     "instrument_business_summary",  # #428 — 10-K Item 1 body, FK → instruments
     # #429 Form 4 tables. Child-to-parent truncation order: transactions

--- a/tests/test_filing_documents.py
+++ b/tests/test_filing_documents.py
@@ -1,0 +1,94 @@
+"""Unit tests for ``app.services.filing_documents.parse_filing_index`` (#452)."""
+
+from __future__ import annotations
+
+from app.services.filing_documents import (
+    ParsedFilingDocument,
+    parse_filing_index,
+)
+
+_INDEX = {
+    "cik": "320193",
+    "form": "10-K",
+    "primaryDocument": "aapl-20240930.htm",
+    "filingDate": "2024-11-01",
+    "items": [
+        {
+            "name": "aapl-20240930.htm",
+            "type": "10-K",
+            "description": "10-K",
+            "size": 1258402,
+        },
+        {
+            "name": "ex-21.htm",
+            "type": "EX-21",
+            "description": "Subsidiaries of the Registrant",
+            "size": 1892,
+        },
+        {
+            "name": "ex-99-1.htm",
+            "type": "EX-99.1",
+            "description": "Press Release dated Nov 1, 2024",
+            "size": 10234,
+        },
+        {
+            "name": "Financial_Report.xlsx",
+            "type": "EXCEL",
+            "description": None,
+            "size": 5120,
+        },
+    ],
+}
+
+
+class TestParseFilingIndex:
+    def test_all_documents_surface(self) -> None:
+        docs = parse_filing_index(_INDEX, accession_number="0000320193-24-000001")
+        assert len(docs) == 4
+        names = {d.document_name for d in docs}
+        assert {"aapl-20240930.htm", "ex-21.htm", "ex-99-1.htm", "Financial_Report.xlsx"} == names
+
+    def test_primary_flag_set_only_on_primary(self) -> None:
+        docs = parse_filing_index(_INDEX, accession_number="0000320193-24-000001")
+        primaries = [d for d in docs if d.is_primary]
+        assert len(primaries) == 1
+        assert primaries[0].document_name == "aapl-20240930.htm"
+
+    def test_url_reconstruction(self) -> None:
+        docs = parse_filing_index(_INDEX, accession_number="0000320193-24-000001")
+        ex21 = next(d for d in docs if d.document_name == "ex-21.htm")
+        assert ex21.document_url == ("https://www.sec.gov/Archives/edgar/data/320193/000032019324000001/ex-21.htm")
+
+    def test_null_description_preserved(self) -> None:
+        docs = parse_filing_index(_INDEX, accession_number="0000320193-24-000001")
+        xlsx = next(d for d in docs if d.document_name == "Financial_Report.xlsx")
+        assert xlsx.description is None
+
+    def test_missing_size_parses_to_none(self) -> None:
+        index = {
+            "cik": "320193",
+            "primaryDocument": "x.htm",
+            "items": [{"name": "x.htm", "type": "10-K", "description": "X", "size": None}],
+        }
+        docs = parse_filing_index(index, accession_number="0000320193-24-000001")
+        assert docs[0].size_bytes is None
+
+    def test_duplicate_names_dedup(self) -> None:
+        """Two entries with the same ``name`` only yield one row."""
+        index = {
+            "cik": "320193",
+            "primaryDocument": "x.htm",
+            "items": [
+                {"name": "x.htm", "type": "10-K", "description": "X", "size": 1000},
+                {"name": "x.htm", "type": "10-K", "description": "X dup", "size": 1000},
+            ],
+        }
+        docs = parse_filing_index(index, accession_number="0000320193-24-000001")
+        assert len(docs) == 1
+
+    def test_missing_items_returns_empty(self) -> None:
+        assert parse_filing_index({"cik": "320193"}, accession_number="X") == ()
+
+    def test_shape(self) -> None:
+        docs = parse_filing_index(_INDEX, accession_number="0000320193-24-000001")
+        assert isinstance(docs[0], ParsedFilingDocument)

--- a/tests/test_filing_documents_ingest.py
+++ b/tests/test_filing_documents_ingest.py
@@ -1,0 +1,149 @@
+"""Integration tests for ``ingest_filing_documents`` (#452)."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import psycopg
+import pytest
+
+from app.services.filing_documents import (
+    ingest_filing_documents,
+    list_filing_documents,
+)
+
+pytestmark = pytest.mark.integration
+
+
+class _StubIndexFetcher:
+    def __init__(self, by_accession: dict[str, dict[str, object] | None]) -> None:
+        self._by = by_accession
+        self.calls: list[str] = []
+
+    def fetch_filing_index(self, accession: str) -> dict[str, object] | None:
+        self.calls.append(accession)
+        return self._by.get(accession)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int = 501) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            (iid, "APEX", "Apex Inc."),
+        )
+        row = cur.fetchone()
+        assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+def _seed_filing(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    accession: str,
+    url: str = "https://www.sec.gov/doc.htm",
+    filing_date: str = "2026-04-01",
+    filing_type: str = "10-K",
+) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO filing_events
+                (instrument_id, filing_date, filing_type, provider,
+                 provider_filing_id, primary_document_url)
+            VALUES (%s, %s, %s, 'sec', %s, %s)
+            RETURNING filing_event_id
+            """,
+            (instrument_id, filing_date, filing_type, accession, url),
+        )
+        row = cur.fetchone()
+        assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+_INDEX_JSON = {
+    "cik": "320193",
+    "form": "10-K",
+    "primaryDocument": "apex-10k.htm",
+    "items": [
+        {"name": "apex-10k.htm", "type": "10-K", "description": "10-K", "size": 999000},
+        {"name": "ex-21.htm", "type": "EX-21", "description": "Subsidiaries", "size": 2000},
+        {"name": "ex-99-1.htm", "type": "EX-99.1", "description": "Press release", "size": 5000},
+    ],
+}
+
+
+class TestIngestFilingDocuments:
+    def test_documents_land_per_filing(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        fid = _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="APEX-10K-1",
+        )
+        fetcher = _StubIndexFetcher({"APEX-10K-1": _INDEX_JSON})
+
+        result = ingest_filing_documents(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        assert result.filings_parsed == 1
+        assert result.documents_inserted == 3
+
+        docs = list_filing_documents(ebull_test_conn, filing_event_id=fid)
+        assert len(docs) == 3
+        # Primary document always sorts first.
+        assert docs[0].is_primary is True
+        assert docs[0].document_name == "apex-10k.htm"
+        ex_types = {d.document_type for d in docs}
+        assert "EX-21" in ex_types
+        assert "EX-99.1" in ex_types
+
+    def test_rerun_skips_filings_with_existing_children(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, iid=502)
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="APEX-10K-2",
+        )
+        fetcher = _StubIndexFetcher({"APEX-10K-2": _INDEX_JSON})
+        ingest_filing_documents(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        # Second pass: existing child rows mean the filing is no
+        # longer a candidate.
+        second = _StubIndexFetcher({"APEX-10K-2": _INDEX_JSON})
+        ingest_filing_documents(ebull_test_conn, cast("object", second))  # type: ignore[arg-type]
+        assert second.calls == []
+
+    def test_fetch_404_increments_fetch_errors_without_raising(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid = _seed_instrument(ebull_test_conn, iid=503)
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="DEAD-ACC",
+        )
+        fetcher = _StubIndexFetcher({"DEAD-ACC": None})
+        result = ingest_filing_documents(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.fetch_errors == 1
+        assert result.filings_parsed == 0
+
+    def test_non_sec_filings_ignored(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, iid=504)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO filing_events
+                    (instrument_id, filing_date, filing_type, provider,
+                     provider_filing_id, primary_document_url)
+                VALUES (%s, CURRENT_DATE, '10-K', 'companies_house',
+                        'CH-1', 'https://example.com/x.pdf')
+                """,
+                (iid,),
+            )
+        ebull_test_conn.commit()
+        fetcher = _StubIndexFetcher({})
+        result = ingest_filing_documents(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.filings_scanned == 0
+        assert fetcher.calls == []


### PR DESCRIPTION
## Summary
- New filing_documents table captures every document in every SEC filing's index.json (primary + exhibits + XBRL + graphics + cover).
- Retires sec_filing_*.json raw dump (~900 MB of the 1.1 GB data/raw/sec/ footprint).
- Unlocks cross-issuer queries ("find every EX-21", "locate all EX-99.1 press releases").
- Hourly ingester job sec_filing_documents_ingest at :35.

## Phase B/C tickets filed
- #463 — submissions.json long-tail normalisation
- #464 — retire sec_submissions_*.json dump after #463

## Test plan
- [x] uv run ruff check / format / pyright (all clean)
- [x] uv run pytest (2606 passed)