### PR TITLE
feat(#451): widen SEC fact extraction + sec_facts_concept_catalog (Phase A)

### DIFF
--- a/app/providers/fundamentals.py
+++ b/app/providers/fundamentals.py
@@ -53,6 +53,28 @@ class XbrlFact:
     decimals: str | None  # XBRL allows non-integer values like "INF"
 
 
+@dataclass(frozen=True)
+class XbrlConceptCatalogEntry:
+    """Per-concept metadata extracted from the SEC companyfacts JSON.
+
+    The companyfacts response carries a ``label`` + ``description``
+    alongside each concept's ``units`` block. Capturing these into
+    ``sec_facts_concept_catalog`` (#451) lets the UI and analysis
+    queries render a human-readable concept name without hard-coding
+    a Python alias map for the entire XBRL taxonomy.
+    """
+
+    taxonomy: str
+    concept: str
+    label: str | None
+    description: str | None
+    # Unit types observed for this concept in the current response.
+    # ``sec_facts_concept_catalog.units_seen`` accumulates the union
+    # across every ingest pass so a concept reporting in multiple
+    # units over time is represented truthfully.
+    units_seen: tuple[str, ...]
+
+
 class FundamentalsProvider(ABC):
     """
     Interface for normalised company fundamentals: income, balance sheet, cash flow.

--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -38,7 +38,12 @@ from typing import Any
 
 import httpx
 
-from app.providers.fundamentals import FundamentalsProvider, FundamentalsSnapshot, XbrlFact
+from app.providers.fundamentals import (
+    FundamentalsProvider,
+    FundamentalsSnapshot,
+    XbrlConceptCatalogEntry,
+    XbrlFact,
+)
 from app.providers.resilient_client import ResilientClient
 from app.services import raw_persistence
 
@@ -173,19 +178,23 @@ def _extract_facts_from_section(
     section: dict[str, Any],
     *,
     taxonomy: str,
-    allowed_tags: frozenset[str],
+    allowed_tags: frozenset[str] | None = None,
 ) -> list[XbrlFact]:
-    """Extract tracked XBRL facts from one ``facts.<taxonomy>`` section.
+    """Extract XBRL facts from one ``facts.<taxonomy>`` section.
 
     ``taxonomy`` names the XBRL namespace (``us-gaap`` or ``dei``) and
     is stamped onto every emitted fact so downstream consumers can
-    partition without string-prefix guessing. ``allowed_tags`` is the
-    taxonomy-specific allowlist (``_ALL_TRACKED_TAGS`` vs
-    ``_ALL_TRACKED_DEI_TAGS``).
+    partition without string-prefix guessing. ``allowed_tags`` is an
+    optional allowlist: when ``None`` (default, #451 Phase A) every
+    concept in the section is emitted; when a frozenset is provided
+    only listed tags survive. The default is now "emit all" so
+    ``financial_facts_raw`` captures the full richness of each
+    filing instead of the narrow ``TRACKED_CONCEPTS`` editorial
+    subset.
     """
     facts: list[XbrlFact] = []
     for tag_name, fact_data in section.items():
-        if tag_name not in allowed_tags:
+        if allowed_tags is not None and tag_name not in allowed_tags:
             continue
         units = fact_data.get("units", {})
         for unit_key in _UNIT_PRIORITY:
@@ -240,6 +249,54 @@ def _extract_facts_from_section(
                     )
                 )
     return facts
+
+
+def _catalog_from_payload(raw: dict[str, Any]) -> list[XbrlConceptCatalogEntry]:
+    """Helper used by :func:`extract_concept_catalog` to avoid
+    duplicating the section walk when the caller only wants the
+    catalogue side of a companyfacts payload."""
+    facts_block: dict[str, Any] = raw.get("facts", {})
+    entries: list[XbrlConceptCatalogEntry] = []
+    for tax_name, section in facts_block.items():
+        if not isinstance(section, dict):
+            continue
+        entries.extend(_extract_catalog_from_section(section, taxonomy=str(tax_name)))
+    return entries
+
+
+def _extract_catalog_from_section(section: dict[str, Any], *, taxonomy: str) -> list[XbrlConceptCatalogEntry]:
+    """Emit one :class:`XbrlConceptCatalogEntry` per concept present
+    in a ``facts.<taxonomy>`` section.
+
+    Populated opportunistically by the ingester so
+    ``sec_facts_concept_catalog`` accumulates metadata (label,
+    description, observed unit types) for every concept seen across
+    every issuer — no additional HTTP round-trips, the data is
+    already in the companyfacts response we fetched for the
+    fact-level extraction.
+    """
+    entries: list[XbrlConceptCatalogEntry] = []
+    for tag_name, fact_data in section.items():
+        if not isinstance(fact_data, dict):
+            continue
+        label = fact_data.get("label")
+        description = fact_data.get("description")
+        units_raw = fact_data.get("units")
+        units_seen: tuple[str, ...]
+        if isinstance(units_raw, dict):
+            units_seen = tuple(str(k) for k in units_raw if k)
+        else:
+            units_seen = ()
+        entries.append(
+            XbrlConceptCatalogEntry(
+                taxonomy=taxonomy,
+                concept=tag_name,
+                label=str(label) if isinstance(label, str) else None,
+                description=str(description) if isinstance(description, str) else None,
+                units_seen=units_seen,
+            )
+        )
+    return entries
 
 
 def _extract_facts_from_gaap(gaap: dict[str, Any]) -> list[XbrlFact]:
@@ -363,13 +420,22 @@ class SecFundamentalsProvider(FundamentalsProvider):
         return _build_history_snapshots(symbol, gaap, from_date, to_date, limit)
 
     def extract_facts(self, symbol: str, cik: str) -> list[XbrlFact]:
-        """Extract all tracked XBRL facts from SEC companyfacts.
+        """Extract XBRL facts from SEC companyfacts.
 
         Reads both ``facts.us-gaap`` and ``facts.dei`` sections (the
         latter under #430). DEI facts carry cover-page metadata that
         us-gaap omits — point-in-time share count, public float,
         employee count. Stamped with ``taxonomy='dei'`` so downstream
         normalisation routes them independently.
+
+        **#451 Phase A**: extractor no longer filters on the
+        editorial ``TRACKED_CONCEPTS`` allowlist. Every concept the
+        issuer reports lands in ``financial_facts_raw`` so segment
+        reporting, deferred-tax breakdown, lease liabilities, and
+        the rest of the long tail are queryable from SQL. The
+        ``TRACKED_CONCEPTS`` alias map is still used by downstream
+        ``financial_periods`` projection logic to select canonical
+        synonyms when aggregating.
         """
         raw = self._fetch_company_facts(cik)
         if raw is None:
@@ -382,22 +448,50 @@ class SecFundamentalsProvider(FundamentalsProvider):
             return []
         facts: list[XbrlFact] = []
         if gaap_section:
-            facts.extend(
-                _extract_facts_from_section(
-                    gaap_section,
-                    taxonomy="us-gaap",
-                    allowed_tags=_ALL_TRACKED_TAGS,
-                )
-            )
+            facts.extend(_extract_facts_from_section(gaap_section, taxonomy="us-gaap"))
         if dei_section:
-            facts.extend(
-                _extract_facts_from_section(
-                    dei_section,
-                    taxonomy="dei",
-                    allowed_tags=_ALL_TRACKED_DEI_TAGS,
-                )
-            )
+            facts.extend(_extract_facts_from_section(dei_section, taxonomy="dei"))
         return facts
+
+    def extract_concept_catalog(self, symbol: str, cik: str) -> list[XbrlConceptCatalogEntry]:
+        """Extract per-concept metadata (label, description, units)
+        from SEC companyfacts.
+
+        Issues its own HTTP fetch; callers that already hold the
+        companyfacts payload should use
+        :func:`extract_facts_and_catalog` instead to avoid double
+        round-trips (#451).
+        """
+        raw = self._fetch_company_facts(cik)
+        if raw is None:
+            return []
+        return _catalog_from_payload(raw)
+
+    def extract_facts_and_catalog(self, symbol: str, cik: str) -> tuple[list[XbrlFact], list[XbrlConceptCatalogEntry]]:
+        """Single-fetch convenience: return both the fact rows AND
+        the concept-catalogue entries from one companyfacts payload.
+
+        Preferred call for the ingester path so we don't double
+        round-trip SEC for facts + catalogue on every refresh.
+        """
+        raw = self._fetch_company_facts(cik)
+        if raw is None:
+            return [], []
+        all_facts: dict[str, Any] = raw.get("facts", {})
+        gaap_section = all_facts.get("us-gaap", {})
+        dei_section = all_facts.get("dei", {})
+        if not gaap_section and not dei_section:
+            logger.info("No us-gaap or dei facts for %s (CIK %s)", symbol, cik)
+            return [], []
+        facts: list[XbrlFact] = []
+        entries: list[XbrlConceptCatalogEntry] = []
+        if gaap_section:
+            facts.extend(_extract_facts_from_section(gaap_section, taxonomy="us-gaap"))
+            entries.extend(_extract_catalog_from_section(gaap_section, taxonomy="us-gaap"))
+        if dei_section:
+            facts.extend(_extract_facts_from_section(dei_section, taxonomy="dei"))
+            entries.extend(_extract_catalog_from_section(dei_section, taxonomy="dei"))
+        return facts, entries
 
     # ------------------------------------------------------------------
     # Private HTTP

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -25,7 +25,12 @@ from typing import TYPE_CHECKING
 
 import psycopg
 
-from app.providers.fundamentals import FundamentalsProvider, FundamentalsSnapshot, XbrlFact
+from app.providers.fundamentals import (
+    FundamentalsProvider,
+    FundamentalsSnapshot,
+    XbrlConceptCatalogEntry,
+    XbrlFact,
+)
 from app.providers.implementations.sec_edgar import (
     MasterIndexEntry,
     SecFilingsProvider,
@@ -340,6 +345,64 @@ WHERE financial_facts_raw.val IS DISTINCT FROM EXCLUDED.val
 _UPSERT_PAGE_SIZE = 1000
 
 
+_UPSERT_CATALOG_SQL = """
+INSERT INTO sec_facts_concept_catalog (
+    taxonomy, concept, label, description, units_seen
+) VALUES (
+    %(taxonomy)s, %(concept)s, %(label)s, %(description)s, %(units_seen)s
+)
+ON CONFLICT (taxonomy, concept) DO UPDATE SET
+    -- Prefer the latest label/description when non-NULL — a later
+    -- filing's wording supersedes an earlier vacuum.
+    label       = COALESCE(EXCLUDED.label, sec_facts_concept_catalog.label),
+    description = COALESCE(EXCLUDED.description, sec_facts_concept_catalog.description),
+    -- Union the observed unit types so concepts that migrated from
+    -- one unit to another over time still report the full set.
+    units_seen  = ARRAY(
+        SELECT DISTINCT unnest(
+            sec_facts_concept_catalog.units_seen || EXCLUDED.units_seen
+        )
+    ),
+    last_seen_at = NOW()
+"""
+
+
+def upsert_concept_catalog(
+    conn: psycopg.Connection[tuple],
+    *,
+    entries: Sequence[XbrlConceptCatalogEntry],
+) -> int:
+    """Upsert per-concept metadata into ``sec_facts_concept_catalog``.
+
+    Idempotent: re-upserting the same (taxonomy, concept) replaces
+    label + description with the latest non-NULL values and unions
+    the observed unit types so historical units accumulate. Runs
+    alongside :func:`upsert_facts_for_instrument` on the same
+    ingest-run transaction.
+
+    Returns the number of rows affected by the operation.
+    """
+    if not entries:
+        return 0
+    rows = [
+        {
+            "taxonomy": e.taxonomy,
+            "concept": e.concept,
+            "label": e.label,
+            "description": e.description,
+            "units_seen": list(e.units_seen),
+        }
+        for e in entries
+    ]
+    affected = 0
+    with conn.cursor() as cur:
+        for i in range(0, len(rows), _UPSERT_PAGE_SIZE):
+            chunk = rows[i : i + _UPSERT_PAGE_SIZE]
+            cur.executemany(_UPSERT_CATALOG_SQL, chunk)
+            affected += cur.rowcount if cur.rowcount and cur.rowcount > 0 else len(chunk)
+    return affected
+
+
 def upsert_facts_for_instrument(
     conn: psycopg.Connection[tuple],
     *,
@@ -440,7 +503,16 @@ def refresh_financial_facts(
     for idx, (symbol, instrument_id, cik) in enumerate(symbols, start=1):
         try:
             with conn.transaction():
-                facts = provider.extract_facts(symbol, cik)
+                # #451 Phase A — single fetch returns both fact rows
+                # and catalogue entries. Avoids a second SEC round-
+                # trip for the editorial metadata. Fall back to the
+                # legacy ``extract_facts`` when a test stub doesn't
+                # implement the combined helper yet.
+                if hasattr(provider, "extract_facts_and_catalog"):
+                    facts, catalog_entries = provider.extract_facts_and_catalog(symbol, cik)
+                else:
+                    facts = provider.extract_facts(symbol, cik)  # type: ignore[attr-defined]
+                    catalog_entries = []
                 if not facts:
                     logger.info("No XBRL facts for %s (CIK %s)", symbol, cik)
                     continue
@@ -450,13 +522,16 @@ def refresh_financial_facts(
                     facts=facts,
                     ingestion_run_id=run_id,
                 )
+                if catalog_entries:
+                    upsert_concept_catalog(conn, entries=catalog_entries)
                 total_upserted += upserted
                 total_skipped += skipped
                 logger.info(
-                    "SEC facts for %s: %d upserted, %d skipped",
+                    "SEC facts for %s: %d upserted, %d skipped, %d catalog concepts",
                     symbol,
                     upserted,
                     skipped,
+                    len(catalog_entries),
                 )
         except Exception:
             failed += 1
@@ -1811,7 +1886,15 @@ def _run_cik_upsert(
                     exc_info=True,
                 )
 
-        facts = fundamentals_provider.extract_facts(symbol, cik)
+        # #451 Phase A — single fetch returns both fact rows and
+        # catalogue entries. Fall back to ``extract_facts`` when a
+        # test stub provider doesn't yet implement the combined
+        # helper.
+        if hasattr(fundamentals_provider, "extract_facts_and_catalog"):
+            facts, catalog_entries = fundamentals_provider.extract_facts_and_catalog(symbol, cik)
+        else:
+            facts = fundamentals_provider.extract_facts(symbol, cik)  # type: ignore[attr-defined]
+            catalog_entries = []
         upserted_in_tx = 0
 
         with conn.transaction():
@@ -1823,6 +1906,8 @@ def _run_cik_upsert(
                     ingestion_run_id=run_id,
                 )
                 upserted_in_tx = upserted
+            if catalog_entries:
+                upsert_concept_catalog(conn, entries=catalog_entries)
             # Upsert each master-index entry for this CIK into
             # filing_events so downstream event-driven triggers
             # (#273 thesis, #276 cascade) have a timestamped signal.

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -394,12 +394,18 @@ def upsert_concept_catalog(
         }
         for e in entries
     ]
+    # psycopg3's ``executemany`` reports the cumulative rowcount
+    # across every parameter set — no per-chunk clamp needed. We
+    # fall back to len(chunk) only when the driver signals "unknown"
+    # via rowcount = -1 (never happens for ON CONFLICT in psycopg3
+    # today but keeps the counter sane against a future driver-
+    # behaviour change).
     affected = 0
     with conn.cursor() as cur:
         for i in range(0, len(rows), _UPSERT_PAGE_SIZE):
             chunk = rows[i : i + _UPSERT_PAGE_SIZE]
             cur.executemany(_UPSERT_CATALOG_SQL, chunk)
-            affected += cur.rowcount if cur.rowcount and cur.rowcount > 0 else len(chunk)
+            affected += cur.rowcount if cur.rowcount and cur.rowcount >= 0 else len(chunk)
     return affected
 
 

--- a/sql/063_sec_facts_concept_catalog.sql
+++ b/sql/063_sec_facts_concept_catalog.sql
@@ -1,0 +1,79 @@
+-- 063_sec_facts_concept_catalog.sql
+--
+-- SEC company-facts concept catalogue (#451 Phase A). Follow-up to
+-- the #448 operator directive: every structured upstream field
+-- lands in SQL; ``data/raw/sec_fundamentals/`` (~11 GB of
+-- companyfacts JSON) stops being a necessary audit substrate once
+-- every concept is queryable in SQL.
+--
+-- Current state (pre-#451): ``financial_facts_raw`` stores XBRL
+-- facts gated on the ``TRACKED_CONCEPTS`` allowlist (~36 us-gaap
+-- concepts + 3 dei concepts). Every other concept in the issuer's
+-- companyfacts.json (segment reporting, deferred-tax breakdown,
+-- lease liabilities, operating-leases detail, etc.) is silent —
+-- available on disk but unqueryable from SQL.
+--
+-- Two changes land together:
+--   1. This catalogue table ``sec_facts_concept_catalog`` storing
+--      (taxonomy, concept) metadata: label, description, first-seen
+--      / last-seen timestamps. Populated opportunistically as the
+--      ingester sees new concepts.
+--   2. Extractor widens to emit facts for EVERY concept (not just
+--      the editorial TRACKED_CONCEPTS subset). TRACKED_CONCEPTS
+--      stays as the canonical-alias map used by the
+--      ``financial_periods`` projection logic, but the raw fact
+--      table now carries the full richness of each filing.
+--
+-- Phase B (#466 follow-up) flips the retention policy on
+-- ``sec_fundamentals`` raw persistence to compact-out once SQL
+-- coverage is verified end-to-end.
+
+CREATE TABLE IF NOT EXISTS sec_facts_concept_catalog (
+    id              BIGSERIAL   PRIMARY KEY,
+    -- XBRL taxonomy namespace. ``us-gaap`` for the standard
+    -- accounting taxonomy; ``dei`` for document-and-entity cover-
+    -- page facts. Issuer-specific extensions land under the
+    -- issuer's own namespace prefix (rare in our universe).
+    taxonomy        TEXT        NOT NULL,
+    -- Raw XBRL tag, e.g. ``Revenues``,
+    -- ``OperatingLeaseLiabilityNoncurrent``,
+    -- ``ShareBasedCompensation``. Case-preserved verbatim from the
+    -- source JSON so lookups match the tag string on
+    -- ``financial_facts_raw.concept`` exactly.
+    concept         TEXT        NOT NULL,
+    -- Human-readable label as it appears on the concept's ``label``
+    -- field in the companyfacts JSON (e.g. "Revenues", "Operating
+    -- Lease Liability, Noncurrent"). Used by the UI to render
+    -- concept names without hard-coding each tag in Python.
+    label           TEXT,
+    -- Full SEC taxonomy description — usually a paragraph explaining
+    -- what the concept measures, unit expectations, and reporting
+    -- notes. Preserved verbatim for audit and for rendering in the
+    -- instrument-page financial-facts explorer.
+    description     TEXT,
+    -- Unit types observed for this concept across all filings
+    -- ingested to date: ``USD``, ``USD/shares``, ``shares``,
+    -- ``pure``, etc. Stored as a TEXT[] so a concept reporting in
+    -- multiple units over time accumulates the full set.
+    units_seen      TEXT[]      NOT NULL DEFAULT '{}'::TEXT[],
+    first_seen_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (taxonomy, concept)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sec_facts_concept_catalog_taxonomy
+    ON sec_facts_concept_catalog (taxonomy);
+
+COMMENT ON TABLE sec_facts_concept_catalog IS
+    'Per-concept metadata for every XBRL tag the SEC fundamentals '
+    'ingester has seen. Populated opportunistically alongside the '
+    'fact-level upsert so a UI / query tool can render concepts '
+    'with their human-readable labels + descriptions without '
+    'hitting the raw companyfacts JSON on disk.';
+
+COMMENT ON COLUMN sec_facts_concept_catalog.units_seen IS
+    'Accumulated set of unit types observed for this concept '
+    '(``USD``, ``USD/shares``, ``shares``, ``pure``, etc.). A '
+    'concept can legitimately report in multiple units across '
+    'filings; the array lets callers know which units to expect '
+    'without re-scanning financial_facts_raw.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -47,6 +47,7 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "cascade_retry_queue",
     "cik_upsert_timing",  # #418 per-CIK timing audit (FK → data_ingestion_runs)
     "financial_facts_raw",
+    "sec_facts_concept_catalog",  # #451 — per-concept metadata
     "data_ingestion_runs",
     # layer_enabled is the home of the #414 fundamentals_ingest pause
     # flag and is written by several observability/planner tests. Keep

--- a/tests/test_sec_facts_concept_catalog.py
+++ b/tests/test_sec_facts_concept_catalog.py
@@ -1,0 +1,202 @@
+"""Tests for the SEC facts concept catalogue (#451).
+
+Unit-level: ``_extract_catalog_from_section`` + ``_catalog_from_payload``
+over a realistic companyfacts shape.
+
+Integration-level: ``upsert_concept_catalog`` against the live test DB
+— ON CONFLICT merges units_seen and refreshes label/description.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.providers.fundamentals import XbrlConceptCatalogEntry
+from app.providers.implementations.sec_fundamentals import (
+    _catalog_from_payload,
+    _extract_catalog_from_section,
+    _extract_facts_from_section,
+)
+
+_SECTION = {
+    "Revenues": {
+        "label": "Revenues",
+        "description": "Amount of revenue recognised from goods sold, services rendered...",
+        "units": {
+            "USD": [
+                {
+                    "accn": "0000320193-24-000001",
+                    "end": "2024-09-30",
+                    "val": 383285000000,
+                    "form": "10-K",
+                    "fp": "FY",
+                    "fy": 2024,
+                    "filed": "2024-11-01",
+                },
+            ]
+        },
+    },
+    # Un-tracked concept — previously dropped by the allowed_tags
+    # filter, now captured under #451.
+    "OperatingLeaseLiabilityNoncurrent": {
+        "label": "Operating Lease Liability, Noncurrent",
+        "description": "Present value of lease payments not yet paid...",
+        "units": {
+            "USD": [
+                {
+                    "accn": "0000320193-24-000001",
+                    "end": "2024-09-30",
+                    "val": 11000000000,
+                    "form": "10-K",
+                    "fp": "FY",
+                    "fy": 2024,
+                    "filed": "2024-11-01",
+                },
+            ]
+        },
+    },
+}
+
+
+class TestExtractCatalog:
+    def test_section_emits_entry_per_concept(self) -> None:
+        entries = _extract_catalog_from_section(_SECTION, taxonomy="us-gaap")
+        codes = {e.concept for e in entries}
+        assert "Revenues" in codes
+        assert "OperatingLeaseLiabilityNoncurrent" in codes
+
+    def test_label_and_description_preserved_verbatim(self) -> None:
+        entries = _extract_catalog_from_section(_SECTION, taxonomy="us-gaap")
+        rev = next(e for e in entries if e.concept == "Revenues")
+        assert rev.label == "Revenues"
+        assert rev.description is not None
+        assert "revenue recognised" in rev.description
+
+    def test_units_seen_captured(self) -> None:
+        entries = _extract_catalog_from_section(_SECTION, taxonomy="us-gaap")
+        rev = next(e for e in entries if e.concept == "Revenues")
+        assert "USD" in rev.units_seen
+
+    def test_catalog_from_payload_walks_every_taxonomy(self) -> None:
+        payload = {
+            "facts": {
+                "us-gaap": {"Revenues": {"label": "Revenues", "description": "x", "units": {}}},
+                "dei": {
+                    "EntityCommonStockSharesOutstanding": {
+                        "label": "Shares Outstanding",
+                        "description": "Cover-page share count.",
+                        "units": {"shares": []},
+                    }
+                },
+            }
+        }
+        entries = _catalog_from_payload(payload)
+        taxes = {e.taxonomy for e in entries}
+        assert taxes == {"us-gaap", "dei"}
+
+    def test_empty_payload_returns_empty(self) -> None:
+        assert _catalog_from_payload({"facts": {}}) == []
+        assert _catalog_from_payload({}) == []
+
+
+class TestExtractorWideningWithoutFilter:
+    """#451 Phase A: extractor emits every concept when no filter."""
+
+    def test_no_filter_captures_untracked_concept(self) -> None:
+        facts = _extract_facts_from_section(_SECTION, taxonomy="us-gaap")
+        concepts = {f.concept for f in facts}
+        assert "OperatingLeaseLiabilityNoncurrent" in concepts
+
+    def test_explicit_filter_still_honoured(self) -> None:
+        facts = _extract_facts_from_section(_SECTION, taxonomy="us-gaap", allowed_tags=frozenset({"Revenues"}))
+        assert {f.concept for f in facts} == {"Revenues"}
+
+
+@pytest.mark.integration
+class TestUpsertConceptCatalogDB:
+    def test_upsert_merges_units_and_refreshes_label(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        from app.services.fundamentals import upsert_concept_catalog
+
+        entries_v1 = [
+            XbrlConceptCatalogEntry(
+                taxonomy="us-gaap",
+                concept="Revenues",
+                label="Revenues",
+                description="v1 description",
+                units_seen=("USD",),
+            ),
+        ]
+        entries_v2 = [
+            XbrlConceptCatalogEntry(
+                taxonomy="us-gaap",
+                concept="Revenues",
+                label="Revenues (updated)",
+                description="v2 description",
+                units_seen=("EUR",),
+            ),
+        ]
+        upsert_concept_catalog(ebull_test_conn, entries=entries_v1)
+        upsert_concept_catalog(ebull_test_conn, entries=entries_v2)
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT label, description, units_seen
+                FROM sec_facts_concept_catalog
+                WHERE taxonomy = 'us-gaap' AND concept = 'Revenues'
+                """
+            )
+            row = cur.fetchone()
+            assert row is not None
+        label, description, units_seen = row
+        # Latest label + description win.
+        assert label == "Revenues (updated)"
+        assert description == "v2 description"
+        # Unit-type union preserves both observed units.
+        assert set(units_seen) == {"USD", "EUR"}
+
+    def test_upsert_preserves_prior_label_on_null(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A later entry with NULL label must not clobber the prior
+        label — COALESCE keeps the earlier non-NULL value."""
+        from app.services.fundamentals import upsert_concept_catalog
+
+        upsert_concept_catalog(
+            ebull_test_conn,
+            entries=[
+                XbrlConceptCatalogEntry(
+                    taxonomy="us-gaap",
+                    concept="GoodConcept",
+                    label="Original",
+                    description="Original description",
+                    units_seen=("USD",),
+                )
+            ],
+        )
+        upsert_concept_catalog(
+            ebull_test_conn,
+            entries=[
+                XbrlConceptCatalogEntry(
+                    taxonomy="us-gaap",
+                    concept="GoodConcept",
+                    label=None,
+                    description=None,
+                    units_seen=("USD",),
+                )
+            ],
+        )
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT label, description
+                FROM sec_facts_concept_catalog
+                WHERE taxonomy = 'us-gaap' AND concept = 'GoodConcept'
+                """
+            )
+            row = cur.fetchone()
+            assert row is not None
+        assert row[0] == "Original"
+        assert row[1] == "Original description"


### PR DESCRIPTION
## Summary
- financial_facts_raw now captures every concept the issuer reports (not just ~36 tracked). Unlocks segment reporting, deferred-tax breakdown, lease liabilities, etc.
- New sec_facts_concept_catalog table stores per-concept label/description/units so UI can render human-readable names.
- Single-fetch provider helper (extract_facts_and_catalog) avoids double HTTP per issuer.
- Raw disk persistence retained for audit trail — Phase B (#466) flips retention policy after coverage verified.

## Test plan
- [x] uv run ruff check / format / pyright (all clean)
- [x] uv run pytest (2615 passed)
- [x] 9 new tests in tests/test_sec_facts_concept_catalog.py

## Phase B
- #466 — retire disk dump after end-to-end SQL coverage audit