### PR TITLE
feat(#463): submissions.json long-tail + sec_entity_change_log

### DIFF
--- a/app/services/sec_entity_profile.py
+++ b/app/services/sec_entity_profile.py
@@ -152,8 +152,10 @@ def _address(value: Any) -> dict[str, Any] | None:
         if isinstance(v, str):
             v = v.strip() or None
         out[dst_key] = v
-    # Drop the dict when every field is None/empty.
-    if not any(out.get(k) for k in _ADDRESS_FIELDS):
+    # Drop the dict only when every field is None / empty. Explicit
+    # None check rather than truthiness — ``isForeignLocation: 0``
+    # (SEC's "not foreign" marker) is meaningful and must survive.
+    if all(out.get(k) is None for k in _ADDRESS_FIELDS):
         return None
     return out
 

--- a/app/services/sec_entity_profile.py
+++ b/app/services/sec_entity_profile.py
@@ -43,6 +43,12 @@ class SecEntityProfile:
     former_names: list[dict[str, Any]]
     has_insider_issuer: bool | None
     has_insider_owner: bool | None
+    # #463 — submissions.json long-tail fields previously dropped.
+    phone: str | None = None
+    entity_type: str | None = None
+    flags: str | None = None
+    address_business: dict[str, Any] | None = None
+    address_mailing: dict[str, Any] | None = None
 
 
 def _non_empty_str(value: Any) -> str | None:
@@ -105,6 +111,53 @@ def _former_names(value: Any) -> list[dict[str, Any]]:
     return out
 
 
+_ADDRESS_FIELDS = (
+    "street1",
+    "street2",
+    "city",
+    "state_or_country",
+    "state_or_country_description",
+    "zip_code",
+    "country",
+    "country_code",
+    "is_foreign_location",
+    "foreign_state_territory",
+)
+
+
+def _address(value: Any) -> dict[str, Any] | None:
+    """Normalise a SEC address block into a stable snake_case shape.
+
+    Returns ``None`` when the source carries no non-empty fields —
+    avoids storing empty-shell dicts that would force every consumer
+    to check emptiness.
+    """
+    if not isinstance(value, dict):
+        return None
+    out: dict[str, Any] = {}
+    mapping = {
+        "street1": "street1",
+        "street2": "street2",
+        "city": "city",
+        "stateOrCountry": "state_or_country",
+        "stateOrCountryDescription": "state_or_country_description",
+        "zipCode": "zip_code",
+        "country": "country",
+        "countryCode": "country_code",
+        "isForeignLocation": "is_foreign_location",
+        "foreignStateTerritory": "foreign_state_territory",
+    }
+    for src_key, dst_key in mapping.items():
+        v = value.get(src_key)
+        if isinstance(v, str):
+            v = v.strip() or None
+        out[dst_key] = v
+    # Drop the dict when every field is None/empty.
+    if not any(out.get(k) for k in _ADDRESS_FIELDS):
+        return None
+    return out
+
+
 def parse_entity_profile(
     submissions: dict[str, Any],
     *,
@@ -113,6 +166,9 @@ def parse_entity_profile(
 ) -> SecEntityProfile:
     """Extract the entity subset. Never raises — every field falls back
     to None/[]/{} if the source omitted or malformed it."""
+    addresses = submissions.get("addresses")
+    address_business = _address(addresses.get("business")) if isinstance(addresses, dict) else None
+    address_mailing = _address(addresses.get("mailing")) if isinstance(addresses, dict) else None
     return SecEntityProfile(
         instrument_id=instrument_id,
         cik=cik,
@@ -132,6 +188,11 @@ def parse_entity_profile(
         former_names=_former_names(submissions.get("formerNames")),
         has_insider_issuer=_int_to_bool(submissions.get("insiderTransactionForIssuerExists")),
         has_insider_owner=_int_to_bool(submissions.get("insiderTransactionForOwnerExists")),
+        phone=_non_empty_str(submissions.get("phone")),
+        entity_type=_non_empty_str(submissions.get("entityType")),
+        flags=_non_empty_str(submissions.get("flags")),
+        address_business=address_business,
+        address_mailing=address_mailing,
     )
 
 
@@ -141,13 +202,18 @@ INSERT INTO instrument_sec_profile (
     description, website, investor_website, ein, lei,
     state_of_incorporation, state_of_incorporation_desc,
     fiscal_year_end, category, exchanges, former_names,
-    has_insider_issuer, has_insider_owner, fetched_at
+    has_insider_issuer, has_insider_owner,
+    phone, entity_type, flags, address_business, address_mailing,
+    fetched_at
 ) VALUES (
     %(instrument_id)s, %(cik)s, %(sic)s, %(sic_description)s, %(owner_org)s,
     %(description)s, %(website)s, %(investor_website)s, %(ein)s, %(lei)s,
     %(state_of_incorporation)s, %(state_of_incorporation_desc)s,
     %(fiscal_year_end)s, %(category)s, %(exchanges)s, %(former_names)s,
-    %(has_insider_issuer)s, %(has_insider_owner)s, NOW()
+    %(has_insider_issuer)s, %(has_insider_owner)s,
+    %(phone)s, %(entity_type)s, %(flags)s,
+    %(address_business)s, %(address_mailing)s,
+    NOW()
 )
 ON CONFLICT (instrument_id) DO UPDATE SET
     cik                         = EXCLUDED.cik,
@@ -167,15 +233,119 @@ ON CONFLICT (instrument_id) DO UPDATE SET
     former_names                = EXCLUDED.former_names,
     has_insider_issuer          = EXCLUDED.has_insider_issuer,
     has_insider_owner           = EXCLUDED.has_insider_owner,
+    phone                       = EXCLUDED.phone,
+    entity_type                 = EXCLUDED.entity_type,
+    flags                       = EXCLUDED.flags,
+    address_business            = EXCLUDED.address_business,
+    address_mailing             = EXCLUDED.address_mailing,
     fetched_at                  = NOW()
 """
+
+
+# Fields whose changes are captured in sec_entity_change_log. Tuple
+# of (field_name, extractor) so adding a field here is a one-line
+# drop. ``extractor`` returns the JSON-serialisable representation
+# used for both diff comparison and log storage.
+_TRACKED_FIELDS: tuple[tuple[str, Any], ...] = (
+    ("sic", lambda p: p.sic),
+    ("sic_description", lambda p: p.sic_description),
+    ("owner_org", lambda p: p.owner_org),
+    ("description", lambda p: p.description),
+    ("website", lambda p: p.website),
+    ("investor_website", lambda p: p.investor_website),
+    ("state_of_incorporation", lambda p: p.state_of_incorporation),
+    ("state_of_incorporation_desc", lambda p: p.state_of_incorporation_desc),
+    ("fiscal_year_end", lambda p: p.fiscal_year_end),
+    ("category", lambda p: p.category),
+    ("exchanges", lambda p: p.exchanges),
+    ("entity_type", lambda p: p.entity_type),
+    ("phone", lambda p: p.phone),
+    ("flags", lambda p: p.flags),
+    ("address_business", lambda p: p.address_business),
+    ("address_mailing", lambda p: p.address_mailing),
+)
+
+
+def _serialise(value: Any) -> str:
+    """Canonical JSON serialisation for diff + log storage.
+
+    ``json.dumps`` with ``sort_keys=True`` so dict-valued addresses
+    compare equal regardless of field-ordering drift in the source
+    JSON. String values pass through JSON-encoded ("foo" not foo)
+    so the diff sees an explicit quoted form and the log stores a
+    uniform shape.
+    """
+    import json
+
+    return json.dumps(value, sort_keys=True, default=str)
+
+
+def detect_profile_changes(
+    prev: SecEntityProfile | None,
+    current: SecEntityProfile,
+) -> list[tuple[str, str | None, str]]:
+    """Return (field_name, prev_value, new_value) for every field in
+    ``_TRACKED_FIELDS`` whose serialised value differs between
+    ``prev`` and ``current``.
+
+    Returns an empty list on initial ingest (``prev is None``) so the
+    first snapshot doesn't synthesise spurious "changed from NULL"
+    events for every field — subsequent ingests are the ones that
+    capture real change.
+    """
+    if prev is None:
+        return []
+    changes: list[tuple[str, str | None, str]] = []
+    for field_name, extractor in _TRACKED_FIELDS:
+        prev_val = extractor(prev)
+        new_val = extractor(current)
+        prev_serialised = _serialise(prev_val)
+        new_serialised = _serialise(new_val)
+        if prev_serialised != new_serialised:
+            changes.append((field_name, prev_serialised, new_serialised))
+    return changes
+
+
+def _append_change_log(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    cik: str,
+    changes: list[tuple[str, str | None, str]],
+    source_accession: str | None = None,
+) -> None:
+    """Insert one row per detected change into ``sec_entity_change_log``.
+
+    No-op when ``changes`` is empty. Caller is responsible for
+    transactional scope — the append runs inline so it commits with
+    the profile upsert.
+    """
+    if not changes:
+        return
+    with conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO sec_entity_change_log
+                (instrument_id, cik, field_name, prev_value, new_value,
+                 source_accession)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            [(instrument_id, cik, name, prev, new, source_accession) for name, prev, new in changes],
+        )
 
 
 def upsert_entity_profile(
     conn: psycopg.Connection[Any],
     profile: SecEntityProfile,
+    *,
+    source_accession: str | None = None,
 ) -> None:
-    """Insert-or-update the profile row for ``profile.instrument_id``."""
+    """Insert-or-update the profile row for ``profile.instrument_id``
+    and append any detected field changes to
+    ``sec_entity_change_log`` in the same transaction (#463).
+    """
+    prev = get_entity_profile(conn, instrument_id=profile.instrument_id)
+    changes = detect_profile_changes(prev, profile)
     conn.execute(
         _UPSERT_SQL,
         {
@@ -197,7 +367,19 @@ def upsert_entity_profile(
             "former_names": Jsonb(profile.former_names),
             "has_insider_issuer": profile.has_insider_issuer,
             "has_insider_owner": profile.has_insider_owner,
+            "phone": profile.phone,
+            "entity_type": profile.entity_type,
+            "flags": profile.flags,
+            "address_business": Jsonb(profile.address_business) if profile.address_business else None,
+            "address_mailing": Jsonb(profile.address_mailing) if profile.address_mailing else None,
         },
+    )
+    _append_change_log(
+        conn,
+        instrument_id=profile.instrument_id,
+        cik=profile.cik,
+        changes=changes,
+        source_accession=source_accession,
     )
 
 
@@ -214,7 +396,9 @@ def get_entity_profile(
                    description, website, investor_website, ein, lei,
                    state_of_incorporation, state_of_incorporation_desc,
                    fiscal_year_end, category, exchanges, former_names,
-                   has_insider_issuer, has_insider_owner
+                   has_insider_issuer, has_insider_owner,
+                   phone, entity_type, flags,
+                   address_business, address_mailing
             FROM instrument_sec_profile
             WHERE instrument_id = %s
             """,
@@ -244,4 +428,9 @@ def get_entity_profile(
         former_names=list(row["former_names"] or []),
         has_insider_issuer=row["has_insider_issuer"],
         has_insider_owner=row["has_insider_owner"],
+        phone=row.get("phone"),
+        entity_type=row.get("entity_type"),
+        flags=row.get("flags"),
+        address_business=(dict(row["address_business"]) if row.get("address_business") else None),
+        address_mailing=(dict(row["address_mailing"]) if row.get("address_mailing") else None),
     )

--- a/sql/064_sec_entity_history.sql
+++ b/sql/064_sec_entity_history.sql
@@ -1,0 +1,114 @@
+-- 064_sec_entity_history.sql
+--
+-- SEC submissions.json long-tail normalisation (#463 / #452 Phase B).
+-- Captures the remaining structured fields from submissions.json that
+-- the #427 migration left on disk, plus a unified change-log for
+-- every mutable entity field so the operator can answer "when did
+-- this issuer's sector / address / fiscal-year / organisation
+-- change" without re-walking historical raw dumps.
+--
+-- Fields added to ``instrument_sec_profile`` (latest-value columns):
+--   - phone                 — registrant contact phone number
+--   - entity_type           — "operating" / "investment" / etc.
+--   - flags                 — SEC free-text marker (rarely populated)
+--   - address_business      — JSONB of the current business address
+--   - address_mailing       — JSONB of the current mailing address
+--
+-- New table ``sec_entity_change_log`` records every detected change
+-- to a tracked entity field. One row per (instrument, field, detection
+-- timestamp). Enables queries like:
+--   - "show every sector re-classification in the last year"
+--   - "which issuers moved headquarters this quarter"
+--   - "when did APPL's fiscal year last change"
+--
+-- Change detection runs in the ingester (``sec_entity_profile``
+-- service) on every submissions.json fetch: compare the incoming
+-- value against the stored row, emit a log entry when they differ.
+-- Initial seed is skipped — the first ingest writes the profile row
+-- without synthesising a spurious "changed from NULL" event.
+
+-- ---------------------------------------------------------------------
+-- instrument_sec_profile — extend with submissions.json long-tail
+-- ---------------------------------------------------------------------
+
+ALTER TABLE instrument_sec_profile
+    ADD COLUMN IF NOT EXISTS phone TEXT;
+ALTER TABLE instrument_sec_profile
+    ADD COLUMN IF NOT EXISTS entity_type TEXT;
+ALTER TABLE instrument_sec_profile
+    ADD COLUMN IF NOT EXISTS flags TEXT;
+ALTER TABLE instrument_sec_profile
+    ADD COLUMN IF NOT EXISTS address_business JSONB;
+ALTER TABLE instrument_sec_profile
+    ADD COLUMN IF NOT EXISTS address_mailing JSONB;
+
+COMMENT ON COLUMN instrument_sec_profile.entity_type IS
+    'SEC entityType classifier — "operating", "investment", "general-purpose '
+    'acquisition company", etc. Rare to change; kept on the latest-value '
+    'row and change events logged to sec_entity_change_log.';
+
+COMMENT ON COLUMN instrument_sec_profile.address_business IS
+    'Current business address as a JSONB object with fields '
+    '{street1, street2, city, state_or_country, state_or_country_description, '
+    'zip_code, country, country_code, is_foreign_location, foreign_state_territory}. '
+    'Historical address changes land in sec_entity_change_log.';
+
+-- ---------------------------------------------------------------------
+-- sec_entity_change_log — unified change log for entity fields
+-- ---------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS sec_entity_change_log (
+    id                 BIGSERIAL   PRIMARY KEY,
+    instrument_id      BIGINT      NOT NULL
+                           REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    -- Denormalised for readable queries. Matches
+    -- instrument_sec_profile.cik for the same instrument.
+    cik                TEXT        NOT NULL,
+    -- Name of the submissions.json field that changed. Known values:
+    --   sic, sic_description, owner_org, description, website,
+    --   investor_website, fiscal_year_end, category, state_of_incorporation,
+    --   state_of_incorporation_desc, entity_type, phone, flags,
+    --   address_business, address_mailing, exchanges.
+    -- Free-text to allow future fields without a schema migration.
+    field_name         TEXT        NOT NULL,
+    -- JSON-serialised snapshot of the value before / after the
+    -- detected change. TEXT rather than JSONB because some fields
+    -- store primitive strings; TEXT keeps the comparison + storage
+    -- path uniform across primitive and object-valued fields.
+    prev_value         TEXT,
+    new_value          TEXT        NOT NULL,
+    -- Timestamp when the ingester noticed the delta — NOT the date
+    -- the change actually happened at the issuer (SEC doesn't
+    -- publish that for most fields). The detection timestamp is an
+    -- upper bound; the true change landed somewhere between this
+    -- row and the previous change-log entry for the same field.
+    detected_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Accession that was being processed when the change was
+    -- detected, if the caller had one in scope. Useful for linking
+    -- a sector-change log back to the 10-K that triggered it.
+    source_accession   TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sec_entity_change_log_instrument
+    ON sec_entity_change_log (instrument_id, detected_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sec_entity_change_log_field
+    ON sec_entity_change_log (field_name, detected_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sec_entity_change_log_cik
+    ON sec_entity_change_log (cik);
+
+COMMENT ON TABLE sec_entity_change_log IS
+    'Append-only log of detected changes to entity fields on '
+    'instrument_sec_profile. Populated by the SEC entity-profile '
+    'ingester when a newly-fetched submissions.json field differs '
+    'from the stored latest value. Distinct from formerNames '
+    '(SEC-published name history) — this captures sector, address, '
+    'fiscal year, organisation, and the rest of the mutable fields '
+    'that do not have a SEC-side historical feed.';
+
+COMMENT ON COLUMN sec_entity_change_log.detected_at IS
+    'Timestamp when the ingester noticed the field delta. Upper '
+    'bound for when the true change landed at SEC — if you need a '
+    'tighter timestamp, correlate with the preceding log entry '
+    'for the same field.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -48,6 +48,7 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "cik_upsert_timing",  # #418 per-CIK timing audit (FK → data_ingestion_runs)
     "financial_facts_raw",
     "sec_facts_concept_catalog",  # #451 — per-concept metadata
+    "sec_entity_change_log",  # #463 — entity-field change events
     "data_ingestion_runs",
     # layer_enabled is the home of the #414 fundamentals_ingest pause
     # flag and is written by several observability/planner tests. Keep

--- a/tests/test_sec_entity_change_log.py
+++ b/tests/test_sec_entity_change_log.py
@@ -73,6 +73,14 @@ class TestLongTailFieldExtraction:
         assert _address({"street1": "", "city": None}) is None
         assert _address(None) is None
 
+    def test_integer_only_address_field_is_not_dropped(self) -> None:
+        """Regression: ``isForeignLocation: 0`` is SEC's explicit
+        'not foreign' marker. The address block must NOT be dropped
+        as empty when that's the only populated field."""
+        result = _address({"isForeignLocation": 0})
+        assert result is not None
+        assert result["is_foreign_location"] == 0
+
     def test_missing_addresses_key_leaves_none(self) -> None:
         payload = {"cik": "0000002098"}
         profile = parse_entity_profile(payload, instrument_id=1, cik="0000002098")

--- a/tests/test_sec_entity_change_log.py
+++ b/tests/test_sec_entity_change_log.py
@@ -167,9 +167,7 @@ class TestUpsertAppendsChangeLog:
         conn.commit()
         return int(row[0])
 
-    def test_first_ingest_writes_no_change_log_entries(
-        self, ebull_test_conn: psycopg.Connection[tuple]
-    ) -> None:
+    def test_first_ingest_writes_no_change_log_entries(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         iid = self._seed_instrument(ebull_test_conn)
         upsert_entity_profile(ebull_test_conn, _profile(instrument_id=iid))
         ebull_test_conn.commit()
@@ -182,9 +180,7 @@ class TestUpsertAppendsChangeLog:
         assert row is not None
         assert row[0] == 0
 
-    def test_second_ingest_writes_one_row_per_changed_field(
-        self, ebull_test_conn: psycopg.Connection[tuple]
-    ) -> None:
+    def test_second_ingest_writes_one_row_per_changed_field(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         iid = self._seed_instrument(ebull_test_conn, iid=902)
         # First ingest.
         upsert_entity_profile(ebull_test_conn, _profile(instrument_id=iid))
@@ -209,9 +205,7 @@ class TestUpsertAppendsChangeLog:
         # No spurious entries for unchanged fields.
         assert "fiscal_year_end" not in field_names
 
-    def test_reader_returns_new_long_tail_fields(
-        self, ebull_test_conn: psycopg.Connection[tuple]
-    ) -> None:
+    def test_reader_returns_new_long_tail_fields(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         iid = self._seed_instrument(ebull_test_conn, iid=903)
         upsert_entity_profile(
             ebull_test_conn,

--- a/tests/test_sec_entity_change_log.py
+++ b/tests/test_sec_entity_change_log.py
@@ -14,7 +14,6 @@ from app.services.sec_entity_profile import (
     upsert_entity_profile,
 )
 
-
 # ---------------------------------------------------------------------------
 # Pure extraction — new long-tail fields
 # ---------------------------------------------------------------------------

--- a/tests/test_sec_entity_change_log.py
+++ b/tests/test_sec_entity_change_log.py
@@ -1,0 +1,232 @@
+"""Tests for SEC entity change-log + long-tail field capture (#463)."""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.services.sec_entity_profile import (
+    SecEntityProfile,
+    _address,
+    detect_profile_changes,
+    get_entity_profile,
+    parse_entity_profile,
+    upsert_entity_profile,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure extraction — new long-tail fields
+# ---------------------------------------------------------------------------
+
+
+class TestLongTailFieldExtraction:
+    def test_phone_entity_type_flags_captured(self) -> None:
+        payload = {
+            "cik": "0000002098",
+            "phone": "203-254-6060",
+            "entityType": "operating",
+            "flags": "",
+        }
+        profile = parse_entity_profile(payload, instrument_id=1, cik="0000002098")
+        assert profile.phone == "203-254-6060"
+        assert profile.entity_type == "operating"
+        # Empty flags normalises to None (consistent with other string
+        # fields).
+        assert profile.flags is None
+
+    def test_addresses_normalised_to_snake_case(self) -> None:
+        payload = {
+            "cik": "0000002098",
+            "addresses": {
+                "business": {
+                    "street1": "1 WATERVIEW DRIVE",
+                    "street2": None,
+                    "city": "SHELTON",
+                    "stateOrCountry": "CT",
+                    "stateOrCountryDescription": "CT",
+                    "zipCode": "06484",
+                    "country": None,
+                    "countryCode": None,
+                    "isForeignLocation": 0,
+                    "foreignStateTerritory": None,
+                },
+                "mailing": {
+                    "street1": "1 WATERVIEW DRIVE",
+                    "city": "SHELTON",
+                    "stateOrCountry": "CT",
+                    "stateOrCountryDescription": "CT",
+                    "zipCode": "06484",
+                },
+            },
+        }
+        profile = parse_entity_profile(payload, instrument_id=1, cik="0000002098")
+        assert profile.address_business is not None
+        assert profile.address_business["street1"] == "1 WATERVIEW DRIVE"
+        assert profile.address_business["city"] == "SHELTON"
+        assert profile.address_business["state_or_country"] == "CT"
+        assert profile.address_business["zip_code"] == "06484"
+        assert profile.address_mailing is not None
+        assert profile.address_mailing["city"] == "SHELTON"
+
+    def test_empty_address_block_returns_none(self) -> None:
+        assert _address({}) is None
+        assert _address({"street1": "", "city": None}) is None
+        assert _address(None) is None
+
+    def test_missing_addresses_key_leaves_none(self) -> None:
+        payload = {"cik": "0000002098"}
+        profile = parse_entity_profile(payload, instrument_id=1, cik="0000002098")
+        assert profile.address_business is None
+        assert profile.address_mailing is None
+
+
+# ---------------------------------------------------------------------------
+# detect_profile_changes — pure diff logic
+# ---------------------------------------------------------------------------
+
+
+def _profile(**overrides: object) -> SecEntityProfile:
+    base: dict[str, object] = {
+        "instrument_id": 1,
+        "cik": "0000001",
+        "sic": "2810",
+        "sic_description": "Chemicals",
+        "owner_org": "08 Industrial",
+        "description": None,
+        "website": None,
+        "investor_website": None,
+        "ein": None,
+        "lei": None,
+        "state_of_incorporation": "DE",
+        "state_of_incorporation_desc": "DE",
+        "fiscal_year_end": "1231",
+        "category": "Large accelerated filer",
+        "exchanges": ["NYSE"],
+        "former_names": [],
+        "has_insider_issuer": True,
+        "has_insider_owner": False,
+        "phone": "555-0100",
+        "entity_type": "operating",
+        "flags": None,
+        "address_business": {"street1": "1 Main St", "city": "Town"},
+        "address_mailing": {"street1": "1 Main St", "city": "Town"},
+    }
+    base.update(overrides)
+    return SecEntityProfile(**base)  # type: ignore[arg-type]
+
+
+class TestDetectProfileChanges:
+    def test_initial_ingest_emits_no_changes(self) -> None:
+        assert detect_profile_changes(None, _profile()) == []
+
+    def test_identical_profiles_no_changes(self) -> None:
+        assert detect_profile_changes(_profile(), _profile()) == []
+
+    def test_sic_change_surfaces(self) -> None:
+        changes = detect_profile_changes(
+            _profile(sic="2810"),
+            _profile(sic="2820"),
+        )
+        names = {name for name, _, _ in changes}
+        assert "sic" in names
+
+    def test_address_change_detected_via_dict_diff(self) -> None:
+        old = _profile(address_business={"street1": "1 Main St", "city": "Town"})
+        new = _profile(address_business={"street1": "2 Oak Rd", "city": "Town"})
+        changes = detect_profile_changes(old, new)
+        names = {name for name, _, _ in changes}
+        assert "address_business" in names
+
+    def test_exchange_list_reorder_detected(self) -> None:
+        """Order matters — SEC publishes a stable listing order so
+        a reorder IS a change."""
+        changes = detect_profile_changes(
+            _profile(exchanges=["NYSE", "NASDAQ"]),
+            _profile(exchanges=["NASDAQ", "NYSE"]),
+        )
+        names = {name for name, _, _ in changes}
+        assert "exchanges" in names
+
+
+# ---------------------------------------------------------------------------
+# Integration — upsert writes change log rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestUpsertAppendsChangeLog:
+    def _seed_instrument(self, conn: psycopg.Connection[tuple], iid: int = 901) -> int:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO instruments (instrument_id, symbol, company_name) "
+                "VALUES (%s, %s, %s) RETURNING instrument_id",
+                (iid, "APEX", "Apex Inc."),
+            )
+            row = cur.fetchone()
+            assert row is not None
+        conn.commit()
+        return int(row[0])
+
+    def test_first_ingest_writes_no_change_log_entries(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid = self._seed_instrument(ebull_test_conn)
+        upsert_entity_profile(ebull_test_conn, _profile(instrument_id=iid))
+        ebull_test_conn.commit()
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM sec_entity_change_log WHERE instrument_id = %s",
+                (iid,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+
+    def test_second_ingest_writes_one_row_per_changed_field(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid = self._seed_instrument(ebull_test_conn, iid=902)
+        # First ingest.
+        upsert_entity_profile(ebull_test_conn, _profile(instrument_id=iid))
+        # Second ingest with sic + website changed.
+        upsert_entity_profile(
+            ebull_test_conn,
+            _profile(instrument_id=iid, sic="9999", website="https://new.example.com"),
+        )
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT field_name, prev_value, new_value "
+                "FROM sec_entity_change_log WHERE instrument_id = %s "
+                "ORDER BY field_name",
+                (iid,),
+            )
+            rows = cur.fetchall()
+        field_names = {r[0] for r in rows}
+        assert "sic" in field_names
+        assert "website" in field_names
+        # No spurious entries for unchanged fields.
+        assert "fiscal_year_end" not in field_names
+
+    def test_reader_returns_new_long_tail_fields(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid = self._seed_instrument(ebull_test_conn, iid=903)
+        upsert_entity_profile(
+            ebull_test_conn,
+            _profile(
+                instrument_id=iid,
+                phone="555-7777",
+                entity_type="investment",
+                address_business={"street1": "42 Elm St", "city": "Springfield"},
+            ),
+        )
+        ebull_test_conn.commit()
+        stored = get_entity_profile(ebull_test_conn, instrument_id=iid)
+        assert stored is not None
+        assert stored.phone == "555-7777"
+        assert stored.entity_type == "investment"
+        assert stored.address_business is not None
+        assert stored.address_business["street1"] == "42 Elm St"


### PR DESCRIPTION
## Summary
- instrument_sec_profile extends with phone, entity_type, flags, address_business, address_mailing.
- New sec_entity_change_log table: append-only change events for 16 tracked entity fields (SIC, sector, owner_org, address, fiscal year, exchanges, etc.).
- Change detection runs on each upsert — diff against stored row, emit one log row per differing field. Initial ingest no-op.

## Test plan
- [x] uv run ruff check / format / pyright (all clean)
- [x] uv run pytest (2627 passed)

## Phase B
- #464 — retire submissions.json disk dump after SQL coverage verified.