### PR TITLE
feat(#464 #466): flip sec + sec_fundamentals raw retention to 30-day rolling

### DIFF
--- a/app/services/raw_persistence.py
+++ b/app/services/raw_persistence.py
@@ -73,9 +73,16 @@ class RetentionPolicy:
 
 
 # Per-source rationale:
-# - sec_fundamentals / sec / companies_house: NO age-based delete.
-#   Raw bodies are small post-dedup; re-fetching SEC is rate-limited
-#   + slow; reproducible audit trail costs nothing.
+# - sec_fundamentals / sec: 30 days rolling. Full SQL coverage landed
+#   across #449 / #450 / #451 / #452 / #463, so every structured field
+#   from companyfacts.json, submissions.json, and filing-index JSON
+#   is queryable in SQL. The raw dump is a short-lived audit trail
+#   (catch a parser regression within 30 days), not a parser
+#   substrate. Previously ``None`` (retain forever); flipped to 30
+#   days under #464 + #466 to reclaim ~12 GB of disk.
+# - companies_house: NO age-based delete. Coverage is thinner than
+#   SEC so the raw Companies House payloads are still the parser
+#   substrate for some fields.
 # - etoro: 7 days covers OHLCV candles (redundant with price_daily),
 #   instrument lists, quote batches, and error bodies collectively.
 #   If a longer diagnostic trail is ever needed, split etoro into
@@ -84,8 +91,16 @@ class RetentionPolicy:
 #   reconciling position / cash discrepancies.
 # - fmp: fallback only; 30 days is enough for re-derivation.
 _RETENTION_POLICY: dict[str, RetentionPolicy] = {
-    "sec_fundamentals": RetentionPolicy(max_age_days=None, max_duplicate_files_per_hash=1),
-    "sec": RetentionPolicy(max_age_days=None, max_duplicate_files_per_hash=1),
+    # sec_fundamentals / sec: flipped to 30 days rolling (#464 / #466).
+    # End-to-end SQL coverage is complete — every field from
+    # companyfacts.json lands in financial_facts_raw + sec_facts_concept_catalog
+    # (#451), submissions.json lands in instrument_sec_profile +
+    # sec_entity_change_log (#463 / #427), and filing-index JSON
+    # lands in filing_documents (#452). The raw dump is now a
+    # short-lived audit trail, not a parser substrate — 30 days is
+    # enough to catch any regression introduced by a parser bump.
+    "sec_fundamentals": RetentionPolicy(max_age_days=30, max_duplicate_files_per_hash=1),
+    "sec": RetentionPolicy(max_age_days=30, max_duplicate_files_per_hash=1),
     "etoro": RetentionPolicy(max_age_days=7, max_duplicate_files_per_hash=1),
     "etoro_broker": RetentionPolicy(max_age_days=90, max_duplicate_files_per_hash=1),
     "fmp": RetentionPolicy(max_age_days=30, max_duplicate_files_per_hash=1),

--- a/tests/test_raw_retention.py
+++ b/tests/test_raw_retention.py
@@ -251,16 +251,49 @@ class TestCompactSource:
 
 class TestSweepSource:
     def test_none_retention_is_noop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """sec_fundamentals policy has max_age_days=None → sweep never
-        deletes regardless of file age."""
+        """companies_house policy has max_age_days=None → sweep never
+        deletes regardless of file age. Previously this test used
+        sec_fundamentals; the policy flipped to 30-day rolling under
+        #464 + #466 once SQL coverage was complete."""
+        monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
+        ch_dir = tmp_path / "companies_house"
+        _seed(ch_dir, "ch_12345_20200101T120000Z.json", {"x": 1}, age=timedelta(days=365 * 5))
+
+        result = sweep_source("companies_house", dry_run=False)
+
+        assert result.files_deleted == 0
+        assert len(list(ch_dir.iterdir())) == 1
+
+    def test_sec_fundamentals_30d_retention_deletes_old(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """#466 — sec_fundamentals policy flipped from ``None`` to
+        30 days once end-to-end SQL coverage landed. Files older
+        than the window are swept; fresh files survive."""
         monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
         sec_dir = tmp_path / "sec_fundamentals"
-        _seed(sec_dir, "sec_facts_AAA_20200101T120000Z.json", {"x": 1}, age=timedelta(days=365 * 5))
+        _seed(sec_dir, "sec_facts_AAA_old.json", {"x": 1}, age=timedelta(days=60))
+        _seed(sec_dir, "sec_facts_BBB_fresh.json", {"y": 2}, age=timedelta(days=10))
 
         result = sweep_source("sec_fundamentals", dry_run=False)
 
-        assert result.files_deleted == 0
-        assert len(list(sec_dir.iterdir())) == 1
+        assert result.files_deleted == 1
+        remaining = {p.name for p in sec_dir.iterdir()}
+        assert "sec_facts_BBB_fresh.json" in remaining
+        assert "sec_facts_AAA_old.json" not in remaining
+
+    def test_sec_30d_retention_deletes_old(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """#464 — sec policy flipped from ``None`` to 30 days once
+        submissions / filing-index / tickers all normalised into SQL."""
+        monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
+        sec_dir = tmp_path / "sec"
+        _seed(sec_dir, "sec_submissions_0000000001_old.json", {"x": 1}, age=timedelta(days=45))
+        _seed(sec_dir, "sec_submissions_0000000002_fresh.json", {"y": 2}, age=timedelta(days=5))
+
+        result = sweep_source("sec", dry_run=False)
+
+        assert result.files_deleted == 1
+        remaining = {p.name for p in sec_dir.iterdir()}
+        assert "sec_submissions_0000000002_fresh.json" in remaining
+        assert "sec_submissions_0000000001_old.json" not in remaining
 
     def test_deletes_files_older_than_policy(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """etoro policy has max_age_days=7 → files older than 7 days


### PR DESCRIPTION
## Summary
- Retires the 11 GB sec_fundamentals and 1.1 GB sec disk dumps. Retention policy flipped from retain-forever to 30-day rolling now that #449/#450/#451/#452/#463 shipped full SQL coverage.
- Raw files age out as unchanged content hashes stop being rewritten. New regression tests pin both 30-day windows.

## Closes
- #464 (sec submissions retirement)
- #466 (sec_fundamentals retirement)
- Completes the #448 structured-field-persistence rule family.

## Test plan
- [x] uv run ruff check / format / pyright (all clean)
- [x] uv run pytest (2630 passed)
- [x] Dry-run sweep on dev: 0 files would delete today (all <30d); mechanism ready for natural age-out.