### PR TITLE
fix(#470): drop raw persistence for sec + sec_fundamentals sources

### DIFF
--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -36,7 +36,6 @@ import httpx
 
 from app.providers.filings import FilingEvent, FilingNotFound, FilingSearchResult, FilingsProvider
 from app.providers.resilient_client import ResilientClient
-from app.services import raw_persistence
 
 _ET = ZoneInfo("America/New_York")
 
@@ -285,14 +284,6 @@ class SecFilingsProvider(FilingsProvider):
         parsed = resp.json()
         if not isinstance(parsed, dict):
             return None
-        # Persist raw audit trail — same contract as the other
-        # provider-JSON methods in this file. The structural capture
-        # into SQL happens in the service layer (#452).
-        raw_persistence.persist_raw_if_new(
-            "sec",
-            f"sec_filing_{provider_filing_id.replace('/', '_')}",
-            parsed,
-        )
         return parsed
 
     def fetch_document_text(self, absolute_url: str) -> str | None:
@@ -348,7 +339,6 @@ class SecFilingsProvider(FilingsProvider):
         resp = self._http_tickers.get(_TICKERS_URL)
         resp.raise_for_status()
         raw = resp.json()
-        raw_persistence.persist_raw_if_new("sec", "sec_tickers", raw)
         return _parse_cik_mapping(raw)
 
     def build_cik_mapping_conditional(
@@ -388,7 +378,6 @@ class SecFilingsProvider(FilingsProvider):
         # might mutate the content view.
         body_hash = hashlib.sha256(resp.content).hexdigest()
         raw = resp.json()
-        raw_persistence.persist_raw_if_new("sec", "sec_tickers", raw)
         return CikMappingResult(
             mapping=_parse_cik_mapping(raw),
             body_hash=body_hash,
@@ -500,7 +489,6 @@ class SecFilingsProvider(FilingsProvider):
             return None
         resp.raise_for_status()
         raw = resp.json()
-        raw_persistence.persist_raw_if_new("sec", f"sec_submissions_page_{name}", raw)
         return raw  # type: ignore[return-value]
 
     # ------------------------------------------------------------------
@@ -515,7 +503,6 @@ class SecFilingsProvider(FilingsProvider):
             return None
         resp.raise_for_status()
         raw = resp.json()
-        raw_persistence.persist_raw_if_new("sec", f"sec_submissions_{cik_padded}", raw)
         return raw  # type: ignore[return-value]
 
 

--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -45,7 +45,6 @@ from app.providers.fundamentals import (
     XbrlFact,
 )
 from app.providers.resilient_client import ResilientClient
-from app.services import raw_persistence
 
 logger = logging.getLogger(__name__)
 
@@ -504,10 +503,8 @@ class SecFundamentalsProvider(FundamentalsProvider):
         if resp.status_code == 404:
             logger.info("SEC fundamentals: no company facts for CIK %s", cik)
             return None
-        # Persist raw response before raise — non-negotiable for auditability.
-        raw = resp.json()
-        raw_persistence.persist_raw_if_new("sec_fundamentals", f"sec_facts_{cik_padded}", raw)
         resp.raise_for_status()
+        raw = resp.json()
         return raw  # type: ignore[no-any-return]
 
 

--- a/app/services/raw_persistence.py
+++ b/app/services/raw_persistence.py
@@ -73,13 +73,16 @@ class RetentionPolicy:
 
 
 # Per-source rationale:
-# - sec_fundamentals / sec: 30 days rolling. Full SQL coverage landed
-#   across #449 / #450 / #451 / #452 / #463, so every structured field
-#   from companyfacts.json, submissions.json, and filing-index JSON
-#   is queryable in SQL. The raw dump is a short-lived audit trail
-#   (catch a parser regression within 30 days), not a parser
-#   substrate. Previously ``None`` (retain forever); flipped to 30
-#   days under #464 + #466 to reclaim ~12 GB of disk.
+# - sec_fundamentals / sec: NO new raw writes. The providers stopped
+#   calling ``persist_raw_if_new`` under #470 once SQL coverage was
+#   complete (every structured field from companyfacts.json,
+#   submissions.json, and filing-index JSON lands in
+#   financial_facts_raw + sec_facts_concept_catalog +
+#   instrument_sec_profile + sec_entity_change_log + filing_documents).
+#   Retention is set to ``max_age_days=0`` so the next sweep tick
+#   reclaims the existing ~12 GB on disk from prior runs. Policy
+#   entries remain in this map so ``sweep_source`` still works for
+#   the cleanup — removing them would KeyError on sweep.
 # - companies_house: NO age-based delete. Coverage is thinner than
 #   SEC so the raw Companies House payloads are still the parser
 #   substrate for some fields.
@@ -91,16 +94,11 @@ class RetentionPolicy:
 #   reconciling position / cash discrepancies.
 # - fmp: fallback only; 30 days is enough for re-derivation.
 _RETENTION_POLICY: dict[str, RetentionPolicy] = {
-    # sec_fundamentals / sec: flipped to 30 days rolling (#464 / #466).
-    # End-to-end SQL coverage is complete — every field from
-    # companyfacts.json lands in financial_facts_raw + sec_facts_concept_catalog
-    # (#451), submissions.json lands in instrument_sec_profile +
-    # sec_entity_change_log (#463 / #427), and filing-index JSON
-    # lands in filing_documents (#452). The raw dump is now a
-    # short-lived audit trail, not a parser substrate — 30 days is
-    # enough to catch any regression introduced by a parser bump.
-    "sec_fundamentals": RetentionPolicy(max_age_days=30, max_duplicate_files_per_hash=1),
-    "sec": RetentionPolicy(max_age_days=30, max_duplicate_files_per_hash=1),
+    # sec_fundamentals / sec: no new writes (providers stopped
+    # calling persist_raw_if_new under #470). Retention at 0 so the
+    # next sweep reclaims the ~12 GB of prior writes on disk.
+    "sec_fundamentals": RetentionPolicy(max_age_days=0, max_duplicate_files_per_hash=1),
+    "sec": RetentionPolicy(max_age_days=0, max_duplicate_files_per_hash=1),
     "etoro": RetentionPolicy(max_age_days=7, max_duplicate_files_per_hash=1),
     "etoro_broker": RetentionPolicy(max_age_days=90, max_duplicate_files_per_hash=1),
     "fmp": RetentionPolicy(max_age_days=30, max_duplicate_files_per_hash=1),

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -527,6 +527,7 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - First seen in: #171
 - Symptom: `get_quotes()` caught `httpx.HTTPStatusError` on a 500 response but skipped the chunk without persisting the error response body. The 500 body (which may contain diagnostic info from the upstream API) was silently discarded, violating the raw-payload persistence rule.
 - Prevention: When catching `httpx.HTTPStatusError` in provider code to skip/continue, call `_persist_raw(tag + "_error", exc.response.text)` before logging or continuing. Network errors (`httpx.RequestError`) have no response body — log with `exc_info` only.
+- **Scope narrowed (#470, 2026-04-24):** the "raw payload persistence" imperative only applies to sources whose SQL normalisation is incomplete. Once every structured field lands in SQL (as for `sec`/`sec_fundamentals` post #449/#450/#451/#452/#463), raw disk persistence is redundant, not audit — operator explicitly directed drop-on-process. The rule stands for `companies_house`, `etoro`, `etoro_broker`, `fmp` whose SQL coverage is thinner.
 - Enforced in: this prevention log
 
 ---

--- a/tests/test_raw_retention.py
+++ b/tests/test_raw_retention.py
@@ -264,36 +264,52 @@ class TestSweepSource:
         assert result.files_deleted == 0
         assert len(list(ch_dir.iterdir())) == 1
 
-    def test_sec_fundamentals_30d_retention_deletes_old(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """#466 — sec_fundamentals policy flipped from ``None`` to
-        30 days once end-to-end SQL coverage landed. Files older
-        than the window are swept; fresh files survive."""
+    def test_sec_fundamentals_zero_day_retention_sweeps_all_mutable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#470 — sec_fundamentals policy flipped to ``max_age_days=0``
+        once the providers stopped writing raw. Every file older than
+        the 24-hour min-age safeguard is swept so the existing 11 GB
+        dump reclaims in one pass."""
         monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
         sec_dir = tmp_path / "sec_fundamentals"
-        _seed(sec_dir, "sec_facts_AAA_old.json", {"x": 1}, age=timedelta(days=60))
-        _seed(sec_dir, "sec_facts_BBB_fresh.json", {"y": 2}, age=timedelta(days=10))
+        _seed(sec_dir, "sec_facts_AAA.json", {"x": 1}, age=timedelta(days=60))
+        _seed(sec_dir, "sec_facts_BBB.json", {"y": 2}, age=timedelta(days=2))
 
         result = sweep_source("sec_fundamentals", dry_run=False)
 
-        assert result.files_deleted == 1
-        remaining = {p.name for p in sec_dir.iterdir()}
-        assert "sec_facts_BBB_fresh.json" in remaining
-        assert "sec_facts_AAA_old.json" not in remaining
+        assert result.files_deleted == 2
+        assert list(sec_dir.iterdir()) == []
 
-    def test_sec_30d_retention_deletes_old(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """#464 — sec policy flipped from ``None`` to 30 days once
-        submissions / filing-index / tickers all normalised into SQL."""
+    def test_sec_zero_day_retention_sweeps_all_mutable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """#470 — sec policy flipped to ``max_age_days=0``."""
         monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
         sec_dir = tmp_path / "sec"
-        _seed(sec_dir, "sec_submissions_0000000001_old.json", {"x": 1}, age=timedelta(days=45))
-        _seed(sec_dir, "sec_submissions_0000000002_fresh.json", {"y": 2}, age=timedelta(days=5))
+        _seed(sec_dir, "sec_submissions_0000000001.json", {"x": 1}, age=timedelta(days=45))
+        _seed(sec_dir, "sec_submissions_0000000002.json", {"y": 2}, age=timedelta(days=2))
+
+        result = sweep_source("sec", dry_run=False)
+
+        assert result.files_deleted == 2
+        assert list(sec_dir.iterdir()) == []
+
+    def test_sec_min_age_safeguard_still_protects_recent_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#470 — files younger than the 24-hour min-age safeguard
+        are preserved even with max_age_days=0. Defensive against a
+        rogue re-introduction of raw writes."""
+        monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
+        sec_dir = tmp_path / "sec"
+        _seed(sec_dir, "sec_submissions_recent.json", {"x": 1}, age=timedelta(hours=2))
+        _seed(sec_dir, "sec_submissions_old.json", {"y": 2}, age=timedelta(days=2))
 
         result = sweep_source("sec", dry_run=False)
 
         assert result.files_deleted == 1
         remaining = {p.name for p in sec_dir.iterdir()}
-        assert "sec_submissions_0000000002_fresh.json" in remaining
-        assert "sec_submissions_0000000001_old.json" not in remaining
+        assert "sec_submissions_recent.json" in remaining
+        assert "sec_submissions_old.json" not in remaining
 
     def test_deletes_files_older_than_policy(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """etoro policy has max_age_days=7 → files older than 7 days


### PR DESCRIPTION
## Summary
- Providers stop calling persist_raw_if_new for SEC sources entirely. Every field is already in SQL via #449/#450/#451/#452/#463.
- Retention flipped to max_age_days=0 so the existing 12 GB reclaims on the next sweep.
- Live verification on dev: reclaimed 10.98 GB from sec_fundamentals + ~1 GB from sec.

## Test plan
- [x] uv run ruff / format / pyright (clean)
- [x] uv run pytest (2631 passed)
- [x] Live: sweep_source reclaimed 5648 files on dev DB