### PR TITLE
fix(#471): drop raw persistence for etoro + etoro_broker (Phase A)

### DIFF
--- a/app/providers/implementations/etoro.py
+++ b/app/providers/implementations/etoro.py
@@ -20,7 +20,6 @@ import httpx
 from app.config import settings
 from app.providers.market_data import InstrumentRecord, MarketDataProvider, OHLCVBar, Quote
 from app.providers.resilient_client import ResilientClient
-from app.services import raw_persistence
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +92,6 @@ class EtoroMarketDataProvider(MarketDataProvider):
         )
         response.raise_for_status()
         raw = response.json()
-        raw_persistence.persist_raw_if_new("etoro", "instruments", raw)
         return _normalise_instruments(raw)
 
     # ------------------------------------------------------------------
@@ -112,7 +110,6 @@ class EtoroMarketDataProvider(MarketDataProvider):
         )
         response.raise_for_status()
         raw = response.json()
-        raw_persistence.persist_raw_if_new("etoro", f"candles_{instrument_id}", raw)
         return _normalise_candles(raw)
 
     # ------------------------------------------------------------------
@@ -154,13 +151,16 @@ class EtoroMarketDataProvider(MarketDataProvider):
                 )
                 response.raise_for_status()
             except httpx.HTTPStatusError as exc:
-                # Persist the error response body for diagnosis.
-                raw_persistence.persist_raw_if_new("etoro", f"rates_batch{batch_num}_error", exc.response.text)
+                # #471: error body no longer persisted to disk per the
+                # SQL-coverage-replaces-raw rule (#470). Status + body
+                # snippet captured in the log line via exc_info so the
+                # diagnostic survives without a separate disk file.
                 logger.warning(
-                    "Rates chunk %d failed (%d IDs, status %d), skipping",
+                    "Rates chunk %d failed (%d IDs, status %d, body=%r), skipping",
                     batch_num,
                     len(chunk),
                     exc.response.status_code,
+                    exc.response.text[:500],
                     exc_info=True,
                 )
                 failed_chunks += 1
@@ -176,7 +176,6 @@ class EtoroMarketDataProvider(MarketDataProvider):
                 failed_chunks += 1
                 continue
             raw = response.json()
-            raw_persistence.persist_raw_if_new("etoro", f"rates_batch{batch_num}", raw)
             all_quotes.extend(_normalise_rates(raw))
 
         if failed_chunks:

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -33,7 +33,6 @@ from app.providers.broker import (
     OrderStatus,
 )
 from app.providers.resilient_client import ResilientClient
-from app.services import raw_persistence
 
 logger = logging.getLogger(__name__)
 
@@ -401,10 +400,6 @@ class EtoroBrokerProvider(BrokerProvider):
             f"{self._info_prefix}/portfolio",
             headers=self._request_headers(),
         )
-        # Best-effort raw persist. Helper swallows OSError internally
-        # (logs + returns None); sync must continue with parsed
-        # response regardless.
-        raw_persistence.persist_raw_if_new("etoro_broker", "etoro_portfolio", response.content)
         response.raise_for_status()
         raw = response.json()
 

--- a/app/services/raw_persistence.py
+++ b/app/services/raw_persistence.py
@@ -73,16 +73,16 @@ class RetentionPolicy:
 
 
 # Per-source rationale:
-# - sec_fundamentals / sec: NO new raw writes. The providers stopped
-#   calling ``persist_raw_if_new`` under #470 once SQL coverage was
-#   complete (every structured field from companyfacts.json,
-#   submissions.json, and filing-index JSON lands in
-#   financial_facts_raw + sec_facts_concept_catalog +
-#   instrument_sec_profile + sec_entity_change_log + filing_documents).
-#   Retention is set to ``max_age_days=0`` so the next sweep tick
-#   reclaims the existing ~12 GB on disk from prior runs. Policy
-#   entries remain in this map so ``sweep_source`` still works for
-#   the cleanup — removing them would KeyError on sweep.
+# - sec_fundamentals / sec: NO new raw writes (#470). All structured
+#   fields from companyfacts.json, submissions.json, and filing-index
+#   JSON land in SQL.
+# - etoro / etoro_broker: NO new raw writes (#471). Instruments,
+#   candles, quotes, and broker portfolio all land in SQL via the
+#   existing pipeline (instruments / price_daily / quotes /
+#   broker_positions / cash_ledger / copy_mirror_positions).
+# - All four sources kept in the policy map at max_age_days=0 so
+#   ``sweep_source`` still works for the residual cleanup —
+#   removing them would KeyError on sweep.
 # - companies_house: NO age-based delete. Coverage is thinner than
 #   SEC so the raw Companies House payloads are still the parser
 #   substrate for some fields.
@@ -99,8 +99,12 @@ _RETENTION_POLICY: dict[str, RetentionPolicy] = {
     # next sweep reclaims the ~12 GB of prior writes on disk.
     "sec_fundamentals": RetentionPolicy(max_age_days=0, max_duplicate_files_per_hash=1),
     "sec": RetentionPolicy(max_age_days=0, max_duplicate_files_per_hash=1),
-    "etoro": RetentionPolicy(max_age_days=7, max_duplicate_files_per_hash=1),
-    "etoro_broker": RetentionPolicy(max_age_days=90, max_duplicate_files_per_hash=1),
+    # etoro / etoro_broker: providers stopped writing raw under #471
+    # — instruments / candles / quotes / portfolio all land in SQL
+    # via the existing pipeline. Policy at 0 so the next sweep
+    # reclaims residual files past the 24-hour safeguard.
+    "etoro": RetentionPolicy(max_age_days=0, max_duplicate_files_per_hash=1),
+    "etoro_broker": RetentionPolicy(max_age_days=0, max_duplicate_files_per_hash=1),
     "fmp": RetentionPolicy(max_age_days=30, max_duplicate_files_per_hash=1),
     "companies_house": RetentionPolicy(max_age_days=None, max_duplicate_files_per_hash=1),
 }

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -527,7 +527,13 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - First seen in: #171
 - Symptom: `get_quotes()` caught `httpx.HTTPStatusError` on a 500 response but skipped the chunk without persisting the error response body. The 500 body (which may contain diagnostic info from the upstream API) was silently discarded, violating the raw-payload persistence rule.
 - Prevention: When catching `httpx.HTTPStatusError` in provider code to skip/continue, call `_persist_raw(tag + "_error", exc.response.text)` before logging or continuing. Network errors (`httpx.RequestError`) have no response body — log with `exc_info` only.
-- **Scope narrowed (#470, 2026-04-24):** the "raw payload persistence" imperative only applies to sources whose SQL normalisation is incomplete. Once every structured field lands in SQL (as for `sec`/`sec_fundamentals` post #449/#450/#451/#452/#463), raw disk persistence is redundant, not audit — operator explicitly directed drop-on-process. The rule stands for `companies_house`, `etoro`, `etoro_broker`, `fmp` whose SQL coverage is thinner.
+- **Scope narrowed (#470, 2026-04-24):** the "raw payload persistence" imperative only applies to sources whose SQL normalisation is incomplete. Once every structured field lands in SQL (as for `sec`/`sec_fundamentals` post #449/#450/#451/#452/#463), raw disk persistence is redundant, not audit — operator explicitly directed drop-on-process.
+- **Further narrowed (#471, 2026-04-24):** `etoro` + `etoro_broker` SQL coverage audit completed and provider-side raw writes dropped. Coverage map:
+  - `etoro/instruments` → `instruments` table (provider_id, symbol, company_name, exchange, sector, is_tradable; `currency` enriched separately by FMP per the live-pricing spec).
+  - `etoro/candles_*` → `price_daily` (price_date, open, high, low, close, volume).
+  - `etoro/rates_batch*` → `quotes` (instrument_id, bid, ask, last_execution, date).
+  - `etoro_broker/etoro_portfolio` → `broker_positions` + `cash_ledger` + `copy_mirror_positions` (full position + cash + mirror snapshot).
+- **Rule remaining scope:** stands for `companies_house` and `fmp` whose SQL coverage is thinner; raw payloads still serve as parser substrate there until coverage audits land.
 - Enforced in: this prevention log
 
 ---

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import httpx
 
@@ -645,9 +645,8 @@ FIXTURE_FULL_PORTFOLIO_RESPONSE = {
 }
 
 
-@patch("app.providers.implementations.etoro_broker.raw_persistence.persist_raw_if_new")
 class TestGetPortfolio:
-    def test_returns_positions_and_cash(self, _mock_persist: MagicMock) -> None:
+    def test_returns_positions_and_cash(self) -> None:
         mock_resp = MagicMock()
         mock_resp.json.return_value = FIXTURE_FULL_PORTFOLIO_RESPONSE
         mock_resp.content = b"{}"
@@ -694,7 +693,7 @@ class TestGetPortfolio:
         assert p2.stop_loss_rate is None
         assert p2.take_profit_rate is None
 
-    def test_empty_portfolio(self, _mock_persist: MagicMock) -> None:
+    def test_empty_portfolio(self) -> None:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"clientPortfolio": {"positions": [], "credit": 100000}}
         mock_resp.content = b"{}"
@@ -710,7 +709,7 @@ class TestGetPortfolio:
         assert len(result.positions) == 0
         assert result.available_cash == Decimal("100000")
 
-    def test_missing_credit_defaults_to_zero(self, _mock_persist: MagicMock) -> None:
+    def test_missing_credit_defaults_to_zero(self) -> None:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"clientPortfolio": {"positions": []}}
         mock_resp.content = b"{}"
@@ -725,7 +724,7 @@ class TestGetPortfolio:
 
         assert result.available_cash == Decimal("0")
 
-    def test_calls_correct_endpoint(self, _mock_persist: MagicMock) -> None:
+    def test_calls_correct_endpoint(self) -> None:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"clientPortfolio": {"positions": [], "credit": 0}}
         mock_resp.content = b"{}"

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -10,7 +10,7 @@ from collections.abc import Sequence
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -322,8 +322,7 @@ class TestNormaliseRates:
 class TestGetQuotesChunking:
     """Test that get_quotes chunks IDs at 50 and builds correct params."""
 
-    @patch("app.providers.implementations.etoro.raw_persistence.persist_raw_if_new")
-    def test_empty_list_no_http_call(self, _mock_persist: MagicMock) -> None:
+    def test_empty_list_no_http_call(self) -> None:
         from app.providers.implementations.etoro import EtoroMarketDataProvider
 
         with EtoroMarketDataProvider(api_key="k", user_key="u") as provider:
@@ -332,8 +331,7 @@ class TestGetQuotesChunking:
             assert result == []
             provider._http.get.assert_not_called()
 
-    @patch("app.providers.implementations.etoro.raw_persistence.persist_raw_if_new")
-    def test_single_batch_params(self, _mock_persist: MagicMock) -> None:
+    def test_single_batch_params(self) -> None:
         """instrumentIds are inlined in the URL with raw commas (not percent-encoded)."""
         from app.providers.implementations.etoro import EtoroMarketDataProvider
 
@@ -351,8 +349,7 @@ class TestGetQuotesChunking:
             url_arg = provider._http.get.call_args.args[0]
             assert "instrumentIds=1001,1002,1003" in url_arg
 
-    @patch("app.providers.implementations.etoro.raw_persistence.persist_raw_if_new")
-    def test_chunking_at_51_ids(self, _mock_persist: MagicMock) -> None:
+    def test_chunking_at_51_ids(self) -> None:
         """51 IDs should produce exactly 2 HTTP requests (50 + 1)."""
         from app.providers.implementations.etoro import EtoroMarketDataProvider
 
@@ -377,8 +374,7 @@ class TestGetQuotesChunking:
             second_ids = second_url.split("instrumentIds=")[1].split("&")[0]
             assert len(second_ids.split(",")) == 1
 
-    @patch("app.providers.implementations.etoro.raw_persistence.persist_raw_if_new")
-    def test_failed_chunk_does_not_poison_others(self, _mock_persist: MagicMock) -> None:
+    def test_failed_chunk_does_not_poison_others(self) -> None:
         """If one chunk 500s, the rest still return quotes."""
         from app.providers.implementations.etoro import EtoroMarketDataProvider
 
@@ -405,12 +401,10 @@ class TestGetQuotesChunking:
             # Should return the quotes from the successful chunk
             assert len(result) == 1
             assert provider._http.get.call_count == 2
-            # Error response body must be persisted for diagnosis.
-            # Shared helper signature: persist_raw_if_new(source, tag, payload)
-            # — tag is positional arg index 1, payload is index 2.
-            persist_calls = {call[0][1]: call[0][2] for call in _mock_persist.call_args_list}
-            assert "rates_batch1_error" in persist_calls
-            assert '{"error":"internal"}' in persist_calls["rates_batch1_error"]
+            # Error body no longer persisted to disk under #471 — the
+            # raw-persistence path was retired now that SQL coverage
+            # is complete. Error diagnostics live in the log line via
+            # exc_info instead.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_raw_retention.py
+++ b/tests/test_raw_retention.py
@@ -312,17 +312,19 @@ class TestSweepSource:
         assert "sec_submissions_old.json" not in remaining
 
     def test_deletes_files_older_than_policy(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """etoro policy has max_age_days=7 → files older than 7 days
-        are deleted; newer preserved."""
+        """``fmp`` policy has max_age_days=30 → files older than 30
+        days are deleted; newer preserved. (Previously used
+        ``etoro`` at max_age_days=7; etoro flipped to 0 under #471
+        once SQL coverage replaced raw persistence.)"""
         monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
-        etoro_dir = tmp_path / "etoro"
-        _seed(etoro_dir, "old_20260101T120000Z.json", {"x": 1}, age=timedelta(days=10))
-        _seed(etoro_dir, "fresh_20260102T120000Z.json", {"y": 2}, age=timedelta(days=3))
+        fmp_dir = tmp_path / "fmp"
+        _seed(fmp_dir, "old_20260101T120000Z.json", {"x": 1}, age=timedelta(days=45))
+        _seed(fmp_dir, "fresh_20260102T120000Z.json", {"y": 2}, age=timedelta(days=10))
 
-        result = sweep_source("etoro", dry_run=False)
+        result = sweep_source("fmp", dry_run=False)
 
         assert result.files_deleted == 1
-        remaining = {p.name for p in etoro_dir.iterdir()}
+        remaining = {p.name for p in fmp_dir.iterdir()}
         assert "fresh_20260102T120000Z.json" in remaining
         assert "old_20260101T120000Z.json" not in remaining
 


### PR DESCRIPTION
## Summary
- Phase A cleanup mirroring #470 for eToro sources. All instruments / candles / quotes / portfolio fields already in SQL.
- Live verification on dev: 256 MB reclaimed (242 MB etoro + 14 MB etoro_broker).
- Phase B (#274 — WebSocket subscriber) is the live-price layer; out of scope here.

## Test plan
- [x] uv run ruff / format / pyright (clean)
- [x] uv run pytest (2631 passed)