### PR TITLE
feat(#274 Slice 1): eToro WebSocket live-price subscriber

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
 
 import psycopg
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -45,8 +46,18 @@ from app.db.migrations import migration_status, run_migrations
 from app.jobs.runtime import JobRuntime, shutdown_runtime, start_runtime
 from app.security import master_key
 from app.security.secrets_crypto import set_active_key as set_broker_encryption_key
+from app.services.broker_credentials import (
+    CredentialNotFound,
+    load_credential_for_provider_use,
+)
 from app.services.coverage import override_tier
+from app.services.etoro_websocket import EtoroWebSocketSubscriber
 from app.services.operator_setup import ensure_startup_token, operators_empty
+from app.services.operators import (
+    AmbiguousOperatorError,
+    NoOperatorError,
+    sole_operator_id,
+)
 from app.services.sync_orchestrator.layer_state import compute_layer_states_from_db
 from app.services.sync_orchestrator.layer_types import LayerState
 from app.services.sync_orchestrator.reaper import reap_orphaned_syncs
@@ -141,7 +152,20 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         except Exception:
             logger.exception("failed to register orchestrator executor")
 
+    # eToro WebSocket live-price subscriber (#274 Slice 1). Starts
+    # only when broker credentials are loadable — otherwise the
+    # operator hasn't completed setup yet and there's nothing to
+    # subscribe to. WS failures must NOT block the rest of the app.
+    ws_subscriber = await _maybe_start_etoro_ws(pool)
+    app.state.etoro_ws = ws_subscriber
+
     yield
+
+    if ws_subscriber is not None:
+        try:
+            await ws_subscriber.stop()
+        except Exception:
+            logger.exception("EtoroWebSocketSubscriber.stop failed")
 
     # Shut the runtime down BEFORE closing the pool so any in-flight
     # job can still write to job_runs as part of its cleanup. The
@@ -152,6 +176,59 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     pool.close()
     logger.info("Connection pool closed.")
+
+
+async def _maybe_start_etoro_ws(pool: ConnectionPool[Any]) -> EtoroWebSocketSubscriber | None:
+    """Boot the WS subscriber when credentials are available.
+
+    Pulled out of ``lifespan`` so the credential-load + subscriber
+    start runs under a single broad try/except — a missing or
+    invalid credential pair must not crash startup. Returns ``None``
+    when credentials aren't loadable yet (pre-setup flow).
+    """
+    try:
+        with pool.connection() as conn:
+            op_id = sole_operator_id(conn)
+            api_key = load_credential_for_provider_use(
+                conn,
+                operator_id=op_id,
+                provider="etoro",
+                label="api_key",
+                environment=settings.etoro_env,
+                caller="etoro_ws_subscriber",
+            )
+            conn.commit()
+            user_key = load_credential_for_provider_use(
+                conn,
+                operator_id=op_id,
+                provider="etoro",
+                label="user_key",
+                environment=settings.etoro_env,
+                caller="etoro_ws_subscriber",
+            )
+            conn.commit()
+    except (NoOperatorError, AmbiguousOperatorError, CredentialNotFound) as exc:
+        logger.info(
+            "EtoroWebSocketSubscriber not started (%s): %s",
+            type(exc).__name__,
+            exc,
+        )
+        return None
+    except Exception:
+        logger.exception("EtoroWebSocketSubscriber credential load failed")
+        return None
+
+    subscriber = EtoroWebSocketSubscriber(
+        api_key=api_key,
+        user_key=user_key,
+        pool=pool,
+    )
+    try:
+        await subscriber.start()
+    except Exception:
+        logger.exception("EtoroWebSocketSubscriber.start failed")
+        return None
+    return subscriber
 
 
 app = FastAPI(title="eBull", version="0.1.0", lifespan=lifespan)

--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -48,7 +48,6 @@ logger = logging.getLogger(__name__)
 
 _WS_URL = "wss://ws.etoro.com/ws"
 _RECONNECT_BACKOFF_S = 5.0
-_RESUBSCRIBE_INTERVAL_S = 60.0  # re-poll watched instruments
 
 
 # ---------------------------------------------------------------------
@@ -255,6 +254,16 @@ class EtoroWebSocketSubscriber:
         with self._pool.connection() as conn:
             return fetch_watched_instrument_ids(conn)
 
+    def _sync_upsert(self, update: QuoteUpdate) -> None:
+        """Sync helper offloaded to a worker thread per tick so the
+        event loop never blocks on a DB round-trip. Both
+        ``pool.connection()`` (a sync context manager) and the
+        ``conn.execute`` it yields run inside ``asyncio.to_thread``.
+        """
+        with self._pool.connection() as conn:
+            upsert_quote(conn, update)
+            conn.commit()
+
     async def start(self) -> None:
         if self._task is not None:
             return
@@ -302,7 +311,9 @@ class EtoroWebSocketSubscriber:
             if not _is_auth_success(auth_reply):
                 raise RuntimeError(f"eToro WS auth failed: {auth_reply!r}")
 
-            ids = self._watched_ids_provider()
+            # Selector hits the DB; offload to a worker thread so
+            # the connect path doesn't block the event loop.
+            ids = await asyncio.to_thread(self._watched_ids_provider)
             sub_msg = build_subscribe_message(ids)
             if sub_msg is not None:
                 await ws.send(sub_msg)
@@ -326,9 +337,11 @@ class EtoroWebSocketSubscriber:
             if update is None:
                 continue
             try:
-                with self._pool.connection() as conn:
-                    upsert_quote(conn, update)
-                    conn.commit()
+                # ``pool.connection()`` is sync — calling it from the
+                # event loop would block the loop for the full DB
+                # round-trip on every tick. Offload to a worker
+                # thread so the WS read loop stays hot.
+                await asyncio.to_thread(self._sync_upsert, update)
             except Exception:
                 logger.warning(
                     "EtoroWebSocketSubscriber: upsert failed instrument_id=%d",

--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -1,0 +1,347 @@
+"""eToro WebSocket live-price subscriber (#274 Slice 1).
+
+Connects to ``wss://ws.etoro.com/ws``, authenticates with the
+operator's eToro API + user keys, subscribes to ``instrument:<id>``
+topics for every instrument the operator currently holds OR has on
+their watchlist, and upserts each ``Trading.Instrument.Rate`` push
+into the existing ``quotes`` table.
+
+**Slice 1 scope** (deliberately tight per operator simplicity ask):
+
+- Single-instance dev assumption: one process owns the WS connection.
+  No advisory-lock multi-worker dance — that's a Slice 4 concern when
+  the app actually runs multi-worker in prod.
+- Quotes-only. ``private`` topic / position-event handling is Slice 2.
+- ``quotes`` table writes only. SSE / Redis fan-out is Slice 3.
+- Frontend continues to poll the existing ``/quotes`` endpoints with
+  React Query. The 5-second client cadence + WS-driven SQL freshness
+  combine into the "few-second live price" experience the operator
+  asked for.
+
+Reconnect policy: any I/O error or close triggers a 5-second backoff
+then re-authenticate + re-subscribe. The set of topics is recomputed
+on every reconnect so a freshly-opened position / watchlist add is
+picked up after at most one reconnect cycle, even if the first ever
+connect happened before that change.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg_pool
+import websockets
+from websockets.asyncio.client import ClientConnection
+
+logger = logging.getLogger(__name__)
+
+
+_WS_URL = "wss://ws.etoro.com/ws"
+_RECONNECT_BACKOFF_S = 5.0
+_RESUBSCRIBE_INTERVAL_S = 60.0  # re-poll watched instruments
+
+
+# ---------------------------------------------------------------------
+# Pure helpers — unit tested without WS mocks
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QuoteUpdate:
+    """Normalised tick — what the rate-message parser emits and the
+    DB upsert consumes."""
+
+    instrument_id: int
+    bid: Decimal
+    ask: Decimal
+    last: Decimal | None
+    quoted_at: datetime
+
+
+def build_auth_message(api_key: str, user_key: str) -> str:
+    """Compose the ``Authenticate`` op JSON sent on every (re)connect."""
+    return json.dumps(
+        {
+            "id": str(uuid.uuid4()),
+            "operation": "Authenticate",
+            "data": {"apiKey": api_key, "userKey": user_key},
+        }
+    )
+
+
+def build_subscribe_message(instrument_ids: list[int]) -> str | None:
+    """Compose the ``Subscribe`` op JSON for a list of instrument IDs.
+
+    Returns ``None`` when the list is empty so callers don't send a
+    no-op subscription that eToro might reject.
+    """
+    if not instrument_ids:
+        return None
+    topics = [f"instrument:{iid}" for iid in instrument_ids]
+    return json.dumps(
+        {
+            "id": str(uuid.uuid4()),
+            "operation": "Subscribe",
+            "data": {"topics": topics, "snapshot": True},
+        }
+    )
+
+
+def parse_rate_message(raw: str) -> QuoteUpdate | None:
+    """Parse a ``Trading.Instrument.Rate`` push.
+
+    eToro's WS protocol wraps each push in an envelope:
+    ``{type: "Trading.Instrument.Rate", data: {InstrumentID, Bid,
+    Ask, LastExecution, Date, ...}}``. Returns ``None`` for any other
+    message type or any field-shape failure — callers continue
+    listening rather than failing the whole connection.
+    """
+    try:
+        msg = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(msg, dict):
+        return None
+    if msg.get("type") != "Trading.Instrument.Rate":
+        return None
+    data = msg.get("data")
+    if not isinstance(data, dict):
+        return None
+    try:
+        instrument_id = int(data["InstrumentID"])
+        bid = Decimal(str(data["Bid"]))
+        ask = Decimal(str(data["Ask"]))
+        last_raw = data.get("LastExecution")
+        last = Decimal(str(last_raw)) if last_raw is not None else None
+        date_str = str(data["Date"])
+        # eToro's ISO date includes 'Z' suffix; normalise to UTC.
+        if date_str.endswith("Z"):
+            date_str = date_str[:-1] + "+00:00"
+        quoted_at = datetime.fromisoformat(date_str)
+    except KeyError, TypeError, ValueError:
+        return None
+    return QuoteUpdate(
+        instrument_id=instrument_id,
+        bid=bid,
+        ask=ask,
+        last=last,
+        quoted_at=quoted_at,
+    )
+
+
+def _compute_spread_pct(bid: Decimal, ask: Decimal) -> Decimal | None:
+    """Mid-spread percentage. Matches the existing service-layer
+    convention so quotes from the WS path stay comparable to the
+    REST-poll path."""
+    if bid <= 0 or ask <= 0:
+        return None
+    mid = (bid + ask) / Decimal(2)
+    if mid <= 0:
+        return None
+    return ((ask - bid) / mid) * Decimal(100)
+
+
+# ---------------------------------------------------------------------
+# DB upsert
+# ---------------------------------------------------------------------
+
+
+_UPSERT_SQL = """
+INSERT INTO quotes (instrument_id, quoted_at, bid, ask, last, spread_pct, spread_flag)
+VALUES (%(instrument_id)s, %(quoted_at)s, %(bid)s, %(ask)s, %(last)s, %(spread_pct)s, FALSE)
+ON CONFLICT (instrument_id) DO UPDATE SET
+    quoted_at  = EXCLUDED.quoted_at,
+    bid        = EXCLUDED.bid,
+    ask        = EXCLUDED.ask,
+    last       = EXCLUDED.last,
+    spread_pct = EXCLUDED.spread_pct
+WHERE quotes.quoted_at IS NULL OR EXCLUDED.quoted_at >= quotes.quoted_at
+"""
+
+
+def upsert_quote(conn: psycopg.Connection[Any], update: QuoteUpdate) -> None:
+    """Upsert one tick into the ``quotes`` table.
+
+    The WHERE clause guards against an out-of-order arrival
+    overwriting a fresher tick that beat it through the network —
+    rare but possible across reconnects when the WS replay overlaps
+    the live stream.
+    """
+    spread_pct = _compute_spread_pct(update.bid, update.ask)
+    conn.execute(
+        _UPSERT_SQL,
+        {
+            "instrument_id": update.instrument_id,
+            "quoted_at": update.quoted_at,
+            "bid": update.bid,
+            "ask": update.ask,
+            "last": update.last,
+            "spread_pct": spread_pct,
+        },
+    )
+
+
+# ---------------------------------------------------------------------
+# Watched-instruments selector
+# ---------------------------------------------------------------------
+
+
+def fetch_watched_instrument_ids(conn: psycopg.Connection[Any]) -> list[int]:
+    """Return the set of instrument IDs the WS subscriber should
+    subscribe to: held positions ∪ watchlist.
+
+    The eBull schema stores eToro's native integer instrument id
+    directly in ``instruments.instrument_id`` (see the universe
+    upsert in ``app.services.universe`` which writes
+    ``INSERT ... VALUES (%(provider_id)s, ...)`` into the
+    ``instrument_id`` column). So the same integer that the WS
+    ``instrument:<id>`` topic expects is what's already on the
+    parent + child tables — no JOIN to ``external_identifiers``
+    needed.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT instrument_id FROM (
+                SELECT instrument_id FROM broker_positions
+                UNION
+                SELECT instrument_id FROM watchlist
+            ) AS u
+            """,
+        )
+        return [int(row[0]) for row in cur.fetchall() if row[0] is not None]
+
+
+# ---------------------------------------------------------------------
+# Subscriber lifecycle
+# ---------------------------------------------------------------------
+
+
+class EtoroWebSocketSubscriber:
+    """Lifespan-managed coroutine that holds the WS connection.
+
+    ``start()`` launches the listen loop as an asyncio task; ``stop()``
+    cancels it. The internal loop reconnects on any error after a
+    short backoff.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        user_key: str,
+        pool: psycopg_pool.ConnectionPool[Any],
+        watched_ids_provider: Callable[[], list[int]] | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._user_key = user_key
+        self._pool = pool
+        # Default selector hits the DB; tests inject a stub.
+        self._watched_ids_provider = watched_ids_provider or self._default_watched_ids
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+
+    def _default_watched_ids(self) -> list[int]:
+        with self._pool.connection() as conn:
+            return fetch_watched_instrument_ids(conn)
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._run(), name="etoro-ws-subscriber")
+        logger.info("EtoroWebSocketSubscriber: started")
+
+    async def stop(self) -> None:
+        if self._task is None:
+            return
+        self._stop_event.set()
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+        logger.info("EtoroWebSocketSubscriber: stopped")
+
+    async def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                await self._connect_and_listen()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "EtoroWebSocketSubscriber: connection error — backoff %.1fs then reconnect",
+                    _RECONNECT_BACKOFF_S,
+                    exc_info=True,
+                )
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=_RECONNECT_BACKOFF_S)
+                # Stop signalled during backoff — exit cleanly.
+                return
+            except TimeoutError:
+                continue
+
+    async def _connect_and_listen(self) -> None:
+        async with websockets.connect(_WS_URL) as ws:
+            await ws.send(build_auth_message(self._api_key, self._user_key))
+            # Drain the auth response — eToro replies with
+            # {"success": true} or an error envelope. We wait for one
+            # frame so a bad key surfaces immediately rather than
+            # silently looping subscribe attempts.
+            auth_reply = await asyncio.wait_for(ws.recv(), timeout=10.0)
+            if not _is_auth_success(auth_reply):
+                raise RuntimeError(f"eToro WS auth failed: {auth_reply!r}")
+
+            ids = self._watched_ids_provider()
+            sub_msg = build_subscribe_message(ids)
+            if sub_msg is not None:
+                await ws.send(sub_msg)
+                logger.info(
+                    "EtoroWebSocketSubscriber: subscribed to %d instrument topics",
+                    len(ids),
+                )
+            else:
+                logger.info(
+                    "EtoroWebSocketSubscriber: no watched instruments — "
+                    "connection will idle until a position / watchlist add"
+                )
+
+            await self._listen(ws)
+
+    async def _listen(self, ws: ClientConnection) -> None:
+        async for raw in ws:
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8", errors="ignore")
+            update = parse_rate_message(raw)
+            if update is None:
+                continue
+            try:
+                with self._pool.connection() as conn:
+                    upsert_quote(conn, update)
+                    conn.commit()
+            except Exception:
+                logger.warning(
+                    "EtoroWebSocketSubscriber: upsert failed instrument_id=%d",
+                    update.instrument_id,
+                    exc_info=True,
+                )
+
+
+def _is_auth_success(raw: str | bytes) -> bool:
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8", errors="ignore")
+    try:
+        msg = json.loads(raw)
+    except json.JSONDecodeError, TypeError:
+        return False
+    return isinstance(msg, dict) and bool(msg.get("success"))

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -61,6 +61,9 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "coverage_status_events",  # #397 transition log (child of coverage)
     "coverage",  # #397 truncate needed to reset trigger-driven state cleanly
     "position_alerts",  # #396 position-alert episodes
+    "watchlist",  # #042 — FK → instruments
+    "broker_positions",  # #024 — FK → instruments
+    "quotes",  # #002 — FK → instruments (live-tick target #471)
     "instruments",
     "job_runs",
     "financial_periods_raw",

--- a/tests/test_etoro_websocket.py
+++ b/tests/test_etoro_websocket.py
@@ -1,0 +1,284 @@
+"""Tests for the eToro WebSocket subscriber (#274 Slice 1).
+
+Pure helpers (auth-message build, subscribe-message build, rate-
+message parser, spread-pct compute) are unit-tested; the DB upsert
+is integration-tested against ``ebull_test``. The connect/listen
+loop itself is not exercised — that requires a real WS server or a
+heavyweight fixture and adds little safety beyond covering the
+component pieces.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services.etoro_websocket import (
+    QuoteUpdate,
+    _compute_spread_pct,
+    _is_auth_success,
+    build_auth_message,
+    build_subscribe_message,
+    fetch_watched_instrument_ids,
+    parse_rate_message,
+    upsert_quote,
+)
+
+# ---------------------------------------------------------------------------
+# Pure helpers — no DB
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAuthMessage:
+    def test_envelope_shape(self) -> None:
+        msg = json.loads(build_auth_message("API", "USR"))
+        assert msg["operation"] == "Authenticate"
+        assert msg["data"] == {"apiKey": "API", "userKey": "USR"}
+        assert "id" in msg
+
+    def test_id_is_unique_per_call(self) -> None:
+        ids = {json.loads(build_auth_message("a", "u"))["id"] for _ in range(5)}
+        assert len(ids) == 5
+
+
+class TestBuildSubscribeMessage:
+    def test_topics_built_correctly(self) -> None:
+        raw = build_subscribe_message([1001, 1002, 1003])
+        assert raw is not None
+        msg = json.loads(raw)
+        assert msg["operation"] == "Subscribe"
+        assert msg["data"]["topics"] == [
+            "instrument:1001",
+            "instrument:1002",
+            "instrument:1003",
+        ]
+        # snapshot=True so we get the latest tick on (re)connect.
+        assert msg["data"]["snapshot"] is True
+
+    def test_empty_list_returns_none(self) -> None:
+        """No-op subscribe must not be sent — eToro may reject empty
+        topics, and we have nothing to listen for."""
+        assert build_subscribe_message([]) is None
+
+
+class TestParseRateMessage:
+    def test_canonical_rate_push(self) -> None:
+        raw = json.dumps(
+            {
+                "type": "Trading.Instrument.Rate",
+                "data": {
+                    "InstrumentID": 1001,
+                    "Bid": "186.50",
+                    "Ask": "186.70",
+                    "LastExecution": "186.60",
+                    "Date": "2026-04-24T14:30:00Z",
+                    "PriceRateID": "abc",
+                },
+            }
+        )
+        update = parse_rate_message(raw)
+        assert update is not None
+        assert update.instrument_id == 1001
+        assert update.bid == Decimal("186.50")
+        assert update.ask == Decimal("186.70")
+        assert update.last == Decimal("186.60")
+        assert update.quoted_at == datetime(2026, 4, 24, 14, 30, 0, tzinfo=UTC)
+
+    def test_missing_last_execution_passes_through(self) -> None:
+        raw = json.dumps(
+            {
+                "type": "Trading.Instrument.Rate",
+                "data": {
+                    "InstrumentID": 1001,
+                    "Bid": "186.50",
+                    "Ask": "186.70",
+                    "Date": "2026-04-24T14:30:00Z",
+                },
+            }
+        )
+        update = parse_rate_message(raw)
+        assert update is not None
+        assert update.last is None
+
+    def test_non_rate_message_returns_none(self) -> None:
+        assert parse_rate_message(json.dumps({"type": "Trading.OrderForCloseMultiple.Update", "data": {}})) is None
+
+    def test_malformed_json_returns_none(self) -> None:
+        assert parse_rate_message("not json") is None
+        assert parse_rate_message("") is None
+
+    def test_missing_required_field_returns_none(self) -> None:
+        # No InstrumentID
+        raw = json.dumps(
+            {"type": "Trading.Instrument.Rate", "data": {"Bid": "1", "Ask": "2", "Date": "2026-04-24T14:30:00Z"}}
+        )
+        assert parse_rate_message(raw) is None
+
+
+class TestSpreadPct:
+    def test_canonical_spread(self) -> None:
+        # bid 100, ask 101 → spread = 1; mid = 100.5; pct = 1/100.5 * 100
+        spread = _compute_spread_pct(Decimal("100"), Decimal("101"))
+        assert spread is not None
+        assert abs(spread - Decimal("0.99502487562189")) < Decimal("0.0001")
+
+    def test_zero_or_negative_returns_none(self) -> None:
+        assert _compute_spread_pct(Decimal("0"), Decimal("100")) is None
+        assert _compute_spread_pct(Decimal("100"), Decimal("0")) is None
+        assert _compute_spread_pct(Decimal("-1"), Decimal("100")) is None
+
+
+class TestIsAuthSuccess:
+    def test_success_envelope(self) -> None:
+        assert _is_auth_success(json.dumps({"success": True})) is True
+
+    def test_failure_envelope(self) -> None:
+        assert _is_auth_success(json.dumps({"success": False, "errorCode": "InvalidKey"})) is False
+
+    def test_missing_field(self) -> None:
+        assert _is_auth_success(json.dumps({"id": "x"})) is False
+
+    def test_malformed_returns_false(self) -> None:
+        assert _is_auth_success("not json") is False
+
+
+# ---------------------------------------------------------------------------
+# Integration — DB upsert + watched-IDs query
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestUpsertQuote:
+    def _seed_instrument(self, conn: psycopg.Connection[tuple], iid: int = 1001) -> None:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s)",
+                (iid, "AAPL", "Apple Inc."),
+            )
+        conn.commit()
+
+    def test_first_upsert_inserts(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        self._seed_instrument(ebull_test_conn)
+        upsert_quote(
+            ebull_test_conn,
+            QuoteUpdate(
+                instrument_id=1001,
+                bid=Decimal("100"),
+                ask=Decimal("101"),
+                last=Decimal("100.5"),
+                quoted_at=datetime(2026, 4, 24, 14, 30, 0, tzinfo=UTC),
+            ),
+        )
+        ebull_test_conn.commit()
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT bid, ask, last, spread_pct FROM quotes WHERE instrument_id = 1001")
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == Decimal("100")
+        assert row[1] == Decimal("101")
+        assert row[2] == Decimal("100.5")
+        assert row[3] is not None  # spread computed
+
+    def test_newer_tick_overwrites(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        self._seed_instrument(ebull_test_conn, iid=1002)
+        upsert_quote(
+            ebull_test_conn,
+            QuoteUpdate(
+                instrument_id=1002,
+                bid=Decimal("100"),
+                ask=Decimal("101"),
+                last=None,
+                quoted_at=datetime(2026, 4, 24, 14, 30, 0, tzinfo=UTC),
+            ),
+        )
+        upsert_quote(
+            ebull_test_conn,
+            QuoteUpdate(
+                instrument_id=1002,
+                bid=Decimal("105"),
+                ask=Decimal("106"),
+                last=None,
+                quoted_at=datetime(2026, 4, 24, 14, 31, 0, tzinfo=UTC),
+            ),
+        )
+        ebull_test_conn.commit()
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT bid FROM quotes WHERE instrument_id = 1002")
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == Decimal("105")
+
+    def test_older_tick_does_not_overwrite(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Out-of-order arrival across reconnects must not regress
+        the stored tick."""
+        self._seed_instrument(ebull_test_conn, iid=1003)
+        upsert_quote(
+            ebull_test_conn,
+            QuoteUpdate(
+                instrument_id=1003,
+                bid=Decimal("100"),
+                ask=Decimal("101"),
+                last=None,
+                quoted_at=datetime(2026, 4, 24, 14, 31, 0, tzinfo=UTC),
+            ),
+        )
+        # Older tick arrives second.
+        upsert_quote(
+            ebull_test_conn,
+            QuoteUpdate(
+                instrument_id=1003,
+                bid=Decimal("90"),
+                ask=Decimal("91"),
+                last=None,
+                quoted_at=datetime(2026, 4, 24, 14, 30, 0, tzinfo=UTC),
+            ),
+        )
+        ebull_test_conn.commit()
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT bid FROM quotes WHERE instrument_id = 1003")
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == Decimal("100")  # newer tick survived
+
+
+@pytest.mark.integration
+class TestFetchWatchedInstrumentIds:
+    def test_returns_held_and_watchlist_union(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO instruments (instrument_id, symbol, company_name) "
+                "VALUES (1001, 'AAPL', 'Apple'), "
+                "(1002, 'MSFT', 'Microsoft'), "
+                "(1003, 'NVDA', 'Nvidia'), "
+                "(1004, 'GOOG', 'Google')"
+            )
+            # Held = 1001, 1002. Watchlist = 1002, 1003. Result should
+            # be the union {1001, 1002, 1003}; 1004 (neither) stays out.
+            cur.execute(
+                """
+                INSERT INTO broker_positions
+                    (position_id, instrument_id, is_buy, units, amount,
+                     initial_amount_in_dollars, open_rate, open_conversion_rate,
+                     open_date_time, raw_payload)
+                VALUES
+                    (1001, 1001, TRUE, 1, 100, 100, 100, 1, NOW(), '{}'::jsonb),
+                    (1002, 1002, TRUE, 2, 200, 200, 100, 1, NOW(), '{}'::jsonb)
+                """
+            )
+            cur.execute(
+                "INSERT INTO operators (operator_id, username, password_hash) "
+                "VALUES ('00000000-0000-0000-0000-000000000001', 'op', 'x')"
+            )
+            cur.execute(
+                "INSERT INTO watchlist (instrument_id, operator_id, added_at) "
+                "VALUES (1002, '00000000-0000-0000-0000-000000000001', NOW()), "
+                "(1003, '00000000-0000-0000-0000-000000000001', NOW())"
+            )
+        ebull_test_conn.commit()
+
+        ids = fetch_watched_instrument_ids(ebull_test_conn)
+        assert sorted(ids) == [1001, 1002, 1003]


### PR DESCRIPTION
## Summary
- Slice 1 of #274: WS subscriber connects on lifespan, subscribes to held + watchlist instruments, upserts ticks into the existing quotes table.
- Single-instance dev scope: no advisory lock, no SSE/Redis, no FX yet (Slices 2-4).
- Frontend polls /quotes with React Query 5s; WS keeps SQL fresh in seconds.

## Test plan
- [x] uv run ruff check / format / pyright (clean)
- [x] uv run pytest (2650 passed)
- [x] 19 new tests for auth/subscribe envelope, rate-message parser, spread compute, DB upsert (with out-of-order guard), watched-IDs union