### PR TITLE
feat(#274 Slice 2): eToro private channel + debounced portfolio reconcile

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -221,6 +221,7 @@ async def _maybe_start_etoro_ws(pool: ConnectionPool[Any]) -> EtoroWebSocketSubs
     subscriber = EtoroWebSocketSubscriber(
         api_key=api_key,
         user_key=user_key,
+        env=settings.etoro_env,
         pool=pool,
     )
     try:

--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -377,8 +377,10 @@ class EtoroWebSocketSubscriber:
             portfolio = broker.get_portfolio()
 
         with self._pool.connection() as conn:
+            # ``ConnectionPool.connection()`` already commits on clean
+            # exit / rolls back on error via ``with conn:`` — no
+            # explicit commit needed here.
             sync_portfolio(conn, portfolio)
-            conn.commit()
 
     def _sync_upsert(self, update: QuoteUpdate) -> None:
         """Sync helper offloaded to a worker thread per tick so the

--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -1,4 +1,4 @@
-"""eToro WebSocket live-price subscriber (#274 Slice 1).
+"""eToro WebSocket live-price subscriber (#274 Slices 1+2).
 
 Connects to ``wss://ws.etoro.com/ws``, authenticates with the
 operator's eToro API + user keys, subscribes to ``instrument:<id>``
@@ -6,23 +6,34 @@ topics for every instrument the operator currently holds OR has on
 their watchlist, and upserts each ``Trading.Instrument.Rate`` push
 into the existing ``quotes`` table.
 
-**Slice 1 scope** (deliberately tight per operator simplicity ask):
+**Slice 1 scope** (rates-only):
 
 - Single-instance dev assumption: one process owns the WS connection.
-  No advisory-lock multi-worker dance — that's a Slice 4 concern when
-  the app actually runs multi-worker in prod.
-- Quotes-only. ``private`` topic / position-event handling is Slice 2.
+  Multi-worker advisory-lock arbitration is a Slice 4 concern.
 - ``quotes`` table writes only. SSE / Redis fan-out is Slice 3.
-- Frontend continues to poll the existing ``/quotes`` endpoints with
-  React Query. The 5-second client cadence + WS-driven SQL freshness
-  combine into the "few-second live price" experience the operator
-  asked for.
+- Frontend continues to poll ``/quotes`` endpoints; the 5-second
+  client cadence + WS-driven SQL freshness combine into the
+  "few-second live price" experience.
+
+**Slice 2 scope** (private channel + reconcile):
+
+- Also subscribes to the ``private`` topic. eToro pushes
+  ``Trading.OrderFor*`` / ``Trading.Position*`` / ``Trading.Credit*``
+  envelopes here whenever the operator's portfolio state changes
+  (orders accepted / rejected, positions opened / closed, cash
+  credit moves).
+- Each private push schedules a debounced REST reconcile —
+  ``EtoroBrokerProvider.get_portfolio()`` followed by
+  ``sync_portfolio()`` against the live DB. Multi-leg trades and
+  rapid order bursts collapse into one reconcile per
+  ``_RECONCILE_DEBOUNCE_S`` window so the public REST limit
+  (60 GET/min) is respected even when the private firehose is
+  noisy.
 
 Reconnect policy: any I/O error or close triggers a 5-second backoff
-then re-authenticate + re-subscribe. The set of topics is recomputed
-on every reconnect so a freshly-opened position / watchlist add is
-picked up after at most one reconnect cycle, even if the first ever
-connect happened before that change.
+then re-authenticate + re-subscribe. The set of instrument topics is
+recomputed on every reconnect so a freshly-opened position /
+watchlist add is picked up after at most one reconnect cycle.
 """
 
 from __future__ import annotations
@@ -31,6 +42,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import threading
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -48,6 +60,12 @@ logger = logging.getLogger(__name__)
 
 _WS_URL = "wss://ws.etoro.com/ws"
 _RECONNECT_BACKOFF_S = 5.0
+# Debounce window for portfolio reconcile after a private-channel
+# event. Multi-leg trades produce a burst of order/position pushes;
+# we collapse them into one REST reconcile so the broker endpoint
+# isn't hammered. 3 seconds is short enough that the operator sees
+# fresh state inside a "feel alive" window without churn.
+_RECONCILE_DEBOUNCE_S = 3.0
 
 
 # ---------------------------------------------------------------------
@@ -94,6 +112,57 @@ def build_subscribe_message(instrument_ids: list[int]) -> str | None:
             "data": {"topics": topics, "snapshot": True},
         }
     )
+
+
+_PRIVATE_TOPIC = "private"
+
+
+def build_private_subscribe_message() -> str:
+    """Compose the ``Subscribe`` op JSON for the ``private`` topic.
+
+    The private channel carries order / position / credit events for
+    the authenticated operator. Always sent — there's no "empty list"
+    case as with instrument topics, since there's exactly one private
+    channel per session. ``snapshot=False`` because we want only
+    forward-going events; the REST reconcile owns the snapshot.
+    """
+    return json.dumps(
+        {
+            "id": str(uuid.uuid4()),
+            "operation": "Subscribe",
+            "data": {"topics": [_PRIVATE_TOPIC], "snapshot": False},
+        }
+    )
+
+
+# Private-channel message types that signal a portfolio state change
+# worth reconciling. eToro's WS docs list at least
+# Trading.OrderForCloseMultiple.Update; we accept any
+# Trading.OrderFor* / Trading.Position* / Trading.Credit* type as a
+# reconcile trigger so we don't have to enumerate every variant up
+# front. Debouncing means duplicates collapse anyway.
+_PRIVATE_EVENT_PREFIXES: tuple[str, ...] = (
+    "Trading.OrderFor",
+    "Trading.Position",
+    "Trading.Credit",
+)
+
+
+def is_private_event(raw: str) -> bool:
+    """True if ``raw`` is a private-channel push that should trigger
+    a portfolio reconcile. Returns False for malformed JSON, non-
+    private types, or unknown shapes — the reconciler is a coarse
+    invalidation, not a precise event handler."""
+    try:
+        msg = json.loads(raw)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(msg, dict):
+        return False
+    msg_type = msg.get("type")
+    if not isinstance(msg_type, str):
+        return False
+    return any(msg_type.startswith(p) for p in _PRIVATE_EVENT_PREFIXES)
 
 
 def parse_rate_message(raw: str) -> QuoteUpdate | None:
@@ -239,20 +308,77 @@ class EtoroWebSocketSubscriber:
         *,
         api_key: str,
         user_key: str,
+        env: str,
         pool: psycopg_pool.ConnectionPool[Any],
         watched_ids_provider: Callable[[], list[int]] | None = None,
+        reconcile_runner: Callable[[], None] | None = None,
     ) -> None:
         self._api_key = api_key
         self._user_key = user_key
+        self._env = env
         self._pool = pool
         # Default selector hits the DB; tests inject a stub.
         self._watched_ids_provider = watched_ids_provider or self._default_watched_ids
+        # Default reconcile runner builds an EtoroBrokerProvider and
+        # calls sync_portfolio. Tests inject a no-op or counter to
+        # avoid hitting the real REST API + DB.
+        self._reconcile_runner = reconcile_runner or self._default_reconcile_runner
         self._task: asyncio.Task[None] | None = None
         self._stop_event = asyncio.Event()
+        # Single dedicated worker coroutine owns reconciliation:
+        # ``_schedule_reconcile`` only ``set()``s the event, the
+        # worker waits on it, drains the burst, then runs at most one
+        # reconcile at a time. This pattern (vs cancel-and-replace
+        # debounce tasks) avoids the race where a cancel arrives
+        # while ``asyncio.to_thread(self._reconcile_runner)`` is in
+        # flight — Task.cancel cancels the *coroutine*, not the
+        # worker thread, so the prior reconcile would otherwise keep
+        # writing to DB while a new task starts a second concurrent
+        # one. Single worker = guaranteed serialisation.
+        self._reconcile_signal = asyncio.Event()
+        self._reconcile_worker_task: asyncio.Task[None] | None = None
+        # ``_reconcile_idle`` is a *thread-side* signal: the runner
+        # wrapper clears it before invoking the user-supplied runner
+        # and sets it back after. ``stop()`` waits on this before
+        # returning so the FastAPI lifespan can't close the
+        # ConnectionPool while a reconcile thread is still inside
+        # ``sync_portfolio``. ``Task.cancel()`` on the worker
+        # coroutine does *not* wait for an in-flight ``to_thread``
+        # worker — the coroutine raises CancelledError immediately
+        # while the OS thread keeps running. So we need an explicit
+        # thread-completion barrier separate from the asyncio
+        # cancellation chain.
+        self._reconcile_idle = threading.Event()
+        self._reconcile_idle.set()
 
     def _default_watched_ids(self) -> list[int]:
         with self._pool.connection() as conn:
             return fetch_watched_instrument_ids(conn)
+
+    def _default_reconcile_runner(self) -> None:
+        """Sync helper: REST snapshot via EtoroBrokerProvider, then
+        ``sync_portfolio`` against a fresh DB connection. Runs in a
+        worker thread (see ``_perform_reconcile``) so the WS event
+        loop stays hot. Mirrors the daily_portfolio_sync pattern in
+        ``app.workers.scheduler`` so the two reconcile paths agree on
+        broker construction + sync semantics.
+        """
+        # Local imports avoid pulling provider stack into module load
+        # (the REST provider has heavy httpx + retry deps that the
+        # WS-only test path doesn't need).
+        from app.providers.implementations.etoro_broker import EtoroBrokerProvider
+        from app.services.portfolio_sync import sync_portfolio
+
+        with EtoroBrokerProvider(
+            api_key=self._api_key,
+            user_key=self._user_key,
+            env=self._env,
+        ) as broker:
+            portfolio = broker.get_portfolio()
+
+        with self._pool.connection() as conn:
+            sync_portfolio(conn, portfolio)
+            conn.commit()
 
     def _sync_upsert(self, update: QuoteUpdate) -> None:
         """Sync helper offloaded to a worker thread per tick so the
@@ -268,6 +394,8 @@ class EtoroWebSocketSubscriber:
         if self._task is not None:
             return
         self._stop_event.clear()
+        self._reconcile_signal.clear()
+        self._reconcile_worker_task = asyncio.create_task(self._reconcile_worker(), name="etoro-ws-reconcile-worker")
         self._task = asyncio.create_task(self._run(), name="etoro-ws-subscriber")
         logger.info("EtoroWebSocketSubscriber: started")
 
@@ -279,7 +407,113 @@ class EtoroWebSocketSubscriber:
         with contextlib.suppress(asyncio.CancelledError):
             await self._task
         self._task = None
+        # Cancel the reconcile worker. The worker coroutine may be
+        # awaiting ``asyncio.to_thread`` — the cancel raises
+        # CancelledError out of the await, but the OS thread running
+        # ``self._reconcile_runner`` keeps going. We then wait on
+        # ``_reconcile_idle`` (set from inside the thread by the
+        # wrapper, see ``_run_reconcile_in_thread``) so the lifespan
+        # caller can safely close the DB pool right after this stop()
+        # returns.
+        if self._reconcile_worker_task is not None:
+            self._reconcile_worker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._reconcile_worker_task
+            self._reconcile_worker_task = None
+        if not self._reconcile_idle.is_set():
+            # Bounded wait — sync_portfolio is fast, but if a thread
+            # is somehow stuck we'd rather log + proceed than hang
+            # shutdown forever.
+            done = await asyncio.to_thread(self._reconcile_idle.wait, 30.0)
+            if not done:
+                logger.warning(
+                    "EtoroWebSocketSubscriber: reconcile thread still "
+                    "running after 30s shutdown wait — proceeding anyway"
+                )
         logger.info("EtoroWebSocketSubscriber: stopped")
+
+    def _schedule_reconcile(self) -> None:
+        """Signal the reconcile worker that a private event landed.
+
+        Idempotent: setting an already-set ``Event`` is a no-op, so a
+        burst of N events ahead of the worker still results in one
+        debounce window and one reconcile — the burst-collapse
+        invariant comes from the worker's wait-then-drain loop, not
+        from cancelling per-event timers.
+        """
+        self._reconcile_signal.set()
+
+    async def _reconcile_worker(self) -> None:
+        """Owner coroutine for portfolio reconciliation.
+
+        Loop:
+          1. Wait for a reconcile signal.
+          2. Drain the debounce window: keep clearing+waiting up to
+             ``_RECONCILE_DEBOUNCE_S`` for further signals; any new
+             signal restarts the window so a long burst collapses
+             into a single reconcile fired only after a quiet gap.
+          3. Run the reconcile via ``asyncio.to_thread`` so the
+             event loop stays responsive.
+          4. Re-iterate. If a signal arrived *during* the reconcile,
+             ``_reconcile_signal.is_set()`` is true at the top of the
+             next loop, so the next reconcile fires after another
+             debounce window — guaranteeing the latest broker state
+             is reflected without ever running two reconciles at
+             once.
+
+        Cancellation is the only exit path; ``stop()`` cancels the
+        task. CancelledError raised mid-``to_thread`` waits for the
+        worker thread to finish before propagating, so the DB write
+        never gets torn mid-flight.
+        """
+        while not self._stop_event.is_set():
+            await self._reconcile_signal.wait()
+            # Debounce drain: collect a quiet gap before firing.
+            while True:
+                self._reconcile_signal.clear()
+                try:
+                    await asyncio.wait_for(
+                        self._reconcile_signal.wait(),
+                        timeout=_RECONCILE_DEBOUNCE_S,
+                    )
+                except TimeoutError:
+                    break
+                # Another signal arrived inside the window — drain
+                # again so the reconcile reflects the latest event.
+            # Clear the idle barrier synchronously *before* handing
+            # work to the executor. If we cleared inside the worker
+            # thread instead, ``stop()`` could fire between
+            # ``asyncio.to_thread`` submission and the thread
+            # actually starting, observe ``is_set() is True``, and
+            # return while the queued thread is about to run a
+            # reconcile against the soon-to-close pool. Synchronous
+            # clear + thread-side ``set()`` in a ``finally`` removes
+            # that submit-not-yet-running window.
+            self._reconcile_idle.clear()
+            try:
+                await asyncio.to_thread(self._run_reconcile_in_thread)
+                logger.info("EtoroWebSocketSubscriber: reconcile complete")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "EtoroWebSocketSubscriber: reconcile failed",
+                    exc_info=True,
+                )
+
+    def _run_reconcile_in_thread(self) -> None:
+        """Wrapper executed inside the worker thread.
+
+        The asyncio side clears ``_reconcile_idle`` before submitting
+        this; the thread's ``finally`` sets it again. The set() runs
+        *inside the thread*, so ``stop()`` can wait on this Event to
+        know the actual OS thread has exited — independent of
+        whatever the asyncio side did with cancellation.
+        """
+        try:
+            self._reconcile_runner()
+        finally:
+            self._reconcile_idle.set()
 
     async def _run(self) -> None:
         while not self._stop_event.is_set():
@@ -324,8 +558,17 @@ class EtoroWebSocketSubscriber:
             else:
                 logger.info(
                     "EtoroWebSocketSubscriber: no watched instruments — "
-                    "connection will idle until a position / watchlist add"
+                    "connection will idle for rates until a position / "
+                    "watchlist add"
                 )
+
+            # Always subscribe to the private channel — even if the
+            # operator has no instruments yet, opening a position will
+            # emit a private event that triggers reconcile, which in
+            # turn picks up the new watched-IDs set on the next
+            # reconnect cycle.
+            await ws.send(build_private_subscribe_message())
+            logger.info("EtoroWebSocketSubscriber: subscribed to private channel")
 
             await self._listen(ws)
 
@@ -333,6 +576,14 @@ class EtoroWebSocketSubscriber:
         async for raw in ws:
             if isinstance(raw, bytes):
                 raw = raw.decode("utf-8", errors="ignore")
+            # Private events come first because they're cheap to test
+            # for and we never want a reconcile-trigger to be
+            # confused with a rate push (the type prefix check
+            # already disambiguates, but ordering keeps the dispatch
+            # readable).
+            if is_private_event(raw):
+                self._schedule_reconcile()
+                continue
             update = parse_rate_message(raw)
             if update is None:
                 continue

--- a/tests/test_etoro_websocket.py
+++ b/tests/test_etoro_websocket.py
@@ -1,29 +1,39 @@
-"""Tests for the eToro WebSocket subscriber (#274 Slice 1).
+"""Tests for the eToro WebSocket subscriber (#274 Slices 1+2).
 
 Pure helpers (auth-message build, subscribe-message build, rate-
-message parser, spread-pct compute) are unit-tested; the DB upsert
-is integration-tested against ``ebull_test``. The connect/listen
-loop itself is not exercised — that requires a real WS server or a
-heavyweight fixture and adds little safety beyond covering the
-component pieces.
+message parser, spread-pct compute, private-event classifier) are
+unit-tested; the DB upsert is integration-tested against
+``ebull_test``. The connect/listen loop is not exercised end-to-end
+— that requires a real WS server or a heavyweight fixture — but the
+debounce dispatch is exercised directly on
+``EtoroWebSocketSubscriber._schedule_reconcile`` with a stub runner
+so the collapse-to-one-call invariant is covered.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
+import threading
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import Any
 
 import psycopg
 import pytest
 
+from app.services import etoro_websocket
 from app.services.etoro_websocket import (
+    EtoroWebSocketSubscriber,
     QuoteUpdate,
     _compute_spread_pct,
     _is_auth_success,
     build_auth_message,
+    build_private_subscribe_message,
     build_subscribe_message,
     fetch_watched_instrument_ids,
+    is_private_event,
     parse_rate_message,
     upsert_quote,
 )
@@ -282,3 +292,358 @@ class TestFetchWatchedInstrumentIds:
 
         ids = fetch_watched_instrument_ids(ebull_test_conn)
         assert sorted(ids) == [1001, 1002, 1003]
+
+
+# ---------------------------------------------------------------------------
+# Slice 2 — private channel + reconcile debounce
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPrivateSubscribeMessage:
+    def test_envelope_shape(self) -> None:
+        msg = json.loads(build_private_subscribe_message())
+        assert msg["operation"] == "Subscribe"
+        assert msg["data"]["topics"] == ["private"]
+        # snapshot=False — REST reconcile owns the snapshot, the WS
+        # private channel is forward-only.
+        assert msg["data"]["snapshot"] is False
+        assert "id" in msg
+
+
+class TestIsPrivateEvent:
+    @pytest.mark.parametrize(
+        "msg_type",
+        [
+            "Trading.OrderForCloseMultiple.Update",
+            "Trading.OrderForOpenMultiple.Update",
+            "Trading.PositionUpdate",
+            "Trading.CreditUpdate",
+        ],
+    )
+    def test_known_private_types(self, msg_type: str) -> None:
+        raw = json.dumps({"type": msg_type, "data": {}})
+        assert is_private_event(raw) is True
+
+    def test_rate_push_is_not_private(self) -> None:
+        raw = json.dumps({"type": "Trading.Instrument.Rate", "data": {}})
+        assert is_private_event(raw) is False
+
+    def test_unknown_type_is_not_private(self) -> None:
+        raw = json.dumps({"type": "Heartbeat", "data": {}})
+        assert is_private_event(raw) is False
+
+    def test_malformed_returns_false(self) -> None:
+        assert is_private_event("not json") is False
+        assert is_private_event("[]") is False
+        assert is_private_event(json.dumps({"type": 42})) is False
+
+
+class TestReconcileDebounce:
+    """The reconcile worker must collapse a burst of private events
+    into exactly one reconcile call. Critical because a multi-leg
+    eToro trade emits several order/position events within a few
+    hundred ms; without debounce we'd hammer the REST endpoint and
+    burn the 60-GET/min budget on a single user action.
+
+    The worker pattern (single dedicated coroutine + Event signal)
+    also guarantees serial execution: if a new event arrives *while*
+    a reconcile is in flight, the worker completes the current
+    reconcile before starting the next, so two ``sync_portfolio``
+    calls never race against the same DB.
+    """
+
+    def _make_subscriber(self, runner: Any) -> EtoroWebSocketSubscriber:
+        # Pool is never touched in this path: ``watched_ids_provider``
+        # short-circuits ``_default_watched_ids`` and ``runner``
+        # short-circuits ``_default_reconcile_runner``. Constructor
+        # only stores the reference, so an inert sentinel is safe.
+        sentinel: Any = object()
+        return EtoroWebSocketSubscriber(
+            api_key="API",
+            user_key="USR",
+            env="demo",
+            pool=sentinel,
+            watched_ids_provider=lambda: [],
+            reconcile_runner=runner,
+        )
+
+    async def _start_worker(self, sub: EtoroWebSocketSubscriber) -> asyncio.Task[None]:
+        """Spin up just the reconcile worker without booting the WS
+        listen loop. Returns the task so the test can cancel it on
+        teardown."""
+        task = asyncio.create_task(sub._reconcile_worker())
+        # Yield once so the worker reaches its first ``event.wait()``
+        # before any test schedules an event — otherwise the very
+        # first set() can be lost between create_task and the worker
+        # actually awaiting.
+        await asyncio.sleep(0)
+        return task
+
+    async def _stop_worker(self, task: asyncio.Task[None]) -> None:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    async def test_burst_collapses_to_single_call(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(etoro_websocket, "_RECONCILE_DEBOUNCE_S", 0.05)
+
+        calls = 0
+        done = asyncio.Event()
+
+        def runner() -> None:
+            nonlocal calls
+            calls += 1
+            done.set()
+
+        sub = self._make_subscriber(runner)
+        worker = await self._start_worker(sub)
+        try:
+            sub._schedule_reconcile()
+            sub._schedule_reconcile()
+            sub._schedule_reconcile()
+            await asyncio.wait_for(done.wait(), timeout=2.0)
+            # Wait one more debounce window to confirm no second
+            # reconcile fires from the burst.
+            await asyncio.sleep(0.15)
+            assert calls == 1
+        finally:
+            await self._stop_worker(worker)
+
+    async def test_event_during_reconcile_triggers_followup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If a new private event arrives while a reconcile is in
+        flight, the worker must finish the current reconcile then
+        run a second one. Previously a cancel-and-replace timer
+        could let two reconciles run concurrently because
+        ``Task.cancel()`` doesn't kill an in-progress
+        ``asyncio.to_thread`` worker."""
+        monkeypatch.setattr(etoro_websocket, "_RECONCILE_DEBOUNCE_S", 0.05)
+
+        in_flight = threading.Event()
+        release = threading.Event()
+        order: list[str] = []
+        calls = 0
+
+        def runner() -> None:
+            nonlocal calls
+            calls += 1
+            n = calls
+            order.append(f"start-{n}")
+            in_flight.set()
+            # Block the first reconcile so the test can land a second
+            # event while it's running. The second reconcile is
+            # released immediately because release is set after the
+            # first call signals.
+            release.wait(timeout=2.0)
+            order.append(f"end-{n}")
+
+        sub = self._make_subscriber(runner)
+        worker = await self._start_worker(sub)
+        try:
+            sub._schedule_reconcile()
+            # Wait for the first reconcile to actually be running
+            # inside the worker thread.
+            await asyncio.to_thread(in_flight.wait, 2.0)
+            assert calls == 1
+
+            # Schedule a second event during the in-flight reconcile.
+            sub._schedule_reconcile()
+            # Release the first reconcile; the worker should re-loop,
+            # debounce again, then run reconcile #2.
+            release.set()
+
+            # Wait for the second reconcile to start AND end.
+            for _ in range(200):
+                if calls >= 2 and order.count("end-") >= 0 and "end-2" in order:
+                    break
+                await asyncio.sleep(0.02)
+            assert calls == 2, f"order={order}"
+            # Sequencing: end-1 must precede start-2 — proves serial
+            # execution, no concurrent reconcile.
+            assert order.index("end-1") < order.index("start-2")
+        finally:
+            release.set()
+            await self._stop_worker(worker)
+
+    async def test_runner_exception_does_not_kill_worker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A failing reconcile must not propagate or kill the worker
+        — the next event re-attempts. Logged as a warning in
+        production."""
+        monkeypatch.setattr(etoro_websocket, "_RECONCILE_DEBOUNCE_S", 0.05)
+
+        calls = 0
+        events = [asyncio.Event(), asyncio.Event()]
+
+        def runner() -> None:
+            nonlocal calls
+            calls += 1
+            events[calls - 1].set()
+            if calls == 1:
+                raise RuntimeError("broker exploded")
+
+        sub = self._make_subscriber(runner)
+        worker = await self._start_worker(sub)
+        try:
+            sub._schedule_reconcile()
+            await asyncio.wait_for(events[0].wait(), timeout=2.0)
+            assert calls == 1
+
+            # Worker should still be alive — schedule a second event
+            # and confirm it runs.
+            sub._schedule_reconcile()
+            await asyncio.wait_for(events[1].wait(), timeout=2.0)
+            assert calls == 2
+            assert not worker.done()
+        finally:
+            await self._stop_worker(worker)
+
+    async def test_stop_waits_for_in_flight_reconcile_thread(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``stop()`` must not return while the reconcile thread is
+        still running, otherwise the lifespan caller can close the
+        DB pool out from under ``sync_portfolio``. Cancelling the
+        worker coroutine cancels the *await* but does not kill the
+        thread — so ``stop()`` has to wait on a thread-side barrier.
+        """
+        monkeypatch.setattr(etoro_websocket, "_RECONCILE_DEBOUNCE_S", 0.05)
+
+        thread_done = threading.Event()
+        in_flight = threading.Event()
+        release = threading.Event()
+
+        def runner() -> None:
+            in_flight.set()
+            release.wait(timeout=5.0)
+            thread_done.set()
+
+        sentinel: Any = object()
+        sub = EtoroWebSocketSubscriber(
+            api_key="API",
+            user_key="USR",
+            env="demo",
+            pool=sentinel,
+            watched_ids_provider=lambda: [],
+            reconcile_runner=runner,
+        )
+
+        # Replace _run so start() doesn't try to open a real
+        # WebSocket. The substitute hangs on the stop event so the
+        # listen loop's Task surface mirrors production.
+        async def fake_run() -> None:
+            await sub._stop_event.wait()
+
+        sub._run = fake_run  # type: ignore[method-assign]
+
+        await sub.start()
+        try:
+            sub._schedule_reconcile()
+            await asyncio.to_thread(in_flight.wait, 2.0)
+            assert in_flight.is_set()
+
+            # Kick stop() concurrently. It should block until the
+            # thread completes — the release.set() unblocks the
+            # runner shortly after.
+            stop_task = asyncio.create_task(sub.stop())
+            await asyncio.sleep(0.05)
+            assert not stop_task.done(), "stop() returned while reconcile thread still running"
+
+            release.set()
+            await asyncio.wait_for(stop_task, timeout=2.0)
+            assert thread_done.is_set()
+        finally:
+            release.set()
+            if sub._task is not None or sub._reconcile_worker_task is not None:
+                with contextlib.suppress(Exception):
+                    await sub.stop()
+
+    async def test_separate_windows_each_fire(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Two events separated by more than the debounce window
+        produce two independent reconciles."""
+        monkeypatch.setattr(etoro_websocket, "_RECONCILE_DEBOUNCE_S", 0.05)
+
+        calls = 0
+        events = [asyncio.Event(), asyncio.Event()]
+
+        def runner() -> None:
+            nonlocal calls
+            calls += 1
+            events[calls - 1].set()
+
+        sub = self._make_subscriber(runner)
+        worker = await self._start_worker(sub)
+        try:
+            sub._schedule_reconcile()
+            await asyncio.wait_for(events[0].wait(), timeout=2.0)
+            sub._schedule_reconcile()
+            await asyncio.wait_for(events[1].wait(), timeout=2.0)
+            assert calls == 2
+        finally:
+            await self._stop_worker(worker)
+
+
+class TestListenResilience:
+    """``_listen`` must keep consuming WS frames after a private-event
+    reconcile dispatch and after a reconcile failure — a noisy
+    private channel must not stall the rate path."""
+
+    async def test_rate_frame_after_private_event_still_upserts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(etoro_websocket, "_RECONCILE_DEBOUNCE_S", 0.05)
+
+        upsert_calls: list[QuoteUpdate] = []
+
+        def runner() -> None:
+            # Private path runs but does nothing observable here —
+            # we only assert that a subsequent rate frame still
+            # reaches the upsert path.
+            return None
+
+        sentinel: Any = object()
+        sub = EtoroWebSocketSubscriber(
+            api_key="API",
+            user_key="USR",
+            env="demo",
+            pool=sentinel,
+            watched_ids_provider=lambda: [],
+            reconcile_runner=runner,
+        )
+
+        # Replace _sync_upsert so we don't need a real DB.
+        def fake_upsert(update: QuoteUpdate) -> None:
+            upsert_calls.append(update)
+
+        sub._sync_upsert = fake_upsert  # type: ignore[method-assign]
+
+        worker = asyncio.create_task(sub._reconcile_worker())
+        await asyncio.sleep(0)
+        try:
+            private = json.dumps({"type": "Trading.PositionUpdate", "data": {}})
+            rate = json.dumps(
+                {
+                    "type": "Trading.Instrument.Rate",
+                    "data": {
+                        "InstrumentID": 1001,
+                        "Bid": "100",
+                        "Ask": "101",
+                        "Date": "2026-04-24T14:30:00Z",
+                    },
+                }
+            )
+
+            class FakeWs:
+                def __init__(self, frames: list[str]) -> None:
+                    self._frames = frames
+
+                def __aiter__(self) -> FakeWs:
+                    return self
+
+                async def __anext__(self) -> str:
+                    if not self._frames:
+                        raise StopAsyncIteration
+                    return self._frames.pop(0)
+
+            await sub._listen(FakeWs([private, rate]))  # type: ignore[arg-type]
+
+            assert len(upsert_calls) == 1
+            assert upsert_calls[0].instrument_id == 1001
+        finally:
+            worker.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await worker


### PR DESCRIPTION
## What

WS subscriber now subscribes to ``private`` topic alongside instrument rates. Trading.OrderFor* / Trading.Position* / Trading.Credit* events trigger a debounced REST reconcile (``get_portfolio()`` + ``sync_portfolio()``) so local DB picks up externally-driven order/position state without waiting for the daily 06:00 sweep.

## Why

Closes the gap between Slice 1 (live prices in ``quotes``) and the operator's experience: opening a position via the eToro web UI now reflects in the eBull dashboard within ~3s, not 24h.

## Test plan

- [x] 33 unit/integration tests including:
  - `test_burst_collapses_to_single_call` — N rapid events → 1 reconcile
  - `test_event_during_reconcile_triggers_followup` — serial execution proven via `end-1 < start-2` ordering
  - `test_runner_exception_does_not_kill_worker` — failure resilience
  - `test_stop_waits_for_in_flight_reconcile_thread` — shutdown safety: stop() blocks until the OS thread completes, so pool.close() can't race against sync_portfolio
  - `test_rate_frame_after_private_event_still_upserts` — _listen() keeps consuming after private dispatch
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 2664 passed
- [x] Codex 3-round review: cancel/replace race, shutdown-mid-reconcile pool race, submit-not-yet-running race all resolved before push