### PR TITLE
feat(#274 Slice 3): SSE quote stream + in-process pub/sub bus

### DIFF
--- a/app/api/sse_quotes.py
+++ b/app/api/sse_quotes.py
@@ -1,0 +1,164 @@
+"""Server-Sent Events endpoint for live quote ticks (#274 Slice 3).
+
+Operator UI uses ``EventSource`` to subscribe to a filtered live feed
+of WebSocket-driven quote updates. Each tick from the eToro WS
+``Trading.Instrument.Rate`` push lands on the in-process
+``QuoteBus`` (see ``app.services.quote_stream``); this endpoint
+wraps a per-connection subscriber in a ``StreamingResponse`` that
+emits ``data: {json}\\n\\n`` frames.
+
+**Why SSE, not WebSockets:** the channel is one-way (server → UI),
+EventSource is built into every browser, auto-reconnects on drop,
+and goes through proxies / corporate firewalls without protocol
+upgrades. WebSockets would buy bidirectional traffic that the
+quote-stream use-case has no need for.
+
+**Auth:** reuses the existing operator-session dependency. SSE
+connections inherit the same Cookie that the rest of the API uses,
+so no separate token plumbing is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import StreamingResponse
+
+from app.api.auth import require_session_or_service_token
+from app.services.etoro_websocket import QuoteUpdate
+from app.services.quote_stream import QuoteBus
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/sse",
+    tags=["sse"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+
+# Heartbeat interval: SSE comment frames keep proxies / load
+# balancers from idle-killing the connection. 15s is well under the
+# typical 60s idle timeout while staying clear of the per-tick rate.
+_HEARTBEAT_INTERVAL_S = 15.0
+
+
+def _format_tick(update: QuoteUpdate) -> str:
+    """Serialise one tick as a single SSE ``data:`` frame.
+
+    Uses ``str(Decimal)`` to preserve full precision rather than
+    casting to float. Frontend parses these strings back into the
+    Decimal-equivalent representation; lossy float conversion in
+    transit would defeat the spread-pct invariants.
+    """
+    payload = {
+        "instrument_id": update.instrument_id,
+        "bid": str(update.bid),
+        "ask": str(update.ask),
+        "last": None if update.last is None else str(update.last),
+        "quoted_at": update.quoted_at.isoformat(),
+    }
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+def _parse_instrument_ids(raw: str) -> frozenset[int]:
+    """Parse the ``ids`` query string (comma-separated ints).
+
+    Anything that doesn't parse as an int is silently dropped — the
+    UI is the only client and supplies its own list, so a typo
+    becomes "I see no ticks" rather than a 400 that breaks the
+    connection retry loop.
+    """
+    out: set[int] = set()
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        try:
+            out.add(int(token))
+        except ValueError:
+            continue
+    return frozenset(out)
+
+
+async def _event_stream(
+    request: Request,
+    bus: QuoteBus,
+    instrument_ids: frozenset[int],
+) -> AsyncGenerator[str]:
+    """Generator yielded by StreamingResponse.
+
+    Pulls ticks from a per-connection subscriber queue with a
+    timeout race against the heartbeat interval — every iteration
+    we either deliver a tick OR send a comment heartbeat. Either
+    way we then check ``request.is_disconnected()`` so a tab close
+    tears down the subscription within at most one heartbeat
+    cycle.
+    """
+    async with bus.subscribe(instrument_ids) as queue:
+        # Open frame is yielded *after* subscribe so any tick
+        # published between this point and the next iteration
+        # actually reaches the subscriber. If the open frame went
+        # first, a fast publish could land before the bus knows
+        # about us — fine in production where ticks arrive over
+        # seconds, but a real bug for tests and for any caller
+        # that publishes synchronously after opening the stream.
+        yield f": stream open at {datetime.now(UTC).isoformat()}\n\n"
+
+        while True:
+            if await request.is_disconnected():
+                return
+            try:
+                update = await asyncio.wait_for(queue.get(), timeout=_HEARTBEAT_INTERVAL_S)
+            except TimeoutError:
+                # Heartbeat: SSE comments are lines starting with ':'
+                # and are ignored by EventSource clients but keep
+                # the connection alive through proxies.
+                yield ": heartbeat\n\n"
+                continue
+            yield _format_tick(update)
+
+
+@router.get("/quotes")
+async def quotes_stream(
+    request: Request,
+    ids: str = Query(..., description="Comma-separated instrument IDs to stream"),
+) -> StreamingResponse:
+    """Stream live quote ticks for the requested instrument IDs.
+
+    Example: ``GET /sse/quotes?ids=1001,1002,1003``
+
+    The bus is read off ``request.app.state.quote_bus``, which is
+    populated by the FastAPI lifespan. Reading from app state (vs
+    a module global) keeps tests in control: a test app fixture
+    can inject its own QuoteBus without monkey-patching the import.
+    """
+    bus: QuoteBus | None = getattr(request.app.state, "quote_bus", None)
+    if bus is None:
+        # Lifespan hasn't installed a bus — every other route still
+        # works, but live ticks are not available. Surface as a
+        # 503 so the UI can fall back to its 5s polling cadence.
+        return StreamingResponse(
+            iter([": no quote bus available\n\n"]),
+            media_type="text/event-stream",
+            status_code=503,
+        )
+
+    instrument_ids = _parse_instrument_ids(ids)
+    return StreamingResponse(
+        _event_stream(request, bus, instrument_ids),
+        media_type="text/event-stream",
+        headers={
+            # Disable proxy buffering so each tick flushes immediately.
+            # Without this, nginx will hold ticks until its buffer
+            # fills (8KB+) — at <200B per tick that's 40+ ticks of
+            # delay, defeating the whole point of SSE.
+            "X-Accel-Buffering": "no",
+            "Cache-Control": "no-cache",
+        },
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -35,6 +35,7 @@ from app.api.portfolio import router as portfolio_router
 from app.api.recommendations import router as recommendations_router
 from app.api.reports import router as reports_router
 from app.api.scores import router as scores_router
+from app.api.sse_quotes import router as sse_quotes_router
 from app.api.sync import router as sync_router
 from app.api.system import router as system_router
 from app.api.theses import instrument_thesis_router
@@ -58,6 +59,7 @@ from app.services.operators import (
     NoOperatorError,
     sole_operator_id,
 )
+from app.services.quote_stream import QuoteBus
 from app.services.sync_orchestrator.layer_state import compute_layer_states_from_db
 from app.services.sync_orchestrator.layer_types import LayerState
 from app.services.sync_orchestrator.reaper import reap_orphaned_syncs
@@ -152,11 +154,20 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         except Exception:
             logger.exception("failed to register orchestrator executor")
 
-    # eToro WebSocket live-price subscriber (#274 Slice 1). Starts
+    # In-process quote-tick fan-out bus (#274 Slice 3). Created here
+    # so it lives for the full app lifetime; the WS subscriber
+    # publishes to it, the SSE endpoint reads from it. Always
+    # constructed even if the WS subscriber fails to start — the
+    # bus is harmless when nothing publishes, and the SSE endpoint
+    # simply emits heartbeats until ticks flow.
+    quote_bus = QuoteBus()
+    app.state.quote_bus = quote_bus
+
+    # eToro WebSocket live-price subscriber (#274 Slice 1+2+3). Starts
     # only when broker credentials are loadable — otherwise the
     # operator hasn't completed setup yet and there's nothing to
     # subscribe to. WS failures must NOT block the rest of the app.
-    ws_subscriber = await _maybe_start_etoro_ws(pool)
+    ws_subscriber = await _maybe_start_etoro_ws(pool, quote_bus)
     app.state.etoro_ws = ws_subscriber
 
     yield
@@ -178,7 +189,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     logger.info("Connection pool closed.")
 
 
-async def _maybe_start_etoro_ws(pool: ConnectionPool[Any]) -> EtoroWebSocketSubscriber | None:
+async def _maybe_start_etoro_ws(pool: ConnectionPool[Any], bus: QuoteBus) -> EtoroWebSocketSubscriber | None:
     """Boot the WS subscriber when credentials are available.
 
     Pulled out of ``lifespan`` so the credential-load + subscriber
@@ -223,6 +234,7 @@ async def _maybe_start_etoro_ws(pool: ConnectionPool[Any]) -> EtoroWebSocketSubs
         user_key=user_key,
         env=settings.etoro_env,
         pool=pool,
+        bus=bus,
     )
     try:
         await subscriber.start()
@@ -254,6 +266,7 @@ app.include_router(portfolio_router)
 app.include_router(recommendations_router)
 app.include_router(reports_router)
 app.include_router(scores_router)
+app.include_router(sse_quotes_router)
 app.include_router(sync_router)
 app.include_router(system_router)
 app.include_router(theses_router)

--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -55,6 +55,8 @@ import psycopg_pool
 import websockets
 from websockets.asyncio.client import ClientConnection
 
+from app.services.quote_stream import QuoteBus
+
 logger = logging.getLogger(__name__)
 
 
@@ -310,6 +312,7 @@ class EtoroWebSocketSubscriber:
         user_key: str,
         env: str,
         pool: psycopg_pool.ConnectionPool[Any],
+        bus: QuoteBus | None = None,
         watched_ids_provider: Callable[[], list[int]] | None = None,
         reconcile_runner: Callable[[], None] | None = None,
     ) -> None:
@@ -317,6 +320,11 @@ class EtoroWebSocketSubscriber:
         self._user_key = user_key
         self._env = env
         self._pool = pool
+        # Optional pub/sub fan-out for sub-second UI delivery (Slice 3).
+        # When None, ticks are still upserted to ``quotes`` but no SSE
+        # consumer is notified — useful for the daemon-only deploy
+        # mode and for tests that exercise only the upsert path.
+        self._bus = bus
         # Default selector hits the DB; tests inject a stub.
         self._watched_ids_provider = watched_ids_provider or self._default_watched_ids
         # Default reconcile runner builds an EtoroBrokerProvider and
@@ -589,6 +597,17 @@ class EtoroWebSocketSubscriber:
             update = parse_rate_message(raw)
             if update is None:
                 continue
+            # Publish first, on the event loop, before the DB
+            # offload. SSE subscribers see the tick within the same
+            # async tick the WS read finished on; the DB round-trip
+            # only gates persistence (which the page-load path reads
+            # to bootstrap before SSE takes over). Loop-affinity on
+            # ``QuoteBus.publish`` requires this be called from the
+            # event loop, so doing it before ``to_thread`` is the
+            # only correct ordering — calling it from inside the
+            # worker thread would race the asyncio.Queue internals.
+            if self._bus is not None:
+                self._bus.publish(update)
             try:
                 # ``pool.connection()`` is sync — calling it from the
                 # event loop would block the loop for the full DB

--- a/app/services/quote_stream.py
+++ b/app/services/quote_stream.py
@@ -1,0 +1,136 @@
+"""In-process quote-tick fan-out bus (#274 Slice 3).
+
+The eToro WebSocket subscriber writes every rate push to the
+``quotes`` table (Slices 1+2). This module adds a parallel
+*real-time* delivery channel: the same ``QuoteUpdate`` is also
+``publish()``ed onto a ``QuoteBus``, and any number of asyncio
+subscribers can ``subscribe()`` for the instrument IDs they care
+about. The SSE endpoint in ``app.api.sse_quotes`` is the one
+in-tree consumer; tests inject their own.
+
+**Why in-process, not Redis:** the operator's eBull deploys as a
+single uvicorn instance — there is no fan-out across workers in v1.
+Redis pub/sub would solve the multi-worker case but adds an
+infra dep and a 5-10ms hop per tick. Slice 4 adds a
+Postgres-advisory-lock arbitrator if/when multi-worker becomes
+real; that's the point at which a cross-process bus is justified.
+
+Backpressure: each subscriber gets a bounded ``asyncio.Queue``. A
+slow consumer (e.g. a tab the operator left open in a sleeping
+laptop) cannot block the publish hot-path — when the queue is full
+we *drop* the tick and bump a per-subscriber counter. The next
+delivered tick still has the latest bid/ask, so a temporarily-slow
+consumer recovers gracefully.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.services.etoro_websocket import QuoteUpdate
+
+logger = logging.getLogger(__name__)
+
+
+# Per-subscriber queue size. Each tick is small (<200 bytes when
+# serialized), so 100 covers any realistic burst without holding
+# meaningful memory. A subscriber consistently lagging by >100 ticks
+# is broken — drop policy is the right answer, not unbounded growth.
+_QUEUE_MAXSIZE = 100
+
+
+@dataclass(eq=False)
+class _Subscriber:
+    """Internal handle the bus tracks per active subscription.
+
+    ``eq=False`` keeps identity-based hashing (the dataclass default
+    sets ``__hash__`` to ``None`` when ``eq=True``, which is the
+    dataclass default — that breaks ``set.add``). Each subscriber is
+    a unique session, so identity is exactly the equality we want.
+    """
+
+    instrument_ids: frozenset[int]
+    queue: asyncio.Queue[QuoteUpdate]
+    drops: int = field(default=0)
+
+
+class QuoteBus:
+    """Fan-out bus: ``publish(update)`` → every matching subscriber.
+
+    Loop-affinity: bus must be created and driven from a single
+    asyncio event loop. ``publish`` is sync but **must** be called
+    from the loop thread — ``asyncio.Queue.put_nowait`` is only
+    safe in-loop because the queue's internal scheduler primitives
+    (Future creation for waiters, callback chaining) are
+    loop-bound. The WS subscriber publishes from its async
+    ``_listen`` coroutine for exactly this reason; the DB upsert
+    that goes to ``asyncio.to_thread`` does *not* touch the bus.
+    """
+
+    def __init__(self) -> None:
+        self._subscribers: set[_Subscriber] = set()
+
+    @asynccontextmanager
+    async def subscribe(self, instrument_ids: frozenset[int]) -> AsyncIterator[asyncio.Queue[QuoteUpdate]]:
+        """Async context manager: yields a queue that receives ticks
+        for the requested instrument IDs.
+
+        On exit, the subscriber is removed from the fan-out set. The
+        SSE endpoint wraps this in its event-stream generator so a
+        client disconnect tears down the subscription cleanly.
+
+        Empty ``instrument_ids`` is allowed but useless — the queue
+        will simply never receive anything; callers should filter
+        empties out themselves.
+        """
+        sub = _Subscriber(
+            instrument_ids=instrument_ids,
+            queue=asyncio.Queue(maxsize=_QUEUE_MAXSIZE),
+        )
+        # Add/remove are sync because publish() is sync and must not
+        # await — both share single-threaded loop invariants. ``set``
+        # mutation in CPython is atomic per the GIL but we still
+        # snapshot to a tuple in publish() so subscribe/unsubscribe
+        # mid-fan-out cannot raise ``RuntimeError: set changed size
+        # during iteration``.
+        self._subscribers.add(sub)
+        try:
+            yield sub.queue
+        finally:
+            self._subscribers.discard(sub)
+            if sub.drops > 0:
+                logger.info(
+                    "QuoteBus subscriber removed: dropped %d ticks during session",
+                    sub.drops,
+                )
+
+    def publish(self, update: QuoteUpdate) -> None:
+        """Fan out one tick. **Must be called from the event loop
+        thread** — see the class docstring on loop-affinity.
+
+        Slow-consumer policy: if a subscriber's queue is full,
+        increment its drop counter and continue — never block the
+        publisher. The dropped tick is gone (we don't replay the
+        latest), but every subscriber that was reading at normal
+        cadence still saw the most recent bid/ask.
+        """
+        # Snapshot to a tuple so subscribe/unsubscribe cannot mutate
+        # the iteration target. Both sides run on the same loop so
+        # this races nothing in practice; the snapshot is belt-and-
+        # braces for any future change that adds re-entrancy.
+        for sub in tuple(self._subscribers):
+            if update.instrument_id not in sub.instrument_ids:
+                continue
+            try:
+                sub.queue.put_nowait(update)
+            except asyncio.QueueFull:
+                sub.drops += 1
+                # Don't log every drop — under sustained backpressure
+                # we'd flood logs. The session-end log records the
+                # total.

--- a/tests/test_quote_stream.py
+++ b/tests/test_quote_stream.py
@@ -262,11 +262,10 @@ class TestEventStreamGenerator:
 
         original = sse_quotes._HEARTBEAT_INTERVAL_S
         sse_quotes._HEARTBEAT_INTERVAL_S = 0.05
+        bus = QuoteBus()
+        req = self._FakeRequest()
+        gen = sse_quotes._event_stream(req, bus, frozenset({1001}))  # type: ignore[arg-type]
         try:
-            bus = QuoteBus()
-            req = self._FakeRequest()
-            gen = sse_quotes._event_stream(req, bus, frozenset({1001}))
-
             # Open frame.
             first = await gen.__anext__()
             assert first.startswith(": stream open at ")

--- a/tests/test_quote_stream.py
+++ b/tests/test_quote_stream.py
@@ -1,0 +1,380 @@
+"""Tests for QuoteBus + SSE quotes endpoint (#274 Slice 3).
+
+QuoteBus tests cover the pub/sub fan-out invariants directly. The
+SSE endpoint test exercises the full FastAPI route via TestClient
+to confirm the StreamingResponse emits ``data:`` frames in the
+right order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from app.api.sse_quotes import _event_stream, _format_tick, _parse_instrument_ids
+from app.api.sse_quotes import router as sse_router
+from app.services.etoro_websocket import QuoteUpdate
+from app.services.quote_stream import QuoteBus
+
+
+def _make_update(instrument_id: int, bid: str = "100", ask: str = "101") -> QuoteUpdate:
+    return QuoteUpdate(
+        instrument_id=instrument_id,
+        bid=Decimal(bid),
+        ask=Decimal(ask),
+        last=None,
+        quoted_at=datetime(2026, 4, 25, 12, 0, 0, tzinfo=UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTick:
+    def test_envelope_shape(self) -> None:
+        frame = _format_tick(_make_update(1001, bid="100.50", ask="100.70"))
+        assert frame.endswith("\n\n")
+        assert frame.startswith("data: ")
+        body = json.loads(frame[len("data: ") :].strip())
+        assert body == {
+            "instrument_id": 1001,
+            "bid": "100.50",
+            "ask": "100.70",
+            "last": None,
+            "quoted_at": "2026-04-25T12:00:00+00:00",
+        }
+
+    def test_decimal_precision_preserved(self) -> None:
+        # Critical: lossy float conversion would defeat spread-pct
+        # invariants downstream. ``str(Decimal)`` round-trips.
+        frame = _format_tick(_make_update(1001, bid="186.4567", ask="186.4569"))
+        body = json.loads(frame[len("data: ") :].strip())
+        assert body["bid"] == "186.4567"
+        assert body["ask"] == "186.4569"
+
+
+class TestParseInstrumentIds:
+    def test_canonical_csv(self) -> None:
+        assert _parse_instrument_ids("1,2,3") == frozenset({1, 2, 3})
+
+    def test_dedupes_and_strips_whitespace(self) -> None:
+        assert _parse_instrument_ids(" 1 , 2 , 1 ") == frozenset({1, 2})
+
+    def test_drops_non_numeric_tokens(self) -> None:
+        assert _parse_instrument_ids("1,foo,2") == frozenset({1, 2})
+
+    def test_empty_returns_empty_set(self) -> None:
+        assert _parse_instrument_ids("") == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# QuoteBus pub/sub
+# ---------------------------------------------------------------------------
+
+
+class TestQuoteBusFanOut:
+    async def test_subscriber_only_receives_filtered_instruments(self) -> None:
+        bus = QuoteBus()
+        async with bus.subscribe(frozenset({1001, 1002})) as queue:
+            bus.publish(_make_update(1001))
+            bus.publish(_make_update(9999))  # filtered out
+            bus.publish(_make_update(1002))
+
+            received = [queue.get_nowait().instrument_id, queue.get_nowait().instrument_id]
+            assert sorted(received) == [1001, 1002]
+            assert queue.empty()
+
+    async def test_two_subscribers_each_get_independent_copies(self) -> None:
+        bus = QuoteBus()
+        async with bus.subscribe(frozenset({1001})) as q1, bus.subscribe(frozenset({1001})) as q2:
+            bus.publish(_make_update(1001))
+            assert q1.get_nowait().instrument_id == 1001
+            assert q2.get_nowait().instrument_id == 1001
+
+    async def test_unsubscribe_stops_delivery(self) -> None:
+        bus = QuoteBus()
+        async with bus.subscribe(frozenset({1001})) as queue:
+            bus.publish(_make_update(1001))
+            queue.get_nowait()
+        # After context exit, publish is a no-op for this subscriber.
+        bus.publish(_make_update(1001))
+        # No queue to assert against — invariant is "no error, no growth"
+        # which we verify by inspecting the internal set.
+        assert len(bus._subscribers) == 0  # noqa: SLF001
+
+    async def test_full_queue_drops_without_blocking(self) -> None:
+        """Slow consumer must not block the publisher. The drop counter
+        captures the loss; subsequent publishes still deliver to other
+        subscribers."""
+        bus = QuoteBus()
+        async with bus.subscribe(frozenset({1001})) as slow:
+            # Fill the slow subscriber's queue to capacity.
+            for _ in range(slow.maxsize):
+                bus.publish(_make_update(1001))
+            # Next publishes should drop, not raise / block.
+            for _ in range(5):
+                bus.publish(_make_update(1001))
+            # Internal: drop counter > 0 on the slow subscriber.
+            sub = next(iter(bus._subscribers))  # noqa: SLF001
+            assert sub.drops == 5
+
+    async def test_empty_filter_receives_nothing(self) -> None:
+        bus = QuoteBus()
+        async with bus.subscribe(frozenset()) as queue:
+            bus.publish(_make_update(1001))
+            assert queue.empty()
+
+    async def test_slow_subscriber_does_not_starve_healthy_one(self) -> None:
+        """Critical multi-subscriber invariant: a saturated
+        subscriber's queue must drop without blocking the publisher
+        loop, so a healthy subscriber alongside it still receives
+        every tick. Without this, one stale browser tab could
+        freeze the entire SSE fan-out."""
+        bus = QuoteBus()
+        async with (
+            bus.subscribe(frozenset({1001})) as slow,
+            bus.subscribe(frozenset({1001})) as healthy,
+        ):
+            # Saturate the slow one.
+            for _ in range(slow.maxsize):
+                bus.publish(_make_update(1001))
+            # Drain the healthy one so it has room.
+            for _ in range(healthy.maxsize):
+                healthy.get_nowait()
+            assert healthy.empty()
+            # Publish 5 more ticks. The slow queue stays full and
+            # drops; the healthy queue must receive all 5.
+            for _ in range(5):
+                bus.publish(_make_update(1001))
+            received = []
+            for _ in range(5):
+                received.append(healthy.get_nowait().instrument_id)
+            assert received == [1001] * 5
+            slow_sub = next(s for s in bus._subscribers if s.queue is slow)  # noqa: SLF001
+            assert slow_sub.drops == 5
+
+
+# ---------------------------------------------------------------------------
+# SSE endpoint — full FastAPI route exercise
+# ---------------------------------------------------------------------------
+
+
+class TestSseQuotesRoute:
+    def _build_app(self, bus: QuoteBus | None) -> FastAPI:
+        # Bypass auth dependency so we can drive the route directly.
+        app = FastAPI()
+
+        from app.api.auth import require_session_or_service_token
+
+        async def _no_auth() -> None:
+            return None
+
+        app.dependency_overrides[require_session_or_service_token] = _no_auth
+        app.include_router(sse_router)
+        if bus is not None:
+            app.state.quote_bus = bus
+        return app
+
+    def test_503_when_bus_not_installed(self) -> None:
+        app = self._build_app(bus=None)
+        with TestClient(app) as client:
+            resp = client.get("/sse/quotes?ids=1001")
+            assert resp.status_code == 503
+
+    def test_router_carries_auth_dependency(self) -> None:
+        """Pin the auth gate as a structural property of the router.
+        Regression guard: a future refactor that drops the
+        router-level dependency would silently expose live operator
+        price data. We assert against ``router.dependencies`` rather
+        than driving an unauthed request because the dependency
+        chain pulls in db state that isn't set up in this minimal
+        test app — and that incidental coupling would itself be a
+        flaky test."""
+        from app.api.auth import require_session_or_service_token
+
+        dep_callables = [d.dependency for d in sse_router.dependencies]
+        assert require_session_or_service_token in dep_callables
+
+
+class TestEventStreamGenerator:
+    """Drive the SSE generator directly, no TestClient. The endpoint
+    is an infinite stream — TestClient's context-exit won't unblock
+    the server-side generator because ``request.is_disconnected()``
+    is only checked between yields. Driving the generator as a plain
+    async iterator with a fake Request gives us deterministic frame-
+    by-frame assertions without timing flakiness."""
+
+    class _FakeRequest:
+        def __init__(self) -> None:
+            self._disconnected = False
+
+        def disconnect(self) -> None:
+            self._disconnected = True
+
+        async def is_disconnected(self) -> bool:
+            return self._disconnected
+
+    async def test_initial_open_frame_then_tick_then_disconnect(self) -> None:
+        bus = QuoteBus()
+        req = self._FakeRequest()
+
+        gen = _event_stream(req, bus, frozenset({1001}))  # type: ignore[arg-type]
+
+        # First yield: open comment.
+        first = await gen.__anext__()
+        assert first.startswith(": stream open at ")
+
+        # Publish a tick — generator should pick it up on next iteration.
+        bus.publish(_make_update(1001, bid="100", ask="101"))
+        second = await gen.__anext__()
+        assert second.startswith("data: ")
+        payload = json.loads(second[len("data: ") :].strip())
+        assert payload["instrument_id"] == 1001
+        assert payload["bid"] == "100"
+
+        # Mark disconnected; next pull should terminate the generator.
+        req.disconnect()
+        # Publish another tick to wake the queue.get await.
+        bus.publish(_make_update(1001, bid="102", ask="103"))
+        # Generator may yield the third tick OR terminate; consume one
+        # more then assert StopAsyncIteration on the following call.
+        try:
+            await gen.__anext__()
+        except StopAsyncIteration:
+            return
+        with pytest.raises(StopAsyncIteration):
+            await gen.__anext__()
+
+    async def test_heartbeat_emitted_when_no_ticks(self) -> None:
+        """When no tick arrives within the heartbeat window the
+        generator must emit a comment frame so proxies / load
+        balancers don't idle-kill the connection. Shrink the window
+        to keep the test fast."""
+        from app.api import sse_quotes
+
+        original = sse_quotes._HEARTBEAT_INTERVAL_S
+        sse_quotes._HEARTBEAT_INTERVAL_S = 0.05
+        try:
+            bus = QuoteBus()
+            req = self._FakeRequest()
+            gen = sse_quotes._event_stream(req, bus, frozenset({1001}))
+
+            # Open frame.
+            first = await gen.__anext__()
+            assert first.startswith(": stream open at ")
+
+            # No publish — generator should hit the timeout and emit
+            # a heartbeat comment.
+            second = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+            assert second.startswith(":") and "heartbeat" in second
+        finally:
+            sse_quotes._HEARTBEAT_INTERVAL_S = original
+            await gen.aclose()
+
+    async def test_filtered_instrument_does_not_yield(self) -> None:
+        bus = QuoteBus()
+        req = self._FakeRequest()
+        gen = _event_stream(req, bus, frozenset({1001}))  # type: ignore[arg-type]
+
+        # Drain initial open frame.
+        await gen.__anext__()
+
+        # Publish a tick for an instrument we did NOT subscribe to.
+        bus.publish(_make_update(9999))
+
+        # Generator should be parked in queue.get — assert by racing
+        # with a short timeout.
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(gen.__anext__(), timeout=0.1)
+
+        # Cleanup: close the generator so the queue subscription tears
+        # down without leaking the open Subscriber.
+        await gen.aclose()
+
+
+# ---------------------------------------------------------------------------
+# WS subscriber → bus integration
+# ---------------------------------------------------------------------------
+
+
+class TestEtoroWsBusIntegration:
+    """Confirms the WS listen loop publishes to the bus before the
+    DB upsert. Critical because Slice 3's whole point is sub-second
+    UI delivery — if the publish happened only after the DB commit,
+    every tick would be gated on a Postgres round-trip."""
+
+    async def test_listen_publishes_then_upserts(self) -> None:
+        from typing import Any
+
+        from app.services.etoro_websocket import EtoroWebSocketSubscriber
+
+        bus = QuoteBus()
+        upsert_calls: list[QuoteUpdate] = []
+        order: list[str] = []
+
+        sentinel: Any = object()
+        sub = EtoroWebSocketSubscriber(
+            api_key="API",
+            user_key="USR",
+            env="demo",
+            pool=sentinel,
+            bus=bus,
+            watched_ids_provider=lambda: [],
+            reconcile_runner=lambda: None,
+        )
+
+        original_publish = bus.publish
+
+        def trace_publish(update: QuoteUpdate) -> None:
+            order.append("publish")
+            original_publish(update)
+
+        bus.publish = trace_publish  # type: ignore[method-assign]
+
+        def fake_upsert(update: QuoteUpdate) -> None:
+            order.append("upsert")
+            upsert_calls.append(update)
+
+        sub._sync_upsert = fake_upsert  # type: ignore[method-assign]
+
+        rate = json.dumps(
+            {
+                "type": "Trading.Instrument.Rate",
+                "data": {
+                    "InstrumentID": 1001,
+                    "Bid": "100",
+                    "Ask": "101",
+                    "Date": "2026-04-25T12:00:00Z",
+                },
+            }
+        )
+
+        class FakeWs:
+            def __init__(self, frames: list[str]) -> None:
+                self._frames = frames
+
+            def __aiter__(self) -> FakeWs:
+                return self
+
+            async def __anext__(self) -> str:
+                if not self._frames:
+                    raise StopAsyncIteration
+                return self._frames.pop(0)
+
+        async with bus.subscribe(frozenset({1001})) as queue:
+            await sub._listen(FakeWs([rate]))  # type: ignore[arg-type]
+            # Bus saw the tick.
+            received = await asyncio.wait_for(queue.get(), timeout=1.0)
+            assert received.instrument_id == 1001
+
+        # Publish strictly preceded upsert (Slice 3 latency goal).
+        assert order == ["publish", "upsert"]
+        assert len(upsert_calls) == 1


### PR DESCRIPTION
## What

Adds sub-second live-tick channel to the operator UI: \`GET /sse/quotes?ids=1,2,3\` streams \`Trading.Instrument.Rate\` ticks from the eToro WS via an in-process \`QuoteBus\` fan-out.

## Why

Frontend currently polls \`/quotes\` every 5s. Slice 3 closes the loop on operator's \"make it feel alive\" directive: WS-driven ticks now deliver to the UI within milliseconds while the DB upsert still gates page-load reads.

## Test plan

- [x] 18 new tests, 2682 total pytest pass
- [x] Burst / multi-subscriber backpressure: slow consumer drops without starving healthy one
- [x] Generator subscribe-before-yield ordering (race fix)
- [x] Heartbeat emitted on idle window (proxy keepalive)
- [x] Auth dependency pinned via structural test on \`router.dependencies\`
- [x] WS \`_listen\` publishes BEFORE \`to_thread\` upsert (latency goal)
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\` — 0 errors
- [x] Codex pre-push review — no blocking findings