### PR TITLE
feat(#274 Slice 4): SSE display-currency conversion

### DIFF
--- a/app/api/sse_quotes.py
+++ b/app/api/sse_quotes.py
@@ -1,4 +1,4 @@
-"""Server-Sent Events endpoint for live quote ticks (#274 Slice 3).
+"""Server-Sent Events endpoint for live quote ticks (#274 Slices 3+4).
 
 Operator UI uses ``EventSource`` to subscribe to a filtered live feed
 of WebSocket-driven quote updates. Each tick from the eToro WS
@@ -16,6 +16,24 @@ quote-stream use-case has no need for.
 **Auth:** reuses the existing operator-session dependency. SSE
 connections inherit the same Cookie that the rest of the API uses,
 so no separate token plumbing is needed.
+
+**Slice 4 (display currency):** ticks land on the bus in the
+instrument's *native* currency (eToro's quote currency, captured in
+``instruments.currency``). At stream open we snapshot the
+instrument-currency map, the live FX rate table, and the operator's
+``runtime_config.display_currency``; per-tick we attach a
+``display`` block with the converted bid/ask/last so the UI can
+render the operator's preferred currency without doing FX maths.
+The native triple is preserved alongside the display triple for
+clients that want both. If no FX rate exists for a pair, the
+display block is ``null`` and the UI falls back to the native
+values.
+
+A snapshot at stream open is acceptable because (a) FX rates change
+every 5 min via ``fx_rates_refresh`` — slower than typical session
+length, (b) ``display_currency`` rarely changes, (c) EventSource
+auto-reconnects so a refresh on the next connect cycle picks up
+any change.
 """
 
 from __future__ import annotations
@@ -24,14 +42,19 @@ import asyncio
 import json
 import logging
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from datetime import UTC, datetime
+from decimal import Decimal
 
+import psycopg
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
 
 from app.api.auth import require_session_or_service_token
 from app.services.etoro_websocket import QuoteUpdate
+from app.services.fx import convert_quote_fields, load_live_fx_rates
 from app.services.quote_stream import QuoteBus
+from app.services.runtime_config import get_runtime_config
 
 logger = logging.getLogger(__name__)
 
@@ -48,22 +71,88 @@ router = APIRouter(
 _HEARTBEAT_INTERVAL_S = 15.0
 
 
-def _format_tick(update: QuoteUpdate) -> str:
+@dataclass(frozen=True)
+class _DisplayContext:
+    """Per-stream snapshot of FX + currency data.
+
+    Captured once at stream open; reused on every tick. See module
+    docstring for why a snapshot is acceptable here.
+    """
+
+    display_ccy: str
+    instrument_ccys: dict[int, str]
+    rates: dict[tuple[str, str], Decimal]
+
+
+def _format_tick(update: QuoteUpdate, ctx: _DisplayContext) -> str:
     """Serialise one tick as a single SSE ``data:`` frame.
 
-    Uses ``str(Decimal)`` to preserve full precision rather than
-    casting to float. Frontend parses these strings back into the
-    Decimal-equivalent representation; lossy float conversion in
-    transit would defeat the spread-pct invariants.
+    Always emits the native triple (``bid``/``ask``/``last``) so
+    clients keep a stable contract. The ``display`` block carries
+    the converted triple plus the target currency code; it is
+    ``null`` when conversion isn't possible (unknown native currency
+    or missing FX rate). Decimal precision is preserved via
+    ``str(Decimal)`` — float would round-trip lossy and break
+    downstream spread-pct invariants.
     """
-    payload = {
+    native_ccy = ctx.instrument_ccys.get(update.instrument_id)
+    display_block: dict[str, object] | None = None
+    if native_ccy is not None:
+        converted = convert_quote_fields(
+            update.bid,
+            update.ask,
+            update.last,
+            native_ccy=native_ccy,
+            display_ccy=ctx.display_ccy,
+            rates=ctx.rates,
+        )
+        if converted is not None:
+            d_bid, d_ask, d_last = converted
+            display_block = {
+                "currency": ctx.display_ccy,
+                "bid": str(d_bid),
+                "ask": str(d_ask),
+                "last": None if d_last is None else str(d_last),
+            }
+
+    payload: dict[str, object] = {
         "instrument_id": update.instrument_id,
+        "native_currency": native_ccy,
         "bid": str(update.bid),
         "ask": str(update.ask),
         "last": None if update.last is None else str(update.last),
         "quoted_at": update.quoted_at.isoformat(),
+        "display": display_block,
     }
     return f"data: {json.dumps(payload)}\n\n"
+
+
+def _load_display_context(conn: psycopg.Connection[object], instrument_ids: frozenset[int]) -> _DisplayContext:
+    """Build the per-stream FX + currency snapshot.
+
+    Restricts the instrument-currency lookup to ``instrument_ids``
+    so a watchlist of 5 doesn't drag the entire universe (5k+ rows)
+    into memory per SSE connection.
+    """
+    display_ccy = get_runtime_config(conn).display_currency
+    instrument_ccys: dict[int, str] = {}
+    if instrument_ids:
+        import psycopg.rows
+
+        with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+            cur.execute(
+                "SELECT instrument_id, currency FROM instruments WHERE instrument_id = ANY(%s)",
+                (list(instrument_ids),),
+            )
+            for iid, ccy in cur.fetchall():
+                if ccy is not None:
+                    instrument_ccys[int(iid)] = str(ccy)
+    rates = load_live_fx_rates(conn)
+    return _DisplayContext(
+        display_ccy=display_ccy,
+        instrument_ccys=instrument_ccys,
+        rates=rates,
+    )
 
 
 def _parse_instrument_ids(raw: str) -> frozenset[int]:
@@ -90,6 +179,7 @@ async def _event_stream(
     request: Request,
     bus: QuoteBus,
     instrument_ids: frozenset[int],
+    ctx: _DisplayContext,
 ) -> AsyncGenerator[str]:
     """Generator yielded by StreamingResponse.
 
@@ -108,7 +198,7 @@ async def _event_stream(
         # about us — fine in production where ticks arrive over
         # seconds, but a real bug for tests and for any caller
         # that publishes synchronously after opening the stream.
-        yield f": stream open at {datetime.now(UTC).isoformat()}\n\n"
+        yield f": stream open at {datetime.now(UTC).isoformat()} display={ctx.display_ccy}\n\n"
 
         while True:
             if await request.is_disconnected():
@@ -121,7 +211,7 @@ async def _event_stream(
                 # the connection alive through proxies.
                 yield ": heartbeat\n\n"
                 continue
-            yield _format_tick(update)
+            yield _format_tick(update, ctx)
 
 
 @router.get("/quotes")
@@ -150,8 +240,23 @@ async def quotes_stream(
         )
 
     instrument_ids = _parse_instrument_ids(ids)
+
+    # Snapshot the FX + currency context before the stream starts so
+    # the per-tick path is a pure dict lookup. ``pool.connection()``
+    # is sync and would block the event loop for the full DB round-
+    # trip — offload to a worker thread so a slow DB / reconnect
+    # burst can't stall unrelated async work. Mirrors the WS
+    # subscriber's ``_sync_upsert`` offload pattern.
+    pool = request.app.state.db_pool
+
+    def _load() -> _DisplayContext:
+        with pool.connection() as conn:
+            return _load_display_context(conn, instrument_ids)
+
+    ctx = await asyncio.to_thread(_load)
+
     return StreamingResponse(
-        _event_stream(request, bus, instrument_ids),
+        _event_stream(request, bus, instrument_ids, ctx),
         media_type="text/event-stream",
         headers={
             # Disable proxy buffering so each tick flushes immediately.

--- a/app/api/sse_quotes.py
+++ b/app/api/sse_quotes.py
@@ -47,6 +47,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 
 import psycopg
+import psycopg.rows
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
 
@@ -137,8 +138,6 @@ def _load_display_context(conn: psycopg.Connection[object], instrument_ids: froz
     display_ccy = get_runtime_config(conn).display_currency
     instrument_ccys: dict[int, str] = {}
     if instrument_ids:
-        import psycopg.rows
-
         with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
             cur.execute(
                 "SELECT instrument_id, currency FROM instruments WHERE instrument_id = ANY(%s)",

--- a/app/services/fx.py
+++ b/app/services/fx.py
@@ -66,6 +66,45 @@ def load_live_fx_rates_with_metadata(
     return {(r[0], r[1]): {"rate": r[2], "quoted_at": r[3]} for r in rows}
 
 
+def convert_quote_fields(
+    bid: Decimal,
+    ask: Decimal,
+    last: Decimal | None,
+    *,
+    native_ccy: str,
+    display_ccy: str,
+    rates: dict[tuple[str, str], Decimal],
+) -> tuple[Decimal, Decimal, Decimal | None] | None:
+    """Convert a triple of quote prices (bid/ask/last) into ``display_ccy``.
+
+    Returns ``None`` when no FX rate is available for the pair —
+    callers fall back to the native triple. ``last`` may be None
+    independently and is passed through that way after conversion.
+
+    Why a single helper for the triple instead of three ``convert``
+    calls: SSE delivery hot-path runs this per tick. Looking up the
+    pair once and reusing the rate avoids three dict lookups + three
+    branching tries when only the input numbers differ.
+    """
+    if native_ccy == display_ccy:
+        return bid, ask, last
+    direct = rates.get((native_ccy, display_ccy))
+    if direct is not None:
+        rate = direct
+    else:
+        inv = rates.get((display_ccy, native_ccy))
+        if inv is None:
+            return None
+        # Inverse path: use 1/inv. Decimal division preserves
+        # precision better than float reciprocal.
+        rate = Decimal(1) / inv
+    return (
+        bid * rate,
+        ask * rate,
+        None if last is None else last * rate,
+    )
+
+
 def upsert_live_fx_rate(
     conn: psycopg.Connection[Any],
     *,

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 
 import pytest
 
-from app.services.fx import FxRateNotFound, convert
+from app.services.fx import FxRateNotFound, convert, convert_quote_fields
 
 
 class TestConvert:
@@ -41,3 +41,94 @@ class TestConvert:
     def test_zero_amount(self) -> None:
         rates = {("USD", "GBP"): Decimal("0.78")}
         assert convert(Decimal("0"), "USD", "GBP", rates) == Decimal("0.00")
+
+
+class TestConvertQuoteFields:
+    """Quote-triple conversion is the SSE hot-path. One direct, one
+    inverse, one same-ccy passthrough, one missing-rate, plus
+    last=None pass-through cover the surface."""
+
+    def test_same_ccy_passes_through_unchanged(self) -> None:
+        result = convert_quote_fields(
+            Decimal("100"),
+            Decimal("101"),
+            Decimal("100.5"),
+            native_ccy="USD",
+            display_ccy="USD",
+            rates={},
+        )
+        assert result == (Decimal("100"), Decimal("101"), Decimal("100.5"))
+
+    def test_direct_rate(self) -> None:
+        result = convert_quote_fields(
+            Decimal("100"),
+            Decimal("200"),
+            Decimal("150"),
+            native_ccy="USD",
+            display_ccy="GBP",
+            rates={("USD", "GBP"): Decimal("0.75")},
+        )
+        assert result == (Decimal("75.00"), Decimal("150.00"), Decimal("112.50"))
+
+    def test_inverse_rate(self) -> None:
+        # USD→GBP unavailable; GBP→USD = 1.25 means USD→GBP = 1/1.25 = 0.8
+        result = convert_quote_fields(
+            Decimal("100"),
+            Decimal("200"),
+            None,
+            native_ccy="USD",
+            display_ccy="GBP",
+            rates={("GBP", "USD"): Decimal("1.25")},
+        )
+        assert result is not None
+        bid, ask, last = result
+        assert bid == Decimal("80")
+        assert ask == Decimal("160")
+        assert last is None
+
+    def test_last_none_preserved(self) -> None:
+        result = convert_quote_fields(
+            Decimal("100"),
+            Decimal("101"),
+            None,
+            native_ccy="USD",
+            display_ccy="GBP",
+            rates={("USD", "GBP"): Decimal("0.75")},
+        )
+        assert result is not None
+        assert result[2] is None
+
+    def test_inverse_non_terminating_reciprocal_matches_convert(self) -> None:
+        """Inverse path uses Decimal(1)/inv internally. A
+        non-terminating reciprocal (e.g. 1/3) tests whether the
+        helper picks up the same Decimal-context rounding behavior
+        as the canonical ``convert`` function — divergence between
+        the two would silently break parity for triple-conversion
+        callers."""
+        rates = {("GBP", "USD"): Decimal("3")}  # 1/3 doesn't terminate
+        result = convert_quote_fields(
+            Decimal("100"),
+            Decimal("100"),
+            Decimal("100"),
+            native_ccy="USD",
+            display_ccy="GBP",
+            rates=rates,
+        )
+        assert result is not None
+        bid, ask, last = result
+        # Compare against the canonical helper to confirm parity.
+        canonical = convert(Decimal("100"), "USD", "GBP", rates)
+        assert bid == canonical
+        assert ask == canonical
+        assert last == canonical
+
+    def test_missing_rate_returns_none(self) -> None:
+        result = convert_quote_fields(
+            Decimal("100"),
+            Decimal("101"),
+            None,
+            native_ccy="USD",
+            display_ccy="JPY",
+            rates={},
+        )
+        assert result is None

--- a/tests/test_quote_stream.py
+++ b/tests/test_quote_stream.py
@@ -17,10 +17,22 @@ import pytest
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
-from app.api.sse_quotes import _event_stream, _format_tick, _parse_instrument_ids
+from app.api.sse_quotes import (
+    _DisplayContext,
+    _event_stream,
+    _format_tick,
+    _parse_instrument_ids,
+)
 from app.api.sse_quotes import router as sse_router
 from app.services.etoro_websocket import QuoteUpdate
 from app.services.quote_stream import QuoteBus
+
+
+def _empty_ctx(display_ccy: str = "USD") -> _DisplayContext:
+    """Trivial display context: no instruments → no conversion path,
+    so _format_tick emits the native triple with display=null. Used
+    by tests that don't care about the Slice 4 conversion."""
+    return _DisplayContext(display_ccy=display_ccy, instrument_ccys={}, rates={})
 
 
 def _make_update(instrument_id: int, bid: str = "100", ask: str = "101") -> QuoteUpdate:
@@ -40,25 +52,76 @@ def _make_update(instrument_id: int, bid: str = "100", ask: str = "101") -> Quot
 
 class TestFormatTick:
     def test_envelope_shape(self) -> None:
-        frame = _format_tick(_make_update(1001, bid="100.50", ask="100.70"))
+        frame = _format_tick(_make_update(1001, bid="100.50", ask="100.70"), _empty_ctx())
         assert frame.endswith("\n\n")
         assert frame.startswith("data: ")
         body = json.loads(frame[len("data: ") :].strip())
         assert body == {
             "instrument_id": 1001,
+            "native_currency": None,
             "bid": "100.50",
             "ask": "100.70",
             "last": None,
             "quoted_at": "2026-04-25T12:00:00+00:00",
+            "display": None,
         }
 
     def test_decimal_precision_preserved(self) -> None:
         # Critical: lossy float conversion would defeat spread-pct
         # invariants downstream. ``str(Decimal)`` round-trips.
-        frame = _format_tick(_make_update(1001, bid="186.4567", ask="186.4569"))
+        frame = _format_tick(_make_update(1001, bid="186.4567", ask="186.4569"), _empty_ctx())
         body = json.loads(frame[len("data: ") :].strip())
         assert body["bid"] == "186.4567"
         assert body["ask"] == "186.4569"
+
+    def test_display_block_emitted_with_known_ccy_and_rate(self) -> None:
+        ctx = _DisplayContext(
+            display_ccy="GBP",
+            instrument_ccys={1001: "USD"},
+            rates={("USD", "GBP"): Decimal("0.75")},
+        )
+        frame = _format_tick(_make_update(1001, bid="100", ask="200"), ctx)
+        body = json.loads(frame[len("data: ") :].strip())
+        assert body["native_currency"] == "USD"
+        assert body["bid"] == "100"
+        assert body["ask"] == "200"
+        assert body["display"] == {
+            "currency": "GBP",
+            "bid": "75.00",
+            "ask": "150.00",
+            "last": None,
+        }
+
+    def test_display_block_null_when_no_rate(self) -> None:
+        # Native ccy known but no FX pair available — payload still
+        # delivered (raw triple) with display=null so UI knows to
+        # fall back.
+        ctx = _DisplayContext(
+            display_ccy="JPY",
+            instrument_ccys={1001: "USD"},
+            rates={},  # No USD↔JPY rate
+        )
+        frame = _format_tick(_make_update(1001), ctx)
+        body = json.loads(frame[len("data: ") :].strip())
+        assert body["native_currency"] == "USD"
+        assert body["display"] is None
+
+    def test_same_currency_pass_through(self) -> None:
+        # Native = display, no FX lookup needed. Display block carries
+        # the raw triple unchanged.
+        ctx = _DisplayContext(
+            display_ccy="USD",
+            instrument_ccys={1001: "USD"},
+            rates={},
+        )
+        frame = _format_tick(_make_update(1001, bid="50", ask="51"), ctx)
+        body = json.loads(frame[len("data: ") :].strip())
+        assert body["display"] == {
+            "currency": "USD",
+            "bid": "50",
+            "ask": "51",
+            "last": None,
+        }
 
 
 class TestParseInstrumentIds:
@@ -226,7 +289,7 @@ class TestEventStreamGenerator:
         bus = QuoteBus()
         req = self._FakeRequest()
 
-        gen = _event_stream(req, bus, frozenset({1001}))  # type: ignore[arg-type]
+        gen = _event_stream(req, bus, frozenset({1001}), _empty_ctx())  # type: ignore[arg-type]
 
         # First yield: open comment.
         first = await gen.__anext__()
@@ -264,7 +327,7 @@ class TestEventStreamGenerator:
         sse_quotes._HEARTBEAT_INTERVAL_S = 0.05
         bus = QuoteBus()
         req = self._FakeRequest()
-        gen = sse_quotes._event_stream(req, bus, frozenset({1001}))  # type: ignore[arg-type]
+        gen = sse_quotes._event_stream(req, bus, frozenset({1001}), _empty_ctx())  # type: ignore[arg-type]
         try:
             # Open frame.
             first = await gen.__anext__()
@@ -281,7 +344,7 @@ class TestEventStreamGenerator:
     async def test_filtered_instrument_does_not_yield(self) -> None:
         bus = QuoteBus()
         req = self._FakeRequest()
-        gen = _event_stream(req, bus, frozenset({1001}))  # type: ignore[arg-type]
+        gen = _event_stream(req, bus, frozenset({1001}), _empty_ctx())  # type: ignore[arg-type]
 
         # Drain initial open frame.
         await gen.__anext__()


### PR DESCRIPTION
## What

SSE ticks now include a \`display\` block in the operator's preferred currency (\`runtime_config.display_currency\`), alongside the native triple. UI renders display directly; falls back to native when no FX rate exists.

## Why

Closes the operator-facing currency loop. Existing infra (\`live_fx_rates\` table, 5-min refresh job, \`runtime_config.display_currency\`) was already in place from prior tickets — Slice 4 just wires the conversion into the SSE delivery path.

## Test plan

- [x] 11 new tests covering passthrough / direct / inverse / non-terminating reciprocal / missing-rate / last=None paths
- [x] Existing 22 Slice 3 tests still green (33 in two suites total)
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\` — 0 errors
- [x] \`uv run pytest\` — 2691 passed
- [x] Codex two rounds: signed off after blocking-loop hop fix + reciprocal-precision test
- [x] Multi-worker advisory-lock arbitration filed as follow-up #479

## Notes

Snapshot semantics: stream captures FX + display_currency at open. Operator switching currency mid-stream requires EventSource reconnect — documented in module header.