### PR TITLE
fix: silence httpx + httpcore INFO logs to unblock asyncio loop

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -65,6 +65,20 @@ from app.services.sync_orchestrator.layer_types import LayerState
 from app.services.sync_orchestrator.reaper import reap_orphaned_syncs
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
+
+# Third-party loggers default to INFO, which is far too noisy for our
+# workload. The SEC ingester fan-out emits 500-1000 httpx requests
+# per hourly tick; without this hoist, every fetch logs an INFO line
+# to stdout. Under sustained load the resulting print-throughput
+# starves the asyncio event loop on stdout I/O — unrelated request
+# handlers go unresponsive while the SEC backfill is mid-run.
+# WARNING preserves error visibility (4xx/5xx, retries) without the
+# per-request flood.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+# httpcore is the connection-level layer underneath httpx; its
+# DEBUG/INFO is even noisier (one line per socket event).
+logging.getLogger("httpcore").setLevel(logging.WARNING)
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Symptom

Site goes unresponsive every time SEC ingester jobs run. Terminal floods with hundreds of \`INFO httpx HTTP Request: GET https://...\` lines.

## Root cause

Default httpx logger is INFO. SEC jobs (\`sec_insider_transactions_ingest\`, \`sec_insider_transactions_backfill\`, \`sec_filing_documents_ingest\`) collectively fire 500-1500 httpx requests per hourly tick — one log line per request. Print throughput to stdout/stderr blocks the GIL and starves the asyncio event loop, so unrelated FastAPI request handlers stall while the ingester runs.

## Fix

Hoist \`httpx\` + \`httpcore\` loggers to \`WARNING\`. Preserves 4xx/5xx + retry visibility; removes the per-request flood.

## Test plan

- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\` — 0 errors
- [x] \`uv run pytest tests/smoke/test_app_boots.py\` — green
- [ ] Live: terminal during next SEC ingest run shows only summary log lines, not per-request

## Out of scope

Root scaling concern (per-job concurrency limits, ingester yielding to async work, splitting SEC backfill across smaller chunks) — file as larger follow-up.