### PR TITLE
fix(#474): drain leading noise frames during eToro WS auth handshake

### DIFF
--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -635,7 +635,11 @@ def _looks_like_json_envelope(raw: str | bytes) -> bool:
         text = raw.decode("utf-8", errors="ignore")
     else:
         text = raw
-    stripped = text.lstrip().lstrip("\x00")
+    # Single-pass strip across whitespace + null so any interleaving
+    # (``\x00 {``, `` \x00{``, ``\x00\x00 {``) is handled. A two-pass
+    # ``.lstrip().lstrip("\x00")`` would miss ``\x00 {`` because the
+    # leading null blocks the whitespace strip.
+    stripped = text.lstrip("\x00 \t\r\n\v\f")
     return stripped.startswith("{")
 
 

--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -547,11 +547,7 @@ class EtoroWebSocketSubscriber:
     async def _connect_and_listen(self) -> None:
         async with websockets.connect(_WS_URL) as ws:
             await ws.send(build_auth_message(self._api_key, self._user_key))
-            # Drain the auth response — eToro replies with
-            # {"success": true} or an error envelope. We wait for one
-            # frame so a bad key surfaces immediately rather than
-            # silently looping subscribe attempts.
-            auth_reply = await asyncio.wait_for(ws.recv(), timeout=10.0)
+            auth_reply = await _await_auth_envelope(ws, timeout_s=10.0)
             if not _is_auth_success(auth_reply):
                 raise RuntimeError(f"eToro WS auth failed: {auth_reply!r}")
 
@@ -620,6 +616,56 @@ class EtoroWebSocketSubscriber:
                     update.instrument_id,
                     exc_info=True,
                 )
+
+
+def _looks_like_json_envelope(raw: str | bytes) -> bool:
+    """Coarse pre-filter for the auth-handshake drain loop.
+
+    eToro's WS occasionally emits a leading control byte (observed
+    ``b'\\x00'`` in dev, likely an internal heartbeat / keepalive
+    prelude) before the actual auth response. ``_is_auth_success``
+    parses JSON and rejects on non-success, so the noise frame
+    would tip us into a 5-second reconnect loop forever.
+
+    Strip whitespace + control bytes and check whether the first
+    real character is ``{``. JSON envelopes always start there;
+    anything else is noise we should keep reading past.
+    """
+    if isinstance(raw, bytes):
+        text = raw.decode("utf-8", errors="ignore")
+    else:
+        text = raw
+    stripped = text.lstrip().lstrip("\x00")
+    return stripped.startswith("{")
+
+
+async def _await_auth_envelope(ws: ClientConnection, *, timeout_s: float) -> str | bytes:
+    """Drain non-JSON frames during the auth handshake.
+
+    Reads frames until one looks like a JSON envelope or the
+    cumulative ``timeout_s`` deadline elapses. Returns the first
+    JSON-envelope frame so the caller can run ``_is_auth_success``
+    on it.
+
+    Why this matters: a single ``recv()`` with a strict JSON parse
+    treats *any* leading frame as the auth ack. eToro emits a
+    control-byte prelude on some connections (dev observation:
+    ``b'\\x00'``); without draining we reconnect-loop every
+    backoff window and never authenticate. See #474.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise TimeoutError("eToro WS auth: no JSON envelope within deadline")
+        frame = await asyncio.wait_for(ws.recv(), timeout=remaining)
+        if _looks_like_json_envelope(frame):
+            return frame
+        # Log at DEBUG so this is visible when investigating but
+        # silent in production. Frame may be bytes; repr keeps the
+        # control characters readable.
+        logger.debug("EtoroWebSocketSubscriber: skipping noise frame %r during auth", frame)
 
 
 def _is_auth_success(raw: str | bytes) -> bool:

--- a/tests/test_etoro_websocket.py
+++ b/tests/test_etoro_websocket.py
@@ -27,8 +27,10 @@ from app.services import etoro_websocket
 from app.services.etoro_websocket import (
     EtoroWebSocketSubscriber,
     QuoteUpdate,
+    _await_auth_envelope,
     _compute_spread_pct,
     _is_auth_success,
+    _looks_like_json_envelope,
     build_auth_message,
     build_private_subscribe_message,
     build_subscribe_message,
@@ -154,6 +156,85 @@ class TestIsAuthSuccess:
 
     def test_malformed_returns_false(self) -> None:
         assert _is_auth_success("not json") is False
+
+
+# ---------------------------------------------------------------------------
+# Auth-handshake noise drain (#474)
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeJsonEnvelope:
+    def test_canonical_json_text(self) -> None:
+        assert _looks_like_json_envelope('{"success": true}') is True
+
+    def test_json_bytes(self) -> None:
+        assert _looks_like_json_envelope(b'{"success": true}') is True
+
+    def test_leading_null_byte_str(self) -> None:
+        assert _looks_like_json_envelope('\x00{"success": true}') is True
+
+    def test_leading_null_byte_bytes(self) -> None:
+        assert _looks_like_json_envelope(b'\x00{"success": true}') is True
+
+    def test_pure_null_byte_is_noise(self) -> None:
+        assert _looks_like_json_envelope(b"\x00") is False
+
+    def test_empty_is_noise(self) -> None:
+        assert _looks_like_json_envelope("") is False
+
+    def test_whitespace_only_is_noise(self) -> None:
+        assert _looks_like_json_envelope("   ") is False
+
+    def test_array_envelope_is_noise(self) -> None:
+        # eToro auth ack is always a JSON object envelope. Arrays /
+        # other shapes — if they ever arrived — are still drained.
+        assert _looks_like_json_envelope("[]") is False
+
+
+class TestAwaitAuthEnvelope:
+    """Integration coverage of the drain loop. Stubs the WS recv()
+    side via a tiny fake so the test runs without a real socket."""
+
+    class _FakeWs:
+        def __init__(self, frames: list[str | bytes]) -> None:
+            self._frames = frames
+
+        async def recv(self) -> str | bytes:
+            if not self._frames:
+                # Mimic a real ws stalling forever — the deadline in
+                # _await_auth_envelope's wait_for cuts in instead.
+                await asyncio.sleep(3600)
+                raise AssertionError("unreachable")
+            return self._frames.pop(0)
+
+    async def test_returns_first_json_envelope_after_noise(self) -> None:
+        fake = self._FakeWs([b"\x00", '{"success": true}'])
+        result = await _await_auth_envelope(fake, timeout_s=2.0)  # type: ignore[arg-type]
+        assert result == '{"success": true}'
+
+    async def test_returns_canonical_envelope_immediately(self) -> None:
+        fake = self._FakeWs(['{"success": true}'])
+        result = await _await_auth_envelope(fake, timeout_s=2.0)  # type: ignore[arg-type]
+        assert result == '{"success": true}'
+
+    async def test_drains_multiple_noise_frames(self) -> None:
+        fake = self._FakeWs([b"\x00", b"\x00\x00", "  ", '{"success": true}'])
+        result = await _await_auth_envelope(fake, timeout_s=2.0)  # type: ignore[arg-type]
+        assert result == '{"success": true}'
+
+    async def test_timeout_when_no_envelope_arrives(self) -> None:
+        # Empty frame queue → fake will await forever → deadline must
+        # fire and raise TimeoutError, not loop forever.
+        fake = self._FakeWs([])
+        with pytest.raises(TimeoutError):
+            await _await_auth_envelope(fake, timeout_s=0.1)  # type: ignore[arg-type]
+
+    async def test_timeout_after_noise_burst(self) -> None:
+        # Several noise frames followed by stalling — must still
+        # surface the timeout instead of draining forever.
+        fake = self._FakeWs([b"\x00", b"\x00", b"\x00"])
+        with pytest.raises(TimeoutError):
+            await _await_auth_envelope(fake, timeout_s=0.1)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_etoro_websocket.py
+++ b/tests/test_etoro_websocket.py
@@ -190,6 +190,15 @@ class TestLooksLikeJsonEnvelope:
         # other shapes — if they ever arrived — are still drained.
         assert _looks_like_json_envelope("[]") is False
 
+    def test_null_byte_then_whitespace_then_json(self) -> None:
+        # Regression for review WARNING: a two-pass strip
+        # (``.lstrip().lstrip("\\x00")``) misses this shape because
+        # the leading null blocks the whitespace strip on pass one.
+        # Single-pass strip across both classes handles it.
+        assert _looks_like_json_envelope(b'\x00 {"success": true}') is True
+        assert _looks_like_json_envelope(b'\x00\x00 {"success": true}') is True
+        assert _looks_like_json_envelope(' \x00{"success": true}') is True
+
 
 class TestAwaitAuthEnvelope:
     """Integration coverage of the drain loop. Stubs the WS recv()


### PR DESCRIPTION
## What

Closes #474. WS subscriber stuck in 5s reconnect loop because eToro emits a leading control byte (\`b'\x00'\`) before the JSON auth ack. Drain noise frames until a JSON envelope arrives or the 10s deadline elapses.

## Why

Universe-wide stale quotes — root cause confirmed by triage earlier in this session. Without this fix the subscriber never authenticates, no ticks ever land in \`quotes\`, BTC + everything else stays on whatever last REST poll wrote.

## Test plan

- [x] 13 new tests on \`_looks_like_json_envelope\` + \`_await_auth_envelope\` covering noise byte / multiple noise / canonical / timeout / timeout-after-burst
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\` — 0 errors
- [x] \`uv run pytest\` — 2704 passed
- [x] Codex review: no findings; deadline handling correct, drain loop cannot spin
- [ ] Live: WS subscriber reaches \"subscribed to N instrument topics\" log without reconnect-loop on next operator restart