### PR TITLE
fix(#477): route fetch_filing_index through www.sec.gov

### DIFF
--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -262,22 +262,22 @@ class SecFilingsProvider(FilingsProvider):
         ``filing_documents`` service for the per-document manifest
         (#452).
 
-        Provider-level JSON payload: the raw response is persisted
-        to ``data/raw/sec/sec_filing_*`` as the audit-trail contract
-        from prevention-log entries #171 / #177 requires — the
-        per-document structural capture lands in ``filing_documents``
-        via the service layer, and the raw dump is retained for
-        audit alongside it (structured JSON payloads remain on disk;
-        body text does not — see docs/review-prevention-log.md
-        "Every structured field from an upstream document lands in
-        SQL").
+        **Host pin (#477):** the ``/Archives/edgar/data/...`` path
+        is served only by ``www.sec.gov``. ``data.sec.gov`` (the
+        host backing ``self._http`` for /submissions/, /api/xbrl/)
+        404s every request against this path. We use
+        ``self._http_tickers`` (configured for ``www.sec.gov``,
+        same 10 req/s shared throttle) with a fully-qualified URL
+        so the host-to-client mapping is explicit at the call site.
+        Mirrors :func:`fetch_document_text` which has the same
+        host requirement.
         """
         raw_id = provider_filing_id.replace("-", "")
         if len(raw_id) != 18:
             raise FilingNotFound(f"Invalid accession number format: {provider_filing_id}")
         cik_padded = raw_id[:10]
-        path = f"/Archives/edgar/data/{int(cik_padded)}/{raw_id}/{raw_id}-index.json"
-        resp = self._http.get(path)
+        absolute_url = f"https://www.sec.gov/Archives/edgar/data/{int(cik_padded)}/{raw_id}/{raw_id}-index.json"
+        resp = self._http_tickers.get(absolute_url)
         if resp.status_code == 404:
             return None
         resp.raise_for_status()

--- a/tests/test_sec_provider_filing_index.py
+++ b/tests/test_sec_provider_filing_index.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 
 import httpx
+import pytest
 
 from app.providers.implementations.sec_edgar import SecFilingsProvider
 from app.providers.resilient_client import ResilientClient
@@ -99,8 +100,5 @@ def test_filing_index_raises_on_500() -> None:
     provider = SecFilingsProvider(user_agent="test test@example.com")
     _rewire_tickers_transport(provider, httpx.MockTransport(handler))
 
-    try:
+    with pytest.raises(httpx.HTTPStatusError):
         provider.fetch_filing_index("0000320193-24-000001")
-    except httpx.HTTPStatusError:
-        return
-    raise AssertionError("expected HTTPStatusError on 500 response")

--- a/tests/test_sec_provider_filing_index.py
+++ b/tests/test_sec_provider_filing_index.py
@@ -1,0 +1,106 @@
+"""Tests for SecFilingsProvider.fetch_filing_index — host pin (#477).
+
+Regression: ``fetch_filing_index`` previously routed through
+``self._http`` (configured for ``data.sec.gov``), but the
+``/Archives/edgar/data/...`` path is only served by
+``www.sec.gov``. Every fetch returned 404, the service layer logged
+``fetch_errors=N`` per run, and ``filing_documents`` never
+populated. The fix routes through ``self._http_tickers``
+(configured for ``www.sec.gov``) with a fully-qualified URL.
+
+These tests pin the host so a future refactor that swaps clients
+fails loudly instead of silently 404ing.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from app.providers.implementations.sec_edgar import SecFilingsProvider
+from app.providers.resilient_client import ResilientClient
+
+
+def _rewire_tickers_transport(
+    provider: SecFilingsProvider,
+    transport: httpx.MockTransport,
+) -> None:
+    """Swap the provider's tickers client for one backed by a MockTransport.
+
+    Mirrors the pattern in ``test_sec_provider_master_index.py`` —
+    `_http_tickers` is the www.sec.gov-targeted client. After the
+    #477 fix, ``fetch_filing_index`` must go through this client, so
+    rewiring it lets the test intercept every call.
+    """
+    provider._tickers_client = httpx.Client(  # noqa: SLF001
+        headers={"User-Agent": "test test@example.com"},
+        transport=transport,
+    )
+    provider._http_tickers = ResilientClient(  # noqa: SLF001
+        provider._tickers_client,
+        min_request_interval_s=0.0,
+    )
+
+
+def test_filing_index_request_hits_www_sec_gov() -> None:
+    """Pin the host: every filing-index fetch must go to
+    ``www.sec.gov``. Regression for #477 where ``data.sec.gov`` was
+    used and 404'd 100% of the time."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, content=json.dumps({"directory": {"item": []}}))
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    result = provider.fetch_filing_index("0000320193-24-000001")
+    assert result == {"directory": {"item": []}}
+    assert len(captured) == 1
+    assert captured[0].url.host == "www.sec.gov"
+    # Path must use the int-coerced CIK (no leading zeros) per SEC's
+    # archive layout convention.
+    assert captured[0].url.path == "/Archives/edgar/data/320193/000032019324000001/000032019324000001-index.json"
+
+
+def test_filing_index_returns_none_on_404() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    result = provider.fetch_filing_index("0000320193-24-000099")
+    assert result is None
+
+
+def test_filing_index_returns_none_when_body_is_not_object() -> None:
+    """Defensive: if SEC returns a non-object JSON shape (array, scalar)
+    we return None rather than crashing the consumer."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=json.dumps([1, 2, 3]))
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    assert provider.fetch_filing_index("0000320193-24-000001") is None
+
+
+def test_filing_index_raises_on_500() -> None:
+    """Server errors propagate — the service layer's per-filing
+    try/except decides retry vs skip."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    try:
+        provider.fetch_filing_index("0000320193-24-000001")
+    except httpx.HTTPStatusError:
+        return
+    raise AssertionError("expected HTTPStatusError on 500 response")


### PR DESCRIPTION
## What

Closes #477. \`fetch_filing_index\` routed through \`data.sec.gov\` host but the \`/Archives/edgar/data/...\` path only resolves on \`www.sec.gov\`. 100% 404 rate. Switched to \`self._http_tickers\` (www.sec.gov) with absolute URL, mirroring \`fetch_document_text\`.

## Test plan

- [x] 4 new tests pin host + cover 404 / non-object body / 500
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\` — 0 errors
- [x] \`uv run pytest\` — 2709 passed
- [x] Codex: no findings
- [ ] Live: \`sec_filing_documents_ingest\` next run shows \`docs > 0\`, \`fetch_errors < 50\`