### PR TITLE
feat(#485): dynamic page-view WS subscribe/unsubscribe

### DIFF
--- a/app/api/sse_quotes.py
+++ b/app/api/sse_quotes.py
@@ -52,7 +52,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
 
 from app.api.auth import require_session_or_service_token
-from app.services.etoro_websocket import QuoteUpdate
+from app.services.etoro_websocket import EtoroWebSocketSubscriber, QuoteUpdate
 from app.services.fx import convert_quote_fields, load_live_fx_rates
 from app.services.quote_stream import QuoteBus
 from app.services.runtime_config import get_runtime_config
@@ -179,6 +179,7 @@ async def _event_stream(
     bus: QuoteBus,
     instrument_ids: frozenset[int],
     ctx: _DisplayContext,
+    ws_subscriber: EtoroWebSocketSubscriber | None,
 ) -> AsyncGenerator[str]:
     """Generator yielded by StreamingResponse.
 
@@ -188,29 +189,58 @@ async def _event_stream(
     way we then check ``request.is_disconnected()`` so a tab close
     tears down the subscription within at most one heartbeat
     cycle.
-    """
-    async with bus.subscribe(instrument_ids) as queue:
-        # Open frame is yielded *after* subscribe so any tick
-        # published between this point and the next iteration
-        # actually reaches the subscriber. If the open frame went
-        # first, a fast publish could land before the bus knows
-        # about us — fine in production where ticks arrive over
-        # seconds, but a real bug for tests and for any caller
-        # that publishes synchronously after opening the stream.
-        yield f": stream open at {datetime.now(UTC).isoformat()} display={ctx.display_ccy}\n\n"
 
-        while True:
-            if await request.is_disconnected():
-                return
-            try:
-                update = await asyncio.wait_for(queue.get(), timeout=_HEARTBEAT_INTERVAL_S)
-            except TimeoutError:
-                # Heartbeat: SSE comments are lines starting with ':'
-                # and are ignored by EventSource clients but keep
-                # the connection alive through proxies.
-                yield ": heartbeat\n\n"
-                continue
-            yield _format_tick(update, ctx)
+    If an eToro WS subscriber is available, the stream also
+    ref-counts the requested instrument IDs into the subscriber's
+    dynamic topic set — so ticks start flowing for any page the
+    operator opens, not just held + watchlist (#485). The
+    ``finally`` below drops the ref count so pages closed / tabs
+    killed release their subscriptions in bounded time.
+    """
+    id_list = sorted(instrument_ids)
+    # ``add_instruments`` call is placed INSIDE the try so a
+    # cancellation during its own await is still followed by the
+    # finally (remove_instruments). ``add_instruments`` commits its
+    # ref-count update under the subscriber's lock with no await in
+    # the critical section, so even a mid-call cancel leaves the
+    # ref incremented — the finally's decrement is correct. Without
+    # this structure, a client disconnect that fires between
+    # ``add_instruments`` entry and the ``try`` block would leak
+    # the dynamic ref permanently.
+    try:
+        if ws_subscriber is not None and id_list:
+            await ws_subscriber.add_instruments(id_list)
+        async with bus.subscribe(instrument_ids) as queue:
+            # Open frame is yielded *after* subscribe so any tick
+            # published between this point and the next iteration
+            # actually reaches the subscriber. If the open frame went
+            # first, a fast publish could land before the bus knows
+            # about us — fine in production where ticks arrive over
+            # seconds, but a real bug for tests and for any caller
+            # that publishes synchronously after opening the stream.
+            yield f": stream open at {datetime.now(UTC).isoformat()} display={ctx.display_ccy}\n\n"
+
+            while True:
+                if await request.is_disconnected():
+                    return
+                try:
+                    update = await asyncio.wait_for(queue.get(), timeout=_HEARTBEAT_INTERVAL_S)
+                except TimeoutError:
+                    # Heartbeat: SSE comments are lines starting
+                    # with ':' and are ignored by EventSource
+                    # clients but keep the connection alive through
+                    # proxies.
+                    yield ": heartbeat\n\n"
+                    continue
+                yield _format_tick(update, ctx)
+    finally:
+        # Drop the dynamic WS subscription. Runs on normal close,
+        # disconnect, or any raised exception — critical so a
+        # burst of closed tabs doesn't leak topic refs. If the ws
+        # is mid-reconnect ``remove_instruments`` just decrements
+        # in-memory state and the next connect won't re-subscribe.
+        if ws_subscriber is not None and id_list:
+            await ws_subscriber.remove_instruments(id_list)
 
 
 @router.get("/quotes")
@@ -254,8 +284,15 @@ async def quotes_stream(
 
     ctx = await asyncio.to_thread(_load)
 
+    # WS subscriber may be absent (pre-setup, credentials missing,
+    # WS auth failing) — live feed still degrades gracefully: the
+    # bus returns no ticks, the SSE stream sends heartbeats, UI
+    # falls back to its 5s poll. Pass whatever's on app.state and
+    # let ``_event_stream`` handle the None branch.
+    ws_subscriber: EtoroWebSocketSubscriber | None = getattr(request.app.state, "etoro_ws", None)
+
     return StreamingResponse(
-        _event_stream(request, bus, instrument_ids, ctx),
+        _event_stream(request, bus, instrument_ids, ctx, ws_subscriber),
         media_type="text/event-stream",
         headers={
             # Disable proxy buffering so each tick flushes immediately.

--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -116,6 +116,26 @@ def build_subscribe_message(instrument_ids: list[int]) -> str | None:
     )
 
 
+def build_unsubscribe_message(instrument_ids: list[int]) -> str | None:
+    """Compose the ``Unsubscribe`` op JSON for a list of instrument IDs.
+
+    Mirrors eToro's documented Subscribe envelope (same id/operation
+    structure, ``topics`` array payload) per
+    https://api-portal.etoro.com/api-reference/websocket/example-code.
+    Returns ``None`` on empty input so the caller skips a no-op frame.
+    """
+    if not instrument_ids:
+        return None
+    topics = [f"instrument:{iid}" for iid in instrument_ids]
+    return json.dumps(
+        {
+            "id": str(uuid.uuid4()),
+            "operation": "Unsubscribe",
+            "data": {"topics": topics},
+        }
+    )
+
+
 _PRIVATE_TOPIC = "private"
 
 
@@ -359,6 +379,39 @@ class EtoroWebSocketSubscriber:
         self._reconcile_idle = threading.Event()
         self._reconcile_idle.set()
 
+        # Dynamic topic registry (#485). Page-view-driven subscribers
+        # (SSE clients opening an instrument page) bump ref counts on
+        # ``add_instruments`` and drop them on ``remove_instruments``;
+        # the subscriber sends live Subscribe/Unsubscribe frames to
+        # eToro so the operator sees ticks for any ticker they're
+        # *actually looking at*, not only held + watchlist.
+        #
+        # Ref-counting avoids race conditions between overlapping
+        # SSE streams on the same instrument: the Nth client's
+        # close() must not yank the topic out from under the
+        # remaining N-1.
+        #
+        # ``_pinned_topics`` is the startup held ∪ watchlist set —
+        # we subscribe to these unconditionally at connect time and
+        # never unsubscribe via the dynamic path, even if
+        # ``remove_instruments`` is called for the same id. That
+        # guarantees the baseline portfolio feed can't be torn down
+        # accidentally by a page navigation.
+        self._dynamic_topic_refs: dict[int, int] = {}
+        self._pinned_topics: set[int] = set()
+        # Live WS connection, set inside ``_connect_and_listen`` once
+        # the auth handshake succeeds and cleared on disconnect. The
+        # dynamic add/remove path reads this to send frames from
+        # external request handlers; ``None`` means the connection
+        # is in a reconnect window and the request-handler path
+        # updates only the in-memory ref counts — the next connect
+        # seeds both pinned + dynamic sets from the committed state.
+        self._ws: ClientConnection | None = None
+        # Serialises concurrent add_instruments / remove_instruments
+        # calls that can arrive from multiple SSE clients on the
+        # same event loop. Small lock, held briefly.
+        self._topic_lock = asyncio.Lock()
+
     def _default_watched_ids(self) -> list[int]:
         with self._pool.connection() as conn:
             return fetch_watched_instrument_ids(conn)
@@ -554,29 +607,148 @@ class EtoroWebSocketSubscriber:
             # Selector hits the DB; offload to a worker thread so
             # the connect path doesn't block the event loop.
             ids = await asyncio.to_thread(self._watched_ids_provider)
-            sub_msg = build_subscribe_message(ids)
-            if sub_msg is not None:
-                await ws.send(sub_msg)
-                logger.info(
-                    "EtoroWebSocketSubscriber: subscribed to %d instrument topics",
-                    len(ids),
-                )
-            else:
-                logger.info(
-                    "EtoroWebSocketSubscriber: no watched instruments — "
-                    "connection will idle for rates until a position / "
-                    "watchlist add"
-                )
 
-            # Always subscribe to the private channel — even if the
-            # operator has no instruments yet, opening a position will
-            # emit a private event that triggers reconcile, which in
-            # turn picks up the new watched-IDs set on the next
-            # reconnect cycle.
-            await ws.send(build_private_subscribe_message())
-            logger.info("EtoroWebSocketSubscriber: subscribed to private channel")
+            # Hold the lock across snapshot + ``_ws`` publish + the
+            # batched initial Subscribe send. This serialises
+            # against every concurrent add/remove: a remove that
+            # would Unsubscribe a topic present in our batched
+            # snapshot cannot fire until we finish sending, so
+            # eToro never sees an out-of-order
+            # ``Unsubscribe(T) → Subscribe(..., T)`` that would
+            # strand T subscribed despite the operator not wanting
+            # it. Sending under the lock also means the batched
+            # frame and any concurrent delta frames are serialised
+            # in wire order.
+            #
+            # The private subscribe + listen loop run outside the
+            # lock but inside the ``_ws``-clearing try/finally, so
+            # any failure after startup-subscribe completes still
+            # clears ``_ws`` before the outer reconnect backoff.
+            try:
+                async with self._topic_lock:
+                    self._pinned_topics = set(ids)
+                    topics_to_send = sorted(self._pinned_topics | set(self._dynamic_topic_refs.keys()))
+                    self._ws = ws
+                    sub_msg = build_subscribe_message(topics_to_send)
+                    if sub_msg is not None:
+                        await ws.send(sub_msg)
+                        logger.info(
+                            "EtoroWebSocketSubscriber: subscribed to %d instrument topics (pinned=%d dynamic=%d)",
+                            len(topics_to_send),
+                            len(self._pinned_topics),
+                            len(self._dynamic_topic_refs),
+                        )
+                    else:
+                        logger.info(
+                            "EtoroWebSocketSubscriber: no watched instruments — "
+                            "connection will idle for rates until a position / "
+                            "watchlist add or a page-view subscribe"
+                        )
 
-            await self._listen(ws)
+                # Always subscribe to the private channel — even if
+                # the operator has no instruments yet, opening a
+                # position will emit a private event that triggers
+                # reconcile, which in turn picks up the new
+                # watched-IDs set on the next reconnect cycle.
+                await ws.send(build_private_subscribe_message())
+                logger.info("EtoroWebSocketSubscriber: subscribed to private channel")
+
+                await self._listen(ws)
+            finally:
+                # Clear ``_ws`` under the lock so any in-flight
+                # add/remove either completed its frame send (not
+                # holding the lock while sending, see those methods)
+                # or queues here on the lock and, on re-entry,
+                # observes ``_ws = None`` — deferring to the next
+                # reconnect cycle rather than sending on a dead
+                # socket.
+                async with self._topic_lock:
+                    self._ws = None
+
+    async def add_instruments(self, instrument_ids: list[int]) -> None:
+        """Bump ref counts for page-view subscribers; send a
+        Subscribe frame for any newly-tracked topics.
+
+        Idempotent for the *same* caller across overlapping calls
+        (bumping the count keeps the topic subscribed). Safe to call
+        from FastAPI request handlers — the frame send happens via
+        the shared ws ref; if the ws is mid-reconnect the counts are
+        still updated and the next connect cycle resubscribes.
+
+        Cancellation-safety: the ref-count update is pure-Python
+        under the lock with no ``await`` in the critical section,
+        so a CancelledError during this method always occurs AFTER
+        state commit. Callers pair this with a ``remove_instruments``
+        in their finally to guarantee no leaked refs.
+        """
+        if not instrument_ids:
+            return
+        newly_tracked: list[int] = []
+        async with self._topic_lock:
+            for iid in instrument_ids:
+                prior = self._dynamic_topic_refs.get(iid, 0)
+                self._dynamic_topic_refs[iid] = prior + 1
+                if prior == 0 and iid not in self._pinned_topics:
+                    newly_tracked.append(iid)
+            # Snapshot the ws ref under the lock to avoid a race
+            # with the connect-finally clearing it between our
+            # None-check and ``.send``. Release the lock before
+            # awaiting send — we don't want to block other
+            # add/remove callers for the full send duration, and
+            # send on a just-closed socket raises into our
+            # try/except below (safe, logged).
+            ws_ref = self._ws
+        if newly_tracked and ws_ref is not None:
+            msg = build_subscribe_message(newly_tracked)
+            if msg is not None:
+                try:
+                    await ws_ref.send(msg)
+                    logger.info(
+                        "EtoroWebSocketSubscriber: page-view subscribe %d topics",
+                        len(newly_tracked),
+                    )
+                except Exception:
+                    logger.warning(
+                        "EtoroWebSocketSubscriber: dynamic Subscribe send failed; "
+                        "next reconnect will resubscribe from ref counts",
+                        exc_info=True,
+                    )
+
+    async def remove_instruments(self, instrument_ids: list[int]) -> None:
+        """Decrement ref counts; send Unsubscribe for topics that
+        hit zero AND aren't in the pinned set.
+
+        Pinned topics (held + watchlist at connect time) are never
+        unsubscribed via this path — they survive every page-view
+        churn until the next reconnect refreshes the pinned set.
+        """
+        if not instrument_ids:
+            return
+        to_unsubscribe: list[int] = []
+        async with self._topic_lock:
+            for iid in instrument_ids:
+                if iid not in self._dynamic_topic_refs:
+                    continue
+                self._dynamic_topic_refs[iid] -= 1
+                if self._dynamic_topic_refs[iid] <= 0:
+                    del self._dynamic_topic_refs[iid]
+                    if iid not in self._pinned_topics:
+                        to_unsubscribe.append(iid)
+            ws_ref = self._ws
+        if to_unsubscribe and ws_ref is not None:
+            msg = build_unsubscribe_message(to_unsubscribe)
+            if msg is not None:
+                try:
+                    await ws_ref.send(msg)
+                    logger.info(
+                        "EtoroWebSocketSubscriber: page-view unsubscribe %d topics",
+                        len(to_unsubscribe),
+                    )
+                except Exception:
+                    logger.warning(
+                        "EtoroWebSocketSubscriber: dynamic Unsubscribe send failed",
+                        exc_info=True,
+                    )
 
     async def _listen(self, ws: ClientConnection) -> None:
         async for raw in ws:

--- a/tests/test_etoro_websocket.py
+++ b/tests/test_etoro_websocket.py
@@ -34,6 +34,7 @@ from app.services.etoro_websocket import (
     build_auth_message,
     build_private_subscribe_message,
     build_subscribe_message,
+    build_unsubscribe_message,
     fetch_watched_instrument_ids,
     is_private_event,
     parse_rate_message,
@@ -737,3 +738,210 @@ class TestListenResilience:
             worker.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await worker
+
+
+# ---------------------------------------------------------------------------
+# Dynamic page-view subscribe / unsubscribe (#485)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUnsubscribeMessage:
+    def test_envelope_shape(self) -> None:
+        raw = build_unsubscribe_message([1001, 1002])
+        assert raw is not None
+        msg = json.loads(raw)
+        assert msg["operation"] == "Unsubscribe"
+        assert msg["data"]["topics"] == ["instrument:1001", "instrument:1002"]
+        # No ``snapshot`` field — unsubscribe envelope per eToro
+        # docs is topics-only.
+        assert "snapshot" not in msg["data"]
+        assert "id" in msg
+
+    def test_empty_returns_none(self) -> None:
+        assert build_unsubscribe_message([]) is None
+
+
+class _DynFakeWs:
+    """Minimal stand-in for ``ClientConnection`` used to capture
+    dynamic frames sent by the subscriber outside of ``_listen``."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.fail_next_send: bool = False
+
+    async def send(self, payload: str) -> None:
+        if self.fail_next_send:
+            self.fail_next_send = False
+            raise OSError("simulated send failure")
+        self.sent.append(payload)
+
+
+def _make_dyn_subscriber() -> EtoroWebSocketSubscriber:
+    sentinel: Any = object()
+    return EtoroWebSocketSubscriber(
+        api_key="API",
+        user_key="USR",
+        env="demo",
+        pool=sentinel,
+        watched_ids_provider=lambda: [],
+        reconcile_runner=lambda: None,
+    )
+
+
+class TestDynamicAddInstruments:
+    async def test_first_add_sends_subscribe_frame(self) -> None:
+        sub = _make_dyn_subscriber()
+        fake = _DynFakeWs()
+        sub._ws = fake  # type: ignore[assignment]
+
+        await sub.add_instruments([1001, 1002])
+
+        assert len(fake.sent) == 1
+        msg = json.loads(fake.sent[0])
+        assert msg["operation"] == "Subscribe"
+        assert sorted(msg["data"]["topics"]) == ["instrument:1001", "instrument:1002"]
+        assert sub._dynamic_topic_refs == {1001: 1, 1002: 1}
+
+    async def test_second_add_for_same_id_bumps_ref_without_frame(self) -> None:
+        sub = _make_dyn_subscriber()
+        fake = _DynFakeWs()
+        sub._ws = fake  # type: ignore[assignment]
+
+        await sub.add_instruments([1001])
+        await sub.add_instruments([1001])
+
+        assert len(fake.sent) == 1  # only initial
+        assert sub._dynamic_topic_refs == {1001: 2}
+
+    async def test_pinned_topic_bumps_ref_without_subscribe_frame(self) -> None:
+        sub = _make_dyn_subscriber()
+        fake = _DynFakeWs()
+        sub._ws = fake  # type: ignore[assignment]
+        sub._pinned_topics = {1001}
+
+        await sub.add_instruments([1001])
+
+        assert fake.sent == []
+        assert sub._dynamic_topic_refs == {1001: 1}
+
+    async def test_add_with_no_live_ws_updates_refs_only(self) -> None:
+        """During a reconnect window ``_ws`` is None. Dynamic path
+        still tracks refs so the next connect re-subscribes from
+        accumulated state."""
+        sub = _make_dyn_subscriber()
+        sub._ws = None
+
+        await sub.add_instruments([1001])
+
+        assert sub._dynamic_topic_refs == {1001: 1}
+
+    async def test_send_failure_preserves_ref_counts(self) -> None:
+        sub = _make_dyn_subscriber()
+        fake = _DynFakeWs()
+        fake.fail_next_send = True
+        sub._ws = fake  # type: ignore[assignment]
+
+        await sub.add_instruments([1001])
+
+        assert sub._dynamic_topic_refs == {1001: 1}
+        assert fake.sent == []
+
+
+class TestDynamicRemoveInstruments:
+    async def test_decrement_to_zero_sends_unsubscribe(self) -> None:
+        sub = _make_dyn_subscriber()
+        fake = _DynFakeWs()
+        sub._ws = fake  # type: ignore[assignment]
+
+        await sub.add_instruments([1001])
+        await sub.remove_instruments([1001])
+
+        assert len(fake.sent) == 2
+        unsub = json.loads(fake.sent[1])
+        assert unsub["operation"] == "Unsubscribe"
+        assert unsub["data"]["topics"] == ["instrument:1001"]
+        assert sub._dynamic_topic_refs == {}
+
+    async def test_decrement_above_zero_does_not_unsubscribe(self) -> None:
+        sub = _make_dyn_subscriber()
+        fake = _DynFakeWs()
+        sub._ws = fake  # type: ignore[assignment]
+
+        await sub.add_instruments([1001])
+        await sub.add_instruments([1001])
+        await sub.remove_instruments([1001])
+
+        assert len(fake.sent) == 1
+        assert sub._dynamic_topic_refs == {1001: 1}
+
+    async def test_remove_pinned_never_unsubscribes(self) -> None:
+        """Held + watchlist (pinned) must survive every page-view
+        remove — baseline portfolio feed can't be torn down by a
+        tab close."""
+        sub = _make_dyn_subscriber()
+        fake = _DynFakeWs()
+        sub._ws = fake  # type: ignore[assignment]
+        sub._pinned_topics = {1001}
+
+        await sub.add_instruments([1001])
+        await sub.remove_instruments([1001])
+
+        assert fake.sent == []
+        assert sub._dynamic_topic_refs == {}
+
+    async def test_remove_unknown_id_is_noop(self) -> None:
+        sub = _make_dyn_subscriber()
+        fake = _DynFakeWs()
+        sub._ws = fake  # type: ignore[assignment]
+
+        await sub.remove_instruments([9999])
+
+        assert fake.sent == []
+        assert sub._dynamic_topic_refs == {}
+
+
+class TestReconnectSubscribesPinnedUnionDynamic:
+    """After reconnect, the Subscribe frame must cover the union of
+    (refreshed) pinned + accumulated dynamic ids. Without this, SSE
+    streams that survived the outage would stop receiving ticks."""
+
+    async def test_connect_subscribes_pinned_union_dynamic(self) -> None:
+        from unittest.mock import AsyncMock, MagicMock
+
+        sub = _make_dyn_subscriber()
+        # Dynamic set accumulated during an outage.
+        sub._dynamic_topic_refs = {2001: 1, 2002: 1}
+        # Override DB selector for startup pinned set.
+        sub._watched_ids_provider = lambda: [1001, 1002]  # type: ignore[method-assign]
+
+        fake_ws = MagicMock()
+        fake_ws.send = AsyncMock()
+        fake_ws.recv = AsyncMock(return_value='{"success": true}')
+        fake_ws.__aenter__ = AsyncMock(return_value=fake_ws)
+        fake_ws.__aexit__ = AsyncMock(return_value=False)
+
+        async def fake_listen(ws: Any) -> None:
+            return
+
+        sub._listen = fake_listen  # type: ignore[method-assign]
+
+        import app.services.etoro_websocket as ws_mod
+
+        original_connect = ws_mod.websockets.connect
+        ws_mod.websockets.connect = MagicMock(return_value=fake_ws)  # type: ignore[assignment]
+        try:
+            await sub._connect_and_listen()
+        finally:
+            ws_mod.websockets.connect = original_connect  # type: ignore[assignment]
+
+        sent_frames = [json.loads(c.args[0]) for c in fake_ws.send.call_args_list]
+        ops = [f["operation"] for f in sent_frames]
+        assert ops[:3] == ["Authenticate", "Subscribe", "Subscribe"]
+        instrument_topics = sorted(sent_frames[1]["data"]["topics"])
+        assert instrument_topics == [
+            "instrument:1001",
+            "instrument:1002",
+            "instrument:2001",
+            "instrument:2002",
+        ]
+        assert sub._pinned_topics == {1001, 1002}

--- a/tests/test_quote_stream.py
+++ b/tests/test_quote_stream.py
@@ -9,6 +9,7 @@ right order.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -289,7 +290,7 @@ class TestEventStreamGenerator:
         bus = QuoteBus()
         req = self._FakeRequest()
 
-        gen = _event_stream(req, bus, frozenset({1001}), _empty_ctx())  # type: ignore[arg-type]
+        gen = _event_stream(req, bus, frozenset({1001}), _empty_ctx(), None)  # type: ignore[arg-type]
 
         # First yield: open comment.
         first = await gen.__anext__()
@@ -327,7 +328,7 @@ class TestEventStreamGenerator:
         sse_quotes._HEARTBEAT_INTERVAL_S = 0.05
         bus = QuoteBus()
         req = self._FakeRequest()
-        gen = sse_quotes._event_stream(req, bus, frozenset({1001}), _empty_ctx())  # type: ignore[arg-type]
+        gen = sse_quotes._event_stream(req, bus, frozenset({1001}), _empty_ctx(), None)  # type: ignore[arg-type]
         try:
             # Open frame.
             first = await gen.__anext__()
@@ -344,7 +345,7 @@ class TestEventStreamGenerator:
     async def test_filtered_instrument_does_not_yield(self) -> None:
         bus = QuoteBus()
         req = self._FakeRequest()
-        gen = _event_stream(req, bus, frozenset({1001}), _empty_ctx())  # type: ignore[arg-type]
+        gen = _event_stream(req, bus, frozenset({1001}), _empty_ctx(), None)  # type: ignore[arg-type]
 
         # Drain initial open frame.
         await gen.__anext__()
@@ -360,6 +361,80 @@ class TestEventStreamGenerator:
         # Cleanup: close the generator so the queue subscription tears
         # down without leaking the open Subscriber.
         await gen.aclose()
+
+    async def test_cancel_during_add_still_calls_remove(self) -> None:
+        """Regression for Codex high finding on #485: if the SSE
+        request is cancelled DURING ``add_instruments``, the ref
+        count has already been committed (pure-Python under a
+        lock, no await in the critical section). The generator's
+        finally must still run ``remove_instruments`` or the ref
+        leaks forever. The fix placed the add INSIDE the try; this
+        test verifies the invariant."""
+        bus = QuoteBus()
+        req = self._FakeRequest()
+
+        class _SlowSubscriber:
+            def __init__(self) -> None:
+                self.added: list[list[int]] = []
+                self.removed: list[list[int]] = []
+
+            async def add_instruments(self, ids: list[int]) -> None:
+                self.added.append(ids)
+                # Simulate the commit-then-await pattern of the
+                # real implementation: state is captured before the
+                # await, so any cancel here still leaves refs
+                # committed.
+                await asyncio.sleep(10)
+
+            async def remove_instruments(self, ids: list[int]) -> None:
+                self.removed.append(ids)
+
+        ws_sub = _SlowSubscriber()
+        gen = _event_stream(req, bus, frozenset({1001}), _empty_ctx(), ws_sub)  # type: ignore[arg-type]
+
+        # Start the generator + cancel mid-add.
+        next_task = asyncio.create_task(gen.__anext__())
+        await asyncio.sleep(0.02)  # let add_instruments begin its sleep
+        next_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await next_task
+        # Generator close drives the finally.
+        await gen.aclose()
+
+        assert ws_sub.added == [[1001]]
+        assert ws_sub.removed == [[1001]]
+
+    async def test_ws_subscriber_add_on_open_remove_on_close(self) -> None:
+        """#485 wiring: SSE stream must register the requested
+        instrument IDs with the WS subscriber on open and release
+        them on close/disconnect. Otherwise opening a page for a
+        ticker outside held+watchlist receives no ticks (the
+        eToro-side Subscribe frame is never sent)."""
+        bus = QuoteBus()
+        req = self._FakeRequest()
+
+        class _RecordingSubscriber:
+            def __init__(self) -> None:
+                self.added: list[list[int]] = []
+                self.removed: list[list[int]] = []
+
+            async def add_instruments(self, ids: list[int]) -> None:
+                self.added.append(ids)
+
+            async def remove_instruments(self, ids: list[int]) -> None:
+                self.removed.append(ids)
+
+        ws_sub = _RecordingSubscriber()
+        gen = _event_stream(req, bus, frozenset({1001, 1002}), _empty_ctx(), ws_sub)  # type: ignore[arg-type]
+
+        # Open frame triggers registration.
+        await gen.__anext__()
+        assert ws_sub.added == [[1001, 1002]]
+        assert ws_sub.removed == []
+
+        # Simulate disconnect path.
+        await gen.aclose()
+        assert ws_sub.removed == [[1001, 1002]]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Closes #485. WS subscriber exposes dynamic \`add_instruments\` / \`remove_instruments\` methods. SSE \`/sse/quotes\` wires them into its stream lifecycle so opening ANY instrument page triggers a live eToro Subscribe frame; closing the stream / disconnect triggers Unsubscribe after the last ref.

Follows eToro's documented protocol (https://api-portal.etoro.com/api-reference/websocket/example-code) — Subscribe + Unsubscribe are post-auth dynamic ops.

## Design

- Two topic sources: \`_pinned_topics\` (held ∪ watchlist, refreshed per reconnect) and \`_dynamic_topic_refs\` (page-view ref counts).
- Pinned topics never torn down by the dynamic path.
- Reconnect resubscribes to the union — SSE streams that survive an outage resume after the new connection.
- Batched startup Subscribe runs under the topic lock so a concurrent \`remove_instruments\` cannot race an Unsubscribe before the Subscribe it's removing from.
- SSE generator's \`finally\` always runs \`remove_instruments\` to pair every \`add_instruments\` — including on cancellation mid-add.

## Test plan

- [x] 15 new tests on subscriber (envelope, add/remove ref semantics, pinned survival, reconnect union)
- [x] 2 new tests on SSE wiring (add-on-open/remove-on-close + cancel-during-add leak regression)
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\` — 0 errors
- [x] \`uv run pytest\` — 2723 passed
- [x] Codex 4 rounds: original cancel leak, reconnect window, stale-_ws on send failure, and Unsub-before-Sub wire ordering — all closed.

## Follow-up

Frontend needs a \`useLiveQuote\` hook to actually open SSE streams when the operator opens an instrument page. Without it, dynamic ref count stays 0 and nothing is page-view subscribed. Separate ticket.