### PR TITLE
feat(#488): useLiveQuote hook — live tick overlay on instrument page

### DIFF
--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -17,6 +17,7 @@ import type {
   InstrumentPositionDetail,
   ThesisDetail,
 } from "@/api/types";
+import { liveTickDisplayPrice, useLiveQuote } from "@/lib/useLiveQuote";
 
 const THESIS_STALE_DAYS = 30;
 
@@ -97,6 +98,16 @@ export function SummaryStrip({
   generatingThesis,
 }: SummaryStripProps): JSX.Element {
   const { identity, price } = summary;
+  // Live-quote overlay (#488). When an SSE tick arrives for this
+  // instrument, it overrides the REST snapshot's current/currency.
+  // Day change columns keep using the snapshot — the live tick
+  // only carries bid/ask/last, not the daily anchor. Hook opens a
+  // stream on mount (triggering a dynamic eToro Subscribe per #487)
+  // and closes on unmount.
+  const live = useLiveQuote(summary.instrument_id);
+  const livePrice = liveTickDisplayPrice(live.tick);
+  const displayCurrent = livePrice?.value ?? price?.current ?? null;
+  const displayCurrency = livePrice?.currency ?? price?.currency ?? null;
   const changeNum = price?.day_change_pct != null ? Number(price.day_change_pct) : null;
   const changeColor =
     changeNum === null
@@ -141,16 +152,23 @@ export function SummaryStrip({
             Tier {summary.coverage_tier}
           </span>
         ) : null}
-        {price ? (
+        {price || livePrice ? (
           <>
-            <span className="ml-auto text-2xl font-semibold tabular-nums text-slate-800">
-              {formatPrice(price.current, price.currency)}
+            <span className="ml-auto flex items-baseline gap-1.5 text-2xl font-semibold tabular-nums text-slate-800">
+              {formatPrice(displayCurrent, displayCurrency)}
+              {live.connected ? (
+                <span
+                  data-testid="live-pulse"
+                  title="Live price stream active"
+                  className="inline-block h-2 w-2 animate-pulse rounded-full bg-emerald-500"
+                />
+              ) : null}
             </span>
             <span className={`text-sm tabular-nums ${changeColor}`}>
-              {price.day_change != null && Number(price.day_change) >= 0
+              {price?.day_change != null && Number(price.day_change) >= 0
                 ? "+"
                 : ""}
-              {price.day_change ?? "—"} ({formatPct(price.day_change_pct, true)})
+              {price?.day_change ?? "—"} ({formatPct(price?.day_change_pct, true)})
             </span>
           </>
         ) : null}

--- a/frontend/src/lib/useLiveQuote.test.ts
+++ b/frontend/src/lib/useLiveQuote.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for useLiveQuote (#488).
+ *
+ * EventSource is not a pure function — we stub it with a minimal
+ * implementation that lets the test trigger onopen/onmessage/onerror
+ * synchronously. Covers: tick delivery, instrument-id filter,
+ * connection status flag, unavailable flag on definitive close.
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { liveTickDisplayPrice, useLiveQuote, type LiveTickPayload } from "@/lib/useLiveQuote";
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+
+  url: string;
+  readyState = FakeEventSource.CONNECTING;
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+
+  constructor(url: string, _init?: EventSourceInit) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+
+  close(): void {
+    this.readyState = FakeEventSource.CLOSED;
+  }
+
+  // Helpers for tests.
+  fireOpen(): void {
+    this.readyState = FakeEventSource.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+  fireMessage(data: string): void {
+    this.onmessage?.(new MessageEvent("message", { data }));
+  }
+  fireError(finalClose = false): void {
+    if (finalClose) {
+      this.readyState = FakeEventSource.CLOSED;
+    }
+    this.onerror?.(new Event("error"));
+  }
+}
+
+const makeTick = (overrides: Partial<LiveTickPayload> = {}): LiveTickPayload => ({
+  instrument_id: 1001,
+  native_currency: "USD",
+  bid: "100",
+  ask: "101",
+  last: "100.5",
+  quoted_at: "2026-04-25T12:00:00+00:00",
+  display: null,
+  ...overrides,
+});
+
+describe("useLiveQuote", () => {
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal("EventSource", FakeEventSource);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("opens a stream for the given instrument id and yields ticks", () => {
+    const { result } = renderHook(() => useLiveQuote(1001));
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0]!.url).toBe("/sse/quotes?ids=1001");
+
+    act(() => {
+      FakeEventSource.instances[0]!.fireOpen();
+    });
+    expect(result.current.connected).toBe(true);
+
+    act(() => {
+      FakeEventSource.instances[0]!.fireMessage(JSON.stringify(makeTick()));
+    });
+    expect(result.current.tick?.instrument_id).toBe(1001);
+    expect(result.current.tick?.bid).toBe("100");
+  });
+
+  it("ignores ticks for foreign instrument ids (defensive)", () => {
+    const { result } = renderHook(() => useLiveQuote(1001));
+    act(() => {
+      FakeEventSource.instances[0]!.fireMessage(
+        JSON.stringify(makeTick({ instrument_id: 9999 })),
+      );
+    });
+    expect(result.current.tick).toBeNull();
+  });
+
+  it("ignores malformed JSON frames without flipping unavailable", () => {
+    const { result } = renderHook(() => useLiveQuote(1001));
+    act(() => {
+      FakeEventSource.instances[0]!.fireMessage("not json");
+    });
+    expect(result.current.tick).toBeNull();
+    expect(result.current.unavailable).toBe(false);
+  });
+
+  it("sets unavailable only on definitive CLOSED, not on transient errors", () => {
+    const { result } = renderHook(() => useLiveQuote(1001));
+
+    // Transient error (reconnect attempt) — must NOT flip unavailable.
+    act(() => {
+      FakeEventSource.instances[0]!.fireError(false);
+    });
+    expect(result.current.unavailable).toBe(false);
+
+    // Definitive close — now flip.
+    act(() => {
+      FakeEventSource.instances[0]!.fireError(true);
+    });
+    expect(result.current.unavailable).toBe(true);
+  });
+
+  it("opens a new stream when the instrument id changes", () => {
+    const { rerender } = renderHook(({ id }: { id: number }) => useLiveQuote(id), {
+      initialProps: { id: 1001 },
+    });
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    rerender({ id: 2002 });
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(FakeEventSource.instances[1]!.url).toBe("/sse/quotes?ids=2002");
+    // First stream was closed.
+    expect(FakeEventSource.instances[0]!.readyState).toBe(FakeEventSource.CLOSED);
+  });
+
+  it("does nothing when id is null or undefined", () => {
+    renderHook(() => useLiveQuote(null));
+    expect(FakeEventSource.instances).toHaveLength(0);
+  });
+
+  it("closes the stream on unmount", () => {
+    const { unmount } = renderHook(() => useLiveQuote(1001));
+    const source = FakeEventSource.instances[0]!;
+    unmount();
+    expect(source.readyState).toBe(FakeEventSource.CLOSED);
+  });
+
+  it("ignores late events from the OLD source after id change (stale-event guard)", () => {
+    // Regression for Codex review high finding on #488: a queued
+    // message or error on the previous EventSource can fire after
+    // cleanup has swapped in the new source; without a guard the
+    // stale handler calls setTick with the old instrument's data.
+    const { result, rerender } = renderHook(({ id }: { id: number }) => useLiveQuote(id), {
+      initialProps: { id: 1001 },
+    });
+    const oldSource = FakeEventSource.instances[0]!;
+
+    // Switch ids. Cleanup closes oldSource; new source opens.
+    rerender({ id: 2002 });
+    const newSource = FakeEventSource.instances[1]!;
+
+    // Stale frame from old source AFTER cleanup — must be ignored.
+    act(() => {
+      oldSource.fireMessage(
+        JSON.stringify(makeTick({ instrument_id: 1001, bid: "STALE" })),
+      );
+      oldSource.fireError(true);
+    });
+    expect(result.current.tick).toBeNull();
+    expect(result.current.unavailable).toBe(false);
+
+    // Fresh frame from new source — still gets through.
+    act(() => {
+      newSource.fireOpen();
+      newSource.fireMessage(
+        JSON.stringify(makeTick({ instrument_id: 2002, bid: "FRESH" })),
+      );
+    });
+    expect(result.current.tick?.bid).toBe("FRESH");
+    expect(result.current.connected).toBe(true);
+  });
+
+  it("no-ops when EventSource is undefined (SSR / non-browser env)", () => {
+    // Simulate an environment without EventSource (e.g. Node SSR).
+    // The hook must NOT throw, NOT construct anything, and must
+    // leave tick/connected/unavailable at their initial values so
+    // the page falls back to its REST snapshot.
+    vi.unstubAllGlobals();
+    vi.stubGlobal("EventSource", undefined);
+    const { result } = renderHook(() => useLiveQuote(1001));
+    expect(FakeEventSource.instances).toHaveLength(0);
+    expect(result.current.tick).toBeNull();
+    expect(result.current.connected).toBe(false);
+    expect(result.current.unavailable).toBe(false);
+  });
+
+  it("resets state when the subscribed id changes", () => {
+    const { result, rerender } = renderHook(({ id }: { id: number }) => useLiveQuote(id), {
+      initialProps: { id: 1001 },
+    });
+    act(() => {
+      FakeEventSource.instances[0]!.fireOpen();
+      FakeEventSource.instances[0]!.fireMessage(JSON.stringify(makeTick()));
+    });
+    expect(result.current.tick?.instrument_id).toBe(1001);
+
+    rerender({ id: 2002 });
+    expect(result.current.tick).toBeNull();
+    expect(result.current.connected).toBe(false);
+  });
+});
+
+describe("liveTickDisplayPrice", () => {
+  it("prefers display block when present", () => {
+    const out = liveTickDisplayPrice(
+      makeTick({
+        display: { currency: "GBP", bid: "75", ask: "76", last: "75.5" },
+      }),
+    );
+    expect(out).toEqual({ value: "75.5", currency: "GBP" });
+  });
+
+  it("falls back to display.bid when last is null", () => {
+    const out = liveTickDisplayPrice(
+      makeTick({
+        display: { currency: "GBP", bid: "75", ask: "76", last: null },
+      }),
+    );
+    expect(out?.value).toBe("75");
+  });
+
+  it("uses native triple when display is null", () => {
+    const out = liveTickDisplayPrice(makeTick({ display: null, last: "100.5" }));
+    expect(out).toEqual({ value: "100.5", currency: "USD" });
+  });
+
+  it("returns null for a null tick", () => {
+    expect(liveTickDisplayPrice(null)).toBeNull();
+  });
+});

--- a/frontend/src/lib/useLiveQuote.ts
+++ b/frontend/src/lib/useLiveQuote.ts
@@ -1,0 +1,162 @@
+/**
+ * useLiveQuote — open an SSE stream for one instrument and return
+ * the latest tick (#488, backend #487).
+ *
+ * The backend endpoint (GET /sse/quotes?ids=<id>) now triggers a
+ * live eToro Subscribe frame for the instrument on stream open
+ * and Unsubscribe on close — so opening the hook on any page adds
+ * the instrument to the WS topic set, and unmounting removes it.
+ *
+ * Payload shape (from app/api/sse_quotes.py _format_tick):
+ *   {
+ *     instrument_id: number,
+ *     native_currency: string | null,
+ *     bid: string,       // Decimal-preserved string
+ *     ask: string,
+ *     last: string | null,
+ *     quoted_at: string, // ISO 8601
+ *     display: null | { currency, bid, ask, last }
+ *   }
+ *
+ * Clients should prefer the display block when present (matches the
+ * operator's runtime_config.display_currency); native is the fallback.
+ *
+ * Fallback: the hook doesn't drive REST polling itself. The page's
+ * existing InstrumentSummary fetch loads the initial snapshot; this
+ * hook overlays live ticks on top of it when they arrive. A 503 or
+ * connection failure leaves the snapshot in place — the page degrades
+ * silently to whatever the last-fetched quote was.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+export interface LiveTickPayload {
+  instrument_id: number;
+  native_currency: string | null;
+  bid: string;
+  ask: string;
+  last: string | null;
+  quoted_at: string;
+  display: null | {
+    currency: string;
+    bid: string;
+    ask: string;
+    last: string | null;
+  };
+}
+
+export interface LiveQuoteState {
+  /** Latest tick received on this connection, or null before the first
+   *  tick arrives. Null is not a "broken" state — it just means eToro
+   *  hasn't pushed a rate for this instrument yet (quiet book). */
+  tick: LiveTickPayload | null;
+  /** True once the SSE connection has opened. Useful for a
+   *  "LIVE" badge UI. */
+  connected: boolean;
+  /** True if the backend returned 503 (no quote bus available) or
+   *  the connection errored in a non-recoverable way. The UI should
+   *  fall back to its REST snapshot. */
+  unavailable: boolean;
+}
+
+export function useLiveQuote(instrumentId: number | null | undefined): LiveQuoteState {
+  const [tick, setTick] = useState<LiveTickPayload | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [unavailable, setUnavailable] = useState(false);
+  // Ref holds the active EventSource across renders so React's strict-
+  // mode double-invocation cleanup doesn't close a live stream while a
+  // new one is being set up.
+  const sourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (instrumentId === null || instrumentId === undefined) return;
+    // Defensive: EventSource is a browser API. Test environments
+    // without a jsdom polyfill hit this branch — no-op and let the
+    // page fall back to its REST snapshot. Also covers SSR if we
+    // ever render this component server-side.
+    if (typeof EventSource === "undefined") return;
+
+    // Reset state when the subscribed id changes so the caller
+    // doesn't see stale ticks from a previous instrument.
+    setTick(null);
+    setConnected(false);
+    setUnavailable(false);
+
+    const url = `/sse/quotes?ids=${encodeURIComponent(String(instrumentId))}`;
+    const source = new EventSource(url, { withCredentials: true });
+    sourceRef.current = source;
+
+    // Guard: after cleanup or id change, the OLD EventSource can
+    // still deliver a queued message/open/error event before the
+    // browser unbinds its handlers. Without a per-effect "active"
+    // check these handlers would mutate state with stale data and
+    // briefly display the previous instrument's price. We compare
+    // against ``sourceRef.current`` (which cleanup nulls before
+    // the new effect runs) so late events from a closed source are
+    // no-ops.
+    const isActive = (): boolean => sourceRef.current === source;
+
+    source.onopen = () => {
+      if (!isActive()) return;
+      setConnected(true);
+    };
+
+    source.onmessage = (ev: MessageEvent) => {
+      if (!isActive()) return;
+      try {
+        const payload = JSON.parse(ev.data) as LiveTickPayload;
+        // Only accept ticks for the currently-subscribed id — defensive
+        // against a server-side filter bug leaking foreign ticks.
+        if (payload.instrument_id === instrumentId) {
+          setTick(payload);
+        }
+      } catch {
+        // Malformed JSON — ignore the frame; the connection stays
+        // open for the next one.
+      }
+    };
+
+    source.onerror = () => {
+      if (!isActive()) return;
+      // EventSource's built-in auto-reconnect handles transient drops.
+      // We only set ``unavailable`` once the connection is definitively
+      // closed (readyState CLOSED = 2). Browsers fire onerror on every
+      // reconnect attempt too, which should NOT flip unavailable.
+      if (source.readyState === EventSource.CLOSED) {
+        setUnavailable(true);
+        setConnected(false);
+      }
+    };
+
+    return () => {
+      source.close();
+      // Null the ref BEFORE any subsequent effect body runs so the
+      // stale-event guard above sees ``sourceRef.current !== source``
+      // and drops any event that fires after close().
+      if (sourceRef.current === source) {
+        sourceRef.current = null;
+      }
+      setConnected(false);
+    };
+  }, [instrumentId]);
+
+  return { tick, connected, unavailable };
+}
+
+/**
+ * Pick the best "current price" string from a live tick, preferring
+ * display currency when available and falling back to native. Returns
+ * null when no useful value exists.
+ */
+export function liveTickDisplayPrice(tick: LiveTickPayload | null): {
+  value: string;
+  currency: string | null;
+} | null {
+  if (tick === null) return null;
+  if (tick.display !== null) {
+    const v = tick.display.last ?? tick.display.bid;
+    return { value: v, currency: tick.display.currency };
+  }
+  const v = tick.last ?? tick.bid;
+  return { value: v, currency: tick.native_currency };
+}


### PR DESCRIPTION
## What

Closes #488. Frontend consumer for \`/sse/quotes\` (backend #487). Hook opens EventSource per instrument, returns latest tick; \`SummaryStrip\` overlays live bid/ask/last onto the REST snapshot.

## Why

All of #274 slices + #485 were invisible without a frontend consumer. This closes the loop — opening ANY instrument page (crypto, non-portfolio tickers, drive-by browse) triggers a dynamic eToro Subscribe and the header price updates sub-second.

## Test plan

- [x] 17 new tests including stale-event-race regression + EventSource-undefined fallback
- [x] \`pnpm --dir frontend typecheck\` — clean
- [x] \`pnpm --dir frontend test:unit\` — 400 passed
- [x] Backend still green (2723 pytest pass)
- [x] Codex 2 rounds: stale-event race caught as high finding, closed by \`sourceRef\` guard; EventSource-undefined fallback test added