### PR TITLE
fix(#488): route useLiveQuote EventSource through /api/ proxy

### DIFF
--- a/frontend/src/lib/useLiveQuote.test.ts
+++ b/frontend/src/lib/useLiveQuote.test.ts
@@ -71,7 +71,7 @@ describe("useLiveQuote", () => {
   it("opens a stream for the given instrument id and yields ticks", () => {
     const { result } = renderHook(() => useLiveQuote(1001));
     expect(FakeEventSource.instances).toHaveLength(1);
-    expect(FakeEventSource.instances[0]!.url).toBe("/sse/quotes?ids=1001");
+    expect(FakeEventSource.instances[0]!.url).toBe("/api/sse/quotes?ids=1001");
 
     act(() => {
       FakeEventSource.instances[0]!.fireOpen();
@@ -128,7 +128,7 @@ describe("useLiveQuote", () => {
 
     rerender({ id: 2002 });
     expect(FakeEventSource.instances).toHaveLength(2);
-    expect(FakeEventSource.instances[1]!.url).toBe("/sse/quotes?ids=2002");
+    expect(FakeEventSource.instances[1]!.url).toBe("/api/sse/quotes?ids=2002");
     // First stream was closed.
     expect(FakeEventSource.instances[0]!.readyState).toBe(FakeEventSource.CLOSED);
   });

--- a/frontend/src/lib/useLiveQuote.ts
+++ b/frontend/src/lib/useLiveQuote.ts
@@ -82,7 +82,11 @@ export function useLiveQuote(instrumentId: number | null | undefined): LiveQuote
     setConnected(false);
     setUnavailable(false);
 
-    const url = `/sse/quotes?ids=${encodeURIComponent(String(instrumentId))}`;
+    // Route through ``/api/*`` so the Vite dev proxy (see
+    // frontend/vite.config.ts) strips the prefix and forwards to
+    // the backend's ``/sse/quotes`` route. In prod the same prefix
+    // lands on the reverse proxy's catch-all.
+    const url = `/api/sse/quotes?ids=${encodeURIComponent(String(instrumentId))}`;
     const source = new EventSource(url, { withCredentials: true });
     sourceRef.current = source;
 


### PR DESCRIPTION
## Symptom

Live price not appearing on instrument pages after #491 merged. LRC page header shows \`— — (—)\`, no green pulse badge.

## Root cause

Vite dev proxy only forwards \`/api/*\` → backend. The \`useLiveQuote\` hook in #491 opened \`/sse/quotes?ids=...\` directly, which hits the Vite dev server and 404s. EventSource retries forever (treating as transient), no visible feedback.

## Fix

Prefix URL with \`/api/\` so the proxy strips the prefix and forwards to the backend's \`/sse/quotes\` route.

## Test plan

- [x] Hook URL test updated
- [x] \`pnpm --dir frontend typecheck\` — clean
- [x] \`pnpm --dir frontend test:unit\` — 400 passed
- [ ] Live: open LRC page, green pulse appears, price updates