### PR TITLE
fix(#476): catch up sec_business_summary_ingest on boot

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -500,7 +500,13 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "re-fetching already-parsed instruments."
         ),
         cadence=Cadence.daily(hour=3, minute=15),
-        catch_up_on_boot=False,
+        # #476: catch up on boot so an empty ``instrument_business_summary``
+        # table populates on the next operator restart instead of waiting
+        # for the daily 03:15 UTC window. Cost is bounded — the ingester
+        # TTL-gates already-parsed instruments and caps at 200 filings
+        # per run (~22s at the SEC 9 req/s floor), so the worst case is
+        # one 22s burst of requests per boot per 24h window.
+        catch_up_on_boot=True,
     ),
     ScheduledJob(
         name=JOB_SEC_INSIDER_TRANSACTIONS_INGEST,


### PR DESCRIPTION
## What

Closes #476. Flip \`catch_up_on_boot=True\` on \`sec_business_summary_ingest\`. Table had 0 rows because the 03:15 UTC daily schedule never fired on dev; now the ingester runs once per boot if overdue.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run pytest\` — 2723 passed
- [x] Codex reviewed: no findings
- [ ] Live: next backend boot logs \`sec_business_summary_ingest complete: scanned=... inserted>0\`

## Notes

Follow-up candidate: primary_document_url for ~12 recent 10-Ks points at \`-index.htm\` (SEC index page) rather than the 10-K HTM body. Parser fails on those. 98.4% of 10-Ks have direct HTM URLs so the first catch-up run still populates thousands of rows. File a follow-up if the edge case becomes visible.