### PR TITLE
refactor(#498): subscriber visibility-only — drop held/watchlist auto-pin

### DIFF
--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -1,39 +1,39 @@
-"""eToro WebSocket live-price subscriber (#274 Slices 1+2).
+"""eToro WebSocket live-price subscriber.
 
 Connects to ``wss://ws.etoro.com/ws``, authenticates with the
-operator's eToro API + user keys, subscribes to ``instrument:<id>``
-topics for every instrument the operator currently holds OR has on
-their watchlist, and upserts each ``Trading.Instrument.Rate`` push
-into the existing ``quotes`` table.
+operator's eToro API + user keys, and subscribes to
+``instrument:<id>`` topics on demand from page-view SSE streams.
+Each ``Trading.Instrument.Rate`` push is upserted into the
+``quotes`` table and fanned out via :class:`QuoteBus` to any
+subscribed SSE consumer.
 
-**Slice 1 scope** (rates-only):
+**Visibility-driven subscription model** (#498):
+The subscriber holds no opinion about which instruments to stream.
+``add_instruments`` and ``remove_instruments`` callers (the SSE
+endpoint at :func:`app.api.sse_quotes._event_stream`) bump and drop
+ref counts on ``_topic_refs``; a topic is sent to eToro iff its
+refcount > 0. Held positions and watchlist entries are **not**
+auto-subscribed — what the operator has on screen drives the
+upstream subscription, nothing else. Boots quiet: a fresh process
+authenticates the WS but sends no Subscribe frame until an SSE
+stream lands.
 
-- Single-instance dev assumption: one process owns the WS connection.
-  Multi-worker advisory-lock arbitration is a Slice 4 concern.
-- ``quotes`` table writes only. SSE / Redis fan-out is Slice 3.
-- Frontend continues to poll ``/quotes`` endpoints; the 5-second
-  client cadence + WS-driven SQL freshness combine into the
-  "few-second live price" experience.
+**Private channel + reconcile**:
+The subscriber also subscribes to the ``private`` topic. eToro
+pushes ``Trading.OrderFor*`` / ``Trading.Position*`` /
+``Trading.Credit*`` envelopes here whenever the operator's
+portfolio state changes. Each private push schedules a debounced
+REST reconcile — ``EtoroBrokerProvider.get_portfolio()`` followed
+by ``sync_portfolio()`` against the live DB. Multi-leg trades and
+rapid order bursts collapse into one reconcile per
+``_RECONCILE_DEBOUNCE_S`` window so the public REST limit
+(60 GET/min) is respected even when the private firehose is noisy.
 
-**Slice 2 scope** (private channel + reconcile):
-
-- Also subscribes to the ``private`` topic. eToro pushes
-  ``Trading.OrderFor*`` / ``Trading.Position*`` / ``Trading.Credit*``
-  envelopes here whenever the operator's portfolio state changes
-  (orders accepted / rejected, positions opened / closed, cash
-  credit moves).
-- Each private push schedules a debounced REST reconcile —
-  ``EtoroBrokerProvider.get_portfolio()`` followed by
-  ``sync_portfolio()`` against the live DB. Multi-leg trades and
-  rapid order bursts collapse into one reconcile per
-  ``_RECONCILE_DEBOUNCE_S`` window so the public REST limit
-  (60 GET/min) is respected even when the private firehose is
-  noisy.
-
-Reconnect policy: any I/O error or close triggers a 5-second backoff
-then re-authenticate + re-subscribe. The set of instrument topics is
-recomputed on every reconnect so a freshly-opened position /
-watchlist add is picked up after at most one reconnect cycle.
+**Reconnect policy**: any I/O error or close triggers a 5-second
+backoff then re-authenticate + re-subscribe. The reconnect's
+batched Subscribe replays whatever ``_topic_refs.keys()`` currently
+holds, so an SSE stream that survived the outage continues to
+receive ticks once auth completes.
 """
 
 from __future__ import annotations
@@ -68,15 +68,6 @@ _RECONNECT_BACKOFF_S = 5.0
 # isn't hammered. 3 seconds is short enough that the operator sees
 # fresh state inside a "feel alive" window without churn.
 _RECONCILE_DEBOUNCE_S = 3.0
-# Periodic interval for the held-∪-watchlist refresh loop. Position
-# open/close events trigger an immediate refresh via the private-
-# channel reconcile (see ``_reconcile_worker``); the periodic timer
-# is the fallback that catches watchlist edits and any state change
-# that arrived without a private push (e.g. cron-level corrections).
-# 60s is the operator-visible "felt-stale" window — fast enough that
-# a watchlist add reaches the WS before the next page navigation,
-# slow enough that the DB poll cost is negligible.
-_SOURCE_RECONCILE_INTERVAL_S = 60.0
 
 
 # ---------------------------------------------------------------------
@@ -388,31 +379,12 @@ class EtoroWebSocketSubscriber:
         self._reconcile_idle = threading.Event()
         self._reconcile_idle.set()
 
-        # Unified topic registry (#490). Every reason to subscribe —
-        # held position, watchlist entry, page-view SSE — adds a ref;
-        # the topic is sent to eToro iff its refcount > 0. Ref-counting
-        # is the single mechanism for both "long-lived" (held /
-        # watchlist) and "short-lived" (page-view) subscriptions, so
-        # we never stream ticks for an instrument no source still
-        # cares about.
-        #
-        # Held-∪-watchlist refs are owned by ``_source_reconcile_worker``
-        # which periodically diffs the DB-backed source set against
-        # ``_source_topic_set`` and translates the diff into add/remove
-        # calls. ``_source_topic_set`` is the worker's private record
-        # of which ids it currently holds a ref for, so it can drop
-        # only its own refs without disturbing page-view refs that
-        # share the same instrument id.
+        # Visibility-driven topic registry. Every page-view SSE stream
+        # bumps a ref on its visible instrument ids; the topic is sent
+        # to eToro iff its refcount > 0 (#498). No DB-backed selector
+        # auto-pins held positions or watchlist — what the operator
+        # has on screen drives the upstream subscription, nothing else.
         self._topic_refs: dict[int, int] = {}
-        self._source_topic_set: set[int] = set()
-        # Signal raised by other paths to ask the source worker to
-        # reconcile immediately rather than waiting for the next
-        # periodic tick. Triggered by the private-channel reconcile
-        # (positions changed) so a freshly opened or closed position
-        # gets its feed adjusted within seconds, not within the
-        # periodic interval.
-        self._source_reconcile_signal = asyncio.Event()
-        self._source_reconcile_task: asyncio.Task[None] | None = None
         # Live WS connection, set inside ``_connect_and_listen`` once
         # the auth handshake succeeds and cleared on disconnect. The
         # add/remove path reads this to send frames from external
@@ -472,30 +444,12 @@ class EtoroWebSocketSubscriber:
             return
         self._stop_event.clear()
         self._reconcile_signal.clear()
-        self._source_reconcile_signal.clear()
         self._reconcile_worker_task = asyncio.create_task(self._reconcile_worker(), name="etoro-ws-reconcile-worker")
-        # Populate source-managed refs before launching the WS task so
-        # the connect path's batched Subscribe carries the full topic
-        # set in one frame instead of "empty + delta". A failure here
-        # is logged and swallowed; we also pre-set the reconcile
-        # signal so the worker's first iteration runs immediately
-        # rather than waiting up to ``_SOURCE_RECONCILE_INTERVAL_S``
-        # for the periodic timeout — without this, a transient
-        # startup DB blip would leave held/watchlist feeds
-        # unsubscribed for a full minute (Codex review on PR for
-        # #490).
-        try:
-            await self._refresh_source_topics()
-        except Exception:
-            logger.warning(
-                "EtoroWebSocketSubscriber: initial source-topic refresh failed; "
-                "kicking source worker to retry immediately",
-                exc_info=True,
-            )
-            self._source_reconcile_signal.set()
-        self._source_reconcile_task = asyncio.create_task(
-            self._source_reconcile_worker(), name="etoro-ws-source-reconcile"
-        )
+        # Subscriber boots with an empty ``_topic_refs``; the WS
+        # connection comes up but doesn't subscribe to anything until
+        # an SSE stream opens and calls ``add_instruments`` for the
+        # ids on screen. Visibility drives the upstream subscription,
+        # not held / watchlist state (#498).
         self._task = asyncio.create_task(self._run(), name="etoro-ws-subscriber")
         logger.info("EtoroWebSocketSubscriber: started")
 
@@ -507,20 +461,6 @@ class EtoroWebSocketSubscriber:
         with contextlib.suppress(asyncio.CancelledError):
             await self._task
         self._task = None
-        # Cancel the source-reconcile worker before the private-event
-        # reconcile worker. It may be awaiting ``asyncio.to_thread``
-        # on the watched-ids selector; the cancel raises
-        # CancelledError out of the await but lets any in-flight
-        # add/remove send finish first because both honour
-        # CancelledError on their own awaits. No thread-completion
-        # barrier needed — the source worker only does DB *reads*, so
-        # there is no in-flight write that the lifespan needs to drain
-        # before closing the pool.
-        if self._source_reconcile_task is not None:
-            self._source_reconcile_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._source_reconcile_task
-            self._source_reconcile_task = None
         # Cancel the reconcile worker. The worker coroutine may be
         # awaiting ``asyncio.to_thread`` — the cancel raises
         # CancelledError out of the await, but the OS thread running
@@ -607,118 +547,11 @@ class EtoroWebSocketSubscriber:
             try:
                 await asyncio.to_thread(self._run_reconcile_in_thread)
                 logger.info("EtoroWebSocketSubscriber: reconcile complete")
-                # Portfolio state likely changed — kick the source-
-                # topic worker so a freshly opened or closed position
-                # gets its feed adjusted within seconds rather than
-                # waiting for the next periodic tick.
-                self._source_reconcile_signal.set()
             except asyncio.CancelledError:
                 raise
             except Exception:
                 logger.warning(
                     "EtoroWebSocketSubscriber: reconcile failed",
-                    exc_info=True,
-                )
-
-    async def _refresh_source_topics(self) -> None:
-        """Diff the held-∪-watchlist DB set against ``_source_topic_set``
-        and translate the diff into ref-count updates + Subscribe /
-        Unsubscribe frames, all under the topic lock.
-
-        Single critical section: ref-count math, ``_source_topic_set``
-        commit, and wire send all happen under ``_topic_lock`` so
-        that a CancelledError mid-method cannot leave
-        ``_source_topic_set`` stale relative to ``_topic_refs`` — if
-        cancellation lands during the awaited send, the in-memory
-        state already matches the post-refresh shape and the next
-        reconcile diff against the same source set sees no work,
-        avoiding the double-add leak (Codex review on PR for #490).
-        Wire delivery may be partial on cancellation; the next
-        reconnect resubscribes from ``_topic_refs.keys()``.
-
-        The ``_watched_ids_provider`` DB read happens *outside* the
-        lock so add/remove callers don't block on a slow DB.
-        """
-        new_set = set(await asyncio.to_thread(self._watched_ids_provider))
-        async with self._topic_lock:
-            to_add = sorted(new_set - self._source_topic_set)
-            to_remove = sorted(self._source_topic_set - new_set)
-            newly_tracked: list[int] = []
-            to_unsubscribe: list[int] = []
-            for iid in to_add:
-                prior = self._topic_refs.get(iid, 0)
-                self._topic_refs[iid] = prior + 1
-                if prior == 0:
-                    newly_tracked.append(iid)
-            for iid in to_remove:
-                if iid not in self._topic_refs:
-                    continue
-                self._topic_refs[iid] -= 1
-                if self._topic_refs[iid] <= 0:
-                    del self._topic_refs[iid]
-                    to_unsubscribe.append(iid)
-            # Commit source-set BEFORE the awaited sends so a cancel
-            # during send leaves source bookkeeping consistent with
-            # the ref-count map. Wire delivery may be partial; the
-            # next reconnect's batched Subscribe replays from
-            # ``_topic_refs.keys()`` and recovers.
-            self._source_topic_set = new_set
-            if newly_tracked and self._ws is not None:
-                msg = build_subscribe_message(newly_tracked)
-                if msg is not None:
-                    try:
-                        await self._ws.send(msg)
-                        logger.info(
-                            "EtoroWebSocketSubscriber: source-refresh subscribe %d topics",
-                            len(newly_tracked),
-                        )
-                    except Exception:
-                        logger.warning(
-                            "EtoroWebSocketSubscriber: source-refresh Subscribe send failed",
-                            exc_info=True,
-                        )
-            if to_unsubscribe and self._ws is not None:
-                msg = build_unsubscribe_message(to_unsubscribe)
-                if msg is not None:
-                    try:
-                        await self._ws.send(msg)
-                        logger.info(
-                            "EtoroWebSocketSubscriber: source-refresh unsubscribe %d topics",
-                            len(to_unsubscribe),
-                        )
-                    except Exception:
-                        logger.warning(
-                            "EtoroWebSocketSubscriber: source-refresh Unsubscribe send failed",
-                            exc_info=True,
-                        )
-
-    async def _source_reconcile_worker(self) -> None:
-        """Periodically refresh the held-∪-watchlist source set.
-
-        Runs every ``_SOURCE_RECONCILE_INTERVAL_S`` as a fallback
-        and also fires immediately when ``_source_reconcile_signal``
-        is set. The signal is set after the private-channel
-        portfolio reconcile completes (positions just changed) so
-        a freshly-opened position gets its feed within seconds.
-        Watchlist edits hit the periodic path — operator-perceived
-        latency is bounded by the interval but cost is negligible.
-        """
-        while not self._stop_event.is_set():
-            try:
-                await asyncio.wait_for(
-                    self._source_reconcile_signal.wait(),
-                    timeout=_SOURCE_RECONCILE_INTERVAL_S,
-                )
-                self._source_reconcile_signal.clear()
-            except TimeoutError:
-                pass  # periodic firing
-            try:
-                await self._refresh_source_topics()
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.warning(
-                    "EtoroWebSocketSubscriber: source-topic reconcile failed; next tick will retry",
                     exc_info=True,
                 )
 
@@ -774,11 +607,13 @@ class EtoroWebSocketSubscriber:
             # serialised in wire order.
             #
             # ``_topic_refs`` is the single source of truth for what
-            # to subscribe to. The source-reconcile worker
-            # populated held + watchlist refs at start-up; page-view
-            # add/remove may have layered additional refs on top
-            # during a reconnect window. Re-subscribing from
-            # ``_topic_refs.keys()`` covers both classes in one frame.
+            # to subscribe to. Page-view SSE streams populate it via
+            # ``add_instruments`` / ``remove_instruments`` as the
+            # operator opens and closes pages; refs accumulated during
+            # a reconnect window survive here. Re-subscribing from
+            # ``_topic_refs.keys()`` replays the current visibility
+            # set in one frame so any SSE that survived the outage
+            # keeps receiving ticks.
             #
             # The private subscribe + listen loop run outside the
             # lock but inside the ``_ws``-clearing try/finally, so
@@ -798,8 +633,7 @@ class EtoroWebSocketSubscriber:
                     else:
                         logger.info(
                             "EtoroWebSocketSubscriber: no tracked instruments — "
-                            "connection will idle for rates until a position / "
-                            "watchlist add or a page-view subscribe"
+                            "connection will idle until a page-view subscribe"
                         )
 
                 # Always subscribe to the private channel — even if
@@ -826,21 +660,22 @@ class EtoroWebSocketSubscriber:
         """Bump ref counts for the given instrument ids; send a
         Subscribe frame for any topics whose refcount just went 0→1.
 
-        Single mechanism for every reason to subscribe — the source
-        worker uses it for held/watchlist refs and the SSE handler
-        uses it for page-view refs. The Nth caller's add does not
-        change wire state if N-1 callers already hold a ref.
+        Single mechanism for every page-view ref — the SSE endpoint
+        in :mod:`app.api.sse_quotes` calls this on stream open with
+        the ids the operator currently has on screen. The Nth caller's
+        add does not change wire state if N-1 callers already hold a
+        ref (multi-tab on the same instrument shares one Subscribe).
 
-        Safe to call from FastAPI request handlers and from internal
-        async workers. If the ws is mid-reconnect the counts are
-        still updated and the next connect cycle re-subscribes from
-        ``_topic_refs.keys()``.
+        Safe to call from FastAPI request handlers. If the ws is
+        mid-reconnect the counts are still updated and the next
+        connect cycle re-subscribes from ``_topic_refs.keys()``.
 
         Cancellation-safety: the ref-count update is pure-Python
-        under the lock with no ``await`` in the critical section,
-        so a CancelledError during this method always occurs AFTER
-        state commit. Callers pair this with a ``remove_instruments``
-        in their finally to guarantee no leaked refs.
+        under the lock with no ``await`` in the critical section
+        before the wire send, so a CancelledError during the awaited
+        send leaves the counts committed. Callers pair this with a
+        ``remove_instruments`` in their finally to guarantee no
+        leaked refs.
         """
         if not instrument_ids:
             return
@@ -881,13 +716,12 @@ class EtoroWebSocketSubscriber:
         """Decrement ref counts; send Unsubscribe for topics that
         hit zero.
 
-        With the unified ref-count model there is no special "pinned"
-        class that survives a remove — held positions hold their own
-        ref through the source-reconcile worker, so a page-view's
-        remove on a held instrument decrements the page-view ref
-        but the source ref keeps the topic subscribed. Only when
-        every source has dropped its ref does the wire-level
-        Unsubscribe go out.
+        Symmetric with :meth:`add_instruments` — the SSE endpoint
+        calls this on stream close with the ids the page was viewing.
+        When two tabs share the same id the first close drops the
+        refcount from 2→1 (no Unsubscribe), the second from 1→0
+        (Unsubscribe goes out). No wire teardown until every page-view
+        ref has dropped.
         """
         if not instrument_ids:
             return

--- a/docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md
+++ b/docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md
@@ -1,0 +1,378 @@
+# Visibility-driven live prices — functional spec
+
+Date: 2026-04-25
+Author: Luke / Claude
+Status: Draft v3 (post-Codex round 3; pending operator sign-off)
+
+## Goal
+
+Live prices on every visible-on-screen instrument across the eBull web UI
+(portfolio, copy-trading, dashboard, instrument page), with FX
+conversion to operator's display currency. **What the operator can see,
+streams. What they can't see, doesn't.** No background subscriptions.
+
+Watchlist is intentionally out of scope: `WatchlistPanel.tsx` has no
+price surface today; adding one is a separate UX decision.
+
+## Why
+
+Operator complaint (2026-04-25):
+1. After #490, app boot logs `subscribed to 5 instrument topics` even when
+   no portfolio page is open. Wasted bandwidth + DB writes.
+2. Copy-trader rows render with a static price, not live ticks.
+3. FX rates refresh runs hourly even when nothing on screen needs them.
+
+Codex second-opinion (default model, 2026-04-25, sessions
+019dc4c0 + resume): confirmed the multi-worker overlay (#479) is overbuilt
+for a single-uvicorn-worker single-operator deployment. Recommended
+**keeping** `EtoroWebSocketSubscriber`, `QuoteBus`, SSE +
+ref-counting; **deferring** advisory lock + LISTEN/NOTIFY + listener.
+Round 2 caught real bugs in spec v1 — see "Resolved findings" below.
+
+## Non-goals (locked)
+
+- **Multi-worker arbitration / leader election.** Deferred until prod is
+  actually multi-worker. Issue #479 stays open, descope the work.
+- **Auto-pinning held positions or watchlist** at the WS subscriber level.
+  Visibility owns subscriptions. If a page renders a held row, it
+  subscribes; if no page renders it, no subscription.
+- **Cross-worker tick fan-out** (LISTEN/NOTIFY). Same reason as above.
+- **Cluster-wide page-view ref propagation.** Out of scope; trivially
+  correct in single-worker.
+- **Replacing REST snapshot price.** REST `current_price` stays as the
+  hydration source on first paint; live tick overlays it.
+- **Frontend chart wiring.** Existing chart components are out of scope.
+- **eToro WS protocol changes** (auth handshake, reconnect, debounced
+  reconcile, dynamic add/remove). Already correct after #487/#488/#490.
+- **Watchlist live prices.** No price surface in `WatchlistPanel.tsx`
+  today; adding one is a separate ticket.
+- **Pre-warming `quotes` for non-visible instruments.** If a future
+  scoring/ranking path needs warm prices, it should explicitly request
+  them, not lean on a hidden subscriber-level pin (Codex Q1).
+
+## Current state (anchors)
+
+### Subscriber (auto-pin to remove)
+- `app/services/etoro_websocket.py:79` — `_SOURCE_RECONCILE_INTERVAL_S = 60.0`
+- `app/services/etoro_websocket.py:298` — `fetch_watched_instrument_ids`
+  (held ∪ watchlist DB selector — caller of the auto-pin path).
+- `app/services/etoro_websocket.py:407` — `self._source_topic_set: set[int]`
+  (auto-pin worker's private ledger of refs it owns).
+- `app/services/etoro_websocket.py:414-415` — source-reconcile signal + task
+  fields.
+- `app/services/etoro_websocket.py:488` — `await self._refresh_source_topics()`
+  inside `start()`.
+- `app/services/etoro_websocket.py:614` — `self._source_reconcile_signal.set()`
+  hook after the post-portfolio-sync reconcile.
+- `app/services/etoro_websocket.py:623-718` — `_refresh_source_topics` +
+  `_source_reconcile_worker` definitions.
+
+### SSE / hooks
+- `app/api/sse_quotes.py:212` — page-view `await ws_subscriber.add_instruments(id_list)`
+  on stream open.
+- `app/api/sse_quotes.py:243` — page-view `await ws_subscriber.remove_instruments(id_list)`
+  on stream close.
+- `frontend/src/lib/useLiveQuote.ts:62-148` — **one EventSource per hook
+  instance**. With per-cell hook calls this hits the browser's ~6
+  SSE-per-origin cap on portfolio rows ≥7 (Codex finding 2). Hook needs
+  page-level redesign — see PR B.
+- `frontend/src/components/instrument/SummaryStrip.tsx:20` — only
+  current call site.
+
+### FX
+- `app/workers/scheduler.py:225` — `JOB_FX_RATES_REFRESH = "fx_rates_refresh"`.
+- `app/workers/scheduler.py:2611` — `fx_rates_refresh()` (Phase 1
+  Frankfurter conditional GET; Phase 2 eToro batch quotes).
+- `app/workers/scheduler.py:2655-2659` — `quoted_at` is set to **ECB
+  publication date**, NOT fetch time. Treating its age as a freshness
+  signal would spuriously refetch every weekend (Codex finding 5).
+- `app/services/fx.py:49-66` — `load_live_fx_rates`,
+  `load_live_fx_rates_with_metadata`.
+- Non-SSE readers of `live_fx_rates` (Codex finding 6):
+  - `app/api/portfolio.py:327` (overview), `:692`, `:848`
+  - `app/api/copy_trading.py:215` (list), `:337` (detail)
+  - `app/services/budget.py:520` (degrades `tax_usd = 0` on missing
+    GBP→USD — not just a UI concern, affects safety logic)
+  - Plus transitive readers via these paths.
+
+### Copy-trader data
+- `app/api/copy_trading.py:235` — `copy_mirror_positions` query with
+  `instrument_id` per row. Same shape as `broker_positions`.
+
+## Architecture invariants (post-spec)
+
+1. **Subscription set ≡ visibility ref-count set.** No path that bumps a
+   ref outside of an SSE stream open / close. No DB-backed selector
+   inside the subscriber.
+2. **One mechanism for held / copy-trader / instrument page.** Each row
+   that renders a price calls into a page-level live-quote provider; the
+   provider opens **one SSE stream per page** with the union of visible
+   ids, fans ticks to consumer cells via React context. (Codex finding 2
+   — fixes the 6-EventSource browser cap.)
+3. **eToro snapshot is best-effort on subscribe.** `snapshot=True` causes
+   eToro to push the latest cached `Trading.Instrument.Rate` *when one
+   exists* (active book, recent close). For halted / never-traded /
+   illiquid instruments **no snapshot frame is guaranteed**. The
+   load-bearing fallback is the REST `current_price` already on the
+   page when the row mounts; live tick overlays only when one arrives.
+4. **FX is not visibility-bound.** Multiple non-SSE handlers
+   (`/portfolio`, `/portfolio/copy-trading`, budget/execution paths) read
+   `live_fx_rates` synchronously during request handling. The table must
+   stay populated independent of any browser tab. (Codex finding 6 —
+   forces C2 over C1.)
+5. **Same id rendered twice on one page → one stream, two consumers.**
+   Provider-level dedup. (Codex finding 3.)
+
+## PRs (sequenced)
+
+### PR A — Subscriber: visibility-only
+
+Branch: `feature/<n>-visibility-only-ws`
+
+**Code changes** (all in `app/services/etoro_websocket.py`):
+- Delete `_SOURCE_RECONCILE_INTERVAL_S`.
+- Delete `_source_topic_set`, `_source_reconcile_signal`,
+  `_source_reconcile_task` fields.
+- Delete `_refresh_source_topics` method.
+- Delete `_source_reconcile_worker` method.
+- Remove the post-portfolio-sync `_source_reconcile_signal.set()` hook
+  inside `_reconcile_worker` (line 614).
+- In `start()`: drop the initial `_refresh_source_topics()` call and the
+  source-reconcile-task creation (lines 488, 496-498).
+- In `stop()`: drop the source-reconcile-task cancel block (lines 519-523).
+- `fetch_watched_instrument_ids` — keep the function (still used by
+  external callers / tests) **but** no longer called from inside the
+  subscriber.
+- Subscriber boots with `_topic_refs == {}`. Connect path subscribes to
+  `_topic_refs.keys()` (empty on first boot → log "no tracked instruments
+   — connection will idle until page-view subscribe").
+- Reconnect re-subscribes whatever refs accumulated during the outage.
+
+**Tests** (`tests/test_etoro_websocket.py`):
+- Delete the source-reconcile tests
+  (`test_initial_refresh_adds_all_source_ids`,
+  `test_subsequent_refresh_only_diffs`,
+  `test_refresh_does_not_disturb_page_view_refs`,
+  `test_provider_failure_does_not_commit_source_set`,
+  `test_signal_kicks_immediate_refresh`,
+  `test_cancel_during_send_does_not_double_add_on_next_refresh`,
+  `test_startup_refresh_failure_signals_worker_for_immediate_retry`,
+  `test_portfolio_reconcile_signals_source_worker`).
+- Keep wire-ordering test
+  (`test_concurrent_remove_blocks_until_add_send_completes`).
+- Keep ref-counted add/remove tests
+  (`TestRefCountedAddInstruments`, `TestRefCountedRemoveInstruments`).
+- Keep `TestReconnectSubscribesFromTopicRefs`.
+
+**Acceptance**:
+- Boot log on a fresh process reads
+  `EtoroWebSocketSubscriber: no tracked instruments — connection will
+   idle until page-view subscribe` (no "subscribed to N topics" line
+  until a page mounts).
+- Opening an instrument page → log
+  `EtoroWebSocketSubscriber: subscribe 1 topics` within ~1 s.
+- Closing the page → log `EtoroWebSocketSubscriber: unsubscribe 1 topics`
+  within ~1 s.
+- `pytest -q` green.
+- Lifespan shutdown completes without hang (verified against current
+  reproducer: boot, observe "subscribed", trigger watchfiles reload,
+  process exits cleanly within 5 s — no manual kill needed).
+
+### PR B — Frontend: page-level live-quote provider + cells
+
+Branch: `feature/<n>-live-quotes-everywhere`
+
+**The shape that matters** (Codex finding 2 + 3):
+
+We move from "one EventSource per hook call" to "one EventSource per page,
+fanning out to consumer cells via React context". Same id rendered N
+times on a page consumes N times from the same stream — one Subscribe
+on the wire, one tick delivered to every consumer.
+
+**New files**:
+- `frontend/src/components/quotes/LiveQuoteProvider.tsx`:
+  - Context provider. Accepts an `instrumentIds: number[]` prop (parent
+    page collects all visible ids and passes them).
+  - Opens one EventSource at `/api/sse/quotes?ids=<csv>`.
+  - Maintains a `Map<instrumentId, LiveTickPayload>` updated on each
+    received tick.
+  - Exposes a `useLiveTick(id)` consumer hook that returns the latest
+    tick (or null) for the given id and re-renders only when that id's
+    value changes.
+  - On `instrumentIds` prop change: compare the **canonical set
+    representation** (dedup + numeric sort + join) of the new ids
+    against the currently-open stream's canonical set; reopen the
+    EventSource only when the canonical strings differ. Raw array
+    identity / order changes from harmless re-renders or row reorders
+    must NOT churn the stream (Codex round 3). Debounce reopen by
+    ~300 ms on top of that so a rapidly-rendering page batches genuine
+    set changes too.
+  - Cleanup on unmount: close the stream → backend
+    `remove_instruments(all)`.
+- `frontend/src/components/quotes/LivePriceCell.tsx`:
+  - Reads `useLiveTick(instrumentId)` from context, falls back to a
+    `fallback` prop (the REST snapshot) until the first tick lands.
+  - Currency-aware via the existing `liveTickDisplayPrice` helper.
+- Tests:
+  - `LiveQuoteProvider.test.tsx`: opens one EventSource for N cells
+    sharing two distinct ids; same-id duplicate cells get the same tick;
+    unmount closes the stream.
+  - `LivePriceCell.test.tsx`: renders fallback when no tick; switches
+    to live tick on arrival.
+
+**Modify**:
+- `frontend/src/components/dashboard/PositionsTable.tsx`: wrap the table
+  with `LiveQuoteProvider` collecting `positions.map(p => p.instrument_id)`;
+  swap the static cell at line ~101 for `<LivePriceCell instrumentId={…}
+  fallback={p.current_price} currency={currency} />`.
+- `frontend/src/pages/PortfolioPage.tsx`: same — provider at page level.
+- `frontend/src/pages/CopyTradingPage.tsx`: provider at page level
+  collecting every `MirrorPositionItem.instrument_id` across all
+  mirrors. **De-dup invariant**: if a parent-CID summary cell and a
+  per-position child cell render the same `instrument_id`, both share
+  the same context tick — no duplicate stream, no stale parent.
+- `frontend/src/components/instrument/SummaryStrip.tsx`: replace the
+  current standalone `useLiveQuote` with the context consumer
+  (`useLiveTick`). The InstrumentPage wraps the strip + sub-tabs in a
+  `LiveQuoteProvider` for that single id.
+
+**Out of scope (locked)**:
+- Delta arrows / colour-on-change UI per row. Future polish.
+- Per-row spread / bid-ask split. Mid (last) only.
+- Sparkline overlays.
+- Watchlist price column (not present today; out of scope).
+
+**Acceptance**:
+- Open `/portfolio` → DevTools network panel shows ONE EventSource
+  carrying every held instrument id; every row updates within ~1 s.
+- Open `/copy-trading` → ONE EventSource for the whole page carrying
+  the union of every visible mirror's `instrument_id`s. Same-id-twice
+  (parent summary + child row) consumes from the single stream.
+- Open `/instrument/AAPL` → ONE EventSource for that single id.
+- A page that renders the same id twice (e.g. mirror summary + position
+  row) shows the same updated price in both cells without opening two
+  streams.
+- `pnpm --dir frontend test:unit` green; new component tests pass.
+
+### PR C — FX: daily cron + bootstrap on empty table
+
+Branch: `feature/<n>-fx-daily-bootstrap`
+
+**Decision**: **C2 over C1.** Codex round 2 demonstrated C1 (fully lazy)
+isn't safe — `live_fx_rates` is read by `app/api/portfolio.py`,
+`app/api/copy_trading.py`, `app/services/budget.py` etc. **before any
+SSE stream opens**, and `budget.py:520` silently degrades `tax_usd = 0`
+on missing GBP→USD. Lazy-on-SSE-open does not cover those paths.
+
+C2 keeps the cron, cuts cadence, and adds a bootstrap rule for fresh DBs.
+
+**Code changes**:
+- `app/workers/scheduler.py:225+`: change `fx_rates_refresh` cron
+  cadence from hourly to once daily at 17:00 CET (post ECB publish
+  window).
+- `app/workers/scheduler.py:2611+`: drop **Phase 2** (eToro batch
+  quotes). The WS live feed already populates `quotes` for any
+  instrument the operator views; the batch path is redundant for the
+  visibility-driven model. Keep Phase 1 (Frankfurter conditional GET).
+- `app/main.py` lifespan, **after migrations and BEFORE
+  `start_runtime()` at line 147** (Codex round 2 finding 3 — pinning
+  ordering so scheduler catch-up cannot race the inline bootstrap
+  fetch/write; both would try to write the same `live_fx_rates` rows
+  otherwise):
+  - Bootstrap rule: query `live_fx_rates`. If empty, fire one inline
+    `fetch_latest_rates_conditional` synchronously (~500 ms) and upsert
+    so the first request after a fresh DB has rates available.
+  - Failure (network down at boot, Frankfurter outage): log loud,
+    continue boot. **Safety implication below.**
+- `app/services/budget.py:520` (Codex round 2 finding 2): the silent
+  `tax_usd = 0` degrade-on-missing-rate is an execution-safety hole,
+  not just a display bug. Replace the silent fallback with a
+  fail-closed raise that the execution guard converts into a clear
+  block on the BUY/ADD path. **In scope for PR C** — moved out of
+  follow-up. Without this fix, a Frankfurter-down boot with an empty
+  `live_fx_rates` table would let an order through with `tax_usd = 0`.
+- Other FX **readers** are unchanged. They continue to read
+  `live_fx_rates` and behave as before. The only behavioural change is
+  the staleness window: rates are at most 24 h old (vs 1 h previously),
+  matching Frankfurter's actual publish cadence.
+
+**Audit (must complete BEFORE this PR merges)**:
+- `grep -r "load_live_fx_rates\|live_fx_rates" app/` and confirm every
+  call site is OK with rates up to 24 h old. Already-known sites:
+  - `app/api/sse_quotes.py:_load_display_context` — at-stream-open
+    snapshot, fine.
+  - `app/api/portfolio.py:327, 692, 848` — all per-request, fine.
+  - `app/api/copy_trading.py:215, 337` — same.
+  - `app/services/budget.py:520` — silent degrade-to-zero on missing
+    pair is an execution-safety hole (Codex round 2 finding 2). **Fixed
+    in this PR**: replace the silent fallback with a fail-closed raise
+    that the execution guard surfaces as a BUY/ADD block. Bootstrap
+    rule populates the table on fresh DBs, but cannot guarantee
+    network-down boot — fail-closed handles that case.
+  - `app/services/portfolio.py`, `app/services/execution_guard.py` —
+    fully audit against the same tolerance.
+- If any site requires <24 h freshness (e.g. an intraday execution
+  path), surface it in the PR description and either move that path
+  back to its own targeted refresh or hold C2.
+
+**Acceptance**:
+- `fx_rates_refresh` runs once daily, not hourly. Verify in
+  `/system/status` job_runs row count.
+- Phase 2 eToro batch path fully removed; no `eToro` mentions remain in
+  `fx_rates_refresh`.
+- Fresh DB boots, hits `/portfolio` immediately → no `FxRateNotFound`,
+  no missing display blocks. Bootstrap rule populated rates inline.
+- Audit list above documented in PR description with per-site
+  tolerance verdict.
+
+## Resolved findings (Codex round 1)
+
+| # | Finding | Resolution in v2 |
+|---|---------|------------------|
+| 1 | snapshot=True "guarantees" tick contradicts halted-instrument fallback | Invariant 3 weakened: snapshot is best-effort; REST fallback is load-bearing. |
+| 2 | useLiveQuote opens one EventSource per cell — hits ~6/origin cap | PR B redesigned around `LiveQuoteProvider` (one stream per page). |
+| 3 | Same-id-twice-on-page de-dup unspecified | Invariant 5 + PR B copy-trader bullet pin de-dup. |
+| 4 | Goal mentions watchlist; no price surface exists there | "Watchlist intentionally out of scope" added to Goal + Non-goals. |
+| 5 | C1 freshness rule used `quoted_at` = ECB date, not fetch time → spurious refetch on weekends | C1 dropped. C2 cadence is calendar-driven, not staleness-driven. |
+| 6 | C1 SSE-only scope leaves `/portfolio`, `/copy-trading`, budget readers stale | C1 dropped. Invariant 4 + Audit list pin the multi-reader requirement. |
+| 7 | Even C2 needs bootstrap for empty/fresh DB | PR C bootstrap rule on lifespan, before yield. |
+
+## Migration / rollback
+
+- PR A: pure refactor + delete. Rollback = revert the squash commit.
+- PR B: pure additive on the frontend. Rollback = revert the row-component
+  swap + delete the new provider/cell components.
+- PR C: rollback = restore hourly cron + Phase 2 + remove bootstrap.
+  Operator can re-enable hourly trivially.
+
+## Risks and mitigations
+
+1. **Operator opens N tabs simultaneously** (PR A + B): backend
+   ref-counting (already wire-ordering-correct after #490) handles N
+   concurrent SSE streams cleanly. Frontend per-page provider keeps
+   browser SSE-per-origin cost bounded to one stream per tab.
+2. **eToro snapshot frame absent for halted / illiquid instruments**
+   (Invariant 3): UI falls back to REST `current_price`. Verified
+   load-bearing in spec.
+3. **Frankfurter outage at boot** (PR C bootstrap): logged, boot
+   continues, daily cron retries. Operator-visible degraded display
+   currency until rates populate. Execution safety **not** at risk
+   because PR C also makes `budget.py` fail-closed on missing rate,
+   so a BUY/ADD path under empty `live_fx_rates` blocks rather than
+   silent-zeroing tax.
+4. **A reader of `live_fx_rates` requires <24 h freshness post-PR-C**
+   (audit gap): caught by the audit list above. Any such site is the
+   PR's own scope to fix or hold.
+5. **PR B same-id dedup regression** (Invariant 5): pinned by component
+   tests in `LiveQuoteProvider.test.tsx`.
+
+## Success criteria (overall)
+
+- Boot is silent on subscriptions until a page renders.
+- Every page that displays a price shows a live-updating one within ~1 s
+  of mount.
+- Closing a page tears down its subscriptions within ~1 s.
+- Lifespan shutdown completes cleanly without hang.
+- One EventSource per page; same-id-twice consumes from the same stream.
+- FX scheduled job runs daily, not hourly. Fresh-DB boot has rates
+  available without operator intervention.

--- a/tests/test_etoro_websocket.py
+++ b/tests/test_etoro_websocket.py
@@ -863,20 +863,20 @@ class TestRefCountedRemoveInstruments:
         assert len(fake.sent) == 1
         assert sub._topic_refs == {1001: 1}
 
-    async def test_held_position_ref_survives_page_view_remove(self) -> None:
-        """With unified ref counting, a held position is just a ref
-        held by the source-reconcile worker. A page-view's remove
-        decrements its own ref but the source ref keeps the topic
-        subscribed — the wire-level Unsubscribe never fires while
-        any source still holds a ref."""
+    async def test_multi_tab_share_keeps_topic_alive_until_last_close(self) -> None:
+        """Two tabs viewing the same instrument share the topic. The
+        first close drops the refcount from 2→1 (no Unsubscribe); the
+        topic stays alive while the second tab is still viewing. Only
+        the second close (1→0) sends Unsubscribe to eToro."""
         sub = _make_dyn_subscriber()
         fake = _DynFakeWs()
         sub._ws = fake  # type: ignore[assignment]
 
-        # Source worker adds a ref (held position).
+        # Tab A opens.
         await sub.add_instruments([1001])
-        # Page-view layer adds + removes its own ref.
+        # Tab B opens (same instrument).
         await sub.add_instruments([1001])
+        # Tab A closes — refcount 2→1, no Unsubscribe.
         await sub.remove_instruments([1001])
 
         # Only the initial Subscribe frame went out; no Unsubscribe.
@@ -942,107 +942,10 @@ class TestReconnectSubscribesFromTopicRefs:
         ]
 
 
-class TestSourceReconcileWorker:
-    """``_refresh_source_topics`` diffs the held-∪-watchlist DB set
-    against ``_source_topic_set`` and translates the diff into add/
-    remove calls. Held positions and watchlist entries become refs
-    held by the source worker; the unified ``_topic_refs`` dict is
-    what every other path reads from."""
-
-    async def test_initial_refresh_adds_all_source_ids(self) -> None:
-        sub = _make_dyn_subscriber()
-        sub._watched_ids_provider = lambda: [1001, 1002]  # type: ignore[method-assign]
-        # No live ws — ref-count update only, no frame send. Mirrors
-        # the start()-before-connect ordering.
-        sub._ws = None
-
-        await sub._refresh_source_topics()
-
-        assert sub._topic_refs == {1001: 1, 1002: 1}
-        assert sub._source_topic_set == {1001, 1002}
-
-    async def test_subsequent_refresh_only_diffs(self) -> None:
-        sub = _make_dyn_subscriber()
-        sub._watched_ids_provider = lambda: [1001, 1002]  # type: ignore[method-assign]
-        sub._ws = None
-
-        await sub._refresh_source_topics()
-
-        # Second tick: 1002 removed from held/watchlist, 1003 added.
-        sub._watched_ids_provider = lambda: [1001, 1003]  # type: ignore[method-assign]
-        await sub._refresh_source_topics()
-
-        assert sub._topic_refs == {1001: 1, 1003: 1}
-        assert sub._source_topic_set == {1001, 1003}
-
-    async def test_refresh_does_not_disturb_page_view_refs(self) -> None:
-        """A page-view ref on the same instrument id keeps the topic
-        subscribed even when the source set drops it."""
-        sub = _make_dyn_subscriber()
-        sub._watched_ids_provider = lambda: [1001]  # type: ignore[method-assign]
-        sub._ws = None
-
-        # Source ref + an independent page-view ref on 1001.
-        await sub._refresh_source_topics()
-        await sub.add_instruments([1001])  # page-view
-
-        # Source set drops 1001 (sold the position).
-        sub._watched_ids_provider = lambda: []  # type: ignore[method-assign]
-        await sub._refresh_source_topics()
-
-        # Page-view ref keeps the topic alive.
-        assert sub._topic_refs == {1001: 1}
-        assert sub._source_topic_set == set()
-
-    async def test_provider_failure_does_not_commit_source_set(self) -> None:
-        """If ``_watched_ids_provider`` raises, ``_source_topic_set``
-        stays unchanged so the next tick retries from the same
-        baseline rather than masking the error."""
-        sub = _make_dyn_subscriber()
-        sub._source_topic_set = {1001}
-        sub._topic_refs = {1001: 1}
-        sub._ws = None
-
-        def boom() -> list[int]:
-            raise RuntimeError("DB hiccup")
-
-        sub._watched_ids_provider = boom  # type: ignore[method-assign]
-
-        with pytest.raises(RuntimeError):
-            await sub._refresh_source_topics()
-
-        assert sub._source_topic_set == {1001}
-        assert sub._topic_refs == {1001: 1}
-
-    async def test_signal_kicks_immediate_refresh(self) -> None:
-        """Setting ``_source_reconcile_signal`` causes the worker
-        coroutine to refresh without waiting for the periodic tick."""
-        sub = _make_dyn_subscriber()
-        provider_calls: list[list[int]] = []
-
-        def provider() -> list[int]:
-            provider_calls.append([1001])
-            return [1001]
-
-        sub._watched_ids_provider = provider  # type: ignore[method-assign]
-        sub._ws = None
-
-        worker = asyncio.create_task(sub._source_reconcile_worker())
-        try:
-            sub._source_reconcile_signal.set()
-            # Wait for the provider to be invoked at least once via
-            # the signal path (well under the periodic interval).
-            for _ in range(100):
-                await asyncio.sleep(0.01)
-                if provider_calls:
-                    break
-            assert provider_calls, "source worker did not refresh on signal"
-            assert sub._topic_refs == {1001: 1}
-        finally:
-            sub._stop_event.set()
-            worker.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await worker
+class TestWireOrdering:
+    """Wire-ordering invariants for add/remove sends. Held under the
+    topic lock so that a concurrent remove cannot queue an
+    Unsubscribe(T) frame that overtakes an in-flight Subscribe(T)."""
 
     async def test_concurrent_remove_blocks_until_add_send_completes(self) -> None:
         """``add_instruments`` and ``remove_instruments`` must hold
@@ -1099,104 +1002,3 @@ class TestSourceReconcileWorker:
         # Wire order must be Subscribe THEN Unsubscribe; reversed
         # would tear down the feed.
         assert sent_order == ["Subscribe", "Unsubscribe"]
-
-    async def test_cancel_during_send_does_not_double_add_on_next_refresh(self) -> None:
-        """If a CancelledError lands during the awaited send inside
-        ``_refresh_source_topics``, ``_source_topic_set`` must already
-        be committed so the next refresh sees no diff and does not
-        bump refs again. Regression for the cancel-leak Codex flagged
-        on PR for #490."""
-        sub = _make_dyn_subscriber()
-
-        class SlowWs:
-            async def send(self, payload: str) -> None:
-                await asyncio.sleep(10)
-
-        sub._ws = SlowWs()  # type: ignore[assignment]
-        sub._watched_ids_provider = lambda: [1001]  # type: ignore[method-assign]
-
-        task = asyncio.create_task(sub._refresh_source_topics())
-        # Yield long enough for the refresh to enter the lock and reach
-        # the awaited send.
-        for _ in range(50):
-            await asyncio.sleep(0.01)
-            if sub._source_topic_set == {1001}:
-                break
-        assert sub._source_topic_set == {1001}, "source set not committed before send"
-        assert sub._topic_refs == {1001: 1}
-
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
-
-        # Drop the slow ws so the next refresh doesn't block.
-        sub._ws = None
-        await sub._refresh_source_topics()
-
-        # No double-add: ref count should still be 1, not 2.
-        assert sub._topic_refs == {1001: 1}
-        assert sub._source_topic_set == {1001}
-
-    async def test_startup_refresh_failure_signals_worker_for_immediate_retry(self) -> None:
-        """When ``_refresh_source_topics`` raises during ``start()``,
-        the source-reconcile signal must be set so the worker's first
-        iteration runs immediately rather than waiting for the
-        periodic timeout. Held/watchlist feeds shouldn't be dark for
-        ``_SOURCE_RECONCILE_INTERVAL_S`` after a transient startup
-        DB hiccup."""
-        sentinel: Any = object()
-        sub = EtoroWebSocketSubscriber(
-            api_key="API",
-            user_key="USR",
-            env="demo",
-            pool=sentinel,
-            watched_ids_provider=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
-            reconcile_runner=lambda: None,
-        )
-
-        # Replace _run so start() doesn't try to open a real WS.
-        async def fake_run() -> None:
-            await sub._stop_event.wait()
-
-        sub._run = fake_run  # type: ignore[method-assign]
-
-        try:
-            await sub.start()
-            assert sub._source_reconcile_signal.is_set(), (
-                "startup-refresh failure must pre-set the source-reconcile signal"
-            )
-        finally:
-            await sub.stop()
-
-    async def test_portfolio_reconcile_signals_source_worker(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """After ``_reconcile_worker`` runs a successful portfolio
-        reconcile, it must set ``_source_reconcile_signal`` so the
-        topic-set worker picks up any newly opened/closed position
-        within seconds rather than waiting for the periodic tick."""
-        monkeypatch.setattr(etoro_websocket, "_RECONCILE_DEBOUNCE_S", 0.05)
-
-        sentinel: Any = object()
-        sub = EtoroWebSocketSubscriber(
-            api_key="API",
-            user_key="USR",
-            env="demo",
-            pool=sentinel,
-            watched_ids_provider=lambda: [],
-            reconcile_runner=lambda: None,
-        )
-
-        worker = asyncio.create_task(sub._reconcile_worker())
-        await asyncio.sleep(0)
-        try:
-            assert not sub._source_reconcile_signal.is_set()
-            sub._schedule_reconcile()
-            for _ in range(200):
-                await asyncio.sleep(0.01)
-                if sub._source_reconcile_signal.is_set():
-                    break
-            assert sub._source_reconcile_signal.is_set(), "post-reconcile hook did not fire source-reconcile signal"
-        finally:
-            sub._stop_event.set()
-            worker.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await worker


### PR DESCRIPTION
## What

PR A of the visibility-driven live-prices plan (spec at [docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md](docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md), v3, three rounds with Codex).

Removes the source-reconcile worker added in #490. Held positions and watchlist entries no longer get auto-subscribed when nothing on screen displays them. Subscriptions are owned exclusively by SSE page-view callers via `add_instruments` / `remove_instruments`.

## Why

Operator complaint after #490: app boot logs `subscribed to 5 instrument topics` even when no portfolio page is open. Wasted bandwidth + DB writes + log noise. Codex independently confirmed the auto-pin model was over-engineered for the single-operator demo deployment.

Side-effect: fixes the lifespan-shutdown hang from #490 — no source-reconcile worker thread holds a pool connection during teardown.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest` (2727 passed, 1 skipped)
- [x] Codex review on diff — only finding was stale doc-strings, fixed in this PR
- [ ] Live smoke (operator runs after merge):
  - Boot fresh process → log reads "no tracked instruments — connection will idle until a page-view subscribe"
  - Open `/instrument/AAPL` → log "subscribe 1 topics" within ~1s
  - Close → log "unsubscribe 1 topics" within ~1s
  - Edit a backend file → watchfiles reload completes in <5s (no shutdown hang)