### PR TITLE
feat(#501): live prices on portfolio + copy-trading + dashboard

### DIFF
--- a/frontend/src/components/dashboard/PositionsTable.tsx
+++ b/frontend/src/components/dashboard/PositionsTable.tsx
@@ -1,8 +1,11 @@
+import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import type { PositionItem, PortfolioMirrorItem } from "@/api/types";
 import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
 import { formatMoney, formatNumber, formatPct, pnlPct } from "@/lib/format";
 import { EmptyState } from "@/components/states/EmptyState";
+import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
+import { LivePriceCell } from "@/components/quotes/LivePriceCell";
 
 /**
  * Positions table — unified view of direct positions and copy-trading mirrors.
@@ -51,7 +54,16 @@ export function PositionsTable({
     return mvB - mvA;
   });
 
+  // Live quote ids for the visible position rows. Mirror rows render
+  // their own aggregated equity, not a per-instrument price, so they
+  // don't contribute ids here.
+  const liveQuoteIds = useMemo(
+    () => positions.map((p) => p.instrument_id),
+    [positions],
+  );
+
   return (
+    <LiveQuoteProvider instrumentIds={liveQuoteIds}>
     <div className="overflow-x-auto">
       <table className="w-full text-left text-sm">
         <thead className="text-xs uppercase text-slate-500">
@@ -76,6 +88,7 @@ export function PositionsTable({
         </tbody>
       </table>
     </div>
+    </LiveQuoteProvider>
   );
 }
 
@@ -98,7 +111,11 @@ function PositionRow({ p, currency }: { p: PositionItem; currency: string }) {
       <Td align="right">{formatNumber(p.current_units)}</Td>
       <Td align="right">{formatMoney(p.cost_basis, currency)}</Td>
       <Td align="right">
-        {p.current_price != null ? formatMoney(p.current_price, currency) : "—"}
+        <LivePriceCell
+          instrumentId={p.instrument_id}
+          fallback={p.current_price}
+          currency={currency}
+        />
       </Td>
       <Td align="right">{formatMoney(p.market_value, currency)}</Td>
       <Td align="right">

--- a/frontend/src/components/quotes/LivePriceCell.tsx
+++ b/frontend/src/components/quotes/LivePriceCell.tsx
@@ -1,0 +1,49 @@
+/**
+ * LivePriceCell — visibility-driven live price overlay (#501).
+ *
+ * Reads the latest tick for ``instrumentId`` from the surrounding
+ * :func:`LiveQuoteProvider` and renders the operator's display
+ * currency price. Until the first tick lands, falls back to the
+ * REST snapshot ``fallback`` so first paint is never blank for an
+ * instrument the operator has just been viewing.
+ *
+ * Per the spec
+ * (docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md
+ * Invariant 3): the snapshot frame is best-effort. For halted /
+ * illiquid / never-traded instruments eToro may not push a tick,
+ * in which case the REST fallback stays on screen indefinitely —
+ * that's correct behaviour, not a bug.
+ */
+import { liveTickDisplayPrice } from "@/lib/useLiveQuote";
+import { formatMoney } from "@/lib/format";
+import { useLiveTick } from "./LiveQuoteProvider";
+
+interface LivePriceCellProps {
+  instrumentId: number | null | undefined;
+  /** REST-snapshot price already on the page when this cell mounts.
+   *  Rendered until the first live tick arrives. */
+  fallback: number | null | undefined;
+  /** Operator's display currency (e.g. "USD", "GBP"). Live ticks
+   *  carry their own currency code in the ``display`` block; the
+   *  fallback uses this. */
+  currency: string | null;
+}
+
+export function LivePriceCell({
+  instrumentId,
+  fallback,
+  currency,
+}: LivePriceCellProps) {
+  const tick = useLiveTick(instrumentId);
+  const live = liveTickDisplayPrice(tick);
+  if (live !== null) {
+    const numeric = Number(live.value);
+    if (Number.isFinite(numeric)) {
+      return <span>{formatMoney(numeric, live.currency ?? currency ?? "USD")}</span>;
+    }
+  }
+  if (fallback === null || fallback === undefined) {
+    return <span className="text-slate-300">—</span>;
+  }
+  return <span className="text-slate-500">{formatMoney(fallback, currency ?? "USD")}</span>;
+}

--- a/frontend/src/components/quotes/LiveQuoteProvider.test.tsx
+++ b/frontend/src/components/quotes/LiveQuoteProvider.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Tests for LiveQuoteProvider — page-level shared SSE for live quotes (#501).
+ *
+ * Verifies:
+ *   - One EventSource per page (not per cell).
+ *   - Same id rendered twice on a page consumes from the same stream
+ *     and both consumers see the same tick.
+ *   - Canonical-set equality: prop changes that don't change the
+ *     unique sorted membership do NOT churn the EventSource.
+ *   - Cleanup closes the stream on unmount + on canonical-set change.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, act, cleanup } from "@testing-library/react";
+
+import {
+  LiveQuoteProvider,
+  useLiveTick,
+} from "./LiveQuoteProvider";
+
+interface FakeEventSource {
+  url: string;
+  withCredentials: boolean;
+  readyState: number;
+  close: () => void;
+  onopen: ((this: EventSource, ev: Event) => unknown) | null;
+  onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null;
+  onerror: ((this: EventSource, ev: Event) => unknown) | null;
+}
+
+let openedSources: FakeEventSource[] = [];
+
+beforeEach(() => {
+  openedSources = [];
+  vi.useFakeTimers();
+  // jsdom doesn't ship EventSource — install a controllable fake.
+  // We capture every constructed instance so tests can assert on
+  // count, url, and dispatch synthetic ticks.
+  // @ts-expect-error — jsdom global lacks the type
+  globalThis.EventSource = class {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSED = 2;
+    url: string;
+    withCredentials: boolean;
+    readyState = 0;
+    onopen: ((this: EventSource, ev: Event) => unknown) | null = null;
+    onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null;
+    onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
+    constructor(url: string, init?: { withCredentials?: boolean }) {
+      this.url = url;
+      this.withCredentials = init?.withCredentials ?? false;
+      openedSources.push(this as unknown as FakeEventSource);
+    }
+    close() {
+      this.readyState = 2;
+    }
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  // @ts-expect-error — restore
+  delete globalThis.EventSource;
+});
+
+function PriceConsumer({ id, label }: { id: number; label: string }) {
+  const tick = useLiveTick(id);
+  return (
+    <div data-testid={`consumer-${label}`}>
+      {tick === null ? "—" : tick.bid}
+    </div>
+  );
+}
+
+function dispatchTick(idx: number, payload: Record<string, unknown>): void {
+  const src = openedSources[idx];
+  if (src === undefined || src.onmessage === null) return;
+  src.onmessage.call(src as unknown as EventSource, new MessageEvent("message", {
+    data: JSON.stringify(payload),
+  }));
+}
+
+describe("LiveQuoteProvider", () => {
+  it("opens exactly one EventSource for N consumers on the same page", async () => {
+    render(
+      <LiveQuoteProvider instrumentIds={[1, 2, 3]}>
+        <PriceConsumer id={1} label="a" />
+        <PriceConsumer id={2} label="b" />
+        <PriceConsumer id={3} label="c" />
+      </LiveQuoteProvider>,
+    );
+    // Debounce timer: advance past it.
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(openedSources).toHaveLength(1);
+    expect(openedSources[0]?.url).toContain("ids=1%2C2%2C3");
+  });
+
+  it("delivers ticks to every consumer subscribed to the same id", async () => {
+    const view = render(
+      <LiveQuoteProvider instrumentIds={[42]}>
+        <PriceConsumer id={42} label="a" />
+        <PriceConsumer id={42} label="b" />
+      </LiveQuoteProvider>,
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+
+    await act(async () => {
+      dispatchTick(0, {
+        instrument_id: 42,
+        bid: "100.50",
+        ask: "100.60",
+        last: "100.55",
+        quoted_at: "2026-04-25T14:30:00Z",
+        native_currency: "USD",
+        display: null,
+      });
+    });
+
+    expect(view.getByTestId("consumer-a").textContent).toBe("100.50");
+    expect(view.getByTestId("consumer-b").textContent).toBe("100.50");
+  });
+
+  it("does NOT reopen the stream when the prop array changes order/identity but membership is the same", async () => {
+    const view = render(
+      <LiveQuoteProvider instrumentIds={[1, 2, 3]}>
+        <PriceConsumer id={1} label="a" />
+      </LiveQuoteProvider>,
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(openedSources).toHaveLength(1);
+
+    // Reorder + duplicate same membership (Codex round 3 finding 1).
+    view.rerender(
+      <LiveQuoteProvider instrumentIds={[3, 1, 1, 2]}>
+        <PriceConsumer id={1} label="a" />
+      </LiveQuoteProvider>,
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(openedSources).toHaveLength(1);
+  });
+
+  it("reopens the stream when the canonical-set membership changes", async () => {
+    const view = render(
+      <LiveQuoteProvider instrumentIds={[1, 2]}>
+        <PriceConsumer id={1} label="a" />
+      </LiveQuoteProvider>,
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(openedSources).toHaveLength(1);
+
+    view.rerender(
+      <LiveQuoteProvider instrumentIds={[1, 2, 3]}>
+        <PriceConsumer id={1} label="a" />
+      </LiveQuoteProvider>,
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(openedSources).toHaveLength(2);
+    // Prior connection closed.
+    expect(openedSources[0]?.readyState).toBe(2);
+  });
+
+  it("opens no stream when the id list is empty", async () => {
+    render(
+      <LiveQuoteProvider instrumentIds={[]}>
+        <PriceConsumer id={1} label="a" />
+      </LiveQuoteProvider>,
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(openedSources).toHaveLength(0);
+  });
+
+  it("closes the stream on unmount", async () => {
+    const view = render(
+      <LiveQuoteProvider instrumentIds={[1]}>
+        <PriceConsumer id={1} label="a" />
+      </LiveQuoteProvider>,
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+    const source = openedSources[0];
+    expect(source).toBeDefined();
+    view.unmount();
+    expect(source?.readyState).toBe(2);
+  });
+});

--- a/frontend/src/components/quotes/LiveQuoteProvider.tsx
+++ b/frontend/src/components/quotes/LiveQuoteProvider.tsx
@@ -1,0 +1,246 @@
+/**
+ * LiveQuoteProvider — page-level shared SSE for quote ticks (#501).
+ *
+ * Why page-level (not per-cell):
+ *   The browser caps SSE connections to ~6 per origin. A portfolio
+ *   table with 7+ rows that each opened its own EventSource would
+ *   silently queue connections beyond the cap. The provider opens
+ *   ONE EventSource per page carrying the union of every visible
+ *   instrument id; consumer cells subscribe to per-id ticks via
+ *   React context.
+ *
+ * Per the spec
+ * (docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md
+ * Invariants 2 + 5):
+ *   - One stream per page.
+ *   - Same id rendered twice on a page consumes from the same stream.
+ *   - Stream re-opens only on canonical-set change (dedup + numeric
+ *     sort + join), so harmless re-renders or row reorders don't
+ *     churn the SSE connection.
+ *
+ * Backend integration:
+ *   The SSE endpoint at GET /sse/quotes?ids=<csv> ref-counts the
+ *   ids on stream open and decrements on close. The subscriber
+ *   sends Subscribe / Unsubscribe frames to eToro accordingly.
+ *   This file is the only consumer the operator's UI needs to
+ *   wire prices everywhere.
+ */
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  type ReactNode,
+} from "react";
+
+import type { LiveTickPayload } from "@/lib/useLiveQuote";
+
+const REOPEN_DEBOUNCE_MS = 300;
+
+interface LiveQuoteContextValue {
+  /** Latest tick by instrument_id; undefined while waiting for the
+   *  first tick (or when no tick will arrive — halted / illiquid
+   *  instruments may never produce a snapshot). */
+  ticks: ReadonlyMap<number, LiveTickPayload>;
+  /** True once the SSE connection has opened. */
+  connected: boolean;
+  /** True if the backend returned 503 or the connection errored
+   *  permanently. UI falls back to its REST snapshot. */
+  unavailable: boolean;
+}
+
+const LiveQuoteContext = createContext<LiveQuoteContextValue>({
+  ticks: new Map(),
+  connected: false,
+  unavailable: false,
+});
+
+interface State {
+  ticks: Map<number, LiveTickPayload>;
+  connected: boolean;
+  unavailable: boolean;
+}
+
+type Action =
+  | { type: "tick"; payload: LiveTickPayload }
+  | { type: "open" }
+  | { type: "error" }
+  | { type: "reset" };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "tick": {
+      // ``Map`` is mutable but React relies on identity; clone so
+      // consumers that select via ``ticks.get(id)`` actually re-
+      // render. Cost is one map allocation per tick — negligible at
+      // typical eToro tick rates.
+      const next = new Map(state.ticks);
+      next.set(action.payload.instrument_id, action.payload);
+      return { ...state, ticks: next };
+    }
+    case "open":
+      return { ...state, connected: true, unavailable: false };
+    case "error":
+      return { ...state, connected: false, unavailable: true };
+    case "reset":
+      return { ticks: new Map(), connected: false, unavailable: false };
+  }
+}
+
+/**
+ * Canonical set representation for the visible-id list — dedup +
+ * numeric sort + comma-join. Two arrays with the same membership
+ * (regardless of order or duplicates) produce the same string, so
+ * the EventSource doesn't churn on re-renders that merely change
+ * row order. Pinned in the spec (Codex round 3 finding 1).
+ */
+function canonicaliseIds(ids: readonly number[]): string {
+  const unique = Array.from(new Set(ids)).filter((n) => Number.isFinite(n));
+  unique.sort((a, b) => a - b);
+  return unique.join(",");
+}
+
+interface LiveQuoteProviderProps {
+  /** Instrument ids the page wants live ticks for. Order, duplicates,
+   *  and per-render identity are all ignored — only the canonical
+   *  set membership matters. */
+  instrumentIds: readonly number[];
+  children: ReactNode;
+}
+
+export function LiveQuoteProvider({
+  instrumentIds,
+  children,
+}: LiveQuoteProviderProps) {
+  const [state, dispatch] = useReducer(reducer, undefined, () => ({
+    ticks: new Map(),
+    connected: false,
+    unavailable: false,
+  }));
+
+  const canonical = useMemo(() => canonicaliseIds(instrumentIds), [instrumentIds]);
+  const sourceRef = useRef<EventSource | null>(null);
+  const reopenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (typeof EventSource === "undefined") return;
+    if (canonical === "") {
+      // No ids → no stream. Close any prior connection cleanly so
+      // pages that briefly drop to zero rows don't leave a dangling
+      // refcount on the backend.
+      const prior = sourceRef.current;
+      if (prior !== null) {
+        prior.close();
+        sourceRef.current = null;
+        dispatch({ type: "reset" });
+      }
+      return;
+    }
+
+    // Debounce reopen so a burst of state changes resolves into one
+    // SSE handshake. ``canonical`` already filters out re-renders
+    // that don't change the set; the debounce guards rapid genuine
+    // changes (e.g. rows arriving in waves from a slow REST fetch).
+    if (reopenTimerRef.current !== null) {
+      clearTimeout(reopenTimerRef.current);
+    }
+    reopenTimerRef.current = setTimeout(() => {
+      const prior = sourceRef.current;
+      if (prior !== null) {
+        prior.close();
+      }
+      // Reset state on each (re)connect so stale ticks from a
+      // previous canonical set don't bleed into the new view.
+      dispatch({ type: "reset" });
+
+      // Route through ``/api/*`` so the Vite dev proxy strips the
+      // prefix and forwards to the backend's /sse/quotes route.
+      const url = `/api/sse/quotes?ids=${encodeURIComponent(canonical)}`;
+      const source = new EventSource(url, { withCredentials: true });
+      sourceRef.current = source;
+
+      const isActive = (): boolean => sourceRef.current === source;
+
+      source.onopen = () => {
+        if (!isActive()) return;
+        dispatch({ type: "open" });
+      };
+
+      source.onmessage = (ev: MessageEvent) => {
+        if (!isActive()) return;
+        try {
+          const payload = JSON.parse(ev.data) as LiveTickPayload;
+          if (typeof payload.instrument_id === "number") {
+            dispatch({ type: "tick", payload });
+          }
+        } catch {
+          // Malformed JSON — drop the frame; the connection stays
+          // open for the next one.
+        }
+      };
+
+      source.onerror = () => {
+        if (!isActive()) return;
+        // EventSource auto-reconnects on transient drops; we only
+        // mark unavailable once the connection is definitively
+        // closed.
+        if (source.readyState === EventSource.CLOSED) {
+          dispatch({ type: "error" });
+        }
+      };
+    }, REOPEN_DEBOUNCE_MS);
+
+    return () => {
+      if (reopenTimerRef.current !== null) {
+        clearTimeout(reopenTimerRef.current);
+        reopenTimerRef.current = null;
+      }
+      const source = sourceRef.current;
+      if (source !== null) {
+        source.close();
+        sourceRef.current = null;
+      }
+    };
+  }, [canonical]);
+
+  const value = useMemo<LiveQuoteContextValue>(
+    () => ({
+      ticks: state.ticks,
+      connected: state.connected,
+      unavailable: state.unavailable,
+    }),
+    [state.ticks, state.connected, state.unavailable],
+  );
+
+  return (
+    <LiveQuoteContext.Provider value={value}>
+      {children}
+    </LiveQuoteContext.Provider>
+  );
+}
+
+/**
+ * Consumer hook — returns the latest tick for the given instrument
+ * id, or ``null`` while waiting for the first tick. A null value is
+ * not "broken" — it just means eToro hasn't pushed a rate for this
+ * instrument yet (quiet book, market closed, halted instrument).
+ * Callers should fall back to whatever REST snapshot they have on
+ * hand for the initial paint.
+ */
+export function useLiveTick(
+  instrumentId: number | null | undefined,
+): LiveTickPayload | null {
+  const ctx = useContext(LiveQuoteContext);
+  if (instrumentId === null || instrumentId === undefined) return null;
+  return ctx.ticks.get(instrumentId) ?? null;
+}
+
+export function useLiveQuoteConnection(): {
+  connected: boolean;
+  unavailable: boolean;
+} {
+  const ctx = useContext(LiveQuoteContext);
+  return { connected: ctx.connected, unavailable: ctx.unavailable };
+}

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { fetchMirrorDetail } from "@/api/copyTrading";
 import { useAsync } from "@/lib/useAsync";
@@ -6,6 +6,8 @@ import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
 import { formatMoney, formatNumber, formatPct, formatDateTime, pnlPct } from "@/lib/format";
 import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
+import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
+import { LivePriceCell } from "@/components/quotes/LivePriceCell";
 import type { MirrorSummary, MirrorPositionItem } from "@/api/types";
 
 /**
@@ -180,6 +182,15 @@ function GroupedPositionsTable({
   positions: MirrorPositionItem[];
   currency: string;
 }) {
+  // Collect every instrument id rendered (group rows AND any
+  // expanded sub-rows share the same id) so one SSE stream covers
+  // the whole table. Same-id-twice de-dup is handled by the
+  // provider; both cells consume from the same context tick.
+  const liveQuoteIds = useMemo(
+    () => positions.map((p) => p.instrument_id),
+    [positions],
+  );
+
   if (positions.length === 0) {
     return <p className="text-xs text-slate-500">No open positions in this mirror.</p>;
   }
@@ -187,6 +198,7 @@ function GroupedPositionsTable({
   const groups = groupByInstrument(positions);
 
   return (
+    <LiveQuoteProvider instrumentIds={liveQuoteIds}>
     <div className="overflow-x-auto">
       <table className="w-full text-left text-sm">
         <thead className="text-xs uppercase text-slate-500">
@@ -206,6 +218,7 @@ function GroupedPositionsTable({
         </tbody>
       </table>
     </div>
+    </LiveQuoteProvider>
   );
 }
 
@@ -246,7 +259,11 @@ function InstrumentGroupRow({
         </td>
         <td className="px-2 py-2 text-right tabular-nums">{formatNumber(group.total_units)}</td>
         <td className="px-2 py-2 text-right tabular-nums">
-          {group.current_price != null ? formatMoney(group.current_price, currency) : "—"}
+          <LivePriceCell
+            instrumentId={group.instrument_id}
+            fallback={group.current_price}
+            currency={currency}
+          />
         </td>
         <td className="px-2 py-2 text-right tabular-nums">
           {formatMoney(group.total_market_value, currency)}
@@ -292,7 +309,11 @@ function SubPositionRow({
       <td className="px-2 py-1.5 text-right" />
       <td className="px-2 py-1.5 text-right tabular-nums">{formatNumber(position.units)}</td>
       <td className="px-2 py-1.5 text-right tabular-nums">
-        {position.current_price != null ? formatMoney(position.current_price, currency) : "—"}
+        <LivePriceCell
+          instrumentId={position.instrument_id}
+          fallback={position.current_price}
+          currency={currency}
+        />
       </td>
       <td className="px-2 py-1.5 text-right tabular-nums">
         {formatMoney(position.market_value, currency)}

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -15,6 +15,8 @@ import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
 import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
+import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
+import { LivePriceCell } from "@/components/quotes/LivePriceCell";
 import type {
   BrokerPositionItem,
   PositionItem,
@@ -70,6 +72,17 @@ export function PortfolioPage() {
   // render.
   const focusedIdxRef = useRef(focusedIdx);
   const pageRowsRef = useRef<RowItem[]>([]);
+
+  // Instrument ids for every held position the page may render —
+  // fed to the page-level LiveQuoteProvider so a single SSE stream
+  // covers every visible row. Mirror rows render an avatar + total,
+  // not a per-instrument price, so they don't contribute ids here;
+  // their underlying instruments only matter on the copy-trading
+  // detail page.
+  const liveQuoteIds = useMemo(() => {
+    if (portfolio.data === null) return [];
+    return portfolio.data.positions.map((p) => p.instrument_id);
+  }, [portfolio.data]);
 
   // Positions + mirrors merged, sorted by dollar value, filtered by
   // search, then paged. Both row types contribute to "account worth",
@@ -217,6 +230,7 @@ export function PortfolioPage() {
       ) : portfolio.loading || portfolio.data === null ? (
         <SectionSkeleton rows={8} />
       ) : (
+        <LiveQuoteProvider instrumentIds={liveQuoteIds}>
         <div className="space-y-3">
           <SummaryBar data={portfolio.data} currency={currency} />
           {allRows.length === 0 ? (
@@ -271,6 +285,7 @@ export function PortfolioPage() {
             </>
           )}
         </div>
+        </LiveQuoteProvider>
       )}
 
       {addFor !== null ? (
@@ -576,7 +591,11 @@ function PositionRow({
         {p.avg_cost != null ? formatMoney(p.avg_cost, currency) : "—"}
       </td>
       <td className="px-2 py-2 text-right tabular-nums">
-        {p.current_price != null ? formatMoney(p.current_price, currency) : "—"}
+        <LivePriceCell
+          instrumentId={p.instrument_id}
+          fallback={p.current_price}
+          currency={currency}
+        />
       </td>
       <td className="px-2 py-2 text-right tabular-nums text-slate-600">
         {formatMoney(p.cost_basis, currency)}


### PR DESCRIPTION
## What

PR B of the visibility-driven live-prices plan (spec at [docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md](docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md)).

Adds a page-level `LiveQuoteProvider` + per-cell `LivePriceCell` and wires them into `PortfolioPage`, `PositionsTable` (dashboard), and `CopyTradingPage`. Operator now sees live updating prices on every visible held position and every copy-trader row, not just the single-instrument page.

## Why

After PR A removed the auto-pin on the subscriber side, the operator expected the portfolio page to show live prices — but the frontend never opened SSE streams for those rows. PR B closes that gap.

## Architecture

Per the spec's Invariants 2 + 5:
- **One stream per page**, not one per cell. The provider opens a single EventSource carrying the union of every visible instrument id. Avoids the ~6-EventSource-per-origin browser cap.
- **Same id rendered twice consumes from the same stream**. Both `InstrumentGroupRow` and any expanded `SubPositionRow` for the same instrument see the same tick.
- **Canonical-set equality**: stream reopens only when the dedup + numeric sort + join of `instrumentIds` changes. Re-renders / row reorders with the same membership don't churn the SSE connection.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `pnpm typecheck`
- [x] `pnpm test:unit` (406/406 — added 6 LiveQuoteProvider tests)
- [ ] Live smoke (operator, after merge):
  - Open `/portfolio` → DevTools shows ONE EventSource carrying every position's instrument id; rows update within ~1s of mount
  - Open `/copy-trading/<id>` → ONE EventSource for the page; group rows + expanded sub-rows show live updating prices
  - Open `/dashboard` → ONE EventSource carrying the dashboard-table's positions
  - Verify backend logs: `EtoroWebSocketSubscriber: subscribe N topics` for the page's instruments; `unsubscribe N topics` on navigation away

## Out of scope (locked)

- `SummaryStrip` keeps its standalone `useLiveQuote`. One stream for one id is below the cap.
- Watchlist live prices (no price surface today).
- Day-change arrows / colour-on-change polish.