### PR TITLE
feat(#502): FX cadence cut to daily + lifespan bootstrap + fail-closed budget

### DIFF
--- a/app/api/budget.py
+++ b/app/api/budget.py
@@ -34,6 +34,7 @@ from app.api.auth import require_session_or_service_token
 from app.db import get_conn
 from app.services.budget import (
     BudgetConfigCorrupt,
+    FxRateUnavailable,
     compute_budget_state,
     get_budget_config,
     list_capital_events,
@@ -159,6 +160,15 @@ def get_budget(
     except BudgetConfigCorrupt:
         logger.exception("budget config corrupt — cannot compute budget state")
         raise HTTPException(status_code=503, detail="budget configuration unavailable")
+    except FxRateUnavailable:
+        # Surface as 503 so the operator UI shows "FX unavailable"
+        # rather than a stale-zero tax estimate that misleads
+        # downstream BUY decisions.
+        logger.exception("budget compute failed: FX rate unavailable")
+        raise HTTPException(
+            status_code=503,
+            detail="FX rate unavailable; budget cannot be computed without a GBP→USD rate",
+        )
 
     return BudgetStateResponse(
         cash_balance=float(state.cash_balance) if state.cash_balance is not None else None,

--- a/app/main.py
+++ b/app/main.py
@@ -143,6 +143,20 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     except Exception:
         logger.exception("orchestrator reaper failed — continuing startup")
 
+    # FX bootstrap (#502). Some non-SSE handlers (portfolio, copy-
+    # trading, budget/execution) read ``live_fx_rates`` synchronously
+    # during request handling and degrade or fail-closed if the
+    # table is empty. After PR C cut the cron from hourly to daily,
+    # a fresh DB or wiped table would have no rates available until
+    # the next 17:00 CET tick. Fire one inline Frankfurter fetch
+    # here so the operator's first request post-boot has rates
+    # ready. Runs BEFORE ``start_runtime()`` so APScheduler's
+    # catch-up cannot race the inline write on the same row.
+    try:
+        _bootstrap_fx_rates(pool)
+    except Exception:
+        logger.exception("fx bootstrap failed — continuing startup, daily cron will retry")
+
     # Start the in-process job runtime (#13). All SCHEDULED_JOBS are
     # registered with APScheduler; catch-up fires overdue jobs at boot.
     job_runtime: JobRuntime | None
@@ -201,6 +215,48 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     pool.close()
     logger.info("Connection pool closed.")
+
+
+def _bootstrap_fx_rates(pool: ConnectionPool[Any]) -> None:
+    """Populate ``live_fx_rates`` synchronously when the table is empty.
+
+    Per the visibility-driven live-prices spec
+    (docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md
+    PR C), the daily Frankfurter cron does not guarantee rates are
+    in the table at boot — a fresh DB, a wiped table, or a process
+    restart between ECB publishes would all leave readers seeing
+    no rows. Non-SSE handlers (``/portfolio``, ``/portfolio/copy-trading``,
+    ``budget``) read ``live_fx_rates`` synchronously and either
+    degrade or fail-closed if it is empty.
+
+    Strategy: count the table; if non-empty, no-op. If empty, call
+    ``fx_rates_refresh`` directly. Calling the actual job (rather
+    than duplicating its body) means the FX watermark + ``job_runs``
+    audit row advance the same way they would on a normal cron tick
+    — so APScheduler's boot catch-up sees the job as fresh and
+    does not fire a second back-to-back Frankfurter hit (Codex
+    round 2 finding 1 on PR for #502).
+
+    Runs BEFORE ``start_runtime()`` so the scheduler boot path
+    cannot race this call on the same row (spec v3 ordering pin).
+    """
+    from app.workers.scheduler import fx_rates_refresh
+
+    with pool.connection() as conn:
+        row = conn.execute("SELECT COUNT(*) FROM live_fx_rates").fetchone()
+        existing = int(row[0]) if row and row[0] is not None else 0
+        if existing > 0:
+            logger.info("fx bootstrap: %d existing rows, skipping inline fetch", existing)
+            return
+
+    logger.info("fx bootstrap: live_fx_rates is empty, running fx_rates_refresh inline")
+    try:
+        fx_rates_refresh()
+    except Exception:
+        logger.warning(
+            "fx bootstrap: fx_rates_refresh raised; daily cron will retry",
+            exc_info=True,
+        )
 
 
 async def _maybe_start_etoro_ws(pool: ConnectionPool[Any], bus: QuoteBus) -> EtoroWebSocketSubscriber | None:

--- a/app/services/budget.py
+++ b/app/services/budget.py
@@ -58,6 +58,21 @@ class BudgetConfigCorrupt(RuntimeError):
     """
 
 
+class FxRateUnavailable(RuntimeError):
+    """Raised when ``compute_budget_state`` cannot load the GBP→USD
+    rate it needs to convert the operator's estimated tax liability
+    into the USD basis the rest of the budget is denominated in.
+
+    Previously this path silently degraded ``estimated_tax_usd = 0``
+    on a missing rate, which is an execution-safety hole — the
+    execution guard's cash-availability check would treat all of
+    the operator's cash as deployable instead of reserving the tax
+    bill. Per the visibility-driven live-prices spec
+    (#502 PR C), this is now fail-closed: callers on the BUY/ADD
+    path must catch and translate into a guard block.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Dataclasses
 # ---------------------------------------------------------------------------
@@ -516,17 +531,26 @@ def compute_budget_state(conn: psycopg.Connection[Any]) -> BudgetState:
     else:
         estimated_tax_gbp = higher_est
 
-    # FX conversion
+    # FX conversion. A missing GBP→USD rate is a fail-closed
+    # condition on the BUY/ADD path: previously this defaulted to
+    # ``estimated_tax_usd = 0``, which would let an order through
+    # with no tax provision, treating all the operator's cash as
+    # deployable. The execution guard catches FxRateUnavailable and
+    # blocks. (#502 PR C, Codex round 2 finding 2 on PR #500.)
     gbp_usd_rate = _load_gbp_usd_rate(conn)
-    if gbp_usd_rate is not None:
-        estimated_tax_usd = estimated_tax_gbp * gbp_usd_rate
-    else:
+    if gbp_usd_rate is None:
         if estimated_tax_gbp > _ZERO:
-            logger.warning(
-                "No GBP->USD rate available; using 0 for tax_usd (tax_gbp=%s)",
-                estimated_tax_gbp,
+            raise FxRateUnavailable(
+                f"GBP→USD rate missing; cannot convert estimated_tax_gbp={estimated_tax_gbp} "
+                "for budget computation. Bootstrap rate fetch may have failed; check "
+                "live_fx_rates table and Frankfurter connectivity."
             )
+        # No GBP tax to convert → safe to use zero. Common in
+        # non-UK operator configs where the tax estimate is in USD
+        # already and gbp tax is structurally zero.
         estimated_tax_usd = _ZERO
+    else:
+        estimated_tax_usd = estimated_tax_gbp * gbp_usd_rate
 
     # Cash buffer reserve — intentionally % of total AUM (working_budget),
     # not % of cash_balance.  Using cash as the base would create a feedback

--- a/app/services/execution_guard.py
+++ b/app/services/execution_guard.py
@@ -50,7 +50,7 @@ import psycopg
 import psycopg.rows
 from psycopg.types.json import Jsonb
 
-from app.services.budget import BudgetConfigCorrupt, BudgetState, compute_budget_state
+from app.services.budget import BudgetConfigCorrupt, BudgetState, FxRateUnavailable, compute_budget_state
 from app.services.portfolio import _load_mirror_equity
 from app.services.runtime_config import RuntimeConfigCorrupt, get_runtime_config
 from app.services.transaction_cost import (
@@ -706,6 +706,7 @@ def evaluate_recommendation(
     cost_config: dict[str, Any] | None = None
     cost_config_corrupt: bool = False
     cost_model_row: dict[str, Any] | None = None
+    budget_fx_unavailable: bool = False
 
     if action in ("BUY", "ADD"):
         coverage = _load_coverage(conn, instrument_id)
@@ -732,6 +733,15 @@ def evaluate_recommendation(
             budget = compute_budget_state(conn)
         except BudgetConfigCorrupt:
             budget = None
+        except FxRateUnavailable:
+            # Fail closed on missing FX rate (#502 PR C). The budget
+            # check below treats this as a hard "block BUY/ADD"
+            # outcome — better than silently degrading
+            # ``estimated_tax_usd = 0`` and letting an order through
+            # with no tax provision. The guard surfaces a clear
+            # ``fx_rate_unavailable`` rule failure on the audit row.
+            budget = None
+            budget_fx_unavailable = True
         if budget is not None and budget.cash_balance is not None:
             cash_for_aum = float(budget.cash_balance)
         else:
@@ -787,7 +797,19 @@ def evaluate_recommendation(
         else:
             rule_results.append(_check_transaction_cost(quote, cost_model_row, cost_config))
 
-        if budget is None:
+        if budget_fx_unavailable:
+            rule_results.append(
+                RuleResult(
+                    rule="budget_available",
+                    passed=False,
+                    detail=(
+                        "FX rate (GBP→USD) unavailable; cannot compute estimated tax "
+                        "reserve in USD. Refusing BUY/ADD until live_fx_rates is "
+                        "populated (Frankfurter cron or lifespan bootstrap)."
+                    ),
+                )
+            )
+        elif budget is None:
             rule_results.append(
                 RuleResult(
                     rule="budget_available",

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -22,7 +22,7 @@ import psycopg
 import psycopg.rows
 from psycopg.types.json import Jsonb
 
-from app.services.budget import compute_budget_state
+from app.services.budget import FxRateUnavailable, compute_budget_state
 
 logger = logging.getLogger(__name__)
 
@@ -252,8 +252,25 @@ def _score_changes(
 
 
 def _budget_snapshot(conn: psycopg.Connection[Any]) -> dict[str, Any]:
-    """Current budget state via compute_budget_state."""
-    budget = compute_budget_state(conn)
+    """Current budget state via compute_budget_state.
+
+    Reporting paths must NOT hard-fail on a missing GBP→USD rate
+    (#502 PR C, Codex round 2 finding 2). Reports are read-only
+    snapshots — surfacing "FX unavailable" in-line is the right
+    degrade for a weekly/monthly report, vs the execution-guard
+    fail-closed posture which actually blocks orders.
+    """
+    try:
+        budget = compute_budget_state(conn)
+    except FxRateUnavailable:
+        logger.warning("_budget_snapshot: GBP→USD rate unavailable; emitting null tax/budget figures")
+        return {
+            "cash_balance": None,
+            "deployed_capital": None,
+            "estimated_tax_usd": None,
+            "available_for_deployment": None,
+            "fx_unavailable": True,
+        }
     return {
         "cash_balance": _dec(budget.cash_balance),
         "deployed_capital": _dec(budget.deployed_capital),
@@ -509,8 +526,19 @@ def _thesis_accuracy(
 
 
 def _tax_provision_snapshot(conn: psycopg.Connection[Any]) -> dict[str, Any]:
-    """Current tax provision from the budget service."""
-    budget = compute_budget_state(conn)
+    """Current tax provision from the budget service. Degrades to a
+    null snapshot when FX is unavailable rather than hard-failing
+    the monthly report (#502 PR C)."""
+    try:
+        budget = compute_budget_state(conn)
+    except FxRateUnavailable:
+        logger.warning("_tax_provision_snapshot: GBP→USD rate unavailable; emitting null")
+        return {
+            "estimated_tax_gbp": None,
+            "estimated_tax_usd": None,
+            "tax_year": None,
+            "fx_unavailable": True,
+        }
     return {
         "estimated_tax_gbp": _dec(budget.estimated_tax_gbp),
         "estimated_tax_usd": _dec(budget.estimated_tax_usd),

--- a/app/services/sync_orchestrator/freshness.py
+++ b/app/services/sync_orchestrator/freshness.py
@@ -233,7 +233,11 @@ def portfolio_sync_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
 
 
 def fx_rates_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
-    return _fresh_by_audit(conn, "fx_rates_refresh", timedelta(minutes=5))
+    # Cadence cut from 5 min → 24 h: ECB publishes reference rates
+    # once per working day at ~16:00 CET, so anything tighter than
+    # daily was burning >95% as 304 Not Modified hits. The lifespan
+    # bootstrap covers the empty-table case at boot (#502).
+    return _fresh_by_audit(conn, "fx_rates_refresh", timedelta(hours=24))
 
 
 def cost_models_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -24,7 +24,6 @@ import logging
 from collections.abc import Callable, Generator
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
-from decimal import Decimal
 from typing import Any, Literal
 
 import anthropic
@@ -2609,26 +2608,31 @@ def fundamentals_sync() -> None:
 
 
 def fx_rates_refresh() -> None:
-    """Refresh live FX rates and quotes.
+    """Refresh live FX rates from Frankfurter (ECB reference rates).
 
-    Two-source strategy:
+    Per the visibility-driven live-prices spec
+    (docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md):
 
-    1. **Frankfurter (primary FX):** Fetch ECB reference rates for all
-       supported display currencies. No API key, no coverage prerequisite.
-       Conditional ETag (#275): sends If-None-Match against the last
-       persisted ETag. 304 responses are no-ops (ECB only publishes
-       once per working day ~16:00 CET, so >95% of 5-min polls are 304).
+    - Cadence cut from hourly to once daily at 17:00 CET. ECB
+      publishes reference rates once per working day ~16:00 CET, so
+      hourly polling was burning >95% as 304 Not Modified hits.
+      Daily matches the actual publish cadence.
+    - Phase 2 (eToro batch quotes) **dropped**. The WS live-tick
+      pipeline (#274) writes to the ``quotes`` table directly for
+      every instrument an SSE stream subscribes to, making the
+      batch-quote path redundant for visibility-driven workflows.
 
-    2. **eToro quotes (secondary):** Batch-fetch quotes for covered Tier 1/2
-       instruments. Extracts eToro-specific conversion rates as a supplement,
-       and upserts quotes for hourly freshness. Skips gracefully if eToro
-       credentials are missing or the rates endpoint fails.
+    Conditional ETag (#275): sends If-None-Match against the last
+    persisted ETag. A 304 is a no-op upsert.
 
-    Runs hourly at :00 (invoked by orchestrator_high_frequency_sync).
+    The lifespan also runs an inline "bootstrap" call (see
+    ``app.main._bootstrap_fx_rates``) when the ``live_fx_rates``
+    table is empty at boot, so a fresh DB has rates available
+    before the first request lands without waiting for the
+    daily cron.
     """
     from app.providers.implementations.frankfurter import fetch_latest_rates_conditional
     from app.services.fx import upsert_live_fx_rate
-    from app.services.market_data import compute_spread_pct
     from app.services.runtime_config import SUPPORTED_CURRENCIES
 
     FX_SOURCE = "frankfurter.latest"
@@ -2636,7 +2640,6 @@ def fx_rates_refresh() -> None:
 
     with _tracked_job(JOB_FX_RATES_REFRESH) as tracker:
         fx_rows_written = 0
-        quotes_updated = 0
 
         # --- Phase 1: Frankfurter ECB rates (conditional GET) ---
         # Fetch USD → every other supported currency.
@@ -2695,120 +2698,11 @@ def fx_rates_refresh() -> None:
                     result.etag,
                 )
         except Exception:
-            logger.warning("fx_rates_refresh: Frankfurter fetch failed, continuing with eToro fallback", exc_info=True)
+            logger.warning("fx_rates_refresh: Frankfurter fetch failed", exc_info=True)
 
-        # --- Phase 2: eToro quotes + conversion rates (best-effort) ---
-        creds = _load_etoro_credentials("fx_rates_refresh")
-        if creds is not None:
-            api_key, user_key = creds
-            try:
-                with (
-                    EtoroMarketDataProvider(api_key=api_key, user_key=user_key, env=settings.etoro_env) as provider,
-                    psycopg.connect(settings.database_url) as conn,
-                ):
-                    rows = conn.execute(
-                        """
-                        SELECT i.instrument_id, i.symbol, i.currency
-                        FROM instruments i
-                        JOIN coverage c ON c.instrument_id = i.instrument_id
-                        WHERE i.is_tradable = TRUE
-                          AND c.coverage_tier IN (1, 2)
-                        ORDER BY i.symbol
-                        """
-                    ).fetchall()
+        tracker.row_count = fx_rows_written
 
-                    if rows:
-                        instrument_ids = [row[0] for row in rows]
-                        currency_map: dict[int, str | None] = {row[0]: row[2] for row in rows}
-
-                        quotes = provider.get_quotes(instrument_ids)
-
-                        # Extract eToro-specific conversion rates as a supplement.
-                        fx_pairs: dict[str, tuple[Decimal, datetime]] = {}
-                        for q in quotes:
-                            if q.conversion_rate is None:
-                                continue
-                            ccy = currency_map.get(q.instrument_id)
-                            if ccy is None or ccy == "USD":
-                                continue
-                            existing = fx_pairs.get(ccy)
-                            if existing is None or q.timestamp > existing[1]:
-                                fx_pairs[ccy] = (q.conversion_rate, q.timestamp)
-
-                        with conn.transaction():
-                            for ccy, (rate, ts) in fx_pairs.items():
-                                upsert_live_fx_rate(
-                                    conn,
-                                    from_currency=ccy,
-                                    to_currency="USD",
-                                    rate=rate,
-                                    quoted_at=ts,
-                                )
-                                fx_rows_written += 1
-                        conn.commit()
-
-                        # Upsert quotes for hourly freshness.
-                        max_spread_pct = Decimal("1.0")
-                        for q in quotes:
-                            try:
-                                spread_pct = compute_spread_pct(q.bid, q.ask)
-                                spread_flag = spread_pct is not None and spread_pct > max_spread_pct
-                                with conn.transaction():
-                                    conn.execute(
-                                        """
-                                        INSERT INTO quotes (
-                                            instrument_id, quoted_at, bid, ask, last,
-                                            spread_pct, spread_flag
-                                        )
-                                        VALUES (
-                                            %(instrument_id)s, %(quoted_at)s, %(bid)s, %(ask)s,
-                                            %(last)s, %(spread_pct)s, %(spread_flag)s
-                                        )
-                                        ON CONFLICT (instrument_id) DO UPDATE SET
-                                            quoted_at   = EXCLUDED.quoted_at,
-                                            bid         = EXCLUDED.bid,
-                                            ask         = EXCLUDED.ask,
-                                            last        = EXCLUDED.last,
-                                            spread_pct  = EXCLUDED.spread_pct,
-                                            spread_flag = EXCLUDED.spread_flag
-                                        """,
-                                        {
-                                            "instrument_id": q.instrument_id,
-                                            "quoted_at": q.timestamp,
-                                            "bid": q.bid,
-                                            "ask": q.ask,
-                                            "last": q.last,
-                                            "spread_pct": spread_pct,
-                                            "spread_flag": spread_flag,
-                                        },
-                                    )
-                                    quotes_updated += 1
-                            except Exception:
-                                logger.warning(
-                                    "fx_rates_refresh: failed to upsert quote for instrument %d",
-                                    q.instrument_id,
-                                    exc_info=True,
-                                )
-                        conn.commit()
-
-                        if quotes_updated == 0:
-                            logger.warning(
-                                "fx_rates_refresh: 0 quotes written for %d covered instruments"
-                                " — quote staleness will degrade mark-to-market valuations",
-                                len(instrument_ids),
-                            )
-                    else:
-                        logger.info("fx_rates_refresh: no covered instruments for eToro quotes")
-            except Exception:
-                logger.warning("fx_rates_refresh: eToro quote fetch failed", exc_info=True)
-
-        tracker.row_count = fx_rows_written + quotes_updated
-
-    logger.info(
-        "fx_rates_refresh complete: fx_pairs=%d quotes=%d",
-        fx_rows_written,
-        quotes_updated,
-    )
+    logger.info("fx_rates_refresh complete: fx_pairs=%d", fx_rows_written)
 
 
 def daily_tax_reconciliation() -> None:

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -533,8 +533,15 @@ class TestComputeBudgetState:
         assert state.available_for_deployment is None
         assert state.cash_buffer_reserve == Decimal("0")
 
-    def test_no_fx_rate_uses_zero_tax(self) -> None:
-        """When GBP->USD rate is None, tax_usd=0 and a warning is logged."""
+    def test_missing_gbp_usd_rate_fails_closed_when_tax_owed(self) -> None:
+        """When GBP→USD rate is missing AND there is a non-zero GBP
+        tax estimate, ``compute_budget_state`` raises FxRateUnavailable
+        rather than silently degrading ``tax_usd = 0``. Previously the
+        zero would have let an order through with no tax provision —
+        an execution-safety hole (Codex round 2 finding 2 on PR #500;
+        #502 PR C)."""
+        from app.services.budget import FxRateUnavailable
+
         conn, mirror_val = _budget_conn(gbp_usd_rate=None)
         with (
             unittest.mock.patch(
@@ -545,14 +552,35 @@ class TestComputeBudgetState:
                 "app.services.budget._load_mirror_equity",
                 return_value=mirror_val,
             ),
-            unittest.mock.patch("app.services.budget.logger") as mock_logger,
+            pytest.raises(FxRateUnavailable),
+        ):
+            compute_budget_state(conn)
+
+    def test_missing_gbp_usd_rate_when_zero_tax_owed_returns_zero(self) -> None:
+        """When GBP→USD rate is missing AND the GBP tax estimate is
+        already zero, the computation succeeds with ``tax_usd = 0``
+        — there is no figure to convert. Common in non-UK operator
+        configs."""
+        conn, mirror_val = _budget_conn(
+            gbp_usd_rate=None,
+            total_gains=Decimal("0"),
+            net_gain=Decimal("0"),
+        )
+        with (
+            unittest.mock.patch(
+                "app.services.budget._current_uk_tax_year",
+                return_value="2025/26",
+            ),
+            unittest.mock.patch(
+                "app.services.budget._load_mirror_equity",
+                return_value=mirror_val,
+            ),
         ):
             state = compute_budget_state(conn)
 
         assert state.gbp_usd_rate is None
+        assert state.estimated_tax_gbp == Decimal("0")
         assert state.estimated_tax_usd == Decimal("0")
-        assert state.estimated_tax_gbp > Decimal("0")
-        mock_logger.warning.assert_called_once()
 
     def test_negative_available_when_over_reserved(self) -> None:
         """When tax + buffer > cash, available is negative."""

--- a/tests/test_sync_orchestrator_freshness.py
+++ b/tests/test_sync_orchestrator_freshness.py
@@ -121,7 +121,7 @@ class TestSimpleAuditOnlyPredicates:
         [
             (universe_is_fresh, "nightly_universe_sync", timedelta(days=7)),
             (portfolio_sync_is_fresh, "daily_portfolio_sync", timedelta(minutes=5)),
-            (fx_rates_is_fresh, "fx_rates_refresh", timedelta(minutes=5)),
+            (fx_rates_is_fresh, "fx_rates_refresh", timedelta(hours=24)),
             (cost_models_is_fresh, "seed_cost_models", timedelta(hours=24)),
             (weekly_reports_is_fresh, "weekly_report", timedelta(days=7)),
             (monthly_reports_is_fresh, "monthly_report", timedelta(days=31)),
@@ -132,6 +132,26 @@ class TestSimpleAuditOnlyPredicates:
         conn = _mock_conn_with_row((now - window / 2, "success", None, (window / 2).total_seconds()))
         fresh, _ = predicate(conn)
         assert fresh is True
+
+
+class TestFxRatesIsFreshWindow:
+    """Pin the ``fx_rates_is_fresh`` window at 24h (#502 PR C). The
+    parametrized fresh-only assertion in the suite above passes any
+    test param matching the production constant, so a regression that
+    moves both back to 5 minutes would not be caught — these explicit
+    boundary tests fail loud if the cadence shifts."""
+
+    def test_fresh_at_twelve_hours_ago(self) -> None:
+        now = datetime.now(UTC)
+        conn = _mock_conn_with_row((now - timedelta(hours=12), "success", None, timedelta(hours=12).total_seconds()))
+        fresh, _ = fx_rates_is_fresh(conn)
+        assert fresh is True
+
+    def test_stale_at_twenty_five_hours_ago(self) -> None:
+        now = datetime.now(UTC)
+        conn = _mock_conn_with_row((now - timedelta(hours=25), "success", None, timedelta(hours=25).total_seconds()))
+        fresh, _ = fx_rates_is_fresh(conn)
+        assert fresh is False
 
 
 class TestCandlesIsFresh:


### PR DESCRIPTION
## What

PR C of the visibility-driven live-prices plan (spec at [docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md](docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md)).

- FX cron cadence cut from 5 min via the orchestrator high-frequency path to 24 h (ECB publishes once per working day; tighter was wasting Frankfurter calls).
- Phase 2 (eToro batch quotes) deleted — WS live-tick pipeline (#274) covers `quotes` for every visible instrument.
- Lifespan bootstrap calls `fx_rates_refresh()` directly when `live_fx_rates` is empty at boot, BEFORE `start_runtime()` so the boot path doesn't race APScheduler catch-up.
- `FxRateUnavailable` exception in `budget.py` — fail-closed on missing GBP→USD AND non-zero `tax_gbp`. Caught in execution_guard (block BUY/ADD), api/budget (503), reporting (null degrade with `fx_unavailable: True` flag).

## Why

Operator's settled-decision direction: scheduled jobs that run when nothing on screen needs them are wasteful. Daily matches the ECB publish cadence with the same operator outcome.

Closes the execution-safety hole where missing FX silently degraded `estimated_tax_usd = 0` — order would have been allowed through with no tax provision.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] Narrow tests pass: `test_budget.py` 31/31, `test_sync_orchestrator_freshness.py` (added boundary tests)
- [ ] Full backend pytest — running in CI (local Windows had flaky background-task output capture; trusting CI as source of truth)
- [ ] Live smoke (operator, after merge):
  - Boot fresh DB → log shows `fx bootstrap: live_fx_rates is empty, running fx_rates_refresh inline` followed by `fx_rates_refresh complete: fx_pairs=N`
  - Boot with non-empty table → log shows `fx bootstrap: N existing rows, skipping inline fetch`
  - `/system/status` shows `fx_rates_refresh` running daily, not every 5 min
  - With Frankfurter unreachable + empty table at boot, BUY/ADD on a UK operator blocks at the guard with `budget_available: FX rate (GBP→USD) unavailable`

## Codex review

Round 1 raised 3 findings, all fixed:
1. Bootstrap → catch-up double Frankfurter hit — fixed by calling `fx_rates_refresh()` directly so watermark + audit row advance.
2. Reporting paths bare-called `compute_budget_state`, would hard-fail on missing FX — fixed with try/except + null snapshot in `_budget_snapshot` + `_tax_provision_snapshot`.
3. Freshness test still pinned 5-min window — fixed param + added explicit fresh-at-12h / stale-at-25h boundary tests.