### PR TITLE
fix: include mirror underlyings in portfolio + dashboard live-tick stream

### DIFF
--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -111,6 +111,13 @@ class PortfolioResponse(BaseModel):
     mirror_equity: float = 0.0
     display_currency: str = "GBP"
     fx_rates_used: dict[str, dict[str, object]] = {}
+    # Union of every instrument_id rendered (or contributing to a
+    # rendered total) on the portfolio page: held positions plus the
+    # underlying instruments inside every active mirror. The frontend
+    # feeds this set to its page-level LiveQuoteProvider so that
+    # mirror equity / pnl figures update as the underlying ticks
+    # come in, not just held-position rows.
+    live_quote_instrument_ids: list[int] = []
 
 
 class NativeTradeItem(BaseModel):
@@ -514,6 +521,15 @@ def get_portfolio(
         pos_rows, raw_cash is not None, raw_mirror_equity, display_currency, rates_meta
     )
 
+    # Union of every instrument_id the page should subscribe to live
+    # ticks for: held position ids + underlying instrument ids inside
+    # every active mirror. Mirror rows render an aggregated equity,
+    # but their underlying tickers must still feed the live-tick
+    # stream so the displayed mirror_equity recomputes as ticks land.
+    held_ids = {p.instrument_id for p in positions}
+    mirror_underlying_ids = _load_mirror_underlying_instrument_ids(conn)
+    live_quote_instrument_ids = sorted(held_ids | set(mirror_underlying_ids))
+
     return PortfolioResponse(
         positions=positions,
         mirrors=mirrors,
@@ -523,7 +539,30 @@ def get_portfolio(
         mirror_equity=mirror_equity,
         display_currency=display_currency,
         fx_rates_used=fx_rates_used,
+        live_quote_instrument_ids=live_quote_instrument_ids,
     )
+
+
+def _load_mirror_underlying_instrument_ids(conn: psycopg.Connection[object]) -> list[int]:
+    """Distinct instrument ids open across every active mirror.
+
+    Used by ``get_portfolio`` to feed the page-level
+    ``LiveQuoteProvider`` with mirror underlyings so the operator
+    sees mirror equity recompute as the underlying tickers tick —
+    not only when they navigate into a copy-trader detail page.
+    Empty when no active mirror has any open positions.
+    """
+    sql = """
+        SELECT DISTINCT cmp.instrument_id
+        FROM copy_mirror_positions cmp
+        JOIN copy_mirrors m USING (mirror_id)
+        WHERE m.active
+          AND cmp.instrument_id IS NOT NULL
+        ORDER BY cmp.instrument_id
+    """
+    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+        cur.execute(sql)
+        return [int(row[0]) for row in cur.fetchall()]
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/mocks.ts
+++ b/frontend/src/api/mocks.ts
@@ -40,6 +40,7 @@ export async function fetchPortfolioMock(): Promise<PortfolioResponse> {
     mirror_equity: 0,
     display_currency: "USD",
     fx_rates_used: {},
+    live_quote_instrument_ids: [],
   };
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -360,6 +360,10 @@ export interface PortfolioResponse {
   mirror_equity: number;
   display_currency: string;
   fx_rates_used: Record<string, FxRateUsed>;
+  /** Held position ids ∪ active-mirror underlying ids. Drives the
+   *  page-level LiveQuoteProvider so mirror equity recomputes as
+   *  underlyings tick. */
+  live_quote_instrument_ids: number[];
 }
 
 // /portfolio/rolling-pnl — #315 Phase 2 rolling unrealised P&L

--- a/frontend/src/components/dashboard/PositionsTable.tsx
+++ b/frontend/src/components/dashboard/PositionsTable.tsx
@@ -1,10 +1,8 @@
-import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import type { PositionItem, PortfolioMirrorItem } from "@/api/types";
 import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
 import { formatMoney, formatNumber, formatPct, pnlPct } from "@/lib/format";
 import { EmptyState } from "@/components/states/EmptyState";
-import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
 import { LivePriceCell } from "@/components/quotes/LivePriceCell";
 
 /**
@@ -54,16 +52,13 @@ export function PositionsTable({
     return mvB - mvA;
   });
 
-  // Live quote ids for the visible position rows. Mirror rows render
-  // their own aggregated equity, not a per-instrument price, so they
-  // don't contribute ids here.
-  const liveQuoteIds = useMemo(
-    () => positions.map((p) => p.instrument_id),
-    [positions],
-  );
-
+  // The live-quote stream is owned by the parent page (Dashboard or
+  // Portfolio) so the instrument-id union — held positions + every
+  // active-mirror underlying — is computed once at the page level
+  // off ``PortfolioResponse.live_quote_instrument_ids``. Wrapping
+  // here would either duplicate the SSE stream or hard-fix the set
+  // to held positions only (regression for #501 mirror underlyings).
   return (
-    <LiveQuoteProvider instrumentIds={liveQuoteIds}>
     <div className="overflow-x-auto">
       <table className="w-full text-left text-sm">
         <thead className="text-xs uppercase text-slate-500">
@@ -88,7 +83,6 @@ export function PositionsTable({
         </tbody>
       </table>
     </div>
-    </LiveQuoteProvider>
   );
 }
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -14,6 +14,7 @@ import { PortfolioValueChart } from "@/components/dashboard/PortfolioValueChart"
 import { RollingPnlStrip } from "@/components/dashboard/RollingPnlStrip";
 import { SummaryCards } from "@/components/dashboard/SummaryCards";
 import { PositionsTable } from "@/components/dashboard/PositionsTable";
+import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
 import { RecentRecommendations } from "@/components/dashboard/RecentRecommendations";
 import { BootstrapProgress, isBootstrapping } from "@/components/dashboard/BootstrapProgress";
 import { WatchlistPanel } from "@/components/dashboard/WatchlistPanel";
@@ -134,10 +135,14 @@ export function DashboardPage() {
             {portfolio.loading ? (
               <SectionSkeleton rows={4} />
             ) : (
-              <PositionsTable
-                positions={portfolio.data?.positions ?? []}
-                mirrors={portfolio.data?.mirrors ?? []}
-              />
+              <LiveQuoteProvider
+                instrumentIds={portfolio.data?.live_quote_instrument_ids ?? []}
+              >
+                <PositionsTable
+                  positions={portfolio.data?.positions ?? []}
+                  mirrors={portfolio.data?.mirrors ?? []}
+                />
+              </LiveQuoteProvider>
             )}
           </Section>
         </>

--- a/frontend/src/pages/PortfolioPage.test.tsx
+++ b/frontend/src/pages/PortfolioPage.test.tsx
@@ -140,6 +140,7 @@ function portfolioWith(
     mirror_equity: mirrors.reduce((s, m) => s + m.mirror_equity, 0),
     display_currency: "GBP",
     fx_rates_used: {},
+    live_quote_instrument_ids: positions.map((p) => p.instrument_id),
   };
 }
 

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -73,15 +73,17 @@ export function PortfolioPage() {
   const focusedIdxRef = useRef(focusedIdx);
   const pageRowsRef = useRef<RowItem[]>([]);
 
-  // Instrument ids for every held position the page may render —
-  // fed to the page-level LiveQuoteProvider so a single SSE stream
-  // covers every visible row. Mirror rows render an avatar + total,
-  // not a per-instrument price, so they don't contribute ids here;
-  // their underlying instruments only matter on the copy-trading
-  // detail page.
+  // Held position ids + every active-mirror underlying id, fed to
+  // the page-level LiveQuoteProvider so a single SSE stream covers
+  // both held rows AND the underlyings inside copy-trader rows.
+  // Without the mirror underlyings, mirror_equity / unrealized_pnl
+  // figures rendered on the page would only update when the
+  // operator opens a copy-trader detail page. The backend computes
+  // the union in `_load_mirror_underlying_instrument_ids` and ships
+  // it on `PortfolioResponse.live_quote_instrument_ids`.
   const liveQuoteIds = useMemo(() => {
     if (portfolio.data === null) return [];
-    return portfolio.data.positions.map((p) => p.instrument_id);
+    return portfolio.data.live_quote_instrument_ids;
   }, [portfolio.data]);
 
   // Positions + mirrors merged, sorted by dollar value, filtered by

--- a/tests/test_api_portfolio.py
+++ b/tests/test_api_portfolio.py
@@ -117,12 +117,13 @@ def _mock_conn(cursor_results: list[list[dict[str, Any]]]) -> MagicMock:
 
 
 def _with_conn(cursor_results: list[list[dict[str, Any]]]) -> MagicMock:
-    # The endpoint runs four DB queries in order:
+    # The endpoint runs five DB queries in order:
     #   1. positions  2. cash  3. broker_positions  4. mirror_breakdowns
+    #   5. mirror underlying instrument_ids (#502 PR follow-up)
     # Existing callers supply [positions, cash] only — pad with empty
-    # broker_positions and mirror_breakdowns results.
+    # broker_positions, mirror_breakdowns, and mirror-underlying results.
     padded = list(cursor_results)
-    while len(padded) < 4:
+    while len(padded) < 5:
         padded.append([])
     conn = _mock_conn(padded)
 


### PR DESCRIPTION
## What

After #501 shipped the page-level ``LiveQuoteProvider``, the portfolio + dashboard pages were only subscribing to live ticks for **held position** ids. Underlying instruments inside copy-trader mirrors were excluded. Result: ``mirror_equity`` / ``unrealized_pnl`` figures only updated when the operator drilled into a copy-trader detail page, not on the portfolio / dashboard themselves.

Per-page hard-coded id sets was the wrong shape — backend now ships the union (held + every active-mirror underlying) on ``PortfolioResponse.live_quote_instrument_ids`` and both pages consume it identically.

## Why

Operator (paraphrased): "I have 5 individual stocks + 2 copy traders with multiple stocks inside each. Why do I only see 5 topics subscribed? I want the mirror underlyings streaming too."

## Changes

Backend:
- ``PortfolioResponse.live_quote_instrument_ids`` (held ∪ active-mirror underlyings).
- New ``_load_mirror_underlying_instrument_ids`` helper.
- Test fixture pad 4 → 5 cursors.

Frontend:
- ``DashboardPage`` wraps ``PositionsTable`` in ``LiveQuoteProvider`` using the new field.
- ``PortfolioPage`` switches its ``liveQuoteIds`` source to the new field.
- ``PositionsTable`` stops wrapping in its own provider — caller owns it. Avoids nested providers when mounted under the dashboard.
- Type + mock fixtures updated.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] Narrow backend tests (`test_api_portfolio.py` 28/28 pass after fixture bump)
- [x] `pnpm typecheck`
- [x] `pnpm test:unit` (406/406)
- [ ] Live smoke (operator, after merge):
  - Open `/dashboard` and `/portfolio` → ONE SSE stream per page; carries held ids + every mirror's underlying ids
  - Subscribe-log line at boot reflects the larger set when navigating to those pages
  - Mirror equity / unrealized_pnl rendered on those pages updates as the underlying tickers tick (no need to drill into the copy-trader page)