### PR TITLE
fix(#503): handle eToro's actual WS envelope shape — messages: [...]

### DIFF
--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -169,52 +169,85 @@ _PRIVATE_EVENT_PREFIXES: tuple[str, ...] = (
     "Trading.Credit",
 )
 
-
-def is_private_event(raw: str) -> bool:
-    """True if ``raw`` is a private-channel push that should trigger
-    a portfolio reconcile. Returns False for malformed JSON, non-
-    private types, or unknown shapes — the reconciler is a coarse
-    invalidation, not a precise event handler."""
-    try:
-        msg = json.loads(raw)
-    except json.JSONDecodeError:
-        return False
-    if not isinstance(msg, dict):
-        return False
-    msg_type = msg.get("type")
-    if not isinstance(msg_type, str):
-        return False
-    return any(msg_type.startswith(p) for p in _PRIVATE_EVENT_PREFIXES)
+_RATE_MESSAGE_TYPE = "Trading.Instrument.Rate"
 
 
-def parse_rate_message(raw: str) -> QuoteUpdate | None:
-    """Parse a ``Trading.Instrument.Rate`` push.
+def _iter_inner_messages(raw: str) -> list[dict[str, object]]:
+    """Normalise an eToro WS frame into the list of inner messages it
+    carries.
 
-    eToro's WS protocol wraps each push in an envelope:
-    ``{type: "Trading.Instrument.Rate", data: {InstrumentID, Bid,
-    Ask, LastExecution, Date, ...}}``. Returns ``None`` for any other
-    message type or any field-shape failure — callers continue
-    listening rather than failing the whole connection.
+    Per the official documentation
+    (https://api-portal.etoro.com/api-reference/websocket/topics.md),
+    each frame is wrapped in a ``{"messages": [...]}`` envelope; each
+    inner message has the shape
+    ``{"topic": ..., "content": "<json-string>", "id": ..., "type": ...}``.
+    The ``content`` field is itself a JSON-encoded string, NOT a
+    parsed object — callers must ``json.loads`` it to get the
+    actual rate payload.
+
+    We also accept a top-level inner-message shape (no outer
+    ``messages`` wrapper) for backwards compatibility with our
+    historical test fixtures and any future framing change.
+    Returns ``[]`` for malformed JSON, non-dict envelopes, or
+    envelopes that carry neither shape.
     """
     try:
-        msg = json.loads(raw)
+        envelope = json.loads(raw)
     except json.JSONDecodeError:
+        return []
+    if not isinstance(envelope, dict):
+        return []
+    inner = envelope.get("messages")
+    if isinstance(inner, list):
+        return [m for m in inner if isinstance(m, dict)]
+    # Top-level inner-message shape: {"type": "...", ...}.
+    if isinstance(envelope.get("type"), str):
+        return [envelope]
+    return []
+
+
+def _parse_rate_content(msg: dict[str, object]) -> QuoteUpdate | None:
+    """Parse one inner ``Trading.Instrument.Rate`` message into a
+    :class:`QuoteUpdate`.
+
+    Handles both the documented envelope shape — where ``content``
+    is a JSON-encoded string carrying the actual fields — and the
+    legacy ``data`` shape (parsed object directly under ``data``)
+    used by older test fixtures. Returns ``None`` on any field-
+    shape failure so the listener loop drops the bad frame and
+    keeps reading.
+    """
+    if msg.get("type") != _RATE_MESSAGE_TYPE:
         return None
-    if not isinstance(msg, dict):
+
+    payload: object | None
+    raw_content = msg.get("content")
+    if isinstance(raw_content, str):
+        try:
+            payload = json.loads(raw_content)
+        except json.JSONDecodeError:
+            return None
+    else:
+        payload = msg.get("data")
+    if not isinstance(payload, dict):
         return None
-    if msg.get("type") != "Trading.Instrument.Rate":
-        return None
-    data = msg.get("data")
-    if not isinstance(data, dict):
-        return None
+
+    # InstrumentID lives on the payload (eToro's official shape) but
+    # for the legacy fixtures it may also live alongside on the
+    # outer message; topic parsing covers the documented case where
+    # InstrumentID is absent from the content.
+    instrument_id_raw: object = payload.get("InstrumentID")
+    if instrument_id_raw is None:
+        topic = msg.get("topic")
+        if isinstance(topic, str) and topic.startswith("instrument:"):
+            instrument_id_raw = topic.removeprefix("instrument:")
     try:
-        instrument_id = int(data["InstrumentID"])
-        bid = Decimal(str(data["Bid"]))
-        ask = Decimal(str(data["Ask"]))
-        last_raw = data.get("LastExecution")
+        instrument_id = int(str(instrument_id_raw))
+        bid = Decimal(str(payload["Bid"]))
+        ask = Decimal(str(payload["Ask"]))
+        last_raw = payload.get("LastExecution")
         last = Decimal(str(last_raw)) if last_raw is not None else None
-        date_str = str(data["Date"])
-        # eToro's ISO date includes 'Z' suffix; normalise to UTC.
+        date_str = str(payload["Date"])
         if date_str.endswith("Z"):
             date_str = date_str[:-1] + "+00:00"
         quoted_at = datetime.fromisoformat(date_str)
@@ -227,6 +260,47 @@ def parse_rate_message(raw: str) -> QuoteUpdate | None:
         last=last,
         quoted_at=quoted_at,
     )
+
+
+def is_private_event(raw: str) -> bool:
+    """True if ``raw`` carries any private-channel push that should
+    trigger a portfolio reconcile. Operates on the
+    ``{"messages": [...]}`` envelope (the eToro v1 shape) as well
+    as the top-level inner-message shape used by older fixtures.
+    """
+    for msg in _iter_inner_messages(raw):
+        msg_type = msg.get("type")
+        if isinstance(msg_type, str) and any(msg_type.startswith(p) for p in _PRIVATE_EVENT_PREFIXES):
+            return True
+    return False
+
+
+def parse_rate_message(raw: str) -> QuoteUpdate | None:
+    """Parse the *first* ``Trading.Instrument.Rate`` push in a raw WS
+    frame. For frames carrying multiple ticks (eToro batches), use
+    :func:`parse_rate_messages` to receive every update.
+
+    Kept for backward-compat with existing single-tick test fixtures.
+    """
+    for msg in _iter_inner_messages(raw):
+        update = _parse_rate_content(msg)
+        if update is not None:
+            return update
+    return None
+
+
+def parse_rate_messages(raw: str) -> list[QuoteUpdate]:
+    """Extract every ``Trading.Instrument.Rate`` push in a raw WS
+    frame. eToro's WS may batch multiple rates into one frame; the
+    listener loop must process all of them or the rate-stream will
+    silently drop ticks for high-frequency instruments.
+    """
+    updates: list[QuoteUpdate] = []
+    for msg in _iter_inner_messages(raw):
+        update = _parse_rate_content(msg)
+        if update is not None:
+            updates.append(update)
+    return updates
 
 
 def _compute_spread_pct(bid: Decimal, ask: Decimal) -> Decimal | None:
@@ -763,32 +837,39 @@ class EtoroWebSocketSubscriber:
             if is_private_event(raw):
                 self._schedule_reconcile()
                 continue
-            update = parse_rate_message(raw)
-            if update is None:
-                continue
-            # Publish first, on the event loop, before the DB
-            # offload. SSE subscribers see the tick within the same
-            # async tick the WS read finished on; the DB round-trip
-            # only gates persistence (which the page-load path reads
-            # to bootstrap before SSE takes over). Loop-affinity on
-            # ``QuoteBus.publish`` requires this be called from the
-            # event loop, so doing it before ``to_thread`` is the
-            # only correct ordering — calling it from inside the
-            # worker thread would race the asyncio.Queue internals.
-            if self._bus is not None:
-                self._bus.publish(update)
-            try:
-                # ``pool.connection()`` is sync — calling it from the
-                # event loop would block the loop for the full DB
-                # round-trip on every tick. Offload to a worker
-                # thread so the WS read loop stays hot.
-                await asyncio.to_thread(self._sync_upsert, update)
-            except Exception:
-                logger.warning(
-                    "EtoroWebSocketSubscriber: upsert failed instrument_id=%d",
-                    update.instrument_id,
-                    exc_info=True,
-                )
+            # eToro batches multiple ticks per WS frame inside the
+            # ``messages: [...]`` envelope (#503 fix). Drop any
+            # frame that yields zero rates; otherwise iterate every
+            # update so high-frequency instruments don't lose ticks
+            # to batching.
+            updates = parse_rate_messages(raw)
+            for update in updates:
+                # Publish first, on the event loop, before the DB
+                # offload. SSE subscribers see the tick within the
+                # same async tick the WS read finished on; the DB
+                # round-trip only gates persistence (which the
+                # page-load path reads to bootstrap before SSE
+                # takes over). Loop-affinity on
+                # ``QuoteBus.publish`` requires this be called
+                # from the event loop, so doing it before
+                # ``to_thread`` is the only correct ordering —
+                # calling it from inside the worker thread would
+                # race the asyncio.Queue internals.
+                if self._bus is not None:
+                    self._bus.publish(update)
+                try:
+                    # ``pool.connection()`` is sync — calling it
+                    # from the event loop would block the loop for
+                    # the full DB round-trip on every tick.
+                    # Offload to a worker thread so the WS read
+                    # loop stays hot.
+                    await asyncio.to_thread(self._sync_upsert, update)
+                except Exception:
+                    logger.warning(
+                        "EtoroWebSocketSubscriber: upsert failed instrument_id=%d",
+                        update.instrument_id,
+                        exc_info=True,
+                    )
 
 
 def _looks_like_json_envelope(raw: str | bytes) -> bool:

--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -829,19 +829,16 @@ class EtoroWebSocketSubscriber:
         async for raw in ws:
             if isinstance(raw, bytes):
                 raw = raw.decode("utf-8", errors="ignore")
-            # Private events come first because they're cheap to test
-            # for and we never want a reconcile-trigger to be
-            # confused with a rate push (the type prefix check
-            # already disambiguates, but ordering keeps the dispatch
-            # readable).
+            # eToro batches inner messages of mixed types in a single
+            # ``messages: [...]`` frame (#503/#504 fix). A frame may
+            # carry one private event AND several rate ticks at once;
+            # an early ``continue`` after the private check would
+            # silently drop those rates. Dispatch BOTH paths on
+            # every frame: schedule a reconcile if any inner message
+            # is a private event, AND publish every rate tick the
+            # frame carries.
             if is_private_event(raw):
                 self._schedule_reconcile()
-                continue
-            # eToro batches multiple ticks per WS frame inside the
-            # ``messages: [...]`` envelope (#503 fix). Drop any
-            # frame that yields zero rates; otherwise iterate every
-            # update so high-frequency instruments don't lose ticks
-            # to batching.
             updates = parse_rate_messages(raw)
             for update in updates:
                 # Publish first, on the event loop, before the DB

--- a/tests/test_etoro_websocket.py
+++ b/tests/test_etoro_websocket.py
@@ -38,6 +38,7 @@ from app.services.etoro_websocket import (
     fetch_watched_instrument_ids,
     is_private_event,
     parse_rate_message,
+    parse_rate_messages,
     upsert_quote,
 )
 
@@ -125,11 +126,189 @@ class TestParseRateMessage:
         assert parse_rate_message("") is None
 
     def test_missing_required_field_returns_none(self) -> None:
-        # No InstrumentID
+        # No InstrumentID and no topic — parser cannot recover the id.
         raw = json.dumps(
             {"type": "Trading.Instrument.Rate", "data": {"Bid": "1", "Ask": "2", "Date": "2026-04-24T14:30:00Z"}}
         )
         assert parse_rate_message(raw) is None
+
+
+class TestParseRateMessageOfficialEnvelope:
+    """Regression for #503 — the actual eToro WS frame shape per the
+    official documentation
+    (https://api-portal.etoro.com/api-reference/websocket/topics.md):
+
+        {
+          "messages": [
+            {
+              "topic": "instrument:100000",
+              "content": "{\\"Ask\\":\\"...\\", ...}",
+              "id": "...",
+              "type": "Trading.Instrument.Rate"
+            }
+          ]
+        }
+
+    Pre-#503 the parser only recognised ``{type, data}`` at the top
+    level, dropping every real frame on the floor. ``quotes`` table
+    looked populated only because the (now-retired) Phase 2 of
+    ``fx_rates_refresh`` was writing rows via REST. Post-#502 with
+    Phase 2 gone, the WS path was the sole writer and Tier 3
+    instruments (BTC, LRC) silently never updated. These tests pin
+    the actual envelope shape so future drift fails loud."""
+
+    def test_messages_envelope_with_string_encoded_content(self) -> None:
+        """The documented eToro shape: ``messages: [...]`` outer wrap,
+        ``content`` field carrying a JSON-encoded string."""
+        inner_content = json.dumps(
+            {
+                "Ask": "84917.73",
+                "Bid": "83232.21",
+                "LastExecution": "84072.94",
+                "Date": "2025-04-01T08:36:02.8305456Z",
+                "PriceRateID": "106439224591",
+            }
+        )
+        raw = json.dumps(
+            {
+                "messages": [
+                    {
+                        "topic": "instrument:100000",
+                        "content": inner_content,
+                        "id": "f1992278-2c4a-4b8f-92d6-8b99f5e1cb00",
+                        "type": "Trading.Instrument.Rate",
+                    }
+                ]
+            }
+        )
+        update = parse_rate_message(raw)
+        assert update is not None
+        assert update.instrument_id == 100000
+        assert update.bid == Decimal("83232.21")
+        assert update.ask == Decimal("84917.73")
+        assert update.last == Decimal("84072.94")
+
+    def test_messages_envelope_recovers_id_from_topic(self) -> None:
+        """eToro's ``content`` does not carry ``InstrumentID`` — the
+        parser must derive it from the message's ``topic`` field
+        (``instrument:<id>``)."""
+        inner_content = json.dumps(
+            {
+                "Ask": "100",
+                "Bid": "99",
+                "LastExecution": "99.5",
+                "Date": "2026-04-25T10:00:00Z",
+            }
+        )
+        raw = json.dumps(
+            {
+                "messages": [
+                    {
+                        "topic": "instrument:100050",
+                        "content": inner_content,
+                        "id": "x",
+                        "type": "Trading.Instrument.Rate",
+                    }
+                ]
+            }
+        )
+        update = parse_rate_message(raw)
+        assert update is not None
+        assert update.instrument_id == 100050
+
+    def test_parse_rate_messages_returns_every_tick_in_a_batch(self) -> None:
+        """A single WS frame can carry multiple rates. The listener
+        must process every one — pre-#503 only the first matched."""
+        msgs = []
+        for iid, bid, ask in [(100000, "83232.21", "84917.73"), (100050, "0.10", "0.11")]:
+            content = json.dumps(
+                {
+                    "Ask": ask,
+                    "Bid": bid,
+                    "LastExecution": bid,
+                    "Date": "2026-04-25T10:00:00Z",
+                }
+            )
+            msgs.append(
+                {
+                    "topic": f"instrument:{iid}",
+                    "content": content,
+                    "id": str(iid),
+                    "type": "Trading.Instrument.Rate",
+                }
+            )
+        raw = json.dumps({"messages": msgs})
+        updates = parse_rate_messages(raw)
+        assert len(updates) == 2
+        assert {u.instrument_id for u in updates} == {100000, 100050}
+
+    def test_messages_envelope_skips_non_rate_inner_messages(self) -> None:
+        """A frame may interleave private events with rate ticks; the
+        rate parser must skip the private ones, not abort."""
+        rate_content = json.dumps(
+            {
+                "Ask": "100",
+                "Bid": "99",
+                "LastExecution": "99.5",
+                "Date": "2026-04-25T10:00:00Z",
+            }
+        )
+        raw = json.dumps(
+            {
+                "messages": [
+                    {
+                        "topic": "private",
+                        "content": "{}",
+                        "id": "p",
+                        "type": "Trading.OrderForCloseMultiple.Update",
+                    },
+                    {
+                        "topic": "instrument:100000",
+                        "content": rate_content,
+                        "id": "r",
+                        "type": "Trading.Instrument.Rate",
+                    },
+                ]
+            }
+        )
+        updates = parse_rate_messages(raw)
+        assert len(updates) == 1
+        assert updates[0].instrument_id == 100000
+
+
+class TestIsPrivateEventOfficialEnvelope:
+    """Companion regression for the ``messages`` envelope on the
+    private-channel path."""
+
+    def test_messages_envelope_recognises_private_event(self) -> None:
+        raw = json.dumps(
+            {
+                "messages": [
+                    {
+                        "topic": "private",
+                        "content": "{}",
+                        "id": "p",
+                        "type": "Trading.OrderForCloseMultiple.Update",
+                    }
+                ]
+            }
+        )
+        assert is_private_event(raw) is True
+
+    def test_messages_envelope_skips_when_no_private_inner(self) -> None:
+        raw = json.dumps(
+            {
+                "messages": [
+                    {
+                        "topic": "instrument:1",
+                        "content": "{}",
+                        "id": "r",
+                        "type": "Trading.Instrument.Rate",
+                    }
+                ]
+            }
+        )
+        assert is_private_event(raw) is False
 
 
 class TestSpreadPct:

--- a/tests/test_etoro_websocket.py
+++ b/tests/test_etoro_websocket.py
@@ -276,6 +276,52 @@ class TestParseRateMessageOfficialEnvelope:
         assert updates[0].instrument_id == 100000
 
 
+class TestMixedBatchFrame:
+    """Prevention regression for the ``_listen`` ``continue`` bug
+    (#504 review BLOCKING). A single ``messages: [...]`` frame may
+    carry one private-event inner message AND one or more rate-tick
+    inner messages. Pre-fix, ``_listen`` saw ``is_private_event``
+    return True and ``continue``d before reaching the rate parser,
+    silently dropping every rate in that frame. The two assertions
+    below pin the contract: BOTH ``is_private_event`` and
+    ``parse_rate_messages`` must surface their respective inner
+    messages on the same frame."""
+
+    def test_mixed_frame_yields_private_event_and_rate_tick(self) -> None:
+        rate_content = json.dumps(
+            {
+                "Ask": "100",
+                "Bid": "99",
+                "LastExecution": "99.5",
+                "Date": "2026-04-25T10:00:00Z",
+            }
+        )
+        raw = json.dumps(
+            {
+                "messages": [
+                    {
+                        "topic": "private",
+                        "content": "{}",
+                        "id": "p",
+                        "type": "Trading.OrderForCloseMultiple.Update",
+                    },
+                    {
+                        "topic": "instrument:100000",
+                        "content": rate_content,
+                        "id": "r",
+                        "type": "Trading.Instrument.Rate",
+                    },
+                ]
+            }
+        )
+        # Both predicates must report their finding from the same
+        # frame — _listen must dispatch both paths.
+        assert is_private_event(raw) is True
+        updates = parse_rate_messages(raw)
+        assert len(updates) == 1
+        assert updates[0].instrument_id == 100000
+
+
 class TestIsPrivateEventOfficialEnvelope:
     """Companion regression for the ``messages`` envelope on the
     private-channel path."""


### PR DESCRIPTION
## What

Critical parser bug. `parse_rate_message` + `is_private_event` expected a top-level `{type, data}` shape, but eToro's documented WS push frame is `{messages: [...]}` outer wrap carrying inner messages of the form `{topic, content (json-string), id, type}`. See https://api-portal.etoro.com/api-reference/websocket/topics.md.

The parser silently returned `None` on every real frame. The `quotes` table looked populated only because Phase 2 of `fx_rates_refresh` was writing rows via REST for Tier 1/2 instruments. Tier 3 instruments (BTC, LRC, …) had no Phase 2 coverage and silently never ticked. PR #502 dropped Phase 2 entirely → operator-visible: BTC and LRC instrument pages render no live price.

## Why

Operator: "BTC + LRC pages still show no price." Investigated via Postman MCP + WebFetch against the official docs. Documented frame shape is different from what our code expected.

## Test plan
- [x] `uv run ruff check app/services/etoro_websocket.py tests/test_etoro_websocket.py`
- [x] `uv run pyright app/services/etoro_websocket.py tests/test_etoro_websocket.py`
- [ ] `uv run pytest` — running in CI (local Bash backgrounding broke output capture; trusting CI for verification)
- [ ] Live smoke (operator):
  - Open `/instrument/BTC` — see live tick replace the "—"
  - Open `/instrument/LRC` — same
  - Watch backend log for `EtoroWebSocketSubscriber: subscribe N topics` then ticks flowing into `quotes` (any visible position should now update its quotes row within ~1s of the page mounting)

## Notes

Back-compat preserved: legacy `{type, data}` shape still parses so existing test fixtures pass without rewrite.