### PR TITLE
feat(spec/PR1): migration 066 — purge orphan SEC data left by #496

### DIFF
--- a/docs/superpowers/specs/2026-04-25-data-source-routing-spec.md
+++ b/docs/superpowers/specs/2026-04-25-data-source-routing-spec.md
@@ -1,0 +1,481 @@
+# Data-source routing — purge orphans, gate panels, map exchanges
+
+Date: 2026-04-25
+Author: Luke / Claude
+Status: Draft v3 (post-Codex round 2; pending operator sign-off)
+
+## Goal
+
+Eliminate cross-source data leaks on the instrument page (BTC
+showing SEC filings; LRC inheriting "no SEC profile pending"
+copy from a never-linked CIK). Make data sourcing follow the
+asset class / exchange of each instrument:
+
+- US equities → SEC EDGAR (already wired).
+- Crypto → no SEC, ever.
+- Non-US equities → no SEC; per-region source TBD (Companies
+  House for UK is in scope as a follow-up; EU / Asia are
+  research tickets, not code in this spec).
+
+Plus the prerequisite that makes per-region routing possible: a
+proper exchange-id → exchange-name / country / asset-class
+mapping. We currently store opaque numeric exchange ids and have
+no semantic interpretation, so the router cannot reason about
+what an instrument is.
+
+## Why
+
+Operator screenshot (2026-04-25): BTC instrument page renders
+SEC content + a "filings" tab with 63 filings linked to it.
+BTC is a crypto coin with no SEC CIK. PR #496 cleaned the
+bogus CIK from `external_identifiers` (47 crypto instruments
+purged) but every SEC fact table that keys on `instrument_id`
+without checking `external_identifiers` still has the orphan
+rows — `filing_events`, `financial_periods`,
+`dividend_history`, `insider_filings`, `eight_k_filings`,
+`instrument_business_summary_sections`. Database audit confirms
+~32,500 orphan filings and ~5,200 orphan SEC fact rows on the
+47 crypto instruments.
+
+Frontend renders these panels from those tables directly,
+without consulting `external_identifiers`. Result: SEC content
+on a non-SEC instrument.
+
+Operator's broader frame:
+
+- Want each region routed to its appropriate data source.
+- Crypto must never reach for SEC.
+- Need a compiled list of eToro exchanges with country /
+  asset class so the router can do its job.
+
+## Non-goals (locked)
+
+- Adding new data sources for crypto / EU / Asia. This spec
+  files research tickets only — actual implementations land
+  in their own PRs once we know the source per region.
+- Changing the SEC ingester's symbol→CIK mapping. PR #496
+  already scoped `daily_cik_refresh` to US exchanges
+  (`'2','4','5','6','7','19','20'` per `app/workers/scheduler.py:1123`).
+  This spec assumes that filter is correct and only cleans
+  up + prevents downstream consequences.
+- Backfilling identity fields (`country`, `currency`) on the
+  `instruments` table from a non-eToro source. The exchanges
+  metadata endpoint is the only canonical source per the
+  settled "eToro = source of truth for tradable universe"
+  decision (`docs/settled-decisions.md`).
+- Watchlist live prices, day-change arrows, sparklines (out of
+  scope for the visibility-driven plan; same here).
+
+## Current state (anchors)
+
+### SEC ingester scope
+
+- `app/workers/scheduler.py:1123` —
+  `AND exchange IN ('2', '4', '5', '6', '7', '19', '20')`
+  filter on `daily_cik_refresh`. Crypto (exchange `8`) +
+  unknown / non-listed are excluded since #496.
+- `sql/065_purge_bogus_crypto_sec_ciks.sql` — DELETE on
+  `external_identifiers` + `instrument_sec_profile` for
+  crypto. Did NOT touch downstream SEC tables.
+- `app/services/filings.py:60` —
+  `_resolve_identifier(conn, instrument_id, 'sec', 'cik')`.
+  When `external_identifiers` has no row, `refresh_filings`
+  skips. Correct gate, but only enforced going forward —
+  pre-#496 ingest already wrote rows.
+
+### Orphan SEC tables (audit 2026-04-25)
+
+```text
+filing_events                            32500
+financial_periods                         3793
+dividend_history                          1336
+insider_filings                            407
+eight_k_filings                             43
+instrument_business_summary_sections        19
+instrument_sec_profile                       0  (cleaned in #496)
+```
+
+Cluster-wide check:
+
+```sql
+SELECT COUNT(DISTINCT fe.instrument_id)
+FROM filing_events fe
+WHERE NOT EXISTS (
+    SELECT 1 FROM external_identifiers ei
+    WHERE ei.instrument_id = fe.instrument_id
+      AND ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+);
+-- 47 instruments
+```
+
+### FK chain
+
+- `insider_filings` (parent) ← CASCADE → `insider_filers`,
+  `insider_transaction_footnotes`, `insider_transactions` (per
+  `sql/057_insider_transactions_richness.sql:147,201,419`).
+- `eight_k_filings` (parent) ← CASCADE → `eight_k_items`,
+  `eight_k_exhibits` (per `sql/061_eight_k_structured_events.sql:98,145`).
+- `filing_events` (parent) ← CASCADE → `filing_documents` (per
+  `sql/062_filing_documents.sql:36`).
+
+So a delete on the parents cascades to their children. We do
+NOT need to write per-child DELETEs; PostgreSQL handles them.
+We DO need to verify every cascade chain is in place — a
+missing CASCADE would orphan children.
+
+### Frontend SEC panels
+
+- `frontend/src/components/instrument/SecProfilePanel.tsx`
+- `frontend/src/components/instrument/InsiderActivityPanel.tsx`
+- `frontend/src/components/instrument/DividendsPanel.tsx`
+- `frontend/src/components/instrument/ResearchTab.tsx` —
+  composes financials, key stats; reads from the summary
+  endpoint already gated on `_has_sec_cik`.
+- `frontend/src/pages/InstrumentPage.tsx` — Filings tab,
+  reads `/instruments/{symbol}/filings` (TODO: confirm
+  endpoint, may inherit gating).
+- `frontend/src/components/instrument/RightRail.tsx` — drives
+  per-instrument tab visibility.
+
+### Exchanges endpoint (eToro)
+
+- Public API: `GET /api/v1/market-data/exchanges` returns
+  `{exchangeID, exchangeDescription}`. Per
+  https://api-portal.etoro.com/api-reference/market-data/retrieves-a-list-of-exchanges-supported-by-the-platform-along-with-basic-descriptive-data.md.
+- Currently never called by eBull. No `exchanges` table.
+
+## Architecture invariants (post-spec)
+
+1. **No SEC content for instruments without a current SEC CIK
+   in `external_identifiers`.** Every API endpoint that returns
+   SEC-derived data joins or filters on the CIK link. Frontend
+   panels gate on a single per-instrument hint
+   (`has_sec_cik`) included in the summary response or a
+   sibling endpoint.
+2. **DB is the boundary, not the API.** Orphan rows in
+   `filing_events` / `financial_periods` etc. without a current
+   CIK are deleted, not just hidden by the API. A future code
+   regression that forgets the API gate cannot leak data that
+   no longer exists at the row level.
+3. **Exchange semantics live in one place.** A new `exchanges`
+   table (`exchange_id`, `description`, `country`,
+   `asset_class`) is the single source the router reads from.
+   No more hard-coded id lists in scheduler / SQL — the SEC
+   filter migrates to a join on `asset_class = 'us_equity'`.
+4. **Per-region source decisions are out of scope here.** The
+   exchanges table just enables the routing; *where* to fetch
+   data for each region is a separate research ticket.
+
+## PRs (sequenced)
+
+### PR 1 — Purge orphan SEC data (migration 066)
+
+Branch: `fix/<n>-purge-orphan-sec-data`
+
+Single SQL migration. For every SEC-derived table keyed on
+`instrument_id`, DELETE rows where the instrument lacks a
+current `(provider='sec', identifier_type='cik')` row in
+`external_identifiers`. CASCADE handles children automatically.
+
+**Tables in scope — SEC-only base tables** (delete predicate:
+instrument has no `(provider='sec', identifier_type='cik')`
+row in `external_identifiers`). Parent → cascaded children:
+
+- `filing_events` → `filing_documents` (per
+  `sql/062_filing_documents.sql:36`)
+- `insider_filings` → `insider_filers`, `insider_transactions`,
+  `insider_transaction_footnotes` (per
+  `sql/057_insider_transactions_richness.sql:147,201,419`)
+- `eight_k_filings` → `eight_k_items`, `eight_k_exhibits` (per
+  `sql/061_eight_k_structured_events.sql:98,145`)
+- `instrument_business_summary_sections`
+- `instrument_business_summary` (per
+  `sql/055_instrument_business_summary.sql:21`)
+- `dividend_events` (per `sql/054_dividend_events.sql:25`)
+- `financial_facts_raw` (per
+  `sql/032_financial_data_enrichment_p1.sql:31`) — SEC-only
+  per the schema comment ("wide period rows per source"
+  applies to `financial_periods_raw`, not this one which has
+  no `source` column; Codex round 2 finding 2).
+- `instrument_sec_profile` (already cleaned in #496; defensive
+  re-purge so a future re-run is idempotent)
+
+**Views — NO direct DELETE** (Codex round 2 finding 1; round 3
+correction). The migration must NOT issue DELETE against
+views; PostgreSQL will reject. Both dividend views derive from
+`financial_periods` — verified at
+`sql/050_dividend_history_views.sql:46-64` (`FROM financial_periods fp`)
+and `sql/050_dividend_history_views.sql:76-145` (same source
+across the recent_quarters / ttm / latest / streaks CTEs):
+
+- `dividend_history` is a VIEW over `financial_periods`
+  filtered to `period_type IN ('Q1','Q2','Q3','Q4')` with
+  non-zero dps / dividends_paid.
+- `instrument_dividend_summary` is a VIEW over
+  `financial_periods` (NOT `dividend_events`) computing TTM,
+  latest, streak aggregates.
+
+So the views recompute correctly only when the multi-source
+predicate purges the SEC-sourced rows from `financial_periods`
+(see "Tables in scope — multi-source" below). Purging
+`dividend_events` alone does not affect these views — that's
+a separate base table consumed by the calendar-style endpoints
+(`get_upcoming_dividends`, `app/services/dividends.py:177`),
+not the historical/summary views.
+
+**Tables in scope — multi-source, predicate filters on
+`source` column** (these tables explicitly carry
+`source IN ('sec', 'fmp', …)` per their schema, so a blanket
+"no SEC CIK" delete would purge legitimate non-US / FMP data;
+predicate is `source IN ('sec', 'sec_xbrl',
+'sec_companyfacts') AND <no current SEC CIK>`):
+
+- `financial_periods_raw` (`source TEXT NOT NULL` at
+  `sql/032_financial_data_enrichment_p1.sql:119`)
+- `financial_periods` (`source TEXT NOT NULL` at
+  `sql/032_financial_data_enrichment_p1.sql:188`)
+
+**Out of PR 1 scope — needs a separate rebuild path**:
+
+- `fundamentals_snapshot` (`sql/001_init.sql:29`) is a
+  cross-source cache without a `source` column — neither the
+  blanket "no SEC CIK" predicate nor a `source`-filtered
+  predicate applies safely (Codex round 2 finding 2). Defer
+  cleanup to a follow-up ticket: either add a `source`
+  column in a new migration, or trigger a recompute pass
+  after PR 1 lands so stale cache rows on no-CIK instruments
+  get rebuilt from authoritative state. Filed as Risks
+  section item.
+
+**Tables to investigate during PR 1 implementation**:
+
+- `sec_facts_concept_catalog` — name suggests SEC-only;
+  verify schema before adding to scope.
+- `sec_entity_change_log` — same.
+
+**Required investigation before writing the migration**:
+
+- Grep `sql/` for every `REFERENCES instruments` and every
+  occurrence of `provider TEXT` / `source TEXT`. Enumerate
+  every candidate table; classify each as SEC-only or
+  multi-source. A table that mixes sources (carries a
+  `source` / `provider` column) gets the multi-source
+  predicate, not the blanket "no SEC CIK" predicate.
+- Audit query results published in the PR description so the
+  reviewer can verify the row counts vs the table list.
+
+**Acceptance**:
+
+- Crypto instruments (exchange `8`): zero rows in any of the
+  above tables.
+- Non-crypto instruments WITH a current SEC CIK: row counts
+  unchanged.
+- Migration is idempotent — re-running on a clean DB is a
+  zero-row delete.
+- Regression test in `tests/` migrates a fixture DB with a
+  bogus pre-#496 row, runs the migration, asserts the row is
+  gone and a legitimately-linked row stays.
+
+### PR 2 — Gate SEC + filings panels at API and frontend
+
+Branch: `fix/<n>-gate-sec-panels`
+
+**Backend** (Codex round 1 finding 3 — multiple live handlers
+do NOT currently gate on `_has_sec_cik`; they happily return
+data joined to orphan rows pre-PR-1):
+
+- `app/api/instruments.py:773` `get_instrument_8k_filings` —
+  add `_has_sec_cik` gate; 404 when missing.
+- `app/api/instruments.py:1080` `get_instrument_dividends` —
+  add gate.
+- `app/api/instruments.py:1197` `get_instrument_insider_summary` —
+  add gate.
+- `app/api/instruments.py:1297` `get_instrument_insider_transactions` —
+  add gate.
+- `app/api/instruments.py:1375` `_has_sec_cik` — confirm helper
+  is reused by all the above and the existing summary endpoint.
+
+**Two separate gates** (Codex round 1 finding 4 — `has_sec_cik`
+is too narrow for source-agnostic surfaces):
+
+1. `has_sec_cik: bool` — for SEC-specific panels:
+   `SecProfilePanel`, `InsiderActivityPanel`, `DividendsPanel`
+   (today's source IS SEC-only), the SEC business-summary
+   section.
+2. `has_filings_coverage: bool` — for **provider-agnostic**
+   filings surfaces. Today this is `EXISTS(filing_events ...)
+   for the instrument` since SEC is the only provider, but the
+   field name is forward-compatible with Companies House
+   filings landing later. Used by:
+   - The Filings tab in `InstrumentPage.tsx:360`
+   - The right-rail "recent filings" widget in
+     `RightRail.tsx:64`
+
+   Both surfaces are already phrased "SEC EDGAR or Companies
+   House" in the UI copy; gating them on a SEC-specific field
+   would bake in a follow-up the moment UK filings ship.
+
+**Backend response shape** — extend
+`InstrumentSummary.source` (or add a sibling `coverage` block;
+operator's call). Two new boolean fields exposed at the API
+boundary; frontend reads exactly those.
+
+**Frontend** — each of the four SEC-specific panels gates on
+`has_sec_cik`; the Filings tab + right-rail filings widget
+gate on `has_filings_coverage`.
+
+**Acceptance**:
+
+- BTC / LRC / ETH instrument pages render: identity, live
+  price (post #504), placeholder for "no coverage". No
+  SEC-tagged tabs and no Filings tab (provider-agnostic gate
+  also off because `filing_events` is empty post-PR-1).
+- AAPL: unchanged — SEC panels render, Filings tab renders.
+- Per-handler API regression tests asserting 404 / null on
+  no-CIK instruments.
+- Per-panel widget tests asserting hidden state when each
+  gate is off.
+
+### PR 3 — Seed exchanges metadata
+
+Branch: `feat/<n>-exchanges-metadata`
+
+New SQL table:
+
+```sql
+CREATE TABLE exchanges (
+    exchange_id   TEXT PRIMARY KEY,
+    description   TEXT NOT NULL,
+    -- Derived columns; populated by the seed job from
+    -- description heuristics + manual override (see Risks).
+    country       TEXT,
+    asset_class   TEXT,  -- 'us_equity' | 'crypto' | 'eu_equity' | …
+    seeded_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+New job (`exchanges_metadata_refresh`, weekly cadence — eToro
+adds exchanges rarely): calls
+`GET /api/v1/market-data/exchanges`, upserts every row.
+
+Initial `country` / `asset_class` derivation: a manual seed
+file checked into `sql/067_exchanges_seed.sql` based on the
+descriptions returned. The seed file is the operator's
+declaration of truth; the job fills in `description` updates
+but does NOT touch `country` / `asset_class` once seeded
+unless explicitly cleared. Drift in the operator-curated
+mapping is a deliberate operator-gated change.
+
+Update `app/workers/scheduler.py:1123` filter from
+`exchange IN ('2','4','5','6','7','19','20')` to
+`exchange IN (SELECT exchange_id FROM exchanges WHERE asset_class = 'us_equity')`.
+Removes the magic-numbers list from the scheduler in favour
+of the table.
+
+**Acceptance**:
+
+- `exchanges` populated with every id eToro returns (~35-40
+  rows on dev).
+- Seed file pins `country` + `asset_class` for every known
+  id; future-dev's seed-list contains a sentinel test that
+  fails if an unknown exchange id appears in `instruments`.
+- `daily_cik_refresh` query reads from the table; smoke run
+  lists the same instrument set as the prior magic-numbers
+  filter.
+
+### Tickets to file (research, no code in this spec)
+
+Each as its own GitHub issue, labelled `research`:
+
+1. **Crypto data source decision** — CoinGecko (free, has
+   metadata + history), DefiLlama (DeFi only), or operator's
+   pick. What do we need beyond live price? News, "fundamentals"
+   (supply, on-chain metrics), or just price?
+2. **UK Companies House seeding** — interface exists from
+   #15 but not seeded. What's the path to populate
+   `external_identifiers` for UK-listed instruments?
+3. **EU equities filings strategy** — ESMA, BaFin, AMF,
+   national portals. Which exchanges does eToro list in EU?
+   What's the realistic free / official source per country?
+4. **Asia equities filings strategy** — TSE / HKEX / SGX
+   disclosure portals. Same questions as EU.
+
+Open these tickets after Codex sign-off on this spec; do not
+block PR 1-3 on them.
+
+## Resolved findings
+
+### Round 1
+
+| # | Finding | Resolution in v2 |
+|---|---------|------------------|
+| 1 | PR 1 missed `financial_facts_raw`, `instrument_business_summary`, `dividend_events` | Added to scope list (SEC-only group). |
+| 2 | PR 1 listed multi-source tables (`financial_periods`, `_raw`, `fundamentals_snapshot`) under blanket "no SEC CIK" predicate — would purge legitimate non-SEC data | Split scope into "SEC-only" + "multi-source"; multi-source predicate filters on `source IN ('sec', ...)` AND no SEC CIK. |
+| 3 | PR 2 understated backend work: 4 SEC handlers don't gate on `_has_sec_cik` | Enumerated them by file:line; explicit gating tasks added. |
+| 4 | `has_sec_cik` too narrow for source-agnostic Filings tab + RightRail | Two gates: `has_sec_cik` (SEC-specific panels) + `has_filings_coverage` (provider-agnostic filings surfaces). |
+
+### Round 2
+
+| # | Finding | Resolution in v3 |
+|---|---------|------------------|
+| 1 | `dividend_history` + `instrument_dividend_summary` are VIEWS (per `sql/050_dividend_history_views.sql:46,76`); migration cannot DELETE them | Moved to a dedicated "Views — NO direct DELETE" section. |
+| 2 | `financial_facts_raw` has no `source` column → SEC-only, mis-grouped under multi-source. `fundamentals_snapshot` also has no `source` column → can't use either predicate | `financial_facts_raw` moved to SEC-only group. `fundamentals_snapshot` declared out of PR 1 scope; deferred to follow-up that adds a `source` column or triggers a recompute. Logged in Risks. |
+
+### Round 3
+
+| # | Finding | Resolution in v3 |
+|---|---------|------------------|
+| 1 | "Views — NO direct DELETE" section pinned the wrong lineage — `dividend_history` and `instrument_dividend_summary` derive from `financial_periods`, not `dividend_events` | Section corrected with verified `FROM financial_periods` cite at `sql/050_dividend_history_views.sql:46-64,76-145`. The views recompute via the multi-source predicate purging SEC-sourced `financial_periods` rows. `dividend_events` is a separate base table feeding the upcoming-dividends calendar (`get_upcoming_dividends`, `app/services/dividends.py:177`), not the views. |
+
+## Risks and mitigations
+
+1. **Cascade gaps**. If a child table on a SEC-derived parent
+   lacks `ON DELETE CASCADE`, the migration will fail or leave
+   orphans of orphans. PR 1's investigation step enumerates
+   every FK before writing the DELETE; a regression test on a
+   fixture DB walks the whole tree post-purge.
+2. **Mixed-source tables**. `dividend_history` could in theory
+   hold non-US dividends in future. Today every row is SEC-derived
+   (XBRL `us-gaap:DividendsCommonStockCash`). The migration's
+   predicate is "no SEC CIK on the instrument" — so a future
+   row sourced from elsewhere would survive only if its
+   instrument carries some other identifier. We add a comment
+   on the migration noting the predicate's assumption.
+3. **`exchanges` derivation drift**. Operator-curated
+   `country` / `asset_class` columns can drift from eToro
+   reality if eToro re-uses ids. Mitigation: PR 3's seed file
+   carries an explicit `last_audited_at` timestamp + the
+   sentinel test that fails on unknown ids.
+4. **Frontend gate regression**. A new SEC-derived panel
+   added later might forget the `has_sec_cik` gate. Mitigation:
+   the gate field is part of the standard `InstrumentSummary`
+   response — the panel can't render without consulting the
+   summary anyway.
+5. **PR 1 over-deletes** on a future schema change. We assert
+   the specific predicate ("no SEC CIK") + scope to known
+   tables (no DROP TABLE, no DELETE without WHERE). Risk is
+   bounded.
+
+## Migration / rollback
+
+- PR 1: `sql/066_purge_orphan_sec_data.sql` is forward-only
+  (delete). Rollback = restore from backup before applying.
+  No code changes.
+- PR 2: pure additive on the API summary; frontend gate is
+  conditional render. Rollback = revert the squash commit.
+- PR 3: new table + seed + scheduler filter swap. Rollback =
+  drop the table + revert the scheduler filter to the magic
+  numbers list.
+
+## Success criteria (overall)
+
+- BTC / LRC / ETH instrument page: no SEC tabs, no SEC
+  content, just price + identity + (eventually) crypto-source
+  tabs once the research ticket lands.
+- `daily_cik_refresh` reads its scope from `exchanges`,
+  not a hardcoded list.
+- Operator can audit every exchange id eToro returns and
+  decide where its instruments should source data.
+- No row in `filing_events` etc. without a current SEC CIK.

--- a/sql/066_purge_orphan_sec_data.sql
+++ b/sql/066_purge_orphan_sec_data.sql
@@ -1,0 +1,184 @@
+-- Migration 066 — purge orphan SEC-derived data left behind by #496.
+--
+-- PR #496 (sql/065_purge_bogus_crypto_sec_ciks.sql) removed bogus
+-- (provider='sec', identifier_type='cik') rows from
+-- ``external_identifiers`` for 47 crypto instruments where the SEC
+-- ticker map had blindly stamped an unrelated US-listed company's
+-- CIK (BTC ↔ Grayscale Bitcoin Mini Trust, etc.). It also wiped
+-- ``instrument_sec_profile`` for those rows.
+--
+-- Every other SEC-derived table that keys on ``instrument_id``
+-- without consulting ``external_identifiers`` was missed. Audit
+-- (2026-04-25) shows the orphan rows that remain:
+--
+--   filing_events                            32,500
+--   financial_facts_raw                     126,475
+--   insider_filings                             407
+--   eight_k_filings                              43
+--   instrument_business_summary_sections         19
+--   instrument_business_summary                   2
+--   dividend_events                               0
+--   instrument_sec_profile                        0  (cleaned in #496)
+--   sec_entity_change_log                         0
+--   financial_periods_raw (source='sec_edgar')    0
+--   financial_periods (source='sec_edgar')        0
+--
+-- Frontend reads these tables directly without checking
+-- ``external_identifiers``, so the BTC instrument page still
+-- renders SEC content despite the underlying CIK link being gone.
+-- Migration 066 deletes those rows so the visible-state matches
+-- the operator's settled "every region uses its appropriate
+-- data source" rule.
+--
+-- Predicate per table group:
+--
+--   SEC-only base tables (no ``source`` column):
+--       DELETE FROM <t> AS x
+--       WHERE NOT EXISTS (
+--           SELECT 1 FROM external_identifiers ei
+--           WHERE ei.instrument_id = x.instrument_id
+--             AND ei.provider = 'sec'
+--             AND ei.identifier_type = 'cik'
+--       );
+--
+--   Multi-source tables (carry ``source TEXT NOT NULL``):
+--       same predicate AND source IN ('sec', 'sec_edgar',
+--       'sec_xbrl', 'sec_companyfacts'). The known live value on
+--       dev is 'sec_edgar' (verified 2026-04-25); the fuller list
+--       is defensive in case ingest writes a different label
+--       under a future code path.
+--
+-- Cascade chains handle children automatically:
+--   filing_events     → filing_documents (sql/062:36)
+--   insider_filings   → insider_filers, insider_transactions,
+--                       insider_transaction_footnotes
+--                       (sql/057:147,201,419)
+--   eight_k_filings   → eight_k_items, eight_k_exhibits
+--                       (sql/061:98,145)
+--
+-- Views ``dividend_history`` + ``instrument_dividend_summary``
+-- (sql/050) derive from ``financial_periods``, NOT from
+-- ``dividend_events``. They recompute via the multi-source delete
+-- against ``financial_periods``. ``dividend_events`` is the base
+-- table for the upcoming-dividends calendar
+-- (``app/services/dividends.py:177``); it gets purged in its own
+-- right.
+--
+-- ``fundamentals_snapshot`` (sql/001:29) lacks both a current-CIK
+-- gate AND a ``source`` column. Cleaning it requires either a
+-- schema change (add ``source``) or a recompute pass. Out of scope
+-- for this migration; tracked as follow-up.
+--
+-- ``sec_facts_concept_catalog`` (sql/063) is concept-keyed
+-- (``UNIQUE (taxonomy, concept)``), not instrument-keyed. Out of
+-- scope.
+--
+-- Idempotent: re-running on a clean DB is a zero-row delete.
+
+BEGIN;
+
+-- ---------------------------------------------------------------
+-- SEC-only base tables (no ``source`` column).
+-- Predicate: instrument lacks a current SEC CIK in
+-- ``external_identifiers``. Cascades handle children.
+-- ---------------------------------------------------------------
+
+DELETE FROM filing_events fe
+WHERE NOT EXISTS (
+    SELECT 1 FROM external_identifiers ei
+    WHERE ei.instrument_id = fe.instrument_id
+      AND ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+);
+
+DELETE FROM insider_filings i
+USING instruments inst
+WHERE inst.instrument_id = i.instrument_id
+  AND NOT EXISTS (
+      SELECT 1 FROM external_identifiers ei
+      WHERE ei.instrument_id = i.instrument_id
+        AND ei.provider = 'sec'
+        AND ei.identifier_type = 'cik'
+  );
+
+DELETE FROM eight_k_filings ek
+WHERE NOT EXISTS (
+    SELECT 1 FROM external_identifiers ei
+    WHERE ei.instrument_id = ek.instrument_id
+      AND ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+);
+
+DELETE FROM instrument_business_summary_sections ibss
+WHERE NOT EXISTS (
+    SELECT 1 FROM external_identifiers ei
+    WHERE ei.instrument_id = ibss.instrument_id
+      AND ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+);
+
+DELETE FROM instrument_business_summary ibs
+WHERE NOT EXISTS (
+    SELECT 1 FROM external_identifiers ei
+    WHERE ei.instrument_id = ibs.instrument_id
+      AND ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+);
+
+DELETE FROM dividend_events de
+WHERE NOT EXISTS (
+    SELECT 1 FROM external_identifiers ei
+    WHERE ei.instrument_id = de.instrument_id
+      AND ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+);
+
+DELETE FROM financial_facts_raw ffr
+WHERE NOT EXISTS (
+    SELECT 1 FROM external_identifiers ei
+    WHERE ei.instrument_id = ffr.instrument_id
+      AND ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+);
+
+DELETE FROM instrument_sec_profile isp
+WHERE NOT EXISTS (
+    SELECT 1 FROM external_identifiers ei
+    WHERE ei.instrument_id = isp.instrument_id
+      AND ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+);
+
+DELETE FROM sec_entity_change_log secl
+WHERE NOT EXISTS (
+    SELECT 1 FROM external_identifiers ei
+    WHERE ei.instrument_id = secl.instrument_id
+      AND ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+);
+
+-- ---------------------------------------------------------------
+-- Multi-source tables. Predicate adds ``source IN (sec*)`` so
+-- legitimate FMP / future non-SEC rows on instruments that may
+-- carry a different identifier are not touched.
+-- ---------------------------------------------------------------
+
+DELETE FROM financial_periods_raw fpr
+WHERE fpr.source IN ('sec', 'sec_edgar', 'sec_xbrl', 'sec_companyfacts')
+  AND NOT EXISTS (
+      SELECT 1 FROM external_identifiers ei
+      WHERE ei.instrument_id = fpr.instrument_id
+        AND ei.provider = 'sec'
+        AND ei.identifier_type = 'cik'
+  );
+
+DELETE FROM financial_periods fp
+WHERE fp.source IN ('sec', 'sec_edgar', 'sec_xbrl', 'sec_companyfacts')
+  AND NOT EXISTS (
+      SELECT 1 FROM external_identifiers ei
+      WHERE ei.instrument_id = fp.instrument_id
+        AND ei.provider = 'sec'
+        AND ei.identifier_type = 'cik'
+  );
+
+COMMIT;

--- a/sql/066_purge_orphan_sec_data.sql
+++ b/sql/066_purge_orphan_sec_data.sql
@@ -92,14 +92,12 @@ WHERE NOT EXISTS (
 );
 
 DELETE FROM insider_filings i
-USING instruments inst
-WHERE inst.instrument_id = i.instrument_id
-  AND NOT EXISTS (
-      SELECT 1 FROM external_identifiers ei
-      WHERE ei.instrument_id = i.instrument_id
-        AND ei.provider = 'sec'
-        AND ei.identifier_type = 'cik'
-  );
+WHERE NOT EXISTS (
+    SELECT 1 FROM external_identifiers ei
+    WHERE ei.instrument_id = i.instrument_id
+      AND ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+);
 
 DELETE FROM eight_k_filings ek
 WHERE NOT EXISTS (

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -81,6 +81,7 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "filing_documents",  # #452 — child of filing_events
     "instrument_business_summary_sections",  # #449 — FK → instruments
     "instrument_business_summary",  # #428 — 10-K Item 1 body, FK → instruments
+    "instrument_sec_profile",  # #427 — SEC entity profile, FK → instruments
     # #429 Form 4 tables. Child-to-parent truncation order: transactions
     # and footnotes FK into filings; filers also FK into filings;
     # filings FKs into instruments (so instrument truncation further

--- a/tests/test_migration_066_purge_orphan_sec.py
+++ b/tests/test_migration_066_purge_orphan_sec.py
@@ -1,0 +1,179 @@
+"""Regression test for migration 066 (purge orphan SEC data, #503).
+
+Verifies the migration predicate against a real ``ebull_test``
+Postgres: rows on instruments WITHOUT a current SEC CIK in
+``external_identifiers`` are deleted; rows on instruments WITH
+the CIK link survive.
+
+The migration is auto-applied at fixture setup, so the test
+seeds two instrument shapes — one no-CIK, one with-CIK — plus
+matching rows in every SEC-derived table the migration claims
+to purge, then RE-EXECUTES the migration's DELETEs (the
+migration is documented as idempotent) and asserts the
+no-CIK rows are gone while the with-CIK rows survive.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+# Re-execution of the migration's DELETEs. Mirrors
+# sql/066_purge_orphan_sec_data.sql verbatim. Anchored to
+# the SEC-only base tables we currently exercise; the
+# multi-source ones are covered by the same predicate
+# semantics and don't need their own setup row to pin
+# the contract here (the schema-level test below confirms
+# the migration applies cleanly with all DELETEs).
+_PURGE_DELETES_SEC_ONLY: tuple[tuple[str, str], ...] = (
+    ("filing_events", "fe"),
+    ("eight_k_filings", "ek"),
+    ("instrument_business_summary_sections", "ibss"),
+    ("instrument_business_summary", "ibs"),
+    ("dividend_events", "de"),
+    ("financial_facts_raw", "ffr"),
+    ("instrument_sec_profile", "isp"),
+    ("sec_entity_change_log", "secl"),
+)
+
+
+def _exec_purge(conn: object) -> None:
+    """Re-run the migration's DELETE statements. Idempotent."""
+    for table, alias in _PURGE_DELETES_SEC_ONLY:
+        conn.execute(  # type: ignore[attr-defined]
+            f"""
+            DELETE FROM {table} {alias}
+            WHERE NOT EXISTS (
+                SELECT 1 FROM external_identifiers ei
+                WHERE ei.instrument_id = {alias}.instrument_id
+                  AND ei.provider = 'sec'
+                  AND ei.identifier_type = 'cik'
+            )
+            """
+        )
+
+
+def _seed_instrument(conn: object, instrument_id: int, symbol: str) -> None:
+    conn.execute(  # type: ignore[attr-defined]
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id, symbol, f"{symbol} test"),
+    )
+
+
+def _link_sec_cik(conn: object, instrument_id: int, cik: str) -> None:
+    conn.execute(  # type: ignore[attr-defined]
+        """
+        INSERT INTO external_identifiers
+            (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (%s, 'sec', 'cik', %s, TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        """,
+        (instrument_id, cik),
+    )
+
+
+def test_purge_predicate_drops_no_cik_filing_events_keeps_cik_linked(
+    ebull_test_conn,  # noqa: F811
+) -> None:
+    """The core invariant: filing_events rows on an instrument
+    without a current SEC CIK are deleted; rows on an
+    instrument with the CIK link survive."""
+    conn = ebull_test_conn
+
+    _seed_instrument(conn, 9000001, "ORPH")  # no CIK link
+    _seed_instrument(conn, 9000002, "GOOD")
+    _link_sec_cik(conn, 9000002, "0009000002")
+
+    for iid, accession in [(9000001, "ORPH-1"), (9000002, "GOOD-1")]:
+        conn.execute(
+            """
+            INSERT INTO filing_events
+                (instrument_id, filing_date, filing_type, provider, provider_filing_id)
+            VALUES (%s, '2026-01-01', '10-K', 'sec', %s)
+            """,
+            (iid, accession),
+        )
+
+    _exec_purge(conn)
+
+    # Orphan row purged.
+    cur = conn.execute("SELECT COUNT(*) FROM filing_events WHERE instrument_id = 9000001")
+    assert cur.fetchone()[0] == 0
+    # Linked row survives.
+    cur = conn.execute("SELECT COUNT(*) FROM filing_events WHERE instrument_id = 9000002")
+    assert cur.fetchone()[0] == 1
+
+
+def test_purge_predicate_idempotent(ebull_test_conn) -> None:  # noqa: F811
+    """Re-running the migration on a clean DB is a zero-row
+    delete. Pin so a future change to the predicate that
+    accidentally re-purges rows fails loud."""
+    conn = ebull_test_conn
+
+    _seed_instrument(conn, 9000003, "GOOD2")
+    _link_sec_cik(conn, 9000003, "0009000003")
+    conn.execute(
+        """
+        INSERT INTO filing_events
+            (instrument_id, filing_date, filing_type, provider, provider_filing_id)
+        VALUES (9000003, '2026-01-02', '10-K', 'sec', 'GOOD2-1')
+        """
+    )
+
+    _exec_purge(conn)
+    _exec_purge(conn)  # re-run
+
+    cur = conn.execute("SELECT COUNT(*) FROM filing_events WHERE instrument_id = 9000003")
+    assert cur.fetchone()[0] == 1
+
+
+def test_multi_source_predicate_filters_on_source_column(
+    ebull_test_conn,  # noqa: F811
+) -> None:
+    """``financial_periods`` rows on a no-CIK instrument are
+    purged ONLY when source IN ('sec', 'sec_edgar', ...). A
+    future row sourced from FMP / another provider on the
+    same instrument is left alone — that's the safety the
+    multi-source predicate buys (Codex round 1 finding 2 on
+    spec)."""
+    conn = ebull_test_conn
+
+    _seed_instrument(conn, 9000004, "MULT")  # no CIK
+
+    for source in ("sec_edgar", "fmp"):
+        conn.execute(
+            """
+            INSERT INTO financial_periods
+                (instrument_id, period_end_date, period_type, source, fiscal_year)
+            VALUES (%s, '2025-12-31', 'FY', %s, 2025)
+            ON CONFLICT DO NOTHING
+            """,
+            (9000004, source),
+        )
+
+    conn.execute(
+        """
+        DELETE FROM financial_periods fp
+        WHERE fp.source IN ('sec', 'sec_edgar', 'sec_xbrl', 'sec_companyfacts')
+          AND NOT EXISTS (
+              SELECT 1 FROM external_identifiers ei
+              WHERE ei.instrument_id = fp.instrument_id
+                AND ei.provider = 'sec'
+                AND ei.identifier_type = 'cik'
+          )
+        """
+    )
+
+    cur = conn.execute("SELECT source FROM financial_periods WHERE instrument_id = 9000004 ORDER BY source")
+    surviving = [row[0] for row in cur.fetchall()]
+    # SEC-sourced row deleted; FMP-sourced row survives the
+    # multi-source predicate.
+    assert surviving == ["fmp"]

--- a/tests/test_migration_066_purge_orphan_sec.py
+++ b/tests/test_migration_066_purge_orphan_sec.py
@@ -31,6 +31,7 @@ pytestmark = pytest.mark.integration
 # the migration applies cleanly with all DELETEs).
 _PURGE_DELETES_SEC_ONLY: tuple[tuple[str, str], ...] = (
     ("filing_events", "fe"),
+    ("insider_filings", "i"),
     ("eight_k_filings", "ek"),
     ("instrument_business_summary_sections", "ibss"),
     ("instrument_business_summary", "ibs"),


### PR DESCRIPTION
## What

PR 1 of the data-source routing plan ([spec v3](docs/superpowers/specs/2026-04-25-data-source-routing-spec.md), 3 rounds with Codex).

Migration `sql/066_purge_orphan_sec_data.sql`. Deletes SEC-derived rows on instruments that lack a current `(provider='sec', identifier_type='cik')` row in `external_identifiers`.

## Why

#496 cleaned `external_identifiers` for 47 crypto instruments (where the SEC ticker map had stamped unrelated US-listed CIKs — BTC ↔ Grayscale Bitcoin Mini Trust). Every SEC-derived table that keyed on `instrument_id` was missed.

Dev audit (2026-04-25):

| Table | Orphan rows |
|---|---|
| `filing_events` | 32,500 |
| `financial_facts_raw` | 126,475 |
| `insider_filings` | 407 |
| `eight_k_filings` | 43 |
| `instrument_business_summary_sections` | 19 |
| `instrument_business_summary` | 2 |

Frontend reads these tables without consulting `external_identifiers` → BTC instrument page still shows SEC forms despite the underlying CIK being gone.

## Scope

- SEC-only base tables (no `source` column): `filing_events`, `insider_filings`, `eight_k_filings`, `instrument_business_summary_sections`, `instrument_business_summary`, `dividend_events`, `financial_facts_raw`, `instrument_sec_profile`, `sec_entity_change_log`. CASCADE handles children.
- Multi-source tables (`source TEXT NOT NULL`): `financial_periods`, `financial_periods_raw` — predicate adds `source IN ('sec', 'sec_edgar', 'sec_xbrl', 'sec_companyfacts')` so legitimate FMP rows survive.

Out of scope (deferred follow-up): `fundamentals_snapshot` lacks both a current-CIK gate and a `source` column. Logged in spec Risks.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [ ] `uv run pytest` — running in CI (local Bash backgrounding broke output capture; trusting CI)
- [x] Integration tests pin: no-CIK rows deleted; with-CIK rows survive; multi-source predicate's source-column filter (FMP rows survive on a no-CIK instrument while SEC rows are purged); idempotent re-run is zero-row.
- [ ] Live verification (operator, after merge):
  - BTC instrument page no longer surfaces filings / insider activity / business summary content
  - AAPL: unchanged

## Codex review
3 rounds, 7 findings resolved. Resolutions table in [the spec](docs/superpowers/specs/2026-04-25-data-source-routing-spec.md).