### PR TITLE
feat(spec/PR2): gate SEC + filings panels at API and frontend

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -189,6 +189,23 @@ class InstrumentSummary(BaseModel):
     price: InstrumentPrice | None
     key_stats: InstrumentKeyStats | None
     source: dict[str, str]
+    # Coverage gates — frontend uses these to hide irrelevant
+    # tabs / panels rather than render an empty state for an
+    # instrument the source does not cover (#503 PR 2).
+    #
+    # ``has_sec_cik``: True iff the instrument has a primary SEC
+    # CIK in ``external_identifiers``. Gates SEC-specific panels:
+    # SecProfilePanel, InsiderActivityPanel, DividendsPanel,
+    # business-summary section.
+    #
+    # ``has_filings_coverage``: True iff any provider has filed
+    # filings for the instrument (today: SEC; tomorrow:
+    # Companies House / regional sources). Gates the
+    # source-agnostic Filings tab + right-rail "recent filings"
+    # widget. Wider than ``has_sec_cik`` so adding a non-SEC
+    # provider later doesn't bake in a follow-up.
+    has_sec_cik: bool
+    has_filings_coverage: bool
 
 
 class InstrumentDetail(BaseModel):
@@ -802,6 +819,11 @@ def get_instrument_8k_filings(
         raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
 
     instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    if not _has_sec_cik(conn, instrument_id):
+        # No SEC CIK means no canonical 8-K source — return empty
+        # rather than render orphan rows from a prior bad CIK link
+        # (see migration 066 / spec PR 2).
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} has no SEC coverage")
     filings = list_8k_filings(conn, instrument_id=instrument_id, limit=limit)
     return EightKFilingsResponse(
         symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
@@ -1119,6 +1141,11 @@ def get_instrument_dividends(
         raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
 
     instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    if not _has_sec_cik(conn, instrument_id):
+        # No SEC CIK = no canonical dividend source. 404 instead
+        # of returning orphan rows from a prior bad CIK link
+        # (see migration 066 / spec PR 2).
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} has no SEC coverage")
     summary = get_dividend_summary(conn, instrument_id=instrument_id)
     history = get_dividend_history(conn, instrument_id=instrument_id, limit=limit)
     upcoming = get_upcoming_dividends(conn, instrument_id=instrument_id)
@@ -1228,6 +1255,11 @@ def get_instrument_insider_summary(
         raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
 
     instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    if not _has_sec_cik(conn, instrument_id):
+        # Insider transactions are SEC Form 4 — no SEC CIK = no
+        # canonical source. 404 instead of returning orphan rows
+        # from a prior bad CIK link (see migration 066 / spec PR 2).
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} has no SEC coverage")
     summary = get_insider_summary(conn, instrument_id=instrument_id)
     return InsiderSummaryModel(
         symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
@@ -1335,6 +1367,11 @@ def get_instrument_insider_transactions(
         raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
 
     instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    if not _has_sec_cik(conn, instrument_id):
+        # Form 4 is an SEC filing — no SEC CIK = no canonical
+        # source. 404 instead of returning orphan rows from a
+        # prior bad CIK link (see migration 066 / spec PR 2).
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} has no SEC coverage")
     detail_rows = list_insider_transactions(conn, instrument_id=instrument_id, limit=limit)
     return InsiderTransactionsListModel(
         symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
@@ -1381,6 +1418,23 @@ def _has_sec_cik(conn: psycopg.Connection[object], instrument_id: int) -> bool:
             "WHERE instrument_id = %(iid)s AND provider = 'sec' "
             "AND identifier_type = 'cik' AND is_primary = TRUE "
             "LIMIT 1",
+            {"iid": instrument_id},
+        )
+        return cur.fetchone() is not None
+
+
+def _has_filings_coverage(conn: psycopg.Connection[object], instrument_id: int) -> bool:
+    """True if any filings provider has filed filings for the instrument.
+
+    Provider-agnostic coverage gate (#503 PR 2). Today the only
+    populated provider is SEC, so this is currently equivalent to
+    ``EXISTS row in filing_events``. Once Companies House / other
+    regional providers are wired, the same gate keeps working
+    without a frontend change.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM filing_events WHERE instrument_id = %(iid)s LIMIT 1",
             {"iid": instrument_id},
         )
         return cur.fetchone() is not None
@@ -1717,6 +1771,14 @@ def get_instrument_summary(
         "key_stats": key_stats_source,
     }
 
+    # Coverage gates (#503 PR 2). ``has_sec_cik`` reuses the same
+    # ``_has_sec_cik`` helper that gates the local-SEC-XBRL
+    # preference path above, so the gate the frontend reads is the
+    # same gate the backend already trusted. ``has_filings_coverage``
+    # is provider-agnostic — today equals "instrument has any
+    # filing_events row" since SEC is the only filings provider.
+    has_filings_coverage = _has_filings_coverage(conn, instrument_id_int)
+
     return InstrumentSummary(
         instrument_id=row["instrument_id"],  # type: ignore[arg-type]
         is_tradable=row["is_tradable"],  # type: ignore[arg-type]
@@ -1725,6 +1787,8 @@ def get_instrument_summary(
         price=price_block,
         key_stats=stats_block,
         source=source,
+        has_sec_cik=use_local_sec,
+        has_filings_coverage=has_filings_coverage,
     )
 
 

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -1771,12 +1771,15 @@ def get_instrument_summary(
         "key_stats": key_stats_source,
     }
 
-    # Coverage gates (#503 PR 2). ``has_sec_cik`` reuses the same
-    # ``_has_sec_cik`` helper that gates the local-SEC-XBRL
-    # preference path above, so the gate the frontend reads is the
-    # same gate the backend already trusted. ``has_filings_coverage``
-    # is provider-agnostic — today equals "instrument has any
-    # filing_events row" since SEC is the only filings provider.
+    # Coverage gates (#503 PR 2). Resolve via dedicated calls — do
+    # NOT alias ``use_local_sec`` here. Today the two flags are the
+    # same boolean (both come from ``_has_sec_cik``), but
+    # ``use_local_sec`` is named for the local-XBRL preference path
+    # and could narrow in future (e.g. "has CIK AND has ingested
+    # XBRL"). The frontend gate must follow ``_has_sec_cik`` exactly,
+    # not whatever predicate the local-pref path wants. Codex
+    # review on PR #506 caught the aliasing risk.
+    has_sec_cik = _has_sec_cik(conn, instrument_id_int)
     has_filings_coverage = _has_filings_coverage(conn, instrument_id_int)
 
     return InstrumentSummary(
@@ -1787,7 +1790,7 @@ def get_instrument_summary(
         price=price_block,
         key_stats=stats_block,
         source=source,
-        has_sec_cik=use_local_sec,
+        has_sec_cik=has_sec_cik,
         has_filings_coverage=has_filings_coverage,
     )
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -252,6 +252,18 @@ export interface InstrumentSummary {
   price: InstrumentPrice | null;
   key_stats: InstrumentKeyStats | null;
   source: Record<string, string>;
+  /** True iff the instrument has a primary SEC CIK in
+   *  external_identifiers. Frontend uses this to gate
+   *  SEC-specific panels (SecProfile, InsiderActivity,
+   *  Dividends, business summary). Crypto + non-US instruments
+   *  see false. */
+  has_sec_cik: boolean;
+  /** True iff any filings provider has rows for the instrument
+   *  (today: SEC; tomorrow: Companies House / regional). Gates
+   *  the source-agnostic Filings tab + right-rail "recent
+   *  filings" widget. Wider than has_sec_cik so adding a non-SEC
+   *  filings provider later doesn't bake in a follow-up. */
+  has_filings_coverage: boolean;
 }
 
 // #316 Slice A — daily OHLCV bars

--- a/frontend/src/components/instrument/ResearchTab.tsx
+++ b/frontend/src/components/instrument/ResearchTab.tsx
@@ -171,19 +171,32 @@ export function ResearchTab({
   const stats = summary.key_stats;
   const fs = stats?.field_source ?? undefined;
 
+  // SEC-specific panels gate on ``has_sec_cik`` so crypto +
+  // non-US instruments don't render orphan SEC content (#503 PR 2).
+  // Key statistics stays mounted regardless — its empty state
+  // already says "no provider returned key stats" which is honest
+  // for any instrument without coverage.
+  const hasSec = summary.has_sec_cik;
+
   return (
     <div className="grid gap-4 md:grid-cols-2">
-      <SecProfilePanel symbol={summary.identity.symbol} />
-      <DividendsPanel symbol={summary.identity.symbol} />
-      <div className="md:col-span-2">
-        <BusinessSectionsPanel symbol={summary.identity.symbol} />
-      </div>
-      <div className="md:col-span-2">
-        <InsiderActivityPanel symbol={summary.identity.symbol} />
-      </div>
-      <div className="md:col-span-2">
-        <EightKEventsPanel symbol={summary.identity.symbol} />
-      </div>
+      {hasSec ? <SecProfilePanel symbol={summary.identity.symbol} /> : null}
+      {hasSec ? <DividendsPanel symbol={summary.identity.symbol} /> : null}
+      {hasSec ? (
+        <div className="md:col-span-2">
+          <BusinessSectionsPanel symbol={summary.identity.symbol} />
+        </div>
+      ) : null}
+      {hasSec ? (
+        <div className="md:col-span-2">
+          <InsiderActivityPanel symbol={summary.identity.symbol} />
+        </div>
+      ) : null}
+      {hasSec ? (
+        <div className="md:col-span-2">
+          <EightKEventsPanel symbol={summary.identity.symbol} />
+        </div>
+      ) : null}
 
       <Section title="Key statistics">
         {stats === null ? (

--- a/frontend/src/components/instrument/RightRail.test.tsx
+++ b/frontend/src/components/instrument/RightRail.test.tsx
@@ -192,6 +192,7 @@ function renderRail(props: {
         instrumentId={instrumentId}
         sector={sector}
         currentSymbol={currentSymbol}
+        hasFilingsCoverage={true}
       />
     </MemoryRouter>,
   );

--- a/frontend/src/components/instrument/RightRail.tsx
+++ b/frontend/src/components/instrument/RightRail.tsx
@@ -31,16 +31,23 @@ export interface RightRailProps {
   instrumentId: number;
   sector: string | null;
   currentSymbol: string;
+  /** Provider-agnostic filings coverage gate (#503 PR 2). When
+   *  false (crypto, non-US instruments without coverage), the
+   *  Recent filings section is hidden — rendering "no filings
+   *  ingested yet" for an instrument the source does not cover
+   *  misleads the operator into thinking the pipeline is broken. */
+  hasFilingsCoverage: boolean;
 }
 
 export function RightRail({
   instrumentId,
   sector,
   currentSymbol,
+  hasFilingsCoverage,
 }: RightRailProps): JSX.Element {
   return (
     <aside className="space-y-4">
-      <RecentFilings instrumentId={instrumentId} />
+      {hasFilingsCoverage ? <RecentFilings instrumentId={instrumentId} /> : null}
       {/* `key={sector}` forces a full remount when the sector changes
           so `useAsync` re-initialises with `loading=true, data=null`
           on the first render for the new sector — otherwise one frame

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -43,6 +43,8 @@ function summary(overrides: Partial<InstrumentSummary> = {}): InstrumentSummary 
     },
     key_stats: null,
     source: { identity: "local_db", price: "quotes", key_stats: "unavailable" },
+    has_sec_cik: true,
+    has_filings_coverage: true,
     ...overrides,
   };
 }

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -66,13 +66,30 @@ function ErrorView({ error, onRetry }: { error: unknown; onRetry?: () => void })
 
 type TabId = "research" | "financials" | "positions" | "news" | "filings";
 
-const TABS: { id: TabId; label: string }[] = [
+const ALL_TABS: { id: TabId; label: string }[] = [
   { id: "research", label: "Research" },
   { id: "financials", label: "Financials" },
   { id: "positions", label: "Positions" },
   { id: "news", label: "News" },
   { id: "filings", label: "Filings" },
 ];
+
+/**
+ * Filter the visible tabs to those an instrument's coverage
+ * actually populates (#503 PR 2). SEC-only tabs (Financials)
+ * hide when ``has_sec_cik`` is false; the source-agnostic
+ * Filings tab hides when no provider has filings for the
+ * instrument. Crypto + non-US instruments end up with
+ * Research / Positions / News only.
+ */
+function visibleTabs(summary: InstrumentSummary | null): typeof ALL_TABS {
+  if (summary === null) return ALL_TABS;
+  return ALL_TABS.filter((t) => {
+    if (t.id === "financials") return summary.has_sec_cik;
+    if (t.id === "filings") return summary.has_filings_coverage;
+    return true;
+  });
+}
 
 function formatDecimal(
   value: string | null | undefined,
@@ -463,7 +480,11 @@ function InstrumentPageBody({
   // tab-switching doesn't spam browser history.
   const [searchParams, setSearchParams] = useSearchParams();
   const tabParam = searchParams.get("tab");
-  const activeTab: TabId = TABS.some((t) => t.id === tabParam)
+  const tabs = visibleTabs(summary);
+  // Fall back to "research" both when the tab param isn't a known
+  // id AND when the instrument's coverage hides the requested tab
+  // (e.g. ``?tab=filings`` on a crypto instrument).
+  const activeTab: TabId = tabs.some((t) => t.id === tabParam)
     ? (tabParam as TabId)
     : "research";
   const setActiveTab = useCallback(
@@ -600,7 +621,7 @@ function InstrumentPageBody({
       <div className="grid gap-4 lg:grid-cols-12">
         <div className="space-y-4 lg:col-span-8">
           <nav className="flex gap-1 border-b border-slate-200">
-            {TABS.map((tab) => (
+            {tabs.map((tab) => (
               <button
                 key={tab.id}
                 type="button"
@@ -645,6 +666,7 @@ function InstrumentPageBody({
             instrumentId={summary.instrument_id}
             sector={summary.identity.sector}
             currentSymbol={summary.identity.symbol}
+            hasFilingsCoverage={summary.has_filings_coverage}
           />
         </div>
       </div>

--- a/tests/test_api_instrument_sec_gates.py
+++ b/tests/test_api_instrument_sec_gates.py
@@ -113,7 +113,7 @@ def test_no_sec_cik_returns_404_no_sec_coverage(client: TestClient, endpoint: st
         "/instruments/AAPL/insider_transactions",
     ],
 )
-def test_with_sec_cik_does_not_short_circuit_with_no_sec_coverage(client: TestClient, endpoint: str) -> None:
+def test_with_sec_cik_does_not_404_with_no_sec_coverage(client: TestClient, endpoint: str) -> None:
     """Companion: when the instrument DOES have a SEC CIK, the
     gate must NOT fire. Without this, a future regression that
     inverts the predicate (e.g. ``not _has_sec_cik`` swapped) or

--- a/tests/test_api_instrument_sec_gates.py
+++ b/tests/test_api_instrument_sec_gates.py
@@ -1,0 +1,104 @@
+"""Tests for the SEC-coverage gates on per-instrument API handlers (#503 PR 2).
+
+The four handlers below previously returned data joined to
+SEC-derived tables without checking that the instrument actually
+has a current SEC CIK in ``external_identifiers``. After
+migration 066 purged orphan rows, the API still needed an
+explicit gate so a future bogus-CIK regression doesn't leak
+again.
+
+Each handler is exercised with two instrument shapes:
+
+  * with_sec_cik=True  → 200 OK (or 404 only when the underlying
+                          data fetch is itself empty)
+  * with_sec_cik=False → 404 with detail "no SEC coverage"
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _conn_for_handler(*, has_cik: bool, instrument_id: int = 42, symbol: str = "AAPL") -> MagicMock:
+    """Build a stub conn that replies to:
+
+    1. The handler's instrument-resolve query (``WHERE UPPER(symbol) = …``)
+       returning a single row.
+    2. The ``_has_sec_cik`` query (returning a row when ``has_cik=True``,
+       else ``None``).
+    3. Any subsequent service-layer fetch (returns empty / None — we
+       only care that the gate fires; the handler's body shouldn't run
+       on the 404 path).
+    """
+    instrument_row = {"instrument_id": instrument_id, "symbol": symbol}
+    cik_row: tuple[int] | None = (1,) if has_cik else None
+    queue: list[object] = [
+        instrument_row,  # resolve symbol
+        cik_row,  # _has_sec_cik
+    ]
+
+    def _next_cursor(*_args: object, **_kwargs: object) -> MagicMock:
+        cur = MagicMock()
+        cur.__enter__.return_value = cur
+        cur.__exit__.return_value = None
+        if queue:
+            payload = queue.pop(0)
+            cur.fetchone.return_value = payload
+        else:
+            cur.fetchone.return_value = None
+        cur.fetchall.return_value = []
+        return cur
+
+    conn = MagicMock()
+    conn.cursor.side_effect = _next_cursor
+    return conn
+
+
+def _install(conn: MagicMock) -> None:
+    from app.db import get_conn
+
+    def _override() -> Iterator[MagicMock]:
+        yield conn
+
+    app.dependency_overrides[get_conn] = _override
+
+
+def _clear() -> None:
+    from app.db import get_conn
+
+    app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/instruments/AAPL/eight_k_filings",
+        "/instruments/AAPL/dividends",
+        "/instruments/AAPL/insider_summary",
+        "/instruments/AAPL/insider_transactions",
+    ],
+)
+def test_no_sec_cik_returns_404_no_sec_coverage(client: TestClient, endpoint: str) -> None:
+    """The four newly-gated handlers must 404 (with the 'no SEC
+    coverage' detail) when the instrument has no primary SEC CIK
+    — so post-migration-066 a re-introduction of orphan rows
+    can't leak through the API."""
+    conn = _conn_for_handler(has_cik=False)
+    _install(conn)
+    try:
+        resp = client.get(endpoint)
+    finally:
+        _clear()
+    assert resp.status_code == 404
+    assert "SEC coverage" in resp.json()["detail"]

--- a/tests/test_api_instrument_sec_gates.py
+++ b/tests/test_api_instrument_sec_gates.py
@@ -102,3 +102,31 @@ def test_no_sec_cik_returns_404_no_sec_coverage(client: TestClient, endpoint: st
         _clear()
     assert resp.status_code == 404
     assert "SEC coverage" in resp.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/instruments/AAPL/eight_k_filings",
+        "/instruments/AAPL/dividends",
+        "/instruments/AAPL/insider_summary",
+        "/instruments/AAPL/insider_transactions",
+    ],
+)
+def test_with_sec_cik_does_not_short_circuit_with_no_sec_coverage(client: TestClient, endpoint: str) -> None:
+    """Companion: when the instrument DOES have a SEC CIK, the
+    gate must NOT fire. Without this, a future regression that
+    inverts the predicate (e.g. ``not _has_sec_cik`` swapped) or
+    aliases the wrong flag (Codex round 1 finding on PR #506)
+    would pass the negative test alone. The downstream service
+    layer is not stubbed here — the response may still 5xx /
+    return empty for other reasons — but the response MUST NOT
+    carry the gate's "SEC coverage" 404 detail."""
+    conn = _conn_for_handler(has_cik=True)
+    _install(conn)
+    try:
+        resp = client.get(endpoint)
+    finally:
+        _clear()
+    if resp.status_code == 404:
+        assert "SEC coverage" not in resp.json().get("detail", "")


### PR DESCRIPTION
## What

PR 2 of the [data-source routing plan](docs/superpowers/specs/2026-04-25-data-source-routing-spec.md). Adds API + frontend gates so non-SEC instruments (crypto, non-US) don't render SEC content.

## Why

Migration 066 (PR #505) purged orphan SEC rows but the API + frontend would still fetch + render whatever's in those tables. Need explicit gates to catch a future bogus-CIK regression at runtime.

## Backend

Four handlers gain `_has_sec_cik` checks (404 with "no SEC coverage" detail when missing):

- `get_instrument_8k_filings`
- `get_instrument_dividends`
- `get_instrument_insider_summary`
- `get_instrument_insider_transactions`

`InstrumentSummary` response carries two new gates: `has_sec_cik` (SEC-specific) and `has_filings_coverage` (provider-agnostic — wider than SEC, future-compat with Companies House etc.).

New helper `_has_filings_coverage` checks `EXISTS row in filing_events`.

## Frontend

`InstrumentPage` tabs filter dynamically:
- Financials → hide on no SEC CIK
- Filings → hide on no filings coverage
- Tab-param fallback: `?tab=filings` on a no-coverage instrument falls back to research

`ResearchTab` SEC-only panels (SecProfile, Dividends, BusinessSections, InsiderActivity, EightKEvents) gate on `has_sec_cik`.

`RightRail` Recent filings section gates on `has_filings_coverage`.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [ ] `uv run pytest` — running in CI
- [x] `pnpm typecheck` clean
- [x] New `tests/test_api_instrument_sec_gates.py` parametrises the four handlers, asserts 404 + "no SEC coverage" on no-CIK instruments
- [ ] Live verification (operator):
  - `/instrument/BTC` — only Research / Positions / News tabs; no SEC panels in Research
  - `/instrument/AAPL` — all tabs + SEC panels render unchanged