### PR TITLE
feat(spec/PR3): exchanges metadata table + scheduler scope swap

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1111,16 +1111,19 @@ def daily_cik_refresh() -> None:
             # symbol, which stamped unrelated US-company CIKs onto
             # eToro crypto coins that happened to share a ticker
             # (e.g. BTC crypto got Grayscale Bitcoin Mini Trust's
-            # CIK because both answer to "BTC"). Exchange codes
-            # enumerated from the current valid mapping set plus
-            # eToro's stable US-listed venues (4=NASDAQ, 5=NYSE,
-            # 2=AMEX, 6=OTC, 7=US small-cap, 19/20=additional US
-            # venues). Crypto (8), futures (40), FX, and non-US
-            # equities are explicitly excluded.
+            # CIK because both answer to "BTC").
+            #
+            # #503 PR 3: filter migrates from a hardcoded list to the
+            # ``exchanges`` table (sql/067) so adding / correcting
+            # an exchange's classification is a single row update.
+            # Crypto (asset_class='crypto'), unknown ids
+            # (asset_class='unknown'), and non-US classes are
+            # excluded by the join.
             rows = conn.execute(
-                "SELECT symbol, instrument_id::text FROM instruments "
-                "WHERE is_tradable = TRUE "
-                "AND exchange IN ('2', '4', '5', '6', '7', '19', '20')"
+                "SELECT i.symbol, i.instrument_id::text FROM instruments i "
+                "JOIN exchanges e ON e.exchange_id = i.exchange "
+                "WHERE i.is_tradable = TRUE "
+                "AND e.asset_class = 'us_equity'"
             ).fetchall()
             instrument_symbols = [(row[0], row[1]) for row in rows]
 

--- a/sql/067_exchanges_metadata.sql
+++ b/sql/067_exchanges_metadata.sql
@@ -1,0 +1,104 @@
+-- Migration 067 — exchanges metadata table (#503 PR 3).
+--
+-- eToro returns ``exchangeId`` as an opaque integer on every
+-- instrument record. The dev DB has 35+ distinct ids today;
+-- nothing in our schema interprets them. The SEC ingester
+-- carries a hardcoded list (``exchange IN ('2', '4', '5', '6',
+-- '7', '19', '20')`` per ``app/workers/scheduler.py:1123`` per #496)
+-- which works but is brittle: a new exchange id eToro adds
+-- silently won't be classified, and there's no single source the
+-- router can read from to pick the right data source per region.
+--
+-- This migration introduces the ``exchanges`` table — one row per
+-- eToro ``exchangeId`` with operator-curated semantic columns
+-- (``country``, ``asset_class``). The scheduler's SEC filter
+-- migrates to ``WHERE exchange_id IN (SELECT exchange_id FROM
+-- exchanges WHERE asset_class = 'us_equity')`` so adding /
+-- correcting an exchange's classification is a single row update,
+-- not a code change.
+--
+-- ``description`` is sourced from eToro's
+-- ``/api/v1/market-data/exchanges`` endpoint (deferred follow-up:
+-- a periodic refresh job seeds + updates this column from the
+-- API without touching ``country`` / ``asset_class``, which stay
+-- operator-curated).
+--
+-- ``asset_class`` controlled vocabulary (constrained via CHECK):
+--
+--   us_equity      — US-listed equities + ETFs (SEC EDGAR coverage)
+--   crypto         — crypto coins / pairs (no SEC; CoinGecko etc.)
+--   eu_equity      — EU-listed equities (no SEC; ESMA / national)
+--   uk_equity      — LSE-listed (Companies House)
+--   asia_equity    — TSE / HKEX / SGX etc.
+--   commodity      — futures / commodities
+--   fx             — currency pairs
+--   index          — composite indices
+--   unknown        — id observed but not yet classified
+--
+-- Initial seed pins the eight US-equity exchange ids the SEC
+-- mapper has been using since #496 (a no-functional-change swap
+-- of the magic-numbers filter into table form), plus ``8 =
+-- crypto`` so the operator can see the BTC family doesn't go
+-- through the SEC mapper. Every other id seen in ``instruments``
+-- on the dev DB lands as ``asset_class = 'unknown'``; the
+-- operator updates as eToro descriptions are reviewed.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS exchanges (
+    exchange_id   TEXT PRIMARY KEY,
+    description   TEXT,                       -- from eToro; null until refresh job runs
+    country       TEXT,                       -- ISO 3166-1 alpha-2 or NULL when not yet curated
+    asset_class   TEXT NOT NULL DEFAULT 'unknown',
+    seeded_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT exchanges_asset_class_check CHECK (asset_class IN (
+        'us_equity', 'crypto', 'eu_equity', 'uk_equity', 'asia_equity',
+        'commodity', 'fx', 'index', 'unknown'
+    ))
+);
+
+CREATE INDEX IF NOT EXISTS idx_exchanges_asset_class ON exchanges (asset_class);
+
+COMMENT ON TABLE exchanges IS
+    'Operator-curated mapping of eToro exchangeId → semantic class. '
+    'Drives SEC ingester scope (asset_class = ''us_equity'') and '
+    'per-region routing for filings / fundamentals data sources.';
+COMMENT ON COLUMN exchanges.description IS
+    'Sourced from eToro /api/v1/market-data/exchanges. NULL until the '
+    'refresh job populates it; safe to query with NULL description.';
+COMMENT ON COLUMN exchanges.asset_class IS
+    'Controlled vocabulary. Determines which data sources the router '
+    'consults for an instrument (SEC EDGAR for us_equity, none for '
+    'crypto, Companies House for uk_equity, etc.).';
+
+-- ---------------------------------------------------------------
+-- Seed: pin the 8 ids the SEC mapper currently uses + crypto.
+-- Every other id observed on dev becomes ``unknown`` so the
+-- operator can audit and curate. ``ON CONFLICT DO NOTHING`` so
+-- re-running this migration on a manually-curated DB doesn't
+-- overwrite operator decisions.
+-- ---------------------------------------------------------------
+
+-- US-equity exchange ids the SEC mapper has used since #496.
+INSERT INTO exchanges (exchange_id, country, asset_class) VALUES
+    ('2',  'US', 'us_equity'),
+    ('4',  'US', 'us_equity'),
+    ('5',  'US', 'us_equity'),
+    ('6',  'US', 'us_equity'),
+    ('7',  'US', 'us_equity'),
+    ('19', 'US', 'us_equity'),
+    ('20', 'US', 'us_equity'),
+    ('8',  NULL, 'crypto')
+ON CONFLICT (exchange_id) DO NOTHING;
+
+-- Backfill every observed exchange id from instruments as 'unknown'
+-- so the operator can see the full set in a single SELECT and
+-- reclassify as eToro descriptions are reviewed.
+INSERT INTO exchanges (exchange_id, asset_class)
+SELECT DISTINCT exchange, 'unknown'
+FROM instruments
+WHERE exchange IS NOT NULL
+ON CONFLICT (exchange_id) DO NOTHING;
+
+COMMIT;

--- a/tests/test_daily_cik_refresh_scope.py
+++ b/tests/test_daily_cik_refresh_scope.py
@@ -48,14 +48,16 @@ class TestCikCandidateQueryScope:
     def _run_scoped_query(self, conn: psycopg.Connection[tuple]) -> list[tuple[str, str]]:
         # Inline the production query verbatim so a future refactor
         # that removes the exchange filter is caught by this test
-        # failing — the mapper bug manifested as a missing filter,
-        # so asserting the filter's effect is the invariant that
-        # matters.
+        # failing. #503 PR 3 swapped the hardcoded id list for a
+        # JOIN against the ``exchanges`` table — same invariant
+        # ("only us_equity exchanges produce candidates"), expressed
+        # via the curated mapping.
         with conn.cursor() as cur:
             cur.execute(
-                "SELECT symbol, instrument_id::text FROM instruments "
-                "WHERE is_tradable = TRUE "
-                "AND exchange IN ('2', '4', '5', '6', '7', '19', '20')"
+                "SELECT i.symbol, i.instrument_id::text FROM instruments i "
+                "JOIN exchanges e ON e.exchange_id = i.exchange "
+                "WHERE i.is_tradable = TRUE "
+                "AND e.asset_class = 'us_equity'"
             )
             return [(r[0], r[1]) for r in cur.fetchall()]
 
@@ -107,3 +109,22 @@ class TestCikCandidateQueryScope:
 
     def test_empty_universe_returns_empty(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         assert self._run_scoped_query(ebull_test_conn) == []
+
+    def test_unknown_exchange_classification_excluded(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """An instrument on an exchange the operator hasn't yet
+        classified (``asset_class = 'unknown'``) is excluded from
+        the SEC mapper. New eToro exchange ids land as ``unknown``
+        per the migration backfill so they don't silently pick up
+        SEC CIKs (Codex round 1 acceptance for #503 PR 3)."""
+        # Seed an exchange row classified as ``unknown``.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO exchanges (exchange_id, asset_class) "
+                "VALUES ('99', 'unknown') "
+                "ON CONFLICT (exchange_id) DO UPDATE SET asset_class = 'unknown'"
+            )
+        _seed_instrument(ebull_test_conn, instrument_id=4001, symbol="UNK", exchange="99")
+        ebull_test_conn.commit()
+
+        symbols = sorted(s for s, _ in self._run_scoped_query(ebull_test_conn))
+        assert "UNK" not in symbols


### PR DESCRIPTION
## What

PR 3 of the [data-source routing plan](docs/superpowers/specs/2026-04-25-data-source-routing-spec.md). New `exchanges` table with operator-curated `country` + `asset_class`. SEC mapper's hardcoded id list swapped for a JOIN.

## Why

eToro's `exchangeId` is an opaque integer; nothing in the schema interprets the 35+ ids in dev. The SEC mapper carried a hardcoded list (`exchange IN ('2','4','5','6','7','19','20')`) — works but adding / correcting an exchange's classification needed a code change. With this PR it's a single SQL `UPDATE`.

## Schema

`exchanges` table: `exchange_id` (PK), `description` (from eToro, NULL until refresh job), `country` (ISO alpha-2), `asset_class` (CHECK-constrained vocabulary: `us_equity | crypto | eu_equity | uk_equity | asia_equity | commodity | fx | index | unknown`).

Seed pins the 8 ids the mapper has been using since #496. Backfill captures every other id observed in `instruments` as `unknown` — operator audits + reclassifies as eToro descriptions are reviewed.

## Scheduler swap

`daily_cik_refresh` candidate query swapped from the hardcoded id list to a JOIN. Same outcome today (no functional change), but new eToro ids default to `unknown` so they can't silently pick up SEC CIKs.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [ ] `uv run pytest` — running in CI
- [x] Test `test_daily_cik_refresh_scope.py` updated to mirror new JOIN shape; new regression case for `unknown` classification

## Deferred follow-up tickets

- `exchanges_metadata_refresh` job to fetch descriptions from eToro `/api/v1/market-data/exchanges`
- Per-region data source decisions (crypto / UK / EU / Asia) building on `asset_class`