### PR TITLE
fix(#503-pr4): exchanges_metadata_refresh — accept live {exchangeInfo} wrapper

### DIFF
--- a/app/providers/implementations/etoro.py
+++ b/app/providers/implementations/etoro.py
@@ -420,25 +420,45 @@ def _normalise_rate(item: Mapping[str, object]) -> Quote | None:
     )
 
 
+_EXCHANGES_WRAPPER_KEY = "exchangeInfo"
+
+
 def _normalise_exchanges(raw: object) -> list[ExchangeRecord]:
     """Normalise an eToro exchanges API response into ExchangeRecord list.
 
-    Per the eToro portal docs, the endpoint returns a bare list of
-    ``{exchangeID, exchangeDescription}`` dicts. We pin that contract
-    here — anything else (including a wrapping object) raises
-    ``ValueError`` so a silent schema drift fails loudly during the
-    weekly cron run rather than parsing the wrong list and reporting
-    a harmless-looking empty feed (a Codex round 2 finding).
+    The live API wraps the list in ``{"exchangeInfo": [...]}`` even
+    though the portal docs show a bare list. We pin the actual shape
+    here (one explicit known wrapper key) — anything else raises
+    ``ValueError`` so a silent schema drift fails loudly rather than
+    parsing the wrong list and reporting a harmless-looking empty
+    feed (Codex round 2 finding from #503 PR 4).
+
+    The bare-list shape is also accepted as a fallback in case eToro
+    eventually aligns the live API with the portal docs; a future
+    silent flip from one to the other is a no-op for us.
     """
-    if not isinstance(raw, list):
+    items: list[object]
+    if isinstance(raw, dict):
+        wrapped = raw.get(_EXCHANGES_WRAPPER_KEY)
+        if not isinstance(wrapped, list):
+            raise ValueError(
+                f"eToro exchanges endpoint returned a dict, but key "
+                f"{_EXCHANGES_WRAPPER_KEY!r} is missing or not a list. "
+                f"Top-level keys: {list(raw.keys())}. If eToro renamed "
+                f"the wrapper key, update _normalise_exchanges."
+            )
+        items = wrapped
+    elif isinstance(raw, list):
+        items = list(raw)
+    else:
         raise ValueError(
-            f"Expected list from eToro exchanges endpoint (per portal docs), "
-            f"got {type(raw).__name__}. If eToro changed the response shape, "
-            f"update _normalise_exchanges to handle the new wrapper."
+            f"Expected dict (with {_EXCHANGES_WRAPPER_KEY!r} key) or list "
+            f"from eToro exchanges endpoint, got {type(raw).__name__}. "
+            f"If eToro changed the response shape, update _normalise_exchanges."
         )
 
     records: list[ExchangeRecord] = []
-    for item in raw:
+    for item in items:
         if not isinstance(item, dict):
             continue
         provider_id = item.get("exchangeID") or item.get("exchangeId")

--- a/tests/test_exchanges_service.py
+++ b/tests/test_exchanges_service.py
@@ -2,9 +2,9 @@
 
 Covers:
 
-* The eToro exchanges normaliser — pins the bare-list contract per
-  the eToro portal docs, raises ``ValueError`` on any dict-wrapped
-  payload (Codex round 2 finding), and skips malformed rows.
+* The eToro exchanges normaliser — pins the live ``{"exchangeInfo":
+  [...]}`` shape (the portal docs show a bare list, but the live
+  API returns the wrapper; both are accepted, anything else raises).
 * ``refresh_exchanges_metadata`` semantics:
 
   - inserts new rows with ``asset_class='unknown'``
@@ -51,15 +51,38 @@ class TestNormaliseExchanges:
         assert records[1].provider_id == "2"
         assert records[1].description == "XETRA"
 
-    def test_dict_shape_raises(self) -> None:
-        """A wrapped-dict response is NOT silently accepted — eToro's
-        portal documents the bare-list shape, and Codex round 2 flagged
-        that picking ``first list-typed value`` would silently mis-parse
-        a future ``{"meta": [...], "exchanges": [...]}`` payload as an
-        empty feed. Raise loudly so the weekly cron run surfaces the
-        schema drift."""
-        with pytest.raises(ValueError, match="Expected list"):
+    def test_live_wrapper_shape(self) -> None:
+        """The live eToro API returns ``{"exchangeInfo": [...]}`` even
+        though the portal docs show a bare list. Pin the actual
+        production shape — discovered when the cron crashed on first
+        run with ValueError after the round-2 tightening rejected
+        the wrapper. We accept the wrapper explicitly by known key
+        only; unknown wrappers still raise."""
+        raw = {
+            "exchangeInfo": [
+                {"exchangeID": 1, "exchangeDescription": "FX"},
+                {"exchangeID": 5, "exchangeDescription": "NASDAQ"},
+            ]
+        }
+        records = _normalise_exchanges(raw)
+        assert len(records) == 2
+        assert records[0].provider_id == "1"
+        assert records[0].description == "FX"
+        assert records[1].provider_id == "5"
+        assert records[1].description == "NASDAQ"
+
+    def test_unknown_wrapper_key_raises(self) -> None:
+        """A dict without the expected ``exchangeInfo`` key raises so
+        a silent schema drift fails the cron run loudly rather than
+        parsing the wrong list and reporting an empty feed."""
+        with pytest.raises(ValueError, match="exchangeInfo"):
             _normalise_exchanges({"exchanges": [{"exchangeID": 8}]})
+
+    def test_wrapper_value_not_list_raises(self) -> None:
+        """``exchangeInfo`` key present but value is not a list →
+        raise rather than silently iterating a non-iterable."""
+        with pytest.raises(ValueError, match="exchangeInfo"):
+            _normalise_exchanges({"exchangeInfo": {"unexpected": "shape"}})
 
     def test_camelCase_id_variant_accepted(self) -> None:
         """eToro is inconsistent — some endpoints use ``exchangeId``,
@@ -95,7 +118,7 @@ class TestNormaliseExchanges:
         assert _normalise_exchanges([]) == []
 
     def test_unknown_shape_raises(self) -> None:
-        with pytest.raises(ValueError, match="Expected list"):
+        with pytest.raises(ValueError, match="Expected dict"):
             _normalise_exchanges("not a payload")
 
 


### PR DESCRIPTION
## What

Hot-fix for the cron that crashed on first boot fire after #512 merged. eToro's live API returns `{"exchangeInfo": [...]}`, not the bare list the portal docs claim. `_normalise_exchanges` now accepts both shapes; unknown wrappers still raise loudly.

## Why

```
ERROR scheduled fire of 'exchanges_metadata_refresh' raised
ValueError: Expected list from eToro exchanges endpoint (per portal docs), got dict.
```

Codex round-2 finding on PR #512 told us to pin the bare-list shape per the portal docs. Correct against the docs, wrong against the live API.

## Test plan

- [x] Live probe against eToro demo creds confirmed `{exchangeInfo: [...]}` shape with 51 exchanges
- [x] Live `refresh_exchanges_metadata` run succeeded post-fix — descriptions populated on all 51 rows
- [x] `uv run pytest tests/test_exchanges_service.py` — 14 passed (3 new tests)
- [x] `uv run ruff check .` / `ruff format --check` / `pyright` — clean
- [x] `uv run pytest tests/smoke/test_app_boots.py` — green
- [x] Codex review — no findings

## Follow-up

Live descriptions revealed a separate misclassification in migration 067's manual seed: e.g. `exchange_id='7'` description "LSE" but seeded as `us_equity`; `exchange_id='6'` description "FRA" same. Files a tech-debt issue — out of scope for this hot-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)