### PR TITLE
fix(#515-pr0): include crypto/fx/commodity/index in T3 candle bootstrap

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -924,11 +924,45 @@ def nightly_universe_sync() -> None:
             tracker.row_count = row_count
 
 
+# Max T3 instruments to include in candle refresh for bootstrap
+# scoring. Prevents hitting API rate limits while giving enough T3
+# instruments price data to enable T3→T2 promotion via the
+# scoring/coverage pipeline.
 _T3_BOOTSTRAP_BATCH_SIZE = 200
-"""Max T3 instruments to include in candle refresh for bootstrap scoring.
 
-Prevents hitting API rate limits while giving enough T3 instruments price
-data to enable T3→T2 promotion via the scoring/coverage pipeline.
+# T3 candle bootstrap eligibility query.
+# Module-level constant so the test suite imports the same SQL the
+# scheduler executes — eliminates the drift risk Codex flagged on
+# PR 0 (#515): a copy-pasted test SQL could stay green after a
+# production regression. Tests import _T3_BOOTSTRAP_SELECT directly.
+#
+# Eligibility branches (post-#515 PR 0):
+#   1. Tradable + tier 3 + no candles + has fundamentals (original).
+#   2. OR tradable + tier 3 + no candles + non-fundamentals-bearing
+#      asset class (crypto / fx / commodity / index — those classes
+#      never get a fundamentals_snapshot row by design).
+# Instruments on exchanges with asset_class='unknown' stay gated;
+# operator curates the row first via the #503 PR 4 admin path.
+_T3_BOOTSTRAP_SELECT = """
+SELECT i.instrument_id, i.symbol
+FROM instruments i
+JOIN coverage c ON c.instrument_id = i.instrument_id
+LEFT JOIN exchanges e ON e.exchange_id = i.exchange
+WHERE i.is_tradable = TRUE
+  AND c.coverage_tier = 3
+  AND NOT EXISTS (
+      SELECT 1 FROM price_daily p
+      WHERE p.instrument_id = i.instrument_id
+  )
+  AND (
+      EXISTS (
+          SELECT 1 FROM fundamentals_snapshot f
+          WHERE f.instrument_id = i.instrument_id
+      )
+      OR e.asset_class IN ('crypto', 'fx', 'commodity', 'index')
+  )
+ORDER BY i.symbol, i.instrument_id
+LIMIT %(limit)s
 """
 
 
@@ -993,33 +1027,14 @@ def daily_candle_refresh() -> None:
                 """
             ).fetchall()
 
-            # T3: bootstrap batch — instruments with fundamentals but no
-            # candle data yet, capped to avoid API rate limit pressure.
-            # NOT EXISTS(price_daily) is intentional: once an instrument
-            # has any candle data it drops out of the bootstrap pool.
+            # T3: bootstrap batch (see _T3_BOOTSTRAP_SELECT comment).
             # refresh_market_data fetches ~400 candles per instrument in
             # a single API call, so a "partial" bootstrap still gives
             # enough data for momentum scoring.  If the API call fails
             # entirely, no rows are inserted and the instrument retries
             # next run.
             t3_rows = conn.execute(
-                """
-                SELECT i.instrument_id, i.symbol
-                FROM instruments i
-                JOIN coverage c ON c.instrument_id = i.instrument_id
-                WHERE i.is_tradable = TRUE
-                  AND c.coverage_tier = 3
-                  AND EXISTS (
-                      SELECT 1 FROM fundamentals_snapshot f
-                      WHERE f.instrument_id = i.instrument_id
-                  )
-                  AND NOT EXISTS (
-                      SELECT 1 FROM price_daily p
-                      WHERE p.instrument_id = i.instrument_id
-                  )
-                ORDER BY i.symbol, i.instrument_id
-                LIMIT %(limit)s
-                """,
+                _T3_BOOTSTRAP_SELECT,
                 {"limit": _T3_BOOTSTRAP_BATCH_SIZE},
             ).fetchall()
 

--- a/tests/test_daily_candle_refresh_crypto_eligibility.py
+++ b/tests/test_daily_candle_refresh_crypto_eligibility.py
@@ -1,0 +1,190 @@
+"""Integration test for the T3 candle-bootstrap eligibility query
+fix in #515 PR 0. Crypto / FX / commodity / index instruments are
+tier-3 + no candles + no fundamentals (by design — those classes
+have no fundamentals_snapshot rows). Before this PR the bootstrap
+required EXISTS fundamentals_snapshot, locking every crypto coin
+out of the candle pipeline forever — operator-visible symptom: BTC
+and LRC instrument pages rendered "no price data".
+
+These tests pin the fixed contract: a non-fundamentals-bearing
+asset_class qualifies via the OR branch even without fundamentals,
+while a us_equity instrument without fundamentals stays gated
+(preserves the original heuristic — "only bother if we'll score
+it" — for fundamentals-bearing classes).
+
+Imports the production SELECT directly so a future refactor that
+changes the SQL is caught by these tests failing — no inline copy
+that could drift (Codex round 1 finding).
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.workers.scheduler import _T3_BOOTSTRAP_BATCH_SIZE, _T3_BOOTSTRAP_SELECT
+
+pytestmark = pytest.mark.integration
+
+
+_QUERY_PARAMS = {"limit": _T3_BOOTSTRAP_BATCH_SIZE}
+
+
+def _seed_exchange(
+    conn: psycopg.Connection[tuple],
+    *,
+    exchange_id: str,
+    asset_class: str,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO exchanges (exchange_id, asset_class)
+            VALUES (%s, %s)
+            ON CONFLICT (exchange_id) DO UPDATE SET
+                asset_class = EXCLUDED.asset_class
+            """,
+            (exchange_id, asset_class),
+        )
+
+
+def _seed_instrument_t3_no_candles(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    symbol: str,
+    exchange: str,
+) -> None:
+    """Tier 3, tradable, no candles, no fundamentals — the exact
+    shape a fresh non-fundamentals-bearing instrument lands in."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable)
+            VALUES (%s, %s, %s, %s, TRUE)
+            """,
+            (instrument_id, symbol, f"Test {symbol}", exchange),
+        )
+        cur.execute(
+            """
+            INSERT INTO coverage (instrument_id, coverage_tier, filings_status)
+            VALUES (%s, 3, 'analysable')
+            """,
+            (instrument_id,),
+        )
+
+
+def _cleanup_exchange(conn: psycopg.Connection[tuple], exchange_ids: list[str]) -> None:
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM exchanges WHERE exchange_id = ANY(%s)", (exchange_ids,))
+    conn.commit()
+
+
+def test_crypto_instrument_qualifies_without_fundamentals(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The PR 0 contract: a crypto instrument at tier 3 with no
+    fundamentals row appears in the T3 bootstrap. Before this fix
+    BTC / LRC / ETH stayed permanently outside the candle ingest."""
+    _seed_exchange(ebull_test_conn, exchange_id="test_crypto", asset_class="crypto")
+    _seed_instrument_t3_no_candles(
+        ebull_test_conn,
+        instrument_id=950100,
+        symbol="TESTBTC",
+        exchange="test_crypto",
+    )
+    ebull_test_conn.commit()
+
+    try:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(_T3_BOOTSTRAP_SELECT, _QUERY_PARAMS)
+            symbols = sorted(r[1] for r in cur.fetchall())
+        assert "TESTBTC" in symbols
+    finally:
+        _cleanup_exchange(ebull_test_conn, ["test_crypto"])
+
+
+@pytest.mark.parametrize("asset_class", ["fx", "commodity", "index"])
+def test_other_non_fundamentals_classes_qualify(
+    ebull_test_conn: psycopg.Connection[tuple],
+    asset_class: str,
+) -> None:
+    """Same OR branch covers fx / commodity / index — none of these
+    asset classes carry fundamentals rows by design."""
+    exchange_id = f"test_{asset_class}"
+    _seed_exchange(ebull_test_conn, exchange_id=exchange_id, asset_class=asset_class)
+    symbol = f"T{asset_class.upper()[:3]}"
+    _seed_instrument_t3_no_candles(
+        ebull_test_conn,
+        instrument_id=950200,
+        symbol=symbol,
+        exchange=exchange_id,
+    )
+    ebull_test_conn.commit()
+
+    try:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(_T3_BOOTSTRAP_SELECT, _QUERY_PARAMS)
+            symbols = sorted(r[1] for r in cur.fetchall())
+        assert symbol in symbols
+    finally:
+        _cleanup_exchange(ebull_test_conn, [exchange_id])
+
+
+def test_us_equity_without_fundamentals_still_gated(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Preserves original behaviour for fundamentals-bearing classes:
+    a us_equity instrument at tier 3 with NO fundamentals_snapshot
+    is still excluded (the heuristic 'only bother if we'll score
+    it'). The OR branch only widens for non-fundamentals-bearing
+    classes; us_equity stays on the original gate."""
+    _seed_exchange(ebull_test_conn, exchange_id="test_us_pr0", asset_class="us_equity")
+    _seed_instrument_t3_no_candles(
+        ebull_test_conn,
+        instrument_id=950300,
+        symbol="TESTUSEQ",
+        exchange="test_us_pr0",
+    )
+    ebull_test_conn.commit()
+
+    try:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(_T3_BOOTSTRAP_SELECT, _QUERY_PARAMS)
+            symbols = sorted(r[1] for r in cur.fetchall())
+        assert "TESTUSEQ" not in symbols
+    finally:
+        _cleanup_exchange(ebull_test_conn, ["test_us_pr0"])
+
+
+def test_crypto_with_existing_candles_excluded(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Crypto with candle history already drops out of the
+    bootstrap (the NOT EXISTS price_daily clause is unaffected by
+    the new OR branch). Pins that the bootstrap doesn't re-fetch
+    instruments that already have data."""
+    _seed_exchange(ebull_test_conn, exchange_id="test_crypto_done", asset_class="crypto")
+    _seed_instrument_t3_no_candles(
+        ebull_test_conn,
+        instrument_id=950400,
+        symbol="TESTDONE",
+        exchange="test_crypto_done",
+    )
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO price_daily (instrument_id, price_date, open, high, low, close, volume)
+            VALUES (%s, '2026-04-25', 1, 2, 0.5, 1.5, 100)
+            """,
+            (950400,),
+        )
+    ebull_test_conn.commit()
+
+    try:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(_T3_BOOTSTRAP_SELECT, _QUERY_PARAMS)
+            symbols = sorted(r[1] for r in cur.fetchall())
+        assert "TESTDONE" not in symbols
+    finally:
+        _cleanup_exchange(ebull_test_conn, ["test_crypto_done"])

--- a/tests/test_daily_candle_refresh_crypto_eligibility.py
+++ b/tests/test_daily_candle_refresh_crypto_eligibility.py
@@ -74,8 +74,22 @@ def _seed_instrument_t3_no_candles(
         )
 
 
-def _cleanup_exchange(conn: psycopg.Connection[tuple], exchange_ids: list[str]) -> None:
+def _cleanup(
+    conn: psycopg.Connection[tuple],
+    *,
+    exchange_ids: list[str],
+    instrument_ids: list[int],
+) -> None:
+    """Drop the seeded fixture rows. Coverage cascades from
+    instruments; price_daily does not always cascade (depends on
+    constraint shape) so it's deleted explicitly. Both arguments
+    are required so a parametrized test that reuses an instrument
+    id across cases (Codex review on PR #524) cannot leave a stale
+    row that PK-collides on the next run."""
     with conn.cursor() as cur:
+        cur.execute("DELETE FROM price_daily WHERE instrument_id = ANY(%s)", (instrument_ids,))
+        cur.execute("DELETE FROM coverage WHERE instrument_id = ANY(%s)", (instrument_ids,))
+        cur.execute("DELETE FROM instruments WHERE instrument_id = ANY(%s)", (instrument_ids,))
         cur.execute("DELETE FROM exchanges WHERE exchange_id = ANY(%s)", (exchange_ids,))
     conn.commit()
 
@@ -101,7 +115,19 @@ def test_crypto_instrument_qualifies_without_fundamentals(
             symbols = sorted(r[1] for r in cur.fetchall())
         assert "TESTBTC" in symbols
     finally:
-        _cleanup_exchange(ebull_test_conn, ["test_crypto"])
+        _cleanup(
+            ebull_test_conn,
+            exchange_ids=["test_crypto"],
+            instrument_ids=[950100],
+        )
+
+
+# Distinct instrument_id per parametrized case — function-scoped
+# `ebull_test_conn` truncates between cases, but if a future
+# refactor moves the fixture to class scope the parametrized cases
+# would collide on a single id. Belt-and-braces (Codex round 1
+# review on PR #524).
+_PARAMETRIZED_INSTRUMENT_IDS = {"fx": 950201, "commodity": 950202, "index": 950203}
 
 
 @pytest.mark.parametrize("asset_class", ["fx", "commodity", "index"])
@@ -112,11 +138,13 @@ def test_other_non_fundamentals_classes_qualify(
     """Same OR branch covers fx / commodity / index — none of these
     asset classes carry fundamentals rows by design."""
     exchange_id = f"test_{asset_class}"
-    _seed_exchange(ebull_test_conn, exchange_id=exchange_id, asset_class=asset_class)
+    instrument_id = _PARAMETRIZED_INSTRUMENT_IDS[asset_class]
     symbol = f"T{asset_class.upper()[:3]}"
+
+    _seed_exchange(ebull_test_conn, exchange_id=exchange_id, asset_class=asset_class)
     _seed_instrument_t3_no_candles(
         ebull_test_conn,
-        instrument_id=950200,
+        instrument_id=instrument_id,
         symbol=symbol,
         exchange=exchange_id,
     )
@@ -128,7 +156,11 @@ def test_other_non_fundamentals_classes_qualify(
             symbols = sorted(r[1] for r in cur.fetchall())
         assert symbol in symbols
     finally:
-        _cleanup_exchange(ebull_test_conn, [exchange_id])
+        _cleanup(
+            ebull_test_conn,
+            exchange_ids=[exchange_id],
+            instrument_ids=[instrument_id],
+        )
 
 
 def test_us_equity_without_fundamentals_still_gated(
@@ -154,7 +186,11 @@ def test_us_equity_without_fundamentals_still_gated(
             symbols = sorted(r[1] for r in cur.fetchall())
         assert "TESTUSEQ" not in symbols
     finally:
-        _cleanup_exchange(ebull_test_conn, ["test_us_pr0"])
+        _cleanup(
+            ebull_test_conn,
+            exchange_ids=["test_us_pr0"],
+            instrument_ids=[950300],
+        )
 
 
 def test_crypto_with_existing_candles_excluded(
@@ -187,4 +223,8 @@ def test_crypto_with_existing_candles_excluded(
             symbols = sorted(r[1] for r in cur.fetchall())
         assert "TESTDONE" not in symbols
     finally:
-        _cleanup_exchange(ebull_test_conn, ["test_crypto_done"])
+        _cleanup(
+            ebull_test_conn,
+            exchange_ids=["test_crypto_done"],
+            instrument_ids=[950400],
+        )


### PR DESCRIPTION
## What

PR 0 of #515. T3 candle bootstrap now qualifies crypto / fx / commodity / index instruments without requiring a `fundamentals_snapshot` row that those asset classes never produce.

## Why

Operator-visible: BTC, LRC, ETH instrument pages rendered "no price data". Diagnosis showed zero `price_daily` rows for every crypto despite tier-3 + tradable status. Root cause: `daily_candle_refresh` T3 query required `EXISTS fundamentals_snapshot`, which is an equity-only heuristic.

## Test plan

- [x] Diagnosed dev DB state — confirmed zero `price_daily` for BTC/LRC/ETH; AAPL has 403 rows
- [x] `uv run ruff check .` / `ruff format --check` / `pyright` — clean
- [x] `uv run pytest tests/test_daily_candle_refresh.py tests/test_daily_candle_refresh_crypto_eligibility.py` — 14 passed (6 new integration tests)
- [x] `uv run pytest tests/smoke/test_app_boots.py` — passed
- [x] Codex review — 2 rounds, no remaining findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)