### PR TITLE
feat(#515-pr1): eToro field audit + lookup ingest + capability matrix

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -59,6 +59,7 @@ from app.workers.scheduler import (
     JOB_DAILY_PORTFOLIO_SYNC,
     JOB_DAILY_RESEARCH_REFRESH,
     JOB_DAILY_TAX_RECONCILIATION,
+    JOB_ETORO_LOOKUPS_REFRESH,
     JOB_EXCHANGES_METADATA_REFRESH,
     JOB_EXECUTE_APPROVED_ORDERS,
     JOB_FUNDAMENTALS_SYNC,
@@ -88,6 +89,7 @@ from app.workers.scheduler import (
     daily_portfolio_sync,
     daily_research_refresh,
     daily_tax_reconciliation,
+    etoro_lookups_refresh,
     exchanges_metadata_refresh,
     execute_approved_orders,
     fundamentals_sync,
@@ -136,6 +138,7 @@ logger = logging.getLogger(__name__)
 _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_NIGHTLY_UNIVERSE_SYNC: nightly_universe_sync,
     JOB_DAILY_CANDLE_REFRESH: daily_candle_refresh,
+    JOB_ETORO_LOOKUPS_REFRESH: etoro_lookups_refresh,
     JOB_EXCHANGES_METADATA_REFRESH: exchanges_metadata_refresh,
     JOB_FX_RATES_REFRESH: fx_rates_refresh,
     JOB_DAILY_RESEARCH_REFRESH: daily_research_refresh,

--- a/app/providers/implementations/etoro.py
+++ b/app/providers/implementations/etoro.py
@@ -25,9 +25,11 @@ from app.config import settings
 from app.providers.market_data import (
     ExchangeRecord,
     InstrumentRecord,
+    InstrumentTypeRecord,
     MarketDataProvider,
     OHLCVBar,
     Quote,
+    StocksIndustryRecord,
 )
 from app.providers.resilient_client import ResilientClient
 
@@ -108,6 +110,37 @@ class EtoroMarketDataProvider(MarketDataProvider):
         response.raise_for_status()
         raw = response.json()
         return _normalise_instruments(raw)
+
+    def get_instrument_types(self) -> list[InstrumentTypeRecord]:
+        """Fetch eToro's instrument-types lookup catalogue.
+
+        Maps numeric ``instrumentTypeID`` (Forex / Commodity / CFD
+        / Stocks / ETF / Bonds / …) to a human-readable
+        description. Used by ``app.services.etoro_lookups.refresh_etoro_lookups``
+        to populate the ``etoro_instrument_types`` table; the
+        frontend joins on it to render meaningful labels instead
+        of numeric ids.
+        """
+        response = self._http.get(
+            "/api/v1/market-data/instrument-types",
+            headers=self._request_headers(),
+        )
+        response.raise_for_status()
+        return _normalise_instrument_types(response.json())
+
+    def get_stocks_industries(self) -> list[StocksIndustryRecord]:
+        """Fetch eToro's stocks-industries lookup catalogue.
+
+        Maps numeric ``industryID`` to industry name (Basic
+        Materials / Healthcare / Technology / …). Same role as
+        ``get_instrument_types`` for the sector label.
+        """
+        response = self._http.get(
+            "/api/v1/market-data/stocks-industries",
+            headers=self._request_headers(),
+        )
+        response.raise_for_status()
+        return _normalise_stocks_industries(response.json())
 
     def get_exchanges(self) -> list[ExchangeRecord]:
         """Fetch the eToro exchange catalogue.
@@ -277,6 +310,7 @@ def _normalise_instrument(item: Mapping[str, object]) -> InstrumentRecord | None
         country=None,  # not available in instruments endpoint
         is_tradable=True,  # only tradable instruments are returned by the API
         instrument_type=_str_or_none(item.get("instrumentTypeName")),
+        instrument_type_id=_int_or_none(item.get("instrumentTypeID")),
     )
 
 
@@ -421,42 +455,92 @@ def _normalise_rate(item: Mapping[str, object]) -> Quote | None:
 
 
 _EXCHANGES_WRAPPER_KEY = "exchangeInfo"
+_INSTRUMENT_TYPES_WRAPPER_KEY = "instrumentTypes"
+_STOCKS_INDUSTRIES_WRAPPER_KEY = "stocksIndustries"
+
+
+def _unwrap_lookup(raw: object, wrapper_key: str) -> list[object]:
+    """Shared shape-validator for the lookup endpoints.
+
+    eToro's lookup endpoints (``exchanges`` / ``instrument-types``
+    / ``stocks-industries``) all wrap a list under a single known
+    key. Bare-list fallback accepted in case eToro aligns the
+    live API with their portal docs in the future. Anything else
+    raises so a silent schema drift fails the cron run loudly
+    rather than reporting an empty feed.
+    """
+    if isinstance(raw, dict):
+        wrapped = raw.get(wrapper_key)
+        if not isinstance(wrapped, list):
+            raise ValueError(
+                f"eToro lookup endpoint returned a dict, but key {wrapper_key!r} "
+                f"is missing or not a list. Top-level keys: {list(raw.keys())}. "
+                f"If eToro renamed the wrapper key, update the lookup normaliser."
+            )
+        return wrapped
+    if isinstance(raw, list):
+        return list(raw)
+    raise ValueError(
+        f"Expected dict (with {wrapper_key!r} key) or list from eToro lookup endpoint, got {type(raw).__name__}."
+    )
+
+
+def _normalise_instrument_types(raw: object) -> list[InstrumentTypeRecord]:
+    """Normalise an eToro instrument-types response into typed records."""
+    items = _unwrap_lookup(raw, _INSTRUMENT_TYPES_WRAPPER_KEY)
+    records: list[InstrumentTypeRecord] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        type_id = item.get("instrumentTypeID")
+        if type_id is None:
+            continue
+        try:
+            type_id_int = int(type_id)
+        except TypeError, ValueError:
+            continue
+        records.append(
+            InstrumentTypeRecord(
+                type_id=type_id_int,
+                description=_str_or_none(item.get("instrumentTypeDescription")),
+            )
+        )
+    return records
+
+
+def _normalise_stocks_industries(raw: object) -> list[StocksIndustryRecord]:
+    """Normalise an eToro stocks-industries response into typed records."""
+    items = _unwrap_lookup(raw, _STOCKS_INDUSTRIES_WRAPPER_KEY)
+    records: list[StocksIndustryRecord] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        industry_id = item.get("industryID")
+        if industry_id is None:
+            continue
+        try:
+            industry_id_int = int(industry_id)
+        except TypeError, ValueError:
+            continue
+        records.append(
+            StocksIndustryRecord(
+                industry_id=industry_id_int,
+                name=_str_or_none(item.get("industryName")),
+            )
+        )
+    return records
 
 
 def _normalise_exchanges(raw: object) -> list[ExchangeRecord]:
     """Normalise an eToro exchanges API response into ExchangeRecord list.
 
     The live API wraps the list in ``{"exchangeInfo": [...]}`` even
-    though the portal docs show a bare list. We pin the actual shape
-    here (one explicit known wrapper key) — anything else raises
-    ``ValueError`` so a silent schema drift fails loudly rather than
-    parsing the wrong list and reporting a harmless-looking empty
-    feed (Codex round 2 finding from #503 PR 4).
-
-    The bare-list shape is also accepted as a fallback in case eToro
-    eventually aligns the live API with the portal docs; a future
-    silent flip from one to the other is a no-op for us.
+    though the portal docs show a bare list. ``_unwrap_lookup``
+    pins the shape — anything else raises ``ValueError`` so a
+    silent schema drift fails loudly rather than parsing the
+    wrong list and reporting a harmless-looking empty feed.
     """
-    items: list[object]
-    if isinstance(raw, dict):
-        wrapped = raw.get(_EXCHANGES_WRAPPER_KEY)
-        if not isinstance(wrapped, list):
-            raise ValueError(
-                f"eToro exchanges endpoint returned a dict, but key "
-                f"{_EXCHANGES_WRAPPER_KEY!r} is missing or not a list. "
-                f"Top-level keys: {list(raw.keys())}. If eToro renamed "
-                f"the wrapper key, update _normalise_exchanges."
-            )
-        items = wrapped
-    elif isinstance(raw, list):
-        items = list(raw)
-    else:
-        raise ValueError(
-            f"Expected dict (with {_EXCHANGES_WRAPPER_KEY!r} key) or list "
-            f"from eToro exchanges endpoint, got {type(raw).__name__}. "
-            f"If eToro changed the response shape, update _normalise_exchanges."
-        )
-
+    items = _unwrap_lookup(raw, _EXCHANGES_WRAPPER_KEY)
     records: list[ExchangeRecord] = []
     for item in items:
         if not isinstance(item, dict):

--- a/app/providers/market_data.py
+++ b/app/providers/market_data.py
@@ -29,6 +29,11 @@ class InstrumentRecord:
     # exchanges.asset_class downstream — a stock-typed instrument on a
     # crypto-classified exchange is a data-integrity flag (#503 PR 4).
     instrument_type: str | None = None
+    # eToro instrumentTypeID — the numeric foreign key into
+    # ``etoro_instrument_types`` so the frontend can render the
+    # description label by joining on a stable id rather than a
+    # text match. Captured alongside the name in #515 PR 1.
+    instrument_type_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -37,6 +42,22 @@ class ExchangeRecord:
 
     provider_id: str  # provider-native exchange id (e.g. eToro exchangeId)
     description: str | None  # eToro's human-readable name; None if not provided
+
+
+@dataclass(frozen=True)
+class InstrumentTypeRecord:
+    """An entry from eToro's instrument-types lookup catalogue."""
+
+    type_id: int  # eToro instrumentTypeID
+    description: str | None  # e.g. "Stocks", "ETF", "Crypto"
+
+
+@dataclass(frozen=True)
+class StocksIndustryRecord:
+    """An entry from eToro's stocks-industries lookup catalogue."""
+
+    industry_id: int  # eToro industryID
+    name: str | None  # e.g. "Healthcare", "Technology"
 
 
 @dataclass(frozen=True)
@@ -103,6 +124,26 @@ class MarketDataProvider(ABC):
 
         Returns None if the instrument is not recognised or not
         currently quoted.
+        """
+
+    @abstractmethod
+    def get_instrument_types(self) -> list[InstrumentTypeRecord]:
+        """Return the provider's instrument-type lookup catalogue.
+
+        eBull joins these rows on ``instruments.instrument_type_id``
+        to render the human-readable label ("Stocks", "ETF",
+        "Crypto", …). Implementations that don't expose a separate
+        catalogue endpoint may return an empty list.
+        """
+
+    @abstractmethod
+    def get_stocks_industries(self) -> list[StocksIndustryRecord]:
+        """Return the provider's stocks-industries lookup catalogue.
+
+        eBull joins on ``instruments.sector`` (which stores the
+        provider's numeric industry id) to render industry names.
+        Empty list permitted for providers that don't ship a
+        catalogue.
         """
 
     @abstractmethod

--- a/app/services/etoro_lookups.py
+++ b/app/services/etoro_lookups.py
@@ -1,0 +1,144 @@
+"""eToro lookup-catalogue refresh.
+
+Pulls the provider's ``get_instrument_types()`` and
+``get_stocks_industries()`` endpoints and upserts their contents
+into reference tables. The frontend joins on those tables so an
+instrument page renders "Stocks" / "Healthcare" instead of
+numeric ids — see #515 spec workstream 1.
+
+Both catalogues rarely churn (a few rows added per year at most),
+so the refresh job runs weekly. ``description`` / ``name`` updates
+in place when eToro changes a label; rows are never deleted, so
+historical references to a retired id still resolve to its label
+on operator audit pages.
+
+Typed against the abstract ``MarketDataProvider`` interface — not
+the concrete eToro class — so the boundary the providers package
+advertises stays clean.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import psycopg
+
+from app.providers.market_data import MarketDataProvider
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LookupRefreshSummary:
+    """Result of one ``refresh_etoro_lookups`` call."""
+
+    instrument_types_fetched: int
+    instrument_types_inserted: int
+    instrument_types_updated: int
+    industries_fetched: int
+    industries_inserted: int
+    industries_updated: int
+
+
+def refresh_etoro_lookups(
+    provider: MarketDataProvider,
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+) -> LookupRefreshSummary:
+    """Refresh ``etoro_instrument_types`` + ``etoro_stocks_industries``.
+
+    Same shape as ``refresh_exchanges_metadata``: only ``description``
+    / ``name`` is upserted; the seeded_at / updated_at columns
+    track first-seen-vs-changed-since. Empty provider responses
+    are no-ops (guards against an eToro blip wiping label data).
+    """
+    type_records = provider.get_instrument_types()
+    industry_records = provider.get_stocks_industries()
+
+    if not type_records and not industry_records:
+        logger.warning(
+            "etoro_lookups_refresh: provider returned zero rows on both endpoints — "
+            "skipping upsert to avoid clobbering label data."
+        )
+        return LookupRefreshSummary(0, 0, 0, 0, 0, 0)
+
+    types_inserted = 0
+    types_updated = 0
+    industries_inserted = 0
+    industries_updated = 0
+
+    with conn.transaction():
+        for rec in type_records:
+            row = conn.execute(
+                """
+                INSERT INTO etoro_instrument_types (instrument_type_id, description)
+                VALUES (%(id)s, %(description)s)
+                ON CONFLICT (instrument_type_id) DO UPDATE SET
+                    description = COALESCE(EXCLUDED.description, etoro_instrument_types.description),
+                    updated_at  = NOW()
+                WHERE EXCLUDED.description IS NOT NULL
+                  AND etoro_instrument_types.description IS DISTINCT FROM EXCLUDED.description
+                RETURNING (xmax = 0) AS was_inserted
+                """,
+                {"id": rec.type_id, "description": rec.description},
+            ).fetchone()
+            if row is None:
+                continue
+            if bool(row[0]):
+                types_inserted += 1
+            else:
+                types_updated += 1
+
+        for rec in industry_records:
+            row = conn.execute(
+                """
+                INSERT INTO etoro_stocks_industries (industry_id, name)
+                VALUES (%(id)s, %(name)s)
+                ON CONFLICT (industry_id) DO UPDATE SET
+                    name       = COALESCE(EXCLUDED.name, etoro_stocks_industries.name),
+                    updated_at = NOW()
+                WHERE EXCLUDED.name IS NOT NULL
+                  AND etoro_stocks_industries.name IS DISTINCT FROM EXCLUDED.name
+                RETURNING (xmax = 0) AS was_inserted
+                """,
+                {"id": rec.industry_id, "name": rec.name},
+            ).fetchone()
+            if row is None:
+                continue
+            if bool(row[0]):
+                industries_inserted += 1
+            else:
+                industries_updated += 1
+
+    # No legacy-row backfill: the eToro instruments endpoint
+    # returns only ``instrumentTypeID`` (int), NOT
+    # ``instrumentTypeName`` (text). The text column added in
+    # migration 068 stays NULL across the universe; the int
+    # column added in migration 070 is the canonical persisted
+    # field. Pre-migration-070 rows pick up
+    # ``instrument_type_id`` on the next ``nightly_universe_sync``
+    # — note: that job is on-demand (operator triggers via Admin
+    # "Run now" or it gets scheduled by orchestrator_full_sync),
+    # NOT catch-up-on-boot. So the rollout gap is: existing rows
+    # stay NULL until the operator's next sync. Acceptable
+    # because the column is purely additive (frontend treats
+    # NULL as "label unknown, fall back to numeric id render").
+
+    summary = LookupRefreshSummary(
+        instrument_types_fetched=len(type_records),
+        instrument_types_inserted=types_inserted,
+        instrument_types_updated=types_updated,
+        industries_fetched=len(industry_records),
+        industries_inserted=industries_inserted,
+        industries_updated=industries_updated,
+    )
+    logger.info(
+        "etoro_lookups_refresh: types fetched=%d inserted=%d updated=%d; industries fetched=%d inserted=%d updated=%d",
+        summary.instrument_types_fetched,
+        summary.instrument_types_inserted,
+        summary.instrument_types_updated,
+        summary.industries_fetched,
+        summary.industries_inserted,
+        summary.industries_updated,
+    )
+    return summary

--- a/app/services/universe.py
+++ b/app/services/universe.py
@@ -65,41 +65,46 @@ def sync_universe(
                 INSERT INTO instruments (
                     instrument_id, symbol, company_name, exchange, currency,
                     sector, industry, country, is_tradable, instrument_type,
+                    instrument_type_id,
                     first_seen_at, last_seen_at
                 )
                 VALUES (
                     %(provider_id)s, %(symbol)s, %(company_name)s, %(exchange)s,
                     %(currency)s, %(sector)s, %(industry)s, %(country)s, %(is_tradable)s,
-                    %(instrument_type)s, NOW(), NOW()
+                    %(instrument_type)s, %(instrument_type_id)s, NOW(), NOW()
                 )
                 ON CONFLICT (instrument_id) DO UPDATE SET
-                    symbol          = EXCLUDED.symbol,
-                    company_name    = EXCLUDED.company_name,
-                    exchange        = EXCLUDED.exchange,
-                    currency        = COALESCE(EXCLUDED.currency, instruments.currency),
-                    sector          = EXCLUDED.sector,
-                    industry        = EXCLUDED.industry,
-                    country         = EXCLUDED.country,
-                    is_tradable     = EXCLUDED.is_tradable,
+                    symbol             = EXCLUDED.symbol,
+                    company_name       = EXCLUDED.company_name,
+                    exchange           = EXCLUDED.exchange,
+                    currency           = COALESCE(EXCLUDED.currency, instruments.currency),
+                    sector             = EXCLUDED.sector,
+                    industry           = EXCLUDED.industry,
+                    country            = EXCLUDED.country,
+                    is_tradable        = EXCLUDED.is_tradable,
                     -- COALESCE preserves a previously-known type when a
-                    -- transient eToro response omits ``instrumentTypeName``.
-                    -- Otherwise a single empty-field response would erase
-                    -- the cross-validation signal we need against
-                    -- ``exchanges.asset_class`` (#503 PR 4).
-                    instrument_type = COALESCE(EXCLUDED.instrument_type, instruments.instrument_type),
-                    last_seen_at    = NOW()
+                    -- transient eToro response omits ``instrumentTypeName``
+                    -- / ``instrumentTypeID``. Otherwise a single empty-
+                    -- field response would erase the cross-validation
+                    -- signal we need against ``exchanges.asset_class``
+                    -- (#503 PR 4).
+                    instrument_type    = COALESCE(EXCLUDED.instrument_type, instruments.instrument_type),
+                    instrument_type_id = COALESCE(EXCLUDED.instrument_type_id, instruments.instrument_type_id),
+                    last_seen_at       = NOW()
                 WHERE (
-                    instruments.symbol          IS DISTINCT FROM EXCLUDED.symbol          OR
-                    instruments.company_name    IS DISTINCT FROM EXCLUDED.company_name    OR
-                    instruments.exchange        IS DISTINCT FROM EXCLUDED.exchange        OR
+                    instruments.symbol             IS DISTINCT FROM EXCLUDED.symbol             OR
+                    instruments.company_name       IS DISTINCT FROM EXCLUDED.company_name       OR
+                    instruments.exchange           IS DISTINCT FROM EXCLUDED.exchange           OR
                     (EXCLUDED.currency IS NOT NULL AND
-                     instruments.currency IS DISTINCT FROM EXCLUDED.currency)             OR
-                    instruments.sector          IS DISTINCT FROM EXCLUDED.sector          OR
-                    instruments.industry        IS DISTINCT FROM EXCLUDED.industry        OR
-                    instruments.country         IS DISTINCT FROM EXCLUDED.country         OR
-                    instruments.is_tradable     IS DISTINCT FROM EXCLUDED.is_tradable     OR
+                     instruments.currency IS DISTINCT FROM EXCLUDED.currency)                   OR
+                    instruments.sector             IS DISTINCT FROM EXCLUDED.sector             OR
+                    instruments.industry           IS DISTINCT FROM EXCLUDED.industry           OR
+                    instruments.country            IS DISTINCT FROM EXCLUDED.country            OR
+                    instruments.is_tradable        IS DISTINCT FROM EXCLUDED.is_tradable        OR
                     (EXCLUDED.instrument_type IS NOT NULL AND
-                     instruments.instrument_type IS DISTINCT FROM EXCLUDED.instrument_type)
+                     instruments.instrument_type IS DISTINCT FROM EXCLUDED.instrument_type)     OR
+                    (EXCLUDED.instrument_type_id IS NOT NULL AND
+                     instruments.instrument_type_id IS DISTINCT FROM EXCLUDED.instrument_type_id)
                 )
                 """,
                 {
@@ -113,6 +118,7 @@ def sync_universe(
                     "country": rec.country,
                     "is_tradable": rec.is_tradable,
                     "instrument_type": rec.instrument_type,
+                    "instrument_type_id": rec.instrument_type_id,
                 },
             )
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -43,6 +43,7 @@ from app.services.coverage import bootstrap_missing_coverage_rows, review_covera
 from app.services.deferred_retry import retry_deferred_recommendations
 from app.services.enrichment import refresh_enrichment
 from app.services.entry_timing import evaluate_entry_conditions
+from app.services.etoro_lookups import refresh_etoro_lookups
 from app.services.exchanges import refresh_exchanges_metadata
 from app.services.execution_guard import evaluate_recommendation
 from app.services.filings import FilingsRefreshSummary, refresh_filings, upsert_cik_mapping
@@ -244,6 +245,7 @@ JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL = "sec_insider_transactions_backfill"
 JOB_SEC_8K_EVENTS_INGEST = "sec_8k_events_ingest"
 JOB_SEC_FILING_DOCUMENTS_INGEST = "sec_filing_documents_ingest"
 JOB_EXCHANGES_METADATA_REFRESH = "exchanges_metadata_refresh"
+JOB_ETORO_LOOKUPS_REFRESH = "etoro_lookups_refresh"
 
 
 # ---------------------------------------------------------------------------
@@ -594,6 +596,25 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # a fresh DB picks up real descriptions instead of NULLs without
         # waiting for the next Sunday.
         cadence=Cadence.weekly(weekday=6, hour=4, minute=0),
+        catch_up_on_boot=True,
+    ),
+    ScheduledJob(
+        name=JOB_ETORO_LOOKUPS_REFRESH,
+        description=(
+            "Weekly refresh of eToro's instrument-types + "
+            "stocks-industries lookup catalogues into "
+            "``etoro_instrument_types`` / ``etoro_stocks_industries`` "
+            "(#515 PR 1). Frontend joins on these tables so the "
+            "instrument page renders 'Stocks' / 'Healthcare' instead "
+            "of numeric ids. Catalogues rarely churn; ~10s rows total "
+            "across both endpoints so the refresh is bounded."
+        ),
+        # Sundays 04:30 UTC — staggered 30 min after
+        # exchanges_metadata_refresh so both jobs don't hit eToro
+        # back-to-back. Catch-up on boot for the same reason as the
+        # exchanges refresh: fresh DB picks up labels without waiting
+        # a week.
+        cadence=Cadence.weekly(weekday=6, hour=4, minute=30),
         catch_up_on_boot=True,
     ),
     # -- On-demand jobs are NOT listed here.  They stay in _INVOKERS
@@ -2773,6 +2794,45 @@ def exchanges_metadata_refresh() -> None:
                 summary.fetched,
                 summary.inserted,
                 summary.description_updated,
+            )
+
+
+def etoro_lookups_refresh() -> None:
+    """Refresh ``etoro_instrument_types`` + ``etoro_stocks_industries``
+    reference tables from eToro's public lookup endpoints.
+
+    Weekly cron — both catalogues rarely churn (a few rows added
+    per year at most). The refresh is bounded (10s of rows total)
+    so it doesn't compete with the universe sync. See
+    ``app.services.etoro_lookups.refresh_etoro_lookups`` for the
+    upsert semantics.
+    """
+    creds = _load_etoro_credentials(JOB_ETORO_LOOKUPS_REFRESH)
+    if creds is None:
+        _record_prereq_skip(JOB_ETORO_LOOKUPS_REFRESH, "etoro credentials missing")
+        return
+    api_key, user_key = creds
+
+    with _tracked_job(JOB_ETORO_LOOKUPS_REFRESH) as tracker:
+        with (
+            EtoroMarketDataProvider(api_key=api_key, user_key=user_key, env=settings.etoro_env) as provider,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            summary = refresh_etoro_lookups(provider, conn)
+            tracker.row_count = (
+                summary.instrument_types_inserted
+                + summary.instrument_types_updated
+                + summary.industries_inserted
+                + summary.industries_updated
+            )
+            logger.info(
+                "etoro_lookups_refresh complete: types=%d/%d/%d industries=%d/%d/%d (fetched/inserted/updated)",
+                summary.instrument_types_fetched,
+                summary.instrument_types_inserted,
+                summary.instrument_types_updated,
+                summary.industries_fetched,
+                summary.industries_inserted,
+                summary.industries_updated,
             )
 
 

--- a/docs/etoro-coverage-matrix.md
+++ b/docs/etoro-coverage-matrix.md
@@ -1,0 +1,75 @@
+# eToro instruments-endpoint field coverage matrix
+
+Date: 2026-04-26
+Source: live `/api/v1/market-data/instruments` capture against `settings.etoro_env` demo creds.
+Samples: `docs/research/etoro-instrument-samples/{tag}_{exchange_id}_{symbol}.json`.
+
+This matrix is workstream 1's deliverable for [`#515`](https://github.com/Luke-Bradford/eBull/pull/515) PR 1. It compares fields eToro returns against what eBull's universe ingest currently captures in the `instruments` table.
+
+## Captured samples
+
+| Tag | Symbol | Exchange ID | Description |
+|---|---|---|---|
+| us_equity_stock | AAPL | 4 | Nasdaq stock |
+| us_equity_etf | ARKK | 20 | CBOE ETF |
+| crypto | BTC | 8 | Digital Currency |
+| uk_equity | BARC.L | 7 | LSE listing |
+| eu_equity_de | 0B2.DE | 6 | Frankfurt listing |
+| asia_equity_tyo | 7203.T | 56 | Tokyo Stock Exchange (Toyota) |
+
+Plus three lookup-catalogue captures:
+
+- `lookup_instrument-types.json` — `{instrumentTypes: [{instrumentTypeID, instrumentTypeDescription}]}`
+- `lookup_stocks-industries.json` — `{stocksIndustries: [{industryID, industryName}]}`
+- `lookup_exchanges.json` — `{exchangeInfo: [{exchangeID, exchangeDescription}]}`
+
+## Field × asset class matrix
+
+Legend:
+
+- ✅ persisted — field captured by `_normalise_instrument` and written to the `instruments` table.
+- 📦 available, dropped — eToro returns it on at least one asset class but eBull doesn't capture it. Cell text states the impact.
+- ⊘ not returned — field absent on this capture.
+
+| Field | us_equity (Stock) | us_equity (ETF) | crypto | uk_equity | eu_equity | asia_equity | Notes |
+|---|---|---|---|---|---|---|---|
+| `instrumentID` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | PK |
+| `symbolFull` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | |
+| `instrumentDisplayName` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `instruments.company_name` |
+| `exchangeID` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `instruments.exchange` |
+| `stocksIndustryID` | ✅ | ✅ | ⊘ | ✅ | ✅ | ✅ | Captured as `instruments.sector` (raw int). PR 1 adds `etoro_stocks_industries` lookup so frontend can render the name. |
+| `instrumentTypeID` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Captured in `instruments.instrument_type_id` (#515 PR 1). The numeric FK joins to the new `etoro_instrument_types` lookup so the frontend renders the description. Note: the eToro instruments endpoint does NOT return `instrumentTypeName` despite migration 068's docstring suggesting otherwise — every sample under `docs/research/etoro-instrument-samples/` confirms only the int is present. The text `instrument_type` column from migration 068 stays NULL across the universe; `instrument_type_id` + the lookup join is the canonical path. |
+| `priceSource` | 📦 | 📦 | 📦 | 📦 | 📦 | 📦 | Free-text source venue ("Nasdaq", "LSE-Vendor"). Operator-page-relevant: tells the trader where the displayed price actually comes from. Defer to a follow-up — not blocking spec workstream 2. |
+| `hasExpirationDate` | 📦 | 📦 | 📦 | 📦 | 📦 | 📦 | Boolean. Always `false` in v1 captures (no futures/options in eBull yet). Capture when eBull starts trading dated instruments. |
+| `isInternalInstrument` | ✅* | ✅* | ✅* | ✅* | ✅* | ✅* | * Used as a **filter** during normalisation (skip-if-true), not persisted as a column. |
+| `images` | 📦 | 📦 | 📦 | 📦 | 📦 | 📦 | List of logo URLs at multiple resolutions. Frontend renders no instrument logo today; defer until UI design calls for it. |
+| `instrumentTypeSubCategoryID` | ⊘ | ⊘ | ✅* | ⊘ | ⊘ | ⊘ | * Crypto-only subcategory id (e.g. token type). Sample shows int. Defer until a use case surfaces. |
+
+## Lookup catalogues (PR 1 ships ingest)
+
+Both endpoints land in dedicated reference tables via `app/services/etoro_lookups.py`:
+
+| Endpoint | Table | Sample row |
+|---|---|---|
+| `/api/v1/market-data/instrument-types` | `etoro_instrument_types(instrument_type_id, description)` | `(5, "Stocks")` |
+| `/api/v1/market-data/stocks-industries` | `etoro_stocks_industries(industry_id, name)` | `(5, "Healthcare")` |
+
+Frontend renders the human-readable label by joining on these tables instead of showing a raw integer.
+
+## Audit gaps to file separately
+
+Each "📦 available, dropped" row above has its own follow-up question for the operator. None block PR 2 (workstream 2 keys on `exchange_id`, not on these fields), so we file them as separate tickets after PR 1 lands rather than expanding PR 1's scope:
+
+- `priceSource` — capture as `instruments.price_source` so the page can label "via LSE-Vendor".
+- `images` — defer until visual design calls for instrument logos.
+- `instrumentTypeSubCategoryID` — defer until a crypto-token-type use case surfaces.
+- `hasExpirationDate` + `expirationDate` — capture once eBull adds dated-instrument support.
+
+## Acceptance
+
+- [x] Lookup-table migration (070) ships with PR 1.
+- [x] Provider methods + normalisers + service ship with PR 1.
+- [x] Weekly cron `etoro_lookups_refresh` registered (Sunday 04:30 UTC).
+- [x] Sample fixtures committed under `docs/research/etoro-instrument-samples/`.
+- [x] Field-coverage matrix above operator-reviewable.
+- [ ] Operator sign-off on which "📦 available, dropped" rows to promote to "must persist" (separate tickets, out of PR 1 scope).

--- a/docs/research/etoro-instrument-samples/asia_equity_tyo_56_7203_T.json
+++ b/docs/research/etoro-instrument-samples/asia_equity_tyo_56_7203_T.json
@@ -1,0 +1,37 @@
+{
+  "instrumentID": 14646,
+  "instrumentDisplayName": "Toyota Motor Corp.",
+  "instrumentTypeID": 5,
+  "exchangeID": 56,
+  "images": [
+    {
+      "instrumentID": 14646,
+      "width": 35.0,
+      "height": 35.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/14646/35x35.png"
+    },
+    {
+      "instrumentID": 14646,
+      "width": 50.0,
+      "height": 50.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/14646/50x50.png"
+    },
+    {
+      "instrumentID": 14646,
+      "width": 150.0,
+      "height": 150.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/14646/150x150.png"
+    },
+    {
+      "instrumentID": 14646,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/14646/14646_EB0A1E_F7F7F7.svg",
+      "backgroundColor": "#EB0A1E",
+      "textColor": "#F7F7F7"
+    }
+  ],
+  "symbolFull": "7203.T",
+  "stocksIndustryID": 1,
+  "priceSource": "Tokyo",
+  "hasExpirationDate": false,
+  "isInternalInstrument": false
+}

--- a/docs/research/etoro-instrument-samples/crypto_8_BTC.json
+++ b/docs/research/etoro-instrument-samples/crypto_8_BTC.json
@@ -1,0 +1,55 @@
+{
+  "instrumentID": 100000,
+  "instrumentDisplayName": "Bitcoin",
+  "instrumentTypeID": 10,
+  "exchangeID": 8,
+  "images": [
+    {
+      "instrumentID": 100000,
+      "width": 50.0,
+      "height": 50.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/btc/50x50.png"
+    },
+    {
+      "instrumentID": 100000,
+      "width": 150.0,
+      "height": 150.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/btc/150x150.png"
+    },
+    {
+      "instrumentID": 100000,
+      "width": 35.0,
+      "height": 35.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/btc/35x35.png"
+    },
+    {
+      "instrumentID": 100000,
+      "width": 90.0,
+      "height": 90.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/btc/90x90.png"
+    },
+    {
+      "instrumentID": 100000,
+      "width": 80.0,
+      "height": 80.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/btc/80x80.png"
+    },
+    {
+      "instrumentID": 100000,
+      "width": 70.0,
+      "height": 70.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/btc/70x70.png"
+    },
+    {
+      "instrumentID": 100000,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/100000/100000_F0AF32_F7F7F7.svg",
+      "backgroundColor": "#F0AF32",
+      "textColor": "#F7F7F7"
+    }
+  ],
+  "symbolFull": "BTC",
+  "instrumentTypeSubCategoryID": 1001,
+  "priceSource": "eToro",
+  "hasExpirationDate": false,
+  "isInternalInstrument": false
+}

--- a/docs/research/etoro-instrument-samples/eu_equity_de_6_0B2_DE.json
+++ b/docs/research/etoro-instrument-samples/eu_equity_de_6_0B2_DE.json
@@ -1,0 +1,31 @@
+{
+  "instrumentID": 12321,
+  "instrumentDisplayName": "BAWAG Group AG",
+  "instrumentTypeID": 5,
+  "exchangeID": 6,
+  "images": [
+    {
+      "instrumentID": 12321,
+      "width": 35.0,
+      "height": 35.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/12321/35x35.png"
+    },
+    {
+      "instrumentID": 12321,
+      "width": 50.0,
+      "height": 50.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/12321/50x50.png"
+    },
+    {
+      "instrumentID": 12321,
+      "width": 150.0,
+      "height": 150.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/12321/150x150.png"
+    }
+  ],
+  "symbolFull": "0B2.DE",
+  "stocksIndustryID": 4,
+  "priceSource": "Xetra",
+  "hasExpirationDate": false,
+  "isInternalInstrument": false
+}

--- a/docs/research/etoro-instrument-samples/lookup_exchanges.json
+++ b/docs/research/etoro-instrument-samples/lookup_exchanges.json
@@ -1,0 +1,208 @@
+{
+  "exchangeInfo": [
+    {
+      "exchangeID": 1,
+      "exchangeDescription": "FX"
+    },
+    {
+      "exchangeID": 2,
+      "exchangeDescription": "Commodity"
+    },
+    {
+      "exchangeID": 3,
+      "exchangeDescription": "CFD"
+    },
+    {
+      "exchangeID": 4,
+      "exchangeDescription": "Nasdaq"
+    },
+    {
+      "exchangeID": 5,
+      "exchangeDescription": "NYSE"
+    },
+    {
+      "exchangeID": 6,
+      "exchangeDescription": "FRA"
+    },
+    {
+      "exchangeID": 7,
+      "exchangeDescription": "LSE"
+    },
+    {
+      "exchangeID": 8,
+      "exchangeDescription": "Digital Currency"
+    },
+    {
+      "exchangeID": 9,
+      "exchangeDescription": "Euronext Paris"
+    },
+    {
+      "exchangeID": 10,
+      "exchangeDescription": "Bolsa De Madrid"
+    },
+    {
+      "exchangeID": 11,
+      "exchangeDescription": "Borsa Italiana"
+    },
+    {
+      "exchangeID": 12,
+      "exchangeDescription": "SIX"
+    },
+    {
+      "exchangeID": 13,
+      "exchangeDescription": "TYO"
+    },
+    {
+      "exchangeID": 14,
+      "exchangeDescription": "Oslo Stock Exchange"
+    },
+    {
+      "exchangeID": 15,
+      "exchangeDescription": "Stockholm  Stock Exchange"
+    },
+    {
+      "exchangeID": 16,
+      "exchangeDescription": "Copenhagen Stock Exchange"
+    },
+    {
+      "exchangeID": 17,
+      "exchangeDescription": "Helsinki Stock Exchange"
+    },
+    {
+      "exchangeID": 18,
+      "exchangeDescription": "Toronto Stock Exchange"
+    },
+    {
+      "exchangeID": 19,
+      "exchangeDescription": "OTC Markets Stock Exchange"
+    },
+    {
+      "exchangeID": 20,
+      "exchangeDescription": "Chicago Board Options Exchange"
+    },
+    {
+      "exchangeID": 21,
+      "exchangeDescription": "Hong Kong Exchanges"
+    },
+    {
+      "exchangeID": 22,
+      "exchangeDescription": "Euronext Lisbon"
+    },
+    {
+      "exchangeID": 23,
+      "exchangeDescription": "Euronext Brussels"
+    },
+    {
+      "exchangeID": 24,
+      "exchangeDescription": "Tadawul"
+    },
+    {
+      "exchangeID": 30,
+      "exchangeDescription": "Euronext Amsterdam"
+    },
+    {
+      "exchangeID": 31,
+      "exchangeDescription": "Sydney"
+    },
+    {
+      "exchangeID": 32,
+      "exchangeDescription": "Vienna"
+    },
+    {
+      "exchangeID": 33,
+      "exchangeDescription": "Regular Trading Hours - RTH"
+    },
+    {
+      "exchangeID": 34,
+      "exchangeDescription": "Dublin EN"
+    },
+    {
+      "exchangeID": 35,
+      "exchangeDescription": "Prague SE"
+    },
+    {
+      "exchangeID": 36,
+      "exchangeDescription": "Warsaw"
+    },
+    {
+      "exchangeID": 37,
+      "exchangeDescription": "Budapest"
+    },
+    {
+      "exchangeID": 38,
+      "exchangeDescription": "Xetra ETFs"
+    },
+    {
+      "exchangeID": 39,
+      "exchangeDescription": "Dubai Financial Market"
+    },
+    {
+      "exchangeID": 40,
+      "exchangeDescription": "CME"
+    },
+    {
+      "exchangeID": 41,
+      "exchangeDescription": "Abu Dhabi"
+    },
+    {
+      "exchangeID": 42,
+      "exchangeDescription": "LSE_AIM"
+    },
+    {
+      "exchangeID": 43,
+      "exchangeDescription": "LSE AIM Auction"
+    },
+    {
+      "exchangeID": 44,
+      "exchangeDescription": "LSE Auction"
+    },
+    {
+      "exchangeID": 45,
+      "exchangeDescription": "Shenzen Stock Exchange"
+    },
+    {
+      "exchangeID": 46,
+      "exchangeDescription": "Shanghai Stock Exchange"
+    },
+    {
+      "exchangeID": 47,
+      "exchangeDescription": "National Stock Exchange of India"
+    },
+    {
+      "exchangeID": 48,
+      "exchangeDescription": "TSX Venture Exchange"
+    },
+    {
+      "exchangeID": 49,
+      "exchangeDescription": "Singapore Exchange"
+    },
+    {
+      "exchangeID": 50,
+      "exchangeDescription": "Nasdaq Iceland"
+    },
+    {
+      "exchangeID": 51,
+      "exchangeDescription": "Nasdaq Tallinn"
+    },
+    {
+      "exchangeID": 52,
+      "exchangeDescription": "Nasdaq Vilnius"
+    },
+    {
+      "exchangeID": 53,
+      "exchangeDescription": "Nasdaq Riga"
+    },
+    {
+      "exchangeID": 54,
+      "exchangeDescription": "Korea Exchange"
+    },
+    {
+      "exchangeID": 55,
+      "exchangeDescription": "Taiwan Stock Exchange"
+    },
+    {
+      "exchangeID": 56,
+      "exchangeDescription": "Tokyo Stock Exchange"
+    }
+  ]
+}

--- a/docs/research/etoro-instrument-samples/lookup_instrument-types.json
+++ b/docs/research/etoro-instrument-samples/lookup_instrument-types.json
@@ -1,0 +1,44 @@
+{
+  "instrumentTypes": [
+    {
+      "instrumentTypeID": 1,
+      "instrumentTypeDescription": "Forex"
+    },
+    {
+      "instrumentTypeID": 2,
+      "instrumentTypeDescription": "Commodity"
+    },
+    {
+      "instrumentTypeID": 3,
+      "instrumentTypeDescription": "CFD"
+    },
+    {
+      "instrumentTypeID": 4,
+      "instrumentTypeDescription": "Indices"
+    },
+    {
+      "instrumentTypeID": 5,
+      "instrumentTypeDescription": "Stocks"
+    },
+    {
+      "instrumentTypeID": 6,
+      "instrumentTypeDescription": "ETF"
+    },
+    {
+      "instrumentTypeID": 7,
+      "instrumentTypeDescription": "Bonds"
+    },
+    {
+      "instrumentTypeID": 8,
+      "instrumentTypeDescription": "TrustFunds"
+    },
+    {
+      "instrumentTypeID": 9,
+      "instrumentTypeDescription": "Options"
+    },
+    {
+      "instrumentTypeID": 10,
+      "instrumentTypeDescription": "Crypto"
+    }
+  ]
+}

--- a/docs/research/etoro-instrument-samples/lookup_stocks-industries.json
+++ b/docs/research/etoro-instrument-samples/lookup_stocks-industries.json
@@ -1,0 +1,40 @@
+{
+  "stocksIndustries": [
+    {
+      "industryID": 1,
+      "industryName": "Basic Materials"
+    },
+    {
+      "industryID": 2,
+      "industryName": "Conglomerates"
+    },
+    {
+      "industryID": 3,
+      "industryName": "Consumer Goods"
+    },
+    {
+      "industryID": 4,
+      "industryName": "Financial"
+    },
+    {
+      "industryID": 5,
+      "industryName": "Healthcare"
+    },
+    {
+      "industryID": 6,
+      "industryName": "Industrial Goods"
+    },
+    {
+      "industryID": 7,
+      "industryName": "Services"
+    },
+    {
+      "industryID": 8,
+      "industryName": "Technology"
+    },
+    {
+      "industryID": 9,
+      "industryName": "Utilities"
+    }
+  ]
+}

--- a/docs/research/etoro-instrument-samples/uk_equity_7_BARC_L.json
+++ b/docs/research/etoro-instrument-samples/uk_equity_7_BARC_L.json
@@ -1,0 +1,49 @@
+{
+  "instrumentID": 2013,
+  "instrumentDisplayName": "Barclays",
+  "instrumentTypeID": 5,
+  "exchangeID": 7,
+  "images": [
+    {
+      "instrumentID": 2013,
+      "width": 35.0,
+      "height": 35.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/barc.l/35x35.png"
+    },
+    {
+      "instrumentID": 2013,
+      "width": 50.0,
+      "height": 50.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/barc.l/50x50.png"
+    },
+    {
+      "instrumentID": 2013,
+      "width": 80.0,
+      "height": 80.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/barc.l/80x80.png"
+    },
+    {
+      "instrumentID": 2013,
+      "width": 90.0,
+      "height": 90.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/barc.l/90x90.png"
+    },
+    {
+      "instrumentID": 2013,
+      "width": 150.0,
+      "height": 150.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/barc.l/150x150.png"
+    },
+    {
+      "instrumentID": 2013,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/2013/2013_00B0EC_F7F7F7.svg",
+      "backgroundColor": "#00B0EC",
+      "textColor": "#F7F7F7"
+    }
+  ],
+  "symbolFull": "BARC.L",
+  "stocksIndustryID": 4,
+  "priceSource": "LSE PLC",
+  "hasExpirationDate": false,
+  "isInternalInstrument": false
+}

--- a/docs/research/etoro-instrument-samples/us_equity_etf_20_ARKK.json
+++ b/docs/research/etoro-instrument-samples/us_equity_etf_20_ARKK.json
@@ -1,0 +1,37 @@
+{
+  "instrumentID": 3166,
+  "instrumentDisplayName": "ARK Innovation ETF",
+  "instrumentTypeID": 6,
+  "exchangeID": 20,
+  "images": [
+    {
+      "instrumentID": 3166,
+      "width": 35.0,
+      "height": 35.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/3166/35x35.png"
+    },
+    {
+      "instrumentID": 3166,
+      "width": 50.0,
+      "height": 50.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/3166/50x50.png"
+    },
+    {
+      "instrumentID": 3166,
+      "width": 150.0,
+      "height": 150.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/3166/150x150.png"
+    },
+    {
+      "instrumentID": 3166,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/3166/3166_F7F7F7_2C2C2C.svg",
+      "backgroundColor": "#F7F7F7",
+      "textColor": "#2C2C2C"
+    }
+  ],
+  "symbolFull": "ARKK",
+  "stocksIndustryID": 4,
+  "priceSource": "NASDAQ",
+  "hasExpirationDate": false,
+  "isInternalInstrument": false
+}

--- a/docs/research/etoro-instrument-samples/us_equity_stock_4_AAPL.json
+++ b/docs/research/etoro-instrument-samples/us_equity_stock_4_AAPL.json
@@ -1,0 +1,49 @@
+{
+  "instrumentID": 1001,
+  "instrumentDisplayName": "Apple",
+  "instrumentTypeID": 5,
+  "exchangeID": 4,
+  "images": [
+    {
+      "instrumentID": 1001,
+      "width": 35.0,
+      "height": 35.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/aapl/35x35.png"
+    },
+    {
+      "instrumentID": 1001,
+      "width": 80.0,
+      "height": 80.0,
+      "uri": "/medium/Apple.png"
+    },
+    {
+      "instrumentID": 1001,
+      "width": 50.0,
+      "height": 50.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/aapl/50x50.png"
+    },
+    {
+      "instrumentID": 1001,
+      "width": 150.0,
+      "height": 150.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/aapl/150x150.png"
+    },
+    {
+      "instrumentID": 1001,
+      "width": 90.0,
+      "height": 90.0,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/aapl/90x90.png"
+    },
+    {
+      "instrumentID": 1001,
+      "uri": "https://etoro-cdn.etorostatic.com/market-avatars/1001/1001_494D5A_F7F7F7.svg",
+      "backgroundColor": "#494D5A",
+      "textColor": "#F7F7F7"
+    }
+  ],
+  "symbolFull": "AAPL",
+  "stocksIndustryID": 3,
+  "priceSource": "NASDAQ",
+  "hasExpirationDate": false,
+  "isInternalInstrument": false
+}

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -533,6 +533,8 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
   - `etoro/candles_*` → `price_daily` (price_date, open, high, low, close, volume).
   - `etoro/rates_batch*` → `quotes` (instrument_id, bid, ask, last_execution, date).
   - `etoro/exchanges` → `exchanges` table (#503 PR 4: provider_id, description; operator-curated `country` + `asset_class` not derived from the API).
+  - `etoro/instrument-types` → `etoro_instrument_types` table (#515 PR 1: instrument_type_id, description).
+  - `etoro/stocks-industries` → `etoro_stocks_industries` table (#515 PR 1: industry_id, name).
   - `etoro_broker/etoro_portfolio` → `broker_positions` + `cash_ledger` + `copy_mirror_positions` (full position + cash + mirror snapshot).
 - **Rule remaining scope:** stands for `companies_house` and `fmp` whose SQL coverage is thinner; raw payloads still serve as parser substrate there until coverage audits land.
 - Enforced in: this prevention log

--- a/sql/070_etoro_lookup_tables.sql
+++ b/sql/070_etoro_lookup_tables.sql
@@ -1,0 +1,88 @@
+-- Migration 070 — eToro lookup tables (#515 PR 1).
+--
+-- The universe ingest stores ``stocksIndustryId`` as a raw
+-- integer in ``instruments.sector``. The frontend can't render a
+-- meaningful label without joining on eToro's lookup catalogues —
+-- see workstream 1 of
+-- docs/superpowers/specs/2026-04-26-complete-coverage-spec.md.
+--
+-- The eToro instruments endpoint also returns ``instrumentTypeID``
+-- (int) but NOT ``instrumentTypeName`` — confirmed against the
+-- live API in docs/research/etoro-instrument-samples/. Migration
+-- 068 added ``instruments.instrument_type`` (TEXT) speculatively
+-- on the assumption the name was returned; that column stays
+-- NULL across the universe in practice. This migration adds
+-- ``instruments.instrument_type_id`` (the field eToro actually
+-- returns) so the new ``etoro_instrument_types`` lookup is
+-- joinable on a stable int key.
+--
+-- These tables are operator-curated only via the refresh job —
+-- they're a thin reflection of eToro's catalogue with no extra
+-- columns. ``description`` / ``name`` are populated from the
+-- live API by ``app.services.etoro_lookups.refresh_etoro_lookups``;
+-- both columns nullable so the refresh job can insert id-only rows
+-- before its first successful body fetch.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS etoro_instrument_types (
+    instrument_type_id     INTEGER PRIMARY KEY,
+    description            TEXT,
+    seeded_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE etoro_instrument_types IS
+    'Reflection of eToro /api/v1/market-data/instrument-types. '
+    'Maps numeric instrumentTypeID (Forex / Commodity / CFD / '
+    'Indices / Stocks / ETF / Bonds / …) to the human-readable '
+    'description rendered on the instrument page. Refreshed weekly '
+    'by app.services.etoro_lookups.refresh_etoro_lookups.';
+
+CREATE TABLE IF NOT EXISTS etoro_stocks_industries (
+    industry_id            INTEGER PRIMARY KEY,
+    name                   TEXT,
+    seeded_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE etoro_stocks_industries IS
+    'Reflection of eToro /api/v1/market-data/stocks-industries. '
+    'Maps numeric industryID (Basic Materials / Healthcare / '
+    'Technology / …) to the human-readable industry name '
+    'rendered as the instrument-page sector label. Refreshed '
+    'weekly with the instrument-types catalogue.';
+
+-- ---------------------------------------------------------------
+-- instrument_type_id on instruments — the FK that lets us join.
+-- ---------------------------------------------------------------
+--
+-- Migration 068 added ``instruments.instrument_type`` (TEXT) for
+-- the human-readable name. PR 1 of #515 adds the numeric
+-- ``instrument_type_id`` so the frontend can join on a stable id
+-- rather than a text match (eToro changes labels occasionally;
+-- the int id is the durable key).
+--
+-- No FK constraint to ``etoro_instrument_types`` because the
+-- universe sync may run before the lookup refresh on a fresh DB
+-- (the universe ingest persists ids it sees; the lookup refresh
+-- is a separate weekly job). A FK would tie the two together and
+-- block universe sync until the lookup is populated.
+--
+-- Rollout: pre-070 rows have ``instrument_type_id = NULL`` until
+-- the next ``nightly_universe_sync`` run. That job is on-demand
+-- (operator triggers via Admin "Run now" or via the daily
+-- ``orchestrator_full_sync`` DAG walk; neither catches up on
+-- boot). The frontend renders NULL as "label unknown" — the
+-- column is additive, no breaking change.
+
+ALTER TABLE instruments
+    ADD COLUMN IF NOT EXISTS instrument_type_id INTEGER;
+
+COMMENT ON COLUMN instruments.instrument_type_id IS
+    'eToro instrumentTypeID. FK-style reference to '
+    'etoro_instrument_types(instrument_type_id) — no CONSTRAINT '
+    'because the universe ingest can run before the lookup '
+    'refresh on a fresh DB.';
+
+COMMIT;

--- a/tests/test_etoro_lookups.py
+++ b/tests/test_etoro_lookups.py
@@ -1,0 +1,241 @@
+"""Tests for eToro lookup-catalogue refresh (#515 PR 1).
+
+Covers:
+
+* Pure-unit normalisers for instrument-types + stocks-industries
+  responses — pin live wrapper shapes, raise on schema drift, skip
+  malformed rows.
+* ``refresh_etoro_lookups`` semantics — insert + update + no-op
+  branches, plus the empty-response no-clobber guard.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import psycopg
+import pytest
+
+from app.providers.implementations.etoro import (
+    _normalise_instrument_types,
+    _normalise_stocks_industries,
+)
+from app.providers.market_data import InstrumentTypeRecord, StocksIndustryRecord
+from app.services.etoro_lookups import LookupRefreshSummary, refresh_etoro_lookups
+
+# ---------------------------------------------------------------------------
+# _normalise_instrument_types
+# ---------------------------------------------------------------------------
+
+
+class TestNormaliseInstrumentTypes:
+    def test_live_wrapper_shape(self) -> None:
+        raw = {
+            "instrumentTypes": [
+                {"instrumentTypeID": 1, "instrumentTypeDescription": "Forex"},
+                {"instrumentTypeID": 5, "instrumentTypeDescription": "Stocks"},
+            ]
+        }
+        records = _normalise_instrument_types(raw)
+        assert len(records) == 2
+        assert records[0] == InstrumentTypeRecord(type_id=1, description="Forex")
+        assert records[1] == InstrumentTypeRecord(type_id=5, description="Stocks")
+
+    def test_bare_list_fallback(self) -> None:
+        """Accept the bare-list shape in case eToro aligns the
+        live API with their portal docs in the future."""
+        records = _normalise_instrument_types([{"instrumentTypeID": 6, "instrumentTypeDescription": "ETF"}])
+        assert records == [InstrumentTypeRecord(type_id=6, description="ETF")]
+
+    def test_unknown_wrapper_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="instrumentTypes"):
+            _normalise_instrument_types({"types": [{"instrumentTypeID": 1}]})
+
+    def test_unknown_top_shape_raises(self) -> None:
+        with pytest.raises(ValueError, match="Expected dict"):
+            _normalise_instrument_types("not a payload")
+
+    def test_skips_malformed(self) -> None:
+        raw = {
+            "instrumentTypes": [
+                {"instrumentTypeID": 1, "instrumentTypeDescription": "Forex"},
+                {"instrumentTypeDescription": "Missing ID"},
+                "not a dict",
+                {"instrumentTypeID": "not-an-int", "instrumentTypeDescription": "Bad ID"},
+                {"instrumentTypeID": 9, "instrumentTypeDescription": ""},
+            ]
+        }
+        records = _normalise_instrument_types(raw)
+        assert {r.type_id for r in records} == {1, 9}
+        # Empty description normalises to None.
+        rec_9 = next(r for r in records if r.type_id == 9)
+        assert rec_9.description is None
+
+
+# ---------------------------------------------------------------------------
+# _normalise_stocks_industries
+# ---------------------------------------------------------------------------
+
+
+class TestNormaliseStocksIndustries:
+    def test_live_wrapper_shape(self) -> None:
+        raw = {
+            "stocksIndustries": [
+                {"industryID": 1, "industryName": "Basic Materials"},
+                {"industryID": 8, "industryName": "Technology"},
+            ]
+        }
+        records = _normalise_stocks_industries(raw)
+        assert records == [
+            StocksIndustryRecord(industry_id=1, name="Basic Materials"),
+            StocksIndustryRecord(industry_id=8, name="Technology"),
+        ]
+
+    def test_unknown_wrapper_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="stocksIndustries"):
+            _normalise_stocks_industries({"industries": [{"industryID": 1}]})
+
+
+# ---------------------------------------------------------------------------
+# refresh_etoro_lookups — DB integration
+# ---------------------------------------------------------------------------
+
+
+def _seed_existing_type(conn: psycopg.Connection[tuple], *, type_id: int, description: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO etoro_instrument_types (instrument_type_id, description)
+            VALUES (%s, %s)
+            ON CONFLICT (instrument_type_id) DO UPDATE SET description = EXCLUDED.description
+            """,
+            (type_id, description),
+        )
+
+
+def _read_type(conn: psycopg.Connection[tuple], type_id: int) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT description FROM etoro_instrument_types WHERE instrument_type_id = %s",
+            (type_id,),
+        )
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def _read_industry(conn: psycopg.Connection[tuple], industry_id: int) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT name FROM etoro_stocks_industries WHERE industry_id = %s",
+            (industry_id,),
+        )
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def _cleanup(conn: psycopg.Connection[tuple], *, type_ids: list[int], industry_ids: list[int]) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM etoro_instrument_types WHERE instrument_type_id = ANY(%s)",
+            (type_ids,),
+        )
+        cur.execute(
+            "DELETE FROM etoro_stocks_industries WHERE industry_id = ANY(%s)",
+            (industry_ids,),
+        )
+    conn.commit()
+
+
+@pytest.mark.integration
+class TestRefreshEtoroLookups:
+    def test_inserts_new_types_and_industries(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        provider = MagicMock()
+        provider.get_instrument_types.return_value = [
+            InstrumentTypeRecord(type_id=9001, description="Test Type"),
+        ]
+        provider.get_stocks_industries.return_value = [
+            StocksIndustryRecord(industry_id=9001, name="Test Industry"),
+        ]
+        try:
+            summary = refresh_etoro_lookups(provider, ebull_test_conn)
+            ebull_test_conn.commit()
+            assert summary.instrument_types_inserted == 1
+            assert summary.industries_inserted == 1
+            assert _read_type(ebull_test_conn, 9001) == "Test Type"
+            assert _read_industry(ebull_test_conn, 9001) == "Test Industry"
+        finally:
+            _cleanup(ebull_test_conn, type_ids=[9001], industry_ids=[9001])
+
+    def test_updates_changed_description(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_existing_type(ebull_test_conn, type_id=9002, description="Old Label")
+        ebull_test_conn.commit()
+
+        provider = MagicMock()
+        provider.get_instrument_types.return_value = [
+            InstrumentTypeRecord(type_id=9002, description="New Label"),
+        ]
+        provider.get_stocks_industries.return_value = []
+        try:
+            summary = refresh_etoro_lookups(provider, ebull_test_conn)
+            ebull_test_conn.commit()
+            assert summary.instrument_types_updated == 1
+            assert summary.instrument_types_inserted == 0
+            assert _read_type(ebull_test_conn, 9002) == "New Label"
+        finally:
+            _cleanup(ebull_test_conn, type_ids=[9002], industry_ids=[])
+
+    def test_unchanged_description_is_noop(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_existing_type(ebull_test_conn, type_id=9003, description="Same")
+        ebull_test_conn.commit()
+
+        provider = MagicMock()
+        provider.get_instrument_types.return_value = [
+            InstrumentTypeRecord(type_id=9003, description="Same"),
+        ]
+        provider.get_stocks_industries.return_value = []
+        try:
+            summary = refresh_etoro_lookups(provider, ebull_test_conn)
+            ebull_test_conn.commit()
+            assert summary.instrument_types_inserted == 0
+            assert summary.instrument_types_updated == 0
+        finally:
+            _cleanup(ebull_test_conn, type_ids=[9003], industry_ids=[])
+
+    def test_blank_description_does_not_clobber(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Partial response that omits the description for a row
+        must NOT erase a previously-known label. COALESCE in the
+        upsert preserves the existing value when EXCLUDED is NULL.
+        Same shape as the exchanges-service guard from #503 PR 4."""
+        _seed_existing_type(ebull_test_conn, type_id=9004, description="Real Label")
+        ebull_test_conn.commit()
+
+        provider = MagicMock()
+        provider.get_instrument_types.return_value = [
+            InstrumentTypeRecord(type_id=9004, description=None),
+        ]
+        provider.get_stocks_industries.return_value = []
+        try:
+            summary = refresh_etoro_lookups(provider, ebull_test_conn)
+            ebull_test_conn.commit()
+            assert summary.instrument_types_inserted == 0
+            assert summary.instrument_types_updated == 0
+            assert _read_type(ebull_test_conn, 9004) == "Real Label"
+        finally:
+            _cleanup(ebull_test_conn, type_ids=[9004], industry_ids=[])
+
+    def test_empty_response_writes_nothing(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Both endpoints returning zero rows must NOT clobber any
+        existing label data."""
+        _seed_existing_type(ebull_test_conn, type_id=9005, description="Persists")
+        ebull_test_conn.commit()
+
+        provider = MagicMock()
+        provider.get_instrument_types.return_value = []
+        provider.get_stocks_industries.return_value = []
+        try:
+            summary = refresh_etoro_lookups(provider, ebull_test_conn)
+            ebull_test_conn.commit()
+            assert summary == LookupRefreshSummary(0, 0, 0, 0, 0, 0)
+            assert _read_type(ebull_test_conn, 9005) == "Persists"
+        finally:
+            _cleanup(ebull_test_conn, type_ids=[9005], industry_ids=[])

--- a/tests/test_universe_normaliser.py
+++ b/tests/test_universe_normaliser.py
@@ -204,6 +204,7 @@ def _make_record(
     provider_id: str,
     symbol: str,
     instrument_type: str | None,
+    instrument_type_id: int | None = None,
 ) -> InstrumentRecord:
     return InstrumentRecord(
         provider_id=provider_id,
@@ -216,6 +217,7 @@ def _make_record(
         country=None,
         is_tradable=True,
         instrument_type=instrument_type,
+        instrument_type_id=instrument_type_id,
     )
 
 
@@ -223,6 +225,17 @@ def _read_instrument_type(conn: psycopg.Connection[tuple], instrument_id: int) -
     with conn.cursor() as cur:
         cur.execute(
             "SELECT instrument_type FROM instruments WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return row[0]
+
+
+def _read_instrument_type_id(conn: psycopg.Connection[tuple], instrument_id: int) -> int | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT instrument_type_id FROM instruments WHERE instrument_id = %s",
             (instrument_id,),
         )
         row = cur.fetchone()
@@ -283,3 +296,75 @@ class TestUniverseInstrumentTypeUpsert:
         ebull_test_conn.commit()
 
         assert _read_instrument_type(ebull_test_conn, 950003) == "ETF"
+
+    def test_initial_insert_persists_instrument_type_id(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """instrument_type_id ships alongside the text label so the
+        new lookup-table join works on a stable int key (#515 PR 1)."""
+        provider = MagicMock()
+        provider.get_tradable_instruments.return_value = [
+            _make_record(
+                provider_id="950010",
+                symbol="ZZZ10",
+                instrument_type="Stocks",
+                instrument_type_id=5,
+            ),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_instrument_type_id(ebull_test_conn, 950010) == 5
+
+    def test_subsequent_null_id_does_not_clobber(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """COALESCE protects instrument_type_id the same way it
+        protects instrument_type — a transient response without
+        instrumentTypeID must NOT erase a previously-known value."""
+        provider = MagicMock()
+        provider.get_tradable_instruments.return_value = [
+            _make_record(
+                provider_id="950011",
+                symbol="ZZZ11",
+                instrument_type="Crypto",
+                instrument_type_id=10,
+            ),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_instrument_type_id(ebull_test_conn, 950011) == 10
+
+        provider.get_tradable_instruments.return_value = [
+            _make_record(
+                provider_id="950011",
+                symbol="ZZZ11",
+                instrument_type=None,
+                instrument_type_id=None,
+            ),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_instrument_type_id(ebull_test_conn, 950011) == 10
+
+    def test_subsequent_id_change_overwrites(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A real id change (eToro reclassifies the instrument) still
+        propagates — COALESCE only blocks NULL clobbers."""
+        provider = MagicMock()
+        provider.get_tradable_instruments.return_value = [
+            _make_record(
+                provider_id="950012",
+                symbol="ZZZ12",
+                instrument_type="Stocks",
+                instrument_type_id=5,
+            ),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+
+        provider.get_tradable_instruments.return_value = [
+            _make_record(
+                provider_id="950012",
+                symbol="ZZZ12",
+                instrument_type="ETF",
+                instrument_type_id=6,
+            ),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_instrument_type_id(ebull_test_conn, 950012) == 6


### PR DESCRIPTION
## What

PR 1 of #515 spec workstream 1. Three deliverables — lookup-table ingest, provider-interface widening, field-coverage matrix.

## Why

Frontend renders raw integer ids ("42") where Bloomberg renders "Pharmaceuticals". eToro publishes lookup catalogues for both `instrumentTypeID` and `stocksIndustryId`; ingesting them lets the frontend do meaningful joins.

Investigation surfaced that migration 068 made a speculative claim — the eToro instruments endpoint does NOT return `instrumentTypeName`, only the int. The text column from 068 stays NULL; the new int column + lookup join is the canonical path.

## Test plan

- [x] `uv run ruff check .` / `ruff format --check` / `pyright` — clean
- [x] `uv run pytest tests/test_etoro_lookups.py tests/test_universe_normaliser.py tests/test_exchanges_service.py tests/test_jobs_runtime.py tests/smoke/test_app_boots.py` — 78 passed
- [x] Live refresh against eToro: 10 instrument types + 9 industries populated on dev DB
- [x] Codex review — 4 rounds, structural finds (ABC widening, column drift, scheduler-comment accuracy, instrumentTypeName myth) all addressed

## Follow-up tickets

Each "📦 available, dropped" row in the matrix doc gets its own ticket post-operator-review:
- `priceSource`, `images`, `hasExpirationDate`, `instrumentTypeSubCategoryID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)