### PR TITLE
feat(#515-pr3a): capability schema + per-instrument resolver + summary endpoint

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -166,6 +166,18 @@ class InstrumentCandles(BaseModel):
     rows: list[CandleBar]
 
 
+class CapabilityCellPayload(BaseModel):
+    """One (capability × instrument) cell in the summary response.
+
+    Mirrors ``app.services.capabilities.CapabilityCell`` — the API
+    layer translates the dataclass to this Pydantic model so the
+    OpenAPI schema is generated correctly.
+    """
+
+    providers: list[str]
+    data_present: dict[str, bool]
+
+
 class InstrumentSummary(BaseModel):
     """Per-ticker research summary.
 
@@ -206,6 +218,16 @@ class InstrumentSummary(BaseModel):
     # provider later doesn't bake in a follow-up.
     has_sec_cik: bool
     has_filings_coverage: bool
+    # Per-capability resolution (#515 PR 3). Keyed by capability
+    # name (filings / fundamentals / dividends / …); each value
+    # carries the operator-decided ``providers`` list and a
+    # per-provider ``data_present`` dict. Frontend renders a
+    # panel iff providers is non-empty AND any data_present
+    # value is true. has_sec_cik / has_filings_coverage above are
+    # kept for now as a thin shim during the migration window;
+    # PR 3b retires them once frontend reads ``capabilities``
+    # directly.
+    capabilities: dict[str, CapabilityCellPayload]
 
 
 class InstrumentDetail(BaseModel):
@@ -1782,6 +1804,17 @@ def get_instrument_summary(
     has_sec_cik = _has_sec_cik(conn, instrument_id_int)
     has_filings_coverage = _has_filings_coverage(conn, instrument_id_int)
 
+    # Per-capability resolution (#515 PR 3). Frontend gates panels
+    # on providers + data_present rather than the older has_sec_cik
+    # / has_filings_coverage shim. Latter kept in the response for
+    # the migration window — PR 3b retires them once frontend reads
+    # ``capabilities`` directly.
+    capabilities = _resolve_capabilities_payload(
+        conn,
+        instrument_id=instrument_id_int,
+        exchange_id=identity.exchange,
+    )
+
     return InstrumentSummary(
         instrument_id=row["instrument_id"],  # type: ignore[arg-type]
         is_tradable=row["is_tradable"],  # type: ignore[arg-type]
@@ -1792,7 +1825,44 @@ def get_instrument_summary(
         source=source,
         has_sec_cik=has_sec_cik,
         has_filings_coverage=has_filings_coverage,
+        capabilities=capabilities,
     )
+
+
+def _resolve_capabilities_payload(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    *,
+    instrument_id: int,
+    exchange_id: str | None,
+) -> dict[str, CapabilityCellPayload]:
+    """Translate the resolver dataclass into the Pydantic payload.
+
+    When the instrument's exchange is unknown (e.g. NULL exchange
+    column from a partial universe sync), every capability comes
+    back with empty ``providers`` — the resolver still runs so the
+    response shape is uniform.
+    """
+    from app.services.capabilities import resolve_capabilities
+
+    # Pass an unmatchable sentinel for NULL-exchange rows so the
+    # resolver still runs — per-instrument augmentation via
+    # ``external_identifiers`` (e.g. a SEC CIK) must flow through
+    # even when the exchange row is missing. Codex round-1 finding
+    # on PR #5XX: returning empty cells short-circuited the SEC
+    # CIK augment and contradicted has_sec_cik on partially-synced
+    # instruments.
+    resolved = resolve_capabilities(
+        conn,
+        instrument_id=instrument_id,
+        exchange_id=exchange_id if exchange_id is not None else "",
+    )
+    return {
+        cap: CapabilityCellPayload(
+            providers=list(cell.providers),
+            data_present=cell.data_present,
+        )
+        for cap, cell in resolved.cells.items()
+    }
 
 
 @router.get("/{instrument_id}", response_model=InstrumentDetail)

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -1830,7 +1830,7 @@ def get_instrument_summary(
 
 
 def _resolve_capabilities_payload(
-    conn: psycopg.Connection,  # type: ignore[type-arg]
+    conn: psycopg.Connection[object],
     *,
     instrument_id: int,
     exchange_id: str | None,

--- a/app/services/capabilities.py
+++ b/app/services/capabilities.py
@@ -1,0 +1,337 @@
+"""Per-instrument capability resolution (#515 PR 3).
+
+The instrument-summary endpoint returns, for every v1 capability,
+two fields:
+
+* ``providers``: ordered list of provider tags from
+  ``CAPABILITY_PROVIDERS`` — the operator-decided source list,
+  possibly including providers that aren't yet wired.
+* ``data_present``: dict keyed identically to ``providers``, value
+  is a bool indicating whether ingest has landed at least one row
+  for this instrument from that provider.
+
+Frontend renders the panel iff
+``providers.length > 0 AND any(data_present.values())``.
+
+Resolution = exchange row's default ∪ per-instrument
+``external_identifiers`` facts. A cross-listed instrument with
+both a Companies House number AND a SEC CIK gets BOTH providers
+in its ``filings`` list automatically.
+
+This module is the single helper API consumers go through; the
+schema migration (sql/071) seeds the exchange-row defaults; the
+data-presence dict is computed via SQL EXISTS at API time per
+provider.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import psycopg
+
+# Closed set of provider tags. Empty list (= []) is the canonical
+# absence-of-provider state — covers both "no public source
+# available on this venue" AND "available but not decision-
+# relevant on this venue, operator deferred". Never use [None],
+# "none", or any sentinel string.
+CapabilityProvider = Literal[
+    # US — SEC family
+    "sec_edgar",  # filings index → filing_events
+    "sec_xbrl",  # fundamentals → financial_periods
+    "sec_dividend_summary",  # dividends → instrument_dividend_summary
+    "sec_8k_events",
+    "sec_10k_item1",
+    "sec_form4",
+    "sec_13f",
+    "sec_13d_13g",
+    # US — non-SEC enrichment
+    "fmp",
+    # UK
+    "companies_house",
+    "lse_rns",
+    # EU
+    "esma",
+    "bafin",
+    "amf",
+    "consob",
+    # Asia
+    "hkex",
+    "tdnet",
+    "edinet",
+    "asx",
+    "krx",
+    "kind",
+    "twse",
+    "mops",
+    "sse",
+    "szse",
+    "nse_india",
+    "bse_india",
+    "sgx",
+    # MENA
+    "tadawul",
+    "adx",
+    "dfm",
+    # Crypto
+    "coingecko",
+    "glassnode",
+    # Commodity / FX
+    "cme",
+    "lme",
+    "ecb",
+    "fed",
+    "boe",
+    # Canada
+    "tmx_group",
+    "sedar_plus",
+]
+
+
+# v1 capability keys — fixed at 11. options + short_interest are
+# explicitly deferred to a follow-up spec; news is tracked under
+# #198 via a separate always-on surface.
+CapabilityName = Literal[
+    "filings",
+    "fundamentals",
+    "dividends",
+    "insider",
+    "analyst",
+    "ratings",
+    "esg",
+    "ownership",
+    "corporate_events",
+    "business_summary",
+    "officers",
+]
+
+V1_CAPABILITIES: tuple[CapabilityName, ...] = (
+    "filings",
+    "fundamentals",
+    "dividends",
+    "insider",
+    "analyst",
+    "ratings",
+    "esg",
+    "ownership",
+    "corporate_events",
+    "business_summary",
+    "officers",
+)
+
+
+# Allowed provider tags as a set for runtime validation. The Python
+# Literal above is the type-check guard; this set is the runtime
+# guard the resolver uses to refuse a row whose JSONB has drifted
+# (e.g. a manual operator UPDATE that typo'd a provider name).
+_ALLOWED_PROVIDERS: frozenset[str] = frozenset(
+    CapabilityProvider.__args__,  # type: ignore[attr-defined]
+)
+
+
+@dataclass(frozen=True)
+class CapabilityCell:
+    """One (capability × instrument) cell in the summary response.
+
+    Mirrors the JSON shape the API returns — tests read these
+    directly to assert on the contract without re-parsing JSON.
+    """
+
+    providers: tuple[str, ...]
+    data_present: dict[str, bool]
+
+
+@dataclass(frozen=True)
+class ResolvedCapabilities:
+    """All 11 v1 capabilities resolved for one instrument."""
+
+    cells: dict[CapabilityName, CapabilityCell]
+
+
+# Mapping from (capability, provider) tuple to the SQL EXISTS
+# test that says "is there at least one row this instrument has
+# from this source for this capability?". Keyed on the tuple
+# because one provider tag (e.g. ``fmp``) can serve multiple
+# capabilities by reading different tables (``fundamentals_snapshot``
+# for ``fundamentals`` vs ``analyst_estimates`` for ``analyst``) —
+# a flat-per-provider lookup misreports ``analyst`` coverage off
+# fundamentals data alone (Codex round-2 finding on PR 3a).
+#
+# Capability-agnostic providers (``sec_xbrl`` / ``sec_form4`` etc.)
+# repeat the same SQL across the (capability, provider) pairs they
+# back; the duplication is intentional — the lookup is by tuple,
+# not by provider.
+#
+# Adding a new provider means adding rows here for every
+# capability it serves AND in the Literal above. Out-of-sync = the
+# type checker catches it (resolver narrows on ``_ALLOWED_PROVIDERS``).
+_PRESENCE_QUERIES: dict[tuple[str, str], str] = {
+    # SEC family — wired per #506.
+    ("filings", "sec_edgar"): ("SELECT EXISTS(SELECT 1 FROM filing_events f WHERE f.instrument_id = %s)"),
+    ("fundamentals", "sec_xbrl"): ("SELECT EXISTS(SELECT 1 FROM financial_periods f WHERE f.instrument_id = %s)"),
+    ("dividends", "sec_dividend_summary"): (
+        "SELECT EXISTS(SELECT 1 FROM instrument_dividend_summary d WHERE d.instrument_id = %s)"
+    ),
+    ("corporate_events", "sec_8k_events"): (
+        "SELECT EXISTS(SELECT 1 FROM eight_k_filings e WHERE e.instrument_id = %s)"
+    ),
+    ("business_summary", "sec_10k_item1"): (
+        "SELECT EXISTS(SELECT 1 FROM instrument_business_summary b WHERE b.instrument_id = %s)"
+    ),
+    ("insider", "sec_form4"): ("SELECT EXISTS(SELECT 1 FROM insider_transactions t WHERE t.instrument_id = %s)"),
+    # ``ownership`` (sec_13f / sec_13d_13g) — no eBull table yet,
+    # falls through to the dict-miss → False branch below.
+    # FMP serves two capabilities via two different tables.
+    ("fundamentals", "fmp"): ("SELECT EXISTS(SELECT 1 FROM fundamentals_snapshot s WHERE s.instrument_id = %s)"),
+    ("analyst", "fmp"): ("SELECT EXISTS(SELECT 1 FROM analyst_estimates a WHERE a.instrument_id = %s)"),
+    # UK / EU / Asia / MENA / crypto / commodity / FX / Canada
+    # providers — no eBull tables yet for any of these, so missing
+    # entries fall through to ``data_present = False`` via the
+    # default branch in ``_compute_data_present``. Each per-region
+    # integration PR lands an entry above for the (capability,
+    # provider) pair it newly wires.
+}
+
+
+def resolve_capabilities(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    *,
+    instrument_id: int,
+    exchange_id: str,
+) -> ResolvedCapabilities:
+    """Resolve the full capability set for one instrument.
+
+    1. Reads ``exchanges.capabilities`` for the instrument's
+       exchange row (the per-exchange_id default).
+    2. Augments via per-instrument ``external_identifiers`` facts
+       (e.g. an LSE-listed ADR with a SEC CIK adds ``sec_xbrl`` /
+       ``sec_form4`` to its ``filings`` / ``insider`` lists).
+    3. Computes ``data_present[provider]`` for every provider in
+       the resulting list via the per-provider EXISTS query.
+
+    Returns ``ResolvedCapabilities`` — frontend gates panels on
+    ``providers AND any(data_present.values())``.
+    """
+    raw_capabilities: dict[str, list[str]] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT capabilities FROM exchanges WHERE exchange_id = %s",
+            (exchange_id,),
+        )
+        row = cur.fetchone()
+    if row is not None and isinstance(row[0], dict):
+        raw_capabilities = row[0]
+
+    # Augment via external_identifiers — each (provider,
+    # identifier_type) row signals additional provider coverage on
+    # the instrument. Today only SEC CIK is wired this way; future
+    # per-region integrations file their own external_identifiers
+    # entries. Filter on identifier_type='cik' to match every
+    # other SEC gate in the codebase (per #506) — a non-CIK SEC
+    # row (e.g. a future SEC EDGAR accession number) would NOT
+    # imply full SEC capability coverage.
+    # Filter on (provider='sec', identifier_type='cik',
+    # is_primary=TRUE) to match _has_sec_cik() in app/api/instruments.py
+    # — every SEC gate in the codebase trusts only the primary
+    # CIK. The schema preserves historical non-primary CIKs (per
+    # sql/003_external_identifiers.sql) but they don't imply
+    # current SEC coverage.
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT provider, identifier_type, is_primary
+              FROM external_identifiers
+             WHERE instrument_id = %s
+            """,
+            (instrument_id,),
+        )
+        ext_rows = cur.fetchall()
+
+    augmentations: dict[CapabilityName, list[str]] = {}
+    for ext_provider, ext_identifier_type, ext_is_primary in ext_rows:
+        if ext_provider == "sec" and ext_identifier_type == "cik" and ext_is_primary:
+            # A primary SEC CIK on a non-US-equity instrument
+            # (e.g. an LSE-listed Chinese ADR) adds the SEC
+            # capabilities to whatever the exchange row already
+            # provides.
+            augmentations.setdefault("filings", []).append("sec_edgar")
+            augmentations.setdefault("fundamentals", []).extend(["sec_xbrl", "fmp"])
+            augmentations.setdefault("dividends", []).append("sec_dividend_summary")
+            augmentations.setdefault("insider", []).append("sec_form4")
+            augmentations.setdefault("ownership", []).extend(["sec_13f", "sec_13d_13g"])
+            augmentations.setdefault("corporate_events", []).append("sec_8k_events")
+            augmentations.setdefault("business_summary", []).append("sec_10k_item1")
+            augmentations.setdefault("analyst", []).append("fmp")
+
+    cells: dict[CapabilityName, CapabilityCell] = {}
+    for cap in V1_CAPABILITIES:
+        seen: set[str] = set()
+        ordered: list[str] = []
+
+        # Defensive merge of exchange-row + augmentation lists.
+        # If an operator override has typoed the JSON shape (e.g.
+        # ``"filings": null`` or ``"filings": "sec_xbrl"`` instead
+        # of a list), skip silently rather than 500 — admin UI
+        # surfaces overrides so the operator can fix without
+        # breaking the instrument page.
+        from_exchange = raw_capabilities.get(cap)
+        from_augment = augmentations.get(cap, [])
+        merged: list[str] = []
+        if isinstance(from_exchange, list):
+            merged.extend(from_exchange)
+        merged.extend(from_augment)
+
+        for raw_provider in merged:
+            if not isinstance(raw_provider, str):
+                continue
+            if raw_provider not in _ALLOWED_PROVIDERS:
+                continue
+            if raw_provider in seen:
+                continue
+            seen.add(raw_provider)
+            ordered.append(raw_provider)
+
+        data_present = _compute_data_present(
+            conn,
+            instrument_id=instrument_id,
+            capability=cap,
+            providers=ordered,
+        )
+        cells[cap] = CapabilityCell(providers=tuple(ordered), data_present=data_present)
+
+    return ResolvedCapabilities(cells=cells)
+
+
+def _compute_data_present(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    *,
+    instrument_id: int,
+    capability: str,
+    providers: list[str],
+) -> dict[str, bool]:
+    """Per-(capability, provider) EXISTS check for one instrument.
+
+    Each (capability, provider) tuple has its own SQL EXISTS query
+    in ``_PRESENCE_QUERIES``. Tuples without a wired entry report
+    ``False`` — the panel stays hidden until each per-region
+    integration PR lands a real EXISTS query for the pair.
+
+    The (capability, provider) keying matters because the same
+    provider tag can serve multiple capabilities by reading
+    different tables — ``fmp`` backs both ``fundamentals``
+    (fundamentals_snapshot) and ``analyst`` (analyst_estimates).
+    A flat-per-provider lookup misreports analyst coverage from
+    fundamentals data (Codex round 2 finding on PR 3a).
+    """
+    out: dict[str, bool] = {}
+    for provider in providers:
+        query = _PRESENCE_QUERIES.get((capability, provider))
+        if query is None:
+            out[provider] = False
+            continue
+        with conn.cursor() as cur:
+            cur.execute(query, (instrument_id,))
+            row = cur.fetchone()
+        out[provider] = bool(row[0]) if row else False
+    return out

--- a/app/services/capabilities.py
+++ b/app/services/capabilities.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from typing import Literal
 
 import psycopg
+import psycopg.rows
+import psycopg.sql
 
 # Closed set of provider tags. Empty list (= []) is the canonical
 # absence-of-provider state — covers both "no public source
@@ -195,7 +197,7 @@ _PRESENCE_QUERIES: dict[tuple[str, str], str] = {
 
 
 def resolve_capabilities(
-    conn: psycopg.Connection,  # type: ignore[type-arg]
+    conn: psycopg.Connection[object],
     *,
     instrument_id: int,
     exchange_id: str,
@@ -214,7 +216,7 @@ def resolve_capabilities(
     ``providers AND any(data_present.values())``.
     """
     raw_capabilities: dict[str, list[str]] = {}
-    with conn.cursor() as cur:
+    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
         cur.execute(
             "SELECT capabilities FROM exchanges WHERE exchange_id = %s",
             (exchange_id,),
@@ -237,7 +239,7 @@ def resolve_capabilities(
     # CIK. The schema preserves historical non-primary CIKs (per
     # sql/003_external_identifiers.sql) but they don't imply
     # current SEC coverage.
-    with conn.cursor() as cur:
+    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
         cur.execute(
             """
             SELECT provider, identifier_type, is_primary
@@ -304,7 +306,7 @@ def resolve_capabilities(
 
 
 def _compute_data_present(
-    conn: psycopg.Connection,  # type: ignore[type-arg]
+    conn: psycopg.Connection[object],
     *,
     instrument_id: int,
     capability: str,
@@ -330,8 +332,12 @@ def _compute_data_present(
         if query is None:
             out[provider] = False
             continue
-        with conn.cursor() as cur:
-            cur.execute(query, (instrument_id,))
+        # Wrap in psycopg.sql.SQL so pyright accepts the str-typed
+        # value from the dict lookup as a valid execute() query —
+        # the dict values are all hand-authored constants in this
+        # module so they're known-safe to wrap as SQL.
+        with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+            cur.execute(psycopg.sql.SQL(query), (instrument_id,))  # type: ignore[arg-type]
             row = cur.fetchone()
         out[provider] = bool(row[0]) if row else False
     return out

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -244,6 +244,21 @@ export interface InstrumentKeyStats {
   field_source?: Record<string, KeyStatsFieldSource> | null;
 }
 
+/** One (capability × instrument) cell in the summary response.
+ *  Mirrors `app.services.capabilities.CapabilityCell` (#515 PR 3).
+ */
+export interface CapabilityCell {
+  /** Operator-decided source list (possibly empty if no source
+   *  picked, possibly multi-source). Closed enum kept loose
+   *  here as `string[]` so a future provider added in a follow-up
+   *  PR doesn't force a frontend release at the same time. */
+  providers: string[];
+  /** Per-provider data-presence (keyed identically to providers).
+   *  True iff at least one row has been ingested for this
+   *  instrument from this provider. */
+  data_present: Record<string, boolean>;
+}
+
 export interface InstrumentSummary {
   instrument_id: number;
   is_tradable: boolean;
@@ -256,14 +271,27 @@ export interface InstrumentSummary {
    *  external_identifiers. Frontend uses this to gate
    *  SEC-specific panels (SecProfile, InsiderActivity,
    *  Dividends, business summary). Crypto + non-US instruments
-   *  see false. */
+   *  see false.
+   *  Deprecated: prefer reading `capabilities` per-cell.
+   *  PR 3b retires this field once frontend reads `capabilities`
+   *  directly. */
   has_sec_cik: boolean;
   /** True iff any filings provider has rows for the instrument
    *  (today: SEC; tomorrow: Companies House / regional). Gates
    *  the source-agnostic Filings tab + right-rail "recent
    *  filings" widget. Wider than has_sec_cik so adding a non-SEC
-   *  filings provider later doesn't bake in a follow-up. */
+   *  filings provider later doesn't bake in a follow-up.
+   *  Deprecated: prefer reading `capabilities.filings`.
+   *  PR 3b retires this field once frontend reads `capabilities`
+   *  directly. */
   has_filings_coverage: boolean;
+  /** Per-capability resolution (#515 PR 3). Keyed by capability
+   *  name (one of the 11 v1 keys: filings / fundamentals /
+   *  dividends / insider / analyst / ratings / esg / ownership /
+   *  corporate_events / business_summary / officers). Frontend
+   *  renders a panel iff `providers.length > 0` AND any
+   *  `data_present` value is true. */
+  capabilities: Record<string, CapabilityCell>;
 }
 
 // #316 Slice A — daily OHLCV bars

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -45,6 +45,19 @@ function summary(overrides: Partial<InstrumentSummary> = {}): InstrumentSummary 
     source: { identity: "local_db", price: "quotes", key_stats: "unavailable" },
     has_sec_cik: true,
     has_filings_coverage: true,
+    capabilities: {
+      filings: { providers: ["sec_edgar"], data_present: { sec_edgar: true } },
+      fundamentals: { providers: [], data_present: {} },
+      dividends: { providers: [], data_present: {} },
+      insider: { providers: [], data_present: {} },
+      analyst: { providers: [], data_present: {} },
+      ratings: { providers: [], data_present: {} },
+      esg: { providers: [], data_present: {} },
+      ownership: { providers: [], data_present: {} },
+      corporate_events: { providers: [], data_present: {} },
+      business_summary: { providers: [], data_present: {} },
+      officers: { providers: [], data_present: {} },
+    },
     ...overrides,
   };
 }

--- a/sql/071_exchanges_capabilities.sql
+++ b/sql/071_exchanges_capabilities.sql
@@ -1,0 +1,107 @@
+-- Migration 071 — exchanges.capabilities JSONB column (#515 PR 3a).
+--
+-- Adds the per-exchange_id capability defaults the per-instrument
+-- ``resolve_capabilities()`` helper unions with
+-- ``external_identifiers`` facts to drive frontend panel gating.
+-- See workstream 3 of
+-- docs/superpowers/specs/2026-04-26-complete-coverage-spec.md.
+--
+-- Shape: ``capabilities`` is a JSONB object keyed by capability
+-- name (one of the 11 v1 keys) → list of provider tags from the
+-- ``CAPABILITY_PROVIDERS`` enum (see app/services/capabilities.py).
+-- Empty list = "no source picked" (covers both "no public source
+-- available" AND "available but not decision-relevant").
+--
+-- The CHECK constraint validates only the OUTER shape — that
+-- ``capabilities`` is a JSONB object, not an array or scalar. The
+-- enum-membership check on the values lives in Python at the
+-- service boundary (app/services/capabilities.py); enforcing it
+-- in SQL would require a CHECK that walks every list value via
+-- a JSONB function and would still need updating each time the
+-- enum grows. Python-side guard is cheaper to maintain.
+--
+-- Seed: every exchange row gets a default capability set for its
+-- asset_class, sourced from the workstream 2 matrix at
+-- docs/per-exchange-capability-matrix.md. Operator can override
+-- per row directly via the admin UI (PR 3b).
+--
+-- ``us_equity`` rows get the SEC + FMP coverage that's already
+-- wired in eBull. Every other asset_class lands with a mostly-
+-- empty default per the matrix's pre-decided cells; the per-region
+-- investigation tickets (#516-#523) fill in the rest.
+
+BEGIN;
+
+ALTER TABLE exchanges
+    ADD COLUMN IF NOT EXISTS capabilities JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE exchanges
+    DROP CONSTRAINT IF EXISTS exchanges_capabilities_is_object;
+
+ALTER TABLE exchanges
+    ADD CONSTRAINT exchanges_capabilities_is_object
+        CHECK (jsonb_typeof(capabilities) = 'object');
+
+COMMENT ON COLUMN exchanges.capabilities IS
+    'Per-exchange_id capability defaults (#515 PR 3). JSONB '
+    'object keyed by capability name (filings / fundamentals / '
+    'dividends / insider / analyst / ratings / esg / ownership / '
+    'corporate_events / business_summary / officers) → list of '
+    'provider tags from CAPABILITY_PROVIDERS. Empty list = no '
+    'source picked. resolve_capabilities() unions this with '
+    'external_identifiers per instrument at API time.';
+
+-- ---------------------------------------------------------------
+-- Seed defaults from the workstream 2 matrix.
+-- ---------------------------------------------------------------
+--
+-- ``us_equity`` venues get the full SEC + FMP coverage map.
+-- Every other asset_class lands with the matrix's pre-decided
+-- empties (most cells empty, rationale recorded in the matrix
+-- doc; per-region tickets fill the rest later).
+--
+-- Idempotency: only seed rows where ``capabilities`` is still
+-- the empty default ``'{}'::jsonb``. An operator override or a
+-- prior migration run is preserved.
+
+UPDATE exchanges
+   SET capabilities = jsonb_build_object(
+           'filings',          jsonb_build_array('sec_edgar'),
+           'fundamentals',     jsonb_build_array('sec_xbrl', 'fmp'),
+           'dividends',        jsonb_build_array('sec_dividend_summary'),
+           'insider',          jsonb_build_array('sec_form4'),
+           'analyst',          jsonb_build_array('fmp'),
+           'ratings',          jsonb_build_array(),
+           'esg',              jsonb_build_array(),
+           'ownership',        jsonb_build_array('sec_13f', 'sec_13d_13g'),
+           'corporate_events', jsonb_build_array('sec_8k_events'),
+           'business_summary', jsonb_build_array('sec_10k_item1'),
+           'officers',         jsonb_build_array()
+       ),
+       updated_at = NOW()
+ WHERE asset_class = 'us_equity'
+   AND capabilities = '{}'::jsonb;
+
+-- Non-us_equity rows: seed the empty-but-correctly-shaped object
+-- so the resolve helper doesn't have to special-case missing
+-- keys. Each per-region ticket UPDATEs its venues with the
+-- decided provider lists once investigation lands.
+UPDATE exchanges
+   SET capabilities = jsonb_build_object(
+           'filings',          jsonb_build_array(),
+           'fundamentals',     jsonb_build_array(),
+           'dividends',        jsonb_build_array(),
+           'insider',          jsonb_build_array(),
+           'analyst',          jsonb_build_array(),
+           'ratings',          jsonb_build_array(),
+           'esg',              jsonb_build_array(),
+           'ownership',        jsonb_build_array(),
+           'corporate_events', jsonb_build_array(),
+           'business_summary', jsonb_build_array(),
+           'officers',         jsonb_build_array()
+       ),
+       updated_at = NOW()
+ WHERE asset_class <> 'us_equity'
+   AND capabilities = '{}'::jsonb;
+
+COMMIT;

--- a/tests/test_capabilities_resolver.py
+++ b/tests/test_capabilities_resolver.py
@@ -1,0 +1,528 @@
+"""Tests for the per-instrument capability resolver (#515 PR 3).
+
+Pins the contract:
+
+1. Exchange-row defaults flow through to the resolved cell.
+2. ``external_identifiers`` SEC CIK augments the cell with the
+   SEC family providers (filings/fundamentals/dividends/insider/
+   ownership/corporate_events/business_summary/analyst).
+3. Multi-source augmentation (LSE row + SEC CIK) yields BOTH
+   provider sets in ``providers`` without duplicates.
+4. ``data_present`` reports True iff the wired SQL EXISTS query
+   returns true for the instrument.
+5. Unknown / drifted provider tags are silently skipped (operator-
+   override safety net).
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.services.capabilities import (
+    V1_CAPABILITIES,
+    resolve_capabilities,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_exchange_with_capabilities(
+    conn: psycopg.Connection[tuple],
+    *,
+    exchange_id: str,
+    asset_class: str,
+    capabilities: dict[str, list[str]],
+) -> None:
+    """Insert (or reset) one exchange row with explicit capabilities."""
+    import json as _json
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO exchanges (exchange_id, asset_class, capabilities)
+            VALUES (%s, %s, %s::jsonb)
+            ON CONFLICT (exchange_id) DO UPDATE SET
+                asset_class  = EXCLUDED.asset_class,
+                capabilities = EXCLUDED.capabilities
+            """,
+            (exchange_id, asset_class, _json.dumps(capabilities)),
+        )
+
+
+def _seed_instrument(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    symbol: str,
+    exchange: str,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable)
+            VALUES (%s, %s, %s, %s, TRUE)
+            """,
+            (instrument_id, symbol, f"Test {symbol}", exchange),
+        )
+
+
+def _seed_sec_cik(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    cik: str,
+    is_primary: bool = True,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO external_identifiers
+                (instrument_id, provider, identifier_type, identifier_value, is_primary)
+            VALUES (%s, 'sec', 'cik', %s, %s)
+            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            """,
+            (instrument_id, cik, is_primary),
+        )
+
+
+def _cleanup(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_ids: list[int],
+    exchange_ids: list[str],
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM external_identifiers WHERE instrument_id = ANY(%s)",
+            (instrument_ids,),
+        )
+        cur.execute("DELETE FROM instruments WHERE instrument_id = ANY(%s)", (instrument_ids,))
+        cur.execute("DELETE FROM exchanges WHERE exchange_id = ANY(%s)", (exchange_ids,))
+    conn.commit()
+
+
+def test_returns_one_cell_per_v1_capability(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The resolver always returns all 11 v1 capabilities, even on
+    an instrument whose exchange row carries empty providers."""
+    _seed_exchange_with_capabilities(
+        ebull_test_conn,
+        exchange_id="test_cap_001",
+        asset_class="unknown",
+        capabilities={cap: [] for cap in V1_CAPABILITIES},
+    )
+    _seed_instrument(
+        ebull_test_conn,
+        instrument_id=960001,
+        symbol="CAP1",
+        exchange="test_cap_001",
+    )
+    ebull_test_conn.commit()
+
+    try:
+        resolved = resolve_capabilities(
+            ebull_test_conn,
+            instrument_id=960001,
+            exchange_id="test_cap_001",
+        )
+        assert set(resolved.cells.keys()) == set(V1_CAPABILITIES)
+        for cap in V1_CAPABILITIES:
+            cell = resolved.cells[cap]
+            assert cell.providers == ()
+            assert cell.data_present == {}
+    finally:
+        _cleanup(ebull_test_conn, instrument_ids=[960001], exchange_ids=["test_cap_001"])
+
+
+def test_exchange_row_defaults_flow_through(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Whatever providers the exchange row lists for a capability
+    appear in the resolved cell — no SEC augmentation when there's
+    no external_identifiers row."""
+    _seed_exchange_with_capabilities(
+        ebull_test_conn,
+        exchange_id="test_cap_002",
+        asset_class="uk_equity",
+        capabilities={
+            **{cap: [] for cap in V1_CAPABILITIES},
+            "filings": ["companies_house"],
+            "dividends": ["lse_rns"],
+        },
+    )
+    _seed_instrument(
+        ebull_test_conn,
+        instrument_id=960002,
+        symbol="CAP2",
+        exchange="test_cap_002",
+    )
+    ebull_test_conn.commit()
+
+    try:
+        resolved = resolve_capabilities(
+            ebull_test_conn,
+            instrument_id=960002,
+            exchange_id="test_cap_002",
+        )
+        assert resolved.cells["filings"].providers == ("companies_house",)
+        assert resolved.cells["dividends"].providers == ("lse_rns",)
+        assert resolved.cells["insider"].providers == ()
+        # Neither companies_house nor lse_rns has a wired EXISTS
+        # query (no UK ingest yet), so data_present is False.
+        assert resolved.cells["filings"].data_present == {"companies_house": False}
+        assert resolved.cells["dividends"].data_present == {"lse_rns": False}
+    finally:
+        _cleanup(ebull_test_conn, instrument_ids=[960002], exchange_ids=["test_cap_002"])
+
+
+def test_sec_cik_augments_capabilities(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """An instrument with a SEC CIK in external_identifiers gets
+    the SEC family providers added to ``filings`` /
+    ``fundamentals`` / ``dividends`` / ``insider`` /
+    ``ownership`` / ``corporate_events`` / ``business_summary`` /
+    ``analyst`` regardless of its exchange row's defaults."""
+    _seed_exchange_with_capabilities(
+        ebull_test_conn,
+        exchange_id="test_cap_003",
+        asset_class="uk_equity",
+        capabilities={
+            **{cap: [] for cap in V1_CAPABILITIES},
+            "filings": ["companies_house"],
+        },
+    )
+    _seed_instrument(
+        ebull_test_conn,
+        instrument_id=960003,
+        symbol="CAP3",
+        exchange="test_cap_003",
+    )
+    _seed_sec_cik(ebull_test_conn, instrument_id=960003, cik="0001000003")
+    ebull_test_conn.commit()
+
+    try:
+        resolved = resolve_capabilities(
+            ebull_test_conn,
+            instrument_id=960003,
+            exchange_id="test_cap_003",
+        )
+        # Multi-source: companies_house FROM exchange row + sec_edgar
+        # FROM the SEC CIK augmentation, in that order, no duplicates.
+        # Note ``filings`` augment is sec_edgar (filing_events),
+        # NOT sec_xbrl — Codex review caught the conflation: filings
+        # capability points at the filings index, fundamentals points
+        # at XBRL.
+        assert resolved.cells["filings"].providers == ("companies_house", "sec_edgar")
+        # SEC-only capabilities surface entirely from the augment.
+        assert resolved.cells["insider"].providers == ("sec_form4",)
+        assert resolved.cells["ownership"].providers == ("sec_13f", "sec_13d_13g")
+        # Capabilities not augmented by SEC stay empty.
+        assert resolved.cells["esg"].providers == ()
+    finally:
+        _cleanup(
+            ebull_test_conn,
+            instrument_ids=[960003],
+            exchange_ids=["test_cap_003"],
+        )
+
+
+def test_unknown_provider_tag_skipped(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Operator hand-edits the JSONB to add a typo (e.g.
+    ``companeis_house``). The resolver skips silently rather
+    than raising — admin UI surfaces the override so the
+    operator can fix the typo without breaking the instrument
+    page."""
+    _seed_exchange_with_capabilities(
+        ebull_test_conn,
+        exchange_id="test_cap_004",
+        asset_class="uk_equity",
+        capabilities={
+            **{cap: [] for cap in V1_CAPABILITIES},
+            "filings": ["companeis_house", "companies_house"],
+        },
+    )
+    _seed_instrument(
+        ebull_test_conn,
+        instrument_id=960004,
+        symbol="CAP4",
+        exchange="test_cap_004",
+    )
+    ebull_test_conn.commit()
+
+    try:
+        resolved = resolve_capabilities(
+            ebull_test_conn,
+            instrument_id=960004,
+            exchange_id="test_cap_004",
+        )
+        # Typo dropped; valid value retained.
+        assert resolved.cells["filings"].providers == ("companies_house",)
+    finally:
+        _cleanup(
+            ebull_test_conn,
+            instrument_ids=[960004],
+            exchange_ids=["test_cap_004"],
+        )
+
+
+def test_unknown_exchange_returns_empty_cells(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """An instrument whose exchange isn't in ``exchanges`` (e.g.
+    a NULL exchange column) gets every cell empty — no crash."""
+    resolved = resolve_capabilities(
+        ebull_test_conn,
+        instrument_id=999_999_999,
+        exchange_id="this_exchange_does_not_exist",
+    )
+    assert set(resolved.cells.keys()) == set(V1_CAPABILITIES)
+    for cap in V1_CAPABILITIES:
+        assert resolved.cells[cap].providers == ()
+
+
+def test_unknown_exchange_with_sec_cik_still_augments(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """An instrument with a NULL exchange BUT a SEC CIK still
+    surfaces SEC capability coverage. Codex round-1 finding:
+    returning empty cells on missing exchange contradicted
+    has_sec_cik on partially-synced instruments."""
+    _seed_instrument(
+        ebull_test_conn,
+        instrument_id=960005,
+        symbol="CAP5",
+        exchange="this_exchange_does_not_exist_either",
+    )
+    _seed_sec_cik(ebull_test_conn, instrument_id=960005, cik="0001000005")
+    ebull_test_conn.commit()
+
+    try:
+        resolved = resolve_capabilities(
+            ebull_test_conn,
+            instrument_id=960005,
+            exchange_id="this_exchange_does_not_exist_either",
+        )
+        # Exchange row missing → no defaults. SEC CIK augment
+        # still adds the SEC family.
+        assert resolved.cells["filings"].providers == ("sec_edgar",)
+        assert resolved.cells["insider"].providers == ("sec_form4",)
+    finally:
+        _cleanup(
+            ebull_test_conn,
+            instrument_ids=[960005],
+            exchange_ids=[],
+        )
+
+
+def test_non_cik_sec_identifier_does_not_augment(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """external_identifiers with provider='sec' but
+    identifier_type != 'cik' must NOT trigger the SEC capability
+    augment — every other SEC gate in the codebase filters on
+    identifier_type='cik' and the resolver must match. A future
+    SEC accession-number row would otherwise overstate coverage."""
+    _seed_exchange_with_capabilities(
+        ebull_test_conn,
+        exchange_id="test_cap_006",
+        asset_class="uk_equity",
+        capabilities={cap: [] for cap in V1_CAPABILITIES},
+    )
+    _seed_instrument(
+        ebull_test_conn,
+        instrument_id=960006,
+        symbol="CAP6",
+        exchange="test_cap_006",
+    )
+    with ebull_test_conn.cursor() as cur:
+        # Non-CIK SEC identifier — e.g. a future accession number type.
+        cur.execute(
+            """
+            INSERT INTO external_identifiers
+                (instrument_id, provider, identifier_type, identifier_value, is_primary)
+            VALUES (%s, 'sec', 'accession_no', '0001234567-26-000001', TRUE)
+            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            """,
+            (960006,),
+        )
+    ebull_test_conn.commit()
+
+    try:
+        resolved = resolve_capabilities(
+            ebull_test_conn,
+            instrument_id=960006,
+            exchange_id="test_cap_006",
+        )
+        # No SEC CIK → no augment. All cells empty.
+        for cap in V1_CAPABILITIES:
+            assert resolved.cells[cap].providers == (), f"id={cap} unexpectedly augmented from non-CIK SEC row"
+    finally:
+        _cleanup(
+            ebull_test_conn,
+            instrument_ids=[960006],
+            exchange_ids=["test_cap_006"],
+        )
+
+
+def test_malformed_jsonb_value_does_not_crash(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """An operator hand-edits the JSONB to put a scalar / null
+    where a list belongs (e.g. ``"filings": "sec_xbrl"`` instead
+    of ``["sec_xbrl"]``). The resolver skips silently rather than
+    500ing — the admin UI surfaces overrides for the operator to
+    fix without breaking the instrument page."""
+    import json as _json
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO exchanges (exchange_id, asset_class, capabilities)
+            VALUES (%s, 'unknown', %s::jsonb)
+            ON CONFLICT (exchange_id) DO UPDATE SET
+                asset_class  = 'unknown',
+                capabilities = EXCLUDED.capabilities
+            """,
+            (
+                "test_cap_007",
+                # Mix of valid + scalar + null — every malformed
+                # cell is skipped, valid ones survive.
+                _json.dumps(
+                    {
+                        "filings": "sec_edgar",  # scalar instead of list
+                        "fundamentals": None,  # null instead of list
+                        "dividends": ["sec_dividend_summary"],  # valid
+                    }
+                ),
+            ),
+        )
+    _seed_instrument(
+        ebull_test_conn,
+        instrument_id=960007,
+        symbol="CAP7",
+        exchange="test_cap_007",
+    )
+    ebull_test_conn.commit()
+
+    try:
+        resolved = resolve_capabilities(
+            ebull_test_conn,
+            instrument_id=960007,
+            exchange_id="test_cap_007",
+        )
+        assert resolved.cells["filings"].providers == ()
+        assert resolved.cells["fundamentals"].providers == ()
+        assert resolved.cells["dividends"].providers == ("sec_dividend_summary",)
+    finally:
+        _cleanup(
+            ebull_test_conn,
+            instrument_ids=[960007],
+            exchange_ids=["test_cap_007"],
+        )
+
+
+def test_non_primary_sec_cik_does_not_augment(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """external_identifiers preserves historical non-primary
+    SEC CIKs (per sql/003). A non-primary CIK alone must NOT
+    trigger the SEC capability augment — _has_sec_cik() filters
+    on is_primary=TRUE and the resolver matches that gate.
+    Codex round-2 finding on PR 3a."""
+    _seed_exchange_with_capabilities(
+        ebull_test_conn,
+        exchange_id="test_cap_008",
+        asset_class="us_equity",
+        capabilities={cap: [] for cap in V1_CAPABILITIES},
+    )
+    _seed_instrument(
+        ebull_test_conn,
+        instrument_id=960008,
+        symbol="CAP8",
+        exchange="test_cap_008",
+    )
+    _seed_sec_cik(
+        ebull_test_conn,
+        instrument_id=960008,
+        cik="0001000008",
+        is_primary=False,
+    )
+    ebull_test_conn.commit()
+
+    try:
+        resolved = resolve_capabilities(
+            ebull_test_conn,
+            instrument_id=960008,
+            exchange_id="test_cap_008",
+        )
+        # Non-primary CIK → no augment. All cells empty.
+        for cap in V1_CAPABILITIES:
+            assert resolved.cells[cap].providers == (), f"id={cap} unexpectedly augmented from non-primary SEC CIK"
+    finally:
+        _cleanup(
+            ebull_test_conn,
+            instrument_ids=[960008],
+            exchange_ids=["test_cap_008"],
+        )
+
+
+def test_fmp_serves_fundamentals_and_analyst_via_distinct_tables(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The ``fmp`` provider tag backs both ``fundamentals`` (via
+    fundamentals_snapshot) and ``analyst`` (via analyst_estimates).
+    A row in fundamentals_snapshot must NOT make
+    analyst.data_present[fmp] = True. Codex round-2 finding on
+    PR 3a: pre-fix, the resolver shared a single SQL EXISTS per
+    provider, mis-reporting analyst coverage off fundamentals
+    data alone."""
+    _seed_exchange_with_capabilities(
+        ebull_test_conn,
+        exchange_id="test_cap_009",
+        asset_class="us_equity",
+        capabilities={
+            **{cap: [] for cap in V1_CAPABILITIES},
+            "fundamentals": ["fmp"],
+            "analyst": ["fmp"],
+        },
+    )
+    _seed_instrument(
+        ebull_test_conn,
+        instrument_id=960009,
+        symbol="CAP9",
+        exchange="test_cap_009",
+    )
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO fundamentals_snapshot
+                (instrument_id, as_of_date)
+            VALUES (%s, '2026-04-25')
+            """,
+            (960009,),
+        )
+    ebull_test_conn.commit()
+
+    try:
+        resolved = resolve_capabilities(
+            ebull_test_conn,
+            instrument_id=960009,
+            exchange_id="test_cap_009",
+        )
+        assert resolved.cells["fundamentals"].data_present == {"fmp": True}
+        # No row in analyst_estimates → analyst.data_present must
+        # be False even though fmp also serves fundamentals.
+        assert resolved.cells["analyst"].data_present == {"fmp": False}
+    finally:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("DELETE FROM fundamentals_snapshot WHERE instrument_id = %s", (960009,))
+        _cleanup(
+            ebull_test_conn,
+            instrument_ids=[960009],
+            exchange_ids=["test_cap_009"],
+        )

--- a/tests/test_migration_071_exchanges_capabilities.py
+++ b/tests/test_migration_071_exchanges_capabilities.py
@@ -1,0 +1,169 @@
+"""Regression tests for migration 071 (#515 PR 3).
+
+Pins three contracts:
+
+1. ``exchanges.capabilities`` JSONB column exists with the
+   ``jsonb_typeof = 'object'`` CHECK constraint.
+2. Every ``us_equity`` row gets the canonical SEC + FMP seed (the
+   ``filings`` cell uses ``sec_edgar``, NOT ``sec_xbrl`` — Codex
+   round-1 finding caught the conflation).
+3. Every non-``us_equity`` row gets the empty-but-correctly-shaped
+   default object so the resolver doesn't have to special-case
+   missing keys.
+
+Migration 071 runs at fixture setup; tests assert post-migration
+state directly.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_capabilities_column_exists_with_object_check(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Schema-level pin: column exists, JSONB type, CHECK
+    constraint enforces an object (not array / scalar)."""
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT data_type
+              FROM information_schema.columns
+             WHERE table_name = 'exchanges'
+               AND column_name = 'capabilities'
+            """
+        )
+        row = cur.fetchone()
+    assert row is not None, "exchanges.capabilities column missing"
+    assert row[0] == "jsonb"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT 1
+              FROM pg_constraint
+             WHERE conname = 'exchanges_capabilities_is_object'
+            """
+        )
+        assert cur.fetchone() is not None, "object-shape CHECK missing"
+
+
+def test_us_equity_seed_includes_sec_edgar_for_filings(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Every us_equity row's ``filings`` cell is ``["sec_edgar"]``,
+    NOT ``["sec_xbrl"]``. PR 3a Codex round-1 finding: the seed
+    originally used sec_xbrl which mis-represents filings as
+    XBRL fundamentals data."""
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT exchange_id, capabilities -> 'filings' AS filings
+              FROM exchanges
+             WHERE asset_class = 'us_equity'
+            """
+        )
+        rows = cur.fetchall()
+
+    assert rows, "no us_equity rows seeded — migration 067 didn't run?"
+    for exchange_id, filings in rows:
+        assert filings == ["sec_edgar"], f"id={exchange_id}: filings drift, expected ['sec_edgar'], got {filings}"
+
+
+def test_us_equity_seed_full_shape(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Pin the full us_equity capability seed so a future drift
+    in the migration's UPDATE values is caught (e.g. someone
+    swaps fmp into ratings by accident)."""
+    expected = {
+        "filings": ["sec_edgar"],
+        "fundamentals": ["sec_xbrl", "fmp"],
+        "dividends": ["sec_dividend_summary"],
+        "insider": ["sec_form4"],
+        "analyst": ["fmp"],
+        "ratings": [],
+        "esg": [],
+        "ownership": ["sec_13f", "sec_13d_13g"],
+        "corporate_events": ["sec_8k_events"],
+        "business_summary": ["sec_10k_item1"],
+        "officers": [],
+    }
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT capabilities FROM exchanges WHERE asset_class = 'us_equity' LIMIT 1")
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == expected
+
+
+def test_non_us_equity_seed_is_empty_shape(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Non-us_equity rows have all 11 keys present with empty
+    lists — resolver doesn't have to special-case missing keys."""
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT exchange_id, capabilities
+              FROM exchanges
+             WHERE asset_class IN ('crypto', 'unknown')
+             LIMIT 1
+            """
+        )
+        row = cur.fetchone()
+    if row is None:
+        pytest.skip("no non-us_equity rows in test DB")
+    capabilities = row[1]
+    expected_keys = {
+        "filings",
+        "fundamentals",
+        "dividends",
+        "insider",
+        "analyst",
+        "ratings",
+        "esg",
+        "ownership",
+        "corporate_events",
+        "business_summary",
+        "officers",
+    }
+    assert set(capabilities.keys()) == expected_keys
+    for k, v in capabilities.items():
+        assert v == [], f"key={k} not empty: {v}"
+
+
+def test_object_check_rejects_non_object(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The CHECK constraint refuses a JSONB array / scalar / null
+    in the capabilities column — operator can't accidentally
+    set capabilities = '[]'::jsonb and break the resolver."""
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO exchanges (exchange_id, asset_class, capabilities)
+            VALUES ('test_071_seed', 'unknown', '{}'::jsonb)
+            ON CONFLICT (exchange_id) DO NOTHING
+            """
+        )
+    ebull_test_conn.commit()
+
+    try:
+        with ebull_test_conn.cursor() as cur:
+            with pytest.raises(psycopg.errors.CheckViolation):
+                cur.execute(
+                    """
+                    UPDATE exchanges
+                       SET capabilities = '[]'::jsonb
+                     WHERE exchange_id = 'test_071_seed'
+                    """
+                )
+        ebull_test_conn.rollback()
+    finally:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("DELETE FROM exchanges WHERE exchange_id = 'test_071_seed'")
+        ebull_test_conn.commit()


### PR DESCRIPTION
## What

PR 3a of #515 — backend half of PR 3. Frontend panel refactor + admin overrides UI deferred to PR 3b.

- Migration sql/071: `exchanges.capabilities` JSONB + CHECK + per-asset_class seed.
- `app/services/capabilities.py`: `resolve_capabilities()` helper. Per-(capability, provider) SQL EXISTS lookup. Defensive JSON tolerance.
- Summary endpoint adds `capabilities: dict[str, CapabilityCellPayload]`. Frontend types mirrored. `has_sec_cik` / `has_filings_coverage` kept as thin shim — PR 3b retires.

## Why

Workstream 3 of #515 — capability flags drive UI presentation per-instrument (exchange default UNION external_identifiers). Multi-source coverage first-class; per-(capability, provider) resolution catches `fmp` serving both `fundamentals` and `analyst` via different tables.

## Test plan

- [x] Backend: 10 resolver tests + 5 migration tests + smoke
- [x] Frontend: pnpm typecheck + 406 unit tests
- [x] `uv run ruff check .` / `ruff format --check` / `pyright` — clean
- [x] Codex review: 4 rounds, all findings addressed (filings vs XBRL, NULL-exchange, identifier_type, is_primary, fmp dual-purpose, frontend type sync, migration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)