### PR TITLE
feat(#515-pr3b): provider-agnostic capability panels

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -809,15 +809,47 @@ class EightKFilingsResponse(BaseModel):
     filings: list[EightKFilingModel]
 
 
+# Per-endpoint allowed `provider` values. Frontend hooks pass the
+# capability's resolved provider tag so the endpoint can route to the
+# right backend once non-SEC sources land. Today every endpoint only
+# wires a single provider; per-region integration PRs add more.
+_EIGHT_K_PROVIDERS: tuple[str, ...] = ("sec_8k_events",)
+_DIVIDEND_PROVIDERS: tuple[str, ...] = ("sec_dividend_summary",)
+_INSIDER_PROVIDERS: tuple[str, ...] = ("sec_form4",)
+
+
+def _validate_provider(provider: str | None, allowed: tuple[str, ...]) -> None:
+    """Reject an unknown ``?provider=`` value.
+
+    ``provider=None`` (param omitted) falls back to the endpoint's
+    historical default behaviour for backward compatibility — every
+    existing caller pre-#515 PR 3b passes nothing. New frontend hooks
+    always pass the capability-resolved provider tag explicitly.
+    """
+    if provider is None:
+        return
+    if provider not in allowed:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unsupported provider {provider!r}; allowed: {list(allowed)}",
+        )
+
+
 @router.get("/{symbol}/eight_k_filings", response_model=EightKFilingsResponse)
 def get_instrument_8k_filings(
     symbol: str,
     limit: int = 50,
+    provider: str | None = Query(
+        default=None,
+        description="Capability provider tag. Today only 'sec_8k_events'.",
+    ),
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> EightKFilingsResponse:
     """Return recent 8-K filings for an instrument with full structured
     item bodies + exhibit pointers (#450)."""
     from app.services.eight_k_events import list_8k_filings
+
+    _validate_provider(provider, _EIGHT_K_PROVIDERS)
 
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:
@@ -1125,6 +1157,10 @@ class InstrumentDividends(BaseModel):
 def get_instrument_dividends(
     symbol: str,
     limit: int = Query(default=40, ge=1, le=400),
+    provider: str | None = Query(
+        default=None,
+        description="Capability provider tag. Today only 'sec_dividend_summary'.",
+    ),
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> InstrumentDividends:
     """Dividend history + TTM yield summary for a single instrument.
@@ -1142,6 +1178,8 @@ def get_instrument_dividends(
         get_dividend_summary,
         get_upcoming_dividends,
     )
+
+    _validate_provider(provider, _DIVIDEND_PROVIDERS)
 
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:
@@ -1246,6 +1284,10 @@ class InsiderSummaryModel(BaseModel):
 @router.get("/{symbol}/insider_summary", response_model=InsiderSummaryModel)
 def get_instrument_insider_summary(
     symbol: str,
+    provider: str | None = Query(
+        default=None,
+        description="Capability provider tag. Today only 'sec_form4'.",
+    ),
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> InsiderSummaryModel:
     """Return the 90-day insider-transaction summary (#429 / #458).
@@ -1256,6 +1298,8 @@ def get_instrument_insider_summary(
     contribute; derivative grants / option exercises are excluded.
     """
     from app.services.insider_transactions import get_insider_summary
+
+    _validate_provider(provider, _INSIDER_PROVIDERS)
 
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:
@@ -1352,6 +1396,10 @@ class InsiderTransactionsListModel(BaseModel):
 def get_instrument_insider_transactions(
     symbol: str,
     limit: int = 100,
+    provider: str | None = Query(
+        default=None,
+        description="Capability provider tag. Today only 'sec_form4'.",
+    ),
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> InsiderTransactionsListModel:
     """Return recent Form 4 insider transactions for an instrument.
@@ -1366,6 +1414,8 @@ def get_instrument_insider_transactions(
     layer (per the "every structured field queryable in SQL" rule).
     """
     from app.services.insider_transactions import list_insider_transactions
+
+    _validate_provider(provider, _INSIDER_PROVIDERS)
 
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -81,9 +81,14 @@ export interface InstrumentDividends {
 
 export function fetchInstrumentDividends(
   symbol: string,
+  provider?: string,
 ): Promise<InstrumentDividends> {
+  const params = new URLSearchParams();
+  if (provider !== undefined) params.set("provider", provider);
+  const qs = params.toString();
+  const suffix = qs.length > 0 ? `?${qs}` : "";
   return apiFetch<InstrumentDividends>(
-    `/instruments/${encodeURIComponent(symbol)}/dividends`,
+    `/instruments/${encodeURIComponent(symbol)}/dividends${suffix}`,
   );
 }
 
@@ -167,8 +172,10 @@ export interface EightKFilingsResponse {
 export function fetchEightKFilings(
   symbol: string,
   limit: number = 25,
+  provider?: string,
 ): Promise<EightKFilingsResponse> {
   const params = new URLSearchParams({ limit: String(limit) });
+  if (provider !== undefined) params.set("provider", provider);
   return apiFetch<EightKFilingsResponse>(
     `/instruments/${encodeURIComponent(symbol)}/eight_k_filings?${params.toString()}`,
   );
@@ -264,17 +271,26 @@ export interface InsiderTransactionsList {
   rows: InsiderTransactionDetail[];
 }
 
-export function fetchInsiderSummary(symbol: string): Promise<InsiderSummary> {
+export function fetchInsiderSummary(
+  symbol: string,
+  provider?: string,
+): Promise<InsiderSummary> {
+  const params = new URLSearchParams();
+  if (provider !== undefined) params.set("provider", provider);
+  const qs = params.toString();
+  const suffix = qs.length > 0 ? `?${qs}` : "";
   return apiFetch<InsiderSummary>(
-    `/instruments/${encodeURIComponent(symbol)}/insider_summary`,
+    `/instruments/${encodeURIComponent(symbol)}/insider_summary${suffix}`,
   );
 }
 
 export function fetchInsiderTransactions(
   symbol: string,
   limit: number = 100,
+  provider?: string,
 ): Promise<InsiderTransactionsList> {
   const params = new URLSearchParams({ limit: String(limit) });
+  if (provider !== undefined) params.set("provider", provider);
   return apiFetch<InsiderTransactionsList>(
     `/instruments/${encodeURIComponent(symbol)}/insider_transactions?${params.toString()}`,
   );

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -268,22 +268,21 @@ export interface InstrumentSummary {
   key_stats: InstrumentKeyStats | null;
   source: Record<string, string>;
   /** True iff the instrument has a primary SEC CIK in
-   *  external_identifiers. Frontend uses this to gate
-   *  SEC-specific panels (SecProfile, InsiderActivity,
-   *  Dividends, business summary). Crypto + non-US instruments
-   *  see false.
-   *  Deprecated: prefer reading `capabilities` per-cell.
-   *  PR 3b retires this field once frontend reads `capabilities`
-   *  directly. */
+   *  external_identifiers. Frontend uses this to gate the
+   *  remaining SEC-specific panels (SecProfile, BusinessSections)
+   *  not yet refactored into provider-agnostic shells. Crypto +
+   *  non-US instruments see false. Retired as a shim for the
+   *  three capability panels (Dividends / InsiderActivity /
+   *  EightKEvents — #515 PR 3b); a follow-up PR removes it
+   *  altogether once SecProfile + BusinessSections also land
+   *  provider-agnostic shells. */
   has_sec_cik: boolean;
-  /** True iff any filings provider has rows for the instrument
-   *  (today: SEC; tomorrow: Companies House / regional). Gates
-   *  the source-agnostic Filings tab + right-rail "recent
-   *  filings" widget. Wider than has_sec_cik so adding a non-SEC
-   *  filings provider later doesn't bake in a follow-up.
-   *  Deprecated: prefer reading `capabilities.filings`.
-   *  PR 3b retires this field once frontend reads `capabilities`
-   *  directly. */
+  /** Legacy filings-coverage flag.
+   *  Frontend no longer reads this — the Filings tab and
+   *  right-rail widget gate via
+   *  ``capabilities.filings.data_present`` instead (#515 PR 3b).
+   *  Field still ships on the wire for one release; a follow-up
+   *  PR drops it from the response model + this interface. */
   has_filings_coverage: boolean;
   /** Per-capability resolution (#515 PR 3). Keyed by capability
    *  name (one of the 11 v1 keys: filings / fundamentals /

--- a/frontend/src/components/instrument/DividendsPanel.test.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.test.tsx
@@ -76,7 +76,7 @@ afterEach(() => vi.clearAllMocks());
 describe("DividendsPanel", () => {
   it("renders summary + per-quarter history for a paying instrument", async () => {
     mockFetch.mockResolvedValue(paid());
-    render(<DividendsPanel symbol="AAPL" />);
+    render(<DividendsPanel symbol="AAPL" provider="sec_dividend_summary" />);
 
     await waitFor(() => {
       expect(screen.getByText(/TTM yield/i)).toBeInTheDocument();
@@ -90,7 +90,7 @@ describe("DividendsPanel", () => {
 
   it("renders empty state when never-paid", async () => {
     mockFetch.mockResolvedValue(notPaid());
-    render(<DividendsPanel symbol="GOOG" />);
+    render(<DividendsPanel symbol="GOOG" provider="sec_dividend_summary" />);
 
     await waitFor(() => {
       expect(screen.getByText(/No dividend history on file/i)).toBeInTheDocument();
@@ -100,7 +100,7 @@ describe("DividendsPanel", () => {
 
   it("renders error state + retry on fetch failure", async () => {
     mockFetch.mockRejectedValue(new Error("boom"));
-    render(<DividendsPanel symbol="AAPL" />);
+    render(<DividendsPanel symbol="AAPL" provider="sec_dividend_summary" />);
 
     await waitFor(() => {
       expect(screen.getByText(/Failed to load/i)).toBeInTheDocument();
@@ -121,7 +121,7 @@ describe("DividendsPanel", () => {
       },
     ];
     mockFetch.mockResolvedValue(withUpcoming);
-    render(<DividendsPanel symbol="AAPL" />);
+    render(<DividendsPanel symbol="AAPL" provider="sec_dividend_summary" />);
 
     await waitFor(() => {
       expect(screen.getByText(/Next dividend/i)).toBeInTheDocument();

--- a/frontend/src/components/instrument/DividendsPanel.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.tsx
@@ -1,6 +1,13 @@
 /**
- * DividendsPanel — TTM yield + per-quarter history for the instrument
- * page. Backed by GET /instruments/{symbol}/dividends.
+ * DividendsPanel — provider-agnostic shell for the per-instrument
+ * dividends capability (#515 PR 3b). Backed by GET
+ * /instruments/{symbol}/dividends?provider=<provider>.
+ *
+ * The shell renders the normalised dividend shape returned by the
+ * endpoint regardless of which provider populated it. Today only
+ * ``sec_dividend_summary`` is wired; per-region integration PRs
+ * (Companies House dividends, KRX dividends, …) reuse the same shell
+ * + endpoint contract — no panel code changes required.
  *
  * Never-paid instruments render an explicit empty state rather than a
  * 404 or a zero row.
@@ -18,11 +25,16 @@ import {
   SectionSkeleton,
 } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
+import { providerLabel } from "@/lib/capabilityProviders";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback } from "react";
 
 export interface DividendsPanelProps {
   readonly symbol: string;
+  /** Capability provider tag, resolved via
+   *  ``summary.capabilities.dividends.providers`` upstream. The
+   *  shell forwards it to the endpoint as ``?provider=<tag>``. */
+  readonly provider: string;
 }
 
 function formatDps(raw: string | null, currency: string | null): string {
@@ -64,14 +76,18 @@ function HistoryBar({ period, max }: { period: DividendPeriod; max: number }) {
   );
 }
 
-export function DividendsPanel({ symbol }: DividendsPanelProps) {
+export function DividendsPanel({ symbol, provider }: DividendsPanelProps) {
   const state = useAsync<InstrumentDividends>(
-    useCallback(() => fetchInstrumentDividends(symbol), [symbol]),
-    [symbol],
+    useCallback(
+      () => fetchInstrumentDividends(symbol, provider),
+      [symbol, provider],
+    ),
+    [symbol, provider],
   );
+  const title = `Dividends · ${providerLabel(provider)}`;
 
   return (
-    <Section title="Dividends">
+    <Section title={title}>
       {state.loading ? (
         <SectionSkeleton rows={3} />
       ) : state.error !== null || state.data === null ? (
@@ -89,7 +105,7 @@ export function DividendsPanel({ symbol }: DividendsPanelProps) {
           state.data.history.length === 0 ? (
             <EmptyState
               title="No dividend history on file"
-              description="This instrument has not reported a positive dividend in its SEC filings."
+              description="This instrument has not reported a positive dividend in this provider's data."
             />
           ) : (
             <DividendsBody data={state.data} />

--- a/frontend/src/components/instrument/EightKEventsPanel.tsx
+++ b/frontend/src/components/instrument/EightKEventsPanel.tsx
@@ -1,6 +1,12 @@
 /**
- * EightKEventsPanel — recent 8-K filings timeline for the instrument
- * page. Backed by GET /instruments/{symbol}/eight_k_filings (#450).
+ * EightKEventsPanel — provider-agnostic shell for the per-instrument
+ * corporate-events capability (#515 PR 3b). Backed by GET
+ * /instruments/{symbol}/eight_k_filings?provider=<provider>.
+ *
+ * Today only ``sec_8k_events`` is wired. Per-region integration PRs
+ * adapting (e.g.) HKEX corporate announcements to the same normalised
+ * filing-card shape reuse this shell unchanged.
+ *
  *
  * Each filing renders as a timeline card with:
  *   - Date of report + document type (8-K vs 8-K/A)
@@ -25,11 +31,15 @@ import {
   SectionSkeleton,
 } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
+import { providerLabel } from "@/lib/capabilityProviders";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback, useState } from "react";
 
 export interface EightKEventsPanelProps {
   readonly symbol: string;
+  /** Capability provider tag, resolved via
+   *  ``summary.capabilities.corporate_events.providers`` upstream. */
+  readonly provider: string;
 }
 
 function severityTone(severity: string | null): string {
@@ -158,13 +168,17 @@ function Body({ data }: { data: EightKFilingsResponse }) {
   );
 }
 
-export function EightKEventsPanel({ symbol }: EightKEventsPanelProps) {
+export function EightKEventsPanel({ symbol, provider }: EightKEventsPanelProps) {
   const state = useAsync<EightKFilingsResponse>(
-    useCallback(() => fetchEightKFilings(symbol, 25), [symbol]),
-    [symbol],
+    useCallback(
+      () => fetchEightKFilings(symbol, 25, provider),
+      [symbol, provider],
+    ),
+    [symbol, provider],
   );
+  const title = `Corporate events · ${providerLabel(provider)}`;
   return (
-    <Section title="8-K events">
+    <Section title={title}>
       {state.loading ? (
         <SectionSkeleton rows={4} />
       ) : state.error !== null ? (

--- a/frontend/src/components/instrument/InsiderActivityPanel.test.tsx
+++ b/frontend/src/components/instrument/InsiderActivityPanel.test.tsx
@@ -63,7 +63,7 @@ describe("InsiderActivityPanel — summary strip", () => {
     mockSummary.mockResolvedValue(makeSummary());
     mockTransactions.mockResolvedValue(emptyTxns());
 
-    render(<InsiderActivityPanel symbol="GME" />);
+    render(<InsiderActivityPanel symbol="GME" provider="sec_form4" />);
 
     await waitFor(() => {
       expect(screen.getByText(/Net change/i)).toBeInTheDocument();
@@ -93,7 +93,7 @@ describe("InsiderActivityPanel — summary strip", () => {
     );
     mockTransactions.mockResolvedValue(emptyTxns());
 
-    render(<InsiderActivityPanel symbol="GME" />);
+    render(<InsiderActivityPanel symbol="GME" provider="sec_form4" />);
 
     await waitFor(() => {
       expect(screen.getByText(/Net change/i)).toBeInTheDocument();

--- a/frontend/src/components/instrument/InsiderActivityPanel.tsx
+++ b/frontend/src/components/instrument/InsiderActivityPanel.tsx
@@ -1,7 +1,13 @@
 /**
- * InsiderActivityPanel — Form 4 insider transaction activity for the
- * instrument page. Backed by GET /instruments/{symbol}/insider_summary
- * + /insider_transactions (#429).
+ * InsiderActivityPanel — provider-agnostic shell for the per-instrument
+ * insider capability (#515 PR 3b). Backed by GET
+ * /instruments/{symbol}/insider_summary + /insider_transactions, both
+ * passed ``?provider=<provider>``.
+ *
+ * Today only ``sec_form4`` is wired; per-region integration PRs reuse
+ * the same shell + endpoint contract — non-SEC insider sources don't
+ * require panel code changes.
+ *
  *
  * Layout:
  *
@@ -35,11 +41,15 @@ import {
   SectionSkeleton,
 } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
+import { providerLabel } from "@/lib/capabilityProviders";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback } from "react";
 
 export interface InsiderActivityPanelProps {
   readonly symbol: string;
+  /** Capability provider tag, resolved via
+   *  ``summary.capabilities.insider.providers`` upstream. */
+  readonly provider: string;
 }
 
 // Human labels for the SEC transaction codes most operators will
@@ -363,18 +373,28 @@ function Body({
   );
 }
 
-export function InsiderActivityPanel({ symbol }: InsiderActivityPanelProps) {
+export function InsiderActivityPanel({
+  symbol,
+  provider,
+}: InsiderActivityPanelProps) {
   const summaryState = useAsync<InsiderSummary>(
-    useCallback(() => fetchInsiderSummary(symbol), [symbol]),
-    [symbol],
+    useCallback(
+      () => fetchInsiderSummary(symbol, provider),
+      [symbol, provider],
+    ),
+    [symbol, provider],
   );
   const txnsState = useAsync<InsiderTransactionsList>(
-    useCallback(() => fetchInsiderTransactions(symbol, 50), [symbol]),
-    [symbol],
+    useCallback(
+      () => fetchInsiderTransactions(symbol, 50, provider),
+      [symbol, provider],
+    ),
+    [symbol, provider],
   );
+  const title = `Insider activity · ${providerLabel(provider)}`;
 
   return (
-    <Section title="Insider activity (Form 4)">
+    <Section title={title}>
       {summaryState.loading || txnsState.loading ? (
         <SectionSkeleton rows={4} />
       ) : summaryState.error !== null || txnsState.error !== null ? (

--- a/frontend/src/components/instrument/ResearchTab.tsx
+++ b/frontend/src/components/instrument/ResearchTab.tsx
@@ -5,6 +5,12 @@
  * Composes existing data into one operator view: key stats with
  * field_source provenance, thesis memo if present, break conditions.
  * Red-flag surfacing and peer context come in Slice 2 (right rail).
+ *
+ * Capability panels (Dividends, Insider activity, Corporate events)
+ * iterate ``summary.capabilities[type]`` and render one shell per
+ * active (data-present) provider — so a cross-listed instrument with
+ * multiple providers renders multiple panels labelled with each
+ * provider tag (#515 PR 3b).
  */
 import { Section } from "@/components/dashboard/Section";
 import { BusinessSectionsPanel } from "@/components/instrument/BusinessSectionsPanel";
@@ -13,7 +19,8 @@ import { EightKEventsPanel } from "@/components/instrument/EightKEventsPanel";
 import { InsiderActivityPanel } from "@/components/instrument/InsiderActivityPanel";
 import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
 import { EmptyState } from "@/components/states/EmptyState";
-import type { InstrumentSummary, ThesisDetail } from "@/api/types";
+import type { CapabilityCell, InstrumentSummary, ThesisDetail } from "@/api/types";
+import { activeProviders } from "@/lib/capabilityProviders";
 
 function formatDecimal(
   value: string | null | undefined,
@@ -163,6 +170,8 @@ export interface ResearchTabProps {
   thesisErrored?: boolean;
 }
 
+const EMPTY_CELL: CapabilityCell = { providers: [], data_present: {} };
+
 export function ResearchTab({
   summary,
   thesis,
@@ -171,32 +180,51 @@ export function ResearchTab({
   const stats = summary.key_stats;
   const fs = stats?.field_source ?? undefined;
 
-  // SEC-specific panels gate on ``has_sec_cik`` so crypto +
-  // non-US instruments don't render orphan SEC content (#503 PR 2).
-  // Key statistics stays mounted regardless — its empty state
-  // already says "no provider returned key stats" which is honest
-  // for any instrument without coverage.
+  // SEC profile + 10-K Item 1 panels are still SEC-specific (not yet
+  // refactored into provider-agnostic shells); gate on the SEC
+  // identifier signal directly. The three capability panels below
+  // (Dividends, Insider, Corporate events) iterate
+  // `summary.capabilities[type]` and render one shell per active
+  // provider — provider-agnostic by construction.
   const hasSec = summary.has_sec_cik;
+  const dividends = summary.capabilities.dividends ?? EMPTY_CELL;
+  const insider = summary.capabilities.insider ?? EMPTY_CELL;
+  const events = summary.capabilities.corporate_events ?? EMPTY_CELL;
+  const dividendProviders = activeProviders(dividends);
+  const insiderProviders = activeProviders(insider);
+  const eventProviders = activeProviders(events);
 
   return (
     <div className="grid gap-4 md:grid-cols-2">
       {hasSec ? <SecProfilePanel symbol={summary.identity.symbol} /> : null}
-      {hasSec ? <DividendsPanel symbol={summary.identity.symbol} /> : null}
+      {dividendProviders.map((p) => (
+        <DividendsPanel
+          key={`dividends-${p}`}
+          symbol={summary.identity.symbol}
+          provider={p}
+        />
+      ))}
       {hasSec ? (
         <div className="md:col-span-2">
           <BusinessSectionsPanel symbol={summary.identity.symbol} />
         </div>
       ) : null}
-      {hasSec ? (
-        <div className="md:col-span-2">
-          <InsiderActivityPanel symbol={summary.identity.symbol} />
+      {insiderProviders.map((p) => (
+        <div key={`insider-${p}`} className="md:col-span-2">
+          <InsiderActivityPanel
+            symbol={summary.identity.symbol}
+            provider={p}
+          />
         </div>
-      ) : null}
-      {hasSec ? (
-        <div className="md:col-span-2">
-          <EightKEventsPanel symbol={summary.identity.symbol} />
+      ))}
+      {eventProviders.map((p) => (
+        <div key={`events-${p}`} className="md:col-span-2">
+          <EightKEventsPanel
+            symbol={summary.identity.symbol}
+            provider={p}
+          />
         </div>
-      ) : null}
+      ))}
 
       <Section title="Key statistics">
         {stats === null ? (

--- a/frontend/src/components/instrument/RightRail.test.tsx
+++ b/frontend/src/components/instrument/RightRail.test.tsx
@@ -192,7 +192,7 @@ function renderRail(props: {
         instrumentId={instrumentId}
         sector={sector}
         currentSymbol={currentSymbol}
-        hasFilingsCoverage={true}
+        filingsActive={true}
       />
     </MemoryRouter>,
   );

--- a/frontend/src/components/instrument/RightRail.tsx
+++ b/frontend/src/components/instrument/RightRail.tsx
@@ -31,23 +31,24 @@ export interface RightRailProps {
   instrumentId: number;
   sector: string | null;
   currentSymbol: string;
-  /** Provider-agnostic filings coverage gate (#503 PR 2). When
-   *  false (crypto, non-US instruments without coverage), the
-   *  Recent filings section is hidden — rendering "no filings
-   *  ingested yet" for an instrument the source does not cover
-   *  misleads the operator into thinking the pipeline is broken. */
-  hasFilingsCoverage: boolean;
+  /** True when at least one filings provider has rows for this
+   *  instrument — derived upstream from
+   *  ``summary.capabilities.filings`` (#515 PR 3b). When false
+   *  (crypto, non-US instruments without coverage), the Recent
+   *  filings section is hidden so the rail doesn't render a
+   *  misleading "no filings ingested yet" empty state. */
+  filingsActive: boolean;
 }
 
 export function RightRail({
   instrumentId,
   sector,
   currentSymbol,
-  hasFilingsCoverage,
+  filingsActive,
 }: RightRailProps): JSX.Element {
   return (
     <aside className="space-y-4">
-      {hasFilingsCoverage ? <RecentFilings instrumentId={instrumentId} /> : null}
+      {filingsActive ? <RecentFilings instrumentId={instrumentId} /> : null}
       {/* `key={sector}` forces a full remount when the sector changes
           so `useAsync` re-initialises with `loading=true, data=null`
           on the first render for the new sector — otherwise one frame

--- a/frontend/src/lib/capabilityProviders.ts
+++ b/frontend/src/lib/capabilityProviders.ts
@@ -1,0 +1,79 @@
+/**
+ * Provider tag → human-readable label for the per-instrument
+ * capability summary (#515 PR 3b).
+ *
+ * The backend's ``CAPABILITY_PROVIDERS`` enum
+ * (``app/services/capabilities.py``) is the source of truth for the
+ * tag set. This map gives each tag a short label the operator sees in
+ * panel chrome ("SEC 8-K", "Companies House"). Unknown tags fall
+ * through to the raw string — adding a new provider on the backend
+ * does not require a frontend release; the operator sees the tag
+ * verbatim until the label lands here.
+ */
+
+const PROVIDER_LABEL: Record<string, string> = {
+  // US — SEC family
+  sec_edgar: "SEC EDGAR",
+  sec_xbrl: "SEC XBRL",
+  sec_dividend_summary: "SEC dividends",
+  sec_8k_events: "SEC 8-K",
+  sec_10k_item1: "SEC 10-K Item 1",
+  sec_form4: "SEC Form 4",
+  sec_13f: "SEC 13F",
+  sec_13d_13g: "SEC 13D/G",
+  // US — non-SEC enrichment
+  fmp: "FMP",
+  // UK
+  companies_house: "Companies House",
+  lse_rns: "LSE RNS",
+  // EU
+  esma: "ESMA",
+  bafin: "BaFin",
+  amf: "AMF",
+  consob: "Consob",
+  // Asia
+  hkex: "HKEX",
+  tdnet: "TDnet",
+  edinet: "EDINET",
+  asx: "ASX",
+  krx: "KRX",
+  kind: "KIND",
+  twse: "TWSE",
+  mops: "MOPS",
+  sse: "SSE",
+  szse: "SZSE",
+  nse_india: "NSE India",
+  bse_india: "BSE India",
+  sgx: "SGX",
+  // MENA
+  tadawul: "Tadawul",
+  adx: "ADX",
+  dfm: "DFM",
+  // Crypto
+  coingecko: "CoinGecko",
+  glassnode: "Glassnode",
+  // Commodity / FX
+  cme: "CME",
+  lme: "LME",
+  ecb: "ECB",
+  fed: "Fed",
+  boe: "BoE",
+  // Canada
+  tmx_group: "TMX",
+  sedar_plus: "SEDAR+",
+};
+
+export function providerLabel(tag: string): string {
+  return PROVIDER_LABEL[tag] ?? tag;
+}
+
+/** Active providers for one capability cell — providers where
+ *  ``data_present[provider]`` is true, in the operator-decided
+ *  order. Frontend renders one shell+hook pair per active provider.
+ */
+export function activeProviders(cell: {
+  providers: string[];
+  data_present: Record<string, boolean>;
+}): string[] {
+  return cell.providers.filter((p) => cell.data_present[p] === true);
+}

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -76,19 +76,49 @@ const ALL_TABS: { id: TabId; label: string }[] = [
 
 /**
  * Filter the visible tabs to those an instrument's coverage
- * actually populates (#503 PR 2). SEC-only tabs (Financials)
- * hide when ``has_sec_cik`` is false; the source-agnostic
- * Filings tab hides when no provider has filings for the
- * instrument. Crypto + non-US instruments end up with
- * Research / Positions / News only.
+ * actually populates (#503 PR 2 / #515 PR 3b).
+ *
+ * Filings: provider-agnostic gate via
+ * ``summary.capabilities.filings`` — any active provider shows
+ * the tab.
+ *
+ * Financials: still SEC-XBRL-only at the data layer
+ * (``/instruments/{symbol}/financials`` reads
+ * ``financial_periods`` exclusively), so the tab gates on the
+ * ``sec_xbrl`` provider specifically. An instrument with only
+ * non-SEC fundamentals (e.g. FMP-only) would render an empty
+ * statement table — gating on the broader ``fundamentals``
+ * capability would regress that. Once the financials surface
+ * lands a provider-agnostic refactor (follow-up to #515), this
+ * gate widens to ``hasActiveCapability(summary, "fundamentals")``.
  */
 function visibleTabs(summary: InstrumentSummary | null): typeof ALL_TABS {
   if (summary === null) return ALL_TABS;
   return ALL_TABS.filter((t) => {
-    if (t.id === "financials") return summary.has_sec_cik;
-    if (t.id === "filings") return summary.has_filings_coverage;
+    if (t.id === "financials")
+      return hasActiveProvider(summary, "fundamentals", "sec_xbrl");
+    if (t.id === "filings") return hasActiveCapability(summary, "filings");
     return true;
   });
+}
+
+function hasActiveCapability(
+  summary: InstrumentSummary,
+  capability: string,
+): boolean {
+  const cell = summary.capabilities[capability];
+  if (cell === undefined) return false;
+  return cell.providers.some((p) => cell.data_present[p] === true);
+}
+
+function hasActiveProvider(
+  summary: InstrumentSummary,
+  capability: string,
+  provider: string,
+): boolean {
+  const cell = summary.capabilities[capability];
+  if (cell === undefined) return false;
+  return cell.data_present[provider] === true;
 }
 
 function formatDecimal(
@@ -666,7 +696,7 @@ function InstrumentPageBody({
             instrumentId={summary.instrument_id}
             sector={summary.identity.sector}
             currentSymbol={summary.identity.symbol}
-            hasFilingsCoverage={summary.has_filings_coverage}
+            filingsActive={hasActiveCapability(summary, "filings")}
           />
         </div>
       </div>

--- a/tests/api/test_instruments_dividends_endpoint.py
+++ b/tests/api/test_instruments_dividends_endpoint.py
@@ -35,7 +35,7 @@ def _build_app(conn: MagicMock) -> FastAPI:
     return app
 
 
-def _cursor_with(rows: list[dict[str, object] | None]) -> MagicMock:
+def _cursor_with(rows: list[dict[str, object] | tuple[object, ...] | None]) -> MagicMock:
     cur = MagicMock()
     cur.__enter__ = MagicMock(return_value=cur)
     cur.__exit__ = MagicMock(return_value=False)
@@ -67,12 +67,18 @@ def test_dividends_endpoint_returns_summary_and_history() -> None:
     ]
 
     conn = MagicMock()
-    conn.cursor.return_value = _cursor_with([{"instrument_id": 1, "symbol": "AAPL"}])
+    # Endpoint calls fetchone twice: symbol lookup, then ``_has_sec_cik``
+    # SEC-CIK gate. The third call (``get_upcoming_dividends`` is fully
+    # patched below) never reaches conn so the side_effect ends here.
+    conn.cursor.return_value = _cursor_with(
+        [{"instrument_id": 1, "symbol": "AAPL"}, (1,)],
+    )
     app = _build_app(conn)
 
     with (
         patch("app.services.dividends.get_dividend_summary", return_value=summary),
         patch("app.services.dividends.get_dividend_history", return_value=history),
+        patch("app.services.dividends.get_upcoming_dividends", return_value=[]),
         TestClient(app) as client,
     ):
         resp = client.get("/instruments/AAPL/dividends")


### PR DESCRIPTION
## What

PR 3b of #515. Three capability panels refactored into provider-agnostic shells driven by `summary.capabilities[type]`. Tab + panel gating moves off `has_sec_cik` / `has_filings_coverage` shims.

- Backend: `?provider=` query param on `/dividends`, `/insider_summary`, `/insider_transactions`, `/eight_k_filings`. Validated against per-endpoint allowlist (today: SEC providers only).
- `frontend/src/lib/capabilityProviders.ts`: provider tag → label map + `activeProviders()` helper.
- `DividendsPanel` / `InsiderActivityPanel` / `EightKEventsPanel`: take required `provider` prop, forward to fetcher, title shows provider label.
- `ResearchTab`: iterates `summary.capabilities[type]` filtered by `data_present`. Renders one shell per active provider (multi-source ready).
- `InstrumentPage`: tab gates read capabilities. Financials tab gates on `sec_xbrl` provider specifically (endpoint is SEC-XBRL-only — broader gate would dead-end FMP-only instruments).
- `RightRail`: `hasFilingsCoverage` → `filingsActive`, derived at caller.

`SecProfilePanel` + `BusinessSectionsPanel` stay on `has_sec_cik`; their provider-agnostic refactor is a follow-up.

Pre-existing failure in `tests/api/test_instruments_dividends_endpoint.py` fixed in passing.

## Why

Workstream 3 of #515 — capability flags drive UI presentation per-instrument. Per-region integration PRs (Companies House, HKEX, …) only need to add a provider hook + capability default. No panel code changes.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 406 tests pass
- [x] `uv run ruff check .` / `ruff format --check` / `pyright` — clean
- [x] `uv run pytest` — 2778 passed (one pre-existing migration-066 failure unrelated to this PR; will file separate ticket)
- [x] Codex review: 1 round, BLOCKING on Financials tab gate addressed; re-reviewed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)