### PR TITLE
feat(#532): drop FMP from capabilities + provider wiring (stage 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,6 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/ebull
 # for migrating from the old env-var approach.
 ETORO_ENV=demo
 
-# Financial Modelling Prep — fundamentals and screening
-FMP_API_KEY=
-
 # Companies House — UK filing documents (SEC EDGAR needs no key)
 COMPANIES_HOUSE_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Long-horizon AI-assisted investment engine for eToro.
 Backend services implemented:
 - Universe sync
 - Market data (OHLCV, quotes, features)
-- Filings and fundamentals (SEC EDGAR, Companies House, FMP)
+- Filings and fundamentals (SEC EDGAR, Companies House)
 - News and sentiment
 - Thesis engine (#6)
 - Scoring and ranking engine

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -98,8 +98,8 @@ class InstrumentPrice(BaseModel):
 
 # Closed set of values for `InstrumentKeyStats.field_source` entries. Mirror
 # in frontend/src/api/types.ts — consumers rely on this being exhaustive.
-# Per settled decision (eToro = market data, SEC = official filings, FMP =
-# normalized fundamentals), yfinance has no role; #498/#499 retired it.
+# Per settled decision (eToro = market data, SEC = official filings),
+# yfinance has no role; #498/#499 retired it.
 #
 # ``sec_dividend_summary`` distinguishes values sourced from
 # ``instrument_dividend_summary.ttm_yield_pct`` (#426) from values
@@ -497,10 +497,11 @@ def get_instrument_financials(
     """Per-ticker financial statement.
 
     Sourced exclusively from local ``financial_periods`` rows (SEC
-    XBRL-derived). Per the settled provider strategy (#498/#499),
-    yfinance is no longer consulted. Non-US issuers without SEC
-    coverage will return an empty row list until FMP normalisation
-    fills the gap.
+    XBRL-derived). Per the settled provider strategy (#498/#499 +
+    #532), yfinance and paid third-party providers have no role.
+    Non-US issuers without regulated-source coverage in this repo
+    return an empty row list — per-region integration PRs add free
+    regulated providers (Companies House, ESMA, etc.).
 
     Returns an empty row list (not 500, not 404) when no SEC data
     exists — the UI shows "no statement data available".

--- a/app/config.py
+++ b/app/config.py
@@ -24,7 +24,6 @@ class Settings(BaseSettings):
     etoro_env: str = "demo"
     etoro_base_url: str = "https://public-api.etoro.com"
 
-    fmp_api_key: str | None = None
     companies_house_api_key: str | None = None
     # SEC EDGAR requires no API key (public API, 10 req/s fair-use limit)
     sec_user_agent: str = "eBull dev@example.com"
@@ -157,9 +156,8 @@ class Settings(BaseSettings):
     # owns ``fundamentals_snapshot`` refresh for CIK-mapped tradable
     # instruments. Collapses the dual SEC ``companyfacts`` fetch path
     # identified in issue #414 so only one scheduled job hits
-    # ``data.sec.gov/api/xbrl/companyfacts/…`` each day. FMP fallback,
-    # FMP enrichment (profile / earnings / estimates), and Companies
-    # House filings all continue to run in ``daily_research_refresh``
+    # ``data.sec.gov/api/xbrl/companyfacts/…`` each day. Companies
+    # House filings continue to run in ``daily_research_refresh``
     # regardless of this flag.
     # Ship as False (default) → operator flips True → observe ~1 day
     # → follow-up PR deletes the guarded SEC-fundamentals block in

--- a/app/providers/enrichment.py
+++ b/app/providers/enrichment.py
@@ -3,9 +3,7 @@ Enrichment provider interface.
 
 Supplies supplemental instrument data beyond core fundamentals: company profile
 metadata, forward-looking earnings calendar, and analyst consensus estimates.
-
-FMP is the v1 implementation. All domain code imports this interface only —
-never the concrete provider.
+Domain code imports this interface only — never the concrete provider.
 """
 
 from __future__ import annotations

--- a/app/providers/fundamentals.py
+++ b/app/providers/fundamentals.py
@@ -1,8 +1,7 @@
 """
 Fundamentals provider interface.
 
-FMP is the v1 implementation. All domain code imports this interface only —
-never the concrete provider.
+Domain code imports this interface only — never the concrete provider.
 """
 
 from abc import ABC, abstractmethod

--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -5,8 +5,10 @@ Implements FundamentalsProvider against the SEC Company Facts API
 (https://data.sec.gov/api/xbrl/companyfacts/).  Completely free, no API key
 required, 10 req/s rate limit.
 
-This is the primary fundamentals source for US-listed companies.  FMP remains
-as a fallback for non-US equities.
+This is the primary fundamentals source for US-listed companies. Non-US
+issuers without regulated-source coverage in this repo (yet) return empty
+rows from fundamentals queries; per-region integration PRs add their own
+free regulated-source providers (Companies House, ESMA, etc.).
 
 Data extraction strategy:
   - Income / cash-flow items (flow over a period): take the most recent 10-K

--- a/app/services/capabilities.py
+++ b/app/services/capabilities.py
@@ -48,8 +48,6 @@ CapabilityProvider = Literal[
     "sec_form4",
     "sec_13f",
     "sec_13d_13g",
-    # US — non-SEC enrichment
-    "fmp",
     # UK
     "companies_house",
     "lse_rns",
@@ -154,11 +152,9 @@ class ResolvedCapabilities:
 # Mapping from (capability, provider) tuple to the SQL EXISTS
 # test that says "is there at least one row this instrument has
 # from this source for this capability?". Keyed on the tuple
-# because one provider tag (e.g. ``fmp``) can serve multiple
-# capabilities by reading different tables (``fundamentals_snapshot``
-# for ``fundamentals`` vs ``analyst_estimates`` for ``analyst``) —
-# a flat-per-provider lookup misreports ``analyst`` coverage off
-# fundamentals data alone (Codex round-2 finding on PR 3a).
+# because one provider tag could in principle serve multiple
+# capabilities by reading different tables. The (capability,
+# provider) keying makes that future-proof without ambiguity.
 #
 # Capability-agnostic providers (``sec_xbrl`` / ``sec_form4`` etc.)
 # repeat the same SQL across the (capability, provider) pairs they
@@ -184,9 +180,6 @@ _PRESENCE_QUERIES: dict[tuple[str, str], str] = {
     ("insider", "sec_form4"): ("SELECT EXISTS(SELECT 1 FROM insider_transactions t WHERE t.instrument_id = %s)"),
     # ``ownership`` (sec_13f / sec_13d_13g) — no eBull table yet,
     # falls through to the dict-miss → False branch below.
-    # FMP serves two capabilities via two different tables.
-    ("fundamentals", "fmp"): ("SELECT EXISTS(SELECT 1 FROM fundamentals_snapshot s WHERE s.instrument_id = %s)"),
-    ("analyst", "fmp"): ("SELECT EXISTS(SELECT 1 FROM analyst_estimates a WHERE a.instrument_id = %s)"),
     # UK / EU / Asia / MENA / crypto / commodity / FX / Canada
     # providers — no eBull tables yet for any of these, so missing
     # entries fall through to ``data_present = False`` via the
@@ -258,13 +251,12 @@ def resolve_capabilities(
             # capabilities to whatever the exchange row already
             # provides.
             augmentations.setdefault("filings", []).append("sec_edgar")
-            augmentations.setdefault("fundamentals", []).extend(["sec_xbrl", "fmp"])
+            augmentations.setdefault("fundamentals", []).append("sec_xbrl")
             augmentations.setdefault("dividends", []).append("sec_dividend_summary")
             augmentations.setdefault("insider", []).append("sec_form4")
             augmentations.setdefault("ownership", []).extend(["sec_13f", "sec_13d_13g"])
             augmentations.setdefault("corporate_events", []).append("sec_8k_events")
             augmentations.setdefault("business_summary", []).append("sec_10k_item1")
-            augmentations.setdefault("analyst", []).append("fmp")
 
     cells: dict[CapabilityName, CapabilityCell] = {}
     for cap in V1_CAPABILITIES:
@@ -321,10 +313,8 @@ def _compute_data_present(
 
     The (capability, provider) keying matters because the same
     provider tag can serve multiple capabilities by reading
-    different tables — ``fmp`` backs both ``fundamentals``
-    (fundamentals_snapshot) and ``analyst`` (analyst_estimates).
-    A flat-per-provider lookup misreports analyst coverage from
-    fundamentals data (Codex round 2 finding on PR 3a).
+    different tables. The keying makes that future-proof without
+    ambiguity (Codex round 2 finding on PR 3a).
     """
     out: dict[str, bool] = {}
     for provider in providers:

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -2,7 +2,7 @@
 
 Per the 2026-04-19 research-tool refocus §1.1 (Chunk 4), this module merges:
 
-- fundamentals.py — FMP snapshot upserts (kept as Section 1)
+- fundamentals.py — fundamentals_snapshot upserts (kept as Section 1)
 - financial_facts.py — XBRL fact storage + ingestion run tracking (Section 2)
 - financial_normalization.py — period derivation + canonical merge (Section 3)
 - sec_incremental.py — SEC change-driven planner/executor (Section 4)
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 class FundamentalsRefreshSummary:
     symbols_attempted: int
     snapshots_upserted: int
-    symbols_skipped: int  # no FMP coverage or identifier missing
+    symbols_skipped: int  # no provider coverage or identifier missing
 
 
 def refresh_fundamentals(
@@ -66,10 +66,11 @@ def refresh_fundamentals(
     """
     For each symbol, fetch the latest fundamentals snapshot and upsert it.
 
-    symbols is a list of (symbol, instrument_id) tuples. FMP uses the ticker
-    symbol as its primary identifier, so no external_identifiers lookup is
-    needed for FMP in v1. If the provider returns None for a symbol, that
-    symbol is skipped and counted.
+    symbols is a list of (symbol, instrument_id) tuples. Providers may
+    use the ticker symbol as their primary identifier or look up the
+    instrument's ``external_identifiers`` row themselves. If the
+    provider returns None for a symbol, that symbol is skipped and
+    counted.
     """
     upserted = 0
     skipped = 0
@@ -1032,7 +1033,6 @@ def _canonical_merge_instrument(
                      CASE source
                          WHEN 'sec_edgar' THEN 1
                          WHEN 'companies_house' THEN 2
-                         WHEN 'fmp' THEN 3
                          ELSE 99
                      END,
                      filed_date DESC NULLS LAST

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -35,13 +35,11 @@ from psycopg.types.json import Jsonb
 from app.config import settings
 from app.providers.implementations.companies_house import CompaniesHouseFilingsProvider
 from app.providers.implementations.etoro import EtoroMarketDataProvider
-from app.providers.implementations.fmp import FmpFundamentalsProvider
 from app.providers.implementations.sec_edgar import SecFilingsProvider
 from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
 from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
 from app.services.coverage import bootstrap_missing_coverage_rows, review_coverage, seed_coverage
 from app.services.deferred_retry import retry_deferred_recommendations
-from app.services.enrichment import refresh_enrichment
 from app.services.entry_timing import evaluate_entry_conditions
 from app.services.etoro_lookups import refresh_etoro_lookups
 from app.services.exchanges import refresh_exchanges_metadata
@@ -77,7 +75,7 @@ from app.services.sync_orchestrator.progress import report_progress
 from app.services.sync_orchestrator.row_count_spikes import check_row_count_spike
 from app.services.tax_ledger import ingest_tax_events, run_disposal_matching
 from app.services.thesis import find_stale_instruments, generate_thesis
-from app.services.universe import enrich_instrument_currencies, sync_universe
+from app.services.universe import sync_universe
 from app.services.watermarks import get_watermark, set_watermark
 
 logger = logging.getLogger(__name__)
@@ -919,29 +917,6 @@ def nightly_universe_sync() -> None:
                     bootstrap_result.bootstrapped,
                 )
 
-            # Enrich instrument currencies from FMP for instruments that
-            # are missing currency data or haven't been enriched in 90 days.
-            # Uses a separate autocommit connection so each per-instrument
-            # UPDATE commits independently, and HTTP I/O (FMP API calls)
-            # does not hold a transaction open.
-            if settings.fmp_api_key:
-                try:
-                    with (
-                        FmpFundamentalsProvider(api_key=settings.fmp_api_key) as fmp_provider,
-                        psycopg.connect(settings.database_url, autocommit=True) as enrich_conn,
-                    ):
-                        enriched = enrich_instrument_currencies(fmp_provider, enrich_conn)
-                        row_count += enriched
-                        tracker.row_count = row_count
-                        logger.info("Currency enrichment: enriched=%d", enriched)
-                except Exception:
-                    logger.warning(
-                        "Currency enrichment failed; universe sync and coverage still committed",
-                        exc_info=True,
-                    )
-            else:
-                logger.info("Currency enrichment skipped: FMP API key not configured")
-
             tracker.row_count = row_count
 
 
@@ -1215,7 +1190,6 @@ def daily_research_refresh() -> None:
 
     Runs daily. Fetches:
       - SEC XBRL fundamentals (primary, free) for US instruments with a CIK
-      - FMP fundamentals (fallback) for remaining instruments if API key is set
       - SEC EDGAR filing metadata for US instruments with a known CIK
       - Companies House filing metadata for UK instruments with a company_number
 
@@ -1268,8 +1242,7 @@ def daily_research_refresh() -> None:
         # skip this call entirely. ``fundamentals_sync`` phase 1b already
         # refreshes ``fundamentals_snapshot`` for every CIK-mapped
         # tradable instrument daily at 02:30 UTC — same data, one HTTP
-        # path. Keeps FMP (non-US) + enrichment + CH filings below
-        # unchanged.
+        # path. Companies House filings below run regardless.
         sec_symbols = [(sym, iid) for sym, iid in symbols if sym.upper() in cik_map]
         if settings.enable_sec_fundamentals_dedupe:
             logger.info(
@@ -1292,49 +1265,6 @@ def daily_research_refresh() -> None:
             )
         else:
             logger.info("daily_research_refresh: no CIK mappings, skipping SEC fundamentals")
-
-        # Fundamentals — FMP (fallback for non-US instruments)
-        fmp_symbols = [(sym, iid) for sym, iid in symbols if sym.upper() not in cik_map]
-        if settings.fmp_api_key:
-            if fmp_symbols:
-                with (
-                    FmpFundamentalsProvider(api_key=settings.fmp_api_key) as fmp,
-                    psycopg.connect(settings.database_url) as conn,
-                ):
-                    fmp_summary = refresh_fundamentals(fmp, conn, fmp_symbols)
-                total_rows += fmp_summary.snapshots_upserted
-                logger.info(
-                    "FMP fundamentals refresh (non-US fallback): attempted=%d upserted=%d skipped=%d",
-                    fmp_summary.symbols_attempted,
-                    fmp_summary.snapshots_upserted,
-                    fmp_summary.symbols_skipped,
-                )
-        elif fmp_symbols:
-            logger.warning(
-                "FMP_API_KEY not set; %d non-US instruments will have no fundamentals",
-                len(fmp_symbols),
-            )
-
-        # Enrichment — profile, earnings, analyst estimates (FMP)
-        if settings.fmp_api_key:
-            try:
-                with (
-                    FmpFundamentalsProvider(api_key=settings.fmp_api_key) as fmp,
-                    psycopg.connect(settings.database_url) as conn,
-                ):
-                    enrich_summary = refresh_enrichment(fmp, conn, symbols)
-                    conn.commit()
-                total_rows += enrich_summary.profiles_upserted + enrich_summary.earnings_upserted
-                logger.info(
-                    "Enrichment refresh: attempted=%d profiles=%d earnings=%d estimates=%d skipped=%d",
-                    enrich_summary.symbols_attempted,
-                    enrich_summary.profiles_upserted,
-                    enrich_summary.earnings_upserted,
-                    enrich_summary.estimates_upserted,
-                    enrich_summary.symbols_skipped,
-                )
-            except Exception:
-                logger.warning("Enrichment refresh failed", exc_info=True)
 
         # Filings — SEC EDGAR
         # Chunk L: when ``enable_filings_fetch_dedupe`` is True, skip

--- a/docs/per-exchange-capability-matrix.md
+++ b/docs/per-exchange-capability-matrix.md
@@ -38,15 +38,15 @@ Per the #515 spec, PR 3 does the explicit reconciliation: the schema migration a
 
 ## US (already covered — document only)
 
-Investigation: NONE — SEC EDGAR + FMP already wired since pre-#515.
+Investigation: NONE — SEC EDGAR already wired since pre-#515. FMP retired in #532 (free regulated-source-only posture).
 
 | Capability | `4` Nasdaq | `5` NYSE | `19` OTC Markets | `20` CBOE | `33` RTH |
 |------------|------------|----------|------------------|-----------|----------|
 | filings | `["sec_xbrl"]` | `["sec_xbrl"]` | `["sec_xbrl"]` | `["sec_xbrl"]` | `["sec_xbrl"]` |
-| fundamentals | `["sec_xbrl", "fmp"]` | `["sec_xbrl", "fmp"]` | `["sec_xbrl", "fmp"]` | `["sec_xbrl", "fmp"]` | `["sec_xbrl", "fmp"]` |
+| fundamentals | `["sec_xbrl"]` | `["sec_xbrl"]` | `["sec_xbrl"]` | `["sec_xbrl"]` | `["sec_xbrl"]` |
 | dividends | `["sec_8k_item_801"]` | `["sec_8k_item_801"]` | `["sec_8k_item_801"]` | `["sec_8k_item_801"]` | `["sec_8k_item_801"]` |
 | insider | `["sec_form4"]` | `["sec_form4"]` | `["sec_form4"]` | `["sec_form4"]` | `["sec_form4"]` |
-| analyst | `["fmp"]` | `["fmp"]` | `["fmp"]` | `["fmp"]` | `["fmp"]` |
+| analyst | `[]` | `[]` | `[]` | `[]` | `[]` |
 | ratings | `[]` | `[]` | `[]` | `[]` | `[]` |
 | esg | `[]` | `[]` | `[]` | `[]` | `[]` |
 | ownership | `["sec_13f", "sec_13d_13g"]` | `["sec_13f", "sec_13d_13g"]` | `["sec_13f", "sec_13d_13g"]` | `["sec_13f", "sec_13d_13g"]` | `["sec_13f", "sec_13d_13g"]` |
@@ -77,13 +77,13 @@ Venues: `7` LSE, `42` LSE_AIM, `43` LSE AIM Auction, `44` LSE Auction.
 | business_summary | _pending #516_ | _pending #516_ | _pending #516_ | _pending #516_ |
 | officers | _pending #516_ | _pending #516_ | _pending #516_ | _pending #516_ |
 
-Source candidates to evaluate: Companies House (free, full filings + officers + accounts), LSE RNS (free announcements). Working hypothesis: filings/officers via Companies House; dividends + corporate_events via LSE RNS; fundamentals possibly via FMP if Companies House XBRL coverage is thin.
+Source candidates to evaluate: Companies House (free, full filings + officers + accounts), LSE RNS (free announcements). Working hypothesis: filings/officers via Companies House; dividends + corporate_events via LSE RNS; fundamentals via Companies House XBRL where coverage exists, otherwise empty (free regulated-source-only posture per #532).
 
 ## EU — investigation ticket #517
 
 Venues: 22 EU venues across `6` FRA / `9` Paris / `10` Madrid / `11` Borsa Italiana / `12` SIX / `14` Oslo / `15` Stockholm / `16` Copenhagen / `17` Helsinki / `22` Lisbon / `23` Brussels / `30` Amsterdam / `32` Vienna / `34` Dublin EN / `35` Prague / `36` Warsaw / `37` Budapest / `38` Xetra ETFs / `50` Nasdaq Iceland / `51` Tallinn / `52` Vilnius / `53` Riga.
 
-Source candidates: ESMA register (pan-EU regulatory data), national regulators (BaFin/AMF/CONSOB/AFM/CMVM/...), Euronext announcements (Paris/Amsterdam/Brussels/Lisbon/Dublin), FMP for fundamentals where coverage exists.
+Source candidates: ESMA register (pan-EU regulatory data), national regulators (BaFin/AMF/CONSOB/AFM/CMVM/...), Euronext announcements (Paris/Amsterdam/Brussels/Lisbon/Dublin). No paid providers (free regulated-source-only posture per #532).
 
 One per-venue capability table follows; every cell `_pending #517_` until investigation lands.
 

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -44,8 +44,12 @@ Before designing or coding for an issue:
   - portfolio/account data
   - execution
 
-### Fundamentals provider
-- FMP is the normalized fundamentals provider in v1.
+### Fundamentals provider posture
+
+- Free regulated-source-only (#532). No paid third-party fundamentals provider.
+- US: SEC XBRL via EDGAR Company Facts API.
+- UK / EU / Asia / MENA / Canada: per-region integration PRs land their own
+  free regulated-source providers (Companies House, ESMA, etc.).
 
 ### Official filings providers
 - SEC EDGAR is the official filings source for US issuers.

--- a/frontend/src/lib/capabilityProviders.ts
+++ b/frontend/src/lib/capabilityProviders.ts
@@ -21,8 +21,6 @@ const PROVIDER_LABEL: Record<string, string> = {
   sec_form4: "SEC Form 4",
   sec_13f: "SEC 13F",
   sec_13d_13g: "SEC 13D/G",
-  // US — non-SEC enrichment
-  fmp: "FMP",
   // UK
   companies_house: "Companies House",
   lse_rns: "LSE RNS",

--- a/sql/072_drop_fmp_from_capabilities.sql
+++ b/sql/072_drop_fmp_from_capabilities.sql
@@ -1,0 +1,50 @@
+-- Migration 072 — drop FMP from exchanges.capabilities (#532).
+--
+-- FMP is a paid third-party data provider; eBull stance is
+-- free regulated-source-only. Migration 071 seeded us_equity
+-- capabilities with FMP listed under ``fundamentals`` and
+-- ``analyst``. This migration retracts that to keep the seed
+-- consistent with the runtime capability resolver after the
+-- FMP provider tag was removed from CAPABILITY_PROVIDERS.
+--
+-- Surgical: removes only the ``fmp`` element from each array.
+-- Operator overrides that have added other providers (e.g.
+-- ``["sec_xbrl", "fmp", "custom_provider"]``) keep their
+-- non-fmp additions. Idempotent: rows that no longer contain
+-- ``fmp`` are untouched.
+
+BEGIN;
+
+-- fundamentals: drop fmp element if present
+UPDATE exchanges
+   SET capabilities = jsonb_set(
+           capabilities,
+           '{fundamentals}',
+           COALESCE(
+               (SELECT jsonb_agg(elem)
+                  FROM jsonb_array_elements(capabilities -> 'fundamentals') elem
+                 WHERE elem <> '"fmp"'::jsonb),
+               '[]'::jsonb
+           )
+       ),
+       updated_at = NOW()
+ WHERE capabilities ? 'fundamentals'
+   AND (capabilities -> 'fundamentals') ? 'fmp';
+
+-- analyst: drop fmp element if present
+UPDATE exchanges
+   SET capabilities = jsonb_set(
+           capabilities,
+           '{analyst}',
+           COALESCE(
+               (SELECT jsonb_agg(elem)
+                  FROM jsonb_array_elements(capabilities -> 'analyst') elem
+                 WHERE elem <> '"fmp"'::jsonb),
+               '[]'::jsonb
+           )
+       ),
+       updated_at = NOW()
+ WHERE capabilities ? 'analyst'
+   AND (capabilities -> 'analyst') ? 'fmp';
+
+COMMIT;

--- a/sql/073_purge_fmp_data.sql
+++ b/sql/073_purge_fmp_data.sql
@@ -1,0 +1,59 @@
+-- Migration 073 — purge FMP-sourced data from read paths (#532).
+--
+-- Stage 1 of FMP removal stopped future writes. This migration
+-- purges already-ingested FMP-backed rows so user-visible
+-- behaviour matches the new free-regulated-source-only posture.
+--
+-- Tables affected:
+--
+-- 1. ``financial_periods`` — DELETE WHERE source = 'fmp'.
+--    Non-US instruments lose their FMP-derived rows. Honest
+--    state under #532: those issuers have no regulated-source
+--    fundamentals until per-region PRs (#516-#523) land their
+--    own free providers.
+--
+-- 2. ``financial_periods_raw`` — same (the raw layer that feeds
+--    ``financial_periods`` via the source-priority CASE).
+--
+-- 3. ``analyst_estimates`` — TRUNCATE. Table is FMP-only.
+--    No replacement source in v1 (free analyst consensus is rare;
+--    deferred to a follow-up spec).
+--
+-- 4. ``earnings_events`` — TRUNCATE. Table is FMP-only.
+--    Replacement comes via SEC 8-K Item 2.02 / 8-K item events
+--    (already wired) and per-region calendars in future PRs.
+--
+-- 5. ``fundamentals_snapshot`` — DELETE rows for instruments
+--    without a primary SEC CIK. The table has no ``source``
+--    column so SEC- and FMP-written rows are indistinguishable,
+--    but rows for instruments without a SEC CIK can only have
+--    been FMP-written. SEC-CIK rows stay (they get refreshed by
+--    the next SEC fundamentals run; even if FMP previously
+--    overlaid them, SEC overwrites on next ingest).
+--
+--    Stage 3 (#540) retrofits consumers to a regulated-source-
+--    only model; stage 4 (#541) drops the table outright. Until
+--    then this surgical purge keeps user-visible behaviour
+--    honest under the FMP-free posture.
+--
+-- ``instrument_profile`` is FMP-only but its writers are still in
+-- the codebase (gated by FMP_API_KEY which is now empty). Drop
+-- the table in stage 2 (#539) along with the writer code.
+
+BEGIN;
+
+DELETE FROM financial_periods WHERE source = 'fmp';
+DELETE FROM financial_periods_raw WHERE source = 'fmp';
+TRUNCATE TABLE analyst_estimates;
+TRUNCATE TABLE earnings_events;
+
+DELETE FROM fundamentals_snapshot fs
+ WHERE NOT EXISTS (
+        SELECT 1 FROM external_identifiers e
+         WHERE e.instrument_id  = fs.instrument_id
+           AND e.provider       = 'sec'
+           AND e.identifier_type = 'cik'
+           AND e.is_primary     = TRUE
+       );
+
+COMMIT;

--- a/tests/test_capabilities_resolver.py
+++ b/tests/test_capabilities_resolver.py
@@ -471,58 +471,12 @@ def test_non_primary_sec_cik_does_not_augment(
         )
 
 
-def test_fmp_serves_fundamentals_and_analyst_via_distinct_tables(
-    ebull_test_conn: psycopg.Connection[tuple],
-) -> None:
-    """The ``fmp`` provider tag backs both ``fundamentals`` (via
-    fundamentals_snapshot) and ``analyst`` (via analyst_estimates).
-    A row in fundamentals_snapshot must NOT make
-    analyst.data_present[fmp] = True. Codex round-2 finding on
-    PR 3a: pre-fix, the resolver shared a single SQL EXISTS per
-    provider, mis-reporting analyst coverage off fundamentals
-    data alone."""
-    _seed_exchange_with_capabilities(
-        ebull_test_conn,
-        exchange_id="test_cap_009",
-        asset_class="us_equity",
-        capabilities={
-            **{cap: [] for cap in V1_CAPABILITIES},
-            "fundamentals": ["fmp"],
-            "analyst": ["fmp"],
-        },
-    )
-    _seed_instrument(
-        ebull_test_conn,
-        instrument_id=960009,
-        symbol="CAP9",
-        exchange="test_cap_009",
-    )
-    with ebull_test_conn.cursor() as cur:
-        cur.execute(
-            """
-            INSERT INTO fundamentals_snapshot
-                (instrument_id, as_of_date)
-            VALUES (%s, '2026-04-25')
-            """,
-            (960009,),
-        )
-    ebull_test_conn.commit()
-
-    try:
-        resolved = resolve_capabilities(
-            ebull_test_conn,
-            instrument_id=960009,
-            exchange_id="test_cap_009",
-        )
-        assert resolved.cells["fundamentals"].data_present == {"fmp": True}
-        # No row in analyst_estimates → analyst.data_present must
-        # be False even though fmp also serves fundamentals.
-        assert resolved.cells["analyst"].data_present == {"fmp": False}
-    finally:
-        with ebull_test_conn.cursor() as cur:
-            cur.execute("DELETE FROM fundamentals_snapshot WHERE instrument_id = %s", (960009,))
-        _cleanup(
-            ebull_test_conn,
-            instrument_ids=[960009],
-            exchange_ids=["test_cap_009"],
-        )
+# Note: pre-#532 this slot held
+# ``test_fmp_serves_fundamentals_and_analyst_via_distinct_tables``,
+# pinning that the (capability, provider) keying did not bleed
+# fundamentals data into analyst's data_present. FMP was retired
+# in #532 (free regulated-source-only posture); the keying logic
+# itself remains correct and is exercised by the existing SEC
+# tests above. If a future provider serves multiple capabilities
+# via distinct tables, restore this style of test pinned on the
+# new provider.

--- a/tests/test_daily_research_refresh_dedupe.py
+++ b/tests/test_daily_research_refresh_dedupe.py
@@ -79,7 +79,6 @@ def test_flag_false_calls_sec_refresh_filings(monkeypatch) -> None:
     stub_settings.database_url = "postgresql://test"
     stub_settings.sec_user_agent = "test"
     stub_settings.companies_house_api_key = None
-    stub_settings.fmp_api_key = None
     stub_settings.enable_filings_fetch_dedupe = False
     stub_settings.enable_sec_fundamentals_dedupe = False
     monkeypatch.setattr(scheduler, "settings", stub_settings)
@@ -101,7 +100,6 @@ def test_flag_true_skips_sec_refresh_filings(monkeypatch) -> None:
     stub_settings.database_url = "postgresql://test"
     stub_settings.sec_user_agent = "test"
     stub_settings.companies_house_api_key = None
-    stub_settings.fmp_api_key = None
     stub_settings.enable_filings_fetch_dedupe = True
     stub_settings.enable_sec_fundamentals_dedupe = False
     monkeypatch.setattr(scheduler, "settings", stub_settings)
@@ -125,7 +123,6 @@ def test_flag_true_leaves_ch_filings_path_available(monkeypatch) -> None:
     stub_settings.database_url = "postgresql://test"
     stub_settings.sec_user_agent = "test"
     stub_settings.companies_house_api_key = "ch-key"
-    stub_settings.fmp_api_key = None
     stub_settings.enable_filings_fetch_dedupe = True
     stub_settings.enable_sec_fundamentals_dedupe = False
     monkeypatch.setattr(scheduler, "settings", stub_settings)
@@ -160,7 +157,6 @@ def test_sec_fundamentals_flag_false_calls_refresh_fundamentals(monkeypatch) -> 
     stub_settings.database_url = "postgresql://test"
     stub_settings.sec_user_agent = "test"
     stub_settings.companies_house_api_key = None
-    stub_settings.fmp_api_key = None
     stub_settings.enable_filings_fetch_dedupe = True  # irrelevant to this test
     stub_settings.enable_sec_fundamentals_dedupe = False
     monkeypatch.setattr(scheduler, "settings", stub_settings)
@@ -169,22 +165,20 @@ def test_sec_fundamentals_flag_false_calls_refresh_fundamentals(monkeypatch) -> 
 
     scheduler.daily_research_refresh()
 
-    # refresh_fundamentals fires once for the SEC-fundamentals block
-    # (no FMP fallback because fmp_api_key is unset and all symbols
-    # have CIKs, so fmp_symbols is empty).
+    # refresh_fundamentals fires once for the SEC-fundamentals block.
+    # FMP was retired in #532; no fallback path remains.
     assert refresh_fund_mock.call_count == 1
 
 
 def test_sec_fundamentals_flag_true_skips_refresh_fundamentals(monkeypatch) -> None:
     """#414 behaviour — flag on, SEC XBRL ``refresh_fundamentals`` block
     skipped. ``fundamentals_sync`` phase 1b is now the single path that
-    hits ``data.sec.gov/api/xbrl/companyfacts/…``. FMP fallback and
-    enrichment paths are untouched."""
+    hits ``data.sec.gov/api/xbrl/companyfacts/…``. Companies House
+    filings path is unaffected."""
     stub_settings = MagicMock()
     stub_settings.database_url = "postgresql://test"
     stub_settings.sec_user_agent = "test"
     stub_settings.companies_house_api_key = None
-    stub_settings.fmp_api_key = None
     stub_settings.enable_filings_fetch_dedupe = True
     stub_settings.enable_sec_fundamentals_dedupe = True
     monkeypatch.setattr(scheduler, "settings", stub_settings)
@@ -193,63 +187,6 @@ def test_sec_fundamentals_flag_true_skips_refresh_fundamentals(monkeypatch) -> N
 
     scheduler.daily_research_refresh()
 
-    # No SEC XBRL path AND no FMP path (fmp_api_key unset), so
-    # refresh_fundamentals is never called.
+    # No SEC XBRL path means refresh_fundamentals is never called.
+    # FMP was retired in #532 — no fallback path remains.
     refresh_fund_mock.assert_not_called()
-
-
-def test_sec_fundamentals_flag_true_preserves_fmp_path(monkeypatch) -> None:
-    """Flag affects only the SEC XBRL block — FMP fallback for non-US
-    tickers still fires when FMP_API_KEY is set."""
-    stub_settings = MagicMock()
-    stub_settings.database_url = "postgresql://test"
-    stub_settings.sec_user_agent = "test"
-    stub_settings.companies_house_api_key = None
-    stub_settings.fmp_api_key = "fmp-key"
-    stub_settings.enable_filings_fetch_dedupe = True
-    stub_settings.enable_sec_fundamentals_dedupe = True
-    monkeypatch.setattr(scheduler, "settings", stub_settings)
-
-    # Override cik_rows to empty — all symbols become FMP fallback.
-    tracker = MagicMock()
-    cm = MagicMock()
-    cm.__enter__.return_value = tracker
-    cm.__exit__.return_value = False
-    monkeypatch.setattr(scheduler, "_tracked_job", MagicMock(return_value=cm))
-
-    fake_conn = MagicMock()
-    fake_conn.execute.return_value.fetchall.side_effect = [
-        [("FOO", "1"), ("BAR", "2")],  # tradable rows (non-US)
-        [],  # cik rows empty → all go to FMP
-    ]
-    conn_cm = MagicMock()
-    conn_cm.__enter__.return_value = fake_conn
-    conn_cm.__exit__.return_value = False
-    monkeypatch.setattr(scheduler.psycopg, "connect", MagicMock(return_value=conn_cm))
-
-    fmp_cm = MagicMock()
-    fmp_cm.__enter__.return_value = MagicMock()
-    fmp_cm.__exit__.return_value = False
-    monkeypatch.setattr(scheduler, "FmpFundamentalsProvider", MagicMock(return_value=fmp_cm))
-    monkeypatch.setattr(scheduler, "SecFundamentalsProvider", MagicMock())
-
-    refresh_fund_mock = MagicMock(return_value=MagicMock(symbols_attempted=2, snapshots_upserted=2, symbols_skipped=0))
-    monkeypatch.setattr(scheduler, "refresh_fundamentals", refresh_fund_mock)
-    monkeypatch.setattr(
-        scheduler,
-        "refresh_enrichment",
-        MagicMock(
-            return_value=MagicMock(
-                symbols_attempted=2,
-                profiles_upserted=0,
-                earnings_upserted=0,
-                estimates_upserted=0,
-                symbols_skipped=0,
-            )
-        ),
-    )
-
-    scheduler.daily_research_refresh()
-
-    # FMP fallback fires once — no SEC XBRL block.
-    assert refresh_fund_mock.call_count == 1

--- a/tests/test_migration_071_exchanges_capabilities.py
+++ b/tests/test_migration_071_exchanges_capabilities.py
@@ -4,9 +4,11 @@ Pins three contracts:
 
 1. ``exchanges.capabilities`` JSONB column exists with the
    ``jsonb_typeof = 'object'`` CHECK constraint.
-2. Every ``us_equity`` row gets the canonical SEC + FMP seed (the
+2. Every ``us_equity`` row gets the canonical SEC seed (the
    ``filings`` cell uses ``sec_edgar``, NOT ``sec_xbrl`` — Codex
-   round-1 finding caught the conflation).
+   round-1 finding caught the conflation). FMP was seeded by the
+   original 071 migration but #532's migration 072 retracts it
+   to keep the seed aligned with the FMP-free runtime.
 3. Every non-``us_equity`` row gets the empty-but-correctly-shaped
    default object so the resolver doesn't have to special-case
    missing keys.
@@ -77,15 +79,14 @@ def test_us_equity_seed_includes_sec_edgar_for_filings(
 def test_us_equity_seed_full_shape(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    """Pin the full us_equity capability seed so a future drift
-    in the migration's UPDATE values is caught (e.g. someone
-    swaps fmp into ratings by accident)."""
+    """Pin the full us_equity capability seed (post-072) so a
+    future drift in the migration's UPDATE values is caught."""
     expected = {
         "filings": ["sec_edgar"],
-        "fundamentals": ["sec_xbrl", "fmp"],
+        "fundamentals": ["sec_xbrl"],
         "dividends": ["sec_dividend_summary"],
         "insider": ["sec_form4"],
-        "analyst": ["fmp"],
+        "analyst": [],
         "ratings": [],
         "esg": [],
         "ownership": ["sec_13f", "sec_13d_13g"],

--- a/tests/test_migration_072_073_drop_fmp.py
+++ b/tests/test_migration_072_073_drop_fmp.py
@@ -1,0 +1,242 @@
+"""Regression tests for migrations 072 + 073 (#532 stage 1).
+
+Pins the surgical contracts Codex flagged on PR review:
+
+* 072 — FMP element is REMOVED from each capability array,
+  not the array clobbered. Operator overrides like
+  ``["sec_xbrl", "fmp", "custom"]`` keep their non-fmp
+  additions.
+* 073 — ``fundamentals_snapshot`` rows for instruments WITHOUT
+  a primary SEC CIK get deleted (FMP-only rows). Rows for SEC-
+  CIK instruments survive (SEC overwrites them on next ingest).
+
+Migration 071 + 072 + 073 all run at fixture setup; tests assert
+post-migration state on a controlled seed inserted into ebull_test.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_072_preserves_custom_providers_in_mixed_arrays(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Operator override containing custom providers alongside fmp
+    keeps the non-fmp additions when 072 strips fmp.
+
+    Re-runs the 072 UPDATE against a synthetic operator-override
+    row to pin the surgical behaviour: only ``fmp`` is removed.
+    """
+    exchange_id = "test_072_custom"
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("DELETE FROM exchanges WHERE exchange_id = %s", (exchange_id,))
+        cur.execute(
+            """
+            INSERT INTO exchanges (
+                exchange_id, asset_class, capabilities
+            )
+            VALUES (
+                %s,
+                'us_equity',
+                jsonb_build_object(
+                    'fundamentals', jsonb_build_array('sec_xbrl', 'fmp', 'custom_x'),
+                    'analyst',      jsonb_build_array('fmp', 'custom_y')
+                )
+            )
+            """,
+            (exchange_id,),
+        )
+    ebull_test_conn.commit()
+
+    # Re-run the 072 UPDATE. Migration 071 + 072 already ran at
+    # fixture setup, but only against rows that existed at that
+    # point — this row is new, so we re-execute the same logic.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE exchanges
+               SET capabilities = jsonb_set(
+                       capabilities,
+                       '{fundamentals}',
+                       COALESCE(
+                           (SELECT jsonb_agg(elem)
+                              FROM jsonb_array_elements(capabilities -> 'fundamentals') elem
+                             WHERE elem <> '"fmp"'::jsonb),
+                           '[]'::jsonb
+                       )
+                   )
+             WHERE exchange_id = %s AND (capabilities -> 'fundamentals') ? 'fmp'
+            """,
+            (exchange_id,),
+        )
+        cur.execute(
+            """
+            UPDATE exchanges
+               SET capabilities = jsonb_set(
+                       capabilities,
+                       '{analyst}',
+                       COALESCE(
+                           (SELECT jsonb_agg(elem)
+                              FROM jsonb_array_elements(capabilities -> 'analyst') elem
+                             WHERE elem <> '"fmp"'::jsonb),
+                           '[]'::jsonb
+                       )
+                   )
+             WHERE exchange_id = %s AND (capabilities -> 'analyst') ? 'fmp'
+            """,
+            (exchange_id,),
+        )
+        cur.execute(
+            "SELECT capabilities FROM exchanges WHERE exchange_id = %s",
+            (exchange_id,),
+        )
+        row = cur.fetchone()
+
+    try:
+        assert row is not None
+        capabilities = row[0]
+        assert capabilities["fundamentals"] == ["sec_xbrl", "custom_x"]
+        assert capabilities["analyst"] == ["custom_y"]
+    finally:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("DELETE FROM exchanges WHERE exchange_id = %s", (exchange_id,))
+        ebull_test_conn.commit()
+
+
+def test_072_idempotent_on_already_clean_arrays(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A row that already has no ``fmp`` is untouched by 072 (no
+    spurious updated_at bump, no array-shape rewrite)."""
+    exchange_id = "test_072_clean"
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("DELETE FROM exchanges WHERE exchange_id = %s", (exchange_id,))
+        cur.execute(
+            """
+            INSERT INTO exchanges (
+                exchange_id, asset_class, capabilities
+            )
+            VALUES (
+                %s,
+                'us_equity',
+                jsonb_build_object(
+                    'fundamentals', jsonb_build_array('sec_xbrl'),
+                    'analyst',      jsonb_build_array()
+                )
+            )
+            """,
+            (exchange_id,),
+        )
+    ebull_test_conn.commit()
+
+    # Re-run the WHERE-guarded UPDATE; it must skip this row.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE exchanges
+               SET capabilities = jsonb_set(
+                       capabilities,
+                       '{fundamentals}',
+                       '[]'::jsonb
+                   )
+             WHERE exchange_id = %s
+               AND capabilities ? 'fundamentals'
+               AND (capabilities -> 'fundamentals') ? 'fmp'
+            """,
+            (exchange_id,),
+        )
+        affected = cur.rowcount
+        cur.execute(
+            "SELECT capabilities FROM exchanges WHERE exchange_id = %s",
+            (exchange_id,),
+        )
+        row = cur.fetchone()
+
+    try:
+        assert affected == 0  # WHERE didn't match
+        assert row is not None
+        assert row[0]["fundamentals"] == ["sec_xbrl"]
+    finally:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("DELETE FROM exchanges WHERE exchange_id = %s", (exchange_id,))
+        ebull_test_conn.commit()
+
+
+def test_073_purges_fundamentals_snapshot_for_non_sec_cik_instruments(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """fundamentals_snapshot rows for instruments WITHOUT a primary
+    SEC CIK get deleted by migration 073. Rows WITH a SEC CIK
+    survive."""
+    sec_id = 970001
+    fmp_id = 970002
+    exchange_id = "test_073_x"
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("DELETE FROM exchanges WHERE exchange_id = %s", (exchange_id,))
+        cur.execute(
+            "INSERT INTO exchanges (exchange_id, asset_class, capabilities) VALUES (%s, 'us_equity', '{}'::jsonb)",
+            (exchange_id,),
+        )
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, exchange) "
+            "VALUES (%s, 'TST073A', 'Test 073 A', %s), (%s, 'TST073B', 'Test 073 B', %s)",
+            (sec_id, exchange_id, fmp_id, exchange_id),
+        )
+        # SEC-CIK on sec_id; fmp_id has no SEC CIK (FMP-only).
+        cur.execute(
+            "INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary) "
+            "VALUES (%s, 'sec', 'cik', '0000999991', TRUE)",
+            (sec_id,),
+        )
+        cur.execute(
+            "INSERT INTO fundamentals_snapshot (instrument_id, as_of_date) "
+            "VALUES (%s, '2026-04-25'), (%s, '2026-04-25')",
+            (sec_id, fmp_id),
+        )
+    ebull_test_conn.commit()
+
+    # Re-run the 073 surgical DELETE. It already ran at fixture
+    # setup but our seeded rows were inserted post-migration.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            DELETE FROM fundamentals_snapshot fs
+             WHERE NOT EXISTS (
+                    SELECT 1 FROM external_identifiers e
+                     WHERE e.instrument_id   = fs.instrument_id
+                       AND e.provider        = 'sec'
+                       AND e.identifier_type = 'cik'
+                       AND e.is_primary      = TRUE
+                   )
+               AND fs.instrument_id IN (%s, %s)
+            """,
+            (sec_id, fmp_id),
+        )
+        cur.execute(
+            "SELECT instrument_id FROM fundamentals_snapshot WHERE instrument_id IN (%s, %s) ORDER BY instrument_id",
+            (sec_id, fmp_id),
+        )
+        rows = cur.fetchall()
+
+    try:
+        assert rows == [(sec_id,)]  # SEC-CIK row kept; FMP-only row deleted
+    finally:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM fundamentals_snapshot WHERE instrument_id IN (%s, %s)",
+                (sec_id, fmp_id),
+            )
+            cur.execute(
+                "DELETE FROM external_identifiers WHERE instrument_id IN (%s, %s)",
+                (sec_id, fmp_id),
+            )
+            cur.execute(
+                "DELETE FROM instruments WHERE instrument_id IN (%s, %s)",
+                (sec_id, fmp_id),
+            )
+            cur.execute("DELETE FROM exchanges WHERE exchange_id = %s", (exchange_id,))
+        ebull_test_conn.commit()


### PR DESCRIPTION
## What

Stage 1 of 4-stage FMP removal. Stops new FMP writes + purges already-ingested FMP-backed data exposed in user-visible read paths.

- **Capabilities**: \`fmp\` removed from CapabilityProvider Literal, presence queries, SEC-CIK augmentation. Migration 072 surgically removes \`fmp\` element from existing rows (preserves operator overrides).
- **Runtime**: FmpFundamentalsProvider import dropped from scheduler. Currency enrichment + FMP fallback + FMP enrichment blocks deleted.
- **Read-path purge**: Migration 073 DELETEs \`source='fmp'\` rows from \`financial_periods\` / \`financial_periods_raw\`, TRUNCATEs \`analyst_estimates\` + \`earnings_events\` (FMP-only), surgical DELETE on \`fundamentals_snapshot\` rows without primary SEC CIK.

## Why

eBull stance per #532: free regulated-source-only data. FMP is paid; \`FMP_API_KEY=\` was empty in \`.env\`. Stage 1 ships the user-visible posture change. Stages 2-4 (#539/#540/#541) remove the dormant code paths and FMP-only schema.

## Test plan

- [x] \`uv run ruff check . / format --check / pyright\` — clean
- [x] \`uv run pytest\` — 2776 passed (1 pre-existing migration-066 failure deselected, see #530)
- [x] \`pnpm typecheck / test:unit\` — clean
- [x] New \`tests/test_migration_072_073_drop_fmp.py\` pins surgical contracts
- [x] Codex review: 2 rounds, both findings addressed (operator-override preservation, fundamentals_snapshot read-path leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)