### PR TITLE
feat(#533): failure taxonomy + backoff + quarantine for business_summary

### DIFF
--- a/app/api/business_summary_admin.py
+++ b/app/api/business_summary_admin.py
@@ -27,6 +27,7 @@ from typing import Literal
 
 import psycopg
 import psycopg.rows
+import psycopg.sql
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
@@ -118,7 +119,8 @@ def list_failures(
 
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            f"""
+            psycopg.sql.SQL(
+                f"""
             SELECT bs.last_failure_reason AS reason,
                    COUNT(*) AS count,
                    COUNT(*) FILTER (WHERE bs.attempt_count >= 4) AS quarantined_count
@@ -126,7 +128,8 @@ def list_failures(
              WHERE {where_sql}
              GROUP BY bs.last_failure_reason
              ORDER BY count DESC
-            """,
+            """
+            ),
             params,
         )
         for r in cur.fetchall():
@@ -139,18 +142,21 @@ def list_failures(
             )
 
         cur.execute(
-            f"""
+            psycopg.sql.SQL(
+                f"""
             SELECT COUNT(*) AS total
               FROM instrument_business_summary bs
              WHERE {where_sql}
-            """,
+            """
+            ),
             params,
         )
         total_row = cur.fetchone()
         total = int(total_row["total"]) if total_row else 0  # type: ignore[arg-type]
 
         cur.execute(
-            f"""
+            psycopg.sql.SQL(
+                f"""
             SELECT bs.instrument_id,
                    i.symbol,
                    i.company_name,
@@ -164,7 +170,8 @@ def list_failures(
              WHERE {where_sql}
              ORDER BY bs.attempt_count DESC, bs.last_parsed_at DESC
              LIMIT %(limit)s OFFSET %(offset)s
-            """,
+            """
+            ),
             params,
         )
         for r in cur.fetchall():

--- a/app/api/business_summary_admin.py
+++ b/app/api/business_summary_admin.py
@@ -1,0 +1,227 @@
+"""Business-summary failure dashboard endpoints (#533).
+
+Read-only operator surface for the per-instrument 10-K Item 1
+parse failure tracking. Two endpoints:
+
+- ``GET /admin/business-summary-failures`` — reason histogram +
+  per-instrument detail (paginated). Lets operators see at a glance
+  whether the queue is dominated by ``no_item_1_marker`` (10-K/A
+  Part-III amendments — fixable via #534), ``fetch_http_5xx``
+  (transient SEC outage), or genuine parser bugs.
+
+- ``POST /admin/business-summary-failures/{instrument_id}/reset`` —
+  zeroes ``attempt_count`` and clears ``next_retry_at`` so the
+  ingester re-attempts on its next run. Used after a parser fix
+  lands or when the operator manually verifies a filing should
+  re-parse.
+
+Auth: both routes require operator auth via
+``require_session_or_service_token``. Failure data reveals
+pipeline-internal state, must not be public.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+import psycopg
+import psycopg.rows
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from app.api.auth import require_session_or_service_token
+from app.db import get_conn
+
+router = APIRouter(
+    prefix="/admin/business-summary-failures",
+    tags=["admin", "business-summary"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+
+class FailureReasonCount(BaseModel):
+    """One row in the reason histogram."""
+
+    reason: str
+    count: int
+    quarantined_count: int
+
+
+class FailureRow(BaseModel):
+    """One failing instrument's detail."""
+
+    instrument_id: int
+    symbol: str
+    company_name: str | None
+    source_accession: str
+    attempt_count: int
+    last_failure_reason: str | None
+    last_parsed_at: datetime
+    next_retry_at: datetime | None
+    is_quarantined: bool
+
+
+class FailureListResponse(BaseModel):
+    """Reason histogram + paginated detail."""
+
+    checked_at: datetime
+    histogram: list[FailureReasonCount]
+    total_failing: int
+    rows: list[FailureRow]
+    limit: int
+    offset: int
+
+
+class ResetResponse(BaseModel):
+    """Result of a manual reset action."""
+
+    instrument_id: int
+    cleared: bool
+
+
+_QUARANTINE_REASON_FILTER = Literal[
+    "all",
+    "quarantined",
+    "active",
+]
+
+
+@router.get("", response_model=FailureListResponse)
+def list_failures(
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    reason: str | None = Query(default=None, description="Filter to one failure reason (e.g. no_item_1_marker)."),
+    state: _QUARANTINE_REASON_FILTER = Query(default="all"),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> FailureListResponse:
+    """List instruments whose ``instrument_business_summary`` row has
+    a non-NULL ``next_retry_at`` (i.e. a failure has been recorded).
+
+    The histogram is computed over the same filter set so the totals
+    line up with the visible rows when an operator is filtering by
+    reason / state."""
+    where_clauses = ["bs.next_retry_at IS NOT NULL"]
+    params: dict[str, object] = {"limit": limit, "offset": offset}
+    if reason is not None:
+        where_clauses.append("bs.last_failure_reason = %(reason)s")
+        params["reason"] = reason
+    if state == "quarantined":
+        where_clauses.append("bs.attempt_count >= 4")
+    elif state == "active":
+        where_clauses.append("bs.attempt_count < 4")
+    where_sql = " AND ".join(where_clauses)
+
+    histogram: list[FailureReasonCount] = []
+    rows: list[FailureRow] = []
+    total = 0
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            f"""
+            SELECT bs.last_failure_reason AS reason,
+                   COUNT(*) AS count,
+                   COUNT(*) FILTER (WHERE bs.attempt_count >= 4) AS quarantined_count
+              FROM instrument_business_summary bs
+             WHERE {where_sql}
+             GROUP BY bs.last_failure_reason
+             ORDER BY count DESC
+            """,
+            params,
+        )
+        for r in cur.fetchall():
+            histogram.append(
+                FailureReasonCount(
+                    reason=str(r["reason"]) if r["reason"] is not None else "unknown",
+                    count=int(r["count"]),  # type: ignore[arg-type]
+                    quarantined_count=int(r["quarantined_count"]),  # type: ignore[arg-type]
+                )
+            )
+
+        cur.execute(
+            f"""
+            SELECT COUNT(*) AS total
+              FROM instrument_business_summary bs
+             WHERE {where_sql}
+            """,
+            params,
+        )
+        total_row = cur.fetchone()
+        total = int(total_row["total"]) if total_row else 0  # type: ignore[arg-type]
+
+        cur.execute(
+            f"""
+            SELECT bs.instrument_id,
+                   i.symbol,
+                   i.company_name,
+                   bs.source_accession,
+                   bs.attempt_count,
+                   bs.last_failure_reason,
+                   bs.last_parsed_at,
+                   bs.next_retry_at
+              FROM instrument_business_summary bs
+              JOIN instruments i ON i.instrument_id = bs.instrument_id
+             WHERE {where_sql}
+             ORDER BY bs.attempt_count DESC, bs.last_parsed_at DESC
+             LIMIT %(limit)s OFFSET %(offset)s
+            """,
+            params,
+        )
+        for r in cur.fetchall():
+            rows.append(
+                FailureRow(
+                    instrument_id=int(r["instrument_id"]),  # type: ignore[arg-type]
+                    symbol=str(r["symbol"]),
+                    company_name=str(r["company_name"]) if r["company_name"] is not None else None,
+                    source_accession=str(r["source_accession"]),
+                    attempt_count=int(r["attempt_count"]),  # type: ignore[arg-type]
+                    last_failure_reason=str(r["last_failure_reason"]) if r["last_failure_reason"] is not None else None,
+                    last_parsed_at=r["last_parsed_at"],  # type: ignore[arg-type]
+                    next_retry_at=r["next_retry_at"],  # type: ignore[arg-type]
+                    is_quarantined=int(r["attempt_count"]) >= 4,  # type: ignore[arg-type]
+                )
+            )
+
+    return FailureListResponse(
+        checked_at=datetime.now().astimezone(),
+        histogram=histogram,
+        total_failing=total,
+        rows=rows,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post("/{instrument_id}/reset", response_model=ResetResponse)
+def reset_failure(
+    instrument_id: int,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> ResetResponse:
+    """Clear failure tracking for one instrument and re-queue it.
+
+    Resets ``attempt_count = 0`` and ``last_failure_reason = NULL``,
+    and sets ``next_retry_at = NOW()`` so the ingester's candidate
+    query picks the row up on the next run via the
+    ``next_retry_at <= NOW()`` predicate. Body and source_accession
+    are untouched so any prior successful narrative is preserved.
+
+    Returns 404 when the instrument has no failure on file
+    (``next_retry_at IS NULL``) — guards against false positives
+    where an operator resets a healthy row by mistake.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE instrument_business_summary
+               SET attempt_count       = 0,
+                   last_failure_reason = NULL,
+                   next_retry_at       = NOW()
+             WHERE instrument_id  = %s
+               AND next_retry_at IS NOT NULL
+            """,
+            (instrument_id,),
+        )
+        if cur.rowcount == 0:
+            raise HTTPException(status_code=404, detail=f"No failure row for instrument_id={instrument_id}")
+        conn.commit()
+    return ResetResponse(instrument_id=instrument_id, cleared=True)

--- a/app/api/business_summary_admin.py
+++ b/app/api/business_summary_admin.py
@@ -119,7 +119,7 @@ def list_failures(
 
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            psycopg.sql.SQL(
+            psycopg.sql.SQL(  # type: ignore[arg-type]
                 f"""
             SELECT bs.last_failure_reason AS reason,
                    COUNT(*) AS count,
@@ -142,7 +142,7 @@ def list_failures(
             )
 
         cur.execute(
-            psycopg.sql.SQL(
+            psycopg.sql.SQL(  # type: ignore[arg-type]
                 f"""
             SELECT COUNT(*) AS total
               FROM instrument_business_summary bs
@@ -155,7 +155,7 @@ def list_failures(
         total = int(total_row["total"]) if total_row else 0  # type: ignore[arg-type]
 
         cur.execute(
-            psycopg.sql.SQL(
+            psycopg.sql.SQL(  # type: ignore[arg-type]
                 f"""
             SELECT bs.instrument_id,
                    i.symbol,

--- a/app/api/business_summary_admin.py
+++ b/app/api/business_summary_admin.py
@@ -119,7 +119,7 @@ def list_failures(
 
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            psycopg.sql.SQL(  # type: ignore[arg-type]
+            psycopg.sql.SQL(  # pyright: ignore[reportArgumentType]
                 f"""
             SELECT bs.last_failure_reason AS reason,
                    COUNT(*) AS count,
@@ -142,7 +142,7 @@ def list_failures(
             )
 
         cur.execute(
-            psycopg.sql.SQL(  # type: ignore[arg-type]
+            psycopg.sql.SQL(  # pyright: ignore[reportArgumentType]
                 f"""
             SELECT COUNT(*) AS total
               FROM instrument_business_summary bs
@@ -155,7 +155,7 @@ def list_failures(
         total = int(total_row["total"]) if total_row else 0  # type: ignore[arg-type]
 
         cur.execute(
-            psycopg.sql.SQL(  # type: ignore[arg-type]
+            psycopg.sql.SQL(  # pyright: ignore[reportArgumentType]
                 f"""
             SELECT bs.instrument_id,
                    i.symbol,

--- a/app/api/business_summary_admin.py
+++ b/app/api/business_summary_admin.py
@@ -102,16 +102,23 @@ def list_failures(
     The histogram is computed over the same filter set so the totals
     line up with the visible rows when an operator is filtering by
     reason / state."""
-    where_clauses = ["bs.next_retry_at IS NOT NULL"]
+    # Compose WHERE clauses as psycopg.sql.SQL fragments. Each
+    # fragment is a bare-string literal (clauses below are
+    # hand-coded; user input lands as bound params), so the
+    # composed query stays safe from injection while keeping
+    # ``cursor.execute`` happy with a real ``Composed`` object
+    # rather than a runtime str.
+    sql = psycopg.sql
+    where_parts: list[psycopg.sql.Composable] = [sql.SQL("bs.next_retry_at IS NOT NULL")]
     params: dict[str, object] = {"limit": limit, "offset": offset}
     if reason is not None:
-        where_clauses.append("bs.last_failure_reason = %(reason)s")
+        where_parts.append(sql.SQL("bs.last_failure_reason = %(reason)s"))
         params["reason"] = reason
     if state == "quarantined":
-        where_clauses.append("bs.attempt_count >= 4")
+        where_parts.append(sql.SQL("bs.attempt_count >= 4"))
     elif state == "active":
-        where_clauses.append("bs.attempt_count < 4")
-    where_sql = " AND ".join(where_clauses)
+        where_parts.append(sql.SQL("bs.attempt_count < 4"))
+    where_sql = sql.SQL(" AND ").join(where_parts)
 
     histogram: list[FailureReasonCount] = []
     rows: list[FailureRow] = []
@@ -119,17 +126,17 @@ def list_failures(
 
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            psycopg.sql.SQL(  # pyright: ignore[reportArgumentType]
-                f"""
+            sql.SQL(
+                """
             SELECT bs.last_failure_reason AS reason,
                    COUNT(*) AS count,
                    COUNT(*) FILTER (WHERE bs.attempt_count >= 4) AS quarantined_count
               FROM instrument_business_summary bs
-             WHERE {where_sql}
+             WHERE {where}
              GROUP BY bs.last_failure_reason
              ORDER BY count DESC
             """
-            ),
+            ).format(where=where_sql),
             params,
         )
         for r in cur.fetchall():
@@ -142,21 +149,21 @@ def list_failures(
             )
 
         cur.execute(
-            psycopg.sql.SQL(  # pyright: ignore[reportArgumentType]
-                f"""
+            sql.SQL(
+                """
             SELECT COUNT(*) AS total
               FROM instrument_business_summary bs
-             WHERE {where_sql}
+             WHERE {where}
             """
-            ),
+            ).format(where=where_sql),
             params,
         )
         total_row = cur.fetchone()
         total = int(total_row["total"]) if total_row else 0  # type: ignore[arg-type]
 
         cur.execute(
-            psycopg.sql.SQL(  # pyright: ignore[reportArgumentType]
-                f"""
+            sql.SQL(
+                """
             SELECT bs.instrument_id,
                    i.symbol,
                    i.company_name,
@@ -167,11 +174,11 @@ def list_failures(
                    bs.next_retry_at
               FROM instrument_business_summary bs
               JOIN instruments i ON i.instrument_id = bs.instrument_id
-             WHERE {where_sql}
+             WHERE {where}
              ORDER BY bs.attempt_count DESC, bs.last_parsed_at DESC
              LIMIT %(limit)s OFFSET %(offset)s
             """
-            ),
+            ).format(where=where_sql),
             params,
         )
         for r in cur.fetchall():

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from app.api.auth_session import router as auth_session_router
 from app.api.auth_setup import router as auth_setup_router
 from app.api.broker_credentials import router as broker_credentials_router
 from app.api.budget import router as budget_router
+from app.api.business_summary_admin import router as business_summary_admin_router
 from app.api.config import KillSwitchRequest, KillSwitchResponse, post_kill_switch
 from app.api.config import router as config_router
 from app.api.copy_trading import router as copy_trading_router
@@ -327,6 +328,7 @@ app.include_router(broker_credentials_router)
 app.include_router(config_router)
 app.include_router(copy_trading_router)
 app.include_router(coverage_router)
+app.include_router(business_summary_admin_router)
 app.include_router(filings_router)
 app.include_router(instruments_router)
 app.include_router(jobs_router)

--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -35,12 +35,55 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 import psycopg
 from psycopg.types.json import Jsonb
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------
+# Failure-reason taxonomy + exponential backoff (#533)
+# ---------------------------------------------------------------------
+
+
+# Closed set of failure categories the ingester records on each
+# parse miss. Operator-facing — surfaced verbatim in the admin
+# failure dashboard. Adding a new value means updating both this
+# Literal and the admin UI's reason→label map.
+FailureReason = Literal[
+    "fetch_http_5xx",  # SEC server error
+    "fetch_http_4xx",  # 4xx other than 404/410 (which return None)
+    "fetch_timeout",  # connection timeout / read timeout
+    "fetch_other",  # unclassified fetch failure (provider returned None or unknown exception)
+    "no_item_1_marker",  # Item 1 heading absent from document (10-K/A Part-III amendments etc.)
+    "body_too_short",  # marker found but slice below ``_MIN_BODY_LEN`` (TOC-only)
+    "parse_exception",  # extractor raised
+    "upsert_exception",  # DB write raised
+    "legacy_tombstone",  # backfill marker for tombstones predating #533
+]
+
+
+# Backoff schedule: attempt_count → days until next retry. Caps at
+# 365 days (effective quarantine) — a row that has missed 4 times
+# in a row is almost always a real classification or content issue
+# the operator needs to address (filing_type leak, broken URL,
+# parser gap), not a transient blip.
+_BACKOFF_SCHEDULE_DAYS: dict[int, int] = {
+    1: 1,
+    2: 7,
+    3: 30,
+}
+_QUARANTINE_DAYS = 365
+
+
+def _next_retry_days(attempt_count: int) -> int:
+    """Return the number of days until the next retry given the
+    attempt counter. ``attempt_count`` is the count AFTER the
+    current failure has been recorded (i.e. 1 means "first failure",
+    not "before any failure"). Quarantine kicks in at 4+."""
+    return _BACKOFF_SCHEDULE_DAYS.get(attempt_count, _QUARANTINE_DAYS)
 
 
 # ---------------------------------------------------------------------
@@ -518,7 +561,9 @@ def upsert_business_summary(
 
     Returns ``True`` on INSERT, ``False`` on UPDATE. The UPDATE path
     overwrites the body + source_accession + timestamps so a later
-    10-K supersedes an older one cleanly."""
+    10-K supersedes an older one cleanly. Resets the failure-tracking
+    columns (#533) so a previously-quarantined instrument that now
+    parses successfully exits quarantine cleanly."""
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -526,10 +571,13 @@ def upsert_business_summary(
                 (instrument_id, body, source_accession)
             VALUES (%s, %s, %s)
             ON CONFLICT (instrument_id) DO UPDATE SET
-                body             = EXCLUDED.body,
-                source_accession = EXCLUDED.source_accession,
-                fetched_at       = NOW(),
-                last_parsed_at   = NOW()
+                body                = EXCLUDED.body,
+                source_accession    = EXCLUDED.source_accession,
+                fetched_at          = NOW(),
+                last_parsed_at      = NOW(),
+                attempt_count       = 0,
+                last_failure_reason = NULL,
+                next_retry_at       = NULL
             RETURNING (xmax = 0) AS inserted
             """,
             (instrument_id, body, source_accession),
@@ -608,31 +656,58 @@ def record_parse_attempt(
     *,
     instrument_id: int,
     source_accession: str,
+    reason: FailureReason,
 ) -> None:
     """Stamp a parse attempt without ever overwriting a real body.
 
     INSERT path (first-time failure): writes a tombstone row with
-    ``body = ''`` and the failing ``source_accession`` so the next
-    ingester pass sees a row with ``source_accession`` == the same
-    accession and ``last_parsed_at`` < 7 days — and skips it.
+    ``body = ''`` and ``attempt_count = 1``, plus the chosen
+    ``next_retry_at`` from the backoff schedule. The next ingester
+    pass sees a row with ``next_retry_at`` in the future and skips
+    it.
 
-    UPDATE path (prior row exists, failed retry): only bumps
-    ``last_parsed_at`` + ``source_accession``. Preserves any real
-    ``body`` from an earlier successful parse so a transient error
-    on a later 10-K can never destroy the extracted narrative
-    (Codex #434 / #446 BLOCKING pattern applied to #428).
+    UPDATE path (prior row exists, failed retry): increments
+    ``attempt_count`` and recomputes ``next_retry_at`` from the
+    schedule. Preserves any real ``body`` from an earlier successful
+    parse so a transient error on a later 10-K can never destroy
+    the extracted narrative (Codex #434 / #446 BLOCKING pattern
+    applied to #428). Records ``last_failure_reason`` so the
+    operator-facing admin dashboard can surface the failure category.
+
+    Backoff schedule (in days): 1 → 1, 2 → 7, 3 → 30, 4+ → 365
+    (effective quarantine).
     """
     with conn.cursor() as cur:
         cur.execute(
             """
             INSERT INTO instrument_business_summary
-                (instrument_id, body, source_accession)
-            VALUES (%s, '', %s)
+                (instrument_id, body, source_accession,
+                 attempt_count, last_failure_reason, next_retry_at)
+            VALUES (
+                %(iid)s, '', %(acc)s,
+                1, %(reason)s,
+                NOW() + (%(days_first)s || ' days')::INTERVAL
+            )
             ON CONFLICT (instrument_id) DO UPDATE SET
-                source_accession = EXCLUDED.source_accession,
-                last_parsed_at   = NOW()
+                source_accession    = EXCLUDED.source_accession,
+                last_parsed_at      = NOW(),
+                attempt_count       = instrument_business_summary.attempt_count + 1,
+                last_failure_reason = EXCLUDED.last_failure_reason,
+                next_retry_at       = NOW() + (
+                    CASE
+                        WHEN instrument_business_summary.attempt_count + 1 = 1 THEN '1 days'::INTERVAL
+                        WHEN instrument_business_summary.attempt_count + 1 = 2 THEN '7 days'::INTERVAL
+                        WHEN instrument_business_summary.attempt_count + 1 = 3 THEN '30 days'::INTERVAL
+                        ELSE '365 days'::INTERVAL
+                    END
+                )
             """,
-            (instrument_id, source_accession),
+            {
+                "iid": instrument_id,
+                "acc": source_accession,
+                "reason": reason,
+                "days_first": _next_retry_days(1),
+            },
         )
 
 
@@ -758,6 +833,28 @@ class IngestResult:
 _MIN_BODY_LEN = 120
 
 
+def _classify_fetch_exception(exc: Exception) -> FailureReason:
+    """Map a fetch-side exception to a FailureReason value.
+
+    Concrete HTTP errors with a status code on a ``response`` attribute
+    split into 5xx vs 4xx. Connection / read timeouts share one category
+    so the operator dashboard can group them cleanly. Anything else
+    falls through to ``fetch_other``.
+    """
+    response = getattr(exc, "response", None)
+    if response is not None:
+        status_code = getattr(response, "status_code", None)
+        if isinstance(status_code, int):
+            if status_code >= 500:
+                return "fetch_http_5xx"
+            if status_code >= 400:
+                return "fetch_http_4xx"
+    name = type(exc).__name__.lower()
+    if "timeout" in name or "connection" in name:
+        return "fetch_timeout"
+    return "fetch_other"
+
+
 def ingest_business_summaries(
     conn: psycopg.Connection[Any],
     fetcher: _DocFetcher,
@@ -766,7 +863,8 @@ def ingest_business_summaries(
 ) -> IngestResult:
     """Scan 10-K filings, fetch primary doc, extract Item 1, upsert.
 
-    Candidate selector (shape addresses Codex #428 findings):
+    Candidate selector (shape addresses Codex #428 findings, extended
+    in #533 with backoff/quarantine):
 
     1. ``fe.filing_type IN ('10-K', '10-K/A')`` — amendments retain
        their ``/A`` suffix through the SEC pipeline (see
@@ -776,8 +874,8 @@ def ingest_business_summaries(
     2. ``fe.primary_document_url IS NOT NULL`` — unparseable without.
     3. No ``instrument_business_summary`` row, OR the stored
        ``source_accession`` differs from this filing's accession
-       (later 10-K supersedes), OR the existing row is older than 7
-       days since last parse (TTL-gated retry).
+       (later 10-K supersedes), OR the existing row's ``next_retry_at``
+       has elapsed.
     4. Newest filing wins per instrument (``DISTINCT ON`` resolves to
        the latest filing_date, tie-break on filing_event_id); the
        outer query then sorts GLOBALLY newest-first so a backlog
@@ -816,7 +914,7 @@ def ingest_business_summaries(
                    ON bs.instrument_id = lpi.instrument_id
             WHERE bs.instrument_id IS NULL
                OR bs.source_accession <> lpi.provider_filing_id
-               OR bs.last_parsed_at < NOW() - INTERVAL '7 days'
+               OR (bs.next_retry_at IS NOT NULL AND bs.next_retry_at <= NOW())
             ORDER BY lpi.filing_date DESC, lpi.filing_event_id DESC
             LIMIT %s
             """,
@@ -834,27 +932,73 @@ def ingest_business_summaries(
     for instrument_id, accession, url in candidates:
         try:
             html = fetcher.fetch_document_text(url)
-        except Exception:
+        except Exception as exc:
+            reason = _classify_fetch_exception(exc)
             logger.warning(
-                "ingest_business_summaries: fetch failed accession=%s url=%s",
+                "ingest_business_summaries: fetch failed accession=%s url=%s reason=%s",
                 accession,
                 url,
+                reason,
                 exc_info=True,
             )
             fetch_errors += 1
-            record_parse_attempt(conn, instrument_id=instrument_id, source_accession=accession)
+            record_parse_attempt(
+                conn,
+                instrument_id=instrument_id,
+                source_accession=accession,
+                reason=reason,
+            )
             conn.commit()
             continue
         if html is None:
+            # Provider returned None on 404/410 (filing withdrawn) or
+            # other "no body" path. Classify as fetch_other so the
+            # operator dashboard separates it from real HTTP errors.
             fetch_errors += 1
-            record_parse_attempt(conn, instrument_id=instrument_id, source_accession=accession)
+            record_parse_attempt(
+                conn,
+                instrument_id=instrument_id,
+                source_accession=accession,
+                reason="fetch_other",
+            )
             conn.commit()
             continue
 
-        body = extract_business_section(html)
-        if body is None or len(body) < _MIN_BODY_LEN:
+        try:
+            body = extract_business_section(html)
+        except Exception:
+            logger.warning(
+                "ingest_business_summaries: parse exception accession=%s",
+                accession,
+                exc_info=True,
+            )
             parse_misses += 1
-            record_parse_attempt(conn, instrument_id=instrument_id, source_accession=accession)
+            record_parse_attempt(
+                conn,
+                instrument_id=instrument_id,
+                source_accession=accession,
+                reason="parse_exception",
+            )
+            conn.commit()
+            continue
+        if body is None:
+            parse_misses += 1
+            record_parse_attempt(
+                conn,
+                instrument_id=instrument_id,
+                source_accession=accession,
+                reason="no_item_1_marker",
+            )
+            conn.commit()
+            continue
+        if len(body) < _MIN_BODY_LEN:
+            parse_misses += 1
+            record_parse_attempt(
+                conn,
+                instrument_id=instrument_id,
+                source_accession=accession,
+                reason="body_too_short",
+            )
             conn.commit()
             continue
 
@@ -896,6 +1040,13 @@ def ingest_business_summaries(
                 accession,
                 exc_info=True,
             )
+            record_parse_attempt(
+                conn,
+                instrument_id=instrument_id,
+                source_accession=accession,
+                reason="upsert_exception",
+            )
+            conn.commit()
             continue
 
         if did_insert:

--- a/sql/074_business_summary_backoff.sql
+++ b/sql/074_business_summary_backoff.sql
@@ -1,0 +1,63 @@
+-- Migration 074 — failure-reason taxonomy + exponential backoff
+-- + quarantine for ``instrument_business_summary`` (#533).
+--
+-- Pre-#533: the ingester wrote a ``body=''`` tombstone on every
+-- parse failure and the candidate query had a hard-coded 7-day
+-- TTL retry. Hopeless cases (10-K/A amendments missing Item 1,
+-- broken document URLs, etc.) cycled through the limit slot
+-- every week forever.
+--
+-- Post-#533: each row carries an attempt_count + last_failure_reason
+-- + next_retry_at. The candidate query filters on next_retry_at so
+-- quarantined rows fall out of the hot set automatically.
+--
+-- Backoff schedule (encoded in Python, not SQL):
+--   attempt 1 → next_retry NOW + 1 day
+--   attempt 2 → NOW + 7 days
+--   attempt 3 → NOW + 30 days
+--   attempt 4+ → NOW + 365 days (effective quarantine)
+--
+-- Backfill of existing tombstones (body = '' rows): attempt_count=1,
+-- next_retry_at = last_parsed_at + 1 day. One fresh first-attempt
+-- retry on the existing TTL cadence; if that fails, the backoff
+-- schedule kicks in. Real bodies (body != '') get NULL retry — the
+-- ``source_accession <> latest`` check in the candidate query
+-- continues to be the (correct) trigger for re-parsing on a new
+-- 10-K, regardless of next_retry_at.
+
+BEGIN;
+
+ALTER TABLE instrument_business_summary
+    ADD COLUMN IF NOT EXISTS attempt_count       INTEGER     NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS last_failure_reason TEXT,
+    ADD COLUMN IF NOT EXISTS next_retry_at       TIMESTAMPTZ;
+
+-- Backfill existing tombstones (failed parses).
+UPDATE instrument_business_summary
+   SET attempt_count = 1,
+       last_failure_reason = 'legacy_tombstone',
+       next_retry_at = last_parsed_at + INTERVAL '1 day'
+ WHERE body = ''
+   AND attempt_count = 0;
+
+COMMENT ON COLUMN instrument_business_summary.attempt_count IS
+    'Consecutive failed parse attempts (#533). 0 = success or '
+    'never attempted. Reset to 0 on successful parse.';
+
+COMMENT ON COLUMN instrument_business_summary.last_failure_reason IS
+    'Last failure category (#533). Closed taxonomy in '
+    'app/services/business_summary.py FailureReason. NULL = no '
+    'failure recorded.';
+
+COMMENT ON COLUMN instrument_business_summary.next_retry_at IS
+    'Earliest UTC time the ingester will re-attempt this filing '
+    '(#533). Computed from attempt_count via exponential backoff. '
+    'Candidate query filters out rows where NOW() < next_retry_at. '
+    'NULL = candidate query ignores the gate (real-body rows or '
+    'never-attempted instruments).';
+
+CREATE INDEX IF NOT EXISTS instrument_business_summary_next_retry_at_idx
+    ON instrument_business_summary (next_retry_at)
+    WHERE next_retry_at IS NOT NULL;
+
+COMMIT;

--- a/tests/api/test_business_summary_admin_endpoint.py
+++ b/tests/api/test_business_summary_admin_endpoint.py
@@ -1,0 +1,125 @@
+"""Tests for /admin/business-summary-failures endpoints (#533).
+
+Pins the failure-dashboard contract: histogram counts match
+visible rows, quarantined filter excludes active failures, reset
+clears the tracking columns without touching body/source_accession.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.business_summary_admin import router as failures_router
+from app.db import get_conn
+
+
+def _build_app(conn: MagicMock) -> FastAPI:
+    app = FastAPI()
+    app.include_router(failures_router)
+
+    def _yield_conn():  # type: ignore[return]
+        yield conn
+
+    app.dependency_overrides[get_conn] = _yield_conn
+    from app.api.auth import require_session_or_service_token
+
+    app.dependency_overrides[require_session_or_service_token] = lambda: None
+    return app
+
+
+def test_list_returns_histogram_and_rows() -> None:
+    from datetime import UTC, datetime
+
+    last_parsed = datetime(2026, 4, 1, tzinfo=UTC)
+    next_retry = datetime(2026, 4, 2, tzinfo=UTC)
+    histogram_rows = [
+        {"reason": "no_item_1_marker", "count": 167, "quarantined_count": 12},
+        {"reason": "fetch_http_5xx", "count": 5, "quarantined_count": 0},
+    ]
+    detail_rows = [
+        {
+            "instrument_id": 7,
+            "symbol": "ABC",
+            "company_name": "ABC Co",
+            "source_accession": "0001-26-1",
+            "attempt_count": 4,
+            "last_failure_reason": "no_item_1_marker",
+            "last_parsed_at": last_parsed,
+            "next_retry_at": next_retry,
+        },
+    ]
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    # 1st execute → histogram fetchall; 2nd execute → total fetchone; 3rd execute → detail fetchall.
+    cur.fetchall.side_effect = [histogram_rows, detail_rows]
+    cur.fetchone.return_value = {"total": 172}
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+
+    app = _build_app(conn)
+    with TestClient(app) as client:
+        resp = client.get("/admin/business-summary-failures")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total_failing"] == 172
+    assert body["histogram"][0] == {
+        "reason": "no_item_1_marker",
+        "count": 167,
+        "quarantined_count": 12,
+    }
+    assert len(body["rows"]) == 1
+    assert body["rows"][0]["symbol"] == "ABC"
+    assert body["rows"][0]["is_quarantined"] is True
+
+
+def test_reset_returns_404_when_no_row() -> None:
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.rowcount = 0
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+
+    app = _build_app(conn)
+    with TestClient(app) as client:
+        resp = client.post("/admin/business-summary-failures/999/reset")
+
+    assert resp.status_code == 404
+
+
+def test_reset_clears_failure_columns_and_requeues() -> None:
+    """The reset SQL must (a) set next_retry_at to NOW() so the
+    ingester picks the row up on its next run via the
+    ``next_retry_at <= NOW()`` predicate (Codex review on #533),
+    and (b) leave body + source_accession alone so any prior
+    successful narrative survives. The WHERE clause must also
+    require ``next_retry_at IS NOT NULL`` so a healthy row never
+    counts as 'cleared'."""
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.rowcount = 1
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+
+    app = _build_app(conn)
+    with TestClient(app) as client:
+        resp = client.post("/admin/business-summary-failures/42/reset")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"instrument_id": 42, "cleared": True}
+    args, _ = cur.execute.call_args
+    sql = args[0]
+    assert "attempt_count       = 0" in sql
+    assert "last_failure_reason = NULL" in sql
+    assert "next_retry_at       = NOW()" in sql
+    # The WHERE guard prevents resetting a healthy row.
+    assert "next_retry_at IS NOT NULL" in sql
+    # body / source_accession must not be touched.
+    assert "body" not in sql
+    assert "source_accession" not in sql

--- a/tests/test_business_summary_ingest.py
+++ b/tests/test_business_summary_ingest.py
@@ -441,3 +441,234 @@ class TestBusinessSectionsIngest:
         offering_sections = [s for s in sections if s.section_label == "Offerings"]
         assert len(offering_sections) == 1
         assert offering_sections[0].section_key == "other"
+
+
+class TestFailureBackoffAndQuarantine:
+    """#533 — failure-reason taxonomy + exponential backoff + quarantine.
+
+    Pins the contract that the ingester records a per-failure
+    category + bumps attempt_count + writes a backoff-scheduled
+    next_retry_at. Hopeless cases (Part-III amendments without
+    Item 1 etc.) escalate from 1d → 7d → 30d → 365d quarantine
+    instead of cycling weekly forever.
+    """
+
+    _NO_ITEM_1_HTML = "<html><body><p>Item 15(a)(3) of Part IV of the Original 10-K.</p></body></html>"
+
+    def test_first_parse_miss_records_no_item_1_marker_reason_and_1d_backoff(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="MISSITEM1", iid=601)
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="A1",
+            url="https://www.sec.gov/Archives/no_item1.htm",
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/no_item1.htm": self._NO_ITEM_1_HTML})
+        ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT attempt_count, last_failure_reason, next_retry_at, last_parsed_at "
+                "FROM instrument_business_summary WHERE instrument_id = %s",
+                (iid,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        attempt_count, reason, next_retry_at, last_parsed_at = row
+        assert attempt_count == 1
+        assert reason == "no_item_1_marker"
+        # 1-day backoff after first miss.
+        delta = (next_retry_at - last_parsed_at).total_seconds()
+        assert 23 * 3600 <= delta <= 25 * 3600
+
+    def test_repeated_misses_escalate_to_quarantine(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """4 consecutive failures push next_retry_at to NOW + 365d
+        (effective quarantine). The candidate query then excludes
+        the row. Pin via direct ``record_parse_attempt`` calls so the
+        backoff arithmetic is unambiguous."""
+        from app.services.business_summary import record_parse_attempt
+
+        iid = _seed_instrument(ebull_test_conn, symbol="QUAR", iid=602)
+        for _ in range(4):
+            record_parse_attempt(
+                ebull_test_conn,
+                instrument_id=iid,
+                source_accession="A1",
+                reason="no_item_1_marker",
+            )
+            ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT attempt_count, next_retry_at, last_parsed_at "
+                "FROM instrument_business_summary WHERE instrument_id = %s",
+                (iid,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        attempt_count, next_retry_at, last_parsed_at = row
+        assert attempt_count == 4
+        # 365-day quarantine — at least 360 days out.
+        delta_days = (next_retry_at - last_parsed_at).total_seconds() / 86400
+        assert 360 <= delta_days <= 366
+
+    def test_quarantined_row_excluded_from_candidate_query(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A row whose next_retry_at is in the future falls out of
+        the candidate set even when filing_events has a fresh 10-K."""
+        iid = _seed_instrument(ebull_test_conn, symbol="QUAR2", iid=603)
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="A1",
+            url="https://www.sec.gov/Archives/x.htm",
+        )
+        # Pre-quarantine the row.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO instrument_business_summary "
+                "(instrument_id, body, source_accession, attempt_count, "
+                " last_failure_reason, next_retry_at) "
+                "VALUES (%s, '', 'A1', 4, 'no_item_1_marker', NOW() + INTERVAL '365 days')",
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/x.htm": _ITEM_1_HTML})
+        result = ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.filings_scanned == 0
+        assert fetcher.calls == []
+
+    def test_successful_upsert_resets_failure_columns(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A previously-quarantined instrument that now parses
+        successfully exits quarantine cleanly (attempt_count=0,
+        next_retry_at NULL, last_failure_reason NULL)."""
+        iid = _seed_instrument(ebull_test_conn, symbol="EXITQ", iid=604)
+        # Pre-existing tombstone with attempt_count=2.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO instrument_business_summary "
+                "(instrument_id, body, source_accession, attempt_count, "
+                " last_failure_reason, next_retry_at) "
+                "VALUES (%s, '', 'A1', 2, 'no_item_1_marker', NOW() - INTERVAL '1 hour')",
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        # Schedule a fresh 10-K with valid Item 1 (different accession
+        # so the candidate query picks it up via the
+        # source_accession <> stored branch — even though
+        # next_retry_at has elapsed).
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="A2",
+            url="https://www.sec.gov/Archives/exitq.htm",
+            filing_date="2026-04-01",
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/exitq.htm": _ITEM_1_HTML})
+        ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT body, attempt_count, last_failure_reason, next_retry_at "
+                "FROM instrument_business_summary WHERE instrument_id = %s",
+                (iid,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        body, attempt_count, reason, next_retry_at = row
+        assert body and "global diversified" in body
+        assert attempt_count == 0
+        assert reason is None
+        assert next_retry_at is None
+
+    def test_admin_reset_requeues_failed_row_for_next_ingest(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Codex residual-risk pin: after the admin reset endpoint
+        clears the failure columns and stamps ``next_retry_at = NOW()``,
+        the next ``ingest_business_summaries`` run picks the row up
+        and re-attempts the same accession. Without ``NOW()`` (e.g.
+        plain ``NULL``) the row would disappear from the dashboard
+        without ever being retried."""
+        iid = _seed_instrument(ebull_test_conn, symbol="REQUEUE", iid=606)
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="A1",
+            url="https://www.sec.gov/Archives/requeue.htm",
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO instrument_business_summary "
+                "(instrument_id, body, source_accession, attempt_count, "
+                " last_failure_reason, next_retry_at) "
+                "VALUES (%s, '', 'A1', 4, 'no_item_1_marker', NOW() + INTERVAL '365 days')",
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        skip_fetcher = _StubFetcher({"https://www.sec.gov/Archives/requeue.htm": _ITEM_1_HTML})
+        skipped = ingest_business_summaries(ebull_test_conn, cast("object", skip_fetcher))  # type: ignore[arg-type]
+        assert skipped.filings_scanned == 0
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE instrument_business_summary
+                   SET attempt_count       = 0,
+                       last_failure_reason = NULL,
+                       next_retry_at       = NOW()
+                 WHERE instrument_id  = %s
+                   AND next_retry_at IS NOT NULL
+                """,
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        good_fetcher = _StubFetcher({"https://www.sec.gov/Archives/requeue.htm": _ITEM_1_HTML})
+        result = ingest_business_summaries(ebull_test_conn, cast("object", good_fetcher))  # type: ignore[arg-type]
+        assert result.filings_scanned == 1
+        assert result.rows_inserted + result.rows_updated == 1
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT body, attempt_count, last_failure_reason, next_retry_at "
+                "FROM instrument_business_summary WHERE instrument_id = %s",
+                (iid,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        body, attempt_count, reason, next_retry_at = row
+        assert body and len(body) > 100
+        assert attempt_count == 0
+        assert reason is None
+        assert next_retry_at is None
+
+    def test_fetch_5xx_classified_as_fetch_http_5xx(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """An HTTPError with response.status_code=503 maps to
+        ``fetch_http_5xx`` reason, not ``fetch_other``."""
+        from types import SimpleNamespace
+
+        class _RaisingFetcher:
+            def fetch_document_text(self, absolute_url: str) -> str | None:
+                err = Exception("boom")
+                err.response = SimpleNamespace(status_code=503)  # type: ignore[attr-defined]
+                raise err
+
+        iid = _seed_instrument(ebull_test_conn, symbol="HTTP5", iid=605)
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="A1",
+            url="https://www.sec.gov/Archives/x.htm",
+        )
+        ingest_business_summaries(ebull_test_conn, cast("object", _RaisingFetcher()))  # type: ignore[arg-type]
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT last_failure_reason FROM instrument_business_summary WHERE instrument_id = %s",
+                (iid,),
+            )
+            row = cur.fetchone()
+        assert row is not None and row[0] == "fetch_http_5xx"

--- a/tests/test_business_summary_ingest.py
+++ b/tests/test_business_summary_ingest.py
@@ -584,6 +584,60 @@ class TestFailureBackoffAndQuarantine:
         assert reason is None
         assert next_retry_at is None
 
+    def test_upsert_exception_path_rolls_back_then_records_failure(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        """Pin the upsert-exception ordering: rollback → record →
+        commit. If ``upsert_business_summary`` raises a DB error,
+        the connection is in aborted-transaction state and the
+        immediately-following ``record_parse_attempt`` would raise
+        ``InFailedSqlTransaction`` without a preceding rollback.
+
+        Forces the failure by monkey-patching
+        ``upsert_business_summary`` to raise psycopg.errors.DataError.
+        Then asserts the failure row exists with attempt_count=1 and
+        reason='upsert_exception' — proving the post-rollback record
+        + commit path actually wrote.
+        """
+        from unittest.mock import patch
+
+        import psycopg.errors
+
+        from app.services import business_summary as bs_module
+
+        iid = _seed_instrument(ebull_test_conn, symbol="UPSERTRAISE", iid=607)
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="A1",
+            url="https://www.sec.gov/Archives/raise.htm",
+        )
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/raise.htm": _ITEM_1_HTML})
+
+        def boom(*args: object, **kwargs: object) -> bool:
+            # Synthesise a real psycopg DataError so the connection
+            # actually transitions to aborted-transaction state — the
+            # exact failure mode the rollback exists to guard against.
+            with ebull_test_conn.cursor() as cur:
+                try:
+                    cur.execute("SELECT CAST('not_a_number' AS INTEGER)")
+                except psycopg.errors.InvalidTextRepresentation:
+                    pass
+            raise psycopg.errors.DataError("synthetic upsert failure")
+
+        with patch.object(bs_module, "upsert_business_summary", side_effect=boom):
+            ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT attempt_count, last_failure_reason FROM instrument_business_summary WHERE instrument_id = %s",
+                (iid,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 1
+        assert row[1] == "upsert_exception"
+
     def test_admin_reset_requeues_failed_row_for_next_ingest(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         """Codex residual-risk pin: after the admin reset endpoint
         clears the failure columns and stamps ``next_retry_at = NOW()``,


### PR DESCRIPTION
## What

Pre-#533 the ingester cycled hopeless cases weekly forever. Now each failure carries a category + attempt counter + scheduled retry. Hopeless cases escalate from 1d → 7d → 30d → 365d quarantine instead of consuming capacity indefinitely.

- **Migration 074**: \`attempt_count\`, \`last_failure_reason\`, \`next_retry_at\` columns + partial index. Backfills existing tombstones with attempt_count=1.
- **Service**: \`FailureReason\` taxonomy (9 values). \`record_parse_attempt(reason=...)\` mandatory kwarg. \`_classify_fetch_exception\` maps httpx errors to taxonomy. Candidate query gates on \`next_retry_at\` instead of 7-day TTL.
- **Admin endpoints**: \`GET /admin/business-summary-failures\` (histogram + paginated detail). \`POST .../reset\` clears tracking + sets next_retry_at=NOW() so ingester re-queues. 404 when row has no failure.
- **Tests**: 6 backoff/quarantine pins + 3 admin shape pins + 1 end-to-end reset→re-ingest integration.

## Why

Diagnosed during #515 post-merge review: 10-K Item 1 backfill stalled at 598/4031 instruments because ~42 known-failing accessions cycled the daily 200-slot capacity without ever escalating. Foundation for #534 (10-K/A fallback), #535 (bootstrap drain), #536 (event-driven trigger).

## Test plan

- [x] \`uv run ruff check . / format --check / pyright\` — clean
- [x] \`uv run pytest\` — 2788 passed (+11 since #532, 1 pre-existing migration-066 deselected)
- [x] Codex review: 2 rounds, both findings addressed (reset re-queue, healthy-row 404 guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)