### PR TITLE
feat(#534): 10-K/A → plain 10-K fallback for business_summary

### DIFF
--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -833,6 +833,52 @@ class IngestResult:
 _MIN_BODY_LEN = 120
 
 
+def _find_prior_plain_10k(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    before_accession: str,
+) -> tuple[str, str] | None:
+    """Find the most recent plain ``10-K`` (NOT ``10-K/A``) filing for
+    ``instrument_id`` strictly older than the filing keyed by
+    ``before_accession``.
+
+    Returns ``(provider_filing_id, primary_document_url)`` or ``None``
+    when no prior plain 10-K exists.
+
+    Used by the 10-K/A fallback path (#534): when the latest filing is
+    an amendment that omits Item 1 (Part-III amendments do this
+    routinely), the ingester re-attempts parsing against the original
+    10-K so the operator still gets the authoritative business
+    narrative. Without this fallback, every Part-III amendment
+    instrument permanently lost its Item 1 view.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT fe.provider_filing_id,
+                   fe.primary_document_url
+              FROM filing_events fe
+             WHERE fe.provider = 'sec'
+               AND fe.filing_type = '10-K'
+               AND fe.instrument_id = %(iid)s
+               AND fe.primary_document_url IS NOT NULL
+               AND fe.filing_date < (
+                    SELECT filing_date FROM filing_events
+                     WHERE provider = 'sec' AND provider_filing_id = %(acc)s
+                     LIMIT 1
+                   )
+             ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+             LIMIT 1
+            """,
+            {"iid": instrument_id, "acc": before_accession},
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return str(row[0]), str(row[1])
+
+
 def _classify_fetch_exception(exc: Exception) -> FailureReason:
     """Map a fetch-side exception to a FailureReason value.
 
@@ -889,7 +935,7 @@ def ingest_business_summaries(
     """
     conn.commit()
 
-    candidates: list[tuple[int, str, str]] = []
+    candidates: list[tuple[int, str, str, str]] = []
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -898,6 +944,7 @@ def ingest_business_summaries(
                        fe.instrument_id,
                        fe.provider_filing_id,
                        fe.primary_document_url,
+                       fe.filing_type,
                        fe.filing_date,
                        fe.filing_event_id
                 FROM filing_events fe
@@ -908,7 +955,8 @@ def ingest_business_summaries(
             )
             SELECT lpi.instrument_id,
                    lpi.provider_filing_id,
-                   lpi.primary_document_url
+                   lpi.primary_document_url,
+                   lpi.filing_type
             FROM latest_per_instrument lpi
             LEFT JOIN instrument_business_summary bs
                    ON bs.instrument_id = lpi.instrument_id
@@ -921,7 +969,7 @@ def ingest_business_summaries(
             (limit,),
         )
         for row in cur.fetchall():
-            candidates.append((int(row[0]), str(row[1]), str(row[2])))
+            candidates.append((int(row[0]), str(row[1]), str(row[2]), str(row[3])))
     conn.commit()
 
     inserted = 0
@@ -929,7 +977,7 @@ def ingest_business_summaries(
     fetch_errors = 0
     parse_misses = 0
 
-    for instrument_id, accession, url in candidates:
+    for instrument_id, accession, url, filing_type in candidates:
         try:
             html = fetcher.fetch_document_text(url)
         except Exception as exc:
@@ -982,6 +1030,88 @@ def ingest_business_summaries(
             conn.commit()
             continue
         if body is None:
+            # 10-K/A fallback (#534): Part-III amendments routinely
+            # omit Item 1. Before tombstoning, retry against the most
+            # recent prior plain 10-K from the same instrument. If
+            # the fallback succeeds, persist with the fallback's
+            # accession so the next run sees a real body and the
+            # ``source_accession <> latest`` predicate alone keeps
+            # the row out of the candidate set until a fresh 10-K
+            # arrives.
+            fallback_used = False
+            if filing_type == "10-K/A":
+                prior = _find_prior_plain_10k(
+                    conn,
+                    instrument_id=instrument_id,
+                    before_accession=accession,
+                )
+                if prior is not None:
+                    fallback_acc, fallback_url = prior
+                    logger.info(
+                        "ingest_business_summaries: 10-K/A fallback accession=%s -> prior plain 10-K accession=%s",
+                        accession,
+                        fallback_acc,
+                    )
+                    fallback_html: str | None = None
+                    try:
+                        fallback_html = fetcher.fetch_document_text(fallback_url)
+                    except Exception:
+                        logger.warning(
+                            "ingest_business_summaries: 10-K/A fallback fetch failed accession=%s url=%s",
+                            fallback_acc,
+                            fallback_url,
+                            exc_info=True,
+                        )
+                    if fallback_html is not None:
+                        try:
+                            fallback_body = extract_business_section(fallback_html)
+                        except Exception:
+                            logger.warning(
+                                "ingest_business_summaries: 10-K/A fallback parse exception accession=%s",
+                                fallback_acc,
+                                exc_info=True,
+                            )
+                            fallback_body = None
+                        if fallback_body is not None and len(fallback_body) >= _MIN_BODY_LEN:
+                            try:
+                                did_insert = upsert_business_summary(
+                                    conn,
+                                    instrument_id=instrument_id,
+                                    body=fallback_body,
+                                    source_accession=fallback_acc,
+                                )
+                                fallback_sections = extract_business_sections(fallback_html)
+                                if fallback_sections:
+                                    try:
+                                        upsert_business_sections(
+                                            conn,
+                                            instrument_id=instrument_id,
+                                            source_accession=fallback_acc,
+                                            sections=fallback_sections,
+                                        )
+                                    except Exception:
+                                        logger.warning(
+                                            "ingest_business_summaries: 10-K/A fallback section "
+                                            "upsert failed accession=%s",
+                                            fallback_acc,
+                                            exc_info=True,
+                                        )
+                                conn.commit()
+                                if did_insert:
+                                    inserted += 1
+                                else:
+                                    updated += 1
+                                fallback_used = True
+                            except Exception:
+                                conn.rollback()
+                                logger.warning(
+                                    "ingest_business_summaries: 10-K/A fallback upsert failed accession=%s",
+                                    fallback_acc,
+                                    exc_info=True,
+                                )
+            if fallback_used:
+                continue
+
             parse_misses += 1
             record_parse_attempt(
                 conn,

--- a/tests/test_business_summary_ingest.py
+++ b/tests/test_business_summary_ingest.py
@@ -726,3 +726,89 @@ class TestFailureBackoffAndQuarantine:
             )
             row = cur.fetchone()
         assert row is not None and row[0] == "fetch_http_5xx"
+
+
+class TestTenKAFallback:
+    """#534 — 10-K/A amendments missing Item 1 fall back to the most
+    recent prior plain 10-K. Without the fallback, every Part-III
+    amendment instrument permanently lost its Item 1 narrative."""
+
+    _PART_III_HTML = (
+        "<html><body><p>Item 15(a)(3) of Part IV of the Original 10-K. "
+        "Item 10. Directors. Item 11. Executive Compensation.</p></body></html>"
+    )
+
+    def test_amendment_no_item1_falls_back_to_prior_plain_10k(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="FBACK1", iid=701)
+        # Original 10-K with full Item 1.
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="ORIG-10K",
+            url="https://www.sec.gov/Archives/orig.htm",
+            filing_date="2025-02-15",
+        )
+        # Later 10-K/A Part-III amendment missing Item 1.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO filing_events (instrument_id, filing_date, filing_type, provider, "
+                "provider_filing_id, primary_document_url) VALUES (%s, '2026-03-01', '10-K/A', 'sec', "
+                "'AMEND-A', 'https://www.sec.gov/Archives/amend.htm')",
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        fetcher = _StubFetcher(
+            {
+                "https://www.sec.gov/Archives/amend.htm": self._PART_III_HTML,
+                "https://www.sec.gov/Archives/orig.htm": _ITEM_1_HTML,
+            }
+        )
+        result = ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.rows_inserted + result.rows_updated == 1
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT body, source_accession, attempt_count, last_failure_reason "
+                "FROM instrument_business_summary WHERE instrument_id = %s",
+                (iid,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        body, source_accession, attempt_count, reason = row
+        assert body and "global diversified" in body
+        # Stored under the fallback's accession, NOT the amendment's.
+        assert source_accession == "ORIG-10K"
+        assert attempt_count == 0
+        assert reason is None
+
+    def test_amendment_no_item1_no_fallback_falls_through_to_tombstone(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        """A 10-K/A with no prior plain 10-K available still records
+        a no_item_1_marker tombstone (no silent skip)."""
+        iid = _seed_instrument(ebull_test_conn, symbol="FBACK2", iid=702)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO filing_events (instrument_id, filing_date, filing_type, provider, "
+                "provider_filing_id, primary_document_url) VALUES (%s, '2026-03-01', '10-K/A', 'sec', "
+                "'AMEND-B', 'https://www.sec.gov/Archives/amend2.htm')",
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        fetcher = _StubFetcher({"https://www.sec.gov/Archives/amend2.htm": self._PART_III_HTML})
+        ingest_business_summaries(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT body, source_accession, last_failure_reason "
+                "FROM instrument_business_summary WHERE instrument_id = %s",
+                (iid,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        body, source_accession, reason = row
+        assert body == ""
+        assert source_accession == "AMEND-B"
+        assert reason == "no_item_1_marker"


### PR DESCRIPTION
## What

When the latest 10-K filing is a Part-III 10-K/A amendment (compensation/director-only restatement, omits Item 1), the ingester now retries against the most recent prior plain 10-K from the same instrument. On success, persists with the fallback's accession.

- Candidate query yields \`filing_type\` (4th column).
- \`_find_prior_plain_10k(conn, instrument_id, before_accession)\` finds the most recent plain 10-K strictly older than the amendment's filing_date.
- Branch in \`body is None\` path: only triggers for \`10-K/A\`; non-amendment misses tombstone directly.
- Two new tests: success-with-fallback + no-fallback-tombstones.

## Why

Pre-#534, ~167 instruments where the latest filing was a Part-III amendment never got an Item 1 narrative — even though the original 10-K's narrative was on file. Diagnosed during #515 post-merge review.

## Test plan

- [x] \`uv run ruff check . / format --check / pyright\` — clean
- [x] \`uv run pytest\` — 2793 passed, 1 pre-existing migration-066 deselected (#530)

🤖 Generated with [Claude Code](https://claude.com/claude-code)