### PR TITLE
fix(#537): process-wide SEC rate-limit clock

### DIFF
--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -53,6 +53,22 @@ _TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
 # SEC rate-limit: 10 req/s. We use a conservative inter-request floor.
 _MIN_REQUEST_INTERVAL_S = 0.11
 
+# Process-wide shared timestamp for the SEC rate limiter (#537).
+# Every ``SecFilingsProvider`` and ``SecFundamentalsProvider``
+# instance inside this Python process funnels its
+# ``ResilientClient(min_request_interval_s=...)`` through this single
+# timestamp so concurrent jobs (e.g. ``sec_8k_events_ingest`` +
+# ``sec_insider_transactions_ingest`` both firing on the hour)
+# share one global 10 req/s budget. Without this, each provider
+# instance carried its own clock and concurrent jobs could burst
+# past the SEC fair-use limit, triggering UA throttling and
+# cascading 4xx/5xx tombstones across every downstream parser.
+#
+# Multi-process / multi-worker concurrency is out of scope here;
+# revive when #479 (multi-worker WS subscriber) lands and look
+# at a Postgres advisory-lock token bucket.
+_PROCESS_RATE_LIMIT_CLOCK: list[float] = [0.0]
+
 
 def _zero_pad_cik(cik: str | int) -> str:
     """Return a 10-digit zero-padded CIK string."""
@@ -179,19 +195,20 @@ class SecFilingsProvider(FilingsProvider):
             headers={"User-Agent": user_agent, "Accept": "application/json"},
             timeout=30.0,
         )
-        # Both clients share the same SEC rate limit (10 req/s).
-        # Shared timestamp ensures interleaved calls to different hosts
-        # don't exceed the combined limit.
-        shared_ts: list[float] = [0.0]
+        # Both clients share the same SEC rate limit (10 req/s) via
+        # a PROCESS-wide shared timestamp (#537). Pre-#537 each
+        # provider instance had its own list[float], so concurrent
+        # ingest jobs each spawning their own SecFilingsProvider
+        # could collectively burst past the SEC fair-use limit.
         self._http = ResilientClient(
             self._client,
             min_request_interval_s=_MIN_REQUEST_INTERVAL_S,
-            shared_last_request=shared_ts,
+            shared_last_request=_PROCESS_RATE_LIMIT_CLOCK,
         )
         self._http_tickers = ResilientClient(
             self._tickers_client,
             min_request_interval_s=_MIN_REQUEST_INTERVAL_S,
-            shared_last_request=shared_ts,
+            shared_last_request=_PROCESS_RATE_LIMIT_CLOCK,
         )
 
     def __enter__(self) -> SecFilingsProvider:

--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -46,6 +46,7 @@ from app.providers.fundamentals import (
     XbrlConceptCatalogEntry,
     XbrlFact,
 )
+from app.providers.implementations.sec_edgar import _PROCESS_RATE_LIMIT_CLOCK
 from app.providers.resilient_client import ResilientClient
 
 logger = logging.getLogger(__name__)
@@ -340,8 +341,6 @@ class SecFundamentalsProvider(FundamentalsProvider):
         )
         # Process-wide shared rate-limit clock (#537) — see
         # ``app.providers.implementations.sec_edgar._PROCESS_RATE_LIMIT_CLOCK``.
-        from app.providers.implementations.sec_edgar import _PROCESS_RATE_LIMIT_CLOCK
-
         self._http = ResilientClient(
             self._client,
             min_request_interval_s=_MIN_REQUEST_INTERVAL_S,

--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -52,9 +52,11 @@ logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://data.sec.gov"
 
-# SEC rate-limit: 10 req/s.  Shared with the filings provider if both are
-# running, but in practice they run in separate phases of daily_research_refresh
-# so no cross-provider coordination is needed.
+# SEC rate-limit: 10 req/s. Funnelled through the same process-wide
+# clock as ``SecFilingsProvider`` so concurrent jobs (e.g. fundamentals
+# sync + 8-K events ingest both firing on the hour) share one global
+# 10 req/s budget rather than each carrying their own clock and
+# collectively bursting past the SEC fair-use limit (#537).
 _MIN_REQUEST_INTERVAL_S = 0.11
 
 # XBRL tags, in priority order, for each concept.
@@ -336,9 +338,14 @@ class SecFundamentalsProvider(FundamentalsProvider):
             headers={"User-Agent": user_agent, "Accept": "application/json"},
             timeout=30.0,
         )
+        # Process-wide shared rate-limit clock (#537) — see
+        # ``app.providers.implementations.sec_edgar._PROCESS_RATE_LIMIT_CLOCK``.
+        from app.providers.implementations.sec_edgar import _PROCESS_RATE_LIMIT_CLOCK
+
         self._http = ResilientClient(
             self._client,
             min_request_interval_s=_MIN_REQUEST_INTERVAL_S,
+            shared_last_request=_PROCESS_RATE_LIMIT_CLOCK,
         )
         # symbol → CIK cache, populated by caller before bulk refresh
         self._cik_cache: dict[str, str] = {}

--- a/tests/test_sec_rate_limit_clock.py
+++ b/tests/test_sec_rate_limit_clock.py
@@ -1,0 +1,52 @@
+"""Tests for process-wide SEC rate-limit clock (#537).
+
+Pre-#537 each ``SecFilingsProvider`` / ``SecFundamentalsProvider``
+instance carried its own ``shared_last_request`` list. Concurrent
+ingest jobs (e.g. ``sec_8k_events_ingest`` + ``sec_insider_transactions_ingest``
+both firing on the hour) collectively bursted past the SEC fair-use
+10 req/s limit even though each individual provider stayed under.
+
+Post-#537 every provider in this Python process funnels through
+``_PROCESS_RATE_LIMIT_CLOCK`` so the global budget is respected.
+"""
+
+from __future__ import annotations
+
+from app.providers.implementations.sec_edgar import (
+    _PROCESS_RATE_LIMIT_CLOCK,
+    SecFilingsProvider,
+)
+from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
+
+
+def test_filings_provider_instances_share_process_clock() -> None:
+    p1 = SecFilingsProvider(user_agent="test-ua")
+    p2 = SecFilingsProvider(user_agent="test-ua")
+    try:
+        # Both clients on a single instance + clients on a separate
+        # instance must reference the SAME list object (identity, not
+        # equality) so writes on one tick the other.
+        assert p1._http._last_request_at is _PROCESS_RATE_LIMIT_CLOCK
+        assert p1._http_tickers._last_request_at is _PROCESS_RATE_LIMIT_CLOCK
+        assert p2._http._last_request_at is _PROCESS_RATE_LIMIT_CLOCK
+        assert p2._http_tickers._last_request_at is _PROCESS_RATE_LIMIT_CLOCK
+    finally:
+        p1.__exit__(None, None, None)
+        p2.__exit__(None, None, None)
+
+
+def test_fundamentals_provider_shares_process_clock_with_filings_provider() -> None:
+    """Cross-class sharing: SecFundamentalsProvider funnels through
+    the same _PROCESS_RATE_LIMIT_CLOCK as SecFilingsProvider so a
+    fundamentals_sync run + a filings ingest run cannot collectively
+    exceed the SEC 10 req/s budget."""
+    filings = SecFilingsProvider(user_agent="test-ua")
+    fundamentals = SecFundamentalsProvider(user_agent="test-ua")
+    try:
+        assert filings._http._last_request_at is _PROCESS_RATE_LIMIT_CLOCK
+        assert fundamentals._http._last_request_at is _PROCESS_RATE_LIMIT_CLOCK
+        # And critically: both reference the same object.
+        assert filings._http._last_request_at is fundamentals._http._last_request_at
+    finally:
+        filings.__exit__(None, None, None)
+        fundamentals.__exit__(None, None, None)


### PR DESCRIPTION
## What

Module-level \`_PROCESS_RATE_LIMIT_CLOCK\` in \`sec_edgar.py\` shared by every SEC provider instance in the Python process. Pre-#537 each provider carried its own clock — concurrent ingest jobs collectively exceeded the SEC 10 req/s fair-use limit even though each stayed under individually.

- \`SecFilingsProvider\`: both clients (data.sec.gov + www.sec.gov) wired to the process-wide clock.
- \`SecFundamentalsProvider\`: same.
- 2 new tests pin cross-instance + cross-class sharing.

## Why

Hourly jobs (\`sec_8k_events_ingest\`, \`sec_insider_transactions_ingest\`, \`sec_filing_documents_ingest\`) all fire on the hour. Each spawned its own \`SecFilingsProvider\` with an independent rate-limit clock. SEC throttling on combined burst would cascade tombstones across every parser.

## Out of scope

Multi-process / multi-worker rate-limit budget. Revives when #479 (multi-worker WS subscriber) lands.

## Test plan

- [x] \`uv run ruff check . / format --check / pyright\` — clean
- [x] \`uv run pytest\` — 2795 passed (1 pre-existing migration-066 deselected)
- [x] 2 new tests for clock sharing

🤖 Generated with [Claude Code](https://claude.com/claude-code)