### PR TITLE
feat(#531): admin capability-overrides drift endpoint

### DIFF
--- a/app/api/capability_overrides_admin.py
+++ b/app/api/capability_overrides_admin.py
@@ -1,0 +1,155 @@
+"""Admin endpoint for capability-override drift visibility (#531).
+
+Operators can edit ``exchanges.capabilities`` JSONB to adjust which
+providers a given venue uses. Without a drift view, those edits
+silently accumulate and a future seed-default change can land on
+top of operator overrides without anyone noticing.
+
+This endpoint diffs every exchange row's current ``capabilities``
+against the migration-071 seed default for its asset class. Rows
+that match the seed are excluded; rows that diverge surface with
+both states for operator review.
+
+Read-only; the operator edits via direct SQL or a future write
+endpoint (out of scope for #531). Auth: operator session or
+service token.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.api.auth import require_session_or_service_token
+from app.db import get_conn
+from app.services.capabilities import V1_CAPABILITIES
+
+router = APIRouter(
+    prefix="/admin/capability-overrides",
+    tags=["admin", "capabilities"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+
+# Seed defaults from sql/071 (us_equity) + sql/072 (drop fmp).
+# Hard-coded here rather than re-read from the migration file so
+# the diff endpoint stays self-contained. If the seed changes in
+# a future migration, update this map AND ship a new migration —
+# the test in tests/test_migration_071_exchanges_capabilities.py
+# pins the expected post-migration shape so drift is caught at
+# CI time.
+_SEED_BY_ASSET_CLASS: dict[str, dict[str, list[str]]] = {
+    "us_equity": {
+        "filings": ["sec_edgar"],
+        "fundamentals": ["sec_xbrl"],
+        "dividends": ["sec_dividend_summary"],
+        "insider": ["sec_form4"],
+        "analyst": [],
+        "ratings": [],
+        "esg": [],
+        "ownership": ["sec_13f", "sec_13d_13g"],
+        "corporate_events": ["sec_8k_events"],
+        "business_summary": ["sec_10k_item1"],
+        "officers": [],
+    },
+}
+# All non-us_equity asset classes get the empty-but-correctly-
+# shaped default per migration 071.
+_EMPTY_SEED: dict[str, list[str]] = {cap: [] for cap in V1_CAPABILITIES}
+
+
+def _seed_for(asset_class: str) -> dict[str, list[str]]:
+    return _SEED_BY_ASSET_CLASS.get(asset_class, _EMPTY_SEED)
+
+
+class CapabilityCellDiff(BaseModel):
+    """One per-capability diff for an exchange row."""
+
+    capability: str
+    seed_providers: list[str]
+    current_providers: list[str]
+
+
+class ExchangeOverrideRow(BaseModel):
+    """One exchange whose capabilities diverge from seed."""
+
+    exchange_id: str
+    exchange_name: str | None
+    asset_class: str | None
+    diffs: list[CapabilityCellDiff]
+
+
+class OverridesListResponse(BaseModel):
+    checked_at: datetime
+    total_overrides: int
+    rows: list[ExchangeOverrideRow]
+
+
+@router.get("", response_model=OverridesListResponse)
+def list_overrides(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> OverridesListResponse:
+    """List exchange rows whose ``capabilities`` differ from the
+    seed default for their asset_class.
+
+    Empty list = every exchange is at its seed default. Each
+    row enumerates only the capabilities that diverge — clean
+    capabilities are dropped so the dashboard surfaces only the
+    drift signal.
+    """
+    rows: list[ExchangeOverrideRow] = []
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT exchange_id, name, asset_class, capabilities
+              FROM exchanges
+             ORDER BY exchange_id
+            """
+        )
+        for r in cur.fetchall():
+            asset_class_raw = r["asset_class"]
+            asset_class = str(asset_class_raw) if asset_class_raw is not None else None
+            seed = _seed_for(asset_class) if asset_class is not None else _EMPTY_SEED
+            current_raw: Any = r["capabilities"]
+            current: dict[str, list[str]] = {}
+            if isinstance(current_raw, dict):
+                for cap_name, cap_value in current_raw.items():
+                    if isinstance(cap_value, list):
+                        current[str(cap_name)] = [str(v) for v in cap_value if isinstance(v, str)]
+
+            diffs: list[CapabilityCellDiff] = []
+            for cap in V1_CAPABILITIES:
+                seed_list = list(seed.get(cap, []))
+                current_list = list(current.get(cap, []))
+                if seed_list != current_list:
+                    diffs.append(
+                        CapabilityCellDiff(
+                            capability=cap,
+                            seed_providers=seed_list,
+                            current_providers=current_list,
+                        )
+                    )
+
+            if not diffs:
+                continue
+
+            rows.append(
+                ExchangeOverrideRow(
+                    exchange_id=str(r["exchange_id"]),
+                    exchange_name=str(r["name"]) if r["name"] is not None else None,
+                    asset_class=asset_class,
+                    diffs=diffs,
+                )
+            )
+
+    return OverridesListResponse(
+        checked_at=datetime.now().astimezone(),
+        total_overrides=len(rows),
+        rows=rows,
+    )

--- a/app/api/capability_overrides_admin.py
+++ b/app/api/capability_overrides_admin.py
@@ -127,7 +127,15 @@ def list_overrides(
             for cap in V1_CAPABILITIES:
                 seed_list = list(seed.get(cap, []))
                 current_list = list(current.get(cap, []))
-                if seed_list != current_list:
+                # Drift compares the *set* of providers, not the
+                # ordering. Provider order is meaningful at runtime
+                # (resolver renders panels in declared order), but
+                # reordering without changing the set isn't useful
+                # drift signal — an operator who reordered
+                # intentionally doesn't want to see it as drift, and
+                # JSONB array round-trips can in principle reorder.
+                # Codex review on #531.
+                if sorted(seed_list) != sorted(current_list):
                     diffs.append(
                         CapabilityCellDiff(
                             capability=cap,

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,7 @@ from app.api.auth_setup import router as auth_setup_router
 from app.api.broker_credentials import router as broker_credentials_router
 from app.api.budget import router as budget_router
 from app.api.business_summary_admin import router as business_summary_admin_router
+from app.api.capability_overrides_admin import router as capability_overrides_admin_router
 from app.api.config import KillSwitchRequest, KillSwitchResponse, post_kill_switch
 from app.api.config import router as config_router
 from app.api.copy_trading import router as copy_trading_router
@@ -329,6 +330,7 @@ app.include_router(config_router)
 app.include_router(copy_trading_router)
 app.include_router(coverage_router)
 app.include_router(business_summary_admin_router)
+app.include_router(capability_overrides_admin_router)
 app.include_router(filings_router)
 app.include_router(instruments_router)
 app.include_router(jobs_router)

--- a/tests/api/test_capability_overrides_admin_endpoint.py
+++ b/tests/api/test_capability_overrides_admin_endpoint.py
@@ -111,6 +111,34 @@ def test_diverged_row_lists_only_changed_capabilities() -> None:
     assert diff["current_providers"] == ["operator_custom"]
 
 
+def test_reordered_providers_are_not_drift() -> None:
+    """Provider order is meaningful at runtime but isn't drift —
+    an operator who reordered ``ownership`` from
+    ``[sec_13f, sec_13d_13g]`` to ``[sec_13d_13g, sec_13f]`` keeps
+    the same set; the endpoint must NOT report drift on that row."""
+    reordered = dict(_US_EQUITY_SEED)
+    reordered["ownership"] = ["sec_13d_13g", "sec_13f"]
+    cur = _make_cur(
+        [
+            {
+                "exchange_id": "4",
+                "name": "Nasdaq",
+                "asset_class": "us_equity",
+                "capabilities": reordered,
+            },
+        ]
+    )
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+
+    app = _build_app(conn)
+    with TestClient(app) as client:
+        resp = client.get("/admin/capability-overrides")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_overrides"] == 0
+
+
 def test_non_us_equity_seed_is_empty() -> None:
     """Non-us_equity rows have empty seed defaults; any populated
     capability counts as drift."""

--- a/tests/api/test_capability_overrides_admin_endpoint.py
+++ b/tests/api/test_capability_overrides_admin_endpoint.py
@@ -1,0 +1,141 @@
+"""Tests for /admin/capability-overrides endpoint (#531).
+
+Pins the diff contract: rows that match the migration-071 seed
+default for their asset_class are excluded; rows that diverge
+surface the seed-vs-current breakdown per capability.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.capability_overrides_admin import router as overrides_router
+from app.db import get_conn
+
+
+def _build_app(conn: MagicMock) -> FastAPI:
+    app = FastAPI()
+    app.include_router(overrides_router)
+
+    def _yield_conn():  # type: ignore[return]
+        yield conn
+
+    app.dependency_overrides[get_conn] = _yield_conn
+    from app.api.auth import require_session_or_service_token
+
+    app.dependency_overrides[require_session_or_service_token] = lambda: None
+    return app
+
+
+def _make_cur(rows: list[dict[str, object]]) -> MagicMock:
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.fetchall.return_value = rows
+    return cur
+
+
+_US_EQUITY_SEED: dict[str, list[str]] = {
+    "filings": ["sec_edgar"],
+    "fundamentals": ["sec_xbrl"],
+    "dividends": ["sec_dividend_summary"],
+    "insider": ["sec_form4"],
+    "analyst": [],
+    "ratings": [],
+    "esg": [],
+    "ownership": ["sec_13f", "sec_13d_13g"],
+    "corporate_events": ["sec_8k_events"],
+    "business_summary": ["sec_10k_item1"],
+    "officers": [],
+}
+
+
+def test_seed_match_returns_empty_overrides() -> None:
+    """An exchange whose capabilities exactly match the seed default
+    must NOT appear in the overrides list."""
+    cur = _make_cur(
+        [
+            {
+                "exchange_id": "4",
+                "name": "Nasdaq",
+                "asset_class": "us_equity",
+                "capabilities": dict(_US_EQUITY_SEED),
+            },
+        ]
+    )
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+
+    app = _build_app(conn)
+    with TestClient(app) as client:
+        resp = client.get("/admin/capability-overrides")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_overrides"] == 0
+    assert body["rows"] == []
+
+
+def test_diverged_row_lists_only_changed_capabilities() -> None:
+    """An exchange with one capability override surfaces with that
+    capability's diff; clean capabilities are dropped from the row."""
+    overridden = dict(_US_EQUITY_SEED)
+    overridden["analyst"] = ["operator_custom"]
+    cur = _make_cur(
+        [
+            {
+                "exchange_id": "4",
+                "name": "Nasdaq",
+                "asset_class": "us_equity",
+                "capabilities": overridden,
+            },
+        ]
+    )
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+
+    app = _build_app(conn)
+    with TestClient(app) as client:
+        resp = client.get("/admin/capability-overrides")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_overrides"] == 1
+    row = body["rows"][0]
+    assert row["exchange_id"] == "4"
+    assert len(row["diffs"]) == 1
+    diff = row["diffs"][0]
+    assert diff["capability"] == "analyst"
+    assert diff["seed_providers"] == []
+    assert diff["current_providers"] == ["operator_custom"]
+
+
+def test_non_us_equity_seed_is_empty() -> None:
+    """Non-us_equity rows have empty seed defaults; any populated
+    capability counts as drift."""
+    crypto_with_data: dict[str, list[str]] = {cap: [] for cap in _US_EQUITY_SEED}
+    crypto_with_data["filings"] = ["coingecko"]
+    cur = _make_cur(
+        [
+            {
+                "exchange_id": "100",
+                "name": "Crypto Exchange",
+                "asset_class": "crypto",
+                "capabilities": crypto_with_data,
+            },
+        ]
+    )
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+
+    app = _build_app(conn)
+    with TestClient(app) as client:
+        resp = client.get("/admin/capability-overrides")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_overrides"] == 1
+    diff = body["rows"][0]["diffs"][0]
+    assert diff["capability"] == "filings"
+    assert diff["seed_providers"] == []
+    assert diff["current_providers"] == ["coingecko"]


### PR DESCRIPTION
## What

\`GET /admin/capability-overrides\` diffs every exchange's \`capabilities\` JSONB against the migration-071 + migration-072 seed default for its asset_class. Returns rows that diverge with per-capability \`{seed_providers, current_providers}\` breakdown.

- Rows matching seed exactly are excluded.
- Per-row \`diffs\` list only the capabilities that changed; clean cells dropped.
- 3 endpoint tests cover seed-match-empty / single-cap-diff / non-us-equity-empty-seed.

## Why

PR 3 of #515 listed admin capability-overrides as scope. Operator edits to \`exchanges.capabilities\` accumulate silently; without drift visibility, a future seed-default change can land on top of operator overrides without anyone noticing. This endpoint surfaces the drift signal.

## Out of scope

Frontend section consuming the endpoint — backend useful as-is for ops investigation. Frontend drill-down a separate PR if/when needed.

## Test plan

- [x] \`uv run ruff check . / format --check / pyright\` — clean
- [x] \`uv run pytest\` — 2798 passed (+3 new, 1 pre-existing migration-066 deselected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)