### PR TITLE
feat(#551): headcount stat from SEC dei:EntityNumberOfEmployees

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -775,6 +775,80 @@ def get_instrument_sec_profile(
 
 
 # ---------------------------------------------------------------------------
+# Headcount endpoint (#551 — XBRL ``dei:EntityNumberOfEmployees``)
+# ---------------------------------------------------------------------------
+
+
+class InstrumentHeadcount(BaseModel):
+    """Most-recent reported employee count for one instrument.
+
+    Sourced from the SEC iXBRL ``dei:EntityNumberOfEmployees`` fact
+    via ``financial_facts_raw``. Block-tagging mandate post-2020 means
+    near-complete coverage on US issuers — the panel is silent (404)
+    when the instrument has no SEC CIK or no DEI fact ingested yet.
+    """
+
+    symbol: str
+    employees: int
+    period_end_date: date
+    source_accession: str
+
+
+@router.get("/{symbol}/employees", response_model=InstrumentHeadcount)
+def get_instrument_employees(
+    symbol: str,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> InstrumentHeadcount:
+    """Latest ``dei:EntityNumberOfEmployees`` fact for an instrument.
+
+    Returns 404 when no fact is on file (non-SEC issuer, fundamentals
+    sync hasn't seeded yet, or DEI cover-page tagging absent).
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT period_end, val, accession_number
+              FROM financial_facts_raw
+             WHERE instrument_id = %s
+               AND concept = 'EntityNumberOfEmployees'
+             ORDER BY period_end DESC, fetched_at DESC
+             LIMIT 1
+            """,
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"No employee count on file for {symbol}")
+
+    return InstrumentHeadcount(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        employees=int(row["val"]),  # type: ignore[arg-type]
+        period_end_date=row["period_end"],  # type: ignore[arg-type]
+        source_accession=str(row["accession_number"]),
+    )
+
+
+# ---------------------------------------------------------------------------
 # 8-K structured-events endpoint (#450)
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -296,6 +296,30 @@ export function fetchInsiderTransactions(
   );
 }
 
+export interface InstrumentHeadcount {
+  symbol: string;
+  employees: number;
+  period_end_date: string;
+  source_accession: string;
+}
+
+/** Latest reported employee count from SEC iXBRL DEI cover-page
+ *  facts (#551). Returns null on 404 (non-SEC issuer or fact not
+ *  ingested yet); rethrows other errors. */
+export async function fetchInstrumentEmployees(
+  symbol: string,
+): Promise<InstrumentHeadcount | null> {
+  try {
+    return await apiFetch<InstrumentHeadcount>(
+      `/instruments/${encodeURIComponent(symbol)}/employees`,
+    );
+  } catch (err) {
+    const { ApiError } = await import("@/api/client");
+    if (err instanceof ApiError && err.status === 404) return null;
+    throw err;
+  }
+}
+
 export function fetchInstrumentDetail(
   instrumentId: number,
 ): Promise<InstrumentDetail> {

--- a/frontend/src/components/instrument/SecProfilePanel.test.tsx
+++ b/frontend/src/components/instrument/SecProfilePanel.test.tsx
@@ -7,6 +7,7 @@ import { SecProfilePanel } from "./SecProfilePanel";
 
 vi.mock("@/api/instruments", () => ({
   fetchInstrumentSecProfile: vi.fn(),
+  fetchInstrumentEmployees: vi.fn().mockResolvedValue(null),
 }));
 
 import { fetchInstrumentSecProfile } from "@/api/instruments";

--- a/frontend/src/components/instrument/SecProfilePanel.tsx
+++ b/frontend/src/components/instrument/SecProfilePanel.tsx
@@ -9,8 +9,14 @@
  * (backed by #429 ingestion) and is no longer summarised here.
  */
 
-import { fetchInstrumentSecProfile } from "@/api/instruments";
-import type { InstrumentSecProfile } from "@/api/instruments";
+import {
+  fetchInstrumentEmployees,
+  fetchInstrumentSecProfile,
+} from "@/api/instruments";
+import type {
+  InstrumentHeadcount,
+  InstrumentSecProfile,
+} from "@/api/instruments";
 import {
   Section,
   SectionError,
@@ -29,6 +35,10 @@ export function SecProfilePanel({ symbol }: SecProfilePanelProps) {
     useCallback(() => fetchInstrumentSecProfile(symbol), [symbol]),
     [symbol],
   );
+  const headcount = useAsync<InstrumentHeadcount | null>(
+    useCallback(() => fetchInstrumentEmployees(symbol), [symbol]),
+    [symbol],
+  );
 
   return (
     <Section title="Company profile (SEC)">
@@ -42,13 +52,19 @@ export function SecProfilePanel({ symbol }: SecProfilePanelProps) {
           description="This instrument has no primary CIK mapping, or the daily SEC ingest has not yet seeded its entity row. Non-US tickers will not have one."
         />
       ) : (
-        <Body profile={state.data} />
+        <Body profile={state.data} headcount={headcount.data} />
       )}
     </Section>
   );
 }
 
-function Body({ profile }: { profile: InstrumentSecProfile }) {
+function Body({
+  profile,
+  headcount,
+}: {
+  profile: InstrumentSecProfile;
+  headcount: InstrumentHeadcount | null;
+}) {
   return (
     <div className="space-y-3 text-sm">
       {profile.description !== null && profile.description.length > 0 && (
@@ -95,6 +111,17 @@ function Body({ profile }: { profile: InstrumentSecProfile }) {
           <>
             <dt className="text-slate-500">Incorporated</dt>
             <dd>{profile.state_of_incorporation_desc}</dd>
+          </>
+        )}
+        {headcount !== null && (
+          <>
+            <dt className="text-slate-500">Employees</dt>
+            <dd>
+              {headcount.employees.toLocaleString()}
+              <span className="ml-1 text-xs text-slate-400">
+                (as of {headcount.period_end_date})
+              </span>
+            </dd>
           </>
         )}
         <dt className="text-slate-500">CIK</dt>

--- a/tests/api/test_instruments_employees_endpoint.py
+++ b/tests/api/test_instruments_employees_endpoint.py
@@ -1,0 +1,90 @@
+"""Tests for GET /instruments/{symbol}/employees (#551).
+
+Service-layer logic is exercised by the existing financial_facts_raw
+ingest tests. This test pins the HTTP response shape, 404 on
+unknown symbol, 404 on no fact on file — via mocked connection so
+the test runs anywhere.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.instruments import router as instruments_router
+from app.db import get_conn
+
+
+def _build_app(conn: MagicMock) -> FastAPI:
+    app = FastAPI()
+    app.include_router(instruments_router)
+
+    def _yield_conn():  # type: ignore[return]
+        yield conn
+
+    app.dependency_overrides[get_conn] = _yield_conn
+    from app.api.auth import require_session_or_service_token
+
+    app.dependency_overrides[require_session_or_service_token] = lambda: None
+    return app
+
+
+def _cursor_with(rows: list[dict[str, object] | None]) -> MagicMock:
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.fetchone.side_effect = rows
+    return cur
+
+
+def test_employees_endpoint_returns_latest_fact() -> None:
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_with(
+        [
+            {"instrument_id": 1, "symbol": "AAPL"},
+            {
+                "period_end": date(2025, 9, 27),
+                "val": Decimal("164000"),
+                "accession_number": "0000320193-25-000079",
+            },
+        ]
+    )
+    app = _build_app(conn)
+    with TestClient(app) as client:
+        resp = client.get("/instruments/AAPL/employees")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body == {
+        "symbol": "AAPL",
+        "employees": 164000,
+        "period_end_date": "2025-09-27",
+        "source_accession": "0000320193-25-000079",
+    }
+
+
+def test_employees_endpoint_404_unknown_symbol() -> None:
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_with([None])
+    app = _build_app(conn)
+    with TestClient(app) as client:
+        resp = client.get("/instruments/NOPE/employees")
+    assert resp.status_code == 404
+
+
+def test_employees_endpoint_404_when_no_fact() -> None:
+    """Instrument exists but has no DEI EntityNumberOfEmployees row."""
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_with(
+        [
+            {"instrument_id": 1, "symbol": "BTC"},
+            None,  # no fact on file
+        ]
+    )
+    app = _build_app(conn)
+    with TestClient(app) as client:
+        resp = client.get("/instruments/BTC/employees")
+    assert resp.status_code == 404


### PR DESCRIPTION
## What

Latest reported employee count surfaces next to SIC / exchanges / fiscal-year on \`SecProfilePanel\`. Sources from existing \`financial_facts_raw\` rows (DEI cover-page block tagging is mandatory post-2020).

- Backend: \`GET /instruments/{symbol}/employees\` returning \`{symbol, employees, period_end_date, source_accession}\`. 404 when no fact on file.
- Frontend: \`fetchInstrumentEmployees\` returns \`null\` on 404. \`SecProfilePanel\` renders "Employees: 164,000 (as of 2025-09-27)" row, hidden when null.

## Why

Bloomberg / CapIQ / Refinitiv pair structured cover-page facts (employees, fiscal year, exchanges) with the company narrative. eBull's instrument page didn't surface headcount despite the data being already ingested for 270 instruments on dev.

## Out of scope

Segment + geographic XBRL dimension extraction split to #554 — needs axis/member columns on \`financial_facts_raw\` (or a new dimension table); larger scope than this MVP.

## Test plan

- [x] \`uv run ruff check . / format --check / pyright\` — clean
- [x] \`uv run pytest\` — 2809 passed
- [x] \`pnpm typecheck / test:unit\` — 406 passed
- [x] 3 new endpoint tests pin happy-path + 404 branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)