### PR TITLE
feat(#552): 10-K narrative drilldown route + teaser

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { DashboardPage } from "@/pages/DashboardPage";
 import { RankingsPage } from "@/pages/RankingsPage";
 import { InstrumentDetailRedirect } from "@/pages/InstrumentDetailRedirect";
 import { InstrumentPage } from "@/pages/InstrumentPage";
+import { Tenk10KDrilldownPage } from "@/pages/Tenk10KDrilldownPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { RecommendationsPage } from "@/pages/RecommendationsPage";
 import { AdminPage } from "@/pages/AdminPage";
@@ -60,6 +61,10 @@ export function App() {
             element={<InstrumentDetailRedirect />}
           />
           <Route path="instrument/:symbol" element={<InstrumentPage />} />
+          <Route
+            path="instrument/:symbol/filings/10-k"
+            element={<Tenk10KDrilldownPage />}
+          />
           <Route path="copy-trading/:mirrorId" element={<CopyTradingPage />} />
           <Route path="recommendations" element={<RecommendationsPage />} />
           <Route path="reports" element={<ReportsPage />} />

--- a/frontend/src/components/instrument/BusinessSectionsTeaser.tsx
+++ b/frontend/src/components/instrument/BusinessSectionsTeaser.tsx
@@ -1,0 +1,91 @@
+/**
+ * BusinessSectionsTeaser — 240-char excerpt of the 10-K Item 1
+ * narrative on the instrument page (#552). Replaces the full inline
+ * BusinessSectionsPanel which was rendering the entire wall-of-text
+ * (up to 102 KB pre-#550 fixes, still verbose post-fix).
+ *
+ * Pattern matches Bloomberg / Refinitiv / CapIQ — the main
+ * instrument view shows a curated short summary + a link to the
+ * full sectioned drilldown. Operator clicks through when they want
+ * to read the issuer's authoritative wording.
+ */
+
+import { fetchBusinessSections } from "@/api/instruments";
+import type {
+  BusinessSection,
+  BusinessSectionsResponse,
+} from "@/api/instruments";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+import { useCallback } from "react";
+import { Link } from "react-router-dom";
+
+export interface BusinessSectionsTeaserProps {
+  readonly symbol: string;
+}
+
+const TEASER_LEN = 240;
+
+function pickTeaser(sections: ReadonlyArray<BusinessSection>): string {
+  // Prefer the first non-empty body — usually the "general" /
+  // "overview" intro paragraph. Fall back to any section's body
+  // if the first is unexpectedly empty.
+  for (const s of sections) {
+    if (s.body && s.body.length > 0) {
+      const text = s.body.replace(/\s+/g, " ").trim();
+      if (text.length <= TEASER_LEN) return text;
+      const slice = text.slice(0, TEASER_LEN);
+      const lastSpace = slice.lastIndexOf(" ");
+      const cut = lastSpace > TEASER_LEN * 0.7 ? lastSpace : TEASER_LEN;
+      return text.slice(0, cut).trim() + "…";
+    }
+  }
+  return "";
+}
+
+export function BusinessSectionsTeaser({ symbol }: BusinessSectionsTeaserProps) {
+  const state = useAsync<BusinessSectionsResponse>(
+    useCallback(() => fetchBusinessSections(symbol), [symbol]),
+    [symbol],
+  );
+
+  return (
+    <Section title="Company narrative (SEC 10-K Item 1)">
+      {state.loading ? (
+        <SectionSkeleton rows={2} />
+      ) : state.error !== null ? (
+        <SectionError onRetry={state.refetch} />
+      ) : state.data === null || state.data.sections.length === 0 ? (
+        <EmptyState
+          title="No 10-K Item 1 on file"
+          description="No 10-K business description has been parsed for this instrument yet."
+        />
+      ) : (
+        <div className="space-y-2 text-sm">
+          <p className="leading-relaxed text-slate-700">
+            {pickTeaser(state.data.sections)}
+          </p>
+          <div>
+            <Link
+              to={`/instrument/${encodeURIComponent(symbol)}/filings/10-k`}
+              className="text-xs font-medium text-sky-700 hover:underline"
+            >
+              View full 10-K narrative →
+            </Link>
+            {state.data.source_accession !== null && (
+              <span className="ml-2 text-[11px] text-slate-500">
+                accession{" "}
+                <span className="font-mono">{state.data.source_accession}</span>
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </Section>
+  );
+}

--- a/frontend/src/components/instrument/ResearchTab.tsx
+++ b/frontend/src/components/instrument/ResearchTab.tsx
@@ -13,7 +13,7 @@
  * provider tag (#515 PR 3b).
  */
 import { Section } from "@/components/dashboard/Section";
-import { BusinessSectionsPanel } from "@/components/instrument/BusinessSectionsPanel";
+import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSectionsTeaser";
 import { DividendsPanel } from "@/components/instrument/DividendsPanel";
 import { EightKEventsPanel } from "@/components/instrument/EightKEventsPanel";
 import { InsiderActivityPanel } from "@/components/instrument/InsiderActivityPanel";
@@ -206,7 +206,7 @@ export function ResearchTab({
       ))}
       {hasSec ? (
         <div className="md:col-span-2">
-          <BusinessSectionsPanel symbol={summary.identity.symbol} />
+          <BusinessSectionsTeaser symbol={summary.identity.symbol} />
         </div>
       ) : null}
       {insiderProviders.map((p) => (

--- a/frontend/src/pages/Tenk10KDrilldownPage.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.tsx
@@ -1,0 +1,143 @@
+/**
+ * /instrument/:symbol/filings/10-k — full SEC 10-K Item 1 drilldown
+ * (#552).
+ *
+ * Layout: left-rail TOC (built from section_order + section_label) +
+ * scrollable main panel. Mirrors what AlphaSense / Sentieo do for
+ * filings — operator picks a section from the TOC, scrolls the body.
+ *
+ * Routes back to ``/instrument/{symbol}`` via a Back link in the
+ * page header.
+ */
+
+import { fetchBusinessSections } from "@/api/instruments";
+import type {
+  BusinessSection,
+  BusinessSectionsResponse,
+} from "@/api/instruments";
+import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+import { useCallback } from "react";
+import { Link, useParams } from "react-router-dom";
+
+function sectionAnchorId(s: BusinessSection): string {
+  // Stable anchor: section_order keeps each row unique even when
+  // labels collide (rare, but pre-#550 the parser emitted multiple
+  // "general" sections — this guards against that).
+  return `s-${s.section_order}-${s.section_key}`;
+}
+
+function SectionBody({ section }: { section: BusinessSection }) {
+  return (
+    <article id={sectionAnchorId(section)} className="border-l-2 border-slate-200 pl-4">
+      <h3 className="text-base font-semibold text-slate-800">{section.section_label}</h3>
+      <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-slate-700">
+        {section.body}
+      </p>
+      {section.cross_references.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1 text-[11px]">
+          <span className="text-slate-500">Cross-refs:</span>
+          {section.cross_references.map((ref, idx) => (
+            <span
+              key={`${ref.reference_type}-${ref.target}-${idx}`}
+              className="rounded bg-slate-100 px-1.5 py-0.5 text-slate-700"
+              title={ref.context}
+            >
+              {ref.target}
+            </span>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function TOCRail({ sections }: { sections: ReadonlyArray<BusinessSection> }) {
+  return (
+    <nav className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto rounded border border-slate-200 bg-slate-50 p-3 text-sm">
+      <div className="mb-2 text-xs font-medium uppercase tracking-wider text-slate-500">
+        Sections
+      </div>
+      <ul className="space-y-1">
+        {sections.map((s) => (
+          <li key={sectionAnchorId(s)}>
+            <a
+              href={`#${sectionAnchorId(s)}`}
+              className="block truncate text-slate-700 hover:text-sky-700 hover:underline"
+              title={s.section_label}
+            >
+              {s.section_label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+function Body({ data, symbol }: { data: BusinessSectionsResponse; symbol: string }) {
+  if (data.sections.length === 0) {
+    return (
+      <EmptyState
+        title="No 10-K Item 1 on file"
+        description="No 10-K business description has been parsed for this instrument yet."
+      />
+    );
+  }
+  return (
+    <div className="grid gap-4 md:grid-cols-[16rem_1fr]">
+      <aside className="hidden md:block">
+        <TOCRail sections={data.sections} />
+      </aside>
+      <div className="space-y-6">
+        <header className="border-b border-slate-200 pb-2">
+          <Link
+            to={`/instrument/${encodeURIComponent(symbol)}`}
+            className="text-xs text-sky-700 hover:underline"
+          >
+            ← Back to {symbol}
+          </Link>
+          <h2 className="mt-1 text-lg font-semibold text-slate-900">
+            Form 10-K · Item 1 Business
+          </h2>
+          {data.source_accession !== null && (
+            <div className="text-[11px] text-slate-500">
+              accession <span className="font-mono">{data.source_accession}</span>
+            </div>
+          )}
+        </header>
+        {data.sections.map((s) => (
+          <SectionBody key={sectionAnchorId(s)} section={s} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function Tenk10KDrilldownPage() {
+  const { symbol = "" } = useParams<{ symbol: string }>();
+  const state = useAsync<BusinessSectionsResponse>(
+    useCallback(() => fetchBusinessSections(symbol), [symbol]),
+    [symbol],
+  );
+
+  return (
+    <div className="mx-auto max-w-6xl p-4">
+      <Section title={`${symbol} — 10-K narrative`}>
+        {state.loading ? (
+          <SectionSkeleton rows={6} />
+        ) : state.error !== null ? (
+          <SectionError onRetry={state.refetch} />
+        ) : state.data === null ? (
+          <EmptyState
+            title="Business narrative unavailable"
+            description="Could not load 10-K Item 1 sections for this instrument."
+          />
+        ) : (
+          <Body data={state.data} symbol={symbol} />
+        )}
+      </Section>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Replace the inline \`BusinessSectionsPanel\` on the instrument page with a 240-char teaser + "View full 10-K narrative →" link. Add new drilldown route \`/instrument/:symbol/filings/10-k\` rendering TOC rail + sectioned body.

- \`BusinessSectionsTeaser\`: 240-char excerpt of first non-empty section body, last-word-boundary truncation, drilldown link.
- \`Tenk10KDrilldownPage\`: sticky-positioned TOC rail + scrollable section panel. Each section = verbatim heading, body prose, cross-ref chips.
- Anchor IDs let TOC clicks scroll-jump.

## Why

Bloomberg / Refinitiv / CapIQ all show a short curated summary on the main view, full filing on drilldown. Pre-#552 GME's instrument page rendered up to 102 KB inline (capped at 10 KB per section but multi-section), crowding out price/key-stats/thesis. Post-#552 the main page is clean.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test:unit\` — 406 passed
- [x] \`uv run ruff check\` — clean
- [x] \`uv run pytest\` — 2809 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)