### PR TITLE
fix: HTML entity decode + paragraph breaks + short SecProfile description

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -706,7 +706,6 @@ def get_instrument_sec_profile(
     been seeded yet (pre-first-seed or non-US ticker without a primary
     CIK).
     """
-    from app.services.business_summary import get_business_summary
     from app.services.sec_entity_profile import get_entity_profile
 
     symbol_clean = symbol.strip().upper()
@@ -736,13 +735,15 @@ def get_instrument_sec_profile(
             detail="no SEC profile on file for this instrument",
         )
 
-    # #428: prefer the authoritative 10-K Item 1 body over the short
-    # entity-level ``description`` from submissions.json. The
-    # submissions description is a ~1-sentence blurb SEC surfaces in
-    # their own UI; Item 1 is the multi-paragraph authoritative text
-    # investors expect on an instrument page.
-    item_1_body = get_business_summary(conn, instrument_id=instrument_id)
-    description = item_1_body if item_1_body is not None else profile.description
+    # Description = SEC submissions.json blurb only. Pre-#552 this
+    # path preferred the authoritative 10-K Item 1 body and the
+    # SecProfilePanel rendered the full multi-paragraph narrative
+    # inline — that produced a wall-of-text on the instrument page
+    # that pushed all other panels off-screen. The 10-K narrative now
+    # lives behind the BusinessSectionsTeaser + drilldown route
+    # (#552); the SecProfile description reverts to the short
+    # submissions blurb that fits the instrument page panel.
+    description = profile.description
 
     return InstrumentSecProfile(
         symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]

--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -32,6 +32,7 @@ queryable row — no silent drops; unmapped headings surface as
 
 from __future__ import annotations
 
+import html
 import logging
 import re
 from dataclasses import dataclass
@@ -95,22 +96,61 @@ def _next_retry_days(attempt_count: int) -> int:
 _IXBRL_TAG_RE = re.compile(r"<ix:[^>]*>|</ix:[^>]*>", re.IGNORECASE)
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 _NBSP_RE = re.compile(r"&nbsp;|&#160;|&#xa0;| ", re.IGNORECASE)
-_WHITESPACE_RE = re.compile(r"\s+")
+
+# Block-level boundary tags that should produce a paragraph break in
+# the stripped output. Closing tags (``</p>``, ``</div>``, ``</li>``,
+# ``</tr>``, ``</h*>``) plus self-closing line breaks (``<br>``,
+# ``<br/>``). Pre-fix the stripped output collapsed every block
+# boundary to a single space, producing run-on text where every
+# original paragraph fused into one wall.
+_BLOCK_BREAK_RE = re.compile(
+    r"</p\s*>|</div\s*>|</li\s*>|</tr\s*>|</h[1-6]\s*>|<br\s*/?>",
+    re.IGNORECASE,
+)
+
+# Inline whitespace (spaces, tabs) but NOT newlines — preserves the
+# paragraph breaks injected by ``_BLOCK_BREAK_RE``. Followed by a
+# pass that collapses 3+ consecutive newlines to exactly two so the
+# final body has at most one blank line between paragraphs.
+_INLINE_WHITESPACE_RE = re.compile(r"[ \t\r\f\v]+")
+_EXCESS_NEWLINES_RE = re.compile(r"\n{3,}")
 
 
 def _strip_html(raw: str) -> str:
-    """Strip HTML + iXBRL to a whitespace-collapsed plain-text stream.
+    """Strip HTML + iXBRL to a plain-text stream with paragraph
+    structure preserved.
 
     iXBRL tags are stripped independently first because their
     attribute content (``contextref``, ``unitref``, ...) otherwise
     leaks through a naive ``<[^>]+>`` pass when the browser-tolerant
     markup has nested/unbalanced tags that confuse the simpler
-    regex. Attribute content is never user-facing narrative."""
+    regex. Attribute content is never user-facing narrative.
+
+    Block-boundary tags (``</p>``, ``</div>``, ``</li>``, ``<br>``,
+    ``</h*>``) become double newlines BEFORE the generic tag strip so
+    the resulting text retains paragraph breaks. Inline whitespace
+    (spaces / tabs) collapses to single space; consecutive newlines
+    cap at two (one blank line between paragraphs).
+
+    HTML entities (``&#8220;``, ``&amp;``, ``&rsquo;``, etc.) get
+    decoded via ``html.unescape`` so the rendered narrative reads as
+    natural prose instead of ``GameStop Corp. (&#8220;GameStop&#8221;)``.
+    """
+    # Block boundaries → paragraph break sentinel BEFORE the generic
+    # tag strip so the boundary survives.
+    with_breaks = _BLOCK_BREAK_RE.sub("\n\n", raw)
     # Strip iXBRL element wrappers; the inner text survives.
-    no_ix = _IXBRL_TAG_RE.sub(" ", raw)
+    no_ix = _IXBRL_TAG_RE.sub(" ", with_breaks)
     no_tags = _HTML_TAG_RE.sub(" ", no_ix)
     no_nbsp = _NBSP_RE.sub(" ", no_tags)
-    return _WHITESPACE_RE.sub(" ", no_nbsp).strip()
+    # Decode HTML entities — &#8220; → ", &amp; → &, &rsquo; → ', etc.
+    decoded = html.unescape(no_nbsp)
+    # Collapse runs of inline whitespace (NOT newlines) to single space.
+    inline_collapsed = _INLINE_WHITESPACE_RE.sub(" ", decoded)
+    # Cap consecutive newlines at two so the body has at most one
+    # blank line between paragraphs.
+    paragraph_collapsed = _EXCESS_NEWLINES_RE.sub("\n\n", inline_collapsed)
+    return paragraph_collapsed.strip()
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_business_summary.py
+++ b/tests/test_business_summary.py
@@ -125,6 +125,49 @@ class TestExtractBusinessSection:
     def test_empty_input_returns_none(self) -> None:
         assert extract_business_section("") is None
 
+    def test_html_entities_decoded(self) -> None:
+        """SEC filings use ``&#8220;`` (left double quote), ``&#8221;``,
+        ``&rsquo;``, ``&amp;`` etc. Pre-fix these leaked through to
+        the stored body as literal entity text. Post-fix they decode
+        to the natural Unicode characters so the rendered narrative
+        reads as natural prose."""
+        body = extract_business_section(
+            "<html><body>"
+            "<h2>Item 1. Business</h2>"
+            "<p>GameStop Corp. (&#8220;GameStop,&#8221; &#8220;we&#8221;) "
+            "offers games &amp; collectibles.</p>"
+            "<h2>Item 1A. Risk Factors</h2>"
+            "</body></html>"
+        )
+        assert body is not None
+        assert "&#8220;" not in body
+        assert "&amp;" not in body
+        # Curly quotes preserved as Unicode.
+        assert "“" in body or '"' in body  # left curly quote
+        assert "&" in body  # ampersand decoded
+
+    def test_paragraph_breaks_preserved_between_block_tags(self) -> None:
+        """Block-level tag boundaries (``</p>``, ``</div>``, ``<br>``)
+        produce paragraph breaks in the stripped output instead of
+        collapsing to a single space. Operator gets a readable
+        narrative with paragraph structure intact, not a wall of
+        run-on text."""
+        body = extract_business_section(
+            "<html><body>"
+            "<h2>Item 1. Business</h2>"
+            "<p>First paragraph about products.</p>"
+            "<p>Second paragraph about markets.</p>"
+            "<p>Third paragraph about competition.</p>"
+            "<h2>Item 1A. Risk Factors</h2>"
+            "</body></html>"
+        )
+        assert body is not None
+        # Paragraphs separated by at least one newline.
+        assert "products.\n" in body or "products.\n\n" in body
+        assert "markets.\n" in body or "markets.\n\n" in body
+        # No three+ consecutive newlines (capped at two).
+        assert "\n\n\n" not in body
+
     def test_whitespace_collapsed_to_single_space(self) -> None:
         """Multi-line + nbsp in the source collapses to a single
         space stream so the stored body is clean to render."""


### PR DESCRIPTION
## What

Three coupled rendering fixes after #550/#552:

1. **HTML entities decoded** — \`&#8220;\` etc. were leaking through to stored body. \`html.unescape\` pass after tag strip.
2. **Paragraph breaks preserved** — \`</p>\` / \`</div>\` / \`<br>\` boundaries become \`\n\n\` instead of single space. Drilldown panel renders multi-paragraph layout instead of one wall of run-on text.
3. **SecProfilePanel description** — switch from full 10-K Item 1 body to short SEC submissions blurb. Item 1 narrative now lives in the teaser + drilldown only (#552).

## Why

Operator screenshot showed:
- Company profile rendering full Item 1 wall-of-text inline.
- Garbled punctuation (\`&#8220;\` instead of \`"\`).
- Drilldown sections as one undifferentiated block per section.

All three resolved by this PR.

## Test plan

- [x] \`uv run ruff check . / format --check / pyright\` — clean
- [x] \`uv run pytest\` — 2811 passed (+2 new tests for entity decode + paragraph breaks)
- [x] Live verification on GME 10-K: \`&#8220;\` → \`"\`, paragraph breaks rendered.
- [x] Forced re-parse on all 4031 SEC-CIK instruments on dev so steady-state ingest refreshes existing bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)