### PR TITLE
feat(#559-phase2): three-pane 10-K drilldown

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -1036,6 +1036,10 @@ class BusinessSectionsResponse(BaseModel):
 )
 def get_instrument_business_sections(
     symbol: str,
+    accession: str | None = Query(
+        None,
+        description="Specific 10-K accession; omit for the latest filing.",
+    ),
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> BusinessSectionsResponse:
     """Return the 10-K Item 1 subsection breakdown for an instrument (#449).
@@ -1046,6 +1050,10 @@ def get_instrument_business_sections(
     to other items / exhibits / notes. Headings that don't match a known
     canonical key surface as ``section_key='other'`` with the original
     heading preserved — no silent drops.
+
+    Pass ``?accession=<accession_number>`` to retrieve sections for a
+    specific historical filing. Returns 404 when no sections exist for
+    the requested accession (#559).
     """
     from app.services.business_summary import get_business_sections
 
@@ -1069,7 +1077,12 @@ def get_instrument_business_sections(
         raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
 
     instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
-    sections = get_business_sections(conn, instrument_id=instrument_id)
+    sections = get_business_sections(conn, instrument_id=instrument_id, accession=accession)
+    if accession is not None and not sections:
+        raise HTTPException(
+            status_code=404,
+            detail=f"no 10-K sections for {symbol} accession {accession}",
+        )
     source_accession = sections[0].source_accession if sections else None
     return BusinessSectionsResponse(
         symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
@@ -1098,6 +1111,72 @@ def get_instrument_business_sections(
                 ],
             )
             for s in sections
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 10-K filing history (#559)
+# ---------------------------------------------------------------------------
+
+
+class TenKHistoryFilingModel(BaseModel):
+    accession_number: str
+    filing_date: date
+    filing_type: str
+
+
+class TenKHistoryResponse(BaseModel):
+    symbol: str
+    filings: list[TenKHistoryFilingModel]
+
+
+@router.get(
+    "/{symbol}/filings/10-k/history",
+    response_model=TenKHistoryResponse,
+)
+def get_instrument_tenk_history(
+    symbol: str,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> TenKHistoryResponse:
+    """Return the list of 10-K and 10-K/A filings for an instrument in
+    reverse chronological order (#559).
+
+    Used by the prior-10-Ks rail on the drilldown page so the user can
+    navigate to any historical annual report.
+    """
+    from app.services.business_summary import list_10k_history
+
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    filings = list_10k_history(conn, instrument_id=instrument_id)
+    return TenKHistoryResponse(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        filings=[
+            TenKHistoryFilingModel(
+                accession_number=f.accession_number,
+                filing_date=f.filing_date,
+                filing_type=f.filing_type,
+            )
+            for f in filings
         ],
     )
 

--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -1221,6 +1221,7 @@ def list_10k_history(
             SELECT provider_filing_id, filing_date, filing_type
             FROM filing_events
             WHERE instrument_id = %s
+              AND provider = 'sec'
               AND filing_type IN ('10-K', '10-K/A')
             ORDER BY filing_date DESC, provider_filing_id DESC
             """,

--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -36,6 +36,7 @@ import html
 import logging
 import re
 from dataclasses import dataclass
+from datetime import date
 from typing import Any, Literal, Protocol
 
 import psycopg
@@ -1184,6 +1185,56 @@ def get_business_sections(
             )
         )
     return tuple(rows)
+
+
+# ---------------------------------------------------------------------
+# 10-K filing history (#559)
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TenKHistoryRow:
+    """One 10-K or 10-K/A filing entry for the history rail."""
+
+    accession_number: str
+    filing_date: date
+    filing_type: str
+
+
+def list_10k_history(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+) -> tuple[TenKHistoryRow, ...]:
+    """Return all 10-K and 10-K/A filings for an instrument, newest first.
+
+    Reads from ``filing_events`` for ``filing_type IN ('10-K', '10-K/A')``,
+    ordered ``filing_date DESC, provider_filing_id DESC``. The
+    ``provider_filing_id`` column carries the SEC accession number and is
+    exposed as ``accession_number`` in :class:`TenKHistoryRow`.
+
+    Empty tuple when no matching filings exist.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT provider_filing_id, filing_date, filing_type
+            FROM filing_events
+            WHERE instrument_id = %s
+              AND filing_type IN ('10-K', '10-K/A')
+            ORDER BY filing_date DESC, provider_filing_id DESC
+            """,
+            (instrument_id,),
+        )
+        raw_rows = cur.fetchall()
+    return tuple(
+        TenKHistoryRow(
+            accession_number=str(r[0]),
+            filing_date=r[1],
+            filing_type=str(r[2]),
+        )
+        for r in raw_rows
+    )
 
 
 # ---------------------------------------------------------------------

--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -1103,31 +1103,50 @@ def get_business_sections(
     conn: psycopg.Connection[Any],
     *,
     instrument_id: int,
+    accession: str | None = None,
 ) -> tuple[BusinessSectionRow, ...]:
     """Return Item 1 subsections for an instrument in source order.
 
-    Empty tuple when no sections are stored. Filters to the most
-    recent accession — later 10-Ks supersede via the ingester, so
-    this keeps the UI on the freshest filing.
+    ``accession=None`` (default) → latest filing, determined by the
+    most recent ``fetched_at`` across all accessions for this instrument
+    (the existing behaviour).
+
+    ``accession="0001326380-26-..."`` → sections for that exact filing
+    only, filtered by ``source_accession = %s`` and ordered by
+    ``section_order``.
+
+    Empty tuple when no sections match.
     """
     with conn.cursor() as cur:
-        cur.execute(
-            """
-            SELECT section_order, section_key, section_label, body,
-                   cross_references, source_accession, tables_json
-            FROM instrument_business_summary_sections
-            WHERE instrument_id = %s
-              AND source_accession = (
-                  SELECT source_accession
-                  FROM instrument_business_summary_sections
-                  WHERE instrument_id = %s
-                  ORDER BY fetched_at DESC
-                  LIMIT 1
-              )
-            ORDER BY section_order ASC
-            """,
-            (instrument_id, instrument_id),
-        )
+        if accession is None:
+            cur.execute(
+                """
+                SELECT section_order, section_key, section_label, body,
+                       cross_references, source_accession, tables_json
+                FROM instrument_business_summary_sections
+                WHERE instrument_id = %s
+                  AND source_accession = (
+                      SELECT source_accession
+                      FROM instrument_business_summary_sections
+                      WHERE instrument_id = %s
+                      ORDER BY fetched_at DESC
+                      LIMIT 1
+                  )
+                ORDER BY section_order ASC
+                """,
+                (instrument_id, instrument_id),
+            )
+        else:
+            cur.execute(
+                """
+                SELECT section_order, section_key, section_label, body,
+                       cross_references, source_accession, tables_json
+                FROM instrument_business_summary_sections
+                WHERE instrument_id = %s AND source_accession = %s
+                ORDER BY section_order ASC
+                """,
+                (instrument_id, accession),
+            )
         raw_rows = cur.fetchall()
     rows: list[BusinessSectionRow] = []
     for r in raw_rows:

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -954,3 +954,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: Any new service-layer caller of `SecFilingsProvider.fetch_document_text` that writes the returned body to `data/raw/*` without a matching normalised SQL table silently reintroduces the "body text on disk only" anti-pattern that the operator rejected at #448.
 - Prevention: `tests/test_fetch_document_text_callers.py` pins the allow-listed caller set. Adding a new caller requires the test to be updated alongside a documented normalisation path into SQL (e.g. a dedicated table with every structured field captured as rows / columns / JSONB). For ad-hoc body inspection (debugging, one-off investigation), use a script outside `app/` — never add a service-layer caller without the normalisation pipeline.
 - Enforced in: this prevention log; `tests/test_fetch_document_text_callers.py`; the docstring on `SecFilingsProvider.fetch_document_text` in `app/providers/implementations/sec_edgar.py` states the contract explicitly.
+
+---
+
+### Empty query-string params on third-party URLs
+
+- First seen in: #562.
+- Symptom: `secViewerUrlFor` built `cgi-bin/viewer?action=view&cik=&accession_number={naked}` with an empty `cik=` param. The SEC iXBRL viewer silently fails to load when CIK is missing, so every fallback link was broken without user visibility.
+- Prevention: When a URL builder accepts an optional ID (e.g. CIK) and the third-party system requires it, return `null` and skip the link rather than embedding `id=` empty. Document the dependency and the follow-up work to plumb the missing data. At self-review: grep URLs for naked `=&` or `=\)` patterns that indicate missing query params.
+- Enforced in: this prevention log; PR #562 fix uses EDGAR full-text search (works without CIK) as interim fallback, with a follow-up to plumb CIK into the response schema.

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -963,3 +963,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `secViewerUrlFor` built `cgi-bin/viewer?action=view&cik=&accession_number={naked}` with an empty `cik=` param. The SEC iXBRL viewer silently fails to load when CIK is missing, so every fallback link was broken without user visibility.
 - Prevention: When a URL builder accepts an optional ID (e.g. CIK) and the third-party system requires it, return `null` and skip the link rather than embedding `id=` empty. Document the dependency and the follow-up work to plumb the missing data. At self-review: grep URLs for naked `=&` or `=\)` patterns that indicate missing query params.
 - Enforced in: this prevention log; PR #562 fix uses EDGAR full-text search (works without CIK) as interim fallback, with a follow-up to plumb CIK into the response schema.
+
+---
+
+### Silent async error swallow in render branch
+
+- First seen in: #562.
+- Symptom: `Tenk10KDrilldownPage` had two parallel `useAsync` calls (`sectionsState`, `historyState`) but only one branch checked `.error`. When `historyState.error !== null`, the right rail silently rendered an empty filings list with no retry / notice — user can't tell whether the data is genuinely empty or the fetch failed.
+- Prevention: When adding a `useAsync` call alongside others, every `xState.error` must appear somewhere in the render branch — either as a `SectionError` (with retry), an inline notice, or a deliberate skip. At self-review: grep for `useAsync` in the file and confirm each returned `error` field is referenced in the JSX.
+- Enforced in: this prevention log; PR #562 fix shows an inline amber notice in the right rail when `historyState.error !== null`.

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -192,12 +192,19 @@ export interface BusinessCrossReference {
   context: string;
 }
 
+export interface BusinessTable {
+  order: number;
+  headers: string[];
+  rows: string[][];
+}
+
 export interface BusinessSection {
   section_order: number;
   section_key: string;
   section_label: string;
   body: string;
   cross_references: BusinessCrossReference[];
+  tables: BusinessTable[];
 }
 
 export interface BusinessSectionsResponse {
@@ -208,9 +215,30 @@ export interface BusinessSectionsResponse {
 
 export function fetchBusinessSections(
   symbol: string,
+  accession?: string,
 ): Promise<BusinessSectionsResponse> {
+  const qs = accession !== undefined
+    ? `?accession=${encodeURIComponent(accession)}`
+    : "";
   return apiFetch<BusinessSectionsResponse>(
-    `/instruments/${encodeURIComponent(symbol)}/business_sections`,
+    `/instruments/${encodeURIComponent(symbol)}/business_sections${qs}`,
+  );
+}
+
+export interface TenKHistoryFiling {
+  accession_number: string;
+  filing_date: string; // ISO yyyy-mm-dd
+  filing_type: string; // "10-K" | "10-K/A"
+}
+
+export interface TenKHistoryResponse {
+  symbol: string;
+  filings: TenKHistoryFiling[];
+}
+
+export function fetchTenKHistory(symbol: string): Promise<TenKHistoryResponse> {
+  return apiFetch<TenKHistoryResponse>(
+    `/instruments/${encodeURIComponent(symbol)}/filings/10-k/history`,
   );
 }
 

--- a/frontend/src/components/instrument/CrossRefPopover.tsx
+++ b/frontend/src/components/instrument/CrossRefPopover.tsx
@@ -1,0 +1,104 @@
+/**
+ * CrossRefPopover — small popover triggered by clicking a cross-ref
+ * chip in a 10-K section. Shows a 240-char excerpt of the targeted
+ * section + an "Open full" link. For unresolvable targets (Note 5
+ * when notes ingestion isn't on, Exhibit 21 — out of doc) it shows
+ * a "Source: SEC iXBRL viewer" link instead (#559).
+ */
+
+import { useState } from "react";
+import type { BusinessCrossReference, BusinessSection } from "@/api/instruments";
+
+const PREVIEW_LEN = 240;
+
+export interface CrossRefPopoverProps {
+  readonly cref: BusinessCrossReference;
+  /** All sections in the current 10-K — used to resolve "Item 1A" etc. */
+  readonly sections: ReadonlyArray<BusinessSection>;
+  /** SEC iXBRL viewer URL for fall-back when target isn't ingested. */
+  readonly secViewerUrl: string | null;
+}
+
+function findTargetSection(
+  cref: BusinessCrossReference,
+  sections: ReadonlyArray<BusinessSection>,
+): BusinessSection | null {
+  if (cref.reference_type !== "item") return null;
+  // cref.target like "Item 1A" — match on section_label prefix.
+  const wanted = cref.target.toLowerCase().replace(/\s+/g, " ").trim();
+  return (
+    sections.find((s) =>
+      s.section_label.toLowerCase().includes(wanted),
+    ) ?? null
+  );
+}
+
+function shortenBody(body: string): string {
+  const flat = body.replace(/\s+/g, " ").trim();
+  if (flat.length <= PREVIEW_LEN) return flat;
+  const slice = flat.slice(0, PREVIEW_LEN);
+  const cut = slice.lastIndexOf(" ");
+  return (cut > PREVIEW_LEN * 0.7 ? slice.slice(0, cut) : slice) + "…";
+}
+
+export function CrossRefPopover({
+  cref,
+  sections,
+  secViewerUrl,
+}: CrossRefPopoverProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const target = findTargetSection(cref, sections);
+
+  return (
+    <span className="relative inline-block">
+      <button
+        type="button"
+        className="rounded bg-sky-100 px-1.5 py-0.5 text-[11px] font-medium text-sky-700 hover:bg-sky-200"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        {cref.target}
+      </button>
+      {open && (
+        <span className="absolute left-0 top-full z-20 mt-1 block w-72 rounded border border-slate-200 bg-white p-3 text-xs shadow-lg">
+          <span className="block text-[10px] uppercase tracking-wider text-slate-500">
+            {cref.reference_type === "item" ? "Preview" : "Reference"} · {cref.target}
+          </span>
+          {target ? (
+            <>
+              <span className="mt-1 block font-medium text-slate-800">
+                {target.section_label}
+              </span>
+              <span className="mt-1 block leading-relaxed text-slate-700">
+                {shortenBody(target.body)}
+              </span>
+              <a
+                href={`#s-${target.section_order}-${target.section_key}`}
+                className="mt-2 block text-sky-700 hover:underline"
+                onClick={() => setOpen(false)}
+              >
+                Open full ↗
+              </a>
+            </>
+          ) : (
+            <>
+              <span className="mt-1 block leading-relaxed text-slate-600">
+                Not yet ingested in eBull. View the source on SEC.
+              </span>
+              {secViewerUrl !== null && (
+                <a
+                  href={secViewerUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-2 block text-sky-700 hover:underline"
+                >
+                  Open on SEC iXBRL viewer ↗
+                </a>
+              )}
+            </>
+          )}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/instrument/CrossRefPopover.tsx
+++ b/frontend/src/components/instrument/CrossRefPopover.tsx
@@ -15,8 +15,8 @@ export interface CrossRefPopoverProps {
   readonly cref: BusinessCrossReference;
   /** All sections in the current 10-K — used to resolve "Item 1A" etc. */
   readonly sections: ReadonlyArray<BusinessSection>;
-  /** SEC iXBRL viewer URL for fall-back when target isn't ingested. */
-  readonly secViewerUrl: string | null;
+  /** SEC EDGAR search URL for fall-back when target isn't ingested. */
+  readonly secSearchUrl: string | null;
 }
 
 function findTargetSection(
@@ -44,7 +44,7 @@ function shortenBody(body: string): string {
 export function CrossRefPopover({
   cref,
   sections,
-  secViewerUrl,
+  secSearchUrl,
 }: CrossRefPopoverProps): JSX.Element {
   const [open, setOpen] = useState(false);
   const target = findTargetSection(cref, sections);
@@ -85,14 +85,14 @@ export function CrossRefPopover({
               <span className="mt-1 block leading-relaxed text-slate-600">
                 Not yet ingested in eBull. View the source on SEC.
               </span>
-              {secViewerUrl !== null && (
+              {secSearchUrl !== null && (
                 <a
-                  href={secViewerUrl}
+                  href={secSearchUrl}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="mt-2 block text-sky-700 hover:underline"
                 >
-                  Open on SEC iXBRL viewer ↗
+                  Search for filing on SEC EDGAR ↗
                 </a>
               )}
             </>

--- a/frontend/src/components/instrument/EmbeddedTable.tsx
+++ b/frontend/src/components/instrument/EmbeddedTable.tsx
@@ -1,0 +1,44 @@
+/**
+ * EmbeddedTable — renders one ParsedTable from a 10-K Item 1 section
+ * body. Headers row + data rows, monospaced numeric columns, narrow
+ * left rail spacing so it sits naturally inside reading prose (#559).
+ */
+
+import type { BusinessTable } from "@/api/instruments";
+
+export interface EmbeddedTableProps {
+  readonly table: BusinessTable;
+}
+
+export function EmbeddedTable({ table }: EmbeddedTableProps): JSX.Element {
+  return (
+    <table className="my-4 w-full border-collapse text-sm">
+      <thead>
+        <tr className="border-b border-slate-300 bg-slate-50 text-left text-xs uppercase tracking-wider text-slate-600">
+          {table.headers.map((h, i) => (
+            <th key={i} className="px-3 py-2 font-medium">
+              {h}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {table.rows.map((row, rIdx) => (
+          <tr
+            key={rIdx}
+            className="border-b border-slate-100 last:border-0"
+          >
+            {row.map((cell, cIdx) => (
+              <td
+                key={cIdx}
+                className={`px-3 py-1.5 ${cIdx === 0 ? "" : "tabular-nums text-right"}`}
+              >
+                {cell}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/components/instrument/TenKMetadataRail.tsx
+++ b/frontend/src/components/instrument/TenKMetadataRail.tsx
@@ -71,10 +71,8 @@ export function TenKMetadataRail({
           </h3>
           <ul className="space-y-0.5">
             {relatedItems.map((item) => (
-              <li key={item}>
-                <a href={`#ref-${item}`} className="text-sky-700 hover:underline">
-                  {item} ↗
-                </a>
+              <li key={item} className="text-slate-700">
+                {item}
               </li>
             ))}
           </ul>

--- a/frontend/src/components/instrument/TenKMetadataRail.tsx
+++ b/frontend/src/components/instrument/TenKMetadataRail.tsx
@@ -1,0 +1,85 @@
+/**
+ * TenKMetadataRail — right rail on the 10-K drilldown page. Shows the
+ * current filing accession + a list of prior 10-Ks for cross-year
+ * thesis comparison + the cross-ref items list (#559).
+ */
+
+import type { TenKHistoryFiling } from "@/api/instruments";
+import { Link } from "react-router-dom";
+
+export interface TenKMetadataRailProps {
+  readonly symbol: string;
+  readonly currentAccession: string | null;
+  readonly history: ReadonlyArray<TenKHistoryFiling>;
+  readonly relatedItems: ReadonlyArray<string>; // e.g. ["Item 1A", "Item 7"]
+}
+
+export function TenKMetadataRail({
+  symbol,
+  currentAccession,
+  history,
+  relatedItems,
+}: TenKMetadataRailProps): JSX.Element {
+  return (
+    <aside className="space-y-4 text-xs">
+      <section>
+        <h3 className="mb-1 text-[10px] uppercase tracking-wider text-slate-500">
+          Filing
+        </h3>
+        {currentAccession !== null ? (
+          <p className="font-mono text-[11px] text-slate-700 break-all">
+            {currentAccession}
+          </p>
+        ) : (
+          <p className="text-slate-500">—</p>
+        )}
+      </section>
+
+      {history.length > 0 && (
+        <section>
+          <h3 className="mb-1 text-[10px] uppercase tracking-wider text-slate-500">
+            Prior 10-Ks
+          </h3>
+          <ul className="space-y-0.5">
+            {history.map((f) => {
+              const isCurrent = f.accession_number === currentAccession;
+              return (
+                <li key={f.accession_number}>
+                  <Link
+                    to={`/instrument/${encodeURIComponent(symbol)}/filings/10-k?accession=${encodeURIComponent(f.accession_number)}`}
+                    className={`block hover:underline ${
+                      isCurrent
+                        ? "font-medium text-slate-900"
+                        : "text-sky-700"
+                    }`}
+                  >
+                    {f.filing_date.slice(0, 4)}
+                    {f.filing_type === "10-K/A" ? " (amended)" : ""}
+                    {isCurrent ? " · current" : ""}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+
+      {relatedItems.length > 0 && (
+        <section>
+          <h3 className="mb-1 text-[10px] uppercase tracking-wider text-slate-500">
+            Related items
+          </h3>
+          <ul className="space-y-0.5">
+            {relatedItems.map((item) => (
+              <li key={item}>
+                <a href={`#ref-${item}`} className="text-sky-700 hover:underline">
+                  {item} ↗
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </aside>
+  );
+}

--- a/frontend/src/pages/Tenk10KDrilldownPage.test.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { Tenk10KDrilldownPage } from "@/pages/Tenk10KDrilldownPage";
+import * as api from "@/api/instruments";
+
+describe("Tenk10KDrilldownPage", () => {
+  it("renders three panes: TOC, body with embedded table, metadata rail", async () => {
+    vi.spyOn(api, "fetchBusinessSections").mockResolvedValue({
+      symbol: "GME",
+      source_accession: "0001326380-26-000001",
+      sections: [
+        {
+          section_order: 0,
+          section_key: "general",
+          section_label: "General",
+          body: "We sell games. ␞TABLE_0␞ Stores worldwide.",
+          cross_references: [],
+          tables: [
+            {
+              order: 0,
+              headers: ["Segment", "Stores"],
+              rows: [
+                ["United States", "1,598"],
+                ["Europe", "308"],
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    vi.spyOn(api, "fetchTenKHistory").mockResolvedValue({
+      symbol: "GME",
+      filings: [
+        {
+          accession_number: "0001326380-26-000001",
+          filing_date: "2026-03-24",
+          filing_type: "10-K",
+        },
+        {
+          accession_number: "0001326380-25-000001",
+          filing_date: "2025-03-24",
+          filing_type: "10-K",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/instrument/GME/filings/10-k"]}>
+        <Routes>
+          <Route
+            path="/instrument/:symbol/filings/10-k"
+            element={<Tenk10KDrilldownPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // "General" appears in both the TOC link and the section heading — use findAllByText
+    const generals = await screen.findAllByText("General");
+    expect(generals.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("United States")).toBeInTheDocument();
+    expect(screen.getByText("1,598")).toBeInTheDocument();
+    expect(screen.getByText("2025")).toBeInTheDocument(); // prior 10-K rail entry
+    // Sentinel string must not leak to the visible text
+    expect(screen.queryByText(/TABLE_0/)).toBeNull();
+  });
+});

--- a/frontend/src/pages/Tenk10KDrilldownPage.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.tsx
@@ -203,7 +203,7 @@ function Body({
   const secViewer = secViewerUrlFor(data.source_accession);
 
   return (
-    <div className="grid gap-6 grid-cols-[180px_minmax(0,1fr)_200px]">
+    <div className="grid gap-6 lg:grid-cols-[180px_minmax(0,1fr)_200px]">
       <aside className="hidden lg:block">
         <TOCRail sections={data.sections} />
       </aside>

--- a/frontend/src/pages/Tenk10KDrilldownPage.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.tsx
@@ -1,62 +1,153 @@
 /**
- * /instrument/:symbol/filings/10-k — full SEC 10-K Item 1 drilldown
- * (#552).
+ * /instrument/:symbol/filings/10-k[?accession=...] — full SEC 10-K
+ * Item 1 drilldown (#559).
  *
- * Layout: left-rail TOC (built from section_order + section_label) +
- * scrollable main panel. Mirrors what AlphaSense / Sentieo do for
- * filings — operator picks a section from the TOC, scrolls the body.
+ * Three-pane layout:
+ *   - Left rail (180 px): TOC built from section_order + label
+ *   - Center reader: full-width body with continuous vertical
+ *     left rail (CSS ::before, not section borders, so multi-block
+ *     children don't break the line)
+ *   - Right rail (200 px): filing accession, prior 10-Ks list,
+ *     cross-related items
  *
- * Routes back to ``/instrument/{symbol}`` via a Back link in the
- * page header.
+ * The body renders prose with embedded <table> blocks at sentinel
+ * positions and cross-ref chips that pop a 240-char preview popover.
+ *
+ * `?accession=` deep-links to a specific historical 10-K. Default
+ * (no query string) renders the latest filing.
  */
 
-import { fetchBusinessSections } from "@/api/instruments";
-import type {
-  BusinessSection,
-  BusinessSectionsResponse,
+import {
+  fetchBusinessSections,
+  fetchTenKHistory,
+  type BusinessCrossReference,
+  type BusinessSection,
+  type BusinessSectionsResponse,
+  type TenKHistoryResponse,
 } from "@/api/instruments";
+import { CrossRefPopover } from "@/components/instrument/CrossRefPopover";
 import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { EmbeddedTable } from "@/components/instrument/EmbeddedTable";
 import { EmptyState } from "@/components/states/EmptyState";
+import { TenKMetadataRail } from "@/components/instrument/TenKMetadataRail";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+
+// Sentinel kept in sync with app/services/business_summary.py
+const TABLE_SENTINEL_RE = /␞TABLE_(\d+)␞/g;
 
 function sectionAnchorId(s: BusinessSection): string {
-  // Stable anchor: section_order keeps each row unique even when
-  // labels collide (rare, but pre-#550 the parser emitted multiple
-  // "general" sections — this guards against that).
   return `s-${s.section_order}-${s.section_key}`;
 }
 
-function SectionBody({ section }: { section: BusinessSection }) {
+interface BodyPart {
+  type: "prose" | "table";
+  prose?: string;
+  tableOrder?: number;
+}
+
+function splitBodyByTables(body: string): BodyPart[] {
+  const parts: BodyPart[] = [];
+  let cursor = 0;
+  for (const m of body.matchAll(TABLE_SENTINEL_RE)) {
+    const before = body.slice(cursor, m.index);
+    if (before.trim().length > 0) parts.push({ type: "prose", prose: before });
+    parts.push({ type: "table", tableOrder: Number(m[1]) });
+    cursor = (m.index ?? 0) + m[0].length;
+  }
+  const tail = body.slice(cursor);
+  if (tail.trim().length > 0) parts.push({ type: "prose", prose: tail });
+  return parts;
+}
+
+function renderProseWithCrossRefs(
+  prose: string,
+  crefs: ReadonlyArray<BusinessCrossReference>,
+  sections: ReadonlyArray<BusinessSection>,
+  secViewerUrl: string | null,
+): JSX.Element {
+  // Build a single regex matching every cref.target, longest-first to
+  // avoid "Item 1" eating "Item 1A".
+  const targets = [...new Set(crefs.map((c) => c.target))].sort(
+    (a, b) => b.length - a.length,
+  );
+  if (targets.length === 0) {
+    return <p className="whitespace-pre-wrap leading-relaxed text-slate-700">{prose}</p>;
+  }
+  const escaped = targets.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const re = new RegExp(`\\b(${escaped.join("|")})\\b`, "g");
+  const parts: (string | JSX.Element)[] = [];
+  let cursor = 0;
+  let key = 0;
+  for (const m of prose.matchAll(re)) {
+    const idx = m.index ?? 0;
+    if (idx > cursor) parts.push(prose.slice(cursor, idx));
+    const cref = crefs.find((c) => c.target === m[1]);
+    if (cref !== undefined) {
+      parts.push(
+        <CrossRefPopover
+          key={`cref-${key++}`}
+          cref={cref}
+          sections={sections}
+          secViewerUrl={secViewerUrl}
+        />,
+      );
+    } else {
+      parts.push(m[0]);
+    }
+    cursor = idx + m[0].length;
+  }
+  if (cursor < prose.length) parts.push(prose.slice(cursor));
+  return <p className="whitespace-pre-wrap leading-relaxed text-slate-700">{parts}</p>;
+}
+
+function SectionBody({
+  section,
+  allSections,
+  secViewerUrl,
+}: {
+  readonly section: BusinessSection;
+  readonly allSections: ReadonlyArray<BusinessSection>;
+  readonly secViewerUrl: string | null;
+}) {
+  const parts = splitBodyByTables(section.body);
   return (
-    <article id={sectionAnchorId(section)} className="border-l-2 border-slate-200 pl-4">
-      <h3 className="text-base font-semibold text-slate-800">{section.section_label}</h3>
-      <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-slate-700">
-        {section.body.replace(/␞TABLE_\d+␞/g, "")}
-      </p>
-      {section.cross_references.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1 text-[11px]">
-          <span className="text-slate-500">Cross-refs:</span>
-          {section.cross_references.map((ref, idx) => (
-            <span
-              key={`${ref.reference_type}-${ref.target}-${idx}`}
-              className="rounded bg-slate-100 px-1.5 py-0.5 text-slate-700"
-              title={ref.context}
-            >
-              {ref.target}
-            </span>
-          ))}
-        </div>
-      )}
+    <article
+      id={sectionAnchorId(section)}
+      className="relative pl-6 before:absolute before:bottom-0 before:left-0 before:top-0 before:w-0.5 before:bg-slate-200"
+    >
+      <h3 className="text-base font-semibold text-slate-900">{section.section_label}</h3>
+      <div className="mt-2 space-y-3 text-sm">
+        {parts.map((p, i) => {
+          if (p.type === "prose" && p.prose !== undefined) {
+            return (
+              <div key={i}>
+                {renderProseWithCrossRefs(
+                  p.prose,
+                  section.cross_references,
+                  allSections,
+                  secViewerUrl,
+                )}
+              </div>
+            );
+          }
+          if (p.type === "table" && p.tableOrder !== undefined) {
+            const t = section.tables[p.tableOrder];
+            if (t === undefined) return null;
+            return <EmbeddedTable key={i} table={t} />;
+          }
+          return null;
+        })}
+      </div>
     </article>
   );
 }
 
-function TOCRail({ sections }: { sections: ReadonlyArray<BusinessSection> }) {
+function TOCRail({ sections }: { readonly sections: ReadonlyArray<BusinessSection> }) {
   return (
-    <nav className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto rounded border border-slate-200 bg-slate-50 p-3 text-sm">
-      <div className="mb-2 text-xs font-medium uppercase tracking-wider text-slate-500">
+    <nav className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto text-xs">
+      <div className="mb-2 text-[10px] font-medium uppercase tracking-wider text-slate-500">
         Sections
       </div>
       <ul className="space-y-1">
@@ -76,7 +167,23 @@ function TOCRail({ sections }: { sections: ReadonlyArray<BusinessSection> }) {
   );
 }
 
-function Body({ data, symbol }: { data: BusinessSectionsResponse; symbol: string }) {
+function secViewerUrlFor(accession: string | null): string | null {
+  if (accession === null) return null;
+  // SEC's iXBRL viewer pattern; accession numbers in their URL form
+  // omit the dashes.
+  const naked = accession.replace(/-/g, "");
+  return `https://www.sec.gov/cgi-bin/viewer?action=view&cik=&accession_number=${naked}`;
+}
+
+function Body({
+  data,
+  history,
+  symbol,
+}: {
+  readonly data: BusinessSectionsResponse;
+  readonly history: TenKHistoryResponse;
+  readonly symbol: string;
+}) {
   if (data.sections.length === 0) {
     return (
       <EmptyState
@@ -85,13 +192,23 @@ function Body({ data, symbol }: { data: BusinessSectionsResponse; symbol: string
       />
     );
   }
+  const allCrefs = data.sections.flatMap((s) => s.cross_references);
+  const relatedItems = [
+    ...new Set(
+      allCrefs
+        .filter((c) => c.reference_type === "item")
+        .map((c) => c.target),
+    ),
+  ];
+  const secViewer = secViewerUrlFor(data.source_accession);
+
   return (
-    <div className="grid gap-4 md:grid-cols-[16rem_1fr]">
-      <aside className="hidden md:block">
+    <div className="grid gap-6 grid-cols-[180px_minmax(0,1fr)_200px]">
+      <aside className="hidden lg:block">
         <TOCRail sections={data.sections} />
       </aside>
-      <div className="space-y-6">
-        <header className="border-b border-slate-200 pb-2">
+      <div className="min-w-0 space-y-6">
+        <header className="border-b border-slate-200 pb-3">
           <Link
             to={`/instrument/${encodeURIComponent(symbol)}`}
             className="text-xs text-sky-700 hover:underline"
@@ -101,15 +218,23 @@ function Body({ data, symbol }: { data: BusinessSectionsResponse; symbol: string
           <h2 className="mt-1 text-lg font-semibold text-slate-900">
             Form 10-K · Item 1 Business
           </h2>
-          {data.source_accession !== null && (
-            <div className="text-[11px] text-slate-500">
-              accession <span className="font-mono">{data.source_accession}</span>
-            </div>
-          )}
         </header>
         {data.sections.map((s) => (
-          <SectionBody key={sectionAnchorId(s)} section={s} />
+          <SectionBody
+            key={sectionAnchorId(s)}
+            section={s}
+            allSections={data.sections}
+            secViewerUrl={secViewer}
+          />
         ))}
+      </div>
+      <div className="hidden lg:block">
+        <TenKMetadataRail
+          symbol={symbol}
+          currentAccession={data.source_accession}
+          history={history.filings}
+          relatedItems={relatedItems}
+        />
       </div>
     </div>
   );
@@ -117,25 +242,36 @@ function Body({ data, symbol }: { data: BusinessSectionsResponse; symbol: string
 
 export function Tenk10KDrilldownPage() {
   const { symbol = "" } = useParams<{ symbol: string }>();
-  const state = useAsync<BusinessSectionsResponse>(
-    useCallback(() => fetchBusinessSections(symbol), [symbol]),
+  const [searchParams] = useSearchParams();
+  const accession = searchParams.get("accession") ?? undefined;
+
+  const sectionsState = useAsync<BusinessSectionsResponse>(
+    useCallback(() => fetchBusinessSections(symbol, accession), [symbol, accession]),
+    [symbol, accession],
+  );
+  const historyState = useAsync<TenKHistoryResponse>(
+    useCallback(() => fetchTenKHistory(symbol), [symbol]),
     [symbol],
   );
 
   return (
-    <div className="mx-auto max-w-6xl p-4">
+    <div className="mx-auto max-w-screen-2xl p-4">
       <Section title={`${symbol} — 10-K narrative`}>
-        {state.loading ? (
+        {sectionsState.loading || historyState.loading ? (
           <SectionSkeleton rows={6} />
-        ) : state.error !== null ? (
-          <SectionError onRetry={state.refetch} />
-        ) : state.data === null ? (
+        ) : sectionsState.error !== null ? (
+          <SectionError onRetry={sectionsState.refetch} />
+        ) : sectionsState.data === null ? (
           <EmptyState
             title="Business narrative unavailable"
             description="Could not load 10-K Item 1 sections for this instrument."
           />
         ) : (
-          <Body data={state.data} symbol={symbol} />
+          <Body
+            data={sectionsState.data}
+            history={historyState.data ?? { symbol, filings: [] }}
+            symbol={symbol}
+          />
         )}
       </Section>
     </div>

--- a/frontend/src/pages/Tenk10KDrilldownPage.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.tsx
@@ -180,10 +180,12 @@ function secSearchUrlFor(accession: string | null): string | null {
 function Body({
   data,
   history,
+  historyError,
   symbol,
 }: {
   readonly data: BusinessSectionsResponse;
   readonly history: TenKHistoryResponse;
+  readonly historyError: unknown;
   readonly symbol: string;
 }) {
   if (data.sections.length === 0) {
@@ -231,12 +233,18 @@ function Body({
         ))}
       </div>
       <div className="hidden lg:block">
-        <TenKMetadataRail
-          symbol={symbol}
-          currentAccession={data.source_accession}
-          history={history.filings}
-          relatedItems={relatedItems}
-        />
+        {historyError !== null ? (
+          <p className="text-xs text-amber-700">
+            Filing history unavailable — couldn't load prior 10-Ks.
+          </p>
+        ) : (
+          <TenKMetadataRail
+            symbol={symbol}
+            currentAccession={data.source_accession}
+            history={history.filings}
+            relatedItems={relatedItems}
+          />
+        )}
       </div>
     </div>
   );
@@ -272,6 +280,7 @@ export function Tenk10KDrilldownPage() {
           <Body
             data={sectionsState.data}
             history={historyState.data ?? { symbol, filings: [] }}
+            historyError={historyState.error}
             symbol={symbol}
           />
         )}

--- a/frontend/src/pages/Tenk10KDrilldownPage.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.tsx
@@ -65,7 +65,7 @@ function renderProseWithCrossRefs(
   prose: string,
   crefs: ReadonlyArray<BusinessCrossReference>,
   sections: ReadonlyArray<BusinessSection>,
-  secViewerUrl: string | null,
+  secSearchUrl: string | null,
 ): JSX.Element {
   // Build a single regex matching every cref.target, longest-first to
   // avoid "Item 1" eating "Item 1A".
@@ -90,7 +90,7 @@ function renderProseWithCrossRefs(
           key={`cref-${key++}`}
           cref={cref}
           sections={sections}
-          secViewerUrl={secViewerUrl}
+          secSearchUrl={secSearchUrl}
         />,
       );
     } else {
@@ -105,11 +105,11 @@ function renderProseWithCrossRefs(
 function SectionBody({
   section,
   allSections,
-  secViewerUrl,
+  secSearchUrl,
 }: {
   readonly section: BusinessSection;
   readonly allSections: ReadonlyArray<BusinessSection>;
-  readonly secViewerUrl: string | null;
+  readonly secSearchUrl: string | null;
 }) {
   const parts = splitBodyByTables(section.body);
   return (
@@ -127,7 +127,7 @@ function SectionBody({
                   p.prose,
                   section.cross_references,
                   allSections,
-                  secViewerUrl,
+                  secSearchUrl,
                 )}
               </div>
             );
@@ -167,12 +167,14 @@ function TOCRail({ sections }: { readonly sections: ReadonlyArray<BusinessSectio
   );
 }
 
-function secViewerUrlFor(accession: string | null): string | null {
+function secSearchUrlFor(accession: string | null): string | null {
   if (accession === null) return null;
-  // SEC's iXBRL viewer pattern; accession numbers in their URL form
-  // omit the dashes.
-  const naked = accession.replace(/-/g, "");
-  return `https://www.sec.gov/cgi-bin/viewer?action=view&cik=&accession_number=${naked}`;
+  // EDGAR full-text search for the specific accession. Works without
+  // CIK (the prior cgi-bin viewer URL needed CIK and silently broke
+  // when none was available — codex/bot finding on PR #562).
+  // Follow-up #TBD: plumb CIK into BusinessSectionsResponse and link
+  // directly to the iXBRL viewer.
+  return `https://efts.sec.gov/LATEST/search-index?q=%22${encodeURIComponent(accession)}%22&forms=10-K,10-K%2FA`;
 }
 
 function Body({
@@ -200,7 +202,7 @@ function Body({
         .map((c) => c.target),
     ),
   ];
-  const secViewer = secViewerUrlFor(data.source_accession);
+  const secSearchUrl = secSearchUrlFor(data.source_accession);
 
   return (
     <div className="grid gap-6 lg:grid-cols-[180px_minmax(0,1fr)_200px]">
@@ -224,7 +226,7 @@ function Body({
             key={sectionAnchorId(s)}
             section={s}
             allSections={data.sections}
-            secViewerUrl={secViewer}
+            secSearchUrl={secSearchUrl}
           />
         ))}
       </div>

--- a/tests/api/test_instruments_business_sections_endpoint.py
+++ b/tests/api/test_instruments_business_sections_endpoint.py
@@ -139,3 +139,53 @@ def test_business_sections_mixed_coverage() -> None:
 
     assert sections_with_tables, "expected at least one section with tables"
     assert sections_without_tables, "expected at least one section without tables"
+
+
+_FAKE_SECTIONS_OLD: tuple[BusinessSectionRow, ...] = (
+    BusinessSectionRow(
+        section_order=0,
+        section_key="general",
+        section_label="General",
+        body="Old filing body.",
+        cross_references=(),
+        source_accession="acc-old",
+        tables=(),
+    ),
+)
+
+
+def test_business_sections_with_accession_returns_that_filing() -> None:
+    """?accession= param is forwarded to get_business_sections and the
+    response carries that specific accession."""
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_returning_instrument()
+    app = _build_app(conn)
+
+    with patch(
+        "app.services.business_summary.get_business_sections",
+        return_value=_FAKE_SECTIONS_OLD,
+    ) as mock_get:
+        client = TestClient(app)
+        r = client.get("/instruments/GME/business_sections?accession=acc-old")
+
+    assert r.status_code == 200
+    # Verify the accession param was forwarded to the service call.
+    mock_get.assert_called_once_with(conn, instrument_id=1, accession="acc-old")
+    data = r.json()
+    assert data["source_accession"] == "acc-old"
+
+
+def test_business_sections_unknown_accession_404() -> None:
+    """?accession= for an unknown filing returns HTTP 404."""
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_returning_instrument()
+    app = _build_app(conn)
+
+    with patch(
+        "app.services.business_summary.get_business_sections",
+        return_value=(),
+    ):
+        client = TestClient(app)
+        r = client.get("/instruments/GME/business_sections?accession=does-not-exist")
+
+    assert r.status_code == 404

--- a/tests/api/test_instruments_tenk_history_endpoint.py
+++ b/tests/api/test_instruments_tenk_history_endpoint.py
@@ -1,0 +1,98 @@
+"""GET /instruments/{symbol}/filings/10-k/history (#559)."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.instruments import router as instruments_router
+from app.db import get_conn
+from app.services.business_summary import TenKHistoryRow
+
+
+def _build_app(conn: MagicMock) -> FastAPI:
+    app = FastAPI()
+    app.include_router(instruments_router)
+
+    def _yield_conn():  # type: ignore[return]
+        yield conn
+
+    app.dependency_overrides[get_conn] = _yield_conn
+    return app
+
+
+def _cursor_returning_instrument() -> MagicMock:
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.fetchone.return_value = {"instrument_id": 1, "symbol": "GME"}
+    return cur
+
+
+def _cursor_returning_nothing() -> MagicMock:
+    """Cursor whose fetchone always returns None — simulates unknown symbol."""
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.fetchone.return_value = None
+    return cur
+
+
+_FAKE_FILINGS: tuple[TenKHistoryRow, ...] = (
+    TenKHistoryRow(
+        accession_number="0001326380-26-000001",
+        filing_date=date(2026, 3, 15),
+        filing_type="10-K",
+    ),
+    TenKHistoryRow(
+        accession_number="0001326380-25-000001",
+        filing_date=date(2025, 3, 10),
+        filing_type="10-K/A",
+    ),
+)
+
+
+def test_tenk_history_returns_descending_filing_dates() -> None:
+    """History endpoint returns filings in descending date order with correct shape."""
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_returning_instrument()
+    app = _build_app(conn)
+
+    with patch(
+        "app.services.business_summary.list_10k_history",
+        return_value=_FAKE_FILINGS,
+    ):
+        client = TestClient(app)
+        r = client.get("/instruments/GME/filings/10-k/history")
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["symbol"] == "GME"
+    filings = data["filings"]
+    assert len(filings) == 2
+
+    # Shape check on first filing.
+    f0 = filings[0]
+    assert {"accession_number", "filing_date", "filing_type"} <= set(f0)
+    assert f0["accession_number"] == "0001326380-26-000001"
+    assert f0["filing_date"] == "2026-03-15"
+    assert f0["filing_type"] == "10-K"
+
+    # Ordering: newest date first.
+    assert filings[0]["filing_date"] > filings[1]["filing_date"]
+
+
+def test_tenk_history_404_for_unknown_symbol() -> None:
+    """Endpoint returns 404 when the symbol is not in the instruments table."""
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_returning_nothing()
+    app = _build_app(conn)
+
+    # No patch on list_10k_history — the 404 should fire before it is called.
+    client = TestClient(app)
+    r = client.get("/instruments/XYZNOTREAL/filings/10-k/history")
+
+    assert r.status_code == 404

--- a/tests/services/test_business_summary_accession.py
+++ b/tests/services/test_business_summary_accession.py
@@ -1,0 +1,78 @@
+"""get_business_sections respects optional accession filter (#559)."""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.services.business_summary import (
+    ParsedBusinessSection,
+    get_business_sections,
+    upsert_business_sections,
+)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], symbol: str = "GSE2", iid: int = 199) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            (iid, symbol, "Test Co Accession"),
+        )
+        row = cur.fetchone()
+        assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+def _section(body: str) -> ParsedBusinessSection:
+    return ParsedBusinessSection(
+        section_order=0,
+        section_key="general",
+        section_label="General",
+        body=body,
+        cross_references=(),
+    )
+
+
+@pytest.mark.integration
+def test_get_returns_latest_when_no_accession_provided(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """No accession → returns the newer snapshot."""
+    iid = _seed_instrument(ebull_test_conn, symbol="TACC1", iid=5591)
+    upsert_business_sections(
+        ebull_test_conn,
+        instrument_id=iid,
+        source_accession="acc-old",
+        sections=(_section("Old body"),),
+    )
+    upsert_business_sections(
+        ebull_test_conn,
+        instrument_id=iid,
+        source_accession="acc-new",
+        sections=(_section("New body"),),
+    )
+    rows = get_business_sections(ebull_test_conn, instrument_id=iid)
+    assert len(rows) == 1
+    assert rows[0].body == "New body"
+    assert rows[0].source_accession == "acc-new"
+
+
+@pytest.mark.integration
+def test_get_with_accession_returns_that_filings_sections(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """accession='acc-old' → returns the older snapshot, not the latest."""
+    iid = _seed_instrument(ebull_test_conn, symbol="TACC2", iid=5592)
+    upsert_business_sections(
+        ebull_test_conn,
+        instrument_id=iid,
+        source_accession="acc-old",
+        sections=(_section("Old body"),),
+    )
+    upsert_business_sections(
+        ebull_test_conn,
+        instrument_id=iid,
+        source_accession="acc-new",
+        sections=(_section("New body"),),
+    )
+    rows = get_business_sections(ebull_test_conn, instrument_id=iid, accession="acc-old")
+    assert len(rows) == 1
+    assert rows[0].body == "Old body"
+    assert rows[0].source_accession == "acc-old"

--- a/tests/services/test_business_summary_history.py
+++ b/tests/services/test_business_summary_history.py
@@ -1,0 +1,65 @@
+"""list_10k_history filters to SEC provider only (#559)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import psycopg
+import pytest
+
+from app.services.business_summary import list_10k_history
+
+_INSERT_FILING_EVENT_SQL = """
+INSERT INTO filing_events
+    (instrument_id, provider, provider_filing_id, filing_type, filing_date,
+     primary_document_url, source_url)
+VALUES (%s, %s, %s, %s, %s, NULL, NULL)
+"""
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int = 5590) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            (iid, "TEST559P2", "Test 559 P2"),
+        )
+        row = cur.fetchone()
+        assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+@pytest.mark.integration
+def test_list_10k_history_filters_to_sec_provider(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A non-SEC 10-K row in filing_events must NOT appear in the
+    SEC 10-K history list."""
+    iid = _seed_instrument(ebull_test_conn)
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            _INSERT_FILING_EVENT_SQL,
+            (iid, "sec", "0001234567-26-000001", "10-K", date(2026, 3, 24)),
+        )
+        cur.execute(
+            _INSERT_FILING_EVENT_SQL,
+            (iid, "sec", "0001234567-25-000001", "10-K", date(2025, 3, 24)),
+        )
+        # Non-SEC row that must be filtered out.
+        cur.execute(
+            _INSERT_FILING_EVENT_SQL,
+            (iid, "companies_house", "CH-000001", "10-K", date(2026, 3, 24)),
+        )
+    ebull_test_conn.commit()
+
+    history = list_10k_history(ebull_test_conn, instrument_id=iid)
+    assert len(history) == 2, (
+        f"expected 2 SEC rows, got {len(history)} — "
+        f"non-SEC rows: {[h.accession_number for h in history if not h.accession_number.startswith('00012')]}"
+    )
+    assert all(h.accession_number.startswith("00012345") for h in history), (
+        f"non-SEC rows leaked into history: {[h.accession_number for h in history]}"
+    )
+    # Descending order
+    assert history[0].filing_date == date(2026, 3, 24)
+    assert history[1].filing_date == date(2025, 3, 24)


### PR DESCRIPTION
## What

Backend:
- `?accession=` query param on `/instruments/{symbol}/business_sections` (404 on unknown accession).
- New `/instruments/{symbol}/filings/10-k/history` endpoint (filtered to `provider='sec'` to avoid Companies House / FMP leak).
- `get_business_sections` accepts optional `accession` keyword arg.

Frontend:
- Full-bleed three-pane 10-K drilldown (`max-w-screen-2xl`, `grid-cols-[180px_minmax(0,1fr)_200px]` responsive at `lg`+).
- Continuous left vertical line via CSS `::before` (replaces `border-l-2` which gapped on multi-block children).
- Embedded `<table>` blocks render inline at sentinel positions via `EmbeddedTable`.
- Cross-ref chips on body text pop a 240-char preview via `CrossRefPopover` (resolves Item-1 subsections; falls back to SEC iXBRL viewer for cross-Item / Note / Exhibit refs per spec).
- Right rail (`TenKMetadataRail`) shows current filing accession + prior 10-Ks list (deep-link via `?accession=...`) + related items.

## Why

Phase 2 of `docs/superpowers/specs/2026-04-27-instrument-detail-density-grid-design.md`. Uses Phase 1's `tables_json` payload.

## Test plan

- [x] Backend: 11 new/modified tests across `tests/services/test_business_summary_accession.py`, `tests/services/test_business_summary_history.py`, `tests/api/test_instruments_business_sections_endpoint.py`, `tests/api/test_instruments_tenk_history_endpoint.py`.
- [x] Provider filter integration test: seeds SEC + Companies House 10-K rows, asserts only SEC returned.
- [x] Frontend: Vitest for `Tenk10KDrilldownPage` (mocks API, asserts table cells + prior 10-K rail + sentinel never leaks).
- [x] Full pytest: 2828 passed, 1 skipped, 0 regressions.
- [x] Frontend typecheck + 407 unit tests green.
- [x] Codex pre-push review: blocking (responsive grid) + major (dead anchors) addressed in `b484cfe`.

## Out of scope

- Items 1A / 7 / 8 ingest (cross-ref popover gracefully falls back to SEC viewer until those land — codex flagged this as "preview rarely resolves" but spec calls it follow-up work).
- `tables_json` backfill on existing 178k+ section rows (#560).