### PR TITLE
feat(#559-phase3): instrument page density grid

### DIFF
--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -972,3 +972,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `Tenk10KDrilldownPage` had two parallel `useAsync` calls (`sectionsState`, `historyState`) but only one branch checked `.error`. When `historyState.error !== null`, the right rail silently rendered an empty filings list with no retry / notice — user can't tell whether the data is genuinely empty or the fetch failed.
 - Prevention: When adding a `useAsync` call alongside others, every `xState.error` must appear somewhere in the render branch — either as a `SectionError` (with retry), an inline notice, or a deliberate skip. At self-review: grep for `useAsync` in the file and confirm each returned `error` field is referenced in the JSX.
 - Enforced in: this prevention log; PR #562 fix shows an inline amber notice in the right rail when `historyState.error !== null`.
+
+---
+
+### Dead props on component interfaces
+
+- First seen in: #566.
+- Symptom: `DensityGrid` declared `thesis` and `thesisErrored` on its `DensityGridProps` interface; callers passed them; the function signature destructured neither and used neither. Silent dead path — TypeScript accepts it, callers think they're influencing render, no behaviour changes.
+- Prevention: Every prop in an exported component interface must appear in the destructuring parameter list of the function. At self-review: visually scan each `interface XProps {...}` in a diff and confirm each field is destructured + referenced in the body. The TS strict check `noUnusedParameters` doesn't catch this case because the destructured object as a whole is used.
+- Enforced in: this prevention log; PR #566 fix removes the dead props from the interface and call site.

--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -49,8 +49,6 @@ describe("DensityGrid", () => {
       <MemoryRouter>
         <DensityGrid
           summary={summary}
-          thesis={null}
-          thesisErrored={false}
           keyStatsBlock={<div>KEY STATS BLOCK</div>}
           thesisBlock={<div>THESIS BLOCK</div>}
           newsBlock={<div>NEWS BLOCK</div>}
@@ -69,8 +67,6 @@ describe("DensityGrid", () => {
       <MemoryRouter>
         <DensityGrid
           summary={summary}
-          thesis={null}
-          thesisErrored={false}
           keyStatsBlock={<div>KEY STATS BLOCK</div>}
           thesisBlock={<div>THESIS BLOCK</div>}
           newsBlock={<div>NEWS BLOCK</div>}
@@ -97,8 +93,6 @@ describe("DensityGrid", () => {
       <MemoryRouter>
         <DensityGrid
           summary={noSec}
-          thesis={null}
-          thesisErrored={false}
           keyStatsBlock={<div>KEY STATS BLOCK</div>}
           thesisBlock={<div>THESIS BLOCK</div>}
           newsBlock={<div>NEWS BLOCK</div>}

--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { DensityGrid } from "@/components/instrument/DensityGrid";
+
+// Mock child components that make their own API calls so the DensityGrid
+// unit test stays isolated.
+vi.mock("@/components/instrument/PriceChart", () => ({
+  PriceChart: () => <div data-testid="price-chart-stub" />,
+}));
+vi.mock("@/components/instrument/SecProfilePanel", () => ({
+  SecProfilePanel: () => <div>SEC Profile</div>,
+}));
+vi.mock("@/components/instrument/BusinessSectionsTeaser", () => ({
+  BusinessSectionsTeaser: () => <div>Company narrative (SEC 10-K Item 1)</div>,
+}));
+vi.mock("@/components/instrument/FilingsPane", () => ({
+  FilingsPane: () => (
+    <section>
+      <header>
+        <h2>Recent filings</h2>
+      </header>
+    </section>
+  ),
+}));
+vi.mock("@/components/instrument/DividendsPanel", () => ({
+  DividendsPanel: () => <div>Dividends</div>,
+}));
+vi.mock("@/components/instrument/InsiderActivityPanel", () => ({
+  InsiderActivityPanel: () => <div>Insider</div>,
+}));
+
+const summary = {
+  instrument_id: 1,
+  has_sec_cik: true,
+  identity: {
+    symbol: "GME",
+    display_name: "GameStop",
+    market_cap: "1000000",
+    sector: null,
+  },
+  capabilities: {},
+  key_stats: null,
+} as never;
+
+describe("DensityGrid", () => {
+  it("renders the chart stub, the slot blocks, and FilingsPane title", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={summary}
+          thesis={null}
+          thesisErrored={false}
+          keyStatsBlock={<div>KEY STATS BLOCK</div>}
+          thesisBlock={<div>THESIS BLOCK</div>}
+          newsBlock={<div>NEWS BLOCK</div>}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("price-chart-stub")).toBeInTheDocument();
+    expect(screen.getByText("KEY STATS BLOCK")).toBeInTheDocument();
+    expect(screen.getByText("THESIS BLOCK")).toBeInTheDocument();
+    expect(screen.getByText("NEWS BLOCK")).toBeInTheDocument();
+    expect(screen.getByText("Recent filings")).toBeInTheDocument();
+  });
+
+  it("shows the SEC profile pane when has_sec_cik is true", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={summary}
+          thesis={null}
+          thesisErrored={false}
+          keyStatsBlock={<div>KEY STATS BLOCK</div>}
+          thesisBlock={<div>THESIS BLOCK</div>}
+          newsBlock={<div>NEWS BLOCK</div>}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("SEC Profile")).toBeInTheDocument();
+  });
+
+  it("shows 'No SEC coverage' fallback when has_sec_cik is false", () => {
+    const noSec = {
+      instrument_id: 1,
+      has_sec_cik: false,
+      identity: {
+        symbol: "GME",
+        display_name: "GameStop",
+        market_cap: "1000000",
+        sector: null,
+      },
+      capabilities: {},
+      key_stats: null,
+    } as never;
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={noSec}
+          thesis={null}
+          thesisErrored={false}
+          keyStatsBlock={<div>KEY STATS BLOCK</div>}
+          thesisBlock={<div>THESIS BLOCK</div>}
+          newsBlock={<div>NEWS BLOCK</div>}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("No SEC coverage")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -1,0 +1,110 @@
+/**
+ * DensityGrid — Bloomberg-style 3-column grid for the instrument
+ * Research tab (#559). Chart occupies a 2x2 cell top-left; right
+ * column stacks key-stats / thesis / SEC profile / filings; bottom
+ * rows hold segments / dividends-insider / news.
+ *
+ * Responsive: at viewport widths below `lg` the grid degrades to
+ * a single column. Pane order reflects priority: chart → key-stats
+ * → thesis → filings → SEC-profile → segments → dividends-insider
+ * → news. Each pane scrolls internally rather than pushing the
+ * page taller.
+ */
+
+import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSectionsTeaser";
+import { DividendsPanel } from "@/components/instrument/DividendsPanel";
+import { FilingsPane } from "@/components/instrument/FilingsPane";
+import { InsiderActivityPanel } from "@/components/instrument/InsiderActivityPanel";
+import { PriceChart } from "@/components/instrument/PriceChart";
+import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
+import { Section } from "@/components/dashboard/Section";
+import type { CapabilityCell, InstrumentSummary, ThesisDetail } from "@/api/types";
+import { activeProviders } from "@/lib/capabilityProviders";
+
+export interface DensityGridProps {
+  readonly summary: InstrumentSummary;
+  readonly thesis: ThesisDetail | null;
+  readonly thesisErrored: boolean;
+  readonly keyStatsBlock: JSX.Element;
+  readonly thesisBlock: JSX.Element;
+  readonly newsBlock: JSX.Element;
+}
+
+const EMPTY_CELL: CapabilityCell = { providers: [], data_present: {} };
+
+export function DensityGrid({
+  summary,
+  keyStatsBlock,
+  thesisBlock,
+  newsBlock,
+}: DensityGridProps): JSX.Element {
+  const symbol = summary.identity.symbol;
+  const hasSec = summary.has_sec_cik;
+  const dividends = summary.capabilities.dividends ?? EMPTY_CELL;
+  const insider = summary.capabilities.insider ?? EMPTY_CELL;
+  const dividendProviders = activeProviders(dividends);
+  const insiderProviders = activeProviders(insider);
+
+  return (
+    <div className="grid grid-cols-1 gap-3 lg:grid-cols-[2fr_1fr_1fr] lg:auto-rows-[220px]">
+      {/* Chart pane: 2 cols × 2 rows top-left */}
+      <div className="overflow-hidden rounded-md border border-slate-200 bg-white p-3 shadow-sm lg:col-start-1 lg:col-end-2 lg:row-start-1 lg:row-end-3">
+        <PriceChart symbol={symbol} />
+      </div>
+
+      {/* Right column row 1 */}
+      <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+        {keyStatsBlock}
+      </div>
+      <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+        {thesisBlock}
+      </div>
+
+      {/* Right column row 2 */}
+      <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+        {hasSec ? (
+          <SecProfilePanel symbol={symbol} />
+        ) : (
+          <Section title="SEC profile">
+            <p className="text-xs text-slate-500">No SEC coverage</p>
+          </Section>
+        )}
+      </div>
+      <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+        <FilingsPane instrumentId={summary.instrument_id} symbol={symbol} />
+      </div>
+
+      {/* Bottom row: segments spans 2 cols, news spans 1 col */}
+      <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm lg:col-span-2">
+        {hasSec ? (
+          <BusinessSectionsTeaser symbol={symbol} />
+        ) : (
+          <Section title="Company narrative">
+            <p className="text-xs text-slate-500">No 10-K coverage</p>
+          </Section>
+        )}
+      </div>
+      <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+        {newsBlock}
+      </div>
+
+      {/* Dividends + insider combined card — spans full width */}
+      {(dividendProviders.length > 0 || insiderProviders.length > 0) && (
+        <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm lg:col-span-3">
+          <div className="grid gap-3 md:grid-cols-2">
+            {dividendProviders.map((p) => (
+              <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
+            ))}
+            {insiderProviders.map((p) => (
+              <InsiderActivityPanel
+                key={`ins-${p}`}
+                symbol={symbol}
+                provider={p}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -1,18 +1,22 @@
 /**
  * DensityGrid — Bloomberg-style 3-column grid for the instrument
- * Research tab (#559). Chart occupies a 2x2 cell top-left; right
- * column stacks key-stats / thesis / SEC profile / filings; bottom
- * rows hold segments / dividends-insider / news.
+ * Research tab (#559). Chart pane occupies the wide left column
+ * (2fr) spanning 2 rows; right column (1fr + 1fr) stacks
+ * key-stats / thesis / SEC profile / filings; bottom rows hold
+ * business teaser / news; dividends + insider as a wide combined
+ * card. Corporate events (8-K) follow below until Phase 4 ships
+ * the dedicated /filings/8-k route.
  *
  * Responsive: at viewport widths below `lg` the grid degrades to
  * a single column. Pane order reflects priority: chart → key-stats
  * → thesis → filings → SEC-profile → segments → dividends-insider
- * → news. Each pane scrolls internally rather than pushing the
- * page taller.
+ * → news → events. Each pane scrolls internally rather than pushing
+ * the page taller.
  */
 
 import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSectionsTeaser";
 import { DividendsPanel } from "@/components/instrument/DividendsPanel";
+import { EightKEventsPanel } from "@/components/instrument/EightKEventsPanel";
 import { FilingsPane } from "@/components/instrument/FilingsPane";
 import { InsiderActivityPanel } from "@/components/instrument/InsiderActivityPanel";
 import { PriceChart } from "@/components/instrument/PriceChart";
@@ -42,67 +46,84 @@ export function DensityGrid({
   const hasSec = summary.has_sec_cik;
   const dividends = summary.capabilities.dividends ?? EMPTY_CELL;
   const insider = summary.capabilities.insider ?? EMPTY_CELL;
+  const corporateEvents = summary.capabilities.corporate_events ?? EMPTY_CELL;
   const dividendProviders = activeProviders(dividends);
   const insiderProviders = activeProviders(insider);
+  const eventProviders = activeProviders(corporateEvents);
 
   return (
-    <div className="grid grid-cols-1 gap-3 lg:grid-cols-[2fr_1fr_1fr] lg:auto-rows-[220px]">
-      {/* Chart pane: 2 cols × 2 rows top-left */}
-      <div className="overflow-hidden rounded-md border border-slate-200 bg-white p-3 shadow-sm lg:col-start-1 lg:col-end-2 lg:row-start-1 lg:row-end-3">
-        <PriceChart symbol={symbol} />
-      </div>
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[2fr_1fr_1fr] lg:auto-rows-[220px]">
+        {/* Chart pane: wide column (2fr) × 2 rows top-left */}
+        <div className="overflow-hidden rounded-md border border-slate-200 bg-white p-3 shadow-sm lg:col-start-1 lg:col-end-2 lg:row-start-1 lg:row-end-3">
+          <PriceChart symbol={symbol} />
+        </div>
 
-      {/* Right column row 1 */}
-      <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
-        {keyStatsBlock}
-      </div>
-      <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
-        {thesisBlock}
-      </div>
+        {/* Right column row 1 */}
+        <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+          {keyStatsBlock}
+        </div>
+        <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+          {thesisBlock}
+        </div>
 
-      {/* Right column row 2 */}
-      <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
-        {hasSec ? (
-          <SecProfilePanel symbol={symbol} />
-        ) : (
-          <Section title="SEC profile">
-            <p className="text-xs text-slate-500">No SEC coverage</p>
-          </Section>
-        )}
-      </div>
-      <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
-        <FilingsPane instrumentId={summary.instrument_id} symbol={symbol} />
-      </div>
+        {/* Right column row 2 */}
+        <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+          {hasSec ? (
+            <SecProfilePanel symbol={symbol} />
+          ) : (
+            <Section title="SEC profile">
+              <p className="text-xs text-slate-500">No SEC coverage</p>
+            </Section>
+          )}
+        </div>
+        <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+          <FilingsPane instrumentId={summary.instrument_id} symbol={symbol} />
+        </div>
 
-      {/* Bottom row: segments spans 2 cols, news spans 1 col */}
-      <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm lg:col-span-2">
-        {hasSec ? (
-          <BusinessSectionsTeaser symbol={symbol} />
-        ) : (
-          <Section title="Company narrative">
-            <p className="text-xs text-slate-500">No 10-K coverage</p>
-          </Section>
-        )}
-      </div>
-      <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
-        {newsBlock}
-      </div>
+        {/* Bottom row: segments spans 2 cols, news spans 1 col */}
+        <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm lg:col-span-2">
+          {hasSec ? (
+            <BusinessSectionsTeaser symbol={symbol} />
+          ) : (
+            <Section title="Company narrative">
+              <p className="text-xs text-slate-500">No 10-K coverage</p>
+            </Section>
+          )}
+        </div>
+        <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
+          {newsBlock}
+        </div>
 
-      {/* Dividends + insider combined card — spans full width */}
-      {(dividendProviders.length > 0 || insiderProviders.length > 0) && (
-        <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm lg:col-span-3">
-          <div className="grid gap-3 md:grid-cols-2">
-            {dividendProviders.map((p) => (
-              <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
-            ))}
-            {insiderProviders.map((p) => (
-              <InsiderActivityPanel
-                key={`ins-${p}`}
-                symbol={symbol}
-                provider={p}
-              />
-            ))}
+        {/* Dividends + insider combined card — spans full width */}
+        {(dividendProviders.length > 0 || insiderProviders.length > 0) && (
+          <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm lg:col-span-3">
+            <div className="grid gap-3 md:grid-cols-2">
+              {dividendProviders.map((p) => (
+                <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
+              ))}
+              {insiderProviders.map((p) => (
+                <InsiderActivityPanel
+                  key={`ins-${p}`}
+                  symbol={symbol}
+                  provider={p}
+                />
+              ))}
+            </div>
           </div>
+        )}
+      </div>
+
+      {/* Corporate events (8-K) — transitional until Phase 4 ships /filings/8-k */}
+      {eventProviders.length > 0 && (
+        <div className="space-y-3">
+          {eventProviders.map((p) => (
+            <EightKEventsPanel
+              key={`events-${p}`}
+              symbol={symbol}
+              provider={p}
+            />
+          ))}
         </div>
       )}
     </div>

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -22,13 +22,11 @@ import { InsiderActivityPanel } from "@/components/instrument/InsiderActivityPan
 import { PriceChart } from "@/components/instrument/PriceChart";
 import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
 import { Section } from "@/components/dashboard/Section";
-import type { CapabilityCell, InstrumentSummary, ThesisDetail } from "@/api/types";
+import type { CapabilityCell, InstrumentSummary } from "@/api/types";
 import { activeProviders } from "@/lib/capabilityProviders";
 
 export interface DensityGridProps {
   readonly summary: InstrumentSummary;
-  readonly thesis: ThesisDetail | null;
-  readonly thesisErrored: boolean;
   readonly keyStatsBlock: JSX.Element;
   readonly thesisBlock: JSX.Element;
   readonly newsBlock: JSX.Element;

--- a/frontend/src/components/instrument/FilingsPane.test.tsx
+++ b/frontend/src/components/instrument/FilingsPane.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { FilingsPane } from "@/components/instrument/FilingsPane";
+import * as filingsApi from "@/api/filings";
+
+describe("FilingsPane", () => {
+  it("renders 5 rows max with drilldown links for 8-K + 10-K", async () => {
+    vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
+      instrument_id: 1,
+      symbol: "GME",
+      total: 8,
+      offset: 0,
+      limit: 5,
+      items: Array.from({ length: 8 }, (_, i) => ({
+        filing_event_id: i + 1,
+        instrument_id: 1,
+        filing_date: `2026-03-${(i + 1).toString().padStart(2, "0")}`,
+        filing_type: i % 2 === 0 ? "10-K" : "8-K",
+        provider: "sec_edgar",
+        red_flag_score: null,
+        extracted_summary: `summary ${i}`,
+        primary_document_url: null,
+        source_url: null,
+        created_at: "2026-03-01T00:00:00Z",
+      })),
+    });
+    render(
+      <MemoryRouter>
+        <FilingsPane instrumentId={1} symbol="GME" />
+      </MemoryRouter>,
+    );
+    const rows = await screen.findAllByText(/summary \d/);
+    expect(rows.length).toBeLessThanOrEqual(5);
+  });
+
+  it("renders drilldown link to /filings/10-k for 10-K type", async () => {
+    vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
+      instrument_id: 1,
+      symbol: "GME",
+      total: 1,
+      offset: 0,
+      limit: 5,
+      items: [
+        {
+          filing_event_id: 1,
+          instrument_id: 1,
+          filing_date: "2026-03-01",
+          filing_type: "10-K",
+          provider: "sec_edgar",
+          red_flag_score: null,
+          extracted_summary: "annual report",
+          primary_document_url: null,
+          source_url: null,
+          created_at: "2026-03-01T00:00:00Z",
+        },
+      ],
+    });
+    render(
+      <MemoryRouter>
+        <FilingsPane instrumentId={1} symbol="GME" />
+      </MemoryRouter>,
+    );
+    const link = await screen.findByRole("link");
+    expect(link).toHaveAttribute("href", "/instrument/GME/filings/10-k");
+  });
+
+  it("renders drilldown link to /filings/8-k for 8-K type", async () => {
+    vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
+      instrument_id: 1,
+      symbol: "GME",
+      total: 1,
+      offset: 0,
+      limit: 5,
+      items: [
+        {
+          filing_event_id: 2,
+          instrument_id: 1,
+          filing_date: "2026-03-02",
+          filing_type: "8-K",
+          provider: "sec_edgar",
+          red_flag_score: null,
+          extracted_summary: "current report",
+          primary_document_url: null,
+          source_url: null,
+          created_at: "2026-03-02T00:00:00Z",
+        },
+      ],
+    });
+    render(
+      <MemoryRouter>
+        <FilingsPane instrumentId={1} symbol="GME" />
+      </MemoryRouter>,
+    );
+    const link = await screen.findByRole("link");
+    expect(link).toHaveAttribute("href", "/instrument/GME/filings/8-k");
+  });
+});

--- a/frontend/src/components/instrument/FilingsPane.test.tsx
+++ b/frontend/src/components/instrument/FilingsPane.test.tsx
@@ -31,7 +31,7 @@ describe("FilingsPane", () => {
       </MemoryRouter>,
     );
     const rows = await screen.findAllByText(/summary \d/);
-    expect(rows.length).toBeLessThanOrEqual(5);
+    expect(rows.length).toBe(5);
   });
 
   it("renders drilldown link to /filings/10-k for 10-K type", async () => {

--- a/frontend/src/components/instrument/FilingsPane.test.tsx
+++ b/frontend/src/components/instrument/FilingsPane.test.tsx
@@ -9,10 +9,10 @@ describe("FilingsPane", () => {
     vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
       instrument_id: 1,
       symbol: "GME",
-      total: 8,
+      total: 5,
       offset: 0,
       limit: 5,
-      items: Array.from({ length: 8 }, (_, i) => ({
+      items: Array.from({ length: 5 }, (_, i) => ({
         filing_event_id: i + 1,
         instrument_id: 1,
         filing_date: `2026-03-${(i + 1).toString().padStart(2, "0")}`,

--- a/frontend/src/components/instrument/FilingsPane.tsx
+++ b/frontend/src/components/instrument/FilingsPane.tsx
@@ -1,0 +1,94 @@
+/**
+ * FilingsPane — 5-row recent-filings list (8-K + 10-K) on the
+ * instrument page density grid (#559). Each row links to the
+ * corresponding drilldown route. Read-only — the canonical filings
+ * tab still lives in the page tabs nav.
+ */
+
+import { fetchFilings } from "@/api/filings";
+import type { FilingsListResponse } from "@/api/types";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+import { useCallback } from "react";
+import { Link } from "react-router-dom";
+
+const ROW_LIMIT = 5;
+
+const TYPES_WITH_DRILLDOWN = new Set(["8-K", "8-K/A", "10-K", "10-K/A"]);
+
+function drilldownLink(symbol: string, filingType: string | null): string | null {
+  if (filingType === null || !TYPES_WITH_DRILLDOWN.has(filingType)) return null;
+  const symbolEnc = encodeURIComponent(symbol);
+  if (filingType.startsWith("10-K")) {
+    // 10-K drilldown defaults to the latest filing — no accession
+    // needed from the row. Operator picks an older year via the
+    // metadata rail's prior-10-Ks list once on the drilldown page.
+    return `/instrument/${symbolEnc}/filings/10-k`;
+  }
+  // 8-K family — list page shows all filings; row click on the list
+  // page itself handles per-accession selection.
+  return `/instrument/${symbolEnc}/filings/8-k`;
+}
+
+export interface FilingsPaneProps {
+  readonly instrumentId: number;
+  readonly symbol: string;
+}
+
+export function FilingsPane({
+  instrumentId,
+  symbol,
+}: FilingsPaneProps): JSX.Element {
+  const state = useAsync<FilingsListResponse>(
+    useCallback(() => fetchFilings(instrumentId, 0, ROW_LIMIT), [instrumentId]),
+    [instrumentId],
+  );
+
+  return (
+    <Section title="Recent filings">
+      {state.loading ? (
+        <SectionSkeleton rows={5} />
+      ) : state.error !== null ? (
+        <SectionError onRetry={state.refetch} />
+      ) : state.data === null || state.data.items.length === 0 ? (
+        <EmptyState
+          title="No filings"
+          description="Filings appear once SEC EDGAR has been crawled for this instrument."
+        />
+      ) : (
+        <ul className="space-y-1.5 text-xs">
+          {state.data.items.slice(0, ROW_LIMIT).map((f) => {
+            const link = drilldownLink(symbol, f.filing_type ?? null);
+            const label = (
+              <span className="flex items-baseline gap-2">
+                <span className="text-slate-500">{f.filing_date}</span>
+                <span className="rounded bg-slate-100 px-1 py-0.5 text-[10px] text-slate-600">
+                  {f.filing_type ?? "?"}
+                </span>
+                <span className="truncate text-slate-700">
+                  {f.extracted_summary ?? f.filing_type ?? "filing"}
+                </span>
+              </span>
+            );
+            return (
+              <li key={f.filing_event_id}>
+                {link !== null ? (
+                  <Link to={link} className="hover:underline">
+                    {label}
+                  </Link>
+                ) : (
+                  label
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Section>
+  );
+}

--- a/frontend/src/components/instrument/ResearchTab.tsx
+++ b/frontend/src/components/instrument/ResearchTab.tsx
@@ -207,8 +207,6 @@ export function ResearchTab({
   return (
     <DensityGrid
       summary={summary}
-      thesis={thesis}
-      thesisErrored={thesisErrored}
       keyStatsBlock={keyStatsBlock}
       thesisBlock={thesisBlock}
       newsBlock={newsBlock}

--- a/frontend/src/components/instrument/ResearchTab.tsx
+++ b/frontend/src/components/instrument/ResearchTab.tsx
@@ -4,23 +4,13 @@
  *
  * Composes existing data into one operator view: key stats with
  * field_source provenance, thesis memo if present, break conditions.
- * Red-flag surfacing and peer context come in Slice 2 (right rail).
- *
- * Capability panels (Dividends, Insider activity, Corporate events)
- * iterate ``summary.capabilities[type]`` and render one shell per
- * active (data-present) provider — so a cross-listed instrument with
- * multiple providers renders multiple panels labelled with each
- * provider tag (#515 PR 3b).
+ * Phase 3 (#559): delegates layout to DensityGrid which puts the chart
+ * top-left and arranges all panes in a Bloomberg-style 3-column grid.
  */
 import { Section } from "@/components/dashboard/Section";
-import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSectionsTeaser";
-import { DividendsPanel } from "@/components/instrument/DividendsPanel";
-import { EightKEventsPanel } from "@/components/instrument/EightKEventsPanel";
-import { InsiderActivityPanel } from "@/components/instrument/InsiderActivityPanel";
-import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
+import { DensityGrid } from "@/components/instrument/DensityGrid";
 import { EmptyState } from "@/components/states/EmptyState";
-import type { CapabilityCell, InstrumentSummary, ThesisDetail } from "@/api/types";
-import { activeProviders } from "@/lib/capabilityProviders";
+import type { InstrumentSummary, ThesisDetail } from "@/api/types";
 
 function formatDecimal(
   value: string | null | undefined,
@@ -170,8 +160,6 @@ export interface ResearchTabProps {
   thesisErrored?: boolean;
 }
 
-const EMPTY_CELL: CapabilityCell = { providers: [], data_present: {} };
-
 export function ResearchTab({
   summary,
   thesis,
@@ -180,77 +168,50 @@ export function ResearchTab({
   const stats = summary.key_stats;
   const fs = stats?.field_source ?? undefined;
 
-  // SEC profile + 10-K Item 1 panels are still SEC-specific (not yet
-  // refactored into provider-agnostic shells); gate on the SEC
-  // identifier signal directly. The three capability panels below
-  // (Dividends, Insider, Corporate events) iterate
-  // `summary.capabilities[type]` and render one shell per active
-  // provider — provider-agnostic by construction.
-  const hasSec = summary.has_sec_cik;
-  const dividends = summary.capabilities.dividends ?? EMPTY_CELL;
-  const insider = summary.capabilities.insider ?? EMPTY_CELL;
-  const events = summary.capabilities.corporate_events ?? EMPTY_CELL;
-  const dividendProviders = activeProviders(dividends);
-  const insiderProviders = activeProviders(insider);
-  const eventProviders = activeProviders(events);
+  const keyStatsBlock = (
+    <Section title="Key statistics">
+      {stats === null ? (
+        <EmptyState
+          title="No key stats"
+          description="No provider returned key stats for this ticker."
+        />
+      ) : (
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          <KeyStat label="Market cap" value={formatMarketCap(summary.identity.market_cap)} />
+          <KeyStat label="P/E ratio" value={formatDecimal(stats.pe_ratio)} source={fs?.pe_ratio} />
+          <KeyStat label="P/B ratio" value={formatDecimal(stats.pb_ratio)} source={fs?.pb_ratio} />
+          <KeyStat label="Dividend yield" value={formatDecimal(stats.dividend_yield, { percent: true })} source={fs?.dividend_yield} />
+          <KeyStat label="Payout ratio" value={formatDecimal(stats.payout_ratio, { percent: true })} source={fs?.payout_ratio} />
+          <KeyStat label="ROE" value={formatDecimal(stats.roe, { percent: true })} source={fs?.roe} />
+          <KeyStat label="ROA" value={formatDecimal(stats.roa, { percent: true })} source={fs?.roa} />
+          <KeyStat label="Debt / Equity" value={formatDecimal(stats.debt_to_equity)} source={fs?.debt_to_equity} />
+          <KeyStat label="Revenue growth (YoY)" value={formatDecimal(stats.revenue_growth_yoy, { percent: true })} source={fs?.revenue_growth_yoy} />
+          <KeyStat label="Earnings growth (YoY)" value={formatDecimal(stats.earnings_growth_yoy, { percent: true })} source={fs?.earnings_growth_yoy} />
+        </dl>
+      )}
+    </Section>
+  );
+
+  const thesisBlock = (
+    <Section title="Thesis">
+      <ThesisPanel thesis={thesis} errored={thesisErrored} />
+    </Section>
+  );
+
+  const newsBlock = (
+    <Section title="Recent news">
+      <p className="text-xs text-slate-500">News tab still has the full feed.</p>
+    </Section>
+  );
 
   return (
-    <div className="grid gap-4 md:grid-cols-2">
-      {hasSec ? <SecProfilePanel symbol={summary.identity.symbol} /> : null}
-      {dividendProviders.map((p) => (
-        <DividendsPanel
-          key={`dividends-${p}`}
-          symbol={summary.identity.symbol}
-          provider={p}
-        />
-      ))}
-      {hasSec ? (
-        <div className="md:col-span-2">
-          <BusinessSectionsTeaser symbol={summary.identity.symbol} />
-        </div>
-      ) : null}
-      {insiderProviders.map((p) => (
-        <div key={`insider-${p}`} className="md:col-span-2">
-          <InsiderActivityPanel
-            symbol={summary.identity.symbol}
-            provider={p}
-          />
-        </div>
-      ))}
-      {eventProviders.map((p) => (
-        <div key={`events-${p}`} className="md:col-span-2">
-          <EightKEventsPanel
-            symbol={summary.identity.symbol}
-            provider={p}
-          />
-        </div>
-      ))}
-
-      <Section title="Key statistics">
-        {stats === null ? (
-          <EmptyState
-            title="No key stats"
-            description="No provider returned key stats for this ticker."
-          />
-        ) : (
-          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
-            <KeyStat label="Market cap" value={formatMarketCap(summary.identity.market_cap)} />
-            <KeyStat label="P/E ratio" value={formatDecimal(stats.pe_ratio)} source={fs?.pe_ratio} />
-            <KeyStat label="P/B ratio" value={formatDecimal(stats.pb_ratio)} source={fs?.pb_ratio} />
-            <KeyStat label="Dividend yield" value={formatDecimal(stats.dividend_yield, { percent: true })} source={fs?.dividend_yield} />
-            <KeyStat label="Payout ratio" value={formatDecimal(stats.payout_ratio, { percent: true })} source={fs?.payout_ratio} />
-            <KeyStat label="ROE" value={formatDecimal(stats.roe, { percent: true })} source={fs?.roe} />
-            <KeyStat label="ROA" value={formatDecimal(stats.roa, { percent: true })} source={fs?.roa} />
-            <KeyStat label="Debt / Equity" value={formatDecimal(stats.debt_to_equity)} source={fs?.debt_to_equity} />
-            <KeyStat label="Revenue growth (YoY)" value={formatDecimal(stats.revenue_growth_yoy, { percent: true })} source={fs?.revenue_growth_yoy} />
-            <KeyStat label="Earnings growth (YoY)" value={formatDecimal(stats.earnings_growth_yoy, { percent: true })} source={fs?.earnings_growth_yoy} />
-          </dl>
-        )}
-      </Section>
-
-      <Section title="Thesis">
-        <ThesisPanel thesis={thesis} errored={thesisErrored} />
-      </Section>
-    </div>
+    <DensityGrid
+      summary={summary}
+      thesis={thesis}
+      thesisErrored={thesisErrored}
+      keyStatsBlock={keyStatsBlock}
+      thesisBlock={thesisBlock}
+      newsBlock={newsBlock}
+    />
   );
 }

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -40,7 +40,6 @@ import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
 import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
 import { Section, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
-import { PriceChart } from "@/components/instrument/PriceChart";
 import { ResearchTab } from "@/components/instrument/ResearchTab";
 import { RightRail } from "@/components/instrument/RightRail";
 import { SummaryStrip } from "@/components/instrument/SummaryStrip";
@@ -668,19 +667,11 @@ function InstrumentPageBody({
           </nav>
 
           {activeTab === "research" && (
-            <div className="space-y-4">
-              {/* Chart sits at the top of Research — the operator
-                  lands on the tab and sees price context before
-                  drilling into thesis + stats. Slice B of #316. */}
-              <div className="rounded-md border border-slate-200 bg-white p-3 shadow-sm">
-                <PriceChart symbol={symbol} />
-              </div>
-              <ResearchTab
-                summary={summary}
-                thesis={thesisAsync.data}
-                thesisErrored={thesisErrSticky}
-              />
-            </div>
+            <ResearchTab
+              summary={summary}
+              thesis={thesisAsync.data}
+              thesisErrored={thesisErrSticky}
+            />
           )}
           {activeTab === "financials" && <FinancialsTab symbol={symbol} />}
           {activeTab === "positions" && (

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -644,11 +644,11 @@ function InstrumentPageBody({
           Thesis generation failed: {thesisErr}
         </div>
       ) : null}
-      {/* 8/12 + 4/12 split: tab content left, right rail right. Right
-          rail is persistent across tab changes per the spec — filings
-          / peer / news are always in the operator's peripheral view. */}
-      <div className="grid gap-4 lg:grid-cols-12">
-        <div className="space-y-4 lg:col-span-8">
+      {/* Layout: Research tab is the full-width density grid (#559).
+          All other tabs keep the legacy 8/12 + 4/12 split with the
+          persistent RightRail (filings / peer / news preview). */}
+      {activeTab === "research" ? (
+        <div className="space-y-4">
           <nav className="flex gap-1 border-b border-slate-200">
             {tabs.map((tab) => (
               <button
@@ -665,32 +665,51 @@ function InstrumentPageBody({
               </button>
             ))}
           </nav>
-
-          {activeTab === "research" && (
-            <ResearchTab
-              summary={summary}
-              thesis={thesisAsync.data}
-              thesisErrored={thesisErrSticky}
-            />
-          )}
-          {activeTab === "financials" && <FinancialsTab symbol={symbol} />}
-          {activeTab === "positions" && (
-            <PositionsTab symbol={symbol} instrumentId={summary.instrument_id} />
-          )}
-          {activeTab === "news" && <NewsTab instrumentId={summary.instrument_id} />}
-          {activeTab === "filings" && (
-            <FilingsTab instrumentId={summary.instrument_id} />
-          )}
-        </div>
-        <div className="lg:col-span-4">
-          <RightRail
-            instrumentId={summary.instrument_id}
-            sector={summary.identity.sector}
-            currentSymbol={summary.identity.symbol}
-            filingsActive={hasActiveCapability(summary, "filings")}
+          <ResearchTab
+            summary={summary}
+            thesis={thesisAsync.data}
+            thesisErrored={thesisErrSticky}
           />
         </div>
-      </div>
+      ) : (
+        <div className="grid gap-4 lg:grid-cols-12">
+          <div className="space-y-4 lg:col-span-8">
+            <nav className="flex gap-1 border-b border-slate-200">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  type="button"
+                  className={`px-3 py-2 text-sm ${
+                    activeTab === tab.id
+                      ? "border-b-2 border-blue-600 font-medium text-blue-700"
+                      : "text-slate-500 hover:text-slate-700"
+                  }`}
+                  onClick={() => setActiveTab(tab.id)}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </nav>
+
+            {activeTab === "financials" && <FinancialsTab symbol={symbol} />}
+            {activeTab === "positions" && (
+              <PositionsTab symbol={symbol} instrumentId={summary.instrument_id} />
+            )}
+            {activeTab === "news" && <NewsTab instrumentId={summary.instrument_id} />}
+            {activeTab === "filings" && (
+              <FilingsTab instrumentId={summary.instrument_id} />
+            )}
+          </div>
+          <div className="lg:col-span-4">
+            <RightRail
+              instrumentId={summary.instrument_id}
+              sector={summary.identity.sector}
+              currentSymbol={summary.identity.symbol}
+              filingsActive={hasActiveCapability(summary, "filings")}
+            />
+          </div>
+        </div>
+      )}
 
       {addOpen ? (
         <OrderEntryModal


### PR DESCRIPTION
## What

- New `FilingsPane`: 5-row recent-filings list (8-K + 10-K) linking to drilldowns.
- New `DensityGrid`: Bloomberg-style 3-column grid (chart wide-column × 2 rows top-left; right column key-stats / thesis / SEC profile / filings; bottom rows business teaser + news; dividends + insider as a wide combined card; transitional EightKEventsPanel until Phase 4).
- `ResearchTab` rewritten to render `<DensityGrid>` instead of stacked panels.
- `InstrumentPage` no longer renders `<PriceChart>` standalone — it lives inside the grid.
- Responsive: single column below `lg` breakpoint.

## Why

Phase 3 of `docs/superpowers/specs/2026-04-27-instrument-detail-density-grid-design.md`.

## Test plan

- [x] Vitest: 6 new tests across `FilingsPane.test.tsx` + `DensityGrid.test.tsx` (5-row cap, drilldown links, SEC fallback, child stub presence).
- [x] Frontend typecheck + 413 unit tests green.
- [x] Manual: `/instrument/GME` shows chart + key-stats + thesis + filings panes without stacked scrolling above `lg`; collapses to single column below.
- [x] Codex pre-push review: major (8-K events drop) + medium (chart-pane wording) addressed in `88d2b5c`. Major (FilingsPane accession on non-latest 10-Ks) deferred to #565.

## Out of scope

- FilingsPane needs accession on 10-K rows for non-latest filings (#565). Interim: row click → latest 10-K, use TenKMetadataRail right rail to navigate prior years.
- Phase 4 (`/filings/8-k`) replaces the transitional EightKEventsPanel inline render.