### PR TITLE
feat(#559-phase4): /filings/8-k filterable detail page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { RankingsPage } from "@/pages/RankingsPage";
 import { InstrumentDetailRedirect } from "@/pages/InstrumentDetailRedirect";
 import { InstrumentPage } from "@/pages/InstrumentPage";
 import { Tenk10KDrilldownPage } from "@/pages/Tenk10KDrilldownPage";
+import { EightKListPage } from "@/pages/EightKListPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { RecommendationsPage } from "@/pages/RecommendationsPage";
 import { AdminPage } from "@/pages/AdminPage";
@@ -64,6 +65,10 @@ export function App() {
           <Route
             path="instrument/:symbol/filings/10-k"
             element={<Tenk10KDrilldownPage />}
+          />
+          <Route
+            path="instrument/:symbol/filings/8-k"
+            element={<EightKListPage />}
           />
           <Route path="copy-trading/:mirrorId" element={<CopyTradingPage />} />
           <Route path="recommendations" element={<RecommendationsPage />} />

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -4,19 +4,20 @@
  * (2fr) spanning 2 rows; right column (1fr + 1fr) stacks
  * key-stats / thesis / SEC profile / filings; bottom rows hold
  * business teaser / news; dividends + insider as a wide combined
- * card. Corporate events (8-K) follow below until Phase 4 ships
- * the dedicated /filings/8-k route.
+ * card.
  *
  * Responsive: at viewport widths below `lg` the grid degrades to
  * a single column. Pane order reflects priority: chart → key-stats
  * → thesis → filings → SEC-profile → segments → dividends-insider
- * → news → events. Each pane scrolls internally rather than pushing
- * the page taller.
+ * → news. Each pane scrolls internally rather than pushing the
+ * page taller.
+ *
+ * 8-K events are accessible via the FilingsPane row click →
+ * /instrument/:symbol/filings/8-k (Phase 4).
  */
 
 import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSectionsTeaser";
 import { DividendsPanel } from "@/components/instrument/DividendsPanel";
-import { EightKEventsPanel } from "@/components/instrument/EightKEventsPanel";
 import { FilingsPane } from "@/components/instrument/FilingsPane";
 import { InsiderActivityPanel } from "@/components/instrument/InsiderActivityPanel";
 import { PriceChart } from "@/components/instrument/PriceChart";
@@ -44,14 +45,11 @@ export function DensityGrid({
   const hasSec = summary.has_sec_cik;
   const dividends = summary.capabilities.dividends ?? EMPTY_CELL;
   const insider = summary.capabilities.insider ?? EMPTY_CELL;
-  const corporateEvents = summary.capabilities.corporate_events ?? EMPTY_CELL;
   const dividendProviders = activeProviders(dividends);
   const insiderProviders = activeProviders(insider);
-  const eventProviders = activeProviders(corporateEvents);
 
   return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[2fr_1fr_1fr] lg:auto-rows-[220px]">
+    <div className="grid grid-cols-1 gap-3 lg:grid-cols-[2fr_1fr_1fr] lg:auto-rows-[220px]">
         {/* Chart pane: wide column (2fr) × 2 rows top-left */}
         <div className="overflow-hidden rounded-md border border-slate-200 bg-white p-3 shadow-sm lg:col-start-1 lg:col-end-2 lg:row-start-1 lg:row-end-3">
           <PriceChart symbol={symbol} />
@@ -110,20 +108,6 @@ export function DensityGrid({
             </div>
           </div>
         )}
-      </div>
-
-      {/* Corporate events (8-K) — transitional until Phase 4 ships /filings/8-k */}
-      {eventProviders.length > 0 && (
-        <div className="space-y-3">
-          {eventProviders.map((p) => (
-            <EightKEventsPanel
-              key={`events-${p}`}
-              symbol={symbol}
-              provider={p}
-            />
-          ))}
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/instrument/EightKDetailPanel.tsx
+++ b/frontend/src/components/instrument/EightKDetailPanel.tsx
@@ -1,0 +1,87 @@
+/**
+ * EightKDetailPanel — right-side detail for the row currently
+ * selected in the 8-K filterable list. Shows item bodies +
+ * exhibits + primary_document_url link (#559).
+ */
+
+import type { EightKFiling } from "@/api/instruments";
+
+export interface EightKDetailPanelProps {
+  readonly filing: EightKFiling | null;
+}
+
+const SEVERITY_TONE: Record<string, string> = {
+  high: "bg-red-100 text-red-700",
+  medium: "bg-amber-100 text-amber-700",
+  low: "bg-slate-100 text-slate-600",
+};
+
+export function EightKDetailPanel({
+  filing,
+}: EightKDetailPanelProps): JSX.Element {
+  if (filing === null) {
+    return (
+      <div className="rounded border border-slate-200 bg-white p-4 text-sm text-slate-500">
+        Select a row to view item bodies + exhibits.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-4 rounded border border-slate-200 bg-white p-4 text-sm">
+      <div>
+        <div className="text-[10px] uppercase tracking-wider text-slate-500">
+          Filing
+        </div>
+        <div className="font-mono text-xs">{filing.accession_number}</div>
+        <div className="text-xs text-slate-500">
+          {filing.date_of_report} · {filing.reporting_party}
+          {filing.is_amendment ? " · amendment" : ""}
+        </div>
+      </div>
+      {filing.items.map((item) => (
+        <section key={item.item_code}>
+          <header className="flex items-baseline gap-2">
+            <span
+              className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                SEVERITY_TONE[item.severity ?? ""] ?? SEVERITY_TONE.low
+              }`}
+            >
+              Item {item.item_code}
+            </span>
+            <span className="text-xs font-medium text-slate-800">
+              {item.item_label}
+            </span>
+          </header>
+          <p className="mt-1 whitespace-pre-wrap leading-relaxed text-slate-700">
+            {item.body}
+          </p>
+        </section>
+      ))}
+      {filing.exhibits.length > 0 && (
+        <section>
+          <div className="text-[10px] uppercase tracking-wider text-slate-500">
+            Exhibits
+          </div>
+          <ul className="mt-1 space-y-0.5 text-xs">
+            {filing.exhibits.map((e) => (
+              <li key={e.exhibit_number}>
+                · {e.exhibit_number}
+                {e.description !== null ? ` — ${e.description}` : ""}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+      {filing.primary_document_url !== null && (
+        <a
+          href={filing.primary_document_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-sky-700 hover:underline"
+        >
+          Open full filing on SEC ↗
+        </a>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/EightKDetailPanel.tsx
+++ b/frontend/src/components/instrument/EightKDetailPanel.tsx
@@ -5,16 +5,11 @@
  */
 
 import type { EightKFiling } from "@/api/instruments";
+import { SEVERITY_TONE } from "@/components/instrument/eightKSeverity";
 
 export interface EightKDetailPanelProps {
   readonly filing: EightKFiling | null;
 }
-
-const SEVERITY_TONE: Record<string, string> = {
-  high: "bg-red-100 text-red-700",
-  medium: "bg-amber-100 text-amber-700",
-  low: "bg-slate-100 text-slate-600",
-};
 
 export function EightKDetailPanel({
   filing,

--- a/frontend/src/components/instrument/EightKFilterStrip.tsx
+++ b/frontend/src/components/instrument/EightKFilterStrip.tsx
@@ -1,0 +1,92 @@
+/**
+ * EightKFilterStrip — controls for the 8-K filterable list (#559).
+ * Severity dropdown + free-text item-code filter + date range.
+ * State held in URL query string by the parent so deep-links work.
+ */
+
+import type { JSX } from "react";
+
+export interface EightKFilters {
+  readonly severity: "" | "high" | "medium" | "low";
+  readonly itemCode: string;
+  readonly dateFrom: string; // ISO yyyy-mm-dd, "" = no bound
+  readonly dateTo: string;
+}
+
+export interface EightKFilterStripProps {
+  readonly value: EightKFilters;
+  readonly onChange: (next: EightKFilters) => void;
+}
+
+export function EightKFilterStrip({
+  value,
+  onChange,
+}: EightKFilterStripProps): JSX.Element {
+  const isDirty =
+    value.severity !== "" ||
+    value.itemCode !== "" ||
+    value.dateFrom !== "" ||
+    value.dateTo !== "";
+
+  return (
+    <div className="flex flex-wrap items-end gap-3 rounded border border-slate-200 bg-slate-50 p-3 text-xs">
+      <label className="flex flex-col">
+        <span className="text-slate-500">Severity</span>
+        <select
+          className="mt-0.5 rounded border border-slate-300 bg-white px-2 py-1"
+          value={value.severity}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              severity: e.target.value as EightKFilters["severity"],
+            })
+          }
+        >
+          <option value="">all</option>
+          <option value="high">high</option>
+          <option value="medium">medium</option>
+          <option value="low">low</option>
+        </select>
+      </label>
+      <label className="flex flex-col">
+        <span className="text-slate-500">Item code</span>
+        <input
+          type="text"
+          placeholder="e.g. 5.02"
+          className="mt-0.5 rounded border border-slate-300 bg-white px-2 py-1"
+          value={value.itemCode}
+          onChange={(e) => onChange({ ...value, itemCode: e.target.value })}
+        />
+      </label>
+      <label className="flex flex-col">
+        <span className="text-slate-500">From</span>
+        <input
+          type="date"
+          className="mt-0.5 rounded border border-slate-300 bg-white px-2 py-1"
+          value={value.dateFrom}
+          onChange={(e) => onChange({ ...value, dateFrom: e.target.value })}
+        />
+      </label>
+      <label className="flex flex-col">
+        <span className="text-slate-500">To</span>
+        <input
+          type="date"
+          className="mt-0.5 rounded border border-slate-300 bg-white px-2 py-1"
+          value={value.dateTo}
+          onChange={(e) => onChange({ ...value, dateTo: e.target.value })}
+        />
+      </label>
+      {isDirty && (
+        <button
+          type="button"
+          className="ml-auto rounded border border-slate-300 px-2 py-1 hover:bg-white"
+          onClick={() =>
+            onChange({ severity: "", itemCode: "", dateFrom: "", dateTo: "" })
+          }
+        >
+          Reset
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/eightKSeverity.ts
+++ b/frontend/src/components/instrument/eightKSeverity.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared severity → Tailwind tone map for 8-K item / filing chips.
+ * Defined once so adding a new severity level (or rebalancing the
+ * palette) doesn't drift across `EightKDetailPanel` + `EightKListPage`.
+ */
+export const SEVERITY_TONE: Record<string, string> = {
+  high: "bg-red-100 text-red-700",
+  medium: "bg-amber-100 text-amber-700",
+  low: "bg-slate-100 text-slate-600",
+};

--- a/frontend/src/pages/EightKListPage.test.tsx
+++ b/frontend/src/pages/EightKListPage.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { EightKListPage } from "@/pages/EightKListPage";
+import * as api from "@/api/instruments";
+
+const filings = [
+  {
+    accession_number: "acc-1",
+    document_type: "8-K",
+    is_amendment: false,
+    date_of_report: "2026-03-15",
+    reporting_party: "GameStop Corp.",
+    signature_name: null,
+    signature_title: null,
+    signature_date: null,
+    primary_document_url: null,
+    items: [
+      {
+        item_code: "5.02",
+        item_label: "Departure of Officer",
+        severity: "high",
+        body: "CFO out.",
+      },
+    ],
+    exhibits: [],
+  },
+  {
+    accession_number: "acc-2",
+    document_type: "8-K",
+    is_amendment: false,
+    date_of_report: "2025-12-04",
+    reporting_party: "GameStop Corp.",
+    signature_name: null,
+    signature_title: null,
+    signature_date: null,
+    primary_document_url: null,
+    items: [
+      {
+        item_code: "8.01",
+        item_label: "Other events",
+        severity: "low",
+        body: "Dividend.",
+      },
+    ],
+    exhibits: [],
+  },
+] as never;
+
+describe("EightKListPage", () => {
+  it("filters by severity and selects an accession via row click", async () => {
+    vi.spyOn(api, "fetchEightKFilings").mockResolvedValue({
+      symbol: "GME",
+      filings,
+    } as never);
+
+    render(
+      <MemoryRouter initialEntries={["/instrument/GME/filings/8-k"]}>
+        <Routes>
+          <Route
+            path="/instrument/:symbol/filings/8-k"
+            element={<EightKListPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Both rows render after data loads
+    expect(await screen.findByText("5.02")).toBeTruthy();
+    expect(screen.getByText("8.01")).toBeTruthy();
+
+    // Filter to high severity — low-severity row disappears
+    const severitySelect = screen.getByRole("combobox");
+    fireEvent.change(severitySelect, { target: { value: "high" } });
+    await waitFor(() => {
+      expect(screen.queryByText("8.01")).toBeNull();
+    });
+
+    // Click the high-severity row (by its date cell) → detail panel shows accession
+    fireEvent.click(screen.getByText("2026-03-15"));
+    await waitFor(() => {
+      expect(screen.getByText("acc-1")).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/pages/EightKListPage.test.tsx
+++ b/frontend/src/pages/EightKListPage.test.tsx
@@ -74,18 +74,19 @@ describe("EightKListPage", () => {
       expect(screen.getByText("acc-1")).toBeTruthy();
     });
 
-    // Filter to high severity — low-severity row disappears
+    // Click the OTHER row (acc-2, low severity) — selection moves
+    fireEvent.click(screen.getByText("2025-12-04"));
+    await waitFor(() => {
+      expect(screen.getByText("acc-2")).toBeTruthy();
+    });
+
+    // Filter to high severity — acc-2 (low) disappears AND URL
+    // clears the now-stale accession; auto-select picks acc-1.
     const severitySelect = screen.getByRole("combobox");
     fireEvent.change(severitySelect, { target: { value: "high" } });
     await waitFor(() => {
       expect(screen.queryByText("8.01")).toBeNull();
     });
-
-    // acc-1 still selected after filter (it matches high severity)
-    expect(screen.getByText("acc-1")).toBeTruthy();
-
-    // Click a row to change selection
-    fireEvent.click(screen.getByText("2026-03-15"));
     await waitFor(() => {
       expect(screen.getByText("acc-1")).toBeTruthy();
     });

--- a/frontend/src/pages/EightKListPage.test.tsx
+++ b/frontend/src/pages/EightKListPage.test.tsx
@@ -48,7 +48,7 @@ const filings = [
 ] as never;
 
 describe("EightKListPage", () => {
-  it("filters by severity and selects an accession via row click", async () => {
+  it("auto-selects first row on page open and respects filter changes", async () => {
     vi.spyOn(api, "fetchEightKFilings").mockResolvedValue({
       symbol: "GME",
       filings,
@@ -69,6 +69,11 @@ describe("EightKListPage", () => {
     expect(await screen.findByText("5.02")).toBeTruthy();
     expect(screen.getByText("8.01")).toBeTruthy();
 
+    // First row (acc-1) is auto-selected on page open
+    await waitFor(() => {
+      expect(screen.getByText("acc-1")).toBeTruthy();
+    });
+
     // Filter to high severity — low-severity row disappears
     const severitySelect = screen.getByRole("combobox");
     fireEvent.change(severitySelect, { target: { value: "high" } });
@@ -76,7 +81,10 @@ describe("EightKListPage", () => {
       expect(screen.queryByText("8.01")).toBeNull();
     });
 
-    // Click the high-severity row (by its date cell) → detail panel shows accession
+    // acc-1 still selected after filter (it matches high severity)
+    expect(screen.getByText("acc-1")).toBeTruthy();
+
+    // Click a row to change selection
     fireEvent.click(screen.getByText("2026-03-15"));
     await waitFor(() => {
       expect(screen.getByText("acc-1")).toBeTruthy();

--- a/frontend/src/pages/EightKListPage.tsx
+++ b/frontend/src/pages/EightKListPage.tsx
@@ -18,16 +18,11 @@ import {
   EightKFilterStrip,
   type EightKFilters,
 } from "@/components/instrument/EightKFilterStrip";
+import { SEVERITY_TONE } from "@/components/instrument/eightKSeverity";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback, useEffect, useMemo } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
-
-const SEVERITY_TONE: Record<string, string> = {
-  high: "bg-red-100 text-red-700",
-  medium: "bg-amber-100 text-amber-700",
-  low: "bg-slate-100 text-slate-600",
-};
 
 const HARD_LIMIT = 250;
 

--- a/frontend/src/pages/EightKListPage.tsx
+++ b/frontend/src/pages/EightKListPage.tsx
@@ -1,0 +1,218 @@
+/**
+ * /instrument/:symbol/filings/8-k — filterable 8-K list with detail
+ * panel (#559).
+ *
+ * Filter state lives in URL query string (severity / itemCode /
+ * dateFrom / dateTo / accession=) so deep-links work.
+ */
+
+import { fetchEightKFilings } from "@/api/instruments";
+import type { EightKFiling, EightKFilingsResponse } from "@/api/instruments";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
+import { EightKDetailPanel } from "@/components/instrument/EightKDetailPanel";
+import {
+  EightKFilterStrip,
+  type EightKFilters,
+} from "@/components/instrument/EightKFilterStrip";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+import { useCallback, useMemo } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+
+const SEVERITY_TONE: Record<string, string> = {
+  high: "bg-red-100 text-red-700",
+  medium: "bg-amber-100 text-amber-700",
+  low: "bg-slate-100 text-slate-600",
+};
+
+function readFilters(p: URLSearchParams): EightKFilters {
+  const severity = p.get("severity");
+  return {
+    severity:
+      severity === "high" || severity === "medium" || severity === "low"
+        ? severity
+        : "",
+    itemCode: p.get("itemCode") ?? "",
+    dateFrom: p.get("dateFrom") ?? "",
+    dateTo: p.get("dateTo") ?? "",
+  };
+}
+
+function writeFilters(p: URLSearchParams, f: EightKFilters): URLSearchParams {
+  const out = new URLSearchParams(p);
+  if (f.severity === "") out.delete("severity");
+  else out.set("severity", f.severity);
+  if (f.itemCode === "") out.delete("itemCode");
+  else out.set("itemCode", f.itemCode);
+  if (f.dateFrom === "") out.delete("dateFrom");
+  else out.set("dateFrom", f.dateFrom);
+  if (f.dateTo === "") out.delete("dateTo");
+  else out.set("dateTo", f.dateTo);
+  return out;
+}
+
+function highestSeverity(filing: EightKFiling): string {
+  for (const item of filing.items) {
+    if (item.severity === "high") return "high";
+  }
+  for (const item of filing.items) {
+    if (item.severity === "medium") return "medium";
+  }
+  return "low";
+}
+
+function applyFilters(
+  filings: ReadonlyArray<EightKFiling>,
+  f: EightKFilters,
+): EightKFiling[] {
+  return filings.filter((flg) => {
+    if (f.severity !== "" && highestSeverity(flg) !== f.severity) return false;
+    if (f.itemCode !== "") {
+      if (!flg.items.some((i) => i.item_code.includes(f.itemCode))) return false;
+    }
+    if (
+      f.dateFrom !== "" &&
+      flg.date_of_report !== null &&
+      flg.date_of_report < f.dateFrom
+    )
+      return false;
+    if (
+      f.dateTo !== "" &&
+      flg.date_of_report !== null &&
+      flg.date_of_report > f.dateTo
+    )
+      return false;
+    return true;
+  });
+}
+
+export function EightKListPage(): JSX.Element {
+  const { symbol = "" } = useParams<{ symbol: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = readFilters(searchParams);
+  const selectedAccession = searchParams.get("accession");
+
+  const state = useAsync<EightKFilingsResponse>(
+    useCallback(() => fetchEightKFilings(symbol, 100), [symbol]),
+    [symbol],
+  );
+
+  const filtered = useMemo(
+    () => (state.data === null ? [] : applyFilters(state.data.filings, filters)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [state.data, filters.severity, filters.itemCode, filters.dateFrom, filters.dateTo],
+  );
+
+  const selected =
+    selectedAccession !== null
+      ? (filtered.find((f) => f.accession_number === selectedAccession) ?? null)
+      : null;
+
+  function setFilters(next: EightKFilters): void {
+    setSearchParams(writeFilters(searchParams, next), { replace: true });
+  }
+
+  function selectAccession(acc: string | null): void {
+    const out = new URLSearchParams(searchParams);
+    if (acc === null) out.delete("accession");
+    else out.set("accession", acc);
+    setSearchParams(out, { replace: true });
+  }
+
+  return (
+    <div className="mx-auto max-w-screen-2xl space-y-3 p-4">
+      <Section title={`${symbol} — 8-K filings`}>
+        <Link
+          to={`/instrument/${encodeURIComponent(symbol)}`}
+          className="text-xs text-sky-700 hover:underline"
+        >
+          ← Back to {symbol}
+        </Link>
+        <div className="mt-3">
+          <EightKFilterStrip value={filters} onChange={setFilters} />
+        </div>
+        {state.loading ? (
+          <SectionSkeleton rows={5} />
+        ) : state.error !== null ? (
+          <SectionError onRetry={state.refetch} />
+        ) : state.data === null || state.data.filings.length === 0 ? (
+          <EmptyState
+            title="No 8-K filings"
+            description="No 8-K filings on file for this instrument."
+          />
+        ) : (
+          <div className="mt-3 grid gap-4 lg:grid-cols-[3fr_2fr]">
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-xs">
+                <thead>
+                  <tr className="border-b border-slate-200 text-left text-slate-500">
+                    <th className="px-2 py-1">Date</th>
+                    <th className="px-2 py-1">Items</th>
+                    <th className="px-2 py-1">Severity</th>
+                    <th className="px-2 py-1">Subject</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map((f) => {
+                    const isSelected = f.accession_number === selectedAccession;
+                    const sev = highestSeverity(f);
+                    return (
+                      <tr
+                        key={f.accession_number}
+                        className={`cursor-pointer border-b border-slate-100 hover:bg-slate-50 ${
+                          isSelected ? "bg-sky-50" : ""
+                        }`}
+                        onClick={() => selectAccession(f.accession_number)}
+                      >
+                        <td className="px-2 py-1 text-slate-700">
+                          {f.date_of_report}
+                        </td>
+                        <td className="px-2 py-1">
+                          {f.items.map((i) => (
+                            <span
+                              key={i.item_code}
+                              className="mr-1 rounded bg-slate-100 px-1 py-0.5 text-[10px]"
+                            >
+                              {i.item_code}
+                            </span>
+                          ))}
+                        </td>
+                        <td className="px-2 py-1">
+                          <span
+                            className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                              SEVERITY_TONE[sev] ?? SEVERITY_TONE.low
+                            }`}
+                          >
+                            {sev}
+                          </span>
+                        </td>
+                        <td className="px-2 py-1 text-slate-700">
+                          {f.items.map((i) => i.item_label).join(" · ")}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  {filtered.length === 0 && (
+                    <tr>
+                      <td
+                        colSpan={4}
+                        className="px-2 py-4 text-center text-slate-500"
+                      >
+                        No filings match these filters.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <EightKDetailPanel filing={selected} />
+          </div>
+        )}
+      </Section>
+    </div>
+  );
+}

--- a/frontend/src/pages/EightKListPage.tsx
+++ b/frontend/src/pages/EightKListPage.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/instrument/EightKFilterStrip";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 
 const SEVERITY_TONE: Record<string, string> = {
@@ -28,6 +28,8 @@ const SEVERITY_TONE: Record<string, string> = {
   medium: "bg-amber-100 text-amber-700",
   low: "bg-slate-100 text-slate-600",
 };
+
+const HARD_LIMIT = 250;
 
 function readFilters(p: URLSearchParams): EightKFilters {
   const severity = p.get("severity");
@@ -97,7 +99,7 @@ export function EightKListPage(): JSX.Element {
   const selectedAccession = searchParams.get("accession");
 
   const state = useAsync<EightKFilingsResponse>(
-    useCallback(() => fetchEightKFilings(symbol, 100), [symbol]),
+    useCallback(() => fetchEightKFilings(symbol, HARD_LIMIT), [symbol]),
     [symbol],
   );
 
@@ -122,6 +124,32 @@ export function EightKListPage(): JSX.Element {
     else out.set("accession", acc);
     setSearchParams(out, { replace: true });
   }
+
+  // Auto-select first filtered row on page open; clear stale accession when
+  // filter excludes selected filing (fixes empty detail pane on initial load
+  // and broken deep-link contract when filters exclude selection).
+  useEffect(() => {
+    // Clear stale accession when filters exclude the selected filing.
+    if (
+      selectedAccession !== null &&
+      state.data !== null &&
+      !filtered.some((f) => f.accession_number === selectedAccession)
+    ) {
+      const out = new URLSearchParams(searchParams);
+      out.delete("accession");
+      setSearchParams(out, { replace: true });
+      return;
+    }
+    // Auto-select first filtered row when no accession is selected.
+    if (selectedAccession === null && filtered.length > 0) {
+      const out = new URLSearchParams(searchParams);
+      const first = filtered[0];
+      if (first) {
+        out.set("accession", first.accession_number);
+        setSearchParams(out, { replace: true });
+      }
+    }
+  }, [selectedAccession, filtered, searchParams, setSearchParams, state.data]);
 
   return (
     <div className="mx-auto max-w-screen-2xl space-y-3 p-4">
@@ -208,6 +236,12 @@ export function EightKListPage(): JSX.Element {
                   )}
                 </tbody>
               </table>
+              {state.data !== null && state.data.filings.length === HARD_LIMIT && (
+                <p className="mt-2 text-xs text-amber-700">
+                  Showing the most recent {HARD_LIMIT} filings. Older 8-Ks not
+                  shown — file a follow-up to add pagination if you need them.
+                </p>
+              )}
             </div>
             <EightKDetailPanel filing={selected} />
           </div>


### PR DESCRIPTION
## What

- New `/instrument/:symbol/filings/8-k` route with filter strip + table + detail panel.
- `EightKDetailPanel` (right pane) and `EightKFilterStrip` (severity / itemCode / dateRange).
- Filter state + selected accession in URL query string for deep-links.
- Auto-select first filtered row on page open so the detail pane is never blank.
- Truncation notice shown when results hit the 250-filing cap.
- `DensityGrid` no longer renders the transitional `EightKEventsPanel` — Phase 3 bridge removed.

## Why

Phase 4 of `docs/superpowers/specs/2026-04-27-instrument-detail-density-grid-design.md`. Closes the 8-K UX gap from Phase 3.

## Test plan

- [x] Vitest: filter + selection + URL deep-link behaviour on `EightKListPage`.
- [x] Frontend typecheck + 414 unit tests green.
- [x] Codex pre-push review: three Major findings (empty detail pane, silent 100-cap, stale accession on filter) all addressed in `3ece158`.

## Out of scope / follow-ups

- #567 — density grid refinement v2 (FilingsPane filing-type filter, scroll-box reduction, charts for revenue/cost/profit + ownership pie, professional UI tooling pass). Operator feedback after Phase 3 merge.