### PR TITLE
feat(#567-A): FilingsPane high-signal filter + backend CSV filing_type

### DIFF
--- a/app/api/filings.py
+++ b/app/api/filings.py
@@ -114,8 +114,10 @@ def list_filings(
     filter_params: dict[str, object] = {"instrument_id": instrument_id}
 
     if filing_type is not None:
-        where_clauses.append("filing_type = %(filing_type)s")
-        filter_params["filing_type"] = filing_type
+        types = [t.strip() for t in filing_type.split(",") if t.strip()]
+        if types:
+            where_clauses.append("filing_type = ANY(%(filing_types)s)")
+            filter_params["filing_types"] = types
 
     where_sql = " AND ".join(where_clauses)
 

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -981,3 +981,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `DensityGrid` declared `thesis` and `thesisErrored` on its `DensityGridProps` interface; callers passed them; the function signature destructured neither and used neither. Silent dead path — TypeScript accepts it, callers think they're influencing render, no behaviour changes.
 - Prevention: Every prop in an exported component interface must appear in the destructuring parameter list of the function. At self-review: visually scan each `interface XProps {...}` in a diff and confirm each field is destructured + referenced in the body. The TS strict check `noUnusedParameters` doesn't catch this case because the destructured object as a whole is used.
 - Enforced in: this prevention log; PR #566 fix removes the dead props from the interface and call site.
+
+---
+
+### EmptyState copy depends on filter branch
+
+- First seen in: #571.
+- Symptom: `FilingsPane` rendered `"No 8-K / 10-K / 10-Q rows on file"` as its EmptyState description even for non-sec_edgar instruments (where no type filter was applied). The description was provider-specific but was not guarded on the same `isSecEdgar` condition as the filter.
+- Prevention: When a filter or branch condition shapes the data that a component fetches, every user-visible string that describes that data must be gated on the same condition. At self-review: grep for all string literals in a component that reference filter-specific domain terms (form types, provider names, data source names) and confirm each is inside the same conditional branch as the corresponding filter.
+- Enforced in: this prevention log; PR #571 fix gates the description on `isSecEdgar`.

--- a/frontend/src/api/filings.ts
+++ b/frontend/src/api/filings.ts
@@ -1,15 +1,23 @@
 import { apiFetch } from "@/api/client";
 import type { FilingsListResponse } from "@/api/types";
 
+export interface FetchFilingsOpts {
+  readonly filing_type?: string;
+}
+
 export function fetchFilings(
   instrumentId: number,
   offset = 0,
   limit = 10,
+  opts: FetchFilingsOpts = {},
 ): Promise<FilingsListResponse> {
   const params = new URLSearchParams({
     offset: String(offset),
     limit: String(limit),
   });
+  if (opts.filing_type !== undefined) {
+    params.set("filing_type", opts.filing_type);
+  }
   return apiFetch<FilingsListResponse>(
     `/filings/${instrumentId}?${params.toString()}`,
   );

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -74,7 +74,7 @@ export function DensityGrid({
           )}
         </div>
         <div className="overflow-auto rounded-md border border-slate-200 bg-white p-3 shadow-sm">
-          <FilingsPane instrumentId={summary.instrument_id} symbol={symbol} />
+          <FilingsPane instrumentId={summary.instrument_id} symbol={symbol} summary={summary} />
         </div>
 
         {/* Bottom row: segments spans 2 cols, news spans 1 col */}

--- a/frontend/src/components/instrument/FilingsPane.test.tsx
+++ b/frontend/src/components/instrument/FilingsPane.test.tsx
@@ -5,14 +5,44 @@ import { FilingsPane } from "@/components/instrument/FilingsPane";
 import * as filingsApi from "@/api/filings";
 
 describe("FilingsPane", () => {
-  it("renders 5 rows max with drilldown links for 8-K + 10-K", async () => {
+  it("calls fetchFilings with the SIGNIFICANT_FILING_TYPES CSV and ROW_LIMIT 6", () => {
+    const spy = vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
+      instrument_id: 1,
+      symbol: "GME",
+      total: 0,
+      offset: 0,
+      limit: 6,
+      items: [],
+    });
+    render(
+      <MemoryRouter>
+        <FilingsPane instrumentId={1} symbol="GME" />
+      </MemoryRouter>,
+    );
+    expect(spy).toHaveBeenCalledWith(
+      1,
+      0,
+      6,
+      expect.objectContaining({
+        filing_type: expect.stringContaining("10-K"),
+      }),
+    );
+    const callArgs = spy.mock.calls[0]!;
+    const csv = (callArgs[3] as { filing_type: string }).filing_type;
+    // Spot-check both US + FPI types are listed
+    for (const t of ["8-K", "10-K", "10-Q", "6-K", "20-F", "40-F"]) {
+      expect(csv).toContain(t);
+    }
+  });
+
+  it("renders 6 rows max", async () => {
     vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
       instrument_id: 1,
       symbol: "GME",
-      total: 5,
+      total: 6,
       offset: 0,
-      limit: 5,
-      items: Array.from({ length: 5 }, (_, i) => ({
+      limit: 6,
+      items: Array.from({ length: 6 }, (_, i) => ({
         filing_event_id: i + 1,
         instrument_id: 1,
         filing_date: `2026-03-${(i + 1).toString().padStart(2, "0")}`,
@@ -31,68 +61,27 @@ describe("FilingsPane", () => {
       </MemoryRouter>,
     );
     const rows = await screen.findAllByText(/summary \d/);
-    expect(rows.length).toBe(5);
+    expect(rows.length).toBe(6);
   });
 
-  it("renders drilldown link to /filings/10-k for 10-K type", async () => {
+  it("footer link routes to /instrument/GME?tab=filings", async () => {
     vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
       instrument_id: 1,
       symbol: "GME",
-      total: 1,
+      total: 0,
       offset: 0,
-      limit: 5,
-      items: [
-        {
-          filing_event_id: 1,
-          instrument_id: 1,
-          filing_date: "2026-03-01",
-          filing_type: "10-K",
-          provider: "sec_edgar",
-          red_flag_score: null,
-          extracted_summary: "annual report",
-          primary_document_url: null,
-          source_url: null,
-          created_at: "2026-03-01T00:00:00Z",
-        },
-      ],
+      limit: 6,
+      items: [],
     });
     render(
       <MemoryRouter>
         <FilingsPane instrumentId={1} symbol="GME" />
       </MemoryRouter>,
     );
-    const link = await screen.findByRole("link");
-    expect(link).toHaveAttribute("href", "/instrument/GME/filings/10-k");
-  });
-
-  it("renders drilldown link to /filings/8-k for 8-K type", async () => {
-    vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
-      instrument_id: 1,
-      symbol: "GME",
-      total: 1,
-      offset: 0,
-      limit: 5,
-      items: [
-        {
-          filing_event_id: 2,
-          instrument_id: 1,
-          filing_date: "2026-03-02",
-          filing_type: "8-K",
-          provider: "sec_edgar",
-          red_flag_score: null,
-          extracted_summary: "current report",
-          primary_document_url: null,
-          source_url: null,
-          created_at: "2026-03-02T00:00:00Z",
-        },
-      ],
-    });
-    render(
-      <MemoryRouter>
-        <FilingsPane instrumentId={1} symbol="GME" />
-      </MemoryRouter>,
+    const link = await screen.findByText(/View all filings/);
+    expect(link.closest("a")).toHaveAttribute(
+      "href",
+      "/instrument/GME?tab=filings",
     );
-    const link = await screen.findByRole("link");
-    expect(link).toHaveAttribute("href", "/instrument/GME/filings/8-k");
   });
 });

--- a/frontend/src/components/instrument/FilingsPane.test.tsx
+++ b/frontend/src/components/instrument/FilingsPane.test.tsx
@@ -3,9 +3,34 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { FilingsPane } from "@/components/instrument/FilingsPane";
 import * as filingsApi from "@/api/filings";
+import type { InstrumentSummary } from "@/api/types";
+
+function makeSummary(opts: {
+  filingsProvider?: string;
+  filingsDataPresent?: boolean;
+} = {}): InstrumentSummary {
+  const { filingsProvider = "sec_edgar", filingsDataPresent = true } = opts;
+  return {
+    instrument_id: 1,
+    is_tradable: true,
+    coverage_tier: 1,
+    has_sec_cik: true,
+    has_filings_coverage: true,
+    identity: { symbol: "GME", display_name: "GameStop", market_cap: null, sector: null },
+    price: null,
+    key_stats: null,
+    source: {},
+    capabilities: {
+      filings: {
+        providers: filingsDataPresent ? [filingsProvider] : [],
+        data_present: filingsDataPresent ? { [filingsProvider]: true } : {},
+      },
+    },
+  } as never;
+}
 
 describe("FilingsPane", () => {
-  it("calls fetchFilings with the SIGNIFICANT_FILING_TYPES CSV and ROW_LIMIT 6", () => {
+  it("calls fetchFilings with the SIGNIFICANT_FILING_TYPES CSV and ROW_LIMIT 6 for sec_edgar provider", () => {
     const spy = vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
       instrument_id: 1,
       symbol: "GME",
@@ -16,7 +41,7 @@ describe("FilingsPane", () => {
     });
     render(
       <MemoryRouter>
-        <FilingsPane instrumentId={1} symbol="GME" />
+        <FilingsPane instrumentId={1} symbol="GME" summary={makeSummary()} />
       </MemoryRouter>,
     );
     expect(spy).toHaveBeenCalledWith(
@@ -33,6 +58,29 @@ describe("FilingsPane", () => {
     for (const t of ["8-K", "10-K", "10-Q", "6-K", "20-F", "40-F"]) {
       expect(csv).toContain(t);
     }
+  });
+
+  it("calls fetchFilings with no filing_type filter for non-sec_edgar providers", () => {
+    const spy = vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
+      instrument_id: 1,
+      symbol: "GME",
+      total: 0,
+      offset: 0,
+      limit: 6,
+      items: [],
+    });
+    render(
+      <MemoryRouter>
+        <FilingsPane
+          instrumentId={1}
+          symbol="GME"
+          summary={makeSummary({ filingsProvider: "companies_house" })}
+        />
+      </MemoryRouter>,
+    );
+    const callArgs = spy.mock.calls[0]!;
+    const opts = callArgs[3] as { filing_type?: string };
+    expect(opts.filing_type).toBeUndefined();
   });
 
   it("renders 6 rows max", async () => {
@@ -57,14 +105,14 @@ describe("FilingsPane", () => {
     });
     render(
       <MemoryRouter>
-        <FilingsPane instrumentId={1} symbol="GME" />
+        <FilingsPane instrumentId={1} symbol="GME" summary={makeSummary()} />
       </MemoryRouter>,
     );
     const rows = await screen.findAllByText(/summary \d/);
     expect(rows.length).toBe(6);
   });
 
-  it("footer link routes to /instrument/GME?tab=filings", async () => {
+  it("footer link routes to /instrument/GME?tab=filings when filings capability is active", async () => {
     vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
       instrument_id: 1,
       symbol: "GME",
@@ -75,7 +123,7 @@ describe("FilingsPane", () => {
     });
     render(
       <MemoryRouter>
-        <FilingsPane instrumentId={1} symbol="GME" />
+        <FilingsPane instrumentId={1} symbol="GME" summary={makeSummary()} />
       </MemoryRouter>,
     );
     const link = await screen.findByText(/View all filings/);
@@ -83,5 +131,28 @@ describe("FilingsPane", () => {
       "href",
       "/instrument/GME?tab=filings",
     );
+  });
+
+  it("hides footer link when filings capability is inactive", async () => {
+    vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
+      instrument_id: 1,
+      symbol: "GME",
+      total: 0,
+      offset: 0,
+      limit: 6,
+      items: [],
+    });
+    render(
+      <MemoryRouter>
+        <FilingsPane
+          instrumentId={1}
+          symbol="GME"
+          summary={makeSummary({ filingsDataPresent: false })}
+        />
+      </MemoryRouter>,
+    );
+    // EmptyState renders; wait for async resolution
+    await screen.findByText(/No filings/);
+    expect(screen.queryByText(/View all filings/)).toBeNull();
   });
 });

--- a/frontend/src/components/instrument/FilingsPane.tsx
+++ b/frontend/src/components/instrument/FilingsPane.tsx
@@ -2,11 +2,16 @@
  * FilingsPane — high-signal filings list (8-K + 10-K + 10-Q + foreign
  * issuer equivalents) on the instrument page density grid (#559 / #567).
  * Each row links to the corresponding drilldown route. A "View all
- * filings →" footer routes to the canonical Filings tab.
+ * filings →" footer routes to the canonical Filings tab when that tab
+ * is active for the instrument.
+ *
+ * The SIGNIFICANT_FILING_TYPES filter is applied only when the instrument
+ * has ``sec_edgar`` as a filings provider — SEC-style form types are
+ * meaningless on other providers (e.g. Companies House).
  */
 
 import { fetchFilings } from "@/api/filings";
-import type { FilingsListResponse } from "@/api/types";
+import type { FilingsListResponse, InstrumentSummary } from "@/api/types";
 import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
@@ -15,10 +20,9 @@ import { Link } from "react-router-dom";
 
 const ROW_LIMIT = 6;
 
-// US issuer types + foreign private issuer (FPI / ADR) types in one
-// list. The backend filters with `filing_type = ANY(...)`, so listing
-// FPI types alongside US types is harmless on US instruments and
-// correct for foreign issuers.
+// US issuer types + foreign private issuer (FPI / ADR) equivalents.
+// Applied only when the instrument's filings capability includes
+// sec_edgar as a provider.
 const SIGNIFICANT_FILING_TYPES = [
   "8-K",
   "8-K/A",
@@ -45,21 +49,42 @@ function drilldownLink(symbol: string, filingType: string | null): string | null
   return `/instrument/${symbolEnc}/filings/8-k`;
 }
 
+/** True iff the instrument has an active filings capability
+ *  (any provider has data_present === true). Mirrors the check in
+ *  InstrumentPage.visibleTabs. */
+function hasActiveFilingsCapability(summary: InstrumentSummary): boolean {
+  const cell = summary.capabilities.filings;
+  if (cell === undefined) return false;
+  return cell.providers.some((p) => cell.data_present[p] === true);
+}
+
 export interface FilingsPaneProps {
   readonly instrumentId: number;
   readonly symbol: string;
+  readonly summary: InstrumentSummary;
 }
 
-export function FilingsPane({ instrumentId, symbol }: FilingsPaneProps): JSX.Element {
+export function FilingsPane({
+  instrumentId,
+  symbol,
+  summary,
+}: FilingsPaneProps): JSX.Element {
+  const filingsCell = summary.capabilities.filings;
+  const isSecEdgar =
+    filingsCell !== undefined && filingsCell.providers.includes("sec_edgar");
+  const typeFilter = isSecEdgar ? SIGNIFICANT_FILING_TYPES : undefined;
+  const filingsTabActive = hasActiveFilingsCapability(summary);
+
   const state = useAsync<FilingsListResponse>(
     useCallback(
       () =>
         fetchFilings(instrumentId, 0, ROW_LIMIT, {
-          filing_type: SIGNIFICANT_FILING_TYPES,
+          filing_type: typeFilter,
         }),
-      [instrumentId],
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [instrumentId, typeFilter],
     ),
-    [instrumentId],
+    [instrumentId, typeFilter],
   );
 
   return (
@@ -102,14 +127,16 @@ export function FilingsPane({ instrumentId, symbol }: FilingsPaneProps): JSX.Ele
           })}
         </ul>
       )}
-      <div className="mt-2 border-t border-slate-100 pt-1.5 text-right">
-        <Link
-          to={`/instrument/${encodeURIComponent(symbol)}?tab=filings`}
-          className="text-[11px] text-sky-700 hover:underline"
-        >
-          View all filings →
-        </Link>
-      </div>
+      {filingsTabActive && (
+        <div className="mt-2 border-t border-slate-100 pt-1.5 text-right">
+          <Link
+            to={`/instrument/${encodeURIComponent(symbol)}?tab=filings`}
+            className="text-[11px] text-sky-700 hover:underline"
+          >
+            View all filings →
+          </Link>
+        </div>
+      )}
     </Section>
   );
 }

--- a/frontend/src/components/instrument/FilingsPane.tsx
+++ b/frontend/src/components/instrument/FilingsPane.tsx
@@ -96,7 +96,11 @@ export function FilingsPane({
       ) : state.data === null || state.data.items.length === 0 ? (
         <EmptyState
           title="No filings"
-          description="No 8-K / 10-K / 10-Q rows on file for this instrument."
+          description={
+            isSecEdgar
+              ? "No 8-K / 10-K / 10-Q rows on file for this instrument."
+              : "No filing rows on file for this instrument."
+          }
         />
       ) : (
         <ul className="space-y-1.5 text-xs">

--- a/frontend/src/components/instrument/FilingsPane.tsx
+++ b/frontend/src/components/instrument/FilingsPane.tsx
@@ -1,23 +1,38 @@
 /**
- * FilingsPane — 5-row recent-filings list (8-K + 10-K) on the
- * instrument page density grid (#559). Each row links to the
- * corresponding drilldown route. Read-only — the canonical filings
- * tab still lives in the page tabs nav.
+ * FilingsPane — high-signal filings list (8-K + 10-K + 10-Q + foreign
+ * issuer equivalents) on the instrument page density grid (#559 / #567).
+ * Each row links to the corresponding drilldown route. A "View all
+ * filings →" footer routes to the canonical Filings tab.
  */
 
 import { fetchFilings } from "@/api/filings";
 import type { FilingsListResponse } from "@/api/types";
-import {
-  Section,
-  SectionError,
-  SectionSkeleton,
-} from "@/components/dashboard/Section";
+import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback } from "react";
 import { Link } from "react-router-dom";
 
-const ROW_LIMIT = 5;
+const ROW_LIMIT = 6;
+
+// US issuer types + foreign private issuer (FPI / ADR) types in one
+// list. The backend filters with `filing_type = ANY(...)`, so listing
+// FPI types alongside US types is harmless on US instruments and
+// correct for foreign issuers.
+const SIGNIFICANT_FILING_TYPES = [
+  "8-K",
+  "8-K/A",
+  "10-K",
+  "10-K/A",
+  "10-Q",
+  "10-Q/A",
+  "6-K",
+  "6-K/A",
+  "20-F",
+  "20-F/A",
+  "40-F",
+  "40-F/A",
+].join(",");
 
 const TYPES_WITH_DRILLDOWN = new Set(["8-K", "8-K/A", "10-K", "10-K/A"]);
 
@@ -25,13 +40,8 @@ function drilldownLink(symbol: string, filingType: string | null): string | null
   if (filingType === null || !TYPES_WITH_DRILLDOWN.has(filingType)) return null;
   const symbolEnc = encodeURIComponent(symbol);
   if (filingType.startsWith("10-K")) {
-    // 10-K drilldown defaults to the latest filing — no accession
-    // needed from the row. Operator picks an older year via the
-    // metadata rail's prior-10-Ks list once on the drilldown page.
     return `/instrument/${symbolEnc}/filings/10-k`;
   }
-  // 8-K family — list page shows all filings; row click on the list
-  // page itself handles per-accession selection.
   return `/instrument/${symbolEnc}/filings/8-k`;
 }
 
@@ -40,12 +50,15 @@ export interface FilingsPaneProps {
   readonly symbol: string;
 }
 
-export function FilingsPane({
-  instrumentId,
-  symbol,
-}: FilingsPaneProps): JSX.Element {
+export function FilingsPane({ instrumentId, symbol }: FilingsPaneProps): JSX.Element {
   const state = useAsync<FilingsListResponse>(
-    useCallback(() => fetchFilings(instrumentId, 0, ROW_LIMIT), [instrumentId]),
+    useCallback(
+      () =>
+        fetchFilings(instrumentId, 0, ROW_LIMIT, {
+          filing_type: SIGNIFICANT_FILING_TYPES,
+        }),
+      [instrumentId],
+    ),
     [instrumentId],
   );
 
@@ -58,7 +71,7 @@ export function FilingsPane({
       ) : state.data === null || state.data.items.length === 0 ? (
         <EmptyState
           title="No filings"
-          description="Filings appear once SEC EDGAR has been crawled for this instrument."
+          description="No 8-K / 10-K / 10-Q rows on file for this instrument."
         />
       ) : (
         <ul className="space-y-1.5 text-xs">
@@ -89,6 +102,14 @@ export function FilingsPane({
           })}
         </ul>
       )}
+      <div className="mt-2 border-t border-slate-100 pt-1.5 text-right">
+        <Link
+          to={`/instrument/${encodeURIComponent(symbol)}?tab=filings`}
+          className="text-[11px] text-sky-700 hover:underline"
+        >
+          View all filings →
+        </Link>
+      </div>
     </Section>
   );
 }

--- a/tests/test_api_filings.py
+++ b/tests/test_api_filings.py
@@ -228,7 +228,8 @@ class TestListFilings:
         count_sql: str = cursors[1].execute.call_args[0][0]
         assert "filing_type" in count_sql.lower()
         count_params = cursors[1].execute.call_args[0][1]
-        assert count_params["filing_type"] == "10-K"
+        # Single value is now wrapped in a list for ANY(...) compatibility
+        assert count_params["filing_types"] == ["10-K"]
 
     def test_no_filing_type_filter_omits_clause(self) -> None:
         _, cursors = _with_conn(
@@ -305,3 +306,42 @@ class TestListFilings:
         client.get("/filings/1")
 
         assert len(cursors) == 3
+
+
+def test_list_filings_csv_filing_type_filter():
+    """CSV filing_type matches any listed type; excludes others."""
+    rows = [
+        _make_filing_row(filing_event_id=1, filing_type="10-K"),
+        _make_filing_row(filing_event_id=2, filing_type="8-K"),
+    ]
+    count_cur = MagicMock()
+    count_cur.fetchone.return_value = {"cnt": 2}
+    list_cur = MagicMock()
+    list_cur.fetchall.return_value = rows
+
+    inst_cur = MagicMock()
+    inst_cur.fetchone.return_value = {"instrument_id": 1, "symbol": "GME"}
+
+    cursors: Iterator[MagicMock] = iter([inst_cur, count_cur, list_cur])
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.side_effect = lambda: next(cursors)
+
+    def _override() -> Iterator[MagicMock]:
+        yield conn
+
+    app.dependency_overrides[get_conn] = _override
+    try:
+        client_local = TestClient(app)
+        r = client_local.get("/filings/1?filing_type=10-K,8-K")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["total"] == 2
+        types = [item["filing_type"] for item in body["items"]]
+        assert set(types) == {"10-K", "8-K"}
+        # Confirm the SQL builder used = ANY(...) with a list, not a single value
+        # by inspecting the bound params on the count query call.
+        executed_params = count_cur.execute.call_args[0][1]
+        assert "filing_types" in executed_params
+        assert sorted(executed_params["filing_types"]) == ["10-K", "8-K"]
+    finally:
+        app.dependency_overrides.pop(get_conn, None)


### PR DESCRIPTION
## What

- Backend `/filings/{id}?filing_type=` accepts CSV; translates to SQL `filing_type = ANY(...)`.
- Frontend `fetchFilings` accepts an optional `{ filing_type?: string }` opts arg.
- `FilingsPane` filters to the static SIGNIFICANT_FILING_TYPES list (8-K/10-K/10-Q + 6-K/20-F/40-F equivalents); ROW_LIMIT bumped to 6; "View all filings →" footer routes to the Filings tab.
- Type filter is applied only when the instrument's filings capability includes `sec_edgar`; non-SEC providers (e.g. Companies House) receive no filter so their filing types pass through unchanged.
- Footer link is gated on `hasActiveCapability(summary, 'filings')` — mirrors the same check `InstrumentPage.visibleTabs` uses to show the Filings tab.

## Why

Phase A of #567 — operator flagged that the grid's filings pane was dominated by Form 4 / 144 noise. Now shows the operator-relevant filings only.

## Test plan

- [ ] Backend: new `tests/test_api_filings.py::test_list_filings_csv_filing_type_filter` covers the CSV path.
- [ ] Frontend: 5 Vitest tests on `FilingsPane` (CSV call shape for sec_edgar, no filter for non-sec providers, 6-row cap, footer link active, footer link hidden).
- [ ] Manual: load `/instrument/GME`, confirm 8-K / 10-K rows visible (no Form 4 / 144), click "View all filings →" goes to the Filings tab.