### PR TITLE
feat(#567-C): Fundamentals sparkline pane

### DIFF
--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -999,3 +999,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `DensityGrid` retained `overflow-auto` on the dividends+insider combined card (intentional scroll-bound), but the test asserting `.overflow-auto` count only rendered the default fixture where the combined card is hidden (`capabilities:{}`). The test passed with count=0, giving a future refactorer false confidence that *all* panes are free of overflow-auto.
 - Prevention: When a CSS class is conditionally applied (present in one render path, absent in another), add a test variant for the branch where the class IS present and assert the exact count. This regression-guards future refactors that remove the class from that branch.
 - Enforced in: this prevention log; PR #572 adds the active-branch variant asserting count=1.
+
+---
+
+### Navigation link outside data guard in async pane
+
+- First seen in: #573.
+- Symptom: `FundamentalsPane` rendered a "View statements →" `<Link>` as a sibling of the loading/error/empty conditional block inside `<Section>`, so the link was visible during skeleton and error states before data was confirmed present.
+- Prevention: Navigation links (and any affordance that implies data is loaded) inside `useAsync`-driven panes must live inside the resolved-data branch, not as unconditional siblings of the loading/error/empty ternary. At self-review: grep for `<Link` in any component that also has `useAsync`, and confirm each link is inside the `state.data !== null` branch or the resolved conditional arm.
+- Enforced in: this prevention log; PR #573 fix moves the "View statements" footer into the data-resolved `<>...</>` fragment.

--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -29,6 +29,9 @@ vi.mock("@/components/instrument/DividendsPanel", () => ({
 vi.mock("@/components/instrument/InsiderActivityPanel", () => ({
   InsiderActivityPanel: () => <div>Insider</div>,
 }));
+vi.mock("@/components/instrument/FundamentalsPane", () => ({
+  FundamentalsPane: () => <div>Fundamentals stub</div>,
+}));
 
 const summary = {
   instrument_id: 1,
@@ -118,6 +121,61 @@ describe("DensityGrid", () => {
     );
     const overflowAuto = container.querySelectorAll(".overflow-auto");
     expect(overflowAuto.length).toBe(0);
+  });
+
+  it("renders FundamentalsPane only when sec_xbrl fundamentals capability is active", () => {
+    const summaryActive = {
+      instrument_id: 1,
+      has_sec_cik: true,
+      identity: {
+        symbol: "GME",
+        display_name: "GameStop",
+        market_cap: "1000000",
+        sector: null,
+      },
+      capabilities: {
+        fundamentals: {
+          providers: ["sec_xbrl"],
+          data_present: { sec_xbrl: true },
+        },
+      },
+      key_stats: null,
+    } as never;
+    const { rerender } = render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={summaryActive}
+          keyStatsBlock={<div>K</div>}
+          thesisBlock={<div>T</div>}
+          newsBlock={<div>N</div>}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Fundamentals stub")).toBeInTheDocument();
+
+    const summaryInactive = {
+      instrument_id: 1,
+      has_sec_cik: true,
+      identity: {
+        symbol: "GME",
+        display_name: "GameStop",
+        market_cap: "1000000",
+        sector: null,
+      },
+      capabilities: {},
+      key_stats: null,
+    } as never;
+    rerender(
+      <MemoryRouter>
+        <DensityGrid
+          summary={summaryInactive}
+          keyStatsBlock={<div>K</div>}
+          thesisBlock={<div>T</div>}
+          newsBlock={<div>N</div>}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText("Fundamentals stub")).toBeNull();
   });
 
   it("combined dividends/insider card uses exactly one overflow-auto scroll-bound (Phase D regression guard)", () => {

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -64,14 +64,6 @@ export function DensityGrid({
           {thesisBlock}
         </div>
 
-        {/* Fundamentals pane: full-width row, gated on sec_xbrl capability */}
-        {summary.capabilities["fundamentals"]?.providers.includes("sec_xbrl") &&
-         summary.capabilities["fundamentals"].data_present["sec_xbrl"] === true ? (
-          <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm lg:col-span-3">
-            <FundamentalsPane summary={summary} />
-          </div>
-        ) : null}
-
         {/* Right column row 2 */}
         <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm">
           {hasSec ? (
@@ -85,6 +77,17 @@ export function DensityGrid({
         <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm">
           <FilingsPane instrumentId={summary.instrument_id} symbol={symbol} summary={summary} />
         </div>
+
+        {/* Fundamentals pane: full-width row after sec profile + filings,
+            gated on sec_xbrl capability. Placed after the row-2 right-column
+            panes so the chart/keyStats/thesis/secProfile/filings layout is
+            preserved regardless of whether fundamentals are active. */}
+        {summary.capabilities["fundamentals"]?.providers.includes("sec_xbrl") &&
+         summary.capabilities["fundamentals"].data_present["sec_xbrl"] === true ? (
+          <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm lg:col-span-3">
+            <FundamentalsPane summary={summary} />
+          </div>
+        ) : null}
 
         {/* Bottom row: segments spans 2 cols, news spans 1 col */}
         <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm lg:col-span-2">

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -19,6 +19,7 @@
 import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSectionsTeaser";
 import { DividendsPanel } from "@/components/instrument/DividendsPanel";
 import { FilingsPane } from "@/components/instrument/FilingsPane";
+import { FundamentalsPane } from "@/components/instrument/FundamentalsPane";
 import { InsiderActivityPanel } from "@/components/instrument/InsiderActivityPanel";
 import { PriceChart } from "@/components/instrument/PriceChart";
 import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
@@ -62,6 +63,14 @@ export function DensityGrid({
         <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm">
           {thesisBlock}
         </div>
+
+        {/* Fundamentals pane: full-width row, gated on sec_xbrl capability */}
+        {summary.capabilities["fundamentals"]?.providers.includes("sec_xbrl") &&
+         summary.capabilities["fundamentals"].data_present["sec_xbrl"] === true ? (
+          <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm lg:col-span-3">
+            <FundamentalsPane summary={summary} />
+          </div>
+        ) : null}
 
         {/* Right column row 2 */}
         <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm">

--- a/frontend/src/components/instrument/FundamentalsPane.test.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.test.tsx
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { FundamentalsPane } from "@/components/instrument/FundamentalsPane";
+import * as api from "@/api/instruments";
+import type { InstrumentSummary } from "@/api/types";
+
+function makeSummary(secXbrlActive: boolean): InstrumentSummary {
+  return {
+    instrument_id: 1,
+    has_sec_cik: true,
+    identity: {
+      symbol: "GME",
+      display_name: "GameStop",
+      market_cap: "1000000",
+      sector: null,
+    },
+    capabilities: {
+      fundamentals: {
+        providers: secXbrlActive ? ["sec_xbrl"] : [],
+        data_present: secXbrlActive ? { sec_xbrl: true } : {},
+      },
+    },
+    key_stats: null,
+  } as never;
+}
+
+const incomeRows = Array.from({ length: 4 }, (_, i) => ({
+  period_end: `2026-0${i + 1}-30`,
+  period_type: `Q${i + 1}`,
+  values: {
+    revenue: String(1000 + i * 100),
+    operating_income: String(50 + i * 5),
+    net_income: String(40 + i * 4),
+  },
+}));
+const balanceRows = Array.from({ length: 4 }, (_, i) => ({
+  period_end: `2026-0${i + 1}-30`,
+  period_type: `Q${i + 1}`,
+  values: {
+    long_term_debt: String(200 + i * 10),
+    short_term_debt: String(50 + i * 2),
+  },
+}));
+
+describe("FundamentalsPane", () => {
+  it("returns null when sec_xbrl capability is inactive", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <FundamentalsPane summary={makeSummary(false)} />
+      </MemoryRouter>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders 4 sparklines when capability active and data present", async () => {
+    vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
+      ((_symbol: string, query: { statement: string }) => {
+        if (query.statement === "income") {
+          return Promise.resolve({
+            symbol: "GME",
+            statement: "income",
+            period: "quarterly",
+            currency: "USD",
+            source: "sec_xbrl",
+            rows: incomeRows,
+          });
+        }
+        return Promise.resolve({
+          symbol: "GME",
+          statement: "balance",
+          period: "quarterly",
+          currency: "USD",
+          source: "sec_xbrl",
+          rows: balanceRows,
+        });
+      }) as never,
+    );
+    render(
+      <MemoryRouter>
+        <FundamentalsPane summary={makeSummary(true)} />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText("Revenue")).toBeInTheDocument();
+    expect(screen.getByText("Op income")).toBeInTheDocument();
+    expect(screen.getByText("Net income")).toBeInTheDocument();
+    expect(screen.getByText("Total debt")).toBeInTheDocument();
+  });
+
+  it("computes total debt as long_term_debt + short_term_debt per period", async () => {
+    vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
+      ((_symbol: string, query: { statement: string }) => {
+        if (query.statement === "income") {
+          return Promise.resolve({
+            symbol: "GME",
+            statement: "income",
+            period: "quarterly",
+            currency: "USD",
+            source: "sec_xbrl",
+            rows: [
+              {
+                period_end: "2026-03-30",
+                period_type: "Q1",
+                values: { revenue: "100", operating_income: "10", net_income: "5" },
+              },
+              {
+                period_end: "2026-06-30",
+                period_type: "Q2",
+                values: { revenue: "200", operating_income: "20", net_income: "10" },
+              },
+            ],
+          });
+        }
+        return Promise.resolve({
+          symbol: "GME",
+          statement: "balance",
+          period: "quarterly",
+          currency: "USD",
+          source: "sec_xbrl",
+          rows: [
+            {
+              period_end: "2026-03-30",
+              period_type: "Q1",
+              values: { long_term_debt: "100", short_term_debt: "20" },
+            },
+            {
+              period_end: "2026-06-30",
+              period_type: "Q2",
+              values: { long_term_debt: "150", short_term_debt: "30" },
+            },
+          ],
+        });
+      }) as never,
+    );
+    render(
+      <MemoryRouter>
+        <FundamentalsPane summary={makeSummary(true)} />
+      </MemoryRouter>,
+    );
+    // Latest total debt = 150 + 30 = 180
+    expect(await screen.findByText(/180/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -138,37 +138,41 @@ export function FundamentalsPane({ summary }: FundamentalsPaneProps): JSX.Elemen
           description="Need at least 2 quarters with both income + balance data."
         />
       ) : (
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <FundamentalCell
-            label="Revenue"
-            values={series.map((r) => r.revenue)}
-            stroke="text-sky-500"
-          />
-          <FundamentalCell
-            label="Op income"
-            values={series.map((r) => r.operatingIncome)}
-            stroke="text-emerald-500"
-          />
-          <FundamentalCell
-            label="Net income"
-            values={series.map((r) => r.netIncome)}
-            stroke="text-emerald-500"
-          />
-          <FundamentalCell
-            label="Total debt"
-            values={series.map((r) => r.totalDebt)}
-            stroke="text-amber-500"
-          />
-        </div>
+        <>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <FundamentalCell
+              label="Revenue"
+              values={series.map((r) => r.revenue)}
+              stroke="text-sky-500"
+            />
+            <FundamentalCell
+              label="Op income"
+              values={series.map((r) => r.operatingIncome)}
+              stroke="text-emerald-500"
+            />
+            <FundamentalCell
+              label="Net income"
+              values={series.map((r) => r.netIncome)}
+              stroke="text-emerald-500"
+            />
+            <FundamentalCell
+              label="Total debt"
+              values={series.map((r) => r.totalDebt)}
+              stroke="text-amber-500"
+            />
+          </div>
+          {/* Footer link only shown when data is present — not during
+              skeleton / error / empty states (see review-prevention-log). */}
+          <div className="mt-2 border-t border-slate-100 pt-1.5 text-right">
+            <Link
+              to={`/instrument/${encodeURIComponent(symbol)}?tab=financials`}
+              className="text-[11px] text-sky-700 hover:underline"
+            >
+              View statements →
+            </Link>
+          </div>
+        </>
       )}
-      <div className="mt-2 border-t border-slate-100 pt-1.5 text-right">
-        <Link
-          to={`/instrument/${encodeURIComponent(symbol)}?tab=financials`}
-          className="text-[11px] text-sky-700 hover:underline"
-        >
-          View statements →
-        </Link>
-      </div>
     </Section>
   );
 }

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -1,0 +1,194 @@
+/**
+ * FundamentalsPane — 4 sparklines (Revenue / Op income / Net income /
+ * Total debt) over the latest 8 quarters from SEC XBRL fundamentals
+ * (#567). Gated on `summary.capabilities.fundamentals.providers` including
+ * "sec_xbrl" with `data_present.sec_xbrl === true` so non-SEC instruments
+ * don't render a dead pane.
+ *
+ * Data path: 2 parallel calls to /instruments/{symbol}/financials —
+ * one for income, one for balance — joined per (period_end, period_type)
+ * to keep all four sparklines on the same quarter set.
+ */
+
+import { fetchInstrumentFinancials } from "@/api/instruments";
+import type { InstrumentFinancialRow, InstrumentSummary } from "@/api/types";
+import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { Sparkline } from "@/components/instrument/Sparkline";
+import { useAsync } from "@/lib/useAsync";
+import { useCallback, useMemo } from "react";
+import { Link } from "react-router-dom";
+
+const SLICE = 8;
+
+interface SeriesRow {
+  readonly period_end: string;
+  readonly revenue: number;
+  readonly operatingIncome: number;
+  readonly netIncome: number;
+  readonly totalDebt: number;
+}
+
+function num(v: string | null | undefined): number | null {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function joinPeriods(
+  income: ReadonlyArray<InstrumentFinancialRow>,
+  balance: ReadonlyArray<InstrumentFinancialRow>,
+): SeriesRow[] {
+  const bMap = new Map(
+    balance.map((r) => [`${r.period_end}|${r.period_type}`, r]),
+  );
+  const joined: SeriesRow[] = [];
+  for (const i of income) {
+    const key = `${i.period_end}|${i.period_type}`;
+    const b = bMap.get(key);
+    if (b === undefined) continue;
+    const revenue = num(i.values["revenue"] ?? null);
+    const operatingIncome = num(i.values["operating_income"] ?? null);
+    const netIncome = num(i.values["net_income"] ?? null);
+    const lt = num(b.values["long_term_debt"] ?? null) ?? 0;
+    const st = num(b.values["short_term_debt"] ?? null) ?? 0;
+    if (revenue === null || operatingIncome === null || netIncome === null) {
+      continue;
+    }
+    joined.push({
+      period_end: i.period_end,
+      revenue,
+      operatingIncome,
+      netIncome,
+      totalDebt: lt + st,
+    });
+  }
+  // Sort newest first then take the latest SLICE; reverse so the
+  // sparklines plot oldest → newest left → right.
+  joined.sort((a, b) => (a.period_end < b.period_end ? 1 : -1));
+  const latest = joined.slice(0, SLICE);
+  latest.reverse();
+  return latest;
+}
+
+function formatLatest(values: ReadonlyArray<number>): string {
+  if (values.length === 0) return "—";
+  const v = values[values.length - 1];
+  if (Math.abs(v) >= 1e9) return `${(v / 1e9).toFixed(2)}B`;
+  if (Math.abs(v) >= 1e6) return `${(v / 1e6).toFixed(2)}M`;
+  if (Math.abs(v) >= 1e3) return `${(v / 1e3).toFixed(2)}K`;
+  return v.toFixed(0);
+}
+
+export interface FundamentalsPaneProps {
+  readonly summary: InstrumentSummary;
+}
+
+export function FundamentalsPane({ summary }: FundamentalsPaneProps): JSX.Element | null {
+  const symbol = summary.identity.symbol;
+  const fundCell = summary.capabilities["fundamentals"];
+  const active =
+    fundCell !== undefined &&
+    fundCell.providers.includes("sec_xbrl") &&
+    fundCell.data_present["sec_xbrl"] === true;
+
+  // Hooks must be called unconditionally — gating via `active` happens
+  // after data is fetched (or while loading shows a skeleton).
+  const income = useAsync(
+    useCallback(
+      () =>
+        fetchInstrumentFinancials(symbol, {
+          statement: "income",
+          period: "quarterly",
+        }),
+      [symbol],
+    ),
+    [symbol],
+  );
+  const balance = useAsync(
+    useCallback(
+      () =>
+        fetchInstrumentFinancials(symbol, {
+          statement: "balance",
+          period: "quarterly",
+        }),
+      [symbol],
+    ),
+    [symbol],
+  );
+
+  const series = useMemo(() => {
+    if (income.data === null || balance.data === null) return [];
+    return joinPeriods(income.data.rows, balance.data.rows);
+  }, [income.data, balance.data]);
+
+  if (!active) return null;
+
+  return (
+    <Section title="Fundamentals">
+      {income.loading || balance.loading ? (
+        <SectionSkeleton rows={3} />
+      ) : income.error !== null || balance.error !== null ? (
+        <SectionError onRetry={() => { income.refetch(); balance.refetch(); }} />
+      ) : series.length < 2 ? (
+        <EmptyState
+          title="Not enough fundamentals history"
+          description="Need at least 2 quarters with both income + balance data."
+        />
+      ) : (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <FundamentalCell
+            label="Revenue"
+            values={series.map((r) => r.revenue)}
+            stroke="text-sky-500"
+          />
+          <FundamentalCell
+            label="Op income"
+            values={series.map((r) => r.operatingIncome)}
+            stroke="text-emerald-500"
+          />
+          <FundamentalCell
+            label="Net income"
+            values={series.map((r) => r.netIncome)}
+            stroke="text-emerald-500"
+          />
+          <FundamentalCell
+            label="Total debt"
+            values={series.map((r) => r.totalDebt)}
+            stroke="text-amber-500"
+          />
+        </div>
+      )}
+      <div className="mt-2 border-t border-slate-100 pt-1.5 text-right">
+        <Link
+          to={`/instrument/${encodeURIComponent(symbol)}?tab=financials`}
+          className="text-[11px] text-sky-700 hover:underline"
+        >
+          View statements →
+        </Link>
+      </div>
+    </Section>
+  );
+}
+
+function FundamentalCell({
+  label,
+  values,
+  stroke,
+}: {
+  readonly label: string;
+  readonly values: ReadonlyArray<number>;
+  readonly stroke: string;
+}) {
+  return (
+    <div className="flex flex-col items-start">
+      <span className="text-[10px] uppercase tracking-wider text-slate-500">
+        {label}
+      </span>
+      <Sparkline values={values} className={stroke} />
+      <span className="text-xs font-medium tabular-nums text-slate-800">
+        {formatLatest(values)}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -73,7 +73,9 @@ function joinPeriods(
 
 function formatLatest(values: ReadonlyArray<number>): string {
   if (values.length === 0) return "—";
-  const v = values[values.length - 1];
+  // length > 0 is guaranteed above; cast away the possible-undefined
+  // that TypeScript infers from array index access in strict mode.
+  const v = values[values.length - 1] as number;
   if (Math.abs(v) >= 1e9) return `${(v / 1e9).toFixed(2)}B`;
   if (Math.abs(v) >= 1e6) return `${(v / 1e6).toFixed(2)}M`;
   if (Math.abs(v) >= 1e3) return `${(v / 1e3).toFixed(2)}K`;

--- a/frontend/src/components/instrument/Sparkline.test.tsx
+++ b/frontend/src/components/instrument/Sparkline.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { Sparkline } from "@/components/instrument/Sparkline";
+
+describe("Sparkline", () => {
+  it("renders <polyline> with 8 comma-separated coords for 8 input values", () => {
+    const { container } = render(
+      <Sparkline values={[1, 2, 3, 4, 5, 4, 3, 2]} width={80} height={24} />,
+    );
+    const polyline = container.querySelector("polyline");
+    expect(polyline).not.toBeNull();
+    const points = polyline?.getAttribute("points") ?? "";
+    const coords = points.trim().split(/\s+/);
+    expect(coords).toHaveLength(8);
+    for (const c of coords) {
+      expect(c).toMatch(/^\d+(?:\.\d+)?,\d+(?:\.\d+)?$/);
+    }
+  });
+
+  it("renders an empty <svg> with no <polyline> when given fewer than 2 values", () => {
+    const { container } = render(<Sparkline values={[42]} />);
+    const polyline = container.querySelector("polyline");
+    expect(polyline).toBeNull();
+  });
+
+  it("uses currentColor as default stroke", () => {
+    const { container } = render(<Sparkline values={[1, 2, 3]} />);
+    const polyline = container.querySelector("polyline");
+    expect(polyline?.getAttribute("stroke")).toBe("currentColor");
+  });
+});

--- a/frontend/src/components/instrument/Sparkline.tsx
+++ b/frontend/src/components/instrument/Sparkline.tsx
@@ -26,12 +26,17 @@ export function Sparkline({
   }
   const min = Math.min(...values);
   const max = Math.max(...values);
-  const range = max - min || 1;
+  const range = max - min;
   const xStep = width / (values.length - 1);
   const points = values
     .map((v, i) => {
       const x = i * xStep;
-      const y = height - ((v - min) / range) * height;
+      // When all values are equal (range === 0) center the flat line
+      // at height/2 rather than clipping it to the bottom boundary.
+      const y =
+        range === 0
+          ? height / 2
+          : height - ((v - min) / range) * height;
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     })
     .join(" ");

--- a/frontend/src/components/instrument/Sparkline.tsx
+++ b/frontend/src/components/instrument/Sparkline.tsx
@@ -1,0 +1,55 @@
+/**
+ * Sparkline — hand-coded SVG <polyline> sparkline. No external chart
+ * dependency. Used in `FundamentalsPane` for compact 8-point time
+ * series (revenue, op income, net income, total debt over 8 quarters).
+ */
+
+import type { JSX } from "react";
+
+export interface SparklineProps {
+  readonly values: ReadonlyArray<number>;
+  readonly width?: number;
+  readonly height?: number;
+  readonly stroke?: string;
+  readonly className?: string;
+}
+
+export function Sparkline({
+  values,
+  width = 80,
+  height = 24,
+  stroke = "currentColor",
+  className,
+}: SparklineProps): JSX.Element {
+  if (values.length < 2) {
+    return <svg width={width} height={height} className={className} />;
+  }
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const xStep = width / (values.length - 1);
+  const points = values
+    .map((v, i) => {
+      const x = i * xStep;
+      const y = height - ((v - min) / range) * height;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={className}
+      aria-hidden="true"
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke={stroke}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## What

- `Sparkline` hand-coded SVG component (no new chart dep).
- `FundamentalsPane`: 4 sparklines for Revenue / Op income / Net income / Total debt over the latest 8 quarters.
- Period-safe join keyed on `(period_end, period_type)` between income + balance statements so all four metrics plot the same quarter set.
- Gated on `summary.capabilities.fundamentals.providers.sec_xbrl.data_present === true`.
- Inserted into the density grid as a full-width row after the row-2 SecProfile/Filings panes (preserves existing layout).

## Why

Phase C of #567 — operator wants Bloomberg-tier visual analysis. Fundamentals over time is the highest-signal chart we can ship today.

## Test plan

- [ ] Vitest: 3 Sparkline tests (polyline shape, empty path, default stroke).
- [ ] Vitest: 3 FundamentalsPane tests (gating off, gating on, total-debt computation).
- [ ] Vitest: DensityGrid renders the pane only when capability active.
- [ ] Manual: load `/instrument/GME`, confirm 4 sparklines visible; load a non-SEC instrument and confirm pane is absent.