### PR TITLE
feat(#567-D): InsiderActivitySummary on density grid

### DIFF
--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -26,8 +26,8 @@ vi.mock("@/components/instrument/FilingsPane", () => ({
 vi.mock("@/components/instrument/DividendsPanel", () => ({
   DividendsPanel: () => <div>Dividends</div>,
 }));
-vi.mock("@/components/instrument/InsiderActivityPanel", () => ({
-  InsiderActivityPanel: () => <div>Insider</div>,
+vi.mock("@/components/instrument/InsiderActivitySummary", () => ({
+  InsiderActivitySummary: () => <div>Insider summary</div>,
 }));
 vi.mock("@/components/instrument/FundamentalsPane", () => ({
   FundamentalsPane: () => <div>Fundamentals stub</div>,
@@ -178,12 +178,10 @@ describe("DensityGrid", () => {
     expect(screen.queryByText("Fundamentals stub")).toBeNull();
   });
 
-  it("combined dividends/insider card uses exactly one overflow-auto scroll-bound (Phase D regression guard)", () => {
-    // When insider is active, InsiderActivityPanel renders up to 50 rows.
-    // The combined card retains overflow-auto + max-h-[360px] intentionally
-    // until Phase D replaces it with InsiderActivitySummary.
-    // This test pins the count to 1 so Phase D's removal of that bound
-    // is explicitly regression-guarded and not silently missed.
+  it("combined dividends/insider card has no overflow-auto after Phase D (InsiderActivitySummary is compact)", () => {
+    // Phase D replaced InsiderActivityPanel (up to 50 rows) with
+    // InsiderActivitySummary (compact 5-field block), so the combined
+    // card no longer needs the scroll-bound wrapper.
     const summaryWithInsider = {
       instrument_id: 1,
       has_sec_cik: true,
@@ -212,6 +210,6 @@ describe("DensityGrid", () => {
       </MemoryRouter>,
     );
     const overflowAuto = container.querySelectorAll(".overflow-auto");
-    expect(overflowAuto.length).toBe(1);
+    expect(overflowAuto.length).toBe(0);
   });
 });

--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -212,4 +212,39 @@ describe("DensityGrid", () => {
     const overflowAuto = container.querySelectorAll(".overflow-auto");
     expect(overflowAuto.length).toBe(0);
   });
+
+  it("combined card retains overflow-auto scroll-bound when dividends are active (DividendsPanel can be tall)", () => {
+    // DividendsPanel can render 40+ history rows; the combined card wrapper
+    // must keep the scroll-bound when dividends are present so the grid
+    // doesn't push other panes far below the fold.
+    const summaryWithDividends = {
+      instrument_id: 1,
+      has_sec_cik: true,
+      identity: {
+        symbol: "GME",
+        display_name: "GameStop",
+        market_cap: "1000000",
+        sector: null,
+      },
+      capabilities: {
+        dividends: {
+          providers: ["sec_dividend_summary"],
+          data_present: { sec_dividend_summary: true },
+        },
+      },
+      key_stats: null,
+    } as never;
+    const { container } = render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={summaryWithDividends}
+          keyStatsBlock={<div>KEY STATS BLOCK</div>}
+          thesisBlock={<div>THESIS BLOCK</div>}
+          newsBlock={<div>NEWS BLOCK</div>}
+        />
+      </MemoryRouter>,
+    );
+    const overflowAuto = container.querySelectorAll(".overflow-auto");
+    expect(overflowAuto.length).toBe(1);
+  });
 });

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -103,9 +103,15 @@ export function DensityGrid({
           {newsBlock}
         </div>
 
-        {/* Dividends + insider combined card — spans full width */}
+        {/* Dividends + insider combined card — spans full width.
+            overflow-auto + max-h guard applies only when dividends are
+            active because DividendsPanel can render 40+ history bars.
+            InsiderActivitySummary is compact (5-field block) and does
+            not need height-capping. */}
         {(dividendProviders.length > 0 || insiderProviders.length > 0) && (
-          <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm lg:col-span-3">
+          <div
+            className={`rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm lg:col-span-3${dividendProviders.length > 0 ? " overflow-auto max-h-[360px]" : ""}`}
+          >
             <div className="grid gap-3 md:grid-cols-2">
               {dividendProviders.map((p) => (
                 <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -20,7 +20,7 @@ import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSections
 import { DividendsPanel } from "@/components/instrument/DividendsPanel";
 import { FilingsPane } from "@/components/instrument/FilingsPane";
 import { FundamentalsPane } from "@/components/instrument/FundamentalsPane";
-import { InsiderActivityPanel } from "@/components/instrument/InsiderActivityPanel";
+import { InsiderActivitySummary } from "@/components/instrument/InsiderActivitySummary";
 import { PriceChart } from "@/components/instrument/PriceChart";
 import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
 import { Section } from "@/components/dashboard/Section";
@@ -105,18 +105,14 @@ export function DensityGrid({
 
         {/* Dividends + insider combined card — spans full width */}
         {(dividendProviders.length > 0 || insiderProviders.length > 0) && (
-          <div className="overflow-auto max-h-[360px] rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm lg:col-span-3">
+          <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm lg:col-span-3">
             <div className="grid gap-3 md:grid-cols-2">
               {dividendProviders.map((p) => (
                 <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
               ))}
-              {insiderProviders.map((p) => (
-                <InsiderActivityPanel
-                  key={`ins-${p}`}
-                  symbol={symbol}
-                  provider={p}
-                />
-              ))}
+              {insiderProviders.length > 0 && (
+                <InsiderActivitySummary symbol={symbol} />
+              )}
             </div>
           </div>
         )}

--- a/frontend/src/components/instrument/InsiderActivitySummary.test.tsx
+++ b/frontend/src/components/instrument/InsiderActivitySummary.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { InsiderActivitySummary } from "@/components/instrument/InsiderActivitySummary";
+import * as api from "@/api/instruments";
+
+const payload = {
+  symbol: "GME",
+  open_market_net_shares_90d: "999999",
+  open_market_buy_count_90d: 99,
+  open_market_sell_count_90d: 99,
+  total_acquired_shares_90d: "42392",
+  total_disposed_shares_90d: "18331",
+  acquisition_count_90d: 22,
+  disposition_count_90d: 16,
+  unique_filers_90d: 12,
+  latest_txn_date: "2026-04-13",
+  net_shares_90d: "999999",
+  buy_count_90d: 99,
+  sell_count_90d: 99,
+};
+
+describe("InsiderActivitySummary", () => {
+  it("renders NET 90d, ACQUIRED, DISPOSED, TXNS, LATEST from total-activity lens", async () => {
+    vi.spyOn(api, "fetchInsiderSummary").mockResolvedValue(payload);
+    render(
+      <MemoryRouter>
+        <InsiderActivitySummary symbol="GME" />
+      </MemoryRouter>,
+    );
+    // NET 90d = 42392 - 18331 = 24061 (positive → leading +)
+    expect(await screen.findByText(/\+24,?061/)).toBeInTheDocument();
+    expect(screen.getByText(/42,?392/)).toBeInTheDocument();
+    expect(screen.getByText(/18,?331/)).toBeInTheDocument();
+    // TXNS = acquisition_count_90d + disposition_count_90d = 22 + 16 = 38
+    expect(screen.getByText("38")).toBeInTheDocument();
+    expect(screen.getByText("2026-04-13")).toBeInTheDocument();
+  });
+
+  it("renders negative NET with leading minus when disposed > acquired", async () => {
+    vi.spyOn(api, "fetchInsiderSummary").mockResolvedValue({
+      ...payload,
+      total_acquired_shares_90d: "10000",
+      total_disposed_shares_90d: "30000",
+    });
+    render(
+      <MemoryRouter>
+        <InsiderActivitySummary symbol="GME" />
+      </MemoryRouter>,
+    );
+    // NET = 10000 - 30000 = -20000
+    expect(await screen.findByText(/-20,?000/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/instrument/InsiderActivitySummary.tsx
+++ b/frontend/src/components/instrument/InsiderActivitySummary.tsx
@@ -1,0 +1,118 @@
+/**
+ * InsiderActivitySummary — compact insider summary block on the
+ * density grid (#567). Uses total-activity lens consistently
+ * (total_acquired_shares_90d, total_disposed_shares_90d,
+ *  acquisition_count_90d + disposition_count_90d).
+ *
+ * NET 90d is computed client-side as acquired - disposed because
+ * the response's `net_shares_90d` legacy alias maps to the
+ * open-market net, NOT total-activity (would cross lenses).
+ */
+
+import { fetchInsiderSummary } from "@/api/instruments";
+import type { InsiderSummary } from "@/api/instruments";
+import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+import { useCallback } from "react";
+
+export interface InsiderActivitySummaryProps {
+  readonly symbol: string;
+}
+
+function fmt(n: number): string {
+  if (Math.abs(n) >= 1e9) return `${(n / 1e9).toFixed(2)}B`;
+  if (Math.abs(n) >= 1e6) return `${(n / 1e6).toFixed(2)}M`;
+  return n.toLocaleString();
+}
+
+function fmtSigned(n: number): string {
+  if (n > 0) return `+${fmt(n)}`;
+  if (n < 0) return `-${fmt(Math.abs(n))}`;
+  return "0";
+}
+
+function num(v: string | null | undefined): number {
+  if (v === null || v === undefined) return 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function InsiderActivitySummary({
+  symbol,
+}: InsiderActivitySummaryProps): JSX.Element {
+  const state = useAsync<InsiderSummary>(
+    useCallback(() => fetchInsiderSummary(symbol), [symbol]),
+    [symbol],
+  );
+
+  return (
+    <Section title="Insider activity (90d)">
+      {state.loading ? (
+        <SectionSkeleton rows={2} />
+      ) : state.error !== null ? (
+        <SectionError onRetry={state.refetch} />
+      ) : state.data === null ? (
+        <EmptyState
+          title="No insider data"
+          description="No Form 4 transactions on file for this instrument."
+        />
+      ) : (
+        (() => {
+          const acquired = num(state.data.total_acquired_shares_90d);
+          const disposed = num(state.data.total_disposed_shares_90d);
+          const net = acquired - disposed;
+          const txns =
+            state.data.acquisition_count_90d + state.data.disposition_count_90d;
+          const arrow = net > 0 ? "↑" : net < 0 ? "↓" : "·";
+          const netClass =
+            net > 0
+              ? "text-emerald-700"
+              : net < 0
+                ? "text-red-700"
+                : "text-slate-700";
+          return (
+            <div className="grid grid-cols-5 gap-2 text-xs">
+              <Field label="NET 90d">
+                <span className={`font-medium tabular-nums ${netClass}`}>
+                  {fmtSigned(net)} {arrow}
+                </span>
+              </Field>
+              <Field label="ACQUIRED">
+                <span className="tabular-nums">{fmt(acquired)} sh</span>
+              </Field>
+              <Field label="DISPOSED">
+                <span className="tabular-nums">{fmt(disposed)} sh</span>
+              </Field>
+              <Field label="TXNS">
+                <span className="tabular-nums">{txns}</span>
+              </Field>
+              <Field label="LATEST">
+                <span className="tabular-nums">
+                  {state.data.latest_txn_date ?? "—"}
+                </span>
+              </Field>
+            </div>
+          );
+        })()
+      )}
+    </Section>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  readonly label: string;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-[10px] uppercase tracking-wider text-slate-500">
+        {label}
+      </span>
+      <span>{children}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

- New `InsiderActivitySummary` component: compact 5-field block (NET 90d, ACQUIRED, DISPOSED, TXNS, LATEST) using the total-activity lens.
- NET 90d computed client-side as `total_acquired_shares_90d - total_disposed_shares_90d` so the lens stays consistent (the legacy `net_shares_90d` alias is open-market, not total-activity).
- Replaces the inline `InsiderActivityPanel` (transaction row list) inside `DensityGrid`.
- `InsiderActivityPanel` file kept for future use on a dedicated tab.
- Combined card wrapper retains `overflow-auto max-h-[360px]` only when dividends are active (DividendsPanel can render 40+ rows); insider-only case drops the scroll-bound since InsiderActivitySummary is a compact 5-field block.

## Why

Phase D of #567 — operator flagged that the row list inside the density grid is too long-form. A compact summary fits the grid better.

## Test plan

- [ ] Vitest: 2 InsiderActivitySummary tests (positive NET + negative NET).
- [ ] Vitest: DensityGrid mock updated; 7 tests pass including insider-only card has no overflow-auto, dividends-active card retains overflow-auto.
- [ ] Manual: load `/instrument/GME`, confirm 5 fields visible (NET / ACQUIRED / DISPOSED / TXNS / LATEST).