### PR TITLE
feat(#575): instrument detail polish round 2

### DIFF
--- a/docs/superpowers/plans/2026-04-27-instrument-detail-polish-round-2.md
+++ b/docs/superpowers/plans/2026-04-27-instrument-detail-polish-round-2.md
@@ -1,0 +1,1807 @@
+# Instrument Detail Polish Round 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land #575 — replace fixed `2fr_1fr_1fr` density grid with a 12-column capability-profiled layout, hide truly-empty panes, unbundle dividends+insider, standardize all panes on a new `<Pane>` + `<PaneHeader>` primitive.
+
+**Architecture:** Three stable layout profiles (`full-sec` / `partial-filings` / `minimal`) selected by `selectProfile(summary)`. Each pane component owns its own `<Pane>` chrome (no parent-renders-Pane double-wrap). Drill affordance is button-only on `PaneHeader` — no whole-card click. Empty-pane rule is four-state per spec Section D, gated mostly at the parent (`DensityGrid` decides which child components to mount based on capabilities).
+
+**Tech Stack:** TypeScript + React 18, Tailwind, Vitest + React Testing Library. No new runtime deps. Spec: `docs/superpowers/specs/2026-04-27-instrument-detail-polish-round-2-design.md`. Issue: #575. Sibling (independent): #576 chart route.
+
+**Branch:** `feature/575-instrument-detail-polish-round-2`
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0.1: Create branch from main**
+
+```bash
+git checkout main
+git pull --ff-only
+git checkout -b feature/575-instrument-detail-polish-round-2
+```
+
+- [ ] **Step 0.2: Confirm dev DB and stack already running**
+
+Per `feedback_keep_stack_running.md`: do NOT stop/restart backend/frontend. The VS Code task `Dev stack` is already running. If stack is down, ask the user before starting.
+
+Run: `pnpm --dir frontend test:unit -- --run` to confirm baseline test suite is green before starting.
+Expected: all existing instrument-page tests PASS.
+
+---
+
+## File Structure
+
+**New files:**
+- `frontend/src/components/instrument/PaneHeader.tsx` + test — header primitive (title · scope · source · `Open →` button)
+- `frontend/src/components/instrument/Pane.tsx` + test — outer card wrapper that renders `PaneHeader` + body, owned by individual pane components
+- `frontend/src/components/instrument/densityProfile.ts` + test — `selectProfile(summary)` returns `"full-sec" | "partial-filings" | "minimal"`
+- `frontend/src/components/instrument/RecentNewsPane.tsx` + test — new news pane that returns `null` when `data.items.length === 0`, replaces the placeholder `newsBlock` in `ResearchTab`
+- `frontend/src/components/instrument/KeyStatsPane.tsx` + test — extracted from `ResearchTab.keyStatsBlock`, now drops fully-null rows, keeps per-row `FieldSourceTag`
+- `frontend/src/components/instrument/ThesisPane.tsx` + test — extracted from `ResearchTab.ThesisPanel`, returns `null` when `thesis === null && !errored`
+
+**Modified files:**
+- `frontend/src/components/instrument/DensityGrid.tsx` — switch to `grid-cols-12`, three profile branches, mount child pane components conditionally (no `<Pane>` wrapping at this layer)
+- `frontend/src/components/instrument/ResearchTab.tsx` — thin pass-through; deletes its inline `keyStatsBlock` / `thesisBlock` / `newsBlock` JSX
+- `frontend/src/components/instrument/FilingsPane.tsx` — replace `<Section>` with `<Pane>`, drop the existing footer `View all filings →` link
+- `frontend/src/components/instrument/FundamentalsPane.tsx` — replace `<Section>` with `<Pane>`, drop the existing footer `View statements →` link
+- `frontend/src/components/instrument/InsiderActivitySummary.tsx` — replace `<Section>` with `<Pane>`
+- `frontend/src/components/instrument/SecProfilePanel.tsx` — replace `<Section>` with `<Pane>` (verify file exists; pane is invoked from `DensityGrid.tsx:69`)
+- `frontend/src/components/instrument/DividendsPanel.tsx` — replace `<Section>` with `<Pane>`, return `null` when both `history.length === 0` AND `upcoming.length === 0`, keep upcoming banner path
+- `frontend/src/components/instrument/BusinessSectionsTeaser.tsx` — replace `<Section>` (or its current chrome) with `<Pane>`, wire `onExpand` to existing 10-K narrative route
+
+**Tests touched:**
+- New per-component tests above
+- `DensityGrid.test.tsx` — extended fixtures for the three profiles + dividends/insider gating
+- Existing pane tests need touch-ups where they assert `Section` chrome (search before editing)
+
+---
+
+## Phase 1 — primitives (no behavior change visible to operator)
+
+### Task 1: PaneHeader component
+
+**Files:**
+- Create: `frontend/src/components/instrument/PaneHeader.tsx`
+- Test: `frontend/src/components/instrument/PaneHeader.test.tsx`
+
+- [ ] **Step 1.1: Write the failing test**
+
+```tsx
+// frontend/src/components/instrument/PaneHeader.test.tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { PaneHeader } from "./PaneHeader";
+
+describe("PaneHeader", () => {
+  it("renders title only with no optional props", () => {
+    render(<PaneHeader title="Recent filings" />);
+    expect(screen.getByRole("heading", { name: /recent filings/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /open/i })).not.toBeInTheDocument();
+  });
+
+  it("renders scope text when provided", () => {
+    render(<PaneHeader title="Insider activity" scope="last 90 days" />);
+    expect(screen.getByText("last 90 days")).toBeInTheDocument();
+  });
+
+  it("renders provider source label", () => {
+    render(
+      <PaneHeader
+        title="Recent filings"
+        source={{ providers: ["sec_edgar"] }}
+      />,
+    );
+    // providerLabel("sec_edgar") = "SEC EDGAR"
+    expect(screen.getByText(/SEC EDGAR/)).toBeInTheDocument();
+  });
+
+  it("renders Open button only when onExpand is defined and calls it on click", async () => {
+    const onExpand = vi.fn();
+    render(<PaneHeader title="Filings" onExpand={onExpand} />);
+    const btn = screen.getByRole("button", { name: /open/i });
+    await userEvent.click(btn);
+    expect(onExpand).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+```bash
+pnpm --dir frontend test:unit -- --run PaneHeader.test.tsx
+```
+
+Expected: FAIL with module-not-found or `PaneHeader is not a function`.
+
+- [ ] **Step 1.3: Implement PaneHeader**
+
+```tsx
+// frontend/src/components/instrument/PaneHeader.tsx
+import { providerLabel } from "@/lib/capabilityProviders";
+
+export interface PaneHeaderProps {
+  readonly title: string;
+  readonly scope?: string;
+  readonly source?: {
+    readonly providers: ReadonlyArray<string>;
+    readonly lastSync?: string;
+  };
+  readonly onExpand?: () => void;
+}
+
+export function PaneHeader({
+  title,
+  scope,
+  source,
+  onExpand,
+}: PaneHeaderProps): JSX.Element {
+  const sourceText =
+    source && source.providers.length > 0
+      ? source.providers.map(providerLabel).join(" · ") +
+        (source.lastSync ? ` · ${source.lastSync}` : "")
+      : null;
+  return (
+    <header className="flex items-baseline justify-between gap-2 border-b border-slate-100 pb-1.5">
+      <div className="flex min-w-0 items-baseline gap-2">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-600">
+          {title}
+        </h2>
+        {scope ? (
+          <span className="text-[10px] text-slate-500">{scope}</span>
+        ) : null}
+      </div>
+      <div className="flex flex-shrink-0 items-center gap-2">
+        {sourceText !== null ? (
+          <span
+            className="truncate rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600"
+            title={sourceText}
+          >
+            {sourceText}
+          </span>
+        ) : null}
+        {onExpand !== undefined ? (
+          <button
+            type="button"
+            onClick={onExpand}
+            className="text-[11px] text-sky-700 hover:underline focus-visible:rounded focus-visible:outline-2 focus-visible:outline-sky-500"
+          >
+            Open →
+          </button>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+```
+
+- [ ] **Step 1.4: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run PaneHeader.test.tsx
+```
+
+Expected: PASS (4 specs).
+
+- [ ] **Step 1.5: Typecheck**
+
+```bash
+pnpm --dir frontend typecheck
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add frontend/src/components/instrument/PaneHeader.tsx frontend/src/components/instrument/PaneHeader.test.tsx
+git commit -m "feat(#575-A): PaneHeader primitive — title/scope/source/Open button"
+```
+
+---
+
+### Task 2: Pane wrapper component
+
+**Files:**
+- Create: `frontend/src/components/instrument/Pane.tsx`
+- Test: `frontend/src/components/instrument/Pane.test.tsx`
+
+- [ ] **Step 2.1: Write the failing test**
+
+```tsx
+// frontend/src/components/instrument/Pane.test.tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { Pane } from "./Pane";
+
+describe("Pane", () => {
+  it("renders header title and body content", () => {
+    render(
+      <Pane title="Recent filings">
+        <p>row content</p>
+      </Pane>,
+    );
+    expect(screen.getByRole("heading", { name: /recent filings/i })).toBeInTheDocument();
+    expect(screen.getByText("row content")).toBeInTheDocument();
+  });
+
+  it("does not attach onClick to the outer article (button-only drill)", async () => {
+    const onExpand = vi.fn();
+    render(
+      <Pane title="Filings" onExpand={onExpand}>
+        <p>body</p>
+      </Pane>,
+    );
+    // Clicking the body must NOT trigger onExpand.
+    await userEvent.click(screen.getByText("body"));
+    expect(onExpand).not.toHaveBeenCalled();
+    // Clicking the Open button MUST trigger onExpand.
+    await userEvent.click(screen.getByRole("button", { name: /open/i }));
+    expect(onExpand).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2.2: Run test to verify it fails**
+
+```bash
+pnpm --dir frontend test:unit -- --run Pane.test.tsx
+```
+
+Expected: FAIL with module-not-found.
+
+- [ ] **Step 2.3: Implement Pane**
+
+```tsx
+// frontend/src/components/instrument/Pane.tsx
+import type { ReactNode } from "react";
+
+import { PaneHeader } from "./PaneHeader";
+import type { PaneHeaderProps } from "./PaneHeader";
+
+export interface PaneProps extends PaneHeaderProps {
+  readonly children: ReactNode;
+  /** Optional className overrides on the outer article. */
+  readonly className?: string;
+}
+
+export function Pane({
+  title,
+  scope,
+  source,
+  onExpand,
+  className,
+  children,
+}: PaneProps): JSX.Element {
+  return (
+    <article
+      className={`rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm ${className ?? ""}`}
+    >
+      <PaneHeader
+        title={title}
+        scope={scope}
+        source={source}
+        onExpand={onExpand}
+      />
+      <div className="mt-2">{children}</div>
+    </article>
+  );
+}
+```
+
+- [ ] **Step 2.4: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run Pane.test.tsx
+```
+
+Expected: PASS (2 specs).
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add frontend/src/components/instrument/Pane.tsx frontend/src/components/instrument/Pane.test.tsx
+git commit -m "feat(#575-A): Pane wrapper — article + PaneHeader, no whole-card click"
+```
+
+---
+
+### Task 3: densityProfile selector
+
+**Files:**
+- Create: `frontend/src/components/instrument/densityProfile.ts`
+- Test: `frontend/src/components/instrument/densityProfile.test.ts`
+
+- [ ] **Step 3.1: Write the failing test**
+
+```ts
+// frontend/src/components/instrument/densityProfile.test.ts
+import { describe, expect, it } from "vitest";
+
+import { selectProfile } from "./densityProfile";
+import type { InstrumentSummary } from "@/api/types";
+
+function fixture(overrides: Partial<InstrumentSummary["capabilities"]>): InstrumentSummary {
+  return {
+    instrument_id: 1,
+    is_tradable: true,
+    coverage_tier: 1,
+    identity: { symbol: "X", display_name: null, sector: null, market_cap: null } as never,
+    price: null,
+    key_stats: null,
+    source: {},
+    has_sec_cik: false,
+    has_filings_coverage: false,
+    capabilities: { ...overrides } as InstrumentSummary["capabilities"],
+  } as InstrumentSummary;
+}
+
+describe("selectProfile", () => {
+  it("returns full-sec when sec_xbrl fundamentals + filings both active", () => {
+    const summary = fixture({
+      fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: true } },
+      filings: { providers: ["sec_edgar"], data_present: { sec_edgar: true } },
+    });
+    expect(selectProfile(summary)).toBe("full-sec");
+  });
+
+  it("returns partial-filings when filings active but no sec_xbrl fundamentals", () => {
+    const summary = fixture({
+      filings: { providers: ["companies_house"], data_present: { companies_house: true } },
+    });
+    expect(selectProfile(summary)).toBe("partial-filings");
+  });
+
+  it("returns partial-filings when sec_xbrl listed but no data present", () => {
+    const summary = fixture({
+      fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: false } },
+      filings: { providers: ["sec_edgar"], data_present: { sec_edgar: true } },
+    });
+    expect(selectProfile(summary)).toBe("partial-filings");
+  });
+
+  it("returns minimal when no fundamentals and no filings", () => {
+    const summary = fixture({});
+    expect(selectProfile(summary)).toBe("minimal");
+  });
+});
+```
+
+- [ ] **Step 3.2: Run test to verify it fails**
+
+```bash
+pnpm --dir frontend test:unit -- --run densityProfile.test.ts
+```
+
+Expected: FAIL with module-not-found.
+
+- [ ] **Step 3.3: Implement selectProfile**
+
+```ts
+// frontend/src/components/instrument/densityProfile.ts
+import type { InstrumentSummary } from "@/api/types";
+import { activeProviders } from "@/lib/capabilityProviders";
+
+export type DensityProfile = "full-sec" | "partial-filings" | "minimal";
+
+const EMPTY_CELL = { providers: [] as string[], data_present: {} as Record<string, boolean> };
+
+export function selectProfile(summary: InstrumentSummary): DensityProfile {
+  const cap = summary.capabilities;
+  const fundCell = cap.fundamentals ?? EMPTY_CELL;
+  const hasFundamentals =
+    fundCell.providers.includes("sec_xbrl") &&
+    fundCell.data_present["sec_xbrl"] === true;
+  const hasFilings = activeProviders(cap.filings ?? EMPTY_CELL).length > 0;
+
+  if (hasFundamentals && hasFilings) return "full-sec";
+  if (hasFilings) return "partial-filings";
+  return "minimal";
+}
+```
+
+- [ ] **Step 3.4: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run densityProfile.test.ts
+```
+
+Expected: PASS (4 specs).
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add frontend/src/components/instrument/densityProfile.ts frontend/src/components/instrument/densityProfile.test.ts
+git commit -m "feat(#575-A): selectProfile — full-sec / partial-filings / minimal"
+```
+
+---
+
+## Phase 2 — wire panes (replace Section with Pane in each)
+
+### Task 4: FilingsPane uses Pane + drops footer link
+
+**Files:**
+- Modify: `frontend/src/components/instrument/FilingsPane.tsx`
+- Modify: `frontend/src/components/instrument/FilingsPane.test.tsx`
+
+- [ ] **Step 4.1: Update existing test to assert new chrome**
+
+The current test at `FilingsPane.test.tsx` asserts the footer `View all filings →` link. That assertion changes: the footer link is removed; the `Open →` button on `PaneHeader` replaces it.
+
+Read the file first, then replace the footer-link assertion with a `Open →` button assertion that triggers navigation to `?tab=filings`.
+
+```tsx
+// In FilingsPane.test.tsx, replace any test like:
+//   expect(screen.getByRole("link", { name: /view all filings/i })).toHaveAttribute("href", expect.stringContaining("?tab=filings"));
+// With:
+it("renders Open button when filings tab is active and routes to ?tab=filings", async () => {
+  // Set up the existing fixture used by the file (full SEC capability)
+  // ...
+  const btn = screen.getByRole("button", { name: /open/i });
+  await userEvent.click(btn);
+  // Assert navigation via the test's MemoryRouter / test history.
+  expect(window.location.search).toContain("tab=filings"); // or use the test's navigate spy
+});
+```
+
+If the existing test uses a `navigate` mock from `react-router-dom`, mock-call the spy and assert it was called with the right URL.
+
+- [ ] **Step 4.2: Run test to verify it fails**
+
+```bash
+pnpm --dir frontend test:unit -- --run FilingsPane.test.tsx
+```
+
+Expected: FAIL — old footer assertion still runs and the new `Open` assertion does not yet match.
+
+- [ ] **Step 4.3: Modify FilingsPane to use Pane + onExpand**
+
+```tsx
+// frontend/src/components/instrument/FilingsPane.tsx
+// Replace the existing return-statement chrome:
+
+import { useNavigate } from "react-router-dom";
+import { Pane } from "@/components/instrument/Pane";
+
+// inside the component:
+const navigate = useNavigate();
+
+// Replace <Section title="Recent filings"> ... </Section> with:
+return (
+  <Pane
+    title="Recent filings"
+    scope="high-signal types"
+    source={{ providers: filingsCell?.providers ?? [] }}
+    onExpand={
+      filingsTabActive
+        ? () => navigate(`/instrument/${encodeURIComponent(symbol)}?tab=filings`)
+        : undefined
+    }
+  >
+    {/* existing body of the Section here, MINUS the
+        "View all filings →" footer block at the bottom */}
+  </Pane>
+);
+```
+
+Delete the entire `{filingsTabActive && (<div className="mt-2 border-t ...">...)}` footer block at `FilingsPane.tsx:134-143`.
+
+Remove the now-unused `Link` import if it's no longer referenced inside the row rendering (it is — row drilldowns still use `Link`, so keep the import).
+
+- [ ] **Step 4.4: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run FilingsPane.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add frontend/src/components/instrument/FilingsPane.tsx frontend/src/components/instrument/FilingsPane.test.tsx
+git commit -m "feat(#575-B): FilingsPane uses Pane + Open button replaces footer link"
+```
+
+---
+
+### Task 5: FundamentalsPane uses Pane + drops footer link
+
+**Files:**
+- Modify: `frontend/src/components/instrument/FundamentalsPane.tsx`
+- Modify: `frontend/src/components/instrument/FundamentalsPane.test.tsx`
+
+- [ ] **Step 5.1: Update test**
+
+Replace any assertion against the existing `View statements →` footer link with one against the `Open` button on `PaneHeader`. Same pattern as Task 4.
+
+- [ ] **Step 5.2: Run test to verify it fails**
+
+```bash
+pnpm --dir frontend test:unit -- --run FundamentalsPane.test.tsx
+```
+
+Expected: FAIL.
+
+- [ ] **Step 5.3: Modify FundamentalsPane**
+
+```tsx
+// frontend/src/components/instrument/FundamentalsPane.tsx
+import { useNavigate } from "react-router-dom";
+import { Pane } from "@/components/instrument/Pane";
+
+// inside the component, replace <Section title="Fundamentals"> ... </Section> with:
+const navigate = useNavigate();
+return (
+  <Pane
+    title="Fundamentals"
+    scope="last 8 quarters"
+    source={{ providers: ["sec_xbrl"] }}
+    onExpand={() => navigate(`/instrument/${encodeURIComponent(symbol)}?tab=financials`)}
+  >
+    {/* existing loading / error / empty / data branches MINUS the
+        "View statements →" footer block at FundamentalsPane.tsx:166-173 */}
+  </Pane>
+);
+```
+
+Delete the `<div className="mt-2 border-t border-slate-100 pt-1.5 text-right">` footer + its `<Link>` to `?tab=financials`.
+
+- [ ] **Step 5.4: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run FundamentalsPane.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add frontend/src/components/instrument/FundamentalsPane.tsx frontend/src/components/instrument/FundamentalsPane.test.tsx
+git commit -m "feat(#575-B): FundamentalsPane uses Pane + Open button replaces footer link"
+```
+
+---
+
+### Task 6: InsiderActivitySummary uses Pane
+
+**Files:**
+- Modify: `frontend/src/components/instrument/InsiderActivitySummary.tsx`
+- Modify: `frontend/src/components/instrument/InsiderActivitySummary.test.tsx`
+
+- [ ] **Step 6.1: Update test**
+
+Existing test asserts the four metric labels render — keep that. Add an assertion that the `<Pane>` chrome shows scope `last 90 days` and source `SEC Form 4`.
+
+```tsx
+// add to existing test file
+it("renders Pane chrome with scope and source", () => {
+  // existing setup ...
+  expect(screen.getByText("last 90 days")).toBeInTheDocument();
+  expect(screen.getByText(/SEC Form 4/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 6.2: Run test to verify it fails**
+
+```bash
+pnpm --dir frontend test:unit -- --run InsiderActivitySummary.test.tsx
+```
+
+Expected: FAIL — scope text not yet rendered.
+
+- [ ] **Step 6.3: Modify InsiderActivitySummary**
+
+Replace `<Section title="Insider activity (90d)">` with:
+
+```tsx
+<Pane
+  title="Insider activity"
+  scope="last 90 days"
+  source={{ providers: ["sec_form4"] }}
+>
+  {/* existing body unchanged */}
+</Pane>
+```
+
+(`onExpand` undefined — no insider tab/route exists yet.)
+
+Update import: drop `Section` (keep `SectionError`, `SectionSkeleton`); add `import { Pane } from "@/components/instrument/Pane";`.
+
+- [ ] **Step 6.4: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run InsiderActivitySummary.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add frontend/src/components/instrument/InsiderActivitySummary.tsx frontend/src/components/instrument/InsiderActivitySummary.test.tsx
+git commit -m "feat(#575-B): InsiderActivitySummary uses Pane (scope last 90 days)"
+```
+
+---
+
+### Task 7: SecProfilePanel uses Pane
+
+**Files:**
+- Modify: `frontend/src/components/instrument/SecProfilePanel.tsx`
+- Modify: `frontend/src/components/instrument/SecProfilePanel.test.tsx`
+
+- [ ] **Step 7.1: Update test**
+
+Add assertion that the source label `SEC EDGAR` renders in the Pane chrome.
+
+```tsx
+it("renders Pane chrome with sec_edgar source", () => {
+  // existing setup ...
+  expect(screen.getByText(/SEC EDGAR/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 7.2: Run test to verify it fails**
+
+```bash
+pnpm --dir frontend test:unit -- --run SecProfilePanel.test.tsx
+```
+
+Expected: FAIL.
+
+- [ ] **Step 7.3: Modify SecProfilePanel**
+
+Replace its existing chrome (currently uses `<Section>` per `DensityGrid.tsx:69-72`) with:
+
+```tsx
+<Pane
+  title="Company profile"
+  source={{ providers: ["sec_edgar"] }}
+>
+  {/* existing body */}
+</Pane>
+```
+
+(`scope` undefined; `onExpand` undefined — no dedicated SEC profile route yet.)
+
+- [ ] **Step 7.4: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run SecProfilePanel.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add frontend/src/components/instrument/SecProfilePanel.tsx frontend/src/components/instrument/SecProfilePanel.test.tsx
+git commit -m "feat(#575-B): SecProfilePanel uses Pane"
+```
+
+---
+
+### Task 8: BusinessSectionsTeaser uses Pane
+
+**Files:**
+- Modify: `frontend/src/components/instrument/BusinessSectionsTeaser.tsx`
+- Modify: existing test if one exists (check via `ls`)
+
+- [ ] **Step 8.1: Identify existing 10-K narrative route**
+
+```bash
+grep -rn "/filings/10-k" frontend/src/components/ frontend/src/pages/
+```
+
+Use the discovered path (likely `/instrument/:symbol/filings/10-k`) as the `onExpand` target.
+
+- [ ] **Step 8.2: Modify BusinessSectionsTeaser to use Pane with onExpand**
+
+Replace the existing chrome with:
+
+```tsx
+import { useNavigate } from "react-router-dom";
+import { Pane } from "@/components/instrument/Pane";
+
+// inside component:
+const navigate = useNavigate();
+return (
+  <Pane
+    title="Company narrative"
+    scope="10-K Item 1"
+    source={{ providers: ["sec_10k_item1"] }}
+    onExpand={() => navigate(`/instrument/${encodeURIComponent(symbol)}/filings/10-k`)}
+  >
+    {/* existing teaser body, drop the inline "View full 10-K narrative →"
+        link if present (replaced by Open → button) */}
+  </Pane>
+);
+```
+
+- [ ] **Step 8.3: Update test if existing**
+
+If `BusinessSectionsTeaser.test.tsx` exists, update assertions: drop `View full 10-K narrative` link assertion; add `Open` button assertion.
+
+If no test exists, write one:
+
+```tsx
+// new file frontend/src/components/instrument/BusinessSectionsTeaser.test.tsx
+// (only if no existing test) — minimal coverage of Pane chrome + Open button.
+```
+
+- [ ] **Step 8.4: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run BusinessSectionsTeaser.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add frontend/src/components/instrument/BusinessSectionsTeaser.tsx
+# include test file if changed/created
+git commit -m "feat(#575-B): BusinessSectionsTeaser uses Pane + Open routes to 10-K"
+```
+
+---
+
+## Phase 3 — empty-pane suppression
+
+### Task 9: ThesisPane component (extracted from ResearchTab)
+
+**Files:**
+- Create: `frontend/src/components/instrument/ThesisPane.tsx`
+- Create: `frontend/src/components/instrument/ThesisPane.test.tsx`
+
+- [ ] **Step 9.1: Write the failing test**
+
+```tsx
+// frontend/src/components/instrument/ThesisPane.test.tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ThesisPane } from "./ThesisPane";
+import type { ThesisDetail } from "@/api/types";
+
+const FIXTURE: ThesisDetail = {
+  thesis_id: 1,
+  instrument_id: 1,
+  memo_markdown: "Buy on weakness.",
+  bear_value: "10",
+  base_value: "20",
+  bull_value: "30",
+  break_conditions_json: ["Lose 50% market share"],
+} as ThesisDetail;
+
+describe("ThesisPane", () => {
+  it("renders memo + bear/base/bull when thesis present", () => {
+    const { container } = render(<ThesisPane thesis={FIXTURE} errored={false} />);
+    expect(screen.getByText("Buy on weakness.")).toBeInTheDocument();
+    expect(screen.getByText("Bear")).toBeInTheDocument();
+    expect(container.querySelector("article")).not.toBeNull();
+  });
+
+  it("returns null when thesis is null and not errored (no card)", () => {
+    const { container } = render(<ThesisPane thesis={null} errored={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders error UI inside Pane when errored", () => {
+    render(<ThesisPane thesis={null} errored={true} />);
+    expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 9.2: Run test to verify it fails**
+
+```bash
+pnpm --dir frontend test:unit -- --run ThesisPane.test.tsx
+```
+
+Expected: FAIL.
+
+- [ ] **Step 9.3: Implement ThesisPane**
+
+Copy the existing `ThesisPanel` body from `ResearchTab.tsx:88-155` into a new component. Wrap in `<Pane>`. When `thesis === null && !errored`, return `null`.
+
+```tsx
+// frontend/src/components/instrument/ThesisPane.tsx
+import { Pane } from "@/components/instrument/Pane";
+import { EmptyState } from "@/components/states/EmptyState";
+import type { ThesisDetail } from "@/api/types";
+
+export interface ThesisPaneProps {
+  readonly thesis: ThesisDetail | null;
+  readonly errored: boolean;
+}
+
+export function ThesisPane({ thesis, errored }: ThesisPaneProps): JSX.Element | null {
+  if (thesis === null && !errored) return null;
+
+  return (
+    <Pane title="Thesis">
+      {errored ? (
+        <EmptyState
+          title="Thesis temporarily unavailable"
+          description="Failed to fetch the latest thesis. Retry via the Generate thesis button in the strip above."
+        />
+      ) : (
+        <ThesisBody thesis={thesis as ThesisDetail} />
+      )}
+    </Pane>
+  );
+}
+
+function ThesisBody({ thesis }: { thesis: ThesisDetail }): JSX.Element {
+  const breaks = thesis.break_conditions_json ?? [];
+  return (
+    <div className="space-y-3 text-sm">
+      <div className="whitespace-pre-wrap text-slate-700">{thesis.memo_markdown}</div>
+      {(thesis.base_value !== null ||
+        thesis.bull_value !== null ||
+        thesis.bear_value !== null) && (
+        <dl className="grid grid-cols-3 gap-2 rounded bg-slate-50 p-3 text-xs">
+          <div>
+            <dt className="text-slate-500">Bear</dt>
+            <dd className="font-medium tabular-nums">
+              {thesis.bear_value !== null ? thesis.bear_value : "—"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-slate-500">Base</dt>
+            <dd className="font-medium tabular-nums">
+              {thesis.base_value !== null ? thesis.base_value : "—"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-slate-500">Bull</dt>
+            <dd className="font-medium tabular-nums">
+              {thesis.bull_value !== null ? thesis.bull_value : "—"}
+            </dd>
+          </div>
+        </dl>
+      )}
+      {breaks.length > 0 && (
+        <div>
+          <div className="mb-1 text-xs font-medium uppercase tracking-wider text-slate-500">
+            Break conditions
+          </div>
+          <ul className="list-inside list-disc space-y-0.5 text-xs text-slate-600">
+            {breaks.map((b, i) => (
+              <li key={i}>{b}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 9.4: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run ThesisPane.test.tsx
+```
+
+Expected: PASS (3 specs).
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add frontend/src/components/instrument/ThesisPane.tsx frontend/src/components/instrument/ThesisPane.test.tsx
+git commit -m "feat(#575-C): ThesisPane returns null when empty + not errored"
+```
+
+---
+
+### Task 10: KeyStatsPane component (extracted from ResearchTab)
+
+**Files:**
+- Create: `frontend/src/components/instrument/KeyStatsPane.tsx`
+- Create: `frontend/src/components/instrument/KeyStatsPane.test.tsx`
+
+- [ ] **Step 10.1: Write the failing test**
+
+```tsx
+// frontend/src/components/instrument/KeyStatsPane.test.tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { KeyStatsPane } from "./KeyStatsPane";
+import type { InstrumentSummary } from "@/api/types";
+
+function fixture(stats: Partial<InstrumentSummary["key_stats"]> | null): InstrumentSummary {
+  return {
+    identity: { symbol: "X", display_name: null, sector: null, market_cap: "1000000000" },
+    key_stats: stats === null ? null : ({
+      pe_ratio: "32.48",
+      pb_ratio: null,
+      dividend_yield: null,
+      payout_ratio: null,
+      roe: null,
+      roa: null,
+      debt_to_equity: "3.15",
+      revenue_growth_yoy: null,
+      earnings_growth_yoy: null,
+      field_source: { pe_ratio: "sec_xbrl", debt_to_equity: "sec_xbrl" },
+      ...stats,
+    } as InstrumentSummary["key_stats"]),
+    capabilities: {},
+  } as InstrumentSummary;
+}
+
+describe("KeyStatsPane", () => {
+  it("renders rows with non-null values, drops fully-null rows", () => {
+    render(<KeyStatsPane summary={fixture({})} />);
+    expect(screen.getByText("P/E ratio")).toBeInTheDocument();
+    expect(screen.getByText("Debt / Equity")).toBeInTheDocument();
+    // Dividend yield is null → row dropped.
+    expect(screen.queryByText("Dividend yield")).not.toBeInTheDocument();
+    // Per-row source tag still rendered.
+    expect(screen.getAllByText(/SEC$/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders empty state when key_stats is null", () => {
+    render(<KeyStatsPane summary={fixture(null)} />);
+    expect(screen.getByText(/No key stats/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 10.2: Run test to verify it fails**
+
+```bash
+pnpm --dir frontend test:unit -- --run KeyStatsPane.test.tsx
+```
+
+Expected: FAIL.
+
+- [ ] **Step 10.3: Implement KeyStatsPane**
+
+Move `keyStatsBlock` body, `formatDecimal`, `formatMarketCap`, `FieldSourceTag`, `KeyStat` from `ResearchTab.tsx` into the new component. Wrap in `<Pane>`. Drop rows whose `value` is `null`.
+
+```tsx
+// frontend/src/components/instrument/KeyStatsPane.tsx
+import { Pane } from "@/components/instrument/Pane";
+import { EmptyState } from "@/components/states/EmptyState";
+import type { InstrumentSummary, KeyStatsFieldSource } from "@/api/types";
+
+function formatDecimal(
+  value: string | null | undefined,
+  opts: { percent?: boolean } = {},
+): string | null {
+  if (value === null || value === undefined) return null;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  if (opts.percent) return `${(num * 100).toFixed(2)}%`;
+  return num.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
+function formatMarketCap(value: string | null): string | null {
+  if (value === null) return null;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  if (num >= 1e12) return `${(num / 1e12).toFixed(2)}T`;
+  if (num >= 1e9) return `${(num / 1e9).toFixed(2)}B`;
+  if (num >= 1e6) return `${(num / 1e6).toFixed(2)}M`;
+  return num.toLocaleString();
+}
+
+function FieldSourceTag({ source }: { source: string | undefined }) {
+  if (!source) return null;
+  let tone = "bg-slate-100 text-slate-600";
+  let label = source;
+  switch (source) {
+    case "sec_xbrl":
+      tone = "bg-emerald-50 text-emerald-700";
+      label = "SEC";
+      break;
+    case "sec_dividend_summary":
+      tone = "bg-emerald-50 text-emerald-700";
+      label = "SEC · div";
+      break;
+    case "sec_xbrl_price_missing":
+      tone = "bg-amber-50 text-amber-700";
+      label = "SEC · price?";
+      break;
+    case "unavailable":
+      tone = "bg-slate-100 text-slate-500";
+      label = "—";
+      break;
+  }
+  return (
+    <span className={`ml-2 rounded px-1.5 py-0.5 text-[10px] uppercase ${tone}`}>
+      {label}
+    </span>
+  );
+}
+
+interface Row {
+  label: string;
+  value: string;
+  source?: string;
+}
+
+function buildRows(summary: InstrumentSummary): Row[] {
+  const stats = summary.key_stats;
+  if (stats === null) return [];
+  const fs = (stats.field_source ?? {}) as Record<string, KeyStatsFieldSource>;
+  const candidates: Array<Row | null> = [
+    cap(formatMarketCap(summary.identity.market_cap), "Market cap", undefined),
+    cap(formatDecimal(stats.pe_ratio), "P/E ratio", fs.pe_ratio),
+    cap(formatDecimal(stats.pb_ratio), "P/B ratio", fs.pb_ratio),
+    cap(formatDecimal(stats.dividend_yield, { percent: true }), "Dividend yield", fs.dividend_yield),
+    cap(formatDecimal(stats.payout_ratio, { percent: true }), "Payout ratio", fs.payout_ratio),
+    cap(formatDecimal(stats.roe, { percent: true }), "ROE", fs.roe),
+    cap(formatDecimal(stats.roa, { percent: true }), "ROA", fs.roa),
+    cap(formatDecimal(stats.debt_to_equity), "Debt / Equity", fs.debt_to_equity),
+    cap(formatDecimal(stats.revenue_growth_yoy, { percent: true }), "Revenue growth (YoY)", fs.revenue_growth_yoy),
+    cap(formatDecimal(stats.earnings_growth_yoy, { percent: true }), "Earnings growth (YoY)", fs.earnings_growth_yoy),
+  ];
+  return candidates.filter((r): r is Row => r !== null);
+}
+
+function cap(value: string | null, label: string, source: string | undefined): Row | null {
+  if (value === null) return null;
+  return { label, value, source };
+}
+
+export interface KeyStatsPaneProps {
+  readonly summary: InstrumentSummary;
+}
+
+export function KeyStatsPane({ summary }: KeyStatsPaneProps): JSX.Element {
+  const rows = buildRows(summary);
+  return (
+    <Pane title="Key statistics">
+      {summary.key_stats === null ? (
+        <EmptyState
+          title="No key stats"
+          description="No provider returned key stats for this ticker."
+        />
+      ) : (
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          {rows.map((r) => (
+            <KeyStatRow key={r.label} row={r} />
+          ))}
+        </dl>
+      )}
+    </Pane>
+  );
+}
+
+function KeyStatRow({ row }: { row: Row }) {
+  return (
+    <>
+      <dt className="text-slate-500">{row.label}</dt>
+      <dd className="flex items-center tabular-nums">
+        <span>{row.value}</span>
+        <FieldSourceTag source={row.source} />
+      </dd>
+    </>
+  );
+}
+```
+
+- [ ] **Step 10.4: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run KeyStatsPane.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add frontend/src/components/instrument/KeyStatsPane.tsx frontend/src/components/instrument/KeyStatsPane.test.tsx
+git commit -m "feat(#575-C): KeyStatsPane drops fully-null rows, keeps per-row source tags"
+```
+
+---
+
+### Task 11: RecentNewsPane component
+
+**Files:**
+- Create: `frontend/src/components/instrument/RecentNewsPane.tsx`
+- Create: `frontend/src/components/instrument/RecentNewsPane.test.tsx`
+
+- [ ] **Step 11.1: Write the failing test**
+
+```tsx
+// frontend/src/components/instrument/RecentNewsPane.test.tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { RecentNewsPane } from "./RecentNewsPane";
+import * as newsApi from "@/api/news";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("RecentNewsPane", () => {
+  it("renders up to 5 items when feed has data", async () => {
+    vi.spyOn(newsApi, "fetchNews").mockResolvedValueOnce({
+      items: Array.from({ length: 7 }).map((_, i) => ({
+        news_event_id: i,
+        event_time: "2026-04-20T00:00:00Z",
+        headline: `Headline ${i}`,
+        snippet: null,
+        category: null,
+        sentiment_score: null,
+        source: null,
+        url: null,
+      })),
+      total: 7,
+    } as never);
+    render(
+      <MemoryRouter>
+        <RecentNewsPane instrumentId={1} symbol="X" />
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(screen.getAllByText(/^Headline /).length).toBeLessThanOrEqual(5),
+    );
+  });
+
+  it("returns null when feed is empty (no card)", async () => {
+    vi.spyOn(newsApi, "fetchNews").mockResolvedValueOnce({
+      items: [],
+      total: 0,
+    } as never);
+    const { container } = render(
+      <MemoryRouter>
+        <RecentNewsPane instrumentId={1} symbol="X" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
+});
+```
+
+- [ ] **Step 11.2: Run test to verify it fails**
+
+```bash
+pnpm --dir frontend test:unit -- --run RecentNewsPane.test.tsx
+```
+
+Expected: FAIL.
+
+- [ ] **Step 11.3: Implement RecentNewsPane**
+
+```tsx
+// frontend/src/components/instrument/RecentNewsPane.tsx
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { fetchNews } from "@/api/news";
+import type { NewsListResponse } from "@/api/types";
+import { Pane } from "@/components/instrument/Pane";
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { useAsync } from "@/lib/useAsync";
+
+const ROW_LIMIT = 5;
+
+export interface RecentNewsPaneProps {
+  readonly instrumentId: number;
+  readonly symbol: string;
+}
+
+export function RecentNewsPane({
+  instrumentId,
+  symbol,
+}: RecentNewsPaneProps): JSX.Element | null {
+  const state = useAsync<NewsListResponse>(
+    useCallback(() => fetchNews(instrumentId, 0, ROW_LIMIT), [instrumentId]),
+    [instrumentId],
+  );
+  const navigate = useNavigate();
+
+  if (state.loading) {
+    return (
+      <Pane title="Recent news">
+        <SectionSkeleton rows={4} />
+      </Pane>
+    );
+  }
+  if (state.error !== null) {
+    return (
+      <Pane title="Recent news">
+        <SectionError onRetry={state.refetch} />
+      </Pane>
+    );
+  }
+  if (state.data === null || state.data.items.length === 0) {
+    return null;
+  }
+
+  const items = state.data.items.slice(0, ROW_LIMIT);
+  return (
+    <Pane
+      title="Recent news"
+      onExpand={() => navigate(`/instrument/${encodeURIComponent(symbol)}?tab=news`)}
+    >
+      <ul className="space-y-1.5 text-xs">
+        {items.map((n) => (
+          <li key={n.news_event_id} className="flex items-baseline gap-2">
+            <span className="text-slate-500">{n.event_time.slice(0, 10)}</span>
+            <span className="truncate text-slate-700">{n.headline}</span>
+          </li>
+        ))}
+      </ul>
+    </Pane>
+  );
+}
+```
+
+- [ ] **Step 11.4: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run RecentNewsPane.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+git add frontend/src/components/instrument/RecentNewsPane.tsx frontend/src/components/instrument/RecentNewsPane.test.tsx
+git commit -m "feat(#575-C): RecentNewsPane — top 5 items, returns null when empty"
+```
+
+---
+
+### Task 12: DividendsPanel — Pane wrapper + null when empty AND no upcoming
+
+**Files:**
+- Modify: `frontend/src/components/instrument/DividendsPanel.tsx`
+- Modify: `frontend/src/components/instrument/DividendsPanel.test.tsx`
+
+- [ ] **Step 12.1: Update test**
+
+Add three cases to the existing test:
+
+```tsx
+it("returns null when history is empty AND upcoming is empty", async () => {
+  vi.spyOn(api, "fetchInstrumentDividends").mockResolvedValueOnce({
+    symbol: "X",
+    summary: { has_dividend: false } as never,
+    history: [],
+    upcoming: [],
+  } as never);
+  const { container } = render(<DividendsPanel symbol="X" provider="sec_dividend_summary" />);
+  await waitFor(() => expect(container.firstChild).toBeNull());
+});
+
+it("renders Pane when history is empty but upcoming has 1 item", async () => {
+  vi.spyOn(api, "fetchInstrumentDividends").mockResolvedValueOnce({
+    symbol: "X",
+    summary: { has_dividend: true } as never,
+    history: [],
+    upcoming: [{ ex_date: "2026-05-01" } as never],
+  } as never);
+  render(<DividendsPanel symbol="X" provider="sec_dividend_summary" />);
+  await waitFor(() => expect(screen.getByText(/Dividends/)).toBeInTheDocument());
+});
+
+it("uses Pane chrome with provider source label", async () => {
+  // existing renders-history test setup …
+  expect(screen.getByText(/SEC dividends/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 12.2: Run test to verify it fails**
+
+```bash
+pnpm --dir frontend test:unit -- --run DividendsPanel.test.tsx
+```
+
+Expected: FAIL.
+
+- [ ] **Step 12.3: Modify DividendsPanel**
+
+Replace `<Section title={title}>` with `<Pane title="Dividends" source={{ providers: [provider] }}>`.
+
+Insert the early-return after data is loaded (before the existing JSX):
+
+```tsx
+if (
+  state.data !== null &&
+  state.error === null &&
+  !state.loading &&
+  state.data.history.length === 0 &&
+  state.data.upcoming.length === 0
+) {
+  return null;
+}
+```
+
+Keep the existing upcoming banner + history rendering branches inside the `<Pane>`.
+
+Drop import of `Section` (keep `SectionError`, `SectionSkeleton`); drop the `EmptyState` "No dividend history on file" branch — the early-return covers it.
+
+Drop the now-unused `providerLabel` if no longer referenced (it WILL still be referenced by Pane via PaneHeader, but not directly here — verify before removing).
+
+- [ ] **Step 12.4: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run DividendsPanel.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 12.5: Commit**
+
+```bash
+git add frontend/src/components/instrument/DividendsPanel.tsx frontend/src/components/instrument/DividendsPanel.test.tsx
+git commit -m "feat(#575-C): DividendsPanel returns null when history+upcoming both empty"
+```
+
+---
+
+## Phase 4 — layout (the visible flip)
+
+### Task 13: DensityGrid switches to grid-cols-12 + three profiles
+
+**Files:**
+- Modify: `frontend/src/components/instrument/DensityGrid.tsx`
+- Modify: `frontend/src/components/instrument/ResearchTab.tsx`
+- Modify: `frontend/src/components/instrument/DensityGrid.test.tsx`
+
+- [ ] **Step 13.1: Update DensityGrid.test.tsx with three-profile fixtures**
+
+Add three new test cases (full-sec, partial-filings, minimal). Replace any test asserting the old `2fr_1fr_1fr` grid class with the new `grid-cols-12` class. Assert pane visibility per profile.
+
+```tsx
+// frontend/src/components/instrument/DensityGrid.test.tsx
+// (extend existing file)
+
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+const baseSummary = (caps: InstrumentSummary["capabilities"]): InstrumentSummary => ({
+  /* fixture builder reused across cases — full path here */
+} as InstrumentSummary);
+
+describe("DensityGrid profiles", () => {
+  it("full-sec: renders fundamentals + filings + insider panes", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid summary={baseSummary({
+          fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: true } },
+          filings: { providers: ["sec_edgar"], data_present: { sec_edgar: true } },
+          insider: { providers: ["sec_form4"], data_present: { sec_form4: true } },
+        })} thesis={null} thesisErrored={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("heading", { name: /Fundamentals/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Recent filings/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Insider activity/i })).toBeInTheDocument();
+  });
+
+  it("partial-filings: no fundamentals pane; insider+dividends share row 4 if both active", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid summary={baseSummary({
+          filings: { providers: ["companies_house"], data_present: { companies_house: true } },
+          insider: { providers: ["sec_form4"], data_present: { sec_form4: true } },
+          dividends: { providers: ["sec_dividend_summary"], data_present: { sec_dividend_summary: true } },
+        })} thesis={null} thesisErrored={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole("heading", { name: /^Fundamentals$/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Recent filings/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Insider activity/i })).toBeInTheDocument();
+    // Dividends pane mounted (renders if upcoming or history present in mock)
+  });
+
+  it("minimal: chart + key stats only (when no thesis, no dividends, no news)", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid summary={baseSummary({})} thesis={null} thesisErrored={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole("heading", { name: /Recent filings/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /^Fundamentals$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /Insider activity/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Key statistics/i })).toBeInTheDocument();
+  });
+
+  it("thesis pane absent when thesis is null and not errored", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid summary={baseSummary({})} thesis={null} thesisErrored={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole("heading", { name: /^Thesis$/i })).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 13.2: Run test to verify it fails**
+
+```bash
+pnpm --dir frontend test:unit -- --run DensityGrid.test.tsx
+```
+
+Expected: FAIL — DensityGrid still uses the old grid + still renders thesis as full empty card.
+
+- [ ] **Step 13.3: Rewrite DensityGrid**
+
+```tsx
+// frontend/src/components/instrument/DensityGrid.tsx
+import { activeProviders } from "@/lib/capabilityProviders";
+import type { InstrumentSummary, ThesisDetail } from "@/api/types";
+
+import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSectionsTeaser";
+import { DividendsPanel } from "@/components/instrument/DividendsPanel";
+import { FilingsPane } from "@/components/instrument/FilingsPane";
+import { FundamentalsPane } from "@/components/instrument/FundamentalsPane";
+import { InsiderActivitySummary } from "@/components/instrument/InsiderActivitySummary";
+import { KeyStatsPane } from "@/components/instrument/KeyStatsPane";
+import { Pane } from "@/components/instrument/Pane";
+import { PriceChart } from "@/components/instrument/PriceChart";
+import { RecentNewsPane } from "@/components/instrument/RecentNewsPane";
+import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
+import { ThesisPane } from "@/components/instrument/ThesisPane";
+import { selectProfile } from "@/components/instrument/densityProfile";
+
+export interface DensityGridProps {
+  readonly summary: InstrumentSummary;
+  readonly thesis: ThesisDetail | null;
+  readonly thesisErrored: boolean;
+}
+
+export function DensityGrid({
+  summary,
+  thesis,
+  thesisErrored,
+}: DensityGridProps): JSX.Element {
+  const symbol = summary.identity.symbol;
+  const instrumentId = summary.instrument_id;
+  const profile = selectProfile(summary);
+  const cap = summary.capabilities;
+  const hasInsider = activeProviders(cap.insider ?? { providers: [], data_present: {} }).length > 0;
+  const hasDividends = activeProviders(cap.dividends ?? { providers: [], data_present: {} }).length > 0;
+  const dividendProviders = activeProviders(cap.dividends ?? { providers: [], data_present: {} });
+  const hasFilings = activeProviders(cap.filings ?? { providers: [], data_present: {} }).length > 0;
+  const hasNarrative = summary.has_sec_cik;
+
+  // Wrap PriceChart in a Pane locally (it doesn't own one yet — keep the
+  // change localized; if/when chart route #576 lands, lift this into PriceChart).
+  const ChartPane = (
+    <Pane title="Price chart">
+      <PriceChart symbol={symbol} />
+    </Pane>
+  );
+
+  const KeyStats = <KeyStatsPane summary={summary} />;
+  const SecProfile = hasNarrative ? <SecProfilePanel symbol={symbol} /> : null;
+  const Thesis = <ThesisPane thesis={thesis} errored={thesisErrored} />;
+  const News = <RecentNewsPane instrumentId={instrumentId} symbol={symbol} />;
+  const Narrative = hasNarrative ? <BusinessSectionsTeaser symbol={symbol} /> : null;
+
+  if (profile === "full-sec") {
+    return (
+      <div className="grid grid-cols-12 gap-2">
+        <div className="col-span-12 lg:col-span-8 lg:row-span-2">{ChartPane}</div>
+        <div className="col-span-12 lg:col-span-4">{KeyStats}</div>
+        <div className="col-span-12 lg:col-span-4">{SecProfile}</div>
+        <div className="col-span-12">
+          <FundamentalsPane summary={summary} />
+        </div>
+        {hasFilings && (
+          <div className="col-span-12 lg:col-span-7">
+            <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
+          </div>
+        )}
+        {hasInsider && (
+          <div className="col-span-12 lg:col-span-5">
+            <InsiderActivitySummary symbol={symbol} />
+          </div>
+        )}
+        {Narrative !== null && <div className="col-span-12">{Narrative}</div>}
+        {hasDividends && (
+          <div className="col-span-12">
+            {dividendProviders.map((p) => (
+              <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
+            ))}
+          </div>
+        )}
+        <div className="col-span-12">{News}</div>
+        <div className="col-span-12">{Thesis}</div>
+      </div>
+    );
+  }
+
+  if (profile === "partial-filings") {
+    return (
+      <div className="grid grid-cols-12 gap-2">
+        <div className="col-span-12 lg:col-span-8 lg:row-span-2">{ChartPane}</div>
+        <div className="col-span-12 lg:col-span-4">{KeyStats}</div>
+        {SecProfile !== null && <div className="col-span-12 lg:col-span-4">{SecProfile}</div>}
+        {hasFilings && (
+          <div className="col-span-12">
+            <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
+          </div>
+        )}
+        {hasInsider && hasDividends && (
+          <>
+            <div className="col-span-12 lg:col-span-7">
+              <InsiderActivitySummary symbol={symbol} />
+            </div>
+            <div className="col-span-12 lg:col-span-5">
+              {dividendProviders.map((p) => (
+                <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
+              ))}
+            </div>
+          </>
+        )}
+        {hasInsider && !hasDividends && (
+          <div className="col-span-12">
+            <InsiderActivitySummary symbol={symbol} />
+          </div>
+        )}
+        {!hasInsider && hasDividends && (
+          <div className="col-span-12">
+            {dividendProviders.map((p) => (
+              <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
+            ))}
+          </div>
+        )}
+        {Narrative !== null && <div className="col-span-12">{Narrative}</div>}
+        <div className="col-span-12">{News}</div>
+        <div className="col-span-12">{Thesis}</div>
+      </div>
+    );
+  }
+
+  // minimal
+  return (
+    <div className="grid grid-cols-12 gap-2">
+      <div className="col-span-12 lg:col-span-8 lg:row-span-2">{ChartPane}</div>
+      <div className="col-span-12 lg:col-span-4">{KeyStats}</div>
+      <div className="col-span-12 lg:col-span-4">{Thesis}</div>
+      {hasDividends && (
+        <div className="col-span-12">
+          {dividendProviders.map((p) => (
+            <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
+          ))}
+        </div>
+      )}
+      <div className="col-span-12">{News}</div>
+    </div>
+  );
+}
+```
+
+(`Thesis` and `News` components return `null` when empty — wrapping them in a `<div className="col-span-12">` produces an empty grid cell, which is harmless. Verify with the test suite.)
+
+If empty grid cells produce unwanted spacing, refactor to `{Thesis !== null && ...}` checks at the parent — but since `ThesisPane` returns `JSX.Element | null` we can't do that with a static check. The cleanest fix is to lift the gate above the wrapper:
+
+```tsx
+{thesis !== null && (
+  <div className="col-span-12">
+    <ThesisPane thesis={thesis} errored={thesisErrored} />
+  </div>
+)}
+```
+
+(Apply same pattern for News by lifting the empty check higher — but RecentNewsPane fetches internally, so the parent can't pre-check. Accept the empty grid cell trade-off, OR have RecentNewsPane render an `aria-hidden` placeholder. Default: accept the empty cell.)
+
+- [ ] **Step 13.4: Update ResearchTab to thin pass-through**
+
+```tsx
+// frontend/src/components/instrument/ResearchTab.tsx
+import { DensityGrid } from "@/components/instrument/DensityGrid";
+import type { InstrumentSummary, ThesisDetail } from "@/api/types";
+
+export interface ResearchTabProps {
+  readonly summary: InstrumentSummary;
+  readonly thesis: ThesisDetail | null;
+  readonly thesisErrored?: boolean;
+}
+
+export function ResearchTab({
+  summary,
+  thesis,
+  thesisErrored = false,
+}: ResearchTabProps): JSX.Element {
+  return (
+    <DensityGrid
+      summary={summary}
+      thesis={thesis}
+      thesisErrored={thesisErrored}
+    />
+  );
+}
+```
+
+Delete the inline `keyStatsBlock`, `thesisBlock` (`ThesisPanel`), `newsBlock`, and helper functions/components that are now relocated.
+
+- [ ] **Step 13.5: Run test to verify pass**
+
+```bash
+pnpm --dir frontend test:unit -- --run DensityGrid.test.tsx ResearchTab.test.tsx
+```
+
+Expected: PASS. (If `ResearchTab.test.tsx` exists and asserts old structure, update it to assert that `DensityGrid` is rendered.)
+
+- [ ] **Step 13.6: Run full unit suite**
+
+```bash
+pnpm --dir frontend test:unit -- --run
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 13.7: Typecheck + lint**
+
+```bash
+pnpm --dir frontend typecheck
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 13.8: Manual smoke test**
+
+Open the running dev frontend (do not restart the stack). Visit:
+1. `/instrument/GME` — `full-sec` profile. Confirm: thesis pane absent (no thesis on file), dividends absent (no history), no internal scrollbars, filings col wider than insider col.
+2. `/instrument/<a UK equity>` if available — `partial-filings` profile.
+3. `/instrument/<a crypto>` if available — `minimal` profile.
+
+If any obvious regression vs the screenshots, capture it before pushing.
+
+- [ ] **Step 13.9: Commit**
+
+```bash
+git add frontend/src/components/instrument/DensityGrid.tsx \
+        frontend/src/components/instrument/DensityGrid.test.tsx \
+        frontend/src/components/instrument/ResearchTab.tsx
+# also include any ResearchTab.test.tsx update
+git commit -m "feat(#575-D): DensityGrid 12-col + 3 capability profiles + empty-pane gates"
+```
+
+---
+
+## Phase 5 — verification + Codex review + push
+
+### Task 14: Local gate run
+
+- [ ] **Step 14.1: Backend gates** (project requires both even on a frontend-only PR per CLAUDE.md)
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 14.2: Frontend gates**
+
+```bash
+pnpm --dir frontend typecheck
+pnpm --dir frontend test:unit
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 14.3: Self-review against pre-flight skill**
+
+Read `.claude/skills/engineering/pre-flight-review.md`. Walk the diff (`git diff main...HEAD`). Confirm:
+- No empty cards remaining.
+- No `overflow-auto` + `max-h-*` wrappers in `DensityGrid.tsx`.
+- All instrument-page panes use `<Pane>` (grep `<Section ` inside `frontend/src/components/instrument/` — only `SectionError` / `SectionSkeleton` should remain).
+- Footer `View …` links removed from FilingsPane / FundamentalsPane.
+- ResearchTab is a thin pass-through.
+- No new backend changes.
+
+### Task 15: Codex pre-push review (CLAUDE.md checkpoint 2)
+
+- [ ] **Step 15.1: Run Codex review on the branch**
+
+```bash
+codex.cmd exec review < /dev/null > /tmp/codex-prepush.out 2>&1 &
+```
+
+Wait for `tokens used` marker, then read the output.
+
+- [ ] **Step 15.2: Address findings**
+
+For each finding: fix, re-run local gates, re-stage, commit. **Do NOT amend.** Each fix = new commit.
+
+### Task 16: Push + open PR
+
+- [ ] **Step 16.1: Push branch**
+
+```bash
+git push -u origin feature/575-instrument-detail-polish-round-2
+```
+
+- [ ] **Step 16.2: Open PR**
+
+Per `feedback_pr_description_brevity.md`: title `feat(#575): instrument detail polish round 2`. Body contains only:
+
+```
+## What
+- Hide truly-empty thesis/news/dividends panes
+- Unbundle dividends + insider combined card
+- 12-col grid with 3 capability profiles
+- New <Pane> + <PaneHeader> primitives
+
+## Why
+Closes #575. Operator review of post-#567 page flagged squish on
+high-signal panes + empty-card waste. Codex direction: stay on page-
+plus-route model, no drawer/ribbon.
+
+## Test plan
+- pnpm --dir frontend test:unit (incl. 3 new profile fixtures)
+- Manual: /instrument/GME, /instrument/<UK equity>, /instrument/<crypto>
+- uv run ruff/format/pyright/pytest all green
+```
+
+```bash
+gh pr create --title "feat(#575): instrument detail polish round 2" --body-file <generated_above>
+```
+
+- [ ] **Step 16.3: Begin post-push polling cycle**
+
+Per `feedback_post_push_cycle.md`: immediately start polling Claude review + CI. Do not wait for user prompt.
+
+```bash
+gh pr view <PR#> --comments
+gh pr checks <PR#>
+```
+
+Repeat until: review posted on the latest commit AND CI green AND every comment reaches a terminal state (`FIXED {sha}` / `DEFERRED #{n}` / `REBUTTED {reason}`).
+
+---
+
+## Self-review against the spec
+
+Spec coverage check:
+
+| Spec section | Covered by |
+|---|---|
+| A. PaneHeader | Task 1 |
+| A. Pane wrapper | Task 2 |
+| B. Capability profiles | Task 3 (selector) + Task 13 (layouts) |
+| C. PriceChart Pane wrap | Task 13 (`ChartPane` local wrap) |
+| C. KeyStats drop null rows + keep FieldSourceTag | Task 10 |
+| C. ThesisPanel returns null when empty | Task 9 |
+| C. SecProfilePanel uses Pane | Task 7 |
+| C. FundamentalsPane uses Pane + drops footer | Task 5 |
+| C. FilingsPane uses Pane + drops footer | Task 4 |
+| C. InsiderActivitySummary uses Pane | Task 6 |
+| C. DividendsPanel uses Pane + null when empty AND no upcoming | Task 12 |
+| C. BusinessSectionsTeaser uses Pane + Open route | Task 8 |
+| C. RecentNewsPane new component | Task 11 |
+| D. Empty-pane four-state policy | Tasks 9, 11, 12 (per-pane); Task 13 (parent gates) |
+| E. Grid sizing (no auto-rows, no overflow-auto) | Task 13 |
+| F. Wiring (ResearchTab thin pass-through) | Task 13 |
+| Risk register | Addressed in Task 1 (focus styles), Task 13 (empty-cell trade-off note) |
+| Testing — Vitest | Tasks 1, 2, 3, 9, 10, 11, 13 |
+| Testing — Manual | Task 13.8 |
+| Build sequence Phase 1–4 | Tasks 1–13 |
+
+No gaps.
+
+Type consistency: `selectProfile` returns `DensityProfile`; `DensityGrid` matches on its return value. `Pane` is imported by every child pane component. `PaneHeader` props match what `Pane` forwards. `RecentNewsPane` returns `JSX.Element | null`; `DensityGrid` mounts it inside a `<div className="col-span-12">` (acceptable empty-cell trade-off documented in Task 13.3).
+
+No placeholders. Every code step contains the actual code.

--- a/docs/superpowers/specs/2026-04-27-instrument-detail-polish-round-2-design.md
+++ b/docs/superpowers/specs/2026-04-27-instrument-detail-polish-round-2-design.md
@@ -1,0 +1,439 @@
+# Instrument detail page — polish round 2 (#575)
+
+Date: 2026-04-27
+Status: design draft (post Codex round 1 second-opinion on parent direction; spec-level Codex review pending)
+Parent: #567 (epic), #559 (visual polish)
+Sibling: #576 (dedicated chart workspace, independent PR)
+
+## Context
+
+PRs #571–#574 shipped phases A–D of the prior refinement spec
+(`docs/superpowers/specs/2026-04-27-instrument-detail-refinement-design.md`).
+Operator review of the rendered page (screenshots 2026-04-27) flags
+remaining gaps that the prior spec did not cover, plus a tightened
+direction validated by Codex second-opinion: stay on the page-plus-route
+model, do **not** add drawer / sheet / verdict-ribbon / universal-L3
+contract, do **not** use `grid-flow-dense` for the outer layout.
+
+This spec is a single-PR polish pass (may split into 2 if pane-header
+standardization grows). It does **not** introduce new interaction layers.
+
+## Pain points (file:line citations)
+
+1. **Empty panes still render full empty-state cards.**
+   - `frontend/src/components/instrument/ResearchTab.tsx:103-110` —
+     `ThesisPanel` returns full `EmptyState` "No thesis yet" when
+     `thesis === null`. Wastes ~25% of right column.
+   - `frontend/src/components/instrument/DensityGrid.tsx:111-124` —
+     dividends + insider combined card uses
+     `overflow-auto max-h-[360px]` even when dividends are empty.
+     Internal scroll wrapper on no content.
+   - `frontend/src/components/instrument/ResearchTab.tsx:201-205` —
+     `newsBlock` literally renders placeholder text "News tab still
+     has the full feed." → vestigial pane.
+2. **Combined dividends+insider card** still alive in
+   `DensityGrid.tsx:111` despite #567 acceptance criterion #5
+   ("drop transitional combined card span").
+3. **Inverse density.** Filings (high-signal, deep data) cramped to
+   1fr column (`DensityGrid.tsx:53` `grid-cols-[2fr_1fr_1fr]`,
+   filings sits in the right 1fr). Insider full-width row but only
+   5 stat fields.
+4. **Inconsistent pane chrome.** `Section.tsx:11-29` is the only
+   header primitive. Some panes display source provenance
+   (`FieldSourceTag` in `ResearchTab.tsx:36-66`), most don't. Drill
+   affordances live as ad-hoc footer links (`FilingsPane.tsx:135-143`,
+   `FundamentalsPane.tsx:166-173`); other panes have no drill cue.
+5. **Layout doesn't adapt to capability coverage.** Current
+   `DensityGrid.tsx` renders the same shape regardless of capabilities.
+   `summary.has_sec_cik` gates SEC profile + business sections inline,
+   but other capability misses (no fundamentals, no insider, no
+   filings) leave layout holes.
+
+## Decisions (with rationale)
+
+| # | Decision | Pick | Rationale |
+|---|---|---|---|
+| 1 | Empty panes | Hide entirely; do not render an empty card | Codex direction. Status moves to `SummaryStrip` for thesis (CTA already there). No vestigial UI. |
+| 2 | Dividends + insider card | Unbundle into two separate panes | Each gets its own capability gate and pane chrome. Drops the combined `overflow-auto max-h-[360px]` wrapper. |
+| 3 | Outer layout primitive | `grid-cols-12` with explicit `col-span-N` per pane | Codex flagged: do **not** use `grid-flow-dense` (panes jumping breaks spatial memory). Do **not** use subgrid (overkill). |
+| 4 | Capability adaptation | 3 stable layout profiles selected by `DensityGrid` based on `summary.capabilities` | Codex pattern: 2-3 stable templates, map instruments into one. Tested as 3 distinct fixtures. |
+| 5 | Pane header primitive | New `<PaneHeader>` component used by every instrument-page pane | Replaces ad-hoc `<Section>` + footer link patterns with one consistent header carrying title / scope / source / drill affordance. |
+| 6 | Drill affordance | `onExpand?: () => void` prop on `PaneHeader` renders an `Open →` button. **Button only — not whole-card click.** | Codex spec-review flagged: nested button + outer-card click double-fires; outer card not keyboard-accessible without `role="button"` + `tabIndex` + key handlers; conflicts with existing internal interactive children in `PriceChart.tsx:160` (range buttons), `FilingsPane.tsx:121` (row links), `BusinessSectionsTeaser.tsx:77` (anchor). Button-only keeps a11y simple, no propagation tax, internal links work unchanged. |
+| 7 | News pane | Hide if no items; if rendering, show ≤5 most-recent items | Drops the placeholder string. Real data only. |
+| 8 | Verdict ribbon | **Out of scope** | Codex: noise duplicating SummaryStrip + key-stats + filings recency. Skip. |
+| 9 | DetailSheet drawer | **Out of scope** | Codex: prove page-route model insufficient first. |
+| 10 | L3 raw-data views | **Out of scope here** (scope of #576 covers chart's L3 OHLCV; other panes opt-in per pane in future tickets) | Codex: L3 is per-pane optional, not universal. |
+
+## Architecture
+
+### A. New `<PaneHeader>` component
+
+`frontend/src/components/instrument/PaneHeader.tsx`:
+
+```tsx
+import { providerLabel } from "@/lib/capabilityProviders";
+
+export interface PaneHeaderProps {
+  readonly title: string;
+  readonly scope?: string;       // e.g. "last 90 days", "latest quarter"
+  readonly source?: {            // optional provenance
+    readonly providers: ReadonlyArray<string>;
+    readonly lastSync?: string;  // ISO date, optional
+  };
+  readonly onExpand?: () => void; // renders "Open →" button (button-only — no card-click)
+}
+
+export function PaneHeader({
+  title, scope, source, onExpand,
+}: PaneHeaderProps): JSX.Element {
+  return (
+    <header className="flex items-baseline justify-between gap-2 border-b border-slate-100 pb-1.5">
+      <div className="flex items-baseline gap-2 min-w-0">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-600">
+          {title}
+        </h2>
+        {scope ? (
+          <span className="text-[10px] text-slate-500">{scope}</span>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0">
+        {source && source.providers.length > 0 ? (
+          <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600">
+            {source.providers.map(providerLabel).join(" · ")}
+            {source.lastSync ? ` · ${source.lastSync}` : ""}
+          </span>
+        ) : null}
+        {onExpand ? (
+          <button
+            type="button"
+            onClick={onExpand}
+            className="text-[11px] text-sky-700 hover:underline"
+          >
+            Open →
+          </button>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+```
+
+Pane wrapper (used by every instrument pane in the grid) becomes:
+
+```tsx
+<article className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm">
+  <PaneHeader title={...} scope={...} source={...} onExpand={onExpand} />
+  <div className="mt-2">{children}</div>
+</article>
+```
+
+No outer-card `onClick`; only the `Open →` button in the header
+triggers `onExpand`. Internal interactive children (chart range
+buttons, filings row `<Link>`s, anchor tags inside narrative teaser)
+operate independently. Hover state is on the `Open →` button itself
+(blue underline), not the whole card. Keeps a11y simple — focus order
+is button-by-button, no `role="button"` shim on the article.
+
+A small wrapper component `<Pane>` encapsulates the article + header
+so individual pane components don't repeat the boilerplate.
+
+**Wrapper ownership rule:** `<Pane>` is owned and rendered by the
+**child pane component** (`FilingsPane`, `FundamentalsPane`,
+`InsiderActivitySummary`, etc.) — **not** by `DensityGrid`.
+`DensityGrid` only decides whether to mount the child component at
+all (capability gate). When a child component decides it has nothing
+to show (its narrow empty rule per Section D), it returns `null` and
+no card appears. This avoids the "parent renders empty wrapper / child
+renders null inside" double-chrome trap Codex flagged.
+
+Existing `<Section>` from `Section.tsx` stays in place for
+non-instrument-page consumers (Dashboard, Portfolio, etc.) — this is a
+new primitive scoped to instrument page panes.
+
+### B. Capability profiles
+
+`frontend/src/components/instrument/densityProfile.ts`:
+
+```ts
+import type { InstrumentSummary } from "@/api/types";
+import { activeProviders } from "@/lib/capabilityProviders";
+
+export type DensityProfile = "full-sec" | "partial-filings" | "minimal";
+
+export function selectProfile(summary: InstrumentSummary): DensityProfile {
+  const cap = summary.capabilities;
+  const hasFundamentals =
+    cap.fundamentals?.providers.includes("sec_xbrl") &&
+    cap.fundamentals.data_present.sec_xbrl === true;
+  const hasFilings = activeProviders(cap.filings ?? { providers: [], data_present: {} }).length > 0;
+
+  if (hasFundamentals && hasFilings) return "full-sec";
+  if (hasFilings) return "partial-filings";
+  return "minimal";
+}
+```
+
+`DensityGrid.tsx` accepts an additional `profile` derived from
+`selectProfile(summary)` and renders one of three stable layouts:
+
+Codex spec-review flagged that `DividendsPanel` is provider-agnostic
+(`DividendsPanel.tsx:2` — applies to UK and other non-SEC regions),
+so every profile that has any active dividends capability must allocate
+a dividends slot. Each profile below now gates dividends on
+`activeProviders(cap.dividends).length > 0` independent of SEC status.
+
+#### Profile: `full-sec` (e.g. GME, AAPL)
+
+```
+12-col grid, gap-2:
+Row 1: chart (col-span-8, row-span-2) | keyStats (col-span-4)
+Row 2:                                | secProfile (col-span-4)
+Row 3: fundamentals (col-span-12)
+Row 4: filings (col-span-7)            | insider (col-span-5)
+Row 5: narrative (col-span-12) [if hasNarrative]
+Row 6: dividends (col-span-12) [if activeProviders(cap.dividends).length > 0]
+Row 7: news (col-span-12) [if newsItems.length > 0]
+Row 8: thesis (col-span-12) [if thesis !== null]
+```
+
+#### Profile: `partial-filings` (e.g. UK Companies House, no SEC XBRL)
+
+```
+12-col grid, gap-2:
+Row 1: chart (col-span-8, row-span-2) | keyStats (col-span-4)
+Row 2:                                | secProfile (col-span-4) [if hasSec]
+Row 3: filings (col-span-12)
+Row 4: insider (col-span-7) [if activeProviders(cap.insider).length > 0]
+       | dividends (col-span-5) [if activeProviders(cap.dividends).length > 0]
+Row 5: narrative (col-span-12) [if hasNarrative]
+Row 6: news (col-span-12) [if newsItems.length > 0]
+Row 7: thesis (col-span-12) [if thesis !== null]
+```
+
+(Row 4 collapses if only one of insider/dividends is active — the
+present pane spans full 12 cols.)
+
+#### Profile: `minimal` (e.g. crypto, forex — no filings, no fundamentals)
+
+```
+12-col grid, gap-2:
+Row 1: chart (col-span-8, row-span-2) | keyStats (col-span-4)
+Row 2:                                | thesis (col-span-4) [if thesis !== null]
+Row 3: dividends (col-span-12) [if activeProviders(cap.dividends).length > 0]
+Row 4: news (col-span-12) [if newsItems.length > 0]
+```
+
+Pane order within each profile is stable; capability misses **remove**
+panes without reflowing the others. Conditional panes use
+`{condition && <ChildPaneComponent ... />}` in `DensityGrid`'s JSX,
+where the child component owns its own `<Pane>` wrapper internally
+(per Section A wrapper-ownership rule). `DensityGrid` does **not**
+render `<Pane>` directly; it only decides which child components to
+mount. No `grid-flow-dense`.
+
+### C. Pane changes (per pane)
+
+| Pane | Change |
+|---|---|
+| `PriceChart` (existing) | Wrap in `<Pane>` with `onExpand` routing to `/instrument/:symbol/chart` (route ships in #576; until then `onExpand` is `undefined` and no `Open →` button renders). `PaneHeader` shows title "Price chart" only — **no `scope` prop**. Codex spec-review flagged: range state lives inside `PriceChart` via URL search params (`PriceChart.tsx:108`); a parent `PaneHeader` cannot read it without lifting state up or duplicating the search-param read at the wrapper. Range stays visible inside the chart UI itself. |
+| `KeyStats` (`ResearchTab.tsx:171-193`) | Replace `<Section title="Key statistics">` with `<Pane title="Key statistics">`. **No pane-level `source` prop and no `scope` prop** — Codex spec-review flagged: rows mix live / TTM / YoY / latest-quarter values (`ResearchTab.tsx:180`), and current per-row `FieldSourceTag` provenance (`ResearchTab.tsx:36`) is per-field. A pane-level scope of `"latest quarter"` would mislabel the live-price-derived rows; a pane-level source badge would be less accurate than per-row tags. **Keep `FieldSourceTag` on each row unchanged.** Drop fully-null rows (e.g. drop "Dividend yield" row when value is `null`); only render rows whose value is not null. |
+| `ThesisPanel` | When `thesis === null`, **render `null`** (parent decides whether to render the pane at all). When errored, render the error inside the pane. When present, render as today. Parent component (`ResearchTab` → `DensityGrid`) gates the pane on `thesis !== null` and passes `onExpand` only if thesis history page exists (it does not yet — leave undefined). |
+| `SecProfilePanel` | Wrap in `<Pane>` with title "Company profile", source `["sec_edgar"]`. `onExpand` undefined for now. |
+| `FundamentalsPane` | Wrap in `<Pane>` with title "Fundamentals", scope = "last 8 quarters", source `["sec_xbrl"]`, `onExpand` routing to `?tab=financials` (existing). Drop the existing footer "View statements →" link (`FundamentalsPane.tsx:166-173`) — replaced by `PaneHeader` "Open →". |
+| `FilingsPane` | Wrap in `<Pane>` with title "Recent filings", scope = "high-signal types", source = active filings providers (e.g. `["sec_edgar"]`), `onExpand` routing to `?tab=filings` (existing). Drop the existing footer "View all filings →" link (`FilingsPane.tsx:135-143`) — replaced by `PaneHeader` "Open →". |
+| `InsiderActivitySummary` | Wrap in `<Pane>` with title "Insider activity", scope = "last 90 days", source `["sec_form4"]`, `onExpand` undefined for now (no insider tab/route exists). |
+| `DividendsPanel` (existing, used elsewhere) | When used inside `DensityGrid`, wrap in `<Pane>` with title "Dividend history", source from active dividend providers. Drop the combined-card `overflow-auto max-h-[360px]` wrapper. Pane only rendered when `activeProviders(dividends).length > 0`. |
+| `BusinessSectionsTeaser` | Wrap in `<Pane>` with title "Company narrative", scope = "10-K Item 1", source `["sec_10k_item1"]`, `onExpand` routing to existing 10-K narrative route. |
+| News pane | New shared component `<RecentNewsPane>`. Renders `<Pane>` with title "Recent news" + up to 5 most-recent items. Hidden entirely when no items. `onExpand` routes to `?tab=news`. |
+
+### D. Empty-pane policy
+
+Codex spec-review flagged that "render nothing on empty" is too broad.
+Several panes already distinguish `no-capability` from
+`active-but-no-current-data` and rely on that distinction
+(`DividendsPanel.tsx:97` shows upcoming dividends even with empty
+history; `FilingsPane.tsx:96` distinguishes "active filings capability
+but no high-signal rows" from "no capability"; `InsiderActivitySummary.tsx:55`
+has its own "no Form 4 data" empty state when the provider is active).
+
+Refined four-state rule:
+
+| State | Definition | UI |
+|---|---|---|
+| **Capability inactive** | `activeProviders(cap.X).length === 0` | Parent does NOT mount the pane component. No card. |
+| **Capability active, future signal only** | Provider active AND no historical data BUT pane has forward-looking content (e.g. upcoming ex-date, upcoming earnings) | Pane renders with the forward-looking content. Card visible. |
+| **Capability active, no current and no forward signal** | Provider active AND no rows AND no forward content | Pane returns `null`. No card. |
+| **Capability active, endpoint returned null/error** | Provider active AND data fetch failed or returned `null` body | Pane renders an explicit error/empty state inside its `<Pane>` chrome (existing `SectionError` / inline empty). Card visible. |
+
+Per-pane mapping (replaces the broad table):
+
+| Pane | Inactive | Active, future-only | Active, nothing | Active, fetch null/err |
+|---|---|---|---|---|
+| Thesis | n/a (no capability — gates on `thesis !== null`) | n/a | parent gates: `thesis === null && !errored` → null | errored → render error UI inside Pane |
+| Dividends | parent gates on `activeProviders(cap.dividends).length === 0` → no mount | `data.upcoming.length > 0` → render normally with upcoming visible | `data.history.length === 0 && data.upcoming.length === 0` → child returns `null` | error → child renders error UI |
+| News | parent gates on `data.items.length === 0` → no mount | n/a | `items.length === 0` → child returns `null` | error → child renders error UI |
+| Insider | parent gates on `activeProviders(cap.insider).length === 0` → no mount | n/a | child renders existing "No insider data" state inside Pane (active provider but null payload) | error → child renders error UI |
+| Fundamentals | parent gates on `!hasFundamentalsActive(summary)` → no mount | n/a | already self-gates (`FundamentalsPane.tsx:127`) | error → existing `SectionError` |
+| Filings | parent gates on `activeProviders(cap.filings).length === 0` → no mount | n/a | child renders existing "No filings" empty inside Pane (active provider but no high-signal rows) | error → child renders error UI |
+| KeyStats | n/a (always rendered when summary exists) | n/a | `stats === null` → child renders existing "No key stats" inside Pane | error → n/a (data is part of summary) |
+| Narrative | parent gates on absent 10-K | n/a | child renders existing absent-narrative state | error → existing |
+
+Net effect: no completely-blank empty cards (the thesis-dead-card and
+news-placeholder problems), but panes with active capabilities still
+get visible cards even when the latest fetch is empty — operator can
+see "yes the data feed exists, it's just empty right now" rather than
+"this capability doesn't exist for this instrument".
+
+### E. Grid-cell sizing
+
+`DensityGrid` uses `grid grid-cols-12 gap-2`. No `auto-rows`. No
+`grid-flow-dense`. Each pane wrapper is `min-h-0` with content-driven
+height. Chart pane keeps `min-h-[440px]` (existing). No internal
+scrollbars (`overflow-auto` removed everywhere). Long lists (filings,
+news) cap row count with `slice(0, N)` and rely on `PaneHeader.onExpand`
+for "view all" via Open → affordance.
+
+### F. Wiring summary
+
+```
+InstrumentPage
+  -> ResearchTab(summary, thesis, thesisErrored)
+       -> DensityGrid(summary, thesis, thesisErrored, profile = selectProfile(summary))
+            -> 1-of-3 layout templates rendering child pane components directly
+            -> conditional mounts use { cond && <ChildPane ... /> }
+            -> each child component owns its own <Pane> wrapper internally
+```
+
+`ResearchTab` no longer hand-builds the `keyStatsBlock` / `thesisBlock`
+/ `newsBlock` JSX. Each becomes its own component (`KeyStatsPane`,
+`ThesisPane`, `RecentNewsPane`) and `DensityGrid` imports + mounts
+them directly. `ResearchTab` becomes a thin pass-through (it stays
+only for tab routing parity). `DensityGrid` itself does not import
+or render the `<Pane>` primitive — only the child pane components do.
+
+## Out of scope (locked — do not expand in implementation)
+
+- Verdict ribbon / status badges. Codex: noise. Defer indefinitely.
+- DetailSheet / drawer primitive. Codex: prove page-route insufficient
+  first. Defer.
+- Universal L3 raw-data contract. Per-pane opt-in only; chart's L3 is
+  scoped to #576.
+- New backend endpoints. None required.
+- New chart workspace route. Tracked in #576.
+- Indicator overlays / compare-mode for chart. Tracked in follow-ups
+  on #576.
+- New capability data sources. None added.
+- Visual polish beyond layout (typography overhaul, color tokens,
+  dark/light mode). Tracked in #559.
+- Ownership pie / 13F ingest. Already deferred per refinement spec.
+
+## Testing
+
+### Vitest
+
+- `PaneHeader.test.tsx` — title/scope/source/onExpand each render
+  conditionally; `Open →` button calls `onExpand`; when `onExpand` is
+  defined the button is rendered, when undefined it is not.
+- `densityProfile.test.ts` — `selectProfile` returns `full-sec` for
+  fixture with sec_xbrl + filings; `partial-filings` for fixture with
+  filings but no sec_xbrl; `minimal` for fixture with neither.
+- `DensityGrid.test.tsx` — extend existing tests:
+  - Renders the `full-sec` profile for the existing GME-shaped fixture.
+  - Renders the `partial-filings` profile for a Companies-House-only
+    fixture with active dividends + insider; asserts no fundamentals
+    pane, filings spans full 12 cols, insider + dividends share row 4
+    (col-span-7 / col-span-5 respectively).
+  - Renders the `partial-filings` profile for a fixture with filings
+    but no insider and no dividends; asserts row 4 is absent entirely.
+  - Renders the `minimal` profile for a crypto-shaped fixture with
+    active dividends; asserts no filings/fundamentals/insider/narrative
+    panes; chart + keyStats + (thesis if present) + dividends + (news
+    if items).
+  - Renders the `minimal` profile for a forex-shaped fixture without
+    dividends; asserts only chart + keyStats render (plus optional
+    thesis/news).
+- Empty-pane suppression (per Section D four-state rule):
+  - Thesis pane absent when `thesis === null && !errored`.
+  - Dividends pane absent when `activeProviders(cap.dividends)` is
+    empty (capability inactive case).
+  - Dividends pane RENDERS when capability is active but only future
+    ex-date is present (active + future-only state).
+  - News pane absent when `data.items.length === 0`.
+- `RecentNewsPane.test.tsx` — renders ≤5 items, hides when empty.
+
+### Manual
+
+- `/instrument/GME` — `full-sec` profile, no empty cards visible at
+  1440×900, no internal scrollbars, filings pane visibly wider than
+  insider pane. Dividends pane absent (no dividend history on file)
+  per the empty-pane policy.
+- A UK equity (Companies House only) — `partial-filings` profile,
+  filings full-width. If the instrument has active dividends/insider,
+  they share row 4 (insider 7-col, dividends 5-col) per the updated
+  profile definition. If neither, row 4 absent.
+- A crypto instrument with active CoinGecko dividends — `minimal`
+  profile, chart + keyStats + dividends only; no SEC panes. If the
+  instrument has no dividends capability, only chart + keyStats render
+  (plus thesis/news when populated).
+
+## Build sequence
+
+Single PR by default. Split into 2 if pane-header standardization +
+capability profiles together exceed reasonable review size.
+
+Phase 1 — primitives (no behavior change):
+
+1. `PaneHeader.tsx` + Vitest.
+2. `Pane.tsx` wrapper component (article + hover + PaneHeader).
+3. `densityProfile.ts` + Vitest.
+
+Phase 2 — wire panes:
+
+4. Replace `<Section>` with `<Pane>` in each instrument pane
+   (`KeyStats`, `SecProfilePanel`, `FundamentalsPane`, `FilingsPane`,
+   `InsiderActivitySummary`, `DividendsPanel`-when-on-instrument,
+   `BusinessSectionsTeaser`).
+5. Drop existing footer "View …" links from `FilingsPane.tsx:135-143`
+   and `FundamentalsPane.tsx:166-173`.
+
+Phase 3 — empty-pane suppression:
+
+6. `ThesisPanel` returns `null` when empty.
+7. New `RecentNewsPane.tsx` (replaces the `newsBlock` placeholder).
+8. Dividends + insider gated in `DensityGrid` via `activeProviders`.
+
+Phase 4 — layout:
+
+9. `DensityGrid` switches to `grid-cols-12` + 3 profiles.
+10. Drop combined dividends+insider card and its `overflow-auto`
+    wrapper.
+11. Update existing `DensityGrid` Vitest fixtures.
+
+If splitting into two PRs: Phase 1+2 first (no visible layout change),
+Phase 3+4 second (the layout flip the user sees).
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Profile selection produces a layout the operator doesn't expect for an edge instrument (e.g. partial-fundamentals: sec_xbrl provider listed but no data). | `selectProfile` checks `data_present` not just `providers.includes`. Fallback to `partial-filings` when fundamentals data is missing. |
+| ~~Whole-card click conflicts with internal links~~ | **Resolved at design time:** `onExpand` is button-only (Decision 6). Internal links (filings rows, narrative anchor, chart range buttons) operate independently — no propagation handling needed. |
+| `PaneHeader` provenance string overflows on narrow viewports. | Truncate with `text-overflow: ellipsis` on the source span; full list visible on hover via `title` attr. |
+| Three profiles are not enough for some real instrument (e.g. ADR with FPI filings + no SEC XBRL but has ownership). | Add a 4th profile in a follow-up; profile system is designed to extend. v1 ships with 3. |
+| `Pane` wrapper hover-state interferes with focus ring on internal buttons. | Internal buttons use `focus-visible:ring-2 focus-visible:ring-sky-500` independent of card hover state. |
+
+## Acceptance criteria (mirror of #575 issue)
+
+- Empty thesis/dividends/news panes do not render on load.
+- No `overflow-auto` + `max-h-*` wrappers anywhere in `DensityGrid.tsx`.
+- Dividends and insider in separate panes (no combined card).
+- Filings pane visibly wider than insider pane on desktop viewport.
+- Every pane on the instrument page uses `<Pane>` + `<PaneHeader>` with
+  consistent label + source + drill affordance where applicable.
+- `/instrument/GME` (full SEC), a UK Companies House instrument, and
+  a crypto instrument each render a clean profile-appropriate layout
+  with no holes.
+- All existing Vitest tests pass; new tests cover the three capability
+  profiles, empty-pane suppression, and the new `PaneHeader`.
+- `uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest` all green.
+- `pnpm --dir frontend typecheck && pnpm --dir frontend test:unit` all green.

--- a/frontend/src/components/instrument/BusinessSectionsTeaser.test.tsx
+++ b/frontend/src/components/instrument/BusinessSectionsTeaser.test.tsx
@@ -1,0 +1,49 @@
+import { describe, beforeEach, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSectionsTeaser";
+import * as api from "@/api/instruments";
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async (importActual) => {
+  const actual = (await importActual()) as object;
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+describe("BusinessSectionsTeaser", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("renders teaser + Pane chrome with sec_10k_item1 source", async () => {
+    vi.spyOn(api, "fetchBusinessSections").mockResolvedValueOnce({
+      sections: [{ heading: "General", level: 2, body: "ACME Corp makes widgets globally." }],
+      source_accession: null,
+    } as never);
+    render(
+      <MemoryRouter>
+        <BusinessSectionsTeaser symbol="GME" />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText(/ACME Corp/)).toBeInTheDocument();
+    // providerLabel("sec_10k_item1") === "SEC 10-K Item 1"
+    expect(screen.getByText(/SEC 10-K Item 1/)).toBeInTheDocument();
+  });
+
+  it("Open button navigates to /instrument/<symbol>/filings/10-k", async () => {
+    vi.spyOn(api, "fetchBusinessSections").mockResolvedValueOnce({
+      sections: [{ heading: "General", level: 2, body: "Test body." }],
+      source_accession: null,
+    } as never);
+    render(
+      <MemoryRouter>
+        <BusinessSectionsTeaser symbol="GME" />
+      </MemoryRouter>,
+    );
+    const btn = await screen.findByRole("button", { name: /open/i });
+    await userEvent.click(btn);
+    expect(navigateMock).toHaveBeenCalledWith("/instrument/GME/filings/10-k");
+  });
+});

--- a/frontend/src/components/instrument/BusinessSectionsTeaser.tsx
+++ b/frontend/src/components/instrument/BusinessSectionsTeaser.tsx
@@ -15,15 +15,12 @@ import type {
   BusinessSection,
   BusinessSectionsResponse,
 } from "@/api/instruments";
-import {
-  Section,
-  SectionError,
-  SectionSkeleton,
-} from "@/components/dashboard/Section";
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { Pane } from "@/components/instrument/Pane";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback } from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 export interface BusinessSectionsTeaserProps {
   readonly symbol: string;
@@ -52,13 +49,19 @@ function pickTeaser(sections: ReadonlyArray<BusinessSection>): string {
 }
 
 export function BusinessSectionsTeaser({ symbol }: BusinessSectionsTeaserProps) {
+  const navigate = useNavigate();
   const state = useAsync<BusinessSectionsResponse>(
     useCallback(() => fetchBusinessSections(symbol), [symbol]),
     [symbol],
   );
 
   return (
-    <Section title="Company narrative (SEC 10-K Item 1)">
+    <Pane
+      title="Company narrative"
+      scope="10-K Item 1"
+      source={{ providers: ["sec_10k_item1"] }}
+      onExpand={() => navigate(`/instrument/${encodeURIComponent(symbol)}/filings/10-k`)}
+    >
       {state.loading ? (
         <SectionSkeleton rows={2} />
       ) : state.error !== null ? (
@@ -73,22 +76,14 @@ export function BusinessSectionsTeaser({ symbol }: BusinessSectionsTeaserProps) 
           <p className="leading-relaxed text-slate-700">
             {pickTeaser(state.data.sections)}
           </p>
-          <div>
-            <Link
-              to={`/instrument/${encodeURIComponent(symbol)}/filings/10-k`}
-              className="text-xs font-medium text-sky-700 hover:underline"
-            >
-              View full 10-K narrative →
-            </Link>
-            {state.data.source_accession !== null && (
-              <span className="ml-2 text-[11px] text-slate-500">
-                accession{" "}
-                <span className="font-mono">{state.data.source_accession}</span>
-              </span>
-            )}
-          </div>
+          {state.data.source_accession !== null && (
+            <span className="text-[11px] text-slate-500">
+              accession{" "}
+              <span className="font-mono">{state.data.source_accession}</span>
+            </span>
+          )}
         </div>
       )}
-    </Section>
+    </Pane>
   );
 }

--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { DensityGrid } from "@/components/instrument/DensityGrid";
+import type { InstrumentSummary } from "@/api/types";
 
 // Mock child components that make their own API calls so the DensityGrid
 // unit test stays isolated.
@@ -15,13 +16,7 @@ vi.mock("@/components/instrument/BusinessSectionsTeaser", () => ({
   BusinessSectionsTeaser: () => <div>Company narrative (SEC 10-K Item 1)</div>,
 }));
 vi.mock("@/components/instrument/FilingsPane", () => ({
-  FilingsPane: () => (
-    <section>
-      <header>
-        <h2>Recent filings</h2>
-      </header>
-    </section>
-  ),
+  FilingsPane: () => <div>Recent filings</div>,
 }));
 vi.mock("@/components/instrument/DividendsPanel", () => ({
   DividendsPanel: () => <div>Dividends</div>,
@@ -30,221 +25,160 @@ vi.mock("@/components/instrument/InsiderActivitySummary", () => ({
   InsiderActivitySummary: () => <div>Insider summary</div>,
 }));
 vi.mock("@/components/instrument/FundamentalsPane", () => ({
-  FundamentalsPane: () => <div>Fundamentals stub</div>,
+  FundamentalsPane: () => <div>Fundamentals</div>,
+}));
+vi.mock("@/components/instrument/KeyStatsPane", () => ({
+  KeyStatsPane: () => <div>Key statistics</div>,
+}));
+vi.mock("@/components/instrument/ThesisPane", () => ({
+  ThesisPane: ({ thesis, errored }: { thesis: unknown; errored: boolean }) =>
+    thesis === null && !errored ? null : <div>Thesis pane</div>,
+}));
+vi.mock("@/components/instrument/RecentNewsPane", () => ({
+  RecentNewsPane: () => <div>Recent news</div>,
 }));
 
-const summary = {
-  instrument_id: 1,
-  has_sec_cik: true,
-  identity: {
-    symbol: "GME",
-    display_name: "GameStop",
-    market_cap: "1000000",
-    sector: null,
-  },
-  capabilities: {},
-  key_stats: null,
-} as never;
+const baseIdentity = {
+  symbol: "GME",
+  display_name: "GameStop",
+  market_cap: "1000000000",
+  sector: null,
+};
 
-describe("DensityGrid", () => {
-  it("renders the chart stub, the slot blocks, and FilingsPane title", () => {
+function makeSummary(
+  capabilities: InstrumentSummary["capabilities"],
+  has_sec_cik: boolean = true,
+): InstrumentSummary {
+  return {
+    instrument_id: 1,
+    is_tradable: true,
+    coverage_tier: 1,
+    identity: baseIdentity,
+    price: null,
+    key_stats: null,
+    source: {},
+    has_sec_cik,
+    has_filings_coverage: false,
+    capabilities,
+  } as InstrumentSummary;
+}
+
+describe("DensityGrid profiles", () => {
+  it("full-sec profile: chart + key stats + sec profile + fundamentals + filings + insider rendered", () => {
     render(
       <MemoryRouter>
         <DensityGrid
-          summary={summary}
-          keyStatsBlock={<div>KEY STATS BLOCK</div>}
-          thesisBlock={<div>THESIS BLOCK</div>}
-          newsBlock={<div>NEWS BLOCK</div>}
+          summary={makeSummary({
+            fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: true } },
+            filings: { providers: ["sec_edgar"], data_present: { sec_edgar: true } },
+            insider: { providers: ["sec_form4"], data_present: { sec_form4: true } },
+          })}
+          thesis={null}
+          thesisErrored={false}
         />
       </MemoryRouter>,
     );
     expect(screen.getByTestId("price-chart-stub")).toBeInTheDocument();
-    expect(screen.getByText("KEY STATS BLOCK")).toBeInTheDocument();
-    expect(screen.getByText("THESIS BLOCK")).toBeInTheDocument();
-    expect(screen.getByText("NEWS BLOCK")).toBeInTheDocument();
-    expect(screen.getByText("Recent filings")).toBeInTheDocument();
-  });
-
-  it("shows the SEC profile pane when has_sec_cik is true", () => {
-    render(
-      <MemoryRouter>
-        <DensityGrid
-          summary={summary}
-          keyStatsBlock={<div>KEY STATS BLOCK</div>}
-          thesisBlock={<div>THESIS BLOCK</div>}
-          newsBlock={<div>NEWS BLOCK</div>}
-        />
-      </MemoryRouter>,
-    );
+    expect(screen.getByText("Key statistics")).toBeInTheDocument();
     expect(screen.getByText("SEC Profile")).toBeInTheDocument();
+    expect(screen.getByText("Fundamentals")).toBeInTheDocument();
+    expect(screen.getByText(/Recent filings/)).toBeInTheDocument();
+    expect(screen.getByText(/Insider summary/)).toBeInTheDocument();
   });
 
-  it("shows 'No SEC coverage' fallback when has_sec_cik is false", () => {
-    const noSec = {
-      instrument_id: 1,
-      has_sec_cik: false,
-      identity: {
-        symbol: "GME",
-        display_name: "GameStop",
-        market_cap: "1000000",
-        sector: null,
-      },
-      capabilities: {},
-      key_stats: null,
-    } as never;
+  it("partial-filings profile: no fundamentals; filings full-width; insider+dividends share row when both active", () => {
     render(
       <MemoryRouter>
         <DensityGrid
-          summary={noSec}
-          keyStatsBlock={<div>KEY STATS BLOCK</div>}
-          thesisBlock={<div>THESIS BLOCK</div>}
-          newsBlock={<div>NEWS BLOCK</div>}
+          summary={makeSummary({
+            filings: { providers: ["companies_house"], data_present: { companies_house: true } },
+            insider: { providers: ["sec_form4"], data_present: { sec_form4: true } },
+            dividends: { providers: ["sec_dividend_summary"], data_present: { sec_dividend_summary: true } },
+          })}
+          thesis={null}
+          thesisErrored={false}
         />
       </MemoryRouter>,
     );
-    expect(screen.getByText("No SEC coverage")).toBeInTheDocument();
+    expect(screen.queryByText("Fundamentals")).not.toBeInTheDocument();
+    expect(screen.getByText(/Recent filings/)).toBeInTheDocument();
+    expect(screen.getByText(/Insider summary/)).toBeInTheDocument();
+    expect(screen.getByText(/Dividends/)).toBeInTheDocument();
   });
 
-  it("individual panes have no overflow-auto (content-driven, not scrollboxes)", () => {
-    // summary has capabilities:{} so the dividends+insider combined card
-    // (which retains overflow-auto + max-h as a scroll-bound until Phase D)
-    // is not rendered — this test covers only the standard pane set.
+  it("partial-filings without insider or dividends: row absent", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={makeSummary({
+            filings: { providers: ["companies_house"], data_present: { companies_house: true } },
+          })}
+          thesis={null}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText(/Insider summary/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Dividends/)).not.toBeInTheDocument();
+  });
+
+  it("minimal profile: no filings/fundamentals/insider/narrative panes", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={makeSummary({}, false)}
+          thesis={null}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText(/Recent filings/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Fundamentals")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Insider summary/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Company narrative/)).not.toBeInTheDocument();
+    expect(screen.getByText("Key statistics")).toBeInTheDocument();
+    expect(screen.getByTestId("price-chart-stub")).toBeInTheDocument();
+  });
+
+  it("thesis pane absent when thesis is null and not errored", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={makeSummary({})}
+          thesis={null}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText("Thesis pane")).not.toBeInTheDocument();
+  });
+
+  it("thesis pane present when thesis is a real object", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={makeSummary({})}
+          thesis={{ thesis_id: 1 } as never}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Thesis pane")).toBeInTheDocument();
+  });
+
+  it("no overflow-auto wrappers anywhere in the grid", () => {
     const { container } = render(
       <MemoryRouter>
         <DensityGrid
-          summary={summary}
-          keyStatsBlock={<div>KEY STATS BLOCK</div>}
-          thesisBlock={<div>THESIS BLOCK</div>}
-          newsBlock={<div>NEWS BLOCK</div>}
+          summary={makeSummary({
+            dividends: { providers: ["sec_dividend_summary"], data_present: { sec_dividend_summary: true } },
+            insider: { providers: ["sec_form4"], data_present: { sec_form4: true } },
+          })}
+          thesis={null}
+          thesisErrored={false}
         />
       </MemoryRouter>,
     );
-    const overflowAuto = container.querySelectorAll(".overflow-auto");
-    expect(overflowAuto.length).toBe(0);
-  });
-
-  it("renders FundamentalsPane only when sec_xbrl fundamentals capability is active", () => {
-    const summaryActive = {
-      instrument_id: 1,
-      has_sec_cik: true,
-      identity: {
-        symbol: "GME",
-        display_name: "GameStop",
-        market_cap: "1000000",
-        sector: null,
-      },
-      capabilities: {
-        fundamentals: {
-          providers: ["sec_xbrl"],
-          data_present: { sec_xbrl: true },
-        },
-      },
-      key_stats: null,
-    } as never;
-    const { rerender } = render(
-      <MemoryRouter>
-        <DensityGrid
-          summary={summaryActive}
-          keyStatsBlock={<div>K</div>}
-          thesisBlock={<div>T</div>}
-          newsBlock={<div>N</div>}
-        />
-      </MemoryRouter>,
-    );
-    expect(screen.getByText("Fundamentals stub")).toBeInTheDocument();
-
-    const summaryInactive = {
-      instrument_id: 1,
-      has_sec_cik: true,
-      identity: {
-        symbol: "GME",
-        display_name: "GameStop",
-        market_cap: "1000000",
-        sector: null,
-      },
-      capabilities: {},
-      key_stats: null,
-    } as never;
-    rerender(
-      <MemoryRouter>
-        <DensityGrid
-          summary={summaryInactive}
-          keyStatsBlock={<div>K</div>}
-          thesisBlock={<div>T</div>}
-          newsBlock={<div>N</div>}
-        />
-      </MemoryRouter>,
-    );
-    expect(screen.queryByText("Fundamentals stub")).toBeNull();
-  });
-
-  it("combined dividends/insider card has no overflow-auto after Phase D (InsiderActivitySummary is compact)", () => {
-    // Phase D replaced InsiderActivityPanel (up to 50 rows) with
-    // InsiderActivitySummary (compact 5-field block), so the combined
-    // card no longer needs the scroll-bound wrapper.
-    const summaryWithInsider = {
-      instrument_id: 1,
-      has_sec_cik: true,
-      identity: {
-        symbol: "GME",
-        display_name: "GameStop",
-        market_cap: "1000000",
-        sector: null,
-      },
-      capabilities: {
-        insider: {
-          providers: ["sec_form4"],
-          data_present: { sec_form4: true },
-        },
-      },
-      key_stats: null,
-    } as never;
-    const { container } = render(
-      <MemoryRouter>
-        <DensityGrid
-          summary={summaryWithInsider}
-          keyStatsBlock={<div>KEY STATS BLOCK</div>}
-          thesisBlock={<div>THESIS BLOCK</div>}
-          newsBlock={<div>NEWS BLOCK</div>}
-        />
-      </MemoryRouter>,
-    );
-    const overflowAuto = container.querySelectorAll(".overflow-auto");
-    expect(overflowAuto.length).toBe(0);
-  });
-
-  it("combined card retains overflow-auto scroll-bound when dividends are active (DividendsPanel can be tall)", () => {
-    // DividendsPanel can render 40+ history rows; the combined card wrapper
-    // must keep the scroll-bound when dividends are present so the grid
-    // doesn't push other panes far below the fold.
-    const summaryWithDividends = {
-      instrument_id: 1,
-      has_sec_cik: true,
-      identity: {
-        symbol: "GME",
-        display_name: "GameStop",
-        market_cap: "1000000",
-        sector: null,
-      },
-      capabilities: {
-        dividends: {
-          providers: ["sec_dividend_summary"],
-          data_present: { sec_dividend_summary: true },
-        },
-      },
-      key_stats: null,
-    } as never;
-    const { container } = render(
-      <MemoryRouter>
-        <DensityGrid
-          summary={summaryWithDividends}
-          keyStatsBlock={<div>KEY STATS BLOCK</div>}
-          thesisBlock={<div>THESIS BLOCK</div>}
-          newsBlock={<div>NEWS BLOCK</div>}
-        />
-      </MemoryRouter>,
-    );
-    const overflowAuto = container.querySelectorAll(".overflow-auto");
-    expect(overflowAuto.length).toBe(1);
+    expect(container.querySelectorAll(".overflow-auto").length).toBe(0);
   });
 });

--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -188,6 +188,22 @@ describe("DensityGrid profiles", () => {
     expect(screen.getByText("Thesis pane")).toBeInTheDocument();
   });
 
+  it("partial-filings profile renders FundamentalsPane when fundamentals are active without filings", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={makeSummary({
+            fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: true } },
+          })}
+          thesis={null}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Fundamentals")).toBeInTheDocument();
+    expect(screen.queryByText(/Recent filings/)).not.toBeInTheDocument();
+  });
+
   it("no overflow-auto wrappers anywhere in the grid", () => {
     const { container } = render(
       <MemoryRouter>

--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -84,6 +84,7 @@ describe("DensityGrid profiles", () => {
     expect(screen.getByText("Fundamentals")).toBeInTheDocument();
     expect(screen.getByText(/Recent filings/)).toBeInTheDocument();
     expect(screen.getByText(/Insider summary/)).toBeInTheDocument();
+    expect(screen.getByText("Recent news")).toBeInTheDocument();
   });
 
   it("full-sec profile without has_sec_cik: SEC profile slot absent (no ghost div)", () => {

--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -86,6 +86,27 @@ describe("DensityGrid profiles", () => {
     expect(screen.getByText(/Insider summary/)).toBeInTheDocument();
   });
 
+  it("full-sec profile without has_sec_cik: SEC profile slot absent (no ghost div)", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={makeSummary(
+            {
+              fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: true } },
+              filings: { providers: ["sec_edgar"], data_present: { sec_edgar: true } },
+            },
+            false, // has_sec_cik = false
+          )}
+          thesis={null}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText("SEC Profile")).not.toBeInTheDocument();
+    // The chart + key stats row should not have an extra empty col-4 slot.
+    // Sanity: the only col-span-4 element in this profile branch is KeyStats.
+  });
+
   it("partial-filings profile: no fundamentals; filings full-width; insider+dividends share row when both active", () => {
     render(
       <MemoryRouter>

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -29,7 +29,11 @@ import { PriceChart } from "@/components/instrument/PriceChart";
 import { RecentNewsPane } from "@/components/instrument/RecentNewsPane";
 import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
 import { ThesisPane } from "@/components/instrument/ThesisPane";
-import { EMPTY_CELL, selectProfile } from "@/components/instrument/densityProfile";
+import {
+  EMPTY_CELL,
+  hasFundamentalsActive,
+  selectProfile,
+} from "@/components/instrument/densityProfile";
 
 export interface DensityGridProps {
   readonly summary: InstrumentSummary;
@@ -118,9 +122,16 @@ export function DensityGrid({
             <SecProfilePanel symbol={symbol} />
           </div>
         )}
-        <div className="col-span-12">
-          <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
-        </div>
+        {hasFundamentalsActive(summary) && (
+          <div className="col-span-12">
+            <FundamentalsPane summary={summary} />
+          </div>
+        )}
+        {activeProviders(cap.filings ?? EMPTY_CELL).length > 0 && (
+          <div className="col-span-12">
+            <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
+          </div>
+        )}
         {insiderActive && dividendProviders.length > 0 ? (
           <>
             <div className="col-span-12 lg:col-span-7">

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -68,9 +68,11 @@ export function DensityGrid({
         <div className="col-span-12 lg:col-span-4">
           <KeyStatsPane summary={summary} />
         </div>
-        <div className="col-span-12 lg:col-span-4">
-          {hasNarrative && <SecProfilePanel symbol={symbol} />}
-        </div>
+        {hasNarrative && (
+          <div className="col-span-12 lg:col-span-4">
+            <SecProfilePanel symbol={symbol} />
+          </div>
+        )}
         <div className="col-span-12">
           <FundamentalsPane summary={summary} />
         </div>

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -1,127 +1,191 @@
 /**
- * DensityGrid — Bloomberg-style 3-column grid for the instrument
- * Research tab (#559). Chart pane occupies the wide left column
- * (2fr) spanning 2 rows; right column (1fr + 1fr) stacks
- * key-stats / thesis / SEC profile / filings; bottom rows hold
- * business teaser / news; dividends + insider as a wide combined
- * card.
+ * DensityGrid — 12-column capability-aware grid for the instrument
+ * Research tab (#575). Three profiles determine which panes render:
  *
- * Responsive: at viewport widths below `lg` the grid degrades to
- * a single column. Pane order reflects priority: chart → key-stats
- * → thesis → filings → SEC-profile → segments → dividends-insider
- * → news. Each pane scrolls internally rather than pushing the
- * page taller.
+ *   full-sec        — fundamentals (sec_xbrl) + filings active
+ *   partial-filings — filings active but no sec_xbrl fundamentals
+ *   minimal         — no filings capability at all
  *
- * 8-K events are accessible via the FilingsPane row click →
- * /instrument/:symbol/filings/8-k (Phase 4).
+ * PriceChart and KeyStatsPane are present in all profiles.
+ * SecProfilePanel / BusinessSectionsTeaser gate on has_sec_cik.
+ * FundamentalsPane is exclusive to the full-sec profile.
+ * FilingsPane / InsiderActivitySummary / DividendsPanel / RecentNewsPane
+ * / ThesisPane appear in profile-specific positions.
+ *
+ * No overflow-auto scroll-boxes: every pane expands to content height
+ * so the grid stays a true content-driven layout.
  */
 
+import type { InstrumentSummary, ThesisDetail } from "@/api/types";
+import { activeProviders } from "@/lib/capabilityProviders";
 import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSectionsTeaser";
 import { DividendsPanel } from "@/components/instrument/DividendsPanel";
 import { FilingsPane } from "@/components/instrument/FilingsPane";
 import { FundamentalsPane } from "@/components/instrument/FundamentalsPane";
 import { InsiderActivitySummary } from "@/components/instrument/InsiderActivitySummary";
+import { KeyStatsPane } from "@/components/instrument/KeyStatsPane";
+import { Pane } from "@/components/instrument/Pane";
 import { PriceChart } from "@/components/instrument/PriceChart";
+import { RecentNewsPane } from "@/components/instrument/RecentNewsPane";
 import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
-import { Section } from "@/components/dashboard/Section";
-import type { CapabilityCell, InstrumentSummary } from "@/api/types";
-import { activeProviders } from "@/lib/capabilityProviders";
+import { ThesisPane } from "@/components/instrument/ThesisPane";
+import { selectProfile } from "@/components/instrument/densityProfile";
+
+const EMPTY_CELL = { providers: [] as string[], data_present: {} as Record<string, boolean> };
 
 export interface DensityGridProps {
   readonly summary: InstrumentSummary;
-  readonly keyStatsBlock: JSX.Element;
-  readonly thesisBlock: JSX.Element;
-  readonly newsBlock: JSX.Element;
+  readonly thesis: ThesisDetail | null;
+  readonly thesisErrored: boolean;
 }
-
-const EMPTY_CELL: CapabilityCell = { providers: [], data_present: {} };
 
 export function DensityGrid({
   summary,
-  keyStatsBlock,
-  thesisBlock,
-  newsBlock,
+  thesis,
+  thesisErrored,
 }: DensityGridProps): JSX.Element {
   const symbol = summary.identity.symbol;
-  const hasSec = summary.has_sec_cik;
-  const dividends = summary.capabilities.dividends ?? EMPTY_CELL;
-  const insider = summary.capabilities.insider ?? EMPTY_CELL;
-  const dividendProviders = activeProviders(dividends);
-  const insiderProviders = activeProviders(insider);
+  const instrumentId = summary.instrument_id;
+  const profile = selectProfile(summary);
+  const cap = summary.capabilities;
+  const insiderActive = activeProviders(cap.insider ?? EMPTY_CELL).length > 0;
+  const dividendProviders = activeProviders(cap.dividends ?? EMPTY_CELL);
+  const filingsActive = activeProviders(cap.filings ?? EMPTY_CELL).length > 0;
+  const hasNarrative = summary.has_sec_cik;
 
-  return (
-    <div className="grid grid-cols-1 gap-2 lg:grid-cols-[2fr_1fr_1fr]">
-        {/* Chart pane: wide column (2fr) × 2 rows top-left */}
-        <div className="overflow-hidden rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm min-h-[440px] lg:col-start-1 lg:col-end-2 lg:row-start-1 lg:row-end-3">
-          <PriceChart symbol={symbol} />
-        </div>
+  // PriceChart isn't yet a self-Pane'd component — wrap it locally.
+  // #576 will own the chart route; until then no onExpand.
+  const ChartPane = (
+    <Pane title="Price chart">
+      <PriceChart symbol={symbol} />
+    </Pane>
+  );
 
-        {/* Right column row 1 */}
-        <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm">
-          {keyStatsBlock}
+  if (profile === "full-sec") {
+    return (
+      <div className="grid grid-cols-12 gap-2">
+        <div className="col-span-12 lg:col-span-8 lg:row-span-2">{ChartPane}</div>
+        <div className="col-span-12 lg:col-span-4">
+          <KeyStatsPane summary={summary} />
         </div>
-        <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm">
-          {thesisBlock}
+        <div className="col-span-12 lg:col-span-4">
+          {hasNarrative && <SecProfilePanel symbol={symbol} />}
         </div>
-
-        {/* Right column row 2 */}
-        <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm">
-          {hasSec ? (
-            <SecProfilePanel symbol={symbol} />
-          ) : (
-            <Section title="SEC profile">
-              <p className="text-xs text-slate-500">No SEC coverage</p>
-            </Section>
-          )}
+        <div className="col-span-12">
+          <FundamentalsPane summary={summary} />
         </div>
-        <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm">
-          <FilingsPane instrumentId={summary.instrument_id} symbol={symbol} summary={summary} />
+        {filingsActive && (
+          <div className="col-span-12 lg:col-span-7">
+            <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
+          </div>
+        )}
+        {insiderActive && (
+          <div className="col-span-12 lg:col-span-5">
+            <InsiderActivitySummary symbol={symbol} />
+          </div>
+        )}
+        {hasNarrative && (
+          <div className="col-span-12">
+            <BusinessSectionsTeaser symbol={symbol} />
+          </div>
+        )}
+        {dividendProviders.length > 0 && (
+          <div className="col-span-12">
+            {dividendProviders.map((p) => (
+              <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
+            ))}
+          </div>
+        )}
+        <div className="col-span-12">
+          <RecentNewsPane instrumentId={instrumentId} symbol={symbol} />
         </div>
-
-        {/* Fundamentals pane: full-width row after sec profile + filings,
-            gated on sec_xbrl capability. Placed after the row-2 right-column
-            panes so the chart/keyStats/thesis/secProfile/filings layout is
-            preserved regardless of whether fundamentals are active. */}
-        {summary.capabilities["fundamentals"]?.providers.includes("sec_xbrl") &&
-         summary.capabilities["fundamentals"].data_present["sec_xbrl"] === true ? (
-          <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm lg:col-span-3">
-            <FundamentalsPane summary={summary} />
+        {thesis !== null || thesisErrored ? (
+          <div className="col-span-12">
+            <ThesisPane thesis={thesis} errored={thesisErrored} />
           </div>
         ) : null}
+      </div>
+    );
+  }
 
-        {/* Bottom row: segments spans 2 cols, news spans 1 col */}
-        <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm lg:col-span-2">
-          {hasSec ? (
-            <BusinessSectionsTeaser symbol={symbol} />
-          ) : (
-            <Section title="Company narrative">
-              <p className="text-xs text-slate-500">No 10-K coverage</p>
-            </Section>
-          )}
+  if (profile === "partial-filings") {
+    return (
+      <div className="grid grid-cols-12 gap-2">
+        <div className="col-span-12 lg:col-span-8 lg:row-span-2">{ChartPane}</div>
+        <div className="col-span-12 lg:col-span-4">
+          <KeyStatsPane summary={summary} />
         </div>
-        <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm">
-          {newsBlock}
-        </div>
-
-        {/* Dividends + insider combined card — spans full width.
-            overflow-auto + max-h guard applies only when dividends are
-            active because DividendsPanel can render 40+ history bars.
-            InsiderActivitySummary is compact (5-field block) and does
-            not need height-capping. */}
-        {(dividendProviders.length > 0 || insiderProviders.length > 0) && (
-          <div
-            className={`rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm lg:col-span-3${dividendProviders.length > 0 ? " overflow-auto max-h-[360px]" : ""}`}
-          >
-            <div className="grid gap-3 md:grid-cols-2">
+        {hasNarrative && (
+          <div className="col-span-12 lg:col-span-4">
+            <SecProfilePanel symbol={symbol} />
+          </div>
+        )}
+        {filingsActive && (
+          <div className="col-span-12">
+            <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
+          </div>
+        )}
+        {insiderActive && dividendProviders.length > 0 ? (
+          <>
+            <div className="col-span-12 lg:col-span-7">
+              <InsiderActivitySummary symbol={symbol} />
+            </div>
+            <div className="col-span-12 lg:col-span-5">
               {dividendProviders.map((p) => (
                 <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
               ))}
-              {insiderProviders.length > 0 && (
-                <InsiderActivitySummary symbol={symbol} />
-              )}
             </div>
+          </>
+        ) : insiderActive ? (
+          <div className="col-span-12">
+            <InsiderActivitySummary symbol={symbol} />
+          </div>
+        ) : dividendProviders.length > 0 ? (
+          <div className="col-span-12">
+            {dividendProviders.map((p) => (
+              <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
+            ))}
+          </div>
+        ) : null}
+        {hasNarrative && (
+          <div className="col-span-12">
+            <BusinessSectionsTeaser symbol={symbol} />
           </div>
         )}
+        <div className="col-span-12">
+          <RecentNewsPane instrumentId={instrumentId} symbol={symbol} />
+        </div>
+        {thesis !== null || thesisErrored ? (
+          <div className="col-span-12">
+            <ThesisPane thesis={thesis} errored={thesisErrored} />
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  // minimal
+  return (
+    <div className="grid grid-cols-12 gap-2">
+      <div className="col-span-12 lg:col-span-8 lg:row-span-2">{ChartPane}</div>
+      <div className="col-span-12 lg:col-span-4">
+        <KeyStatsPane summary={summary} />
+      </div>
+      {(thesis !== null || thesisErrored) && (
+        <div className="col-span-12 lg:col-span-4">
+          <ThesisPane thesis={thesis} errored={thesisErrored} />
+        </div>
+      )}
+      {dividendProviders.length > 0 && (
+        <div className="col-span-12">
+          {dividendProviders.map((p) => (
+            <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
+          ))}
+        </div>
+      )}
+      <div className="col-span-12">
+        <RecentNewsPane instrumentId={instrumentId} symbol={symbol} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -29,9 +29,7 @@ import { PriceChart } from "@/components/instrument/PriceChart";
 import { RecentNewsPane } from "@/components/instrument/RecentNewsPane";
 import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
 import { ThesisPane } from "@/components/instrument/ThesisPane";
-import { selectProfile } from "@/components/instrument/densityProfile";
-
-const EMPTY_CELL = { providers: [] as string[], data_present: {} as Record<string, boolean> };
+import { EMPTY_CELL, selectProfile } from "@/components/instrument/densityProfile";
 
 export interface DensityGridProps {
   readonly summary: InstrumentSummary;
@@ -50,7 +48,6 @@ export function DensityGrid({
   const cap = summary.capabilities;
   const insiderActive = activeProviders(cap.insider ?? EMPTY_CELL).length > 0;
   const dividendProviders = activeProviders(cap.dividends ?? EMPTY_CELL);
-  const filingsActive = activeProviders(cap.filings ?? EMPTY_CELL).length > 0;
   const hasNarrative = summary.has_sec_cik;
 
   // PriceChart isn't yet a self-Pane'd component — wrap it locally.
@@ -74,13 +71,12 @@ export function DensityGrid({
           </div>
         )}
         <div className="col-span-12">
+          {/* full-sec profile guarantees sec_xbrl fundamentals + filings are active per selectProfile */}
           <FundamentalsPane summary={summary} />
         </div>
-        {filingsActive && (
-          <div className="col-span-12 lg:col-span-7">
-            <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
-          </div>
-        )}
+        <div className="col-span-12 lg:col-span-7">
+          <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
+        </div>
         {insiderActive && (
           <div className="col-span-12 lg:col-span-5">
             <InsiderActivitySummary symbol={symbol} />
@@ -122,11 +118,9 @@ export function DensityGrid({
             <SecProfilePanel symbol={symbol} />
           </div>
         )}
-        {filingsActive && (
-          <div className="col-span-12">
-            <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
-          </div>
-        )}
+        <div className="col-span-12">
+          <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
+        </div>
         {insiderActive && dividendProviders.length > 0 ? (
           <>
             <div className="col-span-12 lg:col-span-7">

--- a/frontend/src/components/instrument/DividendsPanel.test.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.test.tsx
@@ -51,24 +51,6 @@ function paid(): InstrumentDividends {
 }
 
 
-function notPaid(): InstrumentDividends {
-  return {
-    symbol: "GOOG",
-    summary: {
-      has_dividend: false,
-      ttm_dps: null,
-      ttm_dividends_paid: null,
-      ttm_yield_pct: null,
-      latest_dps: null,
-      latest_dividend_at: null,
-      dividend_streak_q: 0,
-      dividend_currency: null,
-    },
-    history: [],
-    upcoming: [],
-  };
-}
-
 
 afterEach(() => vi.clearAllMocks());
 
@@ -88,14 +70,32 @@ describe("DividendsPanel", () => {
     expect(screen.getByText("40")).toBeInTheDocument();
   });
 
-  it("renders empty state when never-paid", async () => {
-    mockFetch.mockResolvedValue(notPaid());
-    render(<DividendsPanel symbol="GOOG" provider="sec_dividend_summary" />);
+  it("returns null when history is empty AND upcoming is empty", async () => {
+    mockFetch.mockResolvedValueOnce({
+      symbol: "X",
+      summary: { has_dividend: false } as never,
+      history: [],
+      upcoming: [],
+    } as never);
+    const { container } = render(
+      <DividendsPanel symbol="X" provider="sec_dividend_summary" />,
+    );
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
 
-    await waitFor(() => {
-      expect(screen.getByText(/No dividend history on file/i)).toBeInTheDocument();
-    });
-    expect(screen.queryByText(/TTM yield/i)).not.toBeInTheDocument();
+  it("renders Pane when history is empty but upcoming has 1 item", async () => {
+    mockFetch.mockResolvedValueOnce({
+      symbol: "X",
+      summary: { has_dividend: true } as never,
+      history: [],
+      upcoming: [{ ex_date: "2026-05-01" } as never],
+    } as never);
+    render(<DividendsPanel symbol="X" provider="sec_dividend_summary" />);
+    // Pane renders — the h2 title "Dividends" is present (source badge may also
+    // contain the word; use getAllByText to avoid the "multiple elements" error).
+    await waitFor(() =>
+      expect(screen.getAllByText(/Dividends/i).length).toBeGreaterThan(0),
+    );
   });
 
   it("renders error state + retry on fetch failure", async () => {

--- a/frontend/src/components/instrument/DividendsPanel.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.tsx
@@ -20,12 +20,10 @@ import type {
   UpcomingDividend,
 } from "@/api/instruments";
 import {
-  Section,
   SectionError,
   SectionSkeleton,
 } from "@/components/dashboard/Section";
-import { EmptyState } from "@/components/states/EmptyState";
-import { providerLabel } from "@/lib/capabilityProviders";
+import { Pane } from "@/components/instrument/Pane";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback } from "react";
 
@@ -84,35 +82,40 @@ export function DividendsPanel({ symbol, provider }: DividendsPanelProps) {
     ),
     [symbol, provider],
   );
-  const title = `Dividends · ${providerLabel(provider)}`;
+
+  // Empty case: data loaded, no history AND no upcoming → no card at all.
+  // This implements the four-state empty-pane policy: capability active but
+  // no current and no forward signal → render null.
+  if (
+    !state.loading &&
+    state.error === null &&
+    state.data !== null &&
+    state.data.history.length === 0 &&
+    state.data.upcoming.length === 0
+  ) {
+    return null;
+  }
 
   return (
-    <Section title={title}>
+    <Pane title="Dividends" source={{ providers: [provider] }}>
       {state.loading ? (
         <SectionSkeleton rows={3} />
       ) : state.error !== null || state.data === null ? (
         <SectionError onRetry={state.refetch} />
       ) : (
         <>
-          {/* Upcoming banner renders OUTSIDE the has_dividend gate so a
-              company announcing its first-ever dividend via 8-K (with
-              zero XBRL history yet) still shows the calendar instead
-              of the "never paid" empty state. */}
+          {/* Upcoming banner renders above history so a company announcing
+              its first-ever dividend via 8-K (with zero XBRL history yet)
+              still shows the calendar. */}
           {state.data.upcoming[0] !== undefined && (
             <NextDividendBanner upcoming={state.data.upcoming[0]} />
           )}
-          {!state.data.summary.has_dividend ||
-          state.data.history.length === 0 ? (
-            <EmptyState
-              title="No dividend history on file"
-              description="This instrument has not reported a positive dividend in this provider's data."
-            />
-          ) : (
+          {state.data.history.length > 0 ? (
             <DividendsBody data={state.data} />
-          )}
+          ) : null}
         </>
       )}
-    </Section>
+    </Pane>
   );
 }
 

--- a/frontend/src/components/instrument/FilingsPane.test.tsx
+++ b/frontend/src/components/instrument/FilingsPane.test.tsx
@@ -1,9 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { FilingsPane } from "@/components/instrument/FilingsPane";
 import * as filingsApi from "@/api/filings";
 import type { InstrumentSummary } from "@/api/types";
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  );
+  return { ...actual, useNavigate: () => navigateMock };
+});
 
 function makeSummary(opts: {
   filingsProvider?: string;
@@ -112,7 +121,7 @@ describe("FilingsPane", () => {
     expect(rows.length).toBe(6);
   });
 
-  it("footer link routes to /instrument/GME?tab=filings when filings capability is active", async () => {
+  it("renders Open button when filings tab is active and navigates to ?tab=filings", async () => {
     vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
       instrument_id: 1,
       symbol: "GME",
@@ -121,19 +130,18 @@ describe("FilingsPane", () => {
       limit: 6,
       items: [],
     });
+    navigateMock.mockReset();
     render(
       <MemoryRouter>
         <FilingsPane instrumentId={1} symbol="GME" summary={makeSummary()} />
       </MemoryRouter>,
     );
-    const link = await screen.findByText(/View all filings/);
-    expect(link.closest("a")).toHaveAttribute(
-      "href",
-      "/instrument/GME?tab=filings",
-    );
+    const btn = await screen.findByRole("button", { name: /open/i });
+    await userEvent.click(btn);
+    expect(navigateMock).toHaveBeenCalledWith("/instrument/GME?tab=filings");
   });
 
-  it("hides footer link when filings capability is inactive", async () => {
+  it("hides Open button when filings capability is inactive", async () => {
     vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
       instrument_id: 1,
       symbol: "GME",
@@ -153,6 +161,6 @@ describe("FilingsPane", () => {
     );
     // EmptyState renders; wait for async resolution
     await screen.findByText(/No filings/);
-    expect(screen.queryByText(/View all filings/)).toBeNull();
+    expect(screen.queryByRole("button", { name: /open/i })).toBeNull();
   });
 });

--- a/frontend/src/components/instrument/FilingsPane.tsx
+++ b/frontend/src/components/instrument/FilingsPane.tsx
@@ -1,8 +1,8 @@
 /**
  * FilingsPane — high-signal filings list (8-K + 10-K + 10-Q + foreign
  * issuer equivalents) on the instrument page density grid (#559 / #567).
- * Each row links to the corresponding drilldown route. A "View all
- * filings →" footer routes to the canonical Filings tab when that tab
+ * Each row links to the corresponding drilldown route. An "Open →" button
+ * in the pane header routes to the canonical Filings tab when that tab
  * is active for the instrument.
  *
  * The SIGNIFICANT_FILING_TYPES filter is applied only when the instrument
@@ -12,11 +12,12 @@
 
 import { fetchFilings } from "@/api/filings";
 import type { FilingsListResponse, InstrumentSummary } from "@/api/types";
-import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { Pane } from "@/components/instrument/Pane";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 const ROW_LIMIT = 6;
 
@@ -69,11 +70,14 @@ export function FilingsPane({
   symbol,
   summary,
 }: FilingsPaneProps): JSX.Element {
+  const navigate = useNavigate();
   const filingsCell = summary.capabilities.filings;
   const isSecEdgar =
     filingsCell !== undefined && filingsCell.providers.includes("sec_edgar");
   const typeFilter = isSecEdgar ? SIGNIFICANT_FILING_TYPES : undefined;
   const filingsTabActive = hasActiveFilingsCapability(summary);
+
+  const sourceProviders = filingsCell?.providers ?? [];
 
   const state = useAsync<FilingsListResponse>(
     useCallback(
@@ -88,7 +92,16 @@ export function FilingsPane({
   );
 
   return (
-    <Section title="Recent filings">
+    <Pane
+      title="Recent filings"
+      scope="high-signal types"
+      source={{ providers: sourceProviders }}
+      onExpand={
+        filingsTabActive
+          ? () => navigate(`/instrument/${encodeURIComponent(symbol)}?tab=filings`)
+          : undefined
+      }
+    >
       {state.loading ? (
         <SectionSkeleton rows={5} />
       ) : state.error !== null ? (
@@ -131,16 +144,6 @@ export function FilingsPane({
           })}
         </ul>
       )}
-      {filingsTabActive && (
-        <div className="mt-2 border-t border-slate-100 pt-1.5 text-right">
-          <Link
-            to={`/instrument/${encodeURIComponent(symbol)}?tab=filings`}
-            className="text-[11px] text-sky-700 hover:underline"
-          >
-            View all filings →
-          </Link>
-        </div>
-      )}
-    </Section>
+    </Pane>
   );
 }

--- a/frontend/src/components/instrument/FundamentalsPane.test.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.test.tsx
@@ -1,9 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { FundamentalsPane } from "@/components/instrument/FundamentalsPane";
 import * as api from "@/api/instruments";
 import type { InstrumentSummary } from "@/api/types";
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  );
+  return { ...actual, useNavigate: () => navigateMock };
+});
 
 function makeSummary(secXbrlActive: boolean): InstrumentSummary {
   return {
@@ -85,6 +94,40 @@ describe("FundamentalsPane", () => {
     expect(screen.getByText("Op income")).toBeInTheDocument();
     expect(screen.getByText("Net income")).toBeInTheDocument();
     expect(screen.getByText("Total debt")).toBeInTheDocument();
+  });
+
+  it("renders Open button when fundamentals tab is active and navigates to ?tab=financials", async () => {
+    vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
+      ((_symbol: string, query: { statement: string }) => {
+        if (query.statement === "income") {
+          return Promise.resolve({
+            symbol: "GME",
+            statement: "income",
+            period: "quarterly",
+            currency: "USD",
+            source: "sec_xbrl",
+            rows: incomeRows,
+          });
+        }
+        return Promise.resolve({
+          symbol: "GME",
+          statement: "balance",
+          period: "quarterly",
+          currency: "USD",
+          source: "sec_xbrl",
+          rows: balanceRows,
+        });
+      }) as never,
+    );
+    navigateMock.mockReset();
+    render(
+      <MemoryRouter>
+        <FundamentalsPane summary={makeSummary(true)} />
+      </MemoryRouter>,
+    );
+    const btn = await screen.findByRole("button", { name: /open/i });
+    await userEvent.click(btn);
+    expect(navigateMock).toHaveBeenCalledWith("/instrument/GME?tab=financials");
   });
 
   it("computes total debt as long_term_debt + short_term_debt per period", async () => {

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -12,12 +12,13 @@
 
 import { fetchInstrumentFinancials } from "@/api/instruments";
 import type { InstrumentFinancialRow, InstrumentSummary } from "@/api/types";
-import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { Pane } from "@/components/instrument/Pane";
 import { EmptyState } from "@/components/states/EmptyState";
 import { Sparkline } from "@/components/instrument/Sparkline";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback, useMemo } from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 const SLICE = 8;
 
@@ -88,6 +89,7 @@ export interface FundamentalsPaneProps {
 
 export function FundamentalsPane({ summary }: FundamentalsPaneProps): JSX.Element | null {
   const symbol = summary.identity.symbol;
+  const navigate = useNavigate();
   const fundCell = summary.capabilities["fundamentals"];
   const active =
     fundCell !== undefined &&
@@ -127,7 +129,12 @@ export function FundamentalsPane({ summary }: FundamentalsPaneProps): JSX.Elemen
   if (!active) return null;
 
   return (
-    <Section title="Fundamentals">
+    <Pane
+      title="Fundamentals"
+      scope="last 8 quarters"
+      source={{ providers: ["sec_xbrl"] }}
+      onExpand={() => navigate(`/instrument/${encodeURIComponent(symbol)}?tab=financials`)}
+    >
       {income.loading || balance.loading ? (
         <SectionSkeleton rows={3} />
       ) : income.error !== null || balance.error !== null ? (
@@ -138,42 +145,30 @@ export function FundamentalsPane({ summary }: FundamentalsPaneProps): JSX.Elemen
           description="Need at least 2 quarters with both income + balance data."
         />
       ) : (
-        <>
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <FundamentalCell
-              label="Revenue"
-              values={series.map((r) => r.revenue)}
-              stroke="text-sky-500"
-            />
-            <FundamentalCell
-              label="Op income"
-              values={series.map((r) => r.operatingIncome)}
-              stroke="text-emerald-500"
-            />
-            <FundamentalCell
-              label="Net income"
-              values={series.map((r) => r.netIncome)}
-              stroke="text-emerald-500"
-            />
-            <FundamentalCell
-              label="Total debt"
-              values={series.map((r) => r.totalDebt)}
-              stroke="text-amber-500"
-            />
-          </div>
-          {/* Footer link only shown when data is present — not during
-              skeleton / error / empty states (see review-prevention-log). */}
-          <div className="mt-2 border-t border-slate-100 pt-1.5 text-right">
-            <Link
-              to={`/instrument/${encodeURIComponent(symbol)}?tab=financials`}
-              className="text-[11px] text-sky-700 hover:underline"
-            >
-              View statements →
-            </Link>
-          </div>
-        </>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <FundamentalCell
+            label="Revenue"
+            values={series.map((r) => r.revenue)}
+            stroke="text-sky-500"
+          />
+          <FundamentalCell
+            label="Op income"
+            values={series.map((r) => r.operatingIncome)}
+            stroke="text-emerald-500"
+          />
+          <FundamentalCell
+            label="Net income"
+            values={series.map((r) => r.netIncome)}
+            stroke="text-emerald-500"
+          />
+          <FundamentalCell
+            label="Total debt"
+            values={series.map((r) => r.totalDebt)}
+            stroke="text-amber-500"
+          />
+        </div>
       )}
-    </Section>
+    </Pane>
   );
 }
 

--- a/frontend/src/components/instrument/InsiderActivitySummary.test.tsx
+++ b/frontend/src/components/instrument/InsiderActivitySummary.test.tsx
@@ -37,6 +37,18 @@ describe("InsiderActivitySummary", () => {
     expect(screen.getByText("2026-04-13")).toBeInTheDocument();
   });
 
+  it("renders Pane chrome with scope and source", async () => {
+    vi.spyOn(api, "fetchInsiderSummary").mockResolvedValue(payload);
+    render(
+      <MemoryRouter>
+        <InsiderActivitySummary symbol="GME" />
+      </MemoryRouter>,
+    );
+    // After data loads, chrome shows scope and source
+    expect(await screen.findByText("last 90 days")).toBeInTheDocument();
+    expect(screen.getByText(/SEC Form 4/)).toBeInTheDocument();
+  });
+
   it("renders negative NET with leading minus when disposed > acquired", async () => {
     vi.spyOn(api, "fetchInsiderSummary").mockResolvedValue({
       ...payload,

--- a/frontend/src/components/instrument/InsiderActivitySummary.tsx
+++ b/frontend/src/components/instrument/InsiderActivitySummary.tsx
@@ -11,7 +11,8 @@
 
 import { fetchInsiderSummary } from "@/api/instruments";
 import type { InsiderSummary } from "@/api/instruments";
-import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { Pane } from "@/components/instrument/Pane";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback } from "react";
@@ -47,7 +48,11 @@ export function InsiderActivitySummary({
   );
 
   return (
-    <Section title="Insider activity (90d)">
+    <Pane
+      title="Insider activity"
+      scope="last 90 days"
+      source={{ providers: ["sec_form4"] }}
+    >
       {state.loading ? (
         <SectionSkeleton rows={2} />
       ) : state.error !== null ? (
@@ -96,7 +101,7 @@ export function InsiderActivitySummary({
           );
         })()
       )}
-    </Section>
+    </Pane>
   );
 }
 

--- a/frontend/src/components/instrument/KeyStatsPane.test.tsx
+++ b/frontend/src/components/instrument/KeyStatsPane.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { KeyStatsPane } from "./KeyStatsPane";
+import type { InstrumentSummary } from "@/api/types";
+
+function fixture(stats: Partial<InstrumentSummary["key_stats"]> | null): InstrumentSummary {
+  return {
+    identity: {
+      symbol: "X",
+      display_name: null,
+      sector: null,
+      market_cap: "1000000000",
+    },
+    key_stats:
+      stats === null
+        ? null
+        : ({
+            pe_ratio: "32.48",
+            pb_ratio: null,
+            dividend_yield: null,
+            payout_ratio: null,
+            roe: null,
+            roa: null,
+            debt_to_equity: "3.15",
+            revenue_growth_yoy: null,
+            earnings_growth_yoy: null,
+            field_source: { pe_ratio: "sec_xbrl", debt_to_equity: "sec_xbrl" },
+            ...stats,
+          } as InstrumentSummary["key_stats"]),
+    capabilities: {},
+  } as InstrumentSummary;
+}
+
+describe("KeyStatsPane", () => {
+  it("renders rows with non-null values, drops fully-null rows, keeps per-row source tag", () => {
+    render(<KeyStatsPane summary={fixture({})} />);
+    expect(screen.getByText("P/E ratio")).toBeInTheDocument();
+    expect(screen.getByText("Debt / Equity")).toBeInTheDocument();
+    // Dividend yield is null → row dropped.
+    expect(screen.queryByText("Dividend yield")).not.toBeInTheDocument();
+    // Per-row source tag still rendered (e.g. "SEC" badge for pe_ratio + debt_to_equity).
+    expect(screen.getAllByText("SEC").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders empty state when key_stats is null", () => {
+    render(<KeyStatsPane summary={fixture(null)} />);
+    expect(screen.getByText(/No key stats/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/instrument/KeyStatsPane.tsx
+++ b/frontend/src/components/instrument/KeyStatsPane.tsx
@@ -1,0 +1,123 @@
+import { Pane } from "@/components/instrument/Pane";
+import { EmptyState } from "@/components/states/EmptyState";
+import type { InstrumentSummary, KeyStatsFieldSource } from "@/api/types";
+
+function formatDecimal(
+  value: string | null | undefined,
+  opts: { percent?: boolean } = {},
+): string | null {
+  if (value === null || value === undefined) return null;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  if (opts.percent) return `${(num * 100).toFixed(2)}%`;
+  return num.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
+function formatMarketCap(value: string | null): string | null {
+  if (value === null) return null;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  if (num >= 1e12) return `${(num / 1e12).toFixed(2)}T`;
+  if (num >= 1e9) return `${(num / 1e9).toFixed(2)}B`;
+  if (num >= 1e6) return `${(num / 1e6).toFixed(2)}M`;
+  return num.toLocaleString();
+}
+
+function FieldSourceTag({ source }: { source: KeyStatsFieldSource | undefined }) {
+  if (!source) return null;
+  let tone = "bg-slate-100 text-slate-600";
+  let label: string = source;
+  switch (source) {
+    case "sec_xbrl":
+      tone = "bg-emerald-50 text-emerald-700";
+      label = "SEC";
+      break;
+    case "sec_dividend_summary":
+      tone = "bg-emerald-50 text-emerald-700";
+      label = "SEC · div";
+      break;
+    case "sec_xbrl_price_missing":
+      tone = "bg-amber-50 text-amber-700";
+      label = "SEC · price?";
+      break;
+    case "unavailable":
+      tone = "bg-slate-100 text-slate-500";
+      label = "—";
+      break;
+  }
+  return (
+    <span className={`ml-2 rounded px-1.5 py-0.5 text-[10px] uppercase ${tone}`}>
+      {label}
+    </span>
+  );
+}
+
+interface Row {
+  label: string;
+  value: string;
+  source?: KeyStatsFieldSource;
+}
+
+function makeRow(
+  value: string | null,
+  label: string,
+  source: KeyStatsFieldSource | undefined,
+): Row | null {
+  if (value === null) return null;
+  return { label, value, source };
+}
+
+function buildRows(summary: InstrumentSummary): Row[] {
+  const stats = summary.key_stats;
+  if (stats === null) return [];
+  const fs = stats.field_source ?? {};
+  const candidates: Array<Row | null> = [
+    makeRow(formatMarketCap(summary.identity.market_cap), "Market cap", undefined),
+    makeRow(formatDecimal(stats.pe_ratio), "P/E ratio", fs["pe_ratio"]),
+    makeRow(formatDecimal(stats.pb_ratio), "P/B ratio", fs["pb_ratio"]),
+    makeRow(formatDecimal(stats.dividend_yield, { percent: true }), "Dividend yield", fs["dividend_yield"]),
+    makeRow(formatDecimal(stats.payout_ratio, { percent: true }), "Payout ratio", fs["payout_ratio"]),
+    makeRow(formatDecimal(stats.roe, { percent: true }), "ROE", fs["roe"]),
+    makeRow(formatDecimal(stats.roa, { percent: true }), "ROA", fs["roa"]),
+    makeRow(formatDecimal(stats.debt_to_equity), "Debt / Equity", fs["debt_to_equity"]),
+    makeRow(formatDecimal(stats.revenue_growth_yoy, { percent: true }), "Revenue growth (YoY)", fs["revenue_growth_yoy"]),
+    makeRow(formatDecimal(stats.earnings_growth_yoy, { percent: true }), "Earnings growth (YoY)", fs["earnings_growth_yoy"]),
+  ];
+  return candidates.filter((r): r is Row => r !== null);
+}
+
+export interface KeyStatsPaneProps {
+  readonly summary: InstrumentSummary;
+}
+
+export function KeyStatsPane({ summary }: KeyStatsPaneProps): JSX.Element {
+  const rows = buildRows(summary);
+  return (
+    <Pane title="Key statistics">
+      {summary.key_stats === null ? (
+        <EmptyState
+          title="No key stats"
+          description="No provider returned key stats for this ticker."
+        />
+      ) : (
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          {rows.map((r) => (
+            <KeyStatRow key={r.label} row={r} />
+          ))}
+        </dl>
+      )}
+    </Pane>
+  );
+}
+
+function KeyStatRow({ row }: { row: Row }): JSX.Element {
+  return (
+    <>
+      <dt className="text-slate-500">{row.label}</dt>
+      <dd className="flex items-center tabular-nums">
+        <span>{row.value}</span>
+        <FieldSourceTag source={row.source} />
+      </dd>
+    </>
+  );
+}

--- a/frontend/src/components/instrument/Pane.test.tsx
+++ b/frontend/src/components/instrument/Pane.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { Pane } from "./Pane";
+
+describe("Pane", () => {
+  it("renders header title and body content", () => {
+    render(
+      <Pane title="Recent filings">
+        <p>row content</p>
+      </Pane>,
+    );
+    expect(screen.getByRole("heading", { name: /recent filings/i })).toBeInTheDocument();
+    expect(screen.getByText("row content")).toBeInTheDocument();
+  });
+
+  it("does not attach onClick to the outer article (button-only drill)", async () => {
+    const onExpand = vi.fn();
+    render(
+      <Pane title="Filings" onExpand={onExpand}>
+        <p>body</p>
+      </Pane>,
+    );
+    // Clicking the body must NOT trigger onExpand.
+    await userEvent.click(screen.getByText("body"));
+    expect(onExpand).not.toHaveBeenCalled();
+    // Clicking the Open button MUST trigger onExpand.
+    await userEvent.click(screen.getByRole("button", { name: /open/i }));
+    expect(onExpand).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/instrument/Pane.tsx
+++ b/frontend/src/components/instrument/Pane.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+import { PaneHeader } from "./PaneHeader";
+import type { PaneHeaderProps } from "./PaneHeader";
+
+export interface PaneProps extends PaneHeaderProps {
+  readonly children: ReactNode;
+  /** Optional className overrides on the outer article. */
+  readonly className?: string;
+}
+
+export function Pane({
+  title,
+  scope,
+  source,
+  onExpand,
+  className,
+  children,
+}: PaneProps): JSX.Element {
+  return (
+    <article
+      className={`rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm ${className ?? ""}`}
+    >
+      <PaneHeader
+        title={title}
+        scope={scope}
+        source={source}
+        onExpand={onExpand}
+      />
+      <div className="mt-2">{children}</div>
+    </article>
+  );
+}

--- a/frontend/src/components/instrument/PaneHeader.test.tsx
+++ b/frontend/src/components/instrument/PaneHeader.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { PaneHeader } from "./PaneHeader";
+
+describe("PaneHeader", () => {
+  it("renders title only with no optional props", () => {
+    render(<PaneHeader title="Recent filings" />);
+    expect(screen.getByRole("heading", { name: /recent filings/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /open/i })).not.toBeInTheDocument();
+  });
+
+  it("renders scope text when provided", () => {
+    render(<PaneHeader title="Insider activity" scope="last 90 days" />);
+    expect(screen.getByText("last 90 days")).toBeInTheDocument();
+  });
+
+  it("renders provider source label", () => {
+    render(
+      <PaneHeader
+        title="Recent filings"
+        source={{ providers: ["sec_edgar"] }}
+      />,
+    );
+    expect(screen.getByText(/SEC EDGAR/)).toBeInTheDocument();
+  });
+
+  it("renders Open button only when onExpand is defined and calls it on click", async () => {
+    const onExpand = vi.fn();
+    render(<PaneHeader title="Filings" onExpand={onExpand} />);
+    const btn = screen.getByRole("button", { name: /open/i });
+    await userEvent.click(btn);
+    expect(onExpand).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/instrument/PaneHeader.tsx
+++ b/frontend/src/components/instrument/PaneHeader.tsx
@@ -1,0 +1,55 @@
+import { providerLabel } from "@/lib/capabilityProviders";
+
+export interface PaneHeaderProps {
+  readonly title: string;
+  readonly scope?: string;
+  readonly source?: {
+    readonly providers: ReadonlyArray<string>;
+    readonly lastSync?: string;
+  };
+  readonly onExpand?: () => void; // renders "Open →" button (button-only — no card-click)
+}
+
+export function PaneHeader({
+  title,
+  scope,
+  source,
+  onExpand,
+}: PaneHeaderProps): JSX.Element {
+  const sourceText =
+    source && source.providers.length > 0
+      ? source.providers.map(providerLabel).join(" · ") +
+        (source.lastSync ? ` · ${source.lastSync}` : "")
+      : null;
+  return (
+    <header className="flex items-baseline justify-between gap-2 border-b border-slate-100 pb-1.5">
+      <div className="flex min-w-0 items-baseline gap-2">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-600">
+          {title}
+        </h2>
+        {scope ? (
+          <span className="text-[10px] text-slate-500">{scope}</span>
+        ) : null}
+      </div>
+      <div className="flex flex-shrink-0 items-center gap-2">
+        {sourceText !== null ? (
+          <span
+            className="truncate rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600"
+            title={sourceText}
+          >
+            {sourceText}
+          </span>
+        ) : null}
+        {onExpand !== undefined ? (
+          <button
+            type="button"
+            onClick={onExpand}
+            className="text-[11px] text-sky-700 hover:underline focus-visible:rounded focus-visible:outline-2 focus-visible:outline-sky-500"
+          >
+            Open →
+          </button>
+        ) : null}
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/instrument/RecentNewsPane.test.tsx
+++ b/frontend/src/components/instrument/RecentNewsPane.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { RecentNewsPane } from "./RecentNewsPane";
+import * as newsApi from "@/api/news";
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async (importActual) => {
+  const actual = (await importActual()) as object;
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  navigateMock.mockReset();
+});
+
+function makeItem(id: number) {
+  return {
+    news_event_id: id,
+    event_time: "2026-04-20T00:00:00Z",
+    headline: `Headline ${id}`,
+    snippet: null,
+    category: null,
+    sentiment_score: null,
+    source: null,
+    url: null,
+  };
+}
+
+describe("RecentNewsPane", () => {
+  it("renders up to 5 items when feed has data", async () => {
+    vi.spyOn(newsApi, "fetchNews").mockResolvedValueOnce({
+      items: Array.from({ length: 7 }, (_, i) => makeItem(i)),
+      total: 7,
+    } as never);
+    render(
+      <MemoryRouter>
+        <RecentNewsPane instrumentId={1} symbol="X" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("Headline 0")).toBeInTheDocument());
+    // No more than 5 items rendered
+    const items = screen.queryAllByText(/^Headline /);
+    expect(items.length).toBeLessThanOrEqual(5);
+  });
+
+  it("returns null when feed is empty (no card)", async () => {
+    vi.spyOn(newsApi, "fetchNews").mockResolvedValueOnce({
+      items: [],
+      total: 0,
+    } as never);
+    const { container } = render(
+      <MemoryRouter>
+        <RecentNewsPane instrumentId={1} symbol="X" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
+});

--- a/frontend/src/components/instrument/RecentNewsPane.tsx
+++ b/frontend/src/components/instrument/RecentNewsPane.tsx
@@ -1,0 +1,65 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { fetchNews } from "@/api/news";
+import type { NewsListResponse } from "@/api/types";
+import { Pane } from "@/components/instrument/Pane";
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { useAsync } from "@/lib/useAsync";
+
+const ROW_LIMIT = 5;
+
+export interface RecentNewsPaneProps {
+  readonly instrumentId: number;
+  readonly symbol: string;
+}
+
+export function RecentNewsPane({
+  instrumentId,
+  symbol,
+}: RecentNewsPaneProps): JSX.Element | null {
+  const state = useAsync<NewsListResponse>(
+    useCallback(() => fetchNews(instrumentId, 0, ROW_LIMIT), [instrumentId]),
+    [instrumentId],
+  );
+  const navigate = useNavigate();
+
+  if (state.loading) {
+    return (
+      <Pane title="Recent news">
+        <SectionSkeleton rows={4} />
+      </Pane>
+    );
+  }
+  if (state.error !== null) {
+    return (
+      <Pane title="Recent news">
+        <SectionError onRetry={state.refetch} />
+      </Pane>
+    );
+  }
+  if (state.data === null || state.data.items.length === 0) {
+    return null;
+  }
+
+  const items = state.data.items.slice(0, ROW_LIMIT);
+  return (
+    <Pane
+      title="Recent news"
+      onExpand={() =>
+        navigate(`/instrument/${encodeURIComponent(symbol)}?tab=news`)
+      }
+    >
+      <ul className="space-y-1.5 text-xs">
+        {items.map((n) => (
+          <li key={n.news_event_id} className="flex items-baseline gap-2">
+            <span className="text-slate-500">
+              {n.event_time.slice(0, 10)}
+            </span>
+            <span className="truncate text-slate-700">{n.headline}</span>
+          </li>
+        ))}
+      </ul>
+    </Pane>
+  );
+}

--- a/frontend/src/components/instrument/ResearchTab.tsx
+++ b/frontend/src/components/instrument/ResearchTab.tsx
@@ -1,163 +1,10 @@
-/**
- * ResearchTab — default tab of the per-stock research page (Slice 1 of
- * docs/superpowers/specs/2026-04-20-per-stock-research-page.md).
- *
- * Composes existing data into one operator view: key stats with
- * field_source provenance, thesis memo if present, break conditions.
- * Phase 3 (#559): delegates layout to DensityGrid which puts the chart
- * top-left and arranges all panes in a Bloomberg-style 3-column grid.
- */
-import { Section } from "@/components/dashboard/Section";
 import { DensityGrid } from "@/components/instrument/DensityGrid";
-import { EmptyState } from "@/components/states/EmptyState";
 import type { InstrumentSummary, ThesisDetail } from "@/api/types";
 
-function formatDecimal(
-  value: string | null | undefined,
-  opts: { percent?: boolean } = {},
-): string {
-  if (value === null || value === undefined) return "—";
-  const num = Number(value);
-  if (!Number.isFinite(num)) return "—";
-  if (opts.percent) return `${(num * 100).toFixed(2)}%`;
-  return num.toLocaleString(undefined, { maximumFractionDigits: 2 });
-}
-
-function formatMarketCap(value: string | null): string {
-  if (value === null) return "—";
-  const num = Number(value);
-  if (!Number.isFinite(num)) return "—";
-  if (num >= 1e12) return `${(num / 1e12).toFixed(2)}T`;
-  if (num >= 1e9) return `${(num / 1e9).toFixed(2)}B`;
-  if (num >= 1e6) return `${(num / 1e6).toFixed(2)}M`;
-  return num.toLocaleString();
-}
-
-function FieldSourceTag({ source }: { source: string | undefined }) {
-  if (!source) return null;
-  // Colour-code the provenance so the operator sees at-a-glance where
-  // each figure came from. Matches the KeyStatsFieldSource union from
-  // frontend/src/api/types.ts.
-  let tone = "bg-slate-100 text-slate-600";
-  let label = source;
-  switch (source) {
-    case "sec_xbrl":
-      tone = "bg-emerald-50 text-emerald-700";
-      label = "SEC";
-      break;
-    case "sec_dividend_summary":
-      tone = "bg-emerald-50 text-emerald-700";
-      label = "SEC · div";
-      break;
-    case "sec_xbrl_price_missing":
-      tone = "bg-amber-50 text-amber-700";
-      label = "SEC · price?";
-      break;
-    case "unavailable":
-      tone = "bg-slate-100 text-slate-500";
-      label = "—";
-      break;
-  }
-  return (
-    <span className={`ml-2 rounded px-1.5 py-0.5 text-[10px] uppercase ${tone}`}>
-      {label}
-    </span>
-  );
-}
-
-function KeyStat({
-  label,
-  value,
-  source,
-}: {
-  label: string;
-  value: string;
-  source?: string;
-}) {
-  return (
-    <>
-      <dt className="text-slate-500">{label}</dt>
-      <dd className="flex items-center tabular-nums">
-        <span>{value}</span>
-        <FieldSourceTag source={source} />
-      </dd>
-    </>
-  );
-}
-
-function ThesisPanel({
-  thesis,
-  errored,
-}: {
-  thesis: ThesisDetail | null;
-  errored: boolean;
-}) {
-  if (errored) {
-    return (
-      <EmptyState
-        title="Thesis temporarily unavailable"
-        description="Failed to fetch the latest thesis. Retry via the Generate thesis button in the strip above."
-      />
-    );
-  }
-  if (thesis === null) {
-    return (
-      <EmptyState
-        title="No thesis yet"
-        description="Generate one from the strip above — the AI will pull the latest filings, news, and fundamentals to draft a buy/hold/exit memo."
-      />
-    );
-  }
-  const breaks = thesis.break_conditions_json ?? [];
-  return (
-    <div className="space-y-3 text-sm">
-      <div className="whitespace-pre-wrap text-slate-700">
-        {thesis.memo_markdown}
-      </div>
-      {(thesis.base_value !== null ||
-        thesis.bull_value !== null ||
-        thesis.bear_value !== null) && (
-        <dl className="grid grid-cols-3 gap-2 rounded bg-slate-50 p-3 text-xs">
-          <div>
-            <dt className="text-slate-500">Bear</dt>
-            <dd className="font-medium tabular-nums">
-              {thesis.bear_value !== null ? thesis.bear_value : "—"}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-slate-500">Base</dt>
-            <dd className="font-medium tabular-nums">
-              {thesis.base_value !== null ? thesis.base_value : "—"}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-slate-500">Bull</dt>
-            <dd className="font-medium tabular-nums">
-              {thesis.bull_value !== null ? thesis.bull_value : "—"}
-            </dd>
-          </div>
-        </dl>
-      )}
-      {breaks.length > 0 && (
-        <div>
-          <div className="mb-1 text-xs font-medium uppercase tracking-wider text-slate-500">
-            Break conditions
-          </div>
-          <ul className="list-inside list-disc space-y-0.5 text-xs text-slate-600">
-            {breaks.map((b, i) => (
-              <li key={i}>{b}</li>
-            ))}
-          </ul>
-        </div>
-      )}
-    </div>
-  );
-}
-
 export interface ResearchTabProps {
-  summary: InstrumentSummary;
-  thesis: ThesisDetail | null;
-  thesisErrored?: boolean;
+  readonly summary: InstrumentSummary;
+  readonly thesis: ThesisDetail | null;
+  readonly thesisErrored?: boolean;
 }
 
 export function ResearchTab({
@@ -165,51 +12,11 @@ export function ResearchTab({
   thesis,
   thesisErrored = false,
 }: ResearchTabProps): JSX.Element {
-  const stats = summary.key_stats;
-  const fs = stats?.field_source ?? undefined;
-
-  const keyStatsBlock = (
-    <Section title="Key statistics">
-      {stats === null ? (
-        <EmptyState
-          title="No key stats"
-          description="No provider returned key stats for this ticker."
-        />
-      ) : (
-        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
-          <KeyStat label="Market cap" value={formatMarketCap(summary.identity.market_cap)} />
-          <KeyStat label="P/E ratio" value={formatDecimal(stats.pe_ratio)} source={fs?.pe_ratio} />
-          <KeyStat label="P/B ratio" value={formatDecimal(stats.pb_ratio)} source={fs?.pb_ratio} />
-          <KeyStat label="Dividend yield" value={formatDecimal(stats.dividend_yield, { percent: true })} source={fs?.dividend_yield} />
-          <KeyStat label="Payout ratio" value={formatDecimal(stats.payout_ratio, { percent: true })} source={fs?.payout_ratio} />
-          <KeyStat label="ROE" value={formatDecimal(stats.roe, { percent: true })} source={fs?.roe} />
-          <KeyStat label="ROA" value={formatDecimal(stats.roa, { percent: true })} source={fs?.roa} />
-          <KeyStat label="Debt / Equity" value={formatDecimal(stats.debt_to_equity)} source={fs?.debt_to_equity} />
-          <KeyStat label="Revenue growth (YoY)" value={formatDecimal(stats.revenue_growth_yoy, { percent: true })} source={fs?.revenue_growth_yoy} />
-          <KeyStat label="Earnings growth (YoY)" value={formatDecimal(stats.earnings_growth_yoy, { percent: true })} source={fs?.earnings_growth_yoy} />
-        </dl>
-      )}
-    </Section>
-  );
-
-  const thesisBlock = (
-    <Section title="Thesis">
-      <ThesisPanel thesis={thesis} errored={thesisErrored} />
-    </Section>
-  );
-
-  const newsBlock = (
-    <Section title="Recent news">
-      <p className="text-xs text-slate-500">News tab still has the full feed.</p>
-    </Section>
-  );
-
   return (
     <DensityGrid
       summary={summary}
-      keyStatsBlock={keyStatsBlock}
-      thesisBlock={thesisBlock}
-      newsBlock={newsBlock}
+      thesis={thesis}
+      thesisErrored={thesisErrored}
     />
   );
 }

--- a/frontend/src/components/instrument/SecProfilePanel.test.tsx
+++ b/frontend/src/components/instrument/SecProfilePanel.test.tsx
@@ -83,4 +83,12 @@ describe("SecProfilePanel", () => {
       expect(screen.getByText(/Failed to load/i)).toBeInTheDocument();
     });
   });
+
+  it("renders Pane chrome with sec_edgar source", async () => {
+    mockFetch.mockResolvedValue(seededProfile());
+    render(<SecProfilePanel symbol="AAPL" />);
+
+    await screen.findByText(/Designs consumer electronics/);
+    expect(screen.getByText(/SEC EDGAR/)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/instrument/SecProfilePanel.tsx
+++ b/frontend/src/components/instrument/SecProfilePanel.tsx
@@ -18,10 +18,10 @@ import type {
   InstrumentSecProfile,
 } from "@/api/instruments";
 import {
-  Section,
   SectionError,
   SectionSkeleton,
 } from "@/components/dashboard/Section";
+import { Pane } from "@/components/instrument/Pane";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback } from "react";
@@ -41,7 +41,7 @@ export function SecProfilePanel({ symbol }: SecProfilePanelProps) {
   );
 
   return (
-    <Section title="Company profile (SEC)">
+    <Pane title="Company profile" source={{ providers: ["sec_edgar"] }}>
       {state.loading ? (
         <SectionSkeleton rows={4} />
       ) : state.error !== null ? (
@@ -54,7 +54,7 @@ export function SecProfilePanel({ symbol }: SecProfilePanelProps) {
       ) : (
         <Body profile={state.data} headcount={headcount.data} />
       )}
-    </Section>
+    </Pane>
   );
 }
 

--- a/frontend/src/components/instrument/ThesisPane.test.tsx
+++ b/frontend/src/components/instrument/ThesisPane.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ThesisPane } from "./ThesisPane";
+import type { ThesisDetail } from "@/api/types";
+
+const FIXTURE = {
+  thesis_id: 1,
+  instrument_id: 1,
+  memo_markdown: "Buy on weakness.",
+  bear_value: "10",
+  base_value: "20",
+  bull_value: "30",
+  break_conditions_json: ["Lose 50% market share"],
+} as unknown as ThesisDetail;
+
+describe("ThesisPane", () => {
+  it("renders memo + bear/base/bull when thesis present", () => {
+    const { container } = render(<ThesisPane thesis={FIXTURE} errored={false} />);
+    expect(screen.getByText("Buy on weakness.")).toBeInTheDocument();
+    expect(screen.getByText("Bear")).toBeInTheDocument();
+    expect(screen.getByText("Base")).toBeInTheDocument();
+    expect(screen.getByText("Bull")).toBeInTheDocument();
+    expect(container.querySelector("article")).not.toBeNull();
+  });
+
+  it("returns null when thesis is null and not errored (no card)", () => {
+    const { container } = render(<ThesisPane thesis={null} errored={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders error UI inside Pane when errored", () => {
+    render(<ThesisPane thesis={null} errored={true} />);
+    expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/instrument/ThesisPane.tsx
+++ b/frontend/src/components/instrument/ThesisPane.tsx
@@ -1,0 +1,75 @@
+import { Pane } from "@/components/instrument/Pane";
+import { EmptyState } from "@/components/states/EmptyState";
+import type { ThesisDetail } from "@/api/types";
+
+export interface ThesisPaneProps {
+  readonly thesis: ThesisDetail | null;
+  readonly errored: boolean;
+}
+
+export function ThesisPane({
+  thesis,
+  errored,
+}: ThesisPaneProps): JSX.Element | null {
+  if (thesis === null && !errored) return null;
+
+  return (
+    <Pane title="Thesis">
+      {errored ? (
+        <EmptyState
+          title="Thesis temporarily unavailable"
+          description="Failed to fetch the latest thesis. Retry via the Generate thesis button in the strip above."
+        />
+      ) : (
+        <ThesisBody thesis={thesis as ThesisDetail} />
+      )}
+    </Pane>
+  );
+}
+
+function ThesisBody({ thesis }: { thesis: ThesisDetail }): JSX.Element {
+  const breaks = thesis.break_conditions_json ?? [];
+  return (
+    <div className="space-y-3 text-sm">
+      <div className="whitespace-pre-wrap text-slate-700">
+        {thesis.memo_markdown}
+      </div>
+      {(thesis.base_value !== null ||
+        thesis.bull_value !== null ||
+        thesis.bear_value !== null) && (
+        <dl className="grid grid-cols-3 gap-2 rounded bg-slate-50 p-3 text-xs">
+          <div>
+            <dt className="text-slate-500">Bear</dt>
+            <dd className="font-medium tabular-nums">
+              {thesis.bear_value !== null ? thesis.bear_value : "—"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-slate-500">Base</dt>
+            <dd className="font-medium tabular-nums">
+              {thesis.base_value !== null ? thesis.base_value : "—"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-slate-500">Bull</dt>
+            <dd className="font-medium tabular-nums">
+              {thesis.bull_value !== null ? thesis.bull_value : "—"}
+            </dd>
+          </div>
+        </dl>
+      )}
+      {breaks.length > 0 && (
+        <div>
+          <div className="mb-1 text-xs font-medium uppercase tracking-wider text-slate-500">
+            Break conditions
+          </div>
+          <ul className="list-inside list-disc space-y-0.5 text-xs text-slate-600">
+            {breaks.map((b, i) => (
+              <li key={i}>{b}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/densityProfile.test.ts
+++ b/frontend/src/components/instrument/densityProfile.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { selectProfile } from "./densityProfile";
+import type { InstrumentSummary } from "@/api/types";
+
+function fixture(overrides: Partial<InstrumentSummary["capabilities"]>): InstrumentSummary {
+  return {
+    instrument_id: 1,
+    is_tradable: true,
+    coverage_tier: 1,
+    identity: { symbol: "X", display_name: null, sector: null, market_cap: null } as never,
+    price: null,
+    key_stats: null,
+    source: {},
+    has_sec_cik: false,
+    has_filings_coverage: false,
+    capabilities: { ...overrides } as InstrumentSummary["capabilities"],
+  } as InstrumentSummary;
+}
+
+describe("selectProfile", () => {
+  it("returns full-sec when sec_xbrl fundamentals + filings both active", () => {
+    const summary = fixture({
+      fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: true } },
+      filings: { providers: ["sec_edgar"], data_present: { sec_edgar: true } },
+    });
+    expect(selectProfile(summary)).toBe("full-sec");
+  });
+
+  it("returns partial-filings when filings active but no sec_xbrl fundamentals", () => {
+    const summary = fixture({
+      filings: { providers: ["companies_house"], data_present: { companies_house: true } },
+    });
+    expect(selectProfile(summary)).toBe("partial-filings");
+  });
+
+  it("returns partial-filings when sec_xbrl listed but no data present", () => {
+    const summary = fixture({
+      fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: false } },
+      filings: { providers: ["sec_edgar"], data_present: { sec_edgar: true } },
+    });
+    expect(selectProfile(summary)).toBe("partial-filings");
+  });
+
+  it("returns minimal when no fundamentals and no filings", () => {
+    const summary = fixture({});
+    expect(selectProfile(summary)).toBe("minimal");
+  });
+});

--- a/frontend/src/components/instrument/densityProfile.test.ts
+++ b/frontend/src/components/instrument/densityProfile.test.ts
@@ -46,4 +46,38 @@ describe("selectProfile", () => {
     const summary = fixture({});
     expect(selectProfile(summary)).toBe("minimal");
   });
+
+  it("returns partial-filings when has_sec_cik is true even without fundamentals or filings", () => {
+    const summary: InstrumentSummary = {
+      instrument_id: 1,
+      is_tradable: true,
+      coverage_tier: 1,
+      identity: { symbol: "X", display_name: null, sector: null, market_cap: null } as never,
+      price: null,
+      key_stats: null,
+      source: {},
+      has_sec_cik: true,
+      has_filings_coverage: false,
+      capabilities: {},
+    } as InstrumentSummary;
+    expect(selectProfile(summary)).toBe("partial-filings");
+  });
+
+  it("returns partial-filings when only fundamentals active (no filings, no has_sec_cik)", () => {
+    const summary: InstrumentSummary = {
+      instrument_id: 1,
+      is_tradable: true,
+      coverage_tier: 1,
+      identity: { symbol: "X", display_name: null, sector: null, market_cap: null } as never,
+      price: null,
+      key_stats: null,
+      source: {},
+      has_sec_cik: false,
+      has_filings_coverage: false,
+      capabilities: {
+        fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: true } },
+      },
+    } as InstrumentSummary;
+    expect(selectProfile(summary)).toBe("partial-filings");
+  });
 });

--- a/frontend/src/components/instrument/densityProfile.ts
+++ b/frontend/src/components/instrument/densityProfile.ts
@@ -8,15 +8,20 @@ export const EMPTY_CELL: { providers: string[]; data_present: Record<string, boo
   data_present: {},
 };
 
-export function selectProfile(summary: InstrumentSummary): DensityProfile {
-  const cap = summary.capabilities;
-  const fundCell = cap.fundamentals ?? EMPTY_CELL;
-  const hasFundamentals =
+export function hasFundamentalsActive(summary: InstrumentSummary): boolean {
+  const fundCell = summary.capabilities.fundamentals ?? EMPTY_CELL;
+  return (
     fundCell.providers.includes("sec_xbrl") &&
-    fundCell.data_present["sec_xbrl"] === true;
-  const hasFilings = activeProviders(cap.filings ?? EMPTY_CELL).length > 0;
+    fundCell.data_present["sec_xbrl"] === true
+  );
+}
 
-  if (hasFundamentals && hasFilings) return "full-sec";
-  if (hasFilings) return "partial-filings";
+export function selectProfile(summary: InstrumentSummary): DensityProfile {
+  const hasFunds = hasFundamentalsActive(summary);
+  const hasFilings =
+    activeProviders(summary.capabilities.filings ?? EMPTY_CELL).length > 0;
+
+  if (hasFunds && hasFilings) return "full-sec";
+  if (hasFunds || hasFilings || summary.has_sec_cik) return "partial-filings";
   return "minimal";
 }

--- a/frontend/src/components/instrument/densityProfile.ts
+++ b/frontend/src/components/instrument/densityProfile.ts
@@ -1,0 +1,19 @@
+import type { InstrumentSummary } from "@/api/types";
+import { activeProviders } from "@/lib/capabilityProviders";
+
+export type DensityProfile = "full-sec" | "partial-filings" | "minimal";
+
+const EMPTY_CELL = { providers: [] as string[], data_present: {} as Record<string, boolean> };
+
+export function selectProfile(summary: InstrumentSummary): DensityProfile {
+  const cap = summary.capabilities;
+  const fundCell = cap.fundamentals ?? EMPTY_CELL;
+  const hasFundamentals =
+    fundCell.providers.includes("sec_xbrl") &&
+    fundCell.data_present["sec_xbrl"] === true;
+  const hasFilings = activeProviders(cap.filings ?? EMPTY_CELL).length > 0;
+
+  if (hasFundamentals && hasFilings) return "full-sec";
+  if (hasFilings) return "partial-filings";
+  return "minimal";
+}

--- a/frontend/src/components/instrument/densityProfile.ts
+++ b/frontend/src/components/instrument/densityProfile.ts
@@ -3,7 +3,10 @@ import { activeProviders } from "@/lib/capabilityProviders";
 
 export type DensityProfile = "full-sec" | "partial-filings" | "minimal";
 
-const EMPTY_CELL = { providers: [] as string[], data_present: {} as Record<string, boolean> };
+export const EMPTY_CELL: { providers: string[]; data_present: Record<string, boolean> } = {
+  providers: [],
+  data_present: {},
+};
 
 export function selectProfile(summary: InstrumentSummary): DensityProfile {
   const cap = summary.capabilities;

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -137,8 +137,7 @@ function formatDecimal(
 // Header + Overview tab removed in Slice 1 — replaced by
 // `components/instrument/SummaryStrip.tsx` (sticky strip) and
 // `components/instrument/ResearchTab.tsx` (Research tab content).
-// `formatDecimal` is still used by the Financials tab below;
-// `formatMarketCap` moved to ResearchTab.
+// `formatDecimal` is still used by the Financials tab below.
 
 // ---------------------------------------------------------------------------
 // Financials tab


### PR DESCRIPTION
## What

- Hide truly-empty thesis / news / dividends panes (no more vestigial empty cards)
- Unbundle dividends + insider combined card (`overflow-auto max-h-[360px]` wrapper gone)
- 12-col grid with 3 capability profiles (`full-sec`, `partial-filings`, `minimal`)
- New `<Pane>` + `<PaneHeader>` primitives — every instrument-page pane uses them
- `Open →` button on PaneHeader replaces footer-link drill affordances (button-only, no whole-card click)
- ResearchTab thinned to 22-line pass-through

## Why

Closes #575. Operator review of post-#567 page (screenshots 2026-04-27) flagged squish on high-signal panes (filings cramped to 1fr while insider got full-width with 5 stat fields), empty-card waste (thesis "No thesis yet", news placeholder string, dividends scroll box on empty content), and inconsistent pane chrome.

Codex direction: stay on page-plus-route model, no drawer/ribbon/universal-L3-contract — prove simpler model insufficient first.

Spec: `docs/superpowers/specs/2026-04-27-instrument-detail-polish-round-2-design.md`. Codex reviewed plan + spec + final diff; pre-push review approved (P1/P2 fundamentals-only and SEC-CIK-only regressions caught and fixed before push).

## Test plan

- `pnpm --dir frontend test:unit` (455 tests, +27 new)
- `uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest` all green
- Manual: `/instrument/GME` (full-sec) — thesis/dividends panes absent (empty), filings col-7 wider than insider col-5
- Manual: needs verification on a UK Companies House instrument and a crypto/forex instrument once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)