### PR TITLE
fix(#575): FundamentalsPane returns null on insufficient series

### DIFF
--- a/frontend/src/components/instrument/FundamentalsPane.test.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.test.tsx
@@ -183,4 +183,70 @@ describe("FundamentalsPane", () => {
     // Latest total debt = 150 + 30 = 180
     expect(await screen.findByText(/180/)).toBeInTheDocument();
   });
+
+  it("returns null when capability active but joined series is empty (e.g. SEC ingest before any quarters)", async () => {
+    vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
+      ((_symbol: string, query: { statement: string }) =>
+        Promise.resolve({
+          symbol: "GME",
+          statement: query.statement,
+          period: "quarterly",
+          currency: "USD",
+          source: "sec_xbrl",
+          rows: [],
+        })) as never,
+    );
+    const { container } = render(
+      <MemoryRouter>
+        <FundamentalsPane summary={makeSummary(true)} />
+      </MemoryRouter>,
+    );
+    // Wait for both async fetches to settle, then assert no card.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when capability active but only 1 quarter has both income + balance data", async () => {
+    vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
+      ((_symbol: string, query: { statement: string }) => {
+        if (query.statement === "income") {
+          return Promise.resolve({
+            symbol: "GME",
+            statement: "income",
+            period: "quarterly",
+            currency: "USD",
+            source: "sec_xbrl",
+            rows: [
+              {
+                period_end: "2026-03-30",
+                period_type: "Q1",
+                values: { revenue: "100", operating_income: "10", net_income: "5" },
+              },
+            ],
+          });
+        }
+        return Promise.resolve({
+          symbol: "GME",
+          statement: "balance",
+          period: "quarterly",
+          currency: "USD",
+          source: "sec_xbrl",
+          rows: [
+            {
+              period_end: "2026-03-30",
+              period_type: "Q1",
+              values: { long_term_debt: "100", short_term_debt: "20" },
+            },
+          ],
+        });
+      }) as never,
+    );
+    const { container } = render(
+      <MemoryRouter>
+        <FundamentalsPane summary={makeSummary(true)} />
+      </MemoryRouter>,
+    );
+    await new Promise((r) => setTimeout(r, 30));
+    expect(container.firstChild).toBeNull();
+  });
 });

--- a/frontend/src/components/instrument/FundamentalsPane.test.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { FundamentalsPane } from "@/components/instrument/FundamentalsPane";
@@ -201,9 +201,7 @@ describe("FundamentalsPane", () => {
         <FundamentalsPane summary={makeSummary(true)} />
       </MemoryRouter>,
     );
-    // Wait for both async fetches to settle, then assert no card.
-    await new Promise((r) => setTimeout(r, 30));
-    expect(container.firstChild).toBeNull();
+    await waitFor(() => expect(container.firstChild).toBeNull());
   });
 
   it("returns null when capability active but only 1 quarter has both income + balance data", async () => {
@@ -246,7 +244,6 @@ describe("FundamentalsPane", () => {
         <FundamentalsPane summary={makeSummary(true)} />
       </MemoryRouter>,
     );
-    await new Promise((r) => setTimeout(r, 30));
-    expect(container.firstChild).toBeNull();
+    await waitFor(() => expect(container.firstChild).toBeNull());
   });
 });

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -14,7 +14,6 @@ import { fetchInstrumentFinancials } from "@/api/instruments";
 import type { InstrumentFinancialRow, InstrumentSummary } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { Pane } from "@/components/instrument/Pane";
-import { EmptyState } from "@/components/states/EmptyState";
 import { Sparkline } from "@/components/instrument/Sparkline";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback, useMemo } from "react";
@@ -128,6 +127,18 @@ export function FundamentalsPane({ summary }: FundamentalsPaneProps): JSX.Elemen
 
   if (!active) return null;
 
+  // Capability active but the joined series is too short to plot — return
+  // null to follow the polish round-2 four-state empty rule (no full
+  // empty-state cards on the instrument page). Loading + error states
+  // still render the Pane so the operator sees the chrome.
+  const insufficient =
+    !income.loading &&
+    !balance.loading &&
+    income.error === null &&
+    balance.error === null &&
+    series.length < 2;
+  if (insufficient) return null;
+
   return (
     <Pane
       title="Fundamentals"
@@ -139,11 +150,6 @@ export function FundamentalsPane({ summary }: FundamentalsPaneProps): JSX.Elemen
         <SectionSkeleton rows={3} />
       ) : income.error !== null || balance.error !== null ? (
         <SectionError onRetry={() => { income.refetch(); balance.refetch(); }} />
-      ) : series.length < 2 ? (
-        <EmptyState
-          title="Not enough fundamentals history"
-          description="Need at least 2 quarters with both income + balance data."
-        />
       ) : (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           <FundamentalCell


### PR DESCRIPTION
## What

`FundamentalsPane` returns `null` when SEC XBRL capability is active but the joined income+balance series has fewer than 2 quarters. Previously rendered a full `<EmptyState title="Not enough fundamentals history">` card, violating the polish round-2 four-state rule.

## Why

Operator review of post-#575 page flagged IEP rendering the full empty card (screenshot 2026-04-27). Same fix pattern as #575's `ThesisPane` / `RecentNewsPane` / `DividendsPanel` empty-state suppression. Loading + error states still render the Pane chrome so retry affordance stays visible.

## Test plan

- 2 new vitest cases (zero rows + single-quarter) assert `container.firstChild === null`
- `pnpm --dir frontend test:unit` (457 pass)
- `pnpm --dir frontend typecheck` clean
- `uv run ruff check . && uv run ruff format --check .` clean