### PR TITLE
feat(#578): dividends drill-through page + DividendsPanel trim

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { InstrumentDetailRedirect } from "@/pages/InstrumentDetailRedirect";
 import { InstrumentPage } from "@/pages/InstrumentPage";
 import { Tenk10KDrilldownPage } from "@/pages/Tenk10KDrilldownPage";
 import { EightKListPage } from "@/pages/EightKListPage";
+import { DividendsPage } from "@/pages/DividendsPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { RecommendationsPage } from "@/pages/RecommendationsPage";
 import { AdminPage } from "@/pages/AdminPage";
@@ -69,6 +70,10 @@ export function App() {
           <Route
             path="instrument/:symbol/filings/8-k"
             element={<EightKListPage />}
+          />
+          <Route
+            path="instrument/:symbol/dividends"
+            element={<DividendsPage />}
           />
           <Route path="copy-trading/:mirrorId" element={<CopyTradingPage />} />
           <Route path="recommendations" element={<RecommendationsPage />} />

--- a/frontend/src/components/instrument/DividendsPanel.test.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
 
 import type { InstrumentDividends } from "@/api/instruments";
 
@@ -9,9 +11,31 @@ vi.mock("@/api/instruments", () => ({
   fetchInstrumentDividends: vi.fn(),
 }));
 
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async (importActual) => {
+  const actual = (await importActual()) as object;
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
 import { fetchInstrumentDividends } from "@/api/instruments";
 const mockFetch = vi.mocked(fetchInstrumentDividends);
 
+function makePeriod(
+  fy: number,
+  qt: string,
+  date: string,
+  dps: string,
+): InstrumentDividends["history"][number] {
+  return {
+    period_end_date: date,
+    period_type: qt,
+    fiscal_year: fy,
+    fiscal_quarter: null,
+    dps_declared: dps,
+    dividends_paid: null,
+    reported_currency: "USD",
+  };
+}
 
 function paid(): InstrumentDividends {
   return {
@@ -27,38 +51,27 @@ function paid(): InstrumentDividends {
       dividend_currency: "USD",
     },
     history: [
-      {
-        period_end_date: "2025-12-28",
-        period_type: "Q4",
-        fiscal_year: 2025,
-        fiscal_quarter: 4,
-        dps_declared: "0.2500",
-        dividends_paid: "4000000000.0000",
-        reported_currency: "USD",
-      },
-      {
-        period_end_date: "2025-09-28",
-        period_type: "Q3",
-        fiscal_year: 2025,
-        fiscal_quarter: 3,
-        dps_declared: "0.2500",
-        dividends_paid: "3900000000.0000",
-        reported_currency: "USD",
-      },
+      makePeriod(2025, "Q4", "2025-12-28", "0.2500"),
+      makePeriod(2025, "Q3", "2025-09-28", "0.2500"),
     ],
     upcoming: [],
   };
 }
 
-
+function wrap(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 afterEach(() => vi.clearAllMocks());
 
+beforeEach(() => {
+  navigateMock.mockReset();
+});
 
 describe("DividendsPanel", () => {
   it("renders summary + per-quarter history for a paying instrument", async () => {
     mockFetch.mockResolvedValue(paid());
-    render(<DividendsPanel symbol="AAPL" provider="sec_dividend_summary" />);
+    wrap(<DividendsPanel symbol="AAPL" provider="sec_dividend_summary" />);
 
     await waitFor(() => {
       expect(screen.getByText(/TTM yield/i)).toBeInTheDocument();
@@ -77,7 +90,7 @@ describe("DividendsPanel", () => {
       history: [],
       upcoming: [],
     } as never);
-    const { container } = render(
+    const { container } = wrap(
       <DividendsPanel symbol="X" provider="sec_dividend_summary" />,
     );
     await waitFor(() => expect(container.firstChild).toBeNull());
@@ -90,7 +103,7 @@ describe("DividendsPanel", () => {
       history: [],
       upcoming: [{ ex_date: "2026-05-01" } as never],
     } as never);
-    render(<DividendsPanel symbol="X" provider="sec_dividend_summary" />);
+    wrap(<DividendsPanel symbol="X" provider="sec_dividend_summary" />);
     // Pane renders — the h2 title "Dividends" is present (source badge may also
     // contain the word; use getAllByText to avoid the "multiple elements" error).
     await waitFor(() =>
@@ -100,7 +113,7 @@ describe("DividendsPanel", () => {
 
   it("renders error state + retry on fetch failure", async () => {
     mockFetch.mockRejectedValue(new Error("boom"));
-    render(<DividendsPanel symbol="AAPL" provider="sec_dividend_summary" />);
+    wrap(<DividendsPanel symbol="AAPL" provider="sec_dividend_summary" />);
 
     await waitFor(() => {
       expect(screen.getByText(/Failed to load/i)).toBeInTheDocument();
@@ -121,7 +134,7 @@ describe("DividendsPanel", () => {
       },
     ];
     mockFetch.mockResolvedValue(withUpcoming);
-    render(<DividendsPanel symbol="AAPL" provider="sec_dividend_summary" />);
+    wrap(<DividendsPanel symbol="AAPL" provider="sec_dividend_summary" />);
 
     await waitFor(() => {
       expect(screen.getByText(/Next dividend/i)).toBeInTheDocument();
@@ -130,5 +143,39 @@ describe("DividendsPanel", () => {
     expect(screen.getByText(/2026-02-10/)).toBeInTheDocument();
     expect(screen.getByText(/2026-02-11/)).toBeInTheDocument();
     expect(screen.getByText(/2026-02-20/)).toBeInTheDocument();
+  });
+
+  it("renders at most 4 HistoryBar rows regardless of history length", async () => {
+    const data = paid();
+    // Extend history to 7 quarters.
+    data.history = [
+      makePeriod(2025, "Q4", "2025-12-28", "0.25"),
+      makePeriod(2025, "Q3", "2025-09-28", "0.25"),
+      makePeriod(2025, "Q2", "2025-06-28", "0.24"),
+      makePeriod(2025, "Q1", "2025-03-28", "0.24"),
+      makePeriod(2024, "Q4", "2024-12-28", "0.23"),
+      makePeriod(2024, "Q3", "2024-09-28", "0.23"),
+      makePeriod(2024, "Q2", "2024-06-28", "0.22"),
+    ];
+    mockFetch.mockResolvedValue(data);
+    wrap(<DividendsPanel symbol="AAPL" provider="sec_dividend_summary" />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/FY2025 Q4/)).toBeInTheDocument(),
+    );
+    // Exactly 4 progressbar elements (one per HistoryBar).
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars).toHaveLength(4);
+    // FY2024 Q2 must NOT appear — it is beyond the 4-row limit.
+    expect(screen.queryByText(/FY2024 Q2/)).toBeNull();
+  });
+
+  it("Open button navigates to /instrument/<symbol>/dividends", async () => {
+    mockFetch.mockResolvedValue(paid());
+    wrap(<DividendsPanel symbol="GME" provider="sec_dividend_summary" />);
+
+    const btn = await screen.findByRole("button", { name: /open/i });
+    await userEvent.click(btn);
+    expect(navigateMock).toHaveBeenCalledWith("/instrument/GME/dividends");
   });
 });

--- a/frontend/src/components/instrument/DividendsPanel.test.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.test.tsx
@@ -170,12 +170,14 @@ describe("DividendsPanel", () => {
     expect(screen.queryByText(/FY2024 Q2/)).toBeNull();
   });
 
-  it("Open button navigates to /instrument/<symbol>/dividends", async () => {
+  it("Open button navigates to /instrument/<symbol>/dividends preserving the provider", async () => {
     mockFetch.mockResolvedValue(paid());
     wrap(<DividendsPanel symbol="GME" provider="sec_dividend_summary" />);
 
     const btn = await screen.findByRole("button", { name: /open/i });
     await userEvent.click(btn);
-    expect(navigateMock).toHaveBeenCalledWith("/instrument/GME/dividends");
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/instrument/GME/dividends?provider=sec_dividend_summary",
+    );
   });
 });

--- a/frontend/src/components/instrument/DividendsPanel.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.tsx
@@ -1,31 +1,32 @@
 /**
- * DividendsPanel — provider-agnostic shell for the per-instrument
- * dividends capability (#515 PR 3b). Backed by GET
- * /instruments/{symbol}/dividends?provider=<provider>.
+ * DividendsPanel — compact summary pane on the instrument overview page.
+ * Shows last 4 quarters of history + an "Open →" button that navigates to
+ * the full /instrument/:symbol/dividends drill-through page (#578).
  *
- * The shell renders the normalised dividend shape returned by the
- * endpoint regardless of which provider populated it. Today only
- * ``sec_dividend_summary`` is wired; per-region integration PRs
- * (Companies House dividends, KRX dividends, …) reuse the same shell
- * + endpoint contract — no panel code changes required.
+ * Full history lives at DividendsPage; this panel is intentionally trim:
+ *   - NextDividendBanner (when upcoming[0] present)
+ *   - DividendsSummaryBlock (TTM yield / TTM DPS / Latest DPS / Streak)
+ *   - Last 4 HistoryBar rows
  *
- * Never-paid instruments render an explicit empty state rather than a
- * 404 or a zero row.
+ * Four-state empty rule: return null when both history and upcoming are
+ * empty after data settles (capability active, no current/forward signal).
  */
 
 import { fetchInstrumentDividends } from "@/api/instruments";
-import type {
-  DividendPeriod,
-  InstrumentDividends,
-  UpcomingDividend,
-} from "@/api/instruments";
+import type { InstrumentDividends } from "@/api/instruments";
 import {
   SectionError,
   SectionSkeleton,
 } from "@/components/dashboard/Section";
 import { Pane } from "@/components/instrument/Pane";
+import {
+  DividendsSummaryBlock,
+  HistoryBar,
+  NextDividendBanner,
+} from "@/components/instrument/dividendsShared";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 
 export interface DividendsPanelProps {
   readonly symbol: string;
@@ -35,46 +36,10 @@ export interface DividendsPanelProps {
   readonly provider: string;
 }
 
-function formatDps(raw: string | null, currency: string | null): string {
-  if (raw === null) return "—";
-  const num = Number(raw);
-  if (!Number.isFinite(num)) return "—";
-  return `${currency ?? ""}${currency ? " " : ""}${num.toFixed(4).replace(/\.?0+$/, "")}`.trim();
-}
-
-function formatYieldPct(raw: string | null): string {
-  if (raw === null) return "—";
-  const num = Number(raw);
-  if (!Number.isFinite(num)) return "—";
-  return `${num.toFixed(2)}%`;
-}
-
-function HistoryBar({ period, max }: { period: DividendPeriod; max: number }) {
-  const num = period.dps_declared !== null ? Number(period.dps_declared) : 0;
-  const pct = max > 0 ? Math.min(100, (num / max) * 100) : 0;
-  const label = `FY${period.fiscal_year} ${period.period_type}`;
-  return (
-    <div className="flex items-center gap-2 text-xs">
-      <span className="w-20 shrink-0 text-slate-500">{label}</span>
-      <div className="h-3 flex-1 rounded-sm bg-slate-100">
-        <div
-          className="h-full rounded-sm bg-sky-500"
-          style={{ width: `${pct}%` }}
-          role="progressbar"
-          aria-valuenow={num}
-          aria-valuemin={0}
-          aria-valuemax={max}
-          aria-label={`DPS ${num} in ${label}`}
-        />
-      </div>
-      <span className="w-16 shrink-0 text-right font-mono tabular-nums text-slate-700">
-        {formatDps(period.dps_declared, period.reported_currency)}
-      </span>
-    </div>
-  );
-}
+const PREVIEW_ROWS = 4;
 
 export function DividendsPanel({ symbol, provider }: DividendsPanelProps) {
+  const navigate = useNavigate();
   const state = useAsync<InstrumentDividends>(
     useCallback(
       () => fetchInstrumentDividends(symbol, provider),
@@ -96,8 +61,25 @@ export function DividendsPanel({ symbol, provider }: DividendsPanelProps) {
     return null;
   }
 
+  const last4 =
+    state.data !== null ? state.data.history.slice(0, PREVIEW_ROWS) : [];
+  const max =
+    last4.length > 0
+      ? last4.reduce((acc, p) => {
+          if (p.dps_declared === null) return acc;
+          const n = Number(p.dps_declared);
+          return Number.isFinite(n) && n > acc ? n : acc;
+        }, 0)
+      : 0;
+
   return (
-    <Pane title="Dividends" source={{ providers: [provider] }}>
+    <Pane
+      title="Dividends"
+      source={{ providers: [provider] }}
+      onExpand={() =>
+        navigate(`/instrument/${encodeURIComponent(symbol)}/dividends`)
+      }
+    >
       {state.loading ? (
         <SectionSkeleton rows={3} />
       ) : state.error !== null || state.data === null ? (
@@ -110,109 +92,27 @@ export function DividendsPanel({ symbol, provider }: DividendsPanelProps) {
           {state.data.upcoming[0] !== undefined && (
             <NextDividendBanner upcoming={state.data.upcoming[0]} />
           )}
-          {state.data.history.length > 0 ? (
-            <DividendsBody data={state.data} />
-          ) : null}
+          {state.data.history.length > 0 && (
+            <div className="space-y-4">
+              <DividendsSummaryBlock summary={state.data.summary} />
+              <div>
+                <div className="mb-1 text-xs font-medium uppercase tracking-wider text-slate-500">
+                  Per-quarter DPS
+                </div>
+                <div className="space-y-1">
+                  {last4.map((p) => (
+                    <HistoryBar
+                      key={`${p.period_end_date}-${p.period_type}`}
+                      period={p}
+                      max={max}
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
         </>
       )}
     </Pane>
-  );
-}
-
-function NextDividendBanner({ upcoming }: { upcoming: UpcomingDividend }) {
-  // Banner shows whichever calendar dates survived the 8-K regex parse.
-  // A row with only dps_declared (no dates yet) still renders — the
-  // banner's job is "operator awareness", not a filled-in calendar.
-  const exOrPay = upcoming.ex_date ?? upcoming.pay_date;
-  return (
-    <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm">
-      <div className="flex items-baseline justify-between gap-3">
-        <span className="font-semibold text-amber-900">Next dividend</span>
-        {upcoming.dps_declared !== null && (
-          <span className="font-mono tabular-nums text-amber-900">
-            {formatDps(upcoming.dps_declared, upcoming.currency)}
-          </span>
-        )}
-      </div>
-      <dl className="mt-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs text-amber-800">
-        {upcoming.ex_date !== null && (
-          <>
-            <dt className="text-amber-700">Ex-date</dt>
-            <dd>{upcoming.ex_date}</dd>
-          </>
-        )}
-        {upcoming.record_date !== null && (
-          <>
-            <dt className="text-amber-700">Record</dt>
-            <dd>{upcoming.record_date}</dd>
-          </>
-        )}
-        {upcoming.pay_date !== null && (
-          <>
-            <dt className="text-amber-700">Pay</dt>
-            <dd>{upcoming.pay_date}</dd>
-          </>
-        )}
-        {exOrPay === null && upcoming.declaration_date !== null && (
-          <>
-            <dt className="text-amber-700">Declared</dt>
-            <dd>
-              {upcoming.declaration_date} (calendar TBD)
-            </dd>
-          </>
-        )}
-      </dl>
-    </div>
-  );
-}
-
-
-function DividendsBody({ data }: { data: InstrumentDividends }) {
-  const { summary, history } = data;
-  const max = history.reduce((acc, p) => {
-    if (p.dps_declared === null) return acc;
-    const n = Number(p.dps_declared);
-    return Number.isFinite(n) && n > acc ? n : acc;
-  }, 0);
-
-  return (
-    <div className="space-y-4">
-      {/* Summary row */}
-      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
-        <dt className="text-slate-500">TTM yield</dt>
-        <dd className="font-semibold text-emerald-700">
-          {formatYieldPct(summary.ttm_yield_pct)}
-        </dd>
-        <dt className="text-slate-500">TTM DPS</dt>
-        <dd>{formatDps(summary.ttm_dps, summary.dividend_currency)}</dd>
-        <dt className="text-slate-500">Latest DPS</dt>
-        <dd>
-          {formatDps(summary.latest_dps, summary.dividend_currency)}
-          {summary.latest_dividend_at !== null && (
-            <span className="ml-2 text-xs text-slate-500">
-              period end {summary.latest_dividend_at}
-            </span>
-          )}
-        </dd>
-        <dt className="text-slate-500">Consecutive quarters</dt>
-        <dd>{summary.dividend_streak_q}</dd>
-      </dl>
-
-      {/* Per-quarter history */}
-      <div>
-        <div className="mb-1 text-xs font-medium uppercase tracking-wider text-slate-500">
-          Per-quarter DPS
-        </div>
-        <div className="space-y-1">
-          {history.map((p) => (
-            <HistoryBar
-              key={`${p.period_end_date}-${p.period_type}`}
-              period={p}
-              max={max}
-            />
-          ))}
-        </div>
-      </div>
-    </div>
   );
 }

--- a/frontend/src/components/instrument/DividendsPanel.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.tsx
@@ -77,7 +77,9 @@ export function DividendsPanel({ symbol, provider }: DividendsPanelProps) {
       title="Dividends"
       source={{ providers: [provider] }}
       onExpand={() =>
-        navigate(`/instrument/${encodeURIComponent(symbol)}/dividends`)
+        navigate(
+          `/instrument/${encodeURIComponent(symbol)}/dividends?provider=${encodeURIComponent(provider)}`,
+        )
       }
     >
       {state.loading ? (

--- a/frontend/src/components/instrument/dividendsShared.test.tsx
+++ b/frontend/src/components/instrument/dividendsShared.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  formatDps,
+  formatYieldPct,
+  HistoryBar,
+} from "./dividendsShared";
+
+import type { DividendPeriod } from "@/api/instruments";
+
+function period(dps: string | null, currency: string | null): DividendPeriod {
+  return {
+    period_end_date: "2025-12-28",
+    period_type: "Q4",
+    fiscal_year: 2025,
+    fiscal_quarter: 4,
+    dps_declared: dps,
+    dividends_paid: null,
+    reported_currency: currency,
+  };
+}
+
+describe("formatDps", () => {
+  it("returns em-dash for null input", () => {
+    expect(formatDps(null, "USD")).toBe("—");
+  });
+
+  it("returns em-dash for non-numeric string", () => {
+    expect(formatDps("abc", "USD")).toBe("—");
+  });
+
+  it("formats with currency prefix and trims trailing zeros", () => {
+    expect(formatDps("0.2500", "USD")).toBe("USD 0.25");
+  });
+
+  it("handles null currency — no prefix", () => {
+    expect(formatDps("0.2500", null)).toBe("0.25");
+  });
+
+  it("preserves significant trailing decimal digits", () => {
+    // 0.1234 should not be trimmed
+    expect(formatDps("0.1234", "USD")).toBe("USD 0.1234");
+  });
+});
+
+describe("formatYieldPct", () => {
+  it("returns em-dash for null", () => {
+    expect(formatYieldPct(null)).toBe("—");
+  });
+
+  it("formats to 2 decimal places with % suffix", () => {
+    expect(formatYieldPct("0.52")).toBe("0.52%");
+  });
+});
+
+describe("HistoryBar", () => {
+  it("renders label and progressbar for a period", () => {
+    render(<HistoryBar period={period("0.25", "USD")} max={0.5} />);
+    expect(screen.getByText("FY2025 Q4")).toBeInTheDocument();
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "0.25");
+    expect(bar).toHaveAttribute("aria-valuemax", "0.5");
+  });
+
+  it("renders em-dash when dps_declared is null", () => {
+    render(<HistoryBar period={period(null, "USD")} max={0.5} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+    const bar = screen.getByRole("progressbar");
+    // progressbar value should be 0 when dps_declared is null
+    expect(bar).toHaveAttribute("aria-valuenow", "0");
+  });
+});

--- a/frontend/src/components/instrument/dividendsShared.tsx
+++ b/frontend/src/components/instrument/dividendsShared.tsx
@@ -1,0 +1,143 @@
+/**
+ * Shared helpers for DividendsPanel (compact summary) and DividendsPage
+ * (full drill-through). Extracted as part of #578.
+ *
+ * Exports:
+ *   formatDps            — numeric string → localised "USD 0.25"
+ *   formatYieldPct       — numeric string → "0.52%"
+ *   HistoryBar           — single-row bar chart for a DividendPeriod
+ *   NextDividendBanner   — amber card for UpcomingDividend
+ *   DividendsSummaryBlock — 4-row summary dl (TTM yield / TTM DPS / Latest / Streak)
+ */
+
+import type { DividendPeriod, DividendSummary, UpcomingDividend } from "@/api/instruments";
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+export function formatDps(raw: string | null, currency: string | null): string {
+  if (raw === null) return "—";
+  const num = Number(raw);
+  if (!Number.isFinite(num)) return "—";
+  return `${currency ?? ""}${currency ? " " : ""}${num.toFixed(4).replace(/\.?0+$/, "")}`.trim();
+}
+
+export function formatYieldPct(raw: string | null): string {
+  if (raw === null) return "—";
+  const num = Number(raw);
+  if (!Number.isFinite(num)) return "—";
+  return `${num.toFixed(2)}%`;
+}
+
+// ---------------------------------------------------------------------------
+// HistoryBar
+// ---------------------------------------------------------------------------
+
+export function HistoryBar({
+  period,
+  max,
+}: {
+  period: DividendPeriod;
+  max: number;
+}) {
+  const num = period.dps_declared !== null ? Number(period.dps_declared) : 0;
+  const pct = max > 0 ? Math.min(100, (num / max) * 100) : 0;
+  const label = `FY${period.fiscal_year} ${period.period_type}`;
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span className="w-20 shrink-0 text-slate-500">{label}</span>
+      <div className="h-3 flex-1 rounded-sm bg-slate-100">
+        <div
+          className="h-full rounded-sm bg-sky-500"
+          style={{ width: `${pct}%` }}
+          role="progressbar"
+          aria-valuenow={num}
+          aria-valuemin={0}
+          aria-valuemax={max}
+          aria-label={`DPS ${num} in ${label}`}
+        />
+      </div>
+      <span className="w-16 shrink-0 text-right font-mono tabular-nums text-slate-700">
+        {formatDps(period.dps_declared, period.reported_currency)}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// NextDividendBanner
+// ---------------------------------------------------------------------------
+
+export function NextDividendBanner({ upcoming }: { upcoming: UpcomingDividend }) {
+  // Banner shows whichever calendar dates survived the 8-K regex parse.
+  // A row with only dps_declared (no dates yet) still renders — the
+  // banner's job is "operator awareness", not a filled-in calendar.
+  const exOrPay = upcoming.ex_date ?? upcoming.pay_date;
+  return (
+    <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="font-semibold text-amber-900">Next dividend</span>
+        {upcoming.dps_declared !== null && (
+          <span className="font-mono tabular-nums text-amber-900">
+            {formatDps(upcoming.dps_declared, upcoming.currency)}
+          </span>
+        )}
+      </div>
+      <dl className="mt-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs text-amber-800">
+        {upcoming.ex_date !== null && (
+          <>
+            <dt className="text-amber-700">Ex-date</dt>
+            <dd>{upcoming.ex_date}</dd>
+          </>
+        )}
+        {upcoming.record_date !== null && (
+          <>
+            <dt className="text-amber-700">Record</dt>
+            <dd>{upcoming.record_date}</dd>
+          </>
+        )}
+        {upcoming.pay_date !== null && (
+          <>
+            <dt className="text-amber-700">Pay</dt>
+            <dd>{upcoming.pay_date}</dd>
+          </>
+        )}
+        {exOrPay === null && upcoming.declaration_date !== null && (
+          <>
+            <dt className="text-amber-700">Declared</dt>
+            <dd>{upcoming.declaration_date} (calendar TBD)</dd>
+          </>
+        )}
+      </dl>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DividendsSummaryBlock
+// ---------------------------------------------------------------------------
+
+export function DividendsSummaryBlock({ summary }: { summary: DividendSummary }) {
+  return (
+    <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+      <dt className="text-slate-500">TTM yield</dt>
+      <dd className="font-semibold text-emerald-700">
+        {formatYieldPct(summary.ttm_yield_pct)}
+      </dd>
+      <dt className="text-slate-500">TTM DPS</dt>
+      <dd>{formatDps(summary.ttm_dps, summary.dividend_currency)}</dd>
+      <dt className="text-slate-500">Latest DPS</dt>
+      <dd>
+        {formatDps(summary.latest_dps, summary.dividend_currency)}
+        {summary.latest_dividend_at !== null && (
+          <span className="ml-2 text-xs text-slate-500">
+            period end {summary.latest_dividend_at}
+          </span>
+        )}
+      </dd>
+      <dt className="text-slate-500">Consecutive quarters</dt>
+      <dd>{summary.dividend_streak_q}</dd>
+    </dl>
+  );
+}

--- a/frontend/src/pages/DividendsPage.test.tsx
+++ b/frontend/src/pages/DividendsPage.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import type { InstrumentDividends } from "@/api/instruments";
+import { DividendsPage } from "./DividendsPage";
+
+vi.mock("@/api/instruments", () => ({
+  fetchInstrumentDividends: vi.fn(),
+}));
+
+import { fetchInstrumentDividends } from "@/api/instruments";
+const mockFetch = vi.mocked(fetchInstrumentDividends);
+
+afterEach(() => vi.clearAllMocks());
+
+function makePeriod(
+  fy: number,
+  qt: string,
+  date: string,
+  dps: string,
+): InstrumentDividends["history"][number] {
+  return {
+    period_end_date: date,
+    period_type: qt,
+    fiscal_year: fy,
+    fiscal_quarter: null,
+    dps_declared: dps,
+    dividends_paid: null,
+    reported_currency: "USD",
+  };
+}
+
+function makeSummary(): InstrumentDividends["summary"] {
+  return {
+    has_dividend: true,
+    ttm_dps: "1.0000",
+    ttm_dividends_paid: "15000000000.0000",
+    ttm_yield_pct: "0.52",
+    latest_dps: "0.2500",
+    latest_dividend_at: "2025-12-28",
+    dividend_streak_q: 40,
+    dividend_currency: "USD",
+  };
+}
+
+/** Render DividendsPage under the correct route structure so useParams works. */
+function renderPage(symbol: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/instrument/${symbol}/dividends`]}>
+      <Routes>
+        <Route
+          path="instrument/:symbol/dividends"
+          element={<DividendsPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("DividendsPage", () => {
+  it("renders full history (12 rows) when API returns 12 history entries", async () => {
+    const history: InstrumentDividends["history"] = Array.from(
+      { length: 12 },
+      (_, i) => {
+        const fy = 2025 - Math.floor(i / 4);
+        const qNum = 4 - (i % 4);
+        return makePeriod(
+          fy,
+          `Q${qNum}`,
+          `${fy}-${String(qNum * 3).padStart(2, "0")}-28`,
+          "0.25",
+        );
+      },
+    );
+    mockFetch.mockResolvedValue({
+      symbol: "AAPL",
+      summary: makeSummary(),
+      history,
+      upcoming: [],
+    });
+
+    renderPage("AAPL");
+
+    await waitFor(() =>
+      expect(screen.getByText(/Per-quarter history/i)).toBeInTheDocument(),
+    );
+
+    // All 12 progressbars should be present.
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars).toHaveLength(12);
+  });
+
+  it("renders Per-FY totals section with summed DPS per fiscal year", async () => {
+    mockFetch.mockResolvedValue({
+      symbol: "AAPL",
+      summary: makeSummary(),
+      history: [
+        makePeriod(2025, "Q4", "2025-12-28", "0.25"),
+        makePeriod(2025, "Q3", "2025-09-28", "0.25"),
+        makePeriod(2024, "Q4", "2024-12-28", "0.23"),
+        makePeriod(2024, "Q3", "2024-09-28", "0.23"),
+      ],
+      upcoming: [],
+    });
+
+    renderPage("AAPL");
+
+    await waitFor(() =>
+      expect(screen.getByText(/Per-FY totals/i)).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText("FY2025")).toBeInTheDocument();
+    expect(screen.getByText("FY2024")).toBeInTheDocument();
+    // FY2025 total = 0.50
+    expect(screen.getByText("USD 0.5")).toBeInTheDocument();
+    // FY2024 total = 0.46
+    expect(screen.getByText("USD 0.46")).toBeInTheDocument();
+  });
+
+  it("renders empty state when both history and upcoming are empty", async () => {
+    mockFetch.mockResolvedValue({
+      symbol: "GME",
+      summary: {
+        has_dividend: false,
+        ttm_dps: null,
+        ttm_dividends_paid: null,
+        ttm_yield_pct: null,
+        latest_dps: null,
+        latest_dividend_at: null,
+        dividend_streak_q: 0,
+        dividend_currency: null,
+      },
+      history: [],
+      upcoming: [],
+    });
+
+    renderPage("GME");
+
+    await waitFor(() =>
+      expect(screen.getByText(/No dividend data/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/Per-quarter history/i)).toBeNull();
+  });
+
+  it("back link points to /instrument/:symbol", async () => {
+    mockFetch.mockResolvedValue({
+      symbol: "AAPL",
+      summary: makeSummary(),
+      history: [makePeriod(2025, "Q4", "2025-12-28", "0.25")],
+      upcoming: [],
+    });
+
+    renderPage("AAPL");
+
+    await waitFor(() =>
+      expect(screen.getByText(/Back to AAPL/i)).toBeInTheDocument(),
+    );
+
+    const backLinks = screen.getAllByRole("link", { name: /Back to AAPL/i });
+    // Header back link href must point to instrument overview.
+    expect(backLinks[0]).toHaveAttribute("href", "/instrument/AAPL");
+  });
+});

--- a/frontend/src/pages/DividendsPage.tsx
+++ b/frontend/src/pages/DividendsPage.tsx
@@ -1,0 +1,228 @@
+/**
+ * /instrument/:symbol/dividends — full dividend drill-through page (#578).
+ *
+ * Sections:
+ *   1. Summary  — DividendsSummaryBlock
+ *   2. Upcoming — NextDividendBanner (when present)
+ *   3. Per-quarter history — full HistoryBar list, grouped by FY DESC
+ *   4. Per-FY totals — summed dps_declared per fiscal_year
+ *
+ * URL: /instrument/:symbol/dividends
+ * Optional ?provider= query param forwarded to the API; defaults to the
+ * provider embedded in the data (any row's reported_currency shares the
+ * same provider — we don't need to inspect capabilities here because this
+ * page is only reachable from DividendsPanel which already resolved the
+ * provider).
+ */
+
+import { fetchInstrumentDividends } from "@/api/instruments";
+import type { DividendPeriod, InstrumentDividends } from "@/api/instruments";
+import {
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
+import { Pane } from "@/components/instrument/Pane";
+import {
+  DividendsSummaryBlock,
+  formatDps,
+  HistoryBar,
+  NextDividendBanner,
+} from "@/components/instrument/dividendsShared";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+import { useCallback } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+
+// ---------------------------------------------------------------------------
+// Per-FY totals helper
+// ---------------------------------------------------------------------------
+
+interface FyTotal {
+  fiscal_year: number;
+  total_dps: number;
+  currency: string | null;
+}
+
+function buildFyTotals(history: ReadonlyArray<DividendPeriod>): FyTotal[] {
+  const map = new Map<number, { sum: number; currency: string | null }>();
+  for (const p of history) {
+    const existing = map.get(p.fiscal_year);
+    const dps = p.dps_declared !== null ? Number(p.dps_declared) : 0;
+    const num = Number.isFinite(dps) ? dps : 0;
+    if (existing === undefined) {
+      map.set(p.fiscal_year, {
+        sum: num,
+        currency: p.reported_currency,
+      });
+    } else {
+      existing.sum += num;
+    }
+  }
+  // Sort descending by fiscal year.
+  return [...map.entries()]
+    .sort(([a], [b]) => b - a)
+    .map(([fy, { sum, currency }]) => ({
+      fiscal_year: fy,
+      total_dps: sum,
+      currency,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Full history sorted newest-first
+// ---------------------------------------------------------------------------
+
+function sortedHistory(history: ReadonlyArray<DividendPeriod>): DividendPeriod[] {
+  return [...history].sort((a, b) => {
+    if (b.fiscal_year !== a.fiscal_year) return b.fiscal_year - a.fiscal_year;
+    // Within a FY, sort by period_end_date DESC.
+    return b.period_end_date.localeCompare(a.period_end_date);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+export function DividendsPage(): JSX.Element {
+  const { symbol = "" } = useParams<{ symbol: string }>();
+  const [searchParams] = useSearchParams();
+  const provider = searchParams.get("provider") ?? undefined;
+
+  const state = useAsync<InstrumentDividends>(
+    useCallback(
+      () => fetchInstrumentDividends(symbol, provider),
+      [symbol, provider],
+    ),
+    [symbol, provider],
+  );
+
+  const backHref = `/instrument/${encodeURIComponent(symbol)}`;
+
+  return (
+    <div className="mx-auto max-w-screen-xl space-y-4 p-4">
+      <header className="border-b border-slate-200 pb-3">
+        <Link
+          to={backHref}
+          className="text-xs text-sky-700 hover:underline"
+        >
+          ← Back to {symbol}
+        </Link>
+        <h1 className="mt-1 text-lg font-semibold text-slate-900">
+          Dividends — {symbol}
+        </h1>
+      </header>
+
+      {state.loading ? (
+        <SectionSkeleton rows={6} />
+      ) : state.error !== null || state.data === null ? (
+        <SectionError onRetry={state.refetch} />
+      ) : state.data.history.length === 0 && state.data.upcoming.length === 0 ? (
+        <EmptyState
+          title="No dividend data"
+          description="No dividend history or upcoming dividends on file for this instrument."
+        >
+          <Link
+            to={backHref}
+            className="text-sm text-sky-700 hover:underline"
+          >
+            ← Back to {symbol}
+          </Link>
+        </EmptyState>
+      ) : (
+        <div className="space-y-4">
+          {/* 1. Summary */}
+          <Pane title="Summary">
+            <DividendsSummaryBlock summary={state.data.summary} />
+          </Pane>
+
+          {/* 2. Upcoming dividend (optional) */}
+          {state.data.upcoming[0] !== undefined && (
+            <Pane title="Upcoming dividend">
+              <NextDividendBanner upcoming={state.data.upcoming[0]} />
+            </Pane>
+          )}
+
+          {/* 3. Per-quarter history */}
+          {state.data.history.length > 0 && (
+            <Pane title="Per-quarter history">
+              <PerQuarterHistory history={state.data.history} />
+            </Pane>
+          )}
+
+          {/* 4. Per-FY totals */}
+          {state.data.history.length > 0 && (
+            <Pane title="Per-FY totals">
+              <FyTotalsTable history={state.data.history} />
+            </Pane>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-quarter history
+// ---------------------------------------------------------------------------
+
+function PerQuarterHistory({
+  history,
+}: {
+  readonly history: ReadonlyArray<DividendPeriod>;
+}) {
+  const sorted = sortedHistory(history);
+  const max = sorted.reduce((acc, p) => {
+    if (p.dps_declared === null) return acc;
+    const n = Number(p.dps_declared);
+    return Number.isFinite(n) && n > acc ? n : acc;
+  }, 0);
+  return (
+    <div className="space-y-1">
+      {sorted.map((p) => (
+        <HistoryBar
+          key={`${p.period_end_date}-${p.period_type}`}
+          period={p}
+          max={max}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-FY totals table
+// ---------------------------------------------------------------------------
+
+function FyTotalsTable({
+  history,
+}: {
+  readonly history: ReadonlyArray<DividendPeriod>;
+}) {
+  const totals = buildFyTotals(history);
+  return (
+    <table className="min-w-full text-xs">
+      <thead>
+        <tr className="border-b border-slate-200 text-left text-slate-500">
+          <th className="px-2 py-1">Fiscal year</th>
+          <th className="px-2 py-1 text-right">Total DPS</th>
+        </tr>
+      </thead>
+      <tbody>
+        {totals.map((row) => (
+          <tr
+            key={row.fiscal_year}
+            className="border-b border-slate-100 last:border-0"
+          >
+            <td className="px-2 py-1 font-medium text-slate-700">
+              FY{row.fiscal_year}
+            </td>
+            <td className="px-2 py-1 text-right font-mono tabular-nums text-slate-700">
+              {formatDps(row.total_dps.toString(), row.currency)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## What

- New route `/instrument/:symbol/dividends` — full dividend report (summary, upcoming, full per-quarter history, per-FY totals)
- `DividendsPanel` on instrument page trims to last 4 quarters + Open → button to drill through (preserves `?provider=` query)
- Shared helpers (`formatDps`, `formatYieldPct`, `HistoryBar`, `NextDividendBanner`, `DividendsSummaryBlock`) extracted to `dividendsShared.tsx` — single source of truth for both the panel and the page

## Why

Closes #578. Operator review of post-#575 page (screenshots 2026-04-27): `DividendsPanel` was dumping full per-FY per-Q history (FY2016 → FY2022 visible on GME, all empty rows on IEP) — burned massive vertical space on the overview. Pattern matches Yahoo Finance high-level overview + drill-through to detail.

Codex pre-push caught a P2: original Open button dropped the resolved provider when navigating. Fixed in second commit — query param now flows panel → page so multi-provider instruments fetch the same dataset they previewed.

## Test plan

- 15 new vitest tests covering: ≤4-row cap, Open navigation with provider, full-history page render, FY totals, empty state, back-link, shared formatters
- `pnpm --dir frontend test:unit` (472 pass, +15 new)
- `pnpm --dir frontend typecheck` clean
- `uv run ruff check . && uv run ruff format --check .` clean

## Out of scope

- Payout ratio over time (needs new data source)
- Yield-on-cost progression (needs cost-basis from positions)
- DRP / dividend reinvestment tracking