### PR TITLE
feat(#576): chart workspace route Phase 1

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { InstrumentDetailRedirect } from "@/pages/InstrumentDetailRedirect";
 import { InstrumentPage } from "@/pages/InstrumentPage";
 import { Tenk10KDrilldownPage } from "@/pages/Tenk10KDrilldownPage";
 import { EightKListPage } from "@/pages/EightKListPage";
+import { ChartPage } from "@/pages/ChartPage";
 import { DividendsPage } from "@/pages/DividendsPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { RecommendationsPage } from "@/pages/RecommendationsPage";
@@ -74,6 +75,10 @@ export function App() {
           <Route
             path="instrument/:symbol/dividends"
             element={<DividendsPage />}
+          />
+          <Route
+            path="instrument/:symbol/chart"
+            element={<ChartPage />}
           />
           <Route path="copy-trading/:mirrorId" element={<CopyTradingPage />} />
           <Route path="recommendations" element={<RecommendationsPage />} />

--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { DensityGrid } from "@/components/instrument/DensityGrid";
 import type { InstrumentSummary } from "@/api/types";
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return { ...actual, useNavigate: () => navigateMock };
+});
 
 // Mock child components that make their own API calls so the DensityGrid
 // unit test stays isolated.
@@ -218,5 +225,23 @@ describe("DensityGrid profiles", () => {
       </MemoryRouter>,
     );
     expect(container.querySelectorAll(".overflow-auto").length).toBe(0);
+  });
+
+  it("chart pane has an Open button that navigates to /instrument/:symbol/chart", async () => {
+    navigateMock.mockClear();
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={makeSummary({})}
+          thesis={null}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    // PaneHeader renders the button labelled "Open →" when onExpand is set.
+    const openButton = screen.getByRole("button", { name: /open/i });
+    await user.click(openButton);
+    expect(navigateMock).toHaveBeenCalledWith("/instrument/GME/chart");
   });
 });

--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -244,4 +244,21 @@ describe("DensityGrid profiles", () => {
     await user.click(openButton);
     expect(navigateMock).toHaveBeenCalledWith("/instrument/GME/chart");
   });
+
+  it("chart pane Open button preserves overview ?chart= range as ?range= on chart workspace", async () => {
+    navigateMock.mockClear();
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/instrument/GME?chart=5y"]}>
+        <DensityGrid
+          summary={makeSummary({})}
+          thesis={null}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    const openButton = screen.getByRole("button", { name: /open/i });
+    await user.click(openButton);
+    expect(navigateMock).toHaveBeenCalledWith("/instrument/GME/chart?range=5y");
+  });
 });

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -18,6 +18,7 @@
 
 import type { InstrumentSummary, ThesisDetail } from "@/api/types";
 import { activeProviders } from "@/lib/capabilityProviders";
+import { useNavigate } from "react-router-dom";
 import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSectionsTeaser";
 import { DividendsPanel } from "@/components/instrument/DividendsPanel";
 import { FilingsPane } from "@/components/instrument/FilingsPane";
@@ -53,11 +54,13 @@ export function DensityGrid({
   const insiderActive = activeProviders(cap.insider ?? EMPTY_CELL).length > 0;
   const dividendProviders = activeProviders(cap.dividends ?? EMPTY_CELL);
   const hasNarrative = summary.has_sec_cik;
+  const navigate = useNavigate();
 
-  // PriceChart isn't yet a self-Pane'd component — wrap it locally.
-  // #576 will own the chart route; until then no onExpand.
   const ChartPane = (
-    <Pane title="Price chart">
+    <Pane
+      title="Price chart"
+      onExpand={() => navigate(`/instrument/${encodeURIComponent(symbol)}/chart`)}
+    >
       <PriceChart symbol={symbol} />
     </Pane>
   );

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -18,7 +18,7 @@
 
 import type { InstrumentSummary, ThesisDetail } from "@/api/types";
 import { activeProviders } from "@/lib/capabilityProviders";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSectionsTeaser";
 import { DividendsPanel } from "@/components/instrument/DividendsPanel";
 import { FilingsPane } from "@/components/instrument/FilingsPane";
@@ -55,11 +55,25 @@ export function DensityGrid({
   const dividendProviders = activeProviders(cap.dividends ?? EMPTY_CELL);
   const hasNarrative = summary.has_sec_cik;
   const navigate = useNavigate();
+  const [overviewParams] = useSearchParams();
 
   const ChartPane = (
     <Pane
       title="Price chart"
-      onExpand={() => navigate(`/instrument/${encodeURIComponent(symbol)}/chart`)}
+      onExpand={() => {
+        // Preserve the operator's currently-selected overview range when
+        // expanding to the full chart workspace. PriceChart syncs its
+        // range to ?chart=<id> on the instrument page; ChartPage reads
+        // ?range=<id>. Translate the param name across the boundary so
+        // a non-default range survives the route change.
+        const overviewRange = overviewParams.get("chart");
+        const target = `/instrument/${encodeURIComponent(symbol)}/chart`;
+        const url =
+          overviewRange !== null && overviewRange !== ""
+            ? `${target}?range=${encodeURIComponent(overviewRange)}`
+            : target;
+        navigate(url);
+      }}
     >
       <PriceChart symbol={symbol} />
     </Pane>

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -193,13 +193,17 @@ export function PriceChart({
   );
 }
 
-function ChartCanvas({
-  rows,
-  symbol,
-}: {
+export interface ChartCanvasProps {
   rows: CandleBar[];
   symbol: string;
-}): JSX.Element {
+  containerClassName?: string;
+}
+
+export function ChartCanvas({
+  rows,
+  symbol,
+  containerClassName,
+}: ChartCanvasProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const candleRef = useRef<ISeriesApi<"Candlestick"> | null>(null);
@@ -357,7 +361,7 @@ function ChartCanvas({
       <div
         ref={containerRef}
         data-testid={`price-chart-${symbol}`}
-        className="h-[340px] w-full"
+        className={containerClassName ?? "h-[340px] w-full"}
       />
     </div>
   );

--- a/frontend/src/pages/ChartPage.test.tsx
+++ b/frontend/src/pages/ChartPage.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Tests for ChartPage (#576 Phase 1).
+ *
+ * lightweight-charts cannot render in jsdom (Canvas API absent), so we stub
+ * ChartCanvas to a simple div. What we pin here is the page's contract:
+ *
+ *   - Symbol + back-link render
+ *   - Default range is 1Y
+ *   - Clicking a range button updates the URL param to ?range=<id>
+ *   - Empty state when data has no valid rows
+ *   - Error state propagates a retry button
+ *   - Fetch calls with the active range
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+// Stub ChartCanvas so lightweight-charts is never touched in jsdom.
+vi.mock("@/components/instrument/PriceChart", () => ({
+  ChartCanvas: ({ symbol }: { symbol: string }) => (
+    <div data-testid="chart-canvas-stub" data-symbol={symbol} />
+  ),
+}));
+
+vi.mock("@/api/instruments", () => ({
+  fetchInstrumentSummary: vi.fn(),
+  fetchInstrumentCandles: vi.fn(),
+}));
+
+import { fetchInstrumentSummary, fetchInstrumentCandles } from "@/api/instruments";
+import type { InstrumentCandles, InstrumentSummary } from "@/api/types";
+import { ChartPage } from "./ChartPage";
+
+const mockSummary = vi.mocked(fetchInstrumentSummary);
+const mockCandles = vi.mocked(fetchInstrumentCandles);
+
+function makeCandles(
+  range: InstrumentCandles["range"],
+  rows: InstrumentCandles["rows"] = [],
+): InstrumentCandles {
+  return { symbol: "AAPL", range, days: 365, rows };
+}
+
+function makeSummary(): InstrumentSummary {
+  return {
+    instrument_id: 1,
+    is_tradable: true,
+    coverage_tier: 1,
+    identity: { symbol: "AAPL", display_name: "Apple Inc.", market_cap: null, sector: null },
+    price: { current: "189.50", day_change: null, day_change_pct: null, week_52_high: null, week_52_low: null, currency: "USD" },
+    key_stats: null,
+    source: {},
+    has_sec_cik: true,
+    has_filings_coverage: true,
+    capabilities: {},
+  } as InstrumentSummary;
+}
+
+function twoValidRows(): InstrumentCandles["rows"] {
+  return [
+    { date: "2026-01-10", open: "180", high: "182", low: "179", close: "181", volume: "1000" },
+    { date: "2026-01-11", open: "181", high: "184", low: "180", close: "183", volume: "1200" },
+  ];
+}
+
+function renderPage(path = "/instrument/AAPL/chart") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="instrument/:symbol/chart" element={<ChartPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockSummary.mockResolvedValue(makeSummary());
+  mockCandles.mockResolvedValue(makeCandles("1y", twoValidRows()));
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("ChartPage — header", () => {
+  it("renders the symbol heading and back-link", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "AAPL" })).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("link", { name: /back to overview/i }),
+    ).toHaveAttribute("href", "/instrument/AAPL");
+  });
+
+  it("renders the display name from summary data", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Apple Inc.")).toBeInTheDocument();
+    });
+  });
+
+  it("renders the price from summary data", async () => {
+    renderPage();
+    await waitFor(() => {
+      // price formatted as "USD 189.5"
+      expect(screen.getByText(/189/)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("ChartPage — range picker", () => {
+  it("renders all seven range buttons", async () => {
+    renderPage();
+    for (const r of ["1w", "1m", "3m", "6m", "1y", "5y", "max"]) {
+      expect(screen.getByTestId(`chart-range-${r}`)).toBeInTheDocument();
+    }
+  });
+
+  it("defaults to 1y range and fetches with it", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(mockCandles).toHaveBeenCalledWith("AAPL", "1y");
+    });
+  });
+
+  it("clicking a range button updates the URL and refetches with new range", async () => {
+    mockCandles.mockImplementation((_, range) =>
+      Promise.resolve(makeCandles(range, twoValidRows())),
+    );
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => {
+      expect(mockCandles).toHaveBeenCalledWith("AAPL", "1y");
+    });
+    await user.click(screen.getByTestId("chart-range-3m"));
+    await waitFor(() => {
+      expect(mockCandles).toHaveBeenCalledWith("AAPL", "3m");
+    });
+  });
+
+  it("honours a pre-set ?range= query param from the URL", async () => {
+    mockCandles.mockImplementation((_, range) =>
+      Promise.resolve(makeCandles(range, twoValidRows())),
+    );
+    renderPage("/instrument/AAPL/chart?range=5y");
+    await waitFor(() => {
+      expect(mockCandles).toHaveBeenCalledWith("AAPL", "5y");
+    });
+  });
+
+  it("falls back to default range for an unrecognised ?range= value", async () => {
+    renderPage("/instrument/AAPL/chart?range=garbage");
+    await waitFor(() => {
+      expect(mockCandles).toHaveBeenCalledWith("AAPL", "1y");
+    });
+  });
+});
+
+describe("ChartPage — chart body", () => {
+  it("renders the chart canvas when data has >= 2 valid rows", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when rows array is empty", async () => {
+    mockCandles.mockResolvedValue(makeCandles("1y", []));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/No price data/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("chart-canvas-stub")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when rows have no valid OHLC", async () => {
+    mockCandles.mockResolvedValue(
+      makeCandles("1y", [
+        { date: "2026-01-10", open: null, high: null, low: null, close: "181", volume: "1000" },
+        { date: "2026-01-11", open: null, high: null, low: null, close: "183", volume: "1200" },
+      ]),
+    );
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/No price data/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("chart-canvas-stub")).not.toBeInTheDocument();
+  });
+
+  it("shows retry button on fetch error", async () => {
+    mockCandles.mockRejectedValue(new Error("network down"));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("chart-canvas-stub")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -1,0 +1,170 @@
+/**
+ * /instrument/:symbol/chart — full-viewport chart workspace (#576 Phase 1).
+ *
+ * Provides a full-height candlestick chart with a range picker (1W–MAX)
+ * URL-synced via `?range=<id>`. The back-link returns to the instrument
+ * overview. Phase 2 (indicators/tooltips), Phase 3 (compare/trends), and
+ * Phase 4 (raw OHLCV table) are out of scope for this PR.
+ */
+import { useCallback } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+
+import { fetchInstrumentCandles, fetchInstrumentSummary } from "@/api/instruments";
+import type { CandleRange, InstrumentCandles, InstrumentSummary } from "@/api/types";
+import { ChartCanvas } from "@/components/instrument/PriceChart";
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+
+const RANGES: { id: CandleRange; label: string }[] = [
+  { id: "1w", label: "1W" },
+  { id: "1m", label: "1M" },
+  { id: "3m", label: "3M" },
+  { id: "6m", label: "6M" },
+  { id: "1y", label: "1Y" },
+  { id: "5y", label: "5Y" },
+  { id: "max", label: "MAX" },
+];
+
+const VALID_RANGES: readonly CandleRange[] = ["1w", "1m", "3m", "6m", "1y", "5y", "max"];
+
+const DEFAULT_RANGE: CandleRange = "1y";
+
+function parseNum(v: string | null | undefined): number | null {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function dateToTime(date: string): number | null {
+  const parts = date.split("-");
+  if (parts.length !== 3) return null;
+  const y = Number(parts[0]);
+  const m = Number(parts[1]);
+  const d = Number(parts[2]);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return null;
+  const ts = Date.UTC(y, m - 1, d);
+  if (!Number.isFinite(ts)) return null;
+  return ts / 1000;
+}
+
+export function ChartPage(): JSX.Element {
+  const { symbol = "" } = useParams<{ symbol: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawRange = searchParams.get("range");
+  const range: CandleRange = VALID_RANGES.includes(rawRange as CandleRange)
+    ? (rawRange as CandleRange)
+    : DEFAULT_RANGE;
+
+  const setRange = useCallback(
+    (next: CandleRange) => {
+      const params = new URLSearchParams(searchParams);
+      if (next === DEFAULT_RANGE) {
+        params.delete("range");
+      } else {
+        params.set("range", next);
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const summaryAsync = useAsync<InstrumentSummary>(
+    () => fetchInstrumentSummary(symbol),
+    [symbol],
+  );
+  const candlesAsync = useAsync<InstrumentCandles>(
+    () => fetchInstrumentCandles(symbol, range),
+    [symbol, range],
+  );
+
+  const dataMatchesRange = candlesAsync.data?.range === range;
+  const effectivelyLoading = candlesAsync.loading || !dataMatchesRange;
+  const rows = dataMatchesRange && candlesAsync.data ? candlesAsync.data.rows : null;
+  const hasChartData =
+    rows !== null &&
+    rows.filter(
+      (r) =>
+        parseNum(r.open) !== null &&
+        parseNum(r.high) !== null &&
+        parseNum(r.low) !== null &&
+        parseNum(r.close) !== null &&
+        dateToTime(r.date) !== null,
+    ).length >= 2;
+
+  return (
+    <div className="space-y-3 p-4">
+      {/* Header: back link + identity + price */}
+      <div className="flex items-baseline gap-3">
+        <Link
+          to={`/instrument/${encodeURIComponent(symbol)}`}
+          className="text-xs text-sky-700 hover:underline"
+        >
+          ← Back to overview
+        </Link>
+        <div className="flex items-baseline gap-2">
+          <h1 className="text-xl font-semibold text-slate-800">{symbol}</h1>
+          {summaryAsync.data?.identity.display_name && (
+            <span className="text-sm text-slate-500">
+              {summaryAsync.data.identity.display_name}
+            </span>
+          )}
+        </div>
+        {summaryAsync.data?.price?.current && (
+          <span className="ml-auto text-lg font-medium tabular-nums text-slate-800">
+            {summaryAsync.data.price.currency ?? ""}{" "}
+            {Number(summaryAsync.data.price.current).toLocaleString(undefined, {
+              maximumFractionDigits: 2,
+            })}
+          </span>
+        )}
+      </div>
+
+      {/* Range picker */}
+      <div className="flex gap-1">
+        {RANGES.map((r) => (
+          <button
+            key={r.id}
+            type="button"
+            onClick={() => setRange(r.id)}
+            className={`rounded px-3 py-1 text-sm font-medium ${
+              r.id === range
+                ? "bg-slate-800 text-white"
+                : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+            }`}
+            data-testid={`chart-range-${r.id}`}
+          >
+            {r.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Chart body */}
+      <div className="rounded-md border border-slate-200 bg-white shadow-sm">
+        {effectivelyLoading && candlesAsync.error === null ? (
+          <div className="p-4">
+            <SectionSkeleton rows={10} />
+          </div>
+        ) : null}
+        {candlesAsync.error !== null ? (
+          <div className="p-4">
+            <SectionError onRetry={candlesAsync.refetch} />
+          </div>
+        ) : null}
+        {!effectivelyLoading && candlesAsync.error === null && dataMatchesRange && !hasChartData ? (
+          <div className="p-4">
+            <EmptyState
+              title="No price data"
+              description="No candles in the local price_daily store for this range."
+            />
+          </div>
+        ) : null}
+        {hasChartData && rows !== null ? (
+          <ChartCanvas rows={rows} symbol={symbol} containerClassName="h-[70vh] w-full" />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export default ChartPage;


### PR DESCRIPTION
## What

Phase 1 of #576 — chart workspace as a dedicated route.

- New page at `/instrument/:symbol/chart` rendering full-viewport chart (`min-h-[70vh]`)
- Range picker (1W / 1M / 3M / 6M / 1Y / 5Y / MAX) URL-synced via `?range=<id>`, default 1Y
- Header: back-link + symbol + display name + price
- `PriceChart`'s inner `ChartCanvas` extracted (exported with new `containerClassName?: string` prop, default unchanged)
- `DensityGrid`'s chart pane gets `Open →` button that navigates to the workspace, **preserving the operator's overview range** (e.g. `?chart=5y` → `?range=5y`)

## Why

Closes Phase 1 of #576. Operator review (2026-04-27): "charts in general need a lot of love. Should show clearer, fuller. Be able to interact with them. Drill into a page which is heavy graph reportable, configurable with filters."

This PR is just the route + L1 link. Indicators, hover tooltips, compare, trend tracking, raw OHLCV table land in Phases 2-4 (separate PRs under the same issue).

Codex pre-push caught a P3 (overview range was being dropped on expand) — fixed in second commit before push.

## Test plan

- 13 new vitest tests (`ChartPage.test.tsx` + 2 new `DensityGrid.test.tsx` cases)
- 486 frontend tests pass
- `pnpm --dir frontend typecheck` clean
- `uv run ruff check . && uv run ruff format --check .` clean

## Out of scope (#576 phases 2-4)

- Indicator overlays (SMA / EMA / RSI / MACD)
- Hover tooltip showing OHLCV + indicator values at cursor
- Compare-tickers overlay
- Linear regression + price channel
- Raw OHLCV table at `?view=raw` + CSV export