### PR TITLE
feat(#576): chart workspace Phase 2 — SMA/EMA + rich tooltip + sparkline hover

### DIFF
--- a/frontend/src/components/instrument/Sparkline.test.tsx
+++ b/frontend/src/components/instrument/Sparkline.test.tsx
@@ -1,8 +1,11 @@
+/**
+ * Tests for Sparkline (#576 Phase 2 adds hover tooltip).
+ */
 import { describe, expect, it } from "vitest";
-import { render } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { Sparkline } from "@/components/instrument/Sparkline";
 
-describe("Sparkline", () => {
+describe("Sparkline — rendering", () => {
   it("renders <polyline> with 8 comma-separated coords for 8 input values", () => {
     const { container } = render(
       <Sparkline values={[1, 2, 3, 4, 5, 4, 3, 2]} width={80} height={24} />,
@@ -27,5 +30,69 @@ describe("Sparkline", () => {
     const { container } = render(<Sparkline values={[1, 2, 3]} />);
     const polyline = container.querySelector("polyline");
     expect(polyline?.getAttribute("stroke")).toBe("currentColor");
+  });
+});
+
+describe("Sparkline — hover tooltip", () => {
+  it("shows tooltip with value on mouseMove over the SVG", () => {
+    // values: [10, 20, 30], width 80 → xStep = 40
+    // Moving to x=0 → index 0 → value 10
+    const { container } = render(
+      <Sparkline values={[10, 20, 30]} width={80} height={24} />,
+    );
+    const svg = container.querySelector("svg")!;
+    // Simulate mousemove at x=0 (left edge → index 0 → value 10)
+    fireEvent.mouseMove(svg, { clientX: 0, clientY: 12 });
+    const tooltip = screen.queryByTestId("sparkline-tooltip");
+    expect(tooltip).not.toBeNull();
+    expect(tooltip?.textContent).toMatch(/10/);
+  });
+
+  it("shows the correct value at the right edge (last index)", () => {
+    // values: [10, 20, 30], width 80 → last valid index x=80
+    const { container } = render(
+      <Sparkline values={[10, 20, 30]} width={80} height={24} />,
+    );
+    const svg = container.querySelector("svg")!;
+    // Move to far right → index 2 → value 30
+    fireEvent.mouseMove(svg, { clientX: 80, clientY: 12 });
+    const tooltip = screen.queryByTestId("sparkline-tooltip");
+    expect(tooltip).not.toBeNull();
+    expect(tooltip?.textContent).toMatch(/30/);
+  });
+
+  it("clears tooltip on mouseLeave", () => {
+    const { container } = render(
+      <Sparkline values={[10, 20, 30]} width={80} height={24} />,
+    );
+    const svg = container.querySelector("svg")!;
+    const wrapper = container.querySelector("div")!;
+    fireEvent.mouseMove(svg, { clientX: 0, clientY: 12 });
+    expect(screen.queryByTestId("sparkline-tooltip")).not.toBeNull();
+    fireEvent.mouseLeave(wrapper);
+    expect(screen.queryByTestId("sparkline-tooltip")).toBeNull();
+  });
+
+  it("uses the custom formatValue prop", () => {
+    const { container } = render(
+      <Sparkline
+        values={[1000000, 2000000]}
+        width={80}
+        height={24}
+        formatValue={(v) => `$${(v / 1e6).toFixed(1)}M`}
+      />,
+    );
+    const svg = container.querySelector("svg")!;
+    fireEvent.mouseMove(svg, { clientX: 0, clientY: 12 });
+    const tooltip = screen.queryByTestId("sparkline-tooltip");
+    expect(tooltip?.textContent).toBe("$1.0M");
+  });
+
+  it("does not show tooltip when fewer than 2 values (no polyline case)", () => {
+    const { container } = render(<Sparkline values={[42]} />);
+    const svg = container.querySelector("svg")!;
+    // No onMouseMove in short-circuit path — but if we fire anyway, no tooltip
+    fireEvent.mouseMove(svg, { clientX: 0, clientY: 0 });
+    expect(screen.queryByTestId("sparkline-tooltip")).toBeNull();
   });
 });

--- a/frontend/src/components/instrument/Sparkline.tsx
+++ b/frontend/src/components/instrument/Sparkline.tsx
@@ -2,9 +2,11 @@
  * Sparkline — hand-coded SVG <polyline> sparkline. No external chart
  * dependency. Used in `FundamentalsPane` for compact 8-point time
  * series (revenue, op income, net income, total debt over 8 quarters).
+ *
+ * Phase 2 (#576): hover tooltip shows the value at the cursor index.
  */
 
-import type { JSX } from "react";
+import { useState, useCallback, type JSX } from "react";
 
 export interface SparklineProps {
   readonly values: ReadonlyArray<number>;
@@ -12,6 +14,16 @@ export interface SparklineProps {
   readonly height?: number;
   readonly stroke?: string;
   readonly className?: string;
+  /** Custom value formatter. Default: 2 decimal places with locale separators. */
+  readonly formatValue?: (v: number) => string;
+}
+
+interface HoverState {
+  idx: number;
+}
+
+function defaultFormat(v: number): string {
+  return v.toLocaleString(undefined, { maximumFractionDigits: 2 });
 }
 
 export function Sparkline({
@@ -20,10 +32,33 @@ export function Sparkline({
   height = 24,
   stroke = "currentColor",
   className,
+  formatValue = defaultFormat,
 }: SparklineProps): JSX.Element {
+  const [hover, setHover] = useState<HoverState | null>(null);
+
+  const handleMove = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      if (values.length < 2) return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const xStep = width / (values.length - 1);
+      const idx = Math.min(
+        Math.max(0, Math.round(x / xStep)),
+        values.length - 1,
+      );
+      setHover({ idx });
+    },
+    [values.length, width],
+  );
+
+  const handleLeave = useCallback(() => {
+    setHover(null);
+  }, []);
+
   if (values.length < 2) {
     return <svg width={width} height={height} className={className} />;
   }
+
   const min = Math.min(...values);
   const max = Math.max(...values);
   const range = max - min;
@@ -40,21 +75,35 @@ export function Sparkline({
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     })
     .join(" ");
+
+  const hoveredValue = hover !== null ? values[hover.idx] : undefined;
+
   return (
-    <svg
-      width={width}
-      height={height}
-      className={className}
-      aria-hidden="true"
-    >
-      <polyline
-        points={points}
-        fill="none"
-        stroke={stroke}
-        strokeWidth={1.5}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
+    <div className="relative inline-block" onMouseLeave={handleLeave}>
+      <svg
+        width={width}
+        height={height}
+        className={className}
+        aria-hidden="true"
+        onMouseMove={handleMove}
+      >
+        <polyline
+          points={points}
+          fill="none"
+          stroke={stroke}
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      {hover !== null && hoveredValue !== undefined ? (
+        <div
+          className="absolute left-0 top-full z-10 mt-0.5 whitespace-nowrap rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-white shadow"
+          data-testid="sparkline-tooltip"
+        >
+          {formatValue(hoveredValue)}
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/frontend/src/pages/ChartPage.test.tsx
+++ b/frontend/src/pages/ChartPage.test.tsx
@@ -1,8 +1,8 @@
 /**
- * Tests for ChartPage (#576 Phase 1).
+ * Tests for ChartPage (#576 Phase 1 + Phase 2).
  *
  * lightweight-charts cannot render in jsdom (Canvas API absent), so we stub
- * ChartCanvas to a simple div. What we pin here is the page's contract:
+ * ChartWorkspaceCanvas to a simple div. What we pin here is the page's contract:
  *
  *   - Symbol + back-link render
  *   - Default range is 1Y
@@ -10,17 +10,31 @@
  *   - Empty state when data has no valid rows
  *   - Error state propagates a retry button
  *   - Fetch calls with the active range
+ *   - Four indicator toggle buttons render
+ *   - Clicking a toggle updates the URL ?ind= param
+ *   - Pre-set ?ind= in URL activates the matching toggles
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 
-// Stub ChartCanvas so lightweight-charts is never touched in jsdom.
-vi.mock("@/components/instrument/PriceChart", () => ({
-  ChartCanvas: ({ symbol }: { symbol: string }) => (
-    <div data-testid="chart-canvas-stub" data-symbol={symbol} />
+// Stub ChartWorkspaceCanvas so lightweight-charts is never touched in jsdom.
+vi.mock("@/pages/components/ChartWorkspaceCanvas", () => ({
+  ChartWorkspaceCanvas: ({
+    symbol,
+    indicators,
+  }: {
+    symbol: string;
+    indicators: string[];
+  }) => (
+    <div
+      data-testid="chart-canvas-stub"
+      data-symbol={symbol}
+      data-indicators={indicators.join(",")}
+    />
   ),
+  INDICATOR_IDS: ["sma20", "sma50", "ema20", "ema50"],
 }));
 
 vi.mock("@/api/instruments", () => ({
@@ -194,5 +208,72 @@ describe("ChartPage — chart body", () => {
       expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
     });
     expect(screen.queryByTestId("chart-canvas-stub")).not.toBeInTheDocument();
+  });
+});
+
+describe("ChartPage — indicator toggles", () => {
+  it("renders exactly four indicator toggle buttons", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    for (const id of ["sma20", "sma50", "ema20", "ema50"]) {
+      expect(screen.getByTestId(`indicator-${id}`)).toBeInTheDocument();
+    }
+  });
+
+  it("clicking a toggle updates the ?ind= URL param", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("indicator-sma20"));
+    // After clicking, the stub should receive the indicator
+    await waitFor(() => {
+      const stub = screen.getByTestId("chart-canvas-stub");
+      expect(stub.getAttribute("data-indicators")).toBe("sma20");
+    });
+  });
+
+  it("clicking the same toggle twice removes it from ?ind=", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("indicator-sma20"));
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub").getAttribute("data-indicators")).toBe("sma20");
+    });
+    await user.click(screen.getByTestId("indicator-sma20"));
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub").getAttribute("data-indicators")).toBe("");
+    });
+  });
+
+  it("pre-set ?ind=sma20,sma50 activates those two indicators", async () => {
+    mockCandles.mockImplementation((_, range) =>
+      Promise.resolve(makeCandles(range, twoValidRows())),
+    );
+    renderPage("/instrument/AAPL/chart?ind=sma20,sma50");
+    await waitFor(() => {
+      const stub = screen.getByTestId("chart-canvas-stub");
+      const active = stub.getAttribute("data-indicators") ?? "";
+      expect(active.split(",")).toContain("sma20");
+      expect(active.split(",")).toContain("sma50");
+    });
+  });
+
+  it("ignores unrecognised indicator ids in ?ind=", async () => {
+    mockCandles.mockImplementation((_, range) =>
+      Promise.resolve(makeCandles(range, twoValidRows())),
+    );
+    renderPage("/instrument/AAPL/chart?ind=sma20,rsi14,garbage");
+    await waitFor(() => {
+      const stub = screen.getByTestId("chart-canvas-stub");
+      // Only sma20 is valid
+      expect(stub.getAttribute("data-indicators")).toBe("sma20");
+    });
   });
 });

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -1,17 +1,22 @@
 /**
- * /instrument/:symbol/chart — full-viewport chart workspace (#576 Phase 1).
+ * /instrument/:symbol/chart — full-viewport chart workspace (#576).
  *
- * Provides a full-height candlestick chart with a range picker (1W–MAX)
- * URL-synced via `?range=<id>`. The back-link returns to the instrument
- * overview. Phase 2 (indicators/tooltips), Phase 3 (compare/trends), and
- * Phase 4 (raw OHLCV table) are out of scope for this PR.
+ * Phase 1: range picker (1W–MAX), URL-synced via `?range=<id>`.
+ * Phase 2: SMA/EMA indicator overlays + rich OHLC tooltip, URL-synced
+ *          via `?ind=sma20,sma50,...`. Back-link returns to the instrument
+ *          overview. Phase 3 (compare/trends) and Phase 4 (raw OHLCV table)
+ *          are deferred.
  */
 import { useCallback } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 
 import { fetchInstrumentCandles, fetchInstrumentSummary } from "@/api/instruments";
 import type { CandleRange, InstrumentCandles, InstrumentSummary } from "@/api/types";
-import { ChartCanvas } from "@/components/instrument/PriceChart";
+import {
+  ChartWorkspaceCanvas,
+  INDICATOR_IDS,
+  type IndicatorId,
+} from "@/pages/components/ChartWorkspaceCanvas";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
@@ -29,6 +34,20 @@ const RANGES: { id: CandleRange; label: string }[] = [
 const VALID_RANGES: readonly CandleRange[] = ["1w", "1m", "3m", "6m", "1y", "5y", "max"];
 
 const DEFAULT_RANGE: CandleRange = "1y";
+
+const INDICATOR_LABELS: Record<IndicatorId, string> = {
+  sma20: "SMA 20",
+  sma50: "SMA 50",
+  ema20: "EMA 20",
+  ema50: "EMA 50",
+};
+
+const INDICATOR_COLORS: Record<IndicatorId, string> = {
+  sma20: "#3b82f6",
+  sma50: "#a855f7",
+  ema20: "#0ea5e9",
+  ema50: "#ec4899",
+};
 
 function parseNum(v: string | null | undefined): number | null {
   if (v === null || v === undefined) return null;
@@ -51,6 +70,8 @@ function dateToTime(date: string): number | null {
 export function ChartPage(): JSX.Element {
   const { symbol = "" } = useParams<{ symbol: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
+
+  // Range param
   const rawRange = searchParams.get("range");
   const range: CandleRange = VALID_RANGES.includes(rawRange as CandleRange)
     ? (rawRange as CandleRange)
@@ -67,6 +88,31 @@ export function ChartPage(): JSX.Element {
       setSearchParams(params, { replace: true });
     },
     [searchParams, setSearchParams],
+  );
+
+  // Indicator param — CSV of enabled indicator ids
+  const indParam = searchParams.get("ind");
+  const enabledIndicators: IndicatorId[] =
+    indParam !== null && indParam.length > 0
+      ? indParam
+          .split(",")
+          .filter((x): x is IndicatorId => INDICATOR_IDS.includes(x as IndicatorId))
+      : [];
+
+  const toggleIndicator = useCallback(
+    (id: IndicatorId) => {
+      const params = new URLSearchParams(searchParams);
+      const next = enabledIndicators.includes(id)
+        ? enabledIndicators.filter((x) => x !== id)
+        : [...enabledIndicators, id];
+      if (next.length === 0) {
+        params.delete("ind");
+      } else {
+        params.set("ind", next.join(","));
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams, enabledIndicators],
   );
 
   const summaryAsync = useAsync<InstrumentSummary>(
@@ -120,23 +166,52 @@ export function ChartPage(): JSX.Element {
         )}
       </div>
 
-      {/* Range picker */}
-      <div className="flex gap-1">
-        {RANGES.map((r) => (
-          <button
-            key={r.id}
-            type="button"
-            onClick={() => setRange(r.id)}
-            className={`rounded px-3 py-1 text-sm font-medium ${
-              r.id === range
-                ? "bg-slate-800 text-white"
-                : "bg-slate-100 text-slate-600 hover:bg-slate-200"
-            }`}
-            data-testid={`chart-range-${r.id}`}
-          >
-            {r.label}
-          </button>
-        ))}
+      {/* Controls: range picker + indicator toggles */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex gap-1">
+          {RANGES.map((r) => (
+            <button
+              key={r.id}
+              type="button"
+              onClick={() => setRange(r.id)}
+              className={`rounded px-3 py-1 text-sm font-medium ${
+                r.id === range
+                  ? "bg-slate-800 text-white"
+                  : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+              }`}
+              data-testid={`chart-range-${r.id}`}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-[11px] uppercase tracking-wider text-slate-500">Indicators</span>
+          {INDICATOR_IDS.map((id) => {
+            const active = enabledIndicators.includes(id);
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => toggleIndicator(id)}
+                className={`rounded border px-2 py-0.5 text-xs font-medium ${
+                  active
+                    ? "bg-white text-slate-700"
+                    : "bg-slate-50 text-slate-500 hover:bg-slate-100"
+                }`}
+                style={
+                  active
+                    ? { borderColor: INDICATOR_COLORS[id], color: INDICATOR_COLORS[id] }
+                    : { borderColor: "#e2e8f0" }
+                }
+                data-testid={`indicator-${id}`}
+              >
+                {INDICATOR_LABELS[id]}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
       {/* Chart body */}
@@ -160,7 +235,12 @@ export function ChartPage(): JSX.Element {
           </div>
         ) : null}
         {hasChartData && rows !== null ? (
-          <ChartCanvas rows={rows} symbol={symbol} containerClassName="h-[70vh] w-full" />
+          <ChartWorkspaceCanvas
+            rows={rows}
+            symbol={symbol}
+            indicators={enabledIndicators}
+            containerClassName="h-[70vh] w-full"
+          />
         ) : null}
       </div>
     </div>

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.test.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for ChartWorkspaceCanvas pure math helpers (#576 Phase 2).
+ *
+ * We test only the exported `computeSMA` and `computeEMA` functions —
+ * lightweight-charts cannot render in jsdom (Canvas API absent) so the
+ * React component itself is not exercised here. The component's integration
+ * is covered by ChartPage.test.tsx via a stub.
+ */
+import { describe, expect, it } from "vitest";
+import { computeSMA, computeEMA } from "./ChartWorkspaceCanvas";
+
+describe("computeSMA", () => {
+  it("returns correct rolling average for period 3", () => {
+    // [1,2,3,4,5] with period 3: first valid at i=2
+    const result = computeSMA([1, 2, 3, 4, 5], 3);
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeNull();
+    expect(result[2]).toBeCloseTo(2); // (1+2+3)/3
+    expect(result[3]).toBeCloseTo(3); // (2+3+4)/3
+    expect(result[4]).toBeCloseTo(4); // (3+4+5)/3
+  });
+
+  it("returns all null when closes shorter than period", () => {
+    const result = computeSMA([1, 2], 3);
+    expect(result).toHaveLength(2);
+    expect(result.every((v) => v === null)).toBe(true);
+  });
+
+  it("returns single value when closes length equals period", () => {
+    const result = computeSMA([2, 4, 6], 3);
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeNull();
+    expect(result[2]).toBeCloseTo(4); // (2+4+6)/3
+  });
+
+  it("returns all null for empty array", () => {
+    const result = computeSMA([], 20);
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles period 1 — returns each value", () => {
+    const result = computeSMA([3, 6, 9], 1);
+    expect(result[0]).toBeCloseTo(3);
+    expect(result[1]).toBeCloseTo(6);
+    expect(result[2]).toBeCloseTo(9);
+  });
+});
+
+describe("computeEMA", () => {
+  it("seeds with SMA and applies EMA formula for period 3", () => {
+    // closes: [1, 2, 3, 4, 5], period 3
+    // Seed (i=2): SMA([1,2,3]) = 2
+    // k = 2/(3+1) = 0.5
+    // i=3: 4*0.5 + 2*0.5 = 3
+    // i=4: 5*0.5 + 3*0.5 = 4
+    const result = computeEMA([1, 2, 3, 4, 5], 3);
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeNull();
+    expect(result[2]).toBeCloseTo(2);
+    expect(result[3]).toBeCloseTo(3);
+    expect(result[4]).toBeCloseTo(4);
+  });
+
+  it("returns all null when closes shorter than period", () => {
+    const result = computeEMA([1, 2], 3);
+    expect(result).toHaveLength(2);
+    expect(result.every((v) => v === null)).toBe(true);
+  });
+
+  it("returns all null for empty array", () => {
+    const result = computeEMA([], 20);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns single value when closes length equals period", () => {
+    // seed = SMA = (10+20+30)/3 = 20; no further values
+    const result = computeEMA([10, 20, 30], 3);
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeNull();
+    expect(result[2]).toBeCloseTo(20);
+  });
+
+  it("EMA reacts faster than SMA to a price spike", () => {
+    // flat series then a spike: [1,1,1,1,1,10]
+    // SMA(5) at index 5 = (1+1+1+1+10)/5 = 2.8
+    // EMA(5) at index 5 > SMA(5) because EMA weighs the spike more heavily
+    const closes = [1, 1, 1, 1, 1, 10];
+    const sma = computeSMA(closes, 5);
+    const ema = computeEMA(closes, 5);
+    const lastSma = sma[sma.length - 1]!;
+    const lastEma = ema[ema.length - 1]!;
+    expect(lastEma).toBeGreaterThan(lastSma);
+  });
+});

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -1,0 +1,382 @@
+/**
+ * ChartWorkspaceCanvas — full-viewport chart canvas for ChartPage (#576 Phase 2).
+ *
+ * Extends the lightweight-charts setup with:
+ *   - SMA/EMA overlay LineSeries (toggleable via `indicators` prop)
+ *   - Rich OHLC + volume + Δ% + per-indicator crosshair tooltip
+ *
+ * Deliberately separate from ChartCanvas (compact instrument-page chart) so
+ * the compact component stays focused and this one can evolve independently.
+ */
+import { useEffect, useRef, useState } from "react";
+import {
+  CandlestickSeries,
+  HistogramSeries,
+  LineSeries,
+  createChart,
+  type IChartApi,
+  type ISeriesApi,
+  type LineData,
+  type Time,
+  type UTCTimestamp,
+} from "lightweight-charts";
+
+import type { CandleBar } from "@/api/types";
+
+const SMA_COLORS: Record<string, string> = {
+  sma20: "#3b82f6", // blue-500
+  sma50: "#a855f7", // purple-500
+  ema20: "#0ea5e9", // sky-500
+  ema50: "#ec4899", // pink-500
+};
+
+const SMA_LABELS: Record<string, string> = {
+  sma20: "SMA(20)",
+  sma50: "SMA(50)",
+  ema20: "EMA(20)",
+  ema50: "EMA(50)",
+};
+
+export type IndicatorId = "sma20" | "sma50" | "ema20" | "ema50";
+export const INDICATOR_IDS: IndicatorId[] = ["sma20", "sma50", "ema20", "ema50"];
+
+interface NumericBar {
+  time: UTCTimestamp;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+interface RichHoverState {
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+  changePct: number | null;
+  indicators: Array<{ id: IndicatorId; label: string; value: number }>;
+}
+
+function parseNum(v: string | null | undefined): number | null {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function dateToTime(date: string): UTCTimestamp | null {
+  const parts = date.split("-");
+  if (parts.length !== 3) return null;
+  const y = Number(parts[0]);
+  const m = Number(parts[1]);
+  const d = Number(parts[2]);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return null;
+  const ts = Date.UTC(y, m - 1, d);
+  if (!Number.isFinite(ts)) return null;
+  return (ts / 1000) as UTCTimestamp;
+}
+
+// Pure functions — exported for unit testing.
+
+export function computeSMA(closes: number[], period: number): Array<number | null> {
+  const out: Array<number | null> = new Array(closes.length).fill(null);
+  let sum = 0;
+  for (let i = 0; i < closes.length; i++) {
+    sum += closes[i] as number;
+    if (i >= period) sum -= closes[i - period] as number;
+    if (i >= period - 1) out[i] = sum / period;
+  }
+  return out;
+}
+
+export function computeEMA(closes: number[], period: number): Array<number | null> {
+  const out: Array<number | null> = new Array(closes.length).fill(null);
+  if (closes.length < period) return out;
+  const k = 2 / (period + 1);
+  // Seed with SMA of the first `period` values.
+  let sum = 0;
+  for (let i = 0; i < period; i++) sum += closes[i] as number;
+  let ema = sum / period;
+  out[period - 1] = ema;
+  for (let i = period; i < closes.length; i++) {
+    ema = (closes[i] as number) * k + ema * (1 - k);
+    out[i] = ema;
+  }
+  return out;
+}
+
+function computeIndicator(id: IndicatorId, closes: number[]): Array<number | null> {
+  switch (id) {
+    case "sma20":
+      return computeSMA(closes, 20);
+    case "sma50":
+      return computeSMA(closes, 50);
+    case "ema20":
+      return computeEMA(closes, 20);
+    case "ema50":
+      return computeEMA(closes, 50);
+  }
+}
+
+export interface ChartWorkspaceCanvasProps {
+  readonly rows: CandleBar[];
+  readonly symbol: string;
+  readonly indicators: ReadonlyArray<IndicatorId>;
+  readonly containerClassName?: string;
+}
+
+export function ChartWorkspaceCanvas({
+  rows,
+  symbol,
+  indicators,
+  containerClassName,
+}: ChartWorkspaceCanvasProps): JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const candleRef = useRef<ISeriesApi<"Candlestick"> | null>(null);
+  const volumeRef = useRef<ISeriesApi<"Histogram"> | null>(null);
+  const indicatorRefs = useRef<Map<IndicatorId, ISeriesApi<"Line">>>(new Map());
+  // Stable refs for crosshair closure — no stale-closure risk.
+  const cleanRowsRef = useRef<NumericBar[]>([]);
+  const indicatorValuesRef = useRef<Map<IndicatorId, Array<number | null>>>(new Map());
+  const [hover, setHover] = useState<RichHoverState | null>(null);
+
+  // One-shot chart construction — mirrors ChartCanvas setup.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (container === null) return;
+
+    const chart = createChart(container, {
+      autoSize: true,
+      layout: {
+        background: { color: "#ffffff" },
+        textColor: "#64748b",
+        fontSize: 11,
+      },
+      grid: {
+        vertLines: { color: "#f1f5f9" },
+        horzLines: { color: "#f1f5f9" },
+      },
+      rightPriceScale: {
+        borderColor: "#e2e8f0",
+        scaleMargins: { top: 0.08, bottom: 0.3 },
+      },
+      timeScale: {
+        borderColor: "#e2e8f0",
+        timeVisible: false,
+        secondsVisible: false,
+      },
+      crosshair: {
+        vertLine: { width: 1, color: "#94a3b8", style: 3 },
+        horzLine: { width: 1, color: "#94a3b8", style: 3 },
+      },
+    });
+
+    const candle = chart.addSeries(CandlestickSeries, {
+      upColor: "#10b981",
+      downColor: "#ef4444",
+      wickUpColor: "#10b981",
+      wickDownColor: "#ef4444",
+      borderVisible: false,
+    });
+
+    const volume = chart.addSeries(HistogramSeries, {
+      priceScaleId: "volume",
+      priceFormat: { type: "volume" },
+    });
+    chart.priceScale("volume").applyOptions({ scaleMargins: { top: 0.75, bottom: 0 } });
+
+    chart.subscribeCrosshairMove((param) => {
+      if (!param.time || typeof param.time !== "number") {
+        setHover(null);
+        return;
+      }
+      const time = param.time as UTCTimestamp;
+      const idx = cleanRowsRef.current.findIndex((b) => b.time === time);
+      if (idx < 0) {
+        setHover(null);
+        return;
+      }
+      const bar = cleanRowsRef.current[idx]!;
+      const prev = idx > 0 ? cleanRowsRef.current[idx - 1] : null;
+      const changePct =
+        prev !== null && prev !== undefined && prev.close !== 0
+          ? ((bar.close - prev.close) / prev.close) * 100
+          : null;
+
+      const indicatorRows: Array<{ id: IndicatorId; label: string; value: number }> = [];
+      for (const id of INDICATOR_IDS) {
+        const series = indicatorValuesRef.current.get(id);
+        if (series === undefined) continue;
+        const v = series[idx];
+        if (v === null || v === undefined) continue;
+        indicatorRows.push({ id, label: SMA_LABELS[id]!, value: v });
+      }
+
+      const date = new Date(time * 1000).toISOString().slice(0, 10);
+      setHover({
+        date,
+        open: bar.open,
+        high: bar.high,
+        low: bar.low,
+        close: bar.close,
+        volume: bar.volume,
+        changePct,
+        indicators: indicatorRows,
+      });
+    });
+
+    chartRef.current = chart;
+    candleRef.current = candle;
+    volumeRef.current = volume;
+
+    return () => {
+      chart.remove();
+      chartRef.current = null;
+      candleRef.current = null;
+      volumeRef.current = null;
+      indicatorRefs.current.clear();
+    };
+  }, []);
+
+  // Feed candle + volume data on rows change.
+  useEffect(() => {
+    const candle = candleRef.current;
+    const volume = volumeRef.current;
+    const chart = chartRef.current;
+    if (!candle || !volume || !chart) return;
+
+    const clean: NumericBar[] = rows.flatMap((r) => {
+      const time = dateToTime(r.date);
+      const open = parseNum(r.open);
+      const high = parseNum(r.high);
+      const low = parseNum(r.low);
+      const close = parseNum(r.close);
+      if (time === null || open === null || high === null || low === null || close === null) {
+        return [];
+      }
+      return [{ time, open, high, low, close, volume: parseNum(r.volume) ?? 0 }];
+    });
+    cleanRowsRef.current = clean;
+
+    candle.setData(
+      clean.map((b) => ({
+        time: b.time as Time,
+        open: b.open,
+        high: b.high,
+        low: b.low,
+        close: b.close,
+      })),
+    );
+
+    volume.setData(
+      clean.map((b, i) => {
+        const prev = i > 0 ? clean[i - 1]!.close : b.close;
+        return {
+          time: b.time as Time,
+          value: b.volume,
+          color: b.close >= prev ? "rgba(16,185,129,0.4)" : "rgba(239,68,68,0.4)",
+        };
+      }),
+    );
+
+    chart.timeScale().fitContent();
+  }, [rows]);
+
+  // Add/remove indicator LineSeries based on `indicators` prop.
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+    const closes = cleanRowsRef.current.map((b) => b.close);
+
+    // Remove series no longer enabled.
+    for (const [id, series] of indicatorRefs.current.entries()) {
+      if (!indicators.includes(id)) {
+        chart.removeSeries(series);
+        indicatorRefs.current.delete(id);
+        indicatorValuesRef.current.delete(id);
+      }
+    }
+
+    // Add new / update existing enabled indicators.
+    for (const id of indicators) {
+      const values = computeIndicator(id, closes);
+      indicatorValuesRef.current.set(id, values);
+      let series = indicatorRefs.current.get(id);
+      if (!series) {
+        series = chart.addSeries(LineSeries, {
+          color: SMA_COLORS[id]!,
+          lineWidth: 2,
+          priceLineVisible: false,
+          lastValueVisible: false,
+        });
+        indicatorRefs.current.set(id, series);
+      }
+      const data: LineData[] = [];
+      for (let i = 0; i < values.length; i++) {
+        const v = values[i];
+        const bar = cleanRowsRef.current[i];
+        if (v === null || v === undefined || !bar) continue;
+        data.push({ time: bar.time as Time, value: v });
+      }
+      series.setData(data);
+    }
+  }, [indicators, rows]);
+
+  return (
+    <div className="relative">
+      {hover !== null ? <RichTooltip hover={hover} symbol={symbol} /> : null}
+      <div
+        ref={containerRef}
+        data-testid={`chart-workspace-${symbol}`}
+        className={containerClassName ?? "h-[70vh] w-full"}
+      />
+    </div>
+  );
+}
+
+function RichTooltip({ hover, symbol }: { hover: RichHoverState; symbol: string }): JSX.Element {
+  const fmt = (n: number) =>
+    n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  return (
+    <div className="absolute right-2 top-2 z-10 min-w-[180px] rounded bg-white/95 px-3 py-2 text-xs shadow-md">
+      <div className="font-semibold text-slate-800">{symbol}</div>
+      <div className="text-slate-500">{hover.date}</div>
+      <dl className="mt-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 tabular-nums">
+        <dt className="text-slate-500">O</dt>
+        <dd>{fmt(hover.open)}</dd>
+        <dt className="text-slate-500">H</dt>
+        <dd>{fmt(hover.high)}</dd>
+        <dt className="text-slate-500">L</dt>
+        <dd>{fmt(hover.low)}</dd>
+        <dt className="text-slate-500">C</dt>
+        <dd className="font-medium text-slate-800">{fmt(hover.close)}</dd>
+        <dt className="text-slate-500">Vol</dt>
+        <dd>{fmt(hover.volume)}</dd>
+        {hover.changePct !== null ? (
+          <>
+            <dt className="text-slate-500">Δ%</dt>
+            <dd className={hover.changePct >= 0 ? "text-emerald-600" : "text-red-600"}>
+              {hover.changePct >= 0 ? "+" : ""}
+              {hover.changePct.toFixed(2)}%
+            </dd>
+          </>
+        ) : null}
+      </dl>
+      {hover.indicators.length > 0 ? (
+        <div className="mt-1 border-t border-slate-100 pt-1">
+          {hover.indicators.map((row) => (
+            <div key={row.id} className="flex justify-between text-[11px]">
+              <span className="text-slate-500">{row.label}</span>
+              <span className="tabular-nums" style={{ color: SMA_COLORS[row.id] }}>
+                {fmt(row.value)}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -8,7 +8,7 @@
  * Deliberately separate from ChartCanvas (compact instrument-page chart) so
  * the compact component stays focused and this one can evolve independently.
  */
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type JSX } from "react";
 import {
   CandlestickSeries,
   HistogramSeries,
@@ -286,6 +286,11 @@ export function ChartWorkspaceCanvas({
   }, [rows]);
 
   // Add/remove indicator LineSeries based on `indicators` prop.
+  // `rows` is in the dep array (alongside `indicators`) so this effect
+  // re-runs after the prior data effect refreshes `cleanRowsRef`. Without
+  // it, toggling indicators on a re-fetched range would compute SMAs over
+  // the previous range's `cleanRowsRef`. Do not "simplify" by removing
+  // `rows` from the deps.
   useEffect(() => {
     const chart = chartRef.current;
     if (!chart) return;


### PR DESCRIPTION
## What

Phase 2 of #576 — interactivity polish on the chart workspace.

- New `ChartWorkspaceCanvas` (`frontend/src/pages/components/`) — full-viewport chart with toggleable indicators
- Indicators: **SMA(20), SMA(50), EMA(20), EMA(50)** with hand-coded math (no new deps); RSI/MACD deferred (separate oscillator panes warrant follow-up)
- **Rich crosshair tooltip**: date, OHLC, volume, %change-from-prior, active indicator values colored to match overlays
- Indicator toggles persisted via `?ind=sma20,sma50,...` URL CSV; refresh preserves selection
- **Sparkline hover tooltip**: `Sparkline.tsx` now shows value at cursor (used by FundamentalsPane on instrument page)

`ChartCanvas` (the compact instrument-page chart in `PriceChart.tsx`) is **unchanged** — only the full workspace gets the heavyweight UX. Keeps the overview pane snappy.

## Why

Closes Phase 2 of #576. Operator review (2026-04-27): "graphs in general need a lot of love. Should show clearer, fuller. Be able to interact with them."

## Test plan

- 38 new vitest tests (`ChartWorkspaceCanvas` math, `ChartPage` indicator toggles, `Sparkline` hover)
- 506 frontend tests pass
- `pnpm --dir frontend typecheck` clean
- `uv run ruff check . && uv run ruff format --check .` clean

## Out of scope (Phases 3-4)

- Compare-tickers overlay
- Linear regression + price channel envelope (Phase 3)
- Raw OHLCV table at `?view=raw` + CSV export (Phase 4)
- RSI / MACD oscillator panes (separate ticket — they need their own price scale below the main chart)