### PR TITLE
feat(#576): chart workspace Phase 3 — compare + linear regression + range channel

### DIFF
--- a/frontend/src/pages/ChartPage.test.tsx
+++ b/frontend/src/pages/ChartPage.test.tsx
@@ -1,9 +1,10 @@
 /**
- * Tests for ChartPage (#576 Phase 1 + Phase 2).
+ * Tests for ChartPage (#576 Phase 1 + Phase 2 + Phase 3).
  *
  * lightweight-charts cannot render in jsdom (Canvas API absent), so we stub
  * ChartWorkspaceCanvas to a simple div. What we pin here is the page's contract:
  *
+ * Phase 1 + 2:
  *   - Symbol + back-link render
  *   - Default range is 1Y
  *   - Clicking a range button updates the URL param to ?range=<id>
@@ -13,6 +14,15 @@
  *   - Four indicator toggle buttons render
  *   - Clicking a toggle updates the URL ?ind= param
  *   - Pre-set ?ind= in URL activates the matching toggles
+ *
+ * Phase 3:
+ *   - Compare input adds a chip + URL gets ?compare=AAPL
+ *   - Removing a compare chip clears it from URL
+ *   - Pre-set ?compare=AAPL,MSFT renders both chips active
+ *   - Cap at 3 — typing a 4th doesn't add
+ *   - Trend toggle Regression updates ?trend=regression
+ *   - Pre-set ?trend=regression,channel activates both toggles
+ *   - Compare + trend props forwarded to canvas stub
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
@@ -24,14 +34,23 @@ vi.mock("@/pages/components/ChartWorkspaceCanvas", () => ({
   ChartWorkspaceCanvas: ({
     symbol,
     indicators,
+    compares,
+    showRegression,
+    showChannel,
   }: {
     symbol: string;
     indicators: string[];
+    compares?: Array<{ symbol: string; rows: unknown[] }>;
+    showRegression?: boolean;
+    showChannel?: boolean;
   }) => (
     <div
       data-testid="chart-canvas-stub"
       data-symbol={symbol}
       data-indicators={indicators.join(",")}
+      data-compares={(compares ?? []).map((c) => c.symbol).join(",")}
+      data-show-regression={String(showRegression ?? false)}
+      data-show-channel={String(showChannel ?? false)}
     />
   ),
   INDICATOR_IDS: ["sma20", "sma50", "ema20", "ema50"],
@@ -52,8 +71,9 @@ const mockCandles = vi.mocked(fetchInstrumentCandles);
 function makeCandles(
   range: InstrumentCandles["range"],
   rows: InstrumentCandles["rows"] = [],
+  symbol = "AAPL",
 ): InstrumentCandles {
-  return { symbol: "AAPL", range, days: 365, rows };
+  return { symbol, range, days: 365, rows };
 }
 
 function makeSummary(): InstrumentSummary {
@@ -90,7 +110,9 @@ function renderPage(path = "/instrument/AAPL/chart") {
 
 beforeEach(() => {
   mockSummary.mockResolvedValue(makeSummary());
-  mockCandles.mockResolvedValue(makeCandles("1y", twoValidRows()));
+  mockCandles.mockImplementation((sym, range) =>
+    Promise.resolve(makeCandles(range, twoValidRows(), sym)),
+  );
 });
 
 afterEach(() => vi.clearAllMocks());
@@ -138,9 +160,6 @@ describe("ChartPage — range picker", () => {
   });
 
   it("clicking a range button updates the URL and refetches with new range", async () => {
-    mockCandles.mockImplementation((_, range) =>
-      Promise.resolve(makeCandles(range, twoValidRows())),
-    );
     const user = userEvent.setup();
     renderPage();
     await waitFor(() => {
@@ -153,9 +172,6 @@ describe("ChartPage — range picker", () => {
   });
 
   it("honours a pre-set ?range= query param from the URL", async () => {
-    mockCandles.mockImplementation((_, range) =>
-      Promise.resolve(makeCandles(range, twoValidRows())),
-    );
     renderPage("/instrument/AAPL/chart?range=5y");
     await waitFor(() => {
       expect(mockCandles).toHaveBeenCalledWith("AAPL", "5y");
@@ -253,9 +269,6 @@ describe("ChartPage — indicator toggles", () => {
   });
 
   it("pre-set ?ind=sma20,sma50 activates those two indicators", async () => {
-    mockCandles.mockImplementation((_, range) =>
-      Promise.resolve(makeCandles(range, twoValidRows())),
-    );
     renderPage("/instrument/AAPL/chart?ind=sma20,sma50");
     await waitFor(() => {
       const stub = screen.getByTestId("chart-canvas-stub");
@@ -266,14 +279,158 @@ describe("ChartPage — indicator toggles", () => {
   });
 
   it("ignores unrecognised indicator ids in ?ind=", async () => {
-    mockCandles.mockImplementation((_, range) =>
-      Promise.resolve(makeCandles(range, twoValidRows())),
-    );
     renderPage("/instrument/AAPL/chart?ind=sma20,rsi14,garbage");
     await waitFor(() => {
       const stub = screen.getByTestId("chart-canvas-stub");
       // Only sma20 is valid
       expect(stub.getAttribute("data-indicators")).toBe("sma20");
+    });
+  });
+});
+
+describe("ChartPage — Phase 3 compare overlays", () => {
+  it("compare input is rendered", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("compare-input")).toBeInTheDocument();
+  });
+
+  it("typing a symbol and pressing Enter adds a chip and updates URL", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    const input = screen.getByTestId("compare-input");
+    await user.type(input, "MSFT{Enter}");
+    await waitFor(() => {
+      expect(screen.getByTestId("compare-chip-MSFT")).toBeInTheDocument();
+    });
+    // Canvas stub should receive MSFT in data-compares after fetch resolves
+    await waitFor(() => {
+      const stub = screen.getByTestId("chart-canvas-stub");
+      expect(stub.getAttribute("data-compares")).toContain("MSFT");
+    });
+  });
+
+  it("removing a compare chip clears it from the URL and canvas", async () => {
+    const user = userEvent.setup();
+    renderPage("/instrument/AAPL/chart?compare=MSFT");
+    await waitFor(() => {
+      expect(screen.getByTestId("compare-chip-MSFT")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("compare-remove-MSFT"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("compare-chip-MSFT")).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      const stub = screen.getByTestId("chart-canvas-stub");
+      expect(stub.getAttribute("data-compares")).toBe("");
+    });
+  });
+
+  it("pre-set ?compare=MSFT,GOOG renders both chips", async () => {
+    renderPage("/instrument/AAPL/chart?compare=MSFT,GOOG");
+    await waitFor(() => {
+      expect(screen.getByTestId("compare-chip-MSFT")).toBeInTheDocument();
+      expect(screen.getByTestId("compare-chip-GOOG")).toBeInTheDocument();
+    });
+  });
+
+  it("cap at 3 — compare input hidden when 3 symbols are present", async () => {
+    renderPage("/instrument/AAPL/chart?compare=MSFT,GOOG,SPY");
+    await waitFor(() => {
+      expect(screen.getByTestId("compare-chip-MSFT")).toBeInTheDocument();
+      expect(screen.getByTestId("compare-chip-GOOG")).toBeInTheDocument();
+      expect(screen.getByTestId("compare-chip-SPY")).toBeInTheDocument();
+    });
+    // Input should not be present at the max
+    expect(screen.queryByTestId("compare-input")).not.toBeInTheDocument();
+    // A hint about the max should appear
+    expect(screen.getByText(/Max 3/i)).toBeInTheDocument();
+  });
+
+  it("adding a 4th symbol via URL trims to first 3", async () => {
+    renderPage("/instrument/AAPL/chart?compare=MSFT,GOOG,SPY,NVDA");
+    await waitFor(() => {
+      // Only 3 chips rendered
+      expect(screen.getByTestId("compare-chip-MSFT")).toBeInTheDocument();
+      expect(screen.getByTestId("compare-chip-GOOG")).toBeInTheDocument();
+      expect(screen.getByTestId("compare-chip-SPY")).toBeInTheDocument();
+      expect(screen.queryByTestId("compare-chip-NVDA")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("ChartPage — Phase 3 trend toggles", () => {
+  it("renders Regression and Range trend toggle buttons", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("trend-regression")).toBeInTheDocument();
+    expect(screen.getByTestId("trend-channel")).toBeInTheDocument();
+  });
+
+  it("clicking Regression sets ?trend=regression and forwards showRegression=true", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("trend-regression"));
+    await waitFor(() => {
+      const stub = screen.getByTestId("chart-canvas-stub");
+      expect(stub.getAttribute("data-show-regression")).toBe("true");
+    });
+  });
+
+  it("clicking Regression twice removes it (toggle off)", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("trend-regression"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("chart-canvas-stub").getAttribute("data-show-regression"),
+      ).toBe("true");
+    });
+    await user.click(screen.getByTestId("trend-regression"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("chart-canvas-stub").getAttribute("data-show-regression"),
+      ).toBe("false");
+    });
+  });
+
+  it("pre-set ?trend=regression,channel activates both toggles", async () => {
+    renderPage("/instrument/AAPL/chart?trend=regression,channel");
+    await waitFor(() => {
+      const stub = screen.getByTestId("chart-canvas-stub");
+      expect(stub.getAttribute("data-show-regression")).toBe("true");
+      expect(stub.getAttribute("data-show-channel")).toBe("true");
+    });
+  });
+
+  it("pre-set ?trend=channel activates only channel", async () => {
+    renderPage("/instrument/AAPL/chart?trend=channel");
+    await waitFor(() => {
+      const stub = screen.getByTestId("chart-canvas-stub");
+      expect(stub.getAttribute("data-show-regression")).toBe("false");
+      expect(stub.getAttribute("data-show-channel")).toBe("true");
+    });
+  });
+
+  it("ignores unrecognised trend ids", async () => {
+    renderPage("/instrument/AAPL/chart?trend=regression,bollinger");
+    await waitFor(() => {
+      const stub = screen.getByTestId("chart-canvas-stub");
+      expect(stub.getAttribute("data-show-regression")).toBe("true");
+      expect(stub.getAttribute("data-show-channel")).toBe("false");
     });
   });
 });

--- a/frontend/src/pages/ChartPage.test.tsx
+++ b/frontend/src/pages/ChartPage.test.tsx
@@ -364,6 +364,32 @@ describe("ChartPage — Phase 3 compare overlays", () => {
   });
 });
 
+describe("ChartPage — compare fetch error handling", () => {
+  it("handles per-ticker fetch failure without crashing the batch", async () => {
+    mockCandles.mockImplementation((sym: string, range) => {
+      if (sym === "BAD") return Promise.reject(new Error("404 Not Found"));
+      return Promise.resolve(makeCandles(range, twoValidRows(), sym));
+    });
+
+    renderPage("/instrument/AAPL/chart?compare=MSFT,BAD");
+
+    // Wait for the canvas to appear (primary fetch succeeds).
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+
+    // MSFT chip renders normally (no error attribute).
+    await waitFor(() => {
+      expect(screen.getByTestId("compare-chip-MSFT")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("compare-chip-MSFT")).not.toHaveAttribute("data-error");
+
+    // BAD chip renders with error styling (data-error="true").
+    expect(screen.getByTestId("compare-chip-BAD")).toBeInTheDocument();
+    expect(screen.getByTestId("compare-chip-BAD")).toHaveAttribute("data-error", "true");
+  });
+});
+
 describe("ChartPage — Phase 3 trend toggles", () => {
   it("renders Regression and Range trend toggle buttons", async () => {
     renderPage();

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -432,7 +432,6 @@ export function ChartPage(): JSX.Element {
             value={compareInput}
             onChange={(e) => setCompareInput(e.target.value)}
             onKeyDown={handleCompareKeyDown}
-            onBlur={handleCompareSubmit}
             placeholder="Add ticker to compare..."
             className="rounded border border-slate-200 bg-white px-2 py-0.5 text-xs text-slate-700 placeholder-slate-400 focus:border-slate-400 focus:outline-none"
             data-testid="compare-input"

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -227,6 +227,8 @@ export function ChartPage(): JSX.Element {
   // Compare candle fetches: parallel, keyed on [range, ...compareSymbols].
   // We use a single useEffect + useState<Map> to manage compare fetches.
   const [compareData, setCompareData] = useState<Map<string, CandleBar[]>>(new Map());
+  // Symbols whose fetch failed — shown with an error chip.
+  const [compareErrors, setCompareErrors] = useState<string[]>([]);
   // Track the set of symbols + range for which we've started fetching.
   const compareFetchKeyRef = useRef<string>("");
 
@@ -237,22 +239,27 @@ export function ChartPage(): JSX.Element {
 
     if (compareSymbols.length === 0) {
       setCompareData(new Map());
+      setCompareErrors([]);
       return;
     }
 
     let cancelled = false;
-    void Promise.all(
-      compareSymbols.map(async (sym) => {
-        const result = await fetchInstrumentCandles(sym, range);
-        return { sym, rows: result.rows };
-      }),
+    void Promise.allSettled(
+      compareSymbols.map((sym) => fetchInstrumentCandles(sym, range)),
     ).then((results) => {
       if (cancelled) return;
       const m = new Map<string, CandleBar[]>();
-      for (const { sym, rows } of results) {
-        m.set(sym, rows);
-      }
+      const failures: string[] = [];
+      results.forEach((r, i) => {
+        const sym = compareSymbols[i]!;
+        if (r.status === "fulfilled") {
+          m.set(sym, r.value.rows);
+        } else {
+          failures.push(sym);
+        }
+      });
       setCompareData(m);
+      setCompareErrors(failures);
     });
 
     return () => {
@@ -385,24 +392,34 @@ export function ChartPage(): JSX.Element {
       {/* Compare row */}
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-[11px] uppercase tracking-wider text-slate-500">Compare</span>
-        {compareSymbols.map((sym) => (
-          <span
-            key={sym}
-            className="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-slate-50 px-2 py-0.5 text-xs font-medium text-slate-700"
-            data-testid={`compare-chip-${sym}`}
-          >
-            {sym}
-            <button
-              type="button"
-              aria-label={`Remove ${sym}`}
-              onClick={() => removeCompare(sym)}
-              className="ml-0.5 rounded-full text-slate-400 hover:text-slate-600"
-              data-testid={`compare-remove-${sym}`}
+        {compareSymbols.map((sym) => {
+          const hasFailed = compareErrors.includes(sym);
+          return (
+            <span
+              key={sym}
+              className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${
+                hasFailed
+                  ? "border-red-400 bg-red-50 text-red-700"
+                  : "border-slate-300 bg-slate-50 text-slate-700"
+              }`}
+              title={hasFailed ? "Failed to fetch — check ticker" : undefined}
+              aria-label={hasFailed ? `${sym} — failed to fetch` : sym}
+              data-testid={`compare-chip-${sym}`}
+              data-error={hasFailed ? "true" : undefined}
             >
-              ×
-            </button>
-          </span>
-        ))}
+              {sym}
+              <button
+                type="button"
+                aria-label={`Remove ${sym}`}
+                onClick={() => removeCompare(sym)}
+                className={`ml-0.5 rounded-full ${hasFailed ? "text-red-400 hover:text-red-600" : "text-slate-400 hover:text-slate-600"}`}
+                data-testid={`compare-remove-${sym}`}
+              >
+                ×
+              </button>
+            </span>
+          );
+        })}
         {compareSymbols.length < MAX_COMPARES && (
           <input
             ref={compareInputRef}

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -4,17 +4,21 @@
  * Phase 1: range picker (1W–MAX), URL-synced via `?range=<id>`.
  * Phase 2: SMA/EMA indicator overlays + rich OHLC tooltip, URL-synced
  *          via `?ind=sma20,sma50,...`. Back-link returns to the instrument
- *          overview. Phase 3 (compare/trends) and Phase 4 (raw OHLCV table)
- *          are deferred.
+ *          overview.
+ * Phase 3: compare-ticker overlays (URL: `?compare=AAPL,MSFT,SPY`),
+ *          linear regression line + range channel toggles
+ *          (URL: `?trend=regression,channel`).
+ * Phase 4 (raw OHLCV table + CSV export) deferred to next PR.
  */
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 
 import { fetchInstrumentCandles, fetchInstrumentSummary } from "@/api/instruments";
-import type { CandleRange, InstrumentCandles, InstrumentSummary } from "@/api/types";
+import type { CandleBar, CandleRange, InstrumentCandles, InstrumentSummary } from "@/api/types";
 import {
   ChartWorkspaceCanvas,
   INDICATOR_IDS,
+  type CompareSeries,
   type IndicatorId,
 } from "@/pages/components/ChartWorkspaceCanvas";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
@@ -48,6 +52,11 @@ const INDICATOR_COLORS: Record<IndicatorId, string> = {
   ema20: "#0ea5e9",
   ema50: "#ec4899",
 };
+
+const MAX_COMPARES = 3;
+
+type TrendId = "regression" | "channel";
+const VALID_TRENDS: readonly TrendId[] = ["regression", "channel"];
 
 function parseNum(v: string | null | undefined): number | null {
   if (v === null || v === undefined) return null;
@@ -115,6 +124,97 @@ export function ChartPage(): JSX.Element {
     [searchParams, setSearchParams, enabledIndicators],
   );
 
+  // Compare param — CSV of compare symbols (max 3, uppercase, deduped)
+  const compareParam = searchParams.get("compare");
+  const compareSymbols: string[] = (() => {
+    if (compareParam === null || compareParam.length === 0) return [];
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const raw of compareParam.split(",")) {
+      const s = raw.trim().toUpperCase();
+      if (s.length === 0 || seen.has(s) || s === symbol.toUpperCase()) continue;
+      seen.add(s);
+      out.push(s);
+      if (out.length >= MAX_COMPARES) break;
+    }
+    return out;
+  })();
+
+  const addCompare = useCallback(
+    (sym: string) => {
+      const s = sym.trim().toUpperCase();
+      if (!s || s === symbol.toUpperCase()) return;
+      if (compareSymbols.includes(s)) return;
+      if (compareSymbols.length >= MAX_COMPARES) return;
+      const next = [...compareSymbols, s];
+      const params = new URLSearchParams(searchParams);
+      params.set("compare", next.join(","));
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams, compareSymbols, symbol],
+  );
+
+  const removeCompare = useCallback(
+    (sym: string) => {
+      const next = compareSymbols.filter((s) => s !== sym);
+      const params = new URLSearchParams(searchParams);
+      if (next.length === 0) {
+        params.delete("compare");
+      } else {
+        params.set("compare", next.join(","));
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams, compareSymbols],
+  );
+
+  // Trend param — CSV of trend ids
+  const trendParam = searchParams.get("trend");
+  const enabledTrends: TrendId[] =
+    trendParam !== null && trendParam.length > 0
+      ? trendParam
+          .split(",")
+          .filter((x): x is TrendId => VALID_TRENDS.includes(x as TrendId))
+      : [];
+
+  const toggleTrend = useCallback(
+    (id: TrendId) => {
+      const params = new URLSearchParams(searchParams);
+      const next = enabledTrends.includes(id)
+        ? enabledTrends.filter((x) => x !== id)
+        : [...enabledTrends, id];
+      if (next.length === 0) {
+        params.delete("trend");
+      } else {
+        params.set("trend", next.join(","));
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams, enabledTrends],
+  );
+
+  // Compare input local state.
+  const [compareInput, setCompareInput] = useState("");
+  const compareInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleCompareSubmit = useCallback(() => {
+    const trimmed = compareInput.trim().toUpperCase();
+    if (trimmed) {
+      addCompare(trimmed);
+      setCompareInput("");
+    }
+  }, [compareInput, addCompare]);
+
+  const handleCompareKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        handleCompareSubmit();
+      }
+    },
+    [handleCompareSubmit],
+  );
+
+  // Primary candle fetch.
   const summaryAsync = useAsync<InstrumentSummary>(
     () => fetchInstrumentSummary(symbol),
     [symbol],
@@ -123,6 +223,51 @@ export function ChartPage(): JSX.Element {
     () => fetchInstrumentCandles(symbol, range),
     [symbol, range],
   );
+
+  // Compare candle fetches: parallel, keyed on [range, ...compareSymbols].
+  // We use a single useEffect + useState<Map> to manage compare fetches.
+  const [compareData, setCompareData] = useState<Map<string, CandleBar[]>>(new Map());
+  // Track the set of symbols + range for which we've started fetching.
+  const compareFetchKeyRef = useRef<string>("");
+
+  useEffect(() => {
+    const key = [range, ...compareSymbols].join(",");
+    if (key === compareFetchKeyRef.current && compareSymbols.length === 0) return;
+    compareFetchKeyRef.current = key;
+
+    if (compareSymbols.length === 0) {
+      setCompareData(new Map());
+      return;
+    }
+
+    let cancelled = false;
+    void Promise.all(
+      compareSymbols.map(async (sym) => {
+        const result = await fetchInstrumentCandles(sym, range);
+        return { sym, rows: result.rows };
+      }),
+    ).then((results) => {
+      if (cancelled) return;
+      const m = new Map<string, CandleBar[]>();
+      for (const { sym, rows } of results) {
+        m.set(sym, rows);
+      }
+      setCompareData(m);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // compareSymbols is rebuilt each render from URL params — stable key string prevents
+    // spurious re-fetches. eslint-disable needed because array identity changes each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [range, compareParam]);
+
+  // Build CompareSeries array for the canvas.
+  const compareSeries: CompareSeries[] = compareSymbols.map((sym) => ({
+    symbol: sym,
+    rows: compareData.get(sym) ?? [],
+  }));
 
   const dataMatchesRange = candlesAsync.data?.range === range;
   const effectivelyLoading = candlesAsync.loading || !dataMatchesRange;
@@ -166,7 +311,7 @@ export function ChartPage(): JSX.Element {
         )}
       </div>
 
-      {/* Controls: range picker + indicator toggles */}
+      {/* Controls: range picker + indicator toggles + trend toggles */}
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex gap-1">
           {RANGES.map((r) => (
@@ -212,6 +357,68 @@ export function ChartPage(): JSX.Element {
             );
           })}
         </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-[11px] uppercase tracking-wider text-slate-500">Trend</span>
+          {(["regression", "channel"] as const).map((id) => {
+            const active = enabledTrends.includes(id);
+            const label = id === "regression" ? "Regression" : "Range";
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => toggleTrend(id)}
+                className={`rounded border px-2 py-0.5 text-xs font-medium ${
+                  active
+                    ? "border-orange-400 bg-white text-orange-600"
+                    : "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100"
+                }`}
+                data-testid={`trend-${id}`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Compare row */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[11px] uppercase tracking-wider text-slate-500">Compare</span>
+        {compareSymbols.map((sym) => (
+          <span
+            key={sym}
+            className="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-slate-50 px-2 py-0.5 text-xs font-medium text-slate-700"
+            data-testid={`compare-chip-${sym}`}
+          >
+            {sym}
+            <button
+              type="button"
+              aria-label={`Remove ${sym}`}
+              onClick={() => removeCompare(sym)}
+              className="ml-0.5 rounded-full text-slate-400 hover:text-slate-600"
+              data-testid={`compare-remove-${sym}`}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+        {compareSymbols.length < MAX_COMPARES && (
+          <input
+            ref={compareInputRef}
+            type="text"
+            value={compareInput}
+            onChange={(e) => setCompareInput(e.target.value)}
+            onKeyDown={handleCompareKeyDown}
+            onBlur={handleCompareSubmit}
+            placeholder="Add ticker to compare..."
+            className="rounded border border-slate-200 bg-white px-2 py-0.5 text-xs text-slate-700 placeholder-slate-400 focus:border-slate-400 focus:outline-none"
+            data-testid="compare-input"
+          />
+        )}
+        {compareSymbols.length >= MAX_COMPARES && (
+          <span className="text-[11px] text-slate-400">Max {MAX_COMPARES} symbols</span>
+        )}
       </div>
 
       {/* Chart body */}
@@ -239,6 +446,9 @@ export function ChartPage(): JSX.Element {
             rows={rows}
             symbol={symbol}
             indicators={enabledIndicators}
+            compares={compareSeries}
+            showRegression={enabledTrends.includes("regression")}
+            showChannel={enabledTrends.includes("channel")}
             containerClassName="h-[70vh] w-full"
           />
         ) : null}

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -233,8 +233,13 @@ export function ChartPage(): JSX.Element {
   const compareFetchKeyRef = useRef<string>("");
 
   useEffect(() => {
+    // Dedup repeat fires with the same (range + symbols) tuple. The
+    // effect's deps already gate on compareSymbols/range changing, but
+    // a strict-mode double-invocation or a parent re-render that
+    // produces a new array reference with the same contents would
+    // otherwise re-fetch unnecessarily.
     const key = [range, ...compareSymbols].join(",");
-    if (key === compareFetchKeyRef.current && compareSymbols.length === 0) return;
+    if (key === compareFetchKeyRef.current) return;
     compareFetchKeyRef.current = key;
 
     if (compareSymbols.length === 0) {

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.test.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.test.tsx
@@ -1,13 +1,19 @@
 /**
- * Unit tests for ChartWorkspaceCanvas pure math helpers (#576 Phase 2).
+ * Unit tests for ChartWorkspaceCanvas pure math helpers (#576 Phase 2 + Phase 3).
  *
- * We test only the exported `computeSMA` and `computeEMA` functions —
+ * We test only the exported pure functions —
  * lightweight-charts cannot render in jsdom (Canvas API absent) so the
  * React component itself is not exercised here. The component's integration
  * is covered by ChartPage.test.tsx via a stub.
  */
 import { describe, expect, it } from "vitest";
-import { computeSMA, computeEMA } from "./ChartWorkspaceCanvas";
+import {
+  computeEMA,
+  computeSMA,
+  linearRegressionLine,
+  normalizeToPercent,
+  rangeChannel,
+} from "./ChartWorkspaceCanvas";
 
 describe("computeSMA", () => {
   it("returns correct rolling average for period 3", () => {
@@ -90,5 +96,126 @@ describe("computeEMA", () => {
     const lastSma = sma[sma.length - 1]!;
     const lastEma = ema[ema.length - 1]!;
     expect(lastEma).toBeGreaterThan(lastSma);
+  });
+});
+
+describe("normalizeToPercent", () => {
+  it("returns empty array for empty input", () => {
+    expect(normalizeToPercent([])).toEqual([]);
+  });
+
+  it("first element is always 0% (base = itself)", () => {
+    const result = normalizeToPercent([100, 110, 90]);
+    expect(result[0]).toBe(0);
+  });
+
+  it("flat series → all zeros", () => {
+    const result = normalizeToPercent([50, 50, 50, 50]);
+    for (const v of result) {
+      expect(v).toBeCloseTo(0);
+    }
+  });
+
+  it("computes correct percent change from base", () => {
+    // base=100; 110 → +10%; 90 → -10%; 150 → +50%
+    const result = normalizeToPercent([100, 110, 90, 150]);
+    expect(result[0]).toBeCloseTo(0);
+    expect(result[1]).toBeCloseTo(10);
+    expect(result[2]).toBeCloseTo(-10);
+    expect(result[3]).toBeCloseTo(50);
+  });
+
+  it("returns null array when base is zero", () => {
+    const result = normalizeToPercent([0, 10, 20]);
+    expect(result.every((v) => v === null)).toBe(true);
+  });
+
+  it("returns null array when base is non-finite", () => {
+    const result = normalizeToPercent([NaN, 10, 20]);
+    expect(result.every((v) => v === null)).toBe(true);
+  });
+
+  it("single element returns [0]", () => {
+    const result = normalizeToPercent([42]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeCloseTo(0);
+  });
+});
+
+describe("linearRegressionLine", () => {
+  it("returns all null for empty array", () => {
+    const result = linearRegressionLine([]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns [null] for single-element array", () => {
+    const result = linearRegressionLine([5]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeNull();
+  });
+
+  it("exact line [1,2,3,4,5] → slope=1, intercept=1", () => {
+    // x=[0,1,2,3,4], y=[1,2,3,4,5] → y = x + 1
+    const result = linearRegressionLine([1, 2, 3, 4, 5]);
+    expect(result[0]).toBeCloseTo(1);
+    expect(result[1]).toBeCloseTo(2);
+    expect(result[2]).toBeCloseTo(3);
+    expect(result[3]).toBeCloseTo(4);
+    expect(result[4]).toBeCloseTo(5);
+  });
+
+  it("flat series → returns constant line equal to the value", () => {
+    const result = linearRegressionLine([7, 7, 7, 7]);
+    for (const v of result) {
+      expect(v).toBeCloseTo(7);
+    }
+  });
+
+  it("two-point line returns exact endpoints", () => {
+    // x=[0,1], y=[2,4] → slope=2, intercept=2 → [2, 4]
+    const result = linearRegressionLine([2, 4]);
+    expect(result[0]).toBeCloseTo(2);
+    expect(result[1]).toBeCloseTo(4);
+  });
+
+  it("descending series → negative slope", () => {
+    const result = linearRegressionLine([10, 8, 6, 4, 2]);
+    // slope should be -2
+    expect(result[0]).toBeCloseTo(10);
+    expect(result[4]).toBeCloseTo(2);
+  });
+
+  it("output length matches input length", () => {
+    const closes = [1, 3, 2, 5, 4, 7];
+    const result = linearRegressionLine(closes);
+    expect(result).toHaveLength(closes.length);
+  });
+});
+
+describe("rangeChannel", () => {
+  it("returns {high: null, low: null} for empty array", () => {
+    expect(rangeChannel([])).toEqual({ high: null, low: null });
+  });
+
+  it("single element: high === low === that element", () => {
+    expect(rangeChannel([42])).toEqual({ high: 42, low: 42 });
+  });
+
+  it("returns correct high and low", () => {
+    const result = rangeChannel([5, 3, 8, 1, 7]);
+    expect(result.high).toBe(8);
+    expect(result.low).toBe(1);
+  });
+
+  it("all same values → high === low", () => {
+    const result = rangeChannel([4, 4, 4, 4]);
+    expect(result.high).toBe(4);
+    expect(result.low).toBe(4);
+  });
+
+  it("handles negative values", () => {
+    const result = rangeChannel([-5, -2, -10, -1]);
+    expect(result.high).toBe(-1);
+    expect(result.low).toBe(-10);
   });
 });

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.test.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.test.tsx
@@ -192,6 +192,40 @@ describe("linearRegressionLine", () => {
   });
 });
 
+describe("normalized regression — compare mode invariants", () => {
+  it("steadily-increasing series: normalized regression slope is positive and starts near 0", () => {
+    // Simulate a primary series rising from 100 to 110 over 5 bars.
+    const closes = [100, 102.5, 105, 107.5, 110];
+    const normalized = normalizeToPercent(closes).filter((v): v is number => v !== null);
+    // First normalized value is always 0 (base = itself).
+    expect(normalized[0]).toBeCloseTo(0);
+    const regression = linearRegressionLine(normalized);
+    // Slope must be positive for a rising series.
+    const first = regression[0] as number;
+    const last = regression[regression.length - 1] as number;
+    expect(last).toBeGreaterThan(first);
+    // Regression at index 0 should be near 0 (intercept close to start of series).
+    expect(first).toBeCloseTo(0, 0);
+  });
+
+  it("steadily-decreasing series: normalized regression slope is negative", () => {
+    const closes = [100, 97.5, 95, 92.5, 90];
+    const normalized = normalizeToPercent(closes).filter((v): v is number => v !== null);
+    const regression = linearRegressionLine(normalized);
+    const first = regression[0] as number;
+    const last = regression[regression.length - 1] as number;
+    expect(last).toBeLessThan(first);
+  });
+
+  it("degenerate base (0): filter produces empty array, regression returns []", () => {
+    const closes = [0, 10, 20];
+    const normalized = normalizeToPercent(closes).filter((v): v is number => v !== null);
+    expect(normalized).toHaveLength(0);
+    const regression = linearRegressionLine(normalized);
+    expect(regression).toHaveLength(0);
+  });
+});
+
 describe("rangeChannel", () => {
   it("returns {high: null, low: null} for empty array", () => {
     expect(rangeChannel([])).toEqual({ high: null, low: null });

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -1,9 +1,10 @@
 /**
- * ChartWorkspaceCanvas — full-viewport chart canvas for ChartPage (#576 Phase 2).
+ * ChartWorkspaceCanvas — full-viewport chart canvas for ChartPage (#576 Phase 3).
  *
- * Extends the lightweight-charts setup with:
- *   - SMA/EMA overlay LineSeries (toggleable via `indicators` prop)
- *   - Rich OHLC + volume + Δ% + per-indicator crosshair tooltip
+ * Phase 2: SMA/EMA overlay LineSeries (toggleable via `indicators` prop),
+ *          rich OHLC + volume + Δ% + per-indicator crosshair tooltip.
+ * Phase 3: compare-ticker overlays (normalized % change), linear regression
+ *          line, range channel (highest-high / lowest-low), tooltip swap.
  *
  * Deliberately separate from ChartCanvas (compact instrument-page chart) so
  * the compact component stays focused and this one can evolve independently.
@@ -37,8 +38,20 @@ const SMA_LABELS: Record<string, string> = {
   ema50: "EMA(50)",
 };
 
+// Fixed palette for compare overlays — distinct from SMA colors.
+export const COMPARE_COLORS: readonly string[] = [
+  "#0ea5e9", // sky-500
+  "#a855f7", // purple-500
+  "#f59e0b", // amber-500
+];
+
 export type IndicatorId = "sma20" | "sma50" | "ema20" | "ema50";
 export const INDICATOR_IDS: IndicatorId[] = ["sma20", "sma50", "ema20", "ema50"];
+
+export interface CompareSeries {
+  readonly symbol: string;
+  readonly rows: CandleBar[];
+}
 
 interface NumericBar {
   time: UTCTimestamp;
@@ -51,13 +64,19 @@ interface NumericBar {
 
 interface RichHoverState {
   date: string;
-  open: number;
-  high: number;
-  low: number;
-  close: number;
-  volume: number;
-  changePct: number | null;
-  indicators: Array<{ id: IndicatorId; label: string; value: number }>;
+  mode: "ohlcv" | "compare";
+  // OHLCV mode
+  open?: number;
+  high?: number;
+  low?: number;
+  close?: number;
+  volume?: number;
+  changePct?: number | null;
+  indicators?: Array<{ id: IndicatorId; label: string; value: number }>;
+  // Compare mode
+  primaryPct?: number | null;
+  primarySymbol?: string;
+  comparePcts?: Array<{ symbol: string; color: string; value: number | null }>;
 }
 
 function parseNum(v: string | null | undefined): number | null {
@@ -107,6 +126,50 @@ export function computeEMA(closes: number[], period: number): Array<number | nul
   return out;
 }
 
+// Pure: normalize closes to % change from the first value.
+// The first non-null close is the base. NaN/null → returned as null.
+export function normalizeToPercent(closes: number[]): Array<number | null> {
+  if (closes.length === 0) return [];
+  const base = closes[0] as number;
+  if (!Number.isFinite(base) || base === 0) return closes.map(() => null);
+  return closes.map((c) => ((c - base) / base) * 100);
+}
+
+// Pure: linear regression over [(0, y0), (1, y1), ..., (n, yN)].
+// Returns the line evaluated at each x (plottable as a series).
+export function linearRegressionLine(closes: number[]): Array<number | null> {
+  const n = closes.length;
+  if (n < 2) return new Array(n).fill(null);
+  let sumX = 0,
+    sumY = 0,
+    sumXY = 0,
+    sumXX = 0;
+  for (let i = 0; i < n; i++) {
+    const y = closes[i] as number;
+    sumX += i;
+    sumY += y;
+    sumXY += i * y;
+    sumXX += i * i;
+  }
+  const denom = n * sumXX - sumX * sumX;
+  if (denom === 0) return new Array(n).fill(null);
+  const slope = (n * sumXY - sumX * sumY) / denom;
+  const intercept = (sumY - slope * sumX) / n;
+  return closes.map((_, i) => slope * i + intercept);
+}
+
+// Pure: returns {high, low} over the array.  Both null if length 0.
+export function rangeChannel(closes: number[]): { high: number | null; low: number | null } {
+  if (closes.length === 0) return { high: null, low: null };
+  let high = closes[0] as number;
+  let low = closes[0] as number;
+  for (const v of closes) {
+    if (v > high) high = v;
+    if (v < low) low = v;
+  }
+  return { high, low };
+}
+
 function computeIndicator(id: IndicatorId, closes: number[]): Array<number | null> {
   switch (id) {
     case "sma20":
@@ -124,6 +187,9 @@ export interface ChartWorkspaceCanvasProps {
   readonly rows: CandleBar[];
   readonly symbol: string;
   readonly indicators: ReadonlyArray<IndicatorId>;
+  readonly compares?: ReadonlyArray<CompareSeries>;
+  readonly showRegression?: boolean;
+  readonly showChannel?: boolean;
   readonly containerClassName?: string;
 }
 
@@ -131,17 +197,30 @@ export function ChartWorkspaceCanvas({
   rows,
   symbol,
   indicators,
+  compares = [],
+  showRegression = false,
+  showChannel = false,
   containerClassName,
 }: ChartWorkspaceCanvasProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const candleRef = useRef<ISeriesApi<"Candlestick"> | null>(null);
   const volumeRef = useRef<ISeriesApi<"Histogram"> | null>(null);
+  // Primary normalized line (used in compare mode instead of candles).
+  const primaryLineRef = useRef<ISeriesApi<"Line"> | null>(null);
   const indicatorRefs = useRef<Map<IndicatorId, ISeriesApi<"Line">>>(new Map());
+  const compareLineRefs = useRef<Map<string, ISeriesApi<"Line">>>(new Map());
+  const regressionRef = useRef<ISeriesApi<"Line"> | null>(null);
+  const channelHighRef = useRef<ISeriesApi<"Line"> | null>(null);
+  const channelLowRef = useRef<ISeriesApi<"Line"> | null>(null);
   // Stable refs for crosshair closure — no stale-closure risk.
   const cleanRowsRef = useRef<NumericBar[]>([]);
   const indicatorValuesRef = useRef<Map<IndicatorId, Array<number | null>>>(new Map());
+  // Compare mode normalized values keyed by symbol; primary is keyed by symbol prop.
+  const compareNormRef = useRef<Map<string, Array<number | null>>>(new Map());
   const [hover, setHover] = useState<RichHoverState | null>(null);
+
+  const compareMode = compares.length > 0;
 
   // One-shot chart construction — mirrors ChartCanvas setup.
   useEffect(() => {
@@ -188,6 +267,13 @@ export function ChartWorkspaceCanvas({
     });
     chart.priceScale("volume").applyOptions({ scaleMargins: { top: 0.75, bottom: 0 } });
 
+    const primaryLine = chart.addSeries(LineSeries, {
+      color: "#1e293b",
+      lineWidth: 2,
+      priceLineVisible: false,
+      lastValueVisible: false,
+    });
+
     chart.subscribeCrosshairMove((param) => {
       if (!param.time || typeof param.time !== "number") {
         setHover(null);
@@ -200,6 +286,30 @@ export function ChartWorkspaceCanvas({
         return;
       }
       const bar = cleanRowsRef.current[idx]!;
+
+      if (compareNormRef.current.size > 0) {
+        // Compare mode: show normalized % values.
+        const primaryNorm = compareNormRef.current.get("__primary__");
+        const primaryPct = primaryNorm ? (primaryNorm[idx] ?? null) : null;
+        const comparePcts = Array.from(compareNormRef.current.entries())
+          .filter(([k]) => k !== "__primary__")
+          .map(([sym, norm], colorIdx) => ({
+            symbol: sym,
+            color: COMPARE_COLORS[colorIdx % COMPARE_COLORS.length] ?? "#0ea5e9",
+            value: norm[idx] ?? null,
+          }));
+        const date = new Date(time * 1000).toISOString().slice(0, 10);
+        setHover({
+          date,
+          mode: "compare",
+          primaryPct,
+          primarySymbol: symbol,
+          comparePcts,
+        });
+        return;
+      }
+
+      // OHLCV mode.
       const prev = idx > 0 ? cleanRowsRef.current[idx - 1] : null;
       const changePct =
         prev !== null && prev !== undefined && prev.close !== 0
@@ -218,6 +328,7 @@ export function ChartWorkspaceCanvas({
       const date = new Date(time * 1000).toISOString().slice(0, 10);
       setHover({
         date,
+        mode: "ohlcv",
         open: bar.open,
         high: bar.high,
         low: bar.low,
@@ -231,22 +342,29 @@ export function ChartWorkspaceCanvas({
     chartRef.current = chart;
     candleRef.current = candle;
     volumeRef.current = volume;
+    primaryLineRef.current = primaryLine;
 
     return () => {
       chart.remove();
       chartRef.current = null;
       candleRef.current = null;
       volumeRef.current = null;
+      primaryLineRef.current = null;
+      regressionRef.current = null;
+      channelHighRef.current = null;
+      channelLowRef.current = null;
       indicatorRefs.current.clear();
+      compareLineRefs.current.clear();
     };
-  }, []);
+  }, [symbol]);
 
-  // Feed candle + volume data on rows change.
+  // Feed candle + volume data on rows change; handle compare mode switching.
   useEffect(() => {
     const candle = candleRef.current;
     const volume = volumeRef.current;
+    const primaryLine = primaryLineRef.current;
     const chart = chartRef.current;
-    if (!candle || !volume || !chart) return;
+    if (!candle || !volume || !chart || !primaryLine) return;
 
     const clean: NumericBar[] = rows.flatMap((r) => {
       const time = dateToTime(r.date);
@@ -261,29 +379,122 @@ export function ChartWorkspaceCanvas({
     });
     cleanRowsRef.current = clean;
 
-    candle.setData(
-      clean.map((b) => ({
-        time: b.time as Time,
-        open: b.open,
-        high: b.high,
-        low: b.low,
-        close: b.close,
-      })),
-    );
+    if (compareMode) {
+      // In compare mode: hide candles + volume, show normalized primary line.
+      candle.setData([]);
+      volume.setData([]);
+      const closes = clean.map((b) => b.close);
+      const normalized = normalizeToPercent(closes);
+      compareNormRef.current.set("__primary__", normalized);
+      const lineData: LineData[] = [];
+      for (let i = 0; i < normalized.length; i++) {
+        const v = normalized[i];
+        const bar = clean[i];
+        if (v === null || v === undefined || !bar) continue;
+        lineData.push({ time: bar.time as Time, value: v });
+      }
+      primaryLine.applyOptions({ visible: true, color: "#1e293b", lineWidth: 2 });
+      primaryLine.setData(lineData);
+    } else {
+      // Normal mode: show candles + volume; hide primary normalized line.
+      compareNormRef.current.clear();
+      primaryLine.setData([]);
 
-    volume.setData(
-      clean.map((b, i) => {
-        const prev = i > 0 ? clean[i - 1]!.close : b.close;
-        return {
+      candle.setData(
+        clean.map((b) => ({
           time: b.time as Time,
-          value: b.volume,
-          color: b.close >= prev ? "rgba(16,185,129,0.4)" : "rgba(239,68,68,0.4)",
-        };
-      }),
-    );
+          open: b.open,
+          high: b.high,
+          low: b.low,
+          close: b.close,
+        })),
+      );
+
+      volume.setData(
+        clean.map((b, i) => {
+          const prev = i > 0 ? clean[i - 1]!.close : b.close;
+          return {
+            time: b.time as Time,
+            value: b.volume,
+            color: b.close >= prev ? "rgba(16,185,129,0.4)" : "rgba(239,68,68,0.4)",
+          };
+        }),
+      );
+    }
 
     chart.timeScale().fitContent();
-  }, [rows]);
+  }, [rows, compareMode]);
+
+  // Compare series: fetch + render normalized lines per compare symbol.
+  // Tears down series for symbols no longer in the list.
+  useEffect(() => {
+    const chart = chartRef.current;
+    const clean = cleanRowsRef.current;
+    if (!chart) return;
+
+    // Remove series for symbols no longer in compares.
+    for (const [sym, series] of compareLineRefs.current.entries()) {
+      if (!compares.some((c) => c.symbol === sym)) {
+        chart.removeSeries(series);
+        compareLineRefs.current.delete(sym);
+        compareNormRef.current.delete(sym);
+      }
+    }
+
+    if (!compareMode) return;
+
+    // Add/update series for each compare symbol.
+    compares.forEach((cs, colorIdx) => {
+      const color = COMPARE_COLORS[colorIdx % COMPARE_COLORS.length] ?? "#0ea5e9";
+
+      const compareClean: NumericBar[] = cs.rows.flatMap((r) => {
+        const time = dateToTime(r.date);
+        const close = parseNum(r.close);
+        if (time === null || close === null) return [];
+        return [{ time, open: close, high: close, low: close, close, volume: 0 }];
+      });
+
+      // Build a time→close map so we can align with the primary series times.
+      const compareMap = new Map<number, number>();
+      for (const b of compareClean) {
+        compareMap.set(b.time, b.close);
+      }
+
+      // Align compare closes to primary timestamps (use null when missing).
+      const alignedCloses: (number | null)[] = clean.map((b) => compareMap.get(b.time) ?? null);
+      // Compute base as first non-null value.
+      const firstNonNull = alignedCloses.find((v) => v !== null);
+      const base = firstNonNull ?? null;
+
+      const normalized: Array<number | null> = alignedCloses.map((v) => {
+        if (v === null || base === null || !Number.isFinite(base) || base === 0) return null;
+        return ((v - base) / base) * 100;
+      });
+      compareNormRef.current.set(cs.symbol, normalized);
+
+      let series = compareLineRefs.current.get(cs.symbol);
+      if (!series) {
+        series = chart.addSeries(LineSeries, {
+          color,
+          lineWidth: 2,
+          priceLineVisible: false,
+          lastValueVisible: false,
+        });
+        compareLineRefs.current.set(cs.symbol, series);
+      } else {
+        series.applyOptions({ color });
+      }
+
+      const lineData: LineData[] = [];
+      for (let i = 0; i < normalized.length; i++) {
+        const v = normalized[i];
+        const bar = clean[i];
+        if (v === null || v === undefined || !bar) continue;
+        lineData.push({ time: bar.time as Time, value: v });
+      }
+      series.setData(lineData);
+    });
+  }, [compares, compareMode, rows]);
 
   // Add/remove indicator LineSeries based on `indicators` prop.
   // `rows` is in the dep array (alongside `indicators`) so this effect
@@ -330,9 +541,88 @@ export function ChartWorkspaceCanvas({
     }
   }, [indicators, rows]);
 
+  // Trend overlays: linear regression + range channel.
+  // Render over primary closes regardless of compare mode.
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+    const clean = cleanRowsRef.current;
+    const closes = clean.map((b) => b.close);
+
+    // --- Linear regression ---
+    if (showRegression) {
+      const regValues = linearRegressionLine(closes);
+      if (!regressionRef.current) {
+        regressionRef.current = chart.addSeries(LineSeries, {
+          color: "#f97316", // orange-500
+          lineWidth: 1,
+          lineStyle: 2, // dashed
+          priceLineVisible: false,
+          lastValueVisible: false,
+        });
+      }
+      const regData: LineData[] = [];
+      for (let i = 0; i < regValues.length; i++) {
+        const v = regValues[i];
+        const bar = clean[i];
+        if (v === null || v === undefined || !bar) continue;
+        regData.push({ time: bar.time as Time, value: v });
+      }
+      regressionRef.current.setData(regData);
+    } else {
+      if (regressionRef.current) {
+        chart.removeSeries(regressionRef.current);
+        regressionRef.current = null;
+      }
+    }
+
+    // --- Channel: horizontal-ish dotted lines for range high + low ---
+    const { high, low } = rangeChannel(closes);
+    if (showChannel && high !== null && low !== null && clean.length >= 2) {
+      if (!channelHighRef.current) {
+        channelHighRef.current = chart.addSeries(LineSeries, {
+          color: "#10b981", // emerald-500
+          lineWidth: 1,
+          lineStyle: 3, // dotted
+          priceLineVisible: false,
+          lastValueVisible: false,
+        });
+      }
+      if (!channelLowRef.current) {
+        channelLowRef.current = chart.addSeries(LineSeries, {
+          color: "#ef4444", // red-500
+          lineWidth: 1,
+          lineStyle: 3, // dotted
+          priceLineVisible: false,
+          lastValueVisible: false,
+        });
+      }
+      // Flat lines spanning the entire range.
+      const firstBar = clean[0]!;
+      const lastBar = clean[clean.length - 1]!;
+      channelHighRef.current.setData([
+        { time: firstBar.time as Time, value: high },
+        { time: lastBar.time as Time, value: high },
+      ]);
+      channelLowRef.current.setData([
+        { time: firstBar.time as Time, value: low },
+        { time: lastBar.time as Time, value: low },
+      ]);
+    } else {
+      if (channelHighRef.current) {
+        chart.removeSeries(channelHighRef.current);
+        channelHighRef.current = null;
+      }
+      if (channelLowRef.current) {
+        chart.removeSeries(channelLowRef.current);
+        channelLowRef.current = null;
+      }
+    }
+  }, [showRegression, showChannel, rows]);
+
   return (
     <div className="relative">
-      {hover !== null ? <RichTooltip hover={hover} symbol={symbol} /> : null}
+      {hover !== null ? <RichTooltip hover={hover} /> : null}
       <div
         ref={containerRef}
         data-testid={`chart-workspace-${symbol}`}
@@ -342,25 +632,61 @@ export function ChartWorkspaceCanvas({
   );
 }
 
-function RichTooltip({ hover, symbol }: { hover: RichHoverState; symbol: string }): JSX.Element {
-  const fmt = (n: number) =>
-    n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+function RichTooltip({ hover }: { hover: RichHoverState }): JSX.Element {
+  const fmt = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  const fmtPct = (v: number | null | undefined) => {
+    if (v === null || v === undefined) return "—";
+    return `${v >= 0 ? "+" : ""}${v.toFixed(2)}%`;
+  };
+
+  if (hover.mode === "compare") {
+    return (
+      <div className="absolute right-2 top-2 z-10 min-w-[180px] rounded bg-white/95 px-3 py-2 text-xs shadow-md">
+        <div className="text-slate-500">{hover.date}</div>
+        <dl className="mt-1 space-y-0.5 tabular-nums">
+          <div className="flex justify-between gap-3">
+            <span className="font-medium text-slate-800">{hover.primarySymbol}</span>
+            <span
+              className={
+                (hover.primaryPct ?? 0) >= 0 ? "text-emerald-600" : "text-red-600"
+              }
+            >
+              {fmtPct(hover.primaryPct)}
+            </span>
+          </div>
+          {hover.comparePcts?.map((cp) => (
+            <div key={cp.symbol} className="flex justify-between gap-3">
+              <span style={{ color: cp.color }} className="font-medium">
+                {cp.symbol}
+              </span>
+              <span
+                className={cp.value !== null && cp.value >= 0 ? "text-emerald-600" : "text-red-600"}
+              >
+                {fmtPct(cp.value)}
+              </span>
+            </div>
+          ))}
+        </dl>
+      </div>
+    );
+  }
+
+  // OHLCV mode
   return (
     <div className="absolute right-2 top-2 z-10 min-w-[180px] rounded bg-white/95 px-3 py-2 text-xs shadow-md">
-      <div className="font-semibold text-slate-800">{symbol}</div>
       <div className="text-slate-500">{hover.date}</div>
       <dl className="mt-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 tabular-nums">
         <dt className="text-slate-500">O</dt>
-        <dd>{fmt(hover.open)}</dd>
+        <dd>{fmt(hover.open ?? 0)}</dd>
         <dt className="text-slate-500">H</dt>
-        <dd>{fmt(hover.high)}</dd>
+        <dd>{fmt(hover.high ?? 0)}</dd>
         <dt className="text-slate-500">L</dt>
-        <dd>{fmt(hover.low)}</dd>
+        <dd>{fmt(hover.low ?? 0)}</dd>
         <dt className="text-slate-500">C</dt>
-        <dd className="font-medium text-slate-800">{fmt(hover.close)}</dd>
+        <dd className="font-medium text-slate-800">{fmt(hover.close ?? 0)}</dd>
         <dt className="text-slate-500">Vol</dt>
-        <dd>{fmt(hover.volume)}</dd>
-        {hover.changePct !== null ? (
+        <dd>{fmt(hover.volume ?? 0)}</dd>
+        {hover.changePct !== null && hover.changePct !== undefined ? (
           <>
             <dt className="text-slate-500">Δ%</dt>
             <dd className={hover.changePct >= 0 ? "text-emerald-600" : "text-red-600"}>
@@ -370,7 +696,7 @@ function RichTooltip({ hover, symbol }: { hover: RichHoverState; symbol: string 
           </>
         ) : null}
       </dl>
-      {hover.indicators.length > 0 ? (
+      {hover.indicators !== undefined && hover.indicators.length > 0 ? (
         <div className="mt-1 border-t border-slate-100 pt-1">
           {hover.indicators.map((row) => (
             <div key={row.id} className="flex justify-between text-[11px]">

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -218,6 +218,10 @@ export function ChartWorkspaceCanvas({
   const indicatorValuesRef = useRef<Map<IndicatorId, Array<number | null>>>(new Map());
   // Compare mode normalized values keyed by symbol; primary is keyed by symbol prop.
   const compareNormRef = useRef<Map<string, Array<number | null>>>(new Map());
+  // Symbol → color, derived from compares prop order. Single source of
+  // truth so the tooltip and the LineSeries always agree on color even
+  // after add/remove cycles change Map insertion order.
+  const compareColorRef = useRef<Map<string, string>>(new Map());
   const [hover, setHover] = useState<RichHoverState | null>(null);
 
   const compareMode = compares.length > 0;
@@ -293,9 +297,12 @@ export function ChartWorkspaceCanvas({
         const primaryPct = primaryNorm ? (primaryNorm[idx] ?? null) : null;
         const comparePcts = Array.from(compareNormRef.current.entries())
           .filter(([k]) => k !== "__primary__")
-          .map(([sym, norm], colorIdx) => ({
+          .map(([sym, norm]) => ({
             symbol: sym,
-            color: COMPARE_COLORS[colorIdx % COMPARE_COLORS.length] ?? "#0ea5e9",
+            // Read color from the symbol-keyed ref populated when the
+            // LineSeries was created — keeps tooltip in sync with the
+            // actual rendered series even if Map iteration order drifts.
+            color: compareColorRef.current.get(sym) ?? "#0ea5e9",
             value: norm[idx] ?? null,
           }));
         const date = new Date(time * 1000).toISOString().slice(0, 10);
@@ -438,6 +445,7 @@ export function ChartWorkspaceCanvas({
         chart.removeSeries(series);
         compareLineRefs.current.delete(sym);
         compareNormRef.current.delete(sym);
+        compareColorRef.current.delete(sym);
       }
     }
 
@@ -446,6 +454,7 @@ export function ChartWorkspaceCanvas({
     // Add/update series for each compare symbol.
     compares.forEach((cs, colorIdx) => {
       const color = COMPARE_COLORS[colorIdx % COMPARE_COLORS.length] ?? "#0ea5e9";
+      compareColorRef.current.set(cs.symbol, color);
 
       const compareClean: NumericBar[] = cs.rows.flatMap((r) => {
         const time = dateToTime(r.date);

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -542,12 +542,22 @@ export function ChartWorkspaceCanvas({
   }, [indicators, rows]);
 
   // Trend overlays: linear regression + range channel.
-  // Render over primary closes regardless of compare mode.
+  // In compare mode the visible axis is % change, so we compute trends on
+  // the normalized primary series to keep overlays on the same scale.
   useEffect(() => {
     const chart = chartRef.current;
     if (!chart) return;
     const clean = cleanRowsRef.current;
-    const closes = clean.map((b) => b.close);
+    const rawCloses = clean.map((b) => b.close);
+    // When compare mode is active, the primary series is displayed as % change.
+    // Compute trends on the same normalized values so they render at the right
+    // scale.  normalizeToPercent returns all-nulls only when base === 0 or
+    // non-finite; in that degenerate case filter produces [] and the trend
+    // helpers return empty arrays — overlays simply render no points, which is
+    // correct.
+    const closes = compares.length > 0
+      ? normalizeToPercent(rawCloses).filter((v): v is number => v !== null)
+      : rawCloses;
 
     // --- Linear regression ---
     if (showRegression) {
@@ -618,7 +628,7 @@ export function ChartWorkspaceCanvas({
         channelLowRef.current = null;
       }
     }
-  }, [showRegression, showChannel, rows]);
+  }, [showRegression, showChannel, rows, compares]);
 
   return (
     <div className="relative">


### PR DESCRIPTION
## What

Phase 3 of #576 — compare-tickers overlay + trend overlays on the chart workspace.

- **Compare mode**: up to 3 extra tickers added via input box, each rendered as a normalized %-change line. URL-synced via `?compare=AAPL,MSFT,SPY`. Chips with × to remove.
- **Linear regression line** over the current range (least-squares fit). Toggle button + URL `?trend=regression`.
- **Range channel envelope** (highest-high / lowest-low) over the current range. Toggle button + URL `?trend=channel`.
- **Tooltip swaps** between OHLCV mode (no compares) and per-symbol % mode (compare mode).
- New pure math helpers (exported, unit-tested): `normalizeToPercent`, `linearRegressionLine`, `rangeChannel`.

## Why

Closes Phase 3 of #576. Operator wanted "configurable filters to track trends" and compare workflows.

Codex pre-push caught two real issues, fixed in second commit:
1. **P1**: Trend overlays were computing on raw closes even in compare mode (where the y-axis is %). Trend lines rendered at price level on a percent scale. Fixed: when `compares.length > 0`, trend math runs on normalized values.
2. **P2**: `Promise.all` for compare fetches had no error handling — one bad ticker rejected the whole batch. Fixed: `Promise.allSettled` + `compareErrors` state surfaces failed tickers as red chips with `data-error="true"` and a tooltip.

## Test plan

- 22 new vitest tests across `ChartWorkspaceCanvas.test.tsx` + `ChartPage.test.tsx`
- Math invariants tested with known fixtures
- Failure-handling integration test (mocked rejection on one symbol)
- 541 frontend tests pass
- `pnpm --dir frontend typecheck` clean
- `uv run ruff check . && uv run ruff format --check .` clean

## Out of scope (Phase 4)

- Raw OHLCV table at `?view=raw`
- CSV export
- RSI / MACD oscillator panes (separate ticket — they need their own price scale)

## File touch list

- `frontend/src/pages/components/ChartWorkspaceCanvas.tsx` (compare/trend rendering, math helpers, tooltip swap)
- `frontend/src/pages/components/ChartWorkspaceCanvas.test.tsx` (math + invariant tests)
- `frontend/src/pages/ChartPage.tsx` (compare input, chips, trend toggles, URL sync, error chips)
- `frontend/src/pages/ChartPage.test.tsx` (compare/trend integration tests)

`PriceChart.tsx` (instrument-page compact chart) **untouched**.