### PR TITLE
feat(#576): chart workspace Phase 4 — raw OHLCV view + CSV export

### DIFF
--- a/frontend/src/pages/ChartPage.test.tsx
+++ b/frontend/src/pages/ChartPage.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for ChartPage (#576 Phase 1 + Phase 2 + Phase 3).
+ * Tests for ChartPage (#576 Phase 1 + Phase 2 + Phase 3 + Phase 4).
  *
  * lightweight-charts cannot render in jsdom (Canvas API absent), so we stub
  * ChartWorkspaceCanvas to a simple div. What we pin here is the page's contract:
@@ -23,11 +23,29 @@
  *   - Trend toggle Regression updates ?trend=regression
  *   - Pre-set ?trend=regression,channel activates both toggles
  *   - Compare + trend props forwarded to canvas stub
+ *
+ * Phase 4:
+ *   - View toggle defaults to chart (no ?view= param)
+ *   - Clicking "Raw data" sets ?view=raw and hides canvas
+ *   - Pre-set ?view=raw renders raw table stub instead of chart canvas
+ *   - Indicator / trend / compare controls hidden in raw view
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+// Stub RawOhlcvTable to avoid testing its internals in ChartPage tests.
+vi.mock("@/pages/components/RawOhlcvTable", () => ({
+  RawOhlcvTable: ({ rows, symbol, range }: { rows: unknown[]; symbol: string; range: string }) => (
+    <div
+      data-testid="raw-ohlcv-table-stub"
+      data-row-count={rows.length}
+      data-symbol={symbol}
+      data-range={range}
+    />
+  ),
+}));
 
 // Stub ChartWorkspaceCanvas so lightweight-charts is never touched in jsdom.
 vi.mock("@/pages/components/ChartWorkspaceCanvas", () => ({
@@ -458,5 +476,99 @@ describe("ChartPage — Phase 3 trend toggles", () => {
       expect(stub.getAttribute("data-show-regression")).toBe("true");
       expect(stub.getAttribute("data-show-channel")).toBe("false");
     });
+  });
+});
+
+describe("ChartPage — Phase 4 view toggle", () => {
+  it("defaults to chart view — chart canvas visible, raw table absent", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("raw-ohlcv-table-stub")).not.toBeInTheDocument();
+  });
+
+  it("clicking 'Raw data' button shows raw table and hides chart canvas", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("view-raw"));
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-ohlcv-table-stub")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("chart-canvas-stub")).not.toBeInTheDocument();
+  });
+
+  it("clicking 'Chart' button from raw view restores chart canvas", async () => {
+    const user = userEvent.setup();
+    renderPage("/instrument/AAPL/chart?view=raw");
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-ohlcv-table-stub")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("view-chart"));
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("raw-ohlcv-table-stub")).not.toBeInTheDocument();
+  });
+
+  it("pre-set ?view=raw renders raw table directly", async () => {
+    renderPage("/instrument/AAPL/chart?view=raw");
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-ohlcv-table-stub")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("chart-canvas-stub")).not.toBeInTheDocument();
+  });
+
+  it("indicator toggles hidden in raw view", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("view-raw"));
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-ohlcv-table-stub")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("indicator-sma20")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("indicator-ema50")).not.toBeInTheDocument();
+  });
+
+  it("trend toggles hidden in raw view", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("view-raw"));
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-ohlcv-table-stub")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("trend-regression")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("trend-channel")).not.toBeInTheDocument();
+  });
+
+  it("compare input hidden in raw view", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("view-raw"));
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-ohlcv-table-stub")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("compare-input")).not.toBeInTheDocument();
+  });
+
+  it("view toggle buttons are always visible (both views)", async () => {
+    renderPage("/instrument/AAPL/chart?view=raw");
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-ohlcv-table-stub")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("view-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("view-raw")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -8,7 +8,7 @@
  * Phase 3: compare-ticker overlays (URL: `?compare=AAPL,MSFT,SPY`),
  *          linear regression line + range channel toggles
  *          (URL: `?trend=regression,channel`).
- * Phase 4 (raw OHLCV table + CSV export) deferred to next PR.
+ * Phase 4: raw OHLCV table + CSV export (URL: `?view=raw`).
  */
 import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
@@ -21,6 +21,7 @@ import {
   type CompareSeries,
   type IndicatorId,
 } from "@/pages/components/ChartWorkspaceCanvas";
+import { RawOhlcvTable } from "@/pages/components/RawOhlcvTable";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
@@ -193,6 +194,22 @@ export function ChartPage(): JSX.Element {
     [searchParams, setSearchParams, enabledTrends],
   );
 
+  // View param — "chart" (default) or "raw"
+  const view = searchParams.get("view") === "raw" ? "raw" : "chart";
+
+  const setView = useCallback(
+    (next: "chart" | "raw") => {
+      const params = new URLSearchParams(searchParams);
+      if (next === "chart") {
+        params.delete("view");
+      } else {
+        params.set("view", next);
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
   // Compare input local state.
   const [compareInput, setCompareInput] = useState("");
   const compareInputRef = useRef<HTMLInputElement | null>(null);
@@ -323,7 +340,7 @@ export function ChartPage(): JSX.Element {
         )}
       </div>
 
-      {/* Controls: range picker + indicator toggles + trend toggles */}
+      {/* Controls: range picker + view toggle + chart-only controls */}
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex gap-1">
           {RANGES.map((r) => (
@@ -343,106 +360,138 @@ export function ChartPage(): JSX.Element {
           ))}
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-[11px] uppercase tracking-wider text-slate-500">Indicators</span>
-          {INDICATOR_IDS.map((id) => {
-            const active = enabledIndicators.includes(id);
-            return (
-              <button
-                key={id}
-                type="button"
-                onClick={() => toggleIndicator(id)}
-                className={`rounded border px-2 py-0.5 text-xs font-medium ${
-                  active
-                    ? "bg-white text-slate-700"
-                    : "bg-slate-50 text-slate-500 hover:bg-slate-100"
-                }`}
-                style={
-                  active
-                    ? { borderColor: INDICATOR_COLORS[id], color: INDICATOR_COLORS[id] }
-                    : { borderColor: "#e2e8f0" }
-                }
-                data-testid={`indicator-${id}`}
-              >
-                {INDICATOR_LABELS[id]}
-              </button>
-            );
-          })}
+        {/* View toggle */}
+        <div className="flex gap-1">
+          <button
+            type="button"
+            onClick={() => setView("chart")}
+            className={`rounded px-3 py-1 text-sm font-medium ${
+              view === "chart" ? "bg-slate-800 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+            }`}
+            data-testid="view-chart"
+          >
+            Chart
+          </button>
+          <button
+            type="button"
+            onClick={() => setView("raw")}
+            className={`rounded px-3 py-1 text-sm font-medium ${
+              view === "raw" ? "bg-slate-800 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+            }`}
+            data-testid="view-raw"
+          >
+            Raw data
+          </button>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-[11px] uppercase tracking-wider text-slate-500">Trend</span>
-          {(["regression", "channel"] as const).map((id) => {
-            const active = enabledTrends.includes(id);
-            const label = id === "regression" ? "Regression" : "Range";
-            return (
-              <button
-                key={id}
-                type="button"
-                onClick={() => toggleTrend(id)}
-                className={`rounded border px-2 py-0.5 text-xs font-medium ${
-                  active
-                    ? "border-orange-400 bg-white text-orange-600"
-                    : "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100"
-                }`}
-                data-testid={`trend-${id}`}
-              >
-                {label}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* Compare row */}
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="text-[11px] uppercase tracking-wider text-slate-500">Compare</span>
-        {compareSymbols.map((sym) => {
-          const hasFailed = compareErrors.includes(sym);
-          return (
-            <span
-              key={sym}
-              className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${
-                hasFailed
-                  ? "border-red-400 bg-red-50 text-red-700"
-                  : "border-slate-300 bg-slate-50 text-slate-700"
-              }`}
-              title={hasFailed ? "Failed to fetch — check ticker" : undefined}
-              aria-label={hasFailed ? `${sym} — failed to fetch` : sym}
-              data-testid={`compare-chip-${sym}`}
-              data-error={hasFailed ? "true" : undefined}
-            >
-              {sym}
-              <button
-                type="button"
-                aria-label={`Remove ${sym}`}
-                onClick={() => removeCompare(sym)}
-                className={`ml-0.5 rounded-full ${hasFailed ? "text-red-400 hover:text-red-600" : "text-slate-400 hover:text-slate-600"}`}
-                data-testid={`compare-remove-${sym}`}
-              >
-                ×
-              </button>
-            </span>
-          );
-        })}
-        {compareSymbols.length < MAX_COMPARES && (
-          <input
-            ref={compareInputRef}
-            type="text"
-            value={compareInput}
-            onChange={(e) => setCompareInput(e.target.value)}
-            onKeyDown={handleCompareKeyDown}
-            placeholder="Add ticker to compare..."
-            className="rounded border border-slate-200 bg-white px-2 py-0.5 text-xs text-slate-700 placeholder-slate-400 focus:border-slate-400 focus:outline-none"
-            data-testid="compare-input"
-          />
+        {/* Chart-only: indicator toggles */}
+        {view === "chart" && (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[11px] uppercase tracking-wider text-slate-500">Indicators</span>
+            {INDICATOR_IDS.map((id) => {
+              const active = enabledIndicators.includes(id);
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => toggleIndicator(id)}
+                  className={`rounded border px-2 py-0.5 text-xs font-medium ${
+                    active
+                      ? "bg-white text-slate-700"
+                      : "bg-slate-50 text-slate-500 hover:bg-slate-100"
+                  }`}
+                  style={
+                    active
+                      ? { borderColor: INDICATOR_COLORS[id], color: INDICATOR_COLORS[id] }
+                      : { borderColor: "#e2e8f0" }
+                  }
+                  data-testid={`indicator-${id}`}
+                >
+                  {INDICATOR_LABELS[id]}
+                </button>
+              );
+            })}
+          </div>
         )}
-        {compareSymbols.length >= MAX_COMPARES && (
-          <span className="text-[11px] text-slate-400">Max {MAX_COMPARES} symbols</span>
+
+        {/* Chart-only: trend toggles */}
+        {view === "chart" && (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[11px] uppercase tracking-wider text-slate-500">Trend</span>
+            {(["regression", "channel"] as const).map((id) => {
+              const active = enabledTrends.includes(id);
+              const label = id === "regression" ? "Regression" : "Range";
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => toggleTrend(id)}
+                  className={`rounded border px-2 py-0.5 text-xs font-medium ${
+                    active
+                      ? "border-orange-400 bg-white text-orange-600"
+                      : "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100"
+                  }`}
+                  data-testid={`trend-${id}`}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
         )}
       </div>
 
-      {/* Chart body */}
+      {/* Chart-only: compare row */}
+      {view === "chart" && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-[11px] uppercase tracking-wider text-slate-500">Compare</span>
+          {compareSymbols.map((sym) => {
+            const hasFailed = compareErrors.includes(sym);
+            return (
+              <span
+                key={sym}
+                className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${
+                  hasFailed
+                    ? "border-red-400 bg-red-50 text-red-700"
+                    : "border-slate-300 bg-slate-50 text-slate-700"
+                }`}
+                title={hasFailed ? "Failed to fetch — check ticker" : undefined}
+                aria-label={hasFailed ? `${sym} — failed to fetch` : sym}
+                data-testid={`compare-chip-${sym}`}
+                data-error={hasFailed ? "true" : undefined}
+              >
+                {sym}
+                <button
+                  type="button"
+                  aria-label={`Remove ${sym}`}
+                  onClick={() => removeCompare(sym)}
+                  className={`ml-0.5 rounded-full ${hasFailed ? "text-red-400 hover:text-red-600" : "text-slate-400 hover:text-slate-600"}`}
+                  data-testid={`compare-remove-${sym}`}
+                >
+                  ×
+                </button>
+              </span>
+            );
+          })}
+          {compareSymbols.length < MAX_COMPARES && (
+            <input
+              ref={compareInputRef}
+              type="text"
+              value={compareInput}
+              onChange={(e) => setCompareInput(e.target.value)}
+              onKeyDown={handleCompareKeyDown}
+              placeholder="Add ticker to compare..."
+              className="rounded border border-slate-200 bg-white px-2 py-0.5 text-xs text-slate-700 placeholder-slate-400 focus:border-slate-400 focus:outline-none"
+              data-testid="compare-input"
+            />
+          )}
+          {compareSymbols.length >= MAX_COMPARES && (
+            <span className="text-[11px] text-slate-400">Max {MAX_COMPARES} symbols</span>
+          )}
+        </div>
+      )}
+
+      {/* Body: chart or raw table */}
       <div className="rounded-md border border-slate-200 bg-white shadow-sm">
         {effectivelyLoading && candlesAsync.error === null ? (
           <div className="p-4">
@@ -454,7 +503,7 @@ export function ChartPage(): JSX.Element {
             <SectionError onRetry={candlesAsync.refetch} />
           </div>
         ) : null}
-        {!effectivelyLoading && candlesAsync.error === null && dataMatchesRange && !hasChartData ? (
+        {!effectivelyLoading && candlesAsync.error === null && dataMatchesRange && view === "chart" && !hasChartData ? (
           <div className="p-4">
             <EmptyState
               title="No price data"
@@ -462,7 +511,7 @@ export function ChartPage(): JSX.Element {
             />
           </div>
         ) : null}
-        {hasChartData && rows !== null ? (
+        {view === "chart" && hasChartData && rows !== null ? (
           <ChartWorkspaceCanvas
             rows={rows}
             symbol={symbol}
@@ -472,6 +521,9 @@ export function ChartPage(): JSX.Element {
             showChannel={enabledTrends.includes("channel")}
             containerClassName="h-[70vh] w-full"
           />
+        ) : null}
+        {view === "raw" && !effectivelyLoading && candlesAsync.error === null && dataMatchesRange ? (
+          <RawOhlcvTable rows={rows ?? []} symbol={symbol} range={range} />
         ) : null}
       </div>
     </div>

--- a/frontend/src/pages/components/RawOhlcvTable.test.tsx
+++ b/frontend/src/pages/components/RawOhlcvTable.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { RawOhlcvTable } from "./RawOhlcvTable";
+
+const rows = [
+  { date: "2026-04-01", open: "100", high: "110", low: "95", close: "105", volume: "10000" },
+  { date: "2026-04-02", open: "105", high: "115", low: "100", close: "110", volume: "12000" },
+  { date: "2026-04-03", open: "110", high: "120", low: "105", close: "115", volume: "14000" },
+] as never;
+
+describe("RawOhlcvTable", () => {
+  it("renders all rows in newest-first order by default", () => {
+    render(<RawOhlcvTable rows={rows} symbol="GME" range="1m" />);
+    const dateCells = screen.getAllByText(/^2026-04-/);
+    expect(dateCells[0]?.textContent).toBe("2026-04-03");
+    expect(dateCells[2]?.textContent).toBe("2026-04-01");
+  });
+
+  it("toggles sort to ascending on header click", async () => {
+    render(<RawOhlcvTable rows={rows} symbol="GME" range="1m" />);
+    await userEvent.click(screen.getByTestId("sort-date"));
+    const dateCells = screen.getAllByText(/^2026-04-/);
+    expect(dateCells[0]?.textContent).toBe("2026-04-01");
+  });
+
+  it("renders empty state when rows is empty", () => {
+    render(<RawOhlcvTable rows={[]} symbol="GME" range="1m" />);
+    expect(screen.getByText(/No raw data/)).toBeInTheDocument();
+  });
+
+  it("CSV download button triggers blob URL creation", async () => {
+    const createObjectURL = vi.fn(() => "blob:mock");
+    const revokeObjectURL = vi.fn();
+    global.URL.createObjectURL = createObjectURL as never;
+    global.URL.revokeObjectURL = revokeObjectURL;
+    render(<RawOhlcvTable rows={rows} symbol="GME" range="1m" />);
+    await userEvent.click(screen.getByTestId("csv-download"));
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows row count and range badge", () => {
+    render(<RawOhlcvTable rows={rows} symbol="GME" range="1m" />);
+    expect(screen.getByText(/3 rows/)).toBeInTheDocument();
+    expect(screen.getByText(/1m/)).toBeInTheDocument();
+  });
+
+  it("renders null OHLCV values as em-dash", () => {
+    const nullRow = [
+      { date: "2026-04-01", open: null, high: null, low: null, close: null, volume: null },
+    ] as never;
+    render(<RawOhlcvTable rows={nullRow} symbol="GME" range="1m" />);
+    // 5 em-dashes (open/high/low/close/volume — date is never null)
+    expect(screen.getAllByText("—")).toHaveLength(5);
+  });
+});

--- a/frontend/src/pages/components/RawOhlcvTable.tsx
+++ b/frontend/src/pages/components/RawOhlcvTable.tsx
@@ -1,0 +1,111 @@
+import { useState, type JSX } from "react";
+
+import type { CandleBar, CandleRange } from "@/api/types";
+import { EmptyState } from "@/components/states/EmptyState";
+
+export interface RawOhlcvTableProps {
+  readonly rows: ReadonlyArray<CandleBar>;
+  readonly symbol: string;
+  readonly range: CandleRange;
+}
+
+type SortDir = "asc" | "desc";
+
+function formatNum(v: string | null | undefined): string {
+  if (v === null || v === undefined) return "—";
+  const n = Number(v);
+  if (!Number.isFinite(n)) return "—";
+  return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
+function downloadCsv(rows: ReadonlyArray<CandleBar>, symbol: string, range: CandleRange): void {
+  const header = "date,open,high,low,close,volume\n";
+  const body = rows
+    .map(
+      (r) =>
+        `${r.date},${r.open ?? ""},${r.high ?? ""},${r.low ?? ""},${r.close ?? ""},${r.volume ?? ""}`,
+    )
+    .join("\n");
+  const csv = header + body;
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${symbol}-${range}-ohlcv.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function RawOhlcvTable({ rows, symbol, range }: RawOhlcvTableProps): JSX.Element {
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  if (rows.length === 0) {
+    return (
+      <div className="p-4">
+        <EmptyState
+          title="No raw data"
+          description="No candle rows in the local price_daily store for this range."
+        />
+      </div>
+    );
+  }
+
+  const sorted = [...rows].sort((a, b) =>
+    sortDir === "desc" ? b.date.localeCompare(a.date) : a.date.localeCompare(b.date),
+  );
+
+  return (
+    <div className="p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-xs text-slate-500">
+          {rows.length} rows · {range}
+        </span>
+        <button
+          type="button"
+          onClick={() => downloadCsv(sorted, symbol, range)}
+          className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700"
+          data-testid="csv-download"
+        >
+          Download CSV
+        </button>
+      </div>
+      <div className="overflow-auto">
+        <table className="min-w-full text-sm">
+          <thead className="border-b border-slate-200">
+            <tr className="text-left text-xs text-slate-500">
+              <th className="px-2 py-1">
+                <button
+                  type="button"
+                  onClick={() => setSortDir((d) => (d === "asc" ? "desc" : "asc"))}
+                  className="hover:underline"
+                  data-testid="sort-date"
+                >
+                  Date {sortDir === "desc" ? "↓" : "↑"}
+                </button>
+              </th>
+              <th className="px-2 py-1 text-right">Open</th>
+              <th className="px-2 py-1 text-right">High</th>
+              <th className="px-2 py-1 text-right">Low</th>
+              <th className="px-2 py-1 text-right">Close</th>
+              <th className="px-2 py-1 text-right">Volume</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((r) => (
+              <tr key={r.date} className="border-b border-slate-100 last:border-0">
+                <td className="px-2 py-1 tabular-nums">{r.date}</td>
+                <td className="px-2 py-1 text-right tabular-nums">{formatNum(r.open)}</td>
+                <td className="px-2 py-1 text-right tabular-nums">{formatNum(r.high)}</td>
+                <td className="px-2 py-1 text-right tabular-nums">{formatNum(r.low)}</td>
+                <td className="px-2 py-1 text-right tabular-nums font-medium">{formatNum(r.close)}</td>
+                <td className="px-2 py-1 text-right tabular-nums">{formatNum(r.volume)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/components/RawOhlcvTable.tsx
+++ b/frontend/src/pages/components/RawOhlcvTable.tsx
@@ -64,7 +64,15 @@ export function RawOhlcvTable({ rows, symbol, range }: RawOhlcvTableProps): JSX.
         </span>
         <button
           type="button"
-          onClick={() => downloadCsv(sorted, symbol, range)}
+          onClick={() => {
+            // Always export in chronological order regardless of the
+            // UI sort toggle — downstream tools (Excel, pandas, etc.)
+            // expect time-series ascending.
+            const chronological = [...rows].sort((a, b) =>
+              a.date.localeCompare(b.date),
+            );
+            downloadCsv(chronological, symbol, range);
+          }}
           className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700"
           data-testid="csv-download"
         >


### PR DESCRIPTION
## What

Final phase of #576 (closes the issue).

- New `RawOhlcvTable` component — sortable date column (newest-first default), all OHLCV columns, row count badge
- `Download CSV` button generates `${symbol}-${range}-ohlcv.csv` via Blob URL
- View toggle in chart workspace header: **Chart** / **Raw data** buttons
- URL param `?view=raw` switches the body; default chart view has no param
- Indicator / compare / trend toggle rows hidden when in raw view (chart-only controls)

## Why

Closes #576. Operator wanted "drill into a page which is heavy graph reportable, configurable with filters... raw numbers for analysis". Phase 4 delivers the L3 raw-data path.

## Test plan

- 14 new vitest tests (`RawOhlcvTable.test.tsx` + ChartPage Phase 4 suite)
- 555 frontend tests pass
- `pnpm --dir frontend typecheck` clean
- `uv run ruff check . && uv run ruff format --check .` clean
- Manual: `/instrument/GME/chart?view=raw` renders the table; CSV download produces a valid file

## Whole-issue summary (#576 4 phases)

| Phase | PR | Scope |
|---|---|---|
| 1 | #581 | Route `/instrument/:symbol/chart` + L1 link from instrument-page chart pane |
| 2 | #582 | SMA/EMA indicators + rich crosshair tooltip + sparkline hover |
| 3 | #583 | Compare-tickers (max 3, % normalized) + linear regression + range channel |
| 4 | this PR | Raw OHLCV table + CSV export |

`PriceChart` (instrument-page compact chart) deliberately untouched across all 4 phases — workspace features ride on `ChartWorkspaceCanvas` only.