### PR TITLE
feat(#586): chart theme + recharts dep (Phase 1 foundation)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "lightweight-charts": "^5.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.27.0"
+    "react-router-dom": "^6.27.0",
+    "recharts": "^2.15.4"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-router-dom:
         specifier: ^6.27.0
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts:
+        specifier: ^2.15.4
+        version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.6.3
@@ -557,6 +560,33 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -697,6 +727,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -723,6 +757,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -735,6 +813,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -762,6 +843,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -805,12 +889,19 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   fancy-canvas@2.1.0:
     resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -903,6 +994,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
@@ -961,6 +1056,9 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1118,6 +1216,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1130,8 +1231,14 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -1150,6 +1257,18 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -1160,6 +1279,16 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -1243,6 +1372,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1303,6 +1435,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -1804,6 +1939,30 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@22.19.17':
@@ -1956,6 +2115,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  clsx@2.1.1: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -1975,6 +2136,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-urls@5.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
@@ -1983,6 +2182,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -1999,6 +2200,11 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      csstype: 3.2.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2059,9 +2265,13 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  eventemitter3@4.0.7: {}
+
   expect-type@1.3.0: {}
 
   fancy-canvas@2.1.0: {}
+
+  fast-equals@5.4.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -2162,6 +2372,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  internmap@2.0.3: {}
+
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
@@ -2223,6 +2435,8 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  lodash@4.18.1: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -2342,6 +2556,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
@@ -2352,7 +2572,11 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
 
   react-refresh@0.17.0: {}
 
@@ -2368,6 +2592,23 @@ snapshots:
       '@remix-run/router': 1.23.2
       react: 18.3.1
 
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -2379,6 +2620,23 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.18.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   redent@3.0.0:
     dependencies:
@@ -2506,6 +2764,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -2552,6 +2812,23 @@ snapshots:
       picocolors: 1.1.1
 
   util-deprecate@1.0.2: {}
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-node@2.1.9(@types/node@22.19.17):
     dependencies:

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -32,6 +32,7 @@ import { fetchInstrumentCandles } from "@/api/instruments";
 import type { CandleBar, CandleRange, InstrumentCandles } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
+import { chartTheme } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
 
 const RANGES: { id: CandleRange; label: string }[] = [
@@ -220,36 +221,36 @@ export function ChartCanvas({
     const chart = createChart(container, {
       autoSize: true,
       layout: {
-        background: { color: "#ffffff" },
-        textColor: "#64748b",
+        background: { color: chartTheme.bg },
+        textColor: chartTheme.textSecondary,
         fontSize: 11,
       },
       grid: {
-        vertLines: { color: "#f1f5f9" },
-        horzLines: { color: "#f1f5f9" },
+        vertLines: { color: chartTheme.gridLine },
+        horzLines: { color: chartTheme.gridLine },
       },
       rightPriceScale: {
-        borderColor: "#e2e8f0",
+        borderColor: chartTheme.borderColor,
         // Leave room at the bottom for the volume overlay — matches
         // the TradingView default chart feel.
         scaleMargins: { top: 0.08, bottom: 0.3 },
       },
       timeScale: {
-        borderColor: "#e2e8f0",
+        borderColor: chartTheme.borderColor,
         timeVisible: false,
         secondsVisible: false,
       },
       crosshair: {
-        vertLine: { width: 1, color: "#94a3b8", style: 3 },
-        horzLine: { width: 1, color: "#94a3b8", style: 3 },
+        vertLine: { width: 1, color: chartTheme.crosshair, style: 3 },
+        horzLine: { width: 1, color: chartTheme.crosshair, style: 3 },
       },
     });
 
     const candle = chart.addSeries(CandlestickSeries, {
-      upColor: "#10b981",
-      downColor: "#ef4444",
-      wickUpColor: "#10b981",
-      wickDownColor: "#ef4444",
+      upColor: chartTheme.up,
+      downColor: chartTheme.down,
+      wickUpColor: chartTheme.up,
+      wickDownColor: chartTheme.down,
       borderVisible: false,
     });
 
@@ -338,7 +339,7 @@ export function ChartCanvas({
         return {
           time: b.time as Time,
           value: b.volume,
-          color: b.close >= prev ? "rgba(16,185,129,0.4)" : "rgba(239,68,68,0.4)",
+          color: b.close >= prev ? chartTheme.volumeUpAlpha : chartTheme.volumeDownAlpha,
         };
       }),
     );

--- a/frontend/src/components/instrument/Sparkline.tsx
+++ b/frontend/src/components/instrument/Sparkline.tsx
@@ -4,6 +4,12 @@
  * series (revenue, op income, net income, total debt over 8 quarters).
  *
  * Phase 2 (#576): hover tooltip shows the value at the cursor index.
+ *
+ * Coloring: default `stroke="currentColor"` lets callers drive the
+ * polyline color via a Tailwind `text-*` class on `className` (e.g.
+ * `text-emerald-500`). Existing FundamentalsPane callers rely on this.
+ * For chart-theme alignment, new callers should pass
+ * `stroke={chartTheme.accent[N]}` from `@/lib/chartTheme` — see #586.
  */
 
 import { useState, useCallback, type JSX } from "react";

--- a/frontend/src/lib/chartTheme.ts
+++ b/frontend/src/lib/chartTheme.ts
@@ -1,0 +1,92 @@
+/**
+ * Chart theme — single source of truth for chart colors.
+ *
+ * Light-mode only in v1. Dark variant + theme-mode switch (light / dark /
+ * system, persisted via Settings) are tracked at #596. When that ships,
+ * this module exports `lightTheme` + `darkTheme` and consumers stop
+ * importing the constants directly — they read via `useChartTheme()`.
+ *
+ * Consumers in this PR (#586):
+ *   - lightweight-charts options in `PriceChart` and `ChartWorkspaceCanvas`
+ *   - `Sparkline` (referenced from JSDoc; default stroke remains
+ *     `currentColor` so callers retain Tailwind `text-*`-driven coloring)
+ *
+ * Consumers in upcoming chart-redesign tickets (#587-#594):
+ *   - `recharts` components in per-domain L2 drill pages
+ *
+ * Adding a new color: prefer reusing an existing slot. Add a new key only
+ * if no existing slot fits the semantic role. Do NOT inline hex values in
+ * chart components.
+ */
+
+export const chartTheme = {
+  /** Background of the chart surface. Matches the page card chrome. */
+  bg: "#ffffff",
+
+  /**
+   * Text scale.
+   * - `textPrimary` = hover values, important figures (slate-800)
+   * - `textSecondary` = axis labels, lightweight-charts `textColor` (slate-500)
+   * - `textMuted` = hover dates, ticks (slate-400)
+   */
+  textPrimary: "#1e293b",
+  textSecondary: "#64748b",
+  textMuted: "#94a3b8",
+
+  /** Grid lines (slate-100) and scale-axis borders (slate-200). */
+  gridLine: "#f1f5f9",
+  borderColor: "#e2e8f0",
+
+  /** Crosshair vertical + horizontal guides. */
+  crosshair: "#94a3b8",
+
+  /** Market direction. Used by candles, deltas, and channel high/low. */
+  up: "#10b981",
+  down: "#ef4444",
+
+  /** Volume histogram fill — translucent so it sits visibly under candles. */
+  volumeUpAlpha: "rgba(16,185,129,0.4)",
+  volumeDownAlpha: "rgba(239,68,68,0.4)",
+
+  /**
+   * Accent rotation for series overlays in recharts components and any
+   * future multi-line viz. Cycle by index when rendering N series.
+   */
+  accent: [
+    "#06b6d4", // cyan-500
+    "#3b82f6", // blue-500
+    "#a855f7", // purple-500
+    "#f59e0b", // amber-500
+    "#ec4899", // pink-500
+    "#84cc16", // lime-500
+  ] as const,
+
+  /**
+   * Indicator overlays (chart workspace SMA / EMA). Named slots keep the
+   * operator's mental map of "which color = which line" stable across
+   * sessions. Picks from `accent` plus sky-500 for the EMA(20) slot.
+   */
+  indicator: {
+    sma20: "#3b82f6", // blue-500 (matches accent[1])
+    sma50: "#a855f7", // purple-500 (matches accent[2])
+    ema20: "#0ea5e9", // sky-500
+    ema50: "#ec4899", // pink-500 (matches accent[4])
+  },
+
+  /** Compare-overlay rotation in the chart workspace. Distinct from SMA palette. */
+  compare: [
+    "#0ea5e9", // sky-500
+    "#a855f7", // purple-500
+    "#f59e0b", // amber-500
+  ] as const,
+
+  /** Trend overlays (chart workspace). */
+  regression: "#f97316", // orange-500
+  channelHigh: "#10b981",
+  channelLow: "#ef4444",
+
+  /** Primary normalized line in compare mode (slate-800, picks reading order). */
+  primaryLine: "#1e293b",
+} as const;
+
+export type ChartTheme = typeof chartTheme;

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -23,15 +23,17 @@ import {
 } from "lightweight-charts";
 
 import type { CandleBar } from "@/api/types";
+import { chartTheme } from "@/lib/chartTheme";
 
-const SMA_COLORS: Record<string, string> = {
-  sma20: "#3b82f6", // blue-500
-  sma50: "#a855f7", // purple-500
-  ema20: "#0ea5e9", // sky-500
-  ema50: "#ec4899", // pink-500
-};
+export type IndicatorId = "sma20" | "sma50" | "ema20" | "ema50";
+export const INDICATOR_IDS: IndicatorId[] = ["sma20", "sma50", "ema20", "ema50"];
 
-const SMA_LABELS: Record<string, string> = {
+// Keep palette keys exhaustively typed against IndicatorId so a missing or
+// misspelled key in chartTheme.indicator fails typecheck rather than
+// returning undefined at runtime.
+const SMA_COLORS: Record<IndicatorId, string> = chartTheme.indicator;
+
+const SMA_LABELS: Record<IndicatorId, string> = {
   sma20: "SMA(20)",
   sma50: "SMA(50)",
   ema20: "EMA(20)",
@@ -39,14 +41,7 @@ const SMA_LABELS: Record<string, string> = {
 };
 
 // Fixed palette for compare overlays — distinct from SMA colors.
-export const COMPARE_COLORS: readonly string[] = [
-  "#0ea5e9", // sky-500
-  "#a855f7", // purple-500
-  "#f59e0b", // amber-500
-];
-
-export type IndicatorId = "sma20" | "sma50" | "ema20" | "ema50";
-export const INDICATOR_IDS: IndicatorId[] = ["sma20", "sma50", "ema20", "ema50"];
+export const COMPARE_COLORS: readonly string[] = chartTheme.compare;
 
 export interface CompareSeries {
   readonly symbol: string;
@@ -234,34 +229,34 @@ export function ChartWorkspaceCanvas({
     const chart = createChart(container, {
       autoSize: true,
       layout: {
-        background: { color: "#ffffff" },
-        textColor: "#64748b",
+        background: { color: chartTheme.bg },
+        textColor: chartTheme.textSecondary,
         fontSize: 11,
       },
       grid: {
-        vertLines: { color: "#f1f5f9" },
-        horzLines: { color: "#f1f5f9" },
+        vertLines: { color: chartTheme.gridLine },
+        horzLines: { color: chartTheme.gridLine },
       },
       rightPriceScale: {
-        borderColor: "#e2e8f0",
+        borderColor: chartTheme.borderColor,
         scaleMargins: { top: 0.08, bottom: 0.3 },
       },
       timeScale: {
-        borderColor: "#e2e8f0",
+        borderColor: chartTheme.borderColor,
         timeVisible: false,
         secondsVisible: false,
       },
       crosshair: {
-        vertLine: { width: 1, color: "#94a3b8", style: 3 },
-        horzLine: { width: 1, color: "#94a3b8", style: 3 },
+        vertLine: { width: 1, color: chartTheme.crosshair, style: 3 },
+        horzLine: { width: 1, color: chartTheme.crosshair, style: 3 },
       },
     });
 
     const candle = chart.addSeries(CandlestickSeries, {
-      upColor: "#10b981",
-      downColor: "#ef4444",
-      wickUpColor: "#10b981",
-      wickDownColor: "#ef4444",
+      upColor: chartTheme.up,
+      downColor: chartTheme.down,
+      wickUpColor: chartTheme.up,
+      wickDownColor: chartTheme.down,
       borderVisible: false,
     });
 
@@ -272,7 +267,7 @@ export function ChartWorkspaceCanvas({
     chart.priceScale("volume").applyOptions({ scaleMargins: { top: 0.75, bottom: 0 } });
 
     const primaryLine = chart.addSeries(LineSeries, {
-      color: "#1e293b",
+      color: chartTheme.primaryLine,
       lineWidth: 2,
       priceLineVisible: false,
       lastValueVisible: false,
@@ -302,7 +297,7 @@ export function ChartWorkspaceCanvas({
             // Read color from the symbol-keyed ref populated when the
             // LineSeries was created — keeps tooltip in sync with the
             // actual rendered series even if Map iteration order drifts.
-            color: compareColorRef.current.get(sym) ?? "#0ea5e9",
+            color: compareColorRef.current.get(sym) ?? chartTheme.compare[0],
             value: norm[idx] ?? null,
           }));
         const date = new Date(time * 1000).toISOString().slice(0, 10);
@@ -400,7 +395,7 @@ export function ChartWorkspaceCanvas({
         if (v === null || v === undefined || !bar) continue;
         lineData.push({ time: bar.time as Time, value: v });
       }
-      primaryLine.applyOptions({ visible: true, color: "#1e293b", lineWidth: 2 });
+      primaryLine.applyOptions({ visible: true, color: chartTheme.primaryLine, lineWidth: 2 });
       primaryLine.setData(lineData);
     } else {
       // Normal mode: show candles + volume; hide primary normalized line.
@@ -423,7 +418,7 @@ export function ChartWorkspaceCanvas({
           return {
             time: b.time as Time,
             value: b.volume,
-            color: b.close >= prev ? "rgba(16,185,129,0.4)" : "rgba(239,68,68,0.4)",
+            color: b.close >= prev ? chartTheme.volumeUpAlpha : chartTheme.volumeDownAlpha,
           };
         }),
       );
@@ -453,7 +448,8 @@ export function ChartWorkspaceCanvas({
 
     // Add/update series for each compare symbol.
     compares.forEach((cs, colorIdx) => {
-      const color = COMPARE_COLORS[colorIdx % COMPARE_COLORS.length] ?? "#0ea5e9";
+      const color =
+        COMPARE_COLORS[colorIdx % COMPARE_COLORS.length] ?? chartTheme.compare[0];
       compareColorRef.current.set(cs.symbol, color);
 
       const compareClean: NumericBar[] = cs.rows.flatMap((r) => {
@@ -573,7 +569,7 @@ export function ChartWorkspaceCanvas({
       const regValues = linearRegressionLine(closes);
       if (!regressionRef.current) {
         regressionRef.current = chart.addSeries(LineSeries, {
-          color: "#f97316", // orange-500
+          color: chartTheme.regression,
           lineWidth: 1,
           lineStyle: 2, // dashed
           priceLineVisible: false,
@@ -600,7 +596,7 @@ export function ChartWorkspaceCanvas({
     if (showChannel && high !== null && low !== null && clean.length >= 2) {
       if (!channelHighRef.current) {
         channelHighRef.current = chart.addSeries(LineSeries, {
-          color: "#10b981", // emerald-500
+          color: chartTheme.channelHigh,
           lineWidth: 1,
           lineStyle: 3, // dotted
           priceLineVisible: false,
@@ -609,7 +605,7 @@ export function ChartWorkspaceCanvas({
       }
       if (!channelLowRef.current) {
         channelLowRef.current = chart.addSeries(LineSeries, {
-          color: "#ef4444", // red-500
+          color: chartTheme.channelLow,
           lineWidth: 1,
           lineStyle: 3, // dotted
           priceLineVisible: false,


### PR DESCRIPTION
## What

- Adds `frontend/src/lib/chartTheme.ts` — single source of truth for chart colors (bg, text scale, grid, scale border, crosshair, candle up/down, volume alphas, accent rotation, indicator slots, compare palette, regression/channel/primary line)
- Refactors `PriceChart` + `ChartWorkspaceCanvas` to consume theme constants instead of inline hex values
- Adds `recharts ^2.15.4` as a dep for upcoming non-OHLC drill pages (#587-#594); not imported anywhere yet so tree-shaken out of the current bundle
- Adds JSDoc on `Sparkline` pointing new callers at `chartTheme.accent`
- Tightens `SMA_COLORS` / `SMA_LABELS` keying in `ChartWorkspaceCanvas` from `Record<string, string>` to `Record<IndicatorId, string>` so a missing or misspelled indicator key fails typecheck

## Why

Foundation for #585 chart redesign. Drill pages need a stable color contract before they ship.

## Conscious deviations from ticket text

1. **Theme is light-mode only.** Spec specified dark slate (`bg=#0f172a` etc.) but the app shell is light — no Tailwind `darkMode` config, no `dark:` classes, no theme context. Charting them dark on a light page would visibly mismatch. Filed #596 to add a proper light/dark/system theme switch with Settings UI; `chartTheme.ts` will export `lightTheme` + `darkTheme` there. This PR ships the constants matching current chart appearance.
2. **`Sparkline` default stroke stays `currentColor`.** Existing `FundamentalsPane` callers drive sparkline color via Tailwind `text-*` classes (e.g. `text-amber-500`) that propagate through `currentColor`. Changing the default to a fixed `chartTheme.accent[0]` would silently break those colorings. JSDoc updated to direct new callers to import from `@/lib/chartTheme`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test:unit` — 555/555 pass
- [x] `pnpm build` — 676.45 kB JS / 196.49 kB gz; verified zero `recharts` matches in `dist/assets/index-*.js` (tree-shaken)
- [x] Backend gates: `uv run ruff check .` / `ruff format --check` / `pyright` / `pytest -q` all pass (2829 passed, 1 skipped)
- [x] Codex pre-push review applied (tightened indicator-key typing, confirmed no value drift in extracted hex/rgba)

## Linked

- Parent epic: #585
- Follow-up: #596 (light/dark/system theme switch + Settings UI)
- Spec: `docs/superpowers/specs/2026-04-27-instrument-charts-quant-redesign-design.md`