### PR TITLE
feat(#587): PriceChart overview polish — rich tooltip + type/scale toggles + curved line + drill

### DIFF
--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -261,4 +261,22 @@ describe("DensityGrid profiles", () => {
     await user.click(openButton);
     expect(navigateMock).toHaveBeenCalledWith("/instrument/GME/chart?range=5y");
   });
+
+  it("clicking the chart card itself drills to the chart workspace (#587)", async () => {
+    navigateMock.mockClear();
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/instrument/GME?chart=1y"]}>
+        <DensityGrid
+          summary={makeSummary({})}
+          thesis={null}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    // PriceChart is mocked above to a div with testid `price-chart-stub`.
+    // Clicking the stub bubbles up to the Pane's article-level onClick.
+    await user.click(screen.getByTestId("price-chart-stub"));
+    expect(navigateMock).toHaveBeenCalledWith("/instrument/GME/chart?range=1y");
+  });
 });

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -57,24 +57,23 @@ export function DensityGrid({
   const navigate = useNavigate();
   const [overviewParams] = useSearchParams();
 
+  const drillToWorkspace = () => {
+    // Preserve the operator's currently-selected overview range when
+    // expanding to the full chart workspace. PriceChart syncs its
+    // range to ?chart=<id> on the instrument page; ChartPage reads
+    // ?range=<id>. Translate the param name across the boundary so
+    // a non-default range survives the route change.
+    const overviewRange = overviewParams.get("chart");
+    const target = `/instrument/${encodeURIComponent(symbol)}/chart`;
+    const url =
+      overviewRange !== null && overviewRange !== ""
+        ? `${target}?range=${encodeURIComponent(overviewRange)}`
+        : target;
+    navigate(url);
+  };
+
   const ChartPane = (
-    <Pane
-      title="Price chart"
-      onExpand={() => {
-        // Preserve the operator's currently-selected overview range when
-        // expanding to the full chart workspace. PriceChart syncs its
-        // range to ?chart=<id> on the instrument page; ChartPage reads
-        // ?range=<id>. Translate the param name across the boundary so
-        // a non-default range survives the route change.
-        const overviewRange = overviewParams.get("chart");
-        const target = `/instrument/${encodeURIComponent(symbol)}/chart`;
-        const url =
-          overviewRange !== null && overviewRange !== ""
-            ? `${target}?range=${encodeURIComponent(overviewRange)}`
-            : target;
-        navigate(url);
-      }}
-    >
+    <Pane title="Price chart" onExpand={drillToWorkspace} onCardClick={drillToWorkspace}>
       <PriceChart symbol={symbol} />
     </Pane>
   );

--- a/frontend/src/components/instrument/Pane.test.tsx
+++ b/frontend/src/components/instrument/Pane.test.tsx
@@ -15,18 +15,59 @@ describe("Pane", () => {
     expect(screen.getByText("row content")).toBeInTheDocument();
   });
 
-  it("does not attach onClick to the outer article (button-only drill)", async () => {
+  it("when only onExpand is set, body clicks do NOT drill — only the Open button does", async () => {
     const onExpand = vi.fn();
     render(
       <Pane title="Filings" onExpand={onExpand}>
         <p>body</p>
       </Pane>,
     );
-    // Clicking the body must NOT trigger onExpand.
     await userEvent.click(screen.getByText("body"));
     expect(onExpand).not.toHaveBeenCalled();
-    // Clicking the Open button MUST trigger onExpand.
     await userEvent.click(screen.getByRole("button", { name: /open/i }));
     expect(onExpand).toHaveBeenCalledOnce();
+  });
+
+  it("when onCardClick is set, body clicks invoke it (whole-card drill)", async () => {
+    const onCardClick = vi.fn();
+    render(
+      <Pane title="Price chart" onCardClick={onCardClick}>
+        <p>body</p>
+      </Pane>,
+    );
+    await userEvent.click(screen.getByText("body"));
+    expect(onCardClick).toHaveBeenCalledOnce();
+  });
+
+  it("clicking the Open button stops propagation so onCardClick does not also fire", async () => {
+    const onExpand = vi.fn();
+    const onCardClick = vi.fn();
+    render(
+      <Pane title="Price chart" onExpand={onExpand} onCardClick={onCardClick}>
+        <p>body</p>
+      </Pane>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /open/i }));
+    expect(onExpand).toHaveBeenCalledOnce();
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+
+  it("clickable card does NOT take role=button (avoids nesting interactive descendants)", () => {
+    const onCardClick = vi.fn();
+    render(
+      <Pane title="Price chart" onCardClick={onCardClick} onExpand={vi.fn()}>
+        <button type="button">inner</button>
+      </Pane>,
+    );
+    // Only the descendant Open button + inner button are role=button —
+    // the article itself stays a plain article so assistive tech does
+    // not flatten the inner controls.
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.every((b) => b.tagName === "BUTTON")).toBe(true);
+    // Clickable affordance is signalled via a data-attribute hook for
+    // styling/tests — without role=button, the article stays a
+    // semantic article element.
+    const article = document.querySelector("article");
+    expect(article?.getAttribute("data-clickable")).toBe("true");
   });
 });

--- a/frontend/src/components/instrument/Pane.tsx
+++ b/frontend/src/components/instrument/Pane.tsx
@@ -7,6 +7,24 @@ export interface PaneProps extends PaneHeaderProps {
   readonly children: ReactNode;
   /** Optional className overrides on the outer article. */
   readonly className?: string;
+  /**
+   * Optional whole-card click handler. When provided, the Pane gets a
+   * cursor-pointer + hover-elevate affordance and clicking anywhere on
+   * the card invokes the handler. Internal interactive controls (e.g.
+   * range pickers) must call `e.stopPropagation()` so they don't also
+   * trigger this handler. The PaneHeader's "Open →" button stops
+   * propagation automatically — see PaneHeader.tsx.
+   *
+   * Accessibility: the article does NOT receive `role="button"` or
+   * `tabIndex` because it contains real `<button>` descendants
+   * (PaneHeader Open button, in-pane controls). Nesting interactive
+   * elements inside a custom button is an ARIA violation and can
+   * cause assistive tech to flatten the inner controls. Keyboard
+   * users navigate via the inner Open button instead — that button
+   * is always rendered when `onExpand` is provided, so the drill is
+   * keyboard-reachable without needing a card-level handler.
+   */
+  readonly onCardClick?: () => void;
 }
 
 export function Pane({
@@ -15,11 +33,19 @@ export function Pane({
   source,
   onExpand,
   className,
+  onCardClick,
   children,
 }: PaneProps): JSX.Element {
+  const clickable = onCardClick !== undefined;
   return (
     <article
-      className={`rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm ${className ?? ""}`}
+      className={`rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm ${
+        clickable
+          ? "cursor-pointer transition hover:border-slate-300 hover:shadow-md"
+          : ""
+      } ${className ?? ""}`}
+      onClick={clickable ? onCardClick : undefined}
+      data-clickable={clickable ? "true" : undefined}
     >
       <PaneHeader
         title={title}

--- a/frontend/src/components/instrument/PaneHeader.tsx
+++ b/frontend/src/components/instrument/PaneHeader.tsx
@@ -7,7 +7,12 @@ export interface PaneHeaderProps {
     readonly providers: ReadonlyArray<string>;
     readonly lastSync?: string;
   };
-  readonly onExpand?: () => void; // renders "Open →" button (button-only — no card-click)
+  /**
+   * Renders an "Open →" button. The handler is invoked on click; the
+   * click event's propagation is stopped so an enclosing Pane with
+   * `onCardClick` doesn't also fire.
+   */
+  readonly onExpand?: () => void;
 }
 
 export function PaneHeader({
@@ -43,7 +48,10 @@ export function PaneHeader({
         {onExpand !== undefined ? (
           <button
             type="button"
-            onClick={onExpand}
+            onClick={(e) => {
+              e.stopPropagation();
+              onExpand();
+            }}
             className="text-[11px] text-sky-700 hover:underline focus-visible:rounded focus-visible:outline-2 focus-visible:outline-sky-500"
           >
             Open →

--- a/frontend/src/components/instrument/PriceChart.test.tsx
+++ b/frontend/src/components/instrument/PriceChart.test.tsx
@@ -1,11 +1,15 @@
 /**
- * Tests for PriceChart (#204 lightweight-charts migration).
+ * Tests for PriceChart (#204 lightweight-charts migration; polished in #587).
  *
  * lightweight-charts renders to a Canvas which jsdom cannot paint, so
  * we mock the library wholesale. What we pin here is the component's
  * contract — not the library's rendering:
  *
  *   - All 7 range buttons render + switching refetches.
+ *   - Type toggle (candle/line/area) flips visibility on each series
+ *     and URL-syncs to ?type=line|area (no param for default candle).
+ *   - Log scale toggle URL-syncs to ?scale=log and applies the
+ *     logarithmic mode to the right price scale.
  *   - Empty / single-row data → empty state, no chart mount.
  *   - ≥2 valid rows → chart div mounts and the mocked series receives
  *     setData() with the right shape.
@@ -15,28 +19,61 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 
 // Mock lightweight-charts before importing PriceChart so the module
 // picks up the stubs at module-load time. `vi.hoisted` lets the mock
 // expose handles we can introspect from the tests.
 const libState = vi.hoisted(() => ({
   candleSetData: vi.fn(),
+  lineSetData: vi.fn(),
+  areaSetData: vi.fn(),
   volumeSetData: vi.fn(),
+  candleApply: vi.fn(),
+  lineApply: vi.fn(),
+  areaApply: vi.fn(),
+  rightPriceScaleApply: vi.fn(),
+  volumePriceScaleApply: vi.fn(),
   fitContent: vi.fn(),
   crosshairHandlers: [] as Array<(p: unknown) => void>,
   remove: vi.fn(),
 }));
 
 vi.mock("lightweight-charts", () => {
-  const candleSeries = { setData: libState.candleSetData };
-  const volumeSeries = { setData: libState.volumeSetData };
-  const priceScale = { applyOptions: vi.fn() };
+  const candleSeries = {
+    setData: libState.candleSetData,
+    applyOptions: libState.candleApply,
+  };
+  const lineSeries = {
+    setData: libState.lineSetData,
+    applyOptions: libState.lineApply,
+  };
+  const areaSeries = {
+    setData: libState.areaSetData,
+    applyOptions: libState.areaApply,
+  };
+  const volumeSeries = {
+    setData: libState.volumeSetData,
+    applyOptions: vi.fn(),
+  };
   const chart = {
-    addSeries: vi.fn((seriesDef: unknown) =>
-      seriesDef === "__candlestick__" ? candleSeries : volumeSeries,
+    addSeries: vi.fn((seriesDef: unknown) => {
+      switch (seriesDef) {
+        case "__candlestick__":
+          return candleSeries;
+        case "__line__":
+          return lineSeries;
+        case "__area__":
+          return areaSeries;
+        default:
+          return volumeSeries;
+      }
+    }),
+    priceScale: vi.fn((id: string) =>
+      id === "right"
+        ? { applyOptions: libState.rightPriceScaleApply }
+        : { applyOptions: libState.volumePriceScaleApply },
     ),
-    priceScale: vi.fn(() => priceScale),
     timeScale: vi.fn(() => ({ fitContent: libState.fitContent })),
     subscribeCrosshairMove: vi.fn((h: (p: unknown) => void) => {
       libState.crosshairHandlers.push(h);
@@ -46,7 +83,13 @@ vi.mock("lightweight-charts", () => {
   return {
     createChart: vi.fn(() => chart),
     CandlestickSeries: "__candlestick__",
+    LineSeries: "__line__",
+    AreaSeries: "__area__",
     HistogramSeries: "__histogram__",
+    // Numeric values mirror lightweight-charts' LineType enum so any
+    // assertion on the option passed to addSeries lines up with the
+    // real library shape.
+    LineType: { Simple: 0, WithSteps: 1, Curved: 2 },
   };
 });
 
@@ -70,10 +113,23 @@ function candles(rows: InstrumentCandles["rows"]): InstrumentCandles {
   };
 }
 
+function LocationSpy({ onLocation }: { onLocation: (search: string) => void }) {
+  const loc = useLocation();
+  onLocation(loc.search);
+  return null;
+}
+
 beforeEach(() => {
   mockedFetch.mockReset();
   libState.candleSetData.mockClear();
+  libState.lineSetData.mockClear();
+  libState.areaSetData.mockClear();
   libState.volumeSetData.mockClear();
+  libState.candleApply.mockClear();
+  libState.lineApply.mockClear();
+  libState.areaApply.mockClear();
+  libState.rightPriceScaleApply.mockClear();
+  libState.volumePriceScaleApply.mockClear();
   libState.fitContent.mockClear();
   libState.remove.mockClear();
   libState.crosshairHandlers.length = 0;
@@ -108,6 +164,131 @@ describe("PriceChart — range picker", () => {
     await waitFor(() => {
       expect(mockedFetch).toHaveBeenLastCalledWith("AAPL", "1y");
     });
+  });
+});
+
+describe("PriceChart — type toggle (#587)", () => {
+  it("renders three type buttons (Candle / Line / Area) defaulting to Candle", async () => {
+    mockedFetch.mockResolvedValue(candles([]));
+    render(
+      <MemoryRouter>
+        <PriceChart symbol="AAPL" />
+      </MemoryRouter>,
+    );
+    for (const id of ["candle", "line", "area"]) {
+      expect(screen.getByTestId(`chart-type-${id}`)).toBeInTheDocument();
+    }
+  });
+
+  it("clicking Line writes ?type=line; clicking Candle clears the param", async () => {
+    mockedFetch.mockResolvedValue(candles([]));
+    const user = userEvent.setup();
+    let lastSearch = "";
+    render(
+      <MemoryRouter>
+        <LocationSpy onLocation={(s) => (lastSearch = s)} />
+        <PriceChart symbol="AAPL" />
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByTestId("chart-type-line"));
+    expect(lastSearch).toContain("type=line");
+    await user.click(screen.getByTestId("chart-type-candle"));
+    expect(lastSearch).not.toContain("type=");
+  });
+
+  it("toggles series visibility when ?type=area is set on initial render", async () => {
+    mockedFetch.mockResolvedValue(
+      candles([
+        { date: "2026-04-10", open: "100", high: "102", low: "99", close: "101", volume: "1000" },
+        { date: "2026-04-11", open: "101", high: "104", low: "100", close: "103", volume: "1500" },
+      ]),
+    );
+    render(
+      <MemoryRouter initialEntries={["/?type=area"]}>
+        <PriceChart symbol="AAPL" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("price-chart-AAPL")).toBeInTheDocument();
+    });
+    // Visibility effect runs once per series. Last call's `visible`
+    // flag reflects whether that series is the active type.
+    await waitFor(() => {
+      const last = libState.areaApply.mock.calls.at(-1)?.[0] as { visible?: boolean } | undefined;
+      expect(last?.visible).toBe(true);
+    });
+    const lastCandle = libState.candleApply.mock.calls.at(-1)?.[0] as { visible?: boolean } | undefined;
+    const lastLine = libState.lineApply.mock.calls.at(-1)?.[0] as { visible?: boolean } | undefined;
+    expect(lastCandle?.visible).toBe(false);
+    expect(lastLine?.visible).toBe(false);
+  });
+});
+
+describe("PriceChart — log scale toggle (#587)", () => {
+  it("renders a Log toggle button defaulting to off", async () => {
+    mockedFetch.mockResolvedValue(candles([]));
+    render(
+      <MemoryRouter>
+        <PriceChart symbol="AAPL" />
+      </MemoryRouter>,
+    );
+    const btn = screen.getByTestId("chart-scale-log");
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("clicking Log writes ?scale=log; clicking again clears the param", async () => {
+    mockedFetch.mockResolvedValue(candles([]));
+    const user = userEvent.setup();
+    let lastSearch = "";
+    render(
+      <MemoryRouter>
+        <LocationSpy onLocation={(s) => (lastSearch = s)} />
+        <PriceChart symbol="AAPL" />
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByTestId("chart-scale-log"));
+    expect(lastSearch).toContain("scale=log");
+    await user.click(screen.getByTestId("chart-scale-log"));
+    expect(lastSearch).not.toContain("scale=");
+  });
+
+  it("applies mode=1 to the right price scale when ?scale=log is set", async () => {
+    mockedFetch.mockResolvedValue(
+      candles([
+        { date: "2026-04-10", open: "100", high: "102", low: "99", close: "101", volume: "1000" },
+        { date: "2026-04-11", open: "101", high: "104", low: "100", close: "103", volume: "1500" },
+      ]),
+    );
+    render(
+      <MemoryRouter initialEntries={["/?scale=log"]}>
+        <PriceChart symbol="AAPL" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      const calls = libState.rightPriceScaleApply.mock.calls.map((c) => c[0]);
+      expect(calls.some((opts: { mode?: number }) => opts.mode === 1)).toBe(true);
+    });
+  });
+});
+
+describe("PriceChart — controls swallow card-click events (#587)", () => {
+  it("clicks on the controls bar do not bubble to a parent click handler", async () => {
+    mockedFetch.mockResolvedValue(candles([]));
+    const onCardClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <div data-testid="card" onClick={onCardClick}>
+          <PriceChart symbol="AAPL" />
+        </div>
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByTestId("chart-range-1y"));
+    expect(onCardClick).not.toHaveBeenCalled();
+    await user.click(screen.getByTestId("chart-type-line"));
+    expect(onCardClick).not.toHaveBeenCalled();
+    await user.click(screen.getByTestId("chart-scale-log"));
+    expect(onCardClick).not.toHaveBeenCalled();
   });
 });
 
@@ -148,7 +329,7 @@ describe("PriceChart — data states", () => {
     });
   });
 
-  it("mounts the chart canvas and pushes ≥2 rows to the series", async () => {
+  it("mounts the chart canvas and pushes ≥2 rows to the candle, line, and area series", async () => {
     mockedFetch.mockResolvedValue(
       candles([
         {
@@ -182,13 +363,21 @@ describe("PriceChart — data states", () => {
     await waitFor(() => {
       expect(libState.candleSetData).toHaveBeenCalled();
     });
-    const call = libState.candleSetData.mock.calls[0]?.[0] as Array<{
+    const candleCall = libState.candleSetData.mock.calls[0]?.[0] as Array<{
       open: number;
       close: number;
     }>;
-    expect(call).toHaveLength(2);
-    expect(call[0]?.open).toBe(100);
-    expect(call[1]?.close).toBe(103);
+    expect(candleCall).toHaveLength(2);
+    expect(candleCall[0]?.open).toBe(100);
+    expect(candleCall[1]?.close).toBe(103);
+    // Line + area series receive close-only data.
+    const lineCall = libState.lineSetData.mock.calls[0]?.[0] as Array<{ value: number }>;
+    expect(lineCall).toHaveLength(2);
+    expect(lineCall[0]?.value).toBe(101);
+    expect(lineCall[1]?.value).toBe(103);
+    const areaCall = libState.areaSetData.mock.calls[0]?.[0] as Array<{ value: number }>;
+    expect(areaCall).toHaveLength(2);
+    expect(areaCall[1]?.value).toBe(103);
     // Volume series got the same count.
     expect(libState.volumeSetData).toHaveBeenCalled();
   });

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -1,26 +1,32 @@
 /**
- * PriceChart — candlestick + volume chart backed by TradingView's
- * lightweight-charts (#204). Replaces the Slice B hand-rolled SVG so
- * the operator gets proper OHLC rendering, pinch-zoom, and crosshair
- * tooltip without us maintaining drawing code.
+ * PriceChart — overview candlestick / line / area + volume chart backed
+ * by lightweight-charts (#204, polished in #587). Lives inside a
+ * clickable Pane on the instrument page; clicking the card drills to
+ * the full chart workspace at `/instrument/:symbol/chart`.
  *
- * Library choice: `lightweight-charts` v5, MIT, ~45 KB gzip, Canvas-
- * rendered. We import the specific series types (tree-shake-friendly);
- * the full bundle is not pulled in. Layering approach:
+ * Layering:
+ *   - candlestick / line / area series share the right price scale
+ *     (only one is visible at a time, toggled via `?type=`)
+ *   - volume series (Histogram) on its own overlay price scale pinned
+ *     to the bottom 30% via `scaleMargins`
  *
- *   candlestick series → right price scale (auto-scale)
- *   volume series (Histogram) → overlay price scale pinned to bottom
- *                               30% via scaleMargins
+ * URL params (replace, not push):
+ *   - `?chart=<range>` → 1w | 1m | 3m | 6m | 1y | 5y | max (default 1m)
+ *   - `?type=line|area` → series type (default candle, no param)
+ *   - `?scale=log` → logarithmic right price scale (default linear, no param)
  *
- * Range picker: 1w · 1m · 3m · 6m · 1y · 5y · max. URL-synced via
- * `?chart=<range>` so the operator's choice survives tab switches
- * inside the research page.
+ * Hover tooltip shows date + OHLC + volume + %Δ-from-prior; matches the
+ * pattern in `ChartWorkspaceCanvas.RichTooltip` so an operator's mental
+ * model is consistent between the overview pane and the workspace.
  */
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, type JSX } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
+  AreaSeries,
   CandlestickSeries,
   HistogramSeries,
+  LineSeries,
+  LineType,
   createChart,
   type IChartApi,
   type ISeriesApi,
@@ -55,6 +61,18 @@ const VALID_RANGES: readonly CandleRange[] = [
   "max",
 ];
 
+export type ChartType = "candle" | "line" | "area";
+const VALID_TYPES: readonly ChartType[] = ["candle", "line", "area"];
+const TYPES: { id: ChartType; label: string }[] = [
+  { id: "candle", label: "Candle" },
+  { id: "line", label: "Line" },
+  { id: "area", label: "Area" },
+];
+
+export type PriceScaleMode = "linear" | "log";
+// lightweight-charts: 0 = Normal (linear), 1 = Logarithmic.
+const SCALE_MODE_NUM: Record<PriceScaleMode, 0 | 1> = { linear: 0, log: 1 };
+
 function parseNum(v: string | null | undefined): number | null {
   if (v === null || v === undefined) return null;
   const n = Number(v);
@@ -83,9 +101,14 @@ function dateToTime(date: string): UTCTimestamp | null {
   return (ts / 1000) as UTCTimestamp;
 }
 
-interface HoverState {
+interface RichHoverState {
   date: string;
+  open: number;
+  high: number;
+  low: number;
   close: number;
+  volume: number;
+  changePct: number | null;
 }
 
 interface NumericBar {
@@ -111,6 +134,11 @@ export function PriceChart({
   const range: CandleRange = VALID_RANGES.includes(rawChart as CandleRange)
     ? (rawChart as CandleRange)
     : initialRange;
+  const rawType = searchParams.get("type");
+  const chartType: ChartType = VALID_TYPES.includes(rawType as ChartType)
+    ? (rawType as ChartType)
+    : "candle";
+  const priceScale: PriceScaleMode = searchParams.get("scale") === "log" ? "log" : "linear";
 
   const setRange = useCallback(
     (next: CandleRange) => {
@@ -124,6 +152,29 @@ export function PriceChart({
     },
     [searchParams, setSearchParams, initialRange],
   );
+
+  const setChartType = useCallback(
+    (next: ChartType) => {
+      const params = new URLSearchParams(searchParams);
+      if (next === "candle") {
+        params.delete("type");
+      } else {
+        params.set("type", next);
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const togglePriceScale = useCallback(() => {
+    const params = new URLSearchParams(searchParams);
+    if (priceScale === "log") {
+      params.delete("scale");
+    } else {
+      params.set("scale", "log");
+    }
+    setSearchParams(params, { replace: true });
+  }, [searchParams, setSearchParams, priceScale]);
 
   const { data, error, loading, refetch } = useAsync<InstrumentCandles>(
     () => fetchInstrumentCandles(symbol, range),
@@ -156,7 +207,17 @@ export function PriceChart({
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between">
+      {/*
+        Controls swallow click events so they do NOT trigger the
+        Pane's card-click drill (which navigates to the full chart
+        workspace). Clicks anywhere else inside this component — chart
+        canvas, hover tooltip, empty state — bubble up to the Pane.
+      */}
+      <div
+        className="flex items-center justify-between gap-2"
+        onClick={(e) => e.stopPropagation()}
+        data-testid="chart-controls"
+      >
         <div className="flex gap-1">
           {RANGES.map((r) => (
             <button
@@ -174,6 +235,39 @@ export function PriceChart({
             </button>
           ))}
         </div>
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1">
+            {TYPES.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setChartType(t.id)}
+                className={`rounded px-2 py-0.5 text-xs font-medium ${
+                  t.id === chartType
+                    ? "bg-slate-800 text-white"
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                }`}
+                data-testid={`chart-type-${t.id}`}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={togglePriceScale}
+            aria-pressed={priceScale === "log"}
+            className={`rounded px-2 py-0.5 text-xs font-medium ${
+              priceScale === "log"
+                ? "bg-slate-800 text-white"
+                : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+            }`}
+            data-testid="chart-scale-log"
+            title="Toggle logarithmic price scale"
+          >
+            Log
+          </button>
+        </div>
       </div>
 
       {effectivelyLoading && error === null ? (
@@ -188,7 +282,12 @@ export function PriceChart({
       ) : null}
 
       {hasChartData && rows !== null ? (
-        <ChartCanvas rows={rows} symbol={symbol} />
+        <ChartCanvas
+          rows={rows}
+          symbol={symbol}
+          chartType={chartType}
+          priceScale={priceScale}
+        />
       ) : null}
     </div>
   );
@@ -197,23 +296,33 @@ export function PriceChart({
 export interface ChartCanvasProps {
   rows: CandleBar[];
   symbol: string;
+  chartType?: ChartType;
+  priceScale?: PriceScaleMode;
   containerClassName?: string;
 }
 
 export function ChartCanvas({
   rows,
   symbol,
+  chartType = "candle",
+  priceScale = "linear",
   containerClassName,
 }: ChartCanvasProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const candleRef = useRef<ISeriesApi<"Candlestick"> | null>(null);
+  const lineRef = useRef<ISeriesApi<"Line"> | null>(null);
+  const areaRef = useRef<ISeriesApi<"Area"> | null>(null);
   const volumeRef = useRef<ISeriesApi<"Histogram"> | null>(null);
-  const [hover, setHover] = useState<HoverState | null>(null);
+  // Stable ref into `clean` for the crosshair handler — avoids stale
+  // closure capture when rows update.
+  const cleanRowsRef = useRef<NumericBar[]>([]);
+  const [hover, setHover] = useState<RichHoverState | null>(null);
 
   // One-shot chart construction. lightweight-charts owns the DOM
   // canvas and its own lifecycle; we give it an empty div and clean
-  // up on unmount via `chart.remove()`.
+  // up on unmount via `chart.remove()`. All three price series mount
+  // here; toggling `chartType` only flips visibility.
   useEffect(() => {
     const container = containerRef.current;
     if (container === null) return;
@@ -253,6 +362,27 @@ export function ChartCanvas({
       wickDownColor: chartTheme.down,
       borderVisible: false,
     });
+    // Robinhood-style smooth line. `LineType.Curved` (cardinal-spline)
+    // applies to both Line and Area series; we set it here once and the
+    // subsequent visibility toggles preserve the smoothing.
+    const line = chart.addSeries(LineSeries, {
+      color: chartTheme.primaryLine,
+      lineWidth: 2,
+      lineType: LineType.Curved,
+      priceLineVisible: false,
+      lastValueVisible: false,
+      visible: false,
+    });
+    const area = chart.addSeries(AreaSeries, {
+      lineColor: chartTheme.primaryLine,
+      topColor: chartTheme.volumeUpAlpha,
+      bottomColor: "rgba(30,41,59,0.0)",
+      lineWidth: 2,
+      lineType: LineType.Curved,
+      priceLineVisible: false,
+      lastValueVisible: false,
+      visible: false,
+    });
 
     // Volume on its own overlay price scale pinned to the bottom 25%.
     // priceScaleId: 'volume' is an arbitrary identifier — any string
@@ -266,8 +396,7 @@ export function ChartCanvas({
       .applyOptions({ scaleMargins: { top: 0.75, bottom: 0 } });
 
     chart.subscribeCrosshairMove((param) => {
-      const cp = candleRef.current;
-      if (!param.time || !cp) {
+      if (!param.time) {
         setHover(null);
         return;
       }
@@ -279,34 +408,75 @@ export function ChartCanvas({
         setHover(null);
         return;
       }
-      const bar = param.seriesData.get(cp);
-      if (!bar || typeof bar !== "object" || !("close" in bar)) {
+      const time = param.time as UTCTimestamp;
+      const idx = cleanRowsRef.current.findIndex((b) => b.time === time);
+      if (idx < 0) {
         setHover(null);
         return;
       }
-      const date = new Date(param.time * 1000).toISOString().slice(0, 10);
-      setHover({ date, close: (bar as { close: number }).close });
+      const bar = cleanRowsRef.current[idx]!;
+      const prev = idx > 0 ? cleanRowsRef.current[idx - 1] : null;
+      const changePct =
+        prev !== null && prev !== undefined && prev.close !== 0
+          ? ((bar.close - prev.close) / prev.close) * 100
+          : null;
+      const date = new Date(time * 1000).toISOString().slice(0, 10);
+      setHover({
+        date,
+        open: bar.open,
+        high: bar.high,
+        low: bar.low,
+        close: bar.close,
+        volume: bar.volume,
+        changePct,
+      });
     });
 
     chartRef.current = chart;
     candleRef.current = candle;
+    lineRef.current = line;
+    areaRef.current = area;
     volumeRef.current = volume;
 
     return () => {
       chart.remove();
       chartRef.current = null;
       candleRef.current = null;
+      lineRef.current = null;
+      areaRef.current = null;
       volumeRef.current = null;
     };
   }, []);
+
+  // Toggle which price series is visible whenever `chartType` changes.
+  // The data effect always feeds all three series, so flipping
+  // visibility never reveals a stale series.
+  useEffect(() => {
+    const candle = candleRef.current;
+    const line = lineRef.current;
+    const area = areaRef.current;
+    if (!candle || !line || !area) return;
+    candle.applyOptions({ visible: chartType === "candle" });
+    line.applyOptions({ visible: chartType === "line" });
+    area.applyOptions({ visible: chartType === "area" });
+  }, [chartType]);
+
+  // Apply linear / logarithmic price scale.
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+    chart.priceScale("right").applyOptions({ mode: SCALE_MODE_NUM[priceScale] });
+  }, [priceScale]);
 
   // Feed data on every rows change. lightweight-charts replaces the
   // series wholesale via setData — no incremental diffing needed.
   useEffect(() => {
     const candle = candleRef.current;
+    const line = lineRef.current;
+    const area = areaRef.current;
     const volume = volumeRef.current;
     const chart = chartRef.current;
-    if (!candle || !volume || !chart) return;
+    if (!candle || !line || !area || !volume || !chart) return;
 
     // Pre-convert to numeric bars so downstream `setData` calls work
     // with guaranteed-non-null values (no dead `?? 0` fallbacks). Rows
@@ -322,6 +492,7 @@ export function ChartCanvas({
       }
       return [{ time, open, high, low, close, volume: parseNum(r.volume) ?? 0 }];
     });
+    cleanRowsRef.current = clean;
 
     candle.setData(
       clean.map((b) => ({
@@ -332,6 +503,10 @@ export function ChartCanvas({
         close: b.close,
       })),
     );
+
+    const closeData = clean.map((b) => ({ time: b.time as Time, value: b.close }));
+    line.setData(closeData);
+    area.setData(closeData);
 
     volume.setData(
       clean.map((b, i) => {
@@ -349,21 +524,45 @@ export function ChartCanvas({
 
   return (
     <div className="relative">
-      {hover !== null ? (
-        <div className="absolute right-2 top-2 z-10 rounded bg-white/90 px-2 py-1 text-xs tabular-nums shadow-sm">
-          <span className="text-slate-400">{hover.date}</span>
-          <span className="ml-2 font-medium text-slate-700">
-            {hover.close.toLocaleString(undefined, {
-              maximumFractionDigits: 2,
-            })}
-          </span>
-        </div>
-      ) : null}
+      {hover !== null ? <RichTooltip hover={hover} /> : null}
       <div
         ref={containerRef}
         data-testid={`price-chart-${symbol}`}
         className={containerClassName ?? "h-[340px] w-full"}
       />
+    </div>
+  );
+}
+
+function RichTooltip({ hover }: { hover: RichHoverState }): JSX.Element {
+  const fmt = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  return (
+    <div
+      className="absolute right-2 top-2 z-10 min-w-[160px] rounded bg-white/95 px-3 py-2 text-xs shadow-md"
+      data-testid="price-chart-tooltip"
+    >
+      <div className="text-slate-500">{hover.date}</div>
+      <dl className="mt-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 tabular-nums">
+        <dt className="text-slate-500">O</dt>
+        <dd>{fmt(hover.open)}</dd>
+        <dt className="text-slate-500">H</dt>
+        <dd>{fmt(hover.high)}</dd>
+        <dt className="text-slate-500">L</dt>
+        <dd>{fmt(hover.low)}</dd>
+        <dt className="text-slate-500">C</dt>
+        <dd className="font-medium text-slate-800">{fmt(hover.close)}</dd>
+        <dt className="text-slate-500">Vol</dt>
+        <dd>{fmt(hover.volume)}</dd>
+        {hover.changePct !== null ? (
+          <>
+            <dt className="text-slate-500">Δ%</dt>
+            <dd className={hover.changePct >= 0 ? "text-emerald-600" : "text-red-600"}>
+              {hover.changePct >= 0 ? "+" : ""}
+              {hover.changePct.toFixed(2)}%
+            </dd>
+          </>
+        ) : null}
+      </dl>
     </div>
   );
 }


### PR DESCRIPTION
## What

- Rich hover tooltip on PriceChart (date + OHLC + volume + %Δ-from-prior). Same shape as ChartWorkspaceCanvas so overview ↔ workspace mental model stays consistent.
- Chart type toggle: **candle** (default) / **line** / **area**, URL-synced via `?type=line|area`. All three series mount once; toggling flips `visible`.
- Log scale toggle URL-synced via `?scale=log`. Applies `mode: 1` (Logarithmic) to the right price scale.
- Whole-card drill: clicking the chart card anywhere (away from controls) navigates to `/instrument/:symbol/chart`, preserving range via the existing `?chart=` → `?range=` translation.
- Robinhood-style smooth line: Line + Area series now use `LineType.Curved` (cardinal-spline) — `lightweight-charts` enum value `2`. One-line option per series.

## Why

Operator review 2026-04-27: "Price chart, sure, we need to make these nicer, add more items and make it generally more useful". This is the operator-visible polish backlog from #585 epic — Phase 2 sub-ticket of the chart redesign, ships after the #586 chartTheme foundation.

## Conscious deviations / scope notes

- **Range list unchanged** (still `1W · 1M · 3M · 6M · 1Y · 5Y · MAX`). A TradingView/Robinhood-style table with `1D · 5D · YTD` added — each mapped to a sensible interval (1min / 5min / 1d) — lands with the intraday work. Adding 1D today without intraday data would return one daily bar = broken UX. New tickets to file after this merges: backend intraday-candle proxy, range→interval frontend wiring, live last-bar via the existing SSE quote stream, daily backfill bump 400→1830 days.
- **Pane stays semantic article when clickable.** `onCardClick` adds `onClick` + `cursor-pointer` + hover-elevate, but no `role="button"` / `tabIndex` / `aria-label`. Article contains real `<button>` descendants (PaneHeader Open, in-pane controls); promoting the article to a custom button would nest interactive controls and confuse assistive tech. Keyboard drill goes through the existing Open → button (always rendered when `onExpand` is provided). This was caught + fixed during Codex pre-push review.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test:unit` — 566/566 (added: type-toggle URL sync, log-toggle URL sync, controls swallow card-click, line/area receive close-only data, ?type=area visibility on initial render, ?scale=log mode applied on initial render, DensityGrid whole-card drill preserves range; updated: Pane no longer takes `role=button` when clickable)
- [x] `pnpm build` — bundle 679.86 kB JS / 197.35 kB gz (+3.4 kB / +0.86 kB gz vs #586 baseline; recharts still tree-shaken since not imported on any route)
- [x] Backend gates: ruff/format/pyright clean; pytest 2829 passed (no Python touched, ran for the gate)
- [x] Codex pre-push review applied — caught one BLOCKING a11y issue (article role=button nesting interactive descendants); fixed before push, also added DensityGrid card-click coverage flagged as non-blocking gap

## Linked

- Parent epic: #585
- Predecessor: #586 (chartTheme + recharts dep, merged via #597)
- Follow-ups (will file after merge): backend intraday-candle proxy, range→interval frontend wiring, live last-bar SSE, daily backfill 1830d