### PR TITLE
feat(#600): backend intraday candle proxy + cache + auth

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -6,7 +6,17 @@ Reads from:
   - coverage             (1:1 coverage tier per instrument)
   - external_identifiers (1:N provider-native identifiers per instrument)
 
-No writes. No schema changes.
+No writes (DB-side). No schema changes.
+
+**Carve-out — intraday candles (#600).** The
+``GET /instruments/{symbol}/intraday-candles`` endpoint is a
+provider-backed pass-through: it loads eToro broker credentials,
+calls the live eToro REST endpoint via ``EtoroMarketDataProvider``,
+and serves bars through an in-process TTL cache (no DB persistence).
+This is the one endpoint in this module that consumes external API
+quota and writes an audit row per request (via
+``load_credential_for_provider_use``). All other endpoints stay
+DB-only.
 """
 
 from __future__ import annotations
@@ -14,14 +24,29 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Literal
+from typing import Literal, get_args
 
+import httpx
 import psycopg
 import psycopg.rows
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from app.api.auth import require_session_or_service_token
+from app.config import settings
 from app.db import get_conn
+from app.providers.implementations.etoro import EtoroMarketDataProvider
+from app.providers.market_data import IntradayInterval
+from app.services.broker_credentials import (
+    CredentialNotFound,
+    load_credential_for_provider_use,
+)
+from app.services.intraday_candles import fetch_intraday_candles
+from app.services.operators import (
+    AmbiguousOperatorError,
+    NoOperatorError,
+    sole_operator_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -164,6 +189,48 @@ class InstrumentCandles(BaseModel):
     range: Literal["1w", "1m", "3m", "6m", "1y", "5y", "max"]  # noqa: A003
     days: int | None  # None when range="max"
     rows: list[CandleBar]
+
+
+class IntradayBarPayload(BaseModel):
+    """One intraday OHLCV bar.
+
+    ``timestamp`` is a UTC ISO-8601 datetime — distinct from
+    ``CandleBar.date`` which is YYYY-MM-DD only. Lightweight-charts
+    consumers feed ``timestamp`` straight into the time scale via
+    ``new Date(...).getTime() / 1000``.
+    """
+
+    timestamp: datetime
+    open: Decimal | None
+    high: Decimal | None
+    low: Decimal | None
+    close: Decimal | None
+    volume: int | None
+
+
+class InstrumentIntradayCandles(BaseModel):
+    """Response shape for /instruments/{symbol}/intraday-candles.
+
+    ``persisted`` is always False so the caller knows these bars are
+    not in any DB table — they came directly from the provider via the
+    in-process cache. Useful for ops dashboards and a future
+    persistence-status flag if we ever cache to disk.
+    """
+
+    symbol: str
+    interval: IntradayInterval
+    count: int
+    persisted: Literal[False] = False
+    rows: list[IntradayBarPayload]
+
+
+# Accepted interval tokens — derived from the IntradayInterval Literal
+# so this list cannot drift from the provider contract.
+_VALID_INTERVALS: frozenset[str] = frozenset(get_args(IntradayInterval))
+
+# Hard cap mirrors eToro's documented 1000-candle ceiling. Leaving a
+# small headroom so we never touch the limit.
+_MAX_INTRADAY_COUNT = 1000
 
 
 class CapabilityCellPayload(BaseModel):
@@ -654,6 +721,147 @@ def get_instrument_candles(
         range=range_,
         days=days,
         rows=bars,
+    )
+
+
+@router.get(
+    "/{symbol}/intraday-candles",
+    response_model=InstrumentIntradayCandles,
+    dependencies=[Depends(require_session_or_service_token)],
+)
+def get_instrument_intraday_candles(
+    symbol: str,
+    interval: IntradayInterval = Query(default="OneMinute"),
+    count: int = Query(default=390, ge=1, le=_MAX_INTRADAY_COUNT),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> InstrumentIntradayCandles:
+    """Provider-backed intraday OHLCV bars.
+
+    **Not** read from the local DB. Each call resolves the symbol to
+    an instrument id, loads eToro broker credentials, fetches bars at
+    the requested interval through the in-process TTL cache, and
+    returns them. Daily / longer-horizon ranges should continue to
+    use ``/candles?range=...`` which reads from ``price_daily``.
+
+    Error mapping:
+      * Unknown symbol → 404
+      * Missing eToro credentials → 503 (operator must run setup)
+      * Provider 429 (rate limit) → 503 with Retry-After
+      * Provider 5xx / network failure → 502
+
+    The frontend owns the range → (interval, count) translation
+    table. This endpoint is intentionally count-based to mirror the
+    eToro REST shape exactly.
+    """
+    if interval not in _VALID_INTERVALS:
+        # FastAPI already validates the Literal, but keep this as a
+        # belt-and-braces guard against drift between the type and
+        # the validator's accepted set.
+        raise HTTPException(status_code=400, detail=f"Unsupported interval {interval!r}")
+
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    # Symbol → instrument_id (primary-listing tiebreaker, matches
+    # the daily endpoint).
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    # Load eToro credentials. Each call writes an audit row tied to
+    # the operator and caller name, so chart-driven external spend is
+    # traceable. ``load_credential_for_provider_use`` does not commit
+    # itself; we commit the audit row before the external call so a
+    # network failure does not lose the audit trail.
+    try:
+        op_id = sole_operator_id(conn)
+    except (NoOperatorError, AmbiguousOperatorError) as exc:
+        logger.warning("intraday-candles: operator lookup failed: %s", exc)
+        raise HTTPException(status_code=503, detail="No operator configured") from exc
+
+    try:
+        api_key = load_credential_for_provider_use(
+            conn,
+            operator_id=op_id,
+            provider="etoro",
+            label="api_key",
+            environment=settings.etoro_env,
+            caller="intraday_candles_endpoint",
+        )
+        conn.commit()
+        user_key = load_credential_for_provider_use(
+            conn,
+            operator_id=op_id,
+            provider="etoro",
+            label="user_key",
+            environment=settings.etoro_env,
+            caller="intraday_candles_endpoint",
+        )
+        conn.commit()
+    except CredentialNotFound as exc:
+        logger.warning("intraday-candles: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail="eToro credentials not configured",
+        ) from exc
+
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+
+    try:
+        with EtoroMarketDataProvider(api_key=api_key, user_key=user_key, env=settings.etoro_env) as provider:
+            bars = fetch_intraday_candles(
+                provider,
+                instrument_id=instrument_id,
+                interval=interval,
+                count=count,
+            )
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        if status == 429:
+            retry_after = exc.response.headers.get("Retry-After", "30")
+            logger.warning(
+                "intraday-candles: eToro rate-limited for %s, retry-after=%s",
+                symbol_clean,
+                retry_after,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="Rate limited upstream",
+                headers={"Retry-After": retry_after},
+            ) from exc
+        logger.warning("intraday-candles: eToro returned %d for %s", status, symbol_clean)
+        raise HTTPException(status_code=502, detail="Upstream provider error") from exc
+    except httpx.RequestError as exc:
+        logger.warning("intraday-candles: network error fetching %s: %s", symbol_clean, exc)
+        raise HTTPException(status_code=502, detail="Upstream provider unreachable") from exc
+
+    return InstrumentIntradayCandles(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        interval=interval,
+        count=count,
+        rows=[
+            IntradayBarPayload(
+                timestamp=b.timestamp,
+                open=b.open,
+                high=b.high,
+                low=b.low,
+                close=b.close,
+                volume=b.volume,
+            )
+            for b in bars
+        ],
     )
 
 

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -850,7 +850,11 @@ def get_instrument_intraday_candles(
     return InstrumentIntradayCandles(
         symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
         interval=interval,
-        count=count,
+        # Echo the actual number of bars returned, not the operator's
+        # request — eToro can return fewer than `count` near market
+        # open, on thinly-traded instruments, or after a fresh listing.
+        # Callers reading `body.count` must see what they actually got.
+        count=len(bars),
         rows=[
             IntradayBarPayload(
                 timestamp=b.timestamp,

--- a/app/providers/implementations/etoro.py
+++ b/app/providers/implementations/etoro.py
@@ -8,6 +8,19 @@ field lands in SQL (``instruments``, ``price_daily``, ``quotes``,
 ``docs/review-prevention-log.md`` §"Raw payload persistence" for
 the scope-narrowed rule).
 
+**Intraday candle carve-out (#600).** ``get_intraday_candles`` is
+the one method on this class whose result is NOT mirrored to a SQL
+table. Intraday bars are ephemeral chart-UI data — they do not
+drive scoring, thesis, recommendations, orders, dividends, or tax,
+so the SQL-as-audit-trail invariant does not apply. The pass-through
+is gated by a TTL cache (``app/services/intraday_candles.py``) and
+the API endpoint is auth-gated to keep external quota traceable.
+Persisting intraday rows would expand the audit / sync surface
+without analytical value; the no-persistence design is locked at
+epic #585 and reviewed by Codex pre-implementation. This is the
+**only** sanctioned exception to the structured-fields-land-in-SQL
+rule for this provider — adding more requires reopening the design.
+
 Auth: three-header scheme (x-api-key, x-user-key, x-request-id).
 Base URL: https://public-api.etoro.com (configurable via settings.etoro_base_url).
 """

--- a/app/providers/implementations/etoro.py
+++ b/app/providers/implementations/etoro.py
@@ -26,6 +26,8 @@ from app.providers.market_data import (
     ExchangeRecord,
     InstrumentRecord,
     InstrumentTypeRecord,
+    IntradayBar,
+    IntradayInterval,
     MarketDataProvider,
     OHLCVBar,
     Quote,
@@ -176,6 +178,31 @@ class EtoroMarketDataProvider(MarketDataProvider):
         response.raise_for_status()
         raw = response.json()
         return _normalise_candles(raw)
+
+    def get_intraday_candles(
+        self,
+        instrument_id: int,
+        interval: IntradayInterval,
+        count: int,
+    ) -> list[IntradayBar]:
+        """Fetch intraday OHLCV bars at the requested interval.
+
+        Same URL family as ``get_daily_candles`` but the interval slot
+        is variable. eToro caps ``count`` at 1000 bars per request;
+        callers in eBull stay well under that for chart use (≤600).
+
+        Raw response shape mirrors the daily endpoint exactly — only
+        the bar timestamp granularity differs. We use a sibling
+        normaliser (``_normalise_intraday_candles``) that preserves the
+        time component instead of truncating to a date.
+        """
+        response = self._http.get(
+            f"/api/v1/market-data/instruments/{instrument_id}/history/candles/asc/{interval}/{count}",
+            headers=self._request_headers(),
+        )
+        response.raise_for_status()
+        raw = response.json()
+        return _normalise_intraday_candles(raw)
 
     # ------------------------------------------------------------------
     # Quotes
@@ -371,6 +398,73 @@ def _normalise_candle(item: Mapping[str, object]) -> OHLCVBar | None:
         )
     except (ValueError, ArithmeticError) as exc:
         logger.warning("Skipping malformed candle: %s — %s", item, exc)
+        return None
+
+
+def _normalise_intraday_candles(raw: object) -> list[IntradayBar]:
+    """Normalise an eToro intraday-candles response into IntradayBar list.
+
+    Same outer envelope as the daily endpoint
+    (``{ candles: [{ instrumentId, candles: [...] }] }``); each inner
+    candle carries a ``fromDate`` ISO timestamp with time component
+    instead of date-only.
+    """
+    if not isinstance(raw, dict):
+        raise ValueError(f"Expected dict from eToro candles endpoint, got {type(raw)}")
+
+    outer: list[object] = raw.get("candles") or []
+
+    bars: list[IntradayBar] = []
+    for group in outer:
+        if not isinstance(group, dict):
+            continue
+        inner: list[object] = group.get("candles") or []
+        for item in inner:
+            if not isinstance(item, dict):
+                continue
+            bar = _normalise_intraday_candle(item)
+            if bar is not None:
+                bars.append(bar)
+    return bars
+
+
+def _normalise_intraday_candle(item: Mapping[str, object]) -> IntradayBar | None:
+    """Map a single eToro intraday candle dict to an IntradayBar.
+
+    Returns None and logs a warning on missing required fields rather
+    than raising — a single malformed bar should not poison a 390-bar
+    series. Decimal precision preserved via ``Decimal(str(...))``.
+    """
+    raw_date = item.get("fromDate")
+    raw_open = item.get("open")
+    raw_high = item.get("high")
+    raw_low = item.get("low")
+    raw_close = item.get("close")
+
+    if any(v is None or v == "" for v in (raw_date, raw_open, raw_high, raw_low, raw_close)):
+        logger.warning("Skipping intraday candle missing required fields: %s", item)
+        return None
+
+    try:
+        # eToro uses ISO timestamps with optional `Z` suffix; .fromisoformat
+        # handles `2026-04-27T14:30:00+00:00` natively and accepts the
+        # `Z` form on Python 3.11+. Coerce to UTC.
+        ts_text = str(raw_date).replace("Z", "+00:00")
+        ts = datetime.fromisoformat(ts_text)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        else:
+            ts = ts.astimezone(UTC)
+        return IntradayBar(
+            timestamp=ts,
+            open=Decimal(str(raw_open)),
+            high=Decimal(str(raw_high)),
+            low=Decimal(str(raw_low)),
+            close=Decimal(str(raw_close)),
+            volume=_int_or_none(item.get("volume")),
+        )
+    except (ValueError, ArithmeticError) as exc:
+        logger.warning("Skipping malformed intraday candle: %s — %s", item, exc)
         return None
 
 

--- a/app/providers/market_data.py
+++ b/app/providers/market_data.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Literal
 
 
 @dataclass(frozen=True)
@@ -72,6 +73,48 @@ class OHLCVBar:
     volume: int | None
 
 
+# Intraday candle interval tokens accepted by eToro's history endpoint.
+# Mirrors the URL slot in /history/candles/{direction}/{interval}/{count}.
+#
+# **Sub-day only.** Daily / weekly / monthly views read from `price_daily`
+# via the existing `/candles?range=...` endpoint so chart freshness is
+# served by the persisted, scored series — not a parallel live-fetch
+# path that would shadow it. If a long-horizon range needs a finer
+# series than `price_daily` provides, the right move is to deepen the
+# daily backfill (see #603), not to widen this Literal.
+#
+# Token set matches the documented eToro intraday options
+# (docs/etoro-api-reference.md §candles).
+IntradayInterval = Literal[
+    "OneMinute",
+    "FiveMinutes",
+    "TenMinutes",
+    "FifteenMinutes",
+    "ThirtyMinutes",
+    "OneHour",
+    "FourHours",
+]
+
+
+@dataclass(frozen=True)
+class IntradayBar:
+    """A single intraday OHLCV candle.
+
+    Distinct from `OHLCVBar` because intraday bars carry a full UTC
+    timestamp (bar-open instant) rather than a calendar date. Caller is
+    expected to know the interval so it can compute bar-close from
+    `timestamp + interval`. No DB persistence — these flow live from
+    provider through cache to the chart and never hit `price_daily`.
+    """
+
+    timestamp: datetime
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: int | None
+
+
 @dataclass(frozen=True)
 class Quote:
     """A current best-bid/ask quote."""
@@ -116,6 +159,30 @@ class MarketDataProvider(ABC):
         days than requested due to weekends and holidays. The eToro
         candle endpoint caps at 1000 candles per request; the current
         400-day lookback is well within that limit.
+        """
+
+    @abstractmethod
+    def get_intraday_candles(
+        self,
+        instrument_id: int,
+        interval: IntradayInterval,
+        count: int,
+    ) -> list[IntradayBar]:
+        """Return intraday OHLCV bars for an instrument.
+
+        The provider chooses how many bars to return up to ``count``.
+        Caller must supply both ``interval`` and ``count`` because the
+        underlying eToro endpoint is count-based, not date-range-based.
+
+        Bars carry full UTC timestamps (bar-open instant) and are
+        ordered oldest-first. The still-forming current bar may or may
+        not be included — implementations should pass through whatever
+        the provider returns; consumers that need only completed bars
+        should filter on ``timestamp + interval <= now``.
+
+        Returns an empty list if the instrument has no intraday data.
+        Raises on transport/auth failures so the API layer can surface
+        429s as 503s with a Retry-After hint.
         """
 
     @abstractmethod

--- a/app/services/intraday_candles.py
+++ b/app/services/intraday_candles.py
@@ -1,0 +1,233 @@
+"""Intraday candle fetcher with in-process TTL cache.
+
+Wraps a ``MarketDataProvider`` so chart consumers can fetch sub-day
+candles on demand without DB persistence. Daily candles continue to
+flow through ``app/services/market_data.py`` and ``price_daily`` —
+this module is for the timeframes the daily refresh job does not
+cover (#600).
+
+Design contract:
+
+  * No DB persistence. Bars live only in this process's cache.
+  * Cache key is ``(instrument_id, interval, count)``. Two pages
+    asking for the same window within TTL share one provider call.
+  * TTL is interval-aware: shorter for sub-hour intervals (a 1min
+    chart should refresh fast); longer for daily/weekly/monthly
+    (those barely change intra-session).
+  * Eviction is lazy on lookup; we don't run a background sweeper.
+    The cache is bounded by ``_MAX_ENTRIES`` so a misbehaving caller
+    cannot OOM the worker.
+
+Rate-limit surfacing: the wrapper does NOT translate eToro 429
+responses on its own — callers (the API layer) catch
+``httpx.HTTPStatusError`` and map to a 503 with ``Retry-After``
+themselves. This keeps the cache layer pure.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+
+from app.providers.market_data import IntradayBar, IntradayInterval, MarketDataProvider
+
+# Hard cap on cached entries. Each entry is one chart-window worth
+# of bars (≤1000 IntradayBar dataclass instances ≈ a few hundred KB).
+# 256 entries ≈ ~100MB worst case — comfortably below worker memory.
+_MAX_ENTRIES = 256
+
+# TTL by interval. Sub-15-min intervals refresh fast so a stale tick
+# isn't visible for long; longer intraday intervals (≥30min) tolerate a
+# few minutes of staleness because the next bar is itself minutes away.
+_TTL_SHORT_S = 30.0
+_TTL_LONG_S = 180.0
+
+_SHORT_TTL_INTERVALS: frozenset[IntradayInterval] = frozenset(
+    {"OneMinute", "FiveMinutes", "TenMinutes", "FifteenMinutes"}
+)
+
+
+def _ttl_for(interval: IntradayInterval) -> float:
+    return _TTL_SHORT_S if interval in _SHORT_TTL_INTERVALS else _TTL_LONG_S
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    bars: tuple[IntradayBar, ...]
+    expires_at: float
+
+
+class IntradayCandleCache:
+    """LRU + TTL cache for intraday candle windows.
+
+    Thread-safe: a lock guards the OrderedDict against concurrent
+    mutation from multiple uvicorn worker threads. Lookup is
+    O(1) on the dict; LRU promotion uses ``move_to_end``.
+    """
+
+    def __init__(self, max_entries: int = _MAX_ENTRIES) -> None:
+        self._max_entries = max_entries
+        self._lock = threading.Lock()
+        self._entries: OrderedDict[tuple[int, IntradayInterval, int], _CacheEntry] = OrderedDict()
+        # Singleflight: per-key inflight Event so concurrent misses
+        # collapse to one provider call. Reader threads block on the
+        # Event until the leader's `put` lands, then re-read the
+        # cache. Mirrors the pattern used elsewhere for fan-out
+        # protection.
+        self._inflight: dict[tuple[int, IntradayInterval, int], threading.Event] = {}
+
+    def get(self, instrument_id: int, interval: IntradayInterval, count: int) -> tuple[IntradayBar, ...] | None:
+        """Return cached bars if fresh, else None."""
+        key = (instrument_id, interval, count)
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return None
+            if entry.expires_at <= time.monotonic():
+                # Expired: drop and miss. Do NOT return stale bars
+                # even with a "is-stale" flag — callers are chart
+                # consumers and would have to re-implement freshness
+                # logic themselves.
+                self._entries.pop(key, None)
+                return None
+            self._entries.move_to_end(key)
+            return entry.bars
+
+    def put(
+        self,
+        instrument_id: int,
+        interval: IntradayInterval,
+        count: int,
+        bars: list[IntradayBar],
+    ) -> None:
+        key = (instrument_id, interval, count)
+        ttl = _ttl_for(interval)
+        entry = _CacheEntry(
+            bars=tuple(bars),
+            expires_at=time.monotonic() + ttl,
+        )
+        with self._lock:
+            self._entries[key] = entry
+            self._entries.move_to_end(key)
+            while len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)
+
+    def clear(self) -> None:
+        """Reset the cache. Used by tests."""
+        with self._lock:
+            self._entries.clear()
+            # Wake any waiters so a test that resets between cases
+            # doesn't deadlock a thread mid-singleflight.
+            for event in self._inflight.values():
+                event.set()
+            self._inflight.clear()
+
+    def claim_or_wait(
+        self,
+        instrument_id: int,
+        interval: IntradayInterval,
+        count: int,
+        timeout_s: float = 30.0,
+    ) -> bool:
+        """Coordinate a singleflight fetch for ``(id, interval, count)``.
+
+        Returns True if the caller is the **leader** — it must perform
+        the provider fetch and call ``release_inflight`` once done.
+        Returns False if another thread is already fetching this key;
+        the caller blocks up to ``timeout_s`` waiting for that leader
+        to finish, then returns and the caller re-reads the cache.
+
+        On timeout we still return False — the leader may be wedged,
+        but a follower's only safe option is to fall through and let
+        its own request go to the provider. Better a duplicate fetch
+        than a stuck request.
+        """
+        key = (instrument_id, interval, count)
+        with self._lock:
+            existing = self._inflight.get(key)
+            if existing is None:
+                # Leader: install our event, others will wait on it.
+                self._inflight[key] = threading.Event()
+                return True
+        existing.wait(timeout=timeout_s)
+        return False
+
+    def release_inflight(self, instrument_id: int, interval: IntradayInterval, count: int) -> None:
+        """Signal followers that the leader's fetch is complete.
+
+        Always paired with a successful ``claim_or_wait`` returning
+        True. Idempotent — a second release on a missing event is a
+        no-op so callers can release in `finally` without checking.
+        """
+        key = (instrument_id, interval, count)
+        with self._lock:
+            event = self._inflight.pop(key, None)
+        if event is not None:
+            event.set()
+
+
+# Process-global cache instance. Stored on ``app.state`` would be
+# cleaner for tests, but every other in-process service in eBull
+# (quote_stream.QuoteBus etc.) already uses module-globals plus a
+# `clear` hook for test isolation.
+_GLOBAL_CACHE = IntradayCandleCache()
+
+
+def get_intraday_cache() -> IntradayCandleCache:
+    return _GLOBAL_CACHE
+
+
+def fetch_intraday_candles(
+    provider: MarketDataProvider,
+    *,
+    instrument_id: int,
+    interval: IntradayInterval,
+    count: int,
+    cache: IntradayCandleCache | None = None,
+) -> list[IntradayBar]:
+    """Fetch intraday candles via cache, falling through to provider.
+
+    Cache hit returns the cached tuple (converted back to a list so
+    callers retain the previous mutable-list contract).
+
+    Cache miss enters a singleflight: the first miss for a key fetches
+    from the provider, stores the result, and wakes any waiting
+    followers. Followers re-check the cache after waking and fall
+    through to a fresh fetch only if the leader's fetch failed (so a
+    transient leader failure does not cascade into stuck followers).
+
+    Provider failures propagate to whichever thread owns the leader
+    slot. The cache only stores successful fetches.
+    """
+    cache = cache or _GLOBAL_CACHE
+    cached = cache.get(instrument_id, interval, count)
+    if cached is not None:
+        return list(cached)
+
+    is_leader = cache.claim_or_wait(instrument_id, interval, count)
+    if not is_leader:
+        # Follower: leader has already finished (or timed out). Re-read.
+        cached = cache.get(instrument_id, interval, count)
+        if cached is not None:
+            return list(cached)
+        # Leader's fetch failed or timed out. Fall through to our own
+        # fetch — duplicate work in the rare wedged-leader case is
+        # better than returning a misleading empty list.
+        is_leader = cache.claim_or_wait(instrument_id, interval, count)
+        if not is_leader:
+            # Yet another thread became leader between our re-read and
+            # our re-claim. Re-read once more; if still missing, accept
+            # the duplicate-fetch fallback by going to provider directly.
+            cached = cache.get(instrument_id, interval, count)
+            if cached is not None:
+                return list(cached)
+            return provider.get_intraday_candles(instrument_id, interval, count)
+
+    try:
+        bars = provider.get_intraday_candles(instrument_id, interval, count)
+        cache.put(instrument_id, interval, count, bars)
+        return bars
+    finally:
+        cache.release_inflight(instrument_id, interval, count)

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -546,6 +546,7 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `_fetch_company_facts` called `resp.raise_for_status()` before `_persist_raw()`, so non-404 HTTP errors (429, 503) raised before the raw payload was written to disk, losing diagnostic data.
 - Prevention: In provider HTTP methods, always call `_persist_raw()` before `resp.raise_for_status()`. The persist call captures the response body for auditability regardless of status code.
 - Enforced in: this prevention log
+- Carve-out (#600): ephemeral provider methods that explicitly do **not** feed any SQL audit trail and whose data does not drive scoring / thesis / recommendations / orders / dividends / tax do not require raw-payload persistence. Such methods must (a) be documented as a carve-out in the provider's class docstring naming the locked design ticket, (b) keep the data process-local (in-process cache OK, disk OK only as a debug aid), (c) be auth-gated at the API layer when they consume external quota. The first such carve-out is `EtoroMarketDataProvider.get_intraday_candles` (chart UI). Adding another carve-out requires reopening the design with an architecture-level review (Codex sign-off + epic update), not a unilateral provider-method addition.
 
 ---
 

--- a/tests/test_api_intraday_candles.py
+++ b/tests/test_api_intraday_candles.py
@@ -1,0 +1,271 @@
+"""Tests for GET /instruments/{symbol}/intraday-candles (#600).
+
+The endpoint resolves a symbol, loads eToro creds, and proxies to
+the live eToro REST endpoint via the in-process cache. We mock the
+cred loader, the provider, and the DB cursor so the unit test stays
+isolated.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.providers.market_data import IntradayBar
+
+
+@pytest.fixture
+def client() -> TestClient:
+    # tests/conftest.py installs a global no-op for
+    # `require_session_or_service_token`, so the new authed endpoint
+    # is reachable in tests without per-suite auth setup.
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> Iterator[None]:
+    from app.services.intraday_candles import get_intraday_cache
+
+    get_intraday_cache().clear()
+    yield
+    get_intraday_cache().clear()
+
+
+def _make_cursor(row: object) -> MagicMock:
+    cur = MagicMock()
+    cur.__enter__.return_value = cur
+    cur.__exit__.return_value = None
+    cur.fetchone.return_value = row
+    cur.fetchall.return_value = []
+    return cur
+
+
+def _mock_conn_with_lookup(row: object) -> MagicMock:
+    conn = MagicMock()
+    conn.cursor.return_value = _make_cursor(row)
+    return conn
+
+
+def _bar(close: str = "100.5") -> IntradayBar:
+    return IntradayBar(
+        timestamp=datetime(2026, 4, 27, 14, 30, tzinfo=UTC),
+        open=Decimal(close),
+        high=Decimal(close),
+        low=Decimal(close),
+        close=Decimal(close),
+        volume=1000,
+    )
+
+
+_OPERATOR_ID = UUID("00000000-0000-0000-0000-000000000001")
+_DEFAULT_CRED_SECRETS = ("api-key-value", "user-key-value")
+
+
+def test_intraday_unknown_symbol_returns_404(client: TestClient) -> None:
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield _mock_conn_with_lookup(None)
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/NOTREAL/intraday-candles?interval=OneMinute&count=100")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+    assert resp.status_code == 404
+
+
+def test_intraday_invalid_interval_returns_422(client: TestClient) -> None:
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield MagicMock()
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/AAPL/intraday-candles?interval=BogusInterval&count=100")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+    assert resp.status_code == 422
+
+
+def test_intraday_count_above_cap_returns_422(client: TestClient) -> None:
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield MagicMock()
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        resp = client.get("/instruments/AAPL/intraday-candles?interval=OneMinute&count=99999")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+    assert resp.status_code == 422
+
+
+def test_intraday_missing_credentials_returns_503(client: TestClient) -> None:
+    from app.db import get_conn
+    from app.services.broker_credentials import CredentialNotFound
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield _mock_conn_with_lookup({"instrument_id": 42, "symbol": "AAPL"})
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        with (
+            patch("app.api.instruments.sole_operator_id", return_value=_OPERATOR_ID),
+            patch(
+                "app.api.instruments.load_credential_for_provider_use",
+                side_effect=CredentialNotFound("api_key not configured"),
+            ),
+        ):
+            resp = client.get("/instruments/AAPL/intraday-candles?interval=OneMinute&count=100")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+    assert resp.status_code == 503
+    assert "credentials" in resp.text.lower()
+
+
+def test_intraday_happy_path_returns_bars_with_iso_timestamps(client: TestClient) -> None:
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield _mock_conn_with_lookup({"instrument_id": 42, "symbol": "AAPL"})
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        with (
+            patch("app.api.instruments.sole_operator_id", return_value=_OPERATOR_ID),
+            patch(
+                "app.api.instruments.load_credential_for_provider_use",
+                side_effect=list(_DEFAULT_CRED_SECRETS),
+            ),
+            patch("app.api.instruments.EtoroMarketDataProvider") as MockProv,
+        ):
+            mock_provider = MagicMock()
+            mock_provider.__enter__.return_value = mock_provider
+            mock_provider.get_intraday_candles.return_value = [_bar("180.50")]
+            MockProv.return_value = mock_provider
+            resp = client.get(
+                "/instruments/AAPL/intraday-candles?interval=OneMinute&count=100",
+            )
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["symbol"] == "AAPL"
+    assert body["interval"] == "OneMinute"
+    assert body["count"] == 100
+    assert body["persisted"] is False
+    assert len(body["rows"]) == 1
+    # Timestamp is ISO-8601 with timezone — frontend parses via Date.
+    assert body["rows"][0]["timestamp"].startswith("2026-04-27T14:30:00")
+    assert body["rows"][0]["close"] == "180.50"
+
+
+def test_intraday_rate_limit_returns_503_with_retry_after(client: TestClient) -> None:
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield _mock_conn_with_lookup({"instrument_id": 42, "symbol": "AAPL"})
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        with (
+            patch("app.api.instruments.sole_operator_id", return_value=_OPERATOR_ID),
+            patch(
+                "app.api.instruments.load_credential_for_provider_use",
+                side_effect=list(_DEFAULT_CRED_SECRETS),
+            ),
+            patch("app.api.instruments.EtoroMarketDataProvider") as MockProv,
+        ):
+            mock_provider = MagicMock()
+            mock_provider.__enter__.return_value = mock_provider
+            response_429 = httpx.Response(429, headers={"Retry-After": "60"}, request=httpx.Request("GET", "https://x"))
+            mock_provider.get_intraday_candles.side_effect = httpx.HTTPStatusError(
+                "rate limited", request=response_429.request, response=response_429
+            )
+            MockProv.return_value = mock_provider
+            resp = client.get(
+                "/instruments/AAPL/intraday-candles?interval=OneMinute&count=100",
+            )
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 503
+    assert resp.headers.get("retry-after") == "60"
+
+
+def test_intraday_provider_5xx_returns_502(client: TestClient) -> None:
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield _mock_conn_with_lookup({"instrument_id": 42, "symbol": "AAPL"})
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        with (
+            patch("app.api.instruments.sole_operator_id", return_value=_OPERATOR_ID),
+            patch(
+                "app.api.instruments.load_credential_for_provider_use",
+                side_effect=list(_DEFAULT_CRED_SECRETS),
+            ),
+            patch("app.api.instruments.EtoroMarketDataProvider") as MockProv,
+        ):
+            mock_provider = MagicMock()
+            mock_provider.__enter__.return_value = mock_provider
+            response_500 = httpx.Response(500, request=httpx.Request("GET", "https://x"))
+            mock_provider.get_intraday_candles.side_effect = httpx.HTTPStatusError(
+                "server error", request=response_500.request, response=response_500
+            )
+            MockProv.return_value = mock_provider
+            resp = client.get(
+                "/instruments/AAPL/intraday-candles?interval=OneMinute&count=100",
+            )
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 502
+
+
+def test_intraday_second_call_within_ttl_skips_provider(client: TestClient) -> None:
+    """Two successive requests should hit the provider once, not twice."""
+    from app.db import get_conn
+
+    def _db_conn() -> Iterator[MagicMock]:
+        yield _mock_conn_with_lookup({"instrument_id": 42, "symbol": "AAPL"})
+
+    app.dependency_overrides[get_conn] = _db_conn
+    try:
+        with (
+            patch("app.api.instruments.sole_operator_id", return_value=_OPERATOR_ID),
+            # Cred patch returns 4 secrets — 2 per request × 2 requests.
+            patch(
+                "app.api.instruments.load_credential_for_provider_use",
+                side_effect=["api-key", "user-key", "api-key", "user-key"],
+            ),
+            patch("app.api.instruments.EtoroMarketDataProvider") as MockProv,
+        ):
+            mock_provider = MagicMock()
+            mock_provider.__enter__.return_value = mock_provider
+            mock_provider.get_intraday_candles.return_value = [_bar()]
+            MockProv.return_value = mock_provider
+
+            r1 = client.get("/instruments/AAPL/intraday-candles?interval=OneMinute&count=100")
+            r2 = client.get("/instruments/AAPL/intraday-candles?interval=OneMinute&count=100")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    # Provider hit once across the two requests — second served from cache.
+    assert mock_provider.get_intraday_candles.call_count == 1

--- a/tests/test_api_intraday_candles.py
+++ b/tests/test_api_intraday_candles.py
@@ -164,7 +164,9 @@ def test_intraday_happy_path_returns_bars_with_iso_timestamps(client: TestClient
     body = resp.json()
     assert body["symbol"] == "AAPL"
     assert body["interval"] == "OneMinute"
-    assert body["count"] == 100
+    # `count` reflects bars actually returned, not the request — the
+    # provider returned 1 bar even though we asked for 100.
+    assert body["count"] == 1
     assert body["persisted"] is False
     assert len(body["rows"]) == 1
     # Timestamp is ISO-8601 with timezone — frontend parses via Date.

--- a/tests/test_intraday_candle_cache.py
+++ b/tests/test_intraday_candle_cache.py
@@ -1,0 +1,175 @@
+"""Tests for the in-process intraday candle cache (#600)."""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.providers.market_data import IntradayBar
+from app.services.intraday_candles import (
+    IntradayCandleCache,
+    fetch_intraday_candles,
+)
+
+
+def _bar(ts_iso: str, close: str = "100.0") -> IntradayBar:
+    return IntradayBar(
+        timestamp=datetime.fromisoformat(ts_iso).replace(tzinfo=UTC),
+        open=Decimal(close),
+        high=Decimal(close),
+        low=Decimal(close),
+        close=Decimal(close),
+        volume=1000,
+    )
+
+
+class TestIntradayCandleCache:
+    def test_get_returns_none_on_miss(self) -> None:
+        cache = IntradayCandleCache()
+        assert cache.get(1, "OneMinute", 100) is None
+
+    def test_put_then_get_returns_stored_bars(self) -> None:
+        cache = IntradayCandleCache()
+        bars = [_bar("2026-04-27T14:30:00")]
+        cache.put(1, "OneMinute", 100, bars)
+        result = cache.get(1, "OneMinute", 100)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].close == Decimal("100.0")
+
+    def test_cache_keyed_on_all_three_dimensions(self) -> None:
+        cache = IntradayCandleCache()
+        cache.put(1, "OneMinute", 100, [_bar("2026-04-27T14:30:00", "1")])
+        cache.put(2, "OneMinute", 100, [_bar("2026-04-27T14:30:00", "2")])
+        cache.put(1, "FiveMinutes", 100, [_bar("2026-04-27T14:30:00", "3")])
+        cache.put(1, "OneMinute", 200, [_bar("2026-04-27T14:30:00", "4")])
+
+        assert cache.get(1, "OneMinute", 100)[0].close == Decimal("1")  # type: ignore[index]
+        assert cache.get(2, "OneMinute", 100)[0].close == Decimal("2")  # type: ignore[index]
+        assert cache.get(1, "FiveMinutes", 100)[0].close == Decimal("3")  # type: ignore[index]
+        assert cache.get(1, "OneMinute", 200)[0].close == Decimal("4")  # type: ignore[index]
+
+    def test_expired_entry_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Put a bar at t=0, advance clock past the 30s TTL, get returns None.
+        clock = [1000.0]
+        monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+
+        cache = IntradayCandleCache()
+        cache.put(1, "OneMinute", 100, [_bar("2026-04-27T14:30:00")])
+        assert cache.get(1, "OneMinute", 100) is not None
+
+        clock[0] += 30.1
+        assert cache.get(1, "OneMinute", 100) is None
+
+    def test_long_ttl_for_longer_intraday_interval(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Hourly+ uses long-TTL (180s) — verify a 60s skip does not expire it.
+        clock = [1000.0]
+        monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+
+        cache = IntradayCandleCache()
+        cache.put(1, "OneHour", 100, [_bar("2026-04-27T14:30:00")])
+        clock[0] += 60.0
+        assert cache.get(1, "OneHour", 100) is not None
+
+    def test_lru_evicts_oldest_when_over_capacity(self) -> None:
+        cache = IntradayCandleCache(max_entries=2)
+        cache.put(1, "OneMinute", 100, [_bar("2026-04-27T14:30:00", "1")])
+        cache.put(2, "OneMinute", 100, [_bar("2026-04-27T14:30:00", "2")])
+        cache.put(3, "OneMinute", 100, [_bar("2026-04-27T14:30:00", "3")])
+
+        # Oldest (instrument 1) evicted; newer two remain.
+        assert cache.get(1, "OneMinute", 100) is None
+        assert cache.get(2, "OneMinute", 100) is not None
+        assert cache.get(3, "OneMinute", 100) is not None
+
+    def test_get_promotes_lru_recency(self) -> None:
+        cache = IntradayCandleCache(max_entries=2)
+        cache.put(1, "OneMinute", 100, [_bar("2026-04-27T14:30:00", "1")])
+        cache.put(2, "OneMinute", 100, [_bar("2026-04-27T14:30:00", "2")])
+        # Touch entry 1 — promote to most-recent.
+        assert cache.get(1, "OneMinute", 100) is not None
+        # Insert a third — entry 2 evicts (it is now LRU), not entry 1.
+        cache.put(3, "OneMinute", 100, [_bar("2026-04-27T14:30:00", "3")])
+        assert cache.get(1, "OneMinute", 100) is not None
+        assert cache.get(2, "OneMinute", 100) is None
+        assert cache.get(3, "OneMinute", 100) is not None
+
+
+class TestFetchIntradayCandles:
+    def test_first_call_invokes_provider_subsequent_call_hits_cache(self) -> None:
+        cache = IntradayCandleCache()
+        bars = [_bar("2026-04-27T14:30:00")]
+        provider = MagicMock()
+        provider.get_intraday_candles.return_value = bars
+
+        result1 = fetch_intraday_candles(provider, instrument_id=1, interval="OneMinute", count=100, cache=cache)
+        result2 = fetch_intraday_candles(provider, instrument_id=1, interval="OneMinute", count=100, cache=cache)
+
+        assert result1 == bars
+        assert result2 == bars
+        provider.get_intraday_candles.assert_called_once_with(1, "OneMinute", 100)
+
+    def test_provider_error_does_not_populate_cache(self) -> None:
+        cache = IntradayCandleCache()
+        provider = MagicMock()
+        provider.get_intraday_candles.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            fetch_intraday_candles(provider, instrument_id=1, interval="OneMinute", count=100, cache=cache)
+        # Subsequent call retries the provider; failed fetch is not cached.
+        provider.get_intraday_candles.side_effect = None
+        provider.get_intraday_candles.return_value = [_bar("2026-04-27T14:30:00")]
+        result = fetch_intraday_candles(provider, instrument_id=1, interval="OneMinute", count=100, cache=cache)
+        assert len(result) == 1
+        assert provider.get_intraday_candles.call_count == 2
+
+    def test_singleflight_collapses_concurrent_misses_to_one_provider_call(self) -> None:
+        """Two threads racing on the same key must hit the provider once."""
+        cache = IntradayCandleCache()
+        provider_started = threading.Event()
+        leader_can_finish = threading.Event()
+        provider_calls = 0
+        provider_lock = threading.Lock()
+
+        def slow_fetch(*_args: object, **_kwargs: object) -> list[IntradayBar]:
+            nonlocal provider_calls
+            with provider_lock:
+                provider_calls += 1
+            provider_started.set()
+            # Block the leader until the follower has had a chance to
+            # enter the singleflight wait. Bounded wait so a buggy test
+            # cannot hang indefinitely.
+            leader_can_finish.wait(timeout=5.0)
+            return [_bar("2026-04-27T14:30:00")]
+
+        provider = MagicMock()
+        provider.get_intraday_candles.side_effect = slow_fetch
+
+        results: list[list[IntradayBar]] = []
+
+        def call() -> None:
+            results.append(
+                fetch_intraday_candles(provider, instrument_id=1, interval="OneMinute", count=100, cache=cache)
+            )
+
+        leader = threading.Thread(target=call)
+        leader.start()
+        # Wait for the leader to enter the provider so the follower
+        # cannot win the leadership election.
+        assert provider_started.wait(timeout=5.0)
+        follower = threading.Thread(target=call)
+        follower.start()
+        # Give the follower a beat to enter `claim_or_wait` and block.
+        time.sleep(0.05)
+        leader_can_finish.set()
+        leader.join(timeout=5.0)
+        follower.join(timeout=5.0)
+
+        assert provider_calls == 1
+        assert len(results) == 2
+        assert all(len(r) == 1 for r in results)

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -20,6 +20,8 @@ from app.providers.implementations.etoro import (
     _normalise_candles,
     _normalise_instrument,
     _normalise_instruments,
+    _normalise_intraday_candle,
+    _normalise_intraday_candles,
     _normalise_rate,
     _normalise_rates,
 )
@@ -246,6 +248,92 @@ class TestNormaliseCandles:
             ]
         }
         bars = _normalise_candles(raw)
+        assert len(bars) == 1
+
+
+# ---------------------------------------------------------------------------
+# Intraday candle normalisation (#600)
+# ---------------------------------------------------------------------------
+
+
+_FIXTURE_INTRADAY_CANDLE = {
+    "fromDate": "2026-04-27T14:30:00Z",
+    "open": "180.00",
+    "high": "180.50",
+    "low": "179.80",
+    "close": "180.20",
+    "volume": "12345",
+}
+
+
+class TestNormaliseIntradayCandle:
+    def test_valid_intraday_candle_keeps_time(self) -> None:
+        bar = _normalise_intraday_candle(_FIXTURE_INTRADAY_CANDLE)
+        assert bar is not None
+        assert bar.timestamp == datetime(2026, 4, 27, 14, 30, tzinfo=UTC)
+        assert bar.open == Decimal("180.00")
+        assert bar.close == Decimal("180.20")
+        assert bar.volume == 12345
+
+    def test_iso_timestamp_with_offset_normalised_to_utc(self) -> None:
+        item = {**_FIXTURE_INTRADAY_CANDLE, "fromDate": "2026-04-27T16:30:00+02:00"}
+        bar = _normalise_intraday_candle(item)
+        assert bar is not None
+        # +02:00 at 16:30 == 14:30 UTC
+        assert bar.timestamp == datetime(2026, 4, 27, 14, 30, tzinfo=UTC)
+
+    def test_missing_close_returns_none(self) -> None:
+        item = {k: v for k, v in _FIXTURE_INTRADAY_CANDLE.items() if k != "close"}
+        assert _normalise_intraday_candle(item) is None
+
+    def test_empty_string_timestamp_returns_none(self) -> None:
+        item = {**_FIXTURE_INTRADAY_CANDLE, "fromDate": ""}
+        assert _normalise_intraday_candle(item) is None
+
+    def test_malformed_timestamp_returns_none(self) -> None:
+        item = {**_FIXTURE_INTRADAY_CANDLE, "fromDate": "not-a-datetime"}
+        assert _normalise_intraday_candle(item) is None
+
+
+class TestNormaliseIntradayCandles:
+    def test_nested_response_shape(self) -> None:
+        raw = {
+            "candles": [
+                {
+                    "instrumentId": 1001,
+                    "candles": [
+                        _FIXTURE_INTRADAY_CANDLE,
+                        {**_FIXTURE_INTRADAY_CANDLE, "fromDate": "2026-04-27T14:31:00Z"},
+                    ],
+                }
+            ]
+        }
+        bars = _normalise_intraday_candles(raw)
+        assert len(bars) == 2
+        assert bars[0].timestamp.minute == 30
+        assert bars[1].timestamp.minute == 31
+
+    def test_empty_list(self) -> None:
+        assert _normalise_intraday_candles({"candles": []}) == []
+
+    def test_non_dict_raises(self) -> None:
+        with pytest.raises(ValueError, match="Expected dict"):
+            _normalise_intraday_candles(["not", "a", "dict"])
+
+    def test_bad_items_skipped(self) -> None:
+        raw = {
+            "candles": [
+                {
+                    "instrumentId": 1001,
+                    "candles": [
+                        _FIXTURE_INTRADAY_CANDLE,
+                        {"fromDate": "2026-04-27T14:31:00Z"},  # missing OHLC
+                        "not a dict",
+                    ],
+                }
+            ]
+        }
+        bars = _normalise_intraday_candles(raw)
         assert len(bars) == 1
 
 


### PR DESCRIPTION
## What

- New `GET /instruments/{symbol}/intraday-candles?interval=...&count=...` — provider-backed pass-through for sub-day OHLCV, no DB persistence.
- `IntradayBar` + `IntradayInterval` Literal added to the provider interface (sub-day tokens only: 1m / 5m / 10m / 15m / 30m / 1h / 4h).
- `EtoroMarketDataProvider.get_intraday_candles` hits the same URL family as the daily endpoint with a variable interval slot. New `_normalise_intraday_candle` preserves the timestamp.
- `app/services/intraday_candles.py` — bounded LRU + TTL cache (30s for ≤15m, 180s for ≥30m) with per-key singleflight so concurrent misses collapse to one provider call.
- Endpoint maps eToro 429 → 503 with `Retry-After`; 5xx / network → 502; missing creds → 503. Auth-gated via `require_session_or_service_token` to match other quota-consuming surfaces.

## Why

Operator-requested intraday charts (#585 epic). Long-horizon-fund posture rules out persisting another candle table — pass-through cache satisfies the chart UX without bloating the scoring/thesis data surface.

## Conscious deviations

- Endpoint lives on the existing `/instruments` router instead of a dedicated live-data router. Carve-out documented in the module docstring; keeps the URL space tied to the symbol resource. Codex pre-push agreed this is acceptable once the auth gate was added.
- Daily / weekly / monthly intervals deliberately **excluded** from `IntradayInterval`. They would let callers bypass `price_daily`. The frontend's range table (#601) sends 1y/5y/max through the existing daily endpoint; only short ranges (1d/5d/1m/3m/6m) reach the proxy.
- Frontend wiring is NOT in this PR — separate ticket #601. This PR ships the backend contract only so #601 can review against a stable shape.

## Test plan

- [x] `uv run ruff check .` / `ruff format --check .` / `pyright` clean
- [x] `uv run pytest -q` — 2856 passed (was 2829 pre-#600)
- [x] New: cache TTL boundary, LRU eviction, singleflight collapses concurrent misses to one provider call
- [x] New: endpoint happy path, unknown symbol → 404, invalid interval → 422, count cap → 422, missing creds → 503, 429 → 503+Retry-After, 5xx → 502, second request within TTL skips provider
- [x] New: `_normalise_intraday_candle` valid / with-offset / missing-fields / malformed-timestamp paths
- [x] Codex pre-push review: dropped daily-tier intervals from the Literal, added singleflight, added auth gate

## Linked

Parent: #585
Predecessors landed: #586 (theme + recharts), #587 (PriceChart polish)
Successor: #601 (frontend range→interval wiring), #602 (live last-bar via SSE)
Related: #603 (daily backfill 1830d, runs in parallel)