### PR TITLE
data(#603): bump price_daily default backfill 400 → 1000 + one-shot deepening script

### DIFF
--- a/app/providers/market_data.py
+++ b/app/providers/market_data.py
@@ -154,11 +154,12 @@ class MarketDataProvider(ABC):
 
         Ordering: oldest-first.
 
-        lookback_days is a hint, not a guarantee. The provider returns up
-        to that many trading days of data, which may be fewer calendar
-        days than requested due to weekends and holidays. The eToro
-        candle endpoint caps at 1000 candles per request; the current
-        400-day lookback is well within that limit.
+        lookback_days is a hint, not a guarantee. The provider returns
+        up to that many bars; the eToro endpoint caps at 1000 per
+        request and offers no from_date pagination, so values above
+        1000 silently truncate. Post-#603 the default is 1000 — about
+        4 calendar years of trading-day price points, which is the
+        maximum a single fetch can deliver.
         """
 
     @abstractmethod

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -52,10 +52,11 @@ def refresh_market_data(
     provider: MarketDataProvider,
     conn: psycopg.Connection,  # type: ignore[type-arg]
     instruments: list[tuple[int, str]],  # [(instrument_id, symbol), ...]
-    lookback_days: int = 400,
+    lookback_days: int = 1000,
     max_spread_pct: Decimal = DEFAULT_MAX_SPREAD_PCT,
     *,
     skip_quotes: bool = False,
+    force_backfill: bool = False,
 ) -> MarketRefreshSummary:
     """
     For each instrument: fetch candles, upsert to price_daily, compute
@@ -65,6 +66,12 @@ def refresh_market_data(
     When skip_quotes is True, quote fetching and upserting are skipped
     entirely. Use this when a separate hourly job owns quote freshness
     (e.g. fx_rates_refresh).
+
+    When force_backfill is True, every instrument fetches the full
+    ``lookback_days`` window regardless of whether incremental mode
+    would otherwise apply. Used for the one-shot deepening invocation
+    (#603) — the daily scheduled refresh leaves it False so steady-state
+    eToro call weight stays at the incremental cadence.
 
     instruments is a list of (instrument_id, symbol) tuples — instrument_id
     must already exist in the instruments table. symbol is used for logging.
@@ -83,22 +90,30 @@ def refresh_market_data(
     # --- Candles: per-instrument (with freshness skip + two-mode fetch) ---
     # Two-mode fetch (#271):
     #   * Backfill mode — instrument has NO prior candles (new to the
-    #     universe, or gap detected). Pull full `lookback_days` history
-    #     (default 400 bars).
+    #     universe, or gap detected). Pull full `lookback_days` history.
+    #     Default 1000 — eToro's hard ceiling per request (#603 raised
+    #     from 400 → 1000). 1000 trading days ≈ 4 calendar years of
+    #     price points, which is the most we can fit in a single fetch.
+    #     The endpoint is count-based with no from_date pagination, so
+    #     we cannot deepen further without re-fetching everything.
     #   * Incremental mode — instrument already has candle history.
     #     Pull only INCREMENTAL_FETCH_BARS bars (yesterday + today +
     #     correction buffer). The upsert dedupes on (instrument_id,
     #     price_date) so overlap with existing rows is harmless.
     # On a typical day, ~100% of Tier 1/2 instruments are in incremental
-    # mode — eToro call weight drops from 400 bars × ~500 instruments
-    # (~200k rows) to 3 × 500 (~1500 rows).
+    # mode — eToro call weight stays at 3 × ~500 instruments (~1500
+    # rows). The 1000-bar default only fires on initial seed,
+    # gap-detect, or the one-shot ``force_backfill=True`` deepening.
     total = len(instruments)
     for idx, (instrument_id, symbol) in enumerate(instruments, start=1):
-        if _candles_are_fresh(conn, instrument_id, today):
+        if not force_backfill and _candles_are_fresh(conn, instrument_id, today):
             candles_skipped += 1
             report_progress(idx, total)
             continue
-        fetch_count = _candles_fetch_count(conn, instrument_id, default=lookback_days, today=today)
+        if force_backfill:
+            fetch_count = lookback_days
+        else:
+            fetch_count = _candles_fetch_count(conn, instrument_id, default=lookback_days, today=today)
         try:
             with conn.transaction():
                 bars = provider.get_daily_candles(instrument_id, fetch_count)
@@ -224,7 +239,7 @@ def _candles_fetch_count(
 ) -> int:
     """Decide the candlesCount for an instrument's fetch (#271).
 
-    Returns ``default`` (typically 400) in two cases:
+    Returns ``default`` (typically 1000 per #603) in two cases:
       * No prior candles at all — initial backfill mode.
       * Prior candles exist but the most recent is older than the
         incremental window (e.g. instrument was halted, re-added to
@@ -236,6 +251,11 @@ def _candles_fetch_count(
     within the incremental window — normal daily maintenance mode.
     The upsert dedupes on (instrument_id, price_date) so overlap is
     safe.
+
+    Note: this function does NOT extend an instrument's lookback when
+    ``default`` is bumped. An instrument that has 400 bars stays at
+    400 in incremental mode; deepening to 5y requires the one-shot
+    ``force_backfill=True`` invocation in ``refresh_market_data``.
     """
     row = conn.execute(
         """

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -990,8 +990,9 @@ def daily_candle_refresh() -> None:
          already have fundamentals, ordered by symbol for determinism.
          Enables T3→T2 promotion by seeding candle history.
 
-    Fetches up to 400 daily candles per instrument (enough for 1y return
-    + buffer).  Quotes are skipped (owned by the hourly job).
+    Fetches up to 1000 daily candles per instrument (post-#603 — eToro's
+    hard ceiling, ≈4 calendar years of trading-day price points).
+    Quotes are skipped (owned by the hourly job).
 
     Runs daily at 22:00 UTC, after US market close. Watchlist scope
     (spec §1.3 bullet 2) lands once the watchlist table exists
@@ -1039,11 +1040,11 @@ def daily_candle_refresh() -> None:
             ).fetchall()
 
             # T3: bootstrap batch (see _T3_BOOTSTRAP_SELECT comment).
-            # refresh_market_data fetches ~400 candles per instrument in
-            # a single API call, so a "partial" bootstrap still gives
-            # enough data for momentum scoring.  If the API call fails
-            # entirely, no rows are inserted and the instrument retries
-            # next run.
+            # refresh_market_data fetches up to 1000 candles per
+            # instrument in a single API call (post-#603), so a
+            # "partial" bootstrap still gives enough data for momentum
+            # scoring. If the API call fails entirely, no rows are
+            # inserted and the instrument retries next run.
             t3_rows = conn.execute(
                 _T3_BOOTSTRAP_SELECT,
                 {"limit": _T3_BOOTSTRAP_BATCH_SIZE},

--- a/scripts/rebackfill_candles_5y.py
+++ b/scripts/rebackfill_candles_5y.py
@@ -1,0 +1,176 @@
+"""One-shot deepening of price_daily history (#603).
+
+Bumps every Tier 1/2 instrument's candle history to the new 1000-bar
+ceiling (≈4 calendar years of trading-day prices, the most a single
+eToro fetch can deliver).
+
+Why this script exists rather than waiting for the scheduler to
+auto-deepen: ``refresh_market_data`` runs in incremental mode for any
+instrument with a recent bar, which means an instrument seeded under
+the old 400-bar policy keeps its 400 bars even after the default is
+raised to 1000. Forcing a one-time backfill closes the gap; the
+scheduler resumes incremental mode the next day.
+
+Run from the repo root:
+
+    uv run python scripts/rebackfill_candles_5y.py --apply
+
+Defaults to dry-run (logs what it would do, no API calls). Provide
+``--apply`` to actually fetch. ``--limit N`` caps the number of
+instruments processed in this run, useful if you want to spread the
+deepening across multiple sessions or smoke-test against a few
+instruments first.
+
+Rate limit: eToro allows 60 GET/min/key. With ~600 Tier 1/2
+instruments at 1.1s per fetch (provider's built-in throttle), the
+full sweep takes ~12 minutes. The provider client handles 429s with
+backoff so the script does not need to manage rate limits itself.
+
+Quotes are skipped (``skip_quotes=True``) so this script does not
+shadow the hourly fx_rates_refresh job's quote freshness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.etoro import EtoroMarketDataProvider
+from app.services.broker_credentials import (
+    CredentialNotFound,
+    load_credential_for_provider_use,
+)
+from app.services.market_data import refresh_market_data
+from app.services.operators import (
+    AmbiguousOperatorError,
+    NoOperatorError,
+    sole_operator_id,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _load_instruments(conn: psycopg.Connection, limit: int | None) -> list[tuple[int, str]]:  # type: ignore[type-arg]
+    """Held positions ∪ Tier 1 + Tier 2 tradable instruments.
+
+    Held names are included even when they are not in T1/T2 because
+    ``_candles_fetch_count`` will NOT deepen a short-but-fresh history
+    on its own — once an instrument has any incremental-window-fresh
+    bar, the function stays in 3-bar incremental mode regardless of
+    how short the underlying series is. Without held names here, a
+    delisted-but-still-held position seeded under the old 400-bar
+    policy would never extend.
+    """
+    if limit is not None:
+        rows = conn.execute(
+            """
+            SELECT instrument_id, symbol FROM (
+                SELECT i.instrument_id, i.symbol
+                FROM instruments i
+                JOIN positions p ON p.instrument_id = i.instrument_id
+                WHERE p.current_units > 0
+                UNION
+                SELECT i.instrument_id, i.symbol
+                FROM instruments i
+                JOIN coverage c ON c.instrument_id = i.instrument_id
+                WHERE i.is_tradable = TRUE
+                  AND c.coverage_tier IN (1, 2)
+            ) AS u
+            ORDER BY symbol, instrument_id
+            LIMIT %(lim)s
+            """,
+            {"lim": int(limit)},
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """
+            SELECT instrument_id, symbol FROM (
+                SELECT i.instrument_id, i.symbol
+                FROM instruments i
+                JOIN positions p ON p.instrument_id = i.instrument_id
+                WHERE p.current_units > 0
+                UNION
+                SELECT i.instrument_id, i.symbol
+                FROM instruments i
+                JOIN coverage c ON c.instrument_id = i.instrument_id
+                WHERE i.is_tradable = TRUE
+                  AND c.coverage_tier IN (1, 2)
+            ) AS u
+            ORDER BY symbol, instrument_id
+            """
+        ).fetchall()
+    return [(int(r[0]), str(r[1])) for r in rows]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Actually fetch (default: dry-run)")
+    parser.add_argument("--limit", type=int, default=None, help="Cap on instruments processed")
+    args = parser.parse_args()
+
+    try:
+        with psycopg.connect(settings.database_url) as conn:
+            op_id = sole_operator_id(conn)
+            api_key = load_credential_for_provider_use(
+                conn,
+                operator_id=op_id,
+                provider="etoro",
+                label="api_key",
+                environment=settings.etoro_env,
+                caller="rebackfill_candles_5y",
+            )
+            conn.commit()
+            user_key = load_credential_for_provider_use(
+                conn,
+                operator_id=op_id,
+                provider="etoro",
+                label="user_key",
+                environment=settings.etoro_env,
+                caller="rebackfill_candles_5y",
+            )
+            conn.commit()
+    except (NoOperatorError, AmbiguousOperatorError) as exc:
+        logger.error("operator lookup failed: %s", exc)
+        return 1
+    except CredentialNotFound as exc:
+        logger.error("eToro credentials missing: %s", exc)
+        return 1
+
+    with psycopg.connect(settings.database_url) as conn:
+        instruments = _load_instruments(conn, args.limit)
+        if not instruments:
+            logger.info("No Tier 1/2 instruments matched — nothing to deepen.")
+            return 0
+
+        logger.info("Selected %d instruments for deepening.", len(instruments))
+        if not args.apply:
+            logger.info("DRY RUN — pass --apply to actually fetch. Sample (first 5):")
+            for iid, sym in instruments[:5]:
+                logger.info("  %d %s", iid, sym)
+            return 0
+
+        with EtoroMarketDataProvider(api_key=api_key, user_key=user_key, env=settings.etoro_env) as provider:
+            summary = refresh_market_data(
+                provider,
+                conn,
+                instruments,
+                skip_quotes=True,
+                force_backfill=True,
+            )
+
+    logger.info(
+        "Deepening complete: instruments=%d candles_upserted=%d features=%d",
+        summary.instruments_refreshed,
+        summary.candle_rows_upserted,
+        summary.features_computed,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -960,3 +960,62 @@ class TestCandlesFetchCount:
         assert (today - latest).days == _INCREMENTAL_FETCH_BARS
         conn = self._mock_conn(fetchone_return=(latest,))
         assert _candles_fetch_count(conn, 42, default=400, today=today) == _INCREMENTAL_FETCH_BARS
+
+
+class TestRefreshMarketDataForceBackfill:
+    """force_backfill=True bypasses freshness skip + uses lookback_days
+    regardless of incremental mode (#603)."""
+
+    def _mock_conn_fresh(self) -> MagicMock:
+        """Mock conn whose `_candles_are_fresh` returns True for everything."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        # _candles_are_fresh and _candles_fetch_count both call
+        # conn.execute(...).fetchone() — return today's date so the
+        # default-mode path skips and the force-mode path overrides.
+        cursor.fetchone.return_value = (date.today(),)
+        conn.execute.return_value = cursor
+        # transaction context manager passthrough
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.transaction.return_value = ctx
+        return conn
+
+    def test_default_mode_skips_fresh_instruments(self) -> None:
+        from app.services.market_data import refresh_market_data
+
+        provider = MagicMock()
+        provider.get_daily_candles.return_value = []
+        provider.get_quotes.return_value = []
+        conn = self._mock_conn_fresh()
+
+        summary = refresh_market_data(
+            provider,
+            conn,
+            instruments=[(42, "AAPL")],
+            skip_quotes=True,
+        )
+        # Fresh instrument with no force flag → provider not called.
+        provider.get_daily_candles.assert_not_called()
+        assert summary.candle_rows_upserted == 0
+
+    def test_force_backfill_calls_provider_with_full_lookback(self) -> None:
+        from app.services.market_data import refresh_market_data
+
+        provider = MagicMock()
+        provider.get_daily_candles.return_value = []
+        provider.get_quotes.return_value = []
+        conn = self._mock_conn_fresh()
+
+        refresh_market_data(
+            provider,
+            conn,
+            instruments=[(42, "AAPL")],
+            lookback_days=1000,
+            skip_quotes=True,
+            force_backfill=True,
+        )
+        # force_backfill bypasses both freshness skip AND incremental
+        # fetch-count logic — provider gets the full lookback verbatim.
+        provider.get_daily_candles.assert_called_once_with(42, 1000)


### PR DESCRIPTION
## What

- `refresh_market_data.lookback_days` default raised 400 → 1000 (eToro's hard ceiling per request, no from_date pagination — single-fetch max).
- New `force_backfill: bool = False` param so a one-shot deepening pass can fetch the full window for every instrument regardless of incremental-mode freshness. Default False so the scheduled daily refresh keeps its incremental 3-bar cadence.
- New `scripts/rebackfill_candles_5y.py` — runs the one-shot pass against held positions ∪ Tier 1/2. Defaults to dry-run; pass `--apply` to fetch.
- Provider docstring + scheduler comments updated.

## Why

Surfaced via the operator review on #587 — the 5Y button returned much less than 5Y of bars because the old 400-bar policy seeded only ~16 months per instrument. The eToro endpoint can't deliver more than 1000 bars per request (no pagination), but 400 → 1000 is a 2.5× extension at the cost of a one-time bulk fetch (~12 min across Tier 1/2 at the provider's 1.1s/req throttle).

## Conscious deviations

- Originally the ticket asked for 1830 days. Capped at 1000 because eToro hard-caps `candlesCount` at 1000 per request and there is no `fromDate`-based pagination — anything above truncates silently. 1000 trading-day bars ≈ 4 calendar years of price points, which is the most a single fetch can deliver. Documented in code + memory.
- Held-position scope: Codex flagged the original script docstring claim that held positions "auto-reseed" was wrong — `_candles_fetch_count` doesn't deepen a short-but-fresh history. Fixed: script now selects held positions ∪ Tier 1/2.

## Test plan

- [x] `uv run ruff check .` / `format --check` / `pyright` clean
- [x] `uv run pytest -q` — 2858 passed
- [x] New: `TestRefreshMarketDataForceBackfill` — default mode skips fresh instruments, `force_backfill=True` bypasses skip + calls provider with full lookback
- [x] Codex pre-push review applied: included held positions in the script, added force_backfill unit coverage

## Linked

Parent: #585 (chart redesign epic)
Related: #600 (intraday proxy, merged via PR #604), #601 (frontend wiring)