### PR TITLE
feat(#601): frontend range→interval wiring + 1D/5D/YTD ranges + TradingView-style hover strip

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -646,10 +646,11 @@ def _resolve_range_days(range_: str, today: date) -> int | None:
     """
     if range_ == "ytd":
         # Days from Jan 1 of `today`'s year to `today` (inclusive of
-        # today's bar). January 1 itself returns 0 — the daily query
-        # will then return only today's row, which the chart handles
-        # with its empty-state when there are <2 bars.
-        return (today - date(today.year, 1, 1)).days
+        # today's bar). Clamp to ≥1 so January 1 returns at least
+        # yesterday's bar — without the clamp, Jan 1 returns 0 and the
+        # chart shows an empty state on what should be a sensible
+        # "single-day-into-the-year" view.
+        return max(1, (today - date(today.year, 1, 1)).days)
     return _CANDLE_RANGE_DAYS[range_]
 
 

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -186,7 +186,7 @@ class InstrumentCandles(BaseModel):
     # class scope — pydantic v2's alias+populate_by_name wiring kept
     # tripping pyright, and the shadow is safe inside a BaseModel
     # (the builtin is still reachable as `builtins.range`).
-    range: Literal["1w", "1m", "3m", "6m", "1y", "5y", "max"]  # noqa: A003
+    range: Literal["1w", "1m", "3m", "6m", "ytd", "1y", "5y", "max"]  # noqa: A003
     days: int | None  # None when range="max"
     rows: list[CandleBar]
 
@@ -637,10 +637,26 @@ _CANDLE_RANGE_DAYS: dict[str, int | None] = {
 }
 
 
+def _resolve_range_days(range_: str, today: date) -> int | None:
+    """Map a range token to a calendar-day lookback, or None for max.
+
+    YTD is computed dynamically from ``today`` rather than living in
+    the static dict so the lookback shrinks every Jan 1. The static
+    dict still holds the fixed-window tokens.
+    """
+    if range_ == "ytd":
+        # Days from Jan 1 of `today`'s year to `today` (inclusive of
+        # today's bar). January 1 itself returns 0 — the daily query
+        # will then return only today's row, which the chart handles
+        # with its empty-state when there are <2 bars.
+        return (today - date(today.year, 1, 1)).days
+    return _CANDLE_RANGE_DAYS[range_]
+
+
 @router.get("/{symbol}/candles", response_model=InstrumentCandles)
 def get_instrument_candles(
     symbol: str,
-    range_: Literal["1w", "1m", "3m", "6m", "1y", "5y", "max"] = Query(default="1m", alias="range"),
+    range_: Literal["1w", "1m", "3m", "6m", "ytd", "1y", "5y", "max"] = Query(default="1m", alias="range"),
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> InstrumentCandles:
     """Daily OHLCV bars for `symbol` over the requested lookback.
@@ -677,7 +693,7 @@ def get_instrument_candles(
     if inst_row is None:
         raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
 
-    days = _CANDLE_RANGE_DAYS[range_]
+    days = _resolve_range_days(range_, date.today())
     # Two fixed queries rather than f-string-composing a WHERE clause,
     # so there's no structural-injection footgun if the range-token
     # set grows later. `max` omits the date filter entirely.

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -4,8 +4,10 @@ import type {
   InstrumentCandles,
   InstrumentDetail,
   InstrumentFinancials,
+  InstrumentIntradayCandles,
   InstrumentListResponse,
   InstrumentSummary,
+  IntradayInterval,
 } from "@/api/types";
 
 export interface InstrumentsQuery {
@@ -387,5 +389,19 @@ export function fetchInstrumentCandles(
   const params = new URLSearchParams({ range });
   return apiFetch<InstrumentCandles>(
     `/instruments/${encodeURIComponent(symbol)}/candles?${params.toString()}`,
+  );
+}
+
+export function fetchInstrumentIntradayCandles(
+  symbol: string,
+  interval: IntradayInterval,
+  count: number,
+): Promise<InstrumentIntradayCandles> {
+  const params = new URLSearchParams({
+    interval,
+    count: String(count),
+  });
+  return apiFetch<InstrumentIntradayCandles>(
+    `/instruments/${encodeURIComponent(symbol)}/intraday-candles?${params.toString()}`,
   );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -293,12 +293,16 @@ export interface InstrumentSummary {
   capabilities: Record<string, CapabilityCell>;
 }
 
-// #316 Slice A — daily OHLCV bars
+// #316 Slice A — daily OHLCV bars (existing daily endpoint contract).
+// Note: `1w` is legacy; the chart UI no longer uses it (#601 swapped it
+// for `5d` served by the intraday endpoint). Kept on the backend Literal
+// so any external consumer that still passes `?range=1w` keeps working.
 export type CandleRange =
   | "1w"
   | "1m"
   | "3m"
   | "6m"
+  | "ytd"
   | "1y"
   | "5y"
   | "max";
@@ -319,6 +323,54 @@ export interface InstrumentCandles {
   days: number | null;
   rows: CandleBar[];
 }
+
+// #600 — intraday OHLCV bars served live by the eToro provider.
+// Distinct from CandleBar: bars carry a UTC ISO timestamp instead of
+// a YYYY-MM-DD date. Not persisted in price_daily.
+export type IntradayInterval =
+  | "OneMinute"
+  | "FiveMinutes"
+  | "TenMinutes"
+  | "FifteenMinutes"
+  | "ThirtyMinutes"
+  | "OneHour"
+  | "FourHours";
+
+export interface IntradayBar {
+  /** UTC ISO-8601 timestamp at bar open. */
+  timestamp: string;
+  open: string | null;
+  high: string | null;
+  low: string | null;
+  close: string | null;
+  volume: number | null;
+}
+
+export interface InstrumentIntradayCandles {
+  symbol: string;
+  interval: IntradayInterval;
+  /** Number of bars actually returned (not the requested count). */
+  count: number;
+  /** Always false in v1 — intraday data is not stored in any DB table. */
+  persisted: false;
+  rows: IntradayBar[];
+}
+
+// #601 — chart UI range token (the union the chart buttons render).
+// Translates to either a daily range (existing endpoint) or an
+// intraday (interval, count) pair via CHART_RANGE_PLAN. The API
+// boundary keeps two separate shapes; the chart consumes a unified
+// normalised stream.
+export type ChartRange =
+  | "1d"
+  | "5d"
+  | "1m"
+  | "3m"
+  | "6m"
+  | "ytd"
+  | "1y"
+  | "5y"
+  | "max";
 
 // Phase 2.3 — financials
 export interface InstrumentFinancialRow {

--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -262,7 +262,7 @@ describe("DensityGrid profiles", () => {
     expect(navigateMock).toHaveBeenCalledWith("/instrument/GME/chart?range=5y");
   });
 
-  it("clicking the chart card itself drills to the chart workspace (#587)", async () => {
+  it("clicking the chart card body does NOT drill — only Open button drills (#601 follow-up)", async () => {
     navigateMock.mockClear();
     const user = userEvent.setup();
     render(
@@ -274,9 +274,11 @@ describe("DensityGrid profiles", () => {
         />
       </MemoryRouter>,
     );
-    // PriceChart is mocked above to a div with testid `price-chart-stub`.
-    // Clicking the stub bubbles up to the Pane's article-level onClick.
+    // Clicking the chart body must not fire the drill — operator
+    // reported the whole-card click was firing accidentally during
+    // chart hover/zoom interactions, so the card-click hook was
+    // removed in favour of the explicit "Open →" button only.
     await user.click(screen.getByTestId("price-chart-stub"));
-    expect(navigateMock).toHaveBeenCalledWith("/instrument/GME/chart?range=1y");
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -72,8 +72,12 @@ export function DensityGrid({
     navigate(url);
   };
 
+  // Card-click drill removed (#601 follow-up): the PaneHeader's
+  // "Open →" button is the only drill affordance now. Operator
+  // reported the whole-card click was firing accidentally on chart
+  // hover/zoom.
   const ChartPane = (
-    <Pane title="Price chart" onExpand={drillToWorkspace} onCardClick={drillToWorkspace}>
+    <Pane title="Price chart" onExpand={drillToWorkspace}>
       <PriceChart symbol={symbol} />
     </Pane>
   );

--- a/frontend/src/components/instrument/PriceChart.test.tsx
+++ b/frontend/src/components/instrument/PriceChart.test.tsx
@@ -1,29 +1,25 @@
 /**
- * Tests for PriceChart (#204 lightweight-charts migration; polished in #587).
+ * Tests for PriceChart (#204 lightweight-charts migration; polished in
+ * #587; intraday + 1D/5D/YTD ranges + unified fetch in #601).
  *
- * lightweight-charts renders to a Canvas which jsdom cannot paint, so
+ * lightweight-charts renders to a Canvas that jsdom cannot paint, so
  * we mock the library wholesale. What we pin here is the component's
  * contract — not the library's rendering:
  *
- *   - All 7 range buttons render + switching refetches.
- *   - Type toggle (candle/line/area) flips visibility on each series
- *     and URL-syncs to ?type=line|area (no param for default candle).
- *   - Log scale toggle URL-syncs to ?scale=log and applies the
- *     logarithmic mode to the right price scale.
+ *   - All nine range buttons render (1D/5D/1M/3M/6M/YTD/1Y/5Y/MAX).
+ *   - Switching range refetches via the unified chartData dispatch.
+ *   - Type toggle (candle/line/area) flips visibility per series.
+ *   - Log scale toggle URL-syncs to ?scale=log and applies mode=1.
  *   - Empty / single-row data → empty state, no chart mount.
- *   - ≥2 valid rows → chart div mounts and the mocked series receives
- *     setData() with the right shape.
- *   - Loading / error states.
- *   - Stale-chart guard while a new-range fetch is in flight.
+ *   - ≥2 valid rows → chart canvas mounts and series.setData fires.
+ *   - chart.remove() runs on unmount.
+ *   - Fetch errors propagate via SectionError + retry.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, useLocation } from "react-router-dom";
 
-// Mock lightweight-charts before importing PriceChart so the module
-// picks up the stubs at module-load time. `vi.hoisted` lets the mock
-// expose handles we can introspect from the tests.
 const libState = vi.hoisted(() => ({
   candleSetData: vi.fn(),
   lineSetData: vi.fn(),
@@ -34,6 +30,7 @@ const libState = vi.hoisted(() => ({
   areaApply: vi.fn(),
   rightPriceScaleApply: vi.fn(),
   volumePriceScaleApply: vi.fn(),
+  timeScaleApply: vi.fn(),
   fitContent: vi.fn(),
   crosshairHandlers: [] as Array<(p: unknown) => void>,
   remove: vi.fn(),
@@ -74,7 +71,10 @@ vi.mock("lightweight-charts", () => {
         ? { applyOptions: libState.rightPriceScaleApply }
         : { applyOptions: libState.volumePriceScaleApply },
     ),
-    timeScale: vi.fn(() => ({ fitContent: libState.fitContent })),
+    timeScale: vi.fn(() => ({
+      fitContent: libState.fitContent,
+      applyOptions: libState.timeScaleApply,
+    })),
     subscribeCrosshairMove: vi.fn((h: (p: unknown) => void) => {
       libState.crosshairHandlers.push(h);
     }),
@@ -86,31 +86,42 @@ vi.mock("lightweight-charts", () => {
     LineSeries: "__line__",
     AreaSeries: "__area__",
     HistogramSeries: "__histogram__",
-    // Numeric values mirror lightweight-charts' LineType enum so any
-    // assertion on the option passed to addSeries lines up with the
-    // real library shape.
     LineType: { Simple: 0, WithSteps: 1, Curved: 2 },
   };
 });
 
 import { PriceChart } from "@/components/instrument/PriceChart";
-import type { InstrumentCandles } from "@/api/types";
+import type { NormalisedChartCandles, NormalisedBar } from "@/lib/chartData";
 
-vi.mock("@/api/instruments", () => ({
-  fetchInstrumentCandles: vi.fn(),
-}));
+vi.mock("@/lib/chartData", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/chartData")>("@/lib/chartData");
+  return {
+    ...actual,
+    fetchChartCandles: vi.fn(),
+  };
+});
 
-import { fetchInstrumentCandles } from "@/api/instruments";
+import { fetchChartCandles } from "@/lib/chartData";
 
-const mockedFetch = vi.mocked(fetchInstrumentCandles);
+const mockedFetch = vi.mocked(fetchChartCandles);
 
-function candles(rows: InstrumentCandles["rows"]): InstrumentCandles {
+const T1 = Math.floor(Date.UTC(2026, 3, 10) / 1000);
+const T2 = Math.floor(Date.UTC(2026, 3, 11) / 1000);
+
+function bars(rows: NormalisedBar[], range: NormalisedChartCandles["range"] = "1m"): NormalisedChartCandles {
   return {
     symbol: "AAPL",
-    range: "1m",
-    days: 30,
+    range,
+    kind: range === "1d" || range === "5d" || range === "1m" || range === "3m" || range === "6m" ? "intraday" : "daily",
     rows,
   };
+}
+
+function twoValidRows(): NormalisedBar[] {
+  return [
+    { time: T1, open: "100", high: "102", low: "99", close: "101", volume: "1000" },
+    { time: T2, open: "101", high: "104", low: "100", close: "103", volume: "1500" },
+  ];
 }
 
 function LocationSpy({ onLocation }: { onLocation: (search: string) => void }) {
@@ -130,26 +141,27 @@ beforeEach(() => {
   libState.areaApply.mockClear();
   libState.rightPriceScaleApply.mockClear();
   libState.volumePriceScaleApply.mockClear();
+  libState.timeScaleApply.mockClear();
   libState.fitContent.mockClear();
   libState.remove.mockClear();
   libState.crosshairHandlers.length = 0;
 });
 
 describe("PriceChart — range picker", () => {
-  it("renders all seven range buttons", async () => {
-    mockedFetch.mockResolvedValue(candles([]));
+  it("renders all nine range buttons", async () => {
+    mockedFetch.mockResolvedValue(bars([]));
     render(
       <MemoryRouter>
         <PriceChart symbol="AAPL" />
       </MemoryRouter>,
     );
-    for (const r of ["1w", "1m", "3m", "6m", "1y", "5y", "max"]) {
+    for (const r of ["1d", "5d", "1m", "3m", "6m", "ytd", "1y", "5y", "max"]) {
       expect(screen.getByTestId(`chart-range-${r}`)).toBeInTheDocument();
     }
   });
 
   it("clicking a range button refetches with the new range", async () => {
-    mockedFetch.mockResolvedValue(candles([]));
+    mockedFetch.mockResolvedValue(bars([]));
     const user = userEvent.setup();
     render(
       <MemoryRouter>
@@ -168,8 +180,8 @@ describe("PriceChart — range picker", () => {
 });
 
 describe("PriceChart — type toggle (#587)", () => {
-  it("renders three type buttons (Candle / Line / Area) defaulting to Candle", async () => {
-    mockedFetch.mockResolvedValue(candles([]));
+  it("renders three type buttons defaulting to Candle", async () => {
+    mockedFetch.mockResolvedValue(bars([]));
     render(
       <MemoryRouter>
         <PriceChart symbol="AAPL" />
@@ -181,7 +193,7 @@ describe("PriceChart — type toggle (#587)", () => {
   });
 
   it("clicking Line writes ?type=line; clicking Candle clears the param", async () => {
-    mockedFetch.mockResolvedValue(candles([]));
+    mockedFetch.mockResolvedValue(bars([]));
     const user = userEvent.setup();
     let lastSearch = "";
     render(
@@ -197,12 +209,7 @@ describe("PriceChart — type toggle (#587)", () => {
   });
 
   it("toggles series visibility when ?type=area is set on initial render", async () => {
-    mockedFetch.mockResolvedValue(
-      candles([
-        { date: "2026-04-10", open: "100", high: "102", low: "99", close: "101", volume: "1000" },
-        { date: "2026-04-11", open: "101", high: "104", low: "100", close: "103", volume: "1500" },
-      ]),
-    );
+    mockedFetch.mockResolvedValue(bars(twoValidRows()));
     render(
       <MemoryRouter initialEntries={["/?type=area"]}>
         <PriceChart symbol="AAPL" />
@@ -211,8 +218,6 @@ describe("PriceChart — type toggle (#587)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("price-chart-AAPL")).toBeInTheDocument();
     });
-    // Visibility effect runs once per series. Last call's `visible`
-    // flag reflects whether that series is the active type.
     await waitFor(() => {
       const last = libState.areaApply.mock.calls.at(-1)?.[0] as { visible?: boolean } | undefined;
       expect(last?.visible).toBe(true);
@@ -226,7 +231,7 @@ describe("PriceChart — type toggle (#587)", () => {
 
 describe("PriceChart — log scale toggle (#587)", () => {
   it("renders a Log toggle button defaulting to off", async () => {
-    mockedFetch.mockResolvedValue(candles([]));
+    mockedFetch.mockResolvedValue(bars([]));
     render(
       <MemoryRouter>
         <PriceChart symbol="AAPL" />
@@ -237,7 +242,7 @@ describe("PriceChart — log scale toggle (#587)", () => {
   });
 
   it("clicking Log writes ?scale=log; clicking again clears the param", async () => {
-    mockedFetch.mockResolvedValue(candles([]));
+    mockedFetch.mockResolvedValue(bars([]));
     const user = userEvent.setup();
     let lastSearch = "";
     render(
@@ -253,12 +258,7 @@ describe("PriceChart — log scale toggle (#587)", () => {
   });
 
   it("applies mode=1 to the right price scale when ?scale=log is set", async () => {
-    mockedFetch.mockResolvedValue(
-      candles([
-        { date: "2026-04-10", open: "100", high: "102", low: "99", close: "101", volume: "1000" },
-        { date: "2026-04-11", open: "101", high: "104", low: "100", close: "103", volume: "1500" },
-      ]),
-    );
+    mockedFetch.mockResolvedValue(bars(twoValidRows()));
     render(
       <MemoryRouter initialEntries={["/?scale=log"]}>
         <PriceChart symbol="AAPL" />
@@ -273,7 +273,7 @@ describe("PriceChart — log scale toggle (#587)", () => {
 
 describe("PriceChart — controls swallow card-click events (#587)", () => {
   it("clicks on the controls bar do not bubble to a parent click handler", async () => {
-    mockedFetch.mockResolvedValue(candles([]));
+    mockedFetch.mockResolvedValue(bars([]));
     const onCardClick = vi.fn();
     const user = userEvent.setup();
     render(
@@ -294,7 +294,7 @@ describe("PriceChart — controls swallow card-click events (#587)", () => {
 
 describe("PriceChart — data states", () => {
   it("renders 'No price data' when rows is empty", async () => {
-    mockedFetch.mockResolvedValue(candles([]));
+    mockedFetch.mockResolvedValue(bars([]));
     render(
       <MemoryRouter>
         <PriceChart symbol="AAPL" />
@@ -306,18 +306,9 @@ describe("PriceChart — data states", () => {
     expect(screen.queryByTestId("price-chart-AAPL")).not.toBeInTheDocument();
   });
 
-  it("renders empty state with only one valid close (can't draw a chart)", async () => {
+  it("renders empty state with only one valid row", async () => {
     mockedFetch.mockResolvedValue(
-      candles([
-        {
-          date: "2026-04-10",
-          open: "100",
-          high: "102",
-          low: "99",
-          close: "101",
-          volume: "1000",
-        },
-      ]),
+      bars([{ time: T1, open: "100", high: "102", low: "99", close: "101", volume: "1000" }]),
     );
     render(
       <MemoryRouter>
@@ -329,27 +320,8 @@ describe("PriceChart — data states", () => {
     });
   });
 
-  it("mounts the chart canvas and pushes ≥2 rows to the candle, line, and area series", async () => {
-    mockedFetch.mockResolvedValue(
-      candles([
-        {
-          date: "2026-04-10",
-          open: "100",
-          high: "102",
-          low: "99",
-          close: "101",
-          volume: "1000",
-        },
-        {
-          date: "2026-04-11",
-          open: "101",
-          high: "104",
-          low: "100",
-          close: "103",
-          volume: "1500",
-        },
-      ]),
-    );
+  it("mounts the chart canvas and pushes ≥2 rows to candle, line, and area series", async () => {
+    mockedFetch.mockResolvedValue(bars(twoValidRows()));
     render(
       <MemoryRouter>
         <PriceChart symbol="AAPL" />
@@ -358,8 +330,6 @@ describe("PriceChart — data states", () => {
     await waitFor(() => {
       expect(screen.getByTestId("price-chart-AAPL")).toBeInTheDocument();
     });
-    expect(screen.queryByText(/No price data/i)).not.toBeInTheDocument();
-    // Candlestick series received the two rows in OHLC shape.
     await waitFor(() => {
       expect(libState.candleSetData).toHaveBeenCalled();
     });
@@ -370,41 +340,16 @@ describe("PriceChart — data states", () => {
     expect(candleCall).toHaveLength(2);
     expect(candleCall[0]?.open).toBe(100);
     expect(candleCall[1]?.close).toBe(103);
-    // Line + area series receive close-only data.
     const lineCall = libState.lineSetData.mock.calls[0]?.[0] as Array<{ value: number }>;
     expect(lineCall).toHaveLength(2);
     expect(lineCall[0]?.value).toBe(101);
-    expect(lineCall[1]?.value).toBe(103);
     const areaCall = libState.areaSetData.mock.calls[0]?.[0] as Array<{ value: number }>;
-    expect(areaCall).toHaveLength(2);
     expect(areaCall[1]?.value).toBe(103);
-    // Volume series got the same count.
     expect(libState.volumeSetData).toHaveBeenCalled();
   });
 
   it("hides the chart while a new-range fetch is in flight", async () => {
-    mockedFetch.mockResolvedValue({
-      ...candles([
-        {
-          date: "2026-04-10",
-          open: "100",
-          high: "102",
-          low: "99",
-          close: "101",
-          volume: "1000",
-        },
-        {
-          date: "2026-04-11",
-          open: "101",
-          high: "104",
-          low: "100",
-          close: "103",
-          volume: "1500",
-        },
-      ]),
-      range: "5y",
-      days: 1825,
-    });
+    mockedFetch.mockResolvedValue(bars(twoValidRows(), "5y"));
     render(
       <MemoryRouter>
         <PriceChart symbol="AAPL" />
@@ -413,67 +358,16 @@ describe("PriceChart — data states", () => {
     await waitFor(() => {
       expect(mockedFetch).toHaveBeenCalled();
     });
+    // Fetched 5y rows but range is 1m — gate suppresses chart.
     expect(screen.queryByTestId("price-chart-AAPL")).not.toBeInTheDocument();
     expect(screen.queryByText(/No price data/i)).not.toBeInTheDocument();
   });
 
-  it("treats rows missing OHLC as dropped — empty state not a blank chart", async () => {
-    // Two rows, but only `close` is populated. lightweight-charts
-    // silently drops bars with null O/H/L, so the chart would mount
-    // empty if we gated on `close` alone. Verifies the stricter gate.
+  it("treats rows missing OHLC as dropped — empty state not blank chart", async () => {
     mockedFetch.mockResolvedValue(
-      candles([
-        {
-          date: "2026-04-10",
-          open: null,
-          high: null,
-          low: null,
-          close: "101",
-          volume: "1000",
-        },
-        {
-          date: "2026-04-11",
-          open: null,
-          high: null,
-          low: null,
-          close: "103",
-          volume: "1500",
-        },
-      ]),
-    );
-    render(
-      <MemoryRouter>
-        <PriceChart symbol="AAPL" />
-      </MemoryRouter>,
-    );
-    await waitFor(() => {
-      expect(screen.getByText(/No price data/i)).toBeInTheDocument();
-    });
-    expect(screen.queryByTestId("price-chart-AAPL")).not.toBeInTheDocument();
-  });
-
-  it("drops rows with malformed date strings (no NaN in the time scale)", async () => {
-    // Two rows — one with `date: ""`, one with a non-date. Even though
-    // OHLC is populated, the chart cannot plot these because their
-    // time values would be NaN. Mount gate drops them → empty state.
-    mockedFetch.mockResolvedValue(
-      candles([
-        {
-          date: "",
-          open: "100",
-          high: "102",
-          low: "99",
-          close: "101",
-          volume: "1000",
-        },
-        {
-          date: "not-a-date",
-          open: "101",
-          high: "104",
-          low: "100",
-          close: "103",
-          volume: "1500",
-        },
+      bars([
+        { time: T1, open: null, high: null, low: null, close: "101", volume: "1000" },
+        { time: T2, open: null, high: null, low: null, close: "103", volume: "1500" },
       ]),
     );
     render(
@@ -488,26 +382,7 @@ describe("PriceChart — data states", () => {
   });
 
   it("calls chart.remove() on unmount so the Canvas is released", async () => {
-    mockedFetch.mockResolvedValue(
-      candles([
-        {
-          date: "2026-04-10",
-          open: "100",
-          high: "102",
-          low: "99",
-          close: "101",
-          volume: "1000",
-        },
-        {
-          date: "2026-04-11",
-          open: "101",
-          high: "104",
-          low: "100",
-          close: "103",
-          volume: "1500",
-        },
-      ]),
-    );
+    mockedFetch.mockResolvedValue(bars(twoValidRows()));
     render(
       <MemoryRouter>
         <PriceChart symbol="AAPL" />
@@ -528,10 +403,36 @@ describe("PriceChart — data states", () => {
       </MemoryRouter>,
     );
     await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: /retry/i }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
     });
     expect(screen.queryByTestId("price-chart-AAPL")).not.toBeInTheDocument();
+  });
+});
+
+describe("PriceChart — intraday axis formatting (#601)", () => {
+  it("intraday range applies timeVisible=true on the time scale", async () => {
+    mockedFetch.mockResolvedValue(bars(twoValidRows(), "1d"));
+    render(
+      <MemoryRouter initialEntries={["/?chart=1d"]}>
+        <PriceChart symbol="AAPL" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      const calls = libState.timeScaleApply.mock.calls.map((c) => c[0]);
+      expect(calls.some((opts: { timeVisible?: boolean }) => opts.timeVisible === true)).toBe(true);
+    });
+  });
+
+  it("daily range applies timeVisible=false", async () => {
+    mockedFetch.mockResolvedValue(bars(twoValidRows(), "1y"));
+    render(
+      <MemoryRouter initialEntries={["/?chart=1y"]}>
+        <PriceChart symbol="AAPL" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      const calls = libState.timeScaleApply.mock.calls.map((c) => c[0]);
+      expect(calls.some((opts: { timeVisible?: boolean }) => opts.timeVisible === false)).toBe(true);
+    });
   });
 });

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -43,6 +43,7 @@ import {
   type NormalisedBar,
   type NormalisedChartCandles,
 } from "@/lib/chartData";
+import { formatHoverLabel, humanizeVolume, tickFormatter } from "@/lib/chartFormatters";
 import { chartTheme } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
 
@@ -107,52 +108,10 @@ interface NumericBar {
   volume: number;
 }
 
-function formatHoverLabel(epochSeconds: number, intraday: boolean): string {
-  const d = new Date(epochSeconds * 1000);
-  const date = d.toISOString().slice(0, 10);
-  if (!intraday) return date;
-  const hh = String(d.getUTCHours()).padStart(2, "0");
-  const mm = String(d.getUTCMinutes()).padStart(2, "0");
-  return `${date} ${hh}:${mm}Z`;
-}
-
-const _MONTH_ABBR = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const;
-
-/**
- * Tick-mark formatter for the time scale.
- *
- * lightweight-charts passes a `tickMarkType` discriminator with each
- * tick: 0=Year, 1=Month, 2=DayOfMonth, 3=Time, 4=TimeWithSeconds. We
- * use that to render TradingView-style adaptive labels — within a day
- * the axis shows times (`HH:MM`), at the day boundary it shows the
- * date (`Apr 27`), and at month/year boundaries the abbreviated month
- * or year. This matches the operator's reference (TradingView /
- * Robinhood) so a multi-day intraday chart still tells you which day
- * you're hovering over.
- *
- * Daily / weekly / monthly ranges only ever receive Year/Month/Day
- * tick types — the intraday `Time` branch never fires for them, so
- * this single formatter works for both modes.
- */
-function tickFormatter(time: number, tickMarkType: number): string {
-  const d = new Date(time * 1000);
-  switch (tickMarkType) {
-    case 0: // Year
-      return String(d.getUTCFullYear());
-    case 1: // Month
-      return _MONTH_ABBR[d.getUTCMonth()] ?? "";
-    case 2: // DayOfMonth — start of a new day in intraday mode, or
-      // any tick in daily/weekly mode
-      return `${_MONTH_ABBR[d.getUTCMonth()]} ${d.getUTCDate()}`;
-    case 3: // Time — within a day on intraday charts
-    case 4: // TimeWithSeconds (we never request this density)
-    default: {
-      const hh = String(d.getUTCHours()).padStart(2, "0");
-      const mm = String(d.getUTCMinutes()).padStart(2, "0");
-      return `${hh}:${mm}`;
-    }
-  }
-}
+// formatHoverLabel / tickFormatter / humanizeVolume now live in
+// @/lib/chartFormatters so PriceChart and ChartWorkspaceCanvas share
+// one definition (#601 review feedback — duplicated copies would
+// silently drift).
 
 export interface PriceChartProps {
   symbol: string;
@@ -609,15 +568,6 @@ export function ChartCanvas({
       />
     </div>
   );
-}
-
-function humanizeVolume(v: number): string {
-  if (!Number.isFinite(v) || v === 0) return "0";
-  const abs = Math.abs(v);
-  if (abs >= 1e9) return `${(v / 1e9).toFixed(2)}B`;
-  if (abs >= 1e6) return `${(v / 1e6).toFixed(2)}M`;
-  if (abs >= 1e3) return `${(v / 1e3).toFixed(2)}K`;
-  return v.toLocaleString();
 }
 
 /**

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -1,25 +1,25 @@
 /**
  * PriceChart — overview candlestick / line / area + volume chart backed
- * by lightweight-charts (#204, polished in #587). Lives inside a
- * clickable Pane on the instrument page; clicking the card drills to
- * the full chart workspace at `/instrument/:symbol/chart`.
+ * by lightweight-charts. Lives inside a clickable Pane on the
+ * instrument page; clicking the card drills to the full chart workspace
+ * at `/instrument/:symbol/chart`.
  *
- * Layering:
- *   - candlestick / line / area series share the right price scale
- *     (only one is visible at a time, toggled via `?type=`)
- *   - volume series (Histogram) on its own overlay price scale pinned
- *     to the bottom 30% via `scaleMargins`
+ * Range mapping (#601): 9 buttons across two endpoints —
+ *   1D · 5D · 1M · 3M · 6M  → intraday endpoint at the right interval
+ *   YTD · 1Y · 5Y · MAX     → daily endpoint (price_daily)
+ * The dispatch table lives in `@/lib/chartData` so the same plan is
+ * shared with the chart workspace and any future drill page.
  *
  * URL params (replace, not push):
- *   - `?chart=<range>` → 1w | 1m | 3m | 6m | 1y | 5y | max (default 1m)
+ *   - `?chart=<range>` → 1d | 5d | 1m | 3m | 6m | ytd | 1y | 5y | max (default 1m)
  *   - `?type=line|area` → series type (default candle, no param)
  *   - `?scale=log` → logarithmic right price scale (default linear, no param)
  *
- * Hover tooltip shows date + OHLC + volume + %Δ-from-prior; matches the
- * pattern in `ChartWorkspaceCanvas.RichTooltip` so an operator's mental
- * model is consistent between the overview pane and the workspace.
+ * Hover tooltip shows date (or date+time for intraday) + OHLC + volume +
+ * %Δ-from-prior; matches the pattern in `ChartWorkspaceCanvas.RichTooltip`
+ * so an operator's mental model is consistent between overview and workspace.
  */
-import { useEffect, useRef, useState, useCallback, type JSX } from "react";
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   AreaSeries,
@@ -34,28 +34,37 @@ import {
   type UTCTimestamp,
 } from "lightweight-charts";
 
-import { fetchInstrumentCandles } from "@/api/instruments";
-import type { CandleBar, CandleRange, InstrumentCandles } from "@/api/types";
+import type { ChartRange } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
+import {
+  fetchChartCandles,
+  isIntraday,
+  type NormalisedBar,
+  type NormalisedChartCandles,
+} from "@/lib/chartData";
 import { chartTheme } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
 
-const RANGES: { id: CandleRange; label: string }[] = [
-  { id: "1w", label: "1W" },
+const RANGES: { id: ChartRange; label: string }[] = [
+  { id: "1d", label: "1D" },
+  { id: "5d", label: "5D" },
   { id: "1m", label: "1M" },
   { id: "3m", label: "3M" },
   { id: "6m", label: "6M" },
+  { id: "ytd", label: "YTD" },
   { id: "1y", label: "1Y" },
   { id: "5y", label: "5Y" },
   { id: "max", label: "MAX" },
 ];
 
-const VALID_RANGES: readonly CandleRange[] = [
-  "1w",
+const VALID_RANGES: readonly ChartRange[] = [
+  "1d",
+  "5d",
   "1m",
   "3m",
   "6m",
+  "ytd",
   "1y",
   "5y",
   "max",
@@ -79,30 +88,8 @@ function parseNum(v: string | null | undefined): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-/**
- * Convert a YYYY-MM-DD date string to a UTC-midnight Unix seconds
- * timestamp. We use epoch seconds rather than BusinessDay because
- * BusinessDay mode requires the library to know which dates are
- * trading days — weekends/holidays produce gaps that confuse its
- * internal scaling.
- *
- * Returns null for anything that doesn't parse cleanly so a bad row
- * is dropped rather than poisoning the time scale with NaN.
- */
-function dateToTime(date: string): UTCTimestamp | null {
-  const parts = date.split("-");
-  if (parts.length !== 3) return null;
-  const y = Number(parts[0]);
-  const m = Number(parts[1]);
-  const d = Number(parts[2]);
-  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return null;
-  const ts = Date.UTC(y, m - 1, d);
-  if (!Number.isFinite(ts)) return null;
-  return (ts / 1000) as UTCTimestamp;
-}
-
 interface RichHoverState {
-  date: string;
+  label: string;
   open: number;
   high: number;
   low: number;
@@ -120,9 +107,56 @@ interface NumericBar {
   volume: number;
 }
 
+function formatHoverLabel(epochSeconds: number, intraday: boolean): string {
+  const d = new Date(epochSeconds * 1000);
+  const date = d.toISOString().slice(0, 10);
+  if (!intraday) return date;
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${date} ${hh}:${mm}Z`;
+}
+
+const _MONTH_ABBR = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const;
+
+/**
+ * Tick-mark formatter for the time scale.
+ *
+ * lightweight-charts passes a `tickMarkType` discriminator with each
+ * tick: 0=Year, 1=Month, 2=DayOfMonth, 3=Time, 4=TimeWithSeconds. We
+ * use that to render TradingView-style adaptive labels — within a day
+ * the axis shows times (`HH:MM`), at the day boundary it shows the
+ * date (`Apr 27`), and at month/year boundaries the abbreviated month
+ * or year. This matches the operator's reference (TradingView /
+ * Robinhood) so a multi-day intraday chart still tells you which day
+ * you're hovering over.
+ *
+ * Daily / weekly / monthly ranges only ever receive Year/Month/Day
+ * tick types — the intraday `Time` branch never fires for them, so
+ * this single formatter works for both modes.
+ */
+function tickFormatter(time: number, tickMarkType: number): string {
+  const d = new Date(time * 1000);
+  switch (tickMarkType) {
+    case 0: // Year
+      return String(d.getUTCFullYear());
+    case 1: // Month
+      return _MONTH_ABBR[d.getUTCMonth()] ?? "";
+    case 2: // DayOfMonth — start of a new day in intraday mode, or
+      // any tick in daily/weekly mode
+      return `${_MONTH_ABBR[d.getUTCMonth()]} ${d.getUTCDate()}`;
+    case 3: // Time — within a day on intraday charts
+    case 4: // TimeWithSeconds (we never request this density)
+    default: {
+      const hh = String(d.getUTCHours()).padStart(2, "0");
+      const mm = String(d.getUTCMinutes()).padStart(2, "0");
+      return `${hh}:${mm}`;
+    }
+  }
+}
+
 export interface PriceChartProps {
   symbol: string;
-  initialRange?: CandleRange;
+  initialRange?: ChartRange;
 }
 
 export function PriceChart({
@@ -131,8 +165,8 @@ export function PriceChart({
 }: PriceChartProps): JSX.Element {
   const [searchParams, setSearchParams] = useSearchParams();
   const rawChart = searchParams.get("chart");
-  const range: CandleRange = VALID_RANGES.includes(rawChart as CandleRange)
-    ? (rawChart as CandleRange)
+  const range: ChartRange = VALID_RANGES.includes(rawChart as ChartRange)
+    ? (rawChart as ChartRange)
     : initialRange;
   const rawType = searchParams.get("type");
   const chartType: ChartType = VALID_TYPES.includes(rawType as ChartType)
@@ -141,7 +175,7 @@ export function PriceChart({
   const priceScale: PriceScaleMode = searchParams.get("scale") === "log" ? "log" : "linear";
 
   const setRange = useCallback(
-    (next: CandleRange) => {
+    (next: ChartRange) => {
       const params = new URLSearchParams(searchParams);
       if (next === initialRange) {
         params.delete("chart");
@@ -176,8 +210,8 @@ export function PriceChart({
     setSearchParams(params, { replace: true });
   }, [searchParams, setSearchParams, priceScale]);
 
-  const { data, error, loading, refetch } = useAsync<InstrumentCandles>(
-    () => fetchInstrumentCandles(symbol, range),
+  const { data, error, loading, refetch } = useAsync<NormalisedChartCandles>(
+    () => fetchChartCandles(symbol, range),
     [symbol, range],
   );
 
@@ -190,7 +224,7 @@ export function PriceChart({
 
   const rows = dataMatchesRange && data ? data.rows : null;
   // Candlestick rendering needs all four OHLC values non-null AND a
-  // parseable date; `close`-only isn't enough (lightweight-charts
+  // parseable time; `close`-only isn't enough (lightweight-charts
   // silently drops partial bars, leaving a blank canvas). Mirrors the
   // filter in `ChartCanvas`'s setData effect exactly so the gate
   // can't accept rows the effect will then drop.
@@ -201,9 +235,10 @@ export function PriceChart({
         parseNum(r.open) !== null &&
         parseNum(r.high) !== null &&
         parseNum(r.low) !== null &&
-        parseNum(r.close) !== null &&
-        dateToTime(r.date) !== null,
+        parseNum(r.close) !== null,
     ).length >= 2;
+
+  const intraday = isIntraday(range);
 
   return (
     <div className="space-y-2">
@@ -218,7 +253,7 @@ export function PriceChart({
         onClick={(e) => e.stopPropagation()}
         data-testid="chart-controls"
       >
-        <div className="flex gap-1">
+        <div className="flex flex-wrap gap-1">
           {RANGES.map((r) => (
             <button
               key={r.id}
@@ -277,7 +312,11 @@ export function PriceChart({
       {!effectivelyLoading && error === null && dataMatchesRange && !hasChartData ? (
         <EmptyState
           title="No price data"
-          description="No candles in the local price_daily store for this range. Widen the range or wait for the next market-data refresh."
+          description={
+            intraday
+              ? "No intraday bars from the provider for this range. Try a longer range or check that the broker connection is healthy."
+              : "No candles in the local price_daily store for this range. Widen the range or wait for the next market-data refresh."
+          }
         />
       ) : null}
 
@@ -287,6 +326,7 @@ export function PriceChart({
           symbol={symbol}
           chartType={chartType}
           priceScale={priceScale}
+          intraday={intraday}
         />
       ) : null}
     </div>
@@ -294,10 +334,12 @@ export function PriceChart({
 }
 
 export interface ChartCanvasProps {
-  rows: CandleBar[];
+  rows: ReadonlyArray<NormalisedBar>;
   symbol: string;
   chartType?: ChartType;
   priceScale?: PriceScaleMode;
+  /** When true, hover label includes HH:MM and the time scale shows time. */
+  intraday?: boolean;
   containerClassName?: string;
 }
 
@@ -306,6 +348,7 @@ export function ChartCanvas({
   symbol,
   chartType = "candle",
   priceScale = "linear",
+  intraday = false,
   containerClassName,
 }: ChartCanvasProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -317,7 +360,14 @@ export function ChartCanvas({
   // Stable ref into `clean` for the crosshair handler — avoids stale
   // closure capture when rows update.
   const cleanRowsRef = useRef<NumericBar[]>([]);
+  const intradayRef = useRef<boolean>(intraday);
   const [hover, setHover] = useState<RichHoverState | null>(null);
+
+  // Keep the ref in sync so the crosshair handler (registered once at
+  // mount) sees the current intraday flag without re-subscribing.
+  useEffect(() => {
+    intradayRef.current = intraday;
+  }, [intraday]);
 
   // One-shot chart construction. lightweight-charts owns the DOM
   // canvas and its own lifecycle; we give it an empty div and clean
@@ -348,6 +398,12 @@ export function ChartCanvas({
         borderColor: chartTheme.borderColor,
         timeVisible: false,
         secondsVisible: false,
+        // Explicit formatter — without this the daily axis renders
+        // weekday abbreviations ("Mon Tue Wed") instead of dates and
+        // intraday axis hides the time component below ~minute zoom.
+        // The DeepPartial<HorzScaleOptions> type strips function
+        // properties; pass the formatter via the post-mount
+        // `applyOptions` effect below instead.
       },
       crosshair: {
         vertLine: { width: 1, color: chartTheme.crosshair, style: 3 },
@@ -420,9 +476,8 @@ export function ChartCanvas({
         prev !== null && prev !== undefined && prev.close !== 0
           ? ((bar.close - prev.close) / prev.close) * 100
           : null;
-      const date = new Date(time * 1000).toISOString().slice(0, 10);
       setHover({
-        date,
+        label: formatHoverLabel(time, intradayRef.current),
         open: bar.open,
         high: bar.high,
         low: bar.low,
@@ -468,6 +523,20 @@ export function ChartCanvas({
     chart.priceScale("right").applyOptions({ mode: SCALE_MODE_NUM[priceScale] });
   }, [priceScale]);
 
+  // Show time on the X-axis only for intraday data; the tick formatter
+  // adapts via the tickMarkType param so it does not need re-installing.
+  // tickMarkFormatter is typed via DeepPartial which strips function
+  // properties, so cast through `unknown` to keep the contract.
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+    chart.timeScale().applyOptions({
+      timeVisible: intraday,
+      secondsVisible: false,
+      tickMarkFormatter: tickFormatter,
+    } as unknown as Parameters<ReturnType<IChartApi["timeScale"]>["applyOptions"]>[0]);
+  }, [intraday]);
+
   // Feed data on every rows change. lightweight-charts replaces the
   // series wholesale via setData — no incremental diffing needed.
   useEffect(() => {
@@ -480,17 +549,25 @@ export function ChartCanvas({
 
     // Pre-convert to numeric bars so downstream `setData` calls work
     // with guaranteed-non-null values (no dead `?? 0` fallbacks). Rows
-    // that fail any numeric or date parse are dropped here.
+    // that fail any numeric parse are dropped here.
     const clean: NumericBar[] = rows.flatMap((r) => {
-      const time = dateToTime(r.date);
       const open = parseNum(r.open);
       const high = parseNum(r.high);
       const low = parseNum(r.low);
       const close = parseNum(r.close);
-      if (time === null || open === null || high === null || low === null || close === null) {
+      if (open === null || high === null || low === null || close === null) {
         return [];
       }
-      return [{ time, open, high, low, close, volume: parseNum(r.volume) ?? 0 }];
+      return [
+        {
+          time: r.time as UTCTimestamp,
+          open,
+          high,
+          low,
+          close,
+          volume: parseNum(r.volume) ?? 0,
+        },
+      ];
     });
     cleanRowsRef.current = clean;
 
@@ -534,35 +611,57 @@ export function ChartCanvas({
   );
 }
 
+function humanizeVolume(v: number): string {
+  if (!Number.isFinite(v) || v === 0) return "0";
+  const abs = Math.abs(v);
+  if (abs >= 1e9) return `${(v / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${(v / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${(v / 1e3).toFixed(2)}K`;
+  return v.toLocaleString();
+}
+
+/**
+ * TradingView-style status-line strip — single inline row at top-left.
+ * Replaces the prior multi-row floating box. Compact text, no shadow,
+ * transparent so the chart shows through cleanly. Color cues only on
+ * the close + delta to keep the eye on price action.
+ */
 function RichTooltip({ hover }: { hover: RichHoverState }): JSX.Element {
   const fmt = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  const deltaClass =
+    hover.changePct === null
+      ? "text-slate-500"
+      : hover.changePct >= 0
+        ? "text-emerald-600"
+        : "text-red-600";
   return (
     <div
-      className="absolute right-2 top-2 z-10 min-w-[160px] rounded bg-white/95 px-3 py-2 text-xs shadow-md"
+      className="absolute left-2 top-2 z-10 flex flex-wrap items-baseline gap-x-2 text-[11px] tabular-nums leading-tight text-slate-700"
       data-testid="price-chart-tooltip"
     >
-      <div className="text-slate-500">{hover.date}</div>
-      <dl className="mt-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 tabular-nums">
-        <dt className="text-slate-500">O</dt>
-        <dd>{fmt(hover.open)}</dd>
-        <dt className="text-slate-500">H</dt>
-        <dd>{fmt(hover.high)}</dd>
-        <dt className="text-slate-500">L</dt>
-        <dd>{fmt(hover.low)}</dd>
-        <dt className="text-slate-500">C</dt>
-        <dd className="font-medium text-slate-800">{fmt(hover.close)}</dd>
-        <dt className="text-slate-500">Vol</dt>
-        <dd>{fmt(hover.volume)}</dd>
-        {hover.changePct !== null ? (
-          <>
-            <dt className="text-slate-500">Δ%</dt>
-            <dd className={hover.changePct >= 0 ? "text-emerald-600" : "text-red-600"}>
-              {hover.changePct >= 0 ? "+" : ""}
-              {hover.changePct.toFixed(2)}%
-            </dd>
-          </>
-        ) : null}
-      </dl>
+      <span className="text-slate-500">{hover.label}</span>
+      <span className="text-slate-400">·</span>
+      <span>
+        <span className="text-slate-400">O</span> {fmt(hover.open)}
+      </span>
+      <span>
+        <span className="text-slate-400">H</span> {fmt(hover.high)}
+      </span>
+      <span>
+        <span className="text-slate-400">L</span> {fmt(hover.low)}
+      </span>
+      <span className="font-medium text-slate-800">
+        <span className="font-normal text-slate-400">C</span> {fmt(hover.close)}
+      </span>
+      <span>
+        <span className="text-slate-400">V</span> {humanizeVolume(hover.volume)}
+      </span>
+      {hover.changePct !== null ? (
+        <span className={deltaClass}>
+          {hover.changePct >= 0 ? "+" : ""}
+          {hover.changePct.toFixed(2)}%
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/lib/chartData.ts
+++ b/frontend/src/lib/chartData.ts
@@ -1,0 +1,177 @@
+/**
+ * Unified chart-data fetcher (#601).
+ *
+ * The chart UI exposes 9 range buttons (1D · 5D · 1M · 3M · 6M · YTD · 1Y · 5Y · MAX).
+ * Backend serves them via two endpoints:
+ *
+ *   * Daily (existing): `/instruments/{symbol}/candles?range=...` — reads
+ *     from the persisted `price_daily` series. Used for YTD / 1Y / 5Y / MAX.
+ *   * Intraday (#600):  `/instruments/{symbol}/intraday-candles?interval=...&count=...`
+ *     — eToro REST pass-through with TTL cache, no DB persistence.
+ *     Used for 1D / 5D / 1M / 3M / 6M.
+ *
+ * This module owns the (range → endpoint) dispatch table and the
+ * normalisation that flattens both responses into a single
+ * `NormalisedChartCandles` shape, so chart components can render either
+ * source without branching on endpoint.
+ *
+ * Lightweight-charts consumes time as a UTC epoch-second number
+ * (`UTCTimestamp`). Both daily (`YYYY-MM-DD`) and intraday
+ * (`YYYY-MM-DDTHH:MM:SSZ`) values normalise into that one shape.
+ */
+
+import {
+  fetchInstrumentCandles,
+  fetchInstrumentIntradayCandles,
+} from "@/api/instruments";
+import type {
+  CandleRange,
+  ChartRange,
+  IntradayInterval,
+} from "@/api/types";
+
+export type ChartDataKind = "intraday" | "daily";
+
+interface IntradayPlan {
+  readonly kind: "intraday";
+  readonly interval: IntradayInterval;
+  readonly count: number;
+}
+
+interface DailyPlan {
+  readonly kind: "daily";
+  readonly range: CandleRange;
+}
+
+export type ChartRangePlan = IntradayPlan | DailyPlan;
+
+/**
+ * Range → endpoint translation table.
+ *
+ * Counts target ~250–600 bars for sane chart density:
+ *   * 1d  →   ~390 1-min bars (one US trading day)
+ *   * 5d  →   ~390 5-min bars (five US trading days)
+ *   * 1m  →   ~330 30-min bars (~22 trading days)
+ *   * 3m  →   ~525 1-h bars (~65 trading days)
+ *   * 6m  →   ~390 4-h bars (~130 trading days)
+ *
+ * Daily-tier ranges defer to `price_daily`. Operator's "5Y" is mapped
+ * to the daily endpoint capped at 1000 bars per #603 (eToro's hard
+ * ceiling) — about 4 calendar years of trading-day price points.
+ */
+export const CHART_RANGE_PLAN: Record<ChartRange, ChartRangePlan> = {
+  "1d": { kind: "intraday", interval: "OneMinute", count: 390 },
+  "5d": { kind: "intraday", interval: "FiveMinutes", count: 390 },
+  "1m": { kind: "intraday", interval: "ThirtyMinutes", count: 330 },
+  "3m": { kind: "intraday", interval: "OneHour", count: 525 },
+  "6m": { kind: "intraday", interval: "FourHours", count: 390 },
+  ytd: { kind: "daily", range: "ytd" },
+  "1y": { kind: "daily", range: "1y" },
+  "5y": { kind: "daily", range: "5y" },
+  max: { kind: "daily", range: "max" },
+};
+
+export function planFor(range: ChartRange): ChartRangePlan {
+  return CHART_RANGE_PLAN[range];
+}
+
+export function isIntraday(range: ChartRange): boolean {
+  return CHART_RANGE_PLAN[range].kind === "intraday";
+}
+
+/**
+ * Bar shape consumed by the chart components. Time is a UTC epoch
+ * second so lightweight-charts can plot it directly without further
+ * conversion. OHLCV values stay as nullable strings to match the
+ * existing daily contract — null bars are dropped at the chart layer.
+ */
+export interface NormalisedBar {
+  readonly time: number;
+  readonly open: string | null;
+  readonly high: string | null;
+  readonly low: string | null;
+  readonly close: string | null;
+  readonly volume: string | null;
+}
+
+export interface NormalisedChartCandles {
+  readonly symbol: string;
+  readonly range: ChartRange;
+  readonly kind: ChartDataKind;
+  readonly rows: NormalisedBar[];
+}
+
+function dateToEpochSeconds(date: string): number | null {
+  const parts = date.split("-");
+  if (parts.length !== 3) return null;
+  const y = Number(parts[0]);
+  const m = Number(parts[1]);
+  const d = Number(parts[2]);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return null;
+  const ts = Date.UTC(y, m - 1, d);
+  if (!Number.isFinite(ts)) return null;
+  return Math.floor(ts / 1000);
+}
+
+function isoToEpochSeconds(iso: string): number | null {
+  // `Date(iso)` accepts both `YYYY-MM-DDTHH:MM:SSZ` and offset forms.
+  // NaN is returned by `Date#getTime()` if parsing fails — guard so a
+  // malformed bar is dropped rather than poisoning the time scale.
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return null;
+  return Math.floor(ms / 1000);
+}
+
+/**
+ * Resolve a chart range to bars, dispatched to the correct endpoint.
+ * Returns `null` for any row whose timestamp can't be parsed; the
+ * chart's existing valid-row gate filters those out.
+ */
+export async function fetchChartCandles(
+  symbol: string,
+  range: ChartRange,
+): Promise<NormalisedChartCandles> {
+  const plan = CHART_RANGE_PLAN[range];
+  if (plan.kind === "intraday") {
+    const res = await fetchInstrumentIntradayCandles(symbol, plan.interval, plan.count);
+    return {
+      symbol: res.symbol,
+      range,
+      kind: "intraday",
+      rows: res.rows.flatMap((b) => {
+        const time = isoToEpochSeconds(b.timestamp);
+        if (time === null) return [];
+        return [
+          {
+            time,
+            open: b.open,
+            high: b.high,
+            low: b.low,
+            close: b.close,
+            volume: b.volume === null ? null : String(b.volume),
+          },
+        ];
+      }),
+    };
+  }
+  const res = await fetchInstrumentCandles(symbol, plan.range);
+  return {
+    symbol: res.symbol,
+    range,
+    kind: "daily",
+    rows: res.rows.flatMap((b) => {
+      const time = dateToEpochSeconds(b.date);
+      if (time === null) return [];
+      return [
+        {
+          time,
+          open: b.open,
+          high: b.high,
+          low: b.low,
+          close: b.close,
+          volume: b.volume,
+        },
+      ];
+    }),
+  };
+}

--- a/frontend/src/lib/chartFormatters.ts
+++ b/frontend/src/lib/chartFormatters.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared chart formatters (#601).
+ *
+ * Single source of truth for tick / hover / volume formatting used by
+ * both `PriceChart` (instrument-page overview) and
+ * `ChartWorkspaceCanvas` (workspace). Keeping these here prevents the
+ * two surfaces drifting — a previous patch had `formatHoverLabel`
+ * copy-pasted into both, and a typo in one would silently diverge the
+ * UI without any test catching it.
+ *
+ * All helpers operate on UTC epoch seconds (the unified time format
+ * produced by `lib/chartData.ts` for both daily and intraday bars).
+ */
+
+const _MONTH_ABBR = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+/**
+ * Hover label.
+ *   - Daily/weekly/monthly: `YYYY-MM-DD`
+ *   - Intraday: `YYYY-MM-DD HH:MMZ` so the operator sees the full
+ *     timestamp and the trailing `Z` makes it obvious the time is UTC.
+ */
+export function formatHoverLabel(epochSeconds: number, intraday: boolean): string {
+  const d = new Date(epochSeconds * 1000);
+  const date = d.toISOString().slice(0, 10);
+  if (!intraday) return date;
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${date} ${hh}:${mm}Z`;
+}
+
+/**
+ * Adaptive tick-mark formatter for the time scale. lightweight-charts
+ * passes a `tickMarkType` discriminator with each tick:
+ *   0 = Year, 1 = Month, 2 = DayOfMonth, 3 = Time, 4 = TimeWithSeconds
+ * We use that to render TradingView-style adaptive labels — `HH:MM`
+ * within a day, `Apr 27` at the day boundary, `Apr` at month, year at
+ * year. Single formatter handles both daily and intraday modes
+ * because the library only emits the higher-resolution discriminators
+ * when the chart is actually intraday.
+ */
+export function tickFormatter(time: number, tickMarkType: number): string {
+  const d = new Date(time * 1000);
+  switch (tickMarkType) {
+    case 0:
+      return String(d.getUTCFullYear());
+    case 1:
+      return _MONTH_ABBR[d.getUTCMonth()] ?? "";
+    case 2:
+      return `${_MONTH_ABBR[d.getUTCMonth()]} ${d.getUTCDate()}`;
+    case 3:
+    case 4:
+    default: {
+      const hh = String(d.getUTCHours()).padStart(2, "0");
+      const mm = String(d.getUTCMinutes()).padStart(2, "0");
+      return `${hh}:${mm}`;
+    }
+  }
+}
+
+/**
+ * Volume in TradingView-style abbreviated form: `14.36K`, `1.20M`,
+ * `1.20B`. Kept separate from the price formatter because volumes
+ * have a different scale and the abbreviation is what an operator
+ * expects to see — full integer would dominate the status-line strip.
+ */
+export function humanizeVolume(v: number): string {
+  if (!Number.isFinite(v) || v === 0) return "0";
+  const abs = Math.abs(v);
+  if (abs >= 1e9) return `${(v / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${(v / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${(v / 1e3).toFixed(2)}K`;
+  return v.toLocaleString();
+}

--- a/frontend/src/pages/ChartPage.test.tsx
+++ b/frontend/src/pages/ChartPage.test.tsx
@@ -76,22 +76,37 @@ vi.mock("@/pages/components/ChartWorkspaceCanvas", () => ({
 
 vi.mock("@/api/instruments", () => ({
   fetchInstrumentSummary: vi.fn(),
-  fetchInstrumentCandles: vi.fn(),
 }));
 
-import { fetchInstrumentSummary, fetchInstrumentCandles } from "@/api/instruments";
-import type { InstrumentCandles, InstrumentSummary } from "@/api/types";
+vi.mock("@/lib/chartData", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/chartData")>("@/lib/chartData");
+  return {
+    ...actual,
+    fetchChartCandles: vi.fn(),
+  };
+});
+
+import { fetchInstrumentSummary } from "@/api/instruments";
+import type { InstrumentSummary, ChartRange } from "@/api/types";
+import { fetchChartCandles, type NormalisedBar, type NormalisedChartCandles } from "@/lib/chartData";
 import { ChartPage } from "./ChartPage";
 
 const mockSummary = vi.mocked(fetchInstrumentSummary);
-const mockCandles = vi.mocked(fetchInstrumentCandles);
+const mockCandles = vi.mocked(fetchChartCandles);
 
 function makeCandles(
-  range: InstrumentCandles["range"],
-  rows: InstrumentCandles["rows"] = [],
+  range: ChartRange,
+  rows: NormalisedBar[] = [],
   symbol = "AAPL",
-): InstrumentCandles {
-  return { symbol, range, days: 365, rows };
+): NormalisedChartCandles {
+  // YTD/1Y/5Y/MAX → daily, others → intraday per CHART_RANGE_PLAN.
+  const intradayRanges: ChartRange[] = ["1d", "5d", "1m", "3m", "6m"];
+  return {
+    symbol,
+    range,
+    kind: intradayRanges.includes(range) ? "intraday" : "daily",
+    rows,
+  };
 }
 
 function makeSummary(): InstrumentSummary {
@@ -109,10 +124,24 @@ function makeSummary(): InstrumentSummary {
   } as InstrumentSummary;
 }
 
-function twoValidRows(): InstrumentCandles["rows"] {
+function twoValidRows(): NormalisedBar[] {
   return [
-    { date: "2026-01-10", open: "180", high: "182", low: "179", close: "181", volume: "1000" },
-    { date: "2026-01-11", open: "181", high: "184", low: "180", close: "183", volume: "1200" },
+    {
+      time: Math.floor(Date.UTC(2026, 0, 10) / 1000),
+      open: "180",
+      high: "182",
+      low: "179",
+      close: "181",
+      volume: "1000",
+    },
+    {
+      time: Math.floor(Date.UTC(2026, 0, 11) / 1000),
+      open: "181",
+      high: "184",
+      low: "180",
+      close: "183",
+      volume: "1200",
+    },
   ];
 }
 
@@ -163,9 +192,9 @@ describe("ChartPage — header", () => {
 });
 
 describe("ChartPage — range picker", () => {
-  it("renders all seven range buttons", async () => {
+  it("renders all nine range buttons (post-#601 with 1D/5D/YTD)", async () => {
     renderPage();
-    for (const r of ["1w", "1m", "3m", "6m", "1y", "5y", "max"]) {
+    for (const r of ["1d", "5d", "1m", "3m", "6m", "ytd", "1y", "5y", "max"]) {
       expect(screen.getByTestId(`chart-range-${r}`)).toBeInTheDocument();
     }
   });
@@ -224,8 +253,22 @@ describe("ChartPage — chart body", () => {
   it("shows empty state when rows have no valid OHLC", async () => {
     mockCandles.mockResolvedValue(
       makeCandles("1y", [
-        { date: "2026-01-10", open: null, high: null, low: null, close: "181", volume: "1000" },
-        { date: "2026-01-11", open: null, high: null, low: null, close: "183", volume: "1200" },
+        {
+          time: Math.floor(Date.UTC(2026, 0, 10) / 1000),
+          open: null,
+          high: null,
+          low: null,
+          close: "181",
+          volume: "1000",
+        },
+        {
+          time: Math.floor(Date.UTC(2026, 0, 11) / 1000),
+          open: null,
+          high: null,
+          low: null,
+          close: "183",
+          volume: "1200",
+        },
       ]),
     );
     renderPage();

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -9,12 +9,18 @@
  *          linear regression line + range channel toggles
  *          (URL: `?trend=regression,channel`).
  * Phase 4: raw OHLCV table + CSV export (URL: `?view=raw`).
+ * Phase 5 (#601): range table flipped to 1D/5D/1M/3M/6M/YTD/1Y/5Y/MAX.
+ *          Sub-day ranges hit the live intraday endpoint; longer
+ *          ranges read `price_daily`. Compare overlays are disabled
+ *          on intraday ranges — fanning out N intraday fetches per
+ *          chart open would burn rate budget without analytical
+ *          payoff.
  */
 import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 
-import { fetchInstrumentCandles, fetchInstrumentSummary } from "@/api/instruments";
-import type { CandleBar, CandleRange, InstrumentCandles, InstrumentSummary } from "@/api/types";
+import { fetchInstrumentSummary } from "@/api/instruments";
+import type { ChartRange, InstrumentSummary } from "@/api/types";
 import {
   ChartWorkspaceCanvas,
   INDICATOR_IDS,
@@ -24,21 +30,39 @@ import {
 import { RawOhlcvTable } from "@/pages/components/RawOhlcvTable";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
+import {
+  fetchChartCandles,
+  isIntraday,
+  type NormalisedBar,
+  type NormalisedChartCandles,
+} from "@/lib/chartData";
 import { useAsync } from "@/lib/useAsync";
 
-const RANGES: { id: CandleRange; label: string }[] = [
-  { id: "1w", label: "1W" },
+const RANGES: { id: ChartRange; label: string }[] = [
+  { id: "1d", label: "1D" },
+  { id: "5d", label: "5D" },
   { id: "1m", label: "1M" },
   { id: "3m", label: "3M" },
   { id: "6m", label: "6M" },
+  { id: "ytd", label: "YTD" },
   { id: "1y", label: "1Y" },
   { id: "5y", label: "5Y" },
   { id: "max", label: "MAX" },
 ];
 
-const VALID_RANGES: readonly CandleRange[] = ["1w", "1m", "3m", "6m", "1y", "5y", "max"];
+const VALID_RANGES: readonly ChartRange[] = [
+  "1d",
+  "5d",
+  "1m",
+  "3m",
+  "6m",
+  "ytd",
+  "1y",
+  "5y",
+  "max",
+];
 
-const DEFAULT_RANGE: CandleRange = "1y";
+const DEFAULT_RANGE: ChartRange = "1y";
 
 const INDICATOR_LABELS: Record<IndicatorId, string> = {
   sma20: "SMA 20",
@@ -65,30 +89,18 @@ function parseNum(v: string | null | undefined): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-function dateToTime(date: string): number | null {
-  const parts = date.split("-");
-  if (parts.length !== 3) return null;
-  const y = Number(parts[0]);
-  const m = Number(parts[1]);
-  const d = Number(parts[2]);
-  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return null;
-  const ts = Date.UTC(y, m - 1, d);
-  if (!Number.isFinite(ts)) return null;
-  return ts / 1000;
-}
-
 export function ChartPage(): JSX.Element {
   const { symbol = "" } = useParams<{ symbol: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
 
   // Range param
   const rawRange = searchParams.get("range");
-  const range: CandleRange = VALID_RANGES.includes(rawRange as CandleRange)
-    ? (rawRange as CandleRange)
+  const range: ChartRange = VALID_RANGES.includes(rawRange as ChartRange)
+    ? (rawRange as ChartRange)
     : DEFAULT_RANGE;
 
   const setRange = useCallback(
-    (next: CandleRange) => {
+    (next: ChartRange) => {
       const params = new URLSearchParams(searchParams);
       if (next === DEFAULT_RANGE) {
         params.delete("range");
@@ -99,6 +111,8 @@ export function ChartPage(): JSX.Element {
     },
     [searchParams, setSearchParams],
   );
+
+  const intraday = isIntraday(range);
 
   // Indicator param — CSV of enabled indicator ids
   const indParam = searchParams.get("ind");
@@ -125,9 +139,12 @@ export function ChartPage(): JSX.Element {
     [searchParams, setSearchParams, enabledIndicators],
   );
 
-  // Compare param — CSV of compare symbols (max 3, uppercase, deduped)
+  // Compare param — CSV of compare symbols (max 3, uppercase, deduped).
+  // Disabled on intraday ranges — operator gets the persisted compare
+  // list back when they switch to a daily range.
   const compareParam = searchParams.get("compare");
   const compareSymbols: string[] = (() => {
+    if (intraday) return [];
     if (compareParam === null || compareParam.length === 0) return [];
     const seen = new Set<string>();
     const out: string[] = [];
@@ -231,19 +248,19 @@ export function ChartPage(): JSX.Element {
     [handleCompareSubmit],
   );
 
-  // Primary candle fetch.
+  // Primary candle fetch via the unified dispatch.
   const summaryAsync = useAsync<InstrumentSummary>(
     () => fetchInstrumentSummary(symbol),
     [symbol],
   );
-  const candlesAsync = useAsync<InstrumentCandles>(
-    () => fetchInstrumentCandles(symbol, range),
+  const candlesAsync = useAsync<NormalisedChartCandles>(
+    () => fetchChartCandles(symbol, range),
     [symbol, range],
   );
 
   // Compare candle fetches: parallel, keyed on [range, ...compareSymbols].
   // We use a single useEffect + useState<Map> to manage compare fetches.
-  const [compareData, setCompareData] = useState<Map<string, CandleBar[]>>(new Map());
+  const [compareData, setCompareData] = useState<Map<string, NormalisedBar[]>>(new Map());
   // Symbols whose fetch failed — shown with an error chip.
   const [compareErrors, setCompareErrors] = useState<string[]>([]);
   // Track the set of symbols + range for which we've started fetching.
@@ -267,10 +284,10 @@ export function ChartPage(): JSX.Element {
 
     let cancelled = false;
     void Promise.allSettled(
-      compareSymbols.map((sym) => fetchInstrumentCandles(sym, range)),
+      compareSymbols.map((sym) => fetchChartCandles(sym, range)),
     ).then((results) => {
       if (cancelled) return;
-      const m = new Map<string, CandleBar[]>();
+      const m = new Map<string, NormalisedBar[]>();
       const failures: string[] = [];
       results.forEach((r, i) => {
         const sym = compareSymbols[i]!;
@@ -308,8 +325,7 @@ export function ChartPage(): JSX.Element {
         parseNum(r.open) !== null &&
         parseNum(r.high) !== null &&
         parseNum(r.low) !== null &&
-        parseNum(r.close) !== null &&
-        dateToTime(r.date) !== null,
+        parseNum(r.close) !== null,
     ).length >= 2;
 
   return (
@@ -342,7 +358,7 @@ export function ChartPage(): JSX.Element {
 
       {/* Controls: range picker + view toggle + chart-only controls */}
       <div className="flex flex-wrap items-center gap-3">
-        <div className="flex gap-1">
+        <div className="flex flex-wrap gap-1">
           {RANGES.map((r) => (
             <button
               key={r.id}
@@ -441,8 +457,10 @@ export function ChartPage(): JSX.Element {
         )}
       </div>
 
-      {/* Chart-only: compare row */}
-      {view === "chart" && (
+      {/* Chart-only: compare row. Hidden on intraday ranges — fanning
+          out N intraday fetches per chart open would burn external
+          quota without analytical payoff at sub-day timeframes. */}
+      {view === "chart" && !intraday && (
         <div className="flex flex-wrap items-center gap-2">
           <span className="text-[11px] uppercase tracking-wider text-slate-500">Compare</span>
           {compareSymbols.map((sym) => {
@@ -507,7 +525,11 @@ export function ChartPage(): JSX.Element {
           <div className="p-4">
             <EmptyState
               title="No price data"
-              description="No candles in the local price_daily store for this range."
+              description={
+                intraday
+                  ? "No intraday bars from the provider for this range."
+                  : "No candles in the local price_daily store for this range."
+              }
             />
           </div>
         ) : null}
@@ -519,11 +541,12 @@ export function ChartPage(): JSX.Element {
             compares={compareSeries}
             showRegression={enabledTrends.includes("regression")}
             showChannel={enabledTrends.includes("channel")}
+            intraday={intraday}
             containerClassName="h-[70vh] w-full"
           />
         ) : null}
         {view === "raw" && !effectivelyLoading && candlesAsync.error === null && dataMatchesRange ? (
-          <RawOhlcvTable rows={rows ?? []} symbol={symbol} range={range} />
+          <RawOhlcvTable rows={rows ?? []} symbol={symbol} range={range} intraday={intraday} />
         ) : null}
       </div>
     </div>

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -23,6 +23,7 @@ import {
 } from "lightweight-charts";
 
 import type { NormalisedBar } from "@/lib/chartData";
+import { formatHoverLabel, humanizeVolume, tickFormatter } from "@/lib/chartFormatters";
 import { chartTheme } from "@/lib/chartTheme";
 
 export type IndicatorId = "sma20" | "sma50" | "ema20" | "ema50";
@@ -80,40 +81,8 @@ function parseNum(v: string | null | undefined): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-function formatHoverLabel(epochSeconds: number, intraday: boolean): string {
-  const d = new Date(epochSeconds * 1000);
-  const date = d.toISOString().slice(0, 10);
-  if (!intraday) return date;
-  const hh = String(d.getUTCHours()).padStart(2, "0");
-  const mm = String(d.getUTCMinutes()).padStart(2, "0");
-  return `${date} ${hh}:${mm}Z`;
-}
-
-const _MONTH_ABBR = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const;
-
-/**
- * Adaptive tick-mark formatter — uses lightweight-charts' tickMarkType
- * to render date markers at day/month/year boundaries and time within
- * a day. See PriceChart.tsx for the same formatter and rationale.
- */
-function tickFormatter(time: number, tickMarkType: number): string {
-  const d = new Date(time * 1000);
-  switch (tickMarkType) {
-    case 0:
-      return String(d.getUTCFullYear());
-    case 1:
-      return _MONTH_ABBR[d.getUTCMonth()] ?? "";
-    case 2:
-      return `${_MONTH_ABBR[d.getUTCMonth()]} ${d.getUTCDate()}`;
-    case 3:
-    case 4:
-    default: {
-      const hh = String(d.getUTCHours()).padStart(2, "0");
-      const mm = String(d.getUTCMinutes()).padStart(2, "0");
-      return `${hh}:${mm}`;
-    }
-  }
-}
+// formatHoverLabel / tickFormatter / humanizeVolume share definitions
+// with PriceChart via @/lib/chartFormatters — see comment there.
 
 // Pure functions — exported for unit testing.
 
@@ -707,15 +676,6 @@ export function ChartWorkspaceCanvas({
       />
     </div>
   );
-}
-
-function humanizeVolume(v: number): string {
-  if (!Number.isFinite(v) || v === 0) return "0";
-  const abs = Math.abs(v);
-  if (abs >= 1e9) return `${(v / 1e9).toFixed(2)}B`;
-  if (abs >= 1e6) return `${(v / 1e6).toFixed(2)}M`;
-  if (abs >= 1e3) return `${(v / 1e3).toFixed(2)}K`;
-  return v.toLocaleString();
 }
 
 /**

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -22,7 +22,7 @@ import {
   type UTCTimestamp,
 } from "lightweight-charts";
 
-import type { CandleBar } from "@/api/types";
+import type { NormalisedBar } from "@/lib/chartData";
 import { chartTheme } from "@/lib/chartTheme";
 
 export type IndicatorId = "sma20" | "sma50" | "ema20" | "ema50";
@@ -45,7 +45,7 @@ export const COMPARE_COLORS: readonly string[] = chartTheme.compare;
 
 export interface CompareSeries {
   readonly symbol: string;
-  readonly rows: CandleBar[];
+  readonly rows: ReadonlyArray<NormalisedBar>;
 }
 
 interface NumericBar {
@@ -80,16 +80,39 @@ function parseNum(v: string | null | undefined): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-function dateToTime(date: string): UTCTimestamp | null {
-  const parts = date.split("-");
-  if (parts.length !== 3) return null;
-  const y = Number(parts[0]);
-  const m = Number(parts[1]);
-  const d = Number(parts[2]);
-  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return null;
-  const ts = Date.UTC(y, m - 1, d);
-  if (!Number.isFinite(ts)) return null;
-  return (ts / 1000) as UTCTimestamp;
+function formatHoverLabel(epochSeconds: number, intraday: boolean): string {
+  const d = new Date(epochSeconds * 1000);
+  const date = d.toISOString().slice(0, 10);
+  if (!intraday) return date;
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${date} ${hh}:${mm}Z`;
+}
+
+const _MONTH_ABBR = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const;
+
+/**
+ * Adaptive tick-mark formatter — uses lightweight-charts' tickMarkType
+ * to render date markers at day/month/year boundaries and time within
+ * a day. See PriceChart.tsx for the same formatter and rationale.
+ */
+function tickFormatter(time: number, tickMarkType: number): string {
+  const d = new Date(time * 1000);
+  switch (tickMarkType) {
+    case 0:
+      return String(d.getUTCFullYear());
+    case 1:
+      return _MONTH_ABBR[d.getUTCMonth()] ?? "";
+    case 2:
+      return `${_MONTH_ABBR[d.getUTCMonth()]} ${d.getUTCDate()}`;
+    case 3:
+    case 4:
+    default: {
+      const hh = String(d.getUTCHours()).padStart(2, "0");
+      const mm = String(d.getUTCMinutes()).padStart(2, "0");
+      return `${hh}:${mm}`;
+    }
+  }
 }
 
 // Pure functions — exported for unit testing.
@@ -179,12 +202,14 @@ function computeIndicator(id: IndicatorId, closes: number[]): Array<number | nul
 }
 
 export interface ChartWorkspaceCanvasProps {
-  readonly rows: CandleBar[];
+  readonly rows: ReadonlyArray<NormalisedBar>;
   readonly symbol: string;
   readonly indicators: ReadonlyArray<IndicatorId>;
   readonly compares?: ReadonlyArray<CompareSeries>;
   readonly showRegression?: boolean;
   readonly showChannel?: boolean;
+  /** Show time on the x-axis (intraday data). */
+  readonly intraday?: boolean;
   readonly containerClassName?: string;
 }
 
@@ -195,6 +220,7 @@ export function ChartWorkspaceCanvas({
   compares = [],
   showRegression = false,
   showChannel = false,
+  intraday = false,
   containerClassName,
 }: ChartWorkspaceCanvasProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -217,9 +243,26 @@ export function ChartWorkspaceCanvas({
   // truth so the tooltip and the LineSeries always agree on color even
   // after add/remove cycles change Map insertion order.
   const compareColorRef = useRef<Map<string, string>>(new Map());
+  // Stable ref so the crosshair handler (subscribed once at mount)
+  // sees the current intraday flag without re-subscribing every time
+  // the prop changes.
+  const intradayRef = useRef<boolean>(intraday);
   const [hover, setHover] = useState<RichHoverState | null>(null);
 
   const compareMode = compares.length > 0;
+
+  // Keep intraday ref + time-axis options in sync with the prop.
+  useEffect(() => {
+    intradayRef.current = intraday;
+    const chart = chartRef.current;
+    if (chart) {
+      chart.timeScale().applyOptions({
+        timeVisible: intraday,
+        secondsVisible: false,
+        tickMarkFormatter: tickFormatter,
+      } as unknown as Parameters<ReturnType<IChartApi["timeScale"]>["applyOptions"]>[0]);
+    }
+  }, [intraday]);
 
   // One-shot chart construction — mirrors ChartCanvas setup.
   useEffect(() => {
@@ -300,7 +343,7 @@ export function ChartWorkspaceCanvas({
             color: compareColorRef.current.get(sym) ?? chartTheme.compare[0],
             value: norm[idx] ?? null,
           }));
-        const date = new Date(time * 1000).toISOString().slice(0, 10);
+        const date = formatHoverLabel(time, intradayRef.current);
         setHover({
           date,
           mode: "compare",
@@ -327,7 +370,10 @@ export function ChartWorkspaceCanvas({
         indicatorRows.push({ id, label: SMA_LABELS[id]!, value: v });
       }
 
-      const date = new Date(time * 1000).toISOString().slice(0, 10);
+      // Use the same date formatter as the compare path so intraday
+      // hovers show HH:MM (the date-only branch above used to drop
+      // the time component — Codex flagged this).
+      const date = formatHoverLabel(time, intradayRef.current);
       setHover({
         date,
         mode: "ohlcv",
@@ -369,15 +415,23 @@ export function ChartWorkspaceCanvas({
     if (!candle || !volume || !chart || !primaryLine) return;
 
     const clean: NumericBar[] = rows.flatMap((r) => {
-      const time = dateToTime(r.date);
       const open = parseNum(r.open);
       const high = parseNum(r.high);
       const low = parseNum(r.low);
       const close = parseNum(r.close);
-      if (time === null || open === null || high === null || low === null || close === null) {
+      if (open === null || high === null || low === null || close === null) {
         return [];
       }
-      return [{ time, open, high, low, close, volume: parseNum(r.volume) ?? 0 }];
+      return [
+        {
+          time: r.time as UTCTimestamp,
+          open,
+          high,
+          low,
+          close,
+          volume: parseNum(r.volume) ?? 0,
+        },
+      ];
     });
     cleanRowsRef.current = clean;
 
@@ -453,10 +507,18 @@ export function ChartWorkspaceCanvas({
       compareColorRef.current.set(cs.symbol, color);
 
       const compareClean: NumericBar[] = cs.rows.flatMap((r) => {
-        const time = dateToTime(r.date);
         const close = parseNum(r.close);
-        if (time === null || close === null) return [];
-        return [{ time, open: close, high: close, low: close, close, volume: 0 }];
+        if (close === null) return [];
+        return [
+          {
+            time: r.time as UTCTimestamp,
+            open: close,
+            high: close,
+            low: close,
+            close,
+            volume: 0,
+          },
+        ];
       });
 
       // Build a time→close map so we can align with the primary series times.
@@ -647,6 +709,21 @@ export function ChartWorkspaceCanvas({
   );
 }
 
+function humanizeVolume(v: number): string {
+  if (!Number.isFinite(v) || v === 0) return "0";
+  const abs = Math.abs(v);
+  if (abs >= 1e9) return `${(v / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${(v / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${(v / 1e3).toFixed(2)}K`;
+  return v.toLocaleString();
+}
+
+/**
+ * TradingView-style status-line tooltip — single inline row at top-left,
+ * no shadow box. Replaces the prior multi-row floating box that covered
+ * the price-axis on the workspace chart. Indicator readouts wrap onto
+ * a second row when present.
+ */
 function RichTooltip({ hover }: { hover: RichHoverState }): JSX.Element {
   const fmt = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 2 });
   const fmtPct = (v: number | null | undefined) => {
@@ -655,73 +732,74 @@ function RichTooltip({ hover }: { hover: RichHoverState }): JSX.Element {
   };
 
   if (hover.mode === "compare") {
+    const primaryClass =
+      (hover.primaryPct ?? 0) >= 0 ? "text-emerald-600" : "text-red-600";
     return (
-      <div className="absolute right-2 top-2 z-10 min-w-[180px] rounded bg-white/95 px-3 py-2 text-xs shadow-md">
-        <div className="text-slate-500">{hover.date}</div>
-        <dl className="mt-1 space-y-0.5 tabular-nums">
-          <div className="flex justify-between gap-3">
-            <span className="font-medium text-slate-800">{hover.primarySymbol}</span>
+      <div className="absolute left-2 top-2 z-10 flex flex-wrap items-baseline gap-x-2 text-[11px] tabular-nums leading-tight text-slate-700">
+        <span className="text-slate-500">{hover.date}</span>
+        <span className="text-slate-400">·</span>
+        <span className="font-medium text-slate-800">{hover.primarySymbol}</span>
+        <span className={primaryClass}>{fmtPct(hover.primaryPct)}</span>
+        {hover.comparePcts?.map((cp) => (
+          <span key={cp.symbol} className="flex items-baseline gap-1">
+            <span style={{ color: cp.color }} className="font-medium">
+              {cp.symbol}
+            </span>
             <span
               className={
-                (hover.primaryPct ?? 0) >= 0 ? "text-emerald-600" : "text-red-600"
+                cp.value !== null && cp.value >= 0 ? "text-emerald-600" : "text-red-600"
               }
             >
-              {fmtPct(hover.primaryPct)}
+              {fmtPct(cp.value)}
             </span>
-          </div>
-          {hover.comparePcts?.map((cp) => (
-            <div key={cp.symbol} className="flex justify-between gap-3">
-              <span style={{ color: cp.color }} className="font-medium">
-                {cp.symbol}
-              </span>
-              <span
-                className={cp.value !== null && cp.value >= 0 ? "text-emerald-600" : "text-red-600"}
-              >
-                {fmtPct(cp.value)}
-              </span>
-            </div>
-          ))}
-        </dl>
+          </span>
+        ))}
       </div>
     );
   }
 
-  // OHLCV mode
+  // OHLCV mode — single inline row, indicator chips wrap on overflow.
+  const deltaClass =
+    hover.changePct === null || hover.changePct === undefined
+      ? "text-slate-500"
+      : hover.changePct >= 0
+        ? "text-emerald-600"
+        : "text-red-600";
   return (
-    <div className="absolute right-2 top-2 z-10 min-w-[180px] rounded bg-white/95 px-3 py-2 text-xs shadow-md">
-      <div className="text-slate-500">{hover.date}</div>
-      <dl className="mt-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 tabular-nums">
-        <dt className="text-slate-500">O</dt>
-        <dd>{fmt(hover.open ?? 0)}</dd>
-        <dt className="text-slate-500">H</dt>
-        <dd>{fmt(hover.high ?? 0)}</dd>
-        <dt className="text-slate-500">L</dt>
-        <dd>{fmt(hover.low ?? 0)}</dd>
-        <dt className="text-slate-500">C</dt>
-        <dd className="font-medium text-slate-800">{fmt(hover.close ?? 0)}</dd>
-        <dt className="text-slate-500">Vol</dt>
-        <dd>{fmt(hover.volume ?? 0)}</dd>
-        {hover.changePct !== null && hover.changePct !== undefined ? (
-          <>
-            <dt className="text-slate-500">Δ%</dt>
-            <dd className={hover.changePct >= 0 ? "text-emerald-600" : "text-red-600"}>
-              {hover.changePct >= 0 ? "+" : ""}
-              {hover.changePct.toFixed(2)}%
-            </dd>
-          </>
-        ) : null}
-      </dl>
+    <div className="absolute left-2 top-2 z-10 flex flex-wrap items-baseline gap-x-2 text-[11px] tabular-nums leading-tight text-slate-700">
+      <span className="text-slate-500">{hover.date}</span>
+      <span className="text-slate-400">·</span>
+      <span>
+        <span className="text-slate-400">O</span> {fmt(hover.open ?? 0)}
+      </span>
+      <span>
+        <span className="text-slate-400">H</span> {fmt(hover.high ?? 0)}
+      </span>
+      <span>
+        <span className="text-slate-400">L</span> {fmt(hover.low ?? 0)}
+      </span>
+      <span className="font-medium text-slate-800">
+        <span className="font-normal text-slate-400">C</span> {fmt(hover.close ?? 0)}
+      </span>
+      <span>
+        <span className="text-slate-400">V</span> {humanizeVolume(hover.volume ?? 0)}
+      </span>
+      {hover.changePct !== null && hover.changePct !== undefined ? (
+        <span className={deltaClass}>
+          {hover.changePct >= 0 ? "+" : ""}
+          {hover.changePct.toFixed(2)}%
+        </span>
+      ) : null}
       {hover.indicators !== undefined && hover.indicators.length > 0 ? (
-        <div className="mt-1 border-t border-slate-100 pt-1">
+        <>
+          <span className="text-slate-400">·</span>
           {hover.indicators.map((row) => (
-            <div key={row.id} className="flex justify-between text-[11px]">
-              <span className="text-slate-500">{row.label}</span>
-              <span className="tabular-nums" style={{ color: SMA_COLORS[row.id] }}>
-                {fmt(row.value)}
-              </span>
-            </div>
+            <span key={row.id} className="flex items-baseline gap-1">
+              <span className="text-slate-400">{row.label}</span>
+              <span style={{ color: SMA_COLORS[row.id] }}>{fmt(row.value)}</span>
+            </span>
           ))}
-        </div>
+        </>
       ) : null}
     </div>
   );

--- a/frontend/src/pages/components/RawOhlcvTable.test.tsx
+++ b/frontend/src/pages/components/RawOhlcvTable.test.tsx
@@ -2,13 +2,19 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+import type { NormalisedBar } from "@/lib/chartData";
 import { RawOhlcvTable } from "./RawOhlcvTable";
 
-const rows = [
-  { date: "2026-04-01", open: "100", high: "110", low: "95", close: "105", volume: "10000" },
-  { date: "2026-04-02", open: "105", high: "115", low: "100", close: "110", volume: "12000" },
-  { date: "2026-04-03", open: "110", high: "120", low: "105", close: "115", volume: "14000" },
-] as never;
+// Daily UTC-midnight epoch seconds for 2026-04-01 / 02 / 03.
+const T1 = Math.floor(Date.UTC(2026, 3, 1) / 1000);
+const T2 = Math.floor(Date.UTC(2026, 3, 2) / 1000);
+const T3 = Math.floor(Date.UTC(2026, 3, 3) / 1000);
+
+const rows: NormalisedBar[] = [
+  { time: T1, open: "100", high: "110", low: "95", close: "105", volume: "10000" },
+  { time: T2, open: "105", high: "115", low: "100", close: "110", volume: "12000" },
+  { time: T3, open: "110", high: "120", low: "105", close: "115", volume: "14000" },
+];
 
 describe("RawOhlcvTable", () => {
   it("renders all rows in newest-first order by default", () => {
@@ -47,11 +53,21 @@ describe("RawOhlcvTable", () => {
   });
 
   it("renders null OHLCV values as em-dash", () => {
-    const nullRow = [
-      { date: "2026-04-01", open: null, high: null, low: null, close: null, volume: null },
-    ] as never;
+    const nullRow: NormalisedBar[] = [
+      { time: T1, open: null, high: null, low: null, close: null, volume: null },
+    ];
     render(<RawOhlcvTable rows={nullRow} symbol="GME" range="1m" />);
     // 5 em-dashes (open/high/low/close/volume — date is never null)
     expect(screen.getAllByText("—")).toHaveLength(5);
+  });
+
+  it("intraday=true renders timestamp with HH:MM and uses Time header label", () => {
+    const t = Math.floor(Date.UTC(2026, 3, 27, 14, 30) / 1000);
+    const intradayRows: NormalisedBar[] = [
+      { time: t, open: "100", high: "100", low: "100", close: "100", volume: "1" },
+    ];
+    render(<RawOhlcvTable rows={intradayRows} symbol="GME" range="1d" intraday />);
+    expect(screen.getByText("2026-04-27 14:30Z")).toBeInTheDocument();
+    expect(screen.getByText(/^Time/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/components/RawOhlcvTable.tsx
+++ b/frontend/src/pages/components/RawOhlcvTable.tsx
@@ -3,6 +3,7 @@ import { useState, type JSX } from "react";
 import type { ChartRange } from "@/api/types";
 import { EmptyState } from "@/components/states/EmptyState";
 import type { NormalisedBar } from "@/lib/chartData";
+import { formatHoverLabel } from "@/lib/chartFormatters";
 
 export interface RawOhlcvTableProps {
   readonly rows: ReadonlyArray<NormalisedBar>;
@@ -21,14 +22,8 @@ function formatNum(v: string | null | undefined): string {
   return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
 }
 
-function formatTime(epochSeconds: number, intraday: boolean): string {
-  const d = new Date(epochSeconds * 1000);
-  const date = d.toISOString().slice(0, 10);
-  if (!intraday) return date;
-  const hh = String(d.getUTCHours()).padStart(2, "0");
-  const mm = String(d.getUTCMinutes()).padStart(2, "0");
-  return `${date} ${hh}:${mm}Z`;
-}
+// Time/timestamp rendering shares a single helper with the chart
+// hover tooltip — see @/lib/chartFormatters.
 
 function downloadCsv(
   rows: ReadonlyArray<NormalisedBar>,
@@ -40,7 +35,7 @@ function downloadCsv(
   const body = rows
     .map(
       (r) =>
-        `${formatTime(r.time, intraday)},${r.open ?? ""},${r.high ?? ""},${r.low ?? ""},${r.close ?? ""},${r.volume ?? ""}`,
+        `${formatHoverLabel(r.time, intraday)},${r.open ?? ""},${r.high ?? ""},${r.low ?? ""},${r.close ?? ""},${r.volume ?? ""}`,
     )
     .join("\n");
   const csv = header + body;
@@ -125,7 +120,7 @@ export function RawOhlcvTable({
           <tbody>
             {sorted.map((r) => (
               <tr key={r.time} className="border-b border-slate-100 last:border-0">
-                <td className="px-2 py-1 tabular-nums">{formatTime(r.time, intraday)}</td>
+                <td className="px-2 py-1 tabular-nums">{formatHoverLabel(r.time, intraday)}</td>
                 <td className="px-2 py-1 text-right tabular-nums">{formatNum(r.open)}</td>
                 <td className="px-2 py-1 text-right tabular-nums">{formatNum(r.high)}</td>
                 <td className="px-2 py-1 text-right tabular-nums">{formatNum(r.low)}</td>

--- a/frontend/src/pages/components/RawOhlcvTable.tsx
+++ b/frontend/src/pages/components/RawOhlcvTable.tsx
@@ -1,12 +1,15 @@
 import { useState, type JSX } from "react";
 
-import type { CandleBar, CandleRange } from "@/api/types";
+import type { ChartRange } from "@/api/types";
 import { EmptyState } from "@/components/states/EmptyState";
+import type { NormalisedBar } from "@/lib/chartData";
 
 export interface RawOhlcvTableProps {
-  readonly rows: ReadonlyArray<CandleBar>;
+  readonly rows: ReadonlyArray<NormalisedBar>;
   readonly symbol: string;
-  readonly range: CandleRange;
+  readonly range: ChartRange;
+  /** Show full ISO timestamp in the table when bars are intraday. */
+  readonly intraday?: boolean;
 }
 
 type SortDir = "asc" | "desc";
@@ -18,12 +21,26 @@ function formatNum(v: string | null | undefined): string {
   return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
 }
 
-function downloadCsv(rows: ReadonlyArray<CandleBar>, symbol: string, range: CandleRange): void {
-  const header = "date,open,high,low,close,volume\n";
+function formatTime(epochSeconds: number, intraday: boolean): string {
+  const d = new Date(epochSeconds * 1000);
+  const date = d.toISOString().slice(0, 10);
+  if (!intraday) return date;
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${date} ${hh}:${mm}Z`;
+}
+
+function downloadCsv(
+  rows: ReadonlyArray<NormalisedBar>,
+  symbol: string,
+  range: ChartRange,
+  intraday: boolean,
+): void {
+  const header = `${intraday ? "timestamp" : "date"},open,high,low,close,volume\n`;
   const body = rows
     .map(
       (r) =>
-        `${r.date},${r.open ?? ""},${r.high ?? ""},${r.low ?? ""},${r.close ?? ""},${r.volume ?? ""}`,
+        `${formatTime(r.time, intraday)},${r.open ?? ""},${r.high ?? ""},${r.low ?? ""},${r.close ?? ""},${r.volume ?? ""}`,
     )
     .join("\n");
   const csv = header + body;
@@ -38,7 +55,12 @@ function downloadCsv(rows: ReadonlyArray<CandleBar>, symbol: string, range: Cand
   URL.revokeObjectURL(url);
 }
 
-export function RawOhlcvTable({ rows, symbol, range }: RawOhlcvTableProps): JSX.Element {
+export function RawOhlcvTable({
+  rows,
+  symbol,
+  range,
+  intraday = false,
+}: RawOhlcvTableProps): JSX.Element {
   const [sortDir, setSortDir] = useState<SortDir>("desc");
 
   if (rows.length === 0) {
@@ -46,15 +68,17 @@ export function RawOhlcvTable({ rows, symbol, range }: RawOhlcvTableProps): JSX.
       <div className="p-4">
         <EmptyState
           title="No raw data"
-          description="No candle rows in the local price_daily store for this range."
+          description={
+            intraday
+              ? "No intraday bars from the provider for this range."
+              : "No candle rows in the local price_daily store for this range."
+          }
         />
       </div>
     );
   }
 
-  const sorted = [...rows].sort((a, b) =>
-    sortDir === "desc" ? b.date.localeCompare(a.date) : a.date.localeCompare(b.date),
-  );
+  const sorted = [...rows].sort((a, b) => (sortDir === "desc" ? b.time - a.time : a.time - b.time));
 
   return (
     <div className="p-4">
@@ -68,10 +92,8 @@ export function RawOhlcvTable({ rows, symbol, range }: RawOhlcvTableProps): JSX.
             // Always export in chronological order regardless of the
             // UI sort toggle — downstream tools (Excel, pandas, etc.)
             // expect time-series ascending.
-            const chronological = [...rows].sort((a, b) =>
-              a.date.localeCompare(b.date),
-            );
-            downloadCsv(chronological, symbol, range);
+            const chronological = [...rows].sort((a, b) => a.time - b.time);
+            downloadCsv(chronological, symbol, range, intraday);
           }}
           className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700"
           data-testid="csv-download"
@@ -90,7 +112,7 @@ export function RawOhlcvTable({ rows, symbol, range }: RawOhlcvTableProps): JSX.
                   className="hover:underline"
                   data-testid="sort-date"
                 >
-                  Date {sortDir === "desc" ? "↓" : "↑"}
+                  {intraday ? "Time" : "Date"} {sortDir === "desc" ? "↓" : "↑"}
                 </button>
               </th>
               <th className="px-2 py-1 text-right">Open</th>
@@ -102,8 +124,8 @@ export function RawOhlcvTable({ rows, symbol, range }: RawOhlcvTableProps): JSX.
           </thead>
           <tbody>
             {sorted.map((r) => (
-              <tr key={r.date} className="border-b border-slate-100 last:border-0">
-                <td className="px-2 py-1 tabular-nums">{r.date}</td>
+              <tr key={r.time} className="border-b border-slate-100 last:border-0">
+                <td className="px-2 py-1 tabular-nums">{formatTime(r.time, intraday)}</td>
                 <td className="px-2 py-1 text-right tabular-nums">{formatNum(r.open)}</td>
                 <td className="px-2 py-1 text-right tabular-nums">{formatNum(r.high)}</td>
                 <td className="px-2 py-1 text-right tabular-nums">{formatNum(r.low)}</td>


### PR DESCRIPTION
## What

- New `lib/chartData.ts` unified fetcher: `CHART_RANGE_PLAN` dispatch table maps each UI range to either the daily endpoint or the intraday endpoint at the agreed interval+count. `fetchChartCandles` returns a single `NormalisedChartCandles` shape so lightweight-charts consumers stay one code path.
- Backend: added `ytd` to `/candles` range Literal; new `_resolve_range_days` computes YTD calendar days dynamically.
- 9 range buttons everywhere: **1D · 5D · 1M · 3M · 6M · YTD · 1Y · 5Y · MAX**. `1d/5d/1m/3m/6m` go through the live intraday endpoint at the agreed defaults; `ytd/1y/5y/max` continue to read `price_daily`.
- TradingView-style **adaptive axis**: lightweight-charts `tickMarkType` is now consumed in the formatter so multi-day intraday charts render `Apr 27` markers at day boundaries and `HH:MM` within a day.
- Hover tooltip rewritten as a **single inline status-line strip** at top-left of the chart (no shadow/box). Matches TradingView's inline OHLCV pattern, doesn't cover the live-quote pill on the instrument page or the price axis on the workspace. Volume humanised to `K/M/B`.
- Compare overlays **disabled on intraday ranges** — fanning N intraday fetches per chart open would burn quota without analytical payoff at sub-day timeframes.
- Workspace non-compare hover label now uses `formatHoverLabel(time, intraday)` so intraday hovers show `HH:MM` (Codex MEDIUM caught this — the date-only branch was inconsistent with the axis).
- DensityGrid: **card-click drill removed**. Operator reported the whole-card click was firing accidentally on chart hover/zoom. Header `Open →` button is now the only drill affordance.

## Why

Operator-requested intraday charts (#585 epic). Architecture locked at #600: daily stays in `price_daily` for the auditable scoring/thesis path; intraday is an ephemeral REST proxy with TTL cache. Frontend dispatch keeps both endpoints behind one shape so chart components and tests don't branch on source.

## Conscious deviations

- `CandleRange` retains `1w` even though no UI button uses it. Backend daily endpoint still accepts it — keeps any external consumer / saved URL working. The chart UI's `ChartRange` is the new 9-token union; the daily-endpoint `CandleRange` is its own thing.
- Codex flagged `PriceChart` defaulting to `1m` (now intraday) on every page open as a quota concern. **Intentional** — this is the operator-requested behavior. The intraday cache + singleflight in `app/services/intraday_candles.py` (#600) collapses repeat opens within 30s to one provider call, and at 60 GET/min/key the overview pane has plenty of budget. Leaving the default at `1m`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test:unit` — 568/568 (added: 9-range buttons, intraday/daily axis tickVisible, fetchChartCandles mock with `kind`, RawOhlcvTable intraday HH:MM rendering; updated: DensityGrid card-click no longer drills)
- [x] `pnpm build` — 682.33 kB JS / 198.20 kB gz; recharts still tree-shaken
- [x] Backend gates: ruff / format / pyright clean; pytest 2858 passed
- [x] Codex pre-push review: HIGH (intraday default) marked as conscious deviation; MEDIUM (workspace non-compare hover label) fixed.

## Linked

- Parent: #585
- Predecessors: #586, #587, #600 (backend intraday proxy), #603 (daily backfill bump)
- Successor: #602 (live last-bar via existing SSE quote stream)