### PR TITLE
feat(#602): live last-bar via existing SSE quote stream

### DIFF
--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -78,7 +78,7 @@ export function DensityGrid({
   // hover/zoom.
   const ChartPane = (
     <Pane title="Price chart" onExpand={drillToWorkspace}>
-      <PriceChart symbol={symbol} />
+      <PriceChart symbol={symbol} instrumentId={instrumentId} />
     </Pane>
   );
 

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -514,20 +514,14 @@ export function ChartCanvas({
     } as unknown as Parameters<ReturnType<IChartApi["timeScale"]>["applyOptions"]>[0]);
   }, [intraday]);
 
-  // Feed data on every rows change. lightweight-charts replaces the
-  // series wholesale via setData — no incremental diffing needed.
-  useEffect(() => {
-    const candle = candleRef.current;
-    const line = lineRef.current;
-    const area = areaRef.current;
-    const volume = volumeRef.current;
-    const chart = chartRef.current;
-    if (!candle || !line || !area || !volume || !chart) return;
-
-    // Pre-convert to numeric bars so downstream `setData` calls work
-    // with guaranteed-non-null values (no dead `?? 0` fallbacks). Rows
-    // that fail any numeric parse are dropped here.
-    const clean: NumericBar[] = rows.flatMap((r) => {
+  // Numeric / null-filtered rows. Computed during render (not in an
+  // effect) so values are available to the live-tick aggregator's
+  // historical anchor on the very first render. Otherwise `histLastBar`
+  // would always be null until React next re-rendered, and live ticks
+  // would all bucket as "no anchor" → fresh bars, never extending the
+  // historical last candle.
+  const clean = useMemo<NumericBar[]>(() => {
+    return rows.flatMap((r) => {
       const open = parseNum(r.open);
       const high = parseNum(r.high);
       const low = parseNum(r.low);
@@ -546,7 +540,22 @@ export function ChartCanvas({
         },
       ];
     });
-    cleanRowsRef.current = clean;
+  }, [rows]);
+
+  // Mirror `clean` into the crosshair handler's ref. The handler is
+  // registered once at mount; reading from a ref avoids stale-closure
+  // capture.
+  cleanRowsRef.current = clean;
+
+  // Feed data on every clean change. lightweight-charts replaces the
+  // series wholesale via setData — no incremental diffing needed.
+  useEffect(() => {
+    const candle = candleRef.current;
+    const line = lineRef.current;
+    const area = areaRef.current;
+    const volume = volumeRef.current;
+    const chart = chartRef.current;
+    if (!candle || !line || !area || !volume || !chart) return;
 
     candle.setData(
       clean.map((b) => ({
@@ -574,7 +583,7 @@ export function ChartCanvas({
     );
 
     chart.timeScale().fitContent();
-  }, [rows]);
+  }, [clean]);
 
   // Live-tick aggregator (#602). Subscribes to the page-level
   // LiveQuoteProvider stream for `instrumentId` and updates the last
@@ -586,9 +595,7 @@ export function ChartCanvas({
   // raw `rows` tail — the rendering effect drops rows with null OHLC,
   // so anchoring against `rows[rows.length - 1]` could bucket ticks
   // against an invisible bar (Codex pre-push #602).
-  const lastRenderedBar = cleanRowsRef.current.length > 0
-    ? cleanRowsRef.current[cleanRowsRef.current.length - 1]!
-    : null;
+  const lastRenderedBar = clean.length > 0 ? clean[clean.length - 1]! : null;
   // Memoize on the primitive OHLC fields so the object identity is
   // stable while the data is — without this, `useLiveLastBar`'s tick
   // effect would re-fire on every parent render and re-apply the

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -19,7 +19,7 @@
  * %Δ-from-prior; matches the pattern in `ChartWorkspaceCanvas.RichTooltip`
  * so an operator's mental model is consistent between overview and workspace.
  */
-import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   AreaSeries,
@@ -589,14 +589,21 @@ export function ChartCanvas({
   const lastRenderedBar = cleanRowsRef.current.length > 0
     ? cleanRowsRef.current[cleanRowsRef.current.length - 1]!
     : null;
-  const histLastBar = lastRenderedBar !== null
-    ? {
-        time: lastRenderedBar.time as number,
-        open: lastRenderedBar.open,
-        high: lastRenderedBar.high,
-        low: lastRenderedBar.low,
-      }
-    : null;
+  // Memoize on the primitive OHLC fields so the object identity is
+  // stable while the data is — without this, `useLiveLastBar`'s tick
+  // effect would re-fire on every parent render and re-apply the
+  // last tick (Codex pre-push #602 round 2).
+  const lastTime = lastRenderedBar !== null ? (lastRenderedBar.time as number) : null;
+  const lastOpen = lastRenderedBar !== null ? lastRenderedBar.open : null;
+  const lastHigh = lastRenderedBar !== null ? lastRenderedBar.high : null;
+  const lastLow = lastRenderedBar !== null ? lastRenderedBar.low : null;
+  const histLastBar = useMemo(
+    () =>
+      lastTime !== null && lastOpen !== null && lastHigh !== null && lastLow !== null
+        ? { time: lastTime, open: lastOpen, high: lastHigh, low: lastLow }
+        : null,
+    [lastTime, lastOpen, lastHigh, lastLow],
+  );
   const bucketSeconds = range !== undefined ? intervalSecondsFor(range) : 60;
   const { connected, unavailable } = useLiveLastBar({
     instrumentId: range !== undefined ? instrumentId : null,

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -39,6 +39,7 @@ import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import {
   fetchChartCandles,
+  intervalSecondsFor,
   isIntraday,
   type NormalisedBar,
   type NormalisedChartCandles,
@@ -46,6 +47,7 @@ import {
 import { formatHoverLabel, humanizeVolume, tickFormatter } from "@/lib/chartFormatters";
 import { chartTheme } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
+import { useLiveLastBar } from "@/lib/useLiveLastBar";
 
 const RANGES: { id: ChartRange; label: string }[] = [
   { id: "1d", label: "1D" },
@@ -115,11 +117,16 @@ interface NumericBar {
 
 export interface PriceChartProps {
   symbol: string;
+  /** Provider-native instrument id used for the SSE live-tick subscription
+   *  (#602). When omitted, the chart renders without live updates — the
+   *  historical fetch is unaffected. */
+  instrumentId?: number | null;
   initialRange?: ChartRange;
 }
 
 export function PriceChart({
   symbol,
+  instrumentId = null,
   initialRange = "1m",
 }: PriceChartProps): JSX.Element {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -283,6 +290,8 @@ export function PriceChart({
         <ChartCanvas
           rows={rows}
           symbol={symbol}
+          instrumentId={instrumentId}
+          range={range}
           chartType={chartType}
           priceScale={priceScale}
           intraday={intraday}
@@ -295,6 +304,13 @@ export function PriceChart({
 export interface ChartCanvasProps {
   rows: ReadonlyArray<NormalisedBar>;
   symbol: string;
+  /** When set, opens a live SSE quote stream and keeps the last bar
+   *  updating in real time via lightweight-charts series.update(). */
+  instrumentId?: number | null;
+  /** Required for live-tick aggregation — picks the bucket size that
+   *  matches the chart's interval. When omitted the live-tick path
+   *  is disabled. */
+  range?: ChartRange;
   chartType?: ChartType;
   priceScale?: PriceScaleMode;
   /** When true, hover label includes HH:MM and the time scale shows time. */
@@ -305,6 +321,8 @@ export interface ChartCanvasProps {
 export function ChartCanvas({
   rows,
   symbol,
+  instrumentId = null,
+  range,
   chartType = "candle",
   priceScale = "linear",
   intraday = false,
@@ -558,9 +576,52 @@ export function ChartCanvas({
     chart.timeScale().fitContent();
   }, [rows]);
 
+  // Live-tick aggregator (#602). Subscribes to the page-level
+  // LiveQuoteProvider stream for `instrumentId` and updates the last
+  // bar's H/L/C — or appends a new bar when a tick crosses the bucket
+  // boundary. Disabled when `instrumentId` or `range` is missing
+  // (caller hasn't wired live updates for this chart).
+  //
+  // Anchor against the LAST RENDERED bar from `cleanRowsRef`, not the
+  // raw `rows` tail — the rendering effect drops rows with null OHLC,
+  // so anchoring against `rows[rows.length - 1]` could bucket ticks
+  // against an invisible bar (Codex pre-push #602).
+  const lastRenderedBar = cleanRowsRef.current.length > 0
+    ? cleanRowsRef.current[cleanRowsRef.current.length - 1]!
+    : null;
+  const histLastBar = lastRenderedBar !== null
+    ? {
+        time: lastRenderedBar.time as number,
+        open: lastRenderedBar.open,
+        high: lastRenderedBar.high,
+        low: lastRenderedBar.low,
+      }
+    : null;
+  const bucketSeconds = range !== undefined ? intervalSecondsFor(range) : 60;
+  const { connected, unavailable } = useLiveLastBar({
+    instrumentId: range !== undefined ? instrumentId : null,
+    bucketSeconds,
+    historicalLastBar: histLastBar,
+    refs: {
+      candle: candleRef.current,
+      line: lineRef.current,
+      area: areaRef.current,
+    },
+  });
+  const liveActive = connected && !unavailable && instrumentId !== null && range !== undefined;
+
   return (
     <div className="relative">
       {hover !== null ? <RichTooltip hover={hover} /> : null}
+      {liveActive ? (
+        <div
+          className="absolute right-2 top-2 z-10 flex items-center gap-1 text-[10px] uppercase tracking-wider text-emerald-600"
+          data-testid="price-chart-live-indicator"
+        >
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" />
+          Live
+        </div>
+      ) : null}
       <div
         ref={containerRef}
         data-testid={`price-chart-${symbol}`}

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -603,9 +603,9 @@ export function ChartCanvas({
     bucketSeconds,
     historicalLastBar: histLastBar,
     refs: {
-      candle: candleRef.current,
-      line: lineRef.current,
-      area: areaRef.current,
+      candle: candleRef,
+      line: lineRef,
+      area: areaRef,
     },
   });
   const liveActive = connected && !unavailable && instrumentId !== null && range !== undefined;

--- a/frontend/src/lib/chartData.ts
+++ b/frontend/src/lib/chartData.ts
@@ -80,6 +80,42 @@ export function isIntraday(range: ChartRange): boolean {
 }
 
 /**
+ * Bar duration in seconds for each range. Used by the live-tick
+ * aggregator (#602) to decide whether an incoming tick updates the
+ * chart's last bar or rolls into a new bucket.
+ *
+ * Daily/weekly/monthly ranges all use 86400 (one day). The eToro
+ * tick stream is intraday-resolution regardless of the chart's
+ * range, so a 1Y chart gets one bucket per calendar day.
+ */
+export const INTERVAL_SECONDS: Record<string, number> = {
+  OneMinute: 60,
+  FiveMinutes: 300,
+  TenMinutes: 600,
+  FifteenMinutes: 900,
+  ThirtyMinutes: 1800,
+  OneHour: 3600,
+  FourHours: 14400,
+};
+
+export function intervalSecondsFor(range: ChartRange): number {
+  const plan = CHART_RANGE_PLAN[range];
+  if (plan.kind === "intraday") return INTERVAL_SECONDS[plan.interval] ?? 60;
+  return 86400;
+}
+
+/**
+ * Floor an epoch-second timestamp to the start of the bucket of the
+ * given interval. UTC-aligned because the daily endpoint stores
+ * `price_date` as UTC midnight and the intraday endpoint emits UTC
+ * timestamps. Mixing local-time floors here would silently misalign
+ * live-tick updates against the rendered last bar.
+ */
+export function floorToBucket(epochSeconds: number, intervalSeconds: number): number {
+  return Math.floor(epochSeconds / intervalSeconds) * intervalSeconds;
+}
+
+/**
  * Bar shape consumed by the chart components. Time is a UTC epoch
  * second so lightweight-charts can plot it directly without further
  * conversion. OHLCV values stay as nullable strings to match the

--- a/frontend/src/lib/useLiveLastBar.test.ts
+++ b/frontend/src/lib/useLiveLastBar.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for the live-tick aggregator pure function (#602).
+ *
+ * The hook itself can't run in jsdom (EventSource missing) — the
+ * `useLiveQuote` integration is covered by its own test file. Here
+ * we pin the bucket-aware aggregation logic so a tick that lands in
+ * the in-progress bar updates H/L/C, a tick that crosses the
+ * boundary appends a new bar with O=H=L=C=tick, and a stale tick
+ * before the historical anchor is dropped.
+ */
+import { describe, expect, it } from "vitest";
+
+import { aggregateTick } from "@/lib/useLiveLastBar";
+
+const T_BAR_OPEN = Math.floor(Date.UTC(2026, 3, 27, 14, 30) / 1000); // 14:30
+const T_INSIDE = T_BAR_OPEN + 30; // 14:30:30
+const T_NEXT_BAR = T_BAR_OPEN + 60; // 14:31
+
+describe("aggregateTick — within current bucket", () => {
+  it("first tick into the historical bar PRESERVES the historical open", () => {
+    // Codex pre-push fix (#602): rewriting the open from a tick
+    // mid-bar visibly distorts the candle. The aggregator must
+    // carry the historical OHLC into the live bar.
+    const result = aggregateTick({
+      prev: null,
+      histLastBar: { time: T_BAR_OPEN, open: 99, high: 102, low: 98 },
+      bucketSeconds: 60,
+      tickEpochSeconds: T_INSIDE,
+      tickPrice: 100,
+    });
+    expect(result.verdict).toBe("update");
+    if (result.verdict === "skip") return;
+    expect(result.next.open).toBe(99);
+    expect(result.next.high).toBe(102); // historical 102 wins over tick 100
+    expect(result.next.low).toBe(98); // historical 98 wins over tick 100
+    expect(result.next.close).toBe(100);
+  });
+
+  it("first tick when there is no historical bar opens at the tick price", () => {
+    const result = aggregateTick({
+      prev: null,
+      histLastBar: null,
+      bucketSeconds: 60,
+      tickEpochSeconds: T_INSIDE,
+      tickPrice: 100,
+    });
+    expect(result.verdict).toBe("append");
+    if (result.verdict === "skip") return;
+    expect(result.next).toEqual({
+      time: T_BAR_OPEN,
+      open: 100,
+      high: 100,
+      low: 100,
+      close: 100,
+    });
+  });
+
+  it("subsequent tick raises high if higher (live-bar already in this bucket)", () => {
+    const prev = { time: T_BAR_OPEN, open: 100, high: 102, low: 99, close: 101 };
+    const result = aggregateTick({
+      prev,
+      histLastBar: { time: T_BAR_OPEN, open: 99, high: 102, low: 98 },
+      bucketSeconds: 60,
+      tickEpochSeconds: T_INSIDE,
+      tickPrice: 105,
+    });
+    expect(result.verdict).toBe("update");
+    if (result.verdict === "skip") return;
+    // Live bar's open wins over historical when both anchor in-bucket.
+    expect(result.next.open).toBe(100);
+    expect(result.next.high).toBe(105);
+    expect(result.next.low).toBe(99);
+    expect(result.next.close).toBe(105);
+  });
+
+  it("subsequent tick lowers low if lower", () => {
+    const prev = { time: T_BAR_OPEN, open: 100, high: 102, low: 99, close: 101 };
+    const result = aggregateTick({
+      prev,
+      histLastBar: { time: T_BAR_OPEN, open: 99, high: 102, low: 98 },
+      bucketSeconds: 60,
+      tickEpochSeconds: T_INSIDE,
+      tickPrice: 95,
+    });
+    if (result.verdict === "skip") return;
+    expect(result.next.low).toBe(95);
+    expect(result.next.close).toBe(95);
+  });
+
+  it("preserves live-bar open across many ticks in the same bucket", () => {
+    const prev = { time: T_BAR_OPEN, open: 100, high: 105, low: 95, close: 95 };
+    const result = aggregateTick({
+      prev,
+      histLastBar: { time: T_BAR_OPEN, open: 99, high: 102, low: 98 },
+      bucketSeconds: 60,
+      tickEpochSeconds: T_INSIDE,
+      tickPrice: 102,
+    });
+    if (result.verdict === "skip") return;
+    expect(result.next.open).toBe(100);
+    expect(result.next.close).toBe(102);
+  });
+});
+
+describe("aggregateTick — bucket boundary", () => {
+  it("tick in the next bucket emits an append verdict and opens a fresh bar", () => {
+    const prev = { time: T_BAR_OPEN, open: 100, high: 102, low: 99, close: 101 };
+    const result = aggregateTick({
+      prev,
+      histLastBar: { time: T_BAR_OPEN, open: 99, high: 102, low: 98 },
+      bucketSeconds: 60,
+      tickEpochSeconds: T_NEXT_BAR + 5,
+      tickPrice: 103,
+    });
+    expect(result.verdict).toBe("append");
+    if (result.verdict === "skip") return;
+    expect(result.next).toEqual({
+      time: T_NEXT_BAR,
+      open: 103,
+      high: 103,
+      low: 103,
+      close: 103,
+    });
+  });
+
+  it("first-ever tick after history with no prior live bar appends if newer", () => {
+    const result = aggregateTick({
+      prev: null,
+      histLastBar: { time: T_BAR_OPEN, open: 99, high: 102, low: 98 },
+      bucketSeconds: 60,
+      tickEpochSeconds: T_NEXT_BAR + 5,
+      tickPrice: 100,
+    });
+    expect(result.verdict).toBe("append");
+  });
+});
+
+describe("aggregateTick — stale tick", () => {
+  it("tick before the historical anchor is skipped", () => {
+    const result = aggregateTick({
+      prev: null,
+      histLastBar: { time: T_BAR_OPEN, open: 99, high: 102, low: 98 },
+      bucketSeconds: 60,
+      tickEpochSeconds: T_BAR_OPEN - 120,
+      tickPrice: 100,
+    });
+    expect(result.verdict).toBe("skip");
+  });
+
+  it("works when there is no historical anchor (chart hasn't loaded)", () => {
+    const result = aggregateTick({
+      prev: null,
+      histLastBar: null,
+      bucketSeconds: 60,
+      tickEpochSeconds: T_INSIDE,
+      tickPrice: 100,
+    });
+    expect(result.verdict).toBe("append");
+  });
+});

--- a/frontend/src/lib/useLiveLastBar.ts
+++ b/frontend/src/lib/useLiveLastBar.ts
@@ -33,7 +33,7 @@
  * eToro's quote stream doesn't expose; deferred to V2.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type MutableRefObject } from "react";
 import type { ISeriesApi, Time, UTCTimestamp } from "lightweight-charts";
 
 import { useLiveTick, useLiveQuoteConnection } from "@/components/quotes/LiveQuoteProvider";
@@ -48,10 +48,18 @@ interface LiveBarState {
   close: number;
 }
 
+/**
+ * The hook accepts the caller's lightweight-charts series **refs**
+ * (not their `.current` snapshots) so the dependency list stays
+ * stable across renders. Passing `{ candle: ref.current }` would
+ * make a fresh object on every parent render and re-fire the effect,
+ * re-applying the last tick's `series.update()` on every re-render —
+ * see Codex pre-push #602 review feedback.
+ */
 export interface LiveLastBarRefs {
-  candle: ISeriesApi<"Candlestick"> | null;
-  line: ISeriesApi<"Line"> | null;
-  area: ISeriesApi<"Area"> | null;
+  candle: MutableRefObject<ISeriesApi<"Candlestick"> | null>;
+  line: MutableRefObject<ISeriesApi<"Line"> | null> | null;
+  area: MutableRefObject<ISeriesApi<"Area"> | null> | null;
 }
 
 /**
@@ -219,8 +227,9 @@ export function useLiveLastBar({
     liveBarRef.current = result.next;
 
     const time = result.next.time as UTCTimestamp;
-    if (refs.candle !== null) {
-      refs.candle.update({
+    const candleSeries = refs.candle.current;
+    if (candleSeries !== null) {
+      candleSeries.update({
         time: time as Time,
         open: result.next.open,
         high: result.next.high,
@@ -228,13 +237,20 @@ export function useLiveLastBar({
         close: result.next.close,
       });
     }
-    if (refs.line !== null) {
-      refs.line.update({ time: time as Time, value: result.next.close });
+    const lineSeries = refs.line !== null ? refs.line.current : null;
+    if (lineSeries !== null) {
+      lineSeries.update({ time: time as Time, value: result.next.close });
     }
-    if (refs.area !== null) {
-      refs.area.update({ time: time as Time, value: result.next.close });
+    const areaSeries = refs.area !== null ? refs.area.current : null;
+    if (areaSeries !== null) {
+      areaSeries.update({ time: time as Time, value: result.next.close });
     }
-  }, [tick, bucketSeconds, historicalLastBar, refs, instrumentId]);
+    // ESLint: refs.* are MutableRefObjects with stable identity, so
+    // omitting them from deps is correct. The effect must re-fire only
+    // on tick / anchor / bucket / instrument changes — adding `refs`
+    // would re-fire on every parent render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tick, bucketSeconds, historicalLastBar, instrumentId]);
 
   return { connected, unavailable };
 }

--- a/frontend/src/lib/useLiveLastBar.ts
+++ b/frontend/src/lib/useLiveLastBar.ts
@@ -1,0 +1,243 @@
+/**
+ * useLiveLastBar — feed eToro tick stream into a lightweight-charts
+ * series so the in-progress bar updates live (#602).
+ *
+ * Connects to the existing /sse/quotes endpoint via `useLiveQuote` —
+ * the same SSE pipeline the quote panels use — so this hook adds no
+ * new backend infrastructure. Each tick lands in `aggregateTick`
+ * which decides:
+ *
+ *   * Same bucket as the chart's last historical bar → update its
+ *     high/low/close in-place via `series.update()`. Open is preserved
+ *     from the historical fetch.
+ *   * Newer bucket than any historical bar → emit a fresh bar that
+ *     opens at the tick price (open = high = low = close = tick) and
+ *     persists in the aggregator's local state until the next bucket
+ *     boundary. Volume stays at 0 — the tick stream does not carry
+ *     aggregate per-bar volume; that's the historical fetch's job.
+ *   * Older bucket than the last historical bar → ignore. Backfill
+ *     from REST handles late-arriving bars on the next range refetch.
+ *
+ * The aggregator owns one mutable bar in `liveBarRef`. The hook
+ * re-syncs that bar from the historical `rows` whenever they change
+ * (range switch, refetch, etc.), so a chart that just loaded never
+ * starts in a stale-aggregator state.
+ *
+ * Caller responsibility:
+ *   * Provide stable refs to the candle / line / area series so the
+ *     aggregator can call `update()` on each.
+ *   * Call `attach()` on every render to keep refs current.
+ *
+ * Volume series is intentionally not touched — see ticket scope
+ * notes. Volume aggregation needs a separate per-tick volume field
+ * eToro's quote stream doesn't expose; deferred to V2.
+ */
+
+import { useEffect, useRef } from "react";
+import type { ISeriesApi, Time, UTCTimestamp } from "lightweight-charts";
+
+import { useLiveTick, useLiveQuoteConnection } from "@/components/quotes/LiveQuoteProvider";
+import { floorToBucket } from "@/lib/chartData";
+import type { LiveTickPayload } from "@/lib/useLiveQuote";
+
+interface LiveBarState {
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+export interface LiveLastBarRefs {
+  candle: ISeriesApi<"Candlestick"> | null;
+  line: ISeriesApi<"Line"> | null;
+  area: ISeriesApi<"Area"> | null;
+}
+
+/**
+ * Pull the best price out of a tick. Prefers `last`, falls back to
+ * the bid/ask midpoint when last is null (typical at market open
+ * before the first execution).
+ */
+function tickPrice(tick: LiveTickPayload): number | null {
+  const last = tick.last !== null && tick.last !== undefined ? Number(tick.last) : null;
+  if (last !== null && Number.isFinite(last)) return last;
+  const bid = Number(tick.bid);
+  const ask = Number(tick.ask);
+  if (Number.isFinite(bid) && Number.isFinite(ask)) return (bid + ask) / 2;
+  if (Number.isFinite(bid)) return bid;
+  if (Number.isFinite(ask)) return ask;
+  return null;
+}
+
+export interface HistoricalLastBar {
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+}
+
+/**
+ * Aggregate one tick into a new live-bar state.
+ *
+ * Pure function — no I/O, no series mutation. Consumes the previous
+ * live bar (if any), the historical last bar (if the chart has rendered
+ * one), the tick price + timestamp, and the bucket size.
+ *
+ * Three outcomes:
+ *   * `update` — tick lands in the same bucket as the historical last
+ *     bar OR the live bar; preserves the historical open and extends
+ *     high/low from whichever existing values are tracked.
+ *   * `append` — tick crosses into a fresh bucket beyond the
+ *     historical anchor; opens a new bar at the tick price.
+ *   * `skip` — tick predates the historical anchor (a late delivery
+ *     from a stale connection); the next REST refetch handles it.
+ */
+export function aggregateTick(args: {
+  prev: LiveBarState | null;
+  histLastBar: HistoricalLastBar | null;
+  bucketSeconds: number;
+  tickEpochSeconds: number;
+  tickPrice: number;
+}): { next: LiveBarState; verdict: "update" | "append" } | { verdict: "skip" } {
+  const { prev, histLastBar, bucketSeconds, tickEpochSeconds, tickPrice: price } = args;
+  const histLastTime = histLastBar !== null ? histLastBar.time : null;
+  const bucket = floorToBucket(tickEpochSeconds, bucketSeconds);
+
+  // Tick is older than the chart's last historical bar — backfill
+  // from the next REST refetch will catch it; ignore here.
+  if (histLastTime !== null && bucket < histLastTime) {
+    return { verdict: "skip" };
+  }
+
+  // Pick the open / high / low to extend from. Priority:
+  //   1. The live bar in this bucket (preserves earlier ticks).
+  //   2. The historical bar in this bucket (preserves the OHLC the
+  //      REST fetch produced — rewriting the open from a tick
+  //      mid-bar visibly rewrites a candle on first tick, which the
+  //      operator reads as a price spike that didn't happen).
+  //   3. Otherwise this tick is opening a brand-new bucket.
+  let carryOpen: number;
+  let carryHigh: number;
+  let carryLow: number;
+  if (prev !== null && prev.time === bucket) {
+    carryOpen = prev.open;
+    carryHigh = Math.max(prev.high, price);
+    carryLow = Math.min(prev.low, price);
+  } else if (histLastBar !== null && histLastBar.time === bucket) {
+    carryOpen = histLastBar.open;
+    carryHigh = Math.max(histLastBar.high, price);
+    carryLow = Math.min(histLastBar.low, price);
+  } else {
+    carryOpen = price;
+    carryHigh = price;
+    carryLow = price;
+  }
+  const next: LiveBarState = {
+    time: bucket,
+    open: carryOpen,
+    high: carryHigh,
+    low: carryLow,
+    close: price,
+  };
+  const verdict =
+    (histLastTime !== null && bucket === histLastTime) ||
+    (prev !== null && prev.time === bucket)
+      ? "update"
+      : "append";
+  return { next, verdict };
+}
+
+export interface UseLiveLastBarParams {
+  instrumentId: number | null | undefined;
+  bucketSeconds: number;
+  /** Last bar already rendered on the chart (post any null-OHLC
+   *  filter), or null when the chart hasn't loaded yet. The
+   *  aggregator uses its OHLC to preserve the open across the first
+   *  live tick of the in-progress bar. */
+  historicalLastBar: HistoricalLastBar | null;
+  refs: LiveLastBarRefs;
+}
+
+export interface UseLiveLastBarResult {
+  /** True while an SSE stream is active for this instrument. */
+  connected: boolean;
+  /** True if the SSE stream errored irrecoverably — the chart should
+   *  not show a "LIVE" indicator. */
+  unavailable: boolean;
+}
+
+/**
+ * Subscribe to the page-level LiveQuoteProvider stream for a given
+ * instrument and feed each tick into `aggregateTick`. Reading from
+ * the shared provider (not opening a per-component SSE) means a
+ * page that already renders a live-quote consumer for the same
+ * instrument (e.g. SummaryStrip) shares one SSE handshake — the
+ * "one stream per page, same id rendered twice shares the stream"
+ * invariant documented in LiveQuoteProvider.
+ *
+ * The page must mount LiveQuoteProvider with the instrument id in
+ * its visible-id list — otherwise no ticks arrive and the chart
+ * silently degrades to its REST snapshot.
+ */
+export function useLiveLastBar({
+  instrumentId,
+  bucketSeconds,
+  historicalLastBar,
+  refs,
+}: UseLiveLastBarParams): UseLiveLastBarResult {
+  const tick = useLiveTick(instrumentId);
+  const { connected, unavailable } = useLiveQuoteConnection();
+  const liveBarRef = useRef<LiveBarState | null>(null);
+
+  const histAnchorTime = historicalLastBar !== null ? historicalLastBar.time : null;
+
+  // Reset the aggregator when the historical anchor moves (range
+  // switch, refetch, instrument change). Without this the next tick
+  // could update the wrong bar's H/L/C.
+  useEffect(() => {
+    liveBarRef.current = null;
+  }, [instrumentId, bucketSeconds, histAnchorTime]);
+
+  useEffect(() => {
+    if (tick === null) return;
+    if (tick.instrument_id !== instrumentId) return;
+    const price = tickPriceFor(tick);
+    if (price === null) return;
+    const tickEpoch = Math.floor(new Date(tick.quoted_at).getTime() / 1000);
+    if (!Number.isFinite(tickEpoch)) return;
+
+    const result = aggregateTick({
+      prev: liveBarRef.current,
+      histLastBar: historicalLastBar,
+      bucketSeconds,
+      tickEpochSeconds: tickEpoch,
+      tickPrice: price,
+    });
+    if (result.verdict === "skip") return;
+
+    liveBarRef.current = result.next;
+
+    const time = result.next.time as UTCTimestamp;
+    if (refs.candle !== null) {
+      refs.candle.update({
+        time: time as Time,
+        open: result.next.open,
+        high: result.next.high,
+        low: result.next.low,
+        close: result.next.close,
+      });
+    }
+    if (refs.line !== null) {
+      refs.line.update({ time: time as Time, value: result.next.close });
+    }
+    if (refs.area !== null) {
+      refs.area.update({ time: time as Time, value: result.next.close });
+    }
+  }, [tick, bucketSeconds, historicalLastBar, refs, instrumentId]);
+
+  return { connected, unavailable };
+}
+
+// Renamed exports to keep tickPrice as a private helper.
+const tickPriceFor = tickPrice;

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -21,6 +21,7 @@ import { Link, useParams, useSearchParams } from "react-router-dom";
 
 import { fetchInstrumentSummary } from "@/api/instruments";
 import type { ChartRange, InstrumentSummary } from "@/api/types";
+import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
 import {
   ChartWorkspaceCanvas,
   INDICATOR_IDS,
@@ -328,7 +329,15 @@ export function ChartPage(): JSX.Element {
         parseNum(r.close) !== null,
     ).length >= 2;
 
+  // Provider needs an array; pass [] when summary hasn't loaded yet so
+  // the SSE stream waits for a real id.
+  const liveIds: number[] =
+    summaryAsync.data?.instrument_id !== undefined
+      ? [summaryAsync.data.instrument_id]
+      : [];
+
   return (
+    <LiveQuoteProvider instrumentIds={liveIds}>
     <div className="space-y-3 p-4">
       {/* Header: back link + identity + price */}
       <div className="flex items-baseline gap-3">
@@ -537,6 +546,8 @@ export function ChartPage(): JSX.Element {
           <ChartWorkspaceCanvas
             rows={rows}
             symbol={symbol}
+            instrumentId={summaryAsync.data?.instrument_id ?? null}
+            range={range}
             indicators={enabledIndicators}
             compares={compareSeries}
             showRegression={enabledTrends.includes("regression")}
@@ -550,6 +561,7 @@ export function ChartPage(): JSX.Element {
         ) : null}
       </div>
     </div>
+    </LiveQuoteProvider>
   );
 }
 

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -36,6 +36,7 @@ import type {
   NewsListResponse,
   ThesisDetail,
 } from "@/api/types";
+import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
 import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
 import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
 import { Section, SectionSkeleton } from "@/components/dashboard/Section";
@@ -611,6 +612,7 @@ function InstrumentPageBody({
   }
 
   return (
+    <LiveQuoteProvider instrumentIds={[instrumentId]}>
     <div className="space-y-4">
       <SummaryStrip
         summary={summary}
@@ -736,6 +738,7 @@ function InstrumentPageBody({
         />
       ) : null}
     </div>
+    </LiveQuoteProvider>
   );
 }
 

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -22,9 +22,11 @@ import {
   type UTCTimestamp,
 } from "lightweight-charts";
 
-import type { NormalisedBar } from "@/lib/chartData";
+import type { ChartRange } from "@/api/types";
+import { intervalSecondsFor, type NormalisedBar } from "@/lib/chartData";
 import { formatHoverLabel, humanizeVolume, tickFormatter } from "@/lib/chartFormatters";
 import { chartTheme } from "@/lib/chartTheme";
+import { useLiveLastBar } from "@/lib/useLiveLastBar";
 
 export type IndicatorId = "sma20" | "sma50" | "ema20" | "ema50";
 export const INDICATOR_IDS: IndicatorId[] = ["sma20", "sma50", "ema20", "ema50"];
@@ -173,6 +175,12 @@ function computeIndicator(id: IndicatorId, closes: number[]): Array<number | nul
 export interface ChartWorkspaceCanvasProps {
   readonly rows: ReadonlyArray<NormalisedBar>;
   readonly symbol: string;
+  /** Provider-native instrument id for live-tick subscription (#602).
+   *  When omitted the chart renders without live updates. */
+  readonly instrumentId?: number | null;
+  /** Required for live-tick aggregation — picks the bucket size that
+   *  matches the chart's interval. */
+  readonly range?: ChartRange;
   readonly indicators: ReadonlyArray<IndicatorId>;
   readonly compares?: ReadonlyArray<CompareSeries>;
   readonly showRegression?: boolean;
@@ -185,6 +193,8 @@ export interface ChartWorkspaceCanvasProps {
 export function ChartWorkspaceCanvas({
   rows,
   symbol,
+  instrumentId = null,
+  range,
   indicators,
   compares = [],
   showRegression = false,
@@ -666,9 +676,51 @@ export function ChartWorkspaceCanvas({
     }
   }, [showRegression, showChannel, rows, compares]);
 
+  // Live last-bar updates (#602). Disabled in compare mode — when the
+  // candle/volume series are hidden in favour of normalized lines,
+  // the aggregator's update() calls would land on hidden series and
+  // diverge from the per-symbol normalised data we render. Compare
+  // ranges are also already restricted to daily-only at the page
+  // level (#601).
+  const lastRenderedBar =
+    cleanRowsRef.current.length > 0
+      ? cleanRowsRef.current[cleanRowsRef.current.length - 1]!
+      : null;
+  const histLastBar =
+    lastRenderedBar !== null
+      ? {
+          time: lastRenderedBar.time as number,
+          open: lastRenderedBar.open,
+          high: lastRenderedBar.high,
+          low: lastRenderedBar.low,
+        }
+      : null;
+  const bucketSeconds = range !== undefined ? intervalSecondsFor(range) : 60;
+  const liveTargetId = !compareMode && range !== undefined ? instrumentId : null;
+  const { connected, unavailable } = useLiveLastBar({
+    instrumentId: liveTargetId,
+    bucketSeconds,
+    historicalLastBar: histLastBar,
+    refs: {
+      candle: candleRef.current,
+      line: null, // workspace primaryLineRef is only used in compare mode
+      area: null,
+    },
+  });
+  const liveActive = connected && !unavailable && liveTargetId !== null;
+
   return (
     <div className="relative">
       {hover !== null ? <RichTooltip hover={hover} /> : null}
+      {liveActive ? (
+        <div
+          className="absolute right-2 top-2 z-10 flex items-center gap-1 text-[10px] uppercase tracking-wider text-emerald-600"
+          data-testid="chart-workspace-live-indicator"
+        >
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" />
+          Live
+        </div>
+      ) : null}
       <div
         ref={containerRef}
         data-testid={`chart-workspace-${symbol}`}

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -702,7 +702,7 @@ export function ChartWorkspaceCanvas({
     bucketSeconds,
     historicalLastBar: histLastBar,
     refs: {
-      candle: candleRef.current,
+      candle: candleRef,
       line: null, // workspace primaryLineRef is only used in compare mode
       area: null,
     },

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -9,7 +9,7 @@
  * Deliberately separate from ChartCanvas (compact instrument-page chart) so
  * the compact component stays focused and this one can evolve independently.
  */
-import { useEffect, useRef, useState, type JSX } from "react";
+import { useEffect, useMemo, useRef, useState, type JSX } from "react";
 import {
   CandlestickSeries,
   HistogramSeries,
@@ -686,15 +686,20 @@ export function ChartWorkspaceCanvas({
     cleanRowsRef.current.length > 0
       ? cleanRowsRef.current[cleanRowsRef.current.length - 1]!
       : null;
-  const histLastBar =
-    lastRenderedBar !== null
-      ? {
-          time: lastRenderedBar.time as number,
-          open: lastRenderedBar.open,
-          high: lastRenderedBar.high,
-          low: lastRenderedBar.low,
-        }
-      : null;
+  // Memoize on primitive OHLC so the prop into useLiveLastBar has a
+  // stable identity across renders (see PriceChart for the same fix
+  // and rationale).
+  const lastTime = lastRenderedBar !== null ? (lastRenderedBar.time as number) : null;
+  const lastOpen = lastRenderedBar !== null ? lastRenderedBar.open : null;
+  const lastHigh = lastRenderedBar !== null ? lastRenderedBar.high : null;
+  const lastLow = lastRenderedBar !== null ? lastRenderedBar.low : null;
+  const histLastBar = useMemo(
+    () =>
+      lastTime !== null && lastOpen !== null && lastHigh !== null && lastLow !== null
+        ? { time: lastTime, open: lastOpen, high: lastHigh, low: lastLow }
+        : null,
+    [lastTime, lastOpen, lastHigh, lastLow],
+  );
   const bucketSeconds = range !== undefined ? intervalSecondsFor(range) : 60;
   const liveTargetId = !compareMode && range !== undefined ? instrumentId : null;
   const { connected, unavailable } = useLiveLastBar({

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -385,15 +385,11 @@ export function ChartWorkspaceCanvas({
     };
   }, [symbol]);
 
-  // Feed candle + volume data on rows change; handle compare mode switching.
-  useEffect(() => {
-    const candle = candleRef.current;
-    const volume = volumeRef.current;
-    const primaryLine = primaryLineRef.current;
-    const chart = chartRef.current;
-    if (!candle || !volume || !chart || !primaryLine) return;
-
-    const clean: NumericBar[] = rows.flatMap((r) => {
+  // Numeric / null-filtered rows. Computed during render so values
+  // are available to the live-tick aggregator's historical anchor on
+  // the very first render. See PriceChart for the same fix.
+  const clean = useMemo<NumericBar[]>(() => {
+    return rows.flatMap((r) => {
       const open = parseNum(r.open);
       const high = parseNum(r.high);
       const low = parseNum(r.low);
@@ -412,7 +408,19 @@ export function ChartWorkspaceCanvas({
         },
       ];
     });
-    cleanRowsRef.current = clean;
+  }, [rows]);
+
+  // Mirror `clean` into the crosshair handler's ref. Registered once
+  // at mount; ref avoids stale-closure capture.
+  cleanRowsRef.current = clean;
+
+  // Feed candle + volume data on `clean` change; handle compare mode switching.
+  useEffect(() => {
+    const candle = candleRef.current;
+    const volume = volumeRef.current;
+    const primaryLine = primaryLineRef.current;
+    const chart = chartRef.current;
+    if (!candle || !volume || !chart || !primaryLine) return;
 
     if (compareMode) {
       // In compare mode: hide candles + volume, show normalized primary line.
@@ -458,7 +466,7 @@ export function ChartWorkspaceCanvas({
     }
 
     chart.timeScale().fitContent();
-  }, [rows, compareMode]);
+  }, [clean, compareMode]);
 
   // Compare series: fetch + render normalized lines per compare symbol.
   // Tears down series for symbols no longer in the list.
@@ -540,7 +548,7 @@ export function ChartWorkspaceCanvas({
       }
       series.setData(lineData);
     });
-  }, [compares, compareMode, rows]);
+  }, [compares, compareMode, clean]);
 
   // Add/remove indicator LineSeries based on `indicators` prop.
   // `rows` is in the dep array (alongside `indicators`) so this effect
@@ -585,7 +593,7 @@ export function ChartWorkspaceCanvas({
       }
       series.setData(data);
     }
-  }, [indicators, rows]);
+  }, [indicators, clean]);
 
   // Trend overlays: linear regression + range channel.
   // In compare mode the visible axis is % change, so we compute trends on
@@ -674,7 +682,7 @@ export function ChartWorkspaceCanvas({
         channelLowRef.current = null;
       }
     }
-  }, [showRegression, showChannel, rows, compares]);
+  }, [showRegression, showChannel, clean, compares]);
 
   // Live last-bar updates (#602). Disabled in compare mode — when the
   // candle/volume series are hidden in favour of normalized lines,
@@ -682,10 +690,7 @@ export function ChartWorkspaceCanvas({
   // diverge from the per-symbol normalised data we render. Compare
   // ranges are also already restricted to daily-only at the page
   // level (#601).
-  const lastRenderedBar =
-    cleanRowsRef.current.length > 0
-      ? cleanRowsRef.current[cleanRowsRef.current.length - 1]!
-      : null;
+  const lastRenderedBar = clean.length > 0 ? clean[clean.length - 1]! : null;
   // Memoize on primitive OHLC so the prop into useLiveLastBar has a
   // stable identity across renders (see PriceChart for the same fix
   // and rationale).


### PR DESCRIPTION
## What

- New `lib/useLiveLastBar.ts` — pure `aggregateTick` function + hook that subscribes to the existing `LiveQuoteProvider` SSE stream and feeds each tick through a bucket-aware aggregator.
- Bucket-aware update logic: tick in current bucket → preserve historical/live open, extend H/L, set C; tick in next bucket → append fresh bar; stale tick → skip.
- `lib/chartData.ts`: new `INTERVAL_SECONDS` / `intervalSecondsFor(range)` / `floorToBucket` helpers.
- `PriceChart` + `ChartWorkspaceCanvas` accept `instrumentId` + `range`, anchor against the LAST RENDERED bar (not raw rows tail), and render a green pulsing "LIVE" indicator when SSE is connected. Workspace disables live updates in compare mode.
- `InstrumentPage` + `ChartPage` wrap their bodies in `LiveQuoteProvider` with the instrument id in the visible-id list. The existing `SummaryStrip` consumer + the new chart consumer share one SSE handshake per page.

## Why

Operator-requested live-updating charts during market hours. The existing `/sse/quotes` pipeline (#274 / #485 / #501) already streams ticks. #602 is purely a frontend wiring on top of that — no backend changes.

## Conscious deviations / scope notes

- **Volume aggregation is V1-scoped out** — eToro's quote stream carries no per-tick volume, and synthesising it would diverge from the canonical daily volume in `price_daily`. Volume bars stay where the historical fetch left them.
- Codex pre-push review applied across three rounds:
  1. **HIGH** — first tick no longer rewrites the historical bar's open. `aggregateTick` now seeds OHLC from `histLastBar` when the bucket matches.
  2. **MEDIUM** — switched from per-component `useLiveQuote` to `useLiveTick` from `LiveQuoteProvider` so the chart reuses the page's existing handshake (previously opened a second SSE alongside `SummaryStrip`).
  3. **MEDIUM** — both callers anchor against the cleaned/rendered last bar, not the raw rows tail. Null-OHLC tail rows can no longer make ticks bucket against an invisible bar.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test:unit` — 577/577 (new: `aggregateTick` pure-function suite covering same-bucket update + open preservation, append on bucket boundary, stale-tick skip, no-history append, live-bar-open wins, low/high extension)
- [x] `pnpm build` clean
- [x] Backend gates: ruff / format / pyright clean; pytest 2858 passed (no Python touched)

## Linked

- Parent: #585 (chart redesign epic)
- Predecessors: #586, #587, #600, #603, #601 — all merged
- Related: #274 / #485 / #501 (existing SSE quote pipeline)