### PR TITLE
fix(#602): chart freshness, session shading + axis polish

### DIFF
--- a/app/api/_debug_ws.py
+++ b/app/api/_debug_ws.py
@@ -1,0 +1,59 @@
+"""TEMPORARY debug endpoint for eToro WS subscriber state (#602 live ticks).
+
+Surfaces the bits we need to diagnose "SSE connected but no ticks
+arriving":
+  * Is the WS connection currently open?
+  * Which instrument topics has add_instruments() registered refs for?
+  * Is the subscriber task running, or has it died?
+
+Remove this file once the live-tick path is confirmed healthy on
+this environment.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/_debug", tags=["debug"])
+
+
+class EtoroWsStatus(BaseModel):
+    subscriber_present: bool
+    ws_connected: bool
+    topic_refs: dict[int, int]
+    task_done: bool | None
+    last_quote_max: str | None
+
+
+@router.get("/etoro-ws", response_model=EtoroWsStatus)
+def etoro_ws_status(request: Request) -> EtoroWsStatus:
+    sub = getattr(request.app.state, "etoro_ws", None)
+    if sub is None:
+        return EtoroWsStatus(
+            subscriber_present=False,
+            ws_connected=False,
+            topic_refs={},
+            task_done=None,
+            last_quote_max=None,
+        )
+    ws = getattr(sub, "_ws", None)
+    refs: dict[int, int] = dict(getattr(sub, "_topic_refs", {}))
+    task = getattr(sub, "_task", None)
+    task_done = task.done() if task is not None else None
+
+    last_quote_max: str | None = None
+    pool = getattr(request.app.state, "db_pool", None)
+    if pool is not None:
+        with pool.connection() as conn:
+            row = conn.execute("SELECT MAX(quoted_at) FROM quotes").fetchone()
+            if row is not None and row[0] is not None:
+                last_quote_max = row[0].isoformat()
+
+    return EtoroWsStatus(
+        subscriber_present=True,
+        ws_connected=ws is not None,
+        topic_refs=refs,
+        task_done=task_done,
+        last_quote_max=last_quote_max,
+    )

--- a/app/api/_debug_ws.py
+++ b/app/api/_debug_ws.py
@@ -26,6 +26,64 @@ class EtoroWsStatus(BaseModel):
     last_quote_max: str | None
 
 
+@router.get("/etoro-candles-probe")
+def etoro_candles_probe(request: Request, instrument_id: int = 1699, count: int = 90) -> dict:
+    """Probe eToro intraday candles directly. Returns last N OneMinute
+    bars + timestamps so we can see actual session coverage."""
+    import uuid
+
+    import httpx
+
+    from app.config import settings
+    from app.services.broker_credentials import load_credential_for_provider_use
+    from app.services.operators import sole_operator_id
+
+    pool = getattr(request.app.state, "db_pool", None)
+    if pool is None:
+        return {"error": "no pool"}
+    with pool.connection() as conn:
+        op_id = sole_operator_id(conn)
+        api = load_credential_for_provider_use(
+            conn,
+            operator_id=op_id,
+            provider="etoro",
+            label="api_key",
+            environment=settings.etoro_env,
+            caller="diag",
+        )
+        conn.commit()
+        user = load_credential_for_provider_use(
+            conn,
+            operator_id=op_id,
+            provider="etoro",
+            label="user_key",
+            environment=settings.etoro_env,
+            caller="diag",
+        )
+        conn.commit()
+
+    url = (
+        f"{settings.etoro_base_url}/api/v1/market-data/instruments/"
+        f"{instrument_id}/history/candles/asc/OneMinute/{count}"
+    )
+    headers = {"x-api-key": api, "x-user-key": user, "x-request-id": str(uuid.uuid4())}
+    with httpx.Client(timeout=15.0) as c:
+        r = c.get(url, headers=headers)
+        if r.status_code != 200:
+            return {"status": r.status_code, "body": r.text[:500]}
+        body = r.json()
+        outer = body.get("candles", [])
+        if not outer:
+            return {"empty": True}
+        inner = outer[0].get("candles", [])
+        return {
+            "count": len(inner),
+            "first": inner[0] if inner else None,
+            "last": inner[-1] if inner else None,
+            "samples_every_10": [inner[i] for i in range(0, len(inner), 10)],
+        }
+
+
 @router.get("/etoro-ws", response_model=EtoroWsStatus)
 def etoro_ws_status(request: Request) -> EtoroWsStatus:
     sub = getattr(request.app.state, "etoro_ws", None)

--- a/app/api/_debug_ws.py
+++ b/app/api/_debug_ws.py
@@ -27,9 +27,16 @@ class EtoroWsStatus(BaseModel):
 
 
 @router.get("/etoro-candles-probe")
-def etoro_candles_probe(request: Request, instrument_id: int = 1699, count: int = 90) -> dict:
-    """Probe eToro intraday candles directly. Returns last N OneMinute
-    bars + timestamps so we can see actual session coverage."""
+def etoro_candles_probe(
+    request: Request,
+    instrument_id: int = 1699,
+    count: int = 90,
+    interval: str = "OneMinute",
+) -> dict:
+    """Probe eToro intraday candles directly. Returns last N bars at
+    the requested interval + timestamps so we can see actual session
+    coverage and gap structure.
+    """
     import uuid
 
     import httpx
@@ -64,7 +71,7 @@ def etoro_candles_probe(request: Request, instrument_id: int = 1699, count: int 
 
     url = (
         f"{settings.etoro_base_url}/api/v1/market-data/instruments/"
-        f"{instrument_id}/history/candles/asc/OneMinute/{count}"
+        f"{instrument_id}/history/candles/asc/{interval}/{count}"
     )
     headers = {"x-api-key": api, "x-user-key": user, "x-request-id": str(uuid.uuid4())}
     with httpx.Client(timeout=15.0) as c:
@@ -76,12 +83,69 @@ def etoro_candles_probe(request: Request, instrument_id: int = 1699, count: int 
         if not outer:
             return {"empty": True}
         inner = outer[0].get("candles", [])
+        # Compact timestamp + close-only ladder so the response is
+        # scannable for gap analysis without 30+ KB of JSON.
+        ladder = [{"t": b.get("fromDate"), "c": b.get("close")} for b in inner]
         return {
             "count": len(inner),
             "first": inner[0] if inner else None,
             "last": inner[-1] if inner else None,
-            "samples_every_10": [inner[i] for i in range(0, len(inner), 10)],
+            "ladder": ladder,
         }
+
+
+@router.get("/etoro-instrument-raw")
+def etoro_instrument_raw(request: Request, instrument_id: int = 1699) -> dict:
+    """Probe eToro instruments-list raw response — return the full raw
+    dict for one instrument so we can see every field (including
+    trading-hours / extended-hours classification fields the
+    `_normalise_instrument` mapper drops)."""
+    import uuid
+
+    import httpx
+
+    from app.config import settings
+    from app.services.broker_credentials import load_credential_for_provider_use
+    from app.services.operators import sole_operator_id
+
+    pool = getattr(request.app.state, "db_pool", None)
+    if pool is None:
+        return {"error": "no pool"}
+    with pool.connection() as conn:
+        op_id = sole_operator_id(conn)
+        api = load_credential_for_provider_use(
+            conn,
+            operator_id=op_id,
+            provider="etoro",
+            label="api_key",
+            environment=settings.etoro_env,
+            caller="diag",
+        )
+        conn.commit()
+        user = load_credential_for_provider_use(
+            conn,
+            operator_id=op_id,
+            provider="etoro",
+            label="user_key",
+            environment=settings.etoro_env,
+            caller="diag",
+        )
+        conn.commit()
+
+    headers = {"x-api-key": api, "x-user-key": user, "x-request-id": str(uuid.uuid4())}
+    with httpx.Client(timeout=20.0) as c:
+        r = c.get(
+            f"{settings.etoro_base_url}/api/v1/market-data/instruments",
+            headers=headers,
+        )
+        if r.status_code != 200:
+            return {"status": r.status_code, "body": r.text[:500]}
+        body = r.json()
+        items = body if isinstance(body, list) else body.get("instruments", [])
+        for item in items:
+            if isinstance(item, dict) and item.get("instrumentID") == instrument_id:
+                return {"found": True, "raw": item, "all_keys": sorted(item.keys())}
+        return {"found": False, "sample_keys": sorted(items[0].keys()) if items else []}
 
 
 @router.get("/etoro-ws", response_model=EtoroWsStatus)

--- a/app/main.py
+++ b/app/main.py
@@ -342,10 +342,11 @@ app.include_router(business_summary_admin_router)
 # Debug router is dev/test-only — exposes operator-credentialled
 # pass-throughs to eToro (`/_debug/etoro-candles-probe`,
 # `/_debug/etoro-instrument-raw`) plus internal subscriber state
-# (`/_debug/etoro-ws`). Gating on `app_env` keeps these routes
-# off in production where they would be reachable unauthenticated
-# (PR #610 review BLOCKING).
-if settings.app_env != "prod":
+# (`/_debug/etoro-ws`). Allowlist (NOT denylist on `prod`) so future
+# environments like `staging`/`qa`/`uat` are denied by default and
+# never silently expose operator credentials. Add new envs here
+# explicitly when they need diagnostic access. PR #610 review.
+if settings.app_env in {"dev", "test", "local"}:
     app.include_router(debug_ws_router)
 app.include_router(capability_overrides_admin_router)
 app.include_router(filings_router)

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from app.api.auth_session import router as auth_session_router
 from app.api.auth_setup import router as auth_setup_router
 from app.api.broker_credentials import router as broker_credentials_router
 from app.api.budget import router as budget_router
+from app.api._debug_ws import router as debug_ws_router
 from app.api.business_summary_admin import router as business_summary_admin_router
 from app.api.capability_overrides_admin import router as capability_overrides_admin_router
 from app.api.config import KillSwitchRequest, KillSwitchResponse, post_kill_switch
@@ -338,6 +339,7 @@ app.include_router(config_router)
 app.include_router(copy_trading_router)
 app.include_router(coverage_router)
 app.include_router(business_summary_admin_router)
+app.include_router(debug_ws_router)
 app.include_router(capability_overrides_admin_router)
 app.include_router(filings_router)
 app.include_router(instruments_router)

--- a/app/main.py
+++ b/app/main.py
@@ -339,7 +339,14 @@ app.include_router(config_router)
 app.include_router(copy_trading_router)
 app.include_router(coverage_router)
 app.include_router(business_summary_admin_router)
-app.include_router(debug_ws_router)
+# Debug router is dev/test-only — exposes operator-credentialled
+# pass-throughs to eToro (`/_debug/etoro-candles-probe`,
+# `/_debug/etoro-instrument-raw`) plus internal subscriber state
+# (`/_debug/etoro-ws`). Gating on `app_env` keeps these routes
+# off in production where they would be reachable unauthenticated
+# (PR #610 review BLOCKING).
+if settings.app_env != "prod":
+    app.include_router(debug_ws_router)
 app.include_router(capability_overrides_admin_router)
 app.include_router(filings_router)
 app.include_router(instruments_router)

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 from psycopg_pool import ConnectionPool
 from pydantic import BaseModel, Field
 
+from app.api._debug_ws import router as debug_ws_router
 from app.api.alerts import router as alerts_router
 from app.api.attribution import router as attribution_router
 from app.api.audit import router as audit_router
@@ -21,7 +22,6 @@ from app.api.auth_session import router as auth_session_router
 from app.api.auth_setup import router as auth_setup_router
 from app.api.broker_credentials import router as broker_credentials_router
 from app.api.budget import router as budget_router
-from app.api._debug_ws import router as debug_ws_router
 from app.api.business_summary_admin import router as business_summary_admin_router
 from app.api.capability_overrides_admin import router as capability_overrides_admin_router
 from app.api.config import KillSwitchRequest, KillSwitchResponse, post_kill_switch

--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -68,6 +68,12 @@ _RECONNECT_BACKOFF_S = 5.0
 # isn't hammered. 3 seconds is short enough that the operator sees
 # fresh state inside a "feel alive" window without churn.
 _RECONCILE_DEBOUNCE_S = 3.0
+# REST live-rate poll cadence. eToro's WS is bursty; this poll
+# guarantees a freshness floor so the chart's in-progress bar updates
+# at least every _RATE_POLL_INTERVAL_S regardless of WS push state.
+# 5s × 12 polls/min = 12 GET/min — well under the 60 GET/min budget.
+# Each poll batch-fetches every visible instrument in one rates call.
+_RATE_POLL_INTERVAL_S = 5.0
 
 
 # ---------------------------------------------------------------------
@@ -453,6 +459,16 @@ class EtoroWebSocketSubscriber:
         self._reconcile_idle = threading.Event()
         self._reconcile_idle.set()
 
+        # REST-polled live-rate fallback (#602 follow-up). eToro WS
+        # is bursty / silent for stretches in demo; per-second polling
+        # of /instruments/rates guarantees a freshness floor regardless
+        # of WS state. Every _RATE_POLL_INTERVAL_S the poll loop
+        # snapshots `_topic_refs.keys()` (visible instrument ids),
+        # batch-calls the rates endpoint, and publishes synthesised
+        # ticks to the bus exactly the way the WS path does. Skipped
+        # when no SSE stream has visible ids.
+        self._rest_poll_task: asyncio.Task[None] | None = None
+
         # Visibility-driven topic registry. Every page-view SSE stream
         # bumps a ref on its visible instrument ids; the topic is sent
         # to eToro iff its refcount > 0 (#498). No DB-backed selector
@@ -525,6 +541,7 @@ class EtoroWebSocketSubscriber:
         # ids on screen. Visibility drives the upstream subscription,
         # not held / watchlist state (#498).
         self._task = asyncio.create_task(self._run(), name="etoro-ws-subscriber")
+        self._rest_poll_task = asyncio.create_task(self._rest_poll_loop(), name="etoro-ws-rest-poll")
         logger.info("EtoroWebSocketSubscriber: started")
 
     async def stop(self) -> None:
@@ -535,6 +552,11 @@ class EtoroWebSocketSubscriber:
         with contextlib.suppress(asyncio.CancelledError):
             await self._task
         self._task = None
+        if self._rest_poll_task is not None:
+            self._rest_poll_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._rest_poll_task
+            self._rest_poll_task = None
         # Cancel the reconcile worker. The worker coroutine may be
         # awaiting ``asyncio.to_thread`` — the cancel raises
         # CancelledError out of the await, but the OS thread running
@@ -867,6 +889,93 @@ class EtoroWebSocketSubscriber:
                         update.instrument_id,
                         exc_info=True,
                     )
+
+    async def _rest_poll_loop(self) -> None:
+        """Periodic REST poll of /instruments/rates to guarantee a
+        freshness floor for the visible-id set.
+
+        eToro's WS is bursty: tens of seconds of silence are normal,
+        even on demo with held positions. Pure-WS charts go stale in
+        those windows. This loop runs alongside the WS, polling the
+        REST rates endpoint every _RATE_POLL_INTERVAL_S for whatever
+        ids have a refcount, and synthesises QuoteUpdate objects that
+        feed the same QuoteBus the WS path uses. SSE consumers see
+        identical tick payloads regardless of source.
+
+        Why a loop here, not per-SSE-stream: the rates endpoint
+        batches up to 100 ids in one call. One loop covering the
+        union of all visible ids is strictly cheaper than N parallel
+        per-stream polls. Same scaling argument as
+        LiveQuoteProvider's "one stream per page" rule.
+
+        Rate budget: 12 polls/min × 1 GET = 12 GET/min/key. 60 GET/min
+        is the eToro ceiling, leaving ample headroom for the WS-side
+        Subscribe / Unsubscribe traffic.
+        """
+        # Local import keeps the WS module's startup cycle independent
+        # of the REST provider's heavy httpx + retry deps; only fires
+        # when subscriber.start() is called.
+        from app.providers.implementations.etoro import EtoroMarketDataProvider
+
+        provider = EtoroMarketDataProvider(
+            api_key=self._api_key,
+            user_key=self._user_key,
+            env=self._env,
+        )
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(),
+                        timeout=_RATE_POLL_INTERVAL_S,
+                    )
+                    return
+                except TimeoutError:
+                    pass
+                async with self._topic_lock:
+                    ids = sorted(self._topic_refs.keys())
+                if not ids:
+                    continue
+                try:
+                    quotes = await asyncio.to_thread(provider.get_quotes, ids)
+                except Exception:
+                    logger.warning(
+                        "EtoroWebSocketSubscriber: REST rate poll failed for %d ids — will retry next interval",
+                        len(ids),
+                        exc_info=True,
+                    )
+                    continue
+                if self._bus is None:
+                    continue
+                for q in quotes:
+                    update = QuoteUpdate(
+                        instrument_id=q.instrument_id,
+                        bid=q.bid,
+                        ask=q.ask,
+                        last=q.last,
+                        quoted_at=q.timestamp,
+                    )
+                    self._bus.publish(update)
+                    # Also persist to quotes table so the operator's
+                    # next page-load sees the same fresh value the
+                    # chart is already displaying. Same offload pattern
+                    # as the WS path.
+                    try:
+                        await asyncio.to_thread(self._sync_upsert, update)
+                    except Exception:
+                        logger.warning(
+                            "EtoroWebSocketSubscriber: rate-poll upsert failed instrument_id=%d",
+                            update.instrument_id,
+                            exc_info=True,
+                        )
+        finally:
+            # Best-effort cleanup of the long-lived REST client. Most
+            # of the time the subscriber outlives a single eBull
+            # session so this only runs on lifespan shutdown.
+            try:
+                provider._client.close()  # noqa: SLF001 — provider context-manager only
+            except Exception:
+                pass
 
 
 def _looks_like_json_envelope(raw: str | bytes) -> bool:

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -36,15 +36,22 @@ import {
 
 import type { ChartRange } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { SessionBands } from "@/components/instrument/SessionBands";
 import { EmptyState } from "@/components/states/EmptyState";
 import {
   fetchChartCandles,
+  floorToBucket,
   intervalSecondsFor,
   isIntraday,
   type NormalisedBar,
   type NormalisedChartCandles,
 } from "@/lib/chartData";
-import { formatHoverLabel, humanizeVolume, tickFormatter } from "@/lib/chartFormatters";
+import {
+  classifyUsSession,
+  formatHoverLabel,
+  humanizeVolume,
+  tickFormatter,
+} from "@/lib/chartFormatters";
 import { chartTheme } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
 import { useLiveLastBar } from "@/lib/useLiveLastBar";
@@ -139,6 +146,10 @@ export function PriceChart({
     ? (rawType as ChartType)
     : "candle";
   const priceScale: PriceScaleMode = searchParams.get("scale") === "log" ? "log" : "linear";
+  // Session-visibility toggles. Default ON (omit param to keep clean URLs);
+  // set `?pm=0` / `?ah=0` to hide pre-market / after-hours bars + bands.
+  const showPm = searchParams.get("pm") !== "0";
+  const showAh = searchParams.get("ah") !== "0";
 
   const setRange = useCallback(
     (next: ChartRange) => {
@@ -175,6 +186,19 @@ export function PriceChart({
     }
     setSearchParams(params, { replace: true });
   }, [searchParams, setSearchParams, priceScale]);
+
+  const toggleParam = useCallback(
+    (key: "pm" | "ah", currentlyOn: boolean) => {
+      const params = new URLSearchParams(searchParams);
+      if (currentlyOn) {
+        params.set(key, "0");
+      } else {
+        params.delete(key);
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
 
   const { data, error, loading, refetch } = useAsync<NormalisedChartCandles>(
     () => fetchChartCandles(symbol, range),
@@ -280,6 +304,44 @@ export function PriceChart({
           >
             Log
           </button>
+          {/*
+            Session-visibility + previous-close toggles. Hidden on
+            daily-tier ranges (YTD/1Y/5Y/MAX) — those have one bar per
+            session so PM/AH boundaries don't apply, and the
+            previous-close reference is implicit in the daily series.
+          */}
+          {isIntraday(range) ? (
+            <>
+              <button
+                type="button"
+                onClick={() => toggleParam("pm", showPm)}
+                aria-pressed={showPm}
+                className={`rounded px-2 py-0.5 text-xs font-medium ${
+                  showPm
+                    ? "bg-slate-800 text-white"
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                }`}
+                data-testid="chart-toggle-pm"
+                title="Show / hide pre-market (04:00–09:30 ET)"
+              >
+                PM
+              </button>
+              <button
+                type="button"
+                onClick={() => toggleParam("ah", showAh)}
+                aria-pressed={showAh}
+                className={`rounded px-2 py-0.5 text-xs font-medium ${
+                  showAh
+                    ? "bg-slate-800 text-white"
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                }`}
+                data-testid="chart-toggle-ah"
+                title="Show / hide after-hours (16:00–20:00 ET)"
+              >
+                AH
+              </button>
+            </>
+          ) : null}
         </div>
       </div>
 
@@ -307,6 +369,8 @@ export function PriceChart({
           chartType={chartType}
           priceScale={priceScale}
           intraday={intraday}
+          showPm={showPm}
+          showAh={showAh}
         />
       ) : null}
     </div>
@@ -327,6 +391,10 @@ export interface ChartCanvasProps {
   priceScale?: PriceScaleMode;
   /** When true, hover label includes HH:MM and the time scale shows time. */
   intraday?: boolean;
+  /** Show pre-market (04:00–09:30 ET) bars + tint band. Default true. */
+  showPm?: boolean;
+  /** Show after-hours (16:00–20:00 ET) bars + tint band. Default true. */
+  showAh?: boolean;
   containerClassName?: string;
 }
 
@@ -338,6 +406,8 @@ export function ChartCanvas({
   chartType = "candle",
   priceScale = "linear",
   intraday = false,
+  showPm = true,
+  showAh = true,
   containerClassName,
 }: ChartCanvasProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -350,6 +420,13 @@ export function ChartCanvas({
   // closure capture when rows update.
   const cleanRowsRef = useRef<NumericBar[]>([]);
   const intradayRef = useRef<boolean>(intraday);
+  // Track which `range` we've already auto-fit. fitContent should
+  // only run on the first non-empty load for a given range — the
+  // 60s candle-window refetch (PriceChart's backstop polling) reuses
+  // the same range and would otherwise re-fit on every tick of the
+  // poll, shifting the visible right edge and re-anchoring axis
+  // ticks to whatever bar happens to be rightmost.
+  const fittedRangeRef = useRef<string | null>(null);
   const [hover, setHover] = useState<RichHoverState | null>(null);
 
   // Keep the ref in sync so the crosshair handler (registered once at
@@ -387,6 +464,14 @@ export function ChartCanvas({
         borderColor: chartTheme.borderColor,
         timeVisible: false,
         secondsVisible: false,
+        // rightOffset: 5 leaves a 5-bar buffer past the last bar so
+        // the rightmost time-axis tick lands on a clean grid position
+        // (e.g. 20:55) instead of the just-painted live bar
+        // (e.g. 20:57). TradingView uses the same trick — without
+        // it the live tick repeatedly shifts the visible-range edge,
+        // which forces lightweight-charts' tick generator to label
+        // whatever the rightmost bar happens to be.
+        rightOffset: 5,
         // Explicit formatter — without this the daily axis renders
         // weekday abbreviations ("Mon Tue Wed") instead of dates and
         // intraday axis hides the time component below ~minute zoom.
@@ -532,7 +617,10 @@ export function ChartCanvas({
   // would always be null until React next re-rendered, and live ticks
   // would all bucket as "no anchor" → fresh bars, never extending the
   // historical last candle.
-  const clean = useMemo<NumericBar[]>(() => {
+  //
+  // FULL set — used by the previous-close detector + SessionBands so
+  // they can see ALL sessions regardless of visibility toggles.
+  const cleanAll = useMemo<NumericBar[]>(() => {
     return rows.flatMap((r) => {
       const open = parseNum(r.open);
       const high = parseNum(r.high);
@@ -553,6 +641,20 @@ export function ChartCanvas({
       ];
     });
   }, [rows]);
+
+  // Visibility-filtered set — what gets fed into the price/volume
+  // series. PM/AH bars drop when the operator toggles them off, but
+  // RTH and `closed` bars are never hidden (closed bars are already
+  // collapsed by the ordinal axis).
+  const clean = useMemo<NumericBar[]>(() => {
+    if (!intraday || (showPm && showAh)) return cleanAll;
+    return cleanAll.filter((b) => {
+      const k = classifyUsSession(b.time);
+      if (k === "pre" && !showPm) return false;
+      if (k === "ah" && !showAh) return false;
+      return true;
+    });
+  }, [cleanAll, intraday, showPm, showAh]);
 
   // Mirror `clean` into the crosshair handler's ref. The handler is
   // registered once at mount; reading from a ref avoids stale-closure
@@ -594,8 +696,17 @@ export function ChartCanvas({
       }),
     );
 
-    chart.timeScale().fitContent();
-  }, [clean]);
+    // Re-fit only on the first non-empty load for a given range. The
+    // chart auto-extends visible width as new bars append; calling
+    // fitContent on every clean change would flush the operator's
+    // pan/zoom state every 60s and re-anchor the rightmost tick.
+    const fingerprint = range ?? "?";
+    if (clean.length > 0 && fittedRangeRef.current !== fingerprint) {
+      chart.timeScale().fitContent();
+      fittedRangeRef.current = fingerprint;
+    }
+  }, [clean, range]);
+
 
   // Live-tick aggregator (#602). Subscribes to the page-level
   // LiveQuoteProvider stream for `instrumentId` and updates the last
@@ -634,6 +745,8 @@ export function ChartCanvas({
         line: lineRef,
         area: areaRef,
       },
+      acceptPre: showPm,
+      acceptAh: showAh,
     });
   const liveActive = connected && !unavailable && instrumentId !== null && range !== undefined;
   const lastTickHHMM = lastAppliedAt !== null
@@ -643,8 +756,46 @@ export function ChartCanvas({
       })()
     : null;
 
+  // Bars passed to SessionBands — track the rendered (`clean`) set so
+  // toggling PM/AH off removes both the bars AND the corresponding
+  // tint, keeping the visual consistent. The ordinal axis collapses
+  // gaps either way, so band coordinates align with the rendered bars.
+  //
+  // Live-bar bucket: when the live-tick aggregator appends a fresh
+  // bucket past the historical tail (verdict `append`), the candle
+  // moves immediately via `series.update()` but `clean` doesn't
+  // refresh until the next REST refetch (60s on intraday). Append
+  // the live bucket here so the tint follows the candle without lag.
+  // Codex review #602.
+  const liveBucketTime = useMemo(() => {
+    if (lastAppliedAt === null) return null;
+    const tickEpoch = Math.floor(new Date(lastAppliedAt).getTime() / 1000);
+    if (!Number.isFinite(tickEpoch)) return null;
+    return floorToBucket(tickEpoch, bucketSeconds);
+  }, [lastAppliedAt, bucketSeconds]);
+  const bandBars = useMemo(() => {
+    const base = clean.map((b) => ({ time: b.time as number }));
+    if (
+      liveBucketTime !== null &&
+      (base.length === 0 || base[base.length - 1]!.time < liveBucketTime)
+    ) {
+      base.push({ time: liveBucketTime });
+    }
+    return base;
+  }, [clean, liveBucketTime]);
+
   return (
     <div className="relative">
+      <div
+        ref={containerRef}
+        data-testid={`price-chart-${symbol}`}
+        className={containerClassName ?? "h-[340px] w-full"}
+      />
+      <SessionBands
+        chartRef={chartRef}
+        bars={bandBars}
+        enabled={intraday && (showPm || showAh)}
+      />
       {hover !== null ? <RichTooltip hover={hover} /> : null}
       {liveActive ? (
         <div
@@ -664,11 +815,6 @@ export function ChartCanvas({
           ) : null}
         </div>
       ) : null}
-      <div
-        ref={containerRef}
-        data-testid={`price-chart-${symbol}`}
-        className={containerClassName ?? "h-[340px] w-full"}
-      />
     </div>
   );
 }

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -181,6 +181,22 @@ export function PriceChart({
     [symbol, range],
   );
 
+  // Background poll fallback (#602 follow-up). SSE drives the
+  // smooth-live feel when eToro is actually pushing ticks, but the
+  // demo WS goes silent for stretches and the chart needs to keep
+  // refreshing from REST to stay current. Interval scales with
+  // range — sub-day = 15s (matches the 30s intraday TTL cache, so
+  // alternating polls actually hit the provider), daily = 60s.
+  // The cache + singleflight on the backend (#600) keep this cheap;
+  // worst case is 4 GET/min/instrument across the page.
+  useEffect(() => {
+    const intervalMs = isIntraday(range) ? 15_000 : 60_000;
+    const id = setInterval(() => {
+      refetch();
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [range, refetch]);
+
   // Between a range click and useAsync's effect firing, React renders
   // one frame with loading=false and the prior range's data still in
   // state. Gate chart rendering on `data.range === range` so the old

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -612,28 +612,39 @@ export function ChartCanvas({
     [lastTime, lastOpen, lastHigh, lastLow],
   );
   const bucketSeconds = range !== undefined ? intervalSecondsFor(range) : 60;
-  const { connected, unavailable } = useLiveLastBar({
-    instrumentId: range !== undefined ? instrumentId : null,
-    bucketSeconds,
-    historicalLastBar: histLastBar,
-    refs: {
-      candle: candleRef,
-      line: lineRef,
-      area: areaRef,
-    },
-  });
+  const { connected, unavailable, appliedTicks, lastAppliedAt, lastVerdict } =
+    useLiveLastBar({
+      instrumentId: range !== undefined ? instrumentId : null,
+      bucketSeconds,
+      historicalLastBar: histLastBar,
+      refs: {
+        candle: candleRef,
+        line: lineRef,
+        area: areaRef,
+      },
+    });
   const liveActive = connected && !unavailable && instrumentId !== null && range !== undefined;
+  const lastTickHHMM = lastAppliedAt !== null ? new Date(lastAppliedAt).toISOString().slice(11, 16) : null;
 
   return (
     <div className="relative">
       {hover !== null ? <RichTooltip hover={hover} /> : null}
       {liveActive ? (
         <div
-          className="absolute right-2 top-2 z-10 flex items-center gap-1 text-[10px] uppercase tracking-wider text-emerald-600"
+          className="absolute right-2 top-2 z-10 flex items-center gap-1.5 text-[10px] tabular-nums tracking-wide text-emerald-600"
           data-testid="price-chart-live-indicator"
+          title={`SSE connected · ${appliedTicks} ticks applied · last verdict: ${lastVerdict ?? "(none yet)"}`}
         >
           <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" />
-          Live
+          <span className="uppercase">Live</span>
+          <span className="text-slate-400">·</span>
+          <span className="text-slate-500">{appliedTicks} ticks</span>
+          {lastTickHHMM !== null ? (
+            <>
+              <span className="text-slate-400">·</span>
+              <span className="text-slate-500">{lastTickHHMM}Z</span>
+            </>
+          ) : null}
         </div>
       ) : null}
       <div

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -181,16 +181,12 @@ export function PriceChart({
     [symbol, range],
   );
 
-  // Background poll fallback (#602 follow-up). SSE drives the
-  // smooth-live feel when eToro is actually pushing ticks, but the
-  // demo WS goes silent for stretches and the chart needs to keep
-  // refreshing from REST to stay current. Interval scales with
-  // range — sub-day = 15s (matches the 30s intraday TTL cache, so
-  // alternating polls actually hit the provider), daily = 60s.
-  // The cache + singleflight on the backend (#600) keep this cheap;
-  // worst case is 4 GET/min/instrument across the page.
+  // Coarser-grained candle-window refetch as a backstop. The
+  // backend's REST live-rate poller (#602) keeps the in-progress bar
+  // ticking at 5s; this refetch picks up any historical bar
+  // corrections eToro emits (rare). 60s on intraday is plenty.
   useEffect(() => {
-    const intervalMs = isIntraday(range) ? 15_000 : 60_000;
+    const intervalMs = isIntraday(range) ? 60_000 : 300_000;
     const id = setInterval(() => {
       refetch();
     }, intervalMs);

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -636,7 +636,12 @@ export function ChartCanvas({
       },
     });
   const liveActive = connected && !unavailable && instrumentId !== null && range !== undefined;
-  const lastTickHHMM = lastAppliedAt !== null ? new Date(lastAppliedAt).toISOString().slice(11, 16) : null;
+  const lastTickHHMM = lastAppliedAt !== null
+    ? (() => {
+        const d = new Date(lastAppliedAt);
+        return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+      })()
+    : null;
 
   return (
     <div className="relative">
@@ -654,7 +659,7 @@ export function ChartCanvas({
           {lastTickHHMM !== null ? (
             <>
               <span className="text-slate-400">·</span>
-              <span className="text-slate-500">{lastTickHHMM}Z</span>
+              <span className="text-slate-500">{lastTickHHMM}</span>
             </>
           ) : null}
         </div>

--- a/frontend/src/components/instrument/SessionBands.tsx
+++ b/frontend/src/components/instrument/SessionBands.tsx
@@ -1,0 +1,240 @@
+/**
+ * SessionBands — translucent overlay strips that mark pre-market and
+ * after-hours bars on an intraday lightweight-charts canvas (#602).
+ *
+ * The chart is ordinal by default — closed-market gaps (overnight,
+ * weekends, holidays) are collapsed and don't need shading. The two
+ * windows that DO render but visually differ from RTH are:
+ *
+ *   * pre-market    04:00–09:30 ET → faint sky tint
+ *   * after-hours   16:00–20:00 ET → faint amber tint
+ *
+ * Closed bars (rare in feed-of-record data — eToro doesn't emit them
+ * for US equities) collapse via the ordinal axis so we don't render a
+ * band for them.
+ *
+ * Implementation: absolute-positioned `<div>` siblings of the chart
+ * canvas, sized in pixels via `timeScale().timeToCoordinate()`. Both
+ * tints use `rgba` with low alpha so they read on light AND dark
+ * backgrounds — when the dark theme arrives (#596) no rework needed
+ * for bands. Pure overlay, pointer-events none — never intercepts
+ * crosshair / clicks.
+ *
+ * Recomputes on:
+ *   * `bars` identity change (range switch, fresh fetch)
+ *   * `subscribeVisibleLogicalRangeChange` (zoom / pan)
+ *   * `ResizeObserver` on the chart container (layout shift)
+ */
+import { useEffect, useState, type JSX, type RefObject } from "react";
+import type { IChartApi, Time } from "lightweight-charts";
+
+import { classifyUsSession, type SessionKind } from "@/lib/chartFormatters";
+
+interface Band {
+  readonly kind: SessionKind;
+  readonly left: number;
+  readonly width: number;
+}
+
+interface PaneInset {
+  readonly right: number;
+  readonly bottom: number;
+}
+
+// Tints chosen to read against both white and slate-900 backgrounds.
+// Anything that is NOT regular-trading-hours gets a tint so the
+// operator can see at a glance which slice of the day a candle
+// belongs to:
+//   * pre-market    → sky tint   (US PM, 04:00–09:30 ET)
+//   * after-hours   → amber tint (US AH, 16:00–20:00 ET)
+//   * closed        → slate grey (overnight, weekends, holidays —
+//                                  any bar eToro emits outside
+//                                  the three canonical sessions)
+//   * RTH           → no tint (the canonical "live market" baseline
+//                              the eye reads as default)
+const TINT: Record<SessionKind, string | null> = {
+  pre: "rgba(56, 189, 248, 0.18)", // sky-400 @ 18%
+  rth: null,
+  ah: "rgba(245, 158, 11, 0.18)", // amber-500 @ 18%
+  closed: "rgba(148, 163, 184, 0.18)", // slate-400 @ 18%
+};
+
+export interface SessionBandsProps {
+  readonly chartRef: RefObject<IChartApi | null>;
+  readonly bars: ReadonlyArray<{ readonly time: number }>;
+  /** Daily / weekly / monthly charts have one bar per session — no
+   *  intra-bar boundaries to mark. Caller passes `false` so the
+   *  overlay short-circuits. */
+  readonly enabled: boolean;
+}
+
+export function SessionBands({ chartRef, bars, enabled }: SessionBandsProps): JSX.Element | null {
+  const [bands, setBands] = useState<Band[]>([]);
+  const [inset, setInset] = useState<PaneInset>({ right: 0, bottom: 0 });
+
+  useEffect(() => {
+    if (!enabled) {
+      setBands([]);
+      setInset({ right: 0, bottom: 0 });
+      return;
+    }
+
+    let cancelled = false;
+    let rafReady: number | undefined;
+    let rafFirstPaint: number | undefined;
+    let attachedTs: ReturnType<IChartApi["timeScale"]> | null = null;
+    let ro: ResizeObserver | null = null;
+
+    // recompute reads chartRef.current EVERY call rather than capturing
+    // it. The chart may not exist yet at first invocation (React fires
+    // child effects before parent effects on mount, so the parent's
+    // createChart() runs AFTER this useEffect body).
+    const recompute = (): void => {
+      const chart = chartRef.current;
+      if (chart === null) return;
+      const ts = chart.timeScale();
+
+      try {
+        setInset({
+          right: chart.priceScale("right").width(),
+          bottom: ts.height(),
+        });
+      } catch {
+        return;
+      }
+
+      if (bars.length < 2) {
+        setBands([]);
+        return;
+      }
+      const sessions: SessionKind[] = bars.map((b) => classifyUsSession(b.time));
+
+      // Group consecutive bars with the same session kind into runs.
+      const runs: Array<{ kind: SessionKind; startIdx: number; endIdx: number }> = [];
+      for (let i = 0; i < bars.length; i++) {
+        const k = sessions[i]!;
+        const tail = runs[runs.length - 1];
+        if (tail !== undefined && tail.kind === k) {
+          tail.endIdx = i;
+        } else {
+          runs.push({ kind: k, startIdx: i, endIdx: i });
+        }
+      }
+
+      const next: Band[] = [];
+      for (const run of runs) {
+        if (TINT[run.kind] === null) continue;
+        const startBar = bars[run.startIdx]!;
+        const endBar = bars[run.endIdx]!;
+        const startCoord = ts.timeToCoordinate(startBar.time as Time);
+        const endCoord = ts.timeToCoordinate(endBar.time as Time);
+        if (startCoord === null || endCoord === null) continue;
+
+        // Local bar spacing — one bar's pixel width. lightweight-charts
+        // centers each candle on its bar-time tick; the candle's body
+        // visually spans `[coord(T) - barSpacing/2, coord(T) + barSpacing/2]`.
+        let barSpacing = 0;
+        if (run.endIdx > run.startIdx) {
+          barSpacing = Math.abs(endCoord - startCoord) / Math.max(1, run.endIdx - run.startIdx);
+        } else {
+          const neighbourIdx = run.startIdx > 0 ? run.startIdx - 1 : run.startIdx + 1;
+          if (neighbourIdx >= 0 && neighbourIdx < bars.length) {
+            const nbCoord = ts.timeToCoordinate(bars[neighbourIdx]!.time as Time);
+            if (nbCoord !== null) barSpacing = Math.abs(startCoord - nbCoord);
+          }
+        }
+
+        // Clock-snap mode (TradingView convention): band left edge
+        // sits at `coord(first session bar)` itself — i.e. the
+        // session-start clock tick — rather than half-a-bar earlier.
+        // Band right edge sits one full bucket past `coord(last
+        // session bar)`, which is the session-end clock tick. This
+        // means the first/last candle body straddles the band edge,
+        // which is what TradingView/Robinhood do because the band's
+        // job is to mark THE CLOCK WINDOW, not the candle extent.
+        const left = Math.min(startCoord, endCoord);
+        const right = Math.max(startCoord, endCoord) + barSpacing;
+        next.push({ kind: run.kind, left, width: Math.max(0, right - left) });
+      }
+      setBands(next);
+    };
+
+    // attach() runs once the chart ref is populated AND lightweight-
+    // charts has laid out its time scale enough that
+    // timeToCoordinate() returns real pixels. Because the parent's
+    // createChart() effect runs AFTER this child effect on mount,
+    // the chart ref starts null. Poll via RAF until present.
+    const attach = (): void => {
+      if (cancelled) return;
+      const chart = chartRef.current;
+      if (chart === null) {
+        rafReady = requestAnimationFrame(attach);
+        return;
+      }
+      const ts = chart.timeScale();
+      attachedTs = ts;
+      ts.subscribeVisibleLogicalRangeChange(recompute);
+
+      try {
+        const el = chart.chartElement();
+        if (el !== null) {
+          ro = new ResizeObserver(recompute);
+          ro.observe(el);
+        }
+      } catch {
+        // chart torn down between createChart and observe — skip.
+      }
+
+      // First synchronous compute often races the chart's first
+      // layout pass — timeToCoordinate returns null for every bar.
+      // Schedule a follow-up frame so the time scale is in place
+      // before we recompute. The visibleLogicalRangeChange callback
+      // and ResizeObserver above provide independent triggers, but
+      // both can miss the first paint when fitContent is the only
+      // layout-changing call.
+      recompute();
+      rafFirstPaint = requestAnimationFrame(recompute);
+    };
+
+    attach();
+
+    return () => {
+      cancelled = true;
+      if (rafReady !== undefined) cancelAnimationFrame(rafReady);
+      if (rafFirstPaint !== undefined) cancelAnimationFrame(rafFirstPaint);
+      if (attachedTs !== null) {
+        try {
+          attachedTs.unsubscribeVisibleLogicalRangeChange(recompute);
+        } catch {
+          // chart already torn down — nothing to unsubscribe.
+        }
+      }
+      if (ro !== null) ro.disconnect();
+    };
+  }, [chartRef, bars, enabled]);
+
+  if (!enabled || bands.length === 0) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      data-testid="session-bands"
+      // z-[5] sits above the chart canvas (which has no stacking
+      // context of its own) and below the tooltip + live indicator
+      // (z-10). z-0 was tried first but created a sibling stacking
+      // context that made the bands invisible against the chart's
+      // white fill in some browsers.
+      className="pointer-events-none absolute z-[5] overflow-hidden"
+      style={{ left: 0, top: 0, right: inset.right, bottom: inset.bottom }}
+    >
+      {bands.map((b, i) => (
+        <div
+          key={`${b.kind}-${i}-${b.left}`}
+          data-session={b.kind}
+          className="absolute bottom-0 top-0"
+          style={{ left: `${b.left}px`, width: `${b.width}px`, background: TINT[b.kind] ?? "" }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/lib/chartData.test.ts
+++ b/frontend/src/lib/chartData.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the chart-data gap filler.
+ */
+import { describe, expect, it } from "vitest";
+
+import { fillIntrasessionGaps, type NormalisedBar } from "@/lib/chartData";
+
+const T0 = Math.floor(Date.UTC(2026, 3, 27, 14, 30) / 1000); // 14:30 UTC
+
+function bar(time: number, close: string): NormalisedBar {
+  return { time, open: close, high: close, low: close, close, volume: "100" };
+}
+
+describe("fillIntrasessionGaps", () => {
+  it("returns input unchanged when fewer than 2 bars", () => {
+    expect(fillIntrasessionGaps([], 60, 7200)).toEqual([]);
+    const single: NormalisedBar[] = [bar(T0, "10")];
+    expect(fillIntrasessionGaps(single, 60, 7200)).toEqual(single);
+  });
+
+  it("does NOT fill when bars are contiguous", () => {
+    const bars: NormalisedBar[] = [
+      bar(T0, "10"),
+      bar(T0 + 60, "11"),
+      bar(T0 + 120, "12"),
+    ];
+    expect(fillIntrasessionGaps(bars, 60, 7200)).toEqual(bars);
+  });
+
+  it("fills a 5-minute gap with carry-forward synthetic bars", () => {
+    const bars: NormalisedBar[] = [
+      bar(T0, "10"),
+      bar(T0 + 360, "12"), // 6 minute gap → 5 missing minutes
+    ];
+    const filled = fillIntrasessionGaps(bars, 60, 7200);
+    expect(filled).toHaveLength(7); // 2 originals + 5 synthetic
+    // First original kept
+    expect(filled[0]).toEqual(bars[0]);
+    // 5 synthetic bars carrying close=10
+    for (let i = 1; i <= 5; i++) {
+      expect(filled[i]).toEqual({
+        time: T0 + i * 60,
+        open: "10",
+        high: "10",
+        low: "10",
+        close: "10",
+        volume: "0",
+      });
+    }
+    // Real bar at end
+    expect(filled[6]).toEqual(bars[1]);
+  });
+
+  it("does NOT fill gaps wider than maxGapSeconds (overnight closure)", () => {
+    const bars: NormalisedBar[] = [
+      bar(T0, "10"),
+      bar(T0 + 12 * 60 * 60, "12"), // 12-hour gap, exceeds 2h cap
+    ];
+    const filled = fillIntrasessionGaps(bars, 60, 2 * 60 * 60);
+    // No synthetic fill — both originals preserved as-is.
+    expect(filled).toEqual(bars);
+  });
+
+  it("fills the boundary case at exactly maxGapSeconds", () => {
+    const bars: NormalisedBar[] = [
+      bar(T0, "10"),
+      bar(T0 + 7200, "11"), // exactly 2h gap
+    ];
+    const filled = fillIntrasessionGaps(bars, 60, 7200);
+    // 2h / 60s = 120 minutes, minus the two originals = 119 synthetic
+    expect(filled).toHaveLength(121);
+    expect(filled[0]).toEqual(bars[0]);
+    expect(filled[120]).toEqual(bars[1]);
+  });
+
+  it("synthetic volume is always '0' regardless of original volume", () => {
+    const bars: NormalisedBar[] = [
+      { time: T0, open: "10", high: "10", low: "10", close: "10", volume: "999999" },
+      { time: T0 + 180, open: "11", high: "11", low: "11", close: "11", volume: "111" },
+    ];
+    const filled = fillIntrasessionGaps(bars, 60, 7200);
+    expect(filled[1]?.volume).toBe("0");
+    expect(filled[2]?.volume).toBe("0");
+  });
+
+  it("works for daily range (86400s bucket)", () => {
+    const day = 86400;
+    const monday = Math.floor(Date.UTC(2026, 3, 27) / 1000);
+    const wednesday = monday + 2 * day;
+    const bars: NormalisedBar[] = [bar(monday, "100"), bar(wednesday, "102")];
+    const filled = fillIntrasessionGaps(bars, day, 7 * day);
+    // Tuesday filled
+    expect(filled).toHaveLength(3);
+    expect(filled[1]?.time).toBe(monday + day);
+    expect(filled[1]?.close).toBe("100");
+  });
+});

--- a/frontend/src/lib/chartData.ts
+++ b/frontend/src/lib/chartData.ts
@@ -159,10 +159,66 @@ function isoToEpochSeconds(iso: string): number | null {
 }
 
 /**
+ * Fill gaps within a contiguous market session with carry-forward
+ * synthetic bars so the chart renders continuously even when the
+ * upstream feed (eToro) skips minutes during illiquid AH/PM
+ * windows. Industry-standard pattern — TradingView/Robinhood do
+ * the same when the broker feed has sparse coverage.
+ *
+ * Heuristics:
+ *   * Only fills gaps shorter than `maxGapSeconds` (default = 2h
+ *     for intraday, 7d for daily). Longer gaps = market closed /
+ *     weekend / holiday, leave intact.
+ *   * Synthetic bars carry the prior close as O = H = L = C and
+ *     `volume = "0"`. The chart's volume series renders these as
+ *     zero-height bars so the operator sees the no-liquidity
+ *     marker visually.
+ *
+ * Pure function — bars in, bars out, no I/O.
+ */
+export function fillIntrasessionGaps(
+  bars: ReadonlyArray<NormalisedBar>,
+  bucketSeconds: number,
+  maxGapSeconds: number,
+): NormalisedBar[] {
+  if (bars.length < 2) return bars.slice();
+  const out: NormalisedBar[] = [bars[0]!];
+  for (let i = 1; i < bars.length; i++) {
+    const prev = bars[i - 1]!;
+    const curr = bars[i]!;
+    const gap = curr.time - prev.time;
+    // Inter-bar gap of one bucket is the normal contiguous case.
+    // Anything bigger is a missed-bar window we may want to fill.
+    if (gap > bucketSeconds && gap <= maxGapSeconds) {
+      const carry = prev.close;
+      for (let t = prev.time + bucketSeconds; t < curr.time; t += bucketSeconds) {
+        out.push({
+          time: t,
+          open: carry,
+          high: carry,
+          low: carry,
+          close: carry,
+          volume: "0",
+        });
+      }
+    }
+    out.push(curr);
+  }
+  return out;
+}
+
+/**
  * Resolve a chart range to bars, dispatched to the correct endpoint.
  * Returns `null` for any row whose timestamp can't be parsed; the
  * chart's existing valid-row gate filters those out.
  */
+// Max gap to backfill, by endpoint. Anything bigger is treated as
+// "market closed" and left as a visual gap.
+//   * Intraday: 2 hours covers post-RTH AH lulls + lunch lulls
+//   * Daily: 7 days covers weekends + long weekends
+const _INTRADAY_MAX_GAP_S = 2 * 60 * 60;
+const _DAILY_MAX_GAP_S = 7 * 24 * 60 * 60;
+
 export async function fetchChartCandles(
   symbol: string,
   range: ChartRange,
@@ -170,33 +226,8 @@ export async function fetchChartCandles(
   const plan = CHART_RANGE_PLAN[range];
   if (plan.kind === "intraday") {
     const res = await fetchInstrumentIntradayCandles(symbol, plan.interval, plan.count);
-    return {
-      symbol: res.symbol,
-      range,
-      kind: "intraday",
-      rows: res.rows.flatMap((b) => {
-        const time = isoToEpochSeconds(b.timestamp);
-        if (time === null) return [];
-        return [
-          {
-            time,
-            open: b.open,
-            high: b.high,
-            low: b.low,
-            close: b.close,
-            volume: b.volume === null ? null : String(b.volume),
-          },
-        ];
-      }),
-    };
-  }
-  const res = await fetchInstrumentCandles(symbol, plan.range);
-  return {
-    symbol: res.symbol,
-    range,
-    kind: "daily",
-    rows: res.rows.flatMap((b) => {
-      const time = dateToEpochSeconds(b.date);
+    const raw = res.rows.flatMap((b) => {
+      const time = isoToEpochSeconds(b.timestamp);
       if (time === null) return [];
       return [
         {
@@ -205,9 +236,37 @@ export async function fetchChartCandles(
           high: b.high,
           low: b.low,
           close: b.close,
-          volume: b.volume,
+          volume: b.volume === null ? null : String(b.volume),
         },
       ];
-    }),
+    });
+    const bucketSeconds = INTERVAL_SECONDS[plan.interval] ?? 60;
+    return {
+      symbol: res.symbol,
+      range,
+      kind: "intraday",
+      rows: fillIntrasessionGaps(raw, bucketSeconds, _INTRADAY_MAX_GAP_S),
+    };
+  }
+  const res = await fetchInstrumentCandles(symbol, plan.range);
+  const raw = res.rows.flatMap((b) => {
+    const time = dateToEpochSeconds(b.date);
+    if (time === null) return [];
+    return [
+      {
+        time,
+        open: b.open,
+        high: b.high,
+        low: b.low,
+        close: b.close,
+        volume: b.volume,
+      },
+    ];
+  });
+  return {
+    symbol: res.symbol,
+    range,
+    kind: "daily",
+    rows: fillIntrasessionGaps(raw, 86400, _DAILY_MAX_GAP_S),
   };
 }

--- a/frontend/src/lib/chartData.ts
+++ b/frontend/src/lib/chartData.ts
@@ -212,12 +212,13 @@ export function fillIntrasessionGaps(
  * Returns `null` for any row whose timestamp can't be parsed; the
  * chart's existing valid-row gate filters those out.
  */
-// Max gap to backfill, by endpoint. Anything bigger is treated as
-// "market closed" and left as a visual gap.
-//   * Intraday: 2 hours covers post-RTH AH lulls + lunch lulls
-//   * Daily: 7 days covers weekends + long weekends
-const _INTRADAY_MAX_GAP_S = 2 * 60 * 60;
-const _DAILY_MAX_GAP_S = 7 * 24 * 60 * 60;
+// Note: gap-fill was previously applied here; reverted because
+// lightweight-charts is ordinal by default — bars at equal x-axis
+// spacing regardless of real-time gap. TradingView does the same.
+// Filling sparse AH bars with carry-forward synthetic candles
+// produced a long flat line in the rendered chart that didn't
+// match the gold-standard look. `fillIntrasessionGaps` is kept
+// exported in case a future caller wants opt-in.
 
 export async function fetchChartCandles(
   symbol: string,
@@ -226,8 +227,33 @@ export async function fetchChartCandles(
   const plan = CHART_RANGE_PLAN[range];
   if (plan.kind === "intraday") {
     const res = await fetchInstrumentIntradayCandles(symbol, plan.interval, plan.count);
-    const raw = res.rows.flatMap((b) => {
-      const time = isoToEpochSeconds(b.timestamp);
+    return {
+      symbol: res.symbol,
+      range,
+      kind: "intraday",
+      rows: res.rows.flatMap((b) => {
+        const time = isoToEpochSeconds(b.timestamp);
+        if (time === null) return [];
+        return [
+          {
+            time,
+            open: b.open,
+            high: b.high,
+            low: b.low,
+            close: b.close,
+            volume: b.volume === null ? null : String(b.volume),
+          },
+        ];
+      }),
+    };
+  }
+  const res = await fetchInstrumentCandles(symbol, plan.range);
+  return {
+    symbol: res.symbol,
+    range,
+    kind: "daily",
+    rows: res.rows.flatMap((b) => {
+      const time = dateToEpochSeconds(b.date);
       if (time === null) return [];
       return [
         {
@@ -236,37 +262,9 @@ export async function fetchChartCandles(
           high: b.high,
           low: b.low,
           close: b.close,
-          volume: b.volume === null ? null : String(b.volume),
+          volume: b.volume,
         },
       ];
-    });
-    const bucketSeconds = INTERVAL_SECONDS[plan.interval] ?? 60;
-    return {
-      symbol: res.symbol,
-      range,
-      kind: "intraday",
-      rows: fillIntrasessionGaps(raw, bucketSeconds, _INTRADAY_MAX_GAP_S),
-    };
-  }
-  const res = await fetchInstrumentCandles(symbol, plan.range);
-  const raw = res.rows.flatMap((b) => {
-    const time = dateToEpochSeconds(b.date);
-    if (time === null) return [];
-    return [
-      {
-        time,
-        open: b.open,
-        high: b.high,
-        low: b.low,
-        close: b.close,
-        volume: b.volume,
-      },
-    ];
-  });
-  return {
-    symbol: res.symbol,
-    range,
-    kind: "daily",
-    rows: fillIntrasessionGaps(raw, 86400, _DAILY_MAX_GAP_S),
+    }),
   };
 }

--- a/frontend/src/lib/chartFormatters.test.ts
+++ b/frontend/src/lib/chartFormatters.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyUsSession } from "./chartFormatters";
+
+/**
+ * Lock down US-equity session classification across the four windows
+ * NYSE/NASDAQ define in ET wall-clock, including the DST transition
+ * the implementation depends on (Intl with `America/New_York` is
+ * authoritative for both EDT and EST). All inputs are constructed
+ * from UTC epochs so the test is timezone-independent — what the
+ * developer's machine clock says cannot affect the result.
+ *
+ * Quick reference (April 2026 = EDT, UTC-4):
+ *   PM:     04:00–09:30 ET = 08:00–13:30 UTC
+ *   RTH:    09:30–16:00 ET = 13:30–20:00 UTC
+ *   AH:     16:00–20:00 ET = 20:00–24:00 UTC (rolls into next UTC day)
+ *   closed: 20:00–04:00 ET = 24:00–08:00 UTC (next day)
+ *   weekend (Sat/Sun in ET) = closed regardless of clock
+ */
+function utc(y: number, m: number, d: number, hh: number, mm: number = 0): number {
+  return Math.floor(Date.UTC(y, m - 1, d, hh, mm) / 1000);
+}
+
+describe("classifyUsSession (April 2026 EDT)", () => {
+  it("classifies pre-market start (04:00 ET)", () => {
+    expect(classifyUsSession(utc(2026, 4, 21, 8, 0))).toBe("pre");
+  });
+  it("classifies last pre-market minute (09:29 ET)", () => {
+    expect(classifyUsSession(utc(2026, 4, 21, 13, 29))).toBe("pre");
+  });
+  it("classifies RTH open (09:30 ET)", () => {
+    expect(classifyUsSession(utc(2026, 4, 21, 13, 30))).toBe("rth");
+  });
+  it("classifies mid-RTH (12:00 ET)", () => {
+    expect(classifyUsSession(utc(2026, 4, 21, 16, 0))).toBe("rth");
+  });
+  it("classifies last RTH minute (15:59 ET)", () => {
+    expect(classifyUsSession(utc(2026, 4, 21, 19, 59))).toBe("rth");
+  });
+  it("classifies AH open (16:00 ET)", () => {
+    expect(classifyUsSession(utc(2026, 4, 21, 20, 0))).toBe("ah");
+  });
+  it("classifies mid-AH (18:00 ET)", () => {
+    expect(classifyUsSession(utc(2026, 4, 21, 22, 0))).toBe("ah");
+  });
+  it("classifies last AH minute (19:59 ET)", () => {
+    expect(classifyUsSession(utc(2026, 4, 21, 23, 59))).toBe("ah");
+  });
+  it("classifies AH end / closed start (20:00 ET)", () => {
+    // 20:00 EDT = 00:00 UTC next day.
+    expect(classifyUsSession(utc(2026, 4, 22, 0, 0))).toBe("closed");
+  });
+  it("classifies overnight (02:00 ET)", () => {
+    // 02:00 EDT Tue = 06:00 UTC Tue.
+    expect(classifyUsSession(utc(2026, 4, 21, 6, 0))).toBe("closed");
+  });
+  it("classifies just-before-PM (03:59 ET)", () => {
+    expect(classifyUsSession(utc(2026, 4, 21, 7, 59))).toBe("closed");
+  });
+
+  it("classifies Saturday all-day as closed", () => {
+    // Apr 25 2026 is a Saturday. Every hour → closed.
+    for (const hh of [4, 9, 12, 16, 22]) {
+      expect(classifyUsSession(utc(2026, 4, 25, hh + 4, 0))).toBe("closed");
+    }
+  });
+  it("classifies Sunday all-day as closed", () => {
+    // Apr 26 2026 is a Sunday.
+    for (const hh of [4, 9, 12, 16, 22]) {
+      expect(classifyUsSession(utc(2026, 4, 26, hh + 4, 0))).toBe("closed");
+    }
+  });
+});
+
+describe("classifyUsSession (DST handling)", () => {
+  it("classifies a January day as EST (UTC-5): 09:30 ET = 14:30 UTC", () => {
+    // Jan 5 2026 — Monday, EST.
+    expect(classifyUsSession(utc(2026, 1, 5, 14, 30))).toBe("rth");
+    expect(classifyUsSession(utc(2026, 1, 5, 14, 29))).toBe("pre");
+  });
+  it("classifies a July day as EDT (UTC-4): 09:30 ET = 13:30 UTC", () => {
+    // Jul 6 2026 — Monday, EDT.
+    expect(classifyUsSession(utc(2026, 7, 6, 13, 30))).toBe("rth");
+    expect(classifyUsSession(utc(2026, 7, 6, 13, 29))).toBe("pre");
+  });
+});

--- a/frontend/src/lib/chartFormatters.test.ts
+++ b/frontend/src/lib/chartFormatters.test.ts
@@ -54,6 +54,14 @@ describe("classifyUsSession (April 2026 EDT)", () => {
     // 02:00 EDT Tue = 06:00 UTC Tue.
     expect(classifyUsSession(utc(2026, 4, 21, 6, 0))).toBe("closed");
   });
+  it("classifies exactly midnight ET (00:00) as closed", () => {
+    // 00:00 EDT Tue Apr 21 = 04:00 UTC Tue Apr 21. Boundary case
+    // because some Intl runtimes emit hour="24" for midnight; the
+    // `% 24` normalisation in `_nyParts` must collapse that to 0
+    // so this lands in the closed window, not an unmatched branch.
+    // PR #610 review WARNING.
+    expect(classifyUsSession(utc(2026, 4, 21, 4, 0))).toBe("closed");
+  });
   it("classifies just-before-PM (03:59 ET)", () => {
     expect(classifyUsSession(utc(2026, 4, 21, 7, 59))).toBe("closed");
   });

--- a/frontend/src/lib/chartFormatters.ts
+++ b/frontend/src/lib/chartFormatters.ts
@@ -27,6 +27,59 @@ const _MONTH_ABBR = [
   "Dec",
 ] as const;
 
+/**
+ * US equity session classification for an epoch-second timestamp.
+ * NYSE/NASDAQ standard hours in ET:
+ *   pre-market: 04:00–09:30
+ *   RTH:        09:30–16:00
+ *   after-hours: 16:00–20:00
+ *   closed:     20:00–04:00 (overnight + weekends)
+ *
+ * Computed from the UTC time + the instrument's exchange offset.
+ * Uses ET (UTC-5/UTC-4) by default — both EST and EDT collapse to
+ * the same wall-clock RTH start in ET so deriving from UTC requires
+ * we know whether DST is active for that instant. We use
+ * `Date#toLocaleString` with timezone "America/New_York" which
+ * handles the DST transition automatically; cheaper than
+ * hand-rolling DST rules.
+ *
+ * Saturday/Sunday always classify as `closed` regardless of clock.
+ */
+export type SessionKind = "pre" | "rth" | "ah" | "closed";
+
+const _NY_TZ = "America/New_York";
+
+function _nyParts(epochSeconds: number): { day: number; hh: number; mm: number } {
+  const d = new Date(epochSeconds * 1000);
+  // Intl.DateTimeFormat parts in NY tz.
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: _NY_TZ,
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(d);
+  const w = parts.find((p) => p.type === "weekday")?.value ?? "";
+  const hh = Number(parts.find((p) => p.type === "hour")?.value ?? "0");
+  const mm = Number(parts.find((p) => p.type === "minute")?.value ?? "0");
+  // Map weekday string to 0=Sun..6=Sat (Intl emits Sun/Mon/Tue/Wed/Thu/Fri/Sat).
+  const dayMap: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  const day = dayMap[w] ?? 0;
+  return { day, hh: hh % 24, mm };
+}
+
+export function classifyUsSession(epochSeconds: number): SessionKind {
+  const { day, hh, mm } = _nyParts(epochSeconds);
+  if (day === 0 || day === 6) return "closed";
+  const minutes = hh * 60 + mm;
+  if (minutes >= 4 * 60 && minutes < 9 * 60 + 30) return "pre";
+  if (minutes >= 9 * 60 + 30 && minutes < 16 * 60) return "rth";
+  if (minutes >= 16 * 60 && minutes < 20 * 60) return "ah";
+  return "closed";
+}
+
+
 function _padDateLocal(d: Date): string {
   // Browser-local YYYY-MM-DD. ISO `toISOString()` would force UTC.
   const y = d.getFullYear();

--- a/frontend/src/lib/chartFormatters.ts
+++ b/frontend/src/lib/chartFormatters.ts
@@ -27,19 +27,32 @@ const _MONTH_ABBR = [
   "Dec",
 ] as const;
 
+function _padDateLocal(d: Date): string {
+  // Browser-local YYYY-MM-DD. ISO `toISOString()` would force UTC.
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
 /**
- * Hover label.
- *   - Daily/weekly/monthly: `YYYY-MM-DD`
- *   - Intraday: `YYYY-MM-DD HH:MMZ` so the operator sees the full
- *     timestamp and the trailing `Z` makes it obvious the time is UTC.
+ * Hover label rendered in the **browser's local timezone** so a UK
+ * operator on BST sees `21:30` for a 20:30 UTC bar — matching the
+ * convention TradingView and Robinhood use when the user is in a
+ * different zone from the exchange. The chart's epoch-second time
+ * value is universal; only the rendered label localises.
+ *
+ *   - Daily/weekly/monthly: `YYYY-MM-DD` (local date)
+ *   - Intraday: `YYYY-MM-DD HH:MM` (local time, no zone suffix —
+ *     the chart's controls/range carry the calendar context).
  */
 export function formatHoverLabel(epochSeconds: number, intraday: boolean): string {
   const d = new Date(epochSeconds * 1000);
-  const date = d.toISOString().slice(0, 10);
+  const date = _padDateLocal(d);
   if (!intraday) return date;
-  const hh = String(d.getUTCHours()).padStart(2, "0");
-  const mm = String(d.getUTCMinutes()).padStart(2, "0");
-  return `${date} ${hh}:${mm}Z`;
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${date} ${hh}:${mm}`;
 }
 
 /**
@@ -51,21 +64,25 @@ export function formatHoverLabel(epochSeconds: number, intraday: boolean): strin
  * year. Single formatter handles both daily and intraday modes
  * because the library only emits the higher-resolution discriminators
  * when the chart is actually intraday.
+ *
+ * **Local timezone**: getters use the browser's local zone (e.g. BST
+ * for a UK operator). The chart's underlying time values are still
+ * UTC epoch seconds; only the displayed labels localise.
  */
 export function tickFormatter(time: number, tickMarkType: number): string {
   const d = new Date(time * 1000);
   switch (tickMarkType) {
     case 0:
-      return String(d.getUTCFullYear());
+      return String(d.getFullYear());
     case 1:
-      return _MONTH_ABBR[d.getUTCMonth()] ?? "";
+      return _MONTH_ABBR[d.getMonth()] ?? "";
     case 2:
-      return `${_MONTH_ABBR[d.getUTCMonth()]} ${d.getUTCDate()}`;
+      return `${_MONTH_ABBR[d.getMonth()]} ${d.getDate()}`;
     case 3:
     case 4:
     default: {
-      const hh = String(d.getUTCHours()).padStart(2, "0");
-      const mm = String(d.getUTCMinutes()).padStart(2, "0");
+      const hh = String(d.getHours()).padStart(2, "0");
+      const mm = String(d.getMinutes()).padStart(2, "0");
       return `${hh}:${mm}`;
     }
   }

--- a/frontend/src/lib/useLiveLastBar.test.ts
+++ b/frontend/src/lib/useLiveLastBar.test.ts
@@ -8,9 +8,23 @@
  * boundary appends a new bar with O=H=L=C=tick, and a stale tick
  * before the historical anchor is dropped.
  */
-import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { createRef, type MutableRefObject } from "react";
+import type { ISeriesApi } from "lightweight-charts";
+import { describe, expect, it, vi } from "vitest";
 
-import { aggregateTick } from "@/lib/useLiveLastBar";
+import { aggregateTick, useLiveLastBar } from "@/lib/useLiveLastBar";
+import type { LiveTickPayload } from "@/lib/useLiveQuote";
+
+// Mock the LiveQuoteProvider hooks so the hook-under-test runs in
+// jsdom without the SSE EventSource. `useLiveTick` returns whatever
+// the test pushes via the mutable ref; `useLiveQuoteConnection`
+// reports a healthy stream.
+const mockTickRef: { current: LiveTickPayload | null } = { current: null };
+vi.mock("@/components/quotes/LiveQuoteProvider", () => ({
+  useLiveTick: () => mockTickRef.current,
+  useLiveQuoteConnection: () => ({ connected: true, unavailable: false }),
+}));
 
 const T_BAR_OPEN = Math.floor(Date.UTC(2026, 3, 27, 14, 30) / 1000); // 14:30
 const T_INSIDE = T_BAR_OPEN + 30; // 14:30:30
@@ -132,6 +146,98 @@ describe("aggregateTick — bucket boundary", () => {
       tickPrice: 100,
     });
     expect(result.verdict).toBe("append");
+  });
+});
+
+describe("useLiveLastBar — session-filter dedupe (PR #610 round 3)", () => {
+  // 04:00 ET = 08:00 UTC during EDT — first minute of pre-market.
+  const PM_TICK_AT = "2026-04-28T08:00:00Z";
+
+  function makePmTick(quotedAt: string = PM_TICK_AT): LiveTickPayload {
+    return {
+      instrument_id: 1699,
+      native_currency: "USD",
+      bid: "25.00",
+      ask: "25.05",
+      last: "25.00",
+      quoted_at: quotedAt,
+      display: null,
+    };
+  }
+
+  function makeRefs(): {
+    candle: MutableRefObject<ISeriesApi<"Candlestick"> | null>;
+    line: null;
+    area: null;
+    update: ReturnType<typeof vi.fn>;
+  } {
+    const update = vi.fn();
+    const candle = createRef<ISeriesApi<"Candlestick"> | null>() as MutableRefObject<
+      ISeriesApi<"Candlestick"> | null
+    >;
+    candle.current = { update } as unknown as ISeriesApi<"Candlestick">;
+    return { candle, line: null, area: null, update };
+  }
+
+  it("rejects PM tick when acceptPre=false AND does not retroactively apply when acceptPre flips to true", () => {
+    mockTickRef.current = makePmTick();
+    const refs = makeRefs();
+
+    const { result, rerender } = renderHook(
+      ({ acceptPre }: { acceptPre: boolean }) =>
+        useLiveLastBar({
+          instrumentId: 1699,
+          bucketSeconds: 60,
+          historicalLastBar: null,
+          refs,
+          acceptPre,
+          acceptAh: true,
+        }),
+      { initialProps: { acceptPre: false } },
+    );
+
+    // First render: filter is OFF, tick should be dropped + dedupe key
+    // recorded so a future flip can't replay it.
+    expect(result.current.appliedTicks).toBe(0);
+    expect(refs.update).not.toHaveBeenCalled();
+
+    // Flip filter ON, same tick still in-flight (no new tick arrived).
+    act(() => {
+      rerender({ acceptPre: true });
+    });
+
+    // Stale tick must NOT be retroactively applied — dedupe key was
+    // recorded on the rejected first pass.
+    expect(result.current.appliedTicks).toBe(0);
+    expect(refs.update).not.toHaveBeenCalled();
+  });
+
+  it("accepts a NEW PM tick after filter flips ON", () => {
+    mockTickRef.current = makePmTick();
+    const refs = makeRefs();
+
+    const { rerender, result } = renderHook(
+      ({ acceptPre }: { acceptPre: boolean }) =>
+        useLiveLastBar({
+          instrumentId: 1699,
+          bucketSeconds: 60,
+          historicalLastBar: null,
+          refs,
+          acceptPre,
+          acceptAh: true,
+        }),
+      { initialProps: { acceptPre: false } },
+    );
+    expect(result.current.appliedTicks).toBe(0);
+
+    // Now a fresh tick arrives at a later quoted_at AFTER filter flips.
+    act(() => {
+      mockTickRef.current = makePmTick("2026-04-28T08:01:00Z");
+      rerender({ acceptPre: true });
+    });
+
+    expect(result.current.appliedTicks).toBe(1);
+    expect(refs.update).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/lib/useLiveLastBar.ts
+++ b/frontend/src/lib/useLiveLastBar.ts
@@ -38,6 +38,7 @@ import type { ISeriesApi, Time, UTCTimestamp } from "lightweight-charts";
 
 import { useLiveTick, useLiveQuoteConnection } from "@/components/quotes/LiveQuoteProvider";
 import { floorToBucket } from "@/lib/chartData";
+import { classifyUsSession } from "@/lib/chartFormatters";
 import type { LiveTickPayload } from "@/lib/useLiveQuote";
 
 interface LiveBarState {
@@ -165,6 +166,14 @@ export interface UseLiveLastBarParams {
    *  live tick of the in-progress bar. */
   historicalLastBar: HistoricalLastBar | null;
   refs: LiveLastBarRefs;
+  /** Drop pre-market ticks before they reach the aggregator. Defaults
+   *  true (no filtering). When false, an arriving 04:00–09:30 ET tick
+   *  is silently dropped — pairs with the chart-level PM/AH visibility
+   *  toggles so a hidden session never gets a fresh bar appended. */
+  acceptPre?: boolean;
+  /** Drop after-hours ticks (16:00–20:00 ET). Same contract as
+   *  `acceptPre`. */
+  acceptAh?: boolean;
 }
 
 export interface UseLiveLastBarResult {
@@ -202,10 +211,19 @@ export function useLiveLastBar({
   bucketSeconds,
   historicalLastBar,
   refs,
+  acceptPre = true,
+  acceptAh = true,
 }: UseLiveLastBarParams): UseLiveLastBarResult {
   const tick = useLiveTick(instrumentId);
   const { connected, unavailable } = useLiveQuoteConnection();
   const liveBarRef = useRef<LiveBarState | null>(null);
+  // Dedupe key so toggling effect deps (`acceptPre`/`acceptAh`,
+  // `bucketSeconds`, `historicalLastBar`) doesn't re-apply the SAME
+  // tick we already processed. The effect is keyed on `tick` (and
+  // those props) — without this guard, the latest tick replays on
+  // every prop change, inflating `appliedTicks` and issuing redundant
+  // `series.update()` calls (Codex review #602).
+  const lastAppliedKeyRef = useRef<string | null>(null);
   const [appliedTicks, setAppliedTicks] = useState(0);
   const [lastAppliedAt, setLastAppliedAt] = useState<string | null>(null);
   const [lastVerdict, setLastVerdict] = useState<
@@ -219,6 +237,7 @@ export function useLiveLastBar({
   // could update the wrong bar's H/L/C.
   useEffect(() => {
     liveBarRef.current = null;
+    lastAppliedKeyRef.current = null;
     setAppliedTicks(0);
     setLastAppliedAt(null);
     setLastVerdict(null);
@@ -227,10 +246,21 @@ export function useLiveLastBar({
   useEffect(() => {
     if (tick === null) return;
     if (tick.instrument_id !== instrumentId) return;
+    // Dedupe by quoted_at — re-running the effect on prop change
+    // (e.g. toggling acceptPre/acceptAh) must not replay the last tick.
+    const dedupeKey = `${tick.instrument_id}:${tick.quoted_at}`;
+    if (lastAppliedKeyRef.current === dedupeKey) return;
     const price = tickPriceFor(tick);
     if (price === null) return;
     const tickEpoch = Math.floor(new Date(tick.quoted_at).getTime() / 1000);
     if (!Number.isFinite(tickEpoch)) return;
+
+    // Session-visibility gate (pairs with PriceChart's PM/AH toggles).
+    // Drop ticks whose session is hidden — without this a fresh bar
+    // would be appended into a session the operator chose to hide.
+    const tickSession = classifyUsSession(tickEpoch);
+    if (tickSession === "pre" && !acceptPre) return;
+    if (tickSession === "ah" && !acceptAh) return;
 
     const result = aggregateTick({
       prev: liveBarRef.current,
@@ -243,6 +273,7 @@ export function useLiveLastBar({
     if (result.verdict === "skip") return;
 
     liveBarRef.current = result.next;
+    lastAppliedKeyRef.current = dedupeKey;
     setAppliedTicks((n) => n + 1);
     setLastAppliedAt(tick.quoted_at);
 
@@ -267,10 +298,10 @@ export function useLiveLastBar({
     }
     // ESLint: refs.* are MutableRefObjects with stable identity, so
     // omitting them from deps is correct. The effect must re-fire only
-    // on tick / anchor / bucket / instrument changes — adding `refs`
-    // would re-fire on every parent render.
+    // on tick / anchor / bucket / instrument / session-visibility
+    // changes — adding `refs` would re-fire on every parent render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tick, bucketSeconds, historicalLastBar, instrumentId]);
+  }, [tick, bucketSeconds, historicalLastBar, instrumentId, acceptPre, acceptAh]);
 
   return { connected, unavailable, appliedTicks, lastAppliedAt, lastVerdict };
 }

--- a/frontend/src/lib/useLiveLastBar.ts
+++ b/frontend/src/lib/useLiveLastBar.ts
@@ -258,9 +258,22 @@ export function useLiveLastBar({
     // Session-visibility gate (pairs with PriceChart's PM/AH toggles).
     // Drop ticks whose session is hidden — without this a fresh bar
     // would be appended into a session the operator chose to hide.
+    //
+    // IMPORTANT: record the dedupe key BEFORE the early return so a
+    // subsequent toggle of `acceptPre`/`acceptAh` from false→true
+    // doesn't retroactively apply the stale tick when the effect
+    // re-fires. The filter is "going-forward" — a tick that was
+    // rejected stays rejected even if the user later opens that
+    // session. PR #610 round 3 review WARNING.
     const tickSession = classifyUsSession(tickEpoch);
-    if (tickSession === "pre" && !acceptPre) return;
-    if (tickSession === "ah" && !acceptAh) return;
+    if (tickSession === "pre" && !acceptPre) {
+      lastAppliedKeyRef.current = dedupeKey;
+      return;
+    }
+    if (tickSession === "ah" && !acceptAh) {
+      lastAppliedKeyRef.current = dedupeKey;
+      return;
+    }
 
     const result = aggregateTick({
       prev: liveBarRef.current,

--- a/frontend/src/lib/useLiveLastBar.ts
+++ b/frontend/src/lib/useLiveLastBar.ts
@@ -33,7 +33,7 @@
  * eToro's quote stream doesn't expose; deferred to V2.
  */
 
-import { useEffect, useRef, type MutableRefObject } from "react";
+import { useEffect, useRef, useState, type MutableRefObject } from "react";
 import type { ISeriesApi, Time, UTCTimestamp } from "lightweight-charts";
 
 import { useLiveTick, useLiveQuoteConnection } from "@/components/quotes/LiveQuoteProvider";
@@ -173,6 +173,15 @@ export interface UseLiveLastBarResult {
   /** True if the SSE stream errored irrecoverably — the chart should
    *  not show a "LIVE" indicator. */
   unavailable: boolean;
+  /** Diagnostics: count of ticks the aggregator has actually applied
+   *  to the chart (post-skip, post-filter). Surfaces stuck-stream
+   *  bugs to the operator without needing devtools. */
+  appliedTicks: number;
+  /** Diagnostics: ISO timestamp of the most recent applied tick. */
+  lastAppliedAt: string | null;
+  /** Diagnostics: latest verdict from `aggregateTick` — "update",
+   *  "append", "skip", or null when no tick has arrived. */
+  lastVerdict: "update" | "append" | "skip" | null;
 }
 
 /**
@@ -197,6 +206,11 @@ export function useLiveLastBar({
   const tick = useLiveTick(instrumentId);
   const { connected, unavailable } = useLiveQuoteConnection();
   const liveBarRef = useRef<LiveBarState | null>(null);
+  const [appliedTicks, setAppliedTicks] = useState(0);
+  const [lastAppliedAt, setLastAppliedAt] = useState<string | null>(null);
+  const [lastVerdict, setLastVerdict] = useState<
+    "update" | "append" | "skip" | null
+  >(null);
 
   const histAnchorTime = historicalLastBar !== null ? historicalLastBar.time : null;
 
@@ -205,6 +219,9 @@ export function useLiveLastBar({
   // could update the wrong bar's H/L/C.
   useEffect(() => {
     liveBarRef.current = null;
+    setAppliedTicks(0);
+    setLastAppliedAt(null);
+    setLastVerdict(null);
   }, [instrumentId, bucketSeconds, histAnchorTime]);
 
   useEffect(() => {
@@ -222,9 +239,12 @@ export function useLiveLastBar({
       tickEpochSeconds: tickEpoch,
       tickPrice: price,
     });
+    setLastVerdict(result.verdict);
     if (result.verdict === "skip") return;
 
     liveBarRef.current = result.next;
+    setAppliedTicks((n) => n + 1);
+    setLastAppliedAt(tick.quoted_at);
 
     const time = result.next.time as UTCTimestamp;
     const candleSeries = refs.candle.current;
@@ -252,7 +272,7 @@ export function useLiveLastBar({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tick, bucketSeconds, historicalLastBar, instrumentId]);
 
-  return { connected, unavailable };
+  return { connected, unavailable, appliedTicks, lastAppliedAt, lastVerdict };
 }
 
 // Renamed exports to keep tickPrice as a private helper.

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -259,13 +259,11 @@ export function ChartPage(): JSX.Element {
     [symbol, range],
   );
 
-  // Background poll fallback. SSE live-tick path covers smooth
-  // updates when eToro pushes; this guarantees the chart still
-  // freshens even when the WS goes silent. 15s for intraday,
-  // 60s for daily — backend cache + singleflight (#600) absorb
-  // the load.
+  // Coarser candle-window refetch as a backstop. SSE+REST live-rate
+  // polling on the backend (#602) keeps the in-progress bar fresh at
+  // 5s; this just picks up rare historical bar corrections.
   useEffect(() => {
-    const intervalMs = intraday ? 15_000 : 60_000;
+    const intervalMs = intraday ? 60_000 : 300_000;
     const id = setInterval(() => {
       candlesAsync.refetch();
     }, intervalMs);

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -212,6 +212,25 @@ export function ChartPage(): JSX.Element {
     [searchParams, setSearchParams, enabledTrends],
   );
 
+  // Session-visibility toggles. Default ON (omit param). Mirrors the
+  // PriceChart contract so URL params are consistent across the two
+  // surfaces.
+  const showPm = searchParams.get("pm") !== "0";
+  const showAh = searchParams.get("ah") !== "0";
+
+  const toggleSessionParam = useCallback(
+    (key: "pm" | "ah", currentlyOn: boolean) => {
+      const params = new URLSearchParams(searchParams);
+      if (currentlyOn) {
+        params.set(key, "0");
+      } else {
+        params.delete(key);
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
   // View param — "chart" (default) or "raw"
   const view = searchParams.get("view") === "raw" ? "raw" : "chart";
 
@@ -475,6 +494,36 @@ export function ChartPage(): JSX.Element {
             })}
           </div>
         )}
+
+        {/* Chart-only, intraday-only: session-visibility + previous-close
+            toggles. Mirrors PriceChart for cross-surface consistency. */}
+        {view === "chart" && intraday && (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[11px] uppercase tracking-wider text-slate-500">Session</span>
+            {(
+              [
+                { key: "pm", on: showPm, label: "PM", title: "Pre-market 04:00–09:30 ET" },
+                { key: "ah", on: showAh, label: "AH", title: "After-hours 16:00–20:00 ET" },
+              ] as const
+            ).map(({ key, on, label, title }) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => toggleSessionParam(key, on)}
+                aria-pressed={on}
+                title={title}
+                className={`rounded border px-2 py-0.5 text-xs font-medium ${
+                  on
+                    ? "border-slate-400 bg-white text-slate-700"
+                    : "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100"
+                }`}
+                data-testid={`session-toggle-${key}`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Chart-only: compare row. Hidden on intraday ranges — fanning
@@ -564,6 +613,8 @@ export function ChartPage(): JSX.Element {
             showRegression={enabledTrends.includes("regression")}
             showChannel={enabledTrends.includes("channel")}
             intraday={intraday}
+            showPm={showPm}
+            showAh={showAh}
             containerClassName="h-[70vh] w-full"
           />
         ) : null}

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -259,6 +259,19 @@ export function ChartPage(): JSX.Element {
     [symbol, range],
   );
 
+  // Background poll fallback. SSE live-tick path covers smooth
+  // updates when eToro pushes; this guarantees the chart still
+  // freshens even when the WS goes silent. 15s for intraday,
+  // 60s for daily — backend cache + singleflight (#600) absorb
+  // the load.
+  useEffect(() => {
+    const intervalMs = intraday ? 15_000 : 60_000;
+    const id = setInterval(() => {
+      candlesAsync.refetch();
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [intraday, candlesAsync.refetch]);
+
   // Compare candle fetches: parallel, keyed on [range, ...compareSymbols].
   // We use a single useEffect + useState<Map> to manage compare fetches.
   const [compareData, setCompareData] = useState<Map<string, NormalisedBar[]>>(new Map());

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -707,28 +707,39 @@ export function ChartWorkspaceCanvas({
   );
   const bucketSeconds = range !== undefined ? intervalSecondsFor(range) : 60;
   const liveTargetId = !compareMode && range !== undefined ? instrumentId : null;
-  const { connected, unavailable } = useLiveLastBar({
-    instrumentId: liveTargetId,
-    bucketSeconds,
-    historicalLastBar: histLastBar,
-    refs: {
-      candle: candleRef,
-      line: null, // workspace primaryLineRef is only used in compare mode
-      area: null,
-    },
-  });
+  const { connected, unavailable, appliedTicks, lastAppliedAt, lastVerdict } =
+    useLiveLastBar({
+      instrumentId: liveTargetId,
+      bucketSeconds,
+      historicalLastBar: histLastBar,
+      refs: {
+        candle: candleRef,
+        line: null, // workspace primaryLineRef is only used in compare mode
+        area: null,
+      },
+    });
   const liveActive = connected && !unavailable && liveTargetId !== null;
+  const lastTickHHMM = lastAppliedAt !== null ? new Date(lastAppliedAt).toISOString().slice(11, 16) : null;
 
   return (
     <div className="relative">
       {hover !== null ? <RichTooltip hover={hover} /> : null}
       {liveActive ? (
         <div
-          className="absolute right-2 top-2 z-10 flex items-center gap-1 text-[10px] uppercase tracking-wider text-emerald-600"
+          className="absolute right-2 top-2 z-10 flex items-center gap-1.5 text-[10px] tabular-nums tracking-wide text-emerald-600"
           data-testid="chart-workspace-live-indicator"
+          title={`SSE connected · ${appliedTicks} ticks applied · last verdict: ${lastVerdict ?? "(none yet)"}`}
         >
           <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" />
-          Live
+          <span className="uppercase">Live</span>
+          <span className="text-slate-400">·</span>
+          <span className="text-slate-500">{appliedTicks} ticks</span>
+          {lastTickHHMM !== null ? (
+            <>
+              <span className="text-slate-400">·</span>
+              <span className="text-slate-500">{lastTickHHMM}Z</span>
+            </>
+          ) : null}
         </div>
       ) : null}
       <div

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -719,7 +719,12 @@ export function ChartWorkspaceCanvas({
       },
     });
   const liveActive = connected && !unavailable && liveTargetId !== null;
-  const lastTickHHMM = lastAppliedAt !== null ? new Date(lastAppliedAt).toISOString().slice(11, 16) : null;
+  const lastTickHHMM = lastAppliedAt !== null
+    ? (() => {
+        const d = new Date(lastAppliedAt);
+        return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+      })()
+    : null;
 
   return (
     <div className="relative">
@@ -737,7 +742,7 @@ export function ChartWorkspaceCanvas({
           {lastTickHHMM !== null ? (
             <>
               <span className="text-slate-400">·</span>
-              <span className="text-slate-500">{lastTickHHMM}Z</span>
+              <span className="text-slate-500">{lastTickHHMM}</span>
             </>
           ) : null}
         </div>

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -23,8 +23,14 @@ import {
 } from "lightweight-charts";
 
 import type { ChartRange } from "@/api/types";
-import { intervalSecondsFor, type NormalisedBar } from "@/lib/chartData";
-import { formatHoverLabel, humanizeVolume, tickFormatter } from "@/lib/chartFormatters";
+import { SessionBands } from "@/components/instrument/SessionBands";
+import { floorToBucket, intervalSecondsFor, type NormalisedBar } from "@/lib/chartData";
+import {
+  classifyUsSession,
+  formatHoverLabel,
+  humanizeVolume,
+  tickFormatter,
+} from "@/lib/chartFormatters";
 import { chartTheme } from "@/lib/chartTheme";
 import { useLiveLastBar } from "@/lib/useLiveLastBar";
 
@@ -187,6 +193,10 @@ export interface ChartWorkspaceCanvasProps {
   readonly showChannel?: boolean;
   /** Show time on the x-axis (intraday data). */
   readonly intraday?: boolean;
+  /** Show pre-market (04:00–09:30 ET) bars + tint band. Default true. */
+  readonly showPm?: boolean;
+  /** Show after-hours (16:00–20:00 ET) bars + tint band. Default true. */
+  readonly showAh?: boolean;
   readonly containerClassName?: string;
 }
 
@@ -200,6 +210,8 @@ export function ChartWorkspaceCanvas({
   showRegression = false,
   showChannel = false,
   intraday = false,
+  showPm = true,
+  showAh = true,
   containerClassName,
 }: ChartWorkspaceCanvasProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -226,6 +238,9 @@ export function ChartWorkspaceCanvas({
   // sees the current intraday flag without re-subscribing every time
   // the prop changes.
   const intradayRef = useRef<boolean>(intraday);
+  // Track which range/compareMode combination we've already auto-fit
+  // so polling refetches don't reset the operator's pan/zoom state.
+  const fittedFingerprintRef = useRef<string | null>(null);
   const [hover, setHover] = useState<RichHoverState | null>(null);
 
   const compareMode = compares.length > 0;
@@ -267,6 +282,10 @@ export function ChartWorkspaceCanvas({
         borderColor: chartTheme.borderColor,
         timeVisible: false,
         secondsVisible: false,
+        // 5-bar right buffer keeps the rightmost axis tick on a clean
+        // grid position instead of pinned to the live bar (see
+        // PriceChart for the same rationale).
+        rightOffset: 5,
       },
       crosshair: {
         vertLine: { width: 1, color: chartTheme.crosshair, style: 3 },
@@ -388,7 +407,10 @@ export function ChartWorkspaceCanvas({
   // Numeric / null-filtered rows. Computed during render so values
   // are available to the live-tick aggregator's historical anchor on
   // the very first render. See PriceChart for the same fix.
-  const clean = useMemo<NumericBar[]>(() => {
+  //
+  // FULL set — used by the previous-close detector so it can see RTH
+  // bars regardless of PM/AH visibility toggles.
+  const cleanAll = useMemo<NumericBar[]>(() => {
     return rows.flatMap((r) => {
       const open = parseNum(r.open);
       const high = parseNum(r.high);
@@ -409,6 +431,19 @@ export function ChartWorkspaceCanvas({
       ];
     });
   }, [rows]);
+
+  // Visibility-filtered set — what gets fed into the price/volume
+  // series + indicator/trend pipelines. PM/AH bars drop when the
+  // operator hides them; RTH and `closed` bars are never hidden.
+  const clean = useMemo<NumericBar[]>(() => {
+    if (!intraday || (showPm && showAh)) return cleanAll;
+    return cleanAll.filter((b) => {
+      const k = classifyUsSession(b.time);
+      if (k === "pre" && !showPm) return false;
+      if (k === "ah" && !showAh) return false;
+      return true;
+    });
+  }, [cleanAll, intraday, showPm, showAh]);
 
   // Mirror `clean` into the crosshair handler's ref. Registered once
   // at mount; ref avoids stale-closure capture.
@@ -465,8 +500,15 @@ export function ChartWorkspaceCanvas({
       );
     }
 
-    chart.timeScale().fitContent();
-  }, [clean, compareMode]);
+    // Only auto-fit on first non-empty load for a given
+    // range/compareMode combination — see PriceChart for rationale.
+    const fingerprint = `${range ?? "?"}/${compareMode ? "cmp" : "ohlcv"}`;
+    if (clean.length > 0 && fittedFingerprintRef.current !== fingerprint) {
+      chart.timeScale().fitContent();
+      fittedFingerprintRef.current = fingerprint;
+    }
+  }, [clean, compareMode, range]);
+
 
   // Compare series: fetch + render normalized lines per compare symbol.
   // Tears down series for symbols no longer in the list.
@@ -717,6 +759,8 @@ export function ChartWorkspaceCanvas({
         line: null, // workspace primaryLineRef is only used in compare mode
         area: null,
       },
+      acceptPre: showPm,
+      acceptAh: showAh,
     });
   const liveActive = connected && !unavailable && liveTargetId !== null;
   const lastTickHHMM = lastAppliedAt !== null
@@ -726,8 +770,40 @@ export function ChartWorkspaceCanvas({
       })()
     : null;
 
+  // SessionBands input — track filtered bars so toggling PM/AH
+  // off removes the corresponding tint together with the bars.
+  // Append the live-tick bucket so an appended bar's tint extends
+  // immediately without waiting for the next REST refetch
+  // (Codex review #602).
+  const liveBucketTime = useMemo(() => {
+    if (lastAppliedAt === null) return null;
+    const tickEpoch = Math.floor(new Date(lastAppliedAt).getTime() / 1000);
+    if (!Number.isFinite(tickEpoch)) return null;
+    return floorToBucket(tickEpoch, bucketSeconds);
+  }, [lastAppliedAt, bucketSeconds]);
+  const bandBars = useMemo(() => {
+    const base = clean.map((b) => ({ time: b.time as number }));
+    if (
+      liveBucketTime !== null &&
+      (base.length === 0 || base[base.length - 1]!.time < liveBucketTime)
+    ) {
+      base.push({ time: liveBucketTime });
+    }
+    return base;
+  }, [clean, liveBucketTime]);
+
   return (
     <div className="relative">
+      <div
+        ref={containerRef}
+        data-testid={`chart-workspace-${symbol}`}
+        className={containerClassName ?? "h-[70vh] w-full"}
+      />
+      <SessionBands
+        chartRef={chartRef}
+        bars={bandBars}
+        enabled={intraday && !compareMode && (showPm || showAh)}
+      />
       {hover !== null ? <RichTooltip hover={hover} /> : null}
       {liveActive ? (
         <div
@@ -747,11 +823,6 @@ export function ChartWorkspaceCanvas({
           ) : null}
         </div>
       ) : null}
-      <div
-        ref={containerRef}
-        data-testid={`chart-workspace-${symbol}`}
-        className={containerClassName ?? "h-[70vh] w-full"}
-      />
     </div>
   );
 }

--- a/frontend/src/pages/components/RawOhlcvTable.test.tsx
+++ b/frontend/src/pages/components/RawOhlcvTable.test.tsx
@@ -61,13 +61,22 @@ describe("RawOhlcvTable", () => {
     expect(screen.getAllByText("—")).toHaveLength(5);
   });
 
-  it("intraday=true renders timestamp with HH:MM and uses Time header label", () => {
+  it("intraday=true renders timestamp in browser-local time + uses Time header label", () => {
+    // Pin to a UTC instant; assert the rendered cell matches whatever
+    // the browser's local-tz formatting produces for that instant.
+    // The hover label rule (#602): intraday hovers show local time
+    // not UTC, so a UK operator on BST sees the wall-clock time
+    // they'd see on TradingView.
     const t = Math.floor(Date.UTC(2026, 3, 27, 14, 30) / 1000);
     const intradayRows: NormalisedBar[] = [
       { time: t, open: "100", high: "100", low: "100", close: "100", volume: "1" },
     ];
     render(<RawOhlcvTable rows={intradayRows} symbol="GME" range="1d" intraday />);
-    expect(screen.getByText("2026-04-27 14:30Z")).toBeInTheDocument();
+    const d = new Date(t * 1000);
+    const expected =
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")} ` +
+      `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+    expect(screen.getByText(expected)).toBeInTheDocument();
     expect(screen.getByText(/^Time/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What
- `SessionBands` overlay marks pre-market (sky), after-hours (amber), closed/overnight (slate-grey). Snaps to NYSE clock ticks.
- PM + AH visibility toggles via `?pm=0` / `?ah=0` URL params; live ticks gated via `acceptPre`/`acceptAh` on `useLiveLastBar`.
- Wired into both `PriceChart` (instrument page) and `ChartWorkspaceCanvas` (workspace).
- `rightOffset: 5` + `fitContent` once-per-range so 60s polling no longer flushes operator pan/zoom or re-anchors rightmost axis tick to the live bar.
- `useLiveLastBar` dedupes on `quoted_at` — toggling session deps no longer replays the last tick.
- Live-bucket fed into SessionBands so an appended bar gets tinted immediately, no waiting for next REST refetch.
- Backend `_debug_ws.py`: `etoro-candles-probe` accepts `interval` param; new `etoro-instrument-raw` for diagnosing instrument metadata coverage.
- Files #609 as tech-debt for exchange-aware schedules + calendar/events page (current `classifyUsSession` is hardcoded NYSE; doesn't catch half-day holidays or non-US listings).

## Why
- Operator feedback during chart redesign: needed AH/PM context, axis stability, tint to distinguish overnight bars from RTH on a glance.
- Codex checkpoint 2 caught: dead `findPreviousRthClose` (removed), band tint lag behind appended live bars (fixed via live-bucket feed), tick replay on session-toggle (fixed via dedupe key).

## Test plan
- [x] `uv run ruff check .` + `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend test:unit` — 599/599 pass (15 new boundary tests for `classifyUsSession`)
- [ ] Refresh instrument page in browser — bands render on first paint, no toggle click required
- [ ] Toggle PM/AH off — bars + bands disappear; live ticks in hidden session don't append
- [ ] Hover live AH bar — band tint extends with the candle (no 60s lag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)