### PR TITLE
fix(#246): bootstrap broker key in eToro credential migration script

### DIFF
--- a/scripts/migrate_etoro_credential.py
+++ b/scripts/migrate_etoro_credential.py
@@ -18,7 +18,22 @@ exits cleanly.
 Hard failures (non-zero exit):
   - No operator exists (run /auth/setup first)
   - Multiple operators exist (ambiguous — manual resolution required)
-  - EBULL_SECRETS_KEY not set (encryption layer cannot function)
+  - Bootstrap returns no broker-encryption key. This happens when the
+    persisted root secret is missing AND the EBULL_SECRETS_KEY env
+    override is unset. Two sub-cases:
+      * ``clean_install`` — credentials table is empty; finish
+        ``/auth/setup`` so the first save lazy-generates the root
+        secret, then re-run this script.
+      * ``recovery_required`` — credentials exist but no root secret
+        is reachable; restore via ``/recover``.
+  - EBULL_SECRETS_KEY env override is set but does not match the existing
+    ciphertext (``master_key.bootstrap`` raises ``MasterKeyError``)
+  - EBULL_SECRETS_KEY env override is malformed (not 32 bytes of base64;
+    ``decode_env_key`` raises ``CredentialCryptoConfigError``)
+
+When EBULL_SECRETS_KEY is set and decodes cleanly, ``bootstrap`` installs
+that key in the returned ``BootResult`` regardless of whether credentials
+already exist, so this script will proceed to write under that key.
 """
 
 from __future__ import annotations
@@ -29,6 +44,12 @@ import sys
 import psycopg
 
 from app.config import settings
+from app.security import master_key
+from app.security.master_key import MasterKeyError
+from app.security.secrets_crypto import (
+    CredentialCryptoConfigError,
+    set_active_key,
+)
 from app.services.broker_credentials import (
     CredentialAlreadyExists,
     store_credential,
@@ -49,55 +70,94 @@ def main() -> int:
         print("Nothing to migrate: neither ETORO_READ_API_KEY nor ETORO_WRITE_API_KEY is set.")
         return 0
 
-    if not settings.secrets_key:
-        print("ERROR: EBULL_SECRETS_KEY is not set. Cannot encrypt credentials.", file=sys.stderr)
-        return 1
-
     try:
         with psycopg.connect(settings.database_url) as conn:
-            op_id = sole_operator_id(conn)
-    except NoOperatorError:
-        print("ERROR: no operator exists. Run /auth/setup first.", file=sys.stderr)
+            # ADR-0003: master_key.bootstrap() must run before any
+            # encrypt/decrypt call. Without it secrets_crypto raises
+            # CredentialCryptoConfigError because the AESGCM cache is
+            # empty. The lifespan does this for the running app; the
+            # standalone script must do it itself.
+            try:
+                boot = master_key.bootstrap(conn)
+            except MasterKeyError as exc:
+                print(f"ERROR: master-key bootstrap failed: {exc}", file=sys.stderr)
+                return 1
+            except CredentialCryptoConfigError as exc:
+                # Raised by decode_env_key when EBULL_SECRETS_KEY is
+                # malformed (not 32 bytes of base64). Surfaces from
+                # bootstrap when the env override is set.
+                print(f"ERROR: EBULL_SECRETS_KEY is invalid: {exc}", file=sys.stderr)
+                return 1
+
+            if boot.broker_encryption_key is None:
+                # Bootstrap returned no key. This can only happen when
+                # the persisted root secret file is absent AND no env
+                # override is set. The state distinguishes whether
+                # there is anything to recover.
+                if boot.state == "clean_install":
+                    print(
+                        "ERROR: no broker-encryption key (clean_install state). "
+                        "Complete /auth/setup so the first credential save "
+                        "lazy-generates the root secret, then re-run this script.",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(
+                        "ERROR: no broker-encryption key (recovery_required state). "
+                        "Root secret is missing or does not match existing ciphertext. "
+                        "Restore via /recover before migrating credentials.",
+                        file=sys.stderr,
+                    )
+                return 1
+
+            set_active_key(boot.broker_encryption_key)
+
+            try:
+                op_id = sole_operator_id(conn)
+            except NoOperatorError:
+                print("ERROR: no operator exists. Run /auth/setup first.", file=sys.stderr)
+                return 1
+            except AmbiguousOperatorError as exc:
+                print(f"ERROR: {exc}. Resolve manually.", file=sys.stderr)
+                return 1
+
+            migrated = 0
+
+            # Migrate ETORO_READ_API_KEY → label "api_key", environment "demo"
+            if _READ_KEY:
+                try:
+                    store_credential(
+                        conn,
+                        operator_id=op_id,
+                        provider="etoro",
+                        label="api_key",
+                        environment="demo",
+                        plaintext=_READ_KEY,
+                    )
+                    print("Migrated ETORO_READ_API_KEY → broker_credentials (etoro/api_key/demo)")
+                    migrated += 1
+                except CredentialAlreadyExists:
+                    print("Skipped ETORO_READ_API_KEY: credential (etoro/api_key/demo) already exists.")
+
+            # Migrate ETORO_WRITE_API_KEY → label "user_key", environment "demo"
+            if _WRITE_KEY:
+                try:
+                    store_credential(
+                        conn,
+                        operator_id=op_id,
+                        provider="etoro",
+                        label="user_key",
+                        environment="demo",
+                        plaintext=_WRITE_KEY,
+                    )
+                    print("Migrated ETORO_WRITE_API_KEY → broker_credentials (etoro/user_key/demo)")
+                    migrated += 1
+                except CredentialAlreadyExists:
+                    print("Skipped ETORO_WRITE_API_KEY: credential (etoro/user_key/demo) already exists.")
+
+    except psycopg.Error as exc:
+        print(f"ERROR: database error: {exc}", file=sys.stderr)
         return 1
-    except AmbiguousOperatorError as exc:
-        print(f"ERROR: {exc}. Resolve manually.", file=sys.stderr)
-        return 1
-
-    migrated = 0
-
-    # Migrate ETORO_READ_API_KEY → label "api_key", environment "demo"
-    if _READ_KEY:
-        try:
-            with psycopg.connect(settings.database_url) as conn:
-                store_credential(
-                    conn,
-                    operator_id=op_id,
-                    provider="etoro",
-                    label="api_key",
-                    environment="demo",
-                    plaintext=_READ_KEY,
-                )
-            print("Migrated ETORO_READ_API_KEY → broker_credentials (etoro/api_key/demo)")
-            migrated += 1
-        except CredentialAlreadyExists:
-            print("Skipped ETORO_READ_API_KEY: credential (etoro/api_key/demo) already exists.")
-
-    # Migrate ETORO_WRITE_API_KEY → label "user_key", environment "demo"
-    if _WRITE_KEY:
-        try:
-            with psycopg.connect(settings.database_url) as conn:
-                store_credential(
-                    conn,
-                    operator_id=op_id,
-                    provider="etoro",
-                    label="user_key",
-                    environment="demo",
-                    plaintext=_WRITE_KEY,
-                )
-            print("Migrated ETORO_WRITE_API_KEY → broker_credentials (etoro/user_key/demo)")
-            migrated += 1
-        except CredentialAlreadyExists:
-            print("Skipped ETORO_WRITE_API_KEY: credential (etoro/user_key/demo) already exists.")
 
     print(f"Done. {migrated} credential(s) migrated.")
     return 0

--- a/tests/test_etoro_credential_migration.py
+++ b/tests/test_etoro_credential_migration.py
@@ -19,8 +19,19 @@ from uuid import uuid4
 import pytest
 
 from app.security import secrets_crypto
+from app.security.master_key import BootResult, MasterKeyError
+from app.security.secrets_crypto import CredentialCryptoConfigError
 from app.services.broker_credentials import CredentialAlreadyExists, CredentialNotFound
 from app.services.operators import NoOperatorError
+
+
+def _normal_boot(key: bytes | None = None) -> BootResult:
+    return BootResult(
+        state="normal",
+        broker_encryption_key=key if key is not None else b"\x00" * 32,
+        needs_setup=False,
+        recovery_required=False,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -38,6 +49,8 @@ def _key() -> Iterator[None]:
 class TestMigrateEtoroCredential:
     """Tests for scripts/migrate_etoro_credential.main()."""
 
+    @patch("scripts.migrate_etoro_credential.set_active_key")
+    @patch("scripts.migrate_etoro_credential.master_key")
     @patch("scripts.migrate_etoro_credential.psycopg")
     @patch("scripts.migrate_etoro_credential.store_credential")
     @patch("scripts.migrate_etoro_credential.sole_operator_id")
@@ -50,18 +63,24 @@ class TestMigrateEtoroCredential:
         mock_sole_op: MagicMock,
         mock_store: MagicMock,
         mock_psycopg: MagicMock,
+        mock_master_key: MagicMock,
+        mock_set_active: MagicMock,
     ) -> None:
         from scripts.migrate_etoro_credential import main
 
         op_id = uuid4()
         mock_sole_op.return_value = op_id
-        mock_settings.secrets_key = "some-key"
         mock_settings.database_url = "postgresql://test"
+        derived_key = b"\xab" * 32
+        mock_master_key.bootstrap.return_value = _normal_boot(derived_key)
         mock_conn = MagicMock()
         mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
         mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
 
         assert main() == 0
+        # bootstrap must run before any encrypt call
+        mock_master_key.bootstrap.assert_called_once_with(mock_conn)
+        mock_set_active.assert_called_once_with(derived_key)
         mock_store.assert_called_once_with(
             mock_conn,
             operator_id=op_id,
@@ -78,6 +97,8 @@ class TestMigrateEtoroCredential:
 
         assert main() == 0
 
+    @patch("scripts.migrate_etoro_credential.set_active_key")
+    @patch("scripts.migrate_etoro_credential.master_key")
     @patch("scripts.migrate_etoro_credential.psycopg")
     @patch("scripts.migrate_etoro_credential.sole_operator_id")
     @patch("scripts.migrate_etoro_credential.settings")
@@ -88,11 +109,13 @@ class TestMigrateEtoroCredential:
         mock_settings: MagicMock,
         mock_sole_op: MagicMock,
         mock_psycopg: MagicMock,
+        mock_master_key: MagicMock,
+        mock_set_active: MagicMock,
     ) -> None:
         from scripts.migrate_etoro_credential import main
 
-        mock_settings.secrets_key = "some-key"
         mock_settings.database_url = "postgresql://test"
+        mock_master_key.bootstrap.return_value = _normal_boot()
         mock_sole_op.side_effect = NoOperatorError("no operator")
         mock_conn = MagicMock()
         mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
@@ -100,6 +123,8 @@ class TestMigrateEtoroCredential:
 
         assert main() == 1
 
+    @patch("scripts.migrate_etoro_credential.set_active_key")
+    @patch("scripts.migrate_etoro_credential.master_key")
     @patch("scripts.migrate_etoro_credential.psycopg")
     @patch("scripts.migrate_etoro_credential.store_credential")
     @patch("scripts.migrate_etoro_credential.sole_operator_id")
@@ -112,12 +137,14 @@ class TestMigrateEtoroCredential:
         mock_sole_op: MagicMock,
         mock_store: MagicMock,
         mock_psycopg: MagicMock,
+        mock_master_key: MagicMock,
+        mock_set_active: MagicMock,
     ) -> None:
         from scripts.migrate_etoro_credential import main
 
         mock_sole_op.return_value = uuid4()
         mock_store.side_effect = CredentialAlreadyExists("exists")
-        mock_settings.secrets_key = "some-key"
+        mock_master_key.bootstrap.return_value = _normal_boot()
         mock_settings.database_url = "postgresql://test"
         mock_conn = MagicMock()
         mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
@@ -125,18 +152,154 @@ class TestMigrateEtoroCredential:
 
         assert main() == 0
 
+    @patch("scripts.migrate_etoro_credential.set_active_key")
+    @patch("scripts.migrate_etoro_credential.master_key")
+    @patch("scripts.migrate_etoro_credential.psycopg")
+    @patch("scripts.migrate_etoro_credential.settings")
     @patch("scripts.migrate_etoro_credential._READ_KEY", "test-key-12345")
     @patch("scripts.migrate_etoro_credential._WRITE_KEY", "")
-    @patch("scripts.migrate_etoro_credential.settings")
-    def test_no_secrets_key_exits_nonzero(
+    def test_clean_install_state_exits_nonzero(
         self,
         mock_settings: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_master_key: MagicMock,
+        mock_set_active: MagicMock,
     ) -> None:
         from scripts.migrate_etoro_credential import main
 
-        mock_settings.secrets_key = None
+        mock_settings.database_url = "postgresql://test"
+        mock_master_key.bootstrap.return_value = BootResult(
+            state="clean_install",
+            broker_encryption_key=None,
+            needs_setup=True,
+            recovery_required=False,
+        )
+        mock_conn = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
 
         assert main() == 1
+        # active key MUST NOT be installed when bootstrap returned None
+        mock_set_active.assert_not_called()
+
+    @patch("scripts.migrate_etoro_credential.set_active_key")
+    @patch("scripts.migrate_etoro_credential.master_key")
+    @patch("scripts.migrate_etoro_credential.psycopg")
+    @patch("scripts.migrate_etoro_credential.settings")
+    @patch("scripts.migrate_etoro_credential._READ_KEY", "test-key-12345")
+    @patch("scripts.migrate_etoro_credential._WRITE_KEY", "")
+    def test_recovery_required_state_exits_nonzero(
+        self,
+        mock_settings: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_master_key: MagicMock,
+        mock_set_active: MagicMock,
+    ) -> None:
+        from scripts.migrate_etoro_credential import main
+
+        mock_settings.database_url = "postgresql://test"
+        mock_master_key.bootstrap.return_value = BootResult(
+            state="recovery_required",
+            broker_encryption_key=None,
+            needs_setup=False,
+            recovery_required=True,
+        )
+        mock_conn = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        assert main() == 1
+        mock_set_active.assert_not_called()
+
+    @patch("scripts.migrate_etoro_credential.master_key")
+    @patch("scripts.migrate_etoro_credential.psycopg")
+    @patch("scripts.migrate_etoro_credential.settings")
+    @patch("scripts.migrate_etoro_credential._READ_KEY", "test-key-12345")
+    @patch("scripts.migrate_etoro_credential._WRITE_KEY", "")
+    def test_master_key_error_exits_nonzero(
+        self,
+        mock_settings: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_master_key: MagicMock,
+    ) -> None:
+        from scripts.migrate_etoro_credential import main
+
+        mock_settings.database_url = "postgresql://test"
+        mock_master_key.bootstrap.side_effect = MasterKeyError("EBULL_SECRETS_KEY does not match existing ciphertext")
+        mock_conn = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        assert main() == 1
+
+    @patch("scripts.migrate_etoro_credential.master_key")
+    @patch("scripts.migrate_etoro_credential.psycopg")
+    @patch("scripts.migrate_etoro_credential.settings")
+    @patch("scripts.migrate_etoro_credential._READ_KEY", "test-key-12345")
+    @patch("scripts.migrate_etoro_credential._WRITE_KEY", "")
+    def test_malformed_env_key_exits_nonzero(
+        self,
+        mock_settings: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_master_key: MagicMock,
+    ) -> None:
+        """``decode_env_key`` raises CredentialCryptoConfigError on a malformed
+        EBULL_SECRETS_KEY. master_key.bootstrap propagates it; the script must
+        catch and exit cleanly rather than dump a traceback.
+        """
+        from scripts.migrate_etoro_credential import main
+
+        mock_settings.database_url = "postgresql://test"
+        mock_master_key.bootstrap.side_effect = CredentialCryptoConfigError(
+            "EBULL_SECRETS_KEY must decode to exactly 32 bytes"
+        )
+        mock_conn = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        assert main() == 1
+
+    @patch("scripts.migrate_etoro_credential.set_active_key")
+    @patch("scripts.migrate_etoro_credential.master_key")
+    @patch("scripts.migrate_etoro_credential.psycopg")
+    @patch("scripts.migrate_etoro_credential.store_credential")
+    @patch("scripts.migrate_etoro_credential.sole_operator_id")
+    @patch("scripts.migrate_etoro_credential.settings")
+    @patch("scripts.migrate_etoro_credential._READ_KEY", "test-read-key-1234")
+    @patch("scripts.migrate_etoro_credential._WRITE_KEY", "")
+    def test_clean_install_with_env_override_proceeds(
+        self,
+        mock_settings: MagicMock,
+        mock_sole_op: MagicMock,
+        mock_store: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_master_key: MagicMock,
+        mock_set_active: MagicMock,
+    ) -> None:
+        """When EBULL_SECRETS_KEY is set on a clean_install database,
+        bootstrap returns state=clean_install with the env_key installed.
+        The script must proceed (key is loaded), not bail on the state
+        label. This is the env-override migration path.
+        """
+        from scripts.migrate_etoro_credential import main
+
+        op_id = uuid4()
+        mock_sole_op.return_value = op_id
+        mock_settings.database_url = "postgresql://test"
+        env_key = b"\xcd" * 32
+        mock_master_key.bootstrap.return_value = BootResult(
+            state="clean_install",
+            broker_encryption_key=env_key,
+            needs_setup=True,
+            recovery_required=False,
+        )
+        mock_conn = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        assert main() == 0
+        mock_set_active.assert_called_once_with(env_key)
+        mock_store.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Bootstrap the master key inside `scripts/migrate_etoro_credential.py` before encrypting credentials.

## Why
Since ADR-0003, `secrets_crypto.encrypt()` requires the AESGCM cache to be populated by `master_key.bootstrap()` / `set_active_key()`. The migration script did neither, so `store_credential()` would raise `CredentialCryptoConfigError("broker-encryption key is not loaded")` at runtime. The old `if not settings.secrets_key` guard was also wrong — the persisted root secret is now the default; the env override is optional.

## Test plan
- [x] `uv run pytest tests/test_etoro_credential_migration.py` (13 passed)
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest -m "not integration"` (2651 passed)
- [x] Codex pre-push review: caught two issues (uncaught `CredentialCryptoConfigError` from malformed env key; clean_install + env override path) — both fixed before push.

Closes #246