### PR TITLE
fix(#558): dedupe financial_periods + fix DEI-context pollution

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -525,13 +525,24 @@ def _fetch_local_financials(
     # is bound as a parameter, not formatted, so a future value added to
     # the CHECK constraint won't silently match.
     select_cols = ", ".join(columns)
+    # Defensive ordering: period_end_date DESC is the primary key, but
+    # if any (fy, fq, period_type) leftover dupes survive the migration
+    # 076 dedupe (e.g. provider-side restatement that arrived after the
+    # one-shot purge), the (fiscal_year, fiscal_quarter) tie-break
+    # keeps quarters in chronological order rather than scrambling by
+    # filing-date pollution. filed_date DESC NULLS LAST prefers the
+    # most recently filed row when an instrument's restatement makes
+    # it past the dedupe.
     sql = f"""
         SELECT period_end_date, period_type, reported_currency, {select_cols}
         FROM financial_periods
         WHERE instrument_id = %(iid)s
           AND superseded_at IS NULL
           AND period_type = ANY(%(types)s::text[])
-        ORDER BY period_end_date DESC
+        ORDER BY fiscal_year DESC,
+                 fiscal_quarter DESC NULLS FIRST,
+                 period_end_date DESC,
+                 filed_date DESC NULLS LAST
         LIMIT 20
     """  # noqa: S608 — columns are a hardcoded whitelist; period_types is bound
 

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -525,24 +525,27 @@ def _fetch_local_financials(
     # is bound as a parameter, not formatted, so a future value added to
     # the CHECK constraint won't silently match.
     select_cols = ", ".join(columns)
-    # Defensive ordering: period_end_date DESC is the primary key, but
-    # if any (fy, fq, period_type) leftover dupes survive the migration
-    # 076 dedupe (e.g. provider-side restatement that arrived after the
-    # one-shot purge), the (fiscal_year, fiscal_quarter) tie-break
-    # keeps quarters in chronological order rather than scrambling by
-    # filing-date pollution. filed_date DESC NULLS LAST prefers the
-    # most recently filed row when an instrument's restatement makes
-    # it past the dedupe.
+    # Ordering: ``period_end_date DESC`` is the primary signal so the
+    # rendered columns walk backwards through real fiscal time. The
+    # endpoint is called separately for ``period_types ∈ {Q1..Q4}``
+    # (quarterly view) vs ``{FY}`` (annual view) — see the call sites
+    # below — so a within-row mix of FY and Q4 does not happen at the
+    # API level. Tie-breakers are added defensively so a leftover
+    # duplicate row that slips past the migration 076 dedupe (e.g. a
+    # provider-side restatement that arrives after the one-shot purge)
+    # still renders deterministically: latest ``filed_date`` wins,
+    # then ``filing_event_id`` only as a final pin against a tied
+    # filed_date.
     sql = f"""
         SELECT period_end_date, period_type, reported_currency, {select_cols}
         FROM financial_periods
         WHERE instrument_id = %(iid)s
           AND superseded_at IS NULL
           AND period_type = ANY(%(types)s::text[])
-        ORDER BY fiscal_year DESC,
-                 fiscal_quarter DESC NULLS FIRST,
-                 period_end_date DESC,
-                 filed_date DESC NULLS LAST
+        ORDER BY period_end_date DESC,
+                 filed_date DESC NULLS LAST,
+                 fiscal_year DESC NULLS LAST,
+                 fiscal_quarter DESC NULLS LAST
         LIMIT 20
     """  # noqa: S608 — columns are a hardcoded whitelist; period_types is bound
 

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -758,13 +758,29 @@ def _derive_periods_from_facts(
     for (fy, fp), period_facts in grouped.items():
         period_type, fiscal_quarter = _FP_MAP[fp]
 
-        # Determine period dates from facts
-        period_end = max(f.period_end for f in period_facts)
-        starts = [f.period_start for f in period_facts if f.period_start is not None]
+        # Determine period dates from financial-line-item facts only.
+        # DEI facts (e.g. dei:EntityCommonStockSharesOutstanding) carry
+        # an "as-of" context endDate equal to the filing date, ~6 weeks
+        # after the real fiscal period end. Including them in the
+        # max(period_end) lifted period_end to the filing date and
+        # produced duplicate rows in financial_periods on subsequent
+        # runs (issue #558). Restrict boundary derivation to facts
+        # whose concept maps to a canonical column — those are the
+        # fiscal-period-bearing line items.
+        mapped_facts = [f for f in period_facts if f.concept in _TAG_TO_COLUMN]
+        if not mapped_facts:
+            # Group has only DEI / unmapped concepts. Without a mapped
+            # fact we cannot anchor a real fiscal period; skip rather
+            # than fabricate one from filing-date metadata.
+            continue
+        period_end = max(f.period_end for f in mapped_facts)
+        starts = [f.period_start for f in mapped_facts if f.period_start is not None]
         period_start = min(starts) if starts else None
         months = _months_between(period_start, period_end)
 
-        # Collect accession numbers for source_ref
+        # Collect accession numbers for source_ref (from all facts in
+        # the group — filing provenance is independent of which
+        # concepts the row populates).
         accession_numbers = sorted({f.accession_number for f in period_facts})
         source_ref = accession_numbers[0] if len(accession_numbers) == 1 else ",".join(accession_numbers)
 

--- a/sql/076_dedupe_financial_periods.sql
+++ b/sql/076_dedupe_financial_periods.sql
@@ -5,9 +5,21 @@
 -- the instrument page Financials tab with duplicate columns and
 -- out-of-order quarters.
 --
--- Two distinct mechanisms produce the dupes:
+-- Smoking-gun example from BBBY (CIK 0001130713 = Beyond Inc, formerly
+-- Overstock — ticker reuse after the legacy Bed Bath & Beyond
+-- bankruptcy):
 --
--- 1. **DEI-context pollution (same accession, two period_ends).**
+--   fy=2023 Q4: real row period_end=2023-12-31, source_ref=
+--   '0001130713-24-000013', filed=2024-02-23, revenue=1.232B.
+--
+--   Polluted sibling: period_end=2024-10-29, source_ref=
+--   '0001130713-24-000013,000113071' (compound — extraction merged
+--   facts from a 10-Q across the same fiscal label), filed=2024-10-31,
+--   revenue=1.232B (same value).
+--
+-- Mechanisms producing dupes:
+--
+-- 1. **DEI-context pollution within one filing.**
 --    `_derive_periods_from_facts` did
 --    ``period_end = max(f.period_end for f in period_facts)``. DEI facts
 --    such as ``dei:EntityCommonStockSharesOutstanding`` carry an
@@ -17,25 +29,30 @@
 --    distinct period_end becomes a separate row because period_end_date
 --    is part of the canonical PK.
 --
--- 2. **Cross-accession restatement leftover (different accessions, two
---    period_ends).**
---    A 10-K, 10-K/A, or 10-Q amendment can re-tag the same fiscal label
---    with a different period_end_date than the original filing. Both
---    rows persist because the canonical PK includes period_end_date.
---    Restatements are legitimate — but only the most recently filed
---    row should drive the operator UI, not both.
+-- 2. **Cross-accession pollution leftover.**
+--    Re-extraction over multiple filings can produce a compound
+--    source_ref (comma-joined accessions) and inherit a polluted
+--    period_end from one of the included filings. Same fiscal label,
+--    different period_end, different source_ref.
 --
--- Strategy: TWO DELETE passes.
+-- Reliable signal in both cases: pollution always shifts period_end
+-- LATER than the real fiscal end. The smallest period_end_date per
+-- (instrument, source, fiscal_year, fiscal_quarter, period_type) is
+-- always the row to keep.
 --
--- Pass 1 — same source_ref, smaller-period-end-wins. Catches DEI
--- pollution: same filing produced two rows whose only difference is
--- the as-of context. The real fiscal end is always the smaller
--- period_end; the polluted row is the larger.
+-- Genuine restatements file the SAME period_end_date as the original
+-- (fiscal calendar doesn't move with an amendment), so a "smaller
+-- wins" rule preserves them on tied period_end. Tie-break for true
+-- restatements: keep the most recently filed row.
 --
--- Pass 2 — across source_refs, latest filed_date wins (with period_end
--- as a tie-break). Catches restatement leftover: two rows with the
--- same fiscal label but different accessions. The most recent filing
--- supersedes the older one.
+-- Strategy: TWO DELETE passes per table.
+--
+-- Pass 1 — same source_ref, smaller period_end wins. Catches the
+-- pure DEI case where one filing produced two rows.
+--
+-- Pass 2 — across source_refs, smaller period_end wins; on tied
+-- period_end keep the latest filed_date. Catches the compound /
+-- mixed-extraction cases and preserves real restatements.
 --
 -- Both passes are scoped to a single ``source`` so a future
 -- multi-source row (sec_edgar vs companies_house) is never collapsed
@@ -80,13 +97,6 @@ WHERE EXISTS (
 );
 
 -- ── Pass 2a. financial_periods — across source_refs ─────────────
---
--- Keep the row with the most recent ``filed_date`` per
--- (instrument_id, source, fiscal_year, fiscal_quarter, period_type).
--- Tie-break on ``period_end_date DESC`` so the most-recently-reported
--- period end wins when two filings share a date. NULL filed_date
--- sorts last (NULLS LAST) so a row with a known filing date always
--- beats an unfiled-stub row.
 
 DELETE FROM financial_periods AS keep
 WHERE EXISTS (
@@ -98,12 +108,12 @@ WHERE EXISTS (
       AND other.fiscal_quarter IS NOT DISTINCT FROM keep.fiscal_quarter
       AND other.period_type   = keep.period_type
       AND (
-              -- A different row has a strictly later filed_date.
-              (other.filed_date IS NOT NULL AND keep.filed_date IS NULL)
-           OR (other.filed_date > keep.filed_date)
-              -- Same filed_date (or both NULL) — fall back to period_end.
-           OR (other.filed_date IS NOT DISTINCT FROM keep.filed_date
-               AND other.period_end_date > keep.period_end_date)
+              -- Real period end is always smaller than the polluted one.
+              (other.period_end_date < keep.period_end_date)
+              -- Same period_end_date — true restatement; keep latest filed.
+           OR (other.period_end_date = keep.period_end_date
+               AND ((other.filed_date IS NOT NULL AND keep.filed_date IS NULL)
+                    OR (other.filed_date > keep.filed_date)))
           )
 );
 
@@ -119,10 +129,10 @@ WHERE EXISTS (
       AND other.fiscal_quarter IS NOT DISTINCT FROM keep.fiscal_quarter
       AND other.period_type   = keep.period_type
       AND (
-              (other.filed_date IS NOT NULL AND keep.filed_date IS NULL)
-           OR (other.filed_date > keep.filed_date)
-           OR (other.filed_date IS NOT DISTINCT FROM keep.filed_date
-               AND other.period_end_date > keep.period_end_date)
+              (other.period_end_date < keep.period_end_date)
+           OR (other.period_end_date = keep.period_end_date
+               AND ((other.filed_date IS NOT NULL AND keep.filed_date IS NULL)
+                    OR (other.filed_date > keep.filed_date)))
           )
 );
 

--- a/sql/076_dedupe_financial_periods.sql
+++ b/sql/076_dedupe_financial_periods.sql
@@ -1,0 +1,129 @@
+-- 076_dedupe_financial_periods.sql
+--
+-- #558: financial_periods (and financial_periods_raw) shows the same
+-- fiscal label twice — sometimes more — for one instrument, polluting
+-- the instrument page Financials tab with duplicate columns and
+-- out-of-order quarters.
+--
+-- Two distinct mechanisms produce the dupes:
+--
+-- 1. **DEI-context pollution (same accession, two period_ends).**
+--    `_derive_periods_from_facts` did
+--    ``period_end = max(f.period_end for f in period_facts)``. DEI facts
+--    such as ``dei:EntityCommonStockSharesOutstanding`` carry an
+--    "as-of" instant context endDate equal to the filing date, ~6 weeks
+--    after the real fiscal period end. When a normalisation run
+--    included one, max() lifted period_end to the filing date. Each
+--    distinct period_end becomes a separate row because period_end_date
+--    is part of the canonical PK.
+--
+-- 2. **Cross-accession restatement leftover (different accessions, two
+--    period_ends).**
+--    A 10-K, 10-K/A, or 10-Q amendment can re-tag the same fiscal label
+--    with a different period_end_date than the original filing. Both
+--    rows persist because the canonical PK includes period_end_date.
+--    Restatements are legitimate — but only the most recently filed
+--    row should drive the operator UI, not both.
+--
+-- Strategy: TWO DELETE passes.
+--
+-- Pass 1 — same source_ref, smaller-period-end-wins. Catches DEI
+-- pollution: same filing produced two rows whose only difference is
+-- the as-of context. The real fiscal end is always the smaller
+-- period_end; the polluted row is the larger.
+--
+-- Pass 2 — across source_refs, latest filed_date wins (with period_end
+-- as a tie-break). Catches restatement leftover: two rows with the
+-- same fiscal label but different accessions. The most recent filing
+-- supersedes the older one.
+--
+-- Both passes are scoped to a single ``source`` so a future
+-- multi-source row (sec_edgar vs companies_house) is never collapsed
+-- across providers — those are independently authoritative. The
+-- companion code fix in app/services/fundamentals.py also restricts
+-- period_end derivation to facts whose concept maps to a canonical
+-- column, so future runs cannot reintroduce DEI pollution.
+--
+-- Idempotent: running the file twice on already-deduped data is a
+-- no-op; both DELETEs return rowcount 0.
+
+BEGIN;
+
+-- ── Pass 1a. financial_periods (canonical) — same source_ref ────
+
+DELETE FROM financial_periods AS keep
+WHERE EXISTS (
+    SELECT 1
+    FROM financial_periods AS other
+    WHERE other.instrument_id = keep.instrument_id
+      AND other.source        = keep.source
+      AND other.source_ref    = keep.source_ref
+      AND other.fiscal_year   = keep.fiscal_year
+      AND other.fiscal_quarter IS NOT DISTINCT FROM keep.fiscal_quarter
+      AND other.period_type   = keep.period_type
+      AND other.period_end_date < keep.period_end_date
+);
+
+-- ── Pass 1b. financial_periods_raw — same source_ref ────────────
+
+DELETE FROM financial_periods_raw AS keep
+WHERE EXISTS (
+    SELECT 1
+    FROM financial_periods_raw AS other
+    WHERE other.instrument_id = keep.instrument_id
+      AND other.source        = keep.source
+      AND other.source_ref    = keep.source_ref
+      AND other.fiscal_year   = keep.fiscal_year
+      AND other.fiscal_quarter IS NOT DISTINCT FROM keep.fiscal_quarter
+      AND other.period_type   = keep.period_type
+      AND other.period_end_date < keep.period_end_date
+);
+
+-- ── Pass 2a. financial_periods — across source_refs ─────────────
+--
+-- Keep the row with the most recent ``filed_date`` per
+-- (instrument_id, source, fiscal_year, fiscal_quarter, period_type).
+-- Tie-break on ``period_end_date DESC`` so the most-recently-reported
+-- period end wins when two filings share a date. NULL filed_date
+-- sorts last (NULLS LAST) so a row with a known filing date always
+-- beats an unfiled-stub row.
+
+DELETE FROM financial_periods AS keep
+WHERE EXISTS (
+    SELECT 1
+    FROM financial_periods AS other
+    WHERE other.instrument_id = keep.instrument_id
+      AND other.source        = keep.source
+      AND other.fiscal_year   = keep.fiscal_year
+      AND other.fiscal_quarter IS NOT DISTINCT FROM keep.fiscal_quarter
+      AND other.period_type   = keep.period_type
+      AND (
+              -- A different row has a strictly later filed_date.
+              (other.filed_date IS NOT NULL AND keep.filed_date IS NULL)
+           OR (other.filed_date > keep.filed_date)
+              -- Same filed_date (or both NULL) — fall back to period_end.
+           OR (other.filed_date IS NOT DISTINCT FROM keep.filed_date
+               AND other.period_end_date > keep.period_end_date)
+          )
+);
+
+-- ── Pass 2b. financial_periods_raw — across source_refs ─────────
+
+DELETE FROM financial_periods_raw AS keep
+WHERE EXISTS (
+    SELECT 1
+    FROM financial_periods_raw AS other
+    WHERE other.instrument_id = keep.instrument_id
+      AND other.source        = keep.source
+      AND other.fiscal_year   = keep.fiscal_year
+      AND other.fiscal_quarter IS NOT DISTINCT FROM keep.fiscal_quarter
+      AND other.period_type   = keep.period_type
+      AND (
+              (other.filed_date IS NOT NULL AND keep.filed_date IS NULL)
+           OR (other.filed_date > keep.filed_date)
+           OR (other.filed_date IS NOT DISTINCT FROM keep.filed_date
+               AND other.period_end_date > keep.period_end_date)
+          )
+);
+
+COMMIT;

--- a/tests/test_api_instrument_financials.py
+++ b/tests/test_api_instrument_financials.py
@@ -116,6 +116,44 @@ def test_local_sec_data_returned(client: TestClient) -> None:
     assert body["rows"][0]["period_type"] == "FY"
 
 
+def test_periods_query_orders_by_period_end_date_desc_first(client: TestClient) -> None:
+    """#558/#613 review: ordering pins the chronological-DESC contract.
+
+    ``period_end_date DESC`` is the primary key so the rendered
+    columns walk backwards through real fiscal time. ``filed_date
+    DESC NULLS LAST`` is the tie-breaker — it must NOT precede
+    ``period_end_date`` (that would interleave restatement rows
+    chronologically incorrect on the operator's Financials tab),
+    and it must NOT include ``fiscal_quarter DESC NULLS FIRST``
+    (which would push FY rows ahead of Q4 rows for the same
+    fiscal year on the annual / mixed-period view).
+    """
+
+    cur_mock = MagicMock()
+    cur_mock.__enter__.return_value = cur_mock
+    cur_mock.fetchone.return_value = {"instrument_id": 1, "symbol": "AAPL"}
+    cur_mock.fetchall.return_value = []
+
+    def _conn() -> Iterator[MagicMock]:
+        conn_mock = MagicMock()
+        conn_mock.cursor.return_value = cur_mock
+        yield conn_mock
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _conn
+    try:
+        resp = client.get("/instruments/AAPL/financials?statement=income&period=quarterly")
+        assert resp.status_code == 200
+        executed_sql = "".join(str(call.args[0]) for call in cur_mock.execute.call_args_list if call.args)
+        assert "ORDER BY period_end_date DESC" in executed_sql, executed_sql
+        assert "filed_date DESC NULLS LAST" in executed_sql
+        # NULLS FIRST on fiscal_quarter would re-order FY ahead of Q4 for the same year.
+        assert "NULLS FIRST" not in executed_sql
+    finally:
+        _clear_db_override()
+
+
 def test_no_local_data_returns_unavailable_empty(client: TestClient) -> None:
     """When SEC has no rows for the instrument, return empty payload
     with ``source = "unavailable"`` — no yfinance fallback."""

--- a/tests/test_financial_normalization.py
+++ b/tests/test_financial_normalization.py
@@ -160,6 +160,70 @@ class TestDerivePeriodsFromFacts:
         assert len(periods) == 1
         assert periods[0].period_type == "Q1"
 
+    def test_dei_fact_does_not_pollute_period_end(self) -> None:
+        """Regression for #558.
+
+        DEI facts (e.g. dei:EntityCommonStockSharesOutstanding) carry an
+        "as-of" context endDate equal to the filing date — typically
+        ~6 weeks AFTER the real fiscal period end. Previously
+        ``_derive_periods_from_facts`` did
+        ``period_end = max(f.period_end for f in period_facts)``, which
+        let a DEI fact lift period_end to the filing date and produced
+        a duplicate row in financial_periods on subsequent runs. The
+        fix restricts boundary derivation to facts whose concept maps
+        to a canonical column.
+        """
+        gaap_fact = _fact(
+            concept="Revenues",
+            val=Decimal("100"),
+            period_end="2026-01-31",  # real Q4 end
+            period_start="2025-11-01",
+            fiscal_period="Q4",
+            fiscal_year=2025,
+            frame="CY2025Q4",
+            accession_number="0001326380-26-000013",
+            filed_date="2026-03-19",
+        )
+        dei_fact = _fact(
+            concept="EntityCommonStockSharesOutstanding",  # not in _TAG_TO_COLUMN
+            val=Decimal("268000000"),
+            period_end="2026-03-18",  # filing-date pollution
+            period_start=None,
+            fiscal_period="Q4",
+            fiscal_year=2025,
+            frame=None,  # would be filtered as YTD-duration, but it's instant (no start)
+            accession_number="0001326380-26-000013",
+            filed_date="2026-03-19",
+        )
+        periods = _derive_periods_from_facts([gaap_fact, dei_fact], reported_currency="USD")
+        assert len(periods) == 1
+        p = periods[0]
+        # Real fiscal end, NOT 2026-03-18.
+        assert p.period_end_date == date(2026, 1, 31)
+        # Real period start preserved.
+        assert p.period_start_date == date(2025, 11, 1)
+        # Mapped column populated.
+        assert p.revenue == Decimal("100")
+
+    def test_group_with_only_unmapped_facts_is_skipped(self) -> None:
+        """If a (fy, fp) group contains no facts mapped to a canonical
+        column, it must NOT produce a row anchored on filing-date
+        metadata. Skipping prevents spurious rows like
+        ``period_end_date = filing date`` from appearing in
+        financial_periods (#558).
+        """
+        only_dei = _fact(
+            concept="EntityCommonStockSharesOutstanding",
+            val=Decimal("1"),
+            period_end="2026-03-18",
+            period_start=None,
+            fiscal_period="Q4",
+            fiscal_year=2025,
+            frame=None,
+        )
+        periods = _derive_periods_from_facts([only_dei], reported_currency="USD")
+        assert periods == []
+
     def test_tag_priority_picks_first_match(self) -> None:
         """When multiple tags map to the same concept (e.g. revenue),
         the highest-priority tag's value is used."""

--- a/tests/test_migration_076_dedupe_financial_periods.py
+++ b/tests/test_migration_076_dedupe_financial_periods.py
@@ -223,38 +223,149 @@ class TestDedupePass1SameAccession:
 
 
 class TestDedupePass2CrossAccession:
-    """Pass 2: collapse same (fy, fq, period_type), keep latest filed_date."""
+    """Pass 2: across source_refs, smaller period_end wins; on tied
+    period_end keep the latest filed_date.
+    """
 
-    def test_keeps_latest_filed_amendment(
+    def test_bbby_pattern_keeps_real_fiscal_end(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     ) -> None:
-        """Cross-accession restatement leftover. The instrument page must
-        not show two columns for the same fiscal label; the latest
-        filing's values supersede the original.
+        """Smoking-gun regression for the BBBY (Beyond Inc) pattern:
+
+          real:     period_end=2023-12-31, source_ref='acc-13',
+                    filed=2024-02-23, revenue=1.232B
+          polluted: period_end=2024-10-29, source_ref='acc-13,acc-78'
+                    (compound — extraction merged a 10-Q's facts in
+                    via a re-run), filed=2024-10-31, revenue=1.232B
+
+        The polluted row has the LATER filed_date (a 10-Q amendment is
+        processed after the original 10-K), so a naive
+        keep-latest-filed_date rule would pick the BAD row. Pollution
+        always shifts period_end FORWARD, never backward, so smaller
+        period_end is the reliable signal.
         """
         conn = ebull_test_conn
-        _seed_instrument(conn, instrument_id=3, symbol="MSFT")
+        _seed_instrument(conn, instrument_id=3, symbol="BBBY")
         _seed_period(
             conn,
             instrument_id=3,
-            period_end=date(2024, 6, 30),
+            period_end=date(2023, 12, 31),  # real Q4 2023 end
             period_type="Q4",
-            fiscal_year=2024,
+            fiscal_year=2023,
             fiscal_quarter=4,
-            source_ref="acc-original",
-            filed_date=date(2024, 7, 30),
-            revenue=Decimal("1000"),
+            source_ref="0001130713-24-000013",
+            filed_date=date(2024, 2, 23),
+            revenue=Decimal("1232008000"),
         )
         _seed_period(
             conn,
             instrument_id=3,
-            period_end=date(2024, 7, 15),
+            period_end=date(2024, 10, 29),  # filing-date pollution
             period_type="Q4",
-            fiscal_year=2024,
+            fiscal_year=2023,
             fiscal_quarter=4,
+            source_ref="0001130713-24-000013,000113071",  # compound
+            filed_date=date(2024, 10, 31),  # LATER than real
+            revenue=Decimal("1232008000"),
+        )
+        conn.commit()
+
+        _run_migration(conn)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT period_end_date, source_ref FROM financial_periods "
+                "WHERE instrument_id = 3 AND fiscal_quarter = 4"
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        # Real fiscal end survives — pollution is dropped despite later filed_date.
+        assert rows[0]["period_end_date"] == date(2023, 12, 31)
+        assert rows[0]["source_ref"] == "0001130713-24-000013"
+
+    def test_compound_source_ref_collapses_to_single(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A single-accession row paired with a compound-accession row
+        sharing a fiscal label — same as the BBBY case but with a
+        different fiscal year, to confirm the rule generalises.
+        Smaller period_end wins.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, instrument_id=9, symbol="BYON")
+        _seed_period(
+            conn,
+            instrument_id=9,
+            period_end=date(2022, 12, 31),  # real Q4 2022
+            period_type="Q4",
+            fiscal_year=2022,
+            fiscal_quarter=4,
+            source_ref="acc-14",
+            filed_date=date(2023, 2, 24),
+        )
+        _seed_period(
+            conn,
+            instrument_id=9,
+            period_end=date(2023, 6, 30),  # polluted compound
+            period_type="Q4",
+            fiscal_year=2022,
+            fiscal_quarter=4,
+            source_ref="acc-14,acc-71",
+            filed_date=date(2023, 7, 3),
+        )
+        conn.commit()
+
+        _run_migration(conn)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT period_end_date, source_ref FROM financial_periods "
+                "WHERE instrument_id = 9 AND fiscal_quarter = 4"
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["period_end_date"] == date(2022, 12, 31)
+        assert rows[0]["source_ref"] == "acc-14"
+
+    def test_tied_period_end_amendment_keeps_latest_filed(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Genuine restatement: two filings of the SAME fiscal label
+        with the SAME period_end_date (real amendments do not move the
+        fiscal calendar). Tie-break keeps the most recent filed_date.
+
+        Tested against the raw table because the canonical PK
+        (instrument_id, period_end_date, period_type) cannot hold two
+        rows with identical period_end. Migration logic is identical
+        between canonical and raw.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, instrument_id=8, symbol="ORCL")
+        _seed_period_raw(
+            conn,
+            instrument_id=8,
+            period_end=date(2024, 11, 30),
+            period_type="Q2",
+            fiscal_year=2025,
+            fiscal_quarter=2,
+            source_ref="acc-original",
+            filed_date=date(2024, 12, 11),
+            revenue=Decimal("1000"),
+        )
+        _seed_period_raw(
+            conn,
+            instrument_id=8,
+            period_end=date(2024, 11, 30),
+            period_type="Q2",
+            fiscal_year=2025,
+            fiscal_quarter=2,
             source_ref="acc-amendment",
-            filed_date=date(2024, 9, 12),  # later
+            filed_date=date(2025, 1, 15),  # later
             revenue=Decimal("1100"),
         )
         conn.commit()
@@ -264,94 +375,12 @@ class TestDedupePass2CrossAccession:
 
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute(
-                "SELECT period_end_date, source_ref, revenue FROM financial_periods "
-                "WHERE instrument_id = 3 AND fiscal_quarter = 4"
+                "SELECT source_ref, revenue FROM financial_periods_raw WHERE instrument_id = 8 AND fiscal_quarter = 2"
             )
             rows = cur.fetchall()
         assert len(rows) == 1
         assert rows[0]["source_ref"] == "acc-amendment"
         assert rows[0]["revenue"] == Decimal("1100")
-
-    def test_tied_filed_date_falls_back_to_period_end(
-        self,
-        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
-    ) -> None:
-        """When two cross-accession rows were filed on the same day,
-        the larger period_end_date wins (most-recently-reported period
-        end).
-        """
-        conn = ebull_test_conn
-        _seed_instrument(conn, instrument_id=8, symbol="ORCL")
-        _seed_period(
-            conn,
-            instrument_id=8,
-            period_end=date(2024, 11, 30),
-            period_type="Q2",
-            fiscal_year=2025,
-            fiscal_quarter=2,
-            source_ref="acc-a",
-            filed_date=date(2024, 12, 11),
-        )
-        _seed_period(
-            conn,
-            instrument_id=8,
-            period_end=date(2024, 12, 1),
-            period_type="Q2",
-            fiscal_year=2025,
-            fiscal_quarter=2,
-            source_ref="acc-b",
-            filed_date=date(2024, 12, 11),  # same filed_date
-        )
-        conn.commit()
-
-        _run_migration(conn)
-        conn.commit()
-
-        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-            cur.execute("SELECT period_end_date FROM financial_periods WHERE instrument_id = 8 AND fiscal_quarter = 2")
-            rows = cur.fetchall()
-        assert len(rows) == 1
-        assert rows[0]["period_end_date"] == date(2024, 12, 1)
-
-    def test_null_filed_date_loses_to_known(
-        self,
-        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
-    ) -> None:
-        """A row with a known filed_date supersedes a row whose
-        filed_date is NULL — known-provenance always beats stub.
-        """
-        conn = ebull_test_conn
-        _seed_instrument(conn, instrument_id=9, symbol="ADBE")
-        _seed_period(
-            conn,
-            instrument_id=9,
-            period_end=date(2024, 8, 30),
-            period_type="Q3",
-            fiscal_year=2024,
-            fiscal_quarter=3,
-            source_ref="acc-stub",
-            filed_date=None,
-        )
-        _seed_period(
-            conn,
-            instrument_id=9,
-            period_end=date(2024, 8, 31),
-            period_type="Q3",
-            fiscal_year=2024,
-            fiscal_quarter=3,
-            source_ref="acc-real",
-            filed_date=date(2024, 9, 13),
-        )
-        conn.commit()
-
-        _run_migration(conn)
-        conn.commit()
-
-        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-            cur.execute("SELECT source_ref FROM financial_periods WHERE instrument_id = 9")
-            rows = cur.fetchall()
-        assert len(rows) == 1
-        assert rows[0]["source_ref"] == "acc-real"
 
 
 class TestDedupeIsolation:

--- a/tests/test_migration_076_dedupe_financial_periods.py
+++ b/tests/test_migration_076_dedupe_financial_periods.py
@@ -40,12 +40,28 @@ def _run_migration(conn: psycopg.Connection[tuple]) -> None:
     The migration file is idempotent, so re-running on top of the
     already-applied state is a no-op for already-deduped rows but
     will collapse rows seeded by the test after the auto-apply.
-    Uses ClientCursor because the file uses BEGIN/COMMIT (multiple
-    statements) and the simple-query protocol is required.
+
+    Implementation note (PR #613 review): psycopg3 ``execute()``
+    accepts multi-statement strings only under specific conditions
+    (autocommit mode + simple-query protocol via
+    ``ClientCursor``). We commit any pending test transaction, flip
+    to autocommit, run the file as one ClientCursor execute, then
+    restore autocommit. This is the same code path
+    ``app/db/migrations.run_migrations`` uses in production for
+    each migration file.
     """
     sql_text = _MIGRATION_PATH.read_text(encoding="utf-8")
-    with psycopg.ClientCursor(conn) as cur:
-        cur.execute(sql_text)  # type: ignore[call-overload]
+    # Commit any pending writes from the per-test seed so the
+    # autocommit flip is legal (psycopg3 forbids autocommit toggling
+    # mid-transaction).
+    conn.commit()
+    prior_autocommit = conn.autocommit
+    conn.autocommit = True
+    try:
+        with psycopg.ClientCursor(conn) as cur:
+            cur.execute(sql_text)  # type: ignore[call-overload]
+    finally:
+        conn.autocommit = prior_autocommit
 
 
 def _seed_instrument(conn: psycopg.Connection[tuple], instrument_id: int, symbol: str) -> None:

--- a/tests/test_migration_076_dedupe_financial_periods.py
+++ b/tests/test_migration_076_dedupe_financial_periods.py
@@ -1,0 +1,533 @@
+"""Regression test for migration 076 (dedupe duplicate fiscal-period rows, #558).
+
+Seeds duplicate rows in ``financial_periods`` and ``financial_periods_raw``
+matching the two patterns in #558:
+
+  * **DEI-context pollution** — same accession, two different
+    period_end_date values. The polluted row uses the filing date as
+    period_end. Pass 1 keeps the smallest.
+
+  * **Cross-accession restatement leftover** — different accessions,
+    same fiscal label, two different period_end_date values. The
+    older filing's row should be dropped. Pass 2 keeps the most
+    recently filed.
+
+Tests run the actual migration file (``sql/076_dedupe_financial_periods.sql``)
+to keep the test/migration pair from drifting.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+_MIGRATION_PATH = Path(__file__).resolve().parents[1] / "sql" / "076_dedupe_financial_periods.sql"
+
+
+def _run_migration(conn: psycopg.Connection[tuple]) -> None:
+    """Re-execute migration 076 against the test DB.
+
+    The migration file is idempotent, so re-running on top of the
+    already-applied state is a no-op for already-deduped rows but
+    will collapse rows seeded by the test after the auto-apply.
+    Uses ClientCursor because the file uses BEGIN/COMMIT (multiple
+    statements) and the simple-query protocol is required.
+    """
+    sql_text = _MIGRATION_PATH.read_text(encoding="utf-8")
+    with psycopg.ClientCursor(conn) as cur:
+        cur.execute(sql_text)  # type: ignore[call-overload]
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], instrument_id: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id, symbol, f"{symbol} test"),
+    )
+
+
+def _seed_period(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    period_end: date,
+    period_type: str,
+    fiscal_year: int,
+    fiscal_quarter: int | None,
+    source_ref: str,
+    filed_date: date | None = None,
+    revenue: Decimal | None = Decimal("100"),
+    source: str = "sec_edgar",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO financial_periods (
+            instrument_id, period_end_date, period_type,
+            fiscal_year, fiscal_quarter,
+            revenue,
+            source, source_ref, reported_currency, filed_date
+        ) VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s, 'USD', %s
+        )
+        """,
+        (
+            instrument_id,
+            period_end,
+            period_type,
+            fiscal_year,
+            fiscal_quarter,
+            revenue,
+            source,
+            source_ref,
+            filed_date,
+        ),
+    )
+
+
+def _seed_period_raw(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    period_end: date,
+    period_type: str,
+    fiscal_year: int,
+    fiscal_quarter: int | None,
+    source_ref: str,
+    filed_date: date | None = None,
+    revenue: Decimal | None = Decimal("100"),
+    source: str = "sec_edgar",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO financial_periods_raw (
+            instrument_id, period_end_date, period_type,
+            fiscal_year, fiscal_quarter,
+            revenue,
+            source, source_ref, reported_currency, filed_date
+        ) VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s, 'USD', %s
+        )
+        """,
+        (
+            instrument_id,
+            period_end,
+            period_type,
+            fiscal_year,
+            fiscal_quarter,
+            revenue,
+            source,
+            source_ref,
+            filed_date,
+        ),
+    )
+
+
+class TestDedupePass1SameAccession:
+    """Pass 1: collapse same source_ref, smaller period_end wins (DEI pollution)."""
+
+    def test_canonical_table_keeps_smallest_period_end(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, instrument_id=1, symbol="GME")
+        _seed_period(
+            conn,
+            instrument_id=1,
+            period_end=date(2026, 1, 31),  # real Q4 end
+            period_type="Q4",
+            fiscal_year=2025,
+            fiscal_quarter=4,
+            source_ref="0001326380-26-000013",
+            filed_date=date(2026, 3, 19),
+            revenue=Decimal("2732400000"),
+        )
+        _seed_period(
+            conn,
+            instrument_id=1,
+            period_end=date(2026, 3, 18),  # filing-date pollution
+            period_type="Q4",
+            fiscal_year=2025,
+            fiscal_quarter=4,
+            source_ref="0001326380-26-000013",
+            filed_date=date(2026, 3, 19),
+            revenue=Decimal("2732400000"),
+        )
+        conn.commit()
+
+        _run_migration(conn)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT period_end_date FROM financial_periods "
+                "WHERE instrument_id = 1 AND fiscal_year = 2025 "
+                "AND fiscal_quarter = 4 AND period_type = 'Q4'"
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["period_end_date"] == date(2026, 1, 31)
+
+    def test_fy_row_with_null_quarter_is_collapsed(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """FY rows have fiscal_quarter = NULL. The IS NOT DISTINCT FROM
+        join must still match two FY rows with the same source_ref.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, instrument_id=2, symbol="AAPL")
+        _seed_period(
+            conn,
+            instrument_id=2,
+            period_end=date(2025, 9, 28),
+            period_type="FY",
+            fiscal_year=2025,
+            fiscal_quarter=None,
+            source_ref="acc-fy",
+            filed_date=date(2025, 11, 5),
+        )
+        _seed_period(
+            conn,
+            instrument_id=2,
+            period_end=date(2025, 11, 4),
+            period_type="FY",
+            fiscal_year=2025,
+            fiscal_quarter=None,
+            source_ref="acc-fy",
+            filed_date=date(2025, 11, 5),
+        )
+        conn.commit()
+
+        _run_migration(conn)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT period_end_date FROM financial_periods WHERE instrument_id = 2 AND period_type = 'FY'")
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["period_end_date"] == date(2025, 9, 28)
+
+
+class TestDedupePass2CrossAccession:
+    """Pass 2: collapse same (fy, fq, period_type), keep latest filed_date."""
+
+    def test_keeps_latest_filed_amendment(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Cross-accession restatement leftover. The instrument page must
+        not show two columns for the same fiscal label; the latest
+        filing's values supersede the original.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, instrument_id=3, symbol="MSFT")
+        _seed_period(
+            conn,
+            instrument_id=3,
+            period_end=date(2024, 6, 30),
+            period_type="Q4",
+            fiscal_year=2024,
+            fiscal_quarter=4,
+            source_ref="acc-original",
+            filed_date=date(2024, 7, 30),
+            revenue=Decimal("1000"),
+        )
+        _seed_period(
+            conn,
+            instrument_id=3,
+            period_end=date(2024, 7, 15),
+            period_type="Q4",
+            fiscal_year=2024,
+            fiscal_quarter=4,
+            source_ref="acc-amendment",
+            filed_date=date(2024, 9, 12),  # later
+            revenue=Decimal("1100"),
+        )
+        conn.commit()
+
+        _run_migration(conn)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT period_end_date, source_ref, revenue FROM financial_periods "
+                "WHERE instrument_id = 3 AND fiscal_quarter = 4"
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["source_ref"] == "acc-amendment"
+        assert rows[0]["revenue"] == Decimal("1100")
+
+    def test_tied_filed_date_falls_back_to_period_end(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """When two cross-accession rows were filed on the same day,
+        the larger period_end_date wins (most-recently-reported period
+        end).
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, instrument_id=8, symbol="ORCL")
+        _seed_period(
+            conn,
+            instrument_id=8,
+            period_end=date(2024, 11, 30),
+            period_type="Q2",
+            fiscal_year=2025,
+            fiscal_quarter=2,
+            source_ref="acc-a",
+            filed_date=date(2024, 12, 11),
+        )
+        _seed_period(
+            conn,
+            instrument_id=8,
+            period_end=date(2024, 12, 1),
+            period_type="Q2",
+            fiscal_year=2025,
+            fiscal_quarter=2,
+            source_ref="acc-b",
+            filed_date=date(2024, 12, 11),  # same filed_date
+        )
+        conn.commit()
+
+        _run_migration(conn)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT period_end_date FROM financial_periods WHERE instrument_id = 8 AND fiscal_quarter = 2")
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["period_end_date"] == date(2024, 12, 1)
+
+    def test_null_filed_date_loses_to_known(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A row with a known filed_date supersedes a row whose
+        filed_date is NULL — known-provenance always beats stub.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, instrument_id=9, symbol="ADBE")
+        _seed_period(
+            conn,
+            instrument_id=9,
+            period_end=date(2024, 8, 30),
+            period_type="Q3",
+            fiscal_year=2024,
+            fiscal_quarter=3,
+            source_ref="acc-stub",
+            filed_date=None,
+        )
+        _seed_period(
+            conn,
+            instrument_id=9,
+            period_end=date(2024, 8, 31),
+            period_type="Q3",
+            fiscal_year=2024,
+            fiscal_quarter=3,
+            source_ref="acc-real",
+            filed_date=date(2024, 9, 13),
+        )
+        conn.commit()
+
+        _run_migration(conn)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT source_ref FROM financial_periods WHERE instrument_id = 9")
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["source_ref"] == "acc-real"
+
+
+class TestDedupeIsolation:
+    def test_different_instruments_isolated(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Dedupe is per-instrument. A row on instrument 4 must not
+        delete a row on instrument 5 even when source_ref + fiscal
+        labels collide.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, instrument_id=4, symbol="X")
+        _seed_instrument(conn, instrument_id=5, symbol="Y")
+        _seed_period(
+            conn,
+            instrument_id=4,
+            period_end=date(2025, 12, 31),
+            period_type="Q4",
+            fiscal_year=2025,
+            fiscal_quarter=4,
+            source_ref="shared-acc",
+            filed_date=date(2026, 2, 1),
+        )
+        _seed_period(
+            conn,
+            instrument_id=5,
+            period_end=date(2025, 12, 31),
+            period_type="Q4",
+            fiscal_year=2025,
+            fiscal_quarter=4,
+            source_ref="shared-acc",
+            filed_date=date(2026, 2, 1),
+        )
+        conn.commit()
+
+        _run_migration(conn)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT instrument_id FROM financial_periods ORDER BY instrument_id")
+            rows = cur.fetchall()
+        assert [r["instrument_id"] for r in rows] == [4, 5]
+
+    def test_different_sources_kept(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """sec_edgar and (hypothetical) companies_house rows for the
+        same fiscal label are independently authoritative — the
+        per-source scope on both passes preserves them.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, instrument_id=10, symbol="ZZZ")
+        # Different period_end_date so the canonical PK
+        # (instrument_id, period_end_date, period_type) tolerates both
+        # rows; the dedupe is what we're testing, not insertability.
+        _seed_period(
+            conn,
+            instrument_id=10,
+            period_end=date(2024, 12, 31),
+            period_type="FY",
+            fiscal_year=2024,
+            fiscal_quarter=None,
+            source_ref="sec-a",
+            filed_date=date(2025, 3, 15),
+            source="sec_edgar",
+        )
+        _seed_period(
+            conn,
+            instrument_id=10,
+            period_end=date(2025, 1, 1),
+            period_type="FY",
+            fiscal_year=2024,
+            fiscal_quarter=None,
+            source_ref="ch-a",
+            filed_date=date(2025, 4, 1),
+            source="companies_house",
+        )
+        conn.commit()
+
+        _run_migration(conn)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT source FROM financial_periods WHERE instrument_id = 10 ORDER BY source")
+            rows = cur.fetchall()
+        assert [r["source"] for r in rows] == ["companies_house", "sec_edgar"]
+
+
+class TestDedupeIdempotent:
+    def test_second_run_is_noop(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Running the migration a second time on already-deduped data
+        does not delete any further rows.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, instrument_id=6, symbol="NVDA")
+        _seed_period(
+            conn,
+            instrument_id=6,
+            period_end=date(2025, 1, 26),
+            period_type="Q4",
+            fiscal_year=2024,
+            fiscal_quarter=4,
+            source_ref="acc-x",
+            filed_date=date(2025, 2, 28),
+        )
+        _seed_period(
+            conn,
+            instrument_id=6,
+            period_end=date(2025, 2, 28),
+            period_type="Q4",
+            fiscal_year=2024,
+            fiscal_quarter=4,
+            source_ref="acc-x",
+            filed_date=date(2025, 2, 28),
+        )
+        conn.commit()
+
+        _run_migration(conn)
+        conn.commit()
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT COUNT(*) AS n FROM financial_periods WHERE instrument_id = 6")
+            count_after_first = cur.fetchone()["n"]  # type: ignore[index]
+
+        _run_migration(conn)
+        conn.commit()
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT COUNT(*) AS n FROM financial_periods WHERE instrument_id = 6")
+            count_after_second = cur.fetchone()["n"]  # type: ignore[index]
+
+        assert count_after_first == 1
+        assert count_after_second == 1
+
+
+class TestDedupeRawTable:
+    def test_raw_table_pass1(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """The migration also collapses duplicates in
+        financial_periods_raw so a future canonical merge cannot
+        re-pollute the canonical table from leftover raw rows.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, instrument_id=7, symbol="TSLA")
+        _seed_period_raw(
+            conn,
+            instrument_id=7,
+            period_end=date(2025, 12, 31),
+            period_type="Q4",
+            fiscal_year=2025,
+            fiscal_quarter=4,
+            source_ref="acc-raw",
+            filed_date=date(2026, 2, 1),
+        )
+        _seed_period_raw(
+            conn,
+            instrument_id=7,
+            period_end=date(2026, 2, 1),
+            period_type="Q4",
+            fiscal_year=2025,
+            fiscal_quarter=4,
+            source_ref="acc-raw",
+            filed_date=date(2026, 2, 1),
+        )
+        conn.commit()
+
+        _run_migration(conn)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT period_end_date FROM financial_periods_raw WHERE instrument_id = 7")
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["period_end_date"] == date(2025, 12, 31)


### PR DESCRIPTION
## What
- Migration 076 deletes duplicate rows in \`financial_periods\` and \`financial_periods_raw\` (two passes: same-accession DEI pollution, then cross-accession restatement leftover, both scoped per-source).
- \`app/services/fundamentals.py\` restricts \`_derive_periods_from_facts\` boundary derivation to financial-line-item facts only — DEI facts no longer leak filing dates into \`period_end\`.
- \`app/api/instruments.py\` adds a defensive ORDER BY on \`fiscal_year/fiscal_quarter\` so the instrument page Financials tab keeps chronological order even if a future leftover dupe slips through.

## Why
Instrument detail page Financials tab rendered the same Q4/FY twice with different period_ends, and quarters fell out of chronological order. Two root causes:

1. DEI XBRL facts (e.g. \`dei:EntityCommonStockSharesOutstanding\`) carry an \"as-of\" context endDate equal to the filing date. \`_derive_periods_from_facts\` did \`max(f.period_end)\`, lifting period_end to the filing date. Subsequent runs with a different fact mix produced a second row with the real fiscal end → both rows persisted because period_end_date is in the PK.
2. 10-K/A or 10-Q amendments re-tagged the same fiscal label with a different period_end. Both rows persisted under different accessions.

## Test plan
- [x] \`uv run pytest tests/test_migration_076_dedupe_financial_periods.py\` — 9 integration tests against \`ebull_test\` (both passes, FY null-quarter, isolation, idempotence, raw table).
- [x] \`uv run pytest tests/test_financial_normalization.py\` — 2 new unit tests on the extract path.
- [x] \`uv run pytest -m \"not integration\"\` (2649 passed)
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\`
- [x] Codex pre-push review caught: missing \`source\` scope on canonical Pass 1 (fixed); inlined SQL in tests would let migration drift undetected (fixed — tests now run the migration file).

Closes #558