### PR TITLE
fix(#87): replace 5xx detail=str(exc) with fixed strings in config router

### DIFF
--- a/app/api/config.py
+++ b/app/api/config.py
@@ -169,7 +169,10 @@ def get_config(
     except RuntimeConfigCorrupt as exc:
         # Fail closed: never substitute defaults.
         # Prevention-log: "Health endpoint returns HTTP 200 on infra failure".
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        # #87: do NOT echo str(exc) — internal exception text leaks
+        # schema / migration / state hints to unauthenticated callers.
+        # Framework still logs the traceback via `from exc`.
+        raise HTTPException(status_code=503, detail="runtime config unavailable") from exc
 
     return ConfigResponse(
         app_env=settings.app_env,
@@ -206,7 +209,8 @@ def patch_config(
             display_currency=body.display_currency,
         )
     except RuntimeConfigCorrupt as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        # #87: fixed string instead of str(exc) — see GET handler note.
+        raise HTTPException(status_code=503, detail="runtime config unavailable") from exc
     except RuntimeConfigNoOp as exc:
         # No-op patch — reject so audit table never diverges from singleton.
         raise HTTPException(status_code=422, detail=str(exc)) from exc
@@ -253,7 +257,8 @@ def post_kill_switch(
     except RuntimeError as exc:
         # Singleton row missing -> configuration corrupt.  503 not 500: this
         # is an environmental fault, not a programmer error.
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        # #87: fixed string — same reasoning as the runtime-config handlers.
+        raise HTTPException(status_code=503, detail="kill switch unavailable") from exc
 
     # Build the response from the values the service committed inside its own
     # transaction — never re-read after commit, since a concurrent toggle

--- a/tests/test_api_config.py
+++ b/tests/test_api_config.py
@@ -89,17 +89,24 @@ class TestGetConfig:
         assert "app_env" in body
         assert "etoro_env" in body
 
-    def test_runtime_config_corrupt_returns_503(self) -> None:
+    def test_runtime_config_corrupt_returns_503_with_fixed_detail(self) -> None:
+        """#87: 5xx detail is a fixed string — internal exception text
+        must NOT be echoed to unauthenticated callers. The marker
+        substring from the raised exception must not appear in the
+        response body.
+        """
         _override_conn(_mock_conn())
 
+        marker = "internal-leak-marker-XYZ-singleton-missing"
         with patch(
             "app.api.config.get_runtime_config",
-            side_effect=RuntimeConfigCorrupt("singleton missing"),
+            side_effect=RuntimeConfigCorrupt(marker),
         ):
             resp = client.get("/config")
 
         assert resp.status_code == 503
-        assert "missing" in resp.json()["detail"]
+        assert marker not in resp.text
+        assert resp.json()["detail"] == "runtime config unavailable"
 
 
 # ---------------------------------------------------------------------------
@@ -225,11 +232,13 @@ class TestPatchConfig:
             )
         assert resp.status_code == 200
 
-    def test_corrupt_runtime_config_returns_503(self) -> None:
+    def test_corrupt_runtime_config_returns_503_with_fixed_detail(self) -> None:
+        """#87 — see TestGetConfig docstring."""
         _override_conn(_mock_conn())
+        marker = "patch-internal-leak-marker-ZZZ"
         with patch(
             "app.api.config.update_runtime_config",
-            side_effect=RuntimeConfigCorrupt("missing"),
+            side_effect=RuntimeConfigCorrupt(marker),
         ):
             resp = client.patch(
                 "/config",
@@ -240,6 +249,8 @@ class TestPatchConfig:
                 },
             )
         assert resp.status_code == 503
+        assert marker not in resp.text
+        assert resp.json()["detail"] == "runtime config unavailable"
 
 
 # ---------------------------------------------------------------------------
@@ -300,14 +311,18 @@ class TestPostKillSwitch:
         )
         assert resp.status_code == 422
 
-    def test_missing_kill_switch_row_returns_503(self) -> None:
+    def test_missing_kill_switch_row_returns_503_with_fixed_detail(self) -> None:
+        """#87 — see TestGetConfig docstring."""
         _override_conn(_mock_conn())
+        marker = "killswitch-internal-leak-marker-QQQ-row-missing"
         with patch(
             "app.api.config.activate_kill_switch",
-            side_effect=RuntimeError("kill_switch row missing"),
+            side_effect=RuntimeError(marker),
         ):
             resp = client.post(
                 "/config/kill-switch",
                 json={"active": True, "reason": "halt", "activated_by": "op"},
             )
         assert resp.status_code == 503
+        assert marker not in resp.text
+        assert resp.json()["detail"] == "kill switch unavailable"


### PR DESCRIPTION
## What
Three 5xx HTTPException sites in \`app/api/config.py\` (GET /config, PATCH /config, POST /config/kill-switch) now raise with a fixed-string \`detail\` rather than echoing \`str(exc)\`. The \`from exc\` chain is preserved so the framework still logs the traceback.

## Why
Per the prevention-log entry "Internal exception text leaked into HTTP response bodies" added in #86, these sites leak schema / migration / row-missing hints to unauthenticated callers. The 4xx pydantic sites are intentionally left in place — those messages describe the caller's own input.

## Test plan
- [x] \`uv run pytest tests/test_api_config.py\` (15 passed) — three regression tests use the unique-marker pattern (random string in the raised exception, asserted absent from \`response.text\`).
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\`
- [x] \`grep -rEn 'HTTPException\(status_code=5\d\d.*str\(exc\)' app/\` → no matches.

Closes #87