### PR TITLE
fix(#422): mark 21 clean_client tests @pytest.mark.integration

### DIFF
--- a/tests/api/test_sync_layer_enabled_endpoint.py
+++ b/tests/api/test_sync_layer_enabled_endpoint.py
@@ -44,6 +44,7 @@ def test_post_layer_enabled_portfolio_sync_disable_warning(clean_client: TestCli
         clean_client.post("/sync/layers/portfolio_sync/enabled", json={"enabled": True})
 
 
+@pytest.mark.integration
 def test_post_layer_enabled_unknown_layer_404(clean_client: TestClient) -> None:
     resp = clean_client.post("/sync/layers/not_a_real_layer/enabled", json={"enabled": False})
     assert resp.status_code == 404

--- a/tests/api/test_sync_layers_v1_unchanged.py
+++ b/tests/api/test_sync_layers_v1_unchanged.py
@@ -4,7 +4,15 @@ If a later refactor deliberately retires v1, delete this test in the
 same PR that removes the endpoint.
 """
 
+import pytest
 from fastapi.testclient import TestClient
+
+# Every test below uses the ``clean_client`` fixture, which spins up a
+# real DB-backed FastAPI client. Per the #421 PREVENTION rule, those
+# must be marked ``@pytest.mark.integration`` so unit-only CI passes
+# can deselect them. Module-level pytestmark covers all current and
+# future tests in this file uniformly.
+pytestmark = pytest.mark.integration
 
 EXPECTED_LAYER_KEYS = {
     "name",

--- a/tests/api/test_sync_layers_v2_schema.py
+++ b/tests/api/test_sync_layers_v2_schema.py
@@ -1,4 +1,10 @@
+import pytest
 from fastapi.testclient import TestClient
+
+# All tests use the ``clean_client`` fixture (real DB-backed). Per the
+# #421 PREVENTION rule, mark the whole module integration so unit-only
+# CI passes deselect cleanly.
+pytestmark = pytest.mark.integration
 
 
 def test_v2_endpoint_returns_expected_top_level_keys(clean_client: TestClient) -> None:

--- a/tests/api/test_sync_scope_behind.py
+++ b/tests/api/test_sync_scope_behind.py
@@ -1,6 +1,12 @@
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
+
+# All tests use the ``clean_client`` fixture (real DB-backed). Per the
+# #421 PREVENTION rule, mark the whole module integration so unit-only
+# CI passes deselect cleanly.
+pytestmark = pytest.mark.integration
 
 
 def _make_empty_plan():


### PR DESCRIPTION
## What
Three files get module-level \`pytestmark = pytest.mark.integration\`; one file gets a single per-test decorator on the unmarked sibling. 21 tests now correctly skip under \`pytest -m \"not integration\"\`.

## Why
Per the #421 PREVENTION rule, any test using the \`clean_client\` fixture must be marked \`@pytest.mark.integration\` so unit-only CI passes can deselect them. An unmarked test would either silently skip or error during fixture setup depending on CI mode.

## Test plan
- [x] Audit script confirms zero remaining unmarked \`clean_client\` tests.
- [x] \`uv run pytest -m \"not integration\"\` (2625 passed, 233 deselected — includes my 21 newly deselected).
- [x] \`pytest tests/api -m \"not integration\" --collect-only\` shows 33 deselected, 31 collected.
- [x] \`uv run ruff check . && uv run ruff format --check .\`

Closes #422