### PR TITLE
fix(#29): retry transient Anthropic errors in ClaudeSentimentScorer

### DIFF
--- a/app/services/sentiment.py
+++ b/app/services/sentiment.py
@@ -161,7 +161,13 @@ class ClaudeSentimentScorer(SentimentScorer):
 
         # All retries exhausted — re-raise the last seen transient
         # error so the caller can decide between skip and fail.
-        assert last_exc is not None
+        # Explicit raise (not ``assert``) so production runs under
+        # ``python -O`` (which strips assertions) cannot silently
+        # fall through and return ``None`` — review feedback #618.
+        if last_exc is None:
+            raise RuntimeError(
+                "ClaudeSentimentScorer retry loop exited with no exception captured"
+            )
         raise last_exc
 
     def score(self, headline: str, snippet: str | None) -> SentimentResult:

--- a/app/services/sentiment.py
+++ b/app/services/sentiment.py
@@ -14,11 +14,19 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Literal
 
 logger = logging.getLogger(__name__)
+
+# Retry budget for transient Anthropic errors (#29). Three attempts
+# total: an initial call + two retries with exponential backoff
+# (1s, 2s). Anything beyond raises the SDK's exception so the caller
+# can decide whether to skip the article or fail the run.
+_RETRY_MAX_ATTEMPTS = 3
+_RETRY_INITIAL_BACKOFF_S = 1.0
 
 SentimentLabel = Literal["positive", "negative", "neutral"]
 
@@ -92,17 +100,76 @@ class ClaudeSentimentScorer(SentimentScorer):
 
         self._client = anthropic.Anthropic(api_key=api_key)
 
+    def _call_with_retry(self, user_content: str):
+        """Send the messages.create call with retry on transient errors.
+
+        Retries (#29) are limited to:
+          * ``anthropic.RateLimitError`` — HTTP 429.
+          * ``anthropic.APIStatusError`` with ``status_code >= 500`` —
+            transient server-side faults (529 included).
+
+        Non-retryable: 4xx other than 429 (auth, bad request) and any
+        non-Anthropic exception. Those propagate immediately so the
+        caller's outer ``except Exception`` does not silently swallow
+        a programmer error.
+
+        Backoff is 1s, then 2s — short enough to keep the news loop
+        moving on a brief 429 spike, long enough to clear most
+        token-bucket windows.
+        """
+        import anthropic
+
+        backoff = _RETRY_INITIAL_BACKOFF_S
+        last_exc: Exception | None = None
+        for attempt in range(1, _RETRY_MAX_ATTEMPTS + 1):
+            try:
+                return self._client.messages.create(
+                    model=self.MODEL,
+                    max_tokens=self.MAX_TOKENS,
+                    system=_SYSTEM_PROMPT,
+                    messages=[{"role": "user", "content": user_content}],
+                )
+            except anthropic.RateLimitError as exc:
+                last_exc = exc
+                if attempt == _RETRY_MAX_ATTEMPTS:
+                    break
+                logger.warning(
+                    "Sentiment scorer: 429 rate limit (attempt %d/%d); sleeping %.1fs",
+                    attempt,
+                    _RETRY_MAX_ATTEMPTS,
+                    backoff,
+                )
+            except anthropic.APIStatusError as exc:
+                # Only retry server-side errors. 4xx other than 429
+                # mean the request is malformed or unauthorised —
+                # retrying does not help.
+                if exc.status_code < 500:
+                    raise
+                last_exc = exc
+                if attempt == _RETRY_MAX_ATTEMPTS:
+                    break
+                logger.warning(
+                    "Sentiment scorer: %d %s (attempt %d/%d); sleeping %.1fs",
+                    exc.status_code,
+                    type(exc).__name__,
+                    attempt,
+                    _RETRY_MAX_ATTEMPTS,
+                    backoff,
+                )
+            time.sleep(backoff)
+            backoff *= 2
+
+        # All retries exhausted — re-raise the last seen transient
+        # error so the caller can decide between skip and fail.
+        assert last_exc is not None
+        raise last_exc
+
     def score(self, headline: str, snippet: str | None) -> SentimentResult:
         user_content = f"Headline: {headline}"
         if snippet:
             user_content += f"\nSnippet: {snippet}"
 
-        message = self._client.messages.create(
-            model=self.MODEL,
-            max_tokens=self.MAX_TOKENS,
-            system=_SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": user_content}],
-        )
+        message = self._call_with_retry(user_content)
 
         block = message.content[0]
         if not hasattr(block, "text"):

--- a/app/services/sentiment.py
+++ b/app/services/sentiment.py
@@ -165,9 +165,7 @@ class ClaudeSentimentScorer(SentimentScorer):
         # ``python -O`` (which strips assertions) cannot silently
         # fall through and return ``None`` — review feedback #618.
         if last_exc is None:
-            raise RuntimeError(
-                "ClaudeSentimentScorer retry loop exited with no exception captured"
-            )
+            raise RuntimeError("ClaudeSentimentScorer retry loop exited with no exception captured")
         raise last_exc
 
     def score(self, headline: str, snippet: str | None) -> SentimentResult:

--- a/tests/test_sentiment_retry.py
+++ b/tests/test_sentiment_retry.py
@@ -1,0 +1,144 @@
+"""Regression tests for #29 — retry/backoff on ClaudeSentimentScorer.score().
+
+Anthropic raises ``RateLimitError`` (429) and ``APIStatusError`` (5xx)
+for transient faults. The scorer must retry those a small number of
+times with exponential backoff, but propagate non-retryable 4xx
+errors and exhaust-then-raise on persistent transient errors so the
+caller's outer ``except Exception`` does not silently drop a whole
+instrument's articles.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import anthropic
+import httpx
+import pytest
+
+from app.services.sentiment import ClaudeSentimentScorer, SentimentResult
+
+
+def _mk_message(label: str = "positive", magnitude: float = 0.7) -> MagicMock:
+    block = MagicMock()
+    block.text = f'{{"label": "{label}", "magnitude": {magnitude}}}'
+    msg = MagicMock()
+    msg.content = [block]
+    return msg
+
+
+def _mk_rate_limit() -> anthropic.RateLimitError:
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(429, request=request)
+    return anthropic.RateLimitError("rate limited", response=response, body=None)
+
+
+def _mk_api_status(status: int) -> anthropic.APIStatusError:
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(status, request=request)
+    return anthropic.APIStatusError(f"status {status}", response=response, body=None)
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep() -> object:
+    """Patch time.sleep so retries don't actually wait."""
+    with patch("app.services.sentiment.time.sleep") as p:
+        yield p
+
+
+class TestClaudeSentimentScorerRetry:
+    def test_first_attempt_succeeds_no_retry(self) -> None:
+        scorer = ClaudeSentimentScorer.__new__(ClaudeSentimentScorer)
+        scorer._client = MagicMock()
+        scorer._client.messages.create.return_value = _mk_message()
+
+        result = scorer.score("good earnings", None)
+
+        assert result == SentimentResult(label="positive", magnitude=0.7)
+        assert scorer._client.messages.create.call_count == 1
+
+    def test_one_429_then_success(self, _no_sleep: MagicMock) -> None:
+        scorer = ClaudeSentimentScorer.__new__(ClaudeSentimentScorer)
+        scorer._client = MagicMock()
+        scorer._client.messages.create.side_effect = [_mk_rate_limit(), _mk_message()]
+
+        result = scorer.score("good earnings", None)
+
+        assert result.label == "positive"
+        assert scorer._client.messages.create.call_count == 2
+        # Backoff was applied once (1s before retry).
+        assert _no_sleep.call_count == 1
+
+    def test_three_429s_raises(self, _no_sleep: MagicMock) -> None:
+        """All three attempts hit 429 → re-raise the last RateLimitError."""
+        scorer = ClaudeSentimentScorer.__new__(ClaudeSentimentScorer)
+        scorer._client = MagicMock()
+        scorer._client.messages.create.side_effect = [
+            _mk_rate_limit(),
+            _mk_rate_limit(),
+            _mk_rate_limit(),
+        ]
+
+        with pytest.raises(anthropic.RateLimitError):
+            scorer.score("good earnings", None)
+
+        assert scorer._client.messages.create.call_count == 3
+        # Two backoff sleeps (between attempts 1→2 and 2→3).
+        assert _no_sleep.call_count == 2
+
+    def test_5xx_retried(self, _no_sleep: MagicMock) -> None:
+        """5xx (incl. 529 overloaded) is treated as transient."""
+        scorer = ClaudeSentimentScorer.__new__(ClaudeSentimentScorer)
+        scorer._client = MagicMock()
+        scorer._client.messages.create.side_effect = [_mk_api_status(529), _mk_message()]
+
+        result = scorer.score("good earnings", None)
+
+        assert result.label == "positive"
+        assert scorer._client.messages.create.call_count == 2
+
+    def test_4xx_not_retried(self, _no_sleep: MagicMock) -> None:
+        """A non-429 4xx (e.g. 400 bad_request) is the caller's bug —
+        retrying does not help. Raise immediately.
+        """
+        scorer = ClaudeSentimentScorer.__new__(ClaudeSentimentScorer)
+        scorer._client = MagicMock()
+        scorer._client.messages.create.side_effect = _mk_api_status(400)
+
+        with pytest.raises(anthropic.APIStatusError):
+            scorer.score("good earnings", None)
+
+        assert scorer._client.messages.create.call_count == 1
+        assert _no_sleep.call_count == 0
+
+    def test_exponential_backoff_doubles(self, _no_sleep: MagicMock) -> None:
+        scorer = ClaudeSentimentScorer.__new__(ClaudeSentimentScorer)
+        scorer._client = MagicMock()
+        scorer._client.messages.create.side_effect = [
+            _mk_rate_limit(),
+            _mk_rate_limit(),
+            _mk_rate_limit(),
+        ]
+        with pytest.raises(anthropic.RateLimitError):
+            scorer.score("good earnings", None)
+
+        sleeps = [c.args[0] for c in _no_sleep.call_args_list]
+        # 1.0s then 2.0s — exponential doubling.
+        assert sleeps == [1.0, 2.0]
+
+    def test_non_anthropic_exception_propagates_immediately(
+        self,
+        _no_sleep: MagicMock,
+    ) -> None:
+        """A bug-shaped exception (e.g. ValueError) must NOT be caught
+        by the retry block — the caller's outer handler should see it.
+        """
+        scorer = ClaudeSentimentScorer.__new__(ClaudeSentimentScorer)
+        scorer._client = MagicMock()
+        scorer._client.messages.create.side_effect = ValueError("programmer error")
+
+        with pytest.raises(ValueError):
+            scorer.score("good earnings", None)
+
+        assert scorer._client.messages.create.call_count == 1
+        assert _no_sleep.call_count == 0


### PR DESCRIPTION
## What
Adds a 3-attempt retry with exponential backoff (1s, 2s) to \`ClaudeSentimentScorer.score()\` for \`anthropic.RateLimitError\` and \`APIStatusError\` with \`status_code >= 500\`. Non-retryable 4xx and non-Anthropic exceptions propagate immediately.

## Why
Without retry, a single transient 429 caused \`_process_instrument\`'s outer \`except Exception\` to silently skip the rest of an instrument's articles. Per #29, this becomes increasingly likely as the news loop scales.

No new dependency — uses \`time.sleep\` from the stdlib.

## Test plan
- [x] \`uv run pytest tests/test_sentiment_retry.py\` (7 passed)
- [x] \`uv run pytest -m \"not integration\"\` (2654 passed)
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\`

Closes #29