### PR TITLE
fix(#249): sanitise provider-supplied tags in persist_raw_if_new

### DIFF
--- a/app/services/raw_persistence.py
+++ b/app/services/raw_persistence.py
@@ -50,6 +50,57 @@ _DATA_ROOT = Path("data/raw")
 
 
 # ---------------------------------------------------------------------
+# Filename sanitisation (#249)
+# ---------------------------------------------------------------------
+
+# Conservative safe-character set for raw-file tags: ASCII alphanumeric
+# plus ``_`` ``-`` ``.``. Everything else (incl. ``/``, ``\``, ``..``,
+# ``:``, NUL, control chars, unicode) is replaced with ``_`` so a
+# provider-derived identifier (symbol, company number, transaction id)
+# can never inject path separators or shell metacharacters into the
+# filename.
+_SAFE_TAG_CHARS_RE = re.compile(r"[^A-Za-z0-9._-]")
+
+# Cap a tag at 200 chars so a degenerate identifier can't blow past
+# the typical filesystem 255-byte limit once the 16-char hash suffix
+# and ``.json`` extension are appended. Truncated tags still hash
+# distinctly because the SHA-256 prefix uses the full payload, not
+# the tag.
+_MAX_TAG_LEN = 200
+
+
+def _sanitise_tag(tag: str) -> str:
+    """Reduce ``tag`` to a conservative safe character set (#249).
+
+    Provider-derived identifiers like ``symbol``, ``company_number``,
+    and ``transaction_id`` are interpolated directly into raw filenames
+    by callers. They originate in external systems; treating them as
+    trusted-shape strings risks path traversal, NUL injection, or
+    over-long filenames once an upstream API returns an unusual value.
+
+    Behaviour:
+
+      * Any character outside ``[A-Za-z0-9._-]`` becomes ``_``.
+      * Leading dots are stripped so ``..`` cannot become ``__``
+        and slip past containment (paranoia — the regex already
+        replaces ``.`` only when paired with the second ``.``;
+        an explicit guard is cheaper than reasoning about it).
+      * The result is capped at ``_MAX_TAG_LEN`` characters so the
+        full path stays well below typical filesystem limits.
+      * If the input collapses to an empty string the tag becomes
+        ``"_"`` so the resulting filename always has a body before
+        the ``_{hash}.json`` suffix.
+    """
+    cleaned = _SAFE_TAG_CHARS_RE.sub("_", tag)
+    cleaned = cleaned.lstrip(".")
+    if not cleaned:
+        cleaned = "_"
+    if len(cleaned) > _MAX_TAG_LEN:
+        cleaned = cleaned[:_MAX_TAG_LEN]
+    return cleaned
+
+
+# ---------------------------------------------------------------------
 # Per-source retention policy
 # ---------------------------------------------------------------------
 
@@ -193,6 +244,12 @@ def persist_raw_if_new(
             f"policy entry to _RETENTION_POLICY before calling."
         )
 
+    # Sanitise the provider-supplied tag BEFORE composing the path
+    # (#249). Containment is verified after the path resolves so
+    # symlinks or `..` segments that slipped past the regex still
+    # cannot escape the source directory.
+    safe_tag = _sanitise_tag(tag)
+
     # Everything touching the filesystem is inside this try. A
     # disk-full / permission / transient-FS error at any step must
     # log + return None, never escape into provider sync code.
@@ -201,13 +258,30 @@ def persist_raw_if_new(
         digest = hashlib.sha256(body).hexdigest()[:16]
         dir_ = _DATA_ROOT / source
         dir_.mkdir(parents=True, exist_ok=True)
-        target = dir_ / f"{tag}_{digest}.json"
+        target = dir_ / f"{safe_tag}_{digest}.json"
+
+        # Containment guard (#249). Resolve both paths and assert the
+        # target stays under the source directory. Belt-and-braces
+        # against any sanitisation bypass — tags that survive the
+        # regex and length cap are still subject to the resolved-path
+        # check.
+        try:
+            dir_resolved = dir_.resolve(strict=False)
+            target_resolved = target.resolve(strict=False)
+            target_resolved.relative_to(dir_resolved)
+        except OSError, ValueError:
+            logger.warning(
+                "persist_raw_if_new: tag %r resolves outside source dir %r — refusing",
+                tag,
+                source,
+            )
+            return None
 
         if target.exists():
             logger.debug("persist_raw_if_new: dedup hit %s", target.name)
             return None
 
-        fd, tmp_path = tempfile.mkstemp(dir=dir_, prefix=f".{tag}_", suffix=".tmp")
+        fd, tmp_path = tempfile.mkstemp(dir=dir_, prefix=f".{safe_tag}_", suffix=".tmp")
         try:
             with os.fdopen(fd, "wb") as f:
                 f.write(body)

--- a/app/services/raw_persistence.py
+++ b/app/services/raw_persistence.py
@@ -81,10 +81,13 @@ def _sanitise_tag(tag: str) -> str:
     Behaviour:
 
       * Any character outside ``[A-Za-z0-9._-]`` becomes ``_``.
-      * Leading dots are stripped so ``..`` cannot become ``__``
-        and slip past containment (paranoia — the regex already
-        replaces ``.`` only when paired with the second ``.``;
-        an explicit guard is cheaper than reasoning about it).
+      * Leading dots are stripped after the regex pass. The regex
+        keeps ``.`` because legitimate tags often embed a version
+        suffix (``fmp_profile_v1.2``), so ``..`` survives the regex
+        unchanged. ``lstrip('.')`` then peels off any leading dots
+        so a tag of the form ``../etc/passwd`` cannot leave a
+        ``..`` segment that the resolved-path containment check has
+        to argue about.
       * The result is capped at ``_MAX_TAG_LEN`` characters so the
         full path stays well below typical filesystem limits.
       * If the input collapses to an empty string the tag becomes

--- a/tests/test_raw_persistence.py
+++ b/tests/test_raw_persistence.py
@@ -172,6 +172,118 @@ class TestPersistRawIfNew:
 
 
 # ---------------------------------------------------------------------
+# Tag sanitisation (#249)
+# ---------------------------------------------------------------------
+
+
+class TestTagSanitisation:
+    """Provider-derived identifiers (symbol, company_number,
+    transaction_id) are interpolated directly into raw filenames.
+    Whatever an upstream API returns must NOT be able to escape the
+    source directory, smuggle in NUL/control characters, or blow past
+    typical filesystem name limits.
+    """
+
+    def test_forward_slash_in_tag_replaced(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
+        result = persist_raw_if_new("fmp", "profile/AAPL", {"k": "v"})
+        assert result is not None
+        # No subdirectory was created; the slash is replaced.
+        fmp_dir = tmp_path / "fmp"
+        assert result.parent == fmp_dir
+        assert "/" not in result.name
+        assert "profile_AAPL_" in result.name
+
+    def test_dot_dot_in_tag_replaced(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``..`` cannot escape the source directory — the regex
+        replaces neither dot independently, but leading dots are
+        stripped and the containment check would catch a resolved
+        path outside the source dir.
+        """
+        monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
+        result = persist_raw_if_new("fmp", "../etc/passwd", {"k": "v"})
+        assert result is not None
+        # ``../`` collapses to ``__`` after sanitisation; the file
+        # MUST still live under tmp_path/fmp/.
+        assert result.is_relative_to(tmp_path / "fmp")
+        assert ".." not in result.name
+
+    def test_backslash_in_tag_replaced(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
+        result = persist_raw_if_new("fmp", r"profile\AAPL", {"k": "v"})
+        assert result is not None
+        assert "\\" not in result.name
+        assert "profile_AAPL_" in result.name
+
+    def test_nul_byte_replaced(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
+        result = persist_raw_if_new("fmp", "profile\x00AAPL", {"k": "v"})
+        assert result is not None
+        assert "\x00" not in result.name
+
+    def test_unicode_replaced(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
+        result = persist_raw_if_new("fmp", "profile_日本", {"k": "v"})
+        assert result is not None
+        # Only ASCII alphanumeric + ._- survives.
+        assert all(c in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-" for c in result.name)
+
+    def test_long_tag_truncated(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
+        long_tag = "x" * 5000
+        result = persist_raw_if_new("fmp", long_tag, {"k": "v"})
+        assert result is not None
+        # Tag truncated to <=200 chars; full filename stays under
+        # typical FS limits.
+        assert len(result.name) < 255
+
+    def test_empty_after_sanitisation_uses_underscore(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A tag composed entirely of unsafe chars collapses to the
+        single ``_`` placeholder so the filename always has a body
+        before the ``_{hash}.json`` suffix.
+        """
+        monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
+        result = persist_raw_if_new("fmp", "/\x00\x01", {"k": "v"})
+        assert result is not None
+        # All-unsafe tag collapses to a sequence of ``_`` characters
+        # (the regex maps each unsafe char to ``_`` and the result
+        # becomes the tag prefix). The file MUST land under fmp/ and
+        # MUST end with ``_<16hex>.json``.
+        assert result.is_relative_to(tmp_path / "fmp")
+        # Strip extension, strip 17-char ``_<16hex>`` suffix; what
+        # remains is the sanitised tag — must be non-empty.
+        stem = result.stem  # filename without .json
+        # Stem is ``{tag}_{16hex}`` so split off the last underscore
+        # group (the hash):
+        head, _, hash_part = stem.rpartition("_")
+        assert len(hash_part) == 16
+        assert head != ""
+        # Every char in the sanitised head is a safe-set member.
+        assert all(c in "_" for c in head)
+
+    def test_dedup_robust_across_tag_variants(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Two callers passing different but equivalent-after-sanitise
+        tags + the same payload still dedup to one file (digest is
+        payload-derived, sanitised tag is the same).
+        """
+        monkeypatch.setattr(raw_persistence, "_DATA_ROOT", tmp_path)
+        a = persist_raw_if_new("fmp", "profile/AAPL", {"k": "v"})
+        b = persist_raw_if_new("fmp", "profile_AAPL", {"k": "v"})
+        # The ``/`` in tag a sanitises to ``_``, so both tags become
+        # ``profile_AAPL`` with identical digests → second call dedups.
+        assert a is not None
+        assert b is None
+
+
+# ---------------------------------------------------------------------
 # Writer-discipline regression guard (#436)
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
## What
Adds \`_sanitise_tag\` to \`app/services/raw_persistence.py\`: provider-derived identifiers (symbol, company_number, transaction_id) are reduced to a conservative ASCII safe-set before being composed into the filename, with a length cap and a post-resolution containment check.

## Why
Per #249, callers like \`fmp_profile_{symbol}\` and \`ch_filing_{company_number}_{transaction_id}\` interpolate trusted-shape external identifiers straight into the filesystem path. A symbol containing \`/\`, \`..\`, \`\\`, NUL, or pathological length would let the raw write escape the source directory or fail unpredictably. Defence-in-depth: regex + length cap + resolved-path containment.

## Test plan
- [x] \`uv run pytest tests/test_raw_persistence.py\` (39 passed — 8 new \`#249\` regressions)
- [x] \`uv run pytest -m \"not integration\"\` (2655 passed)
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\`

Closes #249