### PR TITLE
fix(#240): narrow /health/db to a binary public liveness probe

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -417,37 +417,31 @@ def health(request: Request) -> JSONResponse:
 
 @app.get("/health/db")
 def health_db(conn: psycopg.Connection[object] = Depends(get_conn)) -> dict:
-    """Returns migration history and list of public tables in the database."""
-    try:
-        migrations = migration_status(conn)
-    except Exception as exc:
-        return {"db_reachable": False, "db_error": str(exc), "tables": [], "migrations": []}
+    """Public liveness probe for the DB layer.
 
-    try:
-        tables = [
-            row[0]  # type: ignore[index]  # TupleRow from default row factory
-            for row in conn.execute(
-                """
-                SELECT tablename
-                FROM pg_tables
-                WHERE schemaname = 'public'
-                ORDER BY tablename
-                """
-            )
-        ]
-        db_ok = True
-        db_error = None
-    except Exception as exc:
-        tables = []
-        db_ok = False
-        db_error = str(exc)
+    Returns ONLY ``{"db_reachable": bool}`` to unauthenticated callers
+    (#240). Earlier revisions echoed the full ``public`` schema's table
+    list, the migration history, and raw ``str(exc)`` error text — all
+    useful fingerprints for an attacker once the app is reachable
+    off-loopback. Schema state and migration history have moved
+    behind operator auth in the existing observability endpoints
+    (``/sync/layers``, ``/sync/layers/v2``); the public probe is now a
+    binary up/down signal only.
 
-    return {
-        "db_reachable": db_ok,
-        "db_error": db_error,
-        "tables": tables,
-        "migrations": migrations,
-    }
+    Any exception during the probe is logged at warning level
+    (framework + ``logger.warning`` so the operator can still
+    investigate) but is NEVER echoed in the response body.
+    """
+    try:
+        # ``migration_status`` itself runs a SELECT against
+        # schema_migrations — sufficient to verify the pool is up
+        # and the bootstrap table exists, which is all a liveness
+        # probe needs to assert.
+        migration_status(conn)
+        return {"db_reachable": True}
+    except Exception:
+        logger.warning("/health/db: probe failed", exc_info=True)
+        return {"db_reachable": False}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_main.py
+++ b/tests/test_api_main.py
@@ -65,12 +65,19 @@ client = TestClient(app)
 
 
 class TestHealthDb:
-    """GET /health/db — migration status via pooled connection."""
+    """GET /health/db — public liveness probe.
+
+    Per #240, the response body MUST contain only ``db_reachable``.
+    Table names, migration history, and raw exception text were
+    removed because the endpoint is unauthenticated and an attacker
+    can use any of those to fingerprint schema / migration / infra
+    failure modes.
+    """
 
     def teardown_method(self) -> None:
         _cleanup()
 
-    def test_returns_db_health_via_pooled_conn(self) -> None:
+    def test_db_reachable_true_only(self) -> None:
         conn = _mock_conn()
         _setup(conn)
 
@@ -78,20 +85,47 @@ class TestHealthDb:
             {"file": "001_init.sql", "status": "applied", "applied_at": "2026-01-01T00:00:00"}
         ]
 
-        # conn.execute returns rows for the pg_tables query
-        conn.execute.return_value = [("instruments",), ("coverage",)]
-
         with patch("app.main.migration_status", return_value=migrations) as mock_status:
             resp = client.get("/health/db")
 
         assert resp.status_code == 200
         body = resp.json()
-        assert body["db_reachable"] is True
-        assert body["tables"] == ["instruments", "coverage"]
-        assert len(body["migrations"]) == 1
+        assert body == {"db_reachable": True}
 
         # migration_status was called with the pooled connection
+        # (probe still verifies the bootstrap table exists).
         mock_status.assert_called_once_with(conn)
+
+    def test_db_unreachable_does_not_leak_exception_text(self) -> None:
+        """When ``migration_status`` raises, the response is the
+        binary ``db_reachable: false`` only — the original exception
+        message must NEVER appear in the response body (#240).
+        """
+        conn = _mock_conn()
+        _setup(conn)
+
+        marker = "internal-leak-marker-XYZ-pg_connect-failed"
+        with patch("app.main.migration_status", side_effect=RuntimeError(marker)):
+            resp = client.get("/health/db")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {"db_reachable": False}
+        assert marker not in resp.text
+
+    def test_response_does_not_include_legacy_fields(self) -> None:
+        """Belt-and-braces: even on the success path, ``tables`` and
+        ``migrations`` keys must be absent so a future regression
+        that accidentally re-adds them trips this test.
+        """
+        conn = _mock_conn()
+        _setup(conn)
+        with patch("app.main.migration_status", return_value=[]):
+            resp = client.get("/health/db")
+        body = resp.json()
+        assert "tables" not in body
+        assert "migrations" not in body
+        assert "db_error" not in body
 
 
 class TestKillSwitch:


### PR DESCRIPTION
## What
\`GET /health/db\` now returns only \`{\"db_reachable\": bool}\`. The full table list, migration history, and \`str(exc)\` error text are removed.

## Why
Per #240, the prior body leaked schema / migration / failure-mode hints to unauthenticated callers — useful fingerprints once the app is off-loopback. Authenticated observability endpoints (\`/sync/layers\`, \`/sync/layers/v2\`) already cover the rich introspection needs. The test suite explicitly pinned \`/health/db\` as public, so narrowing the body is the right knob to turn.

## Test plan
- [x] \`uv run pytest tests/test_api_main.py tests/test_api_auth.py\` (13 passed) — three new contract tests.
- [x] \`uv run pytest -m \"not integration\"\` (2649 passed)
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\`

Closes #240