### PR TITLE
fix(#227): partition synthetic position_id namespace with negative ids

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -259,7 +259,16 @@ def _persist_order_and_fill(
                 )
 
                 # 4. Insert into broker_positions
-                synthetic_position_id = order_id
+                #
+                # Use a NEGATIVE id derived from order_id so the
+                # synthetic-id namespace is partitioned from real
+                # broker-assigned position_ids (#227). eToro's
+                # broker_positions.position_id is unsigned in
+                # practice, so any negative is guaranteed to never
+                # collide with a real id pulled in by a future
+                # portfolio sync. Pairs with the matching convention
+                # in app/services/order_client._persist_broker_position.
+                synthetic_position_id = -order_id
                 conn.execute(
                     """
                     INSERT INTO broker_positions

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -435,13 +435,20 @@ def _persist_broker_position(
 ) -> None:
     """Insert a broker_positions row for an eBull-originated BUY/ADD fill.
 
-    Uses ``order_id`` as the synthetic ``position_id`` — the same convention
-    as ``app/api/orders._persist_order_and_fill``.  The row is immediately
-    visible to ``_load_position_id_for_exit`` so a subsequent EXIT
-    recommendation does not have to wait for the next broker sync cycle.
+    Uses ``-order_id`` as the synthetic ``position_id`` (#227). The
+    sign partitions the synthetic-id namespace from real
+    broker-assigned position_ids — eToro's positionID is unsigned in
+    practice, so a negative synthetic id can never collide with one
+    pulled in by a future portfolio sync. Pairs with the matching
+    convention in ``app/api/orders._persist_order_and_fill``.
 
-    ON CONFLICT: if a broker sync backfills the same ``position_id`` before
-    this runs (unlikely but safe), update units/amount/updated_at.
+    The row is immediately visible to ``_load_position_id_for_exit``
+    (which filters by ``units > 0`` only — sign-agnostic) so a
+    subsequent EXIT recommendation does not have to wait for the next
+    broker sync cycle.
+
+    ON CONFLICT: if the same synthetic id ever recurs (e.g. a re-run
+    of the same order), update units/amount/updated_at.
     """
     gross = filled_price * filled_units
     conn.execute(
@@ -470,7 +477,7 @@ def _persist_broker_position(
             updated_at = EXCLUDED.updated_at
         """,
         {
-            "pid": order_id,
+            "pid": -order_id,
             "iid": instrument_id,
             "units": filled_units,
             "amount": gross,

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -528,7 +528,11 @@ class TestExecuteOrderDemoMode:
 
         # Verify params passed through execute_order (not just SQL shape)
         params = bp_calls[0].args[1]
-        assert params["pid"] == 7  # position_id = order_id
+        # #227: synthetic position_id is the negation of order_id so the
+        # synthetic-id namespace can never collide with a real broker
+        # position_id pulled in by portfolio sync.
+        assert params["pid"] == -7
+        assert params["pid"] < 0  # negative-namespace contract
         assert params["iid"] == 1  # instrument_id from rec
         assert params["sl"] == Decimal("90")
         assert params["tp"] == Decimal("120")
@@ -1058,7 +1062,10 @@ class TestPersistBrokerPosition:
         assert "raw_payload = EXCLUDED.raw_payload" in normalised
 
         params = conn.execute.call_args_list[0].args[1]
-        assert params["pid"] == 7
+        # #227: synthetic position_id = -order_id (negative-namespace
+        # convention to avoid colliding with real broker position_ids).
+        assert params["pid"] == -7
+        assert params["pid"] < 0
         assert params["iid"] == 42
         assert params["units"] == Decimal("5")
         # amount = price * units = 500

--- a/tests/test_orders_api.py
+++ b/tests/test_orders_api.py
@@ -251,6 +251,17 @@ class TestPlaceOrder:
         assert len(broker_positions_inserts) >= 1, "Expected at least one INSERT into broker_positions"
         assert "INSERT INTO broker_positions" in broker_positions_inserts[0]
 
+        # #227: synthetic position_id is the negation of order_id so
+        # the synthetic-id namespace is partitioned from real
+        # broker-assigned position_ids. order_id was 99 above.
+        bp_call = next(
+            c
+            for c in conn.execute.call_args_list
+            if "broker_positions" in str(c.args[0]) and "INSERT" in str(c.args[0])
+        )
+        assert bp_call.args[1]["pid"] == -99
+        assert bp_call.args[1]["pid"] < 0
+
 
 # ---------------------------------------------------------------------------
 # TestClosePosition


### PR DESCRIPTION
## What
Both synthetic-fill paths now insert \`-order_id\` (negative) as the \`broker_positions.position_id\`. Real broker-assigned ids are unsigned in practice, so the namespace partition is clean.

## Why
Same-namespace overlap risked collision with real broker rows once portfolio sync started backfilling them. \`_load_position_id_for_exit\` would then non-deterministically pick whichever row's \`open_date_time\` happened to win.

## Test plan
- [x] \`uv run pytest tests/test_order_client.py tests/test_orders_api.py\` (58 passed) — existing pid=7 assertion flipped to -7 with a \`pid < 0\` invariant; new manual-order-path assertion added.
- [x] \`uv run pytest -m \"not integration\"\` (2647 passed)
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run pyright\`

Closes #227