### PR TITLE
feat(#563): plumb CIK into BusinessSectionsResponse + iXBRL viewer link

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -1252,10 +1252,17 @@ class BusinessSectionsResponse(BaseModel):
     ``source_accession`` identifies the 10-K the sections were extracted
     from, so the UI can link back to the SEC filing. Empty list when
     no sections are on file (first-time instruments or no 10-K filed).
+
+    ``cik`` is the SEC entity CIK for the instrument, plumbed through
+    so the frontend can build direct iXBRL viewer URLs
+    (``cgi-bin/viewer?cik=...&accession_number=...``) without an
+    EDGAR search redirect (#563). NULL for instruments without a
+    primary SEC CIK link (non-US tickers, crypto, etc.).
     """
 
     symbol: str
     source_accession: str | None
+    cik: str | None
     sections: list[BusinessSectionModel]
 
 
@@ -1313,9 +1320,25 @@ def get_instrument_business_sections(
             detail=f"no 10-K sections for {symbol} accession {accession}",
         )
     source_accession = sections[0].source_accession if sections else None
+
+    # #563: plumb CIK so the frontend can build direct iXBRL viewer
+    # URLs. Single SELECT against the existing primary SEC link;
+    # returns None for instruments without one (non-US tickers).
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT identifier_value FROM external_identifiers "
+            "WHERE instrument_id = %(iid)s AND provider = 'sec' "
+            "AND identifier_type = 'cik' AND is_primary = TRUE "
+            "LIMIT 1",
+            {"iid": instrument_id},
+        )
+        cik_row = cur.fetchone()
+    cik = str(cik_row["identifier_value"]) if cik_row is not None else None  # type: ignore[index]
+
     return BusinessSectionsResponse(
         symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
         source_accession=source_accession,
+        cik=cik,
         sections=[
             BusinessSectionModel(
                 section_order=s.section_order,

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -212,6 +212,14 @@ export interface BusinessSection {
 export interface BusinessSectionsResponse {
   symbol: string;
   source_accession: string | null;
+  /**
+   * SEC entity CIK for the instrument. Plumbed through (#563) so the
+   * frontend can build direct iXBRL viewer URLs
+   * (`cgi-bin/viewer?cik=...&accession_number=...`) instead of falling
+   * back to an EDGAR full-text search by accession. NULL for
+   * instruments without a primary SEC CIK link.
+   */
+  cik: string | null;
   sections: BusinessSection[];
 }
 

--- a/frontend/src/pages/Tenk10KDrilldownPage.test.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.test.tsx
@@ -9,6 +9,7 @@ describe("Tenk10KDrilldownPage", () => {
     vi.spyOn(api, "fetchBusinessSections").mockResolvedValue({
       symbol: "GME",
       source_accession: "0001326380-26-000001",
+      cik: "0001326380",
       sections: [
         {
           section_order: 0,

--- a/frontend/src/pages/Tenk10KDrilldownPage.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.tsx
@@ -167,13 +167,27 @@ function TOCRail({ sections }: { readonly sections: ReadonlyArray<BusinessSectio
   );
 }
 
-function secSearchUrlFor(accession: string | null): string | null {
+function secSearchUrlFor(
+  accession: string | null,
+  cik: string | null,
+): string | null {
   if (accession === null) return null;
-  // EDGAR full-text search for the specific accession. Works without
-  // CIK (the prior cgi-bin viewer URL needed CIK and silently broke
-  // when none was available — codex/bot finding on PR #562).
-  // Follow-up #TBD: plumb CIK into BusinessSectionsResponse and link
-  // directly to the iXBRL viewer.
+  // #563: prefer the iXBRL viewer when both CIK + accession are
+  // available — it lands on the specific filing's iXBRL document
+  // rather than an EDGAR full-text result list. Strip the leading
+  // zero padding from CIK so the viewer URL matches EDGAR's expected
+  // format (the API column stores the zero-padded form).
+  if (cik !== null) {
+    const cikTrimmed = cik.replace(/^0+/, "") || "0";
+    return (
+      `https://www.sec.gov/cgi-bin/viewer?action=view` +
+      `&cik=${encodeURIComponent(cikTrimmed)}` +
+      `&accession_number=${encodeURIComponent(accession)}` +
+      `&type=10-K`
+    );
+  }
+  // Fallback: EDGAR full-text search by accession. Used when the
+  // instrument has no primary SEC CIK link (non-US tickers etc.).
   return `https://efts.sec.gov/LATEST/search-index?q=%22${encodeURIComponent(accession)}%22&forms=10-K,10-K%2FA`;
 }
 
@@ -204,7 +218,7 @@ function Body({
         .map((c) => c.target),
     ),
   ];
-  const secSearchUrl = secSearchUrlFor(data.source_accession);
+  const secSearchUrl = secSearchUrlFor(data.source_accession, data.cik);
 
   return (
     <div className="grid gap-6 lg:grid-cols-[180px_minmax(0,1fr)_200px]">

--- a/tests/api/test_instruments_business_sections_endpoint.py
+++ b/tests/api/test_instruments_business_sections_endpoint.py
@@ -27,11 +27,21 @@ def _build_app(conn: MagicMock) -> FastAPI:
     return app
 
 
-def _cursor_returning_instrument() -> MagicMock:
+def _cursor_returning_instrument(cik: str | None = "0001326380") -> MagicMock:
+    """Mock cursor that yields the instrument row on the first
+    ``fetchone`` and the CIK lookup row on the second (#563).
+    Override ``cik=None`` to simulate a non-US instrument so the
+    response's ``cik`` field comes back as ``None``.
+    """
     cur = MagicMock()
     cur.__enter__ = MagicMock(return_value=cur)
     cur.__exit__ = MagicMock(return_value=False)
-    cur.fetchone.return_value = {"instrument_id": 1, "symbol": "GME"}
+    cik_row = {"identifier_value": cik} if cik is not None else None
+    # Sequence: 1st call resolves instrument_id; 2nd call resolves CIK.
+    cur.fetchone.side_effect = [
+        {"instrument_id": 1, "symbol": "GME"},
+        cik_row,
+    ]
     return cur
 
 
@@ -189,3 +199,38 @@ def test_business_sections_unknown_accession_404() -> None:
         r = client.get("/instruments/GME/business_sections?accession=does-not-exist")
 
     assert r.status_code == 404
+
+
+def test_business_sections_response_includes_cik() -> None:
+    """#563: ``cik`` field is plumbed through from external_identifiers."""
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_returning_instrument(cik="0001326380")
+    app = _build_app(conn)
+    with patch(
+        "app.services.business_summary.get_business_sections",
+        return_value=_FAKE_SECTIONS,
+    ):
+        client = TestClient(app)
+        r = client.get("/instruments/GME/business_sections")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["cik"] == "0001326380"
+
+
+def test_business_sections_cik_null_for_non_us_instrument() -> None:
+    """Instruments without a primary SEC CIK link return ``cik: null``
+    rather than a 500 — the iXBRL viewer fallback in the frontend
+    handles the missing-CIK case by falling back to EDGAR search.
+    """
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_returning_instrument(cik=None)
+    app = _build_app(conn)
+    with patch(
+        "app.services.business_summary.get_business_sections",
+        return_value=_FAKE_SECTIONS,
+    ):
+        client = TestClient(app)
+        r = client.get("/instruments/GME/business_sections")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["cik"] is None


### PR DESCRIPTION
## What
- \`BusinessSectionsResponse\` (backend + frontend) gains a \`cik\` field populated from \`external_identifiers\`.
- \`Tenk10KDrilldownPage\` builds the cgi-bin iXBRL viewer URL when CIK is available; falls back to EDGAR search when the instrument has no primary SEC CIK link.

## Why
Per #563, EDGAR full-text search by accession (#562 interim fix) lands operators on a search-results page rather than the specific filing's iXBRL document. With CIK plumbed through the backend already has the data — single small SELECT — and the viewer URL becomes constructible client-side.

## Test plan
- [x] \`uv run pytest tests/api/test_instruments_business_sections_endpoint.py\` (7 passed) — two new \`cik\` regressions.
- [x] \`uv run pytest -m \"not integration\"\` (2649 passed)
- [x] \`pnpm --dir frontend typecheck\`
- [x] \`pnpm --dir frontend test:unit\` (602 passed)
- [x] \`uv run ruff check . && uv run pyright\`

Closes #563