### PR TITLE
feat(#565): plumb accession_number to FilingsPane + 10-K drilldown link

### DIFF
--- a/app/api/filings.py
+++ b/app/api/filings.py
@@ -6,9 +6,10 @@ Reads from:
 
 No writes. No schema changes.
 
-Filing identity is provider-scoped (settled decision).  The API exposes
-``provider`` and ``filing_type`` for display but does not expose
-``provider_filing_id`` or ``raw_payload_json``.
+Filing identity is provider-scoped (settled decision). The API exposes
+``provider``, ``filing_type``, and ``accession_number`` (the
+provider's primary identifier — see #565). It does NOT expose
+``raw_payload_json``.
 """
 
 from __future__ import annotations
@@ -34,13 +35,24 @@ MAX_PAGE_LIMIT = 200
 
 
 class FilingItem(BaseModel):
-    """Single filing event for an instrument."""
+    """Single filing event for an instrument.
+
+    ``accession_number`` is the provider's primary filing identifier
+    (#565). FilingsPane drilldown links route to
+    ``/instrument/{symbol}/filings/10-k`` — without an accession the
+    drilldown always lands on the latest filing, so clicking a
+    historical 10-K or a 10-K/A row landed on the wrong document.
+    Populated from ``filing_events.provider_filing_id``; nullable
+    only as a defensive guard for rows missing the column (none in
+    the current schema, but the column is nullable).
+    """
 
     filing_event_id: int
     instrument_id: int
     filing_date: date
     filing_type: str | None
     provider: str
+    accession_number: str | None
     source_url: str | None
     primary_document_url: str | None
     extracted_summary: str | None
@@ -69,6 +81,7 @@ def _parse_filing_item(row: dict[str, object]) -> FilingItem:
         filing_date=row["filing_date"],  # type: ignore[arg-type]
         filing_type=row["filing_type"],  # type: ignore[arg-type]
         provider=row["provider"],  # type: ignore[arg-type]
+        accession_number=row.get("provider_filing_id"),  # type: ignore[arg-type]
         source_url=row["source_url"],  # type: ignore[arg-type]
         primary_document_url=row["primary_document_url"],  # type: ignore[arg-type]
         extracted_summary=row["extracted_summary"],  # type: ignore[arg-type]
@@ -137,7 +150,7 @@ def list_filings(
         "offset": offset,
     }
     items_sql = f"""SELECT filing_event_id, instrument_id, filing_date,
-                       filing_type, provider,
+                       filing_type, provider, provider_filing_id,
                        source_url, primary_document_url,
                        extracted_summary, red_flag_score,
                        created_at

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -748,6 +748,13 @@ export interface FilingItem {
   filing_date: string;
   filing_type: string | null;
   provider: string;
+  /**
+   * Provider's primary filing identifier (#565). For SEC filings this
+   * is the accession number; FilingsPane appends `?accession=...` to
+   * the 10-K drilldown so non-latest rows route to their specific
+   * filing instead of always landing on the latest.
+   */
+  accession_number: string | null;
   source_url: string | null;
   primary_document_url: string | null;
   extracted_summary: string | null;

--- a/frontend/src/components/instrument/FilingsPane.test.tsx
+++ b/frontend/src/components/instrument/FilingsPane.test.tsx
@@ -105,6 +105,7 @@ describe("FilingsPane", () => {
         filing_date: `2026-03-${(i + 1).toString().padStart(2, "0")}`,
         filing_type: i % 2 === 0 ? "10-K" : "8-K",
         provider: "sec_edgar",
+        accession_number: `0000000000-26-00000${i}`,
         red_flag_score: null,
         extracted_summary: `summary ${i}`,
         primary_document_url: null,
@@ -139,6 +140,63 @@ describe("FilingsPane", () => {
     const btn = await screen.findByRole("button", { name: /open/i });
     await userEvent.click(btn);
     expect(navigateMock).toHaveBeenCalledWith("/instrument/GME?tab=filings");
+  });
+
+  it("appends accession to 10-K drilldown link (#565)", async () => {
+    vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
+      instrument_id: 1,
+      symbol: "GME",
+      total: 2,
+      offset: 0,
+      limit: 6,
+      items: [
+        {
+          filing_event_id: 1,
+          instrument_id: 1,
+          filing_date: "2026-03-20",
+          filing_type: "10-K",
+          provider: "sec_edgar",
+          accession_number: "0001326380-26-000013",
+          red_flag_score: null,
+          extracted_summary: "FY 2025 10-K",
+          primary_document_url: null,
+          source_url: null,
+          created_at: "2026-03-20T00:00:00Z",
+        },
+        {
+          filing_event_id: 2,
+          instrument_id: 1,
+          filing_date: "2024-04-01",
+          filing_type: "10-K/A",
+          provider: "sec_edgar",
+          accession_number: "0001326380-24-000019",
+          red_flag_score: null,
+          extracted_summary: "FY 2023 10-K/A",
+          primary_document_url: null,
+          source_url: null,
+          created_at: "2024-04-01T00:00:00Z",
+        },
+      ],
+    });
+    render(
+      <MemoryRouter>
+        <FilingsPane instrumentId={1} symbol="GME" summary={makeSummary()} />
+      </MemoryRouter>,
+    );
+    // Wait for data + find the row links by their summary text.
+    const link10k = (await screen.findByText("FY 2025 10-K")).closest("a");
+    expect(link10k).not.toBeNull();
+    expect(link10k!.getAttribute("href")).toBe(
+      "/instrument/GME/filings/10-k?accession=0001326380-26-000013",
+    );
+
+    // 10-K/A also gets accession-targeted drilldown — historical row
+    // no longer routes to "the latest" by default.
+    const link10ka = (await screen.findByText("FY 2023 10-K/A")).closest("a");
+    expect(link10ka).not.toBeNull();
+    expect(link10ka!.getAttribute("href")).toBe(
+      "/instrument/GME/filings/10-k?accession=0001326380-24-000019",
+    );
   });
 
   it("hides Open button when filings capability is inactive", async () => {

--- a/frontend/src/components/instrument/FilingsPane.tsx
+++ b/frontend/src/components/instrument/FilingsPane.tsx
@@ -132,8 +132,8 @@ export function FilingsPane({
           {state.data.items.slice(0, ROW_LIMIT).map((f) => {
             const link = drilldownLink(
               symbol,
-              f.filing_type ?? null,
-              f.accession_number ?? null,
+              f.filing_type,
+              f.accession_number,
             );
             const label = (
               <span className="flex items-baseline gap-2">

--- a/frontend/src/components/instrument/FilingsPane.tsx
+++ b/frontend/src/components/instrument/FilingsPane.tsx
@@ -41,10 +41,22 @@ const SIGNIFICANT_FILING_TYPES = [
 
 const TYPES_WITH_DRILLDOWN = new Set(["8-K", "8-K/A", "10-K", "10-K/A"]);
 
-function drilldownLink(symbol: string, filingType: string | null): string | null {
+function drilldownLink(
+  symbol: string,
+  filingType: string | null,
+  accessionNumber: string | null,
+): string | null {
   if (filingType === null || !TYPES_WITH_DRILLDOWN.has(filingType)) return null;
   const symbolEnc = encodeURIComponent(symbol);
   if (filingType.startsWith("10-K")) {
+    // #565: append ?accession=... so a click on a non-latest 10-K
+    // (or a 10-K/A amendment) lands on that specific filing's
+    // drilldown rather than always on the latest 10-K. Falls back
+    // to the bare URL when accession is missing — Tenk10KDrilldownPage
+    // handles that as "show the latest filing".
+    if (accessionNumber !== null) {
+      return `/instrument/${symbolEnc}/filings/10-k?accession=${encodeURIComponent(accessionNumber)}`;
+    }
     return `/instrument/${symbolEnc}/filings/10-k`;
   }
   return `/instrument/${symbolEnc}/filings/8-k`;
@@ -118,7 +130,11 @@ export function FilingsPane({
       ) : (
         <ul className="space-y-1.5 text-xs">
           {state.data.items.slice(0, ROW_LIMIT).map((f) => {
-            const link = drilldownLink(symbol, f.filing_type ?? null);
+            const link = drilldownLink(
+              symbol,
+              f.filing_type ?? null,
+              f.accession_number ?? null,
+            );
             const label = (
               <span className="flex items-baseline gap-2">
                 <span className="text-slate-500">{f.filing_date}</span>

--- a/frontend/src/components/instrument/RightRail.test.tsx
+++ b/frontend/src/components/instrument/RightRail.test.tsx
@@ -68,6 +68,7 @@ function filingsWith(instrumentId: number): FilingsListResponse {
         filing_date: "2026-04-18",
         filing_type: "10-Q",
         provider: "sec",
+        accession_number: "0001-test",
         source_url: null,
         primary_document_url: "https://sec.gov/10q",
         extracted_summary: null,


### PR DESCRIPTION
## What
- \`FilingItem\` (backend + frontend) gains \`accession_number: str | null\` from \`filing_events.provider_filing_id\`.
- \`FilingsPane.drilldownLink\` for 10-K rows appends \`?accession=...\` so a click on a non-latest 10-K (or a 10-K/A amendment) lands on that specific filing's drilldown.

## Why
Per #565, every 10-K row routed to the bare \`/instrument/{symbol}/filings/10-k\` URL, which always resolves to the latest filing. Historical 10-Ks and amendments landed on the wrong document.

## Test plan
- [x] Frontend: new \`FilingsPane.test\` case verifies the \`?accession=...\` link.
- [x] \`pnpm --dir frontend typecheck\`
- [x] \`pnpm --dir frontend test:unit\` (603 passed)
- [x] \`uv run pytest -m \"not integration\"\` (2647 passed)
- [x] \`uv run ruff check . && uv run pyright\`

Closes #565