### PR TITLE
fix(#624): canonical merge by fiscal label + partial unique index

### DIFF
--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -1065,13 +1065,27 @@ def _canonical_merge_instrument(
         Phase B delete cleared the way.
     """
     # Phase B: delete canonical rows that share a fiscal label with a
-    # raw winner but carry a stale ``period_end_date`` (left over from
-    # a prior arrival of the same fiscal period). Running the DELETE
-    # as a separate statement before the INSERT is mandatory: a
-    # combined data-modifying CTE doesn't expose its DELETE rows to
-    # the sibling INSERT's snapshot, so the partial unique index from
-    # migration 077 would still see the stale row and raise
-    # UniqueViolation.
+    # raw winner but are NOT the winner itself.
+    #
+    # Two cases collapsed into the same predicate:
+    #   * stale ``period_end_date`` for the winning source (e.g.
+    #     amendment with a different period_end than the row already
+    #     on file).
+    #   * stale ghost row from a lower-priority source (e.g.
+    #     companies_house won on a prior run when sec_edgar had no
+    #     raw row; sec_edgar arrives later and outranks it). Without
+    #     this delete the ghost row would survive alongside the
+    #     sec_edgar winner, both showing up as separate rows on the
+    #     instrument page.
+    #
+    # The winner is identified by its ``(source, period_end_date)``
+    # tuple. Anything else matching the fiscal label is dropped.
+    #
+    # Running the DELETE as a separate statement before the INSERT is
+    # mandatory: a combined data-modifying CTE doesn't expose its
+    # DELETE rows to the sibling INSERT's snapshot, so the partial
+    # unique index from migration 077 would still see the stale row
+    # and raise UniqueViolation.
     conn.execute(
         """
         DELETE FROM financial_periods fp
@@ -1090,11 +1104,10 @@ def _canonical_merge_instrument(
                      period_end_date ASC
         ) bs
         WHERE fp.instrument_id = %(iid)s
-          AND fp.source = bs.source
           AND fp.fiscal_year = bs.fiscal_year
           AND fp.fiscal_quarter IS NOT DISTINCT FROM bs.fiscal_quarter
           AND fp.period_type = bs.period_type
-          AND fp.period_end_date IS DISTINCT FROM bs.period_end_date
+          AND NOT (fp.source = bs.source AND fp.period_end_date = bs.period_end_date)
         """,
         {"iid": instrument_id},
     )

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -1035,23 +1035,85 @@ def _canonical_merge_instrument(
 ) -> int:
     """Merge financial_periods_raw into financial_periods for one instrument.
 
-    For each (period_end_date, period_type), picks the row from the
-    highest-priority source.  Returns count of rows upserted.
+    Keys on the **fiscal label** ``(fiscal_year, fiscal_quarter,
+    period_type)`` rather than ``(period_end_date, period_type)``
+    (#624). Period_end_date is data, not identity — a late-arriving
+    amendment with a different period_end_date than the row already
+    on file used to insert as a NEW canonical row, leaving the
+    original behind as a duplicate. Now:
+
+      * Phase A: ``best_source`` CTE picks the winning raw row per
+        ``(fiscal_year, fiscal_quarter, period_type)`` — source
+        priority first (sec_edgar > companies_house > others), then
+        ``filed_date DESC`` (latest filing wins regardless of
+        arrival order), with ``period_end_date ASC`` as a final
+        tiebreak so the smallest (real fiscal end) wins on tied
+        filed_date.
+
+      * Phase B: ``deletions`` CTE removes canonical rows whose
+        fiscal label collides with a winner but whose
+        ``period_end_date`` differs — those are stale leftovers
+        from a prior arrival.
+
+      * Phase C: INSERT the winners. ON CONFLICT on the PK
+        ``(instrument_id, period_end_date, period_type)`` updates
+        the row in place when period_end_date matches (a true
+        same-date restatement); the partial unique index from
+        migration 077 backstops the non-stale path so a same-label
+        insert with a *different* period_end_date than any
+        surviving row simply lands as a fresh row after the
+        Phase B delete cleared the way.
     """
-    cur = conn.execute(
+    # Phase B: delete canonical rows that share a fiscal label with a
+    # raw winner but carry a stale ``period_end_date`` (left over from
+    # a prior arrival of the same fiscal period). Running the DELETE
+    # as a separate statement before the INSERT is mandatory: a
+    # combined data-modifying CTE doesn't expose its DELETE rows to
+    # the sibling INSERT's snapshot, so the partial unique index from
+    # migration 077 would still see the stale row and raise
+    # UniqueViolation.
+    conn.execute(
         """
-        WITH best_source AS (
-            SELECT DISTINCT ON (period_end_date, period_type)
-                *
+        DELETE FROM financial_periods fp
+        USING (
+            SELECT DISTINCT ON (fiscal_year, fiscal_quarter, period_type)
+                source, fiscal_year, fiscal_quarter, period_type, period_end_date
             FROM financial_periods_raw
             WHERE instrument_id = %(iid)s
-            ORDER BY period_end_date, period_type,
+            ORDER BY fiscal_year, fiscal_quarter, period_type,
                      CASE source
                          WHEN 'sec_edgar' THEN 1
                          WHEN 'companies_house' THEN 2
                          ELSE 99
                      END,
-                     filed_date DESC NULLS LAST
+                     filed_date DESC NULLS LAST,
+                     period_end_date ASC
+        ) bs
+        WHERE fp.instrument_id = %(iid)s
+          AND fp.source = bs.source
+          AND fp.fiscal_year = bs.fiscal_year
+          AND fp.fiscal_quarter IS NOT DISTINCT FROM bs.fiscal_quarter
+          AND fp.period_type = bs.period_type
+          AND fp.period_end_date IS DISTINCT FROM bs.period_end_date
+        """,
+        {"iid": instrument_id},
+    )
+
+    cur = conn.execute(
+        """
+        WITH best_source AS (
+            SELECT DISTINCT ON (fiscal_year, fiscal_quarter, period_type)
+                *
+            FROM financial_periods_raw
+            WHERE instrument_id = %(iid)s
+            ORDER BY fiscal_year, fiscal_quarter, period_type,
+                     CASE source
+                         WHEN 'sec_edgar' THEN 1
+                         WHEN 'companies_house' THEN 2
+                         ELSE 99
+                     END,
+                     filed_date DESC NULLS LAST,
+                     period_end_date ASC
         )
         INSERT INTO financial_periods (
             instrument_id, period_end_date, period_type,

--- a/sql/077_financial_periods_fiscal_label_unique.sql
+++ b/sql/077_financial_periods_fiscal_label_unique.sql
@@ -1,0 +1,46 @@
+-- 077_financial_periods_fiscal_label_unique.sql
+--
+-- #624: Harden financial_periods against future-arrival duplicate
+-- rows. #558 fixed existing data + same-run DEI pollution at extract;
+-- this migration closes the remaining gap where a late amendment
+-- arrives with a different period_end_date than the row already on
+-- file, and the previous canonical merge keyed on period_end_date
+-- inserted a NEW row instead of updating the existing one.
+--
+-- Add a partial unique index on the fiscal-label tuple
+-- (instrument_id, source, fiscal_year, fiscal_quarter, period_type)
+-- so the DB itself rejects a second row for the same fiscal period
+-- per source. Second-arrival inserts must come through ON CONFLICT
+-- UPDATE — the canonical merge is rewritten in the matching code
+-- change.
+--
+-- ``COALESCE(fiscal_quarter, 0)`` is needed because PostgreSQL
+-- treats NULLs in unique indexes as distinct (every NULL is a new
+-- value). FY rows have fiscal_quarter=NULL and we WANT them to
+-- collide with each other under the same (instrument, source,
+-- fiscal_year, period_type) tuple, so substitute a sentinel.
+-- 0 cannot collide with the legitimate range 1..4.
+--
+-- ``WHERE superseded_at IS NULL`` keeps the supersede mechanism
+-- intact: a row marked superseded is still on disk for audit but
+-- excluded from the unique constraint, so a fresh insert for the
+-- same fiscal label can replace it.
+--
+-- Idempotent: ``IF NOT EXISTS`` makes re-running the file a no-op.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_financial_periods_fiscal_label
+    ON financial_periods (
+        instrument_id,
+        source,
+        fiscal_year,
+        COALESCE(fiscal_quarter, 0),
+        period_type
+    )
+    WHERE superseded_at IS NULL;
+
+COMMENT ON INDEX uniq_financial_periods_fiscal_label IS
+    '#624: enforces one row per (instrument, source, fiscal_label) so '
+    'late-arriving amendments cannot insert duplicates when '
+    'period_end_date differs from the row already on file. '
+    'Migration 076 dedupe + canonical-merge rewrite are the matching '
+    'code-side guards.';

--- a/tests/test_canonical_merge_arrival_order_624.py
+++ b/tests/test_canonical_merge_arrival_order_624.py
@@ -1,0 +1,278 @@
+"""Regression tests for #624 — canonical merge must converge regardless
+of arrival order.
+
+The previous canonical merge keyed on ``(period_end_date, period_type)``,
+so a late-arriving amendment that reported the same fiscal label
+under a different ``period_end_date`` than the row already on file
+inserted a NEW canonical row instead of replacing the original. The
+fix re-keys the merge on ``(fiscal_year, fiscal_quarter, period_type)``
+plus a per-merge cleanup of stale period_end siblings.
+
+Tests seed the raw table with two rows (original + amendment) per
+fiscal label in both orders and assert ``_canonical_merge_instrument``
+ends with exactly one canonical row carrying the amendment's data.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services.fundamentals import _canonical_merge_instrument
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} test"),
+    )
+
+
+def _seed_raw(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    period_end: date,
+    period_type: str,
+    fiscal_year: int,
+    fiscal_quarter: int | None,
+    source_ref: str,
+    filed_date: date,
+    revenue: Decimal,
+    source: str = "sec_edgar",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO financial_periods_raw (
+            instrument_id, period_end_date, period_type,
+            fiscal_year, fiscal_quarter, revenue,
+            source, source_ref, reported_currency, filed_date
+        ) VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s, 'USD', %s
+        )
+        """,
+        (instrument_id, period_end, period_type, fiscal_year, fiscal_quarter, revenue, source, source_ref, filed_date),
+    )
+
+
+def _canonical_rows(
+    conn: psycopg.Connection[tuple],
+    instrument_id: int,
+) -> list[dict[str, object]]:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT period_end_date, period_type, fiscal_year, fiscal_quarter,
+                   revenue, source_ref, filed_date
+            FROM financial_periods
+            WHERE instrument_id = %s
+            ORDER BY filed_date DESC NULLS LAST, period_end_date DESC
+            """,
+            (instrument_id,),
+        )
+        return cur.fetchall()
+
+
+class TestCanonicalMergeArrivalOrder:
+    def test_amendment_after_original(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Original 10-K (period_end=2023-12-31) ingested first, then a
+        10-K/A amendment with a different period_end (2024-01-15) and
+        a later filed_date. Canonical must converge on the amendment.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=200, symbol="ORIG")
+
+        # Phase 1: original arrives.
+        _seed_raw(
+            conn,
+            instrument_id=200,
+            period_end=date(2023, 12, 31),
+            period_type="FY",
+            fiscal_year=2023,
+            fiscal_quarter=None,
+            source_ref="acc-original",
+            filed_date=date(2024, 2, 23),
+            revenue=Decimal("1000"),
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 200)
+        conn.commit()
+        rows = _canonical_rows(conn, 200)
+        assert len(rows) == 1
+        assert rows[0]["source_ref"] == "acc-original"
+        assert rows[0]["revenue"] == Decimal("1000")
+
+        # Phase 2: amendment arrives with different period_end.
+        _seed_raw(
+            conn,
+            instrument_id=200,
+            period_end=date(2024, 1, 15),
+            period_type="FY",
+            fiscal_year=2023,
+            fiscal_quarter=None,
+            source_ref="acc-amendment",
+            filed_date=date(2024, 6, 1),
+            revenue=Decimal("1100"),
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 200)
+        conn.commit()
+        rows = _canonical_rows(conn, 200)
+        assert len(rows) == 1, [dict(r) for r in rows]
+        assert rows[0]["source_ref"] == "acc-amendment"
+        assert rows[0]["revenue"] == Decimal("1100")
+        # Stale original row deleted, not left behind.
+        assert rows[0]["period_end_date"] == date(2024, 1, 15)
+
+    def test_amendment_arrives_first_then_original_does_not_overwrite(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Reverse order: amendment lands first (later filed_date,
+        different period_end). Then the *original* 10-K's raw row is
+        ingested late (out-of-order replay). The canonical row must
+        still reflect the amendment — the older original cannot
+        overwrite a newer amendment.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=201, symbol="REV")
+
+        # Amendment first (later filed_date).
+        _seed_raw(
+            conn,
+            instrument_id=201,
+            period_end=date(2024, 1, 15),
+            period_type="FY",
+            fiscal_year=2023,
+            fiscal_quarter=None,
+            source_ref="acc-amendment",
+            filed_date=date(2024, 6, 1),
+            revenue=Decimal("1100"),
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 201)
+        conn.commit()
+        rows = _canonical_rows(conn, 201)
+        assert len(rows) == 1
+        assert rows[0]["source_ref"] == "acc-amendment"
+
+        # Original 10-K's raw row arrives later (out-of-order replay).
+        _seed_raw(
+            conn,
+            instrument_id=201,
+            period_end=date(2023, 12, 31),
+            period_type="FY",
+            fiscal_year=2023,
+            fiscal_quarter=None,
+            source_ref="acc-original",
+            filed_date=date(2024, 2, 23),
+            revenue=Decimal("1000"),
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 201)
+        conn.commit()
+        rows = _canonical_rows(conn, 201)
+        assert len(rows) == 1, [dict(r) for r in rows]
+        # Amendment still wins — its filed_date is later.
+        assert rows[0]["source_ref"] == "acc-amendment"
+        assert rows[0]["revenue"] == Decimal("1100")
+        assert rows[0]["period_end_date"] == date(2024, 1, 15)
+
+    def test_same_period_end_restatement_in_place_update(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Genuine restatement: amendment files the SAME period_end as
+        the original (real fiscal calendar doesn't move). Canonical
+        row must update in place — no DELETE + INSERT churn — and
+        the latest filed_date wins.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=202, symbol="SAME")
+
+        _seed_raw(
+            conn,
+            instrument_id=202,
+            period_end=date(2024, 6, 30),
+            period_type="Q2",
+            fiscal_year=2024,
+            fiscal_quarter=2,
+            source_ref="acc-original",
+            filed_date=date(2024, 7, 30),
+            revenue=Decimal("500"),
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 202)
+        conn.commit()
+
+        _seed_raw(
+            conn,
+            instrument_id=202,
+            period_end=date(2024, 6, 30),  # SAME period_end
+            period_type="Q2",
+            fiscal_year=2024,
+            fiscal_quarter=2,
+            source_ref="acc-restatement",
+            filed_date=date(2024, 9, 12),  # later
+            revenue=Decimal("550"),
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 202)
+        conn.commit()
+
+        rows = _canonical_rows(conn, 202)
+        assert len(rows) == 1
+        assert rows[0]["source_ref"] == "acc-restatement"
+        assert rows[0]["revenue"] == Decimal("550")
+
+    def test_partial_unique_index_blocks_direct_dupe(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Migration 077 partial unique index makes a direct duplicate
+        INSERT impossible at the DB layer — even if a future code
+        path bypasses ``_canonical_merge_instrument`` and tries to
+        insert a second row for the same fiscal label, Postgres
+        rejects it.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=203, symbol="UQ")
+        conn.execute(
+            """
+            INSERT INTO financial_periods (
+                instrument_id, period_end_date, period_type,
+                fiscal_year, fiscal_quarter,
+                source, source_ref, reported_currency
+            ) VALUES (%s, %s, 'FY', %s, NULL, 'sec_edgar', 'acc-a', 'USD')
+            """,
+            (203, date(2024, 12, 31), 2024),
+        )
+        conn.commit()
+
+        # Second insert for the same fiscal label MUST raise UniqueViolation.
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            conn.execute(
+                """
+                INSERT INTO financial_periods (
+                    instrument_id, period_end_date, period_type,
+                    fiscal_year, fiscal_quarter,
+                    source, source_ref, reported_currency
+                ) VALUES (%s, %s, 'FY', %s, NULL, 'sec_edgar', 'acc-b', 'USD')
+                """,
+                (203, date(2025, 2, 1), 2024),
+            )
+        conn.rollback()

--- a/tests/test_canonical_merge_arrival_order_624.py
+++ b/tests/test_canonical_merge_arrival_order_624.py
@@ -239,6 +239,70 @@ class TestCanonicalMergeArrivalOrder:
         assert rows[0]["source_ref"] == "acc-restatement"
         assert rows[0]["revenue"] == Decimal("550")
 
+    def test_source_switch_clears_lower_priority_ghost_row(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Bot review (#625) caught the source-switch ghost case:
+
+        Run 1: companies_house has a raw row, sec_edgar does not. CH
+        wins the merge → canonical has one CH row.
+
+        Run 2: sec_edgar raw row arrives. SEC outranks CH (priority
+        1 vs 2). The merge winner switches sources. Phase B must
+        delete the now-stale CH canonical row; otherwise both rows
+        survive and the instrument page renders the same fiscal
+        label twice.
+
+        Without the fix, ``fp.source = bs.source`` filtered the
+        DELETE to the winning source only, leaving the lower-priority
+        ghost behind.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=204, symbol="MIX")
+
+        # Run 1: CH-only raw → CH canonical row.
+        _seed_raw(
+            conn,
+            instrument_id=204,
+            period_end=date(2024, 12, 31),
+            period_type="FY",
+            fiscal_year=2024,
+            fiscal_quarter=None,
+            source_ref="ch-001",
+            filed_date=date(2025, 3, 1),
+            revenue=Decimal("900"),
+            source="companies_house",
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 204)
+        conn.commit()
+        rows = _canonical_rows(conn, 204)
+        assert len(rows) == 1
+        assert rows[0]["source_ref"] == "ch-001"
+
+        # Run 2: SEC raw arrives, outranks CH on the same fiscal label.
+        _seed_raw(
+            conn,
+            instrument_id=204,
+            period_end=date(2024, 12, 31),
+            period_type="FY",
+            fiscal_year=2024,
+            fiscal_quarter=None,
+            source_ref="sec-001",
+            filed_date=date(2025, 4, 1),
+            revenue=Decimal("950"),
+            source="sec_edgar",
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 204)
+        conn.commit()
+
+        rows = _canonical_rows(conn, 204)
+        assert len(rows) == 1, [dict(r) for r in rows]
+        assert rows[0]["source_ref"] == "sec-001"
+        assert rows[0]["revenue"] == Decimal("950")
+
     def test_partial_unique_index_blocks_direct_dupe(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811


### PR DESCRIPTION
## What
- \`sql/077_financial_periods_fiscal_label_unique.sql\` — partial unique index on \`(instrument_id, source, fiscal_year, COALESCE(fiscal_quarter, 0), period_type) WHERE superseded_at IS NULL\`.
- \`_canonical_merge_instrument\` — re-keys ``DISTINCT ON`` to fiscal-label, runs DELETE-of-stale-period_end as its own statement before the INSERT, then INSERT...ON CONFLICT updates same-period_end restatements in place.

## Why
#558 cleaned existing dupes + fixed same-run DEI pollution at extract. #624 closes the future-arrival gap: a late amendment with a different period_end_date than the row already on file would land as a NEW canonical row instead of replacing the original.

## Test plan
- [x] \`uv run pytest tests/test_canonical_merge_arrival_order_624.py\` — 4 integration tests against \`ebull_test\` (amendment-after-original, amendment-first-then-out-of-order-original, same-period_end in-place restatement, direct dupe blocked by index).
- [x] \`uv run pytest -m \"not integration\"\` (2655 passed)
- [x] \`uv run ruff check . && uv run pyright\`
- [x] Migration applied cleanly on dev DB on top of #558's deduped state.

Closes #624