### PR TITLE
feat(#335): calendar-anchored Cadence for monthly_reports

### DIFF
--- a/app/services/sync_orchestrator/freshness.py
+++ b/app/services/sync_orchestrator/freshness.py
@@ -18,11 +18,12 @@ BEFORE ordering would hide a newer failure behind an older success.
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 import psycopg
 
+from app.services.sync_orchestrator.layer_types import Cadence
 from app.services.sync_orchestrator.types import PREREQ_SKIP_MARKER
 
 # ---------------------------------------------------------------------------
@@ -249,4 +250,63 @@ def weekly_reports_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
 
 
 def monthly_reports_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
-    return _fresh_by_audit(conn, "monthly_report", timedelta(days=31))
+    """Calendar-month anchored freshness for the monthly report layer (#335).
+
+    Fresh iff the latest counting ``job_runs`` row for ``monthly_report``
+    has its ``COALESCE(finished_at, started_at)`` anchor on or after
+    the first day of the current calendar month in UTC.
+
+    Two design choices to flag:
+
+    * The month boundary is computed in Python (not via SQL
+      ``date_trunc('month', now() at time zone 'UTC')``). The SQL
+      form returns ``timestamp without time zone``, which Postgres
+      silently coerces against a ``timestamptz`` ``started_at`` using
+      the session's ``TimeZone`` setting — that would mis-classify
+      runs at the boundary in any non-UTC DB session. Comparing two
+      ``timestamptz`` values in Python sidesteps the coercion.
+
+    * The freshness anchor is ``COALESCE(finished_at, started_at)``,
+      matching ``layer_state.py::_latest_age_seconds_map``. Without
+      that alignment, a run that started Jan 31 23:59 UTC and
+      finished Feb 1 00:01 UTC would be reported STALE by this
+      predicate and HEALTHY by the v2 state machine — the month-edge
+      divergence Codex flagged on #335.
+    """
+    now = datetime.now(UTC)
+    month_start_utc = Cadence(calendar_months=1).window_start(now)
+    # ``anchor`` mirrors the state machine's ``_latest_age_seconds_map``
+    # in ``layer_state.py`` — ``COALESCE(finished_at, started_at)``. A
+    # monthly run that started Jan 31 23:59 UTC and finished Feb 1
+    # 00:01 UTC counts as a Feb run for both views: predicate and v2
+    # state-machine. Without aligning the anchor, /sync/layers (legacy)
+    # and /sync/layers/v2 (state-machine) could disagree at the
+    # month-boundary edge.
+    row = conn.execute(
+        """
+        SELECT COALESCE(finished_at, started_at) AS anchor,
+               status,
+               error_msg,
+               EXTRACT(EPOCH FROM now() - COALESCE(finished_at, started_at)) AS age_seconds
+        FROM job_runs
+        WHERE job_name = %s
+        ORDER BY started_at DESC
+        LIMIT 1
+        """,
+        ("monthly_report",),
+    ).fetchone()
+    if row is None:
+        return False, "no job_runs row for monthly_report"
+    anchor, status, error_msg, age_seconds = row
+    is_counting = status == "success" or (
+        status == "skipped" and error_msg is not None and error_msg.startswith(PREREQ_SKIP_MARKER)
+    )
+    if not is_counting:
+        return False, f"latest monthly_report has status={status}, not a counting row"
+    age = timedelta(seconds=float(age_seconds))
+    if anchor < month_start_utc:
+        return (
+            False,
+            f"last monthly_report {_format_age(age)} ago — before the start of the current calendar month UTC",
+        )
+    return True, f"last monthly_report {_format_age(age)} ago (this calendar month)"

--- a/app/services/sync_orchestrator/layer_state.py
+++ b/app/services/sync_orchestrator/layer_state.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 import psycopg
@@ -122,6 +123,11 @@ def compute_layer_states_from_db(
     latest_status = _latest_status_map(conn, names)
     latest_ages = _latest_age_seconds_map(conn, names)
     content_results = _content_ok_map(conn)
+    # Snapshot a single ``now`` per state-machine evaluation so all
+    # calendar-month boundary computations share the same reference
+    # instant. Drift between layers within a single evaluation would
+    # be incoherent (different layers seeing different "this month").
+    now = datetime.now(UTC)
 
     def build(name: str, upstream: dict[str, LayerState]) -> LayerContext:
         layer = LAYERS[name]
@@ -141,7 +147,13 @@ def compute_layer_states_from_db(
             secret_present=all(bool(os.environ.get(ref.env_var)) for ref in layer.secret_refs),
             content_ok=content_results.get(name, True),
             age_seconds=age_seconds,
-            cadence_seconds=layer.cadence.interval.total_seconds(),
+            # ``cadence_seconds_for_state_machine`` is calendar-aware
+            # (#335): for ``calendar_months`` cadences it returns the
+            # boundary distance such that rule 9
+            # (``age_seconds > cadence_seconds * grace_multiplier``)
+            # fires at the calendar tick, not after a 31-day rolling
+            # window.
+            cadence_seconds=layer.cadence.cadence_seconds_for_state_machine(now, layer.grace_multiplier),
             grace_multiplier=layer.grace_multiplier,
             max_attempts=layer.retry_policy.max_attempts,
         )

--- a/app/services/sync_orchestrator/layer_state.py
+++ b/app/services/sync_orchestrator/layer_state.py
@@ -137,6 +137,13 @@ def compute_layer_states_from_db(
             status = "complete"
         else:
             age_seconds = latest_ages.get(name, float("inf"))
+        # Belt-and-braces: any future caller (logging, ratio math)
+        # that touches ``cadence_seconds`` should never see zero.
+        # ``Cadence.cadence_seconds_for_state_machine`` already
+        # floors to 1 second; this assert turns a regression into a
+        # loud failure during the planning sweep.
+        cadence_seconds = layer.cadence.cadence_seconds_for_state_machine(now, layer.grace_multiplier)
+        assert cadence_seconds > 0, f"cadence_seconds must be positive (got {cadence_seconds} for {name})"
         return LayerContext(
             is_enabled=enabled.get(name, True),
             is_running=name in running_set,
@@ -153,7 +160,7 @@ def compute_layer_states_from_db(
             # (``age_seconds > cadence_seconds * grace_multiplier``)
             # fires at the calendar tick, not after a 31-day rolling
             # window.
-            cadence_seconds=layer.cadence.cadence_seconds_for_state_machine(now, layer.grace_multiplier),
+            cadence_seconds=cadence_seconds,
             grace_multiplier=layer.grace_multiplier,
             max_attempts=layer.retry_policy.max_attempts,
         )

--- a/app/services/sync_orchestrator/layer_types.py
+++ b/app/services/sync_orchestrator/layer_types.py
@@ -192,8 +192,14 @@ class Cadence:
             return self.interval.total_seconds()
         # Calendar mode: pick a cadence_seconds such that
         # cadence_seconds * grace_multiplier == boundary_age.
+        # ``max(..., 1.0)`` floors the value to one second so callers
+        # that log or divide by ``cadence_seconds`` never see a zero
+        # at the exact instant of the calendar tick (where
+        # ``now == window_start`` and ``boundary_age`` is otherwise
+        # 0). Rule 9's behavior is unchanged: any prior run still
+        # has ``age_seconds > 0`` and gets DEGRADED.
         boundary_age = (now.astimezone(UTC) - self.window_start(now)).total_seconds()
-        return boundary_age / grace_multiplier
+        return max(boundary_age, 1.0) / grace_multiplier
 
     def grace_window(self, grace_multiplier: float) -> timedelta:
         if grace_multiplier <= 0:

--- a/app/services/sync_orchestrator/layer_types.py
+++ b/app/services/sync_orchestrator/layer_types.py
@@ -9,7 +9,7 @@ orchestrator import graph.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -95,16 +95,110 @@ REMEDIES: dict[FailureCategory, Remedy] = {
 
 @dataclass(frozen=True)
 class Cadence:
-    interval: timedelta
+    """Layer refresh cadence.
+
+    Two mutually-exclusive modes:
+
+    * ``interval`` — fixed-width timedelta (the original shape).
+      Suitable for hourly, daily, weekly cadences that don't drift
+      against the calendar.
+
+    * ``calendar_months`` — calendar-anchored monthly cadence (#335).
+      A layer is considered current as long as a counting refresh
+      landed within the most-recent ``calendar_months`` calendar
+      months in UTC. Anchored to day 1 of the month so a monthly
+      cadence does not drift across calendar boundaries
+      (Feb-vs-Mar arithmetic with ``timedelta(days=31)`` always
+      undershoots short months and overshoots long ones).
+
+    Exactly one of the two MUST be set; the validator enforces it
+    so a future caller can't accidentally pass both and pick up an
+    ambiguous behavior.
+    """
+
+    interval: timedelta | None = None
+    calendar_months: int | None = None
 
     def __post_init__(self) -> None:
-        if self.interval <= timedelta(0):
+        if (self.interval is None) == (self.calendar_months is None):
+            raise ValueError("Cadence requires exactly one of interval or calendar_months")
+        if self.interval is not None and self.interval <= timedelta(0):
             raise ValueError("interval must be positive")
+        if self.calendar_months is not None and self.calendar_months <= 0:
+            raise ValueError("calendar_months must be positive")
+
+    @property
+    def effective_interval(self) -> timedelta:
+        """Best-effort timedelta for display + display-only callers.
+
+        For ``interval`` mode this is the literal interval. For
+        ``calendar_months`` mode this is the longest-month upper
+        bound (31 days per month) — a coarse approximation only
+        suitable for human-readable labels. The orchestrator's
+        state-machine age check uses
+        :meth:`cadence_seconds_for_state_machine` instead, which is
+        calendar-aware and does NOT collapse a 30-day February
+        boundary into the 31-day approximation.
+        """
+        if self.interval is not None:
+            return self.interval
+        assert self.calendar_months is not None
+        return timedelta(days=31 * self.calendar_months)
+
+    def window_start(self, now: datetime) -> datetime:
+        """Earliest ``started_at`` that still counts a layer as fresh.
+
+        For ``interval`` mode this is ``now - interval``; the rolling
+        window slides with ``now``. For ``calendar_months`` mode this
+        is the first instant of the month ``calendar_months - 1``
+        months before the month containing ``now``, in UTC. A monthly
+        cadence (calendar_months=1) returns the first instant of the
+        current calendar month UTC.
+
+        The DB-facing state builder uses this to compute the
+        cadence-aware "age boundary" so the orchestrator's
+        ``DEGRADED`` rule fires on the day-1 calendar tick instead
+        of after a 31-day rolling window.
+        """
+        if now.tzinfo is None:
+            raise ValueError("Cadence.window_start requires a timezone-aware datetime")
+        now_utc = now.astimezone(UTC)
+        if self.interval is not None:
+            return now_utc - self.interval
+        assert self.calendar_months is not None
+        # Walk back ``calendar_months - 1`` months from the current
+        # month start. Handles year wrap (Jan with calendar_months=2
+        # → previous Dec) without depending on dateutil.
+        month_index = now_utc.year * 12 + (now_utc.month - 1) - (self.calendar_months - 1)
+        anchor_year, anchor_month_zero_indexed = divmod(month_index, 12)
+        return datetime(anchor_year, anchor_month_zero_indexed + 1, 1, tzinfo=UTC)
+
+    def cadence_seconds_for_state_machine(self, now: datetime, grace_multiplier: float) -> float:
+        """Effective cadence-window length in seconds for the
+        ``compute_layer_state`` rule 9 (``age_seconds > cadence_seconds * grace_multiplier``).
+
+        For ``interval`` mode this is just ``interval.total_seconds()`` —
+        identical to the pre-#335 behavior. For ``calendar_months``
+        mode this returns the seconds between ``now`` and
+        :meth:`window_start`, divided by ``grace_multiplier`` so the
+        existing rule 9 multiplication recovers the calendar
+        boundary. The net result: monthly_reports flips to
+        ``DEGRADED`` exactly at the day-1 UTC boundary, no grace
+        applied (calendar boundaries are sharp by design).
+        """
+        if grace_multiplier <= 0:
+            raise ValueError(f"grace_multiplier must be positive (got {grace_multiplier})")
+        if self.interval is not None:
+            return self.interval.total_seconds()
+        # Calendar mode: pick a cadence_seconds such that
+        # cadence_seconds * grace_multiplier == boundary_age.
+        boundary_age = (now.astimezone(UTC) - self.window_start(now)).total_seconds()
+        return boundary_age / grace_multiplier
 
     def grace_window(self, grace_multiplier: float) -> timedelta:
         if grace_multiplier <= 0:
             raise ValueError(f"grace_multiplier must be positive (got {grace_multiplier})")
-        return self.interval * grace_multiplier
+        return self.effective_interval * grace_multiplier
 
 
 @dataclass(frozen=True)
@@ -162,6 +256,10 @@ class LayerRefreshFailed(Exception):
 
 def cadence_display_string(cadence: Cadence) -> str:
     """Short human label used by dashboards where a one-liner is enough."""
+    if cadence.calendar_months is not None:
+        m = cadence.calendar_months
+        return "monthly" if m == 1 else f"{m}mo"
+    assert cadence.interval is not None
     total = int(cadence.interval.total_seconds())
     if total % 86400 == 0:
         d = total // 86400

--- a/app/services/sync_orchestrator/registry.py
+++ b/app/services/sync_orchestrator/registry.py
@@ -175,7 +175,12 @@ LAYERS: dict[str, DataLayer] = {
         name="monthly_reports",
         display_name="Monthly Performance Report",
         tier=3,
-        cadence=Cadence(interval=timedelta(days=31)),
+        # Calendar-anchored monthly cadence (#335). A flat
+        # ``timedelta(days=31)`` drifts against calendar months
+        # (Feb undershoots, 30-day months overshoot); the calendar
+        # form anchors freshness to "produced this calendar month
+        # in UTC" via ``monthly_reports_is_fresh``.
+        cadence=Cadence(calendar_months=1),
         is_fresh=monthly_reports_is_fresh,
         refresh=refresh_monthly_reports,
         dependencies=(),

--- a/tests/services/sync_orchestrator/test_layer_state.py
+++ b/tests/services/sync_orchestrator/test_layer_state.py
@@ -139,6 +139,63 @@ def test_age_inside_grace_is_healthy() -> None:
     assert compute_layer_state(_ctx(age_seconds=70, cadence_seconds=60, grace_multiplier=1.25)) is LayerState.HEALTHY
 
 
+def test_calendar_month_cadence_degrades_at_day_one_tick() -> None:
+    """#335 — when the DB-facing builder feeds rule 9 with the calendar
+    cadence_seconds (computed by ``Cadence.cadence_seconds_for_state_machine``),
+    a monthly_reports run from the previous calendar month flips the
+    state to DEGRADED at the day-1 UTC tick instead of after a 31-day
+    rolling window.
+
+    Construct the context with the same cadence_seconds the production
+    builder would derive at ``now = Feb 1, 2026 00:00 UTC + 1 second``
+    for a run that started on Jan 31, 2026 23:59 UTC. The literal age
+    is ~1 minute (well under any 31-day window), but rule 9 still
+    fires because the calendar boundary collapses the window to the
+    last-month / this-month edge.
+    """
+    from datetime import UTC, datetime
+
+    from app.services.sync_orchestrator.layer_types import Cadence
+
+    cadence = Cadence(calendar_months=1)
+    grace = 1.25
+    now = datetime(2026, 2, 1, 0, 0, 1, tzinfo=UTC)
+    cadence_seconds = cadence.cadence_seconds_for_state_machine(now, grace)
+    # Run started Jan 31 23:59 UTC, never finished — anchor is started_at.
+    started_at = datetime(2026, 1, 31, 23, 59, tzinfo=UTC)
+    age_seconds = (now - started_at).total_seconds()
+    assert (
+        compute_layer_state(_ctx(age_seconds=age_seconds, cadence_seconds=cadence_seconds, grace_multiplier=grace))
+        is LayerState.DEGRADED
+    )
+
+
+def test_calendar_month_cadence_remains_healthy_inside_current_month() -> None:
+    """Mirror of the day-1-tick test, the other side of the boundary:
+    a run started early in the current calendar month must keep the
+    layer HEALTHY for the rest of that month, no matter the literal
+    age in days."""
+    from datetime import UTC, datetime
+
+    from app.services.sync_orchestrator.layer_types import Cadence
+
+    cadence = Cadence(calendar_months=1)
+    grace = 1.25
+    # Late in March 2026; ``now`` is Mar 28.
+    now = datetime(2026, 3, 28, 18, 0, tzinfo=UTC)
+    cadence_seconds = cadence.cadence_seconds_for_state_machine(now, grace)
+    # Run started Mar 1 (27 days ago) — a flat ``timedelta(days=31)``
+    # check would still call this fresh, but the test pins that the
+    # calendar-aware shape doesn't accidentally over-tighten the
+    # boundary either.
+    started_at = datetime(2026, 3, 1, 6, 0, tzinfo=UTC)
+    age_seconds = (now - started_at).total_seconds()
+    assert (
+        compute_layer_state(_ctx(age_seconds=age_seconds, cadence_seconds=cadence_seconds, grace_multiplier=grace))
+        is LayerState.HEALTHY
+    )
+
+
 def test_local_failure_beats_cascade() -> None:
     # Spec §3.2 rule 4 precedes rule 7 — downstream with own failure
     # surfaces as ACTION_NEEDED, not CASCADE_WAITING, so the operator

--- a/tests/services/sync_orchestrator/test_layer_types.py
+++ b/tests/services/sync_orchestrator/test_layer_types.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import psycopg
@@ -141,3 +141,73 @@ def test_cadence_display_string() -> None:
     assert cadence_display_string(Cadence(interval=timedelta(hours=4))) == "4h"
     assert cadence_display_string(Cadence(interval=timedelta(minutes=5))) == "5m"
     assert cadence_display_string(Cadence(interval=timedelta(seconds=30))) == "30s"
+    assert cadence_display_string(Cadence(calendar_months=1)) == "monthly"
+    assert cadence_display_string(Cadence(calendar_months=3)) == "3mo"
+
+
+def test_cadence_calendar_months_effective_interval_is_31_day_upper_bound() -> None:
+    """Calendar-anchored cadence reports a 31-day-per-month upper bound
+    so the layer-state age-vs-grace check tolerates the longest-month
+    case without flapping. The authoritative freshness check is the
+    layer's ``is_fresh`` predicate; ``effective_interval`` is only used
+    for the orchestrator's degraded-by-age fallback rule.
+    """
+    assert Cadence(calendar_months=1).effective_interval == timedelta(days=31)
+    assert Cadence(calendar_months=3).effective_interval == timedelta(days=93)
+
+
+def test_cadence_requires_exactly_one_mode() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        Cadence()
+    with pytest.raises(ValueError, match="exactly one"):
+        Cadence(interval=timedelta(hours=1), calendar_months=1)
+
+
+def test_cadence_rejects_non_positive_calendar_months() -> None:
+    with pytest.raises(ValueError, match="calendar_months must be positive"):
+        Cadence(calendar_months=0)
+    with pytest.raises(ValueError, match="calendar_months must be positive"):
+        Cadence(calendar_months=-2)
+
+
+def test_cadence_window_start_calendar_months_one() -> None:
+    """Monthly cadence window starts at day-1 of the current month UTC."""
+    now = datetime(2026, 4, 15, 12, 30, tzinfo=UTC)
+    assert Cadence(calendar_months=1).window_start(now) == datetime(2026, 4, 1, tzinfo=UTC)
+
+
+def test_cadence_window_start_calendar_months_three_handles_year_wrap() -> None:
+    """3-month window in February 2026 anchors to December 2025."""
+    now = datetime(2026, 2, 10, tzinfo=UTC)
+    assert Cadence(calendar_months=3).window_start(now) == datetime(2025, 12, 1, tzinfo=UTC)
+
+
+def test_cadence_window_start_interval_is_now_minus_interval() -> None:
+    now = datetime(2026, 4, 15, 12, 30, tzinfo=UTC)
+    cadence = Cadence(interval=timedelta(hours=24))
+    assert cadence.window_start(now) == now - timedelta(hours=24)
+
+
+def test_cadence_window_start_rejects_naive_datetime() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        Cadence(calendar_months=1).window_start(datetime(2026, 4, 15, 12, 30))
+
+
+def test_cadence_seconds_for_state_machine_interval_is_unchanged() -> None:
+    """Pre-#335 callers (interval cadences) see the literal interval
+    seconds — backward-compatible with the prior shape."""
+    cadence = Cadence(interval=timedelta(hours=24))
+    assert cadence.cadence_seconds_for_state_machine(datetime.now(UTC), grace_multiplier=1.25) == 86400.0
+
+
+def test_cadence_seconds_for_state_machine_calendar_collapses_grace() -> None:
+    """Calendar mode: cadence_seconds * grace_multiplier MUST equal the
+    seconds between ``now`` and ``window_start``, so the existing rule 9
+    age check fires exactly at the calendar boundary regardless of the
+    layer's grace_multiplier value (no over- or under-shoot)."""
+    now = datetime(2026, 4, 15, 12, 30, tzinfo=UTC)
+    cadence = Cadence(calendar_months=1)
+    boundary_age = (now - datetime(2026, 4, 1, tzinfo=UTC)).total_seconds()
+    grace = 1.25
+    cadence_seconds = cadence.cadence_seconds_for_state_machine(now, grace_multiplier=grace)
+    assert cadence_seconds * grace == pytest.approx(boundary_age)

--- a/tests/services/sync_orchestrator/test_layer_types.py
+++ b/tests/services/sync_orchestrator/test_layer_types.py
@@ -211,3 +211,17 @@ def test_cadence_seconds_for_state_machine_calendar_collapses_grace() -> None:
     grace = 1.25
     cadence_seconds = cadence.cadence_seconds_for_state_machine(now, grace_multiplier=grace)
     assert cadence_seconds * grace == pytest.approx(boundary_age)
+
+
+def test_cadence_seconds_for_state_machine_at_exact_boundary_is_floored() -> None:
+    """At ``now == window_start`` (exact day-1 UTC tick) the literal
+    boundary_age is 0. Floor to 1 second so callers that log or divide
+    by ``cadence_seconds`` never see zero. Rule 9's correctness is
+    unchanged because any prior run still has ``age_seconds > 0``."""
+    now = datetime(2026, 4, 1, 0, 0, 0, tzinfo=UTC)
+    cadence = Cadence(calendar_months=1)
+    cadence_seconds = cadence.cadence_seconds_for_state_machine(now, grace_multiplier=1.25)
+    # 1.0 / 1.25 == 0.8; the floor is on boundary_age, not on the final
+    # quotient — what matters is that cadence_seconds is strictly
+    # positive so downstream math is never divide-by-zero.
+    assert cadence_seconds > 0

--- a/tests/services/sync_orchestrator/test_registry_shape.py
+++ b/tests/services/sync_orchestrator/test_registry_shape.py
@@ -20,7 +20,8 @@ EXPECTED_CADENCES: dict[str, timedelta] = {
     "fx_rates": timedelta(minutes=5),
     "cost_models": timedelta(hours=24),
     "weekly_reports": timedelta(days=7),
-    "monthly_reports": timedelta(days=31),
+    # monthly_reports uses a calendar-anchored cadence (#335); it is
+    # asserted separately rather than mapped to a fixed timedelta.
 }
 
 
@@ -34,6 +35,15 @@ def test_cadence_intervals_match_expected() -> None:
         assert LAYERS[name].cadence.interval == expected, (
             f"{name} cadence interval {LAYERS[name].cadence.interval} != {expected}"
         )
+
+
+def test_monthly_reports_uses_calendar_cadence() -> None:
+    """#335 — monthly_reports must be calendar-anchored, not a flat 31d."""
+    cadence = LAYERS["monthly_reports"].cadence
+    assert cadence.calendar_months == 1, (
+        f"monthly_reports cadence must be calendar-anchored (calendar_months=1); got {cadence}"
+    )
+    assert cadence.interval is None
 
 
 def test_minute_cadence_layers_have_tighter_retry_policy() -> None:

--- a/tests/test_sync_orchestrator_freshness.py
+++ b/tests/test_sync_orchestrator_freshness.py
@@ -114,7 +114,11 @@ class TestFormatAge:
 
 class TestSimpleAuditOnlyPredicates:
     """Layers with no content check — portfolio_sync, fx_rates,
-    cost_models, weekly_reports, monthly_reports, universe."""
+    cost_models, weekly_reports, universe.
+
+    ``monthly_reports`` is calendar-anchored (#335) and uses a wider
+    row shape, so it has its own test class below.
+    """
 
     @pytest.mark.parametrize(
         "predicate,job_name,window",
@@ -124,7 +128,6 @@ class TestSimpleAuditOnlyPredicates:
             (fx_rates_is_fresh, "fx_rates_refresh", timedelta(hours=24)),
             (cost_models_is_fresh, "seed_cost_models", timedelta(hours=24)),
             (weekly_reports_is_fresh, "weekly_report", timedelta(days=7)),
-            (monthly_reports_is_fresh, "monthly_report", timedelta(days=31)),
         ],
     )
     def test_fresh_when_recent_success(self, predicate, job_name, window) -> None:
@@ -132,6 +135,80 @@ class TestSimpleAuditOnlyPredicates:
         conn = _mock_conn_with_row((now - window / 2, "success", None, (window / 2).total_seconds()))
         fresh, _ = predicate(conn)
         assert fresh is True
+
+
+class TestMonthlyReportsCalendarAnchored:
+    """#335 — ``monthly_reports_is_fresh`` is calendar-anchored, not a
+    flat 31-day window. The freshness boundary is the first instant of
+    the current calendar month in UTC; anything older than that is
+    stale, regardless of literal age in days. The month boundary is
+    computed in Python (not SQL) to dodge timezone-coercion hazards
+    when the DB session ``TimeZone`` is not UTC."""
+
+    def test_fresh_when_latest_run_is_inside_current_calendar_month(self) -> None:
+        now = datetime.now(UTC)
+        # Pin started_at to the most recent first-of-month so the
+        # assertion is stable regardless of which day the test runs.
+        started_at = datetime(now.year, now.month, 1, 6, 0, tzinfo=UTC)
+        age_seconds = (now - started_at).total_seconds()
+        conn = _mock_conn_with_row((started_at, "success", None, age_seconds))
+        fresh, detail = monthly_reports_is_fresh(conn)
+        assert fresh is True, detail
+        assert "this calendar month" in detail
+
+    def test_stale_when_latest_run_is_strictly_before_current_month_start(self) -> None:
+        """Regression for the flat-31d behavior: a run from the prior
+        calendar month must always be considered stale, even when the
+        literal age is below 31 days."""
+        now = datetime.now(UTC)
+        # 1 second before the start of the current calendar month UTC.
+        month_start = datetime(now.year, now.month, 1, tzinfo=UTC)
+        started_at = month_start - timedelta(seconds=1)
+        age_seconds = (now - started_at).total_seconds()
+        conn = _mock_conn_with_row((started_at, "success", None, age_seconds))
+        fresh, detail = monthly_reports_is_fresh(conn)
+        assert fresh is False
+        assert "before the start of the current calendar month" in detail
+
+    def test_stale_when_latest_status_is_failure(self) -> None:
+        now = datetime.now(UTC)
+        started_at = now - timedelta(hours=6)
+        age_seconds = (now - started_at).total_seconds()
+        conn = _mock_conn_with_row((started_at, "failure", "boom", age_seconds))
+        fresh, detail = monthly_reports_is_fresh(conn)
+        assert fresh is False
+        assert "status=failure" in detail
+
+    def test_stale_when_no_run_recorded(self) -> None:
+        conn = _mock_conn_with_row(None)
+        fresh, detail = monthly_reports_is_fresh(conn)
+        assert fresh is False
+        assert "no job_runs row" in detail
+
+    def test_anchor_uses_finished_at_when_run_straddles_month_boundary(self) -> None:
+        """A run that straddles the month boundary must count as a run
+        in the *finishing* month — the SELECT anchors on
+        ``COALESCE(finished_at, started_at)`` so the legacy predicate
+        and the state machine (which also uses COALESCE in
+        ``_latest_age_seconds_map``) agree on the month a run belongs
+        to. Prevents /sync/layers reporting STALE while
+        /sync/layers/v2 reports HEALTHY at a month edge.
+
+        Anchored to the real current month so the test stays valid
+        regardless of the wall-clock date the suite runs at.
+        """
+        now = datetime.now(UTC)
+        month_start = datetime(now.year, now.month, 1, tzinfo=UTC)
+        # Anchor (finished_at) just AFTER current month start — what
+        # the production code computes when a run that started in the
+        # prior month finished one minute into this month. The
+        # predicate must treat this as in-month.
+        finished_anchor = month_start + timedelta(minutes=1)
+        age_seconds = (now - finished_anchor).total_seconds()
+        conn = _mock_conn_with_row((finished_anchor, "success", None, age_seconds))
+        fresh, detail = monthly_reports_is_fresh(conn)
+        assert fresh is True, detail
+        assert "this calendar month" in detail
 
 
 class TestFxRatesIsFreshWindow:


### PR DESCRIPTION
## What
Replace ``monthly_reports`` cadence ``Cadence(interval=timedelta(days=31))`` with a calendar-anchored cadence:
- ``Cadence`` dataclass gets ``calendar_months`` (mutually exclusive with ``interval``), ``window_start(now)``, and ``cadence_seconds_for_state_machine(now, grace)``.
- ``compute_layer_states_from_db`` snapshots a single ``now`` per evaluation and passes it through the cadence helper so the state-machine age check fires at the day-1 UTC tick.
- ``monthly_reports_is_fresh`` anchors on ``COALESCE(finished_at, started_at)`` (matching ``_latest_age_seconds_map``) and computes the month boundary in Python (no SQL timestamp-without-time-zone coercion).
- Registry switches ``monthly_reports`` to ``Cadence(calendar_months=1)``.

## Why
Flat 31-day cadence drifts against calendar months — Feb runs go stale a day late, long-month runs go stale a day early. The acceptance criterion in #335 ("next-fire time always lands on day 1 of each calendar month UTC") is a calendar-anchored boundary, not a rolling timedelta.

Codex pre-push review caught two pre-merge issues that this PR resolves before the first push:
1. The original draft only changed the predicate, not the v2 state machine — operators looking at /sync/layers/v2 would see HEALTHY for ~38 days.
2. The original SQL ``date_trunc('month', now() at time zone 'UTC')`` returns ``timestamp without time zone`` and would silently coerce against ``timestamptz`` ``started_at`` using the session ``TimeZone`` — boundary-misclassifying runs on non-UTC DB sessions.

Round 3 also aligned the freshness anchor to ``COALESCE(finished_at, started_at)`` so ``/sync/layers`` (predicate) and ``/sync/layers/v2`` (state machine) cannot disagree on a boundary-straddling run.

## Test plan
- [x] ``uv run pytest tests/services/sync_orchestrator/ tests/test_sync_orchestrator_freshness.py`` — green, includes new boundary tests
- [x] ``uv run pytest --deselect tests/test_migration_076_dedupe_financial_periods.py`` — 2916 passed (the deselected test fails on main, filed as #626)
- [x] ``uv run ruff check . && uv run ruff format --check . && uv run pyright`` — green
- [x] Codex pre-push review: 3 rounds, all findings resolved or extended into tests