### PR TITLE
feat(#346): audit trail + reason for layer_enabled toggles

### DIFF
--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -513,9 +513,13 @@ def post_layer_enabled(
     # otherwise be able to flip ``fx_rates`` or ``portfolio_sync`` off
     # without operator attribution, which is inconsistent with the
     # kill-switch / live-trading toggles.
+    # Trim once so both the safety gate and the audit row see the same
+    # value — passing the unstripped form to set_layer_enabled would
+    # store leading/trailing whitespace despite the gate having
+    # rejected it.
+    reason_trimmed = body.reason.strip() if body.reason is not None else None
     if not body.enabled and layer_name in SAFETY_CRITICAL_LAYERS:
-        reason = (body.reason or "").strip()
-        if not reason:
+        if not reason_trimmed:
             raise HTTPException(
                 status_code=400,
                 detail=(f"layer '{layer_name}' is safety-critical; supply a non-empty 'reason' to disable it."),
@@ -524,7 +528,7 @@ def post_layer_enabled(
         conn,
         layer_name,
         enabled=body.enabled,
-        reason=body.reason,
+        reason=reason_trimmed,
         changed_by=body.changed_by,
     )
     conn.commit()

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -25,7 +25,7 @@ from app.services.fundamentals_observability import (
     get_cik_timing_summary,
     get_seed_progress,
 )
-from app.services.layer_enabled import set_layer_enabled
+from app.services.layer_enabled import SAFETY_CRITICAL_LAYERS, set_layer_enabled
 from app.services.sync_orchestrator import (
     ExecutionPlan,
     SyncAlreadyRunning,
@@ -145,6 +145,12 @@ class SyncLayersV2Response(BaseModel):
 
 class LayerEnabledRequest(BaseModel):
     enabled: bool
+    # #346: safety-critical layers (``fx_rates`` / ``portfolio_sync``)
+    # require a non-empty ``reason`` when ``enabled=False``; the
+    # endpoint enforces this. Other layers may include reason +
+    # changed_by for audit completeness without strict enforcement.
+    reason: str | None = None
+    changed_by: str | None = None
 
 
 class LayerEnabledResponse(BaseModel):
@@ -502,7 +508,25 @@ def post_layer_enabled(
     """
     if layer_name not in LAYERS:
         raise HTTPException(status_code=404, detail=f"unknown layer: {layer_name}")
-    set_layer_enabled(conn, layer_name, enabled=body.enabled)
+    # #346: safety-critical disables MUST carry a reason. Direct API
+    # / service-token callers (no UI confirm dialog in the loop) would
+    # otherwise be able to flip ``fx_rates`` or ``portfolio_sync`` off
+    # without operator attribution, which is inconsistent with the
+    # kill-switch / live-trading toggles.
+    if not body.enabled and layer_name in SAFETY_CRITICAL_LAYERS:
+        reason = (body.reason or "").strip()
+        if not reason:
+            raise HTTPException(
+                status_code=400,
+                detail=(f"layer '{layer_name}' is safety-critical; supply a non-empty 'reason' to disable it."),
+            )
+    set_layer_enabled(
+        conn,
+        layer_name,
+        enabled=body.enabled,
+        reason=body.reason,
+        changed_by=body.changed_by,
+    )
     conn.commit()
     return LayerEnabledResponse(
         layer=layer_name,
@@ -553,7 +577,13 @@ def post_ingest_enabled(
             status_code=404,
             detail=f"unknown ingest key: {key}; allowed: {sorted(INGEST_TOGGLES)}",
         )
-    set_layer_enabled(conn, key, enabled=body.enabled)
+    set_layer_enabled(
+        conn,
+        key,
+        enabled=body.enabled,
+        reason=body.reason,
+        changed_by=body.changed_by,
+    )
     conn.commit()
     return IngestToggleResponse(
         key=key,

--- a/app/services/layer_enabled.py
+++ b/app/services/layer_enabled.py
@@ -3,6 +3,13 @@
 Default: enabled. Absent row counts as enabled so adding a new layer
 to the registry never surprises an operator with a disabled-by-default
 row.
+
+Audit (#346): every toggle writes both the latest-state row on
+``layer_enabled`` (reason + changed_by denormalised for hot-path reads)
+and an append-only ``layer_enabled_audit`` row for the full history.
+Safety-critical disables (``fx_rates`` / ``portfolio_sync``) require a
+reason at the API boundary; this module trusts callers to supply one
+when policy demands it.
 """
 
 from __future__ import annotations
@@ -10,6 +17,12 @@ from __future__ import annotations
 from typing import Any
 
 import psycopg
+
+# Layers whose disable carries operational risk (broker drift, P&L
+# drift). The API boundary refuses ``enabled=False`` without a
+# ``reason`` for these names; documented here so the policy lives next
+# to the data definition rather than buried in HTTP-handler code.
+SAFETY_CRITICAL_LAYERS: frozenset[str] = frozenset({"fx_rates", "portfolio_sync"})
 
 
 def is_layer_enabled(conn: psycopg.Connection[Any], layer_name: str) -> bool:
@@ -27,16 +40,36 @@ def set_layer_enabled(
     layer_name: str,
     *,
     enabled: bool,
+    reason: str | None = None,
+    changed_by: str | None = None,
 ) -> None:
+    """Toggle a layer and write a full-history audit row (#346).
+
+    Both writes go on the caller-supplied connection; commit is the
+    caller's responsibility (matches the rest of this module's
+    contract — see e.g. ``layer_enabled.set_layer_enabled`` in
+    ``app/api/sync.py`` which commits after the call). The audit row
+    and the latest-state row therefore land atomically: a crash mid-
+    function rolls back both.
+    """
     conn.execute(
         """
-        INSERT INTO layer_enabled (layer_name, is_enabled, updated_at)
-        VALUES (%s, %s, now())
+        INSERT INTO layer_enabled (layer_name, is_enabled, reason, changed_by, updated_at)
+        VALUES (%s, %s, %s, %s, now())
         ON CONFLICT (layer_name) DO UPDATE
           SET is_enabled = EXCLUDED.is_enabled,
+              reason     = EXCLUDED.reason,
+              changed_by = EXCLUDED.changed_by,
               updated_at = now()
         """,
-        (layer_name, enabled),
+        (layer_name, enabled, reason, changed_by),
+    )
+    conn.execute(
+        """
+        INSERT INTO layer_enabled_audit (layer_name, is_enabled, reason, changed_by)
+        VALUES (%s, %s, %s, %s)
+        """,
+        (layer_name, enabled, reason, changed_by),
     )
 
 

--- a/sql/078_layer_enabled_audit.sql
+++ b/sql/078_layer_enabled_audit.sql
@@ -1,0 +1,43 @@
+-- 078_layer_enabled_audit.sql
+--
+-- #346: audit trail + reason string for layer_enabled toggles.
+--
+-- Before this migration, ``POST /sync/layers/{name}/enabled`` accepted
+-- only ``{enabled}`` and stored a single bit on ``layer_enabled``. A
+-- direct API caller (or anyone with a service token) could disable
+-- ``fx_rates`` / ``portfolio_sync`` without a reason or operator
+-- attribution — inconsistent with the kill-switch / live-trading
+-- toggles which already require ``reason`` + ``activated_by`` and
+-- write audit rows.
+--
+-- This migration:
+--   1. Adds ``reason`` and ``changed_by`` columns to ``layer_enabled``
+--      so the latest toggle's context is queryable from the same row
+--      the orchestrator already reads.
+--   2. Adds ``layer_enabled_audit`` so toggle history is preserved
+--      across overwrites; the latest-row columns are denormalised but
+--      the full sequence lives here.
+--
+-- Idempotent: ``ADD COLUMN IF NOT EXISTS`` + ``CREATE TABLE IF NOT
+-- EXISTS`` make re-running the file a no-op.
+
+ALTER TABLE layer_enabled
+    ADD COLUMN IF NOT EXISTS reason     TEXT,
+    ADD COLUMN IF NOT EXISTS changed_by TEXT;
+
+CREATE TABLE IF NOT EXISTS layer_enabled_audit (
+    audit_id    BIGSERIAL PRIMARY KEY,
+    layer_name  TEXT NOT NULL,
+    is_enabled  BOOLEAN NOT NULL,
+    reason      TEXT,
+    changed_by  TEXT,
+    changed_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_layer_enabled_audit_layer_changed_at
+    ON layer_enabled_audit(layer_name, changed_at DESC);
+
+COMMENT ON TABLE layer_enabled_audit IS
+    '#346: append-only history of every layer_enabled toggle. The '
+    'latest reason/changed_by are denormalised onto layer_enabled '
+    'itself for hot-path reads; this table is the audit trail.';

--- a/tests/api/test_orders_safety_layers.py
+++ b/tests/api/test_orders_safety_layers.py
@@ -16,7 +16,10 @@ from fastapi.testclient import TestClient
 
 @pytest.mark.integration
 def test_manual_buy_blocked_when_fx_rates_disabled(clean_client: TestClient) -> None:
-    clean_client.post("/sync/layers/fx_rates/enabled", json={"enabled": False})
+    clean_client.post(
+        "/sync/layers/fx_rates/enabled",
+        json={"enabled": False, "reason": "test", "changed_by": "pytest"},
+    )
     try:
         resp = clean_client.post(
             "/portfolio/orders",
@@ -32,7 +35,10 @@ def test_manual_buy_blocked_when_fx_rates_disabled(clean_client: TestClient) -> 
 
 @pytest.mark.integration
 def test_manual_buy_blocked_when_portfolio_sync_disabled(clean_client: TestClient) -> None:
-    clean_client.post("/sync/layers/portfolio_sync/enabled", json={"enabled": False})
+    clean_client.post(
+        "/sync/layers/portfolio_sync/enabled",
+        json={"enabled": False, "reason": "test", "changed_by": "pytest"},
+    )
     try:
         resp = clean_client.post(
             "/portfolio/orders",

--- a/tests/api/test_sync_layer_enabled_endpoint.py
+++ b/tests/api/test_sync_layer_enabled_endpoint.py
@@ -21,7 +21,10 @@ def test_post_layer_enabled_happy_path(clean_client: TestClient) -> None:
 @pytest.mark.integration
 def test_post_layer_enabled_fx_rates_disable_warning(clean_client: TestClient) -> None:
     try:
-        resp = clean_client.post("/sync/layers/fx_rates/enabled", json={"enabled": False})
+        resp = clean_client.post(
+            "/sync/layers/fx_rates/enabled",
+            json={"enabled": False, "reason": "test", "changed_by": "pytest"},
+        )
         assert resp.status_code == 200
         body = resp.json()
         assert body["is_enabled"] is False
@@ -34,7 +37,10 @@ def test_post_layer_enabled_fx_rates_disable_warning(clean_client: TestClient) -
 @pytest.mark.integration
 def test_post_layer_enabled_portfolio_sync_disable_warning(clean_client: TestClient) -> None:
     try:
-        resp = clean_client.post("/sync/layers/portfolio_sync/enabled", json={"enabled": False})
+        resp = clean_client.post(
+            "/sync/layers/portfolio_sync/enabled",
+            json={"enabled": False, "reason": "test", "changed_by": "pytest"},
+        )
         assert resp.status_code == 200
         body = resp.json()
         assert body["warning"] is not None
@@ -42,6 +48,46 @@ def test_post_layer_enabled_portfolio_sync_disable_warning(clean_client: TestCli
         assert "broker" in warning_lower or "portfolio" in warning_lower
     finally:
         clean_client.post("/sync/layers/portfolio_sync/enabled", json={"enabled": True})
+
+
+@pytest.mark.integration
+def test_post_layer_enabled_safety_critical_disable_requires_reason(clean_client: TestClient) -> None:
+    """#346 — fx_rates / portfolio_sync disables MUST carry a reason.
+    Without a reason, the API returns 400 and never writes the toggle.
+    """
+    for layer_name in ("fx_rates", "portfolio_sync"):
+        # Missing reason
+        resp = clean_client.post(f"/sync/layers/{layer_name}/enabled", json={"enabled": False})
+        assert resp.status_code == 400, f"{layer_name} no-reason: {resp.text}"
+        assert "safety-critical" in resp.json()["detail"]
+        # Empty / whitespace-only reason
+        resp = clean_client.post(
+            f"/sync/layers/{layer_name}/enabled",
+            json={"enabled": False, "reason": "   "},
+        )
+        assert resp.status_code == 400, f"{layer_name} blank-reason: {resp.text}"
+
+
+@pytest.mark.integration
+def test_post_layer_enabled_safety_critical_enable_does_not_require_reason(
+    clean_client: TestClient,
+) -> None:
+    """The reason gate is asymmetric: disable requires it, enable
+    does not. Re-enabling a layer is the safe direction; making the
+    operator type a justification to UN-pause would just delay safety.
+    """
+    # Pre-disable with a reason, then verify re-enable without one is OK.
+    pre = clean_client.post(
+        "/sync/layers/fx_rates/enabled",
+        json={"enabled": False, "reason": "setup"},
+    )
+    assert pre.status_code == 200
+    try:
+        resp = clean_client.post("/sync/layers/fx_rates/enabled", json={"enabled": True})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["is_enabled"] is True
+    finally:
+        clean_client.post("/sync/layers/fx_rates/enabled", json={"enabled": True})
 
 
 @pytest.mark.integration

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -55,6 +55,10 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # it in the planner truncation set so a failed test cannot leak
     # a disabled state across the next function-scoped run and
     # silently make subsequent "not paused" assertions trip.
+    # layer_enabled_audit is the #346 append-only history table — also
+    # truncated so audit-row leakage between cases doesn't make a
+    # later assertion observe a phantom prior toggle.
+    "layer_enabled_audit",
     "layer_enabled",
     "external_identifiers",
     "external_data_watermarks",

--- a/tests/services/test_layer_enabled.py
+++ b/tests/services/test_layer_enabled.py
@@ -33,7 +33,48 @@ def test_read_all_enabled_batched() -> None:
     with psycopg.connect(_test_database_url()) as conn:
         conn.execute("DELETE FROM layer_enabled WHERE layer_name = ANY(%s)", (["news", "thesis", "fx_rates"],))
         conn.commit()
-        set_layer_enabled(conn, "news", enabled=False)
+        set_layer_enabled(conn, "news", enabled=False, reason="batched-read test", changed_by="pytest")
         conn.commit()
         result = read_all_enabled(conn, ["news", "thesis", "fx_rates"])
     assert result == {"news": False, "thesis": True, "fx_rates": True}
+
+
+@pytest.mark.integration
+def test_set_layer_enabled_persists_reason_and_changed_by() -> None:
+    """#346: latest-state row carries reason + changed_by for hot-path
+    reads (no second query needed to surface 'why is this disabled?')."""
+    with psycopg.connect(_test_database_url()) as conn:
+        conn.execute("DELETE FROM layer_enabled WHERE layer_name = %s", ("candles",))
+        conn.execute("DELETE FROM layer_enabled_audit WHERE layer_name = %s", ("candles",))
+        conn.commit()
+        set_layer_enabled(conn, "candles", enabled=False, reason="provider 5xx storm", changed_by="ops@example.com")
+        conn.commit()
+        row = conn.execute(
+            "SELECT is_enabled, reason, changed_by FROM layer_enabled WHERE layer_name = %s",
+            ("candles",),
+        ).fetchone()
+    assert row == (False, "provider 5xx storm", "ops@example.com")
+
+
+@pytest.mark.integration
+def test_set_layer_enabled_writes_audit_row_per_toggle() -> None:
+    """#346: every toggle appends a layer_enabled_audit row so the
+    full sequence is queryable, not just the most-recent state."""
+    with psycopg.connect(_test_database_url()) as conn:
+        conn.execute("DELETE FROM layer_enabled WHERE layer_name = %s", ("candles",))
+        conn.execute("DELETE FROM layer_enabled_audit WHERE layer_name = %s", ("candles",))
+        conn.commit()
+        set_layer_enabled(conn, "candles", enabled=False, reason="r1", changed_by="op1")
+        conn.commit()
+        set_layer_enabled(conn, "candles", enabled=True, reason="r2", changed_by="op2")
+        conn.commit()
+        rows = conn.execute(
+            """
+            SELECT is_enabled, reason, changed_by
+            FROM layer_enabled_audit
+            WHERE layer_name = %s
+            ORDER BY changed_at ASC, audit_id ASC
+            """,
+            ("candles",),
+        ).fetchall()
+    assert rows == [(False, "r1", "op1"), (True, "r2", "op2")]


### PR DESCRIPTION
## What
Close the operator-attribution gap on \`layer_enabled\` toggles:
- \`layer_enabled\` gains \`reason\` + \`changed_by\` (sql/078).
- New \`layer_enabled_audit\` table preserves the full toggle history.
- \`set_layer_enabled\` writes both rows on the caller's connection.
- \`POST /sync/layers/{name}/enabled\` rejects safety-critical disables (\`fx_rates\`, \`portfolio_sync\`) without a non-empty reason — 400 before any write.
- \`POST /sync/ingest/{key}/enabled\` routes through the same service so both endpoints emit audit rows.

## Why
Before this PR a direct API / service-token caller could disable \`fx_rates\` (live P&L drift) or \`portfolio_sync\` (broker drift) without leaving a trace or attribution — inconsistent with the kill-switch / live-trading toggles. Issue #346 calls out that the UI's \`window.confirm\` is not enforcement; this PR puts the gate at the API boundary and the audit row in the database.

The reason gate is asymmetric: required on disable, not required on enable. Re-enabling is the safe direction; making the operator type a justification to UN-pause would just delay safety.

## Test plan
- [x] \`uv run pytest tests/services/test_layer_enabled.py tests/api/test_sync_layer_enabled_endpoint.py tests/api/test_orders_safety_layers.py tests/test_execution_guard_safety_layers.py tests/test_order_client_safety_layers.py\` — green
- [x] Full suite \`uv run pytest --deselect tests/test_migration_076_dedupe_financial_periods.py\` — 2921 passed (the deselected test fails on main, filed as #626)
- [x] \`uv run ruff check . && uv run ruff format --check . && uv run pyright\` — green
- [x] Codex pre-push review: caught the migration file being untracked; resolved before first push

## Out of scope (deliberate)
- UI prompt for the reason input. The HTTP gate alone unblocks the audit-trail requirement; the UI textarea is a frontend follow-up that should land alongside whichever Admin redesign claims this surface.