### PR TITLE
ci(#247, #598): run backend tests + frontend tests + supply-chain audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,126 @@ jobs:
 
       - name: Pyright typecheck
         run: uv run pyright
+
+  pytest:
+    # #247: run backend test suite. Postgres service is required; the
+    # smoke test (tests/smoke/test_app_boots.py) drives the FastAPI
+    # lifespan against a live DB and is the canonical gate against
+    # broken migrations / lifespan-only failures. Without a real
+    # Postgres, the integration tests skip and merge gates regress.
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ebull
+        ports:
+          - 5432:5432
+        # Service must be ready before the suite starts; without
+        # health-check args the runner moves on while the server is
+        # still booting and the first connection attempt errors.
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      EBULL_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ebull
+      # Deterministic 32-byte base64 key used only for CI. Real
+      # deployments derive this per-environment via ADR 0001 — never
+      # share this value with prod.
+      EBULL_SECRETS_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+      # Tests that hit the bearer-auth path require this to be set
+      # and ≥32 chars; pick a fixed-but-non-prod token.
+      EBULL_SERVICE_TOKEN: ci-service-token-0123456789abcdef
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run backend pytest
+        # Deselect the test that fails on main (#626 — pre-existing
+        # uniq_financial_periods_fiscal_label collision in the
+        # migration 076 dedupe fixture). Remove the deselect once #626
+        # lands.
+        run: uv run pytest --deselect tests/test_migration_076_dedupe_financial_periods.py
+
+  supply-chain:
+    # #598: catch yanked / phantom / advisory-laden lockfile entries
+    # before merge. Runs alongside the frontend / backend lint jobs;
+    # advisories block the merge so a CVE in a transitive dep cannot
+    # ship silently.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: frontend/.nvmrc
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install frontend deps (lockfile fetchability gate)
+        # ``--frozen-lockfile`` resolves every entry in
+        # ``frontend/pnpm-lock.yaml`` against the registry. A yanked /
+        # unpublished / phantom version that ``pnpm audit`` would not
+        # surface fails this step instead. Without this, a backend-
+        # only PR could merge green despite a non-fetchable frontend
+        # lockfile entry (the "phantom version" case #598 was filed
+        # to catch).
+        run: pnpm --dir frontend install --frozen-lockfile
+
+      - name: pnpm audit (frontend, all deps)
+        # Audit dev + prod deps. The frontend toolchain (vite,
+        # vitest, typescript) executes during builds and tests, so
+        # advisories there are still in the supply chain we ship
+        # through CI. ``high`` floor matches what we'd accept as a
+        # merge gate; ``moderate`` produced too many false alarms in
+        # tooling chains we don't deploy.
+        run: pnpm --dir frontend audit --audit-level high
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv + pip-audit
+        run: pip install uv pip-audit
+
+      - name: Export Python lockfile to requirements.txt
+        # GitHub's default ``bash -e`` does not reliably run process
+        # substitution across runners. Materialise the requirements
+        # to disk so pip-audit can read it as a real file. Include
+        # dev deps so the CI / pre-push toolchain (pytest, ruff,
+        # pyright) is also covered — those packages execute on
+        # operator machines and CI runners, so their advisories are
+        # supply-chain risks too.
+        run: uv export --no-hashes --no-emit-project > /tmp/requirements.txt
+
+      - name: Audit Python dependencies
+        # ``pip-audit`` resolves the lockfile against the PyPA
+        # advisory database. Strict-mode failure surfaces both
+        # advisory-laden and yanked versions; tolerated exceptions
+        # belong in this step's allowlist (none today).
+        run: pip-audit --strict --requirement /tmp/requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
           python-version: "3.14"
 
       - name: Install uv
-        run: pip install uv
+        # Pinned so CI / local dev / supply-chain audit see the
+        # same resolver behavior across runs.
+        run: pip install "uv==0.5.21"
 
       - name: Install dependencies
         run: uv sync --group dev
@@ -43,7 +45,13 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        # Match production Postgres major version. Newer plan docs
+        # (docs/superpowers/plans/2026-04-13-live-pricing-currency-
+        # conversion.md, 2026-04-14-fundamentals-enrichment.md,
+        # 2026-04-16-data-orchestrator-p1.md) target PG17; running
+        # PG16 on CI would let a PG17-only feature pass green here
+        # and fail at deploy time.
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -78,7 +86,9 @@ jobs:
           python-version: "3.14"
 
       - name: Install uv
-        run: pip install uv
+        # Pinned so CI / local dev / supply-chain audit see the
+        # same resolver behavior across runs.
+        run: pip install "uv==0.5.21"
 
       - name: Install dependencies
         run: uv sync --group dev
@@ -137,7 +147,10 @@ jobs:
           python-version: "3.14"
 
       - name: Install uv + pip-audit
-        run: pip install uv pip-audit
+        # uv pinned for resolver determinism (matches the lint/pytest
+        # jobs above); pip-audit floats so we always hit the latest
+        # advisory database — pinning that would defeat the gate.
+        run: pip install "uv==0.5.21" pip-audit
 
       - name: Export Python lockfile to requirements.txt
         # GitHub's default ``bash -e`` does not reliably run process

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -42,3 +42,11 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Run frontend tests (#247)
+        # Full ``pnpm test`` includes the SetupPage integration tests
+        # — heavier but representative of the user-visible path. The
+        # local pre-push gate uses ``test:unit``; CI runs the wider
+        # ``test`` so an integration-only regression cannot ship
+        # behind a green pre-push.
+        run: pnpm test

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -646,9 +646,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Three CI workflow additions, two issues:

**#247 — run backend + frontend test suites**
- New \`pytest\` job in \`.github/workflows/ci.yml\` with a Postgres 16 service + CI-only env vars (\`EBULL_DATABASE_URL\`, \`EBULL_SECRETS_KEY\`, \`EBULL_SERVICE_TOKEN\`). Without the Postgres service, the smoke + integration tests would skip and merge gates would regress.
- \`frontend-ci.yml\` now runs the full \`pnpm test\` (was: typecheck + build only). Pre-push gate stays \`pnpm test:unit\` for speed; CI runs the wider \`test\` so an integration-only regression cannot ship behind a green pre-push.

**#598 — supply-chain scan**
- New \`supply-chain\` job in \`ci.yml\` with three steps:
  1. \`pnpm install --frozen-lockfile\` — turns phantom-version / yanked / unpublished tarballs into a hard fail (which \`pnpm audit\` alone misses).
  2. \`pnpm audit --audit-level high\` (no \`--prod\`) — audits the full toolchain since vite/vitest/typescript run on CI and dev machines.
  3. \`pip-audit\` against the full \`uv.lock\` (no \`--no-dev\`) — same reasoning for pytest / ruff / pyright.
- Targeted lockfile bump: \`pytest 9.0.2 → 9.0.3\` (CVE-2025-71176, surfaced when expanding pip-audit to dev deps).

## Why
Before this PR, CI ran only lint + typecheck + frontend build. Test failures could merge if the local pre-push step was skipped, and supply-chain advisories had no automated gate at all. Both issues call out that the human rule already exists; this PR puts the enforcement in the workflow.

Codex pre-push review caught two real flaws the original draft would have shipped:
- \`pnpm audit\` does not prove tarball fetchability — added \`pnpm install --frozen-lockfile\` as the proper phantom-version gate.
- \`--prod\` / \`--no-dev\` excluded the toolchain that actually executes on CI runners — dropped both flags and bumped the one CVE that surfaced.

## Test plan
- [x] \`pnpm install --frozen-lockfile\` (frontend) — green
- [x] \`pnpm audit --audit-level high\` — exit 0 (3 moderate, no high/critical)
- [x] \`pip-audit --strict\` against \`uv export\` — clean after pytest bump
- [x] Full backend suite \`uv run pytest --deselect tests/test_migration_076_dedupe_financial_periods.py\` — 2921 passed
- [x] Full frontend suite \`pnpm test\` — 609 passed
- [ ] Watch CI on this PR to confirm the new jobs themselves go green