### PR TITLE
fix(#564): decouple 10-K sections loading from history rail

### DIFF
--- a/frontend/src/pages/Tenk10KDrilldownPage.test.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.test.tsx
@@ -66,4 +66,44 @@ describe("Tenk10KDrilldownPage", () => {
     // Sentinel string must not leak to the visible text
     expect(screen.queryByText(/TABLE_0/)).toBeNull();
   });
+
+  it("renders sections while history is still loading (#564)", async () => {
+    vi.spyOn(api, "fetchBusinessSections").mockResolvedValue({
+      symbol: "GME",
+      source_accession: "0001326380-26-000001",
+      cik: "0001326380",
+      sections: [
+        {
+          section_order: 0,
+          section_key: "general",
+          section_label: "General",
+          body: "We sell games.",
+          cross_references: [],
+          tables: [],
+        },
+      ],
+    });
+    // History never resolves — sections must still render.
+    vi.spyOn(api, "fetchTenKHistory").mockReturnValue(
+      new Promise<api.TenKHistoryResponse>(() => {
+        /* never resolves */
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/instrument/GME/filings/10-k"]}>
+        <Routes>
+          <Route
+            path="/instrument/:symbol/filings/10-k"
+            element={<Tenk10KDrilldownPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Body content for the section is visible despite history being pending.
+    expect(await screen.findByText("We sell games.")).toBeInTheDocument();
+    // Prior 10-K rail content (which only appears when history resolves) is absent.
+    expect(screen.queryByText(/Prior 10-Ks/i)).toBeNull();
+  });
 });

--- a/frontend/src/pages/Tenk10KDrilldownPage.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.tsx
@@ -194,11 +194,13 @@ function secSearchUrlFor(
 function Body({
   data,
   history,
+  historyLoading,
   historyError,
   symbol,
 }: {
   readonly data: BusinessSectionsResponse;
   readonly history: TenKHistoryResponse;
+  readonly historyLoading: boolean;
   readonly historyError: unknown;
   readonly symbol: string;
 }) {
@@ -247,7 +249,9 @@ function Body({
         ))}
       </div>
       <div className="hidden lg:block">
-        {historyError !== null ? (
+        {historyLoading ? (
+          <SectionSkeleton rows={4} />
+        ) : historyError !== null ? (
           <p className="text-xs text-amber-700">
             Filing history unavailable — couldn't load prior 10-Ks.
           </p>
@@ -281,7 +285,7 @@ export function Tenk10KDrilldownPage() {
   return (
     <div className="mx-auto max-w-screen-2xl p-4">
       <Section title={`${symbol} — 10-K narrative`}>
-        {sectionsState.loading || historyState.loading ? (
+        {sectionsState.loading ? (
           <SectionSkeleton rows={6} />
         ) : sectionsState.error !== null ? (
           <SectionError onRetry={sectionsState.refetch} />
@@ -294,6 +298,7 @@ export function Tenk10KDrilldownPage() {
           <Body
             data={sectionsState.data}
             history={historyState.data ?? { symbol, filings: [] }}
+            historyLoading={historyState.loading}
             historyError={historyState.error}
             symbol={symbol}
           />


### PR DESCRIPTION
## What

Top-level loading gate on `Tenk10KDrilldownPage` keys on `sectionsState.loading` only. `Body` now receives `historyLoading` and renders a small `SectionSkeleton` in the right rail until history resolves.

## Why

Per PR #562 review NITPICK and issue #559: the reader was blocked on `sectionsState.loading || historyState.loading`. A slow `fetchTenKHistory` held back the section body — the actual content the user navigated here for — even after sections had loaded.

## Test plan

- [x] `pnpm exec vitest run src/pages/Tenk10KDrilldownPage.test.tsx` — 2 pass (existing 3-pane test + new "renders sections while history is still loading")
- [x] `pnpm typecheck` clean
- [x] `pnpm test:unit` 604 pass
- [x] Backend gates clean (no backend touched)
- [x] Codex review: no correctness/regression issues

The new test is the regression guard: history mock returns a never-resolving Promise; section body text is asserted visible and the rail's "Prior 10-Ks" header is asserted absent.