### PR TITLE
feat(#560): self-terminating tables_json backfill via candidate query

### DIFF
--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -1402,7 +1402,8 @@ def ingest_business_summaries(
     """Scan 10-K filings, fetch primary doc, extract Item 1, upsert.
 
     Candidate selector (shape addresses Codex #428 findings, extended
-    in #533 with backoff/quarantine):
+    in #533 with backoff/quarantine, in #560 with tables_json
+    backfill):
 
     1. ``fe.filing_type IN ('10-K', '10-K/A')`` — amendments retain
        their ``/A`` suffix through the SEC pipeline (see
@@ -1413,7 +1414,12 @@ def ingest_business_summaries(
     3. No ``instrument_business_summary`` row, OR the stored
        ``source_accession`` differs from this filing's accession
        (later 10-K supersedes), OR the existing row's ``next_retry_at``
-       has elapsed.
+       has elapsed, OR any child section row has ``tables_json IS
+       NULL`` AND the row is not currently quarantined (rows ingested
+       before migration 075 — re-parse populates the column from the
+       new parser; clause self-empties once backfilled). The
+       quarantine AND-guard preserves the #533 backoff contract for
+       repeatedly-failing backfill candidates.
     4. Newest filing wins per instrument (``DISTINCT ON`` resolves to
        the latest filing_date, tie-break on filing_event_id); the
        outer query then sorts GLOBALLY newest-first so a backlog
@@ -1455,6 +1461,22 @@ def ingest_business_summaries(
             WHERE bs.instrument_id IS NULL
                OR bs.source_accession <> lpi.provider_filing_id
                OR (bs.next_retry_at IS NOT NULL AND bs.next_retry_at <= NOW())
+               OR (
+                   -- #560 backfill: re-select parent rows whose child
+                   -- sections still have tables_json IS NULL (pre-075
+                   -- ingest). AND-guarded by the quarantine clock so
+                   -- a repeatedly-failing reparse doesn't bypass
+                   -- exponential backoff (#533) and re-fetch on every
+                   -- ingest pass.
+                   (bs.next_retry_at IS NULL OR bs.next_retry_at <= NOW())
+                   AND EXISTS (
+                       SELECT 1
+                       FROM instrument_business_summary_sections s
+                       WHERE s.instrument_id = bs.instrument_id
+                         AND s.source_accession = bs.source_accession
+                         AND s.tables_json IS NULL
+                   )
+               )
             ORDER BY lpi.filing_date DESC, lpi.filing_event_id DESC
             LIMIT %s
             """,

--- a/sql/079_business_sections_tables_json_null_idx.sql
+++ b/sql/079_business_sections_tables_json_null_idx.sql
@@ -1,0 +1,24 @@
+-- 079_business_sections_tables_json_null_idx.sql
+--
+-- #560: Partial index supporting the candidate-query EXISTS clause
+-- in ``ingest_business_summaries`` that surfaces rows whose child
+-- sections have ``tables_json IS NULL`` (pre-migration-075 ingest).
+--
+-- Without an index the EXISTS subquery scans the full sections
+-- table on every candidate evaluation — fine while the backfill is
+-- in flight (~178k rows) but slow once the candidate count grows.
+-- Partial WHERE clause keeps the index tiny in steady state: rows
+-- with populated ``tables_json`` are not indexed at all, and once
+-- the backfill completes the index is empty.
+--
+-- Idempotent.
+
+CREATE INDEX IF NOT EXISTS
+    instrument_business_summary_sections_tables_json_null_idx
+    ON instrument_business_summary_sections (instrument_id, source_accession)
+    WHERE tables_json IS NULL;
+
+COMMENT ON INDEX instrument_business_summary_sections_tables_json_null_idx IS
+    '#560: supports the tables_json-backfill candidate-query EXISTS '
+    'clause; partial filter on tables_json IS NULL keeps the index '
+    'empty once backfill completes so steady-state cost is zero.';

--- a/tests/test_business_summary_ingest.py
+++ b/tests/test_business_summary_ingest.py
@@ -364,6 +364,10 @@ class TestBusinessSectionsIngest:
         fetcher_second = _StubFetcher({"https://www.sec.gov/Archives/apex560.htm": self._RICH_10K})
         second = ingest_business_summaries(ebull_test_conn, cast("object", fetcher_second))  # type: ignore[arg-type]
         assert second.filings_scanned == 1
+        # rows_updated proves the upsert branch actually executed — a
+        # silent no-op reparse would still pass scan + fetch assertions
+        # alone (#633 NITPICK).
+        assert second.rows_updated == 1
         assert fetcher_second.calls == ["https://www.sec.gov/Archives/apex560.htm"]
 
         # tables_json now repopulated (non-NULL on every section row).

--- a/tests/test_business_summary_ingest.py
+++ b/tests/test_business_summary_ingest.py
@@ -330,6 +330,101 @@ class TestBusinessSectionsIngest:
         prod_refs = {(r.reference_type, r.target) for r in products.cross_references}
         assert ("item", "Item 7") in prod_refs
 
+    def test_null_tables_json_re_selects_for_reparse(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """#560 — pre-migration-075 rows have tables_json = NULL on
+        sections; the candidate query must re-select them so the next
+        ingest re-parses and populates tables_json from the new
+        parser. Once populated the EXISTS clause goes false and the
+        gate behaves as steady-state.
+        """
+        iid = _seed_instrument(ebull_test_conn, symbol="APEX", iid=303)
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="APEX-10K-560",
+            url="https://www.sec.gov/Archives/apex560.htm",
+        )
+        fetcher_first = _StubFetcher({"https://www.sec.gov/Archives/apex560.htm": self._RICH_10K})
+        first = ingest_business_summaries(ebull_test_conn, cast("object", fetcher_first))  # type: ignore[arg-type]
+        assert first.rows_inserted == 1
+
+        # Simulate pre-#075 state: NULL tables_json on every child row.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "UPDATE instrument_business_summary_sections SET tables_json = NULL WHERE instrument_id = %s",
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        # Without the #560 EXISTS clause this would skip (source_accession
+        # matches, no retry pending). The clause should re-select the row.
+        fetcher_second = _StubFetcher({"https://www.sec.gov/Archives/apex560.htm": self._RICH_10K})
+        second = ingest_business_summaries(ebull_test_conn, cast("object", fetcher_second))  # type: ignore[arg-type]
+        assert second.filings_scanned == 1
+        assert fetcher_second.calls == ["https://www.sec.gov/Archives/apex560.htm"]
+
+        # tables_json now repopulated (non-NULL on every section row).
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM instrument_business_summary_sections "
+                "WHERE instrument_id = %s AND tables_json IS NULL",
+                (iid,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert int(row[0]) == 0
+
+        # Steady-state: a third run with all tables_json populated must
+        # NOT re-select. EXISTS clause goes false; gate empties.
+        fetcher_third = _StubFetcher({"https://www.sec.gov/Archives/apex560.htm": self._RICH_10K})
+        third = ingest_business_summaries(ebull_test_conn, cast("object", fetcher_third))  # type: ignore[arg-type]
+        assert third.filings_scanned == 0
+        assert fetcher_third.calls == []
+
+    def test_null_tables_json_quarantined_row_skipped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """#560 — a backfill candidate that is currently quarantined
+        (``next_retry_at`` in the future) must NOT be re-selected by
+        the new EXISTS clause. Without the AND-guard a repeatedly-
+        failing reparse would bypass the #533 exponential backoff and
+        fetch on every ingest pass.
+        """
+        iid = _seed_instrument(ebull_test_conn, symbol="QRTN", iid=304)
+        _seed_10k(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="QRTN-10K-560",
+            url="https://www.sec.gov/Archives/qrtn560.htm",
+        )
+        fetcher_first = _StubFetcher({"https://www.sec.gov/Archives/qrtn560.htm": self._RICH_10K})
+        ingest_business_summaries(ebull_test_conn, cast("object", fetcher_first))  # type: ignore[arg-type]
+
+        # Simulate pre-#075 NULL tables_json AND quarantined parent.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "UPDATE instrument_business_summary_sections SET tables_json = NULL WHERE instrument_id = %s",
+                (iid,),
+            )
+            cur.execute(
+                "UPDATE instrument_business_summary "
+                "SET next_retry_at = NOW() + INTERVAL '7 days' "
+                "WHERE instrument_id = %s",
+                (iid,),
+            )
+        ebull_test_conn.commit()
+
+        fetcher_second = _StubFetcher({"https://www.sec.gov/Archives/qrtn560.htm": self._RICH_10K})
+        second = ingest_business_summaries(ebull_test_conn, cast("object", fetcher_second))  # type: ignore[arg-type]
+        # The quarantine clock keeps the row out of the candidate set
+        # despite the NULL tables_json — backoff contract preserved.
+        assert second.filings_scanned == 0
+        assert fetcher_second.calls == []
+
     def test_insert_failure_rolls_back_delete_atomically(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         """#449 BLOCKING regression — a failure inside the sections
         upsert must not leave an empty sections table committed. If


### PR DESCRIPTION
## What

Adds a fourth OR clause to the \`ingest_business_summaries\` candidate selector that re-selects parent rows whose child sections still have \`tables_json IS NULL\`. AND-guarded by the existing quarantine clock so backoff is preserved. Migration 079 adds a partial index supporting the EXISTS subquery; it stays empty in steady state.

## Why

Pre-migration-075 ingest left \`tables_json IS NULL\` on existing 178k+ section rows. The post-#075 parser populates the column on new parses but the steady-state candidate gate never re-selects rows whose \`source_accession\` already matches the latest 10-K. Backfill needed a mechanism that:
- doesn't require an operational script or DB mutation
- self-terminates once every row has \`tables_json\` populated
- respects the #533 exponential-backoff quarantine for failing reparses

A data-driven candidate clause does all three.

## Test plan

- [x] \`uv run pytest\` 2932 pass, 1 skipped
- [x] \`uv run ruff check . && uv run ruff format --check .\` clean
- [x] \`uv run pyright\` clean
- [x] \`test_null_tables_json_re_selects_for_reparse\`: NULL tables_json triggers re-select; third run after repopulation does NOT
- [x] \`test_null_tables_json_quarantined_row_skipped\`: future \`next_retry_at\` keeps the row out despite NULL tables_json (regression coverage for the Codex-caught bypass)
- [x] Codex review APPROVE on the AND-guarded shape

## Operational notes

After merge, the next regularly-scheduled \`bootstrap_business_summaries\` run will start picking up backfill candidates under SEC fair-use rate limits. No operator action required. The partial index keeps the EXISTS subquery sub-millisecond and disappears once the backfill completes.