### PR TITLE
feat(#194): rankings search + contained-scroll on rankings/instruments

### DIFF
--- a/frontend/src/components/dashboard/Section.tsx
+++ b/frontend/src/components/dashboard/Section.tsx
@@ -7,23 +7,35 @@ import type { ReactNode } from "react";
  * failing /system/status must not blank /portfolio. Sections render an
  * inline ErrorBanner with a Retry button rather than throwing, so the
  * top-level ErrorBoundary is reserved for unexpected exceptions.
+ *
+ * ``scrollable=true`` (#194) switches the Section into a contained-
+ * scroll layout: the section claims remaining flex space and its
+ * body scrolls vertically, instead of growing the page-level scroll.
+ * Use when the parent is a flex column with ``h-full`` and the
+ * section sits below header/filter chrome that should stay visible.
  */
 export function Section({
   title,
   action,
   children,
+  scrollable = false,
 }: {
   title: string;
   action?: ReactNode;
   children: ReactNode;
+  scrollable?: boolean;
 }) {
+  const sectionClass = scrollable
+    ? "flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-sm"
+    : "rounded-md border border-slate-200 bg-white shadow-sm";
+  const bodyClass = scrollable ? "min-h-0 flex-1 overflow-auto p-4" : "p-4";
   return (
-    <section className="rounded-md border border-slate-200 bg-white shadow-sm">
-      <header className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
+    <section className={sectionClass}>
+      <header className="flex flex-shrink-0 items-center justify-between border-b border-slate-100 px-4 py-3">
         <h2 className="text-sm font-semibold text-slate-700">{title}</h2>
         {action ? <div className="text-xs">{action}</div> : null}
       </header>
-      <div className="p-4">{children}</div>
+      <div className={bodyClass}>{children}</div>
     </section>
   );
 }

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -206,8 +206,8 @@ export function InstrumentsPage() {
   );
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
+    <div className="flex h-full flex-col gap-6">
+      <div className="flex flex-shrink-0 items-center justify-between">
         <h1 className="text-xl font-semibold text-slate-800">Instruments</h1>
         {result.data && (
           <span className="text-xs text-slate-500">
@@ -217,7 +217,7 @@ export function InstrumentsPage() {
       </div>
 
       {/* Search + filters bar */}
-      <div className="flex flex-wrap items-end gap-3">
+      <div className="flex flex-shrink-0 flex-wrap items-end gap-3">
         <div className="flex-1">
           <label className="mb-1 block text-xs font-medium text-slate-600">
             Search
@@ -288,7 +288,7 @@ export function InstrumentsPage() {
         </div>
       </div>
 
-      <Section title="Results">
+      <Section title="Results" scrollable>
         {result.loading ? (
           <SectionSkeleton rows={10} />
         ) : result.error !== null ? (

--- a/frontend/src/pages/RankingsPage.test.tsx
+++ b/frontend/src/pages/RankingsPage.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { RankingsPage } from "@/pages/RankingsPage";
+import * as rankingsApi from "@/api/rankings";
+import type { RankingItem, RankingsListResponse } from "@/api/types";
+
+function _item(overrides: Partial<RankingItem>): RankingItem {
+  return {
+    instrument_id: 1,
+    symbol: "AAA",
+    company_name: "Alpha Co",
+    sector: "Tech",
+    coverage_tier: 1,
+    rank: 1,
+    rank_delta: 0,
+    total_score: 80,
+    raw_total: 80,
+    quality_score: 70,
+    value_score: 60,
+    turnaround_score: 50,
+    momentum_score: 40,
+    sentiment_score: 30,
+    confidence_score: 20,
+    penalties_json: null,
+    explanation: null,
+    model_version: "v1-balanced",
+    scored_at: "2026-04-28T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("RankingsPage — #194 search", () => {
+  it("filters rows by symbol substring (debounced)", async () => {
+    const response: RankingsListResponse = {
+      items: [
+        _item({ instrument_id: 1, symbol: "AAA", company_name: "Alpha Co" }),
+        _item({ instrument_id: 2, symbol: "BBB", company_name: "Beta Inc" }),
+        _item({ instrument_id: 3, symbol: "CCC", company_name: "Charlie Ltd" }),
+      ],
+      total: 3,
+      offset: 0,
+      limit: 200,
+      model_version: "v1-balanced",
+      scored_at: "2026-04-28T12:00:00Z",
+    };
+    vi.spyOn(rankingsApi, "fetchRankings").mockResolvedValue(response);
+
+    render(
+      <MemoryRouter>
+        <RankingsPage />
+      </MemoryRouter>,
+    );
+
+    // Initial render shows all three rows.
+    expect(await screen.findByText("AAA")).toBeInTheDocument();
+    expect(screen.getByText("BBB")).toBeInTheDocument();
+    expect(screen.getByText("CCC")).toBeInTheDocument();
+
+    const searchInput = screen.getByLabelText(/search/i);
+    await userEvent.type(searchInput, "BBB");
+
+    // 300ms debounce — wait for filter to apply.
+    await waitFor(
+      () => {
+        expect(screen.queryByText("AAA")).not.toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
+    expect(screen.getByText("BBB")).toBeInTheDocument();
+    expect(screen.queryByText("CCC")).not.toBeInTheDocument();
+  });
+
+  it("warns when search runs over a truncated page (#194 Codex)", async () => {
+    const response: RankingsListResponse = {
+      items: [_item({ instrument_id: 1, symbol: "AAA", company_name: "Alpha Co" })],
+      // total > items.length triggers the truncation banner once the
+      // user starts searching. Otherwise an out-of-page match would
+      // silently appear as "No instruments match the current filters".
+      total: 250,
+      offset: 0,
+      limit: 200,
+      model_version: "v1-balanced",
+      scored_at: "2026-04-28T12:00:00Z",
+    };
+    vi.spyOn(rankingsApi, "fetchRankings").mockResolvedValue(response);
+
+    render(
+      <MemoryRouter>
+        <RankingsPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("AAA")).toBeInTheDocument();
+    // No banner before search.
+    expect(screen.queryByText(/matches outside the page/i)).not.toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText(/search/i), "foo");
+    await waitFor(
+      () => {
+        expect(screen.getByText(/matches outside the page/i)).toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
+  });
+
+  it("filters by company-name substring (case-insensitive)", async () => {
+    const response: RankingsListResponse = {
+      items: [
+        _item({ instrument_id: 1, symbol: "AAA", company_name: "Alpha Co" }),
+        _item({ instrument_id: 2, symbol: "BBB", company_name: "Beta Inc" }),
+      ],
+      total: 2,
+      offset: 0,
+      limit: 200,
+      model_version: "v1-balanced",
+      scored_at: "2026-04-28T12:00:00Z",
+    };
+    vi.spyOn(rankingsApi, "fetchRankings").mockResolvedValue(response);
+
+    render(
+      <MemoryRouter>
+        <RankingsPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("AAA")).toBeInTheDocument();
+
+    const searchInput = screen.getByLabelText(/search/i);
+    await userEvent.type(searchInput, "alpha");
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText("BBB")).not.toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
+    expect(screen.getByText("AAA")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -84,7 +84,9 @@ export function RankingsPage() {
     query.sector !== null ||
     query.stance !== null ||
     scoreThreshold !== null ||
-    search !== "";
+    // Use the un-debounced searchInput so Clear All shows immediately
+    // on first keystroke rather than 300 ms later (#634 NITPICK).
+    searchInput !== "";
 
   const filteredItems = useMemo(() => {
     if (rankings.data === null) return [];

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -36,6 +36,15 @@ export function RankingsPage() {
     stance: null,
   });
   const [scoreThreshold, setScoreThreshold] = useState<number | null>(null);
+  // #194 — debounced symbol/name search; client-side filter over the
+  // current response (server-side `search` is not supported on the
+  // rankings endpoint and the page caps at RANKINGS_PAGE_LIMIT rows).
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  useEffect(() => {
+    const timer = setTimeout(() => setSearch(searchInput.trim().toLowerCase()), 300);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
 
   // Sector dropdown options must be derived from data the page has seen,
   // not from the *current* response. Once a sector filter is applied the
@@ -74,15 +83,24 @@ export function RankingsPage() {
     query.coverage_tier !== null ||
     query.sector !== null ||
     query.stance !== null ||
-    scoreThreshold !== null;
+    scoreThreshold !== null ||
+    search !== "";
 
   const filteredItems = useMemo(() => {
     if (rankings.data === null) return [];
-    if (scoreThreshold === null) return rankings.data.items;
-    return rankings.data.items.filter(
-      (i) => i.total_score !== null && i.total_score >= scoreThreshold,
-    );
-  }, [rankings.data, scoreThreshold]);
+    let items: ReadonlyArray<RankingItem> = rankings.data.items;
+    if (scoreThreshold !== null) {
+      items = items.filter((i) => i.total_score !== null && i.total_score >= scoreThreshold);
+    }
+    if (search !== "") {
+      items = items.filter(
+        (i) =>
+          i.symbol.toLowerCase().includes(search) ||
+          i.company_name.toLowerCase().includes(search),
+      );
+    }
+    return items;
+  }, [rankings.data, scoreThreshold, search]);
 
   // Surface the single edge case where the universe outgrew our single-page
   // assumption (>200 Tier 1+2 instruments). Loud in dev, harmless in prod.
@@ -97,6 +115,8 @@ export function RankingsPage() {
   const onClearAll = () => {
     setQuery({ coverage_tier: null, sector: null, stance: null });
     setScoreThreshold(null);
+    setSearchInput("");
+    setSearch("");
   };
 
   const view: RankingsView = computeView({
@@ -110,8 +130,8 @@ export function RankingsPage() {
   });
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
+    <div className="flex h-full flex-col gap-6">
+      <div className="flex flex-shrink-0 items-center justify-between">
         <h1 className="text-xl font-semibold text-slate-800">Rankings</h1>
         <span className="text-xs text-slate-500">
           {rankings.data?.scored_at
@@ -120,17 +140,48 @@ export function RankingsPage() {
         </span>
       </div>
 
-      <RankingsFilters
-        query={query}
-        onQueryChange={setQuery}
-        scoreThreshold={scoreThreshold}
-        onScoreThresholdChange={setScoreThreshold}
-        knownSectors={knownSectors}
-        onClearAll={onClearAll}
-        filtersDirty={filtersDirty}
-      />
+      <div className="flex-shrink-0 space-y-3">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="rankings-search">
+            Search
+          </label>
+          <input
+            id="rankings-search"
+            type="text"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Symbol or company name…"
+            className="w-full rounded border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+          />
+          {/* Search is client-side over the page-bounded response.
+              When the universe outgrows RANKINGS_PAGE_LIMIT a match
+              outside the first page would silently fail to surface;
+              warn the operator so they don't read a false-negative
+              empty state as authoritative. Server-side search is the
+              proper fix and is tracked under the same paginated-
+              rankings follow-up referenced at line 92. */}
+          {search !== "" &&
+            rankings.data !== null &&
+            rankings.data.total > rankings.data.items.length && (
+              <p className="mt-1 text-xs text-amber-700">
+                Search covers the first {rankings.data.items.length} of {rankings.data.total} ranked
+                rows; matches outside the page are not shown.
+              </p>
+            )}
+        </div>
 
-      <Section title="Candidates">
+        <RankingsFilters
+          query={query}
+          onQueryChange={setQuery}
+          scoreThreshold={scoreThreshold}
+          onScoreThresholdChange={setScoreThreshold}
+          knownSectors={knownSectors}
+          onClearAll={onClearAll}
+          filtersDirty={filtersDirty}
+        />
+      </div>
+
+      <Section title="Candidates" scrollable>
         <RankingsTable view={view} />
       </Section>
     </div>


### PR DESCRIPTION
## What

- \`Section\` gains a \`scrollable\` prop (default false). When true, the card switches to a flex column claiming remaining vertical space with internal \`overflow-auto\` on the body.
- \`RankingsPage\` and \`InstrumentsPage\` page wrappers move to \`flex h-full flex-col gap-6\` and pass \`scrollable\` on the main results Section.
- \`RankingsPage\` adds a debounced (300ms) search input that filters rows client-side by symbol or company-name substring.

## Why

Per #194: page-level scroll on rankings + instruments scrolls headers/filters out of view before reaching table rows. Rankings also had no way to search for a specific symbol against the up-to-200 candidates. Both are blockers for operator UX.

Codex review flagged a false-negative when \`total > RANKINGS_PAGE_LIMIT\` (search runs over a truncated page; out-of-page matches disappear silently). A truncation banner under the search input surfaces the limitation once search is active.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test:unit\` 606 pass (3 new)
  - filters by symbol substring
  - filters by company-name substring
  - warns when search runs over a truncated page (Codex regression)
- [x] Backend gates clean (no backend touched)
- [x] Codex review APPROVE on the truncation-banner fix

Visual scroll behaviour (filters stick, table scrolls within the card) is browser-verifiable. Tests cover the search filter logic and truncation banner.