### PR TITLE
fix(#229): broker_positions P&L applies open_conversion_rate

### DIFF
--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -594,7 +594,7 @@ def get_instrument_positions(
     """
     trades_sql = """
         SELECT bp.position_id, bp.is_buy, bp.units, bp.amount,
-               bp.open_rate, bp.open_date_time,
+               bp.open_rate, bp.open_conversion_rate, bp.open_date_time,
                bp.stop_loss_rate, bp.take_profit_rate,
                bp.is_tsl_enabled, bp.leverage, bp.total_fees
         FROM broker_positions bp
@@ -627,16 +627,24 @@ def get_instrument_positions(
         units = float(tr["units"])
         amount = float(tr["amount"])
         open_rate = float(tr["open_rate"])
+        # eToro stores ``amount`` in USD but ``open_rate`` and the
+        # current quote in the instrument's native currency.
+        # ``open_conversion_rate`` (native→USD at open) reconciles the
+        # native price delta back into USD before adding to ``amount``
+        # so non-USD positions value correctly. Same pattern as the
+        # copy-trading aggregate at app/services/portfolio.py:225-230.
+        # USD positions store conversion_rate=1 → no-op.
+        open_conv = float(tr["open_conversion_rate"])
         is_buy = tr["is_buy"]
 
         if current_price is not None:
             if is_buy:
                 # Long: invested capital + leveraged price delta.
-                mv = amount + units * (current_price - open_rate)
+                mv = amount + units * (current_price - open_rate) * open_conv
                 pnl = mv - amount
             else:
                 # Short: profit when price drops below open_rate.
-                mv = amount + units * (open_rate - current_price)
+                mv = amount + units * (open_rate - current_price) * open_conv
                 pnl = mv - amount
         else:
             mv = amount

--- a/tests/test_api_portfolio.py
+++ b/tests/test_api_portfolio.py
@@ -702,3 +702,191 @@ class TestPortfolioMirrors:
         assert m["funded"] == 10000.0
         # unrealized = total_return - realised = (10500 - 10000) - 500 = 0
         assert m["unrealized_pnl"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# TestInstrumentPositionsOpenConversionRate (#229)
+# ---------------------------------------------------------------------------
+
+
+def _make_instrument_row(
+    instrument_id: int = 1,
+    symbol: str = "AAPL",
+    company_name: str = "Apple Inc",
+    currency: str = "USD",
+    quote_last: float | None = 200.0,
+    daily_close: float | None = None,
+) -> dict[str, Any]:
+    """Build a row matching the instrument_sql shape in get_instrument_positions."""
+    return {
+        "instrument_id": instrument_id,
+        "symbol": symbol,
+        "company_name": company_name,
+        "currency": currency,
+        "quote_last": quote_last,
+        "daily_close": daily_close,
+    }
+
+
+def _make_broker_position_row(
+    position_id: int = 9001,
+    is_buy: bool = True,
+    units: float = 10.0,
+    amount: float = 1800.0,
+    open_rate: float = 180.0,
+    open_conversion_rate: float = 1.0,
+    open_date_time: datetime | None = None,
+    stop_loss_rate: float | None = None,
+    take_profit_rate: float | None = None,
+    is_tsl_enabled: bool = False,
+    leverage: int = 1,
+    total_fees: float = 0.0,
+) -> dict[str, Any]:
+    """Build a row matching the trades_sql shape in get_instrument_positions."""
+    return {
+        "position_id": position_id,
+        "is_buy": is_buy,
+        "units": units,
+        "amount": amount,
+        "open_rate": open_rate,
+        "open_conversion_rate": open_conversion_rate,
+        "open_date_time": open_date_time or _NOW,
+        "stop_loss_rate": stop_loss_rate,
+        "take_profit_rate": take_profit_rate,
+        "is_tsl_enabled": is_tsl_enabled,
+        "leverage": leverage,
+        "total_fees": total_fees,
+    }
+
+
+class TestInstrumentPositionsOpenConversionRate:
+    """GET /portfolio/instruments/{id} — #229 P&L formula honours
+    open_conversion_rate so native-currency price deltas reconcile
+    back to the USD-denominated ``amount`` column."""
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_usd_position_open_conv_one_is_noop(self) -> None:
+        """USD position with open_conversion_rate=1 must produce the
+        same market_value the pre-#229 formula did — regression guard."""
+        instrument = _make_instrument_row(instrument_id=1, symbol="AAPL", currency="USD", quote_last=200.0)
+        pos = _make_broker_position_row(units=10.0, amount=1800.0, open_rate=180.0, open_conversion_rate=1.0)
+        # Endpoint runs two queries in order: instrument, broker_positions.
+        # The mock helper is row-list per execute; instrument query uses
+        # fetchone so wrap as a single-row list.
+        conn = _mock_conn([[instrument], [pos]])
+
+        def _override() -> Iterator[MagicMock]:
+            yield conn
+
+        app.dependency_overrides[get_conn] = _override
+
+        resp = client.get("/portfolio/instruments/1")
+        assert resp.status_code == 200
+        body = resp.json()
+
+        # mv = 1800 + 10 * (200 - 180) * 1.0 = 2000
+        assert body["trades"][0]["market_value"] == 2000.0
+        assert body["trades"][0]["unrealized_pnl"] == 200.0
+
+    def test_non_usd_long_applies_open_conversion_rate(self) -> None:
+        """Native-currency price delta is multiplied by open_conv to
+        convert to USD before adding to the USD-denominated amount.
+
+        Example: GBP-denominated instrument opened at 1.25 GBP/USD,
+        position size 10 units, open_rate 100 GBP, current 110 GBP.
+        Native delta = 10 * (110 - 100) = 100 GBP.
+        USD delta   = 100 * 1.25       = 125 USD.
+        amount in USD already = 1250 (10 units * 100 GBP * 1.25).
+        mv = 1250 + 125 = 1375 USD.
+        Pre-#229 (no conv multiplier) would have given 1250 + 100 = 1350.
+        """
+        instrument = _make_instrument_row(
+            instrument_id=2,
+            symbol="LSE.X",
+            currency="GBP",
+            quote_last=110.0,
+        )
+        pos = _make_broker_position_row(
+            units=10.0,
+            amount=1250.0,
+            open_rate=100.0,
+            open_conversion_rate=1.25,
+        )
+        conn = _mock_conn([[instrument], [pos]])
+
+        def _override() -> Iterator[MagicMock]:
+            yield conn
+
+        app.dependency_overrides[get_conn] = _override
+
+        resp = client.get("/portfolio/instruments/2")
+        assert resp.status_code == 200
+        body = resp.json()
+
+        assert body["trades"][0]["market_value"] == 1375.0
+        assert body["trades"][0]["unrealized_pnl"] == 125.0
+
+    def test_non_usd_short_applies_open_conversion_rate(self) -> None:
+        """Short P&L: profit when price drops below open_rate. Native
+        delta is signed against the long; conversion still applies."""
+        instrument = _make_instrument_row(
+            instrument_id=3,
+            symbol="LSE.S",
+            currency="GBP",
+            quote_last=90.0,
+        )
+        pos = _make_broker_position_row(
+            position_id=9002,
+            is_buy=False,
+            units=10.0,
+            amount=1250.0,
+            open_rate=100.0,
+            open_conversion_rate=1.25,
+        )
+        conn = _mock_conn([[instrument], [pos]])
+
+        def _override() -> Iterator[MagicMock]:
+            yield conn
+
+        app.dependency_overrides[get_conn] = _override
+
+        resp = client.get("/portfolio/instruments/3")
+        assert resp.status_code == 200
+        body = resp.json()
+
+        # mv = 1250 + 10 * (100 - 90) * 1.25 = 1375
+        assert body["trades"][0]["market_value"] == 1375.0
+        assert body["trades"][0]["unrealized_pnl"] == 125.0
+
+    def test_no_quote_keeps_market_value_at_amount(self) -> None:
+        """When current_price is unavailable the formula short-circuits
+        to mv=amount with pnl=0 — open_conversion_rate is irrelevant on
+        that branch and must not cause a KeyError or NaN."""
+        instrument = _make_instrument_row(
+            instrument_id=4,
+            symbol="GBP.NQ",
+            currency="GBP",
+            quote_last=None,
+            daily_close=None,
+        )
+        pos = _make_broker_position_row(
+            units=10.0,
+            amount=1250.0,
+            open_rate=100.0,
+            open_conversion_rate=1.25,
+        )
+        conn = _mock_conn([[instrument], [pos]])
+
+        def _override() -> Iterator[MagicMock]:
+            yield conn
+
+        app.dependency_overrides[get_conn] = _override
+
+        resp = client.get("/portfolio/instruments/4")
+        assert resp.status_code == 200
+        body = resp.json()
+
+        assert body["trades"][0]["market_value"] == 1250.0
+        assert body["trades"][0]["unrealized_pnl"] == 0.0


### PR DESCRIPTION
## What

\`get_instrument_positions\` (\`/portfolio/instruments/{id}\`) now reads \`bp.open_conversion_rate\` and multiplies it into the native price delta before adding to the USD-denominated \`amount\` column. Same shape as the copy-trading aggregate at [\`app/services/portfolio.py:225-230\`](app/services/portfolio.py#L225-L230).

## Why

eToro stores \`broker_positions.amount\` in USD but \`open_rate\` and the current quote in the instrument's native currency. The pre-#229 formula \`mv = amount + units * (current_price - open_rate)\` mixes currencies once the universe is no longer USD-only. The column already exists (NOT NULL, sql/024:23, defaulted to 1 for USD positions), so the fix is a one-line formula change plus a SELECT widening.

USD-only universe today → no behavioural change in production. Future-proofs the formula for non-USD instruments.

## Test plan

- [x] \`uv run pytest\` 2936 pass, 1 skipped
- [x] \`uv run ruff check . && uv run ruff format --check .\` clean
- [x] \`uv run pyright\` clean
- [x] New test class \`TestInstrumentPositionsOpenConversionRate\`:
  - USD position with \`open_conversion_rate=1.0\` produces same MV as before (regression guard)
  - GBP long with \`open_conversion_rate=1.25\` applies multiplier
  - GBP short with \`open_conversion_rate=1.25\` applies multiplier on the sign-flipped delta
  - No-quote branch short-circuits to \`mv=amount\`, no \`open_conversion_rate\` lookup needed
- [x] Codex review confirms shape matches copy-trading reference and covers risky paths