### PR TITLE
fix(#395): snapshot_read helper for multi-query GET handlers

### DIFF
--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -47,6 +47,7 @@ from pydantic import BaseModel, Field
 
 from app.api.auth import require_session_or_service_token
 from app.db import get_conn
+from app.db.snapshot import snapshot_read
 from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
 
 router = APIRouter(
@@ -137,7 +138,12 @@ def get_guard_rejections(
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> GuardRejectionsResponse:
     operator_id = _resolve_operator(conn)
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+    # #395: three sequential reads must agree on a single snapshot,
+    # otherwise a concurrent guard FAIL between Q2 and Q3 lets the
+    # list contain N+1 rows while unseen_count reports N (pill lags
+    # by one). REPEATABLE READ over the whole handler closes the
+    # window. Read-only block — no writes inside.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur, snapshot_read(conn):
         # 1. Read operator's cursor.
         cur.execute(
             "SELECT alerts_last_seen_decision_id FROM operators WHERE operator_id = %(op)s",

--- a/app/db/snapshot.py
+++ b/app/db/snapshot.py
@@ -1,0 +1,80 @@
+"""Snapshot-consistent multi-query reads (#395).
+
+The ``get_conn`` pool yields connections in READ COMMITTED isolation
+(see ``docs/review-prevention-log.md`` — every statement re-reads the
+latest committed snapshot). Multi-query read handlers therefore see
+a fresh snapshot per statement, which lets a concurrent writer slip
+between query 1 and query 2 and produces brief count/list drift.
+
+``snapshot_read(conn)`` opens a single REPEATABLE READ transaction so
+all reads inside the block run against one consistent snapshot. The
+helper is for read-only handlers; writers should use
+``conn.transaction()`` directly so the default READ COMMITTED applies
+(REPEATABLE READ would force serialization-failure retries on
+concurrent writes, which is not what most write handlers want).
+
+Usage::
+
+    from app.db.snapshot import snapshot_read
+
+    @router.get("/example")
+    def example(conn: psycopg.Connection = Depends(get_conn)):
+        with snapshot_read(conn):
+            row1 = conn.execute("SELECT ...").fetchone()
+            row2 = conn.execute("SELECT ...").fetchone()
+        return ...
+
+The connection's prior ``isolation_level`` is captured and restored on
+exit so the pool returns it to its default state. psycopg3 sets
+isolation as a connection-level property that takes effect on the
+next transaction; we set it before opening the transaction and
+restore it afterward.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import psycopg
+from psycopg import IsolationLevel
+
+
+@contextmanager
+def snapshot_read(conn: psycopg.Connection[Any]) -> Iterator[None]:
+    """Run a block of reads inside one REPEATABLE READ transaction.
+
+    Pool connections from ``get_conn`` are autocommit-off, so any
+    statement issued before this helper (e.g. an operator-id lookup
+    in a FastAPI dependency) silently opens an implicit READ
+    COMMITTED transaction. Entering ``conn.transaction()`` while one
+    is already active produces a SAVEPOINT — the
+    ``isolation_level`` change applies only to the *next* top-level
+    transaction, so the snapshot would silently inherit READ
+    COMMITTED. Codex review on PR for #395.
+
+    Mitigation: commit any pending implicit transaction before
+    setting isolation. Read-only by contract: the caller MUST NOT
+    issue writes inside the block, and prior reads on the same
+    connection are committable no-ops, so the upfront commit is
+    safe.
+
+    The connection's prior isolation level is restored on exit so
+    pool reuse does not leak REPEATABLE READ. psycopg3's
+    isolation_level is a connection-level setting that persists
+    across transactions until changed.
+    """
+    # Commit (no-op for read-only state) any implicit transaction
+    # opened by an earlier statement on this connection — without
+    # this, conn.transaction() below opens a savepoint instead of a
+    # new top-level transaction, and the isolation change never
+    # takes effect.
+    conn.commit()
+    prior = conn.isolation_level
+    conn.isolation_level = IsolationLevel.REPEATABLE_READ
+    try:
+        with conn.transaction():
+            yield
+    finally:
+        conn.isolation_level = prior

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -1018,3 +1018,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: A pytest fixture restoring shared `ebull_test` schema in `finally` ran two SQL files sequentially without per-step `try`. If step N (re-running migration 076 to dedupe leftover seeds) ever raised, step N+1 (re-creating the migration 077 partial unique index) would be skipped — leaving the index dropped for every subsequent test in the run, because `apply_migrations_to_test_db` only applies files not yet recorded in `schema_migrations`.
 - Prevention: Each step in a multi-step `finally` block that mutates shared DB schema (drop/recreate index, re-apply migration, restore singleton) must be wrapped in its own `try/except`. A failure in step N must not abandon steps N+1..end. Swallow + warn for non-fatal recovery steps; re-raise the final restore so the test framework reports the leak instead of silently corrupting later test runs.
 - Enforced in: this prevention log; PR #631 fix wraps the migration 076 dedupe call in its own `try/except` so the migration 077 recreate runs unconditionally.
+
+---
+
+### Multi-query read handlers must use a single snapshot
+
+- First seen in: #395.
+- Symptom: GET handlers that issue 2+ sequential reads on the same `get_conn` connection see a fresh READ COMMITTED snapshot per statement. A concurrent writer between Q1 and Q2 produces brief drift — counts and lists disagree, totals and details lag by one. Cosmetic in steady state, hides real bugs in tests, becomes a correctness issue under multi-operator concurrency.
+- Prevention: Any read handler that issues 2+ statements whose results must agree (counts, list of items, sub-aggregates of the same set) MUST wrap the reads in `with snapshot_read(conn): ...` from `app.db.snapshot`. The helper opens a REPEATABLE READ transaction so all statements run against one consistent snapshot. At self-review: grep for `cur.execute(` count >= 2 inside any GET handler and confirm `snapshot_read` wraps them, or that the handler's docstring justifies READ COMMITTED.
+- Enforced in: this prevention log; PR for #395 introduces `app/db/snapshot.py::snapshot_read` and applies it to `GET /alerts/guard-rejections`. Apply to other multi-query GETs as the pattern is encountered.

--- a/tests/test_db_snapshot.py
+++ b/tests/test_db_snapshot.py
@@ -1,0 +1,149 @@
+"""Integration tests for ``app.db.snapshot.snapshot_read`` (#395).
+
+The helper opens a REPEATABLE READ transaction so multi-query read
+handlers see one consistent snapshot. Verified by:
+
+  1. Setting up a known row count.
+  2. Opening ``snapshot_read`` and executing the first read.
+  3. From a second connection, INSERTing a row that would otherwise
+     change the count.
+  4. Executing a second read inside the same ``snapshot_read`` block
+     and asserting the count is unchanged from step 2.
+
+Without REPEATABLE READ the second read would see the new row.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.db.snapshot import snapshot_read
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
+from tests.fixtures.ebull_test_db import test_database_url as _test_database_url
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_operator(conn: psycopg.Connection[tuple]) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO operators (operator_id, username, password_hash)
+            VALUES ('22222222-2222-2222-2222-222222222222', 'snapshot_test_op', 'x')
+            ON CONFLICT DO NOTHING
+            """
+        )
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (501, 'SNP', 'Snapshot test', 'USD', TRUE) "
+            "ON CONFLICT DO NOTHING"
+        )
+    conn.commit()
+
+
+def _count_guard_fails(conn: psycopg.Connection[tuple]) -> int:
+    row = conn.execute(
+        "SELECT COUNT(*) FROM decision_audit "
+        "WHERE pass_fail = 'FAIL' AND stage = 'execution_guard' "
+        "AND decision_time >= now() - INTERVAL '7 days'"
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def test_snapshot_read_isolates_from_concurrent_insert(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A concurrent INSERT on a second connection must not be visible
+    to the second read inside ``snapshot_read``."""
+    _seed_operator(ebull_test_conn)
+
+    with snapshot_read(ebull_test_conn):
+        before = _count_guard_fails(ebull_test_conn)
+
+        # Concurrent writer on a second connection. The COMMIT here
+        # publishes the new row globally — but the snapshot-bound
+        # reader connection must not see it because REPEATABLE READ
+        # pins its visible snapshot to transaction start.
+        with psycopg.connect(_test_database_url()) as writer:
+            with writer.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO decision_audit "
+                    "(decision_time, instrument_id, stage, pass_fail, explanation) "
+                    "VALUES (now(), 501, 'execution_guard', 'FAIL', 'concurrent')"
+                )
+            writer.commit()
+
+        after = _count_guard_fails(ebull_test_conn)
+
+    assert after == before, f"snapshot_read must hide concurrent inserts; saw before={before} after={after}"
+
+    # Outside the block, the next read sees the now-committed row.
+    eventual = _count_guard_fails(ebull_test_conn)
+    assert eventual == before + 1
+
+
+def test_snapshot_read_isolates_after_prior_statement(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Codex regression for #395: pool connections are autocommit-off,
+    so any statement issued BEFORE ``snapshot_read`` opens an implicit
+    READ COMMITTED transaction. ``conn.transaction()`` inside the
+    helper would then nest as a SAVEPOINT and the isolation_level
+    change never takes effect — the handler would silently inherit
+    READ COMMITTED.
+
+    The helper commits the implicit transaction first; this test
+    seeds a prior SELECT (mirrors what a FastAPI dependency does
+    when it resolves an operator id) and asserts the snapshot still
+    hides concurrent inserts.
+    """
+    _seed_operator(ebull_test_conn)
+
+    # Prior statement opens the implicit transaction. Mirrors
+    # _resolve_operator(conn) in app/api/alerts.py.
+    ebull_test_conn.execute("SELECT 1").fetchone()
+
+    with snapshot_read(ebull_test_conn):
+        before = _count_guard_fails(ebull_test_conn)
+
+        with psycopg.connect(_test_database_url()) as writer:
+            with writer.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO decision_audit "
+                    "(decision_time, instrument_id, stage, pass_fail, explanation) "
+                    "VALUES (now(), 501, 'execution_guard', 'FAIL', 'codex-regression')"
+                )
+            writer.commit()
+
+        after = _count_guard_fails(ebull_test_conn)
+
+    assert after == before, (
+        "snapshot_read must commit any prior implicit transaction so "
+        "the isolation change opens a real REPEATABLE READ snapshot, "
+        f"not a nested savepoint; saw before={before} after={after}"
+    )
+
+
+def test_snapshot_read_restores_isolation_level(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """The connection's isolation level must be restored on exit so
+    pool reuse does not leak REPEATABLE READ into the next request."""
+    prior = ebull_test_conn.isolation_level
+    with snapshot_read(ebull_test_conn):
+        pass
+    assert ebull_test_conn.isolation_level == prior
+
+
+def test_snapshot_read_restores_isolation_level_on_exception(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Restoration must run even when the block raises — otherwise a
+    test that errors mid-handler would leak REPEATABLE READ."""
+    prior = ebull_test_conn.isolation_level
+    with pytest.raises(RuntimeError, match="boom"):
+        with snapshot_read(ebull_test_conn):
+            raise RuntimeError("boom")
+    assert ebull_test_conn.isolation_level == prior


### PR DESCRIPTION
## What

- New helper [\`app/db/snapshot.py::snapshot_read\`](app/db/snapshot.py) — opens a REPEATABLE READ transaction so multi-query reads see one consistent snapshot. Captures prior \`isolation_level\` and restores it on exit so pool reuse can't leak.
- Applied to \`GET /alerts/guard-rejections\` (the 3-query handler from the issue body).
- Prevention rule extracted to [\`docs/review-prevention-log.md\`](docs/review-prevention-log.md) — multi-query GETs MUST use \`snapshot_read\`.

## Why

Per #395: three sequential reads through a READ COMMITTED connection let concurrent writers drift the count vs the rejections list. Same pattern lives in every multi-query GET in the repo; this PR ships the helper + first conversion + the prevention rule.

## Codex catch

First-pass shape ran \`_resolve_operator(conn)\` BEFORE \`snapshot_read\` opened its transaction. Pool connections are autocommit-off, so the resolver's SELECT silently opened an implicit READ COMMITTED transaction. \`conn.transaction()\` then nested as a savepoint and the isolation change had no effect — the snapshot would silently inherit READ COMMITTED. Fix: \`snapshot_read\` commits any pending implicit transaction at entry. Regression test \`test_snapshot_read_isolates_after_prior_statement\` mimics the FastAPI dependency pattern (prior SELECT → snapshot block) and asserts the snapshot still hides concurrent inserts.

## Test plan

- [x] \`uv run pytest\` 2940 pass, 1 skipped (4 new tests in \`tests/test_db_snapshot.py\`)
- [x] \`uv run ruff check . && uv run ruff format --check .\` clean
- [x] \`uv run pyright\` clean
- [x] Snapshot tests cover:
  - concurrent INSERT on a 2nd connection invisible inside the block
  - prior-statement scenario (Codex regression)
  - prior \`isolation_level\` restored on success
  - prior \`isolation_level\` restored on exception
- [x] Codex approve on the AND-guarded shape after the upfront \`commit()\`

## Follow-up

Other multi-query GETs in the repo should be migrated to \`snapshot_read\` as the pattern is encountered. Not in scope for this PR — the helper + first conversion + prevention rule is the deliverable.