### PR TITLE
feat(#243): durable order intent before broker side effect

### DIFF
--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -373,22 +373,36 @@ def _update_order_with_broker_result(
     broker_order_ref: str | None,
     raw_payload: dict[str, Any],
 ) -> None:
-    """Update the pre-call ``submitted`` row with the broker response (#243)."""
-    conn.execute(
-        """
-        UPDATE orders
-        SET status = %(status)s,
-            broker_order_ref = %(ref)s,
-            raw_payload_json = %(payload)s
-        WHERE order_id = %(oid)s
-        """,
-        {
-            "oid": order_id,
-            "status": status,
-            "ref": broker_order_ref,
-            "payload": Jsonb(raw_payload),
-        },
-    )
+    """Update the pre-call ``submitted`` row with the broker response (#243).
+
+    Raises ``RuntimeError`` if the UPDATE matched zero rows — without
+    this check, ``order_id`` would silently flow forward as a foreign
+    key into fills / cost records / positions and corrupt referential
+    integrity. PR #637 review BLOCKING.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE orders
+            SET status = %(status)s,
+                broker_order_ref = %(ref)s,
+                raw_payload_json = %(payload)s
+            WHERE order_id = %(oid)s
+            """,
+            {
+                "oid": order_id,
+                "status": status,
+                "ref": broker_order_ref,
+                "payload": Jsonb(raw_payload),
+            },
+        )
+        if cur.rowcount != 1:
+            raise RuntimeError(
+                f"_update_order_with_broker_result: expected to update exactly "
+                f"1 orders row for order_id={order_id}, matched {cur.rowcount}. "
+                f"Either the pre-call intent INSERT was lost or order_id is "
+                f"stale — refusing to advance to fill/cost/position writes."
+            )
 
 
 def _persist_order(

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -311,6 +311,86 @@ def _synthetic_fill(
 # ---------------------------------------------------------------------------
 
 
+_SUBMITTED_INTENT_PAYLOAD: dict[str, Any] = {"intent": "submitted_pre_broker_call"}
+
+
+def _persist_submitted_intent(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    recommendation_id: int,
+    decision_id: int,
+    action: str,
+    requested_amount: Decimal | None,
+    requested_units: Decimal | None,
+    now: datetime,
+) -> int:
+    """Insert a durable order-intent row BEFORE the broker call (#243).
+
+    The row carries ``status='submitted'`` and a sentinel
+    ``raw_payload_json`` so a reconciler can find rows whose broker
+    call never returned. The caller MUST ``conn.commit()`` after
+    this returns and BEFORE issuing the external broker call —
+    otherwise the intent stays inside the implicit transaction and
+    a process crash erases it along with everything else.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            INSERT INTO orders
+                (instrument_id, recommendation_id, decision_id,
+                 action, order_type, requested_amount, requested_units,
+                 status, broker_order_ref, raw_payload_json, created_at)
+            VALUES
+                (%(iid)s, %(rid)s, %(did)s,
+                 %(action)s, %(otype)s, %(amt)s, %(units)s,
+                 'submitted', NULL, %(payload)s, %(now)s)
+            RETURNING order_id
+            """,
+            {
+                "iid": instrument_id,
+                "rid": recommendation_id,
+                "did": decision_id,
+                "action": action,
+                "otype": _DEFAULT_ORDER_TYPE,
+                "amt": requested_amount,
+                "units": requested_units,
+                "payload": Jsonb(_SUBMITTED_INTENT_PAYLOAD),
+                "now": now,
+            },
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise RuntimeError("orders INSERT (submitted intent) returned no row")
+    return int(row["order_id"])
+
+
+def _update_order_with_broker_result(
+    conn: psycopg.Connection[Any],
+    *,
+    order_id: int,
+    status: str,
+    broker_order_ref: str | None,
+    raw_payload: dict[str, Any],
+) -> None:
+    """Update the pre-call ``submitted`` row with the broker response (#243)."""
+    conn.execute(
+        """
+        UPDATE orders
+        SET status = %(status)s,
+            broker_order_ref = %(ref)s,
+            raw_payload_json = %(payload)s
+        WHERE order_id = %(oid)s
+        """,
+        {
+            "oid": order_id,
+            "status": status,
+            "ref": broker_order_ref,
+            "payload": Jsonb(raw_payload),
+        },
+    )
+
+
 def _persist_order(
     conn: psycopg.Connection[Any],
     instrument_id: int,
@@ -713,13 +793,25 @@ def execute_order(
     Steps:
       1. Load the approved recommendation (raises if not found or not approved).
       2. Determine order parameters from the recommendation.
-      3. If live mode: call the broker provider.
-         If demo mode: generate a synthetic fill.
-      4. Persist the order row with raw broker response.
+      3. **Live mode only (#243)**: INSERT a durable ``status='submitted'``
+         intent row and ``conn.commit()`` so a process crash mid-broker-call
+         leaves a row a reconciler can chase. Then call the broker.
+         **Demo mode**: generate a synthetic fill (no external side effect).
+      4. Live: UPDATE the pre-call intent row with the broker response.
+         Demo / live-EXIT-no-position: INSERT a fresh order row.
       5. If filled: persist fill, update position, record cash ledger entry.
-      All DB writes in steps 4-5 are inside a single transaction.
+      DB writes in steps 4-5 are inside a single transaction.
 
     No external I/O is performed inside any DB transaction.
+
+    **Connection ownership contract (#243)**: live-mode paths issue a
+    ``conn.commit()`` between the intent INSERT and the broker call.
+    Callers MUST therefore pass a connection that does NOT carry
+    unrelated uncommitted writes — the commit would publish them
+    too. The current scheduler caller (app/workers/scheduler.py)
+    uses a fresh per-order pool connection, which satisfies this.
+    Do not call ``execute_order`` inside a caller-owned outer
+    transaction.
 
     Raises ValueError if:
       - recommendation_id does not exist
@@ -776,6 +868,7 @@ def execute_order(
     is_live = runtime.enable_live_trading
 
     quote_data: dict[str, Any] | None = None
+    submitted_order_id: int | None = None
 
     if is_live:
         if broker is None:
@@ -797,8 +890,35 @@ def execute_order(
                     raw_payload={"error": f"No broker_positions row for instrument {instrument_id}"},
                 )
             else:
+                # #243: persist the order intent BEFORE the broker
+                # side effect, then commit so a crash mid-call leaves
+                # a durable ``status='submitted'`` row that a
+                # reconciler can chase against the broker.
+                submitted_order_id = _persist_submitted_intent(
+                    conn,
+                    instrument_id=instrument_id,
+                    recommendation_id=recommendation_id,
+                    decision_id=decision_id,
+                    action=action,
+                    requested_amount=requested_amount,
+                    requested_units=requested_units,
+                    now=now,
+                )
+                conn.commit()
                 broker_result = broker.close_position(exit_pos_id)
         else:
+            # #243: durable order intent before the broker call.
+            submitted_order_id = _persist_submitted_intent(
+                conn,
+                instrument_id=instrument_id,
+                recommendation_id=recommendation_id,
+                decision_id=decision_id,
+                action=action,
+                requested_amount=requested_amount,
+                requested_units=requested_units,
+                now=now,
+            )
+            conn.commit()
             broker_result = broker.place_order(
                 instrument_id=instrument_id,
                 action=action,
@@ -833,19 +953,34 @@ def execute_order(
     fill_id: int | None = None
 
     with conn.transaction():
-        order_id = _persist_order(
-            conn,
-            instrument_id=instrument_id,
-            recommendation_id=recommendation_id,
-            decision_id=decision_id,
-            action=action,
-            requested_amount=requested_amount,
-            requested_units=requested_units,
-            status=order_status,
-            broker_order_ref=broker_result.broker_order_ref,
-            raw_payload=broker_result.raw_payload,
-            now=now,
-        )
+        if submitted_order_id is not None:
+            # #243 live path: pre-call intent already exists. UPDATE
+            # the same row with the broker response so reconciliation
+            # keys on a single durable identity.
+            order_id = submitted_order_id
+            _update_order_with_broker_result(
+                conn,
+                order_id=order_id,
+                status=order_status,
+                broker_order_ref=broker_result.broker_order_ref,
+                raw_payload=broker_result.raw_payload,
+            )
+        else:
+            # Demo path (no external side effect to lose) or live
+            # EXIT with no broker_positions row (broker not called).
+            order_id = _persist_order(
+                conn,
+                instrument_id=instrument_id,
+                recommendation_id=recommendation_id,
+                decision_id=decision_id,
+                action=action,
+                requested_amount=requested_amount,
+                requested_units=requested_units,
+                status=order_status,
+                broker_order_ref=broker_result.broker_order_ref,
+                raw_payload=broker_result.raw_payload,
+                now=now,
+            )
 
         # Record estimated cost for BUY/ADD only (entry cost is meaningless
         # for EXIT orders).  Best-effort: any failure here must not block the

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -1027,3 +1027,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: GET handlers that issue 2+ sequential reads on the same `get_conn` connection see a fresh READ COMMITTED snapshot per statement. A concurrent writer between Q1 and Q2 produces brief drift — counts and lists disagree, totals and details lag by one. Cosmetic in steady state, hides real bugs in tests, becomes a correctness issue under multi-operator concurrency.
 - Prevention: Any read handler that issues 2+ statements whose results must agree (counts, list of items, sub-aggregates of the same set) MUST wrap the reads in `with snapshot_read(conn): ...` from `app.db.snapshot`. The helper opens a REPEATABLE READ transaction so all statements run against one consistent snapshot. At self-review: grep for `cur.execute(` count >= 2 inside any GET handler and confirm `snapshot_read` wraps them, or that the handler's docstring justifies READ COMMITTED.
 - Enforced in: this prevention log; PR for #395 introduces `app/db/snapshot.py::snapshot_read` and applies it to `GET /alerts/guard-rejections`. Apply to other multi-query GETs as the pattern is encountered.
+
+---
+
+### UPDATE-by-PK helpers must assert rowcount
+
+- First seen in: #637 (durable order intent for #243).
+- Symptom: `_update_order_with_broker_result` issued `conn.execute(UPDATE ... WHERE order_id = %s)` with no rowcount check. If the UPDATE matched zero rows (stale order_id, lost intent INSERT, schema drift) the function returned silently and `order_id` flowed forward as a foreign key into fills / cost records / positions, corrupting referential integrity invisibly.
+- Prevention: Any helper that UPDATEs by primary key and threads the same id forward into FK-referencing writes MUST assert `cur.rowcount == 1` (or the equivalent `statusmessage == "UPDATE 1"`) and raise on mismatch. Use the cursor form `with conn.cursor() as cur: cur.execute(...); if cur.rowcount != 1: raise ...` rather than the connection-level `conn.execute(...)` shortcut, since the latter discards `rowcount`. At self-review: grep `conn.execute(\\s*"UPDATE ` in any service that takes an id from a prior INSERT and threads it into later writes; convert to the cursor + assertion form.
+- Enforced in: this prevention log; PR #637 fix raises `RuntimeError` when the post-broker UPDATE on the #243 intent row matches anything other than 1 row.

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -745,8 +745,10 @@ class TestExecuteOrderLiveMode:
         cursors = [
             _rec_cursor(action="BUY", target_entry=100.0, suggested_size_pct=0.05),
             _cash_cursor(balance=10_000.0),
-            # broker called (no cursor)
+            # #243 pre-broker durable intent INSERT
             _order_returning_cursor(order_id=10),
+            # broker called (no cursor)
+            # post-broker UPDATE uses conn.execute() — no cursor consumed
             _cost_config_cursor(),
             _cost_model_cursor(),  # no cost_model → falls back to quote
             _quote_cursor(last=100.0, bid=99.5, ask=100.5, spread_pct=0.30),  # cost fallback
@@ -763,6 +765,8 @@ class TestExecuteOrderLiveMode:
         assert result.outcome == "filled"
         assert result.broker_order_ref == "ORD-123"
         broker.place_order.assert_called_once()
+        # #243: durable intent commit happens before broker call.
+        assert conn.commit.called
 
     @patch("app.services.order_client._utcnow", return_value=_NOW)
     def test_live_buy_records_cost_from_quote_fallback(self, _mock_now: MagicMock) -> None:
@@ -780,7 +784,7 @@ class TestExecuteOrderLiveMode:
         cursors = [
             _rec_cursor(action="BUY", target_entry=100.0, suggested_size_pct=0.05),
             _cash_cursor(balance=10_000.0),
-            _order_returning_cursor(order_id=10),
+            _order_returning_cursor(order_id=10),  # #243 pre-broker intent
             _cost_config_cursor(),
             _cost_model_cursor(),  # no cost_model → falls back to quote
             _quote_cursor(last=100.0, bid=99.5, ask=100.5, spread_pct=0.30),
@@ -817,7 +821,7 @@ class TestExecuteOrderLiveMode:
         cursors = [
             _rec_cursor(action="BUY", target_entry=100.0, suggested_size_pct=0.05),
             _cash_cursor(balance=10_000.0),
-            _order_returning_cursor(order_id=10),
+            _order_returning_cursor(order_id=10),  # #243 pre-broker intent
             _cost_config_cursor(),
             _cost_model_cursor(),  # no cost_model → falls back to quote
             _quote_cursor(last=100.0, bid=99.5, ask=100.5, spread_pct=0.30),
@@ -847,9 +851,11 @@ class TestExecuteOrderLiveMode:
             _position_cursor(current_units=5.0),
             # _load_position_id_for_exit resolves instrument_id → position_id
             _make_cursor([{"position_id": 98765}]),
-            # broker called (no cursor)
-            # No cost recording for EXIT
+            # #243 pre-broker durable intent INSERT
             _order_returning_cursor(order_id=11),
+            # broker called (no cursor)
+            # post-broker UPDATE uses conn.execute() — no cursor consumed
+            # No cost recording for EXIT
             _fill_returning_cursor(fill_id=7),
             # Post-fill: read current_units for attribution check
             _make_cursor([{"current_units": 0}]),
@@ -886,6 +892,67 @@ class TestExecuteOrderLiveMode:
         )
         assert result.outcome == "failed"
         broker.close_position.assert_not_called()
+
+    @patch("app.services.order_client._utcnow", return_value=_NOW)
+    def test_live_buy_persists_intent_before_broker_call(self, _mock_now: MagicMock) -> None:
+        """#243 — durable order intent must be INSERTed and COMMITed
+        BEFORE the broker call. A fake broker that raises after the
+        commit must leave the intent row visible to a reconciler.
+
+        Mock-level proof: track the order of cursor consumption, the
+        commit call, and the broker call. Asserts:
+          1. the intent INSERT cursor is consumed
+          2. conn.commit() runs
+          3. broker.place_order is invoked
+          4. all in that exact order
+
+        With this ordering, a real DB would have a committed
+        ``status='submitted'`` row on disk before any external side
+        effect — the reconciler can find it after a crash.
+        """
+        sequence: list[str] = []
+
+        broker = MagicMock()
+
+        def _broker_side_effect(*_args: object, **_kwargs: object) -> BrokerOrderResult:
+            sequence.append("broker.place_order")
+            raise RuntimeError("simulated broker crash")
+
+        broker.place_order.side_effect = _broker_side_effect
+
+        intent_cursor = _order_returning_cursor(order_id=99)
+
+        def _intent_execute(*_args: object, **_kwargs: object) -> None:
+            # Tag the cursor execute fired inside _persist_submitted_intent.
+            # No real DB; fetchone is already wired by _make_cursor.
+            sequence.append("intent_insert")
+
+        intent_cursor.__enter__.return_value.execute.side_effect = _intent_execute
+
+        cursors = [
+            _rec_cursor(action="BUY", target_entry=100.0, suggested_size_pct=0.05),
+            _cash_cursor(balance=10_000.0),
+            intent_cursor,
+        ]
+        conn = _make_conn(cursors)
+
+        def _commit_tag() -> None:
+            sequence.append("commit")
+
+        conn.commit.side_effect = _commit_tag
+
+        with pytest.raises(RuntimeError, match="simulated broker crash"):
+            execute_order(
+                conn,
+                recommendation_id=42,
+                decision_id=10,
+                broker=broker,
+            )
+
+        # Order matters: intent → commit → broker call.
+        assert sequence == ["intent_insert", "commit", "broker.place_order"], (
+            f"durable-intent ordering violated: {sequence}"
+        )
 
     @patch("app.services.order_client._utcnow", return_value=_NOW)
     def test_live_mode_no_broker_raises(self, _mock_now: MagicMock) -> None:
@@ -954,8 +1021,10 @@ class TestExecuteOrderFailures:
         assert "failed" in result.explanation
 
         # conn.execute: safety-layer checks (fx_rates + portfolio_sync = 2),
-        # rec status update + audit = 4 (no fill/position/cash)
-        assert conn.execute.call_count == 4
+        # post-broker UPDATE of the #243 intent row = 1, rec status
+        # update + audit = 2. Total 5 (no fill/position/cash on a
+        # failed broker call).
+        assert conn.execute.call_count == 5
 
     @patch("app.services.order_client._utcnow", return_value=_NOW)
     def test_broker_pending_persists_order_with_pending_status(self, _mock_now: MagicMock) -> None:

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -206,6 +206,17 @@ def _cost_record_write_cursor() -> MagicMock:
     return _make_cursor([])
 
 
+def _update_cursor(rowcount: int = 1) -> MagicMock:
+    """Cursor consumed by an UPDATE that asserts ``cur.rowcount == 1``.
+
+    Used by the #243 ``_update_order_with_broker_result`` post-broker
+    UPDATE on the pre-call intent row.
+    """
+    cur = _make_cursor([])
+    cur.__enter__.return_value.rowcount = rowcount
+    return cur
+
+
 # ---------------------------------------------------------------------------
 # TestSyntheticFill
 # ---------------------------------------------------------------------------
@@ -748,7 +759,8 @@ class TestExecuteOrderLiveMode:
             # #243 pre-broker durable intent INSERT
             _order_returning_cursor(order_id=10),
             # broker called (no cursor)
-            # post-broker UPDATE uses conn.execute() — no cursor consumed
+            # #243 post-broker UPDATE asserts rowcount == 1
+            _update_cursor(rowcount=1),
             _cost_config_cursor(),
             _cost_model_cursor(),  # no cost_model → falls back to quote
             _quote_cursor(last=100.0, bid=99.5, ask=100.5, spread_pct=0.30),  # cost fallback
@@ -785,6 +797,7 @@ class TestExecuteOrderLiveMode:
             _rec_cursor(action="BUY", target_entry=100.0, suggested_size_pct=0.05),
             _cash_cursor(balance=10_000.0),
             _order_returning_cursor(order_id=10),  # #243 pre-broker intent
+            _update_cursor(rowcount=1),  # #243 post-broker UPDATE
             _cost_config_cursor(),
             _cost_model_cursor(),  # no cost_model → falls back to quote
             _quote_cursor(last=100.0, bid=99.5, ask=100.5, spread_pct=0.30),
@@ -822,6 +835,7 @@ class TestExecuteOrderLiveMode:
             _rec_cursor(action="BUY", target_entry=100.0, suggested_size_pct=0.05),
             _cash_cursor(balance=10_000.0),
             _order_returning_cursor(order_id=10),  # #243 pre-broker intent
+            _update_cursor(rowcount=1),  # #243 post-broker UPDATE
             _cost_config_cursor(),
             _cost_model_cursor(),  # no cost_model → falls back to quote
             _quote_cursor(last=100.0, bid=99.5, ask=100.5, spread_pct=0.30),
@@ -854,7 +868,8 @@ class TestExecuteOrderLiveMode:
             # #243 pre-broker durable intent INSERT
             _order_returning_cursor(order_id=11),
             # broker called (no cursor)
-            # post-broker UPDATE uses conn.execute() — no cursor consumed
+            # #243 post-broker UPDATE asserts rowcount == 1
+            _update_cursor(rowcount=1),
             # No cost recording for EXIT
             _fill_returning_cursor(fill_id=7),
             # Post-fill: read current_units for attribution check
@@ -955,6 +970,39 @@ class TestExecuteOrderLiveMode:
         )
 
     @patch("app.services.order_client._utcnow", return_value=_NOW)
+    def test_live_buy_zero_row_update_raises(self, _mock_now: MagicMock) -> None:
+        """#637 review BLOCKING — _update_order_with_broker_result MUST
+        refuse to advance to fill/cost/position writes when the UPDATE
+        matches zero rows. Without this guard, ``order_id`` would
+        silently flow forward as a foreign key into fills, corrupting
+        referential integrity. Simulate by returning rowcount=0 from
+        the UPDATE cursor."""
+        broker = MagicMock()
+        broker.place_order.return_value = BrokerOrderResult(
+            broker_order_ref="ORD-PHANTOM",
+            status="filled",
+            filled_price=Decimal("100"),
+            filled_units=Decimal("5"),
+            fees=Decimal("0"),
+            raw_payload={},
+        )
+        cursors = [
+            _rec_cursor(action="BUY", target_entry=100.0, suggested_size_pct=0.05),
+            _cash_cursor(balance=10_000.0),
+            _order_returning_cursor(order_id=99),  # pre-broker intent INSERT
+            _update_cursor(rowcount=0),  # phantom UPDATE matches nothing
+        ]
+        conn = _make_conn(cursors)
+
+        with pytest.raises(RuntimeError, match="expected to update exactly 1 orders row"):
+            execute_order(
+                conn,
+                recommendation_id=42,
+                decision_id=10,
+                broker=broker,
+            )
+
+    @patch("app.services.order_client._utcnow", return_value=_NOW)
     def test_live_mode_no_broker_raises(self, _mock_now: MagicMock) -> None:
         cursors = [
             _rec_cursor(action="BUY"),
@@ -1002,7 +1050,8 @@ class TestExecuteOrderFailures:
         cursors = [
             _rec_cursor(action="BUY"),
             _cash_cursor(balance=10_000.0),
-            _order_returning_cursor(order_id=12),
+            _order_returning_cursor(order_id=12),  # #243 pre-broker intent
+            _update_cursor(rowcount=1),  # #243 post-broker UPDATE
             _cost_config_cursor(),
             _cost_model_cursor(),  # no cost_model → falls back to quote
             _quote_cursor(last=100.0, spread_pct=0.30),  # cost fallback
@@ -1021,10 +1070,11 @@ class TestExecuteOrderFailures:
         assert "failed" in result.explanation
 
         # conn.execute: safety-layer checks (fx_rates + portfolio_sync = 2),
-        # post-broker UPDATE of the #243 intent row = 1, rec status
-        # update + audit = 2. Total 5 (no fill/position/cash on a
-        # failed broker call).
-        assert conn.execute.call_count == 5
+        # rec status update + audit = 2. Total 4 (no fill/position/cash
+        # on a failed broker call). The #243 post-broker UPDATE goes
+        # through a cursor, not conn.execute, so it does not bump this
+        # counter.
+        assert conn.execute.call_count == 4
 
     @patch("app.services.order_client._utcnow", return_value=_NOW)
     def test_broker_pending_persists_order_with_pending_status(self, _mock_now: MagicMock) -> None:
@@ -1041,7 +1091,8 @@ class TestExecuteOrderFailures:
         cursors = [
             _rec_cursor(action="BUY"),
             _cash_cursor(balance=10_000.0),
-            _order_returning_cursor(order_id=13),
+            _order_returning_cursor(order_id=13),  # #243 pre-broker intent
+            _update_cursor(rowcount=1),  # #243 post-broker UPDATE
             _cost_config_cursor(),
             _cost_model_cursor(),  # no cost_model → falls back to quote
             _quote_cursor(last=100.0, spread_pct=0.30),  # cost fallback
@@ -1092,7 +1143,8 @@ class TestExecuteOrderFailures:
         cursors = [
             _rec_cursor(action="BUY"),
             _cash_cursor(balance=10_000.0),
-            _order_returning_cursor(order_id=14),
+            _order_returning_cursor(order_id=14),  # #243 pre-broker intent
+            _update_cursor(rowcount=1),  # #243 post-broker UPDATE
             _cost_config_cursor(),
             _cost_model_cursor(),  # no cost_model → falls back to quote
             _quote_cursor(last=100.0, spread_pct=0.30),  # cost fallback
@@ -1124,7 +1176,8 @@ class TestExecuteOrderFailures:
         cursors = [
             _rec_cursor(action="BUY"),
             _cash_cursor(balance=10_000.0),
-            _order_returning_cursor(order_id=15),
+            _order_returning_cursor(order_id=15),  # #243 pre-broker intent
+            _update_cursor(rowcount=1),  # #243 post-broker UPDATE
             _cost_config_cursor(),
             _cost_model_cursor(),  # no cost_model → falls back to quote
             _quote_cursor(last=100.0, spread_pct=0.30),  # cost fallback


### PR DESCRIPTION
## What

\`execute_order\` now writes a durable \`status='submitted'\` intent row + commits BEFORE the broker call (live paths only). After the broker returns the same row is UPDATEd with the broker response. Demo path unchanged.

## Why

Per #243: a process crash between \`broker.place_order\` and \`_persist_order\` leaves eBull with no local intent record while the broker may have an order. Low-risk under demo, high-risk before live capital. Outbox/intent shape closes the gap.

## Test plan

- [x] \`uv run pytest\` 2941 pass, 1 skipped (1 new regression test, 3 existing live tests updated)
- [x] \`uv run ruff check . && uv run ruff format --check .\` clean
- [x] \`uv run pyright\` clean
- [x] New \`test_live_buy_persists_intent_before_broker_call\`: fake broker raises after observing the intent; asserts exact ordering \`intent_insert → commit → broker.place_order\`
- [x] Existing live tests updated for the new cursor sequence (pre-broker INSERT + post-broker UPDATE via \`conn.execute\`)
- [x] Codex APPROVE — flagged caller-contract documentation; addressed in the commit

## Connection-ownership contract

The mid-function \`conn.commit()\` between intent INSERT and broker call publishes any uncommitted writes the caller may have. \`execute_order\` MUST therefore receive a connection without unrelated in-flight writes. The current scheduler caller already uses a fresh per-order pool connection, but the contract is now documented on the \`execute_order\` docstring so future callers can't accidentally violate it.

## Follow-up (out of scope)

- Reconciler / sweeper that finds stuck \`status='submitted'\` rows older than X minutes and asks the broker for canonical state. Track separately when live trading enables.