### PR TITLE
feat(#540): retrofit fundamentals_snapshot to SEC-only cohort

### DIFF
--- a/app/services/sync_orchestrator/content_predicates.py
+++ b/app/services/sync_orchestrator/content_predicates.py
@@ -49,7 +49,10 @@ def candles_content_ok(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
 
 
 def fundamentals_content_ok(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
-    """Every tradable instrument must have a fundamentals_snapshot row in the current quarter."""
+    """Every SEC-CIK-mapped tradable instrument must have a fundamentals_snapshot
+    row in the current quarter. #540: scoped to SEC-CIK only — non-US
+    instruments have no fundamentals source today.
+    """
     today = date.today()
     quarter = (today.month - 1) // 3
     quarter_start = date(today.year, quarter * 3 + 1, 1)
@@ -57,6 +60,11 @@ def fundamentals_content_ok(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
         """
         SELECT COUNT(*) AS missing
         FROM instruments i
+        JOIN external_identifiers ei
+            ON ei.instrument_id = i.instrument_id
+           AND ei.provider = 'sec'
+           AND ei.identifier_type = 'cik'
+           AND ei.is_primary = TRUE
         WHERE i.is_tradable = TRUE
           AND NOT EXISTS (
               SELECT 1 FROM fundamentals_snapshot fs
@@ -70,7 +78,7 @@ def fundamentals_content_ok(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
     if missing > 0:
         return (
             False,
-            f"{missing} tradable instruments lack fundamentals snapshot "
+            f"{missing} SEC-CIK tradable instruments lack fundamentals snapshot "
             f"for quarter starting {quarter_start.isoformat()}",
         )
     return True, "all tradable instruments have snapshot"

--- a/app/services/sync_orchestrator/freshness.py
+++ b/app/services/sync_orchestrator/freshness.py
@@ -156,13 +156,33 @@ def fundamentals_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
     audit_fresh, audit_detail = _fresh_by_audit(conn, "daily_research_refresh", timedelta(hours=24))
     if not audit_fresh:
         return False, audit_detail
-    # Content check: every tradable instrument must have a
-    # fundamentals_snapshot row with as_of_date in the current quarter.
+    # Content check: every SEC-CIK-mapped tradable instrument must
+    # have a fundamentals_snapshot row with as_of_date in the
+    # current quarter. #540: scoped to SEC-CIK only — non-US /
+    # crypto / commodity instruments have no public-source
+    # fundamentals path today and would otherwise alarm
+    # indefinitely (cosmetic noise on the operator dashboard).
+    #
+    # Cohort alignment with the producer: this reader scopes to
+    # ``is_primary = TRUE`` CIKs, and the SEC fundamentals producer
+    # in ``app/workers/scheduler.py::daily_research_refresh`` was
+    # tightened in this PR (#540) to filter on the same predicate.
+    # Either side regressing back to "every sec/cik row" would
+    # re-introduce silent issuer-mix corruption on instruments with
+    # demoted historical CIKs — the SQL-shape regression tests in
+    # ``tests/test_sync_orchestrator_freshness.py`` and
+    # ``tests/services/sync_orchestrator/test_content_predicates.py``
+    # pin both sides.
     quarter_start = _current_quarter_start(date.today())
     row = conn.execute(
         """
         SELECT COUNT(*) AS missing
         FROM instruments i
+        JOIN external_identifiers ei
+            ON ei.instrument_id = i.instrument_id
+           AND ei.provider = 'sec'
+           AND ei.identifier_type = 'cik'
+           AND ei.is_primary = TRUE
         WHERE i.is_tradable = TRUE
           AND NOT EXISTS (
               SELECT 1 FROM fundamentals_snapshot fs
@@ -176,7 +196,7 @@ def fundamentals_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
     if missing > 0:
         return (
             False,
-            f"{missing} tradable instruments lack fundamentals snapshot "
+            f"{missing} SEC-CIK tradable instruments lack fundamentals snapshot "
             f"for quarter starting {quarter_start.isoformat()}",
         )
     return True, audit_detail

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1228,7 +1228,13 @@ def daily_research_refresh() -> None:
                 """
             ).fetchall()
 
-            # Build symbol→CIK mapping for SEC fundamentals
+            # Build symbol→CIK mapping for SEC fundamentals.
+            # #540: scope to primary CIKs only so the producer cohort
+            # matches the reader's freshness check (which now also
+            # filters on is_primary=TRUE). Without this, a demoted
+            # historical CIK row could feed the refresh against the
+            # wrong issuer while the reader counted the instrument as
+            # missing — silent issuer-mix corruption.
             cik_rows = conn.execute(
                 """
                 SELECT i.symbol, ei.identifier_value
@@ -1236,6 +1242,7 @@ def daily_research_refresh() -> None:
                 JOIN instruments i ON i.instrument_id = ei.instrument_id
                 WHERE ei.provider = 'sec'
                   AND ei.identifier_type = 'cik'
+                  AND ei.is_primary = TRUE
                   AND i.is_tradable = TRUE
                 """
             ).fetchall()

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -1036,3 +1036,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `_update_order_with_broker_result` issued `conn.execute(UPDATE ... WHERE order_id = %s)` with no rowcount check. If the UPDATE matched zero rows (stale order_id, lost intent INSERT, schema drift) the function returned silently and `order_id` flowed forward as a foreign key into fills / cost records / positions, corrupting referential integrity invisibly.
 - Prevention: Any helper that UPDATEs by primary key and threads the same id forward into FK-referencing writes MUST assert `cur.rowcount == 1` (or the equivalent `statusmessage == "UPDATE 1"`) and raise on mismatch. Use the cursor form `with conn.cursor() as cur: cur.execute(...); if cur.rowcount != 1: raise ...` rather than the connection-level `conn.execute(...)` shortcut, since the latter discards `rowcount`. At self-review: grep `conn.execute(\\s*"UPDATE ` in any service that takes an id from a prior INSERT and threads it into later writes; convert to the cursor + assertion form.
 - Enforced in: this prevention log; PR #637 fix raises `RuntimeError` when the post-broker UPDATE on the #243 intent row matches anything other than 1 row.
+
+---
+
+### Positional `call_args_list` index in SQL-shape regression tests
+
+- First seen in: #639 (#540 SEC-CIK cohort pins).
+- Symptom: SQL-shape regression tests asserted on `mock.call_args_list[1].args[0]` (the second mock-conn execute call). A future refactor that inserts an extra `conn.execute()` earlier in the flow silently shifts the index, so the test asserts on the wrong call and the actual SQL filter regression goes undetected. The test stays green for the wrong reason.
+- Prevention: Identify the target call by content filter, not position. Use `[c for c in mock.call_args_list if c.args and "<distinguishing token>" in c.args[0]]` and assert exactly one match before reading the SQL. The distinguishing token should be a noun the query is meant to use (e.g. `external_identifiers`, the table the predicate is enforcing) — not a generic SQL keyword. At self-review: grep `call_args_list\[\d\]\.args\[0\]` and convert each to a content-filter form.
+- Enforced in: this prevention log; PR #639 fix replaces both positional indexes with content filters in `test_daily_research_refresh_dedupe.py` and `test_sync_orchestrator_freshness.py`.

--- a/tests/services/sync_orchestrator/test_content_predicates.py
+++ b/tests/services/sync_orchestrator/test_content_predicates.py
@@ -47,3 +47,18 @@ def test_fundamentals_content_missing_reports_count() -> None:
     ok, detail = fundamentals_content_ok(conn)
     assert ok is False
     assert "5" in detail
+
+
+def test_fundamentals_content_query_filters_to_sec_cik_cohort() -> None:
+    # #540: pin the SEC-CIK JOIN so a future refactor cannot silently
+    # widen the cohort back to "every tradable instrument", which
+    # would re-introduce the cosmetic alarm storm on non-US / crypto
+    # / commodity instruments that have no public fundamentals source.
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = (0,)
+    fundamentals_content_ok(conn)
+    sql = conn.execute.call_args.args[0]
+    assert "external_identifiers" in sql
+    assert "ei.provider = 'sec'" in sql
+    assert "ei.identifier_type = 'cik'" in sql
+    assert "ei.is_primary = TRUE" in sql

--- a/tests/test_daily_research_refresh_dedupe.py
+++ b/tests/test_daily_research_refresh_dedupe.py
@@ -190,3 +190,38 @@ def test_sec_fundamentals_flag_true_skips_refresh_fundamentals(monkeypatch) -> N
     # No SEC XBRL path means refresh_fundamentals is never called.
     # FMP was retired in #532 — no fallback path remains.
     refresh_fund_mock.assert_not_called()
+
+
+def test_cik_lookup_query_filters_to_primary_cik(monkeypatch) -> None:
+    """#540 producer-side cohort guard: the symbol→CIK lookup MUST
+    filter on ``ei.is_primary = TRUE`` so the SEC fundamentals
+    refresh runs against the same cohort the freshness reader
+    expects (``app/services/sync_orchestrator/freshness.py::
+    fundamentals_is_fresh``). Regressing this filter would let a
+    demoted historical CIK feed the refresh against the wrong
+    issuer while the freshness reader silently reports the
+    instrument as missing — issuer-mix corruption.
+    """
+    stub_settings = MagicMock()
+    stub_settings.database_url = "postgresql://test"
+    stub_settings.sec_user_agent = "test"
+    stub_settings.companies_house_api_key = None
+    stub_settings.enable_filings_fetch_dedupe = False
+    stub_settings.enable_sec_fundamentals_dedupe = False
+    monkeypatch.setattr(scheduler, "settings", stub_settings)
+
+    _base_mocks(monkeypatch)
+
+    scheduler.daily_research_refresh()
+
+    # Inspect every conn.execute() call for the cik lookup. The
+    # second execute on the connection is the cik_rows query.
+    connect_call = scheduler.psycopg.connect.call_args_list[0]
+    fake_conn = scheduler.psycopg.connect.return_value.__enter__.return_value
+    cik_query = fake_conn.execute.call_args_list[1].args[0]
+    assert "external_identifiers" in cik_query
+    assert "ei.provider = 'sec'" in cik_query
+    assert "ei.identifier_type = 'cik'" in cik_query
+    assert "ei.is_primary = TRUE" in cik_query
+    # Sanity: the connect call argument is the configured DB URL.
+    assert connect_call.args[0] == "postgresql://test"

--- a/tests/test_daily_research_refresh_dedupe.py
+++ b/tests/test_daily_research_refresh_dedupe.py
@@ -224,13 +224,8 @@ def test_cik_lookup_query_filters_to_primary_cik(monkeypatch) -> None:
     # Content filter rather than positional index: a future refactor
     # that inserts another conn.execute() earlier in the flow would
     # otherwise silently assert on the wrong query (#639 WARNING).
-    cik_query_calls = [
-        c for c in fake_conn.execute.call_args_list
-        if c.args and "external_identifiers" in c.args[0]
-    ]
-    assert len(cik_query_calls) == 1, (
-        f"expected exactly one cik-lookup execute, got {len(cik_query_calls)}"
-    )
+    cik_query_calls = [c for c in fake_conn.execute.call_args_list if c.args and "external_identifiers" in c.args[0]]
+    assert len(cik_query_calls) == 1, f"expected exactly one cik-lookup execute, got {len(cik_query_calls)}"
     cik_query = cik_query_calls[0].args[0]
     assert "ei.provider = 'sec'" in cik_query
     assert "ei.identifier_type = 'cik'" in cik_query

--- a/tests/test_daily_research_refresh_dedupe.py
+++ b/tests/test_daily_research_refresh_dedupe.py
@@ -215,16 +215,23 @@ def test_cik_lookup_query_filters_to_primary_cik(monkeypatch) -> None:
 
     scheduler.daily_research_refresh()
 
-    # Inspect every conn.execute() call for the cik lookup. The
-    # second execute on the connection is the cik_rows query.
     # ``scheduler.psycopg.connect`` is monkeypatched with a MagicMock
     # at the top of this test (via _base_mocks), but pyright sees
     # the real function signature; cast through Any.
     connect_mock: Any = scheduler.psycopg.connect
     connect_call = connect_mock.call_args_list[0]
     fake_conn = connect_mock.return_value.__enter__.return_value
-    cik_query = fake_conn.execute.call_args_list[1].args[0]
-    assert "external_identifiers" in cik_query
+    # Content filter rather than positional index: a future refactor
+    # that inserts another conn.execute() earlier in the flow would
+    # otherwise silently assert on the wrong query (#639 WARNING).
+    cik_query_calls = [
+        c for c in fake_conn.execute.call_args_list
+        if c.args and "external_identifiers" in c.args[0]
+    ]
+    assert len(cik_query_calls) == 1, (
+        f"expected exactly one cik-lookup execute, got {len(cik_query_calls)}"
+    )
+    cik_query = cik_query_calls[0].args[0]
     assert "ei.provider = 'sec'" in cik_query
     assert "ei.identifier_type = 'cik'" in cik_query
     assert "ei.is_primary = TRUE" in cik_query

--- a/tests/test_daily_research_refresh_dedupe.py
+++ b/tests/test_daily_research_refresh_dedupe.py
@@ -7,6 +7,7 @@ the reason. Companies House path unaffected either way.
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 from app.workers import scheduler
@@ -216,8 +217,12 @@ def test_cik_lookup_query_filters_to_primary_cik(monkeypatch) -> None:
 
     # Inspect every conn.execute() call for the cik lookup. The
     # second execute on the connection is the cik_rows query.
-    connect_call = scheduler.psycopg.connect.call_args_list[0]
-    fake_conn = scheduler.psycopg.connect.return_value.__enter__.return_value
+    # ``scheduler.psycopg.connect`` is monkeypatched with a MagicMock
+    # at the top of this test (via _base_mocks), but pyright sees
+    # the real function signature; cast through Any.
+    connect_mock: Any = scheduler.psycopg.connect
+    connect_call = connect_mock.call_args_list[0]
+    fake_conn = connect_mock.return_value.__enter__.return_value
     cik_query = fake_conn.execute.call_args_list[1].args[0]
     assert "external_identifiers" in cik_query
     assert "ei.provider = 'sec'" in cik_query

--- a/tests/test_sync_orchestrator_freshness.py
+++ b/tests/test_sync_orchestrator_freshness.py
@@ -274,7 +274,9 @@ class TestFundamentalsIsFresh:
         )
         fresh, detail = fundamentals_is_fresh(conn)
         assert fresh is False
-        assert "5 tradable instruments lack fundamentals snapshot" in detail
+        # #540: scoped to SEC-CIK only — non-US / crypto / commodity
+        # instruments cannot have a fundamentals_snapshot row today.
+        assert "5 SEC-CIK tradable instruments lack fundamentals snapshot" in detail
 
     def test_fresh_when_all_have_quarter_snapshot(self) -> None:
         now = datetime.now(UTC)
@@ -283,6 +285,22 @@ class TestFundamentalsIsFresh:
         )
         fresh, _ = fundamentals_is_fresh(conn)
         assert fresh is True
+
+    def test_query_filters_to_sec_cik_cohort(self) -> None:
+        # #540: pin the SEC-CIK JOIN so a future refactor cannot
+        # silently widen the cohort back to "every tradable
+        # instrument" and re-introduce noise on non-SEC instruments.
+        now = datetime.now(UTC)
+        conn = _mock_conn_with_rows(
+            [(now - timedelta(hours=1), "success", None, timedelta(hours=1).total_seconds()), (0,)]
+        )
+        fundamentals_is_fresh(conn)
+        # Second execute call is the missing-snapshot count query.
+        snapshot_query = conn.execute.call_args_list[1].args[0]
+        assert "external_identifiers" in snapshot_query
+        assert "ei.provider = 'sec'" in snapshot_query
+        assert "ei.identifier_type = 'cik'" in snapshot_query
+        assert "ei.is_primary = TRUE" in snapshot_query
 
 
 class TestScoringIsFresh:

--- a/tests/test_sync_orchestrator_freshness.py
+++ b/tests/test_sync_orchestrator_freshness.py
@@ -295,9 +295,19 @@ class TestFundamentalsIsFresh:
             [(now - timedelta(hours=1), "success", None, timedelta(hours=1).total_seconds()), (0,)]
         )
         fundamentals_is_fresh(conn)
-        # Second execute call is the missing-snapshot count query.
-        snapshot_query = conn.execute.call_args_list[1].args[0]
-        assert "external_identifiers" in snapshot_query
+        # Content filter rather than positional index — a future
+        # refactor inserting another conn.execute() before the
+        # snapshot query would otherwise silently assert on the
+        # wrong call (#639 WARNING).
+        snapshot_query_calls = [
+            c for c in conn.execute.call_args_list
+            if c.args and "external_identifiers" in c.args[0]
+        ]
+        assert len(snapshot_query_calls) == 1, (
+            f"expected exactly one snapshot-cohort execute, "
+            f"got {len(snapshot_query_calls)}"
+        )
+        snapshot_query = snapshot_query_calls[0].args[0]
         assert "ei.provider = 'sec'" in snapshot_query
         assert "ei.identifier_type = 'cik'" in snapshot_query
         assert "ei.is_primary = TRUE" in snapshot_query

--- a/tests/test_sync_orchestrator_freshness.py
+++ b/tests/test_sync_orchestrator_freshness.py
@@ -300,12 +300,10 @@ class TestFundamentalsIsFresh:
         # snapshot query would otherwise silently assert on the
         # wrong call (#639 WARNING).
         snapshot_query_calls = [
-            c for c in conn.execute.call_args_list
-            if c.args and "external_identifiers" in c.args[0]
+            c for c in conn.execute.call_args_list if c.args and "external_identifiers" in c.args[0]
         ]
         assert len(snapshot_query_calls) == 1, (
-            f"expected exactly one snapshot-cohort execute, "
-            f"got {len(snapshot_query_calls)}"
+            f"expected exactly one snapshot-cohort execute, got {len(snapshot_query_calls)}"
         )
         snapshot_query = snapshot_query_calls[0].args[0]
         assert "ei.provider = 'sec'" in snapshot_query


### PR DESCRIPTION
## What

- \`fundamentals_is_fresh\` and \`fundamentals_content_ok\` now JOIN \`external_identifiers\` on \`provider='sec', identifier_type='cik', is_primary=TRUE\` before counting missing snapshots. Detail message says "SEC-CIK tradable instruments...".
- \`daily_research_refresh\` symbol→CIK lookup filtered on \`ei.is_primary=TRUE\` so producer + reader cohorts match.
- Three SQL-shape regression tests pin the predicate on both reader paths AND the producer query.

## Why

After #532 / #539 retired FMP, fundamentals_snapshot only covers SEC-CIK instruments. Treating "every tradable instrument needs a row" as the invariant alarmed indefinitely on non-US / crypto / commodity instruments that have no public-source fundamentals path.

## Codex catches across review rounds

- Round 2: tests only pinned the detail-string output, not the SQL shape. Fixed with explicit \`assert "external_identifiers" in sql\` etc. on both reader paths.
- Round 3: producer (\`daily_research_refresh\` cik_rows query) iterated every sec/cik row regardless of \`is_primary\`. Fixed with the matching filter; reader and producer are now in lockstep. Pin test added.

## Test plan

- [x] \`uv run pytest\` 2882 pass, 1 skipped (3 new tests)
- [x] \`uv run ruff check . && uv run ruff format --check .\` clean
- [x] \`uv run pyright\` clean

## Out of scope

- coverage.py \`has_fundamentals\` flag retained — gates T1 promotion, product-meaningful semantics for non-SEC instruments
- ops_monitor.py legacy staleness query retained — queued for retirement under #340 (blocked on #330)
- #541 drops the table outright; this PR keeps it for SEC instruments only