### PR TITLE
tech-debt(#112): caller-owned transactions for broker_credentials

### DIFF
--- a/app/api/broker_credentials.py
+++ b/app/api/broker_credentials.py
@@ -278,14 +278,26 @@ def create(
                     # inside store_credential could raise on a
                     # value the outer pass accepted (review
                     # feedback PR #118 round 12).
-                    meta = store_credential(
-                        conn,
-                        operator_id=session.operator_id,
-                        provider=provider_norm,
-                        label=label_norm,
-                        environment=env_norm,
-                        plaintext=secret_norm,
-                    )
+                    #
+                    # #112: caller owns transaction lifecycle.
+                    # ``conn.commit()`` flushes the implicit
+                    # transaction opened by ``_active_credential_
+                    # exists`` above so ``conn.transaction()``
+                    # opens a real top-level txn (not a savepoint
+                    # that defers commit until get_conn teardown,
+                    # which would publish the recovery phrase
+                    # before the credential row is durable —
+                    # Codex medium-severity finding).
+                    conn.commit()
+                    with conn.transaction():
+                        meta = store_credential(
+                            conn,
+                            operator_id=session.operator_id,
+                            provider=provider_norm,
+                            label=label_norm,
+                            environment=env_norm,
+                            plaintext=secret_norm,
+                        )
                 except KeyboardInterrupt, SystemExit:
                     # Signal-driven shutdown: do NOT touch the
                     # file. At signal time it is unknowable
@@ -406,15 +418,28 @@ def _do_store(
     plaintext: str,
     phrase: list[str] | None,
 ) -> CreateCredentialResponse:
+    # #112: caller owns transaction lifecycle. The duplicate
+    # pre-check (``_active_credential_exists``) runs an earlier
+    # SELECT on this autocommit-off pool connection, which opens an
+    # implicit transaction. Without the explicit ``conn.commit()``
+    # below, the ``with conn.transaction()`` block would nest as a
+    # SAVEPOINT and the INSERT would commit only on get_conn
+    # teardown — i.e. AFTER the 201 response had been sent
+    # (Codex high-severity finding on PR #112). Flush the implicit
+    # transaction first; the wrapping block then opens a real
+    # top-level txn so the INSERT is durable before the handler
+    # returns.
+    conn.commit()
     try:
-        meta = store_credential(
-            conn,
-            operator_id=operator_id,
-            provider=provider,
-            label=label,
-            environment=environment,
-            plaintext=plaintext,
-        )
+        with conn.transaction():
+            meta = store_credential(
+                conn,
+                operator_id=operator_id,
+                provider=provider,
+                label=label,
+                environment=environment,
+                plaintext=plaintext,
+            )
     except CredentialValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -490,12 +515,20 @@ def delete(
 ) -> None:
     """Soft-delete a credential. Returns 404 if it does not exist or is
     already revoked; 204 on success."""
+    # #112: caller owns transaction lifecycle. ``conn.commit()``
+    # flushes any implicit transaction opened earlier on this
+    # connection (FastAPI dependencies that issued reads, etc.) so
+    # ``conn.transaction()`` opens a real top-level txn — not a
+    # savepoint that would defer the soft-delete commit to
+    # get_conn teardown (Codex finding pattern, see _do_store).
+    conn.commit()
     try:
-        revoke_credential(
-            conn,
-            credential_id=credential_id,
-            operator_id=session.operator_id,
-        )
+        with conn.transaction():
+            revoke_credential(
+                conn,
+                credential_id=credential_id,
+                operator_id=session.operator_id,
+            )
     except CredentialNotFound as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/app/services/broker_credentials.py
+++ b/app/services/broker_credentials.py
@@ -188,6 +188,15 @@ def store_credential(
 ) -> CredentialMetadata:
     """Encrypt and insert a new credential row.
 
+    Transaction model (#112): caller owns the lifecycle. This
+    function does NOT call ``conn.commit()`` or ``conn.rollback()``
+    and does NOT open its own ``conn.transaction()`` block — runs
+    the INSERT on whatever transaction the caller has set up. A
+    ``CredentialAlreadyExists`` raised on UniqueViolation aborts
+    the caller's transaction (psycopg3 marks it failed); the
+    caller must rollback. Use ``with conn.transaction():`` at the
+    call site to get clean rollback-on-exception semantics.
+
     Raises:
       CredentialValidationError -- provider / label / environment / secret invalid.
       CredentialAlreadyExists   -- an active row with the same (operator,
@@ -236,9 +245,7 @@ def store_credential(
                 # This branch is defensive so pyright does not see an
                 # Optional leak downstream.
                 raise RuntimeError("INSERT ... RETURNING produced no row")
-        conn.commit()
     except psycopg.errors.UniqueViolation as exc:
-        conn.rollback()
         raise CredentialAlreadyExists(
             f"credential already exists for ({provider_norm!r}, {label_norm!r}, {env_norm!r})"
         ) from exc
@@ -282,49 +289,30 @@ def revoke_credential(
     """Soft-delete a credential. Idempotent-ish: revoking an already-revoked
     row returns ``CredentialNotFound`` so the caller gets a clear 404 and
     cannot accidentally treat "already revoked" as "just revoked".
+
+    Transaction model (#112): caller owns the lifecycle. This
+    function does NOT call ``conn.commit()`` or ``conn.rollback()``
+    and does NOT open its own ``conn.transaction()`` block — runs
+    the UPDATE on whatever transaction the caller has set up. The
+    no-row branch raises ``CredentialNotFound``; the caller must
+    rollback the (otherwise empty) transaction. Use
+    ``with conn.transaction():`` at the call site to get clean
+    rollback-on-exception semantics.
     """
-    # Transaction discipline: every exit path from this function leaves
-    # the connection in either a committed or rolled-back state, never
-    # in an open implicit transaction. psycopg3 opens an implicit txn
-    # on any statement (even an UPDATE that touches no rows), so the
-    # rollback path matters for the not-found case as well as the
-    # genuine-error case. The structure below ensures rollback happens
-    # in a `finally` block when committed=False, so a rollback that
-    # itself raises does not silently mask the original exception.
-    committed = False
-    try:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE broker_credentials
-                   SET revoked_at = now()
-                 WHERE id = %s
-                   AND operator_id = %s
-                   AND revoked_at IS NULL
-                """,
-                (credential_id, operator_id),
-            )
-            rowcount = cur.rowcount
-        if rowcount == 0:
-            raise CredentialNotFound(f"credential {credential_id} not found")
-        conn.commit()
-        committed = True
-    finally:
-        if not committed:
-            # Either CredentialNotFound on the no-row branch or any
-            # unexpected DB error. In both cases the connection has an
-            # open (and possibly aborted) transaction we must clear
-            # before returning it to the pool.
-            try:
-                conn.rollback()
-            except Exception:
-                # A rollback that itself raises (e.g. broken
-                # connection) is logged via the standard exception
-                # chaining and does not mask the original error,
-                # because we are in a `finally` -- the original
-                # exception will continue to propagate after we exit
-                # this block.
-                logger.exception("broker_credentials.revoke_credential: rollback failed")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE broker_credentials
+               SET revoked_at = now()
+             WHERE id = %s
+               AND operator_id = %s
+               AND revoked_at IS NULL
+            """,
+            (credential_id, operator_id),
+        )
+        rowcount = cur.rowcount
+    if rowcount == 0:
+        raise CredentialNotFound(f"credential {credential_id} not found")
 
 
 def _write_access_log(

--- a/scripts/migrate_etoro_credential.py
+++ b/scripts/migrate_etoro_credential.py
@@ -123,17 +123,22 @@ def main() -> int:
 
             migrated = 0
 
-            # Migrate ETORO_READ_API_KEY → label "api_key", environment "demo"
+            # Migrate ETORO_READ_API_KEY → label "api_key", environment "demo".
+            # #112: each store_credential call now requires a caller-owned
+            # transaction. Wrap each independently so a UniqueViolation on
+            # one (CredentialAlreadyExists → handled below) doesn't roll
+            # back the other.
             if _READ_KEY:
                 try:
-                    store_credential(
-                        conn,
-                        operator_id=op_id,
-                        provider="etoro",
-                        label="api_key",
-                        environment="demo",
-                        plaintext=_READ_KEY,
-                    )
+                    with conn.transaction():
+                        store_credential(
+                            conn,
+                            operator_id=op_id,
+                            provider="etoro",
+                            label="api_key",
+                            environment="demo",
+                            plaintext=_READ_KEY,
+                        )
                     print("Migrated ETORO_READ_API_KEY → broker_credentials (etoro/api_key/demo)")
                     migrated += 1
                 except CredentialAlreadyExists:
@@ -142,14 +147,15 @@ def main() -> int:
             # Migrate ETORO_WRITE_API_KEY → label "user_key", environment "demo"
             if _WRITE_KEY:
                 try:
-                    store_credential(
-                        conn,
-                        operator_id=op_id,
-                        provider="etoro",
-                        label="user_key",
-                        environment="demo",
-                        plaintext=_WRITE_KEY,
-                    )
+                    with conn.transaction():
+                        store_credential(
+                            conn,
+                            operator_id=op_id,
+                            provider="etoro",
+                            label="user_key",
+                            environment="demo",
+                            plaintext=_WRITE_KEY,
+                        )
                     print("Migrated ETORO_WRITE_API_KEY → broker_credentials (etoro/user_key/demo)")
                     migrated += 1
                 except CredentialAlreadyExists:

--- a/tests/test_api_broker_credentials.py
+++ b/tests/test_api_broker_credentials.py
@@ -218,6 +218,36 @@ class TestCreate:
             )
         assert resp.status_code == 400
 
+    def test_commit_called_before_transaction_to_flush_implicit_pending_tx(self) -> None:
+        """#112 regression — the duplicate pre-check (`_active_credential_exists`)
+        opens an implicit transaction on the autocommit-off pool conn.
+        Without an explicit ``conn.commit()`` before ``conn.transaction()``,
+        the wrapping block nests as a SAVEPOINT and the INSERT commits
+        only on get_conn teardown — i.e. AFTER the 201 response.
+        Assert ``conn.commit`` was called during the successful create."""
+        gen = app.dependency_overrides[get_conn]
+        # The dependency yields a MagicMock; grab it.
+        mock_conn = next(iter(gen()))
+        with patch(
+            "app.api.broker_credentials.store_credential",
+            return_value=_meta(),
+        ):
+            resp = client.post(
+                "/broker-credentials",
+                json={
+                    "provider": "etoro",
+                    "label": "primary",
+                    "secret": "secret-value-1234",
+                },
+            )
+        assert resp.status_code == 201
+        assert mock_conn.commit.called, (
+            "POST /broker-credentials must call conn.commit() to flush the "
+            "implicit transaction opened by _active_credential_exists before "
+            "entering conn.transaction(); otherwise the INSERT defers commit "
+            "to get_conn teardown, after the response is sent."
+        )
+
     def test_duplicate_returns_409(self) -> None:
         with patch(
             "app.api.broker_credentials.store_credential",


### PR DESCRIPTION
## What

Removes internal \`conn.commit()\`/\`conn.rollback()\` from \`store_credential\` and \`revoke_credential\`. Callers (the FastAPI handlers in \`app/api/broker_credentials.py\` and the migration script) now own the transaction lifecycle — same convention \`load_credential_for_provider_use\` already follows from #110.

Critically: the API handlers issue an explicit \`conn.commit()\` BEFORE \`with conn.transaction():\` to flush the implicit transaction opened by the \`_active_credential_exists\` pre-check SELECT. Without this, \`conn.transaction()\` would nest as a SAVEPOINT and the INSERT would commit only on \`get_conn\` teardown — i.e. AFTER the 201 response.

## Why

Per #112 and the existing prevention-log rule at [\`docs/review-prevention-log.md:344\`](docs/review-prevention-log.md#L344): a service function that accepts a caller-supplied connection MUST NOT call \`conn.commit()\` or \`conn.rollback()\`. Composing such a service inside a larger caller transaction silently flushes the caller's accumulated writes.

## Test plan

- [x] \`uv run pytest\` 2890 pass, 1 skipped (1 new regression test)
- [x] \`uv run ruff check . && uv run ruff format --check .\` clean
- [x] \`uv run pyright\` clean
- [x] Codex review:
  - Initial round flagged HIGH (no top-level commit) and MEDIUM (lazy-gen path not updated). Both addressed with the explicit \`conn.commit()\` flush + wrapping \`conn.transaction()\` on all three call sites.
  - Codex APPROVE on the second pass.
- Test \`test_commit_called_before_transaction_to_flush_implicit_pending_tx\` asserts the explicit flush is invoked during a successful create.

## Residual gap

The lazy-gen branch test coverage is limited because the existing API fixture forces \`boot_state="normal"\` to skip lazy-gen entirely. Codex flagged this as a coverage gap (LOW severity); a follow-up integration test against \`ebull_test\` could prove the lazy-gen commit ordering, but that requires bigger fixture surgery and is out of scope for this PR.