### PR TITLE
fix(#647): chart fills DensityGrid cell instead of leaving whitespace

### DIFF
--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -77,7 +77,7 @@ export function DensityGrid({
   // reported the whole-card click was firing accidentally on chart
   // hover/zoom.
   const ChartPane = (
-    <Pane title="Price chart" onExpand={drillToWorkspace}>
+    <Pane title="Price chart" onExpand={drillToWorkspace} fillHeight>
       <PriceChart symbol={symbol} instrumentId={instrumentId} />
     </Pane>
   );

--- a/frontend/src/components/instrument/Pane.test.tsx
+++ b/frontend/src/components/instrument/Pane.test.tsx
@@ -52,6 +52,44 @@ describe("Pane", () => {
     expect(onCardClick).not.toHaveBeenCalled();
   });
 
+  it("fillHeight=true applies h-full + flex-col so the pane stretches to the parent grid cell (#647)", () => {
+    render(
+      <Pane title="Price chart" fillHeight>
+        <p>body</p>
+      </Pane>,
+    );
+    const article = document.querySelector("article");
+    expect(article?.className).toContain("h-full");
+    expect(article?.className).toContain("flex");
+    expect(article?.className).toContain("flex-col");
+    const body = screen.getByText("body").parentElement;
+    expect(body?.className).toContain("flex-1");
+    expect(body?.className).toContain("min-h-0");
+  });
+
+  it("fillHeight defaults to false — existing panes unchanged", () => {
+    render(
+      <Pane title="Recent filings">
+        <p>body</p>
+      </Pane>,
+    );
+    const article = document.querySelector("article");
+    expect(article?.className).not.toContain("h-full");
+    const body = screen.getByText("body").parentElement;
+    expect(body?.className).not.toContain("flex-1");
+  });
+
+  it("article className builder produces no double spaces or trailing space when optional segments are omitted", () => {
+    render(
+      <Pane title="Recent filings">
+        <p>body</p>
+      </Pane>,
+    );
+    const article = document.querySelector("article");
+    expect(article?.className).not.toMatch(/ {2,}/);
+    expect(article?.className).not.toMatch(/ $/);
+  });
+
   it("clickable card does NOT take role=button (avoids nesting interactive descendants)", () => {
     const onCardClick = vi.fn();
     render(

--- a/frontend/src/components/instrument/Pane.tsx
+++ b/frontend/src/components/instrument/Pane.tsx
@@ -25,6 +25,13 @@ export interface PaneProps extends PaneHeaderProps {
    * keyboard-reachable without needing a card-level handler.
    */
   readonly onCardClick?: () => void;
+  /**
+   * Stretch the pane (and its single child) to fill the parent grid
+   * cell vertically. Use when the cell uses `lg:row-span-N` to span
+   * multiple rows — without this, the child sits at its intrinsic
+   * height and leaves whitespace below when the right rail is taller.
+   */
+  readonly fillHeight?: boolean;
 }
 
 export function Pane({
@@ -34,16 +41,24 @@ export function Pane({
   onExpand,
   className,
   onCardClick,
+  fillHeight = false,
   children,
 }: PaneProps): JSX.Element {
   const clickable = onCardClick !== undefined;
+  // Build the article className from atomic segments so optional
+  // segments do not leave double spaces when omitted.
+  const articleCls = [
+    "rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm",
+    fillHeight ? "flex h-full flex-col" : null,
+    clickable ? "cursor-pointer transition hover:border-slate-300 hover:shadow-md" : null,
+    className ?? null,
+  ]
+    .filter((x): x is string => x !== null)
+    .join(" ");
+  const childCls = fillHeight ? "mt-2 flex min-h-0 flex-1 flex-col" : "mt-2";
   return (
     <article
-      className={`rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm ${
-        clickable
-          ? "cursor-pointer transition hover:border-slate-300 hover:shadow-md"
-          : ""
-      } ${className ?? ""}`}
+      className={articleCls}
       onClick={clickable ? onCardClick : undefined}
       data-clickable={clickable ? "true" : undefined}
     >
@@ -53,7 +68,7 @@ export function Pane({
         source={source}
         onExpand={onExpand}
       />
-      <div className="mt-2">{children}</div>
+      <div className={childCls}>{children}</div>
     </article>
   );
 }

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -243,7 +243,13 @@ export function PriceChart({
   const intraday = isIntraday(range);
 
   return (
-    <div className="space-y-2">
+    // Flex column with `flex-1 min-h-0` so when mounted inside a Pane
+    // with `fillHeight` (DensityGrid chart cell uses lg:row-span-2),
+    // the chart canvas below expands to fill the grid cell instead
+    // of sitting at its 340px intrinsic height. In a non-fillHeight
+    // (block-layout) parent, the modifiers are inert and intrinsic
+    // sizing is preserved.
+    <div className="flex flex-1 flex-col gap-2 min-h-0">
       {/*
         Controls swallow click events so they do NOT trigger the
         Pane's card-click drill (which navigates to the full chart
@@ -371,6 +377,12 @@ export function PriceChart({
           intraday={intraday}
           showPm={showPm}
           showAh={showAh}
+          // Override the default `h-[340px] w-full` so the chart
+          // fills the Pane fillHeight layout instead of sitting at
+          // the intrinsic 340px. min-h-[340px] preserves the
+          // sensible floor when the cell happens to be small (e.g.
+          // narrow viewport).
+          containerClassName="h-full w-full min-h-[340px]"
         />
       ) : null}
     </div>
@@ -785,7 +797,14 @@ export function ChartCanvas({
   }, [clean, liveBucketTime]);
 
   return (
-    <div className="relative">
+    // `relative` for the absolutely-positioned hover tooltip + LIVE
+    // indicator children. `flex-1` makes the canvas wrapper absorb
+    // the remaining height in a flex parent (PriceChart's wrapper
+    // when fillHeight is on); inert when the parent is block layout
+    // (every other caller). NOTHING ELSE — the previous attempt at
+    // this fix added `flex flex-col min-h-0` here too and broke the
+    // chart's visible time range, see PR #652 revert.
+    <div className="relative flex-1">
       <div
         ref={containerRef}
         data-testid={`price-chart-${symbol}`}


### PR DESCRIPTION
## Summary

- Chart container was hardcoded `h-[340px]`, so when the right rail (KeyStats + SecProfile + Fundamentals) was taller than 340px, the grid stretched the chart cell to match but the chart sat at the top with whitespace below.
- Added `fillHeight` prop on Pane that plumbs flex-column + h-full / flex-1 / min-h-0 from the grid cell down to the canvas.
- **Sizing-ONLY** — no flicker fix, no ChartCanvas internal flex restructure. The previous attempt at this (PR #652, reverted in #653) added `flex flex-col min-h-0` on ChartCanvas's outer relative div alongside flex-1 and broke the historical bar visible time range. This PR adds ONLY `flex-1` to that outer div, with an inline note pointing at the prior revert.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — 610 pass, 8 Pane cases incl. fillHeight on/off + no-double-space class builder
- [x] **Visual gate** against live Vite dev server on RMR 1M before pushing — historical bars + volume + axis labels render across full range, chart fills cell, no whitespace below.
- Operator: spot-check CAL (full-sec profile, tall right rail) at desktop width; flicker still present (separate ticket #650).

🤖 Generated with [Claude Code](https://claude.com/claude-code)