### PR TITLE
feat(#645): orchestrator forensics MVP — error_message + cancelled status

### DIFF
--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -33,7 +33,10 @@ from app.services.sync_orchestrator import (
     submit_sync,
 )
 from app.services.sync_orchestrator.cascade import collapse_cascades
-from app.services.sync_orchestrator.layer_failure_history import all_layer_histories
+from app.services.sync_orchestrator.layer_failure_history import (
+    all_layer_error_excerpts,
+    all_layer_histories,
+)
 from app.services.sync_orchestrator.layer_state import compute_layer_states_from_db
 from app.services.sync_orchestrator.layer_types import (
     REMEDIES,
@@ -94,6 +97,12 @@ class ActionNeededItem(BaseModel):
     self_heal: bool
     consecutive_failures: int
     affected_downstream: list[str]
+    # First line of the latest captured exception (sync_layer_progress
+    # .error_message). None when the layer has never recorded a
+    # forensic message — older rows pre-#645 will be NULL until the
+    # next failure is recorded. The Admin banner shows this alongside
+    # the category so "Unclassified error" is no longer opaque.
+    error_excerpt: str | None = None
 
 
 class SecretMissingItem(BaseModel):
@@ -367,6 +376,7 @@ def get_sync_layers_v2(
     states = compute_layer_states_from_db(conn)
     names = list(states.keys())
     streaks, categories = all_layer_histories(conn, names)
+    error_excerpts = all_layer_error_excerpts(conn, names)
     last_updates = _layer_last_updated_map(conn, names)
 
     if any(s in {LayerState.ACTION_NEEDED, LayerState.SECRET_MISSING} for s in states.values()):
@@ -413,6 +423,7 @@ def get_sync_layers_v2(
                     self_heal=remedy.self_heal,
                     consecutive_failures=streaks.get(name, 0),
                     affected_downstream=groups_by_root.get(name, []),
+                    error_excerpt=error_excerpts.get(name),
                 )
             )
         elif state is LayerState.SECRET_MISSING:

--- a/app/services/sync_orchestrator/executor.py
+++ b/app/services/sync_orchestrator/executor.py
@@ -20,7 +20,10 @@ autocommit, with conn.transaction() becomes a SAVEPOINT).
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import re
+import traceback
 from collections.abc import Mapping
 from typing import Any, Protocol
 
@@ -263,8 +266,14 @@ def _run_layers_loop(
                 layer_plan.emits,
                 returned_names,
             )
+            # Sort BOTH sequences so the message text is deterministic
+            # across worker restarts. `set` repr ordering is
+            # hash-seed-dependent (PYTHONHASHSEED varies per process),
+            # which would otherwise make the #645 error_fingerprint
+            # for the same contract violation hash to a different value
+            # on every restart and defeat the repeat-grouping intent.
             contract_exc = RuntimeError(
-                f"refresh contract violation: expected {set(layer_plan.emits)}, got {returned_names}"
+                f"refresh contract violation: expected {sorted(layer_plan.emits)}, got {sorted(returned_names)}"
             )
             for emit in layer_plan.emits:
                 _record_layer_failed(sync_run_id, emit, error=contract_exc)
@@ -418,22 +427,72 @@ def _record_layer_result(
             )
 
 
+_FORENSICS_MESSAGE_LIMIT = 1000
+_FORENSICS_TRACEBACK_LIMIT = 8000
+
+# Strip absolute paths + line numbers from a traceback so the
+# fingerprint groups repeats of the same exception class + frame
+# regardless of refactor noise. e.g. `File "D:\\Repos\\eBull\\app\\
+# services\\foo.py", line 142, in bar` collapses to `File foo.py, in
+# bar`. Conservative — keeps file basename + function name (the bits
+# that actually identify the failure site).
+_FRAME_LINE_PATTERN = re.compile(r'File "(?:.*[\\/])?([^"\\/]+)", line \d+, in (\S+)')
+
+
+def _build_forensics(error: BaseException) -> tuple[str, str, str]:
+    """Return (error_message, error_traceback, error_fingerprint).
+
+    Caller passes the exception. Uses
+    ``traceback.format_exception(error)`` (NOT ``format_exc()``) so the
+    function works for exceptions constructed but not raised — e.g.
+    the contract-guard path in ``_run_layers_loop`` builds a
+    ``RuntimeError`` to record without raising it. ``format_exc()``
+    only reads the active exception via ``sys.exc_info()``; outside
+    an active ``except`` block it returns the literal stub
+    ``'NoneType: None\\n'`` which would poison both the traceback
+    column and the fingerprint hash.
+
+    Strings are length-capped so a pathological adapter (e.g. an LLM
+    client raising a multi-MB error) cannot blow up the row.
+    Fingerprint groups repeats of the same exception class + call
+    stack so the operator can tell "this is the same failure as the
+    prior run" without diffing tracebacks by hand.
+    """
+    message = repr(error)[:_FORENSICS_MESSAGE_LIMIT]
+    tb_text = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+    tb = tb_text[:_FORENSICS_TRACEBACK_LIMIT]
+    normalised = _FRAME_LINE_PATTERN.sub(r"File \1, in \2", tb)
+    fingerprint = hashlib.sha1(normalised.encode("utf-8")).hexdigest()
+    return message, tb, fingerprint
+
+
 def _record_layer_failed(
     sync_run_id: int,
     layer_name: str,
     error: BaseException,
 ) -> None:
+    error_message, error_traceback, error_fingerprint = _build_forensics(error)
     with psycopg.connect(settings.database_url, autocommit=True) as conn:
         with conn.transaction():
             conn.execute(
                 """
                 UPDATE sync_layer_progress
-                SET status = 'failed',
-                    finished_at = now(),
-                    error_category = %s
+                SET status            = 'failed',
+                    finished_at       = now(),
+                    error_category    = %s,
+                    error_message     = %s,
+                    error_traceback   = %s,
+                    error_fingerprint = %s
                 WHERE sync_run_id = %s AND layer_name = %s
                 """,
-                (classify_exception(error).value, sync_run_id, layer_name),
+                (
+                    classify_exception(error).value,
+                    error_message,
+                    error_traceback,
+                    error_fingerprint,
+                    sync_run_id,
+                    layer_name,
+                ),
             )
 
 
@@ -457,16 +516,48 @@ def _record_layer_skipped(
 
 
 def _fail_unfinished_layers(sync_run_id: int) -> dict[str, LayerOutcome]:
-    """Mark any 'pending' or 'running' sync_layer_progress rows for the
-    given sync as 'failed' with error_category='orchestrator_crash'.
-    Returns {layer_name: FAILED} for rows actually updated."""
+    """Finalize any unfinished sync_layer_progress rows after a crash.
+
+    Two cases — distinguished by `started_at` to keep the consecutive-
+    failure streak in the admin banner truthful (#645):
+
+    - `pending` rows (started_at IS NULL) — the adapter never ran. The
+      worker died between row insert and adapter dispatch. Marked
+      `'cancelled'` (NOT `'failed'`) so the streak counter does not
+      treat reaper noise from dev `--reload` cycles as real adapter
+      failures. The legacy behavior here was the dominant source of
+      the 140/328 inflated streak counts the operator reported.
+    - `running` rows (started_at IS NOT NULL) — the adapter started
+      and the worker died mid-flight. Marked `'failed'` with
+      `'orchestrator_crash'` because real work was in progress.
+
+    Returns {layer_name: outcome} for rows actually updated.
+    """
+    cancelled: dict[str, LayerOutcome] = {}
+    failed: dict[str, LayerOutcome] = {}
     with psycopg.connect(settings.database_url, autocommit=True) as conn:
         with conn.transaction():
-            rows = conn.execute(
+            cancelled_rows = conn.execute(
                 """
                 UPDATE sync_layer_progress
-                SET status = 'failed',
+                SET status      = 'cancelled',
                     finished_at = now(),
+                    skip_reason = 'worker died before adapter dispatched'
+                WHERE sync_run_id = %s
+                  AND status      = 'pending'
+                  AND started_at IS NULL
+                RETURNING layer_name
+                """,
+                (sync_run_id,),
+            ).fetchall()
+            for r in cancelled_rows:
+                cancelled[r[0]] = LayerOutcome.DEP_SKIPPED
+
+            failed_rows = conn.execute(
+                """
+                UPDATE sync_layer_progress
+                SET status         = 'failed',
+                    finished_at    = now(),
                     error_category = 'orchestrator_crash'
                 WHERE sync_run_id = %s
                   AND status IN ('pending', 'running')
@@ -474,7 +565,9 @@ def _fail_unfinished_layers(sync_run_id: int) -> dict[str, LayerOutcome]:
                 """,
                 (sync_run_id,),
             ).fetchall()
-    return {r[0]: LayerOutcome.FAILED for r in rows}
+            for r in failed_rows:
+                failed[r[0]] = LayerOutcome.FAILED
+    return {**cancelled, **failed}
 
 
 def _finalize_sync_run(
@@ -489,20 +582,34 @@ def _finalize_sync_run(
             counts_row = conn.execute(
                 """
                 SELECT
-                    COUNT(*) FILTER (WHERE status IN ('complete', 'partial')) AS done,
-                    COUNT(*) FILTER (WHERE status = 'failed')                 AS failed,
-                    COUNT(*) FILTER (WHERE status = 'skipped')                AS skipped
+                    COUNT(*) FILTER (WHERE status IN ('complete', 'partial'))   AS done,
+                    COUNT(*) FILTER (WHERE status = 'failed')                   AS failed,
+                    -- `cancelled` is rolled into the skipped bucket for
+                    -- parent-status accounting (#645). Layer-row distinction
+                    -- (skipped = blocked by dep, cancelled = worker died
+                    -- before adapter dispatched) is preserved on
+                    -- sync_layer_progress; sync_runs.layers_skipped just
+                    -- tracks "didn't complete and didn't fail".
+                    COUNT(*) FILTER (WHERE status IN ('skipped', 'cancelled'))  AS skipped,
+                    COUNT(*)                                                    AS total
                 FROM sync_layer_progress
                 WHERE sync_run_id = %s
                 """,
                 (sync_run_id,),
             ).fetchone()
             assert counts_row is not None, "COUNT(*) aggregate returned no row"
-            done, failed, skipped = counts_row
+            done, failed, skipped, total = counts_row
 
-            if failed == 0:
+            # `failed=0 && done=total` → complete (every layer ran and won).
+            # Anything that didn't run AND didn't fail still leaves the
+            # parent in an "incomplete success" state — `partial` rather
+            # than `complete` so the operator can spot crash-early
+            # finalizations from the /sync/runs feed (a sync that died
+            # before any adapter dispatched would otherwise report
+            # `complete` with zero layers done).
+            if failed == 0 and done == total:
                 status = "complete"
-            elif done == 0:
+            elif done == 0 and failed > 0:
                 status = "failed"
             else:
                 status = "partial"

--- a/app/services/sync_orchestrator/layer_failure_history.py
+++ b/app/services/sync_orchestrator/layer_failure_history.py
@@ -232,3 +232,50 @@ def all_layer_histories(
             categories[str(row["layer_name"])] = str(row["error_category"])
 
     return streaks, categories
+
+
+def all_layer_error_excerpts(
+    conn: psycopg.Connection[Any],
+    layer_names: list[str] | tuple[str, ...],
+) -> dict[str, str | None]:
+    """Most recent non-null `error_message` per layer (#645 forensics).
+
+    Returns the first line of the message so the admin banner can
+    show "Unclassified error -- KeyError: 'fundamentals.cik'"
+    instead of the bare category. Multiline tracebacks are
+    deliberately collapsed to the first line; the full traceback
+    lives in `sync_layer_progress.error_traceback` for deep triage.
+
+    Layers without a recorded message map to None. Pre-#645 rows
+    that never captured a message stay None until the next failure.
+    """
+    if not layer_names:
+        return {}
+    names = list(layer_names)
+    excerpts: dict[str, str | None] = {n: None for n in names}
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            WITH ranked AS (
+                SELECT
+                    layer_name,
+                    error_message,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY layer_name
+                        ORDER BY COALESCE(started_at, finished_at) DESC NULLS LAST, sync_run_id DESC
+                    ) AS rn
+                FROM sync_layer_progress
+                WHERE error_message IS NOT NULL AND layer_name = ANY(%s)
+            )
+            SELECT layer_name, error_message
+            FROM ranked
+            WHERE rn = 1;
+            """,
+            (names,),
+        )
+        for row in cur.fetchall():
+            raw = str(row["error_message"])
+            # First non-empty line, capped — banner copy is one line.
+            first_line = next((ln for ln in raw.splitlines() if ln.strip()), raw)
+            excerpts[str(row["layer_name"])] = first_line[:240]
+    return excerpts

--- a/app/services/sync_orchestrator/reaper.py
+++ b/app/services/sync_orchestrator/reaper.py
@@ -48,30 +48,57 @@ def reap_orphaned_syncs(
             # of a timedelta=0 age check.
             reaped_rows = conn.execute(
                 """
-                WITH reaped AS (
-                    UPDATE sync_runs
-                    SET status = 'failed',
-                        finished_at = now(),
-                        error_category = 'orchestrator_crash'
-                    WHERE status = 'running'
-                      AND (%(reap_all)s OR started_at < now() - %(timeout)s::interval)
-                    RETURNING sync_run_id
-                ),
-                _progress_cleanup AS (
-                    UPDATE sync_layer_progress slp
-                    SET status = 'failed',
-                        finished_at = now(),
-                        error_category = 'orchestrator_crash'
-                    FROM reaped r
-                    WHERE slp.sync_run_id = r.sync_run_id
-                      AND slp.status IN ('pending', 'running')
-                    RETURNING 1
-                )
-                SELECT sync_run_id FROM reaped
+                UPDATE sync_runs
+                SET status = 'failed',
+                    finished_at = now(),
+                    error_category = 'orchestrator_crash'
+                WHERE status = 'running'
+                  AND (%(reap_all)s OR started_at < now() - %(timeout)s::interval)
+                RETURNING sync_run_id
                 """,
                 {"timeout": timeout, "reap_all": reap_all},
             ).fetchall()
             reaped_ids = [r[0] for r in reaped_rows]
+
+            # #645 split — two SEPARATE statements (NOT a single WITH
+            # with both updates). PostgreSQL CTE semantics let
+            # concurrent data-modifying CTEs see the same row snapshot,
+            # so a single WITH containing both the cancel and the fail
+            # UPDATE would race: the fail CTE could clobber rows the
+            # cancel CTE just transitioned. Sequencing them inside the
+            # transaction guarantees the fail UPDATE only sees rows
+            # the cancel UPDATE left behind.
+            if reaped_ids:
+                # Step A: never-started pending rows become 'cancelled'
+                # so the consecutive-failure streak in the admin banner
+                # is not inflated by reaper noise (uvicorn --reload
+                # cycles during dev iteration were the dominant source).
+                conn.execute(
+                    """
+                    UPDATE sync_layer_progress
+                    SET status      = 'cancelled',
+                        finished_at = now(),
+                        skip_reason = 'worker died before adapter dispatched'
+                    WHERE sync_run_id = ANY(%s)
+                      AND status      = 'pending'
+                      AND started_at IS NULL
+                    """,
+                    (reaped_ids,),
+                )
+                # Step B: any remaining pending/running rows had
+                # `started_at` populated, meaning the adapter actually
+                # began work — those are real mid-flight failures.
+                conn.execute(
+                    """
+                    UPDATE sync_layer_progress
+                    SET status         = 'failed',
+                        finished_at    = now(),
+                        error_category = 'orchestrator_crash'
+                    WHERE sync_run_id = ANY(%s)
+                      AND status IN ('pending', 'running')
+                    """,
+                    (reaped_ids,),
+                )
 
             # Step 2: recompute aggregate counts. Inside the SAME
             # transaction so status='failed' and counts either both
@@ -90,7 +117,11 @@ def reap_orphaned_syncs(
                         SELECT sync_run_id,
                                COUNT(*) FILTER (WHERE status IN ('complete','partial')) AS done,
                                COUNT(*) FILTER (WHERE status = 'failed')                AS failed,
-                               COUNT(*) FILTER (WHERE status = 'skipped')               AS skipped
+                               -- `cancelled` (#645 reaper split) rolled
+                               -- into the skipped bucket so layers_done +
+                               -- layers_failed + layers_skipped continues
+                               -- to equal the row count for the run.
+                               COUNT(*) FILTER (WHERE status IN ('skipped','cancelled')) AS skipped
                         FROM sync_layer_progress
                         WHERE sync_run_id = ANY(%s)
                         GROUP BY sync_run_id

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -969,6 +969,13 @@ export interface ActionNeededItem {
   self_heal: boolean;
   consecutive_failures: number;
   affected_downstream: string[];
+  /**
+   * First line of the most recent captured exception
+   * (sync_layer_progress.error_message). Populated by #645 forensics.
+   * Null when the layer has never recorded a forensic message — older
+   * pre-#645 rows stay null until the next failure is recorded.
+   */
+  error_excerpt?: string | null;
 }
 
 export interface SecretMissingItem {

--- a/frontend/src/components/admin/ProblemsPanel.test.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.test.tsx
@@ -96,6 +96,47 @@ describe("ProblemsPanel", () => {
     expect(screen.getByText(/3 consecutive failures/)).toBeInTheDocument();
   });
 
+  it("renders error_excerpt under the message when the API returns one (#645 forensics)", () => {
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.action_needed = [
+      {
+        root_layer: "fundamentals",
+        display_name: "Fundamentals",
+        category: "internal_error",
+        operator_message: "Unclassified error — retrying with backoff",
+        operator_fix: null,
+        self_heal: true,
+        consecutive_failures: 7,
+        affected_downstream: [],
+        error_excerpt: "KeyError: 'cik'",
+      },
+    ];
+    renderPanel({ v2 });
+    expect(screen.getByTestId("problems-error-excerpt")).toHaveTextContent("KeyError: 'cik'");
+  });
+
+  it("omits the error_excerpt block when the API does not return one (legacy pre-#645 row)", () => {
+    const v2 = emptyV2();
+    v2.system_state = "needs_attention";
+    v2.action_needed = [
+      {
+        root_layer: "fundamentals",
+        display_name: "Fundamentals",
+        category: "internal_error",
+        operator_message: "Unclassified error — retrying with backoff",
+        operator_fix: null,
+        self_heal: true,
+        consecutive_failures: 1,
+        affected_downstream: [],
+        // error_excerpt omitted entirely (undefined) — same as a
+        // legacy row with no message column populated.
+      },
+    ];
+    renderPanel({ v2 });
+    expect(screen.queryByTestId("problems-error-excerpt")).not.toBeInTheDocument();
+  });
+
   it("renders secret_missing row with a Link to /settings#providers", () => {
     const v2 = emptyV2();
     v2.system_state = "needs_attention";

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -211,6 +211,15 @@ function ActionNeededRow({ item, onOpen }: { item: ActionNeededItem; onOpen: () 
           <div className="font-medium text-red-800">
             {item.display_name} — {item.operator_message}
           </div>
+          {item.error_excerpt !== null && item.error_excerpt !== undefined ? (
+            <div
+              className="mt-0.5 truncate font-mono text-xs text-red-700"
+              title={item.error_excerpt}
+              data-testid="problems-error-excerpt"
+            >
+              {item.error_excerpt}
+            </div>
+          ) : null}
           {fix !== null ? (
             <div className="text-xs text-slate-700">
               {fixAsLink ? (

--- a/sql/081_sync_layer_progress_forensics.sql
+++ b/sql/081_sync_layer_progress_forensics.sql
@@ -1,0 +1,49 @@
+-- 081_sync_layer_progress_forensics.sql
+--
+-- Issue #645 — orchestrator forensics (MVP slice).
+--
+-- Adds three optional columns to `sync_layer_progress` so an operator
+-- triaging a red banner can see WHAT broke, not just the coarse
+-- `error_category` enum. Today an "Unclassified error" banner means
+-- the exception did not match the small set of recognised types in
+-- `exception_classifier.py` and the actual exception text is gone —
+-- investigating any failure required an in-process repro.
+--
+-- Columns:
+--   error_message     -- repr(exc)[:1000], one-line summary for the banner
+--   error_traceback   -- traceback.format_exc()[:8000], full chain for triage
+--   error_fingerprint -- sha1 of normalised traceback for grouping repeats
+--
+-- Also extends the `status` CHECK to allow `'cancelled'`. Today the
+-- reaper (and `_fail_unfinished_layers`) flips `pending`/`running`
+-- rows to `'failed'` with `error_category='orchestrator_crash'` on
+-- the next boot. Rows that never started (uvicorn --reload killed
+-- the worker before the adapter ran, `started_at IS NULL`) get
+-- counted as real failures and inflate the consecutive-failure
+-- streak in the admin banner — the user-visible "140 candles
+-- failures" was almost entirely reaper noise from dev iteration,
+-- not real adapter failures.
+--
+-- The new `'cancelled'` status lets the reaper distinguish
+-- never-started from started-and-died, and the existing
+-- `consecutive_failures` query naturally treats `'cancelled'` as a
+-- streak break (it only counts `status='failed'`).
+--
+-- All ALTERs are idempotent. Re-running the migration is a no-op.
+
+ALTER TABLE sync_layer_progress
+    ADD COLUMN IF NOT EXISTS error_message     TEXT,
+    ADD COLUMN IF NOT EXISTS error_traceback   TEXT,
+    ADD COLUMN IF NOT EXISTS error_fingerprint TEXT;
+
+-- Replace the status CHECK constraint to include 'cancelled'. The
+-- original constraint name in 033_sync_orchestrator.sql is the
+-- Postgres-default `sync_layer_progress_status_check`. Drop it if
+-- present (it always is on databases that ran 033 cleanly), then
+-- re-add with the extended set.
+ALTER TABLE sync_layer_progress
+    DROP CONSTRAINT IF EXISTS sync_layer_progress_status_check;
+
+ALTER TABLE sync_layer_progress
+    ADD CONSTRAINT sync_layer_progress_status_check
+    CHECK (status IN ('pending', 'running', 'complete', 'failed', 'skipped', 'partial', 'cancelled'));

--- a/tests/test_executor_forensics.py
+++ b/tests/test_executor_forensics.py
@@ -1,0 +1,270 @@
+"""Tests for executor `_record_layer_failed` forensics capture (#645).
+
+Verifies the new error_message + error_traceback + error_fingerprint
+columns get populated, the message length is capped, and the
+fingerprint groups repeats of the same exception class + frame.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from uuid import uuid4
+
+import psycopg
+import pytest
+
+from tests.fixtures.ebull_test_db import (
+    test_database_url as _test_database_url,
+)
+from tests.fixtures.ebull_test_db import (
+    test_db_available as _test_db_available,
+)
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test Postgres not reachable",
+)
+
+
+@pytest.fixture(autouse=True)
+def _redirect_settings_to_test_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point `settings.database_url` at ebull_test for every test in
+    this module. `_record_layer_failed` opens its own connection via
+    `settings.database_url`; without this redirect it would write to
+    the dev DB and the test seed/assert in ebull_test would never
+    observe its mutation."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "database_url", _test_database_url())
+
+
+@pytest.fixture
+def conn() -> Iterator[psycopg.Connection[object]]:
+    c: psycopg.Connection[object] = psycopg.connect(_test_database_url(), autocommit=True)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def _seed_running_layer(conn: psycopg.Connection[object], layer: str) -> int:
+    """Seed a sync_layer_progress row in 'running' state.
+
+    The parent sync_run is inserted as 'complete' (NOT 'running') so
+    the partial unique index `idx_sync_runs_single_running` does not
+    block parallel test cases — what the test exercises is the layer
+    row's status transition, not the parent sync_run gate.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO sync_runs
+                (scope, trigger, started_at, finished_at, status, layers_planned)
+            VALUES ('full', 'manual', now() - interval '1 min', now(), 'complete', 1)
+            RETURNING sync_run_id
+            """,
+        )
+        row = cur.fetchone()
+        assert row is not None
+        sid = int(row[0])  # type: ignore[index]
+        cur.execute(
+            """
+            INSERT INTO sync_layer_progress
+                (sync_run_id, layer_name, status, started_at)
+            VALUES (%s, %s, 'running', now())
+            """,
+            (sid, layer),
+        )
+    return sid
+
+
+def _read_forensics(
+    conn: psycopg.Connection[object],
+    sync_run_id: int,
+    layer: str,
+) -> tuple[str, str | None, str | None, str | None]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT status, error_message, error_traceback, error_fingerprint
+            FROM sync_layer_progress
+            WHERE sync_run_id = %s AND layer_name = %s
+            """,
+            (sync_run_id, layer),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        return (
+            str(row[0]),  # type: ignore[index]
+            None if row[1] is None else str(row[1]),  # type: ignore[index]
+            None if row[2] is None else str(row[2]),  # type: ignore[index]
+            None if row[3] is None else str(row[3]),  # type: ignore[index]
+        )
+
+
+def _raise_keyerror() -> None:
+    """Helper that always raises from the same source line so the
+    fingerprint test can compare two captures of the same failure."""
+    d: dict[str, int] = {}
+    _ = d["nope"]  # KeyError: 'nope'
+
+
+def _raise_runtimeerror_with_long_message() -> None:
+    raise RuntimeError("X" * 5000)
+
+
+class TestRecordLayerFailedCapturesForensics:
+    def test_captures_message_traceback_fingerprint(self, conn: psycopg.Connection[object]) -> None:
+        from app.services.sync_orchestrator.executor import _record_layer_failed
+
+        layer = f"test-forensics-{uuid4()}"
+        sid = _seed_running_layer(conn, layer)
+
+        try:
+            _raise_keyerror()
+        except KeyError as exc:
+            _record_layer_failed(sid, layer, exc)
+
+        status, msg, tb, fp = _read_forensics(conn, sid, layer)
+        assert status == "failed"
+        assert msg is not None
+        assert "KeyError" in msg
+        assert "'nope'" in msg
+        assert tb is not None
+        assert "_raise_keyerror" in tb
+        assert fp is not None
+        # SHA1 hex = 40 chars
+        assert len(fp) == 40
+
+    def test_message_length_capped(self, conn: psycopg.Connection[object]) -> None:
+        from app.services.sync_orchestrator.executor import _record_layer_failed
+
+        layer = f"test-msg-cap-{uuid4()}"
+        sid = _seed_running_layer(conn, layer)
+
+        try:
+            _raise_runtimeerror_with_long_message()
+        except RuntimeError as exc:
+            _record_layer_failed(sid, layer, exc)
+
+        _status, msg, _tb, _fp = _read_forensics(conn, sid, layer)
+        assert msg is not None
+        # repr() adds wrapping ('RuntimeError(...)') so the cap is on
+        # the repr, not on the inner string.
+        assert len(msg) <= 1000
+
+    def test_traceback_length_capped(self, conn: psycopg.Connection[object]) -> None:
+        from app.services.sync_orchestrator.executor import _record_layer_failed
+
+        layer = f"test-tb-cap-{uuid4()}"
+        sid = _seed_running_layer(conn, layer)
+
+        # Force a deep stack so format_exc could exceed the cap on a
+        # debug build with verbose locals. Cap is 8000.
+        def deep(n: int) -> None:
+            if n == 0:
+                _raise_keyerror()
+                return
+            deep(n - 1)
+
+        try:
+            deep(10)
+        except KeyError as exc:
+            _record_layer_failed(sid, layer, exc)
+
+        _status, _msg, tb, _fp = _read_forensics(conn, sid, layer)
+        assert tb is not None
+        assert len(tb) <= 8000
+
+    def test_fingerprint_groups_repeats_of_same_failure(self, conn: psycopg.Connection[object]) -> None:
+        # Two captures of the SAME source-line KeyError should produce
+        # the same fingerprint, even though tracebacks contain
+        # different absolute paths or line numbers across runs.
+        from app.services.sync_orchestrator.executor import _record_layer_failed
+
+        layer_a = f"test-fp-a-{uuid4()}"
+        layer_b = f"test-fp-b-{uuid4()}"
+        sid_a = _seed_running_layer(conn, layer_a)
+        sid_b = _seed_running_layer(conn, layer_b)
+
+        try:
+            _raise_keyerror()
+        except KeyError as exc:
+            _record_layer_failed(sid_a, layer_a, exc)
+        try:
+            _raise_keyerror()
+        except KeyError as exc:
+            _record_layer_failed(sid_b, layer_b, exc)
+
+        _, _, _, fp_a = _read_forensics(conn, sid_a, layer_a)
+        _, _, _, fp_b = _read_forensics(conn, sid_b, layer_b)
+        assert fp_a is not None and fp_b is not None
+        assert fp_a == fp_b
+
+    def test_contract_guard_fingerprint_is_deterministic_across_restarts(self) -> None:
+        # The contract-guard path in `_run_layers_loop` formats the
+        # expected/got sequences into the exception message. If those
+        # were rendered as `set(...)` reprs the fingerprint would be
+        # hash-seed-dependent and the same contract violation would
+        # group differently on every worker restart. Sorting both
+        # sides keeps the message + fingerprint stable.
+        from app.services.sync_orchestrator.executor import _build_forensics
+
+        # Reproduce the executor's contract-guard message verbatim
+        # (the actual call site sorts both sequences).
+        emits = ["scoring", "recommendations"]
+        returned = ["recommendations", "scoring"]
+        msg = f"refresh contract violation: expected {sorted(emits)}, got {sorted(returned)}"
+        # Same logical violation reported by another worker that may
+        # have shuffled the inputs.
+        msg_alt = f"refresh contract violation: expected {sorted(reversed(emits))}, got {sorted(reversed(returned))}"
+        _, _, fp_a = _build_forensics(RuntimeError(msg))
+        _, _, fp_b = _build_forensics(RuntimeError(msg_alt))
+        assert fp_a == fp_b
+
+    def test_records_traceback_when_called_outside_active_except(self, conn: psycopg.Connection[object]) -> None:
+        # The contract-guard path in `_run_layers_loop` builds a
+        # RuntimeError without raising it, then calls
+        # `_record_layer_failed(error=that_runtime_error)`. If
+        # `_build_forensics` used `traceback.format_exc()` the
+        # traceback column would record the literal stub
+        # `"NoneType: None\n"` and the fingerprint would collapse to
+        # the hash of that stub for every contract violation.
+        from app.services.sync_orchestrator.executor import _record_layer_failed
+
+        layer = f"test-no-active-except-{uuid4()}"
+        sid = _seed_running_layer(conn, layer)
+
+        # Construct an error WITHOUT raising it — mirrors the contract
+        # guard path exactly (see executor.py:269 `contract_exc = ...`).
+        contract_exc = RuntimeError("refresh contract violation: expected {a}, got [b]")
+        _record_layer_failed(sid, layer, contract_exc)
+
+        _status, msg, tb, fp = _read_forensics(conn, sid, layer)
+        assert msg is not None and "refresh contract violation" in msg
+        assert tb is not None
+        assert "NoneType: None" not in tb
+        assert "RuntimeError" in tb
+        assert fp is not None and len(fp) == 40
+
+    def test_fingerprint_differs_for_different_exception_class(self, conn: psycopg.Connection[object]) -> None:
+        from app.services.sync_orchestrator.executor import _record_layer_failed
+
+        layer_a = f"test-fp-diff-a-{uuid4()}"
+        layer_b = f"test-fp-diff-b-{uuid4()}"
+        sid_a = _seed_running_layer(conn, layer_a)
+        sid_b = _seed_running_layer(conn, layer_b)
+
+        try:
+            _raise_keyerror()
+        except KeyError as exc:
+            _record_layer_failed(sid_a, layer_a, exc)
+        try:
+            raise ValueError("not the same shape")
+        except ValueError as exc:
+            _record_layer_failed(sid_b, layer_b, exc)
+
+        _, _, _, fp_a = _read_forensics(conn, sid_a, layer_a)
+        _, _, _, fp_b = _read_forensics(conn, sid_b, layer_b)
+        assert fp_a is not None and fp_b is not None
+        assert fp_a != fp_b

--- a/tests/test_layer_failure_history.py
+++ b/tests/test_layer_failure_history.py
@@ -22,6 +22,7 @@ import psycopg
 import pytest
 
 from app.services.sync_orchestrator.layer_failure_history import (
+    all_layer_error_excerpts,
     all_layer_histories,
     consecutive_failures,
     last_error_category,
@@ -325,3 +326,142 @@ class TestBatchedAllLayerHistories:
         assert included in categories
         assert excluded not in streaks
         assert excluded not in categories
+
+
+class TestCancelledStatusBreaksStreak:
+    """`cancelled` is the new status #645 added so the reaper can
+    distinguish never-started rows from real failures. The streak
+    counter must treat it like any other non-failed status — a
+    cancelled row at the head zeros the streak."""
+
+    def test_cancelled_at_head_zeroes_streak(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-{uuid4()}"
+        _seed_progress_rows(
+            conn,
+            layer,
+            [
+                ("failed", 60, "db_constraint"),
+                ("failed", 30, "db_constraint"),
+                ("cancelled", 5, None),  # reaper fired; never started
+            ],
+        )
+        # Without the new status in the streak-break set this would
+        # have been 0 anyway (the loop already breaks on any non-
+        # failed). Assert the contract explicitly.
+        assert consecutive_failures(conn, layer) == 0
+
+    def test_cancelled_in_middle_breaks_older_failures(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-{uuid4()}"
+        _seed_progress_rows(
+            conn,
+            layer,
+            [
+                ("failed", 100, "db_constraint"),
+                ("cancelled", 60, None),  # breaks streak
+                ("failed", 30, "db_constraint"),
+                ("failed", 10, "db_constraint"),  # head
+            ],
+        )
+        assert consecutive_failures(conn, layer) == 2
+
+
+class TestAllLayerErrorExcerpts:
+    """`#645 forensics. Returns most-recent non-null error_message
+    per layer, first line only, length-capped."""
+
+    def test_returns_first_line_of_recent_error(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-exc-{uuid4()}"
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO sync_runs
+                    (scope, trigger, started_at, finished_at, status, layers_planned)
+                VALUES ('full', 'manual', now() - interval '5 min', now(), 'failed', 1)
+                RETURNING sync_run_id
+                """,
+            )
+            row = cur.fetchone()
+            assert row is not None
+            sid = int(row[0])  # type: ignore[index]
+            cur.execute(
+                """
+                INSERT INTO sync_layer_progress
+                    (sync_run_id, layer_name, status, started_at, finished_at,
+                     error_category, error_message, error_traceback, error_fingerprint)
+                VALUES (%s, %s, 'failed', now() - interval '5 min', now(),
+                        'internal_error',
+                        %s, 'full traceback here', 'fp123')
+                """,
+                (sid, layer, "KeyError: 'cik'\nTraceback follows..."),
+            )
+        conn.commit()
+        result = all_layer_error_excerpts(conn, [layer])
+        # First line only, no traceback prefix.
+        assert result[layer] == "KeyError: 'cik'"
+
+    def test_returns_none_when_no_error_message(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-exc-none-{uuid4()}"
+        # A row with error_category but no error_message (legacy pre-#645).
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO sync_runs
+                    (scope, trigger, started_at, finished_at, status, layers_planned)
+                VALUES ('full', 'manual', now() - interval '5 min', now(), 'failed', 1)
+                RETURNING sync_run_id
+                """,
+            )
+            row = cur.fetchone()
+            assert row is not None
+            sid = int(row[0])  # type: ignore[index]
+            cur.execute(
+                """
+                INSERT INTO sync_layer_progress
+                    (sync_run_id, layer_name, status, started_at, finished_at,
+                     error_category)
+                VALUES (%s, %s, 'failed', now() - interval '5 min', now(), 'internal_error')
+                """,
+                (sid, layer),
+            )
+        conn.commit()
+        result = all_layer_error_excerpts(conn, [layer])
+        assert result[layer] is None
+
+    def test_caps_length_at_240_chars(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-exc-cap-{uuid4()}"
+        long_msg = "RuntimeError: " + ("x" * 500)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO sync_runs
+                    (scope, trigger, started_at, finished_at, status, layers_planned)
+                VALUES ('full', 'manual', now() - interval '5 min', now(), 'failed', 1)
+                RETURNING sync_run_id
+                """,
+            )
+            row = cur.fetchone()
+            assert row is not None
+            sid = int(row[0])  # type: ignore[index]
+            cur.execute(
+                """
+                INSERT INTO sync_layer_progress
+                    (sync_run_id, layer_name, status, started_at, finished_at,
+                     error_category, error_message)
+                VALUES (%s, %s, 'failed', now() - interval '5 min', now(),
+                        'internal_error', %s)
+                """,
+                (sid, layer, long_msg),
+            )
+        conn.commit()
+        result = all_layer_error_excerpts(conn, [layer])
+        excerpt = result[layer]
+        assert excerpt is not None
+        assert len(excerpt) == 240
+
+    def test_empty_layer_list_returns_empty_dict(self, conn: psycopg.Connection[object]) -> None:
+        assert all_layer_error_excerpts(conn, []) == {}
+
+    def test_unknown_layer_maps_to_none(self, conn: psycopg.Connection[object]) -> None:
+        layer = f"test-layer-exc-unknown-{uuid4()}"
+        result = all_layer_error_excerpts(conn, [layer])
+        assert result == {layer: None}

--- a/tests/test_reaper_split.py
+++ b/tests/test_reaper_split.py
@@ -1,0 +1,257 @@
+"""Tests for reaper.reap_orphaned_syncs split behaviour (#645).
+
+The reaper must distinguish never-started rows (`started_at IS NULL`)
+from started-and-died rows (`started_at IS NOT NULL`). Only the latter
+become `'failed'` with `'orchestrator_crash'`; the former become
+`'cancelled'` with a `skip_reason` so the consecutive-failure streak
+does not get inflated by uvicorn `--reload` noise during dev iteration.
+
+Runs against `ebull_test` Postgres so the seed + assertion can be
+exact. The dev-DB smoke test in `test_sync_orchestrator_api.py`
+covers the no-rows-to-reap path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from uuid import uuid4
+
+import psycopg
+import pytest
+
+from tests.fixtures.ebull_test_db import (
+    test_database_url as _test_database_url,
+)
+from tests.fixtures.ebull_test_db import (
+    test_db_available as _test_db_available,
+)
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test Postgres not reachable",
+)
+
+
+@pytest.fixture(autouse=True)
+def _redirect_settings_to_test_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point `settings.database_url` at ebull_test for every test in
+    this module. `reap_orphaned_syncs` opens its own connection via
+    `settings.database_url`; without this redirect it would mutate
+    the dev DB instead of the test seed."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "database_url", _test_database_url())
+
+
+_DELETE_RUNNING_LAYERS = (
+    "DELETE FROM sync_layer_progress WHERE sync_run_id IN (SELECT sync_run_id FROM sync_runs WHERE status = 'running')"
+)
+_DELETE_RUNNING_RUNS = "DELETE FROM sync_runs WHERE status = 'running'"
+
+
+def _drop_running_rows(c: psycopg.Connection[object]) -> None:
+    with c.cursor() as cur:
+        cur.execute(_DELETE_RUNNING_LAYERS)
+        cur.execute(_DELETE_RUNNING_RUNS)
+
+
+@pytest.fixture
+def conn() -> Iterator[psycopg.Connection[object]]:
+    """Yields a fresh test-DB connection. Each test deletes the
+    pre-existing `status='running'` sync_runs rows it cares about
+    BEFORE seeding so the partial unique index
+    `idx_sync_runs_single_running` does not block — and reaps any
+    seeded rows AFTER so the next test starts clean."""
+    c: psycopg.Connection[object] = psycopg.connect(_test_database_url(), autocommit=True)
+    _drop_running_rows(c)
+    try:
+        yield c
+    finally:
+        try:
+            _drop_running_rows(c)
+        finally:
+            c.close()
+
+
+def _seed_running_sync_with_layers(
+    conn: psycopg.Connection[object],
+    pending_never_started_layers: list[str],
+    pending_or_running_after_start_layers: list[tuple[str, str]],
+) -> int:
+    """Insert a `status='running'` sync_runs row + the two kinds of
+    progress rows the reaper has to distinguish.
+
+    `pending_never_started_layers` -> rows with `status='pending'` and
+    `started_at IS NULL`. These are what the reaper should `cancelled`.
+
+    `pending_or_running_after_start_layers` -> list of (status, layer_name).
+    `started_at` set to now() on insert. Reaper should `failed` these.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO sync_runs
+                (scope, trigger, started_at, status, layers_planned)
+            VALUES ('full', 'manual', now(), 'running', %s)
+            RETURNING sync_run_id
+            """,
+            (len(pending_never_started_layers) + len(pending_or_running_after_start_layers),),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        sid = int(row[0])  # type: ignore[index]
+
+        for layer in pending_never_started_layers:
+            cur.execute(
+                """
+                INSERT INTO sync_layer_progress
+                    (sync_run_id, layer_name, status, started_at)
+                VALUES (%s, %s, 'pending', NULL)
+                """,
+                (sid, layer),
+            )
+        for status, layer in pending_or_running_after_start_layers:
+            cur.execute(
+                """
+                INSERT INTO sync_layer_progress
+                    (sync_run_id, layer_name, status, started_at)
+                VALUES (%s, %s, %s, now())
+                """,
+                (sid, layer, status),
+            )
+    return sid
+
+
+def _layer_status(conn: psycopg.Connection[object], sync_run_id: int, layer: str) -> tuple[str, str | None, str | None]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT status, error_category, skip_reason
+            FROM sync_layer_progress
+            WHERE sync_run_id = %s AND layer_name = %s
+            """,
+            (sync_run_id, layer),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        return (
+            str(row[0]),  # type: ignore[index]
+            None if row[1] is None else str(row[1]),  # type: ignore[index]
+            None if row[2] is None else str(row[2]),  # type: ignore[index]
+        )
+
+
+class TestReaperCancelsNeverStartedRows:
+    """`reap_orphaned_syncs(reap_all=True)` must cancel never-started
+    rows, not fail them — that's the #645 fix that stops dev `--reload`
+    cycles inflating the consecutive-failure streak."""
+
+    def test_pending_no_started_at_becomes_cancelled(self, conn: psycopg.Connection[object]) -> None:
+        from app.services.sync_orchestrator.reaper import reap_orphaned_syncs
+
+        cancelled_layer = f"test-cancel-{uuid4()}"
+        sid = _seed_running_sync_with_layers(
+            conn,
+            pending_never_started_layers=[cancelled_layer],
+            pending_or_running_after_start_layers=[],
+        )
+
+        reap_orphaned_syncs(reap_all=True)
+
+        status, error_cat, skip_reason = _layer_status(conn, sid, cancelled_layer)
+        assert status == "cancelled"
+        assert error_cat is None
+        assert skip_reason == "worker died before adapter dispatched"
+
+    def test_running_with_started_at_becomes_failed_orchestrator_crash(self, conn: psycopg.Connection[object]) -> None:
+        from app.services.sync_orchestrator.reaper import reap_orphaned_syncs
+
+        failed_layer = f"test-fail-{uuid4()}"
+        sid = _seed_running_sync_with_layers(
+            conn,
+            pending_never_started_layers=[],
+            pending_or_running_after_start_layers=[("running", failed_layer)],
+        )
+
+        reap_orphaned_syncs(reap_all=True)
+
+        status, error_cat, skip_reason = _layer_status(conn, sid, failed_layer)
+        assert status == "failed"
+        assert error_cat == "orchestrator_crash"
+        assert skip_reason is None
+
+    def test_pending_with_started_at_becomes_failed_orchestrator_crash(self, conn: psycopg.Connection[object]) -> None:
+        # Edge: row was bumped to status='pending' AND started_at was
+        # populated (e.g. mid-transition between mark-running and
+        # mark-pending — defensive check). Treat as failed since work
+        # may have begun.
+        from app.services.sync_orchestrator.reaper import reap_orphaned_syncs
+
+        failed_layer = f"test-fail-pending-with-start-{uuid4()}"
+        sid = _seed_running_sync_with_layers(
+            conn,
+            pending_never_started_layers=[],
+            pending_or_running_after_start_layers=[("pending", failed_layer)],
+        )
+
+        reap_orphaned_syncs(reap_all=True)
+
+        status, error_cat, skip_reason = _layer_status(conn, sid, failed_layer)
+        assert status == "failed"
+        assert error_cat == "orchestrator_crash"
+        assert skip_reason is None
+
+    def test_aggregate_counts_roll_cancelled_into_skipped(self, conn: psycopg.Connection[object]) -> None:
+        # After reaper, sync_runs.layers_done + .layers_failed +
+        # .layers_skipped must equal the total row count for the run.
+        # `cancelled` rolls into the skipped bucket so that invariant
+        # holds across the new status (#645 codex pre-push round 2).
+        from app.services.sync_orchestrator.reaper import reap_orphaned_syncs
+
+        cancelled_layer = f"test-agg-c-{uuid4()}"
+        failed_layer = f"test-agg-f-{uuid4()}"
+        sid = _seed_running_sync_with_layers(
+            conn,
+            pending_never_started_layers=[cancelled_layer],
+            pending_or_running_after_start_layers=[("running", failed_layer)],
+        )
+
+        reap_orphaned_syncs(reap_all=True)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT layers_planned, layers_done, layers_failed, layers_skipped
+                FROM sync_runs WHERE sync_run_id = %s
+                """,
+                (sid,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            planned, done, failed, skipped = row  # type: ignore[misc]
+
+        assert planned == 2
+        assert done == 0
+        assert failed == 1
+        assert skipped == 1  # cancelled row counted here
+        assert done + failed + skipped == planned  # invariant
+
+    def test_mixed_run_splits_correctly(self, conn: psycopg.Connection[object]) -> None:
+        from app.services.sync_orchestrator.reaper import reap_orphaned_syncs
+
+        cancelled = f"test-mixed-cancel-{uuid4()}"
+        failed = f"test-mixed-fail-{uuid4()}"
+        sid = _seed_running_sync_with_layers(
+            conn,
+            pending_never_started_layers=[cancelled],
+            pending_or_running_after_start_layers=[("running", failed)],
+        )
+
+        reap_orphaned_syncs(reap_all=True)
+
+        c_status, c_err, _c_reason = _layer_status(conn, sid, cancelled)
+        f_status, f_err, _f_reason = _layer_status(conn, sid, failed)
+        assert c_status == "cancelled"
+        assert c_err is None
+        assert f_status == "failed"
+        assert f_err == "orchestrator_crash"


### PR DESCRIPTION
## Summary

- Adds `error_message`, `error_traceback`, `error_fingerprint` to `sync_layer_progress` so "Unclassified error" banners now show the actual exception. Investigating the operator's recent 4 red banners took 30+ tool calls because none of that detail existed.
- Adds `'cancelled'` status. Reaper + executor split unfinished rows: `pending` + `started_at IS NULL` → `cancelled` (no streak inflation), anything else still pending/running → `failed` with `'orchestrator_crash'`. The "140 candles failures" the operator saw was almost entirely uvicorn `--reload` reaper noise being miscounted.
- `/sync/layers/v2` returns `error_excerpt`; ProblemsPanel renders it under the message in red mono.
- Sequenced reaper UPDATEs (not one WITH) so PG CTE concurrent-modification race can't clobber the cancel pass.
- Sorted contract-guard message so fingerprint is deterministic across worker restarts.

## Out of scope (deferred to follow-ups)

- `next_retry_at` + circuit breaker
- Actual `sleep` enforcement of declared backoff_seconds
- DAG-ifying `sec_dividend_calendar_ingest` (overlap with #644)

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` clean
- [x] `uv run pytest tests/{smoke,test_executor_forensics,test_reaper_split,test_layer_failure_history,test_sync_orchestrator_executor,test_sync_orchestrator_api}.py` — 55 pass
- [x] `pnpm typecheck` + ProblemsPanel tests (21 pass incl. 2 new for error_excerpt)
- [x] Codex pre-push reviewed in 3 rounds, all findings addressed
- Known pre-existing test-pollution flake when `tests/test_sync_orchestrator_api.py tests/smoke/` run together (verified on main — see #655)

🤖 Generated with [Claude Code](https://claude.com/claude-code)