### PR TITLE
fix(#657): JobRuntime shutdown returns fast, boot reaper does recovery

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -452,33 +452,59 @@ class JobRuntime:
             fut = self._manual_executor.submit(wrapped)
             fut.add_done_callback(self._log_future_exception)
 
-    def shutdown(self, *, timeout_s: float = 30.0) -> None:
-        """Stop the scheduler with a bounded wait for in-flight jobs.
+    def shutdown(self, *, timeout_s: float = 5.0) -> None:
+        """Stop the scheduler quickly; rely on the boot reaper for recovery.
 
         Called from the FastAPI lifespan teardown *before* the
-        connection pool is closed so any job currently writing to
-        ``job_runs`` can finish cleanly.
+        connection pool is closed.
 
-        Two-phase teardown:
+        Recovery model (#657):
 
-        1. Graceful: try ``shutdown(wait=True)`` for up to
-           ``timeout_s`` seconds. If in-flight jobs return cleanly,
-           every ``job_runs`` write lands.
+        eBull treats shutdown as best-effort and crash recovery as
+        authoritative — the same pattern Postgres uses for its own
+        WAL replay, Kubernetes for ReplicaSet failover, Sidekiq for
+        ReliableFetch, etc. Two consequences:
 
-        2. Bounded escalation: if the graceful wait exceeds the
-           timeout, log loud and fall back to ``shutdown(wait=False)``
-           so the lifespan teardown can proceed. In-flight jobs
-           continue running in the background; their late writes to
-           ``job_runs`` will fail against the (about to close)
-           connection pool.
+        1. We do NOT block waiting for in-flight jobs. APScheduler is
+           stopped with ``wait=False`` so it stops accepting new jobs
+           and returns immediately; in-flight scheduled jobs get
+           hard-killed by process exit and Postgres rolls back their
+           open transactions when the connection drops. The manual
+           ThreadPoolExecutor likewise stops with
+           ``shutdown(wait=False, cancel_futures=True)`` so queued
+           manual triggers do not delay teardown.
 
-        Pre-fix history: the original implementation (PR #131) used
-        unbounded ``wait=True``. A hung job (e.g. SEC HTTP call
-        wedged behind a watcher-driven uvicorn reload) blocked the
-        lifespan teardown indefinitely; the old worker held port
-        8000 and the new worker couldn't bind, requiring a manual
-        process kill. Bounded wait converts a hard hang into
-        best-effort teardown + a visible operator-facing warning.
+        2. The orchestrator boot reaper
+           (``app.services.sync_orchestrator.reaper.reap_orphaned_syncs``,
+           called with ``reap_all=True`` from the lifespan startup) is
+           the authoritative cleanup. It transitions any
+           ``status='running'`` ``sync_runs`` row + its leftover
+           ``pending``/``running`` layer rows to terminal status with
+           ``error_category='orchestrator_crash'`` (or ``'cancelled'``
+           per #645 for never-started rows). This recovery runs on
+           every boot, regardless of how the prior process exited
+           (clean reload, SIGKILL, OOM, host reboot).
+
+        Pre-fix history (#131 → #657): the original implementation
+        used ``wait=True`` to drain jobs. A hung job blocked teardown
+        for the full timeout, and a uvicorn ``--reload`` cycle that
+        runs into an in-flight long-running job (SEC ingest,
+        fundamentals refresh) would routinely abandon the daemon
+        thread after 30s — slow enough that uvicorn's reload
+        supervisor often gave up and left the dev server dead with
+        no follow-up "Started server process" log. The fix lets
+        shutdown return in milliseconds and shifts trust onto the
+        boot reaper that already exists.
+
+        Idempotency requirement: any long-running job MUST be safe
+        under mid-flight kill. This already holds for orchestrator-
+        managed layers (UPSERT semantics + the reaper). Future jobs
+        added via APScheduler must not assume they'll always finish.
+
+        ``timeout_s`` (default 5.0) is the belt-and-suspenders cap.
+        With ``wait=False`` the underlying call should return in
+        milliseconds; the timeout exists in case APScheduler /
+        ThreadPoolExecutor itself hangs in cleanup.
         """
         if not self._started:
             return
@@ -486,34 +512,34 @@ class JobRuntime:
 
         def _graceful_scheduler() -> None:
             try:
-                self._scheduler.shutdown(wait=True)
+                # wait=False per #657 — do not block on in-flight jobs.
+                # The boot reaper handles their orphaned state on the
+                # next process startup.
+                self._scheduler.shutdown(wait=False)
             except Exception:
                 logger.exception("JobRuntime scheduler shutdown raised")
 
         def _graceful_executor() -> None:
             try:
-                self._manual_executor.shutdown(wait=True)
+                # cancel_futures=True drops queued manual triggers
+                # that haven't started yet; in-flight ones get
+                # hard-killed by process exit.
+                self._manual_executor.shutdown(wait=False, cancel_futures=True)
             except Exception:
                 logger.exception("JobRuntime manual executor shutdown raised")
 
-        # Run each shutdown on a DAEMON thread. If the join times out,
-        # we ABANDON the daemon thread rather than make a concurrent
-        # ``shutdown(wait=False)`` call: APScheduler / ThreadPoolExecutor
-        # don't document concurrent ``shutdown`` re-entry as safe and
-        # the second call could corrupt internal state or race with
-        # the still-blocked first call (Codex review on this PR).
-        # Daemon=True ensures the abandoned thread does not block
-        # interpreter exit; the underlying scheduler / executor goes
-        # to undefined state but that's acceptable for lifespan
-        # teardown — the process is on its way out either way and a
-        # uvicorn reload spawns a fresh runtime.
+        # Daemon-thread isolation kept from the prior impl so the
+        # join timeout cannot trap the lifespan teardown if either
+        # underlying ``shutdown`` itself wedges (rare; should not
+        # happen with wait=False but cheap insurance).
         sched_thread = threading.Thread(target=_graceful_scheduler, daemon=True)
         sched_thread.start()
         sched_thread.join(timeout=timeout_s)
         if sched_thread.is_alive():
             logger.warning(
-                "JobRuntime scheduler shutdown exceeded %.0fs — abandoning the daemon thread "
-                "and proceeding with teardown; in-flight scheduled jobs will not be drained",
+                "JobRuntime scheduler shutdown(wait=False) wedged for %.0fs — "
+                "abandoning daemon and proceeding; boot reaper will reconcile "
+                "any orphaned sync_runs on next startup",
                 timeout_s,
             )
 
@@ -522,8 +548,8 @@ class JobRuntime:
         exec_thread.join(timeout=timeout_s)
         if exec_thread.is_alive():
             logger.warning(
-                "JobRuntime manual executor shutdown exceeded %.0fs — abandoning the daemon "
-                "thread and proceeding; in-flight manual triggers will not be drained",
+                "JobRuntime manual executor shutdown(wait=False) wedged for %.0fs — "
+                "abandoning daemon and proceeding; queued manual triggers are dropped",
                 timeout_s,
             )
 

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -925,3 +925,88 @@ class TestShutdownBoundedWait:
         rt.shutdown(timeout_s=0.5)
         elapsed = time.monotonic() - start
         assert elapsed < 5.0, f"shutdown took {elapsed:.2f}s"
+
+
+class TestShutdownDoesNotBlockOnInflightJobs:
+    """#657 — shutdown must NOT wait for in-flight jobs. APScheduler is
+    stopped with wait=False; the manual executor with wait=False +
+    cancel_futures=True. Recovery is the boot reaper's job."""
+
+    def test_scheduler_shutdown_uses_wait_false(self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The previous impl used wait=True and routinely hit the 30s
+        cap on edits-during-fundamentals-sync, causing the uvicorn
+        --reload supervisor to give up and exit dirty. wait=False
+        means in-flight jobs get hard-killed by process exit and the
+        boot reaper transitions their orphaned sync_runs / layer rows
+        on the next startup."""
+        rt = _make_runtime({"j1": lambda: None})
+        rt.start()
+
+        captured: dict[str, object] = {}
+
+        def fake_scheduler_shutdown(*args: object, **kwargs: object) -> None:
+            captured["scheduler_kwargs"] = kwargs
+            captured["scheduler_args"] = args
+
+        monkeypatch.setattr(rt._scheduler, "shutdown", fake_scheduler_shutdown)
+        monkeypatch.setattr(rt._manual_executor, "shutdown", lambda *a, **kw: None)
+
+        rt.shutdown()
+
+        assert captured["scheduler_kwargs"] == {"wait": False}
+
+    def test_executor_shutdown_uses_wait_false_and_cancel_futures(
+        self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """cancel_futures=True drops manual triggers that are still
+        queued so they don't keep the executor alive past shutdown.
+        In-flight ones get hard-killed by process exit."""
+        rt = _make_runtime({"j1": lambda: None})
+        rt.start()
+
+        captured: dict[str, object] = {}
+
+        def fake_executor_shutdown(*args: object, **kwargs: object) -> None:
+            captured["executor_kwargs"] = kwargs
+
+        monkeypatch.setattr(rt._scheduler, "shutdown", lambda *a, **kw: None)
+        monkeypatch.setattr(rt._manual_executor, "shutdown", fake_executor_shutdown)
+
+        rt.shutdown()
+
+        assert captured["executor_kwargs"] == {"wait": False, "cancel_futures": True}
+
+    def test_inflight_job_does_not_delay_shutdown(self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Real-process simulation: a manual trigger submits a job that
+        sleeps long; shutdown must return promptly because we no longer
+        wait for it. The previous wait=True path would have blocked
+        until the sleep completed."""
+        import time
+
+        slept_for = 60.0  # job would sleep 60s if waited on
+        rt = _make_runtime({"slow": lambda: time.sleep(slept_for)})
+        rt.start()
+        rt._manual_executor.submit(lambda: time.sleep(slept_for))
+
+        start = time.monotonic()
+        rt.shutdown()
+        elapsed = time.monotonic() - start
+        assert elapsed < 2.0, (
+            f"shutdown took {elapsed:.2f}s — should be sub-second with wait=False; "
+            f"a value near {slept_for}s would mean wait=True regressed"
+        )
+
+    def test_default_timeout_is_short(self, patched_runtime: None) -> None:
+        """Default timeout is the belt-and-suspenders cap for the case
+        where the underlying shutdown(wait=False) call ITSELF wedges
+        (very rare). 5s is short enough that the uvicorn supervisor
+        does not give up on the relaunch but long enough to absorb
+        any cleanup the libraries do."""
+        import inspect
+
+        sig = inspect.signature(JobRuntime.shutdown)
+        default = sig.parameters["timeout_s"].default
+        assert default <= 10.0, (
+            f"shutdown default timeout is {default}s — should be <=10s so "
+            f"the uvicorn --reload supervisor does not abandon the relaunch"
+        )


### PR DESCRIPTION
## Summary

- Dev server frequently shuts down (no follow-up restart) on file edits because `scheduler.shutdown(wait=True)` blocked draining in-flight long-running jobs (SEC ingest, fundamentals walk). Hit the 30s cap → daemon thread abandoned → uvicorn `--reload` supervisor failed to relaunch.
- Fix: aligns with industry-standard "fast shutdown + boot recovery" — APScheduler stops with `wait=False`, manual executor with `wait=False, cancel_futures=True`. In-flight jobs hard-killed by process exit; Postgres rolls back open transactions when connection drops. The orchestrator boot reaper already wired into lifespan startup is the authoritative recovery and runs on every boot regardless of how the prior process exited (any crash: dev edit, SIGKILL, OOM, host reboot).
- Default timeout drops from 30s to 5s as belt-and-suspenders. With `wait=False` the call returns in milliseconds; 5s short enough that supervisor doesn't give up.

Patterns this matches: Postgres WAL replay, Kubernetes ReplicaSet failover, Sidekiq ReliableFetch.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` clean
- [x] `uv run pytest tests/test_jobs_runtime.py` — 35 pass (4 new under TestShutdownDoesNotBlockOnInflightJobs)
- Manual: edit `app/services/sync_orchestrator/executor.py` mid-fundamentals-sync, verify dev server restarts within ~5s instead of dying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)