### PR TITLE
feat(#643): MasterKeyNotLoadedError + classifier maps to MASTER_KEY_MISSING

### DIFF
--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -90,6 +90,7 @@ class ActionNeededItem(BaseModel):
         "db_constraint",
         "data_gap",
         "upstream_waiting",
+        "master_key_missing",
         "internal_error",
     ]
     operator_message: str

--- a/app/security/secrets_crypto.py
+++ b/app/security/secrets_crypto.py
@@ -45,6 +45,21 @@ class CredentialCryptoConfigError(RuntimeError):
     """Raised at startup when EBULL_SECRETS_KEY is missing or malformed."""
 
 
+class MasterKeyNotLoadedError(CredentialCryptoConfigError):
+    """Raised when ``encrypt`` / ``decrypt`` is called before
+    :func:`set_active_key` (i.e. before ``master_key.bootstrap()``).
+
+    Distinct from the env-key configuration errors above so the
+    sync orchestrator's exception classifier can map it to the
+    operator-actionable ``MASTER_KEY_MISSING`` category instead of
+    the generic ``INTERNAL_ERROR`` "Unclassified error" banner.
+
+    Inherits from :class:`CredentialCryptoConfigError` so existing
+    callers that catch the parent class continue to handle it
+    correctly (no behavior change for code paths that don't
+    distinguish the subclass)."""
+
+
 class CredentialDecryptError(Exception):
     """Raised when a ciphertext cannot be decrypted or authenticated."""
 
@@ -104,7 +119,7 @@ def clear_active_key() -> None:
 def _get_aesgcm() -> AESGCM:
     cached = _aesgcm
     if cached is None:
-        raise CredentialCryptoConfigError(
+        raise MasterKeyNotLoadedError(
             "broker-encryption key is not loaded -- master_key.bootstrap() must run before encrypt/decrypt is called"
         )
     return cached

--- a/app/services/sync_orchestrator/exception_classifier.py
+++ b/app/services/sync_orchestrator/exception_classifier.py
@@ -11,6 +11,7 @@ import httpx
 import psycopg
 import psycopg.errors
 
+from app.security.secrets_crypto import MasterKeyNotLoadedError
 from app.services.sync_orchestrator.layer_types import FailureCategory, LayerRefreshFailed
 
 
@@ -29,6 +30,14 @@ def classify_exception(exc: BaseException) -> FailureCategory:
     # information than this helper can recover from the exception type.
     if isinstance(exc, LayerRefreshFailed):
         return exc.category
+    # #643 — broker-encryption key not loaded. Distinct from the
+    # generic AUTH_EXPIRED (which means the credential decrypted but
+    # the upstream provider rejected it) and from the catch-all
+    # INTERNAL_ERROR. Surfaced with an operator-actionable banner
+    # via REMEDIES[MASTER_KEY_MISSING] instead of the opaque
+    # "Unclassified error" the path used to hit.
+    if isinstance(exc, MasterKeyNotLoadedError):
+        return FailureCategory.MASTER_KEY_MISSING
     if isinstance(exc, httpx.HTTPStatusError):
         status = exc.response.status_code
         if status in (401, 403):

--- a/app/services/sync_orchestrator/layer_types.py
+++ b/app/services/sync_orchestrator/layer_types.py
@@ -39,6 +39,13 @@ class FailureCategory(StrEnum):
     DB_CONSTRAINT = "db_constraint"
     DATA_GAP = "data_gap"
     UPSTREAM_WAITING = "upstream_waiting"
+    # #643 — broker-encryption key not loaded into the in-process
+    # cache when an adapter tried to encrypt/decrypt. Distinct from
+    # AUTH_EXPIRED (which means the credential decrypted but the
+    # provider rejected it). Triggers the operator-actionable
+    # "restore EBULL_SECRETS_KEY or run /recover" banner instead of
+    # the opaque "Unclassified error" the path used to hit.
+    MASTER_KEY_MISSING = "master_key_missing"
     INTERNAL_ERROR = "internal_error"
 
 
@@ -84,6 +91,17 @@ REMEDIES: dict[FailureCategory, Remedy] = {
         message="Waiting on upstream layer",
         operator_fix=None,
         self_heal=True,
+    ),
+    FailureCategory.MASTER_KEY_MISSING: Remedy(
+        message="Broker-encryption key not loaded — credentials cannot decrypt",
+        operator_fix=(
+            "Restart the backend so master_key.bootstrap() can load the persisted "
+            "root secret, or open Settings → /recover if the secret is missing"
+        ),
+        # No self-heal: a backoff retry won't help — the key has to
+        # come back via either the persisted root secret or the
+        # operator-driven recovery flow.
+        self_heal=False,
     ),
     FailureCategory.INTERNAL_ERROR: Remedy(
         message="Unclassified error — retrying with backoff",

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -963,6 +963,7 @@ export interface ActionNeededItem {
     | "db_constraint"
     | "data_gap"
     | "upstream_waiting"
+    | "master_key_missing"
     | "internal_error";
   operator_message: string;
   operator_fix: string | null;

--- a/tests/services/sync_orchestrator/test_layer_types.py
+++ b/tests/services/sync_orchestrator/test_layer_types.py
@@ -46,6 +46,10 @@ def test_failure_category_members() -> None:
         "db_constraint",
         "data_gap",
         "upstream_waiting",
+        # #643 — broker-encryption key not loaded; distinct category
+        # so the operator-actionable banner fires instead of the
+        # opaque INTERNAL_ERROR fallback.
+        "master_key_missing",
         "internal_error",
     }
 
@@ -65,6 +69,9 @@ def test_non_self_heal_categories_match_spec() -> None:
         FailureCategory.AUTH_EXPIRED,
         FailureCategory.SCHEMA_DRIFT,
         FailureCategory.DB_CONSTRAINT,
+        # #643 — backoff retry won't recover a missing master key;
+        # the operator must restart or run /recover.
+        FailureCategory.MASTER_KEY_MISSING,
     }
     for category in FailureCategory:
         assert REMEDIES[category].self_heal == (category not in non_self_heal)

--- a/tests/test_sync_orchestrator_executor.py
+++ b/tests/test_sync_orchestrator_executor.py
@@ -228,6 +228,33 @@ class TestCategorizeError:
         exc = KeyError("nope")
         assert classify_exception(exc) is FailureCategory.INTERNAL_ERROR
 
+    def test_master_key_not_loaded_maps_to_master_key_missing(self) -> None:
+        # #643 — distinct category so the operator-actionable banner
+        # ("restart the backend / open /recover") fires instead of the
+        # opaque "Unclassified error" the path used to hit.
+        from app.security.secrets_crypto import MasterKeyNotLoadedError
+        from app.services.sync_orchestrator.exception_classifier import classify_exception
+        from app.services.sync_orchestrator.layer_types import FailureCategory
+
+        exc = MasterKeyNotLoadedError("broker-encryption key is not loaded")
+        assert classify_exception(exc) is FailureCategory.MASTER_KEY_MISSING
+
+    def test_master_key_missing_remedy_present(self) -> None:
+        # The classifier mapping is useless without the REMEDIES entry.
+        # Pin the wiring so a future contributor can't drop one without
+        # the other.
+        from app.services.sync_orchestrator.layer_types import REMEDIES, FailureCategory
+
+        assert FailureCategory.MASTER_KEY_MISSING in REMEDIES
+        remedy = REMEDIES[FailureCategory.MASTER_KEY_MISSING]
+        # operator_fix is required — this category exists specifically
+        # because there's an operator action to take.
+        assert remedy.operator_fix is not None
+        # NOT self_heal — backoff retry won't recover; the key has to
+        # come back via either the persisted root secret or the
+        # operator-driven recovery flow.
+        assert remedy.self_heal is False
+
 
 class TestSetExecutor:
     def test_submit_sync_raises_when_no_executor_set(self) -> None:


### PR DESCRIPTION
## Summary

- New exception class `MasterKeyNotLoadedError` (subclass of `CredentialCryptoConfigError` for backward compat) raised by `_get_aesgcm` when the in-process AESGCM cache is empty.
- New `FailureCategory.MASTER_KEY_MISSING` + REMEDIES entry. Banner now reads "Broker-encryption key not loaded — credentials cannot decrypt" with operator_fix "Restart the backend / open /recover" instead of the opaque "Unclassified error".
- Classifier maps the new exception class to the new category. Frontend types + API Literal extended.

## Out of scope (deferred)

The "lifespan asserts on missing key" piece from the original ticket. `master_key.bootstrap()`'s `recovery_required` state IS the legitimate "creds exist but key missing" path — operator goes to /recover. Asserting there would break recovery.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` clean
- [x] `pnpm typecheck` clean
- [x] `pytest tests/test_sync_orchestrator_executor.py tests/test_executor_forensics.py` — 21 pass (2 new for classifier mapping + REMEDIES wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)