### PR TITLE
feat(#648): BusinessSectionsTeaser distinguishes parse_pending / failed / no_item_1

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -1262,6 +1262,39 @@ class BusinessSectionModel(BaseModel):
     tables: list[BusinessTableModel] = []
 
 
+class BusinessSectionsParseStatus(BaseModel):
+    """Why ``sections`` is empty (#648).
+
+    Populated only when ``sections`` is empty. Lets the operator UI
+    distinguish "the parser hasn't run yet" from "the parser tried
+    and failed" from "the filing genuinely has no Item 1" — all of
+    which used to render as the same opaque "No 10-K Item 1 on file"
+    empty state.
+
+    ``state``:
+      * ``not_attempted`` — no parent ``instrument_business_summary``
+        row exists. The ingester hasn't visited this instrument yet.
+      * ``parse_failed`` — parent row body is empty + an explicit
+        ``last_failure_reason`` from the FailureReason taxonomy is
+        set. Includes ``failure_reason``, ``next_retry_at``, and
+        ``last_attempted_at``.
+      * ``no_item_1`` — parent row body is empty AND the failure
+        reason was ``no_item_1_marker`` (or a body-too-short slice
+        from the same Item 1 absence). The 10-K filed by this issuer
+        doesn't have a parseable Item 1 — common for 10-K/A Part-III
+        amendments. Distinct from generic ``parse_failed`` so the
+        operator doesn't waste time investigating a fix.
+      * ``sections_pending`` — parent row body is non-empty (Item 1
+        was extracted) but the section splitter hasn't written
+        children yet. Should be transient.
+    """
+
+    state: Literal["not_attempted", "parse_failed", "no_item_1", "sections_pending"]
+    failure_reason: str | None = None
+    next_retry_at: datetime | None = None
+    last_attempted_at: datetime | None = None
+
+
 class BusinessSectionsResponse(BaseModel):
     """Response payload for ``/instruments/{symbol}/business_sections``.
 
@@ -1275,12 +1308,16 @@ class BusinessSectionsResponse(BaseModel):
     (``cgi-bin/viewer?cik=...&accession_number=...``) without an
     EDGAR search redirect (#563). NULL for instruments without a
     primary SEC CIK link (non-US tickers, crypto, etc.).
+
+    ``parse_status`` (#648) explains WHY ``sections`` is empty when
+    it is. NULL when ``sections`` has any content.
     """
 
     symbol: str
     source_accession: str | None
     cik: str | None
     sections: list[BusinessSectionModel]
+    parse_status: BusinessSectionsParseStatus | None = None
 
 
 @router.get(
@@ -1308,7 +1345,7 @@ def get_instrument_business_sections(
     specific historical filing. Returns 404 when no sections exist for
     the requested accession (#559).
     """
-    from app.services.business_summary import get_business_sections
+    from app.services.business_summary import get_business_sections, get_parse_status
 
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:
@@ -1337,6 +1374,26 @@ def get_instrument_business_sections(
             detail=f"no 10-K sections for {symbol} accession {accession}",
         )
     source_accession = sections[0].source_accession if sections else None
+
+    # #648 — when the latest-filing path returns empty, classify why
+    # so the operator UI can render distinct empty states. We only
+    # attempt classification on the latest-filing path (accession=None)
+    # — when an explicit accession was requested and missed, the 404
+    # above is the right answer; parse status is for the "is the
+    # narrative panel waiting on parsing or did it fail?" use case.
+    parse_status_model: BusinessSectionsParseStatus | None = None
+    if not sections and accession is None:
+        ps = get_parse_status(conn, instrument_id=instrument_id)
+        if ps is not None:
+            parse_status_model = BusinessSectionsParseStatus(
+                # The Literal narrows it for the response model — the
+                # service-layer dataclass uses str so the service
+                # tests don't pull in fastapi.
+                state=ps.state,  # type: ignore[arg-type]
+                failure_reason=ps.failure_reason,
+                next_retry_at=ps.next_retry_at,  # type: ignore[arg-type]
+                last_attempted_at=ps.last_attempted_at,  # type: ignore[arg-type]
+            )
 
     # #563: plumb CIK so the frontend can build direct iXBRL viewer
     # URLs. Single SELECT against the existing primary SEC link;
@@ -1381,6 +1438,7 @@ def get_instrument_business_sections(
             )
             for s in sections
         ],
+        parse_status=parse_status_model,
     )
 
 

--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -1100,6 +1100,85 @@ class BusinessSectionRow:
     tables: tuple[ParsedTable, ...] = ()
 
 
+@dataclass(frozen=True)
+class ParseStatus:
+    """Why ``get_business_sections`` returned empty for an instrument
+    (#648). Shape mirrors ``BusinessSectionsParseStatus`` in the API
+    layer; lifted here so service-side tests can assert on it without
+    pulling in FastAPI."""
+
+    state: str  # 'not_attempted' | 'parse_failed' | 'no_item_1' | 'sections_pending'
+    failure_reason: str | None = None
+    next_retry_at: object | None = None  # datetime, kept loose to avoid datetime import
+    last_attempted_at: object | None = None
+
+
+def get_parse_status(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+) -> ParseStatus | None:
+    """Classify the parse state when no sections are on file (#648).
+
+    Returns None when sections DO exist (caller shouldn't be asking).
+    Otherwise returns one of:
+      * ``not_attempted`` — no parent row.
+      * ``parse_failed`` — parent body empty + explicit failure_reason
+        other than the no-Item-1 marker.
+      * ``no_item_1`` — parent body empty AND failure_reason indicates
+        the filing has no Item 1 (no_item_1_marker / body_too_short).
+      * ``sections_pending`` — parent body non-empty but splitter
+        hasn't written children yet.
+
+    Caller is responsible for verifying ``sections`` is empty before
+    calling — this helper does not double-check (extra round-trip
+    against a hot path the API layer already handled).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT body, last_failure_reason, next_retry_at, last_parsed_at
+            FROM instrument_business_summary
+            WHERE instrument_id = %s
+            """,
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        return ParseStatus(state="not_attempted")
+
+    body = row[0] or ""
+    failure_reason = row[1]
+    next_retry_at = row[2]
+    last_parsed_at = row[3]
+
+    if body:
+        # Body extracted but the splitter hasn't written sections yet —
+        # transient, the splitter trigger should run shortly.
+        return ParseStatus(
+            state="sections_pending",
+            last_attempted_at=last_parsed_at,
+        )
+
+    # body is empty — tombstone path. Distinguish "no Item 1 to extract"
+    # from a real parse failure.
+    if failure_reason in {"no_item_1_marker", "body_too_short"}:
+        return ParseStatus(
+            state="no_item_1",
+            failure_reason=str(failure_reason) if failure_reason is not None else None,
+            next_retry_at=next_retry_at,
+            last_attempted_at=last_parsed_at,
+        )
+
+    return ParseStatus(
+        state="parse_failed",
+        failure_reason=str(failure_reason) if failure_reason is not None else None,
+        next_retry_at=next_retry_at,
+        last_attempted_at=last_parsed_at,
+    )
+
+
 def get_business_sections(
     conn: psycopg.Connection[Any],
     *,

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -209,6 +209,23 @@ export interface BusinessSection {
   tables: BusinessTable[];
 }
 
+/**
+ * Why `sections` is empty (#648). Populated only when `sections` is
+ * empty. Lets the operator UI distinguish "the parser hasn't run yet"
+ * from "the parser tried and failed" from "the filing genuinely has
+ * no Item 1" — all of which used to render as the same opaque
+ * "No 10-K Item 1 on file" empty state.
+ */
+export interface BusinessSectionsParseStatus {
+  state: "not_attempted" | "parse_failed" | "no_item_1" | "sections_pending";
+  failure_reason: string | null;
+  /** ISO timestamp (UTC). Backoff schedule applies; the next ingester
+   * pass after this timestamp will retry. */
+  next_retry_at: string | null;
+  /** ISO timestamp (UTC) of the most recent parse attempt. */
+  last_attempted_at: string | null;
+}
+
 export interface BusinessSectionsResponse {
   symbol: string;
   source_accession: string | null;
@@ -221,6 +238,9 @@ export interface BusinessSectionsResponse {
    */
   cik: string | null;
   sections: BusinessSection[];
+  /** #648 — explains WHY sections is empty when it is. NULL when
+   * sections has any content. */
+  parse_status?: BusinessSectionsParseStatus | null;
 }
 
 export function fetchBusinessSections(

--- a/frontend/src/components/instrument/BusinessSectionsTeaser.test.tsx
+++ b/frontend/src/components/instrument/BusinessSectionsTeaser.test.tsx
@@ -46,4 +46,108 @@ describe("BusinessSectionsTeaser", () => {
     await userEvent.click(btn);
     expect(navigateMock).toHaveBeenCalledWith("/instrument/GME/filings/10-k");
   });
+
+  it("renders the no_item_1 distinct empty state when parse_status.state is no_item_1 (#648)", async () => {
+    vi.spyOn(api, "fetchBusinessSections").mockResolvedValueOnce({
+      symbol: "GME",
+      source_accession: null,
+      cik: null,
+      sections: [],
+      parse_status: {
+        state: "no_item_1",
+        failure_reason: "no_item_1_marker",
+        next_retry_at: null,
+        last_attempted_at: "2026-04-01T00:00:00Z",
+      },
+    } as never);
+    render(
+      <MemoryRouter>
+        <BusinessSectionsTeaser symbol="GME" />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText(/10-K has no Item 1/i)).toBeInTheDocument();
+    // Generic legacy copy must NOT appear when the parse_status shape is set.
+    expect(screen.queryByText(/No 10-K Item 1 on file/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the parse_failed empty state with reason + retry timestamps (#648)", async () => {
+    vi.spyOn(api, "fetchBusinessSections").mockResolvedValueOnce({
+      symbol: "GME",
+      source_accession: null,
+      cik: null,
+      sections: [],
+      parse_status: {
+        state: "parse_failed",
+        failure_reason: "parse_exception",
+        next_retry_at: "2026-04-29T03:00:00Z",
+        last_attempted_at: "2026-04-28T03:00:00Z",
+      },
+    } as never);
+    render(
+      <MemoryRouter>
+        <BusinessSectionsTeaser symbol="GME" />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText(/parse failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/parse_exception/)).toBeInTheDocument();
+    expect(screen.getByText(/2026-04-28 03:00 UTC/)).toBeInTheDocument();
+    expect(screen.getByText(/2026-04-29 03:00 UTC/)).toBeInTheDocument();
+  });
+
+  it("renders the not_attempted empty state for fresh instruments (#648)", async () => {
+    vi.spyOn(api, "fetchBusinessSections").mockResolvedValueOnce({
+      symbol: "GME",
+      source_accession: null,
+      cik: null,
+      sections: [],
+      parse_status: {
+        state: "not_attempted",
+        failure_reason: null,
+        next_retry_at: null,
+        last_attempted_at: null,
+      },
+    } as never);
+    render(
+      <MemoryRouter>
+        <BusinessSectionsTeaser symbol="GME" />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText(/not yet parsed/i)).toBeInTheDocument();
+  });
+
+  it("renders the sections_pending empty state when body is set but splitter hasn't run (#648)", async () => {
+    vi.spyOn(api, "fetchBusinessSections").mockResolvedValueOnce({
+      symbol: "GME",
+      source_accession: null,
+      cik: null,
+      sections: [],
+      parse_status: {
+        state: "sections_pending",
+        failure_reason: null,
+        next_retry_at: null,
+        last_attempted_at: "2026-04-29T01:00:00Z",
+      },
+    } as never);
+    render(
+      <MemoryRouter>
+        <BusinessSectionsTeaser symbol="GME" />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText(/Sections pending/i)).toBeInTheDocument();
+  });
+
+  it("falls back to the legacy generic empty state when the API omits parse_status", async () => {
+    vi.spyOn(api, "fetchBusinessSections").mockResolvedValueOnce({
+      symbol: "GME",
+      source_accession: null,
+      cik: null,
+      sections: [],
+    } as never);
+    render(
+      <MemoryRouter>
+        <BusinessSectionsTeaser symbol="GME" />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText(/No 10-K Item 1 on file/i)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/instrument/BusinessSectionsTeaser.tsx
+++ b/frontend/src/components/instrument/BusinessSectionsTeaser.tsx
@@ -13,6 +13,7 @@
 import { fetchBusinessSections } from "@/api/instruments";
 import type {
   BusinessSection,
+  BusinessSectionsParseStatus,
   BusinessSectionsResponse,
 } from "@/api/instruments";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
@@ -48,6 +49,83 @@ function pickTeaser(sections: ReadonlyArray<BusinessSection>): string {
   return "";
 }
 
+/**
+ * Format the absolute timestamp for the empty-state hint. Keeps
+ * conditionally-rendered absolute times consistent across the four
+ * empty-state branches and makes a future "use relative time" swap
+ * a one-line change.
+ */
+function formatStamp(iso: string | null): string | null {
+  if (!iso) return null;
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return null;
+    return d.toISOString().slice(0, 16).replace("T", " ") + " UTC";
+  } catch {
+    return null;
+  }
+}
+
+interface ParseStatusEmptyStateProps {
+  status: BusinessSectionsParseStatus;
+}
+
+function ParseStatusEmptyState({ status }: ParseStatusEmptyStateProps): JSX.Element {
+  // Distinct copy per state so the operator can tell at a glance
+  // whether the empty panel needs investigation, will fix itself, or
+  // is intrinsic to the filing.
+  if (status.state === "no_item_1") {
+    return (
+      <EmptyState
+        title="10-K has no Item 1"
+        description={
+          "The latest 10-K filed by this issuer does not contain a parseable Item 1 " +
+          "Business section — common for 10-K/A amendments and shell-company filings. " +
+          "Nothing to investigate."
+        }
+      />
+    );
+  }
+  if (status.state === "parse_failed") {
+    const stamp = formatStamp(status.last_attempted_at);
+    const retry = formatStamp(status.next_retry_at);
+    const desc = [
+      `Parser failed${status.failure_reason ? ` (${status.failure_reason})` : ""}.`,
+      stamp ? ` Last attempted ${stamp}.` : "",
+      retry ? ` Next retry after ${retry}.` : "",
+    ]
+      .join("")
+      .trim();
+    return (
+      <EmptyState
+        title="10-K Item 1 parse failed"
+        description={desc || "Parser failed; will retry on the next ingester pass."}
+      />
+    );
+  }
+  if (status.state === "sections_pending") {
+    return (
+      <EmptyState
+        title="Sections pending"
+        description={
+          "Item 1 was extracted but the section splitter has not written subsections " +
+          "yet. Should appear shortly."
+        }
+      />
+    );
+  }
+  // not_attempted
+  return (
+    <EmptyState
+      title="10-K Item 1 not yet parsed"
+      description={
+        "The narrative ingester has not visited this instrument yet. It will be " +
+        "picked up on the next scheduled SEC business-summary pass."
+      }
+    />
+  );
+}
+
 export function BusinessSectionsTeaser({ symbol }: BusinessSectionsTeaserProps) {
   const navigate = useNavigate();
   const state = useAsync<BusinessSectionsResponse>(
@@ -67,10 +145,17 @@ export function BusinessSectionsTeaser({ symbol }: BusinessSectionsTeaserProps) 
       ) : state.error !== null ? (
         <SectionError onRetry={state.refetch} />
       ) : state.data === null || state.data.sections.length === 0 ? (
-        <EmptyState
-          title="No 10-K Item 1 on file"
-          description="No 10-K business description has been parsed for this instrument yet."
-        />
+        // #648 — render distinct empty states instead of the generic
+        // "No 10-K Item 1 on file" so the operator can tell parse-
+        // pending from parse-failed from genuinely-no-Item-1.
+        state.data?.parse_status ? (
+          <ParseStatusEmptyState status={state.data.parse_status} />
+        ) : (
+          <EmptyState
+            title="No 10-K Item 1 on file"
+            description="No 10-K business description has been parsed for this instrument yet."
+          />
+        )
       ) : (
         <div className="space-y-2 text-sm">
           <p className="leading-relaxed text-slate-700">

--- a/tests/test_business_sections_parse_status.py
+++ b/tests/test_business_sections_parse_status.py
@@ -1,0 +1,183 @@
+"""Tests for `get_parse_status` (#648).
+
+Pins the four empty-state classifications the API serializes into
+`BusinessSectionsParseStatus` so the frontend can render distinct
+empty-state copy. Runs against `ebull_test`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from uuid import uuid4
+
+import psycopg
+import pytest
+
+from app.services.business_summary import get_parse_status
+from tests.fixtures.ebull_test_db import (
+    test_database_url as _test_database_url,
+)
+from tests.fixtures.ebull_test_db import (
+    test_db_available as _test_db_available,
+)
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test Postgres not reachable",
+)
+
+
+@pytest.fixture
+def conn() -> Iterator[psycopg.Connection[object]]:
+    c: psycopg.Connection[object] = psycopg.connect(_test_database_url(), autocommit=True)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def _seed_instrument(conn: psycopg.Connection[object]) -> int:
+    """Insert a unique-symbol instrument row and return its id.
+
+    `instruments.instrument_id` has no DEFAULT in the schema (it's
+    populated by the universe sync via provider id mapping). Tests
+    pick a high random value with low collision probability.
+    """
+    sym = f"TEST_{uuid4().hex[:8]}"
+    # Random in a high range so collisions with real or other test
+    # rows are vanishingly unlikely. UUID4 hex prefix → int in
+    # [0, 2^32]; offset by 10^12 to stay well clear of anything the
+    # universe sync would assign.
+    iid = 10**12 + int(uuid4().hex[:8], 16)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO instruments
+                (instrument_id, symbol, company_name, currency,
+                 is_tradable, is_primary_listing)
+            VALUES (%s, %s, %s, 'USD', TRUE, TRUE)
+            RETURNING instrument_id
+            """,
+            (iid, sym, f"Test Instrument {sym}"),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        return int(row[0])  # type: ignore[index]
+
+
+def _delete_summary(conn: psycopg.Connection[object], instrument_id: int) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM instrument_business_summary WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        # Also delete the instrument row so the next test_case doesn't
+        # accumulate seeded rows (FK CASCADE handles dependents).
+        cur.execute(
+            "DELETE FROM instruments WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+
+
+class TestGetParseStatus:
+    def test_not_attempted_when_no_parent_row(self, conn: psycopg.Connection[object]) -> None:
+        instrument_id = _seed_instrument(conn)
+        try:
+            ps = get_parse_status(conn, instrument_id=instrument_id)
+            assert ps is not None
+            assert ps.state == "not_attempted"
+            assert ps.failure_reason is None
+            assert ps.next_retry_at is None
+            assert ps.last_attempted_at is None
+        finally:
+            _delete_summary(conn, instrument_id)
+
+    def test_no_item_1_when_failure_reason_is_marker(self, conn: psycopg.Connection[object]) -> None:
+        instrument_id = _seed_instrument(conn)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO instrument_business_summary
+                    (instrument_id, body, source_accession,
+                     attempt_count, last_failure_reason, next_retry_at)
+                VALUES (%s, '', 'acc-1', 1, 'no_item_1_marker', now() + interval '1 day')
+                """,
+                (instrument_id,),
+            )
+        try:
+            ps = get_parse_status(conn, instrument_id=instrument_id)
+            assert ps is not None
+            assert ps.state == "no_item_1"
+            assert ps.failure_reason == "no_item_1_marker"
+            assert ps.next_retry_at is not None
+            assert ps.last_attempted_at is not None
+        finally:
+            _delete_summary(conn, instrument_id)
+
+    def test_no_item_1_when_failure_reason_is_body_too_short(self, conn: psycopg.Connection[object]) -> None:
+        # body_too_short is the same root cause (Item 1 absent or
+        # truncated) so it's grouped with no_item_1 in the UI.
+        instrument_id = _seed_instrument(conn)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO instrument_business_summary
+                    (instrument_id, body, source_accession,
+                     attempt_count, last_failure_reason, next_retry_at)
+                VALUES (%s, '', 'acc-2', 1, 'body_too_short', now() + interval '1 day')
+                """,
+                (instrument_id,),
+            )
+        try:
+            ps = get_parse_status(conn, instrument_id=instrument_id)
+            assert ps is not None
+            assert ps.state == "no_item_1"
+        finally:
+            _delete_summary(conn, instrument_id)
+
+    def test_parse_failed_for_real_failures(self, conn: psycopg.Connection[object]) -> None:
+        # fetch_other / parse_exception / fetch_timeout are real
+        # failures the operator might want to investigate; they map
+        # to the parse_failed state distinct from no_item_1.
+        instrument_id = _seed_instrument(conn)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO instrument_business_summary
+                    (instrument_id, body, source_accession,
+                     attempt_count, last_failure_reason, next_retry_at)
+                VALUES (%s, '', 'acc-3', 2, 'parse_exception', now() + interval '7 days')
+                """,
+                (instrument_id,),
+            )
+        try:
+            ps = get_parse_status(conn, instrument_id=instrument_id)
+            assert ps is not None
+            assert ps.state == "parse_failed"
+            assert ps.failure_reason == "parse_exception"
+            assert ps.next_retry_at is not None
+            assert ps.last_attempted_at is not None
+        finally:
+            _delete_summary(conn, instrument_id)
+
+    def test_sections_pending_when_body_set_but_no_sections(self, conn: psycopg.Connection[object]) -> None:
+        # Parent row has a real body — the splitter just hasn't written
+        # children yet. Transient state; the splitter trigger should
+        # run shortly.
+        instrument_id = _seed_instrument(conn)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO instrument_business_summary
+                    (instrument_id, body, source_accession)
+                VALUES (%s, 'real Item 1 body text', 'acc-4')
+                """,
+                (instrument_id,),
+            )
+        try:
+            ps = get_parse_status(conn, instrument_id=instrument_id)
+            assert ps is not None
+            assert ps.state == "sections_pending"
+            assert ps.last_attempted_at is not None
+        finally:
+            _delete_summary(conn, instrument_id)

--- a/tests/test_business_sections_parse_status.py
+++ b/tests/test_business_sections_parse_status.py
@@ -94,13 +94,17 @@ class TestGetParseStatus:
 
     def test_no_item_1_when_failure_reason_is_marker(self, conn: psycopg.Connection[object]) -> None:
         instrument_id = _seed_instrument(conn)
+        # last_parsed_at populated explicitly so the assertion below
+        # doesn't depend on the schema-level NOT NULL DEFAULT NOW().
         with conn.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO instrument_business_summary
                     (instrument_id, body, source_accession,
-                     attempt_count, last_failure_reason, next_retry_at)
-                VALUES (%s, '', 'acc-1', 1, 'no_item_1_marker', now() + interval '1 day')
+                     attempt_count, last_failure_reason, next_retry_at,
+                     last_parsed_at)
+                VALUES (%s, '', 'acc-1', 1, 'no_item_1_marker',
+                        now() + interval '1 day', now())
                 """,
                 (instrument_id,),
             )
@@ -123,8 +127,10 @@ class TestGetParseStatus:
                 """
                 INSERT INTO instrument_business_summary
                     (instrument_id, body, source_accession,
-                     attempt_count, last_failure_reason, next_retry_at)
-                VALUES (%s, '', 'acc-2', 1, 'body_too_short', now() + interval '1 day')
+                     attempt_count, last_failure_reason, next_retry_at,
+                     last_parsed_at)
+                VALUES (%s, '', 'acc-2', 1, 'body_too_short',
+                        now() + interval '1 day', now())
                 """,
                 (instrument_id,),
             )
@@ -145,8 +151,10 @@ class TestGetParseStatus:
                 """
                 INSERT INTO instrument_business_summary
                     (instrument_id, body, source_accession,
-                     attempt_count, last_failure_reason, next_retry_at)
-                VALUES (%s, '', 'acc-3', 2, 'parse_exception', now() + interval '7 days')
+                     attempt_count, last_failure_reason, next_retry_at,
+                     last_parsed_at)
+                VALUES (%s, '', 'acc-3', 2, 'parse_exception',
+                        now() + interval '7 days', now())
                 """,
                 (instrument_id,),
             )
@@ -169,8 +177,8 @@ class TestGetParseStatus:
             cur.execute(
                 """
                 INSERT INTO instrument_business_summary
-                    (instrument_id, body, source_accession)
-                VALUES (%s, 'real Item 1 body text', 'acc-4')
+                    (instrument_id, body, source_accession, last_parsed_at)
+                VALUES (%s, 'real Item 1 body text', 'acc-4', now())
                 """,
                 (instrument_id,),
             )
@@ -178,6 +186,34 @@ class TestGetParseStatus:
             ps = get_parse_status(conn, instrument_id=instrument_id)
             assert ps is not None
             assert ps.state == "sections_pending"
+            assert ps.last_attempted_at is not None
+        finally:
+            _delete_summary(conn, instrument_id)
+
+    def test_parse_failed_when_failure_reason_is_null(self, conn: psycopg.Connection[object]) -> None:
+        # Edge case the bot flagged: a row with body='' but
+        # last_failure_reason IS NULL (race window where the ingester
+        # wrote the tombstone but failed before stamping the reason,
+        # or a manual operator-inserted row). Falls through to
+        # parse_failed with failure_reason=None — UI omits the
+        # parenthetical so it reads "Parser failed." rather than
+        # "Parser failed (None)" or similar awkward fallback.
+        instrument_id = _seed_instrument(conn)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO instrument_business_summary
+                    (instrument_id, body, source_accession,
+                     attempt_count, last_parsed_at)
+                VALUES (%s, '', 'acc-null-reason', 1, now())
+                """,
+                (instrument_id,),
+            )
+        try:
+            ps = get_parse_status(conn, instrument_id=instrument_id)
+            assert ps is not None
+            assert ps.state == "parse_failed"
+            assert ps.failure_reason is None
             assert ps.last_attempted_at is not None
         finally:
             _delete_summary(conn, instrument_id)


### PR DESCRIPTION
## Summary

- CAL was rendering "No 10-K Item 1 on file" despite a 10-K showing in Recent Filings — operator couldn't tell parse-pending from parse-failed from genuinely-no-Item-1.
- New `BusinessSectionsParseStatus` Pydantic model + optional `parse_status` on `BusinessSectionsResponse`. Populated only when `sections` is empty AND accession was unspecified (latest-filing path).
- New `get_parse_status` service helper classifies `instrument_business_summary` row into 4 states: `not_attempted` / `parse_failed` / `no_item_1` / `sections_pending`.
- BusinessSectionsTeaser renders distinct `EmptyState` per state with operator-actionable copy. Falls back to legacy "No 10-K Item 1 on file" when `parse_status` absent.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` clean
- [x] `pnpm typecheck` clean
- [x] `pytest tests/test_business_sections_parse_status.py` — 5 pass (one per classification + edge)
- [x] `pnpm exec vitest run BusinessSectionsTeaser` — 7 pass (5 new + 2 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)