### PR TITLE
feat(#646): notification bell in header — aggregates 3 existing alert feeds

### DIFF
--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -1,5 +1,7 @@
 import { useSession } from "@/lib/session";
 
+import { NotificationBell } from "./NotificationBell";
+
 export function Header() {
   const { status, operator, logout } = useSession();
   const connected = status === "authenticated";
@@ -8,6 +10,10 @@ export function Header() {
     <header className="flex h-14 items-center justify-between border-b border-slate-200 bg-white px-6">
       <div className="text-sm font-medium text-slate-500">Operator console</div>
       <div className="flex items-center gap-3 text-xs">
+        {/* Bell only when authenticated — the alerts endpoints are
+         *  session-protected; rendering it on the login page would
+         *  trigger silent 401s every 30s. */}
+        {connected && <NotificationBell />}
         <span
           className={[
             "inline-block h-2 w-2 rounded-full",

--- a/frontend/src/layout/NotificationBell.test.tsx
+++ b/frontend/src/layout/NotificationBell.test.tsx
@@ -1,0 +1,186 @@
+import { describe, beforeEach, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+import { NotificationBell } from "./NotificationBell";
+import * as alertsApi from "@/api/alerts";
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async (importActual) => {
+  const actual = (await importActual()) as object;
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+describe("NotificationBell (#646)", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("renders no badge when all three feeds report zero unseen", async () => {
+    vi.spyOn(alertsApi, "fetchGuardRejections").mockResolvedValue({
+      unseen_count: 0,
+      rejections: [],
+    } as never);
+    vi.spyOn(alertsApi, "fetchPositionAlerts").mockResolvedValue({
+      unseen_count: 0,
+      alerts: [],
+    } as never);
+    vi.spyOn(alertsApi, "fetchCoverageStatusDrops").mockResolvedValue({
+      unseen_count: 0,
+      drops: [],
+    } as never);
+
+    render(
+      <MemoryRouter>
+        <NotificationBell />
+      </MemoryRouter>,
+    );
+
+    const bell = await screen.findByTestId("notification-bell");
+    await waitFor(() => {
+      expect(bell.dataset.unseenCount).toBe("0");
+    });
+    expect(screen.queryByTestId("notification-bell-badge")).not.toBeInTheDocument();
+  });
+
+  it("sums unseen_count across all three feeds and renders the badge", async () => {
+    vi.spyOn(alertsApi, "fetchGuardRejections").mockResolvedValue({
+      unseen_count: 2,
+      rejections: [],
+    } as never);
+    vi.spyOn(alertsApi, "fetchPositionAlerts").mockResolvedValue({
+      unseen_count: 5,
+      alerts: [],
+    } as never);
+    vi.spyOn(alertsApi, "fetchCoverageStatusDrops").mockResolvedValue({
+      unseen_count: 1,
+      drops: [],
+    } as never);
+
+    render(
+      <MemoryRouter>
+        <NotificationBell />
+      </MemoryRouter>,
+    );
+
+    const badge = await screen.findByTestId("notification-bell-badge");
+    expect(badge).toHaveTextContent("8");
+    const bell = screen.getByTestId("notification-bell");
+    expect(bell.dataset.unseenCount).toBe("8");
+  });
+
+  it("treats a single failing feed as zero (best-effort) and still renders the others", async () => {
+    vi.spyOn(alertsApi, "fetchGuardRejections").mockRejectedValue(new Error("boom"));
+    vi.spyOn(alertsApi, "fetchPositionAlerts").mockResolvedValue({
+      unseen_count: 4,
+      alerts: [],
+    } as never);
+    vi.spyOn(alertsApi, "fetchCoverageStatusDrops").mockResolvedValue({
+      unseen_count: 1,
+      drops: [],
+    } as never);
+
+    render(
+      <MemoryRouter>
+        <NotificationBell />
+      </MemoryRouter>,
+    );
+
+    const badge = await screen.findByTestId("notification-bell-badge");
+    expect(badge).toHaveTextContent("5");
+  });
+
+  it("caps the badge display at 99+ for huge counts", async () => {
+    vi.spyOn(alertsApi, "fetchGuardRejections").mockResolvedValue({
+      unseen_count: 50,
+      rejections: [],
+    } as never);
+    vi.spyOn(alertsApi, "fetchPositionAlerts").mockResolvedValue({
+      unseen_count: 50,
+      alerts: [],
+    } as never);
+    vi.spyOn(alertsApi, "fetchCoverageStatusDrops").mockResolvedValue({
+      unseen_count: 50,
+      drops: [],
+    } as never);
+
+    render(
+      <MemoryRouter>
+        <NotificationBell />
+      </MemoryRouter>,
+    );
+
+    const badge = await screen.findByTestId("notification-bell-badge");
+    expect(badge).toHaveTextContent("99+");
+    // Internal data attribute carries the real number for tests /
+    // assistive tech parsing.
+    const bell = screen.getByTestId("notification-bell");
+    expect(bell.dataset.unseenCount).toBe("150");
+  });
+
+  it("clicking the bell navigates to /dashboard", async () => {
+    vi.spyOn(alertsApi, "fetchGuardRejections").mockResolvedValue({
+      unseen_count: 1,
+      rejections: [],
+    } as never);
+    vi.spyOn(alertsApi, "fetchPositionAlerts").mockResolvedValue({
+      unseen_count: 0,
+      alerts: [],
+    } as never);
+    vi.spyOn(alertsApi, "fetchCoverageStatusDrops").mockResolvedValue({
+      unseen_count: 0,
+      drops: [],
+    } as never);
+
+    render(
+      <MemoryRouter>
+        <NotificationBell />
+      </MemoryRouter>,
+    );
+
+    const bell = await screen.findByTestId("notification-bell");
+    await userEvent.click(bell);
+    expect(navigateMock).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("polls again after the interval — refresh picks up new unseen state", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const guardSpy = vi
+        .spyOn(alertsApi, "fetchGuardRejections")
+        .mockResolvedValueOnce({ unseen_count: 0, rejections: [] } as never)
+        .mockResolvedValueOnce({ unseen_count: 3, rejections: [] } as never);
+      vi.spyOn(alertsApi, "fetchPositionAlerts").mockResolvedValue({
+        unseen_count: 0,
+        alerts: [],
+      } as never);
+      vi.spyOn(alertsApi, "fetchCoverageStatusDrops").mockResolvedValue({
+        unseen_count: 0,
+        drops: [],
+      } as never);
+
+      render(
+        <MemoryRouter>
+          <NotificationBell />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(guardSpy).toHaveBeenCalledTimes(1);
+      });
+
+      // Advance past the 30s poll interval.
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await waitFor(() => {
+        expect(guardSpy).toHaveBeenCalledTimes(2);
+      });
+      const badge = await screen.findByTestId("notification-bell-badge");
+      expect(badge).toHaveTextContent("3");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/layout/NotificationBell.tsx
+++ b/frontend/src/layout/NotificationBell.tsx
@@ -1,0 +1,113 @@
+/**
+ * NotificationBell — header-bar bell with aggregate unseen-count
+ * badge across the three existing alert feeds (#646).
+ *
+ * Surfaces what already exists rather than adding new infrastructure:
+ *   - GET /alerts/guard-rejections          (#399)
+ *   - GET /alerts/position-alerts           (#396/#401)
+ *   - GET /alerts/coverage-status-drops     (#397/#402)
+ *
+ * Each feed already exposes `unseen_count` per the per-operator
+ * cursor pattern. The bell sums them, shows a small red badge when
+ * non-zero, and navigates to /dashboard on click — that's where the
+ * existing AlertsStrip renders the unified feed in detail.
+ *
+ * Polls every 30s. Failures are silent (each feed is best-effort);
+ * a single feed erroring just contributes 0 to the count and the
+ * badge keeps reflecting the others. Same posture as AlertsStrip.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import {
+  fetchCoverageStatusDrops,
+  fetchGuardRejections,
+  fetchPositionAlerts,
+} from "@/api/alerts";
+
+const POLL_INTERVAL_MS = 30_000;
+
+/**
+ * Resolve a single feed's unseen_count to a number, swallowing any
+ * fetch error so one broken feed doesn't black out the badge for
+ * the others. Mirrors AlertsStrip's per-feed best-effort posture.
+ */
+async function safeUnseen(load: () => Promise<{ unseen_count: number }>): Promise<number> {
+  try {
+    const r = await load();
+    const n = r.unseen_count;
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function NotificationBell(): JSX.Element {
+  const navigate = useNavigate();
+  const [count, setCount] = useState<number>(0);
+
+  const refresh = useCallback(async () => {
+    const [guard, position, coverage] = await Promise.all([
+      safeUnseen(fetchGuardRejections),
+      safeUnseen(fetchPositionAlerts),
+      safeUnseen(fetchCoverageStatusDrops),
+    ]);
+    setCount(guard + position + coverage);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const id = window.setInterval(() => {
+      void refresh();
+    }, POLL_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [refresh]);
+
+  // Cap displayed count at 99+ — past the badge's visual budget,
+  // operator gets the click signal anyway.
+  const display = count > 99 ? "99+" : String(count);
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate("/dashboard")}
+      aria-label={count > 0 ? `${count} unread notifications` : "Notifications"}
+      data-testid="notification-bell"
+      data-unseen-count={count}
+      title={count > 0 ? `${count} unread — click to open dashboard` : "No unread alerts"}
+      className={[
+        "relative rounded p-1 text-slate-600 transition hover:bg-slate-50",
+        count > 0 ? "text-red-700" : "",
+      ].join(" ")}
+    >
+      {/* Inline SVG bell — keeps the component dependency-free. */}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-4 w-4"
+        aria-hidden
+      >
+        <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+        <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+      </svg>
+      {count > 0 && (
+        <span
+          data-testid="notification-bell-badge"
+          className={[
+            "absolute -right-1 -top-1 flex min-w-[16px] items-center justify-center",
+            "rounded-full bg-red-600 px-1 text-[10px] font-medium leading-none text-white",
+            "tabular-nums",
+          ].join(" ")}
+        >
+          {display}
+        </span>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- Lighter-than-spec scope per operator: surface what's already there instead of new infrastructure.
- New `NotificationBell` in Header polls the 3 existing alert endpoints (guard rejections, position alerts, coverage status drops) every 30s, sums `unseen_count`, shows a red badge.
- Click → `/dashboard` (where the existing `AlertsStrip` already renders the unified feed in detail).
- Per-feed errors swallowed silently — one broken feed contributes 0 and the others keep working.
- Mounted only when authenticated; alerts endpoints are session-protected.

## Out of scope (deferred)

- `system_events` table / 4th feed for orchestrator-level events. Admin red banners already cover that surface; rolling into the bell is a separate ticket if needed.
- Per-feed dropdown popover. Click → /dashboard delivers the same outcome.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm exec vitest run NotificationBell` — 6 pass (zero-state no-badge, sum-across-feeds, single-feed-failure best-effort, 99+ cap, click→navigate, 30s poll refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)