### PR TITLE
feat(#649A): boot-time freshness sweep — recovers from missed schedule slots

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -208,7 +209,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # clicked "Sync now". Recovery model is now: every boot
         # opportunistically catches up everything that drifted past
         # its freshness target.
-        if settings.orchestrator_enabled:
+        #
+        # Gated by EBULL_SKIP_BOOT_SWEEP (mirrors EBULL_SKIP_CATCH_UP)
+        # so the test suite can disable it — every TestClient(app)
+        # enter would otherwise dispatch a behind sync that holds the
+        # partial-unique-index gate and 409s subsequent POST /sync
+        # scope='behind' tests in unrelated test modules.
+        skip_boot_sweep = os.environ.get("EBULL_SKIP_BOOT_SWEEP") == "1"
+        if settings.orchestrator_enabled and not skip_boot_sweep:
             try:
                 asyncio.create_task(_boot_freshness_sweep())
             except Exception:

--- a/app/main.py
+++ b/app/main.py
@@ -198,6 +198,22 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         except Exception:
             logger.exception("failed to register orchestrator executor")
 
+        # #649A — boot-time freshness sweep. Fires once on startup as
+        # a non-blocking asyncio task; uses scope='behind' which the
+        # planner short-circuits when nothing is past its freshness
+        # target, so this is cheap on a fresh dev DB. Without this
+        # the daily 03:00 UTC orchestrator_full_sync was the only
+        # scheduled refresh path and any restart that missed that
+        # window left the data stale until the operator manually
+        # clicked "Sync now". Recovery model is now: every boot
+        # opportunistically catches up everything that drifted past
+        # its freshness target.
+        if settings.orchestrator_enabled:
+            try:
+                asyncio.create_task(_boot_freshness_sweep())
+            except Exception:
+                logger.exception("failed to schedule boot freshness sweep")
+
     # In-process quote-tick fan-out bus (#274 Slice 3). Created here
     # so it lives for the full app lifetime; the WS subscriber
     # publishes to it, the SSE endpoint reads from it. Always
@@ -283,6 +299,48 @@ def _bootstrap_fx_rates(pool: ConnectionPool[Any]) -> None:
             "fx bootstrap: fx_rates_refresh raised; daily cron will retry",
             exc_info=True,
         )
+
+
+async def _boot_freshness_sweep() -> None:
+    """Boot-time `scope='behind'` sweep (#649A).
+
+    Fires once per app startup as a non-blocking asyncio task.
+    Uses the existing `scope='behind'` planner which only refreshes
+    layers past their freshness target — cheap when the data is
+    current, useful when the daily 03:00 UTC slot was missed (dev
+    laptop asleep, prod restart, host reboot).
+
+    All exceptions swallowed: this is a best-effort recovery on top
+    of the regular schedule, not a critical path. The orchestrator's
+    own audit (sync_runs / sync_layer_progress) records what fired
+    and what failed; we just dispatch.
+    """
+    try:
+        from app.services.sync_orchestrator import (
+            SyncAlreadyRunning,
+            SyncScope,
+            submit_sync,
+        )
+
+        # Submit on a worker thread — submit_sync's planner does some
+        # synchronous DB work and `asyncio.create_task` runs us on
+        # the event loop. Off-load via to_thread so we don't block
+        # other startup tasks.
+        def _dispatch() -> None:
+            try:
+                submit_sync(SyncScope.behind(), trigger="boot_sweep")
+                logger.info("boot freshness sweep dispatched (scope=behind)")
+            except SyncAlreadyRunning:
+                # The 5-minute high_frequency tick may have beaten us
+                # to the gate, or a manual sync is already running.
+                # Fine — that sync covers the catch-up either way.
+                logger.info("boot freshness sweep skipped: sync already running")
+            except Exception:
+                logger.exception("boot freshness sweep dispatch failed")
+
+        await asyncio.to_thread(_dispatch)
+    except Exception:
+        logger.exception("boot freshness sweep helper failed")
 
 
 async def _maybe_start_etoro_ws(

--- a/app/services/sync_orchestrator/types.py
+++ b/app/services/sync_orchestrator/types.py
@@ -120,7 +120,7 @@ class ExecutionPlan:
 # ---------------------------------------------------------------------------
 
 
-SyncTrigger = Literal["manual", "scheduled", "catch_up"]
+SyncTrigger = Literal["manual", "scheduled", "catch_up", "boot_sweep"]
 
 
 @dataclass(frozen=True)

--- a/sql/083_sync_runs_trigger_boot_sweep.sql
+++ b/sql/083_sync_runs_trigger_boot_sweep.sql
@@ -1,0 +1,18 @@
+-- 083_sync_runs_trigger_boot_sweep.sql
+--
+-- Issue #649A — boot-time freshness sweep.
+--
+-- Adds 'boot_sweep' as a valid sync_runs.trigger value. Boot sweep
+-- fires once per app startup as a non-blocking asyncio task; uses
+-- the existing scope='behind' planner which is idempotent and only
+-- refreshes layers that are past their freshness target. Distinct
+-- from 'manual' (operator click) and 'scheduled' (APScheduler cron)
+-- so the audit trail in `/sync/runs` shows the recovery cause when
+-- triaging "what brought the data back to current after the
+-- restart".
+
+ALTER TABLE sync_runs DROP CONSTRAINT IF EXISTS sync_runs_trigger_check;
+
+ALTER TABLE sync_runs
+    ADD CONSTRAINT sync_runs_trigger_check
+    CHECK (trigger IN ('manual', 'scheduled', 'catch_up', 'boot_sweep'));

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,13 @@ import os
 # EBULL_SKIP_CATCH_UP=0 pytest to reproduce catch-up bugs.
 os.environ.setdefault("EBULL_SKIP_CATCH_UP", "1")
 
+# Skip the #649A boot freshness sweep in every TestClient(app) enter
+# cycle. Without this, every test that enters the FastAPI lifespan
+# would dispatch a `scope='behind'` sync that holds the partial-
+# unique-index gate; subsequent POST /sync scope='behind' tests in
+# unrelated test modules would 409 against it.
+os.environ.setdefault("EBULL_SKIP_BOOT_SWEEP", "1")
+
 import pytest  # noqa: E402
 
 from app.api.auth import require_session_or_service_token  # noqa: E402

--- a/tests/test_boot_freshness_sweep.py
+++ b/tests/test_boot_freshness_sweep.py
@@ -1,0 +1,131 @@
+"""Tests for `_boot_freshness_sweep` (#649A).
+
+Covers:
+- Helper dispatches `submit_sync(SyncScope.behind(), trigger='boot_sweep')`.
+- `SyncAlreadyRunning` raised by the planner is swallowed (the
+  high_frequency tick or a manual sync may have beaten us to the gate).
+- Any other exception is logged but not propagated — boot must not
+  fail because the recovery sweep failed.
+- Migration 083 lets the orchestrator INSERT a row with
+  trigger='boot_sweep' (the CHECK constraint accepts it).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import psycopg
+import pytest
+
+from tests.fixtures.ebull_test_db import (
+    test_database_url as _test_database_url,
+)
+from tests.fixtures.ebull_test_db import (
+    test_db_available as _test_db_available,
+)
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test Postgres not reachable",
+)
+
+
+@pytest.fixture
+def conn() -> Iterator[psycopg.Connection[object]]:
+    c: psycopg.Connection[object] = psycopg.connect(_test_database_url(), autocommit=True)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+class TestBootSweepDispatch:
+    def test_helper_calls_submit_sync_with_boot_sweep_trigger(self) -> None:
+        """The helper must call submit_sync with the new trigger
+        value so the audit trail in /sync/runs distinguishes
+        recovery-on-startup from operator-clicked manual triggers."""
+        from app.main import _boot_freshness_sweep
+
+        captured: dict[str, object] = {}
+
+        def fake_submit(scope: object, trigger: str) -> tuple[int, object]:
+            captured["scope"] = scope
+            captured["trigger"] = trigger
+            return (1, object())
+
+        with patch("app.services.sync_orchestrator.submit_sync", side_effect=fake_submit):
+            asyncio.run(_boot_freshness_sweep())
+
+        assert captured["trigger"] == "boot_sweep"
+        # SyncScope.behind() returns a frozen dataclass; assert the
+        # scope kind without coupling to the exact import path.
+        scope = captured["scope"]
+        assert getattr(scope, "kind", None) == "behind"
+
+    def test_helper_swallows_sync_already_running(self) -> None:
+        """The 5-minute high_frequency APScheduler tick may have
+        beaten us to the gate. SyncAlreadyRunning is the expected
+        outcome in that race; must not propagate."""
+        from app.main import _boot_freshness_sweep
+        from app.services.sync_orchestrator.types import SyncAlreadyRunning, SyncScope
+
+        def fake_submit(scope: object, trigger: str) -> tuple[int, object]:
+            raise SyncAlreadyRunning(SyncScope.behind(), active_sync_run_id=42)
+
+        with patch("app.services.sync_orchestrator.submit_sync", side_effect=fake_submit):
+            # Must not raise — best-effort recovery.
+            asyncio.run(_boot_freshness_sweep())
+
+    def test_helper_swallows_arbitrary_exceptions(self) -> None:
+        """Any other failure (DB blip, classifier bug, etc.) must
+        also be swallowed: the boot path must continue regardless of
+        what the recovery sweep encounters."""
+        from app.main import _boot_freshness_sweep
+
+        def fake_submit(scope: object, trigger: str) -> tuple[int, object]:
+            raise RuntimeError("unexpected planner failure")
+
+        with patch("app.services.sync_orchestrator.submit_sync", side_effect=fake_submit):
+            # Must not raise.
+            asyncio.run(_boot_freshness_sweep())
+
+
+class TestMigration083AcceptsBootSweepTrigger:
+    """The trigger CHECK constraint on sync_runs must accept the new
+    'boot_sweep' value. Without migration 083 the helper would
+    INSERT a row that violated the prior {manual, scheduled,
+    catch_up} check — the planner catches IntegrityError but the
+    recovery sweep would silently never record a row."""
+
+    def test_insert_with_boot_sweep_trigger_succeeds(self, conn: psycopg.Connection[object]) -> None:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO sync_runs
+                    (scope, trigger, started_at, status, layers_planned)
+                VALUES ('behind', 'boot_sweep', now(), 'complete', 0)
+                RETURNING sync_run_id
+                """,
+            )
+            row = cur.fetchone()
+            assert row is not None
+            sync_run_id = int(row[0])  # type: ignore[index]
+
+        # Cleanup.
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM sync_runs WHERE sync_run_id = %s", (sync_run_id,))
+
+    def test_insert_with_unknown_trigger_still_rejected(self, conn: psycopg.Connection[object]) -> None:
+        # Constraint must remain a positive allowlist — the new
+        # value gets added but garbage values still fail.
+        with conn.cursor() as cur:
+            with pytest.raises(psycopg.errors.CheckViolation):
+                cur.execute(
+                    """
+                    INSERT INTO sync_runs
+                        (scope, trigger, started_at, status, layers_planned)
+                    VALUES ('behind', 'not_a_real_trigger', now(), 'complete', 0)
+                    """,
+                )


### PR DESCRIPTION
## Summary

Part A of the #649 plan. Every app boot opportunistically dispatches a non-blocking `scope='behind'` sync after the executor is registered. The behind-scope planner only refreshes layers past their freshness target, so this is cheap on fresh DBs and useful when the daily 03:00 UTC slot was missed.

- New SyncTrigger value `boot_sweep` (migration 083 extends the CHECK).
- Best-effort: `SyncAlreadyRunning` swallowed (the high_frequency tick may beat us); arbitrary failures swallowed (boot must not fail because recovery failed).
- Lifespan continues without waiting; helper runs via `asyncio.to_thread`.

## Out of scope (deferred to follow-up PRs)

- **#649B** periodic hourly `behind` cadence (so multi-hour drift between boots is caught without operator clicks).
- **#649C** incremental adapters so `daily_research_refresh` etc. query "instruments past target" instead of walking the universe.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` clean
- [x] `uv run pytest tests/smoke/ tests/test_boot_freshness_sweep.py` — 7 pass (5 new + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)