### PR TITLE
fix(#646): bell navigates to / not /dashboard

### DIFF
--- a/frontend/src/layout/NotificationBell.test.tsx
+++ b/frontend/src/layout/NotificationBell.test.tsx
@@ -120,7 +120,7 @@ describe("NotificationBell (#646)", () => {
     expect(bell.dataset.unseenCount).toBe("150");
   });
 
-  it("clicking the bell navigates to /dashboard", async () => {
+  it("clicking the bell navigates to / (dashboard root)", async () => {
     vi.spyOn(alertsApi, "fetchGuardRejections").mockResolvedValue({
       unseen_count: 1,
       rejections: [],
@@ -142,7 +142,7 @@ describe("NotificationBell (#646)", () => {
 
     const bell = await screen.findByTestId("notification-bell");
     await userEvent.click(bell);
-    expect(navigateMock).toHaveBeenCalledWith("/dashboard");
+    expect(navigateMock).toHaveBeenCalledWith("/");
   });
 
   it("polls again after the interval — refresh picks up new unseen state", async () => {

--- a/frontend/src/layout/NotificationBell.tsx
+++ b/frontend/src/layout/NotificationBell.tsx
@@ -71,11 +71,11 @@ export function NotificationBell(): JSX.Element {
   return (
     <button
       type="button"
-      onClick={() => navigate("/dashboard")}
+      onClick={() => navigate("/")}
       aria-label={count > 0 ? `${count} unread notifications` : "Notifications"}
       data-testid="notification-bell"
       data-unseen-count={count}
-      title={count > 0 ? `${count} unread — click to open dashboard` : "No unread alerts"}
+      title={count > 0 ? `${count} unread — click to open the dashboard` : "No unread alerts"}
       className={[
         "relative rounded p-1 text-slate-600 transition hover:bg-slate-50",
         count > 0 ? "text-red-700" : "",


### PR DESCRIPTION
## Summary

NotificationBell click navigated to `/dashboard` but no such route exists — the dashboard component is mounted as the index route at `/`. Operator hit the bell on the live stack and got the catch-all NotFoundPage.

Fix: navigate to `/`. One-line + test + tooltip update.

## Test plan

- [x] `pnpm exec vitest run NotificationBell.test.tsx` — 6 pass
- Manual: bell click on live stack → AlertsStrip on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)