### PR TITLE
feat(#674): track MLP/LP partnership distribution XBRL concepts

### DIFF
--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -131,12 +131,48 @@ TRACKED_CONCEPTS: dict[str, tuple[str, ...]] = {
     "investing_cf": ("NetCashProvidedByUsedInInvestingActivities",),
     "financing_cf": ("NetCashProvidedByUsedInFinancingActivities",),
     "capex": ("PaymentsToAcquirePropertyPlantAndEquipment", "CapitalExpenditures"),
-    "dividends_paid": ("PaymentsOfDividends", "PaymentsOfDividendsCommonStock"),
-    "dps_declared": ("CommonStockDividendsPerShareDeclared",),
+    # Cash dividends/distributions paid in the period. Corp issuers
+    # use ``PaymentsOfDividends*``; pass-through entities (MLPs, LPs,
+    # LLCs taxed as partnerships, REIT operating-partnership tiers)
+    # report the same flow under the partnership taxonomy concepts
+    # ``DistributionMadeTo{LimitedPartner,MemberOrLimitedPartner,
+    # LimitedLiabilityCompanyLLCMember}CashDistributionsPaid``.
+    # Without these, IEP / ET / EPD / MPLX / pass-through LLCs land at
+    # zero recorded dividends paid post-LP-conversion — see #674.
+    "dividends_paid": (
+        "PaymentsOfDividends",
+        "PaymentsOfDividendsCommonStock",
+        "DistributionMadeToLimitedPartnerCashDistributionsPaid",
+        "DistributionMadeToMemberOrLimitedPartnerCashDistributionsPaid",
+        "DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsPaid",
+    ),
+    # Per-unit/share declared. SEC tags partnership distributions
+    # under three parallel concepts depending on the issuer's legal
+    # form (LP / LP+member-aggregate / pure LLC). All three report
+    # in ``USD/shares`` units which the existing ``_UNIT_PRIORITY``
+    # list already covers, so no unit-priority change is needed. The
+    # legacy ``DistributionsPerLimitedPartnershipUnitOutstanding``
+    # tag is still emitted by some pre-2018 filers, kept for
+    # compatibility.
+    "dps_declared": (
+        "CommonStockDividendsPerShareDeclared",
+        "DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit",
+        "DistributionMadeToMemberOrLimitedPartnerDistributionsDeclaredPerUnit",
+        "DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsDeclaredPerUnit",
+        "DistributionsPerLimitedPartnershipUnitOutstanding",
+    ),
     # Cash actually distributed per share (often differs from declared
     # by a quarter). Captured separately so dividend-capture strategies
-    # can tell declared-but-not-paid cases from paid.
-    "dps_cash_paid": ("CommonStockDividendsPerShareCashPaid",),
+    # can tell declared-but-not-paid cases from paid. Currently lands
+    # in ``financial_facts_raw`` only — `PeriodRow` doesn't surface
+    # this column yet, so adding more aliases here is purely about
+    # raw-store completeness for future analytics work.
+    "dps_cash_paid": (
+        "CommonStockDividendsPerShareCashPaid",
+        "DistributionMadeToLimitedPartnerCashDistributionsPaidPerUnit",
+        "DistributionMadeToMemberOrLimitedPartnerCashDistributionsPaidPerUnit",
+        "DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsPaidPerUnit",
+    ),
     # Per-share declared amount still payable at period end.
     "dividends_payable_per_share": ("DividendsPayableAmountPerShare",),
     "buyback_spend": ("PaymentsForRepurchaseOfCommonStock",),

--- a/tests/test_xbrl_fact_extraction.py
+++ b/tests/test_xbrl_fact_extraction.py
@@ -327,3 +327,228 @@ class TestExtendedUsGaapConcepts:
         facts = _extract_facts_from_gaap(gaap)
         assert len(facts) == 1
         assert facts[0].concept == "TreasuryStockSharesAcquired"
+
+
+class TestPartnershipDistributionConcepts:
+    """#674: pass-through entities (MLPs, LPs, LLCs taxed as partnerships)
+    file dividend / distribution facts under partnership-specific
+    XBRL tags. Without these in the allowlist, IEP / ET / EPD / MPLX
+    etc. landed at zero declared DPS in dividend_history despite
+    continuing to file quarterly distributions on SEC.
+
+    Live cross-check: SEC ships
+    ``DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit``
+    on Icahn Enterprises (CIK 0000813762) quarterly under
+    ``USD/shares`` units — the same priority slot the corp-style
+    ``CommonStockDividendsPerShareDeclared`` already used."""
+
+    def test_lp_distributions_declared_per_unit_extracted(self) -> None:
+        gaap = {
+            "DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit": {
+                "units": {
+                    "USD/shares": [
+                        _make_xbrl_entry(end="2025-09-30", val=0.50, fp="Q3", fy=2025),
+                    ]
+                }
+            }
+        }
+        facts = _extract_facts_from_gaap(gaap)
+        assert len(facts) == 1
+        assert facts[0].concept == "DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit"
+        assert facts[0].val == Decimal("0.5")
+        assert facts[0].unit == "USD/shares"
+
+    def test_lp_legacy_distributions_per_unit_outstanding_extracted(self) -> None:
+        # Older MLPs (some still filing) use this legacy concept name.
+        gaap = {
+            "DistributionsPerLimitedPartnershipUnitOutstanding": {
+                "units": {
+                    "USD/shares": [
+                        _make_xbrl_entry(end="2024-12-31", val=1.25, fp="Q4", fy=2024),
+                    ]
+                }
+            }
+        }
+        facts = _extract_facts_from_gaap(gaap)
+        assert len(facts) == 1
+        assert facts[0].concept == "DistributionsPerLimitedPartnershipUnitOutstanding"
+
+    def test_lp_cash_distributions_paid_per_unit_extracted(self) -> None:
+        gaap = {
+            "DistributionMadeToLimitedPartnerCashDistributionsPaidPerUnit": {
+                "units": {
+                    "USD/shares": [
+                        _make_xbrl_entry(end="2025-06-30", val=0.50, fp="Q2", fy=2025),
+                    ]
+                }
+            }
+        }
+        facts = _extract_facts_from_gaap(gaap)
+        assert len(facts) == 1
+        assert facts[0].concept == "DistributionMadeToLimitedPartnerCashDistributionsPaidPerUnit"
+
+    def test_llc_member_distributions_paid_per_unit_extracted(self) -> None:
+        # LLC variant for entities that file LLC member distribution
+        # rather than LP unit distribution (e.g. some MLPs structured
+        # as LLCs taxed as partnerships).
+        gaap = {
+            "DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsPaidPerUnit": {
+                "units": {
+                    "USD/shares": [
+                        _make_xbrl_entry(end="2024-09-30", val=0.75, fp="Q3", fy=2024),
+                    ]
+                }
+            }
+        }
+        facts = _extract_facts_from_gaap(gaap)
+        assert len(facts) == 1
+        assert facts[0].concept == "DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsPaidPerUnit"
+
+    def test_lp_aggregate_cash_distributions_paid_extracted(self) -> None:
+        gaap = {
+            "DistributionMadeToLimitedPartnerCashDistributionsPaid": {
+                "units": {
+                    "USD": [
+                        _make_xbrl_entry(end="2025-12-31", val=200_000_000.0, fp="FY", fy=2025),
+                    ]
+                }
+            }
+        }
+        facts = _extract_facts_from_gaap(gaap)
+        assert len(facts) == 1
+        assert facts[0].concept == "DistributionMadeToLimitedPartnerCashDistributionsPaid"
+        assert facts[0].unit == "USD"
+
+    def test_member_or_lp_aggregate_cash_distributions_paid_extracted(self) -> None:
+        gaap = {
+            "DistributionMadeToMemberOrLimitedPartnerCashDistributionsPaid": {
+                "units": {
+                    "USD": [
+                        _make_xbrl_entry(end="2025-12-31", val=150_000_000.0, fp="FY", fy=2025),
+                    ]
+                }
+            }
+        }
+        facts = _extract_facts_from_gaap(gaap)
+        assert len(facts) == 1
+
+    def test_member_or_lp_declared_per_unit_extracted(self) -> None:
+        # LP+member-aggregate variant of the per-unit declared concept.
+        gaap = {
+            "DistributionMadeToMemberOrLimitedPartnerDistributionsDeclaredPerUnit": {
+                "units": {
+                    "USD/shares": [
+                        _make_xbrl_entry(end="2025-09-30", val=0.30, fp="Q3", fy=2025),
+                    ]
+                }
+            }
+        }
+        facts = _extract_facts_from_gaap(gaap)
+        assert len(facts) == 1
+        assert facts[0].concept == "DistributionMadeToMemberOrLimitedPartnerDistributionsDeclaredPerUnit"
+
+    def test_llc_member_declared_per_unit_extracted(self) -> None:
+        # Pure-LLC variant (e.g. some MLPs structured as LLCs taxed
+        # as partnerships emit this rather than the LP-side concept).
+        gaap = {
+            "DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsDeclaredPerUnit": {
+                "units": {
+                    "USD/shares": [
+                        _make_xbrl_entry(end="2024-12-31", val=2.10, fp="FY", fy=2024),
+                    ]
+                }
+            }
+        }
+        facts = _extract_facts_from_gaap(gaap)
+        assert len(facts) == 1
+        assert facts[0].concept == "DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsDeclaredPerUnit"
+
+    def test_llc_member_aggregate_cash_distributions_paid_extracted(self) -> None:
+        # Pure-LLC paid-aggregate counterpart to the LP variant.
+        gaap = {
+            "DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsPaid": {
+                "units": {
+                    "USD": [
+                        _make_xbrl_entry(end="2025-12-31", val=180_000_000.0, fp="FY", fy=2025),
+                    ]
+                }
+            }
+        }
+        facts = _extract_facts_from_gaap(gaap)
+        assert len(facts) == 1
+        assert facts[0].concept == "DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsPaid"
+
+
+class TestPartnershipDistributionAliasing:
+    """The TRACKED_CONCEPTS allowlist is also the alias map that
+    drives the canonical projection in financial_periods. Verify each
+    new partnership tag routes to the correct canonical column with
+    the expected priority — corp-style stays priority 0 (so legacy
+    converters that file BOTH tags don't double-count or flip)."""
+
+    def test_lp_declared_aliases_to_dps_declared_at_priority_after_corp(self) -> None:
+        from app.services.fundamentals import _TAG_TO_COLUMN
+
+        col, prio = _TAG_TO_COLUMN["DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit"]
+        assert col == "dps_declared"
+        # Corp-style is priority 0; LP-style must be a higher index so
+        # the corp-style tag wins when both exist for the same period.
+        assert prio > 0
+        corp_col, corp_prio = _TAG_TO_COLUMN["CommonStockDividendsPerShareDeclared"]
+        assert corp_col == "dps_declared"
+        assert corp_prio == 0
+        assert prio > corp_prio
+
+    def test_lp_legacy_per_unit_aliases_to_dps_declared(self) -> None:
+        from app.services.fundamentals import _TAG_TO_COLUMN
+
+        col, _ = _TAG_TO_COLUMN["DistributionsPerLimitedPartnershipUnitOutstanding"]
+        assert col == "dps_declared"
+
+    def test_lp_cash_paid_per_unit_aliases_to_dps_cash_paid(self) -> None:
+        from app.services.fundamentals import _TAG_TO_COLUMN
+
+        col, _ = _TAG_TO_COLUMN["DistributionMadeToLimitedPartnerCashDistributionsPaidPerUnit"]
+        assert col == "dps_cash_paid"
+
+    def test_llc_member_cash_paid_per_unit_aliases_to_dps_cash_paid(self) -> None:
+        from app.services.fundamentals import _TAG_TO_COLUMN
+
+        col, _ = _TAG_TO_COLUMN["DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsPaidPerUnit"]
+        assert col == "dps_cash_paid"
+
+    def test_lp_aggregate_cash_paid_aliases_to_dividends_paid(self) -> None:
+        from app.services.fundamentals import _TAG_TO_COLUMN
+
+        col, _ = _TAG_TO_COLUMN["DistributionMadeToLimitedPartnerCashDistributionsPaid"]
+        assert col == "dividends_paid"
+
+    def test_member_or_lp_aggregate_cash_paid_aliases_to_dividends_paid(self) -> None:
+        from app.services.fundamentals import _TAG_TO_COLUMN
+
+        col, _ = _TAG_TO_COLUMN["DistributionMadeToMemberOrLimitedPartnerCashDistributionsPaid"]
+        assert col == "dividends_paid"
+
+    def test_llc_member_aggregate_cash_paid_aliases_to_dividends_paid(self) -> None:
+        from app.services.fundamentals import _TAG_TO_COLUMN
+
+        col, _ = _TAG_TO_COLUMN["DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsPaid"]
+        assert col == "dividends_paid"
+
+    def test_member_or_lp_declared_per_unit_aliases_to_dps_declared(self) -> None:
+        from app.services.fundamentals import _TAG_TO_COLUMN
+
+        col, _ = _TAG_TO_COLUMN["DistributionMadeToMemberOrLimitedPartnerDistributionsDeclaredPerUnit"]
+        assert col == "dps_declared"
+
+    def test_llc_member_declared_per_unit_aliases_to_dps_declared(self) -> None:
+        from app.services.fundamentals import _TAG_TO_COLUMN
+
+        col, _ = _TAG_TO_COLUMN["DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsDeclaredPerUnit"]
+        assert col == "dps_declared"
+
+    def test_member_or_lp_paid_per_unit_aliases_to_dps_cash_paid(self) -> None:
+        from app.services.fundamentals import _TAG_TO_COLUMN
+
+        col, _ = _TAG_TO_COLUMN["DistributionMadeToMemberOrLimitedPartnerCashDistributionsPaidPerUnit"]
+        assert col == "dps_cash_paid"


### PR DESCRIPTION
Closes #674.

## What

Surfaced by operator review 2026-04-29 against PR #673: IEP dividend chart flat from 2017 despite continued quarterly distributions. Diagnosed as missing partnership-style XBRL concepts in the \`TRACKED_CONCEPTS\` allowlist that drives both the raw-fact emit and the canonical-column alias map.

Extended \`TRACKED_CONCEPTS\` symmetrically across LP / member-or-LP / pure-LLC variants for three roles (\`dps_declared\`, \`dividends_paid\`, \`dps_cash_paid\`):

- \`DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit\` (+ member-or-LP + LLC variants)
- \`DistributionMadeToLimitedPartnerCashDistributionsPaid\` (+ member-or-LP + LLC variants)
- \`DistributionMadeToLimitedPartnerCashDistributionsPaidPerUnit\` (+ member-or-LP + LLC variants)
- \`DistributionsPerLimitedPartnershipUnitOutstanding\` (legacy pre-2018 MLP tag)

Corp-style tags stay at priority 0 so converters that filed both during cross-over periods read through corp-style first.

## Why

\`SELECT COUNT(DISTINCT concept) FROM financial_facts_raw WHERE instrument_id = 1571\` (IEP) → **27** concepts. SEC live ships **434** for the same CIK. Zero of the 27 contain \"dividend\" or \"distribution\". IEP files \`DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit\` quarterly (e.g. Q3 2025 = \$0.50/unit) but our pre-#451-Phase-A allowlist dropped everything outside corp-style. Same gap affects ET, EPD, MPLX, KMI, BIP, BX-style PTPs and any pass-through LLC.

## Test plan

- \`uv run pytest tests/test_xbrl_fact_extraction.py\` — 37 tests, 12 new (8 extraction + 8 aliasing)
- \`uv run pytest tests/\` — 2952 pass, 1 skipped
- \`uv run ruff check .\` + \`uv run ruff format --check .\` — clean
- \`uv run pyright\` — 0 errors
- Live end-to-end: piped IEP \`companyfacts\` through \`_extract_facts_from_section\` after the change → 24 LP DeclaredPerUnit rows alias to \`dps_declared\`, 41 LP CashDistributionsPaid rows alias to \`dividends_paid\`. \`_UNIT_PRIORITY\` already covers \`USD/shares\` + \`USD\`.
- Codex round 1 caught asymmetric LLC handling; round-2 extends to all 3 roles. Round-2 review clean.

## Operational note

\`dividend_history\` is a VIEW over \`financial_periods\` (sql/050); once the next fundamentals refresh re-derives IEP's rows from the now-aliased facts, the chart fills without further code. The quarterly cron picks up the affected cohort on schedule. An ad-hoc \`refresh_financial_facts\` + \`normalize_financial_periods\` run scoped to MLP / pass-through LLC instruments accelerates that — recommend running for the operator-watched tickers (IEP, ET, EPD, MPLX, KMI) right after merge.

## Linked

Surface symptom: operator's \`/instrument/IEP/dividends\` view. Companion ticket for the universally-NULL \`filing_events.items[]\` regression (which independently breaks the dividend-calendar 8.01 ingest): #675.