### PR TITLE
feat: scripts/force_refresh_fundamentals.py — targeted SEC refetch

### DIFF
--- a/scripts/force_refresh_fundamentals.py
+++ b/scripts/force_refresh_fundamentals.py
@@ -1,0 +1,238 @@
+"""Targeted SEC fundamentals refresh for a hand-picked set of symbols
+(#674 follow-up, #677 precursor).
+
+Bypasses the staleness gate in
+:func:`app.services.fundamentals.plan_refresh` so the operator can
+re-fetch SEC company-facts + re-derive ``financial_periods`` for a
+specific cohort without waiting for SEC to ship them a new filing
+or for the next universe-wide sweep.
+
+Concrete trigger: PR #676 (#674) extended ``TRACKED_CONCEPTS`` with
+LP/LLC partnership-distribution tags. The dividend chart for IEP /
+ET / EPD / MPLX / KMI etc. won't fill until each of those CIKs is
+re-fetched with the new allowlist applied. ``plan_refresh``'s
+master-index selector only schedules CIKs SEC has filed something
+new for in the last 7 days — schema changes don't qualify, so
+without this script those instruments wait days/weeks.
+
+Run from the repo root via the module form so the ``app`` package
+imports resolve:
+
+    uv run python -m scripts.force_refresh_fundamentals IEP ET EPD MPLX KMI
+
+(The bare ``uv run python scripts/foo.py`` form does NOT add the
+repo root to ``sys.path`` on this layout — every script under
+``scripts/`` has to be invoked as a module.)
+
+Defaults to dry-run (logs the resolved (symbol, CIK) cohort, no
+fetches). Pass ``--apply`` to actually call SEC + write to the DB.
+The script is idempotent: re-fetching the same companyfacts payload
+and re-running normalisation is a no-op for unchanged rows
+(``upsert_facts_for_instrument`` ON CONFLICT DO UPDATE WHERE
+``IS DISTINCT FROM``; ``_canonical_merge_instrument`` likewise).
+
+Rate limit: SEC public-key tier is 10 req/sec. The provider's
+internal throttle handles spacing; this script does not need to
+manage rate limits itself.
+
+Out of scope (deliberate): no new HTTP API surface, no UI, no
+expected-filings poller. Those live in #677 — this is the
+operational quick-win that unblocks the dividend chart for the
+known-affected MLP cohort while #677 is designed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
+from app.services.fundamentals import (
+    normalize_financial_periods,
+    refresh_financial_facts,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedSymbol:
+    symbol: str
+    instrument_id: int
+    cik: str
+
+
+def resolve_symbols(
+    conn: psycopg.Connection[tuple],
+    symbols: list[str],
+) -> tuple[list[ResolvedSymbol], list[str]]:
+    """Map each symbol to its (instrument_id, primary SEC CIK).
+
+    Returns ``(resolved, missing)``: ``resolved`` contains every symbol
+    with a primary SEC CIK, in caller order; ``missing`` is the list of
+    symbols that either don't exist in ``instruments`` or have no
+    primary SEC CIK row in ``external_identifiers``. The caller logs
+    the missing list rather than aborting — partial coverage is
+    expected (operator may include a non-US symbol by mistake).
+    """
+    if not symbols:
+        return [], []
+    upper = [s.upper() for s in symbols]
+    rows = conn.execute(
+        """
+        SELECT i.symbol, i.instrument_id, ei.identifier_value
+        FROM instruments i
+        JOIN external_identifiers ei
+          ON ei.instrument_id = i.instrument_id
+         AND ei.provider = 'sec'
+         AND ei.identifier_type = 'cik'
+         AND ei.is_primary = TRUE
+        WHERE UPPER(i.symbol) = ANY(%(symbols)s)
+        ORDER BY i.is_primary_listing DESC NULLS LAST, i.instrument_id ASC
+        """,
+        {"symbols": upper},
+    ).fetchall()
+
+    by_symbol: dict[str, ResolvedSymbol] = {}
+    for row in rows:
+        sym = str(row[0]).upper()
+        # Caller may pass duplicates — keep the first match (highest
+        # is_primary_listing) per symbol.
+        if sym not in by_symbol:
+            by_symbol[sym] = ResolvedSymbol(
+                symbol=str(row[0]),
+                instrument_id=int(row[1]),
+                cik=str(row[2]),
+            )
+
+    resolved = [by_symbol[s] for s in upper if s in by_symbol]
+    missing = [s for s in upper if s not in by_symbol]
+    return resolved, missing
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "symbols",
+        nargs="+",
+        help="Stock symbols to force-refresh (e.g. IEP ET EPD MPLX KMI).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually call SEC + write to the DB. Default is dry-run.",
+    )
+    args = parser.parse_args(argv)
+
+    with psycopg.connect(settings.database_url) as conn:
+        resolved, missing = resolve_symbols(conn, args.symbols)
+        # Close the implicit read transaction opened by the resolver
+        # SELECT before any HTTP-backed work below. Without this, the
+        # ``with conn.transaction()`` blocks inside
+        # ``refresh_financial_facts`` / ``normalize_financial_periods``
+        # would degrade to savepoints under one giant outer
+        # transaction, leaving the session idle-in-transaction
+        # across multi-minute SEC fetches and rolling back the
+        # whole cohort on a late failure. Same pattern the per-CIK
+        # path in app/services/fundamentals.py uses.
+        conn.commit()
+
+        if missing:
+            logger.warning(
+                "force_refresh: %d/%d symbols have no primary SEC CIK and will be skipped: %s",
+                len(missing),
+                len(args.symbols),
+                ", ".join(missing),
+            )
+
+        if not resolved:
+            logger.error("force_refresh: no resolvable symbols; nothing to do")
+            return 1
+
+        # Dedupe by instrument_id before the expensive work — the
+        # operator's CLI is positional, so a typo like
+        # ``IEP IEP MPLX`` shouldn't triple-fetch IEP. Caller-order
+        # of first occurrence is preserved so log output stays
+        # predictable.
+        seen_ids: set[int] = set()
+        unique: list[ResolvedSymbol] = []
+        for r in resolved:
+            if r.instrument_id in seen_ids:
+                continue
+            seen_ids.add(r.instrument_id)
+            unique.append(r)
+        if len(unique) < len(resolved):
+            logger.info(
+                "force_refresh: deduped %d duplicate input(s)",
+                len(resolved) - len(unique),
+            )
+
+        logger.info(
+            "force_refresh: %d symbols resolved: %s",
+            len(unique),
+            ", ".join(f"{r.symbol}({r.cik})" for r in unique),
+        )
+
+        if not args.apply:
+            logger.info("force_refresh: DRY-RUN — pass --apply to actually fetch")
+            return 0
+
+        # Re-fetch companyfacts for every resolved CIK and write to
+        # ``financial_facts_raw``. ``refresh_financial_facts`` owns the
+        # ingestion-run ledger + per-symbol error isolation, so a
+        # single SEC 5xx for one CIK doesn't abort the rest of the
+        # cohort.
+        instrument_ids = [r.instrument_id for r in unique]
+        symbols_for_refresh: list[tuple[str, int, str]] = [(r.symbol, r.instrument_id, r.cik) for r in unique]
+        with SecFundamentalsProvider(user_agent=settings.sec_user_agent) as provider:
+            facts_summary = refresh_financial_facts(provider, conn, symbols_for_refresh)
+        # `refresh_financial_facts` opens an `ingestion_runs` row at
+        # entry and closes it at exit; the per-CIK `with
+        # conn.transaction()` blocks inside its loop work correctly,
+        # but the surrounding ledger writes can leave the session in
+        # a transaction once the function returns. Explicit commit
+        # here separates the fetch phase from the normalisation
+        # phase so the per-instrument transactions inside
+        # `normalize_financial_periods` are top-level (not savepoints
+        # under a multi-minute outer tx). Codex review #2 finding.
+        conn.commit()
+        logger.info(
+            "force_refresh: facts upserted=%d skipped=%d failed=%d",
+            facts_summary.facts_upserted,
+            facts_summary.facts_skipped,
+            facts_summary.symbols_failed,
+        )
+
+        # Re-derive ``financial_periods`` from the now-current raw
+        # store. Scoped to the resolved cohort so unrelated rows
+        # don't get touched.
+        norm_summary = normalize_financial_periods(conn, instrument_ids=instrument_ids)
+        conn.commit()
+        logger.info(
+            "force_refresh: normalisation processed=%d raw_upserted=%d canonical_upserted=%d",
+            norm_summary.instruments_processed,
+            norm_summary.periods_raw_upserted,
+            norm_summary.periods_canonical_upserted,
+        )
+
+    # Surface any per-symbol SEC failure as a non-zero exit so an
+    # automation wrapper / shell pipeline can detect it. A partial
+    # failure (some succeeded, some failed) returns 2 so the caller
+    # can distinguish "nothing landed" (1) from "review the log"
+    # (2). Resolver-only failures (no resolvable symbols) already
+    # returned 1 earlier.
+    if facts_summary.symbols_failed == len(unique):
+        return 1
+    if facts_summary.symbols_failed > 0:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_force_refresh_fundamentals.py
+++ b/tests/test_force_refresh_fundamentals.py
@@ -1,0 +1,118 @@
+"""Tests for the force_refresh_fundamentals script (#674 follow-up).
+
+Targets the symbol-resolution helper. The end-to-end refresh path
+is exercised by the existing fundamentals tests; this file just
+pins the resolver's contract: it must return CIK-having symbols
+in caller order, list missing ones separately, and tolerate dups
++ casing variations.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import psycopg
+import pytest
+
+from scripts.force_refresh_fundamentals import (
+    ResolvedSymbol,
+    resolve_symbols,
+)
+
+TEST_DB_URL = "postgresql://postgres:postgres@127.0.0.1:5432/ebull_test"
+
+
+@pytest.fixture
+def conn() -> Iterator[psycopg.Connection]:  # type: ignore[type-arg]
+    try:
+        c = psycopg.connect(TEST_DB_URL)
+    except psycopg.OperationalError:
+        pytest.skip("ebull_test DB not available")
+    try:
+        yield c
+    finally:
+        c.rollback()
+        c.close()
+
+
+def _seed(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    instrument_id: int,
+    symbol: str,
+    *,
+    cik: str | None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO exchanges (exchange_id, description, country, asset_class)
+        VALUES (%s, %s, 'US', 'us_equity')
+        ON CONFLICT (exchange_id) DO NOTHING
+        """,
+        (f"frt_{instrument_id}", f"Test {instrument_id}"),
+    )
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange)
+        VALUES (%s, %s, %s, %s)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id, symbol, f"Test {symbol}", f"frt_{instrument_id}"),
+    )
+    if cik is not None:
+        conn.execute(
+            """
+            INSERT INTO external_identifiers
+                (instrument_id, provider, identifier_type, identifier_value, is_primary)
+            VALUES (%s, 'sec', 'cik', %s, TRUE)
+            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            """,
+            (instrument_id, cik),
+        )
+
+
+def test_resolve_returns_cik_having_symbols_and_separates_missing(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+) -> None:
+    _seed(conn, 970001, "FRTA", cik="0000970001")
+    _seed(conn, 970002, "FRTB", cik=None)
+    _seed(conn, 970003, "FRTC", cik="0000970003")
+
+    resolved, missing = resolve_symbols(conn, ["FRTA", "FRTB", "FRTC", "NEVER"])
+
+    assert resolved == [
+        ResolvedSymbol(symbol="FRTA", instrument_id=970001, cik="0000970001"),
+        ResolvedSymbol(symbol="FRTC", instrument_id=970003, cik="0000970003"),
+    ]
+    # FRTB lacks CIK, NEVER doesn't exist — both miss.
+    assert sorted(missing) == ["FRTB", "NEVER"]
+
+
+def test_resolve_is_case_insensitive(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+) -> None:
+    _seed(conn, 970010, "FRTUP", cik="0000970010")
+    resolved, missing = resolve_symbols(conn, ["frtup"])
+    assert len(resolved) == 1
+    assert resolved[0].instrument_id == 970010
+    assert missing == []
+
+
+def test_resolve_preserves_duplicate_inputs(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+) -> None:
+    """The resolver itself is order-preserving and does NOT dedupe —
+    every caller input slot resolves to a record. Dedupe happens in
+    the script's ``main()`` before the expensive SEC fetch (so a
+    typo like ``IEP IEP MPLX`` doesn't triple-fetch). Tested here so
+    the resolver's contract is locked at the call-site interface."""
+    _seed(conn, 970020, "FRTDUP", cik="0000970020")
+    resolved, missing = resolve_symbols(conn, ["FRTDUP", "FRTDUP", "FRTDUP"])
+    assert len(resolved) == 3
+    assert {r.instrument_id for r in resolved} == {970020}
+    assert missing == []
+
+
+def test_resolve_handles_empty_input(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+) -> None:
+    assert resolve_symbols(conn, []) == ([], [])

--- a/tests/test_force_refresh_fundamentals.py
+++ b/tests/test_force_refresh_fundamentals.py
@@ -5,44 +5,32 @@ is exercised by the existing fundamentals tests; this file just
 pins the resolver's contract: it must return CIK-having symbols
 in caller order, list missing ones separately, and tolerate dups
 + casing variations.
+
+Uses the canonical ``ebull_test_conn`` fixture (auto-imported via
+``tests/conftest.py``) so the test-DB URL is derived from
+``settings.database_url`` rather than hardcoded — a misconfigured CI
+environment fails visibly on connect rather than silently skipping
+every assertion (PR #680 review).
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-
 import psycopg
-import pytest
 
 from scripts.force_refresh_fundamentals import (
     ResolvedSymbol,
     resolve_symbols,
 )
 
-TEST_DB_URL = "postgresql://postgres:postgres@127.0.0.1:5432/ebull_test"
-
-
-@pytest.fixture
-def conn() -> Iterator[psycopg.Connection]:  # type: ignore[type-arg]
-    try:
-        c = psycopg.connect(TEST_DB_URL)
-    except psycopg.OperationalError:
-        pytest.skip("ebull_test DB not available")
-    try:
-        yield c
-    finally:
-        c.rollback()
-        c.close()
-
 
 def _seed(
-    conn: psycopg.Connection,  # type: ignore[type-arg]
+    ebull_test_conn: psycopg.Connection[tuple],
     instrument_id: int,
     symbol: str,
     *,
     cik: str | None,
 ) -> None:
-    conn.execute(
+    ebull_test_conn.execute(
         """
         INSERT INTO exchanges (exchange_id, description, country, asset_class)
         VALUES (%s, %s, 'US', 'us_equity')
@@ -50,7 +38,7 @@ def _seed(
         """,
         (f"frt_{instrument_id}", f"Test {instrument_id}"),
     )
-    conn.execute(
+    ebull_test_conn.execute(
         """
         INSERT INTO instruments (instrument_id, symbol, company_name, exchange)
         VALUES (%s, %s, %s, %s)
@@ -59,7 +47,7 @@ def _seed(
         (instrument_id, symbol, f"Test {symbol}", f"frt_{instrument_id}"),
     )
     if cik is not None:
-        conn.execute(
+        ebull_test_conn.execute(
             """
             INSERT INTO external_identifiers
                 (instrument_id, provider, identifier_type, identifier_value, is_primary)
@@ -71,13 +59,13 @@ def _seed(
 
 
 def test_resolve_returns_cik_having_symbols_and_separates_missing(
-    conn: psycopg.Connection,  # type: ignore[type-arg]
+    ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    _seed(conn, 970001, "FRTA", cik="0000970001")
-    _seed(conn, 970002, "FRTB", cik=None)
-    _seed(conn, 970003, "FRTC", cik="0000970003")
+    _seed(ebull_test_conn, 970001, "FRTA", cik="0000970001")
+    _seed(ebull_test_conn, 970002, "FRTB", cik=None)
+    _seed(ebull_test_conn, 970003, "FRTC", cik="0000970003")
 
-    resolved, missing = resolve_symbols(conn, ["FRTA", "FRTB", "FRTC", "NEVER"])
+    resolved, missing = resolve_symbols(ebull_test_conn, ["FRTA", "FRTB", "FRTC", "NEVER"])
 
     assert resolved == [
         ResolvedSymbol(symbol="FRTA", instrument_id=970001, cik="0000970001"),
@@ -88,31 +76,31 @@ def test_resolve_returns_cik_having_symbols_and_separates_missing(
 
 
 def test_resolve_is_case_insensitive(
-    conn: psycopg.Connection,  # type: ignore[type-arg]
+    ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    _seed(conn, 970010, "FRTUP", cik="0000970010")
-    resolved, missing = resolve_symbols(conn, ["frtup"])
+    _seed(ebull_test_conn, 970010, "FRTUP", cik="0000970010")
+    resolved, missing = resolve_symbols(ebull_test_conn, ["frtup"])
     assert len(resolved) == 1
     assert resolved[0].instrument_id == 970010
     assert missing == []
 
 
 def test_resolve_preserves_duplicate_inputs(
-    conn: psycopg.Connection,  # type: ignore[type-arg]
+    ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
     """The resolver itself is order-preserving and does NOT dedupe —
     every caller input slot resolves to a record. Dedupe happens in
     the script's ``main()`` before the expensive SEC fetch (so a
     typo like ``IEP IEP MPLX`` doesn't triple-fetch). Tested here so
     the resolver's contract is locked at the call-site interface."""
-    _seed(conn, 970020, "FRTDUP", cik="0000970020")
-    resolved, missing = resolve_symbols(conn, ["FRTDUP", "FRTDUP", "FRTDUP"])
+    _seed(ebull_test_conn, 970020, "FRTDUP", cik="0000970020")
+    resolved, missing = resolve_symbols(ebull_test_conn, ["FRTDUP", "FRTDUP", "FRTDUP"])
     assert len(resolved) == 3
     assert {r.instrument_id for r in resolved} == {970020}
     assert missing == []
 
 
 def test_resolve_handles_empty_input(
-    conn: psycopg.Connection,  # type: ignore[type-arg]
+    ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    assert resolve_symbols(conn, []) == ([], [])
+    assert resolve_symbols(ebull_test_conn, []) == ([], [])


### PR DESCRIPTION
Operational script unblocking the dividend-chart gap for the MLP cohort affected by #674. Companion ticket #677 covers the proper API + UI surface; this is the small quick-win.

## What

\`scripts/force_refresh_fundamentals.py\` — argparse CLI, dry-run by default. Resolves \`<SYMBOL>...\` to (instrument_id, primary SEC CIK) pairs in one query, dedupes by instrument_id, then calls \`refresh_financial_facts\` + \`normalize_financial_periods\` scoped to those instruments.

\`\`\`
uv run python -m scripts.force_refresh_fundamentals IEP ET EPD MPLX KMI
\`\`\`

(Bare \`uv run python scripts/foo.py\` doesn't work on this layout — script docstring spells out the module form.)

## Why

\`plan_refresh\`'s master-index selector ([fundamentals.py:1506](app/services/fundamentals.py#L1506)) only schedules CIKs SEC has filed something new for in the last 7-day window. Schema/allowlist changes (#674) don't qualify, so the affected MLPs would wait until SEC ships them a new filing — could be days/weeks — before the dividend chart fills in. This script bypasses that gate.

Scope is deliberately narrow: no new HTTP API, no UI, no expected-filings poller. All of that lives in #677. Operational quick-win first; proper feature later.

## Test plan

- \`uv run pytest tests/test_force_refresh_fundamentals.py\` — 4 tests pin the resolver contract (CIK-having vs missing, case-insensitive, duplicate tolerance, empty input)
- \`uv run pytest tests/\` — 2965 pass, 1 skipped
- \`uv run ruff check . / format / pyright\` — clean
- Local dry-run smoke: \`IEP ET EPD MPLX KMI BIP\` resolves 5/6, surfaces MPLX as missing CIK
- Codex review across 3 rounds: 3 substantive findings (open transaction across HTTP, false-success exit code, no input dedupe) — first two fixed in round 2, third fixed in round 2; round 3 surfaced a pre-existing upstream pattern (\`refresh_financial_facts\` wraps SEC HTTP in \`conn.transaction()\` at [fundamentals.py:533](app/services/fundamentals.py#L533)) that's out of scope for an ad-hoc script — same pattern is used by the daily cron path

## Operational note

After merge, recommend running for the affected cohort to populate the dividend chart for IEP and the other MLPs:

\`\`\`
uv run python -m scripts.force_refresh_fundamentals IEP ET EPD MPLX KMI BIP
uv run python -m scripts.force_refresh_fundamentals IEP ET EPD MPLX KMI BIP --apply
\`\`\`

(MPLX may need its CIK manually linked in \`external_identifiers\` first — current dev DB has no row.)

## Linked

#674 (LP XBRL allowlist — merged b28710e); #677 (proper API + poller).