### PR TITLE
fix(#674): drop legacy LP cumulative tag corrupting IEP chart (workaround for #682)

### DIFF
--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -150,16 +150,28 @@ TRACKED_CONCEPTS: dict[str, tuple[str, ...]] = {
     # under three parallel concepts depending on the issuer's legal
     # form (LP / LP+member-aggregate / pure LLC). All three report
     # in ``USD/shares`` units which the existing ``_UNIT_PRIORITY``
-    # list already covers, so no unit-priority change is needed. The
-    # legacy ``DistributionsPerLimitedPartnershipUnitOutstanding``
-    # tag is still emitted by some pre-2018 filers, kept for
-    # compatibility.
+    # list already covers, so no unit-priority change is needed.
+    #
+    # Excluded deliberately: ``DistributionsPerLimitedPartnership
+    # UnitOutstanding`` is an FY-cumulative concept that issuers
+    # report on the 10-K alongside prior-year comparatives. SEC's
+    # companyfacts emits the SAME period_end row under multiple
+    # ``fy`` contexts (the 10-K's filing year stamps every prior
+    # comparative). The normaliser keys on ``(fy, fp)`` rather than
+    # ``period_end``, so a 2026-filed 10-K's IEP row for 2023 (val
+    # = $6.00) lands as "fy=2025, fp=FY" alongside the actual 2025
+    # row, and `_canonical_merge` then derives a wrong Q4 = FY −
+    # YTD = $6 − $1.50 = $4.50. Tracked at #682 as a normaliser
+    # bug; until that lands, this concept's downside (wrong values)
+    # outweighs its upside (FY summary line for issuers that don't
+    # emit the primary concept). The primary
+    # ``DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit``
+    # already covers per-quarter for IEP / EPD / current-era MLPs.
     "dps_declared": (
         "CommonStockDividendsPerShareDeclared",
         "DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit",
         "DistributionMadeToMemberOrLimitedPartnerDistributionsDeclaredPerUnit",
         "DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsDeclaredPerUnit",
-        "DistributionsPerLimitedPartnershipUnitOutstanding",
     ),
     # Cash actually distributed per share (often differs from declared
     # by a quarter). Captured separately so dividend-capture strategies

--- a/tests/test_xbrl_fact_extraction.py
+++ b/tests/test_xbrl_fact_extraction.py
@@ -358,8 +358,18 @@ class TestPartnershipDistributionConcepts:
         assert facts[0].val == Decimal("0.5")
         assert facts[0].unit == "USD/shares"
 
-    def test_lp_legacy_distributions_per_unit_outstanding_extracted(self) -> None:
-        # Older MLPs (some still filing) use this legacy concept name.
+    def test_lp_legacy_distributions_per_unit_outstanding_excluded(self) -> None:
+        # ``DistributionsPerLimitedPartnershipUnitOutstanding`` is
+        # deliberately NOT in the ``dps_declared`` allowlist (#682).
+        # SEC's companyfacts emits this FY-cumulative concept under
+        # multiple ``fy`` contexts when 10-K filings include prior-
+        # year comparatives, and the canonical normaliser keys on
+        # ``(fy, fp)`` not ``period_end`` — so a 2023 historical row
+        # restamped with the filing's 2025 fy lands as "FY 2025"
+        # and corrupts the chart. Until the normaliser is fixed
+        # (#682), this concept stays out and the primary
+        # ``DistributionMadeToLimitedPartnerDistributionsDeclaredPer
+        # Unit`` carries the load.
         gaap = {
             "DistributionsPerLimitedPartnershipUnitOutstanding": {
                 "units": {
@@ -370,8 +380,7 @@ class TestPartnershipDistributionConcepts:
             }
         }
         facts = _extract_facts_from_gaap(gaap)
-        assert len(facts) == 1
-        assert facts[0].concept == "DistributionsPerLimitedPartnershipUnitOutstanding"
+        assert facts == []
 
     def test_lp_cash_distributions_paid_per_unit_extracted(self) -> None:
         gaap = {
@@ -499,11 +508,14 @@ class TestPartnershipDistributionAliasing:
         assert corp_prio == 0
         assert prio > corp_prio
 
-    def test_lp_legacy_per_unit_aliases_to_dps_declared(self) -> None:
+    def test_lp_legacy_per_unit_NOT_in_alias_map(self) -> None:
+        # See test_lp_legacy_distributions_per_unit_outstanding_excluded
+        # — this concept is intentionally absent from TRACKED_CONCEPTS
+        # to prevent SEC's prior-year-comparative re-stamping bug
+        # from corrupting the chart (#682).
         from app.services.fundamentals import _TAG_TO_COLUMN
 
-        col, _ = _TAG_TO_COLUMN["DistributionsPerLimitedPartnershipUnitOutstanding"]
-        assert col == "dps_declared"
+        assert "DistributionsPerLimitedPartnershipUnitOutstanding" not in _TAG_TO_COLUMN
 
     def test_lp_cash_paid_per_unit_aliases_to_dps_cash_paid(self) -> None:
         from app.services.fundamentals import _TAG_TO_COLUMN


### PR DESCRIPTION
Operator report 2026-04-29 against PR #680's IEP backfill: dividend chart showed FY2025 = \$6.00 and Q4 = \$4.50. Correct values are \$2.00 (annual) and \$0.50 (per quarter — IEP's actual distribution).

## Root cause

\`\`\`sql
SELECT period_end, fiscal_year, fiscal_period, val
FROM financial_facts_raw
WHERE instrument_id = 1571
  AND concept = 'DistributionsPerLimitedPartnershipUnitOutstanding'
  AND fiscal_year = 2025 AND fiscal_period = 'FY';
-- 2023-12-31 fy=2025 fp=FY val=6.00
-- 2024-12-31 fy=2025 fp=FY val=3.50
-- 2025-12-31 fy=2025 fp=FY val=2.00
\`\`\`

SEC's \`companyfacts\` API restamps prior-year comparative columns from a 2026-filed 10-K with the FILING's \`fiscal_year=2025\`. \`_derive_periods_from_facts\` keys on \`(fy, fp)\` not \`period_end\` and writes the 2023 historical row (\$6.00) as the canonical FY2025 row. \`_canonical_merge\` then derives Q4 = FY − YTD = \$6 − \$1.50 = \$4.50.

## Fix

Drop \`DistributionsPerLimitedPartnershipUnitOutstanding\` from \`TRACKED_CONCEPTS[\"dps_declared\"]\`. This concept is the worst offender (it's the FY-cumulative form). The primary \`DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit\` covers per-quarter for IEP and current-era MLPs because IEP's per-quarter facts have \`period_end\` = announcement date (one row per quarter, no prior-year-comparative restamping).

The proper fix — making the normaliser key on \`period_end\` instead — is tracked at [#682](../issues/682).

## Test plan

- \`uv run pytest tests/test_xbrl_fact_extraction.py\` — 37 pass; updated 2 cases to assert exclusion + non-presence in \`_TAG_TO_COLUMN\`
- \`uv run pytest tests/\` — all green
- Manual: after merge + re-running force-refresh for IEP, verify FY2025 = \$2.00 and Q4 = \$0.50 in \`SELECT * FROM dividend_history WHERE instrument_id=1571 ORDER BY period_end_date DESC LIMIT 5\`

## Linked

#674 (LP XBRL allowlist — merged); #680 (force-refresh script — merged); #682 (proper normaliser fix).