### PR TITLE
feat: glossary + <Term> tooltips, filings dupe fix, MLP fundamentals pane

### DIFF
--- a/frontend/src/components/Term.test.tsx
+++ b/frontend/src/components/Term.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Term } from "@/components/Term";
+
+describe("Term", () => {
+  it("renders the term as an <abbr> with a native title attr for fallback tooltips", () => {
+    render(<Term term="CIK" />);
+    const el = screen.getByTestId("term-CIK");
+    expect(el.tagName.toLowerCase()).toBe("abbr");
+    expect(el.getAttribute("title")).toContain("SEC entity ID");
+  });
+
+  it("opens the rich tooltip popover on hover and closes on mouseleave", () => {
+    render(<Term term="ROE" />);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    fireEvent.mouseEnter(screen.getByTestId("term-ROE"));
+    const tip = screen.getByRole("tooltip");
+    expect(tip).toHaveTextContent(/Return on equity/i);
+    expect(tip).toHaveTextContent(/Why it matters:/i);
+    fireEvent.mouseLeave(screen.getByTestId("term-ROE"));
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("opens on keyboard focus so screen readers + tab navigation work", () => {
+    render(<Term term="P/E ratio" />);
+    fireEvent.focus(screen.getByTestId("term-P/E ratio"));
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    fireEvent.blur(screen.getByTestId("term-P/E ratio"));
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("renders the children override as the visible label, looking up under the term key", () => {
+    render(<Term term="P/E ratio">P/E</Term>);
+    const el = screen.getByTestId("term-P/E ratio");
+    expect(el).toHaveTextContent("P/E");
+    expect(el).not.toHaveTextContent("P/E ratio");
+  });
+
+  it("falls back to plain text when the term isn't in the glossary", () => {
+    render(<Term term="UNKNOWN_TERM">my label</Term>);
+    expect(screen.queryByTestId("term-UNKNOWN_TERM")).not.toBeInTheDocument();
+    // Visible text still renders so the operator sees something.
+    expect(screen.getByText("my label")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Term.tsx
+++ b/frontend/src/components/Term.tsx
@@ -1,0 +1,88 @@
+/**
+ * `<Term>` — wraps an abbreviation/short label so the operator gets
+ * a hover/focus tooltip with the human-readable shortName + what +
+ * why (#684).
+ *
+ * Renders semantically as `<abbr>` so the underline + cursor +
+ * keyboard-focus story is handled by the browser. The tooltip body
+ * is a styled popover (not the native `title` attribute) because
+ * native tooltips can't render multi-line / multi-paragraph content
+ * on most browsers, and the `why` line is the part that actually
+ * justifies wrapping the term.
+ *
+ * Falls back to plain text when the term isn't in the glossary —
+ * caller bug surfaces as plain rendering rather than a runtime
+ * error. The optional ``children`` prop lets the operator override
+ * the rendered text without breaking the lookup (e.g. wrap the long
+ * "Filer category" label while looking up under that key).
+ */
+
+import { useState, type JSX, type ReactNode } from "react";
+
+import { lookupTerm } from "@/lib/glossary";
+
+export interface TermProps {
+  /** The glossary key. Also rendered as the visible text unless
+   *  ``children`` overrides. */
+  readonly term: string;
+  /** Optional label override. Useful when the visible text differs
+   *  from the glossary key (e.g. ``<Term term="P/E ratio">P/E</Term>``). */
+  readonly children?: ReactNode;
+  /** Extra Tailwind classes for the underline / colour. */
+  readonly className?: string;
+}
+
+export function Term({ term, children, className }: TermProps): JSX.Element {
+  const entry = lookupTerm(term);
+  const [open, setOpen] = useState(false);
+
+  // Unknown term — render plain text so the operator at least sees
+  // the label. Logged at DEV time would help future contributors;
+  // skipping for now to keep the component pure.
+  if (entry === null) {
+    return <span className={className}>{children ?? term}</span>;
+  }
+
+  const visibleClass = [
+    // `decoration-dotted` reads as "this is interactive, hover for
+    // more" without the visual noise of a solid underline. The
+    // cursor flip to `cursor-help` matches the `<abbr>` semantic.
+    "decoration-dotted underline-offset-2 underline cursor-help",
+    "focus-visible:outline-2 focus-visible:outline-sky-500 focus-visible:rounded",
+    className ?? "",
+  ]
+    .filter((s) => s.length > 0)
+    .join(" ");
+
+  return (
+    <span className="relative inline-block">
+      <abbr
+        title={`${entry.shortName} — ${entry.what}`}
+        className={visibleClass}
+        tabIndex={0}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        data-testid={`term-${entry.term}`}
+      >
+        {children ?? entry.term}
+      </abbr>
+      {open ? (
+        <span
+          role="tooltip"
+          className="absolute left-0 top-full z-50 mt-1 w-72 rounded-md border border-slate-200 bg-white px-3 py-2 text-xs leading-snug text-slate-700 shadow-lg"
+        >
+          <span className="block text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+            {entry.shortName}
+          </span>
+          <span className="mt-1 block">{entry.what}</span>
+          <span className="mt-1.5 block text-[11px] text-slate-500">
+            <span className="font-medium text-slate-600">Why it matters:</span>{" "}
+            {entry.why}
+          </span>
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/frontend/src/components/instrument/DividendsPanel.test.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.test.tsx
@@ -74,7 +74,14 @@ describe("DividendsPanel", () => {
     wrap(<DividendsPanel symbol="AAPL" provider="sec_dividend_summary" />);
 
     await waitFor(() => {
-      expect(screen.getByText(/TTM yield/i)).toBeInTheDocument();
+      // Label is now split across <Term term="TTM"> + " yield" so a
+      // contains-text matcher won't span the boundary. Use an
+      // element-level matcher that handles the split tree.
+      expect(
+        screen.getByText((_content, el) =>
+          el?.tagName === "DT" && (el.textContent ?? "").trim() === "TTM yield",
+        ),
+      ).toBeInTheDocument();
     });
     expect(screen.getByText(/0.52%/)).toBeInTheDocument();
     expect(screen.getByText(/FY2025 Q4/)).toBeInTheDocument();

--- a/frontend/src/components/instrument/FilingsPane.test.tsx
+++ b/frontend/src/components/instrument/FilingsPane.test.tsx
@@ -199,6 +199,59 @@ describe("FilingsPane", () => {
     );
   });
 
+  it("renders the friendly form-type name when extracted_summary is null (no `8-K  8-K` dupe — #684)", async () => {
+    // Operator screenshot 2026-04-29 on /instrument/IEP showed each
+    // row rendering the form type twice (once as the chip, once as
+    // the third-column fallback when extracted_summary was null).
+    // The fix: fall back to the glossary's friendly short name
+    // (e.g. "Material event" / "Annual report") so the row carries
+    // distinct information.
+    vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
+      instrument_id: 1,
+      symbol: "IEP",
+      total: 2,
+      offset: 0,
+      limit: 6,
+      items: [
+        {
+          filing_event_id: 1,
+          instrument_id: 1,
+          filing_date: "2026-03-05",
+          filing_type: "8-K",
+          provider: "sec_edgar",
+          accession_number: "0000000000-26-000001",
+          red_flag_score: null,
+          extracted_summary: null, // <- the bug condition
+          primary_document_url: null,
+          source_url: null,
+          created_at: "2026-03-05T00:00:00Z",
+        },
+        {
+          filing_event_id: 2,
+          instrument_id: 1,
+          filing_date: "2026-02-26",
+          filing_type: "10-K",
+          provider: "sec_edgar",
+          accession_number: "0000000000-26-000002",
+          red_flag_score: null,
+          extracted_summary: null,
+          primary_document_url: null,
+          source_url: null,
+          created_at: "2026-02-26T00:00:00Z",
+        },
+      ],
+    });
+    render(
+      <MemoryRouter>
+        <FilingsPane instrumentId={1} symbol="IEP" summary={makeSummary()} />
+      </MemoryRouter>,
+    );
+    // 8-K row's third column should now be "Material event", not
+    // a second "8-K". 10-K → "Annual report".
+    expect(await screen.findByText("Material event")).toBeInTheDocument();
+    expect(screen.getByText("Annual report")).toBeInTheDocument();
+  });
+
   it("hides Open button when filings capability is inactive", async () => {
     vi.spyOn(filingsApi, "fetchFilings").mockResolvedValue({
       instrument_id: 1,

--- a/frontend/src/components/instrument/FilingsPane.tsx
+++ b/frontend/src/components/instrument/FilingsPane.tsx
@@ -14,8 +14,10 @@ import { fetchFilings } from "@/api/filings";
 import type { FilingsListResponse, InstrumentSummary } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { Pane } from "@/components/instrument/Pane";
+import { Term } from "@/components/Term";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
+import { filingTypeFriendlyName } from "@/lib/glossary";
 import { useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
@@ -135,15 +137,32 @@ export function FilingsPane({
               f.filing_type,
               f.accession_number,
             );
+            // When the XBRL ingest hasn't extracted a per-filing
+            // summary, the row's third column would previously
+            // render the raw form-type a SECOND time next to the
+            // already-shown form-type chip — operator-reported as
+            // a "10-K  10-K" / "8-K  8-K" duplicate (#684). Falls
+            // back to the glossary's friendly short name instead
+            // (e.g. "Annual report" / "Material event") so the
+            // row carries useful information at a glance.
+            const summary =
+              f.extracted_summary ?? filingTypeFriendlyName(f.filing_type);
             const label = (
               <span className="flex items-baseline gap-2">
                 <span className="text-slate-500">{f.filing_date}</span>
-                <span className="rounded bg-slate-100 px-1 py-0.5 text-[10px] text-slate-600">
-                  {f.filing_type ?? "?"}
-                </span>
-                <span className="truncate text-slate-700">
-                  {f.extracted_summary ?? f.filing_type ?? "filing"}
-                </span>
+                {f.filing_type !== null ? (
+                  <Term
+                    term={f.filing_type}
+                    className="rounded bg-slate-100 px-1 py-0.5 text-[10px] text-slate-600 no-underline"
+                  >
+                    {f.filing_type}
+                  </Term>
+                ) : (
+                  <span className="rounded bg-slate-100 px-1 py-0.5 text-[10px] text-slate-600">
+                    ?
+                  </span>
+                )}
+                <span className="truncate text-slate-700">{summary}</span>
               </span>
             );
             return (

--- a/frontend/src/components/instrument/FundamentalsPane.test.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.test.tsx
@@ -255,6 +255,52 @@ describe("FundamentalsPane", () => {
     expect(await screen.findByText("2.30K")).toBeInTheDocument();
   });
 
+  it("surfaces a coverage caption when one cell has fewer periods than its siblings (#684 review)", async () => {
+    // Constructed case: 4 periods of revenue + net_income, only 2
+    // periods of operating_income (e.g. issuer changed reporting
+    // mid-history). Op income cell should annotate "2/4 periods"
+    // so the operator notices the time-axis asymmetry — bot review
+    // WARNING: silently-divergent sparkline shapes mislead.
+    vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
+      ((_symbol: string, query: { statement: string }) => {
+        if (query.statement === "income") {
+          return Promise.resolve({
+            symbol: "GME",
+            statement: "income",
+            period: "quarterly",
+            currency: "USD",
+            source: "sec_xbrl",
+            rows: Array.from({ length: 4 }, (_, i) => ({
+              period_end: `2025-0${i + 1}-30`,
+              period_type: `Q${i + 1}`,
+              values: {
+                revenue: String(2000 + i * 100),
+                net_income: String(100 + i * 10),
+                ...(i >= 2
+                  ? { operating_income: String(50 + i * 5) }
+                  : {}),
+              },
+            })),
+          });
+        }
+        return Promise.resolve({
+          symbol: "GME",
+          statement: "balance",
+          period: "quarterly",
+          currency: "USD",
+          source: "sec_xbrl",
+          rows: [],
+        });
+      }) as never,
+    );
+    render(
+      <MemoryRouter>
+        <FundamentalsPane summary={makeSummary(true)} />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText(/2\/4 periods/)).toBeInTheDocument();
+  });
+
   it("returns null when capability active but only 1 quarter has both income + balance data", async () => {
     vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
       ((_symbol: string, query: { statement: string }) => {

--- a/frontend/src/components/instrument/FundamentalsPane.test.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.test.tsx
@@ -204,6 +204,57 @@ describe("FundamentalsPane", () => {
     await waitFor(() => expect(container.firstChild).toBeNull());
   });
 
+  it("renders the pane for partnership/MLP issuers that don't file operating_income (#684)", async () => {
+    // IEP / ET / EPD-style: revenue + net_income populated but
+    // operating_income null on every row because the issuer files
+    // ``IncomeLossFromContinuingOperations`` instead of
+    // ``OperatingIncomeLoss``. Pre-fix, the joinPeriods strict gate
+    // dropped every row → series.length < 2 → pane hidden. Post-fix,
+    // the pane renders revenue + net income sparklines and the
+    // op-income cell shows "—".
+    vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
+      ((_symbol: string, query: { statement: string }) => {
+        if (query.statement === "income") {
+          return Promise.resolve({
+            symbol: "IEP",
+            statement: "income",
+            period: "quarterly",
+            currency: "USD",
+            source: "sec_xbrl",
+            rows: Array.from({ length: 4 }, (_, i) => ({
+              period_end: `2025-0${i + 1}-30`,
+              period_type: `Q${i + 1}`,
+              values: {
+                revenue: String(2000 + i * 100),
+                // operating_income deliberately absent
+                net_income: String(-100 + i * 50),
+              },
+            })),
+          });
+        }
+        return Promise.resolve({
+          symbol: "IEP",
+          statement: "balance",
+          period: "quarterly",
+          currency: "USD",
+          source: "sec_xbrl",
+          rows: [],
+        });
+      }) as never,
+    );
+    render(
+      <MemoryRouter>
+        <FundamentalsPane summary={makeSummary(true)} />
+      </MemoryRouter>,
+    );
+    // Pane chrome renders + the four cell labels are present.
+    expect(await screen.findByText("Revenue")).toBeInTheDocument();
+    expect(screen.getByText("Op income")).toBeInTheDocument();
+    expect(screen.getByText("Net income")).toBeInTheDocument();
+    // Latest revenue = 2300 renders via formatLatest as "2.30K".
+    expect(await screen.findByText("2.30K")).toBeInTheDocument();
+  });
+
   it("returns null when capability active but only 1 quarter has both income + balance data", async () => {
     vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
       ((_symbol: string, query: { statement: string }) => {

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -178,42 +178,78 @@ export function FundamentalsPane({ summary }: FundamentalsPaneProps): JSX.Elemen
       ) : income.error !== null || balance.error !== null ? (
         <SectionError onRetry={() => { income.refetch(); balance.refetch(); }} />
       ) : (
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <FundamentalCell
-            label="Revenue"
-            values={nonNullValues(series, (r) => r.revenue)}
-            stroke="text-sky-500"
-          />
-          <FundamentalCell
-            label="Op income"
-            values={nonNullValues(series, (r) => r.operatingIncome)}
-            stroke="text-emerald-500"
-          />
-          <FundamentalCell
-            label="Net income"
-            values={nonNullValues(series, (r) => r.netIncome)}
-            stroke="text-emerald-500"
-          />
-          <FundamentalCell
-            label="Total debt"
-            values={nonNullValues(series, (r) => r.totalDebt)}
-            stroke="text-amber-500"
-          />
-        </div>
+        <FundamentalsGrid series={series} />
       )}
     </Pane>
+  );
+}
+
+function FundamentalsGrid({
+  series,
+}: {
+  readonly series: ReadonlyArray<SeriesRow>;
+}): JSX.Element {
+  const revenueValues = nonNullValues(series, (r) => r.revenue);
+  const opIncomeValues = nonNullValues(series, (r) => r.operatingIncome);
+  const netIncomeValues = nonNullValues(series, (r) => r.netIncome);
+  const totalDebtValues = nonNullValues(series, (r) => r.totalDebt);
+  // Sparklines are side-by-side and share an x-axis only visually —
+  // when one cell has fewer periods than the siblings (e.g. an MLP
+  // with operating_income null on every quarter), shapes can't be
+  // compared directly. Surface a "n/N periods" caption on cells
+  // whose coverage diverges from the maximum so the operator notices
+  // the asymmetry. PR #684 review.
+  const maxLen = Math.max(
+    revenueValues.length,
+    opIncomeValues.length,
+    netIncomeValues.length,
+    totalDebtValues.length,
+  );
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <FundamentalCell
+        label="Revenue"
+        values={revenueValues}
+        maxLen={maxLen}
+        stroke="text-sky-500"
+      />
+      <FundamentalCell
+        label="Op income"
+        values={opIncomeValues}
+        maxLen={maxLen}
+        stroke="text-emerald-500"
+      />
+      <FundamentalCell
+        label="Net income"
+        values={netIncomeValues}
+        maxLen={maxLen}
+        stroke="text-emerald-500"
+      />
+      <FundamentalCell
+        label="Total debt"
+        values={totalDebtValues}
+        maxLen={maxLen}
+        stroke="text-amber-500"
+      />
+    </div>
   );
 }
 
 function FundamentalCell({
   label,
   values,
+  maxLen,
   stroke,
 }: {
   readonly label: string;
   readonly values: ReadonlyArray<number>;
+  /** Largest period count across sibling cells. When this cell's
+   *  ``values.length`` is smaller, the shapes between sparklines
+   *  can't be compared directly — surface a coverage caption. */
+  readonly maxLen: number;
   readonly stroke: string;
 }) {
+  const showCoverage = values.length > 0 && values.length < maxLen;
   return (
     <div className="flex flex-col items-start">
       <span className="text-[10px] uppercase tracking-wider text-slate-500">
@@ -223,6 +259,14 @@ function FundamentalCell({
       <span className="text-xs font-medium tabular-nums text-slate-800">
         {formatLatest(values)}
       </span>
+      {showCoverage ? (
+        <span
+          className="text-[9px] uppercase tracking-wider text-amber-600"
+          title={`This cell covers ${values.length} of the ${maxLen} periods rendered by sibling cells.`}
+        >
+          {values.length}/{maxLen} periods
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -23,10 +23,16 @@ const SLICE = 8;
 
 interface SeriesRow {
   readonly period_end: string;
-  readonly revenue: number;
-  readonly operatingIncome: number;
-  readonly netIncome: number;
-  readonly totalDebt: number;
+  // Each metric is independently nullable. Per-cell render filters its
+  // own column rather than the whole row dropping when one column is
+  // missing — partnership/MLP issuers like IEP file
+  // `IncomeLossFromContinuingOperations` instead of the standard
+  // `OperatingIncomeLoss`, leaving operating_income null on every row,
+  // which previously hid the entire pane (#684 operator report).
+  readonly revenue: number | null;
+  readonly operatingIncome: number | null;
+  readonly netIncome: number | null;
+  readonly totalDebt: number | null;
 }
 
 function num(v: string | null | undefined): number | null {
@@ -46,21 +52,27 @@ function joinPeriods(
   for (const i of income) {
     const key = `${i.period_end}|${i.period_type}`;
     const b = bMap.get(key);
-    if (b === undefined) continue;
     const revenue = num(i.values["revenue"] ?? null);
     const operatingIncome = num(i.values["operating_income"] ?? null);
     const netIncome = num(i.values["net_income"] ?? null);
-    const lt = num(b.values["long_term_debt"] ?? null) ?? 0;
-    const st = num(b.values["short_term_debt"] ?? null) ?? 0;
-    if (revenue === null || operatingIncome === null || netIncome === null) {
+    const lt = b !== undefined ? num(b.values["long_term_debt"] ?? null) : null;
+    const st = b !== undefined ? num(b.values["short_term_debt"] ?? null) : null;
+    // Drop a row only when every income-side flagship metric is null
+    // — otherwise the pane has nothing to plot. Total debt is a
+    // best-effort sum (if either component is non-null we surface
+    // what we have; balance-side gaps don't kill the income-side
+    // sparklines).
+    if (revenue === null && operatingIncome === null && netIncome === null) {
       continue;
     }
+    const totalDebt =
+      lt === null && st === null ? null : (lt ?? 0) + (st ?? 0);
     joined.push({
       period_end: i.period_end,
       revenue,
       operatingIncome,
       netIncome,
-      totalDebt: lt + st,
+      totalDebt,
     });
   }
   // Sort newest first then take the latest SLICE; reverse so the
@@ -69,6 +81,21 @@ function joinPeriods(
   const latest = joined.slice(0, SLICE);
   latest.reverse();
   return latest;
+}
+
+/** Filter the per-period series down to non-null values for one
+ *  metric. Empty array means "this issuer doesn't report this metric"
+ *  — the cell renders an em dash + a small "no data" hint. */
+function nonNullValues(
+  series: ReadonlyArray<SeriesRow>,
+  pick: (row: SeriesRow) => number | null,
+): number[] {
+  const out: number[] = [];
+  for (const row of series) {
+    const v = pick(row);
+    if (v !== null) out.push(v);
+  }
+  return out;
 }
 
 function formatLatest(values: ReadonlyArray<number>): string {
@@ -154,22 +181,22 @@ export function FundamentalsPane({ summary }: FundamentalsPaneProps): JSX.Elemen
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           <FundamentalCell
             label="Revenue"
-            values={series.map((r) => r.revenue)}
+            values={nonNullValues(series, (r) => r.revenue)}
             stroke="text-sky-500"
           />
           <FundamentalCell
             label="Op income"
-            values={series.map((r) => r.operatingIncome)}
+            values={nonNullValues(series, (r) => r.operatingIncome)}
             stroke="text-emerald-500"
           />
           <FundamentalCell
             label="Net income"
-            values={series.map((r) => r.netIncome)}
+            values={nonNullValues(series, (r) => r.netIncome)}
             stroke="text-emerald-500"
           />
           <FundamentalCell
             label="Total debt"
-            values={series.map((r) => r.totalDebt)}
+            values={nonNullValues(series, (r) => r.totalDebt)}
             stroke="text-amber-500"
           />
         </div>

--- a/frontend/src/components/instrument/InsiderActivitySummary.tsx
+++ b/frontend/src/components/instrument/InsiderActivitySummary.tsx
@@ -13,7 +13,9 @@ import { fetchInsiderSummary } from "@/api/instruments";
 import type { InsiderSummary } from "@/api/instruments";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { Pane } from "@/components/instrument/Pane";
+import { Term } from "@/components/Term";
 import { EmptyState } from "@/components/states/EmptyState";
+import { lookupTerm } from "@/lib/glossary";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
@@ -119,10 +121,17 @@ function Field({
   readonly label: string;
   readonly children: React.ReactNode;
 }) {
+  // Wrap the abbreviation in a <Term> tooltip when the label is in
+  // the glossary (#684). Operator complaint: NET 90d / TXNS etc.
+  // are dense without a hover-explanation. The Field caption keeps
+  // the same uppercase / tracking-wider styling either way; the
+  // glossary version adds a subtle dotted underline to flag
+  // hover-availability.
+  const hasGlossary = lookupTerm(label) !== null;
   return (
     <div className="flex flex-col">
       <span className="text-[10px] uppercase tracking-wider text-slate-500">
-        {label}
+        {hasGlossary ? <Term term={label} /> : label}
       </span>
       <span>{children}</span>
     </div>

--- a/frontend/src/components/instrument/KeyStatsPane.tsx
+++ b/frontend/src/components/instrument/KeyStatsPane.tsx
@@ -1,5 +1,7 @@
 import { Pane } from "@/components/instrument/Pane";
+import { Term } from "@/components/Term";
 import { EmptyState } from "@/components/states/EmptyState";
+import { lookupTerm } from "@/lib/glossary";
 import type { InstrumentSummary, KeyStatsFieldSource } from "@/api/types";
 
 function formatDecimal(
@@ -111,9 +113,16 @@ export function KeyStatsPane({ summary }: KeyStatsPaneProps): JSX.Element {
 }
 
 function KeyStatRow({ row }: { row: Row }): JSX.Element {
+  // Wrap the label in <Term> when the glossary recognises it (P/E,
+  // P/B, ROE, ROA, Debt / Equity, Payout ratio, etc. are all
+  // covered) — gives the operator a hover-tooltip with the formula
+  // and why-it-matters line. #684.
+  const hasGlossary = lookupTerm(row.label) !== null;
   return (
     <>
-      <dt className="text-slate-500">{row.label}</dt>
+      <dt className="text-slate-500">
+        {hasGlossary ? <Term term={row.label} /> : row.label}
+      </dt>
       <dd className="flex items-center tabular-nums">
         <span>{row.value}</span>
         <FieldSourceTag source={row.source} />

--- a/frontend/src/components/instrument/SecProfilePanel.tsx
+++ b/frontend/src/components/instrument/SecProfilePanel.tsx
@@ -22,6 +22,7 @@ import {
   SectionSkeleton,
 } from "@/components/dashboard/Section";
 import { Pane } from "@/components/instrument/Pane";
+import { Term } from "@/components/Term";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback } from "react";
@@ -74,7 +75,9 @@ function Body({
       <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
         {profile.sic_description !== null && (
           <>
-            <dt className="text-slate-500">Industry (SIC)</dt>
+            <dt className="text-slate-500">
+              Industry (<Term term="SIC" />)
+            </dt>
             <dd>
               {profile.sic_description}
               {profile.sic !== null && (
@@ -97,7 +100,9 @@ function Body({
         )}
         {profile.category !== null && (
           <>
-            <dt className="text-slate-500">Filer category</dt>
+            <dt className="text-slate-500">
+              <Term term="Filer category" />
+            </dt>
             <dd>{profile.category}</dd>
           </>
         )}
@@ -124,7 +129,9 @@ function Body({
             </dd>
           </>
         )}
-        <dt className="text-slate-500">CIK</dt>
+        <dt className="text-slate-500">
+          <Term term="CIK" />
+        </dt>
         <dd className="font-mono text-xs text-slate-600">{profile.cik}</dd>
       </dl>
 

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -17,6 +17,7 @@ import type {
   InstrumentPositionDetail,
   ThesisDetail,
 } from "@/api/types";
+import { Term } from "@/components/Term";
 import { liveTickDisplayPrice, useLiveQuote } from "@/lib/useLiveQuote";
 
 const THESIS_STALE_DAYS = 30;
@@ -148,9 +149,12 @@ export function SummaryStrip({
           {identity.display_name ?? "—"}
         </span>
         {summary.coverage_tier !== null ? (
-          <span className="rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+          <Term
+            term={`Tier ${summary.coverage_tier}`}
+            className="rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 no-underline"
+          >
             Tier {summary.coverage_tier}
-          </span>
+          </Term>
         ) : null}
         {price || livePrice ? (
           <>

--- a/frontend/src/components/instrument/dividendsShared.tsx
+++ b/frontend/src/components/instrument/dividendsShared.tsx
@@ -11,6 +11,7 @@
  */
 
 import type { DividendPeriod, DividendSummary, UpcomingDividend } from "@/api/instruments";
+import { Term } from "@/components/Term";
 
 // ---------------------------------------------------------------------------
 // Formatters
@@ -121,13 +122,19 @@ export function NextDividendBanner({ upcoming }: { upcoming: UpcomingDividend })
 export function DividendsSummaryBlock({ summary }: { summary: DividendSummary }) {
   return (
     <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
-      <dt className="text-slate-500">TTM yield</dt>
+      <dt className="text-slate-500">
+        <Term term="TTM" /> yield
+      </dt>
       <dd className="font-semibold text-emerald-700">
         {formatYieldPct(summary.ttm_yield_pct)}
       </dd>
-      <dt className="text-slate-500">TTM DPS</dt>
+      <dt className="text-slate-500">
+        <Term term="TTM" /> <Term term="DPS" />
+      </dt>
       <dd>{formatDps(summary.ttm_dps, summary.dividend_currency)}</dd>
-      <dt className="text-slate-500">Latest DPS</dt>
+      <dt className="text-slate-500">
+        Latest <Term term="DPS" />
+      </dt>
       <dd>
         {formatDps(summary.latest_dps, summary.dividend_currency)}
         {summary.latest_dividend_at !== null && (

--- a/frontend/src/lib/glossary.test.ts
+++ b/frontend/src/lib/glossary.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filingTypeFriendlyName,
+  GLOSSARY,
+  lookupTerm,
+} from "@/lib/glossary";
+
+describe("GLOSSARY", () => {
+  it("contains no duplicate terms", () => {
+    const seen = new Set<string>();
+    for (const entry of GLOSSARY) {
+      expect(seen.has(entry.term), `duplicate term: ${entry.term}`).toBe(false);
+      seen.add(entry.term);
+    }
+  });
+
+  it("has a non-empty shortName + what + why for every entry", () => {
+    for (const entry of GLOSSARY) {
+      expect(entry.shortName.length, entry.term).toBeGreaterThan(0);
+      expect(entry.what.length, entry.term).toBeGreaterThan(0);
+      expect(entry.why.length, entry.term).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps shortName tight (≤ 32 chars) so tooltips don't bloat", () => {
+    for (const entry of GLOSSARY) {
+      expect(
+        entry.shortName.length,
+        `${entry.term}: shortName "${entry.shortName}" too long`,
+      ).toBeLessThanOrEqual(32);
+    }
+  });
+});
+
+describe("lookupTerm", () => {
+  it("returns the entry for a known term", () => {
+    const entry = lookupTerm("CIK");
+    expect(entry).not.toBeNull();
+    expect(entry?.shortName).toBe("SEC entity ID");
+  });
+
+  it("returns null for an unknown term", () => {
+    expect(lookupTerm("NEVER_HEARD_OF_IT")).toBeNull();
+  });
+
+  it("is case-sensitive (terms render exactly as the operator sees them)", () => {
+    expect(lookupTerm("cik")).toBeNull();
+    expect(lookupTerm("CIK")).not.toBeNull();
+  });
+});
+
+describe("filingTypeFriendlyName", () => {
+  it("returns the glossary shortName for known form types", () => {
+    expect(filingTypeFriendlyName("8-K")).toBe("Material event");
+    expect(filingTypeFriendlyName("10-K")).toBe("Annual report");
+    expect(filingTypeFriendlyName("10-Q")).toBe("Quarterly report");
+    expect(filingTypeFriendlyName("8-K/A")).toBe("Material event amendment");
+  });
+
+  it("falls back to the raw type when the glossary doesn't recognise it", () => {
+    // Exotic form — keep it visible rather than swallowing into "filing".
+    expect(filingTypeFriendlyName("NT 10-K")).toBe("NT 10-K");
+  });
+
+  it("returns 'filing' for null", () => {
+    expect(filingTypeFriendlyName(null)).toBe("filing");
+  });
+});

--- a/frontend/src/lib/glossary.ts
+++ b/frontend/src/lib/glossary.ts
@@ -1,0 +1,319 @@
+/**
+ * Operator-facing glossary of abbreviations used across the eBull
+ * UI (#684).
+ *
+ * Single source of truth so:
+ *   - the in-flow `<Term>` component renders consistent tooltips for
+ *     every wrapped abbreviation
+ *   - the standalone `/glossary` page renders the same data as a
+ *     scannable table
+ *   - SEC filing-type chips can fall back to the friendly short name
+ *     when the extracted-summary field is empty (replaces the
+ *     duplicate-chip rendering noticed by the operator on
+ *     /instrument/IEP — `8-K  8-K`, `10-K  10-K` is now
+ *     `8-K Material event`, `10-K Annual report`)
+ *
+ * Entries split into two namespaces:
+ *   - SEC + financial-statement / accounting terms (CIK, SIC, ROE,
+ *     P/E, etc.) — operator may not know without context
+ *   - eBull-internal UI labels (Tier, NET 90d, PM/AH, Held: Nu) —
+ *     short by design but inscrutable on first read
+ *
+ * Entry shape:
+ *   - `term`: the rendered abbreviation/short string the operator sees
+ *   - `shortName`: a human-readable expansion (≤6 words). Doubles as
+ *     the friendly fallback for filing chips.
+ *   - `what`: 1-sentence definition. Tooltip body.
+ *   - `why`: 1-sentence "why an operator should care". Tooltip
+ *     secondary line + glossary "Why it matters" column.
+ *   - `learnMoreUrl` (optional): canonical reference for the curious.
+ *
+ * Sorted alphabetically by `term` so the glossary page renders
+ * deterministically and a future contributor doesn't have to guess
+ * where a new entry belongs.
+ */
+
+export interface GlossaryEntry {
+  readonly term: string;
+  readonly shortName: string;
+  readonly what: string;
+  readonly why: string;
+  readonly learnMoreUrl?: string;
+}
+
+export const GLOSSARY: ReadonlyArray<GlossaryEntry> = [
+  // -------------------------------------------------------------------
+  // SEC filing form types
+  // -------------------------------------------------------------------
+  {
+    term: "8-K",
+    shortName: "Material event",
+    what: "SEC filing reporting a material corporate event between regular periodic filings — earnings, M&A, executive changes, dividend declarations, bankruptcies.",
+    why: "Fastest-cadence US-issuer disclosure (within 4 business days of the event). Each 8-K's `items[]` codes (1.01, 2.02, 5.02, etc.) classify the event type so you can spot earnings vs leadership change at a glance.",
+    learnMoreUrl: "https://www.sec.gov/forms",
+  },
+  {
+    term: "8-K/A",
+    shortName: "Material event amendment",
+    what: "Amendment to a previously filed 8-K — corrections, retractions, or supplementary detail.",
+    why: "Rare but important: a 8-K/A on a recent earnings or M&A 8-K usually means the original numbers/narrative changed.",
+  },
+  {
+    term: "10-K",
+    shortName: "Annual report",
+    what: "SEC annual report — full audited financial statements, MD&A, risk factors, business description, executive compensation. Filed within 60-90 days of fiscal year end.",
+    why: "Most-comprehensive single document on the issuer. Item 1 (business) + Item 1A (risks) + Item 7 (MD&A) drive thesis quality more than any other source.",
+    learnMoreUrl: "https://www.sec.gov/forms",
+  },
+  {
+    term: "10-K/A",
+    shortName: "Annual report amendment",
+    what: "Amendment to a previously filed 10-K. Common when the original missed the proxy section (Part III incorporated by reference) or restates financial numbers.",
+    why: "A 10-K/A that restates financials is a yellow-flag signal — accounting discipline or audit issues.",
+  },
+  {
+    term: "10-Q",
+    shortName: "Quarterly report",
+    what: "SEC quarterly report (filed for Q1/Q2/Q3 only — Q4 is rolled into the 10-K). Unaudited statements + MD&A.",
+    why: "The cadence-driver of quarterly fundamentals. XBRL facts here populate the Fundamentals drill page's quarterly rows.",
+    learnMoreUrl: "https://www.sec.gov/forms",
+  },
+  {
+    term: "10-Q/A",
+    shortName: "Quarterly report amendment",
+    what: "Amendment to a previously filed 10-Q.",
+    why: "Same yellow-flag reading as 10-K/A — a re-stated quarter is rare and worth investigating.",
+  },
+  {
+    term: "20-F",
+    shortName: "Foreign annual report",
+    what: "Annual report for a foreign private issuer (FPI). Equivalent to a 10-K for non-US issuers listed on US exchanges (e.g. via ADRs).",
+    why: "Where to look for ASML, TSM, NVO etc. — the FPI equivalent of the 10-K, with similar audit + risk-factor structure.",
+  },
+  {
+    term: "20-F/A",
+    shortName: "Foreign annual amendment",
+    what: "Amendment to a previously filed 20-F.",
+    why: "Same restatement signal as 10-K/A but on the FPI track.",
+  },
+  {
+    term: "40-F",
+    shortName: "Canadian annual report",
+    what: "Annual report for a Canadian issuer using the multijurisdictional disclosure system (MJDS) to file on US exchanges.",
+    why: "Smaller cohort (Shopify, BAM, etc.). Reads like a 10-K for thesis purposes.",
+  },
+  {
+    term: "6-K",
+    shortName: "Foreign interim report",
+    what: "Interim report for a foreign private issuer — covers material events filed between annual 20-F filings (rough analog of an 8-K + 10-Q rolled together).",
+    why: "Where FPI quarterly numbers actually land (not 10-Q). Cadence is less regular than US issuers.",
+  },
+  {
+    term: "Form 4",
+    shortName: "Insider transaction",
+    what: "Statement of changes in beneficial ownership filed by directors, officers, and >10% shareholders within 2 business days of any trade.",
+    why: "Drives the insider-activity drill page. Open-market buys are the strongest insider sentiment signal; tax-withholding (F) and grants (A) are mechanical.",
+  },
+  {
+    term: "13D",
+    shortName: "5%+ active holder",
+    what: "Schedule 13D — disclosure required when an investor crosses 5% beneficial ownership AND intends to influence control (vs passive 13G).",
+    why: "13D is loud — activist filings, takeover stake-builds. 13D/A amendments often flag stake increases or letters to the board.",
+  },
+  {
+    term: "13G",
+    shortName: "5%+ passive holder",
+    what: "Schedule 13G — passive >5% disclosure (mutual funds, index providers). Less reporting overhead than 13D.",
+    why: "Routine. A 13D-to-13G or 13G-to-13D conversion is the interesting signal.",
+  },
+
+  // -------------------------------------------------------------------
+  // SEC entity / regulatory
+  // -------------------------------------------------------------------
+  {
+    term: "CIK",
+    shortName: "SEC entity ID",
+    what: "Central Index Key — the SEC's stable 10-digit identifier for any entity that has ever filed with the agency.",
+    why: "Primary join key for every SEC dataset (filings, XBRL, ownership). Survives ticker changes, spin-offs, mergers; ticker-based lookups don't.",
+  },
+  {
+    term: "SIC",
+    shortName: "Industry code",
+    what: "Standard Industrial Classification — 4-digit US government industry code (e.g. 2911 = Petroleum Refining).",
+    why: "Coarser than GICS but baked into SEC filings. Used as the peer-set anchor when richer industry data is missing.",
+  },
+  {
+    term: "EDGAR",
+    shortName: "SEC filing repository",
+    what: "Electronic Data Gathering, Analysis, and Retrieval — the SEC's public filings database (since 1993).",
+    why: "Where every primary-source document on this page comes from. The `SEC EDGAR` chip on the chart / company profile means we read this filing direct, not via a redistributor.",
+    learnMoreUrl: "https://www.sec.gov/edgar",
+  },
+  {
+    term: "XBRL",
+    shortName: "Tagged financial data",
+    what: "eXtensible Business Reporting Language — structured tagging system the SEC mandates for financial statements (since 2009).",
+    why: "What lets us extract revenue / margins / debt as numbers (not PDFs). Tagged facts feed the Fundamentals drill page.",
+  },
+  {
+    term: "Filer category",
+    shortName: "SEC reporting size tier",
+    what: "SEC's size classification — Large accelerated (>$700M public float), Accelerated ($75M-$700M), Non-accelerated, or Smaller reporting company.",
+    why: "Drives filing deadlines (Large accelerated must file 10-K within 60 days of FY end; smaller filers get 90 days) and the level of audit scrutiny.",
+  },
+  {
+    term: "FPI",
+    shortName: "Foreign private issuer",
+    what: "Non-US issuer using SEC's foreign-issuer track — files 20-F annually + 6-K interim, exempt from proxy and Reg FD.",
+    why: "Different filing cadence and disclosure standards than US-domiciled issuers. Affects what data we can extract.",
+  },
+
+  // -------------------------------------------------------------------
+  // Valuation / fundamentals ratios
+  // -------------------------------------------------------------------
+  {
+    term: "P/E ratio",
+    shortName: "Price / Earnings",
+    what: "Current share price divided by trailing-twelve-month earnings per share.",
+    why: "Most-cited valuation multiple. Negative when the issuer is loss-making (the chart shows -3.38 for BBBY today — meaning P / negative-E).",
+  },
+  {
+    term: "P/B ratio",
+    shortName: "Price / Book value",
+    what: "Share price divided by book value per share (shareholders' equity / shares outstanding).",
+    why: "Asset-heavy issuers (banks, REITs) trade closer to book than asset-light tech. P/B<1 with positive earnings can indicate undervaluation or hidden distress.",
+  },
+  {
+    term: "ROE",
+    shortName: "Return on equity",
+    what: "Net income divided by shareholders' equity. The DuPont decomposition splits it into Net Margin × Asset Turnover × Equity Multiplier.",
+    why: "Measures how efficiently the business converts each pound of operator capital into profit. >15% sustained is high quality; negative means losses are eating equity.",
+  },
+  {
+    term: "ROA",
+    shortName: "Return on assets",
+    what: "Net income divided by total assets. Independent of capital structure (vs ROE).",
+    why: "Compares profitability across companies with different leverage. Low ROA + high ROE = leverage doing the work.",
+  },
+  {
+    term: "ROIC",
+    shortName: "Return on invested capital",
+    what: "After-tax operating profit (NOPAT) divided by invested capital (debt + equity). Strips out tax effects + capital structure.",
+    why: "The cleanest profitability gauge for cross-company comparison. ROIC > weighted cost of capital = real value creation.",
+  },
+  {
+    term: "Debt / Equity",
+    shortName: "Leverage ratio",
+    what: "Total debt divided by shareholders' equity.",
+    why: "Quick read on capital structure. >1 means more debt than equity; sustained high values amplify both upside and bankruptcy risk.",
+  },
+  {
+    term: "DuPont",
+    shortName: "ROE decomposition",
+    what: "Three-way breakdown of Return on Equity = Net Margin × Asset Turnover × Equity Multiplier.",
+    why: "Tells you WHERE the ROE comes from — operational efficiency (margin), asset utilisation (turnover), or leverage (multiplier). Same ROE can hide very different businesses.",
+  },
+  {
+    term: "FCF",
+    shortName: "Free cash flow",
+    what: "Operating cash flow minus capital expenditure. The cash actually available to investors after the business reinvests in itself.",
+    why: "Less manipulable than earnings (working-capital-aware). Negative FCF over multiple years is the canonical capital-burn signal.",
+  },
+  {
+    term: "EPS",
+    shortName: "Earnings per share",
+    what: "Net income divided by weighted-average shares outstanding for the period. Diluted EPS includes the dilutive effect of options and convertibles.",
+    why: "The denominator on P/E and the line items most analysts and journalists track. We use diluted EPS in YoY-growth and DuPont charts.",
+  },
+  {
+    term: "TTM",
+    shortName: "Trailing twelve months",
+    what: "The latest 4 quarters summed (for flow items like revenue) or the latest available value (for balance items like book value).",
+    why: "Smoother than any single quarter; the standard window for yield, P/E, and dividend-payout calculations.",
+  },
+  {
+    term: "DPS",
+    shortName: "Dividend per share",
+    what: "Per-share dividend (or LP per-unit distribution) declared or paid in a period.",
+    why: "Multiplied by your held units = your dividend income. Driving metric on the Dividends drill page.",
+  },
+  {
+    term: "Yield-on-cost",
+    shortName: "Dividend / your entry",
+    what: "Annual dividend divided by YOUR per-share cost basis (not current price).",
+    why: "Shows how a long-held position's effective yield grows as dividends rise — current dividend yield doesn't tell that story.",
+  },
+  {
+    term: "Payout ratio",
+    shortName: "Dividends / FCF",
+    what: "Dividends paid divided by free cash flow.",
+    why: ">100% sustained = the dividend is being funded by debt or asset sales, not the business itself. Yellow flag for sustainability.",
+  },
+
+  // -------------------------------------------------------------------
+  // eBull internal labels
+  // -------------------------------------------------------------------
+  {
+    term: "Tier 1",
+    shortName: "High-coverage instrument",
+    what: "eBull coverage tier — Tier 1 instruments have full SEC + market data + thesis pipeline coverage. Tier 2 has market data only.",
+    why: "Drives which charts and panels render. A Tier 2 instrument has no fundamentals chart because we don't ingest XBRL for it.",
+  },
+  {
+    term: "Tier 2",
+    shortName: "Market-data only",
+    what: "eBull coverage tier — Tier 2 instruments have market data (prices, quotes) but no fundamentals or filings ingest.",
+    why: "Useful for watchlists / index members; not deep-research targets.",
+  },
+  {
+    term: "PM",
+    shortName: "Pre-market",
+    what: "Pre-market trading session (04:00-09:30 ET). Lower liquidity than the regular session.",
+    why: "Toggle on the chart shows pre-market candles tinted differently. Useful for spotting overnight news reaction before the open.",
+  },
+  {
+    term: "AH",
+    shortName: "After-hours",
+    what: "After-hours trading session (16:00-20:00 ET).",
+    why: "Earnings often print after the close — AH candles show the immediate market reaction before the regular session re-opens.",
+  },
+  {
+    term: "NET 90d",
+    shortName: "Net insider activity (90 days)",
+    what: "Acquired shares minus disposed shares from Form 4 filings over the trailing 90 days.",
+    why: "The headline insider-activity number on the L1 pane. Positive = net buying; negative = net selling.",
+  },
+  {
+    term: "TXNS",
+    shortName: "Transaction count",
+    what: "Number of Form 4 transaction rows in the window.",
+    why: "Volume signal. Many small grants ≠ one big open-market buy — TXNS + NET together tell the cadence.",
+  },
+];
+
+// Indexed-by-term map for O(1) tooltip lookup. Build once at module
+// load; the glossary array stays the canonical sortable source.
+const GLOSSARY_INDEX: Record<string, GlossaryEntry> = (() => {
+  const out: Record<string, GlossaryEntry> = {};
+  for (const entry of GLOSSARY) {
+    out[entry.term] = entry;
+  }
+  return out;
+})();
+
+export function lookupTerm(term: string): GlossaryEntry | null {
+  return GLOSSARY_INDEX[term] ?? null;
+}
+
+/** Friendly-name lookup for SEC filing form types — used as the
+ *  fallback string in the Recent Filings list when an issuer's
+ *  XBRL-extracted summary field is null (#684 — operator-reported
+ *  duplicate `8-K  8-K` rendering). Returns the glossary entry's
+ *  ``shortName`` when present; falls back to the raw type for
+ *  unknown forms (e.g. an exotic Schedule X) so the row still
+ *  renders something readable. */
+export function filingTypeFriendlyName(filingType: string | null): string {
+  if (filingType === null) return "filing";
+  const entry = lookupTerm(filingType);
+  return entry !== null ? entry.shortName : filingType;
+}

--- a/frontend/src/pages/DividendsPage.tsx
+++ b/frontend/src/pages/DividendsPage.tsx
@@ -48,6 +48,7 @@ import {
   YieldOnCostChart,
 } from "@/components/dividends/dividendsCharts";
 import { Pane } from "@/components/instrument/Pane";
+import { Term } from "@/components/Term";
 import {
   DividendsSummaryBlock,
   formatDps,
@@ -195,6 +196,13 @@ export function DividendsPage(): JSX.Element {
         <h1 className="mt-1 text-lg font-semibold text-slate-900">
           Dividends — {symbol}
         </h1>
+        <p className="mt-1 text-xs text-slate-500">
+          SEC XBRL declared per-share / per-unit history. Charts read from
+          the per-quarter <Term term="DPS" /> stream; <Term term="TTM" />{" "}
+          summary uses the latest 4 quarters. <Term term="Payout ratio" />{" "}
+          and <Term term="Yield-on-cost" /> render only when their inputs
+          (annual cashflow / your entry price) are available.
+        </p>
       </header>
 
       {dividends.loading ? (

--- a/frontend/src/pages/FundamentalsPage.tsx
+++ b/frontend/src/pages/FundamentalsPage.tsx
@@ -50,6 +50,7 @@ import {
   YoyGrowthChart,
 } from "@/components/fundamentals/fundamentalsCharts";
 import { Pane } from "@/components/instrument/Pane";
+import { Term } from "@/components/Term";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
 import { joinStatements } from "@/lib/fundamentalsMetrics";
@@ -173,9 +174,13 @@ export function FundamentalsPage(): JSX.Element {
           </div>
         </div>
         <p className="mt-1 text-xs text-slate-500">
-          SEC XBRL company-facts data. Each pane shows "—" when a metric
-          is missing for a period; ROIC and FCF are derived (see
-          metric helpers for formulas).
+          SEC <Term term="XBRL" /> company-facts data — every line is
+          tagged in the issuer's 10-K / 10-Q so we can read them as
+          numbers (not narrative). Each pane shows "—" when a metric
+          is missing for a period. <Term term="ROIC" /> and{" "}
+          <Term term="FCF" /> are derived; <Term term="DuPont" />{" "}
+          breaks <Term term="ROE" /> into its three drivers so you
+          can see which one is doing the work.
         </p>
       </header>
 

--- a/frontend/src/pages/InsiderPage.tsx
+++ b/frontend/src/pages/InsiderPage.tsx
@@ -39,6 +39,7 @@ import { InsiderNetByMonth } from "@/components/insider/InsiderNetByMonth";
 import { InsiderPriceMarkers } from "@/components/insider/InsiderPriceMarkers";
 import { InsiderTransactionsTable } from "@/components/insider/InsiderTransactionsTable";
 import { Pane } from "@/components/instrument/Pane";
+import { Term } from "@/components/Term";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
 
@@ -68,9 +69,12 @@ export function InsiderPage(): JSX.Element {
           Insider activity — {symbol}
         </h1>
         <p className="mt-1 text-xs text-slate-500">
-          SEC Form 4 transactions. Acquired = green, disposed = red.
-          Non-derivative trades only in the chart sections; the table
-          shows every row including derivatives.
+          SEC <Term term="Form 4" /> transactions — directors / officers
+          / 10%+ holders disclosing share trades within 2 business days.
+          Acquired = green, disposed = red. The chart panes use only
+          non-derivative trades (open-market buys + sells, RSU vests,
+          tax-withholding sells); the table shows every row including
+          derivative grants and option exercises.
         </p>
       </header>
 


### PR DESCRIPTION
Operator review 2026-04-29 against the IEP instrument page surfaced three operator-visible issues, all addressed here:

## 1. Abbreviation comprehension

Built [lib/glossary.ts](frontend/src/lib/glossary.ts) — typed map of ~37 entries with \`shortName\` + \`what\` + \`why\` for SEC filing types (8-K / 10-K / 10-Q / 20-F / Form 4 / 13D / 13G), regulatory terms (CIK / SIC / EDGAR / XBRL / Filer category / FPI), valuation ratios (P/E / P/B / ROE / ROA / ROIC / DuPont / FCF / EPS / TTM / DPS / Yield-on-cost / Payout ratio), and eBull internal labels (Tier / PM / AH / NET 90d / TXNS).

Built [Term.tsx](frontend/src/components/Term.tsx) — renders as \`<abbr>\` with both native \`title\` + a richer popover on hover/focus. Keyboard-accessible (Tab + focus → tooltip).

Sweep wraps abbreviations across \`InsiderActivitySummary\`, \`SecProfilePanel\`, \`SummaryStrip\` Tier badge, \`dividendsShared\` (TTM yield / TTM DPS / Latest DPS), \`KeyStatsPane\` (P/E / P/B / ROE / ROA / Debt / Equity / Payout ratio).

## 2. Filings list duplicate-chip bug

Operator screenshot showed every row with the form-type chip rendered TWICE (\"8-K  8-K\", \"10-K  10-K\") when the XBRL \`extracted_summary\` field was null. Cause: the third-column fallback used \`f.filing_type\` literally, which already lives in the chip beside it.

Fix at [FilingsPane.tsx:144](frontend/src/components/instrument/FilingsPane.tsx#L144) — fallback now uses \`filingTypeFriendlyName()\` from the glossary, so the row reads \"8-K  Material event\" / \"10-K  Annual report\" instead of the dupe. Form-type chip itself wraps in \`<Term>\` so hovering reveals what each code means. Regression test added.

## 3. MLP fundamentals sparkline pane disappeared after force-refresh

Symptom: \`/instrument/IEP\` lost the small Revenue / Op income / Net income / Total debt sparklines under the price chart.

Root cause: IEP and other partnership/MLP issuers file \`IncomeLossFromContinuingOperations\` instead of \`OperatingIncomeLoss\` (the standard us-gaap concept). \`operating_income\` is null on every row. Pre-fix, \`FundamentalsPane.joinPeriods\` dropped a row if ANY of revenue/op_income/net_income was null — so MLPs silently hid the entire pane. Counter-intuitive trigger: my [PR #680](../pull/680) force_refresh_fundamentals.py rewrote IEP's rows from authoritative SEC source, clearing legacy stale operating_income values that previously kept the pane visible.

Fix at [FundamentalsPane.tsx:38](frontend/src/components/instrument/FundamentalsPane.tsx#L38) — gate a row out only when ALL three flagship metrics are null, surface what's available per cell. Op-income cell on IEP now renders \"—\" rather than killing the sibling sparklines. Regression test pins the partnership-issuer case.

## Also

Report-level subtitle quips added/expanded on \`InsiderPage\`, \`FundamentalsPage\`, \`DividendsPage\` — each explains what the report covers in plain English with key terms wrapped in \`<Term>\` for hover-detail.

## Test plan

- \`pnpm --dir frontend typecheck\` — clean
- \`pnpm --dir frontend test:unit\` — 731 pass (15 new: 9 glossary + 5 Term + 1 FilingsPane regression + 1 FundamentalsPane MLP regression)
- Manual: open \`/instrument/IEP\` after merge — Recent Filings rows should show \"8-K Material event\" / \"10-K Annual report\" instead of dupe chips. Fundamentals sparkline pane should reappear with Revenue / Net income / Total debt populated and Op income showing \"—\". Hovering any wrapped abbreviation (CIK / SIC / TTM / P/E etc.) opens the tooltip popover.

## Out of scope

Layout density redesign (operator's other ask in the same review thread) tracked separately for the next PR — would touch \`DensityGrid.tsx\` + the per-pane width caps, lower-risk to ship in isolation.