### PR TITLE
feat: cap narrow-content panes on instrument page (layout density)

### DIFF
--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -106,13 +106,20 @@ export function DensityGrid({
             <InsiderActivitySummary symbol={symbol} />
           </div>
         )}
+        {/* BusinessSections narrative stays full-width (long-form
+            content reads fine wide). Dividends panel caps at 6 cols
+            so its narrow stat-block doesn't stretch — was previously
+            paired with narrative but DividendsPanel and
+            BusinessSectionsTeaser each null-out independently when
+            their own data is empty, which would have left a 5-column
+            ghost slot in mixed-coverage states (#684 review). */}
         {hasNarrative && (
           <div className="col-span-12">
             <BusinessSectionsTeaser symbol={symbol} />
           </div>
         )}
         {dividendProviders.length > 0 && (
-          <div className="col-span-12">
+          <div className="col-span-12 lg:col-span-6">
             {dividendProviders.map((p) => (
               <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
             ))}
@@ -168,7 +175,10 @@ export function DensityGrid({
             <InsiderActivitySummary symbol={symbol} />
           </div>
         ) : dividendProviders.length > 0 ? (
-          <div className="col-span-12">
+          // Standalone dividends pane caps at 6 cols so a narrow
+          // stat-block doesn't stretch across the viewport (#684
+          // operator review).
+          <div className="col-span-12 lg:col-span-6">
             {dividendProviders.map((p) => (
               <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
             ))}
@@ -204,7 +214,8 @@ export function DensityGrid({
         </div>
       )}
       {dividendProviders.length > 0 && (
-        <div className="col-span-12">
+        // Minimal-profile dividends caps at 6 cols too (#684).
+        <div className="col-span-12 lg:col-span-6">
           {dividendProviders.map((p) => (
             <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
           ))}

--- a/frontend/src/components/instrument/InsiderActivitySummary.tsx
+++ b/frontend/src/components/instrument/InsiderActivitySummary.tsx
@@ -86,7 +86,10 @@ export function InsiderActivitySummary({
                 ? "text-red-700"
                 : "text-slate-700";
           return (
-            <div className="grid grid-cols-5 gap-2 text-xs">
+            // Cap width so the 5 stat boxes don't stretch with empty
+            // gaps when the pane sits in a wide grid cell — operator
+            // 2026-04-29 review (#684).
+            <div className="grid max-w-2xl grid-cols-5 gap-2 text-xs">
               <Field label="NET 90d">
                 <span className={`font-medium tabular-nums ${netClass}`}>
                   {fmtSigned(net)} {arrow}

--- a/frontend/src/components/instrument/KeyStatsPane.tsx
+++ b/frontend/src/components/instrument/KeyStatsPane.tsx
@@ -102,7 +102,10 @@ export function KeyStatsPane({ summary }: KeyStatsPaneProps): JSX.Element {
           description="No provider returned key stats for this ticker."
         />
       ) : (
-        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+        // Cap dl width so on a wide grid cell the key/value columns
+        // don't stretch with whitespace between them — narrow
+        // stat-block content reads tighter at ~28rem (#684).
+        <dl className="grid max-w-md grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
           {rows.map((r) => (
             <KeyStatRow key={r.label} row={r} />
           ))}

--- a/frontend/src/components/instrument/SecProfilePanel.tsx
+++ b/frontend/src/components/instrument/SecProfilePanel.tsx
@@ -72,7 +72,7 @@ function Body({
         <p className="leading-relaxed text-slate-700">{profile.description}</p>
       )}
 
-      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+      <dl className="grid max-w-xl grid-cols-[auto_1fr] gap-x-4 gap-y-1">
         {profile.sic_description !== null && (
           <>
             <dt className="text-slate-500">

--- a/frontend/src/components/instrument/dividendsShared.tsx
+++ b/frontend/src/components/instrument/dividendsShared.tsx
@@ -121,7 +121,7 @@ export function NextDividendBanner({ upcoming }: { upcoming: UpcomingDividend })
 
 export function DividendsSummaryBlock({ summary }: { summary: DividendSummary }) {
   return (
-    <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+    <dl className="grid max-w-md grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
       <dt className="text-slate-500">
         <Term term="TTM" /> yield
       </dt>


### PR DESCRIPTION
Follow-up to #684. Operator review 2026-04-29: \"feel like a poor use of space, making things wide just to fill the width when it could be 1/3 or 1/2 the length\".

## What

**Outer grid** ([DensityGrid.tsx](frontend/src/components/instrument/DensityGrid.tsx)):
- DividendsPanel caps at \`lg:col-span-6\` instead of 12 in every profile (full-sec, partial-filings standalone, minimal). The narrow stat-block layout doesn't need full viewport width.
- BusinessSectionsTeaser stays full-width — long-form narrative reads fine wide.

**Inner stat blocks** — \`max-w\` caps on narrow content so key/value columns don't stretch with whitespace:
- \`KeyStatsPane\` dl → \`max-w-md\` (28rem)
- \`SecProfilePanel\` dl → \`max-w-xl\` (36rem — slightly wider for the longer SIC / former-names rows)
- \`dividendsShared\` TTM block → \`max-w-md\`
- \`InsiderActivitySummary\` 5-stat row → \`max-w-2xl\` (42rem — fits the 5 boxes tight)

## Why

Operator screenshot showed Insider Activity 5 boxes stretching across 2000px with empty space between, and Dividends panel's 4-row stat block similarly stretched. Capping width pulls content tighter without touching the surrounding card chrome.

## Test plan

- \`pnpm --dir frontend typecheck\` — clean
- \`pnpm --dir frontend test:unit\` — 732 pass
- Codex round 1 caught a mixed-coverage ghost-column issue (paired narrative + dividends would leave a 5-col blank slot when DividendsPanel null-outs from empty history). Reverted to standalone-but-capped-6 layout. Round 2 clean.
- Manual: reload \`/instrument/IEP\` and \`/instrument/AAPL\` post-merge — Dividends pane should sit at half-width, KeyStats / SecProfile dls should stop stretching across their cards.

## Out of scope

The chart workspace + drill pages (insider, fundamentals, dividends) keep their current layout — operator complaint was specifically about the overview page. Drill-page density tuning can be a follow-up if needed.