### PR TITLE
feat: sparkline polish + tighten narrative pane widths (round 2)

### DIFF
--- a/frontend/src/components/instrument/BusinessSectionsTeaser.tsx
+++ b/frontend/src/components/instrument/BusinessSectionsTeaser.tsx
@@ -158,7 +158,7 @@ export function BusinessSectionsTeaser({ symbol }: BusinessSectionsTeaserProps) 
         )
       ) : (
         <div className="space-y-2 text-sm">
-          <p className="leading-relaxed text-slate-700">
+          <p className="max-w-prose leading-relaxed text-slate-700">
             {pickTeaser(state.data.sections)}
           </p>
           {state.data.source_accession !== null && (

--- a/frontend/src/components/instrument/FilingsPane.tsx
+++ b/frontend/src/components/instrument/FilingsPane.tsx
@@ -130,7 +130,7 @@ export function FilingsPane({
           }
         />
       ) : (
-        <ul className="space-y-1.5 text-xs">
+        <ul className="max-w-2xl space-y-1.5 text-xs">
           {state.data.items.slice(0, ROW_LIMIT).map((f) => {
             const link = drilldownLink(
               symbol,

--- a/frontend/src/components/instrument/FundamentalsPane.test.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.test.tsx
@@ -298,7 +298,7 @@ describe("FundamentalsPane", () => {
         <FundamentalsPane summary={makeSummary(true)} />
       </MemoryRouter>,
     );
-    expect(await screen.findByText(/2\/4 periods/)).toBeInTheDocument();
+    expect(await screen.findByText("2/4")).toBeInTheDocument();
   });
 
   it("returns null when capability active but only 1 quarter has both income + balance data", async () => {

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -235,6 +235,17 @@ function FundamentalsGrid({
   );
 }
 
+/** Period-over-period delta as a percentage. Sign carried by the
+ *  display layer; null when fewer than 2 points OR when prior is
+ *  zero (undefined growth). */
+function periodDelta(values: ReadonlyArray<number>): number | null {
+  if (values.length < 2) return null;
+  const prev = values[values.length - 2]!;
+  const last = values[values.length - 1]!;
+  if (prev === 0) return null;
+  return ((last - prev) / Math.abs(prev)) * 100;
+}
+
 function FundamentalCell({
   label,
   values,
@@ -250,23 +261,42 @@ function FundamentalCell({
   readonly stroke: string;
 }) {
   const showCoverage = values.length > 0 && values.length < maxLen;
+  const delta = periodDelta(values);
+  const deltaClass =
+    delta === null
+      ? "text-slate-400"
+      : delta > 0
+        ? "text-emerald-600"
+        : delta < 0
+          ? "text-red-600"
+          : "text-slate-500";
   return (
-    <div className="flex flex-col items-start">
-      <span className="text-[10px] uppercase tracking-wider text-slate-500">
-        {label}
-      </span>
-      <Sparkline values={values} className={stroke} />
-      <span className="text-xs font-medium tabular-nums text-slate-800">
-        {formatLatest(values)}
-      </span>
-      {showCoverage ? (
-        <span
-          className="text-[9px] uppercase tracking-wider text-amber-600"
-          title={`This cell covers ${values.length} of the ${maxLen} periods rendered by sibling cells.`}
-        >
-          {values.length}/{maxLen} periods
+    <div className="flex flex-col items-start gap-0.5">
+      <span className="flex w-full items-baseline justify-between gap-2">
+        <span className="text-[10px] uppercase tracking-wider text-slate-500">
+          {label}
         </span>
-      ) : null}
+        {showCoverage ? (
+          <span
+            className="text-[9px] uppercase tracking-wider text-amber-600"
+            title={`This cell covers ${values.length} of the ${maxLen} periods rendered by sibling cells.`}
+          >
+            {values.length}/{maxLen}
+          </span>
+        ) : null}
+      </span>
+      <Sparkline values={values} width={120} height={36} className={stroke} />
+      <span className="flex items-baseline gap-1.5">
+        <span className="text-sm font-semibold tabular-nums text-slate-800">
+          {formatLatest(values)}
+        </span>
+        {delta !== null ? (
+          <span className={`text-[10px] font-medium tabular-nums ${deltaClass}`}>
+            {delta > 0 ? "▲" : delta < 0 ? "▼" : "·"}
+            {Math.abs(delta).toFixed(1)}%
+          </span>
+        ) : null}
+      </span>
     </div>
   );
 }

--- a/frontend/src/components/instrument/RecentNewsPane.tsx
+++ b/frontend/src/components/instrument/RecentNewsPane.tsx
@@ -50,7 +50,7 @@ export function RecentNewsPane({
         navigate(`/instrument/${encodeURIComponent(symbol)}?tab=news`)
       }
     >
-      <ul className="space-y-1.5 text-xs">
+      <ul className="max-w-3xl space-y-1.5 text-xs">
         {items.map((n) => (
           <li key={n.news_event_id} className="flex items-baseline gap-2">
             <span className="text-slate-500">

--- a/frontend/src/components/instrument/ThesisPane.tsx
+++ b/frontend/src/components/instrument/ThesisPane.tsx
@@ -31,7 +31,7 @@ function ThesisBody({ thesis }: { thesis: ThesisDetail }): JSX.Element {
   const breaks = thesis.break_conditions_json ?? [];
   return (
     <div className="space-y-3 text-sm">
-      <div className="whitespace-pre-wrap text-slate-700">
+      <div className="max-w-prose whitespace-pre-wrap text-slate-700">
         {thesis.memo_markdown}
       </div>
       {(thesis.base_value !== null ||


### PR DESCRIPTION
Follow-up on #686. Operator review 2026-04-29 against the IEP screenshot:
- \"does the filings section need to be that wide, same with 10-K, should it be shorter width and a bit deeper?\"
- \"the charts that are visible, need some love\"

## Two visual passes

### 1. Fundamentals sparkline cells

Before: tiny 80×24 line, dim styling, just one number under it.

After:
- Sparkline grows to 120×36 (50% taller, 50% wider — actually readable)
- Latest value: \`text-sm semibold\` (was \`text-xs medium\`)
- Period-over-period delta surfaced inline next to the value: ▲ green for up, ▼ red for down, · slate for flat. Reads as \"3.47B  ▲5.2%\".
- Coverage caption (the \"n/N\" hint when a metric covers fewer periods than siblings) moves to the cell header right-side and shortens to just \`{n}/{maxLen}\` so it doesn't compete with the value below.

### 2. Long-form / list pane inner max-widths

Card chrome keeps the full 12-col grid width — only the inner readable text/list constrains:

| Pane                       | Cap         |
|----------------------------|-------------|
| BusinessSectionsTeaser \`<p>\` | \`max-w-prose\` |
| FilingsPane \`<ul>\`           | \`max-w-2xl\`   |
| RecentNewsPane \`<ul>\`        | \`max-w-3xl\`   |
| ThesisPane memo \`<div>\`      | \`max-w-prose\` |

Operator now sees text columns at ~75ch instead of stretching across a 2000px viewport.

## Test plan

- \`pnpm --dir frontend typecheck\` — clean
- \`pnpm --dir frontend test:unit\` — 732 pass (caption regex updated for the new short format)
- Manual: reload \`/instrument/IEP\` and \`/instrument/AAPL\` post-merge — sparklines should be visibly bigger with delta % beside the latest value; filings rows + 10-K narrative should sit at readable width with whitespace to the right rather than stretching.

## Out of scope

Card outer width caps (e.g. making the FilingsPane card itself \`col-span-7\` instead of 12) are deferred — would need re-pairing with another pane to avoid empty grid cells. This PR keeps the card chrome flexible and constrains only the inner content, so future re-pairing remains a single-line grid change.