### PR TITLE
feat: bento-grid DensityGrid v3 + null-out-safe empty states

### DIFF
--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -1,21 +1,32 @@
 /**
- * DensityGrid — 12-column capability-aware grid for the instrument
- * Research tab (#575). Three profiles determine which panes render:
+ * DensityGrid — bento-grid instrument page (#684 round 3).
  *
- *   full-sec        — fundamentals (sec_xbrl) + filings active
- *   partial-filings — filings active but no sec_xbrl fundamentals
- *   minimal         — no filings capability at all
+ * Operator review 2026-04-29: previous flat 12-col layout had two
+ * recurring gripes —
+ *   1. Half-width tiles (Dividends at lg:col-span-6) sat next to
+ *      empty grid cells when their would-be neighbour wasn't
+ *      capability-active — visible dead space.
+ *   2. Static row layouts (Filings col-span-7 + Insider col-span-5)
+ *      didn't re-flow when one of the panes was absent — left a
+ *      lone narrow stat block stretched across the row.
  *
- * PriceChart and KeyStatsPane are present in all profiles.
- * SecProfilePanel / BusinessSectionsTeaser gate on has_sec_cik.
- * FundamentalsPane is exclusive to the full-sec profile.
- * FilingsPane / InsiderActivitySummary / DividendsPanel / RecentNewsPane
- * / ThesisPane appear in profile-specific positions.
+ * Fix: every dynamic row routes through ``allocateTiles``, which
+ * filters out absent panes BEFORE the grid sees them and allocates
+ * column spans deterministically based on the surviving count
+ * (1 → 12, 2 → 6+6, 3 → 4+4+4, 4 → 3+3+3+3). PriceChart + KeyStats
+ * + SecProfile keep their existing fixed allocations because they're
+ * always present (or KeyStats can render with a "no key stats" empty
+ * state in-pane). Long-form panes (BusinessSections, ThesisPane)
+ * stay full-width — narrative content reads fine wide given the
+ * inner ``max-w-prose`` cap shipped in #687.
  *
- * No overflow-auto scroll-boxes: every pane expands to content height
- * so the grid stays a true content-driven layout.
+ * Bento aesthetic per ``ui-ux-pro-max`` skill (Apple/dashboard
+ * pattern): rounded-xl card chrome, subtle hover lift, varied
+ * tile sizes (1x1 + 2x1), neutral shadows. Card chrome itself
+ * lives in ``Pane.tsx``; this file allocates the grid spans.
  */
 
+import type { ReactNode } from "react";
 import type { InstrumentSummary, ThesisDetail } from "@/api/types";
 import { activeProviders } from "@/lib/capabilityProviders";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -42,6 +53,46 @@ export interface DensityGridProps {
   readonly thesisErrored: boolean;
 }
 
+/** A renderable tile + the gating predicate. ``content`` is only
+ *  evaluated when ``present`` is true, so we don't force-render
+ *  panes that are about to null-out. */
+interface TileSpec {
+  readonly key: string;
+  readonly present: boolean;
+  readonly content: () => ReactNode;
+}
+
+/** Allocate column spans across the surviving tiles deterministically.
+ *  Fills the 12-col row regardless of which subset of inputs is
+ *  present — when a pane null-outs, the survivors absorb its width
+ *  rather than leaving a ghost cell.
+ *
+ *  | Surviving | Spans                        |
+ *  |-----------|------------------------------|
+ *  | 1         | col-span-12                  |
+ *  | 2         | 6 + 6                        |
+ *  | 3         | 4 + 4 + 4                    |
+ *  | 4         | 3 + 3 + 3 + 3                |
+ *  | >4        | falls through to col-span-12 (unsupported — won't fire today) |
+ */
+function allocateTiles(tiles: ReadonlyArray<TileSpec>): ReactNode[] {
+  const present = tiles.filter((t) => t.present);
+  const n = present.length;
+  if (n === 0) return [];
+  const spanByCount: Record<number, string> = {
+    1: "col-span-12",
+    2: "col-span-12 lg:col-span-6",
+    3: "col-span-12 lg:col-span-4",
+    4: "col-span-12 lg:col-span-3",
+  };
+  const span = spanByCount[n] ?? "col-span-12";
+  return present.map((t) => (
+    <div key={t.key} className={span}>
+      {t.content()}
+    </div>
+  ));
+}
+
 export function DensityGrid({
   summary,
   thesis,
@@ -53,16 +104,14 @@ export function DensityGrid({
   const cap = summary.capabilities;
   const insiderActive = activeProviders(cap.insider ?? EMPTY_CELL).length > 0;
   const dividendProviders = activeProviders(cap.dividends ?? EMPTY_CELL);
+  const filingsActive = activeProviders(cap.filings ?? EMPTY_CELL).length > 0;
+  const fundamentalsActive = hasFundamentalsActive(summary);
   const hasNarrative = summary.has_sec_cik;
+  const hasThesis = thesis !== null || thesisErrored;
   const navigate = useNavigate();
   const [overviewParams] = useSearchParams();
 
   const drillToWorkspace = () => {
-    // Preserve the operator's currently-selected overview range when
-    // expanding to the full chart workspace. PriceChart syncs its
-    // range to ?chart=<id> on the instrument page; ChartPage reads
-    // ?range=<id>. Translate the param name across the boundary so
-    // a non-default range survives the route change.
     const overviewRange = overviewParams.get("chart");
     const target = `/instrument/${encodeURIComponent(symbol)}/chart`;
     const url =
@@ -72,156 +121,159 @@ export function DensityGrid({
     navigate(url);
   };
 
-  // Card-click drill removed (#601 follow-up): the PaneHeader's
-  // "Open →" button is the only drill affordance now. Operator
-  // reported the whole-card click was firing accidentally on chart
-  // hover/zoom.
-  const ChartPane = (
-    <Pane title="Price chart" onExpand={drillToWorkspace} fillHeight>
-      <PriceChart symbol={symbol} instrumentId={instrumentId} />
-    </Pane>
+  // ---- Top hero row: chart (col-span-8, row-span-2) + KeyStats +
+  // SecProfile stacked on the right. PriceChart's tall row-span keeps
+  // the chart visually anchored; KeyStats and SecProfile share the
+  // narrow right rail.
+  const heroRow = (
+    <>
+      <div className="col-span-12 lg:col-span-8 lg:row-span-2">
+        <Pane title="Price chart" onExpand={drillToWorkspace} fillHeight>
+          <PriceChart symbol={symbol} instrumentId={instrumentId} />
+        </Pane>
+      </div>
+      <div className="col-span-12 lg:col-span-4">
+        <KeyStatsPane summary={summary} />
+      </div>
+      {hasNarrative && (
+        <div className="col-span-12 lg:col-span-4">
+          <SecProfilePanel symbol={symbol} />
+        </div>
+      )}
+    </>
   );
+
+  // ---- Stat-block row: Filings + Insider + Dividends. Each
+  // null-outs independently when its capability is inactive; the
+  // allocator re-flows so the row always fills.
+  const statTiles: TileSpec[] = [
+    {
+      key: "filings",
+      present: filingsActive,
+      content: () => (
+        <FilingsPane
+          instrumentId={instrumentId}
+          symbol={symbol}
+          summary={summary}
+        />
+      ),
+    },
+    {
+      key: "insider",
+      present: insiderActive,
+      content: () => <InsiderActivitySummary symbol={symbol} />,
+    },
+    {
+      key: "dividends",
+      present: dividendProviders.length > 0,
+      content: () => (
+        <>
+          {dividendProviders.map((p) => (
+            <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
+          ))}
+        </>
+      ),
+    },
+  ];
+
+  // ---- Mid row: Fundamentals + RecentNews paired when both
+  // present (fundamentals takes 2/3, news 1/3 — the 4 sparkline
+  // cells fit a wide tile, news list reads fine in a narrower one).
+  // When only one is present, allocator gives it the full row.
+  const midTiles: TileSpec[] = [
+    {
+      key: "fundamentals",
+      present: fundamentalsActive,
+      content: () => <FundamentalsPane summary={summary} />,
+    },
+    {
+      key: "news",
+      present: true, // news pane has its own empty state; always show
+      content: () => <RecentNewsPane instrumentId={instrumentId} symbol={symbol} />,
+    },
+  ];
+  // Override the standard 6+6 split when fundamentals is present —
+  // the 4-cell sparkline strip wants 8 cols, news is happy with 4.
+  const midRow =
+    fundamentalsActive ? (
+      <>
+        <div className="col-span-12 lg:col-span-8">
+          <FundamentalsPane summary={summary} />
+        </div>
+        <div className="col-span-12 lg:col-span-4">
+          <RecentNewsPane instrumentId={instrumentId} symbol={symbol} />
+        </div>
+      </>
+    ) : (
+      allocateTiles(midTiles)
+    );
+
+  // ---- Long-form footer: narrative (when has_sec_cik) + thesis
+  // (when present). Each is full-width because the inner content
+  // already caps at max-w-prose.
+  const narrativeRow = hasNarrative ? (
+    <div className="col-span-12">
+      <BusinessSectionsTeaser symbol={symbol} />
+    </div>
+  ) : null;
+
+  const thesisRow = hasThesis ? (
+    <div className="col-span-12">
+      <ThesisPane thesis={thesis} errored={thesisErrored} />
+    </div>
+  ) : null;
 
   if (profile === "full-sec") {
     return (
-      <div className="grid grid-cols-12 gap-2">
-        <div className="col-span-12 lg:col-span-8 lg:row-span-2">{ChartPane}</div>
-        <div className="col-span-12 lg:col-span-4">
-          <KeyStatsPane summary={summary} />
-        </div>
-        {hasNarrative && (
-          <div className="col-span-12 lg:col-span-4">
-            <SecProfilePanel symbol={symbol} />
-          </div>
-        )}
-        <div className="col-span-12">
-          {/* full-sec profile guarantees sec_xbrl fundamentals + filings are active per selectProfile */}
-          <FundamentalsPane summary={summary} />
-        </div>
-        <div className="col-span-12 lg:col-span-7">
-          <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
-        </div>
-        {insiderActive && (
-          <div className="col-span-12 lg:col-span-5">
-            <InsiderActivitySummary symbol={symbol} />
-          </div>
-        )}
-        {/* BusinessSections narrative stays full-width (long-form
-            content reads fine wide). Dividends panel caps at 6 cols
-            so its narrow stat-block doesn't stretch — was previously
-            paired with narrative but DividendsPanel and
-            BusinessSectionsTeaser each null-out independently when
-            their own data is empty, which would have left a 5-column
-            ghost slot in mixed-coverage states (#684 review). */}
-        {hasNarrative && (
-          <div className="col-span-12">
-            <BusinessSectionsTeaser symbol={symbol} />
-          </div>
-        )}
-        {dividendProviders.length > 0 && (
-          <div className="col-span-12 lg:col-span-6">
-            {dividendProviders.map((p) => (
-              <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
-            ))}
-          </div>
-        )}
-        <div className="col-span-12">
-          <RecentNewsPane instrumentId={instrumentId} symbol={symbol} />
-        </div>
-        {thesis !== null || thesisErrored ? (
-          <div className="col-span-12">
-            <ThesisPane thesis={thesis} errored={thesisErrored} />
-          </div>
-        ) : null}
+      <div className="grid grid-cols-12 gap-3">
+        {heroRow}
+        {midRow}
+        {allocateTiles(statTiles)}
+        {narrativeRow}
+        {thesisRow}
       </div>
     );
   }
 
   if (profile === "partial-filings") {
+    // Same shape minus the fundamentals pane in midRow.
     return (
-      <div className="grid grid-cols-12 gap-2">
-        <div className="col-span-12 lg:col-span-8 lg:row-span-2">{ChartPane}</div>
-        <div className="col-span-12 lg:col-span-4">
-          <KeyStatsPane summary={summary} />
-        </div>
-        {hasNarrative && (
-          <div className="col-span-12 lg:col-span-4">
-            <SecProfilePanel symbol={symbol} />
-          </div>
-        )}
-        {hasFundamentalsActive(summary) && (
-          <div className="col-span-12">
-            <FundamentalsPane summary={summary} />
-          </div>
-        )}
-        {activeProviders(cap.filings ?? EMPTY_CELL).length > 0 && (
-          <div className="col-span-12">
-            <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
-          </div>
-        )}
-        {insiderActive && dividendProviders.length > 0 ? (
-          <>
-            <div className="col-span-12 lg:col-span-7">
-              <InsiderActivitySummary symbol={symbol} />
-            </div>
-            <div className="col-span-12 lg:col-span-5">
-              {dividendProviders.map((p) => (
-                <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
-              ))}
-            </div>
-          </>
-        ) : insiderActive ? (
-          <div className="col-span-12">
-            <InsiderActivitySummary symbol={symbol} />
-          </div>
-        ) : dividendProviders.length > 0 ? (
-          // Standalone dividends pane caps at 6 cols so a narrow
-          // stat-block doesn't stretch across the viewport (#684
-          // operator review).
-          <div className="col-span-12 lg:col-span-6">
-            {dividendProviders.map((p) => (
-              <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
-            ))}
-          </div>
-        ) : null}
-        {hasNarrative && (
-          <div className="col-span-12">
-            <BusinessSectionsTeaser symbol={symbol} />
-          </div>
-        )}
-        <div className="col-span-12">
-          <RecentNewsPane instrumentId={instrumentId} symbol={symbol} />
-        </div>
-        {thesis !== null || thesisErrored ? (
-          <div className="col-span-12">
-            <ThesisPane thesis={thesis} errored={thesisErrored} />
-          </div>
-        ) : null}
+      <div className="grid grid-cols-12 gap-3">
+        {heroRow}
+        {midRow}
+        {allocateTiles(statTiles)}
+        {narrativeRow}
+        {thesisRow}
       </div>
     );
   }
 
-  // minimal
+  // minimal — no SEC fundamentals, no filings. The hero row gives us
+  // PriceChart (8x2) + KeyStats (4) on top; place ThesisPane in the
+  // right-rail 4-col slot below KeyStats so the chart's row-span-2
+  // gap fills, mirroring the SecProfile pattern in full-sec.
   return (
-    <div className="grid grid-cols-12 gap-2">
-      <div className="col-span-12 lg:col-span-8 lg:row-span-2">{ChartPane}</div>
-      <div className="col-span-12 lg:col-span-4">
-        <KeyStatsPane summary={summary} />
-      </div>
-      {(thesis !== null || thesisErrored) && (
+    <div className="grid grid-cols-12 gap-3">
+      {heroRow}
+      {hasThesis && (
         <div className="col-span-12 lg:col-span-4">
           <ThesisPane thesis={thesis} errored={thesisErrored} />
         </div>
       )}
       {dividendProviders.length > 0 && (
-        // Minimal-profile dividends caps at 6 cols too (#684).
         <div className="col-span-12 lg:col-span-6">
           {dividendProviders.map((p) => (
             <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
           ))}
         </div>
       )}
-      <div className="col-span-12">
+      <div
+        className={
+          dividendProviders.length > 0
+            ? "col-span-12 lg:col-span-6"
+            : "col-span-12"
+        }
+      >
         <RecentNewsPane instrumentId={instrumentId} symbol={symbol} />
       </div>
     </div>

--- a/frontend/src/components/instrument/DividendsPanel.test.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.test.tsx
@@ -90,17 +90,24 @@ describe("DividendsPanel", () => {
     expect(screen.getByText("40")).toBeInTheDocument();
   });
 
-  it("returns null when history is empty AND upcoming is empty", async () => {
+  it("renders an in-pane empty state when history is empty AND upcoming is empty (#684 round 3)", async () => {
+    // Was: returned null. Changed to render the Pane chrome with an
+    // empty-state line so the bento grid's allocator doesn't reserve
+    // a phantom column for a pane that disappears at runtime.
     mockFetch.mockResolvedValueOnce({
       symbol: "X",
       summary: { has_dividend: false } as never,
       history: [],
       upcoming: [],
     } as never);
-    const { container } = wrap(
-      <DividendsPanel symbol="X" provider="sec_dividend_summary" />,
-    );
-    await waitFor(() => expect(container.firstChild).toBeNull());
+    wrap(<DividendsPanel symbol="X" provider="sec_dividend_summary" />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /No dividend history or upcoming dividends on file/i,
+        ),
+      ).toBeInTheDocument();
+    });
   });
 
   it("renders Pane when history is empty but upcoming has 1 item", async () => {

--- a/frontend/src/components/instrument/DividendsPanel.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.tsx
@@ -48,9 +48,11 @@ export function DividendsPanel({ symbol, provider }: DividendsPanelProps) {
     [symbol, provider],
   );
 
-  // Empty case: data loaded, no history AND no upcoming → no card at all.
-  // This implements the four-state empty-pane policy: capability active but
-  // no current and no forward signal → render null.
+  // Empty case: data loaded, no history AND no upcoming → render an
+  // in-pane empty state instead of null. Returning null left the
+  // bento grid's pre-allocated column blank (operator-visible dead
+  // space — #684 round 3 Codex finding). The empty-state card carries
+  // honest "no dividend history" copy + the same Pane chrome.
   if (
     !state.loading &&
     state.error === null &&
@@ -58,7 +60,24 @@ export function DividendsPanel({ symbol, provider }: DividendsPanelProps) {
     state.data.history.length === 0 &&
     state.data.upcoming.length === 0
   ) {
-    return null;
+    // Match the populated card's chrome — provider provenance + the
+    // Open→ drill stay so the operator can still navigate to the
+    // L2 dividends page for context, even with no data here.
+    return (
+      <Pane
+        title="Dividends"
+        source={{ providers: [provider] }}
+        onExpand={() =>
+          navigate(
+            `/instrument/${encodeURIComponent(symbol)}/dividends?provider=${encodeURIComponent(provider)}`,
+          )
+        }
+      >
+        <p className="text-xs text-slate-500">
+          No dividend history or upcoming dividends on file.
+        </p>
+      </Pane>
+    );
   }
 
   const last4 =

--- a/frontend/src/components/instrument/Pane.tsx
+++ b/frontend/src/components/instrument/Pane.tsx
@@ -47,10 +47,16 @@ export function Pane({
   const clickable = onCardClick !== undefined;
   // Build the article className from atomic segments so optional
   // segments do not leave double spaces when omitted.
+  // Bento-aesthetic chrome (#684 round 3): rounded-xl (12px) per
+  // ui-ux-pro-max guidance — distinctive without being cartoonish.
+  // ``transition-shadow`` on every pane gives a subtle hover lift
+  // even on non-clickable cards, signalling "this is a tile in a
+  // bento grid" without the layout-shifting hover-scale that #687
+  // explicitly avoided.
   const articleCls = [
-    "rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm",
+    "rounded-xl border border-slate-200 bg-white px-3 py-2.5 shadow-sm transition-shadow hover:shadow-md",
     fillHeight ? "flex h-full flex-col" : null,
-    clickable ? "cursor-pointer transition hover:border-slate-300 hover:shadow-md" : null,
+    clickable ? "cursor-pointer hover:border-slate-300" : null,
     className ?? null,
   ]
     .filter((x): x is string => x !== null)

--- a/frontend/src/components/instrument/RecentNewsPane.test.tsx
+++ b/frontend/src/components/instrument/RecentNewsPane.test.tsx
@@ -46,16 +46,23 @@ describe("RecentNewsPane", () => {
     expect(items.length).toBeLessThanOrEqual(5);
   });
 
-  it("returns null when feed is empty (no card)", async () => {
+  it("renders an in-pane empty state when feed is empty (#684 round 3)", async () => {
+    // Was: returned null. Changed to render the Pane chrome with an
+    // empty-state line so the bento grid's allocator doesn't reserve
+    // a phantom column for a pane that disappears at runtime.
     vi.spyOn(newsApi, "fetchNews").mockResolvedValueOnce({
       items: [],
       total: 0,
     } as never);
-    const { container } = render(
+    render(
       <MemoryRouter>
         <RecentNewsPane instrumentId={1} symbol="X" />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(container.firstChild).toBeNull());
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No news on file for this instrument/i),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/instrument/RecentNewsPane.tsx
+++ b/frontend/src/components/instrument/RecentNewsPane.tsx
@@ -38,8 +38,18 @@ export function RecentNewsPane({
       </Pane>
     );
   }
+  // Render an in-pane empty state instead of returning null so the
+  // bento grid's allocator doesn't reserve a phantom column for the
+  // pane and leave operator-visible dead space (#684 round 3 — Codex
+  // finding 2). The "no news yet" copy is more honest than a hole.
   if (state.data === null || state.data.items.length === 0) {
-    return null;
+    return (
+      <Pane title="Recent news">
+        <p className="text-xs text-slate-500">
+          No news on file for this instrument.
+        </p>
+      </Pane>
+    );
   }
 
   const items = state.data.items.slice(0, ROW_LIMIT);


### PR DESCRIPTION
Operator review against #686 + #687: dividends panel still sat at half-width with empty grid cell beside it; mid-page sparkline strip stretched all 4 cells across 12 cols. Operator: \"these should be bento boxes\" — invoked \`/ui-ux-pro-max\` skill, picked the **Bento Box Grid** pattern (Apple/dashboard tile aesthetic, varied 1×1 / 2×1 spans, rounded-xl chrome, subtle hover lift).

## Three changes

### 1. \`DensityGrid\` bento allocator

New \`allocateTiles()\` helper filters out absent panes BEFORE the grid sees them and assigns deterministic column spans by surviving count:

| Surviving | Spans          |
|-----------|----------------|
| 1         | col-span-12    |
| 2         | 6 + 6          |
| 3         | 4 + 4 + 4      |
| 4         | 3 + 3 + 3 + 3  |

Stat-block row (Filings + Insider + Dividends) routes through it so the row always fills regardless of which subset is present.

Mid row pairs **Fundamentals (8) + RecentNews (4)** when fundamentals active — the 4-cell sparkline strip wants the wider tile, news list reads fine in the narrower one. Falls through to news-only when fundamentals inactive.

Minimal profile puts \`ThesisPane\` in the \`lg:col-span-4\` right-rail slot under KeyStats, mirroring the SecProfile pattern in full-sec.

### 2. Late-null-render ghost cells fixed

\`RecentNewsPane\` + \`DividendsPanel\` previously returned \`null\` when data was empty post-load — left the bento grid's pre-allocated column blank (Codex caught this). Both now render Pane chrome with an in-pane empty state. \`DividendsPanel\` keeps its provider source tag + \`Open →\` drill in the empty case so the operator can still navigate to the L2 page.

### 3. Pane chrome bento aesthetic

\`rounded-md\` → \`rounded-xl\` + \`transition-shadow\` + \`hover:shadow-md\` per ui-ux-pro-max guidance. Subtle hover lift on every card without the layout-shifting hover-scale that #687 explicitly avoided.

## Test plan

- \`pnpm --dir frontend typecheck\` — clean
- \`pnpm --dir frontend test:unit\` — 732 pass (2 tests updated for new empty-state contract)
- Codex 2 rounds: round-1 caught minimal-profile right-rail dead-end + ghost cells (resolved); round-2 caught empty DividendsPanel losing source/onExpand props (resolved). 
- Manual: reload \`/instrument/IEP\` — Filings + Insider + Dividends should fill row 4+4+4 cleanly; Fundamentals strip + News should pair 8+4; no empty grid cells when capability is on but data is empty.

## Out of scope

The right-rail-thesis pattern is currently minimal-profile-only. If operator wants thesis in the right rail across other profiles, that's a small follow-up.