### PR TITLE
feat: design-system v1 — borderless Pane, real Recharts on Fundamentals, bento v4 row order

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Tells dark-mode browser extensions (Dark Reader, browser auto-darken)
+      that the site is light-mode-native. Without this hint, those tools
+      fight our contrast — making opaque bg-white panels translucent and
+      letting scrolled content bleed through sticky headers (operator
+      report, design-system v1). Native dark mode tracked separately.
+    -->
+    <meta name="color-scheme" content="only light" />
     <title>eBull</title>
   </head>
   <body class="bg-slate-50 text-slate-900 antialiased">

--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -262,6 +262,82 @@ describe("DensityGrid profiles", () => {
     expect(navigateMock).toHaveBeenCalledWith("/instrument/GME/chart?range=5y");
   });
 
+  it("v4 health row: Fundamentals + Dividends pair as 6+6 when both active (full-sec)", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={makeSummary({
+            fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: true } },
+            filings: { providers: ["sec_edgar"], data_present: { sec_edgar: true } },
+            dividends: { providers: ["sec_dividend_summary"], data_present: { sec_dividend_summary: true } },
+          })}
+          thesis={null}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    // Both Health-zone slots are present and each carries lg:col-span-6,
+    // i.e. neither pane stretches full-width and neither leaves a gap.
+    const fundamentalsSlot = screen.getByText("Fundamentals").closest("div.col-span-12");
+    const dividendsSlot = screen.getByText("Dividends").closest("div.col-span-12");
+    expect(fundamentalsSlot?.className).toContain("lg:col-span-6");
+    expect(dividendsSlot?.className).toContain("lg:col-span-6");
+    // Sanity: container has the v1 design-system grid spacing (gap-x-8 gap-y-6).
+    const grid = container.querySelector(".grid.grid-cols-12");
+    expect(grid?.className).toContain("gap-x-8");
+    expect(grid?.className).toContain("gap-y-6");
+  });
+
+  it("v4 activity row: Filings + Insider pair as 6+6 when both active", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={makeSummary({
+            fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: true } },
+            filings: { providers: ["sec_edgar"], data_present: { sec_edgar: true } },
+            insider: { providers: ["sec_form4"], data_present: { sec_form4: true } },
+          })}
+          thesis={null}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    const filingsSlot = screen.getByText(/Recent filings/).closest("div.col-span-12");
+    const insiderSlot = screen.getByText(/Insider summary/).closest("div.col-span-12");
+    expect(filingsSlot?.className).toContain("lg:col-span-6");
+    expect(insiderSlot?.className).toContain("lg:col-span-6");
+  });
+
+  it("v4 zone B: BusinessSections sits directly under the hero (full-sec), not at page bottom", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={makeSummary({
+            fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: true } },
+            filings: { providers: ["sec_edgar"], data_present: { sec_edgar: true } },
+          })}
+          thesis={null}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    // Reading priority sequence in the DOM: hero → narrative → health → activity →
+    // news → thesis. Assert narrative appears BEFORE fundamentals/filings/news.
+    const narrative = screen.getByText(/Company narrative/);
+    const fundamentals = screen.getByText("Fundamentals");
+    const filings = screen.getByText(/Recent filings/);
+    const news = screen.getByText("Recent news");
+    expect(narrative.compareDocumentPosition(fundamentals)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(narrative.compareDocumentPosition(filings)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(narrative.compareDocumentPosition(news)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
   it("clicking the chart card body does NOT drill — only Open button drills (#601 follow-up)", async () => {
     navigateMock.mockClear();
     const user = userEvent.setup();

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -1,19 +1,33 @@
 /**
- * DensityGrid — 12-column capability-aware grid for the instrument
+ * DensityGrid — capability-aware 12-col grid for the instrument
  * Research tab (#575). Three profiles determine which panes render:
  *
  *   full-sec        — fundamentals (sec_xbrl) + filings active
  *   partial-filings — filings active but no sec_xbrl fundamentals
  *   minimal         — no filings capability at all
  *
- * PriceChart and KeyStatsPane are present in all profiles.
- * SecProfilePanel / BusinessSectionsTeaser gate on has_sec_cik.
- * FundamentalsPane is exclusive to the full-sec profile.
- * FilingsPane / InsiderActivitySummary / DividendsPanel / RecentNewsPane
- * / ThesisPane appear in profile-specific positions.
+ * Design-system v1 row order (operator review): the page is a five-zone
+ * editorial spread from top to bottom, ordered by operator scan
+ * priority for a held instrument:
  *
- * No overflow-auto scroll-boxes: every pane expands to content height
- * so the grid stays a true content-driven layout.
+ *   Zone A — Hero      :  Price chart (visual anchor), Key stats,
+ *                         SEC profile (identity rail under stats)
+ *   Zone B — Identity  :  10-K narrative (BusinessSections) — what is
+ *                         this company? Reads like a column inch under
+ *                         the hero rather than buried at page bottom.
+ *   Zone C — Health    :  Fundamentals + Dividends paired 6+6 — read
+ *                         financial trajectory and shareholder return
+ *                         together in one scan.
+ *   Zone D — Activity  :  Filings + Insider paired 6+6 — what's
+ *                         happening right now. Recent news full-width
+ *                         below since news lists scan vertically.
+ *   Zone E — Operator  :  Thesis pane — operator's own call, last so
+ *                         it doesn't anchor your read of the data.
+ *
+ * Pane chrome itself is borderless (Pane.tsx — design-system v1):
+ * the grid reads as one continuous editorial spread, not a card grid.
+ *
+ * No overflow-auto scroll-boxes anywhere — content drives height.
  */
 
 import type { InstrumentSummary, ThesisDetail } from "@/api/types";
@@ -52,7 +66,9 @@ export function DensityGrid({
   const profile = selectProfile(summary);
   const cap = summary.capabilities;
   const insiderActive = activeProviders(cap.insider ?? EMPTY_CELL).length > 0;
+  const filingsActive = activeProviders(cap.filings ?? EMPTY_CELL).length > 0;
   const dividendProviders = activeProviders(cap.dividends ?? EMPTY_CELL);
+  const fundamentalsActive = hasFundamentalsActive(summary);
   const hasNarrative = summary.has_sec_cik;
   const navigate = useNavigate();
   const [overviewParams] = useSearchParams();
@@ -73,18 +89,50 @@ export function DensityGrid({
   };
 
   // Card-click drill removed (#601 follow-up): the PaneHeader's
-  // "Open →" button is the only drill affordance now. Operator
-  // reported the whole-card click was firing accidentally on chart
-  // hover/zoom.
+  // "Open →" button is the only drill affordance now.
   const ChartPane = (
     <Pane title="Price chart" onExpand={drillToWorkspace} fillHeight>
       <PriceChart symbol={symbol} instrumentId={instrumentId} />
     </Pane>
   );
 
+  const HealthRow = renderHealthRow({
+    fundamentalsActive,
+    fundamentalsNode: fundamentalsActive ? (
+      <FundamentalsPane summary={summary} />
+    ) : null,
+    dividendProviders,
+    dividendsNode:
+      dividendProviders.length > 0 ? (
+        <>
+          {dividendProviders.map((p) => (
+            <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
+          ))}
+        </>
+      ) : null,
+  });
+
+  const ActivityRow = renderActivityRow({
+    filingsActive,
+    filingsNode: filingsActive ? (
+      <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
+    ) : null,
+    insiderActive,
+    insiderNode: insiderActive ? (
+      <InsiderActivitySummary symbol={symbol} />
+    ) : null,
+  });
+
+  // Inter-pane vertical gap is 6 (gap-y-6) — without card borders, the
+  // hairline rules need breathing room above/below to read as section
+  // breaks. Horizontal gap-x-8 lets paired panes (Fund+Div, Fil+Ins)
+  // sit as discrete columns without their hairlines visually merging.
+  const gridCls = "grid grid-cols-12 gap-x-8 gap-y-6";
+
   if (profile === "full-sec") {
     return (
-      <div className="grid grid-cols-12 gap-2">
+      <div className={gridCls}>
+        {/* Zone A — Hero */}
         <div className="col-span-12 lg:col-span-8 lg:row-span-2">{ChartPane}</div>
         <div className="col-span-12 lg:col-span-4">
           <KeyStatsPane summary={summary} />
@@ -94,40 +142,20 @@ export function DensityGrid({
             <SecProfilePanel symbol={symbol} />
           </div>
         )}
-        <div className="col-span-12">
-          {/* full-sec profile guarantees sec_xbrl fundamentals + filings are active per selectProfile */}
-          <FundamentalsPane summary={summary} />
-        </div>
-        <div className="col-span-12 lg:col-span-7">
-          <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
-        </div>
-        {insiderActive && (
-          <div className="col-span-12 lg:col-span-5">
-            <InsiderActivitySummary symbol={symbol} />
-          </div>
-        )}
-        {/* BusinessSections narrative stays full-width (long-form
-            content reads fine wide). Dividends panel caps at 6 cols
-            so its narrow stat-block doesn't stretch — was previously
-            paired with narrative but DividendsPanel and
-            BusinessSectionsTeaser each null-out independently when
-            their own data is empty, which would have left a 5-column
-            ghost slot in mixed-coverage states (#684 review). */}
+        {/* Zone B — Identity */}
         {hasNarrative && (
           <div className="col-span-12">
             <BusinessSectionsTeaser symbol={symbol} />
           </div>
         )}
-        {dividendProviders.length > 0 && (
-          <div className="col-span-12 lg:col-span-6">
-            {dividendProviders.map((p) => (
-              <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
-            ))}
-          </div>
-        )}
+        {/* Zone C — Health */}
+        {HealthRow}
+        {/* Zone D — Activity */}
+        {ActivityRow}
         <div className="col-span-12">
           <RecentNewsPane instrumentId={instrumentId} symbol={symbol} />
         </div>
+        {/* Zone E — Operator */}
         {thesis !== null || thesisErrored ? (
           <div className="col-span-12">
             <ThesisPane thesis={thesis} errored={thesisErrored} />
@@ -139,7 +167,8 @@ export function DensityGrid({
 
   if (profile === "partial-filings") {
     return (
-      <div className="grid grid-cols-12 gap-2">
+      <div className={gridCls}>
+        {/* Zone A — Hero */}
         <div className="col-span-12 lg:col-span-8 lg:row-span-2">{ChartPane}</div>
         <div className="col-span-12 lg:col-span-4">
           <KeyStatsPane summary={summary} />
@@ -149,49 +178,20 @@ export function DensityGrid({
             <SecProfilePanel symbol={symbol} />
           </div>
         )}
-        {hasFundamentalsActive(summary) && (
-          <div className="col-span-12">
-            <FundamentalsPane summary={summary} />
-          </div>
-        )}
-        {activeProviders(cap.filings ?? EMPTY_CELL).length > 0 && (
-          <div className="col-span-12">
-            <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
-          </div>
-        )}
-        {insiderActive && dividendProviders.length > 0 ? (
-          <>
-            <div className="col-span-12 lg:col-span-7">
-              <InsiderActivitySummary symbol={symbol} />
-            </div>
-            <div className="col-span-12 lg:col-span-5">
-              {dividendProviders.map((p) => (
-                <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
-              ))}
-            </div>
-          </>
-        ) : insiderActive ? (
-          <div className="col-span-12">
-            <InsiderActivitySummary symbol={symbol} />
-          </div>
-        ) : dividendProviders.length > 0 ? (
-          // Standalone dividends pane caps at 6 cols so a narrow
-          // stat-block doesn't stretch across the viewport (#684
-          // operator review).
-          <div className="col-span-12 lg:col-span-6">
-            {dividendProviders.map((p) => (
-              <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
-            ))}
-          </div>
-        ) : null}
+        {/* Zone B — Identity (only when narrative source exists) */}
         {hasNarrative && (
           <div className="col-span-12">
             <BusinessSectionsTeaser symbol={symbol} />
           </div>
         )}
+        {/* Zone C — Health (fundamentals optional in partial profile) */}
+        {HealthRow}
+        {/* Zone D — Activity */}
+        {ActivityRow}
         <div className="col-span-12">
           <RecentNewsPane instrumentId={instrumentId} symbol={symbol} />
         </div>
+        {/* Zone E — Operator */}
         {thesis !== null || thesisErrored ? (
           <div className="col-span-12">
             <ThesisPane thesis={thesis} errored={thesisErrored} />
@@ -201,9 +201,11 @@ export function DensityGrid({
     );
   }
 
-  // minimal
+  // minimal profile — no filings/fundamentals/narrative. Hero + thesis
+  // in the right rail (fills the row-2 slot under KeyStats), then the
+  // small set of remaining panes the operator might still have.
   return (
-    <div className="grid grid-cols-12 gap-2">
+    <div className={gridCls}>
       <div className="col-span-12 lg:col-span-8 lg:row-span-2">{ChartPane}</div>
       <div className="col-span-12 lg:col-span-4">
         <KeyStatsPane summary={summary} />
@@ -214,7 +216,6 @@ export function DensityGrid({
         </div>
       )}
       {dividendProviders.length > 0 && (
-        // Minimal-profile dividends caps at 6 cols too (#684).
         <div className="col-span-12 lg:col-span-6">
           {dividendProviders.map((p) => (
             <DividendsPanel key={`div-${p}`} symbol={symbol} provider={p} />
@@ -226,4 +227,71 @@ export function DensityGrid({
       </div>
     </div>
   );
+}
+
+/** Health zone — Fundamentals + Dividends. Pairs at 6+6 when both
+ *  capabilities are active; otherwise the surviving pane caps at 6
+ *  cols so a narrow stat-block doesn't stretch full-width. */
+function renderHealthRow({
+  fundamentalsActive,
+  fundamentalsNode,
+  dividendProviders,
+  dividendsNode,
+}: {
+  readonly fundamentalsActive: boolean;
+  readonly fundamentalsNode: JSX.Element | null;
+  readonly dividendProviders: ReadonlyArray<string>;
+  readonly dividendsNode: JSX.Element | null;
+}): JSX.Element | null {
+  const hasDividends = dividendProviders.length > 0;
+  if (fundamentalsActive && hasDividends) {
+    return (
+      <>
+        <div className="col-span-12 lg:col-span-6">{fundamentalsNode}</div>
+        <div className="col-span-12 lg:col-span-6">{dividendsNode}</div>
+      </>
+    );
+  }
+  if (fundamentalsActive) {
+    // Fundamentals alone fills wide — its 4 charts benefit from
+    // horizontal room (2x2 inside a 12-col container becomes
+    // wider per-cell than 2x2 in a 6-col container).
+    return <div className="col-span-12">{fundamentalsNode}</div>;
+  }
+  if (hasDividends) {
+    return <div className="col-span-12 lg:col-span-6">{dividendsNode}</div>;
+  }
+  return null;
+}
+
+/** Activity zone — Filings + Insider. Pairs at 6+6 when both are
+ *  active. Filings alone goes full-width (list scans wide fine);
+ *  insider alone caps at 6 since the 5-stat strip looks stretched
+ *  full-width. */
+function renderActivityRow({
+  filingsActive,
+  filingsNode,
+  insiderActive,
+  insiderNode,
+}: {
+  readonly filingsActive: boolean;
+  readonly filingsNode: JSX.Element | null;
+  readonly insiderActive: boolean;
+  readonly insiderNode: JSX.Element | null;
+}): JSX.Element | null {
+  if (filingsActive && insiderActive) {
+    return (
+      <>
+        <div className="col-span-12 lg:col-span-6">{filingsNode}</div>
+        <div className="col-span-12 lg:col-span-6">{insiderNode}</div>
+      </>
+    );
+  }
+  if (filingsActive) {
+    return <div className="col-span-12">{filingsNode}</div>;
+  }
+  if (insiderActive) {
+    return <div className="col-span-12 lg:col-span-6">{insiderNode}</div>;
+  }
+  return null;
 }

--- a/frontend/src/components/instrument/DividendsPanel.test.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.test.tsx
@@ -90,17 +90,21 @@ describe("DividendsPanel", () => {
     expect(screen.getByText("40")).toBeInTheDocument();
   });
 
-  it("returns null when history is empty AND upcoming is empty", async () => {
+  it("renders an in-pane empty state when history AND upcoming are empty (design-system v1)", async () => {
+    // Was: returned null. Codex review of design-system v1 caught
+    // that this left a dead 6-col slot in the bento Health row.
     mockFetch.mockResolvedValueOnce({
       symbol: "X",
       summary: { has_dividend: false } as never,
       history: [],
       upcoming: [],
     } as never);
-    const { container } = wrap(
-      <DividendsPanel symbol="X" provider="sec_dividend_summary" />,
-    );
-    await waitFor(() => expect(container.firstChild).toBeNull());
+    wrap(<DividendsPanel symbol="X" provider="sec_dividend_summary" />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No dividend history or upcoming dividends on file/i),
+      ).toBeInTheDocument();
+    });
   });
 
   it("renders Pane when history is empty but upcoming has 1 item", async () => {

--- a/frontend/src/components/instrument/DividendsPanel.tsx
+++ b/frontend/src/components/instrument/DividendsPanel.tsx
@@ -8,8 +8,13 @@
  *   - DividendsSummaryBlock (TTM yield / TTM DPS / Latest DPS / Streak)
  *   - Last 4 HistoryBar rows
  *
- * Four-state empty rule: return null when both history and upcoming are
- * empty after data settles (capability active, no current/forward signal).
+ * Empty-state policy (Codex review of design-system v1): when both
+ * history and upcoming are empty after data settles we render Pane
+ * chrome with an empty-state line rather than null. Returning null
+ * left an empty `lg:col-span-6` slot in the bento grid's Health row
+ * (operator-visible dead space). Provider source + Open→ are
+ * preserved so the operator can still drill through to the L2
+ * dividends page for context.
  */
 
 import { fetchInstrumentDividends } from "@/api/instruments";
@@ -48,9 +53,10 @@ export function DividendsPanel({ symbol, provider }: DividendsPanelProps) {
     [symbol, provider],
   );
 
-  // Empty case: data loaded, no history AND no upcoming → no card at all.
-  // This implements the four-state empty-pane policy: capability active but
-  // no current and no forward signal → render null.
+  // Empty case: data loaded, no history AND no upcoming → render Pane
+  // chrome with empty-state copy (carry source + onExpand so operator
+  // can still drill to L2). Returning null would leave a dead 6-col
+  // slot in the bento Health row.
   if (
     !state.loading &&
     state.error === null &&
@@ -58,7 +64,21 @@ export function DividendsPanel({ symbol, provider }: DividendsPanelProps) {
     state.data.history.length === 0 &&
     state.data.upcoming.length === 0
   ) {
-    return null;
+    return (
+      <Pane
+        title="Dividends"
+        source={{ providers: [provider] }}
+        onExpand={() =>
+          navigate(
+            `/instrument/${encodeURIComponent(symbol)}/dividends?provider=${encodeURIComponent(provider)}`,
+          )
+        }
+      >
+        <p className="text-xs text-slate-500">
+          No dividend history or upcoming dividends on file.
+        </p>
+      </Pane>
+    );
   }
 
   const last4 =

--- a/frontend/src/components/instrument/FundamentalsPane.test.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.test.tsx
@@ -184,7 +184,9 @@ describe("FundamentalsPane", () => {
     expect(await screen.findByText(/180/)).toBeInTheDocument();
   });
 
-  it("returns null when capability active but joined series is empty (e.g. SEC ingest before any quarters)", async () => {
+  it("renders an in-pane empty state when capability active but joined series is empty (design-system v1)", async () => {
+    // Was: returned null. Codex review of design-system v1 caught
+    // that this left a dead 6-col wrapper in the bento Health row.
     vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
       ((_symbol: string, query: { statement: string }) =>
         Promise.resolve({
@@ -196,12 +198,16 @@ describe("FundamentalsPane", () => {
           rows: [],
         })) as never,
     );
-    const { container } = render(
+    render(
       <MemoryRouter>
         <FundamentalsPane summary={makeSummary(true)} />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(container.firstChild).toBeNull());
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Insufficient quarterly history yet/i),
+      ).toBeInTheDocument();
+    });
   });
 
   it("renders the pane for partnership/MLP issuers that don't file operating_income (#684)", async () => {
@@ -301,7 +307,7 @@ describe("FundamentalsPane", () => {
     expect(await screen.findByText("2/4")).toBeInTheDocument();
   });
 
-  it("returns null when capability active but only 1 quarter has both income + balance data", async () => {
+  it("renders an in-pane empty state when capability active but only 1 quarter has data (design-system v1)", async () => {
     vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
       ((_symbol: string, query: { statement: string }) => {
         if (query.statement === "income") {
@@ -336,11 +342,15 @@ describe("FundamentalsPane", () => {
         });
       }) as never,
     );
-    const { container } = render(
+    render(
       <MemoryRouter>
         <FundamentalsPane summary={makeSummary(true)} />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(container.firstChild).toBeNull());
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Insufficient quarterly history yet/i),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -455,7 +455,19 @@ function FundamentalCell({
               />
               <Tooltip
                 cursor={{ stroke: chartTheme.crosshair, strokeWidth: 1, strokeDasharray: "3 3" }}
-                formatter={(value: number) => [formatBigNumber(value), label]}
+                formatter={(value) => {
+                  // Recharts ValueType is string | number | (string|number)[].
+                  // For null-valued points we expect Recharts to skip the
+                  // tooltip row, but coerce defensively so the formatter
+                  // signature is honest about every value Recharts can pass.
+                  const n =
+                    typeof value === "number"
+                      ? value
+                      : typeof value === "string" && value !== ""
+                        ? Number(value)
+                        : null;
+                  return [formatBigNumber(Number.isFinite(n) ? n : null), label];
+                }}
                 labelFormatter={formatPeriodTick}
                 contentStyle={{
                   fontSize: "11px",

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -3,17 +3,27 @@
  * Op income, Net income, Total debt) over the latest 8 quarters from
  * SEC XBRL fundamentals (#567).
  *
- * Design-system v1 redesign (operator review): replaced the four
- * 120×36 sparklines with full Recharts AreaCharts (~h-24, gradient
- * fill, hover tooltip, period x-axis ticks). Asymmetric "lead +
- * supporting" was rejected because financial scanning is comparison-
- * driven — operators read 4 metrics side-by-side to spot trajectory
- * divergence (revenue up + FCF flat → working-capital problem). Equal
- * visual weight is correct for that scan.
+ * Design-system v1 redesign (operator review): replaced four 120×36
+ * sparklines with full Recharts AreaCharts (~h-24, gradient fill,
+ * hover tooltip, period x-axis ticks). Asymmetric "lead + supporting"
+ * was rejected because financial scanning is comparison-driven —
+ * operators read 4 metrics side-by-side to spot trajectory divergence
+ * (revenue up + FCF flat → working-capital problem). Equal visual
+ * weight is correct for that scan.
  *
- * Per-cell coverage caption preserved (PR #684 review): when one
- * cell's period count diverges from siblings, the cell footer notes
- * `n/N periods` so the operator sees the time-axis asymmetry.
+ * Sparse-period honesty (Codex review): each cell keeps every row
+ * from `series` with `value: null` for missing quarters. AreaChart
+ * uses `connectNulls={false}` so the line breaks at gaps, and the
+ * x-axis spacing reflects actual reporting cadence rather than
+ * collapsing missing quarters into adjacent ones.
+ *
+ * YoY / QoQ delta: lookback uses period_end dates (~365 days back
+ * with ±45-day tolerance) rather than array-index, so a missing
+ * quarter mid-history doesn't get silently labelled YoY.
+ *
+ * Per-cell coverage caption preserved (PR #684 review): when this
+ * metric has fewer non-null values than the joined series length,
+ * the cell footer notes `n/N quarters`.
  *
  * Gating: `summary.capabilities.fundamentals.providers` includes
  * "sec_xbrl" with `data_present.sec_xbrl === true`. Hooks fire
@@ -25,6 +35,12 @@
  * Per-cell null filtering means revenue + net_income still render
  * even when operating_income is null on every row — pre-fix the
  * strict joinPeriods gate dropped every row and hid the entire pane.
+ *
+ * Insufficient-data empty state (Codex review): when the joined
+ * series has <2 rows we still render the Pane chrome with an
+ * empty-state line. Returning null left an empty `lg:col-span-6`
+ * wrapper in the Health row of the bento grid (operator-visible
+ * dead space). Same rationale as DividendsPanel/RecentNewsPane.
  */
 
 import {
@@ -41,7 +57,7 @@ import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { Pane } from "@/components/instrument/Pane";
 import { chartTheme } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
-import { useCallback, useMemo } from "react";
+import { useCallback, useId, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 const SLICE = 8;
@@ -104,21 +120,34 @@ function joinPeriods(
 
 interface CellPoint {
   readonly period_end: string;
-  readonly value: number;
+  readonly value: number | null;
 }
 
-/** Filter the per-period series down to non-null cell points for one
- *  metric, preserving period_end so the chart x-axis is honest. */
+/** Map the joined series to per-cell points keeping every period
+ *  (including those with null values for this metric) so the chart
+ *  x-axis spacing reflects actual reporting cadence. Recharts will
+ *  skip null values when ``connectNulls={false}``. */
 function buildCellPoints(
   series: ReadonlyArray<SeriesRow>,
   pick: (row: SeriesRow) => number | null,
 ): CellPoint[] {
-  const out: CellPoint[] = [];
-  for (const row of series) {
-    const v = pick(row);
-    if (v !== null) out.push({ period_end: row.period_end, value: v });
+  return series.map((row) => ({
+    period_end: row.period_end,
+    value: pick(row),
+  }));
+}
+
+function nonNullCount(points: ReadonlyArray<CellPoint>): number {
+  let n = 0;
+  for (const p of points) if (p.value !== null) n += 1;
+  return n;
+}
+
+function lastNonNullIndex(points: ReadonlyArray<CellPoint>): number {
+  for (let i = points.length - 1; i >= 0; i--) {
+    if (points[i]!.value !== null) return i;
   }
-  return out;
+  return -1;
 }
 
 function formatBigNumber(n: number | null): string {
@@ -144,26 +173,56 @@ function formatPeriodTick(period_end: string): string {
   return period_end;
 }
 
-/** Year-over-year delta for the latest period. Uses index-4 lookback
- *  when 4 prior quarters are available (true YoY); falls back to
- *  period-over-period when the series is too short for YoY. Returns
- *  null when prior is zero (undefined growth). */
+const ONE_DAY_MS = 86400000;
+
+/** Year-over-year delta against the row whose period_end is ~365 days
+ *  earlier (±45-day window — covers fiscal-year ending day shifts and
+ *  thirteen-week quarters). Falls back to QoQ when no YoY-distance
+ *  prior row exists. Returns null when fewer than 2 non-null points
+ *  or when the prior is zero (undefined growth).
+ *
+ *  Codex review: array-index lookback was wrong because
+ *  buildCellPoints used to drop null rows — index 5 back could mean
+ *  any number of calendar quarters. Date-based lookup is robust to
+ *  sparse coverage. */
 function yoyDelta(points: ReadonlyArray<CellPoint>): {
   readonly pct: number;
   readonly label: "YoY" | "QoQ";
 } | null {
-  if (points.length < 2) return null;
-  const last = points[points.length - 1]!.value;
-  // YoY: lookback 4 quarters when available — financially meaningful
-  // for quarterly fundamentals where seasonality dominates QoQ.
-  if (points.length >= 5) {
-    const prior = points[points.length - 5]!.value;
-    if (prior === 0) return null;
-    return { pct: ((last - prior) / Math.abs(prior)) * 100, label: "YoY" };
+  const lastIdx = lastNonNullIndex(points);
+  if (lastIdx < 0) return null;
+  const lastPoint = points[lastIdx]!;
+  const lastVal = lastPoint.value!;
+  const lastTs = Date.parse(lastPoint.period_end);
+  if (!Number.isFinite(lastTs)) return null;
+  // Look for a prior non-null row whose period_end is roughly one
+  // year before. Walk backward from lastIdx so the closest match wins.
+  for (let i = lastIdx - 1; i >= 0; i--) {
+    const p = points[i]!;
+    if (p.value === null) continue;
+    const ts = Date.parse(p.period_end);
+    if (!Number.isFinite(ts)) continue;
+    const diffDays = (lastTs - ts) / ONE_DAY_MS;
+    if (diffDays >= 320 && diffDays <= 410) {
+      if (p.value === 0) return null;
+      return {
+        pct: ((lastVal - p.value) / Math.abs(p.value)) * 100,
+        label: "YoY",
+      };
+    }
   }
-  const prev = points[points.length - 2]!.value;
-  if (prev === 0) return null;
-  return { pct: ((last - prev) / Math.abs(prev)) * 100, label: "QoQ" };
+  // QoQ fallback: immediate previous non-null point.
+  for (let i = lastIdx - 1; i >= 0; i--) {
+    const p = points[i]!;
+    if (p.value !== null) {
+      if (p.value === 0) return null;
+      return {
+        pct: ((lastVal - p.value) / Math.abs(p.value)) * 100,
+        label: "QoQ",
+      };
+    }
+  }
+  return null;
 }
 
 export interface FundamentalsPaneProps {
@@ -211,24 +270,38 @@ export function FundamentalsPane({ summary }: FundamentalsPaneProps): JSX.Elemen
 
   if (!active) return null;
 
-  // Capability active but the joined series is too short to plot.
-  // Return null — four-state empty rule: capability active + zero
-  // data is a SEC-ingest-running-but-no-quarters-yet state, not an
-  // operator-actionable empty case worth its own chrome.
-  const insufficient =
+  const onExpand = () => navigate(`/instrument/${encodeURIComponent(symbol)}/fundamentals`);
+  const settled =
     !income.loading &&
     !balance.loading &&
     income.error === null &&
-    balance.error === null &&
-    series.length < 2;
-  if (insufficient) return null;
+    balance.error === null;
+
+  // Capability active but the joined series is too short to plot —
+  // render the Pane chrome with empty-state copy rather than null.
+  // Returning null left an empty col-span-6 wrapper in the bento
+  // Health row (operator-visible dead space). #684 round-3 policy.
+  if (settled && series.length < 2) {
+    return (
+      <Pane
+        title="Fundamentals"
+        scope="last 8 quarters"
+        source={{ providers: ["sec_xbrl"] }}
+        onExpand={onExpand}
+      >
+        <p className="text-xs text-slate-500">
+          Insufficient quarterly history yet for this instrument.
+        </p>
+      </Pane>
+    );
+  }
 
   return (
     <Pane
       title="Fundamentals"
       scope="last 8 quarters"
       source={{ providers: ["sec_xbrl"] }}
-      onExpand={() => navigate(`/instrument/${encodeURIComponent(symbol)}/fundamentals`)}
+      onExpand={onExpand}
     >
       {income.loading || balance.loading ? (
         <SectionSkeleton rows={3} />
@@ -250,41 +323,48 @@ function FundamentalsGrid({
   const opIncome = buildCellPoints(series, (r) => r.operatingIncome);
   const netIncome = buildCellPoints(series, (r) => r.netIncome);
   const totalDebt = buildCellPoints(series, (r) => r.totalDebt);
-  // Cells share an x-axis only visually — when one cell has fewer
-  // periods than siblings (e.g. an MLP with operating_income null on
-  // every quarter), shapes can't be compared directly. Surface a
-  // ``n/N periods`` caption on cells whose coverage diverges from
-  // the maximum so the operator notices the asymmetry. PR #684 review.
-  const maxLen = Math.max(
-    revenue.length,
-    opIncome.length,
-    netIncome.length,
-    totalDebt.length,
-  );
+  // Coverage = non-null entries against the full series length. When
+  // a metric is missing in some quarters (e.g. MLP issuer with
+  // operating_income null on every row) the cell footer notes the
+  // shortfall so the operator notices the time-axis asymmetry.
+  // PR #684 review.
+  const totalLen = series.length;
+  // useId() per-instance hash so that two FundamentalsPane components
+  // mounted in the same document don't collide on gradient ids in
+  // <defs>. Codex review caught the prior label-only id was global.
+  const idPrefix = useId().replace(/[^a-z0-9]/gi, "");
   return (
     <div className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
       <FundamentalCell
         label="Revenue"
+        idPrefix={idPrefix}
         points={revenue}
-        maxLen={maxLen}
+        nonNull={nonNullCount(revenue)}
+        totalLen={totalLen}
         fillColor={chartTheme.accent[1]}
       />
       <FundamentalCell
         label="Op income"
+        idPrefix={idPrefix}
         points={opIncome}
-        maxLen={maxLen}
+        nonNull={nonNullCount(opIncome)}
+        totalLen={totalLen}
         fillColor={chartTheme.up}
       />
       <FundamentalCell
         label="Net income"
+        idPrefix={idPrefix}
         points={netIncome}
-        maxLen={maxLen}
+        nonNull={nonNullCount(netIncome)}
+        totalLen={totalLen}
         fillColor={chartTheme.up}
       />
       <FundamentalCell
         label="Total debt"
+        idPrefix={idPrefix}
         points={totalDebt}
-        maxLen={maxLen}
+        nonNull={nonNullCount(totalDebt)}
+        totalLen={totalLen}
         fillColor={chartTheme.accent[3]}
       />
     </div>
@@ -293,21 +373,23 @@ function FundamentalsGrid({
 
 function FundamentalCell({
   label,
+  idPrefix,
   points,
-  maxLen,
+  nonNull,
+  totalLen,
   fillColor,
 }: {
   readonly label: string;
+  readonly idPrefix: string;
   readonly points: ReadonlyArray<CellPoint>;
-  /** Largest period count across sibling cells. When this cell's
-   *  ``points.length`` is smaller, the chart x-axis can't be compared
-   *  directly to siblings — surface a coverage caption. */
-  readonly maxLen: number;
+  readonly nonNull: number;
+  readonly totalLen: number;
   readonly fillColor: string;
 }) {
-  const showCoverage = points.length > 0 && points.length < maxLen;
+  const showCoverage = nonNull > 0 && nonNull < totalLen;
   const delta = yoyDelta(points);
-  const latestVal = points.length > 0 ? points[points.length - 1]!.value : null;
+  const lastIdx = lastNonNullIndex(points);
+  const latestVal = lastIdx >= 0 ? points[lastIdx]!.value : null;
   const deltaClass =
     delta === null
       ? "text-slate-400"
@@ -316,9 +398,9 @@ function FundamentalCell({
         : delta.pct < 0
           ? "text-rose-600"
           : "text-slate-500";
-  // Recharts gradient id must be unique per chart instance — collisions
-  // pollute the gradient defs and cells render with wrong fills.
-  const gradId = `fund-grad-${label.replace(/[^a-z]/gi, "")}`;
+  // Per-instance + per-label gradient id (Codex review): two
+  // FundamentalsPane instances in the same DOM previously collided.
+  const gradId = `fund-grad-${idPrefix}-${label.replace(/[^a-z]/gi, "")}`;
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex items-baseline justify-between gap-2">
@@ -328,9 +410,9 @@ function FundamentalCell({
         {showCoverage ? (
           <span
             className="text-[9px] uppercase tracking-wider text-amber-600"
-            title={`This cell covers ${points.length} of the ${maxLen} periods rendered by sibling cells.`}
+            title={`This metric reported ${nonNull} of the ${totalLen} quarters in view.`}
           >
-            {points.length}/{maxLen}
+            {nonNull}/{totalLen}
           </span>
         ) : null}
       </div>
@@ -348,7 +430,7 @@ function FundamentalCell({
           </span>
         ) : null}
       </div>
-      {points.length >= 2 ? (
+      {nonNull >= 2 ? (
         <div style={{ height: CELL_HEIGHT }} className="w-full">
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart
@@ -387,6 +469,7 @@ function FundamentalCell({
                 stroke={fillColor}
                 strokeWidth={1.75}
                 fill={`url(#${gradId})`}
+                connectNulls={false}
                 isAnimationActive={false}
               />
             </AreaChart>

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -1,33 +1,59 @@
 /**
- * FundamentalsPane — 4 sparklines (Revenue / Op income / Net income /
- * Total debt) over the latest 8 quarters from SEC XBRL fundamentals
- * (#567). Gated on `summary.capabilities.fundamentals.providers` including
- * "sec_xbrl" with `data_present.sec_xbrl === true` so non-SEC instruments
- * don't render a dead pane.
+ * FundamentalsPane — 2×2 editorial grid of real charts (Revenue,
+ * Op income, Net income, Total debt) over the latest 8 quarters from
+ * SEC XBRL fundamentals (#567).
  *
- * Data path: 2 parallel calls to /instruments/{symbol}/financials —
- * one for income, one for balance — joined per (period_end, period_type)
- * to keep all four sparklines on the same quarter set.
+ * Design-system v1 redesign (operator review): replaced the four
+ * 120×36 sparklines with full Recharts AreaCharts (~h-24, gradient
+ * fill, hover tooltip, period x-axis ticks). Asymmetric "lead +
+ * supporting" was rejected because financial scanning is comparison-
+ * driven — operators read 4 metrics side-by-side to spot trajectory
+ * divergence (revenue up + FCF flat → working-capital problem). Equal
+ * visual weight is correct for that scan.
+ *
+ * Per-cell coverage caption preserved (PR #684 review): when one
+ * cell's period count diverges from siblings, the cell footer notes
+ * `n/N periods` so the operator sees the time-axis asymmetry.
+ *
+ * Gating: `summary.capabilities.fundamentals.providers` includes
+ * "sec_xbrl" with `data_present.sec_xbrl === true`. Hooks fire
+ * unconditionally; the active-flag check happens after the data is
+ * fetched (or while loading shows a skeleton).
+ *
+ * MLP/partnership issuers (e.g. IEP) file
+ * `IncomeLossFromContinuingOperations` instead of `OperatingIncomeLoss`.
+ * Per-cell null filtering means revenue + net_income still render
+ * even when operating_income is null on every row — pre-fix the
+ * strict joinPeriods gate dropped every row and hid the entire pane.
  */
+
+import {
+  Area,
+  AreaChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+} from "recharts";
 
 import { fetchInstrumentFinancials } from "@/api/instruments";
 import type { InstrumentFinancialRow, InstrumentSummary } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { Pane } from "@/components/instrument/Pane";
-import { Sparkline } from "@/components/instrument/Sparkline";
+import { chartTheme } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
 import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 const SLICE = 8;
+const CELL_HEIGHT = 96;
 
 interface SeriesRow {
   readonly period_end: string;
   // Each metric is independently nullable. Per-cell render filters its
   // own column rather than the whole row dropping when one column is
   // missing — partnership/MLP issuers like IEP file
-  // `IncomeLossFromContinuingOperations` instead of the standard
-  // `OperatingIncomeLoss`, leaving operating_income null on every row,
+  // ``IncomeLossFromContinuingOperations`` instead of the standard
+  // ``OperatingIncomeLoss``, leaving operating_income null on every row,
   // which previously hid the entire pane (#684 operator report).
   readonly revenue: number | null;
   readonly operatingIncome: number | null;
@@ -57,11 +83,6 @@ function joinPeriods(
     const netIncome = num(i.values["net_income"] ?? null);
     const lt = b !== undefined ? num(b.values["long_term_debt"] ?? null) : null;
     const st = b !== undefined ? num(b.values["short_term_debt"] ?? null) : null;
-    // Drop a row only when every income-side flagship metric is null
-    // — otherwise the pane has nothing to plot. Total debt is a
-    // best-effort sum (if either component is non-null we surface
-    // what we have; balance-side gaps don't kill the income-side
-    // sparklines).
     if (revenue === null && operatingIncome === null && netIncome === null) {
       continue;
     }
@@ -75,38 +96,74 @@ function joinPeriods(
       totalDebt,
     });
   }
-  // Sort newest first then take the latest SLICE; reverse so the
-  // sparklines plot oldest → newest left → right.
   joined.sort((a, b) => (a.period_end < b.period_end ? 1 : -1));
   const latest = joined.slice(0, SLICE);
   latest.reverse();
   return latest;
 }
 
-/** Filter the per-period series down to non-null values for one
- *  metric. Empty array means "this issuer doesn't report this metric"
- *  — the cell renders an em dash + a small "no data" hint. */
-function nonNullValues(
+interface CellPoint {
+  readonly period_end: string;
+  readonly value: number;
+}
+
+/** Filter the per-period series down to non-null cell points for one
+ *  metric, preserving period_end so the chart x-axis is honest. */
+function buildCellPoints(
   series: ReadonlyArray<SeriesRow>,
   pick: (row: SeriesRow) => number | null,
-): number[] {
-  const out: number[] = [];
+): CellPoint[] {
+  const out: CellPoint[] = [];
   for (const row of series) {
     const v = pick(row);
-    if (v !== null) out.push(v);
+    if (v !== null) out.push({ period_end: row.period_end, value: v });
   }
   return out;
 }
 
-function formatLatest(values: ReadonlyArray<number>): string {
-  if (values.length === 0) return "—";
-  // length > 0 is guaranteed above; cast away the possible-undefined
-  // that TypeScript infers from array index access in strict mode.
-  const v = values[values.length - 1] as number;
-  if (Math.abs(v) >= 1e9) return `${(v / 1e9).toFixed(2)}B`;
-  if (Math.abs(v) >= 1e6) return `${(v / 1e6).toFixed(2)}M`;
-  if (Math.abs(v) >= 1e3) return `${(v / 1e3).toFixed(2)}K`;
-  return v.toFixed(0);
+function formatBigNumber(n: number | null): string {
+  if (n === null) return "—";
+  const abs = Math.abs(n);
+  const sign = n < 0 ? "-" : "";
+  if (abs >= 1e12) return `${sign}${(abs / 1e12).toFixed(2)}T`;
+  if (abs >= 1e9) return `${sign}${(abs / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${sign}${(abs / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${sign}${(abs / 1e3).toFixed(2)}K`;
+  return n.toFixed(0);
+}
+
+function formatPeriodTick(period_end: string): string {
+  // SEC XBRL emits YYYY-MM-DD — slice safe.
+  const months = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+  const m = Number(period_end.slice(5, 7));
+  const y = period_end.slice(2, 4);
+  if (m >= 1 && m <= 12) return `${months[m - 1]} '${y}`;
+  return period_end;
+}
+
+/** Year-over-year delta for the latest period. Uses index-4 lookback
+ *  when 4 prior quarters are available (true YoY); falls back to
+ *  period-over-period when the series is too short for YoY. Returns
+ *  null when prior is zero (undefined growth). */
+function yoyDelta(points: ReadonlyArray<CellPoint>): {
+  readonly pct: number;
+  readonly label: "YoY" | "QoQ";
+} | null {
+  if (points.length < 2) return null;
+  const last = points[points.length - 1]!.value;
+  // YoY: lookback 4 quarters when available — financially meaningful
+  // for quarterly fundamentals where seasonality dominates QoQ.
+  if (points.length >= 5) {
+    const prior = points[points.length - 5]!.value;
+    if (prior === 0) return null;
+    return { pct: ((last - prior) / Math.abs(prior)) * 100, label: "YoY" };
+  }
+  const prev = points[points.length - 2]!.value;
+  if (prev === 0) return null;
+  return { pct: ((last - prev) / Math.abs(prev)) * 100, label: "QoQ" };
 }
 
 export interface FundamentalsPaneProps {
@@ -154,10 +211,10 @@ export function FundamentalsPane({ summary }: FundamentalsPaneProps): JSX.Elemen
 
   if (!active) return null;
 
-  // Capability active but the joined series is too short to plot — return
-  // null to follow the polish round-2 four-state empty rule (no full
-  // empty-state cards on the instrument page). Loading + error states
-  // still render the Pane so the operator sees the chrome.
+  // Capability active but the joined series is too short to plot.
+  // Return null — four-state empty rule: capability active + zero
+  // data is a SEC-ingest-running-but-no-quarters-yet state, not an
+  // operator-actionable empty case worth its own chrome.
   const insufficient =
     !income.loading &&
     !balance.loading &&
@@ -189,114 +246,160 @@ function FundamentalsGrid({
 }: {
   readonly series: ReadonlyArray<SeriesRow>;
 }): JSX.Element {
-  const revenueValues = nonNullValues(series, (r) => r.revenue);
-  const opIncomeValues = nonNullValues(series, (r) => r.operatingIncome);
-  const netIncomeValues = nonNullValues(series, (r) => r.netIncome);
-  const totalDebtValues = nonNullValues(series, (r) => r.totalDebt);
-  // Sparklines are side-by-side and share an x-axis only visually —
-  // when one cell has fewer periods than the siblings (e.g. an MLP
-  // with operating_income null on every quarter), shapes can't be
-  // compared directly. Surface a "n/N periods" caption on cells
-  // whose coverage diverges from the maximum so the operator notices
-  // the asymmetry. PR #684 review.
+  const revenue = buildCellPoints(series, (r) => r.revenue);
+  const opIncome = buildCellPoints(series, (r) => r.operatingIncome);
+  const netIncome = buildCellPoints(series, (r) => r.netIncome);
+  const totalDebt = buildCellPoints(series, (r) => r.totalDebt);
+  // Cells share an x-axis only visually — when one cell has fewer
+  // periods than siblings (e.g. an MLP with operating_income null on
+  // every quarter), shapes can't be compared directly. Surface a
+  // ``n/N periods`` caption on cells whose coverage diverges from
+  // the maximum so the operator notices the asymmetry. PR #684 review.
   const maxLen = Math.max(
-    revenueValues.length,
-    opIncomeValues.length,
-    netIncomeValues.length,
-    totalDebtValues.length,
+    revenue.length,
+    opIncome.length,
+    netIncome.length,
+    totalDebt.length,
   );
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+    <div className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
       <FundamentalCell
         label="Revenue"
-        values={revenueValues}
+        points={revenue}
         maxLen={maxLen}
-        stroke="text-sky-500"
+        fillColor={chartTheme.accent[1]}
       />
       <FundamentalCell
         label="Op income"
-        values={opIncomeValues}
+        points={opIncome}
         maxLen={maxLen}
-        stroke="text-emerald-500"
+        fillColor={chartTheme.up}
       />
       <FundamentalCell
         label="Net income"
-        values={netIncomeValues}
+        points={netIncome}
         maxLen={maxLen}
-        stroke="text-emerald-500"
+        fillColor={chartTheme.up}
       />
       <FundamentalCell
         label="Total debt"
-        values={totalDebtValues}
+        points={totalDebt}
         maxLen={maxLen}
-        stroke="text-amber-500"
+        fillColor={chartTheme.accent[3]}
       />
     </div>
   );
 }
 
-/** Period-over-period delta as a percentage. Sign carried by the
- *  display layer; null when fewer than 2 points OR when prior is
- *  zero (undefined growth). */
-function periodDelta(values: ReadonlyArray<number>): number | null {
-  if (values.length < 2) return null;
-  const prev = values[values.length - 2]!;
-  const last = values[values.length - 1]!;
-  if (prev === 0) return null;
-  return ((last - prev) / Math.abs(prev)) * 100;
-}
-
 function FundamentalCell({
   label,
-  values,
+  points,
   maxLen,
-  stroke,
+  fillColor,
 }: {
   readonly label: string;
-  readonly values: ReadonlyArray<number>;
+  readonly points: ReadonlyArray<CellPoint>;
   /** Largest period count across sibling cells. When this cell's
-   *  ``values.length`` is smaller, the shapes between sparklines
-   *  can't be compared directly — surface a coverage caption. */
+   *  ``points.length`` is smaller, the chart x-axis can't be compared
+   *  directly to siblings — surface a coverage caption. */
   readonly maxLen: number;
-  readonly stroke: string;
+  readonly fillColor: string;
 }) {
-  const showCoverage = values.length > 0 && values.length < maxLen;
-  const delta = periodDelta(values);
+  const showCoverage = points.length > 0 && points.length < maxLen;
+  const delta = yoyDelta(points);
+  const latestVal = points.length > 0 ? points[points.length - 1]!.value : null;
   const deltaClass =
     delta === null
       ? "text-slate-400"
-      : delta > 0
+      : delta.pct > 0
         ? "text-emerald-600"
-        : delta < 0
-          ? "text-red-600"
+        : delta.pct < 0
+          ? "text-rose-600"
           : "text-slate-500";
+  // Recharts gradient id must be unique per chart instance — collisions
+  // pollute the gradient defs and cells render with wrong fills.
+  const gradId = `fund-grad-${label.replace(/[^a-z]/gi, "")}`;
   return (
-    <div className="flex flex-col items-start gap-0.5">
-      <span className="flex w-full items-baseline justify-between gap-2">
-        <span className="text-[10px] uppercase tracking-wider text-slate-500">
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-[10px] uppercase tracking-[0.08em] text-slate-500">
           {label}
         </span>
         {showCoverage ? (
           <span
             className="text-[9px] uppercase tracking-wider text-amber-600"
-            title={`This cell covers ${values.length} of the ${maxLen} periods rendered by sibling cells.`}
+            title={`This cell covers ${points.length} of the ${maxLen} periods rendered by sibling cells.`}
           >
-            {values.length}/{maxLen}
+            {points.length}/{maxLen}
           </span>
         ) : null}
-      </span>
-      <Sparkline values={values} width={120} height={36} className={stroke} />
-      <span className="flex items-baseline gap-1.5">
-        <span className="text-sm font-semibold tabular-nums text-slate-800">
-          {formatLatest(values)}
+      </div>
+      <div className="flex items-baseline gap-2">
+        <span className="text-xl font-semibold tabular-nums text-slate-900">
+          {formatBigNumber(latestVal)}
         </span>
         {delta !== null ? (
-          <span className={`text-[10px] font-medium tabular-nums ${deltaClass}`}>
-            {delta > 0 ? "▲" : delta < 0 ? "▼" : "·"}
-            {Math.abs(delta).toFixed(1)}%
+          <span className={`text-[11px] font-medium tabular-nums ${deltaClass}`}>
+            {delta.pct > 0 ? "▲" : delta.pct < 0 ? "▼" : "·"}
+            {Math.abs(delta.pct).toFixed(1)}%
+            <span className="ml-1 text-[9px] uppercase tracking-wider text-slate-400">
+              {delta.label}
+            </span>
           </span>
         ) : null}
-      </span>
+      </div>
+      {points.length >= 2 ? (
+        <div style={{ height: CELL_HEIGHT }} className="w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart
+              data={points as CellPoint[]}
+              margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
+            >
+              <defs>
+                <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor={fillColor} stopOpacity={0.35} />
+                  <stop offset="100%" stopColor={fillColor} stopOpacity={0.02} />
+                </linearGradient>
+              </defs>
+              <XAxis
+                dataKey="period_end"
+                tickFormatter={formatPeriodTick}
+                interval="preserveStartEnd"
+                minTickGap={28}
+                tick={{ fill: chartTheme.textMuted, fontSize: 9 }}
+                stroke={chartTheme.borderColor}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip
+                cursor={{ stroke: chartTheme.crosshair, strokeWidth: 1, strokeDasharray: "3 3" }}
+                formatter={(value: number) => [formatBigNumber(value), label]}
+                labelFormatter={formatPeriodTick}
+                contentStyle={{
+                  fontSize: "11px",
+                  borderColor: chartTheme.borderColor,
+                  borderRadius: 4,
+                }}
+              />
+              <Area
+                type="monotone"
+                dataKey="value"
+                stroke={fillColor}
+                strokeWidth={1.75}
+                fill={`url(#${gradId})`}
+                isAnimationActive={false}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      ) : (
+        <div
+          style={{ height: CELL_HEIGHT }}
+          className="flex w-full items-center justify-center text-[10px] uppercase tracking-wider text-slate-400"
+        >
+          insufficient history
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/instrument/Pane.tsx
+++ b/frontend/src/components/instrument/Pane.tsx
@@ -8,32 +8,44 @@ export interface PaneProps extends PaneHeaderProps {
   /** Optional className overrides on the outer article. */
   readonly className?: string;
   /**
-   * Optional whole-card click handler. When provided, the Pane gets a
-   * cursor-pointer + hover-elevate affordance and clicking anywhere on
-   * the card invokes the handler. Internal interactive controls (e.g.
-   * range pickers) must call `e.stopPropagation()` so they don't also
-   * trigger this handler. The PaneHeader's "Open →" button stops
-   * propagation automatically — see PaneHeader.tsx.
+   * Optional whole-card click handler. When provided, clicking anywhere
+   * on the card invokes the handler. Internal interactive controls
+   * (range pickers, etc.) must call `e.stopPropagation()` so they don't
+   * also fire this handler. PaneHeader's "Open →" button stops
+   * propagation automatically.
    *
    * Accessibility: the article does NOT receive `role="button"` or
-   * `tabIndex` because it contains real `<button>` descendants
-   * (PaneHeader Open button, in-pane controls). Nesting interactive
-   * elements inside a custom button is an ARIA violation and can
-   * cause assistive tech to flatten the inner controls. Keyboard
-   * users navigate via the inner Open button instead — that button
-   * is always rendered when `onExpand` is provided, so the drill is
-   * keyboard-reachable without needing a card-level handler.
+   * `tabIndex` because it contains real `<button>` descendants. Nesting
+   * interactive elements inside a custom button is an ARIA violation
+   * and assistive tech may flatten the inner controls. Keyboard users
+   * navigate via the inner Open button instead.
    */
   readonly onCardClick?: () => void;
   /**
    * Stretch the pane (and its single child) to fill the parent grid
    * cell vertically. Use when the cell uses `lg:row-span-N` to span
-   * multiple rows — without this, the child sits at its intrinsic
-   * height and leaves whitespace below when the right rail is taller.
+   * multiple rows.
    */
   readonly fillHeight?: boolean;
 }
 
+/**
+ * Pane — borderless editorial chrome (design-system v1).
+ *
+ * Replaces the prior rounded card (border + shadow + bg-white) with a
+ * single hairline rule on top + a small-caps title row. The grid reads
+ * as one continuous editorial spread instead of a Trello-board of
+ * tiles, which suits financial data (operators scan across panes
+ * looking for cross-pane signal: revenue trend → dividend yield →
+ * insider buying — that's one document, not separate cards).
+ *
+ * Visual grouping comes from the top rule + title pair, not from a
+ * bordered box. Hover affordance for clickable panes is a subtle
+ * slate-50 tint, not a shadow lift (no layout shift).
+ *
+ * Horizontal padding is zero so the rule extends edge-to-edge of the
+ * grid cell — the parent grid container owns horizontal rhythm.
+ */
 export function Pane({
   title,
   scope,
@@ -45,17 +57,17 @@ export function Pane({
   children,
 }: PaneProps): JSX.Element {
   const clickable = onCardClick !== undefined;
-  // Build the article className from atomic segments so optional
-  // segments do not leave double spaces when omitted.
+  // Atomic className segments — null entries are filtered so optional
+  // pieces do not leave double spaces when omitted.
   const articleCls = [
-    "rounded-md border border-slate-200 bg-white px-3 py-2.5 shadow-sm",
+    "border-t border-slate-200 pt-3 pb-1",
     fillHeight ? "flex h-full flex-col" : null,
-    clickable ? "cursor-pointer transition hover:border-slate-300 hover:shadow-md" : null,
+    clickable ? "cursor-pointer transition-colors hover:bg-slate-50/60" : null,
     className ?? null,
   ]
     .filter((x): x is string => x !== null)
     .join(" ");
-  const childCls = fillHeight ? "mt-2 flex min-h-0 flex-1 flex-col" : "mt-2";
+  const childCls = fillHeight ? "mt-3 flex min-h-0 flex-1 flex-col" : "mt-3";
   return (
     <article
       className={articleCls}

--- a/frontend/src/components/instrument/PaneHeader.tsx
+++ b/frontend/src/components/instrument/PaneHeader.tsx
@@ -8,13 +8,25 @@ export interface PaneHeaderProps {
     readonly lastSync?: string;
   };
   /**
-   * Renders an "Open →" button. The handler is invoked on click; the
-   * click event's propagation is stopped so an enclosing Pane with
-   * `onCardClick` doesn't also fire.
+   * Renders an "Open →" button. Click handler is invoked on click;
+   * propagation is stopped so an enclosing Pane with `onCardClick`
+   * doesn't also fire.
    */
   readonly onExpand?: () => void;
 }
 
+/**
+ * PaneHeader — small-caps editorial title row (design-system v1).
+ *
+ * Lives directly under the Pane's hairline top-rule with no extra
+ * border-bottom — the rule above the title is the visual section
+ * marker. Tracking-[0.08em] (slightly tighter than tracking-widest)
+ * keeps the small-caps feeling intentional without going into
+ * decorative-label territory.
+ *
+ * Open button uses amber-500 hover (Bloomberg-echo accent reserved
+ * for interactivity) instead of sky — keeps blue free for charts.
+ */
 export function PaneHeader({
   title,
   scope,
@@ -27,9 +39,9 @@ export function PaneHeader({
         (source.lastSync ? ` · ${source.lastSync}` : "")
       : null;
   return (
-    <header className="flex items-baseline justify-between gap-2 border-b border-slate-100 pb-1.5">
+    <header className="flex items-baseline justify-between gap-2">
       <div className="flex min-w-0 items-baseline gap-2">
-        <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-600">
+        <h2 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-700">
           {title}
         </h2>
         {scope ? (
@@ -39,7 +51,7 @@ export function PaneHeader({
       <div className="flex flex-shrink-0 items-center gap-2">
         {sourceText !== null ? (
           <span
-            className="truncate rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600"
+            className="truncate text-[10px] uppercase tracking-wide text-slate-400"
             title={sourceText}
           >
             {sourceText}
@@ -52,7 +64,7 @@ export function PaneHeader({
               e.stopPropagation();
               onExpand();
             }}
-            className="text-[11px] text-sky-700 hover:underline focus-visible:rounded focus-visible:outline-2 focus-visible:outline-sky-500"
+            className="text-[11px] font-medium text-slate-600 transition-colors hover:text-amber-600 focus-visible:rounded focus-visible:outline-2 focus-visible:outline-amber-500"
           >
             Open →
           </button>

--- a/frontend/src/components/instrument/RecentNewsPane.test.tsx
+++ b/frontend/src/components/instrument/RecentNewsPane.test.tsx
@@ -46,16 +46,23 @@ describe("RecentNewsPane", () => {
     expect(items.length).toBeLessThanOrEqual(5);
   });
 
-  it("returns null when feed is empty (no card)", async () => {
+  it("renders an in-pane empty state when feed is empty (design-system v1)", async () => {
+    // Was: returned null. Codex review of design-system v1 caught
+    // that this left a dead grid slot since DensityGrid reserves
+    // space from capability flags, not runtime render decisions.
     vi.spyOn(newsApi, "fetchNews").mockResolvedValueOnce({
       items: [],
       total: 0,
     } as never);
-    const { container } = render(
+    render(
       <MemoryRouter>
         <RecentNewsPane instrumentId={1} symbol="X" />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(container.firstChild).toBeNull());
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No news on file for this instrument/i),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/instrument/RecentNewsPane.tsx
+++ b/frontend/src/components/instrument/RecentNewsPane.tsx
@@ -38,8 +38,18 @@ export function RecentNewsPane({
       </Pane>
     );
   }
+  // Empty case: data loaded, zero items → render Pane chrome with
+  // empty-state copy (Codex review of design-system v1). Returning
+  // null left a dead full-width row in the bento grid since the
+  // capability flag had already reserved the slot.
   if (state.data === null || state.data.items.length === 0) {
-    return null;
+    return (
+      <Pane title="Recent news">
+        <p className="text-xs text-slate-500">
+          No news on file for this instrument.
+        </p>
+      </Pane>
+    );
   }
 
   const items = state.data.items.slice(0, ROW_LIMIT);


### PR DESCRIPTION
## What

Three coordinated changes responding to operator feedback that the instrument page felt basic and tile-y:

1. **Pane.tsx — borderless editorial chrome.** Drops rounded-md/border/bg-white/shadow card. Replaces with a hairline top-rule + small-caps title row. Hover affordance for clickable panes is a `bg-slate-50/60` tint, not a shadow lift.
2. **PaneHeader.tsx — refined small-caps + amber accent.** 11px tracking-[0.08em] title; `Open →` hover transitions to `amber-600` (Bloomberg-echo accent reserved for interactivity, keeps blue free for charts); provider source becomes a quiet 10px slate-400 line, no pill chrome.
3. **FundamentalsPane.tsx — 2×2 real Recharts AreaCharts.** Replaces 120×36 sparklines with full charts (~h-24, gradient fill, hover tooltip, period x-axis ticks). Equal visual weight per metric since financial scanning is comparison-driven, not editorial. YoY delta when 5+ quarters available, QoQ fallback. Per-cell coverage caption preserved.

Plus **DensityGrid bento v4 row order**:
- Zone A — Hero: PriceChart 8×2 + KeyStats 4 + SecProfile 4
- Zone B — Identity: BusinessSections 12 (moved up from page bottom per operator)
- Zone C — Health: Fundamentals 6 + Dividends 6 paired
- Zone D — Activity: Filings 6 + Insider 6 paired
- Zone E — Operator: RecentNews 12 → Thesis 12

## Why

Operator review (PR #688): card-grid pattern made the page read like a Trello board, asymmetric "lead + supporting" Fundamentals was wrong for comparison scanning, and the 10-K narrative buried at page bottom didn't match operator scan priority for a held instrument. Hairline-rule + small-caps is the editorial pattern Bloomberg/NYTimes use — signals "continuous reference document" instead of "discrete tiles to rearrange."

## Codex review

Three findings fixed in 59ea56e:
- **Late-null-out** holes in the bento grid: DividendsPanel/RecentNewsPane/FundamentalsPane now render Pane chrome with empty-state copy when their data settles empty. Source + Open→ preserved on dividends so operator can still drill to L2.
- **Sparse-period x-axis collapse + YoY mislabeling**: buildCellPoints keeps every joined-series row with `value: null` for missing quarters; AreaChart uses `connectNulls={false}`; yoyDelta walks period_end dates with ±45-day window.
- **Gradient id collisions**: ids prefixed with `useId()`.

Codex confirmed all three resolved.

## Plus: Dark-Reader bleed-through fix

`<meta name="color-scheme" content="only light">` in index.html. Without it, Dark Reader and similar browser extensions fight our contrast — making `bg-white` sticky elements translucent so scrolled content bleeds through. Native dark mode tracked separately.

## Test plan

- [x] All 735 frontend unit tests pass
- [x] tsc -b clean
- [x] ruff + pyright clean
- [x] 3 new DensityGrid tests assert v4 health-pair / activity-pair col-spans + DOM order (BusinessSections before fundamentals/filings/news)
- [x] FundamentalsPane MLP-coverage test still passes (per-cell null filtering preserved)
- [x] Codex pre-push review: clean

Supersedes PR #688 (closed).