### PR TITLE
feat(#691): design-system v1 propagation — Dashboard + Section primitive

### DIFF
--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -396,13 +396,13 @@ export function AlertsStrip(): JSX.Element | null {
   return (
     <section
       aria-labelledby="alerts-strip-heading"
-      className="rounded-md border border-slate-200 bg-white shadow-sm"
+      className="border-t border-slate-200 pt-3"
     >
-      <header className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
-        <div className="flex items-center gap-2">
+      <header className="flex items-baseline justify-between gap-2">
+        <div className="flex items-baseline gap-2">
           <h2
             id="alerts-strip-heading"
-            className="text-sm font-semibold text-slate-700"
+            className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-700"
           >
             Alerts
           </h2>

--- a/frontend/src/components/dashboard/BootstrapProgress.tsx
+++ b/frontend/src/components/dashboard/BootstrapProgress.tsx
@@ -103,8 +103,8 @@ export function BootstrapProgress({
   const steps = buildSteps(stage);
 
   return (
-    <div className="rounded-md border border-blue-200 bg-blue-50 p-4">
-      <h2 className="text-sm font-semibold text-blue-800">
+    <div className="border-l-2 border-blue-400 bg-blue-50/60 pl-4 pr-3 py-3">
+      <h2 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-blue-800">
         Getting started
       </h2>
       <p className="mt-1 text-xs text-blue-700">

--- a/frontend/src/components/dashboard/PortfolioValueChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueChart.tsx
@@ -117,10 +117,12 @@ export function PortfolioValueChart(): JSX.Element | null {
   if (!effectivelyLoading && !hasMovement && fxSkipped === 0) return null;
 
   return (
-    <div className="rounded-md border border-slate-200 bg-white p-3 shadow-sm">
-      <div className="flex items-center justify-between">
+    <div className="border-t border-slate-200 pt-3">
+      <div className="flex items-baseline justify-between">
         <div className="flex items-baseline gap-2">
-          <h2 className="text-sm font-medium text-slate-700">Portfolio value</h2>
+          <h2 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-700">
+            Portfolio value
+          </h2>
           {/* Two mutually-exclusive FX signals:
               - caption  → fine state (live FX applied cleanly)
               - badge    → partial state (some pairs dropped)

--- a/frontend/src/components/dashboard/RollingPnlStrip.tsx
+++ b/frontend/src/components/dashboard/RollingPnlStrip.tsx
@@ -39,21 +39,17 @@ function Pill({
       : sign === "neg"
         ? "text-red-700"
         : "text-slate-600";
-  const toneBorder =
-    sign === "pos"
-      ? "border-emerald-200"
-      : sign === "neg"
-        ? "border-red-200"
-        : "border-slate-200";
+  // Design-system v1: hairline-top chrome shared with Section/Pane.
+  // Tone is carried by text colour only — no border accent.
   return (
     <div
-      className={`flex-1 rounded-md border ${toneBorder} bg-white p-3 shadow-sm`}
+      className="flex-1 border-t border-slate-200 px-3 pt-3 pb-1"
       data-testid={`rolling-pnl-${period.period}`}
     >
-      <div className="text-[11px] font-medium uppercase tracking-wider text-slate-400">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
         {LABELS[period.period] ?? period.period}
       </div>
-      <div className={`mt-0.5 text-lg font-semibold tabular-nums ${toneText}`}>
+      <div className={`mt-1 text-lg font-semibold tabular-nums ${toneText}`}>
         {`${sign === "pos" ? "+" : ""}${formatMoney(period.pnl, currency)}`}
       </div>
       <div className={`text-xs tabular-nums ${toneText}`}>
@@ -69,12 +65,9 @@ export function RollingPnlStrip(): JSX.Element | null {
 
   if (loading) {
     return (
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-x-6 sm:grid-cols-3">
         {[0, 1, 2].map((i) => (
-          <div
-            key={i}
-            className="rounded-md border border-slate-200 bg-white p-3 shadow-sm"
-          >
+          <div key={i} className="border-t border-slate-200 px-3 pt-3 pb-1">
             <SectionSkeleton rows={1} />
           </div>
         ))}
@@ -90,7 +83,7 @@ export function RollingPnlStrip(): JSX.Element | null {
   }
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+    <div className="grid grid-cols-1 gap-x-6 sm:grid-cols-3">
       {data.periods.map((period) => (
         <Pill
           key={period.period}

--- a/frontend/src/components/dashboard/Section.tsx
+++ b/frontend/src/components/dashboard/Section.tsx
@@ -1,18 +1,24 @@
 import type { ReactNode } from "react";
 
 /**
- * Section card container used by every dashboard panel.
+ * Section — canonical card primitive used by every dashboard panel and
+ * many list/detail pages.
  *
  * Each section owns its own loading / error / empty / data state — a
  * failing /system/status must not blank /portfolio. Sections render an
  * inline ErrorBanner with a Retry button rather than throwing, so the
  * top-level ErrorBoundary is reserved for unexpected exceptions.
  *
- * ``scrollable=true`` (#194) switches the Section into a contained-
- * scroll layout: the section claims remaining flex space and its
- * body scrolls vertically, instead of growing the page-level scroll.
- * Use when the parent is a flex column with ``h-full`` and the
- * section sits below header/filter chrome that should stay visible.
+ * Design-system v1 chrome (issue #691): hairline top-rule + small-caps
+ * uppercase title. Replaces the prior rounded card + border + shadow
+ * pattern so the page reads as a continuous editorial spread instead
+ * of a Trello-board of tiles. Matches the Pane component on the
+ * instrument page.
+ *
+ * `scrollable=true` (#194) switches the Section into a contained-scroll
+ * layout: the section claims remaining flex space and its body scrolls
+ * vertically. Use when the parent is a flex column with `h-full` and
+ * the section sits below header/filter chrome that should stay visible.
  */
 export function Section({
   title,
@@ -25,15 +31,21 @@ export function Section({
   children: ReactNode;
   scrollable?: boolean;
 }) {
+  // Hairline chrome — no background, no border, no shadow. The top-rule
+  // + small-caps title pair carries the section break visually.
   const sectionClass = scrollable
-    ? "flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-sm"
-    : "rounded-md border border-slate-200 bg-white shadow-sm";
-  const bodyClass = scrollable ? "min-h-0 flex-1 overflow-auto p-4" : "p-4";
+    ? "flex min-h-0 flex-1 flex-col overflow-hidden border-t border-slate-200 pt-3"
+    : "border-t border-slate-200 pt-3";
+  const bodyClass = scrollable ? "min-h-0 flex-1 overflow-auto pt-3" : "pt-3";
   return (
     <section className={sectionClass}>
-      <header className="flex flex-shrink-0 items-center justify-between border-b border-slate-100 px-4 py-3">
-        <h2 className="text-sm font-semibold text-slate-700">{title}</h2>
-        {action ? <div className="text-xs">{action}</div> : null}
+      <header className="flex flex-shrink-0 items-baseline justify-between gap-2">
+        <h2 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-700">
+          {title}
+        </h2>
+        {action ? (
+          <div className="text-[11px] text-slate-600">{action}</div>
+        ) : null}
       </header>
       <div className={bodyClass}>{children}</div>
     </section>
@@ -44,7 +56,7 @@ export function SectionError({ onRetry }: { onRetry: () => void }) {
   return (
     <div
       role="alert"
-      className="flex items-center justify-between rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+      className="flex items-center justify-between rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
     >
       <span>Failed to load. Check the browser console for details.</span>
       <button

--- a/frontend/src/components/dashboard/SummaryCards.tsx
+++ b/frontend/src/components/dashboard/SummaryCards.tsx
@@ -33,9 +33,9 @@ export function SummaryCards({
   const currency = useDisplayCurrency();
   if (data === null) {
     return (
-      <div className="grid grid-cols-1 divide-y divide-slate-200 sm:grid-cols-2 sm:divide-x sm:divide-y-0 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-x-6 sm:grid-cols-2 lg:grid-cols-4">
         {[0, 1, 2, 3].map((i) => (
-          <div key={i} className="px-4 py-3 first:pl-0 sm:first:pl-4 sm:[&:nth-child(3)]:pl-4 lg:[&:nth-child(3)]:pl-4">
+          <div key={i} className="border-t border-slate-200 px-1 pt-3 pb-1">
             <SectionSkeleton rows={2} />
           </div>
         ))}
@@ -58,7 +58,7 @@ export function SummaryCards({
   const pnlFraction = pnlPct(totalPnl, totalCost);
 
   return (
-    <div className="grid grid-cols-1 divide-y divide-slate-200 sm:grid-cols-2 sm:divide-x sm:divide-y-0 lg:grid-cols-4">
+    <div className="grid grid-cols-1 gap-x-6 sm:grid-cols-2 lg:grid-cols-4">
       <Card label="Total AUM" value={formatMoney(data.total_aum, currency)} />
       <Card
         label="Cash balance"
@@ -91,7 +91,7 @@ function DeploymentCard({
       return <Card label="Available for deployment" value="—" hint="Budget unavailable" />;
     }
     return (
-      <div className="px-4 py-3">
+      <div className="border-t border-slate-200 px-1 pt-3 pb-1">
         <SectionSkeleton rows={2} />
       </div>
     );
@@ -140,7 +140,7 @@ function Card({
         ? "text-rose-600"
         : "text-slate-900";
   return (
-    <div className="px-4 py-3">
+    <div className="border-t border-slate-200 px-1 pt-3 pb-1">
       <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
         {label}
       </div>

--- a/frontend/src/components/dashboard/SummaryCards.tsx
+++ b/frontend/src/components/dashboard/SummaryCards.tsx
@@ -4,7 +4,8 @@ import { formatMoney, formatPct, pnlPct } from "@/lib/format";
 import { SectionSkeleton } from "@/components/dashboard/Section";
 
 /**
- * Three top-level cards: Total AUM, Cash, Unrealized P&L.
+ * Four top-level cards: Total AUM, Cash, Unrealized P&L, Available for
+ * deployment.
  *
  * AUM honours the settled decision: backend uses mark-to-market first and
  * falls back to cost basis when no quote exists (see app/api/portfolio.py).
@@ -15,6 +16,10 @@ import { SectionSkeleton } from "@/components/dashboard/Section";
  * expose a top-line `unrealized_pnl` field. Percentage uses sum-of-PnL over
  * sum-of-cost-basis (capital-weighted), not an average of per-position
  * percentages.
+ *
+ * Design-system v1 chrome (#691): borderless, divided by hairlines on
+ * sm+ screens. Replaces the prior bordered+shadowed card pattern so
+ * the page reads as one editorial spread.
  */
 export function SummaryCards({
   data,
@@ -28,9 +33,9 @@ export function SummaryCards({
   const currency = useDisplayCurrency();
   if (data === null) {
     return (
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 divide-y divide-slate-200 sm:grid-cols-2 sm:divide-x sm:divide-y-0 lg:grid-cols-4">
         {[0, 1, 2, 3].map((i) => (
-          <div key={i} className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+          <div key={i} className="px-4 py-3 first:pl-0 sm:first:pl-4 sm:[&:nth-child(3)]:pl-4 lg:[&:nth-child(3)]:pl-4">
             <SectionSkeleton rows={2} />
           </div>
         ))}
@@ -53,7 +58,7 @@ export function SummaryCards({
   const pnlFraction = pnlPct(totalPnl, totalCost);
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+    <div className="grid grid-cols-1 divide-y divide-slate-200 sm:grid-cols-2 sm:divide-x sm:divide-y-0 lg:grid-cols-4">
       <Card label="Total AUM" value={formatMoney(data.total_aum, currency)} />
       <Card
         label="Cash balance"
@@ -86,7 +91,7 @@ function DeploymentCard({
       return <Card label="Available for deployment" value="—" hint="Budget unavailable" />;
     }
     return (
-      <div className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="px-4 py-3">
         <SectionSkeleton rows={2} />
       </div>
     );
@@ -132,13 +137,17 @@ function Card({
     tone === "positive"
       ? "text-emerald-600"
       : tone === "negative"
-        ? "text-red-600"
+        ? "text-rose-600"
         : "text-slate-900";
   return (
-    <div className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
-      <div className="text-xs uppercase tracking-wide text-slate-500">{label}</div>
-      <div className={`mt-1 text-2xl font-semibold ${toneClass}`}>{value}</div>
-      {hint ? <div className="mt-1 text-xs text-slate-500">{hint}</div> : null}
+    <div className="px-4 py-3">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
+        {label}
+      </div>
+      <div className={`mt-1 text-2xl font-semibold tabular-nums ${toneClass}`}>
+        {value}
+      </div>
+      {hint ? <div className="mt-1 text-xs tabular-nums text-slate-500">{hint}</div> : null}
     </div>
   );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -112,7 +112,7 @@ export function DashboardPage() {
         // they share the `/portfolio` fetch so duplicating the retry
         // affordance would just confuse the operator (Codex #387
         // review).
-        <div className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="border-t border-slate-200 pt-3">
           <SectionError onRetry={portfolio.refetch} />
         </div>
       ) : (


### PR DESCRIPTION
## Summary

Propagates the design-system v1 chrome from PR #689 (instrument page) to the Dashboard, and refactors the shared \`Section\` primitive that's used by 15+ other pages.

## Why

Operator review of #689: \"the styling is better, could do with this across the site\". Issue #691 plans phased per-page-area rollout. This PR is the Dashboard + shared primitive slice.

## What changed

| File | Change |
|---|---|
| \`Section.tsx\` | Hairline top-rule + small-caps title (used by 15 pages — propagates everywhere) |
| \`SummaryCards.tsx\` | 4 cards → 4-column \`divide-x\` group |
| \`RollingPnlStrip.tsx\` | 3 pills lose card chrome |
| \`PortfolioValueChart.tsx\` | Chart wrapper hairline |
| \`AlertsStrip.tsx\` | Alerts wrapper hairline |
| \`BootstrapProgress.tsx\` | Kept tinted-alert variant (left-rule blue) |
| \`DashboardPage.tsx\` | Inline error wrapper |

## Test plan

- [x] All 735 frontend unit tests pass
- [x] tsc clean
- [x] ruff + pyright clean
- [x] Pure visual refactor — no prop or behavioural changes

## Why it's safe

\`Section\` keeps its public API (\`title\`, \`action\`, \`scrollable\` props all unchanged). Existing callers continue to compile and render — they just look different. The \`scrollable=true\` contract for #194 Rankings still holds.

Continues #690-#694 site-wide propagation. Next: #692 Rankings + Portfolio.