### PR TITLE
feat(#692): design-system v1 propagation — Rankings + Portfolio

### DIFF
--- a/frontend/src/components/rankings/RankingsFilters.tsx
+++ b/frontend/src/components/rankings/RankingsFilters.tsx
@@ -45,7 +45,7 @@ export function RankingsFilters({
 }: RankingsFiltersProps) {
   return (
     <div
-      className="flex flex-wrap items-end gap-3 rounded-md border border-slate-200 bg-white p-3 shadow-sm"
+      className="flex flex-wrap items-end gap-3 border-t border-slate-200 px-1 pt-3 pb-2"
       role="group"
       aria-label="Rankings filters"
     >

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -344,7 +344,7 @@ function SummaryBar({
   const mirrorCount = mirrors.length;
 
   return (
-    <div className="flex flex-wrap gap-6 rounded-md border border-slate-200 bg-white px-5 py-3 text-sm shadow-sm">
+    <div className="flex flex-wrap gap-x-8 gap-y-2 border-t border-slate-200 px-1 pt-3 pb-2 text-sm">
       <Stat label="AUM" value={formatMoney(data.total_aum, currency)} />
       <Stat label="Cash" value={formatMoney(data.cash_balance, currency)} />
       <Stat
@@ -444,8 +444,8 @@ function PortfolioTable({
   onClose: (t: CloseTarget) => void;
 }) {
   return (
-    <div className="rounded-md border border-slate-200 bg-white shadow-sm">
-      <div className="border-b border-slate-100 px-4 py-2">
+    <div className="border-t border-slate-200 pt-3">
+      <div className="px-1 pb-3">
         <input
           ref={searchRef}
           type="text"
@@ -517,7 +517,7 @@ function PaginationBar({
   onNext: () => void;
 }) {
   return (
-    <div className="flex items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs shadow-sm">
+    <div className="flex items-center justify-between border-t border-slate-200 px-1 pt-2 pb-1 text-xs">
       <button
         type="button"
         onClick={onPrev}


### PR DESCRIPTION
## Summary

Continues #695 site-wide rollout. Drops rounded card + shadow chrome on Rankings filters and Portfolio page chrome.

## Changes

- \`components/rankings/RankingsFilters.tsx\` — filter bar uses border-t hairline
- \`pages/PortfolioPage.tsx\` — header stat strip, positions table wrapper, pagination footer

## Why preserved

- RankingsTable inner alert/error/empty banners kept as bordered notices — contextual messages inside the table body, dashed-border empty state carries information
- Tables themselves unchanged — operator preference per ticket

## Test plan

- [x] 735 tests pass
- [x] tsc clean
- [x] ruff + pyright clean