### PR TITLE
feat(#694): design-system v1 propagation — L2 drill + Settings + Recommendations

### DIFF
--- a/frontend/src/components/recommendations/AuditFilters.tsx
+++ b/frontend/src/components/recommendations/AuditFilters.tsx
@@ -19,7 +19,7 @@ export function AuditFilters({
 }: AuditFiltersProps) {
   return (
     <div
-      className="flex flex-wrap items-end gap-3 rounded-md border border-slate-200 bg-white p-3 shadow-sm"
+      className="flex flex-wrap items-end gap-3 border-t border-slate-200 px-1 pt-3 pb-2"
       role="group"
       aria-label="Audit filters"
     >

--- a/frontend/src/components/recommendations/RecommendationsFilters.tsx
+++ b/frontend/src/components/recommendations/RecommendationsFilters.tsx
@@ -19,7 +19,7 @@ export function RecommendationsFilters({
 }: RecommendationsFiltersProps) {
   return (
     <div
-      className="flex flex-wrap items-end gap-3 rounded-md border border-slate-200 bg-white p-3 shadow-sm"
+      className="flex flex-wrap items-end gap-3 border-t border-slate-200 px-1 pt-3 pb-2"
       role="group"
       aria-label="Recommendations filters"
     >

--- a/frontend/src/components/settings/BudgetConfigSection.tsx
+++ b/frontend/src/components/settings/BudgetConfigSection.tsx
@@ -118,14 +118,14 @@ export function BudgetConfigSection() {
     eventAmount === "" || !Number.isFinite(parsedEventAmount) || parsedEventAmount <= 0;
 
   return (
-    <section className="rounded-md border border-slate-200 bg-white shadow-sm">
-      <header className="border-b border-slate-100 px-4 py-3">
-        <h2 className="text-sm font-semibold text-slate-700">
+    <section className="border-t border-slate-200 pt-3">
+      <header>
+        <h2 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-700">
           Budget Configuration
         </h2>
       </header>
 
-      <div className="space-y-6 p-4">
+      <div className="mt-3 space-y-6">
         {/* ---- Sub-section 1: Config Controls ---- */}
         <div>
           <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -579,7 +579,7 @@ export function ChartPage(): JSX.Element {
       )}
 
       {/* Body: chart or raw table */}
-      <div className="rounded-md border border-slate-200 bg-white shadow-sm">
+      <div className="border-t border-slate-200 pt-3">
         {effectivelyLoading && candlesAsync.error === null ? (
           <div className="p-4">
             <SectionSkeleton rows={10} />

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -55,7 +55,7 @@ export function CopyTradingPage() {
       </div>
 
       {detail.error !== null ? (
-        <div className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="border-t border-slate-200 pt-3">
           <SectionError onRetry={detail.refetch} />
         </div>
       ) : detail.loading || detail.data === null ? (
@@ -107,7 +107,7 @@ function TraderAvatar({ username }: { username: string }) {
 
 function MirrorStats({ mirror, currency }: { mirror: MirrorSummary; currency: string }) {
   return (
-    <div className="grid grid-cols-2 gap-x-6 gap-y-2 rounded-md border border-slate-200 bg-white p-4 text-sm shadow-sm sm:grid-cols-3">
+    <div className="grid grid-cols-2 gap-x-6 gap-y-2 border-t border-slate-200 px-1 pt-3 pb-2 text-sm sm:grid-cols-3">
       <LabelValue label="Initial investment" value={formatMoney(mirror.initial_investment, currency)} />
       <LabelValue label="Deposits" value={formatMoney(mirror.deposit_summary, currency)} />
       <LabelValue label="Withdrawals" value={formatMoney(mirror.withdrawal_summary, currency)} />


### PR DESCRIPTION
## Summary

Continues #696 site-wide rollout. Drops card chrome on non-admin remaining pages.

## Files

- \`pages/ChartPage.tsx\` — chart body wrapper
- \`pages/CopyTradingPage.tsx\` — 2 wrappers
- \`components/recommendations/{AuditFilters,RecommendationsFilters}.tsx\`
- \`components/settings/BudgetConfigSection.tsx\` — also small-caps title

## Notes

L2 drill pages (FundamentalsPage / InsiderPage / DividendsPage / Tenk10KDrilldownPage / EightKListPage) inherit chrome automatically via the Section primitive refactor in #695 — no edits needed there.

Auth pages (Login / Recover / Setup) and Term popover deliberately keep card chrome — full-page modals + floating tooltips, not section chrome.

Admin tracked in #693.

## Test plan

- [x] 735 tests pass
- [x] tsc clean
- [x] ruff + pyright clean