### PR TITLE
feat(#693): design-system v1 propagation — Admin

### DIFF
--- a/frontend/src/components/admin/CollapsibleSection.tsx
+++ b/frontend/src/components/admin/CollapsibleSection.tsx
@@ -52,7 +52,7 @@ export function CollapsibleSection({
         type="button"
         onClick={toggle}
         aria-expanded={isOpen}
-        className="flex w-full items-baseline justify-between gap-2 text-left transition-colors hover:text-amber-600"
+        className="group flex w-full items-baseline justify-between gap-2 text-left"
       >
         <div className="flex items-baseline gap-2">
           <span
@@ -61,14 +61,14 @@ export function CollapsibleSection({
           >
             ▸
           </span>
-          <h2 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-700">
+          <h2 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-700 transition-colors group-hover:text-amber-600">
             {title}
           </h2>
           {summary ? (
             <span className="text-xs text-slate-500">— {summary}</span>
           ) : null}
         </div>
-        <span className="text-[11px] text-slate-500">
+        <span className="text-[11px] text-slate-500 transition-colors group-hover:text-amber-600">
           {isOpen ? "Hide" : "Show"}
         </span>
       </button>

--- a/frontend/src/components/admin/CollapsibleSection.tsx
+++ b/frontend/src/components/admin/CollapsibleSection.tsx
@@ -47,33 +47,32 @@ export function CollapsibleSection({
   }
 
   return (
-    <section
-      className="rounded-md border border-slate-200 bg-white shadow-sm"
-      id={sectionId}
-    >
+    <section className="border-t border-slate-200 pt-3" id={sectionId}>
       <button
         type="button"
         onClick={toggle}
         aria-expanded={isOpen}
-        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-slate-50"
+        className="flex w-full items-baseline justify-between gap-2 text-left transition-colors hover:text-amber-600"
       >
-        <div className="flex items-center gap-2">
+        <div className="flex items-baseline gap-2">
           <span
             aria-hidden
             className={`inline-block text-slate-400 transition-transform ${isOpen ? "rotate-90" : ""}`}
           >
             ▸
           </span>
-          <h2 className="text-sm font-semibold text-slate-700">{title}</h2>
+          <h2 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-700">
+            {title}
+          </h2>
           {summary ? (
             <span className="text-xs text-slate-500">— {summary}</span>
           ) : null}
         </div>
-        <span className="text-xs text-slate-400">
+        <span className="text-[11px] text-slate-500">
           {isOpen ? "Hide" : "Show"}
         </span>
       </button>
-      {isOpen ? <div className="border-t border-slate-100 p-4">{children}</div> : null}
+      {isOpen ? <div className="mt-3">{children}</div> : null}
     </section>
   );
 }

--- a/frontend/src/components/admin/FundDataRow.tsx
+++ b/frontend/src/components/admin/FundDataRow.tsx
@@ -118,7 +118,7 @@ export function FundDataRow({
 
   return (
     <div
-      className="grid grid-cols-2 gap-3 rounded-md border border-slate-200 bg-white p-3 shadow-sm sm:grid-cols-4 lg:grid-cols-7"
+      className="grid grid-cols-2 gap-x-6 gap-y-3 border-t border-slate-200 px-1 pt-3 pb-2 sm:grid-cols-4 lg:grid-cols-7"
       data-testid="fund-data-row"
     >
       {cells.map((c) => (


### PR DESCRIPTION
## Summary

Final non-dark-mode slice of the site-wide rollout (#691-#694).

## Files

- \`components/admin/CollapsibleSection.tsx\` — admin section primitive (used by AdminPage, SyncDashboard)
- \`components/admin/FundDataRow.tsx\` — 7-col status grid

## Preserved chrome

Tone-on-border cards stay because the border carries information:
- ProblemsPanel — red/amber/slate severity
- SyncDashboard layer cards — running/fresh/stale state
- AdminPage + SyncDashboard amber banners — alert notices
- SeedProgressPanel inline errors — alerts

The design-system rule is borderless for **sections**, not alerts.

## Test plan

- [x] 735 tests pass
- [x] tsc clean
- [x] ruff + pyright clean