### PR TITLE
feat(#701): dark mode Phase 2a — chart theme + useChartTheme hook

### DIFF
--- a/frontend/src/components/dividends/dividendsCharts.tsx
+++ b/frontend/src/components/dividends/dividendsCharts.tsx
@@ -27,7 +27,8 @@ import {
 
 import type { DividendPeriod } from "@/api/instruments";
 import type { InstrumentFinancialRow } from "@/api/types";
-import { chartTheme } from "@/lib/chartTheme";
+import { type ChartTheme, lightTheme } from "@/lib/chartTheme";
+import { useChartTheme } from "@/lib/useChartTheme";
 import {
   buildCumulativeDps,
   buildDpsSeries,
@@ -87,14 +88,16 @@ function NoData({ message }: { readonly message: string }) {
   return <p className="px-2 py-3 text-xs text-slate-500">{message}</p>;
 }
 
-const SHARED_AXIS = {
-  stroke: chartTheme.textSecondary,
-  tick: { fill: chartTheme.textMuted, fontSize: 10 } as const,
-};
+function sharedAxis(theme: ChartTheme) {
+  return {
+    stroke: theme.textSecondary,
+    tick: { fill: theme.textMuted, fontSize: 10 } as const,
+  };
+}
 
-const SHARED_GRID = (
-  <CartesianGrid stroke={chartTheme.gridLine} vertical={false} />
-);
+function SharedGrid({ theme }: { readonly theme: ChartTheme }): JSX.Element {
+  return <CartesianGrid stroke={theme.gridLine} vertical={false} />;
+}
 
 // ---------------------------------------------------------------------------
 // 1. DPS line chart
@@ -105,6 +108,7 @@ export interface HistoryProps {
 }
 
 export function DpsLineChart({ history }: HistoryProps): JSX.Element {
+  const theme = useChartTheme();
   const series = buildDpsSeries(history);
   const hasData = series.some((p) => p.dps !== null);
   if (!hasData) {
@@ -115,18 +119,18 @@ export function DpsLineChart({ history }: HistoryProps): JSX.Element {
     <div style={{ height: CHART_HEIGHT }} className="w-full">
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={series} margin={{ top: 8, right: 8, left: 8, bottom: 4 }}>
-          {SHARED_GRID}
+          <SharedGrid theme={theme} />
           <XAxis
             dataKey="period_end_date"
             tickFormatter={formatPeriod}
             interval="preserveStartEnd"
             minTickGap={20}
-            {...SHARED_AXIS}
+            {...sharedAxis(theme)}
           />
           <YAxis
             tickFormatter={(v: number) => formatDps(v, currency)}
             width={64}
-            {...SHARED_AXIS}
+            {...sharedAxis(theme)}
           />
           <Tooltip
             formatter={(value: number) => formatDps(value, currency)}
@@ -137,7 +141,7 @@ export function DpsLineChart({ history }: HistoryProps): JSX.Element {
             type="monotone"
             dataKey="dps"
             name="DPS declared"
-            stroke={chartTheme.accent[0]}
+            stroke={lightTheme.accent[0]}
             strokeWidth={2.5}
             dot={false}
             isAnimationActive={false}
@@ -153,6 +157,7 @@ export function DpsLineChart({ history }: HistoryProps): JSX.Element {
 // ---------------------------------------------------------------------------
 
 export function CumulativeDpsChart({ history }: HistoryProps): JSX.Element {
+  const theme = useChartTheme();
   const series = buildCumulativeDps(history);
   // Empty hint fires when:
   //   - the helper returned no rows at all, or
@@ -173,18 +178,18 @@ export function CumulativeDpsChart({ history }: HistoryProps): JSX.Element {
     <div style={{ height: CHART_HEIGHT }} className="w-full">
       <ResponsiveContainer width="100%" height="100%">
         <AreaChart data={series} margin={{ top: 8, right: 8, left: 8, bottom: 4 }}>
-          {SHARED_GRID}
+          <SharedGrid theme={theme} />
           <XAxis
             dataKey="period_end_date"
             tickFormatter={formatPeriod}
             interval="preserveStartEnd"
             minTickGap={20}
-            {...SHARED_AXIS}
+            {...sharedAxis(theme)}
           />
           <YAxis
             tickFormatter={(v: number) => formatDps(v, currency)}
             width={64}
-            {...SHARED_AXIS}
+            {...sharedAxis(theme)}
           />
           <Tooltip
             formatter={(value: number) => formatDps(value, currency)}
@@ -195,8 +200,8 @@ export function CumulativeDpsChart({ history }: HistoryProps): JSX.Element {
             type="monotone"
             dataKey="cumulative_dps"
             name="Cumulative DPS"
-            stroke={chartTheme.accent[1]}
-            fill={chartTheme.accent[1]}
+            stroke={lightTheme.accent[1]}
+            fill={lightTheme.accent[1]}
             fillOpacity={0.15}
             strokeWidth={2.5}
             dot={false}
@@ -217,6 +222,7 @@ export interface PayoutRatioProps {
 }
 
 export function PayoutRatioChart({ cashflowRows }: PayoutRatioProps): JSX.Element {
+  const theme = useChartTheme();
   const series = buildPayoutRatio(cashflowRows);
   const hasData = series.some((p) => p.payout_pct !== null);
   if (!hasData) {
@@ -228,27 +234,27 @@ export function PayoutRatioChart({ cashflowRows }: PayoutRatioProps): JSX.Elemen
     <div style={{ height: CHART_HEIGHT }} className="w-full">
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={series} margin={{ top: 8, right: 8, left: 8, bottom: 4 }}>
-          {SHARED_GRID}
+          <SharedGrid theme={theme} />
           <XAxis
             dataKey="period_end_date"
             tickFormatter={formatPeriod}
             interval="preserveStartEnd"
             minTickGap={20}
-            {...SHARED_AXIS}
+            {...sharedAxis(theme)}
           />
           <YAxis
             tickFormatter={(v: number) => `${v.toFixed(0)}%`}
             width={48}
-            {...SHARED_AXIS}
+            {...sharedAxis(theme)}
           />
           <ReferenceLine
             y={100}
-            stroke={chartTheme.accent[3]}
+            stroke={lightTheme.accent[3]}
             strokeDasharray="4 4"
             label={{
               value: "100%",
               position: "right",
-              fill: chartTheme.textMuted,
+              fill: theme.textMuted,
               fontSize: 10,
             }}
           />
@@ -261,9 +267,9 @@ export function PayoutRatioChart({ cashflowRows }: PayoutRatioProps): JSX.Elemen
             type="monotone"
             dataKey="payout_pct"
             name="Payout / FCF"
-            stroke={chartTheme.accent[2]}
+            stroke={lightTheme.accent[2]}
             strokeWidth={2.5}
-            dot={{ r: 3, fill: chartTheme.accent[2] }}
+            dot={{ r: 3, fill: lightTheme.accent[2] }}
             isAnimationActive={false}
           />
         </LineChart>
@@ -288,6 +294,7 @@ export function YieldOnCostChart({
   history,
   avgEntry,
 }: YieldOnCostProps): JSX.Element {
+  const theme = useChartTheme();
   const series = buildYieldOnCost(history, avgEntry);
   if (series === null) {
     return <NoData message="Yield-on-cost is shown only when this instrument is held." />;
@@ -299,12 +306,12 @@ export function YieldOnCostChart({
     <div style={{ height: CHART_HEIGHT }} className="w-full">
       <ResponsiveContainer width="100%" height="100%">
         <BarChart data={series} margin={{ top: 8, right: 8, left: 8, bottom: 4 }}>
-          {SHARED_GRID}
-          <XAxis dataKey="fiscal_year" {...SHARED_AXIS} />
+          <SharedGrid theme={theme} />
+          <XAxis dataKey="fiscal_year" {...sharedAxis(theme)} />
           <YAxis
             tickFormatter={(v: number) => `${v.toFixed(1)}%`}
             width={48}
-            {...SHARED_AXIS}
+            {...sharedAxis(theme)}
           />
           <Tooltip
             formatter={(value: number, name: string) =>
@@ -317,7 +324,7 @@ export function YieldOnCostChart({
           />
           <Bar dataKey="yoc_pct" name="Yield-on-cost" isAnimationActive={false}>
             {series.map((s) => (
-              <Cell key={s.fiscal_year} fill={chartTheme.up} />
+              <Cell key={s.fiscal_year} fill={lightTheme.up} />
             ))}
           </Bar>
         </BarChart>

--- a/frontend/src/components/fundamentals/fundamentalsCharts.tsx
+++ b/frontend/src/components/fundamentals/fundamentalsCharts.tsx
@@ -30,7 +30,8 @@ import {
   YAxis,
 } from "recharts";
 
-import { chartTheme } from "@/lib/chartTheme";
+import { type ChartTheme, lightTheme } from "@/lib/chartTheme";
+import { useChartTheme } from "@/lib/useChartTheme";
 import {
   buildCashflowWaterfall,
   buildDebtStructure,
@@ -97,14 +98,16 @@ function NoData({ message }: { readonly message: string }) {
   return <p className="px-2 py-3 text-xs text-slate-500">{message}</p>;
 }
 
-const SHARED_AXIS = {
-  stroke: chartTheme.textSecondary,
-  tick: { fill: chartTheme.textMuted, fontSize: 10 } as const,
-};
+function sharedAxis(theme: ChartTheme) {
+  return {
+    stroke: theme.textSecondary,
+    tick: { fill: theme.textMuted, fontSize: 10 } as const,
+  };
+}
 
-const SHARED_GRID = (
-  <CartesianGrid stroke={chartTheme.gridLine} vertical={false} />
-);
+function SharedGrid({ theme }: { readonly theme: ChartTheme }): JSX.Element {
+  return <CartesianGrid stroke={theme.gridLine} vertical={false} />;
+}
 
 // ---------------------------------------------------------------------------
 // 1. Quarterly P&L stacked bar
@@ -123,6 +126,7 @@ interface YoyChartProps extends PnlChartProps {
 }
 
 export function PnlStackedChart({ periods }: PnlChartProps): JSX.Element {
+  const theme = useChartTheme();
   const buckets = buildPnlBuckets(periods);
   const hasData = buckets.some(
     (b) => b.cogs !== null || b.opex !== null || b.op_income !== null,
@@ -132,25 +136,25 @@ export function PnlStackedChart({ periods }: PnlChartProps): JSX.Element {
     <div style={{ height: CHART_HEIGHT }} className="w-full">
       <ResponsiveContainer width="100%" height="100%">
         <BarChart data={buckets} margin={{ top: 8, right: 8, left: 8, bottom: 4 }}>
-          {SHARED_GRID}
+          <SharedGrid theme={theme} />
           <XAxis
             dataKey="period_end"
             tickFormatter={formatPeriod}
             interval="preserveStartEnd"
             minTickGap={20}
-            {...SHARED_AXIS}
+            {...sharedAxis(theme)}
           />
-          <YAxis tickFormatter={(v: number) => formatBigNumber(v)} width={60} {...SHARED_AXIS} />
+          <YAxis tickFormatter={(v: number) => formatBigNumber(v)} width={60} {...sharedAxis(theme)} />
           <Tooltip
-            cursor={{ fill: chartTheme.gridLine }}
+            cursor={{ fill: theme.gridLine }}
             formatter={(value: number) => formatBigNumber(value)}
             labelFormatter={formatPeriod}
             contentStyle={{ fontSize: "11px" }}
           />
           <Legend wrapperStyle={{ fontSize: "11px" }} />
-          <Bar dataKey="cogs" name="COGS" stackId="a" fill={chartTheme.accent[3]} isAnimationActive={false} />
-          <Bar dataKey="opex" name="Opex (R&D + SG&A)" stackId="a" fill={chartTheme.accent[2]} isAnimationActive={false} />
-          <Bar dataKey="op_income" name="Operating income" stackId="a" fill={chartTheme.accent[0]} isAnimationActive={false} />
+          <Bar dataKey="cogs" name="COGS" stackId="a" fill={lightTheme.accent[3]} isAnimationActive={false} />
+          <Bar dataKey="opex" name="Opex (R&D + SG&A)" stackId="a" fill={lightTheme.accent[2]} isAnimationActive={false} />
+          <Bar dataKey="op_income" name="Operating income" stackId="a" fill={lightTheme.accent[0]} isAnimationActive={false} />
         </BarChart>
       </ResponsiveContainer>
     </div>
@@ -162,6 +166,7 @@ export function PnlStackedChart({ periods }: PnlChartProps): JSX.Element {
 // ---------------------------------------------------------------------------
 
 export function MarginTrendsChart({ periods }: PnlChartProps): JSX.Element {
+  const theme = useChartTheme();
   const margins = buildMargins(periods);
   const hasData = margins.some(
     (m) => m.gross_pct !== null || m.operating_pct !== null || m.net_pct !== null,
@@ -171,19 +176,19 @@ export function MarginTrendsChart({ periods }: PnlChartProps): JSX.Element {
     <div style={{ height: CHART_HEIGHT }} className="w-full">
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={margins} margin={{ top: 8, right: 8, left: 8, bottom: 4 }}>
-          {SHARED_GRID}
-          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...SHARED_AXIS} />
-          <YAxis tickFormatter={(v: number) => `${v.toFixed(0)}%`} width={48} {...SHARED_AXIS} />
-          <ReferenceLine y={0} stroke={chartTheme.borderColor} />
+          <SharedGrid theme={theme} />
+          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...sharedAxis(theme)} />
+          <YAxis tickFormatter={(v: number) => `${v.toFixed(0)}%`} width={48} {...sharedAxis(theme)} />
+          <ReferenceLine y={0} stroke={theme.borderColor} />
           <Tooltip
             formatter={(value: number) => formatPct(value)}
             labelFormatter={formatPeriod}
             contentStyle={{ fontSize: "11px" }}
           />
           <Legend wrapperStyle={{ fontSize: "11px" }} />
-          <Line type="monotone" dataKey="gross_pct" name="Gross" stroke={chartTheme.accent[1]} strokeWidth={2} dot={false} isAnimationActive={false} />
-          <Line type="monotone" dataKey="operating_pct" name="Operating" stroke={chartTheme.accent[2]} strokeWidth={2} dot={false} isAnimationActive={false} />
-          <Line type="monotone" dataKey="net_pct" name="Net" stroke={chartTheme.accent[0]} strokeWidth={2} dot={false} isAnimationActive={false} />
+          <Line type="monotone" dataKey="gross_pct" name="Gross" stroke={lightTheme.accent[1]} strokeWidth={2} dot={false} isAnimationActive={false} />
+          <Line type="monotone" dataKey="operating_pct" name="Operating" stroke={lightTheme.accent[2]} strokeWidth={2} dot={false} isAnimationActive={false} />
+          <Line type="monotone" dataKey="net_pct" name="Net" stroke={lightTheme.accent[0]} strokeWidth={2} dot={false} isAnimationActive={false} />
         </LineChart>
       </ResponsiveContainer>
     </div>
@@ -198,6 +203,7 @@ export function YoyGrowthChart({
   periods,
   period,
 }: YoyChartProps): JSX.Element {
+  const theme = useChartTheme();
   const yoy = buildYoyGrowth(periods, period);
   const hasData = yoy.some(
     (r) =>
@@ -214,15 +220,15 @@ export function YoyGrowthChart({
     <div style={{ height: CHART_HEIGHT }} className="w-full">
       <ResponsiveContainer width="100%" height="100%">
         <BarChart data={yoy} margin={{ top: 8, right: 8, left: 8, bottom: 4 }}>
-          {SHARED_GRID}
-          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...SHARED_AXIS} />
-          <YAxis tickFormatter={(v: number) => `${v.toFixed(0)}%`} width={48} {...SHARED_AXIS} />
-          <ReferenceLine y={0} stroke={chartTheme.borderColor} />
+          <SharedGrid theme={theme} />
+          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...sharedAxis(theme)} />
+          <YAxis tickFormatter={(v: number) => `${v.toFixed(0)}%`} width={48} {...sharedAxis(theme)} />
+          <ReferenceLine y={0} stroke={theme.borderColor} />
           <Tooltip formatter={(value: number) => formatPct(value)} labelFormatter={formatPeriod} contentStyle={{ fontSize: "11px" }} />
           <Legend wrapperStyle={{ fontSize: "11px" }} />
-          <Bar dataKey="revenue_yoy_pct" name="Revenue" fill={chartTheme.accent[1]} isAnimationActive={false} />
-          <Bar dataKey="eps_yoy_pct" name="EPS (diluted)" fill={chartTheme.accent[2]} isAnimationActive={false} />
-          <Bar dataKey="fcf_yoy_pct" name="FCF" fill={chartTheme.accent[3]} isAnimationActive={false} />
+          <Bar dataKey="revenue_yoy_pct" name="Revenue" fill={lightTheme.accent[1]} isAnimationActive={false} />
+          <Bar dataKey="eps_yoy_pct" name="EPS (diluted)" fill={lightTheme.accent[2]} isAnimationActive={false} />
+          <Bar dataKey="fcf_yoy_pct" name="FCF" fill={lightTheme.accent[3]} isAnimationActive={false} />
         </BarChart>
       </ResponsiveContainer>
     </div>
@@ -246,6 +252,7 @@ interface WaterfallBar {
 }
 
 export function CashflowWaterfallChart({ period }: WaterfallProps): JSX.Element {
+  const theme = useChartTheme();
   if (period === null) return <NoData message="No cash-flow statement on file for the latest period." />;
   const steps = buildCashflowWaterfall(period);
   if (steps === null) {
@@ -279,12 +286,12 @@ export function CashflowWaterfallChart({ period }: WaterfallProps): JSX.Element 
     <div style={{ height: CHART_HEIGHT }} className="w-full">
       <ResponsiveContainer width="100%" height="100%">
         <BarChart data={data} margin={{ top: 8, right: 8, left: 8, bottom: 4 }}>
-          {SHARED_GRID}
-          <XAxis dataKey="label" {...SHARED_AXIS} />
-          <YAxis tickFormatter={(v: number) => formatBigNumber(v)} width={60} {...SHARED_AXIS} />
-          <ReferenceLine y={0} stroke={chartTheme.borderColor} />
+          <SharedGrid theme={theme} />
+          <XAxis dataKey="label" {...sharedAxis(theme)} />
+          <YAxis tickFormatter={(v: number) => formatBigNumber(v)} width={60} {...sharedAxis(theme)} />
+          <ReferenceLine y={0} stroke={theme.borderColor} />
           <Tooltip
-            cursor={{ fill: chartTheme.gridLine }}
+            cursor={{ fill: theme.gridLine }}
             formatter={(_value, _name, item) => {
               const payload = item.payload as WaterfallBar | undefined;
               if (payload === undefined) return ["—", ""];
@@ -300,10 +307,10 @@ export function CashflowWaterfallChart({ period }: WaterfallProps): JSX.Element 
                 key={d.label}
                 fill={
                   d.is_total
-                    ? chartTheme.accent[1]
+                    ? lightTheme.accent[1]
                     : d.delta >= 0
-                      ? chartTheme.up
-                      : chartTheme.down
+                      ? lightTheme.up
+                      : lightTheme.down
                 }
               />
             ))}
@@ -321,6 +328,7 @@ export function CashflowWaterfallChart({ period }: WaterfallProps): JSX.Element 
 export function BalanceStructureChart({
   periods,
 }: PnlChartProps): JSX.Element {
+  const theme = useChartTheme();
   const snap = latestBalanceStructure(periods);
   if (snap === null) {
     return <NoData message="No complete balance sheet (assets + liabilities + equity) on file." />;
@@ -347,16 +355,16 @@ export function BalanceStructureChart({
       <div style={{ height: 160 }} className="w-full">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart layout="vertical" data={data} margin={{ top: 4, right: 24, left: 8, bottom: 4 }}>
-            <XAxis type="number" tickFormatter={(v: number) => formatBigNumber(v)} {...SHARED_AXIS} />
-            <YAxis type="category" dataKey="side" width={140} {...SHARED_AXIS} />
+            <XAxis type="number" tickFormatter={(v: number) => formatBigNumber(v)} {...sharedAxis(theme)} />
+            <YAxis type="category" dataKey="side" width={140} {...sharedAxis(theme)} />
             <Tooltip
               formatter={(value: number, name: string) => [formatBigNumber(value), name]}
               contentStyle={{ fontSize: "11px" }}
             />
             <Legend wrapperStyle={{ fontSize: "11px" }} />
-            <Bar dataKey="assets" name="Assets" stackId="a" fill={chartTheme.accent[1]} isAnimationActive={false} />
-            <Bar dataKey="liabilities" name="Liabilities" stackId="a" fill={chartTheme.down} isAnimationActive={false} />
-            <Bar dataKey="equity" name="Equity" stackId="a" fill={chartTheme.up} isAnimationActive={false} />
+            <Bar dataKey="assets" name="Assets" stackId="a" fill={lightTheme.accent[1]} isAnimationActive={false} />
+            <Bar dataKey="liabilities" name="Liabilities" stackId="a" fill={lightTheme.down} isAnimationActive={false} />
+            <Bar dataKey="equity" name="Equity" stackId="a" fill={lightTheme.up} isAnimationActive={false} />
           </BarChart>
         </ResponsiveContainer>
       </div>
@@ -369,6 +377,7 @@ export function BalanceStructureChart({
 // ---------------------------------------------------------------------------
 
 export function DebtStructureChart({ periods }: PnlChartProps): JSX.Element {
+  const theme = useChartTheme();
   const rows = buildDebtStructure(periods);
   const hasData = rows.some(
     (r) => r.long_term !== null || r.short_term !== null,
@@ -378,10 +387,10 @@ export function DebtStructureChart({ periods }: PnlChartProps): JSX.Element {
     <div style={{ height: CHART_HEIGHT }} className="w-full">
       <ResponsiveContainer width="100%" height="100%">
         <ComposedChart data={rows} margin={{ top: 8, right: 32, left: 8, bottom: 4 }}>
-          {SHARED_GRID}
-          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...SHARED_AXIS} />
-          <YAxis yAxisId="left" tickFormatter={(v: number) => formatBigNumber(v)} width={60} {...SHARED_AXIS} />
-          <YAxis yAxisId="right" orientation="right" tickFormatter={(v: number) => `${v.toFixed(0)}×`} width={48} {...SHARED_AXIS} />
+          <SharedGrid theme={theme} />
+          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...sharedAxis(theme)} />
+          <YAxis yAxisId="left" tickFormatter={(v: number) => formatBigNumber(v)} width={60} {...sharedAxis(theme)} />
+          <YAxis yAxisId="right" orientation="right" tickFormatter={(v: number) => `${v.toFixed(0)}×`} width={48} {...sharedAxis(theme)} />
           <Tooltip
             formatter={(value: number, name: string) =>
               name === "Interest coverage"
@@ -392,9 +401,9 @@ export function DebtStructureChart({ periods }: PnlChartProps): JSX.Element {
             contentStyle={{ fontSize: "11px" }}
           />
           <Legend wrapperStyle={{ fontSize: "11px" }} />
-          <Bar yAxisId="left" dataKey="long_term" name="Long-term debt" stackId="d" fill={chartTheme.accent[3]} isAnimationActive={false} />
-          <Bar yAxisId="left" dataKey="short_term" name="Short-term debt" stackId="d" fill={chartTheme.accent[4]} isAnimationActive={false} />
-          <Line yAxisId="right" type="monotone" dataKey="interest_coverage" name="Interest coverage" stroke={chartTheme.accent[0]} strokeWidth={2} dot={false} isAnimationActive={false} />
+          <Bar yAxisId="left" dataKey="long_term" name="Long-term debt" stackId="d" fill={lightTheme.accent[3]} isAnimationActive={false} />
+          <Bar yAxisId="left" dataKey="short_term" name="Short-term debt" stackId="d" fill={lightTheme.accent[4]} isAnimationActive={false} />
+          <Line yAxisId="right" type="monotone" dataKey="interest_coverage" name="Interest coverage" stroke={lightTheme.accent[0]} strokeWidth={2} dot={false} isAnimationActive={false} />
         </ComposedChart>
       </ResponsiveContainer>
     </div>
@@ -406,6 +415,7 @@ export function DebtStructureChart({ periods }: PnlChartProps): JSX.Element {
 // ---------------------------------------------------------------------------
 
 export function DupontChart({ periods }: PnlChartProps): JSX.Element {
+  const theme = useChartTheme();
   const dp = buildDupont(periods);
   const hasData = dp.some(
     (r) =>
@@ -431,11 +441,11 @@ export function DupontChart({ periods }: PnlChartProps): JSX.Element {
     <div style={{ height: CHART_HEIGHT }} className="w-full">
       <ResponsiveContainer width="100%" height="100%">
         <ComposedChart data={displayed} margin={{ top: 8, right: 32, left: 8, bottom: 4 }}>
-          {SHARED_GRID}
-          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...SHARED_AXIS} />
-          <YAxis yAxisId="pct" tickFormatter={(v: number) => `${v.toFixed(0)}%`} width={48} {...SHARED_AXIS} />
-          <YAxis yAxisId="x" orientation="right" tickFormatter={(v: number) => `${v.toFixed(1)}×`} width={48} {...SHARED_AXIS} />
-          <ReferenceLine yAxisId="pct" y={0} stroke={chartTheme.borderColor} />
+          <SharedGrid theme={theme} />
+          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...sharedAxis(theme)} />
+          <YAxis yAxisId="pct" tickFormatter={(v: number) => `${v.toFixed(0)}%`} width={48} {...sharedAxis(theme)} />
+          <YAxis yAxisId="x" orientation="right" tickFormatter={(v: number) => `${v.toFixed(1)}×`} width={48} {...sharedAxis(theme)} />
+          <ReferenceLine yAxisId="pct" y={0} stroke={theme.borderColor} />
           <Tooltip
             formatter={(value: number, name: string) =>
               name === "ROE" || name === "Net margin"
@@ -446,10 +456,10 @@ export function DupontChart({ periods }: PnlChartProps): JSX.Element {
             contentStyle={{ fontSize: "11px" }}
           />
           <Legend wrapperStyle={{ fontSize: "11px" }} />
-          <Line yAxisId="pct" type="monotone" dataKey="roe_pct" name="ROE" stroke={chartTheme.accent[0]} strokeWidth={2.5} dot={false} isAnimationActive={false} />
-          <Line yAxisId="pct" type="monotone" dataKey="npm_pct" name="Net margin" stroke={chartTheme.accent[1]} strokeWidth={1.5} dot={false} isAnimationActive={false} strokeDasharray="4 4" />
-          <Line yAxisId="x" type="monotone" dataKey="asset_turnover" name="Asset turnover" stroke={chartTheme.accent[2]} strokeWidth={1.5} dot={false} isAnimationActive={false} strokeDasharray="4 4" />
-          <Line yAxisId="x" type="monotone" dataKey="equity_multiplier" name="Equity multiplier" stroke={chartTheme.accent[3]} strokeWidth={1.5} dot={false} isAnimationActive={false} strokeDasharray="4 4" />
+          <Line yAxisId="pct" type="monotone" dataKey="roe_pct" name="ROE" stroke={lightTheme.accent[0]} strokeWidth={2.5} dot={false} isAnimationActive={false} />
+          <Line yAxisId="pct" type="monotone" dataKey="npm_pct" name="Net margin" stroke={lightTheme.accent[1]} strokeWidth={1.5} dot={false} isAnimationActive={false} strokeDasharray="4 4" />
+          <Line yAxisId="x" type="monotone" dataKey="asset_turnover" name="Asset turnover" stroke={lightTheme.accent[2]} strokeWidth={1.5} dot={false} isAnimationActive={false} strokeDasharray="4 4" />
+          <Line yAxisId="x" type="monotone" dataKey="equity_multiplier" name="Equity multiplier" stroke={lightTheme.accent[3]} strokeWidth={1.5} dot={false} isAnimationActive={false} strokeDasharray="4 4" />
         </ComposedChart>
       </ResponsiveContainer>
     </div>
@@ -461,6 +471,7 @@ export function DupontChart({ periods }: PnlChartProps): JSX.Element {
 // ---------------------------------------------------------------------------
 
 export function RoicChart({ periods }: PnlChartProps): JSX.Element {
+  const theme = useChartTheme();
   const r = buildRoic(periods);
   const hasData = r.some((row) => row.roic !== null);
   if (!hasData) {
@@ -474,12 +485,12 @@ export function RoicChart({ periods }: PnlChartProps): JSX.Element {
     <div style={{ height: CHART_HEIGHT }} className="w-full">
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={data} margin={{ top: 8, right: 8, left: 8, bottom: 4 }}>
-          {SHARED_GRID}
-          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...SHARED_AXIS} />
-          <YAxis tickFormatter={(v: number) => `${v.toFixed(0)}%`} width={48} {...SHARED_AXIS} />
-          <ReferenceLine y={0} stroke={chartTheme.borderColor} />
+          <SharedGrid theme={theme} />
+          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...sharedAxis(theme)} />
+          <YAxis tickFormatter={(v: number) => `${v.toFixed(0)}%`} width={48} {...sharedAxis(theme)} />
+          <ReferenceLine y={0} stroke={theme.borderColor} />
           <Tooltip formatter={(value: number) => formatPct(value)} labelFormatter={formatPeriod} contentStyle={{ fontSize: "11px" }} />
-          <Line type="monotone" dataKey="roic_pct" name="ROIC" stroke={chartTheme.accent[2]} strokeWidth={2.5} dot={false} isAnimationActive={false} />
+          <Line type="monotone" dataKey="roic_pct" name="ROIC" stroke={lightTheme.accent[2]} strokeWidth={2.5} dot={false} isAnimationActive={false} />
         </LineChart>
       </ResponsiveContainer>
     </div>
@@ -491,6 +502,7 @@ export function RoicChart({ periods }: PnlChartProps): JSX.Element {
 // ---------------------------------------------------------------------------
 
 export function FcfChart({ periods }: PnlChartProps): JSX.Element {
+  const theme = useChartTheme();
   const f = buildFcf(periods);
   const hasData = f.some((r) => r.fcf !== null);
   if (!hasData) {
@@ -500,12 +512,12 @@ export function FcfChart({ periods }: PnlChartProps): JSX.Element {
     <div style={{ height: CHART_HEIGHT }} className="w-full">
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={f} margin={{ top: 8, right: 8, left: 8, bottom: 4 }}>
-          {SHARED_GRID}
-          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...SHARED_AXIS} />
-          <YAxis tickFormatter={(v: number) => formatBigNumber(v)} width={60} {...SHARED_AXIS} />
-          <ReferenceLine y={0} stroke={chartTheme.borderColor} />
+          <SharedGrid theme={theme} />
+          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...sharedAxis(theme)} />
+          <YAxis tickFormatter={(v: number) => formatBigNumber(v)} width={60} {...sharedAxis(theme)} />
+          <ReferenceLine y={0} stroke={theme.borderColor} />
           <Tooltip formatter={(value: number) => formatBigNumber(value)} labelFormatter={formatPeriod} contentStyle={{ fontSize: "11px" }} />
-          <Line type="monotone" dataKey="fcf" name="FCF" stroke={chartTheme.accent[1]} strokeWidth={2.5} dot={false} isAnimationActive={false} />
+          <Line type="monotone" dataKey="fcf" name="FCF" stroke={lightTheme.accent[1]} strokeWidth={2.5} dot={false} isAnimationActive={false} />
         </LineChart>
       </ResponsiveContainer>
     </div>

--- a/frontend/src/components/insider/InsiderByOfficer.tsx
+++ b/frontend/src/components/insider/InsiderByOfficer.tsx
@@ -21,7 +21,8 @@ import {
 } from "recharts";
 
 import type { InsiderTransactionDetail } from "@/api/instruments";
-import { chartTheme } from "@/lib/chartTheme";
+import { lightTheme } from "@/lib/chartTheme";
+import { useChartTheme } from "@/lib/useChartTheme";
 import {
   directionOf,
   signedShares,
@@ -165,6 +166,7 @@ export interface InsiderByOfficerProps {
 export function InsiderByOfficer({
   transactions,
 }: InsiderByOfficerProps): JSX.Element {
+  const theme = useChartTheme();
   const buckets = buildOfficerBuckets(transactions);
   if (buckets.length === 0) {
     return (
@@ -191,20 +193,20 @@ export function InsiderByOfficer({
             <XAxis
               type="number"
               tickFormatter={formatShares}
-              stroke={chartTheme.textSecondary}
-              tick={{ fill: chartTheme.textMuted, fontSize: 10 }}
+              stroke={theme.textSecondary}
+              tick={{ fill: theme.textMuted, fontSize: 10 }}
             />
             <YAxis
               type="category"
               dataKey="officer"
               width={180}
-              stroke={chartTheme.textSecondary}
-              tick={{ fill: chartTheme.textPrimary, fontSize: 10 }}
+              stroke={theme.textSecondary}
+              tick={{ fill: theme.textPrimary, fontSize: 10 }}
               interval={0}
             />
             <Tooltip
               content={<OfficerTooltip />}
-              cursor={{ fill: chartTheme.gridLine }}
+              cursor={{ fill: theme.gridLine }}
             />
             <Bar dataKey="net" isAnimationActive={false}>
               {buckets.map((b) => (
@@ -212,10 +214,10 @@ export function InsiderByOfficer({
                   key={b.key}
                   fill={
                     b.net > 0
-                      ? chartTheme.up
+                      ? lightTheme.up
                       : b.net < 0
-                        ? chartTheme.down
-                        : chartTheme.borderColor
+                        ? lightTheme.down
+                        : theme.borderColor
                   }
                 />
               ))}

--- a/frontend/src/components/insider/InsiderNetByMonth.tsx
+++ b/frontend/src/components/insider/InsiderNetByMonth.tsx
@@ -21,7 +21,8 @@ import {
 } from "recharts";
 
 import type { InsiderTransactionDetail } from "@/api/instruments";
-import { chartTheme } from "@/lib/chartTheme";
+import { lightTheme } from "@/lib/chartTheme";
+import { useChartTheme } from "@/lib/useChartTheme";
 import { directionOf, signedShares } from "@/lib/insiderClassify";
 
 interface MonthBucket {
@@ -154,6 +155,7 @@ export interface InsiderNetByMonthProps {
 export function InsiderNetByMonth({
   transactions,
 }: InsiderNetByMonthProps): JSX.Element {
+  const theme = useChartTheme();
   const { buckets, hadActivity } = buildMonthBuckets(transactions);
   if (!hadActivity) {
     return (
@@ -166,29 +168,29 @@ export function InsiderNetByMonth({
     <div className="h-72 w-full" data-testid="insider-net-by-month">
       <ResponsiveContainer width="100%" height="100%">
         <BarChart data={buckets} margin={{ top: 8, right: 8, left: 8, bottom: 4 }}>
-          <CartesianGrid stroke={chartTheme.gridLine} vertical={false} />
+          <CartesianGrid stroke={theme.gridLine} vertical={false} />
           <XAxis
             dataKey="month"
             tickFormatter={shortMonthLabel}
-            stroke={chartTheme.textSecondary}
-            tick={{ fill: chartTheme.textMuted, fontSize: 10 }}
+            stroke={theme.textSecondary}
+            tick={{ fill: theme.textMuted, fontSize: 10 }}
             interval="preserveStartEnd"
             minTickGap={20}
           />
           <YAxis
             tickFormatter={formatShares}
-            stroke={chartTheme.textSecondary}
-            tick={{ fill: chartTheme.textMuted, fontSize: 10 }}
+            stroke={theme.textSecondary}
+            tick={{ fill: theme.textMuted, fontSize: 10 }}
             width={56}
           />
-          <ReferenceLine y={0} stroke={chartTheme.borderColor} />
-          <Tooltip content={<NetTooltip />} cursor={{ fill: chartTheme.gridLine }} />
+          <ReferenceLine y={0} stroke={theme.borderColor} />
+          <Tooltip content={<NetTooltip />} cursor={{ fill: theme.gridLine }} />
           <Bar dataKey="net" isAnimationActive={false}>
             {buckets.map((b) => (
               <Cell
                 key={b.month}
                 fill={
-                  b.net > 0 ? chartTheme.up : b.net < 0 ? chartTheme.down : chartTheme.borderColor
+                  b.net > 0 ? lightTheme.up : b.net < 0 ? lightTheme.down : theme.borderColor
                 }
               />
             ))}

--- a/frontend/src/components/insider/InsiderPriceMarkers.tsx
+++ b/frontend/src/components/insider/InsiderPriceMarkers.tsx
@@ -270,7 +270,12 @@ export function InsiderPriceMarkers({
     }));
     markersRef.current?.detach();
     markersRef.current = createSeriesMarkers(line, markers);
-  }, [transactions, cutoffMs, theme]);
+    // `theme` intentionally NOT in deps: marker colours come from
+    // `theme.up` / `theme.down` which are identical across light and
+    // dark (saturated palette, operator color memory). A theme flip
+    // would otherwise rebuild the entire marker plugin for no visible
+    // change.
+  }, [transactions, cutoffMs]);
 
   return (
     <div className="relative h-72 w-full" data-testid="insider-price-markers">

--- a/frontend/src/components/insider/InsiderPriceMarkers.tsx
+++ b/frontend/src/components/insider/InsiderPriceMarkers.tsx
@@ -34,8 +34,8 @@ import {
 
 import type { InsiderTransactionDetail } from "@/api/instruments";
 import type { CandleBar } from "@/api/types";
-import { chartTheme } from "@/lib/chartTheme";
 import { tickFormatter } from "@/lib/chartFormatters";
+import { useChartTheme } from "@/lib/useChartTheme";
 import {
   directionOf,
   notionalValue,
@@ -150,6 +150,7 @@ export function InsiderPriceMarkers({
   const markersRef = useRef<ReturnType<typeof createSeriesMarkers<Time>> | null>(
     null,
   );
+  const theme = useChartTheme();
 
   // Anchor at the start of the calendar month 23 months ago so the
   // marker pane shares its window with `InsiderNetByMonth` exactly.
@@ -165,23 +166,23 @@ export function InsiderPriceMarkers({
     const chart = createChart(container, {
       autoSize: true,
       layout: {
-        background: { color: chartTheme.bg },
-        textColor: chartTheme.textSecondary,
+        background: { color: theme.bg },
+        textColor: theme.textSecondary,
         fontSize: 11,
       },
       grid: {
-        vertLines: { color: chartTheme.gridLine },
-        horzLines: { color: chartTheme.gridLine },
+        vertLines: { color: theme.gridLine },
+        horzLines: { color: theme.gridLine },
       },
-      rightPriceScale: { borderColor: chartTheme.borderColor },
+      rightPriceScale: { borderColor: theme.borderColor },
       timeScale: {
-        borderColor: chartTheme.borderColor,
+        borderColor: theme.borderColor,
         timeVisible: false,
         secondsVisible: false,
       },
       crosshair: {
-        vertLine: { width: 1, color: chartTheme.crosshair, style: 3 },
-        horzLine: { width: 1, color: chartTheme.crosshair, style: 3 },
+        vertLine: { width: 1, color: theme.crosshair, style: 3 },
+        horzLine: { width: 1, color: theme.crosshair, style: 3 },
       },
     });
     chart.timeScale().applyOptions({
@@ -189,7 +190,7 @@ export function InsiderPriceMarkers({
     } as unknown as Parameters<ReturnType<IChartApi["timeScale"]>["applyOptions"]>[0]);
 
     const line = chart.addSeries(LineSeries, {
-      color: chartTheme.primaryLine,
+      color: theme.primaryLine,
       lineWidth: 2,
       lineType: LineType.Curved,
       priceLineVisible: false,
@@ -206,6 +207,29 @@ export function InsiderPriceMarkers({
       lineRef.current = null;
     };
   }, []);
+
+  // Re-apply theme-driven options on light/dark toggle. See PriceChart
+  // for the same pattern: applyOptions instead of recreating the chart
+  // preserves operator pan/zoom on the marker pane.
+  useEffect(() => {
+    const chart = chartRef.current;
+    const line = lineRef.current;
+    if (!chart || !line) return;
+    chart.applyOptions({
+      layout: { background: { color: theme.bg }, textColor: theme.textSecondary },
+      grid: {
+        vertLines: { color: theme.gridLine },
+        horzLines: { color: theme.gridLine },
+      },
+      rightPriceScale: { borderColor: theme.borderColor },
+      timeScale: { borderColor: theme.borderColor },
+      crosshair: {
+        vertLine: { color: theme.crosshair },
+        horzLine: { color: theme.crosshair },
+      },
+    });
+    line.applyOptions({ color: theme.primaryLine });
+  }, [theme]);
 
   // Feed price data. Filter to the last 24m window so the time axis
   // matches the markers' window.
@@ -239,14 +263,14 @@ export function InsiderPriceMarkers({
     const markers: SeriesMarker<Time>[] = buckets.map((b) => ({
       time: b.time as Time,
       position: b.direction === "acquired" ? "belowBar" : "aboveBar",
-      color: b.direction === "acquired" ? chartTheme.up : chartTheme.down,
+      color: b.direction === "acquired" ? theme.up : theme.down,
       shape: b.direction === "acquired" ? "arrowUp" : "arrowDown",
       size: markerSize(b.notional),
       text: bucketLabel(b),
     }));
     markersRef.current?.detach();
     markersRef.current = createSeriesMarkers(line, markers);
-  }, [transactions, cutoffMs]);
+  }, [transactions, cutoffMs, theme]);
 
   return (
     <div className="relative h-72 w-full" data-testid="insider-price-markers">

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -55,8 +55,9 @@ import { fetchInstrumentFinancials } from "@/api/instruments";
 import type { InstrumentFinancialRow, InstrumentSummary } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { Pane } from "@/components/instrument/Pane";
-import { chartTheme } from "@/lib/chartTheme";
+import { lightTheme } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
+import { useChartTheme } from "@/lib/useChartTheme";
 import { useCallback, useId, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -341,7 +342,7 @@ function FundamentalsGrid({
         points={revenue}
         nonNull={nonNullCount(revenue)}
         totalLen={totalLen}
-        fillColor={chartTheme.accent[1]}
+        fillColor={lightTheme.accent[1]}
       />
       <FundamentalCell
         label="Op income"
@@ -349,7 +350,7 @@ function FundamentalsGrid({
         points={opIncome}
         nonNull={nonNullCount(opIncome)}
         totalLen={totalLen}
-        fillColor={chartTheme.up}
+        fillColor={lightTheme.up}
       />
       <FundamentalCell
         label="Net income"
@@ -357,7 +358,7 @@ function FundamentalsGrid({
         points={netIncome}
         nonNull={nonNullCount(netIncome)}
         totalLen={totalLen}
-        fillColor={chartTheme.up}
+        fillColor={lightTheme.up}
       />
       <FundamentalCell
         label="Total debt"
@@ -365,7 +366,7 @@ function FundamentalsGrid({
         points={totalDebt}
         nonNull={nonNullCount(totalDebt)}
         totalLen={totalLen}
-        fillColor={chartTheme.accent[3]}
+        fillColor={lightTheme.accent[3]}
       />
     </div>
   );
@@ -386,6 +387,7 @@ function FundamentalCell({
   readonly totalLen: number;
   readonly fillColor: string;
 }) {
+  const theme = useChartTheme();
   const showCoverage = nonNull > 0 && nonNull < totalLen;
   const delta = yoyDelta(points);
   const lastIdx = lastNonNullIndex(points);
@@ -448,13 +450,13 @@ function FundamentalCell({
                 tickFormatter={formatPeriodTick}
                 interval="preserveStartEnd"
                 minTickGap={28}
-                tick={{ fill: chartTheme.textMuted, fontSize: 9 }}
-                stroke={chartTheme.borderColor}
+                tick={{ fill: theme.textMuted, fontSize: 9 }}
+                stroke={theme.borderColor}
                 tickLine={false}
                 axisLine={false}
               />
               <Tooltip
-                cursor={{ stroke: chartTheme.crosshair, strokeWidth: 1, strokeDasharray: "3 3" }}
+                cursor={{ stroke: theme.crosshair, strokeWidth: 1, strokeDasharray: "3 3" }}
                 formatter={(value) => {
                   // Recharts ValueType is string | number | (string|number)[].
                   // For null-valued points we expect Recharts to skip the
@@ -471,7 +473,7 @@ function FundamentalCell({
                 labelFormatter={formatPeriodTick}
                 contentStyle={{
                   fontSize: "11px",
-                  borderColor: chartTheme.borderColor,
+                  borderColor: theme.borderColor,
                   borderRadius: 4,
                 }}
               />

--- a/frontend/src/components/instrument/PriceChart.test.tsx
+++ b/frontend/src/components/instrument/PriceChart.test.tsx
@@ -89,6 +89,7 @@ vi.mock("lightweight-charts", () => {
     subscribeCrosshairMove: vi.fn((h: (p: unknown) => void) => {
       libState.crosshairHandlers.push(h);
     }),
+    applyOptions: vi.fn(),
     remove: libState.remove,
   };
   return {

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -52,8 +52,8 @@ import {
   humanizeVolume,
   tickFormatter,
 } from "@/lib/chartFormatters";
-import { chartTheme } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
+import { useChartTheme } from "@/lib/useChartTheme";
 import { useLiveLastBar } from "@/lib/useLiveLastBar";
 
 const RANGES: { id: ChartRange; label: string }[] = [
@@ -437,6 +437,7 @@ export function ChartCanvas({
   const lineRef = useRef<ISeriesApi<"Line"> | null>(null);
   const areaRef = useRef<ISeriesApi<"Area"> | null>(null);
   const volumeRef = useRef<ISeriesApi<"Histogram"> | null>(null);
+  const theme = useChartTheme();
   // Stable ref into `clean` for the crosshair handler — avoids stale
   // closure capture when rows update.
   const cleanRowsRef = useRef<NumericBar[]>([]);
@@ -467,22 +468,22 @@ export function ChartCanvas({
     const chart = createChart(container, {
       autoSize: true,
       layout: {
-        background: { color: chartTheme.bg },
-        textColor: chartTheme.textSecondary,
+        background: { color: theme.bg },
+        textColor: theme.textSecondary,
         fontSize: 11,
       },
       grid: {
-        vertLines: { color: chartTheme.gridLine },
-        horzLines: { color: chartTheme.gridLine },
+        vertLines: { color: theme.gridLine },
+        horzLines: { color: theme.gridLine },
       },
       rightPriceScale: {
-        borderColor: chartTheme.borderColor,
+        borderColor: theme.borderColor,
         // Leave room at the bottom for the volume overlay — matches
         // the TradingView default chart feel.
         scaleMargins: { top: 0.08, bottom: 0.3 },
       },
       timeScale: {
-        borderColor: chartTheme.borderColor,
+        borderColor: theme.borderColor,
         timeVisible: false,
         secondsVisible: false,
         // rightOffset: 5 leaves a 5-bar buffer past the last bar so
@@ -501,23 +502,23 @@ export function ChartCanvas({
         // `applyOptions` effect below instead.
       },
       crosshair: {
-        vertLine: { width: 1, color: chartTheme.crosshair, style: 3 },
-        horzLine: { width: 1, color: chartTheme.crosshair, style: 3 },
+        vertLine: { width: 1, color: theme.crosshair, style: 3 },
+        horzLine: { width: 1, color: theme.crosshair, style: 3 },
       },
     });
 
     const candle = chart.addSeries(CandlestickSeries, {
-      upColor: chartTheme.up,
-      downColor: chartTheme.down,
-      wickUpColor: chartTheme.up,
-      wickDownColor: chartTheme.down,
+      upColor: theme.up,
+      downColor: theme.down,
+      wickUpColor: theme.up,
+      wickDownColor: theme.down,
       borderVisible: false,
     });
     // Robinhood-style smooth line. `LineType.Curved` (cardinal-spline)
     // applies to both Line and Area series; we set it here once and the
     // subsequent visibility toggles preserve the smoothing.
     const line = chart.addSeries(LineSeries, {
-      color: chartTheme.primaryLine,
+      color: theme.primaryLine,
       lineWidth: 2,
       lineType: LineType.Curved,
       priceLineVisible: false,
@@ -525,8 +526,8 @@ export function ChartCanvas({
       visible: false,
     });
     const area = chart.addSeries(AreaSeries, {
-      lineColor: chartTheme.primaryLine,
-      topColor: chartTheme.volumeUpAlpha,
+      lineColor: theme.primaryLine,
+      topColor: theme.volumeUpAlpha,
       bottomColor: "rgba(30,41,59,0.0)",
       lineWidth: 2,
       lineType: LineType.Curved,
@@ -597,6 +598,40 @@ export function ChartCanvas({
       volumeRef.current = null;
     };
   }, []);
+
+  // Re-apply theme-driven options whenever the operator toggles
+  // light / dark. lightweight-charts has no first-class theme API, so
+  // we mirror every theme reference from the construction effect
+  // here. Running through applyOptions instead of recreating the
+  // chart preserves operator pan/zoom and the live-tick subscription.
+  useEffect(() => {
+    const chart = chartRef.current;
+    const candle = candleRef.current;
+    const line = lineRef.current;
+    const area = areaRef.current;
+    if (!chart || !candle || !line || !area) return;
+    chart.applyOptions({
+      layout: { background: { color: theme.bg }, textColor: theme.textSecondary },
+      grid: {
+        vertLines: { color: theme.gridLine },
+        horzLines: { color: theme.gridLine },
+      },
+      rightPriceScale: { borderColor: theme.borderColor },
+      timeScale: { borderColor: theme.borderColor },
+      crosshair: {
+        vertLine: { color: theme.crosshair },
+        horzLine: { color: theme.crosshair },
+      },
+    });
+    candle.applyOptions({
+      upColor: theme.up,
+      downColor: theme.down,
+      wickUpColor: theme.up,
+      wickDownColor: theme.down,
+    });
+    line.applyOptions({ color: theme.primaryLine });
+    area.applyOptions({ lineColor: theme.primaryLine, topColor: theme.volumeUpAlpha });
+  }, [theme]);
 
   // Toggle which price series is visible whenever `chartType` changes.
   // The data effect always feeds all three series, so flipping
@@ -737,7 +772,7 @@ export function ChartCanvas({
         return {
           time: b.time as Time,
           value: b.volume,
-          color: b.close >= prev ? chartTheme.volumeUpAlpha : chartTheme.volumeDownAlpha,
+          color: b.close >= prev ? theme.volumeUpAlpha : theme.volumeDownAlpha,
         };
       }),
     );
@@ -751,7 +786,7 @@ export function ChartCanvas({
       chart.timeScale().fitContent();
       fittedRangeRef.current = fingerprint;
     }
-  }, [clean, range]);
+  }, [clean, range, theme]);
 
 
   // Live-tick aggregator (#602). Subscribes to the page-level

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -786,7 +786,12 @@ export function ChartCanvas({
       chart.timeScale().fitContent();
       fittedRangeRef.current = fingerprint;
     }
-  }, [clean, range, theme]);
+    // `theme` intentionally NOT in deps: volumeUpAlpha / volumeDownAlpha
+    // are identical between light and dark (operator color memory), so
+    // a theme flip never changes the colour any bar should render.
+    // Re-running setData on every toggle would burn O(N bars) for no
+    // visible effect.
+  }, [clean, range]);
 
 
   // Live-tick aggregator (#602). Subscribes to the page-level

--- a/frontend/src/components/instrument/Sparkline.tsx
+++ b/frontend/src/components/instrument/Sparkline.tsx
@@ -9,7 +9,7 @@
  * polyline color via a Tailwind `text-*` class on `className` (e.g.
  * `text-emerald-500`). Existing FundamentalsPane callers rely on this.
  * For chart-theme alignment, new callers should pass
- * `stroke={chartTheme.accent[N]}` from `@/lib/chartTheme` — see #586.
+ * `stroke={lightTheme.accent[N]}` from `@/lib/chartTheme` — see #586.
  */
 
 import { useState, useCallback, type JSX } from "react";

--- a/frontend/src/lib/chartTheme.ts
+++ b/frontend/src/lib/chartTheme.ts
@@ -1,57 +1,101 @@
 /**
  * Chart theme — single source of truth for chart colors.
  *
- * Light-mode only in v1. Dark variant + theme-mode switch (light / dark /
- * system, persisted via Settings) are tracked at #596. When that ships,
- * this module exports `lightTheme` + `darkTheme` and consumers stop
- * importing the constants directly — they read via `useChartTheme()`.
+ * Two palettes (`lightTheme`, `darkTheme`) keyed identically. Consumers
+ * read the resolved palette via `useChartTheme()` so charts react to
+ * the operator's theme preference without remounting.
  *
- * Consumers in this PR (#586):
- *   - lightweight-charts options in `PriceChart` and `ChartWorkspaceCanvas`
- *   - `Sparkline` (referenced from JSDoc; default stroke remains
- *     `currentColor` so callers retain Tailwind `text-*`-driven coloring)
+ * Consumers in this module:
+ *   - lightweight-charts options in `PriceChart`, `ChartWorkspaceCanvas`,
+ *     and `InsiderPriceMarkers`
+ *   - recharts components in fundamentals / dividends / insider drill pages
+ *   - `Sparkline` (default stroke remains `currentColor` so callers retain
+ *     Tailwind `text-*`-driven coloring)
  *
- * Consumers in upcoming chart-redesign tickets (#587-#594):
- *   - `recharts` components in per-domain L2 drill pages
- *
- * Adding a new color: prefer reusing an existing slot. Add a new key only
- * if no existing slot fits the semantic role. Do NOT inline hex values in
- * chart components.
+ * Adding a new color: prefer reusing an existing slot. Add a new key
+ * only if no existing slot fits the semantic role. Add the key to BOTH
+ * palettes. Do NOT inline hex values in chart components.
  */
-
-export const chartTheme = {
+export interface ChartTheme {
   /** Background of the chart surface. Matches the page card chrome. */
-  bg: "#ffffff",
+  readonly bg: string;
 
   /**
    * Text scale.
-   * - `textPrimary` = hover values, important figures (slate-800)
-   * - `textSecondary` = axis labels, lightweight-charts `textColor` (slate-500)
-   * - `textMuted` = hover dates, ticks (slate-400)
+   * - `textPrimary` = hover values, important figures
+   * - `textSecondary` = axis labels, lightweight-charts `textColor`
+   * - `textMuted` = hover dates, ticks
    */
-  textPrimary: "#1e293b",
-  textSecondary: "#64748b",
-  textMuted: "#94a3b8",
+  readonly textPrimary: string;
+  readonly textSecondary: string;
+  readonly textMuted: string;
 
-  /** Grid lines (slate-100) and scale-axis borders (slate-200). */
-  gridLine: "#f1f5f9",
-  borderColor: "#e2e8f0",
+  /** Grid lines and scale-axis borders. */
+  readonly gridLine: string;
+  readonly borderColor: string;
 
   /** Crosshair vertical + horizontal guides. */
-  crosshair: "#94a3b8",
+  readonly crosshair: string;
 
   /** Market direction. Used by candles, deltas, and channel high/low. */
-  up: "#10b981",
-  down: "#ef4444",
+  readonly up: string;
+  readonly down: string;
 
   /** Volume histogram fill — translucent so it sits visibly under candles. */
-  volumeUpAlpha: "rgba(16,185,129,0.4)",
-  volumeDownAlpha: "rgba(239,68,68,0.4)",
+  readonly volumeUpAlpha: string;
+  readonly volumeDownAlpha: string;
 
   /**
    * Accent rotation for series overlays in recharts components and any
    * future multi-line viz. Cycle by index when rendering N series.
+   * Pinned to a 6-tuple so positional reads stay non-nullable under
+   * strict mode.
    */
+  readonly accent: readonly [string, string, string, string, string, string];
+
+  /**
+   * Indicator overlays (chart workspace SMA / EMA). Named slots keep the
+   * operator's mental map of "which color = which line" stable across
+   * sessions.
+   */
+  readonly indicator: {
+    readonly sma20: string;
+    readonly sma50: string;
+    readonly ema20: string;
+    readonly ema50: string;
+  };
+
+  /** Compare-overlay rotation in the chart workspace. Distinct from SMA palette.
+   *  Pinned to a 3-tuple for positional non-null reads. */
+  readonly compare: readonly [string, string, string];
+
+  /** Trend overlays (chart workspace). */
+  readonly regression: string;
+  readonly channelHigh: string;
+  readonly channelLow: string;
+
+  /** Primary normalized line in compare mode. */
+  readonly primaryLine: string;
+}
+
+export const lightTheme: ChartTheme = {
+  bg: "#ffffff",
+
+  textPrimary: "#1e293b", // slate-800
+  textSecondary: "#64748b", // slate-500
+  textMuted: "#94a3b8", // slate-400
+
+  gridLine: "#f1f5f9", // slate-100
+  borderColor: "#e2e8f0", // slate-200
+
+  crosshair: "#94a3b8", // slate-400
+
+  up: "#10b981", // emerald-500
+  down: "#ef4444", // red-500
+
+  volumeUpAlpha: "rgba(16,185,129,0.4)",
+  volumeDownAlpha: "rgba(239,68,68,0.4)",
+
   accent: [
     "#06b6d4", // cyan-500
     "#3b82f6", // blue-500
@@ -59,13 +103,8 @@ export const chartTheme = {
     "#f59e0b", // amber-500
     "#ec4899", // pink-500
     "#84cc16", // lime-500
-  ] as const,
+  ],
 
-  /**
-   * Indicator overlays (chart workspace SMA / EMA). Named slots keep the
-   * operator's mental map of "which color = which line" stable across
-   * sessions. Picks from `accent` plus sky-500 for the EMA(20) slot.
-   */
   indicator: {
     sma20: "#3b82f6", // blue-500 (matches accent[1])
     sma50: "#a855f7", // purple-500 (matches accent[2])
@@ -73,20 +112,51 @@ export const chartTheme = {
     ema50: "#ec4899", // pink-500 (matches accent[4])
   },
 
-  /** Compare-overlay rotation in the chart workspace. Distinct from SMA palette. */
   compare: [
     "#0ea5e9", // sky-500
     "#a855f7", // purple-500
     "#f59e0b", // amber-500
-  ] as const,
+  ],
 
-  /** Trend overlays (chart workspace). */
   regression: "#f97316", // orange-500
   channelHigh: "#10b981",
   channelLow: "#ef4444",
 
-  /** Primary normalized line in compare mode (slate-800, picks reading order). */
-  primaryLine: "#1e293b",
-} as const;
+  primaryLine: "#1e293b", // slate-800
+};
 
-export type ChartTheme = typeof chartTheme;
+/**
+ * Dark palette. Keys mirror `lightTheme`; only surface / chrome tones
+ * are overridden. Saturated accents (up/down/accent rotation/indicator
+ * slots/regression/channel) reuse the light-mode references — they
+ * remain legible on dark surfaces and preserve the operator's color
+ * memory ("blue line = SMA20" across sessions).
+ */
+export const darkTheme: ChartTheme = {
+  bg: "#0f172a", // slate-900 — matches dark page card chrome
+
+  textPrimary: "#f1f5f9", // slate-100
+  textSecondary: "#94a3b8", // slate-400
+  textMuted: "#64748b", // slate-500
+
+  gridLine: "#1e293b", // slate-800
+  borderColor: "#334155", // slate-700
+
+  crosshair: "#64748b", // slate-500
+
+  up: lightTheme.up,
+  down: lightTheme.down,
+
+  volumeUpAlpha: lightTheme.volumeUpAlpha,
+  volumeDownAlpha: lightTheme.volumeDownAlpha,
+
+  accent: lightTheme.accent,
+  indicator: lightTheme.indicator,
+  compare: lightTheme.compare,
+
+  regression: lightTheme.regression,
+  channelHigh: lightTheme.channelHigh,
+  channelLow: lightTheme.channelLow,
+
+  primaryLine: "#f1f5f9", // slate-100 — keeps reading-order weight in dark
+};

--- a/frontend/src/lib/theme.tsx
+++ b/frontend/src/lib/theme.tsx
@@ -13,7 +13,7 @@
  *
  * Consumers:
  *   - Components: use Tailwind `dark:` utility variants directly.
- *   - Charts: import `useChartTheme()` from `@/lib/chartTheme` to
+ *   - Charts: import `useChartTheme()` from `@/lib/useChartTheme` to
  *     get a tone-aware theme object.
  */
 import {
@@ -37,7 +37,13 @@ interface ThemeContextValue {
   readonly setPreference: (next: ThemePreference) => void;
 }
 
-const ThemeContext = createContext<ThemeContextValue | null>(null);
+/**
+ * Exported so `useChartTheme()` can read the context directly with a
+ * defensive fallback to the light palette when no provider is mounted
+ * (matters for isolated chart unit tests). Components needing the
+ * provider's full contract should still call `useTheme()`.
+ */
+export const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 const STORAGE_KEY = "ebull.theme";
 

--- a/frontend/src/lib/useChartTheme.test.tsx
+++ b/frontend/src/lib/useChartTheme.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { darkTheme, lightTheme } from "./chartTheme";
+import { ThemeProvider, useTheme } from "./theme";
+import { useChartTheme } from "./useChartTheme";
+
+function ProbeAndToggle() {
+  const theme = useChartTheme();
+  const { setPreference } = useTheme();
+  return (
+    <div>
+      <span data-testid="bg">{theme.bg}</span>
+      <span data-testid="primary-line">{theme.primaryLine}</span>
+      <button onClick={() => setPreference("dark")}>force-dark</button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.classList.remove("dark");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useChartTheme", () => {
+  it("returns the light palette when the resolved theme is light", () => {
+    // Pin to light explicitly so the system-pref fallback does not flip
+    // the resolved value on a dark-defaulted CI runner.
+    window.localStorage.setItem("ebull.theme", "light");
+    render(
+      <ThemeProvider>
+        <ProbeAndToggle />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("bg")).toHaveTextContent(lightTheme.bg);
+    expect(screen.getByTestId("primary-line")).toHaveTextContent(
+      lightTheme.primaryLine,
+    );
+  });
+
+  it("flips to the dark palette when the operator switches preference", async () => {
+    window.localStorage.setItem("ebull.theme", "light");
+    render(
+      <ThemeProvider>
+        <ProbeAndToggle />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByText("force-dark"));
+    expect(screen.getByTestId("bg")).toHaveTextContent(darkTheme.bg);
+    expect(screen.getByTestId("primary-line")).toHaveTextContent(
+      darkTheme.primaryLine,
+    );
+  });
+
+  it("keeps saturated accents identical across light and dark", () => {
+    // Operator color memory: blue line = SMA20 across sessions. The
+    // dark-mode design intentionally reuses the light palette for
+    // accent / indicator / compare slots; this test pins that contract.
+    expect(darkTheme.accent).toBe(lightTheme.accent);
+    expect(darkTheme.indicator).toBe(lightTheme.indicator);
+    expect(darkTheme.compare).toBe(lightTheme.compare);
+    expect(darkTheme.up).toBe(lightTheme.up);
+    expect(darkTheme.down).toBe(lightTheme.down);
+  });
+});

--- a/frontend/src/lib/useChartTheme.ts
+++ b/frontend/src/lib/useChartTheme.ts
@@ -1,0 +1,31 @@
+/**
+ * Theme-aware chart palette accessor.
+ *
+ * Resolves the operator's current theme preference (light / dark /
+ * system) to the matching `ChartTheme` object. Charts call this at the
+ * top of their component body and either:
+ *
+ *   - pass the resolved theme through `useEffect` deps so a
+ *     lightweight-charts instance re-applies options on theme change
+ *     (without recreating the chart and dropping operator pan/zoom);
+ *   - reference the resolved theme directly in JSX, since recharts
+ *     re-renders on prop change.
+ *
+ * Falls back to `lightTheme` when no `ThemeProvider` is in the tree.
+ * The App root always wraps in `ThemeProvider`, so the fallback only
+ * fires in unit tests that mount chart components in isolation —
+ * keeping every existing chart test from needing a Provider wrapper.
+ */
+import { useContext, useMemo } from "react";
+
+import { darkTheme, lightTheme, type ChartTheme } from "@/lib/chartTheme";
+import { ThemeContext } from "@/lib/theme";
+
+export function useChartTheme(): ChartTheme {
+  const ctx = useContext(ThemeContext);
+  const resolved = ctx?.resolved ?? "light";
+  return useMemo<ChartTheme>(
+    () => (resolved === "dark" ? darkTheme : lightTheme),
+    [resolved],
+  );
+}

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -31,16 +31,19 @@ import {
   humanizeVolume,
   tickFormatter,
 } from "@/lib/chartFormatters";
-import { chartTheme } from "@/lib/chartTheme";
+import { lightTheme } from "@/lib/chartTheme";
+import { useChartTheme } from "@/lib/useChartTheme";
 import { useLiveLastBar } from "@/lib/useLiveLastBar";
 
 export type IndicatorId = "sma20" | "sma50" | "ema20" | "ema50";
 export const INDICATOR_IDS: IndicatorId[] = ["sma20", "sma50", "ema20", "ema50"];
 
 // Keep palette keys exhaustively typed against IndicatorId so a missing or
-// misspelled key in chartTheme.indicator fails typecheck rather than
-// returning undefined at runtime.
-const SMA_COLORS: Record<IndicatorId, string> = chartTheme.indicator;
+// misspelled key in theme.indicator fails typecheck rather than
+// returning undefined at runtime. Indicator slots are saturated and
+// identical across light/dark, so reading from `lightTheme` directly
+// avoids threading the theme hook through every indicator setter.
+const SMA_COLORS: Record<IndicatorId, string> = lightTheme.indicator;
 
 const SMA_LABELS: Record<IndicatorId, string> = {
   sma20: "SMA(20)",
@@ -50,7 +53,8 @@ const SMA_LABELS: Record<IndicatorId, string> = {
 };
 
 // Fixed palette for compare overlays — distinct from SMA colors.
-export const COMPARE_COLORS: readonly string[] = chartTheme.compare;
+// Compare slots are also saturated and identical across light/dark.
+export const COMPARE_COLORS: readonly string[] = lightTheme.compare;
 
 export interface CompareSeries {
   readonly symbol: string;
@@ -218,6 +222,7 @@ export function ChartWorkspaceCanvas({
   const chartRef = useRef<IChartApi | null>(null);
   const candleRef = useRef<ISeriesApi<"Candlestick"> | null>(null);
   const volumeRef = useRef<ISeriesApi<"Histogram"> | null>(null);
+  const theme = useChartTheme();
   // Primary normalized line (used in compare mode instead of candles).
   const primaryLineRef = useRef<ISeriesApi<"Line"> | null>(null);
   const indicatorRefs = useRef<Map<IndicatorId, ISeriesApi<"Line">>>(new Map());
@@ -266,20 +271,20 @@ export function ChartWorkspaceCanvas({
     const chart = createChart(container, {
       autoSize: true,
       layout: {
-        background: { color: chartTheme.bg },
-        textColor: chartTheme.textSecondary,
+        background: { color: theme.bg },
+        textColor: theme.textSecondary,
         fontSize: 11,
       },
       grid: {
-        vertLines: { color: chartTheme.gridLine },
-        horzLines: { color: chartTheme.gridLine },
+        vertLines: { color: theme.gridLine },
+        horzLines: { color: theme.gridLine },
       },
       rightPriceScale: {
-        borderColor: chartTheme.borderColor,
+        borderColor: theme.borderColor,
         scaleMargins: { top: 0.08, bottom: 0.3 },
       },
       timeScale: {
-        borderColor: chartTheme.borderColor,
+        borderColor: theme.borderColor,
         timeVisible: false,
         secondsVisible: false,
         // 5-bar right buffer keeps the rightmost axis tick on a clean
@@ -288,16 +293,16 @@ export function ChartWorkspaceCanvas({
         rightOffset: 5,
       },
       crosshair: {
-        vertLine: { width: 1, color: chartTheme.crosshair, style: 3 },
-        horzLine: { width: 1, color: chartTheme.crosshair, style: 3 },
+        vertLine: { width: 1, color: theme.crosshair, style: 3 },
+        horzLine: { width: 1, color: theme.crosshair, style: 3 },
       },
     });
 
     const candle = chart.addSeries(CandlestickSeries, {
-      upColor: chartTheme.up,
-      downColor: chartTheme.down,
-      wickUpColor: chartTheme.up,
-      wickDownColor: chartTheme.down,
+      upColor: theme.up,
+      downColor: theme.down,
+      wickUpColor: theme.up,
+      wickDownColor: theme.down,
       borderVisible: false,
     });
 
@@ -308,7 +313,7 @@ export function ChartWorkspaceCanvas({
     chart.priceScale("volume").applyOptions({ scaleMargins: { top: 0.75, bottom: 0 } });
 
     const primaryLine = chart.addSeries(LineSeries, {
-      color: chartTheme.primaryLine,
+      color: theme.primaryLine,
       lineWidth: 2,
       priceLineVisible: false,
       lastValueVisible: false,
@@ -338,7 +343,7 @@ export function ChartWorkspaceCanvas({
             // Read color from the symbol-keyed ref populated when the
             // LineSeries was created — keeps tooltip in sync with the
             // actual rendered series even if Map iteration order drifts.
-            color: compareColorRef.current.get(sym) ?? chartTheme.compare[0],
+            color: compareColorRef.current.get(sym) ?? theme.compare[0],
             value: norm[idx] ?? null,
           }));
         const date = formatHoverLabel(time, intradayRef.current);
@@ -403,6 +408,37 @@ export function ChartWorkspaceCanvas({
       compareLineRefs.current.clear();
     };
   }, [symbol]);
+
+  // Re-apply theme-driven options on light/dark toggle. Mirrors the
+  // construction effect's chrome-tone references. applyOptions instead
+  // of recreating the chart preserves operator pan/zoom and the
+  // live-tick subscription. See PriceChart for the same pattern.
+  useEffect(() => {
+    const chart = chartRef.current;
+    const candle = candleRef.current;
+    const primaryLine = primaryLineRef.current;
+    if (!chart || !candle || !primaryLine) return;
+    chart.applyOptions({
+      layout: { background: { color: theme.bg }, textColor: theme.textSecondary },
+      grid: {
+        vertLines: { color: theme.gridLine },
+        horzLines: { color: theme.gridLine },
+      },
+      rightPriceScale: { borderColor: theme.borderColor },
+      timeScale: { borderColor: theme.borderColor },
+      crosshair: {
+        vertLine: { color: theme.crosshair },
+        horzLine: { color: theme.crosshair },
+      },
+    });
+    candle.applyOptions({
+      upColor: theme.up,
+      downColor: theme.down,
+      wickUpColor: theme.up,
+      wickDownColor: theme.down,
+    });
+    primaryLine.applyOptions({ color: theme.primaryLine });
+  }, [theme]);
 
   // Numeric / null-filtered rows. Computed during render so values
   // are available to the live-tick aggregator's historical anchor on
@@ -471,7 +507,7 @@ export function ChartWorkspaceCanvas({
         if (v === null || v === undefined || !bar) continue;
         lineData.push({ time: bar.time as Time, value: v });
       }
-      primaryLine.applyOptions({ visible: true, color: chartTheme.primaryLine, lineWidth: 2 });
+      primaryLine.applyOptions({ visible: true, color: theme.primaryLine, lineWidth: 2 });
       primaryLine.setData(lineData);
     } else {
       // Normal mode: show candles + volume; hide primary normalized line.
@@ -494,7 +530,7 @@ export function ChartWorkspaceCanvas({
           return {
             time: b.time as Time,
             value: b.volume,
-            color: b.close >= prev ? chartTheme.volumeUpAlpha : chartTheme.volumeDownAlpha,
+            color: b.close >= prev ? theme.volumeUpAlpha : theme.volumeDownAlpha,
           };
         }),
       );
@@ -507,7 +543,7 @@ export function ChartWorkspaceCanvas({
       chart.timeScale().fitContent();
       fittedFingerprintRef.current = fingerprint;
     }
-  }, [clean, compareMode, range]);
+  }, [clean, compareMode, range, theme]);
 
 
   // Compare series: fetch + render normalized lines per compare symbol.
@@ -532,7 +568,7 @@ export function ChartWorkspaceCanvas({
     // Add/update series for each compare symbol.
     compares.forEach((cs, colorIdx) => {
       const color =
-        COMPARE_COLORS[colorIdx % COMPARE_COLORS.length] ?? chartTheme.compare[0];
+        COMPARE_COLORS[colorIdx % COMPARE_COLORS.length] ?? theme.compare[0];
       compareColorRef.current.set(cs.symbol, color);
 
       const compareClean: NumericBar[] = cs.rows.flatMap((r) => {
@@ -660,7 +696,7 @@ export function ChartWorkspaceCanvas({
       const regValues = linearRegressionLine(closes);
       if (!regressionRef.current) {
         regressionRef.current = chart.addSeries(LineSeries, {
-          color: chartTheme.regression,
+          color: theme.regression,
           lineWidth: 1,
           lineStyle: 2, // dashed
           priceLineVisible: false,
@@ -687,7 +723,7 @@ export function ChartWorkspaceCanvas({
     if (showChannel && high !== null && low !== null && clean.length >= 2) {
       if (!channelHighRef.current) {
         channelHighRef.current = chart.addSeries(LineSeries, {
-          color: chartTheme.channelHigh,
+          color: theme.channelHigh,
           lineWidth: 1,
           lineStyle: 3, // dotted
           priceLineVisible: false,
@@ -696,7 +732,7 @@ export function ChartWorkspaceCanvas({
       }
       if (!channelLowRef.current) {
         channelLowRef.current = chart.addSeries(LineSeries, {
-          color: chartTheme.channelLow,
+          color: theme.channelLow,
           lineWidth: 1,
           lineStyle: 3, // dotted
           priceLineVisible: false,

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -543,7 +543,11 @@ export function ChartWorkspaceCanvas({
       chart.timeScale().fitContent();
       fittedFingerprintRef.current = fingerprint;
     }
-  }, [clean, compareMode, range, theme]);
+    // `theme` intentionally NOT in deps: volume alphas are identical
+    // across light/dark; primaryLine recolouring is handled by the
+    // theme-update effect via applyOptions. See PriceChart for the
+    // same rationale.
+  }, [clean, compareMode, range]);
 
 
   // Compare series: fetch + render normalized lines per compare symbol.


### PR DESCRIPTION
Closes #701. First slice of #700 epic.

## What

- Split `frontend/src/lib/chartTheme.ts` into `lightTheme` + `darkTheme` behind a stable `ChartTheme` interface
- New `frontend/src/lib/useChartTheme.ts` resolves operator preference to the matching palette
- Wired all 8 chart consumers to the hook:
  - lightweight-charts: `PriceChart`, `ChartWorkspaceCanvas`, `InsiderPriceMarkers`
  - Recharts: `FundamentalsPane`, `fundamentalsCharts`, `dividendsCharts`, `InsiderByOfficer`, `InsiderNetByMonth`

## Why

Operator screenshot pass on PR #699 (dark mode Phase 1) flagged white chart panels leaking through the dark shell — chartTheme was hardcoded light-mode hex literals. This is the most jarring finding in the Phase 2 token coverage scan; ships first ahead of #702 / #703 / #704.

## Test plan

- [x] `pnpm --dir frontend typecheck` — clean
- [x] `pnpm --dir frontend test:unit` — 746/746 pass (added 3 new tests in `useChartTheme.test.tsx`)
- [ ] Operator pass: toggle L / D in header, confirm PriceChart, FundamentalsPane, all L2 drill charts switch palettes live without remount
- [ ] Operator pass: pan/zoom on PriceChart survives a theme flip (lightweight-charts `applyOptions` path)

## Implementation notes

- **lightweight-charts** has no first-class theme API. Construction effect keeps `[]` deps; a separate theme-update effect calls `chart.applyOptions(...)` + per-series `applyOptions` on theme change so operator pan/zoom and the live-tick subscription survive.
- **Recharts** re-renders on prop change. Module-level `SHARED_AXIS` / `SHARED_GRID` constants became `sharedAxis(theme)` factories + `<SharedGrid theme={theme} />`.
- Saturated palette slots (`up`, `down`, `accent`, `indicator`, `compare`, `regression`, `channelHigh/Low`) reuse the light-mode references in dark — preserves the operator's color memory ("blue line = SMA20" across sessions). Only chrome tones flip.
- `useChartTheme()` falls back to `lightTheme` when no `ThemeProvider` is mounted so existing chart unit tests render in isolation without a wrapper.

## Out of scope (other Phase 2 sub-issues)

- #702 — form input + button surface sweep
- #703 — page heading + dense table cell text sweep
- #704 — border + hover state polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)