### PR TITLE
feat(#702): dark mode Phase 2b — form input + button surface sweep

### DIFF
--- a/frontend/src/components/admin/LayerHealthList.tsx
+++ b/frontend/src/components/admin/LayerHealthList.tsx
@@ -112,12 +112,12 @@ export function LayerHealthList({ layers, onToggle }: LayerHealthListProps): JSX
                 type="button"
                 aria-label={`${entry.layer} actions`}
                 onClick={() => setMenuOpen(menuOpen === entry.layer ? null : entry.layer)}
-                className="rounded border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50"
+                className="rounded border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
               >
                 ⋯
               </button>
               {menuOpen === entry.layer ? (
-                <div className="absolute right-0 top-full z-10 mt-1 w-40 rounded border border-slate-200 bg-white shadow">
+                <div className="absolute right-0 top-full z-10 mt-1 w-40 rounded border border-slate-200 bg-white shadow dark:border-slate-700 dark:bg-slate-900">
                   <button
                     type="button"
                     onClick={() => {
@@ -137,7 +137,7 @@ export function LayerHealthList({ layers, onToggle }: LayerHealthListProps): JSX
                       onToggle(entry.layer, nextEnabled);
                       setMenuOpen(null);
                     }}
-                    className="block w-full px-3 py-1 text-left text-xs text-slate-700 hover:bg-slate-50"
+                    className="block w-full px-3 py-1 text-left text-xs text-slate-700 hover:bg-slate-50 dark:text-slate-100 dark:hover:bg-slate-800"
                   >
                     {isDisabled ? "Enable layer" : "Disable layer"}
                   </button>

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -86,7 +86,7 @@ export function ProblemsPanel({
   const allPending = pendingSources.length === 3;
   if (allPending) {
     return (
-      <div className="rounded-md border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600">
+      <div className="rounded-md border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900/40 dark:text-slate-300">
         Checking for problems…
       </div>
     );
@@ -117,16 +117,16 @@ export function ProblemsPanel({
   const tone = totalProblems > 0 ? "red" : erroredSources.length > 0 ? "amber" : "neutral";
   const sectionTone =
     tone === "red"
-      ? "border-red-200 bg-red-50"
+      ? "border-red-200 bg-red-50 dark:border-red-900/60 dark:bg-red-950/30"
       : tone === "amber"
-        ? "border-amber-200 bg-amber-50"
-        : "border-slate-200 bg-slate-50";
+        ? "border-amber-200 bg-amber-50 dark:border-amber-900/60 dark:bg-amber-950/30"
+        : "border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-900/40";
   const headerTone =
     tone === "red"
-      ? "border-red-200 text-red-800"
+      ? "border-red-200 text-red-800 dark:border-red-900/60 dark:text-red-300"
       : tone === "amber"
-        ? "border-amber-200 text-amber-800"
-        : "border-slate-200 text-slate-700";
+        ? "border-amber-200 text-amber-800 dark:border-amber-900/60 dark:text-amber-300"
+        : "border-slate-200 text-slate-700 dark:border-slate-800 dark:text-slate-200";
 
   return (
     <section role="region" aria-label="Current problems" className={`rounded-md border shadow-sm ${sectionTone}`}>

--- a/frontend/src/components/admin/SeedProgressPanel.tsx
+++ b/frontend/src/components/admin/SeedProgressPanel.tsx
@@ -107,7 +107,7 @@ export function SeedProgressPanel() {
           type="button"
           onClick={handleTogglePause}
           disabled={toggleBusy || seed === null}
-          className="rounded border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
         >
           {toggleLabel}
         </button>
@@ -151,7 +151,7 @@ export function SeedProgressPanel() {
                       {formatPct(src.seeded, src.total)}
                     </span>
                   </div>
-                  <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-slate-100">
+                  <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
                     <div
                       className="h-full rounded-full bg-sky-500 transition-all"
                       style={{ width: `${pct}%` }}
@@ -194,9 +194,9 @@ function LatestRunRow({
           ? "text-amber-600"
           : "text-red-600";
   return (
-    <div className="rounded border border-slate-200 bg-slate-50 px-3 py-2 text-xs">
+    <div className="rounded border border-slate-200 bg-slate-50 px-3 py-2 text-xs dark:border-slate-800 dark:bg-slate-900/40">
       <div className="flex items-center justify-between">
-        <span className="font-medium text-slate-700">Latest run #{run.ingestion_run_id}</span>
+        <span className="font-medium text-slate-700 dark:text-slate-200">Latest run #{run.ingestion_run_id}</span>
         <span className={`font-semibold ${tone}`}>{run.status}</span>
       </div>
       <div className="mt-1 grid grid-cols-2 gap-x-4 gap-y-1 text-slate-600 sm:grid-cols-4">

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -136,12 +136,12 @@ function RowShell({
 }) {
   const border = unseen
     ? "border-l-4 border-amber-400"
-    : "border-l-4 border-slate-200";
+    : "border-l-4 border-slate-200 dark:border-slate-800";
   const content = (
     <div
       data-testid="alerts-row"
       role="listitem"
-      className={`flex items-center gap-3 px-3 py-2 text-sm ${border} bg-white`}
+      className={`flex items-center gap-3 px-3 py-2 text-sm ${border} bg-white dark:bg-slate-900`}
     >
       <KindPill kind={kind} />
       {children}
@@ -149,7 +149,10 @@ function RowShell({
   );
   if (instrumentId !== null) {
     return (
-      <Link to={`/instruments/${instrumentId}`} className="block hover:bg-slate-50">
+      <Link
+        to={`/instruments/${instrumentId}`}
+        className="block hover:bg-slate-50 dark:hover:bg-slate-800/40"
+      >
         {content}
       </Link>
     );
@@ -416,7 +419,7 @@ export function AlertsStrip(): JSX.Element | null {
           <button
             type="button"
             onClick={onMarkAllRead}
-            className="rounded border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+            className="rounded border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
           >
             Mark all read
           </button>

--- a/frontend/src/components/instrument/EightKDetailPanel.tsx
+++ b/frontend/src/components/instrument/EightKDetailPanel.tsx
@@ -16,13 +16,13 @@ export function EightKDetailPanel({
 }: EightKDetailPanelProps): JSX.Element {
   if (filing === null) {
     return (
-      <div className="rounded border border-slate-200 bg-white p-4 text-sm text-slate-500">
+      <div className="rounded border border-slate-200 bg-white p-4 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
         Select a row to view item bodies + exhibits.
       </div>
     );
   }
   return (
-    <div className="space-y-4 rounded border border-slate-200 bg-white p-4 text-sm">
+    <div className="space-y-4 rounded border border-slate-200 bg-white p-4 text-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100">
       <div>
         <div className="text-[10px] uppercase tracking-wider text-slate-500">
           Filing

--- a/frontend/src/components/instrument/EightKFilterStrip.tsx
+++ b/frontend/src/components/instrument/EightKFilterStrip.tsx
@@ -29,11 +29,11 @@ export function EightKFilterStrip({
     value.dateTo !== "";
 
   return (
-    <div className="flex flex-wrap items-end gap-3 rounded border border-slate-200 bg-slate-50 p-3 text-xs">
+    <div className="flex flex-wrap items-end gap-3 rounded border border-slate-200 bg-slate-50 p-3 text-xs dark:border-slate-800 dark:bg-slate-900/40">
       <label className="flex flex-col">
-        <span className="text-slate-500">Severity</span>
+        <span className="text-slate-500 dark:text-slate-400">Severity</span>
         <select
-          className="mt-0.5 rounded border border-slate-300 bg-white px-2 py-1"
+          className="mt-0.5 rounded border border-slate-300 bg-white px-2 py-1 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
           value={value.severity}
           onChange={(e) =>
             onChange({
@@ -49,29 +49,29 @@ export function EightKFilterStrip({
         </select>
       </label>
       <label className="flex flex-col">
-        <span className="text-slate-500">Item code</span>
+        <span className="text-slate-500 dark:text-slate-400">Item code</span>
         <input
           type="text"
           placeholder="e.g. 5.02"
-          className="mt-0.5 rounded border border-slate-300 bg-white px-2 py-1"
+          className="mt-0.5 rounded border border-slate-300 bg-white px-2 py-1 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500"
           value={value.itemCode}
           onChange={(e) => onChange({ ...value, itemCode: e.target.value })}
         />
       </label>
       <label className="flex flex-col">
-        <span className="text-slate-500">From</span>
+        <span className="text-slate-500 dark:text-slate-400">From</span>
         <input
           type="date"
-          className="mt-0.5 rounded border border-slate-300 bg-white px-2 py-1"
+          className="mt-0.5 rounded border border-slate-300 bg-white px-2 py-1 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
           value={value.dateFrom}
           onChange={(e) => onChange({ ...value, dateFrom: e.target.value })}
         />
       </label>
       <label className="flex flex-col">
-        <span className="text-slate-500">To</span>
+        <span className="text-slate-500 dark:text-slate-400">To</span>
         <input
           type="date"
-          className="mt-0.5 rounded border border-slate-300 bg-white px-2 py-1"
+          className="mt-0.5 rounded border border-slate-300 bg-white px-2 py-1 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
           value={value.dateTo}
           onChange={(e) => onChange({ ...value, dateTo: e.target.value })}
         />
@@ -79,7 +79,7 @@ export function EightKFilterStrip({
       {isDirty && (
         <button
           type="button"
-          className="ml-auto rounded border border-slate-300 px-2 py-1 hover:bg-white"
+          className="ml-auto rounded border border-slate-300 px-2 py-1 hover:bg-white dark:border-slate-700 dark:hover:bg-slate-800"
           onClick={() =>
             onChange({ severity: "", itemCode: "", dateFrom: "", dateTo: "" })
           }

--- a/frontend/src/components/orders/ClosePositionModal.tsx
+++ b/frontend/src/components/orders/ClosePositionModal.tsx
@@ -249,7 +249,7 @@ export function ClosePositionModal({
                       value={rawUnits}
                       onChange={(e) => setRawUnits(e.target.value)}
                       placeholder={formatNumber(trade.units, 6)}
-                      className="w-28 rounded border border-slate-300 bg-white px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
+                      className="w-28 rounded border border-slate-300 bg-white px-2 py-1 text-sm focus:border-blue-400 focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500"
                     />
                   </div>
                   {parsedUnits !== null && parsedUnits > trade.units ? (
@@ -293,7 +293,7 @@ export function ClosePositionModal({
             type="button"
             onClick={onRequestClose}
             disabled={submitting}
-            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
           >
             Cancel
           </button>

--- a/frontend/src/components/orders/OrderEntryModal.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.tsx
@@ -206,7 +206,7 @@ export function OrderEntryModal({
               value={rawInput}
               onChange={(e) => setRawInput(e.target.value)}
               placeholder={mode === "amount" ? "250.00" : "2.000000"}
-              className="rounded border border-slate-300 bg-white px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+              className="rounded border border-slate-300 bg-white px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500"
             />
           </label>
         </fieldset>
@@ -234,7 +234,7 @@ export function OrderEntryModal({
             type="button"
             onClick={onRequestClose}
             disabled={submitting}
-            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
           >
             Cancel
           </button>

--- a/frontend/src/components/rankings/RankingsFilters.tsx
+++ b/frontend/src/components/rankings/RankingsFilters.tsx
@@ -136,7 +136,7 @@ export function RankingsFilters({
         type="button"
         onClick={onClearAll}
         disabled={!filtersDirty}
-        className="ml-auto rounded border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+        className="ml-auto rounded border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
       >
         Clear filters
       </button>
@@ -167,4 +167,4 @@ function FilterField({
 }
 
 const fieldClass =
-  "mt-1 rounded border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-700 focus:border-blue-500 focus:outline-none";
+  "mt-1 rounded border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-700 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500";

--- a/frontend/src/components/recommendations/AuditFilters.tsx
+++ b/frontend/src/components/recommendations/AuditFilters.tsx
@@ -103,7 +103,7 @@ export function AuditFilters({
         type="button"
         onClick={onClearAll}
         disabled={!filtersDirty}
-        className="ml-auto rounded border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+        className="ml-auto rounded border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
       >
         Clear filters
       </button>
@@ -134,4 +134,4 @@ function FilterField({
 }
 
 const fieldClass =
-  "mt-1 rounded border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-700 focus:border-blue-500 focus:outline-none";
+  "mt-1 rounded border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-700 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500";

--- a/frontend/src/components/recommendations/RecommendationsFilters.tsx
+++ b/frontend/src/components/recommendations/RecommendationsFilters.tsx
@@ -71,7 +71,7 @@ export function RecommendationsFilters({
         type="button"
         onClick={onClearAll}
         disabled={!filtersDirty}
-        className="ml-auto rounded border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+        className="ml-auto rounded border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
       >
         Clear filters
       </button>
@@ -102,4 +102,4 @@ function FilterField({
 }
 
 const fieldClass =
-  "mt-1 rounded border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-700 focus:border-blue-500 focus:outline-none";
+  "mt-1 rounded border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-700 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500";

--- a/frontend/src/components/security/RecoveryPhraseConfirm.tsx
+++ b/frontend/src/components/security/RecoveryPhraseConfirm.tsx
@@ -308,7 +308,7 @@ export function RecoveryPhraseConfirm({
           <button
             type="button"
             onClick={onCancel}
-            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-100"
+            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
           >
             Cancel
           </button>
@@ -362,7 +362,7 @@ export function RecoveryPhraseConfirm({
                 onChange={(event: ChangeEvent<HTMLInputElement>) =>
                   handleEntryChange(slot, event.target.value)
                 }
-                className="rounded border border-slate-300 px-2 py-1.5 font-mono text-sm text-slate-800"
+                className="rounded border border-slate-300 px-2 py-1.5 font-mono text-sm text-slate-800 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
               />
             </label>
           );
@@ -381,7 +381,7 @@ export function RecoveryPhraseConfirm({
         <button
           type="button"
           onClick={onCancel}
-          className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-100"
+          className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
         >
           Cancel
         </button>

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -568,7 +568,7 @@ export function ChartPage(): JSX.Element {
               onChange={(e) => setCompareInput(e.target.value)}
               onKeyDown={handleCompareKeyDown}
               placeholder="Add ticker to compare..."
-              className="rounded border border-slate-200 bg-white px-2 py-0.5 text-xs text-slate-700 placeholder-slate-400 focus:border-slate-400 focus:outline-none"
+              className="rounded border border-slate-200 bg-white px-2 py-0.5 text-xs text-slate-700 placeholder-slate-400 focus:border-slate-400 focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder-slate-500"
               data-testid="compare-input"
             />
           )}

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -227,7 +227,7 @@ export function InstrumentsPage() {
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             placeholder="Symbol or company name…"
-            className="w-full rounded border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+            className="w-full rounded border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500"
           />
         </div>
 
@@ -255,7 +255,7 @@ export function InstrumentsPage() {
                 e.target.value ? Number(e.target.value) : null,
               )
             }
-            className="rounded border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-700"
+            className="rounded border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
           >
             <option value="">All</option>
             <option value="1">Tier 1</option>
@@ -270,7 +270,7 @@ export function InstrumentsPage() {
           >
             Dividend
           </label>
-          <label className="flex items-center gap-2 rounded border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-700">
+          <label className="flex items-center gap-2 rounded border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100">
             <input
               id="filter-has-dividend"
               type="checkbox"
@@ -349,7 +349,7 @@ function FilterSelect({
       <select
         value={value}
         onChange={(e) => onChange(e.target.value || null)}
-        className="rounded border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-700"
+        className="rounded border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
       >
         <option value="">All</option>
         {options.map((opt) => (

--- a/frontend/src/pages/OperatorsPage.tsx
+++ b/frontend/src/pages/OperatorsPage.tsx
@@ -131,16 +131,16 @@ export function OperatorsPage(): JSX.Element {
         ) : rows.length === 0 ? (
           <p className="text-xs text-slate-400">No operators.</p>
         ) : (
-          <ul className="divide-y divide-slate-200 rounded border border-slate-200 bg-white">
+          <ul className="divide-y divide-slate-200 rounded border border-slate-200 bg-white dark:divide-slate-800 dark:border-slate-800 dark:bg-slate-900">
             {rows.map((row) => (
               <li
                 key={row.id}
                 className="flex items-center justify-between px-3 py-2 text-sm"
               >
                 <div>
-                  <span className="font-medium text-slate-800">{row.username}</span>
+                  <span className="font-medium text-slate-800 dark:text-slate-100">{row.username}</span>
                   {row.is_self && (
-                    <span className="ml-2 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-slate-500">
+                    <span className="ml-2 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-slate-500 dark:bg-slate-800 dark:text-slate-300">
                       you
                     </span>
                   )}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -437,7 +437,7 @@ function BrokerCredentialsSection(): JSX.Element {
       ) : rows.length === 0 ? (
         <p className="text-xs text-slate-400">No broker credentials saved yet.</p>
       ) : (
-        <ul className="divide-y divide-slate-200 rounded border border-slate-200 bg-white">
+        <ul className="divide-y divide-slate-200 rounded border border-slate-200 bg-white dark:divide-slate-800 dark:border-slate-800 dark:bg-slate-900">
           {rows.map((row) => {
             const revoked = row.revoked_at !== null;
             const isActiveEtoro =
@@ -459,7 +459,7 @@ function BrokerCredentialsSection(): JSX.Element {
                     {row.provider} · {row.environment} · ••••{row.last_four}
                   </span>
                   {revoked && (
-                    <span className="ml-2 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-slate-500">
+                    <span className="ml-2 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-slate-500 dark:bg-slate-800 dark:text-slate-300">
                       revoked
                     </span>
                   )}
@@ -470,7 +470,7 @@ function BrokerCredentialsSection(): JSX.Element {
                       type="button"
                       onClick={() => startEdit(editLabel)}
                       disabled={manageAction !== "idle"}
-                      className="rounded border border-slate-300 px-2 py-1 text-xs text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+                      className="rounded border border-slate-300 px-2 py-1 text-xs text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-700 dark:text-slate-100 dark:hover:bg-slate-800"
                     >
                       Edit
                     </button>
@@ -499,21 +499,21 @@ function BrokerCredentialsSection(): JSX.Element {
 
       {/* Complete mode — management panel */}
       {mode === "complete" && manageAction === "idle" && (
-        <div className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4">
+        <div className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
           <p className="text-sm text-slate-700">Credentials configured.</p>
           <div className="flex flex-wrap gap-2">
             <button
               type="button"
               onClick={() => void handleTestStored()}
               disabled={validating}
-              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-700 dark:text-slate-100 dark:hover:bg-slate-800"
             >
               {validating ? "Testing…" : "Test connection"}
             </button>
             <button
               type="button"
               onClick={startReplace}
-              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-100 dark:hover:bg-slate-800"
             >
               Replace both
             </button>
@@ -529,7 +529,7 @@ function BrokerCredentialsSection(): JSX.Element {
       {mode === "complete" && (manageAction === "edit-api_key" || manageAction === "edit-user_key") && (
         <form
           onSubmit={handleEditSave}
-          className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4"
+          className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900"
         >
           <h3 className="text-sm font-medium text-slate-700">
             Edit {manageAction === "edit-api_key" ? "API key" : "user key"}
@@ -548,7 +548,7 @@ function BrokerCredentialsSection(): JSX.Element {
               onChange={(e) => setEditSecret(e.target.value)}
               minLength={MIN_SECRET_LEN}
               required
-              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500"
             />
           </label>
           {editError !== null && (
@@ -568,7 +568,7 @@ function BrokerCredentialsSection(): JSX.Element {
               type="button"
               onClick={cancelManage}
               disabled={editing}
-              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-700 dark:text-slate-100 dark:hover:bg-slate-800"
             >
               Cancel
             </button>
@@ -580,7 +580,7 @@ function BrokerCredentialsSection(): JSX.Element {
       {mode === "complete" && manageAction === "replace" && (
         <form
           onSubmit={handleReplaceSave}
-          className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4"
+          className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900"
         >
           <h3 className="text-sm font-medium text-slate-700">Replace both keys</h3>
           <p className="text-xs text-slate-500">
@@ -597,7 +597,7 @@ function BrokerCredentialsSection(): JSX.Element {
               onChange={(e) => setApiKey(e.target.value)}
               minLength={MIN_SECRET_LEN}
               required
-              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500"
             />
           </label>
           <label className="block text-sm">
@@ -610,7 +610,7 @@ function BrokerCredentialsSection(): JSX.Element {
               onChange={(e) => setUserKey(e.target.value)}
               minLength={MIN_SECRET_LEN}
               required
-              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500"
             />
           </label>
 
@@ -623,7 +623,7 @@ function BrokerCredentialsSection(): JSX.Element {
                 userKey.length < MIN_SECRET_LEN ||
                 validating
               }
-              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-700 dark:text-slate-100 dark:hover:bg-slate-800"
             >
               {validating ? "Testing…" : "Test connection"}
             </button>
@@ -655,7 +655,7 @@ function BrokerCredentialsSection(): JSX.Element {
               type="button"
               onClick={cancelManage}
               disabled={editing}
-              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-700 dark:text-slate-100 dark:hover:bg-slate-800"
             >
               Cancel
             </button>
@@ -667,7 +667,7 @@ function BrokerCredentialsSection(): JSX.Element {
       {mode !== "complete" && (
         <form
           onSubmit={handleCreate}
-          className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4"
+          className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900"
         >
           <h3 className="text-sm font-medium text-slate-700">
             {mode === "repair" ? "Complete credential setup" : "Add eToro credentials"}
@@ -690,7 +690,7 @@ function BrokerCredentialsSection(): JSX.Element {
                 onChange={(e) => setApiKey(e.target.value)}
                 minLength={MIN_SECRET_LEN}
                 required
-                className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+                className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500"
               />
             </label>
           )}
@@ -706,7 +706,7 @@ function BrokerCredentialsSection(): JSX.Element {
                 onChange={(e) => setUserKey(e.target.value)}
                 minLength={MIN_SECRET_LEN}
                 required
-                className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+                className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500"
               />
             </label>
           )}
@@ -717,7 +717,7 @@ function BrokerCredentialsSection(): JSX.Element {
               type="button"
               onClick={() => void handleTestConnection()}
               disabled={!canTestConnection || validating}
-              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-700 dark:text-slate-100 dark:hover:bg-slate-800"
             >
               {validating ? "Testing…" : "Test connection"}
             </button>


### PR DESCRIPTION
Closes #702. Second slice of #700 epic.

## What

Dark variants on form inputs, action buttons, dropdowns, and container cards across the operator surfaces flagged by the Phase 2 token coverage scan.

Pattern applied:
- \`bg-white\` → \`dark:bg-slate-900\`
- \`border-slate-300/200\` → \`dark:border-slate-700/800\`
- \`text-slate-700\` → \`dark:text-slate-100\`
- \`hover:bg-slate-50/100\` → \`dark:hover:bg-slate-800\`
- placeholder → \`dark:placeholder:text-slate-500\`

## Why

Operator screenshot pass on PR #699 flagged white inputs and bright cards leaking through the dark shell on Settings, filter rows, the Operators page, and modals. Form surfaces are the highest-traffic remaining gap after the chart palette pass (#705).

## Files

- Filter rows: RankingsFilters, RecommendationsFilters, AuditFilters
- Modals: OrderEntryModal, ClosePositionModal
- L2 instrument: EightKFilterStrip, EightKDetailPanel
- Admin: LayerHealthList, SeedProgressPanel, ProblemsPanel
- Dashboard: AlertsStrip (rows + Mark-all-read button)
- Pages: InstrumentsPage, ChartPage, OperatorsPage, SettingsPage
- Security: RecoveryPhraseConfirm

## Test plan

- [x] \`pnpm --dir frontend typecheck\` — clean
- [x] \`pnpm --dir frontend test:unit\` — 746/746 pass
- [ ] Operator pass: toggle dark mode, walk Settings → Rankings → Recommendations → Operators → modals → confirm no white surface leaks

## Out of scope

- #703 — page heading + dense table cell text sweep
- #704 — border + hover state polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)