### PR TITLE
feat(#703): dark mode Phase 2c — page heading + dense text sweep

### DIFF
--- a/frontend/src/components/admin/CollapsibleSection.tsx
+++ b/frontend/src/components/admin/CollapsibleSection.tsx
@@ -57,7 +57,7 @@ export function CollapsibleSection({
         <div className="flex items-baseline gap-2">
           <span
             aria-hidden
-            className={`inline-block text-slate-400 transition-transform ${isOpen ? "rotate-90" : ""}`}
+            className={`inline-block text-slate-400 dark:text-slate-500 transition-transform ${isOpen ? "rotate-90" : ""}`}
           >
             ▸
           </span>
@@ -65,10 +65,10 @@ export function CollapsibleSection({
             {title}
           </h2>
           {summary ? (
-            <span className="text-xs text-slate-500">— {summary}</span>
+            <span className="text-xs text-slate-500 dark:text-slate-400">— {summary}</span>
           ) : null}
         </div>
-        <span className="text-[11px] text-slate-500 transition-colors group-hover:text-amber-600">
+        <span className="text-[11px] text-slate-500 dark:text-slate-400 transition-colors group-hover:text-amber-600">
           {isOpen ? "Hide" : "Show"}
         </span>
       </button>

--- a/frontend/src/components/admin/FundDataRow.tsx
+++ b/frontend/src/components/admin/FundDataRow.tsx
@@ -131,20 +131,20 @@ export function FundDataRow({
 function StatCell({ cell }: { cell: Cell }): JSX.Element {
   const valueTone =
     cell.tone === "ok"
-      ? "text-slate-800"
+      ? "text-slate-800 dark:text-slate-100"
       : cell.tone === "error"
         ? "text-red-700"
-        : "text-slate-400";
+        : "text-slate-400 dark:text-slate-500";
   return (
     <div title={cell.hint ?? undefined}>
-      <div className="text-[10px] font-medium uppercase tracking-wider text-slate-400">
+      <div className="text-[10px] font-medium uppercase tracking-wider text-slate-400 dark:text-slate-500">
         {cell.label}
       </div>
       <div className={`text-lg font-semibold tabular-nums ${valueTone}`}>
         {cell.value}
       </div>
       {cell.hint ? (
-        <div className="text-[11px] text-slate-400">{cell.hint}</div>
+        <div className="text-[11px] text-slate-400 dark:text-slate-500">{cell.hint}</div>
       ) : null}
     </div>
   );

--- a/frontend/src/components/admin/LayerHealthList.tsx
+++ b/frontend/src/components/admin/LayerHealthList.tsx
@@ -96,7 +96,7 @@ export function LayerHealthList({ layers, onToggle }: LayerHealthListProps): JSX
           >
             <div className="flex-1">
               <div className="flex items-center gap-2">
-                <span className="font-medium text-slate-800">{entry.display_name}</span>
+                <span className="font-medium text-slate-800 dark:text-slate-100">{entry.display_name}</span>
                 <span
                   aria-label={`${entry.layer} state`}
                   className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${PILL_CLASS[pill]}`}

--- a/frontend/src/components/admin/SeedProgressPanel.tsx
+++ b/frontend/src/components/admin/SeedProgressPanel.tsx
@@ -201,19 +201,19 @@ function LatestRunRow({
       </div>
       <div className="mt-1 grid grid-cols-2 gap-x-4 gap-y-1 text-slate-600 sm:grid-cols-4">
         <div>
-          <span className="text-slate-500">Started </span>
+          <span className="text-slate-500 dark:text-slate-400">Started </span>
           {formatDateTime(run.started_at)}
         </div>
         <div>
-          <span className="text-slate-500">Finished </span>
+          <span className="text-slate-500 dark:text-slate-400">Finished </span>
           {run.finished_at ? formatDateTime(run.finished_at) : "—"}
         </div>
         <div>
-          <span className="text-slate-500">Rows upserted </span>
+          <span className="text-slate-500 dark:text-slate-400">Rows upserted </span>
           {run.rows_upserted.toLocaleString()}
         </div>
         <div>
-          <span className="text-slate-500">Rows skipped </span>
+          <span className="text-slate-500 dark:text-slate-400">Rows skipped </span>
           {run.rows_skipped.toLocaleString()}
         </div>
       </div>
@@ -234,7 +234,7 @@ function TimingSection({
   }
   if (data === null || data.ingestion_run_id === null) {
     return (
-      <p className="text-xs text-slate-500">
+      <p className="text-xs text-slate-500 dark:text-slate-400">
         Per-CIK timing will appear here after the next SEC ingest run.
       </p>
     );
@@ -243,12 +243,12 @@ function TimingSection({
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
           Per-CIK timing · run #{data.ingestion_run_id}
         </h3>
       </div>
       <table className="w-full text-xs">
-        <thead className="text-left text-[11px] uppercase text-slate-500">
+        <thead className="text-left text-[11px] uppercase text-slate-500 dark:text-slate-400">
           <tr>
             <th className="py-1">Mode</th>
             <th>Count</th>
@@ -278,7 +278,7 @@ function TimingSection({
             Slowest {data.slowest.length} CIKs
           </summary>
           <table className="mt-2 w-full">
-            <thead className="text-left text-[11px] uppercase text-slate-500">
+            <thead className="text-left text-[11px] uppercase text-slate-500 dark:text-slate-400">
               <tr>
                 <th className="py-1">CIK</th>
                 <th>Mode</th>

--- a/frontend/src/components/broker/ValidationResultDisplay.tsx
+++ b/frontend/src/components/broker/ValidationResultDisplay.tsx
@@ -31,7 +31,7 @@ export function ValidationResultDisplay({
           Authenticated, but environment check failed: {result.env_check}
         </div>
         {result.note && (
-          <p className="text-xs text-slate-400">{result.note}</p>
+          <p className="text-xs text-slate-400 dark:text-slate-500">{result.note}</p>
         )}
       </div>
     );
@@ -48,7 +48,7 @@ export function ValidationResultDisplay({
         )}
       </div>
       {result.note && (
-        <p className="text-xs text-slate-400">{result.note}</p>
+        <p className="text-xs text-slate-400 dark:text-slate-500">{result.note}</p>
       )}
     </div>
   );

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -164,11 +164,11 @@ function GuardRow({ row, unseen }: { row: GuardRejection; unseen: boolean }) {
   return (
     <RowShell kind="guard" unseen={unseen} instrumentId={row.instrument_id}>
       <span className="w-16 font-semibold tabular-nums">{row.symbol ?? "—"}</span>
-      <span className="w-16 text-xs uppercase text-slate-500">{row.action ?? "—"}</span>
+      <span className="w-16 text-xs uppercase text-slate-500 dark:text-slate-400">{row.action ?? "—"}</span>
       <span className="flex-1 truncate text-slate-700" title={row.explanation}>
         {row.explanation}
       </span>
-      <span className="w-20 text-right text-xs text-slate-400">
+      <span className="w-20 text-right text-xs text-slate-400 dark:text-slate-500">
         {formatRelativeTime(row.decision_time)}
       </span>
     </RowShell>
@@ -184,11 +184,11 @@ function PositionRow({ row, unseen }: { row: PositionAlert; unseen: boolean }) {
   return (
     <RowShell kind="position" unseen={unseen} instrumentId={row.instrument_id}>
       <span className="w-16 font-semibold tabular-nums">{row.symbol}</span>
-      <span className="w-16 text-xs uppercase text-slate-500">{alertLabel}</span>
+      <span className="w-16 text-xs uppercase text-slate-500 dark:text-slate-400">{alertLabel}</span>
       <span className="flex-1 truncate text-slate-700" title={row.detail}>
         {row.detail}
       </span>
-      <span className="w-20 text-right text-xs text-slate-400">
+      <span className="w-20 text-right text-xs text-slate-400 dark:text-slate-500">
         {formatRelativeTime(row.opened_at)}
       </span>
     </RowShell>
@@ -203,7 +203,7 @@ function CoverageRow({ row, unseen }: { row: CoverageStatusDrop; unseen: boolean
       <span className="flex-1 truncate text-slate-700" title={transition}>
         {transition}
       </span>
-      <span className="w-20 text-right text-xs text-slate-400">
+      <span className="w-20 text-right text-xs text-slate-400 dark:text-slate-500">
         {formatRelativeTime(row.changed_at)}
       </span>
     </RowShell>
@@ -435,7 +435,7 @@ export function AlertsStrip(): JSX.Element | null {
             </button>
             <Link
               to="/recommendations"
-              className="text-xs text-slate-500 underline hover:text-slate-700"
+              className="text-xs text-slate-500 dark:text-slate-400 underline hover:text-slate-700"
             >
               Triage at /recommendations
             </Link>

--- a/frontend/src/components/dashboard/PortfolioValueChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueChart.tsx
@@ -130,7 +130,7 @@ export function PortfolioValueChart(): JSX.Element | null {
               since it already implies the live-FX context and the
               caption would just duplicate. */}
           {data?.fx_mode === "live" && hasMovement && fxSkipped === 0 ? (
-            <span className="text-[10px] text-slate-400">
+            <span className="text-[10px] text-slate-400 dark:text-slate-500">
               historical converted at today's FX
             </span>
           ) : null}
@@ -272,7 +272,7 @@ function ValueCanvas({
     <div className="relative mt-2">
       {hover !== null ? (
         <div className="absolute right-2 top-2 z-10 rounded bg-white/90 px-2 py-1 text-xs tabular-nums shadow-sm">
-          <span className="text-slate-400">{hover.date}</span>
+          <span className="text-slate-400 dark:text-slate-500">{hover.date}</span>
           <span className="ml-2 font-medium text-slate-700">
             {formatMoney(hover.value, currency)}
           </span>

--- a/frontend/src/components/dashboard/PositionsTable.tsx
+++ b/frontend/src/components/dashboard/PositionsTable.tsx
@@ -61,7 +61,7 @@ export function PositionsTable({
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-left text-sm">
-        <thead className="text-xs uppercase text-slate-500">
+        <thead className="text-xs uppercase text-slate-500 dark:text-slate-400">
           <tr>
             <Th>Name</Th>
             <Th className="hidden sm:table-cell" />
@@ -159,16 +159,16 @@ function MirrorRow({ m, currency }: { m: PortfolioMirrorItem; currency: string }
         </Link>
       </Td>
       <Td className="hidden sm:table-cell">
-        <span className="text-slate-500">
+        <span className="text-slate-500 dark:text-slate-400">
           {m.position_count} position{m.position_count !== 1 ? "s" : ""}
         </span>
       </Td>
       <Td align="right">
-        <span className="text-slate-400">—</span>
+        <span className="text-slate-400 dark:text-slate-500">—</span>
       </Td>
       <Td align="right">{formatMoney(m.funded, currency)}</Td>
       <Td align="right">
-        <span className="text-slate-400">—</span>
+        <span className="text-slate-400 dark:text-slate-500">—</span>
       </Td>
       <Td align="right">{formatMoney(m.mirror_equity, currency)}</Td>
       <Td align="right">

--- a/frontend/src/components/dashboard/SummaryCards.tsx
+++ b/frontend/src/components/dashboard/SummaryCards.tsx
@@ -135,10 +135,10 @@ function Card({
 }) {
   const toneClass =
     tone === "positive"
-      ? "text-emerald-600"
+      ? "text-emerald-600 dark:text-emerald-400"
       : tone === "negative"
-        ? "text-rose-600"
-        : "text-slate-900";
+        ? "text-rose-600 dark:text-rose-400"
+        : "text-slate-900 dark:text-slate-100";
   return (
     <div className="border-t border-slate-200 px-1 pt-3 pb-1">
       <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">

--- a/frontend/src/components/dashboard/WatchlistPanel.tsx
+++ b/frontend/src/components/dashboard/WatchlistPanel.tsx
@@ -29,12 +29,12 @@ export function WatchlistPanel({ items, onRemove }: Props) {
     <div className="overflow-x-auto">
       <table className="min-w-full text-sm">
         <thead>
-          <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
+          <tr className="border-b border-slate-200 text-left text-xs text-slate-500 dark:text-slate-400">
             <th className="px-2 py-1">Symbol</th>
             <th className="px-2 py-1">Name</th>
             <th className="px-2 py-1">Sector</th>
             <th className="px-2 py-1">Notes</th>
-            <th className="px-2 py-1 text-xs text-slate-400">Added</th>
+            <th className="px-2 py-1 text-xs text-slate-400 dark:text-slate-500">Added</th>
             {onRemove && <th className="px-2 py-1" />}
           </tr>
         </thead>
@@ -53,11 +53,11 @@ export function WatchlistPanel({ items, onRemove }: Props) {
                 </Link>
               </td>
               <td className="px-2 py-1">{item.company_name}</td>
-              <td className="px-2 py-1 text-slate-500">{item.sector ?? "—"}</td>
-              <td className="px-2 py-1 text-xs text-slate-500">
+              <td className="px-2 py-1 text-slate-500 dark:text-slate-400">{item.sector ?? "—"}</td>
+              <td className="px-2 py-1 text-xs text-slate-500 dark:text-slate-400">
                 {item.notes ?? ""}
               </td>
-              <td className="px-2 py-1 text-xs text-slate-400">
+              <td className="px-2 py-1 text-xs text-slate-400 dark:text-slate-500">
                 {formatAddedAt(item.added_at)}
               </td>
               {onRemove && (

--- a/frontend/src/components/insider/InsiderTransactionsTable.tsx
+++ b/frontend/src/components/insider/InsiderTransactionsTable.tsx
@@ -325,7 +325,7 @@ export function InsiderTransactionsTable({
                   <td className="px-2 py-1 font-mono tabular-nums text-slate-700">
                     {r.txn_date}
                   </td>
-                  <td className="px-2 py-1 text-slate-800">{r.filer_name}</td>
+                  <td className="px-2 py-1 text-slate-800 dark:text-slate-100">{r.filer_name}</td>
                   <td className="px-2 py-1 text-slate-600">
                     {r.filer_role ?? "—"}
                   </td>

--- a/frontend/src/components/instrument/BusinessSectionsPanel.tsx
+++ b/frontend/src/components/instrument/BusinessSectionsPanel.tsx
@@ -89,7 +89,7 @@ function SectionBlock({
   return (
     <div className="border-l-2 border-slate-200 pl-3">
       <div className="mb-1 flex items-center justify-between gap-2">
-        <div className="text-sm font-semibold text-slate-800">
+        <div className="text-sm font-semibold text-slate-800 dark:text-slate-100">
           {labelFor(section)}
         </div>
         {showExpandToggle && (

--- a/frontend/src/components/instrument/CrossRefPopover.tsx
+++ b/frontend/src/components/instrument/CrossRefPopover.tsx
@@ -66,7 +66,7 @@ export function CrossRefPopover({
           </span>
           {target ? (
             <>
-              <span className="mt-1 block font-medium text-slate-800">
+              <span className="mt-1 block font-medium text-slate-800 dark:text-slate-100">
                 {target.section_label}
               </span>
               <span className="mt-1 block leading-relaxed text-slate-700">

--- a/frontend/src/components/instrument/EightKDetailPanel.tsx
+++ b/frontend/src/components/instrument/EightKDetailPanel.tsx
@@ -43,7 +43,7 @@ export function EightKDetailPanel({
             >
               Item {item.item_code}
             </span>
-            <span className="text-xs font-medium text-slate-800">
+            <span className="text-xs font-medium text-slate-800 dark:text-slate-100">
               {item.item_label}
             </span>
           </header>

--- a/frontend/src/components/instrument/EightKEventsPanel.tsx
+++ b/frontend/src/components/instrument/EightKEventsPanel.tsx
@@ -103,7 +103,7 @@ function FilingCard({ filing }: { filing: EightKFiling }) {
   return (
     <div className="rounded-sm border border-slate-200 p-3">
       <div className="mb-2 flex flex-wrap items-center gap-2">
-        <span className="font-mono text-xs text-slate-800">
+        <span className="font-mono text-xs text-slate-800 dark:text-slate-100">
           {dateText}
         </span>
         <span

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -419,7 +419,7 @@ function FundamentalCell({
         ) : null}
       </div>
       <div className="flex items-baseline gap-2">
-        <span className="text-xl font-semibold tabular-nums text-slate-900">
+        <span className="text-xl font-semibold tabular-nums text-slate-900 dark:text-slate-100">
           {formatBigNumber(latestVal)}
         </span>
         {delta !== null ? (

--- a/frontend/src/components/instrument/InsiderActivityPanel.tsx
+++ b/frontend/src/components/instrument/InsiderActivityPanel.tsx
@@ -147,7 +147,7 @@ function SummaryStrip({ summary }: { summary: InsiderSummary }) {
       <div>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
           <div className="flex flex-col">
-            <span className="text-xs uppercase tracking-wide text-slate-500">
+            <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Net change
             </span>
             <span
@@ -158,14 +158,14 @@ function SummaryStrip({ summary }: { summary: InsiderSummary }) {
             </span>
           </div>
           <div className="flex flex-col">
-            <span className="text-xs uppercase tracking-wide text-slate-500">
+            <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Acquired
             </span>
             <span className="mt-1 font-mono text-base tabular-nums text-emerald-700">
               {totalAcquired > 0 ? "+" : ""}
               {Math.round(totalAcquired).toLocaleString("en-US")}
             </span>
-            <span className="text-[10px] text-slate-500">
+            <span className="text-[10px] text-slate-500 dark:text-slate-400">
               {summary.acquisition_count_90d} txns
               {summary.open_market_buy_count_90d > 0 && (
                 <> · {summary.open_market_buy_count_90d} open-market</>
@@ -173,14 +173,14 @@ function SummaryStrip({ summary }: { summary: InsiderSummary }) {
             </span>
           </div>
           <div className="flex flex-col">
-            <span className="text-xs uppercase tracking-wide text-slate-500">
+            <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Disposed
             </span>
             <span className="mt-1 font-mono text-base tabular-nums text-rose-700">
               {totalDisposed > 0 ? "-" : ""}
               {Math.round(totalDisposed).toLocaleString("en-US")}
             </span>
-            <span className="text-[10px] text-slate-500">
+            <span className="text-[10px] text-slate-500 dark:text-slate-400">
               {summary.disposition_count_90d} txns
               {summary.open_market_sell_count_90d > 0 && (
                 <> · {summary.open_market_sell_count_90d} open-market</>
@@ -188,18 +188,18 @@ function SummaryStrip({ summary }: { summary: InsiderSummary }) {
             </span>
           </div>
           <div className="flex flex-col">
-            <span className="text-xs uppercase tracking-wide text-slate-500">
+            <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Unique insiders
             </span>
-            <span className="mt-1 font-mono text-base tabular-nums text-slate-800">
+            <span className="mt-1 font-mono text-base tabular-nums text-slate-800 dark:text-slate-100">
               {summary.unique_filers_90d}
             </span>
           </div>
           <div className="flex flex-col">
-            <span className="text-xs uppercase tracking-wide text-slate-500">
+            <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Latest trade
             </span>
-            <span className="mt-1 font-mono text-base tabular-nums text-slate-800">
+            <span className="mt-1 font-mono text-base tabular-nums text-slate-800 dark:text-slate-100">
               {formatDate(summary.latest_txn_date)}
             </span>
           </div>
@@ -223,7 +223,7 @@ function SummaryStrip({ summary }: { summary: InsiderSummary }) {
           · {summary.open_market_buy_count_90d} buys ·{" "}
           {summary.open_market_sell_count_90d} sells
           <span
-            className="ml-1 text-slate-400"
+            className="ml-1 text-slate-400 dark:text-slate-500"
             title="Only SEC transaction codes P (open-market purchase) and S (open-market sale). Excludes grants, RSU vests, option exercises, tax withholding, gifts."
           >
             ⓘ
@@ -249,7 +249,7 @@ function Row({ txn }: { txn: InsiderTransactionDetail }) {
   return (
     <tr
       className={
-        txn.is_derivative ? "border-t border-slate-100 text-slate-500" : "border-t border-slate-100"
+        txn.is_derivative ? "border-t border-slate-100 text-slate-500 dark:text-slate-400" : "border-t border-slate-100"
       }
     >
       <td className="py-2 pr-3 font-mono tabular-nums text-xs">
@@ -257,8 +257,8 @@ function Row({ txn }: { txn: InsiderTransactionDetail }) {
       </td>
       <td className="py-2 pr-3">
         <div className="flex flex-col">
-          <span className="font-medium text-slate-800">{txn.filer_name}</span>
-          <span className="text-xs text-slate-500">{roleBadge(txn.filer_role)}</span>
+          <span className="font-medium text-slate-800 dark:text-slate-100">{txn.filer_name}</span>
+          <span className="text-xs text-slate-500 dark:text-slate-400">{roleBadge(txn.filer_role)}</span>
         </div>
       </td>
       <td className={`py-2 pr-3 text-xs ${codeColour}`}>
@@ -305,7 +305,7 @@ function Row({ txn }: { txn: InsiderTransactionDetail }) {
           </span>
         )}
       </td>
-      <td className="py-2 text-xs text-slate-500">
+      <td className="py-2 text-xs text-slate-500 dark:text-slate-400">
         {footnoteEntries.length === 0 ? (
           "—"
         ) : (
@@ -347,7 +347,7 @@ function Body({
       <div className="overflow-x-auto">
         <table className="w-full text-left text-sm">
           <thead>
-            <tr className="text-xs uppercase tracking-wide text-slate-500">
+            <tr className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
               <th className="pb-2 pr-3">Date</th>
               <th className="pb-2 pr-3">Insider</th>
               <th className="pb-2 pr-3">Transaction</th>

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -942,7 +942,7 @@ function RichTooltip({ hover }: { hover: RichHoverState }): JSX.Element {
       <span>
         <span className="text-slate-400">L</span> {fmt(hover.low)}
       </span>
-      <span className="font-medium text-slate-800">
+      <span className="font-medium text-slate-800 dark:text-slate-100">
         <span className="font-normal text-slate-400">C</span> {fmt(hover.close)}
       </span>
       <span>

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -142,7 +142,7 @@ export function SummaryStrip({
     >
       {/* Row 1: identity + price */}
       <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-        <h1 className="text-2xl font-semibold text-slate-800">
+        <h1 className="text-2xl font-semibold text-slate-800 dark:text-slate-100">
           {identity.symbol}
         </h1>
         <span className="text-lg text-slate-600">
@@ -158,7 +158,7 @@ export function SummaryStrip({
         ) : null}
         {price || livePrice ? (
           <>
-            <span className="ml-auto flex items-baseline gap-1.5 text-2xl font-semibold tabular-nums text-slate-800">
+            <span className="ml-auto flex items-baseline gap-1.5 text-2xl font-semibold tabular-nums text-slate-800 dark:text-slate-100">
               {formatPrice(displayCurrent, displayCurrency)}
               {live.connected ? (
                 <span

--- a/frontend/src/components/instrument/TenKMetadataRail.tsx
+++ b/frontend/src/components/instrument/TenKMetadataRail.tsx
@@ -49,8 +49,8 @@ export function TenKMetadataRail({
                     to={`/instrument/${encodeURIComponent(symbol)}/filings/10-k?accession=${encodeURIComponent(f.accession_number)}`}
                     className={`block hover:underline ${
                       isCurrent
-                        ? "font-medium text-slate-900"
-                        : "text-sky-700"
+                        ? "font-medium text-slate-900 dark:text-slate-100"
+                        : "text-sky-700 dark:text-sky-300"
                     }`}
                   >
                     {f.filing_date.slice(0, 4)}

--- a/frontend/src/components/orders/ClosePositionModal.tsx
+++ b/frontend/src/components/orders/ClosePositionModal.tsx
@@ -148,7 +148,7 @@ export function ClosePositionModal({
       <div className="flex flex-col gap-3">
         <header className="flex items-center justify-between">
           <div>
-            <h2 className="text-sm font-semibold text-slate-800">{title}</h2>
+            <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-100">{title}</h2>
             <p className="text-xs text-slate-500">Position #{positionId}</p>
           </div>
           <DemoLivePill />

--- a/frontend/src/components/orders/OrderEntryModal.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.tsx
@@ -148,7 +148,7 @@ export function OrderEntryModal({
       <div className="flex flex-col gap-3">
         <header className="flex items-center justify-between">
           <div>
-            <h2 className="text-sm font-semibold text-slate-800">{title}</h2>
+            <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-100">{title}</h2>
             <p className="text-xs text-slate-500">{companyName}</p>
           </div>
           <DemoLivePill />

--- a/frontend/src/components/rankings/RankingsTable.tsx
+++ b/frontend/src/components/rankings/RankingsTable.tsx
@@ -89,7 +89,7 @@ export function RankingsTable({ view }: { view: RankingsView }) {
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-left text-sm">
-        <thead className="text-xs uppercase text-slate-500">
+        <thead className="text-xs uppercase text-slate-500 dark:text-slate-400">
           <tr>
             {COLUMNS.map((col) => {
               const active = col.key === sortKey;
@@ -104,7 +104,7 @@ export function RankingsTable({ view }: { view: RankingsView }) {
                   <button
                     type="button"
                     onClick={() => onHeaderClick(col)}
-                    className="font-semibold uppercase tracking-wide text-slate-500 hover:text-slate-800"
+                    className="font-semibold uppercase tracking-wide text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
                   >
                     {col.label}
                     {indicator}
@@ -150,7 +150,7 @@ export function RankingsTable({ view }: { view: RankingsView }) {
             <MessageRow>
               <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-slate-200 bg-white p-8 text-center">
                 <h2 className="text-base font-semibold text-slate-700">{view.title}</h2>
-                <p className="mt-1 max-w-md text-sm text-slate-500">{view.description}</p>
+                <p className="mt-1 max-w-md text-sm text-slate-500 dark:text-slate-400">{view.description}</p>
                 {view.action ? <div className="mt-4">{view.action}</div> : null}
               </div>
             </MessageRow>
@@ -210,7 +210,7 @@ function RankingRow({ item }: { item: RankingItem }) {
       <td className="px-2 py-2 text-right tabular-nums">
         {item.coverage_tier === null ? "—" : item.coverage_tier}
       </td>
-      <td className="px-2 py-2 text-right font-semibold tabular-nums text-slate-800">
+      <td className="px-2 py-2 text-right font-semibold tabular-nums text-slate-800 dark:text-slate-100">
         {formatScore(item.total_score)}
       </td>
       <td className="px-2 py-2 text-right tabular-nums">{formatScore(item.quality_score)}</td>

--- a/frontend/src/components/security/RecoveryPhraseConfirm.tsx
+++ b/frontend/src/components/security/RecoveryPhraseConfirm.tsx
@@ -269,7 +269,7 @@ export function RecoveryPhraseConfirm({
         </header>
         <ol
           aria-label="Recovery phrase words"
-          className="grid grid-cols-2 gap-x-6 gap-y-2 rounded border border-slate-200 bg-slate-50 p-4 font-mono text-sm text-slate-800"
+          className="grid grid-cols-2 gap-x-6 gap-y-2 rounded border border-slate-200 bg-slate-50 p-4 font-mono text-sm text-slate-800 dark:text-slate-100"
         >
           {phrase.map((word, index) => (
             <li
@@ -362,7 +362,7 @@ export function RecoveryPhraseConfirm({
                 onChange={(event: ChangeEvent<HTMLInputElement>) =>
                   handleEntryChange(slot, event.target.value)
                 }
-                className="rounded border border-slate-300 px-2 py-1.5 font-mono text-sm text-slate-800 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                className="rounded border border-slate-300 px-2 py-1.5 font-mono text-sm text-slate-800 dark:text-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
               />
             </label>
           );

--- a/frontend/src/components/security/RecoveryPhraseConfirm.tsx
+++ b/frontend/src/components/security/RecoveryPhraseConfirm.tsx
@@ -362,7 +362,7 @@ export function RecoveryPhraseConfirm({
                 onChange={(event: ChangeEvent<HTMLInputElement>) =>
                   handleEntryChange(slot, event.target.value)
                 }
-                className="rounded border border-slate-300 px-2 py-1.5 font-mono text-sm text-slate-800 dark:text-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                className="rounded border border-slate-300 px-2 py-1.5 font-mono text-sm text-slate-800 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
               />
             </label>
           );

--- a/frontend/src/pages/AdminJobDetailPage.tsx
+++ b/frontend/src/pages/AdminJobDetailPage.tsx
@@ -47,7 +47,7 @@ export function AdminJobDetailPage() {
       <div className="flex items-center justify-between">
         <div>
           <div className="text-xs text-slate-500">Admin / Jobs</div>
-          <h1 className="text-xl font-semibold text-slate-800">{name}</h1>
+          <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">{name}</h1>
         </div>
         <Link to="/admin" className="text-xs text-blue-700 hover:underline">
           ← Back to Admin
@@ -155,7 +155,7 @@ function RunRow({ row }: { row: JobRunResponse }) {
       {expandable && expanded ? (
         <tr>
           <td colSpan={6} className="bg-slate-50 px-4 py-3">
-            <pre className="whitespace-pre-wrap text-xs text-slate-800">
+            <pre className="whitespace-pre-wrap text-xs text-slate-800 dark:text-slate-100">
               {row.error_msg}
             </pre>
           </td>

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -227,7 +227,7 @@ export function AdminPage() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold text-slate-800">Admin</h1>
+        <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Admin</h1>
         <SyncNowButton
           triggerKind={triggerKind}
           message={triggerMessage}

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -378,7 +378,7 @@ export function ChartPage(): JSX.Element {
           ← Back to overview
         </Link>
         <div className="flex items-baseline gap-2">
-          <h1 className="text-xl font-semibold text-slate-800">{symbol}</h1>
+          <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">{symbol}</h1>
           {summaryAsync.data?.identity.display_name && (
             <span className="text-sm text-slate-500">
               {summaryAsync.data.identity.display_name}
@@ -386,7 +386,7 @@ export function ChartPage(): JSX.Element {
           )}
         </div>
         {summaryAsync.data?.price?.current && (
-          <span className="ml-auto text-lg font-medium tabular-nums text-slate-800">
+          <span className="ml-auto text-lg font-medium tabular-nums text-slate-800 dark:text-slate-100">
             {summaryAsync.data.price.currency ?? ""}{" "}
             {Number(summaryAsync.data.price.current).toLocaleString(undefined, {
               maximumFractionDigits: 2,

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -45,12 +45,12 @@ export function CopyTradingPage() {
           ← Portfolio
         </Link>
         {username ? (
-          <h1 className="flex items-center gap-2 text-xl font-semibold text-slate-800">
+          <h1 className="flex items-center gap-2 text-xl font-semibold text-slate-800 dark:text-slate-100">
             <TraderAvatar username={username} />
             {username}
           </h1>
         ) : (
-          <h1 className="text-xl font-semibold text-slate-800">Mirror detail</h1>
+          <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Mirror detail</h1>
         )}
       </div>
 
@@ -242,7 +242,7 @@ function InstrumentGroupRow({
         onClick={hasMultiple ? () => setExpanded((v) => !v) : undefined}
       >
         <td className="px-2 py-2 text-left">
-          <span className="font-medium text-slate-800">
+          <span className="font-medium text-slate-800 dark:text-slate-100">
             {group.symbol ?? `#${group.instrument_id}`}
           </span>
           {group.company_name ? (

--- a/frontend/src/pages/CoverageInsufficientPage.tsx
+++ b/frontend/src/pages/CoverageInsufficientPage.tsx
@@ -32,7 +32,7 @@ export function CoverageInsufficientPage() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold text-slate-800">
+        <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">
           Coverage drill-down
         </h1>
         <Link

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -96,7 +96,7 @@ export function DashboardPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold text-slate-800">Dashboard</h1>
+        <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Dashboard</h1>
       </div>
 
       {allFailed ? (

--- a/frontend/src/pages/DividendsPage.tsx
+++ b/frontend/src/pages/DividendsPage.tsx
@@ -193,7 +193,7 @@ export function DividendsPage(): JSX.Element {
         <Link to={backHref} className="text-xs text-sky-700 hover:underline">
           ← Back to {symbol}
         </Link>
-        <h1 className="mt-1 text-lg font-semibold text-slate-900">
+        <h1 className="mt-1 text-lg font-semibold text-slate-900 dark:text-slate-100">
           Dividends — {symbol}
         </h1>
         <p className="mt-1 text-xs text-slate-500">

--- a/frontend/src/pages/FundamentalsPage.tsx
+++ b/frontend/src/pages/FundamentalsPage.tsx
@@ -144,7 +144,7 @@ export function FundamentalsPage(): JSX.Element {
           ← Back to {symbol}
         </Link>
         <div className="mt-1 flex flex-wrap items-baseline justify-between gap-2">
-          <h1 className="text-lg font-semibold text-slate-900">
+          <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
             Fundamentals — {symbol}
           </h1>
           <div className="flex items-center gap-2 text-xs">

--- a/frontend/src/pages/InsiderPage.tsx
+++ b/frontend/src/pages/InsiderPage.tsx
@@ -65,7 +65,7 @@ export function InsiderPage(): JSX.Element {
         <Link to={backHref} className="text-xs text-sky-700 hover:underline">
           ← Back to {symbol}
         </Link>
-        <h1 className="mt-1 text-lg font-semibold text-slate-900">
+        <h1 className="mt-1 text-lg font-semibold text-slate-900 dark:text-slate-100">
           Insider activity — {symbol}
         </h1>
         <p className="mt-1 text-xs text-slate-500">

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -208,7 +208,7 @@ export function InstrumentsPage() {
   return (
     <div className="flex h-full flex-col gap-6">
       <div className="flex flex-shrink-0 items-center justify-between">
-        <h1 className="text-xl font-semibold text-slate-800">Instruments</h1>
+        <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Instruments</h1>
         {result.data && (
           <span className="text-xs text-slate-500">
             {result.data.total.toLocaleString()} instruments

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -69,7 +69,7 @@ export function LoginPage(): JSX.Element {
         onSubmit={handleSubmit}
         className="w-full max-w-sm rounded border border-slate-200 bg-white p-6 shadow-sm"
       >
-        <h1 className="mb-4 text-lg font-semibold text-slate-800">eBull operator</h1>
+        <h1 className="mb-4 text-lg font-semibold text-slate-800 dark:text-slate-100">eBull operator</h1>
         <label className="mb-3 block text-sm">
           <span className="mb-1 block text-slate-600">Username</span>
           <input
@@ -115,7 +115,7 @@ export function LoginPage(): JSX.Element {
           <div className="mt-3 text-center text-xs">
             <a
               href="/recover"
-              className="text-slate-600 underline hover:text-slate-800"
+              className="text-slate-600 underline hover:text-slate-800 dark:text-slate-300 dark:hover:text-slate-100"
             >
               Recover existing eBull data
             </a>

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -224,7 +224,7 @@ export function PortfolioPage() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold text-slate-800">Portfolio</h1>
+        <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Portfolio</h1>
       </div>
 
       {portfolio.error !== null ? (
@@ -378,7 +378,7 @@ function Stat({
       <div className="text-[11px] font-medium uppercase tracking-wider text-slate-400">
         {label}
       </div>
-      <div className="text-sm font-semibold text-slate-800">{value}</div>
+      <div className="text-sm font-semibold text-slate-800 dark:text-slate-100">{value}</div>
       {hint ? (
         <div
           className={`text-xs font-medium ${tone === "positive" ? "text-emerald-600" : "text-red-600"}`}
@@ -580,7 +580,7 @@ function PositionRow({
       data-testid={`position-row-${p.instrument_id}`}
     >
       <td className="px-4 py-2 text-left">
-        <span className="font-medium text-slate-800">{p.symbol}</span>
+        <span className="font-medium text-slate-800 dark:text-slate-100">{p.symbol}</span>
         <span className="ml-1.5 text-xs text-slate-500">{p.company_name}</span>
       </td>
       <td className="px-2 py-2 text-right tabular-nums text-slate-600">
@@ -681,7 +681,7 @@ function MirrorRow({
           >
             {m.parent_username.charAt(0).toUpperCase()}
           </span>
-          <span className="font-medium text-slate-800">
+          <span className="font-medium text-slate-800 dark:text-slate-100">
             {m.parent_username}
           </span>
           <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500">

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -134,7 +134,7 @@ export function RankingsPage() {
   return (
     <div className="flex h-full flex-col gap-6">
       <div className="flex flex-shrink-0 items-center justify-between">
-        <h1 className="text-xl font-semibold text-slate-800">Rankings</h1>
+        <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Rankings</h1>
         <span className="text-xs text-slate-500">
           {rankings.data?.scored_at
             ? `Latest run: ${formatDateTime(rankings.data.scored_at)}`

--- a/frontend/src/pages/RecommendationsPage.tsx
+++ b/frontend/src/pages/RecommendationsPage.tsx
@@ -139,7 +139,7 @@ export function RecommendationsPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-xl font-semibold text-slate-800">Recommendations</h1>
+      <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Recommendations</h1>
 
       {allFailed ? (
         <ErrorBanner message="The API is unreachable. Check that the backend is running and the auth token is configured." />

--- a/frontend/src/pages/RecoverPage.tsx
+++ b/frontend/src/pages/RecoverPage.tsx
@@ -260,7 +260,7 @@ export function RecoverPage(): JSX.Element {
         onSubmit={handleSubmit}
         className="w-full max-w-2xl rounded border border-slate-200 bg-white p-6 shadow-sm"
       >
-        <h1 className="mb-1 text-lg font-semibold text-slate-800">
+        <h1 className="mb-1 text-lg font-semibold text-slate-800 dark:text-slate-100">
           Recover existing eBull data
         </h1>
         <p className="mb-4 text-xs text-slate-500">
@@ -306,7 +306,7 @@ export function RecoverPage(): JSX.Element {
                     handleWordChange(index, e.target.value)
                   }
                   onPaste={(e) => handlePaste(index, e)}
-                  className="w-full rounded border border-slate-300 px-2 py-1 font-mono text-sm text-slate-800"
+                  className="w-full rounded border border-slate-300 px-2 py-1 font-mono text-sm text-slate-800 dark:text-slate-100"
                 />
               </li>
             );

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -454,7 +454,7 @@ function BrokerCredentialsSection(): JSX.Element {
                 className="flex items-center justify-between px-3 py-2 text-sm"
               >
                 <div>
-                  <span className="font-medium text-slate-800">{row.label}</span>
+                  <span className="font-medium text-slate-800 dark:text-slate-100">{row.label}</span>
                   <span className="ml-2 text-xs text-slate-500">
                     {row.provider} · {row.environment} · ••••{row.last_four}
                   </span>

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -200,7 +200,7 @@ export function SetupPage(): JSX.Element {
           onSubmit={handleOperatorSubmit}
           className="w-full max-w-sm rounded border border-slate-200 bg-white p-6 shadow-sm"
         >
-          <h1 className="mb-1 text-lg font-semibold text-slate-800">
+          <h1 className="mb-1 text-lg font-semibold text-slate-800 dark:text-slate-100">
             First-run setup
           </h1>
           <p className="mb-4 text-xs text-slate-500">
@@ -266,7 +266,7 @@ export function SetupPage(): JSX.Element {
         </form>
       ) : mode === "complete" ? (
         <div className="w-full max-w-sm rounded border border-slate-200 bg-white p-6 shadow-sm">
-          <h1 className="mb-1 text-lg font-semibold text-slate-800">
+          <h1 className="mb-1 text-lg font-semibold text-slate-800 dark:text-slate-100">
             Credentials configured
           </h1>
           <p className="mb-4 text-xs text-slate-500">
@@ -285,7 +285,7 @@ export function SetupPage(): JSX.Element {
           onSubmit={handleBrokerSubmit}
           className="w-full max-w-sm space-y-3 rounded border border-slate-200 bg-white p-6 shadow-sm"
         >
-          <h1 className="text-lg font-semibold text-slate-800">
+          <h1 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
             {mode === "repair" ? "Complete credential setup" : "Add eToro credentials"}
           </h1>
           <p className="text-xs text-slate-500">

--- a/frontend/src/pages/SyncDashboard.tsx
+++ b/frontend/src/pages/SyncDashboard.tsx
@@ -156,7 +156,7 @@ export function SyncDashboard({ syncTrigger }: SyncDashboardProps) {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold text-slate-800">Data sync</h1>
+        <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Data sync</h1>
       </div>
 
       {/* --- Status banner --- */}
@@ -345,7 +345,7 @@ function LayerCard({
       className={`rounded border ${border} bg-white p-3 text-sm shadow-sm`}
     >
       <div className="flex items-center justify-between">
-        <span className="font-medium text-slate-800">{layer.display_name}</span>
+        <span className="font-medium text-slate-800 dark:text-slate-100">{layer.display_name}</span>
         <span className="flex items-center gap-1">
           <span className="sr-only">
             {isRunning ? "running" : layer.is_fresh ? "fresh" : "stale"}

--- a/frontend/src/pages/Tenk10KDrilldownPage.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.tsx
@@ -117,7 +117,7 @@ function SectionBody({
       id={sectionAnchorId(section)}
       className="relative pl-6 before:absolute before:bottom-0 before:left-0 before:top-0 before:w-0.5 before:bg-slate-200"
     >
-      <h3 className="text-base font-semibold text-slate-900">{section.section_label}</h3>
+      <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">{section.section_label}</h3>
       <div className="mt-2 space-y-3 text-sm">
         {parts.map((p, i) => {
           if (p.type === "prose" && p.prose !== undefined) {
@@ -235,7 +235,7 @@ function Body({
           >
             ← Back to {symbol}
           </Link>
-          <h2 className="mt-1 text-lg font-semibold text-slate-900">
+          <h2 className="mt-1 text-lg font-semibold text-slate-900 dark:text-slate-100">
             Form 10-K · Item 1 Business
           </h2>
         </header>

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -887,7 +887,7 @@ function RichTooltip({ hover }: { hover: RichHoverState }): JSX.Element {
       <div className="absolute left-2 top-2 z-10 flex flex-wrap items-baseline gap-x-2 text-[11px] tabular-nums leading-tight text-slate-700">
         <span className="text-slate-500">{hover.date}</span>
         <span className="text-slate-400">·</span>
-        <span className="font-medium text-slate-800">{hover.primarySymbol}</span>
+        <span className="font-medium text-slate-800 dark:text-slate-100">{hover.primarySymbol}</span>
         <span className={primaryClass}>{fmtPct(hover.primaryPct)}</span>
         {hover.comparePcts?.map((cp) => (
           <span key={cp.symbol} className="flex items-baseline gap-1">
@@ -927,7 +927,7 @@ function RichTooltip({ hover }: { hover: RichHoverState }): JSX.Element {
       <span>
         <span className="text-slate-400">L</span> {fmt(hover.low ?? 0)}
       </span>
-      <span className="font-medium text-slate-800">
+      <span className="font-medium text-slate-800 dark:text-slate-100">
         <span className="font-normal text-slate-400">C</span> {fmt(hover.close ?? 0)}
       </span>
       <span>


### PR DESCRIPTION
Closes #703. Third slice of #700 epic.

## What

Dark partners across page-level headings, KPI / value displays, and dense table cell text.

Mappings:
- \`text-slate-800\` → \`dark:text-slate-100\` (page h1, table values, hover labels)
- \`text-slate-900\` → \`dark:text-slate-100\` (KPI tile values, drilldown headings)
- \`text-slate-500\` → \`dark:text-slate-400\` (axis labels, table headers, timestamps)
- \`text-slate-400\` → \`dark:text-slate-500\` (very-muted hints, sub-labels)

Two hover-state utilities also picked up dark partners explicitly:
- RankingsTable column-header hover → \`dark:hover:text-slate-200\`
- LoginPage register link hover → \`dark:hover:text-slate-100\`

\`SummaryCards\` tone branches get dark variants for emerald / rose KPI deltas (\`dark:text-emerald-400\`, \`dark:text-rose-400\`) so positive/negative P&L stays legible on dark surface without losing semantic colour.

## Why

Operator screenshot pass on PR #699 flagged dim KPI tiles, near-invisible Rankings numerics, and unreadable table headers in dark mode. This sweep takes the dim-text findings to terminal state across all pages.

## Test plan

- [x] \`pnpm --dir frontend typecheck\` — clean
- [x] \`pnpm --dir frontend test:unit\` — 746/746 pass
- [ ] Operator pass: dark mode walk Dashboard → Portfolio → Rankings → Recommendations → L2 drill — confirm all numerics readable, page h1 visible, dim secondary text legible

## Out of scope

- #704 — border + hover state polish (final Phase 2 slice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)