### PR TITLE
feat(#704): dark mode Phase 2d — border + hover state polish

### DIFF
--- a/frontend/src/components/Term.tsx
+++ b/frontend/src/components/Term.tsx
@@ -71,7 +71,7 @@ export function Term({ term, children, className }: TermProps): JSX.Element {
       {open ? (
         <span
           role="tooltip"
-          className="absolute left-0 top-full z-50 mt-1 w-72 rounded-md border border-slate-200 bg-white px-3 py-2 text-xs leading-snug text-slate-700 shadow-lg"
+          className="absolute left-0 top-full z-50 mt-1 w-72 rounded-md border border-slate-200 dark:border-slate-800 bg-white px-3 py-2 text-xs leading-snug text-slate-700 shadow-lg"
         >
           <span className="block text-[10px] font-semibold uppercase tracking-wider text-slate-500">
             {entry.shortName}

--- a/frontend/src/components/admin/CollapsibleSection.tsx
+++ b/frontend/src/components/admin/CollapsibleSection.tsx
@@ -47,7 +47,7 @@ export function CollapsibleSection({
   }
 
   return (
-    <section className="border-t border-slate-200 pt-3" id={sectionId}>
+    <section className="border-t border-slate-200 dark:border-slate-800 pt-3" id={sectionId}>
       <button
         type="button"
         onClick={toggle}

--- a/frontend/src/components/admin/FundDataRow.tsx
+++ b/frontend/src/components/admin/FundDataRow.tsx
@@ -118,7 +118,7 @@ export function FundDataRow({
 
   return (
     <div
-      className="grid grid-cols-2 gap-x-6 gap-y-3 border-t border-slate-200 px-1 pt-3 pb-2 sm:grid-cols-4 lg:grid-cols-7"
+      className="grid grid-cols-2 gap-x-6 gap-y-3 border-t border-slate-200 dark:border-slate-800 px-1 pt-3 pb-2 sm:grid-cols-4 lg:grid-cols-7"
       data-testid="fund-data-row"
     >
       {cells.map((c) => (

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -399,7 +399,7 @@ export function AlertsStrip(): JSX.Element | null {
   return (
     <section
       aria-labelledby="alerts-strip-heading"
-      className="border-t border-slate-200 pt-3"
+      className="border-t border-slate-200 dark:border-slate-800 pt-3"
     >
       <header className="flex items-baseline justify-between gap-2">
         <div className="flex items-baseline gap-2">

--- a/frontend/src/components/dashboard/BootstrapProgress.tsx
+++ b/frontend/src/components/dashboard/BootstrapProgress.tsx
@@ -120,7 +120,7 @@ export function BootstrapProgress({
             ) : step.active ? (
               <span className="inline-block h-3 w-3 animate-pulse rounded-full bg-blue-400" />
             ) : (
-              <span className="inline-block h-3 w-3 rounded-full border border-slate-300" />
+              <span className="inline-block h-3 w-3 rounded-full border border-slate-300 dark:border-slate-700" />
             )}
             <span
               className={

--- a/frontend/src/components/dashboard/PortfolioValueChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueChart.tsx
@@ -117,7 +117,7 @@ export function PortfolioValueChart(): JSX.Element | null {
   if (!effectivelyLoading && !hasMovement && fxSkipped === 0) return null;
 
   return (
-    <div className="border-t border-slate-200 pt-3">
+    <div className="border-t border-slate-200 dark:border-slate-800 pt-3">
       <div className="flex items-baseline justify-between">
         <div className="flex items-baseline gap-2">
           <h2 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-700">

--- a/frontend/src/components/dashboard/RollingPnlStrip.tsx
+++ b/frontend/src/components/dashboard/RollingPnlStrip.tsx
@@ -43,7 +43,7 @@ function Pill({
   // Tone is carried by text colour only — no border accent.
   return (
     <div
-      className="flex-1 border-t border-slate-200 px-3 pt-3 pb-1"
+      className="flex-1 border-t border-slate-200 dark:border-slate-800 px-3 pt-3 pb-1"
       data-testid={`rolling-pnl-${period.period}`}
     >
       <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
@@ -67,7 +67,7 @@ export function RollingPnlStrip(): JSX.Element | null {
     return (
       <div className="grid grid-cols-1 gap-x-6 sm:grid-cols-3">
         {[0, 1, 2].map((i) => (
-          <div key={i} className="border-t border-slate-200 px-3 pt-3 pb-1">
+          <div key={i} className="border-t border-slate-200 dark:border-slate-800 px-3 pt-3 pb-1">
             <SectionSkeleton rows={1} />
           </div>
         ))}

--- a/frontend/src/components/dashboard/SummaryCards.tsx
+++ b/frontend/src/components/dashboard/SummaryCards.tsx
@@ -35,7 +35,7 @@ export function SummaryCards({
     return (
       <div className="grid grid-cols-1 gap-x-6 sm:grid-cols-2 lg:grid-cols-4">
         {[0, 1, 2, 3].map((i) => (
-          <div key={i} className="border-t border-slate-200 px-1 pt-3 pb-1">
+          <div key={i} className="border-t border-slate-200 dark:border-slate-800 px-1 pt-3 pb-1">
             <SectionSkeleton rows={2} />
           </div>
         ))}
@@ -91,7 +91,7 @@ function DeploymentCard({
       return <Card label="Available for deployment" value="—" hint="Budget unavailable" />;
     }
     return (
-      <div className="border-t border-slate-200 px-1 pt-3 pb-1">
+      <div className="border-t border-slate-200 dark:border-slate-800 px-1 pt-3 pb-1">
         <SectionSkeleton rows={2} />
       </div>
     );
@@ -140,7 +140,7 @@ function Card({
         ? "text-rose-600 dark:text-rose-400"
         : "text-slate-900 dark:text-slate-100";
   return (
-    <div className="border-t border-slate-200 px-1 pt-3 pb-1">
+    <div className="border-t border-slate-200 dark:border-slate-800 px-1 pt-3 pb-1">
       <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
         {label}
       </div>

--- a/frontend/src/components/dashboard/WatchlistPanel.tsx
+++ b/frontend/src/components/dashboard/WatchlistPanel.tsx
@@ -29,7 +29,7 @@ export function WatchlistPanel({ items, onRemove }: Props) {
     <div className="overflow-x-auto">
       <table className="min-w-full text-sm">
         <thead>
-          <tr className="border-b border-slate-200 text-left text-xs text-slate-500 dark:text-slate-400">
+          <tr className="border-b border-slate-200 dark:border-slate-800 text-left text-xs text-slate-500 dark:text-slate-400">
             <th className="px-2 py-1">Symbol</th>
             <th className="px-2 py-1">Name</th>
             <th className="px-2 py-1">Sector</th>

--- a/frontend/src/components/insider/InsiderByOfficer.tsx
+++ b/frontend/src/components/insider/InsiderByOfficer.tsx
@@ -146,7 +146,7 @@ function OfficerTooltip({ active, payload }: TooltipProps) {
         ? "text-red-700"
         : "text-slate-600";
   return (
-    <div className="rounded border border-slate-200 bg-white px-2 py-1 text-xs shadow-md">
+    <div className="rounded border border-slate-200 dark:border-slate-800 bg-white px-2 py-1 text-xs shadow-md">
       <div className="font-medium text-slate-700">{bucket.officer}</div>
       <div className={`font-mono tabular-nums ${colorClass}`}>
         {bucket.net > 0 ? "+" : ""}

--- a/frontend/src/components/insider/InsiderNetByMonth.tsx
+++ b/frontend/src/components/insider/InsiderNetByMonth.tsx
@@ -136,7 +136,7 @@ function NetTooltip({ active, payload }: TooltipProps) {
         ? "text-red-700"
         : "text-slate-700";
   return (
-    <div className="rounded border border-slate-200 bg-white px-2 py-1 text-xs shadow-md">
+    <div className="rounded border border-slate-200 dark:border-slate-800 bg-white px-2 py-1 text-xs shadow-md">
       <div className="font-medium text-slate-700">
         {shortMonthLabel(bucket.month)}
       </div>

--- a/frontend/src/components/insider/InsiderTransactionsTable.tsx
+++ b/frontend/src/components/insider/InsiderTransactionsTable.tsx
@@ -268,7 +268,7 @@ export function InsiderTransactionsTable({
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
           placeholder="Filter by officer / role / security title"
-          className="w-72 rounded border border-slate-200 px-2 py-1 text-xs focus:border-sky-500 focus:outline-none"
+          className="w-72 rounded border border-slate-200 dark:border-slate-800 px-2 py-1 text-xs focus:border-sky-500 focus:outline-none"
           data-testid="insider-table-filter"
         />
         <div className="flex items-center gap-2 text-[11px] text-slate-500">
@@ -286,14 +286,14 @@ export function InsiderTransactionsTable({
           </button>
         </div>
       </div>
-      <div className="max-h-[60vh] overflow-auto rounded border border-slate-200">
+      <div className="max-h-[60vh] overflow-auto rounded border border-slate-200 dark:border-slate-800">
         <table className="min-w-full text-xs">
           <thead className="sticky top-0 bg-slate-50 text-slate-500">
             <tr>
               {COLUMNS.map((col) => (
                 <th
                   key={col.key}
-                  className={`cursor-pointer px-2 py-1 font-medium uppercase tracking-wider ${col.align === "right" ? "text-right" : "text-left"} hover:bg-slate-100`}
+                  className={`cursor-pointer px-2 py-1 font-medium uppercase tracking-wider ${col.align === "right" ? "text-right" : "text-left"} hover:bg-slate-100 dark:hover:bg-slate-800`}
                   onClick={() => toggleSort(col.key)}
                   data-testid={`insider-table-sort-${col.key}`}
                 >
@@ -320,7 +320,7 @@ export function InsiderTransactionsTable({
               return (
                 <tr
                   key={`${r.accession_number}-${r.txn_row_num}`}
-                  className="border-t border-slate-100 hover:bg-slate-50"
+                  className="border-t border-slate-100 hover:bg-slate-50 dark:hover:bg-slate-800/40"
                 >
                   <td className="px-2 py-1 font-mono tabular-nums text-slate-700">
                     {r.txn_date}

--- a/frontend/src/components/instrument/BusinessSectionsPanel.tsx
+++ b/frontend/src/components/instrument/BusinessSectionsPanel.tsx
@@ -87,7 +87,7 @@ function SectionBlock({
   const hasRefs = section.cross_references.length > 0;
   const showExpandToggle = section.body.length > 360;
   return (
-    <div className="border-l-2 border-slate-200 pl-3">
+    <div className="border-l-2 border-slate-200 dark:border-slate-800 pl-3">
       <div className="mb-1 flex items-center justify-between gap-2">
         <div className="text-sm font-semibold text-slate-800 dark:text-slate-100">
           {labelFor(section)}

--- a/frontend/src/components/instrument/CrossRefPopover.tsx
+++ b/frontend/src/components/instrument/CrossRefPopover.tsx
@@ -60,7 +60,7 @@ export function CrossRefPopover({
         {cref.target}
       </button>
       {open && (
-        <span className="absolute left-0 top-full z-20 mt-1 block w-72 rounded border border-slate-200 bg-white p-3 text-xs shadow-lg">
+        <span className="absolute left-0 top-full z-20 mt-1 block w-72 rounded border border-slate-200 dark:border-slate-800 bg-white p-3 text-xs shadow-lg">
           <span className="block text-[10px] uppercase tracking-wider text-slate-500">
             {cref.reference_type === "item" ? "Preview" : "Reference"} · {cref.target}
           </span>

--- a/frontend/src/components/instrument/EightKEventsPanel.tsx
+++ b/frontend/src/components/instrument/EightKEventsPanel.tsx
@@ -60,7 +60,7 @@ function ItemBlock({ item }: { item: EightKItem }) {
   const hasBody = item.body.length > 0;
   const showToggle = item.body.length > 200;
   return (
-    <div className="border-l-2 border-slate-200 pl-3">
+    <div className="border-l-2 border-slate-200 dark:border-slate-800 pl-3">
       <div className="mb-1 flex items-center gap-2">
         <span
           className={`rounded px-1.5 py-0.5 font-mono text-[11px] font-semibold ${severityTone(item.severity)}`}
@@ -101,7 +101,7 @@ function ItemBlock({ item }: { item: EightKItem }) {
 function FilingCard({ filing }: { filing: EightKFiling }) {
   const dateText = filing.date_of_report ?? "—";
   return (
-    <div className="rounded-sm border border-slate-200 p-3">
+    <div className="rounded-sm border border-slate-200 dark:border-slate-800 p-3">
       <div className="mb-2 flex flex-wrap items-center gap-2">
         <span className="font-mono text-xs text-slate-800 dark:text-slate-100">
           {dateText}

--- a/frontend/src/components/instrument/EmbeddedTable.tsx
+++ b/frontend/src/components/instrument/EmbeddedTable.tsx
@@ -14,7 +14,7 @@ export function EmbeddedTable({ table }: EmbeddedTableProps): JSX.Element {
   return (
     <table className="my-4 w-full border-collapse text-sm">
       <thead>
-        <tr className="border-b border-slate-300 bg-slate-50 text-left text-xs uppercase tracking-wider text-slate-600">
+        <tr className="border-b border-slate-300 dark:border-slate-700 bg-slate-50 text-left text-xs uppercase tracking-wider text-slate-600">
           {table.headers.map((h, i) => (
             <th key={i} className="px-3 py-2 font-medium">
               {h}

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -58,12 +58,12 @@ function thesisTone(stance: string): string {
     case "buy":
       return "bg-emerald-50 text-emerald-700 border-emerald-300";
     case "hold":
-      return "bg-slate-100 text-slate-700 border-slate-300";
+      return "bg-slate-100 text-slate-700 border-slate-300 dark:border-slate-700";
     case "exit":
     case "sell":
       return "bg-red-50 text-red-700 border-red-300";
     default:
-      return "bg-slate-100 text-slate-700 border-slate-300";
+      return "bg-slate-100 text-slate-700 border-slate-300 dark:border-slate-700";
   }
 }
 
@@ -209,7 +209,7 @@ export function SummaryStrip({
         ) : thesisLoaded ? (
           <span
             data-testid="thesis-badge-missing"
-            className="inline-flex items-center rounded border border-slate-300 bg-slate-50 px-2 py-0.5 text-xs font-medium text-slate-500"
+            className="inline-flex items-center rounded border border-slate-300 dark:border-slate-700 bg-slate-50 px-2 py-0.5 text-xs font-medium text-slate-500"
           >
             No thesis yet
           </span>
@@ -267,7 +267,7 @@ export function SummaryStrip({
               data-testid="action-generate-thesis"
               onClick={onGenerateThesis}
               disabled={generatingThesis}
-              className="rounded border border-slate-300 bg-white px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+              className="rounded border border-slate-300 dark:border-slate-700 bg-white px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
             >
               {generatingThesis ? "Generating…" : "Generate thesis"}
             </button>

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -267,7 +267,7 @@ export function SummaryStrip({
               data-testid="action-generate-thesis"
               onClick={onGenerateThesis}
               disabled={generatingThesis}
-              className="rounded border border-slate-300 dark:border-slate-700 bg-white px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+              className="rounded border border-slate-300 bg-white px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800/40"
             >
               {generatingThesis ? "Generating…" : "Generate thesis"}
             </button>

--- a/frontend/src/components/orders/ClosePositionModal.tsx
+++ b/frontend/src/components/orders/ClosePositionModal.tsx
@@ -337,7 +337,7 @@ function InfoStrip({
 }): JSX.Element {
   const amber = valuationSource !== "quote";
   return (
-    <div className="rounded border border-slate-200 bg-slate-50 px-2 py-1.5 text-xs text-slate-700">
+    <div className="rounded border border-slate-200 dark:border-slate-800 bg-slate-50 px-2 py-1.5 text-xs text-slate-700">
       <div>
         {formatNumber(trade.units, 6)} units @ {formatNumber(trade.open_rate, 4)}{" "}
         {currency}
@@ -388,7 +388,7 @@ function PreviewBlock({
       ? "using latest quote"
       : `using latest ${valuationSource} — backend may fall back to open rate`;
   return (
-    <div className="rounded border border-slate-200 bg-slate-50 px-2 py-1.5 text-xs">
+    <div className="rounded border border-slate-200 dark:border-slate-800 bg-slate-50 px-2 py-1.5 text-xs">
       <div>
         Closing: {formatNumber(unitsToClose, 6)} /{" "}
         {formatNumber(trade.units, 6)} units

--- a/frontend/src/components/orders/OrderEntryModal.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.tsx
@@ -332,7 +332,7 @@ function PreviewBlock({
     estimate = "No usable quote — submit will likely 422";
   }
   return (
-    <div className="rounded border border-slate-200 bg-slate-50 px-2 py-1.5 text-xs text-slate-700">
+    <div className="rounded border border-slate-200 dark:border-slate-800 bg-slate-50 px-2 py-1.5 text-xs text-slate-700">
       <div>{estimate}</div>
       <div className="text-slate-500">Estimated fees: 0.00 (demo)</div>
     </div>

--- a/frontend/src/components/rankings/RankingsFilters.tsx
+++ b/frontend/src/components/rankings/RankingsFilters.tsx
@@ -45,7 +45,7 @@ export function RankingsFilters({
 }: RankingsFiltersProps) {
   return (
     <div
-      className="flex flex-wrap items-end gap-3 border-t border-slate-200 px-1 pt-3 pb-2"
+      className="flex flex-wrap items-end gap-3 border-t border-slate-200 dark:border-slate-800 px-1 pt-3 pb-2"
       role="group"
       aria-label="Rankings filters"
     >

--- a/frontend/src/components/rankings/RankingsTable.tsx
+++ b/frontend/src/components/rankings/RankingsTable.tsx
@@ -148,7 +148,7 @@ export function RankingsTable({ view }: { view: RankingsView }) {
             </MessageRow>
           ) : view.kind === "empty" ? (
             <MessageRow>
-              <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-slate-200 bg-white p-8 text-center">
+              <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-slate-200 dark:border-slate-800 bg-white p-8 text-center">
                 <h2 className="text-base font-semibold text-slate-700">{view.title}</h2>
                 <p className="mt-1 max-w-md text-sm text-slate-500 dark:text-slate-400">{view.description}</p>
                 {view.action ? <div className="mt-4">{view.action}</div> : null}

--- a/frontend/src/components/recommendations/AuditFilters.tsx
+++ b/frontend/src/components/recommendations/AuditFilters.tsx
@@ -19,7 +19,7 @@ export function AuditFilters({
 }: AuditFiltersProps) {
   return (
     <div
-      className="flex flex-wrap items-end gap-3 border-t border-slate-200 px-1 pt-3 pb-2"
+      className="flex flex-wrap items-end gap-3 border-t border-slate-200 dark:border-slate-800 px-1 pt-3 pb-2"
       role="group"
       aria-label="Audit filters"
     >

--- a/frontend/src/components/recommendations/AuditTrail.tsx
+++ b/frontend/src/components/recommendations/AuditTrail.tsx
@@ -62,7 +62,7 @@ export function AuditTrail({ view }: { view: AuditView }) {
     <div className="overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-slate-200 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr className="border-b border-slate-200 dark:border-slate-800 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
             <th className="px-2 py-2">Time</th>
             <th className="px-2 py-2">Symbol</th>
             <th className="px-2 py-2">Stage</th>

--- a/frontend/src/components/recommendations/AuditTrail.tsx
+++ b/frontend/src/components/recommendations/AuditTrail.tsx
@@ -86,7 +86,7 @@ function AuditRow({ item }: { item: AuditListItem }) {
   return (
     <>
       <tr
-        className="cursor-pointer hover:bg-slate-50"
+        className="cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800/40"
         onClick={() => setExpanded((prev) => !prev)}
       >
         <td className="px-2 py-2 text-xs text-slate-500">{formatDateTime(item.decision_time)}</td>

--- a/frontend/src/components/recommendations/RecommendationsFilters.tsx
+++ b/frontend/src/components/recommendations/RecommendationsFilters.tsx
@@ -19,7 +19,7 @@ export function RecommendationsFilters({
 }: RecommendationsFiltersProps) {
   return (
     <div
-      className="flex flex-wrap items-end gap-3 border-t border-slate-200 px-1 pt-3 pb-2"
+      className="flex flex-wrap items-end gap-3 border-t border-slate-200 dark:border-slate-800 px-1 pt-3 pb-2"
       role="group"
       aria-label="Recommendations filters"
     >

--- a/frontend/src/components/recommendations/RecommendationsTable.tsx
+++ b/frontend/src/components/recommendations/RecommendationsTable.tsx
@@ -90,7 +90,7 @@ function RecommendationRow({ item }: { item: RecommendationListItem }) {
   return (
     <>
       <tr
-        className="cursor-pointer hover:bg-slate-50"
+        className="cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800/40"
         onClick={() => setExpanded((prev) => !prev)}
       >
         <td className="px-2 py-2">

--- a/frontend/src/components/recommendations/RecommendationsTable.tsx
+++ b/frontend/src/components/recommendations/RecommendationsTable.tsx
@@ -65,7 +65,7 @@ export function RecommendationsTable({ view }: { view: RecommendationsView }) {
     <div className="overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-slate-200 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr className="border-b border-slate-200 dark:border-slate-800 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
             <th className="px-2 py-2">Symbol</th>
             <th className="px-2 py-2">Action</th>
             <th className="px-2 py-2">Status</th>

--- a/frontend/src/components/security/RecoveryPhraseConfirm.tsx
+++ b/frontend/src/components/security/RecoveryPhraseConfirm.tsx
@@ -269,7 +269,7 @@ export function RecoveryPhraseConfirm({
         </header>
         <ol
           aria-label="Recovery phrase words"
-          className="grid grid-cols-2 gap-x-6 gap-y-2 rounded border border-slate-200 bg-slate-50 p-4 font-mono text-sm text-slate-800 dark:text-slate-100"
+          className="grid grid-cols-2 gap-x-6 gap-y-2 rounded border border-slate-200 dark:border-slate-800 bg-slate-50 p-4 font-mono text-sm text-slate-800 dark:text-slate-100"
         >
           {phrase.map((word, index) => (
             <li

--- a/frontend/src/components/settings/BudgetConfigSection.tsx
+++ b/frontend/src/components/settings/BudgetConfigSection.tsx
@@ -118,7 +118,7 @@ export function BudgetConfigSection() {
     eventAmount === "" || !Number.isFinite(parsedEventAmount) || parsedEventAmount <= 0;
 
   return (
-    <section className="border-t border-slate-200 pt-3">
+    <section className="border-t border-slate-200 dark:border-slate-800 pt-3">
       <header>
         <h2 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-700">
           Budget Configuration
@@ -158,7 +158,7 @@ export function BudgetConfigSection() {
                       setCashBufferPct(val === serverBufferPct ? null : val);
                     }}
                     disabled={configSaving}
-                    className="mt-1 block w-24 rounded border border-slate-300 px-2 py-1.5 text-sm"
+                    className="mt-1 block w-24 rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
                   />
                 </label>
 
@@ -175,7 +175,7 @@ export function BudgetConfigSection() {
                       setCgtScenario(val === serverScenario ? null : val);
                     }}
                     disabled={configSaving}
-                    className="mt-1 block rounded border border-slate-300 px-2 py-1.5 text-sm"
+                    className="mt-1 block rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
                   >
                     <option value="basic">basic</option>
                     <option value="higher">higher</option>
@@ -193,7 +193,7 @@ export function BudgetConfigSection() {
                   onChange={(e) => setConfigReason(e.target.value)}
                   disabled={configSaving}
                   placeholder="Why are you changing this?"
-                  className="mt-1 block w-full max-w-md rounded border border-slate-300 px-2 py-1.5 text-sm"
+                  className="mt-1 block w-full max-w-md rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
                 />
               </label>
 
@@ -244,7 +244,7 @@ export function BudgetConfigSection() {
                     )
                   }
                   disabled={eventSaving}
-                  className="mt-1 block rounded border border-slate-300 px-2 py-1.5 text-sm"
+                  className="mt-1 block rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
                 >
                   <option value="injection">injection</option>
                   <option value="withdrawal">withdrawal</option>
@@ -261,7 +261,7 @@ export function BudgetConfigSection() {
                   onChange={(e) => setEventAmount(e.target.value)}
                   disabled={eventSaving}
                   placeholder="0.00"
-                  className="mt-1 block w-32 rounded border border-slate-300 px-2 py-1.5 text-sm"
+                  className="mt-1 block w-32 rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
                 />
               </label>
 
@@ -273,7 +273,7 @@ export function BudgetConfigSection() {
                     setEventCurrency(e.target.value as "USD" | "GBP")
                   }
                   disabled={eventSaving}
-                  className="mt-1 block rounded border border-slate-300 px-2 py-1.5 text-sm"
+                  className="mt-1 block rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
                 >
                   <option value="USD">USD</option>
                   <option value="GBP">GBP</option>
@@ -288,7 +288,7 @@ export function BudgetConfigSection() {
                 onChange={(e) => setEventNote(e.target.value)}
                 disabled={eventSaving}
                 rows={2}
-                className="mt-1 block w-full max-w-md rounded border border-slate-300 px-2 py-1.5 text-sm"
+                className="mt-1 block w-full max-w-md rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
               />
             </label>
 

--- a/frontend/src/components/settings/DisplayCurrencySection.tsx
+++ b/frontend/src/components/settings/DisplayCurrencySection.tsx
@@ -49,13 +49,13 @@ export function DisplayCurrencySection({ currentCurrency, onChanged }: Props) {
         </p>
       </div>
 
-      <div className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4">
+      <div className="max-w-sm space-y-3 rounded border border-slate-200 dark:border-slate-800 bg-white p-4">
         <div className="flex items-center gap-3">
           <select
             value={selected}
             onChange={(e) => setSelected(e.target.value)}
             disabled={saving}
-            className="rounded border border-slate-300 px-2 py-1.5 text-sm"
+            className="rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
           >
             {SUPPORTED_CURRENCIES.map((c) => (
               <option key={c} value={c}>

--- a/frontend/src/components/states/EmptyState.tsx
+++ b/frontend/src/components/states/EmptyState.tsx
@@ -10,7 +10,7 @@ export function EmptyState({
   children?: ReactNode;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-slate-200 bg-white p-12 text-center">
+    <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-slate-200 dark:border-slate-800 bg-white p-12 text-center">
       <h2 className="text-base font-semibold text-slate-700">{title}</h2>
       {description ? (
         <p className="mt-1 max-w-md text-sm text-slate-500">{description}</p>

--- a/frontend/src/components/states/LoadingSkeleton.tsx
+++ b/frontend/src/components/states/LoadingSkeleton.tsx
@@ -3,7 +3,7 @@ export function LoadingSkeleton({ label = "Loading…" }: { label?: string }) {
     <div
       role="status"
       aria-live="polite"
-      className="flex animate-pulse items-center justify-center rounded-md border border-dashed border-slate-200 bg-white p-12 text-sm text-slate-400"
+      className="flex animate-pulse items-center justify-center rounded-md border border-dashed border-slate-200 dark:border-slate-800 bg-white p-12 text-sm text-slate-400"
     >
       {label}
     </div>

--- a/frontend/src/components/ui/Pagination.tsx
+++ b/frontend/src/components/ui/Pagination.tsx
@@ -51,11 +51,11 @@ export interface PaginationProps {
 const BTN_BASE =
   "rounded border px-2 py-1 text-xs font-medium transition-colors";
 const BTN_IDLE =
-  "border-slate-200 bg-white text-slate-600 hover:bg-slate-50 dark:hover:bg-slate-800/40";
+  "border-slate-200 dark:border-slate-800 bg-white text-slate-600 hover:bg-slate-50 dark:hover:bg-slate-800/40";
 const BTN_ACTIVE =
   "border-blue-400 bg-blue-50 text-blue-700";
 const BTN_DISABLED =
-  "border-slate-200 bg-white text-slate-300 cursor-not-allowed";
+  "border-slate-200 dark:border-slate-800 bg-white text-slate-300 cursor-not-allowed";
 
 export function Pagination({ page, totalPages, onPageChange }: PaginationProps) {
   if (totalPages <= 1) return null;

--- a/frontend/src/components/ui/Pagination.tsx
+++ b/frontend/src/components/ui/Pagination.tsx
@@ -51,7 +51,7 @@ export interface PaginationProps {
 const BTN_BASE =
   "rounded border px-2 py-1 text-xs font-medium transition-colors";
 const BTN_IDLE =
-  "border-slate-200 bg-white text-slate-600 hover:bg-slate-50";
+  "border-slate-200 bg-white text-slate-600 hover:bg-slate-50 dark:hover:bg-slate-800/40";
 const BTN_ACTIVE =
   "border-blue-400 bg-blue-50 text-blue-700";
 const BTN_DISABLED =

--- a/frontend/src/layout/NotificationBell.tsx
+++ b/frontend/src/layout/NotificationBell.tsx
@@ -77,7 +77,7 @@ export function NotificationBell(): JSX.Element {
       data-unseen-count={count}
       title={count > 0 ? `${count} unread — click to open the dashboard` : "No unread alerts"}
       className={[
-        "relative rounded p-1 text-slate-600 transition hover:bg-slate-50",
+        "relative rounded p-1 text-slate-600 transition hover:bg-slate-50 dark:hover:bg-slate-800/40",
         count > 0 ? "text-red-700" : "",
       ].join(" ")}
     >

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -530,7 +530,7 @@ function RunButton({
       ? "border-red-300 bg-red-50 text-red-700 hover:bg-red-100"
       : state.kind === "queued"
         ? "border-emerald-300 bg-emerald-50 text-emerald-700"
-        : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50";
+        : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40";
   return (
     <button
       type="button"

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -413,7 +413,7 @@ function CoverageSummaryCard({
     <div className="space-y-3">
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         {cells.map((c) => (
-          <div key={c.label} className="rounded border border-slate-200 bg-slate-50 p-3">
+          <div key={c.label} className="rounded border border-slate-200 dark:border-slate-800 bg-slate-50 p-3">
             <div className="text-xs uppercase tracking-wide text-slate-500">
               {c.label}
             </div>
@@ -530,7 +530,7 @@ function RunButton({
       ? "border-red-300 bg-red-50 text-red-700 hover:bg-red-100"
       : state.kind === "queued"
         ? "border-emerald-300 bg-emerald-50 text-emerald-700"
-        : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40";
+        : "border-slate-200 dark:border-slate-800 bg-white text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40";
   return (
     <button
       type="button"

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -484,7 +484,7 @@ export function ChartPage(): JSX.Element {
                   className={`rounded border px-2 py-0.5 text-xs font-medium ${
                     active
                       ? "border-orange-400 bg-white text-orange-600"
-                      : "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
+                      : "border-slate-200 dark:border-slate-800 bg-slate-50 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
                   }`}
                   data-testid={`trend-${id}`}
                 >
@@ -515,7 +515,7 @@ export function ChartPage(): JSX.Element {
                 className={`rounded border px-2 py-0.5 text-xs font-medium ${
                   on
                     ? "border-slate-400 bg-white text-slate-700"
-                    : "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
+                    : "border-slate-200 dark:border-slate-800 bg-slate-50 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
                 }`}
                 data-testid={`session-toggle-${key}`}
               >
@@ -540,7 +540,7 @@ export function ChartPage(): JSX.Element {
                 className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${
                   hasFailed
                     ? "border-red-400 bg-red-50 text-red-700"
-                    : "border-slate-300 bg-slate-50 text-slate-700"
+                    : "border-slate-300 dark:border-slate-700 bg-slate-50 text-slate-700"
                 }`}
                 title={hasFailed ? "Failed to fetch — check ticker" : undefined}
                 aria-label={hasFailed ? `${sym} — failed to fetch` : sym}
@@ -579,7 +579,7 @@ export function ChartPage(): JSX.Element {
       )}
 
       {/* Body: chart or raw table */}
-      <div className="border-t border-slate-200 pt-3">
+      <div className="border-t border-slate-200 dark:border-slate-800 pt-3">
         {effectivelyLoading && candlesAsync.error === null ? (
           <div className="p-4">
             <SectionSkeleton rows={10} />

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -453,7 +453,7 @@ export function ChartPage(): JSX.Element {
                   className={`rounded border px-2 py-0.5 text-xs font-medium ${
                     active
                       ? "bg-white text-slate-700"
-                      : "bg-slate-50 text-slate-500 hover:bg-slate-100"
+                      : "bg-slate-50 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
                   }`}
                   style={
                     active
@@ -484,7 +484,7 @@ export function ChartPage(): JSX.Element {
                   className={`rounded border px-2 py-0.5 text-xs font-medium ${
                     active
                       ? "border-orange-400 bg-white text-orange-600"
-                      : "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100"
+                      : "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
                   }`}
                   data-testid={`trend-${id}`}
                 >
@@ -515,7 +515,7 @@ export function ChartPage(): JSX.Element {
                 className={`rounded border px-2 py-0.5 text-xs font-medium ${
                   on
                     ? "border-slate-400 bg-white text-slate-700"
-                    : "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100"
+                    : "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
                 }`}
                 data-testid={`session-toggle-${key}`}
               >

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -55,7 +55,7 @@ export function CopyTradingPage() {
       </div>
 
       {detail.error !== null ? (
-        <div className="border-t border-slate-200 pt-3">
+        <div className="border-t border-slate-200 dark:border-slate-800 pt-3">
           <SectionError onRetry={detail.refetch} />
         </div>
       ) : detail.loading || detail.data === null ? (
@@ -107,7 +107,7 @@ function TraderAvatar({ username }: { username: string }) {
 
 function MirrorStats({ mirror, currency }: { mirror: MirrorSummary; currency: string }) {
   return (
-    <div className="grid grid-cols-2 gap-x-6 gap-y-2 border-t border-slate-200 px-1 pt-3 pb-2 text-sm sm:grid-cols-3">
+    <div className="grid grid-cols-2 gap-x-6 gap-y-2 border-t border-slate-200 dark:border-slate-800 px-1 pt-3 pb-2 text-sm sm:grid-cols-3">
       <LabelValue label="Initial investment" value={formatMoney(mirror.initial_investment, currency)} />
       <LabelValue label="Deposits" value={formatMoney(mirror.deposit_summary, currency)} />
       <LabelValue label="Withdrawals" value={formatMoney(mirror.withdrawal_summary, currency)} />

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -238,7 +238,7 @@ function InstrumentGroupRow({
   return (
     <>
       <tr
-        className={`border-t border-slate-100 ${hasMultiple ? "cursor-pointer hover:bg-slate-50" : ""}`}
+        className={`border-t border-slate-100 ${hasMultiple ? "cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800/40" : ""}`}
         onClick={hasMultiple ? () => setExpanded((v) => !v) : undefined}
       >
         <td className="px-2 py-2 text-left">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -112,7 +112,7 @@ export function DashboardPage() {
         // they share the `/portfolio` fetch so duplicating the retry
         // affordance would just confuse the operator (Codex #387
         // review).
-        <div className="border-t border-slate-200 pt-3">
+        <div className="border-t border-slate-200 dark:border-slate-800 pt-3">
           <SectionError onRetry={portfolio.refetch} />
         </div>
       ) : (

--- a/frontend/src/pages/DividendsPage.tsx
+++ b/frontend/src/pages/DividendsPage.tsx
@@ -189,7 +189,7 @@ export function DividendsPage(): JSX.Element {
 
   return (
     <div className="mx-auto max-w-screen-xl space-y-4 p-4">
-      <header className="border-b border-slate-200 pb-3">
+      <header className="border-b border-slate-200 dark:border-slate-800 pb-3">
         <Link to={backHref} className="text-xs text-sky-700 hover:underline">
           ← Back to {symbol}
         </Link>
@@ -373,7 +373,7 @@ function FyTotalsTable({
   return (
     <table className="min-w-full text-xs">
       <thead>
-        <tr className="border-b border-slate-200 text-left text-slate-500">
+        <tr className="border-b border-slate-200 dark:border-slate-800 text-left text-slate-500">
           <th className="px-2 py-1">Fiscal year</th>
           <th className="px-2 py-1 text-right">Total DPS</th>
         </tr>

--- a/frontend/src/pages/EightKListPage.tsx
+++ b/frontend/src/pages/EightKListPage.tsx
@@ -186,7 +186,7 @@ export function EightKListPage(): JSX.Element {
                     return (
                       <tr
                         key={f.accession_number}
-                        className={`cursor-pointer border-b border-slate-100 hover:bg-slate-50 ${
+                        className={`cursor-pointer border-b border-slate-100 hover:bg-slate-50 dark:hover:bg-slate-800/40 ${
                           isSelected ? "bg-sky-50" : ""
                         }`}
                         onClick={() => selectAccession(f.accession_number)}

--- a/frontend/src/pages/EightKListPage.tsx
+++ b/frontend/src/pages/EightKListPage.tsx
@@ -172,7 +172,7 @@ export function EightKListPage(): JSX.Element {
             <div className="overflow-x-auto">
               <table className="min-w-full text-xs">
                 <thead>
-                  <tr className="border-b border-slate-200 text-left text-slate-500">
+                  <tr className="border-b border-slate-200 dark:border-slate-800 text-left text-slate-500">
                     <th className="px-2 py-1">Date</th>
                     <th className="px-2 py-1">Items</th>
                     <th className="px-2 py-1">Severity</th>

--- a/frontend/src/pages/FundamentalsPage.tsx
+++ b/frontend/src/pages/FundamentalsPage.tsx
@@ -139,7 +139,7 @@ export function FundamentalsPage(): JSX.Element {
 
   return (
     <div className="mx-auto max-w-screen-xl space-y-4 p-4">
-      <header className="border-b border-slate-200 pb-3">
+      <header className="border-b border-slate-200 dark:border-slate-800 pb-3">
         <Link to={backHref} className="text-xs text-sky-700 hover:underline">
           ← Back to {symbol}
         </Link>

--- a/frontend/src/pages/InsiderPage.tsx
+++ b/frontend/src/pages/InsiderPage.tsx
@@ -61,7 +61,7 @@ export function InsiderPage(): JSX.Element {
 
   return (
     <div className="mx-auto max-w-screen-xl space-y-4 p-4">
-      <header className="border-b border-slate-200 pb-3">
+      <header className="border-b border-slate-200 dark:border-slate-800 pb-3">
         <Link to={backHref} className="text-xs text-sky-700 hover:underline">
           ← Back to {symbol}
         </Link>

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -164,7 +164,7 @@ function FinancialsTab({ symbol }: { symbol: string }) {
   return (
     <Section title={`${statement.charAt(0).toUpperCase()}${statement.slice(1)} statement`}>
       <div className="mb-3 flex gap-2 text-xs">
-        <div className="flex rounded border border-slate-300">
+        <div className="flex rounded border border-slate-300 dark:border-slate-700">
           {(["income", "balance", "cashflow"] as const).map((s) => (
             <button
               key={s}
@@ -178,7 +178,7 @@ function FinancialsTab({ symbol }: { symbol: string }) {
             </button>
           ))}
         </div>
-        <div className="flex rounded border border-slate-300">
+        <div className="flex rounded border border-slate-300 dark:border-slate-700">
           {(["quarterly", "annual"] as const).map((p) => (
             <button
               key={p}
@@ -207,7 +207,7 @@ function FinancialsTab({ symbol }: { symbol: string }) {
         <div className="overflow-x-auto">
           <table className="min-w-full text-sm">
             <thead>
-              <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
+              <tr className="border-b border-slate-200 dark:border-slate-800 text-left text-xs text-slate-500">
                 <th className="px-2 py-1">Metric</th>
                 {rows.map((row) => (
                   <th key={row.period_end} className="px-2 py-1 text-right">
@@ -650,7 +650,7 @@ function InstrumentPageBody({
           persistent RightRail (filings / peer / news preview). */}
       {activeTab === "research" ? (
         <div className="space-y-4">
-          <nav className="flex gap-1 border-b border-slate-200">
+          <nav className="flex gap-1 border-b border-slate-200 dark:border-slate-800">
             {tabs.map((tab) => (
               <button
                 key={tab.id}
@@ -675,7 +675,7 @@ function InstrumentPageBody({
       ) : (
         <div className="grid gap-4 lg:grid-cols-12">
           <div className="space-y-4 lg:col-span-8">
-            <nav className="flex gap-1 border-b border-slate-200">
+            <nav className="flex gap-1 border-b border-slate-200 dark:border-slate-800">
               {tabs.map((tab) => (
                 <button
                   key={tab.id}

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -424,7 +424,7 @@ function InstrumentsTable({
         </thead>
         <tbody className="divide-y divide-slate-100">
           {items.map((item) => (
-            <tr key={item.instrument_id} className="align-top hover:bg-slate-50">
+            <tr key={item.instrument_id} className="align-top hover:bg-slate-50 dark:hover:bg-slate-800/40">
               <td className="py-2 pr-4">
                 <Link
                   to={`/instrument/${encodeURIComponent(item.symbol)}`}

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -86,14 +86,14 @@ function sortValue(item: InstrumentListItem, key: SortKey): unknown {
 const TIER_TONE: Record<number, string> = {
   1: "bg-emerald-50 text-emerald-700 border-emerald-200",
   2: "bg-blue-50 text-blue-700 border-blue-200",
-  3: "bg-slate-50 text-slate-600 border-slate-200",
+  3: "bg-slate-50 text-slate-600 border-slate-200 dark:border-slate-800",
 };
 
 function TierBadge({ tier }: { tier: number | null }) {
   if (tier === null) {
     return <span className="text-xs text-slate-400">—</span>;
   }
-  const tone = TIER_TONE[tier] ?? "bg-slate-50 text-slate-600 border-slate-200";
+  const tone = TIER_TONE[tier] ?? "bg-slate-50 text-slate-600 border-slate-200 dark:border-slate-800";
   return (
     <span
       className={`inline-block rounded border px-1.5 py-0.5 text-[10px] font-medium ${tone}`}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -67,7 +67,7 @@ export function LoginPage(): JSX.Element {
     <div className="flex h-screen w-screen items-center justify-center bg-slate-50">
       <form
         onSubmit={handleSubmit}
-        className="w-full max-w-sm rounded border border-slate-200 bg-white p-6 shadow-sm"
+        className="w-full max-w-sm rounded border border-slate-200 dark:border-slate-800 bg-white p-6 shadow-sm"
       >
         <h1 className="mb-4 text-lg font-semibold text-slate-800 dark:text-slate-100">eBull operator</h1>
         <label className="mb-3 block text-sm">
@@ -78,7 +78,7 @@ export function LoginPage(): JSX.Element {
             value={username}
             onChange={(e) => setUsername(e.target.value)}
             required
-            className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+            className="w-full rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
           />
         </label>
         <label className="mb-4 block text-sm">
@@ -89,7 +89,7 @@ export function LoginPage(): JSX.Element {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
-            className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+            className="w-full rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
           />
         </label>
         {error !== null && (

--- a/frontend/src/pages/OperatorsPage.tsx
+++ b/frontend/src/pages/OperatorsPage.tsx
@@ -168,7 +168,7 @@ export function OperatorsPage(): JSX.Element {
         <h2 className="mb-2 text-sm font-medium text-slate-700">Add operator</h2>
         <form
           onSubmit={handleCreate}
-          className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4"
+          className="max-w-sm space-y-3 rounded border border-slate-200 dark:border-slate-800 bg-white p-4"
         >
           <label className="block text-sm">
             <span className="mb-1 block text-slate-600">Username</span>
@@ -178,7 +178,7 @@ export function OperatorsPage(): JSX.Element {
               value={newUsername}
               onChange={(e) => setNewUsername(e.target.value)}
               required
-              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+              className="w-full rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
             />
           </label>
           <label className="block text-sm">
@@ -192,7 +192,7 @@ export function OperatorsPage(): JSX.Element {
               onChange={(e) => setNewPassword(e.target.value)}
               minLength={MIN_PASSWORD_LEN}
               required
-              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+              className="w-full rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
             />
           </label>
           {createError !== null && (

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -522,7 +522,7 @@ function PaginationBar({
         type="button"
         onClick={onPrev}
         disabled={page <= 1}
-        className="rounded border border-slate-200 bg-white px-2 py-0.5 font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-40"
+        className="rounded border border-slate-200 bg-white px-2 py-0.5 font-medium text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40 disabled:opacity-40"
       >
         ← Prev
       </button>
@@ -533,7 +533,7 @@ function PaginationBar({
         type="button"
         onClick={onNext}
         disabled={page >= totalPages}
-        className="rounded border border-slate-200 bg-white px-2 py-0.5 font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-40"
+        className="rounded border border-slate-200 bg-white px-2 py-0.5 font-medium text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40 disabled:opacity-40"
       >
         Next →
       </button>
@@ -570,7 +570,7 @@ function PositionRow({
     "cursor-pointer border-t border-slate-100 transition-colors",
     focused
       ? "bg-slate-100 border-l-2 border-l-slate-400"
-      : "hover:bg-slate-50/70",
+      : "hover:bg-slate-50/70 dark:hover:bg-slate-800/40",
   ].join(" ");
 
   return (
@@ -665,7 +665,7 @@ function MirrorRow({
 
   const rowClass = [
     "cursor-pointer border-t border-slate-100 transition-colors",
-    focused ? "bg-slate-100 border-l-2 border-l-slate-400" : "hover:bg-slate-50/70",
+    focused ? "bg-slate-100 border-l-2 border-l-slate-400" : "hover:bg-slate-50/70 dark:hover:bg-slate-800/40",
   ].join(" ");
 
   return (

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -344,7 +344,7 @@ function SummaryBar({
   const mirrorCount = mirrors.length;
 
   return (
-    <div className="flex flex-wrap gap-x-8 gap-y-2 border-t border-slate-200 px-1 pt-3 pb-2 text-sm">
+    <div className="flex flex-wrap gap-x-8 gap-y-2 border-t border-slate-200 dark:border-slate-800 px-1 pt-3 pb-2 text-sm">
       <Stat label="AUM" value={formatMoney(data.total_aum, currency)} />
       <Stat label="Cash" value={formatMoney(data.cash_balance, currency)} />
       <Stat
@@ -444,7 +444,7 @@ function PortfolioTable({
   onClose: (t: CloseTarget) => void;
 }) {
   return (
-    <div className="border-t border-slate-200 pt-3">
+    <div className="border-t border-slate-200 dark:border-slate-800 pt-3">
       <div className="px-1 pb-3">
         <input
           ref={searchRef}
@@ -453,7 +453,7 @@ function PortfolioTable({
           onChange={(e) => onSearchChange(e.target.value)}
           placeholder="Search positions…   (press / to focus)"
           aria-label="Search positions"
-          className="w-full rounded border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700 placeholder-slate-400 outline-none focus:border-blue-300 focus:ring-1 focus:ring-blue-200"
+          className="w-full rounded border border-slate-200 dark:border-slate-800 bg-slate-50 px-3 py-1.5 text-sm text-slate-700 placeholder-slate-400 outline-none focus:border-blue-300 focus:ring-1 focus:ring-blue-200"
         />
       </div>
       {pageRows.length === 0 ? (
@@ -463,7 +463,7 @@ function PortfolioTable({
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-slate-200 bg-slate-50 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+            <tr className="border-b border-slate-200 dark:border-slate-800 bg-slate-50 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
               <th className="px-4 py-2 text-left">Instrument</th>
               <th className="px-2 py-2 text-right">Trades</th>
               <th className="px-2 py-2 text-right">Units</th>
@@ -517,12 +517,12 @@ function PaginationBar({
   onNext: () => void;
 }) {
   return (
-    <div className="flex items-center justify-between border-t border-slate-200 px-1 pt-2 pb-1 text-xs">
+    <div className="flex items-center justify-between border-t border-slate-200 dark:border-slate-800 px-1 pt-2 pb-1 text-xs">
       <button
         type="button"
         onClick={onPrev}
         disabled={page <= 1}
-        className="rounded border border-slate-200 bg-white px-2 py-0.5 font-medium text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40 disabled:opacity-40"
+        className="rounded border border-slate-200 dark:border-slate-800 bg-white px-2 py-0.5 font-medium text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40 disabled:opacity-40"
       >
         ← Prev
       </button>
@@ -533,7 +533,7 @@ function PaginationBar({
         type="button"
         onClick={onNext}
         disabled={page >= totalPages}
-        className="rounded border border-slate-200 bg-white px-2 py-0.5 font-medium text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40 disabled:opacity-40"
+        className="rounded border border-slate-200 dark:border-slate-800 bg-white px-2 py-0.5 font-medium text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40 disabled:opacity-40"
       >
         Next →
       </button>

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -289,7 +289,7 @@ function ClearFiltersButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="rounded border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100"
+      className="rounded border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800"
     >
       Clear filters
     </button>

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -153,7 +153,7 @@ export function RankingsPage() {
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             placeholder="Symbol or company name…"
-            className="w-full rounded border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+            className="w-full rounded border border-slate-200 dark:border-slate-800 bg-white px-3 py-1.5 text-sm text-slate-700 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
           />
           {/* Search is client-side over the page-bounded response.
               When the universe outgrows RANKINGS_PAGE_LIMIT a match
@@ -289,7 +289,7 @@ function ClearFiltersButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="rounded border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800"
+      className="rounded border border-slate-300 dark:border-slate-700 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800"
     >
       Clear filters
     </button>

--- a/frontend/src/pages/RecommendationsPage.tsx
+++ b/frontend/src/pages/RecommendationsPage.tsx
@@ -305,7 +305,7 @@ function ClearFiltersButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="rounded border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800"
+      className="rounded border border-slate-300 dark:border-slate-700 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800"
     >
       Clear filters
     </button>
@@ -340,7 +340,7 @@ function Pagination({
         type="button"
         disabled={!hasPrev}
         onClick={onPrev}
-        className="rounded border border-slate-300 px-1.5 py-0.5 text-xs hover:bg-slate-100 dark:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+        className="rounded border border-slate-300 dark:border-slate-700 px-1.5 py-0.5 text-xs hover:bg-slate-100 dark:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
       >
         Prev
       </button>
@@ -348,7 +348,7 @@ function Pagination({
         type="button"
         disabled={!hasNext}
         onClick={onNext}
-        className="rounded border border-slate-300 px-1.5 py-0.5 text-xs hover:bg-slate-100 dark:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+        className="rounded border border-slate-300 dark:border-slate-700 px-1.5 py-0.5 text-xs hover:bg-slate-100 dark:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
       >
         Next
       </button>

--- a/frontend/src/pages/RecommendationsPage.tsx
+++ b/frontend/src/pages/RecommendationsPage.tsx
@@ -305,7 +305,7 @@ function ClearFiltersButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="rounded border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100"
+      className="rounded border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800"
     >
       Clear filters
     </button>
@@ -340,7 +340,7 @@ function Pagination({
         type="button"
         disabled={!hasPrev}
         onClick={onPrev}
-        className="rounded border border-slate-300 px-1.5 py-0.5 text-xs hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+        className="rounded border border-slate-300 px-1.5 py-0.5 text-xs hover:bg-slate-100 dark:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
       >
         Prev
       </button>
@@ -348,7 +348,7 @@ function Pagination({
         type="button"
         disabled={!hasNext}
         onClick={onNext}
-        className="rounded border border-slate-300 px-1.5 py-0.5 text-xs hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+        className="rounded border border-slate-300 px-1.5 py-0.5 text-xs hover:bg-slate-100 dark:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
       >
         Next
       </button>

--- a/frontend/src/pages/RecoverPage.tsx
+++ b/frontend/src/pages/RecoverPage.tsx
@@ -258,7 +258,7 @@ export function RecoverPage(): JSX.Element {
     <div className="flex h-screen w-screen items-center justify-center bg-slate-50">
       <form
         onSubmit={handleSubmit}
-        className="w-full max-w-2xl rounded border border-slate-200 bg-white p-6 shadow-sm"
+        className="w-full max-w-2xl rounded border border-slate-200 dark:border-slate-800 bg-white p-6 shadow-sm"
       >
         <h1 className="mb-1 text-lg font-semibold text-slate-800 dark:text-slate-100">
           Recover existing eBull data
@@ -306,7 +306,7 @@ export function RecoverPage(): JSX.Element {
                     handleWordChange(index, e.target.value)
                   }
                   onPaste={(e) => handlePaste(index, e)}
-                  className="w-full rounded border border-slate-300 px-2 py-1 font-mono text-sm text-slate-800 dark:text-slate-100"
+                  className="w-full rounded border border-slate-300 dark:border-slate-700 px-2 py-1 font-mono text-sm text-slate-800 dark:text-slate-100"
                 />
               </li>
             );

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -333,7 +333,7 @@ function ReportList({ reports }: { reports: ReportSnapshot[] }) {
 
   return (
     <div className="grid gap-4 md:grid-cols-[200px_1fr]">
-      <aside className="border-r border-slate-200 pr-3">
+      <aside className="border-r border-slate-200 dark:border-slate-800 pr-3">
         <ul className="space-y-1 text-sm">
           {reports.map((r) => (
             <li key={r.snapshot_id}>
@@ -381,13 +381,13 @@ export function ReportsPage() {
 
   return (
     <div className="space-y-4">
-      <header className="border-b border-slate-200 pb-2">
+      <header className="border-b border-slate-200 dark:border-slate-800 pb-2">
         <h1 className="text-xl font-semibold">Reports</h1>
         <p className="text-sm text-slate-500">
           Weekly + monthly performance snapshots from the report jobs.
         </p>
       </header>
-      <nav className="flex gap-1 border-b border-slate-200">
+      <nav className="flex gap-1 border-b border-slate-200 dark:border-slate-800">
         {(["weekly", "monthly"] as TabId[]).map((id) => (
           <button
             key={id}

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -342,7 +342,7 @@ function ReportList({ reports }: { reports: ReportSnapshot[] }) {
                 className={`w-full rounded px-2 py-1 text-left ${
                   r.snapshot_id === selected?.snapshot_id
                     ? "bg-slate-200 font-medium"
-                    : "hover:bg-slate-100"
+                    : "hover:bg-slate-100 dark:hover:bg-slate-800"
                 }`}
                 onClick={() => setSelectedId(r.snapshot_id)}
               >

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -332,7 +332,7 @@ export function SetupPage(): JSX.Element {
               type="button"
               onClick={() => void handleTestConnection()}
               disabled={!canTestConnection || validating}
-              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40 disabled:opacity-50"
             >
               {validating ? "Testing…" : "Test connection"}
             </button>
@@ -361,7 +361,7 @@ export function SetupPage(): JSX.Element {
               type="button"
               onClick={handleSkipBroker}
               disabled={brokerSubmitting}
-              className="flex-1 rounded border border-slate-300 bg-white py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+              className="flex-1 rounded border border-slate-300 bg-white py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50"
             >
               Skip for now
             </button>

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -198,7 +198,7 @@ export function SetupPage(): JSX.Element {
       {step === "operator" ? (
         <form
           onSubmit={handleOperatorSubmit}
-          className="w-full max-w-sm rounded border border-slate-200 bg-white p-6 shadow-sm"
+          className="w-full max-w-sm rounded border border-slate-200 dark:border-slate-800 bg-white p-6 shadow-sm"
         >
           <h1 className="mb-1 text-lg font-semibold text-slate-800 dark:text-slate-100">
             First-run setup
@@ -215,7 +215,7 @@ export function SetupPage(): JSX.Element {
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               required
-              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+              className="w-full rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
             />
           </label>
           <label className="mb-3 block text-sm">
@@ -230,7 +230,7 @@ export function SetupPage(): JSX.Element {
               onChange={(e) => setPassword(e.target.value)}
               minLength={MIN_PASSWORD_LEN}
               required
-              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+              className="w-full rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
             />
           </label>
           <label className="mb-4 block text-sm">
@@ -243,7 +243,7 @@ export function SetupPage(): JSX.Element {
               autoComplete="off"
               value={setupToken}
               onChange={(e) => setSetupToken(e.target.value)}
-              className="w-full rounded border border-slate-300 px-2 py-1.5 font-mono text-xs"
+              className="w-full rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 font-mono text-xs"
             />
           </label>
           {error !== null && (
@@ -265,7 +265,7 @@ export function SetupPage(): JSX.Element {
           </button>
         </form>
       ) : mode === "complete" ? (
-        <div className="w-full max-w-sm rounded border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="w-full max-w-sm rounded border border-slate-200 dark:border-slate-800 bg-white p-6 shadow-sm">
           <h1 className="mb-1 text-lg font-semibold text-slate-800 dark:text-slate-100">
             Credentials configured
           </h1>
@@ -283,7 +283,7 @@ export function SetupPage(): JSX.Element {
       ) : (
         <form
           onSubmit={handleBrokerSubmit}
-          className="w-full max-w-sm space-y-3 rounded border border-slate-200 bg-white p-6 shadow-sm"
+          className="w-full max-w-sm space-y-3 rounded border border-slate-200 dark:border-slate-800 bg-white p-6 shadow-sm"
         >
           <h1 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
             {mode === "repair" ? "Complete credential setup" : "Add eToro credentials"}
@@ -305,7 +305,7 @@ export function SetupPage(): JSX.Element {
                 onChange={(e) => setBrokerApiKey(e.target.value)}
                 minLength={MIN_SECRET_LEN}
                 required
-                className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+                className="w-full rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
               />
             </label>
           )}
@@ -321,7 +321,7 @@ export function SetupPage(): JSX.Element {
                 onChange={(e) => setBrokerUserKey(e.target.value)}
                 minLength={MIN_SECRET_LEN}
                 required
-                className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+                className="w-full rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm"
               />
             </label>
           )}
@@ -332,7 +332,7 @@ export function SetupPage(): JSX.Element {
               type="button"
               onClick={() => void handleTestConnection()}
               disabled={!canTestConnection || validating}
-              className="rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40 disabled:opacity-50"
+              className="rounded border border-slate-300 dark:border-slate-700 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40 disabled:opacity-50"
             >
               {validating ? "Testing…" : "Test connection"}
             </button>
@@ -361,7 +361,7 @@ export function SetupPage(): JSX.Element {
               type="button"
               onClick={handleSkipBroker}
               disabled={brokerSubmitting}
-              className="flex-1 rounded border border-slate-300 bg-white py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50"
+              className="flex-1 rounded border border-slate-300 dark:border-slate-700 bg-white py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50"
             >
               Skip for now
             </button>

--- a/frontend/src/pages/Tenk10KDrilldownPage.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.tsx
@@ -228,7 +228,7 @@ function Body({
         <TOCRail sections={data.sections} />
       </aside>
       <div className="min-w-0 space-y-6">
-        <header className="border-b border-slate-200 pb-3">
+        <header className="border-b border-slate-200 dark:border-slate-800 pb-3">
           <Link
             to={`/instrument/${encodeURIComponent(symbol)}`}
             className="text-xs text-sky-700 hover:underline"

--- a/frontend/src/pages/components/RawOhlcvTable.tsx
+++ b/frontend/src/pages/components/RawOhlcvTable.tsx
@@ -98,7 +98,7 @@ export function RawOhlcvTable({
       </div>
       <div className="overflow-auto">
         <table className="min-w-full text-sm">
-          <thead className="border-b border-slate-200">
+          <thead className="border-b border-slate-200 dark:border-slate-800">
             <tr className="text-left text-xs text-slate-500">
               <th className="px-2 py-1">
                 <button


### PR DESCRIPTION
Closes #704. Final slice of #700 epic.

## What

Dark partners on remaining \`border-slate-200/300\` and \`hover:bg-slate-50/100\` utilities flagged in the Phase 2 token coverage scan.

Mappings:
- \`border-slate-200\` → \`dark:border-slate-800\`
- \`border-slate-300\` → \`dark:border-slate-700\`
- \`hover:bg-slate-50\` → \`dark:hover:bg-slate-800/40\`
- \`hover:bg-slate-100\` → \`dark:hover:bg-slate-800\`

## Files

- Dashboard: SummaryCards, RollingPnlStrip, AlertsStrip, PortfolioValueChart
- Insider: InsiderTransactionsTable, InsiderByOfficer, InsiderNetByMonth
- Instrument: EightKEventsPanel, BusinessSectionsPanel, CrossRefPopover, SummaryStrip
- Admin: CollapsibleSection
- Recommendations: AuditTrail, RecommendationsTable

## Test plan

- [x] \`pnpm --dir frontend typecheck\` — clean
- [x] \`pnpm --dir frontend test:unit\` — 746/746 pass
- [ ] Operator pass: dark mode sanity sweep on Dashboard, L2 instrument page (8-K events, business sections, insider transactions table), Recommendations audit trail — confirm borders visible and hover transitions feel native

## Phase 2 status

Closes #700 epic when this merges. All four sub-issues will be done:
- ✅ #701 charts (PR #705)
- ✅ #702 forms (PR #706)
- ✅ #703 text (PR #707)
- ✅ #704 borders/hover (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)