### PR TITLE
fix(#708): dark-mode class hygiene gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -28,4 +28,13 @@ uv run ruff format --check .
 echo "==> Pre-push gate: pyright"
 uv run pyright
 
+# Frontend dark-mode class hygiene (#708). Skipped if frontend/ is
+# absent (e.g. backend-only worktrees) or if `pnpm` is not on PATH —
+# CI runs the same gate, so a missing local toolchain doesn't block
+# push.
+if [[ -d frontend && -f frontend/package.json ]] && command -v pnpm >/dev/null 2>&1; then
+  echo "==> Pre-push gate: dark-mode class check"
+  pnpm --dir frontend dark:check
+fi
+
 echo "==> Pre-push gate: green. Pushing."

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Dark-mode class gate (#708)
+        run: pnpm dark:check
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -1090,6 +1090,13 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Prevention: when a metric helper's null-handling contract changes (null-coerced → null-propagated, or vice versa), grep every call site for the empty-state guards that follow and re-verify each branch against the new contract. The guard must answer "does the user see *any* meaningful series?", not "is the latest scalar zero?". Self-review prompt: after editing a `build*` helper, grep for the helper name across the codebase and read each consumer's `if (...)` guard with the new return shape in mind. Test prompt: every chart component with an inline "no data" branch needs a vitest case where every row of its source data has a null in the relevant field.
 - Enforced in: this prevention log; PR #673 widens the cumulative-DPS guard to recognise the all-null case and adds a regression test (`CumulativeDpsChart` "renders the inline no-data hint when every row has null dps_declared").
 
+### Dark-mode token sweeps must produce neither duplicate nor missing partner utilities
+
+- First seen in: #707 review + #709 review (Phase 2 dark-mode rollout, #700 epic).
+- Symptom: two independent sweeps that each touch the same className end up with duplicate `dark:text-slate-100`s on one input (PR #707, RecoveryPhraseConfirm:365 — caught by `dark:text-slate-100.*dark:text-slate-100`); a follow-up PR adds `dark:hover:bg-slate-800/40` to a button but leaves its `border-slate-300` without the `dark:border-slate-700` partner the same PR's stated mapping requires (PR #709). Both shapes ship green CI because the existing typecheck + tests do not look at the visual tokens, only the runtime semantics — Tailwind dedupes duplicates at build, so there is no functional regression to catch.
+- Prevention: enforced by `frontend/scripts/check-dark-classes.mjs`, wired into the pre-push hook and `frontend-ci.yml`. Three checks per line in every `frontend/src/**/*.tsx`: (a) duplicate `dark:|sm:|md:|lg:|xl:|2xl:`-prefixed utility token; (b) `border-slate-200|300` without a `dark:border-` partner; (c) `hover:bg-slate-50|100` without a `dark:hover:bg-` partner. Run locally with `pnpm --dir frontend dark:check`. New mapping pairs (e.g. extending the gate to text or background utilities later) get added to the script; do not introduce a separate ad-hoc grep step in the hook.
+- Enforced in: `frontend/scripts/check-dark-classes.mjs`, `frontend/package.json` (`dark:check` script), `.githooks/pre-push`, `.github/workflows/frontend-ci.yml`.
+
 ### Column-side casts in WHERE clauses defeat indexes
 
 - First seen in: #669 review (PR #679).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "typecheck": "tsc -b --noEmit",
+    "dark:check": "node scripts/check-dark-classes.mjs",
     "preview": "vite preview",
     "test": "vitest run",
     "test:unit": "vitest run --exclude src/pages/SetupPage.test.tsx",

--- a/frontend/scripts/check-dark-classes.mjs
+++ b/frontend/scripts/check-dark-classes.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Dark-mode class hygiene gate (#708).
+ *
+ * Three checks run line-by-line over every .tsx in frontend/src:
+ *
+ *   A. Duplicate Tailwind variant utility on the same line. Catches
+ *      the PR #707 case where two independent sweeps (#706 + #703)
+ *      both appended `dark:text-slate-100` to the same className.
+ *
+ *   B. `border-slate-200` / `border-slate-300` without a
+ *      `dark:border-` partner on the same line.
+ *
+ *   C. `hover:bg-slate-50` / `hover:bg-slate-100` without a
+ *      `dark:hover:bg-` partner on the same line.
+ *
+ * Exits non-zero with file:line:reason for each violation.
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("../src", import.meta.url));
+const SKIP_DIRS = new Set(["test", "__mocks__"]);
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (SKIP_DIRS.has(entry)) continue;
+      out.push(...walk(full));
+    } else if (entry.endsWith(".tsx")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const VARIANT_RE = /(?:dark|sm|md|lg|xl|2xl):(?:hover:|focus:|disabled:|placeholder:|active:|group-hover:|aria-[a-z-]+:)?[a-z][\w-]*(?:-\d+(?:\/\d+)?)?(?![\w/])/g;
+
+function findDuplicateVariants(line) {
+  const seen = new Map();
+  const dups = new Set();
+  let m;
+  VARIANT_RE.lastIndex = 0;
+  while ((m = VARIANT_RE.exec(line)) !== null) {
+    const tok = m[0];
+    if (seen.has(tok)) {
+      dups.add(tok);
+    } else {
+      seen.set(tok, m.index);
+    }
+  }
+  return [...dups];
+}
+
+function findMissingBorderPartner(line) {
+  const hasLight = /(?<![\w-])border-slate-(?:200|300)(?![0-9])/.test(line);
+  if (!hasLight) return null;
+  if (/dark:border-/.test(line)) return null;
+  return "border-slate-200|300 missing dark:border partner";
+}
+
+function findMissingHoverPartner(line) {
+  const hasLight = /(?<![\w-])hover:bg-slate-(?:50|100)(?![0-9])/.test(line);
+  if (!hasLight) return null;
+  if (/dark:hover:bg-/.test(line)) return null;
+  return "hover:bg-slate-50|100 missing dark:hover:bg- partner";
+}
+
+const violations = [];
+const files = walk(ROOT);
+for (const file of files) {
+  const lines = readFileSync(file, "utf8").split("\n");
+  lines.forEach((line, i) => {
+    const lineNo = i + 1;
+    const dups = findDuplicateVariants(line);
+    if (dups.length > 0) {
+      violations.push({
+        file,
+        line: lineNo,
+        reason: `duplicate Tailwind variant utility: ${dups.join(", ")}`,
+      });
+    }
+    const borderMiss = findMissingBorderPartner(line);
+    if (borderMiss) {
+      violations.push({ file, line: lineNo, reason: borderMiss });
+    }
+    const hoverMiss = findMissingHoverPartner(line);
+    if (hoverMiss) {
+      violations.push({ file, line: lineNo, reason: hoverMiss });
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error(`x ${violations.length} dark-mode class violation(s):\n`);
+  for (const v of violations) {
+    const rel = relative(process.cwd(), v.file).split(sep).join("/");
+    console.error(`  ${rel}:${v.line}: ${v.reason}`);
+  }
+  console.error(
+    "\nFix: add the missing dark: partner OR remove the duplicate utility.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `OK dark-mode class gate: ${files.length} files, no violations`,
+);


### PR DESCRIPTION
Closes #708. Surfaced from PREVENTION feedback on PRs #707 and #709 during the #700 dark-mode rollout.

## What

Zero-deps Node script that fails CI + pre-push when a \`.tsx\` file contains:

- **A.** A duplicate Tailwind variant utility on the same line (\`dark:text-slate-100 ... dark:text-slate-100\` — the PR #707 case where the form sweep and the text sweep both appended to the same input className).
- **B.** \`border-slate-200|300\` without a \`dark:border-\` partner.
- **C.** \`hover:bg-slate-50|100\` without a \`dark:hover:bg-\` partner.

## Why grep-gate over eslint-plugin-tailwindcss

Repo has no frontend ESLint config (verified during #701). Bootstrapping ESLint to land one rule is bigger than the issue scopes. Three regex checks in a 100-line Node script fit the existing pre-push pattern alongside ruff/pyright.

## Wiring

| File | Change |
|---|---|
| \`frontend/scripts/check-dark-classes.mjs\` | new gate script (Node 22+, no deps) |
| \`frontend/package.json\` | \`pnpm dark:check\` script |
| \`.githooks/pre-push\` | runs gate after pyright; skipped if pnpm absent |
| \`.github/workflows/frontend-ci.yml\` | runs gate before typecheck (fail-fast) |
| \`docs/review-prevention-log.md\` | new entry naming the gate as the enforcement |

## Verification

- 170 \`.tsx\` files in \`frontend/src\` — all pass the gate cleanly post-#700.
- Manual injection test: deliberately added \`dark:bg-slate-900 dark:bg-slate-900\` to \`Section.tsx\` and the gate flagged it correctly with file:line:reason; revert restores green.
- Pre-push hook runs the gate end-to-end on this very push — visible in the push log above.

## Test plan

- [x] \`pnpm --dir frontend dark:check\` — green (170 files, 0 violations)
- [x] Manual injection test confirms detection
- [x] Pre-push hook fires the new step
- [ ] CI \`Frontend CI\` workflow runs the new step before typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)