### PR TITLE
fix(dark-mode): chart blends with body + sticky header flushes top

### DIFF
--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -138,7 +138,7 @@ export function SummaryStrip({
   return (
     <div
       data-testid="summary-strip"
-      className="sticky top-0 z-20 border-b border-slate-200 bg-white px-4 py-3 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:shadow-none"
+      className="sticky top-0 z-20 -mx-6 border-b border-slate-200 bg-white px-6 py-3 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:shadow-none"
     >
       {/* Row 1: identity + price */}
       <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">

--- a/frontend/src/layout/AppShell.tsx
+++ b/frontend/src/layout/AppShell.tsx
@@ -8,7 +8,11 @@ export function AppShell() {
       <Sidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
         <Header />
-        <main className="flex-1 overflow-auto p-6">
+        {/* No top padding: pages with sticky headers (e.g. SummaryStrip
+            on the instrument page) must be able to flush with the
+            <Header> bar above. Pages that need top breathing room add
+            their own `pt-6` to the root container. */}
+        <main className="flex-1 overflow-auto px-6 pb-6">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/lib/chartTheme.ts
+++ b/frontend/src/lib/chartTheme.ts
@@ -133,7 +133,11 @@ export const lightTheme: ChartTheme = {
  * memory ("blue line = SMA20" across sessions).
  */
 export const darkTheme: ChartTheme = {
-  bg: "#0f172a", // slate-900 — matches dark page card chrome
+  // slate-950 matches the dark body bg so the chart canvas blends
+  // with the page instead of rendering as a visible card outline.
+  // Chart elevation is conveyed by the Pane title rule above the
+  // chart, not by a panel surface tint.
+  bg: "#020617",
 
   textPrimary: "#f1f5f9", // slate-100
   textSecondary: "#94a3b8", // slate-400

--- a/frontend/src/pages/AdminJobDetailPage.tsx
+++ b/frontend/src/pages/AdminJobDetailPage.tsx
@@ -43,7 +43,7 @@ export function AdminJobDetailPage() {
   );
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 pt-6">
       <div className="flex items-center justify-between">
         <div>
           <div className="text-xs text-slate-500">Admin / Jobs</div>

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -225,7 +225,7 @@ export function AdminPage() {
   ).length;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 pt-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Admin</h1>
         <SyncNowButton

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -39,7 +39,7 @@ export function CopyTradingPage() {
   const username = detail.data?.parent_username;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pt-6">
       <div className="flex items-center gap-3">
         <Link to="/portfolio" className="text-sm text-slate-500 hover:text-slate-700">
           ← Portfolio

--- a/frontend/src/pages/CoverageInsufficientPage.tsx
+++ b/frontend/src/pages/CoverageInsufficientPage.tsx
@@ -30,7 +30,7 @@ export function CoverageInsufficientPage() {
   const list = useAsync(fetchCoverageInsufficient, []);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 pt-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">
           Coverage drill-down

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -94,7 +94,7 @@ export function DashboardPage() {
     budget.error !== null;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pt-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Dashboard</h1>
       </div>

--- a/frontend/src/pages/DividendsPage.tsx
+++ b/frontend/src/pages/DividendsPage.tsx
@@ -348,7 +348,7 @@ function PerQuarterHistory({
     return Number.isFinite(n) && n > acc ? n : acc;
   }, 0);
   return (
-    <div className="space-y-1">
+    <div className="space-y-1 pt-6">
       {sorted.map((p) => (
         <HistoryBar
           key={`${p.period_end_date}-${p.period_type}`}

--- a/frontend/src/pages/DividendsPage.tsx
+++ b/frontend/src/pages/DividendsPage.tsx
@@ -188,7 +188,7 @@ export function DividendsPage(): JSX.Element {
   const backHref = `/instrument/${encodeURIComponent(symbol)}`;
 
   return (
-    <div className="mx-auto max-w-screen-xl space-y-4 p-4">
+    <div className="mx-auto max-w-screen-xl space-y-4 p-4 pt-6">
       <header className="border-b border-slate-200 dark:border-slate-800 pb-3">
         <Link to={backHref} className="text-xs text-sky-700 hover:underline">
           ← Back to {symbol}
@@ -348,7 +348,7 @@ function PerQuarterHistory({
     return Number.isFinite(n) && n > acc ? n : acc;
   }, 0);
   return (
-    <div className="space-y-1 pt-6">
+    <div className="space-y-1">
       {sorted.map((p) => (
         <HistoryBar
           key={`${p.period_end_date}-${p.period_type}`}

--- a/frontend/src/pages/EightKListPage.tsx
+++ b/frontend/src/pages/EightKListPage.tsx
@@ -147,7 +147,7 @@ export function EightKListPage(): JSX.Element {
   }, [selectedAccession, filtered, searchParams, setSearchParams, state.data]);
 
   return (
-    <div className="mx-auto max-w-screen-2xl space-y-3 p-4">
+    <div className="mx-auto max-w-screen-2xl space-y-3 p-4 pt-6">
       <Section title={`${symbol} — 8-K filings`}>
         <Link
           to={`/instrument/${encodeURIComponent(symbol)}`}

--- a/frontend/src/pages/FundamentalsPage.tsx
+++ b/frontend/src/pages/FundamentalsPage.tsx
@@ -207,7 +207,7 @@ export function FundamentalsPage(): JSX.Element {
           </Link>
         </EmptyState>
       ) : (
-        <div className="space-y-4">
+        <div className="space-y-4 pt-6">
           <Pane
             title="P&L breakdown"
             scope={periodScope(period)}

--- a/frontend/src/pages/InsiderPage.tsx
+++ b/frontend/src/pages/InsiderPage.tsx
@@ -136,7 +136,7 @@ function InsiderPageBody({
 
   const rows = txnState.data.rows;
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 pt-6">
       <Pane
         title="Net by month"
         scope="last 24 months"

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -206,7 +206,7 @@ export function InstrumentsPage() {
   );
 
   return (
-    <div className="flex h-full flex-col gap-6">
+    <div className="flex h-full flex-col gap-6 pt-6">
       <div className="flex flex-shrink-0 items-center justify-between">
         <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Instruments</h1>
         {result.data && (

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -2,7 +2,7 @@ import { EmptyState } from "@/components/states/EmptyState";
 
 export function NotFoundPage() {
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 pt-6">
       <EmptyState title="Not found" description="That route does not exist." />
     </div>
   );

--- a/frontend/src/pages/OperatorsPage.tsx
+++ b/frontend/src/pages/OperatorsPage.tsx
@@ -109,7 +109,7 @@ export function OperatorsPage(): JSX.Element {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pt-6">
       <div>
         <h1 className="text-xl font-semibold">Operators</h1>
         <p className="text-xs text-slate-500">

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -222,7 +222,7 @@ export function PortfolioPage() {
   }, [addFor, closeFor, drillInto]);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 pt-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Portfolio</h1>
       </div>

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -132,7 +132,7 @@ export function RankingsPage() {
   });
 
   return (
-    <div className="flex h-full flex-col gap-6">
+    <div className="flex h-full flex-col gap-6 pt-6">
       <div className="flex flex-shrink-0 items-center justify-between">
         <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Rankings</h1>
         <span className="text-xs text-slate-500">

--- a/frontend/src/pages/RecommendationsPage.tsx
+++ b/frontend/src/pages/RecommendationsPage.tsx
@@ -138,7 +138,7 @@ export function RecommendationsPage() {
   const auditHasNext = auditOffset + AUDIT_PAGE_LIMIT < auditTotal;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pt-6">
       <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Recommendations</h1>
 
       {allFailed ? (

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -118,7 +118,7 @@ function ReportDetail({ report }: { report: ReportSnapshot }) {
   const drags = periodContribution?.drags ?? [];
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 pt-6">
       <div className="flex items-baseline gap-3 text-sm">
         <span className="font-medium">
           {formatDate(report.period_start)} → {formatDate(report.period_end)}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -43,7 +43,7 @@ type ManageAction = "idle" | "edit-api_key" | "edit-user_key" | "replace";
 export function SettingsPage(): JSX.Element {
   const displayCurrency = useDisplayCurrency();
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pt-6">
       <h1 className="text-xl font-semibold">Settings</h1>
       <DisplayCurrencySection
         currentCurrency={displayCurrency}

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -327,7 +327,7 @@ export function SetupPage(): JSX.Element {
           )}
 
           {/* Test connection — only in Create mode (both keys present). */}
-          <div className="space-y-1">
+          <div className="space-y-1 pt-6">
             <button
               type="button"
               onClick={() => void handleTestConnection()}

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -327,7 +327,7 @@ export function SetupPage(): JSX.Element {
           )}
 
           {/* Test connection — only in Create mode (both keys present). */}
-          <div className="space-y-1 pt-6">
+          <div className="space-y-1">
             <button
               type="button"
               onClick={() => void handleTestConnection()}

--- a/frontend/src/pages/SyncDashboard.tsx
+++ b/frontend/src/pages/SyncDashboard.tsx
@@ -154,7 +154,7 @@ export function SyncDashboard({ syncTrigger }: SyncDashboardProps) {
   }, [layerList]);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pt-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Data sync</h1>
       </div>

--- a/frontend/src/pages/Tenk10KDrilldownPage.tsx
+++ b/frontend/src/pages/Tenk10KDrilldownPage.tsx
@@ -223,7 +223,7 @@ function Body({
   const secSearchUrl = secSearchUrlFor(data.source_accession, data.cik);
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[180px_minmax(0,1fr)_200px]">
+    <div className="grid gap-6 pt-6 lg:grid-cols-[180px_minmax(0,1fr)_200px]">
       <aside className="hidden lg:block">
         <TOCRail sections={data.sections} />
       </aside>


### PR DESCRIPTION
Two niggles from a live dark-mode walkthrough on the dev stack.

## Niggle 1 — faint boxes above the price chart

\`chartTheme.darkTheme.bg\` was \`slate-900\` against a \`slate-950\` body, so the chart canvas rendered as a visibly-elevated rectangle on the page. Switched dark bg to \`slate-950\` — chart blends seamlessly with the body. Visual elevation is conveyed by the Pane title hairline above the chart (existing design-system pattern), not by a panel surface tint.

## Niggle 2 — slither gap above the sticky SummaryStrip

AppShell \`<main>\` had \`p-6\`. \`position: sticky; top: 0\` resolves against the scroll container's padding edge, so the strip pinned 24px below the visible top of \`<main>\`, leaving a 24px gutter of body bg visible above it during scroll.

Restructured:

| File | Change |
|---|---|
| \`AppShell.tsx\` | \`p-6\` → \`px-6 pb-6\` (no top padding) |
| \`SummaryStrip.tsx\` | Added \`-mx-6 px-6\` to escape main's horizontal padding so the strip spans full width and aligns with Header content (previously content sat 16px right of Header due to \`px-4\` inside the padded main) |
| Non-sticky pages (15 files) | Added \`pt-6\` to root container so first heading does not jam against the Header |

Skipped:
- \`LoginPage.tsx\`, \`RecoverPage.tsx\`, \`SetupPage.tsx\` — full-screen auth shells, don't go through main scroll area
- \`ChartPage.tsx\` — already self-pads with \`p-4\`
- \`InstrumentDetailRedirect.tsx\` — redirect-only

## Verification

Live Playwright on \`/instrument/1699\` (GME):
- Chart canvas now matches body — no visible card outline
- SummaryStrip flushes with Header bar above — no scroll-bg gap
- Content alignment preserved across left edge (sidebar / header / strip / page content all share the 24px content-edge offset)

## Test plan

- [x] \`pnpm --dir frontend dark:check\` — green
- [x] \`pnpm --dir frontend typecheck\` — clean
- [x] \`pnpm --dir frontend test:unit\` — 746/746 pass
- [ ] Operator pass: scroll on Instrument / Dashboard / Portfolio in dark — confirm sticky flush + no chart elevation outline

🤖 Generated with [Claude Code](https://claude.com/claude-code)