### PR TITLE
refactor(grid): pair 10-K narrative with FilingsPane (8+4 bento)

### DIFF
--- a/frontend/src/components/instrument/DensityGrid.test.tsx
+++ b/frontend/src/components/instrument/DensityGrid.test.tsx
@@ -288,7 +288,12 @@ describe("DensityGrid profiles", () => {
     expect(grid?.className).toContain("gap-y-6");
   });
 
-  it("v4 activity row: Filings + Insider pair as 6+6 when both active", () => {
+  it("v4 narrative pairing: Filings sits beside the 10-K narrative at 8+4 when both active", () => {
+    // The 10-K narrative is itself a filing summary, so pairing the
+    // Recent Filings rail beside it fills the right-half dead space
+    // the narrative leaves with contextually-related history. With
+    // filings consumed by the narrative pairing, Insider stands at
+    // col-span-6 in the activity zone.
     render(
       <MemoryRouter>
         <DensityGrid
@@ -302,10 +307,33 @@ describe("DensityGrid profiles", () => {
         />
       </MemoryRouter>,
     );
+    const narrativeSlot = screen.getByText(/Company narrative/).closest(
+      "div.col-span-12",
+    );
     const filingsSlot = screen.getByText(/Recent filings/).closest("div.col-span-12");
     const insiderSlot = screen.getByText(/Insider summary/).closest("div.col-span-12");
-    expect(filingsSlot?.className).toContain("lg:col-span-6");
+    expect(narrativeSlot?.className).toContain("lg:col-span-8");
+    expect(filingsSlot?.className).toContain("lg:col-span-4");
     expect(insiderSlot?.className).toContain("lg:col-span-6");
+  });
+
+  it("v4 narrative falls back to full-width when filings inactive", () => {
+    render(
+      <MemoryRouter>
+        <DensityGrid
+          summary={makeSummary({
+            fundamentals: { providers: ["sec_xbrl"], data_present: { sec_xbrl: true } },
+            filings: { providers: [], data_present: {} },
+          })}
+          thesis={null}
+          thesisErrored={false}
+        />
+      </MemoryRouter>,
+    );
+    const narrativeSlot = screen.getByText(/Company narrative/).closest(
+      "div.col-span-12",
+    );
+    expect(narrativeSlot?.className).not.toContain("lg:col-span-8");
   });
 
   it("v4 zone B: BusinessSections sits directly under the hero (full-sec), not at page bottom", () => {

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -13,14 +13,22 @@
  *   Zone A — Hero      :  Price chart (visual anchor), Key stats,
  *                         SEC profile (identity rail under stats)
  *   Zone B — Identity  :  10-K narrative (BusinessSections) — what is
- *                         this company? Reads like a column inch under
- *                         the hero rather than buried at page bottom.
+ *                         this company? Paired with Recent Filings at
+ *                         8+4 so the right-half dead space the
+ *                         narrative left behind is filled with
+ *                         contextually-related filing history (the
+ *                         narrative IS itself a filing). When filings
+ *                         are inactive, narrative falls back to
+ *                         full-width.
  *   Zone C — Health    :  Fundamentals + Dividends paired 6+6 — read
  *                         financial trajectory and shareholder return
  *                         together in one scan.
- *   Zone D — Activity  :  Filings + Insider paired 6+6 — what's
- *                         happening right now. Recent news full-width
- *                         below since news lists scan vertically.
+ *   Zone D — Activity  :  Insider activity. Filings have moved up to
+ *                         pair with the narrative; when filings are
+ *                         active but no narrative exists, Filings
+ *                         drops back into this zone alongside Insider
+ *                         at 6+6. Recent news full-width below since
+ *                         news lists scan vertically.
  *   Zone E — Operator  :  Thesis pane — operator's own call, last so
  *                         it doesn't anchor your read of the data.
  *
@@ -112,11 +120,16 @@ export function DensityGrid({
       ) : null,
   });
 
+  // Filings pairs with the 10-K narrative when both are active so the
+  // right-half dead space next to the narrative gets contextually
+  // related content. Otherwise filings stay in the activity zone.
+  const filingsPairedWithNarrative = hasNarrative && filingsActive;
+  const filingsNode = filingsActive ? (
+    <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
+  ) : null;
   const ActivityRow = renderActivityRow({
-    filingsActive,
-    filingsNode: filingsActive ? (
-      <FilingsPane instrumentId={instrumentId} symbol={symbol} summary={summary} />
-    ) : null,
+    filingsActive: !filingsPairedWithNarrative && filingsActive,
+    filingsNode: filingsPairedWithNarrative ? null : filingsNode,
     insiderActive,
     insiderNode: insiderActive ? (
       <InsiderActivitySummary symbol={symbol} />
@@ -142,12 +155,19 @@ export function DensityGrid({
             <SecProfilePanel symbol={symbol} />
           </div>
         )}
-        {/* Zone B — Identity */}
-        {hasNarrative && (
+        {/* Zone B — Identity (paired with Filings at 8+4 when both active) */}
+        {hasNarrative && filingsPairedWithNarrative ? (
+          <>
+            <div className="col-span-12 lg:col-span-8">
+              <BusinessSectionsTeaser symbol={symbol} />
+            </div>
+            <div className="col-span-12 lg:col-span-4">{filingsNode}</div>
+          </>
+        ) : hasNarrative ? (
           <div className="col-span-12">
             <BusinessSectionsTeaser symbol={symbol} />
           </div>
-        )}
+        ) : null}
         {/* Zone C — Health */}
         {HealthRow}
         {/* Zone D — Activity */}
@@ -178,12 +198,19 @@ export function DensityGrid({
             <SecProfilePanel symbol={symbol} />
           </div>
         )}
-        {/* Zone B — Identity (only when narrative source exists) */}
-        {hasNarrative && (
+        {/* Zone B — Identity (paired with Filings at 8+4 when both active) */}
+        {hasNarrative && filingsPairedWithNarrative ? (
+          <>
+            <div className="col-span-12 lg:col-span-8">
+              <BusinessSectionsTeaser symbol={symbol} />
+            </div>
+            <div className="col-span-12 lg:col-span-4">{filingsNode}</div>
+          </>
+        ) : hasNarrative ? (
           <div className="col-span-12">
             <BusinessSectionsTeaser symbol={symbol} />
           </div>
-        )}
+        ) : null}
         {/* Zone C — Health (fundamentals optional in partial profile) */}
         {HealthRow}
         {/* Zone D — Activity */}


### PR DESCRIPTION
## What

Pairs the 10-K narrative pane with Recent Filings on the same grid row (col-span-8 + col-span-4) instead of the narrative consuming a full col-span-12 row with the right half empty.

## Why

Operator review of the live dark-mode dev stack: \"the 10-K is sitting on its own row with a lot of dead space and wasn't sure why we didn't have the filings and insider sections on the same row, allowing the bento design to dynamically work with those.\"

The narrative IS itself a filing summary, so pairing Recent Filings beside it is the contextually-coherent fill.

## Layout changes

| Profile | Before | After |
|---|---|---|
| **full-sec** (narrative + filings + insider) | Narrative col-12, ActivityRow [Filings 6 + Insider 6] | Zone B [Narrative 8 + Filings 4], Activity [Insider 6] |
| **partial-filings** (narrative + filings) | Narrative col-12, ActivityRow [Filings 6 + Insider 6] | Zone B [Narrative 8 + Filings 4], Activity [Insider 6] |
| **filings only, no narrative** | unchanged — Filings 6 + Insider 6 | unchanged — Filings 6 + Insider 6 |
| **narrative only, no filings** | unchanged — Narrative col-12 | unchanged — Narrative col-12 |
| **minimal** | unchanged | unchanged |

## Tests

- Renamed \`v4 activity row: Filings + Insider pair as 6+6 when both active\` → \`v4 narrative pairing: Filings sits beside the 10-K narrative at 8+4 when both active\`. Pins narrative col-8, filings col-4, insider col-6.
- Added \`v4 narrative falls back to full-width when filings inactive\` to pin the fallback path so the next regex sweep / refactor does not silently regress it.

## Test plan

- [x] \`pnpm --dir frontend dark:check\` — green
- [x] \`pnpm --dir frontend typecheck\` — clean
- [x] \`pnpm --dir frontend test:unit\` — 747/747 pass (+1 new)
- [x] Live Playwright on \`/instrument/1699\` (GME, full-sec): narrative at col-8, Recent Filings at col-4, no dead space
- [ ] Operator pass: walk a partial-filings instrument (no fundamentals) to confirm pairing holds
- [ ] Operator pass: walk a no-filings instrument to confirm narrative reverts to full-width

🤖 Generated with [Claude Code](https://claude.com/claude-code)