### PR TITLE
fix(#685): log 5xx body + Retry-After + correlation; honour Retry-After

### DIFF
--- a/app/providers/resilient_client.py
+++ b/app/providers/resilient_client.py
@@ -4,8 +4,11 @@ Shared resilient HTTP client for all providers.
 Wraps httpx.Client with:
   - Throttle: configurable minimum interval between requests
   - Retry on 429: respects Retry-After header, exponential backoff
-  - Retry on 5xx: same backoff for transient server errors
-  - Logging: WARNING on each retry, ERROR on final failure
+  - Retry on 5xx: backoff for transient server errors; honours
+    Retry-After (delta-seconds or HTTP-date) when present and
+    shorter than the backoff schedule
+  - Logging: WARNING on each retry (status, Retry-After, correlation
+    ID, body preview), ERROR on final failure
 
 Single implementation used by all providers — not copy-pasted.
 """
@@ -15,6 +18,8 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Mapping
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 
 import httpx
 
@@ -25,6 +30,11 @@ _RETRYABLE_5XX = frozenset({500, 502, 503, 504})
 
 # Default backoff schedule (seconds) for retries.  Length = max retries.
 _DEFAULT_BACKOFF = (1.0, 2.0, 4.0)
+
+# Cap on the response-body excerpt logged on retryable errors. Bodies
+# above this are truncated in-place; oversized payloads (e.g. an HTML
+# 502 page from a CDN) would otherwise blow up log lines.
+_BODY_PREVIEW_LIMIT = 200
 
 
 class ResilientClient:
@@ -143,14 +153,19 @@ class ResilientClient:
                     )
 
                 sleep_s = self._retry_delay(response, attempt)
+                diag = _diagnostics(response)
                 logger.warning(
-                    "Retryable %d from %s %s — attempt %d/%d, sleeping %.1fs",
+                    "Retryable %d from %s %s — attempt %d/%d, sleeping %gs"
+                    " (retry_after=%s, correlation_id=%s, body=%r)",
                     response.status_code,
                     method,
                     url,
                     attempt + 1,
                     self._max_retries,
                     sleep_s,
+                    diag["retry_after"],
+                    diag["correlation_id"],
+                    diag["body_preview"],
                 )
                 time.sleep(sleep_s)
                 continue
@@ -171,21 +186,84 @@ class ResilientClient:
     def _retry_delay(self, response: httpx.Response, attempt: int) -> float:
         """Determine how long to sleep before the next retry.
 
-        Uses ``Retry-After`` header if present (429 responses),
-        otherwise falls back to the backoff schedule.
+        - 429: ``Retry-After`` header overrides the backoff schedule
+          when parseable.
+        - 5xx: ``Retry-After`` (if parseable) caps the backoff from
+          above — server hint shortens our wait but cannot extend it
+          beyond our configured budget.
+        - Otherwise: fall back to the backoff schedule.
         """
-        if response.status_code == 429:
-            retry_after = response.headers.get("retry-after")
-            if retry_after is not None:
-                try:
-                    return max(float(retry_after), 0.1)
-                except ValueError:
-                    # Retry-After may be an HTTP-date (RFC 7231 §7.1.3).
-                    # We don't parse dates — log and fall back to backoff.
-                    logger.warning(
-                        "Unparseable Retry-After header %r, using backoff schedule",
-                        retry_after,
-                    )
-
         idx = min(attempt, len(self._backoff) - 1)
-        return self._backoff[idx]
+        backoff = self._backoff[idx]
+
+        retry_after = _parse_retry_after(response.headers.get("retry-after"))
+
+        if response.status_code == 429:
+            return retry_after if retry_after is not None else backoff
+
+        if response.status_code in _RETRYABLE_5XX and retry_after is not None:
+            return min(retry_after, backoff)
+
+        return backoff
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """Parse a ``Retry-After`` header value (RFC 7231 §7.1.3) to seconds.
+
+    Accepts both forms the spec defines:
+      - delta-seconds: an integer or float number of seconds
+      - HTTP-date: an RFC 7231 IMF-fixdate timestamp
+
+    Returns ``None`` when the header is absent, blank, or unparseable —
+    callers fall back to the backoff schedule. A 0.1s floor stops a
+    malicious or buggy ``Retry-After: 0`` (or a past HTTP-date) from
+    busy-looping; on a healthy server hint the floor is a no-op.
+    """
+    if value is None or not value.strip():
+        return None
+    try:
+        return max(float(value), 0.1)
+    except ValueError:
+        pass
+
+    # HTTP-date form — parse, return delta vs now.
+    try:
+        target = parsedate_to_datetime(value)
+    except TypeError, ValueError:
+        target = None
+    if target is not None:
+        if target.tzinfo is None:
+            target = target.replace(tzinfo=UTC)
+        delta = (target - datetime.now(UTC)).total_seconds()
+        return max(delta, 0.1)
+
+    logger.warning(
+        "Unparseable Retry-After header %r, using backoff schedule",
+        value,
+    )
+    return None
+
+
+def _diagnostics(response: httpx.Response) -> dict[str, object]:
+    """Extract structured diagnostics from a retryable response for
+    logging. Every field is best-effort — providers vary in which
+    headers they emit and a missing field never blocks logging.
+    """
+    correlation = response.headers.get("X-Correlation-ID") or response.headers.get("X-Request-ID")
+    body_preview: str | None
+    try:
+        text = response.text
+    except Exception:
+        body_preview = None
+    else:
+        if not text:
+            body_preview = None
+        elif len(text) > _BODY_PREVIEW_LIMIT:
+            body_preview = text[:_BODY_PREVIEW_LIMIT] + "…"
+        else:
+            body_preview = text
+    return {
+        "retry_after": response.headers.get("Retry-After"),
+        "correlation_id": correlation,
+        "body_preview": body_preview,
+    }

--- a/tests/test_resilient_client.py
+++ b/tests/test_resilient_client.py
@@ -15,6 +15,8 @@ Scope:
 from __future__ import annotations
 
 from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
 from unittest.mock import MagicMock
 
 import httpx
@@ -24,11 +26,17 @@ import app.providers.resilient_client as _mod
 from app.providers.resilient_client import ResilientClient
 
 
-def _make_response(status_code: int, headers: dict[str, str] | None = None) -> httpx.Response:
+def _make_response(
+    status_code: int,
+    headers: dict[str, str] | None = None,
+    *,
+    content: bytes | None = None,
+) -> httpx.Response:
     """Build a minimal httpx.Response for testing."""
     return httpx.Response(
         status_code=status_code,
         headers=headers or {},
+        content=content if content is not None else b"",
         request=httpx.Request("GET", "https://example.com/test"),
     )
 
@@ -136,6 +144,61 @@ def test_retry_on_429_respects_retry_after_header(_patch_time: MagicMock) -> Non
     assert any(s == 5.0 for s in retry_sleeps)
 
 
+def test_429_respects_retry_after_http_date(
+    _patch_time: MagicMock,
+) -> None:
+    """429 with HTTP-date Retry-After parses to a delta and overrides backoff."""
+    near_future = datetime.now(UTC).replace(microsecond=0) + timedelta(seconds=3)
+    header = format_datetime(near_future, usegmt=True)
+    r429 = _make_response(429, headers={"retry-after": header})
+    r200 = _make_response(200)
+    mock_httpx = MagicMock(spec=httpx.Client)
+    mock_httpx.build_request.return_value = httpx.Request("GET", "https://example.com/test")
+    mock_httpx.send.side_effect = [r429, r200]
+    client = ResilientClient(mock_httpx, max_retries=3, backoff_schedule=(60.0, 120.0, 240.0))
+
+    client.get("/test")
+
+    retry_sleeps = [call[0][0] for call in _patch_time.sleep.call_args_list]
+    # 429 path uses Retry-After verbatim (override, not min). Delta is
+    # ~3s so a sleep in (0.1, 4) range proves the date drove it, not
+    # the 60s backoff.
+    matched = [s for s in retry_sleeps if 0.1 <= s <= 4.0]
+    assert matched, f"no Retry-After-driven sleep found in {retry_sleeps}"
+
+
+def test_429_unparseable_retry_after_falls_back_to_backoff(
+    _patch_time: MagicMock,
+) -> None:
+    """429 with garbage Retry-After falls back to backoff."""
+    r429 = _make_response(429, headers={"retry-after": "soon-ish"})
+    r200 = _make_response(200)
+    client, _ = _make_client([r429, r200])
+
+    client.get("/test")
+
+    retry_sleeps = [call[0][0] for call in _patch_time.sleep.call_args_list if call[0][0] >= 0.001]
+    assert 0.01 in retry_sleeps
+
+
+def test_429_subsecond_retry_after_floored_to_min(
+    _patch_time: MagicMock,
+) -> None:
+    """429 with a sub-floor Retry-After (e.g. ``0``) is clamped to 0.1s."""
+    r429 = _make_response(429, headers={"retry-after": "0"})
+    r200 = _make_response(200)
+    mock_httpx = MagicMock(spec=httpx.Client)
+    mock_httpx.build_request.return_value = httpx.Request("GET", "https://example.com/test")
+    mock_httpx.send.side_effect = [r429, r200]
+    client = ResilientClient(mock_httpx, max_retries=3, backoff_schedule=(1.0, 2.0, 4.0))
+
+    client.get("/test")
+
+    retry_sleeps = [call[0][0] for call in _patch_time.sleep.call_args_list]
+    assert 0.1 in retry_sleeps
+    assert 0 not in retry_sleeps
+
+
 def test_max_retries_exceeded_raises(_patch_time: MagicMock) -> None:
     """After max_retries 429s, the final 429 raises HTTPStatusError."""
     responses = [_make_response(429)] * 4  # 1 initial + 3 retries
@@ -229,6 +292,242 @@ def test_post_is_throttled_and_retried(_patch_time: MagicMock) -> None:
     assert mock_httpx.send.call_count == 2
     mock_httpx.build_request.assert_called()
     assert mock_httpx.build_request.call_args_list[0][0][0] == "POST"
+
+
+# ---------------------------------------------------------------------------
+# Shared throttle state
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# 5xx Retry-After + diagnostics logging (#685)
+# ---------------------------------------------------------------------------
+
+
+def test_5xx_retry_after_caps_backoff_when_shorter(
+    _patch_time: MagicMock,
+) -> None:
+    """5xx with Retry-After shorter than backoff should sleep for Retry-After."""
+    # Custom backoff well above the 0.1s parse floor so Retry-After=0.2
+    # is genuinely "shorter than backoff".
+    r503 = _make_response(503, headers={"retry-after": "0.2"})
+    r200 = _make_response(200)
+    mock_httpx = MagicMock(spec=httpx.Client)
+    mock_httpx.build_request.return_value = httpx.Request("GET", "https://example.com/test")
+    mock_httpx.send.side_effect = [r503, r200]
+    client = ResilientClient(
+        mock_httpx,
+        max_retries=3,
+        backoff_schedule=(1.0, 2.0, 4.0),
+    )
+
+    result = client.get("/test")
+
+    assert result.status_code == 200
+    retry_sleeps = [call[0][0] for call in _patch_time.sleep.call_args_list]
+    # Retry-After 0.2 < backoff[0] 1.0 — the shorter value wins.
+    assert 0.2 in retry_sleeps
+
+
+def test_5xx_retry_after_does_not_extend_backoff(
+    _patch_time: MagicMock,
+) -> None:
+    """5xx with Retry-After longer than backoff still sleeps for backoff."""
+    # Backoff[0] = 0.01s; Retry-After of 60s would be way too long.
+    r503 = _make_response(503, headers={"retry-after": "60"})
+    r200 = _make_response(200)
+    client, _ = _make_client([r503, r200])
+
+    client.get("/test")
+
+    retry_sleeps = [call[0][0] for call in _patch_time.sleep.call_args_list if call[0][0] >= 0.001]
+    assert 60.0 not in retry_sleeps
+    assert 0.01 in retry_sleeps
+
+
+def test_5xx_unparseable_retry_after_falls_back_to_backoff(
+    _patch_time: MagicMock,
+) -> None:
+    """Retry-After that is neither delta-seconds nor an HTTP-date falls back to backoff."""
+    r503 = _make_response(503, headers={"retry-after": "soon-ish"})
+    r200 = _make_response(200)
+    client, _ = _make_client([r503, r200])
+
+    client.get("/test")
+
+    retry_sleeps = [call[0][0] for call in _patch_time.sleep.call_args_list if call[0][0] >= 0.001]
+    assert 0.01 in retry_sleeps
+
+
+def test_5xx_retry_after_http_date_in_past_uses_floor(
+    _patch_time: MagicMock,
+) -> None:
+    """An HTTP-date Retry-After in the past should not busy-loop —
+    it gets clamped to the 0.1s floor and then capped by the backoff
+    schedule. With backoff[0]=1.0s, the floor wins as the shorter cap.
+    """
+    r503 = _make_response(503, headers={"retry-after": "Mon, 01 Jan 1990 00:00:00 GMT"})
+    r200 = _make_response(200)
+    mock_httpx = MagicMock(spec=httpx.Client)
+    mock_httpx.build_request.return_value = httpx.Request("GET", "https://example.com/test")
+    mock_httpx.send.side_effect = [r503, r200]
+    client = ResilientClient(mock_httpx, max_retries=3, backoff_schedule=(1.0, 2.0, 4.0))
+
+    client.get("/test")
+
+    retry_sleeps = [call[0][0] for call in _patch_time.sleep.call_args_list]
+    assert 0.1 in retry_sleeps
+
+
+def test_5xx_retry_after_http_date_near_future_wins(
+    _patch_time: MagicMock,
+) -> None:
+    """An HTTP-date Retry-After in the near future (delta < backoff)
+    should win as the shorter cap. Constructs a date ~0.5s ahead so
+    delta < backoff[0]=2.0s.
+    """
+    near_future = datetime.now(UTC).replace(microsecond=0) + timedelta(seconds=2)
+    header = format_datetime(near_future, usegmt=True)
+    r503 = _make_response(503, headers={"retry-after": header})
+    r200 = _make_response(200)
+    mock_httpx = MagicMock(spec=httpx.Client)
+    mock_httpx.build_request.return_value = httpx.Request("GET", "https://example.com/test")
+    mock_httpx.send.side_effect = [r503, r200]
+    client = ResilientClient(mock_httpx, max_retries=3, backoff_schedule=(60.0, 120.0, 240.0))
+
+    client.get("/test")
+
+    retry_sleeps = [call[0][0] for call in _patch_time.sleep.call_args_list]
+    # Some value 0.1 < s <= 2.0 (delta), well below the 60s backoff.
+    matched = [s for s in retry_sleeps if 0.1 <= s <= 2.5]
+    assert matched, f"no Retry-After-driven sleep found in {retry_sleeps}"
+
+
+def test_5xx_retry_after_subsecond_value_floored_to_min(
+    _patch_time: MagicMock,
+) -> None:
+    """A sub-floor Retry-After (e.g. 0.05s) is clamped to the 0.1s
+    floor — defends against hostile/buggy servers that would force
+    us into a busy-loop.
+    """
+    r503 = _make_response(503, headers={"retry-after": "0.05"})
+    r200 = _make_response(200)
+    mock_httpx = MagicMock(spec=httpx.Client)
+    mock_httpx.build_request.return_value = httpx.Request("GET", "https://example.com/test")
+    mock_httpx.send.side_effect = [r503, r200]
+    client = ResilientClient(mock_httpx, max_retries=3, backoff_schedule=(1.0, 2.0, 4.0))
+
+    client.get("/test")
+
+    retry_sleeps = [call[0][0] for call in _patch_time.sleep.call_args_list]
+    assert 0.05 not in retry_sleeps
+    assert 0.1 in retry_sleeps
+
+
+def test_5xx_warning_logs_actual_sleep_duration(
+    _patch_time: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The WARNING line must report the real sleep duration (no
+    truncation of sub-second values to '0.0s').
+    """
+    r503 = _make_response(503)
+    r200 = _make_response(200)
+    client, _ = _make_client([r503, r200])
+
+    with caplog.at_level("WARNING", logger="app.providers.resilient_client"):
+        client.get("/test")
+
+    retry_logs = [r for r in caplog.records if "Retryable" in r.getMessage()]
+    msg = retry_logs[0].getMessage()
+    # backoff[0]=0.01 — the format must surface that, not "0.0s".
+    assert "sleeping 0.01s" in msg
+
+
+def test_5xx_warning_includes_body_correlation_and_retry_after(
+    _patch_time: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """5xx WARNING log carries body preview, correlation ID, Retry-After."""
+    body = b'{"error":"upstream_unavailable","trace":"abc-123"}'
+    r503 = _make_response(
+        503,
+        headers={
+            "retry-after": "0.005",
+            "X-Correlation-ID": "corr-xyz-1",
+        },
+        content=body,
+    )
+    r200 = _make_response(200)
+    client, _ = _make_client([r503, r200])
+
+    with caplog.at_level("WARNING", logger="app.providers.resilient_client"):
+        client.get("/test")
+
+    # Exactly one retry warning — the second response (200) is not retried.
+    retry_logs = [r for r in caplog.records if "Retryable" in r.getMessage()]
+    assert len(retry_logs) == 1
+    msg = retry_logs[0].getMessage()
+    assert "corr-xyz-1" in msg
+    assert "upstream_unavailable" in msg
+    assert "retry_after=0.005" in msg
+
+
+def test_5xx_warning_handles_missing_headers_and_body(
+    _patch_time: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Bare 5xx (no Retry-After, no correlation, no body) still logs cleanly."""
+    r500 = _make_response(500)
+    r200 = _make_response(200)
+    client, _ = _make_client([r500, r200])
+
+    with caplog.at_level("WARNING", logger="app.providers.resilient_client"):
+        client.get("/test")
+
+    retry_logs = [r for r in caplog.records if "Retryable" in r.getMessage()]
+    assert len(retry_logs) == 1
+    msg = retry_logs[0].getMessage()
+    assert "retry_after=None" in msg
+    assert "correlation_id=None" in msg
+    assert "body=None" in msg
+
+
+def test_5xx_correlation_id_falls_back_to_x_request_id(
+    _patch_time: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When X-Correlation-ID is absent, use X-Request-ID."""
+    r503 = _make_response(503, headers={"X-Request-ID": "req-id-42"})
+    r200 = _make_response(200)
+    client, _ = _make_client([r503, r200])
+
+    with caplog.at_level("WARNING", logger="app.providers.resilient_client"):
+        client.get("/test")
+
+    retry_logs = [r for r in caplog.records if "Retryable" in r.getMessage()]
+    assert "req-id-42" in retry_logs[0].getMessage()
+
+
+def test_5xx_body_preview_truncates_long_bodies(
+    _patch_time: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Bodies longer than the preview cap are truncated with an ellipsis."""
+    long_body = ("x" * 500).encode("utf-8")
+    r502 = _make_response(502, content=long_body)
+    r200 = _make_response(200)
+    client, _ = _make_client([r502, r200])
+
+    with caplog.at_level("WARNING", logger="app.providers.resilient_client"):
+        client.get("/test")
+
+    retry_logs = [r for r in caplog.records if "Retryable" in r.getMessage()]
+    msg = retry_logs[0].getMessage()
+    # Truncated to 200 chars + ellipsis; the original 500 chars must not appear.
+    assert "x" * 500 not in msg
+    assert "x" * 200 in msg
+    assert "…" in msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Extends `ResilientClient` retry warning + 5xx backoff to surface eToro's structured error metadata.

## Why

Operator hit a 503 chain on IEP intraday-candles (#685). Existing log line captured only status + URL + attempt count — not body, not `Retry-After`, not correlation header. Without those, escalating to eToro support has no request handle to cite.

## Test plan

- [x] `uv run pytest tests/test_resilient_client.py` (26 passed)
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pyright`
- [x] Full `uv run pytest` suite green (2974 passed locally)
- [x] Codex pre-push review (2 findings addressed: HTTP-date parsing + sleep-duration format; 1 rebutted: PEP 758 parens-less multi-exception except is valid Python 3.14+)

## Notes

- 5xx caps Retry-After by configured backoff (server hint shortens our wait but cannot extend it past our budget).
- 429 keeps existing Retry-After-overrides-backoff semantics — but the parser is now shared, so 429 also accepts HTTP-date and applies the 0.1s busy-loop floor.
- New WARNING format string changed from `%.1fs` to `%gs` so sub-second sleeps no longer log as `0.0s`.