### PR TITLE
fix(#675): apply 8-K items + entity profile on planner-driven refresh

### DIFF
--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -2363,6 +2363,18 @@ def execute_refresh(
                 instrument_id, symbol = inst
                 new_filings = plan.new_filings_by_cik.get(cik)
                 submissions_body = plan.submissions_by_cik.get(cik)
+                # Codex residual finding (#675): if a hand-built /
+                # legacy plan supplies ``submissions_only_advances``
+                # without a matching ``submissions_by_cik`` entry, fall
+                # back to a fresh fetch so extractions still run. Real
+                # planner output always pairs them, but a
+                # silently-skipped extraction is exactly the bug class
+                # this PR exists to close. Mirrors the seed-path
+                # fallback inside ``_run_cik_upsert``.
+                if submissions_body is None:
+                    fetched = filings_provider.fetch_submissions(cik)
+                    if fetched is not None:
+                        submissions_body = fetched
                 with conn.transaction():
                     # Upsert filing_events for each master-index entry
                     # on this CIK so the 8-K (or similar) is visible to

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -21,7 +21,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import psycopg
 
@@ -37,6 +37,11 @@ from app.providers.implementations.sec_edgar import (
     parse_master_index,
 )
 from app.providers.implementations.sec_fundamentals import TRACKED_CONCEPTS
+from app.services.sec_entity_profile import parse_entity_profile, upsert_entity_profile
+from app.services.sec_filing_items import (
+    apply_8k_items_to_filing_events,
+    parse_8k_items_by_accession,
+)
 from app.services.sync_orchestrator.progress import report_progress
 from app.services.watermarks import get_watermark, set_watermark
 
@@ -1399,6 +1404,17 @@ class RefreshPlan:
       consumes this dict on the refresh + submissions-only paths; the
       seed path ignores it because seeds need full historical backfill
       (#268 Chunk E), not just this week's entries.
+    - ``submissions_by_cik`` — per-CIK ``submissions.json`` dict the
+      planner already fetched while computing ``top_accession``.
+      Populated for every CIK on the refresh / submissions-only /
+      stale-watermark-backfill paths so the executor reuses the body
+      to apply 8-K ``items[]`` and entity-profile extractions instead
+      of re-fetching (or, worse, silently skipping the extractions —
+      #675 was caused by the planner discarding this dict and the
+      executor's extractions sitting inside an ``else`` branch that
+      only fired on seed/first-time-refresh). Seed-path CIKs are
+      absent here because the planner doesn't fetch submissions for
+      seeds; the executor still fetches them directly in that case.
     """
 
     seeds: list[str] = field(default_factory=list)
@@ -1410,6 +1426,7 @@ class RefreshPlan:
     pending_master_index_writes: list[tuple[str, str, str]] = field(default_factory=list)
     ciks_by_day: dict[str, list[str]] = field(default_factory=dict)
     new_filings_by_cik: dict[str, list[MasterIndexEntry]] = field(default_factory=dict)
+    submissions_by_cik: dict[str, dict[str, Any]] = field(default_factory=dict)
     # CIKs skipped during planning itself (fetch_submissions returned None
     # or filings.recent was empty). These never make it to
     # seeds/refreshes/submissions_only_advances, so the executor's
@@ -1593,6 +1610,12 @@ def plan_refresh(
     seeds: list[str] = []
     refreshes: list[tuple[str, str]] = []
     submissions_only: list[tuple[str, str]] = []
+    # #675: keep the planner-fetched submissions body alive so the
+    # executor can apply 8-K items[] + entity profile without a second
+    # fetch (or, worse, silently skipping the extraction). Populated
+    # for every CIK that lands in refreshes / submissions_only /
+    # stale-backfill refreshes.
+    submissions_by_cik: dict[str, dict[str, Any]] = {}
     failed_plan_ciks: list[str] = []
 
     covered_set = set(covered)
@@ -1641,8 +1664,19 @@ def plan_refresh(
             continue
         if top_accession == wm.watermark:
             # Amendment or re-listing of a filing we already have.
+            # We still capture the submissions body — even when
+            # ``top_accession`` is unchanged, the executor may want
+            # the dict for items/entity-profile extraction. The
+            # current main path returns above without enqueueing
+            # this CIK, so we do too — extraction-only paths land
+            # via stale-watermark backfill.
             continue
 
+        # Capture the submissions body so the executor can apply 8-K
+        # items[] + entity profile without a second fetch (#675). Set
+        # before the form-type branching so both refreshes and
+        # submissions-only land in ``submissions_by_cik``.
+        submissions_by_cik[cik] = submissions
         hit_forms = {e.form_type for e in entries}
         if hit_forms & FUNDAMENTALS_FORMS:
             refreshes.append((cik, top_accession))
@@ -1722,7 +1756,10 @@ def plan_refresh(
             continue
         # A new filing arrived during the outage. Enqueue as refresh —
         # the executor will fetch companyfacts and advance both
-        # watermarks atomically.
+        # watermarks atomically. Capture the submissions body so the
+        # executor extracts 8-K items + entity profile without a
+        # second fetch (#675).
+        submissions_by_cik[cik] = submissions
         refreshes.append((cik, top_accession))
 
     return RefreshPlan(
@@ -1736,6 +1773,7 @@ def plan_refresh(
         # covered cohort above; pass it through so the executor can
         # upsert each hit into filing_events.
         new_filings_by_cik=master_hits_by_cik,
+        submissions_by_cik=submissions_by_cik,
     )
 
 
@@ -1850,6 +1888,59 @@ def _upsert_filing_from_master_index(
     )
 
 
+def _apply_submissions_extractions(
+    conn: psycopg.Connection[tuple],
+    *,
+    cik: str,
+    instrument_id: int,
+    submissions: dict[str, Any],
+) -> None:
+    """Apply zero-extra-HTTP extractions derived from a fetched
+    ``submissions.json`` dict.
+
+    Two extractions land here:
+
+    * #427 — entity profile (description, SIC, exchanges, former
+      names, addresses).
+    * #431 — 8-K ``items[]`` typing on existing ``filing_events``
+      rows.
+
+    Each extraction is wrapped in its own ``conn.transaction()``
+    savepoint per #439 so a parse/write failure cannot poison the
+    outer per-CIK transaction that still has XBRL facts to write.
+    Failures are logged at WARNING + ``exc_info=True`` and do not
+    propagate — these extractions are best-effort relative to the
+    fact upsert (#675: even when both fail, the executor must still
+    advance the watermarks for the CIKs whose facts wrote).
+    """
+    try:
+        profile = parse_entity_profile(
+            submissions,
+            instrument_id=instrument_id,
+            cik=cik,
+        )
+        with conn.transaction():
+            upsert_entity_profile(conn, profile)
+    except Exception:
+        logger.warning(
+            "sec_incremental: entity-profile upsert failed for cik=%s",
+            cik,
+            exc_info=True,
+        )
+
+    try:
+        items_map = parse_8k_items_by_accession(submissions)
+        if items_map:
+            with conn.transaction():
+                apply_8k_items_to_filing_events(conn, items_map)
+    except Exception:
+        logger.warning(
+            "sec_incremental: 8-K items apply failed for cik=%s",
+            cik,
+            exc_info=True,
+        )
+
+
 def _run_cik_upsert(
     conn: psycopg.Connection[tuple],
     *,
@@ -1859,6 +1950,7 @@ def _run_cik_upsert(
     run_id: int,
     failed: list[tuple[str, str]],
     known_top_accession: str | None = None,
+    known_submissions: dict[str, Any] | None = None,
     new_filings: list[MasterIndexEntry] | None = None,
 ) -> int | None:
     """Per-CIK seed/refresh body.
@@ -1869,6 +1961,14 @@ def _run_cik_upsert(
     executor would otherwise re-fetch to read the top accession again).
     Seeds pass ``None`` because the planner has no prior watermark and
     doesn't call ``fetch_submissions`` for them.
+
+    ``known_submissions`` carries the planner-fetched ``submissions.json``
+    body. When supplied, the executor runs the entity-profile upsert and
+    8-K items[] apply against it — these extractions are required on
+    EVERY refresh, not just the seed path. Pre-#675 the extractions
+    sat inside the seed-only ``else`` branch and the planner threw the
+    submissions body away, leaving items[] universally NULL on 8-K
+    rows and entity-profile rows stale forever after seed.
 
     Returns the number of fact rows upserted on success (``int >= 0``)
     or ``None`` on skip or failure. Failures additionally append
@@ -1912,12 +2012,23 @@ def _run_cik_upsert(
         # transaction for multi-second windows × hundreds of CIKs.
         conn.commit()
 
-        # Skip the second fetch_submissions round-trip if the planner
-        # already captured the top accession (refresh / submissions-only
-        # paths). Seeds have no prior watermark, so the planner never
-        # fetched for them — executor still fetches once.
-        if known_top_accession is not None:
-            top_accession: str | None = known_top_accession
+        # Resolve submissions body + top accession. Three valid input
+        # combinations:
+        #
+        #   1. Refresh via planner: known_top_accession AND
+        #      known_submissions both set. Skip fetch entirely.
+        #   2. Stale-backfill / new-cycle refresh where the planner
+        #      enqueued only top_accession (legacy callers): known_top_accession
+        #      set, known_submissions None. Re-fetch so extractions can
+        #      run. Cost: one extra HTTP per such CIK — uncommon path
+        #      after #675's planner update propagates.
+        #   3. Seed: neither set. Planner has no watermark for this
+        #      CIK so didn't fetch. Executor fetches.
+        submissions: dict[str, Any] | None
+        top_accession: str | None
+        if known_top_accession is not None and known_submissions is not None:
+            top_accession = known_top_accession
+            submissions = known_submissions
         else:
             submissions = filings_provider.fetch_submissions(cik)
             if submissions is None:
@@ -1933,7 +2044,7 @@ def _run_cik_upsert(
                 failed.append((cik, "SubmissionsMissing"))
                 outcome = "skip_submissions_missing"
                 return None
-            top_accession = _top_accession_from_submissions(submissions)
+            top_accession = known_top_accession or _top_accession_from_submissions(submissions)
             if top_accession is None:
                 # Transient: submissions.json returned but filings.recent
                 # is empty despite a master-index hit. Same invariant —
@@ -1945,64 +2056,6 @@ def _run_cik_upsert(
                 failed.append((cik, "EmptyFilingsRecent"))
                 outcome = "skip_empty_filings"
                 return None
-            # #427: extract rich entity metadata from the submissions
-            # dict we already have in memory. Zero extra HTTP. Only
-            # happens when the executor fetches submissions itself
-            # (seed path + first-time refresh) — on the refresh-via-
-            # planner path the dict is thrown away before we get here,
-            # which is acceptable because entity metadata (description,
-            # SIC, exchanges, former names) changes rarely; any stale
-            # row converges on the next seed cycle.
-            #
-            # Wrapped in ``with conn.transaction():`` so any DB error
-            # inside the upsert rolls back a SAVEPOINT rather than
-            # leaving the outer per-CIK transaction in
-            # ``InFailedSqlTransaction`` state. Without the savepoint,
-            # a bare ``except Exception`` still catches the error but
-            # the subsequent XBRL facts upsert below would fail with
-            # "current transaction is aborted, commands ignored".
-            # Review #439 BLOCKING.
-            try:
-                from app.services.sec_entity_profile import (
-                    parse_entity_profile,
-                    upsert_entity_profile,
-                )
-
-                profile = parse_entity_profile(
-                    submissions,
-                    instrument_id=instrument_id,
-                    cik=cik,
-                )
-                with conn.transaction():
-                    upsert_entity_profile(conn, profile)
-            except Exception:
-                logger.warning(
-                    "sec_incremental: entity-profile upsert failed for cik=%s",
-                    cik,
-                    exc_info=True,
-                )
-
-            # #431: 8-K items[] typing. Parse the items column in the
-            # submissions.filings.recent table and UPDATE the matching
-            # filing_events rows. Savepoint-scoped per the #439 pattern
-            # so a parse/write failure cannot poison the outer per-CIK
-            # transaction that still has XBRL facts to write.
-            try:
-                from app.services.sec_filing_items import (
-                    apply_8k_items_to_filing_events,
-                    parse_8k_items_by_accession,
-                )
-
-                items_map = parse_8k_items_by_accession(submissions)
-                if items_map:
-                    with conn.transaction():
-                        apply_8k_items_to_filing_events(conn, items_map)
-            except Exception:
-                logger.warning(
-                    "sec_incremental: 8-K items apply failed for cik=%s",
-                    cik,
-                    exc_info=True,
-                )
 
         # #451 Phase A — single fetch returns both fact rows and
         # catalogue entries. Fall back to ``extract_facts`` when a
@@ -2032,6 +2085,10 @@ def _run_cik_upsert(
             # Idempotent: ON CONFLICT preserves richer URLs stored by
             # the submissions-based ingest path. Atomic with the facts
             # upsert and watermark writes below.
+            #
+            # Order matters with the ``_apply_submissions_extractions``
+            # call below: master-index inserts FIRST so the items
+            # UPDATE has rows to match against (#675).
             if new_filings:
                 for entry in new_filings:
                     _upsert_filing_from_master_index(
@@ -2040,6 +2097,27 @@ def _run_cik_upsert(
                         entry=entry,
                         symbol=symbol,
                     )
+
+            # #427 + #431 + #675: extract entity profile + 8-K items[]
+            # from the submissions dict we have in memory. Zero extra
+            # HTTP. Runs on EVERY executor invocation that has
+            # submissions in hand — seed AND refresh. Pre-#675 these
+            # blocks lived inside a seed-only ``else`` branch and the
+            # planner discarded the submissions dict on the refresh
+            # path, so 8-K items[] never populated in steady state and
+            # entity-profile rows went stale silently. The #439
+            # invariant (savepoint-scoped so a parse/write failure
+            # cannot poison the outer per-CIK transaction) is
+            # preserved by the ``with conn.transaction():`` wrappers
+            # inside ``_apply_submissions_extractions`` — when called
+            # from inside this outer transaction they nest as
+            # SAVEPOINTs.
+            _apply_submissions_extractions(
+                conn,
+                cik=cik,
+                instrument_id=instrument_id,
+                submissions=submissions,
+            )
             set_watermark(
                 conn,
                 source="sec.submissions",
@@ -2257,6 +2335,7 @@ def execute_refresh(
                 run_id=run_id,
                 failed=failed,
                 known_top_accession=top_accession,
+                known_submissions=plan.submissions_by_cik.get(cik),
                 new_filings=plan.new_filings_by_cik.get(cik),
             )
             if upserted is not None:
@@ -2287,7 +2366,9 @@ def execute_refresh(
                     # Upsert filing_events for each master-index entry
                     # on this CIK so the 8-K (or similar) is visible to
                     # downstream event-driven triggers, even though we
-                    # don't fetch companyfacts.
+                    # don't fetch companyfacts. Order matters: insert
+                    # the master-index rows BEFORE applying items so
+                    # the items UPDATE has rows to match against.
                     if new_filings:
                         for entry in new_filings:
                             _upsert_filing_from_master_index(
@@ -2303,6 +2384,20 @@ def execute_refresh(
                         watermark=accession,
                     )
                 conn.commit()
+                # #675: apply 8-K items[] + entity profile from the
+                # planner-fetched submissions body. Best-effort — runs
+                # AFTER the watermark commit so a transient failure
+                # cannot un-advance the watermark, and uses its own
+                # savepoints inside ``_apply_submissions_extractions``
+                # for #439 compliance.
+                submissions_body = plan.submissions_by_cik.get(cik)
+                if submissions_body is not None:
+                    _apply_submissions_extractions(
+                        conn,
+                        cik=cik,
+                        instrument_id=instrument_id,
+                        submissions=submissions_body,
+                    )
                 submissions_advanced += 1
             except Exception as exc:
                 try:

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -2362,6 +2362,7 @@ def execute_refresh(
                     continue
                 instrument_id, symbol = inst
                 new_filings = plan.new_filings_by_cik.get(cik)
+                submissions_body = plan.submissions_by_cik.get(cik)
                 with conn.transaction():
                     # Upsert filing_events for each master-index entry
                     # on this CIK so the 8-K (or similar) is visible to
@@ -2377,6 +2378,25 @@ def execute_refresh(
                                 entry=entry,
                                 symbol=symbol,
                             )
+                    # #675: apply 8-K items[] + entity profile inside
+                    # the same per-CIK transaction, BEFORE the
+                    # watermark commit. Codex flagged a silent-skip
+                    # risk if extractions ran post-commit: a crash or
+                    # DB error in the post-commit window would leave
+                    # the accession marked done so the next planner
+                    # run skips this CIK and items[] never applies.
+                    # Inside the transaction, the helper's internal
+                    # savepoints still soak up parse/write failures
+                    # without rolling back the master-index inserts
+                    # (#439 invariant); the watermark advance and the
+                    # extraction attempt commit atomically.
+                    if submissions_body is not None:
+                        _apply_submissions_extractions(
+                            conn,
+                            cik=cik,
+                            instrument_id=instrument_id,
+                            submissions=submissions_body,
+                        )
                     set_watermark(
                         conn,
                         source="sec.submissions",
@@ -2384,20 +2404,6 @@ def execute_refresh(
                         watermark=accession,
                     )
                 conn.commit()
-                # #675: apply 8-K items[] + entity profile from the
-                # planner-fetched submissions body. Best-effort — runs
-                # AFTER the watermark commit so a transient failure
-                # cannot un-advance the watermark, and uses its own
-                # savepoints inside ``_apply_submissions_extractions``
-                # for #439 compliance.
-                submissions_body = plan.submissions_by_cik.get(cik)
-                if submissions_body is not None:
-                    _apply_submissions_extractions(
-                        conn,
-                        cik=cik,
-                        instrument_id=instrument_id,
-                        submissions=submissions_body,
-                    )
                 submissions_advanced += 1
             except Exception as exc:
                 try:

--- a/scripts/backfill_8k_items.py
+++ b/scripts/backfill_8k_items.py
@@ -160,7 +160,13 @@ def main(argv: list[str] | None = None) -> int:
     if not args.apply:
         logger.info("DRY RUN — no fetches, no writes. Use --apply to commit.")
 
-    with psycopg.connect(settings.database_url) as conn:
+    # autocommit=True so every per-CIK ``with conn.transaction()`` is a
+    # real BEGIN/COMMIT pair rather than a savepoint nested inside the
+    # implicit outer transaction that ``conn.execute(SELECT)`` would
+    # otherwise open. Without this, a process crash mid-loop would roll
+    # back every preceding CIK's writes when the outer transaction
+    # aborts. Codex checkpoint-2 flagged this.
+    with psycopg.connect(settings.database_url, autocommit=True) as conn:
         covered = _load_covered_ciks(conn, limit=args.limit, offset=args.offset)
         if not covered:
             logger.info("backfill: no covered CIKs found in slice (offset=%d, limit=%s)", args.offset, args.limit)
@@ -188,13 +194,26 @@ def main(argv: list[str] | None = None) -> int:
         failed_profile = 0
         with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
             for idx, (instrument_id, symbol, cik) in enumerate(covered, start=1):
-                items_updated, profile_updated, status = _process_cik(
-                    conn,
-                    instrument_id=instrument_id,
-                    cik=cik,
-                    provider=provider,
-                    apply=args.apply,
-                )
+                # Trap per-CIK provider exceptions (network, 5xx
+                # bursts, malformed JSON) so one bad CIK cannot abort
+                # the rest of the sweep. With autocommit=True, every
+                # prior CIK's writes are already durable.
+                try:
+                    items_updated, profile_updated, status = _process_cik(
+                        conn,
+                        instrument_id=instrument_id,
+                        cik=cik,
+                        provider=provider,
+                        apply=args.apply,
+                    )
+                except Exception:
+                    logger.warning(
+                        "backfill: _process_cik raised for cik=%s — skipping",
+                        cik,
+                        exc_info=True,
+                    )
+                    failed_items += 1
+                    continue
                 items_total += items_updated
                 profile_total += profile_updated
                 if status == "ok":

--- a/scripts/backfill_8k_items.py
+++ b/scripts/backfill_8k_items.py
@@ -1,0 +1,238 @@
+"""One-shot backfill of ``filing_events.items`` for SEC 8-K rows (#675).
+
+Pre-#675 the executor's 8-K items[] apply lived inside an ``else``
+branch that only fired on the seed / first-time-refresh path; the
+planner-driven refresh path (the steady-state common case) silently
+discarded the submissions body and skipped the items extraction. As
+a result, 480k+ existing 8-K rows have ``items=NULL`` even though
+the parser is correct and the column type is non-NULLable in spirit.
+
+This script re-fetches ``submissions.json`` for every covered CIK and
+applies items to every existing 8-K ``filing_events`` row. Same logic
+as the executor's #431 path, just iterated once across the universe.
+The same script also re-applies the entity profile extraction (#427)
+which had the same staleness defect. Idempotent — re-running is safe
+because the UPDATE matches by ``(provider, provider_filing_id)`` and
+``upsert_entity_profile`` is upsert-based.
+
+Run from the repo root::
+
+    uv run python scripts/backfill_8k_items.py --apply
+
+Dry-run by default. ``--apply`` does the real fetches and writes.
+``--limit N`` caps CIKs processed in this invocation (resumable —
+the script always processes CIKs in deterministic identifier order
+so a follow-up run with the same ``--limit`` after ``--offset N``
+covers the next slice).
+
+Rate limit: SEC fair-use is 10 req/s per UA. The provider's shared
+process-wide throttle handles this; with ~5k covered CIKs and 100ms
+per fetch the full sweep is ~8 minutes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.sec_edgar import SecFilingsProvider
+from app.services.sec_entity_profile import parse_entity_profile, upsert_entity_profile
+from app.services.sec_filing_items import (
+    apply_8k_items_to_filing_events,
+    parse_8k_items_by_accession,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _load_covered_ciks(
+    conn: psycopg.Connection[tuple],
+    *,
+    limit: int | None,
+    offset: int,
+) -> list[tuple[int, str, str]]:
+    """Return ``(instrument_id, symbol, cik)`` for every tradable
+    instrument with a primary SEC CIK identifier. Ordered by CIK so
+    ``--offset`` / ``--limit`` produce stable slices across runs.
+
+    Uses ``LIMIT ALL`` when ``limit is None`` so the same parameterised
+    SQL handles both bounded and unbounded slices — keeps the query a
+    PEP 675 ``LiteralString`` (psycopg + pyright reject f-string SQL).
+    """
+    cur = conn.execute(
+        """
+        SELECT i.instrument_id, i.symbol, ei.identifier_value
+        FROM instruments i
+        JOIN external_identifiers ei
+          ON ei.instrument_id = i.instrument_id
+         AND ei.provider = 'sec'
+         AND ei.identifier_type = 'cik'
+         AND ei.is_primary = TRUE
+        WHERE i.is_tradable = TRUE
+        ORDER BY ei.identifier_value
+        OFFSET %(offset)s
+        LIMIT %(limit)s
+        """,
+        {"offset": int(offset), "limit": limit},
+    )
+    return [(int(r[0]), str(r[1]), str(r[2])) for r in cur.fetchall()]
+
+
+def _process_cik(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    cik: str,
+    provider: SecFilingsProvider,
+    apply: bool,
+) -> tuple[int, int, str]:
+    """Fetch submissions and apply items + profile for one CIK.
+
+    Returns ``(items_updated, profile_updated, status)`` where
+    ``items_updated`` is the rowcount of the UPDATE and
+    ``profile_updated`` is 1 if the profile upsert ran (always 1 on
+    success, 0 on failure). ``status`` is one of ``ok``,
+    ``no_submissions``, ``items_failed``, ``profile_failed``,
+    ``both_failed``.
+    """
+    submissions = provider.fetch_submissions(cik)
+    if submissions is None:
+        return (0, 0, "no_submissions")
+
+    items_updated = 0
+    profile_updated = 0
+    items_status = "ok"
+    profile_status = "ok"
+
+    if apply:
+        try:
+            items_map = parse_8k_items_by_accession(submissions)
+            if items_map:
+                with conn.transaction():
+                    items_updated = apply_8k_items_to_filing_events(conn, items_map)
+        except Exception:
+            logger.warning("backfill: items apply failed for cik=%s", cik, exc_info=True)
+            items_status = "failed"
+
+        try:
+            profile = parse_entity_profile(submissions, instrument_id=instrument_id, cik=cik)
+            with conn.transaction():
+                upsert_entity_profile(conn, profile)
+            profile_updated = 1
+        except Exception:
+            logger.warning("backfill: profile upsert failed for cik=%s", cik, exc_info=True)
+            profile_status = "failed"
+    else:
+        # Dry-run: parse only, count what *would* change.
+        items_map = parse_8k_items_by_accession(submissions)
+        items_updated = sum(1 for _ in items_map)  # would-touch accession count
+        profile_updated = 1  # would always upsert
+
+    if items_status == "failed" and profile_status == "failed":
+        status = "both_failed"
+    elif items_status == "failed":
+        status = "items_failed"
+    elif profile_status == "failed":
+        status = "profile_failed"
+    else:
+        status = "ok"
+    return (items_updated, profile_updated, status)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Perform fetches and writes (default: dry-run).")
+    parser.add_argument("--limit", type=int, default=None, help="Cap CIKs processed this run.")
+    parser.add_argument("--offset", type=int, default=0, help="Skip first N CIKs (for resumable runs).")
+    parser.add_argument(
+        "--progress-every",
+        type=int,
+        default=50,
+        help="Log progress every N CIKs (default: 50).",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.apply:
+        logger.info("DRY RUN — no fetches, no writes. Use --apply to commit.")
+
+    with psycopg.connect(settings.database_url) as conn:
+        covered = _load_covered_ciks(conn, limit=args.limit, offset=args.offset)
+        if not covered:
+            logger.info("backfill: no covered CIKs found in slice (offset=%d, limit=%s)", args.offset, args.limit)
+            return 0
+
+        logger.info(
+            "backfill: %d CIKs to process (offset=%d, limit=%s, apply=%s)",
+            len(covered),
+            args.offset,
+            args.limit,
+            args.apply,
+        )
+
+        if not args.apply:
+            # Dry-run: only count, do not invoke the provider — keep
+            # SEC traffic to zero.
+            logger.info("backfill: dry-run skips submissions fetches; pass --apply to test the real path")
+            return 0
+
+        items_total = 0
+        profile_total = 0
+        ok_count = 0
+        no_submissions = 0
+        failed_items = 0
+        failed_profile = 0
+        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+            for idx, (instrument_id, symbol, cik) in enumerate(covered, start=1):
+                items_updated, profile_updated, status = _process_cik(
+                    conn,
+                    instrument_id=instrument_id,
+                    cik=cik,
+                    provider=provider,
+                    apply=args.apply,
+                )
+                items_total += items_updated
+                profile_total += profile_updated
+                if status == "ok":
+                    ok_count += 1
+                elif status == "no_submissions":
+                    no_submissions += 1
+                elif status == "items_failed":
+                    failed_items += 1
+                elif status == "profile_failed":
+                    failed_profile += 1
+                elif status == "both_failed":
+                    failed_items += 1
+                    failed_profile += 1
+
+                if idx % args.progress_every == 0:
+                    logger.info(
+                        "backfill: %d/%d processed (symbol=%s cik=%s items=%d profile=%d status=%s)",
+                        idx,
+                        len(covered),
+                        symbol,
+                        cik,
+                        items_updated,
+                        profile_updated,
+                        status,
+                    )
+
+        logger.info(
+            "backfill: complete. ok=%d no_submissions=%d failed_items=%d failed_profile=%d "
+            "items_rows_updated=%d profiles_upserted=%d",
+            ok_count,
+            no_submissions,
+            failed_items,
+            failed_profile,
+            items_total,
+            profile_total,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sec_incremental_executor.py
+++ b/tests/test_sec_incremental_executor.py
@@ -312,6 +312,9 @@ def test_submissions_only_advance_skips_companyfacts(
 
     plan = RefreshPlan(
         submissions_only_advances=[("0000789019", "0000789019-26-000017")],
+        submissions_by_cik={
+            "0000789019": _submissions_with_top("0000789019-26-000017", form="8-K"),
+        },
     )
     filings = StubFilingsProvider()  # fetch_submissions must NOT be called
     fundamentals = StubFundamentalsProvider()  # extract_facts must NOT be called
@@ -324,6 +327,7 @@ def test_submissions_only_advance_skips_companyfacts(
     )
 
     assert outcome.submissions_advanced == 1
+    # Planner-fed submissions in plan → no fallback fetch.
     assert filings.fetch_calls == 0
     assert fundamentals.extract_calls == []
 

--- a/tests/test_sec_incremental_executor.py
+++ b/tests/test_sec_incremental_executor.py
@@ -182,10 +182,12 @@ def test_refresh_advances_both_watermarks(
         )
     ebull_test_conn.commit()
 
-    plan = RefreshPlan(refreshes=[("0000320193", "0000320193-26-000042")])
-    filings = StubFilingsProvider(
-        submissions_by_cik={"0000320193": _submissions_with_top("0000320193-26-000042")},
+    submissions_payload = _submissions_with_top("0000320193-26-000042")
+    plan = RefreshPlan(
+        refreshes=[("0000320193", "0000320193-26-000042")],
+        submissions_by_cik={"0000320193": submissions_payload},
     )
+    filings = StubFilingsProvider()  # body comes from the plan
     fundamentals = StubFundamentalsProvider(
         facts_by_cik={"0000320193": [_sample_fact("0000320193-26-000042")]},
     )
@@ -200,8 +202,11 @@ def test_refresh_advances_both_watermarks(
     assert outcome.refreshed == 1
     assert outcome.failed == []
 
-    # Refresh path must NOT call fetch_submissions — the planner
-    # already captured top_accession and passed it via known_top_accession.
+    # Refresh path must NOT call fetch_submissions — the planner already
+    # supplied both ``known_top_accession`` and ``known_submissions``
+    # (#675 contract: planner-fed submissions are how the executor
+    # avoids a second fetch AND still runs the items/entity-profile
+    # extractions).
     assert filings.fetch_calls == 0
 
     submissions_wm = get_watermark(ebull_test_conn, "sec.submissions", "0000320193")
@@ -830,3 +835,202 @@ def test_cik_upsert_timing_row_persisted(
     assert outcome == "skip_instrument_missing"
     assert facts == 0
     assert float(seconds) >= 0
+
+
+# ---------------------------------------------------------------------------
+# #675: items[] + entity-profile must apply on the planner-driven refresh
+# path. Pre-fix the planner discarded the submissions body and the executor's
+# extractions sat inside a seed-only ``else`` branch — so 480k+ existing 8-K
+# rows had ``items=NULL`` and entity-profile rows went stale silently.
+# ---------------------------------------------------------------------------
+
+
+def _submissions_with_items(
+    accession: str,
+    form: str,
+    items_csv: str,
+    primary_doc: str = "doc.htm",
+) -> dict[str, object]:
+    """submissions.json shape carrying enough fields for both
+    ``parse_8k_items_by_accession`` and ``parse_entity_profile`` to
+    return a non-empty result."""
+    return {
+        "name": "TEST CORP",
+        "sic": "1234",
+        "sicDescription": "Test Industry",
+        "exchanges": ["NASDAQ"],
+        "tickers": ["TEST"],
+        "addresses": {"business": {}, "mailing": {}},
+        "formerNames": [],
+        "filings": {
+            "recent": {
+                "accessionNumber": [accession],
+                "form": [form],
+                "items": [items_csv],
+                "filingDate": ["2026-04-15"],
+                "primaryDocument": [primary_doc],
+                "reportDate": [""],
+                "acceptedDate": ["2026-04-15T09:00:00.000Z"],
+            }
+        },
+    }
+
+
+def test_refresh_path_applies_8k_items_from_planner_submissions(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Regression guard for #675: when the planner passes through the
+    submissions body via ``RefreshPlan.submissions_by_cik``, the
+    executor's refresh path MUST apply 8-K ``items[]`` to the
+    matching ``filing_events`` row. Pre-fix this UPDATE never ran on
+    the refresh path because the extraction lived inside a seed-only
+    ``else`` branch."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="TEST", cik="0000320193")
+    with ebull_test_conn.transaction():
+        set_watermark(
+            ebull_test_conn,
+            source="sec.submissions",
+            key="0000320193",
+            watermark="0000320193-25-000108",
+        )
+        set_watermark(
+            ebull_test_conn,
+            source="sec.companyfacts",
+            key="0000320193",
+            watermark="0000320193-25-000108",
+        )
+    ebull_test_conn.commit()
+
+    accession_8k = "0000320193-26-000099"
+    submissions = _submissions_with_items(accession_8k, "8-K", "1.01,8.01")
+
+    plan = RefreshPlan(
+        refreshes=[("0000320193", "0000320193-26-000042")],
+        submissions_by_cik={"0000320193": submissions},
+        new_filings_by_cik={
+            "0000320193": [
+                _mk_entry("0000320193-26-000042", "10-Q"),
+                _mk_entry(accession_8k, "8-K"),
+            ],
+        },
+    )
+    filings = StubFilingsProvider()  # no fetch — known_submissions provided
+    fundamentals = StubFundamentalsProvider(
+        facts_by_cik={"0000320193": [_sample_fact("0000320193-26-000042")]},
+    )
+
+    outcome = execute_refresh(
+        ebull_test_conn,
+        filings_provider=cast(SecFilingsProvider, filings),
+        fundamentals_provider=cast(SecFundamentalsProvider, fundamentals),
+        plan=plan,
+    )
+
+    assert outcome.refreshed == 1
+    assert outcome.failed == []
+    # Planner-fed submissions → no provider fetch expected.
+    assert filings.fetch_calls == 0
+
+    items_row = ebull_test_conn.execute(
+        "SELECT items FROM filing_events WHERE provider_filing_id = %s",
+        (accession_8k,),
+    ).fetchone()
+    assert items_row is not None
+    assert items_row[0] == ["1.01", "8.01"]
+
+
+def test_refresh_path_applies_entity_profile_from_planner_submissions(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Companion to the items test: the entity-profile upsert (#427)
+    sat in the same seed-only else branch and was equally affected
+    by #675. Refresh path with planner-fed submissions must upsert
+    the profile too."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="TEST", cik="0000320193")
+    with ebull_test_conn.transaction():
+        set_watermark(
+            ebull_test_conn,
+            source="sec.submissions",
+            key="0000320193",
+            watermark="0000320193-25-000108",
+        )
+        set_watermark(
+            ebull_test_conn,
+            source="sec.companyfacts",
+            key="0000320193",
+            watermark="0000320193-25-000108",
+        )
+    ebull_test_conn.commit()
+
+    submissions = _submissions_with_items("0000320193-26-000042", "10-Q", "")
+
+    plan = RefreshPlan(
+        refreshes=[("0000320193", "0000320193-26-000042")],
+        submissions_by_cik={"0000320193": submissions},
+    )
+    filings = StubFilingsProvider()
+    fundamentals = StubFundamentalsProvider(
+        facts_by_cik={"0000320193": [_sample_fact("0000320193-26-000042")]},
+    )
+
+    execute_refresh(
+        ebull_test_conn,
+        filings_provider=cast(SecFilingsProvider, filings),
+        fundamentals_provider=cast(SecFundamentalsProvider, fundamentals),
+        plan=plan,
+    )
+
+    profile = ebull_test_conn.execute(
+        "SELECT sic, sic_description FROM instrument_sec_profile WHERE instrument_id = 1"
+    ).fetchone()
+    assert profile is not None
+    assert profile[0] == "1234"
+    assert profile[1] == "Test Industry"
+
+
+def test_submissions_only_path_applies_8k_items(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """submissions_only_advances path (8-K only, no companyfacts)
+    must also apply items[] using the planner-fed submissions body
+    so ``dividend_calendar`` selectors that filter on
+    ``'8.01' = ANY(items)`` see today's filing."""
+    _seed_instrument(ebull_test_conn, instrument_id=1, symbol="TEST", cik="0000789019")
+    with ebull_test_conn.transaction():
+        set_watermark(
+            ebull_test_conn,
+            source="sec.submissions",
+            key="0000789019",
+            watermark="older",
+        )
+    ebull_test_conn.commit()
+
+    accession = "0000789019-26-000017"
+    submissions = _submissions_with_items(accession, "8-K", "8.01")
+
+    plan = RefreshPlan(
+        submissions_only_advances=[("0000789019", accession)],
+        submissions_by_cik={"0000789019": submissions},
+        new_filings_by_cik={
+            "0000789019": [_mk_entry(accession, "8-K", cik="0000789019")],
+        },
+    )
+    filings = StubFilingsProvider()
+    fundamentals = StubFundamentalsProvider()
+
+    outcome = execute_refresh(
+        ebull_test_conn,
+        filings_provider=cast(SecFilingsProvider, filings),
+        fundamentals_provider=cast(SecFundamentalsProvider, fundamentals),
+        plan=plan,
+    )
+
+    assert outcome.submissions_advanced == 1
+    assert filings.fetch_calls == 0
+
+    items_row = ebull_test_conn.execute(
+        "SELECT items FROM filing_events WHERE provider_filing_id = %s",
+        (accession,),
+    ).fetchone()
+    assert items_row is not None
+    assert items_row[0] == ["8.01"]

--- a/tests/test_sec_incremental_planner.py
+++ b/tests/test_sec_incremental_planner.py
@@ -151,9 +151,10 @@ def test_master_index_hit_with_fundamentals_form_becomes_refresh(
             watermark="0000320193-25-000108",  # older than fixture top 0000320193-26-000042
         )
     master = FIXTURE_MASTER.read_bytes()
+    submissions_payload = json.loads(FIXTURE_SUBMISSIONS)
     provider = StubFilingsProvider(
         master_bodies={d: master if d == date(2026, 4, 15) else None for d in _window(date(2026, 4, 15))},
-        submissions_by_cik={"0000320193": json.loads(FIXTURE_SUBMISSIONS)},
+        submissions_by_cik={"0000320193": submissions_payload},
     )
     plan = plan_refresh(
         ebull_test_conn,
@@ -163,6 +164,11 @@ def test_master_index_hit_with_fundamentals_form_becomes_refresh(
     assert ("0000320193", "0000320193-26-000042") in plan.refreshes
     assert plan.seeds == []
     assert plan.submissions_only_advances == []
+    # #675: planner must keep the submissions body alive on the
+    # refreshes path so the executor can apply 8-K items + entity
+    # profile without a second fetch (or, worse, silently skipping
+    # the extractions).
+    assert plan.submissions_by_cik.get("0000320193") is submissions_payload
 
 
 def test_master_index_hit_with_8k_only_is_submissions_only_advance(
@@ -181,19 +187,19 @@ def test_master_index_hit_with_8k_only_is_submissions_only_advance(
         b"--------------------------------------------------------------------------------\n"
         b"789019|MICROSOFT CORP|8-K|2026-04-15|edgar/data/789019/0000789019-26-000017.txt\n"
     )
+    submissions_payload: dict[str, object] = {
+        "filings": {
+            "recent": {
+                "accessionNumber": ["0000789019-26-000017"],
+                "form": ["8-K"],
+                "items": ["8.01,2.02"],
+                "acceptedDate": ["2026-04-15T09:00:00.000Z"],
+            }
+        }
+    }
     provider = StubFilingsProvider(
         master_bodies={d: custom_master if d == date(2026, 4, 15) else None for d in _window(date(2026, 4, 15))},
-        submissions_by_cik={
-            "0000789019": {
-                "filings": {
-                    "recent": {
-                        "accessionNumber": ["0000789019-26-000017"],
-                        "form": ["8-K"],
-                        "acceptedDate": ["2026-04-15T09:00:00.000Z"],
-                    }
-                }
-            }
-        },
+        submissions_by_cik={"0000789019": submissions_payload},
     )
     plan = plan_refresh(
         ebull_test_conn,
@@ -203,6 +209,10 @@ def test_master_index_hit_with_8k_only_is_submissions_only_advance(
     assert plan.refreshes == []
     assert plan.seeds == []
     assert ("0000789019", "0000789019-26-000017") in plan.submissions_only_advances
+    # #675: planner must keep submissions body alive on the
+    # submissions-only path too — executor needs it to apply 8-K
+    # items[] for the freshly-inserted master-index row.
+    assert plan.submissions_by_cik.get("0000789019") is submissions_payload
 
 
 def test_master_index_hit_non_covered_cik_ignored(


### PR DESCRIPTION
## What

`filing_events.items[]` was universe-wide NULL on 8-K rows; `dividend_events` was empty.

The bug was structural, not parser-side. `_run_cik_upsert` extracted entity profile + 8-K items inside an `else` branch that only fired on the seed / first-time-refresh path. The planner always supplied `known_top_accession` on the steady-state refresh / submissions-only paths and discarded the submissions body, so both extractions silently skipped on every refresh after the first one.

## Why

- 480k+ existing 8-K rows had `items=NULL`, blocking `dividend_calendar.ingest_dividend_events` (selector requires `'8.01' = ANY(fe.items)`) → zero `dividend_events` ever.
- Per-item filings filter UX rendered nothing because items[] was always NULL.
- Same defect silently affected the entity-profile upsert (#427) — staleness assumption "converges on next seed cycle" was empirically false because seeds happen once.

## How

1. `RefreshPlan.submissions_by_cik`: planner keeps the fetched `submissions.json` body alive for refresh / submissions-only / stale-watermark-backfill paths. Zero new HTTP.
2. `_run_cik_upsert` accepts `known_submissions`. Entity profile + items[] extractions hoisted out of the seed-only `else` into a new `_apply_submissions_extractions` helper that runs on EVERY invocation that has submissions in hand. Helper called inside the per-CIK transaction AFTER the master-index inserts so the items UPDATE has rows to match. Helper's internal `with conn.transaction()` blocks become savepoints under the outer tx — preserves the #439 invariant.
3. `execute_refresh` submissions-only path: also runs extractions, INSIDE the per-CIK transaction BEFORE the watermark commit (Codex flagged a silent-loss window when it was post-commit).
4. Fallback fetch: if a hand-built plan supplies `submissions_only_advances` without a matching `submissions_by_cik` entry, executor falls back to `fetch_submissions`. Real planner output always pairs them, but a silently-skipped extraction is exactly the bug class this PR closes.
5. `scripts/backfill_8k_items.py`: one-shot CLI to re-fetch submissions for every covered CIK and apply items + profile to existing rows. `autocommit=True` so every per-CIK transaction is a durable BEGIN/COMMIT pair (Codex flagged that the implicit outer tx would otherwise roll back the whole sweep on partial failure). Per-CIK exception trap so one bad CIK can't abort the run. Dry-run by default; `--limit/--offset` for resumable slices.

## Test plan

- [x] `uv run pytest tests/test_sec_incremental_planner.py tests/test_sec_incremental_executor.py tests/test_sec_filing_items.py` — 49 pass
- [x] `uv run pytest` — 3006 pass, 1 skip
- [x] `uv run ruff check .` / `ruff format --check` / `pyright` — clean
- [x] Codex checkpoint-2 reviewed; both HIGH findings + 1 residual addressed
- [ ] Post-merge: run `uv run python scripts/backfill_8k_items.py --apply` once to populate items[] + entity profiles for the existing 480k 8-K rows, then verify `SELECT COUNT(*) FILTER (WHERE items IS NOT NULL) FROM filing_events WHERE provider='sec' AND filing_type='8-K'` is non-zero
- [ ] Post-backfill: confirm `dividend_calendar` ingest tick produces non-zero `dividend_events` rows

## Security model

No new HTTP per ingest run (planner-fed body); SEC fair-use rate limit unchanged. The backfill script reuses `SecFilingsProvider`'s shared process-wide rate limiter so it cannot burst past 10 req/s. No user-supplied input.

## Settled decisions

- Provider boundary: extractions stay in services, not providers — preserved.
- Filing identity provider-scoped: dashed accession on both write paths — unchanged.
- Persist structured evidence: items[] is the evidence backing dividend ingest + per-item filings filter — restored.

## Trade-offs

- The submissions body is now held in memory across the planner→executor handoff for every refresh CIK in a run. Per-CIK ~100KB × ~hundreds of CIKs/run ≈ tens of MB peak. Acceptable; alternative was re-fetching, which doubles SEC traffic.
- One-shot backfill required for the 480k existing rows — chose explicit operator-triggered CLI over auto-on-boot to match eBull's "deterministic execution + auditable" posture.

Closes #675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)