### PR TITLE
fix(#682): re-include DistributionsPerLimitedPartnershipUnitOutstanding

### DIFF
--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -152,26 +152,25 @@ TRACKED_CONCEPTS: dict[str, tuple[str, ...]] = {
     # in ``USD/shares`` units which the existing ``_UNIT_PRIORITY``
     # list already covers, so no unit-priority change is needed.
     #
-    # Excluded deliberately: ``DistributionsPerLimitedPartnership
-    # UnitOutstanding`` is an FY-cumulative concept that issuers
-    # report on the 10-K alongside prior-year comparatives. SEC's
-    # companyfacts emits the SAME period_end row under multiple
-    # ``fy`` contexts (the 10-K's filing year stamps every prior
-    # comparative). The normaliser keys on ``(fy, fp)`` rather than
-    # ``period_end``, so a 2026-filed 10-K's IEP row for 2023 (val
-    # = $6.00) lands as "fy=2025, fp=FY" alongside the actual 2025
-    # row, and `_canonical_merge` then derives a wrong Q4 = FY −
-    # YTD = $6 − $1.50 = $4.50. Tracked at #682 as a normaliser
-    # bug; until that lands, this concept's downside (wrong values)
-    # outweighs its upside (FY summary line for issuers that don't
-    # emit the primary concept). The primary
-    # ``DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit``
-    # already covers per-quarter for IEP / EPD / current-era MLPs.
+    # ``DistributionsPerLimitedPartnershipUnitOutstanding`` is an
+    # FY-cumulative concept that issuers report on the 10-K alongside
+    # prior-year comparatives. SEC's companyfacts re-stamps the SAME
+    # XBRL fact under multiple ``(fy, fp)`` contexts (the 10-K's
+    # filing year stamps every prior comparative). Pre-#682 the
+    # normaliser keyed on ``(fy, fp)`` and picked the EARLIEST
+    # period_end's value as canonical (e.g. IEP's 2023 $6.00 row),
+    # which then drove a wrong Q4 = FY − YTD = $4.50 in
+    # ``_canonical_merge``. #682 (PR #721) fixed this by filtering
+    # value attribution to facts whose ``period_end`` matches the
+    # canonical max for the group, so this concept is safe to
+    # re-include now as a last-priority fallback for FY summary on
+    # issuers that don't emit the primary per-quarter concept.
     "dps_declared": (
         "CommonStockDividendsPerShareDeclared",
         "DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit",
         "DistributionMadeToMemberOrLimitedPartnerDistributionsDeclaredPerUnit",
         "DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsDeclaredPerUnit",
+        "DistributionsPerLimitedPartnershipUnitOutstanding",
     ),
     # Cash actually distributed per share (often differs from declared
     # by a quarter). Captured separately so dividend-capture strategies

--- a/tests/test_xbrl_fact_extraction.py
+++ b/tests/test_xbrl_fact_extraction.py
@@ -358,18 +358,11 @@ class TestPartnershipDistributionConcepts:
         assert facts[0].val == Decimal("0.5")
         assert facts[0].unit == "USD/shares"
 
-    def test_lp_legacy_distributions_per_unit_outstanding_excluded(self) -> None:
-        # ``DistributionsPerLimitedPartnershipUnitOutstanding`` is
-        # deliberately NOT in the ``dps_declared`` allowlist (#682).
-        # SEC's companyfacts emits this FY-cumulative concept under
-        # multiple ``fy`` contexts when 10-K filings include prior-
-        # year comparatives, and the canonical normaliser keys on
-        # ``(fy, fp)`` not ``period_end`` — so a 2023 historical row
-        # restamped with the filing's 2025 fy lands as "FY 2025"
-        # and corrupts the chart. Until the normaliser is fixed
-        # (#682), this concept stays out and the primary
-        # ``DistributionMadeToLimitedPartnerDistributionsDeclaredPer
-        # Unit`` carries the load.
+    def test_lp_legacy_distributions_per_unit_outstanding_extracted(self) -> None:
+        # #682 (PR #721) fixed the normaliser's prior-year-comparative
+        # re-stamping bug, so this FY-cumulative concept is now safely
+        # included as a last-priority ``dps_declared`` fallback for
+        # issuers that don't emit the primary per-quarter concept.
         gaap = {
             "DistributionsPerLimitedPartnershipUnitOutstanding": {
                 "units": {
@@ -380,7 +373,9 @@ class TestPartnershipDistributionConcepts:
             }
         }
         facts = _extract_facts_from_gaap(gaap)
-        assert facts == []
+        assert len(facts) == 1
+        assert facts[0].concept == "DistributionsPerLimitedPartnershipUnitOutstanding"
+        assert facts[0].val == Decimal("1.25")
 
     def test_lp_cash_distributions_paid_per_unit_extracted(self) -> None:
         gaap = {
@@ -508,14 +503,21 @@ class TestPartnershipDistributionAliasing:
         assert corp_prio == 0
         assert prio > corp_prio
 
-    def test_lp_legacy_per_unit_NOT_in_alias_map(self) -> None:
-        # See test_lp_legacy_distributions_per_unit_outstanding_excluded
-        # — this concept is intentionally absent from TRACKED_CONCEPTS
-        # to prevent SEC's prior-year-comparative re-stamping bug
-        # from corrupting the chart (#682).
+    def test_lp_legacy_per_unit_aliases_to_dps_declared_lowest_priority(self) -> None:
+        # #682 (PR #721) fixed the normaliser's prior-year-comparative
+        # re-stamping bug, so this concept is now safe to include as a
+        # last-priority fallback for FY summary on issuers that don't
+        # emit the primary per-quarter concept.
         from app.services.fundamentals import _TAG_TO_COLUMN
 
-        assert "DistributionsPerLimitedPartnershipUnitOutstanding" not in _TAG_TO_COLUMN
+        assert "DistributionsPerLimitedPartnershipUnitOutstanding" in _TAG_TO_COLUMN
+        col, prio = _TAG_TO_COLUMN["DistributionsPerLimitedPartnershipUnitOutstanding"]
+        assert col == "dps_declared"
+        # Must be lowest priority (highest index) — primary per-quarter
+        # concepts take precedence when present.
+        primary_col, primary_prio = _TAG_TO_COLUMN["DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit"]
+        assert primary_col == "dps_declared"
+        assert prio > primary_prio
 
     def test_lp_cash_paid_per_unit_aliases_to_dps_cash_paid(self) -> None:
         from app.services.fundamentals import _TAG_TO_COLUMN


### PR DESCRIPTION
## What

Reverts the workaround from #673 that excluded `DistributionsPerLimitedPartnershipUnitOutstanding` from the `dps_declared` allowlist.

## Why

PR #721 fixed the underlying normaliser bug (prior-year comparative re-stamping). The workaround's only purpose was to avoid that bug. With the bug fixed, the FY-cumulative concept can be safely re-included as a last-priority fallback for issuers that don't emit the primary per-quarter concept.

## How

- Added the concept to `dps_declared` aliases as the lowest-priority entry.
- Updated the corresponding test from `..._excluded` (asserting absent) to `..._extracted` (asserting extracted at last-priority).

## Test plan

- [x] `pytest tests/test_xbrl_fact_extraction.py tests/test_financial_normalization.py` — 57 pass
- [x] ruff/format/pyright — clean
- [ ] Post-merge: re-derive IEP financial_periods (`normalize_financial_periods` for instrument_id=1571) and verify FY 2025 dps_declared = $2.00 and Q4 2025 = $0.50 — proves the #682 fix end-to-end

## Trade-offs

The concept is FY-cumulative. Issuers that emit ONLY this concept (no primary per-quarter) will get FY rows populated but quarterly rows derive Q4 = FY − YTD. Issuers that emit BOTH have the per-quarter primary win at higher priority; the FY-cumulative is just a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)