### PR TITLE
fix: disable filing_documents ingest — 100% broken, burning SEC bandwidth (#723)

### DIFF
--- a/app/services/filing_documents.py
+++ b/app/services/filing_documents.py
@@ -229,99 +229,34 @@ def ingest_filing_documents(
     """Scan ``filing_events`` for accessions missing any
     ``filing_documents`` children, fetch the index JSON, upsert.
 
-    Candidate selector:
+    Currently disabled (#723). Returns immediately with zero counts.
 
-    1. ``fe.provider = 'sec'`` — only SEC filings carry an index
-       JSON in this shape.
-    2. No existing ``filing_documents`` row for the filing_event_id.
-    3. Ordered by filing_date DESC so fresh filings always get
-       budget; historical backlog drains via the scheduler's
-       continuous tick.
+    Two independent bugs make the live path 100% broken:
 
-    Bounded per run (``limit=500``). The index JSON is small (~2 KB
-    typical) so the rate-limit cost is modest even on a large
-    backlog tick.
+    1. URL builder targets ``{accession}-index.json`` but SEC's actual
+       canonical manifest at that path is ``/index.json`` (no
+       accession prefix). Every fetch 404s.
+    2. ``parse_filing_index`` expects a top-level ``items: [...]``
+       shape that SEC has never returned for this endpoint — the real
+       response is ``{"directory": {"item": [...]}}`` with different
+       per-item fields.
+
+    ``filing_documents`` is empty in production (0 rows) and no
+    consumer reads from it, so disabling the ingest is a zero-impact
+    stop-the-bleeding step. The hourly schedule was burning ~50s of
+    SEC rate budget per tick on 404s. Re-enable in the rework PR
+    that fixes the URL + parser together.
     """
-    conn.commit()
-
-    candidates: list[tuple[int, str]] = []
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            SELECT fe.filing_event_id, fe.provider_filing_id
-            FROM filing_events fe
-            LEFT JOIN filing_documents fd
-                ON fd.filing_event_id = fe.filing_event_id
-            WHERE fe.provider = 'sec'
-              AND fd.id IS NULL
-            GROUP BY fe.filing_event_id, fe.provider_filing_id, fe.filing_date
-            ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
-            LIMIT %s
-            """,
-            (limit,),
-        )
-        for row in cur.fetchall():
-            candidates.append((int(row[0]), str(row[1])))
-    conn.commit()
-
-    filings_parsed = 0
-    documents_inserted = 0
-    fetch_errors = 0
-    parse_misses = 0
-
-    for filing_event_id, accession in candidates:
-        try:
-            raw = fetcher.fetch_filing_index(accession)
-        except Exception:
-            logger.warning(
-                "ingest_filing_documents: fetch failed accession=%s",
-                accession,
-                exc_info=True,
-            )
-            fetch_errors += 1
-            continue
-        if raw is None:
-            fetch_errors += 1
-            continue
-
-        docs = parse_filing_index(raw, accession_number=accession)
-        if not docs:
-            parse_misses += 1
-            continue
-
-        try:
-            upsert_filing_documents(
-                conn,
-                filing_event_id=filing_event_id,
-                accession_number=accession,
-                documents=docs,
-            )
-            conn.commit()
-        except Exception:
-            conn.rollback()
-            logger.warning(
-                "ingest_filing_documents: upsert failed accession=%s",
-                accession,
-                exc_info=True,
-            )
-            continue
-
-        filings_parsed += 1
-        documents_inserted += len(docs)
-
-    logger.info(
-        "ingest_filing_documents: parser_version=%d scanned=%d parsed=%d",
-        _PARSER_VERSION,
-        len(candidates),
-        filings_parsed,
-    )
-
+    # Touch params so unused-argument lints don't fire while the
+    # function body is stubbed pending #723.
+    del conn, fetcher, limit
+    logger.info("ingest_filing_documents: DISABLED pending rewrite (#723) — see filing_documents.py docstring")
     return IngestResult(
-        filings_scanned=len(candidates),
-        filings_parsed=filings_parsed,
-        documents_inserted=documents_inserted,
-        fetch_errors=fetch_errors,
-        parse_misses=parse_misses,
+        filings_scanned=0,
+        filings_parsed=0,
+        documents_inserted=0,
+        fetch_errors=0,
+        parse_misses=0,
     )
 
 

--- a/tests/test_filing_documents_ingest.py
+++ b/tests/test_filing_documents_ingest.py
@@ -12,7 +12,12 @@ from app.services.filing_documents import (
     list_filing_documents,
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    # Path disabled pending #723 rewrite (URL builder + parser shape
+    # both wrong — current code 100% 404s in production).
+    pytest.mark.skip(reason="ingest_filing_documents disabled pending #723"),
+]
 
 
 class _StubIndexFetcher:


### PR DESCRIPTION
## What

Stop the hourly \`sec_filing_documents_ingest\` job from burning ~50s of SEC rate budget on pure 404s.

## Why

Operator surfaced 404 spam in the live log:

\`\`\`
GET https://www.sec.gov/Archives/edgar/data/1159036/000115903626000053/000115903626000053-index.json 404
GET https://www.sec.gov/Archives/edgar/data/1652044/000165204426000048/000165204426000048-index.json 404
GET https://www.sec.gov/Archives/edgar/data/1628280/000162828026028601/000162828026028601-index.json 404
GET https://www.sec.gov/Archives/edgar/data/1628280/000162828026028605/000162828026028605-index.json 404
\`\`\`

Two independent bugs make this path 100% broken:

1. **URL is wrong**. Code targets \`/{accession}-index.json\` but SEC's canonical manifest at that path is \`/index.json\` (no accession prefix). Verified empirically against multiple recent filings — both the dashed and no-dashes \`{accession}-index.json\` forms 404; only \`/index.json\` returns 200.
2. **Parser shape is wrong**. \`parse_filing_index\` expects top-level \`items: [...]\` with rich per-item fields. Real SEC response is \`{"directory": {"item": [...]}}\` with different fields and no \`cik\` / \`primaryDocument\` at top level.

Production state: \`SELECT COUNT(*) FROM filing_documents\` → **0 rows** vs 3.5M \`filing_events\`. The path has never worked.

## How

- \`ingest_filing_documents\` body replaced with an early-return + DISABLED log. Schedule still fires (no scheduler config change), but produces zero SEC traffic.
- Tests for the disabled path marked skip pending #723.
- Comprehensive root-cause + rewrite plan filed at #723.

## Trade-offs

- **Zero functional regression**: \`filing_documents\` is empty in prod and nothing reads from it.
- **Bandwidth saved**: 500 wasted SEC requests/hour → 0.
- **Tech debt acknowledged**: rewrite tracked at #723 — needs URL change + parser rewrite for the real \`directory.item\` shape, plus a fixture captured from a recent real SEC filing.

## Test plan

- [x] \`pytest tests/test_filing_documents.py tests/test_filing_documents_ingest.py\` — 8 pass, 4 skip (the disabled-path tests)
- [x] ruff/format/pyright clean
- [x] Verified production state via DB: 0 rows
- [x] Verified URL/parser bugs empirically against live SEC

🤖 Generated with [Claude Code](https://claude.com/claude-code)