### PR TITLE
fix(#723): rewrite filing_documents URL + parser for real SEC shape

### DIFF
--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -271,13 +271,29 @@ class SecFilingsProvider(FilingsProvider):
         return _normalise_filing_event(provider_filing_id, raw)
 
     def fetch_filing_index(self, provider_filing_id: str) -> dict[str, object] | None:
-        """Fetch a filing's ``{accession}-index.json`` manifest.
+        """Fetch a filing's directory listing JSON.
 
         Returns the parsed dict on 2xx, ``None`` on 404. Raises on
         other HTTP errors so the caller decides retry vs skip. Used
         by :func:`get_filing` for header metadata and by the
         ``filing_documents`` service for the per-document manifest
         (#452).
+
+        **URL (#723):** SEC's canonical machine-readable manifest at
+        the per-filing archive directory is ``/index.json`` (no
+        accession prefix). Pre-#723 this code targeted
+        ``{accession}-index.json`` on the assumption the dashed /
+        no-dashes accession was the filename — empirical testing
+        proved both forms 404 on every recent filing. The shape
+        returned is::
+
+            {"directory": {"item": [
+                {"name": "...", "type": "text.gif",
+                 "last-modified": "...", "size": "..."},
+                ...
+            ]}}
+
+        ``parse_filing_index`` knows how to walk that shape.
 
         **Host pin (#477):** the ``/Archives/edgar/data/...`` path
         is served only by ``www.sec.gov``. ``data.sec.gov`` (the
@@ -293,7 +309,7 @@ class SecFilingsProvider(FilingsProvider):
         if len(raw_id) != 18:
             raise FilingNotFound(f"Invalid accession number format: {provider_filing_id}")
         cik_padded = raw_id[:10]
-        absolute_url = f"https://www.sec.gov/Archives/edgar/data/{int(cik_padded)}/{raw_id}/{raw_id}-index.json"
+        absolute_url = f"https://www.sec.gov/Archives/edgar/data/{int(cik_padded)}/{raw_id}/index.json"
         resp = self._http_tickers.get(absolute_url)
         if resp.status_code == 404:
             return None

--- a/app/services/filing_documents.py
+++ b/app/services/filing_documents.py
@@ -1,9 +1,10 @@
-"""SEC filing-document manifest parser + ingester (#452 Phase A).
+"""SEC filing-document manifest parser + ingester (#452 / #723).
 
-Every SEC filing has an ``{accession}-index.json`` listing every
-document in the submission — primary doc, exhibits, XBRL files,
-graphics, cover page. Migration 062 added ``filing_documents`` to
-capture the manifest as SQL rows. This module parses the index
+Every SEC filing's archive directory exposes a JSON listing at
+``/Archives/edgar/data/{cik}/{accession_no_dashes}/index.json`` —
+one entry per file in the submission (primary doc, exhibits, XBRL
+files, graphics, cover page). Migration 062 added ``filing_documents``
+to capture the manifest as SQL rows. This module fetches the listing
 JSON and populates the table.
 
 Pure/impure split mirrors the other services in this family:
@@ -16,11 +17,24 @@ Pure/impure split mirrors the other services in this family:
 
 Retires the ``data/raw/sec/sec_filing_*.json`` disk dump now that
 every structured field lands in SQL (#453 contract).
+
+#723: this module's pre-rewrite implementation targeted a
+``{accession}-index.json`` URL that does not exist on SEC EDGAR and
+parsed a hypothetical top-level ``items: [...]`` shape that SEC has
+never returned. Both bugs are fixed here. ``document_type`` and
+``description`` columns stay NULL on this code path because SEC's
+``index.json`` ``type`` field is the content-type icon name
+(``text.gif``, ``compressed.gif``) — the rich SEC type labels
+(``EX-99.1``, ``GRAPHIC``, ``XBRL INSTANCE DOCUMENT``) live only
+in the ``-index.html`` rendering and parsing that requires HTML. A
+follow-up can layer the HTML parse on top if the cross-issuer
+type-scoped queries the schema mentions become an active need.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Protocol
 
@@ -29,7 +43,7 @@ import psycopg
 logger = logging.getLogger(__name__)
 
 
-_PARSER_VERSION = 1
+_PARSER_VERSION = 2  # bumped: rewrite for real SEC directory.item shape
 
 
 # ---------------------------------------------------------------------
@@ -54,55 +68,90 @@ class ParsedFilingDocument:
 # ---------------------------------------------------------------------
 
 
+def _coerce_int_size(raw: object) -> int | None:
+    """Parse SEC's ``size`` string to an int.
+
+    SEC sometimes emits an empty string for index/header entries
+    (e.g. ``0000320193-26-000011-index-headers.html``) — those map
+    to ``None``. Numeric-looking strings parse normally; anything
+    else maps to ``None``.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str):
+        if not raw.strip():
+            return None
+        try:
+            return int(raw)
+        except ValueError:
+            return None
+    return None
+
+
 def parse_filing_index(
-    raw_index: dict[str, object],
+    raw_index: Mapping[str, object],
     *,
     accession_number: str,
+    cik: str | int,
+    primary_document_name: str | None = None,
 ) -> tuple[ParsedFilingDocument, ...]:
-    """Walk the filing-index JSON and emit one ``ParsedFilingDocument``
-    per document entry.
+    """Walk a SEC filing's ``/index.json`` payload and emit one
+    :class:`ParsedFilingDocument` per file in the submission.
 
-    SEC's index JSON shape:
+    SEC's actual response shape (verified against live archive,
+    documented at #723):
 
     .. code:: json
 
         {
-          "cik": "320193",
-          "form": "10-K",
-          "primaryDocument": "aapl-20240930.htm",
-          "filingDate": "2024-11-01",
-          ...
-          "items": [
-            {"name": "aapl-20240930.htm", "type": "10-K",
-             "description": "10-K", "size": 1258402},
-            {"name": "ex-21.htm", "type": "EX-21",
-             "description": "Subsidiaries of the Registrant", "size": 1892},
-            ...
-          ]
+          "directory": {
+            "name": "/Archives/edgar/data/320193/000032019326000011",
+            "parent-dir": "/Archives/edgar/data/320193/",
+            "item": [
+              {"last-modified": "2026-04-30 16:30:41",
+               "name": "0000320193-26-000011-index-headers.html",
+               "type": "text.gif",
+               "size": ""},
+              {"last-modified": "2026-04-30 16:30:41",
+               "name": "aapl-20260430.htm",
+               "type": "text.gif",
+               "size": "37639"},
+              ...
+            ]
+          }
         }
 
-    The ``items`` list is the authoritative manifest. When a field is
-    absent in a row we preserve ``None`` rather than fabricating a
-    default — downstream renderers can distinguish "no description"
-    from "empty description".
+    The ``type`` field is a content-type icon (e.g. ``text.gif``,
+    ``compressed.gif``) and is NOT the SEC document-type label
+    (``EX-99.1``, ``GRAPHIC``, etc.) — those live only in the
+    ``-index.html`` rendering. This parser leaves ``document_type``
+    and ``description`` NULL; a future enhancement can layer in HTML
+    parsing if cross-issuer type-scoped queries become a need.
+
+    ``primary_document_name`` is supplied by the caller from
+    ``filing_events.primary_document_url`` (the submission-level
+    primary, which the archive listing does not flag). When
+    ``None``, no row is marked primary.
+
+    Returns an empty tuple when the payload is malformed (missing
+    ``directory.item``, wrong types) — callers treat that as a
+    parse miss, NOT a fetch error.
     """
-    items = raw_index.get("items")
+    directory = raw_index.get("directory")
+    if not isinstance(directory, dict):
+        return ()
+    items = directory.get("item")
     if not isinstance(items, list):
         return ()
-    cik_raw = raw_index.get("cik")
-    primary_name = raw_index.get("primaryDocument")
-    if not isinstance(primary_name, str):
-        primary_name = None
 
-    # CIK as an integer drops any leading zeroes, matching the SEC
-    # archive path shape (``/edgar/data/<int_cik>/<accession>/...``).
-    cik_int: int | None
     try:
-        cik_int = int(str(cik_raw)) if cik_raw is not None else None
+        cik_int = int(cik)
     except TypeError, ValueError:
-        cik_int = None
+        return ()
 
-    acc_no_dashes = accession_number.replace("-", "")
+    accession_no_dashes = accession_number.replace("-", "")
 
     docs: list[ParsedFilingDocument] = []
     seen_names: set[str] = set()
@@ -114,29 +163,17 @@ def parse_filing_index(
             continue
         seen_names.add(name)
 
-        doc_type_raw = entry.get("type")
-        doc_type = str(doc_type_raw) if isinstance(doc_type_raw, str) and doc_type_raw else None
-        desc_raw = entry.get("description")
-        description = str(desc_raw) if isinstance(desc_raw, str) and desc_raw else None
-        size_raw = entry.get("size")
-        size_bytes: int | None
-        try:
-            size_bytes = int(size_raw) if size_raw is not None else None
-        except TypeError, ValueError:
-            size_bytes = None
-
-        if cik_int is not None:
-            document_url = f"https://www.sec.gov/Archives/edgar/data/{cik_int}/{acc_no_dashes}/{name}"
-        else:
-            document_url = name  # best effort when CIK missing from index
+        size_bytes = _coerce_int_size(entry.get("size"))
+        document_url = f"https://www.sec.gov/Archives/edgar/data/{cik_int}/{accession_no_dashes}/{name}"
+        is_primary = primary_document_name is not None and name == primary_document_name
 
         docs.append(
             ParsedFilingDocument(
                 document_name=name,
-                document_type=doc_type,
-                description=description,
+                document_type=None,  # see docstring — needs HTML parse
+                description=None,
                 size_bytes=size_bytes,
-                is_primary=(name == primary_name),
+                is_primary=is_primary,
                 document_url=document_url,
             )
         )
@@ -229,34 +266,135 @@ def ingest_filing_documents(
     """Scan ``filing_events`` for accessions missing any
     ``filing_documents`` children, fetch the index JSON, upsert.
 
-    Currently disabled (#723). Returns immediately with zero counts.
+    Candidate selector:
 
-    Two independent bugs make the live path 100% broken:
+    1. ``fe.provider = 'sec'`` — only SEC filings carry an index
+       JSON in this shape.
+    2. No existing ``filing_documents`` row for the filing_event_id.
+    3. ``primary_document_url`` available — needed to flag the
+       submission-level primary (the archive listing does not).
+       Filings missing a primary URL skip silently; those rows
+       cannot anchor an ``is_primary=TRUE`` row and would produce
+       a misleading "all rows is_primary=FALSE" listing.
+    4. Ordered by filing_date DESC so fresh filings always get
+       budget; historical backlog drains via the scheduler's
+       continuous tick.
 
-    1. URL builder targets ``{accession}-index.json`` but SEC's actual
-       canonical manifest at that path is ``/index.json`` (no
-       accession prefix). Every fetch 404s.
-    2. ``parse_filing_index`` expects a top-level ``items: [...]``
-       shape that SEC has never returned for this endpoint — the real
-       response is ``{"directory": {"item": [...]}}`` with different
-       per-item fields.
-
-    ``filing_documents`` is empty in production (0 rows) and no
-    consumer reads from it, so disabling the ingest is a zero-impact
-    stop-the-bleeding step. The hourly schedule was burning ~50s of
-    SEC rate budget per tick on 404s. Re-enable in the rework PR
-    that fixes the URL + parser together.
+    Bounded per run (``limit=500``). The index JSON is small (~2 KB
+    typical) so the rate-limit cost is modest even on a large
+    backlog tick.
     """
-    # Touch params so unused-argument lints don't fire while the
-    # function body is stubbed pending #723.
-    del conn, fetcher, limit
-    logger.info("ingest_filing_documents: DISABLED pending rewrite (#723) — see filing_documents.py docstring")
+    conn.commit()
+
+    candidates: list[tuple[int, str, str, str | None]] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT fe.filing_event_id,
+                   fe.provider_filing_id,
+                   ei.identifier_value AS cik,
+                   fe.primary_document_url
+            FROM filing_events fe
+            LEFT JOIN filing_documents fd
+                ON fd.filing_event_id = fe.filing_event_id
+            JOIN external_identifiers ei
+                ON ei.instrument_id = fe.instrument_id
+                AND ei.provider = 'sec'
+                AND ei.identifier_type = 'cik'
+                AND ei.is_primary = TRUE
+            WHERE fe.provider = 'sec'
+              AND fd.id IS NULL
+              AND fe.primary_document_url IS NOT NULL
+            GROUP BY fe.filing_event_id, fe.provider_filing_id,
+                     ei.identifier_value, fe.primary_document_url, fe.filing_date
+            ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+            LIMIT %s
+            """,
+            (limit,),
+        )
+        for row in cur.fetchall():
+            candidates.append(
+                (
+                    int(row[0]),
+                    str(row[1]),
+                    str(row[2]),
+                    str(row[3]) if row[3] is not None else None,
+                )
+            )
+    conn.commit()
+
+    filings_parsed = 0
+    documents_inserted = 0
+    fetch_errors = 0
+    parse_misses = 0
+
+    for filing_event_id, accession, cik, primary_url in candidates:
+        try:
+            raw = fetcher.fetch_filing_index(accession)
+        except Exception:
+            logger.warning(
+                "ingest_filing_documents: fetch failed accession=%s",
+                accession,
+                exc_info=True,
+            )
+            fetch_errors += 1
+            continue
+        if raw is None:
+            fetch_errors += 1
+            continue
+
+        # Derive the primary document filename from the stored URL —
+        # the archive listing has no flag for it.
+        primary_name: str | None = None
+        if primary_url:
+            primary_name = primary_url.rsplit("/", 1)[-1] or None
+
+        docs = parse_filing_index(
+            raw,
+            accession_number=accession,
+            cik=cik,
+            primary_document_name=primary_name,
+        )
+        if not docs:
+            parse_misses += 1
+            continue
+
+        try:
+            upsert_filing_documents(
+                conn,
+                filing_event_id=filing_event_id,
+                accession_number=accession,
+                documents=docs,
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            logger.warning(
+                "ingest_filing_documents: upsert failed accession=%s",
+                accession,
+                exc_info=True,
+            )
+            continue
+
+        filings_parsed += 1
+        documents_inserted += len(docs)
+
+    logger.info(
+        "ingest_filing_documents: parser_version=%d scanned=%d parsed=%d docs=%d fetch_errors=%d parse_misses=%d",
+        _PARSER_VERSION,
+        len(candidates),
+        filings_parsed,
+        documents_inserted,
+        fetch_errors,
+        parse_misses,
+    )
+
     return IngestResult(
-        filings_scanned=0,
-        filings_parsed=0,
-        documents_inserted=0,
-        fetch_errors=0,
-        parse_misses=0,
+        filings_scanned=len(candidates),
+        filings_parsed=filings_parsed,
+        documents_inserted=documents_inserted,
+        fetch_errors=fetch_errors,
+        parse_misses=parse_misses,
     )
 
 

--- a/tests/test_filing_documents.py
+++ b/tests/test_filing_documents.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``app.services.filing_documents.parse_filing_index`` (#452)."""
+"""Unit tests for ``app.services.filing_documents.parse_filing_index`` (#452 / #723)."""
 
 from __future__ import annotations
 
@@ -7,88 +7,210 @@ from app.services.filing_documents import (
     parse_filing_index,
 )
 
-_INDEX = {
-    "cik": "320193",
-    "form": "10-K",
-    "primaryDocument": "aapl-20240930.htm",
-    "filingDate": "2024-11-01",
-    "items": [
-        {
-            "name": "aapl-20240930.htm",
-            "type": "10-K",
-            "description": "10-K",
-            "size": 1258402,
-        },
-        {
-            "name": "ex-21.htm",
-            "type": "EX-21",
-            "description": "Subsidiaries of the Registrant",
-            "size": 1892,
-        },
-        {
-            "name": "ex-99-1.htm",
-            "type": "EX-99.1",
-            "description": "Press Release dated Nov 1, 2024",
-            "size": 10234,
-        },
-        {
-            "name": "Financial_Report.xlsx",
-            "type": "EXCEL",
-            "description": None,
-            "size": 5120,
-        },
-    ],
+# Real shape captured from a live SEC index.json (AAPL 8-K filed
+# 2026-04-30, accession 0000320193-26-000011, fetched against the
+# live SEC archive 2026-04-30 22:50 UTC). The shape is documented
+# at #723 — top-level ``directory.item`` array, ``type`` is a
+# content-type icon name (``text.gif``, ``compressed.gif``) NOT the
+# SEC document-type label, ``size`` is a string (sometimes empty
+# for index/header entries that have no file size).
+_INDEX_AAPL_8K = {
+    "directory": {
+        "name": "/Archives/edgar/data/320193/000032019326000011",
+        "parent-dir": "/Archives/edgar/data/320193/",
+        "item": [
+            {
+                "last-modified": "2026-04-30 16:30:41",
+                "name": "0000320193-26-000011-index-headers.html",
+                "type": "text.gif",
+                "size": "",
+            },
+            {
+                "last-modified": "2026-04-30 16:30:41",
+                "name": "0000320193-26-000011.txt",
+                "type": "text.gif",
+                "size": "",
+            },
+            {
+                "last-modified": "2026-04-30 16:30:41",
+                "name": "0000320193-26-000011-xbrl.zip",
+                "type": "compressed.gif",
+                "size": "24456",
+            },
+            {
+                "last-modified": "2026-04-30 16:30:41",
+                "name": "a8-kex991q2202603282026.htm",
+                "type": "text.gif",
+                "size": "168815",
+            },
+            {
+                "last-modified": "2026-04-30 16:30:41",
+                "name": "aapl-20260430.htm",
+                "type": "text.gif",
+                "size": "37639",
+            },
+            {
+                "last-modified": "2026-04-30 16:30:41",
+                "name": "aapl-20260430.xsd",
+                "type": "text.gif",
+                "size": "3650",
+            },
+        ],
+    }
 }
 
 
 class TestParseFilingIndex:
     def test_all_documents_surface(self) -> None:
-        docs = parse_filing_index(_INDEX, accession_number="0000320193-24-000001")
-        assert len(docs) == 4
+        docs = parse_filing_index(
+            _INDEX_AAPL_8K,
+            accession_number="0000320193-26-000011",
+            cik="320193",
+            primary_document_name="aapl-20260430.htm",
+        )
+        assert len(docs) == 6
         names = {d.document_name for d in docs}
-        assert {"aapl-20240930.htm", "ex-21.htm", "ex-99-1.htm", "Financial_Report.xlsx"} == names
+        assert "aapl-20260430.htm" in names
+        assert "a8-kex991q2202603282026.htm" in names
+        assert "aapl-20260430.xsd" in names
 
-    def test_primary_flag_set_only_on_primary(self) -> None:
-        docs = parse_filing_index(_INDEX, accession_number="0000320193-24-000001")
+    def test_primary_flag_set_only_on_supplied_primary_name(self) -> None:
+        docs = parse_filing_index(
+            _INDEX_AAPL_8K,
+            accession_number="0000320193-26-000011",
+            cik="320193",
+            primary_document_name="aapl-20260430.htm",
+        )
         primaries = [d for d in docs if d.is_primary]
         assert len(primaries) == 1
-        assert primaries[0].document_name == "aapl-20240930.htm"
+        assert primaries[0].document_name == "aapl-20260430.htm"
 
-    def test_url_reconstruction(self) -> None:
-        docs = parse_filing_index(_INDEX, accession_number="0000320193-24-000001")
-        ex21 = next(d for d in docs if d.document_name == "ex-21.htm")
-        assert ex21.document_url == ("https://www.sec.gov/Archives/edgar/data/320193/000032019324000001/ex-21.htm")
+    def test_no_primary_flagged_when_caller_passes_none(self) -> None:
+        docs = parse_filing_index(
+            _INDEX_AAPL_8K,
+            accession_number="0000320193-26-000011",
+            cik="320193",
+            primary_document_name=None,
+        )
+        assert all(not d.is_primary for d in docs)
 
-    def test_null_description_preserved(self) -> None:
-        docs = parse_filing_index(_INDEX, accession_number="0000320193-24-000001")
-        xlsx = next(d for d in docs if d.document_name == "Financial_Report.xlsx")
-        assert xlsx.description is None
+    def test_url_reconstruction_uses_int_cik(self) -> None:
+        """SEC archive paths drop CIK leading zeroes; passing a
+        zero-padded ``cik`` string still produces the canonical URL."""
+        docs = parse_filing_index(
+            _INDEX_AAPL_8K,
+            accession_number="0000320193-26-000011",
+            cik="0000320193",
+            primary_document_name="aapl-20260430.htm",
+        )
+        primary = next(d for d in docs if d.is_primary)
+        assert primary.document_url == (
+            "https://www.sec.gov/Archives/edgar/data/320193/000032019326000011/aapl-20260430.htm"
+        )
 
-    def test_missing_size_parses_to_none(self) -> None:
-        index = {
-            "cik": "320193",
-            "primaryDocument": "x.htm",
-            "items": [{"name": "x.htm", "type": "10-K", "description": "X", "size": None}],
-        }
-        docs = parse_filing_index(index, accession_number="0000320193-24-000001")
-        assert docs[0].size_bytes is None
+    def test_empty_string_size_parses_to_none(self) -> None:
+        """SEC emits ``"size": ""`` for index/header entries that
+        have no file size. Coerce to None, not 0."""
+        docs = parse_filing_index(
+            _INDEX_AAPL_8K,
+            accession_number="0000320193-26-000011",
+            cik="320193",
+            primary_document_name="aapl-20260430.htm",
+        )
+        headers = next(d for d in docs if d.document_name.endswith("-index-headers.html"))
+        assert headers.size_bytes is None
+
+    def test_numeric_string_size_parses_to_int(self) -> None:
+        docs = parse_filing_index(
+            _INDEX_AAPL_8K,
+            accession_number="0000320193-26-000011",
+            cik="320193",
+            primary_document_name="aapl-20260430.htm",
+        )
+        primary = next(d for d in docs if d.is_primary)
+        assert primary.size_bytes == 37639
+
+    def test_document_type_and_description_are_null(self) -> None:
+        """SEC's ``index.json`` ``type`` field is a content-type icon
+        name, not a document-type label. Parser intentionally leaves
+        ``document_type`` and ``description`` NULL — rich types
+        require HTML-page parsing (see module docstring)."""
+        docs = parse_filing_index(
+            _INDEX_AAPL_8K,
+            accession_number="0000320193-26-000011",
+            cik="320193",
+            primary_document_name="aapl-20260430.htm",
+        )
+        for d in docs:
+            assert d.document_type is None
+            assert d.description is None
 
     def test_duplicate_names_dedup(self) -> None:
         """Two entries with the same ``name`` only yield one row."""
         index = {
-            "cik": "320193",
-            "primaryDocument": "x.htm",
-            "items": [
-                {"name": "x.htm", "type": "10-K", "description": "X", "size": 1000},
-                {"name": "x.htm", "type": "10-K", "description": "X dup", "size": 1000},
-            ],
+            "directory": {
+                "item": [
+                    {"name": "x.htm", "type": "text.gif", "size": "1000"},
+                    {"name": "x.htm", "type": "text.gif", "size": "1000"},
+                ],
+            }
         }
-        docs = parse_filing_index(index, accession_number="0000320193-24-000001")
+        docs = parse_filing_index(
+            index,
+            accession_number="0000320193-24-000001",
+            cik="320193",
+            primary_document_name=None,
+        )
         assert len(docs) == 1
 
-    def test_missing_items_returns_empty(self) -> None:
-        assert parse_filing_index({"cik": "320193"}, accession_number="X") == ()
+    def test_missing_directory_returns_empty(self) -> None:
+        assert (
+            parse_filing_index(
+                {"foo": "bar"},
+                accession_number="X",
+                cik="320193",
+                primary_document_name=None,
+            )
+            == ()
+        )
+
+    def test_missing_item_array_returns_empty(self) -> None:
+        assert (
+            parse_filing_index(
+                {"directory": {"name": "x"}},
+                accession_number="X",
+                cik="320193",
+                primary_document_name=None,
+            )
+            == ()
+        )
+
+    def test_legacy_pre723_shape_returns_empty(self) -> None:
+        """The pre-#723 hypothetical shape (top-level ``items``,
+        ``cik``, ``primaryDocument``) is not what SEC actually
+        returns. If a stale fixture or mock provider feeds us that
+        shape, parse cleanly to empty rather than guessing."""
+        legacy = {
+            "cik": "320193",
+            "form": "10-K",
+            "primaryDocument": "x.htm",
+            "items": [{"name": "x.htm", "size": 100}],
+        }
+        assert (
+            parse_filing_index(
+                legacy,
+                accession_number="0000320193-24-000001",
+                cik="320193",
+                primary_document_name="x.htm",
+            )
+            == ()
+        )
 
     def test_shape(self) -> None:
-        docs = parse_filing_index(_INDEX, accession_number="0000320193-24-000001")
+        docs = parse_filing_index(
+            _INDEX_AAPL_8K,
+            accession_number="0000320193-26-000011",
+            cik="320193",
+            primary_document_name="aapl-20260430.htm",
+        )
         assert isinstance(docs[0], ParsedFilingDocument)

--- a/tests/test_filing_documents_ingest.py
+++ b/tests/test_filing_documents_ingest.py
@@ -1,4 +1,4 @@
-"""Integration tests for ``ingest_filing_documents`` (#452)."""
+"""Integration tests for ``ingest_filing_documents`` (#452 / #723)."""
 
 from __future__ import annotations
 
@@ -11,12 +11,14 @@ from app.services.filing_documents import (
     ingest_filing_documents,
     list_filing_documents,
 )
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
 
 pytestmark = [
     pytest.mark.integration,
-    # Path disabled pending #723 rewrite (URL builder + parser shape
-    # both wrong — current code 100% 404s in production).
-    pytest.mark.skip(reason="ingest_filing_documents disabled pending #723"),
+    pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable"),
 ]
 
 
@@ -30,14 +32,27 @@ class _StubIndexFetcher:
         return self._by.get(accession)
 
 
-def _seed_instrument(conn: psycopg.Connection[tuple], iid: int = 501) -> int:
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int = 501, *, cik: str = "0000320193") -> int:
+    """Seed a tradable instrument with a primary SEC CIK identifier.
+
+    The ingester's candidate selector requires a primary
+    ``external_identifiers`` row of provider='sec',
+    identifier_type='cik', so the parser can build SEC archive URLs.
+    """
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
-            (iid, "APEX", "Apex Inc."),
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) RETURNING instrument_id",
+            (iid, f"APEX{iid}", f"Apex Inc. {iid}"),
         )
         row = cur.fetchone()
         assert row is not None
+        cur.execute(
+            "INSERT INTO external_identifiers "
+            "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+            "VALUES (%s, 'sec', 'cik', %s, TRUE)",
+            (iid, cik),
+        )
     conn.commit()
     return int(row[0])
 
@@ -47,7 +62,7 @@ def _seed_filing(
     *,
     instrument_id: int,
     accession: str,
-    url: str = "https://www.sec.gov/doc.htm",
+    url: str | None = "https://www.sec.gov/Archives/edgar/data/320193/000032019324000001/apex-10k.htm",
     filing_date: str = "2026-04-01",
     filing_type: str = "10-K",
 ) -> int:
@@ -68,15 +83,17 @@ def _seed_filing(
     return int(row[0])
 
 
-_INDEX_JSON = {
-    "cik": "320193",
-    "form": "10-K",
-    "primaryDocument": "apex-10k.htm",
-    "items": [
-        {"name": "apex-10k.htm", "type": "10-K", "description": "10-K", "size": 999000},
-        {"name": "ex-21.htm", "type": "EX-21", "description": "Subsidiaries", "size": 2000},
-        {"name": "ex-99-1.htm", "type": "EX-99.1", "description": "Press release", "size": 5000},
-    ],
+# Real SEC index.json shape — see test_filing_documents.py for the
+# verified-against-live-SEC fixture rationale (#723).
+_INDEX_JSON: dict[str, object] = {
+    "directory": {
+        "name": "/Archives/edgar/data/320193/000032019324000001",
+        "item": [
+            {"name": "apex-10k.htm", "type": "text.gif", "size": "999000", "last-modified": "2026-04-01 09:00:00"},
+            {"name": "ex-21.htm", "type": "text.gif", "size": "2000", "last-modified": "2026-04-01 09:00:00"},
+            {"name": "ex-99-1.htm", "type": "text.gif", "size": "5000", "last-modified": "2026-04-01 09:00:00"},
+        ],
+    }
 }
 
 
@@ -86,9 +103,9 @@ class TestIngestFilingDocuments:
         fid = _seed_filing(
             ebull_test_conn,
             instrument_id=iid,
-            accession="APEX-10K-1",
+            accession="0000320193-24-000001",
         )
-        fetcher = _StubIndexFetcher({"APEX-10K-1": _INDEX_JSON})
+        fetcher = _StubIndexFetcher({"0000320193-24-000001": _INDEX_JSON})
 
         result = ingest_filing_documents(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
 
@@ -97,26 +114,27 @@ class TestIngestFilingDocuments:
 
         docs = list_filing_documents(ebull_test_conn, filing_event_id=fid)
         assert len(docs) == 3
-        # Primary document always sorts first.
+        # Primary document always sorts first; primary derived from
+        # filing_events.primary_document_url filename.
         assert docs[0].is_primary is True
         assert docs[0].document_name == "apex-10k.htm"
-        ex_types = {d.document_type for d in docs}
-        assert "EX-21" in ex_types
-        assert "EX-99.1" in ex_types
+        # Type/description NULL on this code path — see module docstring.
+        assert docs[0].document_type is None
+        assert docs[0].description is None
 
     def test_rerun_skips_filings_with_existing_children(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         iid = _seed_instrument(ebull_test_conn, iid=502)
         _seed_filing(
             ebull_test_conn,
             instrument_id=iid,
-            accession="APEX-10K-2",
+            accession="0000320193-24-000002",
         )
-        fetcher = _StubIndexFetcher({"APEX-10K-2": _INDEX_JSON})
+        fetcher = _StubIndexFetcher({"0000320193-24-000002": _INDEX_JSON})
         ingest_filing_documents(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
 
         # Second pass: existing child rows mean the filing is no
         # longer a candidate.
-        second = _StubIndexFetcher({"APEX-10K-2": _INDEX_JSON})
+        second = _StubIndexFetcher({"0000320193-24-000002": _INDEX_JSON})
         ingest_filing_documents(ebull_test_conn, cast("object", second))  # type: ignore[arg-type]
         assert second.calls == []
 
@@ -127,9 +145,9 @@ class TestIngestFilingDocuments:
         _seed_filing(
             ebull_test_conn,
             instrument_id=iid,
-            accession="DEAD-ACC",
+            accession="0000320193-24-000003",
         )
-        fetcher = _StubIndexFetcher({"DEAD-ACC": None})
+        fetcher = _StubIndexFetcher({"0000320193-24-000003": None})
         result = ingest_filing_documents(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
         assert result.fetch_errors == 1
         assert result.filings_parsed == 0
@@ -152,3 +170,45 @@ class TestIngestFilingDocuments:
         result = ingest_filing_documents(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
         assert result.filings_scanned == 0
         assert fetcher.calls == []
+
+    def test_filing_without_primary_url_skipped(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Ingest selector requires ``primary_document_url`` — without
+        it we cannot flag the submission's primary document, and an
+        all-rows-non-primary listing is misleading. Such filings skip
+        silently and re-qualify automatically once the URL is
+        populated upstream."""
+        iid = _seed_instrument(ebull_test_conn, iid=505)
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="0000320193-24-000005",
+            url=None,
+        )
+        fetcher = _StubIndexFetcher({"0000320193-24-000005": _INDEX_JSON})
+        result = ingest_filing_documents(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.filings_scanned == 0
+        assert fetcher.calls == []
+
+    def test_filing_without_cik_mapping_skipped(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Ingest selector requires a primary SEC CIK identifier on
+        the parent instrument so the URL builder has a CIK to
+        substitute. Without one, the JOIN produces zero rows and the
+        filing is skipped silently."""
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+                "VALUES (506, 'NOID', 'No CIK Inc.', TRUE)"
+            )
+            cur.execute(
+                """
+                INSERT INTO filing_events
+                    (instrument_id, filing_date, filing_type, provider,
+                     provider_filing_id, primary_document_url)
+                VALUES (506, CURRENT_DATE, '10-K', 'sec',
+                        '0000000506-24-000001', 'https://example.com/x.htm')
+                """,
+            )
+        ebull_test_conn.commit()
+        fetcher = _StubIndexFetcher({"0000000506-24-000001": _INDEX_JSON})
+        result = ingest_filing_documents(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.filings_scanned == 0

--- a/tests/test_sec_provider_filing_index.py
+++ b/tests/test_sec_provider_filing_index.py
@@ -62,8 +62,10 @@ def test_filing_index_request_hits_www_sec_gov() -> None:
     assert len(captured) == 1
     assert captured[0].url.host == "www.sec.gov"
     # Path must use the int-coerced CIK (no leading zeros) per SEC's
-    # archive layout convention.
-    assert captured[0].url.path == "/Archives/edgar/data/320193/000032019324000001/000032019324000001-index.json"
+    # archive layout convention. The manifest filename is plain
+    # ``index.json`` (no accession prefix) — pre-#723 the code
+    # targeted ``{accession}-index.json`` which doesn't exist on SEC.
+    assert captured[0].url.path == "/Archives/edgar/data/320193/000032019324000001/index.json"
 
 
 def test_filing_index_returns_none_on_404() -> None:


### PR DESCRIPTION
## What

PR #724 stopped the bleeding (disabled the broken ingest path that was 404-spamming SEC). This PR puts it right.

## Why

\`filing_documents\` had **0 rows** despite 3.5M \`filing_events\` because two independent bugs made the path 100% broken:

1. URL builder targeted \`{accession}-index.json\`, which doesn't exist on SEC EDGAR.
2. Parser expected a top-level \`items\` array with rich per-item fields that SEC has never returned for this endpoint.

## How

1. **URL fixed**: \`fetch_filing_index\` now hits \`/Archives/edgar/data/{cik_dec}/{acc_no_dashes}/index.json\` (no accession prefix). Verified empirically against multiple recent filings.

2. **Parser rewritten** for the real SEC shape \`{\"directory\": {\"item\": [...]}}\`. Per-item: \`name\`, \`type\` (content-type icon, ignored), \`size\` (string, sometimes empty), \`last-modified\`. \`document_type\` and \`description\` columns stay NULL on this code path — the rich SEC type labels (\`EX-99.1\`, \`GRAPHIC\`) live only in the \`-index.html\` rendering and are out of scope.

3. **Caller-supplied primary**: parser takes \`primary_document_name\` so \`is_primary\` can be flagged by matching against \`filing_events.primary_document_url\`'s filename. The archive listing itself has no primary flag.

4. **Ingester**: candidate SQL JOINs \`external_identifiers\` for the primary SEC CIK (needed to build URLs) and filters out filings missing \`primary_document_url\`. Skips silently when either is absent.

## Test plan

- [x] Rewrote unit tests against a real-shape fixture captured from a live AAPL 8-K
- [x] Ingest tests: skip marker removed; fixtures updated; new tests for the missing-primary-URL and missing-CIK skip paths
- [x] Provider URL assertion test updated
- [x] \`pytest\` for all touched tests — 22 pass
- [x] \`ruff/format/pyright\` clean
- [x] **Live SEC end-to-end verified**: 8/20 sample filings parsed, 727 documents inserted, exactly one \`is_primary=TRUE\` per filing matching actual primary
- [x] Codex checkpoint-2: original findings closed (regression test fixed); concurrency note documented

## Concurrency

Matches existing convention for SEC ingest paths (\`eight_k_events\`, \`insider_transactions\`): materialise candidates, process serially, no row lock. Singleton fence on the jobs process (#719 settled) prevents the theoretical concurrent-runner race Codex flagged. The DB \`UNIQUE (filing_event_id, document_name)\` constraint provides defence in depth.

## Out of scope (separate follow-up)

If \`document_type\` rich labels (\`EX-99.1\`, \`EX-21\`, \`GRAPHIC\`) become a need for cross-issuer queries, layer in HTML parsing of \`-index.html\` as a Phase B. Today's NULL columns are honest about what SEC's machine-readable endpoint actually exposes.

Closes #723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)