### PR TITLE
feat(#726): bounded-concurrency SEC fetcher — 7.5x throughput

### DIFF
--- a/app/providers/concurrent_fetch.py
+++ b/app/providers/concurrent_fetch.py
@@ -1,0 +1,92 @@
+"""Bounded-concurrency text-fetch helper for SEC ingest paths (#726).
+
+Sequential ``for url in urls: fetch_document_text(url)`` loops are
+bottlenecked by SEC's per-request response time (~700-900ms) rather
+than the rate-limit floor — at ~1 req/s, every SEC ingest job uses
+about 10% of the allowed 10 req/s budget.
+
+This helper runs ``fetch_document_text`` in a ``ThreadPoolExecutor``
+so a single ingest job can keep multiple requests in flight against
+SEC, overlapping response wait time. The shared
+``_PROCESS_RATE_LIMIT_CLOCK`` + ``_PROCESS_RATE_LIMIT_LOCK`` in
+``sec_edgar.py`` keep the aggregate request rate under SEC's
+fair-use ceiling regardless of how many threads are active —
+concurrency overlaps wait time, it does NOT bypass the floor.
+
+Per-future exceptions are caught and surfaced as ``None`` results so
+one bad URL cannot crash the whole batch — callers handle ``None``
+the same way they handle a 404 (typically: tombstone + continue).
+
+Worker count default 8: at 0.11s floor + 800ms response time, 8
+workers is enough to saturate the rate ceiling. More workers wouldn't
+help; fewer would leave throughput on the table.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+from collections.abc import Iterable
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# Default thread count. Bigger isn't better — the floor is the
+# bottleneck above this. Keeps memory + connection-pool pressure
+# bounded.
+DEFAULT_FETCH_WORKERS: int = 8
+
+
+class _TextFetcher(Protocol):
+    def fetch_document_text(self, absolute_url: str) -> str | None: ...
+
+
+def fetch_document_texts(
+    fetcher: _TextFetcher,
+    urls: Iterable[str],
+    *,
+    max_workers: int = DEFAULT_FETCH_WORKERS,
+) -> dict[str, str | None]:
+    """Fetch every URL concurrently and return a ``{url: body}`` map.
+
+    ``body`` is the response text on a 2xx, ``None`` on 404 / fetch
+    error / per-future exception. Callers cannot tell the three
+    apart from the result alone — by convention the failure modes
+    map to the same downstream action (tombstone, skip, or count
+    as ``fetch_errors``).
+
+    Order is NOT preserved; callers index by URL through the
+    returned dict. Duplicate URLs in ``urls`` are de-duplicated
+    before submission so we never spend the rate budget twice on
+    the same document.
+    """
+    unique = list({u for u in urls if u})
+    if not unique:
+        return {}
+
+    workers = max(1, min(max_workers, len(unique)))
+    out: dict[str, str | None] = {}
+
+    def _safe_fetch(url: str) -> tuple[str, str | None]:
+        try:
+            return url, fetcher.fetch_document_text(url)
+        except Exception:
+            # Caller treats None identically to 404 — log once at
+            # WARNING with the URL so the operator can grep without
+            # losing the failure cause.
+            logger.warning(
+                "concurrent_fetch: per-future failure url=%s",
+                url,
+                exc_info=True,
+            )
+            return url, None
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=workers,
+        thread_name_prefix="sec-fetch",
+    ) as pool:
+        for url, body in pool.map(_safe_fetch, unique):
+            out[url] = body
+
+    return out

--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -27,6 +27,7 @@ Provider contract:
 
 import hashlib
 import logging
+import threading
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, time
 from types import TracebackType
@@ -68,6 +69,15 @@ _MIN_REQUEST_INTERVAL_S = 0.11
 # revive when #479 (multi-worker WS subscriber) lands and look
 # at a Postgres advisory-lock token bucket.
 _PROCESS_RATE_LIMIT_CLOCK: list[float] = [0.0]
+
+# Companion lock for ``_PROCESS_RATE_LIMIT_CLOCK`` (#726). Every
+# ``ResilientClient`` instance that shares the clock list must also
+# share this lock so the throttle's read-modify-write of the
+# timestamp is atomic across concurrent fetchers. Without the lock,
+# 8-thread concurrent fetchers could all clear the floor
+# simultaneously and burst SEC's 10 req/s ceiling — triggering UA
+# throttling and cascading 4xx/5xx tombstones.
+_PROCESS_RATE_LIMIT_LOCK: threading.Lock = threading.Lock()
 
 
 def _zero_pad_cik(cik: str | int) -> str:
@@ -204,11 +214,13 @@ class SecFilingsProvider(FilingsProvider):
             self._client,
             min_request_interval_s=_MIN_REQUEST_INTERVAL_S,
             shared_last_request=_PROCESS_RATE_LIMIT_CLOCK,
+            shared_throttle_lock=_PROCESS_RATE_LIMIT_LOCK,
         )
         self._http_tickers = ResilientClient(
             self._tickers_client,
             min_request_interval_s=_MIN_REQUEST_INTERVAL_S,
             shared_last_request=_PROCESS_RATE_LIMIT_CLOCK,
+            shared_throttle_lock=_PROCESS_RATE_LIMIT_LOCK,
         )
 
     def __enter__(self) -> SecFilingsProvider:

--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -46,7 +46,10 @@ from app.providers.fundamentals import (
     XbrlConceptCatalogEntry,
     XbrlFact,
 )
-from app.providers.implementations.sec_edgar import _PROCESS_RATE_LIMIT_CLOCK
+from app.providers.implementations.sec_edgar import (
+    _PROCESS_RATE_LIMIT_CLOCK,
+    _PROCESS_RATE_LIMIT_LOCK,
+)
 from app.providers.resilient_client import ResilientClient
 
 logger = logging.getLogger(__name__)
@@ -392,6 +395,7 @@ class SecFundamentalsProvider(FundamentalsProvider):
             self._client,
             min_request_interval_s=_MIN_REQUEST_INTERVAL_S,
             shared_last_request=_PROCESS_RATE_LIMIT_CLOCK,
+            shared_throttle_lock=_PROCESS_RATE_LIMIT_LOCK,
         )
         # symbol → CIK cache, populated by caller before bulk refresh
         self._cik_cache: dict[str, str] = {}

--- a/app/providers/resilient_client.py
+++ b/app/providers/resilient_client.py
@@ -16,6 +16,7 @@ Single implementation used by all providers — not copy-pasted.
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from collections.abc import Mapping
 from datetime import UTC, datetime
@@ -62,6 +63,7 @@ class ResilientClient:
         max_retries: int = 3,
         backoff_schedule: tuple[float, ...] = _DEFAULT_BACKOFF,
         shared_last_request: list[float] | None = None,
+        shared_throttle_lock: threading.Lock | None = None,
     ) -> None:
         self._client = client
         self._min_interval = min_request_interval_s
@@ -73,6 +75,17 @@ class ResilientClient:
         # one advances the shared timestamp, preventing combined rates from
         # exceeding the API limit.
         self._last_request_at: list[float] = shared_last_request if shared_last_request is not None else [0.0]
+        # Lock around the read-modify-write of ``_last_request_at`` so
+        # concurrent fetchers (#726) cannot race past the rate-limit
+        # floor. Each instance holds its own lock so providers with
+        # independent rate budgets are isolated; providers sharing a
+        # ``shared_last_request`` list also need to share this lock to
+        # keep the throttle atomic across instances. We surface that
+        # via the ``shared_throttle_lock`` parameter — callers that
+        # share a clock pass the same lock object.
+        self._throttle_lock: threading.Lock = (
+            shared_throttle_lock if shared_throttle_lock is not None else threading.Lock()
+        )
 
     # ------------------------------------------------------------------
     # Public API — mirrors httpx.Client.get / .post
@@ -102,13 +115,28 @@ class ResilientClient:
     # Internal
     # ------------------------------------------------------------------
 
-    def _throttle(self) -> None:
-        """Sleep if needed to enforce the minimum inter-request interval."""
+    def _throttle_and_stamp(self) -> None:
+        """Sleep if needed to enforce the inter-request floor, then
+        advance the shared timestamp atomically.
+
+        Pre-#726 this was a separate ``_throttle`` step + an
+        unsynchronised ``_last_request_at[0] = ...`` write at the
+        request site. Under concurrent fetchers (issue #726) the
+        check-and-write race let multiple threads pass the floor
+        simultaneously and burst past the API rate limit. Combining
+        the two steps under a single lock keeps the floor atomic
+        across N concurrent callers — at most one thread is firing
+        a request per ``min_request_interval_s``.
+        """
         if self._min_interval <= 0:
+            with self._throttle_lock:
+                self._last_request_at[0] = time.monotonic()
             return
-        elapsed = time.monotonic() - self._last_request_at[0]
-        if elapsed < self._min_interval:
-            time.sleep(self._min_interval - elapsed)
+        with self._throttle_lock:
+            elapsed = time.monotonic() - self._last_request_at[0]
+            if elapsed < self._min_interval:
+                time.sleep(self._min_interval - elapsed)
+            self._last_request_at[0] = time.monotonic()
 
     def _request(
         self,
@@ -127,8 +155,7 @@ class ResilientClient:
         last_response: httpx.Response | None = None
 
         for attempt in range(1 + self._max_retries):
-            self._throttle()
-            self._last_request_at[0] = time.monotonic()
+            self._throttle_and_stamp()
 
             request = self._client.build_request(
                 method,

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -48,6 +48,8 @@ from typing import Any, Protocol
 import psycopg
 from psycopg.types.json import Jsonb
 
+from app.providers.concurrent_fetch import fetch_document_texts
+
 logger = logging.getLogger(__name__)
 
 # Bump whenever parse_form_4_xml shape changes so the ingester can
@@ -1073,32 +1075,39 @@ def _process_candidates(
     canonical_url)``. Fetch errors / None bodies / parse misses all
     write a filing-level tombstone so the ingester never re-fetches
     a dead accession. Successful parses flow through
-    :func:`upsert_filing` which refreshes every column on conflict."""
+    :func:`upsert_filing` which refreshes every column on conflict.
+
+    #726: the network leg fans out to a thread pool so SEC's
+    ~800 ms per-request response time overlaps across workers.
+    Aggregate request rate stays bounded by the shared rate-limit
+    clock (``_PROCESS_RATE_LIMIT_CLOCK``) + lock
+    (``_PROCESS_RATE_LIMIT_LOCK``) inside ``ResilientClient``.
+    Parse + DB upsert stay serial on the caller's connection (no
+    concurrent psycopg writes — a future change could parallelise
+    that too with a per-thread connection but that's out of scope).
+    """
     filings_parsed = 0
     rows_inserted = 0
     fetch_errors = 0
     parse_misses = 0
 
+    # Pre-fetch every URL concurrently. ``bodies[url]`` is the XML
+    # text on success, ``None`` on 404 / fetch error / per-future
+    # exception (the helper traps + logs each).
+    bodies = fetch_document_texts(fetcher, (url for _, _, url in candidates))
+
     for instrument_id, accession, url in candidates:
-        try:
-            xml = fetcher.fetch_document_text(url)
-        except Exception:
+        xml = bodies.get(url)
+        if xml is None:
+            # Codex pre-flight: per-future exceptions logged
+            # generically by the helper. Re-emit at this scope with
+            # ``accession`` so operators can grep failures by
+            # filing identifier (matches the pre-#726 log shape).
             logger.warning(
                 "ingest_insider_transactions: fetch failed accession=%s url=%s",
                 accession,
                 url,
-                exc_info=True,
             )
-            fetch_errors += 1
-            _write_tombstone(
-                conn,
-                instrument_id=instrument_id,
-                accession_number=accession,
-                primary_document_url=url,
-            )
-            conn.commit()
-            continue
-        if xml is None:
             fetch_errors += 1
             _write_tombstone(
                 conn,

--- a/tests/test_concurrent_fetch.py
+++ b/tests/test_concurrent_fetch.py
@@ -90,6 +90,62 @@ class TestConcurrentFetch:
         assert result == {"u1": "body1"}
 
 
+class TestConcurrencyAchievesActualThroughput:
+    """Wall-clock regression guard for #726. Bot pre-flight raised
+    a concern that ``time.sleep`` inside the throttle lock would
+    serialise threads end-to-end and erase the concurrency gain.
+    Live SEC tests showed 7.5 req/s actual vs ~1 req/s sequential,
+    so the design works — but the bot's intuition is reasonable
+    enough that we want a deterministic CI check.
+
+    The math: with N concurrent workers, each lock holder spends
+    ``min_interval`` sleeping (since the previous holder just
+    stamped). After release, the next thread acquires and sleeps
+    ``min_interval`` again. Aggregate rate = ``1 / min_interval``
+    regardless of N (the lock IS the rate gate). Crucially, the
+    HTTP RTT happens AFTER lock release, in parallel across threads
+    — so total wall-clock for N requests with response_time R is
+    ``N * min_interval + R`` (the last request's response), NOT
+    ``N * (min_interval + R)`` which is what the sequential
+    pre-PR loop took.
+    """
+
+    def test_concurrent_total_time_smaller_than_sequential(self) -> None:
+        from concurrent.futures import ThreadPoolExecutor
+
+        from app.providers.resilient_client import ResilientClient
+
+        rc = ResilientClient.__new__(ResilientClient)
+        rc._min_interval = 0.02  # 20 ms floor
+        rc._last_request_at = [0.0]
+        rc._throttle_lock = threading.Lock()
+
+        # Simulated work: each worker stamps then sleeps 100ms
+        # (the "HTTP RTT") OUTSIDE the lock, exactly like the real
+        # ResilientClient._request flow.
+        N_REQUESTS = 16
+        RESPONSE_MS = 0.1
+
+        def fire() -> None:
+            rc._throttle_and_stamp()  # pyright: ignore[reportPrivateUsage]
+            time.sleep(RESPONSE_MS)  # outside the lock
+
+        sequential_estimate = N_REQUESTS * (rc._min_interval + RESPONSE_MS)
+
+        t0 = time.monotonic()
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(lambda _: fire(), range(N_REQUESTS)))
+        elapsed = time.monotonic() - t0
+
+        # With 8 workers, response time overlaps. Wall-clock should
+        # be much closer to N*min_interval + RESPONSE_MS (~0.42s)
+        # than the sequential estimate (~1.92s).
+        assert elapsed < sequential_estimate * 0.5, (
+            f"Concurrent total {elapsed:.3f}s did not beat sequential {sequential_estimate:.3f}s "
+            "by ≥2x — throttle design may be serialising HTTP RTT across threads."
+        )
+
+
 class TestRateLimitSafetyUnderConcurrency:
     """ResilientClient throttle must remain atomic under concurrent
     callers. A regression here lets concurrent fetchers burst past the

--- a/tests/test_concurrent_fetch.py
+++ b/tests/test_concurrent_fetch.py
@@ -1,0 +1,136 @@
+"""Unit tests for ``app.providers.concurrent_fetch.fetch_document_texts`` (#726)."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from app.providers.concurrent_fetch import fetch_document_texts
+
+
+class _Fetcher:
+    """Captures call ordering + concurrency for assertions."""
+
+    def __init__(self, by_url: dict[str, str | None | type[Exception]]) -> None:
+        self._by = by_url
+        self.calls: list[str] = []
+        self.live: int = 0
+        self.peak_live: int = 0
+        self._lock = threading.Lock()
+
+    def fetch_document_text(self, absolute_url: str) -> str | None:
+        with self._lock:
+            self.calls.append(absolute_url)
+            self.live += 1
+            self.peak_live = max(self.peak_live, self.live)
+        try:
+            time.sleep(0.05)  # simulate SEC response time
+            outcome = self._by[absolute_url]
+            if isinstance(outcome, type) and issubclass(outcome, Exception):
+                raise outcome("simulated fetch error")
+            return outcome
+        finally:
+            with self._lock:
+                self.live -= 1
+
+
+class TestConcurrentFetch:
+    def test_returns_body_per_url(self) -> None:
+        fetcher = _Fetcher({"u1": "body1", "u2": "body2", "u3": "body3"})
+        result = fetch_document_texts(fetcher, ["u1", "u2", "u3"], max_workers=4)
+        assert result == {"u1": "body1", "u2": "body2", "u3": "body3"}
+
+    def test_concurrency_actually_overlaps(self) -> None:
+        """Peak-live counter > 1 proves multiple fetches were in flight
+        simultaneously. Without concurrency the peak would always be 1."""
+        fetcher = _Fetcher({f"u{i}": f"body{i}" for i in range(8)})
+        fetch_document_texts(fetcher, [f"u{i}" for i in range(8)], max_workers=4)
+        assert fetcher.peak_live > 1
+        assert fetcher.peak_live <= 4  # bounded by max_workers
+
+    def test_per_future_exception_becomes_none(self) -> None:
+        """One bad URL must not crash the batch — surfaces as None
+        in the result map. Caller treats None identical to a 404."""
+        fetcher = _Fetcher(
+            {
+                "good": "ok",
+                "bad": RuntimeError,
+                "good2": "ok2",
+            }
+        )
+        result = fetch_document_texts(fetcher, ["good", "bad", "good2"], max_workers=2)
+        assert result == {"good": "ok", "bad": None, "good2": "ok2"}
+
+    def test_empty_input_returns_empty(self) -> None:
+        fetcher = _Fetcher({})
+        assert fetch_document_texts(fetcher, []) == {}
+
+    def test_duplicate_urls_dedup_before_fetch(self) -> None:
+        """Sending the same URL twice must not double-fetch — the
+        rate-budget cost has to match the unique URL count."""
+        fetcher = _Fetcher({"u1": "body1"})
+        result = fetch_document_texts(fetcher, ["u1", "u1", "u1"], max_workers=4)
+        assert result == {"u1": "body1"}
+        assert fetcher.calls.count("u1") == 1
+
+    def test_workers_capped_to_unique_url_count(self) -> None:
+        """Asking for more workers than URLs must not over-allocate."""
+        fetcher = _Fetcher({"u1": "body1", "u2": "body2"})
+        fetch_document_texts(fetcher, ["u1", "u2"], max_workers=16)
+        assert fetcher.peak_live <= 2
+
+    def test_filters_falsy_urls(self) -> None:
+        """Empty-string / falsy URLs in the input are dropped before
+        fetch. Caller probably has a None primary_document_url that
+        leaked through; we don't want to hit SEC with an empty path."""
+        fetcher = _Fetcher({"u1": "body1"})
+        result = fetch_document_texts(fetcher, ["u1", "", "u1"], max_workers=4)
+        assert result == {"u1": "body1"}
+
+
+class TestRateLimitSafetyUnderConcurrency:
+    """ResilientClient throttle must remain atomic under concurrent
+    callers. A regression here lets concurrent fetchers burst past the
+    rate-limit floor → SEC UA throttling → cascading 4xx/5xx
+    tombstones across every ingest path."""
+
+    @pytest.mark.parametrize("workers", [4, 8, 16])
+    def test_throttle_lock_serialises_request_stamping(self, workers: int) -> None:
+        from concurrent.futures import ThreadPoolExecutor
+
+        from app.providers.resilient_client import ResilientClient
+
+        # Build a ResilientClient with no real httpx underneath — we
+        # only exercise ``_throttle_and_stamp`` directly. The lock
+        # protects the read-modify-write of ``_last_request_at[0]``.
+        clock: list[float] = [0.0]
+        lock = threading.Lock()
+        # min_interval=0 path still locks for a deterministic stamp
+        # write; min_interval>0 path tests the throttle branch.
+        rc = ResilientClient.__new__(ResilientClient)
+        rc._min_interval = 0.02  # 20 ms floor — easy to detect violation
+        rc._last_request_at = clock
+        rc._throttle_lock = lock
+
+        stamps: list[float] = []
+        stamps_lock = threading.Lock()
+
+        def fire() -> None:
+            rc._throttle_and_stamp()  # pyright: ignore[reportPrivateUsage]
+            with stamps_lock:
+                stamps.append(time.monotonic())
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            for _ in range(40):
+                pool.submit(fire)
+
+        stamps.sort()
+        # No two consecutive successful fires can be within the floor.
+        # Allow 2 ms slack for OS sleep imprecision.
+        slack = 0.002
+        for prev, cur in zip(stamps, stamps[1:], strict=False):
+            assert cur - prev >= rc._min_interval - slack, (
+                f"throttle violation: {cur - prev:.4f}s < {rc._min_interval}s floor"
+            )

--- a/tests/test_fetch_document_text_callers.py
+++ b/tests/test_fetch_document_text_callers.py
@@ -41,6 +41,12 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         "app/services/eight_k_events.py",
         # Provider implementation owns the method itself.
         "app/providers/implementations/sec_edgar.py",
+        # Bounded-concurrency wrapper (#726). Calls the method via a
+        # narrow Protocol but does NOT persist anything itself —
+        # callers (insider_transactions / dividend_calendar / etc.)
+        # own the SQL normalisation as before. The helper is
+        # transport-only.
+        "app/providers/concurrent_fetch.py",
         # Docstring-only reference in the scheduler job that invokes
         # one of the ingesters. No runtime call site.
         "app/workers/scheduler.py",
@@ -51,6 +57,7 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         "tests/test_dividend_calendar_ingest.py",
         "tests/test_insider_transactions_ingest.py",
         "tests/test_eight_k_events_ingest.py",
+        "tests/test_concurrent_fetch.py",
         # This guard file itself references the method name in its
         # contract sentence.
         "tests/test_fetch_document_text_callers.py",


### PR DESCRIPTION
## What

Replace the sequential ``for url in urls: fetch_document_text(url)`` loop with a bounded-concurrency thread pool. Aggregate request rate stays bounded by the existing shared rate-limit clock (now lock-protected for thread safety).

## Why

SEC fair-use is 10 req/s per UA. Pre-PR the ingest paths ran at ~1 req/s — every request blocked on SEC's ~700-900ms response time, so we used 10% of the allowed budget. Operator surfaced the bandwidth gap in #726.

\`\`\`
Pre-PR:  rate ≈ 1 / (0.11 + 0.8) ≈ 1.1 req/s
Post-PR: rate ≈ rate-limit ceiling ≈ 9 req/s (8 concurrent workers overlap response wait)
\`\`\`

**Live verification (dev DB):** 40 Form 4 candidates in 5.3s = **7.53 req/s effective**. The 221k Form 4 backlog drains in ~8h instead of 5+ days.

## How

1. **Lock-protect the rate-limit clock**. ``ResilientClient._throttle_and_stamp`` combines the check + sleep + timestamp-write into one lock-protected critical section. New ``shared_throttle_lock`` parameter so providers sharing a clock list also share the lock. ``_PROCESS_RATE_LIMIT_LOCK`` companion to ``_PROCESS_RATE_LIMIT_CLOCK`` wired through both SEC clients.

2. **Add ``concurrent_fetch.fetch_document_texts``** — shared utility. Default 8 workers, dedupes inputs, caps workers to unique URL count, isolates per-future exceptions as ``None`` so one bad URL can't crash the batch.

3. **Wire into insider_transactions** — pre-fetch all XML bodies concurrently, then iterate parse + upsert + commit serially on the caller's psycopg connection (DB writes stay single-threaded; concurrency is on the network leg only).

## Test plan

- [x] ``pytest tests/test_concurrent_fetch.py`` — 10 unit tests including a parameterised throttle-safety check across 4/8/16 concurrent threads
- [x] ``pytest tests/test_insider_transactions*`` — 50+ existing tests pass against the new pre-fetch + serial-process flow
- [x] ``ruff/format/pyright`` clean
- [x] **Live SEC end-to-end**: 40 candidates in 5.3s = 7.53 req/s, zero throttle violations
- [x] Codex checkpoint-2: 3 design questions confirmed correct (throttle atomicity, shared lock plumbing, helper safety) + 1 Low finding (lost accession context in failure logs) addressed by re-emitting at caller scope

## Out of scope

Other ingest paths (8-K events, business_summary, dividend_calendar, filing_documents) can adopt the helper one-by-one. Same change pattern: replace the per-iteration ``fetch_document_text`` call with a pre-fetch step. Keeping this PR scoped to insider_transactions for reviewability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)