### PR TITLE
fix: insider Form 4 URL canonicalisation — match all xslF345 variants

### DIFF
--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -926,17 +926,24 @@ class _DocFetcher(Protocol):
 
 # SEC submissions.json ``primaryDocument`` for ownership filings
 # (Forms 3/4/5) commonly points at an XSL-rendered HTML view rather
-# than the raw XML. The rendered path carries an ``xslF345X06/`` (or
-# sibling ``xslF345X05/`` / ``xslF345/``) segment before the filename;
-# the same file without that segment is the canonical XML.
+# than the raw XML. The rendered path carries an ``xslF345`` segment
+# (with a versioned suffix that has rotated over the years —
+# ``xslF345X02``, ``xslF345X03``, ``xslF345X04``, ``xslF345X05``,
+# ``xslF345X06`` are all observed in production filings) before the
+# filename; the same file without that segment is the canonical XML.
 #
 #   XSL:  /Archives/edgar/data/320193/000114036126015421/xslF345X06/form4.xml  → text/html
 #   Raw:  /Archives/edgar/data/320193/000114036126015421/form4.xml             → text/xml
 #
-# Without normalisation the ingester fetches HTML, the parser sees an
-# ``<html>`` root instead of ``<ownershipDocument>``, and every filing
-# gets tombstoned (#454).
-_XSL_FORM345_PREFIX_RE = re.compile(r"/xslF345(?:X0[56])?/")
+# Pre-fix the regex matched only ``xslF345``, ``xslF345X05`` and
+# ``xslF345X06``. Older filings (pre-2018) carry ``X02`` / ``X03`` /
+# ``X04`` suffixes — those passed through unchanged, the ingester
+# fetched HTML, and the parser failed with a 98%+ parse_miss rate
+# on backfill ticks against historical Form 4s.
+#
+# Match any ``xslF345`` followed by an optional alphanumeric suffix
+# so future SEC variants are absorbed without another patch.
+_XSL_FORM345_PREFIX_RE = re.compile(r"/xslF345[A-Z0-9]*/")
 
 
 def _canonical_form_4_url(url: str) -> str:

--- a/tests/test_insider_transactions.py
+++ b/tests/test_insider_transactions.py
@@ -578,6 +578,29 @@ class TestCanonicalForm4Url:
         raw = "https://www.sec.gov/Archives/edgar/data/xslF345X06extra/form4.xml"
         assert _canonical_form_4_url(raw) == raw
 
+    def test_strips_older_xslf345x02_segment(self) -> None:
+        """Operator surfaced 2026-05-01: backfill against pre-2018
+        Form 4 filings hit a 98% parse_miss rate because the
+        ``xslF345X02`` / ``xslF345X03`` variants weren't matched by
+        the regex. The ingester fetched the XSL-rendered HTML and
+        the XML parser failed on every filing."""
+        raw = "https://www.sec.gov/Archives/edgar/data/871763/000120919108030833/xslF345X02/doc4.xml"
+        assert _canonical_form_4_url(raw) == (
+            "https://www.sec.gov/Archives/edgar/data/871763/000120919108030833/doc4.xml"
+        )
+
+    def test_strips_older_xslf345x03_segment(self) -> None:
+        raw = "https://www.sec.gov/Archives/edgar/data/871763/000120919108047089/xslF345X03/doc4.xml"
+        assert _canonical_form_4_url(raw) == (
+            "https://www.sec.gov/Archives/edgar/data/871763/000120919108047089/doc4.xml"
+        )
+
+    def test_strips_intermediate_xslf345x04_segment(self) -> None:
+        """Future-proofing: the ``[A-Z0-9]*`` suffix matches any new
+        SEC XSL variant without another regex patch."""
+        raw = "https://www.sec.gov/Archives/edgar/data/320193/abc/xslF345X04/form4.xml"
+        assert _canonical_form_4_url(raw) == ("https://www.sec.gov/Archives/edgar/data/320193/abc/form4.xml")
+
 
 class TestFilerRoleString:
     def _filer(self, **overrides: object) -> ParsedFiler:


### PR DESCRIPTION
## What

Fix the regex that strips SEC's XSL-rendered HTML segment from Form 4 URLs. Pre-fix it matched only \`xslF345\`, \`xslF345X05\`, \`xslF345X06\`. Older filings (pre-2018) carry \`xslF345X02\` / \`X03\` / \`X04\` and slipped through, causing the ingester to fetch HTML and the XML parser to fail on every filing.

## Why

Operator surfaced 2026-05-01:
\`\`\`
sec_insider_transactions_backfill: instruments=25 parsed=20 inserted=27 fetch_errors=0 parse_misses=1230
\`\`\`

98% parse-miss with zero fetch errors → fetcher successfully returned bodies but parser couldn't read them. Inspection of the prior log confirmed the URLs being fetched were of the form:

\`\`\`
.../000120919108030833/xslF345X02/doc4.xml
.../000120919108047089/xslF345X03/doc4.xml
\`\`\`

The X02 / X03 suffixes weren't in the regex, so canonicalisation no-op'd, fetcher pulled HTML, parser saw \`<html>\` instead of \`<ownershipDocument>\`, every filing tombstoned.

## How

Regex changes from \`/xslF345(?:X0[56])?/\` to \`/xslF345[A-Z0-9]*/\`. Matches any \`xslF345\` followed by any alphanumeric suffix — absorbs every observed SEC variant + future ones.

## Test plan

- [x] 3 new cases: X02, X03, X04 variants — pass
- [x] Existing 5 cases still pass (X05 / X06 / no-suffix / canonical / unrelated-substring)
- [x] ruff/format clean

## Post-merge action required

The 1,230 filings that tombstoned in the bad backfill window are now permanently excluded by the dedup gate (\`WHERE fil.accession_number IS NULL\`). Run the following on the dev DB to let them re-qualify:

\`\`\`sql
-- Delete tombstones for Form 4 filings, leaving real parsed rows alone.
-- Tombstones have ``is_tombstone=TRUE``; real ingests are FALSE.
DELETE FROM insider_filings
WHERE is_tombstone = TRUE
  AND accession_number IN (
    SELECT provider_filing_id FROM filing_events
    WHERE provider = 'sec' AND filing_type IN ('4', '4/A')
  );
\`\`\`

Next \`sec_insider_transactions_backfill\` tick (every 15 min) re-fetches them with the fixed URL.

## Out of scope

A TTL on tombstones (auto-retry after N days) would prevent this kind of permanent-skip after a buggy ingest window. Worth a follow-up if other ingest paths gain similar tombstone systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)