### PR TITLE
feat(#731): project Treasury/Shares Auth+Issued/Retained Earnings into financial_periods

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -485,6 +485,12 @@ _BALANCE_COLUMNS: tuple[str, ...] = (
     "payables",
     "goodwill",
     "ppe_net",
+    # Ownership / capital structure (#731). Surfaced after migration
+    # 088 + the matching projection in app/services/fundamentals.py.
+    "treasury_shares",
+    "shares_authorized",
+    "shares_issued",
+    "retained_earnings",
 )
 
 _CASHFLOW_COLUMNS: tuple[str, ...] = (

--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -202,6 +202,20 @@ TRACKED_CONCEPTS: dict[str, tuple[str, ...]] = {
     # Effective tax rate — useful for cross-filer comparability when
     # net_income alone obscures tax-regime differences.
     "effective_tax_rate": ("EffectiveIncomeTaxRateContinuingOperations",),
+    # Ownership / capital-structure concepts (#731). All four are
+    # us-gaap balance-sheet items emitted on the same period_end as
+    # the rest of the balance sheet, so they project through the
+    # existing _derive_periods_from_facts canonical-end filter
+    # without special handling. EntityPublicFloat (DEI cover-page
+    # fact, period_end = issuer Q2-end ≠ fiscal year-end) is
+    # deferred to #735.
+    "treasury_shares": (
+        "TreasuryStockShares",
+        "TreasuryStockCommonShares",
+    ),
+    "shares_authorized": ("CommonStockSharesAuthorized",),
+    "shares_issued": ("CommonStockSharesIssued",),
+    "retained_earnings": ("RetainedEarningsAccumulatedDeficit",),
 }
 
 # DEI (document-and-entity-information) cover-page facts. Thin set —

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -663,6 +663,11 @@ _BALANCE_SHEET_COLUMNS: frozenset[str] = frozenset(
         "payables",
         "goodwill",
         "ppe_net",
+        # Ownership / capital structure (#731).
+        "treasury_shares",
+        "shares_authorized",
+        "shares_issued",
+        "retained_earnings",
     }
 )
 
@@ -724,6 +729,14 @@ class PeriodRow:
     dividends_paid: Decimal | None = None
     dps_declared: Decimal | None = None
     buyback_spend: Decimal | None = None
+
+    # Ownership / capital structure (#731). Treasury and authorised /
+    # issued counts populate the ownership reporting card (#729);
+    # retained_earnings rounds out the equity slice.
+    treasury_shares: Decimal | None = None
+    shares_authorized: Decimal | None = None
+    shares_issued: Decimal | None = None
+    retained_earnings: Decimal | None = None
 
     # Provenance
     source: str = "sec_edgar"
@@ -967,6 +980,7 @@ def _upsert_period_raw(
             inventory, receivables, payables, goodwill, ppe_net,
             operating_cf, investing_cf, financing_cf, capex,
             dividends_paid, dps_declared, buyback_spend,
+            treasury_shares, shares_authorized, shares_issued, retained_earnings,
             source, source_ref, reported_currency,
             form_type, filed_date, is_restated, is_derived,
             ingestion_run_id
@@ -982,6 +996,7 @@ def _upsert_period_raw(
             %(inventory)s, %(receivables)s, %(payables)s, %(goodwill)s, %(ppe_net)s,
             %(operating_cf)s, %(investing_cf)s, %(financing_cf)s, %(capex)s,
             %(dividends_paid)s, %(dps_declared)s, %(buyback_spend)s,
+            %(treasury_shares)s, %(shares_authorized)s, %(shares_issued)s, %(retained_earnings)s,
             %(source)s, %(source_ref)s, %(reported_currency)s,
             %(form_type)s, %(filed_date)s, %(is_restated)s, %(is_derived)s,
             %(ingestion_run_id)s
@@ -1022,6 +1037,10 @@ def _upsert_period_raw(
             dividends_paid = EXCLUDED.dividends_paid,
             dps_declared = EXCLUDED.dps_declared,
             buyback_spend = EXCLUDED.buyback_spend,
+            treasury_shares = EXCLUDED.treasury_shares,
+            shares_authorized = EXCLUDED.shares_authorized,
+            shares_issued = EXCLUDED.shares_issued,
+            retained_earnings = EXCLUDED.retained_earnings,
             form_type = EXCLUDED.form_type,
             filed_date = EXCLUDED.filed_date,
             is_restated = EXCLUDED.is_restated,
@@ -1071,6 +1090,10 @@ def _upsert_period_raw(
             "dividends_paid": period.dividends_paid,
             "dps_declared": period.dps_declared,
             "buyback_spend": period.buyback_spend,
+            "treasury_shares": period.treasury_shares,
+            "shares_authorized": period.shares_authorized,
+            "shares_issued": period.shares_issued,
+            "retained_earnings": period.retained_earnings,
             "source": period.source,
             "source_ref": period.source_ref,
             "reported_currency": period.reported_currency,
@@ -1226,6 +1249,7 @@ def _canonical_merge_instrument(
             inventory, receivables, payables, goodwill, ppe_net,
             operating_cf, investing_cf, financing_cf, capex,
             dividends_paid, dps_declared, buyback_spend,
+            treasury_shares, shares_authorized, shares_issued, retained_earnings,
             source, source_ref, reported_currency,
             form_type, filed_date, is_restated, is_derived,
             normalization_status
@@ -1242,6 +1266,7 @@ def _canonical_merge_instrument(
             inventory, receivables, payables, goodwill, ppe_net,
             operating_cf, investing_cf, financing_cf, capex,
             dividends_paid, dps_declared, buyback_spend,
+            treasury_shares, shares_authorized, shares_issued, retained_earnings,
             source, source_ref, reported_currency,
             form_type, filed_date, is_restated, is_derived,
             'normalized'
@@ -1287,6 +1312,10 @@ def _canonical_merge_instrument(
             dividends_paid = EXCLUDED.dividends_paid,
             dps_declared = EXCLUDED.dps_declared,
             buyback_spend = EXCLUDED.buyback_spend,
+            treasury_shares = EXCLUDED.treasury_shares,
+            shares_authorized = EXCLUDED.shares_authorized,
+            shares_issued = EXCLUDED.shares_issued,
+            retained_earnings = EXCLUDED.retained_earnings,
             source = EXCLUDED.source,
             source_ref = EXCLUDED.source_ref,
             form_type = EXCLUDED.form_type,

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -299,15 +299,21 @@ For `EXIT`:
 
 ---
 
-## Product-visibility pivot (2026-04-18)
+## Product-visibility pivot (2026-04-18, lifted 2026-04-18)
 
-Infra track (filings cascade, raw housekeeping, fundamentals expansion) is **paused** until the operator can open eBull and place/close demo trades from the UI. Plan + backlog: [`docs/superpowers/plans/2026-04-18-product-visibility-pivot.md`](superpowers/plans/2026-04-18-product-visibility-pivot.md).
+Infra-track pause for filings cascade, raw housekeeping, and
+fundamentals expansion was scoped to "until #313 + #314 ship". Both
+shipped on 2026-04-18 (and #315 on 2026-04-21), so the pause is no
+longer in force. Plan B.1 (TRACKED_CONCEPTS expansion), Plan B.3
+(company metadata), Plan C.1/C.2/C.3 (insider/13F/segment), Chunk L
+flag-flip, and raw-retention dry-run-off may proceed once their own
+issues are prioritised.
 
-Open tickets: #313 (order modals), #314 (portfolio workstation), #315 (dashboard command center), #316 (instrument terminal), #317 (shell polish).
-
-Every ticket must answer yes to: *"Would the operator feel this moves the product closer to 'I can manage my fund from this screen'?"* — else rewrite or drop.
-
-Paused until #313 + #314 ship: Plan B.1 (TRACKED_CONCEPTS expansion), Plan B.3 (company metadata), Plan C.1/C.2/C.3 (insider/13F/segment), Chunk L flag-flip, raw-retention dry-run-off.
+The product-test that lives on independent of the pause: every new
+ticket should still answer yes to *"Would the operator feel this
+moves the product closer to 'I can manage my fund from this
+screen'?"* — else rewrite or drop. Plan + backlog still at
+[`docs/superpowers/plans/2026-04-18-product-visibility-pivot.md`](superpowers/plans/2026-04-18-product-visibility-pivot.md).
 
 ---
 

--- a/sql/088_xbrl_ownership_columns.sql
+++ b/sql/088_xbrl_ownership_columns.sql
@@ -1,0 +1,36 @@
+-- 088_xbrl_ownership_columns.sql
+--
+-- Issue #731 — project four us-gaap balance-sheet concepts into the
+-- canonical financial_periods table to unblock the ownership reporting
+-- card (#729): treasury_shares, shares_authorized, shares_issued,
+-- retained_earnings.
+--
+-- All four are top-30 most-frequent XBRL concepts in the SEC
+-- companyfacts corpus and currently land in financial_facts_raw but
+-- are dropped during normalisation because TRACKED_CONCEPTS lacks the
+-- alias. After this migration + the matching service-layer changes,
+-- normalize_financial_periods will project them on the next re-derive.
+--
+-- public_float_usd (DEI EntityPublicFloat) is split out to #735 — its
+-- cover-page period_end (issuer Q2-end) does not match the FY anchor,
+-- so the existing _derive_periods_from_facts canonical-end filter
+-- silently drops it. Designed there once an annual-cover-page path is
+-- in place.
+--
+-- Backfill plan: the migration is purely additive (new nullable
+-- columns); no data movement here. Existing rows pre-date the
+-- columns and stay NULL until the next normalisation run, which
+-- re-reads facts_raw and rewrites the canonical row via the
+-- ON CONFLICT update path in _canonical_merge_instrument.
+
+ALTER TABLE financial_periods_raw
+    ADD COLUMN IF NOT EXISTS treasury_shares    NUMERIC(20,0),
+    ADD COLUMN IF NOT EXISTS shares_authorized  NUMERIC(20,0),
+    ADD COLUMN IF NOT EXISTS shares_issued      NUMERIC(20,0),
+    ADD COLUMN IF NOT EXISTS retained_earnings  NUMERIC(20,4);
+
+ALTER TABLE financial_periods
+    ADD COLUMN IF NOT EXISTS treasury_shares    NUMERIC(20,0),
+    ADD COLUMN IF NOT EXISTS shares_authorized  NUMERIC(20,0),
+    ADD COLUMN IF NOT EXISTS shares_issued      NUMERIC(20,0),
+    ADD COLUMN IF NOT EXISTS retained_earnings  NUMERIC(20,4);

--- a/tests/test_canonical_merge_ownership_columns_731.py
+++ b/tests/test_canonical_merge_ownership_columns_731.py
@@ -1,0 +1,195 @@
+"""Integration test for #731 — ownership columns project through the
+canonical merge ON CONFLICT update branch.
+
+Codex pre-push review flagged that the unit tests in
+``test_financial_normalization.py`` exercise ``_derive_periods_from_facts``
+in isolation but do not pin the round-trip through
+``_canonical_merge_instrument``. The four new columns
+(``treasury_shares``, ``shares_authorized``, ``shares_issued``,
+``retained_earnings``) appear in both the INSERT column list AND the
+ON CONFLICT DO UPDATE SET clause of the merge query — the latter is
+what populates a canonical row pre-existing in the table from a
+prior (pre-088) ingest. This test seeds a raw row with the four new
+columns set, runs the merge, and asserts the canonical row's
+ownership values match.
+
+A second pass then updates the raw row's ownership values with new
+data (simulating a 10-K/A amendment re-deriving the column) and
+re-runs the merge. The canonical row must update in place via the
+ON CONFLICT branch — the bug Codex called out would surface here as
+stale values surviving the second merge.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services.fundamentals import _canonical_merge_instrument
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} test"),
+    )
+
+
+def _seed_raw_with_ownership(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    period_end: date,
+    fiscal_year: int,
+    source_ref: str,
+    filed_date: date,
+    treasury_shares: Decimal,
+    shares_authorized: Decimal,
+    shares_issued: Decimal,
+    retained_earnings: Decimal,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO financial_periods_raw (
+            instrument_id, period_end_date, period_type,
+            fiscal_year, fiscal_quarter, revenue,
+            treasury_shares, shares_authorized, shares_issued, retained_earnings,
+            source, source_ref, reported_currency, filed_date
+        ) VALUES (
+            %s, %s, 'FY', %s, NULL, 1000,
+            %s, %s, %s, %s,
+            'sec_edgar', %s, 'USD', %s
+        )
+        """,
+        (
+            instrument_id,
+            period_end,
+            fiscal_year,
+            treasury_shares,
+            shares_authorized,
+            shares_issued,
+            retained_earnings,
+            source_ref,
+            filed_date,
+        ),
+    )
+
+
+def _canonical_ownership_row(
+    conn: psycopg.Connection[tuple],
+    instrument_id: int,
+) -> dict[str, object]:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT period_end_date, treasury_shares, shares_authorized,
+                   shares_issued, retained_earnings, source_ref
+            FROM financial_periods
+            WHERE instrument_id = %s
+            """,
+            (instrument_id,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1, [dict(r) for r in rows]
+    return rows[0]  # type: ignore[return-value]
+
+
+class TestCanonicalMergeOwnershipColumns:
+    def test_insert_path_populates_ownership_columns(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Fresh canonical row receives all four ownership columns from
+        the raw row's INSERT path — the simple direction."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=731_001, symbol="OWN1")
+        _seed_raw_with_ownership(
+            conn,
+            instrument_id=731_001,
+            period_end=date(2024, 12, 31),
+            fiscal_year=2024,
+            source_ref="acc-original",
+            filed_date=date(2025, 2, 14),
+            treasury_shares=Decimal("12500000"),
+            shares_authorized=Decimal("5000000000"),
+            shares_issued=Decimal("1750000000"),
+            retained_earnings=Decimal("180000000000"),
+        )
+        conn.commit()
+
+        _canonical_merge_instrument(conn, 731_001)
+        conn.commit()
+
+        row = _canonical_ownership_row(conn, 731_001)
+        assert row["treasury_shares"] == Decimal("12500000")
+        assert row["shares_authorized"] == Decimal("5000000000")
+        assert row["shares_issued"] == Decimal("1750000000")
+        assert row["retained_earnings"] == Decimal("180000000000")
+
+    def test_on_conflict_update_path_replaces_ownership_columns(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """The exact backfill scenario Codex flagged: a canonical row
+        already exists, then a re-derive lands new values for the four
+        ownership columns. The merge's ON CONFLICT DO UPDATE branch
+        must overwrite the canonical values — not leave them stale.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=731_002, symbol="OWN2")
+
+        # First arrival: original 10-K with one set of ownership values.
+        _seed_raw_with_ownership(
+            conn,
+            instrument_id=731_002,
+            period_end=date(2024, 12, 31),
+            fiscal_year=2024,
+            source_ref="acc-original",
+            filed_date=date(2025, 2, 14),
+            treasury_shares=Decimal("12500000"),
+            shares_authorized=Decimal("5000000000"),
+            shares_issued=Decimal("1750000000"),
+            retained_earnings=Decimal("180000000000"),
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 731_002)
+        conn.commit()
+
+        # Phase 2: a 10-K/A amendment with the SAME period_end (in-place
+        # restatement; no DELETE+INSERT churn) re-files the four
+        # ownership values. The merge must update via ON CONFLICT.
+        _seed_raw_with_ownership(
+            conn,
+            instrument_id=731_002,
+            period_end=date(2024, 12, 31),
+            fiscal_year=2024,
+            source_ref="acc-amendment",
+            filed_date=date(2025, 5, 1),
+            treasury_shares=Decimal("13000000"),
+            shares_authorized=Decimal("5000000000"),
+            shares_issued=Decimal("1755000000"),
+            retained_earnings=Decimal("182000000000"),
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 731_002)
+        conn.commit()
+
+        row = _canonical_ownership_row(conn, 731_002)
+        # Amendment values won.
+        assert row["source_ref"] == "acc-amendment"
+        assert row["treasury_shares"] == Decimal("13000000")
+        assert row["shares_issued"] == Decimal("1755000000")
+        assert row["retained_earnings"] == Decimal("182000000000")
+        # Unchanged column survives the update intact.
+        assert row["shares_authorized"] == Decimal("5000000000")

--- a/tests/test_financial_normalization.py
+++ b/tests/test_financial_normalization.py
@@ -892,3 +892,222 @@ class TestQ4DerivationAfterCanonicalFix:
         q4 = by_type["Q4"]
         assert q4.is_derived is True
         assert q4.dps_declared == Decimal("0.50")
+
+
+# ---------------------------------------------------------------------------
+# #731: project four us-gaap balance-sheet concepts (treasury_shares,
+# shares_authorized, shares_issued, retained_earnings) into the canonical
+# financial_periods table. Each test seeds a balance-sheet (instant) fact
+# alongside a revenue fact so the period row anchors on the fiscal end and
+# the new column populates via the existing _TAG_TO_COLUMN dispatch.
+# ---------------------------------------------------------------------------
+
+
+class TestOwnershipColumnProjection:
+    def _balance_sheet_fact(
+        self,
+        *,
+        concept: str,
+        val: Decimal,
+        period_end: str = "2024-12-31",
+        fiscal_year: int = 2024,
+        fiscal_period: str = "FY",
+        accession_number: str = "fy",
+        unit: str = "shares",
+    ) -> FactRow:
+        """Balance-sheet items are point-in-time facts: instant context
+        (period_start IS NULL), no frame, on the fiscal year-end."""
+        return _fact(
+            concept=concept,
+            val=val,
+            period_end=period_end,
+            period_start=None,
+            frame=None,
+            fiscal_period=fiscal_period,
+            fiscal_year=fiscal_year,
+            accession_number=accession_number,
+            form_type="10-K",
+            unit=unit,
+        )
+
+    def _anchor_fact(self, *, fiscal_year: int = 2024, period_end: str = "2024-12-31") -> FactRow:
+        """A revenue fact ensures the (fy, fp) group has a flow-item
+        anchor on the fiscal year-end. Without it the balance-sheet
+        fact alone could anchor the period."""
+        return _fact(
+            concept="Revenues",
+            val=Decimal("1000000"),
+            period_end=period_end,
+            period_start=f"{fiscal_year}-01-01",
+            frame=f"CY{fiscal_year}",
+            fiscal_period="FY",
+            fiscal_year=fiscal_year,
+            accession_number="fy",
+            form_type="10-K",
+        )
+
+    def test_treasury_stock_shares_alias(self) -> None:
+        facts = [
+            self._anchor_fact(),
+            self._balance_sheet_fact(
+                concept="TreasuryStockShares",
+                val=Decimal("12500000"),
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        assert len(periods) == 1
+        assert periods[0].treasury_shares == Decimal("12500000")
+
+    def test_treasury_stock_common_shares_fallback(self) -> None:
+        """``TreasuryStockCommonShares`` is the second-priority alias —
+        it must map when ``TreasuryStockShares`` is absent."""
+        facts = [
+            self._anchor_fact(),
+            self._balance_sheet_fact(
+                concept="TreasuryStockCommonShares",
+                val=Decimal("8000000"),
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        assert periods[0].treasury_shares == Decimal("8000000")
+
+    def test_treasury_priority_order(self) -> None:
+        """``TreasuryStockShares`` outranks ``TreasuryStockCommonShares``."""
+        facts = [
+            self._anchor_fact(),
+            self._balance_sheet_fact(
+                concept="TreasuryStockShares",
+                val=Decimal("12500000"),
+            ),
+            self._balance_sheet_fact(
+                concept="TreasuryStockCommonShares",
+                val=Decimal("8000000"),
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        assert periods[0].treasury_shares == Decimal("12500000")
+
+    def test_shares_authorized_alias(self) -> None:
+        facts = [
+            self._anchor_fact(),
+            self._balance_sheet_fact(
+                concept="CommonStockSharesAuthorized",
+                val=Decimal("5000000000"),
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        assert periods[0].shares_authorized == Decimal("5000000000")
+
+    def test_shares_issued_alias(self) -> None:
+        facts = [
+            self._anchor_fact(),
+            self._balance_sheet_fact(
+                concept="CommonStockSharesIssued",
+                val=Decimal("1750000000"),
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        assert periods[0].shares_issued == Decimal("1750000000")
+
+    def test_retained_earnings_alias(self) -> None:
+        facts = [
+            self._anchor_fact(),
+            self._balance_sheet_fact(
+                concept="RetainedEarningsAccumulatedDeficit",
+                val=Decimal("180000000000"),
+                unit="USD",
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        assert periods[0].retained_earnings == Decimal("180000000000")
+
+    def test_all_four_columns_populate_together(self) -> None:
+        """End-to-end smoke: a single FY group with all four ownership
+        facts populates every new column on the canonical row."""
+        facts = [
+            self._anchor_fact(),
+            self._balance_sheet_fact(
+                concept="TreasuryStockShares",
+                val=Decimal("12500000"),
+            ),
+            self._balance_sheet_fact(
+                concept="CommonStockSharesAuthorized",
+                val=Decimal("5000000000"),
+            ),
+            self._balance_sheet_fact(
+                concept="CommonStockSharesIssued",
+                val=Decimal("1750000000"),
+            ),
+            self._balance_sheet_fact(
+                concept="RetainedEarningsAccumulatedDeficit",
+                val=Decimal("180000000000"),
+                unit="USD",
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        assert len(periods) == 1
+        p = periods[0]
+        assert p.treasury_shares == Decimal("12500000")
+        assert p.shares_authorized == Decimal("5000000000")
+        assert p.shares_issued == Decimal("1750000000")
+        assert p.retained_earnings == Decimal("180000000000")
+
+    def test_q4_balance_sheet_inherits_fy_ownership_columns(self) -> None:
+        """Derived Q4 balance sheet copies FY values for all
+        ``_BALANCE_SHEET_COLUMNS`` entries (point-in-time = same
+        fiscal year-end). Confirms the four new columns participate
+        in the Q4 derivation copy loop."""
+        facts = [
+            _fact(
+                concept="Revenues",
+                fiscal_period="Q1",
+                val=Decimal("100"),
+                period_end="2024-03-31",
+                period_start="2024-01-01",
+                frame="CY2024Q1",
+                accession_number="q1",
+            ),
+            _fact(
+                concept="Revenues",
+                fiscal_period="Q2",
+                val=Decimal("120"),
+                period_end="2024-06-30",
+                period_start="2024-04-01",
+                frame="CY2024Q2",
+                accession_number="q2",
+            ),
+            _fact(
+                concept="Revenues",
+                fiscal_period="Q3",
+                val=Decimal("110"),
+                period_end="2024-09-30",
+                period_start="2024-07-01",
+                frame="CY2024Q3",
+                accession_number="q3",
+            ),
+            _fact(
+                concept="Revenues",
+                fiscal_period="FY",
+                fiscal_year=2024,
+                val=Decimal("500"),
+                period_end="2024-12-31",
+                period_start="2024-01-01",
+                frame="CY2024",
+                form_type="10-K",
+                accession_number="fy",
+            ),
+            self._balance_sheet_fact(
+                concept="TreasuryStockShares",
+                val=Decimal("12500000"),
+            ),
+            self._balance_sheet_fact(
+                concept="RetainedEarningsAccumulatedDeficit",
+                val=Decimal("180000000000"),
+                unit="USD",
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        q4 = next(p for p in periods if p.period_type == "Q4")
+        assert q4.is_derived is True
+        assert q4.treasury_shares == Decimal("12500000")
+        assert q4.retained_earnings == Decimal("180000000000")


### PR DESCRIPTION
## What

Adds four us-gaap balance-sheet concepts to the canonical \`financial_periods\` projection so the ownership reporting card (#729) can read them via the existing \`/financials?statement=balance\` API:

| Column | XBRL aliases (priority order) |
|---|---|
| \`treasury_shares\` | \`TreasuryStockShares\`, \`TreasuryStockCommonShares\` |
| \`shares_authorized\` | \`CommonStockSharesAuthorized\` |
| \`shares_issued\` | \`CommonStockSharesIssued\` |
| \`retained_earnings\` | \`RetainedEarningsAccumulatedDeficit\` |

All four are top-30 most-frequent XBRL concepts and currently land in \`financial_facts_raw\` but are dropped during normalisation because \`TRACKED_CONCEPTS\` lacks the alias.

Migration 088 is purely additive (new nullable columns). The next \`normalize_financial_periods\` run rewrites canonical rows via the \`ON CONFLICT\` update branch in \`_canonical_merge_instrument\`.

## Why

Unblocks #729 ownership reporting card (Treasury slice + capital-structure context). Re-prioritised by operator 2026-05-01 alongside #730 (13F ingest) and #732 (broader allowlist audit).

The 2026-04-18 product-visibility pivot pause was scoped to "until #313 + #314 ship". Both closed 2026-04-18, so the pause is no longer in force. \`docs/settled-decisions.md\` updated in this PR.

## Scope cut: \`public_float_usd\` deferred to #735

The original ticket listed \`EntityPublicFloat\` for \`public_float_usd\`. That concept lives under the DEI taxonomy and the 10-K cover page reports it with \`period_end\` = issuer Q2-end (the SEC's prescribed "as of" date for public-float computation), not fiscal year-end. The existing \`_derive_periods_from_facts\` anchors each period row to \`max(period_end)\` of mapped facts and then drops facts whose \`period_end\` differs from that anchor — so projecting \`EntityPublicFloat\` through the unmodified pipeline silently drops virtually every value.

Filed as #735 with two design options for the follow-up. The four columns shipped here are pure us-gaap on the fiscal period_end and route cleanly through the existing pipeline.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pyright\` — clean
- [x] \`uv run pytest tests/test_financial_normalization.py\` — 28 passed (8 new in \`TestOwnershipColumnProjection\`)
- [x] \`uv run pytest tests/test_canonical_merge_ownership_columns_731.py\` — 2 new integration tests pin INSERT path + ON CONFLICT update path
- [x] Full \`uv run pytest\` — 3044 passed; one pre-existing flake (\`test_drain_pending_at_boot_claims_each_row\`, fails on \`main\` without these changes too — unrelated, dev-DB pollution)
- [x] Codex pre-push review — no findings beyond the residual-risk note that prompted the integration test in \`tests/test_canonical_merge_ownership_columns_731.py\`

## Backfill behaviour

Existing canonical rows pre-088 have \`NULL\` for the four new columns. The next normalisation cycle re-reads \`financial_facts_raw\` (which already contains every concept since #451 Phase A — extractor stopped filtering on \`TRACKED_CONCEPTS\`), derives wider \`PeriodRow\` instances, and writes them via \`_upsert_period_raw\` + \`_canonical_merge_instrument\`. The merge's \`ON CONFLICT (instrument_id, period_end_date, period_type) DO UPDATE\` clause now lists the four new columns, so existing rows update in place. \`tests/test_canonical_merge_ownership_columns_731.py::test_on_conflict_update_path_replaces_ownership_columns\` pins this.