### PR TITLE
feat(#732): Tier 1 + Tier 2 XBRL allowlist expansion

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -470,6 +470,15 @@ _INCOME_COLUMNS: tuple[str, ...] = (
     "shares_basic",
     "shares_diluted",
     "sbc_expense",
+    # Tier 1 + Tier 2 expansion (#732). Comprehensive income (true-up
+    # vs net income via OCI), separated intangible amortisation,
+    # deferred-tax bridge, other non-operating, antidilutive share
+    # equivalents excluded from EPS.
+    "comprehensive_income",
+    "intangible_amortization",
+    "deferred_income_tax",
+    "other_nonoperating_income",
+    "antidilutive_securities",
 )
 
 _BALANCE_COLUMNS: tuple[str, ...] = (
@@ -491,6 +500,15 @@ _BALANCE_COLUMNS: tuple[str, ...] = (
     "shares_authorized",
     "shares_issued",
     "retained_earnings",
+    # Tier 1 + Tier 2 expansion (#732). Working-capital + liquidity
+    # additions (assets_current, liabilities_current, cash_restricted)
+    # plus equity-section components (additional_paid_in_capital,
+    # accumulated_oci).
+    "assets_current",
+    "liabilities_current",
+    "cash_restricted",
+    "additional_paid_in_capital",
+    "accumulated_oci",
 )
 
 _CASHFLOW_COLUMNS: tuple[str, ...] = (

--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -216,6 +216,26 @@ TRACKED_CONCEPTS: dict[str, tuple[str, ...]] = {
     "shares_authorized": ("CommonStockSharesAuthorized",),
     "shares_issued": ("CommonStockSharesIssued",),
     "retained_earnings": ("RetainedEarningsAccumulatedDeficit",),
+    # Tier 1 + Tier 2 allowlist expansion (#732). Top-30 most-frequent
+    # XBRL concepts that previously landed in financial_facts_raw but
+    # were dropped during normalisation. Working-capital + liquidity +
+    # supplementary P&L items.
+    "assets_current": ("AssetsCurrent",),
+    "liabilities_current": ("LiabilitiesCurrent",),
+    # FASB ASU 2016-18 concept (post-2017 filings include restricted
+    # cash by definition). Kept SEPARATE from the legacy `cash` column
+    # because the two concepts differ in scope by design.
+    "cash_restricted": ("CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents",),
+    "comprehensive_income": ("ComprehensiveIncomeNetOfTax",),
+    "intangible_amortization": ("AmortizationOfIntangibleAssets",),
+    "deferred_income_tax": ("DeferredIncomeTaxExpenseBenefit",),
+    "other_nonoperating_income": ("OtherNonoperatingIncomeExpense",),
+    "additional_paid_in_capital": ("AdditionalPaidInCapital",),
+    "accumulated_oci": ("AccumulatedOtherComprehensiveIncomeLossNetOfTax",),
+    # Weighted-average count of share-equivalents excluded from EPS;
+    # treated as a point-in-time stock (mirrors how shares_basic /
+    # shares_diluted are aggregated — TTM uses latest, not sum).
+    "antidilutive_securities": ("AntidilutiveSecuritiesExcludedFromComputationOfEarningsPerShareAmount",),
 }
 
 # DEI (document-and-entity-information) cover-page facts. Thin set —

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -646,6 +646,11 @@ _FLOW_COLUMNS: frozenset[str] = frozenset(
         "buyback_spend",
         # shares_basic/shares_diluted are weighted averages for a period, so they
         # belong to the period, but TTM uses latest rather than sum.
+        # Tier 1 + Tier 2 expansion (#732) — flow items.
+        "comprehensive_income",
+        "intangible_amortization",
+        "deferred_income_tax",
+        "other_nonoperating_income",
     }
 )
 
@@ -668,6 +673,18 @@ _BALANCE_SHEET_COLUMNS: frozenset[str] = frozenset(
         "shares_authorized",
         "shares_issued",
         "retained_earnings",
+        # Tier 1 + Tier 2 expansion (#732) — point-in-time items.
+        # antidilutive_securities is a weighted-average share-equivalent
+        # count; treated as point-in-time so the Q4-derivation copy
+        # loop carries the FY value forward without a Q4 = FY - Q123
+        # subtraction (same handling as shares_basic / shares_diluted
+        # via the explicit copy at lines ~935–938).
+        "assets_current",
+        "liabilities_current",
+        "cash_restricted",
+        "additional_paid_in_capital",
+        "accumulated_oci",
+        "antidilutive_securities",
     }
 )
 
@@ -737,6 +754,21 @@ class PeriodRow:
     shares_authorized: Decimal | None = None
     shares_issued: Decimal | None = None
     retained_earnings: Decimal | None = None
+
+    # Tier 1 + Tier 2 allowlist expansion (#732). Working-capital,
+    # liquidity, comprehensive income, intangible amortisation,
+    # deferred-tax, paid-in capital, accumulated OCI, antidilutive
+    # share-equivalent count.
+    assets_current: Decimal | None = None
+    liabilities_current: Decimal | None = None
+    cash_restricted: Decimal | None = None
+    comprehensive_income: Decimal | None = None
+    intangible_amortization: Decimal | None = None
+    deferred_income_tax: Decimal | None = None
+    other_nonoperating_income: Decimal | None = None
+    additional_paid_in_capital: Decimal | None = None
+    accumulated_oci: Decimal | None = None
+    antidilutive_securities: Decimal | None = None
 
     # Provenance
     source: str = "sec_edgar"
@@ -981,6 +1013,11 @@ def _upsert_period_raw(
             operating_cf, investing_cf, financing_cf, capex,
             dividends_paid, dps_declared, buyback_spend,
             treasury_shares, shares_authorized, shares_issued, retained_earnings,
+            assets_current, liabilities_current, cash_restricted,
+            comprehensive_income, intangible_amortization,
+            deferred_income_tax, other_nonoperating_income,
+            additional_paid_in_capital, accumulated_oci,
+            antidilutive_securities,
             source, source_ref, reported_currency,
             form_type, filed_date, is_restated, is_derived,
             ingestion_run_id
@@ -997,6 +1034,11 @@ def _upsert_period_raw(
             %(operating_cf)s, %(investing_cf)s, %(financing_cf)s, %(capex)s,
             %(dividends_paid)s, %(dps_declared)s, %(buyback_spend)s,
             %(treasury_shares)s, %(shares_authorized)s, %(shares_issued)s, %(retained_earnings)s,
+            %(assets_current)s, %(liabilities_current)s, %(cash_restricted)s,
+            %(comprehensive_income)s, %(intangible_amortization)s,
+            %(deferred_income_tax)s, %(other_nonoperating_income)s,
+            %(additional_paid_in_capital)s, %(accumulated_oci)s,
+            %(antidilutive_securities)s,
             %(source)s, %(source_ref)s, %(reported_currency)s,
             %(form_type)s, %(filed_date)s, %(is_restated)s, %(is_derived)s,
             %(ingestion_run_id)s
@@ -1041,6 +1083,16 @@ def _upsert_period_raw(
             shares_authorized = EXCLUDED.shares_authorized,
             shares_issued = EXCLUDED.shares_issued,
             retained_earnings = EXCLUDED.retained_earnings,
+            assets_current = EXCLUDED.assets_current,
+            liabilities_current = EXCLUDED.liabilities_current,
+            cash_restricted = EXCLUDED.cash_restricted,
+            comprehensive_income = EXCLUDED.comprehensive_income,
+            intangible_amortization = EXCLUDED.intangible_amortization,
+            deferred_income_tax = EXCLUDED.deferred_income_tax,
+            other_nonoperating_income = EXCLUDED.other_nonoperating_income,
+            additional_paid_in_capital = EXCLUDED.additional_paid_in_capital,
+            accumulated_oci = EXCLUDED.accumulated_oci,
+            antidilutive_securities = EXCLUDED.antidilutive_securities,
             form_type = EXCLUDED.form_type,
             filed_date = EXCLUDED.filed_date,
             is_restated = EXCLUDED.is_restated,
@@ -1094,6 +1146,16 @@ def _upsert_period_raw(
             "shares_authorized": period.shares_authorized,
             "shares_issued": period.shares_issued,
             "retained_earnings": period.retained_earnings,
+            "assets_current": period.assets_current,
+            "liabilities_current": period.liabilities_current,
+            "cash_restricted": period.cash_restricted,
+            "comprehensive_income": period.comprehensive_income,
+            "intangible_amortization": period.intangible_amortization,
+            "deferred_income_tax": period.deferred_income_tax,
+            "other_nonoperating_income": period.other_nonoperating_income,
+            "additional_paid_in_capital": period.additional_paid_in_capital,
+            "accumulated_oci": period.accumulated_oci,
+            "antidilutive_securities": period.antidilutive_securities,
             "source": period.source,
             "source_ref": period.source_ref,
             "reported_currency": period.reported_currency,
@@ -1250,6 +1312,11 @@ def _canonical_merge_instrument(
             operating_cf, investing_cf, financing_cf, capex,
             dividends_paid, dps_declared, buyback_spend,
             treasury_shares, shares_authorized, shares_issued, retained_earnings,
+            assets_current, liabilities_current, cash_restricted,
+            comprehensive_income, intangible_amortization,
+            deferred_income_tax, other_nonoperating_income,
+            additional_paid_in_capital, accumulated_oci,
+            antidilutive_securities,
             source, source_ref, reported_currency,
             form_type, filed_date, is_restated, is_derived,
             normalization_status
@@ -1267,6 +1334,11 @@ def _canonical_merge_instrument(
             operating_cf, investing_cf, financing_cf, capex,
             dividends_paid, dps_declared, buyback_spend,
             treasury_shares, shares_authorized, shares_issued, retained_earnings,
+            assets_current, liabilities_current, cash_restricted,
+            comprehensive_income, intangible_amortization,
+            deferred_income_tax, other_nonoperating_income,
+            additional_paid_in_capital, accumulated_oci,
+            antidilutive_securities,
             source, source_ref, reported_currency,
             form_type, filed_date, is_restated, is_derived,
             'normalized'
@@ -1316,6 +1388,16 @@ def _canonical_merge_instrument(
             shares_authorized = EXCLUDED.shares_authorized,
             shares_issued = EXCLUDED.shares_issued,
             retained_earnings = EXCLUDED.retained_earnings,
+            assets_current = EXCLUDED.assets_current,
+            liabilities_current = EXCLUDED.liabilities_current,
+            cash_restricted = EXCLUDED.cash_restricted,
+            comprehensive_income = EXCLUDED.comprehensive_income,
+            intangible_amortization = EXCLUDED.intangible_amortization,
+            deferred_income_tax = EXCLUDED.deferred_income_tax,
+            other_nonoperating_income = EXCLUDED.other_nonoperating_income,
+            additional_paid_in_capital = EXCLUDED.additional_paid_in_capital,
+            accumulated_oci = EXCLUDED.accumulated_oci,
+            antidilutive_securities = EXCLUDED.antidilutive_securities,
             source = EXCLUDED.source,
             source_ref = EXCLUDED.source_ref,
             form_type = EXCLUDED.form_type,

--- a/sql/089_xbrl_tier1_tier2_columns.sql
+++ b/sql/089_xbrl_tier1_tier2_columns.sql
@@ -1,0 +1,65 @@
+-- 089_xbrl_tier1_tier2_columns.sql
+--
+-- Issue #732 — extend the XBRL allowlist with the Tier 1 + Tier 2
+-- concepts identified by the 2026-05-01 coverage audit. These all
+-- live in financial_facts_raw today (per #451 Phase A the extractor
+-- already captures every concept) but are dropped at normalisation
+-- because TRACKED_CONCEPTS lacks the alias.
+--
+-- Tier 1 (operationally load-bearing for working-capital + liquidity):
+--   AssetsCurrent                                                 -> assets_current        (BS, NUMERIC)
+--   LiabilitiesCurrent                                            -> liabilities_current   (BS, NUMERIC)
+--   CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents -> cash_restricted       (BS, NUMERIC)
+--   ComprehensiveIncomeNetOfTax                                   -> comprehensive_income  (P&L flow)
+--   AmortizationOfIntangibleAssets                                -> intangible_amortization (P&L flow)
+--
+-- Tier 2 (useful, secondary):
+--   DeferredIncomeTaxExpenseBenefit                                  -> deferred_income_tax       (P&L flow)
+--   OtherNonoperatingIncomeExpense                                   -> other_nonoperating_income (P&L flow)
+--   AdditionalPaidInCapital                                          -> additional_paid_in_capital (BS)
+--   AccumulatedOtherComprehensiveIncomeLossNetOfTax                  -> accumulated_oci           (BS)
+--   AntidilutiveSecuritiesExcludedFromComputationOfEarningsPerShareAmount
+--                                                                    -> antidilutive_securities  (weighted-average count)
+--
+-- cash_restricted is added as a SEPARATE column from existing `cash`
+-- because the FASB ASU 2016-18 concept includes restricted cash by
+-- definition while the legacy CashAndCashEquivalentsAtCarryingValue
+-- excludes it. Mixing them in one column would corrupt the time
+-- series. Migration of `cash` callers to the broader concept is a
+-- follow-up not in scope here.
+--
+-- antidilutive_securities is a weighted-average share count, not a
+-- balance-sheet stock; classified as point-in-time (BS) for the Q4
+-- derivation copy + TTM "latest quarter" aggregation, mirroring how
+-- shares_basic / shares_diluted are handled (see comments on
+-- _FLOW_COLUMNS in app/services/fundamentals.py).
+--
+-- Backfill plan: purely additive (new nullable columns); no data
+-- movement. Existing rows stay NULL until the next
+-- normalize_financial_periods run, which re-derives via the
+-- ON CONFLICT DO UPDATE branch in _canonical_merge_instrument
+-- (verified against the same path tested in PR #737 / #731).
+
+ALTER TABLE financial_periods_raw
+    ADD COLUMN IF NOT EXISTS assets_current             NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS liabilities_current        NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS cash_restricted            NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS comprehensive_income       NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS intangible_amortization    NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS deferred_income_tax        NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS other_nonoperating_income  NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS additional_paid_in_capital NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS accumulated_oci            NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS antidilutive_securities    NUMERIC(20,0);
+
+ALTER TABLE financial_periods
+    ADD COLUMN IF NOT EXISTS assets_current             NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS liabilities_current        NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS cash_restricted            NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS comprehensive_income       NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS intangible_amortization    NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS deferred_income_tax        NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS other_nonoperating_income  NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS additional_paid_in_capital NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS accumulated_oci            NUMERIC(20,4),
+    ADD COLUMN IF NOT EXISTS antidilutive_securities    NUMERIC(20,0);

--- a/tests/test_canonical_merge_tier1_tier2_columns_732.py
+++ b/tests/test_canonical_merge_tier1_tier2_columns_732.py
@@ -1,0 +1,274 @@
+"""Integration test for #732 — Tier 1 + Tier 2 column expansion projects
+through the canonical merge ON CONFLICT update branch.
+
+Mirrors the residual-risk pin added in PR #737 / #731 for the four
+ownership columns. Confirms that all ten new columns added by
+migration 089 round-trip from financial_periods_raw through
+_canonical_merge_instrument's ON CONFLICT DO UPDATE branch — the path
+that backfills canonical rows pre-existing from a prior ingest.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services.fundamentals import _canonical_merge_instrument
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+_TIER12_COLUMNS = (
+    "assets_current",
+    "liabilities_current",
+    "cash_restricted",
+    "comprehensive_income",
+    "intangible_amortization",
+    "deferred_income_tax",
+    "other_nonoperating_income",
+    "additional_paid_in_capital",
+    "accumulated_oci",
+    "antidilutive_securities",
+)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} test"),
+    )
+
+
+def _seed_raw_with_tier12(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    period_end: date,
+    fiscal_year: int,
+    source_ref: str,
+    filed_date: date,
+    values: dict[str, Decimal],
+) -> None:
+    """Seed a raw row with whatever subset of Tier 1 / Tier 2 columns
+    appears in ``values``. Columns not in the dict default to NULL."""
+    columns = list(values.keys())
+    placeholders = ", ".join(f"%({c})s" for c in columns)
+    column_list = ", ".join(columns)
+    sql = f"""
+        INSERT INTO financial_periods_raw (
+            instrument_id, period_end_date, period_type,
+            fiscal_year, fiscal_quarter, revenue,
+            {column_list},
+            source, source_ref, reported_currency, filed_date
+        ) VALUES (
+            %(instrument_id)s, %(period_end)s, 'FY',
+            %(fiscal_year)s, NULL, 1000,
+            {placeholders},
+            'sec_edgar', %(source_ref)s, 'USD', %(filed_date)s
+        )
+    """  # noqa: S608 — column list is a hardcoded test whitelist
+    params: dict[str, object] = {
+        "instrument_id": instrument_id,
+        "period_end": period_end,
+        "fiscal_year": fiscal_year,
+        "source_ref": source_ref,
+        "filed_date": filed_date,
+    }
+    params.update(values)  # type: ignore[arg-type]
+    conn.execute(sql, params)  # type: ignore[arg-type]  # SQL built from hardcoded test whitelist
+
+
+def _canonical_tier12_row(
+    conn: psycopg.Connection[tuple],
+    instrument_id: int,
+) -> dict[str, object]:
+    select_cols = ", ".join(["period_end_date", "source_ref", *_TIER12_COLUMNS])
+    sql = f"""
+        SELECT {select_cols}
+        FROM financial_periods
+        WHERE instrument_id = %s
+    """  # noqa: S608 — column list is a hardcoded test whitelist
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(sql, (instrument_id,))
+        rows = cur.fetchall()
+    assert len(rows) == 1, [dict(r) for r in rows]
+    return rows[0]  # type: ignore[return-value]
+
+
+class TestCanonicalMergeTier1Tier2Columns:
+    def test_insert_path_populates_all_tier12_columns(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Fresh canonical row receives every Tier 1 + Tier 2 column from
+        the raw row's INSERT path."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=732_001, symbol="T12A")
+
+        values = {
+            "assets_current": Decimal("450000000"),
+            "liabilities_current": Decimal("320000000"),
+            "cash_restricted": Decimal("85000000"),
+            "comprehensive_income": Decimal("220000"),
+            "intangible_amortization": Decimal("18000"),
+            "deferred_income_tax": Decimal("12000"),
+            "other_nonoperating_income": Decimal("-3500"),
+            "additional_paid_in_capital": Decimal("250000000"),
+            "accumulated_oci": Decimal("-15000000"),
+            "antidilutive_securities": Decimal("4500000"),
+        }
+        _seed_raw_with_tier12(
+            conn,
+            instrument_id=732_001,
+            period_end=date(2024, 12, 31),
+            fiscal_year=2024,
+            source_ref="acc-original",
+            filed_date=date(2025, 2, 14),
+            values=values,
+        )
+        conn.commit()
+
+        _canonical_merge_instrument(conn, 732_001)
+        conn.commit()
+
+        row = _canonical_tier12_row(conn, 732_001)
+        for col, expected in values.items():
+            assert row[col] == expected, f"{col}: expected {expected}, got {row[col]!r}"
+
+    def test_on_conflict_update_path_replaces_all_tier12_columns(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """All ten Tier 1 + Tier 2 columns must round-trip through the
+        merge's ON CONFLICT DO UPDATE clause. A missed assignment for
+        any single column would let stale data survive the amendment.
+
+        The amendment seeds DIFFERENT values for every column so each
+        column's update path is independently observable — a missed
+        SET clause for one column would leave the original value
+        intact and fail the per-column assertion.
+        """
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=732_002, symbol="T12B")
+
+        original: dict[str, Decimal] = {
+            "assets_current": Decimal("400000000"),
+            "liabilities_current": Decimal("300000000"),
+            "cash_restricted": Decimal("80000000"),
+            "comprehensive_income": Decimal("200000"),
+            "intangible_amortization": Decimal("15000"),
+            "deferred_income_tax": Decimal("10000"),
+            "other_nonoperating_income": Decimal("-3000"),
+            "additional_paid_in_capital": Decimal("240000000"),
+            "accumulated_oci": Decimal("-14000000"),
+            "antidilutive_securities": Decimal("4000000"),
+        }
+        _seed_raw_with_tier12(
+            conn,
+            instrument_id=732_002,
+            period_end=date(2024, 12, 31),
+            fiscal_year=2024,
+            source_ref="acc-original",
+            filed_date=date(2025, 2, 14),
+            values=original,
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 732_002)
+        conn.commit()
+
+        # Amendment re-files every column with a distinct value so any
+        # missed DO UPDATE SET assignment trips the per-column assert.
+        amended: dict[str, Decimal] = {
+            "assets_current": Decimal("450000000"),
+            "liabilities_current": Decimal("320000000"),
+            "cash_restricted": Decimal("85000000"),
+            "comprehensive_income": Decimal("220000"),
+            "intangible_amortization": Decimal("18000"),
+            "deferred_income_tax": Decimal("12000"),
+            "other_nonoperating_income": Decimal("-3500"),
+            "additional_paid_in_capital": Decimal("250000000"),
+            "accumulated_oci": Decimal("-15000000"),
+            "antidilutive_securities": Decimal("4500000"),
+        }
+        # Sanity: every original/amended pair MUST differ — otherwise
+        # a missed SET clause could pass silently because the column
+        # value happens to match.
+        for col in original:
+            assert original[col] != amended[col], f"test design bug: {col} unchanged between original and amendment"
+        _seed_raw_with_tier12(
+            conn,
+            instrument_id=732_002,
+            period_end=date(2024, 12, 31),
+            fiscal_year=2024,
+            source_ref="acc-amendment",
+            filed_date=date(2025, 5, 1),
+            values=amended,
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 732_002)
+        conn.commit()
+
+        row = _canonical_tier12_row(conn, 732_002)
+        assert row["source_ref"] == "acc-amendment"
+        for col, expected in amended.items():
+            assert row[col] == expected, f"{col}: expected {expected}, got {row[col]!r}"
+
+    def test_on_conflict_update_clears_columns_dropped_by_amendment(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A column populated on the original but absent (NULL) on the
+        amendment must be cleared on the canonical row. The
+        ``EXCLUDED.col`` semantics propagate NULL correctly only if
+        the column appears in the DO UPDATE SET clause — verifying
+        per Codex residual-risk note on PR review."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=732_003, symbol="T12C")
+
+        # Original: every Tier 1 + Tier 2 column populated.
+        original: dict[str, Decimal] = {col: Decimal(1_000_000 + i) for i, col in enumerate(_TIER12_COLUMNS)}
+        _seed_raw_with_tier12(
+            conn,
+            instrument_id=732_003,
+            period_end=date(2024, 12, 31),
+            fiscal_year=2024,
+            source_ref="acc-original",
+            filed_date=date(2025, 2, 14),
+            values=original,
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 732_003)
+        conn.commit()
+
+        # Amendment: ONLY assets_current populated; the other nine
+        # columns absent → NULL in the raw row → must propagate to
+        # canonical via EXCLUDED.col.
+        amended: dict[str, Decimal] = {"assets_current": Decimal("999000000")}
+        _seed_raw_with_tier12(
+            conn,
+            instrument_id=732_003,
+            period_end=date(2024, 12, 31),
+            fiscal_year=2024,
+            source_ref="acc-amendment",
+            filed_date=date(2025, 5, 1),
+            values=amended,
+        )
+        conn.commit()
+        _canonical_merge_instrument(conn, 732_003)
+        conn.commit()
+
+        row = _canonical_tier12_row(conn, 732_003)
+        assert row["assets_current"] == Decimal("999000000")
+        for col in _TIER12_COLUMNS:
+            if col == "assets_current":
+                continue
+            assert row[col] is None, f"{col}: expected NULL after amendment dropped it, got {row[col]!r}"

--- a/tests/test_financial_normalization.py
+++ b/tests/test_financial_normalization.py
@@ -1115,12 +1115,13 @@ class TestOwnershipColumnProjection:
 
 # ---------------------------------------------------------------------------
 # #732: Tier 1 + Tier 2 allowlist expansion. Ten new aliases project into
-# financial_periods. Five flow items (comprehensive_income,
-# intangible_amortization, deferred_income_tax, other_nonoperating_income,
-# plus the implicit antidilutive_securities which the schema treats as
-# point-in-time so it inherits the FY value on Q4 derivation), and five
-# point-in-time items (assets_current, liabilities_current, cash_restricted,
-# additional_paid_in_capital, accumulated_oci, antidilutive_securities).
+# financial_periods. Four flow items (comprehensive_income,
+# intangible_amortization, deferred_income_tax, other_nonoperating_income),
+# and six point-in-time items (assets_current, liabilities_current,
+# cash_restricted, additional_paid_in_capital, accumulated_oci,
+# antidilutive_securities — the last is a weighted-average share count
+# kept as point-in-time so the Q4 derivation copies the FY value forward
+# instead of subtracting Q1+Q2+Q3 from FY).
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_financial_normalization.py
+++ b/tests/test_financial_normalization.py
@@ -1111,3 +1111,354 @@ class TestOwnershipColumnProjection:
         assert q4.is_derived is True
         assert q4.treasury_shares == Decimal("12500000")
         assert q4.retained_earnings == Decimal("180000000000")
+
+
+# ---------------------------------------------------------------------------
+# #732: Tier 1 + Tier 2 allowlist expansion. Ten new aliases project into
+# financial_periods. Five flow items (comprehensive_income,
+# intangible_amortization, deferred_income_tax, other_nonoperating_income,
+# plus the implicit antidilutive_securities which the schema treats as
+# point-in-time so it inherits the FY value on Q4 derivation), and five
+# point-in-time items (assets_current, liabilities_current, cash_restricted,
+# additional_paid_in_capital, accumulated_oci, antidilutive_securities).
+# ---------------------------------------------------------------------------
+
+
+class TestTier1Tier2AllowlistProjection:
+    def _bs_fact(
+        self,
+        *,
+        concept: str,
+        val: Decimal,
+        period_end: str = "2024-12-31",
+        fiscal_year: int = 2024,
+        fiscal_period: str = "FY",
+        accession_number: str = "fy",
+        unit: str = "USD",
+    ) -> FactRow:
+        return _fact(
+            concept=concept,
+            val=val,
+            period_end=period_end,
+            period_start=None,
+            frame=None,
+            fiscal_period=fiscal_period,
+            fiscal_year=fiscal_year,
+            accession_number=accession_number,
+            form_type="10-K",
+            unit=unit,
+        )
+
+    def _fy_anchor(self, fiscal_year: int = 2024) -> FactRow:
+        return _fact(
+            concept="Revenues",
+            val=Decimal("1000000"),
+            period_end=f"{fiscal_year}-12-31",
+            period_start=f"{fiscal_year}-01-01",
+            frame=f"CY{fiscal_year}",
+            fiscal_period="FY",
+            fiscal_year=fiscal_year,
+            accession_number="fy",
+            form_type="10-K",
+        )
+
+    def test_tier1_balance_sheet_aliases(self) -> None:
+        """AssetsCurrent / LiabilitiesCurrent / CashCashEquivalentsRestrictedCash
+        all project to their canonical columns from a single FY balance
+        sheet."""
+        facts = [
+            self._fy_anchor(),
+            self._bs_fact(concept="AssetsCurrent", val=Decimal("450000000")),
+            self._bs_fact(concept="LiabilitiesCurrent", val=Decimal("320000000")),
+            self._bs_fact(
+                concept="CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents",
+                val=Decimal("85000000"),
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        assert len(periods) == 1
+        p = periods[0]
+        assert p.assets_current == Decimal("450000000")
+        assert p.liabilities_current == Decimal("320000000")
+        assert p.cash_restricted == Decimal("85000000")
+
+    def test_cash_restricted_separate_from_cash(self) -> None:
+        """CashAndCashEquivalentsAtCarryingValue → cash; the FASB
+        ASU 2016-18 concept → cash_restricted. The two columns must
+        not collide — they are distinct concepts and an issuer can
+        emit both."""
+        facts = [
+            self._fy_anchor(),
+            self._bs_fact(
+                concept="CashAndCashEquivalentsAtCarryingValue",
+                val=Decimal("60000000"),
+            ),
+            self._bs_fact(
+                concept="CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents",
+                val=Decimal("85000000"),
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        p = periods[0]
+        assert p.cash == Decimal("60000000")
+        assert p.cash_restricted == Decimal("85000000")
+
+    def test_tier1_flow_aliases(self) -> None:
+        """ComprehensiveIncomeNetOfTax + AmortizationOfIntangibleAssets
+        project into the FY row alongside the revenue anchor."""
+        facts = [
+            _fact(
+                concept="Revenues",
+                val=Decimal("1000000"),
+                period_end="2024-12-31",
+                period_start="2024-01-01",
+                frame="CY2024",
+                fiscal_period="FY",
+                fiscal_year=2024,
+                accession_number="fy",
+                form_type="10-K",
+            ),
+            _fact(
+                concept="ComprehensiveIncomeNetOfTax",
+                val=Decimal("220000"),
+                period_end="2024-12-31",
+                period_start="2024-01-01",
+                frame="CY2024",
+                fiscal_period="FY",
+                fiscal_year=2024,
+                accession_number="fy",
+                form_type="10-K",
+            ),
+            _fact(
+                concept="AmortizationOfIntangibleAssets",
+                val=Decimal("18000"),
+                period_end="2024-12-31",
+                period_start="2024-01-01",
+                frame="CY2024",
+                fiscal_period="FY",
+                fiscal_year=2024,
+                accession_number="fy",
+                form_type="10-K",
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        p = periods[0]
+        assert p.comprehensive_income == Decimal("220000")
+        assert p.intangible_amortization == Decimal("18000")
+
+    def test_tier2_flow_aliases(self) -> None:
+        facts = [
+            _fact(
+                concept="Revenues",
+                val=Decimal("1000000"),
+                period_end="2024-12-31",
+                period_start="2024-01-01",
+                frame="CY2024",
+                fiscal_period="FY",
+                fiscal_year=2024,
+                accession_number="fy",
+                form_type="10-K",
+            ),
+            _fact(
+                concept="DeferredIncomeTaxExpenseBenefit",
+                val=Decimal("12000"),
+                period_end="2024-12-31",
+                period_start="2024-01-01",
+                frame="CY2024",
+                fiscal_period="FY",
+                fiscal_year=2024,
+                accession_number="fy",
+                form_type="10-K",
+            ),
+            _fact(
+                concept="OtherNonoperatingIncomeExpense",
+                val=Decimal("-3500"),
+                period_end="2024-12-31",
+                period_start="2024-01-01",
+                frame="CY2024",
+                fiscal_period="FY",
+                fiscal_year=2024,
+                accession_number="fy",
+                form_type="10-K",
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        p = periods[0]
+        assert p.deferred_income_tax == Decimal("12000")
+        assert p.other_nonoperating_income == Decimal("-3500")
+
+    def test_tier2_balance_sheet_aliases(self) -> None:
+        facts = [
+            self._fy_anchor(),
+            self._bs_fact(
+                concept="AdditionalPaidInCapital",
+                val=Decimal("250000000"),
+            ),
+            self._bs_fact(
+                concept="AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+                val=Decimal("-15000000"),
+            ),
+            self._bs_fact(
+                concept="AntidilutiveSecuritiesExcludedFromComputationOfEarningsPerShareAmount",
+                val=Decimal("4500000"),
+                unit="shares",
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        p = periods[0]
+        assert p.additional_paid_in_capital == Decimal("250000000")
+        assert p.accumulated_oci == Decimal("-15000000")
+        assert p.antidilutive_securities == Decimal("4500000")
+
+    def test_q4_derivation_subtracts_flow_columns(self) -> None:
+        """Tier 1 + Tier 2 flow items participate in the Q4 = FY -
+        Q1+Q2+Q3 subtraction. comprehensive_income is the canonical
+        one to pin (most-frequent flow concept in the Tier 1 audit)."""
+        facts = [
+            _fact(
+                concept="ComprehensiveIncomeNetOfTax",
+                fiscal_period="Q1",
+                val=Decimal("50"),
+                period_end="2024-03-31",
+                period_start="2024-01-01",
+                frame="CY2024Q1",
+                accession_number="q1",
+            ),
+            _fact(
+                concept="ComprehensiveIncomeNetOfTax",
+                fiscal_period="Q2",
+                val=Decimal("60"),
+                period_end="2024-06-30",
+                period_start="2024-04-01",
+                frame="CY2024Q2",
+                accession_number="q2",
+            ),
+            _fact(
+                concept="ComprehensiveIncomeNetOfTax",
+                fiscal_period="Q3",
+                val=Decimal("55"),
+                period_end="2024-09-30",
+                period_start="2024-07-01",
+                frame="CY2024Q3",
+                accession_number="q3",
+            ),
+            _fact(
+                concept="ComprehensiveIncomeNetOfTax",
+                fiscal_period="FY",
+                fiscal_year=2024,
+                val=Decimal("250"),
+                period_end="2024-12-31",
+                period_start="2024-01-01",
+                frame="CY2024",
+                form_type="10-K",
+                accession_number="fy",
+            ),
+            # Revenue facts so Q4 derivation triggers (driven by FY +
+            # all three quarters present for the canonical row).
+            _fact(
+                concept="Revenues",
+                fiscal_period="Q1",
+                val=Decimal("100"),
+                period_end="2024-03-31",
+                period_start="2024-01-01",
+                frame="CY2024Q1",
+                accession_number="q1",
+            ),
+            _fact(
+                concept="Revenues",
+                fiscal_period="Q2",
+                val=Decimal("120"),
+                period_end="2024-06-30",
+                period_start="2024-04-01",
+                frame="CY2024Q2",
+                accession_number="q2",
+            ),
+            _fact(
+                concept="Revenues",
+                fiscal_period="Q3",
+                val=Decimal("110"),
+                period_end="2024-09-30",
+                period_start="2024-07-01",
+                frame="CY2024Q3",
+                accession_number="q3",
+            ),
+            _fact(
+                concept="Revenues",
+                fiscal_period="FY",
+                fiscal_year=2024,
+                val=Decimal("500"),
+                period_end="2024-12-31",
+                period_start="2024-01-01",
+                frame="CY2024",
+                form_type="10-K",
+                accession_number="fy",
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        q4 = next(p for p in periods if p.period_type == "Q4")
+        assert q4.is_derived is True
+        # 250 - 50 - 60 - 55 = 85
+        assert q4.comprehensive_income == Decimal("85")
+
+    def test_q4_balance_sheet_inherits_fy_for_tier1_tier2(self) -> None:
+        """Tier 1 / Tier 2 point-in-time columns (assets_current,
+        liabilities_current, additional_paid_in_capital, etc.) inherit
+        the FY value on Q4 derivation — same handling as total_assets."""
+        facts = [
+            _fact(
+                concept="Revenues",
+                fiscal_period="Q1",
+                val=Decimal("100"),
+                period_end="2024-03-31",
+                period_start="2024-01-01",
+                frame="CY2024Q1",
+                accession_number="q1",
+            ),
+            _fact(
+                concept="Revenues",
+                fiscal_period="Q2",
+                val=Decimal("120"),
+                period_end="2024-06-30",
+                period_start="2024-04-01",
+                frame="CY2024Q2",
+                accession_number="q2",
+            ),
+            _fact(
+                concept="Revenues",
+                fiscal_period="Q3",
+                val=Decimal("110"),
+                period_end="2024-09-30",
+                period_start="2024-07-01",
+                frame="CY2024Q3",
+                accession_number="q3",
+            ),
+            _fact(
+                concept="Revenues",
+                fiscal_period="FY",
+                fiscal_year=2024,
+                val=Decimal("500"),
+                period_end="2024-12-31",
+                period_start="2024-01-01",
+                frame="CY2024",
+                form_type="10-K",
+                accession_number="fy",
+            ),
+            self._bs_fact(
+                concept="AssetsCurrent",
+                val=Decimal("450000000"),
+            ),
+            self._bs_fact(
+                concept="LiabilitiesCurrent",
+                val=Decimal("320000000"),
+            ),
+            self._bs_fact(
+                concept="AdditionalPaidInCapital",
+                val=Decimal("250000000"),
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        q4 = next(p for p in periods if p.period_type == "Q4")
+        assert q4.is_derived is True
+        assert q4.assets_current == Decimal("450000000")
+        assert q4.liabilities_current == Decimal("320000000")
+        assert q4.additional_paid_in_capital == Decimal("250000000")


### PR DESCRIPTION
## What

Extends \`TRACKED_CONCEPTS\` with ten high-frequency concepts identified by the 2026-05-01 coverage audit. Same mechanical pattern as #731 (PR #737): new alias → \`PeriodRow\` field → \`_upsert_period_raw\` SQL → \`_canonical_merge_instrument\` INSERT + ON CONFLICT UPDATE → reader \`_INCOME_COLUMNS\` / \`_BALANCE_COLUMNS\`.

### Tier 1 (operationally load-bearing)

| XBRL concept | Column | Statement |
|---|---|---|
| \`AssetsCurrent\` | \`assets_current\` | balance |
| \`LiabilitiesCurrent\` | \`liabilities_current\` | balance |
| \`CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents\` | \`cash_restricted\` | balance |
| \`ComprehensiveIncomeNetOfTax\` | \`comprehensive_income\` | income (flow) |
| \`AmortizationOfIntangibleAssets\` | \`intangible_amortization\` | income (flow) |

### Tier 2 (useful, secondary)

| XBRL concept | Column | Statement |
|---|---|---|
| \`DeferredIncomeTaxExpenseBenefit\` | \`deferred_income_tax\` | income (flow) |
| \`OtherNonoperatingIncomeExpense\` | \`other_nonoperating_income\` | income (flow) |
| \`AdditionalPaidInCapital\` | \`additional_paid_in_capital\` | balance |
| \`AccumulatedOtherComprehensiveIncomeLossNetOfTax\` | \`accumulated_oci\` | balance |
| \`AntidilutiveSecuritiesExcludedFromComputationOfEarningsPerShareAmount\` | \`antidilutive_securities\` | income |

## Why

Coverage audit: 96.7% of distinct XBRL concepts in \`financial_facts_raw\` are parsed-and-dropped. In the top-200 most-frequent concepts, 148 are dropped. This PR closes ten of the most-frequent gaps in two tiers as the ticket prescribes.

## Conscious tradeoffs

**\`cash_restricted\` is a separate column from \`cash\`.** The FASB ASU 2016-18 concept (\`CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents\`) includes restricted cash by definition; the legacy \`CashAndCashEquivalentsAtCarryingValue\` excludes it. Folding both into \`cash\` would corrupt the time series. Migration of \`cash\` callers to the broader concept is a deliberate follow-up — out of scope here.

**\`antidilutive_securities\` is classified as point-in-time, not flow.** It is a weighted-average share-equivalent count for the period. Including it in \`_FLOW_COLUMNS\` would make Q4 derivation compute \`Q4 = FY - Q1 - Q2 - Q3\` over share counts, which is wrong. Mirrors how \`shares_basic\` / \`shares_diluted\` are handled (excluded from \`_FLOW_COLUMNS\`; explicit FY-copy in the Q4 derivation block).

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pyright\` — clean
- [x] \`uv run pytest tests/test_financial_normalization.py\` — 35 passed (7 new in \`TestTier1Tier2AllowlistProjection\`)
- [x] \`uv run pytest tests/test_canonical_merge_tier1_tier2_columns_732.py\` — 3 new integration tests:
   - \`test_insert_path_populates_all_tier12_columns\` — fresh canonical row
   - \`test_on_conflict_update_path_replaces_all_tier12_columns\` — every column round-trips through the update branch (covers Codex pre-push finding that the prior 5/10-column version was incomplete)
   - \`test_on_conflict_update_clears_columns_dropped_by_amendment\` — stale-clearing via \`EXCLUDED.col\` propagating NULL when the amendment drops a previously-set column
- [x] Full \`uv run pytest\` — 3055 passed; one pre-existing flake (\`test_drain_pending_at_boot_claims_each_row\`, fails on \`main\` without these changes — unrelated, dev-DB pollution)
- [x] Codex pre-push review — only finding was the integration-test coverage gap above; addressed in the same PR.

## Backfill

Same as #731: existing canonical rows pre-089 have NULL for the ten new columns. The next \`normalize_financial_periods\` run rewrites canonical rows via the ON CONFLICT UPDATE branch. \`tests/test_canonical_merge_tier1_tier2_columns_732.py::test_on_conflict_update_path_replaces_all_tier12_columns\` pins this for every column individually.

## Linked

Depends on #731 (#737) — landed first because its surface was smaller and ownership-card-blocking. This PR builds on top of the same projection pattern.