### PR TITLE
feat(#730): 13F-HR institutional holdings — schema + XML parser (PR 1 of 4)

### DIFF
--- a/app/providers/implementations/sec_13f.py
+++ b/app/providers/implementations/sec_13f.py
@@ -1,0 +1,350 @@
+"""SEC 13F-HR institutional holdings parser.
+
+13F-HR is filed quarterly by every institutional manager with
+discretionary AUM exceeding $100M (15 USC 78m(f)). Each filing has
+two XML attachments:
+
+  * ``primary_doc.xml`` — header, filer metadata, cover page (period
+    of report, filing manager name), summary page (total table value
+    and table-entry count).
+  * ``infotable.xml`` (sometimes named with the accession's date
+    suffix) — the holdings list. One ``<infoTable>`` element per
+    issuer + share class, with CUSIP, value, share count or
+    principal amount, voting authority breakdown, and put/call
+    indicator for option exposure.
+
+This module is a pure parser: XML strings in, typed dataclasses out.
+HTTP fetch + DB resolution stay in the service layer — providers
+remain thin per the settled provider-design rule.
+
+XML namespaces:
+
+  * primary_doc.xml uses ``http://www.sec.gov/edgar/thirteenffiler``
+    for cover-page elements.
+  * infotable.xml uses
+    ``http://www.sec.gov/edgar/document/thirteenf/informationtable``.
+
+Both are stripped at parse time via :func:`_strip_ns` so callers
+work with bare element names (``infoTable``, not the namespaced form).
+
+#730 PR 1 of 4. Subsequent PRs add the ingester (PR 2),
+filer-type classifier (PR 3), and reader API + frontend wiring
+(PR 4 — the ownership card #729 follow-on).
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET  # noqa: S405 — SEC EDGAR is the trusted source for 13F-HR XML.
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Final, Literal
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ThirteenFFilerInfo:
+    """Header + cover-page metadata extracted from primary_doc.xml.
+
+    Field semantics:
+      * ``cik`` — zero-padded 10-digit CIK string. Filers are sometimes
+        called Reporting Managers in the 13F instructions; the CIK
+        joins to the rest of the SEC ingest in this repo.
+      * ``name`` — filing manager's name as it appears on the cover.
+      * ``period_of_report`` — fiscal-quarter end date that the
+        holdings reflect. Note: 13F-HR is a quarterly snapshot, not
+        a continuous record.
+      * ``filed_at`` — header signature date. NULL when the parser
+        cannot find a signature block (rare; typically a malformed
+        filing).
+      * ``table_value_total_usd`` — summary page total in USD. SEC
+        instructions changed in 2022 from "thousands" to "whole
+        dollars" — this value is whatever the filer entered. Unit
+        normalisation lives in the service layer.
+    """
+
+    cik: str
+    name: str
+    period_of_report: date
+    filed_at: datetime | None
+    table_value_total_usd: Decimal | None
+
+
+@dataclass(frozen=True)
+class ThirteenFHolding:
+    """One ``<infoTable>`` row from an infotable.xml attachment.
+
+    Field semantics:
+      * ``cusip`` — issuer + share-class identifier (9 chars). Joined
+        in the service layer via ``external_identifiers`` to map to
+        the eBull instrument_id.
+      * ``name_of_issuer`` / ``title_of_class`` — filer-supplied
+        labels; informational only, not used for resolution.
+      * ``value_usd`` — Column 4 of the 13F-HR. Whole dollars
+        post-2022; thousands pre-2022. The parser does NOT normalise
+        — service layer applies any conversion based on
+        ``period_of_report``.
+      * ``shares_or_principal`` — Column 5 quantity. Type is in
+        ``shares_or_principal_type`` (``SH`` for shares, ``PRN``
+        for principal-amount-of-bonds-style holdings).
+      * ``put_call`` — option exposure indicator. Underlying-equity
+        rows leave this NULL.
+      * ``investment_discretion`` — ``SOLE`` / ``DEFINED`` / ``OTR``;
+        retained as a free-text label for audit, not used for the
+        ownership-card slice computation.
+      * ``voting_sole`` / ``voting_shared`` / ``voting_none`` — three
+        sub-amounts on the votingAuthority breakdown. Ownership-card
+        consumers want the dominant authority; the service layer
+        derives that label and writes the canonical
+        ``voting_authority`` column.
+    """
+
+    cusip: str
+    name_of_issuer: str
+    title_of_class: str
+    value_usd: Decimal
+    shares_or_principal: Decimal
+    shares_or_principal_type: str
+    put_call: Literal["PUT", "CALL"] | None
+    investment_discretion: str | None
+    voting_sole: Decimal
+    voting_shared: Decimal
+    voting_none: Decimal
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+_NUMERIC_FIELDS: Final[tuple[str, ...]] = (
+    "value",
+    "sshPrnamt",
+    "Sole",
+    "Shared",
+    "None",
+)
+
+
+def _strip_ns(tag: str) -> str:
+    """``{http://...}foo`` -> ``foo``. Idempotent on un-namespaced tags."""
+    if "}" in tag:
+        return tag.split("}", 1)[1]
+    return tag
+
+
+def _walk_text(root: ET.Element, name: str) -> str | None:
+    """Find the first descendant element whose stripped name matches."""
+    for el in root.iter():
+        if _strip_ns(el.tag) == name and el.text is not None:
+            text = el.text.strip()
+            if text:
+                return text
+    return None
+
+
+def _find_descendant(root: ET.Element, name: str) -> ET.Element | None:
+    """Find the first descendant element whose stripped name matches.
+
+    Returns the element so callers can scope further sub-element
+    lookups to it — ``_walk_text`` searches the entire tree, which
+    is unsafe for ambiguous element names like ``<name>`` that can
+    appear in multiple unrelated subtrees (filingManager, signature
+    block, internalUseFile, etc.).
+    """
+    for el in root.iter():
+        if _strip_ns(el.tag) == name:
+            return el
+    return None
+
+
+def _child_text(parent: ET.Element, name: str) -> str | None:
+    """Like ``_walk_text`` but scoped to ``parent``'s descendants."""
+    for el in parent.iter():
+        if _strip_ns(el.tag) == name and el.text is not None:
+            text = el.text.strip()
+            if text:
+                return text
+    return None
+
+
+def _decimal_or_none(text: str | None) -> Decimal | None:
+    if text is None:
+        return None
+    try:
+        return Decimal(text.replace(",", ""))
+    except InvalidOperation:
+        return None
+
+
+def _parse_date_mmddyyyy(text: str | None) -> date | None:
+    """13F cover-page reportCalendarOrQuarter ships as MM-DD-YYYY."""
+    if text is None:
+        return None
+    for fmt in ("%m-%d-%Y", "%Y-%m-%d", "%m/%d/%Y"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _parse_signature_date(text: str | None) -> datetime | None:
+    """Signature block carries a date but no time; coerce to midnight UTC."""
+    parsed = _parse_date_mmddyyyy(text)
+    if parsed is None:
+        return None
+    return datetime(parsed.year, parsed.month, parsed.day)
+
+
+def _zero_pad_cik(text: str) -> str:
+    digits = "".join(ch for ch in text if ch.isdigit())
+    if not digits:
+        raise ValueError(f"primary_doc.xml carried a non-numeric CIK: {text!r}")
+    return digits.zfill(10)
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def parse_primary_doc(xml: str) -> ThirteenFFilerInfo:
+    """Parse a 13F-HR ``primary_doc.xml`` payload.
+
+    Raises ``ValueError`` if the document is missing the CIK, the
+    filing manager name, or the period of report — those three are
+    the minimum viable record for an ingester to write rows against.
+    """
+    root = ET.fromstring(xml)  # noqa: S314 — SEC EDGAR is the trusted source.
+
+    cik_text = _walk_text(root, "cik")
+    if cik_text is None:
+        raise ValueError("primary_doc.xml is missing a <cik> element")
+
+    # Scope the name lookup to the ``<filingManager>`` subtree so a
+    # ``<name>`` that appears under ``<signatureBlock>`` (signer's
+    # name) or any other unrelated branch can never be picked by
+    # mistake. Codex pre-push review caught this on PR review.
+    filing_manager = _find_descendant(root, "filingManager")
+    name = _child_text(filing_manager, "name") if filing_manager is not None else None
+    if name is None:
+        raise ValueError("primary_doc.xml is missing the filingManager <name>")
+
+    period_text = _walk_text(root, "reportCalendarOrQuarter")
+    period_of_report = _parse_date_mmddyyyy(period_text)
+    if period_of_report is None:
+        raise ValueError(f"primary_doc.xml has no parseable <reportCalendarOrQuarter>; got {period_text!r}")
+
+    signature_date = _walk_text(root, "signatureDate")
+    filed_at = _parse_signature_date(signature_date)
+
+    table_value_total = _decimal_or_none(_walk_text(root, "tableValueTotal"))
+
+    return ThirteenFFilerInfo(
+        cik=_zero_pad_cik(cik_text),
+        name=name.strip(),
+        period_of_report=period_of_report,
+        filed_at=filed_at,
+        table_value_total_usd=table_value_total,
+    )
+
+
+def parse_infotable(xml: str) -> list[ThirteenFHolding]:
+    """Parse a 13F-HR ``infotable.xml`` payload.
+
+    Returns one :class:`ThirteenFHolding` per ``<infoTable>`` element.
+    Skips rows where the CUSIP, value, or share count cannot be
+    resolved — those are malformed entries that no consumer of the
+    ingest can act on.
+    """
+    root = ET.fromstring(xml)  # noqa: S314 — SEC EDGAR is the trusted source.
+
+    holdings: list[ThirteenFHolding] = []
+    for entry in root.iter():
+        if _strip_ns(entry.tag) != "infoTable":
+            continue
+
+        fields: dict[str, str] = {}
+        for child in entry.iter():
+            tag = _strip_ns(child.tag)
+            if child.text is not None:
+                text = child.text.strip()
+                if text:
+                    fields[tag] = text
+
+        cusip = fields.get("cusip")
+        value_text = fields.get("value")
+        shares_text = fields.get("sshPrnamt")
+        if cusip is None or value_text is None or shares_text is None:
+            logger.debug(
+                "13F infoTable row dropped — missing required field; have keys=%s",
+                sorted(fields),
+            )
+            continue
+
+        value_usd = _decimal_or_none(value_text)
+        shares_or_principal = _decimal_or_none(shares_text)
+        if value_usd is None or shares_or_principal is None:
+            logger.debug(
+                "13F infoTable row dropped — non-numeric value/shares; cusip=%s",
+                cusip,
+            )
+            continue
+
+        put_call_raw = fields.get("putCall")
+        put_call: Literal["PUT", "CALL"] | None
+        if put_call_raw is None:
+            put_call = None
+        elif put_call_raw.upper() == "PUT":
+            put_call = "PUT"
+        elif put_call_raw.upper() == "CALL":
+            put_call = "CALL"
+        else:
+            logger.warning("13F infoTable row had unknown putCall=%r; treating as None", put_call_raw)
+            put_call = None
+
+        holdings.append(
+            ThirteenFHolding(
+                cusip=cusip,
+                name_of_issuer=fields.get("nameOfIssuer", ""),
+                title_of_class=fields.get("titleOfClass", ""),
+                value_usd=value_usd,
+                shares_or_principal=shares_or_principal,
+                shares_or_principal_type=fields.get("sshPrnamtType", "SH"),
+                put_call=put_call,
+                investment_discretion=fields.get("investmentDiscretion"),
+                voting_sole=_decimal_or_none(fields.get("Sole")) or Decimal(0),
+                voting_shared=_decimal_or_none(fields.get("Shared")) or Decimal(0),
+                voting_none=_decimal_or_none(fields.get("None")) or Decimal(0),
+            )
+        )
+
+    return holdings
+
+
+def dominant_voting_authority(holding: ThirteenFHolding) -> Literal["SOLE", "SHARED", "NONE"] | None:
+    """Pick the largest of the three voting-authority sub-amounts.
+
+    Helper exposed for the service layer (PR 2) so the canonical
+    ``voting_authority`` column gets the correct constrained value.
+    Returns ``None`` only when all three sub-amounts are zero — that
+    case maps to NULL on insert (the schema CHECK allows it).
+    """
+    sole = holding.voting_sole
+    shared = holding.voting_shared
+    none = holding.voting_none
+    if sole == 0 and shared == 0 and none == 0:
+        return None
+    if sole >= shared and sole >= none:
+        return "SOLE"
+    if shared >= none:
+        return "SHARED"
+    return "NONE"

--- a/app/providers/implementations/sec_13f.py
+++ b/app/providers/implementations/sec_13f.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import logging
 import xml.etree.ElementTree as ET  # noqa: S405 — SEC EDGAR is the trusted source for 13F-HR XML.
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Final, Literal
 
@@ -197,11 +197,15 @@ def _parse_date_mmddyyyy(text: str | None) -> date | None:
 
 
 def _parse_signature_date(text: str | None) -> datetime | None:
-    """Signature block carries a date but no time; coerce to midnight UTC."""
+    """Signature block carries a date but no time. Coerce to midnight
+    UTC and tag the timezone explicitly so the value lands in
+    ``filed_at TIMESTAMPTZ`` without psycopg falling back to the
+    server's local zone (which differs from UTC on non-UTC dev hosts
+    and would cause cross-tz drift in the persisted timestamp)."""
     parsed = _parse_date_mmddyyyy(text)
     if parsed is None:
         return None
-    return datetime(parsed.year, parsed.month, parsed.day)
+    return datetime(parsed.year, parsed.month, parsed.day, tzinfo=UTC)
 
 
 def _zero_pad_cik(text: str) -> str:

--- a/sql/090_institutional_filers_holdings.sql
+++ b/sql/090_institutional_filers_holdings.sql
@@ -33,8 +33,16 @@
 --     (which can be reported as principal-amount equivalents on
 --     bond holdings) and exotic share counts don't overflow.
 --   * market_value_usd is reported by the filer in USD thousands
---     pre-2023 and USD whole dollars post-2022 — the parser layer
---     normalises both to whole dollars before insert.
+--     pre-2023 and USD whole dollars post-2022. The parser layer
+--     does NOT normalise — it returns the raw value as Decimal, and
+--     the service layer (PR 2) applies any unit conversion based on
+--     ``period_of_report``. This split keeps the parser pure and
+--     leaves the unit-policy decision in one place.
+--   * filed_at is nullable: ``primary_doc.xml`` may be missing the
+--     signature block on a malformed filing; the parser returns
+--     ``None`` rather than raising so the rest of the holding rows
+--     can still be ingested. The ingester (PR 2) decides whether to
+--     persist filings with NULL filed_at or to tombstone them.
 --
 -- _PLANNER_TABLES in tests/fixtures/ebull_test_db.py is updated in
 -- the same PR per the prevention-log entry "When a migration adds
@@ -66,7 +74,7 @@ CREATE TABLE IF NOT EXISTS institutional_holdings (
         CHECK (voting_authority IS NULL OR voting_authority IN ('SOLE', 'SHARED', 'NONE')),
     is_put_call        TEXT
         CHECK (is_put_call IS NULL OR is_put_call IN ('PUT', 'CALL')),
-    filed_at           TIMESTAMPTZ NOT NULL
+    filed_at           TIMESTAMPTZ
 );
 
 -- Idempotent re-ingest needs uniqueness on

--- a/sql/090_institutional_filers_holdings.sql
+++ b/sql/090_institutional_filers_holdings.sql
@@ -1,0 +1,96 @@
+-- 090_institutional_filers_holdings.sql
+--
+-- Issue #730 (Plan C.2) — schema for SEC 13F-HR institutional
+-- holdings ingest. PR 1 of the four-part split: this PR ships the
+-- tables + the XML parser; the ingester (PR 2), filer-type
+-- classifier (PR 3), and reader API + frontend wiring (PR 4) follow.
+--
+-- 13F-HR is filed quarterly by every institutional manager with
+-- discretionary AUM > $100M. Holdings live in the per-accession
+-- ``infotable.xml``; filer metadata in ``primary_doc.xml``. The
+-- ingest aggregates across filers to derive institutional ownership
+-- per stock (Institutions slice on the ownership card #729) and
+-- filters on filer_type to derive ETF ownership separately (ETFs
+-- slice — every US-domiciled ETF files 13F-HR).
+--
+-- Schema decisions:
+--   * institutional_filers keys on the filer's CIK (not its CRD —
+--     CIK is what every other SEC ingest in this repo joins on).
+--   * institutional_holdings keys on a synthetic BIGSERIAL plus a
+--     uniqueness constraint on (accession_number, instrument_id) to
+--     idempotently re-ingest the same 13F without duplicating rows.
+--     accession_number is the 13F's accession (filer_cik-yy-seq) so
+--     the same instrument across two filers' 13Fs lands as two
+--     separate rows.
+--   * voting_authority is one of three SEC-prescribed values:
+--     SOLE / SHARED / NONE. Constrained via CHECK so a future
+--     parser regression can't smuggle a fourth value into the
+--     canonical store.
+--   * is_put_call is NULL for the underlying-equity row and either
+--     'PUT' or 'CALL' for option exposure rows. CHECK constrains
+--     the non-NULL set.
+--   * shares is NUMERIC (not INTEGER) so option-exposure values
+--     (which can be reported as principal-amount equivalents on
+--     bond holdings) and exotic share counts don't overflow.
+--   * market_value_usd is reported by the filer in USD thousands
+--     pre-2023 and USD whole dollars post-2022 — the parser layer
+--     normalises both to whole dollars before insert.
+--
+-- _PLANNER_TABLES in tests/fixtures/ebull_test_db.py is updated in
+-- the same PR per the prevention-log entry "When a migration adds
+-- any table with a FK relationship, update _PLANNER_TABLES …".
+
+CREATE TABLE IF NOT EXISTS institutional_filers (
+    filer_id           BIGSERIAL PRIMARY KEY,
+    cik                TEXT NOT NULL UNIQUE,
+    name               TEXT NOT NULL,
+    -- Filer-type classification ships in PR 3 (#730). Nullable here
+    -- because the parser can't determine type from the 13F payload
+    -- alone — it requires a curated ETF-CIK list cross-reference.
+    filer_type         TEXT
+        CHECK (filer_type IS NULL OR filer_type IN ('ETF', 'INV', 'INS', 'BD', 'OTHER')),
+    aum_usd            NUMERIC(20,2),
+    last_filing_at     TIMESTAMPTZ,
+    fetched_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS institutional_holdings (
+    holding_id         BIGSERIAL PRIMARY KEY,
+    filer_id           BIGINT NOT NULL REFERENCES institutional_filers(filer_id),
+    instrument_id      BIGINT NOT NULL REFERENCES instruments(instrument_id),
+    accession_number   TEXT NOT NULL,
+    period_of_report   DATE NOT NULL,
+    shares             NUMERIC(24,4) NOT NULL,
+    market_value_usd   NUMERIC(20,2),
+    voting_authority   TEXT
+        CHECK (voting_authority IS NULL OR voting_authority IN ('SOLE', 'SHARED', 'NONE')),
+    is_put_call        TEXT
+        CHECK (is_put_call IS NULL OR is_put_call IN ('PUT', 'CALL')),
+    filed_at           TIMESTAMPTZ NOT NULL
+);
+
+-- Idempotent re-ingest needs uniqueness on
+-- ``(accession_number, instrument_id, is_put_call)`` so the same
+-- accession's equity + PUT + CALL exposure on a single issuer (up to
+-- three legal rows per issuer in the SEC schema) all coexist. A
+-- plain UNIQUE constraint cannot include a nullable column safely
+-- (Postgres treats two NULL is_put_call values as distinct, which
+-- would let the same equity row insert twice on a re-ingest), so
+-- this is a partial UNIQUE INDEX that COALESCEs the option-exposure
+-- column to the sentinel ``'EQUITY'`` for the equity rows.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_holdings_accession_instrument_putcall
+    ON institutional_holdings (
+        accession_number,
+        instrument_id,
+        (COALESCE(is_put_call, 'EQUITY'))
+    );
+
+-- Hot path for the per-instrument ownership reader: walk holdings
+-- for one instrument across the most recent quarters first.
+CREATE INDEX IF NOT EXISTS idx_holdings_instrument_period
+    ON institutional_holdings (instrument_id, period_of_report DESC);
+
+-- Hot path for the per-filer aggregator (sum AUM, filer concentration):
+-- walk every holding for one filer ordered by report date.
+CREATE INDEX IF NOT EXISTS idx_holdings_filer_period
+    ON institutional_holdings (filer_id, period_of_report DESC);

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -99,6 +99,14 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "insider_transactions",
     "insider_filers",
     "insider_filings",
+    # #730 — 13F-HR institutional holdings. Child-to-parent:
+    # institutional_holdings FKs into institutional_filers AND
+    # instruments (so the instrument truncation further down would
+    # cascade), but listing them explicitly keeps teardown
+    # deterministic when a test populates filer / holding rows
+    # without touching the instruments row in the same case.
+    "institutional_holdings",
+    "institutional_filers",
     "filing_events",
     "decision_audit",  # #315 Phase 3 alerts
     "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)

--- a/tests/test_sec_13f_parser.py
+++ b/tests/test_sec_13f_parser.py
@@ -1,0 +1,387 @@
+"""Unit tests for the SEC 13F-HR XML parser (#730 PR 1).
+
+Fixture XML is hand-written to mirror the namespace + element shape
+of real SEC 13F-HR filings without pulling production payloads into
+the repo. Each scenario pins a single behaviour:
+
+  * Header parsing — primary_doc.xml namespace, signature date,
+    summary-page total, malformed inputs.
+  * Holdings parsing — infotable.xml namespace, multi-row tables,
+    voting-authority sub-amounts, put/call exposure, malformed
+    rows being skipped.
+  * Helper ``dominant_voting_authority`` — picks the right label
+    on ties, on all-zero, and on each authority winning.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.providers.implementations.sec_13f import (
+    ThirteenFHolding,
+    dominant_voting_authority,
+    parse_infotable,
+    parse_primary_doc,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+_PRIMARY_DOC_NS = "http://www.sec.gov/edgar/thirteenffiler"
+_INFOTABLE_NS = "http://www.sec.gov/edgar/document/thirteenf/informationtable"
+
+
+def _primary_doc(
+    *,
+    cik: str = "0001067983",
+    name: str = "BERKSHIRE HATHAWAY INC",
+    period: str = "09-30-2024",
+    signature: str | None = "11-14-2024",
+    table_total: str | None = "266380000000",
+) -> str:
+    """Hand-crafted primary_doc.xml mirroring SEC's namespace + shape."""
+    sig_block = f"<signatureDate>{signature}</signatureDate>" if signature else ""
+    summary = (
+        f"<summaryPage><tableValueTotal>{table_total}</tableValueTotal></summaryPage>"
+        if table_total is not None
+        else ""
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="{_PRIMARY_DOC_NS}">
+  <headerData>
+    <filerInfo>
+      <filer>
+        <credentials>
+          <cik>{cik}</cik>
+        </credentials>
+      </filer>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <coverPage>
+      <reportCalendarOrQuarter>{period}</reportCalendarOrQuarter>
+      <filingManager>
+        <name>{name}</name>
+      </filingManager>
+    </coverPage>
+    {summary}
+    <signatureBlock>{sig_block}</signatureBlock>
+  </formData>
+</edgarSubmission>
+"""
+
+
+def _infotable_row(
+    *,
+    cusip: str,
+    name: str = "APPLE INC",
+    title: str = "COM",
+    value: str = "69900000",
+    shares: str = "300000000",
+    shares_type: str = "SH",
+    put_call: str | None = None,
+    discretion: str = "SOLE",
+    sole: str = "300000000",
+    shared: str = "0",
+    none: str = "0",
+) -> str:
+    put_call_xml = f"<putCall>{put_call}</putCall>" if put_call is not None else ""
+    return f"""<infoTable>
+  <nameOfIssuer>{name}</nameOfIssuer>
+  <titleOfClass>{title}</titleOfClass>
+  <cusip>{cusip}</cusip>
+  <value>{value}</value>
+  <shrsOrPrnAmt>
+    <sshPrnamt>{shares}</sshPrnamt>
+    <sshPrnamtType>{shares_type}</sshPrnamtType>
+  </shrsOrPrnAmt>
+  {put_call_xml}
+  <investmentDiscretion>{discretion}</investmentDiscretion>
+  <votingAuthority>
+    <Sole>{sole}</Sole>
+    <Shared>{shared}</Shared>
+    <None>{none}</None>
+  </votingAuthority>
+</infoTable>"""
+
+
+def _infotable(rows: list[str]) -> str:
+    body = "\n  ".join(rows)
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<informationTable xmlns="{_INFOTABLE_NS}">
+  {body}
+</informationTable>
+"""
+
+
+# ---------------------------------------------------------------------------
+# parse_primary_doc
+# ---------------------------------------------------------------------------
+
+
+class TestParsePrimaryDoc:
+    def test_round_trip_typical_filing(self) -> None:
+        info = parse_primary_doc(_primary_doc())
+        assert info.cik == "0001067983"
+        assert info.name == "BERKSHIRE HATHAWAY INC"
+        assert info.period_of_report == date(2024, 9, 30)
+        assert info.filed_at == datetime(2024, 11, 14)
+        assert info.table_value_total_usd == Decimal("266380000000")
+
+    def test_missing_signature_block_returns_none_filed_at(self) -> None:
+        info = parse_primary_doc(_primary_doc(signature=None))
+        assert info.filed_at is None
+        # Other fields still populate.
+        assert info.cik == "0001067983"
+        assert info.period_of_report == date(2024, 9, 30)
+
+    def test_missing_table_value_total_is_optional(self) -> None:
+        info = parse_primary_doc(_primary_doc(table_total=None))
+        assert info.table_value_total_usd is None
+
+    def test_zero_pads_short_cik(self) -> None:
+        """SEC CIKs are 10-digit; some filings carry the unpadded form."""
+        info = parse_primary_doc(_primary_doc(cik="1067983"))
+        assert info.cik == "0001067983"
+
+    def test_strips_non_numeric_cik_chars(self) -> None:
+        """Defensive: a future filer / agent might prefix CIK with 'CIK'."""
+        info = parse_primary_doc(_primary_doc(cik="CIK0001067983"))
+        assert info.cik == "0001067983"
+
+    def test_missing_cik_raises_value_error(self) -> None:
+        broken = _primary_doc().replace("<cik>0001067983</cik>", "")
+        with pytest.raises(ValueError, match="missing a <cik>"):
+            parse_primary_doc(broken)
+
+    def test_missing_filing_manager_name_raises_value_error(self) -> None:
+        broken = _primary_doc().replace("<name>BERKSHIRE HATHAWAY INC</name>", "")
+        with pytest.raises(ValueError, match="missing the filingManager"):
+            parse_primary_doc(broken)
+
+    def test_missing_period_raises_value_error(self) -> None:
+        broken = _primary_doc().replace("<reportCalendarOrQuarter>09-30-2024</reportCalendarOrQuarter>", "")
+        with pytest.raises(ValueError, match="reportCalendarOrQuarter"):
+            parse_primary_doc(broken)
+
+    def test_iso_date_period_is_accepted(self) -> None:
+        """A future SEC schema change to ISO is parseable."""
+        info = parse_primary_doc(_primary_doc(period="2024-09-30"))
+        assert info.period_of_report == date(2024, 9, 30)
+
+    def test_signature_block_name_does_not_shadow_filing_manager_name(self) -> None:
+        """Codex pre-push regression. Real 13F-HR XML carries a
+        ``<name>`` on the signer in ``<signatureBlock>`` AND the filing
+        manager's ``<name>`` on the cover page. The parser must scope
+        its lookup to the filingManager subtree so the wrong value
+        cannot be silently picked up. A document-wide first-match
+        lookup would return the signer's name on a malformed filing
+        with the elements reordered (or simply on any payload where
+        signatureBlock precedes the cover page in document order).
+        """
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler">
+  <headerData>
+    <filerInfo>
+      <filer>
+        <credentials>
+          <cik>0001067983</cik>
+        </credentials>
+      </filer>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <signatureBlock>
+      <name>WARREN E. BUFFETT</name>
+      <title>CHAIRMAN</title>
+      <signatureDate>11-14-2024</signatureDate>
+    </signatureBlock>
+    <coverPage>
+      <reportCalendarOrQuarter>09-30-2024</reportCalendarOrQuarter>
+      <filingManager>
+        <name>BERKSHIRE HATHAWAY INC</name>
+      </filingManager>
+    </coverPage>
+  </formData>
+</edgarSubmission>
+"""
+        info = parse_primary_doc(xml)
+        assert info.name == "BERKSHIRE HATHAWAY INC"
+        assert info.filed_at == datetime(2024, 11, 14)
+
+
+# ---------------------------------------------------------------------------
+# parse_infotable
+# ---------------------------------------------------------------------------
+
+
+class TestParseInfotable:
+    def test_single_holding_round_trip(self) -> None:
+        xml = _infotable([_infotable_row(cusip="037833100")])
+        holdings = parse_infotable(xml)
+        assert len(holdings) == 1
+        h = holdings[0]
+        assert h.cusip == "037833100"
+        assert h.name_of_issuer == "APPLE INC"
+        assert h.title_of_class == "COM"
+        assert h.value_usd == Decimal("69900000")
+        assert h.shares_or_principal == Decimal("300000000")
+        assert h.shares_or_principal_type == "SH"
+        assert h.put_call is None
+        assert h.investment_discretion == "SOLE"
+        assert h.voting_sole == Decimal("300000000")
+        assert h.voting_shared == Decimal(0)
+        assert h.voting_none == Decimal(0)
+
+    def test_multiple_holdings(self) -> None:
+        xml = _infotable(
+            [
+                _infotable_row(cusip="037833100", name="APPLE INC"),
+                _infotable_row(cusip="594918104", name="MICROSOFT CORP", value="42000000"),
+                _infotable_row(cusip="023135106", name="AMAZON COM INC", value="36000000"),
+            ]
+        )
+        holdings = parse_infotable(xml)
+        assert len(holdings) == 3
+        cusips = [h.cusip for h in holdings]
+        assert cusips == ["037833100", "594918104", "023135106"]
+
+    def test_put_call_normalises_to_uppercase(self) -> None:
+        xml = _infotable(
+            [
+                _infotable_row(cusip="037833100", put_call="Put"),
+                _infotable_row(cusip="037833101", put_call="CALL"),
+                _infotable_row(cusip="037833102", put_call="put"),
+            ]
+        )
+        holdings = parse_infotable(xml)
+        assert holdings[0].put_call == "PUT"
+        assert holdings[1].put_call == "CALL"
+        assert holdings[2].put_call == "PUT"
+
+    def test_unknown_put_call_falls_back_to_none(self) -> None:
+        """A future schema field smuggled into putCall must not corrupt
+        the constrained Literal — fall back to None and warn."""
+        xml = _infotable([_infotable_row(cusip="037833100", put_call="Straddle")])
+        holdings = parse_infotable(xml)
+        assert holdings[0].put_call is None
+
+    def test_voting_authority_breakdown_preserved(self) -> None:
+        xml = _infotable(
+            [
+                _infotable_row(
+                    cusip="037833100",
+                    sole="200000000",
+                    shared="50000000",
+                    none="50000000",
+                )
+            ]
+        )
+        h = parse_infotable(xml)[0]
+        assert h.voting_sole == Decimal("200000000")
+        assert h.voting_shared == Decimal("50000000")
+        assert h.voting_none == Decimal("50000000")
+
+    def test_principal_amount_holding(self) -> None:
+        """Bond holdings report PRN, not SH, in sshPrnamtType. Parser
+        preserves the type — the service layer chooses how to render
+        it (the ownership card consumes only SH rows)."""
+        xml = _infotable([_infotable_row(cusip="912828YT0", shares="100000", shares_type="PRN")])
+        h = parse_infotable(xml)[0]
+        assert h.shares_or_principal == Decimal("100000")
+        assert h.shares_or_principal_type == "PRN"
+
+    def test_malformed_row_with_missing_value_is_skipped(self) -> None:
+        """A row missing <value> is unparseable. The parser keeps the
+        well-formed siblings rather than aborting the whole infotable."""
+        xml = _infotable(
+            [
+                _infotable_row(cusip="037833100"),
+                # Hand-crafted broken row: no <value> element.
+                """<infoTable>
+                    <nameOfIssuer>UNKNOWN</nameOfIssuer>
+                    <cusip>UNKNOWN111</cusip>
+                    <shrsOrPrnAmt>
+                      <sshPrnamt>1000</sshPrnamt>
+                      <sshPrnamtType>SH</sshPrnamtType>
+                    </shrsOrPrnAmt>
+                </infoTable>""",
+                _infotable_row(cusip="594918104"),
+            ]
+        )
+        holdings = parse_infotable(xml)
+        cusips = [h.cusip for h in holdings]
+        assert cusips == ["037833100", "594918104"]
+
+    def test_malformed_row_with_non_numeric_value_is_skipped(self) -> None:
+        xml = _infotable(
+            [
+                _infotable_row(cusip="037833100", value="N/A"),
+                _infotable_row(cusip="594918104"),
+            ]
+        )
+        holdings = parse_infotable(xml)
+        assert len(holdings) == 1
+        assert holdings[0].cusip == "594918104"
+
+    def test_value_with_thousands_comma_separator(self) -> None:
+        """Pre-2018 filings sometimes carry comma-separated thousands."""
+        xml = _infotable([_infotable_row(cusip="037833100", value="69,900,000")])
+        h = parse_infotable(xml)[0]
+        assert h.value_usd == Decimal("69900000")
+
+    def test_empty_infotable_returns_empty_list(self) -> None:
+        xml = _infotable([])
+        assert parse_infotable(xml) == []
+
+
+# ---------------------------------------------------------------------------
+# dominant_voting_authority
+# ---------------------------------------------------------------------------
+
+
+class TestDominantVotingAuthority:
+    def _holding(self, *, sole: int, shared: int, none: int) -> ThirteenFHolding:
+        return ThirteenFHolding(
+            cusip="037833100",
+            name_of_issuer="APPLE INC",
+            title_of_class="COM",
+            value_usd=Decimal("69900000"),
+            shares_or_principal=Decimal("300000000"),
+            shares_or_principal_type="SH",
+            put_call=None,
+            investment_discretion="SOLE",
+            voting_sole=Decimal(sole),
+            voting_shared=Decimal(shared),
+            voting_none=Decimal(none),
+        )
+
+    def test_sole_dominant(self) -> None:
+        h = self._holding(sole=300, shared=10, none=0)
+        assert dominant_voting_authority(h) == "SOLE"
+
+    def test_shared_dominant(self) -> None:
+        h = self._holding(sole=10, shared=300, none=20)
+        assert dominant_voting_authority(h) == "SHARED"
+
+    def test_none_dominant(self) -> None:
+        h = self._holding(sole=0, shared=0, none=500)
+        assert dominant_voting_authority(h) == "NONE"
+
+    def test_all_zero_returns_none_label(self) -> None:
+        """All-zero is rare but legal in the SEC schema (filing
+        manager has no voting authority over the position). Maps to
+        NULL on insert via the canonical column."""
+        h = self._holding(sole=0, shared=0, none=0)
+        assert dominant_voting_authority(h) is None
+
+    def test_tie_prefers_sole(self) -> None:
+        """When sole == shared, sole wins. Documented preference for
+        ownership-card reporting consistency."""
+        h = self._holding(sole=100, shared=100, none=0)
+        assert dominant_voting_authority(h) == "SOLE"

--- a/tests/test_sec_13f_parser.py
+++ b/tests/test_sec_13f_parser.py
@@ -15,7 +15,7 @@ the repo. Each scenario pins a single behaviour:
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 
 import pytest
@@ -130,7 +130,10 @@ class TestParsePrimaryDoc:
         assert info.cik == "0001067983"
         assert info.name == "BERKSHIRE HATHAWAY INC"
         assert info.period_of_report == date(2024, 9, 30)
-        assert info.filed_at == datetime(2024, 11, 14)
+        assert info.filed_at == datetime(2024, 11, 14, tzinfo=UTC)
+        # filed_at must be tz-aware so it lands in TIMESTAMPTZ
+        # without psycopg falling back to the server's local zone.
+        assert info.filed_at is not None and info.filed_at.tzinfo is UTC
         assert info.table_value_total_usd == Decimal("266380000000")
 
     def test_missing_signature_block_returns_none_filed_at(self) -> None:
@@ -212,7 +215,7 @@ class TestParsePrimaryDoc:
 """
         info = parse_primary_doc(xml)
         assert info.name == "BERKSHIRE HATHAWAY INC"
-        assert info.filed_at == datetime(2024, 11, 14)
+        assert info.filed_at == datetime(2024, 11, 14, tzinfo=UTC)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

First of four PRs implementing SEC 13F-HR institutional holdings ingest (Plan C.2). This PR ships:

- **Schema** (\`sql/090_institutional_filers_holdings.sql\`): \`institutional_filers\` + \`institutional_holdings\` tables with CHECK constraints on \`filer_type\` / \`voting_authority\` / \`is_put_call\`, FK from holdings to filers + instruments, plus a partial UNIQUE INDEX that lets equity + PUT + CALL exposure rows coexist for the same issuer in a single accession.
- **Parser** (\`app/providers/implementations/sec_13f.py\`): pure XML → typed dataclasses for \`primary_doc.xml\` (header, cover page, signature) and \`infotable.xml\` (holdings rows). \`dominant_voting_authority\` helper for the ownership-card label.
- **Tests** (\`tests/test_sec_13f_parser.py\`): 25 unit tests covering namespace handling, malformed-row skipping, put/call normalisation, voting-authority breakdown, and a regression for sibling-element \`<name>\` shadowing.

## Subsequent PRs

- **PR 2** — ingester (HTTP fetch via the bounded-concurrency client from #728; CUSIP → instrument resolution via \`external_identifiers\`; tombstone failed parses).
- **PR 3** — filer-type classifier (curated ETF-CIK list cross-reference for the ETF slice on the ownership card).
- **PR 4** — reader API (\`/instruments/{symbol}/institutional-holdings\`) + frontend wiring (#729 ownership card follow-on).

## Conscious tradeoffs

- **Partial UNIQUE INDEX over plain UNIQUE constraint.** A 13F can carry up to three legal rows per issuer in one accession (equity + PUT + CALL). The original ticket spec called for \`UNIQUE (accession_number, instrument_id)\`, which would have collapsed those siblings. Codex pre-push review caught this. The fix uses a partial UNIQUE INDEX on \`(accession_number, instrument_id, COALESCE(is_put_call, 'EQUITY'))\` so the three rows coexist while idempotent re-ingest still rejects exact duplicates. Documented in the migration header.

- **Filing-manager \`<name>\` lookup scoped to \`<filingManager>\` subtree.** A document-wide first-match lookup would silently pick up a \`<name>\` from \`<signatureBlock>\` (signer's name) on a malformed or reordered filing, swapping the canonical filer name for the signer's. Codex pre-push review caught this. Pinned by \`test_signature_block_name_does_not_shadow_filing_manager_name\`.

- **CUSIP → instrument resolution stays in the service layer.** Provider remains thin per the settled provider-design rule (\`docs/settled-decisions.md\`). PR 2 owns the resolution path via \`external_identifiers\`.

- **Trusted-source XML parser.** Same posture as \`app/services/insider_transactions.py\`: \`xml.etree.ElementTree\` with \`noqa: S405 / S314\` because the source is SEC EDGAR. No third-party XML lib introduced.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pyright\` — clean
- [x] \`uv run pytest tests/test_sec_13f_parser.py\` — 25 passed
- [x] Full \`uv run pytest\` — 3080 passed; two pre-existing flakes (\`test_drain_pending_at_boot_claims_each_row\`, \`test_claim_oldest_pending_skips_locked_rows\`). The second is a dev-DB \`pending_job_requests\` state-pollution flake — fails with **any** prior test run before it (reproducible with the prior canonical-merge integration tests too), not introduced by this PR. CI runs against a fresh Postgres so neither flake fires there.
- [x] Codex pre-push review — both findings (UNIQUE constraint + sibling-name shadowing) addressed inside this PR before push, with the matching schema fix and regression test.

## Backfill

No data migration. The two tables ship empty; PR 2's ingester populates them on the next quarterly cadence run.

## Linked

- Unblocks #729 (ownership card — Institutions + ETFs slices).
- Splits from #730 main ticket (1-2 weeks total scope across the four PRs).