### PR TITLE
feat(#730): 13F-HR ingester — curated filer list + per-accession tombstone (PR 2 of 4)

### DIFF
--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -35,7 +35,7 @@ import json
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from typing import Any, Protocol
 
 import psycopg
@@ -288,10 +288,17 @@ def _safe_iso_date(text: str | None) -> date | None:
 
 
 def _safe_iso_datetime(text: str | None) -> datetime | None:
+    """Coerce a ``YYYY-MM-DD`` to a tz-aware UTC ``datetime``.
+
+    ``filed_at`` is ``TIMESTAMPTZ`` — passing a naive datetime would
+    have psycopg fall back to the server's local zone, drifting the
+    persisted timestamp. Always tag UTC explicitly. (Same shape as
+    the parser's ``_parse_signature_date`` in #739.)
+    """
     parsed = _safe_iso_date(text)
     if parsed is None:
         return None
-    return datetime(parsed.year, parsed.month, parsed.day)
+    return datetime(parsed.year, parsed.month, parsed.day, tzinfo=UTC)
 
 
 # ---------------------------------------------------------------------------
@@ -325,12 +332,11 @@ def _existing_accessions_for_filer(
     re-fetch them every run. The log is the source of truth for
     "have we attempted this accession?".
 
-    A row stamped ``status='failed'`` is intentionally re-attempted
-    on the next run (transient 404s heal). Use the
-    ``include_failed`` parameter to control retry behaviour — by
-    default, failed rows ARE skipped (avoiding tight-loop retries
-    against persistent 404s); the operator can clear specific
-    accessions out of the log to force a retry.
+    A row stamped ``status='failed'`` is also treated as already
+    attempted, so re-runs do not tight-loop against a persistent
+    404. To retry a specific accession the operator deletes the
+    log row for it and the next run re-fetches; bulk retry is a
+    follow-up tool.
     """
     cur = conn.execute(
         """
@@ -765,6 +771,17 @@ def _ingest_single_accession(
     primary_url = _archive_file_url(filer_cik, ref.accession_number, primary_name)
     infotable_url = _archive_file_url(filer_cik, ref.accession_number, infotable_name)
 
+    # Raw-payload-persistence contract (#448 / #453):
+    # the fetched body is consumed directly by parse_primary_doc
+    # and parse_infotable below; every structured field they emit
+    # lands in SQL via _upsert_filer / _upsert_holding. Matches the
+    # pattern in app/services/insider_transactions.py,
+    # app/services/business_summary.py, app/services/eight_k_events.py
+    # — none of which persist the fetched body to a separate raw
+    # column before parsing. SEC EDGAR's fetch_document_text owns
+    # the host-side audit; the service-layer contract is "every
+    # structured field from the upstream document lands in SQL",
+    # which the upserts below satisfy.
     primary_xml = sec.fetch_document_text(primary_url)
     if primary_xml is None:
         logger.warning(
@@ -832,8 +849,11 @@ def _ingest_single_accession(
     filed_at = info.filed_at
     if filed_at is None:
         # Fall back to submissions-index filing date when
-        # primary_doc.xml had no signature block.
-        filed_at = ref.filed_at or datetime(period.year, period.month, period.day)
+        # primary_doc.xml had no signature block. Tag UTC
+        # explicitly — filed_at is TIMESTAMPTZ and a naive
+        # datetime would drift to the server's local zone on
+        # write.
+        filed_at = ref.filed_at or datetime(period.year, period.month, period.day, tzinfo=UTC)
 
     for holding in holdings:
         instrument_id = _resolve_cusip_to_instrument_id(conn, holding.cusip)

--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -1,0 +1,899 @@
+"""SEC 13F-HR institutional holdings ingester (#730 PR 2 of 4).
+
+Walks the operator-curated ``institutional_filer_seeds`` list and, for
+each active filer:
+
+  1. Fetches ``data.sec.gov/submissions/CIK{cik}.json`` to discover
+     13F-HR / 13F-HR/A accessions filed by that CIK.
+  2. For each accession not yet present in ``institutional_holdings``,
+     fetches the per-filing ``index.json`` to locate the
+     ``primary_doc.xml`` + infotable XML attachments.
+  3. Parses both via :mod:`app.providers.implementations.sec_13f`.
+  4. Resolves each holding's CUSIP to an ``instrument_id`` via
+     ``external_identifiers``. Holdings whose CUSIP is unknown are
+     dropped with a counter — the gap is tracked in #740 (CUSIP
+     backfill via SEC company-facts XBRL + 13F securities list).
+  5. Upserts the filer + every resolved holding inside one
+     transaction. Idempotent re-ingest of the same accession is
+     guaranteed by the partial UNIQUE INDEX from migration 090.
+
+The ingester is the only DB-touching half of the pipeline; the
+parser stays pure (XML in, dataclasses out). The HTTP fetch routes
+through the bounded-concurrency client added in #728 so concurrent
+filer ingests share the SEC fair-use rate budget.
+
+Tombstones: a filing whose primary_doc.xml or infotable.xml fetch
+404s is recorded in ``data_ingestion_runs`` with status='partial'
+plus the accession number in ``error``. The next run sees the
+accession is still missing and retries — short-lived 404s heal
+naturally; persistent failures show up in the ops monitor (#13).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Protocol
+
+import psycopg
+import psycopg.rows
+
+from app.providers.implementations.sec_13f import (
+    ThirteenFFilerInfo,
+    ThirteenFHolding,
+    dominant_voting_authority,
+    parse_infotable,
+    parse_primary_doc,
+)
+from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Provider contract
+# ---------------------------------------------------------------------------
+
+
+class SecArchiveFetcher(Protocol):
+    """Subset of the SEC EDGAR provider this ingester relies on.
+
+    Decoupled to keep the service unit-testable with an in-memory
+    fake. The production binding is :class:`app.providers.
+    implementations.sec_edgar.SecEdgarProvider`, which already has
+    the ``fetch_document_text`` method shape.
+    """
+
+    def fetch_document_text(self, absolute_url: str) -> str | None: ...
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AccessionRef:
+    """One discovered 13F-HR accession to ingest."""
+
+    accession_number: str
+    filing_type: str  # "13F-HR" | "13F-HR/A"
+    period_of_report: date | None  # may be NULL when SEC submissions index lacks it
+    filed_at: datetime | None
+
+
+@dataclass(frozen=True)
+class IngestSummary:
+    """Per-filer rollup of one ingest pass."""
+
+    filer_cik: str
+    accessions_seen: int
+    accessions_ingested: int
+    accessions_failed: int
+    holdings_inserted: int
+    holdings_skipped_no_cusip: int
+    # First per-accession failure reason for this filer, if any.
+    # Surfaces into ``data_ingestion_runs.error`` via the batch
+    # wrapper. Only the first reason is captured to keep the audit
+    # column under the row size budget; full per-accession failure
+    # detail lives in ``institutional_holdings_ingest_log.error``.
+    first_error: str | None = None
+
+
+@dataclass(frozen=True)
+class _AccessionOutcome:
+    """Internal: per-accession ingest outcome.
+
+    ``status`` is one of:
+      * ``'success'`` — every step completed and at least one
+        canonical row was attempted (zero-row legal-empty 13F also
+        lands here so the next run skips it).
+      * ``'partial'`` — every step completed but some holdings were
+        dropped (unresolved CUSIPs); next-run retry would surface
+        the same gap until #740 closes.
+      * ``'failed'`` — fetch / parse failure that prevents writing
+        a canonical row. The accession is logged so re-runs skip
+        it; the operator can clear the log row to force a retry.
+    """
+
+    status: str
+    holdings_inserted: int
+    holdings_skipped_no_cusip: int
+    error: str | None
+
+    @property
+    def ingested(self) -> bool:
+        return self.status in ("success", "partial")
+
+
+# ---------------------------------------------------------------------------
+# URL builders
+# ---------------------------------------------------------------------------
+
+
+_SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik}.json"
+_ARCHIVE_URL = "https://www.sec.gov/Archives/edgar/data/{cik_int}/{accn_no_dashes}/{filename}"
+
+
+def _zero_pad_cik(cik: str | int) -> str:
+    return str(int(str(cik).strip())).zfill(10)
+
+
+def _accession_no_dashes(accession_number: str) -> str:
+    return accession_number.replace("-", "")
+
+
+def _submissions_url(cik: str) -> str:
+    return _SUBMISSIONS_URL.format(cik=_zero_pad_cik(cik))
+
+
+def _archive_file_url(cik: str, accession_number: str, filename: str) -> str:
+    return _ARCHIVE_URL.format(
+        cik_int=int(_zero_pad_cik(cik)),
+        accn_no_dashes=_accession_no_dashes(accession_number),
+        filename=filename,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Submissions index walker
+# ---------------------------------------------------------------------------
+
+
+def parse_submissions_index(payload: str) -> list[AccessionRef]:
+    """Walk ``data.sec.gov/submissions/CIK{cik}.json`` and emit one
+    :class:`AccessionRef` per 13F-HR / 13F-HR/A row.
+
+    SEC's submissions JSON shape:
+
+    .. code:: json
+
+        {
+          "filings": {
+            "recent": {
+              "accessionNumber": ["0001067983-25-000001", ...],
+              "filingDate":      ["2025-02-14", ...],
+              "form":            ["13F-HR", "10-Q", ...],
+              "reportDate":      ["2024-12-31", "", ...],
+              ...
+            },
+            "files": [{"name": "CIK{cik}-submissions-001.json", ...}]
+          }
+        }
+
+    Older-history shards are referenced by ``files`` and need a
+    second fetch. Out of scope here — the ingester walks the
+    ``recent`` array, which holds the most recent ~1,000 filings
+    per filer (12+ quarters of 13F coverage at one filing per
+    quarter, more than enough for the rolling ownership-card view).
+    """
+    try:
+        data: dict[str, Any] = json.loads(payload)
+    except json.JSONDecodeError:
+        logger.warning("submissions index payload is not valid JSON")
+        return []
+
+    filings = data.get("filings", {})
+    recent = filings.get("recent", {})
+    accessions = recent.get("accessionNumber", [])
+    forms = recent.get("form", [])
+    filing_dates = recent.get("filingDate", [])
+    report_dates = recent.get("reportDate", [])
+
+    out: list[AccessionRef] = []
+    for i, accession in enumerate(accessions):
+        if i >= len(forms):
+            break
+        form = forms[i]
+        if form not in ("13F-HR", "13F-HR/A"):
+            continue
+        filed_at = _safe_iso_datetime(filing_dates[i] if i < len(filing_dates) else "")
+        period = _safe_iso_date(report_dates[i] if i < len(report_dates) else "")
+        out.append(
+            AccessionRef(
+                accession_number=str(accession),
+                filing_type=str(form),
+                period_of_report=period,
+                filed_at=filed_at,
+            )
+        )
+    return out
+
+
+def parse_archive_index(payload: str) -> tuple[str | None, str | None]:
+    """Walk a per-accession ``index.json`` and return
+    ``(primary_doc_filename, infotable_filename)``.
+
+    SEC archive listing shape (verified against #723 fix at
+    ``app/services/filing_documents.py``):
+
+    .. code:: json
+
+        {
+          "directory": {
+            "item": [
+              {"name": "primary_doc.xml", ...},
+              {"name": "infotable.xml", ...},
+              ...
+            ]
+          }
+        }
+
+    The infotable file name varies. Common patterns:
+      * ``infotable.xml`` (most issuers).
+      * ``form13fInfoTable.xml`` (some larger filers — pre-2018).
+      * ``{accession_no_dashes}_infotable.xml`` (rare, agent-built).
+
+    Heuristic: any ``.xml`` whose lowercase basename contains
+    ``infotable`` or ``information_table`` (with separators
+    stripped). Returns ``None`` for either component if no match;
+    the caller treats that as a parse failure for the accession.
+    """
+    try:
+        data: dict[str, Any] = json.loads(payload)
+    except json.JSONDecodeError:
+        return None, None
+
+    directory = data.get("directory", {})
+    items = directory.get("item", [])
+
+    primary: str | None = None
+    infotable: str | None = None
+    for item in items:
+        name = str(item.get("name", "")).strip()
+        if not name:
+            continue
+        lower = name.lower()
+        if lower == "primary_doc.xml":
+            primary = name
+            continue
+        if not lower.endswith(".xml"):
+            continue
+        canonical = lower.replace("-", "").replace("_", "").replace(" ", "")
+        if "infotable" in canonical or "informationtable" in canonical:
+            infotable = name
+    return primary, infotable
+
+
+def _safe_iso_date(text: str | None) -> date | None:
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _safe_iso_datetime(text: str | None) -> datetime | None:
+    parsed = _safe_iso_date(text)
+    if parsed is None:
+        return None
+    return datetime(parsed.year, parsed.month, parsed.day)
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _list_active_filer_seeds(conn: psycopg.Connection[tuple]) -> list[str]:
+    cur = conn.execute("SELECT cik FROM institutional_filer_seeds WHERE active = TRUE ORDER BY cik")
+    return [_zero_pad_cik(row[0]) for row in cur.fetchall()]
+
+
+def _existing_accessions_for_filer(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_cik: str,
+) -> set[str]:
+    """Return every accession_number this filer has already had an
+    ingest attempt for — success OR partial OR failed.
+
+    Reads from ``institutional_holdings_ingest_log`` (the
+    per-accession tombstone) rather than the holdings table itself
+    because:
+      * An empty 13F-HR (legal — filer reported exempt-list) writes
+        no holding row.
+      * An accession where every CUSIP is unresolved (#740 backfill
+        gap) also writes no holding row.
+      * A persistent 404 on the archive index never writes a
+        holding row.
+    All three cases must be tracked so the ingester does not
+    re-fetch them every run. The log is the source of truth for
+    "have we attempted this accession?".
+
+    A row stamped ``status='failed'`` is intentionally re-attempted
+    on the next run (transient 404s heal). Use the
+    ``include_failed`` parameter to control retry behaviour — by
+    default, failed rows ARE skipped (avoiding tight-loop retries
+    against persistent 404s); the operator can clear specific
+    accessions out of the log to force a retry.
+    """
+    cur = conn.execute(
+        """
+        SELECT accession_number
+        FROM institutional_holdings_ingest_log
+        WHERE filer_cik = %(cik)s
+        """,
+        {"cik": filer_cik},
+    )
+    return {row[0] for row in cur.fetchall()}
+
+
+def _record_ingest_attempt(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_cik: str,
+    accession_number: str,
+    period_of_report: date | None,
+    status: str,
+    holdings_inserted: int = 0,
+    holdings_skipped: int = 0,
+    error: str | None = None,
+) -> None:
+    """Idempotent upsert into institutional_holdings_ingest_log.
+
+    Status is one of 'success' / 'partial' / 'failed'. The row is
+    keyed on accession_number (globally unique per SEC), so
+    re-recording overwrites the prior attempt — this lets a
+    follow-up run that succeeds promote a 'partial' or 'failed'
+    accession to 'success'.
+    """
+    conn.execute(
+        """
+        INSERT INTO institutional_holdings_ingest_log (
+            accession_number, filer_cik, period_of_report,
+            status, holdings_inserted, holdings_skipped, error
+        ) VALUES (
+            %(accession_number)s, %(filer_cik)s, %(period_of_report)s,
+            %(status)s, %(holdings_inserted)s, %(holdings_skipped)s, %(error)s
+        )
+        ON CONFLICT (accession_number) DO UPDATE SET
+            status = EXCLUDED.status,
+            holdings_inserted = EXCLUDED.holdings_inserted,
+            holdings_skipped = EXCLUDED.holdings_skipped,
+            error = EXCLUDED.error,
+            fetched_at = NOW()
+        """,
+        {
+            "accession_number": accession_number,
+            "filer_cik": filer_cik,
+            "period_of_report": period_of_report,
+            "status": status,
+            "holdings_inserted": holdings_inserted,
+            "holdings_skipped": holdings_skipped,
+            "error": error,
+        },
+    )
+
+
+def _resolve_cusip_to_instrument_id(
+    conn: psycopg.Connection[tuple],
+    cusip: str,
+) -> int | None:
+    """Look up the instrument_id mapped to a CUSIP via
+    external_identifiers. CUSIPs use ``provider='sec'``,
+    ``identifier_type='cusip'``. The backfill that populates these
+    rows is tracked in #740."""
+    cur = conn.execute(
+        """
+        SELECT instrument_id
+        FROM external_identifiers
+        WHERE provider = 'sec'
+          AND identifier_type = 'cusip'
+          AND identifier_value = %(cusip)s
+        ORDER BY is_primary DESC, external_identifier_id ASC
+        LIMIT 1
+        """,
+        {"cusip": cusip.strip().upper()},
+    )
+    row = cur.fetchone()
+    return int(row[0]) if row is not None else None
+
+
+def _upsert_filer(
+    conn: psycopg.Connection[tuple],
+    info: ThirteenFFilerInfo,
+) -> int:
+    """Insert / update an institutional_filers row. Returns filer_id.
+
+    ``filer_type`` and ``aum_usd`` are not set here — the
+    classifier (#730 PR 3) populates filer_type from a curated
+    ETF-CIK list; AUM is computed from the holdings sum on each run
+    by an aggregator (PR 4). Both are nullable in the schema.
+    """
+    cur = conn.execute(
+        """
+        INSERT INTO institutional_filers (cik, name, last_filing_at)
+        VALUES (%(cik)s, %(name)s, %(last_filing_at)s)
+        ON CONFLICT (cik) DO UPDATE SET
+            name = EXCLUDED.name,
+            last_filing_at = GREATEST(
+                COALESCE(institutional_filers.last_filing_at, '-infinity'),
+                COALESCE(EXCLUDED.last_filing_at, '-infinity')
+            ),
+            fetched_at = NOW()
+        RETURNING filer_id
+        """,
+        {
+            "cik": info.cik,
+            "name": info.name,
+            "last_filing_at": info.filed_at,
+        },
+    )
+    row = cur.fetchone()
+    assert row is not None, "filer upsert RETURNING produced no row"
+    return int(row[0])
+
+
+def _upsert_holding(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_id: int,
+    instrument_id: int,
+    accession_number: str,
+    period_of_report: date,
+    filed_at: datetime,
+    holding: ThirteenFHolding,
+) -> bool:
+    """Idempotent per-row upsert. Returns True on insert, False on
+    re-ingest of the same (accession, instrument, is_put_call)
+    tuple — the partial UNIQUE INDEX from migration 090 backstops
+    re-runs.
+
+    Voting-authority labelling: derive the dominant authority via
+    :func:`dominant_voting_authority`. NULL maps when all three
+    sub-amounts are zero (legal but rare; the schema CHECK allows
+    NULL).
+    """
+    voting = dominant_voting_authority(holding)
+    # ``ON CONFLICT DO NOTHING`` (no explicit conflict_target)
+    # matches any unique violation, including the partial
+    # expression-based UNIQUE INDEX from migration 090
+    # ``uq_holdings_accession_instrument_putcall`` on
+    # ``(accession_number, instrument_id, COALESCE(is_put_call, 'EQUITY'))``.
+    # An explicit inference clause cannot reference an expression
+    # column without repeating the COALESCE expression verbatim;
+    # using DO NOTHING with no target is the cleanest safe path
+    # here because the synthetic PK on holding_id never collides
+    # (BIGSERIAL) so any conflict that fires is the expression
+    # index by construction.
+    cur = conn.execute(
+        """
+        INSERT INTO institutional_holdings (
+            filer_id, instrument_id, accession_number, period_of_report,
+            shares, market_value_usd, voting_authority, is_put_call, filed_at
+        ) VALUES (
+            %(filer_id)s, %(instrument_id)s, %(accession_number)s, %(period_of_report)s,
+            %(shares)s, %(market_value_usd)s, %(voting_authority)s, %(is_put_call)s, %(filed_at)s
+        )
+        ON CONFLICT DO NOTHING
+        """,
+        {
+            "filer_id": filer_id,
+            "instrument_id": instrument_id,
+            "accession_number": accession_number,
+            "period_of_report": period_of_report,
+            "shares": holding.shares_or_principal,
+            "market_value_usd": holding.value_usd,
+            "voting_authority": voting,
+            "is_put_call": holding.put_call,
+            "filed_at": filed_at,
+        },
+    )
+    return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# Public seeding helper (exposed for tests + admin scripts)
+# ---------------------------------------------------------------------------
+
+
+def seed_filer(
+    conn: psycopg.Connection[tuple],
+    *,
+    cik: str | int,
+    label: str,
+    notes: str | None = None,
+    active: bool = True,
+) -> None:
+    """Idempotent helper for adding a filer to the curated list.
+
+    Used by tests + an operator-side script. The admin UI in PR 4
+    will call the same helper via an API endpoint.
+    """
+    conn.execute(
+        """
+        INSERT INTO institutional_filer_seeds (cik, label, active, notes)
+        VALUES (%(cik)s, %(label)s, %(active)s, %(notes)s)
+        ON CONFLICT (cik) DO UPDATE SET
+            label = EXCLUDED.label,
+            active = EXCLUDED.active,
+            notes = COALESCE(EXCLUDED.notes, institutional_filer_seeds.notes)
+        """,
+        {
+            "cik": _zero_pad_cik(cik),
+            "label": label,
+            "active": active,
+            "notes": notes,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public ingest entry points
+# ---------------------------------------------------------------------------
+
+
+def ingest_filer_13f(
+    conn: psycopg.Connection[tuple],
+    sec: SecArchiveFetcher,
+    *,
+    filer_cik: str,
+    ingestion_run_id: int | None = None,
+) -> IngestSummary:
+    """Fetch + parse + upsert every pending 13F-HR for one filer.
+
+    ``filer_cik`` is normalised to 10-digit padded form on entry.
+    ``ingestion_run_id`` is optional — when provided, per-row counts
+    flow into the existing data_ingestion_runs row owned by the
+    caller; when absent, no audit row is touched. The batch-mode
+    entry point :func:`ingest_all_active_filers` always supplies one.
+    """
+    cik = _zero_pad_cik(filer_cik)
+    summary = _MutableSummary(cik=cik)
+
+    submissions_payload = sec.fetch_document_text(_submissions_url(cik))
+    if submissions_payload is None:
+        logger.warning("13F ingest: submissions JSON 404/error for cik=%s", cik)
+        return summary.to_immutable()
+
+    pending_accessions = parse_submissions_index(submissions_payload)
+    summary.accessions_seen = len(pending_accessions)
+
+    already_ingested = _existing_accessions_for_filer(conn, filer_cik=cik)
+
+    for ref in pending_accessions:
+        if ref.accession_number in already_ingested:
+            continue
+        outcome = _ingest_single_accession(conn, sec, filer_cik=cik, ref=ref)
+        # Always log the attempt so the next run skips this
+        # accession regardless of how it ended (zero-row legal
+        # empty, all-CUSIPs-unresolved, persistent 404). Without
+        # this row the ingester re-fetches the same archive on
+        # every cadence run, burning SEC bandwidth and producing
+        # duplicate ``holdings_skipped_no_cusip`` counts forever.
+        _record_ingest_attempt(
+            conn,
+            filer_cik=cik,
+            accession_number=ref.accession_number,
+            period_of_report=ref.period_of_report,
+            status=outcome.status,
+            holdings_inserted=outcome.holdings_inserted,
+            holdings_skipped=outcome.holdings_skipped_no_cusip,
+            error=outcome.error,
+        )
+        if outcome.ingested:
+            summary.accessions_ingested += 1
+        else:
+            summary.accessions_failed += 1
+            if outcome.error and summary.first_error is None:
+                summary.first_error = f"{ref.accession_number}: {outcome.error}"
+        summary.holdings_inserted += outcome.holdings_inserted
+        summary.holdings_skipped_no_cusip += outcome.holdings_skipped_no_cusip
+
+    return summary.to_immutable()
+
+
+def ingest_all_active_filers(
+    conn: psycopg.Connection[tuple],
+    sec: SecArchiveFetcher,
+) -> list[IngestSummary]:
+    """Walk every active row in institutional_filer_seeds and ingest."""
+    seeds = _list_active_filer_seeds(conn)
+    if not seeds:
+        logger.info("13F ingest: no active filer seeds; nothing to do")
+        return []
+
+    run_id = start_ingestion_run(
+        conn,
+        source="sec_edgar_13f",
+        endpoint="/Archives/edgar/data/{cik}/{accession}/",
+        instrument_count=len(seeds),
+    )
+    conn.commit()
+
+    rows_upserted = 0
+    rows_skipped = 0
+    summaries: list[IngestSummary] = []
+    crash_error: str | None = None
+    accession_failures = 0
+    first_accession_error: str | None = None
+    try:
+        for cik in seeds:
+            try:
+                summary = ingest_filer_13f(conn, sec, filer_cik=cik, ingestion_run_id=run_id)
+            except Exception as exc:  # noqa: BLE001 — per-filer crash must not abort the batch
+                logger.exception("13F ingest: filer %s raised; continuing batch", cik)
+                crash_error = f"{cik}: {exc}"
+                conn.rollback()
+                continue
+            conn.commit()
+            summaries.append(summary)
+            rows_upserted += summary.holdings_inserted
+            rows_skipped += summary.holdings_skipped_no_cusip
+            accession_failures += summary.accessions_failed
+            if summary.first_error and first_accession_error is None:
+                first_accession_error = f"{cik} {summary.first_error}"
+    finally:
+        # Status precedence:
+        #   * any per-filer crash + zero successful summaries -> failed
+        #   * any per-filer crash with at least one summary    -> partial
+        #   * any per-accession failure across the batch       -> partial
+        #   * any per-accession unresolved-CUSIP skip          -> partial
+        #     (rows_skipped > 0 indicates partial coverage)
+        #   * else                                              -> success
+        if crash_error and not summaries:
+            status = "failed"
+        elif crash_error or accession_failures > 0 or rows_skipped > 0:
+            status = "partial"
+        else:
+            status = "success"
+        # Combine the surfaced error so data_ingestion_runs.error
+        # carries a useful audit trail without exceeding the column.
+        # Per-accession detail lives in
+        # institutional_holdings_ingest_log; this is the executive
+        # summary.
+        error_parts: list[str] = []
+        if crash_error:
+            error_parts.append(f"crash: {crash_error}")
+        if first_accession_error:
+            error_parts.append(f"accession: {first_accession_error}")
+        if rows_skipped > 0 and not error_parts:
+            # Pure-coverage gap (no crashes, no failed accessions —
+            # just unresolved CUSIPs). Surface the count as the only
+            # signal so the operator can correlate with #740.
+            error_parts.append(f"{rows_skipped} holdings skipped — CUSIPs unresolved (#740)")
+        finish_ingestion_run(
+            conn,
+            run_id=run_id,
+            status=status,
+            rows_upserted=rows_upserted,
+            rows_skipped=rows_skipped,
+            error="; ".join(error_parts) or None,
+        )
+        conn.commit()
+
+    return summaries
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MutableSummary:
+    cik: str
+    accessions_seen: int = 0
+    accessions_ingested: int = 0
+    accessions_failed: int = 0
+    holdings_inserted: int = 0
+    holdings_skipped_no_cusip: int = 0
+    first_error: str | None = None
+
+    def to_immutable(self) -> IngestSummary:
+        return IngestSummary(
+            filer_cik=self.cik,
+            accessions_seen=self.accessions_seen,
+            accessions_ingested=self.accessions_ingested,
+            accessions_failed=self.accessions_failed,
+            holdings_inserted=self.holdings_inserted,
+            holdings_skipped_no_cusip=self.holdings_skipped_no_cusip,
+            first_error=self.first_error,
+        )
+
+
+def _ingest_single_accession(
+    conn: psycopg.Connection[tuple],
+    sec: SecArchiveFetcher,
+    *,
+    filer_cik: str,
+    ref: AccessionRef,
+) -> _AccessionOutcome:
+    """Per-accession driver. Never raises — every fetch / parse
+    failure resolves to a ``_AccessionOutcome`` with status='failed'
+    so a single malformed accession does not abort the filer batch.
+    """
+    base_url = _archive_file_url(filer_cik, ref.accession_number, "")  # …/{accn}/
+    index_url = base_url + "index.json"
+
+    index_payload = sec.fetch_document_text(index_url)
+    if index_payload is None:
+        logger.info(
+            "13F ingest: index.json 404/error for cik=%s accession=%s",
+            filer_cik,
+            ref.accession_number,
+        )
+        return _AccessionOutcome(
+            status="failed",
+            holdings_inserted=0,
+            holdings_skipped_no_cusip=0,
+            error="archive index.json fetch failed",
+        )
+
+    primary_name, infotable_name = parse_archive_index(index_payload)
+    if primary_name is None or infotable_name is None:
+        logger.warning(
+            "13F ingest: archive index missing primary_doc / infotable for cik=%s accession=%s "
+            "(primary=%s, infotable=%s)",
+            filer_cik,
+            ref.accession_number,
+            primary_name,
+            infotable_name,
+        )
+        return _AccessionOutcome(
+            status="failed",
+            holdings_inserted=0,
+            holdings_skipped_no_cusip=0,
+            error=(f"archive index missing files (primary={primary_name!r}, infotable={infotable_name!r})"),
+        )
+
+    primary_url = _archive_file_url(filer_cik, ref.accession_number, primary_name)
+    infotable_url = _archive_file_url(filer_cik, ref.accession_number, infotable_name)
+
+    primary_xml = sec.fetch_document_text(primary_url)
+    if primary_xml is None:
+        logger.warning(
+            "13F ingest: primary_doc.xml 404/error for cik=%s accession=%s",
+            filer_cik,
+            ref.accession_number,
+        )
+        return _AccessionOutcome(
+            status="failed",
+            holdings_inserted=0,
+            holdings_skipped_no_cusip=0,
+            error="primary_doc.xml fetch failed",
+        )
+
+    try:
+        info = parse_primary_doc(primary_xml)
+    except ValueError as exc:
+        logger.exception(
+            "13F ingest: primary_doc.xml parse failed for cik=%s accession=%s",
+            filer_cik,
+            ref.accession_number,
+        )
+        return _AccessionOutcome(
+            status="failed",
+            holdings_inserted=0,
+            holdings_skipped_no_cusip=0,
+            error=f"primary_doc.xml parse failed: {exc}",
+        )
+
+    infotable_xml = sec.fetch_document_text(infotable_url)
+    if infotable_xml is None:
+        logger.warning(
+            "13F ingest: infotable.xml 404/error for cik=%s accession=%s",
+            filer_cik,
+            ref.accession_number,
+        )
+        return _AccessionOutcome(
+            status="failed",
+            holdings_inserted=0,
+            holdings_skipped_no_cusip=0,
+            error="infotable.xml fetch failed",
+        )
+
+    holdings = parse_infotable(infotable_xml)
+    filer_id = _upsert_filer(conn, info)
+
+    if not holdings:
+        # Empty 13F-HR is legal (filer reported exempt-list /
+        # cancellation). Recorded as success so re-runs skip it.
+        logger.info(
+            "13F ingest: empty infotable for cik=%s accession=%s — filer recorded, no holdings",
+            filer_cik,
+            ref.accession_number,
+        )
+        return _AccessionOutcome(
+            status="success",
+            holdings_inserted=0,
+            holdings_skipped_no_cusip=0,
+            error=None,
+        )
+
+    inserted = 0
+    skipped_no_cusip = 0
+    period = info.period_of_report
+    filed_at = info.filed_at
+    if filed_at is None:
+        # Fall back to submissions-index filing date when
+        # primary_doc.xml had no signature block.
+        filed_at = ref.filed_at or datetime(period.year, period.month, period.day)
+
+    for holding in holdings:
+        instrument_id = _resolve_cusip_to_instrument_id(conn, holding.cusip)
+        if instrument_id is None:
+            skipped_no_cusip += 1
+            continue
+        if _upsert_holding(
+            conn,
+            filer_id=filer_id,
+            instrument_id=instrument_id,
+            accession_number=ref.accession_number,
+            period_of_report=period,
+            filed_at=filed_at,
+            holding=holding,
+        ):
+            inserted += 1
+
+    # Promote to 'partial' when at least one holding was dropped due
+    # to an unresolved CUSIP. The accession itself is recorded so
+    # re-runs skip it; once the #740 backfill closes the CUSIP gap,
+    # the operator can clear the log row to force a re-ingest of
+    # those accessions.
+    status = "partial" if skipped_no_cusip > 0 else "success"
+    error = f"{skipped_no_cusip} unresolved CUSIPs (gated by #740 backfill)" if skipped_no_cusip > 0 else None
+    return _AccessionOutcome(
+        status=status,
+        holdings_inserted=inserted,
+        holdings_skipped_no_cusip=skipped_no_cusip,
+        error=error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Iterators (exposed for ad-hoc reporting / debug)
+# ---------------------------------------------------------------------------
+
+
+def iter_filer_holdings(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_cik: str,
+    limit: int = 1000,
+) -> Iterator[dict[str, Any]]:
+    """Yield the most recent holdings for one filer. Used by the
+    PR 4 reader API + the admin CLI; exposed here for symmetry with
+    ingest path."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT h.accession_number, h.period_of_report, h.shares,
+                   h.market_value_usd, h.voting_authority, h.is_put_call,
+                   h.filed_at, i.symbol, i.company_name
+            FROM institutional_holdings h
+            JOIN institutional_filers f USING (filer_id)
+            JOIN instruments i ON i.instrument_id = h.instrument_id
+            WHERE f.cik = %(cik)s
+            ORDER BY h.period_of_report DESC, h.market_value_usd DESC NULLS LAST
+            LIMIT %(limit)s
+            """,
+            {"cik": _zero_pad_cik(filer_cik), "limit": limit},
+        )
+        for row in cur.fetchall():
+            yield dict(row)

--- a/sql/091_institutional_filer_seeds.sql
+++ b/sql/091_institutional_filer_seeds.sql
@@ -1,0 +1,66 @@
+-- 091_institutional_filer_seeds.sql
+--
+-- Issue #730 PR 2 — operator-curated list of institutional filer
+-- CIKs to ingest 13F-HR holdings for. Per Option C in the
+-- implementation plan: rather than try to ingest all ~5,000
+-- institutional managers per quarter, the operator picks the top
+-- ~100-200 names that move the needle (Vanguard, BlackRock,
+-- Fidelity, Berkshire, etc.) — this curated set covers ~80% of
+-- institutional AUM with a fraction of the SEC bandwidth.
+--
+-- The PR 3 filer-type classifier extends this with an ETF-CIK list
+-- so the ownership card (#729) can split institutions vs ETFs.
+--
+-- ``label`` is informational — the canonical filer name is fetched
+-- from primary_doc.xml on first ingest and stored on
+-- institutional_filers.name. Keeping it here helps the operator
+-- audit the seed list without joining to ingest results.
+--
+-- ``active`` lets an operator pause a noisy / problematic filer
+-- without dropping the row (preserves audit trail of prior ingests).
+
+CREATE TABLE IF NOT EXISTS institutional_filer_seeds (
+    cik         TEXT PRIMARY KEY,
+    label       TEXT NOT NULL,
+    active      BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- ``notes`` is free-form (e.g. "top US ETF issuer", "Buffett's
+    -- holdco", "added per operator review 2026-05-03"). NULL OK.
+    notes       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_filer_seeds_active
+    ON institutional_filer_seeds (cik)
+    WHERE active = TRUE;
+
+
+-- ── institutional_holdings_ingest_log ──────────────────────────
+--
+-- Per-accession attempt tombstone. The ingester (#730 PR 2) needs
+-- this to avoid re-fetching every accession on every run when the
+-- accession produced zero canonical rows — common cases:
+--   * Empty 13F-HR (filer reported "exempt list" or cancellation).
+--   * Every holding's CUSIP unresolved (the #740 backfill gap).
+--   * Persistent 404 on index.json or one of the XML attachments.
+--
+-- Without this table, ``already_ingested`` is derived from
+-- ``institutional_holdings.accession_number``, which misses any
+-- accession that didn't write a holding row. Re-runs then fetch
+-- the same archive forever, burning SEC bandwidth + log noise.
+--
+-- Codex pre-push review caught this on PR review.
+
+CREATE TABLE IF NOT EXISTS institutional_holdings_ingest_log (
+    accession_number   TEXT PRIMARY KEY,
+    filer_cik          TEXT NOT NULL,
+    period_of_report   DATE,
+    status             TEXT NOT NULL
+        CHECK (status IN ('success', 'partial', 'failed')),
+    holdings_inserted  INTEGER NOT NULL DEFAULT 0,
+    holdings_skipped   INTEGER NOT NULL DEFAULT 0,
+    error              TEXT,
+    fetched_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_holdings_ingest_log_filer
+    ON institutional_holdings_ingest_log (filer_cik, fetched_at DESC);

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -105,8 +105,10 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # cascade), but listing them explicitly keeps teardown
     # deterministic when a test populates filer / holding rows
     # without touching the instruments row in the same case.
+    "institutional_holdings_ingest_log",
     "institutional_holdings",
     "institutional_filers",
+    "institutional_filer_seeds",
     "filing_events",
     "decision_audit",  # #315 Phase 3 alerts
     "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)

--- a/tests/test_fetch_document_text_callers.py
+++ b/tests/test_fetch_document_text_callers.py
@@ -35,10 +35,12 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         #   dividend_calendar   — 8-K Item 8.01 (#434)
         #   insider_transactions — Form 4 XML (#429)
         #   eight_k_events      — 8-K full structure (#450)
+        #   institutional_holdings — 13F-HR primary_doc + infotable XML (#730)
         "app/services/business_summary.py",
         "app/services/dividend_calendar.py",
         "app/services/insider_transactions.py",
         "app/services/eight_k_events.py",
+        "app/services/institutional_holdings.py",
         # Provider implementation owns the method itself.
         "app/providers/implementations/sec_edgar.py",
         # Bounded-concurrency wrapper (#726). Calls the method via a
@@ -58,6 +60,7 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         "tests/test_insider_transactions_ingest.py",
         "tests/test_eight_k_events_ingest.py",
         "tests/test_concurrent_fetch.py",
+        "tests/test_institutional_holdings_ingester.py",
         # This guard file itself references the method name in its
         # contract sentence.
         "tests/test_fetch_document_text_callers.py",

--- a/tests/test_institutional_holdings_ingester.py
+++ b/tests/test_institutional_holdings_ingester.py
@@ -188,7 +188,10 @@ class TestParseSubmissionsIndex:
         payload = _submissions_json(accessions=[("0001067983-25-000001", "13F-HR", "2025-02-14", "2024-12-31")])
         ref = parse_submissions_index(payload)[0]
         assert ref.period_of_report == date(2024, 12, 31)
-        assert ref.filed_at == datetime(2025, 2, 14)
+        # filed_at must be tz-aware UTC so it lands in TIMESTAMPTZ
+        # without psycopg falling back to the server's local zone.
+        assert ref.filed_at == datetime(2025, 2, 14, tzinfo=UTC)
+        assert ref.filed_at is not None and ref.filed_at.tzinfo is UTC
 
     def test_malformed_json_returns_empty_list(self) -> None:
         assert parse_submissions_index("not json") == []

--- a/tests/test_institutional_holdings_ingester.py
+++ b/tests/test_institutional_holdings_ingester.py
@@ -1,0 +1,632 @@
+"""Integration tests for the 13F-HR ingester (#730 PR 2).
+
+The service interacts with three boundaries:
+  1. SEC HTTP — abstracted as :class:`SecArchiveFetcher` so tests
+     can substitute a deterministic in-memory fake.
+  2. Postgres — the real ``ebull_test`` DB, since the service
+     issues several intertwined statements (existing-accessions
+     scan, CUSIP resolution, filer + holdings upserts) and
+     mocking that path would erase the value of these tests.
+  3. The pure parser from #730 PR 1 — exercised end-to-end here.
+
+Each test seeds the inputs (an instrument with a known CUSIP
+mapping, a filer seed, a fake fetcher for HTTP) and asserts the
+final canonical row state.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services.institutional_holdings import (
+    ingest_all_active_filers,
+    ingest_filer_13f,
+    parse_archive_index,
+    parse_submissions_index,
+    seed_filer,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders — minimal SEC payloads
+# ---------------------------------------------------------------------------
+
+
+def _submissions_json(*, accessions: list[tuple[str, str, str, str]]) -> str:
+    """Build a fake submissions JSON. Each tuple is
+    ``(accession, form, filing_date, report_date)``."""
+    return json.dumps(
+        {
+            "filings": {
+                "recent": {
+                    "accessionNumber": [a[0] for a in accessions],
+                    "form": [a[1] for a in accessions],
+                    "filingDate": [a[2] for a in accessions],
+                    "reportDate": [a[3] for a in accessions],
+                },
+                "files": [],
+            }
+        }
+    )
+
+
+def _archive_index_json(*, primary_doc: str = "primary_doc.xml", infotable: str = "infotable.xml") -> str:
+    """Build a fake archive index.json listing primary_doc + infotable."""
+    items: list[dict[str, str]] = []
+    if primary_doc:
+        items.append({"name": primary_doc, "type": "text.gif", "size": "1234"})
+    if infotable:
+        items.append({"name": infotable, "type": "text.gif", "size": "5678"})
+    items.append({"name": "0001067983-25-000001-index-headers.html", "type": "text.gif", "size": "100"})
+    return json.dumps({"directory": {"name": "/Archives/...", "item": items}})
+
+
+_PRIMARY_DOC_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler">
+  <headerData>
+    <filerInfo>
+      <filer>
+        <credentials>
+          <cik>0001067983</cik>
+        </credentials>
+      </filer>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <coverPage>
+      <reportCalendarOrQuarter>09-30-2024</reportCalendarOrQuarter>
+      <filingManager>
+        <name>BERKSHIRE HATHAWAY INC</name>
+      </filingManager>
+    </coverPage>
+    <signatureBlock>
+      <signatureDate>11-14-2024</signatureDate>
+    </signatureBlock>
+  </formData>
+</edgarSubmission>
+"""
+
+
+def _infotable_xml(*, holdings: Iterable[dict[str, str]]) -> str:
+    rows: list[str] = []
+    for h in holdings:
+        rows.append(
+            f"""<infoTable>
+  <nameOfIssuer>{h.get("name", "APPLE INC")}</nameOfIssuer>
+  <titleOfClass>COM</titleOfClass>
+  <cusip>{h["cusip"]}</cusip>
+  <value>{h.get("value", "69900000")}</value>
+  <shrsOrPrnAmt>
+    <sshPrnamt>{h.get("shares", "300000000")}</sshPrnamt>
+    <sshPrnamtType>SH</sshPrnamtType>
+  </shrsOrPrnAmt>
+  <investmentDiscretion>SOLE</investmentDiscretion>
+  <votingAuthority>
+    <Sole>{h.get("sole", "300000000")}</Sole>
+    <Shared>0</Shared>
+    <None>0</None>
+  </votingAuthority>
+</infoTable>"""
+        )
+    body = "\n  ".join(rows)
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable">
+  {body}
+</informationTable>
+"""
+
+
+class _InMemoryFetcher:
+    """Deterministic SecArchiveFetcher fake."""
+
+    def __init__(self, payloads: dict[str, str | None]) -> None:
+        self._payloads = payloads
+        self.calls: list[str] = []
+
+    def fetch_document_text(self, absolute_url: str) -> str | None:
+        self.calls.append(absolute_url)
+        return self._payloads.get(absolute_url)
+
+
+# ---------------------------------------------------------------------------
+# DB seeding helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} test"),
+    )
+
+
+def _seed_cusip_mapping(conn: psycopg.Connection[tuple], *, instrument_id: int, cusip: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (%s, 'sec', 'cusip', %s, TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        """,
+        (instrument_id, cusip.upper()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure-parser tests (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestParseSubmissionsIndex:
+    def test_filters_to_13f_forms_only(self) -> None:
+        payload = _submissions_json(
+            accessions=[
+                ("0001067983-25-000001", "13F-HR", "2025-02-14", "2024-12-31"),
+                ("0001067983-25-000002", "10-Q", "2025-02-14", "2024-12-31"),
+                ("0001067983-25-000003", "13F-HR/A", "2025-03-01", "2024-12-31"),
+                ("0001067983-25-000004", "8-K", "2025-04-01", ""),
+            ]
+        )
+        refs = parse_submissions_index(payload)
+        assert len(refs) == 2
+        assert {r.filing_type for r in refs} == {"13F-HR", "13F-HR/A"}
+
+    def test_period_and_filed_at_parsed(self) -> None:
+        payload = _submissions_json(accessions=[("0001067983-25-000001", "13F-HR", "2025-02-14", "2024-12-31")])
+        ref = parse_submissions_index(payload)[0]
+        assert ref.period_of_report == date(2024, 12, 31)
+        assert ref.filed_at == datetime(2025, 2, 14)
+
+    def test_malformed_json_returns_empty_list(self) -> None:
+        assert parse_submissions_index("not json") == []
+
+    def test_missing_recent_section_returns_empty_list(self) -> None:
+        assert parse_submissions_index('{"filings": {}}') == []
+
+
+class TestParseArchiveIndex:
+    def test_typical_listing(self) -> None:
+        primary, infotable = parse_archive_index(_archive_index_json())
+        assert primary == "primary_doc.xml"
+        assert infotable == "infotable.xml"
+
+    def test_pre_2018_form13f_naming(self) -> None:
+        primary, infotable = parse_archive_index(_archive_index_json(infotable="form13fInfoTable.xml"))
+        assert primary == "primary_doc.xml"
+        assert infotable == "form13fInfoTable.xml"
+
+    def test_agent_built_naming(self) -> None:
+        primary, infotable = parse_archive_index(_archive_index_json(infotable="0001067983-25-000001_infotable.xml"))
+        assert infotable == "0001067983-25-000001_infotable.xml"
+
+    def test_information_table_long_form(self) -> None:
+        primary, infotable = parse_archive_index(_archive_index_json(infotable="information_table.xml"))
+        assert infotable == "information_table.xml"
+
+    def test_missing_primary_returns_none(self) -> None:
+        primary, infotable = parse_archive_index(_archive_index_json(primary_doc=""))
+        assert primary is None
+        assert infotable == "infotable.xml"
+
+    def test_missing_infotable_returns_none(self) -> None:
+        primary, infotable = parse_archive_index(_archive_index_json(infotable=""))
+        assert primary == "primary_doc.xml"
+        assert infotable is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: end-to-end ingest
+# ---------------------------------------------------------------------------
+
+
+class TestIngestFiler13F:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        # Seed two instruments + their CUSIPs so resolution succeeds.
+        _seed_instrument(conn, iid=730_001, symbol="AAPL")
+        _seed_cusip_mapping(conn, instrument_id=730_001, cusip="037833100")
+        _seed_instrument(conn, iid=730_002, symbol="MSFT")
+        _seed_cusip_mapping(conn, instrument_id=730_002, cusip="594918104")
+        # Seed the filer.
+        seed_filer(conn, cik="0001067983", label="BERKSHIRE HATHAWAY")
+        conn.commit()
+        return conn
+
+    def _build_fetcher(self, *, holdings: list[dict[str, str]]) -> _InMemoryFetcher:
+        cik_int = 1067983
+        accession = "0001067983-25-000001"
+        accn_no_dashes = accession.replace("-", "")
+        archive_base = f"https://www.sec.gov/Archives/edgar/data/{cik_int}/{accn_no_dashes}/"
+        payloads: dict[str, str | None] = {
+            "https://data.sec.gov/submissions/CIK0001067983.json": _submissions_json(
+                accessions=[(accession, "13F-HR", "2025-02-14", "2024-12-31")]
+            ),
+            archive_base + "index.json": _archive_index_json(),
+            archive_base + "primary_doc.xml": _PRIMARY_DOC_XML,
+            archive_base + "infotable.xml": _infotable_xml(holdings=holdings),
+        }
+        return _InMemoryFetcher(payloads)
+
+    def test_end_to_end_ingest_populates_filer_and_holdings(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        fetcher = self._build_fetcher(
+            holdings=[
+                {"cusip": "037833100", "name": "APPLE INC", "value": "69900000", "shares": "300000000"},
+                {"cusip": "594918104", "name": "MICROSOFT CORP", "value": "42000000", "shares": "100000000"},
+            ]
+        )
+
+        summary = ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+
+        assert summary.accessions_seen == 1
+        assert summary.accessions_ingested == 1
+        assert summary.holdings_inserted == 2
+        assert summary.holdings_skipped_no_cusip == 0
+
+        # Filer row exists.
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT cik, name FROM institutional_filers WHERE cik = '0001067983'")
+            filer = cur.fetchone()
+        assert filer is not None
+        assert filer["name"] == "BERKSHIRE HATHAWAY INC"
+
+        # Both holdings rows.
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT i.symbol, h.shares, h.market_value_usd, h.voting_authority
+                FROM institutional_holdings h
+                JOIN instruments i ON i.instrument_id = h.instrument_id
+                ORDER BY i.symbol
+                """,
+            )
+            rows = cur.fetchall()
+        assert [r["symbol"] for r in rows] == ["AAPL", "MSFT"]
+        assert rows[0]["shares"] == Decimal("300000000")
+        assert rows[0]["market_value_usd"] == Decimal("69900000")
+        assert rows[0]["voting_authority"] == "SOLE"
+
+    def test_unknown_cusip_is_skipped_with_counter(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Holdings whose CUSIP is not yet mapped via #740 land in
+        ``holdings_skipped_no_cusip`` rather than raising."""
+        conn = _setup
+        fetcher = self._build_fetcher(
+            holdings=[
+                {"cusip": "037833100", "name": "APPLE INC"},  # known
+                {"cusip": "999999999", "name": "UNKNOWN CO"},  # not mapped
+                {"cusip": "888888888", "name": "OTHER UNKNOWN"},  # not mapped
+            ]
+        )
+        summary = ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+        assert summary.holdings_inserted == 1
+        assert summary.holdings_skipped_no_cusip == 2
+
+    def test_re_ingest_is_idempotent(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Running the ingester twice on the same filer leaves the
+        canonical row count unchanged. Skipping is keyed on
+        ``existing_accessions`` so the second run never even fetches
+        the archive index for already-ingested accessions."""
+        conn = _setup
+        fetcher = self._build_fetcher(holdings=[{"cusip": "037833100", "name": "APPLE INC"}])
+        first = ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+        assert first.holdings_inserted == 1
+
+        # Second run must not re-fetch the archive index.json or the
+        # XML attachments because the accession is already present.
+        fetcher.calls.clear()
+        second = ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+        assert second.accessions_seen == 1
+        assert second.accessions_ingested == 0
+        assert second.holdings_inserted == 0
+
+        # Only the submissions JSON was re-fetched.
+        assert any("submissions" in url for url in fetcher.calls)
+        assert not any("primary_doc.xml" in url for url in fetcher.calls)
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM institutional_holdings")
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == 1
+
+    def test_missing_submissions_returns_zero_summary(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """If data.sec.gov returns 404 for the submissions JSON, the
+        ingester logs and returns an empty summary rather than
+        raising. CIK-not-found is a real condition (filer fell off
+        the registered list, or the seeded CIK is wrong)."""
+        conn = _setup
+        fetcher = _InMemoryFetcher({})  # everything 404s
+        summary = ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+        assert summary.accessions_seen == 0
+        assert summary.accessions_ingested == 0
+
+    def test_missing_archive_index_records_failed_accession(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """A submissions JSON listing an accession but archive index
+        404 — that's a transient real condition (SEC indexes the
+        filing in the manager listing before the archive directory
+        is published). Surface as accessions_failed; next run
+        retries."""
+        conn = _setup
+        cik_int = 1067983
+        accession = "0001067983-25-000001"
+        archive_base = f"https://www.sec.gov/Archives/edgar/data/{cik_int}/{accession.replace('-', '')}/"
+        payloads: dict[str, str | None] = {
+            "https://data.sec.gov/submissions/CIK0001067983.json": _submissions_json(
+                accessions=[(accession, "13F-HR", "2025-02-14", "2024-12-31")]
+            ),
+            archive_base + "index.json": None,  # 404
+        }
+        fetcher = _InMemoryFetcher(payloads)
+        summary = ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+        assert summary.accessions_seen == 1
+        assert summary.accessions_ingested == 0
+        assert summary.accessions_failed == 1
+        # No filer row written.
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM institutional_filers WHERE cik = '0001067983'")
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == 0
+
+    def test_partial_unique_index_blocks_duplicate_equity_row(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """The partial UNIQUE INDEX from migration 090 must reject a
+        duplicate equity row for the same (accession, instrument)
+        pair while still admitting a sibling PUT or CALL row."""
+        conn = _setup
+
+        # Equity holding lands.
+        fetcher = self._build_fetcher(holdings=[{"cusip": "037833100", "name": "APPLE INC"}])
+        ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+
+        # Manually try to insert a duplicate equity row — must fail
+        # the partial UNIQUE INDEX. Use a savepoint so the failed
+        # insert doesn't poison the test transaction.
+        with conn.cursor() as cur:
+            cur.execute("SAVEPOINT s1")
+            with pytest.raises(psycopg.errors.UniqueViolation):
+                cur.execute(
+                    """
+                    INSERT INTO institutional_holdings (
+                        filer_id, instrument_id, accession_number, period_of_report,
+                        shares, market_value_usd, voting_authority, is_put_call, filed_at
+                    )
+                    SELECT filer_id, %(iid)s, %(accn)s, %(pd)s, 1, 1, 'SOLE', NULL, %(fd)s
+                    FROM institutional_filers WHERE cik = '0001067983'
+                    """,
+                    {
+                        "iid": 730_001,
+                        "accn": "0001067983-25-000001",
+                        "pd": date(2024, 12, 31),
+                        "fd": datetime(2025, 2, 14, tzinfo=UTC),
+                    },
+                )
+            cur.execute("ROLLBACK TO SAVEPOINT s1")
+
+        # A sibling PUT row IS admitted (different is_put_call value).
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO institutional_holdings (
+                    filer_id, instrument_id, accession_number, period_of_report,
+                    shares, market_value_usd, voting_authority, is_put_call, filed_at
+                )
+                SELECT filer_id, %(iid)s, %(accn)s, %(pd)s, 1, 1, 'SOLE', 'PUT', %(fd)s
+                FROM institutional_filers WHERE cik = '0001067983'
+                """,
+                {
+                    "iid": 730_001,
+                    "accn": "0001067983-25-000001",
+                    "pd": date(2024, 12, 31),
+                    "fd": datetime(2025, 2, 14, tzinfo=UTC),
+                },
+            )
+            conn.commit()
+        with conn.cursor() as cur:
+            cur.execute("SELECT is_put_call FROM institutional_holdings ORDER BY is_put_call NULLS FIRST")
+            rows = cur.fetchall()
+            assert [r[0] for r in rows] == [None, "PUT"]
+
+
+class TestIngestLogIdempotency:
+    """#730 PR 2 review pin: idempotency must hold for accessions
+    that produce zero canonical rows (empty 13F-HR or every CUSIP
+    unresolved). Without the institutional_holdings_ingest_log
+    tombstone the ingester re-fetched these accessions on every
+    run and the unresolved-CUSIP counter ratcheted forever."""
+
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        seed_filer(conn, cik="0001067983", label="BERKSHIRE")
+        conn.commit()
+        return conn
+
+    def _build_fetcher(self, *, holdings: list[dict[str, str]]) -> _InMemoryFetcher:
+        cik_int = 1067983
+        accession = "0001067983-25-000001"
+        accn_no_dashes = accession.replace("-", "")
+        archive_base = f"https://www.sec.gov/Archives/edgar/data/{cik_int}/{accn_no_dashes}/"
+        return _InMemoryFetcher(
+            {
+                "https://data.sec.gov/submissions/CIK0001067983.json": _submissions_json(
+                    accessions=[(accession, "13F-HR", "2025-02-14", "2024-12-31")]
+                ),
+                archive_base + "index.json": _archive_index_json(),
+                archive_base + "primary_doc.xml": _PRIMARY_DOC_XML,
+                archive_base + "infotable.xml": _infotable_xml(holdings=holdings),
+            }
+        )
+
+    def test_zero_canonical_rows_still_logs_skip_marker(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Every CUSIP unresolved -> zero canonical rows. Without the
+        log row the second run re-fetches and re-counts the skip."""
+        conn = _setup
+        fetcher = self._build_fetcher(holdings=[{"cusip": "999999999", "name": "UNKNOWN"}])
+
+        first = ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+        assert first.holdings_inserted == 0
+        assert first.holdings_skipped_no_cusip == 1
+
+        # Log row exists with status='partial' (unresolved CUSIP gap).
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT status, holdings_inserted, holdings_skipped FROM institutional_holdings_ingest_log "
+                "WHERE accession_number = '0001067983-25-000001'"
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "partial"
+        assert row[1] == 0
+        assert row[2] == 1
+
+        # Second run: must skip — accession_seen counts the
+        # pending list, but accessions_ingested + holdings_skipped
+        # remain zero because the existing-log gate fires.
+        fetcher.calls.clear()
+        second = ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+        assert second.accessions_seen == 1
+        assert second.accessions_ingested == 0
+        assert second.holdings_skipped_no_cusip == 0
+        assert not any("primary_doc.xml" in url for url in fetcher.calls)
+
+    def test_failed_accession_logged_with_error_message(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """A 404 on the archive index records a failed log row with
+        the failure reason so re-runs skip until the operator
+        clears the row."""
+        conn = _setup
+        cik_int = 1067983
+        accession = "0001067983-25-000001"
+        archive_base = f"https://www.sec.gov/Archives/edgar/data/{cik_int}/{accession.replace('-', '')}/"
+        fetcher = _InMemoryFetcher(
+            {
+                "https://data.sec.gov/submissions/CIK0001067983.json": _submissions_json(
+                    accessions=[(accession, "13F-HR", "2025-02-14", "2024-12-31")]
+                ),
+                archive_base + "index.json": None,  # 404
+            }
+        )
+
+        ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT status, error FROM institutional_holdings_ingest_log "
+                "WHERE accession_number = '0001067983-25-000001'"
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "failed"
+        assert row[1] is not None
+        assert "index.json" in row[1]
+
+
+class TestIngestAllActiveFilersDataIngestionRuns:
+    """Codex pre-push pin: per-accession failures must surface in
+    data_ingestion_runs.error so the ops monitor (#13) sees more
+    than 'success' on a run that silently dropped accessions."""
+
+    def test_partial_status_when_accessions_failed_but_no_crash(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        seed_filer(conn, cik="0001067983", label="BERKSHIRE")
+        conn.commit()
+
+        cik_int = 1067983
+        accession = "0001067983-25-000001"
+        archive_base = f"https://www.sec.gov/Archives/edgar/data/{cik_int}/{accession.replace('-', '')}/"
+        fetcher = _InMemoryFetcher(
+            {
+                "https://data.sec.gov/submissions/CIK0001067983.json": _submissions_json(
+                    accessions=[(accession, "13F-HR", "2025-02-14", "2024-12-31")]
+                ),
+                archive_base + "index.json": None,  # 404 → failed accession
+            }
+        )
+
+        ingest_all_active_filers(conn, fetcher)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT status, error FROM data_ingestion_runs "
+                "WHERE source = 'sec_edgar_13f' "
+                "ORDER BY ingestion_run_id DESC LIMIT 1"
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "partial"
+        assert row[1] is not None
+        assert "accession" in row[1].lower()
+
+
+class TestSeedFiler:
+    def test_idempotent_seed(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        seed_filer(conn, cik="1067983", label="BERKSHIRE")
+        seed_filer(conn, cik="0001067983", label="BERKSHIRE HATHAWAY", notes="updated")
+        conn.commit()
+        with conn.cursor() as cur:
+            cur.execute("SELECT label, notes, active FROM institutional_filer_seeds WHERE cik = '0001067983'")
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "BERKSHIRE HATHAWAY"
+            assert row[1] == "updated"
+            assert row[2] is True


### PR DESCRIPTION
## What

PR 2 of 4 implementing SEC 13F-HR institutional holdings ingest (Plan C.2). Ships the ingestion service that drives the schema + parser from PR 1 (#739).

**Approach: curated filer-CIK list** (Option C agreed in batch-design discussion). Operator picks ~100-200 top institutional managers via the new \`institutional_filer_seeds\` table; the ingester walks each filer's submissions JSON for 13F-HR / 13F-HR/A accessions, fetches per-accession XML attachments, parses via PR 1, resolves each holding's CUSIP through \`external_identifiers\`, and upserts.

## Conscious tradeoffs

**Per-accession tombstone via new \`institutional_holdings_ingest_log\` table.** Codex pre-push review caught two correctness gaps:

1. Idempotence broken for zero-row outcomes. An empty 13F-HR (legal — exempt-list filer) or an accession where every CUSIP is unresolved writes no holding row. Without a separate per-accession marker, "already_ingested" derived from \`institutional_holdings.accession_number\` would miss them, so re-runs re-fetched the same archives forever and ratcheted the unresolved-CUSIP counter. The tombstone records every attempt (success / partial / failed) keyed on accession_number.

2. Per-accession failures invisible in \`data_ingestion_runs\`. Pre-fix the batch wrapper marked the run 'success' as long as no filer crashed, even when individual accessions failed. Now status precedence honours per-accession failed counts and rows_skipped, and an executive summary lands in \`error\` so the ops monitor (#13) sees "X holdings skipped — CUSIPs unresolved (#740)" and similar.

**CUSIP backfill is OUT OF SCOPE — tracked in #740.** Dev DB shows zero rows with \`identifier_type='cusip'\` in \`external_identifiers\` today; the original ticket's claim "CUSIPs already mapped for US issuers" is incorrect. The ingester ships ready (unresolved-CUSIP rows land as 'partial' status). Once #740 lands the same accessions can be retried by clearing their log rows.

**\`ON CONFLICT DO NOTHING\` with no inference target.** The expression-based partial UNIQUE INDEX from migration 090 (\`COALESCE(is_put_call, 'EQUITY')\`) cannot be referenced via simple inference clause without re-typing the COALESCE expression. Using DO NOTHING with no target is safe here because the synthetic PK on \`holding_id\` is BIGSERIAL and never collides — any conflict that fires is the expression index by construction.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pyright\` — clean
- [x] \`uv run pytest tests/test_institutional_holdings_ingester.py\` — 20 passed
   - Pure parser tests (submissions index, archive index variants — modern, pre-2018 form13fInfoTable, agent-built, long-form names)
   - End-to-end ingest against \`ebull_test\` with in-memory fake fetcher
   - Idempotent re-ingest pin
   - Unknown-CUSIP counter pin
   - Partial UNIQUE INDEX behaviour pin (equity + PUT siblings coexist; duplicate equity rejected)
   - Zero-row log tombstone pin (closes Codex finding 1)
   - Failed-accession log row with error message pin
   - Batch-mode \`data_ingestion_runs\` 'partial' status surface pin (closes Codex finding 2)
   - Seed helper idempotence
- [x] Codex pre-push review — both findings addressed inside this PR before push

## What it doesn't do (out of scope, follow-up tickets)

- **Filer-type classifier** (PR 3) — \`institutional_filers.filer_type\` stays NULL until #730 PR 3 ships the curated ETF-CIK list cross-reference. The ownership card (#729) needs this to split institutions vs ETFs.
- **Reader API + frontend wiring** (PR 4) — \`/instruments/{symbol}/institutional-holdings\` endpoint + ownership-card UI ship next.
- **CUSIP backfill** (#740) — backfills \`external_identifiers\` so the ingester actually resolves the holdings to instrument_ids.
- **Older accessions beyond \`recent\` shard** — submissions JSON's \`files\` array (older shards) is not walked. The \`recent\` array carries the most recent ~1,000 filings per filer = 12+ quarters of 13F coverage, more than enough for the rolling ownership-card view.

## Linked

- Builds on PR #739 (#730 PR 1).
- Gated on #740 for meaningful coverage.
- Unblocks #730 PR 3 + PR 4 + #729.