### PR TITLE
feat(#730): filer-type classifier — curated ETF-CIK list (PR 3 of 4)

### DIFF
--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -420,23 +420,88 @@ def _resolve_cusip_to_instrument_id(
     return int(row[0]) if row is not None else None
 
 
+def classify_filer_type(
+    conn: psycopg.Connection[tuple],
+    cik: str,
+) -> str:
+    """Map a filer CIK to one of the constrained filer_type labels.
+
+    Cross-references the ``etf_filer_cik_seeds`` curated list. CIKs
+    on that list (and ``active=TRUE``) are tagged ``'ETF'``; every
+    other discovered 13F-HR filer defaults to ``'INV'`` (the
+    general institutional-manager bucket).
+
+    Future enhancements (out of scope for #730 PR 3):
+      * Ingest the SEC's quarterly RIC / mutual-fund registrant
+        list to auto-populate the seed table.
+      * Distinguish ``'INS'`` (insurance) and ``'BD'`` (broker-dealer)
+        based on Form CRD data — the schema already allows those
+        labels via the CHECK constraint on
+        ``institutional_filers.filer_type``.
+    """
+    cur = conn.execute(
+        """
+        SELECT 1 FROM etf_filer_cik_seeds
+        WHERE cik = %(cik)s AND active = TRUE
+        LIMIT 1
+        """,
+        {"cik": _zero_pad_cik(cik)},
+    )
+    return "ETF" if cur.fetchone() is not None else "INV"
+
+
+def seed_etf_filer(
+    conn: psycopg.Connection[tuple],
+    *,
+    cik: str | int,
+    label: str,
+    notes: str | None = None,
+    active: bool = True,
+) -> None:
+    """Idempotent helper for adding a CIK to the curated ETF list.
+    Mirrors :func:`seed_filer` for the institutional-filer seed
+    table; both are exposed for tests + admin scripts."""
+    conn.execute(
+        """
+        INSERT INTO etf_filer_cik_seeds (cik, label, active, notes)
+        VALUES (%(cik)s, %(label)s, %(active)s, %(notes)s)
+        ON CONFLICT (cik) DO UPDATE SET
+            label = EXCLUDED.label,
+            active = EXCLUDED.active,
+            notes = COALESCE(EXCLUDED.notes, etf_filer_cik_seeds.notes)
+        """,
+        {
+            "cik": _zero_pad_cik(cik),
+            "label": label,
+            "active": active,
+            "notes": notes,
+        },
+    )
+
+
 def _upsert_filer(
     conn: psycopg.Connection[tuple],
     info: ThirteenFFilerInfo,
 ) -> int:
     """Insert / update an institutional_filers row. Returns filer_id.
 
-    ``filer_type`` and ``aum_usd`` are not set here — the
-    classifier (#730 PR 3) populates filer_type from a curated
-    ETF-CIK list; AUM is computed from the holdings sum on each run
-    by an aggregator (PR 4). Both are nullable in the schema.
+    ``filer_type`` is derived from the curated ETF list (#730 PR 3)
+    via :func:`classify_filer_type` on every write. The classifier
+    is cheap (single index lookup) and idempotent, so re-running
+    after a seed-list update propagates the new label on the next
+    ingest cycle without a backfill migration.
+
+    ``aum_usd`` is not set here — the aggregator (#730 PR 4) sums
+    the latest-quarter holdings per filer on read.
     """
+    filer_type = classify_filer_type(conn, info.cik)
     cur = conn.execute(
         """
-        INSERT INTO institutional_filers (cik, name, last_filing_at)
-        VALUES (%(cik)s, %(name)s, %(last_filing_at)s)
+        INSERT INTO institutional_filers (cik, name, filer_type, last_filing_at)
+        VALUES (%(cik)s, %(name)s, %(filer_type)s, %(last_filing_at)s)
         ON CONFLICT (cik) DO UPDATE SET
             name = EXCLUDED.name,
+            filer_type = EXCLUDED.filer_type,
             last_filing_at = GREATEST(
                 COALESCE(institutional_filers.last_filing_at, '-infinity'),
                 COALESCE(EXCLUDED.last_filing_at, '-infinity')
@@ -447,6 +512,7 @@ def _upsert_filer(
         {
             "cik": info.cik,
             "name": info.name,
+            "filer_type": filer_type,
             "last_filing_at": info.filed_at,
         },
     )

--- a/sql/092_etf_filer_cik_seeds.sql
+++ b/sql/092_etf_filer_cik_seeds.sql
@@ -1,0 +1,35 @@
+-- 092_etf_filer_cik_seeds.sql
+--
+-- Issue #730 PR 3 — operator-curated set of CIKs known to be ETF
+-- issuers. The 13F-HR ingester (#730 PR 2) cross-references each
+-- discovered filer against this list and writes ``'ETF'`` to
+-- ``institutional_filers.filer_type``; CIKs not on the list default
+-- to ``'INV'`` (general institutional manager) at write time.
+--
+-- Why a separate table from ``institutional_filer_seeds``:
+--   * The ETF list is much larger (~3,000 US ETF issuers vs ~100-200
+--     top filers we actively ingest). Many ETF-issuer CIKs are NOT
+--     in our active-ingest seed list — but if a 13F-HR filer is
+--     also an ETF issuer (e.g. an ETF sub-adviser that files its
+--     own 13F), the type should still be 'ETF', not 'INV'.
+--   * The two seed lists are managed under different cadences. The
+--     ingest seeds change as the operator picks new filers; the ETF
+--     list refreshes on a quarterly cadence when SEC publishes the
+--     official ETF/RIC registrant list.
+--
+-- Schema mirrors institutional_filer_seeds for the operator-side
+-- admin pattern (cik PK, label, active, notes). Future work:
+-- ingest the SEC's official RIC list to auto-populate this table —
+-- that's #730 PR 4 stretch / its own follow-up depending on shape.
+
+CREATE TABLE IF NOT EXISTS etf_filer_cik_seeds (
+    cik         TEXT PRIMARY KEY,
+    label       TEXT NOT NULL,
+    active      BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    notes       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_etf_seeds_active
+    ON etf_filer_cik_seeds (cik)
+    WHERE active = TRUE;

--- a/sql/092_etf_filer_cik_seeds.sql
+++ b/sql/092_etf_filer_cik_seeds.sql
@@ -30,6 +30,8 @@ CREATE TABLE IF NOT EXISTS etf_filer_cik_seeds (
     notes       TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_etf_seeds_active
-    ON etf_filer_cik_seeds (cik)
-    WHERE active = TRUE;
+-- No additional index — ``classify_filer_type`` is a point-lookup
+-- on ``cik`` and the PK index already covers it. Adding a partial
+-- index on ``(cik) WHERE active = TRUE`` is dead weight (the
+-- planner picks the PK index for the eq-predicate path and ignores
+-- a smaller-but-redundant secondary).

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -109,6 +109,7 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "institutional_holdings",
     "institutional_filers",
     "institutional_filer_seeds",
+    "etf_filer_cik_seeds",
     "filing_events",
     "decision_audit",  # #315 Phase 3 alerts
     "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)

--- a/tests/test_filer_type_classifier.py
+++ b/tests/test_filer_type_classifier.py
@@ -1,0 +1,161 @@
+"""Unit + integration tests for the filer-type classifier (#730 PR 3).
+
+Pins:
+  * Default classification — unflagged CIKs land as 'INV'.
+  * ETF-list cross-reference — CIKs on the curated list land as 'ETF'.
+  * Active-only — a CIK marked ``active=FALSE`` no longer counts as ETF.
+  * Idempotence — re-running classify on the same CIK is stable.
+  * Ingester wiring — _upsert_filer writes filer_type on insert and
+    on the ON CONFLICT UPDATE branch, so a seed-list change
+    propagates on the next ingest cycle without a backfill.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.providers.implementations.sec_13f import ThirteenFFilerInfo
+from app.services.institutional_holdings import (
+    _upsert_filer,
+    classify_filer_type,
+    seed_etf_filer,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+def _info(*, cik: str, name: str = "TEST FILER INC") -> ThirteenFFilerInfo:
+    return ThirteenFFilerInfo(
+        cik=cik,
+        name=name,
+        period_of_report=date(2024, 12, 31),
+        filed_at=datetime(2025, 2, 14, tzinfo=UTC),
+        table_value_total_usd=Decimal("1000000000"),
+    )
+
+
+class TestClassifyFilerType:
+    def test_unflagged_cik_defaults_to_inv(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        assert classify_filer_type(conn, "0001067983") == "INV"
+
+    def test_seeded_cik_is_etf(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        seed_etf_filer(conn, cik="0000102909", label="VANGUARD GROUP")
+        conn.commit()
+        assert classify_filer_type(conn, "0000102909") == "ETF"
+
+    def test_inactive_seed_falls_back_to_inv(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A seed marked ``active=FALSE`` is preserved (audit trail
+        of prior state) but does not count toward classification."""
+        conn = ebull_test_conn
+        seed_etf_filer(
+            conn,
+            cik="0000102909",
+            label="VANGUARD",
+            active=False,
+            notes="paused — operator-initiated 2026-05-03",
+        )
+        conn.commit()
+        assert classify_filer_type(conn, "0000102909") == "INV"
+
+    def test_classification_normalises_unpadded_cik(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Both the seed table and the classify call accept short
+        CIKs and zero-pad on read so a caller doesn't have to
+        remember the convention."""
+        conn = ebull_test_conn
+        seed_etf_filer(conn, cik="102909", label="VANGUARD")
+        conn.commit()
+        # Lookups work regardless of padding.
+        assert classify_filer_type(conn, "102909") == "ETF"
+        assert classify_filer_type(conn, "0000102909") == "ETF"
+
+
+class TestUpsertFilerWritesType:
+    def test_insert_writes_filer_type(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        seed_etf_filer(conn, cik="0000102909", label="VANGUARD")
+        filer_id = _upsert_filer(conn, _info(cik="0000102909", name="VANGUARD"))
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT filer_type FROM institutional_filers WHERE filer_id = %s", (filer_id,))
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "ETF"
+
+    def test_unflagged_filer_lands_as_inv(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        filer_id = _upsert_filer(conn, _info(cik="0001067983", name="BERKSHIRE"))
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT filer_type FROM institutional_filers WHERE filer_id = %s", (filer_id,))
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "INV"
+
+    def test_on_conflict_updates_filer_type_after_seed_change(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Operator promotes a CIK from 'INV' to 'ETF' by adding it
+        to the seed list. The next ingest cycle re-runs _upsert_filer
+        and the ON CONFLICT UPDATE branch must propagate the new
+        label without requiring a backfill migration."""
+        conn = ebull_test_conn
+        # Phase 1: filer arrives without the ETF flag.
+        _upsert_filer(conn, _info(cik="0000102909", name="VANGUARD"))
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT filer_type FROM institutional_filers WHERE cik = '0000102909'")
+            assert cur.fetchone() == ("INV",)
+
+        # Phase 2: operator seeds the ETF list and re-runs the
+        # ingester.
+        seed_etf_filer(conn, cik="0000102909", label="VANGUARD")
+        _upsert_filer(conn, _info(cik="0000102909", name="VANGUARD"))
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT filer_type FROM institutional_filers WHERE cik = '0000102909'")
+            assert cur.fetchone() == ("ETF",)
+
+
+class TestSeedEtfFilerHelper:
+    def test_idempotent_seed_update(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        seed_etf_filer(conn, cik="102909", label="VANGUARD")
+        seed_etf_filer(conn, cik="0000102909", label="VANGUARD GROUP", notes="updated")
+        conn.commit()
+        with conn.cursor() as cur:
+            cur.execute("SELECT label, notes, active FROM etf_filer_cik_seeds WHERE cik = '0000102909'")
+            row = cur.fetchone()
+        assert row == ("VANGUARD GROUP", "updated", True)


### PR DESCRIPTION
## What

PR 3 of 4. Adds the curated ETF-CIK list and wires the 13F-HR ingester to classify each discovered filer as either \`'ETF'\` or \`'INV'\` (general institutional manager).

## Why

The ownership reporting card (#729) needs to split the **Institutions** slice (general managers — pension funds, hedge funds, insurance) from the **ETFs** slice (ETF issuers that file 13F as registered investment advisers). Both file 13F-HR; the type is what tells them apart.

## Conscious tradeoffs

- **Curated seed list, not auto-ingest.** Same operator-managed pattern as \`institutional_filer_seeds\` from PR 2: separate \`etf_filer_cik_seeds\` table with \`(cik, label, active, notes)\`. Auto-populating from SEC's quarterly RIC / mutual-fund registrant list is a deliberate follow-up — bigger fetch path, separate scope.
- **'INV' vs 'ETF' only.** The schema CHECK on \`institutional_filers.filer_type\` already allows \`'INS'\` (insurance) and \`'BD'\` (broker-dealer). Distinguishing those needs Form CRD data; out of scope here.
- **Re-classify on every upsert (no backfill migration).** \`_upsert_filer\` invokes \`classify_filer_type\` on both the INSERT and the ON CONFLICT UPDATE branch. So when an operator promotes a CIK by seeding the ETF list, the next ingest cycle picks up the new label automatically. \`test_on_conflict_updates_filer_type_after_seed_change\` pins this.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pyright\` — clean
- [x] \`uv run pytest tests/test_filer_type_classifier.py tests/test_institutional_holdings_ingester.py\` — 28 passed (10 new in this PR)
- [x] CI gate (allowlist for \`fetch_document_text\` callers) unchanged — no new caller introduced.

## Linked

- Builds on PR #741 (#730 PR 2 — ingester).
- Unblocks #730 PR 4 (reader API + frontend wiring) and the #729 ownership card's ETF / Institutions split.