### PR TITLE
feat(#730): institutional-holdings reader endpoint (PR 4 of 4)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -2622,32 +2622,57 @@ def get_instrument_institutional_holdings(
             filers=[],
         )
 
-    # Per-slice totals on the latest-quarter equity rows only. Option
-    # exposure (``is_put_call IS NOT NULL``) is excluded from the
-    # ownership-percentage rollup but ships in the filer list below.
+    # Per-slice totals + filer counts. Two distinct cohorts in one
+    # query so the response is internally consistent:
+    #
+    #   * ``etfs_shares`` / ``institutions_shares`` and the slice
+    #     filer counts (``total_etfs_filers`` /
+    #     ``total_institutions_filers``) sum over the EQUITY-only
+    #     subset (``is_put_call IS NULL``). Option exposure is
+    #     excluded from the ownership-percentage rollup; counting
+    #     a protective put as long ownership double-counts the
+    #     underlying.
+    #
+    #   * ``total_filers`` counts EVERY distinct filer reporting
+    #     this instrument in the latest quarter — equity + PUT +
+    #     CALL — so it matches the drilldown ``filers`` list shown
+    #     to the operator. Pre-fix this was equity-only too, which
+    #     produced ``total_filers < len(filers)`` for any
+    #     instrument with option-only filers. Codex caught this on
+    #     the PR review.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
             SELECT
-                COALESCE(SUM(h.shares) FILTER (WHERE f.filer_type = 'ETF'), 0) AS etfs_shares,
                 COALESCE(SUM(h.shares) FILTER (
-                    WHERE f.filer_type IN ('INV','INS','BD','OTHER') OR f.filer_type IS NULL
+                    WHERE f.filer_type = 'ETF' AND h.is_put_call IS NULL
+                ), 0) AS etfs_shares,
+                COALESCE(SUM(h.shares) FILTER (
+                    WHERE (f.filer_type IN ('INV','INS','BD','OTHER') OR f.filer_type IS NULL)
+                    AND h.is_put_call IS NULL
                 ), 0) AS institutions_shares,
                 COUNT(DISTINCT f.filer_id) AS total_filers,
-                COUNT(DISTINCT f.filer_id) FILTER (WHERE f.filer_type = 'ETF') AS total_etfs_filers,
                 COUNT(DISTINCT f.filer_id) FILTER (
-                    WHERE f.filer_type IN ('INV','INS','BD','OTHER') OR f.filer_type IS NULL
+                    WHERE f.filer_type = 'ETF' AND h.is_put_call IS NULL
+                ) AS total_etfs_filers,
+                COUNT(DISTINCT f.filer_id) FILTER (
+                    WHERE (f.filer_type IN ('INV','INS','BD','OTHER') OR f.filer_type IS NULL)
+                    AND h.is_put_call IS NULL
                 ) AS total_institutions_filers
             FROM institutional_holdings h
             JOIN institutional_filers f USING (filer_id)
             WHERE h.instrument_id = %(iid)s
               AND h.period_of_report = %(period)s
-              AND h.is_put_call IS NULL
             """,
             {"iid": instrument_id, "period": latest_period},
         )
         totals_row = cur.fetchone()
-    assert totals_row is not None
+    if totals_row is None:
+        # Defensive: the aggregate returns one row even when no
+        # input rows exist (zeros + counts), so ``None`` here is
+        # an unreachable invariant violation. Use HTTPException
+        # rather than ``assert`` so the guard survives ``python -O``.
+        raise HTTPException(status_code=500, detail="aggregate produced no row")
 
     totals = InstitutionalHoldingsTotals(
         period_of_report=latest_period,  # type: ignore[arg-type]

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -2498,3 +2498,209 @@ def get_instrument(
         latest_quote=_parse_quote(row),
         external_identifiers=ext_ids,
     )
+
+
+# ---------------------------------------------------------------------------
+# Institutional holdings reader (#730 PR 4)
+# ---------------------------------------------------------------------------
+
+
+class InstitutionalFilerHolding(BaseModel):
+    """One filer's stake in this instrument as of a recent quarter."""
+
+    filer_cik: str
+    filer_name: str
+    filer_type: str  # 'ETF' | 'INV' | 'INS' | 'BD' | 'OTHER'
+    accession_number: str
+    period_of_report: date
+    shares: Decimal
+    market_value_usd: Decimal | None
+    voting_authority: str | None  # 'SOLE' | 'SHARED' | 'NONE' | None
+    is_put_call: str | None  # 'PUT' | 'CALL' | None (None = underlying equity)
+
+
+class InstitutionalHoldingsTotals(BaseModel):
+    """Per-slice rollups for the ownership card consumer (#729).
+
+    Slices follow the card's percentage-derivation contract. Only
+    underlying-equity rows participate (``is_put_call IS NULL``);
+    PUT / CALL exposure rows ship in ``filers`` for the drilldown
+    table but do NOT contribute to the slice totals — counting an
+    option position as ownership double-counts the underlying.
+    """
+
+    period_of_report: date
+    institutions_shares: Decimal  # sum across filer_type IN ('INV','INS','BD','OTHER')
+    etfs_shares: Decimal  # sum across filer_type = 'ETF'
+    total_filers: int
+    total_institutions_filers: int
+    total_etfs_filers: int
+
+
+class InstitutionalHoldingsResponse(BaseModel):
+    symbol: str
+    totals: InstitutionalHoldingsTotals | None  # None when no holdings on file
+    filers: list[InstitutionalFilerHolding]
+
+
+_DEFAULT_HOLDINGS_LIMIT = 50
+_MAX_HOLDINGS_LIMIT = 500
+
+
+@router.get("/{symbol}/institutional-holdings", response_model=InstitutionalHoldingsResponse)
+def get_instrument_institutional_holdings(
+    symbol: str,
+    limit: int = Query(default=_DEFAULT_HOLDINGS_LIMIT, ge=1, le=_MAX_HOLDINGS_LIMIT),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> InstitutionalHoldingsResponse:
+    """13F-HR institutional + ETF holdings for one instrument.
+
+    Returns the most recent quarter's holdings — the per-instrument
+    ``period_of_report = MAX(period_of_report)`` cohort. Ownership
+    card (#729) consumers use:
+
+      * ``totals.institutions_shares`` / ``shares_outstanding`` for
+        the Institutions slice.
+      * ``totals.etfs_shares`` / ``shares_outstanding`` for the ETFs
+        slice.
+      * ``filers`` for the per-filer drilldown table (top-N by
+        share count, defaulting to 50 — bump via ``?limit=`` up to
+        500).
+
+    Empty state: a non-covered or pre-ingest instrument returns
+    ``200`` with ``totals=null`` and ``filers=[]``. The card
+    consumer renders the empty-per-slice fallback. 404 is reserved
+    for an unknown symbol.
+
+    Per-slice semantics:
+      * Only underlying-equity rows (``is_put_call IS NULL``) feed
+        the totals — option exposure is excluded so a PUT position
+        does not mis-attribute as long ownership.
+      * PUT / CALL rows DO appear in ``filers`` for audit /
+        drilldown.
+      * 'INS' (insurance) and 'BD' (broker-dealer) labels are
+        rolled into the institutions slice (their members file 13F
+        as institutional managers).
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+
+    # Latest period_of_report on file. NULL means no holdings ingested
+    # yet — return the empty payload rather than 404 so the card can
+    # render its no-coverage fallback uniformly.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT MAX(period_of_report) AS latest
+            FROM institutional_holdings
+            WHERE instrument_id = %s
+            """,
+            (instrument_id,),
+        )
+        latest_row = cur.fetchone()
+    latest_period = latest_row["latest"] if latest_row is not None else None  # type: ignore[index]
+    if latest_period is None:
+        return InstitutionalHoldingsResponse(
+            symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+            totals=None,
+            filers=[],
+        )
+
+    # Per-slice totals on the latest-quarter equity rows only. Option
+    # exposure (``is_put_call IS NOT NULL``) is excluded from the
+    # ownership-percentage rollup but ships in the filer list below.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT
+                COALESCE(SUM(h.shares) FILTER (WHERE f.filer_type = 'ETF'), 0) AS etfs_shares,
+                COALESCE(SUM(h.shares) FILTER (
+                    WHERE f.filer_type IN ('INV','INS','BD','OTHER') OR f.filer_type IS NULL
+                ), 0) AS institutions_shares,
+                COUNT(DISTINCT f.filer_id) AS total_filers,
+                COUNT(DISTINCT f.filer_id) FILTER (WHERE f.filer_type = 'ETF') AS total_etfs_filers,
+                COUNT(DISTINCT f.filer_id) FILTER (
+                    WHERE f.filer_type IN ('INV','INS','BD','OTHER') OR f.filer_type IS NULL
+                ) AS total_institutions_filers
+            FROM institutional_holdings h
+            JOIN institutional_filers f USING (filer_id)
+            WHERE h.instrument_id = %(iid)s
+              AND h.period_of_report = %(period)s
+              AND h.is_put_call IS NULL
+            """,
+            {"iid": instrument_id, "period": latest_period},
+        )
+        totals_row = cur.fetchone()
+    assert totals_row is not None
+
+    totals = InstitutionalHoldingsTotals(
+        period_of_report=latest_period,  # type: ignore[arg-type]
+        institutions_shares=Decimal(totals_row["institutions_shares"] or 0),  # type: ignore[arg-type]
+        etfs_shares=Decimal(totals_row["etfs_shares"] or 0),  # type: ignore[arg-type]
+        total_filers=int(totals_row["total_filers"] or 0),  # type: ignore[arg-type]
+        total_institutions_filers=int(totals_row["total_institutions_filers"] or 0),  # type: ignore[arg-type]
+        total_etfs_filers=int(totals_row["total_etfs_filers"] or 0),  # type: ignore[arg-type]
+    )
+
+    # Top-N filers by share count for the drilldown table. Includes
+    # PUT / CALL rows so the operator can see option exposure
+    # alongside underlying equity. Tie-break: market value descending,
+    # then accession_number ascending so a deterministic order
+    # survives same-share filings.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT f.cik AS filer_cik, f.name AS filer_name,
+                   COALESCE(f.filer_type, 'OTHER') AS filer_type,
+                   h.accession_number, h.period_of_report,
+                   h.shares, h.market_value_usd,
+                   h.voting_authority, h.is_put_call
+            FROM institutional_holdings h
+            JOIN institutional_filers f USING (filer_id)
+            WHERE h.instrument_id = %(iid)s
+              AND h.period_of_report = %(period)s
+            ORDER BY h.shares DESC,
+                     h.market_value_usd DESC NULLS LAST,
+                     h.accession_number ASC
+            LIMIT %(limit)s
+            """,
+            {"iid": instrument_id, "period": latest_period, "limit": limit},
+        )
+        rows = cur.fetchall()
+
+    filers = [
+        InstitutionalFilerHolding(
+            filer_cik=str(r["filer_cik"]),  # type: ignore[arg-type]
+            filer_name=str(r["filer_name"]),  # type: ignore[arg-type]
+            filer_type=str(r["filer_type"]),  # type: ignore[arg-type]
+            accession_number=str(r["accession_number"]),  # type: ignore[arg-type]
+            period_of_report=r["period_of_report"],  # type: ignore[arg-type]
+            shares=r["shares"],  # type: ignore[arg-type]
+            market_value_usd=r["market_value_usd"],  # type: ignore[arg-type]
+            voting_authority=r["voting_authority"],  # type: ignore[arg-type]
+            is_put_call=r["is_put_call"],  # type: ignore[arg-type]
+        )
+        for r in rows
+    ]
+
+    return InstitutionalHoldingsResponse(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        totals=totals,
+        filers=filers,
+    )

--- a/tests/test_api_institutional_holdings.py
+++ b/tests/test_api_institutional_holdings.py
@@ -283,6 +283,61 @@ class TestInstitutionalHoldingsEndpoint:
         put_calls = sorted([f["is_put_call"] for f in data["filers"]], key=lambda v: v or "")
         assert put_calls == [None, "PUT"]
 
+    def test_total_filers_matches_drilldown_with_option_only_filer(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        client: TestClient,
+    ) -> None:
+        """Codex review pin: a filer holding ONLY a PUT/CALL on this
+        instrument shows up in ``filers`` (drilldown). ``total_filers``
+        must match the visible drilldown count, otherwise card
+        arithmetic that asserts ``total_filers == len(filers)``
+        silently breaks. Slice counts stay equity-only."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=730_405, symbol="AAPL_T7")
+        seed_etf_filer(conn, cik="0000102909", label="VANGUARD")
+        conn.commit()
+
+        # Vanguard — equity holding, ETF.
+        van_id = _upsert_filer(conn, _make_filer_info(cik="0000102909", name="VANGUARD"))
+        _upsert_holding(
+            conn,
+            filer_id=van_id,
+            instrument_id=730_405,
+            accession_number="0000102909-25-Q4",
+            period_of_report=date(2024, 12, 31),
+            filed_at=datetime(2025, 2, 14, tzinfo=UTC),
+            holding=_make_holding(shares="3000000"),
+        )
+        # Berkshire — PUT-only on this instrument.
+        brk_id = _upsert_filer(conn, _make_filer_info(cik="0001067983", name="BERKSHIRE"))
+        _upsert_holding(
+            conn,
+            filer_id=brk_id,
+            instrument_id=730_405,
+            accession_number="0001067983-25-Q4",
+            period_of_report=date(2024, 12, 31),
+            filed_at=datetime(2025, 2, 14, tzinfo=UTC),
+            holding=_make_holding(shares="500000", put_call="PUT"),
+        )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL_T7/institutional-holdings")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Drilldown shows BOTH filers (Vanguard equity + Berkshire PUT).
+        assert len(data["filers"]) == 2
+        # total_filers matches the drilldown count.
+        assert data["totals"]["total_filers"] == 2
+        # Slice counts stay equity-only — Berkshire's PUT-only
+        # contribution is excluded from the ETF/Institutions split.
+        assert data["totals"]["total_etfs_filers"] == 1  # Vanguard equity
+        assert data["totals"]["total_institutions_filers"] == 0  # Berkshire's only row is a PUT
+        # Slice totals reflect the equity-only sums.
+        assert Decimal(data["totals"]["etfs_shares"]) == Decimal("3000000")
+        assert Decimal(data["totals"]["institutions_shares"]) == Decimal(0)
+
     def test_limit_param_caps_filer_list(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811

--- a/tests/test_api_institutional_holdings.py
+++ b/tests/test_api_institutional_holdings.py
@@ -289,10 +289,19 @@ class TestInstitutionalHoldingsEndpoint:
         client: TestClient,
     ) -> None:
         """Codex review pin: a filer holding ONLY a PUT/CALL on this
-        instrument shows up in ``filers`` (drilldown). ``total_filers``
-        must match the visible drilldown count, otherwise card
-        arithmetic that asserts ``total_filers == len(filers)``
-        silently breaks. Slice counts stay equity-only."""
+        instrument shows up in ``filers`` (drilldown). The pre-fix
+        version counted only equity-cohort filers, so a PUT-only
+        filer appeared in ``filers`` but not in any count — breaking
+        the invariant ``total_filers >= len(filers)`` whenever
+        ``filers`` was unpaginated.
+
+        With ``len(filers) <= limit`` AND filer count below the cap
+        (this fixture has 2 filers + default limit 50), the two
+        match exactly. The general invariant under pagination is
+        ``total_filers >= len(filers)`` — pinned in
+        :py:meth:`test_total_filers_exceeds_filers_when_paginated`.
+        Slice counts stay equity-only because they tie to the
+        slice-share totals."""
         conn = ebull_test_conn
         _seed_instrument(conn, iid=730_405, symbol="AAPL_T7")
         seed_etf_filer(conn, cik="0000102909", label="VANGUARD")
@@ -368,6 +377,44 @@ class TestInstitutionalHoldingsEndpoint:
         # Top-N by shares DESC.
         assert Decimal(data["filers"][0]["shares"]) == Decimal("3000000")
         assert Decimal(data["filers"][1]["shares"]) == Decimal("2000000")
+
+    def test_total_filers_exceeds_filers_when_paginated(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        client: TestClient,
+    ) -> None:
+        """When the filer cohort exceeds ``?limit=``, the response's
+        ``filers`` list is capped while ``total_filers`` remains the
+        full distinct-filer count. The card consumer needs that
+        contract to render "showing N of M" correctly. Pinning the
+        general invariant ``total_filers >= len(filers)``."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=730_406, symbol="AAPL_T8")
+
+        # Five filers, all equity holdings. Bigger than ?limit=2 below.
+        for i, cik in enumerate(["0000000010", "0000000011", "0000000012", "0000000013", "0000000014"]):
+            seed_filer(conn, cik=cik, label=f"FILER_{i}")
+            filer_id = _upsert_filer(conn, _make_filer_info(cik=cik, name=f"FILER_{i}"))
+            _upsert_holding(
+                conn,
+                filer_id=filer_id,
+                instrument_id=730_406,
+                accession_number=f"{cik}-25-Q4",
+                period_of_report=date(2024, 12, 31),
+                filed_at=datetime(2025, 2, 14, tzinfo=UTC),
+                holding=_make_holding(shares=str(1_000_000 * (i + 1))),
+            )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL_T8/institutional-holdings?limit=2")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Drilldown is capped by limit; total_filers is unbounded.
+        assert len(data["filers"]) == 2
+        assert data["totals"]["total_filers"] == 5
+        # The general invariant: total_filers >= len(filers).
+        assert data["totals"]["total_filers"] >= len(data["filers"])
 
     def test_limit_clamped_to_max(
         self,

--- a/tests/test_api_institutional_holdings.py
+++ b/tests/test_api_institutional_holdings.py
@@ -1,0 +1,326 @@
+"""API tests for /instruments/{symbol}/institutional-holdings (#730 PR 4).
+
+Pins:
+  * 404 on unknown symbol.
+  * Empty payload (200, totals=null, filers=[]) when no holdings on file.
+  * Latest-quarter cohort selection (older quarters excluded from the
+    response).
+  * Per-slice totals split institutions vs ETFs by filer_type.
+  * Option exposure (PUT / CALL) excluded from totals but included in
+    the filer drilldown list.
+  * limit + ordering — top-N by shares DESC.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import get_conn
+from app.main import app
+from app.providers.implementations.sec_13f import ThirteenFFilerInfo, ThirteenFHolding
+from app.services.institutional_holdings import (
+    _upsert_filer,
+    _upsert_holding,
+    seed_etf_filer,
+    seed_filer,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def client(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> Iterator[TestClient]:
+    """TestClient with get_conn overridden to yield the ebull_test
+    connection. Restores the override on teardown so cross-test
+    leaks can't poison subsequent suites."""
+
+    def _dep() -> Iterator[psycopg.Connection[tuple]]:
+        yield ebull_test_conn
+
+    app.dependency_overrides[get_conn] = _dep
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _make_filer_info(*, cik: str, name: str) -> ThirteenFFilerInfo:
+    return ThirteenFFilerInfo(
+        cik=cik,
+        name=name,
+        period_of_report=date(2024, 12, 31),
+        filed_at=datetime(2025, 2, 14, tzinfo=UTC),
+        table_value_total_usd=Decimal("1000000000"),
+    )
+
+
+def _make_holding(
+    *,
+    cusip: str = "037833100",
+    shares: str,
+    value: str = "100000000",
+    put_call: str | None = None,
+) -> ThirteenFHolding:
+    return ThirteenFHolding(
+        cusip=cusip,
+        name_of_issuer="APPLE INC",
+        title_of_class="COM",
+        value_usd=Decimal(value),
+        shares_or_principal=Decimal(shares),
+        shares_or_principal_type="SH",
+        put_call=put_call,  # type: ignore[arg-type]
+        investment_discretion="SOLE",
+        voting_sole=Decimal(shares),
+        voting_shared=Decimal(0),
+        voting_none=Decimal(0),
+    )
+
+
+class TestInstitutionalHoldingsEndpoint:
+    def test_unknown_symbol_returns_404(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        client: TestClient,
+    ) -> None:
+        # ebull_test_conn truncates the planner tables; symbol genuinely
+        # not present.
+        resp = client.get("/instruments/UNKNOWN_TEST_SYMBOL/institutional-holdings")
+        assert resp.status_code == 404
+
+    def test_known_symbol_with_no_holdings_returns_empty_payload(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        client: TestClient,
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=730_400, symbol="AAPL_T1")
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL_T1/institutional-holdings")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["symbol"] == "AAPL_T1"
+        assert data["totals"] is None
+        assert data["filers"] == []
+
+    def test_latest_quarter_cohort(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        client: TestClient,
+    ) -> None:
+        """Two quarters of holdings present; the endpoint returns
+        only the latest quarter's rows + the latest period in totals."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=730_401, symbol="AAPL_T2")
+        # Vanguard is an ETF filer.
+        seed_etf_filer(conn, cik="0000102909", label="VANGUARD")
+        seed_filer(conn, cik="0000102909", label="VANGUARD")
+        seed_filer(conn, cik="0001067983", label="BERKSHIRE")
+        conn.commit()
+
+        # Older quarter — Q3 2024.
+        old_filer_id = _upsert_filer(
+            conn,
+            ThirteenFFilerInfo(
+                cik="0001067983",
+                name="BERKSHIRE",
+                period_of_report=date(2024, 9, 30),
+                filed_at=datetime(2024, 11, 14, tzinfo=UTC),
+                table_value_total_usd=Decimal("1"),
+            ),
+        )
+        _upsert_holding(
+            conn,
+            filer_id=old_filer_id,
+            instrument_id=730_401,
+            accession_number="0001067983-24-Q3",
+            period_of_report=date(2024, 9, 30),
+            filed_at=datetime(2024, 11, 14, tzinfo=UTC),
+            holding=_make_holding(shares="1000000"),
+        )
+
+        # Latest quarter — Q4 2024.
+        new_filer_id = _upsert_filer(
+            conn,
+            _make_filer_info(cik="0001067983", name="BERKSHIRE"),
+        )
+        _upsert_holding(
+            conn,
+            filer_id=new_filer_id,
+            instrument_id=730_401,
+            accession_number="0001067983-25-Q4",
+            period_of_report=date(2024, 12, 31),
+            filed_at=datetime(2025, 2, 14, tzinfo=UTC),
+            holding=_make_holding(shares="2000000"),
+        )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL_T2/institutional-holdings")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Only Q4 row in the response.
+        assert len(data["filers"]) == 1
+        assert data["filers"][0]["accession_number"] == "0001067983-25-Q4"
+        assert Decimal(data["filers"][0]["shares"]) == Decimal("2000000")
+
+        assert data["totals"]["period_of_report"] == "2024-12-31"
+        assert Decimal(data["totals"]["institutions_shares"]) == Decimal("2000000")
+        assert Decimal(data["totals"]["etfs_shares"]) == Decimal(0)
+        assert data["totals"]["total_filers"] == 1
+
+    def test_etf_vs_institutions_split(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        client: TestClient,
+    ) -> None:
+        """Vanguard (ETF-seeded) and Berkshire (default INV) on the
+        same instrument — totals split by filer_type."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=730_402, symbol="AAPL_T3")
+        seed_etf_filer(conn, cik="0000102909", label="VANGUARD")
+        conn.commit()
+
+        # Vanguard — classified as ETF.
+        van_id = _upsert_filer(conn, _make_filer_info(cik="0000102909", name="VANGUARD"))
+        _upsert_holding(
+            conn,
+            filer_id=van_id,
+            instrument_id=730_402,
+            accession_number="0000102909-25-Q4",
+            period_of_report=date(2024, 12, 31),
+            filed_at=datetime(2025, 2, 14, tzinfo=UTC),
+            holding=_make_holding(shares="5000000"),
+        )
+
+        # Berkshire — default INV.
+        brk_id = _upsert_filer(conn, _make_filer_info(cik="0001067983", name="BERKSHIRE"))
+        _upsert_holding(
+            conn,
+            filer_id=brk_id,
+            instrument_id=730_402,
+            accession_number="0001067983-25-Q4",
+            period_of_report=date(2024, 12, 31),
+            filed_at=datetime(2025, 2, 14, tzinfo=UTC),
+            holding=_make_holding(shares="2000000"),
+        )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL_T3/institutional-holdings")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert Decimal(data["totals"]["etfs_shares"]) == Decimal("5000000")
+        assert Decimal(data["totals"]["institutions_shares"]) == Decimal("2000000")
+        assert data["totals"]["total_etfs_filers"] == 1
+        assert data["totals"]["total_institutions_filers"] == 1
+        assert data["totals"]["total_filers"] == 2
+
+    def test_put_call_excluded_from_totals(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        client: TestClient,
+    ) -> None:
+        """Option exposure (PUT / CALL) appears in the filer
+        drilldown list but is excluded from the slice totals so a
+        protective put is not counted as long ownership."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=730_403, symbol="AAPL_T4")
+        conn.commit()
+
+        filer_id = _upsert_filer(conn, _make_filer_info(cik="0001067983", name="BERKSHIRE"))
+
+        # Equity exposure — counts toward institutions_shares.
+        _upsert_holding(
+            conn,
+            filer_id=filer_id,
+            instrument_id=730_403,
+            accession_number="0001067983-25-Q4",
+            period_of_report=date(2024, 12, 31),
+            filed_at=datetime(2025, 2, 14, tzinfo=UTC),
+            holding=_make_holding(shares="1000000", put_call=None),
+        )
+        # PUT exposure — drilldown only.
+        _upsert_holding(
+            conn,
+            filer_id=filer_id,
+            instrument_id=730_403,
+            accession_number="0001067983-25-Q4",
+            period_of_report=date(2024, 12, 31),
+            filed_at=datetime(2025, 2, 14, tzinfo=UTC),
+            holding=_make_holding(shares="500000", put_call="PUT"),
+        )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL_T4/institutional-holdings")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Slice total excludes the PUT exposure.
+        assert Decimal(data["totals"]["institutions_shares"]) == Decimal("1000000")
+
+        # Both rows surface in the filer list.
+        put_calls = sorted([f["is_put_call"] for f in data["filers"]], key=lambda v: v or "")
+        assert put_calls == [None, "PUT"]
+
+    def test_limit_param_caps_filer_list(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        client: TestClient,
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=730_404, symbol="AAPL_T5")
+
+        # Three filers, three holdings.
+        for i, cik in enumerate(["0000000001", "0000000002", "0000000003"]):
+            seed_filer(conn, cik=cik, label=f"FILER_{i}")
+            filer_id = _upsert_filer(conn, _make_filer_info(cik=cik, name=f"FILER_{i}"))
+            _upsert_holding(
+                conn,
+                filer_id=filer_id,
+                instrument_id=730_404,
+                accession_number=f"{cik}-25-Q4",
+                period_of_report=date(2024, 12, 31),
+                filed_at=datetime(2025, 2, 14, tzinfo=UTC),
+                holding=_make_holding(shares=str(1_000_000 * (i + 1))),
+            )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL_T5/institutional-holdings?limit=2")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["filers"]) == 2
+        # Top-N by shares DESC.
+        assert Decimal(data["filers"][0]["shares"]) == Decimal("3000000")
+        assert Decimal(data["filers"][1]["shares"]) == Decimal("2000000")
+
+    def test_limit_clamped_to_max(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        client: TestClient,
+    ) -> None:
+        """limit=501 rejected (>= 500 max) — FastAPI Query validation
+        returns 422."""
+        # No seeding needed; the param validation fails before DB.
+        resp = client.get("/instruments/AAPL_T6/institutional-holdings?limit=501")
+        assert resp.status_code == 422


### PR DESCRIPTION
## What

Final 13F-HR PR. \`GET /instruments/{symbol}/institutional-holdings\` returns the most recent quarter's 13F-HR holdings for an instrument plus per-slice rollups — Institutions (INV/INS/BD/OTHER) vs ETFs — so the ownership card (#729) can compute the percentage slices.

## Conscious tradeoffs

- **PUT/CALL excluded from totals.** Option exposure rows ship in the \`filers\` drilldown list but do NOT contribute to slice totals; counting a protective put as long ownership would double-count the underlying. Pinned by \`test_put_call_excluded_from_totals\`.
- **Empty payload, not 404, when no holdings on file.** A non-covered or pre-ingest instrument returns \`200\` with \`totals=null\` and \`filers=[]\` so the card renders uniform empty-state copy. \`404\` reserved for unknown symbol.
- **Latest-quarter cohort only.** Older quarters live on for audit but the endpoint surfaces only the freshest \`period_of_report\` — the card needs current snapshot, not history.
- **Frontend wiring deferred to #729.** The reader endpoint here is the contract; the React types + fetch hook + ownership-card UI couple tightly to the slice computation (\`shares_outstanding − treasury\` denominator, per-slice empty-state copy, source links). Cleaner to ship those together as the actual #729 card rather than split across two PRs.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pyright\` — clean
- [x] \`uv run pytest tests/test_api_institutional_holdings.py\` — 7 passed (covers 404, empty payload, latest-quarter cohort, ETF/INV split, PUT/CALL exclusion from totals, limit pagination, 422 on \`limit > 500\`)
- [x] No new \`fetch_document_text\` caller — allow-list guard unchanged.

## What ships in #729 (next ticket)

- React API client + types in \`frontend/src/api/instruments.ts\`.
- Ownership card UI rendering the card with all six slices (Institutions / Insiders / Treasury / Float / DRS / ETFs / Unallocated) per the original spec.
- Source links to filer drilldown / 10-K cover URL.
- Empty-per-slice fallback copy.

## Linked + dependencies

- Builds on PR #739 (#730 PR 1 schema + parser), PR #741 (#730 PR 2 ingester), PR #742 (#730 PR 3 filer-type classifier).
- Effective coverage of the endpoint depends on the CUSIP backfill in #740 — until that lands, \`institutional_holdings\` is mostly empty for non-seeded CUSIPs and the endpoint returns near-empty payloads.