### PR TITLE
fix(#736): SEC archive index.json 404 — route under issuer CIK, not accession prefix

### DIFF
--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -282,7 +282,12 @@ class SecFilingsProvider(FilingsProvider):
             raise FilingNotFound(f"Filing not found: {provider_filing_id}")
         return _normalise_filing_event(provider_filing_id, raw)
 
-    def fetch_filing_index(self, provider_filing_id: str) -> dict[str, object] | None:
+    def fetch_filing_index(
+        self,
+        provider_filing_id: str,
+        *,
+        issuer_cik: str | None = None,
+    ) -> dict[str, object] | None:
         """Fetch a filing's directory listing JSON.
 
         Returns the parsed dict on 2xx, ``None`` on 404. Raises on
@@ -290,6 +295,20 @@ class SecFilingsProvider(FilingsProvider):
         by :func:`get_filing` for header metadata and by the
         ``filing_documents`` service for the per-document manifest
         (#452).
+
+        **CIK (#736):** SEC archives a filing under the **issuer's**
+        CIK, not the filer-of-record's. For most filings the two
+        are the same (issuer self-files), but registered filing
+        agents (EdgarOnline CIK=1213900, Donnelley CIK=1571049,
+        Workiva CIK=1185185, etc.) file 10-Q / 8-K / etc. on behalf
+        of operating issuers — and the agent's CIK appears in the
+        accession-number prefix even though the archive lives
+        under the issuer. Caller MUST pass ``issuer_cik`` when the
+        filing is agent-filed; the legacy behaviour (parse the
+        first 10 digits of the accession) is preserved as a
+        fallback for callers that genuinely don't know the CIK
+        (e.g. the bare ``get_filing`` lookup), but logs a warning
+        because the URL may 404 for agent-filed accessions.
 
         **URL (#723):** SEC's canonical machine-readable manifest at
         the per-filing archive directory is ``/index.json`` (no
@@ -320,8 +339,23 @@ class SecFilingsProvider(FilingsProvider):
         raw_id = provider_filing_id.replace("-", "")
         if len(raw_id) != 18:
             raise FilingNotFound(f"Invalid accession number format: {provider_filing_id}")
-        cik_padded = raw_id[:10]
-        absolute_url = f"https://www.sec.gov/Archives/edgar/data/{int(cik_padded)}/{raw_id}/index.json"
+        if issuer_cik is not None:
+            digits = "".join(ch for ch in issuer_cik if ch.isdigit())
+            if not digits:
+                raise FilingNotFound(f"Non-numeric issuer_cik: {issuer_cik!r}")
+            cik_for_url = int(digits)
+        else:
+            # Legacy fallback (#736): the accession prefix is the
+            # filer-of-record's CIK, which collides with the
+            # archive's issuer-CIK key only for self-filers. Log so
+            # an operator investigating 404 noise can correlate.
+            logger.debug(
+                "fetch_filing_index: using accession-prefix CIK fallback "
+                "for accession=%s — pass issuer_cik to avoid agent-CIK 404s",
+                provider_filing_id,
+            )
+            cik_for_url = int(raw_id[:10])
+        absolute_url = f"https://www.sec.gov/Archives/edgar/data/{cik_for_url}/{raw_id}/index.json"
         resp = self._http_tickers.get(absolute_url)
         if resp.status_code == 404:
             return None

--- a/app/services/filing_documents.py
+++ b/app/services/filing_documents.py
@@ -245,7 +245,12 @@ class _IndexFetcher(Protocol):
     implementing the full provider interface.
     """
 
-    def fetch_filing_index(self, provider_filing_id: str) -> dict[str, object] | None: ...
+    def fetch_filing_index(
+        self,
+        provider_filing_id: str,
+        *,
+        issuer_cik: str | None = None,
+    ) -> dict[str, object] | None: ...
 
 
 @dataclass(frozen=True)
@@ -330,7 +335,9 @@ def ingest_filing_documents(
 
     for filing_event_id, accession, cik, primary_url in candidates:
         try:
-            raw = fetcher.fetch_filing_index(accession)
+            # Pass the issuer CIK explicitly so the archive URL
+            # routes under the issuer-not-filer path (#736).
+            raw = fetcher.fetch_filing_index(accession, issuer_cik=cik)
         except Exception:
             logger.warning(
                 "ingest_filing_documents: fetch failed accession=%s",

--- a/tests/test_filing_documents_ingest.py
+++ b/tests/test_filing_documents_ingest.py
@@ -25,10 +25,15 @@ pytestmark = [
 class _StubIndexFetcher:
     def __init__(self, by_accession: dict[str, dict[str, object] | None]) -> None:
         self._by = by_accession
-        self.calls: list[str] = []
+        self.calls: list[tuple[str, str | None]] = []
 
-    def fetch_filing_index(self, accession: str) -> dict[str, object] | None:
-        self.calls.append(accession)
+    def fetch_filing_index(
+        self,
+        accession: str,
+        *,
+        issuer_cik: str | None = None,
+    ) -> dict[str, object] | None:
+        self.calls.append((accession, issuer_cik))
         return self._by.get(accession)
 
 

--- a/tests/test_sec_provider_filing_index.py
+++ b/tests/test_sec_provider_filing_index.py
@@ -104,3 +104,71 @@ def test_filing_index_raises_on_500() -> None:
 
     with pytest.raises(httpx.HTTPStatusError):
         provider.fetch_filing_index("0000320193-24-000001")
+
+
+def test_filing_index_uses_explicit_issuer_cik_not_accession_prefix() -> None:
+    """Regression for #736. SEC accession numbers carry the
+    filing-of-record's CIK in the prefix, but the archive lives
+    under the **issuer's** CIK. For agent-filed accessions
+    (EdgarOnline 1213900, Donnelley 1571049, Workiva 1185185 etc.),
+    parsing the prefix as the URL CIK produces 404s on every
+    fetch. The fix takes ``issuer_cik`` as a keyword argument and
+    routes the URL under it.
+    """
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, content=json.dumps({"directory": {"item": []}}))
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    # Accession filed by EdgarOnline (CIK 1213900) on behalf of
+    # issuer CIK 0000019617 (JPM). The URL must route under JPM,
+    # not the agent.
+    result = provider.fetch_filing_index(
+        "0001213900-26-050022",
+        issuer_cik="0000019617",
+    )
+    assert result == {"directory": {"item": []}}
+    assert len(captured) == 1
+    assert captured[0].url.path == "/Archives/edgar/data/19617/000121390026050022/index.json"
+
+
+def test_filing_index_strips_non_digits_from_issuer_cik() -> None:
+    """Defensive: issuer_cik may arrive with the ``CIK`` prefix
+    or whitespace from a stale data source. The provider strips
+    non-digits before constructing the URL."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, content=json.dumps({"directory": {"item": []}}))
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    provider.fetch_filing_index("0000320193-24-000001", issuer_cik=" CIK0000320193 ")
+    assert len(captured) == 1
+    assert "/Archives/edgar/data/320193/" in captured[0].url.path
+
+
+def test_filing_index_legacy_path_still_works_for_self_filers() -> None:
+    """Back-compat: callers that don't pass ``issuer_cik`` (e.g.
+    bare ``get_filing(accession)`` lookups) keep the legacy
+    accession-prefix-as-CIK behaviour. Self-filers (issuer files
+    its own accessions — every 10-K from a publicly traded
+    company) work unchanged."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, content=json.dumps({"directory": {"item": []}}))
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    provider.fetch_filing_index("0000320193-24-000001")
+    assert len(captured) == 1
+    assert captured[0].url.path == "/Archives/edgar/data/320193/000032019324000001/index.json"


### PR DESCRIPTION
## What

Production logs (2026-05-01) showed repeat \`404\`s on \`Archives/edgar/data/1213900/.../index.json\`. Root cause: \`SecFilingsProvider.fetch_filing_index\` derived the URL CIK by parsing the first 10 digits of the accession number. SEC accession numbers carry the **filing-of-record's** CIK in the prefix — for self-filing issuers (Apple's 10-K, Microsoft's 8-K) that's the issuer CIK, but for **agent-filed** accessions (EdgarOnline 1213900, Donnelley 1571049, Workiva 1185185, etc.) the agent CIK is in the prefix while the archive lives under the issuer's CIK. Every agent-filed accession 404'd.

## Fix

\`fetch_filing_index\` now accepts \`issuer_cik\` as a keyword argument. The \`filing_documents\` service caller already had the issuer CIK from \`external_identifiers\` — just wasn't passing it. URL is now constructed under the issuer CIK explicitly.

## Conscious tradeoffs

- **Back-compat preserved**: when \`issuer_cik\` is omitted, the legacy accession-prefix-as-CIK behaviour is kept (with a debug log noting the agent-CIK risk). Bare \`get_filing(accession)\` lookups continue to work for self-filer accessions; only the documented path (\`ingest_filing_documents\` via \`_IndexFetcher\` protocol) is required to pass \`issuer_cik\`. Migrating that path was the only callsite in scope.
- **No backfill of failed accessions**: existing \`fetch_errors\` increments stay; the next ingest cycle naturally re-fetches the same accessions and now succeeds. Operator can monitor \`data_ingestion_runs\` to see the rate drop.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pyright\` — clean
- [x] \`uv run pytest tests/test_sec_provider_filing_index.py tests/test_filing_documents_ingest.py\` — 13 passed (3 new regression tests)
- [x] Affected SEC budget: ingester previously 404'd every agent-filed accession, burning #728 bounded-concurrency budget. Post-fix, those archives resolve under the issuer CIK and the document manifest populates.

## Linked

- Closes #736.
- Related: #728 (bounded-concurrency SEC fetcher — was burning rate budget on these 404s).
- Related: #195 (broad filing-ingest tech-debt — this is one specific bug under that umbrella).