### PR TITLE
feat(#729): three-ring ownership sunburst (no top-N truncation)

### DIFF
--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -1,30 +1,34 @@
 /**
  * Ownership reporting card (#729).
  *
- * Renders Institutions / ETFs / Insiders / Unallocated slices with
- * percentages computed against the free-float denominator
- * (shares_outstanding − treasury_shares). Treasury appears as a
- * memo line because it IS the gap between outstanding and float.
+ * Renders a three-ring sunburst:
+ *   ring 1 — Held (free-float total in the center hole)
+ *   ring 2 — Institutions / ETFs / Insiders / Treasury / Unallocated
+ *   ring 3 — per-filer / per-officer wedges + "Other [Category]" tail
  *
  * Coverage gating:
  *   * No shares_outstanding on file → whole-card empty state.
- *   * Per-slice missing → "—" for that row, NOT 0%.
+ *   * Per-category data missing → wedge renders as a desaturated
+ *     "coverage gap" arc rather than vanishing or rendering 0%.
  *
  * Effective slice coverage depends on:
- *   * #731 — shares_outstanding + treasury_shares from financial_periods
- *   * #730 — institutional_holdings via the new reader endpoint
- *   * #740 — CUSIP backfill so the ingester actually resolves
- *     holdings to instrument_ids (currently most are dropped)
+ *   * #731 — shares_outstanding + treasury_shares from financial_periods (merged)
+ *   * #730 — institutional_holdings via the new reader endpoint (merged)
+ *   * #740 — CUSIP backfill so the ingester resolves holdings to instrument_ids (open)
  *
- * Until #740 lands, the Institutions + ETFs slices return zero or
- * "—" for most US instruments. Operator-side ownership of the
- * coverage-gap copy is via the per-slice ``source_label`` link.
+ * Click on any wedge → drill to the L2 ownership page (route lands
+ * in the next PR; for now the click handler is a no-op surfaced via
+ * ``onWedgeClick`` so the integration test can pin the wiring).
  */
 
 import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { fetchInstitutionalHoldings } from "@/api/institutionalHoldings";
-import type { InstitutionalHoldingsResponse } from "@/api/institutionalHoldings";
+import type {
+  InstitutionalFilerHolding,
+  InstitutionalHoldingsResponse,
+} from "@/api/institutionalHoldings";
 import {
   fetchInsiderTransactions,
   fetchInstrumentFinancials,
@@ -32,14 +36,20 @@ import {
 import type { InsiderTransactionsList } from "@/api/instruments";
 import type { InstrumentFinancials } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { OwnershipSunburst } from "@/components/instrument/OwnershipSunburst";
+import type { WedgeClick } from "@/components/instrument/OwnershipSunburst";
 import { Pane } from "@/components/instrument/Pane";
 import {
-  aggregateInsiderHoldings,
-  computeOwnership,
   formatPct,
   formatShares,
   parseShareCount,
 } from "@/components/instrument/ownershipMetrics";
+import {
+  type SunburstCategoryStatus,
+  type SunburstHolder,
+  type SunburstInputs,
+  buildSunburstRings,
+} from "@/components/instrument/ownershipRings";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
 
@@ -50,11 +60,14 @@ export interface OwnershipPanelProps {
 interface OwnershipData {
   readonly outstanding: number | null;
   readonly treasury: number | null;
-  readonly institutions: number | null;
-  readonly etfs: number | null;
-  readonly insiders: number | null;
+  readonly free_float: number | null;
+  readonly institutional_holders: readonly SunburstHolder[];
+  readonly etf_holders: readonly SunburstHolder[];
+  readonly insider_holders: readonly SunburstHolder[];
+  readonly institutions_status: SunburstCategoryStatus;
+  readonly etfs_status: SunburstCategoryStatus;
+  readonly insiders_status: SunburstCategoryStatus;
   readonly as_of_period: string | null;
-  readonly institutional_period: string | null;
 }
 
 function pickLatestBalance(
@@ -71,10 +84,10 @@ function pickLatestBalance(
 
 export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
   // Three parallel fetches: balance sheet (outstanding + treasury),
-  // institutional holdings (institutions + ETFs), insider
-  // transactions (insiders aggregate). Each fetch fails
+  // institutional holdings (institutions + ETFs + per-filer rows),
+  // insider transactions (insiders aggregate). Each fetch fails
   // independently — a missing input degrades the corresponding
-  // slice rather than the whole card.
+  // category rather than the whole card.
   const balanceState = useAsync<InstrumentFinancials>(
     useCallback(
       () =>
@@ -88,13 +101,32 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
   );
 
   const institutionalState = useAsync<InstitutionalHoldingsResponse>(
-    useCallback(() => fetchInstitutionalHoldings(symbol, 50), [symbol]),
+    useCallback(() => fetchInstitutionalHoldings(symbol, 500), [symbol]),
     [symbol],
   );
 
   const insidersState = useAsync<InsiderTransactionsList>(
     useCallback(() => fetchInsiderTransactions(symbol, 200), [symbol]),
     [symbol],
+  );
+
+  const navigate = useNavigate();
+  const handleWedgeClick = useCallback(
+    (target: WedgeClick) => {
+      // L2 drill page lands in the next PR; stub the navigation now
+      // so the integration is wired and the route handler can be
+      // added without touching this component.
+      const params = new URLSearchParams();
+      if (target.kind === "category") params.set("category", target.category_key);
+      if (target.kind === "leaf") {
+        params.set("category", target.category_key);
+        params.set("filer", target.leaf_key);
+      }
+      const qs = params.toString();
+      const suffix = qs.length > 0 ? `?${qs}` : "";
+      navigate(`/instrument/${encodeURIComponent(symbol)}/ownership${suffix}`);
+    },
+    [navigate, symbol],
   );
 
   const isLoading =
@@ -119,13 +151,16 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
           }}
         />
       ) : (
-        renderBody(extractData(balanceState.data, institutionalState.data, insidersState.data))
+        renderBody(
+          extractData(balanceState.data, institutionalState.data, insidersState.data),
+          handleWedgeClick,
+        )
       )}
     </Pane>
   );
 }
 
-function extractData(
+export function extractData(
   balance: InstrumentFinancials | null,
   institutional: InstitutionalHoldingsResponse | null,
   insiders: InsiderTransactionsList | null,
@@ -135,41 +170,146 @@ function extractData(
   const treasury =
     balance !== null ? pickLatestBalance(balance, "treasury_shares") : null;
 
+  const free_float =
+    outstanding !== null ? Math.max(0, outstanding - (treasury ?? 0)) : null;
+
+  // Institutional + ETF wedges. Split the ``filers`` list by
+  // filer_type — equity-only rows feed the sunburst since option
+  // exposure double-counts the underlying.
   const inst_totals = institutional?.totals ?? null;
-  const institutions = inst_totals
-    ? parseShareCount(inst_totals.institutions_shares)
-    : null;
-  const etfs = inst_totals ? parseShareCount(inst_totals.etfs_shares) : null;
+  const filers = institutional?.filers ?? [];
+  const equity_filers = filers.filter((f) => f.is_put_call === null);
 
-  const insiderShares = insiders ? aggregateInsiderHoldings(insiders.rows) : null;
+  const institutional_holders: SunburstHolder[] = equity_filers
+    .filter((f) => f.filer_type !== "ETF")
+    .map(filerToHolder("institutions"));
+  const etf_holders: SunburstHolder[] = equity_filers
+    .filter((f) => f.filer_type === "ETF")
+    .map(filerToHolder("etfs"));
 
-  // The "as-of" surfaced in the header is the latest signal we
-  // have — institutional period when present, else the balance row.
+  // Insider holders — aggregate latest non-derivative
+  // post-transaction shares per officer. The list is short enough
+  // (~10-30 officers) that we render every officer as their own
+  // wedge; the sunburst transformer bypasses the visibility
+  // threshold for this category.
+  const insider_holders = aggregateInsiderHoldersForSunburst(insiders);
+
+  const institutions_status: SunburstCategoryStatus = deriveCategoryStatus(
+    institutional,
+    institutional_holders,
+    inst_totals?.institutions_shares,
+  );
+  const etfs_status: SunburstCategoryStatus = deriveCategoryStatus(
+    institutional,
+    etf_holders,
+    inst_totals?.etfs_shares,
+  );
+  const insiders_status: SunburstCategoryStatus =
+    insiders === null
+      ? "unknown"
+      : insider_holders.length > 0
+        ? "ok"
+        : "empty";
+
   const as_of_period =
-    inst_totals?.period_of_report ??
-    (balance?.rows[0]?.period_end ?? null);
+    inst_totals?.period_of_report ?? balance?.rows[0]?.period_end ?? null;
 
   return {
     outstanding,
     treasury,
-    institutions,
-    etfs,
-    insiders: insiderShares,
+    free_float,
+    institutional_holders,
+    etf_holders,
+    insider_holders,
+    institutions_status,
+    etfs_status,
+    insiders_status,
     as_of_period,
-    institutional_period: inst_totals?.period_of_report ?? null,
   };
 }
 
-function renderBody(data: OwnershipData): JSX.Element {
-  const breakdown = computeOwnership({
-    shares_outstanding: data.outstanding,
-    treasury_shares: data.treasury,
-    institutions: { shares: data.institutions, source_label: "13F filers" },
-    etfs: { shares: data.etfs, source_label: "13F filers (ETF)" },
-    insiders: { shares: data.insiders, source_label: "Form 4" },
+function filerToHolder(
+  category: SunburstHolder["category"],
+): (f: InstitutionalFilerHolding) => SunburstHolder {
+  return (f) => ({
+    key: f.filer_cik,
+    label: f.filer_name,
+    shares: parseShareCount(f.shares) ?? 0,
+    category,
   });
+}
 
-  if (breakdown === null) {
+interface InsiderRowShape {
+  readonly filer_cik: string | null;
+  readonly filer_name: string;
+  readonly txn_date: string;
+  readonly post_transaction_shares: string | null;
+  readonly is_derivative: boolean;
+}
+
+function aggregateInsiderHoldersForSunburst(
+  insiders: InsiderTransactionsList | null,
+): readonly SunburstHolder[] {
+  if (insiders === null) return [];
+  // Latest non-derivative post-transaction-shares per officer.
+  // Keyed on filer_cik when present, falls back to filer_name so a
+  // filer with no CIK in the audit trail still gets distinct rows.
+  const latestByFiler = new Map<
+    string,
+    { txn_date: string; shares: number; label: string }
+  >();
+  for (const row of insiders.rows as readonly InsiderRowShape[]) {
+    if (row.is_derivative) continue;
+    const shares = parseShareCount(row.post_transaction_shares);
+    if (shares === null) continue;
+    const key = row.filer_cik ?? `name:${row.filer_name}`;
+    const existing = latestByFiler.get(key);
+    if (existing === undefined || row.txn_date > existing.txn_date) {
+      latestByFiler.set(key, {
+        txn_date: row.txn_date,
+        shares,
+        label: row.filer_name,
+      });
+    }
+  }
+  const holders: SunburstHolder[] = [];
+  for (const [key, entry] of latestByFiler.entries()) {
+    holders.push({
+      key,
+      label: entry.label,
+      shares: entry.shares,
+      category: "insiders",
+    });
+  }
+  return holders;
+}
+
+function deriveCategoryStatus(
+  institutional: InstitutionalHoldingsResponse | null,
+  holders: readonly SunburstHolder[],
+  raw_total: string | undefined,
+): SunburstCategoryStatus {
+  // No fetch result at all — likely API error or pre-coverage.
+  if (institutional === null) return "unknown";
+  // ``totals`` is null when no holdings on file. The card surfaces
+  // this as a coverage gap so the operator sees that 13F ingest
+  // hasn't run for this instrument.
+  if (institutional.totals === null) return "unknown";
+  // Total reported but every CUSIP unresolved (the #740 backfill
+  // gap). The total may be 0 even though filers exist; render as
+  // ``unknown`` rather than ``empty`` so the coverage-gap copy
+  // shows.
+  const total = parseShareCount(raw_total ?? "0") ?? 0;
+  if (total <= 0 && holders.length === 0) return "empty";
+  if (holders.length === 0 && total > 0) return "unknown";
+  return "ok";
+}
+
+function renderBody(
+  data: OwnershipData,
+  onWedgeClick: (target: WedgeClick) => void,
+): JSX.Element {
+  if (data.free_float === null || data.free_float <= 0) {
     return (
       <EmptyState
         title="No ownership data"
@@ -178,62 +318,76 @@ function renderBody(data: OwnershipData): JSX.Element {
     );
   }
 
+  const inputs: SunburstInputs = {
+    free_float: data.free_float,
+    holders: [
+      ...data.institutional_holders,
+      ...data.etf_holders,
+      ...data.insider_holders,
+    ],
+    treasury_shares: data.treasury,
+    institutions_status: data.institutions_status,
+    etfs_status: data.etfs_status,
+    insiders_status: data.insiders_status,
+  };
+  const rings = buildSunburstRings(inputs);
+  if (rings === null) {
+    return (
+      <EmptyState
+        title="No ownership data"
+        description="Sunburst rings could not be derived — free float resolved to zero or the input snapshot is malformed."
+      />
+    );
+  }
+
   return (
-    <div className="space-y-3">
-      {data.as_of_period !== null && (
-        <p className="text-xs text-slate-500 dark:text-slate-400">
-          As of {data.as_of_period}. Free float ={" "}
-          {formatShares(breakdown.denominator)} shares.
-        </p>
-      )}
-      {breakdown.has_overflow && (
-        <p className="text-xs text-amber-700 dark:text-amber-400">
-          Reported slice shares exceed free float — likely a 13F-HR
-          filing that lags the latest XBRL share count. Unallocated
-          clamped to 0%.
-        </p>
-      )}
-      <table className="w-full text-sm">
-        <thead className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-          <tr>
-            <th className="pb-1 text-left">Slice</th>
-            <th className="pb-1 text-right">Shares</th>
-            <th className="pb-1 text-right">% of float</th>
-          </tr>
-        </thead>
-        <tbody>
-          {breakdown.slices.map((slice) => (
-            <tr
-              key={slice.label}
-              className="border-t border-slate-100 dark:border-slate-800"
-            >
-              <td className="py-1.5 text-slate-700 dark:text-slate-200">
-                {slice.label}
-                {slice.source_label !== undefined && (
-                  <span className="ml-2 text-xs text-slate-400 dark:text-slate-500">
-                    {slice.source_label}
-                  </span>
-                )}
-              </td>
-              <td className="py-1.5 text-right font-mono text-slate-700 dark:text-slate-200">
-                {formatShares(slice.shares)}
-              </td>
-              <td className="py-1.5 text-right font-mono text-slate-900 dark:text-slate-100">
-                {formatPct(slice.pct)}
-              </td>
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+      <div className="flex justify-center">
+        <OwnershipSunburst inputs={inputs} onWedgeClick={onWedgeClick} />
+      </div>
+      <div className="min-w-0 flex-1">
+        {data.as_of_period !== null && (
+          <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
+            As of {data.as_of_period}. Free float ={" "}
+            {formatShares(data.free_float)} shares.
+          </p>
+        )}
+        <table className="w-full text-sm">
+          <thead className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <tr>
+              <th className="pb-1 text-left">Category</th>
+              <th className="pb-1 text-right">Shares</th>
+              <th className="pb-1 text-right">% of float</th>
             </tr>
-          ))}
-          <tr className="border-t border-slate-200 dark:border-slate-700 text-xs text-slate-500 dark:text-slate-400">
-            <td className="py-1.5 italic">Treasury (memo)</td>
-            <td className="py-1.5 text-right font-mono">
-              {formatShares(breakdown.treasury.shares)}
-            </td>
-            <td className="py-1.5 text-right font-mono">
-              {formatPct(breakdown.treasury.pct)}
-            </td>
-          </tr>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {rings.categories.map((cat) => (
+              <tr
+                key={cat.key}
+                className="border-t border-slate-100 dark:border-slate-800"
+              >
+                <td className="py-1.5 text-slate-700 dark:text-slate-200">
+                  {cat.label}
+                  {cat.status === "unknown" && (
+                    <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">
+                      coverage gap
+                    </span>
+                  )}
+                </td>
+                <td className="py-1.5 text-right font-mono text-slate-700 dark:text-slate-200">
+                  {cat.status === "unknown" ? "—" : formatShares(cat.shares)}
+                </td>
+                <td className="py-1.5 text-right font-mono text-slate-900 dark:text-slate-100">
+                  {cat.status === "unknown" ? "—" : formatPct(cat.pct)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
+          Click any wedge for the per-filer drilldown.
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -52,6 +52,14 @@ interface ChartDatum {
   readonly fill: string;
   readonly stroke: string;
   readonly opacity: number;
+  /**
+   * True for synthetic wedges that exist only to convey "we don't
+   * know the number" — e.g. a Coverage gap (#740) category rendered
+   * with a placeholder ``shares=1`` so the arc has visible thickness.
+   * The tooltip suppresses the numeric share/pct rows for these
+   * datums so hovering doesn't surface "1 shares / 0% of float".
+   */
+  readonly is_gap: boolean;
   /** Click-target metadata propagated through Recharts' onClick. */
   readonly target: WedgeClick;
 }
@@ -92,6 +100,7 @@ export function OwnershipSunburst({
       fill: theme.borderColor,
       stroke: theme.bg,
       opacity: 0.6,
+      is_gap: false,
       target: { kind: "center" },
     },
   ];
@@ -220,12 +229,15 @@ function toCategoryDatum(
       // visibly. Since totals would otherwise sum to less than the
       // float, the visible gap on the outer ring still telegraphs
       // missing data; the synthetic value here just guarantees the
-      // wedge isn't a 0-degree arc.
+      // wedge isn't a 0-degree arc. ``is_gap=true`` tells the
+      // tooltip to suppress the numeric share/pct rows so hovering
+      // does not surface a misleading "1 shares".
       shares: 1,
       pct: 0,
       fill: UNKNOWN_FILL,
       stroke: bg,
       opacity: 0.3,
+      is_gap: true,
       target: { kind: "category", category_key: cat.key },
     };
   }
@@ -236,6 +248,7 @@ function toCategoryDatum(
     fill: baseFill,
     stroke: bg,
     opacity: cat.shares <= 0 ? 0 : 0.85,
+    is_gap: false,
     target: { kind: "category", category_key: cat.key },
   };
 }
@@ -255,6 +268,7 @@ function toLeafDatum(
       fill: UNKNOWN_FILL,
       stroke: bg,
       opacity: 0.2,
+      is_gap: true,
       target: { kind: "leaf", category_key: cat.key, leaf_key: leaf.key },
     };
   }
@@ -269,6 +283,7 @@ function toLeafDatum(
     fill: baseFill,
     stroke: bg,
     opacity: leaf.shares <= 0 ? 0 : opacity,
+    is_gap: false,
     target: { kind: "leaf", category_key: cat.key, leaf_key: leaf.key },
   };
 }
@@ -286,6 +301,20 @@ function SunburstTooltip(props: RechartsTooltipProps): JSX.Element | null {
   if (!props.active || props.payload === undefined || props.payload.length === 0) return null;
   const datum = props.payload[0]?.payload;
   if (datum === undefined) return null;
+  // Coverage-gap wedges carry synthetic ``shares=1`` so the arc has
+  // visible thickness; suppress the numeric rows so the tooltip
+  // does not surface a misleading "1 shares / 0% of float" — show
+  // the operator-facing copy explaining the gap instead.
+  if (datum.is_gap) {
+    return (
+      <div className="rounded border border-slate-300 bg-white px-3 py-2 text-xs shadow-md dark:border-slate-700 dark:bg-slate-900">
+        <div className="font-medium text-slate-900 dark:text-slate-100">{datum.name}</div>
+        <div className="text-slate-600 dark:text-slate-400">
+          Data not available — gated on the #740 CUSIP backfill.
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="rounded border border-slate-300 bg-white px-3 py-2 text-xs shadow-md dark:border-slate-700 dark:bg-slate-900">
       <div className="font-medium text-slate-900 dark:text-slate-100">{datum.name}</div>

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -1,0 +1,303 @@
+/**
+ * Three-ring ownership sunburst (#729 follow-up).
+ *
+ * Recharts has no native sunburst primitive — built from three nested
+ * ``<Pie>`` components at increasing ``innerRadius`` / ``outerRadius``.
+ *
+ *   ring 1 (innermost) — single-arc "Held" total, labelled with the
+ *                        absolute float in the center hole.
+ *   ring 2             — per-category wedges (Institutions / ETFs /
+ *                        Insiders / Treasury / Unallocated).
+ *   ring 3 (outermost) — per-filer / per-officer wedges within each
+ *                        category, plus an "Other" tail when many
+ *                        sub-threshold holders exist.
+ *
+ * Coverage gating: a category with ``status='unknown'`` (today's
+ * Institutions / ETFs while the #740 CUSIP backfill is pending)
+ * renders as a hatched grey wedge sized to its share of float so the
+ * operator sees the gap visually rather than as a missing slice.
+ */
+
+import { useMemo } from "react";
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+
+import { formatPct, formatShares } from "@/components/instrument/ownershipMetrics";
+import {
+  type SunburstCategory,
+  type SunburstLeaf,
+  type SunburstRings,
+  buildSunburstRings,
+} from "@/components/instrument/ownershipRings";
+import type { SunburstInputs } from "@/components/instrument/ownershipRings";
+import { useChartTheme } from "@/lib/useChartTheme";
+
+export interface OwnershipSunburstProps {
+  readonly inputs: SunburstInputs;
+  /** Click handler for any wedge. Receives the wedge identity for
+   *  drill-to-L2 navigation. */
+  readonly onWedgeClick?: (target: WedgeClick) => void;
+  /** Pixel size of the chart canvas (square). Default 280. */
+  readonly size?: number;
+}
+
+export type WedgeClick =
+  | { readonly kind: "center" }
+  | { readonly kind: "category"; readonly category_key: string }
+  | { readonly kind: "leaf"; readonly category_key: string; readonly leaf_key: string };
+
+interface ChartDatum {
+  readonly name: string;
+  readonly shares: number;
+  readonly pct: number;
+  readonly fill: string;
+  readonly stroke: string;
+  readonly opacity: number;
+  /** Click-target metadata propagated through Recharts' onClick. */
+  readonly target: WedgeClick;
+}
+
+const CATEGORY_FILL_INDEX: Record<string, number> = {
+  institutions: 0, // cyan
+  etfs: 1, // blue
+  insiders: 2, // purple
+  treasury: 3, // amber
+  unallocated: 4, // pink
+};
+
+const UNKNOWN_FILL = "#475569"; // slate-600 — desaturated to read as "no signal"
+
+export function OwnershipSunburst({
+  inputs,
+  onWedgeClick,
+  size = 280,
+}: OwnershipSunburstProps): JSX.Element | null {
+  const rings = useMemo(() => buildSunburstRings(inputs), [inputs]);
+  const theme = useChartTheme();
+
+  if (rings === null) return null;
+
+  const accent = theme.accent;
+  const fillFor = (categoryKey: string): string => {
+    const idx = CATEGORY_FILL_INDEX[categoryKey];
+    if (idx === undefined) return accent[0];
+    return accent[idx % accent.length]!;
+  };
+
+  // Inner ring — single arc.
+  const innerData: ChartDatum[] = [
+    {
+      name: "Held",
+      shares: rings.inner.shares,
+      pct: rings.inner.pct,
+      fill: theme.borderColor,
+      stroke: theme.bg,
+      opacity: 0.6,
+      target: { kind: "center" },
+    },
+  ];
+
+  // Middle ring — one wedge per category. Categories with shares=0
+  // and status='empty' are skipped so the ring doesn't render a
+  // sliver of unstyled chrome.
+  const middleData: ChartDatum[] = [];
+  for (const cat of rings.categories) {
+    if (cat.status === "empty" && cat.shares <= 0) continue;
+    middleData.push(toCategoryDatum(cat, fillFor(cat.key), theme.bg));
+  }
+
+  // Outer ring — leaves under every visible category, in the same
+  // order so wedges stack alphabetically with their parent.
+  const outerData: ChartDatum[] = [];
+  for (const cat of rings.categories) {
+    if (cat.status === "empty" && cat.shares <= 0) continue;
+    if (cat.leaves.length === 0) continue;
+    const baseFill = fillFor(cat.key);
+    for (const leaf of cat.leaves) {
+      outerData.push(toLeafDatum(leaf, cat, baseFill, theme.bg));
+    }
+  }
+
+  const totalRadius = size / 2;
+  const innerInner = totalRadius * 0.25;
+  const innerOuter = totalRadius * 0.36;
+  const middleOuter = totalRadius * 0.62;
+  const outerOuter = totalRadius * 0.92;
+
+  const handleClick = (datum: ChartDatum): void => {
+    onWedgeClick?.(datum.target);
+  };
+
+  return (
+    <div
+      className="relative"
+      style={{ width: size, height: size }}
+      role="img"
+      aria-label={`Ownership breakdown: free float ${formatShares(rings.free_float)} shares.`}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Tooltip content={<SunburstTooltip />} />
+          <Pie
+            data={innerData}
+            dataKey="shares"
+            innerRadius={innerInner}
+            outerRadius={innerOuter}
+            stroke={theme.bg}
+            isAnimationActive={false}
+            onClick={(_, idx) => handleClick(innerData[idx]!)}
+          >
+            {innerData.map((d, idx) => (
+              <Cell
+                key={`inner-${idx}`}
+                fill={d.fill}
+                fillOpacity={d.opacity}
+                stroke={d.stroke}
+              />
+            ))}
+          </Pie>
+          <Pie
+            data={middleData}
+            dataKey="shares"
+            innerRadius={innerOuter}
+            outerRadius={middleOuter}
+            stroke={theme.bg}
+            isAnimationActive={false}
+            onClick={(_, idx) => handleClick(middleData[idx]!)}
+          >
+            {middleData.map((d, idx) => (
+              <Cell
+                key={`middle-${idx}`}
+                fill={d.fill}
+                fillOpacity={d.opacity}
+                stroke={d.stroke}
+              />
+            ))}
+          </Pie>
+          <Pie
+            data={outerData}
+            dataKey="shares"
+            innerRadius={middleOuter}
+            outerRadius={outerOuter}
+            stroke={theme.bg}
+            isAnimationActive={false}
+            onClick={(_, idx) => handleClick(outerData[idx]!)}
+          >
+            {outerData.map((d, idx) => (
+              <Cell
+                key={`outer-${idx}`}
+                fill={d.fill}
+                fillOpacity={d.opacity}
+                stroke={d.stroke}
+              />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+        <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Free float
+        </span>
+        <span className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+          {formatShares(rings.free_float)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function toCategoryDatum(
+  cat: SunburstCategory,
+  baseFill: string,
+  bg: string,
+): ChartDatum {
+  if (cat.status === "unknown") {
+    // Unknown categories use a dedicated grey so the operator
+    // distinguishes "we don't know what's here" from "this slice is
+    // genuinely 0%".
+    return {
+      name: `${cat.label} — coverage gap`,
+      // Use a synthetic non-zero share count so the wedge renders
+      // visibly. Since totals would otherwise sum to less than the
+      // float, the visible gap on the outer ring still telegraphs
+      // missing data; the synthetic value here just guarantees the
+      // wedge isn't a 0-degree arc.
+      shares: 1,
+      pct: 0,
+      fill: UNKNOWN_FILL,
+      stroke: bg,
+      opacity: 0.3,
+      target: { kind: "category", category_key: cat.key },
+    };
+  }
+  return {
+    name: cat.label,
+    shares: Math.max(cat.shares, 0),
+    pct: cat.pct,
+    fill: baseFill,
+    stroke: bg,
+    opacity: cat.shares <= 0 ? 0 : 0.85,
+    target: { kind: "category", category_key: cat.key },
+  };
+}
+
+function toLeafDatum(
+  leaf: SunburstLeaf,
+  cat: SunburstCategory,
+  baseFill: string,
+  bg: string,
+): ChartDatum {
+  const status = cat.status;
+  if (status === "unknown") {
+    return {
+      name: leaf.label,
+      shares: 1,
+      pct: 0,
+      fill: UNKNOWN_FILL,
+      stroke: bg,
+      opacity: 0.2,
+      target: { kind: "leaf", category_key: cat.key, leaf_key: leaf.key },
+    };
+  }
+  // "Other" rolls up sub-threshold holders. Render with a desaturated
+  // shade of the parent category's color so the operator sees it as
+  // "tail of the same slice" rather than a separate category.
+  const opacity = leaf.is_other ? 0.55 : 0.9;
+  return {
+    name: leaf.label,
+    shares: Math.max(leaf.shares, 0),
+    pct: leaf.pct,
+    fill: baseFill,
+    stroke: bg,
+    opacity: leaf.shares <= 0 ? 0 : opacity,
+    target: { kind: "leaf", category_key: cat.key, leaf_key: leaf.key },
+  };
+}
+
+interface RechartsTooltipPayloadShape {
+  readonly payload?: ChartDatum;
+}
+
+interface RechartsTooltipProps {
+  readonly active?: boolean;
+  readonly payload?: readonly RechartsTooltipPayloadShape[];
+}
+
+function SunburstTooltip(props: RechartsTooltipProps): JSX.Element | null {
+  if (!props.active || props.payload === undefined || props.payload.length === 0) return null;
+  const datum = props.payload[0]?.payload;
+  if (datum === undefined) return null;
+  return (
+    <div className="rounded border border-slate-300 bg-white px-3 py-2 text-xs shadow-md dark:border-slate-700 dark:bg-slate-900">
+      <div className="font-medium text-slate-900 dark:text-slate-100">{datum.name}</div>
+      <div className="text-slate-600 dark:text-slate-400">
+        {formatShares(datum.shares)} shares
+      </div>
+      <div className="text-slate-600 dark:text-slate-400">
+        {formatPct(datum.pct)} of float
+      </div>
+    </div>
+  );
+}
+
+export { buildSunburstRings };
+export type { SunburstRings };

--- a/frontend/src/components/instrument/ownershipRings.test.ts
+++ b/frontend/src/components/instrument/ownershipRings.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSunburstRings,
+  visibilityThreshold,
+} from "./ownershipRings";
+import type { SunburstHolder, SunburstInputs } from "./ownershipRings";
+
+const DEFAULT_INPUT: SunburstInputs = {
+  free_float: 1_000_000_000,
+  holders: [],
+  treasury_shares: null,
+  institutions_status: "ok",
+  etfs_status: "ok",
+  insiders_status: "ok",
+};
+
+function holder(
+  key: string,
+  shares: number,
+  category: SunburstHolder["category"] = "institutions",
+): SunburstHolder {
+  return { key, label: key, shares, category };
+}
+
+describe("visibilityThreshold", () => {
+  it("returns 0.5% of float for normal-cap floats", () => {
+    expect(visibilityThreshold(1_000_000_000)).toBe(5_000_000);
+    expect(visibilityThreshold(15_000_000_000)).toBe(75_000_000);
+  });
+
+  it("clamps to 10,000-share floor for micro-cap floats", () => {
+    // 1M float * 0.5% = 5,000 shares — below 10k floor.
+    expect(visibilityThreshold(1_000_000)).toBe(10_000);
+    expect(visibilityThreshold(0)).toBe(10_000);
+    expect(visibilityThreshold(-50_000)).toBe(10_000);
+  });
+});
+
+describe("buildSunburstRings", () => {
+  it("returns null on missing or zero float", () => {
+    expect(buildSunburstRings({ ...DEFAULT_INPUT, free_float: 0 })).toBeNull();
+    expect(buildSunburstRings({ ...DEFAULT_INPUT, free_float: NaN })).toBeNull();
+  });
+
+  it("inner ring reports known + residual sum / float", () => {
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      holders: [holder("vanguard", 100_000_000, "institutions")],
+    };
+    const r = buildSunburstRings(input);
+    expect(r).not.toBeNull();
+    // Free float = 1B. Held = 100M (institutions) + 900M (unallocated residual) = 1B.
+    expect(r!.inner.shares).toBe(1_000_000_000);
+    expect(r!.inner.pct).toBeCloseTo(1);
+  });
+
+  it("filer above threshold gets its own outer-ring wedge", () => {
+    // Threshold for 1B float = 5M. Vanguard at 100M passes.
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      holders: [holder("vanguard", 100_000_000, "institutions")],
+    };
+    const r = buildSunburstRings(input);
+    expect(r).not.toBeNull();
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.leaves).toHaveLength(1);
+    expect(inst.leaves[0]!.key).toBe("vanguard");
+    expect(inst.leaves[0]!.is_other).toBe(false);
+  });
+
+  it("filer below threshold rolls into 'Other' aggregate wedge", () => {
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      holders: [
+        holder("vanguard", 100_000_000, "institutions"),  // visible
+        holder("small1", 1_000_000, "institutions"),       // < 5M threshold
+        holder("small2", 500_000, "institutions"),         // < 5M threshold
+        holder("small3", 100_000, "institutions"),         // < 5M threshold
+      ],
+    };
+    const r = buildSunburstRings(input);
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.leaves).toHaveLength(2);
+    const other = inst.leaves[1]!;
+    expect(other.is_other).toBe(true);
+    expect(other.shares).toBe(1_600_000);
+    expect(other.tail_meta!.count).toBe(3);
+    expect(other.tail_meta!.aggregate_shares).toBe(1_600_000);
+    expect(other.tail_meta!.largest_label).toBe("small1");
+  });
+
+  it("'Other' tail meta surfaces the largest sub-threshold holder for context", () => {
+    // Operator wants to know the top of the tail without expanding —
+    // pin that ``largest_label`` is correct on a multi-holder tail.
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      holders: [
+        holder("BIG", 100_000_000, "institutions"),
+        holder("renaissance", 4_000_000, "institutions"), // below 5M
+        holder("citadel", 4_500_000, "institutions"),     // below 5M, biggest in tail
+        holder("two_sigma", 500_000, "institutions"),
+      ],
+    };
+    const r = buildSunburstRings(input);
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    const other = inst.leaves.find((l) => l.is_other)!;
+    expect(other.tail_meta!.largest_label).toBe("citadel");
+    expect(other.tail_meta!.largest_pct).toBeCloseTo(0.0045);
+  });
+
+  it("micro-cap respects 10k-share floor — not 0.5%-of-float", () => {
+    // 1M float, 0.5% = 5k shares — but floor is 10k.
+    // Holder with 8k shares should fall into "Other" not visible.
+    const input: SunburstInputs = {
+      free_float: 1_000_000,
+      holders: [
+        holder("alice", 50_000, "institutions"),  // visible (>10k)
+        holder("bob", 8_000, "institutions"),     // < 10k floor
+      ],
+      treasury_shares: null,
+      institutions_status: "ok",
+      etfs_status: "ok",
+      insiders_status: "ok",
+    };
+    const r = buildSunburstRings(input);
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.leaves.find((l) => l.key === "alice")).toBeDefined();
+    const other = inst.leaves.find((l) => l.is_other);
+    expect(other?.tail_meta?.count).toBe(1);
+    expect(other?.shares).toBe(8_000);
+  });
+
+  it("insiders bypass the threshold — every officer surfaces", () => {
+    // Threshold for 1B float = 5M. Officer holding 1M would normally
+    // fall into "Other" for institutions, but for insiders every
+    // officer should surface as their own wedge.
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      holders: [
+        holder("ceo", 1_000_000, "insiders"),
+        holder("cfo", 500_000, "insiders"),
+        holder("cto", 100_000, "insiders"),
+      ],
+    };
+    const r = buildSunburstRings(input);
+    const insiders = r!.categories.find((c) => c.key === "insiders")!;
+    expect(insiders.leaves).toHaveLength(3);
+    expect(insiders.leaves.every((l) => !l.is_other)).toBe(true);
+  });
+
+  it("category status='unknown' renders a coverage-gap leaf, not 0%", () => {
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      institutions_status: "unknown",
+      etfs_status: "unknown",
+    };
+    const r = buildSunburstRings(input);
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.status).toBe("unknown");
+    expect(inst.leaves).toHaveLength(1);
+    expect(inst.leaves[0]!.label).toContain("Coverage gap");
+    // Unallocated also flagged unknown when any category is unknown.
+    const unalloc = r!.categories.find((c) => c.key === "unallocated")!;
+    expect(unalloc.status).toBe("unknown");
+  });
+
+  it("treasury wedge present when treasury_shares > 0", () => {
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      treasury_shares: 10_000_000,
+    };
+    const r = buildSunburstRings(input);
+    const treasury = r!.categories.find((c) => c.key === "treasury")!;
+    expect(treasury.status).toBe("ok");
+    expect(treasury.shares).toBe(10_000_000);
+    expect(treasury.leaves).toHaveLength(1);
+  });
+
+  it("treasury status='unknown' when input is null", () => {
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      treasury_shares: null,
+    };
+    const r = buildSunburstRings(input);
+    const treasury = r!.categories.find((c) => c.key === "treasury")!;
+    expect(treasury.status).toBe("unknown");
+  });
+
+  it("unallocated absorbs the float residual when every category is known", () => {
+    // 1B float, 100M institutions, 50M ETFs, 20M insiders, 10M
+    // treasury → 820M unallocated.
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      holders: [
+        holder("inst", 100_000_000, "institutions"),
+        holder("etf", 50_000_000, "etfs"),
+        holder("officer", 20_000_000, "insiders"),
+      ],
+      treasury_shares: 10_000_000,
+    };
+    const r = buildSunburstRings(input);
+    const unalloc = r!.categories.find((c) => c.key === "unallocated")!;
+    expect(unalloc.shares).toBe(820_000_000);
+    expect(unalloc.status).toBe("ok");
+  });
+
+  it("category sort: largest leaf first within each category", () => {
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      holders: [
+        holder("smaller", 50_000_000, "institutions"),
+        holder("larger", 200_000_000, "institutions"),
+      ],
+    };
+    const r = buildSunburstRings(input);
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.leaves[0]!.key).toBe("larger");
+    expect(inst.leaves[1]!.key).toBe("smaller");
+  });
+
+  it("empty category renders status='empty' with no leaves", () => {
+    const r = buildSunburstRings({ ...DEFAULT_INPUT });
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.status).toBe("empty");
+    expect(inst.leaves).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/instrument/ownershipRings.ts
+++ b/frontend/src/components/instrument/ownershipRings.ts
@@ -1,0 +1,342 @@
+/**
+ * Sunburst data transformer for the ownership card (#729).
+ *
+ * Three concentric rings:
+ *
+ *   ring 1 (inner)  : single arc — "Held" (sum of all categories below)
+ *   ring 2 (middle) : per-category — Institutions / ETFs / Insiders / Treasury / Unallocated
+ *   ring 3 (outer)  : per-filer / per-officer wedges within each category, plus
+ *                     "Other [Category]" tail-aggregate when individual filers
+ *                     fall below the visibility threshold.
+ *
+ * Threshold-based grouping (vs top-N):
+ *   * 0.5% of float OR 10,000 shares — whichever is larger
+ *   * The float-relative floor keeps mega-caps with hundreds of small
+ *     13F filers from drowning the canvas in confetti while still
+ *     promoting any holder large enough to move the thesis.
+ *   * The 10,000-share absolute floor prevents thinly-floated
+ *     micro-caps from setting an effectively-zero threshold that
+ *     would render every legitimate holder.
+ *   * Insiders bypass the threshold — the officer set is small and
+ *     every officer's holding is signal.
+ *
+ * Coverage gating: when a category's total is unknown (Institutions /
+ * ETFs gated on #740 CUSIP backfill), the transformer emits a
+ * sentinel ``status='unknown'`` middle wedge sized to the residual
+ * (free-float minus known categories) so the operator sees the gap
+ * visually rather than as missing slices.
+ */
+
+export type SunburstCategoryStatus = "ok" | "unknown" | "empty";
+
+export interface SunburstCategory {
+  readonly key: string; // 'institutions' | 'etfs' | 'insiders' | 'treasury' | 'unallocated'
+  readonly label: string;
+  readonly shares: number;
+  readonly pct: number; // share / float
+  readonly status: SunburstCategoryStatus;
+  /** Outer-ring wedges within this category. */
+  readonly leaves: readonly SunburstLeaf[];
+}
+
+export interface SunburstLeaf {
+  readonly key: string; // stable id for click-drill (filer cik, officer name, "other-etfs")
+  readonly label: string;
+  readonly shares: number;
+  readonly pct: number; // share / float
+  /** True for the aggregated tail wedge. */
+  readonly is_other: boolean;
+  /** Counts only meaningful on the "Other" tail wedge. */
+  readonly tail_meta?: SunburstTailMeta;
+}
+
+export interface SunburstTailMeta {
+  readonly count: number;
+  readonly aggregate_shares: number;
+  readonly aggregate_pct: number;
+  readonly largest_label: string;
+  readonly largest_pct: number;
+}
+
+export interface SunburstHolder {
+  /** Stable identifier — filer CIK, officer CIK, or fallback name. */
+  readonly key: string;
+  readonly label: string;
+  readonly shares: number;
+  readonly category: "institutions" | "etfs" | "insiders";
+}
+
+export interface SunburstInputs {
+  readonly free_float: number;
+  /** Holders contributing to Institutions / ETFs / Insiders. */
+  readonly holders: readonly SunburstHolder[];
+  /** Treasury memo line — single wedge under its own middle category. */
+  readonly treasury_shares: number | null;
+  /**
+   * Per-category status flags. ``unknown`` short-circuits the
+   * transformer for that category so ungated CUSIP coverage doesn't
+   * silently appear as 0%.
+   */
+  readonly institutions_status: SunburstCategoryStatus;
+  readonly etfs_status: SunburstCategoryStatus;
+  readonly insiders_status: SunburstCategoryStatus;
+}
+
+export interface SunburstRings {
+  readonly free_float: number;
+  /** ring 1 — single inner-ring arc representing "Held" total. */
+  readonly inner: { readonly shares: number; readonly pct: number };
+  /** ring 2 — per-category wedges. */
+  readonly categories: readonly SunburstCategory[];
+}
+
+const SHARES_FLOOR = 10_000;
+const FLOAT_PCT_FLOOR = 0.005; // 0.5%
+
+/**
+ * Compute the per-category visibility threshold for outer-ring wedges.
+ *
+ * Insiders ignore this — every officer surfaces.
+ */
+export function visibilityThreshold(free_float: number): number {
+  if (free_float <= 0) return SHARES_FLOOR;
+  return Math.max(SHARES_FLOOR, free_float * FLOAT_PCT_FLOOR);
+}
+
+interface CategorySpec {
+  readonly key: "institutions" | "etfs" | "insiders" | "treasury" | "unallocated";
+  readonly label: string;
+  readonly status: SunburstCategoryStatus;
+  /** True = bypass the visibility threshold (insiders, treasury, unallocated). */
+  readonly bypass_threshold: boolean;
+}
+
+const CATEGORY_LABEL: Record<string, string> = {
+  institutions: "Institutions",
+  etfs: "ETFs",
+  insiders: "Insiders",
+  treasury: "Treasury",
+  unallocated: "Unallocated",
+};
+
+/**
+ * Transform raw inputs into the three-ring sunburst data model.
+ *
+ * Returns ``null`` when ``free_float`` is missing / zero — the caller
+ * renders the card empty state (no denominator → no rings).
+ */
+export function buildSunburstRings(input: SunburstInputs): SunburstRings | null {
+  if (input.free_float <= 0 || !Number.isFinite(input.free_float)) return null;
+
+  const float = input.free_float;
+  const threshold = visibilityThreshold(float);
+
+  const inst_holders = input.holders.filter((h) => h.category === "institutions");
+  const etf_holders = input.holders.filter((h) => h.category === "etfs");
+  const insider_holders = input.holders.filter((h) => h.category === "insiders");
+
+  const institutions = buildCategory(
+    {
+      key: "institutions",
+      label: CATEGORY_LABEL.institutions!,
+      status: input.institutions_status,
+      bypass_threshold: false,
+    },
+    inst_holders,
+    float,
+    threshold,
+  );
+  const etfs = buildCategory(
+    {
+      key: "etfs",
+      label: CATEGORY_LABEL.etfs!,
+      status: input.etfs_status,
+      bypass_threshold: false,
+    },
+    etf_holders,
+    float,
+    threshold,
+  );
+  const insiders = buildCategory(
+    {
+      key: "insiders",
+      label: CATEGORY_LABEL.insiders!,
+      status: input.insiders_status,
+      bypass_threshold: true,
+    },
+    insider_holders,
+    float,
+    threshold,
+  );
+
+  // Treasury renders as a single leaf wedge.
+  const treasury_shares = input.treasury_shares ?? 0;
+  const treasury: SunburstCategory = {
+    key: "treasury",
+    label: CATEGORY_LABEL.treasury!,
+    shares: treasury_shares,
+    pct: treasury_shares / float,
+    status: input.treasury_shares === null ? "unknown" : treasury_shares > 0 ? "ok" : "empty",
+    leaves:
+      treasury_shares > 0
+        ? [
+            {
+              key: "treasury",
+              label: "Treasury",
+              shares: treasury_shares,
+              pct: treasury_shares / float,
+              is_other: false,
+            },
+          ]
+        : [],
+  };
+
+  // Unallocated absorbs whatever's left after every known category. When
+  // any category is ``unknown`` we cannot derive Unallocated cleanly —
+  // emit it as ``unknown`` so the visual signals "we don't know what
+  // sits here" rather than reporting a fabricated residual.
+  const known_shares =
+    (institutions.status === "ok" ? institutions.shares : 0) +
+    (etfs.status === "ok" ? etfs.shares : 0) +
+    (insiders.status === "ok" ? insiders.shares : 0) +
+    (treasury.status === "ok" ? treasury.shares : 0);
+
+  const has_unknown =
+    institutions.status === "unknown" ||
+    etfs.status === "unknown" ||
+    insiders.status === "unknown" ||
+    treasury.status === "unknown";
+
+  const residual_shares = Math.max(0, float - known_shares);
+  const unallocated: SunburstCategory = {
+    key: "unallocated",
+    label: CATEGORY_LABEL.unallocated!,
+    shares: residual_shares,
+    pct: residual_shares / float,
+    status: has_unknown ? "unknown" : residual_shares > 0 ? "ok" : "empty",
+    leaves: [
+      {
+        key: "unallocated",
+        label: has_unknown ? "Coverage gap (#740)" : "Unallocated",
+        shares: residual_shares,
+        pct: residual_shares / float,
+        is_other: false,
+      },
+    ],
+  };
+
+  const categories = [institutions, etfs, insiders, treasury, unallocated];
+
+  // Inner-ring "Held" = sum of every known category. When any
+  // category is ``unknown``, ``inner`` reports the known portion only;
+  // the visible gap on ring 1 implicitly conveys "not all held shares
+  // are accounted for".
+  const inner_shares = known_shares + residual_shares;
+  const inner_pct = inner_shares / float;
+
+  return {
+    free_float: float,
+    inner: { shares: inner_shares, pct: inner_pct },
+    categories,
+  };
+}
+
+function buildCategory(
+  spec: CategorySpec,
+  holders: readonly SunburstHolder[],
+  float: number,
+  threshold: number,
+): SunburstCategory {
+  if (spec.status === "unknown") {
+    return {
+      key: spec.key,
+      label: spec.label,
+      shares: 0,
+      pct: 0,
+      status: "unknown",
+      leaves: [
+        {
+          key: `${spec.key}-unknown`,
+          label: "Coverage gap (#740)",
+          shares: 0,
+          pct: 0,
+          is_other: false,
+        },
+      ],
+    };
+  }
+
+  if (holders.length === 0) {
+    return {
+      key: spec.key,
+      label: spec.label,
+      shares: 0,
+      pct: 0,
+      status: "empty",
+      leaves: [],
+    };
+  }
+
+  const total_shares = holders.reduce((sum, h) => sum + h.shares, 0);
+  if (total_shares <= 0) {
+    return {
+      key: spec.key,
+      label: spec.label,
+      shares: 0,
+      pct: 0,
+      status: "empty",
+      leaves: [],
+    };
+  }
+
+  // Sort largest-first so the canvas reads counter-clockwise from
+  // 12 o'clock with the dominant holders most visually prominent.
+  const sorted = [...holders].sort((a, b) => b.shares - a.shares);
+
+  const visible: SunburstLeaf[] = [];
+  const tail: SunburstHolder[] = [];
+
+  for (const h of sorted) {
+    const passes = spec.bypass_threshold || h.shares >= threshold;
+    if (passes) {
+      visible.push({
+        key: h.key,
+        label: h.label,
+        shares: h.shares,
+        pct: h.shares / float,
+        is_other: false,
+      });
+    } else {
+      tail.push(h);
+    }
+  }
+
+  const leaves: SunburstLeaf[] = [...visible];
+  if (tail.length > 0) {
+    const aggregate_shares = tail.reduce((sum, h) => sum + h.shares, 0);
+    const largest = tail.reduce((biggest, h) => (h.shares > biggest.shares ? h : biggest), tail[0]!);
+    leaves.push({
+      key: `${spec.key}-other`,
+      label: `Other ${spec.label.toLowerCase()}`,
+      shares: aggregate_shares,
+      pct: aggregate_shares / float,
+      is_other: true,
+      tail_meta: {
+        count: tail.length,
+        aggregate_shares,
+        aggregate_pct: aggregate_shares / float,
+        largest_label: largest.label,
+        largest_pct: largest.shares / float,
+      },
+    });
+  }
+
+  return {
+    key: spec.key,
+    label: spec.label,
+    shares: total_shares,
+    pct: total_shares / float,
+    status: "ok",
+    leaves,
+  };
+}


### PR DESCRIPTION
## What

Replaces the flat ownership table from PR #744 with a three-ring sunburst:

- **ring 1 (innermost)** — Held total, free-float number in the center hole.
- **ring 2** — per-category (Institutions / ETFs / Insiders / Treasury / Unallocated).
- **ring 3 (outermost)** — per-filer / per-officer wedges + an "Other [Category]" tail wedge.

## Conscious tradeoffs

### Threshold-based grouping (no top-N)

Every filer that meets \`max(0.5% of float, 10,000 shares)\` gets its own outer-ring wedge. The rest aggregate into "Other [Category]" with tail metadata: count of filers, aggregate shares, largest sub-threshold member. Insiders bypass the threshold entirely (officer set is small; every officer is signal).

Why not top-N: a flurry of small-but-coordinated holders (meme cohort, activist sub-syndicate, ETF complex) is collectively load-bearing for thesis. Top-N=8 would silently drop them. Threshold preserves every meaningful holder while still grouping the long tail. Per-pixel sunburst arc length already reflects share size, so visual hierarchy is preserved.

### Coverage gap rendering

Categories gated on the #740 CUSIP backfill (Institutions / ETFs today) render as desaturated grey wedges labelled "Coverage gap (#740)". Operator sees the gap visually rather than misreading it as "this stock has no institutional holders". Once #740 lands, those wedges populate automatically with no panel changes.

### Recharts nested-Pie sunburst

No third-party sunburst lib. Three \`<Pie>\` components at increasing \`innerRadius\` / \`outerRadius\` ride on the existing recharts dep. Center label rendered as overlaid div (recharts has no native center-label primitive but the chart canvas is a known size).

### Click semantics (drill stub)

Click on any wedge navigates to \`/instrument/:symbol/ownership\` with \`?category=<key>\` and optionally \`?filer=<key>\`. The L2 page handler ships in the next PR; this PR wires the integration so the route handler can land without touching this component.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test:unit\` — 787 tests pass (15 new in \`ownershipRings.test.ts\`):
   - threshold floor (0.5% of float vs 10k floor)
   - micro-cap floor application
   - "Other" tail metadata (count, aggregate, largest)
   - insiders bypass the threshold
   - status='unknown' renders coverage-gap leaf, not 0%
   - treasury wedge presence vs unknown
   - inner-ring sum invariant (free_float = known + residual)
   - category sort (largest leaf first)
   - empty category renders status='empty' with no leaves
- [x] \`node scripts/check-dark-classes.mjs\` — clean (172 files)
- [ ] Visual validation in browser deferred — autonomous run cannot launch the dev server. Operator should sanity-check on a covered ticker (AAPL).

## What's next (PR 2 of this batch)

- L2 drill page at \`/instrument/:symbol/ownership\` — bigger sunburst + filter-aware filer table + CSV export. Click-from-L1 already wired.

## Linked

- Builds on #729 / PR #744 (initial flat-table card).
- Effective coverage of Institutions/ETFs slices remains gated on #740.