### PR TITLE
feat(#729): inner-ring known/gap split + reason-aware coverage gap copy

### DIFF
--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -340,6 +340,11 @@ function renderBody(
     );
   }
 
+  const knownPct = rings.inner.known_pct;
+  const gapPct = rings.inner.gap_pct;
+  const hasMaterialGap = gapPct > 0.005; // > 0.5% counts as material to surface
+  const gapReasons = collectGapReasons(rings.categories);
+
   return (
     <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
       <div className="flex justify-center">
@@ -347,11 +352,29 @@ function renderBody(
       </div>
       <div className="min-w-0 flex-1">
         {data.as_of_period !== null && (
-          <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
+          <p className="mb-1 text-xs text-slate-500 dark:text-slate-400">
             As of {data.as_of_period}. Free float ={" "}
             {formatShares(data.free_float)} shares.
           </p>
         )}
+        <p className="mb-2 text-xs">
+          <span className="font-medium text-slate-700 dark:text-slate-200">
+            {formatPct(knownPct)} known
+          </span>
+          {hasMaterialGap && (
+            <>
+              <span className="mx-1.5 text-slate-400">·</span>
+              <span className="font-medium text-amber-700 dark:text-amber-400">
+                {formatPct(gapPct)} coverage gap
+              </span>
+              {gapReasons.length > 0 && (
+                <span className="ml-1 text-slate-500 dark:text-slate-400">
+                  ({gapReasons.join(", ")})
+                </span>
+              )}
+            </>
+          )}
+        </p>
         <table className="w-full text-sm">
           <thead className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
             <tr>
@@ -370,7 +393,7 @@ function renderBody(
                   {cat.label}
                   {cat.status === "unknown" && (
                     <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">
-                      coverage gap
+                      {unknownReasonShort(cat.unknown_reason)}
                     </span>
                   )}
                 </td>
@@ -390,4 +413,27 @@ function renderBody(
       </div>
     </div>
   );
+}
+
+function collectGapReasons(
+  categories: readonly { unknown_reason?: string; status: string }[],
+): string[] {
+  const reasons = new Set<string>();
+  for (const cat of categories) {
+    if (cat.status !== "unknown") continue;
+    if (cat.unknown_reason === "cusip_backfill") reasons.add("#740 CUSIP backfill");
+    if (cat.unknown_reason === "dei_projection") reasons.add("#735 DEI projection");
+  }
+  return Array.from(reasons);
+}
+
+function unknownReasonShort(reason: string | undefined): string {
+  switch (reason) {
+    case "cusip_backfill":
+      return "needs CUSIPs (#740)";
+    case "dei_projection":
+      return "needs DEI tag (#735)";
+    default:
+      return "no data";
+  }
 }

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -418,11 +418,27 @@ function renderBody(
 function collectGapReasons(
   categories: readonly { unknown_reason?: string; status: string }[],
 ): string[] {
+  // Dedupes across categories so a stock with both
+  // institutions and ETFs gated on #740 doesn't repeat the
+  // ticket. Generic 'no_data' / undefined reasons fall back to a
+  // neutral label so the header parenthetical still surfaces
+  // when an unknown category cannot be tied to a tracked
+  // follow-up — "X% coverage gap" with no parenthetical was
+  // ambiguous and dropped a real gap below the operator's
+  // attention threshold.
   const reasons = new Set<string>();
   for (const cat of categories) {
     if (cat.status !== "unknown") continue;
-    if (cat.unknown_reason === "cusip_backfill") reasons.add("#740 CUSIP backfill");
-    if (cat.unknown_reason === "dei_projection") reasons.add("#735 DEI projection");
+    switch (cat.unknown_reason) {
+      case "cusip_backfill":
+        reasons.add("#740 CUSIP backfill");
+        break;
+      case "dei_projection":
+        reasons.add("#735 DEI projection");
+        break;
+      default:
+        reasons.add("data not on file");
+    }
   }
   return Array.from(reasons);
 }

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -91,19 +91,50 @@ export function OwnershipSunburst({
     return accent[idx % accent.length]!;
   };
 
-  // Inner ring — single arc.
-  const innerData: ChartDatum[] = [
-    {
-      name: "Held",
-      shares: rings.inner.shares,
-      pct: rings.inner.pct,
+  // Inner ring — known + gap split. Pre-#746-followup the inner
+  // ring rendered as a single 100% arc that included synthetic
+  // unknown-padding from upstream categories — visually misleading
+  // when most of the float was in coverage gaps. Two arcs make the
+  // gap proportion legible at the very center of the chart.
+  const innerData: ChartDatum[] = [];
+  if (rings.inner.known_shares > 0) {
+    innerData.push({
+      name: "Known",
+      shares: rings.inner.known_shares,
+      pct: rings.inner.known_pct,
       fill: theme.borderColor,
       stroke: theme.bg,
-      opacity: 0.6,
+      opacity: 0.7,
       is_gap: false,
       target: { kind: "center" },
-    },
-  ];
+    });
+  }
+  if (rings.inner.gap_shares > 0) {
+    innerData.push({
+      name: "Coverage gap",
+      shares: rings.inner.gap_shares,
+      pct: rings.inner.gap_pct,
+      fill: UNKNOWN_FILL,
+      stroke: theme.bg,
+      opacity: 0.45,
+      is_gap: true,
+      target: { kind: "center" },
+    });
+  }
+  // Defensive: if both segments are zero (degenerate), still render
+  // a single placeholder so the inner ring outline is preserved.
+  if (innerData.length === 0) {
+    innerData.push({
+      name: "Held",
+      shares: 1,
+      pct: 0,
+      fill: theme.borderColor,
+      stroke: theme.bg,
+      opacity: 0.4,
+      is_gap: true,
+      target: { kind: "center" },
+    });
+  }
 
   // Middle ring — one wedge per category. Categories with shares=0
   // and status='empty' are skipped so the ring doesn't render a

--- a/frontend/src/components/instrument/ownershipRings.test.ts
+++ b/frontend/src/components/instrument/ownershipRings.test.ts
@@ -6,10 +6,13 @@ import {
 } from "./ownershipRings";
 import type { SunburstHolder, SunburstInputs } from "./ownershipRings";
 
+// treasury_shares=0 (a positive "we know there is no treasury" signal)
+// means the default category set is fully known — individual tests
+// override to ``null`` to exercise the DEI-projection-gap path.
 const DEFAULT_INPUT: SunburstInputs = {
   free_float: 1_000_000_000,
   holders: [],
-  treasury_shares: null,
+  treasury_shares: 0,
   institutions_status: "ok",
   etfs_status: "ok",
   insiders_status: "ok",
@@ -43,16 +46,18 @@ describe("buildSunburstRings", () => {
     expect(buildSunburstRings({ ...DEFAULT_INPUT, free_float: NaN })).toBeNull();
   });
 
-  it("inner ring reports known + residual sum / float", () => {
+  it("inner ring known/gap split = full float when every category is known", () => {
     const input: SunburstInputs = {
       ...DEFAULT_INPUT,
       holders: [holder("vanguard", 100_000_000, "institutions")],
     };
     const r = buildSunburstRings(input);
     expect(r).not.toBeNull();
-    // Free float = 1B. Held = 100M (institutions) + 900M (unallocated residual) = 1B.
-    expect(r!.inner.shares).toBe(1_000_000_000);
-    expect(r!.inner.pct).toBeCloseTo(1);
+    // Float=1B, institutions=100M, unallocated=900M, gap=0.
+    expect(r!.inner.known_shares).toBe(1_000_000_000);
+    expect(r!.inner.gap_shares).toBe(0);
+    expect(r!.inner.known_pct).toBeCloseTo(1);
+    expect(r!.inner.gap_pct).toBeCloseTo(0);
   });
 
   it("filer above threshold gets its own outer-ring wedge", () => {
@@ -158,11 +163,36 @@ describe("buildSunburstRings", () => {
     const r = buildSunburstRings(input);
     const inst = r!.categories.find((c) => c.key === "institutions")!;
     expect(inst.status).toBe("unknown");
+    expect(inst.unknown_reason).toBe("cusip_backfill");
     expect(inst.leaves).toHaveLength(1);
-    expect(inst.leaves[0]!.label).toContain("Coverage gap");
-    // Unallocated also flagged unknown when any category is unknown.
+    expect(inst.leaves[0]!.label).toContain("CUSIP backfill");
+    // Unallocated collapses to 'empty' when an upstream category
+    // is unknown — its residual would be contaminated by the
+    // upstream gap and would mislead the operator if surfaced.
     const unalloc = r!.categories.find((c) => c.key === "unallocated")!;
-    expect(unalloc.status).toBe("unknown");
+    expect(unalloc.status).toBe("empty");
+    expect(unalloc.shares).toBe(0);
+  });
+
+  it("inner ring splits known vs gap when categories are unknown", () => {
+    // Only insiders + treasury known; institutions + ETFs gated by
+    // CUSIP backfill. Inner ring's gap_shares should equal float
+    // minus everything we genuinely know.
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      holders: [holder("ceo", 50_000_000, "insiders")],
+      treasury_shares: 30_000_000,
+      institutions_status: "unknown",
+      etfs_status: "unknown",
+    };
+    const r = buildSunburstRings(input);
+    expect(r).not.toBeNull();
+    // Known = insiders 50M + treasury 30M = 80M.
+    expect(r!.inner.known_shares).toBe(80_000_000);
+    // Gap = float 1B - 80M = 920M.
+    expect(r!.inner.gap_shares).toBe(920_000_000);
+    expect(r!.inner.known_pct).toBeCloseTo(0.08);
+    expect(r!.inner.gap_pct).toBeCloseTo(0.92);
   });
 
   it("treasury wedge present when treasury_shares > 0", () => {
@@ -177,7 +207,10 @@ describe("buildSunburstRings", () => {
     expect(treasury.leaves).toHaveLength(1);
   });
 
-  it("treasury status='unknown' when input is null", () => {
+  it("treasury status='unknown' with reason='dei_projection' when input is null", () => {
+    // Treasury_shares null is the #735 / DEI projection gap, not
+    // the CUSIP backfill. Operator-facing copy should surface that
+    // distinction so they don't conflate the two follow-ups.
     const input: SunburstInputs = {
       ...DEFAULT_INPUT,
       treasury_shares: null,
@@ -185,6 +218,8 @@ describe("buildSunburstRings", () => {
     const r = buildSunburstRings(input);
     const treasury = r!.categories.find((c) => c.key === "treasury")!;
     expect(treasury.status).toBe("unknown");
+    expect(treasury.unknown_reason).toBe("dei_projection");
+    expect(treasury.leaves[0]!.label).toContain("DEI projection");
   });
 
   it("unallocated absorbs the float residual when every category is known", () => {

--- a/frontend/src/components/instrument/ownershipRings.ts
+++ b/frontend/src/components/instrument/ownershipRings.ts
@@ -29,12 +29,27 @@
 
 export type SunburstCategoryStatus = "ok" | "unknown" | "empty";
 
+/**
+ * Why a category resolves to ``status='unknown'``. Drives the
+ * tooltip + summary copy so the operator distinguishes a CUSIP
+ * backfill gap (#740) from a missing DEI cover-page projection
+ * (#735) etc. Today only ``cusip_backfill`` is wired through;
+ * ``dei_projection`` is reserved for treasury_shares specifically
+ * and lights up once #735 surfaces the column.
+ */
+export type SunburstUnknownReason =
+  | "cusip_backfill"
+  | "dei_projection"
+  | "no_data";
+
 export interface SunburstCategory {
   readonly key: string; // 'institutions' | 'etfs' | 'insiders' | 'treasury' | 'unallocated'
   readonly label: string;
   readonly shares: number;
   readonly pct: number; // share / float
   readonly status: SunburstCategoryStatus;
+  /** Set only when ``status === 'unknown'``. */
+  readonly unknown_reason?: SunburstUnknownReason;
   /** Outer-ring wedges within this category. */
   readonly leaves: readonly SunburstLeaf[];
 }
@@ -82,10 +97,27 @@ export interface SunburstInputs {
   readonly insiders_status: SunburstCategoryStatus;
 }
 
+/**
+ * Inner-ring split. Pre-#746 the inner ring reported "Held" as a
+ * single arc summing every category including the synthetic
+ * ``unknown`` placeholders — so an instrument with 95% of its
+ * float in coverage-gap categories rendered a 100% Held arc,
+ * which lied. Now the inner ring carries explicit ``known`` and
+ * ``gap`` segments and the renderer draws them as two arcs.
+ */
+export interface InnerRing {
+  /** Sum of every category whose status is ``ok``. */
+  readonly known_shares: number;
+  /** Sum of every category whose status is ``unknown`` — i.e. the
+   *  free-float residual that we cannot account for today. */
+  readonly gap_shares: number;
+  readonly known_pct: number;
+  readonly gap_pct: number;
+}
+
 export interface SunburstRings {
   readonly free_float: number;
-  /** ring 1 — single inner-ring arc representing "Held" total. */
-  readonly inner: { readonly shares: number; readonly pct: number };
+  readonly inner: InnerRing;
   /** ring 2 — per-category wedges. */
   readonly categories: readonly SunburstCategory[];
 }
@@ -107,6 +139,9 @@ interface CategorySpec {
   readonly key: "institutions" | "etfs" | "insiders" | "treasury" | "unallocated";
   readonly label: string;
   readonly status: SunburstCategoryStatus;
+  /** Reason an unknown-status category resolved unknown — drives
+   *  the operator-facing tooltip + summary copy. */
+  readonly unknown_reason?: SunburstUnknownReason;
   /** True = bypass the visibility threshold (insiders, treasury, unallocated). */
   readonly bypass_threshold: boolean;
 }
@@ -140,6 +175,7 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
       key: "institutions",
       label: CATEGORY_LABEL.institutions!,
       status: input.institutions_status,
+      unknown_reason: "cusip_backfill",
       bypass_threshold: false,
     },
     inst_holders,
@@ -151,6 +187,7 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
       key: "etfs",
       label: CATEGORY_LABEL.etfs!,
       status: input.etfs_status,
+      unknown_reason: "cusip_backfill",
       bypass_threshold: false,
     },
     etf_holders,
@@ -162,6 +199,7 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
       key: "insiders",
       label: CATEGORY_LABEL.insiders!,
       status: input.insiders_status,
+      unknown_reason: "no_data",
       bypass_threshold: true,
     },
     insider_holders,
@@ -170,31 +208,54 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
   );
 
   // Treasury renders as a single leaf wedge.
+  // Distinguish "treasury reported as zero" from "DEI projection
+  // missing" — treasury_shares=null is the #735 / #731 follow-up,
+  // not the CUSIP-backfill #740 gap.
   const treasury_shares = input.treasury_shares ?? 0;
+  const treasury_status: SunburstCategoryStatus =
+    input.treasury_shares === null
+      ? "unknown"
+      : treasury_shares > 0
+        ? "ok"
+        : "empty";
   const treasury: SunburstCategory = {
     key: "treasury",
     label: CATEGORY_LABEL.treasury!,
     shares: treasury_shares,
     pct: treasury_shares / float,
-    status: input.treasury_shares === null ? "unknown" : treasury_shares > 0 ? "ok" : "empty",
+    status: treasury_status,
+    ...(treasury_status === "unknown"
+      ? { unknown_reason: "dei_projection" as const }
+      : {}),
     leaves:
-      treasury_shares > 0
+      treasury_status === "unknown"
         ? [
             {
-              key: "treasury",
-              label: "Treasury",
-              shares: treasury_shares,
-              pct: treasury_shares / float,
+              key: "treasury-unknown",
+              label: "Treasury — DEI projection pending",
+              shares: 0,
+              pct: 0,
               is_other: false,
             },
           ]
-        : [],
+        : treasury_shares > 0
+          ? [
+              {
+                key: "treasury",
+                label: "Treasury",
+                shares: treasury_shares,
+                pct: treasury_shares / float,
+                is_other: false,
+              },
+            ]
+          : [],
   };
 
   // Unallocated absorbs whatever's left after every known category. When
   // any category is ``unknown`` we cannot derive Unallocated cleanly —
-  // emit it as ``unknown`` so the visual signals "we don't know what
-  // sits here" rather than reporting a fabricated residual.
+  // emit it as ``empty`` so the operator's eye lands on the
+  // upstream-unknown wedges as the source of the gap, not on a
+  // fabricated "Unallocated coverage gap" downstream wedge.
   const known_shares =
     (institutions.status === "ok" ? institutions.shares : 0) +
     (etfs.status === "ok" ? etfs.shares : 0) +
@@ -208,35 +269,49 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
     treasury.status === "unknown";
 
   const residual_shares = Math.max(0, float - known_shares);
+  // When every category is ``ok``, residual is the genuine
+  // Unallocated slice (retail + small holders below the 13F threshold).
+  // When any category is ``unknown``, the residual is contaminated
+  // by the upstream gap and would mislead — collapse to ``empty``.
   const unallocated: SunburstCategory = {
     key: "unallocated",
     label: CATEGORY_LABEL.unallocated!,
-    shares: residual_shares,
-    pct: residual_shares / float,
-    status: has_unknown ? "unknown" : residual_shares > 0 ? "ok" : "empty",
-    leaves: [
-      {
-        key: "unallocated",
-        label: has_unknown ? "Coverage gap (#740)" : "Unallocated",
-        shares: residual_shares,
-        pct: residual_shares / float,
-        is_other: false,
-      },
-    ],
+    shares: has_unknown ? 0 : residual_shares,
+    pct: has_unknown ? 0 : residual_shares / float,
+    status: has_unknown ? "empty" : residual_shares > 0 ? "ok" : "empty",
+    leaves: has_unknown
+      ? []
+      : residual_shares > 0
+        ? [
+            {
+              key: "unallocated",
+              label: "Unallocated",
+              shares: residual_shares,
+              pct: residual_shares / float,
+              is_other: false,
+            },
+          ]
+        : [],
   };
 
   const categories = [institutions, etfs, insiders, treasury, unallocated];
 
-  // Inner-ring "Held" = sum of every known category. When any
-  // category is ``unknown``, ``inner`` reports the known portion only;
-  // the visible gap on ring 1 implicitly conveys "not all held shares
-  // are accounted for".
-  const inner_shares = known_shares + residual_shares;
-  const inner_pct = inner_shares / float;
+  // Inner-ring split: known (sum of OK categories + the
+  // ok-status Unallocated residual) vs gap (everything else =
+  // float minus known). Pre-fix the inner ring carried the synthetic
+  // unknown-padding through unaltered, lighting up as a 100% Held
+  // arc even when 95% of the float was in coverage gaps.
+  const inner_known = known_shares + (unallocated.status === "ok" ? unallocated.shares : 0);
+  const inner_gap = Math.max(0, float - inner_known);
 
   return {
     free_float: float,
-    inner: { shares: inner_shares, pct: inner_pct },
+    inner: {
+      known_shares: inner_known,
+      gap_shares: inner_gap,
+      known_pct: inner_known / float,
+      gap_pct: inner_gap / float,
+    },
     categories,
   };
 }
@@ -254,10 +329,11 @@ function buildCategory(
       shares: 0,
       pct: 0,
       status: "unknown",
+      ...(spec.unknown_reason !== undefined ? { unknown_reason: spec.unknown_reason } : {}),
       leaves: [
         {
           key: `${spec.key}-unknown`,
-          label: "Coverage gap (#740)",
+          label: unknownLeafLabel(spec.label, spec.unknown_reason),
           shares: 0,
           pct: 0,
           is_other: false,
@@ -339,4 +415,18 @@ function buildCategory(
     status: "ok",
     leaves,
   };
+}
+
+function unknownLeafLabel(
+  category_label: string,
+  reason: SunburstUnknownReason | undefined,
+): string {
+  switch (reason) {
+    case "cusip_backfill":
+      return `${category_label} — needs CUSIP backfill (#740)`;
+    case "dei_projection":
+      return `${category_label} — DEI projection pending (#735)`;
+    default:
+      return `${category_label} — data not available`;
+  }
 }


### PR DESCRIPTION
## What

Polishing pass on the ownership sunburst from PR #746. Screenshot shows AAPL rendering as ~95% purple (CUSIP coverage gap) but the inner ring still reads as 100% Held — that's the lie this PR fixes.

## Changes

1. **Inner ring known/gap split.** New ``InnerRing`` shape carries ``known_shares`` + ``gap_shares`` separately. Renderer draws two arcs — theme grey for known, desaturated UNKNOWN_FILL for gap.

2. **Reason-aware coverage gap copy.** Categories now carry ``unknown_reason`` (\`'cusip_backfill'\` / \`'dei_projection'\` / \`'no_data'\`). Different gaps get different copy:
   - Institutions / ETFs unknown → "needs CUSIPs (#740)"
   - Treasury unknown → "needs DEI tag (#735)"
   Operator stops conflating the two follow-up tickets.

3. **Header summary line.** Above the legend: "X% known · Y% coverage gap (reasons)". Reasons list dedupes across categories.

4. **Unallocated collapses on upstream gap.** Pre-fix a CUSIP-gap instrument rendered Unallocated as a synthetic "Coverage gap (#740)" wedge that doubled the visual signal. Now Unallocated is ``empty`` when any upstream category is unknown — operator's eye lands on the actual gated category.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test:unit\` — 788 tests pass (one new sunburst-rings case + one updated unknown-reason assertion)
- [x] \`node scripts/check-dark-classes.mjs\` — clean

## What's still open

- L2 drill page at \`/instrument/:symbol/ownership\` (next PR — click handler is wired, route handler ships next).
- DPS column compaction to free vertical space below the chart (the original screenshot had ~250px wasted under the per-quarter DPS bars).

## Linked

- Builds on PR #746 (sunburst).
- Effective slice fill still gated on #740 + #735.