### PR TITLE
fix(#736 followup): thread issuer_cik through get_filing → coverage 8-K backfill

### DIFF
--- a/app/providers/filings.py
+++ b/app/providers/filings.py
@@ -92,8 +92,20 @@ class FilingsProvider(ABC):
         """
 
     @abstractmethod
-    def get_filing(self, provider_filing_id: str) -> FilingEvent:
+    def get_filing(
+        self,
+        provider_filing_id: str,
+        *,
+        issuer_cik: str | None = None,
+    ) -> FilingEvent:
         """
         Fetch a single filing by its provider-native ID.
         Raises FilingNotFound if the ID does not exist on the provider.
+
+        ``issuer_cik`` (#736) is provider-specific. SEC implementations
+        use it to route the archive URL under the issuer's CIK rather
+        than the filing-of-record CIK (agent-filed accessions like
+        EdgarOnline / GlobeNewswire / Donnelley would otherwise 404).
+        Other providers (Companies House) ignore it because their
+        per-filing endpoint is not CIK-keyed.
         """

--- a/app/providers/implementations/companies_house.py
+++ b/app/providers/implementations/companies_house.py
@@ -105,10 +105,19 @@ class CompaniesHouseFilingsProvider(FilingsProvider):
 
         return _normalise_filings(company_number, raw, start_date, end_date, filing_types)
 
-    def get_filing(self, provider_filing_id: str) -> FilingEvent:
+    def get_filing(
+        self,
+        provider_filing_id: str,
+        *,
+        issuer_cik: str | None = None,  # noqa: ARG002 — protocol uniformity; SEC-only
+    ) -> FilingEvent:
         """
         Fetch a filing by its Companies House transaction ID.
         Raises FilingNotFound if not found (404).
+
+        ``issuer_cik`` is part of the protocol for SEC compatibility
+        (#736) and is ignored here — Companies House filings are
+        keyed on company_number + transaction_id, not CIK.
 
         Note: Companies House filing-history items do not have a stable
         single-document URL in the same way as EDGAR. This method fetches

--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -264,12 +264,28 @@ class SecFilingsProvider(FilingsProvider):
 
         return _normalise_filings(raw, cik_padded, start_date, end_date, filing_types)
 
-    def get_filing(self, provider_filing_id: str) -> FilingEvent:
+    def get_filing(
+        self,
+        provider_filing_id: str,
+        *,
+        issuer_cik: str | None = None,
+    ) -> FilingEvent:
         """
         Fetch metadata for a single filing by accession number.
 
         provider_filing_id is the accession number, e.g. '0000320193-24-000001'.
         Raises FilingNotFound if the accession number cannot be resolved.
+
+        ``issuer_cik`` (#736) routes the archive URL under the issuer's
+        CIK rather than the filing-of-record CIK. SEC accessions filed
+        by registered filing agents (EdgarOnline 1213900, GlobeNewswire
+        1493152, Donnelley 1571049, etc.) prefix the accession number
+        with the agent's CIK; the archive directory always lives under
+        the issuer's CIK. Without this hint every agent-filed accession
+        404s on the legacy fallback path. Callers that have the issuer
+        CIK from ``external_identifiers`` MUST pass it; bare
+        ``get_filing(accession)`` retains the legacy fallback for
+        diagnostic / one-off use.
 
         Does not persist the raw index JSON — every structured field
         from that JSON now lands in ``filing_documents`` via the
@@ -277,7 +293,7 @@ class SecFilingsProvider(FilingsProvider):
         would re-introduce the "body text on disk without a matching
         SQL table" anti-pattern (see docs/review-prevention-log.md).
         """
-        raw = self.fetch_filing_index(provider_filing_id)
+        raw = self.fetch_filing_index(provider_filing_id, issuer_cik=issuer_cik)
         if raw is None:
             raise FilingNotFound(f"Filing not found: {provider_filing_id}")
         return _normalise_filing_event(provider_filing_id, raw)

--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -1801,7 +1801,13 @@ def backfill_filings(
 
     for missing_accession in sorted(fetched_eight_ks - db_eight_ks):
         try:
-            event = provider.get_filing(missing_accession)
+            # Pass the issuer's CIK (#736) so the archive URL routes
+            # under the issuer rather than the filing-of-record. SEC
+            # accessions filed by registered agents (EdgarOnline,
+            # GlobeNewswire, Donnelley etc.) carry the agent's CIK in
+            # the prefix; without this hint every agent-filed 8-K
+            # 404s on the archive index fetch.
+            event = provider.get_filing(missing_accession, issuer_cik=cik_padded)
         except FilingNotFound:
             continue  # SEC deleted between pages; skip.
         except httpx.HTTPError:

--- a/tests/test_filings_backfill.py
+++ b/tests/test_filings_backfill.py
@@ -77,7 +77,12 @@ class FakeSecProvider:
             raise self._resp.page_raises[name]
         return self._resp.pages.get(name)
 
-    def get_filing(self, provider_filing_id: str) -> FilingEvent:
+    def get_filing(
+        self,
+        provider_filing_id: str,
+        *,
+        issuer_cik: str | None = None,  # noqa: ARG002 — protocol uniformity
+    ) -> FilingEvent:
         self.get_filing_calls.append(provider_filing_id)
         if self._resp.get_filing_raises and provider_filing_id in self._resp.get_filing_raises:
             raise self._resp.get_filing_raises[provider_filing_id]

--- a/tests/test_filings_backfill.py
+++ b/tests/test_filings_backfill.py
@@ -63,7 +63,10 @@ class FakeSecProvider:
         self._resp = resp
         self.fetch_submissions_calls: list[str] = []
         self.fetch_page_calls: list[str] = []
-        self.get_filing_calls: list[str] = []
+        # Records (provider_filing_id, issuer_cik) so tests can pin
+        # that callers (e.g. coverage.py 8-K backfill) thread the
+        # CIK hint through correctly — #736 followup.
+        self.get_filing_calls: list[tuple[str, str | None]] = []
 
     def fetch_submissions(self, cik: str) -> dict[str, object] | None:
         self.fetch_submissions_calls.append(cik)
@@ -81,9 +84,9 @@ class FakeSecProvider:
         self,
         provider_filing_id: str,
         *,
-        issuer_cik: str | None = None,  # noqa: ARG002 — protocol uniformity
+        issuer_cik: str | None = None,
     ) -> FilingEvent:
-        self.get_filing_calls.append(provider_filing_id)
+        self.get_filing_calls.append((provider_filing_id, issuer_cik))
         if self._resp.get_filing_raises and provider_filing_id in self._resp.get_filing_raises:
             raise self._resp.get_filing_raises[provider_filing_id]
         if provider_filing_id not in self._resp.filings:
@@ -792,7 +795,13 @@ class TestEightKGap:
             result = backfill_filings(ebull_test_conn, provider, "0000000001", 1)  # type: ignore[arg-type]
 
             assert result.outcome == BackfillOutcome.STILL_INSUFFICIENT_HTTP_ERROR
-            assert provider.get_filing_calls == ["K-26-000100"]
+            # #736 followup: coverage.py threads the issuer's CIK
+            # through to get_filing so the archive URL routes under
+            # the issuer rather than the agent. Pin the keyword
+            # value here too — without this assertion a future
+            # refactor that drops the keyword silently re-introduces
+            # the agent-CIK 404 bug for backfilled 8-Ks.
+            assert provider.get_filing_calls == [("K-26-000100", "0000000001")]
         finally:
             backfill_module._upsert_filing = orig_upsert
 

--- a/tests/test_sec_provider_filing_index.py
+++ b/tests/test_sec_provider_filing_index.py
@@ -154,6 +154,40 @@ def test_filing_index_strips_non_digits_from_issuer_cik() -> None:
     assert "/Archives/edgar/data/320193/" in captured[0].url.path
 
 
+def test_get_filing_threads_issuer_cik_through_to_archive_url() -> None:
+    """Regression for the second wave of #736. ``get_filing`` is the
+    bare-accession entry point used by ``coverage.py`` 8-K backfill;
+    pre-fix it called ``fetch_filing_index`` without forwarding any
+    CIK hint, so the legacy accession-prefix fallback fired and
+    every agent-filed accession 404'd. This pins that the keyword
+    flows through to the URL builder."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200,
+            content=json.dumps(
+                {
+                    "directory": {
+                        "name": "/Archives/edgar/data/19617/000149315226019548",
+                        "item": [],
+                    }
+                }
+            ),
+        )
+
+    provider = SecFilingsProvider(user_agent="test test@example.com")
+    _rewire_tickers_transport(provider, httpx.MockTransport(handler))
+
+    # Accession filed by GlobeNewswire / Issuer Direct (CIK 1493152)
+    # on behalf of issuer CIK 19617. Pre-fix the URL routed under
+    # 1493152 and 404'd; post-fix it routes under the issuer.
+    provider.get_filing("0001493152-26-019548", issuer_cik="0000019617")
+    assert len(captured) == 1
+    assert captured[0].url.path == "/Archives/edgar/data/19617/000149315226019548/index.json"
+
+
 def test_filing_index_legacy_path_still_works_for_self_filers() -> None:
     """Back-compat: callers that don't pass ``issuer_cik`` (e.g.
     bare ``get_filing(accession)`` lookups) keep the legacy


### PR DESCRIPTION
## What

Second wave of the #736 agent-CIK fix. Production logs (2026-05-01 14:52:37) show 5-in-a-row 404s on \`Archives/edgar/data/1493152/...\` + a 1213900-prefixed accession — same root cause as #736, **different call site**.

#736 / PR #745 fixed \`fetch_filing_index\` for the \`filing_documents\` service path I knew about, but \`coverage.py:1804\` calls \`provider.get_filing(accession)\` for 8-K gap reconciliation. \`get_filing\` internally called \`fetch_filing_index\` **without forwarding any CIK hint**, so the legacy accession-prefix fallback fired. For agent-filed accessions the prefix is the agent's CIK; archive lives under issuer.

GlobeNewswire / Issuer Direct (1493152) and EdgarOnline (1213900) are the agents currently producing 404 noise.

## Fix

- \`FilingsProvider.get_filing\` protocol takes optional keyword \`issuer_cik\`.
- \`SecFilingsProvider.get_filing\` forwards to \`fetch_filing_index\`.
- \`CompaniesHouseProvider.get_filing\` accepts but ignores (filings keyed on company_number + transaction_id, not CIK).
- \`coverage.py\` 8-K reconciliation passes \`issuer_cik=cik_padded\` from earlier in the function.

## Why I missed this on PR #745

Honest answer: I grepped \`fetch_filing_index\` callers, found two (\`get_filing\` + \`ingest_filing_documents\`), assumed \`get_filing\`'s docstring "for header metadata" meant ad-hoc/diagnostic only and left the legacy fallback in place. The actual production caller (\`coverage.py\` 8-K backfill) was masked by the more obvious \`ingest_filing_documents\` callsite. Pre-flight grep should have followed every call to \`get_filing\` not just \`fetch_filing_index\`.

To prevent: ran \`grep -rn '\.get_filing('\` across app/scripts/tests and confirmed coverage.py is the sole production caller. Test added pinning that \`get_filing\` threads \`issuer_cik\` through.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pyright\` — clean
- [x] \`uv run pytest tests/test_sec_provider_filing_index.py tests/test_filing_documents_ingest.py\` — 14 passed (1 new regression test using GlobeNewswire CIK 1493152, the actual agent from prod logs)

## Linked

- Closes the GlobeNewswire / 1493152 404 noise reported 2026-05-01.
- Builds on #736 / PR #745 (initial agent-CIK fix on the filing_documents path).