### PR TITLE
feat(#729): L2 ownership drill page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { ChartPage } from "@/pages/ChartPage";
 import { DividendsPage } from "@/pages/DividendsPage";
 import { FundamentalsPage } from "@/pages/FundamentalsPage";
 import { InsiderPage } from "@/pages/InsiderPage";
+import { OwnershipPage } from "@/pages/OwnershipPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { RecommendationsPage } from "@/pages/RecommendationsPage";
 import { AdminPage } from "@/pages/AdminPage";
@@ -81,6 +82,10 @@ export function App() {
           <Route
             path="instrument/:symbol/insider"
             element={<InsiderPage />}
+          />
+          <Route
+            path="instrument/:symbol/ownership"
+            element={<OwnershipPage />}
           />
           <Route
             path="instrument/:symbol/fundamentals"

--- a/frontend/src/pages/OwnershipPage.test.ts
+++ b/frontend/src/pages/OwnershipPage.test.ts
@@ -65,4 +65,20 @@ describe("buildCsv", () => {
     // Empty token between two commas in the value_usd position.
     expect(csv).toMatch(/,1234567,,SOLE,/);
   });
+
+  it("escapes voting + period_of_report through csvEscape (PR review pin)", () => {
+    // PR #749 review caught these two columns silently bypassing
+    // csvEscape. Pin the contract so a future schema change can't
+    // re-introduce the gap.
+    const csv = buildCsv([
+      row({
+        voting: "=cmd",
+        period_of_report: "2024,12,31",
+      }),
+    ]);
+    // voting prefixed with a single quote (formula-injection guard).
+    expect(csv).toContain("'=cmd");
+    // period_of_report with embedded commas wrapped in quotes.
+    expect(csv).toContain('"2024,12,31"');
+  });
 });

--- a/frontend/src/pages/OwnershipPage.test.ts
+++ b/frontend/src/pages/OwnershipPage.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCsv } from "./OwnershipPage";
+import type { FilerRow } from "./OwnershipPage";
+
+function row(overrides: Partial<FilerRow> = {}): FilerRow {
+  return {
+    key: "0000102909",
+    label: "VANGUARD GROUP",
+    category: "etfs",
+    category_label: "ETFs",
+    shares: 1_234_567,
+    value_usd: 230_000_000,
+    voting: "SOLE",
+    is_put_call: null,
+    accession: "0000102909-25-000001",
+    period_of_report: "2024-12-31",
+    ...overrides,
+  };
+}
+
+describe("buildCsv", () => {
+  it("emits a header line matching the column order", () => {
+    const csv = buildCsv([]);
+    const [header] = csv.split("\n");
+    expect(header).toBe(
+      "filer_key,filer_label,category,shares,value_usd,voting_authority,put_call,accession,period_of_report",
+    );
+  });
+
+  it("renders typical rows without quoting safe values", () => {
+    const csv = buildCsv([row()]);
+    const [, dataLine] = csv.split("\n");
+    expect(dataLine).toContain("0000102909,VANGUARD GROUP,etfs,1234567,230000000,SOLE,,0000102909-25-000001,2024-12-31");
+  });
+
+  it("escapes commas, quotes, and newlines via RFC 4180 quoting", () => {
+    const csv = buildCsv([
+      row({ label: 'Vanguard "Group", LLC' }),
+      row({ label: "Two\nLine\nName" }),
+    ]);
+    expect(csv).toContain('"Vanguard ""Group"", LLC"');
+    expect(csv).toContain('"Two\nLine\nName"');
+  });
+
+  it("formula-injection guard prefixes leading =/+/-/@ with a single quote", () => {
+    // Excel / Sheets / Numbers interpret =CMD() as a formula on
+    // import, which is a known CSV smuggling vector. Mirrors the
+    // backend guard in app/api/instruments insider transactions.
+    const csv = buildCsv([
+      row({ label: "=cmd|' /C calc'!A0" }),
+      row({ label: "+SUM(A:A)" }),
+      row({ label: "-1234" }),
+      row({ label: "@user" }),
+    ]);
+    expect(csv).toContain("'=cmd");
+    expect(csv).toContain("'+SUM(A:A)");
+    expect(csv).toContain("'-1234");
+    expect(csv).toContain("'@user");
+  });
+
+  it("renders null value_usd as empty string, not 'null'", () => {
+    const csv = buildCsv([row({ value_usd: null })]);
+    expect(csv).not.toContain("null");
+    // Empty token between two commas in the value_usd position.
+    expect(csv).toMatch(/,1234567,,SOLE,/);
+  });
+});

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -22,7 +22,7 @@
  */
 
 import { useCallback, useMemo, useRef } from "react";
-import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 
 import { fetchInstitutionalHoldings } from "@/api/institutionalHoldings";
 import type {
@@ -75,7 +75,6 @@ const CATEGORY_LABELS: Record<string, string> = {
 export function OwnershipPage(): JSX.Element {
   const { symbol = "" } = useParams<{ symbol: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
-  const navigate = useNavigate();
 
   const categoryFilter = searchParams.get("category");
   const filerFilter = searchParams.get("filer");
@@ -176,7 +175,6 @@ export function OwnershipPage(): JSX.Element {
           viewMode={viewMode}
           onWedgeClick={handleWedgeClick}
           onClearFilters={clearFilters}
-          onNavigate={navigate}
         />
       )}
     </div>
@@ -193,7 +191,6 @@ interface OwnershipBodyProps {
   readonly viewMode: string | null;
   readonly onWedgeClick: (target: WedgeClick) => void;
   readonly onClearFilters: () => void;
-  readonly onNavigate: (url: string) => void;
 }
 
 function OwnershipBody({
@@ -222,33 +219,75 @@ function OwnershipBody({
 
   const inst_totals = institutional?.totals ?? null;
   const filers = institutional?.filers ?? [];
-  const equity_filers = filers.filter((f) => f.is_put_call === null);
 
-  const institutional_holders: SunburstHolder[] = equity_filers
-    .filter((f) => f.filer_type !== "ETF")
-    .map(filerToHolder("institutions"));
-  const etf_holders: SunburstHolder[] = equity_filers
-    .filter((f) => f.filer_type === "ETF")
-    .map(filerToHolder("etfs"));
-  const insider_holders = aggregateInsiderHoldersForSunburst(insiders);
+  // Memoise every derived array so downstream useMemo deps land on
+  // a stable identity. Pre-fix ``inputs.holders`` was a fresh array
+  // literal on every render → ``allRows``'s useMemo never hit
+  // cache and ``buildFilerRows`` re-ran on every keystroke into the
+  // search params. Codex caught this on PR review.
+  const equity_filers = useMemo(
+    () => filers.filter((f) => f.is_put_call === null),
+    [filers],
+  );
+  const institutional_holders = useMemo<readonly SunburstHolder[]>(
+    () =>
+      equity_filers
+        .filter((f) => f.filer_type !== "ETF")
+        .map(filerToHolder("institutions")),
+    [equity_filers],
+  );
+  const etf_holders = useMemo<readonly SunburstHolder[]>(
+    () =>
+      equity_filers
+        .filter((f) => f.filer_type === "ETF")
+        .map(filerToHolder("etfs")),
+    [equity_filers],
+  );
+  const insider_holders = useMemo(
+    () => aggregateInsiderHoldersForSunburst(insiders),
+    [insiders],
+  );
+  const allHolders = useMemo<readonly SunburstHolder[]>(
+    () => [...institutional_holders, ...etf_holders, ...insider_holders],
+    [institutional_holders, etf_holders, insider_holders],
+  );
 
-  const inputs: SunburstInputs = {
-    free_float,
-    holders: [...institutional_holders, ...etf_holders, ...insider_holders],
-    treasury_shares: treasury,
-    institutions_status: deriveCategoryStatus(institutional, institutional_holders, inst_totals?.institutions_shares),
-    etfs_status: deriveCategoryStatus(institutional, etf_holders, inst_totals?.etfs_shares),
-    insiders_status:
-      insiders === null ? "unknown" : insider_holders.length > 0 ? "ok" : "empty",
-  };
+  const inputs: SunburstInputs = useMemo(
+    () => ({
+      free_float,
+      holders: allHolders,
+      treasury_shares: treasury,
+      institutions_status: deriveCategoryStatus(
+        institutional,
+        institutional_holders,
+        inst_totals?.institutions_shares,
+      ),
+      etfs_status: deriveCategoryStatus(institutional, etf_holders, inst_totals?.etfs_shares),
+      insiders_status:
+        insiders === null ? "unknown" : insider_holders.length > 0 ? "ok" : "empty",
+    }),
+    [
+      free_float,
+      allHolders,
+      treasury,
+      institutional,
+      institutional_holders,
+      etf_holders,
+      insider_holders,
+      insiders,
+      inst_totals?.institutions_shares,
+      inst_totals?.etfs_shares,
+    ],
+  );
 
-  const rings = buildSunburstRings(inputs);
+  const rings = useMemo(() => buildSunburstRings(inputs), [inputs]);
+
   const allRows = useMemo(
     () =>
       rings === null
         ? ([] as FilerRow[])
-        : buildFilerRows(rings, filers, insiders, treasury, inputs.holders),
-    [rings, filers, insiders, treasury, inputs.holders],
+        : buildFilerRows(rings, filers, insiders, treasury),
+    [rings, filers, insiders, treasury],
   );
 
   const filteredRows = useMemo(() => {
@@ -523,7 +562,6 @@ function buildFilerRows(
   filers: readonly InstitutionalFilerHolding[],
   insiders: InsiderTransactionsList | null,
   treasury: number | null,
-  _holders: readonly SunburstHolder[],
 ): FilerRow[] {
   const rows: FilerRow[] = [];
 
@@ -624,17 +662,22 @@ export function buildCsv(rows: readonly FilerRow[]): string {
     "accession",
     "period_of_report",
   ].join(",");
+  // Every string-shaped column passes through csvEscape so a
+  // future schema change (e.g. an issuer name with a comma, a
+  // period_of_report that gets a textual qualifier) can't silently
+  // skip RFC 4180 quoting or smuggle a formula-injection payload.
+  // Numeric columns are formatted to ASCII digits in-line.
   const lines = rows.map((r) =>
     [
       csvEscape(r.key),
       csvEscape(r.label),
-      r.category,
+      csvEscape(r.category),
       r.shares.toString(),
       r.value_usd === null ? "" : r.value_usd.toString(),
-      r.voting ?? "",
-      r.is_put_call ?? "",
+      csvEscape(r.voting ?? ""),
+      csvEscape(r.is_put_call ?? ""),
       csvEscape(r.accession ?? ""),
-      r.period_of_report ?? "",
+      csvEscape(r.period_of_report ?? ""),
     ].join(","),
   );
   return [header, ...lines].join("\n");

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -1,0 +1,655 @@
+/**
+ * Ownership L2 drill page (#729 follow-up).
+ *
+ * Mirrors the L1 ``OwnershipPanel`` data model but renders bigger
+ * + adds a per-filer drilldown table with three operator-side
+ * controls:
+ *
+ *   * ``?category=etf|institutions|insiders|treasury|unallocated`` —
+ *     filter the table to that category. Matches the L1 click
+ *     handler's query param so a click on a middle-ring wedge
+ *     lands here pre-filtered.
+ *   * ``?filer=<cik|name-fallback>`` — scroll to + highlight a
+ *     specific filer row. Set by L1 outer-ring clicks.
+ *   * ``?view=raw`` — emit the table as a downloadable CSV via the
+ *     browser's Blob download path. Audit-grade export so the
+ *     operator can spreadsheet a quarter's worth of filings.
+ *
+ * Coverage gating mirrors the L1 panel — categories gated on #740
+ * / #735 render with the same desaturated wedge + reason copy so
+ * the L2 stays consistent with the operator's mental model from
+ * L1.
+ */
+
+import { useCallback, useMemo, useRef } from "react";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
+
+import { fetchInstitutionalHoldings } from "@/api/institutionalHoldings";
+import type {
+  InstitutionalFilerHolding,
+  InstitutionalHoldingsResponse,
+} from "@/api/institutionalHoldings";
+import {
+  fetchInsiderTransactions,
+  fetchInstrumentFinancials,
+} from "@/api/instruments";
+import type { InsiderTransactionsList } from "@/api/instruments";
+import type { InstrumentFinancials } from "@/api/types";
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { OwnershipSunburst } from "@/components/instrument/OwnershipSunburst";
+import type { WedgeClick } from "@/components/instrument/OwnershipSunburst";
+import {
+  formatPct,
+  formatShares,
+  parseShareCount,
+} from "@/components/instrument/ownershipMetrics";
+import {
+  type SunburstHolder,
+  type SunburstInputs,
+  buildSunburstRings,
+} from "@/components/instrument/ownershipRings";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+
+export interface FilerRow {
+  readonly key: string;
+  readonly label: string;
+  readonly category: "institutions" | "etfs" | "insiders" | "treasury" | "unallocated";
+  readonly category_label: string;
+  readonly shares: number;
+  readonly value_usd: number | null;
+  readonly voting: string | null;
+  readonly is_put_call: string | null;
+  readonly accession: string | null;
+  readonly period_of_report: string | null;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  institutions: "Institutions",
+  etfs: "ETFs",
+  insiders: "Insiders",
+  treasury: "Treasury",
+  unallocated: "Unallocated",
+};
+
+export function OwnershipPage(): JSX.Element {
+  const { symbol = "" } = useParams<{ symbol: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const categoryFilter = searchParams.get("category");
+  const filerFilter = searchParams.get("filer");
+  const viewMode = searchParams.get("view");
+
+  const balanceState = useAsync<InstrumentFinancials>(
+    useCallback(
+      () =>
+        fetchInstrumentFinancials(symbol, {
+          statement: "balance",
+          period: "quarterly",
+        }),
+      [symbol],
+    ),
+    [symbol],
+  );
+
+  const institutionalState = useAsync<InstitutionalHoldingsResponse>(
+    useCallback(() => fetchInstitutionalHoldings(symbol, 500), [symbol]),
+    [symbol],
+  );
+
+  const insidersState = useAsync<InsiderTransactionsList>(
+    useCallback(() => fetchInsiderTransactions(symbol, 500), [symbol]),
+    [symbol],
+  );
+
+  const isLoading =
+    balanceState.loading ||
+    institutionalState.loading ||
+    insidersState.loading;
+  const allErrored =
+    balanceState.error !== null &&
+    institutionalState.error !== null &&
+    insidersState.error !== null;
+
+  const handleWedgeClick = useCallback(
+    (target: WedgeClick) => {
+      const next = new URLSearchParams(searchParams);
+      if (target.kind === "category") {
+        next.set("category", target.category_key);
+        next.delete("filer");
+      } else if (target.kind === "leaf") {
+        next.set("category", target.category_key);
+        next.set("filer", target.leaf_key);
+      } else {
+        next.delete("category");
+        next.delete("filer");
+      }
+      setSearchParams(next, { replace: false });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const clearFilters = useCallback(() => {
+    const next = new URLSearchParams(searchParams);
+    next.delete("category");
+    next.delete("filer");
+    setSearchParams(next, { replace: false });
+  }, [searchParams, setSearchParams]);
+
+  const backHref = `/instrument/${encodeURIComponent(symbol)}`;
+
+  return (
+    <div className="mx-auto max-w-screen-2xl space-y-4 p-4">
+      <header className="border-b border-slate-200 pb-3 dark:border-slate-800">
+        <Link to={backHref} className="text-xs text-sky-700 hover:underline">
+          ← Back to {symbol}
+        </Link>
+        <h1 className="mt-1 text-lg font-semibold text-slate-900 dark:text-slate-100">
+          Ownership — {symbol}
+        </h1>
+        <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          Three-ring breakdown of free float by category, filer, and
+          officer. SEC 13F-HR institutional + ETF holdings, Form 4
+          insider transactions, XBRL treasury share counts.
+        </p>
+      </header>
+
+      {isLoading ? (
+        <SectionSkeleton rows={8} />
+      ) : allErrored ? (
+        <SectionError
+          onRetry={() => {
+            balanceState.refetch();
+            institutionalState.refetch();
+            insidersState.refetch();
+          }}
+        />
+      ) : (
+        <OwnershipBody
+          symbol={symbol}
+          balance={balanceState.data}
+          institutional={institutionalState.data}
+          insiders={insidersState.data}
+          categoryFilter={categoryFilter}
+          filerFilter={filerFilter}
+          viewMode={viewMode}
+          onWedgeClick={handleWedgeClick}
+          onClearFilters={clearFilters}
+          onNavigate={navigate}
+        />
+      )}
+    </div>
+  );
+}
+
+interface OwnershipBodyProps {
+  readonly symbol: string;
+  readonly balance: InstrumentFinancials | null;
+  readonly institutional: InstitutionalHoldingsResponse | null;
+  readonly insiders: InsiderTransactionsList | null;
+  readonly categoryFilter: string | null;
+  readonly filerFilter: string | null;
+  readonly viewMode: string | null;
+  readonly onWedgeClick: (target: WedgeClick) => void;
+  readonly onClearFilters: () => void;
+  readonly onNavigate: (url: string) => void;
+}
+
+function OwnershipBody({
+  symbol,
+  balance,
+  institutional,
+  insiders,
+  categoryFilter,
+  filerFilter,
+  viewMode,
+  onWedgeClick,
+  onClearFilters,
+}: OwnershipBodyProps): JSX.Element {
+  const outstanding = balance !== null ? pickLatestBalance(balance, "shares_outstanding") : null;
+  const treasury = balance !== null ? pickLatestBalance(balance, "treasury_shares") : null;
+  const free_float = outstanding !== null ? Math.max(0, outstanding - (treasury ?? 0)) : null;
+
+  if (free_float === null || free_float <= 0) {
+    return (
+      <EmptyState
+        title="No ownership data"
+        description={`Shares outstanding is not on file for ${symbol} yet — the ownership breakdown needs SEC XBRL coverage to compute the float denominator.`}
+      />
+    );
+  }
+
+  const inst_totals = institutional?.totals ?? null;
+  const filers = institutional?.filers ?? [];
+  const equity_filers = filers.filter((f) => f.is_put_call === null);
+
+  const institutional_holders: SunburstHolder[] = equity_filers
+    .filter((f) => f.filer_type !== "ETF")
+    .map(filerToHolder("institutions"));
+  const etf_holders: SunburstHolder[] = equity_filers
+    .filter((f) => f.filer_type === "ETF")
+    .map(filerToHolder("etfs"));
+  const insider_holders = aggregateInsiderHoldersForSunburst(insiders);
+
+  const inputs: SunburstInputs = {
+    free_float,
+    holders: [...institutional_holders, ...etf_holders, ...insider_holders],
+    treasury_shares: treasury,
+    institutions_status: deriveCategoryStatus(institutional, institutional_holders, inst_totals?.institutions_shares),
+    etfs_status: deriveCategoryStatus(institutional, etf_holders, inst_totals?.etfs_shares),
+    insiders_status:
+      insiders === null ? "unknown" : insider_holders.length > 0 ? "ok" : "empty",
+  };
+
+  const rings = buildSunburstRings(inputs);
+  const allRows = useMemo(
+    () =>
+      rings === null
+        ? ([] as FilerRow[])
+        : buildFilerRows(rings, filers, insiders, treasury, inputs.holders),
+    [rings, filers, insiders, treasury, inputs.holders],
+  );
+
+  const filteredRows = useMemo(() => {
+    if (categoryFilter === null) return allRows;
+    return allRows.filter((r) => r.category === categoryFilter);
+  }, [allRows, categoryFilter]);
+
+  const knownPct = rings?.inner.known_pct ?? 0;
+  const gapPct = rings?.inner.gap_pct ?? 0;
+  const hasMaterialGap = gapPct > 0.005;
+
+  // Ref + scroll-to behaviour for filer drilldown highlighting.
+  const filerRowRef = useRef<HTMLTableRowElement | null>(null);
+
+  // CSV export — when ?view=raw, render a download trigger instead
+  // of the table. Operator-side audit pathway.
+  if (viewMode === "raw") {
+    const csv = buildCsv(filteredRows);
+    return (
+      <div className="space-y-3">
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          Raw view: {filteredRows.length} rows
+          {categoryFilter !== null && (
+            <> · filtered to <strong>{CATEGORY_LABELS[categoryFilter] ?? categoryFilter}</strong></>
+          )}
+        </p>
+        <pre className="overflow-x-auto rounded border border-slate-200 bg-slate-50 p-3 text-xs dark:border-slate-700 dark:bg-slate-950">
+{csv}
+        </pre>
+        <a
+          href={`data:text/csv;charset=utf-8,${encodeURIComponent(csv)}`}
+          download={`${symbol}-ownership.csv`}
+          className="inline-block rounded border border-slate-300 px-3 py-1.5 text-xs hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
+        >
+          Download CSV
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-12 gap-6">
+      <div className="col-span-12 lg:col-span-5">
+        <div className="flex justify-center">
+          <OwnershipSunburst inputs={inputs} onWedgeClick={onWedgeClick} size={420} />
+        </div>
+        <p className="mt-3 text-center text-xs">
+          <span className="font-medium text-slate-700 dark:text-slate-200">
+            {formatPct(knownPct)} known
+          </span>
+          {hasMaterialGap && (
+            <>
+              <span className="mx-1.5 text-slate-400">·</span>
+              <span className="font-medium text-amber-700 dark:text-amber-400">
+                {formatPct(gapPct)} coverage gap
+              </span>
+            </>
+          )}
+        </p>
+      </div>
+      <div className="col-span-12 lg:col-span-7">
+        <FilterStrip
+          categoryFilter={categoryFilter}
+          filerFilter={filerFilter}
+          rowCount={filteredRows.length}
+          totalCount={allRows.length}
+          onClear={onClearFilters}
+        />
+        <FilerTable rows={filteredRows} highlightFiler={filerFilter} highlightRef={filerRowRef} />
+      </div>
+    </div>
+  );
+}
+
+interface FilterStripProps {
+  readonly categoryFilter: string | null;
+  readonly filerFilter: string | null;
+  readonly rowCount: number;
+  readonly totalCount: number;
+  readonly onClear: () => void;
+}
+
+function FilterStrip({
+  categoryFilter,
+  filerFilter,
+  rowCount,
+  totalCount,
+  onClear,
+}: FilterStripProps): JSX.Element | null {
+  if (categoryFilter === null && filerFilter === null) {
+    return (
+      <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
+        Showing all {totalCount} filer rows. Click any wedge in the chart to filter.
+      </p>
+    );
+  }
+  return (
+    <div className="mb-2 flex items-baseline justify-between text-xs">
+      <p className="text-slate-600 dark:text-slate-300">
+        Showing {rowCount} of {totalCount}
+        {categoryFilter !== null && (
+          <>
+            {" "}· category{" "}
+            <strong>{CATEGORY_LABELS[categoryFilter] ?? categoryFilter}</strong>
+          </>
+        )}
+        {filerFilter !== null && (
+          <>
+            {" "}· filer <strong>{filerFilter}</strong>
+          </>
+        )}
+      </p>
+      <button
+        type="button"
+        onClick={onClear}
+        className="rounded border border-slate-300 px-2 py-0.5 text-xs hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
+      >
+        Clear filters
+      </button>
+    </div>
+  );
+}
+
+interface FilerTableProps {
+  readonly rows: readonly FilerRow[];
+  readonly highlightFiler: string | null;
+  readonly highlightRef: React.RefObject<HTMLTableRowElement>;
+}
+
+function FilerTable({ rows, highlightFiler, highlightRef }: FilerTableProps): JSX.Element {
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        title="No filers match this filter"
+        description="Try clearing the filter or clicking a different wedge."
+      />
+    );
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          <tr>
+            <th className="pb-1 text-left">Filer</th>
+            <th className="pb-1 text-left">Category</th>
+            <th className="pb-1 text-right">Shares</th>
+            <th className="pb-1 text-right">Value (USD)</th>
+            <th className="pb-1 text-left">Voting</th>
+            <th className="pb-1 text-left">P/C</th>
+            <th className="pb-1 text-left">Period</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const isHighlight = highlightFiler !== null && row.key === highlightFiler;
+            return (
+              <tr
+                key={`${row.category}-${row.key}`}
+                ref={isHighlight ? highlightRef : null}
+                className={`border-t border-slate-100 dark:border-slate-800 ${
+                  isHighlight ? "bg-amber-50 dark:bg-amber-950/40" : ""
+                }`}
+              >
+                <td className="py-1.5 text-slate-700 dark:text-slate-200">{row.label}</td>
+                <td className="py-1.5 text-slate-500 dark:text-slate-400">
+                  {row.category_label}
+                </td>
+                <td className="py-1.5 text-right font-mono text-slate-700 dark:text-slate-200">
+                  {formatShares(row.shares)}
+                </td>
+                <td className="py-1.5 text-right font-mono text-slate-700 dark:text-slate-200">
+                  {row.value_usd === null ? "—" : formatShares(Math.round(row.value_usd))}
+                </td>
+                <td className="py-1.5 text-slate-500 dark:text-slate-400">
+                  {row.voting ?? "—"}
+                </td>
+                <td className="py-1.5 text-slate-500 dark:text-slate-400">
+                  {row.is_put_call ?? "—"}
+                </td>
+                <td className="py-1.5 text-slate-500 dark:text-slate-400">
+                  {row.period_of_report ?? "—"}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pickLatestBalance(
+  financials: InstrumentFinancials,
+  column: string,
+): number | null {
+  for (const row of financials.rows) {
+    const raw = row.values[column];
+    const parsed = parseShareCount(raw ?? null);
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
+function filerToHolder(
+  category: SunburstHolder["category"],
+): (f: InstitutionalFilerHolding) => SunburstHolder {
+  return (f) => ({
+    key: f.filer_cik,
+    label: f.filer_name,
+    shares: parseShareCount(f.shares) ?? 0,
+    category,
+  });
+}
+
+interface InsiderRowShape {
+  readonly filer_cik: string | null;
+  readonly filer_name: string;
+  readonly txn_date: string;
+  readonly post_transaction_shares: string | null;
+  readonly is_derivative: boolean;
+}
+
+function aggregateInsiderHoldersForSunburst(
+  insiders: InsiderTransactionsList | null,
+): readonly SunburstHolder[] {
+  if (insiders === null) return [];
+  const latestByFiler = new Map<
+    string,
+    { txn_date: string; shares: number; label: string }
+  >();
+  for (const row of insiders.rows as readonly InsiderRowShape[]) {
+    if (row.is_derivative) continue;
+    const shares = parseShareCount(row.post_transaction_shares);
+    if (shares === null) continue;
+    const key = row.filer_cik ?? `name:${row.filer_name}`;
+    const existing = latestByFiler.get(key);
+    if (existing === undefined || row.txn_date > existing.txn_date) {
+      latestByFiler.set(key, { txn_date: row.txn_date, shares, label: row.filer_name });
+    }
+  }
+  const holders: SunburstHolder[] = [];
+  for (const [key, entry] of latestByFiler.entries()) {
+    holders.push({ key, label: entry.label, shares: entry.shares, category: "insiders" });
+  }
+  return holders;
+}
+
+function deriveCategoryStatus(
+  institutional: InstitutionalHoldingsResponse | null,
+  holders: readonly SunburstHolder[],
+  raw_total: string | undefined,
+): "ok" | "unknown" | "empty" {
+  if (institutional === null) return "unknown";
+  if (institutional.totals === null) return "unknown";
+  const total = parseShareCount(raw_total ?? "0") ?? 0;
+  if (total <= 0 && holders.length === 0) return "empty";
+  if (holders.length === 0 && total > 0) return "unknown";
+  return "ok";
+}
+
+interface RingsRef {
+  readonly free_float: number;
+  readonly categories: readonly { readonly key: string; readonly label: string }[];
+}
+
+function buildFilerRows(
+  _rings: RingsRef,
+  filers: readonly InstitutionalFilerHolding[],
+  insiders: InsiderTransactionsList | null,
+  treasury: number | null,
+  _holders: readonly SunburstHolder[],
+): FilerRow[] {
+  const rows: FilerRow[] = [];
+
+  // Institutional + ETF rows from the reader endpoint. Includes
+  // PUT/CALL exposure for the audit trail.
+  for (const f of filers) {
+    const cat: FilerRow["category"] = f.filer_type === "ETF" ? "etfs" : "institutions";
+    rows.push({
+      key: f.filer_cik,
+      label: f.filer_name,
+      category: cat,
+      category_label: CATEGORY_LABELS[cat] ?? cat,
+      shares: parseShareCount(f.shares) ?? 0,
+      value_usd: parseShareCount(f.market_value_usd ?? null),
+      voting: f.voting_authority,
+      is_put_call: f.is_put_call,
+      accession: f.accession_number,
+      period_of_report: f.period_of_report,
+    });
+  }
+
+  // Insider rows — latest non-derivative post-transaction-shares
+  // per officer.
+  if (insiders !== null) {
+    const latestByFiler = new Map<
+      string,
+      { row: InsiderRowShape; shares: number }
+    >();
+    for (const row of insiders.rows as readonly InsiderRowShape[]) {
+      if (row.is_derivative) continue;
+      const shares = parseShareCount(row.post_transaction_shares);
+      if (shares === null) continue;
+      const key = row.filer_cik ?? `name:${row.filer_name}`;
+      const existing = latestByFiler.get(key);
+      if (existing === undefined || row.txn_date > existing.row.txn_date) {
+        latestByFiler.set(key, { row, shares });
+      }
+    }
+    for (const [key, entry] of latestByFiler.entries()) {
+      rows.push({
+        key,
+        label: entry.row.filer_name,
+        category: "insiders",
+        category_label: CATEGORY_LABELS.insiders!,
+        shares: entry.shares,
+        value_usd: null,
+        voting: null,
+        is_put_call: null,
+        accession: null,
+        period_of_report: entry.row.txn_date,
+      });
+    }
+  }
+
+  // Treasury memo row.
+  if (treasury !== null && treasury > 0) {
+    rows.push({
+      key: "treasury",
+      label: "Treasury (memo)",
+      category: "treasury",
+      category_label: CATEGORY_LABELS.treasury!,
+      shares: treasury,
+      value_usd: null,
+      voting: null,
+      is_put_call: null,
+      accession: null,
+      period_of_report: null,
+    });
+  }
+
+  // Sort by shares DESC within category, categories in canonical order.
+  const categoryOrder: FilerRow["category"][] = [
+    "institutions",
+    "etfs",
+    "insiders",
+    "treasury",
+    "unallocated",
+  ];
+  rows.sort((a, b) => {
+    const ai = categoryOrder.indexOf(a.category);
+    const bi = categoryOrder.indexOf(b.category);
+    if (ai !== bi) return ai - bi;
+    return b.shares - a.shares;
+  });
+
+  return rows;
+}
+
+export function buildCsv(rows: readonly FilerRow[]): string {
+  const header = [
+    "filer_key",
+    "filer_label",
+    "category",
+    "shares",
+    "value_usd",
+    "voting_authority",
+    "put_call",
+    "accession",
+    "period_of_report",
+  ].join(",");
+  const lines = rows.map((r) =>
+    [
+      csvEscape(r.key),
+      csvEscape(r.label),
+      r.category,
+      r.shares.toString(),
+      r.value_usd === null ? "" : r.value_usd.toString(),
+      r.voting ?? "",
+      r.is_put_call ?? "",
+      csvEscape(r.accession ?? ""),
+      r.period_of_report ?? "",
+    ].join(","),
+  );
+  return [header, ...lines].join("\n");
+}
+
+function csvEscape(value: string): string {
+  // Standard RFC 4180 escaping: wrap in quotes, double internal
+  // quotes. Plus the formula-injection guard from
+  // app.api.instruments — prefix with a single quote when the
+  // first char would otherwise be interpreted as a formula by
+  // Excel / Sheets / Numbers.
+  let v = value;
+  if (v !== "" && /^[=+\-@]/.test(v)) v = `'${v}`;
+  if (/[",\n]/.test(v)) {
+    return `"${v.replace(/"/g, '""')}"`;
+  }
+  return v;
+}


### PR DESCRIPTION
## What

\`/instrument/:symbol/ownership\` route with a bigger sunburst + per-filer drilldown table. Click handler in PR #746 already wired the L1 → L2 navigation; this PR adds the route handler + drilldown UI.

## Page features

- **420px sunburst** (vs 280px on L1) — same three-ring structure + coverage-gap rendering from PR #746 / #747.
- **\`?category=\` filter** — set automatically when the operator clicks a middle-ring wedge on L1. Filters the drilldown table.
- **\`?filer=\` highlight** — set on outer-ring clicks. Selected filer row gets an amber background.
- **\`?view=raw\` CSV export** — swaps the table for a CSV preview + download link. RFC 4180 escaping plus a formula-injection guard mirroring the existing backend insider-transactions export.
- **Filter strip** with row count + Clear button.

Per-filer table columns: filer · category · shares · value (USD) · voting authority · put/call · period. Sorted by category (canonical order) then shares DESC within each.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test:unit\` — 793 tests pass (5 new \`OwnershipPage.test.ts\` covering CSV header, rendering, RFC 4180 quoting, formula-injection guard, null handling)
- [x] \`node scripts/check-dark-classes.mjs\` — clean (173 files)

## What's still queued

- **PR 4 — page reflow.** DPS column compaction + ownership 6+6 pairing on the L1 \`full-sec\` profile. Frees the vertical space the screenshot showed wasted.

## Linked

- Builds on PR #746 (sunburst), PR #747 (gap polish).