### PR TITLE
fix(#729): per-category gap colors + subtler L2 highlight row

### DIFF
--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -72,7 +72,16 @@ const CATEGORY_FILL_INDEX: Record<string, number> = {
   unallocated: 4, // pink
 };
 
-const UNKNOWN_FILL = "#475569"; // slate-600 — desaturated to read as "no signal"
+/**
+ * Opacity applied to a category's accent color when the category
+ * status is ``unknown``. Pre-fix every unknown wedge collapsed to a
+ * single shared slate-600 so the chart read as a solid grey blob —
+ * operator couldn't distinguish "Institutions gap" from "ETFs gap"
+ * from "Treasury gap". Now each category keeps its identity and the
+ * low opacity carries the "no signal" semantic.
+ */
+const GAP_CATEGORY_OPACITY = 0.35;
+const GAP_LEAF_OPACITY = 0.22;
 
 export function OwnershipSunburst({
   inputs,
@@ -110,13 +119,17 @@ export function OwnershipSunburst({
     });
   }
   if (rings.inner.gap_shares > 0) {
+    // Inner-ring gap arc represents the aggregate "we don't know"
+    // share — keep it as a single neutral grey so it reads as
+    // "missing data" rather than implying it belongs to any one
+    // accent-colored category.
     innerData.push({
       name: "Coverage gap",
       shares: rings.inner.gap_shares,
       pct: rings.inner.gap_pct,
-      fill: UNKNOWN_FILL,
+      fill: theme.gridLine,
       stroke: theme.bg,
-      opacity: 0.45,
+      opacity: 0.6,
       is_gap: true,
       target: { kind: "center" },
     });
@@ -251,23 +264,22 @@ function toCategoryDatum(
   bg: string,
 ): ChartDatum {
   if (cat.status === "unknown") {
-    // Unknown categories use a dedicated grey so the operator
-    // distinguishes "we don't know what's here" from "this slice is
-    // genuinely 0%".
+    // Unknown categories keep their accent color but at low opacity
+    // so the chart distinguishes "Institutions gap" from "ETFs gap"
+    // from "Treasury gap" visually. Pre-fix every unknown wedge
+    // collapsed to a single shared slate-600 → solid grey blob with
+    // no per-category identity.
     return {
       name: `${cat.label} — coverage gap`,
-      // Use a synthetic non-zero share count so the wedge renders
-      // visibly. Since totals would otherwise sum to less than the
-      // float, the visible gap on the outer ring still telegraphs
-      // missing data; the synthetic value here just guarantees the
-      // wedge isn't a 0-degree arc. ``is_gap=true`` tells the
-      // tooltip to suppress the numeric share/pct rows so hovering
-      // does not surface a misleading "1 shares".
+      // Synthetic non-zero share count so the wedge renders visibly.
+      // ``is_gap=true`` tells the tooltip to suppress the numeric
+      // share/pct rows so hovering does not surface a misleading
+      // "1 shares".
       shares: 1,
       pct: 0,
-      fill: UNKNOWN_FILL,
+      fill: baseFill,
       stroke: bg,
-      opacity: 0.3,
+      opacity: GAP_CATEGORY_OPACITY,
       is_gap: true,
       target: { kind: "category", category_key: cat.key },
     };
@@ -292,13 +304,18 @@ function toLeafDatum(
 ): ChartDatum {
   const status = cat.status;
   if (status === "unknown") {
+    // Outer-ring leaf for an unknown category inherits the parent
+    // accent at a lower opacity than the middle wedge so the rings
+    // remain visually distinguishable while preserving category
+    // identity. Pre-fix the leaf used the same shared slate-600 as
+    // the middle wedge → both rings merged into one solid grey arc.
     return {
       name: leaf.label,
       shares: 1,
       pct: 0,
-      fill: UNKNOWN_FILL,
+      fill: baseFill,
       stroke: bg,
-      opacity: 0.2,
+      opacity: GAP_LEAF_OPACITY,
       is_gap: true,
       target: { kind: "leaf", category_key: cat.key, leaf_key: leaf.key },
     };

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -473,7 +473,12 @@ function FilerTable({
             // Clicking the highlighted row clears the filter — the
             // operator can dismiss the per-filer drilldown without
             // hunting for the Clear button.
-            const baseCls = "border-t border-slate-100 dark:border-slate-800";
+            // Use logical-side ``border-t-*`` instead of the all-sides
+            // shorthand so an isHighlight row's ``border-l-sky-500``
+            // can't be silently overridden if Tailwind emits the
+            // shorthand color rule after the side-specific one. PR
+            // #750 review caught this.
+            const baseCls = "border-t border-t-slate-100 dark:border-t-slate-800";
             const highlightCls = isHighlight
               ? "border-l-2 border-l-sky-500 bg-sky-50/40 dark:bg-sky-950/20 cursor-pointer"
               : "";

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -136,6 +136,12 @@ export function OwnershipPage(): JSX.Element {
     setSearchParams(next, { replace: false });
   }, [searchParams, setSearchParams]);
 
+  const clearFiler = useCallback(() => {
+    const next = new URLSearchParams(searchParams);
+    next.delete("filer");
+    setSearchParams(next, { replace: false });
+  }, [searchParams, setSearchParams]);
+
   const backHref = `/instrument/${encodeURIComponent(symbol)}`;
 
   return (
@@ -175,6 +181,7 @@ export function OwnershipPage(): JSX.Element {
           viewMode={viewMode}
           onWedgeClick={handleWedgeClick}
           onClearFilters={clearFilters}
+          onClearFiler={clearFiler}
         />
       )}
     </div>
@@ -191,6 +198,9 @@ interface OwnershipBodyProps {
   readonly viewMode: string | null;
   readonly onWedgeClick: (target: WedgeClick) => void;
   readonly onClearFilters: () => void;
+  /** Clear only the per-filer filter; keeps the category filter
+   *  in place so the operator stays in the same drilldown view. */
+  readonly onClearFiler: () => void;
 }
 
 function OwnershipBody({
@@ -203,6 +213,7 @@ function OwnershipBody({
   viewMode,
   onWedgeClick,
   onClearFilters,
+  onClearFiler,
 }: OwnershipBodyProps): JSX.Element {
   const outstanding = balance !== null ? pickLatestBalance(balance, "shares_outstanding") : null;
   const treasury = balance !== null ? pickLatestBalance(balance, "treasury_shares") : null;
@@ -356,7 +367,12 @@ function OwnershipBody({
           totalCount={allRows.length}
           onClear={onClearFilters}
         />
-        <FilerTable rows={filteredRows} highlightFiler={filerFilter} highlightRef={filerRowRef} />
+        <FilerTable
+          rows={filteredRows}
+          highlightFiler={filerFilter}
+          highlightRef={filerRowRef}
+          onClearHighlight={onClearFiler}
+        />
       </div>
     </div>
   );
@@ -415,9 +431,16 @@ interface FilerTableProps {
   readonly rows: readonly FilerRow[];
   readonly highlightFiler: string | null;
   readonly highlightRef: React.RefObject<HTMLTableRowElement>;
+  /** Clicking the highlighted row clears the filer filter. */
+  readonly onClearHighlight?: () => void;
 }
 
-function FilerTable({ rows, highlightFiler, highlightRef }: FilerTableProps): JSX.Element {
+function FilerTable({
+  rows,
+  highlightFiler,
+  highlightRef,
+  onClearHighlight,
+}: FilerTableProps): JSX.Element {
   if (rows.length === 0) {
     return (
       <EmptyState
@@ -443,13 +466,24 @@ function FilerTable({ rows, highlightFiler, highlightRef }: FilerTableProps): JS
         <tbody>
           {rows.map((row) => {
             const isHighlight = highlightFiler !== null && row.key === highlightFiler;
+            // Highlighted row uses a left-border accent rather than
+            // a full-row background tint. Amber backgrounds read as
+            // "warning / error" in dashboard convention; the
+            // operator-facing semantic here is "selected", not "alert".
+            // Clicking the highlighted row clears the filter — the
+            // operator can dismiss the per-filer drilldown without
+            // hunting for the Clear button.
+            const baseCls = "border-t border-slate-100 dark:border-slate-800";
+            const highlightCls = isHighlight
+              ? "border-l-2 border-l-sky-500 bg-sky-50/40 dark:bg-sky-950/20 cursor-pointer"
+              : "";
             return (
               <tr
                 key={`${row.category}-${row.key}`}
                 ref={isHighlight ? highlightRef : null}
-                className={`border-t border-slate-100 dark:border-slate-800 ${
-                  isHighlight ? "bg-amber-50 dark:bg-amber-950/40" : ""
-                }`}
+                className={`${baseCls} ${highlightCls}`}
+                onClick={isHighlight ? onClearHighlight : undefined}
+                title={isHighlight ? "Click to clear the per-filer filter" : undefined}
               >
                 <td className="py-1.5 text-slate-700 dark:text-slate-200">{row.label}</td>
                 <td className="py-1.5 text-slate-500 dark:text-slate-400">


### PR DESCRIPTION
## What

Two operator-flagged visual issues from the screenshot review.

### 1. Sunburst middle + outer rings rendered as one solid grey blob

Pre-fix every \`status='unknown'\` wedge used a single shared \`UNKNOWN_FILL\` slate-600. On an instrument like AAPL where 4 of 5 categories are gated on #740 / #735, the middle ring rendered as 3 grey wedges packed together with no per-category identity. Outer-ring leaves used the same fill so both rings merged into one purple/grey mass.

Fix: gap wedges now keep their parent category's accent color (cyan / blue / purple / amber / pink) and convey "no signal" via low opacity — 35% middle ring, 22% outer ring. Operator can distinguish Institutions / ETFs / Treasury gaps visually even when every category is gated.

Inner-ring gap arc keeps a neutral grey (\`theme.gridLine\`) because it represents the aggregate "we don't know" share, not any one category.

### 2. L2 ownership highlight row read as warning, not selected

PR #749 used \`bg-amber-50\` for the clicked-filer row. Amber reads as "warning / error" in dashboard convention; the operator-facing semantic here is "selected".

Fix: replaced full-row amber with a left-border sky-500 accent + near-transparent sky-50 fill. Row is now clickable to clear the per-filer filter — operator can dismiss the drilldown without hunting for the Clear button. Scroll-to-filer still works on initial nav.

New \`onClearFiler\` callback clears only \`?filer=\` while preserving \`?category=\` so the operator stays in the same drilldown view after clearing the highlight.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test:unit\` — 794 tests pass
- [x] \`node scripts/check-dark-classes.mjs\` — clean (173 files)

## Linked

- Fixes operator screenshot feedback on PR #746 / #747 / #749.
- Effective slice fill still gated on #740 + #735.