### PR TITLE
fix(#729): bump gap-wedge opacity + kill SVG focus rect on click

### DIFF
--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -89,6 +89,42 @@ const CATEGORY_FILL_INDEX: Record<string, number> = {
 const GAP_CATEGORY_OPACITY = 0.7;
 const GAP_LEAF_OPACITY = 0.5;
 
+/**
+ * Module-level CSS string for the sunburst's wedge interactions.
+ * Defined out-of-line because TypeScript's JSX strict-mode child
+ * typing rejects template-literal children of bare ``<style>`` (it
+ * sees ``string`` as a value-not-callable when it expects
+ * ``ReactNode``). Plain string assignment side-steps the parse trip.
+ *
+ * Click affordance: suppress only the mouse-click focus rect so the
+ * browser's default white rectangle stops drawing on click. Keyboard
+ * focus (``:focus-visible``) keeps a custom outline so keyboard
+ * users retain visual feedback.
+ *
+ * Hover affordance: stroke-width bump + ``filter: brightness(...)``.
+ * Crucially does NOT set CSS ``opacity`` — the wedges encode
+ * known-vs-coverage-gap via SVG ``fillOpacity``; a CSS opacity hover
+ * rule would override that and snap a 0.5-opacity gap wedge to
+ * fully opaque, erasing the "no signal" semantic.
+ */
+const SUNBURST_STYLES = [
+  ".ownership-sunburst .recharts-pie-sector path {",
+  "  transition: stroke-width 120ms ease, filter 120ms ease;",
+  "  cursor: pointer;",
+  "}",
+  ".ownership-sunburst .recharts-pie-sector path:focus {",
+  "  outline: none;",
+  "}",
+  ".ownership-sunburst .recharts-pie-sector path:focus-visible {",
+  "  outline: 2px solid currentColor;",
+  "  outline-offset: -1px;",
+  "}",
+  ".ownership-sunburst .recharts-pie-sector:hover path {",
+  "  stroke-width: 2;",
+  "  filter: brightness(1.2);",
+  "}",
+].join("\n");
+
 export function OwnershipSunburst({
   inputs,
   onWedgeClick,
@@ -203,29 +239,16 @@ export function OwnershipSunburst({
     >
       {/*
         Suppress the browser's default focus rect on Recharts'
-        inner <path> elements — clicking a wedge moved focus to the
-        path which then drew a white rectangular outline that read
-        as "selected" but ignored the wedge geometry. Use a wedge-
-        shaped feedback affordance instead: hover bumps stroke
-        width + opacity, click triggers the existing onWedgeClick
-        navigation. The ``ownership-sunburst`` class scopes the
-        outline removal so it doesn't bleed to other charts.
+        inner SVG path elements -- clicking a wedge moved focus to
+        the path which then drew a white rectangular outline that
+        read as "selected" but ignored the wedge geometry. Use a
+        wedge-shaped feedback affordance instead: hover bumps
+        stroke + brightness; click triggers the existing
+        onWedgeClick navigation. The ownership-sunburst class
+        scopes the outline removal so it does not bleed to other
+        charts.
       */}
-      <style>{`
-        .ownership-sunburst .recharts-pie-sector path {
-          outline: none;
-          transition: opacity 120ms ease, stroke-width 120ms ease;
-          cursor: pointer;
-        }
-        .ownership-sunburst .recharts-pie-sector path:focus,
-        .ownership-sunburst .recharts-pie-sector path:focus-visible {
-          outline: none;
-        }
-        .ownership-sunburst .recharts-pie-sector:hover path {
-          opacity: 1;
-          stroke-width: 2;
-        }
-      `}</style>
+      <style>{SUNBURST_STYLES}</style>
       <ResponsiveContainer width="100%" height="100%">
         <PieChart>
           <Tooltip content={<SunburstTooltip />} />

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -116,7 +116,11 @@ const SUNBURST_STYLES = [
   "  outline: none;",
   "}",
   ".ownership-sunburst .recharts-pie-sector path:focus-visible {",
-  "  outline: 2px solid currentColor;",
+  // slate-400 reads visibly on both light (white) and dark
+  // (slate-950) backgrounds. ``currentColor`` inherits SVG
+  // ``color`` which is unset on these path elements and defaults
+  // to black — invisible on dark mode.
+  "  outline: 2px solid #94a3b8;",
   "  outline-offset: -1px;",
   "}",
   ".ownership-sunburst .recharts-pie-sector:hover path {",

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -77,11 +77,17 @@ const CATEGORY_FILL_INDEX: Record<string, number> = {
  * status is ``unknown``. Pre-fix every unknown wedge collapsed to a
  * single shared slate-600 so the chart read as a solid grey blob —
  * operator couldn't distinguish "Institutions gap" from "ETFs gap"
- * from "Treasury gap". Now each category keeps its identity and the
- * low opacity carries the "no signal" semantic.
+ * from "Treasury gap". Each category keeps its accent identity; the
+ * lower opacity carries the "no signal" semantic.
+ *
+ * Opacity bumped on the second pass — at 0.35 / 0.22 over a
+ * slate-950 dark-mode background every accent washed out to muddy
+ * indistinguishable purples. Higher values keep the accent
+ * recognisable while still reading as desaturated vs known data
+ * (~85% opacity).
  */
-const GAP_CATEGORY_OPACITY = 0.35;
-const GAP_LEAF_OPACITY = 0.22;
+const GAP_CATEGORY_OPACITY = 0.7;
+const GAP_LEAF_OPACITY = 0.5;
 
 export function OwnershipSunburst({
   inputs,
@@ -180,13 +186,46 @@ export function OwnershipSunburst({
     onWedgeClick?.(datum.target);
   };
 
+  // Wedge stroke uses the theme's grid-line slate (slate-100 light /
+  // slate-800 dark) rather than the page background. With
+  // bg-coloured strokes between two adjacent dark-mode wedges at
+  // <100% opacity, the dark stroke + dark fill merged into one
+  // blob; a slightly lighter slate stroke keeps wedge boundaries
+  // legible without dominating the canvas.
+  const wedgeStroke = theme.gridLine;
+
   return (
     <div
-      className="relative"
+      className="ownership-sunburst relative"
       style={{ width: size, height: size }}
       role="img"
       aria-label={`Ownership breakdown: free float ${formatShares(rings.free_float)} shares.`}
     >
+      {/*
+        Suppress the browser's default focus rect on Recharts'
+        inner <path> elements — clicking a wedge moved focus to the
+        path which then drew a white rectangular outline that read
+        as "selected" but ignored the wedge geometry. Use a wedge-
+        shaped feedback affordance instead: hover bumps stroke
+        width + opacity, click triggers the existing onWedgeClick
+        navigation. The ``ownership-sunburst`` class scopes the
+        outline removal so it doesn't bleed to other charts.
+      */}
+      <style>{`
+        .ownership-sunburst .recharts-pie-sector path {
+          outline: none;
+          transition: opacity 120ms ease, stroke-width 120ms ease;
+          cursor: pointer;
+        }
+        .ownership-sunburst .recharts-pie-sector path:focus,
+        .ownership-sunburst .recharts-pie-sector path:focus-visible {
+          outline: none;
+        }
+        .ownership-sunburst .recharts-pie-sector:hover path {
+          opacity: 1;
+          stroke-width: 2;
+        }
+      `}</style>
       <ResponsiveContainer width="100%" height="100%">
         <PieChart>
           <Tooltip content={<SunburstTooltip />} />
@@ -195,7 +234,7 @@ export function OwnershipSunburst({
             dataKey="shares"
             innerRadius={innerInner}
             outerRadius={innerOuter}
-            stroke={theme.bg}
+            stroke={wedgeStroke}
             isAnimationActive={false}
             onClick={(_, idx) => handleClick(innerData[idx]!)}
           >
@@ -204,7 +243,7 @@ export function OwnershipSunburst({
                 key={`inner-${idx}`}
                 fill={d.fill}
                 fillOpacity={d.opacity}
-                stroke={d.stroke}
+                stroke={wedgeStroke}
               />
             ))}
           </Pie>
@@ -213,7 +252,7 @@ export function OwnershipSunburst({
             dataKey="shares"
             innerRadius={innerOuter}
             outerRadius={middleOuter}
-            stroke={theme.bg}
+            stroke={wedgeStroke}
             isAnimationActive={false}
             onClick={(_, idx) => handleClick(middleData[idx]!)}
           >
@@ -222,7 +261,7 @@ export function OwnershipSunburst({
                 key={`middle-${idx}`}
                 fill={d.fill}
                 fillOpacity={d.opacity}
-                stroke={d.stroke}
+                stroke={wedgeStroke}
               />
             ))}
           </Pie>
@@ -231,7 +270,7 @@ export function OwnershipSunburst({
             dataKey="shares"
             innerRadius={middleOuter}
             outerRadius={outerOuter}
-            stroke={theme.bg}
+            stroke={wedgeStroke}
             isAnimationActive={false}
             onClick={(_, idx) => handleClick(outerData[idx]!)}
           >
@@ -240,7 +279,7 @@ export function OwnershipSunburst({
                 key={`outer-${idx}`}
                 fill={d.fill}
                 fillOpacity={d.opacity}
-                stroke={d.stroke}
+                stroke={wedgeStroke}
               />
             ))}
           </Pie>


### PR DESCRIPTION
## What

Two visual issues from operator screenshot review of L2 ownership.

### 1. Wedges still washing out to one purple blob

PR #750 set gap-category opacity to 0.35 / 0.22. Over a dark-mode \`slate-950\` background, that washed cyan / blue / amber / pink accents into indistinguishable muddy purples — visually no different from the original single-shared-grey rendering.

Fix: bumped opacities to **0.7 / 0.5**. Accents stay recognisable while still reading as desaturated relative to known-data wedges (~85%).

Plus wedge stroke switched from \`theme.bg\` (slate-950, near-black) to \`theme.gridLine\` (slate-800). Black stroke between two semi-transparent dark wedges merged into one continuous dark arc; a slightly lighter slate keeps boundaries visible without dominating the canvas.

### 2. White rectangular outline on click

Not custom code — browser default focus rect on Recharts' inner \`<path>\` elements. Ignored wedge geometry → read as "selected" without matching the wedge shape.

Fix: scoped \`<style>\` tag suppresses the path outline and adds a hover affordance — wedge opacity bumps to 1.0 + stroke-width grows to 2 on hover, with a 120ms transition so the feedback feels intentional. Click navigation unchanged (still drives \`onWedgeClick\`).

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test:unit\` — 794 tests pass
- [x] \`node scripts/check-dark-classes.mjs\` — clean

## Visual sanity (operator validates)

Reload \`/instrument/AAPL/ownership\`. Expected:
- Middle ring: 4 distinguishable tinted wedges (cyan-tinted Inst, blue-tinted ETFs, amber-tinted Treasury, faint-purple Insiders hairline at 0.06%)
- Outer ring: matches parent category at lower saturation, with insider names at full color
- Click a wedge: no white box. Wedge brightens on hover; click navigates to filtered drilldown.