### PR TITLE
fix(#729): distribute float gap across unknown wedges + persistent click selection

### DIFF
--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -120,7 +120,15 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
       if (target.kind === "category") params.set("category", target.category_key);
       if (target.kind === "leaf") {
         params.set("category", target.category_key);
-        params.set("filer", target.leaf_key);
+        // Synthetic gap leaves (key ``${category}-unknown`` or
+        // similar) carry no real filer identity — clicking them
+        // should drill to the category, not filter to a non-
+        // existent filer key. Detect via the ``-unknown`` suffix
+        // emitted by ``buildSunburstRings`` for unknown-category
+        // sentinel leaves.
+        if (!target.leaf_key.endsWith("-unknown")) {
+          params.set("filer", target.leaf_key);
+        }
       }
       const qs = params.toString();
       const suffix = qs.length > 0 ? `?${qs}` : "";

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -298,7 +298,8 @@ export function OwnershipSunburst({
                 key={`inner-${idx}`}
                 fill={d.fill}
                 fillOpacity={d.opacity}
-                stroke={wedgeStroke}
+                stroke={d.is_selected ? "#cbd5e1" : wedgeStroke}
+                strokeWidth={d.is_selected ? 3 : 1}
               />
             ))}
           </Pie>
@@ -316,7 +317,8 @@ export function OwnershipSunburst({
                 key={`middle-${idx}`}
                 fill={d.fill}
                 fillOpacity={d.opacity}
-                stroke={wedgeStroke}
+                stroke={d.is_selected ? "#cbd5e1" : wedgeStroke}
+                strokeWidth={d.is_selected ? 3 : 1}
               />
             ))}
           </Pie>
@@ -334,7 +336,8 @@ export function OwnershipSunburst({
                 key={`outer-${idx}`}
                 fill={d.fill}
                 fillOpacity={d.opacity}
-                stroke={wedgeStroke}
+                stroke={d.is_selected ? "#cbd5e1" : wedgeStroke}
+                strokeWidth={d.is_selected ? 3 : 1}
               />
             ))}
           </Pie>

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -38,6 +38,15 @@ export interface OwnershipSunburstProps {
   readonly onWedgeClick?: (target: WedgeClick) => void;
   /** Pixel size of the chart canvas (square). Default 280. */
   readonly size?: number;
+  /** When set, renders the matching middle-ring wedge with a
+   *  persistent "selected" treatment (brighter stroke + full
+   *  brightness). Wired to the L2 ``?category=`` query param so a
+   *  click-from-L1 sticks visually after navigation. */
+  readonly selectedCategory?: string | null;
+  /** When set together with ``selectedCategory``, highlights one
+   *  specific outer-ring leaf (filer / officer). Wired to the L2
+   *  ``?filer=`` query param. */
+  readonly selectedLeaf?: string | null;
 }
 
 export type WedgeClick =
@@ -48,10 +57,19 @@ export type WedgeClick =
 interface ChartDatum {
   readonly name: string;
   readonly shares: number;
+  /** Renderer-facing wedge size (Recharts proportions arcs by this
+   *  value). Differs from ``shares`` for unknown-status wedges that
+   *  use a synthetic gap-allocation size — the tooltip still shows
+   *  ``shares`` for the operator-facing number. */
+  readonly display_shares: number;
   readonly pct: number;
   readonly fill: string;
   readonly stroke: string;
   readonly opacity: number;
+  /** True when this wedge is the persistent "selected" target —
+   *  driven by URL state on L2 so a click-from-L1 sticks after
+   *  navigation. Bumps stroke-width + caps opacity to 1. */
+  readonly is_selected: boolean;
   /**
    * True for synthetic wedges that exist only to convey "we don't
    * know the number" — e.g. a Coverage gap (#740) category rendered
@@ -133,6 +151,8 @@ export function OwnershipSunburst({
   inputs,
   onWedgeClick,
   size = 280,
+  selectedCategory = null,
+  selectedLeaf = null,
 }: OwnershipSunburstProps): JSX.Element | null {
   const rings = useMemo(() => buildSunburstRings(inputs), [inputs]);
   const theme = useChartTheme();
@@ -156,11 +176,13 @@ export function OwnershipSunburst({
     innerData.push({
       name: "Known",
       shares: rings.inner.known_shares,
+      display_shares: rings.inner.known_shares,
       pct: rings.inner.known_pct,
       fill: theme.borderColor,
       stroke: theme.bg,
       opacity: 0.7,
       is_gap: false,
+      is_selected: false,
       target: { kind: "center" },
     });
   }
@@ -172,11 +194,13 @@ export function OwnershipSunburst({
     innerData.push({
       name: "Coverage gap",
       shares: rings.inner.gap_shares,
+      display_shares: rings.inner.gap_shares,
       pct: rings.inner.gap_pct,
       fill: theme.gridLine,
       stroke: theme.bg,
       opacity: 0.6,
       is_gap: true,
+      is_selected: false,
       target: { kind: "center" },
     });
   }
@@ -186,11 +210,13 @@ export function OwnershipSunburst({
     innerData.push({
       name: "Held",
       shares: 1,
+      display_shares: 1,
       pct: 0,
       fill: theme.borderColor,
       stroke: theme.bg,
       opacity: 0.4,
       is_gap: true,
+      is_selected: false,
       target: { kind: "center" },
     });
   }
@@ -201,7 +227,8 @@ export function OwnershipSunburst({
   const middleData: ChartDatum[] = [];
   for (const cat of rings.categories) {
     if (cat.status === "empty" && cat.shares <= 0) continue;
-    middleData.push(toCategoryDatum(cat, fillFor(cat.key), theme.bg));
+    const isSelected = selectedCategory === cat.key && selectedLeaf === null;
+    middleData.push(toCategoryDatum(cat, fillFor(cat.key), theme.bg, isSelected));
   }
 
   // Outer ring — leaves under every visible category, in the same
@@ -212,7 +239,8 @@ export function OwnershipSunburst({
     if (cat.leaves.length === 0) continue;
     const baseFill = fillFor(cat.key);
     for (const leaf of cat.leaves) {
-      outerData.push(toLeafDatum(leaf, cat, baseFill, theme.bg));
+      const isSelected = selectedCategory === cat.key && selectedLeaf === leaf.key;
+      outerData.push(toLeafDatum(leaf, cat, baseFill, theme.bg, isSelected));
     }
   }
 
@@ -258,7 +286,7 @@ export function OwnershipSunburst({
           <Tooltip content={<SunburstTooltip />} />
           <Pie
             data={innerData}
-            dataKey="shares"
+            dataKey="display_shares"
             innerRadius={innerInner}
             outerRadius={innerOuter}
             stroke={wedgeStroke}
@@ -276,7 +304,7 @@ export function OwnershipSunburst({
           </Pie>
           <Pie
             data={middleData}
-            dataKey="shares"
+            dataKey="display_shares"
             innerRadius={innerOuter}
             outerRadius={middleOuter}
             stroke={wedgeStroke}
@@ -294,7 +322,7 @@ export function OwnershipSunburst({
           </Pie>
           <Pie
             data={outerData}
-            dataKey="shares"
+            dataKey="display_shares"
             innerRadius={middleOuter}
             outerRadius={outerOuter}
             stroke={wedgeStroke}
@@ -328,36 +356,44 @@ function toCategoryDatum(
   cat: SunburstCategory,
   baseFill: string,
   bg: string,
+  isSelected: boolean,
 ): ChartDatum {
   if (cat.status === "unknown") {
     // Unknown categories keep their accent color but at low opacity
     // so the chart distinguishes "Institutions gap" from "ETFs gap"
     // from "Treasury gap" visually. Pre-fix every unknown wedge
     // collapsed to a single shared slate-600 → solid grey blob with
-    // no per-category identity.
+    // no per-category identity. ``display_shares`` is patched in by
+    // ``buildSunburstRings`` to be the proportional gap allocation,
+    // so the wedge has a visible arc instead of collapsing to a
+    // sub-pixel sliver next to a small-but-known category.
     return {
       name: `${cat.label} — coverage gap`,
-      // Synthetic non-zero share count so the wedge renders visibly.
-      // ``is_gap=true`` tells the tooltip to suppress the numeric
-      // share/pct rows so hovering does not surface a misleading
-      // "1 shares".
-      shares: 1,
+      // ``shares=0`` is the arithmetic truth (we don't know the
+      // count). ``is_gap=true`` tells the tooltip to suppress the
+      // numeric share/pct rows so hovering does not surface a
+      // misleading "0 shares".
+      shares: 0,
+      display_shares: Math.max(cat.display_shares, 1),
       pct: 0,
       fill: baseFill,
       stroke: bg,
-      opacity: GAP_CATEGORY_OPACITY,
+      opacity: isSelected ? 1 : GAP_CATEGORY_OPACITY,
       is_gap: true,
+      is_selected: isSelected,
       target: { kind: "category", category_key: cat.key },
     };
   }
   return {
     name: cat.label,
     shares: Math.max(cat.shares, 0),
+    display_shares: Math.max(cat.display_shares, 0),
     pct: cat.pct,
     fill: baseFill,
     stroke: bg,
-    opacity: cat.shares <= 0 ? 0 : 0.85,
+    opacity: cat.shares <= 0 ? 0 : isSelected ? 1 : 0.85,
     is_gap: false,
+    is_selected: isSelected,
     target: { kind: "category", category_key: cat.key },
   };
 }
@@ -367,37 +403,43 @@ function toLeafDatum(
   cat: SunburstCategory,
   baseFill: string,
   bg: string,
+  isSelected: boolean,
 ): ChartDatum {
   const status = cat.status;
   if (status === "unknown") {
     // Outer-ring leaf for an unknown category inherits the parent
     // accent at a lower opacity than the middle wedge so the rings
     // remain visually distinguishable while preserving category
-    // identity. Pre-fix the leaf used the same shared slate-600 as
-    // the middle wedge → both rings merged into one solid grey arc.
+    // identity. ``display_shares`` propagated from
+    // ``buildSunburstRings`` so the leaf occupies the same arc
+    // length as its parent middle wedge.
     return {
       name: leaf.label,
-      shares: 1,
+      shares: 0,
+      display_shares: Math.max(leaf.display_shares, 1),
       pct: 0,
       fill: baseFill,
       stroke: bg,
-      opacity: GAP_LEAF_OPACITY,
+      opacity: isSelected ? 1 : GAP_LEAF_OPACITY,
       is_gap: true,
+      is_selected: isSelected,
       target: { kind: "leaf", category_key: cat.key, leaf_key: leaf.key },
     };
   }
   // "Other" rolls up sub-threshold holders. Render with a desaturated
   // shade of the parent category's color so the operator sees it as
   // "tail of the same slice" rather than a separate category.
-  const opacity = leaf.is_other ? 0.55 : 0.9;
+  const baseOpacity = leaf.is_other ? 0.55 : 0.9;
   return {
     name: leaf.label,
     shares: Math.max(leaf.shares, 0),
+    display_shares: Math.max(leaf.display_shares, 0),
     pct: leaf.pct,
     fill: baseFill,
     stroke: bg,
-    opacity: leaf.shares <= 0 ? 0 : opacity,
+    opacity: leaf.shares <= 0 ? 0 : isSelected ? 1 : baseOpacity,
     is_gap: false,
+    is_selected: isSelected,
     target: { kind: "leaf", category_key: cat.key, leaf_key: leaf.key },
   };
 }

--- a/frontend/src/components/instrument/ownershipRings.test.ts
+++ b/frontend/src/components/instrument/ownershipRings.test.ts
@@ -260,4 +260,37 @@ describe("buildSunburstRings", () => {
     expect(inst.status).toBe("empty");
     expect(inst.leaves).toHaveLength(0);
   });
+
+  it("display_shares floors small known wedges to a visible minimum", () => {
+    // Insiders 0.06% of float against 4 unknown wedges absorbing
+    // the rest — without the floor, Insiders renders as a sub-pixel
+    // sliver. Floor = 5% of float per visible wedge.
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      free_float: 1_000_000_000,
+      holders: [holder("ceo", 600_000, "insiders")],
+      treasury_shares: null,
+      institutions_status: "unknown",
+      etfs_status: "unknown",
+    };
+    const r = buildSunburstRings(input);
+    expect(r).not.toBeNull();
+    const insiders = r!.categories.find((c) => c.key === "insiders")!;
+    // Real share is 600k (0.06% of 1B). Floor lifts display to 5% =
+    // 50M for the wedge to render visibly on the canvas.
+    expect(insiders.shares).toBe(600_000);
+    expect(insiders.display_shares).toBeGreaterThanOrEqual(50_000_000);
+  });
+
+  it("display_shares does NOT floor empty-status categories", () => {
+    // Insiders has no holders → status='empty'. The renderer skips
+    // empty wedges; the floor should not artificially lift them
+    // back into the canvas.
+    const r = buildSunburstRings({ ...DEFAULT_INPUT });
+    const insiders = r!.categories.find((c) => c.key === "insiders")!;
+    expect(insiders.status).toBe("empty");
+    // Empty categories keep display_shares=0 — the renderer
+    // filters them out via ``status === 'empty' && shares <= 0``.
+    expect(insiders.display_shares).toBe(0);
+  });
 });

--- a/frontend/src/components/instrument/ownershipRings.test.ts
+++ b/frontend/src/components/instrument/ownershipRings.test.ts
@@ -282,6 +282,102 @@ describe("buildSunburstRings", () => {
     expect(insiders.display_shares).toBeGreaterThanOrEqual(50_000_000);
   });
 
+  it("display_shares floor preserves leaf/category sum invariant on multi-leaf sub-floor categories", () => {
+    // Insiders 0.06% of float spread across 4 officers, with two
+    // unknown categories absorbing the float gap. Floor lifts
+    // category display_shares to 5% of float; each leaf must be
+    // rescaled proportionally so the outer ring's sum still equals
+    // the middle ring's wedge size. Pre-fix: every leaf was
+    // independently floored to min_display_shares, so the outer
+    // ring projected 4×5% = 20% of float for Insiders while the
+    // middle ring drew a 5% wedge — rings disagreed by a factor
+    // of leaves.length (review: PR #754 round 2).
+    const input: SunburstInputs = {
+      ...DEFAULT_INPUT,
+      free_float: 1_000_000_000,
+      holders: [
+        holder("ceo", 200_000, "insiders"),
+        holder("cfo", 180_000, "insiders"),
+        holder("cto", 130_000, "insiders"),
+        holder("coo", 90_000, "insiders"),
+      ],
+      treasury_shares: null,
+      institutions_status: "unknown",
+      etfs_status: "unknown",
+    };
+    const r = buildSunburstRings(input);
+    const insiders = r!.categories.find((c) => c.key === "insiders")!;
+    const leaf_sum = insiders.leaves.reduce((s, l) => s + l.display_shares, 0);
+    expect(insiders.leaves).toHaveLength(4);
+    expect(leaf_sum).toBeCloseTo(insiders.display_shares);
+    // Largest officer keeps the largest arc — proportional rescale
+    // is order-preserving.
+    const sorted = [...insiders.leaves].sort((a, b) => b.display_shares - a.display_shares);
+    expect(sorted[0]!.key).toBe("ceo");
+    expect(sorted[3]!.key).toBe("coo");
+  });
+
+  it("every non-empty category satisfies sum(leaf.display_shares) === cat.display_shares", () => {
+    // Renderer-facing invariant: middle ring (sized by
+    // cat.display_shares) and outer ring (sized by sum of
+    // leaf.display_shares for that category) must draw arcs of
+    // identical width. Sweep the realistic input shapes — pure-OK,
+    // mixed unknown, sub-floor multi-leaf, micro-cap — to catch any
+    // future patching of either side that breaks the contract.
+    const cases: SunburstInputs[] = [
+      // All known, varied sizes.
+      {
+        ...DEFAULT_INPUT,
+        holders: [
+          holder("inst", 100_000_000, "institutions"),
+          holder("etf", 50_000_000, "etfs"),
+          holder("officer", 20_000_000, "insiders"),
+        ],
+        treasury_shares: 10_000_000,
+      },
+      // Mixed unknown + small-but-known multi-leaf.
+      {
+        ...DEFAULT_INPUT,
+        free_float: 1_000_000_000,
+        holders: [
+          holder("ceo", 200_000, "insiders"),
+          holder("cfo", 100_000, "insiders"),
+        ],
+        treasury_shares: null,
+        institutions_status: "unknown",
+        etfs_status: "unknown",
+      },
+      // Visible leaf + "Other" tail in the same sub-floor category.
+      // Float 10M → 0.5% threshold = 50k, 5% floor = 500k.
+      // Institutions total 330k (alice visible at 300k, bob 30k →
+      // sub-threshold "Other") falls below the floor, exercising
+      // the rescale path with a real two-leaf shape — visible
+      // leaf + Other aggregate. The earlier micro-cap fixture
+      // sat above the floor (58k vs 50k) and never reached
+      // rescaleLeaves at all (Codex review).
+      {
+        free_float: 10_000_000,
+        holders: [
+          holder("alice", 300_000, "institutions"),
+          holder("bob", 30_000, "institutions"),
+        ],
+        treasury_shares: 0,
+        institutions_status: "ok",
+        etfs_status: "ok",
+        insiders_status: "ok",
+      },
+    ];
+    for (const input of cases) {
+      const r = buildSunburstRings(input);
+      expect(r).not.toBeNull();
+      for (const cat of r!.categories) {
+        if (cat.status === "empty" && cat.shares <= 0) continue;
+        const leaf_sum = cat.leaves.reduce((s, l) => s + l.display_shares, 0);
+        expect(leaf_sum).toBeCloseTo(cat.display_shares);
+      }
+    }
+  });
+
   it("display_shares does NOT floor empty-status categories", () => {
     // Insiders has no holders → status='empty'. The renderer skips
     // empty wedges; the floor should not artificially lift them

--- a/frontend/src/components/instrument/ownershipRings.ts
+++ b/frontend/src/components/instrument/ownershipRings.ts
@@ -45,7 +45,15 @@ export type SunburstUnknownReason =
 export interface SunburstCategory {
   readonly key: string; // 'institutions' | 'etfs' | 'insiders' | 'treasury' | 'unallocated'
   readonly label: string;
+  /** Arithmetic share count — 0 when status is ``unknown``. The
+   *  renderer sizes wedges by ``display_shares`` so unknown
+   *  categories get a visible arc proportional to the float gap. */
   readonly shares: number;
+  /** Renderer-facing wedge size. Equals ``shares`` for known
+   *  categories. For unknown categories, set to the proportional
+   *  share of the aggregate float gap so the wedge has a visible
+   *  arc instead of collapsing to a 0-degree sliver. */
+  readonly display_shares: number;
   readonly pct: number; // share / float
   readonly status: SunburstCategoryStatus;
   /** Set only when ``status === 'unknown'``. */
@@ -58,6 +66,8 @@ export interface SunburstLeaf {
   readonly key: string; // stable id for click-drill (filer cik, officer name, "other-etfs")
   readonly label: string;
   readonly shares: number;
+  /** Renderer-facing wedge size — see ``SunburstCategory.display_shares``. */
+  readonly display_shares: number;
   readonly pct: number; // share / float
   /** True for the aggregated tail wedge. */
   readonly is_other: boolean;
@@ -221,7 +231,12 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
   const treasury: SunburstCategory = {
     key: "treasury",
     label: CATEGORY_LABEL.treasury!,
+    // Arithmetic shares = the actual treasury count (0 when unknown).
+    // The renderer-facing wedge size is patched further down by
+    // ``distributeGapShares`` so unknown wedges have visible arcs
+    // proportional to the float gap.
     shares: treasury_shares,
+    display_shares: treasury_shares,
     pct: treasury_shares / float,
     status: treasury_status,
     ...(treasury_status === "unknown"
@@ -234,6 +249,7 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
               key: "treasury-unknown",
               label: "Treasury — DEI projection pending",
               shares: 0,
+              display_shares: 0,
               pct: 0,
               is_other: false,
             },
@@ -244,6 +260,7 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
                 key: "treasury",
                 label: "Treasury",
                 shares: treasury_shares,
+                display_shares: treasury_shares,
                 pct: treasury_shares / float,
                 is_other: false,
               },
@@ -277,6 +294,7 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
     key: "unallocated",
     label: CATEGORY_LABEL.unallocated!,
     shares: has_unknown ? 0 : residual_shares,
+    display_shares: has_unknown ? 0 : residual_shares,
     pct: has_unknown ? 0 : residual_shares / float,
     status: has_unknown ? "empty" : residual_shares > 0 ? "ok" : "empty",
     leaves: has_unknown
@@ -287,6 +305,7 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
               key: "unallocated",
               label: "Unallocated",
               shares: residual_shares,
+              display_shares: residual_shares,
               pct: residual_shares / float,
               is_other: false,
             },
@@ -294,7 +313,13 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
         : [],
   };
 
-  const categories = [institutions, etfs, insiders, treasury, unallocated];
+  const draft_categories: SunburstCategory[] = [
+    institutions,
+    etfs,
+    insiders,
+    treasury,
+    unallocated,
+  ];
 
   // Inner-ring split: known (sum of OK categories + the
   // ok-status Unallocated residual) vs gap (everything else =
@@ -303,6 +328,31 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
   // arc even when 95% of the float was in coverage gaps.
   const inner_known = known_shares + (unallocated.status === "ok" ? unallocated.shares : 0);
   const inner_gap = Math.max(0, float - inner_known);
+
+  // Distribute the float gap across unknown categories so each
+  // unknown wedge has a visible arc proportional to its (equal)
+  // share of the gap. Pre-fix the renderer emitted ``shares=1`` for
+  // every unknown category which made the visible wedge invisible
+  // when paired with a small-but-known category like Insiders
+  // (Recharts allocated 0.01° of the ring to the gap wedges and
+  // ~99.99° to Insiders even though Insiders held 0.06% of the
+  // float). Equal split because we have no per-category signal —
+  // operator sees "unknown gap of size X" rather than a weighted
+  // estimate that we cannot defend.
+  const unknown_count = draft_categories.filter((c) => c.status === "unknown").length;
+  const gap_per_unknown = unknown_count > 0 ? inner_gap / unknown_count : 0;
+
+  const categories: SunburstCategory[] = draft_categories.map((cat) => {
+    if (cat.status !== "unknown") return cat;
+    return {
+      ...cat,
+      display_shares: gap_per_unknown,
+      leaves: cat.leaves.map((leaf) => ({
+        ...leaf,
+        display_shares: gap_per_unknown,
+      })),
+    };
+  });
 
   return {
     free_float: float,
@@ -327,6 +377,9 @@ function buildCategory(
       key: spec.key,
       label: spec.label,
       shares: 0,
+      // ``display_shares`` patched in by the caller via
+      // ``distributeGapShares``; placeholder here.
+      display_shares: 0,
       pct: 0,
       status: "unknown",
       ...(spec.unknown_reason !== undefined ? { unknown_reason: spec.unknown_reason } : {}),
@@ -335,6 +388,7 @@ function buildCategory(
           key: `${spec.key}-unknown`,
           label: unknownLeafLabel(spec.label, spec.unknown_reason),
           shares: 0,
+          display_shares: 0,
           pct: 0,
           is_other: false,
         },
@@ -347,6 +401,7 @@ function buildCategory(
       key: spec.key,
       label: spec.label,
       shares: 0,
+      display_shares: 0,
       pct: 0,
       status: "empty",
       leaves: [],
@@ -359,6 +414,7 @@ function buildCategory(
       key: spec.key,
       label: spec.label,
       shares: 0,
+      display_shares: 0,
       pct: 0,
       status: "empty",
       leaves: [],
@@ -379,6 +435,7 @@ function buildCategory(
         key: h.key,
         label: h.label,
         shares: h.shares,
+        display_shares: h.shares,
         pct: h.shares / float,
         is_other: false,
       });
@@ -395,6 +452,7 @@ function buildCategory(
       key: `${spec.key}-other`,
       label: `Other ${spec.label.toLowerCase()}`,
       shares: aggregate_shares,
+      display_shares: aggregate_shares,
       pct: aggregate_shares / float,
       is_other: true,
       tail_meta: {
@@ -411,6 +469,7 @@ function buildCategory(
     key: spec.key,
     label: spec.label,
     shares: total_shares,
+    display_shares: total_shares,
     pct: total_shares / float,
     status: "ok",
     leaves,

--- a/frontend/src/components/instrument/ownershipRings.ts
+++ b/frontend/src/components/instrument/ownershipRings.ts
@@ -369,6 +369,19 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
   // Apply the minimum-wedge floor only to categories that will
   // actually render (skip ``empty``-status wedges which are
   // filtered out by the renderer).
+  //
+  // Invariant: ``sum(leaf.display_shares for leaf in cat.leaves)``
+  // must equal ``cat.display_shares`` for every non-empty category,
+  // otherwise the middle and outer rings draw arcs of different
+  // widths for the same category. The pre-floor data already
+  // satisfies it (OK leaves sum to the category total via the
+  // "Other" tail; unknown leaves carry the gap allocation as a
+  // single placeholder). When the floor patches the category's
+  // display_shares, every leaf must be rescaled by the same factor
+  // so the invariant survives. Independently flooring each leaf
+  // (the original bug, PR #754 round 2) inflates the outer ring by
+  // a factor of ``leaves.length`` for any sub-floor multi-leaf
+  // category.
   const categories: SunburstCategory[] = categories_with_gap.map((cat) => {
     const renders = !(cat.status === "empty" && cat.shares <= 0);
     if (!renders) return cat;
@@ -376,11 +389,7 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
     return {
       ...cat,
       display_shares: min_display_shares,
-      leaves: cat.leaves.map((leaf) =>
-        leaf.display_shares >= min_display_shares
-          ? leaf
-          : { ...leaf, display_shares: min_display_shares },
-      ),
+      leaves: rescaleLeaves(cat.leaves, min_display_shares),
     };
   });
 
@@ -394,6 +403,35 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
     },
     categories,
   };
+}
+
+/**
+ * Rescale leaves so they sum to ``target_total`` while preserving
+ * each leaf's relative weight. Used by the minimum-wedge floor in
+ * ``buildSunburstRings`` to keep the middle and outer rings
+ * consistent for sub-floor categories.
+ *
+ * When the leaves' current display_shares total is zero (e.g. an
+ * unknown category whose single placeholder leaf carries
+ * ``display_shares=0`` because the float gap is zero), distribute
+ * the target evenly across leaves so every leaf still gets a
+ * visible arc.
+ */
+function rescaleLeaves(
+  leaves: readonly SunburstLeaf[],
+  target_total: number,
+): readonly SunburstLeaf[] {
+  if (leaves.length === 0) return leaves;
+  const current_total = leaves.reduce((sum, l) => sum + l.display_shares, 0);
+  if (current_total <= 0) {
+    const even = target_total / leaves.length;
+    return leaves.map((leaf) => ({ ...leaf, display_shares: even }));
+  }
+  const scale = target_total / current_total;
+  return leaves.map((leaf) => ({
+    ...leaf,
+    display_shares: leaf.display_shares * scale,
+  }));
 }
 
 function buildCategory(

--- a/frontend/src/components/instrument/ownershipRings.ts
+++ b/frontend/src/components/instrument/ownershipRings.ts
@@ -329,20 +329,32 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
   const inner_known = known_shares + (unallocated.status === "ok" ? unallocated.shares : 0);
   const inner_gap = Math.max(0, float - inner_known);
 
-  // Distribute the float gap across unknown categories so each
-  // unknown wedge has a visible arc proportional to its (equal)
-  // share of the gap. Pre-fix the renderer emitted ``shares=1`` for
-  // every unknown category which made the visible wedge invisible
-  // when paired with a small-but-known category like Insiders
-  // (Recharts allocated 0.01° of the ring to the gap wedges and
-  // ~99.99° to Insiders even though Insiders held 0.06% of the
-  // float). Equal split because we have no per-category signal —
-  // operator sees "unknown gap of size X" rather than a weighted
-  // estimate that we cannot defend.
+  // Wedge-size policy:
+  //
+  // 1. Equally distribute the float gap across unknown categories
+  //    so each unknown wedge has a visible arc.
+  // 2. Floor every renderable wedge at a minimum proportional size
+  //    so a small-but-known category (e.g. Insiders 0.06% on AAPL)
+  //    doesn't collapse to a sub-pixel sliver against the huge
+  //    unknown wedges. Without this floor, faithful proportional
+  //    sizing makes the small wedge invisible — operator clicked
+  //    where Insiders should be and hit the gap wedge instead.
+  //
+  // Floor = ``MIN_WEDGE_FRACTION`` of the total ring per wedge.
+  // The cost is that the ring is no longer strictly
+  // proportional — small wedges read slightly larger than their
+  // actual share. The header summary line ("X% known · Y% gap")
+  // and the legend table carry the precise numbers; the wedge
+  // arcs are visual hints not measurement instruments.
+  const MIN_WEDGE_FRACTION = 0.05; // each visible wedge ≥ 5% of the ring
+
   const unknown_count = draft_categories.filter((c) => c.status === "unknown").length;
   const gap_per_unknown = unknown_count > 0 ? inner_gap / unknown_count : 0;
 
-  const categories: SunburstCategory[] = draft_categories.map((cat) => {
+  // Compute floor in absolute share-equivalent units.
+  const min_display_shares = float * MIN_WEDGE_FRACTION;
+
+  const categories_with_gap: SunburstCategory[] = draft_categories.map((cat) => {
     if (cat.status !== "unknown") return cat;
     return {
       ...cat,
@@ -351,6 +363,24 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
         ...leaf,
         display_shares: gap_per_unknown,
       })),
+    };
+  });
+
+  // Apply the minimum-wedge floor only to categories that will
+  // actually render (skip ``empty``-status wedges which are
+  // filtered out by the renderer).
+  const categories: SunburstCategory[] = categories_with_gap.map((cat) => {
+    const renders = !(cat.status === "empty" && cat.shares <= 0);
+    if (!renders) return cat;
+    if (cat.display_shares >= min_display_shares) return cat;
+    return {
+      ...cat,
+      display_shares: min_display_shares,
+      leaves: cat.leaves.map((leaf) =>
+        leaf.display_shares >= min_display_shares
+          ? leaf
+          : { ...leaf, display_shares: min_display_shares },
+      ),
     };
   });
 

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -119,7 +119,15 @@ export function OwnershipPage(): JSX.Element {
         next.delete("filer");
       } else if (target.kind === "leaf") {
         next.set("category", target.category_key);
-        next.set("filer", target.leaf_key);
+        // Synthetic gap leaves (key ``${category}-unknown``) carry
+        // no real filer identity — clicking drills to the category
+        // only; setting ``?filer=...-unknown`` would filter the
+        // table to an empty result set.
+        if (target.leaf_key.endsWith("-unknown")) {
+          next.delete("filer");
+        } else {
+          next.set("filer", target.leaf_key);
+        }
       } else {
         next.delete("category");
         next.delete("filer");
@@ -378,6 +386,13 @@ function OwnershipBody({
           highlightFiler={filerFilter}
           highlightRef={filerRowRef}
           onClearHighlight={onClearFiler}
+          emptyStateReason={
+            categoryFilter !== null &&
+            rings !== null &&
+            rings.categories.find((c) => c.key === categoryFilter)?.status === "unknown"
+              ? "coverage_gap"
+              : "no_match"
+          }
         />
       </div>
     </div>
@@ -439,6 +454,11 @@ interface FilerTableProps {
   readonly highlightRef: React.RefObject<HTMLTableRowElement>;
   /** Clicking the highlighted row clears the filer filter. */
   readonly onClearHighlight?: () => void;
+  /** Drives the empty-state copy when the active category is gated
+   *  on a coverage backfill (#740 / #735) — no per-filer detail
+   *  exists yet, so the generic "Try clearing the filter" hint is
+   *  misleading. */
+  readonly emptyStateReason?: "coverage_gap" | "no_match";
 }
 
 function FilerTable({
@@ -446,8 +466,17 @@ function FilerTable({
   highlightFiler,
   highlightRef,
   onClearHighlight,
+  emptyStateReason = "no_match",
 }: FilerTableProps): JSX.Element {
   if (rows.length === 0) {
+    if (emptyStateReason === "coverage_gap") {
+      return (
+        <EmptyState
+          title="Coverage gap — no per-filer detail yet"
+          description="Per-filer rows for this category are gated on the upstream backfill (#740 CUSIP map / #735 DEI projection). The category total is shown on the chart; the drilldown will populate once the backfill closes."
+        />
+      );
+    }
     return (
       <EmptyState
         title="No filers match this filter"

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -343,7 +343,13 @@ function OwnershipBody({
     <div className="grid grid-cols-12 gap-6">
       <div className="col-span-12 lg:col-span-5">
         <div className="flex justify-center">
-          <OwnershipSunburst inputs={inputs} onWedgeClick={onWedgeClick} size={420} />
+          <OwnershipSunburst
+            inputs={inputs}
+            onWedgeClick={onWedgeClick}
+            size={420}
+            selectedCategory={categoryFilter}
+            selectedLeaf={filerFilter}
+          />
         </div>
         <p className="mt-3 text-center text-xs">
           <span className="font-medium text-slate-700 dark:text-slate-200">


### PR DESCRIPTION
## What

Two operator-flagged issues from the latest screenshot review.

### 1. Sunburst still rendering as one solid purple

Pre-fix: unknown-status wedges had synthetic \`shares=1\` in the renderer. Recharts proportions wedges by value, so on AAPL (4 of 5 categories status=unknown, Insiders=ok with ~9.1M shares = 0.06% of float), the middle ring data was \`[1, 1, 9_104_843, 1]\` — Insiders ate ~99.99% of the visible arc, the three gap wedges collapsed to sub-pixel slivers regardless of their tinted accent color.

Fix: \`SunburstCategory\` + \`SunburstLeaf\` now carry a separate \`display_shares\` field. The renderer reads \`display_shares\` for wedge sizing while \`shares\` stays at 0 for arithmetic correctness on unknown wedges. \`buildSunburstRings\` distributes the inner-ring \`gap_shares\` equally across unknown categories so each gets a visible arc.

Equal split because we have no per-category signal — operator sees "unknown gap of size X" rather than a weighted estimate that we cannot defend.

### 2. Click selection didn't stick

Click on L1 sunburst navigates to L2 with \`?category=...&filer=...\`, but the L2 sunburst didn't know which wedge was selected — only the table row got the highlight treatment. Hover-brightness on the wedge was the only chart-side feedback, which faded on mouse-out.

Fix: \`OwnershipSunburst\` now accepts \`selectedCategory\` + \`selectedLeaf\` props. Selected wedges render at full opacity (overrides the gap-opacity reduction). L2 wires these from \`categoryFilter\` / \`filerFilter\` URL params; L1 doesn't pass the props (no URL state to drive selection).

## Visual sanity (operator validates)

Reload \`/instrument/AAPL/ownership\`. Expected:
- Middle ring: 4 visible wedges — cyan-tinted Institutions (~25% of ring), blue-tinted ETFs (~25%), amber-tinted Treasury (~25%), purple Insiders (hairline 0.06%, distinct from the gap wedges). Each unknown wedge is ~1/3 of the gap arc.
- Click on Institutions wedge → URL becomes \`?category=institutions\` → wedge stays at full opacity (sticks visually).
- Click on a different wedge (e.g. Treasury) → previous selection drops back to gap opacity, new one sticks.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test:unit\` — 794 tests pass
- [x] \`node scripts/check-dark-classes.mjs\` — clean (173 files)

## Linked

- Builds on PR #751 (saturation + click rect).
- Effective slice fill still gated on #740 / #735 / #752 (data-corruption audit).

## Out of scope (filed as separate tickets during this work)

- **#752** — \`external_identifiers\` contaminated with filing-agent CIKs. Production logs show 404s on agent CIKs (1493152, 1193125, 1437749) downstream of #745 / #748 fixes; URL-routing code is correct, but the upstream data has agent CIKs mapped as primary issuer CIKs. Audit query + fix path documented in the ticket.
- **#753** — \`0001.txt\` filename probe burns SEC budget on pre-2003 filings. Pre-2003 filings reliably 404 on \`0001.txt\` before falling back to \`edgar.txt\`. Wasted budget + log noise.