### PR TITLE
feat(#729): faithful proportional ownership rings

### DIFF
--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -1,24 +1,28 @@
 /**
  * Ownership reporting card (#729).
  *
- * Renders a three-ring sunburst:
- *   ring 1 — Held (free-float total in the center hole)
- *   ring 2 — Institutions / ETFs / Insiders / Treasury / Unallocated
- *   ring 3 — per-filer / per-officer wedges + "Other [Category]" tail
+ * Three-ring sunburst keyed on ``shares_outstanding`` as the
+ * denominator. Treasury is one of the categories — the denominator
+ * includes it, not free float.
  *
- * Coverage gating:
- *   * No shares_outstanding on file → whole-card empty state.
- *   * Per-category data missing → wedge renders as a desaturated
- *     "coverage gap" arc rather than vanishing or rendering 0%.
+ *   ring 1 (inner)  — total shares outstanding (label in center hole)
+ *   ring 2 (middle) — Institutions / ETFs / Insiders / Treasury,
+ *                     plus a transparent residual for the unaccounted
+ *                     portion.
+ *   ring 3 (outer)  — per-filer / per-officer wedges, plus a
+ *                     transparent within-category gap when the filer
+ *                     detail is incomplete (e.g. Institutions reports
+ *                     a 50% aggregate but the #740 CUSIP backfill
+ *                     hasn't resolved every filer to an instrument).
  *
- * Effective slice coverage depends on:
+ * Effective coverage depends on:
  *   * #731 — shares_outstanding + treasury_shares from financial_periods (merged)
  *   * #730 — institutional_holdings via the new reader endpoint (merged)
  *   * #740 — CUSIP backfill so the ingester resolves holdings to instrument_ids (open)
+ *   * #735 — DEI projection so XBRL ownership columns (treasury, public float) flow (open)
  *
- * Click on any wedge → drill to the L2 ownership page (route lands
- * in the next PR; for now the click handler is a no-op surfaced via
- * ``onWedgeClick`` so the integration test can pin the wiring).
+ * Click on any colored wedge → drill to the L2 ownership page with
+ * the corresponding filter pre-applied.
  */
 
 import { useCallback } from "react";
@@ -36,7 +40,10 @@ import {
 import type { InsiderTransactionsList } from "@/api/instruments";
 import type { InstrumentFinancials } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
-import { OwnershipSunburst } from "@/components/instrument/OwnershipSunburst";
+import {
+  OwnershipLegend,
+  OwnershipSunburst,
+} from "@/components/instrument/OwnershipSunburst";
 import type { WedgeClick } from "@/components/instrument/OwnershipSunburst";
 import { Pane } from "@/components/instrument/Pane";
 import {
@@ -45,7 +52,6 @@ import {
   parseShareCount,
 } from "@/components/instrument/ownershipMetrics";
 import {
-  type SunburstCategoryStatus,
   type SunburstHolder,
   type SunburstInputs,
   buildSunburstRings,
@@ -60,13 +66,12 @@ export interface OwnershipPanelProps {
 interface OwnershipData {
   readonly outstanding: number | null;
   readonly treasury: number | null;
-  readonly free_float: number | null;
+  readonly institutions_total: number | null;
+  readonly etfs_total: number | null;
+  readonly insiders_total: number | null;
   readonly institutional_holders: readonly SunburstHolder[];
   readonly etf_holders: readonly SunburstHolder[];
   readonly insider_holders: readonly SunburstHolder[];
-  readonly institutions_status: SunburstCategoryStatus;
-  readonly etfs_status: SunburstCategoryStatus;
-  readonly insiders_status: SunburstCategoryStatus;
   readonly as_of_period: string | null;
 }
 
@@ -83,11 +88,6 @@ function pickLatestBalance(
 }
 
 export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
-  // Three parallel fetches: balance sheet (outstanding + treasury),
-  // institutional holdings (institutions + ETFs + per-filer rows),
-  // insider transactions (insiders aggregate). Each fetch fails
-  // independently — a missing input degrades the corresponding
-  // category rather than the whole card.
   const balanceState = useAsync<InstrumentFinancials>(
     useCallback(
       () =>
@@ -113,9 +113,6 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
   const navigate = useNavigate();
   const handleWedgeClick = useCallback(
     (target: WedgeClick) => {
-      // L2 drill page lands in the next PR; stub the navigation now
-      // so the integration is wired and the route handler can be
-      // added without touching this component.
       const params = new URLSearchParams();
       if (target.kind === "category") params.set("category", target.category_key);
       if (target.kind === "leaf") {
@@ -170,14 +167,9 @@ export function extractData(
   const treasury =
     balance !== null ? pickLatestBalance(balance, "treasury_shares") : null;
 
-  const free_float =
-    outstanding !== null ? Math.max(0, outstanding - (treasury ?? 0)) : null;
-
-  // Institutional + ETF wedges. Split the ``filers`` list by
-  // filer_type — equity-only rows feed the sunburst since option
-  // exposure double-counts the underlying.
   const inst_totals = institutional?.totals ?? null;
   const filers = institutional?.filers ?? [];
+  // Equity-only — option exposure double-counts the underlying.
   const equity_filers = filers.filter((f) => f.is_put_call === null);
 
   const institutional_holders: SunburstHolder[] = equity_filers
@@ -186,30 +178,17 @@ export function extractData(
   const etf_holders: SunburstHolder[] = equity_filers
     .filter((f) => f.filer_type === "ETF")
     .map(filerToHolder("etfs"));
-
-  // Insider holders — aggregate latest non-derivative
-  // post-transaction shares per officer. The list is short enough
-  // (~10-30 officers) that we render every officer as their own
-  // wedge; the sunburst transformer bypasses the visibility
-  // threshold for this category.
   const insider_holders = aggregateInsiderHoldersForSunburst(insiders);
 
-  const institutions_status: SunburstCategoryStatus = deriveCategoryStatus(
-    institutional,
-    institutional_holders,
-    inst_totals?.institutions_shares,
-  );
-  const etfs_status: SunburstCategoryStatus = deriveCategoryStatus(
-    institutional,
-    etf_holders,
-    inst_totals?.etfs_shares,
-  );
-  const insiders_status: SunburstCategoryStatus =
-    insiders === null
-      ? "unknown"
-      : insider_holders.length > 0
-        ? "ok"
-        : "empty";
+  const institutions_total = parseShareCount(inst_totals?.institutions_shares ?? null);
+  const etfs_total = parseShareCount(inst_totals?.etfs_shares ?? null);
+  // Form 4 has no aggregate-total endpoint — sum the per-officer
+  // post-transaction balances. When no officer rows are on file the
+  // total is null (category does not render).
+  const insiders_total =
+    insider_holders.length === 0
+      ? null
+      : insider_holders.reduce((s, h) => s + h.shares, 0);
 
   const as_of_period =
     inst_totals?.period_of_report ?? balance?.rows[0]?.period_end ?? null;
@@ -217,13 +196,12 @@ export function extractData(
   return {
     outstanding,
     treasury,
-    free_float,
+    institutions_total,
+    etfs_total,
+    insiders_total,
     institutional_holders,
     etf_holders,
     insider_holders,
-    institutions_status,
-    etfs_status,
-    insiders_status,
     as_of_period,
   };
 }
@@ -251,9 +229,6 @@ function aggregateInsiderHoldersForSunburst(
   insiders: InsiderTransactionsList | null,
 ): readonly SunburstHolder[] {
   if (insiders === null) return [];
-  // Latest non-derivative post-transaction-shares per officer.
-  // Keyed on filer_cik when present, falls back to filer_name so a
-  // filer with no CIK in the audit trail still gets distinct rows.
   const latestByFiler = new Map<
     string,
     { txn_date: string; shares: number; label: string }
@@ -284,95 +259,83 @@ function aggregateInsiderHoldersForSunburst(
   return holders;
 }
 
-function deriveCategoryStatus(
-  institutional: InstitutionalHoldingsResponse | null,
-  holders: readonly SunburstHolder[],
-  raw_total: string | undefined,
-): SunburstCategoryStatus {
-  // No fetch result at all — likely API error or pre-coverage.
-  if (institutional === null) return "unknown";
-  // ``totals`` is null when no holdings on file. The card surfaces
-  // this as a coverage gap so the operator sees that 13F ingest
-  // hasn't run for this instrument.
-  if (institutional.totals === null) return "unknown";
-  // Total reported but every CUSIP unresolved (the #740 backfill
-  // gap). The total may be 0 even though filers exist; render as
-  // ``unknown`` rather than ``empty`` so the coverage-gap copy
-  // shows.
-  const total = parseShareCount(raw_total ?? "0") ?? 0;
-  if (total <= 0 && holders.length === 0) return "empty";
-  if (holders.length === 0 && total > 0) return "unknown";
-  return "ok";
-}
-
 function renderBody(
   data: OwnershipData,
   onWedgeClick: (target: WedgeClick) => void,
 ): JSX.Element {
-  if (data.free_float === null || data.free_float <= 0) {
+  if (data.outstanding === null || data.outstanding <= 0) {
     return (
       <EmptyState
         title="No ownership data"
-        description="Shares outstanding is not on file for this instrument yet — the ownership breakdown needs SEC XBRL coverage to compute the float denominator."
+        description="Shares outstanding is not on file for this instrument yet — the ownership breakdown needs SEC XBRL coverage to compute the denominator."
       />
     );
   }
 
+  // Denominator = outstanding + treasury. Operator's mental model:
+  // "100% of issued / allotted shares — some held in market, some
+  // held back in vault." Treasury renders as a category wedge.
+  const total_shares = data.outstanding + (data.treasury ?? 0);
   const inputs: SunburstInputs = {
-    free_float: data.free_float,
+    total_shares,
     holders: [
       ...data.institutional_holders,
       ...data.etf_holders,
       ...data.insider_holders,
     ],
+    institutions_total: data.institutions_total,
+    etfs_total: data.etfs_total,
+    insiders_total: data.insiders_total,
     treasury_shares: data.treasury,
-    institutions_status: data.institutions_status,
-    etfs_status: data.etfs_status,
-    insiders_status: data.insiders_status,
   };
   const rings = buildSunburstRings(inputs);
   if (rings === null) {
     return (
       <EmptyState
         title="No ownership data"
-        description="Sunburst rings could not be derived — free float resolved to zero or the input snapshot is malformed."
+        description="Sunburst rings could not be derived — shares outstanding resolved to zero or the input snapshot is malformed."
       />
     );
   }
 
-  const knownPct = rings.inner.known_pct;
-  const gapPct = rings.inner.gap_pct;
-  const hasMaterialGap = gapPct > 0.005; // > 0.5% counts as material to surface
-  const gapReasons = collectGapReasons(rings.categories);
+  const denom = rings.total_shares;
+  const accountedFor = rings.categories.reduce((s, c) => s + c.shares, 0);
+  const accountedPct = accountedFor / denom;
+  const oversubscribed = rings.total_shares > rings.reported_total;
 
   return (
     <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
-      <div className="flex justify-center">
+      <div className="flex flex-col items-center gap-3">
         <OwnershipSunburst inputs={inputs} onWedgeClick={onWedgeClick} />
+        <OwnershipLegend rings={rings} />
       </div>
       <div className="min-w-0 flex-1">
         {data.as_of_period !== null && (
           <p className="mb-1 text-xs text-slate-500 dark:text-slate-400">
-            As of {data.as_of_period}. Free float ={" "}
-            {formatShares(data.free_float)} shares.
+            As of {data.as_of_period}. {formatShares(data.outstanding)} outstanding
+            {data.treasury !== null && data.treasury > 0 && (
+              <> + {formatShares(data.treasury)} treasury</>
+            )}
+            .
           </p>
         )}
         <p className="mb-2 text-xs">
           <span className="font-medium text-slate-700 dark:text-slate-200">
-            {formatPct(knownPct)} known
+            {formatPct(accountedPct)} accounted for
           </span>
-          {hasMaterialGap && (
-            <>
-              <span className="mx-1.5 text-slate-400">·</span>
-              <span className="font-medium text-amber-700 dark:text-amber-400">
-                {formatPct(gapPct)} coverage gap
-              </span>
-              {gapReasons.length > 0 && (
-                <span className="ml-1 text-slate-500 dark:text-slate-400">
-                  ({gapReasons.join(", ")})
-                </span>
-              )}
-            </>
+          {accountedPct < 0.999 && (
+            <span className="ml-1.5 text-slate-500 dark:text-slate-400">
+              · remainder is unallocated public float (gated on
+              {" "}
+              <span className="font-mono">#740</span> CUSIP backfill +{" "}
+              <span className="font-mono">#735</span> DEI projection).
+            </span>
+          )}
+          {oversubscribed && (
+            <span className="ml-1.5 text-amber-700 dark:text-amber-400">
+              · category totals exceed reported total shares by{" "}
+              {formatShares(rings.total_shares - rings.reported_total)} (snapshot lag).
+            </span>
           )}
         </p>
         <table className="w-full text-sm">
@@ -380,76 +343,42 @@ function renderBody(
             <tr>
               <th className="pb-1 text-left">Category</th>
               <th className="pb-1 text-right">Shares</th>
-              <th className="pb-1 text-right">% of float</th>
+              <th className="pb-1 text-right">% of total</th>
+              <th className="pb-1 text-right">Resolved filers</th>
             </tr>
           </thead>
           <tbody>
-            {rings.categories.map((cat) => (
-              <tr
-                key={cat.key}
-                className="border-t border-slate-100 dark:border-slate-800"
-              >
-                <td className="py-1.5 text-slate-700 dark:text-slate-200">
-                  {cat.label}
-                  {cat.status === "unknown" && (
-                    <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">
-                      {unknownReasonShort(cat.unknown_reason)}
-                    </span>
-                  )}
-                </td>
-                <td className="py-1.5 text-right font-mono text-slate-700 dark:text-slate-200">
-                  {cat.status === "unknown" ? "—" : formatShares(cat.shares)}
-                </td>
-                <td className="py-1.5 text-right font-mono text-slate-900 dark:text-slate-100">
-                  {cat.status === "unknown" ? "—" : formatPct(cat.pct)}
-                </td>
-              </tr>
-            ))}
+            {rings.categories.map((cat) => {
+              const resolvedPct =
+                cat.shares > 0 ? cat.resolved_leaf_shares / cat.shares : 0;
+              return (
+                <tr
+                  key={cat.key}
+                  className="border-t border-t-slate-100 dark:border-t-slate-800"
+                >
+                  <td className="py-1.5 text-slate-700 dark:text-slate-200">
+                    {cat.label}
+                  </td>
+                  <td className="py-1.5 text-right font-mono text-slate-700 dark:text-slate-200">
+                    {formatShares(cat.shares)}
+                  </td>
+                  <td className="py-1.5 text-right font-mono text-slate-900 dark:text-slate-100">
+                    {formatPct(cat.shares / denom)}
+                  </td>
+                  <td className="py-1.5 text-right font-mono text-slate-500 dark:text-slate-400">
+                    {cat.leaves.length === 0 && cat.shares > 0
+                      ? "—"
+                      : formatPct(resolvedPct)}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
         <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
-          Click any wedge for the per-filer drilldown.
+          Click any colored wedge for the per-filer drilldown.
         </p>
       </div>
     </div>
   );
-}
-
-function collectGapReasons(
-  categories: readonly { unknown_reason?: string; status: string }[],
-): string[] {
-  // Dedupes across categories so a stock with both
-  // institutions and ETFs gated on #740 doesn't repeat the
-  // ticket. Generic 'no_data' / undefined reasons fall back to a
-  // neutral label so the header parenthetical still surfaces
-  // when an unknown category cannot be tied to a tracked
-  // follow-up — "X% coverage gap" with no parenthetical was
-  // ambiguous and dropped a real gap below the operator's
-  // attention threshold.
-  const reasons = new Set<string>();
-  for (const cat of categories) {
-    if (cat.status !== "unknown") continue;
-    switch (cat.unknown_reason) {
-      case "cusip_backfill":
-        reasons.add("#740 CUSIP backfill");
-        break;
-      case "dei_projection":
-        reasons.add("#735 DEI projection");
-        break;
-      default:
-        reasons.add("data not on file");
-    }
-  }
-  return Array.from(reasons);
-}
-
-function unknownReasonShort(reason: string | undefined): string {
-  switch (reason) {
-    case "cusip_backfill":
-      return "needs CUSIPs (#740)";
-    case "dei_projection":
-      return "needs DEI tag (#735)";
-    default:
-      return "no data";
-  }
 }

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -183,17 +183,11 @@ export function OwnershipSunburst({
 
   const wedgeStroke = theme.gridLine;
 
-  // Recharts' Pie crashes on empty data — keep ring 3 alive with a
-  // single transparent wedge when there are no categories at all
-  // (``denom`` known but every category total null).
-  const safeOuter: ChartDatum[] =
-    outerData.length === 0
-      ? [makeGapDatum("outer-empty", "Unaccounted", denom, denom)]
-      : outerData;
-  const safeMiddle: ChartDatum[] =
-    middleData.length === 0
-      ? [makeGapDatum("middle-empty", "Unaccounted", denom, denom)]
-      : middleData;
+  // ``middleData`` and ``outerData`` are always non-empty when
+  // ``denom > 0``: buildSunburstRings guarantees ``category_residual
+  // = total_shares - sum_known``, so when no category renders the
+  // residual gap is the entire denominator and gets pushed below.
+  // (Codex review pin — no defensive fallback needed.)
 
   return (
     <div
@@ -220,15 +214,15 @@ export function OwnershipSunburst({
             <Cell fill={theme.borderColor} fillOpacity={0.6} stroke={wedgeStroke} />
           </Pie>
           <Pie
-            data={safeMiddle}
+            data={middleData}
             dataKey="shares"
             innerRadius={innerOuter}
             outerRadius={middleOuter}
             stroke={wedgeStroke}
             isAnimationActive={false}
-            onClick={(_, idx) => handleClick(safeMiddle[idx])}
+            onClick={(_, idx) => handleClick(middleData[idx])}
           >
-            {safeMiddle.map((d) => (
+            {middleData.map((d) => (
               <Cell
                 key={d.id}
                 fill={d.fill}
@@ -238,15 +232,15 @@ export function OwnershipSunburst({
             ))}
           </Pie>
           <Pie
-            data={safeOuter}
+            data={outerData}
             dataKey="shares"
             innerRadius={middleOuter}
             outerRadius={outerOuter}
             stroke={wedgeStroke}
             isAnimationActive={false}
-            onClick={(_, idx) => handleClick(safeOuter[idx])}
+            onClick={(_, idx) => handleClick(outerData[idx])}
           >
-            {safeOuter.map((d) => (
+            {outerData.map((d) => (
               <Cell
                 key={d.id}
                 fill={d.fill}

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -1,21 +1,27 @@
 /**
- * Three-ring ownership sunburst (#729 follow-up).
+ * Three-ring ownership sunburst (#729).
+ *
+ * Faithful proportional rendering. Single denominator
+ * (``shares_outstanding``); every wedge is sized as its true share of
+ * the total. Categories or filers we don't have data for render as
+ * transparent arcs — literal empty space — so the operator sees the
+ * coverage gap in proper proportion rather than a synthetic
+ * placeholder.
+ *
+ *   ring 1 (inner)  — single solid band, decorative; denominator
+ *                     label sits in the center hole.
+ *   ring 2 (middle) — per-category wedges (Institutions / ETFs /
+ *                     Insiders / Treasury) plus a transparent wedge
+ *                     for the unaccounted residual.
+ *   ring 3 (outer)  — per-filer / per-officer wedges within each
+ *                     category, plus a transparent wedge for any
+ *                     within-category gap (filer detail incomplete)
+ *                     and a transparent wedge for the same outer
+ *                     residual so ring 3 reaches the same
+ *                     circumference as ring 2.
  *
  * Recharts has no native sunburst primitive — built from three nested
  * ``<Pie>`` components at increasing ``innerRadius`` / ``outerRadius``.
- *
- *   ring 1 (innermost) — single-arc "Held" total, labelled with the
- *                        absolute float in the center hole.
- *   ring 2             — per-category wedges (Institutions / ETFs /
- *                        Insiders / Treasury / Unallocated).
- *   ring 3 (outermost) — per-filer / per-officer wedges within each
- *                        category, plus an "Other" tail when many
- *                        sub-threshold holders exist.
- *
- * Coverage gating: a category with ``status='unknown'`` (today's
- * Institutions / ETFs while the #740 CUSIP backfill is pending)
- * renders as a hatched grey wedge sized to its share of float so the
- * operator sees the gap visually rather than as a missing slice.
  */
 
 import { useMemo } from "react";
@@ -23,18 +29,21 @@ import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 
 import { formatPct, formatShares } from "@/components/instrument/ownershipMetrics";
 import {
+  type CategoryKey,
   type SunburstCategory,
+  type SunburstInputs,
   type SunburstLeaf,
   type SunburstRings,
   buildSunburstRings,
 } from "@/components/instrument/ownershipRings";
-import type { SunburstInputs } from "@/components/instrument/ownershipRings";
+import { type ChartTheme } from "@/lib/chartTheme";
 import { useChartTheme } from "@/lib/useChartTheme";
 
 export interface OwnershipSunburstProps {
   readonly inputs: SunburstInputs;
-  /** Click handler for any wedge. Receives the wedge identity for
-   *  drill-to-L2 navigation. */
+  /** Click handler for any colored (known-data) wedge. Transparent
+   *  gap wedges are non-interactive — they have no identity to
+   *  drill into. */
   readonly onWedgeClick?: (target: WedgeClick) => void;
   /** Pixel size of the chart canvas (square). Default 280. */
   readonly size?: number;
@@ -42,88 +51,75 @@ export interface OwnershipSunburstProps {
 
 export type WedgeClick =
   | { readonly kind: "center" }
-  | { readonly kind: "category"; readonly category_key: string }
-  | { readonly kind: "leaf"; readonly category_key: string; readonly leaf_key: string };
+  | { readonly kind: "category"; readonly category_key: CategoryKey }
+  | {
+      readonly kind: "leaf";
+      readonly category_key: CategoryKey;
+      readonly leaf_key: string;
+    };
+
+/** Index into ``ChartTheme.accent`` for each category's color. */
+export const CATEGORY_FILL_INDEX: Record<CategoryKey, number> = {
+  institutions: 0, // cyan-500
+  etfs: 1, // blue-500
+  insiders: 2, // purple-500
+  treasury: 3, // amber-500
+};
+
+export function categoryFill(theme: ChartTheme, key: CategoryKey): string {
+  const idx = CATEGORY_FILL_INDEX[key];
+  return theme.accent[idx % theme.accent.length] ?? theme.accent[0]!;
+}
 
 interface ChartDatum {
+  readonly id: string;
   readonly name: string;
   readonly shares: number;
   readonly pct: number;
   readonly fill: string;
-  readonly stroke: string;
-  readonly opacity: number;
-  /**
-   * True for synthetic wedges that exist only to convey "we don't
-   * know the number" — e.g. a Coverage gap (#740) category rendered
-   * with a placeholder ``shares=1`` so the arc has visible thickness.
-   * The tooltip suppresses the numeric share/pct rows for these
-   * datums so hovering doesn't surface "1 shares / 0% of float".
-   */
+  /** True for transparent wedges — they are non-interactive and
+   *  the tooltip / hover affordances suppress on them. */
   readonly is_gap: boolean;
-  /** Click-target metadata propagated through Recharts' onClick. */
-  readonly target: WedgeClick;
+  readonly target: WedgeClick | null;
 }
 
-const CATEGORY_FILL_INDEX: Record<string, number> = {
-  institutions: 0, // cyan
-  etfs: 1, // blue
-  insiders: 2, // purple
-  treasury: 3, // amber
-  unallocated: 4, // pink
-};
-
 /**
- * Opacity applied to a category's accent color when the category
- * status is ``unknown``. Pre-fix every unknown wedge collapsed to a
- * single shared slate-600 so the chart read as a solid grey blob —
- * operator couldn't distinguish "Institutions gap" from "ETFs gap"
- * from "Treasury gap". Each category keeps its accent identity; the
- * lower opacity carries the "no signal" semantic.
- *
- * Opacity bumped on the second pass — at 0.35 / 0.22 over a
- * slate-950 dark-mode background every accent washed out to muddy
- * indistinguishable purples. Higher values keep the accent
- * recognisable while still reading as desaturated vs known data
- * (~85% opacity).
- */
-const GAP_CATEGORY_OPACITY = 0.7;
-const GAP_LEAF_OPACITY = 0.5;
-
-/**
- * Module-level CSS string for the sunburst's wedge interactions.
- * Defined out-of-line because TypeScript's JSX strict-mode child
- * typing rejects template-literal children of bare ``<style>`` (it
- * sees ``string`` as a value-not-callable when it expects
- * ``ReactNode``). Plain string assignment side-steps the parse trip.
- *
- * Click affordance: suppress only the mouse-click focus rect so the
- * browser's default white rectangle stops drawing on click. Keyboard
- * focus (``:focus-visible``) keeps a custom outline so keyboard
- * users retain visual feedback.
- *
- * Hover affordance: stroke-width bump + ``filter: brightness(...)``.
- * Crucially does NOT set CSS ``opacity`` — the wedges encode
- * known-vs-coverage-gap via SVG ``fillOpacity``; a CSS opacity hover
- * rule would override that and snap a 0.5-opacity gap wedge to
- * fully opaque, erasing the "no signal" semantic.
+ * Module-level CSS for wedge interactions. Defined out-of-line because
+ * TypeScript's strict JSX child typing rejects template-literal
+ * children of bare ``<style>`` (sees ``string`` as not-callable). The
+ * ``[data-known='true']`` attribute, set per-Cell, scopes hover and
+ * focus affordances to colored wedges only — gap arcs stay inert.
  */
 const SUNBURST_STYLES = [
   ".ownership-sunburst .recharts-pie-sector path {",
   "  transition: stroke-width 120ms ease, filter 120ms ease;",
-  "  cursor: pointer;",
   "}",
   ".ownership-sunburst .recharts-pie-sector path:focus {",
   "  outline: none;",
   "}",
-  ".ownership-sunburst .recharts-pie-sector path:focus-visible {",
-  // slate-400 reads visibly on both light (white) and dark
-  // (slate-950) backgrounds. ``currentColor`` inherits SVG
-  // ``color`` which is unset on these path elements and defaults
-  // to black — invisible on dark mode.
+  // Sector wrapper hit-testing — Recharts' click + tooltip handlers
+  // attach on the parent ``.recharts-pie-sector`` Layer, not on the
+  // path Cell ``style`` lands on. Use ``:has()`` to disable hit
+  // tests on the wrapper for any sector whose Cell carries
+  // ``data-known='false'`` so transparent gap wedges don't absorb
+  // clicks/hover at all (instead of relying on the JS click filter
+  // to no-op them after the fact).
+  ".ownership-sunburst .recharts-pie-sector:has(path[data-known='false']) {",
+  "  pointer-events: none;",
+  "}",
+  ".ownership-sunburst .recharts-pie-sector:has(path[data-known='true']) path {",
+  "  cursor: pointer;",
+  "}",
+  // slate-400 outline reads on both light (white) and dark
+  // (slate-950) backgrounds. Default ``currentColor`` defaults to
+  // black — invisible on dark mode.
+  ".ownership-sunburst .recharts-pie-sector:has(path[data-known='true']) path:focus-visible {",
   "  outline: 2px solid #94a3b8;",
   "  outline-offset: -1px;",
   "}",
-  ".ownership-sunburst .recharts-pie-sector:hover path {",
+  // Hover affordance via ``filter: brightness`` — never via CSS
+  // ``opacity`` so the gap-vs-known semantic survives hover.
+  ".ownership-sunburst .recharts-pie-sector:has(path[data-known='true']):hover path {",
   "  stroke-width: 2;",
   "  filter: brightness(1.2);",
   "}",
@@ -139,81 +135,39 @@ export function OwnershipSunburst({
 
   if (rings === null) return null;
 
-  const accent = theme.accent;
-  const fillFor = (categoryKey: string): string => {
-    const idx = CATEGORY_FILL_INDEX[categoryKey];
-    if (idx === undefined) return accent[0];
-    return accent[idx % accent.length]!;
-  };
+  const denom = rings.total_shares;
+  const fillFor = (key: CategoryKey): string => categoryFill(theme, key);
 
-  // Inner ring — known + gap split. Pre-#746-followup the inner
-  // ring rendered as a single 100% arc that included synthetic
-  // unknown-padding from upstream categories — visually misleading
-  // when most of the float was in coverage gaps. Two arcs make the
-  // gap proportion legible at the very center of the chart.
-  const innerData: ChartDatum[] = [];
-  if (rings.inner.known_shares > 0) {
-    innerData.push({
-      name: "Known",
-      shares: rings.inner.known_shares,
-      pct: rings.inner.known_pct,
-      fill: theme.borderColor,
-      stroke: theme.bg,
-      opacity: 0.7,
-      is_gap: false,
-      target: { kind: "center" },
-    });
-  }
-  if (rings.inner.gap_shares > 0) {
-    // Inner-ring gap arc represents the aggregate "we don't know"
-    // share — keep it as a single neutral grey so it reads as
-    // "missing data" rather than implying it belongs to any one
-    // accent-colored category.
-    innerData.push({
-      name: "Coverage gap",
-      shares: rings.inner.gap_shares,
-      pct: rings.inner.gap_pct,
-      fill: theme.gridLine,
-      stroke: theme.bg,
-      opacity: 0.6,
-      is_gap: true,
-      target: { kind: "center" },
-    });
-  }
-  // Defensive: if both segments are zero (degenerate), still render
-  // a single placeholder so the inner ring outline is preserved.
-  if (innerData.length === 0) {
-    innerData.push({
-      name: "Held",
-      shares: 1,
-      pct: 0,
-      fill: theme.borderColor,
-      stroke: theme.bg,
-      opacity: 0.4,
-      is_gap: true,
-      target: { kind: "center" },
-    });
+  // Middle ring — per-category wedges + transparent residual.
+  const middleData: ChartDatum[] = rings.categories.map((cat) =>
+    toCategoryDatum(cat, fillFor(cat.key), denom),
+  );
+  if (rings.category_residual > 0) {
+    middleData.push(makeGapDatum("middle-residual", "Unaccounted", rings.category_residual, denom));
   }
 
-  // Middle ring — one wedge per category. Categories with shares=0
-  // and status='empty' are skipped so the ring doesn't render a
-  // sliver of unstyled chrome.
-  const middleData: ChartDatum[] = [];
-  for (const cat of rings.categories) {
-    if (cat.status === "empty" && cat.shares <= 0) continue;
-    middleData.push(toCategoryDatum(cat, fillFor(cat.key), theme.bg));
-  }
-
-  // Outer ring — leaves under every visible category, in the same
-  // order so wedges stack alphabetically with their parent.
+  // Outer ring — leaves under each visible category, then the
+  // category's within_category_gap (transparent), then the same
+  // outer residual so ring 3 closes flush with ring 2.
   const outerData: ChartDatum[] = [];
   for (const cat of rings.categories) {
-    if (cat.status === "empty" && cat.shares <= 0) continue;
-    if (cat.leaves.length === 0) continue;
     const baseFill = fillFor(cat.key);
     for (const leaf of cat.leaves) {
-      outerData.push(toLeafDatum(leaf, cat, baseFill, theme.bg));
+      outerData.push(toLeafDatum(leaf, cat.key, baseFill, denom));
     }
+    if (cat.within_category_gap > 0) {
+      outerData.push(
+        makeGapDatum(
+          `${cat.key}-gap`,
+          `${cat.label} — unresolved filers`,
+          cat.within_category_gap,
+          denom,
+        ),
+      );
+    }
+  }
+  if (rings.category_residual > 0) {
+    outerData.push(makeGapDatum("outer-residual", "Unaccounted", rings.category_residual, denom));
   }
 
   const totalRadius = size / 2;
@@ -222,91 +176,82 @@ export function OwnershipSunburst({
   const middleOuter = totalRadius * 0.62;
   const outerOuter = totalRadius * 0.92;
 
-  const handleClick = (datum: ChartDatum): void => {
+  const handleClick = (datum: ChartDatum | undefined): void => {
+    if (datum === undefined || datum.target === null) return;
     onWedgeClick?.(datum.target);
   };
 
-  // Wedge stroke uses the theme's grid-line slate (slate-100 light /
-  // slate-800 dark) rather than the page background. With
-  // bg-coloured strokes between two adjacent dark-mode wedges at
-  // <100% opacity, the dark stroke + dark fill merged into one
-  // blob; a slightly lighter slate stroke keeps wedge boundaries
-  // legible without dominating the canvas.
   const wedgeStroke = theme.gridLine;
+
+  // Recharts' Pie crashes on empty data — keep ring 3 alive with a
+  // single transparent wedge when there are no categories at all
+  // (``denom`` known but every category total null).
+  const safeOuter: ChartDatum[] =
+    outerData.length === 0
+      ? [makeGapDatum("outer-empty", "Unaccounted", denom, denom)]
+      : outerData;
+  const safeMiddle: ChartDatum[] =
+    middleData.length === 0
+      ? [makeGapDatum("middle-empty", "Unaccounted", denom, denom)]
+      : middleData;
 
   return (
     <div
       className="ownership-sunburst relative"
       style={{ width: size, height: size }}
       role="img"
-      aria-label={`Ownership breakdown: free float ${formatShares(rings.free_float)} shares.`}
+      aria-label={`Ownership breakdown: ${formatShares(denom)} total shares.`}
     >
-      {/*
-        Suppress the browser's default focus rect on Recharts'
-        inner SVG path elements -- clicking a wedge moved focus to
-        the path which then drew a white rectangular outline that
-        read as "selected" but ignored the wedge geometry. Use a
-        wedge-shaped feedback affordance instead: hover bumps
-        stroke + brightness; click triggers the existing
-        onWedgeClick navigation. The ownership-sunburst class
-        scopes the outline removal so it does not bleed to other
-        charts.
-      */}
       <style>{SUNBURST_STYLES}</style>
       <ResponsiveContainer width="100%" height="100%">
         <PieChart>
           <Tooltip content={<SunburstTooltip />} />
+          {/* Inner ring — single solid arc. Click navigates without a
+              filter (operator-side: "show me the L2 view"). */}
           <Pie
-            data={innerData}
+            data={[{ name: "Total", shares: 1 }]}
             dataKey="shares"
             innerRadius={innerInner}
             outerRadius={innerOuter}
             stroke={wedgeStroke}
             isAnimationActive={false}
-            onClick={(_, idx) => handleClick(innerData[idx]!)}
+            onClick={() => onWedgeClick?.({ kind: "center" })}
           >
-            {innerData.map((d, idx) => (
-              <Cell
-                key={`inner-${idx}`}
-                fill={d.fill}
-                fillOpacity={d.opacity}
-                stroke={wedgeStroke}
-              />
-            ))}
+            <Cell fill={theme.borderColor} fillOpacity={0.6} stroke={wedgeStroke} />
           </Pie>
           <Pie
-            data={middleData}
+            data={safeMiddle}
             dataKey="shares"
             innerRadius={innerOuter}
             outerRadius={middleOuter}
             stroke={wedgeStroke}
             isAnimationActive={false}
-            onClick={(_, idx) => handleClick(middleData[idx]!)}
+            onClick={(_, idx) => handleClick(safeMiddle[idx])}
           >
-            {middleData.map((d, idx) => (
+            {safeMiddle.map((d) => (
               <Cell
-                key={`middle-${idx}`}
+                key={d.id}
                 fill={d.fill}
-                fillOpacity={d.opacity}
-                stroke={wedgeStroke}
+                stroke={d.is_gap ? "transparent" : wedgeStroke}
+                data-known={d.is_gap ? "false" : "true"}
               />
             ))}
           </Pie>
           <Pie
-            data={outerData}
+            data={safeOuter}
             dataKey="shares"
             innerRadius={middleOuter}
             outerRadius={outerOuter}
             stroke={wedgeStroke}
             isAnimationActive={false}
-            onClick={(_, idx) => handleClick(outerData[idx]!)}
+            onClick={(_, idx) => handleClick(safeOuter[idx])}
           >
-            {outerData.map((d, idx) => (
+            {safeOuter.map((d) => (
               <Cell
-                key={`outer-${idx}`}
+                key={d.id}
                 fill={d.fill}
-                fillOpacity={d.opacity}
-                stroke={wedgeStroke}
+                stroke={d.is_gap ? "transparent" : wedgeStroke}
+                data-known={d.is_gap ? "false" : "true"}
               />
             ))}
           </Pie>
@@ -314,10 +259,10 @@ export function OwnershipSunburst({
       </ResponsiveContainer>
       <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
         <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-          Free float
+          Total shares
         </span>
         <span className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-          {formatShares(rings.free_float)}
+          {formatShares(denom)}
         </span>
       </div>
     </div>
@@ -327,36 +272,14 @@ export function OwnershipSunburst({
 function toCategoryDatum(
   cat: SunburstCategory,
   baseFill: string,
-  bg: string,
+  denom: number,
 ): ChartDatum {
-  if (cat.status === "unknown") {
-    // Unknown categories keep their accent color but at low opacity
-    // so the chart distinguishes "Institutions gap" from "ETFs gap"
-    // from "Treasury gap" visually. Pre-fix every unknown wedge
-    // collapsed to a single shared slate-600 → solid grey blob with
-    // no per-category identity.
-    return {
-      name: `${cat.label} — coverage gap`,
-      // Synthetic non-zero share count so the wedge renders visibly.
-      // ``is_gap=true`` tells the tooltip to suppress the numeric
-      // share/pct rows so hovering does not surface a misleading
-      // "1 shares".
-      shares: 1,
-      pct: 0,
-      fill: baseFill,
-      stroke: bg,
-      opacity: GAP_CATEGORY_OPACITY,
-      is_gap: true,
-      target: { kind: "category", category_key: cat.key },
-    };
-  }
   return {
+    id: `cat-${cat.key}`,
     name: cat.label,
-    shares: Math.max(cat.shares, 0),
-    pct: cat.pct,
+    shares: cat.shares,
+    pct: denom > 0 ? cat.shares / denom : 0,
     fill: baseFill,
-    stroke: bg,
-    opacity: cat.shares <= 0 ? 0 : 0.85,
     is_gap: false,
     target: { kind: "category", category_key: cat.key },
   };
@@ -364,41 +287,30 @@ function toCategoryDatum(
 
 function toLeafDatum(
   leaf: SunburstLeaf,
-  cat: SunburstCategory,
+  category_key: CategoryKey,
   baseFill: string,
-  bg: string,
+  denom: number,
 ): ChartDatum {
-  const status = cat.status;
-  if (status === "unknown") {
-    // Outer-ring leaf for an unknown category inherits the parent
-    // accent at a lower opacity than the middle wedge so the rings
-    // remain visually distinguishable while preserving category
-    // identity. Pre-fix the leaf used the same shared slate-600 as
-    // the middle wedge → both rings merged into one solid grey arc.
-    return {
-      name: leaf.label,
-      shares: 1,
-      pct: 0,
-      fill: baseFill,
-      stroke: bg,
-      opacity: GAP_LEAF_OPACITY,
-      is_gap: true,
-      target: { kind: "leaf", category_key: cat.key, leaf_key: leaf.key },
-    };
-  }
-  // "Other" rolls up sub-threshold holders. Render with a desaturated
-  // shade of the parent category's color so the operator sees it as
-  // "tail of the same slice" rather than a separate category.
-  const opacity = leaf.is_other ? 0.55 : 0.9;
   return {
+    id: `leaf-${category_key}-${leaf.key}`,
     name: leaf.label,
-    shares: Math.max(leaf.shares, 0),
-    pct: leaf.pct,
+    shares: leaf.shares,
+    pct: denom > 0 ? leaf.shares / denom : 0,
     fill: baseFill,
-    stroke: bg,
-    opacity: leaf.shares <= 0 ? 0 : opacity,
     is_gap: false,
-    target: { kind: "leaf", category_key: cat.key, leaf_key: leaf.key },
+    target: { kind: "leaf", category_key, leaf_key: leaf.key },
+  };
+}
+
+function makeGapDatum(id: string, name: string, shares: number, denom: number): ChartDatum {
+  return {
+    id,
+    name,
+    shares,
+    pct: denom > 0 ? shares / denom : 0,
+    fill: "transparent",
+    is_gap: true,
+    target: null,
   };
 }
 
@@ -414,21 +326,7 @@ interface RechartsTooltipProps {
 function SunburstTooltip(props: RechartsTooltipProps): JSX.Element | null {
   if (!props.active || props.payload === undefined || props.payload.length === 0) return null;
   const datum = props.payload[0]?.payload;
-  if (datum === undefined) return null;
-  // Coverage-gap wedges carry synthetic ``shares=1`` so the arc has
-  // visible thickness; suppress the numeric rows so the tooltip
-  // does not surface a misleading "1 shares / 0% of float" — show
-  // the operator-facing copy explaining the gap instead.
-  if (datum.is_gap) {
-    return (
-      <div className="rounded border border-slate-300 bg-white px-3 py-2 text-xs shadow-md dark:border-slate-700 dark:bg-slate-900">
-        <div className="font-medium text-slate-900 dark:text-slate-100">{datum.name}</div>
-        <div className="text-slate-600 dark:text-slate-400">
-          Data not available — gated on the #740 CUSIP backfill.
-        </div>
-      </div>
-    );
-  }
+  if (datum === undefined || datum.is_gap) return null;
   return (
     <div className="rounded border border-slate-300 bg-white px-3 py-2 text-xs shadow-md dark:border-slate-700 dark:bg-slate-900">
       <div className="font-medium text-slate-900 dark:text-slate-100">{datum.name}</div>
@@ -436,9 +334,83 @@ function SunburstTooltip(props: RechartsTooltipProps): JSX.Element | null {
         {formatShares(datum.shares)} shares
       </div>
       <div className="text-slate-600 dark:text-slate-400">
-        {formatPct(datum.pct)} of float
+        {formatPct(datum.pct)} of total shares
       </div>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Color legend
+// ---------------------------------------------------------------------------
+
+export interface OwnershipLegendProps {
+  readonly rings: SunburstRings;
+}
+
+/**
+ * Color legend for the sunburst. Renders one row per category that
+ * actually rendered, plus an "Unaccounted" row for the residual. Each
+ * row shows the swatch, label, share count, and % of outstanding so
+ * the operator can read the ring at a glance without hovering.
+ */
+export function OwnershipLegend({ rings }: OwnershipLegendProps): JSX.Element | null {
+  const theme = useChartTheme();
+  const denom = rings.total_shares;
+  if (denom <= 0) return null;
+
+  interface LegendRow {
+    readonly key: string;
+    readonly label: string;
+    readonly shares: number;
+    readonly pct: number;
+    readonly swatch_fill: string;
+    readonly swatch_outline: boolean;
+  }
+
+  const rows: LegendRow[] = rings.categories.map((cat) => ({
+    key: cat.key,
+    label: cat.label,
+    shares: cat.shares,
+    pct: cat.shares / denom,
+    swatch_fill: categoryFill(theme, cat.key),
+    swatch_outline: false,
+  }));
+  if (rings.category_residual > 0) {
+    rows.push({
+      key: "unaccounted",
+      label: "Unaccounted",
+      shares: rings.category_residual,
+      pct: rings.category_residual / denom,
+      swatch_fill: "transparent",
+      swatch_outline: true,
+    });
+  }
+  if (rows.length === 0) return null;
+
+  return (
+    <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+      {rows.map((row) => (
+        <li key={row.key} className="flex items-center gap-1.5">
+          <span
+            aria-hidden
+            className={`inline-block h-3 w-3 rounded-sm ${
+              row.swatch_outline
+                ? "border border-dashed border-slate-400 dark:border-slate-500"
+                : ""
+            }`}
+            style={{ backgroundColor: row.swatch_fill }}
+          />
+          <span className="text-slate-700 dark:text-slate-200">{row.label}</span>
+          <span className="font-mono text-slate-500 dark:text-slate-400">
+            {formatShares(row.shares)}
+          </span>
+          <span className="font-mono text-slate-400 dark:text-slate-500">
+            ({formatPct(row.pct)})
+          </span>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/frontend/src/components/instrument/ownershipRings.test.ts
+++ b/frontend/src/components/instrument/ownershipRings.test.ts
@@ -1,21 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  buildSunburstRings,
-  visibilityThreshold,
-} from "./ownershipRings";
+import { buildSunburstRings, visibilityThreshold } from "./ownershipRings";
 import type { SunburstHolder, SunburstInputs } from "./ownershipRings";
 
-// treasury_shares=0 (a positive "we know there is no treasury" signal)
-// means the default category set is fully known — individual tests
-// override to ``null`` to exercise the DEI-projection-gap path.
 const DEFAULT_INPUT: SunburstInputs = {
-  free_float: 1_000_000_000,
+  total_shares: 1_000_000_000,
   holders: [],
-  treasury_shares: 0,
-  institutions_status: "ok",
-  etfs_status: "ok",
-  insiders_status: "ok",
+  institutions_total: null,
+  etfs_total: null,
+  insiders_total: null,
+  treasury_shares: null,
 };
 
 function holder(
@@ -27,237 +21,244 @@ function holder(
 }
 
 describe("visibilityThreshold", () => {
-  it("returns 0.5% of float for normal-cap floats", () => {
+  it("returns 0.5% of denominator for normal-cap counts", () => {
     expect(visibilityThreshold(1_000_000_000)).toBe(5_000_000);
     expect(visibilityThreshold(15_000_000_000)).toBe(75_000_000);
   });
 
-  it("clamps to 10,000-share floor for micro-cap floats", () => {
-    // 1M float * 0.5% = 5,000 shares — below 10k floor.
+  it("clamps to 10,000-share floor for micro-cap counts", () => {
     expect(visibilityThreshold(1_000_000)).toBe(10_000);
     expect(visibilityThreshold(0)).toBe(10_000);
     expect(visibilityThreshold(-50_000)).toBe(10_000);
   });
 });
 
-describe("buildSunburstRings", () => {
-  it("returns null on missing or zero float", () => {
-    expect(buildSunburstRings({ ...DEFAULT_INPUT, free_float: 0 })).toBeNull();
-    expect(buildSunburstRings({ ...DEFAULT_INPUT, free_float: NaN })).toBeNull();
+describe("buildSunburstRings — denominator + null handling", () => {
+  it("returns null on missing or non-positive total_shares", () => {
+    expect(buildSunburstRings({ ...DEFAULT_INPUT, total_shares: 0 })).toBeNull();
+    expect(buildSunburstRings({ ...DEFAULT_INPUT, total_shares: -1 })).toBeNull();
+    expect(buildSunburstRings({ ...DEFAULT_INPUT, total_shares: NaN })).toBeNull();
   });
 
-  it("inner ring known/gap split = full float when every category is known", () => {
-    const input: SunburstInputs = {
+  it("preserves total_shares as the denominator and exposes reported_total", () => {
+    const r = buildSunburstRings({ ...DEFAULT_INPUT });
+    expect(r!.total_shares).toBe(1_000_000_000);
+    expect(r!.reported_total).toBe(1_000_000_000);
+  });
+
+  it("renders no categories when every total is null/zero", () => {
+    const r = buildSunburstRings({ ...DEFAULT_INPUT });
+    expect(r!.categories).toEqual([]);
+    expect(r!.category_residual).toBe(1_000_000_000);
+  });
+});
+
+describe("buildSunburstRings — category sizing", () => {
+  it("includes a category when its total is positive", () => {
+    const r = buildSunburstRings({
       ...DEFAULT_INPUT,
-      holders: [holder("vanguard", 100_000_000, "institutions")],
-    };
-    const r = buildSunburstRings(input);
-    expect(r).not.toBeNull();
-    // Float=1B, institutions=100M, unallocated=900M, gap=0.
-    expect(r!.inner.known_shares).toBe(1_000_000_000);
-    expect(r!.inner.gap_shares).toBe(0);
-    expect(r!.inner.known_pct).toBeCloseTo(1);
-    expect(r!.inner.gap_pct).toBeCloseTo(0);
+      institutions_total: 500_000_000,
+      holders: [holder("vanguard", 200_000_000, "institutions")],
+    });
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.shares).toBe(500_000_000);
+    expect(inst.reported_total).toBe(500_000_000);
   });
 
+  it("category_residual equals denom minus sum of category totals", () => {
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      institutions_total: 500_000_000,
+      etfs_total: 200_000_000,
+      insiders_total: 50_000_000,
+      treasury_shares: 30_000_000,
+      holders: [
+        holder("inst1", 200_000_000, "institutions"),
+        holder("etf1", 100_000_000, "etfs"),
+        holder("officer", 30_000_000, "insiders"),
+      ],
+    });
+    // 1B − (500M + 200M + 50M + 30M) = 220M residual.
+    expect(r!.category_residual).toBe(220_000_000);
+  });
+
+  it("category_residual stays at total_shares when no categories render", () => {
+    const r = buildSunburstRings({ ...DEFAULT_INPUT });
+    expect(r!.category_residual).toBe(1_000_000_000);
+  });
+
+  it("treasury renders as a single-leaf category", () => {
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      treasury_shares: 50_000_000,
+    });
+    const treasury = r!.categories.find((c) => c.key === "treasury")!;
+    expect(treasury.shares).toBe(50_000_000);
+    expect(treasury.leaves).toHaveLength(1);
+    expect(treasury.within_category_gap).toBe(0);
+  });
+});
+
+describe("buildSunburstRings — within-category gaps", () => {
+  it("renders within_category_gap = total − resolved when filers are incomplete", () => {
+    // Institutions total = 500M; we resolve only 350M to named filers
+    // (CUSIP-backfill gap). Outer ring should leave 150M empty.
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      institutions_total: 500_000_000,
+      holders: [
+        holder("vanguard", 200_000_000, "institutions"),
+        holder("blackrock", 150_000_000, "institutions"),
+      ],
+    });
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.shares).toBe(500_000_000);
+    expect(inst.resolved_leaf_shares).toBe(350_000_000);
+    expect(inst.within_category_gap).toBe(150_000_000);
+  });
+
+  it("within_category_gap is zero when filers fully cover the total", () => {
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      institutions_total: 350_000_000,
+      holders: [
+        holder("vanguard", 200_000_000, "institutions"),
+        holder("blackrock", 150_000_000, "institutions"),
+      ],
+    });
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.within_category_gap).toBe(0);
+  });
+
+  it("snapshot-lag: bumps category shares to sum(leaves) when filers oversubscribe", () => {
+    // 13F filer detail can be slightly newer than the totals
+    // snapshot — a holder may report shares the aggregate doesn't
+    // yet reflect. ``shares`` becomes max(reported, sum_of_leaves)
+    // so ring 3 fits inside ring 2; ``reported_total`` preserved for
+    // diagnostics; within_category_gap becomes 0.
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      institutions_total: 100_000_000,
+      holders: [holder("vanguard", 120_000_000, "institutions")],
+    });
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.shares).toBe(120_000_000);
+    expect(inst.reported_total).toBe(100_000_000);
+    expect(inst.resolved_leaf_shares).toBe(120_000_000);
+    expect(inst.within_category_gap).toBe(0);
+  });
+
+  it("within_category_gap = total when API reports a total but no per-filer detail", () => {
+    // Common case: institutional total known via reader endpoint
+    // but CUSIP-backfill (#740) hasn't run, filers list empty.
+    // Whole category renders as a transparent within-category gap.
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      institutions_total: 500_000_000,
+      holders: [],
+    });
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.shares).toBe(500_000_000);
+    expect(inst.resolved_leaf_shares).toBe(0);
+    expect(inst.within_category_gap).toBe(500_000_000);
+    expect(inst.leaves).toHaveLength(0);
+  });
+});
+
+describe("buildSunburstRings — cross-category oversubscription", () => {
+  it("bumps total_shares to sum_known when category totals exceed input denominator", () => {
+    // Outstanding lag: XBRL period-end is slightly older than the
+    // 13F snapshot, and reported institutional + insider shares
+    // exceed the recorded outstanding. Bumping the effective denom
+    // prevents Recharts from renormalising ring 2 to 360° at the
+    // wrong proportions.
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      total_shares: 1_000_000_000,
+      institutions_total: 800_000_000,
+      etfs_total: 300_000_000,
+      holders: [
+        holder("vanguard", 800_000_000, "institutions"),
+        holder("spdr", 300_000_000, "etfs"),
+      ],
+    });
+    expect(r!.reported_total).toBe(1_000_000_000);
+    expect(r!.total_shares).toBe(1_100_000_000);
+    expect(r!.category_residual).toBe(0);
+  });
+
+  it("leaves total_shares unchanged when categories fit within reported_total", () => {
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      institutions_total: 500_000_000,
+    });
+    expect(r!.total_shares).toBe(1_000_000_000);
+    expect(r!.reported_total).toBe(1_000_000_000);
+    expect(r!.category_residual).toBe(500_000_000);
+  });
+});
+
+describe("buildSunburstRings — outer-ring threshold grouping", () => {
   it("filer above threshold gets its own outer-ring wedge", () => {
-    // Threshold for 1B float = 5M. Vanguard at 100M passes.
-    const input: SunburstInputs = {
+    const r = buildSunburstRings({
       ...DEFAULT_INPUT,
+      institutions_total: 100_000_000,
       holders: [holder("vanguard", 100_000_000, "institutions")],
-    };
-    const r = buildSunburstRings(input);
-    expect(r).not.toBeNull();
+    });
     const inst = r!.categories.find((c) => c.key === "institutions")!;
     expect(inst.leaves).toHaveLength(1);
     expect(inst.leaves[0]!.key).toBe("vanguard");
-    expect(inst.leaves[0]!.is_other).toBe(false);
   });
 
-  it("filer below threshold rolls into 'Other' aggregate wedge", () => {
-    const input: SunburstInputs = {
+  it("sub-threshold filers aggregate into 'Other' with tail metadata", () => {
+    const r = buildSunburstRings({
       ...DEFAULT_INPUT,
+      institutions_total: 102_000_000,
       holders: [
-        holder("vanguard", 100_000_000, "institutions"),  // visible
-        holder("small1", 1_000_000, "institutions"),       // < 5M threshold
-        holder("small2", 500_000, "institutions"),         // < 5M threshold
-        holder("small3", 100_000, "institutions"),         // < 5M threshold
+        holder("vanguard", 100_000_000, "institutions"),
+        holder("small1", 1_000_000, "institutions"),
+        holder("small2", 800_000, "institutions"),
+        holder("small3", 200_000, "institutions"),
       ],
-    };
-    const r = buildSunburstRings(input);
+    });
     const inst = r!.categories.find((c) => c.key === "institutions")!;
     expect(inst.leaves).toHaveLength(2);
     const other = inst.leaves[1]!;
     expect(other.is_other).toBe(true);
-    expect(other.shares).toBe(1_600_000);
+    expect(other.shares).toBe(2_000_000);
     expect(other.tail_meta!.count).toBe(3);
-    expect(other.tail_meta!.aggregate_shares).toBe(1_600_000);
     expect(other.tail_meta!.largest_label).toBe("small1");
   });
 
-  it("'Other' tail meta surfaces the largest sub-threshold holder for context", () => {
-    // Operator wants to know the top of the tail without expanding —
-    // pin that ``largest_label`` is correct on a multi-holder tail.
-    const input: SunburstInputs = {
-      ...DEFAULT_INPUT,
-      holders: [
-        holder("BIG", 100_000_000, "institutions"),
-        holder("renaissance", 4_000_000, "institutions"), // below 5M
-        holder("citadel", 4_500_000, "institutions"),     // below 5M, biggest in tail
-        holder("two_sigma", 500_000, "institutions"),
-      ],
-    };
-    const r = buildSunburstRings(input);
-    const inst = r!.categories.find((c) => c.key === "institutions")!;
-    const other = inst.leaves.find((l) => l.is_other)!;
-    expect(other.tail_meta!.largest_label).toBe("citadel");
-    expect(other.tail_meta!.largest_pct).toBeCloseTo(0.0045);
-  });
-
-  it("micro-cap respects 10k-share floor — not 0.5%-of-float", () => {
-    // 1M float, 0.5% = 5k shares — but floor is 10k.
-    // Holder with 8k shares should fall into "Other" not visible.
-    const input: SunburstInputs = {
-      free_float: 1_000_000,
-      holders: [
-        holder("alice", 50_000, "institutions"),  // visible (>10k)
-        holder("bob", 8_000, "institutions"),     // < 10k floor
-      ],
-      treasury_shares: null,
-      institutions_status: "ok",
-      etfs_status: "ok",
-      insiders_status: "ok",
-    };
-    const r = buildSunburstRings(input);
-    const inst = r!.categories.find((c) => c.key === "institutions")!;
-    expect(inst.leaves.find((l) => l.key === "alice")).toBeDefined();
-    const other = inst.leaves.find((l) => l.is_other);
-    expect(other?.tail_meta?.count).toBe(1);
-    expect(other?.shares).toBe(8_000);
-  });
-
   it("insiders bypass the threshold — every officer surfaces", () => {
-    // Threshold for 1B float = 5M. Officer holding 1M would normally
-    // fall into "Other" for institutions, but for insiders every
-    // officer should surface as their own wedge.
-    const input: SunburstInputs = {
+    const r = buildSunburstRings({
       ...DEFAULT_INPUT,
+      insiders_total: 1_600_000,
       holders: [
         holder("ceo", 1_000_000, "insiders"),
         holder("cfo", 500_000, "insiders"),
         holder("cto", 100_000, "insiders"),
       ],
-    };
-    const r = buildSunburstRings(input);
+    });
     const insiders = r!.categories.find((c) => c.key === "insiders")!;
     expect(insiders.leaves).toHaveLength(3);
     expect(insiders.leaves.every((l) => !l.is_other)).toBe(true);
   });
 
-  it("category status='unknown' renders a coverage-gap leaf, not 0%", () => {
-    const input: SunburstInputs = {
+  it("micro-cap respects 10k-share floor — not 0.5% of total", () => {
+    const r = buildSunburstRings({
       ...DEFAULT_INPUT,
-      institutions_status: "unknown",
-      etfs_status: "unknown",
-    };
-    const r = buildSunburstRings(input);
-    const inst = r!.categories.find((c) => c.key === "institutions")!;
-    expect(inst.status).toBe("unknown");
-    expect(inst.unknown_reason).toBe("cusip_backfill");
-    expect(inst.leaves).toHaveLength(1);
-    expect(inst.leaves[0]!.label).toContain("CUSIP backfill");
-    // Unallocated collapses to 'empty' when an upstream category
-    // is unknown — its residual would be contaminated by the
-    // upstream gap and would mislead the operator if surfaced.
-    const unalloc = r!.categories.find((c) => c.key === "unallocated")!;
-    expect(unalloc.status).toBe("empty");
-    expect(unalloc.shares).toBe(0);
-  });
-
-  it("inner ring splits known vs gap when categories are unknown", () => {
-    // Only insiders + treasury known; institutions + ETFs gated by
-    // CUSIP backfill. Inner ring's gap_shares should equal float
-    // minus everything we genuinely know.
-    const input: SunburstInputs = {
-      ...DEFAULT_INPUT,
-      holders: [holder("ceo", 50_000_000, "insiders")],
-      treasury_shares: 30_000_000,
-      institutions_status: "unknown",
-      etfs_status: "unknown",
-    };
-    const r = buildSunburstRings(input);
-    expect(r).not.toBeNull();
-    // Known = insiders 50M + treasury 30M = 80M.
-    expect(r!.inner.known_shares).toBe(80_000_000);
-    // Gap = float 1B - 80M = 920M.
-    expect(r!.inner.gap_shares).toBe(920_000_000);
-    expect(r!.inner.known_pct).toBeCloseTo(0.08);
-    expect(r!.inner.gap_pct).toBeCloseTo(0.92);
-  });
-
-  it("treasury wedge present when treasury_shares > 0", () => {
-    const input: SunburstInputs = {
-      ...DEFAULT_INPUT,
-      treasury_shares: 10_000_000,
-    };
-    const r = buildSunburstRings(input);
-    const treasury = r!.categories.find((c) => c.key === "treasury")!;
-    expect(treasury.status).toBe("ok");
-    expect(treasury.shares).toBe(10_000_000);
-    expect(treasury.leaves).toHaveLength(1);
-  });
-
-  it("treasury status='unknown' with reason='dei_projection' when input is null", () => {
-    // Treasury_shares null is the #735 / DEI projection gap, not
-    // the CUSIP backfill. Operator-facing copy should surface that
-    // distinction so they don't conflate the two follow-ups.
-    const input: SunburstInputs = {
-      ...DEFAULT_INPUT,
-      treasury_shares: null,
-    };
-    const r = buildSunburstRings(input);
-    const treasury = r!.categories.find((c) => c.key === "treasury")!;
-    expect(treasury.status).toBe("unknown");
-    expect(treasury.unknown_reason).toBe("dei_projection");
-    expect(treasury.leaves[0]!.label).toContain("DEI projection");
-  });
-
-  it("unallocated absorbs the float residual when every category is known", () => {
-    // 1B float, 100M institutions, 50M ETFs, 20M insiders, 10M
-    // treasury → 820M unallocated.
-    const input: SunburstInputs = {
-      ...DEFAULT_INPUT,
+      total_shares: 1_000_000,
+      institutions_total: 58_000,
       holders: [
-        holder("inst", 100_000_000, "institutions"),
-        holder("etf", 50_000_000, "etfs"),
-        holder("officer", 20_000_000, "insiders"),
+        holder("alice", 50_000, "institutions"),
+        holder("bob", 8_000, "institutions"),
       ],
-      treasury_shares: 10_000_000,
-    };
-    const r = buildSunburstRings(input);
-    const unalloc = r!.categories.find((c) => c.key === "unallocated")!;
-    expect(unalloc.shares).toBe(820_000_000);
-    expect(unalloc.status).toBe("ok");
-  });
-
-  it("category sort: largest leaf first within each category", () => {
-    const input: SunburstInputs = {
-      ...DEFAULT_INPUT,
-      holders: [
-        holder("smaller", 50_000_000, "institutions"),
-        holder("larger", 200_000_000, "institutions"),
-      ],
-    };
-    const r = buildSunburstRings(input);
+    });
     const inst = r!.categories.find((c) => c.key === "institutions")!;
-    expect(inst.leaves[0]!.key).toBe("larger");
-    expect(inst.leaves[1]!.key).toBe("smaller");
-  });
-
-  it("empty category renders status='empty' with no leaves", () => {
-    const r = buildSunburstRings({ ...DEFAULT_INPUT });
-    const inst = r!.categories.find((c) => c.key === "institutions")!;
-    expect(inst.status).toBe("empty");
-    expect(inst.leaves).toHaveLength(0);
+    expect(inst.leaves.find((l) => l.key === "alice")).toBeDefined();
+    const other = inst.leaves.find((l) => l.is_other);
+    expect(other?.tail_meta?.count).toBe(1);
+    expect(other?.shares).toBe(8_000);
   });
 });

--- a/frontend/src/components/instrument/ownershipRings.ts
+++ b/frontend/src/components/instrument/ownershipRings.ts
@@ -1,371 +1,270 @@
 /**
- * Sunburst data transformer for the ownership card (#729).
+ * Ownership sunburst data model (#729).
  *
- * Three concentric rings:
+ * Three concentric rings keyed on a single denominator:
+ * ``total_shares`` (= ``shares_outstanding + treasury_shares``).
+ * Treasury counts toward the denominator because the operator's
+ * mental model is "100% of issued / allotted shares — some held in
+ * the market, some held back in the company's vault". Treasury
+ * appears as one of the categories.
  *
- *   ring 1 (inner)  : single arc — "Held" (sum of all categories below)
- *   ring 2 (middle) : per-category — Institutions / ETFs / Insiders / Treasury / Unallocated
- *   ring 3 (outer)  : per-filer / per-officer wedges within each category, plus
- *                     "Other [Category]" tail-aggregate when individual filers
- *                     fall below the visibility threshold.
+ *   ring 1 (inner)  : center hole shows ``total_shares``.
+ *   ring 2 (middle) : per-category wedges sized faithfully against
+ *                     ``total_shares``. Categories with shares=0 are
+ *                     not rendered. After every known category, a
+ *                     single transparent wedge soaks up the residual
+ *                     so the visible arcs stop short and the operator
+ *                     sees a literal empty arc for the unaccounted
+ *                     portion of the float.
+ *   ring 3 (outer)  : per-filer / per-officer wedges within each
+ *                     category, sized faithfully. If a category's
+ *                     known leaves sum to less than the category
+ *                     total (e.g. Institutions reports 50% of
+ *                     outstanding via 13F totals but only resolves
+ *                     47% to named filers), the outer ring shows
+ *                     a transparent arc for the within-category
+ *                     gap.
  *
- * Threshold-based grouping (vs top-N):
- *   * 0.5% of float OR 10,000 shares — whichever is larger
- *   * The float-relative floor keeps mega-caps with hundreds of small
- *     13F filers from drowning the canvas in confetti while still
- *     promoting any holder large enough to move the thesis.
- *   * The 10,000-share absolute floor prevents thinly-floated
- *     micro-caps from setting an effectively-zero threshold that
- *     would render every legitimate holder.
- *   * Insiders bypass the threshold — the officer set is small and
- *     every officer's holding is signal.
+ * Threshold-based grouping for outer-ring leaves: every filer that
+ * meets ``max(0.5% of outstanding, 10,000 shares)`` gets its own
+ * wedge. Sub-threshold filers aggregate into "Other [Category]"
+ * with tail metadata.
  *
- * Coverage gating: when a category's total is unknown (Institutions /
- * ETFs gated on #740 CUSIP backfill), the transformer emits a
- * sentinel ``status='unknown'`` middle wedge sized to the residual
- * (free-float minus known categories) so the operator sees the gap
- * visually rather than as missing slices.
+ * Snapshot-lag / oversubscription handling — both can occur because
+ * totals (13F aggregate snapshot, XBRL period-end balance) and
+ * per-filer detail (13F filings) carry independent snapshot dates:
+ *
+ *   * Per-category leaf cap: when filer detail sums to MORE than the
+ *     category total (snapshot lag), the category's reported total
+ *     is bumped to ``max(reported, sum_of_leaves)``. The leaves are
+ *     more recent ground truth — using their sum as the wedge size
+ *     keeps ring 3 inside ring 2 geometrically.
+ *   * Cross-category oversubscription: when category totals sum to
+ *     more than the input ``total_shares`` (XBRL outstanding +
+ *     treasury can lag), the effective denominator is bumped to the
+ *     sum so wedges aren't silently renormalised by Recharts.
+ *
+ * No synthetic placeholders. No "unknown" status hack. The chart
+ * faithfully reports what we know and literally leaves the rest
+ * empty.
  */
-
-export type SunburstCategoryStatus = "ok" | "unknown" | "empty";
-
-/**
- * Why a category resolves to ``status='unknown'``. Drives the
- * tooltip + summary copy so the operator distinguishes a CUSIP
- * backfill gap (#740) from a missing DEI cover-page projection
- * (#735) etc. Today only ``cusip_backfill`` is wired through;
- * ``dei_projection`` is reserved for treasury_shares specifically
- * and lights up once #735 surfaces the column.
- */
-export type SunburstUnknownReason =
-  | "cusip_backfill"
-  | "dei_projection"
-  | "no_data";
-
-export interface SunburstCategory {
-  readonly key: string; // 'institutions' | 'etfs' | 'insiders' | 'treasury' | 'unallocated'
-  readonly label: string;
-  readonly shares: number;
-  readonly pct: number; // share / float
-  readonly status: SunburstCategoryStatus;
-  /** Set only when ``status === 'unknown'``. */
-  readonly unknown_reason?: SunburstUnknownReason;
-  /** Outer-ring wedges within this category. */
-  readonly leaves: readonly SunburstLeaf[];
-}
-
-export interface SunburstLeaf {
-  readonly key: string; // stable id for click-drill (filer cik, officer name, "other-etfs")
-  readonly label: string;
-  readonly shares: number;
-  readonly pct: number; // share / float
-  /** True for the aggregated tail wedge. */
-  readonly is_other: boolean;
-  /** Counts only meaningful on the "Other" tail wedge. */
-  readonly tail_meta?: SunburstTailMeta;
-}
-
-export interface SunburstTailMeta {
-  readonly count: number;
-  readonly aggregate_shares: number;
-  readonly aggregate_pct: number;
-  readonly largest_label: string;
-  readonly largest_pct: number;
-}
 
 export interface SunburstHolder {
   /** Stable identifier — filer CIK, officer CIK, or fallback name. */
   readonly key: string;
   readonly label: string;
   readonly shares: number;
-  readonly category: "institutions" | "etfs" | "insiders";
+  readonly category: "institutions" | "etfs" | "insiders" | "treasury";
 }
 
 export interface SunburstInputs {
-  readonly free_float: number;
-  /** Holders contributing to Institutions / ETFs / Insiders. */
+  /** Denominator. Every category + leaf is sized as a proportion of
+   *  this number; the visible arcs sum to ≤100%. Callers typically
+   *  compute this as ``shares_outstanding + (treasury_shares ?? 0)``. */
+  readonly total_shares: number;
+
+  /** Per-filer detail for institutional / ETF / insider categories.
+   *  May be incomplete (e.g. CUSIP-backfill #740 means many filers
+   *  resolve to no instrument and are dropped). */
   readonly holders: readonly SunburstHolder[];
-  /** Treasury memo line — single wedge under its own middle category. */
+
+  /** Aggregate share counts per category from the upstream API.
+   *  These can exceed ``sum(holders.shares)`` when the per-filer
+   *  detail is incomplete — the ring 3 transparent arc visualises
+   *  that gap. ``null`` = the API returned no data; the category
+   *  does not render at all (its share of the ring stays empty). */
+  readonly institutions_total: number | null;
+  readonly etfs_total: number | null;
+  readonly insiders_total: number | null;
+
+  /** Treasury (issuer-held) shares from XBRL. ``null`` = not on
+   *  file; treasury wedge does not render. Counted in the
+   *  denominator when present. */
   readonly treasury_shares: number | null;
-  /**
-   * Per-category status flags. ``unknown`` short-circuits the
-   * transformer for that category so ungated CUSIP coverage doesn't
-   * silently appear as 0%.
-   */
-  readonly institutions_status: SunburstCategoryStatus;
-  readonly etfs_status: SunburstCategoryStatus;
-  readonly insiders_status: SunburstCategoryStatus;
 }
 
-/**
- * Inner-ring split. Pre-#746 the inner ring reported "Held" as a
- * single arc summing every category including the synthetic
- * ``unknown`` placeholders — so an instrument with 95% of its
- * float in coverage-gap categories rendered a 100% Held arc,
- * which lied. Now the inner ring carries explicit ``known`` and
- * ``gap`` segments and the renderer draws them as two arcs.
- */
-export interface InnerRing {
-  /** Sum of every category whose status is ``ok``. */
-  readonly known_shares: number;
-  /** Sum of every category whose status is ``unknown`` — i.e. the
-   *  free-float residual that we cannot account for today. */
-  readonly gap_shares: number;
-  readonly known_pct: number;
-  readonly gap_pct: number;
+export type CategoryKey = "institutions" | "etfs" | "insiders" | "treasury";
+
+export interface SunburstLeaf {
+  readonly key: string;
+  readonly label: string;
+  readonly shares: number;
+  /** True for the aggregated tail wedge from threshold grouping. */
+  readonly is_other: boolean;
+  readonly tail_meta?: SunburstTailMeta;
+}
+
+export interface SunburstTailMeta {
+  readonly count: number;
+  readonly aggregate_shares: number;
+  readonly largest_label: string;
+  readonly largest_shares: number;
+}
+
+export interface SunburstCategory {
+  readonly key: CategoryKey;
+  readonly label: string;
+  /** Aggregate share count for the category. Drives the middle-ring
+   *  wedge size. Bumped to ``sum(leaves)`` when filer detail
+   *  oversubscribes the upstream-reported total (snapshot lag). */
+  readonly shares: number;
+  /** Upstream-reported total before snapshot-lag bump. Surfaced for
+   *  diagnostics — operator-facing copy can flag when ``shares !=
+   *  reported_total``. */
+  readonly reported_total: number;
+  /** Sum of named-filer shares we have detail on. Equals
+   *  ``shares`` when detail is complete; less when incomplete. */
+  readonly resolved_leaf_shares: number;
+  /** Per-filer wedges. */
+  readonly leaves: readonly SunburstLeaf[];
+  /** Outer-ring residual = ``shares - resolved_leaf_shares``. The
+   *  renderer paints a transparent wedge of this size so the named
+   *  leaves don't get inflated to fill the parent arc. */
+  readonly within_category_gap: number;
 }
 
 export interface SunburstRings {
-  readonly free_float: number;
-  readonly inner: InnerRing;
-  /** ring 2 — per-category wedges. */
+  /** Effective denominator. Equals input ``total_shares`` unless
+   *  category totals oversubscribe — in that case bumped to the
+   *  sum so wedges aren't silently renormalised by Recharts. */
+  readonly total_shares: number;
+  /** Input ``total_shares`` before oversubscription bump. Surfaced
+   *  for diagnostic copy when the two diverge. */
+  readonly reported_total: number;
+  /** Categories that render. Any category whose total is null/0 is
+   *  omitted; its proportion of the ring stays empty. */
   readonly categories: readonly SunburstCategory[];
+  /** ``total_shares - sum(categories.shares)``. The renderer paints
+   *  a transparent wedge of this size on ring 2 so the visible arcs
+   *  faithfully report only what we know. */
+  readonly category_residual: number;
 }
 
 const SHARES_FLOOR = 10_000;
-const FLOAT_PCT_FLOOR = 0.005; // 0.5%
+const OUTSTANDING_PCT_FLOOR = 0.005; // 0.5%
 
 /**
- * Compute the per-category visibility threshold for outer-ring wedges.
+ * Per-category visibility threshold for outer-ring leaves. Filers
+ * below this size aggregate into the category's "Other" wedge.
  *
- * Insiders ignore this — every officer surfaces.
+ * Insiders ignore the threshold — every officer surfaces.
  */
-export function visibilityThreshold(free_float: number): number {
-  if (free_float <= 0) return SHARES_FLOOR;
-  return Math.max(SHARES_FLOOR, free_float * FLOAT_PCT_FLOOR);
+export function visibilityThreshold(total_shares: number): number {
+  if (total_shares <= 0) return SHARES_FLOOR;
+  return Math.max(SHARES_FLOOR, total_shares * OUTSTANDING_PCT_FLOOR);
 }
 
-interface CategorySpec {
-  readonly key: "institutions" | "etfs" | "insiders" | "treasury" | "unallocated";
-  readonly label: string;
-  readonly status: SunburstCategoryStatus;
-  /** Reason an unknown-status category resolved unknown — drives
-   *  the operator-facing tooltip + summary copy. */
-  readonly unknown_reason?: SunburstUnknownReason;
-  /** True = bypass the visibility threshold (insiders, treasury, unallocated). */
-  readonly bypass_threshold: boolean;
-}
-
-const CATEGORY_LABEL: Record<string, string> = {
+const CATEGORY_LABEL: Record<CategoryKey, string> = {
   institutions: "Institutions",
   etfs: "ETFs",
   insiders: "Insiders",
   treasury: "Treasury",
-  unallocated: "Unallocated",
 };
 
 /**
- * Transform raw inputs into the three-ring sunburst data model.
- *
- * Returns ``null`` when ``free_float`` is missing / zero — the caller
- * renders the card empty state (no denominator → no rings).
+ * Build the ring data. Returns ``null`` when ``total_shares`` is
+ * missing / zero — caller renders the empty state.
  */
 export function buildSunburstRings(input: SunburstInputs): SunburstRings | null {
-  if (input.free_float <= 0 || !Number.isFinite(input.free_float)) return null;
-
-  const float = input.free_float;
-  const threshold = visibilityThreshold(float);
+  const reported_total = input.total_shares;
+  if (reported_total <= 0 || !Number.isFinite(reported_total)) return null;
 
   const inst_holders = input.holders.filter((h) => h.category === "institutions");
   const etf_holders = input.holders.filter((h) => h.category === "etfs");
   const insider_holders = input.holders.filter((h) => h.category === "insiders");
 
-  const institutions = buildCategory(
-    {
-      key: "institutions",
-      label: CATEGORY_LABEL.institutions!,
-      status: input.institutions_status,
-      unknown_reason: "cusip_backfill",
-      bypass_threshold: false,
-    },
-    inst_holders,
-    float,
-    threshold,
-  );
-  const etfs = buildCategory(
-    {
-      key: "etfs",
-      label: CATEGORY_LABEL.etfs!,
-      status: input.etfs_status,
-      unknown_reason: "cusip_backfill",
-      bypass_threshold: false,
-    },
-    etf_holders,
-    float,
-    threshold,
-  );
-  const insiders = buildCategory(
-    {
-      key: "insiders",
-      label: CATEGORY_LABEL.insiders!,
-      status: input.insiders_status,
-      unknown_reason: "no_data",
-      bypass_threshold: true,
-    },
-    insider_holders,
-    float,
-    threshold,
-  );
+  // Threshold should align with the effective denominator the chart
+  // ends up rendering against. When category totals oversubscribe
+  // ``reported_total`` (snapshot lag), the renderer bumps the
+  // denominator to ``sum_known`` — base the visibility threshold on
+  // a pessimistic upper bound (max of reported_total and the sum of
+  // every input holder's shares) so the 0.5% rule applies to the
+  // denom the operator actually sees.
+  const sum_holders = input.holders.reduce((s, h) => s + h.shares, 0);
+  const threshold = visibilityThreshold(Math.max(reported_total, sum_holders));
 
-  // Treasury renders as a single leaf wedge.
-  // Distinguish "treasury reported as zero" from "DEI projection
-  // missing" — treasury_shares=null is the #735 / #731 follow-up,
-  // not the CUSIP-backfill #740 gap.
-  const treasury_shares = input.treasury_shares ?? 0;
-  const treasury_status: SunburstCategoryStatus =
-    input.treasury_shares === null
-      ? "unknown"
-      : treasury_shares > 0
-        ? "ok"
-        : "empty";
-  const treasury: SunburstCategory = {
-    key: "treasury",
-    label: CATEGORY_LABEL.treasury!,
-    shares: treasury_shares,
-    pct: treasury_shares / float,
-    status: treasury_status,
-    ...(treasury_status === "unknown"
-      ? { unknown_reason: "dei_projection" as const }
-      : {}),
-    leaves:
-      treasury_status === "unknown"
-        ? [
-            {
-              key: "treasury-unknown",
-              label: "Treasury — DEI projection pending",
-              shares: 0,
-              pct: 0,
-              is_other: false,
-            },
-          ]
-        : treasury_shares > 0
-          ? [
-              {
-                key: "treasury",
-                label: "Treasury",
-                shares: treasury_shares,
-                pct: treasury_shares / float,
-                is_other: false,
-              },
-            ]
-          : [],
-  };
+  const categories: SunburstCategory[] = [];
 
-  // Unallocated absorbs whatever's left after every known category. When
-  // any category is ``unknown`` we cannot derive Unallocated cleanly —
-  // emit it as ``empty`` so the operator's eye lands on the
-  // upstream-unknown wedges as the source of the gap, not on a
-  // fabricated "Unallocated coverage gap" downstream wedge.
-  const known_shares =
-    (institutions.status === "ok" ? institutions.shares : 0) +
-    (etfs.status === "ok" ? etfs.shares : 0) +
-    (insiders.status === "ok" ? insiders.shares : 0) +
-    (treasury.status === "ok" ? treasury.shares : 0);
-
-  const has_unknown =
-    institutions.status === "unknown" ||
-    etfs.status === "unknown" ||
-    insiders.status === "unknown" ||
-    treasury.status === "unknown";
-
-  const residual_shares = Math.max(0, float - known_shares);
-  // When every category is ``ok``, residual is the genuine
-  // Unallocated slice (retail + small holders below the 13F threshold).
-  // When any category is ``unknown``, the residual is contaminated
-  // by the upstream gap and would mislead — collapse to ``empty``.
-  const unallocated: SunburstCategory = {
-    key: "unallocated",
-    label: CATEGORY_LABEL.unallocated!,
-    shares: has_unknown ? 0 : residual_shares,
-    pct: has_unknown ? 0 : residual_shares / float,
-    status: has_unknown ? "empty" : residual_shares > 0 ? "ok" : "empty",
-    leaves: has_unknown
-      ? []
-      : residual_shares > 0
-        ? [
-            {
-              key: "unallocated",
-              label: "Unallocated",
-              shares: residual_shares,
-              pct: residual_shares / float,
-              is_other: false,
-            },
-          ]
-        : [],
-  };
-
-  const categories = [institutions, etfs, insiders, treasury, unallocated];
-
-  // Inner-ring split: known (sum of OK categories + the
-  // ok-status Unallocated residual) vs gap (everything else =
-  // float minus known). Pre-fix the inner ring carried the synthetic
-  // unknown-padding through unaltered, lighting up as a 100% Held
-  // arc even when 95% of the float was in coverage gaps.
-  const inner_known = known_shares + (unallocated.status === "ok" ? unallocated.shares : 0);
-  const inner_gap = Math.max(0, float - inner_known);
-
-  return {
-    free_float: float,
-    inner: {
-      known_shares: inner_known,
-      gap_shares: inner_gap,
-      known_pct: inner_known / float,
-      gap_pct: inner_gap / float,
-    },
-    categories,
-  };
-}
-
-function buildCategory(
-  spec: CategorySpec,
-  holders: readonly SunburstHolder[],
-  float: number,
-  threshold: number,
-): SunburstCategory {
-  if (spec.status === "unknown") {
-    return {
-      key: spec.key,
-      label: spec.label,
-      shares: 0,
-      pct: 0,
-      status: "unknown",
-      ...(spec.unknown_reason !== undefined ? { unknown_reason: spec.unknown_reason } : {}),
+  if (input.institutions_total !== null && input.institutions_total > 0) {
+    categories.push(
+      buildCategoryFromTotal("institutions", input.institutions_total, inst_holders, threshold, false),
+    );
+  }
+  if (input.etfs_total !== null && input.etfs_total > 0) {
+    categories.push(
+      buildCategoryFromTotal("etfs", input.etfs_total, etf_holders, threshold, false),
+    );
+  }
+  if (input.insiders_total !== null && input.insiders_total > 0) {
+    categories.push(
+      buildCategoryFromTotal(
+        "insiders",
+        input.insiders_total,
+        insider_holders,
+        threshold,
+        true, // bypass threshold — every officer surfaces
+      ),
+    );
+  }
+  if (input.treasury_shares !== null && input.treasury_shares > 0) {
+    categories.push({
+      key: "treasury",
+      label: CATEGORY_LABEL.treasury,
+      shares: input.treasury_shares,
+      reported_total: input.treasury_shares,
+      resolved_leaf_shares: input.treasury_shares,
       leaves: [
         {
-          key: `${spec.key}-unknown`,
-          label: unknownLeafLabel(spec.label, spec.unknown_reason),
-          shares: 0,
-          pct: 0,
+          key: "treasury",
+          label: "Treasury",
+          shares: input.treasury_shares,
           is_other: false,
         },
       ],
-    };
+      within_category_gap: 0,
+    });
   }
 
+  // Cross-category oversubscription guard. If reported category
+  // totals sum to MORE than input total_shares, bump the effective
+  // denominator to the sum so Recharts doesn't silently renormalise
+  // ring 2 to occupy 360° at the wrong proportions.
+  const sum_known = categories.reduce((s, c) => s + c.shares, 0);
+  const total_shares = Math.max(reported_total, sum_known);
+  const category_residual = total_shares - sum_known;
+
+  return {
+    total_shares,
+    reported_total,
+    categories,
+    category_residual,
+  };
+}
+
+function buildCategoryFromTotal(
+  key: CategoryKey,
+  reported_total: number,
+  holders: readonly SunburstHolder[],
+  threshold: number,
+  bypass_threshold: boolean,
+): SunburstCategory {
   if (holders.length === 0) {
+    // Total from upstream API but zero per-filer detail (e.g.
+    // CUSIP-backfill #740 dropped every filer at ingest). Middle
+    // ring renders the category total; outer ring is one big
+    // transparent within-category gap.
     return {
-      key: spec.key,
-      label: spec.label,
-      shares: 0,
-      pct: 0,
-      status: "empty",
+      key,
+      label: CATEGORY_LABEL[key],
+      shares: reported_total,
+      reported_total,
+      resolved_leaf_shares: 0,
       leaves: [],
+      within_category_gap: reported_total,
     };
   }
 
-  const total_shares = holders.reduce((sum, h) => sum + h.shares, 0);
-  if (total_shares <= 0) {
-    return {
-      key: spec.key,
-      label: spec.label,
-      shares: 0,
-      pct: 0,
-      status: "empty",
-      leaves: [],
-    };
-  }
-
-  // Sort largest-first so the canvas reads counter-clockwise from
+  // Sort largest-first so wedges read counter-clockwise from
   // 12 o'clock with the dominant holders most visually prominent.
   const sorted = [...holders].sort((a, b) => b.shares - a.shares);
 
@@ -373,13 +272,12 @@ function buildCategory(
   const tail: SunburstHolder[] = [];
 
   for (const h of sorted) {
-    const passes = spec.bypass_threshold || h.shares >= threshold;
+    const passes = bypass_threshold || h.shares >= threshold;
     if (passes) {
       visible.push({
         key: h.key,
         label: h.label,
         shares: h.shares,
-        pct: h.shares / float,
         is_other: false,
       });
     } else {
@@ -392,41 +290,37 @@ function buildCategory(
     const aggregate_shares = tail.reduce((sum, h) => sum + h.shares, 0);
     const largest = tail.reduce((biggest, h) => (h.shares > biggest.shares ? h : biggest), tail[0]!);
     leaves.push({
-      key: `${spec.key}-other`,
-      label: `Other ${spec.label.toLowerCase()}`,
+      key: `${key}-other`,
+      label: `Other ${CATEGORY_LABEL[key].toLowerCase()}`,
       shares: aggregate_shares,
-      pct: aggregate_shares / float,
       is_other: true,
       tail_meta: {
         count: tail.length,
         aggregate_shares,
-        aggregate_pct: aggregate_shares / float,
         largest_label: largest.label,
-        largest_pct: largest.shares / float,
+        largest_shares: largest.shares,
       },
     });
   }
 
-  return {
-    key: spec.key,
-    label: spec.label,
-    shares: total_shares,
-    pct: total_shares / float,
-    status: "ok",
-    leaves,
-  };
-}
+  const resolved_leaf_shares = leaves.reduce((s, l) => s + l.shares, 0);
 
-function unknownLeafLabel(
-  category_label: string,
-  reason: SunburstUnknownReason | undefined,
-): string {
-  switch (reason) {
-    case "cusip_backfill":
-      return `${category_label} — needs CUSIP backfill (#740)`;
-    case "dei_projection":
-      return `${category_label} — DEI projection pending (#735)`;
-    default:
-      return `${category_label} — data not available`;
-  }
+  // Snapshot-lag bump: if filer detail sums to MORE than the
+  // upstream-reported category total, the leaves are more recent
+  // ground truth (13F filings post-date the aggregate snapshot).
+  // Use ``max(reported, sum_of_leaves)`` so ring 3 fits inside
+  // ring 2 geometrically; the ``reported_total`` field is preserved
+  // for diagnostic copy.
+  const shares = Math.max(reported_total, resolved_leaf_shares);
+  const within_category_gap = shares - resolved_leaf_shares;
+
+  return {
+    key,
+    label: CATEGORY_LABEL[key],
+    shares,
+    reported_total,
+    resolved_leaf_shares,
+    leaves,
+    within_category_gap,
+  };
 }

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -1,24 +1,16 @@
 /**
- * Ownership L2 drill page (#729 follow-up).
+ * Ownership L2 drill page (#729).
  *
- * Mirrors the L1 ``OwnershipPanel`` data model but renders bigger
- * + adds a per-filer drilldown table with three operator-side
- * controls:
+ * Mirrors the L1 ``OwnershipPanel`` data model — same denominator
+ * (``shares_outstanding``), same faithful-proportional rings, same
+ * transparent gap arcs — at a larger size with a per-filer drilldown
+ * table and three operator-side controls:
  *
- *   * ``?category=etf|institutions|insiders|treasury|unallocated`` —
- *     filter the table to that category. Matches the L1 click
- *     handler's query param so a click on a middle-ring wedge
- *     lands here pre-filtered.
+ *   * ``?category=etf|institutions|insiders|treasury`` — filter the
+ *     table to that category. Set by L1 / L2 middle-ring clicks.
  *   * ``?filer=<cik|name-fallback>`` — scroll to + highlight a
- *     specific filer row. Set by L1 outer-ring clicks.
- *   * ``?view=raw`` — emit the table as a downloadable CSV via the
- *     browser's Blob download path. Audit-grade export so the
- *     operator can spreadsheet a quarter's worth of filings.
- *
- * Coverage gating mirrors the L1 panel — categories gated on #740
- * / #735 render with the same desaturated wedge + reason copy so
- * the L2 stays consistent with the operator's mental model from
- * L1.
+ *     specific filer row. Set by L1 / L2 outer-ring clicks.
+ *   * ``?view=raw`` — emit the table as a downloadable CSV.
  */
 
 import { useCallback, useMemo, useRef } from "react";
@@ -36,7 +28,10 @@ import {
 import type { InsiderTransactionsList } from "@/api/instruments";
 import type { InstrumentFinancials } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
-import { OwnershipSunburst } from "@/components/instrument/OwnershipSunburst";
+import {
+  OwnershipLegend,
+  OwnershipSunburst,
+} from "@/components/instrument/OwnershipSunburst";
 import type { WedgeClick } from "@/components/instrument/OwnershipSunburst";
 import {
   formatPct,
@@ -44,6 +39,7 @@ import {
   parseShareCount,
 } from "@/components/instrument/ownershipMetrics";
 import {
+  type CategoryKey,
   type SunburstHolder,
   type SunburstInputs,
   buildSunburstRings,
@@ -54,7 +50,7 @@ import { useAsync } from "@/lib/useAsync";
 export interface FilerRow {
   readonly key: string;
   readonly label: string;
-  readonly category: "institutions" | "etfs" | "insiders" | "treasury" | "unallocated";
+  readonly category: CategoryKey;
   readonly category_label: string;
   readonly shares: number;
   readonly value_usd: number | null;
@@ -64,12 +60,11 @@ export interface FilerRow {
   readonly period_of_report: string | null;
 }
 
-const CATEGORY_LABELS: Record<string, string> = {
+const CATEGORY_LABELS: Record<CategoryKey, string> = {
   institutions: "Institutions",
   etfs: "ETFs",
   insiders: "Insiders",
   treasury: "Treasury",
-  unallocated: "Unallocated",
 };
 
 export function OwnershipPage(): JSX.Element {
@@ -154,9 +149,9 @@ export function OwnershipPage(): JSX.Element {
           Ownership — {symbol}
         </h1>
         <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-          Three-ring breakdown of free float by category, filer, and
-          officer. SEC 13F-HR institutional + ETF holdings, Form 4
-          insider transactions, XBRL treasury share counts.
+          Three-ring breakdown of shares outstanding by category, filer, and
+          officer. SEC 13F-HR institutional + ETF holdings, Form 4 insider
+          transactions, XBRL treasury share counts.
         </p>
       </header>
 
@@ -217,13 +212,12 @@ function OwnershipBody({
 }: OwnershipBodyProps): JSX.Element {
   const outstanding = balance !== null ? pickLatestBalance(balance, "shares_outstanding") : null;
   const treasury = balance !== null ? pickLatestBalance(balance, "treasury_shares") : null;
-  const free_float = outstanding !== null ? Math.max(0, outstanding - (treasury ?? 0)) : null;
 
-  if (free_float === null || free_float <= 0) {
+  if (outstanding === null || outstanding <= 0) {
     return (
       <EmptyState
         title="No ownership data"
-        description={`Shares outstanding is not on file for ${symbol} yet — the ownership breakdown needs SEC XBRL coverage to compute the float denominator.`}
+        description={`Shares outstanding is not on file for ${symbol} yet — the ownership breakdown needs SEC XBRL coverage to compute the denominator.`}
       />
     );
   }
@@ -235,7 +229,7 @@ function OwnershipBody({
   // a stable identity. Pre-fix ``inputs.holders`` was a fresh array
   // literal on every render → ``allRows``'s useMemo never hit
   // cache and ``buildFilerRows`` re-ran on every keystroke into the
-  // search params. Codex caught this on PR review.
+  // search params.
   const equity_filers = useMemo(
     () => filers.filter((f) => f.is_put_call === null),
     [filers],
@@ -263,42 +257,47 @@ function OwnershipBody({
     [institutional_holders, etf_holders, insider_holders],
   );
 
+  const institutions_total = useMemo(
+    () => parseShareCount(inst_totals?.institutions_shares ?? null),
+    [inst_totals?.institutions_shares],
+  );
+  const etfs_total = useMemo(
+    () => parseShareCount(inst_totals?.etfs_shares ?? null),
+    [inst_totals?.etfs_shares],
+  );
+  const insiders_total = useMemo(
+    () =>
+      insider_holders.length === 0
+        ? null
+        : insider_holders.reduce((s, h) => s + h.shares, 0),
+    [insider_holders],
+  );
+
+  // Denominator = outstanding + treasury (issued/allotted). Treasury
+  // renders as a category wedge so the operator sees the issuer's
+  // held-back portion in proportion.
+  const total_shares = useMemo(
+    () => outstanding + (treasury ?? 0),
+    [outstanding, treasury],
+  );
+
   const inputs: SunburstInputs = useMemo(
     () => ({
-      free_float,
+      total_shares,
       holders: allHolders,
+      institutions_total,
+      etfs_total,
+      insiders_total,
       treasury_shares: treasury,
-      institutions_status: deriveCategoryStatus(
-        institutional,
-        institutional_holders,
-        inst_totals?.institutions_shares,
-      ),
-      etfs_status: deriveCategoryStatus(institutional, etf_holders, inst_totals?.etfs_shares),
-      insiders_status:
-        insiders === null ? "unknown" : insider_holders.length > 0 ? "ok" : "empty",
     }),
-    [
-      free_float,
-      allHolders,
-      treasury,
-      institutional,
-      institutional_holders,
-      etf_holders,
-      insider_holders,
-      insiders,
-      inst_totals?.institutions_shares,
-      inst_totals?.etfs_shares,
-    ],
+    [total_shares, allHolders, institutions_total, etfs_total, insiders_total, treasury],
   );
 
   const rings = useMemo(() => buildSunburstRings(inputs), [inputs]);
 
   const allRows = useMemo(
-    () =>
-      rings === null
-        ? ([] as FilerRow[])
-        : buildFilerRows(rings, filers, insiders, treasury),
-    [rings, filers, insiders, treasury],
+    () => buildFilerRows(filers, insiders, treasury),
+    [filers, insiders, treasury],
   );
 
   const filteredRows = useMemo(() => {
@@ -306,15 +305,15 @@ function OwnershipBody({
     return allRows.filter((r) => r.category === categoryFilter);
   }, [allRows, categoryFilter]);
 
-  const knownPct = rings?.inner.known_pct ?? 0;
-  const gapPct = rings?.inner.gap_pct ?? 0;
-  const hasMaterialGap = gapPct > 0.005;
+  const accountedFor = rings?.categories.reduce((s, c) => s + c.shares, 0) ?? 0;
+  const accountedPct =
+    rings !== null && rings.total_shares > 0
+      ? accountedFor / rings.total_shares
+      : 0;
+  const oversubscribed = rings !== null && rings.total_shares > rings.reported_total;
 
-  // Ref + scroll-to behaviour for filer drilldown highlighting.
   const filerRowRef = useRef<HTMLTableRowElement | null>(null);
 
-  // CSV export — when ?view=raw, render a download trigger instead
-  // of the table. Operator-side audit pathway.
   if (viewMode === "raw") {
     const csv = buildCsv(filteredRows);
     return (
@@ -322,7 +321,7 @@ function OwnershipBody({
         <p className="text-xs text-slate-500 dark:text-slate-400">
           Raw view: {filteredRows.length} rows
           {categoryFilter !== null && (
-            <> · filtered to <strong>{CATEGORY_LABELS[categoryFilter] ?? categoryFilter}</strong></>
+            <> · filtered to <strong>{labelFor(categoryFilter)}</strong></>
           )}
         </p>
         <pre className="overflow-x-auto rounded border border-slate-200 bg-slate-50 p-3 text-xs dark:border-slate-700 dark:bg-slate-950">
@@ -342,20 +341,32 @@ function OwnershipBody({
   return (
     <div className="grid grid-cols-12 gap-6">
       <div className="col-span-12 lg:col-span-5">
-        <div className="flex justify-center">
+        <div className="flex flex-col items-center gap-3">
           <OwnershipSunburst inputs={inputs} onWedgeClick={onWedgeClick} size={420} />
+          {rings !== null && <OwnershipLegend rings={rings} />}
         </div>
-        <p className="mt-3 text-center text-xs">
+        <p className="mt-3 text-center text-xs text-slate-500 dark:text-slate-400">
+          {formatShares(outstanding)} outstanding
+          {treasury !== null && treasury > 0 && (
+            <> + {formatShares(treasury)} treasury</>
+          )}
+          {" = "}
+          {formatShares(total_shares)} total shares
+        </p>
+        <p className="mt-1 text-center text-xs">
           <span className="font-medium text-slate-700 dark:text-slate-200">
-            {formatPct(knownPct)} known
+            {formatPct(accountedPct)} accounted for
           </span>
-          {hasMaterialGap && (
-            <>
-              <span className="mx-1.5 text-slate-400">·</span>
-              <span className="font-medium text-amber-700 dark:text-amber-400">
-                {formatPct(gapPct)} coverage gap
-              </span>
-            </>
+          {accountedPct < 0.999 && (
+            <span className="ml-1.5 text-slate-500 dark:text-slate-400">
+              · remainder is unallocated public float
+            </span>
+          )}
+          {oversubscribed && rings !== null && (
+            <span className="ml-1.5 text-amber-700 dark:text-amber-400">
+              · category totals exceed reported total shares by{" "}
+              {formatShares(rings.total_shares - rings.reported_total)} (snapshot lag)
+            </span>
           )}
         </p>
       </div>
@@ -396,7 +407,7 @@ function FilterStrip({
   if (categoryFilter === null && filerFilter === null) {
     return (
       <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
-        Showing all {totalCount} filer rows. Click any wedge in the chart to filter.
+        Showing all {totalCount} filer rows. Click any colored wedge in the chart to filter.
       </p>
     );
   }
@@ -406,8 +417,7 @@ function FilterStrip({
         Showing {rowCount} of {totalCount}
         {categoryFilter !== null && (
           <>
-            {" "}· category{" "}
-            <strong>{CATEGORY_LABELS[categoryFilter] ?? categoryFilter}</strong>
+            {" "}· category <strong>{labelFor(categoryFilter)}</strong>
           </>
         )}
         {filerFilter !== null && (
@@ -431,7 +441,6 @@ interface FilerTableProps {
   readonly rows: readonly FilerRow[];
   readonly highlightFiler: string | null;
   readonly highlightRef: React.RefObject<HTMLTableRowElement>;
-  /** Clicking the highlighted row clears the filer filter. */
   readonly onClearHighlight?: () => void;
 }
 
@@ -466,18 +475,10 @@ function FilerTable({
         <tbody>
           {rows.map((row) => {
             const isHighlight = highlightFiler !== null && row.key === highlightFiler;
-            // Highlighted row uses a left-border accent rather than
-            // a full-row background tint. Amber backgrounds read as
-            // "warning / error" in dashboard convention; the
-            // operator-facing semantic here is "selected", not "alert".
-            // Clicking the highlighted row clears the filter — the
-            // operator can dismiss the per-filer drilldown without
-            // hunting for the Clear button.
-            // Use logical-side ``border-t-*`` instead of the all-sides
-            // shorthand so an isHighlight row's ``border-l-sky-500``
-            // can't be silently overridden if Tailwind emits the
-            // shorthand color rule after the side-specific one. PR
-            // #750 review caught this.
+            // Logical-side ``border-t-*`` instead of all-sides shorthand
+            // so an isHighlight row's ``border-l-sky-500`` can't be
+            // silently overridden if Tailwind emits the shorthand color
+            // rule after the side-specific one.
             const baseCls = "border-t border-t-slate-100 dark:border-t-slate-800";
             const highlightCls = isHighlight
               ? "border-l-2 border-l-sky-500 bg-sky-50/40 dark:bg-sky-950/20 cursor-pointer"
@@ -521,6 +522,10 @@ function FilerTable({
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function labelFor(key: string): string {
+  return (CATEGORY_LABELS as Record<string, string>)[key] ?? key;
+}
 
 function pickLatestBalance(
   financials: InstrumentFinancials,
@@ -578,41 +583,20 @@ function aggregateInsiderHoldersForSunburst(
   return holders;
 }
 
-function deriveCategoryStatus(
-  institutional: InstitutionalHoldingsResponse | null,
-  holders: readonly SunburstHolder[],
-  raw_total: string | undefined,
-): "ok" | "unknown" | "empty" {
-  if (institutional === null) return "unknown";
-  if (institutional.totals === null) return "unknown";
-  const total = parseShareCount(raw_total ?? "0") ?? 0;
-  if (total <= 0 && holders.length === 0) return "empty";
-  if (holders.length === 0 && total > 0) return "unknown";
-  return "ok";
-}
-
-interface RingsRef {
-  readonly free_float: number;
-  readonly categories: readonly { readonly key: string; readonly label: string }[];
-}
-
 function buildFilerRows(
-  _rings: RingsRef,
   filers: readonly InstitutionalFilerHolding[],
   insiders: InsiderTransactionsList | null,
   treasury: number | null,
 ): FilerRow[] {
   const rows: FilerRow[] = [];
 
-  // Institutional + ETF rows from the reader endpoint. Includes
-  // PUT/CALL exposure for the audit trail.
   for (const f of filers) {
-    const cat: FilerRow["category"] = f.filer_type === "ETF" ? "etfs" : "institutions";
+    const cat: CategoryKey = f.filer_type === "ETF" ? "etfs" : "institutions";
     rows.push({
       key: f.filer_cik,
       label: f.filer_name,
       category: cat,
-      category_label: CATEGORY_LABELS[cat] ?? cat,
+      category_label: CATEGORY_LABELS[cat],
       shares: parseShareCount(f.shares) ?? 0,
       value_usd: parseShareCount(f.market_value_usd ?? null),
       voting: f.voting_authority,
@@ -622,8 +606,6 @@ function buildFilerRows(
     });
   }
 
-  // Insider rows — latest non-derivative post-transaction-shares
-  // per officer.
   if (insiders !== null) {
     const latestByFiler = new Map<
       string,
@@ -644,7 +626,7 @@ function buildFilerRows(
         key,
         label: entry.row.filer_name,
         category: "insiders",
-        category_label: CATEGORY_LABELS.insiders!,
+        category_label: CATEGORY_LABELS.insiders,
         shares: entry.shares,
         value_usd: null,
         voting: null,
@@ -655,13 +637,12 @@ function buildFilerRows(
     }
   }
 
-  // Treasury memo row.
   if (treasury !== null && treasury > 0) {
     rows.push({
       key: "treasury",
       label: "Treasury (memo)",
       category: "treasury",
-      category_label: CATEGORY_LABELS.treasury!,
+      category_label: CATEGORY_LABELS.treasury,
       shares: treasury,
       value_usd: null,
       voting: null,
@@ -671,14 +652,7 @@ function buildFilerRows(
     });
   }
 
-  // Sort by shares DESC within category, categories in canonical order.
-  const categoryOrder: FilerRow["category"][] = [
-    "institutions",
-    "etfs",
-    "insiders",
-    "treasury",
-    "unallocated",
-  ];
+  const categoryOrder: CategoryKey[] = ["institutions", "etfs", "insiders", "treasury"];
   rows.sort((a, b) => {
     const ai = categoryOrder.indexOf(a.category);
     const bi = categoryOrder.indexOf(b.category);
@@ -701,11 +675,6 @@ export function buildCsv(rows: readonly FilerRow[]): string {
     "accession",
     "period_of_report",
   ].join(",");
-  // Every string-shaped column passes through csvEscape so a
-  // future schema change (e.g. an issuer name with a comma, a
-  // period_of_report that gets a textual qualifier) can't silently
-  // skip RFC 4180 quoting or smuggle a formula-injection payload.
-  // Numeric columns are formatted to ASCII digits in-line.
   const lines = rows.map((r) =>
     [
       csvEscape(r.key),
@@ -723,11 +692,8 @@ export function buildCsv(rows: readonly FilerRow[]): string {
 }
 
 function csvEscape(value: string): string {
-  // Standard RFC 4180 escaping: wrap in quotes, double internal
-  // quotes. Plus the formula-injection guard from
-  // app.api.instruments — prefix with a single quote when the
-  // first char would otherwise be interpreted as a formula by
-  // Excel / Sheets / Numbers.
+  // RFC 4180 escaping + formula-injection guard (mirrors
+  // app.api.instruments).
   let v = value;
   if (v !== "" && /^[=+\-@]/.test(v)) v = `'${v}`;
   if (/[",\n]/.test(v)) {


### PR DESCRIPTION
## What

Rewrites the ownership sunburst (#729) to render faithful proportional rings against a single denominator (\`total_shares = shares_outstanding + treasury\`). Operator's mental model: 100% of issued/allotted shares; treasury is held back in the vault and renders as one of the categories. No more synthetic padding, gap distribution, or unknown-status placeholders — gaps render as literal transparent arcs.

## Why

Operator screenshot review on #729 / PR #754 caught fundamental wrongness: previous renderer used \`display_shares\` distribution + min-wedge floor to make tiny slices visible, distorting proportions. Operator: *"the chart should faithfully report what we know and literally leave the rest empty"*. This rewrite implements that contract end-to-end.

## Changes

- **Data model** (\`ownershipRings.ts\`): \`SunburstInputs.total_shares\` is the denominator (callers compute \`outstanding + treasury\`). \`SunburstCategory\` carries \`shares\`, \`reported_total\` (pre-snapshot-lag-bump), \`resolved_leaf_shares\`, \`within_category_gap\`. Cross-category oversubscription bumps effective denom; within-category snapshot lag bumps category shares to sum-of-leaves.
- **Renderer** (\`OwnershipSunburst.tsx\`): per-category colored wedges + transparent residual on ring 2; per-leaf wedges + transparent within-category gap + transparent residual on ring 3. Hit-testing on gap wedges killed at sector-wrapper level via \`:has()\` selector — they don't absorb clicks/hover.
- **Legend** (\`OwnershipLegend\` exported): swatch + label + shares + % per visible category; dashed swatch for unaccounted residual. Surfaces sub-pixel categories the wheel can't show (e.g. Insiders @ 0.06%).
- **L1 + L2 panels**: memo strip showing \`outstanding + treasury = total\`. Oversubscription warning copy when categories exceed reported total. \"Resolved filers\" % column on L1.

## Visual coverage today

Most tickers render with low accounted-for % because the data pipeline isn't backfilled — \`institutional_holdings\` is sparse-to-empty (gated on #740 CUSIP backfill), and \`treasury_shares\` is null for most issuers (gated on #735 DEI projection). The renderer is correct; the data populates via:

- **#755** — Ownership backfill drive (#740 + #735 to completion)
- **#756** — Ownership over time chart on L2

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] 797 frontend unit tests pass (added 2 oversubscription/snapshot-lag pins to ring-model suite)
- [x] Dark-class gate — clean
- [x] Codex review — high/medium findings on first pass all addressed; 2 low-severity nits resolved (threshold uses effective denom; warning copy says \"reported total shares\" not \"outstanding\")
- [ ] Manual verification on populated ticker — blocked on #755 (backfill drive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)