### PR TITLE
feat(#735): one-shot XBRL ownership-column normalization backfill

### DIFF
--- a/scripts/backfill_xbrl_normalization.py
+++ b/scripts/backfill_xbrl_normalization.py
@@ -231,16 +231,19 @@ def main(argv: list[str] | None = None) -> int:
         conn.commit()
         elapsed = time.monotonic() - started
 
-        # Post-normalize verification probe (codex review medium).
-        # ``normalize_financial_periods`` catches per-instrument
-        # exceptions and counts every input as ``processed``, so a
-        # partial failure looks identical to a clean run in its
-        # summary. Re-query the cohort: any instrument still missing a
-        # migration-088 column (despite having raw facts for it) is a
-        # rollback signal — surface that as a non-zero exit so a CI
-        # wrapper / shell pipeline can distinguish a clean
-        # backfill from one that needs the operator to read the log.
-        unresolved = count_unprojected_088(conn, cohort) if not args.all_instruments else 0
+        # Post-normalize verification probe (codex review medium / PR
+        # review WARNING). ``normalize_financial_periods`` catches
+        # per-instrument exceptions and counts every input as
+        # ``processed``, so a partial failure looks identical to a
+        # clean run in its summary. Re-query the cohort: any instrument
+        # still missing a migration-088 column (despite having raw
+        # facts for it) is a rollback signal — surface that as a
+        # non-zero exit so a CI wrapper / shell pipeline can
+        # distinguish a clean backfill from one that needs the operator
+        # to read the log. Probe runs in BOTH cohort modes —
+        # ``--all-instruments`` just expands the cohort, the same 088
+        # rollback signal still applies.
+        unresolved = count_unprojected_088(conn, cohort)
 
         logger.info(
             "backfill_xbrl_normalization: done in %.1fs — instruments=%d "

--- a/scripts/backfill_xbrl_normalization.py
+++ b/scripts/backfill_xbrl_normalization.py
@@ -1,0 +1,268 @@
+"""One-shot ``financial_periods`` re-projection (#735).
+
+Re-derives every issuer's canonical ``financial_periods`` row from
+``financial_facts_raw`` so newly-added TRACKED_CONCEPTS (treasury_shares,
+shares_authorized, shares_issued, retained_earnings — migration 088 /
+issue #731) project onto the canonical table for issuers whose facts
+were ingested *before* the alias map carried those concepts.
+
+Why a backfill is needed: ``app.workers.scheduler`` runs
+``normalize_financial_periods`` only on instruments whose facts changed
+that day (``touched_ciks``). Issuers whose raw facts pre-date migration
+088 already have their canonical rows; the daily pass skips them; the
+new columns stay NULL until the next time SEC ships a fresh filing for
+that issuer (which, for slow-filers, can be a quarter+ away). Without
+this backfill, the ownership reporting card (#729) renders treasury as
+"not on file" for almost every ticker.
+
+Idempotent: ``normalize_financial_periods`` upserts via ON CONFLICT DO
+UPDATE WHERE IS DISTINCT FROM, so re-running over already-projected
+rows is a no-op for unchanged values. Safe to run repeatedly.
+
+Bootstrap-only: this is intended as a once-per-install / once-per-new-
+TRACKED_CONCEPTS-migration operation. Not a nightly job. The daily
+cadence handles new data.
+
+Run from repo root:
+
+    uv run python -m scripts.backfill_xbrl_normalization
+    uv run python -m scripts.backfill_xbrl_normalization --apply
+    uv run python -m scripts.backfill_xbrl_normalization --apply --limit 100
+
+Defaults to dry-run (counts the affected cohort, no writes). The
+``--limit`` flag caps the cohort for sample / staging runs.
+
+Rate limit: no SEC HTTP calls — this is pure DB-side normalization.
+Wall clock dominated by per-instrument transaction overhead;
+~50-200 ms / instrument depending on facts cardinality.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+
+import psycopg
+
+from app.config import settings
+from app.services.fundamentals import normalize_financial_periods
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+# Migration-088 SEC us-gaap concepts that need re-projection. Mirrors
+# the ``TRACKED_CONCEPTS`` aliases in
+# ``app.providers.implementations.sec_fundamentals`` for the four
+# columns added in ``sql/088_xbrl_ownership_columns.sql``. Kept here as
+# a literal so the cohort SELECT can run without importing the provider
+# module (which pulls in HTTP client deps).
+MIGRATION_088_CONCEPTS: tuple[str, ...] = (
+    "TreasuryStockShares",
+    "TreasuryStockCommonShares",
+    "CommonStockSharesAuthorized",
+    "CommonStockSharesIssued",
+    "RetainedEarningsAccumulatedDeficit",
+)
+
+
+def select_cohort(
+    conn: psycopg.Connection[tuple],
+    *,
+    only_unprojected_088: bool,
+    limit: int | None,
+) -> list[int]:
+    """Return instrument_ids that need re-projection.
+
+    When ``only_unprojected_088`` is True (default), narrow to issuers
+    that have raw facts for ANY of the four migration-088 concepts and
+    still have at least one of the four target canonical columns NULL.
+    This is the minimum cohort that materially benefits from the
+    backfill — full no-op runs still update zero rows but the
+    per-instrument tx overhead adds up across 5000+ issuers.
+
+    The first cohort definition (PR review, codex high) only checked
+    treasury_shares and missed issuers that needed shares_authorized /
+    shares_issued / retained_earnings projection but had no treasury
+    facts at all. Broadened here to track all four migration-088
+    columns.
+
+    When ``only_unprojected_088`` is False (``--all-instruments``),
+    process every instrument with any raw facts. Use this after adding
+    NEW TRACKED_CONCEPTS in a future migration that affects every
+    issuer regardless of which subset of facts they file.
+    """
+    if only_unprojected_088:
+        sql = """
+            SELECT DISTINCT i.instrument_id
+            FROM instruments i
+            WHERE EXISTS (
+                SELECT 1 FROM financial_facts_raw f
+                WHERE f.instrument_id = i.instrument_id
+                  AND f.concept = ANY(%(concepts)s)
+            )
+            AND EXISTS (
+                SELECT 1 FROM financial_periods p
+                WHERE p.instrument_id = i.instrument_id
+                  AND (
+                      p.treasury_shares IS NULL
+                      OR p.shares_authorized IS NULL
+                      OR p.shares_issued IS NULL
+                      OR p.retained_earnings IS NULL
+                  )
+            )
+            ORDER BY i.instrument_id
+        """
+        params: dict[str, object] = {"concepts": list(MIGRATION_088_CONCEPTS)}
+    else:
+        sql = """
+            SELECT DISTINCT instrument_id
+            FROM financial_facts_raw
+            ORDER BY instrument_id
+        """
+        params = {}
+    if limit is not None:
+        sql += "\nLIMIT %(limit)s"
+        params["limit"] = limit
+    rows = conn.execute(sql, params).fetchall()
+    return [int(r[0]) for r in rows]
+
+
+def count_unprojected_088(
+    conn: psycopg.Connection[tuple],
+    instrument_ids: list[int],
+) -> int:
+    """Count instruments in cohort that STILL have an unprojected 088
+    column despite having raw facts for it.
+
+    ``normalize_financial_periods`` swallows per-instrument exceptions
+    (logs + continues) and reports ``instruments_processed=len(ids)``
+    regardless. For a one-shot backfill that masks partial failure.
+    Run this post-normalize as a verification probe — if any rows come
+    back, the operator knows specific instruments rolled back and can
+    investigate the per-instrument exception in the application log.
+    """
+    if not instrument_ids:
+        return 0
+    rows = conn.execute(
+        """
+        SELECT COUNT(DISTINCT i.instrument_id)
+        FROM instruments i
+        WHERE i.instrument_id = ANY(%(ids)s)
+          AND EXISTS (
+              SELECT 1 FROM financial_facts_raw f
+              WHERE f.instrument_id = i.instrument_id
+                AND f.concept = ANY(%(concepts)s)
+          )
+          AND EXISTS (
+              SELECT 1 FROM financial_periods p
+              WHERE p.instrument_id = i.instrument_id
+                AND (
+                    p.treasury_shares IS NULL
+                    OR p.shares_authorized IS NULL
+                    OR p.shares_issued IS NULL
+                    OR p.retained_earnings IS NULL
+                )
+          )
+        """,
+        {"ids": instrument_ids, "concepts": list(MIGRATION_088_CONCEPTS)},
+    ).fetchall()
+    return int(rows[0][0]) if rows else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually run the normaliser. Default is dry-run (cohort report only).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap cohort size for sample / staging runs.",
+    )
+    parser.add_argument(
+        "--all-instruments",
+        action="store_true",
+        help=(
+            "Process every instrument with raw facts, not only those "
+            "missing migration-088 columns. Use after adding NEW "
+            "TRACKED_CONCEPTS in a future migration that affects every "
+            "issuer (not just ones with treasury / capital-structure "
+            "data on file)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    with psycopg.connect(settings.database_url) as conn:
+        cohort = select_cohort(
+            conn,
+            only_unprojected_088=not args.all_instruments,
+            limit=args.limit,
+        )
+        # Close the implicit read transaction before per-instrument
+        # transactions inside ``normalize_financial_periods`` run.
+        # Same pattern the per-CIK path in app/services/fundamentals.py
+        # and scripts/force_refresh_fundamentals.py use.
+        conn.commit()
+
+        cohort_label = "all-instruments" if args.all_instruments else "unprojected-088"
+        logger.info(
+            "backfill_xbrl_normalization: cohort=%s size=%d limit=%s",
+            cohort_label,
+            len(cohort),
+            args.limit,
+        )
+
+        if not cohort:
+            logger.info("backfill_xbrl_normalization: nothing to do")
+            return 0
+
+        if not args.apply:
+            logger.info("backfill_xbrl_normalization: DRY-RUN — pass --apply to project the canonical rows")
+            return 0
+
+        started = time.monotonic()
+        summary = normalize_financial_periods(conn, instrument_ids=cohort)
+        conn.commit()
+        elapsed = time.monotonic() - started
+
+        # Post-normalize verification probe (codex review medium).
+        # ``normalize_financial_periods`` catches per-instrument
+        # exceptions and counts every input as ``processed``, so a
+        # partial failure looks identical to a clean run in its
+        # summary. Re-query the cohort: any instrument still missing a
+        # migration-088 column (despite having raw facts for it) is a
+        # rollback signal — surface that as a non-zero exit so a CI
+        # wrapper / shell pipeline can distinguish a clean
+        # backfill from one that needs the operator to read the log.
+        unresolved = count_unprojected_088(conn, cohort) if not args.all_instruments else 0
+
+        logger.info(
+            "backfill_xbrl_normalization: done in %.1fs — instruments=%d "
+            "raw_upserted=%d canonical_upserted=%d unresolved=%d",
+            elapsed,
+            summary.instruments_processed,
+            summary.periods_raw_upserted,
+            summary.periods_canonical_upserted,
+            unresolved,
+        )
+
+        if unresolved > 0:
+            logger.warning(
+                "backfill_xbrl_normalization: %d instrument(s) still have NULL migration-088 columns "
+                "despite raw facts on file — likely per-instrument exceptions during normalize. "
+                "Check the application log for 'Failed to normalize instrument N' lines.",
+                unresolved,
+            )
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_backfill_xbrl_normalization.py
+++ b/tests/test_backfill_xbrl_normalization.py
@@ -1,0 +1,245 @@
+"""Tests for the XBRL normalization backfill script (#735).
+
+Pins the cohort selector — the script's only piece of non-trivial
+logic. The end-to-end normalization path is covered by the existing
+fundamentals tests; this file just verifies the cohort SELECT picks
+the right instruments under each ``--all-instruments`` flag setting,
+and that the post-normalize verification probe correctly reports
+unresolved migration-088 columns.
+
+Uses the canonical ``ebull_test_conn`` fixture from
+``tests/conftest.py`` so the test-DB URL is derived from
+``settings.database_url`` rather than hardcoded.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import psycopg
+
+from scripts.backfill_xbrl_normalization import (
+    count_unprojected_088,
+    select_cohort,
+)
+
+
+def _seed_instrument(
+    conn: psycopg.Connection[tuple],
+    instrument_id: int,
+    symbol: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO exchanges (exchange_id, description, country, asset_class)
+        VALUES (%s, %s, 'US', 'us_equity')
+        ON CONFLICT (exchange_id) DO NOTHING
+        """,
+        (f"bxn_{instrument_id}", f"Test {instrument_id}"),
+    )
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange)
+        VALUES (%s, %s, %s, %s)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id, symbol, f"Test {symbol}", f"bxn_{instrument_id}"),
+    )
+
+
+def _seed_fact(
+    conn: psycopg.Connection[tuple],
+    instrument_id: int,
+    concept: str,
+    val: int = 100,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO financial_facts_raw
+            (instrument_id, concept, unit, period_start, period_end, val,
+             form_type, fiscal_year, fiscal_period, accession_number, filed_date)
+        VALUES (%s, %s, 'shares', NULL, %s, %s, '10-K', 2024, 'FY', %s, %s)
+        ON CONFLICT DO NOTHING
+        """,
+        (
+            instrument_id,
+            concept,
+            date(2024, 12, 31),
+            val,
+            f"acc-{instrument_id}-{concept}",
+            date(2025, 2, 1),
+        ),
+    )
+
+
+def _seed_period(
+    conn: psycopg.Connection[tuple],
+    instrument_id: int,
+    *,
+    treasury_shares: int | None = None,
+    shares_authorized: int | None = None,
+    shares_issued: int | None = None,
+    retained_earnings: int | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO financial_periods
+            (instrument_id, fiscal_year, fiscal_quarter, period_end_date,
+             period_start_date, period_type, form_type, filed_date,
+             reported_currency, source, source_ref,
+             treasury_shares, shares_authorized, shares_issued, retained_earnings)
+        VALUES (%s, 2024, 4, %s, %s, 'FY', '10-K', %s, 'USD', 'sec', %s, %s, %s, %s, %s)
+        ON CONFLICT DO NOTHING
+        """,
+        (
+            instrument_id,
+            date(2024, 12, 31),
+            date(2024, 1, 1),
+            date(2025, 2, 1),
+            f"acc-{instrument_id}-period",
+            treasury_shares,
+            shares_authorized,
+            shares_issued,
+            retained_earnings,
+        ),
+    )
+
+
+def test_cohort_picks_issuers_with_any_unprojected_088_column(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    # A: TreasuryStockShares in raw, treasury_shares NULL in canonical → IN cohort.
+    _seed_instrument(ebull_test_conn, 9001, "AAA")
+    _seed_fact(ebull_test_conn, 9001, "TreasuryStockShares", val=50)
+    _seed_period(ebull_test_conn, 9001)
+
+    # B: All 088 columns populated → EXCLUDED.
+    _seed_instrument(ebull_test_conn, 9002, "BBB")
+    _seed_fact(ebull_test_conn, 9002, "TreasuryStockShares", val=75)
+    _seed_period(
+        ebull_test_conn,
+        9002,
+        treasury_shares=75,
+        shares_authorized=1_000_000,
+        shares_issued=900_000,
+        retained_earnings=500_000,
+    )
+
+    # C: Raw facts but no 088-relevant concepts → EXCLUDED.
+    _seed_instrument(ebull_test_conn, 9003, "CCC")
+    _seed_fact(ebull_test_conn, 9003, "Revenues", val=1000)
+    _seed_period(ebull_test_conn, 9003)
+
+    # D: TreasuryStockCommonShares (alias) → IN cohort.
+    _seed_instrument(ebull_test_conn, 9004, "DDD")
+    _seed_fact(ebull_test_conn, 9004, "TreasuryStockCommonShares", val=20)
+    _seed_period(ebull_test_conn, 9004)
+
+    # E: CommonStockSharesAuthorized in raw, shares_authorized NULL → IN cohort.
+    # This is the case the original narrow cohort missed (codex review high).
+    _seed_instrument(ebull_test_conn, 9005, "EEE")
+    _seed_fact(ebull_test_conn, 9005, "CommonStockSharesAuthorized", val=2_000_000)
+    _seed_period(ebull_test_conn, 9005)
+
+    # F: RetainedEarningsAccumulatedDeficit in raw, retained_earnings NULL → IN cohort.
+    _seed_instrument(ebull_test_conn, 9006, "FFF")
+    _seed_fact(ebull_test_conn, 9006, "RetainedEarningsAccumulatedDeficit", val=100_000)
+    _seed_period(ebull_test_conn, 9006)
+
+    cohort = select_cohort(ebull_test_conn, only_unprojected_088=True, limit=None)
+
+    assert 9001 in cohort
+    assert 9002 not in cohort
+    assert 9003 not in cohort
+    assert 9004 in cohort
+    assert 9005 in cohort
+    assert 9006 in cohort
+
+
+def test_cohort_all_instruments_picks_every_issuer_with_raw_facts(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_instrument(ebull_test_conn, 9101, "EEE")
+    _seed_fact(ebull_test_conn, 9101, "Revenues")
+
+    _seed_instrument(ebull_test_conn, 9102, "FFF")
+    _seed_fact(ebull_test_conn, 9102, "TreasuryStockShares")
+    _seed_period(
+        ebull_test_conn,
+        9102,
+        treasury_shares=999,
+        shares_authorized=1,
+        shares_issued=1,
+        retained_earnings=1,
+    )  # already populated — still in cohort under --all-instruments.
+
+    _seed_instrument(ebull_test_conn, 9103, "GGG")
+    # No raw facts → EXCLUDED even with --all-instruments.
+
+    cohort = select_cohort(ebull_test_conn, only_unprojected_088=False, limit=None)
+
+    assert 9101 in cohort
+    assert 9102 in cohort
+    assert 9103 not in cohort
+
+
+def test_cohort_limit_caps_size(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    for iid in range(9201, 9206):
+        _seed_instrument(ebull_test_conn, iid, f"L{iid}")
+        _seed_fact(ebull_test_conn, iid, "TreasuryStockShares")
+        _seed_period(ebull_test_conn, iid)
+
+    cohort = select_cohort(ebull_test_conn, only_unprojected_088=True, limit=3)
+    assert len(cohort) == 3
+    assert cohort == [9201, 9202, 9203]
+
+
+def test_count_unprojected_088_returns_zero_after_full_projection(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    # Issuer with raw treasury fact + canonical row populated.
+    _seed_instrument(ebull_test_conn, 9301, "PPP")
+    _seed_fact(ebull_test_conn, 9301, "TreasuryStockShares", val=50)
+    _seed_period(
+        ebull_test_conn,
+        9301,
+        treasury_shares=50,
+        shares_authorized=1,
+        shares_issued=1,
+        retained_earnings=1,
+    )
+    assert count_unprojected_088(ebull_test_conn, [9301]) == 0
+
+
+def test_count_unprojected_088_flags_partial_failure(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    # Issuer with raw retained-earnings fact but canonical column NULL —
+    # simulates a normalize() that rolled back this instrument.
+    _seed_instrument(ebull_test_conn, 9401, "QQQ")
+    _seed_fact(ebull_test_conn, 9401, "RetainedEarningsAccumulatedDeficit", val=100)
+    _seed_period(ebull_test_conn, 9401)  # all 088 columns NULL
+
+    # Healthy issuer in same cohort — should not contribute to count.
+    _seed_instrument(ebull_test_conn, 9402, "RRR")
+    _seed_fact(ebull_test_conn, 9402, "TreasuryStockShares", val=10)
+    _seed_period(
+        ebull_test_conn,
+        9402,
+        treasury_shares=10,
+        shares_authorized=1,
+        shares_issued=1,
+        retained_earnings=1,
+    )
+
+    assert count_unprojected_088(ebull_test_conn, [9401, 9402]) == 1
+
+
+def test_count_unprojected_088_handles_empty_cohort(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    # Defensive: empty list short-circuits to 0 without hitting Postgres
+    # with a `WHERE id = ANY('{}')` corner case.
+    assert count_unprojected_088(ebull_test_conn, []) == 0

--- a/tests/test_backfill_xbrl_normalization.py
+++ b/tests/test_backfill_xbrl_normalization.py
@@ -159,10 +159,10 @@ def test_cohort_picks_issuers_with_any_unprojected_088_column(
 def test_cohort_all_instruments_picks_every_issuer_with_raw_facts(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    _seed_instrument(ebull_test_conn, 9101, "EEE")
+    _seed_instrument(ebull_test_conn, 9101, "ALL_EEE")
     _seed_fact(ebull_test_conn, 9101, "Revenues")
 
-    _seed_instrument(ebull_test_conn, 9102, "FFF")
+    _seed_instrument(ebull_test_conn, 9102, "ALL_FFF")
     _seed_fact(ebull_test_conn, 9102, "TreasuryStockShares")
     _seed_period(
         ebull_test_conn,
@@ -173,7 +173,7 @@ def test_cohort_all_instruments_picks_every_issuer_with_raw_facts(
         retained_earnings=1,
     )  # already populated — still in cohort under --all-instruments.
 
-    _seed_instrument(ebull_test_conn, 9103, "GGG")
+    _seed_instrument(ebull_test_conn, 9103, "ALL_GGG")
     # No raw facts → EXCLUDED even with --all-instruments.
 
     cohort = select_cohort(ebull_test_conn, only_unprojected_088=False, limit=None)


### PR DESCRIPTION
## What

Adds \`scripts/backfill_xbrl_normalization.py\` — a once-per-install operator script that re-projects every issuer's canonical \`financial_periods\` row from \`financial_facts_raw\` so the four migration-088 ownership / capital-structure columns (\`treasury_shares\`, \`shares_authorized\`, \`shares_issued\`, \`retained_earnings\`) populate for issuers whose facts were ingested *before* the alias map carried those concepts.

## Why

The daily scheduler runs \`normalize_financial_periods\` only on instruments **touched that day**. Issuers whose raw facts pre-date migration 088 already have canonical rows; the daily pass skips them; the new columns stay NULL until SEC ships a fresh filing (slow-filers wait quarters).

Without this, the ownership reporting card (#729) shows treasury as "not on file" for almost every ticker — operator screenshot in #757 review confirmed this.

## Scope

- **Default cohort:** instruments with raw facts for any migration-088 concept AND at least one canonical column still NULL.
- **\`--all-instruments\`:** every instrument with raw facts. Use after future \`TRACKED_CONCEPTS\` migrations.
- **\`--limit\`:** cap cohort for staging runs.
- **Dry-run by default;** \`--apply\` actually projects.

## Verification probe (codex review)

Post-normalize, re-counts instruments still missing migration-088 columns despite raw facts on file. Surfaces partial-failure cases that the normalizer's per-instrument try/except would otherwise hide. Returns exit code 2 when any remain.

## Idempotency

\`normalize_financial_periods\` upserts WHERE IS DISTINCT FROM, so re-running over already-projected rows is a no-op for unchanged values. Safe to re-run.

## Bootstrap-only

Not a nightly job. The daily cadence handles new data.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pyright\` — clean
- [x] \`uv run pytest tests/test_backfill_xbrl_normalization.py\` — 6/6 pass
- [x] Codex review — high (cohort too narrow) + medium (partial-failure hidden) both addressed
- [ ] Operator: dry-run on dev DB, confirm cohort size
- [ ] Operator: \`--apply\` on dev DB, confirm ownership card shows treasury for treasury-holding issuers

🤖 Generated with [Claude Code](https://claude.com/claude-code)