### PR TITLE
feat(#759): bulk SEC company-facts re-fetch + normalize backfill

### DIFF
--- a/scripts/backfill_company_facts.py
+++ b/scripts/backfill_company_facts.py
@@ -1,0 +1,332 @@
+"""Bulk SEC ``companyfacts`` re-fetch (#759).
+
+Re-fetches every primary-SEC-CIK issuer's full XBRL fact corpus from
+SEC ``companyfacts`` so the unfiltered concept set lands in
+``financial_facts_raw``. Resolves the gap left by the daily change-
+driven planner: pre-#451-Phase-A the extractor filtered concepts on a
+narrow editorial allowlist, and the daily refresher only re-fetches
+CIKs that ship a new filing. Issuers without recent filings keep stale
+narrow facts forever; their post-088 canonical columns (treasury_shares,
+shares_authorized, shares_issued, retained_earnings) stay NULL.
+
+Bootstrap-only — once-per-install, or after a TRACKED_CONCEPTS-affecting
+migration. Not a nightly job.
+
+Pipeline:
+
+  1. Select every instrument with a primary SEC CIK in
+     ``external_identifiers``.
+  2. Re-fetch ``companyfacts`` for each via
+     ``refresh_financial_facts``. SEC public-key tier is 10 req/sec —
+     provider's internal throttle handles spacing. ~5000 issuers ≈
+     10 min wall clock.
+  3. Re-derive canonical ``financial_periods`` from the refreshed raw
+     store via ``normalize_financial_periods``.
+
+Both writes are idempotent: ``upsert_facts_for_instrument`` and the
+canonical merge both use ON CONFLICT DO UPDATE WHERE IS DISTINCT FROM,
+so re-runs over already-current data are no-ops for unchanged values.
+
+Resumable: ``--start-from N`` skips instrument_ids ≤ N (useful after a
+mid-run network blip). ``--limit N`` caps the cohort for staging runs.
+
+Run from repo root:
+
+    uv run python -m scripts.backfill_company_facts
+    uv run python -m scripts.backfill_company_facts --apply
+    uv run python -m scripts.backfill_company_facts --apply --limit 50
+    uv run python -m scripts.backfill_company_facts --apply --start-from 1500
+
+Defaults to dry-run (lists cohort, no fetches, no DB writes).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from dataclasses import dataclass
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
+from app.services.fundamentals import (
+    normalize_financial_periods,
+    refresh_financial_facts,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CohortRow:
+    symbol: str
+    instrument_id: int
+    cik: str
+
+
+def select_cohort(
+    conn: psycopg.Connection[tuple],
+    *,
+    start_from: int,
+    limit: int | None,
+) -> list[CohortRow]:
+    """Return primary-SEC-CIK instruments to fetch in this run.
+
+    Ordered by ``instrument_id`` ASC so ``--start-from`` produces a
+    deterministic resume point. Filters on ``is_primary = TRUE`` so an
+    issuer with multiple historical CIKs (e.g. spin-offs, mergers)
+    gets its current canonical CIK only.
+    """
+    sql = """
+        SELECT i.symbol, i.instrument_id, ei.identifier_value
+        FROM instruments i
+        JOIN external_identifiers ei
+            ON ei.instrument_id = i.instrument_id
+            AND ei.provider = 'sec'
+            AND ei.identifier_type = 'cik'
+            AND ei.is_primary = TRUE
+        WHERE i.instrument_id > %(start_from)s
+        ORDER BY i.instrument_id ASC
+    """
+    params: dict[str, object] = {"start_from": start_from}
+    if limit is not None:
+        sql += "\nLIMIT %(limit)s"
+        params["limit"] = limit
+    rows = conn.execute(sql, params).fetchall()
+    return [CohortRow(symbol=str(r[0]), instrument_id=int(r[1]), cik=str(r[2])) for r in rows]
+
+
+def select_all_primary_sec_instrument_ids(
+    conn: psycopg.Connection[tuple],
+) -> list[int]:
+    """Return EVERY primary-SEC-CIK instrument_id, ignoring
+    ``--start-from`` / ``--limit``.
+
+    Used by the normalize phase to re-derive the canonical store for
+    the entire SEC universe, not just this invocation's fetch cohort
+    (codex review High #1). Without this, a script run with
+    ``--start-from N`` would fetch IDs > N but only normalize IDs > N,
+    leaving a prior run's fetched-but-unnormalized prefix stranded
+    under a stale canonical row.
+
+    Idempotent — ``normalize_financial_periods`` no-ops on rows whose
+    derived values are unchanged, so re-normalizing IDs that were
+    already current adds no DB churn.
+    """
+    rows = conn.execute(
+        """
+        SELECT DISTINCT i.instrument_id
+        FROM instruments i
+        JOIN external_identifiers ei
+            ON ei.instrument_id = i.instrument_id
+            AND ei.provider = 'sec'
+            AND ei.identifier_type = 'cik'
+            AND ei.is_primary = TRUE
+        ORDER BY i.instrument_id ASC
+        """,
+    ).fetchall()
+    return [int(r[0]) for r in rows]
+
+
+def count_facts_without_periods(
+    conn: psycopg.Connection[tuple],
+    instrument_ids: list[int],
+) -> int:
+    """Count cohort members that have raw facts on file but no
+    canonical ``financial_periods`` row at all — an approximate signal
+    for "normalize raised an exception and rolled the row back".
+
+    ``normalize_financial_periods`` swallows per-instrument exceptions
+    (logs and continues), and ``NormalizationSummary`` reports
+    ``instruments_processed = len(input_ids)`` regardless of whether
+    each one actually committed (codex review High #2). For a one-shot
+    backfill that masks partial failure. This probe is cheap to run
+    (one indexed SELECT) and surfaces the "completely failed
+    instrument" case at the exit boundary.
+
+    Limitation: an instrument that committed *some* canonical rows but
+    rolled back *others* shows up as healthy here. The schema-level
+    invariant we can cheaply assert is "raw facts AND zero canonical
+    rows" — anything finer-grained needs a per-period probe which
+    ``backfill_xbrl_normalization.py`` already provides for the
+    migration-088 column subset.
+    """
+    if not instrument_ids:
+        return 0
+    rows = conn.execute(
+        """
+        SELECT COUNT(DISTINCT i.instrument_id)
+        FROM instruments i
+        WHERE i.instrument_id = ANY(%(ids)s)
+          AND EXISTS (SELECT 1 FROM financial_facts_raw f WHERE f.instrument_id = i.instrument_id)
+          AND NOT EXISTS (SELECT 1 FROM financial_periods p WHERE p.instrument_id = i.instrument_id)
+        """,
+        {"ids": instrument_ids},
+    ).fetchall()
+    return int(rows[0][0]) if rows else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually fetch + write. Default is dry-run (cohort report only).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap cohort size for staging runs.",
+    )
+    parser.add_argument(
+        "--start-from",
+        type=int,
+        default=0,
+        help=(
+            "Skip instrument_ids ≤ this value. Use to resume after a "
+            "mid-run network blip without re-fetching the already-done "
+            "prefix."
+        ),
+    )
+    parser.add_argument(
+        "--skip-normalize",
+        action="store_true",
+        help=(
+            "Run only the SEC re-fetch phase. Use when chaining with a "
+            "separate normalize-only run, or when the cohort is being "
+            "split across multiple invocations."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    with psycopg.connect(settings.database_url) as conn:
+        cohort = select_cohort(conn, start_from=args.start_from, limit=args.limit)
+        # Close the implicit read transaction opened by ``select_cohort``
+        # before the multi-minute SEC fetch begins. Without this, the
+        # cohort-SELECT cursor's read transaction stays open across the
+        # whole fetch loop. Same pattern ``force_refresh_fundamentals``
+        # uses.
+        conn.commit()
+
+        logger.info(
+            "backfill_company_facts: cohort=%d (start_from=%d limit=%s)",
+            len(cohort),
+            args.start_from,
+            args.limit,
+        )
+
+        if not cohort:
+            logger.info("backfill_company_facts: nothing to do")
+            return 0
+
+        if not args.apply:
+            logger.info(
+                "backfill_company_facts: DRY-RUN — pass --apply to actually fetch + write. "
+                "Estimated wall clock at 10 req/sec: ~%.1f minutes.",
+                len(cohort) / 600.0,
+            )
+            return 0
+
+        symbols_for_refresh: list[tuple[str, int, str]] = [(r.symbol, r.instrument_id, r.cik) for r in cohort]
+
+        started = time.monotonic()
+        with SecFundamentalsProvider(user_agent=settings.sec_user_agent) as provider:
+            facts_summary = refresh_financial_facts(provider, conn, symbols_for_refresh)
+        # Commit the fetch phase before normalize so the per-instrument
+        # transactions inside ``normalize_financial_periods`` are
+        # top-level (not nested savepoints under any outer ledger tx
+        # that ``refresh_financial_facts`` may still hold open). Same
+        # boundary pattern ``force_refresh_fundamentals`` uses (codex
+        # review #2 on PR #680).
+        conn.commit()
+        fetch_elapsed = time.monotonic() - started
+
+        logger.info(
+            "backfill_company_facts: fetch done in %.1fs — upserted=%d skipped=%d failed=%d",
+            fetch_elapsed,
+            facts_summary.facts_upserted,
+            facts_summary.facts_skipped,
+            facts_summary.symbols_failed,
+        )
+
+        if args.skip_normalize:
+            logger.info("backfill_company_facts: --skip-normalize — leaving canonical re-derive for a separate run")
+            return _exit_code_from_failures(facts_summary.symbols_failed, len(cohort), normalize_failed=0)
+
+        # Normalize EVERY primary-SEC-CIK instrument — not just this
+        # run's fetch cohort. With ``--start-from`` users can split a
+        # multi-hour fetch across runs; scoping normalize to the
+        # current cohort would strand prior-run fetches under stale
+        # canonical rows. Re-normalizing already-current rows is a
+        # no-op (ON CONFLICT DO UPDATE WHERE IS DISTINCT FROM), so
+        # the only cost is per-instrument tx overhead — a few minutes
+        # for the full universe (codex review High #1).
+        norm_ids = select_all_primary_sec_instrument_ids(conn)
+        conn.commit()
+
+        norm_started = time.monotonic()
+        norm_summary = normalize_financial_periods(conn, instrument_ids=norm_ids)
+        conn.commit()
+        norm_elapsed = time.monotonic() - norm_started
+
+        # Approximate normalize-failure probe: count instruments with
+        # raw facts on file but no canonical rows at all. Catches the
+        # "every period rolled back" case that
+        # ``NormalizationSummary`` hides (codex review High #2).
+        normalize_failed = count_facts_without_periods(conn, norm_ids)
+
+        logger.info(
+            "backfill_company_facts: normalize done in %.1fs — instruments=%d "
+            "raw_periods_upserted=%d canonical_upserted=%d normalize_failed=%d",
+            norm_elapsed,
+            norm_summary.instruments_processed,
+            norm_summary.periods_raw_upserted,
+            norm_summary.periods_canonical_upserted,
+            normalize_failed,
+        )
+        if normalize_failed > 0:
+            logger.warning(
+                "backfill_company_facts: %d instrument(s) have raw facts on file but no canonical "
+                "financial_periods row — normalize likely raised an exception. "
+                "Check the application log for 'Failed to normalize instrument N' lines.",
+                normalize_failed,
+            )
+
+        return _exit_code_from_failures(facts_summary.symbols_failed, len(cohort), normalize_failed=normalize_failed)
+
+
+def _exit_code_from_failures(
+    fetch_failed: int,
+    fetch_total: int,
+    *,
+    normalize_failed: int,
+) -> int:
+    """Return shell-friendly exit status: 0 clean, 1 total fetch
+    failure, 2 partial / normalize failure.
+
+    Three input states feed into the decision:
+      * ``fetch_failed`` — count of CIKs whose SEC fetch raised.
+      * ``fetch_total`` — cohort size at fetch phase.
+      * ``normalize_failed`` — instruments with raw facts but no
+        canonical rows after normalize (apparent rollback).
+
+    Codex review High #2: prior version derived exit code only from
+    fetch failures and missed normalize rollbacks entirely. Now any
+    normalize failure also flips the exit to 2 so the operator's
+    automation wrapper can distinguish a clean backfill from one that
+    needs the application log read.
+    """
+    if fetch_failed == 0 and normalize_failed == 0:
+        return 0
+    if fetch_failed == fetch_total and fetch_total > 0:
+        return 1
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_backfill_company_facts.py
+++ b/tests/test_backfill_company_facts.py
@@ -1,0 +1,213 @@
+"""Tests for the bulk SEC company-facts backfill script (#759).
+
+Pins the cohort selector. The end-to-end refresh + normalize path is
+covered by ``test_force_refresh_fundamentals`` and the existing
+fundamentals tests; this file just verifies the cohort SELECT
+correctly enumerates primary-SEC-CIK instruments and respects
+``--start-from`` / ``--limit``.
+
+Uses the canonical ``ebull_test_conn`` fixture from
+``tests/conftest.py`` so the test-DB URL is derived from
+``settings.database_url`` rather than hardcoded.
+"""
+
+from __future__ import annotations
+
+import psycopg
+
+from scripts.backfill_company_facts import (
+    _exit_code_from_failures,
+    count_facts_without_periods,
+    select_all_primary_sec_instrument_ids,
+    select_cohort,
+)
+
+
+def _seed(
+    conn: psycopg.Connection[tuple],
+    instrument_id: int,
+    symbol: str,
+    *,
+    cik: str | None,
+    is_primary_cik: bool = True,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO exchanges (exchange_id, description, country, asset_class)
+        VALUES (%s, %s, 'US', 'us_equity')
+        ON CONFLICT (exchange_id) DO NOTHING
+        """,
+        (f"bcf_{instrument_id}", f"Test {instrument_id}"),
+    )
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange)
+        VALUES (%s, %s, %s, %s)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id, symbol, f"Test {symbol}", f"bcf_{instrument_id}"),
+    )
+    if cik is not None:
+        conn.execute(
+            """
+            INSERT INTO external_identifiers
+                (instrument_id, provider, identifier_type, identifier_value, is_primary)
+            VALUES (%s, 'sec', 'cik', %s, %s)
+            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            """,
+            (instrument_id, cik, is_primary_cik),
+        )
+
+
+def test_cohort_picks_only_primary_sec_cik_instruments(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    # A: has primary SEC CIK → IN cohort.
+    _seed(ebull_test_conn, 9501, "BCF_AAA", cik="0000111111", is_primary_cik=True)
+
+    # B: has secondary (is_primary=False) SEC CIK → EXCLUDED.
+    # Operator-side rationale: secondary CIKs are historical / spin-off
+    # holdovers; refreshing them would double-fetch the same issuer.
+    _seed(ebull_test_conn, 9502, "BCF_BBB", cik="0000222222", is_primary_cik=False)
+
+    # C: instrument with no external_identifiers row → EXCLUDED.
+    _seed(ebull_test_conn, 9503, "BCF_CCC", cik=None)
+
+    cohort = select_cohort(ebull_test_conn, start_from=0, limit=None)
+    cohort_ids = {r.instrument_id for r in cohort}
+
+    assert 9501 in cohort_ids
+    assert 9502 not in cohort_ids
+    assert 9503 not in cohort_ids
+
+
+def test_cohort_start_from_skips_lower_ids(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    for iid in range(9601, 9606):
+        _seed(ebull_test_conn, iid, f"BCF_S{iid}", cik=f"00000{iid:05d}")
+
+    cohort = select_cohort(ebull_test_conn, start_from=9603, limit=None)
+    cohort_ids = [r.instrument_id for r in cohort]
+
+    # ``start_from`` is exclusive — IDs ≤ 9603 are skipped.
+    assert 9601 not in cohort_ids
+    assert 9603 not in cohort_ids
+    assert 9604 in cohort_ids
+    assert 9605 in cohort_ids
+
+
+def test_cohort_limit_caps_size_after_start_from(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    for iid in range(9701, 9706):
+        _seed(ebull_test_conn, iid, f"BCF_L{iid}", cik=f"00001{iid:05d}")
+
+    cohort = select_cohort(ebull_test_conn, start_from=0, limit=3)
+    assert len(cohort) == 3
+    # ORDER BY instrument_id ASC — first 3 by ID.
+    assert [r.instrument_id for r in cohort] == [9701, 9702, 9703]
+
+
+def test_cohort_returns_symbol_and_cik(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed(ebull_test_conn, 9801, "BCF_X", cik="0000777777")
+    cohort = select_cohort(ebull_test_conn, start_from=0, limit=None)
+    matched = [r for r in cohort if r.instrument_id == 9801]
+    assert len(matched) == 1
+    assert matched[0].symbol == "BCF_X"
+    assert matched[0].cik == "0000777777"
+
+
+def test_exit_code_from_failures_clean() -> None:
+    assert _exit_code_from_failures(0, 10, normalize_failed=0) == 0
+
+
+def test_exit_code_from_failures_total_fetch_failure() -> None:
+    assert _exit_code_from_failures(10, 10, normalize_failed=0) == 1
+
+
+def test_exit_code_from_failures_partial_fetch_failure() -> None:
+    assert _exit_code_from_failures(3, 10, normalize_failed=0) == 2
+
+
+def test_exit_code_from_failures_normalize_failure_alone_flips_to_2() -> None:
+    # Codex review High #2 — normalize rollbacks must surface even
+    # when every fetch succeeded.
+    assert _exit_code_from_failures(0, 10, normalize_failed=2) == 2
+
+
+def test_exit_code_from_failures_total_with_zero_cohort_is_clean() -> None:
+    # Edge: empty cohort with zero failures must not trip the
+    # "fetch_failed == fetch_total" branch.
+    assert _exit_code_from_failures(0, 0, normalize_failed=0) == 0
+
+
+def test_select_all_primary_returns_every_primary_cik(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed(ebull_test_conn, 9901, "BCF_AP_A", cik="0000900001", is_primary_cik=True)
+    _seed(ebull_test_conn, 9902, "BCF_AP_B", cik="0000900002", is_primary_cik=True)
+    _seed(ebull_test_conn, 9903, "BCF_AP_C", cik="0000900003", is_primary_cik=False)
+    _seed(ebull_test_conn, 9904, "BCF_AP_D", cik=None)
+
+    ids = select_all_primary_sec_instrument_ids(ebull_test_conn)
+    assert 9901 in ids
+    assert 9902 in ids
+    assert 9903 not in ids
+    assert 9904 not in ids
+
+
+def test_count_facts_without_periods_flags_instruments_with_no_canonical(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    from datetime import date
+
+    # A: has facts, no canonical row → counts as 1 (apparent rollback).
+    _seed(ebull_test_conn, 9911, "BCF_PROBE_A", cik="0000910001")
+    ebull_test_conn.execute(
+        """
+        INSERT INTO financial_facts_raw
+            (instrument_id, concept, unit, period_start, period_end, val,
+             form_type, fiscal_year, fiscal_period, accession_number, filed_date)
+        VALUES (%s, 'Revenues', 'USD', NULL, %s, 1000, '10-K', 2024, 'FY', 'a-9911', %s)
+        ON CONFLICT DO NOTHING
+        """,
+        (9911, date(2024, 12, 31), date(2025, 2, 1)),
+    )
+
+    # B: has facts AND canonical row → not counted.
+    _seed(ebull_test_conn, 9912, "BCF_PROBE_B", cik="0000910002")
+    ebull_test_conn.execute(
+        """
+        INSERT INTO financial_facts_raw
+            (instrument_id, concept, unit, period_start, period_end, val,
+             form_type, fiscal_year, fiscal_period, accession_number, filed_date)
+        VALUES (%s, 'Revenues', 'USD', NULL, %s, 2000, '10-K', 2024, 'FY', 'a-9912', %s)
+        ON CONFLICT DO NOTHING
+        """,
+        (9912, date(2024, 12, 31), date(2025, 2, 1)),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO financial_periods
+            (instrument_id, fiscal_year, fiscal_quarter, period_end_date,
+             period_start_date, period_type, form_type, filed_date,
+             reported_currency, source, source_ref)
+        VALUES (%s, 2024, 4, %s, %s, 'FY', '10-K', %s, 'USD', 'sec', 'a-9912')
+        ON CONFLICT DO NOTHING
+        """,
+        (9912, date(2024, 12, 31), date(2024, 1, 1), date(2025, 2, 1)),
+    )
+
+    # C: no facts, no canonical row → not counted (nothing to normalize).
+    _seed(ebull_test_conn, 9913, "BCF_PROBE_C", cik="0000910003")
+
+    assert count_facts_without_periods(ebull_test_conn, [9911, 9912, 9913]) == 1
+
+
+def test_count_facts_without_periods_handles_empty_cohort(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    assert count_facts_without_periods(ebull_test_conn, []) == 0

--- a/tests/test_backfill_company_facts.py
+++ b/tests/test_backfill_company_facts.py
@@ -97,16 +97,42 @@ def test_cohort_start_from_skips_lower_ids(
     assert 9605 in cohort_ids
 
 
-def test_cohort_limit_caps_size_after_start_from(
+def test_cohort_limit_caps_size_within_seeded_range(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    for iid in range(9701, 9706):
+    seeded = list(range(9701, 9706))
+    for iid in seeded:
         _seed(ebull_test_conn, iid, f"BCF_L{iid}", cik=f"00001{iid:05d}")
 
-    cohort = select_cohort(ebull_test_conn, start_from=0, limit=3)
+    # Pin the LIMIT contract robustly even if the fixture's
+    # per-test TRUNCATE stops working: rather than asserting the
+    # cohort equals a positional slice of seeded ids (which would
+    # break the moment IDs from a sibling test leak in), assert
+    # ``limit`` truncates AND the truncated set is a subset of what
+    # this test actually seeded. Reviewer PREVENTION pin on PR #760.
+    cohort = select_cohort(ebull_test_conn, start_from=9700, limit=3)
     assert len(cohort) == 3
-    # ORDER BY instrument_id ASC — first 3 by ID.
-    assert [r.instrument_id for r in cohort] == [9701, 9702, 9703]
+    cohort_ids = {r.instrument_id for r in cohort}
+    assert cohort_ids.issubset(set(seeded))
+    # ORDER BY instrument_id ASC — the three smallest seeded IDs.
+    assert sorted(cohort_ids) == seeded[:3]
+
+
+def test_cohort_start_from_combined_with_limit_advances_window(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    seeded = list(range(9751, 9756))
+    for iid in seeded:
+        _seed(ebull_test_conn, iid, f"BCF_W{iid}", cik=f"00002{iid:05d}")
+
+    # ``start_from=9752`` skips ID 9751 + 9752; ``limit=2`` then caps
+    # at 9753, 9754. Reviewer NITPICK pin: previously test name
+    # implied this interaction but called ``start_from=0``.
+    cohort = select_cohort(ebull_test_conn, start_from=9752, limit=2)
+    assert len(cohort) == 2
+    cohort_ids = {r.instrument_id for r in cohort}
+    assert cohort_ids.issubset(set(seeded))
+    assert sorted(cohort_ids) == [9753, 9754]
 
 
 def test_cohort_returns_symbol_and_cik(


### PR DESCRIPTION
## What

Adds \`scripts/backfill_company_facts.py\` — a once-per-install operator script that bulk-refetches every primary-SEC-CIK issuer's full XBRL fact corpus from SEC \`companyfacts\`, then re-derives every primary-SEC-CIK instrument's canonical \`financial_periods\` row.

## Why

Pre-#451-Phase-A, the extractor filtered concepts on a narrow editorial allowlist. The daily refresher only re-fetches CIKs with new filings. Result: issuers without recent filings keep stale narrow facts forever; their post-088 canonical columns (\`treasury_shares\`, \`shares_authorized\`, \`shares_issued\`, \`retained_earnings\`) stay NULL.

Verified on dev DB after PR #758 backfill ran:

\`\`\`
AAPL financial_facts_raw concepts matching Treasury/Authorized/Retained: 0 rows
\`\`\`

AAPL files all four quarterly. Without this re-fetch, the ownership card (#729) shows treasury as "not on file" forever.

## Pipeline

1. Select primary-SEC-CIK cohort (\`--start-from\` / \`--limit\` gates).
2. Re-fetch \`companyfacts\` via \`refresh_financial_facts\` (10 req/sec ≈ 10 min for full universe).
3. Re-derive \`financial_periods\` over **every** primary-SEC-CIK instrument (not just this run's fetch cohort).

## Codex review (resolved)

- **High #1** — \`--start-from\` was only fetch-resumable. Fixed: normalize phase widened to all primary-SEC-CIK instruments so prior runs aren't stranded under stale canonical rows. Idempotent (no-op on unchanged values).
- **High #2** — exit status ignored normalize failures (\`NormalizationSummary\` swallows per-instrument exceptions). Fixed: post-normalize \`count_facts_without_periods\` probe surfaces apparent rollbacks; \`_exit_code_from_failures\` accepts \`normalize_failed\` keyword and returns 2 when set.
- **Medium** — transaction comment overstated. Fixed: tightened to describe phase boundary without misattributing cause.

## Idempotency

Both phases use ON CONFLICT DO UPDATE WHERE IS DISTINCT FROM. Safe to re-run.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pyright\` — clean
- [x] \`uv run pytest tests/test_backfill_company_facts.py\` — 12/12 pass
- [x] Codex review — high + medium both addressed
- [ ] Operator: dry-run on dev DB, confirm cohort size + ETA
- [ ] Operator: \`--apply\` on dev DB; verify AAPL/MSFT/NVDA \`treasury_shares\` populate

## Related

- #735 — XBRL projection backfill (PR #758, merged)
- #451 — Phase A unfiltered fact ingestion
- #729 — Ownership card (motivating UI gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)