### PR TITLE
fix(#752): agent-CIK defense-in-depth + diagnostic audit script

### DIFF
--- a/app/providers/implementations/sec_edgar.py
+++ b/app/providers/implementations/sec_edgar.py
@@ -80,6 +80,35 @@ _PROCESS_RATE_LIMIT_CLOCK: list[float] = [0.0]
 _PROCESS_RATE_LIMIT_LOCK: threading.Lock = threading.Lock()
 
 
+# Known SEC filing-agent CIKs (#752 defense-in-depth). These are
+# registered EDGAR submitters that file ON BEHALF of issuers — their
+# CIK appears as the prefix of the accession number for any filing
+# they submit, but the archive directory ALWAYS lives under the
+# issuer's CIK. Routing an archive fetch under any of these CIKs is
+# guaranteed to 404. The ``fetch_filing_index`` legacy fallback
+# rejects on hit so a stale long-running process running pre-#736
+# code surfaces a clear log line ("known agent CIK; pass issuer_cik")
+# instead of generating thousands of 404 round-trips against SEC.
+#
+# Source: cross-referenced from accession-prefix patterns observed in
+# the SEC master-index across 2024-2026. Adding a new agent here is
+# a code change rather than a DB migration so the block-list is
+# auditable in version control.
+KNOWN_FILING_AGENT_CIKS: frozenset[str] = frozenset(
+    {
+        "0001213900",  # EdgarOnline (Issuer Direct)
+        "0001493152",  # GlobeNewswire / Issuer Direct
+        "0001193125",  # Donnelley R.R. & Sons
+        "0001437749",  # Edgar Agents LLC
+        "0001571049",  # Donnelley Financial Solutions (DFIN)
+        "0001185185",  # Workiva
+        "0001387131",  # RR Donnelley
+        "0001469734",  # Toppan Merrill
+        "0001628280",  # Sec Compliance Services
+    }
+)
+
+
 def _zero_pad_cik(cik: str | int) -> str:
     """Return a 10-digit zero-padded CIK string."""
     return str(int(cik)).zfill(10)
@@ -363,8 +392,29 @@ class SecFilingsProvider(FilingsProvider):
         else:
             # Legacy fallback (#736): the accession prefix is the
             # filer-of-record's CIK, which collides with the
-            # archive's issuer-CIK key only for self-filers. Log so
-            # an operator investigating 404 noise can correlate.
+            # archive's issuer-CIK key only for self-filers.
+            #
+            # Defense-in-depth (#752): if the prefix CIK is a known
+            # filing-agent (EdgarOnline, GlobeNewswire, Donnelley
+            # etc.) the legacy URL is GUARANTEED to 404 — the agent
+            # never owns archive directories. Reject early with an
+            # explicit warning so a stale long-running process holding
+            # pre-#736 code surfaces a clear log line instead of
+            # generating thousands of 404 round-trips. Operator action
+            # on this warning: restart the jobs process so the
+            # post-#736 routing is in-memory.
+            prefix_cik = raw_id[:10]
+            if prefix_cik in KNOWN_FILING_AGENT_CIKS:
+                logger.warning(
+                    "fetch_filing_index: refusing legacy fallback for "
+                    "accession=%s — prefix CIK %s is a known filing-agent "
+                    "(URL would 404). Caller MUST pass issuer_cik. If this "
+                    "fires from a long-running worker, the process is "
+                    "running pre-#736 code; restart to pick up the routing fix.",
+                    provider_filing_id,
+                    prefix_cik,
+                )
+                return None
             logger.debug(
                 "fetch_filing_index: using accession-prefix CIK fallback "
                 "for accession=%s — pass issuer_cik to avoid agent-CIK 404s",

--- a/scripts/audit_agent_cik_contamination.py
+++ b/scripts/audit_agent_cik_contamination.py
@@ -1,0 +1,122 @@
+"""Operator audit for agent-CIK contamination in ``external_identifiers`` (#752).
+
+Reports any instrument whose primary SEC CIK is a known filing-agent CIK
+(EdgarOnline, GlobeNewswire, Donnelley etc.). Such rows would route
+``Archives/edgar/data/{CIK}/{accession}/`` fetches under the agent's
+non-existent archive directory and produce 100% fetch_errors.
+
+Original #752 ticket hypothesised that the daily master-index ingest
+(``app/services/fundamentals.py:1769``) was bucketing accessions by
+column-1 CIK (the filer-of-record, often the agent for agent-filed
+accessions) and propagating that into ``external_identifiers``.
+
+Diagnostic run on 2026-05-02 against a populated dev DB returned
+**zero contaminated rows** — even with ``is_primary=FALSE`` rows
+included. So the data plane is clean; the production 404s the user
+observed at 2026-05-01 20:51:44 came from a long-running ``app.jobs``
+worker process started 2026-05-01 01:12:14, holding pre-#745+#748
+in-memory code that fell through to the legacy CIK-prefix fallback.
+
+This script remains valuable as:
+
+  1. **Boot-time / scheduled audit**: confirms the data plane stays
+     clean on every install / migration.
+  2. **Operator-facing remediation tool**: exits non-zero with a CSV
+     dump if a future bug reintroduces contamination.
+
+Run from repo root:
+
+    uv run python -m scripts.audit_agent_cik_contamination
+    uv run python -m scripts.audit_agent_cik_contamination --include-secondary
+
+Exit codes:
+  0 — clean
+  1 — contamination found (CSV emitted to stdout)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import sys
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.sec_edgar import KNOWN_FILING_AGENT_CIKS
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def find_contaminated(
+    conn: psycopg.Connection[tuple],
+    *,
+    include_secondary: bool,
+) -> list[tuple[int, str, str, str, bool]]:
+    """Return ``(instrument_id, symbol, company_name, agent_cik, is_primary)``
+    for every external_identifier row whose CIK matches a known agent.
+
+    ``include_secondary`` toggles whether ``is_primary=FALSE`` rows
+    appear in the report. Default off — primary rows are the ones that
+    drive the production fetch URL routing.
+    """
+    sql = """
+        SELECT i.instrument_id, i.symbol, i.company_name,
+               ei.identifier_value AS agent_cik, ei.is_primary
+        FROM external_identifiers ei
+        JOIN instruments i USING (instrument_id)
+        WHERE ei.provider = 'sec'
+          AND ei.identifier_type = 'cik'
+          AND ei.identifier_value = ANY(%(agents)s)
+    """
+    if not include_secondary:
+        sql += "\n          AND ei.is_primary = TRUE"
+    sql += "\n        ORDER BY ei.identifier_value, i.symbol"
+    rows = conn.execute(sql, {"agents": list(KNOWN_FILING_AGENT_CIKS)}).fetchall()
+    return [(int(r[0]), str(r[1]), str(r[2]), str(r[3]), bool(r[4])) for r in rows]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--include-secondary",
+        action="store_true",
+        help=(
+            "Include is_primary=FALSE rows in the audit. These do not "
+            "drive production routing but a non-empty list signals the "
+            "ingest path leaked agent CIKs into the table at some point."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    with psycopg.connect(settings.database_url) as conn:
+        rows = find_contaminated(conn, include_secondary=args.include_secondary)
+
+    logger.info(
+        "audit_agent_cik_contamination: agents=%d rows_found=%d include_secondary=%s",
+        len(KNOWN_FILING_AGENT_CIKS),
+        len(rows),
+        args.include_secondary,
+    )
+
+    if not rows:
+        logger.info("audit_agent_cik_contamination: clean — no agent-CIK contamination found")
+        return 0
+
+    writer = csv.writer(sys.stdout)
+    writer.writerow(["instrument_id", "symbol", "company_name", "agent_cik", "is_primary"])
+    for r in rows:
+        writer.writerow(r)
+    logger.warning(
+        "audit_agent_cik_contamination: %d contaminated row(s) — see CSV above. "
+        "Remediation: demote affected rows to is_primary=FALSE and re-resolve "
+        "the issuer's true CIK via SEC's company_tickers.json.",
+        len(rows),
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_agent_cik_defense.py
+++ b/tests/test_agent_cik_defense.py
@@ -1,0 +1,200 @@
+"""Tests for #752 agent-CIK defense-in-depth.
+
+Pins two contracts:
+  1. ``fetch_filing_index`` legacy fallback REJECTS known-agent
+     CIK prefixes — returns ``None`` with a clear warning rather than
+     producing a guaranteed-404 round trip against SEC.
+  2. ``audit_agent_cik_contamination`` reports every external_identifier
+     row whose CIK matches the block-list, splitting on ``is_primary``.
+
+The original ticket #752 hypothesised that ``external_identifiers`` was
+contaminated. Live diagnostic on 2026-05-02 returned zero contaminated
+rows — root cause was a stale long-running worker. Tests here cover the
+defense-in-depth path so a future regression that leaks agent CIKs into
+the table OR that drops issuer_cik from a fetch_filing_index call site
+fails fast instead of silently 404'ing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import psycopg
+import pytest
+
+from app.providers.implementations.sec_edgar import (
+    KNOWN_FILING_AGENT_CIKS,
+    SecFilingsProvider,
+)
+from scripts.audit_agent_cik_contamination import find_contaminated
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, body: dict[str, object] | None = None) -> None:
+        self.status_code = status_code
+        self._body = body or {}
+
+    def json(self) -> dict[str, object]:
+        return self._body
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _RecordingClient:
+    """Captures URLs the legacy fallback would otherwise send to SEC."""
+
+    def __init__(self, status: int = 404) -> None:
+        self.urls: list[str] = []
+        self.status = status
+
+    def get(self, url: str) -> _FakeResponse:
+        self.urls.append(url)
+        return _FakeResponse(self.status)
+
+
+@pytest.fixture
+def provider_with_recording_clients() -> tuple[SecFilingsProvider, _RecordingClient]:
+    provider = SecFilingsProvider(user_agent="test")
+    recorder = _RecordingClient(status=404)
+    provider._http_tickers = recorder  # type: ignore[assignment]
+    return provider, recorder
+
+
+class TestLegacyFallbackRejectsAgentCiks:
+    def test_agent_prefix_returns_none_without_http_call(
+        self,
+        provider_with_recording_clients: tuple[SecFilingsProvider, _RecordingClient],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        provider, recorder = provider_with_recording_clients
+        # Accession with EdgarOnline (1213900) prefix — known agent.
+        with caplog.at_level(logging.WARNING):
+            result = provider.fetch_filing_index("0001213900-26-048837")
+
+        assert result is None
+        # Must NOT have hit SEC — the URL would be guaranteed 404
+        # and burn rate-limit budget.
+        assert recorder.urls == []
+        # Operator-facing warning must surface so a stale-process
+        # diagnosis is one log grep away.
+        assert any("0001213900" in r.message for r in caplog.records)
+        assert any("issuer_cik" in r.message for r in caplog.records)
+
+    def test_globenewswire_prefix_also_rejected(
+        self,
+        provider_with_recording_clients: tuple[SecFilingsProvider, _RecordingClient],
+    ) -> None:
+        provider, recorder = provider_with_recording_clients
+        # GlobeNewswire (1493152).
+        result = provider.fetch_filing_index("0001493152-26-019605")
+        assert result is None
+        assert recorder.urls == []
+
+    def test_non_agent_prefix_falls_through_to_legacy_fetch(
+        self,
+        provider_with_recording_clients: tuple[SecFilingsProvider, _RecordingClient],
+    ) -> None:
+        # AAPL self-files as 0000320193 — not an agent. Legacy
+        # fallback proceeds (the URL might still 404 in the real
+        # world but the block-list doesn't trip).
+        provider, recorder = provider_with_recording_clients
+        provider.fetch_filing_index("0000320193-24-000001")
+        assert len(recorder.urls) == 1
+        assert "320193" in recorder.urls[0]
+
+    def test_explicit_issuer_cik_bypasses_block_list(
+        self,
+        provider_with_recording_clients: tuple[SecFilingsProvider, _RecordingClient],
+    ) -> None:
+        # When the caller passes issuer_cik explicitly, the block-list
+        # branch is not reached — even if the accession's agent-prefix
+        # would otherwise trigger it. This is the production happy path.
+        provider, recorder = provider_with_recording_clients
+        recorder.status = 404  # SEC returns 404 — caller handles None.
+        result = provider.fetch_filing_index("0001493152-26-019605", issuer_cik="0002032379")
+        assert result is None
+        # URL was still attempted (under the issuer's CIK).
+        assert len(recorder.urls) == 1
+        assert "/2032379/" in recorder.urls[0]
+
+    def test_known_agent_set_includes_documented_filers(self) -> None:
+        # Pin the block-list contents so a future PR that adds /
+        # removes an agent has to update the set explicitly.
+        for cik in (
+            "0001213900",  # EdgarOnline
+            "0001493152",  # GlobeNewswire
+            "0001193125",  # Donnelley R.R. & Sons
+            "0001437749",  # Edgar Agents LLC
+        ):
+            assert cik in KNOWN_FILING_AGENT_CIKS
+
+
+# ---------------------------------------------------------------------------
+# Audit script: ``find_contaminated``
+# ---------------------------------------------------------------------------
+
+
+def _seed(
+    conn: psycopg.Connection[tuple],
+    instrument_id: int,
+    symbol: str,
+    cik: str,
+    *,
+    is_primary: bool,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO exchanges (exchange_id, description, country, asset_class)
+        VALUES (%s, %s, 'US', 'us_equity')
+        ON CONFLICT (exchange_id) DO NOTHING
+        """,
+        (f"acd_{instrument_id}", f"Test {instrument_id}"),
+    )
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange)
+        VALUES (%s, %s, %s, %s)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id, symbol, f"Test {symbol}", f"acd_{instrument_id}"),
+    )
+    conn.execute(
+        """
+        INSERT INTO external_identifiers
+            (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (%s, 'sec', 'cik', %s, %s)
+        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        """,
+        (instrument_id, cik, is_primary),
+    )
+
+
+def test_audit_finds_primary_agent_cik_contamination(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    # Contaminated: GlobeNewswire CIK as primary identifier on a
+    # real-looking instrument. The whole point of the audit.
+    _seed(ebull_test_conn, 991_001, "ACD_BAD", "0001493152", is_primary=True)
+    # Healthy: real issuer CIK on a real instrument.
+    _seed(ebull_test_conn, 991_002, "ACD_OK", "0000320193", is_primary=True)
+
+    rows = find_contaminated(ebull_test_conn, include_secondary=False)
+    contaminated_ids = {r[0] for r in rows}
+    assert 991_001 in contaminated_ids
+    assert 991_002 not in contaminated_ids
+
+
+def test_audit_excludes_secondary_by_default(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    # Secondary (is_primary=FALSE) agent CIK doesn't drive routing —
+    # excluded from default report so operators don't get false
+    # alarms on benign historical CIK aliases.
+    _seed(ebull_test_conn, 992_001, "ACD_SEC", "0001493152", is_primary=False)
+    rows = find_contaminated(ebull_test_conn, include_secondary=False)
+    assert 992_001 not in {r[0] for r in rows}
+
+    rows_all = find_contaminated(ebull_test_conn, include_secondary=True)
+    assert 992_001 in {r[0] for r in rows_all}

--- a/tests/test_agent_cik_defense.py
+++ b/tests/test_agent_cik_defense.py
@@ -192,7 +192,14 @@ def test_audit_excludes_secondary_by_default(
     # Secondary (is_primary=FALSE) agent CIK doesn't drive routing —
     # excluded from default report so operators don't get false
     # alarms on benign historical CIK aliases.
-    _seed(ebull_test_conn, 992_001, "ACD_SEC", "0001493152", is_primary=False)
+    #
+    # Use a *different* agent CIK from the sibling test
+    # ``test_audit_finds_primary_agent_cik_contamination`` so the
+    # ``ON CONFLICT (provider, identifier_type, identifier_value) DO
+    # NOTHING`` partial unique index doesn't silently skip this seed
+    # if test ordering leaves the prior test's row alive (PR #765
+    # review BLOCKING).
+    _seed(ebull_test_conn, 992_001, "ACD_SEC", "0001213900", is_primary=False)
     rows = find_contaminated(ebull_test_conn, include_secondary=False)
     assert 992_001 not in {r[0] for r in rows}
 


### PR DESCRIPTION
## Diagnosis

Live audit on 2026-05-02 dev DB: \`external_identifiers\` is **clean** — zero rows match any known filing-agent CIK across either \`is_primary\` value. The data plane is not corrupted; #752's contamination hypothesis is not the production issue.

**Real cause** of the 2026-05-01 20:51:44 production 404 burst:

- \`app.jobs\` worker process started **2026-05-01 01:12:14**
- PR #748 (\`issuer_cik\` thread-through) merged **2026-05-01 15:33:27**

The long-lived worker held pre-#736 code in-memory for 14 hours after the fix shipped. New accessions hit the legacy CIK-prefix fallback in \`fetch_filing_index\` and 404'd against the agent's archive directory. **Operator action: restart \`app.jobs\` so post-#736 routing is in-memory.**

## Defense-in-depth (this PR)

- **\`KNOWN_FILING_AGENT_CIKS\` block-list** in \`sec_edgar.py\` — EdgarOnline, GlobeNewswire, Donnelley etc. Codified in version control so adding a new agent is auditable.
- **\`fetch_filing_index\` legacy fallback rejects agent prefixes** with an operator-facing WARNING that names the stale-process failure mode and remediation. Saves SEC rate budget (no guaranteed-404 round-trips).
- **Behaviour unchanged** for non-agent prefixes (self-filers go through legacy as before) and when caller passes \`issuer_cik\` (production happy path unaffected).

## Diagnostic + remediation

- **\`scripts/audit_agent_cik_contamination.py\`** runs the original #752 SQL audit. Exits 0 clean / 1 contaminated, emits CSV on hit. Suitable for boot-time / scheduled invocation so a future regression that leaks agent CIKs into the table fails fast.
- **\`tests/test_agent_cik_defense.py\`** pins both contracts: block-list rejects without HTTP, audit splits primary vs. secondary, set-membership locked.

## Out of scope (deferred)

- \`upsert_cik_mapping\` proactive reject — master-index column-1 CIK path already validated as not contaminating.
- Boot-time audit hook in \`app/main.py\` lifespan — re-add when CI gains a production-DB smoke step.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pyright\` — clean
- [x] 15 tests pass — \`test_agent_cik_defense.py\` (7 new) + \`test_sec_provider_filing_index.py\` (8 existing, no regression)
- [ ] Operator: restart \`app.jobs\` worker (NOT in PR scope)

## Related

- Followup to #736 / PR #745 / PR #748 — URL-routing code is correct; this PR adds belt-and-suspenders for the stale-process case.
- #195 broad filing-ingest tech-debt umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)