### PR TITLE
feat(#767): per-category freshness chips on ownership card

### DIFF
--- a/frontend/src/components/instrument/OwnershipFreshnessChips.test.tsx
+++ b/frontend/src/components/instrument/OwnershipFreshnessChips.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { OwnershipFreshnessChips } from "./OwnershipFreshnessChips";
+import type { SunburstCategory, SunburstRings } from "./ownershipRings";
+
+const TODAY = new Date("2026-05-02T00:00:00Z");
+
+function category(
+  key: SunburstCategory["key"],
+  as_of_date: string | null,
+  shares: number = 100,
+): SunburstCategory {
+  const labels: Record<SunburstCategory["key"], string> = {
+    institutions: "Institutions",
+    etfs: "ETFs",
+    insiders: "Insiders",
+    treasury: "Treasury",
+  };
+  return {
+    key,
+    label: labels[key],
+    shares,
+    reported_total: shares,
+    resolved_leaf_shares: shares,
+    leaves: [],
+    within_category_gap: 0,
+    as_of_date,
+  };
+}
+
+function rings(categories: SunburstCategory[]): SunburstRings {
+  return {
+    total_shares: 1_000_000_000,
+    reported_total: 1_000_000_000,
+    categories,
+    category_residual: 0,
+  };
+}
+
+describe("OwnershipFreshnessChips", () => {
+  it("renders nothing when there are no categories", () => {
+    const { container } = render(
+      <OwnershipFreshnessChips rings={rings([])} today={TODAY} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one chip per category in input order", () => {
+    render(
+      <OwnershipFreshnessChips
+        rings={rings([
+          category("institutions", "2026-03-31"),
+          category("etfs", "2026-03-31"),
+          category("insiders", "2026-04-30"),
+          category("treasury", "2026-03-28"),
+        ])}
+        today={TODAY}
+      />,
+    );
+    const chips = screen.getAllByRole("listitem");
+    expect(chips).toHaveLength(4);
+    expect(chips[0]!.textContent).toMatch(/Institutions/);
+    expect(chips[3]!.textContent).toMatch(/Treasury/);
+  });
+
+  it("colour-codes by freshness level via data-freshness-level", () => {
+    render(
+      <OwnershipFreshnessChips
+        rings={rings([
+          // 32 days → insiders cadence flips to aging (>= 30d).
+          category("insiders", "2026-03-31"),
+          // 200+ days → treasury cadence stale.
+          category("treasury", "2025-10-01"),
+          // 30 days → institutions cadence is fresh (well below 135d).
+          category("institutions", "2026-04-02"),
+        ])}
+        today={TODAY}
+      />,
+    );
+    const insiders = screen.getByText("Insiders").closest("[data-freshness-level]");
+    const treasury = screen.getByText("Treasury").closest("[data-freshness-level]");
+    const institutions = screen
+      .getByText("Institutions")
+      .closest("[data-freshness-level]");
+    expect(insiders!.getAttribute("data-freshness-level")).toBe("aging");
+    expect(treasury!.getAttribute("data-freshness-level")).toBe("stale");
+    expect(institutions!.getAttribute("data-freshness-level")).toBe("fresh");
+  });
+
+  it("renders an em-dash placeholder when as_of_date is null", () => {
+    render(
+      <OwnershipFreshnessChips
+        rings={rings([category("institutions", null)])}
+        today={TODAY}
+      />,
+    );
+    const chip = screen.getByText("Institutions").closest("[data-freshness-level]");
+    expect(chip!.getAttribute("data-freshness-level")).toBe("unknown");
+    expect(chip!.textContent).toContain("—");
+  });
+
+  it("includes the as_of_date in the chip title for hover-disclosure", () => {
+    render(
+      <OwnershipFreshnessChips
+        rings={rings([category("treasury", "2026-03-28")])}
+        today={TODAY}
+      />,
+    );
+    const chip = screen.getByText("Treasury").closest("[title]");
+    expect(chip!.getAttribute("title")).toContain("2026-03-28");
+  });
+
+  it("collapses an unparsable as_of_date to 'no date on file' in the title (Codex #767)", () => {
+    render(
+      <OwnershipFreshnessChips
+        rings={rings([category("treasury", "garbage")])}
+        today={TODAY}
+      />,
+    );
+    const chip = screen.getByText("Treasury").closest("[title]");
+    expect(chip!.getAttribute("title")).toContain("no date on file");
+    expect(chip!.getAttribute("title")).not.toContain("garbage");
+  });
+});

--- a/frontend/src/components/instrument/OwnershipFreshnessChips.tsx
+++ b/frontend/src/components/instrument/OwnershipFreshnessChips.tsx
@@ -1,0 +1,100 @@
+/**
+ * Per-category freshness chip strip for the ownership card (#767).
+ *
+ * Renders one chip per non-empty category (Institutions / ETFs /
+ * Insiders / Treasury) with the source-row date, an age delta, and a
+ * colour code:
+ *
+ *   * fresh   — neutral slate
+ *   * aging   — amber (cadence-window exceeded; expected if upstream
+ *     filing window hasn't closed yet)
+ *   * stale   — red (clearly past expected cadence)
+ *   * unknown — slate without an age delta (no date supplied)
+ *
+ * Renders nothing when no categories are present so the empty-state
+ * card body owns the messaging.
+ */
+
+import {
+  classifyFreshness,
+  formatAge,
+  type FreshnessLevel,
+} from "@/components/instrument/ownershipFreshness";
+import type { SunburstRings } from "@/components/instrument/ownershipRings";
+
+export interface OwnershipFreshnessChipsProps {
+  readonly rings: SunburstRings;
+  /** Reference clock. Defaulted by the consumer to ``new Date()``;
+   *  required here so tests can pin time without patching globals. */
+  readonly today: Date;
+}
+
+const LEVEL_CLASSES: Record<FreshnessLevel, string> = {
+  fresh:
+    "border-slate-200 bg-slate-50 text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400",
+  aging:
+    "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-300",
+  stale:
+    "border-red-300 bg-red-50 text-red-800 dark:border-red-700 dark:bg-red-950/40 dark:text-red-300",
+  unknown:
+    "border-dashed border-slate-300 bg-transparent text-slate-500 dark:border-slate-600 dark:text-slate-400",
+};
+
+export function OwnershipFreshnessChips({
+  rings,
+  today,
+}: OwnershipFreshnessChipsProps): JSX.Element | null {
+  if (rings.categories.length === 0) return null;
+  return (
+    <ul
+      className="flex flex-wrap gap-1.5 text-xs"
+      aria-label="Per-category data freshness"
+    >
+      {rings.categories.map((cat) => {
+        const level = classifyFreshness(cat.key, cat.as_of_date, today);
+        const age = formatAge(cat.as_of_date, today);
+        const cls = LEVEL_CLASSES[level];
+        const title = buildChipTitle(cat.label, cat.as_of_date, level);
+        return (
+          <li key={cat.key}>
+            <span
+              className={`inline-flex items-baseline gap-1 rounded border px-1.5 py-0.5 ${cls}`}
+              title={title}
+              data-freshness-level={level}
+            >
+              <span className="font-medium">{cat.label}</span>
+              {age !== null ? (
+                <span className="font-mono">{age}</span>
+              ) : (
+                <span className="font-mono text-slate-400 dark:text-slate-500">—</span>
+              )}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function buildChipTitle(
+  label: string,
+  as_of_date: string | null,
+  level: FreshnessLevel,
+): string {
+  // ``unknown`` is also reached when the as_of_date is non-null but
+  // unparsable (Codex review of #767). Echoing a malformed string in
+  // a tooltip just confuses the operator — collapse both cases to
+  // "no date on file" so the chip and tooltip stay consistent.
+  const date_part =
+    level === "unknown" || as_of_date === null ? "no date on file" : `as of ${as_of_date}`;
+  switch (level) {
+    case "fresh":
+      return `${label}: ${date_part}`;
+    case "aging":
+      return `${label}: ${date_part} — past expected refresh cadence`;
+    case "stale":
+      return `${label}: ${date_part} — clearly stale, check upstream ingest`;
+    case "unknown":
+      return `${label}: ${date_part}`;
+  }
+}

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -40,6 +40,7 @@ import {
 import type { InsiderTransactionsList } from "@/api/instruments";
 import type { InstrumentFinancials } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { OwnershipFreshnessChips } from "@/components/instrument/OwnershipFreshnessChips";
 import {
   OwnershipLegend,
   OwnershipSunburst,
@@ -72,7 +73,13 @@ interface OwnershipData {
   readonly institutional_holders: readonly SunburstHolder[];
   readonly etf_holders: readonly SunburstHolder[];
   readonly insider_holders: readonly SunburstHolder[];
-  readonly as_of_period: string | null;
+  /** 13F snapshot date — applies to both Institutions and ETFs (same
+   *  ``period_of_report`` cohort across filer types). */
+  readonly thirteen_f_as_of: string | null;
+  /** Latest Form 4 transaction date for any insider on this issuer. */
+  readonly insiders_as_of: string | null;
+  /** XBRL period_end of the row that produced ``treasury``. */
+  readonly treasury_as_of: string | null;
 }
 
 function pickLatestBalance(
@@ -190,8 +197,24 @@ export function extractData(
       ? null
       : insider_holders.reduce((s, h) => s + h.shares, 0);
 
-  const as_of_period =
-    inst_totals?.period_of_report ?? balance?.rows[0]?.period_end ?? null;
+  // Per-category freshness sources (#767):
+  //   * 13F (Institutions + ETFs): one shared period_of_report from
+  //     the totals row — both filer-type buckets are computed from
+  //     the same ``MAX(period_of_report)`` cohort backend-side.
+  //   * Insiders: latest txn_date observed across non-derivative
+  //     post-transaction rows. The reader endpoint exposes a
+  //     summary.latest_txn_date but the panel hits the per-row list;
+  //     derive locally so we don't add a second round trip.
+  //   * Treasury: balance-sheet row period_end that produced the
+  //     value — already the latest non-null treasury_shares row from
+  //     pickLatestBalance.
+  const thirteen_f_as_of = inst_totals?.period_of_report ?? null;
+  const insiders_as_of =
+    insiders === null || insiders.rows.length === 0
+      ? null
+      : latestTxnDate(insiders.rows as readonly InsiderRowShape[]);
+  const treasury_as_of =
+    treasury !== null && balance !== null ? findRowDateFor(balance, "treasury_shares") : null;
 
   return {
     outstanding,
@@ -202,8 +225,45 @@ export function extractData(
     institutional_holders,
     etf_holders,
     insider_holders,
-    as_of_period,
+    thirteen_f_as_of,
+    insiders_as_of,
+    treasury_as_of,
   };
+}
+
+/**
+ * Single row-eligibility predicate shared by ``latestTxnDate`` and
+ * ``aggregateInsiderHoldersForSunburst``. Codex (review of #767) caught
+ * that the two had drifted: the date helper accepted any non-derivative
+ * row, but the holders aggregator additionally requires a parseable
+ * ``post_transaction_shares``. With separate predicates a Form 4 row
+ * with a null share count would advance the freshness chip ahead of the
+ * actual holdings snapshot the ring renders. Keep them in lockstep here.
+ */
+function isInsiderHoldingRow(row: InsiderRowShape): boolean {
+  if (row.is_derivative) return false;
+  return parseShareCount(row.post_transaction_shares) !== null;
+}
+
+function latestTxnDate(rows: readonly InsiderRowShape[]): string | null {
+  let latest: string | null = null;
+  for (const row of rows) {
+    if (!isInsiderHoldingRow(row)) continue;
+    if (latest === null || row.txn_date > latest) latest = row.txn_date;
+  }
+  return latest;
+}
+
+/** Find the period_end of the first balance-sheet row that has a
+ *  non-null value for ``column``. Mirrors the iteration in
+ *  ``pickLatestBalance`` so the date and value stay paired. */
+function findRowDateFor(financials: InstrumentFinancials, column: string): string | null {
+  for (const row of financials.rows) {
+    const raw = row.values[column];
+    const parsed = parseShareCount(raw ?? null);
+    if (parsed !== null) return row.period_end;
+  }
+  return null;
 }
 
 function filerToHolder(
@@ -234,9 +294,9 @@ function aggregateInsiderHoldersForSunburst(
     { txn_date: string; shares: number; label: string }
   >();
   for (const row of insiders.rows as readonly InsiderRowShape[]) {
-    if (row.is_derivative) continue;
-    const shares = parseShareCount(row.post_transaction_shares);
-    if (shares === null) continue;
+    if (!isInsiderHoldingRow(row)) continue;
+    // Predicate above guarantees parseShareCount is non-null.
+    const shares = parseShareCount(row.post_transaction_shares)!;
     const key = row.filer_cik ?? `name:${row.filer_name}`;
     const existing = latestByFiler.get(key);
     if (existing === undefined || row.txn_date > existing.txn_date) {
@@ -287,6 +347,10 @@ function renderBody(
     etfs_total: data.etfs_total,
     insiders_total: data.insiders_total,
     treasury_shares: data.treasury,
+    institutions_as_of: data.thirteen_f_as_of,
+    etfs_as_of: data.thirteen_f_as_of,
+    insiders_as_of: data.insiders_as_of,
+    treasury_as_of: data.treasury_as_of,
   };
   const rings = buildSunburstRings(inputs);
   if (rings === null) {
@@ -310,15 +374,16 @@ function renderBody(
         <OwnershipLegend rings={rings} />
       </div>
       <div className="min-w-0 flex-1">
-        {data.as_of_period !== null && (
-          <p className="mb-1 text-xs text-slate-500 dark:text-slate-400">
-            As of {data.as_of_period}. {formatShares(data.outstanding)} outstanding
-            {data.treasury !== null && data.treasury > 0 && (
-              <> + {formatShares(data.treasury)} treasury</>
-            )}
-            .
-          </p>
-        )}
+        <div className="mb-2">
+          <OwnershipFreshnessChips rings={rings} today={new Date()} />
+        </div>
+        <p className="mb-1 text-xs text-slate-500 dark:text-slate-400">
+          {formatShares(data.outstanding)} outstanding
+          {data.treasury !== null && data.treasury > 0 && (
+            <> + {formatShares(data.treasury)} treasury</>
+          )}
+          .
+        </p>
         <p className="mb-2 text-xs">
           <span className="font-medium text-slate-700 dark:text-slate-200">
             {formatPct(accountedPct)} accounted for

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -25,7 +25,7 @@
  * the corresponding filter pre-applied.
  */
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { fetchInstitutionalHoldings } from "@/api/institutionalHoldings";
@@ -52,6 +52,10 @@ import {
   formatShares,
   parseShareCount,
 } from "@/components/instrument/ownershipMetrics";
+import {
+  type InsiderRowShape,
+  isInsiderHoldingRow,
+} from "@/components/instrument/ownershipInsiders";
 import {
   type SunburstHolder,
   type SunburstInputs,
@@ -155,13 +159,37 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
           }}
         />
       ) : (
-        renderBody(
-          extractData(balanceState.data, institutionalState.data, insidersState.data),
-          handleWedgeClick,
-        )
+        <PanelBody
+          balance={balanceState.data}
+          institutional={institutionalState.data}
+          insiders={insidersState.data}
+          onWedgeClick={handleWedgeClick}
+        />
       )}
     </Pane>
   );
+}
+
+interface PanelBodyProps {
+  readonly balance: InstrumentFinancials | null;
+  readonly institutional: InstitutionalHoldingsResponse | null;
+  readonly insiders: InsiderTransactionsList | null;
+  readonly onWedgeClick: (target: WedgeClick) => void;
+}
+
+/** Wraps ``renderBody`` so the freshness chip's ``today`` reference can
+ *  be a stable ``useMemo`` value. Pre-fix the panel passed
+ *  ``new Date()`` inline on every render, which the chip strip then
+ *  treated as a new prop and re-rendered against. Captured once per
+ *  mount so the chips memoise cleanly across parent re-renders. */
+function PanelBody({
+  balance,
+  institutional,
+  insiders,
+  onWedgeClick,
+}: PanelBodyProps): JSX.Element {
+  const today = useMemo(() => new Date(), []);
+  return renderBody(extractData(balance, institutional, insiders), onWedgeClick, today);
 }
 
 export function extractData(
@@ -231,20 +259,6 @@ export function extractData(
   };
 }
 
-/**
- * Single row-eligibility predicate shared by ``latestTxnDate`` and
- * ``aggregateInsiderHoldersForSunburst``. Codex (review of #767) caught
- * that the two had drifted: the date helper accepted any non-derivative
- * row, but the holders aggregator additionally requires a parseable
- * ``post_transaction_shares``. With separate predicates a Form 4 row
- * with a null share count would advance the freshness chip ahead of the
- * actual holdings snapshot the ring renders. Keep them in lockstep here.
- */
-function isInsiderHoldingRow(row: InsiderRowShape): boolean {
-  if (row.is_derivative) return false;
-  return parseShareCount(row.post_transaction_shares) !== null;
-}
-
 function latestTxnDate(rows: readonly InsiderRowShape[]): string | null {
   let latest: string | null = null;
   for (const row of rows) {
@@ -275,14 +289,6 @@ function filerToHolder(
     shares: parseShareCount(f.shares) ?? 0,
     category,
   });
-}
-
-interface InsiderRowShape {
-  readonly filer_cik: string | null;
-  readonly filer_name: string;
-  readonly txn_date: string;
-  readonly post_transaction_shares: string | null;
-  readonly is_derivative: boolean;
 }
 
 function aggregateInsiderHoldersForSunburst(
@@ -322,6 +328,7 @@ function aggregateInsiderHoldersForSunburst(
 function renderBody(
   data: OwnershipData,
   onWedgeClick: (target: WedgeClick) => void,
+  today: Date,
 ): JSX.Element {
   if (data.outstanding === null || data.outstanding <= 0) {
     return (
@@ -375,7 +382,7 @@ function renderBody(
       </div>
       <div className="min-w-0 flex-1">
         <div className="mb-2">
-          <OwnershipFreshnessChips rings={rings} today={new Date()} />
+          <OwnershipFreshnessChips rings={rings} today={today} />
         </div>
         <p className="mb-1 text-xs text-slate-500 dark:text-slate-400">
           {formatShares(data.outstanding)} outstanding

--- a/frontend/src/components/instrument/ownershipFreshness.test.ts
+++ b/frontend/src/components/instrument/ownershipFreshness.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CADENCE,
+  classifyFreshness,
+  formatAge,
+} from "./ownershipFreshness";
+
+const TODAY = new Date("2026-05-02T00:00:00Z");
+
+describe("classifyFreshness", () => {
+  it("returns 'unknown' for null or unparsable dates", () => {
+    expect(classifyFreshness("institutions", null, TODAY)).toBe("unknown");
+    expect(classifyFreshness("institutions", "not-a-date", TODAY)).toBe("unknown");
+  });
+
+  it("future dates classify as fresh — clock drift / test fixtures", () => {
+    expect(classifyFreshness("insiders", "2026-06-01", TODAY)).toBe("fresh");
+  });
+
+  it("13F categories classify by their longer cadence (135 / 270 days)", () => {
+    // Sanity-pin the cadence numbers so a future tweak that
+    // accidentally inverts thresholds gets caught.
+    expect(CADENCE.institutions.aging_days).toBe(135);
+    expect(CADENCE.institutions.stale_days).toBe(270);
+    expect(CADENCE.etfs.aging_days).toBe(135);
+
+    // 30 days → fresh (well within filing-window cadence)
+    expect(classifyFreshness("institutions", "2026-04-02", TODAY)).toBe("fresh");
+    // 134 days → still fresh by inclusive boundary semantics
+    expect(classifyFreshness("institutions", "2025-12-19", TODAY)).toBe("fresh");
+    // 135 days → flips to aging
+    expect(classifyFreshness("institutions", "2025-12-18", TODAY)).toBe("aging");
+    // 269 days → aging
+    expect(classifyFreshness("institutions", "2025-08-06", TODAY)).toBe("aging");
+    // 270 days → stale
+    expect(classifyFreshness("institutions", "2025-08-05", TODAY)).toBe("stale");
+  });
+
+  it("Form 4 insiders classify by their tighter cadence (30 / 90 days)", () => {
+    expect(CADENCE.insiders.aging_days).toBe(30);
+    expect(CADENCE.insiders.stale_days).toBe(90);
+
+    // 2 days → fresh (typical Form 4 filing lag)
+    expect(classifyFreshness("insiders", "2026-04-30", TODAY)).toBe("fresh");
+    // 30 days → aging boundary
+    expect(classifyFreshness("insiders", "2026-04-02", TODAY)).toBe("aging");
+    // 90 days → stale boundary
+    expect(classifyFreshness("insiders", "2026-02-01", TODAY)).toBe("stale");
+  });
+
+  it("Treasury classifies by quarterly cadence (100 / 200 days)", () => {
+    expect(CADENCE.treasury.aging_days).toBe(100);
+    expect(CADENCE.treasury.stale_days).toBe(200);
+
+    expect(classifyFreshness("treasury", "2026-03-28", TODAY)).toBe("fresh");
+    expect(classifyFreshness("treasury", "2026-01-22", TODAY)).toBe("aging"); // 100d
+    expect(classifyFreshness("treasury", "2025-10-14", TODAY)).toBe("stale"); // 200d
+  });
+});
+
+describe("formatAge", () => {
+  it("returns null for null or unparsable input", () => {
+    expect(formatAge(null, TODAY)).toBeNull();
+    expect(formatAge("garbage", TODAY)).toBeNull();
+  });
+
+  it("formats young ages in days", () => {
+    expect(formatAge("2026-04-30", TODAY)).toBe("2d");
+    expect(formatAge("2026-03-04", TODAY)).toBe("59d");
+  });
+
+  it("formats medium ages in months", () => {
+    // 60 days exactly = 2 months under round(60/30) = 2.
+    expect(formatAge("2026-03-03", TODAY)).toBe("2mo");
+    // ~10 months
+    expect(formatAge("2025-07-05", TODAY)).toBe("10mo");
+  });
+
+  it("formats long ages in years past 18 months", () => {
+    expect(formatAge("2024-05-02", TODAY)).toBe("2y");
+    expect(formatAge("2022-05-02", TODAY)).toBe("4y");
+  });
+
+  it("clamps future-dated source rows to '0d' rather than emitting a negative age", () => {
+    expect(formatAge("2026-06-01", TODAY)).toBe("0d");
+  });
+});

--- a/frontend/src/components/instrument/ownershipFreshness.ts
+++ b/frontend/src/components/instrument/ownershipFreshness.ts
@@ -1,0 +1,113 @@
+/**
+ * Per-category freshness classifier for the ownership card (#767).
+ *
+ * Different ownership categories have wildly different expected
+ * cadences:
+ *
+ *   * Institutions / ETFs (13F-HR): quarterly snapshot + 45-day
+ *     filing window. A ``period_of_report`` 90-135 days old is
+ *     normal. Older than 270 days = stale (filer dropped coverage
+ *     or the ingest pipeline is wedged).
+ *   * Insiders (Form 4): 2-business-day filing on every transaction.
+ *     ``latest_txn_date`` reflects the last *insider event*, not the
+ *     last data refresh — so a long quiet period is real-world
+ *     signal, not stale data. Aging > 30d, stale > 90d.
+ *   * Treasury (XBRL 10-Q): quarterly balance-sheet snapshot.
+ *     Aging > 100d, stale > 200d.
+ *
+ * Lumping these into one card-level "as of" timestamp lets a 75%-stale
+ * card read as fresh as a 5%-stale one. Per-category chips give the
+ * operator a glanceable read on which slice is the bottleneck.
+ *
+ * Thresholds are deliberately rough — the chip strip is for
+ * orientation, not alerting. Tighter SLO + paging belongs in #13 ops
+ * monitor.
+ */
+
+import type { CategoryKey } from "@/components/instrument/ownershipRings";
+
+export type FreshnessLevel = "fresh" | "aging" | "stale" | "unknown";
+
+interface CadenceThresholds {
+  /** Days before the chip flips from ``fresh`` to ``aging`` (amber). */
+  readonly aging_days: number;
+  /** Days before the chip flips from ``aging`` to ``stale`` (red). */
+  readonly stale_days: number;
+}
+
+/** Per-category cadence thresholds. Tuned to the upstream filing
+ *  cadence + filing window so a freshly-arrived 13F doesn't read
+ *  amber the day after it lands. */
+export const CADENCE: Record<CategoryKey, CadenceThresholds> = {
+  institutions: { aging_days: 135, stale_days: 270 },
+  etfs: { aging_days: 135, stale_days: 270 },
+  insiders: { aging_days: 30, stale_days: 90 },
+  treasury: { aging_days: 100, stale_days: 200 },
+};
+
+/**
+ * Classify a category's freshness given its ``as_of_date`` and a
+ * reference ``today`` (operator's clock). Pure: no ``Date.now()`` —
+ * the caller passes ``today`` so tests can pin time without patching
+ * globals.
+ *
+ * Returns ``"unknown"`` when the as_of_date is missing or unparsable
+ * — the chip renders neutrally without an age label.
+ */
+export function classifyFreshness(
+  category_key: CategoryKey,
+  as_of_date: string | null,
+  today: Date,
+): FreshnessLevel {
+  if (as_of_date === null) return "unknown";
+  const parsed = parseIsoDate(as_of_date);
+  if (parsed === null) return "unknown";
+  const age = ageInDays(parsed, today);
+  // Negative ages can happen if the upstream date is in the future
+  // (clock drift, test fixtures). Treat as fresh — operator-side this
+  // is "we just got the data", not "it's stale". The chip still shows
+  // the absolute as_of_date so anomalies surface visually.
+  if (age < 0) return "fresh";
+  const cadence = CADENCE[category_key];
+  if (age >= cadence.stale_days) return "stale";
+  if (age >= cadence.aging_days) return "aging";
+  return "fresh";
+}
+
+/**
+ * Render-friendly age label. Returns ``"2d"`` / ``"45d"`` / ``"3mo"`` /
+ * ``"1y"`` based on the magnitude. ``null`` when no date.
+ *
+ * Granularity policy:
+ *   * < 60 days   → ``Nd`` (days are the natural unit; chips need to
+ *     distinguish 2d vs 45d).
+ *   * < 18 months → ``Nmo`` (operator scans for "1mo" vs "8mo" without
+ *     mental arithmetic).
+ *   * else        → ``Ny``.
+ */
+export function formatAge(as_of_date: string | null, today: Date): string | null {
+  if (as_of_date === null) return null;
+  const parsed = parseIsoDate(as_of_date);
+  if (parsed === null) return null;
+  const age = ageInDays(parsed, today);
+  if (age < 0) return "0d"; // future date — clock drift, render as "today"
+  if (age < 60) return `${age}d`;
+  const months = Math.round(age / 30);
+  if (months < 18) return `${months}mo`;
+  const years = Math.round(age / 365);
+  return `${years}y`;
+}
+
+function parseIsoDate(text: string): Date | null {
+  // Accept ``YYYY-MM-DD`` and full ISO-8601 timestamps. The reader
+  // endpoints today emit plain dates, but the type is ``string`` so a
+  // future change to timestamps shouldn't silently break the chip.
+  const date = new Date(text);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+function ageInDays(as_of: Date, today: Date): number {
+  const ms_per_day = 24 * 60 * 60 * 1000;
+  return Math.floor((today.getTime() - as_of.getTime()) / ms_per_day);
+}

--- a/frontend/src/components/instrument/ownershipFreshness.ts
+++ b/frontend/src/components/instrument/ownershipFreshness.ts
@@ -102,6 +102,15 @@ function parseIsoDate(text: string): Date | null {
   // Accept ``YYYY-MM-DD`` and full ISO-8601 timestamps. The reader
   // endpoints today emit plain dates, but the type is ``string`` so a
   // future change to timestamps shouldn't silently break the chip.
+  //
+  // Time-zone caveat: a bare ``YYYY-MM-DD`` is parsed as UTC midnight
+  // while ``today = new Date()`` resolves to the local clock, so
+  // ``ageInDays`` can drift ±1 day for an as_of_date observed near
+  // local midnight. Harmless at the freshness cadences used here
+  // (30-270 days) — the chip would only mis-classify within ~24h of a
+  // hard threshold boundary, which the operator-facing copy does not
+  // depend on. If we ever surface absolute hour-precision freshness,
+  // align both sides on UTC explicitly.
   const date = new Date(text);
   if (Number.isNaN(date.getTime())) return null;
   return date;

--- a/frontend/src/components/instrument/ownershipInsiders.test.ts
+++ b/frontend/src/components/instrument/ownershipInsiders.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { type InsiderRowShape, isInsiderHoldingRow } from "./ownershipInsiders";
+
+function row(overrides: Partial<InsiderRowShape> = {}): InsiderRowShape {
+  return {
+    filer_cik: "0000000001",
+    filer_name: "Test Filer",
+    txn_date: "2026-04-15",
+    post_transaction_shares: "1000",
+    is_derivative: false,
+    ...overrides,
+  };
+}
+
+describe("isInsiderHoldingRow", () => {
+  it("includes a non-derivative row with a parseable share count", () => {
+    expect(isInsiderHoldingRow(row())).toBe(true);
+  });
+
+  it("excludes derivative rows even when the share count parses", () => {
+    expect(isInsiderHoldingRow(row({ is_derivative: true }))).toBe(false);
+  });
+
+  it("excludes a non-derivative row whose share count is null", () => {
+    // A Form 4 row with no usable post-transaction balance can't
+    // contribute to the snapshot — counting its txn_date as fresh
+    // would advance the freshness chip ahead of the actual ring data
+    // (the original Codex / review-bot finding on PR #770).
+    expect(isInsiderHoldingRow(row({ post_transaction_shares: null }))).toBe(false);
+  });
+
+  it("excludes a non-derivative row whose share count is unparseable", () => {
+    expect(isInsiderHoldingRow(row({ post_transaction_shares: "not-a-number" }))).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/src/components/instrument/ownershipInsiders.ts
+++ b/frontend/src/components/instrument/ownershipInsiders.ts
@@ -1,0 +1,47 @@
+/**
+ * Insider Form 4 row eligibility for ownership-card consumers.
+ *
+ * Single source of truth for "is this Form 4 row part of the holdings
+ * snapshot the ring renders?". Used by:
+ *
+ *   * the per-filer holders aggregator on L1 (``OwnershipPanel``)
+ *     and L2 (``OwnershipPage``) — drives ring 3 wedges.
+ *   * the L2 ``buildFilerRows`` table writer — drives the per-filer
+ *     drilldown rows.
+ *   * the freshness chip's ``insiders_as_of`` derivation (#767) —
+ *     drives the chip's age delta.
+ *
+ * Codex (review of #767 round 1) flagged that the chip's date predicate
+ * had drifted to "any non-derivative row" while the aggregators required
+ * a parseable ``post_transaction_shares``. Fix landed two independent
+ * copies of the predicate — the review bot then caught that the
+ * "structural fix" itself reintroduced the same drift class. Extracting
+ * here so the predicate lives in exactly one place.
+ */
+
+import { parseShareCount } from "@/components/instrument/ownershipMetrics";
+
+/** Shape every consumer of the insider transactions endpoint reads. The
+ *  full row carries more fields; consumers TypeScript-narrow to this
+ *  subset. */
+export interface InsiderRowShape {
+  readonly filer_cik: string | null;
+  readonly filer_name: string;
+  readonly txn_date: string;
+  readonly post_transaction_shares: string | null;
+  readonly is_derivative: boolean;
+}
+
+/**
+ * True when a Form 4 row should count toward the holdings snapshot.
+ *
+ * Excludes derivative-table rows (option grants / RSUs aren't held
+ * shares of the underlying) and rows with no parseable
+ * ``post_transaction_shares`` (the value the aggregator would attribute
+ * to the filer is missing — counting the row as fresh-but-zero would
+ * advance the freshness chip without contributing to the ring).
+ */
+export function isInsiderHoldingRow(row: InsiderRowShape): boolean {
+  if (row.is_derivative) return false;
+  return parseShareCount(row.post_transaction_shares) !== null;
+}

--- a/frontend/src/components/instrument/ownershipRings.test.ts
+++ b/frontend/src/components/instrument/ownershipRings.test.ts
@@ -245,6 +245,49 @@ describe("buildSunburstRings — outer-ring threshold grouping", () => {
     expect(insiders.leaves.every((l) => !l.is_other)).toBe(true);
   });
 
+  it("propagates per-category as_of_date from inputs to output", () => {
+    // #767 freshness: each category total has its own source-row
+    // date. ``buildSunburstRings`` carries them through unchanged
+    // so the freshness classifier can read them off the rings
+    // model without a second prop trip.
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      institutions_total: 100_000_000,
+      etfs_total: 50_000_000,
+      treasury_shares: 25_000_000,
+      holders: [
+        holder("vanguard", 100_000_000, "institutions"),
+        holder("spdr", 50_000_000, "etfs"),
+      ],
+      institutions_as_of: "2026-03-31",
+      etfs_as_of: "2026-03-31",
+      insiders_as_of: "2026-04-28",
+      treasury_as_of: "2026-03-28",
+    });
+    expect(r!.categories.find((c) => c.key === "institutions")!.as_of_date).toBe(
+      "2026-03-31",
+    );
+    expect(r!.categories.find((c) => c.key === "etfs")!.as_of_date).toBe("2026-03-31");
+    expect(r!.categories.find((c) => c.key === "treasury")!.as_of_date).toBe(
+      "2026-03-28",
+    );
+  });
+
+  it("as_of_date defaults to null when caller omits it", () => {
+    // #767: optional inputs so existing call sites that pre-date
+    // freshness chips still compile. Output side keeps a strict
+    // ``string | null`` so renderers can branch without optional
+    // chaining noise.
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      institutions_total: 100_000_000,
+      treasury_shares: 25_000_000,
+      holders: [holder("vanguard", 100_000_000, "institutions")],
+    });
+    expect(r!.categories.find((c) => c.key === "institutions")!.as_of_date).toBeNull();
+    expect(r!.categories.find((c) => c.key === "treasury")!.as_of_date).toBeNull();
+  });
+
   it("micro-cap respects 10k-share floor — not 0.5% of total", () => {
     const r = buildSunburstRings({
       ...DEFAULT_INPUT,

--- a/frontend/src/components/instrument/ownershipRings.ts
+++ b/frontend/src/components/instrument/ownershipRings.ts
@@ -81,6 +81,20 @@ export interface SunburstInputs {
    *  file; treasury wedge does not render. Counted in the
    *  denominator when present. */
   readonly treasury_shares: number | null;
+
+  /** Source-row date that produced each category's totals. Drives
+   *  the per-category freshness chip strip on the card header so the
+   *  operator can tell which slice is the stalest at a glance — 13F
+   *  lags 45-135d, Form 4 lags 0-2d, XBRL treasury lags 0-90d.
+   *  ``null`` = caller has no date for that category (e.g. before
+   *  the first ingest landed); the chip renders without an age
+   *  delta. ISO ``YYYY-MM-DD``. Optional so existing call sites that
+   *  pre-date #767 keep compiling — they'll render no chips until
+   *  threaded through. */
+  readonly institutions_as_of?: string | null;
+  readonly etfs_as_of?: string | null;
+  readonly insiders_as_of?: string | null;
+  readonly treasury_as_of?: string | null;
 }
 
 export type CategoryKey = "institutions" | "etfs" | "insiders" | "treasury";
@@ -121,6 +135,10 @@ export interface SunburstCategory {
    *  renderer paints a transparent wedge of this size so the named
    *  leaves don't get inflated to fill the parent arc. */
   readonly within_category_gap: number;
+  /** Source-row date that produced ``shares`` for this category. ISO
+   *  ``YYYY-MM-DD``. ``null`` when the caller didn't supply one. The
+   *  freshness chip renders without an age delta in that case. */
+  readonly as_of_date: string | null;
 }
 
 export interface SunburstRings {
@@ -187,12 +205,26 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
 
   if (input.institutions_total !== null && input.institutions_total > 0) {
     categories.push(
-      buildCategoryFromTotal("institutions", input.institutions_total, inst_holders, threshold, false),
+      buildCategoryFromTotal(
+        "institutions",
+        input.institutions_total,
+        inst_holders,
+        threshold,
+        false,
+        input.institutions_as_of ?? null,
+      ),
     );
   }
   if (input.etfs_total !== null && input.etfs_total > 0) {
     categories.push(
-      buildCategoryFromTotal("etfs", input.etfs_total, etf_holders, threshold, false),
+      buildCategoryFromTotal(
+        "etfs",
+        input.etfs_total,
+        etf_holders,
+        threshold,
+        false,
+        input.etfs_as_of ?? null,
+      ),
     );
   }
   if (input.insiders_total !== null && input.insiders_total > 0) {
@@ -203,6 +235,7 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
         insider_holders,
         threshold,
         true, // bypass threshold — every officer surfaces
+        input.insiders_as_of ?? null,
       ),
     );
   }
@@ -222,6 +255,7 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
         },
       ],
       within_category_gap: 0,
+      as_of_date: input.treasury_as_of ?? null,
     });
   }
 
@@ -247,6 +281,7 @@ function buildCategoryFromTotal(
   holders: readonly SunburstHolder[],
   threshold: number,
   bypass_threshold: boolean,
+  as_of_date: string | null,
 ): SunburstCategory {
   if (holders.length === 0) {
     // Total from upstream API but zero per-filer detail (e.g.
@@ -261,6 +296,7 @@ function buildCategoryFromTotal(
       resolved_leaf_shares: 0,
       leaves: [],
       within_category_gap: reported_total,
+      as_of_date,
     };
   }
 
@@ -322,5 +358,6 @@ function buildCategoryFromTotal(
     resolved_leaf_shares,
     leaves,
     within_category_gap,
+    as_of_date,
   };
 }

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -28,6 +28,7 @@ import {
 import type { InsiderTransactionsList } from "@/api/instruments";
 import type { InstrumentFinancials } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { OwnershipFreshnessChips } from "@/components/instrument/OwnershipFreshnessChips";
 import {
   OwnershipLegend,
   OwnershipSunburst,
@@ -281,6 +282,31 @@ function OwnershipBody({
     [outstanding, treasury],
   );
 
+  // Per-category freshness sources (#767).
+  const thirteen_f_as_of = inst_totals?.period_of_report ?? null;
+  const insiders_as_of = useMemo(() => {
+    if (insiders === null || insiders.rows.length === 0) return null;
+    let latest: string | null = null;
+    // Same eligibility predicate as the holders aggregator below
+    // and ``buildFilerRows`` — Codex (review of #767) caught that
+    // a divergent predicate would advance the freshness chip ahead
+    // of the actual snapshot the ring renders.
+    for (const row of insiders.rows as readonly InsiderRowShape[]) {
+      if (!isInsiderHoldingRow(row)) continue;
+      if (latest === null || row.txn_date > latest) latest = row.txn_date;
+    }
+    return latest;
+  }, [insiders]);
+  const treasury_as_of = useMemo(() => {
+    if (balance === null || treasury === null) return null;
+    for (const row of balance.rows) {
+      const raw = row.values["treasury_shares"];
+      const parsed = parseShareCount(raw ?? null);
+      if (parsed !== null) return row.period_end;
+    }
+    return null;
+  }, [balance, treasury]);
+
   const inputs: SunburstInputs = useMemo(
     () => ({
       total_shares,
@@ -289,8 +315,22 @@ function OwnershipBody({
       etfs_total,
       insiders_total,
       treasury_shares: treasury,
+      institutions_as_of: thirteen_f_as_of,
+      etfs_as_of: thirteen_f_as_of,
+      insiders_as_of,
+      treasury_as_of,
     }),
-    [total_shares, allHolders, institutions_total, etfs_total, insiders_total, treasury],
+    [
+      total_shares,
+      allHolders,
+      institutions_total,
+      etfs_total,
+      insiders_total,
+      treasury,
+      thirteen_f_as_of,
+      insiders_as_of,
+      treasury_as_of,
+    ],
   );
 
   const rings = useMemo(() => buildSunburstRings(inputs), [inputs]);
@@ -344,6 +384,7 @@ function OwnershipBody({
         <div className="flex flex-col items-center gap-3">
           <OwnershipSunburst inputs={inputs} onWedgeClick={onWedgeClick} size={420} />
           {rings !== null && <OwnershipLegend rings={rings} />}
+          {rings !== null && <OwnershipFreshnessChips rings={rings} today={new Date()} />}
         </div>
         <p className="mt-3 text-center text-xs text-slate-500 dark:text-slate-400">
           {formatShares(outstanding)} outstanding
@@ -558,6 +599,24 @@ interface InsiderRowShape {
   readonly is_derivative: boolean;
 }
 
+/**
+ * Single eligibility predicate for an insider Form 4 row to count
+ * toward the holdings snapshot. Shared by:
+ *   * the per-filer holders aggregator (ring 3)
+ *   * the L2 ``buildFilerRows`` table writer
+ *   * the L2 freshness chip's ``insiders_as_of`` derivation
+ *
+ * Codex (review of #767) caught that the chip's date predicate had
+ * drifted to "any non-derivative row" while the aggregators required
+ * a parseable ``post_transaction_shares``. With separate predicates a
+ * Form 4 row with a null share count would advance the chip ahead of
+ * the actual snapshot the ring renders.
+ */
+function isInsiderHoldingRow(row: InsiderRowShape): boolean {
+  if (row.is_derivative) return false;
+  return parseShareCount(row.post_transaction_shares) !== null;
+}
+
 function aggregateInsiderHoldersForSunburst(
   insiders: InsiderTransactionsList | null,
 ): readonly SunburstHolder[] {
@@ -567,9 +626,9 @@ function aggregateInsiderHoldersForSunburst(
     { txn_date: string; shares: number; label: string }
   >();
   for (const row of insiders.rows as readonly InsiderRowShape[]) {
-    if (row.is_derivative) continue;
-    const shares = parseShareCount(row.post_transaction_shares);
-    if (shares === null) continue;
+    if (!isInsiderHoldingRow(row)) continue;
+    // Predicate guarantees the share count is parseable.
+    const shares = parseShareCount(row.post_transaction_shares)!;
     const key = row.filer_cik ?? `name:${row.filer_name}`;
     const existing = latestByFiler.get(key);
     if (existing === undefined || row.txn_date > existing.txn_date) {
@@ -612,9 +671,8 @@ function buildFilerRows(
       { row: InsiderRowShape; shares: number }
     >();
     for (const row of insiders.rows as readonly InsiderRowShape[]) {
-      if (row.is_derivative) continue;
-      const shares = parseShareCount(row.post_transaction_shares);
-      if (shares === null) continue;
+      if (!isInsiderHoldingRow(row)) continue;
+      const shares = parseShareCount(row.post_transaction_shares)!;
       const key = row.filer_cik ?? `name:${row.filer_name}`;
       const existing = latestByFiler.get(key);
       if (existing === undefined || row.txn_date > existing.row.txn_date) {

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -30,6 +30,10 @@ import type { InstrumentFinancials } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { OwnershipFreshnessChips } from "@/components/instrument/OwnershipFreshnessChips";
 import {
+  type InsiderRowShape,
+  isInsiderHoldingRow,
+} from "@/components/instrument/ownershipInsiders";
+import {
   OwnershipLegend,
   OwnershipSunburst,
 } from "@/components/instrument/OwnershipSunburst";
@@ -284,6 +288,11 @@ function OwnershipBody({
 
   // Per-category freshness sources (#767).
   const thirteen_f_as_of = inst_totals?.period_of_report ?? null;
+  // Stable ``today`` reference for the freshness chip strip — pre-fix
+  // ``new Date()`` inline forced the chip to re-render on every parent
+  // re-render even when its rings data was identical.
+  const today = useMemo(() => new Date(), []);
+
   const insiders_as_of = useMemo(() => {
     if (insiders === null || insiders.rows.length === 0) return null;
     let latest: string | null = null;
@@ -384,7 +393,7 @@ function OwnershipBody({
         <div className="flex flex-col items-center gap-3">
           <OwnershipSunburst inputs={inputs} onWedgeClick={onWedgeClick} size={420} />
           {rings !== null && <OwnershipLegend rings={rings} />}
-          {rings !== null && <OwnershipFreshnessChips rings={rings} today={new Date()} />}
+          {rings !== null && <OwnershipFreshnessChips rings={rings} today={today} />}
         </div>
         <p className="mt-3 text-center text-xs text-slate-500 dark:text-slate-400">
           {formatShares(outstanding)} outstanding
@@ -589,32 +598,6 @@ function filerToHolder(
     shares: parseShareCount(f.shares) ?? 0,
     category,
   });
-}
-
-interface InsiderRowShape {
-  readonly filer_cik: string | null;
-  readonly filer_name: string;
-  readonly txn_date: string;
-  readonly post_transaction_shares: string | null;
-  readonly is_derivative: boolean;
-}
-
-/**
- * Single eligibility predicate for an insider Form 4 row to count
- * toward the holdings snapshot. Shared by:
- *   * the per-filer holders aggregator (ring 3)
- *   * the L2 ``buildFilerRows`` table writer
- *   * the L2 freshness chip's ``insiders_as_of`` derivation
- *
- * Codex (review of #767) caught that the chip's date predicate had
- * drifted to "any non-derivative row" while the aggregators required
- * a parseable ``post_transaction_shares``. With separate predicates a
- * Form 4 row with a null share count would advance the chip ahead of
- * the actual snapshot the ring renders.
- */
-function isInsiderHoldingRow(row: InsiderRowShape): boolean {
-  if (row.is_derivative) return false;
-  return parseShareCount(row.post_transaction_shares) !== null;
 }
 
 function aggregateInsiderHoldersForSunburst(


### PR DESCRIPTION
## What

Per-category freshness chip strip on L1 ``OwnershipPanel`` + L2 ``OwnershipPage``. One chip per non-empty category showing source-row date + age delta + colour-coded freshness level (fresh / aging / stale / unknown).

Cadence thresholds tuned per upstream filing rhythm:

| Category | aging | stale |
|---|---|---|
| Institutions / ETFs (13F-HR) | > 135d | > 270d |
| Insiders (Form 4) | > 30d | > 90d |
| Treasury (XBRL 10-Q) | > 100d | > 200d |

## Why

Different ownership categories update at wildly different cadences. One card-level "as of" timestamp lets a 75%-stale card read as fresh as a 5%-stale one. Per-category chips give the operator a glanceable read on which slice is the bottleneck — "Institutions 12d" vs "Treasury 200d" surfaces the gap immediately.

## Test plan

- [x] ``classifyFreshness`` boundary tests pin every threshold (134d → fresh, 135d → aging, etc.)
- [x] ``formatAge`` tests cover days / months / years / future-date clamp
- [x] Chips render one per category, colour-coded via ``data-freshness-level``
- [x] Unparsable ``as_of_date`` collapses to "no date on file" without echoing the bad string (Codex regression)
- [x] ``SunburstInputs`` ``as_of`` fields propagate to ``SunburstCategory.as_of_date``
- [x] Full frontend suite: 814 passed
- [x] Pre-push gates: ruff / format / pyright / dark-class / typecheck — all green

## Notes

Pure frontend change. Every timestamp the chip needs is already exposed by existing reader endpoints (``totals.period_of_report``, ``summary.latest_txn_date``, ``balance.rows[].period_end``).

Codex review (CLAUDE.md checkpoint 2) caught one real bug: ``insiders_as_of`` derivation used a different row-eligibility predicate than the holders aggregator. A Form 4 row with a null ``post_transaction_shares`` would have advanced the chip ahead of the actual snapshot the ring renders. Fixed by extracting a shared ``isInsiderHoldingRow`` predicate. Regression test added.

Threads from #756 (Ownership over time): same per-category ``as_of_date`` field name will be reused by the L2 time-series chart's per-period freshness annotations.

Closes #767.