### PR TITLE
feat(#768): Form 3 parser + initial-holdings schema (PR 1/N)

### DIFF
--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -588,6 +588,301 @@ def _parse_one_transaction(
 
 
 # ---------------------------------------------------------------------
+# Form 3 parser (#768) — initial holdings snapshot
+# ---------------------------------------------------------------------
+#
+# Form 3 is filed once when an insider becomes subject to Section 16
+# reporting (officer / director / 10% holder appointment). It carries
+# the *snapshot* of their positions on that date — no transactions, no
+# acquired/disposed codes. Cumulative balance at any later point =
+# Form 3 baseline + signed sum of Form 4 deltas since.
+#
+# XML structure mirrors Form 4 but uses ``nonDerivativeHolding`` /
+# ``derivativeHolding`` (not ``...Transaction``) under
+# ``nonDerivativeTable`` / ``derivativeTable``. Each holding carries
+# ``postTransactionAmounts/sharesOwnedFollowingTransaction/value`` for
+# the share count (the only "transaction" semantics on a Form 3 are
+# the synthetic "you now hold this many shares as of periodOfReport").
+
+
+@dataclass(frozen=True)
+class ParsedHolding:
+    """One row from a Form 3 (non-derivative or derivative) holding
+    table. Mirrors :class:`ParsedTransaction` but drops the
+    transaction-state fields (``txn_code``, ``acquired_disposed_code``,
+    ``shares`` of the transaction itself) since a holding row records
+    the snapshot, not a delta.
+
+    Share-vs-value semantics: SEC ``postTransactionAmounts`` allows
+    *either* ``sharesOwnedFollowingTransaction`` *or*
+    ``valueOwnedFollowingTransaction`` (typically used for
+    fractional-undivided-interest securities). Both surface here so
+    the ingester / reader can pick the populated branch without a
+    silent drop. Same shape as ``ParsedTransaction`` for Form 4 (post-
+    migration 057): every structured field surfaced, no silent drops.
+    """
+
+    row_num: int
+    is_derivative: bool
+    # Filer linkage — same convention as Form 4 transactions: when the
+    # filing has multiple owners, attribute each row to the first
+    # listed owner (joint-filing convention).
+    filer_cik: str | None
+    security_title: str | None
+    shares: Decimal | None
+    value_owned: Decimal | None
+    direct_indirect: str | None
+    nature_of_ownership: str | None
+    # Derivative-only fields. ``None`` on non-derivative rows.
+    conversion_exercise_price: Decimal | None
+    exercise_date: date | None
+    expiration_date: date | None
+    underlying_security_title: str | None
+    underlying_shares: Decimal | None
+    # Value-branch alternative for derivative underlyings — parallels
+    # ParsedTransaction.underlying_value added in migration 057.
+    underlying_value: Decimal | None
+    # Pointers from this row to footnote bodies on the filing. Mirrors
+    # ParsedTransaction.footnote_refs — operator-facing UX must surface
+    # the footnote next to the field it qualifies. Form 3 footnotes
+    # commonly explain indirect-ownership chains (e.g. "Held by family
+    # trust of which the reporting person is trustee"). Dropping them
+    # silently violates the migration-057 "every structured field
+    # surfaced" precedent.
+    footnote_refs: tuple[ParsedFootnoteRef, ...] = ()
+
+
+@dataclass(frozen=True)
+class ParsedForm3:
+    """Structured extraction of one Form 3 XML primary document.
+
+    Holding rows for both tables are flattened into a single
+    ``holdings`` tuple with stable ``row_num`` so the
+    ``(accession, row_num)`` UNIQUE key in
+    :data:`insider_initial_holdings` doesn't collide between
+    non-derivative and derivative rows from the same filing.
+
+    ``footnotes`` carries the body of every ``<footnote id="...">``
+    on the filing; ``ParsedHolding.footnote_refs`` points at them by
+    id so the reader can render the body next to the field it
+    qualifies (matches the Form 4 model post-057).
+
+    ``no_securities_owned`` is the Form 3 header flag asserting the
+    filer holds nothing. Set to ``True`` on a "blank" Form 3 (newly-
+    appointed director with no positions yet); the holdings list will
+    also be empty in that case but the explicit flag lets the operator
+    distinguish "we know they hold nothing" from "data not on file".
+
+    ``date_of_original_submission`` is non-null on ``3/A`` amendments
+    and points back at the date of the original Form 3 being amended
+    — useful for chaining + drift detection.
+    """
+
+    document_type: str
+    period_of_report: date | None
+    date_of_original_submission: date | None
+    no_securities_owned: bool | None
+    issuer_cik: str | None
+    issuer_name: str | None
+    issuer_trading_symbol: str | None
+    remarks: str | None
+    signature_name: str | None
+    signature_date: date | None
+    filers: tuple[ParsedFiler, ...]
+    footnotes: tuple[ParsedFootnote, ...]
+    holdings: tuple[ParsedHolding, ...]
+
+
+def parse_form_3_xml(raw_xml: str) -> ParsedForm3 | None:
+    """Extract the structured holdings snapshot from a Form 3 primary
+    document.
+
+    Returns ``None`` when:
+
+    - Input is empty or fails to parse as XML.
+    - Document root is not ``ownershipDocument`` (URL rot — caller
+      pointed us at a cover page or a wrong document).
+    - ``documentType`` is not ``3`` or ``3/A`` (caller mis-routed a
+      Form 4 / 5 / amendment).
+    - Zero reporting owners (the file is unattributable — drop rather
+      than persist a phantom).
+
+    Empty holdings tables are *not* an error: a filer can submit a
+    Form 3 declaring "no holdings" (e.g. a newly-appointed director
+    who holds nothing yet). The caller writes a row with no holdings
+    so re-runs skip it; the absence of a row in
+    ``insider_initial_holdings`` is then meaningful (vs "we never
+    looked").
+    """
+    if not raw_xml:
+        return None
+    cleaned_xml = _XMLNS_RE.sub("", raw_xml)
+    try:
+        root = ET.fromstring(cleaned_xml)  # noqa: S314 — same trust posture as Form 4 parser.
+    except ET.ParseError:
+        return None
+
+    if _localname(root.tag) != "ownershipDocument":
+        return None
+
+    document_type = _text(root.find("./documentType")) or "3"
+    if document_type not in ("3", "3/A"):
+        return None
+
+    period_of_report = _date(_text(root.find("./periodOfReport")))
+    date_of_original_submission = _date(_text(root.find("./dateOfOriginalSubmission")))
+    no_securities_owned = _flag(_text(root.find("./noSecuritiesOwned")))
+
+    issuer_el = root.find("./issuer")
+    issuer_cik = _text(issuer_el.find("./issuerCik")) if issuer_el is not None else None
+    issuer_name = _text(issuer_el.find("./issuerName")) if issuer_el is not None else None
+    issuer_trading_symbol = _text(issuer_el.find("./issuerTradingSymbol")) if issuer_el is not None else None
+
+    filers = _extract_filers(root)
+    if not filers:
+        return None
+    default_filer_cik = filers[0].filer_cik
+
+    footnotes = _extract_footnotes(root)
+    holdings = _extract_holdings(root, default_filer_cik=default_filer_cik)
+
+    remarks = _text(root.find("./remarks"))
+    owner_sig = root.find("./ownerSignature")
+    signature_name = _text(owner_sig.find("./signatureName")) if owner_sig is not None else None
+    signature_date = _date(_text(owner_sig.find("./signatureDate"))) if owner_sig is not None else None
+
+    return ParsedForm3(
+        document_type=document_type,
+        period_of_report=period_of_report,
+        date_of_original_submission=date_of_original_submission,
+        no_securities_owned=no_securities_owned,
+        issuer_cik=issuer_cik,
+        issuer_name=issuer_name,
+        issuer_trading_symbol=issuer_trading_symbol,
+        remarks=remarks,
+        signature_name=signature_name,
+        signature_date=signature_date,
+        filers=filers,
+        footnotes=footnotes,
+        holdings=holdings,
+    )
+
+
+def _extract_holdings(
+    root: ET.Element,
+    *,
+    default_filer_cik: str,
+) -> tuple[ParsedHolding, ...]:
+    """Walk ``nonDerivativeTable/nonDerivativeHolding`` then
+    ``derivativeTable/derivativeHolding`` in document order. Row index
+    is shared across both tables so ``(accession, row_num)`` is a
+    stable dedup key for the upsert path."""
+    holdings: list[ParsedHolding] = []
+    row_num = 0
+    for non_der in root.findall("./nonDerivativeTable/nonDerivativeHolding"):
+        holdings.append(
+            _parse_one_holding(non_der, row_num=row_num, is_derivative=False, default_filer_cik=default_filer_cik)
+        )
+        row_num += 1
+    for der in root.findall("./derivativeTable/derivativeHolding"):
+        holdings.append(
+            _parse_one_holding(der, row_num=row_num, is_derivative=True, default_filer_cik=default_filer_cik)
+        )
+        row_num += 1
+    return tuple(holdings)
+
+
+def _parse_one_holding(
+    el: ET.Element,
+    *,
+    row_num: int,
+    is_derivative: bool,
+    default_filer_cik: str,
+) -> ParsedHolding:
+    security_title = _child_text(el.find("./securityTitle"), "./value")
+    # SEC postTransactionAmounts allows EITHER a share count OR a value
+    # (fractional-undivided-interest securities use the value branch).
+    # Surface both — the ingester picks whichever is populated.
+    shares = _safe_decimal(
+        _child_text(
+            el.find("./postTransactionAmounts/sharesOwnedFollowingTransaction"),
+            "./value",
+        ),
+        max_value=_MAX_SHARES,
+    )
+    value_owned = _safe_decimal(
+        _child_text(
+            el.find("./postTransactionAmounts/valueOwnedFollowingTransaction"),
+            "./value",
+        ),
+        max_value=_MAX_PRICE,
+    )
+    own_nature = el.find("./ownershipNature")
+    direct_indirect = _child_text(
+        own_nature.find("./directOrIndirectOwnership") if own_nature is not None else None,
+        "./value",
+    )
+    # Sanitise direct/indirect — SEC enumerates only "D" and "I"; any
+    # other value is malformed and persisting it would mislead the
+    # ownership-card filter that branches on this column. Mirrors the
+    # Form 4 sanitiser at _parse_one_transaction.
+    if direct_indirect not in ("D", "I"):
+        direct_indirect = None
+    nature_of_ownership = _child_text(
+        own_nature.find("./natureOfOwnership") if own_nature is not None else None,
+        "./value",
+    )
+
+    conversion_exercise_price: Decimal | None = None
+    exercise_date: date | None = None
+    expiration_date: date | None = None
+    underlying_security_title: str | None = None
+    underlying_shares: Decimal | None = None
+    underlying_value: Decimal | None = None
+    if is_derivative:
+        conversion_exercise_price = _safe_decimal(
+            _child_text(el.find("./conversionOrExercisePrice"), "./value"),
+            max_value=_MAX_PRICE,
+        )
+        exercise_date = _date(_child_text(el.find("./exerciseDate"), "./value"))
+        expiration_date = _date(_child_text(el.find("./expirationDate"), "./value"))
+        underlying = el.find("./underlyingSecurity")
+        if underlying is not None:
+            underlying_security_title = _child_text(underlying.find("./underlyingSecurityTitle"), "./value")
+            underlying_shares = _safe_decimal(
+                _child_text(underlying.find("./underlyingSecurityShares"), "./value"),
+                max_value=_MAX_SHARES,
+            )
+            # Value-branch alternative (matches ParsedTransaction
+            # .underlying_value added in migration 057). Some
+            # derivative grants — particularly performance / dollar-
+            # denominated awards — express the underlying as a value
+            # rather than a share count.
+            underlying_value = _safe_decimal(
+                _child_text(underlying.find("./underlyingSecurityValue"), "./value"),
+                max_value=_MAX_PRICE,
+            )
+
+    return ParsedHolding(
+        row_num=row_num,
+        is_derivative=is_derivative,
+        filer_cik=default_filer_cik,
+        security_title=security_title,
+        shares=shares,
+        value_owned=value_owned,
+        direct_indirect=direct_indirect,
+        nature_of_ownership=nature_of_ownership,
+        conversion_exercise_price=conversion_exercise_price,
+        exercise_date=exercise_date,
+        expiration_date=expiration_date,
+        underlying_security_title=underlying_security_title,
+        underlying_shares=underlying_shares,
+        underlying_value=underlying_value,
+        footnote_refs=_collect_footnote_refs(el),
+    )
+
+
+# ---------------------------------------------------------------------
 # DB upsert
 # ---------------------------------------------------------------------
 

--- a/sql/093_insider_initial_holdings.sql
+++ b/sql/093_insider_initial_holdings.sql
@@ -1,0 +1,118 @@
+-- 093_insider_initial_holdings.sql
+--
+-- Form 3 initial-holdings seeding (#768). PR 1 of N: schema only —
+-- the parser lands in this PR alongside; the ingester + service-
+-- layer cumulative-update wiring follow in PR 2 + 3.
+--
+-- Form 3 is filed once when an insider becomes subject to Section 16
+-- reporting (officer / director / 10% holder appointment). It records
+-- the *snapshot* of their positions on that date. Form 4 then records
+-- subsequent *changes*. Cumulative balance at any later point =
+-- Form 3 baseline + signed sum of Form 4 deltas since.
+--
+-- Why this matters operationally:
+--   * Insiders who never trade after appointment are invisible to the
+--     ownership card today — no Form 4 events for them, so the per-
+--     officer ring 3 wedges silently miss them.
+--   * The L2 ownership-over-time chart (#756) starts the insider band
+--     at zero before our coverage window because there's no baseline
+--     to anchor the running total.
+--
+-- Storage model parallels insider_filings / insider_transactions
+-- (migration 057) but for the snapshot semantics:
+--   * One row per (accession, row_num) — non-derivative + derivative
+--     holdings interleave inside a single accession; row_num
+--     disambiguates them, mirroring insider_transactions.txn_row_num.
+--   * shares is NUMERIC(20, 4) to match insider_transactions.shares so
+--     downstream cumulative-sum queries stay arithmetic-clean.
+--   * direct_indirect mirrors insider_transactions ('D' / 'I').
+--   * is_derivative discriminates the two tables (a Form 3 can carry
+--     both an underlying-equity holding and an option-grant holding
+--     for the same officer).
+
+CREATE TABLE IF NOT EXISTS insider_initial_holdings (
+    id                          BIGSERIAL   PRIMARY KEY,
+    instrument_id               BIGINT      NOT NULL REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    accession_number            TEXT        NOT NULL,
+    -- Zero-indexed row within the filing's combined holdings list
+    -- (non-derivative rows first, then derivative). Matches the
+    -- txn_row_num convention in insider_transactions so the same
+    -- (accession, row_num) pattern works across both tables.
+    row_num                     INT         NOT NULL,
+    filer_cik                   TEXT        NOT NULL,
+    filer_name                  TEXT        NOT NULL,
+    -- Pipe-joined roles from the Form 3 reportingOwnerRelationship
+    -- block. Same convention as insider_transactions.filer_role.
+    filer_role                  TEXT,
+    -- periodOfReport from Form 3 — the snapshot date the filer
+    -- declares their holdings as "as of". Distinct from filed_at —
+    -- a Form 3 filed late can declare an as_of_date weeks earlier.
+    -- Operator-facing copy and the cumulative-balance computation
+    -- use this column, not the filing-time stamp.
+    as_of_date                  DATE        NOT NULL,
+    security_title              TEXT,
+    -- Snapshot share count from
+    -- postTransactionAmounts/sharesOwnedFollowingTransaction. NULL when
+    -- the SEC value-branch is used instead (see value_owned below) or
+    -- when the value parses as malformed.
+    shares                      NUMERIC(20, 4),
+    -- Snapshot value alternative from
+    -- postTransactionAmounts/valueOwnedFollowingTransaction. SEC
+    -- allows EITHER shares OR value (fractional-undivided-interest
+    -- securities use the value branch). Both columns surface so the
+    -- reader can pick the populated one without a silent drop —
+    -- mirrors the Form 4 underlying_value precedent in migration 057.
+    value_owned                 NUMERIC(18, 6),
+    is_derivative               BOOLEAN     NOT NULL DEFAULT FALSE,
+    -- "D" (direct) / "I" (indirect). Same encoding as
+    -- insider_transactions.direct_indirect. Parser sanitises any other
+    -- value to NULL so a malformed filing can't smuggle a third value
+    -- past the read-side filter.
+    direct_indirect             CHAR(1)     CHECK (direct_indirect IS NULL OR direct_indirect IN ('D', 'I')),
+    nature_of_ownership         TEXT,
+    -- Derivative-only fields. NULL on non-derivative rows.
+    conversion_exercise_price   NUMERIC(18, 6),
+    exercise_date               DATE,
+    expiration_date             DATE,
+    underlying_security_title   TEXT,
+    underlying_shares           NUMERIC(20, 4),
+    -- Value alternative for derivative underlyings (parallels Form 4
+    -- post-057). Some derivative grants — performance / dollar-
+    -- denominated awards — express the underlying as a value not a
+    -- share count.
+    underlying_value            NUMERIC(18, 6),
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (accession_number, row_num)
+);
+
+-- Footnote storage + filing-level metadata (issuer, signature,
+-- noSecuritiesOwned flag, dateOfOriginalSubmission, joint-filing
+-- owners list) lands in PR2 alongside the ingester that needs the
+-- FK relationship to insider_filings. Pre-empting the table here
+-- without an ingester to write it would create dead schema.
+
+-- Hot path for the per-instrument cumulative-balance reader: walk
+-- every Form 3 baseline row for one issuer ordered by snapshot date.
+CREATE INDEX IF NOT EXISTS idx_insider_initial_holdings_instrument
+    ON insider_initial_holdings (instrument_id, as_of_date DESC);
+
+-- Hot path for the per-filer running total: pick the latest Form 3
+-- snapshot per (filer, instrument) before folding Form 4 deltas.
+CREATE INDEX IF NOT EXISTS idx_insider_initial_holdings_filer
+    ON insider_initial_holdings (filer_cik, instrument_id, as_of_date DESC);
+
+COMMENT ON TABLE insider_initial_holdings IS
+    'Form 3 per-row holdings snapshot. One row per holding line in '
+    'a Form 3 filing (non-derivative + derivative interleaved by row_num). '
+    'Source: SEC EDGAR primary_doc.xml. Used as the cumulative-balance '
+    'baseline in get_insider_summary; Form 4 deltas accrete on top.';
+
+COMMENT ON COLUMN insider_initial_holdings.as_of_date IS
+    'periodOfReport from Form 3 — snapshot date the filer declares. '
+    'Distinct from the filing date; a late-filed Form 3 can declare '
+    'an as_of_date earlier than its filing.';
+
+COMMENT ON COLUMN insider_initial_holdings.row_num IS
+    'Zero-indexed position within the filing''s combined holdings '
+    'list (non-derivative rows first, then derivative). Matches the '
+    'txn_row_num pattern in insider_transactions for symmetry.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -97,6 +97,7 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # without touching instruments).
     "insider_transaction_footnotes",
     "insider_transactions",
+    "insider_initial_holdings",  # #768 — Form 3 baseline, FK → instruments
     "insider_filers",
     "insider_filings",
     # #730 — 13F-HR institutional holdings. Child-to-parent:

--- a/tests/test_insider_form3_parser.py
+++ b/tests/test_insider_form3_parser.py
@@ -1,0 +1,527 @@
+"""Unit tests for ``parse_form_3_xml`` (#768).
+
+Form 3 records the *initial* holdings snapshot when an insider becomes
+subject to Section 16 reporting. Tests cover the holding-row parser
+shape, the row-num interleave between non-derivative + derivative
+tables, and the gating returns (``None`` for malformed / wrong
+documentType / no reporting owners).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.insider_transactions import (
+    ParsedHolding,
+    parse_form_3_xml,
+)
+
+
+def _wrap(inner_body: str, *, document_type: str = "3") -> str:
+    """Minimal Form 3 envelope with one reporting owner — tests inject
+    the holdings tables via ``inner_body``."""
+    return f"""<?xml version="1.0"?>
+<ownershipDocument>
+  <documentType>{document_type}</documentType>
+  <periodOfReport>2026-01-15</periodOfReport>
+  <issuer>
+    <issuerCik>0000320193</issuerCik>
+    <issuerName>Apple Inc.</issuerName>
+    <issuerTradingSymbol>AAPL</issuerTradingSymbol>
+  </issuer>
+  <reportingOwner>
+    <reportingOwnerId>
+      <rptOwnerCik>0001000001</rptOwnerCik>
+      <rptOwnerName>Jane Smith</rptOwnerName>
+    </reportingOwnerId>
+    <reportingOwnerRelationship>
+      <isOfficer>1</isOfficer>
+      <officerTitle>Chief Financial Officer</officerTitle>
+    </reportingOwnerRelationship>
+  </reportingOwner>
+  {inner_body}
+  <ownerSignature>
+    <signatureName>Jane Smith</signatureName>
+    <signatureDate>2026-01-16</signatureDate>
+  </ownerSignature>
+</ownershipDocument>
+"""
+
+
+_NON_DERIVATIVE_HOLDING = """
+  <nonDerivativeTable>
+    <nonDerivativeHolding>
+      <securityTitle><value>Common Stock</value></securityTitle>
+      <postTransactionAmounts>
+        <sharesOwnedFollowingTransaction><value>50000</value></sharesOwnedFollowingTransaction>
+      </postTransactionAmounts>
+      <ownershipNature>
+        <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+      </ownershipNature>
+    </nonDerivativeHolding>
+  </nonDerivativeTable>
+"""
+
+
+_DERIVATIVE_HOLDING = """
+  <derivativeTable>
+    <derivativeHolding>
+      <securityTitle><value>Stock Option (Right to Buy)</value></securityTitle>
+      <conversionOrExercisePrice><value>120.00</value></conversionOrExercisePrice>
+      <exerciseDate><value>2025-01-01</value></exerciseDate>
+      <expirationDate><value>2030-01-01</value></expirationDate>
+      <underlyingSecurity>
+        <underlyingSecurityTitle><value>Common Stock</value></underlyingSecurityTitle>
+        <underlyingSecurityShares><value>10000</value></underlyingSecurityShares>
+      </underlyingSecurity>
+      <postTransactionAmounts>
+        <sharesOwnedFollowingTransaction><value>10000</value></sharesOwnedFollowingTransaction>
+      </postTransactionAmounts>
+      <ownershipNature>
+        <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+      </ownershipNature>
+    </derivativeHolding>
+  </derivativeTable>
+"""
+
+
+class TestGatingReturns:
+    def test_empty_input_returns_none(self) -> None:
+        assert parse_form_3_xml("") is None
+
+    def test_malformed_xml_returns_none(self) -> None:
+        assert parse_form_3_xml("<not-xml") is None
+
+    def test_wrong_root_tag_returns_none(self) -> None:
+        assert parse_form_3_xml("<otherDoc/>") is None
+
+    def test_form_4_document_type_is_rejected(self) -> None:
+        # Caller mis-routed a Form 4 to the Form 3 parser. Drop rather
+        # than try to coerce.
+        assert parse_form_3_xml(_wrap(_NON_DERIVATIVE_HOLDING, document_type="4")) is None
+
+    def test_no_reporting_owners_returns_none(self) -> None:
+        # Strip the reportingOwner block.
+        xml = _wrap(_NON_DERIVATIVE_HOLDING).replace("<reportingOwner>", "<!--").replace("</reportingOwner>", "-->")
+        assert parse_form_3_xml(xml) is None
+
+
+class TestHeader:
+    def test_period_of_report_and_issuer_extracted(self) -> None:
+        result = parse_form_3_xml(_wrap(_NON_DERIVATIVE_HOLDING))
+        assert result is not None
+        assert result.document_type == "3"
+        assert result.period_of_report is not None
+        assert result.period_of_report.isoformat() == "2026-01-15"
+        assert result.issuer_cik == "0000320193"
+        assert result.issuer_name == "Apple Inc."
+        assert result.issuer_trading_symbol == "AAPL"
+
+    def test_amendment_document_type_3a_accepted(self) -> None:
+        result = parse_form_3_xml(_wrap(_NON_DERIVATIVE_HOLDING, document_type="3/A"))
+        assert result is not None
+        assert result.document_type == "3/A"
+
+    def test_signature_extracted(self) -> None:
+        result = parse_form_3_xml(_wrap(_NON_DERIVATIVE_HOLDING))
+        assert result is not None
+        assert result.signature_name == "Jane Smith"
+        assert result.signature_date is not None
+        assert result.signature_date.isoformat() == "2026-01-16"
+
+    def test_filer_extracted_from_reporting_owner(self) -> None:
+        result = parse_form_3_xml(_wrap(_NON_DERIVATIVE_HOLDING))
+        assert result is not None
+        assert len(result.filers) == 1
+        filer = result.filers[0]
+        assert filer.filer_cik == "0001000001"
+        assert filer.filer_name == "Jane Smith"
+        assert filer.is_officer is True
+        assert filer.officer_title == "Chief Financial Officer"
+
+
+class TestNonDerivativeHolding:
+    def test_single_non_derivative_row_parsed(self) -> None:
+        result = parse_form_3_xml(_wrap(_NON_DERIVATIVE_HOLDING))
+        assert result is not None
+        assert len(result.holdings) == 1
+        holding = result.holdings[0]
+        assert holding.row_num == 0
+        assert holding.is_derivative is False
+        assert holding.security_title == "Common Stock"
+        assert holding.shares == Decimal("50000")
+        assert holding.direct_indirect == "D"
+        assert holding.filer_cik == "0001000001"
+
+    def test_share_count_above_cap_resolves_to_none(self) -> None:
+        # 1e10 share count is the parser cap (matches Form 4 sanitiser).
+        # A Form 3 reporting an obviously corrupt value should drop the
+        # share count rather than persist a bogus number.
+        body = _NON_DERIVATIVE_HOLDING.replace("50000", "99999999999")
+        result = parse_form_3_xml(_wrap(body))
+        assert result is not None
+        assert result.holdings[0].shares is None
+
+
+class TestDerivativeHolding:
+    def test_single_derivative_row_parsed_with_underlying(self) -> None:
+        result = parse_form_3_xml(_wrap(_DERIVATIVE_HOLDING))
+        assert result is not None
+        assert len(result.holdings) == 1
+        holding = result.holdings[0]
+        assert holding.row_num == 0
+        assert holding.is_derivative is True
+        assert holding.security_title == "Stock Option (Right to Buy)"
+        assert holding.shares == Decimal("10000")
+        assert holding.conversion_exercise_price == Decimal("120.00")
+        assert holding.exercise_date is not None and holding.exercise_date.isoformat() == "2025-01-01"
+        assert holding.expiration_date is not None and holding.expiration_date.isoformat() == "2030-01-01"
+        assert holding.underlying_security_title == "Common Stock"
+        assert holding.underlying_shares == Decimal("10000")
+
+    def test_non_derivative_fields_are_none_on_derivative_row(self) -> None:
+        result = parse_form_3_xml(_wrap(_DERIVATIVE_HOLDING))
+        # The derivative-row contract: non-derivative-only fields stay
+        # populated (security_title, shares, direct_indirect) — the
+        # derivative-only block adds exercise / expiry / underlying.
+        # Sanity-pin nothing leaks the *other* direction.
+        assert result is not None
+        # There is no "non-derivative-only" field on ParsedHolding
+        # today; the row is fully described by the same dataclass for
+        # both. Lock the row's is_derivative flag so a future schema
+        # split (separate dataclasses) doesn't silently mark a
+        # derivative as non-derivative.
+        assert result.holdings[0].is_derivative is True
+
+
+class TestRowNumInterleave:
+    def test_non_derivative_first_then_derivative_with_continuous_row_num(self) -> None:
+        # Non-derivative + derivative tables in the same Form 3 must
+        # produce a single contiguous ``row_num`` sequence so the
+        # ``(accession, row_num)`` UNIQUE key in
+        # insider_initial_holdings doesn't collide between the two
+        # tables.
+        result = parse_form_3_xml(_wrap(_NON_DERIVATIVE_HOLDING + _DERIVATIVE_HOLDING))
+        assert result is not None
+        assert len(result.holdings) == 2
+        assert result.holdings[0].row_num == 0
+        assert result.holdings[0].is_derivative is False
+        assert result.holdings[1].row_num == 1
+        assert result.holdings[1].is_derivative is True
+
+    def test_multiple_rows_within_one_table_increment_row_num(self) -> None:
+        body = """
+        <nonDerivativeTable>
+          <nonDerivativeHolding>
+            <securityTitle><value>Common Stock</value></securityTitle>
+            <postTransactionAmounts><sharesOwnedFollowingTransaction><value>100</value></sharesOwnedFollowingTransaction></postTransactionAmounts>
+            <ownershipNature><directOrIndirectOwnership><value>D</value></directOrIndirectOwnership></ownershipNature>
+          </nonDerivativeHolding>
+          <nonDerivativeHolding>
+            <securityTitle><value>Common Stock</value></securityTitle>
+            <postTransactionAmounts><sharesOwnedFollowingTransaction><value>200</value></sharesOwnedFollowingTransaction></postTransactionAmounts>
+            <ownershipNature><directOrIndirectOwnership><value>I</value></directOrIndirectOwnership></ownershipNature>
+          </nonDerivativeHolding>
+        </nonDerivativeTable>
+        """
+        result = parse_form_3_xml(_wrap(body))
+        assert result is not None
+        assert [h.row_num for h in result.holdings] == [0, 1]
+        assert [h.shares for h in result.holdings] == [Decimal("100"), Decimal("200")]
+        assert [h.direct_indirect for h in result.holdings] == ["D", "I"]
+
+
+class TestEmptyHoldingsAccepted:
+    def test_filer_only_form_3_returns_parsed_with_no_holdings(self) -> None:
+        # Form 3 declaring no positions is legal (newly appointed
+        # director who holds nothing yet). Parser returns the parsed
+        # filing with empty ``holdings`` so the ingester can record
+        # the accession and skip it on re-runs.
+        result = parse_form_3_xml(_wrap(""))
+        assert result is not None
+        assert result.holdings == ()
+
+
+class TestNamespaceHandling:
+    def test_default_xmlns_is_stripped_so_findall_succeeds(self) -> None:
+        # Real Form 3 XMLs from EDGAR carry a default xmlns on the
+        # root. The parser pre-strips it so namespace-blind findall
+        # works — pin that behaviour here so a regression in the
+        # _XMLNS_RE pre-strip is caught.
+        body = _NON_DERIVATIVE_HOLDING
+        wrapped = _wrap(body).replace(
+            "<ownershipDocument>",
+            '<ownershipDocument xmlns="http://www.sec.gov/edgar/ownership">',
+        )
+        result = parse_form_3_xml(wrapped)
+        assert result is not None
+        assert len(result.holdings) == 1
+        assert result.holdings[0].shares == Decimal("50000")
+
+
+@pytest.mark.parametrize(
+    "raw,expected_shares",
+    [
+        ("0", Decimal("0")),
+        ("0.0001", Decimal("0.0001")),
+        ("1234567.5", Decimal("1234567.5")),
+    ],
+)
+def test_share_count_parses_decimal_shapes(raw: str, expected_shares: Decimal) -> None:
+    body = _NON_DERIVATIVE_HOLDING.replace("50000", raw)
+    result = parse_form_3_xml(_wrap(body))
+    assert result is not None
+    assert result.holdings[0].shares == expected_shares
+
+
+def test_parsed_holding_is_immutable() -> None:
+    # Dataclass is frozen — pin so a future refactor doesn't silently
+    # make holdings mutable (matters for hashability + the ParsedFiling
+    # frozen contract elsewhere in the module).
+    result = parse_form_3_xml(_wrap(_NON_DERIVATIVE_HOLDING))
+    assert result is not None
+    holding = result.holdings[0]
+    with pytest.raises(Exception):
+        holding.shares = Decimal("999")  # type: ignore[misc]
+    # And it really is a ParsedHolding (not ParsedTransaction):
+    assert isinstance(holding, ParsedHolding)
+
+
+# ---------------------------------------------------------------------
+# Codex review (#768 PR1) — fixture cases for real-world Form 3 shapes
+# ---------------------------------------------------------------------
+
+
+_FOOTNOTE_HOLDING = """
+  <nonDerivativeTable>
+    <nonDerivativeHolding>
+      <securityTitle><value>Common Stock</value></securityTitle>
+      <postTransactionAmounts>
+        <sharesOwnedFollowingTransaction><value>12000</value></sharesOwnedFollowingTransaction>
+      </postTransactionAmounts>
+      <ownershipNature>
+        <directOrIndirectOwnership>
+          <value>I</value>
+          <footnoteId id="F1"/>
+        </directOrIndirectOwnership>
+        <natureOfOwnership>
+          <value>By Trust</value>
+          <footnoteId id="F1"/>
+        </natureOfOwnership>
+      </ownershipNature>
+    </nonDerivativeHolding>
+  </nonDerivativeTable>
+  <footnotes>
+    <footnote id="F1">Held by family trust of which the reporting person is trustee.</footnote>
+  </footnotes>
+"""
+
+
+def test_footnote_refs_and_bodies_extracted_from_holding() -> None:
+    # Codex (#768 PR1 review) — Form 3 footnotes are common on
+    # indirect-ownership rows; silently dropping them violates the
+    # migration-057 "every structured field surfaced" precedent.
+    result = parse_form_3_xml(_wrap(_FOOTNOTE_HOLDING))
+    assert result is not None
+    assert len(result.footnotes) == 1
+    assert result.footnotes[0].footnote_id == "F1"
+    assert "family trust" in result.footnotes[0].footnote_text
+    holding = result.holdings[0]
+    assert len(holding.footnote_refs) >= 1
+    assert any(ref.footnote_id == "F1" for ref in holding.footnote_refs)
+
+
+def test_no_securities_owned_header_flag_extracted() -> None:
+    # A "blank" Form 3 (newly-appointed director with no positions
+    # yet) carries the noSecuritiesOwned header flag. The flag lets
+    # downstream distinguish "we know they hold nothing" from "data
+    # not on file" — both states have an empty holdings list, but
+    # only the former is positively confirmed.
+    body = "<noSecuritiesOwned>1</noSecuritiesOwned>"
+    xml = _wrap(body).replace("<periodOfReport>", body + "<periodOfReport>", 1)
+    # Above replacement injects the flag right before periodOfReport;
+    # parser reads from root so order doesn't matter.
+    result = parse_form_3_xml(xml)
+    assert result is not None
+    assert result.no_securities_owned is True
+    assert result.holdings == ()
+
+
+def test_amendment_carries_date_of_original_submission() -> None:
+    # 3/A amendments link back to the original filing's date via
+    # dateOfOriginalSubmission. Useful for chaining + drift detection
+    # between the corrected snapshot and what was originally reported.
+    body = "<dateOfOriginalSubmission>2026-01-10</dateOfOriginalSubmission>"
+    xml = _wrap(_NON_DERIVATIVE_HOLDING, document_type="3/A").replace("<periodOfReport>", body + "<periodOfReport>", 1)
+    result = parse_form_3_xml(xml)
+    assert result is not None
+    assert result.document_type == "3/A"
+    assert result.date_of_original_submission is not None
+    assert result.date_of_original_submission.isoformat() == "2026-01-10"
+
+
+def test_value_owned_branch_populated_when_shares_branch_absent() -> None:
+    # postTransactionAmounts can carry valueOwnedFollowingTransaction
+    # *instead of* sharesOwnedFollowingTransaction — typical for
+    # fractional-undivided-interest securities. Both columns must
+    # surface or the value-branch holdings drop silently.
+    body = """
+      <nonDerivativeTable>
+        <nonDerivativeHolding>
+          <securityTitle><value>Series A Units</value></securityTitle>
+          <postTransactionAmounts>
+            <valueOwnedFollowingTransaction><value>250000</value></valueOwnedFollowingTransaction>
+          </postTransactionAmounts>
+          <ownershipNature>
+            <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+          </ownershipNature>
+        </nonDerivativeHolding>
+      </nonDerivativeTable>
+    """
+    result = parse_form_3_xml(_wrap(body))
+    assert result is not None
+    assert len(result.holdings) == 1
+    holding = result.holdings[0]
+    assert holding.shares is None
+    assert holding.value_owned == Decimal("250000")
+
+
+def test_underlying_security_value_extracted_on_derivative_row() -> None:
+    # Performance / dollar-denominated derivative grants express the
+    # underlying as a value, not a share count. Mirrors the Form 4
+    # underlying_value extraction added in migration 057.
+    body = """
+      <derivativeTable>
+        <derivativeHolding>
+          <securityTitle><value>Performance Stock Unit</value></securityTitle>
+          <conversionOrExercisePrice><value>0.00</value></conversionOrExercisePrice>
+          <exerciseDate><value>2025-01-01</value></exerciseDate>
+          <expirationDate><value>2030-01-01</value></expirationDate>
+          <underlyingSecurity>
+            <underlyingSecurityTitle><value>Common Stock</value></underlyingSecurityTitle>
+            <underlyingSecurityValue><value>1500000</value></underlyingSecurityValue>
+          </underlyingSecurity>
+          <postTransactionAmounts>
+            <sharesOwnedFollowingTransaction><value>0</value></sharesOwnedFollowingTransaction>
+          </postTransactionAmounts>
+          <ownershipNature>
+            <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+          </ownershipNature>
+        </derivativeHolding>
+      </derivativeTable>
+    """
+    result = parse_form_3_xml(_wrap(body))
+    assert result is not None
+    holding = result.holdings[0]
+    assert holding.underlying_security_title == "Common Stock"
+    assert holding.underlying_shares is None
+    assert holding.underlying_value == Decimal("1500000")
+
+
+def test_invalid_direct_indirect_value_sanitised_to_none() -> None:
+    # SEC enumerates only "D" and "I"; any other value is malformed.
+    # Persisting it would mislead read-side filters that branch on
+    # this column. Mirrors the Form 4 sanitiser.
+    body = _NON_DERIVATIVE_HOLDING.replace(
+        "<directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>",
+        "<directOrIndirectOwnership><value>X</value></directOrIndirectOwnership>",
+    )
+    result = parse_form_3_xml(_wrap(body))
+    assert result is not None
+    assert result.holdings[0].direct_indirect is None
+
+
+_TWO_OWNER_HEADER = """
+  <reportingOwner>
+    <reportingOwnerId>
+      <rptOwnerCik>0001000001</rptOwnerCik>
+      <rptOwnerName>Jane Smith</rptOwnerName>
+    </reportingOwnerId>
+    <reportingOwnerRelationship>
+      <isOfficer>1</isOfficer>
+      <officerTitle>CFO</officerTitle>
+    </reportingOwnerRelationship>
+  </reportingOwner>
+  <reportingOwner>
+    <reportingOwnerId>
+      <rptOwnerCik>0001000002</rptOwnerCik>
+      <rptOwnerName>Smith Family Trust</rptOwnerName>
+    </reportingOwnerId>
+    <reportingOwnerRelationship>
+      <isOther>1</isOther>
+      <otherText>Trust controlled by reporting officer</otherText>
+    </reportingOwnerRelationship>
+  </reportingOwner>
+"""
+
+
+def test_joint_filing_extracts_every_reporting_owner() -> None:
+    # Joint-filing convention: all listed owners report jointly. PR1
+    # attributes every holding row to the first listed owner (matches
+    # Form 4 default_filer_cik); the full filer list still surfaces so
+    # PR2's ingester can persist all owners under their own dim rows.
+    xml = (
+        _wrap(_NON_DERIVATIVE_HOLDING)
+        .replace(
+            "<reportingOwner>",
+            _TWO_OWNER_HEADER + "<!--orig-->",
+            1,
+        )
+        .replace("<!--orig--><reportingOwner>", "<reportingOwner>")
+    )
+    # The above replace is a tad fragile — simpler: build directly.
+    xml = f"""<?xml version="1.0"?>
+<ownershipDocument>
+  <documentType>3</documentType>
+  <periodOfReport>2026-01-15</periodOfReport>
+  <issuer>
+    <issuerCik>0000320193</issuerCik>
+    <issuerName>Apple Inc.</issuerName>
+    <issuerTradingSymbol>AAPL</issuerTradingSymbol>
+  </issuer>
+  {_TWO_OWNER_HEADER}
+  {_NON_DERIVATIVE_HOLDING}
+</ownershipDocument>
+"""
+    result = parse_form_3_xml(xml)
+    assert result is not None
+    assert len(result.filers) == 2
+    assert {f.filer_cik for f in result.filers} == {"0001000001", "0001000002"}
+    # First-listed owner is the holding-row attribution.
+    assert result.holdings[0].filer_cik == "0001000001"
+
+
+def test_pure_ten_percent_holder_with_no_officer_director_flags() -> None:
+    # 10% holders are reporting persons under Section 16 even without
+    # an officer / director appointment. Pin that the parser surfaces
+    # the bare role without coercing to officer / director.
+    xml = f"""<?xml version="1.0"?>
+<ownershipDocument>
+  <documentType>3</documentType>
+  <periodOfReport>2026-01-15</periodOfReport>
+  <issuer>
+    <issuerCik>0000320193</issuerCik>
+    <issuerName>Apple Inc.</issuerName>
+    <issuerTradingSymbol>AAPL</issuerTradingSymbol>
+  </issuer>
+  <reportingOwner>
+    <reportingOwnerId>
+      <rptOwnerCik>0009999999</rptOwnerCik>
+      <rptOwnerName>Activist Capital LP</rptOwnerName>
+    </reportingOwnerId>
+    <reportingOwnerRelationship>
+      <isTenPercentOwner>1</isTenPercentOwner>
+    </reportingOwnerRelationship>
+  </reportingOwner>
+  {_NON_DERIVATIVE_HOLDING}
+</ownershipDocument>
+"""
+    result = parse_form_3_xml(xml)
+    assert result is not None
+    assert len(result.filers) == 1
+    filer = result.filers[0]
+    assert filer.is_ten_percent_owner is True
+    assert filer.is_officer is None or filer.is_officer is False
+    assert filer.is_director is None or filer.is_director is False

--- a/tests/test_insider_form3_parser.py
+++ b/tests/test_insider_form3_parser.py
@@ -462,16 +462,6 @@ def test_joint_filing_extracts_every_reporting_owner() -> None:
     # attributes every holding row to the first listed owner (matches
     # Form 4 default_filer_cik); the full filer list still surfaces so
     # PR2's ingester can persist all owners under their own dim rows.
-    xml = (
-        _wrap(_NON_DERIVATIVE_HOLDING)
-        .replace(
-            "<reportingOwner>",
-            _TWO_OWNER_HEADER + "<!--orig-->",
-            1,
-        )
-        .replace("<!--orig--><reportingOwner>", "<reportingOwner>")
-    )
-    # The above replace is a tad fragile — simpler: build directly.
     xml = f"""<?xml version="1.0"?>
 <ownershipDocument>
   <documentType>3</documentType>


### PR DESCRIPTION
## What

PR 1 of N for #768. Pure parser ``parse_form_3_xml`` + ``insider_initial_holdings`` schema.

## Why

Insiders who get an RSU grant on appointment and never trade are invisible today (no Form 4 events for them). The L2 ownership-over-time chart (#756) starts the insider band at zero before our coverage window. Form 3 is the missing baseline.

## Scope split

- **PR 1 (this)**: parser + holdings table.
- **PR 2 (next)**: ingester walks SEC submissions for Form 3 accessions; reuses ``insider_filings`` / ``insider_filers`` via ``document_type='3'`` rows; new ``insider_initial_footnotes`` parallels ``insider_transaction_footnotes``.
- **PR 3 (after)**: ``get_insider_summary`` folds Form 3 baseline into the cumulative running total.

## Test plan

- [x] 29 new parser tests covering: gating returns, header extraction, non-derivative + derivative holdings, row_num interleave, namespace handling, footnote refs, ``noSecuritiesOwned``, ``3/A`` amendments with ``dateOfOriginalSubmission``, value-branch holdings, ``underlyingSecurityValue``, sanitised invalid ``directOrIndirectOwnership``, joint filings, pure 10%-holder filers.
- [x] 70 insider tests pass (37 Form 4 + 29 Form 3 + 4 smoke).
- [x] Pre-push gates: ruff / format / pyright / dark-class — all green.

## Codex review (CLAUDE.md checkpoint 2)

Found three substantive issues; all fixed in this PR before push:
- **HIGH** — Form 3 footnotes were being dropped end-to-end. Fixed by adding ``ParsedHolding.footnote_refs`` + ``ParsedForm3.footnotes`` and calling existing extractors per holding.
- **MEDIUM** — Missing ``valueOwnedFollowingTransaction``, ``underlyingSecurityValue``, ``noSecuritiesOwned`` flag, ``dateOfOriginalSubmission`` (3/A amendment link). All four added to dataclasses + extracted by parser; ``value_owned`` + ``underlying_value`` columns added to migration 093.
- **MEDIUM (DEFERRED to PR 2)** — Filing-level metadata storage (issuer / signature / joint-filing owners / footnote bodies) lives on parser dataclasses but has no DB home in PR 1. Deferred to PR 2 where the ingester reuses ``insider_filings`` via ``document_type='3'`` rows.

Refs #768.