### PR TITLE
feat(#768): Form 3 ingester — fetch, parse, upsert (PR 2/N)

### DIFF
--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -415,11 +415,11 @@ def ingest_form_3_filings_for_instrument(
               AND fe.filing_type IN ('3', '3/A')
               AND fe.primary_document_url IS NOT NULL
               AND fe.instrument_id = %s
-              AND fil.accession_number IS NULL
+              AND (fil.accession_number IS NULL OR fil.parser_version < %s)
             ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
             LIMIT %s
             """,
-            (instrument_id, limit),
+            (instrument_id, _FORM3_PARSER_VERSION, limit),
         )
         for row in cur.fetchall():
             candidates.append((int(row[0]), str(row[1]), _canonical_form_4_url(str(row[2]))))
@@ -439,7 +439,10 @@ def ingest_form_3_filings(
     Candidate selector:
       1. ``fe.filing_type IN ('3', '3/A')``.
       2. ``fe.primary_document_url IS NOT NULL``.
-      3. No existing ``insider_filings`` row.
+      3. No existing ``insider_filings`` row, OR the existing row's
+         ``parser_version`` is below the current
+         ``_FORM3_PARSER_VERSION`` (re-parse trigger when the parser
+         shape changes — Codex round 1 / round 2 review of #768 PR2).
       4. No backfill floor — Form 3 volume per issuer is bounded
          (~5-30 lifetime), and a 10-year-old Form 3 for a still-
          serving officer IS the correct baseline.
@@ -460,11 +463,11 @@ def ingest_form_3_filings(
             WHERE fe.provider = 'sec'
               AND fe.filing_type IN ('3', '3/A')
               AND fe.primary_document_url IS NOT NULL
-              AND fil.accession_number IS NULL
+              AND (fil.accession_number IS NULL OR fil.parser_version < %s)
             ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
             LIMIT %s
             """,
-            (limit,),
+            (_FORM3_PARSER_VERSION, limit),
         )
         for row in cur.fetchall():
             candidates.append((int(row[0]), str(row[1]), _canonical_form_4_url(str(row[2]))))
@@ -539,6 +542,20 @@ def _process_form_3_candidates(
                 accession,
                 exc_info=True,
             )
+            # Tombstone the accession so a persistent constraint
+            # violation (or any other deterministic upsert failure)
+            # doesn't loop the scheduler refetching the same dead
+            # XML on every tick. A fix-and-bump of the parser version
+            # will re-pick the accession via the parser_version <
+            # selector branch above. Codex round 2 review of #768 PR2.
+            _write_form_3_tombstone(
+                conn,
+                instrument_id=instrument_id,
+                accession_number=accession,
+                primary_document_url=url,
+            )
+            conn.commit()
+            parse_misses += 1
             continue
 
         filings_parsed += 1

--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -1,0 +1,553 @@
+"""Form 3 ingester (#768 PR 2/N).
+
+Walks ``filing_events`` for Form 3 / 3/A accessions without an
+``insider_filings`` row, fetches each primary doc XML through the
+shared SEC fetcher, parses via
+:func:`app.services.insider_transactions.parse_form_3_xml`, and upserts
+across the four insider tables:
+
+  * ``insider_filings``           — document_type='3'/'3/A' rows live
+                                    alongside Form 4 rows. The table
+                                    accepts any ownership form.
+  * ``insider_filers``            — reporting owners on the filing.
+  * ``insider_transaction_footnotes`` — filing-scoped footnote bodies.
+                                    Despite the name, the table is
+                                    keyed on accession + footnote_id —
+                                    it works for any ownership form.
+  * ``insider_initial_holdings``  — Form 3-specific holding rows
+                                    (migration 093).
+
+Tombstone path mirrors Form 4: a fetch / parse failure writes a
+filing-level tombstone so the ingester never re-fetches a dead URL.
+
+Parser version is shared with Form 4 — bumping the Form 4 parser
+intentionally invalidates Form 3 rows too only when ``parser_version``
+on the filing is below the current shared value. Form 3 ingestion uses
+its own ``_FORM3_PARSER_VERSION`` so a Form 3 parser tweak doesn't
+trigger a Form 4 re-ingest cycle.
+
+Cumulative-balance integration into ``get_insider_summary`` ships in
+PR 3.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import psycopg
+
+from app.providers.concurrent_fetch import fetch_document_texts
+from app.services.insider_transactions import (
+    ParsedForm3,
+    _canonical_form_4_url,
+    parse_form_3_xml,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Bump whenever ``parse_form_3_xml`` shape changes so the ingester can
+# re-parse older Form 3 filings under the new parser without a fresh
+# SEC fetch. Independent from the Form 4 ``_PARSER_VERSION`` so a
+# Form 4 parser tweak doesn't trigger a Form 3 re-ingest cycle.
+_FORM3_PARSER_VERSION = 1
+
+
+# Form 3 backfill floor — unlike Form 4 (5y floor) we keep every
+# historical Form 3 we can find. Form 3 is filed once per officer-
+# issuer appointment, so volume is bounded (~5-30 lifetime per issuer)
+# and the snapshot from 10y ago for a still-serving officer is the
+# correct cumulative-balance baseline. No throttling needed.
+INSIDER_FORM3_BACKFILL_FLOOR_YEARS: int | None = None
+
+
+# ---------------------------------------------------------------------
+# DB upsert
+# ---------------------------------------------------------------------
+
+
+def upsert_form_3_filing(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    accession_number: str,
+    primary_document_url: str,
+    parsed: ParsedForm3,
+) -> None:
+    """Insert / refresh the Form 3 filing header + filer dim + footnote
+    bodies + holding rows for one accession.
+
+    Idempotency: every child table keys on ``(accession, …)`` with
+    ON CONFLICT DO UPDATE so re-running on the same accession (e.g.
+    after a parser bump) refreshes every field in place. Tombstones
+    are flipped back to live via the ``is_tombstone = FALSE`` reset on
+    the filings UPDATE branch.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO insider_filings (
+                accession_number, instrument_id, document_type,
+                period_of_report, date_of_original_submission,
+                not_subject_to_section_16,
+                form3_holdings_reported, form4_transactions_reported,
+                issuer_cik, issuer_name, issuer_trading_symbol,
+                remarks, signature_name, signature_date,
+                primary_document_url, parser_version, is_tombstone
+            ) VALUES (
+                %s, %s, %s,
+                %s, %s,
+                %s,
+                %s, %s,
+                %s, %s, %s,
+                %s, %s, %s,
+                %s, %s, FALSE
+            )
+            ON CONFLICT (accession_number) DO UPDATE SET
+                document_type                = EXCLUDED.document_type,
+                period_of_report             = EXCLUDED.period_of_report,
+                date_of_original_submission  = EXCLUDED.date_of_original_submission,
+                not_subject_to_section_16    = EXCLUDED.not_subject_to_section_16,
+                form3_holdings_reported      = EXCLUDED.form3_holdings_reported,
+                form4_transactions_reported  = EXCLUDED.form4_transactions_reported,
+                issuer_cik                   = EXCLUDED.issuer_cik,
+                issuer_name                  = EXCLUDED.issuer_name,
+                issuer_trading_symbol        = EXCLUDED.issuer_trading_symbol,
+                remarks                      = EXCLUDED.remarks,
+                signature_name               = EXCLUDED.signature_name,
+                signature_date               = EXCLUDED.signature_date,
+                primary_document_url         = EXCLUDED.primary_document_url,
+                parser_version               = EXCLUDED.parser_version,
+                is_tombstone                 = FALSE,
+                fetched_at                   = NOW()
+            """,
+            (
+                accession_number,
+                instrument_id,
+                parsed.document_type,
+                parsed.period_of_report,
+                parsed.date_of_original_submission,
+                # Form 3 doesn't use the section-16 / form3-reported /
+                # form4-reported flags; persist as NULL so a future
+                # cross-form query can branch on document_type without
+                # reading bogus values.
+                None,
+                None,
+                None,
+                parsed.issuer_cik,
+                parsed.issuer_name,
+                parsed.issuer_trading_symbol,
+                parsed.remarks,
+                parsed.signature_name,
+                parsed.signature_date,
+                primary_document_url,
+                _FORM3_PARSER_VERSION,
+            ),
+        )
+
+        # Filer dim — same shape as Form 4 ingester. Re-running upserts
+        # in place because ``insider_filers`` keys on (accession,
+        # filer_cik) via the UNIQUE constraint from migration 057.
+        #
+        # Replace-then-insert (mirrors holdings below): without the
+        # DELETE, a parser version that stops emitting a secondary
+        # joint-filer would leave the stale row pinned to the
+        # accession forever. Codex review of #768 PR2 caught the gap.
+        cur.execute(
+            "DELETE FROM insider_filers WHERE accession_number = %s",
+            (accession_number,),
+        )
+        for filer in parsed.filers:
+            cur.execute(
+                """
+                INSERT INTO insider_filers (
+                    accession_number, filer_cik, filer_name,
+                    street1, street2, city, state, zip_code,
+                    state_description,
+                    is_director, is_officer, officer_title,
+                    is_ten_percent_owner, is_other, other_text
+                ) VALUES (
+                    %s, %s, %s,
+                    %s, %s, %s, %s, %s,
+                    %s,
+                    %s, %s, %s,
+                    %s, %s, %s
+                )
+                ON CONFLICT (accession_number, filer_cik) DO UPDATE SET
+                    filer_name           = EXCLUDED.filer_name,
+                    street1              = EXCLUDED.street1,
+                    street2              = EXCLUDED.street2,
+                    city                 = EXCLUDED.city,
+                    state                = EXCLUDED.state,
+                    zip_code             = EXCLUDED.zip_code,
+                    state_description    = EXCLUDED.state_description,
+                    is_director          = EXCLUDED.is_director,
+                    is_officer           = EXCLUDED.is_officer,
+                    officer_title        = EXCLUDED.officer_title,
+                    is_ten_percent_owner = EXCLUDED.is_ten_percent_owner,
+                    is_other             = EXCLUDED.is_other,
+                    other_text           = EXCLUDED.other_text
+                """,
+                (
+                    accession_number,
+                    filer.filer_cik,
+                    filer.filer_name,
+                    filer.street1,
+                    filer.street2,
+                    filer.city,
+                    filer.state,
+                    filer.zip_code,
+                    filer.state_description,
+                    filer.is_director,
+                    filer.is_officer,
+                    filer.officer_title,
+                    filer.is_ten_percent_owner,
+                    filer.is_other,
+                    filer.other_text,
+                ),
+            )
+
+        # Footnote bodies. Re-uses ``insider_transaction_footnotes`` —
+        # the table name is historical (migration 057 named it for
+        # Form 4) but its key is (accession, footnote_id), filing-
+        # scoped, so it carries Form 3 footnotes equally well. PR3
+        # may rename the table; the data shape is correct.
+        #
+        # Replace-then-insert (matches holdings + filers): a parser
+        # version that drops a footnote should not leave the stale
+        # body pinned to the accession. Codex review of #768 PR2
+        # caught the gap.
+        cur.execute(
+            "DELETE FROM insider_transaction_footnotes WHERE accession_number = %s",
+            (accession_number,),
+        )
+        for footnote in parsed.footnotes:
+            cur.execute(
+                """
+                INSERT INTO insider_transaction_footnotes (
+                    accession_number, footnote_id, footnote_text
+                ) VALUES (%s, %s, %s)
+                ON CONFLICT (accession_number, footnote_id) DO UPDATE SET
+                    footnote_text = EXCLUDED.footnote_text
+                """,
+                (accession_number, footnote.footnote_id, footnote.footnote_text),
+            )
+
+        # Holding rows — replace-then-insert so a re-parse cleanly drops
+        # rows that no longer appear in the latest XML (e.g. parser
+        # bump that filtered a malformed entry). Mirrors the Form 4
+        # transactions pattern but on the new insider_initial_holdings
+        # table from migration 093.
+        cur.execute(
+            "DELETE FROM insider_initial_holdings WHERE accession_number = %s",
+            (accession_number,),
+        )
+        for holding in parsed.holdings:
+            cur.execute(
+                """
+                INSERT INTO insider_initial_holdings (
+                    instrument_id, accession_number, row_num,
+                    filer_cik, filer_name, filer_role,
+                    as_of_date,
+                    security_title, shares, value_owned, is_derivative,
+                    direct_indirect, nature_of_ownership,
+                    conversion_exercise_price,
+                    exercise_date, expiration_date,
+                    underlying_security_title, underlying_shares,
+                    underlying_value
+                ) VALUES (
+                    %s, %s, %s,
+                    %s, %s, %s,
+                    %s,
+                    %s, %s, %s, %s,
+                    %s, %s,
+                    %s,
+                    %s, %s,
+                    %s, %s,
+                    %s
+                )
+                """,
+                (
+                    instrument_id,
+                    accession_number,
+                    holding.row_num,
+                    holding.filer_cik,
+                    _filer_name_for(parsed, holding.filer_cik),
+                    _filer_role_for(parsed, holding.filer_cik),
+                    # Form 3 ``period_of_report`` IS the as_of_date —
+                    # the snapshot the filer declares. Required NOT
+                    # NULL by the migration; if the parser produced a
+                    # NULL period (rare; SEC requires it), fall back
+                    # to the signature date so the row still lands.
+                    parsed.period_of_report or parsed.signature_date,
+                    holding.security_title,
+                    holding.shares,
+                    holding.value_owned,
+                    holding.is_derivative,
+                    holding.direct_indirect,
+                    holding.nature_of_ownership,
+                    holding.conversion_exercise_price,
+                    holding.exercise_date,
+                    holding.expiration_date,
+                    holding.underlying_security_title,
+                    holding.underlying_shares,
+                    holding.underlying_value,
+                ),
+            )
+
+
+def _filer_name_for(parsed: ParsedForm3, filer_cik: str | None) -> str:
+    """Resolve ``filer_cik`` to a display name from the filing's filer
+    list. Falls back to the first listed owner when the holding row's
+    ``filer_cik`` doesn't match any (joint-filing convention)."""
+    if filer_cik is not None:
+        for f in parsed.filers:
+            if f.filer_cik == filer_cik:
+                return f.filer_name
+    return parsed.filers[0].filer_name if parsed.filers else "<unknown>"
+
+
+def _filer_role_for(parsed: ParsedForm3, filer_cik: str | None) -> str | None:
+    """Pipe-joined relationship-flag string for the filer matching
+    ``filer_cik``. Same encoding as
+    :func:`app.services.insider_transactions.filer_role_string`.
+    Returns ``None`` when the filer has no relationship data on file
+    (rare; SEC requires at least one flag)."""
+    target = None
+    if filer_cik is not None:
+        for f in parsed.filers:
+            if f.filer_cik == filer_cik:
+                target = f
+                break
+    if target is None:
+        target = parsed.filers[0] if parsed.filers else None
+    if target is None:
+        return None
+    parts: list[str] = []
+    if target.is_director:
+        parts.append("director")
+    if target.is_officer:
+        parts.append(f"officer:{target.officer_title}" if target.officer_title else "officer")
+    if target.is_ten_percent_owner:
+        parts.append("ten_percent_owner")
+    if target.is_other:
+        parts.append(f"other:{target.other_text}" if target.other_text else "other")
+    return "|".join(parts) or None
+
+
+_TOMBSTONE_DOC_TYPE = "3"
+
+
+def _write_form_3_tombstone(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    accession_number: str,
+    primary_document_url: str,
+) -> None:
+    """Mark a Form 3 accession as unfetchable / unparseable so the next
+    pass skips it. Tombstones carry no children; the cumulative-
+    balance reader (PR 3) joins ``insider_filings`` with
+    ``is_tombstone = FALSE`` to exclude them. A successful re-parse
+    flips the row back to live via :func:`upsert_form_3_filing`."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO insider_filings (
+                accession_number, instrument_id, document_type,
+                primary_document_url, parser_version, is_tombstone
+            ) VALUES (%s, %s, %s, %s, %s, TRUE)
+            ON CONFLICT (accession_number) DO NOTHING
+            """,
+            (
+                accession_number,
+                instrument_id,
+                _TOMBSTONE_DOC_TYPE,
+                primary_document_url,
+                _FORM3_PARSER_VERSION,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------
+# Ingester
+# ---------------------------------------------------------------------
+
+
+class _DocFetcher(Protocol):
+    def fetch_document_text(self, absolute_url: str) -> str | None: ...
+
+
+@dataclass(frozen=True)
+class IngestForm3Result:
+    filings_scanned: int
+    filings_parsed: int
+    rows_inserted: int
+    fetch_errors: int
+    parse_misses: int
+
+
+def ingest_form_3_filings_for_instrument(
+    conn: psycopg.Connection[Any],
+    fetcher: _DocFetcher,
+    *,
+    instrument_id: int,
+    limit: int = 500,
+) -> IngestForm3Result:
+    """Targeted backfill for one instrument's Form 3 filings.
+
+    Same candidate-selector contract as
+    :func:`ingest_form_3_filings` but scoped to a single instrument.
+    """
+    conn.commit()
+    candidates: list[tuple[int, str, str]] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT fe.instrument_id,
+                   fe.provider_filing_id,
+                   fe.primary_document_url
+            FROM filing_events fe
+            LEFT JOIN insider_filings fil ON fil.accession_number = fe.provider_filing_id
+            WHERE fe.provider = 'sec'
+              AND fe.filing_type IN ('3', '3/A')
+              AND fe.primary_document_url IS NOT NULL
+              AND fe.instrument_id = %s
+              AND fil.accession_number IS NULL
+            ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+            LIMIT %s
+            """,
+            (instrument_id, limit),
+        )
+        for row in cur.fetchall():
+            candidates.append((int(row[0]), str(row[1]), _canonical_form_4_url(str(row[2]))))
+    conn.commit()
+
+    return _process_form_3_candidates(conn, fetcher, candidates)
+
+
+def ingest_form_3_filings(
+    conn: psycopg.Connection[Any],
+    fetcher: _DocFetcher,
+    *,
+    limit: int = 500,
+) -> IngestForm3Result:
+    """Universe-wide newest-first scan of Form 3 candidates.
+
+    Candidate selector:
+      1. ``fe.filing_type IN ('3', '3/A')``.
+      2. ``fe.primary_document_url IS NOT NULL``.
+      3. No existing ``insider_filings`` row.
+      4. No backfill floor — Form 3 volume per issuer is bounded
+         (~5-30 lifetime), and a 10-year-old Form 3 for a still-
+         serving officer IS the correct baseline.
+
+    Bounded per run by ``limit``.
+    """
+    conn.commit()
+
+    candidates: list[tuple[int, str, str]] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT fe.instrument_id,
+                   fe.provider_filing_id,
+                   fe.primary_document_url
+            FROM filing_events fe
+            LEFT JOIN insider_filings fil ON fil.accession_number = fe.provider_filing_id
+            WHERE fe.provider = 'sec'
+              AND fe.filing_type IN ('3', '3/A')
+              AND fe.primary_document_url IS NOT NULL
+              AND fil.accession_number IS NULL
+            ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+            LIMIT %s
+            """,
+            (limit,),
+        )
+        for row in cur.fetchall():
+            candidates.append((int(row[0]), str(row[1]), _canonical_form_4_url(str(row[2]))))
+    conn.commit()
+
+    return _process_form_3_candidates(conn, fetcher, candidates)
+
+
+def _process_form_3_candidates(
+    conn: psycopg.Connection[Any],
+    fetcher: _DocFetcher,
+    candidates: list[tuple[int, str, str]],
+) -> IngestForm3Result:
+    """Shared fetch-parse-upsert loop for the Form 3 entry points.
+
+    Mirrors :func:`app.services.insider_transactions._process_candidates`
+    but routes through :func:`parse_form_3_xml` and
+    :func:`upsert_form_3_filing`. Per-candidate failures (fetch / parse
+    / upsert) tombstone the accession and continue to the next so a
+    single bad URL doesn't abort the batch.
+    """
+    filings_parsed = 0
+    rows_inserted = 0
+    fetch_errors = 0
+    parse_misses = 0
+
+    bodies = fetch_document_texts(fetcher, (url for _, _, url in candidates))
+
+    for instrument_id, accession, url in candidates:
+        xml = bodies.get(url)
+        if xml is None:
+            logger.warning(
+                "ingest_form_3_filings: fetch failed accession=%s url=%s",
+                accession,
+                url,
+            )
+            fetch_errors += 1
+            _write_form_3_tombstone(
+                conn,
+                instrument_id=instrument_id,
+                accession_number=accession,
+                primary_document_url=url,
+            )
+            conn.commit()
+            continue
+
+        parsed = parse_form_3_xml(xml)
+        if parsed is None:
+            parse_misses += 1
+            _write_form_3_tombstone(
+                conn,
+                instrument_id=instrument_id,
+                accession_number=accession,
+                primary_document_url=url,
+            )
+            conn.commit()
+            continue
+
+        try:
+            upsert_form_3_filing(
+                conn,
+                instrument_id=instrument_id,
+                accession_number=accession,
+                primary_document_url=url,
+                parsed=parsed,
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            logger.warning(
+                "ingest_form_3_filings: upsert failed accession=%s",
+                accession,
+                exc_info=True,
+            )
+            continue
+
+        filings_parsed += 1
+        rows_inserted += len(parsed.holdings)
+
+    return IngestForm3Result(
+        filings_scanned=len(candidates),
+        filings_parsed=filings_parsed,
+        rows_inserted=rows_inserted,
+        fetch_errors=fetch_errors,
+        parse_misses=parse_misses,
+    )

--- a/tests/test_fetch_document_text_callers.py
+++ b/tests/test_fetch_document_text_callers.py
@@ -36,9 +36,11 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         #   insider_transactions — Form 4 XML (#429)
         #   eight_k_events      — 8-K full structure (#450)
         #   institutional_holdings — 13F-HR primary_doc + infotable XML (#730)
+        #   insider_form3_ingest    — Form 3 initial-holdings XML (#768)
         "app/services/business_summary.py",
         "app/services/dividend_calendar.py",
         "app/services/insider_transactions.py",
+        "app/services/insider_form3_ingest.py",
         "app/services/eight_k_events.py",
         "app/services/institutional_holdings.py",
         # Provider implementation owns the method itself.
@@ -58,6 +60,7 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         "tests/test_business_summary_ingest.py",
         "tests/test_dividend_calendar_ingest.py",
         "tests/test_insider_transactions_ingest.py",
+        "tests/test_insider_form3_ingest.py",
         "tests/test_eight_k_events_ingest.py",
         "tests/test_concurrent_fetch.py",
         "tests/test_institutional_holdings_ingester.py",

--- a/tests/test_insider_form3_ingest.py
+++ b/tests/test_insider_form3_ingest.py
@@ -379,6 +379,109 @@ class TestIdempotency:
             assert row[0] == 1
 
 
+class TestParserVersionRefresh:
+    def test_existing_filing_below_current_parser_version_is_re_picked(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        # Codex round 1+2 review of #768 PR2: bumping
+        # _FORM3_PARSER_VERSION must trigger re-ingest of stored
+        # accessions (the module docstring promises this). Pin the
+        # selector branch so a future regression that drops the
+        # ``OR fil.parser_version < %s`` clause is caught.
+        iid = _seed_instrument(ebull_test_conn)
+        url = "https://example.test/form3.xml"
+        accession = "0000000111-26-000001"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession=accession,
+            url=url,
+        )
+
+        # Pre-populate insider_filings with a stale parser_version.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO insider_filings (
+                    accession_number, instrument_id, document_type,
+                    primary_document_url, parser_version, is_tombstone
+                ) VALUES (%s, %s, '3', %s, 0, FALSE)
+                """,
+                (accession, iid, url),
+            )
+        ebull_test_conn.commit()
+
+        # Even though the filing already has an insider_filings row,
+        # parser_version=0 is below _FORM3_PARSER_VERSION=1 so the
+        # selector picks it up for re-parse.
+        fetcher = _StubFetcher({url: _FORM_3_RICH})
+        result = ingest_form_3_filings(ebull_test_conn, fetcher)
+        assert result.filings_parsed == 1
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT parser_version FROM insider_filings WHERE accession_number = %s",
+                (accession,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            # Parser version bumped to current.
+            assert row[0] >= 1
+
+
+class TestUpsertFailureTombstone:
+    def test_upsert_exception_writes_tombstone_so_scheduler_does_not_retry(
+        self, ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Codex round 2 review of #768 PR2: a persistent upsert
+        # failure (e.g. DB constraint violation, deterministic bug in
+        # the upsert path) must tombstone the accession so the
+        # scheduler doesn't re-fetch the same dead XML on every tick.
+        # Pre-fix the except branch only rollback'd + continue'd,
+        # leaving the accession eligible for re-fetch forever.
+        from app.services import insider_form3_ingest
+
+        iid = _seed_instrument(ebull_test_conn)
+        url = "https://example.test/form3.xml"
+        accession = "0000000222-26-000001"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession=accession,
+            url=url,
+        )
+
+        # Force the upsert path to raise. Monkey-patch is more
+        # contract-faithful than dropping FKs at runtime — we want
+        # to test the EXCEPT branch, not a specific kind of DB
+        # failure.
+        def _boom(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("simulated upsert failure")
+
+        monkeypatch.setattr(insider_form3_ingest, "upsert_form_3_filing", _boom)
+
+        fetcher = _StubFetcher({url: _FORM_3_RICH})
+        result = ingest_form_3_filings(ebull_test_conn, fetcher)
+        # Upsert raised — accession tombstoned, parsed_count=0.
+        assert result.filings_parsed == 0
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT is_tombstone FROM insider_filings WHERE accession_number = %s",
+                (accession,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] is True
+
+        # Second pass: with the tombstone written, the candidate
+        # selector excludes the row (parser_version >= current,
+        # tombstone or not). Confirm by un-patching and re-running.
+        monkeypatch.undo()
+        result2 = ingest_form_3_filings(ebull_test_conn, fetcher)
+        assert result2.filings_scanned == 0
+
+
 class TestStaleChildCleanup:
     def test_reparse_to_smaller_xml_drops_stale_footnotes_and_filers(
         self, ebull_test_conn: psycopg.Connection[tuple]

--- a/tests/test_insider_form3_ingest.py
+++ b/tests/test_insider_form3_ingest.py
@@ -1,0 +1,499 @@
+"""Integration tests for ``ingest_form_3_filings`` (#768 PR 2/N).
+
+Covers:
+- Happy path: header + non-derivative + derivative + footnote land
+  across insider_filings + insider_filers + insider_transaction_footnotes
+  + insider_initial_holdings.
+- Tombstones on fetch 404 / parse miss; second pass does not re-fetch.
+- Per-instrument scope + non-Form-3 filings excluded.
+- XSL-rendered URL canonicalisation (Form 3 reuses the Form 4 helper
+  since the XSL prefix is the same across Forms 3/4/5).
+- Idempotency: re-running upserts in place; replace-then-insert on
+  holdings drops stale rows from a prior parse.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services.insider_form3_ingest import (
+    ingest_form_3_filings,
+    ingest_form_3_filings_for_instrument,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------
+
+
+class _StubFetcher:
+    def __init__(self, by_url: dict[str, str | None]) -> None:
+        self._by_url = by_url
+        self.calls: list[str] = []
+
+    def fetch_document_text(self, absolute_url: str) -> str | None:
+        self.calls.append(absolute_url)
+        return self._by_url.get(absolute_url)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int = 991, symbol: str = "AAPL") -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            (iid, symbol, "Test Co"),
+        )
+        row = cur.fetchone()
+        assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+def _seed_filing(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    accession: str,
+    url: str,
+    filing_type: str = "3",
+    filing_date: str = "2026-01-15",
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO filing_events
+                (instrument_id, filing_date, filing_type, provider,
+                 provider_filing_id, primary_document_url)
+            VALUES (%s, %s, %s, 'sec', %s, %s)
+            """,
+            (instrument_id, filing_date, filing_type, accession, url),
+        )
+    conn.commit()
+
+
+_FORM_3_RICH = """<?xml version="1.0"?>
+<ownershipDocument>
+  <schemaVersion>X0202</schemaVersion>
+  <documentType>3</documentType>
+  <periodOfReport>2026-01-15</periodOfReport>
+  <issuer>
+    <issuerCik>0000320193</issuerCik>
+    <issuerName>Apple Inc.</issuerName>
+    <issuerTradingSymbol>AAPL</issuerTradingSymbol>
+  </issuer>
+  <reportingOwner>
+    <reportingOwnerId>
+      <rptOwnerCik>0001000001</rptOwnerCik>
+      <rptOwnerName>Smith, Jane</rptOwnerName>
+    </reportingOwnerId>
+    <reportingOwnerAddress>
+      <rptOwnerStreet1>1 Apple Park Way</rptOwnerStreet1>
+      <rptOwnerCity>Cupertino</rptOwnerCity>
+      <rptOwnerState>CA</rptOwnerState>
+      <rptOwnerZipCode>95014</rptOwnerZipCode>
+    </reportingOwnerAddress>
+    <reportingOwnerRelationship>
+      <isOfficer>1</isOfficer>
+      <officerTitle>Chief Financial Officer</officerTitle>
+    </reportingOwnerRelationship>
+  </reportingOwner>
+  <nonDerivativeTable>
+    <nonDerivativeHolding>
+      <securityTitle><value>Common Stock</value></securityTitle>
+      <postTransactionAmounts>
+        <sharesOwnedFollowingTransaction><value>50000</value></sharesOwnedFollowingTransaction>
+      </postTransactionAmounts>
+      <ownershipNature>
+        <directOrIndirectOwnership>
+          <value>I</value>
+          <footnoteId id="F1"/>
+        </directOrIndirectOwnership>
+        <natureOfOwnership>
+          <value>By Trust</value>
+          <footnoteId id="F1"/>
+        </natureOfOwnership>
+      </ownershipNature>
+    </nonDerivativeHolding>
+  </nonDerivativeTable>
+  <derivativeTable>
+    <derivativeHolding>
+      <securityTitle><value>Stock Option (Right to Buy)</value></securityTitle>
+      <conversionOrExercisePrice><value>120.00</value></conversionOrExercisePrice>
+      <exerciseDate><value>2025-01-01</value></exerciseDate>
+      <expirationDate><value>2030-01-01</value></expirationDate>
+      <underlyingSecurity>
+        <underlyingSecurityTitle><value>Common Stock</value></underlyingSecurityTitle>
+        <underlyingSecurityShares><value>10000</value></underlyingSecurityShares>
+      </underlyingSecurity>
+      <postTransactionAmounts>
+        <sharesOwnedFollowingTransaction><value>10000</value></sharesOwnedFollowingTransaction>
+      </postTransactionAmounts>
+      <ownershipNature>
+        <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+      </ownershipNature>
+    </derivativeHolding>
+  </derivativeTable>
+  <footnotes>
+    <footnote id="F1">Held by family trust of which the reporting person is trustee.</footnote>
+  </footnotes>
+  <ownerSignature>
+    <signatureName>Jane Smith</signatureName>
+    <signatureDate>2026-01-16</signatureDate>
+  </ownerSignature>
+</ownershipDocument>
+"""
+
+
+# ---------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------
+
+
+class TestRichHappyPath:
+    def test_full_filing_lands_across_four_tables(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        url = "https://www.sec.gov/Archives/edgar/data/320193/000119312526001000/form3.xml"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="0001193125-26-001000",
+            url=url,
+        )
+        fetcher = _StubFetcher({url: _FORM_3_RICH})
+
+        result = ingest_form_3_filings(ebull_test_conn, fetcher)
+        assert result.filings_scanned == 1
+        assert result.filings_parsed == 1
+        assert result.rows_inserted == 2  # 1 non-derivative + 1 derivative
+        assert result.fetch_errors == 0
+        assert result.parse_misses == 0
+
+        with ebull_test_conn.cursor() as cur:
+            # insider_filings: header captured, document_type='3'.
+            cur.execute(
+                "SELECT document_type, period_of_report, signature_name, is_tombstone "
+                "FROM insider_filings WHERE accession_number = '0001193125-26-001000'"
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "3"
+            assert row[1].isoformat() == "2026-01-15"
+            assert row[2] == "Jane Smith"
+            assert row[3] is False
+
+            # insider_filers: one row.
+            cur.execute(
+                "SELECT filer_cik, is_officer, officer_title FROM insider_filers "
+                "WHERE accession_number = '0001193125-26-001000'"
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "0001000001"
+            assert row[1] is True
+            assert row[2] == "Chief Financial Officer"
+
+            # insider_transaction_footnotes: F1 body persisted.
+            cur.execute(
+                "SELECT footnote_id, footnote_text FROM insider_transaction_footnotes "
+                "WHERE accession_number = '0001193125-26-001000'"
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "F1"
+            assert "family trust" in row[1]
+
+            # insider_initial_holdings: 2 rows, row_num interleaved.
+            cur.execute(
+                "SELECT row_num, is_derivative, shares, direct_indirect, security_title "
+                "FROM insider_initial_holdings "
+                "WHERE accession_number = '0001193125-26-001000' "
+                "ORDER BY row_num"
+            )
+            rows = cur.fetchall()
+            assert len(rows) == 2
+            assert rows[0][0] == 0
+            assert rows[0][1] is False
+            assert rows[0][2] == Decimal("50000")
+            assert rows[0][3] == "I"
+            assert rows[0][4] == "Common Stock"
+            assert rows[1][0] == 1
+            assert rows[1][1] is True
+            assert rows[1][2] == Decimal("10000")
+            assert rows[1][3] == "D"
+
+
+class TestTombstones:
+    def test_fetch_404_writes_tombstone_and_skips_next_run(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        url = "https://www.sec.gov/Archives/edgar/data/320193/000099/form3.xml"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="0000000099-26-000001",
+            url=url,
+        )
+        fetcher = _StubFetcher({url: None})  # 404
+
+        result = ingest_form_3_filings(ebull_test_conn, fetcher)
+        assert result.fetch_errors == 1
+        assert result.filings_parsed == 0
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT is_tombstone FROM insider_filings WHERE accession_number = '0000000099-26-000001'")
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] is True
+
+        # Second pass does not re-fetch — the tombstone row anchors
+        # the LEFT JOIN exclusion in the candidate selector.
+        result2 = ingest_form_3_filings(ebull_test_conn, fetcher)
+        assert result2.filings_scanned == 0
+
+    def test_parse_miss_writes_tombstone(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn)
+        url = "https://www.sec.gov/Archives/edgar/data/320193/000098/form3.xml"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="0000000098-26-000001",
+            url=url,
+        )
+        fetcher = _StubFetcher({url: "<not-an-ownership-doc/>"})
+
+        result = ingest_form_3_filings(ebull_test_conn, fetcher)
+        assert result.parse_misses == 1
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT is_tombstone FROM insider_filings WHERE accession_number = '0000000098-26-000001'")
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] is True
+
+
+class TestScoping:
+    def test_form_4_filings_are_not_picked_up_by_form_3_ingester(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        # Form 4 in filing_events with no Form 3 — universe-wide scan
+        # should report zero candidates (filing_type = '4' fails the
+        # candidate selector's IN ('3', '3/A')).
+        iid = _seed_instrument(ebull_test_conn)
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="0000000097-26-000001",
+            url="https://example.test/form4.xml",
+            filing_type="4",
+        )
+        fetcher = _StubFetcher({})
+
+        result = ingest_form_3_filings(ebull_test_conn, fetcher)
+        assert result.filings_scanned == 0
+        # Fetch was never called.
+        assert fetcher.calls == []
+
+    def test_per_instrument_scope_excludes_other_instruments(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid_a = _seed_instrument(ebull_test_conn, iid=991, symbol="AAPL")
+        iid_b = _seed_instrument(ebull_test_conn, iid=992, symbol="MSFT")
+        url_a = "https://example.test/aapl-form3.xml"
+        url_b = "https://example.test/msft-form3.xml"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid_a,
+            accession="0000000091-26-000001",
+            url=url_a,
+        )
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid_b,
+            accession="0000000092-26-000001",
+            url=url_b,
+        )
+        fetcher = _StubFetcher({url_a: _FORM_3_RICH, url_b: _FORM_3_RICH})
+
+        result = ingest_form_3_filings_for_instrument(
+            ebull_test_conn,
+            fetcher,
+            instrument_id=iid_a,
+        )
+        assert result.filings_scanned == 1
+        assert result.filings_parsed == 1
+        # Only the AAPL URL should have been fetched.
+        assert fetcher.calls == [url_a]
+
+
+class TestIdempotency:
+    def test_rerun_refreshes_holdings_and_drops_stale_rows(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # Re-parse drops rows that no longer appear in the latest XML.
+        # Simulated by ingesting the rich XML, then ingesting a smaller
+        # XML at the same accession (parser version "bump" simulated
+        # by stripping the derivative table).
+        iid = _seed_instrument(ebull_test_conn)
+        url = "https://example.test/form3.xml"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="0000000093-26-000001",
+            url=url,
+        )
+
+        fetcher_v1 = _StubFetcher({url: _FORM_3_RICH})
+        ingest_form_3_filings(ebull_test_conn, fetcher_v1)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM insider_initial_holdings WHERE accession_number = '0000000093-26-000001'")
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == 2
+
+        # Re-ingest at the same accession would normally short-circuit
+        # via the "no existing insider_filings row" gate. To exercise
+        # the upsert path explicitly, call upsert_form_3_filing
+        # directly with the new parsed shape.
+        from app.services.insider_form3_ingest import upsert_form_3_filing
+        from app.services.insider_transactions import parse_form_3_xml
+
+        smaller = _FORM_3_RICH.split("<derivativeTable>")[0] + _FORM_3_RICH.split("</derivativeTable>")[1]
+        parsed = parse_form_3_xml(smaller)
+        assert parsed is not None
+
+        upsert_form_3_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession_number="0000000093-26-000001",
+            primary_document_url=url,
+            parsed=parsed,
+        )
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM insider_initial_holdings WHERE accession_number = '0000000093-26-000001'")
+            row = cur.fetchone()
+            assert row is not None
+            # Stale derivative row dropped; only the non-derivative
+            # row remains.
+            assert row[0] == 1
+
+
+class TestStaleChildCleanup:
+    def test_reparse_to_smaller_xml_drops_stale_footnotes_and_filers(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        # Codex review of #768 PR2: the original "replace-on-reparse"
+        # contract only DELETE-then-INSERT'd holdings. Footnotes and
+        # filers were ON CONFLICT-only — a parser version that stops
+        # emitting a footnote or secondary filer would leave the
+        # stale rows pinned to the accession. Pin the cleanup
+        # behaviour so a future regression of either DELETE is caught.
+        from app.services.insider_form3_ingest import upsert_form_3_filing
+        from app.services.insider_transactions import parse_form_3_xml
+
+        iid = _seed_instrument(ebull_test_conn)
+        url = "https://example.test/form3.xml"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="0000000095-26-000001",
+            url=url,
+        )
+        # First parse — rich XML with one footnote.
+        parsed_v1 = parse_form_3_xml(_FORM_3_RICH)
+        assert parsed_v1 is not None
+        upsert_form_3_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession_number="0000000095-26-000001",
+            primary_document_url=url,
+            parsed=parsed_v1,
+        )
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM insider_transaction_footnotes WHERE accession_number = '0000000095-26-000001'"
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == 1
+
+        # Second parse — strip the footnote from the XML.
+        smaller = _FORM_3_RICH.split("<footnotes>")[0] + _FORM_3_RICH.split("</footnotes>")[1]
+        parsed_v2 = parse_form_3_xml(smaller)
+        assert parsed_v2 is not None
+        assert len(parsed_v2.footnotes) == 0
+
+        upsert_form_3_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession_number="0000000095-26-000001",
+            primary_document_url=url,
+            parsed=parsed_v2,
+        )
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM insider_transaction_footnotes WHERE accession_number = '0000000095-26-000001'"
+            )
+            row = cur.fetchone()
+            assert row is not None
+            # Stale footnote dropped on reparse.
+            assert row[0] == 0
+
+
+class TestAmendmentPath:
+    def test_3a_amendment_filing_picked_up_by_candidate_selector(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        # filing_type IN ('3', '3/A') in the selector — confirm 3/A
+        # amendments aren't accidentally excluded by an over-tight
+        # equality predicate.
+        iid = _seed_instrument(ebull_test_conn)
+        url = "https://example.test/form3a.xml"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="0000000096-26-000001",
+            url=url,
+            filing_type="3/A",
+        )
+        amended_xml = _FORM_3_RICH.replace(
+            "<documentType>3</documentType>",
+            "<documentType>3/A</documentType>",
+        )
+        fetcher = _StubFetcher({url: amended_xml})
+
+        result = ingest_form_3_filings(ebull_test_conn, fetcher)
+        assert result.filings_parsed == 1
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT document_type FROM insider_filings WHERE accession_number = '0000000096-26-000001'")
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "3/A"
+
+
+class TestUrlCanonicalisation:
+    def test_xsl_rendered_url_normalised_before_fetch(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # SEC primaryDocument for Forms 3/4/5 commonly points at an
+        # XSL-rendered HTML view. The candidate selector strips the
+        # xslF345 prefix so the fetcher pulls raw XML, not HTML.
+        # Reuses the Form 4 helper (the prefix is shared across forms).
+        iid = _seed_instrument(ebull_test_conn)
+        rendered = "https://www.sec.gov/Archives/edgar/data/320193/000099/xslF345X06/form3.xml"
+        canonical = "https://www.sec.gov/Archives/edgar/data/320193/000099/form3.xml"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="0000000094-26-000001",
+            url=rendered,
+        )
+        fetcher = _StubFetcher({canonical: _FORM_3_RICH})
+
+        ingest_form_3_filings(ebull_test_conn, fetcher)
+        # Fetch hit the canonical URL, not the rendered one.
+        assert fetcher.calls == [canonical]


### PR DESCRIPTION
## What

PR 2 of N for #768. The fetch + parse + upsert path on top of PR 1's parser. ``ingest_form_3_filings`` walks ``filing_events`` for Form 3/3-A accessions without an ``insider_filings`` row, fetches each XML through the shared SEC fetcher, parses, and upserts across four tables.

## Why

PR 1 shipped the parser + ``insider_initial_holdings`` table; without an ingester they're dead weight. PR 3 will fold the Form 3 baseline into ``get_insider_summary`` so the cumulative running total surfaces on the ownership card.

## Test plan

- [x] 9 integration tests covering: rich happy path (4-table writes), fetch-404 + parse-miss tombstones, Form 4 not picked up by Form 3 ingester, per-instrument scope, idempotency, stale-child cleanup on reparse, ``3/A`` amendment path, XSL URL canonicalisation.
- [x] Pre-push gates: ruff / format / pyright / dark-class — all green.

## Codex review (CLAUDE.md checkpoint 2)

- **MEDIUM (FIXED)**: ``replace-on-reparse`` was only true for holdings. Footnotes + filers were ``ON CONFLICT``-only — a parser version that stops emitting a footnote / secondary joint-filer would leave stale rows pinned forever. Added DELETE-then-INSERT for both, mirroring holdings.
- **HIGH (DEFERRED to PR 3 with explicit precondition)**: Some SEC ingest paths store ``primary_document_url`` as ``-index.htm`` rather than the raw XML. If Form 3 rows land in ``filing_events`` via that path, the ingester would tombstone valid filings. This is the **same shape risk the existing Form 4 ingester carries today**; both assume an XML primary doc URL. PR 3 wires the scheduler tick that decides which Form 3 URLs end up in ``filing_events``, so PR 3 is the natural home for the fix.

Refs #768.