### PR TITLE
feat(#768): scheduler tick + baseline-only insider reader (PR 3/N)

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -77,6 +77,7 @@ from app.workers.scheduler import (
     JOB_SEC_BUSINESS_SUMMARY_INGEST,
     JOB_SEC_DIVIDEND_CALENDAR_INGEST,
     JOB_SEC_FILING_DOCUMENTS_INGEST,
+    JOB_SEC_FORM3_INGEST,
     JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL,
     JOB_SEC_INSIDER_TRANSACTIONS_INGEST,
     JOB_SEED_COST_MODELS,
@@ -108,6 +109,7 @@ from app.workers.scheduler import (
     sec_business_summary_ingest,
     sec_dividend_calendar_ingest,
     sec_filing_documents_ingest,
+    sec_form3_ingest,
     sec_insider_transactions_backfill,
     sec_insider_transactions_ingest,
     seed_cost_models,
@@ -163,6 +165,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_SEC_DIVIDEND_CALENDAR_INGEST: sec_dividend_calendar_ingest,
     JOB_SEC_INSIDER_TRANSACTIONS_INGEST: sec_insider_transactions_ingest,
     JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL: sec_insider_transactions_backfill,
+    JOB_SEC_FORM3_INGEST: sec_form3_ingest,
     JOB_SEC_8K_EVENTS_INGEST: sec_8k_events_ingest,
     JOB_SEC_FILING_DOCUMENTS_INGEST: sec_filing_documents_ingest,
 }

--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
 from typing import Any, Protocol
 
 import psycopg
@@ -568,3 +570,137 @@ def _process_form_3_candidates(
         fetch_errors=fetch_errors,
         parse_misses=parse_misses,
     )
+
+
+# ---------------------------------------------------------------------
+# Reader — baseline-only insider holdings (#768 PR 3)
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BaselineInsiderHolding:
+    """Form 3 holding for a filer who has no Form 4 activity on file
+    for this instrument.
+
+    These are the operationally-meaningful "invisible insiders" — they
+    received a grant on appointment, never traded after, and therefore
+    never produced a Form 4 row. Without surfacing the baseline
+    snapshot, the per-filer ownership ring under-counts current
+    insiders.
+
+    The ingester writes one row per holding-line in a Form 3 (non-
+    derivative + derivative interleaved). The reader here aggregates
+    to one row per (filer_cik, security_title, is_derivative) and
+    picks the latest ``as_of_date`` per group, mirroring the Form 4
+    reader's ``post_transaction_shares`` latest-observation pattern.
+    """
+
+    filer_cik: str
+    filer_name: str
+    filer_role: str | None
+    security_title: str | None
+    is_derivative: bool
+    direct_indirect: str | None
+    shares: Decimal | None
+    value_owned: Decimal | None
+    as_of_date: date
+
+
+def list_baseline_only_insider_holdings(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+) -> list[BaselineInsiderHolding]:
+    """Return Form 3 baseline holdings for filers who have *no* Form 4
+    transaction on file for this instrument.
+
+    Filers with any non-tombstoned Form 4 row in
+    ``insider_transactions`` are excluded — their cumulative balance
+    is already derivable from
+    :func:`app.services.insider_transactions.list_insider_transactions`
+    via the latest ``post_transaction_shares`` observation. Returning
+    them here would double-count the per-filer ring 3 wedge.
+
+    Tombstoned Form 3 filings (fetch / parse failures) excluded via an
+    INNER JOIN to ``insider_filings`` with ``is_tombstone = FALSE``,
+    matching the convention used by ``get_insider_summary``.
+
+    Returns rows ordered by ``shares DESC NULLS LAST`` so the consumer
+    can render largest-first without a second pass.
+    """
+    rows: list[BaselineInsiderHolding] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            WITH baseline AS (
+                SELECT DISTINCT ON (
+                    iih.filer_cik, iih.security_title, iih.is_derivative
+                )
+                    iih.filer_cik,
+                    iih.filer_name,
+                    iih.filer_role,
+                    iih.security_title,
+                    iih.is_derivative,
+                    iih.direct_indirect,
+                    iih.shares,
+                    iih.value_owned,
+                    iih.as_of_date
+                FROM insider_initial_holdings iih
+                INNER JOIN insider_filings f
+                    ON f.accession_number = iih.accession_number
+                   AND f.is_tombstone = FALSE
+                WHERE iih.instrument_id = %s
+                ORDER BY
+                    iih.filer_cik,
+                    iih.security_title,
+                    iih.is_derivative,
+                    -- Tie-break in priority order:
+                    --   1. Latest as_of_date (period_of_report) wins.
+                    --   2. Within the same as_of_date (the realistic
+                    --      3/A case where the amendment keeps the
+                    --      original snapshot date), prefer the larger
+                    --      accession_number — within a filer, SEC
+                    --      assigns monotonically increasing
+                    --      sequence numbers, so the amendment's
+                    --      accession sorts after the original. Codex
+                    --      review of #768 PR3 caught the original
+                    --      ordering's silent loss of amendment
+                    --      precedence.
+                    --   3. Within the same accession (option exposure
+                    --      vs underlying-equity rows on a single
+                    --      filing), prefer the lower row_num so the
+                    --      first listed holding wins.
+                    iih.as_of_date DESC,
+                    iih.accession_number DESC,
+                    iih.row_num ASC
+            )
+            SELECT b.*
+            FROM baseline b
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM insider_transactions it
+                INNER JOIN insider_filings ft
+                    ON ft.accession_number = it.accession_number
+                   AND ft.is_tombstone = FALSE
+                WHERE it.instrument_id = %s
+                  AND it.filer_cik = b.filer_cik
+            )
+            ORDER BY b.shares DESC NULLS LAST, b.filer_name ASC
+            """,
+            (instrument_id, instrument_id),
+        )
+        for row in cur.fetchall():
+            rows.append(
+                BaselineInsiderHolding(
+                    filer_cik=str(row[0]),
+                    filer_name=str(row[1]),
+                    filer_role=row[2],
+                    security_title=row[3],
+                    is_derivative=bool(row[4]),
+                    direct_indirect=row[5],
+                    shares=Decimal(row[6]) if row[6] is not None else None,
+                    value_owned=Decimal(row[7]) if row[7] is not None else None,
+                    as_of_date=row[8],
+                )
+            )
+    return rows

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -241,6 +241,7 @@ JOB_SEC_BUSINESS_SUMMARY_INGEST = "sec_business_summary_ingest"
 JOB_SEC_BUSINESS_SUMMARY_BOOTSTRAP = "sec_business_summary_bootstrap"
 JOB_SEC_INSIDER_TRANSACTIONS_INGEST = "sec_insider_transactions_ingest"
 JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL = "sec_insider_transactions_backfill"
+JOB_SEC_FORM3_INGEST = "sec_form3_ingest"
 JOB_SEC_8K_EVENTS_INGEST = "sec_8k_events_ingest"
 JOB_SEC_FILING_DOCUMENTS_INGEST = "sec_filing_documents_ingest"
 JOB_EXCHANGES_METADATA_REFRESH = "exchanges_metadata_refresh"
@@ -576,6 +577,23 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "the historical tail drains predictably."
         ),
         cadence=Cadence.hourly(minute=45),
+        catch_up_on_boot=False,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_FORM3_INGEST,
+        description=(
+            "Parse SEC Form 3 filings into ``insider_initial_holdings`` "
+            "(#768). Form 3 is the per-officer initial-snapshot filing "
+            "(once per appointment); volume per issuer is bounded "
+            "(~5-30 lifetime) and the data isn't time-sensitive once "
+            "captured, so a daily cadence is plenty. Idempotent via "
+            "the (accession, row_num) UNIQUE key on the holdings table; "
+            "parser-version-bump triggers re-parse via the candidate "
+            "selector. Fills the ownership-card gap where insiders who "
+            "held a Form 3 grant but never traded after appointment "
+            "were invisible to the per-filer ring."
+        ),
+        cadence=Cadence.daily(hour=4, minute=20),
         catch_up_on_boot=False,
     ),
     ScheduledJob(
@@ -3197,6 +3215,38 @@ def sec_insider_transactions_ingest() -> None:
         tracker.row_count = result.rows_inserted
         logger.info(
             "sec_insider_transactions_ingest: scanned=%d parsed=%d inserted=%d fetch_errors=%d parse_misses=%d",
+            result.filings_scanned,
+            result.filings_parsed,
+            result.rows_inserted,
+            result.fetch_errors,
+            result.parse_misses,
+        )
+
+
+def sec_form3_ingest() -> None:
+    """Parse SEC Form 3 filings into ``insider_initial_holdings`` (#768).
+
+    Form 3 is the per-officer initial-snapshot filing — one per
+    Section-16 appointment, no transactions. Without this ingest,
+    insiders who get an RSU grant on appointment and never trade
+    after are invisible to the ownership card's per-officer ring
+    (no Form 4 events for them). Daily cadence is plenty: Form 3
+    volume is bounded (~5-30 lifetime per issuer) and the snapshot
+    isn't time-sensitive once captured.
+    """
+    from app.providers.implementations.sec_edgar import SecFilingsProvider
+    from app.services.insider_form3_ingest import ingest_form_3_filings
+
+    with _tracked_job(JOB_SEC_FORM3_INGEST) as tracker:
+        with (
+            psycopg.connect(settings.database_url) as conn,
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as provider,
+        ):
+            result = ingest_form_3_filings(conn, provider)
+
+        tracker.row_count = result.rows_inserted
+        logger.info(
+            "sec_form3_ingest: scanned=%d parsed=%d inserted=%d fetch_errors=%d parse_misses=%d",
             result.filings_scanned,
             result.filings_parsed,
             result.rows_inserted,

--- a/sql/094_insider_transactions_filer_cik_index.sql
+++ b/sql/094_insider_transactions_filer_cik_index.sql
@@ -1,0 +1,33 @@
+-- 094_insider_transactions_filer_cik_index.sql
+--
+-- Composite (instrument_id, filer_cik) index on insider_transactions
+-- (#768 PR 3 — Codex review).
+--
+-- The Form 3 baseline-only reader (``list_baseline_only_insider_holdings``)
+-- runs a NOT EXISTS anti-join against insider_transactions:
+--
+--   WHERE NOT EXISTS (
+--       SELECT 1
+--       FROM insider_transactions it
+--       INNER JOIN insider_filings ft ON ft.accession_number = it.accession_number
+--       WHERE it.instrument_id = ?
+--         AND it.filer_cik    = b.filer_cik
+--   )
+--
+-- Existing indexes on insider_transactions only cover (instrument_id,
+-- txn_date) — migration 056. The new lookup fixes instrument_id AND
+-- filer_cik but not txn_date, so the planner falls back to a scan of
+-- the instrument's Form 4 rows on every probe. At reader scale that
+-- becomes the dominant cost as soon as the ownership card hits a
+-- liquid issuer with hundreds of insiders.
+--
+-- Adding the composite index drops the probe to an index-only scan
+-- and keeps the anti-join cheap as the baseline endpoint becomes
+-- API-backed (#768 PR 4).
+--
+-- Storage note: insider_transactions is medium-volume (~1M rows
+-- expected at full coverage); the index is ~30 MB at that scale —
+-- well below the threshold where an index needs justification.
+
+CREATE INDEX IF NOT EXISTS idx_insider_transactions_instrument_filer_cik
+    ON insider_transactions (instrument_id, filer_cik);

--- a/tests/test_insider_form3_ingest.py
+++ b/tests/test_insider_form3_ingest.py
@@ -22,6 +22,7 @@ import pytest
 from app.services.insider_form3_ingest import (
     ingest_form_3_filings,
     ingest_form_3_filings_for_instrument,
+    list_baseline_only_insider_holdings,
 )
 
 pytestmark = pytest.mark.integration
@@ -600,3 +601,223 @@ class TestUrlCanonicalisation:
         ingest_form_3_filings(ebull_test_conn, fetcher)
         # Fetch hit the canonical URL, not the rendered one.
         assert fetcher.calls == [canonical]
+
+
+# ---------------------------------------------------------------------
+# #768 PR3 — baseline-only reader
+# ---------------------------------------------------------------------
+
+
+def _seed_form_4_for_filer(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    filer_cik: str,
+    filer_name: str,
+    accession: str,
+    txn_date: str = "2026-01-20",
+) -> None:
+    """Plant a non-tombstoned Form 4 row for ``filer_cik`` so the
+    baseline-only reader excludes them. Mirrors what
+    ``ingest_insider_transactions`` would write."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO insider_filings (
+                accession_number, instrument_id, document_type,
+                primary_document_url, parser_version, is_tombstone
+            ) VALUES (%s, %s, '4', 'https://example.test/form4.xml', 1, FALSE)
+            """,
+            (accession, instrument_id),
+        )
+        cur.execute(
+            """
+            INSERT INTO insider_filers (
+                accession_number, filer_cik, filer_name, is_officer
+            ) VALUES (%s, %s, %s, TRUE)
+            """,
+            (accession, filer_cik, filer_name),
+        )
+        cur.execute(
+            """
+            INSERT INTO insider_transactions (
+                instrument_id, accession_number, txn_row_num,
+                filer_name, filer_cik, txn_date, txn_code, shares
+            ) VALUES (%s, %s, 0, %s, %s, %s, 'P', 100)
+            """,
+            (instrument_id, accession, filer_name, filer_cik, txn_date),
+        )
+    conn.commit()
+
+
+class TestBaselineOnlyReader:
+    def test_returns_form_3_holding_when_filer_has_no_form_4_activity(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        # Operationally meaningful case: officer received a Form 3
+        # initial holding and never traded after — invisible without
+        # the baseline reader.
+        iid = _seed_instrument(ebull_test_conn)
+        url = "https://example.test/form3.xml"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="0000000301-26-000001",
+            url=url,
+        )
+        fetcher = _StubFetcher({url: _FORM_3_RICH})
+        ingest_form_3_filings(ebull_test_conn, fetcher)
+
+        rows = list_baseline_only_insider_holdings(ebull_test_conn, instrument_id=iid)
+
+        # _FORM_3_RICH has 2 holdings: 1 non-derivative + 1 derivative.
+        # No Form 4 activity for filer 0001000001 → both surface.
+        assert len(rows) == 2
+        # Largest-first ordering by shares.
+        assert rows[0].is_derivative is False
+        assert rows[0].shares == Decimal("50000")
+        assert rows[1].is_derivative is True
+        assert rows[1].shares == Decimal("10000")
+        assert rows[0].filer_cik == "0001000001"
+        assert rows[0].filer_name == "Smith, Jane"
+
+    def test_excludes_filers_with_form_4_activity(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # Filer who has both Form 3 baseline AND Form 4 transactions
+        # should NOT appear in the baseline-only list — their
+        # cumulative balance is derivable from the latest
+        # post_transaction_shares observation. Including them here
+        # would double-count the per-filer wedge on the ownership
+        # ring.
+        iid = _seed_instrument(ebull_test_conn)
+        url = "https://example.test/form3.xml"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="0000000302-26-000001",
+            url=url,
+        )
+        fetcher = _StubFetcher({url: _FORM_3_RICH})
+        ingest_form_3_filings(ebull_test_conn, fetcher)
+
+        # Plant a Form 4 row for the same filer.
+        _seed_form_4_for_filer(
+            ebull_test_conn,
+            instrument_id=iid,
+            filer_cik="0001000001",
+            filer_name="Smith, Jane",
+            accession="0000000302-26-000002",
+        )
+
+        rows = list_baseline_only_insider_holdings(ebull_test_conn, instrument_id=iid)
+        assert rows == []
+
+    def test_excludes_tombstoned_form_3_filings(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # A tombstoned Form 3 (fetch / parse failure) should not
+        # surface its (zero) holdings via the baseline reader. The
+        # tombstone path writes the filings row but no holdings rows;
+        # this test pins the INNER JOIN exclusion contract by directly
+        # inserting a tombstoned filing + a phantom holding row.
+        iid = _seed_instrument(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO insider_filings (
+                    accession_number, instrument_id, document_type,
+                    primary_document_url, parser_version, is_tombstone
+                ) VALUES (%s, %s, '3', 'https://example.test/dead.xml', 1, TRUE)
+                """,
+                ("0000000303-26-000001", iid),
+            )
+            cur.execute(
+                """
+                INSERT INTO insider_initial_holdings (
+                    instrument_id, accession_number, row_num,
+                    filer_cik, filer_name, as_of_date,
+                    security_title, shares, is_derivative
+                ) VALUES (%s, %s, 0, %s, %s, %s, 'Common Stock', 999, FALSE)
+                """,
+                (iid, "0000000303-26-000001", "0009999998", "Phantom", "2026-01-15"),
+            )
+        ebull_test_conn.commit()
+
+        rows = list_baseline_only_insider_holdings(ebull_test_conn, instrument_id=iid)
+        assert rows == []
+
+    def test_3a_amendment_at_same_as_of_date_supersedes_original(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        # Codex review of #768 PR3: the realistic 3/A case keeps the
+        # same periodOfReport as the original — the tie-break must
+        # prefer the amendment via accession_number. Without the
+        # tie-break the original could win, silently surfacing stale
+        # baseline shares on the ownership ring.
+        iid = _seed_instrument(ebull_test_conn)
+        as_of = "2026-02-01"
+        with ebull_test_conn.cursor() as cur:
+            # Original Form 3 — earlier accession sequence.
+            for accn, doc_type, shares in (
+                ("0000000305-26-000001", "3", 4000),  # original
+                ("0000000305-26-000002", "3/A", 4500),  # amendment, same as_of
+            ):
+                cur.execute(
+                    """
+                    INSERT INTO insider_filings (
+                        accession_number, instrument_id, document_type,
+                        primary_document_url, parser_version, is_tombstone
+                    ) VALUES (%s, %s, %s, 'https://example.test/x.xml', 1, FALSE)
+                    """,
+                    (accn, iid, doc_type),
+                )
+                cur.execute(
+                    """
+                    INSERT INTO insider_initial_holdings (
+                        instrument_id, accession_number, row_num,
+                        filer_cik, filer_name, as_of_date,
+                        security_title, shares, is_derivative
+                    ) VALUES (%s, %s, 0, '0001000300', 'Roe, Richard', %s, 'Common Stock', %s, FALSE)
+                    """,
+                    (iid, accn, as_of, shares),
+                )
+        ebull_test_conn.commit()
+
+        rows = list_baseline_only_insider_holdings(ebull_test_conn, instrument_id=iid)
+        # Amendment wins via accession_number DESC tie-break.
+        assert len(rows) == 1
+        assert rows[0].shares == Decimal("4500")
+        assert rows[0].as_of_date.isoformat() == as_of
+
+    def test_picks_latest_as_of_date_per_filer_security_pair(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # If a filer has two Form 3 amendments (3 + 3/A) for the same
+        # security, the reader must surface only the latest snapshot
+        # — older amendments are superseded.
+        iid = _seed_instrument(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            for accn, as_of, shares in (
+                ("0000000304-26-000001", "2026-01-10", 5000),
+                ("0000000304-26-000002", "2026-03-15", 7500),
+            ):
+                cur.execute(
+                    """
+                    INSERT INTO insider_filings (
+                        accession_number, instrument_id, document_type,
+                        primary_document_url, parser_version, is_tombstone
+                    ) VALUES (%s, %s, '3', 'https://example.test/x.xml', 1, FALSE)
+                    """,
+                    (accn, iid),
+                )
+                cur.execute(
+                    """
+                    INSERT INTO insider_initial_holdings (
+                        instrument_id, accession_number, row_num,
+                        filer_cik, filer_name, as_of_date,
+                        security_title, shares, is_derivative
+                    ) VALUES (%s, %s, 0, '0001000099', 'Doe, John', %s, 'Common Stock', %s, FALSE)
+                    """,
+                    (iid, accn, as_of, shares),
+                )
+        ebull_test_conn.commit()
+
+        rows = list_baseline_only_insider_holdings(ebull_test_conn, instrument_id=iid)
+        assert len(rows) == 1
+        assert rows[0].shares == Decimal("7500")
+        assert rows[0].as_of_date.isoformat() == "2026-03-15"


### PR DESCRIPTION
## What

PR 3 of N for #768. Wires the Form 3 data flow + the reader function the ownership card needs to surface insiders with a Form 3 baseline but no Form 4 activity. Frontend wiring + API endpoint land in PR 4.

## Components

- **Scheduler**: ``sec_form3_ingest`` job (daily 04:20 UTC) + ``_INVOKERS`` registration.
- **Reader**: ``list_baseline_only_insider_holdings(instrument_id)`` — returns Form 3 baseline rows for filers with no non-tombstoned Form 4 transaction. Excludes filers visible via ``insider_transactions`` so the per-filer ring 3 wedge doesn't double-count.
- **Migration 094**: composite ``(instrument_id, filer_cik)`` index on ``insider_transactions`` to support the reader's NOT EXISTS anti-join.

## Test plan

- [x] 5 new reader tests: happy path, Form-4-filer exclusion, tombstone exclusion, latest-as_of_date selection, **3/A same-as_of_date tie-break**.
- [x] 16 ingester tests still pass.
- [x] ``test_jobs_runtime.py`` parity (35 tests) — invoker map ↔ registry stays in sync.
- [x] Pre-push gates: ruff / format / pyright — all green.

## Codex review (CLAUDE.md checkpoint 2) — both findings fixed

- **HIGH (FIXED)**: 3/A amendments share ``periodOfReport`` with the original. Original ``DISTINCT ON`` ordering tie-broke on ``row_num``, which doesn't distinguish original from amendment. Added ``accession_number DESC`` tie-break (within a filer, SEC accession sequence numbers monotonically increase). Regression test added.
- **MEDIUM (FIXED)**: ``insider_transactions`` had no ``(instrument_id, filer_cik)`` index for the NOT EXISTS anti-join. Migration 094 adds one — drops the probe to an index-only scan at reader scale.

Refs #768.