### PR TITLE
feat(#768): API endpoint + ownership-card wiring for baseline insiders (PR 4/N)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -1161,7 +1161,7 @@ class EightKFilingsResponse(BaseModel):
 # wires a single provider; per-region integration PRs add more.
 _EIGHT_K_PROVIDERS: tuple[str, ...] = ("sec_8k_events",)
 _DIVIDEND_PROVIDERS: tuple[str, ...] = ("sec_dividend_summary",)
-_INSIDER_PROVIDERS: tuple[str, ...] = ("sec_form4",)
+_INSIDER_PROVIDERS: tuple[str, ...] = ("sec_form4", "sec_form3")
 
 
 def _validate_provider(provider: str | None, allowed: tuple[str, ...]) -> None:
@@ -1998,6 +1998,114 @@ def get_instrument_insider_transactions(
                 footnotes=d.footnotes,
             )
             for d in detail_rows
+        ],
+    )
+
+
+# ---------------------------------------------------------------------
+# Form 3 baseline-only insider holdings (#768 PR 4)
+# ---------------------------------------------------------------------
+#
+# Surfaces insiders who hold a Form 3 baseline grant but have no Form 4
+# activity on file — the "invisible insiders" the ownership card
+# currently misses (RSU on appointment, never traded after). Frontend
+# merges these rows with the Form 4 holders to produce the per-officer
+# ring 3 wedges.
+
+
+class InsiderBaselineHoldingModel(BaseModel):
+    filer_cik: str
+    filer_name: str
+    filer_role: str | None
+    security_title: str | None
+    is_derivative: bool
+    direct_indirect: str | None  # 'D' / 'I' / None
+    shares: Decimal | None
+    value_owned: Decimal | None
+    as_of_date: date
+
+
+class InsiderBaselineListModel(BaseModel):
+    symbol: str
+    rows: list[InsiderBaselineHoldingModel]
+
+
+@router.get(
+    "/{symbol}/insider_baseline",
+    response_model=InsiderBaselineListModel,
+)
+def get_instrument_insider_baseline(
+    symbol: str,
+    provider: str | None = Query(
+        default=None,
+        description="Capability provider tag. Today only 'sec_form3'.",
+    ),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> InsiderBaselineListModel:
+    """Return Form 3 baseline holdings for filers with no Form 4
+    activity on file (#768 PR 4).
+
+    Operationally meaningful slice: officers who received an RSU /
+    initial grant on appointment and never traded after are invisible
+    to the per-filer ring 3 today (no Form 4 events for them). The
+    ownership panel merges these rows with the Form 4 holders to
+    surface the complete current insider population.
+
+    Filers with any non-tombstoned Form 4 row are excluded — their
+    cumulative balance is already derivable from the latest
+    ``post_transaction_shares`` observation on the
+    ``insider_transactions`` reader. Including them here would
+    double-count the per-filer wedge.
+
+    Empty-state contract: a non-covered or pre-ingest instrument
+    returns ``200`` with ``rows=[]``. Reserved 404 for unknown
+    symbol or no SEC coverage (matches the existing
+    ``/insider_transactions`` endpoint).
+    """
+    from app.services.insider_form3_ingest import list_baseline_only_insider_holdings
+
+    _validate_provider(provider, _INSIDER_PROVIDERS)
+
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    if not _has_sec_cik(conn, instrument_id):
+        # Form 3 is an SEC filing — no SEC CIK = no source.
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} has no SEC coverage")
+
+    holdings = list_baseline_only_insider_holdings(conn, instrument_id=instrument_id)
+    return InsiderBaselineListModel(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        rows=[
+            InsiderBaselineHoldingModel(
+                filer_cik=h.filer_cik,
+                filer_name=h.filer_name,
+                filer_role=h.filer_role,
+                security_title=h.security_title,
+                is_derivative=h.is_derivative,
+                direct_indirect=h.direct_indirect,
+                shares=h.shares,
+                value_owned=h.value_owned,
+                as_of_date=h.as_of_date,
+            )
+            for h in holdings
         ],
     )
 

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -1161,7 +1161,12 @@ class EightKFilingsResponse(BaseModel):
 # wires a single provider; per-region integration PRs add more.
 _EIGHT_K_PROVIDERS: tuple[str, ...] = ("sec_8k_events",)
 _DIVIDEND_PROVIDERS: tuple[str, ...] = ("sec_dividend_summary",)
-_INSIDER_PROVIDERS: tuple[str, ...] = ("sec_form4", "sec_form3")
+_INSIDER_PROVIDERS: tuple[str, ...] = ("sec_form4",)
+# Form 3 baseline (#768 PR 4) — separate tuple so a stray
+# ``?provider=sec_form3`` on the Form 4 endpoint fails validation
+# rather than silently passing through to a reader that doesn't
+# consume it. PR #774 review caught the cross-contamination risk.
+_INSIDER_BASELINE_PROVIDERS: tuple[str, ...] = ("sec_form3",)
 
 
 def _validate_provider(provider: str | None, allowed: tuple[str, ...]) -> None:
@@ -2064,7 +2069,7 @@ def get_instrument_insider_baseline(
     """
     from app.services.insider_form3_ingest import list_baseline_only_insider_holdings
 
-    _validate_provider(provider, _INSIDER_PROVIDERS)
+    _validate_provider(provider, _INSIDER_BASELINE_PROVIDERS)
 
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -354,6 +354,56 @@ export function fetchInsiderTransactions(
   );
 }
 
+/** Form 3 baseline insider holding (#768 PR 4). Per-officer initial-
+ *  snapshot from a Form 3 filing, surfaced only when the filer has
+ *  no Form 4 activity on file (otherwise the cumulative balance is
+ *  derivable from the latest ``post_transaction_shares`` observation
+ *  on the ``insider_transactions`` reader). */
+export interface InsiderBaselineHolding {
+  filer_cik: string;
+  filer_name: string;
+  filer_role: string | null;
+  security_title: string | null;
+  is_derivative: boolean;
+  direct_indirect: string | null;
+  shares: string | null;
+  value_owned: string | null;
+  as_of_date: string;
+}
+
+export interface InsiderBaselineList {
+  symbol: string;
+  rows: InsiderBaselineHolding[];
+}
+
+/** Baseline-only insider holdings for an instrument. Returns
+ *  ``rows: []`` for non-covered or pre-ingest issuers (200, not
+ *  404 — same empty-state contract as ``insider_transactions``).
+ *  404 only on unknown symbol or no SEC coverage. */
+export async function fetchInsiderBaseline(
+  symbol: string,
+  provider?: string,
+): Promise<InsiderBaselineList> {
+  const params = new URLSearchParams();
+  if (provider !== undefined) params.set("provider", provider);
+  const qs = params.toString();
+  const suffix = qs.length > 0 ? `?${qs}` : "";
+  try {
+    return await apiFetch<InsiderBaselineList>(
+      `/instruments/${encodeURIComponent(symbol)}/insider_baseline${suffix}`,
+    );
+  } catch (err) {
+    const { ApiError } = await import("@/api/client");
+    // No SEC coverage / unknown symbol: treat as empty rather than
+    // breaking the panel render. Matches the existing
+    // ``fetchInstrumentEmployees`` 404-tolerance pattern.
+    if (err instanceof ApiError && err.status === 404) {
+      return { symbol, rows: [] };
+    }
+    throw err;
+  }
+}
+
 export interface InstrumentHeadcount {
   symbol: string;
   employees: number;

--- a/frontend/src/components/instrument/OwnershipPanel.test.ts
+++ b/frontend/src/components/instrument/OwnershipPanel.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for the ownership panel's data extraction.
+ *
+ * Focused on the Form 3 baseline merging behaviour added in #768 PR4.
+ * The full panel is React+ResponsiveContainer-heavy and not amenable
+ * to a fast unit test; we test the pure ``extractData`` helper that
+ * decides which insider holders surface on the per-officer ring.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  InsiderBaselineList,
+  InsiderTransactionsList,
+} from "@/api/instruments";
+import type { InstitutionalHoldingsResponse } from "@/api/institutionalHoldings";
+import type { InstrumentFinancials } from "@/api/types";
+
+import { extractData } from "./OwnershipPanel";
+
+const _BALANCE: InstrumentFinancials = {
+  symbol: "AAPL",
+  statement: "balance",
+  period: "quarterly",
+  currency: "USD",
+  source: "sec_xbrl",
+  rows: [
+    {
+      period_end: "2026-03-28",
+      values: {
+        shares_outstanding: "14000000000",
+        treasury_shares: "100000000",
+      },
+    },
+  ],
+} as unknown as InstrumentFinancials;
+
+const _EMPTY_INSTITUTIONAL: InstitutionalHoldingsResponse = {
+  symbol: "AAPL",
+  totals: null,
+  filers: [],
+};
+
+const _EMPTY_INSIDERS: InsiderTransactionsList = {
+  symbol: "AAPL",
+  rows: [],
+};
+
+const _EMPTY_BASELINE: InsiderBaselineList = {
+  symbol: "AAPL",
+  rows: [],
+};
+
+describe("extractData — Form 3 baseline merging (#768 PR4)", () => {
+  it("returns no insider holders when both Form 4 and baseline are empty", () => {
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE);
+    expect(data.insider_holders).toHaveLength(0);
+    expect(data.insiders_total).toBeNull();
+  });
+
+  it("surfaces baseline-only filers on the insider holders list", () => {
+    const baseline: InsiderBaselineList = {
+      symbol: "AAPL",
+      rows: [
+        {
+          filer_cik: "0001000099",
+          filer_name: "Doe, Jane",
+          filer_role: "officer:CFO",
+          security_title: "Common Stock",
+          is_derivative: false,
+          direct_indirect: "D",
+          shares: "12500",
+          value_owned: null,
+          as_of_date: "2026-01-15",
+        },
+      ],
+    };
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline);
+    expect(data.insider_holders).toHaveLength(1);
+    expect(data.insider_holders[0]!.label).toBe("Doe, Jane");
+    expect(data.insider_holders[0]!.shares).toBe(12500);
+    expect(data.insiders_total).toBe(12500);
+  });
+
+  it("merges Form 4 holders with baseline filers without overlap", () => {
+    // Backend's NOT EXISTS gate guarantees no CIK overlap between
+    // the two sets, but the frontend must additionally key the
+    // baseline rows under a distinct ``baseline:`` prefix so a
+    // future bug in the gate doesn't cause two same-CIK rows to
+    // collide on the same SunburstHolder.key (Recharts would
+    // silently drop one).
+    const insiders: InsiderTransactionsList = {
+      symbol: "AAPL",
+      rows: [
+        {
+          filer_cik: "0001000001",
+          filer_name: "Smith, John",
+          txn_date: "2026-04-15",
+          post_transaction_shares: "50000",
+          is_derivative: false,
+        },
+      ] as InsiderTransactionsList["rows"],
+    };
+    const baseline: InsiderBaselineList = {
+      symbol: "AAPL",
+      rows: [
+        {
+          filer_cik: "0001000099",
+          filer_name: "Doe, Jane",
+          filer_role: "officer:CFO",
+          security_title: "Common Stock",
+          is_derivative: false,
+          direct_indirect: "D",
+          shares: "12500",
+          value_owned: null,
+          as_of_date: "2026-01-15",
+        },
+      ],
+    };
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, insiders, baseline);
+    expect(data.insider_holders).toHaveLength(2);
+    const keys = data.insider_holders.map((h) => h.key);
+    expect(new Set(keys).size).toBe(2); // no key collision
+    expect(keys.some((k) => k.startsWith("baseline:"))).toBe(true);
+    // Total sums Form 4 + baseline.
+    expect(data.insiders_total).toBe(62500);
+  });
+
+  it("drops baseline rows with null or non-positive shares", () => {
+    // A baseline row with a null share count (e.g. value-branch
+    // holding without a share count, or a malformed ingest) must
+    // not produce a phantom wedge.
+    const baseline: InsiderBaselineList = {
+      symbol: "AAPL",
+      rows: [
+        {
+          filer_cik: "0001000099",
+          filer_name: "Null Filer",
+          filer_role: null,
+          security_title: "Series A Units",
+          is_derivative: false,
+          direct_indirect: "D",
+          shares: null,
+          value_owned: "250000",
+          as_of_date: "2026-01-15",
+        },
+        {
+          filer_cik: "0001000100",
+          filer_name: "Zero Filer",
+          filer_role: null,
+          security_title: "Common Stock",
+          is_derivative: false,
+          direct_indirect: "D",
+          shares: "0",
+          value_owned: null,
+          as_of_date: "2026-01-15",
+        },
+      ],
+    };
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline);
+    expect(data.insider_holders).toHaveLength(0);
+  });
+
+  it("insiders_as_of takes the max of latest Form 4 txn_date and baseline as_of_date", () => {
+    // Issuer with one Form 4 row from 2026-02-10 and one baseline
+    // row from 2026-04-01 — the baseline date is more recent so
+    // the chip's "as of" reflects the baseline.
+    const insiders: InsiderTransactionsList = {
+      symbol: "AAPL",
+      rows: [
+        {
+          filer_cik: "0001000001",
+          filer_name: "Smith, John",
+          txn_date: "2026-02-10",
+          post_transaction_shares: "100",
+          is_derivative: false,
+        },
+      ] as InsiderTransactionsList["rows"],
+    };
+    const baseline: InsiderBaselineList = {
+      symbol: "AAPL",
+      rows: [
+        {
+          filer_cik: "0001000099",
+          filer_name: "Doe, Jane",
+          filer_role: null,
+          security_title: "Common Stock",
+          is_derivative: false,
+          direct_indirect: "D",
+          shares: "5000",
+          value_owned: null,
+          as_of_date: "2026-04-01",
+        },
+      ],
+    };
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, insiders, baseline);
+    expect(data.insiders_as_of).toBe("2026-04-01");
+  });
+
+  it("when Form 4 is newer than baseline, insiders_as_of takes the Form 4 date (Codex coverage gap)", () => {
+    const insiders: InsiderTransactionsList = {
+      symbol: "AAPL",
+      rows: [
+        {
+          filer_cik: "0001000001",
+          filer_name: "Smith, John",
+          txn_date: "2026-04-15",
+          post_transaction_shares: "50000",
+          is_derivative: false,
+        },
+      ] as InsiderTransactionsList["rows"],
+    };
+    const baseline: InsiderBaselineList = {
+      symbol: "AAPL",
+      rows: [
+        {
+          filer_cik: "0001000099",
+          filer_name: "Doe, Jane",
+          filer_role: null,
+          security_title: "Common Stock",
+          is_derivative: false,
+          direct_indirect: "D",
+          shares: "5000",
+          value_owned: null,
+          as_of_date: "2025-11-30",
+        },
+      ],
+    };
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, insiders, baseline);
+    // Form 4 (2026-04-15) is newer than baseline (2025-11-30) — chip
+    // takes the Form 4 date so the chip stays in lockstep with the
+    // most recent insider activity. An older baseline never silently
+    // overrides a newer trade.
+    expect(data.insiders_as_of).toBe("2026-04-15");
+  });
+
+  it("baseline-only issuer (no Form 4 rows) still produces an Insiders as_of_date", () => {
+    const baseline: InsiderBaselineList = {
+      symbol: "AAPL",
+      rows: [
+        {
+          filer_cik: "0001000099",
+          filer_name: "Doe, Jane",
+          filer_role: null,
+          security_title: "Common Stock",
+          is_derivative: false,
+          direct_indirect: "D",
+          shares: "5000",
+          value_owned: null,
+          as_of_date: "2026-03-10",
+        },
+      ],
+    };
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline);
+    expect(data.insiders_as_of).toBe("2026-03-10");
+  });
+});

--- a/frontend/src/components/instrument/OwnershipPanel.test.ts
+++ b/frontend/src/components/instrument/OwnershipPanel.test.ts
@@ -159,6 +159,11 @@ describe("extractData — Form 3 baseline merging (#768 PR4)", () => {
     };
     const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline);
     expect(data.insider_holders).toHaveLength(0);
+    // Codex / bot review of #768 PR4: the freshness chip's
+    // ``insiders_as_of`` must use the same eligibility predicate as
+    // the holders builder. A null/zero-shares baseline row that
+    // never renders must not advance the chip past the actual ring.
+    expect(data.insiders_as_of).toBeNull();
   });
 
   it("insiders_as_of takes the max of latest Form 4 txn_date and baseline as_of_date", () => {

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -34,10 +34,14 @@ import type {
   InstitutionalHoldingsResponse,
 } from "@/api/institutionalHoldings";
 import {
+  fetchInsiderBaseline,
   fetchInsiderTransactions,
   fetchInstrumentFinancials,
 } from "@/api/instruments";
-import type { InsiderTransactionsList } from "@/api/instruments";
+import type {
+  InsiderBaselineList,
+  InsiderTransactionsList,
+} from "@/api/instruments";
 import type { InstrumentFinancials } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { OwnershipFreshnessChips } from "@/components/instrument/OwnershipFreshnessChips";
@@ -121,6 +125,11 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
     [symbol],
   );
 
+  const baselineState = useAsync<InsiderBaselineList>(
+    useCallback(() => fetchInsiderBaseline(symbol), [symbol]),
+    [symbol],
+  );
+
   const navigate = useNavigate();
   const handleWedgeClick = useCallback(
     (target: WedgeClick) => {
@@ -140,14 +149,16 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
   const isLoading =
     balanceState.loading ||
     institutionalState.loading ||
-    insidersState.loading;
+    insidersState.loading ||
+    baselineState.loading;
   const allErrored =
     balanceState.error !== null &&
     institutionalState.error !== null &&
-    insidersState.error !== null;
+    insidersState.error !== null &&
+    baselineState.error !== null;
 
   return (
-    <Pane title="Ownership" source={{ providers: ["sec_13f", "sec_form4", "sec_xbrl"] }}>
+    <Pane title="Ownership" source={{ providers: ["sec_13f", "sec_form3", "sec_form4", "sec_xbrl"] }}>
       {isLoading ? (
         <SectionSkeleton rows={4} />
       ) : allErrored ? (
@@ -156,6 +167,7 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
             balanceState.refetch();
             institutionalState.refetch();
             insidersState.refetch();
+            baselineState.refetch();
           }}
         />
       ) : (
@@ -163,6 +175,7 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
           balance={balanceState.data}
           institutional={institutionalState.data}
           insiders={insidersState.data}
+          baseline={baselineState.data}
           onWedgeClick={handleWedgeClick}
         />
       )}
@@ -174,6 +187,7 @@ interface PanelBodyProps {
   readonly balance: InstrumentFinancials | null;
   readonly institutional: InstitutionalHoldingsResponse | null;
   readonly insiders: InsiderTransactionsList | null;
+  readonly baseline: InsiderBaselineList | null;
   readonly onWedgeClick: (target: WedgeClick) => void;
 }
 
@@ -186,16 +200,22 @@ function PanelBody({
   balance,
   institutional,
   insiders,
+  baseline,
   onWedgeClick,
 }: PanelBodyProps): JSX.Element {
   const today = useMemo(() => new Date(), []);
-  return renderBody(extractData(balance, institutional, insiders), onWedgeClick, today);
+  return renderBody(
+    extractData(balance, institutional, insiders, baseline),
+    onWedgeClick,
+    today,
+  );
 }
 
 export function extractData(
   balance: InstrumentFinancials | null,
   institutional: InstitutionalHoldingsResponse | null,
   insiders: InsiderTransactionsList | null,
+  baseline: InsiderBaselineList | null,
 ): OwnershipData {
   const outstanding =
     balance !== null ? pickLatestBalance(balance, "shares_outstanding") : null;
@@ -213,7 +233,18 @@ export function extractData(
   const etf_holders: SunburstHolder[] = equity_filers
     .filter((f) => f.filer_type === "ETF")
     .map(filerToHolder("etfs"));
-  const insider_holders = aggregateInsiderHoldersForSunburst(insiders);
+
+  // Insider holders = Form 4 cumulative (latest post_transaction_shares
+  // per filer) + Form 3 baseline-only filers (#768 PR4) so officers
+  // who never traded after appointment surface on the per-officer
+  // ring. The backend NOT EXISTS gate guarantees no overlap between
+  // the two sets.
+  const form4_insider_holders = aggregateInsiderHoldersForSunburst(insiders);
+  const baseline_insider_holders = baselineToHolders(baseline);
+  const insider_holders: SunburstHolder[] = [
+    ...form4_insider_holders,
+    ...baseline_insider_holders,
+  ];
 
   const institutions_total = parseShareCount(inst_totals?.institutions_shares ?? null);
   const etfs_total = parseShareCount(inst_totals?.etfs_shares ?? null);
@@ -237,10 +268,17 @@ export function extractData(
   //     value — already the latest non-null treasury_shares row from
   //     pickLatestBalance.
   const thirteen_f_as_of = inst_totals?.period_of_report ?? null;
-  const insiders_as_of =
+  // Insider freshness factors in BOTH sources: latest Form 4 txn_date
+  // AND latest Form 3 baseline as_of_date. An issuer where every
+  // observed insider holds via a Form 3 grant and never trades would
+  // have no Form 4 rows at all but should still surface the latest
+  // baseline date as the Insiders chip's "as of".
+  const form4_latest =
     insiders === null || insiders.rows.length === 0
       ? null
       : latestTxnDate(insiders.rows as readonly InsiderRowShape[]);
+  const baseline_latest = latestBaselineDate(baseline);
+  const insiders_as_of = maxIsoDate(form4_latest, baseline_latest);
   const treasury_as_of =
     treasury !== null && balance !== null ? findRowDateFor(balance, "treasury_shares") : null;
 
@@ -257,6 +295,51 @@ export function extractData(
     insiders_as_of,
     treasury_as_of,
   };
+}
+
+/** Map baseline-API rows into the SunburstHolder shape so the
+ *  ownership ring renders Form-3-only insiders alongside Form 4
+ *  cumulative balances (#768 PR4). Filters rows with null/zero
+ *  shares so the wedge sizing never goes negative. */
+function baselineToHolders(
+  baseline: InsiderBaselineList | null,
+): readonly SunburstHolder[] {
+  if (baseline === null || baseline.rows.length === 0) return [];
+  const out: SunburstHolder[] = [];
+  for (const row of baseline.rows) {
+    const shares = parseShareCount(row.shares);
+    if (shares === null || shares <= 0) continue;
+    // Disambiguate against any same-CIK Form 4 leaf (the backend
+    // gate excludes them but defensively suffix the key — render
+    // collisions on a flat ring would silently swap wedges).
+    const key = `baseline:${row.filer_cik}:${row.is_derivative ? "d" : "n"}`;
+    out.push({
+      key,
+      label: row.filer_name,
+      shares,
+      category: "insiders",
+    });
+  }
+  return out;
+}
+
+/** Latest ``as_of_date`` across the baseline rows, or null when no
+ *  baseline holdings on file. */
+function latestBaselineDate(baseline: InsiderBaselineList | null): string | null {
+  if (baseline === null || baseline.rows.length === 0) return null;
+  let latest: string | null = null;
+  for (const row of baseline.rows) {
+    if (latest === null || row.as_of_date > latest) latest = row.as_of_date;
+  }
+  return latest;
+}
+
+/** Max of two ISO ``YYYY-MM-DD`` strings (lex-sortable so string
+ *  compare is correct). Returns null when both are null. */
+function maxIsoDate(a: string | null, b: string | null): string | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return a >= b ? a : b;
 }
 
 function latestTxnDate(rows: readonly InsiderRowShape[]): string | null {

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -58,6 +58,7 @@ import {
 } from "@/components/instrument/ownershipMetrics";
 import {
   type InsiderRowShape,
+  isBaselineHoldingRow,
   isInsiderHoldingRow,
 } from "@/components/instrument/ownershipInsiders";
 import {
@@ -299,16 +300,18 @@ export function extractData(
 
 /** Map baseline-API rows into the SunburstHolder shape so the
  *  ownership ring renders Form-3-only insiders alongside Form 4
- *  cumulative balances (#768 PR4). Filters rows with null/zero
- *  shares so the wedge sizing never goes negative. */
+ *  cumulative balances (#768 PR4). Uses the shared
+ *  ``isBaselineHoldingRow`` predicate so the holders set and the
+ *  freshness chip's ``as_of_date`` derivation can never drift. */
 function baselineToHolders(
   baseline: InsiderBaselineList | null,
 ): readonly SunburstHolder[] {
   if (baseline === null || baseline.rows.length === 0) return [];
   const out: SunburstHolder[] = [];
   for (const row of baseline.rows) {
-    const shares = parseShareCount(row.shares);
-    if (shares === null || shares <= 0) continue;
+    if (!isBaselineHoldingRow(row)) continue;
+    // Predicate guarantees parseShareCount > 0.
+    const shares = parseShareCount(row.shares)!;
     // Disambiguate against any same-CIK Form 4 leaf (the backend
     // gate excludes them but defensively suffix the key — render
     // collisions on a flat ring would silently swap wedges).
@@ -323,12 +326,15 @@ function baselineToHolders(
   return out;
 }
 
-/** Latest ``as_of_date`` across the baseline rows, or null when no
- *  baseline holdings on file. */
+/** Latest ``as_of_date`` across the baseline rows that actually
+ *  render. Uses the same eligibility predicate as
+ *  ``baselineToHolders`` so the chip never advances past a wedge
+ *  that doesn't render. */
 function latestBaselineDate(baseline: InsiderBaselineList | null): string | null {
   if (baseline === null || baseline.rows.length === 0) return null;
   let latest: string | null = null;
   for (const row of baseline.rows) {
+    if (!isBaselineHoldingRow(row)) continue;
     if (latest === null || row.as_of_date > latest) latest = row.as_of_date;
   }
   return latest;

--- a/frontend/src/components/instrument/ownershipInsiders.test.ts
+++ b/frontend/src/components/instrument/ownershipInsiders.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { type InsiderRowShape, isInsiderHoldingRow } from "./ownershipInsiders";
+import {
+  type InsiderBaselineRowShape,
+  type InsiderRowShape,
+  isBaselineHoldingRow,
+  isInsiderHoldingRow,
+} from "./ownershipInsiders";
 
 function row(overrides: Partial<InsiderRowShape> = {}): InsiderRowShape {
   return {
@@ -34,5 +39,51 @@ describe("isInsiderHoldingRow", () => {
     expect(isInsiderHoldingRow(row({ post_transaction_shares: "not-a-number" }))).toBe(
       false,
     );
+  });
+});
+
+
+function baselineRow(
+  overrides: Partial<InsiderBaselineRowShape> = {},
+): InsiderBaselineRowShape {
+  return {
+    filer_cik: "0000000099",
+    filer_name: "Test Officer",
+    is_derivative: false,
+    shares: "5000",
+    as_of_date: "2026-02-15",
+    ...overrides,
+  };
+}
+
+
+describe("isBaselineHoldingRow", () => {
+  it("includes a row with a positive share count", () => {
+    expect(isBaselineHoldingRow(baselineRow())).toBe(true);
+  });
+
+  it("excludes a row with null shares (value-branch holding without share count)", () => {
+    // Codex / bot review of #768 PR4: a baseline row with null
+    // shares (value-branch holding) must not advance the freshness
+    // chip — the wedge it would correspond to is filtered out of
+    // the rendered ring.
+    expect(isBaselineHoldingRow(baselineRow({ shares: null }))).toBe(false);
+  });
+
+  it("excludes a row with zero shares", () => {
+    // A zero-shares baseline row is also non-rendering — same drift
+    // class.
+    expect(isBaselineHoldingRow(baselineRow({ shares: "0" }))).toBe(false);
+  });
+
+  it("excludes a row with unparseable shares", () => {
+    expect(isBaselineHoldingRow(baselineRow({ shares: "garbage" }))).toBe(false);
+  });
+
+  it("includes a derivative row with positive shares", () => {
+    // is_derivative is informational on baseline rows (it splits the
+    // SunburstHolder.key namespace) — but doesn't gate inclusion.
+    // Derivative-equity-grant baselines DO render as ring 3 wedges.
+    expect(isBaselineHoldingRow(baselineRow({ is_derivative: true }))).toBe(true);
   });
 });

--- a/frontend/src/components/instrument/ownershipInsiders.ts
+++ b/frontend/src/components/instrument/ownershipInsiders.ts
@@ -45,3 +45,29 @@ export function isInsiderHoldingRow(row: InsiderRowShape): boolean {
   if (row.is_derivative) return false;
   return parseShareCount(row.post_transaction_shares) !== null;
 }
+
+/** Shape every consumer of the insider-baseline endpoint reads. The
+ *  full row carries more fields; consumers TypeScript-narrow to this
+ *  subset. */
+export interface InsiderBaselineRowShape {
+  readonly filer_cik: string;
+  readonly filer_name: string;
+  readonly is_derivative: boolean;
+  readonly shares: string | null;
+  readonly as_of_date: string;
+}
+
+/**
+ * True when a Form 3 baseline row should count toward the rendered
+ * ring. Single source of truth for "is this baseline row part of the
+ * snapshot?" — the holders builder, the L2 table writer, and the
+ * Insiders freshness chip's ``as_of`` derivation must all use this
+ * predicate so a null/zero-shares baseline row never advances the
+ * chip past the actual rendered ring (PR #774 round 2 — same drift
+ * class as the PR #770 ``isInsiderHoldingRow`` extraction).
+ */
+export function isBaselineHoldingRow(row: InsiderBaselineRowShape): boolean {
+  const shares = parseShareCount(row.shares);
+  if (shares === null) return false;
+  return shares > 0;
+}

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -22,10 +22,14 @@ import type {
   InstitutionalHoldingsResponse,
 } from "@/api/institutionalHoldings";
 import {
+  fetchInsiderBaseline,
   fetchInsiderTransactions,
   fetchInstrumentFinancials,
 } from "@/api/instruments";
-import type { InsiderTransactionsList } from "@/api/instruments";
+import type {
+  InsiderBaselineList,
+  InsiderTransactionsList,
+} from "@/api/instruments";
 import type { InstrumentFinancials } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { OwnershipFreshnessChips } from "@/components/instrument/OwnershipFreshnessChips";
@@ -102,14 +106,21 @@ export function OwnershipPage(): JSX.Element {
     [symbol],
   );
 
+  const baselineState = useAsync<InsiderBaselineList>(
+    useCallback(() => fetchInsiderBaseline(symbol), [symbol]),
+    [symbol],
+  );
+
   const isLoading =
     balanceState.loading ||
     institutionalState.loading ||
-    insidersState.loading;
+    insidersState.loading ||
+    baselineState.loading;
   const allErrored =
     balanceState.error !== null &&
     institutionalState.error !== null &&
-    insidersState.error !== null;
+    insidersState.error !== null &&
+    baselineState.error !== null;
 
   const handleWedgeClick = useCallback(
     (target: WedgeClick) => {
@@ -168,6 +179,7 @@ export function OwnershipPage(): JSX.Element {
             balanceState.refetch();
             institutionalState.refetch();
             insidersState.refetch();
+            baselineState.refetch();
           }}
         />
       ) : (
@@ -176,6 +188,7 @@ export function OwnershipPage(): JSX.Element {
           balance={balanceState.data}
           institutional={institutionalState.data}
           insiders={insidersState.data}
+          baseline={baselineState.data}
           categoryFilter={categoryFilter}
           filerFilter={filerFilter}
           viewMode={viewMode}
@@ -193,6 +206,7 @@ interface OwnershipBodyProps {
   readonly balance: InstrumentFinancials | null;
   readonly institutional: InstitutionalHoldingsResponse | null;
   readonly insiders: InsiderTransactionsList | null;
+  readonly baseline: InsiderBaselineList | null;
   readonly categoryFilter: string | null;
   readonly filerFilter: string | null;
   readonly viewMode: string | null;
@@ -208,6 +222,7 @@ function OwnershipBody({
   balance,
   institutional,
   insiders,
+  baseline,
   categoryFilter,
   filerFilter,
   viewMode,
@@ -253,9 +268,20 @@ function OwnershipBody({
         .map(filerToHolder("etfs")),
     [equity_filers],
   );
-  const insider_holders = useMemo(
+  const form4_insider_holders = useMemo(
     () => aggregateInsiderHoldersForSunburst(insiders),
     [insiders],
+  );
+  // Form-3-only filers (#768 PR4) — officers who hold a baseline
+  // grant but never traded after appointment. Backend NOT EXISTS
+  // gate guarantees no overlap with form4_insider_holders.
+  const baseline_insider_holders = useMemo<readonly SunburstHolder[]>(
+    () => baselineToInsiderHolders(baseline),
+    [baseline],
+  );
+  const insider_holders = useMemo<readonly SunburstHolder[]>(
+    () => [...form4_insider_holders, ...baseline_insider_holders],
+    [form4_insider_holders, baseline_insider_holders],
   );
   const allHolders = useMemo<readonly SunburstHolder[]>(
     () => [...institutional_holders, ...etf_holders, ...insider_holders],
@@ -294,18 +320,36 @@ function OwnershipBody({
   const today = useMemo(() => new Date(), []);
 
   const insiders_as_of = useMemo(() => {
-    if (insiders === null || insiders.rows.length === 0) return null;
-    let latest: string | null = null;
-    // Same eligibility predicate as the holders aggregator below
-    // and ``buildFilerRows`` — Codex (review of #767) caught that
-    // a divergent predicate would advance the freshness chip ahead
-    // of the actual snapshot the ring renders.
-    for (const row of insiders.rows as readonly InsiderRowShape[]) {
-      if (!isInsiderHoldingRow(row)) continue;
-      if (latest === null || row.txn_date > latest) latest = row.txn_date;
+    // Insider freshness factors in BOTH sources: latest Form 4
+    // txn_date AND latest Form 3 baseline as_of_date (#768 PR4).
+    // An issuer where every observed insider holds via a Form 3
+    // grant and never trades has no Form 4 rows but should still
+    // surface the latest baseline date as the chip's "as of".
+    let latest_form4: string | null = null;
+    if (insiders !== null && insiders.rows.length > 0) {
+      // Same eligibility predicate as the holders aggregator below
+      // and ``buildFilerRows`` — Codex (review of #767) caught that
+      // a divergent predicate would advance the freshness chip
+      // ahead of the actual snapshot the ring renders.
+      for (const row of insiders.rows as readonly InsiderRowShape[]) {
+        if (!isInsiderHoldingRow(row)) continue;
+        if (latest_form4 === null || row.txn_date > latest_form4) {
+          latest_form4 = row.txn_date;
+        }
+      }
     }
-    return latest;
-  }, [insiders]);
+    let latest_baseline: string | null = null;
+    if (baseline !== null && baseline.rows.length > 0) {
+      for (const row of baseline.rows) {
+        if (latest_baseline === null || row.as_of_date > latest_baseline) {
+          latest_baseline = row.as_of_date;
+        }
+      }
+    }
+    if (latest_form4 === null) return latest_baseline;
+    if (latest_baseline === null) return latest_form4;
+    return latest_form4 >= latest_baseline ? latest_form4 : latest_baseline;
+  }, [insiders, baseline]);
   const treasury_as_of = useMemo(() => {
     if (balance === null || treasury === null) return null;
     for (const row of balance.rows) {
@@ -345,8 +389,8 @@ function OwnershipBody({
   const rings = useMemo(() => buildSunburstRings(inputs), [inputs]);
 
   const allRows = useMemo(
-    () => buildFilerRows(filers, insiders, treasury),
-    [filers, insiders, treasury],
+    () => buildFilerRows(filers, insiders, baseline, treasury),
+    [filers, insiders, baseline, treasury],
   );
 
   const filteredRows = useMemo(() => {
@@ -625,9 +669,34 @@ function aggregateInsiderHoldersForSunburst(
   return holders;
 }
 
+/** Map baseline-API rows to SunburstHolder shape (#768 PR4). The
+ *  ``baseline:`` key prefix prevents collisions with same-CIK Form 4
+ *  leaves — the backend NOT EXISTS gate already excludes overlap, but
+ *  this defends against a future regression. Rows with null/zero
+ *  shares are dropped so the wedge sizing never goes negative. */
+function baselineToInsiderHolders(
+  baseline: InsiderBaselineList | null,
+): readonly SunburstHolder[] {
+  if (baseline === null || baseline.rows.length === 0) return [];
+  const out: SunburstHolder[] = [];
+  for (const row of baseline.rows) {
+    const shares = parseShareCount(row.shares);
+    if (shares === null || shares <= 0) continue;
+    out.push({
+      key: `baseline:${row.filer_cik}:${row.is_derivative ? "d" : "n"}`,
+      label: row.filer_name,
+      shares,
+      category: "insiders",
+    });
+  }
+  return out;
+}
+
+
 function buildFilerRows(
   filers: readonly InstitutionalFilerHolding[],
   insiders: InsiderTransactionsList | null,
+  baseline: InsiderBaselineList | null,
   treasury: number | null,
 ): FilerRow[] {
   const rows: FilerRow[] = [];
@@ -674,6 +743,29 @@ function buildFilerRows(
         is_put_call: null,
         accession: null,
         period_of_report: entry.row.txn_date,
+      });
+    }
+  }
+
+  // Form 3 baseline-only insiders (#768 PR4). Backend gate
+  // guarantees no CIK overlap with the Form 4 set above; the
+  // ``baseline:`` key prefix matches the SunburstHolder key so a
+  // wedge click on the L1 ring lands on the right L2 row.
+  if (baseline !== null) {
+    for (const row of baseline.rows) {
+      const shares = parseShareCount(row.shares);
+      if (shares === null || shares <= 0) continue;
+      rows.push({
+        key: `baseline:${row.filer_cik}:${row.is_derivative ? "d" : "n"}`,
+        label: row.filer_name,
+        category: "insiders",
+        category_label: CATEGORY_LABELS.insiders,
+        shares,
+        value_usd: parseShareCount(row.value_owned ?? null),
+        voting: null,
+        is_put_call: null,
+        accession: null,
+        period_of_report: row.as_of_date,
       });
     }
   }

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -35,6 +35,7 @@ import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { OwnershipFreshnessChips } from "@/components/instrument/OwnershipFreshnessChips";
 import {
   type InsiderRowShape,
+  isBaselineHoldingRow,
   isInsiderHoldingRow,
 } from "@/components/instrument/ownershipInsiders";
 import {
@@ -340,7 +341,12 @@ function OwnershipBody({
     }
     let latest_baseline: string | null = null;
     if (baseline !== null && baseline.rows.length > 0) {
+      // Same eligibility predicate as ``baselineToInsiderHolders``
+      // and ``buildFilerRows`` — without the guard a null/zero-
+      // shares row would advance the chip past a wedge that never
+      // renders (Codex / bot review of #768 PR4).
       for (const row of baseline.rows) {
+        if (!isBaselineHoldingRow(row)) continue;
         if (latest_baseline === null || row.as_of_date > latest_baseline) {
           latest_baseline = row.as_of_date;
         }
@@ -669,19 +675,20 @@ function aggregateInsiderHoldersForSunburst(
   return holders;
 }
 
-/** Map baseline-API rows to SunburstHolder shape (#768 PR4). The
- *  ``baseline:`` key prefix prevents collisions with same-CIK Form 4
- *  leaves — the backend NOT EXISTS gate already excludes overlap, but
- *  this defends against a future regression. Rows with null/zero
- *  shares are dropped so the wedge sizing never goes negative. */
+/** Map baseline-API rows to SunburstHolder shape (#768 PR4). Uses
+ *  the shared ``isBaselineHoldingRow`` predicate so the holders set,
+ *  the L2 ``buildFilerRows`` table writer, and the L2 freshness
+ *  chip's ``as_of_date`` derivation cannot drift. The ``baseline:``
+ *  key prefix prevents collisions with same-CIK Form 4 leaves. */
 function baselineToInsiderHolders(
   baseline: InsiderBaselineList | null,
 ): readonly SunburstHolder[] {
   if (baseline === null || baseline.rows.length === 0) return [];
   const out: SunburstHolder[] = [];
   for (const row of baseline.rows) {
-    const shares = parseShareCount(row.shares);
-    if (shares === null || shares <= 0) continue;
+    if (!isBaselineHoldingRow(row)) continue;
+    // Predicate guarantees parseShareCount > 0.
+    const shares = parseShareCount(row.shares)!;
     out.push({
       key: `baseline:${row.filer_cik}:${row.is_derivative ? "d" : "n"}`,
       label: row.filer_name,
@@ -753,8 +760,9 @@ function buildFilerRows(
   // wedge click on the L1 ring lands on the right L2 row.
   if (baseline !== null) {
     for (const row of baseline.rows) {
-      const shares = parseShareCount(row.shares);
-      if (shares === null || shares <= 0) continue;
+      if (!isBaselineHoldingRow(row)) continue;
+      // Predicate guarantees parseShareCount > 0.
+      const shares = parseShareCount(row.shares)!;
       rows.push({
         key: `baseline:${row.filer_cik}:${row.is_derivative ? "d" : "n"}`,
         label: row.filer_name,

--- a/tests/test_api_instrument_sec_gates.py
+++ b/tests/test_api_instrument_sec_gates.py
@@ -87,6 +87,7 @@ def _clear() -> None:
         "/instruments/AAPL/dividends",
         "/instruments/AAPL/insider_summary",
         "/instruments/AAPL/insider_transactions",
+        "/instruments/AAPL/insider_baseline",
     ],
 )
 def test_no_sec_cik_returns_404_no_sec_coverage(client: TestClient, endpoint: str) -> None:
@@ -111,6 +112,7 @@ def test_no_sec_cik_returns_404_no_sec_coverage(client: TestClient, endpoint: st
         "/instruments/AAPL/dividends",
         "/instruments/AAPL/insider_summary",
         "/instruments/AAPL/insider_transactions",
+        "/instruments/AAPL/insider_baseline",
     ],
 )
 def test_with_sec_cik_does_not_404_with_no_sec_coverage(client: TestClient, endpoint: str) -> None:

--- a/tests/test_api_instrument_sec_gates.py
+++ b/tests/test_api_instrument_sec_gates.py
@@ -80,6 +80,33 @@ def _clear() -> None:
     app.dependency_overrides.pop(get_conn, None)
 
 
+def test_insider_transactions_rejects_sec_form3_provider(client: TestClient) -> None:
+    """PR #774 review (BLOCKING): _INSIDER_PROVIDERS was originally
+    shared between Form 4 and Form 3 endpoints; adding 'sec_form3'
+    silently passed validation against a Form-4-only reader. Pin the
+    split so a regression that re-merges the tuples is caught.
+    """
+    conn = _conn_for_handler(has_cik=True)
+    _install(conn)
+    try:
+        resp = client.get("/instruments/AAPL/insider_transactions?provider=sec_form3")
+    finally:
+        _clear()
+    assert resp.status_code == 400
+
+
+def test_insider_baseline_rejects_sec_form4_provider(client: TestClient) -> None:
+    """Symmetric to the test above — Form 3 baseline endpoint must
+    reject ``?provider=sec_form4``."""
+    conn = _conn_for_handler(has_cik=True)
+    _install(conn)
+    try:
+        resp = client.get("/instruments/AAPL/insider_baseline?provider=sec_form4")
+    finally:
+        _clear()
+    assert resp.status_code == 400
+
+
 @pytest.mark.parametrize(
     "endpoint",
     [


### PR DESCRIPTION
## What

PR 4 of N for #768 — closes the loop end-to-end. Insiders with a Form 3 baseline grant but no Form 4 activity now surface on the ownership card's per-officer ring + L2 drilldown.

## Components

- **Backend endpoint** ``GET /instruments/{symbol}/insider_baseline`` reading the PR 3 reader. Same SEC-coverage 404 gate + empty-state contract as ``insider_transactions``.
- **Frontend API client** ``fetchInsiderBaseline`` with 404-tolerance for non-covered issuers.
- **L1 ``OwnershipPanel``**: fetches baseline alongside Form 4, merges into ``insider_holders``, factors latest ``as_of_date`` from BOTH sources into the freshness chip.
- **L2 ``OwnershipPage``**: same merge + ``buildFilerRows`` emits baseline rows with the ``baseline:{cik}:{n|d}`` key so a click on a baseline wedge from L1 lands on the right L2 row.

## Test plan

- [x] Backend: ``test_api_instrument_sec_gates`` parametrisation covers ``/insider_baseline`` (404 with no SEC CIK; 200 with SEC CIK).
- [x] Frontend: 7 ``OwnershipPanel.test.ts`` tests covering merge shape, empty-state, no-CIK-collision keying, null/zero-shares filter, freshness max-of-both branch (including Codex-flagged "baseline older than Form 4" branch).
- [x] Full frontend suite: 825 passed.
- [x] Pre-push gates: ruff / format / pyright / typecheck — all green.

## Codex review (CLAUDE.md checkpoint 2)

No findings on the three focus points (key prefix safety, L1→L2 highlight match, freshness merge logic). Coverage gap on "baseline older than Form 4" branch flagged + addressed.

Refs #768.