### PR TITLE
feat(#766): 13D/G blockholders schema + parser (PR 1/3)

### DIFF
--- a/app/providers/implementations/sec_13dg.py
+++ b/app/providers/implementations/sec_13dg.py
@@ -1,0 +1,506 @@
+"""SEC Schedule 13D / 13G blockholder ownership parser.
+
+Schedule 13D is filed by any entity that becomes the beneficial owner
+of more than 5% of a registered class of voting equity and intends to
+influence the issuer (Section 13(d) of the Exchange Act). Schedule
+13G covers the same threshold but is reserved for passive holders —
+qualified institutional investors, exempt investors, and passive
+investors who explicitly disclaim an intent to influence (Rule
+13d-1(b), (c), (d)).
+
+Both forms became structured-XML submissions under the SEC's
+Beneficial Ownership Modernization rule (effective 2024-12-19). Each
+filing's ``primary_doc.xml`` is the canonical source. Pre-rule HTML
+text filings are out of scope for this parser — those accessions are
+older than the data window the ownership card cares about and the
+ingester (PR 2) will simply skip them.
+
+The two forms share enough cover-page structure that one parser can
+serve both, but field names and namespaces diverge:
+
+  * 13D root namespace:  ``http://www.sec.gov/edgar/schedule13D``
+  * 13G root namespace:  ``http://www.sec.gov/edgar/schedule13g``
+
+  * 13D issuer block:    ``<issuerCIK>`` / ``<issuerCUSIP>``
+  * 13G issuer block:    ``<issuerCik>`` / ``<issuerCusip>`` (camelCase)
+
+  * 13D event date:      ``<dateOfEvent>`` (MM/DD/YYYY)
+  * 13G event date:      ``<eventDateRequiresFilingThisStatement>``
+
+  * 13D reporter array:  ``<reportingPersons>/<reportingPersonInfo>+``
+  * 13G reporter array:  ``<coverPageHeaderReportingPersonDetails>+``
+                         (repeats directly under ``<formData>``;
+                         no wrapper element)
+
+  * 13D ownership block: flat under ``<reportingPersonInfo>``
+                         (``<soleVotingPower>``, ``<percentOfClass>``)
+  * 13G ownership block: nested inside
+                         ``<reportingPersonBeneficiallyOwnedNumberOfShares>``
+                         and ``<classPercent>``
+
+This module is a pure parser: XML strings in, typed dataclasses out.
+HTTP fetch + DB resolution stay in the service layer — providers
+remain thin per the settled provider-design rule.
+
+#766 PR 1 of 3. Subsequent PRs add the SEC walker + ingester
+(PR 2) and the reader endpoint + 5th sunburst category (PR 3 — the
+ownership card #729 follow-on).
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET  # noqa: S405 — SEC EDGAR is the trusted source for 13D/G XML.
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Final, Literal
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+SubmissionType = Literal[
+    "SCHEDULE 13D",
+    "SCHEDULE 13D/A",
+    "SCHEDULE 13G",
+    "SCHEDULE 13G/A",
+]
+Status = Literal["active", "passive"]
+
+
+@dataclass(frozen=True)
+class BlockholderReportingPerson:
+    """One reporting-person record from a 13D / 13G primary_doc.xml.
+
+    A single accession can carry multiple reporting persons (joint
+    filings — e.g. a hedge fund + its general partner + its principal
+    all reporting on the same issuer). Each becomes a separate row in
+    ``blockholder_filings`` so the PR 2 aggregator can detect joint
+    filings via ``member_of_group`` and avoid double-counting shares.
+
+    Field semantics:
+
+      * ``cik`` — zero-padded 10-digit CIK string when the reporter
+        is an EDGAR-registered entity. ``None`` for natural persons,
+        family trusts, or foreign holdcos that have no CIK
+        (``reportingPersonNoCIK = Y`` in the source).
+      * ``no_cik`` — explicit boolean form of the above for callers
+        that want the binary signal without a None-vs-empty check.
+      * ``name`` — the reporting person's name as it appears on the
+        cover page. Stripped of leading/trailing whitespace.
+      * ``member_of_group`` — Item 2(a) checkbox: ``'a'`` if the
+        reporter is a member of a Rule 13d-1(b)(1)(ii)(J) group,
+        ``'b'`` if not. Source field is free-text on some legacy
+        filings — pass-through with no validation.
+      * ``type_of_reporting_person`` — SEC code (``IN``, ``CO``,
+        ``OO``, ``HC``, etc.). Pass-through.
+      * ``citizenship`` — state/country code (e.g. ``DE``, ``NY``,
+        ``D5`` for foreign).
+      * ``sole_voting_power`` / ``shared_voting_power`` /
+        ``sole_dispositive_power`` / ``shared_dispositive_power`` —
+        Items 5–8 of the cover page. May be ``None`` when the filing
+        defers to the prior cover page rather than restating numbers
+        (legal on amendments but yields a non-canonical row).
+      * ``aggregate_amount_owned`` — Item 9 / 13G total beneficially
+        owned. ``None`` under the same defer-to-prior-cover rule.
+      * ``percent_of_class`` — Item 11 / 13G ``classPercent``. NUMERIC
+        because SEC allows up to 4 decimals (e.g. ``47.6843``).
+    """
+
+    cik: str | None
+    no_cik: bool
+    name: str
+    member_of_group: str | None
+    type_of_reporting_person: str | None
+    citizenship: str | None
+    sole_voting_power: Decimal | None
+    shared_voting_power: Decimal | None
+    sole_dispositive_power: Decimal | None
+    shared_dispositive_power: Decimal | None
+    aggregate_amount_owned: Decimal | None
+    percent_of_class: Decimal | None
+
+
+@dataclass(frozen=True)
+class BlockholderFiling:
+    """The full parsed payload from one 13D / 13G primary_doc.xml.
+
+    Field semantics:
+
+      * ``submission_type`` — verbatim ``<submissionType>`` from the
+        XML header. Constrained to the four legal values; the parser
+        raises ``ValueError`` on any other value to make a future
+        SEC schema change visible rather than silently miscategorised.
+      * ``status`` — derived enum: ``13D|13D/A → active``,
+        ``13G|13G/A → passive``. Set by the parser, not the ingester.
+      * ``primary_filer_cik`` — zero-padded CIK of the entity that
+        actually submitted the filing on EDGAR
+        (``headerData/filerInfo/filer/filerCredentials/cik``). This
+        is what the ``blockholder_filer_seeds`` table keys on. Note
+        that this is sometimes the same as the first reporting
+        person, sometimes a service company (e.g. a transfer-agent
+        filing on behalf of a family trust).
+      * ``issuer_cik`` — the issuing company's CIK. Joins to the
+        eBull ``instruments`` table via
+        ``instrument_sec_profile.cik``.
+      * ``issuer_cusip`` — issuer + share-class identifier. The
+        ingester (PR 2) resolves this to ``instrument_id`` via
+        ``external_identifiers``. Issuer-level dedupe across share
+        classes is the ingester's responsibility, not the parser's.
+      * ``issuer_name`` — informational; pass-through from cover.
+      * ``securities_class_title`` — the share class on the cover
+        (e.g. "Class A Common Stock, par value $.01 per share").
+        Pass-through; not normalised.
+      * ``date_of_event`` — Item 4 / 13G "event requiring filing"
+        date. ``None`` if missing or unparseable.
+      * ``filed_at`` — first signature-block date in the filing,
+        coerced to UTC midnight. ``None`` if no signature is found
+        (rare; typically a malformed filing). The signature date is
+        the closest the SEC schema gets to a filing timestamp — the
+        accession-date filed-at on EDGAR's web UI carries a clock
+        but is not in the primary_doc.xml itself.
+      * ``reporting_persons`` — 1..N. Empty list is treated as a
+        parse error and raised; an accession with zero reporting
+        persons is malformed by definition.
+    """
+
+    submission_type: SubmissionType
+    status: Status
+    primary_filer_cik: str
+    issuer_cik: str
+    issuer_cusip: str
+    issuer_name: str
+    securities_class_title: str | None
+    date_of_event: date | None
+    filed_at: datetime | None
+    reporting_persons: list[BlockholderReportingPerson]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+_SUBMISSION_TYPES: Final[frozenset[SubmissionType]] = frozenset(
+    ("SCHEDULE 13D", "SCHEDULE 13D/A", "SCHEDULE 13G", "SCHEDULE 13G/A")
+)
+
+
+def _strip_ns(tag: str) -> str:
+    """``{http://...}foo`` -> ``foo``. Idempotent on un-namespaced tags."""
+    if "}" in tag:
+        return tag.split("}", 1)[1]
+    return tag
+
+
+def _find_descendant(root: ET.Element, name: str) -> ET.Element | None:
+    """Find the first descendant element whose stripped name matches."""
+    for el in root.iter():
+        if _strip_ns(el.tag) == name:
+            return el
+    return None
+
+
+def _find_descendants(root: ET.Element, name: str) -> list[ET.Element]:
+    """Find every descendant element whose stripped name matches."""
+    return [el for el in root.iter() if _strip_ns(el.tag) == name]
+
+
+def _child_text(parent: ET.Element | None, name: str) -> str | None:
+    """Find the first descendant of ``parent`` whose stripped name matches.
+
+    Scoped to ``parent``'s subtree so an ambiguously-named element
+    (``<name>``, ``<cik>``) under one branch can't be picked from a
+    sibling branch — important on the 13D primary doc, where cover-
+    page issuer info, reporting persons, and the signature block
+    each have their own nested ``<name>`` elements.
+    """
+    if parent is None:
+        return None
+    for el in parent.iter():
+        if _strip_ns(el.tag) == name and el.text is not None:
+            text = el.text.strip()
+            if text:
+                return text
+    return None
+
+
+def _decimal_or_none(text: str | None) -> Decimal | None:
+    if text is None:
+        return None
+    try:
+        return Decimal(text.replace(",", ""))
+    except InvalidOperation:
+        return None
+
+
+def _parse_date_loose(text: str | None) -> date | None:
+    """Both 13D ``dateOfEvent`` and 13G
+    ``eventDateRequiresFilingThisStatement`` ship as MM/DD/YYYY in
+    the wild. Accept the SEC-form dash variant and ISO too so a
+    future SEC formatting change doesn't silently null the column.
+    """
+    if text is None:
+        return None
+    for fmt in ("%m/%d/%Y", "%m-%d-%Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _parse_signature_datetime(text: str | None) -> datetime | None:
+    """Coerce a date-only signature value to UTC midnight so the
+    persisted ``filed_at TIMESTAMPTZ`` does not drift across local
+    timezones (Codex #730 PR 1 review caught the same bug there)."""
+    parsed = _parse_date_loose(text)
+    if parsed is None:
+        return None
+    return datetime(parsed.year, parsed.month, parsed.day, tzinfo=UTC)
+
+
+def _zero_pad_cik(text: str) -> str:
+    digits = "".join(ch for ch in text if ch.isdigit())
+    if not digits:
+        raise ValueError(f"primary_doc.xml carried a non-numeric CIK: {text!r}")
+    return digits.zfill(10)
+
+
+def _classify(submission_type: str) -> tuple[SubmissionType, Status]:
+    """Validate the submission-type string against the SEC enum and
+    derive the active/passive status. Raises ``ValueError`` on any
+    value outside the four-form set so a schema change fails loudly
+    rather than landing wrong rows."""
+    if submission_type not in _SUBMISSION_TYPES:
+        raise ValueError(f"unsupported submission type: {submission_type!r}")
+    typed: SubmissionType = submission_type  # type: ignore[assignment]
+    status: Status = "active" if typed.startswith("SCHEDULE 13D") else "passive"
+    return typed, status
+
+
+# ---------------------------------------------------------------------------
+# 13D-specific extractors
+# ---------------------------------------------------------------------------
+
+
+def _parse_13d_reporting_person(node: ET.Element) -> BlockholderReportingPerson:
+    """Extract one ``<reportingPersonInfo>`` block from a 13D filing.
+
+    The 13D schema lays the ownership block flat under the reporter
+    element — ``<soleVotingPower>``, ``<percentOfClass>`` etc. are
+    direct children of ``<reportingPersonInfo>``. A ``<noCIK>`` flag
+    marks reporters that have no EDGAR CIK (natural persons, family
+    trusts).
+    """
+    cik_text = _child_text(node, "reportingPersonCIK")
+    no_cik_text = _child_text(node, "reportingPersonNoCIK")
+    no_cik = (no_cik_text or "").upper() == "Y"
+    cik = _zero_pad_cik(cik_text) if (cik_text and not no_cik) else None
+
+    name = _child_text(node, "reportingPersonName") or ""
+    if not name:
+        raise ValueError("13D reportingPersonInfo is missing <reportingPersonName>")
+
+    return BlockholderReportingPerson(
+        cik=cik,
+        no_cik=no_cik,
+        name=name,
+        member_of_group=_child_text(node, "memberOfGroup"),
+        type_of_reporting_person=_child_text(node, "typeOfReportingPerson"),
+        citizenship=_child_text(node, "citizenshipOrOrganization"),
+        sole_voting_power=_decimal_or_none(_child_text(node, "soleVotingPower")),
+        shared_voting_power=_decimal_or_none(_child_text(node, "sharedVotingPower")),
+        sole_dispositive_power=_decimal_or_none(_child_text(node, "soleDispositivePower")),
+        shared_dispositive_power=_decimal_or_none(_child_text(node, "sharedDispositivePower")),
+        aggregate_amount_owned=_decimal_or_none(_child_text(node, "aggregateAmountOwned")),
+        percent_of_class=_decimal_or_none(_child_text(node, "percentOfClass")),
+    )
+
+
+def _extract_13d(root: ET.Element) -> tuple[str, str, str, str | None, date | None, list[BlockholderReportingPerson]]:
+    """Extract the 13D-shaped subset of cover-page + reporter data.
+
+    Returns ``(issuer_cik, issuer_cusip, issuer_name,
+    securities_class_title, date_of_event, reporting_persons)``.
+    """
+    issuer_info = _find_descendant(root, "issuerInfo")
+    issuer_cik_text = _child_text(issuer_info, "issuerCIK")
+    issuer_cusip = _child_text(issuer_info, "issuerCUSIP")
+    issuer_name = _child_text(issuer_info, "issuerName")
+
+    if issuer_cik_text is None:
+        raise ValueError("13D primary_doc.xml is missing <issuerCIK>")
+    if issuer_cusip is None:
+        raise ValueError("13D primary_doc.xml is missing <issuerCUSIP>")
+    if issuer_name is None:
+        raise ValueError("13D primary_doc.xml is missing <issuerName>")
+
+    cover = _find_descendant(root, "coverPageHeader")
+    securities_class_title = _child_text(cover, "securitiesClassTitle")
+    date_of_event = _parse_date_loose(_child_text(cover, "dateOfEvent"))
+
+    reporters_root = _find_descendant(root, "reportingPersons")
+    if reporters_root is None:
+        raise ValueError("13D primary_doc.xml is missing <reportingPersons>")
+    reporter_nodes = [el for el in reporters_root if _strip_ns(el.tag) == "reportingPersonInfo"]
+    if not reporter_nodes:
+        raise ValueError("13D primary_doc.xml has no <reportingPersonInfo> children")
+
+    reporters = [_parse_13d_reporting_person(n) for n in reporter_nodes]
+
+    return (
+        _zero_pad_cik(issuer_cik_text),
+        issuer_cusip,
+        issuer_name,
+        securities_class_title,
+        date_of_event,
+        reporters,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 13G-specific extractors
+# ---------------------------------------------------------------------------
+
+
+def _parse_13g_reporting_person(node: ET.Element) -> BlockholderReportingPerson:
+    """Extract one ``<coverPageHeaderReportingPersonDetails>`` block.
+
+    13G nests the ownership numbers inside
+    ``<reportingPersonBeneficiallyOwnedNumberOfShares>`` and uses
+    ``<classPercent>`` instead of ``<percentOfClass>``. The reporter
+    CIK is not reliably present on the 13G cover-page subtree (the
+    SEC schema makes it optional); when missing, fall back to
+    ``no_cik = True`` and persist the name only.
+    """
+    name = _child_text(node, "reportingPersonName") or ""
+    if not name:
+        raise ValueError("13G reporting person details missing <reportingPersonName>")
+
+    cik_text = _child_text(node, "reportingPersonCik") or _child_text(node, "reportingPersonCIK")
+    no_cik_text = _child_text(node, "reportingPersonNoCIK") or _child_text(node, "reportingPersonNoCik")
+    no_cik = (no_cik_text or "").upper() == "Y" or (cik_text is None)
+    cik = _zero_pad_cik(cik_text) if (cik_text and not no_cik) else None
+
+    powers = _find_descendant(node, "reportingPersonBeneficiallyOwnedNumberOfShares")
+    sole_voting = _decimal_or_none(_child_text(powers, "soleVotingPower"))
+    shared_voting = _decimal_or_none(_child_text(powers, "sharedVotingPower"))
+    sole_disp = _decimal_or_none(_child_text(powers, "soleDispositivePower"))
+    shared_disp = _decimal_or_none(_child_text(powers, "sharedDispositivePower"))
+
+    aggregate = _decimal_or_none(_child_text(node, "reportingPersonBeneficiallyOwnedAggregateNumberOfShares"))
+    percent = _decimal_or_none(_child_text(node, "classPercent"))
+
+    return BlockholderReportingPerson(
+        cik=cik,
+        no_cik=no_cik,
+        name=name,
+        member_of_group=_child_text(node, "memberOfGroup"),
+        type_of_reporting_person=_child_text(node, "typeOfReportingPerson"),
+        citizenship=_child_text(node, "citizenshipOrOrganization"),
+        sole_voting_power=sole_voting,
+        shared_voting_power=shared_voting,
+        sole_dispositive_power=sole_disp,
+        shared_dispositive_power=shared_disp,
+        aggregate_amount_owned=aggregate,
+        percent_of_class=percent,
+    )
+
+
+def _extract_13g(root: ET.Element) -> tuple[str, str, str, str | None, date | None, list[BlockholderReportingPerson]]:
+    """Extract the 13G-shaped subset of cover-page + reporter data."""
+    issuer_info = _find_descendant(root, "issuerInfo")
+    issuer_cik_text = _child_text(issuer_info, "issuerCik") or _child_text(issuer_info, "issuerCIK")
+    issuer_cusip = _child_text(issuer_info, "issuerCusip") or _child_text(issuer_info, "issuerCUSIP")
+    issuer_name = _child_text(issuer_info, "issuerName")
+
+    if issuer_cik_text is None:
+        raise ValueError("13G primary_doc.xml is missing <issuerCik>")
+    if issuer_cusip is None:
+        raise ValueError("13G primary_doc.xml is missing <issuerCusip>")
+    if issuer_name is None:
+        raise ValueError("13G primary_doc.xml is missing <issuerName>")
+
+    cover = _find_descendant(root, "coverPageHeader")
+    securities_class_title = _child_text(cover, "securitiesClassTitle")
+    date_of_event = _parse_date_loose(_child_text(cover, "eventDateRequiresFilingThisStatement"))
+
+    reporter_nodes = _find_descendants(root, "coverPageHeaderReportingPersonDetails")
+    if not reporter_nodes:
+        raise ValueError("13G primary_doc.xml has no <coverPageHeaderReportingPersonDetails>")
+
+    reporters = [_parse_13g_reporting_person(n) for n in reporter_nodes]
+
+    return (
+        _zero_pad_cik(issuer_cik_text),
+        issuer_cusip,
+        issuer_name,
+        securities_class_title,
+        date_of_event,
+        reporters,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_primary_doc(xml: str) -> BlockholderFiling:
+    """Parse a 13D or 13G ``primary_doc.xml`` payload.
+
+    Branches on ``<submissionType>`` to pick the correct cover-page
+    extractor — the two schemas share enough structure that one
+    return type fits, but field names and nesting differ.
+
+    Raises ``ValueError`` on any of:
+
+      * missing or unrecognised ``<submissionType>``
+      * missing primary filer CIK
+      * missing issuer CIK / CUSIP / name
+      * empty reporting-persons array
+      * empty / missing reporter name on any reporter row
+
+    The ingester (PR 2) decides whether a ``ValueError`` becomes a
+    ``failed`` tombstone or a hard log-and-continue — that policy
+    does not belong in the parser.
+    """
+    root = ET.fromstring(xml)  # noqa: S314 — SEC EDGAR is the trusted source.
+
+    submission_type_text = _child_text(_find_descendant(root, "headerData"), "submissionType")
+    if submission_type_text is None:
+        raise ValueError("primary_doc.xml is missing <submissionType>")
+    submission_type, status = _classify(submission_type_text)
+
+    primary_filer_cik_text = _child_text(_find_descendant(root, "filerCredentials"), "cik")
+    if primary_filer_cik_text is None:
+        raise ValueError("primary_doc.xml is missing the primary filer <cik>")
+    primary_filer_cik = _zero_pad_cik(primary_filer_cik_text)
+
+    if submission_type.startswith("SCHEDULE 13D"):
+        issuer_cik, issuer_cusip, issuer_name, class_title, date_of_event, reporters = _extract_13d(root)
+    else:
+        issuer_cik, issuer_cusip, issuer_name, class_title, date_of_event, reporters = _extract_13g(root)
+
+    signature_info = _find_descendant(root, "signatureInfo")
+    signature_date = _child_text(signature_info, "date") if signature_info is not None else None
+    filed_at = _parse_signature_datetime(signature_date)
+
+    return BlockholderFiling(
+        submission_type=submission_type,
+        status=status,
+        primary_filer_cik=primary_filer_cik,
+        issuer_cik=issuer_cik,
+        issuer_cusip=issuer_cusip,
+        issuer_name=issuer_name,
+        securities_class_title=class_title,
+        date_of_event=date_of_event,
+        filed_at=filed_at,
+        reporting_persons=reporters,
+    )

--- a/sql/095_blockholder_filers_filings.sql
+++ b/sql/095_blockholder_filers_filings.sql
@@ -1,0 +1,173 @@
+-- 095_blockholder_filers_filings.sql
+--
+-- Issue #766 PR 1 of 3 — schema for SEC Schedule 13D / 13G
+-- blockholder ingest. Mirrors migration 090 (institutional_filers /
+-- institutional_holdings, #730) in shape but with 13D/G semantics:
+--
+--   * 13F-HR is filed by managers with >$100M discretionary AUM and
+--     enumerates *every* position quarterly. 13D/G are filed by any
+--     beneficial owner who crosses the 5% threshold on a single
+--     issuer — one accession ⇒ one issuer (not a portfolio dump).
+--   * 13D ("active") signals an intent to influence; 13G ("passive")
+--     signals a fund/index posture that will not engage. The
+--     active/passive enum is intrinsic to the form type and is set by
+--     the parser, not by a downstream classifier (this is why #766
+--     ships in 3 PRs vs #730's 4 — there is no separate filer-type
+--     classifier round).
+--   * A single 13D/G accession can carry 1..N reporting persons
+--     (joint filings — see e.g. SCHEDULE 13G accession
+--     0001193125-25-270277, three reporters: Silver Point Capital +
+--     two of its principals). Each reporting person is a row in
+--     ``blockholder_filings``.
+--
+-- Schema decisions:
+--
+--   * ``blockholder_filers`` keys on the *primary* filer's CIK from
+--     ``headerData/filerInfo/filer/filerCredentials/cik``. Joint-
+--     filing co-reporters that have their own CIK still write
+--     ``reporter_cik`` on the filing row but do NOT get their own
+--     ``blockholder_filers`` record — the seed list curates the
+--     primary filer (the entity actually submitting on EDGAR).
+--   * ``blockholder_filings`` carries one row per
+--     reporting-person-per-accession. The PR 2 amendment-chain
+--     aggregator picks the latest non-superseded filing per
+--     ``(reporter_identity, issuer_cik)`` regardless of form type
+--     where ``reporter_identity = COALESCE(reporter_cik,
+--     reporter_name)`` so natural-person / family-trust reporters
+--     (which have no EDGAR CIK) still chain correctly. A 13D filed
+--     after a prior 13G/A by the same reporter on the same issuer
+--     supersedes the 13G chain (the SEC's actual semantics for a
+--     passive→active conversion).
+--   * ``status`` is a derived enum (``13D|13D/A → active``,
+--     ``13G|13G/A → passive``) constrained via CHECK so a parser
+--     regression cannot smuggle a third value into the canonical
+--     store.
+--   * ``instrument_id`` is nullable: the issuer's CUSIP may not yet
+--     resolve via ``external_identifiers`` (the same gap #740 is
+--     tracking for 13F-HR). Persisting the row with ``NULL``
+--     instrument_id keeps the audit trail intact and lets the PR 2
+--     reader skip rows that haven't been resolved yet.
+--   * ``shares`` columns are NUMERIC(24, 4) to match
+--     ``institutional_holdings.shares`` so cross-source aggregation
+--     queries stay arithmetic-clean.
+--   * ``percent_of_class`` is NUMERIC(8, 4) — SEC reports allow up
+--     to 4 decimals (e.g. "47.6843"). 8 total digits gives
+--     headroom for the rare "100.0000" without overflow.
+--   * ``filed_at`` is nullable: the primary_doc.xml signature block
+--     may be missing on a malformed filing; the parser returns
+--     ``None`` rather than raising so the rest of the reporters can
+--     still be ingested. The ingester (PR 2) decides whether to
+--     persist filings with NULL filed_at or to tombstone them.
+--   * ``reporter_cik`` is nullable because individual reporting
+--     persons (natural persons, family trusts, foreign holdcos) often
+--     do not have their own EDGAR CIK; the schema records that case
+--     via ``reporter_no_cik = TRUE`` and falls back to
+--     ``reporter_name`` for identity.
+--
+-- _PLANNER_TABLES in tests/fixtures/ebull_test_db.py is updated in
+-- the same PR per the prevention-log entry "When a migration adds
+-- any table with a FK relationship, update _PLANNER_TABLES …".
+
+CREATE TABLE IF NOT EXISTS blockholder_filers (
+    filer_id      BIGSERIAL PRIMARY KEY,
+    cik           TEXT NOT NULL UNIQUE,
+    name          TEXT NOT NULL,
+    fetched_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS blockholder_filings (
+    filing_id                 BIGSERIAL PRIMARY KEY,
+    filer_id                  BIGINT NOT NULL REFERENCES blockholder_filers(filer_id),
+    accession_number          TEXT NOT NULL,
+    submission_type           TEXT NOT NULL,
+    status                    TEXT NOT NULL,
+    -- ``status`` is parser-derived from ``submission_type`` (13D and
+    -- 13D/A are active; 13G and 13G/A are passive). Enforce the
+    -- invariant at the DB layer with a single cross-column CHECK so
+    -- a future ingester bug or a manual INSERT cannot persist
+    -- e.g. ``submission_type='SCHEDULE 13D' AND status='passive'``
+    -- and silently mislabel an activist filer as passive. Two
+    -- independent enum CHECKs would let that combination through.
+    -- Codex pre-push review caught this on PR review.
+    CONSTRAINT blockholder_filings_submission_type_status_consistent
+        CHECK (
+            (submission_type IN ('SCHEDULE 13D', 'SCHEDULE 13D/A') AND status = 'active')
+            OR
+            (submission_type IN ('SCHEDULE 13G', 'SCHEDULE 13G/A') AND status = 'passive')
+        ),
+    instrument_id             BIGINT REFERENCES instruments(instrument_id),
+    issuer_cik                TEXT NOT NULL,
+    issuer_cusip              TEXT NOT NULL,
+    securities_class_title    TEXT,
+
+    -- Per-reporter identity. ``reporter_cik`` may be NULL for natural
+    -- persons / foreign trusts that have no EDGAR CIK; in that case
+    -- ``reporter_no_cik = TRUE`` and identity falls back to the name.
+    reporter_cik              TEXT,
+    reporter_no_cik           BOOLEAN NOT NULL DEFAULT FALSE,
+    reporter_name             TEXT NOT NULL,
+    member_of_group           TEXT,
+    type_of_reporting_person  TEXT,
+    citizenship               TEXT,
+
+    -- Beneficial-ownership block. NULL when the source filing
+    -- references the prior cover page rather than restating the
+    -- numbers (rare on initial filings; common on amendments).
+    sole_voting_power         NUMERIC(24, 4),
+    shared_voting_power       NUMERIC(24, 4),
+    sole_dispositive_power    NUMERIC(24, 4),
+    shared_dispositive_power  NUMERIC(24, 4),
+    aggregate_amount_owned    NUMERIC(24, 4),
+    percent_of_class          NUMERIC(8, 4),
+
+    date_of_event             DATE,
+    filed_at                  TIMESTAMPTZ,
+    fetched_at                TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Idempotent re-ingest for joint filings: one accession × one
+-- reporter == one row. ``reporter_cik`` is nullable, so use
+-- COALESCE(reporter_cik, '') to keep the unique-index expression
+-- safe — Postgres treats two NULL values as distinct under a plain
+-- UNIQUE constraint, which would let the same reporter insert twice
+-- on a re-ingest of a noCIK row. ``reporter_name`` is the
+-- tie-breaker for accessions where two natural-person reporters both
+-- file with no CIK.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_blockholder_filings_accession_reporter
+    ON blockholder_filings (
+        accession_number,
+        COALESCE(reporter_cik, ''),
+        reporter_name
+    );
+
+-- Hot path for the per-instrument ownership reader (PR 3): walk
+-- filings for one instrument across the most recent dates first.
+CREATE INDEX IF NOT EXISTS idx_blockholder_filings_instrument_filed_at
+    ON blockholder_filings (instrument_id, filed_at DESC);
+
+-- Hot path for the amendment-chain aggregator (PR 2): walk every
+-- filing for a given (reporter, issuer) ordered by filed date so the
+-- latest non-superseded row can be picked in one query.
+--
+-- Reporter identity is ``COALESCE(reporter_cik, reporter_name)``: when
+-- the reporter has an EDGAR CIK, that CIK alone identifies the chain
+-- (cover-page name changes across amendments must NOT split the
+-- chain — e.g. an LLC rebranding). Only when ``reporter_cik IS
+-- NULL`` (natural persons, family trusts, foreign holdcos) does the
+-- name carry the identity. Without the COALESCE, every no-CIK
+-- reporter collapses under ``reporter_cik IS NULL`` in a plain
+-- B-tree index and the aggregator's chain walk silently misses
+-- them. Codex pre-push review caught this on PR review (and a
+-- follow-up review caught the over-strict variant that included
+-- ``reporter_name`` even when ``reporter_cik`` was present).
+CREATE INDEX IF NOT EXISTS idx_blockholder_filings_reporter_issuer_filed_at
+    ON blockholder_filings (
+        COALESCE(reporter_cik, reporter_name),
+        issuer_cik,
+        filed_at DESC
+    );
+
+-- Hot path for the per-filer view (operator audit, ops monitor):
+-- walk every filing for a primary filer ordered by filed date.
+CREATE INDEX IF NOT EXISTS idx_blockholder_filings_filer_filed_at
+    ON blockholder_filings (filer_id, filed_at DESC);

--- a/sql/096_blockholder_filer_seeds_and_log.sql
+++ b/sql/096_blockholder_filer_seeds_and_log.sql
@@ -1,0 +1,76 @@
+-- 096_blockholder_filer_seeds_and_log.sql
+--
+-- Issue #766 PR 1 — operator-curated blockholder seed list and
+-- per-accession ingest tombstone log. Mirrors migration 091
+-- (institutional_filer_seeds + institutional_holdings_ingest_log).
+--
+-- ── blockholder_filer_seeds ────────────────────────────────────
+--
+-- Same logic as the 13F-HR seed list: rather than walk every CIK
+-- that has ever filed a 13D/G (tens of thousands of one-shot family
+-- trusts and small holdcos), the operator curates the few dozen
+-- names that move the needle for tradable mid-cap and small-cap
+-- coverage:
+--
+--   * Activist hedge funds (Icahn, Pershing, Elliott, Starboard,
+--     ValueAct, Trian, Engaged, etc.)
+--   * Founder / founder-family holdcos (Lauder family trusts on
+--     EL, Wachowski-on-NXT-style positions, Soros-on-X-style
+--     positions, etc.)
+--   * Other ≥5%-holders the operator wants to track explicitly
+--
+-- ``label`` is informational — the canonical filer name is fetched
+-- from primary_doc.xml on first ingest and stored on
+-- blockholder_filers.name. Keeping it here helps the operator
+-- audit the seed list without joining to ingest results.
+--
+-- ``active`` lets the operator pause a noisy / problematic filer
+-- without dropping the row (preserves audit trail of prior ingests).
+
+CREATE TABLE IF NOT EXISTS blockholder_filer_seeds (
+    cik         TEXT PRIMARY KEY,
+    label       TEXT NOT NULL,
+    active      BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    notes       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_blockholder_filer_seeds_active
+    ON blockholder_filer_seeds (cik)
+    WHERE active = TRUE;
+
+
+-- ── blockholder_filings_ingest_log ─────────────────────────────
+--
+-- Per-accession attempt tombstone. Same rationale as
+-- ``institutional_holdings_ingest_log``: the ingester (PR 2) needs
+-- a record of *attempts* so empty / failed accessions don't get
+-- re-fetched on every run.
+--
+-- Common reasons an accession produces zero canonical rows:
+--   * Reporter cover page references prior amendments rather than
+--     restating ownership numbers (legal but yields no usable row
+--     for the aggregator).
+--   * Issuer CUSIP unresolved against ``external_identifiers`` (the
+--     same gap #740 tracks for 13F-HR).
+--   * Persistent 404 on the per-accession primary_doc.xml.
+--
+-- Without this table, ``already_ingested`` would be derived from
+-- ``blockholder_filings.accession_number``, which misses every
+-- accession that didn't write a row. Re-runs would then fetch the
+-- same archive forever, burning SEC bandwidth and log noise.
+
+CREATE TABLE IF NOT EXISTS blockholder_filings_ingest_log (
+    accession_number   TEXT PRIMARY KEY,
+    filer_cik          TEXT NOT NULL,
+    submission_type    TEXT,
+    status             TEXT NOT NULL
+        CHECK (status IN ('success', 'partial', 'failed')),
+    rows_inserted      INTEGER NOT NULL DEFAULT 0,
+    rows_skipped       INTEGER NOT NULL DEFAULT 0,
+    error              TEXT,
+    fetched_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_blockholder_filings_ingest_log_filer
+    ON blockholder_filings_ingest_log (filer_cik, fetched_at DESC);

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -111,6 +111,16 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "institutional_filers",
     "institutional_filer_seeds",
     "etf_filer_cik_seeds",
+    # #766 — 13D/G blockholders. Child-to-parent: blockholder_filings
+    # FKs into blockholder_filers AND instruments. The instrument row
+    # truncation further down would cascade, but listing them
+    # explicitly keeps teardown deterministic when a test populates
+    # filer / filing rows without touching the instruments row in the
+    # same case.
+    "blockholder_filings_ingest_log",
+    "blockholder_filings",
+    "blockholder_filers",
+    "blockholder_filer_seeds",
     "filing_events",
     "decision_audit",  # #315 Phase 3 alerts
     "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)

--- a/tests/test_sec_13dg_parser.py
+++ b/tests/test_sec_13dg_parser.py
@@ -1,0 +1,443 @@
+"""Unit tests for the SEC Schedule 13D / 13G XML parser (#766 PR 1).
+
+Fixture XML is hand-built to mirror the namespace + element shape of
+real SEC primary_doc.xml payloads (sampled from accessions
+0001140361-25-040863 — Estee Lauder family 13D — and
+0000950103-25-014355 — Aura Minerals 13G — and
+0001193125-25-270277 — Carmart 13G with 3 joint reporters).
+
+Each scenario pins a single behaviour:
+
+  * Status enum — 13D / 13D/A → active, 13G / 13G/A → passive.
+  * Submission-type validation — unrecognised values raise.
+  * Multi-reporter joint filings — one ``BlockholderReportingPerson``
+    per cover-page block.
+  * 13D vs 13G schema divergence — different field names, different
+    nesting, different namespaces.
+  * No-CIK reporters — natural persons / family trusts persisted via
+    name only with ``no_cik = True``.
+  * Issuer cover-page parsing — CIK / CUSIP / class title / event
+    date.
+  * Signature block — UTC tz-aware datetime, ``None`` when missing.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.providers.implementations.sec_13dg import (
+    BlockholderFiling,
+    parse_primary_doc,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+_NS_13D = "http://www.sec.gov/edgar/schedule13D"
+_NS_13G = "http://www.sec.gov/edgar/schedule13g"
+
+
+def _13d_xml(
+    *,
+    submission_type: str = "SCHEDULE 13D",
+    primary_filer_cik: str = "0002093607",
+    issuer_cik: str = "0001001250",
+    issuer_cusip: str = "518439104",
+    issuer_name: str = "The Estee Lauder Companies Inc.",
+    securities_class_title: str = "Class A Common Stock, par value $.01 per share",
+    date_of_event: str | None = "11/03/2025",
+    signature_date: str | None = "11/06/2025",
+    reporters_xml: str = """
+        <reportingPersonInfo>
+          <reportingPersonCIK>0002093607</reportingPersonCIK>
+          <reportingPersonNoCIK>N</reportingPersonNoCIK>
+          <reportingPersonName>Roaring Fork Trust Company, Inc.</reportingPersonName>
+          <memberOfGroup>b</memberOfGroup>
+          <citizenshipOrOrganization>SD</citizenshipOrOrganization>
+          <soleVotingPower>0</soleVotingPower>
+          <sharedVotingPower>0</sharedVotingPower>
+          <soleDispositivePower>0</soleDispositivePower>
+          <sharedDispositivePower>0</sharedDispositivePower>
+          <aggregateAmountOwned>0</aggregateAmountOwned>
+          <percentOfClass>0</percentOfClass>
+          <typeOfReportingPerson>CO</typeOfReportingPerson>
+        </reportingPersonInfo>
+        <reportingPersonInfo>
+          <reportingPersonNoCIK>Y</reportingPersonNoCIK>
+          <reportingPersonName>The LAL 2015 ELF Trust</reportingPersonName>
+          <memberOfGroup>b</memberOfGroup>
+          <citizenshipOrOrganization>NY</citizenshipOrOrganization>
+          <soleVotingPower>1500000</soleVotingPower>
+          <sharedVotingPower>0</sharedVotingPower>
+          <soleDispositivePower>1500000</soleDispositivePower>
+          <sharedDispositivePower>0</sharedDispositivePower>
+          <aggregateAmountOwned>1500000</aggregateAmountOwned>
+          <percentOfClass>2.5</percentOfClass>
+          <typeOfReportingPerson>OO</typeOfReportingPerson>
+        </reportingPersonInfo>
+    """,
+) -> str:
+    event_block = f"<dateOfEvent>{date_of_event}</dateOfEvent>" if date_of_event else ""
+    sig_block = (
+        f"""
+    <signatureInfo>
+      <signaturePerson>
+        <signatureDetails>
+          <date>{signature_date}</date>
+        </signatureDetails>
+      </signaturePerson>
+    </signatureInfo>"""
+        if signature_date
+        else ""
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="{_NS_13D}">
+  <headerData>
+    <submissionType>{submission_type}</submissionType>
+    <filerInfo>
+      <filer>
+        <filerCredentials>
+          <cik>{primary_filer_cik}</cik>
+        </filerCredentials>
+      </filer>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <coverPageHeader>
+      <securitiesClassTitle>{securities_class_title}</securitiesClassTitle>
+      {event_block}
+      <issuerInfo>
+        <issuerCIK>{issuer_cik}</issuerCIK>
+        <issuerCUSIP>{issuer_cusip}</issuerCUSIP>
+        <issuerName>{issuer_name}</issuerName>
+      </issuerInfo>
+    </coverPageHeader>
+    <reportingPersons>
+      {reporters_xml}
+    </reportingPersons>{sig_block}
+  </formData>
+</edgarSubmission>
+"""
+
+
+def _13g_xml(
+    *,
+    submission_type: str = "SCHEDULE 13G",
+    primary_filer_cik: str = "0002083532",
+    issuer_cik: str = "0001468642",
+    issuer_cusip: str = "G06973112",
+    issuer_name: str = "Aura Minerals Inc.",
+    securities_class_title: str = "Common Shares, no par value",
+    date_of_event: str | None = "09/30/2025",
+    signature_date: str | None = "10/15/2025",
+    reporter_blocks: str = """
+        <coverPageHeaderReportingPersonDetails>
+          <reportingPersonName>De Brito Paulo Carlos</reportingPersonName>
+          <citizenshipOrOrganization>D5</citizenshipOrOrganization>
+          <reportingPersonBeneficiallyOwnedNumberOfShares>
+            <soleVotingPower>39838685.00</soleVotingPower>
+            <sharedVotingPower>0.00</sharedVotingPower>
+            <soleDispositivePower>39838685.00</soleDispositivePower>
+            <sharedDispositivePower>0.00</sharedDispositivePower>
+          </reportingPersonBeneficiallyOwnedNumberOfShares>
+          <reportingPersonBeneficiallyOwnedAggregateNumberOfShares>39838685.00</reportingPersonBeneficiallyOwnedAggregateNumberOfShares>
+          <classPercent>47.6843</classPercent>
+          <typeOfReportingPerson>IN</typeOfReportingPerson>
+        </coverPageHeaderReportingPersonDetails>
+    """,
+) -> str:
+    event_block = (
+        f"<eventDateRequiresFilingThisStatement>{date_of_event}</eventDateRequiresFilingThisStatement>"
+        if date_of_event
+        else ""
+    )
+    sig_block = (
+        f"""
+    <signatureInfo>
+      <signaturePerson>
+        <signatureDetails>
+          <date>{signature_date}</date>
+        </signatureDetails>
+      </signaturePerson>
+    </signatureInfo>"""
+        if signature_date
+        else ""
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="{_NS_13G}">
+  <headerData>
+    <submissionType>{submission_type}</submissionType>
+    <filerInfo>
+      <filer>
+        <filerCredentials>
+          <cik>{primary_filer_cik}</cik>
+        </filerCredentials>
+      </filer>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <coverPageHeader>
+      <securitiesClassTitle>{securities_class_title}</securitiesClassTitle>
+      {event_block}
+      <issuerInfo>
+        <issuerCik>{issuer_cik}</issuerCik>
+        <issuerName>{issuer_name}</issuerName>
+        <issuerCusip>{issuer_cusip}</issuerCusip>
+      </issuerInfo>
+    </coverPageHeader>
+    {reporter_blocks}{sig_block}
+  </formData>
+</edgarSubmission>
+"""
+
+
+# ---------------------------------------------------------------------------
+# 13D parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_13d_returns_active_status_and_zero_padded_ciks() -> None:
+    parsed = parse_primary_doc(_13d_xml())
+
+    assert parsed.submission_type == "SCHEDULE 13D"
+    assert parsed.status == "active"
+    assert parsed.primary_filer_cik == "0002093607"
+    assert parsed.issuer_cik == "0001001250"
+    assert parsed.issuer_cusip == "518439104"
+    assert parsed.issuer_name == "The Estee Lauder Companies Inc."
+    assert parsed.securities_class_title is not None
+    assert parsed.securities_class_title.startswith("Class A Common Stock")
+    assert parsed.date_of_event == date(2025, 11, 3)
+    assert parsed.filed_at == datetime(2025, 11, 6, tzinfo=UTC)
+
+
+def test_parse_13d_amendment_classifies_as_active() -> None:
+    parsed = parse_primary_doc(_13d_xml(submission_type="SCHEDULE 13D/A"))
+    assert parsed.submission_type == "SCHEDULE 13D/A"
+    assert parsed.status == "active"
+
+
+def test_parse_13d_multi_reporter_yields_one_row_each() -> None:
+    parsed = parse_primary_doc(_13d_xml())
+
+    assert len(parsed.reporting_persons) == 2
+
+    rftc, elf = parsed.reporting_persons
+    assert rftc.cik == "0002093607"
+    assert rftc.no_cik is False
+    assert rftc.name == "Roaring Fork Trust Company, Inc."
+    assert rftc.percent_of_class == Decimal("0")
+    assert rftc.type_of_reporting_person == "CO"
+
+    assert elf.cik is None
+    assert elf.no_cik is True
+    assert elf.name == "The LAL 2015 ELF Trust"
+    assert elf.aggregate_amount_owned == Decimal("1500000")
+    assert elf.percent_of_class == Decimal("2.5")
+
+
+def test_parse_13d_pads_short_cik() -> None:
+    parsed = parse_primary_doc(
+        _13d_xml(primary_filer_cik="12345", issuer_cik="67890"),
+    )
+    assert parsed.primary_filer_cik == "0000012345"
+    assert parsed.issuer_cik == "0000067890"
+
+
+def test_parse_13d_missing_signature_returns_none_filed_at() -> None:
+    parsed = parse_primary_doc(_13d_xml(signature_date=None))
+    assert parsed.filed_at is None
+
+
+def test_parse_13d_missing_event_date_returns_none() -> None:
+    parsed = parse_primary_doc(_13d_xml(date_of_event=None))
+    assert parsed.date_of_event is None
+
+
+def test_parse_13d_no_reporters_raises() -> None:
+    with pytest.raises(ValueError, match="no <reportingPersonInfo>"):
+        parse_primary_doc(_13d_xml(reporters_xml=""))
+
+
+def test_parse_13d_missing_issuer_cusip_raises() -> None:
+    xml = _13d_xml().replace("<issuerCUSIP>518439104</issuerCUSIP>", "")
+    with pytest.raises(ValueError, match="<issuerCUSIP>"):
+        parse_primary_doc(xml)
+
+
+def test_parse_13d_missing_reporter_name_raises() -> None:
+    bad_reporter = """
+        <reportingPersonInfo>
+          <reportingPersonCIK>0001234567</reportingPersonCIK>
+          <reportingPersonNoCIK>N</reportingPersonNoCIK>
+          <memberOfGroup>b</memberOfGroup>
+        </reportingPersonInfo>
+    """
+    with pytest.raises(ValueError, match="reportingPersonName"):
+        parse_primary_doc(_13d_xml(reporters_xml=bad_reporter))
+
+
+# ---------------------------------------------------------------------------
+# 13G parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_13g_returns_passive_status() -> None:
+    parsed = parse_primary_doc(_13g_xml())
+
+    assert parsed.submission_type == "SCHEDULE 13G"
+    assert parsed.status == "passive"
+    assert parsed.primary_filer_cik == "0002083532"
+    assert parsed.issuer_cik == "0001468642"
+    assert parsed.issuer_cusip == "G06973112"
+    assert parsed.issuer_name == "Aura Minerals Inc."
+    assert parsed.date_of_event == date(2025, 9, 30)
+
+
+def test_parse_13g_amendment_classifies_as_passive() -> None:
+    parsed = parse_primary_doc(_13g_xml(submission_type="SCHEDULE 13G/A"))
+    assert parsed.submission_type == "SCHEDULE 13G/A"
+    assert parsed.status == "passive"
+
+
+def test_parse_13g_extracts_nested_voting_powers_and_class_percent() -> None:
+    parsed = parse_primary_doc(_13g_xml())
+
+    assert len(parsed.reporting_persons) == 1
+    person = parsed.reporting_persons[0]
+    assert person.name == "De Brito Paulo Carlos"
+    assert person.cik is None  # no CIK element on the cover-page block
+    assert person.no_cik is True
+    assert person.sole_voting_power == Decimal("39838685.00")
+    assert person.aggregate_amount_owned == Decimal("39838685.00")
+    assert person.percent_of_class == Decimal("47.6843")
+    assert person.type_of_reporting_person == "IN"
+
+
+def test_parse_13g_with_explicit_reporter_cik_zero_pads_and_strips_no_cik() -> None:
+    """Some 13G filings carry an explicit ``<reportingPersonCik>`` even
+    though the SEC schema makes it optional; the parser must zero-pad
+    it like every other CIK in the codebase and report ``no_cik=False``
+    when the element is present and non-empty. Both the camelCase
+    (``Cik``) and the all-caps (``CIK``) tag spellings are valid in
+    practice and the parser tolerates either."""
+    blocks_camel = """
+        <coverPageHeaderReportingPersonDetails>
+          <reportingPersonCik>12345</reportingPersonCik>
+          <reportingPersonName>Some Registered Holder LLC</reportingPersonName>
+          <classPercent>9.9</classPercent>
+        </coverPageHeaderReportingPersonDetails>
+    """
+    parsed = parse_primary_doc(_13g_xml(reporter_blocks=blocks_camel))
+    assert len(parsed.reporting_persons) == 1
+    person = parsed.reporting_persons[0]
+    assert person.cik == "0000012345"
+    assert person.no_cik is False
+    assert person.name == "Some Registered Holder LLC"
+    assert person.percent_of_class == Decimal("9.9")
+
+    blocks_caps = blocks_camel.replace(
+        "<reportingPersonCik>12345</reportingPersonCik>",
+        "<reportingPersonCIK>67890</reportingPersonCIK>",
+    )
+    parsed_caps = parse_primary_doc(_13g_xml(reporter_blocks=blocks_caps))
+    assert parsed_caps.reporting_persons[0].cik == "0000067890"
+    assert parsed_caps.reporting_persons[0].no_cik is False
+
+
+def test_parse_13g_multi_reporter_joint_filing() -> None:
+    """Carmart-style joint filing — three reporters (firm + 2 principals)."""
+    blocks = """
+        <coverPageHeaderReportingPersonDetails>
+          <reportingPersonName>Silver Point Capital, L.P.</reportingPersonName>
+          <citizenshipOrOrganization>DE</citizenshipOrOrganization>
+          <reportingPersonBeneficiallyOwnedNumberOfShares>
+            <soleVotingPower>0</soleVotingPower>
+            <sharedVotingPower>800000</sharedVotingPower>
+            <soleDispositivePower>0</soleDispositivePower>
+            <sharedDispositivePower>800000</sharedDispositivePower>
+          </reportingPersonBeneficiallyOwnedNumberOfShares>
+          <reportingPersonBeneficiallyOwnedAggregateNumberOfShares>800000</reportingPersonBeneficiallyOwnedAggregateNumberOfShares>
+          <classPercent>15.3</classPercent>
+          <typeOfReportingPerson>IA</typeOfReportingPerson>
+        </coverPageHeaderReportingPersonDetails>
+        <coverPageHeaderReportingPersonDetails>
+          <reportingPersonName>Edward A. Mule</reportingPersonName>
+          <citizenshipOrOrganization>US</citizenshipOrOrganization>
+          <classPercent>15.3</classPercent>
+          <typeOfReportingPerson>IN</typeOfReportingPerson>
+        </coverPageHeaderReportingPersonDetails>
+        <coverPageHeaderReportingPersonDetails>
+          <reportingPersonName>Robert J. O'Shea</reportingPersonName>
+          <citizenshipOrOrganization>US</citizenshipOrOrganization>
+          <classPercent>15.3</classPercent>
+          <typeOfReportingPerson>IN</typeOfReportingPerson>
+        </coverPageHeaderReportingPersonDetails>
+    """
+    parsed = parse_primary_doc(_13g_xml(reporter_blocks=blocks))
+
+    names = [p.name for p in parsed.reporting_persons]
+    assert names == [
+        "Silver Point Capital, L.P.",
+        "Edward A. Mule",
+        "Robert J. O'Shea",
+    ]
+    # All three claim the same percent — joint-filing semantics.
+    percents = {p.percent_of_class for p in parsed.reporting_persons}
+    assert percents == {Decimal("15.3")}
+    # Only the firm has voting/dispositive numbers; the individuals
+    # defer to the firm's cover page.
+    assert parsed.reporting_persons[0].shared_voting_power == Decimal("800000")
+    assert parsed.reporting_persons[1].shared_voting_power is None
+    assert parsed.reporting_persons[2].shared_voting_power is None
+
+
+def test_parse_13g_no_reporters_raises() -> None:
+    with pytest.raises(ValueError, match="coverPageHeaderReportingPersonDetails"):
+        parse_primary_doc(_13g_xml(reporter_blocks=""))
+
+
+def test_parse_13g_missing_issuer_cik_raises() -> None:
+    xml = _13g_xml().replace("<issuerCik>0001468642</issuerCik>", "")
+    with pytest.raises(ValueError, match="<issuerCik>"):
+        parse_primary_doc(xml)
+
+
+# ---------------------------------------------------------------------------
+# Submission-type validation
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_submission_type_raises() -> None:
+    xml = _13d_xml(submission_type="SCHEDULE 13F")
+    with pytest.raises(ValueError, match="unsupported submission type"):
+        parse_primary_doc(xml)
+
+
+def test_missing_submission_type_raises() -> None:
+    xml = _13d_xml().replace("<submissionType>SCHEDULE 13D</submissionType>", "")
+    with pytest.raises(ValueError, match="<submissionType>"):
+        parse_primary_doc(xml)
+
+
+def test_missing_primary_filer_cik_raises() -> None:
+    xml = _13d_xml().replace("<cik>0002093607</cik>", "")
+    # The header CIK is the first <cik> element; removing it makes
+    # the parser miss the primary filer credentials block.
+    with pytest.raises(ValueError, match="primary filer"):
+        parse_primary_doc(xml)
+
+
+# ---------------------------------------------------------------------------
+# Sanity: dataclass identity
+# ---------------------------------------------------------------------------
+
+
+def test_returned_dataclass_is_blockholder_filing() -> None:
+    parsed = parse_primary_doc(_13d_xml())
+    assert isinstance(parsed, BlockholderFiling)


### PR DESCRIPTION
## What

Schema + XML parser for SEC Schedule 13D / 13G blockholder ingest. PR 1 of a 3-PR series for #766.

- `sql/095_blockholder_filers_filings.sql` — filers + filings tables
- `sql/096_blockholder_filer_seeds_and_log.sql` — operator seed list + per-accession tombstone
- `app/providers/implementations/sec_13dg.py` — XML parser handling both 13D and 13G namespaces
- `tests/test_sec_13dg_parser.py` — 20 cases
- `tests/fixtures/ebull_test_db.py` — `_PLANNER_TABLES` update

## Why

Activist hedge funds, founders, and ≥5%-holders that file 13D/G are currently invisible on the ownership card — they collapse silently into the open-market residual when in fact they're often the single largest holder on small / mid caps (Icahn, Ackman, Buffett private holdings, founder retention). The 5th sunburst category lands in PR 3.

3 PRs (vs #730's 4) because passive/active is intrinsic to 13G/13D form type — no separate filer-type classifier round.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pyright` — clean
- [x] `uv run pytest tests/test_sec_13dg_parser.py` — 20 pass
- [x] `uv run pytest tests/smoke/test_app_boots.py` — pass (migrations apply)
- [x] Codex pre-push review — clean after 2 follow-up rounds (see below)

3 pre-existing test failures on main (`test_jobs_queue_boot_drain`, `test_migration_071_exchanges_capabilities`, `test_sync_orchestrator_dispatcher`) are unrelated and not touched by this PR.

## Codex pre-push findings (all addressed)

1. **Cross-column CHECK on `(submission_type, status)`** — independent enum CHECKs would let `SCHEDULE 13D + passive` slip through and silently mislabel an activist filer. Replaced with single `blockholder_filings_submission_type_status_consistent` CHECK.
2. **Amendment-chain hot-path index** — original keyed on `reporter_cik` alone, collapsing all no-CIK reporters under NULL. Now `COALESCE(reporter_cik, reporter_name)` so natural-person reporters chain correctly while CIK-registered reporters chain across cover-page name changes.
3. **Positive-CIK 13G test fixture** — added `test_parse_13g_with_explicit_reporter_cik_zero_pads_and_strips_no_cik` covering both `<reportingPersonCik>` (camelCase) and `<reportingPersonCIK>` (all-caps) tag spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)