### PR TITLE
feat(#766): 13D/G blockholders ingester + amendment-chain aggregator (PR 2/3)

### DIFF
--- a/app/services/blockholders.py
+++ b/app/services/blockholders.py
@@ -1,0 +1,925 @@
+"""SEC Schedule 13D / 13G blockholder ingester (#766 PR 2 of 3).
+
+Walks the operator-curated ``blockholder_filer_seeds`` list and, for
+each active filer:
+
+  1. Fetches ``data.sec.gov/submissions/CIK{cik}.json`` to discover
+     SC 13D / SC 13D/A / SC 13G / SC 13G/A accessions filed by that
+     CIK. The submissions index uses ``SC 13D`` / ``SC 13D/A`` /
+     ``SC 13G`` / ``SC 13G/A`` form labels; the canonical
+     ``SCHEDULE 13D`` / ``SCHEDULE 13G`` strings come from the parsed
+     primary_doc.xml itself, not the index.
+  2. For each accession not yet present in
+     ``blockholder_filings_ingest_log``, fetches the per-filing
+     ``primary_doc.xml`` directly. Unlike 13F-HR the 13D/G archive
+     has no separate infotable — every canonical field (issuer
+     CUSIP, ownership block, reporter list) lives in primary_doc.
+     The ``index.json`` walk is therefore unnecessary.
+  3. Parses primary_doc.xml via :mod:`app.providers.implementations.
+     sec_13dg`. A single accession yields 1..N reporting persons
+     (joint filings), and the ingester writes one
+     ``blockholder_filings`` row per reporter.
+  4. Resolves the issuer CUSIP to an ``instrument_id`` via
+     ``external_identifiers``. Filings whose CUSIP is unknown still
+     write rows (with ``instrument_id IS NULL``) so the audit trail
+     stays intact and the PR 3 reader can re-attempt resolution
+     once the #740 backfill closes the gap.
+  5. Upserts the primary filer + every reporter row inside one
+     transaction. Idempotent re-ingest of the same accession is
+     guaranteed by the partial UNIQUE INDEX from migration 095.
+
+The ingester is the only DB-touching half of the pipeline; the
+parser stays pure. The HTTP fetch routes through the bounded-
+concurrency client added in #728 so concurrent filer ingests share
+the SEC fair-use rate budget.
+
+Tombstones: a filing whose primary_doc.xml fetch 404s is recorded in
+``blockholder_filings_ingest_log`` with ``status='failed'`` plus the
+accession number in ``error``. The next run sees the accession is
+still missing and skips it — short-lived 404s heal naturally;
+persistent failures show up in the ops monitor (#13). To force a
+retry the operator deletes the log row.
+
+The amendment-chain aggregator (:func:`latest_blockholder_positions`)
+is exposed here so PR 3's reader endpoint can call it without
+re-implementing the SEC supersession semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import xml.etree.ElementTree as ET  # noqa: S405 — only used to catch ET.ParseError; no untrusted input parsed here.
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any, Protocol
+
+import psycopg
+import psycopg.rows
+
+from app.providers.implementations.sec_13dg import (
+    BlockholderFiling,
+    BlockholderReportingPerson,
+    parse_primary_doc,
+)
+from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Provider contract
+# ---------------------------------------------------------------------------
+
+
+class SecArchiveFetcher(Protocol):
+    """Subset of the SEC EDGAR provider this ingester relies on.
+
+    Decoupled to keep the service unit-testable with an in-memory
+    fake. The production binding is :class:`app.providers.
+    implementations.sec_edgar.SecEdgarProvider`.
+    """
+
+    def fetch_document_text(self, absolute_url: str) -> str | None: ...
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+# SEC submissions JSON labels SC 13D forms with the abbreviated
+# ``SC`` prefix; primary_doc.xml carries the long-form
+# ``SCHEDULE 13D`` instead. Both representations are valid.
+_SUBMISSIONS_INDEX_FORMS: frozenset[str] = frozenset(("SC 13D", "SC 13D/A", "SC 13G", "SC 13G/A"))
+
+
+@dataclass(frozen=True)
+class AccessionRef:
+    """One discovered 13D / 13G accession to ingest."""
+
+    accession_number: str
+    filing_type: str  # one of _SUBMISSIONS_INDEX_FORMS values
+    filed_at: datetime | None
+
+
+@dataclass(frozen=True)
+class IngestSummary:
+    """Per-filer rollup of one ingest pass.
+
+    ``submissions_fetch_failed`` is set when the per-CIK
+    submissions JSON itself is unreachable. The batch wrapper uses
+    this signal to downgrade ``data_ingestion_runs.status`` to
+    ``partial`` so a stale seed entry (CIK renamed, EDGAR archive
+    moved, fair-use throttling) does not silently masquerade as
+    ``success`` with zero rows. Codex pre-push review caught this on
+    PR review.
+    """
+
+    filer_cik: str
+    accessions_seen: int
+    accessions_ingested: int
+    accessions_failed: int
+    rows_inserted: int  # one row per reporter; sums across accessions
+    rows_skipped_no_cusip: int
+    submissions_fetch_failed: bool = False
+    first_error: str | None = None
+
+
+@dataclass(frozen=True)
+class BlockholderPosition:
+    """Aggregator row: latest non-superseded filing per reporter on
+    one issuer. Returned by :func:`latest_blockholder_positions`.
+
+    ``reporter_identity`` matches the schema's hot-path index key:
+    the reporter CIK when present, the reporter name when not. Joint
+    filers under one CIK collapse to a single position; co-reporters
+    on a joint filing with different CIKs (or names) each get their
+    own position so the consumer can dedupe via ``member_of_group``
+    if needed.
+    """
+
+    reporter_identity: str
+    reporter_cik: str | None
+    reporter_name: str
+    issuer_cik: str
+    instrument_id: int | None
+    submission_type: str
+    status: str
+    aggregate_amount_owned: Decimal | None
+    percent_of_class: Decimal | None
+    member_of_group: str | None
+    type_of_reporting_person: str | None
+    accession_number: str
+    date_of_event: date | None
+    filed_at: datetime | None
+
+
+# ---------------------------------------------------------------------------
+# URL builders
+# ---------------------------------------------------------------------------
+
+
+_SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik}.json"
+_ARCHIVE_URL = "https://www.sec.gov/Archives/edgar/data/{cik_int}/{accn_no_dashes}/{filename}"
+
+
+def _zero_pad_cik(cik: str | int) -> str:
+    return str(int(str(cik).strip())).zfill(10)
+
+
+def _accession_no_dashes(accession_number: str) -> str:
+    return accession_number.replace("-", "")
+
+
+def _submissions_url(cik: str) -> str:
+    return _SUBMISSIONS_URL.format(cik=_zero_pad_cik(cik))
+
+
+def _archive_file_url(cik: str, accession_number: str, filename: str) -> str:
+    return _ARCHIVE_URL.format(
+        cik_int=int(_zero_pad_cik(cik)),
+        accn_no_dashes=_accession_no_dashes(accession_number),
+        filename=filename,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Submissions index walker
+# ---------------------------------------------------------------------------
+
+
+def parse_submissions_index(payload: str) -> list[AccessionRef] | None:
+    """Walk ``data.sec.gov/submissions/CIK{cik}.json`` and emit one
+    :class:`AccessionRef` per SC 13D / SC 13G row.
+
+    Returns ``None`` when the payload is not valid JSON — the
+    ingester treats that the same as a 404 / transport failure so a
+    malformed 200-body cannot silently masquerade as "no recent
+    filings" (which would emit a clean ``success`` audit record for a
+    filer whose seed entry has actually gone stale). Codex pre-push
+    review caught this on PR review.
+
+    Returns ``[]`` when the payload is valid JSON but carries no
+    13D/G accessions in the ``recent`` array — that is a legitimate
+    "filer has nothing on file in this form family" outcome.
+
+    Mirrors the 13F-HR equivalent in ``app/services/
+    institutional_holdings.py`` but filters on the four 13D/G
+    submission-form labels instead of 13F-HR. ``period_of_report``
+    has no analogue on 13D/G (the form covers a single event, not a
+    fiscal quarter), so the ref carries only the accession + form +
+    filing-date timestamp; the canonical event date comes from the
+    parser's ``date_of_event`` later.
+
+    Older-history shards referenced via ``files`` are out of scope —
+    the recent array holds the latest ~1,000 filings per CIK, far
+    more than the operator-curated seed list will need.
+    """
+    try:
+        data: dict[str, Any] = json.loads(payload)
+    except json.JSONDecodeError:
+        logger.warning("13D/G submissions index payload is not valid JSON")
+        return None
+
+    filings = data.get("filings", {})
+    recent = filings.get("recent", {})
+    accessions = recent.get("accessionNumber", [])
+    forms = recent.get("form", [])
+    filing_dates = recent.get("filingDate", [])
+
+    out: list[AccessionRef] = []
+    for i, accession in enumerate(accessions):
+        if i >= len(forms):
+            break
+        form = str(forms[i]).strip()
+        if form not in _SUBMISSIONS_INDEX_FORMS:
+            continue
+        filed_at = _safe_iso_datetime(filing_dates[i] if i < len(filing_dates) else "")
+        out.append(
+            AccessionRef(
+                accession_number=str(accession),
+                filing_type=form,
+                filed_at=filed_at,
+            )
+        )
+    return out
+
+
+def _safe_iso_date(text: str | None) -> date | None:
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _safe_iso_datetime(text: str | None) -> datetime | None:
+    """Coerce ``YYYY-MM-DD`` to a UTC tz-aware ``datetime``. The 13F
+    ingester carries the same helper for the same reason: ``filed_at``
+    is TIMESTAMPTZ and a naive datetime would drift to the server's
+    local zone on write."""
+    parsed = _safe_iso_date(text)
+    if parsed is None:
+        return None
+    return datetime(parsed.year, parsed.month, parsed.day, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _list_active_filer_seeds(conn: psycopg.Connection[tuple]) -> list[str]:
+    cur = conn.execute("SELECT cik FROM blockholder_filer_seeds WHERE active = TRUE ORDER BY cik")
+    return [_zero_pad_cik(row[0]) for row in cur.fetchall()]
+
+
+def _existing_accessions_for_filer(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_cik: str,
+) -> set[str]:
+    """Return every accession_number this filer has already had an
+    ingest attempt for — success / partial / failed all count.
+
+    Reads from ``blockholder_filings_ingest_log`` rather than
+    ``blockholder_filings.accession_number`` because:
+
+      * A failed accession (404, parse error) writes no filing row
+        but must still be skipped by the next run to avoid
+        re-fetching forever.
+      * A partial accession (issuer CUSIP unresolved) DOES write
+        filing rows with ``instrument_id IS NULL``, but the log
+        carries the canonical "have we attempted this?" answer.
+
+    To force a retry, the operator deletes the log row.
+    """
+    cur = conn.execute(
+        "SELECT accession_number FROM blockholder_filings_ingest_log WHERE filer_cik = %(cik)s",
+        {"cik": filer_cik},
+    )
+    return {row[0] for row in cur.fetchall()}
+
+
+def _record_ingest_attempt(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_cik: str,
+    accession_number: str,
+    submission_type: str | None,
+    status: str,
+    rows_inserted: int = 0,
+    rows_skipped: int = 0,
+    error: str | None = None,
+) -> None:
+    """Idempotent upsert into ``blockholder_filings_ingest_log``.
+
+    Status is one of ``'success'`` / ``'partial'`` / ``'failed'``.
+    Re-recording the same accession overwrites the prior attempt so a
+    follow-up successful run can promote a failed/partial accession
+    to success.
+    """
+    conn.execute(
+        """
+        INSERT INTO blockholder_filings_ingest_log (
+            accession_number, filer_cik, submission_type,
+            status, rows_inserted, rows_skipped, error
+        ) VALUES (
+            %(accession_number)s, %(filer_cik)s, %(submission_type)s,
+            %(status)s, %(rows_inserted)s, %(rows_skipped)s, %(error)s
+        )
+        ON CONFLICT (accession_number) DO UPDATE SET
+            status = EXCLUDED.status,
+            rows_inserted = EXCLUDED.rows_inserted,
+            rows_skipped = EXCLUDED.rows_skipped,
+            error = EXCLUDED.error,
+            fetched_at = NOW()
+        """,
+        {
+            "accession_number": accession_number,
+            "filer_cik": filer_cik,
+            "submission_type": submission_type,
+            "status": status,
+            "rows_inserted": rows_inserted,
+            "rows_skipped": rows_skipped,
+            "error": error,
+        },
+    )
+
+
+def _resolve_cusip_to_instrument_id(
+    conn: psycopg.Connection[tuple],
+    cusip: str,
+) -> int | None:
+    """Look up the instrument_id mapped to a CUSIP via
+    external_identifiers. Same lookup shape as the 13F-HR ingester —
+    the CUSIP backfill (#740) populates these rows."""
+    cur = conn.execute(
+        """
+        SELECT instrument_id
+        FROM external_identifiers
+        WHERE provider = 'sec'
+          AND identifier_type = 'cusip'
+          AND identifier_value = %(cusip)s
+        ORDER BY is_primary DESC, external_identifier_id ASC
+        LIMIT 1
+        """,
+        {"cusip": cusip.strip().upper()},
+    )
+    row = cur.fetchone()
+    return int(row[0]) if row is not None else None
+
+
+def seed_filer(
+    conn: psycopg.Connection[tuple],
+    *,
+    cik: str | int,
+    label: str,
+    notes: str | None = None,
+    active: bool = True,
+) -> None:
+    """Idempotent helper for adding a filer to the curated seed list.
+
+    Used by tests + an operator-side script. The admin UI in PR 3
+    will call the same helper via an API endpoint.
+    """
+    conn.execute(
+        """
+        INSERT INTO blockholder_filer_seeds (cik, label, active, notes)
+        VALUES (%(cik)s, %(label)s, %(active)s, %(notes)s)
+        ON CONFLICT (cik) DO UPDATE SET
+            label = EXCLUDED.label,
+            active = EXCLUDED.active,
+            notes = COALESCE(EXCLUDED.notes, blockholder_filer_seeds.notes)
+        """,
+        {
+            "cik": _zero_pad_cik(cik),
+            "label": label,
+            "active": active,
+            "notes": notes,
+        },
+    )
+
+
+def _upsert_filer(
+    conn: psycopg.Connection[tuple],
+    *,
+    cik: str,
+    name: str,
+) -> int:
+    """Insert / update a ``blockholder_filers`` row. Returns filer_id.
+
+    Unlike the 13F-HR ``institutional_filers`` row this carries no
+    derived ``filer_type`` — 13D/G has no analogue (the active /
+    passive split lives on each filing row, derived from
+    submission_type by the parser). The filer record is just an
+    EDGAR-CIK-to-name map for audit + the operator UI.
+    """
+    cur = conn.execute(
+        """
+        INSERT INTO blockholder_filers (cik, name)
+        VALUES (%(cik)s, %(name)s)
+        ON CONFLICT (cik) DO UPDATE SET
+            name = EXCLUDED.name,
+            fetched_at = NOW()
+        RETURNING filer_id
+        """,
+        {"cik": cik, "name": name},
+    )
+    row = cur.fetchone()
+    assert row is not None, "filer upsert RETURNING produced no row"
+    return int(row[0])
+
+
+def _upsert_filing_row(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_id: int,
+    accession_number: str,
+    submission_type: str,
+    status: str,
+    instrument_id: int | None,
+    issuer_cik: str,
+    issuer_cusip: str,
+    securities_class_title: str | None,
+    date_of_event: date | None,
+    filed_at: datetime | None,
+    person: BlockholderReportingPerson,
+) -> bool:
+    """Per-reporter upsert. Returns True on insert, False on
+    re-ingest of the same ``(accession, reporter_cik COALESCE '',
+    reporter_name)`` tuple — the partial UNIQUE INDEX from migration
+    095 backstops re-runs.
+    """
+    cur = conn.execute(
+        """
+        INSERT INTO blockholder_filings (
+            filer_id, accession_number, submission_type, status,
+            instrument_id, issuer_cik, issuer_cusip, securities_class_title,
+            reporter_cik, reporter_no_cik, reporter_name,
+            member_of_group, type_of_reporting_person, citizenship,
+            sole_voting_power, shared_voting_power,
+            sole_dispositive_power, shared_dispositive_power,
+            aggregate_amount_owned, percent_of_class,
+            date_of_event, filed_at
+        ) VALUES (
+            %(filer_id)s, %(accession_number)s, %(submission_type)s, %(status)s,
+            %(instrument_id)s, %(issuer_cik)s, %(issuer_cusip)s, %(securities_class_title)s,
+            %(reporter_cik)s, %(reporter_no_cik)s, %(reporter_name)s,
+            %(member_of_group)s, %(type_of_reporting_person)s, %(citizenship)s,
+            %(sole_voting_power)s, %(shared_voting_power)s,
+            %(sole_dispositive_power)s, %(shared_dispositive_power)s,
+            %(aggregate_amount_owned)s, %(percent_of_class)s,
+            %(date_of_event)s, %(filed_at)s
+        )
+        ON CONFLICT DO NOTHING
+        """,
+        {
+            "filer_id": filer_id,
+            "accession_number": accession_number,
+            "submission_type": submission_type,
+            "status": status,
+            "instrument_id": instrument_id,
+            "issuer_cik": issuer_cik,
+            "issuer_cusip": issuer_cusip,
+            "securities_class_title": securities_class_title,
+            "reporter_cik": person.cik,
+            "reporter_no_cik": person.no_cik,
+            "reporter_name": person.name,
+            "member_of_group": person.member_of_group,
+            "type_of_reporting_person": person.type_of_reporting_person,
+            "citizenship": person.citizenship,
+            "sole_voting_power": person.sole_voting_power,
+            "shared_voting_power": person.shared_voting_power,
+            "sole_dispositive_power": person.sole_dispositive_power,
+            "shared_dispositive_power": person.shared_dispositive_power,
+            "aggregate_amount_owned": person.aggregate_amount_owned,
+            "percent_of_class": person.percent_of_class,
+            "date_of_event": date_of_event,
+            "filed_at": filed_at,
+        },
+    )
+    return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# Internal mutable helper
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MutableSummary:
+    cik: str
+    accessions_seen: int = 0
+    accessions_ingested: int = 0
+    accessions_failed: int = 0
+    rows_inserted: int = 0
+    rows_skipped_no_cusip: int = 0
+    submissions_fetch_failed: bool = False
+    first_error: str | None = None
+
+    def to_immutable(self) -> IngestSummary:
+        return IngestSummary(
+            filer_cik=self.cik,
+            accessions_seen=self.accessions_seen,
+            accessions_ingested=self.accessions_ingested,
+            accessions_failed=self.accessions_failed,
+            rows_inserted=self.rows_inserted,
+            rows_skipped_no_cusip=self.rows_skipped_no_cusip,
+            submissions_fetch_failed=self.submissions_fetch_failed,
+            first_error=self.first_error,
+        )
+
+
+@dataclass(frozen=True)
+class _AccessionOutcome:
+    status: str
+    rows_inserted: int
+    rows_skipped_no_cusip: int
+    error: str | None
+    submission_type: str | None  # None when the parse never produced one
+
+    @property
+    def ingested(self) -> bool:
+        return self.status in ("success", "partial")
+
+
+# ---------------------------------------------------------------------------
+# Ingest core
+# ---------------------------------------------------------------------------
+
+
+def _ingest_single_accession(
+    conn: psycopg.Connection[tuple],
+    sec: SecArchiveFetcher,
+    *,
+    filer_cik: str,
+    ref: AccessionRef,
+) -> _AccessionOutcome:
+    """Per-accession driver. Never raises — every fetch / parse
+    failure resolves to an ``_AccessionOutcome`` with status='failed'
+    so a single malformed accession does not abort the filer batch.
+
+    13D/G accessions only have one canonical XML attachment
+    (primary_doc.xml). No archive index walk is necessary.
+    """
+    primary_url = _archive_file_url(filer_cik, ref.accession_number, "primary_doc.xml")
+
+    primary_xml = sec.fetch_document_text(primary_url)
+    if primary_xml is None:
+        logger.info(
+            "13D/G ingest: primary_doc.xml 404/error for cik=%s accession=%s",
+            filer_cik,
+            ref.accession_number,
+        )
+        return _AccessionOutcome(
+            status="failed",
+            rows_inserted=0,
+            rows_skipped_no_cusip=0,
+            error="primary_doc.xml fetch failed",
+            submission_type=None,
+        )
+
+    try:
+        filing: BlockholderFiling = parse_primary_doc(primary_xml)
+    except (ValueError, ET.ParseError) as exc:
+        # ``ET.ParseError`` covers malformed XML (truncated download,
+        # mid-byte cutoff, accidental HTML error page returned with a
+        # 200). ``ValueError`` covers parser-side schema errors
+        # (missing required field, unrecognised submissionType).
+        # Both must tombstone so the batch loop does not roll back
+        # the whole filer's transaction. Codex pre-push review caught
+        # the missing ParseError handler.
+        logger.exception(
+            "13D/G ingest: primary_doc.xml parse failed for cik=%s accession=%s",
+            filer_cik,
+            ref.accession_number,
+        )
+        return _AccessionOutcome(
+            status="failed",
+            rows_inserted=0,
+            rows_skipped_no_cusip=0,
+            error=f"primary_doc.xml parse failed: {exc}",
+            submission_type=None,
+        )
+
+    instrument_id = _resolve_cusip_to_instrument_id(conn, filing.issuer_cusip)
+    skipped_no_cusip = 0 if instrument_id is not None else len(filing.reporting_persons)
+
+    # Resolve the *filer's* canonical name. ``filing.issuer_name`` is
+    # the issuer (the company being filed against), not the filer.
+    # The filer's name is not carried directly in primary_doc.xml —
+    # the SEC schema records only the filer's CIK in
+    # ``<filerCredentials>``. We pick:
+    #   1. A reporting-person row whose CIK matches the primary
+    #      filer's CIK — covers the common case where the filer is
+    #      also one of the reporters on its own filing.
+    #   2. Otherwise the first reporting person — the filer is then
+    #      a service company (transfer agent, edgar agent) acting on
+    #      behalf of the reporters; the first reporter's name is the
+    #      most useful operator-facing label.
+    #   3. Otherwise a placeholder. Should not occur — the parser
+    #      already raises ValueError when reporting_persons is empty.
+    filer_name = next(
+        (p.name for p in filing.reporting_persons if p.cik == filing.primary_filer_cik),
+        filing.reporting_persons[0].name if filing.reporting_persons else f"CIK {filing.primary_filer_cik}",
+    )
+    filer_id = _upsert_filer(conn, cik=filing.primary_filer_cik, name=filer_name)
+
+    inserted = 0
+    for person in filing.reporting_persons:
+        if _upsert_filing_row(
+            conn,
+            filer_id=filer_id,
+            accession_number=ref.accession_number,
+            submission_type=filing.submission_type,
+            status=filing.status,
+            instrument_id=instrument_id,
+            issuer_cik=filing.issuer_cik,
+            issuer_cusip=filing.issuer_cusip,
+            securities_class_title=filing.securities_class_title,
+            date_of_event=filing.date_of_event,
+            filed_at=filing.filed_at or ref.filed_at,
+            person=person,
+        ):
+            inserted += 1
+
+    if instrument_id is None:
+        # Issuer CUSIP unresolved — every reporter row writes with
+        # ``instrument_id IS NULL``. Mark the accession ``partial`` so
+        # the operator sees the gap on the ops monitor and the audit
+        # trail tracks why the rows are unjoinable to ``instruments``.
+        return _AccessionOutcome(
+            status="partial",
+            rows_inserted=inserted,
+            rows_skipped_no_cusip=skipped_no_cusip,
+            error=f"issuer CUSIP {filing.issuer_cusip!r} unresolved (gated by #740 backfill)",
+            submission_type=filing.submission_type,
+        )
+
+    return _AccessionOutcome(
+        status="success",
+        rows_inserted=inserted,
+        rows_skipped_no_cusip=0,
+        error=None,
+        submission_type=filing.submission_type,
+    )
+
+
+def ingest_filer_blockholders(
+    conn: psycopg.Connection[tuple],
+    sec: SecArchiveFetcher,
+    *,
+    filer_cik: str,
+) -> IngestSummary:
+    """Fetch + parse + upsert every pending 13D/G filing for one filer.
+
+    ``filer_cik`` is normalised to 10-digit padded form on entry.
+    The function commits no transactions itself — the caller (test
+    code or :func:`ingest_all_active_filers`) decides commit cadence.
+    """
+    cik = _zero_pad_cik(filer_cik)
+    summary = _MutableSummary(cik=cik)
+
+    submissions_payload = sec.fetch_document_text(_submissions_url(cik))
+    if submissions_payload is None:
+        logger.warning("13D/G ingest: submissions JSON 404/error for cik=%s", cik)
+        summary.submissions_fetch_failed = True
+        summary.first_error = "submissions JSON 404/error"
+        return summary.to_immutable()
+
+    pending_accessions = parse_submissions_index(submissions_payload)
+    if pending_accessions is None:
+        # Malformed 200-body — treated the same as a 404 so a stale
+        # CIK whose archive returns garbage (or HTML) does not
+        # silently masquerade as "no filings = success".
+        logger.warning("13D/G ingest: submissions JSON malformed for cik=%s", cik)
+        summary.submissions_fetch_failed = True
+        summary.first_error = "submissions JSON malformed"
+        return summary.to_immutable()
+    summary.accessions_seen = len(pending_accessions)
+
+    already_ingested = _existing_accessions_for_filer(conn, filer_cik=cik)
+
+    for ref in pending_accessions:
+        if ref.accession_number in already_ingested:
+            continue
+        outcome = _ingest_single_accession(conn, sec, filer_cik=cik, ref=ref)
+        _record_ingest_attempt(
+            conn,
+            filer_cik=cik,
+            accession_number=ref.accession_number,
+            submission_type=outcome.submission_type or ref.filing_type,
+            status=outcome.status,
+            rows_inserted=outcome.rows_inserted,
+            rows_skipped=outcome.rows_skipped_no_cusip,
+            error=outcome.error,
+        )
+        if outcome.ingested:
+            summary.accessions_ingested += 1
+        else:
+            summary.accessions_failed += 1
+            if outcome.error and summary.first_error is None:
+                summary.first_error = f"{ref.accession_number}: {outcome.error}"
+        summary.rows_inserted += outcome.rows_inserted
+        summary.rows_skipped_no_cusip += outcome.rows_skipped_no_cusip
+
+    return summary.to_immutable()
+
+
+def ingest_all_active_filers(
+    conn: psycopg.Connection[tuple],
+    sec: SecArchiveFetcher,
+) -> list[IngestSummary]:
+    """Walk every active row in ``blockholder_filer_seeds`` and ingest."""
+    seeds = _list_active_filer_seeds(conn)
+    if not seeds:
+        logger.info("13D/G ingest: no active filer seeds; nothing to do")
+        return []
+
+    run_id = start_ingestion_run(
+        conn,
+        source="sec_edgar_13dg",
+        endpoint="/Archives/edgar/data/{cik}/{accession}/primary_doc.xml",
+        instrument_count=len(seeds),
+    )
+    conn.commit()
+
+    rows_upserted = 0
+    rows_skipped = 0
+    summaries: list[IngestSummary] = []
+    crash_error: str | None = None
+    accession_failures = 0
+    submissions_failures = 0
+    first_filer_error: str | None = None
+    try:
+        for cik in seeds:
+            try:
+                summary = ingest_filer_blockholders(conn, sec, filer_cik=cik)
+            except Exception as exc:  # noqa: BLE001 — per-filer crash must not abort the batch
+                logger.exception("13D/G ingest: filer %s raised; continuing batch", cik)
+                crash_error = f"{cik}: {exc}"
+                conn.rollback()
+                continue
+            conn.commit()
+            summaries.append(summary)
+            rows_upserted += summary.rows_inserted
+            rows_skipped += summary.rows_skipped_no_cusip
+            accession_failures += summary.accessions_failed
+            if summary.submissions_fetch_failed:
+                submissions_failures += 1
+            if summary.first_error and first_filer_error is None:
+                first_filer_error = f"{cik} {summary.first_error}"
+    finally:
+        # Status precedence:
+        #   * any per-filer crash + zero summaries -> failed
+        #   * any per-filer crash with summaries  -> partial
+        #   * any submissions-fetch failure        -> partial
+        #     (a curated seed is silently invisible without this)
+        #   * any per-accession failure            -> partial
+        #   * any unresolved-CUSIP skip            -> partial
+        #   * else                                 -> success
+        if crash_error and not summaries:
+            status = "failed"
+        elif crash_error or accession_failures > 0 or rows_skipped > 0 or submissions_failures > 0:
+            status = "partial"
+        else:
+            status = "success"
+        error_parts: list[str] = []
+        if crash_error:
+            error_parts.append(f"crash: {crash_error}")
+        if submissions_failures > 0:
+            error_parts.append(f"{submissions_failures} filer submissions fetch failed")
+        if first_filer_error:
+            error_parts.append(f"first: {first_filer_error}")
+        if rows_skipped > 0 and not error_parts:
+            error_parts.append(f"{rows_skipped} reporter rows skipped — issuer CUSIPs unresolved (#740)")
+        finish_ingestion_run(
+            conn,
+            run_id=run_id,
+            status=status,
+            rows_upserted=rows_upserted,
+            rows_skipped=rows_skipped,
+            error="; ".join(error_parts) or None,
+        )
+        conn.commit()
+
+    return summaries
+
+
+# ---------------------------------------------------------------------------
+# Amendment-chain aggregator
+# ---------------------------------------------------------------------------
+
+
+def latest_blockholder_positions(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+) -> list[BlockholderPosition]:
+    """Return the latest non-superseded blockholder filing per
+    ``(reporter_identity, issuer_cik)`` for one instrument.
+
+    Reporter identity is ``COALESCE(reporter_cik, reporter_name)``,
+    matching the schema's hot-path index. The aggregator picks the
+    row with the latest ``filed_at`` per identity regardless of form
+    type, so a 13D filed after a prior 13G/A by the same reporter on
+    the same issuer correctly supersedes the 13G chain (passive →
+    active conversion).
+
+    Ordering: ``filed_at DESC NULLS LAST`` so a row with NULL filed_at
+    (parser failed to extract a signature date) never wins against a
+    row with a real filed_at.
+
+    The PR 3 reader endpoint calls this directly. Exposed as a
+    service function rather than an ORM-style method so unit tests
+    can call it without going through the HTTP layer.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT ON (
+                COALESCE(reporter_cik, reporter_name),
+                issuer_cik
+            )
+                COALESCE(reporter_cik, reporter_name) AS reporter_identity,
+                reporter_cik,
+                reporter_name,
+                issuer_cik,
+                instrument_id,
+                submission_type,
+                status,
+                aggregate_amount_owned,
+                percent_of_class,
+                member_of_group,
+                type_of_reporting_person,
+                accession_number,
+                date_of_event,
+                filed_at
+            FROM blockholder_filings
+            WHERE instrument_id = %(instrument_id)s
+            ORDER BY
+                COALESCE(reporter_cik, reporter_name),
+                issuer_cik,
+                filed_at DESC NULLS LAST,
+                accession_number DESC
+            """,
+            {"instrument_id": instrument_id},
+        )
+        rows = cur.fetchall()
+
+    return [
+        BlockholderPosition(
+            reporter_identity=row["reporter_identity"],
+            reporter_cik=row["reporter_cik"],
+            reporter_name=row["reporter_name"],
+            issuer_cik=row["issuer_cik"],
+            instrument_id=row["instrument_id"],
+            submission_type=row["submission_type"],
+            status=row["status"],
+            aggregate_amount_owned=row["aggregate_amount_owned"],
+            percent_of_class=row["percent_of_class"],
+            member_of_group=row["member_of_group"],
+            type_of_reporting_person=row["type_of_reporting_person"],
+            accession_number=row["accession_number"],
+            date_of_event=row["date_of_event"],
+            filed_at=row["filed_at"],
+        )
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Iterator (exposed for ad-hoc reporting / debug)
+# ---------------------------------------------------------------------------
+
+
+def iter_filer_filings(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_cik: str,
+    limit: int = 1000,
+) -> Iterator[dict[str, Any]]:
+    """Yield the most recent filings for one primary filer."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT bf.accession_number, bf.submission_type, bf.status,
+                   bf.reporter_name, bf.reporter_cik, bf.aggregate_amount_owned,
+                   bf.percent_of_class, bf.date_of_event, bf.filed_at,
+                   bf.issuer_cusip, i.symbol, i.company_name
+            FROM blockholder_filings bf
+            JOIN blockholder_filers f USING (filer_id)
+            LEFT JOIN instruments i ON i.instrument_id = bf.instrument_id
+            WHERE f.cik = %(cik)s
+            ORDER BY bf.filed_at DESC NULLS LAST, bf.accession_number DESC
+            LIMIT %(limit)s
+            """,
+            {"cik": _zero_pad_cik(filer_cik), "limit": limit},
+        )
+        for row in cur.fetchall():
+            yield dict(row)

--- a/tests/test_blockholders_ingester.py
+++ b/tests/test_blockholders_ingester.py
@@ -1,0 +1,902 @@
+"""Integration tests for the 13D/G blockholders ingester (#766 PR 2).
+
+The service interacts with three boundaries:
+  1. SEC HTTP — abstracted as :class:`SecArchiveFetcher` so tests
+     can substitute a deterministic in-memory fake.
+  2. Postgres — the real ``ebull_test`` DB, since the service
+     issues several intertwined statements (existing-accessions
+     scan, CUSIP resolution, filer + filings upserts) and mocking
+     that path would erase the value of these tests.
+  3. The pure parser from #766 PR 1 — exercised end-to-end here.
+
+Each test seeds the inputs (an instrument with a known CUSIP
+mapping, a filer seed, a fake fetcher for HTTP) and asserts the
+final canonical row state.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services.blockholders import (
+    ingest_all_active_filers,
+    ingest_filer_blockholders,
+    latest_blockholder_positions,
+    parse_submissions_index,
+    seed_filer,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders — minimal SEC payloads
+# ---------------------------------------------------------------------------
+
+
+def _submissions_json(*, accessions: list[tuple[str, str, str]]) -> str:
+    """Build a fake submissions JSON. Each tuple is
+    ``(accession, form, filing_date)``."""
+    return json.dumps(
+        {
+            "filings": {
+                "recent": {
+                    "accessionNumber": [a[0] for a in accessions],
+                    "form": [a[1] for a in accessions],
+                    "filingDate": [a[2] for a in accessions],
+                },
+                "files": [],
+            }
+        }
+    )
+
+
+_NS_13D = "http://www.sec.gov/edgar/schedule13D"
+_NS_13G = "http://www.sec.gov/edgar/schedule13g"
+
+
+def _13d_xml(
+    *,
+    submission_type: str = "SCHEDULE 13D",
+    primary_filer_cik: str = "0001234567",
+    primary_filer_name: str = "Test Activist Fund LP",
+    issuer_cik: str = "0000012345",
+    issuer_cusip: str = "037833100",
+    issuer_name: str = "APPLE INC",
+    signature_date: str = "11/06/2025",
+    aggregate_shares: str = "1500000",
+    percent: str = "5.5",
+) -> str:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="{_NS_13D}">
+  <headerData>
+    <submissionType>{submission_type}</submissionType>
+    <filerInfo>
+      <filer>
+        <filerCredentials>
+          <cik>{primary_filer_cik}</cik>
+        </filerCredentials>
+      </filer>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <coverPageHeader>
+      <securitiesClassTitle>Common Stock</securitiesClassTitle>
+      <dateOfEvent>11/03/2025</dateOfEvent>
+      <issuerInfo>
+        <issuerCIK>{issuer_cik}</issuerCIK>
+        <issuerCUSIP>{issuer_cusip}</issuerCUSIP>
+        <issuerName>{issuer_name}</issuerName>
+      </issuerInfo>
+    </coverPageHeader>
+    <reportingPersons>
+      <reportingPersonInfo>
+        <reportingPersonCIK>{primary_filer_cik}</reportingPersonCIK>
+        <reportingPersonNoCIK>N</reportingPersonNoCIK>
+        <reportingPersonName>{primary_filer_name}</reportingPersonName>
+        <memberOfGroup>b</memberOfGroup>
+        <citizenshipOrOrganization>DE</citizenshipOrOrganization>
+        <soleVotingPower>{aggregate_shares}</soleVotingPower>
+        <sharedVotingPower>0</sharedVotingPower>
+        <soleDispositivePower>{aggregate_shares}</soleDispositivePower>
+        <sharedDispositivePower>0</sharedDispositivePower>
+        <aggregateAmountOwned>{aggregate_shares}</aggregateAmountOwned>
+        <percentOfClass>{percent}</percentOfClass>
+        <typeOfReportingPerson>PN</typeOfReportingPerson>
+      </reportingPersonInfo>
+    </reportingPersons>
+    <signatureInfo>
+      <signaturePerson>
+        <signatureDetails>
+          <date>{signature_date}</date>
+        </signatureDetails>
+      </signaturePerson>
+    </signatureInfo>
+  </formData>
+</edgarSubmission>
+"""
+
+
+def _13g_xml(
+    *,
+    submission_type: str = "SCHEDULE 13G",
+    primary_filer_cik: str = "0001234567",
+    primary_filer_name: str = "Test Passive Holder",
+    issuer_cik: str = "0000012345",
+    issuer_cusip: str = "037833100",
+    issuer_name: str = "APPLE INC",
+    signature_date: str = "09/15/2025",
+    aggregate_shares: str = "500000",
+    percent: str = "2.5",
+) -> str:
+    """Build a real-shape 13G primary_doc.xml for the supersession test.
+
+    13G uses a different namespace (``schedule13g``), different
+    casing on issuer fields (``issuerCik`` not ``issuerCIK``), and
+    repeats ``<coverPageHeaderReportingPersonDetails>`` directly under
+    ``<formData>`` rather than wrapping reporters in
+    ``<reportingPersons>``. Codex pre-push review caught the prior
+    test using ``_13d_xml(submission_type='SCHEDULE 13G/A')`` which
+    was syntactically 13D but labelled 13G — the parser raised
+    instead of exercising the supersession path.
+    """
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="{_NS_13G}">
+  <headerData>
+    <submissionType>{submission_type}</submissionType>
+    <filerInfo>
+      <filer>
+        <filerCredentials>
+          <cik>{primary_filer_cik}</cik>
+        </filerCredentials>
+      </filer>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <coverPageHeader>
+      <securitiesClassTitle>Common Stock</securitiesClassTitle>
+      <eventDateRequiresFilingThisStatement>09/10/2025</eventDateRequiresFilingThisStatement>
+      <issuerInfo>
+        <issuerCik>{issuer_cik}</issuerCik>
+        <issuerName>{issuer_name}</issuerName>
+        <issuerCusip>{issuer_cusip}</issuerCusip>
+      </issuerInfo>
+    </coverPageHeader>
+    <coverPageHeaderReportingPersonDetails>
+      <reportingPersonCik>{primary_filer_cik}</reportingPersonCik>
+      <reportingPersonName>{primary_filer_name}</reportingPersonName>
+      <citizenshipOrOrganization>DE</citizenshipOrOrganization>
+      <reportingPersonBeneficiallyOwnedNumberOfShares>
+        <soleVotingPower>{aggregate_shares}</soleVotingPower>
+        <sharedVotingPower>0</sharedVotingPower>
+        <soleDispositivePower>{aggregate_shares}</soleDispositivePower>
+        <sharedDispositivePower>0</sharedDispositivePower>
+      </reportingPersonBeneficiallyOwnedNumberOfShares>
+      <reportingPersonBeneficiallyOwnedAggregateNumberOfShares>{aggregate_shares}</reportingPersonBeneficiallyOwnedAggregateNumberOfShares>
+      <classPercent>{percent}</classPercent>
+      <typeOfReportingPerson>IA</typeOfReportingPerson>
+    </coverPageHeaderReportingPersonDetails>
+    <signatureInfo>
+      <signaturePerson>
+        <signatureDetails>
+          <date>{signature_date}</date>
+        </signatureDetails>
+      </signaturePerson>
+    </signatureInfo>
+  </formData>
+</edgarSubmission>
+"""
+
+
+def _13d_multi_reporter_xml(
+    *,
+    primary_filer_cik: str = "0001234567",
+    issuer_cusip: str = "037833100",
+    signature_date: str = "11/06/2025",
+) -> str:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="{_NS_13D}">
+  <headerData>
+    <submissionType>SCHEDULE 13D</submissionType>
+    <filerInfo>
+      <filer>
+        <filerCredentials>
+          <cik>{primary_filer_cik}</cik>
+        </filerCredentials>
+      </filer>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <coverPageHeader>
+      <securitiesClassTitle>Common Stock</securitiesClassTitle>
+      <dateOfEvent>11/03/2025</dateOfEvent>
+      <issuerInfo>
+        <issuerCIK>0000012345</issuerCIK>
+        <issuerCUSIP>{issuer_cusip}</issuerCUSIP>
+        <issuerName>APPLE INC</issuerName>
+      </issuerInfo>
+    </coverPageHeader>
+    <reportingPersons>
+      <reportingPersonInfo>
+        <reportingPersonCIK>{primary_filer_cik}</reportingPersonCIK>
+        <reportingPersonNoCIK>N</reportingPersonNoCIK>
+        <reportingPersonName>Test Activist Fund LP</reportingPersonName>
+        <memberOfGroup>b</memberOfGroup>
+        <citizenshipOrOrganization>DE</citizenshipOrOrganization>
+        <aggregateAmountOwned>1500000</aggregateAmountOwned>
+        <percentOfClass>5.5</percentOfClass>
+        <typeOfReportingPerson>PN</typeOfReportingPerson>
+      </reportingPersonInfo>
+      <reportingPersonInfo>
+        <reportingPersonNoCIK>Y</reportingPersonNoCIK>
+        <reportingPersonName>Jane Doe (managing member)</reportingPersonName>
+        <memberOfGroup>b</memberOfGroup>
+        <citizenshipOrOrganization>NY</citizenshipOrOrganization>
+        <aggregateAmountOwned>1500000</aggregateAmountOwned>
+        <percentOfClass>5.5</percentOfClass>
+        <typeOfReportingPerson>IN</typeOfReportingPerson>
+      </reportingPersonInfo>
+    </reportingPersons>
+    <signatureInfo>
+      <signaturePerson>
+        <signatureDetails>
+          <date>{signature_date}</date>
+        </signatureDetails>
+      </signaturePerson>
+    </signatureInfo>
+  </formData>
+</edgarSubmission>
+"""
+
+
+class _InMemoryFetcher:
+    """Deterministic SecArchiveFetcher fake."""
+
+    def __init__(self, payloads: dict[str, str | None]) -> None:
+        self._payloads = payloads
+        self.calls: list[str] = []
+
+    def fetch_document_text(self, absolute_url: str) -> str | None:
+        self.calls.append(absolute_url)
+        return self._payloads.get(absolute_url)
+
+
+# ---------------------------------------------------------------------------
+# DB seeding helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} test"),
+    )
+
+
+def _seed_cusip_mapping(conn: psycopg.Connection[tuple], *, instrument_id: int, cusip: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (%s, 'sec', 'cusip', %s, TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        """,
+        (instrument_id, cusip.upper()),
+    )
+
+
+def _archive_url(filer_cik: str, accession: str, filename: str) -> str:
+    return f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/{filename}"
+
+
+# ---------------------------------------------------------------------------
+# Pure-parser tests (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestParseSubmissionsIndex:
+    def test_filters_to_13dg_forms_only(self) -> None:
+        payload = _submissions_json(
+            accessions=[
+                ("0001234567-25-000001", "SC 13D", "2025-11-06"),
+                ("0001234567-25-000002", "10-K", "2025-09-15"),
+                ("0001234567-25-000003", "SC 13D/A", "2025-11-15"),
+                ("0001234567-25-000004", "SC 13G", "2025-10-01"),
+                ("0001234567-25-000005", "SC 13G/A", "2025-10-15"),
+                ("0001234567-25-000006", "13F-HR", "2025-11-14"),
+            ]
+        )
+        refs = parse_submissions_index(payload)
+        assert refs is not None
+        assert len(refs) == 4
+        assert {r.filing_type for r in refs} == {"SC 13D", "SC 13D/A", "SC 13G", "SC 13G/A"}
+
+    def test_filed_at_is_utc_tz_aware(self) -> None:
+        payload = _submissions_json(accessions=[("0001234567-25-000001", "SC 13D", "2025-11-06")])
+        refs = parse_submissions_index(payload)
+        assert refs is not None
+        ref = refs[0]
+        assert ref.filed_at == datetime(2025, 11, 6, tzinfo=UTC)
+        assert ref.filed_at is not None and ref.filed_at.tzinfo is UTC
+
+    def test_malformed_json_returns_none(self) -> None:
+        """Malformed payload returns None (not []) so the ingester can
+        distinguish ``no 13D/G filings on file`` (legitimate empty
+        list) from ``cannot parse the index`` (treat as a failure).
+        """
+        assert parse_submissions_index("not json") is None
+
+    def test_missing_recent_returns_empty_list(self) -> None:
+        """Valid JSON with no 'recent' array is a legitimate empty
+        result — distinct from malformed JSON above."""
+        assert parse_submissions_index('{"filings": {}}') == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: end-to-end ingest
+# ---------------------------------------------------------------------------
+
+
+class TestIngestFilerBlockholders:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=766_001, symbol="AAPL")
+        _seed_cusip_mapping(conn, instrument_id=766_001, cusip="037833100")
+        seed_filer(conn, cik="0001234567", label="TEST ACTIVIST FUND")
+        conn.commit()
+        return conn
+
+    def _build_fetcher(
+        self,
+        *,
+        accessions: list[tuple[str, str, str]],
+        xml_by_accession: dict[str, str],
+    ) -> _InMemoryFetcher:
+        cik = "0001234567"
+        payloads: dict[str, str | None] = {
+            f"https://data.sec.gov/submissions/CIK{cik}.json": _submissions_json(accessions=accessions),
+        }
+        for accession, xml in xml_by_accession.items():
+            payloads[_archive_url(cik, accession, "primary_doc.xml")] = xml
+        return _InMemoryFetcher(payloads)
+
+    def test_single_reporter_13d_writes_one_row(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        accession = "0001234567-25-000001"
+        fetcher = self._build_fetcher(
+            accessions=[(accession, "SC 13D", "2025-11-06")],
+            xml_by_accession={accession: _13d_xml()},
+        )
+
+        summary = ingest_filer_blockholders(conn, fetcher, filer_cik="0001234567")
+        conn.commit()
+
+        assert summary.accessions_seen == 1
+        assert summary.accessions_ingested == 1
+        assert summary.rows_inserted == 1
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT bf.accession_number, bf.submission_type, bf.status,
+                       bf.reporter_name, bf.reporter_cik, bf.aggregate_amount_owned,
+                       bf.percent_of_class, bf.instrument_id, i.symbol, f.name AS filer_name
+                FROM blockholder_filings bf
+                JOIN blockholder_filers f USING (filer_id)
+                JOIN instruments i ON i.instrument_id = bf.instrument_id
+                """
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["submission_type"] == "SCHEDULE 13D"
+        assert row["status"] == "active"
+        assert row["reporter_cik"] == "0001234567"
+        assert row["aggregate_amount_owned"] == Decimal("1500000")
+        assert row["percent_of_class"] == Decimal("5.5")
+        assert row["symbol"] == "AAPL"
+        assert row["filer_name"] == "Test Activist Fund LP"
+
+    def test_multi_reporter_writes_n_rows(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Joint 13D with a fund + a no-CIK individual reporter writes
+        2 rows under the same accession; both link to the same
+        instrument and the same filer record."""
+        conn = _setup
+        accession = "0001234567-25-000002"
+        fetcher = self._build_fetcher(
+            accessions=[(accession, "SC 13D", "2025-11-06")],
+            xml_by_accession={accession: _13d_multi_reporter_xml()},
+        )
+
+        summary = ingest_filer_blockholders(conn, fetcher, filer_cik="0001234567")
+        conn.commit()
+
+        assert summary.rows_inserted == 2
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT reporter_name, reporter_cik, reporter_no_cik FROM blockholder_filings ORDER BY reporter_name"
+            )
+            rows = cur.fetchall()
+        assert [r["reporter_name"] for r in rows] == [
+            "Jane Doe (managing member)",
+            "Test Activist Fund LP",
+        ]
+        assert rows[0]["reporter_cik"] is None
+        assert rows[0]["reporter_no_cik"] is True
+        assert rows[1]["reporter_cik"] == "0001234567"
+        assert rows[1]["reporter_no_cik"] is False
+
+    def test_re_ingest_is_idempotent(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        accession = "0001234567-25-000003"
+        fetcher = self._build_fetcher(
+            accessions=[(accession, "SC 13D", "2025-11-06")],
+            xml_by_accession={accession: _13d_xml()},
+        )
+
+        first = ingest_filer_blockholders(conn, fetcher, filer_cik="0001234567")
+        conn.commit()
+        assert first.rows_inserted == 1
+
+        fetcher.calls.clear()
+        second = ingest_filer_blockholders(conn, fetcher, filer_cik="0001234567")
+        conn.commit()
+        assert second.accessions_seen == 1
+        assert second.accessions_ingested == 0
+        assert second.rows_inserted == 0
+        # Only the submissions JSON was re-fetched; primary_doc skipped.
+        assert any("submissions" in url for url in fetcher.calls)
+        assert not any("primary_doc.xml" in url for url in fetcher.calls)
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM blockholder_filings")
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 1
+
+    def test_unresolved_cusip_writes_partial_row(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """A filing whose issuer CUSIP isn't yet mapped via #740 writes
+        the reporter row(s) with ``instrument_id IS NULL`` and tags
+        the ingest log entry as ``partial``."""
+        conn = _setup
+        accession = "0001234567-25-000004"
+        fetcher = self._build_fetcher(
+            accessions=[(accession, "SC 13D", "2025-11-06")],
+            xml_by_accession={accession: _13d_xml(issuer_cusip="999999999")},
+        )
+
+        summary = ingest_filer_blockholders(conn, fetcher, filer_cik="0001234567")
+        conn.commit()
+
+        assert summary.accessions_ingested == 1
+        assert summary.rows_inserted == 1
+        assert summary.rows_skipped_no_cusip == 1
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT instrument_id, issuer_cusip FROM blockholder_filings")
+            row = cur.fetchone()
+        assert row is not None
+        assert row["instrument_id"] is None
+        assert row["issuer_cusip"] == "999999999"
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT status, error FROM blockholder_filings_ingest_log WHERE accession_number = %s",
+                (accession,),
+            )
+            log = cur.fetchone()
+        assert log is not None
+        assert log["status"] == "partial"
+        assert log["error"] is not None and "999999999" in log["error"]
+
+    def test_primary_doc_404_is_recorded_failed(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        accession = "0001234567-25-000005"
+        fetcher = self._build_fetcher(
+            accessions=[(accession, "SC 13D", "2025-11-06")],
+            xml_by_accession={},  # primary_doc absent → 404
+        )
+
+        summary = ingest_filer_blockholders(conn, fetcher, filer_cik="0001234567")
+        conn.commit()
+
+        assert summary.accessions_failed == 1
+        assert summary.rows_inserted == 0
+        assert summary.first_error is not None and "primary_doc" in summary.first_error
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT status, error FROM blockholder_filings_ingest_log WHERE accession_number = %s",
+                (accession,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "failed"
+
+    def test_parse_failure_recorded_failed(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Malformed primary_doc.xml lands in the log as failed; the
+        next run skips the accession instead of re-fetching."""
+        conn = _setup
+        accession = "0001234567-25-000006"
+        bad_xml = """<?xml version="1.0"?><edgarSubmission xmlns="http://www.sec.gov/edgar/schedule13D"><headerData><submissionType>WRONG</submissionType></headerData></edgarSubmission>"""
+        fetcher = self._build_fetcher(
+            accessions=[(accession, "SC 13D", "2025-11-06")],
+            xml_by_accession={accession: bad_xml},
+        )
+
+        summary = ingest_filer_blockholders(conn, fetcher, filer_cik="0001234567")
+        conn.commit()
+
+        assert summary.accessions_failed == 1
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT status FROM blockholder_filings_ingest_log WHERE accession_number = %s",
+                (accession,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "failed"
+
+    def test_submissions_404_is_no_op(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """If the per-CIK submissions JSON is unreachable the ingester
+        logs a warning and returns an empty summary — the next run
+        retries without writing any tombstone."""
+        conn = _setup
+        fetcher = _InMemoryFetcher({})
+
+        summary = ingest_filer_blockholders(conn, fetcher, filer_cik="0001234567")
+        conn.commit()
+
+        assert summary.accessions_seen == 0
+        assert summary.rows_inserted == 0
+
+
+# ---------------------------------------------------------------------------
+# Amendment-chain aggregator
+# ---------------------------------------------------------------------------
+
+
+class TestLatestBlockholderPositions:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=766_010, symbol="AAPL")
+        _seed_cusip_mapping(conn, instrument_id=766_010, cusip="037833100")
+        seed_filer(conn, cik="0001234567", label="TEST FUND")
+        conn.commit()
+        return conn
+
+    def _ingest(self, conn: psycopg.Connection[tuple], accession: str, xml: str) -> None:
+        fetcher = _InMemoryFetcher(
+            {
+                "https://data.sec.gov/submissions/CIK0001234567.json": _submissions_json(
+                    accessions=[(accession, "SC 13D", "2025-11-06")]
+                ),
+                _archive_url("0001234567", accession, "primary_doc.xml"): xml,
+            }
+        )
+        ingest_filer_blockholders(conn, fetcher, filer_cik="0001234567")
+        conn.commit()
+        # Reset the seed-list ingest skip so the next call picks up
+        # a new accession. We do that by NOT calling the same
+        # ingest cycle again; instead each test ingests once per
+        # accession via separate fetchers below.
+
+    def test_13d_supersedes_prior_13g_amendment(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Passive→active conversion: a 13D filed after a prior 13G/A
+        by the same reporter on the same issuer must win the chain.
+        Verifies the aggregator picks the latest filed_at regardless
+        of form-family (the schema's intended supersession semantic).
+        """
+        conn = _setup
+        # First filing: real-shape 13G/A (passive). Build with
+        # _13g_xml so the parser actually round-trips it; previous
+        # version of this test built a 13D body with a 13G label
+        # which silently failed to parse. Codex pre-push review.
+        first_accession = "0001234567-25-000010"
+        first_xml = _13g_xml(
+            submission_type="SCHEDULE 13G/A",
+            signature_date="09/15/2025",
+            aggregate_shares="500000",
+            percent="2.5",
+        )
+        # Second filing: 13D active, supersedes the prior 13G/A
+        second_accession = "0001234567-25-000011"
+        second_xml = _13d_xml(
+            submission_type="SCHEDULE 13D",
+            signature_date="11/06/2025",
+            aggregate_shares="2000000",
+            percent="7.0",
+        )
+
+        f1 = _InMemoryFetcher(
+            {
+                "https://data.sec.gov/submissions/CIK0001234567.json": _submissions_json(
+                    accessions=[(first_accession, "SC 13G/A", "2025-09-15")]
+                ),
+                _archive_url("0001234567", first_accession, "primary_doc.xml"): first_xml,
+            }
+        )
+        first_summary = ingest_filer_blockholders(conn, f1, filer_cik="0001234567")
+        conn.commit()
+        # Sanity: the prior 13G/A must actually have ingested. Without
+        # this the supersession assertion below would pass vacuously.
+        assert first_summary.rows_inserted == 1
+        assert first_summary.accessions_failed == 0
+
+        f2 = _InMemoryFetcher(
+            {
+                "https://data.sec.gov/submissions/CIK0001234567.json": _submissions_json(
+                    accessions=[(second_accession, "SC 13D", "2025-11-06")]
+                ),
+                _archive_url("0001234567", second_accession, "primary_doc.xml"): second_xml,
+            }
+        )
+        second_summary = ingest_filer_blockholders(conn, f2, filer_cik="0001234567")
+        conn.commit()
+        assert second_summary.rows_inserted == 1
+
+        positions = latest_blockholder_positions(conn, instrument_id=766_010)
+
+        assert len(positions) == 1
+        position = positions[0]
+        assert position.reporter_cik == "0001234567"
+        assert position.submission_type == "SCHEDULE 13D"
+        assert position.status == "active"
+        assert position.aggregate_amount_owned == Decimal("2000000")
+        assert position.percent_of_class == Decimal("7.0")
+        assert position.accession_number == second_accession
+
+    def test_no_cik_reporter_chains_by_name(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Two filings by the same no-CIK natural-person reporter on
+        the same issuer should collapse to one position keyed on the
+        reporter's name."""
+        conn = _setup
+        first_accession = "0001234567-25-000020"
+        second_accession = "0001234567-25-000021"
+
+        f1 = _InMemoryFetcher(
+            {
+                "https://data.sec.gov/submissions/CIK0001234567.json": _submissions_json(
+                    accessions=[(first_accession, "SC 13D", "2025-09-01")]
+                ),
+                _archive_url("0001234567", first_accession, "primary_doc.xml"): _13d_multi_reporter_xml(
+                    signature_date="09/01/2025",
+                ),
+            }
+        )
+        ingest_filer_blockholders(conn, f1, filer_cik="0001234567")
+        conn.commit()
+
+        f2 = _InMemoryFetcher(
+            {
+                "https://data.sec.gov/submissions/CIK0001234567.json": _submissions_json(
+                    accessions=[(second_accession, "SC 13D/A", "2025-11-06")]
+                ),
+                _archive_url("0001234567", second_accession, "primary_doc.xml"): _13d_multi_reporter_xml(
+                    signature_date="11/06/2025",
+                ),
+            }
+        )
+        ingest_filer_blockholders(conn, f2, filer_cik="0001234567")
+        conn.commit()
+
+        positions = latest_blockholder_positions(conn, instrument_id=766_010)
+        # 2 reporters in the joint filing, each chains independently;
+        # the latest accession wins for each.
+        assert len(positions) == 2
+        accessions = {p.accession_number for p in positions}
+        assert accessions == {second_accession}
+
+
+# ---------------------------------------------------------------------------
+# Batch entry point
+# ---------------------------------------------------------------------------
+
+
+class TestIngestAllActiveFilers:
+    def test_no_seeds_returns_empty(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        fetcher = _InMemoryFetcher({})
+        result = ingest_all_active_filers(ebull_test_conn, fetcher)
+        assert result == []
+
+    def test_per_filer_crash_does_not_abort_batch(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A filer whose ingest raises (DB error, parser bug, network
+        exception bubbling past the per-accession handler) must not
+        abort the batch — the loop catches and records the crash,
+        then continues. Codex pre-push review caught the prior
+        version of this test exercising the clean no-op path
+        instead of the actual ``except Exception`` branch."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=766_030, symbol="AAPL")
+        _seed_cusip_mapping(conn, instrument_id=766_030, cusip="037833100")
+        seed_filer(conn, cik="0001234567", label="WORKING FUND")
+        seed_filer(conn, cik="0009999999", label="CRASHING FUND")
+        conn.commit()
+
+        accession = "0001234567-25-000050"
+        good_payloads: dict[str, str | None] = {
+            "https://data.sec.gov/submissions/CIK0001234567.json": _submissions_json(
+                accessions=[(accession, "SC 13D", "2025-11-06")]
+            ),
+            _archive_url("0001234567", accession, "primary_doc.xml"): _13d_xml(),
+        }
+
+        class _RaisingForOneCikFetcher:
+            """Returns happy payloads for the working filer; raises a
+            transport-style exception for the crashing filer's
+            submissions URL. Exercises the batch's
+            ``except Exception`` branch."""
+
+            def __init__(self) -> None:
+                self.calls: list[str] = []
+
+            def fetch_document_text(self, absolute_url: str) -> str | None:
+                self.calls.append(absolute_url)
+                if "CIK0009999999" in absolute_url:
+                    raise RuntimeError("simulated transport failure")
+                return good_payloads.get(absolute_url)
+
+        fetcher = _RaisingForOneCikFetcher()
+        summaries = ingest_all_active_filers(conn, fetcher)
+
+        # Working filer's summary is present; the crashing filer is
+        # absent (its summary never returned because the function
+        # raised — the loop's except-branch logged and continued).
+        assert len(summaries) == 1
+        assert summaries[0].filer_cik == "0001234567"
+        assert summaries[0].rows_inserted == 1
+
+        # data_ingestion_runs row records the partial run with the
+        # crash citation in error.
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT status, error FROM data_ingestion_runs ORDER BY ingestion_run_id DESC LIMIT 1")
+            row = cur.fetchone()
+        assert row is not None
+        assert row["status"] == "partial"
+        assert row["error"] is not None and "0009999999" in row["error"]
+
+    def test_malformed_submissions_payload_downgrades_run_to_partial(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A 200-body submissions payload that is not valid JSON (e.g.
+        an HTML error page returned with a 200 status) must downgrade
+        the batch run to ``partial``, not silently report ``success``
+        with zero rows. Codex pre-push review caught this on PR
+        review."""
+        conn = ebull_test_conn
+        seed_filer(conn, cik="0001234567", label="MALFORMED FUND")
+        conn.commit()
+
+        fetcher = _InMemoryFetcher(
+            {
+                "https://data.sec.gov/submissions/CIK0001234567.json": "<html>500 error</html>",
+            }
+        )
+        summaries = ingest_all_active_filers(conn, fetcher)
+
+        assert len(summaries) == 1
+        assert summaries[0].submissions_fetch_failed is True
+        assert summaries[0].first_error == "submissions JSON malformed"
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT status, error FROM data_ingestion_runs ORDER BY ingestion_run_id DESC LIMIT 1")
+            row = cur.fetchone()
+        assert row is not None
+        assert row["status"] == "partial"
+        assert row["error"] is not None and "submissions fetch failed" in row["error"]
+
+    def test_submissions_404_downgrades_run_to_partial(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A curated filer whose per-CIK submissions JSON 404s gets a
+        partial-status run with an explicit error citation, instead
+        of a silent 'success' that hides the stale seed entry. Codex
+        pre-push review caught the silent-success bug."""
+        conn = ebull_test_conn
+        seed_filer(conn, cik="0009999999", label="STALE FUND")
+        conn.commit()
+
+        fetcher = _InMemoryFetcher({})  # all fetches return None
+        summaries = ingest_all_active_filers(conn, fetcher)
+
+        assert len(summaries) == 1
+        assert summaries[0].submissions_fetch_failed is True
+        assert summaries[0].first_error == "submissions JSON 404/error"
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT status, error FROM data_ingestion_runs ORDER BY ingestion_run_id DESC LIMIT 1")
+            row = cur.fetchone()
+        assert row is not None
+        assert row["status"] == "partial"
+        assert row["error"] is not None and "submissions fetch failed" in row["error"]
+
+    def test_malformed_xml_is_tombstoned_not_raised(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Malformed primary_doc.xml (truncated / non-XML body) must
+        produce a per-accession ``failed`` tombstone row, not a raise
+        that escapes the per-accession handler. Codex pre-push
+        review caught the missing ``ET.ParseError`` catch."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=766_040, symbol="AAPL")
+        _seed_cusip_mapping(conn, instrument_id=766_040, cusip="037833100")
+        seed_filer(conn, cik="0001234567", label="TEST")
+        conn.commit()
+
+        accession = "0001234567-25-000099"
+        fetcher = _InMemoryFetcher(
+            {
+                "https://data.sec.gov/submissions/CIK0001234567.json": _submissions_json(
+                    accessions=[(accession, "SC 13D", "2025-11-06")]
+                ),
+                _archive_url("0001234567", accession, "primary_doc.xml"): "<not-xml",
+            }
+        )
+
+        summary = ingest_filer_blockholders(conn, fetcher, filer_cik="0001234567")
+        conn.commit()
+
+        assert summary.accessions_failed == 1
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT status, error FROM blockholder_filings_ingest_log WHERE accession_number = %s",
+                (accession,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["status"] == "failed"
+        assert row["error"] is not None and "primary_doc.xml parse failed" in row["error"]

--- a/tests/test_fetch_document_text_callers.py
+++ b/tests/test_fetch_document_text_callers.py
@@ -37,12 +37,14 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         #   eight_k_events      — 8-K full structure (#450)
         #   institutional_holdings — 13F-HR primary_doc + infotable XML (#730)
         #   insider_form3_ingest    — Form 3 initial-holdings XML (#768)
+        #   blockholders        — Schedule 13D / 13G primary_doc XML (#766)
         "app/services/business_summary.py",
         "app/services/dividend_calendar.py",
         "app/services/insider_transactions.py",
         "app/services/insider_form3_ingest.py",
         "app/services/eight_k_events.py",
         "app/services/institutional_holdings.py",
+        "app/services/blockholders.py",
         # Provider implementation owns the method itself.
         "app/providers/implementations/sec_edgar.py",
         # Bounded-concurrency wrapper (#726). Calls the method via a
@@ -64,6 +66,7 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         "tests/test_eight_k_events_ingest.py",
         "tests/test_concurrent_fetch.py",
         "tests/test_institutional_holdings_ingester.py",
+        "tests/test_blockholders_ingester.py",
         # This guard file itself references the method name in its
         # contract sentence.
         "tests/test_fetch_document_text_callers.py",


### PR DESCRIPTION
## What

SEC submissions-index walker → primary_doc.xml fetcher → parser → CUSIP resolver → multi-reporter row writer + amendment-chain aggregator. PR 2 of 3 for #766 (PR 1: #775).

- ``app/services/blockholders.py`` — service module
- ``tests/test_blockholders_ingester.py`` — 18 integration tests
- ``tests/test_fetch_document_text_callers.py`` — allow-list update

## Why

Bridges PR 1's schema + parser to a real data-flow path. After this PR an operator-curated seed list of activist hedge funds / founders / ≥5%-holders gets walked on each ingest cycle, every new 13D / 13G accession's primary_doc.xml is parsed into N reporter rows, and the latest non-superseded position per reporter on each issuer is queryable via ``latest_blockholder_positions``.

## Test plan

- [x] ``uv run ruff check .`` — clean
- [x] ``uv run ruff format --check .`` — clean
- [x] ``uv run pyright`` — clean
- [x] ``uv run pytest tests/test_blockholders_ingester.py`` — 18 pass
- [x] ``uv run pytest tests/test_fetch_document_text_callers.py`` — pass (allow-list updated)
- [x] ``uv run pytest tests/smoke/test_app_boots.py`` — pass
- [x] Codex pre-push review — clean after 3 follow-up rounds

3 pre-existing test failures on main (``jobs_queue_boot_drain``, ``migration_071_exchanges_capabilities``, ``sync_orchestrator_dispatcher``) are unrelated.

## Codex pre-push findings (all addressed)

1. **High** — ``ET.ParseError`` not in the parser-exception catch; malformed XML escaped per-accession isolation. Added to the except clause + new ``test_malformed_xml_is_tombstoned_not_raised``.
2. **Medium** — submissions 404 silently reported batch ``success`` with zero rows. Added ``IngestSummary.submissions_fetch_failed`` flag; batch wrapper downgrades run to ``partial`` with explicit count + ``test_submissions_404_downgrades_run_to_partial``.
3. **Medium** — supersession test built a 13D-shape body labelled SCHEDULE 13G/A; parser raised, supersession path never exercised. Added real ``_13g_xml`` builder + sanity assertion on prior ingest; crash test now uses a fetcher that *raises* RuntimeError to exercise the actual ``except Exception`` branch.
4. **Medium** — malformed 200-body submissions JSON still slipped (parsed empty list = "no filings = success"). ``parse_submissions_index`` now returns ``None`` on JSON decode error (vs ``[]`` for legitimate empty); ingester treats None same as 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)