### PR TITLE
feat(#766): blockholders reader endpoint + 5th sunburst category (PR 3/3)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -2842,3 +2842,301 @@ def get_instrument_institutional_holdings(
         totals=totals,
         filers=filers,
     )
+
+
+# ---------------------------------------------------------------------------
+# 13D/G blockholders — #766 PR 3 of 3
+# ---------------------------------------------------------------------------
+
+
+class BlockholderRow(BaseModel):
+    """One block on the cap table — the latest non-superseded 13D / 13G
+    filing for a (primary filer, issuer) pair.
+
+    Joint filings have N reporting persons under one accession, all
+    typically claiming the same beneficial ownership. The reader
+    collapses them to one row per primary filer (the EDGAR
+    submitter), picking the largest-aggregate reporter as the
+    canonical "block representative". The ``additional_reporters``
+    count surfaces the joint-filing depth so the operator knows the
+    block is held jointly without inflating the totals.
+    """
+
+    filer_cik: str  # primary filer's CIK (the EDGAR submitter)
+    filer_name: str
+    reporter_cik: str | None  # representative reporter's CIK
+    reporter_name: str
+    submission_type: str  # 'SCHEDULE 13D' | 'SCHEDULE 13D/A' | 'SCHEDULE 13G' | 'SCHEDULE 13G/A'
+    status: str  # 'active' | 'passive'
+    accession_number: str
+    aggregate_amount_owned: Decimal | None
+    percent_of_class: Decimal | None
+    additional_reporters: int  # joint-filing co-reporters omitted from this row
+    date_of_event: date | None
+    filed_at: datetime | None
+
+
+class BlockholdersTotals(BaseModel):
+    """Per-instrument blockholders rollup for the ownership card.
+
+    ``blockholders_shares`` sums the per-block ``aggregate_amount_owned``
+    across every block (one block per primary filer). The reader
+    deduplicates joint-filing reporters via the per-filer DISTINCT ON
+    so two indirect beneficial owners of the same 1.5M-share block
+    contribute 1.5M, not 3M.
+
+    ``active_shares`` and ``passive_shares`` partition the same total
+    by ``status`` (13D = active, 13G = passive) so the card can show
+    a stacked "engaged vs index" sub-bar if the operator wants it.
+
+    ``as_of_date`` is the latest ``filed_at`` across the included
+    blocks — drives the per-category freshness chip (#767).
+    """
+
+    blockholders_shares: Decimal
+    active_shares: Decimal
+    passive_shares: Decimal
+    total_filers: int
+    as_of_date: date | None
+
+
+class BlockholdersResponse(BaseModel):
+    symbol: str
+    totals: BlockholdersTotals | None
+    blockholders: list[BlockholderRow]
+
+
+_DEFAULT_BLOCKHOLDERS_LIMIT = 50
+_MAX_BLOCKHOLDERS_LIMIT = 500
+
+
+@router.get("/{symbol}/blockholders", response_model=BlockholdersResponse)
+def get_instrument_blockholders(
+    symbol: str,
+    limit: int = Query(default=_DEFAULT_BLOCKHOLDERS_LIMIT, ge=1, le=_MAX_BLOCKHOLDERS_LIMIT),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> BlockholdersResponse:
+    """13D / 13G blockholders for one instrument (#766 PR 3).
+
+    Returns the latest non-superseded filing per primary-filer per
+    issuer, with joint-filing reporters collapsed to a single
+    representative row. Each row corresponds to one ≥5% block on the
+    cap table.
+
+    Empty state: a non-covered or pre-ingest instrument returns
+    ``200`` with ``totals=null`` and ``blockholders=[]``. Card
+    consumers render the empty-per-slice fallback. 404 is reserved
+    for an unknown symbol.
+
+    Aggregation semantics match :func:`app.services.blockholders.
+    latest_blockholder_positions` but at the *primary filer* grain
+    rather than per-reporter-identity, so the ownership card's
+    blockholders slice does not double-count joint filers.
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+
+    # Per-reporter chain: pick the latest filing per
+    # ``(reporter_identity, issuer_cik)`` where ``reporter_identity =
+    # COALESCE(reporter_cik, reporter_name)``. Matches the schema's
+    # hot-path index from migration 095 and the PR 2 aggregator's
+    # supersession semantic — a 13D filed after a prior 13G/A by the
+    # same reporter wins regardless of which submitter (filer_id)
+    # routed it.
+    #
+    # ``additional_reporters`` is computed per-accession to surface
+    # joint-filing depth on each row (e.g. "Carl Icahn + 2 others").
+    # The totals query downstream dedupes by accession to avoid
+    # double-counting joint filers.
+    #
+    # Codex pre-push review caught the prior version of this query
+    # which deduped on ``filer_id`` (the EDGAR submitter, not the
+    # beneficial-owner identity) — that broke supersession across
+    # submitter changes and conflated distinct holders that shared
+    # one submitter.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            WITH per_reporter_chain AS (
+                SELECT DISTINCT ON (COALESCE(bf.reporter_cik, bf.reporter_name), bf.issuer_cik)
+                    bf.filer_id,
+                    bf.accession_number,
+                    bf.submission_type,
+                    bf.status,
+                    bf.reporter_cik,
+                    bf.reporter_name,
+                    bf.aggregate_amount_owned,
+                    bf.percent_of_class,
+                    bf.date_of_event,
+                    bf.filed_at
+                FROM blockholder_filings bf
+                WHERE bf.instrument_id = %(iid)s
+                ORDER BY
+                    COALESCE(bf.reporter_cik, bf.reporter_name),
+                    bf.issuer_cik,
+                    bf.filed_at DESC NULLS LAST,
+                    bf.accession_number DESC
+            ),
+            accession_reporter_count AS (
+                SELECT
+                    accession_number,
+                    COUNT(*) AS reporter_count
+                FROM per_reporter_chain
+                GROUP BY accession_number
+            )
+            SELECT
+                f.cik AS filer_cik,
+                f.name AS filer_name,
+                prc.accession_number,
+                prc.submission_type,
+                prc.status,
+                prc.reporter_cik,
+                prc.reporter_name,
+                prc.aggregate_amount_owned,
+                prc.percent_of_class,
+                prc.date_of_event,
+                prc.filed_at,
+                COALESCE(arc.reporter_count, 1) - 1 AS additional_reporters
+            FROM per_reporter_chain prc
+            JOIN blockholder_filers f ON f.filer_id = prc.filer_id
+            LEFT JOIN accession_reporter_count arc
+              ON arc.accession_number = prc.accession_number
+            ORDER BY prc.aggregate_amount_owned DESC NULLS LAST,
+                     prc.filed_at DESC NULLS LAST,
+                     prc.accession_number DESC,
+                     prc.reporter_name
+            LIMIT %(limit)s
+            """,
+            {"iid": instrument_id, "limit": limit},
+        )
+        block_rows = cur.fetchall()
+
+    if not block_rows:
+        return BlockholdersResponse(
+            symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+            totals=None,
+            blockholders=[],
+        )
+
+    # Totals span every block, not just the per-page slice. Compute
+    # in a separate query so a small ``limit`` does not truncate the
+    # rollup.
+    #
+    # Two-step rollup so joint-filing reporters (multiple per-reporter
+    # chain rows that share an accession) do not double-count:
+    #
+    #   1. ``per_reporter_chain`` — same shape as the drilldown query
+    #      above. One row per reporter chain.
+    #   2. ``per_accession_block`` — collapse to one row per
+    #      accession by picking the largest aggregate_amount_owned
+    #      among the joint reporters. SEC instructions require all
+    #      joint filers to claim the same beneficial ownership, so
+    #      MAX is canonical (and tolerates the rare misfiling where
+    #      one reporter's row defers to the prior cover page with
+    #      NULL aggregate). ``MAX(filed_at)`` so the per-block
+    #      filed_at is the most recent in the chain.
+    #   3. Sum across blocks — that is the slice total.
+    #
+    # ``total_filers`` counts distinct *blocks* (= accessions in the
+    # latest-per-reporter set), not reporter rows — matches the
+    # operator's "how many ≥5% blocks are on the cap table" mental
+    # model. Codex pre-push review caught the prior filer_id-keyed
+    # approach for the same reason.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            WITH per_reporter_chain AS (
+                SELECT DISTINCT ON (COALESCE(bf.reporter_cik, bf.reporter_name), bf.issuer_cik)
+                    bf.accession_number,
+                    bf.status,
+                    bf.aggregate_amount_owned,
+                    bf.filed_at
+                FROM blockholder_filings bf
+                WHERE bf.instrument_id = %(iid)s
+                ORDER BY
+                    COALESCE(bf.reporter_cik, bf.reporter_name),
+                    bf.issuer_cik,
+                    bf.filed_at DESC NULLS LAST,
+                    bf.accession_number DESC
+            ),
+            per_accession_block AS (
+                SELECT
+                    accession_number,
+                    -- ``BOOL_OR(status = 'active')`` so an accession
+                    -- with any active reporter row counts as active
+                    -- in the partition (typical: all reporters of
+                    -- one accession share the same status, but the
+                    -- check survives an edge-case mixed-status
+                    -- joint filing without raising).
+                    BOOL_OR(status = 'active') AS is_active,
+                    MAX(aggregate_amount_owned) AS aggregate_amount_owned,
+                    MAX(filed_at) AS filed_at
+                FROM per_reporter_chain
+                GROUP BY accession_number
+            )
+            SELECT
+                COALESCE(SUM(aggregate_amount_owned), 0) AS blockholders_shares,
+                COALESCE(SUM(aggregate_amount_owned) FILTER (WHERE is_active), 0) AS active_shares,
+                COALESCE(SUM(aggregate_amount_owned) FILTER (WHERE NOT is_active), 0) AS passive_shares,
+                COUNT(*) AS total_filers,
+                MAX(filed_at) AS latest_filed_at
+            FROM per_accession_block
+            """,
+            {"iid": instrument_id},
+        )
+        totals_row = cur.fetchone()
+    if totals_row is None:
+        # Defensive: aggregate always returns one row even on empty
+        # input. ``None`` here would be an invariant violation.
+        raise HTTPException(status_code=500, detail="aggregate produced no row")
+
+    latest_filed_at = totals_row["latest_filed_at"]  # type: ignore[index]
+    as_of_date = latest_filed_at.date() if isinstance(latest_filed_at, datetime) else None
+
+    totals = BlockholdersTotals(
+        blockholders_shares=Decimal(totals_row["blockholders_shares"] or 0),  # type: ignore[arg-type]
+        active_shares=Decimal(totals_row["active_shares"] or 0),  # type: ignore[arg-type]
+        passive_shares=Decimal(totals_row["passive_shares"] or 0),  # type: ignore[arg-type]
+        total_filers=int(totals_row["total_filers"] or 0),  # type: ignore[arg-type]
+        as_of_date=as_of_date,
+    )
+
+    blockholders = [
+        BlockholderRow(
+            filer_cik=str(r["filer_cik"]),  # type: ignore[arg-type]
+            filer_name=str(r["filer_name"]),  # type: ignore[arg-type]
+            reporter_cik=(str(r["reporter_cik"]) if r["reporter_cik"] is not None else None),  # type: ignore[arg-type]
+            reporter_name=str(r["reporter_name"]),  # type: ignore[arg-type]
+            submission_type=str(r["submission_type"]),  # type: ignore[arg-type]
+            status=str(r["status"]),  # type: ignore[arg-type]
+            accession_number=str(r["accession_number"]),  # type: ignore[arg-type]
+            aggregate_amount_owned=r["aggregate_amount_owned"],  # type: ignore[arg-type]
+            percent_of_class=r["percent_of_class"],  # type: ignore[arg-type]
+            additional_reporters=int(r["additional_reporters"] or 0),  # type: ignore[arg-type]
+            date_of_event=r["date_of_event"],  # type: ignore[arg-type]
+            filed_at=r["filed_at"],  # type: ignore[arg-type]
+        )
+        for r in block_rows
+    ]
+
+    return BlockholdersResponse(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        totals=totals,
+        blockholders=blockholders,
+    )

--- a/frontend/src/api/blockholders.ts
+++ b/frontend/src/api/blockholders.ts
@@ -1,0 +1,89 @@
+/**
+ * Client for /instruments/{symbol}/blockholders (#766 PR 3).
+ *
+ * Surfaces the latest non-superseded 13D / 13G filing per primary
+ * filer per issuer — one row per ≥5% block on the cap table. The
+ * ownership card (#729) renders this as the 5th sunburst category
+ * alongside Institutions / ETFs / Insiders / Treasury.
+ *
+ * Joint-filing reporters (e.g. a fund + its principals all claiming
+ * the same block) collapse to one row per primary filer; the
+ * ``additional_reporters`` count surfaces the joint-filing depth so
+ * the operator can drill in for detail without the totals slice
+ * double-counting them.
+ *
+ * `totals` is `null` when no 13D/G filings on file (non-covered or
+ * pre-ingest instrument); the consumer renders the no-coverage
+ * empty-state.
+ */
+
+import { apiFetch } from "@/api/client";
+
+export interface BlockholdersTotals {
+  /** Sum of per-block aggregate_amount_owned across every primary
+   *  filer's latest non-superseded filing on this issuer. Decimal
+   *  as string. */
+  readonly blockholders_shares: string;
+  /** 13D-only subtotal. Decimal as string. */
+  readonly active_shares: string;
+  /** 13G-only subtotal. Decimal as string. */
+  readonly passive_shares: string;
+  /** Distinct primary-filer count = block count. */
+  readonly total_filers: number;
+  /** Latest filed_at across the included blocks (ISO yyyy-mm-dd).
+   *  Null when every included filing has a NULL signature date —
+   *  rare, but the parser leaves filed_at unset on malformed
+   *  signature blocks. The freshness chip renders neutrally in that
+   *  case. */
+  readonly as_of_date: string | null;
+}
+
+export interface BlockholderRow {
+  /** Primary filer's CIK — the EDGAR submitter for the accession. */
+  readonly filer_cik: string;
+  /** Primary filer's name (operator-facing label). */
+  readonly filer_name: string;
+  /** Representative reporter's CIK; null for natural persons /
+   *  family trusts that have no EDGAR CIK. */
+  readonly reporter_cik: string | null;
+  /** Representative reporter's name (largest-aggregate of the joint
+   *  filing). */
+  readonly reporter_name: string;
+  /** 'SCHEDULE 13D' | 'SCHEDULE 13D/A' | 'SCHEDULE 13G' | 'SCHEDULE 13G/A'. */
+  readonly submission_type: string;
+  /** 'active' (13D / 13D/A) | 'passive' (13G / 13G/A). */
+  readonly status: string;
+  readonly accession_number: string;
+  /** Decimal as string. May be null if the filing references the
+   *  prior cover page rather than restating numbers. */
+  readonly aggregate_amount_owned: string | null;
+  /** Decimal as string (e.g. "5.5000"). Null under the same
+   *  defer-to-prior rule. */
+  readonly percent_of_class: string | null;
+  /** Joint-filing co-reporters omitted from this row. ``0`` when the
+   *  filing has only one reporting person. */
+  readonly additional_reporters: number;
+  /** SEC item 4 / 13G event date (ISO yyyy-mm-dd). */
+  readonly date_of_event: string | null;
+  /** Filing signature date coerced to UTC midnight (ISO datetime). */
+  readonly filed_at: string | null;
+}
+
+export interface BlockholdersResponse {
+  readonly symbol: string;
+  /** Null when no 13D/G blocks on file for this instrument. */
+  readonly totals: BlockholdersTotals | null;
+  /** Top-N blocks by aggregate_amount_owned DESC; capped at the
+   *  request limit. */
+  readonly blockholders: readonly BlockholderRow[];
+}
+
+export function fetchBlockholders(
+  symbol: string,
+  limit: number = 50,
+): Promise<BlockholdersResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  return apiFetch<BlockholdersResponse>(
+    `/instruments/${encodeURIComponent(symbol)}/blockholders?${params.toString()}`,
+  );
+}

--- a/frontend/src/components/instrument/OwnershipFreshnessChips.test.tsx
+++ b/frontend/src/components/instrument/OwnershipFreshnessChips.test.tsx
@@ -16,6 +16,7 @@ function category(
     etfs: "ETFs",
     insiders: "Insiders",
     treasury: "Treasury",
+    blockholders: "Blockholders",
   };
   return {
     key,

--- a/frontend/src/components/instrument/OwnershipPanel.test.ts
+++ b/frontend/src/components/instrument/OwnershipPanel.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, expect, it } from "vitest";
 
+import type { BlockholdersResponse } from "@/api/blockholders";
 import type {
   InsiderBaselineList,
   InsiderTransactionsList,
@@ -51,9 +52,15 @@ const _EMPTY_BASELINE: InsiderBaselineList = {
   rows: [],
 };
 
+const _EMPTY_BLOCKHOLDERS: BlockholdersResponse = {
+  symbol: "AAPL",
+  totals: null,
+  blockholders: [],
+};
+
 describe("extractData — Form 3 baseline merging (#768 PR4)", () => {
   it("returns no insider holders when both Form 4 and baseline are empty", () => {
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE);
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE, _EMPTY_BLOCKHOLDERS);
     expect(data.insider_holders).toHaveLength(0);
     expect(data.insiders_total).toBeNull();
   });
@@ -75,7 +82,7 @@ describe("extractData — Form 3 baseline merging (#768 PR4)", () => {
         },
       ],
     };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline);
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline, _EMPTY_BLOCKHOLDERS);
     expect(data.insider_holders).toHaveLength(1);
     expect(data.insider_holders[0]!.label).toBe("Doe, Jane");
     expect(data.insider_holders[0]!.shares).toBe(12500);
@@ -117,7 +124,7 @@ describe("extractData — Form 3 baseline merging (#768 PR4)", () => {
         },
       ],
     };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, insiders, baseline);
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, insiders, baseline, _EMPTY_BLOCKHOLDERS);
     expect(data.insider_holders).toHaveLength(2);
     const keys = data.insider_holders.map((h) => h.key);
     expect(new Set(keys).size).toBe(2); // no key collision
@@ -157,7 +164,7 @@ describe("extractData — Form 3 baseline merging (#768 PR4)", () => {
         },
       ],
     };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline);
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline, _EMPTY_BLOCKHOLDERS);
     expect(data.insider_holders).toHaveLength(0);
     // Codex / bot review of #768 PR4: the freshness chip's
     // ``insiders_as_of`` must use the same eligibility predicate as
@@ -198,7 +205,7 @@ describe("extractData — Form 3 baseline merging (#768 PR4)", () => {
         },
       ],
     };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, insiders, baseline);
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, insiders, baseline, _EMPTY_BLOCKHOLDERS);
     expect(data.insiders_as_of).toBe("2026-04-01");
   });
 
@@ -231,7 +238,7 @@ describe("extractData — Form 3 baseline merging (#768 PR4)", () => {
         },
       ],
     };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, insiders, baseline);
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, insiders, baseline, _EMPTY_BLOCKHOLDERS);
     // Form 4 (2026-04-15) is newer than baseline (2025-11-30) — chip
     // takes the Form 4 date so the chip stays in lockstep with the
     // most recent insider activity. An older baseline never silently
@@ -256,7 +263,223 @@ describe("extractData — Form 3 baseline merging (#768 PR4)", () => {
         },
       ],
     };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline);
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline, _EMPTY_BLOCKHOLDERS);
     expect(data.insiders_as_of).toBe("2026-03-10");
+  });
+});
+
+describe("extractData — blockholders 5th category (#766 PR3)", () => {
+  it("returns no blockholder holders when response totals are null", () => {
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE, _EMPTY_BLOCKHOLDERS);
+    expect(data.blockholder_holders).toHaveLength(0);
+    expect(data.blockholders_total).toBeNull();
+    expect(data.blockholders_as_of).toBeNull();
+  });
+
+  it("maps each block to one holder keyed on filer_cik", () => {
+    const blockholders: BlockholdersResponse = {
+      symbol: "AAPL",
+      totals: {
+        blockholders_shares: "4500000",
+        active_shares: "1500000",
+        passive_shares: "3000000",
+        total_filers: 2,
+        as_of_date: "2025-11-06",
+      },
+      blockholders: [
+        {
+          filer_cik: "0001234567",
+          filer_name: "Test Activist Fund LP",
+          reporter_cik: "0001234567",
+          reporter_name: "Test Activist Fund LP",
+          submission_type: "SCHEDULE 13D",
+          status: "active",
+          accession_number: "0001234567-25-000001",
+          aggregate_amount_owned: "1500000",
+          percent_of_class: "5.5",
+          additional_reporters: 0,
+          date_of_event: "2025-11-03",
+          filed_at: "2025-11-06T00:00:00Z",
+        },
+        {
+          filer_cik: "0007654321",
+          filer_name: "Index Fund",
+          reporter_cik: "0007654321",
+          reporter_name: "Index Fund",
+          submission_type: "SCHEDULE 13G",
+          status: "passive",
+          accession_number: "0007654321-25-000001",
+          aggregate_amount_owned: "3000000",
+          percent_of_class: "11.0",
+          additional_reporters: 0,
+          date_of_event: "2025-09-30",
+          filed_at: "2025-10-01T00:00:00Z",
+        },
+      ],
+    };
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE, blockholders);
+    expect(data.blockholder_holders).toHaveLength(2);
+    expect(data.blockholder_holders.map((h) => h.key)).toEqual([
+      "block:0001234567",
+      "block:0007654321",
+    ]);
+    expect(data.blockholder_holders[0]!.shares).toBe(1500000);
+    expect(data.blockholder_holders[0]!.category).toBe("blockholders");
+    expect(data.blockholders_total).toBe(4500000);
+    expect(data.blockholders_as_of).toBe("2025-11-06");
+  });
+
+  it("collapses joint-filing reporters to one wedge per accession", () => {
+    // A joint 13D filing surfaces as 2 per-reporter rows from the
+    // backend, both pointing at the same accession with the same
+    // 1.5M-share aggregate. The frontend must dedupe by accession
+    // so the wedge count matches the backend's per-accession-block
+    // count — without this dedupe, the snapshot-lag leaf-sum bump
+    // in buildSunburstRings would inflate the category total to 3M.
+    const blockholders: BlockholdersResponse = {
+      symbol: "AAPL",
+      totals: {
+        blockholders_shares: "1500000",
+        active_shares: "1500000",
+        passive_shares: "0",
+        total_filers: 1,
+        as_of_date: "2025-11-06",
+      },
+      blockholders: [
+        {
+          filer_cik: "0001234567",
+          filer_name: "Test Activist Fund LP",
+          reporter_cik: "0001234567",
+          reporter_name: "Test Activist Fund LP",
+          submission_type: "SCHEDULE 13D",
+          status: "active",
+          accession_number: "0001234567-25-000010",
+          aggregate_amount_owned: "1500000",
+          percent_of_class: "5.5",
+          additional_reporters: 1,
+          date_of_event: "2025-11-03",
+          filed_at: "2025-11-06T00:00:00Z",
+        },
+        {
+          filer_cik: "0001234567",
+          filer_name: "Test Activist Fund LP",
+          reporter_cik: null,
+          reporter_name: "Jane Doe (managing member)",
+          submission_type: "SCHEDULE 13D",
+          status: "active",
+          accession_number: "0001234567-25-000010", // same accession!
+          aggregate_amount_owned: "1500000",
+          percent_of_class: "5.5",
+          additional_reporters: 1,
+          date_of_event: "2025-11-03",
+          filed_at: "2025-11-06T00:00:00Z",
+        },
+      ],
+    };
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE, blockholders);
+    expect(data.blockholder_holders).toHaveLength(1);
+    expect(data.blockholder_holders[0]!.shares).toBe(1500000);
+  });
+
+  it("does not collide wedge keys when one submitter has two distinct holders", () => {
+    // One EDGAR submitter (same filer_cik) files for two different
+    // beneficial owners (different reporter_cik). The wedge keys
+    // must be distinct so Recharts does not silently drop one.
+    const blockholders: BlockholdersResponse = {
+      symbol: "AAPL",
+      totals: {
+        blockholders_shares: "3000000",
+        active_shares: "3000000",
+        passive_shares: "0",
+        total_filers: 2,
+        as_of_date: "2025-11-06",
+      },
+      blockholders: [
+        {
+          filer_cik: "0003333333", // shared submitter
+          filer_name: "Shared Adviser LLC",
+          reporter_cik: "0008000001",
+          reporter_name: "Beneficial Owner A",
+          submission_type: "SCHEDULE 13D",
+          status: "active",
+          accession_number: "0003333333-25-000001",
+          aggregate_amount_owned: "1000000",
+          percent_of_class: "3.5",
+          additional_reporters: 0,
+          date_of_event: "2025-11-01",
+          filed_at: "2025-11-01T00:00:00Z",
+        },
+        {
+          filer_cik: "0003333333", // shared submitter
+          filer_name: "Shared Adviser LLC",
+          reporter_cik: "0008000002",
+          reporter_name: "Beneficial Owner B",
+          submission_type: "SCHEDULE 13D",
+          status: "active",
+          accession_number: "0003333333-25-000002",
+          aggregate_amount_owned: "2000000",
+          percent_of_class: "7.0",
+          additional_reporters: 0,
+          date_of_event: "2025-11-06",
+          filed_at: "2025-11-06T00:00:00Z",
+        },
+      ],
+    };
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE, blockholders);
+    expect(data.blockholder_holders).toHaveLength(2);
+    const keys = data.blockholder_holders.map((h) => h.key);
+    expect(new Set(keys).size).toBe(2);
+    expect(keys).toContain("block:0008000001");
+    expect(keys).toContain("block:0008000002");
+  });
+
+  it("drops blockholder rows with null or non-positive aggregate_amount_owned", () => {
+    // A defer-to-prior-cover-page filing carries null aggregate
+    // numbers — those rows surface in the drilldown table but
+    // cannot size a wedge. Blockholders_total still reflects the
+    // backend totals (sum across blocks with real numbers).
+    const blockholders: BlockholdersResponse = {
+      symbol: "AAPL",
+      totals: {
+        blockholders_shares: "1500000",
+        active_shares: "1500000",
+        passive_shares: "0",
+        total_filers: 1,
+        as_of_date: "2025-11-06",
+      },
+      blockholders: [
+        {
+          filer_cik: "0001234567",
+          filer_name: "Real Block",
+          reporter_cik: "0001234567",
+          reporter_name: "Real Block",
+          submission_type: "SCHEDULE 13D",
+          status: "active",
+          accession_number: "0001234567-25-000001",
+          aggregate_amount_owned: "1500000",
+          percent_of_class: "5.5",
+          additional_reporters: 0,
+          date_of_event: "2025-11-03",
+          filed_at: "2025-11-06T00:00:00Z",
+        },
+        {
+          filer_cik: "0009999999",
+          filer_name: "Defer-to-Prior Block",
+          reporter_cik: null,
+          reporter_name: "Defer-to-Prior Block",
+          submission_type: "SCHEDULE 13D/A",
+          status: "active",
+          accession_number: "0009999999-25-000001",
+          aggregate_amount_owned: null,
+          percent_of_class: null,
+          additional_reporters: 0,
+          date_of_event: "2025-11-03",
+          filed_at: "2025-11-06T00:00:00Z",
+        },
+      ],
+    };
+    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE, blockholders);
+    expect(data.blockholder_holders).toHaveLength(1);
+    expect(data.blockholder_holders[0]!.label).toBe("Real Block");
   });
 });

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -28,6 +28,8 @@
 import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { fetchBlockholders } from "@/api/blockholders";
+import type { BlockholdersResponse } from "@/api/blockholders";
 import { fetchInstitutionalHoldings } from "@/api/institutionalHoldings";
 import type {
   InstitutionalFilerHolding,
@@ -79,9 +81,11 @@ interface OwnershipData {
   readonly institutions_total: number | null;
   readonly etfs_total: number | null;
   readonly insiders_total: number | null;
+  readonly blockholders_total: number | null;
   readonly institutional_holders: readonly SunburstHolder[];
   readonly etf_holders: readonly SunburstHolder[];
   readonly insider_holders: readonly SunburstHolder[];
+  readonly blockholder_holders: readonly SunburstHolder[];
   /** 13F snapshot date — applies to both Institutions and ETFs (same
    *  ``period_of_report`` cohort across filer types). */
   readonly thirteen_f_as_of: string | null;
@@ -89,6 +93,8 @@ interface OwnershipData {
   readonly insiders_as_of: string | null;
   /** XBRL period_end of the row that produced ``treasury``. */
   readonly treasury_as_of: string | null;
+  /** Latest 13D/G filed_at across the blocks on this issuer (#766). */
+  readonly blockholders_as_of: string | null;
 }
 
 function pickLatestBalance(
@@ -131,6 +137,11 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
     [symbol],
   );
 
+  const blockholdersState = useAsync<BlockholdersResponse>(
+    useCallback(() => fetchBlockholders(symbol, 200), [symbol]),
+    [symbol],
+  );
+
   const navigate = useNavigate();
   const handleWedgeClick = useCallback(
     (target: WedgeClick) => {
@@ -151,15 +162,20 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
     balanceState.loading ||
     institutionalState.loading ||
     insidersState.loading ||
-    baselineState.loading;
+    baselineState.loading ||
+    blockholdersState.loading;
   const allErrored =
     balanceState.error !== null &&
     institutionalState.error !== null &&
     insidersState.error !== null &&
-    baselineState.error !== null;
+    baselineState.error !== null &&
+    blockholdersState.error !== null;
 
   return (
-    <Pane title="Ownership" source={{ providers: ["sec_13f", "sec_form3", "sec_form4", "sec_xbrl"] }}>
+    <Pane
+      title="Ownership"
+      source={{ providers: ["sec_13f", "sec_form3", "sec_form4", "sec_13dg", "sec_xbrl"] }}
+    >
       {isLoading ? (
         <SectionSkeleton rows={4} />
       ) : allErrored ? (
@@ -169,6 +185,7 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
             institutionalState.refetch();
             insidersState.refetch();
             baselineState.refetch();
+            blockholdersState.refetch();
           }}
         />
       ) : (
@@ -177,6 +194,7 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
           institutional={institutionalState.data}
           insiders={insidersState.data}
           baseline={baselineState.data}
+          blockholders={blockholdersState.data}
           onWedgeClick={handleWedgeClick}
         />
       )}
@@ -189,6 +207,7 @@ interface PanelBodyProps {
   readonly institutional: InstitutionalHoldingsResponse | null;
   readonly insiders: InsiderTransactionsList | null;
   readonly baseline: InsiderBaselineList | null;
+  readonly blockholders: BlockholdersResponse | null;
   readonly onWedgeClick: (target: WedgeClick) => void;
 }
 
@@ -202,11 +221,12 @@ function PanelBody({
   institutional,
   insiders,
   baseline,
+  blockholders,
   onWedgeClick,
 }: PanelBodyProps): JSX.Element {
   const today = useMemo(() => new Date(), []);
   return renderBody(
-    extractData(balance, institutional, insiders, baseline),
+    extractData(balance, institutional, insiders, baseline, blockholders),
     onWedgeClick,
     today,
   );
@@ -217,6 +237,7 @@ export function extractData(
   institutional: InstitutionalHoldingsResponse | null,
   insiders: InsiderTransactionsList | null,
   baseline: InsiderBaselineList | null,
+  blockholders: BlockholdersResponse | null,
 ): OwnershipData {
   const outstanding =
     balance !== null ? pickLatestBalance(balance, "shares_outstanding") : null;
@@ -249,6 +270,20 @@ export function extractData(
 
   const institutions_total = parseShareCount(inst_totals?.institutions_shares ?? null);
   const etfs_total = parseShareCount(inst_totals?.etfs_shares ?? null);
+
+  // Blockholders (#766): one wedge per ≥5% block. The reader
+  // returns per-reporter chain rows (matching the issue spec); the
+  // frontend dedupes by accession so joint-filing reporters
+  // collapse to a single wedge whose ``shares`` matches the
+  // backend's per-accession ``MAX(aggregate_amount_owned)`` rollup.
+  // Without this dedupe, two joint reporters claiming the same 1.5M
+  // block would surface as 2 wedges summing to 3M, which then
+  // triggers the snapshot-lag leaf-sum bump in ``buildSunburstRings``
+  // and double-counts the block in the category total. Codex
+  // pre-push review caught this.
+  const blockholder_holders: readonly SunburstHolder[] = blockholdersToHolders(blockholders);
+  const blockholders_total = parseShareCount(blockholders?.totals?.blockholders_shares ?? null);
+  const blockholders_as_of = blockholders?.totals?.as_of_date ?? null;
   // Form 4 has no aggregate-total endpoint — sum the per-officer
   // post-transaction balances. When no officer rows are on file the
   // total is null (category does not render).
@@ -289,13 +324,49 @@ export function extractData(
     institutions_total,
     etfs_total,
     insiders_total,
+    blockholders_total,
     institutional_holders,
     etf_holders,
     insider_holders,
+    blockholder_holders,
     thirteen_f_as_of,
     insiders_as_of,
     treasury_as_of,
+    blockholders_as_of,
   };
+}
+
+/** Map blockholder API rows into SunburstHolder wedges, deduping
+ *  by accession_number so joint-filing reporters collapse to one
+ *  wedge per block. The backend orders rows by
+ *  ``aggregate_amount_owned DESC`` per accession, so the first
+ *  occurrence of each accession is the largest-aggregate
+ *  representative — keep that one and drop the rest.
+ *
+ *  Wedge identity uses reporter_cik (or name fallback) rather than
+ *  filer_cik because two distinct beneficial owners can share one
+ *  EDGAR submitter; keying on filer_cik would collide their
+ *  wedges. Codex pre-push review caught this. */
+function blockholdersToHolders(
+  blockholders: BlockholdersResponse | null,
+): readonly SunburstHolder[] {
+  if (blockholders === null) return [];
+  const seen_accessions = new Set<string>();
+  const out: SunburstHolder[] = [];
+  for (const row of blockholders.blockholders) {
+    if (seen_accessions.has(row.accession_number)) continue;
+    seen_accessions.add(row.accession_number);
+    const shares = parseShareCount(row.aggregate_amount_owned);
+    if (shares === null || shares <= 0) continue;
+    const reporter_identity = row.reporter_cik ?? `name:${row.reporter_name}`;
+    out.push({
+      key: `block:${reporter_identity}`,
+      label: row.filer_name,
+      shares,
+      category: "blockholders",
+    });
+  }
+  return out;
 }
 
 /** Map baseline-API rows into the SunburstHolder shape so the
@@ -438,15 +509,18 @@ function renderBody(
       ...data.institutional_holders,
       ...data.etf_holders,
       ...data.insider_holders,
+      ...data.blockholder_holders,
     ],
     institutions_total: data.institutions_total,
     etfs_total: data.etfs_total,
     insiders_total: data.insiders_total,
+    blockholders_total: data.blockholders_total,
     treasury_shares: data.treasury,
     institutions_as_of: data.thirteen_f_as_of,
     etfs_as_of: data.thirteen_f_as_of,
     insiders_as_of: data.insiders_as_of,
     treasury_as_of: data.treasury_as_of,
+    blockholders_as_of: data.blockholders_as_of,
   };
   const rings = buildSunburstRings(inputs);
   if (rings === null) {

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -64,6 +64,11 @@ export const CATEGORY_FILL_INDEX: Record<CategoryKey, number> = {
   etfs: 1, // blue-500
   insiders: 2, // purple-500
   treasury: 3, // amber-500
+  blockholders: 4, // rose-500 — distinct from the other four; activist
+  //                            holds usually warrant a high-contrast
+  //                            wedge so an Icahn / Ackman position
+  //                            does not blend into the institutions
+  //                            cyan band on small-caps.
 };
 
 export function categoryFill(theme: ChartTheme, key: CategoryKey): string {

--- a/frontend/src/components/instrument/ownershipFreshness.ts
+++ b/frontend/src/components/instrument/ownershipFreshness.ts
@@ -43,6 +43,13 @@ export const CADENCE: Record<CategoryKey, CadenceThresholds> = {
   etfs: { aging_days: 135, stale_days: 270 },
   insiders: { aging_days: 30, stale_days: 90 },
   treasury: { aging_days: 100, stale_days: 200 },
+  // Blockholders (13D / 13G #766) are event-driven, not periodic —
+  // a reporter only re-files when their position changes materially
+  // (>=1% delta) or on the annual 13G refresh. Long quiet periods
+  // are normal, but a 9-month-old block on a small-cap is usually
+  // either a stale ingest or a position that quietly evaporated.
+  // Aging > 180d, stale > 365d.
+  blockholders: { aging_days: 180, stale_days: 365 },
 };
 
 /**

--- a/frontend/src/components/instrument/ownershipRings.test.ts
+++ b/frontend/src/components/instrument/ownershipRings.test.ts
@@ -9,6 +9,7 @@ const DEFAULT_INPUT: SunburstInputs = {
   institutions_total: null,
   etfs_total: null,
   insiders_total: null,
+  blockholders_total: null,
   treasury_shares: null,
 };
 

--- a/frontend/src/components/instrument/ownershipRings.ts
+++ b/frontend/src/components/instrument/ownershipRings.ts
@@ -54,7 +54,12 @@ export interface SunburstHolder {
   readonly key: string;
   readonly label: string;
   readonly shares: number;
-  readonly category: "institutions" | "etfs" | "insiders" | "treasury";
+  readonly category:
+    | "institutions"
+    | "etfs"
+    | "insiders"
+    | "treasury"
+    | "blockholders";
 }
 
 export interface SunburstInputs {
@@ -76,6 +81,11 @@ export interface SunburstInputs {
   readonly institutions_total: number | null;
   readonly etfs_total: number | null;
   readonly insiders_total: number | null;
+  /** 13D/G blockholders aggregate (#766). One block per primary
+   *  filer per issuer (joint reporters collapse upstream so this
+   *  count does NOT double-count co-reporters of the same filing).
+   *  Null = no 13D/G blocks on file. */
+  readonly blockholders_total: number | null;
 
   /** Treasury (issuer-held) shares from XBRL. ``null`` = not on
    *  file; treasury wedge does not render. Counted in the
@@ -95,9 +105,17 @@ export interface SunburstInputs {
   readonly etfs_as_of?: string | null;
   readonly insiders_as_of?: string | null;
   readonly treasury_as_of?: string | null;
+  /** Blockholders as_of_date — latest filed_at across the included
+   *  blocks (the reader endpoint returns this directly). */
+  readonly blockholders_as_of?: string | null;
 }
 
-export type CategoryKey = "institutions" | "etfs" | "insiders" | "treasury";
+export type CategoryKey =
+  | "institutions"
+  | "etfs"
+  | "insiders"
+  | "treasury"
+  | "blockholders";
 
 export interface SunburstLeaf {
   readonly key: string;
@@ -177,6 +195,7 @@ const CATEGORY_LABEL: Record<CategoryKey, string> = {
   etfs: "ETFs",
   insiders: "Insiders",
   treasury: "Treasury",
+  blockholders: "Blockholders",
 };
 
 /**
@@ -190,6 +209,9 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
   const inst_holders = input.holders.filter((h) => h.category === "institutions");
   const etf_holders = input.holders.filter((h) => h.category === "etfs");
   const insider_holders = input.holders.filter((h) => h.category === "insiders");
+  const blockholder_holders = input.holders.filter(
+    (h) => h.category === "blockholders",
+  );
 
   // Threshold should align with the effective denominator the chart
   // ends up rendering against. When category totals oversubscribe
@@ -236,6 +258,18 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
         threshold,
         true, // bypass threshold — every officer surfaces
         input.insiders_as_of ?? null,
+      ),
+    );
+  }
+  if (input.blockholders_total !== null && input.blockholders_total > 0) {
+    categories.push(
+      buildCategoryFromTotal(
+        "blockholders",
+        input.blockholders_total,
+        blockholder_holders,
+        threshold,
+        true, // bypass threshold — every ≥5% block is, by definition, large enough
+        input.blockholders_as_of ?? null,
       ),
     );
   }

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -16,6 +16,8 @@
 import { useCallback, useMemo, useRef } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 
+import { fetchBlockholders } from "@/api/blockholders";
+import type { BlockholdersResponse } from "@/api/blockholders";
 import { fetchInstitutionalHoldings } from "@/api/institutionalHoldings";
 import type {
   InstitutionalFilerHolding,
@@ -75,6 +77,7 @@ const CATEGORY_LABELS: Record<CategoryKey, string> = {
   etfs: "ETFs",
   insiders: "Insiders",
   treasury: "Treasury",
+  blockholders: "Blockholders",
 };
 
 export function OwnershipPage(): JSX.Element {
@@ -112,16 +115,23 @@ export function OwnershipPage(): JSX.Element {
     [symbol],
   );
 
+  const blockholdersState = useAsync<BlockholdersResponse>(
+    useCallback(() => fetchBlockholders(symbol, 500), [symbol]),
+    [symbol],
+  );
+
   const isLoading =
     balanceState.loading ||
     institutionalState.loading ||
     insidersState.loading ||
-    baselineState.loading;
+    baselineState.loading ||
+    blockholdersState.loading;
   const allErrored =
     balanceState.error !== null &&
     institutionalState.error !== null &&
     insidersState.error !== null &&
-    baselineState.error !== null;
+    baselineState.error !== null &&
+    blockholdersState.error !== null;
 
   const handleWedgeClick = useCallback(
     (target: WedgeClick) => {
@@ -181,6 +191,7 @@ export function OwnershipPage(): JSX.Element {
             institutionalState.refetch();
             insidersState.refetch();
             baselineState.refetch();
+            blockholdersState.refetch();
           }}
         />
       ) : (
@@ -190,6 +201,7 @@ export function OwnershipPage(): JSX.Element {
           institutional={institutionalState.data}
           insiders={insidersState.data}
           baseline={baselineState.data}
+          blockholders={blockholdersState.data}
           categoryFilter={categoryFilter}
           filerFilter={filerFilter}
           viewMode={viewMode}
@@ -208,6 +220,7 @@ interface OwnershipBodyProps {
   readonly institutional: InstitutionalHoldingsResponse | null;
   readonly insiders: InsiderTransactionsList | null;
   readonly baseline: InsiderBaselineList | null;
+  readonly blockholders: BlockholdersResponse | null;
   readonly categoryFilter: string | null;
   readonly filerFilter: string | null;
   readonly viewMode: string | null;
@@ -224,6 +237,7 @@ function OwnershipBody({
   institutional,
   insiders,
   baseline,
+  blockholders,
   categoryFilter,
   filerFilter,
   viewMode,
@@ -284,9 +298,18 @@ function OwnershipBody({
     () => [...form4_insider_holders, ...baseline_insider_holders],
     [form4_insider_holders, baseline_insider_holders],
   );
+  const blockholder_holders = useMemo<readonly SunburstHolder[]>(
+    () => blockholdersToHolders(blockholders),
+    [blockholders],
+  );
   const allHolders = useMemo<readonly SunburstHolder[]>(
-    () => [...institutional_holders, ...etf_holders, ...insider_holders],
-    [institutional_holders, etf_holders, insider_holders],
+    () => [
+      ...institutional_holders,
+      ...etf_holders,
+      ...insider_holders,
+      ...blockholder_holders,
+    ],
+    [institutional_holders, etf_holders, insider_holders, blockholder_holders],
   );
 
   const institutions_total = useMemo(
@@ -366,6 +389,12 @@ function OwnershipBody({
     return null;
   }, [balance, treasury]);
 
+  const blockholders_total = useMemo(
+    () => parseShareCount(blockholders?.totals?.blockholders_shares ?? null),
+    [blockholders?.totals?.blockholders_shares],
+  );
+  const blockholders_as_of = blockholders?.totals?.as_of_date ?? null;
+
   const inputs: SunburstInputs = useMemo(
     () => ({
       total_shares,
@@ -373,11 +402,13 @@ function OwnershipBody({
       institutions_total,
       etfs_total,
       insiders_total,
+      blockholders_total,
       treasury_shares: treasury,
       institutions_as_of: thirteen_f_as_of,
       etfs_as_of: thirteen_f_as_of,
       insiders_as_of,
       treasury_as_of,
+      blockholders_as_of,
     }),
     [
       total_shares,
@@ -385,18 +416,20 @@ function OwnershipBody({
       institutions_total,
       etfs_total,
       insiders_total,
+      blockholders_total,
       treasury,
       thirteen_f_as_of,
       insiders_as_of,
       treasury_as_of,
+      blockholders_as_of,
     ],
   );
 
   const rings = useMemo(() => buildSunburstRings(inputs), [inputs]);
 
   const allRows = useMemo(
-    () => buildFilerRows(filers, insiders, baseline, treasury),
-    [filers, insiders, baseline, treasury],
+    () => buildFilerRows(filers, insiders, baseline, treasury, blockholders),
+    [filers, insiders, baseline, treasury, blockholders],
   );
 
   const filteredRows = useMemo(() => {
@@ -700,11 +733,43 @@ function baselineToInsiderHolders(
 }
 
 
+/** Map blockholder API rows into SunburstHolder wedges, deduping
+ *  by accession_number so joint-filing reporters collapse to one
+ *  wedge per block. Mirrors the L1 implementation in
+ *  ``OwnershipPanel.tsx`` so a wedge click on the L1 ring lands on
+ *  the corresponding wedge on the L2 ring. Codex pre-push review
+ *  caught the prior version that surfaced one wedge per per-reporter
+ *  row, which double-counted joint filings via the snapshot-lag
+ *  leaf-sum bump in ``buildSunburstRings``. */
+function blockholdersToHolders(
+  blockholders: BlockholdersResponse | null,
+): readonly SunburstHolder[] {
+  if (blockholders === null) return [];
+  const seen_accessions = new Set<string>();
+  const out: SunburstHolder[] = [];
+  for (const row of blockholders.blockholders) {
+    if (seen_accessions.has(row.accession_number)) continue;
+    seen_accessions.add(row.accession_number);
+    const shares = parseShareCount(row.aggregate_amount_owned);
+    if (shares === null || shares <= 0) continue;
+    const reporter_identity = row.reporter_cik ?? `name:${row.reporter_name}`;
+    out.push({
+      key: `block:${reporter_identity}`,
+      label: row.filer_name,
+      shares,
+      category: "blockholders",
+    });
+  }
+  return out;
+}
+
+
 function buildFilerRows(
   filers: readonly InstitutionalFilerHolding[],
   insiders: InsiderTransactionsList | null,
   baseline: InsiderBaselineList | null,
   treasury: number | null,
+  blockholders: BlockholdersResponse | null,
 ): FilerRow[] {
   const rows: FilerRow[] = [];
 
@@ -793,7 +858,51 @@ function buildFilerRows(
     });
   }
 
-  const categoryOrder: CategoryKey[] = ["institutions", "etfs", "insiders", "treasury"];
+  // 13D / 13G blockholders (#766). The drilldown table keeps every
+  // per-reporter chain row so the operator can see joint filings in
+  // detail. Wedges, by contrast, are deduped per-accession in
+  // ``blockholdersToHolders`` so the chart's leaf-sum matches the
+  // backend totals.
+  //
+  // Row key matches the wedge leaf key (``block:${reporter_identity}``)
+  // verbatim so a wedge click that navigates to ``?filer=block:CIK``
+  // highlights the corresponding L2 row. The backend's
+  // ``per_reporter_chain`` DISTINCT ON guarantees one row per
+  // reporter per issuer, so reporter_identity alone is unique
+  // within the table without an accession suffix. Codex pre-push
+  // review caught the wedge↔table key mismatch from a prior fix.
+  if (blockholders !== null) {
+    for (const row of blockholders.blockholders) {
+      const shares = parseShareCount(row.aggregate_amount_owned);
+      if (shares === null || shares <= 0) continue;
+      const reporter_identity = row.reporter_cik ?? `name:${row.reporter_name}`;
+      rows.push({
+        key: `block:${reporter_identity}`,
+        // Label includes the joint-filing depth so the operator can
+        // see at a glance which blocks are held by groups.
+        label:
+          row.additional_reporters > 0
+            ? `${row.reporter_name} (+${row.additional_reporters} co-reporter${row.additional_reporters === 1 ? "" : "s"})`
+            : row.reporter_name,
+        category: "blockholders",
+        category_label: CATEGORY_LABELS.blockholders,
+        shares,
+        value_usd: null,
+        voting: row.submission_type, // surface 13D / 13G as the "voting" column
+        is_put_call: null,
+        accession: row.accession_number,
+        period_of_report: row.date_of_event ?? null,
+      });
+    }
+  }
+
+  const categoryOrder: CategoryKey[] = [
+    "institutions",
+    "etfs",
+    "blockholders",
+    "insiders",
+    "treasury",
+  ];
   rows.sort((a, b) => {
     const ai = categoryOrder.indexOf(a.category);
     const bi = categoryOrder.indexOf(b.category);

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -393,7 +393,10 @@ function OwnershipBody({
     () => parseShareCount(blockholders?.totals?.blockholders_shares ?? null),
     [blockholders?.totals?.blockholders_shares],
   );
-  const blockholders_as_of = blockholders?.totals?.as_of_date ?? null;
+  const blockholders_as_of = useMemo(
+    () => blockholders?.totals?.as_of_date ?? null,
+    [blockholders?.totals?.as_of_date],
+  );
 
   const inputs: SunburstInputs = useMemo(
     () => ({

--- a/tests/test_api_blockholders.py
+++ b/tests/test_api_blockholders.py
@@ -246,7 +246,11 @@ class TestBlockholdersEndpoint:
         # total_filers counts distinct blocks (accessions), not rows.
         assert Decimal(body["totals"]["blockholders_shares"]) == Decimal("1500000")
         assert body["totals"]["total_filers"] == 1
+        # Each per-reporter row carries the same 1.5M aggregate — the
+        # SEC instructions require joint filers to claim the same
+        # beneficial ownership.
         assert Decimal(body["blockholders"][0]["aggregate_amount_owned"]) == Decimal("1500000")
+        assert Decimal(body["blockholders"][1]["aggregate_amount_owned"]) == Decimal("1500000")
         assert Decimal(body["blockholders"][0]["aggregate_amount_owned"]) == Decimal("1500000")
 
     def test_amendment_chain_supersession(

--- a/tests/test_api_blockholders.py
+++ b/tests/test_api_blockholders.py
@@ -251,7 +251,6 @@ class TestBlockholdersEndpoint:
         # beneficial ownership.
         assert Decimal(body["blockholders"][0]["aggregate_amount_owned"]) == Decimal("1500000")
         assert Decimal(body["blockholders"][1]["aggregate_amount_owned"]) == Decimal("1500000")
-        assert Decimal(body["blockholders"][0]["aggregate_amount_owned"]) == Decimal("1500000")
 
     def test_amendment_chain_supersession(
         self,

--- a/tests/test_api_blockholders.py
+++ b/tests/test_api_blockholders.py
@@ -1,0 +1,513 @@
+"""API tests for /instruments/{symbol}/blockholders (#766 PR 3).
+
+Pins:
+  * 404 on unknown symbol.
+  * Empty payload (200, totals=null, blockholders=[]) when no
+    filings on file.
+  * Latest-filing-per-primary-filer aggregation (older accessions
+    superseded).
+  * Joint-filing reporters collapse to one block row, not N (matches
+    the operator's mental model of "5+% blocks", not "individual
+    reporters").
+  * additional_reporters surfaces joint-filing depth without
+    inflating the totals.
+  * 13D vs 13G partition by status — active_shares + passive_shares
+    sum to blockholders_shares.
+  * limit + ordering — top-N by aggregate_amount_owned DESC.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import get_conn
+from app.main import app
+from app.services.blockholders import seed_filer
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def client(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> Iterator[TestClient]:
+    """TestClient with get_conn overridden to yield the ebull_test
+    connection. Restores the override on teardown so cross-test
+    leaks cannot poison subsequent suites."""
+
+    def _dep() -> Iterator[psycopg.Connection[tuple]]:
+        yield ebull_test_conn
+
+    app.dependency_overrides[get_conn] = _dep
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _seed_filer_row(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_id: int,
+    cik: str,
+    name: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO blockholder_filers (filer_id, cik, name)
+        VALUES (%s, %s, %s)
+        ON CONFLICT (cik) DO NOTHING
+        """,
+        (filer_id, cik, name),
+    )
+
+
+def _seed_filing(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_id: int,
+    accession: str,
+    submission_type: str,
+    status: str,
+    instrument_id: int | None,
+    issuer_cik: str = "0000012345",
+    issuer_cusip: str = "037833100",
+    reporter_cik: str | None,
+    reporter_no_cik: bool,
+    reporter_name: str,
+    aggregate_shares: str,
+    percent: str,
+    filed_at: datetime,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO blockholder_filings (
+            filer_id, accession_number, submission_type, status,
+            instrument_id, issuer_cik, issuer_cusip,
+            reporter_cik, reporter_no_cik, reporter_name,
+            aggregate_amount_owned, percent_of_class,
+            filed_at
+        ) VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+        )
+        """,
+        (
+            filer_id,
+            accession,
+            submission_type,
+            status,
+            instrument_id,
+            issuer_cik,
+            issuer_cusip,
+            reporter_cik,
+            reporter_no_cik,
+            reporter_name,
+            Decimal(aggregate_shares),
+            Decimal(percent),
+            filed_at,
+        ),
+    )
+
+
+class TestBlockholdersEndpoint:
+    def test_unknown_symbol_returns_404(self, client: TestClient) -> None:
+        resp = client.get("/instruments/NOPE/blockholders")
+        assert resp.status_code == 404
+
+    def test_empty_when_no_filings(
+        self,
+        client: TestClient,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_instrument(ebull_test_conn, iid=766_300, symbol="NEW")
+        ebull_test_conn.commit()
+        resp = client.get("/instruments/NEW/blockholders")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["symbol"] == "NEW"
+        assert body["totals"] is None
+        assert body["blockholders"] == []
+
+    def test_single_13d_block_renders(
+        self,
+        client: TestClient,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=766_310, symbol="AAPL")
+        seed_filer(conn, cik="0001234567", label="Test Activist")
+        _seed_filer_row(conn, filer_id=1001, cik="0001234567", name="Test Activist Fund LP")
+        _seed_filing(
+            conn,
+            filer_id=1001,
+            accession="0001234567-25-000001",
+            submission_type="SCHEDULE 13D",
+            status="active",
+            instrument_id=766_310,
+            reporter_cik="0001234567",
+            reporter_no_cik=False,
+            reporter_name="Test Activist Fund LP",
+            aggregate_shares="1500000",
+            percent="5.5",
+            filed_at=datetime(2025, 11, 6, tzinfo=UTC),
+        )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL/blockholders")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["totals"] is not None
+        assert Decimal(body["totals"]["blockholders_shares"]) == Decimal("1500000")
+        assert Decimal(body["totals"]["active_shares"]) == Decimal("1500000")
+        assert Decimal(body["totals"]["passive_shares"]) == Decimal(0)
+        assert body["totals"]["total_filers"] == 1
+        assert body["totals"]["as_of_date"] == "2025-11-06"
+        assert len(body["blockholders"]) == 1
+        block = body["blockholders"][0]
+        assert block["status"] == "active"
+        assert block["submission_type"] == "SCHEDULE 13D"
+        assert Decimal(block["aggregate_amount_owned"]) == Decimal("1500000")
+        assert Decimal(block["percent_of_class"]) == Decimal("5.5")
+        assert block["additional_reporters"] == 0
+
+    def test_joint_filing_renders_per_reporter_but_totals_dedupe(
+        self,
+        client: TestClient,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Per-reporter rows in the response (matches the issue spec:
+        ``blockholders list (per-reporter rows)``), but the totals
+        slice dedupes by accession so a 1.5M-share block claimed by
+        two joint reporters contributes 1.5M to the totals, not 3M.
+        ``total_filers`` counts distinct blocks (accessions), not
+        reporter rows."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=766_320, symbol="AAPL")
+        seed_filer(conn, cik="0001234567", label="Joint Filing Test")
+        _seed_filer_row(conn, filer_id=1010, cik="0001234567", name="Test Activist Fund LP")
+        accession = "0001234567-25-000010"
+        _seed_filing(
+            conn,
+            filer_id=1010,
+            accession=accession,
+            submission_type="SCHEDULE 13D",
+            status="active",
+            instrument_id=766_320,
+            reporter_cik="0001234567",
+            reporter_no_cik=False,
+            reporter_name="Test Activist Fund LP",
+            aggregate_shares="1500000",
+            percent="5.5",
+            filed_at=datetime(2025, 11, 6, tzinfo=UTC),
+        )
+        _seed_filing(
+            conn,
+            filer_id=1010,
+            accession=accession,
+            submission_type="SCHEDULE 13D",
+            status="active",
+            instrument_id=766_320,
+            reporter_cik=None,
+            reporter_no_cik=True,
+            reporter_name="Jane Doe (managing member)",
+            aggregate_shares="1500000",
+            percent="5.5",
+            filed_at=datetime(2025, 11, 6, tzinfo=UTC),
+        )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL/blockholders")
+        body = resp.json()
+        # Per-reporter rows: 2 reporters in the joint filing yield
+        # 2 rows in the response. Each carries
+        # ``additional_reporters=1`` surfacing the joint-filing depth.
+        assert len(body["blockholders"]) == 2
+        for row in body["blockholders"]:
+            assert row["additional_reporters"] == 1
+        # Totals dedupe by accession — 1.5M (one block), not 3M.
+        # total_filers counts distinct blocks (accessions), not rows.
+        assert Decimal(body["totals"]["blockholders_shares"]) == Decimal("1500000")
+        assert body["totals"]["total_filers"] == 1
+        assert Decimal(body["blockholders"][0]["aggregate_amount_owned"]) == Decimal("1500000")
+        assert Decimal(body["blockholders"][0]["aggregate_amount_owned"]) == Decimal("1500000")
+
+    def test_amendment_chain_supersession(
+        self,
+        client: TestClient,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """An older 13G/A is superseded by a later 13D from the same
+        primary filer on the same issuer. Only the 13D appears."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=766_330, symbol="AAPL")
+        seed_filer(conn, cik="0001234567", label="Convert")
+        _seed_filer_row(conn, filer_id=1020, cik="0001234567", name="Converting Fund")
+
+        _seed_filing(
+            conn,
+            filer_id=1020,
+            accession="0001234567-25-000020",
+            submission_type="SCHEDULE 13G/A",
+            status="passive",
+            instrument_id=766_330,
+            reporter_cik="0001234567",
+            reporter_no_cik=False,
+            reporter_name="Converting Fund",
+            aggregate_shares="500000",
+            percent="2.5",
+            filed_at=datetime(2025, 9, 15, tzinfo=UTC),
+        )
+        _seed_filing(
+            conn,
+            filer_id=1020,
+            accession="0001234567-25-000021",
+            submission_type="SCHEDULE 13D",
+            status="active",
+            instrument_id=766_330,
+            reporter_cik="0001234567",
+            reporter_no_cik=False,
+            reporter_name="Converting Fund",
+            aggregate_shares="2000000",
+            percent="7.0",
+            filed_at=datetime(2025, 11, 6, tzinfo=UTC),
+        )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL/blockholders")
+        body = resp.json()
+        assert len(body["blockholders"]) == 1
+        assert body["blockholders"][0]["status"] == "active"
+        assert body["blockholders"][0]["submission_type"] == "SCHEDULE 13D"
+        assert Decimal(body["blockholders"][0]["aggregate_amount_owned"]) == Decimal("2000000")
+        assert Decimal(body["totals"]["blockholders_shares"]) == Decimal("2000000")
+        assert Decimal(body["totals"]["active_shares"]) == Decimal("2000000")
+        assert Decimal(body["totals"]["passive_shares"]) == Decimal(0)
+
+    def test_supersession_across_different_submitters(
+        self,
+        client: TestClient,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Same beneficial owner (same reporter_cik) files a 13D/A
+        through a different EDGAR submitter than the original 13D.
+        The chain identity is the reporter, not the submitter — so
+        the later filing supersedes the earlier one even though
+        ``filer_id`` differs. Codex pre-push review flagged the
+        prior filer_id-keyed query for missing this case."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=766_360, symbol="AAPL")
+        # Two distinct submitters, but they file on behalf of the
+        # same beneficial owner (same reporter_cik).
+        seed_filer(conn, cik="0001111111", label="Old Submitter")
+        seed_filer(conn, cik="0002222222", label="New Submitter")
+        _seed_filer_row(conn, filer_id=2001, cik="0001111111", name="Old Submitter LLC")
+        _seed_filer_row(conn, filer_id=2002, cik="0002222222", name="New Submitter LLC")
+
+        # First filing: old submitter, original 13D.
+        _seed_filing(
+            conn,
+            filer_id=2001,
+            accession="0001111111-25-000001",
+            submission_type="SCHEDULE 13D",
+            status="active",
+            instrument_id=766_360,
+            reporter_cik="0009999999",
+            reporter_no_cik=False,
+            reporter_name="Carl Icahn",
+            aggregate_shares="1000000",
+            percent="3.5",
+            filed_at=datetime(2025, 6, 1, tzinfo=UTC),
+        )
+        # Second filing: same beneficial owner, NEW submitter, 13D/A
+        # with updated position. Must supersede the original.
+        _seed_filing(
+            conn,
+            filer_id=2002,
+            accession="0002222222-25-000001",
+            submission_type="SCHEDULE 13D/A",
+            status="active",
+            instrument_id=766_360,
+            reporter_cik="0009999999",
+            reporter_no_cik=False,
+            reporter_name="Carl Icahn",
+            aggregate_shares="2500000",
+            percent="8.5",
+            filed_at=datetime(2025, 11, 6, tzinfo=UTC),
+        )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL/blockholders")
+        body = resp.json()
+        # Only the latest filing should appear — supersession via
+        # reporter identity, not submitter identity.
+        assert len(body["blockholders"]) == 1
+        assert body["blockholders"][0]["accession_number"] == "0002222222-25-000001"
+        assert body["blockholders"][0]["submission_type"] == "SCHEDULE 13D/A"
+        assert Decimal(body["blockholders"][0]["aggregate_amount_owned"]) == Decimal("2500000")
+        assert Decimal(body["totals"]["blockholders_shares"]) == Decimal("2500000")
+        assert body["totals"]["total_filers"] == 1
+
+    def test_distinct_holders_under_one_submitter_dont_collapse(
+        self,
+        client: TestClient,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """One EDGAR submitter (e.g. an investment adviser) files
+        separately on behalf of two distinct beneficial owners (two
+        different reporter_ciks, two different accessions). The
+        response must expose both blocks — not collapse them under
+        the shared submitter. Codex pre-push review flagged the
+        prior filer_id-keyed query for collapsing this case."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=766_370, symbol="AAPL")
+        seed_filer(conn, cik="0003333333", label="Shared Adviser")
+        _seed_filer_row(conn, filer_id=2010, cik="0003333333", name="Shared Adviser LLC")
+
+        # Two filings under the same submitter (filer_id=2010), but
+        # for two different beneficial owners (distinct reporter_cik).
+        _seed_filing(
+            conn,
+            filer_id=2010,
+            accession="0003333333-25-000001",
+            submission_type="SCHEDULE 13D",
+            status="active",
+            instrument_id=766_370,
+            reporter_cik="0008000001",
+            reporter_no_cik=False,
+            reporter_name="Beneficial Owner A",
+            aggregate_shares="1000000",
+            percent="3.5",
+            filed_at=datetime(2025, 11, 1, tzinfo=UTC),
+        )
+        _seed_filing(
+            conn,
+            filer_id=2010,
+            accession="0003333333-25-000002",
+            submission_type="SCHEDULE 13D",
+            status="active",
+            instrument_id=766_370,
+            reporter_cik="0008000002",
+            reporter_no_cik=False,
+            reporter_name="Beneficial Owner B",
+            aggregate_shares="2000000",
+            percent="7.0",
+            filed_at=datetime(2025, 11, 6, tzinfo=UTC),
+        )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL/blockholders")
+        body = resp.json()
+        # Two distinct holders → two rows + two blocks in totals.
+        assert len(body["blockholders"]) == 2
+        names = {row["reporter_name"] for row in body["blockholders"]}
+        assert names == {"Beneficial Owner A", "Beneficial Owner B"}
+        assert Decimal(body["totals"]["blockholders_shares"]) == Decimal("3000000")
+        assert body["totals"]["total_filers"] == 2
+
+    def test_active_passive_partition(
+        self,
+        client: TestClient,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Two filers — one 13D, one 13G — produce active + passive
+        share counts that sum to the total."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=766_340, symbol="AAPL")
+        seed_filer(conn, cik="0001234567", label="Active")
+        seed_filer(conn, cik="0007654321", label="Passive")
+        _seed_filer_row(conn, filer_id=1030, cik="0001234567", name="Activist Fund")
+        _seed_filer_row(conn, filer_id=1031, cik="0007654321", name="Index Fund")
+
+        _seed_filing(
+            conn,
+            filer_id=1030,
+            accession="0001234567-25-000030",
+            submission_type="SCHEDULE 13D",
+            status="active",
+            instrument_id=766_340,
+            reporter_cik="0001234567",
+            reporter_no_cik=False,
+            reporter_name="Activist Fund",
+            aggregate_shares="1500000",
+            percent="5.5",
+            filed_at=datetime(2025, 11, 6, tzinfo=UTC),
+        )
+        _seed_filing(
+            conn,
+            filer_id=1031,
+            accession="0007654321-25-000001",
+            submission_type="SCHEDULE 13G",
+            status="passive",
+            instrument_id=766_340,
+            reporter_cik="0007654321",
+            reporter_no_cik=False,
+            reporter_name="Index Fund",
+            aggregate_shares="3000000",
+            percent="11.0",
+            filed_at=datetime(2025, 10, 1, tzinfo=UTC),
+        )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL/blockholders")
+        body = resp.json()
+        assert Decimal(body["totals"]["blockholders_shares"]) == Decimal("4500000")
+        assert Decimal(body["totals"]["active_shares"]) == Decimal("1500000")
+        assert Decimal(body["totals"]["passive_shares"]) == Decimal("3000000")
+        assert body["totals"]["total_filers"] == 2
+
+    def test_limit_truncates_drilldown_but_not_totals(
+        self,
+        client: TestClient,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A small ``?limit=`` truncates the per-row list but the
+        totals row spans every block — so the ownership card never
+        mis-reports the slice when the operator filters the table."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=766_350, symbol="AAPL")
+        for i in range(3):
+            cik = f"00099999{i:02d}"
+            seed_filer(conn, cik=cik, label=f"Filer {i}")
+            _seed_filer_row(conn, filer_id=1100 + i, cik=cik, name=f"Filer {i}")
+            _seed_filing(
+                conn,
+                filer_id=1100 + i,
+                accession=f"00099999{i:02d}-25-000001",
+                submission_type="SCHEDULE 13D",
+                status="active",
+                instrument_id=766_350,
+                reporter_cik=cik,
+                reporter_no_cik=False,
+                reporter_name=f"Filer {i}",
+                aggregate_shares=str(1000000 * (i + 1)),
+                percent=str(i + 1),
+                filed_at=datetime(2025, 11, 6, tzinfo=UTC),
+            )
+        conn.commit()
+
+        resp = client.get("/instruments/AAPL/blockholders?limit=1")
+        body = resp.json()
+        assert len(body["blockholders"]) == 1
+        # Largest block first.
+        assert Decimal(body["blockholders"][0]["aggregate_amount_owned"]) == Decimal("3000000")
+        # Totals span all 3 blocks.
+        assert Decimal(body["totals"]["blockholders_shares"]) == Decimal("6000000")
+        assert body["totals"]["total_filers"] == 3


### PR DESCRIPTION
## What

Lands the 5th category on the ownership card. Activist hedge funds, founders, and ≥5%-holders now render as a distinct rose-500 wedge alongside Institutions / ETFs / Insiders / Treasury. Final PR for #766.

- ``app/api/instruments.py`` — ``GET /instruments/{symbol}/blockholders``
- ``tests/test_api_blockholders.py`` — 9 integration tests
- ``frontend/src/api/blockholders.ts`` — typed client
- Frontend: ownershipRings + OwnershipPanel + OwnershipPage + OwnershipSunburst + ownershipFreshness all wired through

## Why

PR 1 (#775) and PR 2 (#776) landed schema + parser + ingester + aggregator; this PR makes blockholders visible to the operator on the ownership card. Open-market residual on small/mid-caps with a known 13D filer no longer silently absorbs the activist position.

## Test plan

- [x] ``uv run ruff check / format / pyright`` — clean
- [x] ``uv run pytest tests/test_api_blockholders.py tests/smoke/test_app_boots.py`` — 10 pass
- [x] ``pnpm typecheck`` — clean
- [x] ``pnpm test:unit`` — 836 pass (+5 new for blockholders)
- [x] Codex pre-push review — clean after 3 follow-up rounds (see below)

3 pre-existing test failures on main remain unrelated.

## Codex pre-push findings (all addressed)

1. **High** — DISTINCT ON used ``filer_id`` (EDGAR submitter), not reporter identity. Broke supersession across submitter changes and conflated distinct holders under one submitter. Replaced with ``DISTINCT ON (COALESCE(reporter_cik, reporter_name), issuer_cik)``. Added ``test_supersession_across_different_submitters`` and ``test_distinct_holders_under_one_submitter_dont_collapse``.
2. **High** — frontend wedge mapping returned per-reporter rows; the snapshot-lag leaf-sum bump in ``buildSunburstRings`` then double-counted joint filings. ``blockholdersToHolders`` now dedupes by accession_number so wedge count + leaf-sum match the backend's per-accession totals.
3. **High** — wedge keys used ``block:${filer_cik}`` so two distinct beneficial owners under one submitter collided (Recharts silently dropped one wedge). Keys now use reporter identity (``reporter_cik`` or ``name:`` fallback).
4. **Medium** — L2 table row key briefly included accession suffix while wedge leaf key did not, breaking the wedge-click → highlight path. Both now ``block:${reporter_identity}`` verbatim.
5. **Low** — ``BlockholdersTotals.as_of_date`` was typed always-string while the API model allows ``null`` (filed_at can be NULL on malformed signature blocks). Fixed to ``string | null``.

## Tradeoffs

- **Joint filings**: backend returns per-reporter rows (matches issue spec — ``blockholders list (per-reporter rows)``); frontend dedupes per-accession for wedges only. Drilldown table keeps the per-reporter detail so operators can see the joint-filing depth.
- **Block identity**: chain key is ``COALESCE(reporter_cik, reporter_name)`` not ``filer_id``. Same beneficial owner re-filing through a different submitter still chains correctly.
- **L2 wiring**: full L2 drilldown for blockholders included in this PR rather than deferred — clicking the new wedge would otherwise land on an empty drilldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)