### PR TITLE
feat(#769): DEF 14A beneficial-ownership parser + schema (PR 1/N)

### DIFF
--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -1,0 +1,803 @@
+"""SEC DEF 14A (proxy statement) beneficial-ownership table parser.
+
+DEF 14A is filed annually by every Section 12-registered issuer.
+Item 12 of the proxy carries the "Security Ownership of Certain
+Beneficial Owners and Management" table — every officer + director
++ 5%+ holder with their share count and percent of class as of the
+proxy's record date.
+
+Use cases (per #769):
+
+  * Cross-check Form 4 cumulative running total — flag drift > 5%.
+  * Backfill historical insider holdings before Form 4 coverage
+    starts.
+  * Catch insiders who hold but never trade (no Form 4 events).
+  * Validate 13D/G blockholder ingest (#766) once shipped — Item 12
+    lists 5%+ holders independently of the holders' own filings.
+
+This module is a pure parser: HTML strings in, typed dataclasses
+out. HTTP fetch + DB resolution stay in the service layer per the
+settled provider-design rule.
+
+Parser strategy (deliberately conservative):
+
+  1. **Section locator** — find the "Security Ownership" / "5%
+     Holders" / "Beneficial Ownership" heading in the HTML stream.
+     Returns the byte offset of the heading; the caller scans for
+     ``<table>`` blocks at or after that offset.
+  2. **Table scoring** — for each candidate ``<table>`` block, score
+     the headers row by how many of {name|holder|owner,
+     shares|number, percent|%} substrings it contains. The
+     highest-scoring table within the section's window is the
+     beneficial-ownership table.
+  3. **Row extraction** — walk rows, extract holder name, shares,
+     percent. Tolerate footnote markers, asterisks, and numeric
+     formatting (commas, parentheses for negatives, leading "(1)" /
+     "(*)" footnote refs).
+  4. **Role inference** — section subheadings ("Directors and
+     Executive Officers", "5% Holders", "Principal Stockholders")
+     drive a heuristic role tag on each row. Defaults to NULL when
+     the table is one flat list with no subheadings.
+
+Variance tolerance:
+
+DEF 14A tables vary wildly across filers. Some put officers and 5%
+holders in one table; others split them. Some include "All directors
+and executive officers as a group" as a synthesis row; others don't.
+Some footnote shares with explanatory notes that the parser must
+preserve as suffixes on the holder_name (so audit trails stay
+intact) without polluting the share-count column.
+
+The parser errs on the side of returning fewer rows when a table is
+ambiguous. Empty result = "could not confidently identify the
+table"; the ingester (PR 2) tombstones the accession.
+
+#769 PR 1 of N. Subsequent PRs add the ingester (PR 2) and the
+drift-detector job that compares DEF 14A snapshots against Form 4
+cumulative balances (PR 3).
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Def14ABeneficialHolder:
+    """One row from the Item 12 beneficial-ownership table.
+
+    Field semantics:
+
+      * ``holder_name`` — the holder's name as it appears in the
+        table's first column. Footnote markers (``(1)``, ``(*)``,
+        ``[a]``) are stripped; explanatory parenthetical suffixes
+        in the same cell (e.g. ``"John Doe, CFO"``) are preserved
+        so a downstream Form-4 reconciliation can use them.
+      * ``holder_role`` — one of ``'officer'`` / ``'director'`` /
+        ``'principal'`` / ``'group'`` (for a synthesis row like
+        "All directors and executive officers as a group") or
+        ``None`` when the table is one flat list and the parser
+        cannot infer a role from a section subheading. The
+        ingester layer is free to enrich this via a curated
+        name→role seed table.
+      * ``shares`` — share count as ``Decimal``. ``None`` when the
+        cell is empty, dashed, or unparseable; this is rare but
+        legal (some issuers redact closely-held positions).
+      * ``percent_of_class`` — percent as ``Decimal``. ``None``
+        under the same rule. Asterisk markers (``*``) typically
+        denote "less than 1%" in the proxy footnotes — those map
+        to ``Decimal('0.5')`` per industry convention since "less
+        than 1%" is not literally zero.
+    """
+
+    holder_name: str
+    holder_role: str | None
+    shares: Decimal | None
+    percent_of_class: Decimal | None
+
+
+@dataclass(frozen=True)
+class Def14ABeneficialOwnershipTable:
+    """The full parsed payload from a DEF 14A primary doc.
+
+    Field semantics:
+
+      * ``as_of_date`` — the table's "as of" record date when the
+        parser can extract one from the surrounding prose
+        (typical: ``"as of March 1, 2026"`` in the section
+        introduction). NULL when no date is found.
+      * ``rows`` — 0..N. An empty list signals "table not
+        confidently identified"; the ingester tombstones the
+        accession.
+      * ``raw_table_score`` — internal diagnostics: the score of
+        the chosen table, exposed so the ingester's audit log can
+        record how confident the parser was. Higher is better.
+    """
+
+    as_of_date: date | None
+    rows: list[Def14ABeneficialHolder]
+    raw_table_score: int
+
+
+# ---------------------------------------------------------------------------
+# Regex helpers (mirror the proven patterns from
+# app/services/business_summary.py — duplicated rather than imported
+# to keep the parser provider-side / pure)
+# ---------------------------------------------------------------------------
+
+
+_TABLE_OPEN_RE: Final[re.Pattern[str]] = re.compile(r"<table\b[^>]*>", re.IGNORECASE)
+_TABLE_CLOSE_RE: Final[re.Pattern[str]] = re.compile(r"</table\s*>", re.IGNORECASE)
+_TR_RE: Final[re.Pattern[str]] = re.compile(r"<tr\b[^>]*>(.*?)</tr\s*>", re.IGNORECASE | re.DOTALL)
+_CELL_RE: Final[re.Pattern[str]] = re.compile(r"<(?:t[hd])\b[^>]*>(.*?)</t[hd]\s*>", re.IGNORECASE | re.DOTALL)
+_HTML_TAG_RE: Final[re.Pattern[str]] = re.compile(r"<[^>]+>")
+_NBSP_RE: Final[re.Pattern[str]] = re.compile(r"&nbsp;| ")
+_INLINE_WHITESPACE_RE: Final[re.Pattern[str]] = re.compile(r"[ \t\r\f\v]+")
+
+# Section heading variants. Case-insensitive; tolerate intervening
+# punctuation / line breaks. The proxy form mandates the heading
+# wording but issuers vary in casing and punctuation.
+_SECTION_HEADING_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:Security\s+Ownership\s+of\s+Certain\s+Beneficial\s+Owners"
+    r"|Beneficial\s+Ownership\s+of\s+(?:Common\s+Stock|Securities)"
+    r"|Principal\s+Stockholders"
+    r"|5\s*%\s*(?:or\s+(?:more|greater)\s+)?(?:Beneficial\s+)?(?:Stock)?holders?)",
+    re.IGNORECASE,
+)
+
+# "as of <date>" extraction — accepts both ``January 1, 2026`` and
+# ``1/1/2026`` formats. The proxy form requires a record date but
+# issuers vary in surface format.
+_AS_OF_DATE_RE: Final[re.Pattern[str]] = re.compile(
+    r"as\s+of\s+("
+    r"(?:January|February|March|April|May|June|July|August|September|October|November|December)"
+    r"\s+\d{1,2},?\s+\d{4}"
+    r"|\d{1,2}/\d{1,2}/\d{4}"
+    r"|\d{4}-\d{2}-\d{2}"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _strip_inline_html(raw: str) -> str:
+    """Strip HTML tags + entities, collapse whitespace. Used on cell
+    contents so footnote-superscript ``<sup>(1)</sup>`` markers
+    survive as plain ``(1)`` text and can be detected by the
+    footnote-stripping regex below.
+    """
+    no_tags = _HTML_TAG_RE.sub(" ", raw)
+    no_nbsp = _NBSP_RE.sub(" ", no_tags)
+    decoded = html.unescape(no_nbsp)
+    return _INLINE_WHITESPACE_RE.sub(" ", decoded).strip()
+
+
+def _scan_outer_tables(raw_html: str, *, start: int = 0, end: int | None = None) -> list[tuple[int, int]]:
+    """Return ``(start, end)`` offsets for every OUTERMOST
+    ``<table>...</table>`` block in ``raw_html`` between the given
+    bounds. Mirrors :func:`app.services.business_summary._scan_outer_tables`
+    but adds optional bounds so the caller can scope the scan to the
+    section window after locating the heading.
+    """
+    if end is None:
+        end = len(raw_html)
+    spans: list[tuple[int, int]] = []
+    pos = start
+    depth = 0
+    span_start = -1
+    while pos < end:
+        open_match = _TABLE_OPEN_RE.search(raw_html, pos, end)
+        close_match = _TABLE_CLOSE_RE.search(raw_html, pos, end)
+        if open_match is None and close_match is None:
+            break
+        if open_match is not None and (close_match is None or open_match.start() < close_match.start()):
+            if depth == 0:
+                span_start = open_match.start()
+            depth += 1
+            pos = open_match.end()
+        else:
+            assert close_match is not None
+            depth -= 1
+            if depth == 0 and span_start != -1:
+                spans.append((span_start, close_match.end()))
+                span_start = -1
+            elif depth < 0:
+                depth = 0
+                span_start = -1
+            pos = close_match.end()
+    return spans
+
+
+# ---------------------------------------------------------------------------
+# Section locator
+# ---------------------------------------------------------------------------
+
+
+# Window of HTML to scan for the beneficial-ownership table after
+# the section heading. Half a megabyte is enough for any DEF 14A
+# table even on the largest filers (Atlassian's iXBRL DEF 14A is
+# ~1.5MB total; the section + table fit in a 500KB tail).
+_SECTION_SCAN_BYTES: Final[int] = 500 * 1024
+
+
+def _is_inside_table(raw_html: str, position: int) -> bool:
+    """True when ``position`` falls inside an open ``<table>`` block.
+
+    Counts ``<table`` / ``</table`` tags before ``position`` — if
+    open > close, the position is inside a table cell. Used to
+    filter out section-heading regex matches that surface inside
+    table data cells (e.g. a row whose text reads ``"5% Holders"``
+    as a mid-table subheading) — those are not real headings and
+    should not anchor the section locator. Codex pre-push review
+    caught this on the multi-pass fix.
+    """
+    prefix = raw_html[:position]
+    opens = sum(1 for _ in _TABLE_OPEN_RE.finditer(prefix))
+    closes = sum(1 for _ in _TABLE_CLOSE_RE.finditer(prefix))
+    return opens > closes
+
+
+def _find_section_windows(raw_html: str) -> list[tuple[int, int]]:
+    """Find candidate byte ranges for the beneficial-ownership
+    section, in priority order.
+
+    Returns a list of ``(start, end)`` windows that the table
+    scorer tries in sequence. The first window whose best table
+    meets the score floor wins.
+
+    Priority order:
+
+      1. **Last heading match** — handles the TOC trap. Real DEF
+         14As open with a Table of Contents listing every section
+         heading verbatim; the actual section header is the last
+         occurrence in the document.
+      2. **First heading match** — handles the in-cell false
+         positive. Some tables have a row whose text reads
+         ``"5% Holders"`` (mid-table subheading); that pattern
+         matches our heading regex so last-match is wrong in that
+         case but first-match (the real ``<h2>`` in proxy header)
+         is correct.
+      3. **Whole document** — handles small DEF 14As that inline
+         the table without a dedicated section heading.
+
+    Codex pre-push review identified the TOC trap; the in-cell
+    false positive surfaced when fixing it. Multi-pass falls back
+    cleanly across both.
+    """
+    # Filter out heading matches that occur inside an open
+    # ``<table>`` — those are mid-table subheading rows
+    # (e.g. ``"5% Holders"`` in a cell that splits officers from
+    # principals), not actual section headings. Without this
+    # filter, an in-cell match could anchor a window that starts
+    # mid-ownership-table and miss the real table entirely.
+    matches = [m for m in _SECTION_HEADING_RE.finditer(raw_html) if not _is_inside_table(raw_html, m.start())]
+    windows: list[tuple[int, int]] = []
+    seen_starts: set[int] = set()
+
+    if matches:
+        # Last match — TOC fix.
+        last_start = matches[-1].start()
+        last_end = min(last_start + _SECTION_SCAN_BYTES, len(raw_html))
+        windows.append((last_start, last_end))
+        seen_starts.add(last_start)
+        # First match — fallback when the last match doesn't yield a
+        # scoring table (e.g. a heading mention in body prose
+        # without a following table). Skip when last == first.
+        first_start = matches[0].start()
+        if first_start not in seen_starts:
+            first_end = min(first_start + _SECTION_SCAN_BYTES, len(raw_html))
+            windows.append((first_start, first_end))
+            seen_starts.add(first_start)
+
+    # Whole-document fallback always tried last.
+    if 0 not in seen_starts:
+        windows.append((0, len(raw_html)))
+    return windows
+
+
+def _extract_as_of_date(raw_html: str, *, window_start: int, window_end: int) -> date | None:
+    """Find the ``"as of <date>"`` phrase nearest the section heading.
+
+    Scans the windowed slice (the heading + ~500KB tail). Returns
+    ``None`` when no recognisable date phrase is found.
+    """
+    text = _strip_inline_html(raw_html[window_start:window_end])
+    match = _AS_OF_DATE_RE.search(text)
+    if match is None:
+        return None
+    raw_date = match.group(1).strip().rstrip(",")
+    for fmt in ("%B %d, %Y", "%B %d %Y", "%m/%d/%Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(raw_date, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Table scoring + row extraction
+# ---------------------------------------------------------------------------
+
+
+# Header substring → score weight. Higher weight = more diagnostic
+# of the beneficial-ownership table specifically (vs e.g. the
+# stock-options table, the executive-compensation table).
+_HEADER_KEYWORDS: Final[tuple[tuple[str, int], ...]] = (
+    ("beneficial", 4),
+    ("amount and nature", 3),  # SEC-prescribed column heading
+    ("number of shares", 3),
+    ("name and address", 2),
+    ("name of beneficial", 3),
+    ("percent of class", 3),
+    ("percentage of", 2),
+    ("shares owned", 2),
+    ("shares beneficially", 3),
+    ("name", 1),  # weak — only fires when paired with a stronger keyword
+    ("shares", 1),
+    ("percent", 1),
+    ("%", 1),
+)
+
+
+def _score_table_headers(headers: tuple[str, ...]) -> int:
+    """Score a candidate table's header row. Higher is better."""
+    if not headers:
+        return 0
+    joined = " ".join(headers).lower()
+    score = 0
+    for keyword, weight in _HEADER_KEYWORDS:
+        if keyword in joined:
+            score += weight
+    return score
+
+
+@dataclass(frozen=True)
+class _RawTable:
+    """Internal carrier from ``_parse_table_html``.
+
+    ``score_headers`` is what the table scorer reads to decide if
+    this is the beneficial-ownership table — it merges parent-row
+    keywords with sub-header keywords when a two-row header layout
+    is detected, so the SEC-prescribed phrase ``"Amount and Nature
+    of Beneficial Ownership"`` from the parent row keeps boosting
+    the score even after the sub-row is promoted to canonical
+    column labels.
+
+    ``column_headers`` is what ``_resolve_columns`` reads to map
+    canonical columns (Name / Shares / Percent) to indices. In the
+    single-row-header case ``column_headers == score_headers``; in
+    the two-row case ``column_headers`` is just the sub-row so the
+    ``Total`` sub-column wins over ``Sole`` / ``Shared``.
+    """
+
+    score_headers: tuple[str, ...]
+    column_headers: tuple[str, ...]
+    rows: tuple[tuple[str, ...], ...]
+
+
+_NUMERIC_LIKE_RE: Final[re.Pattern[str]] = re.compile(r"\d{2,}")
+
+
+def _looks_like_subheader(cells: tuple[str, ...]) -> bool:
+    """True when a row looks like a sub-header continuation rather
+    than a data row.
+
+    A sub-header row:
+      * Has no cell containing a multi-digit run (data rows have
+        share counts like ``1,500,000``).
+      * Has at least one cell containing a column-label keyword
+        like ``Sole`` / ``Shared`` / ``Total`` / ``Voting`` /
+        ``Dispositive`` — these are the SEC-prescribed subdivisions
+        of the ``Amount and Nature of Beneficial Ownership``
+        merged-header column.
+    Codex pre-push review caught the merged-header case where a
+    proxy uses two header rows and the parser only saw row 0.
+    """
+    if not cells:
+        return False
+    for c in cells:
+        if _NUMERIC_LIKE_RE.search(c):
+            return False
+    joined = " ".join(cells).lower()
+    sub_keywords = ("sole", "shared", "total", "voting", "dispositive", "common", "preferred")
+    return any(k in joined for k in sub_keywords)
+
+
+def _parse_table_html(table_html: str) -> _RawTable | None:
+    """Extract one ``<table>`` block. Mirrors the helper in
+    business_summary but kept inlined so this module is provider-
+    side / self-contained (parsers should not import from
+    services).
+
+    Detects two-row header tables. Some DEF 14As use a merged top
+    header (``Name | Amount and Nature of Beneficial Ownership |
+    Percent``) with a sub-header (``Sole | Shared | Total``)
+    underneath. When the row-0 header has fewer cells than the
+    median data row AND row 1 looks like a sub-header (all-text,
+    contains column-label keywords), promote row 1 to canonical
+    headers so the column resolver can find ``Total``. Codex
+    pre-push review caught this on PR review.
+    """
+    open_match = _TABLE_OPEN_RE.search(table_html)
+    close_idx = table_html.rfind("</table")
+    if open_match is None or close_idx == -1:
+        return None
+    inner = table_html[open_match.end() : close_idx]
+    nested = _scan_outer_tables(inner)
+    if nested:
+        pieces: list[str] = []
+        cursor = 0
+        for start, end in nested:
+            pieces.append(inner[cursor:start])
+            pieces.append(" ")
+            cursor = end
+        pieces.append(inner[cursor:])
+        scrubbed = "".join(pieces)
+    else:
+        scrubbed = inner
+    cells_per_row: list[tuple[str, ...]] = []
+    for tr_match in _TR_RE.finditer(scrubbed):
+        cells = tuple(_strip_inline_html(cell) for cell in _CELL_RE.findall(tr_match.group(1)))
+        if any(c for c in cells):
+            cells_per_row.append(cells)
+    if not cells_per_row:
+        return None
+
+    parent_headers = cells_per_row[0]
+    body = cells_per_row[1:]
+    column_headers = parent_headers
+    score_headers = parent_headers
+
+    # Two-row header detection: when row 0 is narrower than the
+    # data rows AND row 1 looks like a sub-header continuation,
+    # the canonical column labels come from row 1 (so ``Total``
+    # wins over ``Sole`` / ``Shared``) but score still considers
+    # the parent row's SEC-prescribed keywords (so the table is
+    # still recognisable as the beneficial-ownership table). Codex
+    # pre-push review caught the missing parent-row score combine.
+    if body:
+        median_data_width = max(len(r) for r in body)
+        if len(parent_headers) < median_data_width and _looks_like_subheader(body[0]):
+            column_headers = body[0]
+            score_headers = parent_headers + body[0]
+            body = body[1:]
+
+    return _RawTable(score_headers=score_headers, column_headers=column_headers, rows=tuple(body))
+
+
+# Footnote / asterisk markers stripped from holder-name cells. The
+# raw cell often looks like ``"John Doe (1)"``, ``"John Doe[a]"``,
+# ``"John Doe*"``, or ``"John Doe (*)"`` — the marker is dropped,
+# the rest preserved.
+#
+# Three alternation branches:
+#   1. Bracketed numeric / asterisk / single alphabetic letter:
+#      ``(1)`` / ``[a]`` / ``[*]``. Single letter only — multi-letter
+#      bracketed strings (``[abc]``) are rare in proxies and may be
+#      legitimate suffixes (e.g. tickers in cross-references).
+#   2. Trailing single asterisk(s): ``"name*"`` / ``"name**"``.
+#   3. Parenthesised asterisks: ``"(*)"`` / ``"(**)"``.
+#
+# Codex pre-push review caught the prior version which only matched
+# digits or asterisks inside brackets — alphabetic markers like
+# ``[a]`` survived through the share-count parser and dropped the
+# whole row.
+_FOOTNOTE_RE: Final[re.Pattern[str]] = re.compile(r"\s*[\(\[](?:\d+|\*+|[a-zA-Z])[\)\]]|\s*\*+\s*$|\s*\(\*+\)")
+_LESS_THAN_ONE_PERCENT_VALUE: Final[Decimal] = Decimal("0.5")
+
+
+def _clean_holder_name(raw: str) -> str:
+    """Strip footnote markers from the holder name; keep the rest."""
+    return _FOOTNOTE_RE.sub("", raw).strip()
+
+
+def _parse_share_count(raw: str) -> Decimal | None:
+    """Parse a share-count cell. Accepts ``"1,234,567"`` /
+    ``"1234567"`` / ``"1,234,567(1)"`` / dash / em-dash / empty."""
+    if not raw:
+        return None
+    cleaned = _FOOTNOTE_RE.sub("", raw).strip().replace(",", "").replace(" ", "")
+    if cleaned in ("", "-", "—", "–", "N/A", "n/a"):
+        return None
+    try:
+        return Decimal(cleaned)
+    except InvalidOperation:
+        return None
+
+
+def _parse_percent(raw: str) -> Decimal | None:
+    """Parse a percent-of-class cell. Accepts ``"5.5%"`` /
+    ``"5.5"`` / ``"*"`` (less than 1% per industry convention) /
+    dash / empty.
+
+    The lone-asterisk check happens BEFORE the footnote-stripping
+    regex because that regex's trailing-asterisk branch would
+    otherwise erase the cell content and return None — losing the
+    less-than-1% signal the proxy explicitly conveys.
+    """
+    if not raw:
+        return None
+    cleaned = raw.strip().replace("%", "").replace(",", "").strip()
+    if cleaned in ("*", "**"):
+        # Industry convention: ``*`` denotes "less than 1%" in the
+        # proxy footnote. Persist as 0.5 so the cell is non-NULL but
+        # operators can still distinguish it from a real 0.5%
+        # holding (rare; the holder would then surface in Form 4
+        # cumulative anyway).
+        return _LESS_THAN_ONE_PERCENT_VALUE
+    cleaned = _FOOTNOTE_RE.sub("", cleaned).strip()
+    if cleaned in ("", "-", "—", "–"):
+        return None
+    try:
+        return Decimal(cleaned)
+    except InvalidOperation:
+        return None
+
+
+# Column-finder. DEF 14A tables vary in column order and labelling;
+# the parser locates each canonical column by header substring and
+# falls back to positional defaults (col 0 = name, col 1 = shares,
+# col -1 = percent) when the headers are missing or ambiguous.
+def _resolve_columns(headers: tuple[str, ...]) -> tuple[int, int, int]:
+    """Return ``(name_idx, shares_idx, percent_idx)``.
+
+    Shares column resolution is tiered. Some DEF 14As subdivide the
+    SEC-prescribed "Amount and Nature of Beneficial Ownership"
+    column into ``Sole | Shared | Total`` voting-power sub-columns.
+    A naive first-match-on-"shares"-or-"amount" picks ``Sole`` when
+    the real total lives in the ``Total`` column. The tiered
+    preference order is:
+
+      1. ``"total"`` (explicit total column wins)
+      2. ``"amount and nature"`` (SEC-prescribed merged-header text)
+      3. ``"shares beneficially"`` / ``"shares owned"``
+      4. ``"shares"`` / ``"number"`` / ``"amount"`` (weakest fallback)
+
+    Codex pre-push review caught this — without the tiered
+    preference, a Sole/Shared/Total/Percent layout reads ``Sole`` as
+    shares and ``Shared`` as percent.
+
+    Defaults to ``(0, 1, len(headers) - 1)`` when no header match
+    fires.
+    """
+    name_idx = -1
+    percent_idx = -1
+    # Tiered shares search — try strongest signal first, fall back.
+    shares_idx = -1
+    shares_tier_priority: list[tuple[str, int]] = []  # (header_substring, score)
+    SHARES_TIERS: tuple[tuple[str, int], ...] = (
+        ("total", 4),
+        ("amount and nature", 3),
+        ("shares beneficially", 3),
+        ("shares owned", 3),
+        ("number of shares", 2),
+        ("shares", 1),
+        ("number", 1),
+        ("amount", 1),
+    )
+
+    for i, h in enumerate(headers):
+        lower = h.lower()
+        if name_idx == -1 and ("name" in lower or "beneficial" in lower):
+            name_idx = i
+        if percent_idx == -1 and ("percent" in lower or "%" in lower):
+            percent_idx = i
+        for keyword, weight in SHARES_TIERS:
+            if keyword in lower:
+                shares_tier_priority.append((str(i), weight))
+                break
+
+    if shares_tier_priority:
+        # Sort by weight DESC (highest tier first), then by original
+        # column position ASC so the leftmost top-tier column wins.
+        shares_tier_priority.sort(key=lambda x: (-x[1], int(x[0])))
+        shares_idx = int(shares_tier_priority[0][0])
+
+    # Fallbacks. Many issuers use a multi-line nested-header style
+    # where the first row is "Name and Address / Amount and Nature
+    # of Beneficial Ownership / Percent of Class" with a sub-row
+    # "Sole / Shared / Total". The scoring pass picks the merged
+    # header row but column resolution can still see ambiguous
+    # entries.
+    if name_idx == -1:
+        name_idx = 0
+    if shares_idx == -1:
+        shares_idx = 1 if len(headers) >= 2 else 0
+    if percent_idx == -1:
+        percent_idx = len(headers) - 1
+    return (name_idx, shares_idx, percent_idx)
+
+
+# Section sub-heading detection within rows. Some issuers split the
+# table into "Officers and Directors" + "5% Holders" with bold
+# section-heading rows between groups. Any single-cell row whose
+# text matches one of these patterns flips the role tag for
+# subsequent rows.
+_ROLE_HEADING_PATTERNS: Final[tuple[tuple[re.Pattern[str], str], ...]] = (
+    (re.compile(r"\b(directors?|trustees?)\b.*\b(officers?|executives?)\b", re.IGNORECASE), "officer"),
+    (re.compile(r"\bofficers?\s+and\s+directors?\b", re.IGNORECASE), "officer"),
+    (re.compile(r"\bdirectors?\b", re.IGNORECASE), "director"),
+    (re.compile(r"\bofficers?\b", re.IGNORECASE), "officer"),
+    (re.compile(r"5\s*%.*holders?", re.IGNORECASE), "principal"),
+    (re.compile(r"principal\s+(?:share|stock)holders?", re.IGNORECASE), "principal"),
+    (re.compile(r"all\s+(?:directors?\s+and\s+)?executive\s+officers?\s+as\s+a\s+group", re.IGNORECASE), "group"),
+)
+
+
+def _detect_role_heading(cells: tuple[str, ...]) -> str | None:
+    """If ``cells`` is a single-text section heading row, return the
+    role tag for subsequent rows; else ``None``."""
+    non_empty = [c for c in cells if c.strip()]
+    if not non_empty:
+        return None
+    # A heading row is typically one cell or one cell plus a few empties.
+    if len(non_empty) > 1:
+        return None
+    text = non_empty[0]
+    for pattern, role in _ROLE_HEADING_PATTERNS:
+        if pattern.search(text):
+            return role
+    return None
+
+
+def _detect_inline_role(holder_name: str) -> str | None:
+    """Heuristic: when the holder cell carries the role inline
+    (e.g. ``"John Doe, CFO"`` / ``"Jane Smith — Director"``),
+    return the role tag. Used as a fallback when section
+    subheadings are missing."""
+    if not holder_name:
+        return None
+    lower = holder_name.lower()
+    if "as a group" in lower:
+        return "group"
+    role_keywords = (
+        ("director", "director"),
+        ("trustee", "director"),
+        ("ceo", "officer"),
+        ("cfo", "officer"),
+        ("coo", "officer"),
+        ("president", "officer"),
+        ("chairman", "officer"),
+        ("officer", "officer"),
+    )
+    for keyword, role in role_keywords:
+        if keyword in lower:
+            return role
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_beneficial_ownership_table(html_text: str) -> Def14ABeneficialOwnershipTable:
+    """Parse a DEF 14A primary doc HTML body and extract the
+    Item 12 beneficial-ownership table.
+
+    Returns an empty-rows result when no candidate table scores
+    above the floor. The ingester (PR 2) tombstones the accession
+    in that case so a non-standard issuer layout doesn't tight-loop
+    re-fetching the same proxy.
+
+    Does not raise on malformed HTML — best-effort extraction. The
+    surrounding ingester is responsible for fetch failures and for
+    persisting the result (or its absence) to the audit log.
+    """
+    if not html_text:
+        return Def14ABeneficialOwnershipTable(as_of_date=None, rows=[], raw_table_score=0)
+
+    # Score floor — below this we don't trust the match. Empirically
+    # tuned: a minimal-header beneficial-ownership table
+    # (``Name`` / ``Shares`` / ``Percent``) scores 3; tables with
+    # SEC-prescribed wording score 6+. Compensation / option-grant
+    # tables typically score 0-2 even when they include a "Name"
+    # column because they lack ``shares``/``percent`` cues.
+    SCORE_FLOOR = 3
+
+    candidate_windows = _find_section_windows(html_text)
+    best_score = 0
+    best_table: _RawTable | None = None
+    chosen_window: tuple[int, int] | None = None
+
+    # Multi-pass: try each priority window in order; the first one
+    # whose best table meets the floor wins.
+    for window_start, window_end in candidate_windows:
+        candidate_tables = _scan_outer_tables(html_text, start=window_start, end=window_end)
+        window_best_score = 0
+        window_best_table: _RawTable | None = None
+        for start, end in candidate_tables:
+            parsed = _parse_table_html(html_text[start:end])
+            if parsed is None:
+                continue
+            score = _score_table_headers(parsed.score_headers)
+            if score > window_best_score:
+                window_best_score = score
+                window_best_table = parsed
+        if window_best_table is not None and window_best_score >= SCORE_FLOOR:
+            best_score = window_best_score
+            best_table = window_best_table
+            chosen_window = (window_start, window_end)
+            break
+        # Also track the global best in case no window meets floor —
+        # lets callers see the best diagnostic score for tombstone
+        # logging (PR 2 will surface this).
+        if window_best_score > best_score:
+            best_score = window_best_score
+
+    if best_table is None or chosen_window is None:
+        logger.debug(
+            "DEF 14A: no beneficial-ownership table met score floor across %d window(s); best_score=%d",
+            len(candidate_windows),
+            best_score,
+        )
+        return Def14ABeneficialOwnershipTable(as_of_date=None, rows=[], raw_table_score=best_score)
+
+    window_start, window_end = chosen_window
+    as_of_date = _extract_as_of_date(html_text, window_start=window_start, window_end=window_end)
+
+    name_idx, shares_idx, percent_idx = _resolve_columns(best_table.column_headers)
+    rows: list[Def14ABeneficialHolder] = []
+    current_role: str | None = None
+
+    for raw_row in best_table.rows:
+        # Single-cell heading rows flip the role tag.
+        heading_role = _detect_role_heading(raw_row)
+        if heading_role is not None:
+            current_role = heading_role
+            continue
+
+        # Skip totally-empty rows defensively (the regex above
+        # already filters most but trailing footnote rows can slip
+        # through with one whitespace-only cell).
+        if not any(c.strip() for c in raw_row):
+            continue
+
+        # Pad short rows (some issuers omit trailing cells when the
+        # value is blank) so positional access doesn't IndexError.
+        cells = list(raw_row) + [""] * max(0, percent_idx + 1 - len(raw_row))
+
+        holder_name_raw = cells[name_idx] if name_idx < len(cells) else ""
+        shares_raw = cells[shares_idx] if shares_idx < len(cells) else ""
+        percent_raw = cells[percent_idx] if percent_idx < len(cells) else ""
+
+        holder_name = _clean_holder_name(holder_name_raw)
+        if not holder_name:
+            continue
+        shares = _parse_share_count(shares_raw)
+        percent = _parse_percent(percent_raw)
+
+        # Drop rows where neither shares nor percent parsed — that's
+        # almost always a free-text annotation row ("Notes:",
+        # "(continued from previous page)") and not real data.
+        if shares is None and percent is None:
+            continue
+
+        role = current_role or _detect_inline_role(holder_name)
+
+        rows.append(
+            Def14ABeneficialHolder(
+                holder_name=holder_name,
+                holder_role=role,
+                shares=shares,
+                percent_of_class=percent,
+            )
+        )
+
+    return Def14ABeneficialOwnershipTable(
+        as_of_date=as_of_date,
+        rows=rows,
+        raw_table_score=best_score,
+    )

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -411,7 +411,14 @@ def _looks_like_subheader(cells: tuple[str, ...]) -> bool:
         if _NUMERIC_LIKE_RE.search(c):
             return False
     joined = " ".join(cells).lower()
-    sub_keywords = ("sole", "shared", "total", "voting", "dispositive", "common", "preferred")
+    # Sub-header keywords scope tightly to ownership-block subdivisions.
+    # ``common`` / ``preferred`` were originally on this list as share
+    # class indicators but they collide with legitimate holder names
+    # (e.g. ``"Common Fund LLC"``) — Codex / bot review caught the
+    # false positive: a one-cell holder-name row with "common" in the
+    # name AND no numeric cell would be silently promoted to column
+    # headers and dropped from the data set. Removed both.
+    sub_keywords = ("sole", "shared", "total", "voting", "dispositive")
     return any(k in joined for k in sub_keywords)
 
 
@@ -468,8 +475,8 @@ def _parse_table_html(table_html: str) -> _RawTable | None:
     # still recognisable as the beneficial-ownership table). Codex
     # pre-push review caught the missing parent-row score combine.
     if body:
-        median_data_width = max(len(r) for r in body)
-        if len(parent_headers) < median_data_width and _looks_like_subheader(body[0]):
+        max_data_width = max(len(r) for r in body)
+        if len(parent_headers) < max_data_width and _looks_like_subheader(body[0]):
             column_headers = body[0]
             score_headers = parent_headers + body[0]
             body = body[1:]

--- a/sql/097_def14a_beneficial_holdings.sql
+++ b/sql/097_def14a_beneficial_holdings.sql
@@ -1,0 +1,128 @@
+-- 097_def14a_beneficial_holdings.sql
+--
+-- Issue #769 PR 1 of N — schema for SEC DEF 14A beneficial-ownership
+-- table parser. DEF 14A is the proxy statement filed annually by
+-- every Section 12-registered issuer. Item 12 of the proxy (Schedule
+-- 14A) carries a beneficial-ownership table listing every officer +
+-- director + 5%+ holder along with their share count and percent of
+-- class as of a recent record date.
+--
+-- Why this matters operationally:
+--
+--   * Form 4 is event-driven — an officer who is granted shares on
+--     appointment and never sells them generates no Form 4 events,
+--     and our cumulative running total starts at zero. Form 3 (#768)
+--     covers the appointment baseline; DEF 14A is the canonical
+--     annual reconciliation point for both.
+--   * 13D/G blockholders (#766) are also reconciled via Item 12 —
+--     the proxy lists 5%+ holders independently of the holders'
+--     own filings, so a missing 13D/G ingest surfaces as a DEF 14A
+--     row without a matching ``blockholder_filings`` chain.
+--   * Drift between Form 4 cumulative and the DEF 14A snapshot >5%
+--     is the operator's signal that ingest coverage is broken (or
+--     that an unreported transaction exists).
+--
+-- Schema decisions:
+--
+--   * ``instrument_id`` is nullable — DEF 14A's issuer CIK is
+--     resolved via ``external_identifiers`` post-parse; rows whose
+--     CIK is unmapped are persisted with NULL so the audit trail
+--     stays intact and a later mapping backfill can promote them.
+--   * ``holder_role`` is a free-text label (``'officer'``,
+--     ``'director'``, ``'principal'``, ``'officer:CFO'``, etc.) —
+--     the parser derives this from the table's section heading or
+--     row label. No CHECK constraint: roles vary by issuer and a
+--     restrictive enum would silently drop unfamiliar labels at
+--     ingest time.
+--   * ``shares`` is NUMERIC(24, 4) to match
+--     ``insider_transactions.shares`` so cross-source cumulative
+--     queries stay arithmetic-clean.
+--   * ``percent_of_class`` is NUMERIC(8, 4) for the same reason as
+--     ``blockholder_filings`` (#766) — SEC allows 4 decimals.
+--   * ``as_of_date`` is the record date the table reports against.
+--     Frequently the issuer's record date for the upcoming annual
+--     meeting (typically 60-90 days before the meeting). NULL when
+--     the parser cannot find an explicit date string in the
+--     surrounding section.
+--   * Identity / dedupe is ``(accession_number, holder_name)`` —
+--     the same accession with the same holder is the same row. The
+--     unique constraint deliberately does NOT include
+--     ``holder_role`` because the role tag is parser-derived
+--     (heuristic) — re-parsing the same accession with improved
+--     role inference would otherwise insert a duplicate row.
+--     Two-officers-with-the-same-full-name in one accession is
+--     virtually impossible (the proxy form uses distinct legal
+--     names); on the rare collision the second row UPSERTs over
+--     the first which is acceptable for v1. Codex pre-push review
+--     caught the prior version's role-keyed identity.
+--
+-- _PLANNER_TABLES in tests/fixtures/ebull_test_db.py is updated in
+-- the same PR per the prevention-log entry.
+
+CREATE TABLE IF NOT EXISTS def14a_beneficial_holdings (
+    holding_id        BIGSERIAL PRIMARY KEY,
+    instrument_id     BIGINT REFERENCES instruments(instrument_id),
+    accession_number  TEXT NOT NULL,
+    issuer_cik        TEXT NOT NULL,
+    holder_name       TEXT NOT NULL,
+    holder_role       TEXT,
+    shares            NUMERIC(24, 4),
+    percent_of_class  NUMERIC(8, 4),
+    as_of_date        DATE,
+    fetched_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Idempotent re-ingest. Identity is ``(accession_number,
+-- holder_name)``. Holder role is heuristic-derived and excluded
+-- from the unique key so re-parsing with improved role inference
+-- promotes the existing row via UPSERT instead of inserting a
+-- duplicate. Codex pre-push review caught this on PR review.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_def14a_holdings_accession_holder
+    ON def14a_beneficial_holdings (accession_number, holder_name);
+
+-- Hot path for the per-instrument reader (PR 3 reconciliation
+-- view): walk holdings for one instrument across the most recent
+-- as_of dates first.
+CREATE INDEX IF NOT EXISTS idx_def14a_holdings_instrument_as_of
+    ON def14a_beneficial_holdings (instrument_id, as_of_date DESC);
+
+-- Hot path for the drift detector (PR 2): walk every snapshot for
+-- one issuer + holder ordered by date so the latest position is
+-- a single index lookup.
+CREATE INDEX IF NOT EXISTS idx_def14a_holdings_issuer_holder
+    ON def14a_beneficial_holdings (issuer_cik, holder_name, as_of_date DESC);
+
+
+-- ── def14a_ingest_log ──────────────────────────────────────────
+--
+-- Per-accession attempt tombstone. Same rationale as the
+-- institutional-holdings and blockholder-filings ingest logs: an
+-- accession that produces zero canonical rows (no recognisable
+-- beneficial-ownership table, malformed HTML, every holder name
+-- unparseable) must still be marked attempted so the next run
+-- skips it instead of re-fetching the primary doc forever.
+--
+-- Common reasons for zero rows:
+--
+--   * Section heading present but the table-finder picked the wrong
+--     <table> block (header mismatch on a non-standard issuer
+--     layout).
+--   * Issuer files DEF 14A as a notice-only statement (e.g. annual
+--     meeting only ratifies auditor; no governance changes; some
+--     small-cap issuers omit the ownership table when there's no
+--     5% holder and only a sole executive).
+--   * Persistent 404 on the primary doc.
+
+CREATE TABLE IF NOT EXISTS def14a_ingest_log (
+    accession_number   TEXT PRIMARY KEY,
+    issuer_cik         TEXT NOT NULL,
+    status             TEXT NOT NULL
+        CHECK (status IN ('success', 'partial', 'failed')),
+    rows_inserted      INTEGER NOT NULL DEFAULT 0,
+    rows_skipped       INTEGER NOT NULL DEFAULT 0,
+    error              TEXT,
+    fetched_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_def14a_ingest_log_issuer
+    ON def14a_ingest_log (issuer_cik, fetched_at DESC);

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -121,6 +121,11 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "blockholder_filings",
     "blockholder_filers",
     "blockholder_filer_seeds",
+    # #769 — DEF 14A beneficial ownership cross-check. FK → instruments
+    # (nullable). Listing explicitly keeps teardown deterministic when
+    # a test populates DEF 14A rows without touching instruments.
+    "def14a_ingest_log",
+    "def14a_beneficial_holdings",
     "filing_events",
     "decision_audit",  # #315 Phase 3 alerts
     "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -1,0 +1,439 @@
+"""Unit tests for the SEC DEF 14A beneficial-ownership parser (#769 PR 1).
+
+Fixture HTML is hand-built to mirror the shape of real DEF 14A
+proxy statements without pulling production payloads into the repo.
+Each scenario pins a single behaviour:
+
+  * Section locator — finds the heading even with extra inline
+    markup; falls back to whole-document scan when absent.
+  * Table scoring — picks the beneficial-ownership table over a
+    competing options-grants / compensation table on the same page.
+  * Footnote stripping — ``(1)``, ``(*)``, asterisks, brackets all
+    drop from holder names + numeric cells.
+  * Less-than-1% convention — bare ``*`` in the percent column maps
+    to ``Decimal('0.5')`` per industry convention.
+  * Role inference — section subheadings flip the role tag for
+    subsequent rows; inline labels fire as fallback.
+  * Numeric tolerance — commas, em-dash, N/A all parse safely.
+  * No-match safety — a proxy without a recognisable
+    beneficial-ownership table returns empty rows + score floor.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from app.providers.implementations.sec_def14a import (
+    Def14ABeneficialOwnershipTable,
+    parse_beneficial_ownership_table,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _proxy_html(*, body: str, heading: str = "Security Ownership of Certain Beneficial Owners and Management") -> str:
+    """Wrap an HTML fragment in a minimal proxy-statement skeleton."""
+    return f"""<!DOCTYPE html>
+<html><head><title>Proxy Statement</title></head>
+<body>
+<h1>Notice of Annual Meeting</h1>
+<p>Some preamble prose.</p>
+
+<h2>{heading}</h2>
+<p>The following table sets forth the beneficial ownership as of March 1, 2026.</p>
+{body}
+<p>Footnotes:</p>
+<ol><li>Includes options exercisable within 60 days.</li></ol>
+</body></html>"""
+
+
+_STANDARD_TABLE = """
+<table>
+  <tr>
+    <th>Name and Address of Beneficial Owner</th>
+    <th>Number of Shares Beneficially Owned</th>
+    <th>Percent of Class</th>
+  </tr>
+  <tr><td>John Doe, CEO</td><td>1,500,000</td><td>5.5%</td></tr>
+  <tr><td>Jane Smith, Director</td><td>250,000(1)</td><td>*</td></tr>
+  <tr><td>Vanguard Group, Inc.</td><td>3,000,000</td><td>11.0%</td></tr>
+  <tr>
+    <td>All directors and executive officers as a group (5 persons)</td>
+    <td>2,100,000</td>
+    <td>7.7%</td>
+  </tr>
+</table>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Happy-path parsing
+# ---------------------------------------------------------------------------
+
+
+def test_standard_table_parses_holder_count_and_percent() -> None:
+    parsed = parse_beneficial_ownership_table(_proxy_html(body=_STANDARD_TABLE))
+
+    assert isinstance(parsed, Def14ABeneficialOwnershipTable)
+    assert len(parsed.rows) == 4
+    assert parsed.rows[0].holder_name == "John Doe, CEO"
+    assert parsed.rows[0].shares == Decimal("1500000")
+    assert parsed.rows[0].percent_of_class == Decimal("5.5")
+    assert parsed.rows[0].holder_role == "officer"  # via inline "CEO"
+
+    # Footnote (1) stripped from shares + name; ``*`` percent maps to
+    # the less-than-one-percent convention (0.5).
+    assert parsed.rows[1].holder_name == "Jane Smith, Director"
+    assert parsed.rows[1].shares == Decimal("250000")
+    assert parsed.rows[1].percent_of_class == Decimal("0.5")
+    assert parsed.rows[1].holder_role == "director"
+
+    assert parsed.rows[2].holder_name == "Vanguard Group, Inc."
+    assert parsed.rows[2].shares == Decimal("3000000")
+    assert parsed.rows[2].percent_of_class == Decimal("11.0")
+
+    assert parsed.rows[3].holder_role == "group"  # synthesis row
+    assert parsed.rows[3].shares == Decimal("2100000")
+
+
+def test_as_of_date_extracted_from_section_intro() -> None:
+    parsed = parse_beneficial_ownership_table(_proxy_html(body=_STANDARD_TABLE))
+    assert parsed.as_of_date == date(2026, 3, 1)
+
+
+def test_as_of_date_iso_format_supported() -> None:
+    body = _STANDARD_TABLE
+    html = _proxy_html(body=body).replace("March 1, 2026", "2026-03-01")
+    parsed = parse_beneficial_ownership_table(html)
+    assert parsed.as_of_date == date(2026, 3, 1)
+
+
+def test_as_of_date_slash_format_supported() -> None:
+    html = _proxy_html(body=_STANDARD_TABLE).replace("March 1, 2026", "3/1/2026")
+    parsed = parse_beneficial_ownership_table(html)
+    assert parsed.as_of_date == date(2026, 3, 1)
+
+
+def test_as_of_date_absent_returns_none() -> None:
+    body = _STANDARD_TABLE
+    html = _proxy_html(body=body).replace("as of March 1, 2026", "shown below")
+    parsed = parse_beneficial_ownership_table(html)
+    assert parsed.as_of_date is None
+
+
+# ---------------------------------------------------------------------------
+# Section locator + table scoring
+# ---------------------------------------------------------------------------
+
+
+def test_options_grants_table_is_not_picked_over_ownership_table() -> None:
+    """A competing grants table ahead of the ownership section
+    must NOT be picked — the section locator scopes the scan to
+    the post-heading window."""
+    competing = """
+    <h2>Stock Option Grants in Last Fiscal Year</h2>
+    <table>
+      <tr><th>Name</th><th>Options Granted</th><th>Exercise Price</th></tr>
+      <tr><td>John Doe, CEO</td><td>50,000</td><td>$120.00</td></tr>
+    </table>
+    """
+    html = competing + _proxy_html(body=_STANDARD_TABLE)
+    parsed = parse_beneficial_ownership_table(html)
+    assert len(parsed.rows) == 4
+    # Make sure none of the parsed shares were 50,000 (the grants
+    # value) — that would mean the parser picked the wrong table.
+    assert all(r.shares != Decimal("50000") for r in parsed.rows)
+
+
+def test_section_heading_variants_all_resolve() -> None:
+    for heading in (
+        "Security Ownership of Certain Beneficial Owners and Management",
+        "Beneficial Ownership of Common Stock",
+        "Principal Stockholders",
+        "5% Holders",
+        "5 % or more Beneficial Owners",
+    ):
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=_STANDARD_TABLE, heading=heading))
+        assert len(parsed.rows) >= 1, f"heading variant did not resolve: {heading!r}"
+
+
+def test_no_section_heading_falls_back_to_whole_document() -> None:
+    """Small DEF 14As sometimes inline the table without a
+    dedicated heading. Whole-document scan still picks it up."""
+    html = f"<html><body><p>Annual meeting notice.</p>{_STANDARD_TABLE}</body></html>"
+    parsed = parse_beneficial_ownership_table(html)
+    assert len(parsed.rows) == 4
+
+
+def test_no_recognisable_table_returns_empty_rows() -> None:
+    """A proxy without an ownership table (notice-only filing,
+    options-only filing) returns zero rows and a low score so the
+    ingester can tombstone."""
+    html = _proxy_html(
+        body="<table><tr><th>Auditor</th><th>Term</th></tr><tr><td>Acme LLP</td><td>1 year</td></tr></table>"
+    )
+    parsed = parse_beneficial_ownership_table(html)
+    assert parsed.rows == []
+    assert parsed.raw_table_score < 3
+
+
+# ---------------------------------------------------------------------------
+# Role inference
+# ---------------------------------------------------------------------------
+
+
+def test_role_section_heading_flips_role_for_subsequent_rows() -> None:
+    """A single-cell heading row inside the table (some issuers split
+    officers from 5%-holders this way) flips the role tag."""
+    body = """
+    <table>
+      <tr><th>Name</th><th>Shares</th><th>Percent</th></tr>
+      <tr><td>Officers and Directors</td><td></td><td></td></tr>
+      <tr><td>John Doe</td><td>1,500,000</td><td>5.5%</td></tr>
+      <tr><td>Jane Smith</td><td>800,000</td><td>3.0%</td></tr>
+      <tr><td>5% Holders</td><td></td><td></td></tr>
+      <tr><td>Vanguard Group</td><td>3,000,000</td><td>11.0%</td></tr>
+    </table>
+    """
+    parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+    assert len(parsed.rows) == 3
+    assert parsed.rows[0].holder_role == "officer"
+    assert parsed.rows[1].holder_role == "officer"
+    assert parsed.rows[2].holder_role == "principal"
+
+
+def test_inline_role_label_fires_when_no_section_heading() -> None:
+    """Without a section subheading, the parser detects the role
+    from inline text in the holder cell."""
+    body = """
+    <table>
+      <tr><th>Beneficial Owner</th><th>Shares Owned</th><th>Percent</th></tr>
+      <tr><td>John Doe</td><td>1,500,000</td><td>5.5%</td></tr>
+      <tr><td>Jane Smith - Director</td><td>800,000</td><td>3.0%</td></tr>
+    </table>
+    """
+    parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+    assert parsed.rows[0].holder_role is None  # no inline label
+    assert parsed.rows[1].holder_role == "director"
+
+
+# ---------------------------------------------------------------------------
+# Numeric tolerance + footnote stripping
+# ---------------------------------------------------------------------------
+
+
+def test_dash_and_na_share_counts_resolve_to_none() -> None:
+    body = """
+    <table>
+      <tr><th>Name</th><th>Shares Beneficially Owned</th><th>Percent of Class</th></tr>
+      <tr><td>Holder A</td><td>—</td><td>—</td></tr>
+      <tr><td>Holder B</td><td>N/A</td><td>—</td></tr>
+      <tr><td>Holder C</td><td>0</td><td>0%</td></tr>
+    </table>
+    """
+    parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+    # Holder A + B drop because both shares AND percent unparseable.
+    # Holder C survives because shares=0 + percent=0 are valid.
+    assert len(parsed.rows) == 1
+    assert parsed.rows[0].holder_name == "Holder C"
+    assert parsed.rows[0].shares == Decimal("0")
+    assert parsed.rows[0].percent_of_class == Decimal("0")
+
+
+def test_bracketed_footnote_markers_stripped() -> None:
+    body = """
+    <table>
+      <tr><th>Name</th><th>Number of Shares</th><th>Percent of Class</th></tr>
+      <tr><td>Bracketed Holder [1]</td><td>1,000,000 [2]</td><td>3.5%[3]</td></tr>
+    </table>
+    """
+    parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+    assert len(parsed.rows) == 1
+    assert parsed.rows[0].holder_name == "Bracketed Holder"
+    assert parsed.rows[0].shares == Decimal("1000000")
+    assert parsed.rows[0].percent_of_class == Decimal("3.5")
+
+
+def test_sup_footnote_markers_stripped() -> None:
+    body = """
+    <table>
+      <tr><th>Name</th><th>Number of Shares</th><th>Percent of Class</th></tr>
+      <tr><td>Sup Holder<sup>(1)</sup></td><td>500,000<sup>(2)</sup></td><td>2.0%</td></tr>
+    </table>
+    """
+    parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+    assert len(parsed.rows) == 1
+    assert parsed.rows[0].holder_name == "Sup Holder"
+    assert parsed.rows[0].shares == Decimal("500000")
+
+
+# ---------------------------------------------------------------------------
+# Sanity guards
+# ---------------------------------------------------------------------------
+
+
+def test_empty_html_returns_empty_result_safely() -> None:
+    parsed = parse_beneficial_ownership_table("")
+    assert parsed.rows == []
+    assert parsed.raw_table_score == 0
+    assert parsed.as_of_date is None
+
+
+def test_garbage_html_does_not_raise() -> None:
+    """The parser never raises — best-effort extraction. The
+    ingester is responsible for tombstoning malformed accessions."""
+    parsed = parse_beneficial_ownership_table("<not really html<<<>>>")
+    assert parsed.rows == []
+
+
+# ---------------------------------------------------------------------------
+# Codex pre-push fixes — TOC trap, multi-column block, alpha footnotes
+# ---------------------------------------------------------------------------
+
+
+def test_toc_entry_does_not_anchor_section_window() -> None:
+    """Real DEF 14As open with a Table of Contents listing every
+    section heading. The section locator must pick the LAST match,
+    not the first — otherwise the TOC entry's window would miss the
+    real section (especially on large filings where >500KB of prose
+    sits between TOC and section). Codex pre-push review caught
+    this."""
+    toc = """
+    <h1>Table of Contents</h1>
+    <ul>
+      <li>Election of Directors</li>
+      <li>Security Ownership of Certain Beneficial Owners and Management</li>
+      <li>Auditor Ratification</li>
+    </ul>
+    """
+    # Pad with prose to simulate distance between TOC and section.
+    padding = "<p>Some governance prose.</p>" * 50
+    real_section = _proxy_html(body=_STANDARD_TABLE)
+    html = toc + padding + real_section
+    parsed = parse_beneficial_ownership_table(html)
+    assert len(parsed.rows) == 4, "TOC entry stole the window from the real section"
+
+
+def test_sole_shared_total_layout_picks_total_column() -> None:
+    """SEC-prescribed Sole/Shared/Total/Percent layout — the parser
+    must pick the ``Total`` column for shares, not ``Sole`` (the
+    first column matching ``"shares"``-ish). Codex pre-push review
+    caught the prior version reading ``Sole`` as shares and
+    ``Shared`` as percent."""
+    body = """
+    <table>
+      <tr>
+        <th>Name and Address of Beneficial Owner</th>
+        <th>Sole Voting Power</th>
+        <th>Shared Voting Power</th>
+        <th>Total Shares Beneficially Owned</th>
+        <th>Percent of Class</th>
+      </tr>
+      <tr>
+        <td>Activist Holder LLC</td>
+        <td>100</td><td>50</td><td>1,500,000</td><td>5.5%</td>
+      </tr>
+    </table>
+    """
+    parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+    assert len(parsed.rows) == 1
+    assert parsed.rows[0].shares == Decimal("1500000"), f"expected Total column (1.5M), got {parsed.rows[0].shares}"
+    assert parsed.rows[0].percent_of_class == Decimal("5.5")
+
+
+def test_in_table_subheading_does_not_anchor_section_window() -> None:
+    """A table cell whose text reads ``"5% Holders"`` (mid-table
+    subheading splitting officers from principals) matches the
+    section-heading regex but is not a real heading. The locator
+    must skip it so the real ``<h2>`` heading anchors the window —
+    not the in-cell text. Codex pre-push review caught this when
+    fixing the TOC trap."""
+    body_with_subheading_row = """
+    <table>
+      <tr>
+        <th>Name and Address of Beneficial Owner</th>
+        <th>Number of Shares Beneficially Owned</th>
+        <th>Percent of Class</th>
+      </tr>
+      <tr><td>John Doe</td><td>1,000,000</td><td>3.5%</td></tr>
+      <tr><td>5% Holders</td><td></td><td></td></tr>
+      <tr><td>Vanguard Group</td><td>3,000,000</td><td>11.0%</td></tr>
+    </table>
+    """
+    # Add a competing post-table compensation table so the wrong
+    # window would land somewhere with rows.
+    competing_after = """
+    <h3>Executive Compensation Summary</h3>
+    <table>
+      <tr><th>Name</th><th>Salary</th><th>Bonus</th></tr>
+      <tr><td>Option Grants Bucket</td><td>50,000</td><td>25</td></tr>
+    </table>
+    """
+    html = _proxy_html(body=body_with_subheading_row) + competing_after
+    parsed = parse_beneficial_ownership_table(html)
+    # Real ownership table parsed — 2 holder rows + 1 mid-table
+    # subheading row that flips role tag (no data emitted from it).
+    assert len(parsed.rows) == 2
+    assert parsed.rows[0].holder_name == "John Doe"
+    assert parsed.rows[1].holder_name == "Vanguard Group"
+    # Compensation row must NOT have leaked through.
+    assert all(r.shares != Decimal("50000") for r in parsed.rows)
+
+
+def test_two_row_header_with_sole_shared_total_promotes_subheader() -> None:
+    """Some DEF 14As use a merged top header
+    (``Name | Amount and Nature | Percent``) with a sub-row
+    (``Sole | Shared | Total``) underneath. The parser must promote
+    the sub-row to canonical headers so the column resolver finds
+    ``Total``. Codex pre-push review caught this."""
+    body = """
+    <table>
+      <tr>
+        <th>Name and Address of Beneficial Owner</th>
+        <th>Amount and Nature of Beneficial Ownership</th>
+        <th>Percent of Class</th>
+      </tr>
+      <tr>
+        <th></th><th>Sole</th><th>Shared</th><th>Total</th><th></th>
+      </tr>
+      <tr>
+        <td>Activist Holder LLC</td>
+        <td>100</td><td>50</td><td>1,500,000</td><td>5.5%</td>
+      </tr>
+    </table>
+    """
+    parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+    assert len(parsed.rows) == 1
+    # Total column wins, not Sole.
+    assert parsed.rows[0].shares == Decimal("1500000")
+    assert parsed.rows[0].percent_of_class == Decimal("5.5")
+
+
+def test_alphabetic_footnote_markers_stripped_from_holder_and_numeric_cells() -> None:
+    """``[a]`` / ``(b)`` / ``[c]`` footnote markers (used by some
+    issuers instead of numeric ``(1)`` / ``[1]``) must strip
+    cleanly so the share-count parser sees a clean number. Codex
+    pre-push review caught the prior regex matching only digits and
+    asterisks."""
+    body = """
+    <table>
+      <tr>
+        <th>Name and Address of Beneficial Owner</th>
+        <th>Number of Shares</th>
+        <th>Percent of Class</th>
+      </tr>
+      <tr><td>Holder With Letter Footnote [a]</td><td>1,000,000 [b]</td><td>3.5% [c]</td></tr>
+      <tr><td>Holder With Paren Letter (d)</td><td>500,000(e)</td><td>1.5%(f)</td></tr>
+    </table>
+    """
+    parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+    assert len(parsed.rows) == 2
+    assert parsed.rows[0].holder_name == "Holder With Letter Footnote"
+    assert parsed.rows[0].shares == Decimal("1000000")
+    assert parsed.rows[0].percent_of_class == Decimal("3.5")
+    assert parsed.rows[1].holder_name == "Holder With Paren Letter"
+    assert parsed.rows[1].shares == Decimal("500000")
+    assert parsed.rows[1].percent_of_class == Decimal("1.5")

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -383,6 +383,30 @@ def test_in_table_subheading_does_not_anchor_section_window() -> None:
     assert all(r.shares != Decimal("50000") for r in parsed.rows)
 
 
+def test_holder_named_common_fund_is_not_treated_as_subheader() -> None:
+    """A holder cell containing the word ``"common"`` (e.g. a fund
+    named ``"Common Fund LLC"``) must not be silently promoted to
+    column-headers and dropped from the data set. Codex / bot
+    review caught this on PR review — ``common`` was originally in
+    the sub-header keyword list as a share-class indicator but
+    collided with legitimate holder names."""
+    body = """
+    <table>
+      <tr>
+        <th>Name and Address of Beneficial Owner</th>
+        <th>Number of Shares</th>
+        <th>Percent of Class</th>
+      </tr>
+      <tr><td>Common Fund LLC</td><td>3,000,000</td><td>11.0%</td></tr>
+      <tr><td>Other Holder</td><td>1,000,000</td><td>3.5%</td></tr>
+    </table>
+    """
+    parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+    assert len(parsed.rows) == 2
+    names = [r.holder_name for r in parsed.rows]
+    assert "Common Fund LLC" in names
+
+
 def test_two_row_header_with_sole_shared_total_promotes_subheader() -> None:
     """Some DEF 14As use a merged top header
     (``Name | Amount and Nature | Percent``) with a sub-row


### PR DESCRIPTION
## What

SEC DEF 14A (proxy statement) Item 12 beneficial-ownership table parser + schema. PR 1 of N for #769.

- ``sql/097_def14a_beneficial_holdings.sql`` — schema (holdings + ingest log)
- ``app/providers/implementations/sec_def14a.py`` — pure HTML parser
- ``tests/test_sec_def14a_parser.py`` — 21 unit tests with hand-built fixtures

Subsequent PRs add the ingester (PR 2) and the drift-detector job that compares DEF 14A snapshots against Form 4 cumulative balances (PR 3).

## Why

DEF 14A's Item 12 is the SEC-authoritative annual reconciliation point for insider + blockholder coverage. Use cases:
- Cross-check Form 4 cumulative running total — flag drift > 5%.
- Backfill historical insider holdings before Form 4 coverage starts.
- Catch insiders who hold but never trade (no Form 4 events).
- Validate 13D/G blockholder ingest (#766 — just shipped) — Item 12 lists 5%+ holders independently of the holders' own filings.

## Test plan

- [x] ``uv run ruff check / format / pyright`` — clean
- [x] ``uv run pytest tests/smoke/test_app_boots.py tests/test_sec_def14a_parser.py`` — 22 pass
- [x] Codex pre-push review — clean after 2 follow-up rounds (6 findings fixed)

## Codex pre-push findings (all addressed)

1. **High** — section locator picked first heading match (TOC trap on real proxies that list sections in a TOC). Multi-pass: last-match → first-match → whole-doc.
2. **High** — Sole/Shared/Total layout: shares column resolver picked Sole instead of Total. Tiered preference: ``Total`` > ``Amount and Nature`` > ``shares beneficially`` > ``number``/``amount``.
3. **Medium** — alphabetic footnote markers ``[a]`` / ``[b]`` not stripped despite docstring claim. Regex extended to match ``[a-zA-Z]`` / ``(a-z)``.
4. **Medium** — unique index keyed on heuristic ``holder_role`` would re-insert duplicates when role inference improved on re-parse. Dropped from key; identity is ``(accession_number, holder_name)``.
5. **High** (follow-up) — multi-pass last-match-first triggered in-cell false positive when a table row's text reads ``"5% Holders"`` (mid-table subheading). ``_is_inside_table`` filter counts ``<table>`` / ``</table>`` tags before each match.
6. **High** (follow-up) — two-row header tables lost parent-row keywords when sub-row was promoted to canonical headers. ``_RawTable`` split into ``score_headers`` (parent + sub union) and ``column_headers`` (sub alone).

## Variance tolerance

DEF 14A tables vary wildly across filers. The parser:
- Tolerates section heading variants ("Security Ownership", "Beneficial Ownership", "Principal Stockholders", "5% Holders").
- Detects two-row header layouts (``Amount and Nature`` merged top + ``Sole | Shared | Total`` sub-row).
- Strips footnote markers (``(1)``, ``[a]``, ``*``, ``(*)``).
- Maps ``*`` in percent column to ``Decimal('0.5')`` per industry less-than-1% convention.
- Falls back gracefully: empty-rows result + best diagnostic score → ingester (PR 2) tombstones the accession.

🤖 Generated with [Claude Code](https://claude.com/claude-code)