### PR TITLE
feat(#769): DEF 14A vs Form 4 drift detector (PR 3/N)

### DIFF
--- a/app/services/def14a_drift.py
+++ b/app/services/def14a_drift.py
@@ -1,0 +1,514 @@
+"""DEF 14A vs Form 4 cumulative drift detector (#769 PR 3 of N).
+
+Compares each named insider's DEF 14A snapshot (the latest
+``def14a_beneficial_holdings`` row per (instrument, holder)) against
+the equivalent Form 4 cumulative running total + Form 3 baseline.
+Emits ``def14a_drift_alerts`` rows when the absolute drift exceeds
+the warning threshold so the ops monitor (#13) can render a
+per-issuer reconciliation health indicator.
+
+Three drift outcomes:
+
+  * ``info`` — DEF 14A names a holder that has NO matching Form 4
+    filer. Most common reasons: officer never traded post-baseline
+    (and Form 3 isn't on file either), DEF 14A holder name is a
+    name variant the matcher didn't catch (per #769 the holder→CIK
+    auto-resolution is out of scope for v1; a curated mapping seed
+    table is a follow-up). Either way the operator should see the
+    gap.
+  * ``warning`` — drift >= 5%. Likely a missed Form 4 transaction or
+    a baseline mis-classification.
+  * ``critical`` — drift >= 25%. Strong signal of a systematic
+    coverage gap; flagged loudly so the operator triages first.
+
+Holder-name match is exact case-insensitive equality after
+normalising both sides via :func:`_normalise_name` — strips
+trailing role suffixes (``", CEO"`` / ``" - Director"`` /
+``" — Director"`` / ``" – Director"``). The detector deliberately
+does NOT do fuzzy substring matching: ``"Ann"`` would silently
+match ``"Joanne Smith"`` and ``"John Doe"`` would silently match
+``"John Doe Jr"``. Variants that genuinely refer to the same
+person (mid-life name changes, suffix differences) fall through
+to the info-severity coverage gap, which the v2 curated holder→
+filer mapping seed table will resolve.
+
+For each matched filer we take:
+
+  1. Form 4 latest ``post_transaction_shares`` for the same
+     ``(instrument_id, filer)`` — the most recent cumulative
+     position post-transaction.
+  2. Falling back to Form 3 baseline ``shares`` when no Form 4 row
+     matches (officer who was granted shares on appointment and
+     never traded).
+
+Match accepts ``filer_cik IS NULL`` rows: legacy / backfilled
+Form 4 rows can have NULL CIK and a zero-drift reconciliation on
+such a row is still a real reconciliation, not a coverage gap.
+
+Idempotent + self-clearing: re-running the detector on the same
+accession promotes existing alert rows in place via UPSERT, AND
+clears stale alerts when the underlying drift has since been
+resolved (the detector deletes any row whose new severity is
+``None``). An operator who wants to suppress an alert temporarily
+should mark the source row instead of deleting from
+``def14a_drift_alerts``, since the next detector run would
+re-emit it.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DriftAlert:
+    """One drift finding. Mirrors the table column set 1:1 so the
+    detector can build the row dict directly from the dataclass."""
+
+    instrument_id: int
+    holder_name: str
+    matched_filer_cik: str | None
+    def14a_shares: Decimal | None
+    form4_cumulative: Decimal | None
+    drift_pct: Decimal | None
+    severity: str  # 'info' | 'warning' | 'critical'
+    accession_number: str
+    as_of_date: date | None
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """Per-run rollup. Drives the ops monitor's coverage chip and
+    the run-status logging. ``alerts`` is the full set the detector
+    persisted (or refreshed) on this pass."""
+
+    holders_evaluated: int
+    alerts_emitted: int
+    alerts_by_severity: dict[str, int]
+
+
+# ---------------------------------------------------------------------------
+# Thresholds
+# ---------------------------------------------------------------------------
+
+
+# Drift fraction (not percent) thresholds. Stored on the alert row
+# as a fraction so ``Decimal('0.05')`` = 5%; the ops monitor's UI
+# multiplies by 100 for display. Issue #769's "drift > 5% surfaces
+# on ops monitor" maps to >= ``WARNING_THRESHOLD``.
+WARNING_THRESHOLD: Decimal = Decimal("0.05")
+CRITICAL_THRESHOLD: Decimal = Decimal("0.25")
+
+# Sentinel — DEF 14A holder rows whose ``issuer_cik`` is the
+# placeholder from the ingester (#769 PR 2) for instruments without
+# an ``instrument_sec_profile`` row. Skipped during detection
+# because the issuer-side context is incomplete.
+_CIK_MISSING_SENTINEL = "CIK-MISSING"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _classify_severity(
+    *,
+    matched: bool,
+    drift_pct: Decimal | None,
+) -> str | None:
+    """Map a (matched, drift) tuple to a severity tag, or ``None``
+    when the drift is below the warning threshold AND a Form 4
+    match was found.
+
+    Returning ``None`` lets the caller skip emitting alerts for
+    holders that reconcile cleanly — the alert table is intended as
+    "open issues", not a full audit log of every reconciliation
+    pass."""
+    if not matched:
+        # Holder visible on the proxy but no Form 4 match — coverage
+        # gap, surfaces as info-severity.
+        return "info"
+    if drift_pct is None:
+        return None
+    if drift_pct >= CRITICAL_THRESHOLD:
+        return "critical"
+    if drift_pct >= WARNING_THRESHOLD:
+        return "warning"
+    return None
+
+
+def _compute_drift_pct(
+    *,
+    def14a_shares: Decimal | None,
+    form4_cumulative: Decimal | None,
+) -> Decimal | None:
+    """Compute |def14a - form4| / def14a as a Decimal fraction.
+
+    Returns ``None`` when:
+      * Either side is NULL (cannot compute).
+      * ``def14a_shares == 0`` AND ``form4_cumulative == 0`` (both
+        zero is a clean reconciliation, not a divide-by-zero
+        failure).
+      * ``def14a_shares == 0`` while ``form4_cumulative != 0`` —
+        infinite drift; the detector treats this as a critical
+        finding via a pinned ``Decimal('999')`` so the severity
+        classifier still fires loudly. Codex pre-push review of
+        the parser caught the equivalent issue with bare ``*``
+        percentages — same pattern here.
+    """
+    if def14a_shares is None or form4_cumulative is None:
+        return None
+    if def14a_shares == 0:
+        if form4_cumulative == 0:
+            return None
+        return Decimal("999")
+    diff = abs(def14a_shares - form4_cumulative)
+    return diff / def14a_shares
+
+
+def _normalise_name(holder_name: str) -> str:
+    """Normalise a holder / filer name for exact case-insensitive
+    match.
+
+    Strips:
+      * Leading / trailing whitespace
+      * Trailing role suffixes (``", CEO"`` / ``" - Director"``)
+
+    Returns the lowercase residual. Used on both sides of the
+    DEF 14A holder ↔ Form 4 filer match — the proxy name is
+    normalised once when building the SQL parameter, the Form 4
+    filer name is normalised in SQL via ``LOWER(...)``.
+
+    Codex pre-push review caught the prior ILIKE-substring approach
+    matching false positives (``"Ann"`` -> ``"Joanne Smith"``;
+    ``"John Doe"`` -> ``"John Doe Jr"``). Exact match after
+    role-suffix strip is conservative — name variants fall through
+    to the info-severity coverage gap, which v2's curated holder→
+    filer mapping seed table will resolve.
+    """
+    base = holder_name.strip()
+    for sep in (",", " - ", " — ", " – "):
+        if sep in base:
+            base = base.split(sep, 1)[0].strip()
+            break
+    return base.lower()
+
+
+def _resolve_holder_match(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    holder_name: str,
+) -> tuple[bool, str | None, Decimal | None]:
+    """Resolve a DEF 14A holder against Form 4 + Form 3 baseline.
+
+    Returns ``(matched, matched_filer_cik, form4_cumulative_shares)``:
+
+      * ``matched`` is ``True`` when a Form 4 or Form 3 row was
+        found whose normalised filer name equals the normalised
+        holder name. Distinct from ``matched_filer_cik`` because
+        legacy Form 4 rows can have NULL ``filer_cik`` — a zero
+        drift on a NULL-CIK row is still a real reconciliation,
+        not a coverage gap. Codex pre-push review caught this.
+      * ``matched_filer_cik`` is the resolved CIK (when present)
+        or ``None`` for legacy rows.
+      * ``form4_cumulative_shares`` is the latest
+        ``post_transaction_shares`` for the matched filer, or the
+        Form 3 baseline ``shares`` when no Form 4 row exists.
+
+    Match precedence:
+      1. Latest Form 4 ``post_transaction_shares`` for the same
+         instrument whose ``_normalise_name(filer_name)`` equals
+         the normalised holder name. Tie-broken by ``txn_date DESC,
+         id DESC``.
+      2. Falling back to ``insider_initial_holdings`` (Form 3
+         baseline) when no Form 4 row matches.
+      3. Otherwise ``(False, None, None)`` — coverage gap.
+
+    Implementation note: candidate filers are fetched in bulk per
+    instrument and filtered in Python via ``_normalise_name`` so the
+    full role-suffix strip (``,`` / ` - ` / ` — ` / ` – ``) is the
+    single canonical source. An earlier draft did the strip in SQL
+    via ``SPLIT_PART(..., ',', 1)``, which only matched the comma
+    case and silently failed for the dash variants. Codex pre-push
+    review caught the SQL-vs-Python normalisation drift.
+    """
+    normalised = _normalise_name(holder_name)
+    if not normalised:
+        return (False, None, None)
+
+    # Try Form 4 first — the cumulative running total. Per-instrument
+    # candidate count is small (typical issuer has <50 distinct
+    # insiders across history), so an in-Python filter with the
+    # canonical name normaliser is cheaper and safer than SQL gymnastics.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT filer_cik, filer_name, post_transaction_shares
+            FROM insider_transactions
+            WHERE instrument_id = %(iid)s
+              AND post_transaction_shares IS NOT NULL
+            ORDER BY txn_date DESC NULLS LAST, id DESC
+            """,
+            {"iid": instrument_id},
+        )
+        for row in cur.fetchall():
+            if _normalise_name(str(row["filer_name"])) == normalised:
+                return (
+                    True,
+                    str(row["filer_cik"]) if row["filer_cik"] is not None else None,
+                    row["post_transaction_shares"],
+                )
+
+    # Fall back to Form 3 baseline.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT filer_cik, filer_name, shares
+            FROM insider_initial_holdings
+            WHERE instrument_id = %(iid)s
+              AND shares IS NOT NULL
+              AND is_derivative = FALSE
+            ORDER BY as_of_date DESC NULLS LAST
+            """,
+            {"iid": instrument_id},
+        )
+        for row in cur.fetchall():
+            if _normalise_name(str(row["filer_name"])) == normalised:
+                return (
+                    True,
+                    str(row["filer_cik"]) if row["filer_cik"] is not None else None,
+                    row["shares"],
+                )
+
+    return (False, None, None)
+
+
+def _delete_alert(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    holder_name: str,
+    accession_number: str,
+) -> None:
+    """Clear any stale alert row for a (instrument, holder,
+    accession) tuple that has since reconciled cleanly. Idempotent:
+    no-op when the row never existed.
+    """
+    conn.execute(
+        """
+        DELETE FROM def14a_drift_alerts
+        WHERE instrument_id = %(iid)s
+          AND holder_name = %(name)s
+          AND accession_number = %(accession)s
+        """,
+        {"iid": instrument_id, "name": holder_name, "accession": accession_number},
+    )
+
+
+def _upsert_alert(conn: psycopg.Connection[tuple], alert: DriftAlert) -> None:
+    """Idempotent INSERT — refreshes ``detected_at`` on conflict."""
+    conn.execute(
+        """
+        INSERT INTO def14a_drift_alerts (
+            instrument_id, holder_name, matched_filer_cik,
+            def14a_shares, form4_cumulative, drift_pct,
+            severity, accession_number, as_of_date
+        ) VALUES (
+            %(iid)s, %(name)s, %(cik)s,
+            %(def14a)s, %(form4)s, %(drift)s,
+            %(severity)s, %(accession)s, %(as_of)s
+        )
+        ON CONFLICT (instrument_id, holder_name, accession_number) DO UPDATE SET
+            matched_filer_cik = EXCLUDED.matched_filer_cik,
+            def14a_shares = EXCLUDED.def14a_shares,
+            form4_cumulative = EXCLUDED.form4_cumulative,
+            drift_pct = EXCLUDED.drift_pct,
+            severity = EXCLUDED.severity,
+            as_of_date = EXCLUDED.as_of_date,
+            detected_at = NOW()
+        """,
+        {
+            "iid": alert.instrument_id,
+            "name": alert.holder_name,
+            "cik": alert.matched_filer_cik,
+            "def14a": alert.def14a_shares,
+            "form4": alert.form4_cumulative,
+            "drift": alert.drift_pct,
+            "severity": alert.severity,
+            "accession": alert.accession_number,
+            "as_of": alert.as_of_date,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detector entry points
+# ---------------------------------------------------------------------------
+
+
+def _select_latest_def14a_holders(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return the latest DEF 14A holder rows per (instrument,
+    holder), excluding rows with the CIK-MISSING sentinel.
+
+    DISTINCT ON (instrument_id, holder_name) keyed on
+    ``as_of_date DESC`` so re-filings or amendments use the most
+    recent snapshot. Rows without numeric shares (defer-to-prior-
+    cover-page entries) are skipped — there's nothing to drift-
+    check.
+
+    The optional ``instrument_id`` filter uses an
+    ``%(iid)s IS NULL`` short-circuit so the SQL is a fixed literal
+    string (pyright's LiteralString contract) regardless of whether
+    the caller passes a scoping value.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT ON (instrument_id, holder_name)
+                instrument_id, holder_name, holder_role,
+                shares, accession_number, as_of_date
+            FROM def14a_beneficial_holdings
+            WHERE issuer_cik <> %(sentinel)s
+              AND instrument_id IS NOT NULL
+              AND shares IS NOT NULL
+              AND (%(iid)s::BIGINT IS NULL OR instrument_id = %(iid)s::BIGINT)
+            ORDER BY instrument_id, holder_name, as_of_date DESC NULLS LAST,
+                     accession_number DESC
+            """,
+            {"sentinel": _CIK_MISSING_SENTINEL, "iid": instrument_id},
+        )
+        return list(cur.fetchall())
+
+
+def detect_drift(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int | None = None,
+) -> DriftReport:
+    """Run the drift detector across DEF 14A holders.
+
+    ``instrument_id=None`` evaluates every holder in the system;
+    otherwise scopes to a single issuer (used by ad-hoc re-runs and
+    PR 4's per-instrument reconciliation view).
+
+    Caller is responsible for committing — this function writes
+    via ``_upsert_alert`` but does NOT commit, so a batch
+    invocation can wrap multiple runs in one transaction. Tests
+    explicitly commit after each call.
+    """
+    holders = _select_latest_def14a_holders(conn, instrument_id=instrument_id)
+
+    holders_evaluated = 0
+    alerts_emitted = 0
+    by_severity: dict[str, int] = {"info": 0, "warning": 0, "critical": 0}
+
+    for row in holders:
+        holders_evaluated += 1
+        iid = int(row["instrument_id"])
+        holder_name = str(row["holder_name"])
+        def14a_shares: Decimal | None = row["shares"]
+        accession = str(row["accession_number"])
+        as_of: date | None = row["as_of_date"]
+
+        matched, matched_cik, form4_cumulative = _resolve_holder_match(conn, instrument_id=iid, holder_name=holder_name)
+
+        drift_pct = _compute_drift_pct(def14a_shares=def14a_shares, form4_cumulative=form4_cumulative)
+        severity = _classify_severity(matched=matched, drift_pct=drift_pct)
+        if severity is None:
+            # Reconciliation is now clean — clear any stale alert
+            # row for this (instrument, holder, accession) so a
+            # since-resolved finding doesn't sit in the table
+            # forever. Codex pre-push review caught the prior code
+            # that silently left stale rows after the underlying
+            # drift was fixed.
+            _delete_alert(
+                conn,
+                instrument_id=iid,
+                holder_name=holder_name,
+                accession_number=accession,
+            )
+            continue
+
+        _upsert_alert(
+            conn,
+            DriftAlert(
+                instrument_id=iid,
+                holder_name=holder_name,
+                matched_filer_cik=matched_cik,
+                def14a_shares=def14a_shares,
+                form4_cumulative=form4_cumulative,
+                drift_pct=drift_pct,
+                severity=severity,
+                accession_number=accession,
+                as_of_date=as_of,
+            ),
+        )
+        alerts_emitted += 1
+        by_severity[severity] += 1
+
+    return DriftReport(
+        holders_evaluated=holders_evaluated,
+        alerts_emitted=alerts_emitted,
+        alerts_by_severity=by_severity,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reader (exposed for the ops monitor view + ad-hoc admin queries)
+# ---------------------------------------------------------------------------
+
+
+def iter_alerts(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int | None = None,
+    severity: str | None = None,
+    limit: int = 100,
+) -> Iterator[dict[str, Any]]:
+    """Yield drift alert rows in detected_at-DESC order.
+
+    ``severity`` filter accepts ``'info'`` / ``'warning'`` /
+    ``'critical'`` or ``None`` for all. ``instrument_id`` scopes
+    to a single issuer.
+    """
+    # Always pass NULL params for unspecified filters and rely on
+    # ``%(param)s IS NULL`` short-circuits in the WHERE clause —
+    # avoids dynamic SQL composition (which trips pyright's
+    # LiteralString check) while keeping the filter logic
+    # parameter-driven and SQL-injection-safe.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT alert_id, instrument_id, holder_name, matched_filer_cik,
+                   def14a_shares, form4_cumulative, drift_pct, severity,
+                   accession_number, as_of_date, detected_at
+            FROM def14a_drift_alerts
+            WHERE (%(iid)s::BIGINT IS NULL OR instrument_id = %(iid)s::BIGINT)
+              AND (%(severity)s::TEXT IS NULL OR severity = %(severity)s::TEXT)
+            ORDER BY detected_at DESC, alert_id DESC
+            LIMIT %(limit)s
+            """,
+            {"iid": instrument_id, "severity": severity, "limit": limit},
+        )
+        for row in cur.fetchall():
+            yield dict(row)

--- a/app/services/def14a_drift.py
+++ b/app/services/def14a_drift.py
@@ -252,18 +252,24 @@ def _resolve_holder_match(
     if not normalised:
         return (False, None, None)
 
-    # Try Form 4 first — the cumulative running total. Per-instrument
-    # candidate count is small (typical issuer has <50 distinct
-    # insiders across history), so an in-Python filter with the
-    # canonical name normaliser is cheaper and safer than SQL gymnastics.
+    # Try Form 4 first — the cumulative running total. The
+    # ``DISTINCT ON (filer_cik, filer_name)`` cap pre-collapses
+    # multi-transaction filer histories to one row each (the
+    # latest), so the Python filter sees one row per filer
+    # regardless of an issuer's transaction volume. A
+    # COALESCE-keyed ``filer_cik`` keeps NULL-CIK rows
+    # individually addressable rather than collapsed to a single
+    # NULL bucket. Bot review caught the prior unbounded fetch.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT filer_cik, filer_name, post_transaction_shares
+            SELECT DISTINCT ON (COALESCE(filer_cik, ''), filer_name)
+                filer_cik, filer_name, post_transaction_shares
             FROM insider_transactions
             WHERE instrument_id = %(iid)s
               AND post_transaction_shares IS NOT NULL
-            ORDER BY txn_date DESC NULLS LAST, id DESC
+            ORDER BY COALESCE(filer_cik, ''), filer_name,
+                     txn_date DESC NULLS LAST, id DESC
             """,
             {"iid": instrument_id},
         )
@@ -275,16 +281,19 @@ def _resolve_holder_match(
                     row["post_transaction_shares"],
                 )
 
-    # Fall back to Form 3 baseline.
+    # Fall back to Form 3 baseline. Same DISTINCT ON cap so the
+    # Python filter never sees more than one row per filer.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT filer_cik, filer_name, shares
+            SELECT DISTINCT ON (COALESCE(filer_cik, ''), filer_name)
+                filer_cik, filer_name, shares
             FROM insider_initial_holdings
             WHERE instrument_id = %(iid)s
               AND shares IS NOT NULL
               AND is_derivative = FALSE
-            ORDER BY as_of_date DESC NULLS LAST
+            ORDER BY COALESCE(filer_cik, ''), filer_name,
+                     as_of_date DESC NULLS LAST
             """,
             {"iid": instrument_id},
         )

--- a/sql/098_def14a_drift_alerts.sql
+++ b/sql/098_def14a_drift_alerts.sql
@@ -1,0 +1,85 @@
+-- 098_def14a_drift_alerts.sql
+--
+-- Issue #769 PR 3 of N — schema for DEF 14A vs Form 4 drift
+-- alerts. The drift detector compares each named insider's DEF 14A
+-- snapshot (most-recent-per-holder beneficial-ownership row) against
+-- the equivalent Form 4 cumulative running total + Form 3 baseline
+-- (#768 PR 4) and writes a row here when the absolute drift exceeds
+-- the warning threshold.
+--
+-- Why this matters operationally:
+--
+--   * DEF 14A is the SEC-authoritative annual reconciliation point.
+--     If our Form 4 + Form 3 cumulative for a named officer disagrees
+--     with the proxy by >5%, either we missed a Form 4 transaction,
+--     mis-classified a baseline row, or the insider has off-platform
+--     activity (gifts, family-trust transfers) that's invisible to
+--     Form 4. All three deserve operator attention.
+--   * 13D/G blockholders (#766) are validated the same way — Item 12
+--     lists 5%+ holders independently of the holders' own filings,
+--     so a blockholder visible on the proxy but missing from
+--     ``blockholder_filings`` is a coverage gap.
+--   * The ops monitor (#13) reads this table to render a per-issuer
+--     "reconciliation health" indicator.
+--
+-- Schema decisions:
+--
+--   * ``severity`` is a constrained text enum, mirroring the pattern
+--     used by ``ingest_log`` rows elsewhere in the codebase. Values:
+--       - ``info``     — no Form 4 filer matched (coverage gap).
+--       - ``warning``  — drift >= 5% (the issue's flag threshold).
+--       - ``critical`` — drift >= 25% (likely missed transaction or
+--         systematic mis-mapping).
+--   * ``matched_filer_cik`` is nullable: when the DEF 14A holder
+--     name cannot be matched to any Form 4 filer, the alert is
+--     still emitted (severity=info) so the operator sees the gap.
+--     Per #769 the holder→CIK auto-resolution is explicitly out of
+--     scope for v1; a curated mapping seed table is a follow-up.
+--   * ``def14a_shares`` and ``form4_cumulative`` are both
+--     NUMERIC(24, 4) to match the source columns
+--     (``def14a_beneficial_holdings.shares`` and
+--     ``insider_transactions.shares``) so cross-source diffs stay
+--     arithmetic-clean.
+--   * ``drift_pct`` is NUMERIC(10, 4) to fit a four-decimal
+--     percentage (e.g. ``0.0537`` for 5.37% drift, or ``5.37`` —
+--     the detector stores the percent-of-DEF14A as a fraction so
+--     ``0.05`` = 5%; the operator UI multiplies by 100 for display).
+--   * Identity / dedupe = ``(instrument_id, holder_name,
+--     accession_number)`` — re-running the detector on the same
+--     accession should UPSERT the alert row in place rather than
+--     stack duplicates. UPDATE refreshes ``detected_at`` so the
+--     ops monitor sees the latest evaluation timestamp.
+--
+-- _PLANNER_TABLES in tests/fixtures/ebull_test_db.py is updated in
+-- the same PR per the prevention-log entry.
+
+CREATE TABLE IF NOT EXISTS def14a_drift_alerts (
+    alert_id            BIGSERIAL PRIMARY KEY,
+    instrument_id       BIGINT NOT NULL REFERENCES instruments(instrument_id),
+    holder_name         TEXT NOT NULL,
+    matched_filer_cik   TEXT,
+    def14a_shares       NUMERIC(24, 4),
+    form4_cumulative    NUMERIC(24, 4),
+    drift_pct           NUMERIC(10, 4),
+    severity            TEXT NOT NULL
+        CHECK (severity IN ('info', 'warning', 'critical')),
+    accession_number    TEXT NOT NULL,
+    as_of_date          DATE,
+    detected_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Idempotent re-detection: re-running the detector on the same
+-- accession promotes the existing alert row in place rather than
+-- stacking duplicates each time.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_def14a_drift_alerts_holder_accession
+    ON def14a_drift_alerts (instrument_id, holder_name, accession_number);
+
+-- Hot path: per-instrument alert reader for the ops monitor view —
+-- "which issuers have open drift alerts, ordered most recent first".
+CREATE INDEX IF NOT EXISTS idx_def14a_drift_alerts_instrument_detected
+    ON def14a_drift_alerts (instrument_id, detected_at DESC);
+
+-- Hot path: per-severity scan for the ops monitor's
+-- "any open critical alerts?" indicator.
+CREATE INDEX IF NOT EXISTS idx_def14a_drift_alerts_severity_detected
+    ON def14a_drift_alerts (severity, detected_at DESC);

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -124,6 +124,7 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # #769 — DEF 14A beneficial ownership cross-check. FK → instruments
     # (nullable). Listing explicitly keeps teardown deterministic when
     # a test populates DEF 14A rows without touching instruments.
+    "def14a_drift_alerts",
     "def14a_ingest_log",
     "def14a_beneficial_holdings",
     "filing_events",

--- a/tests/test_def14a_drift.py
+++ b/tests/test_def14a_drift.py
@@ -1,0 +1,747 @@
+"""Integration tests for the DEF 14A drift detector (#769 PR 3).
+
+Tests run against the real ``ebull_test`` DB so the cross-table
+JOINs (def14a_beneficial_holdings × insider_transactions ×
+insider_initial_holdings) exercise actual SQL semantics including
+DISTINCT ON and the ILIKE name match.
+
+Each scenario seeds the inputs (DEF 14A holders + matching Form 4
+or Form 3 rows) and asserts the alert table contents.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services.def14a_drift import (
+    CRITICAL_THRESHOLD,
+    WARNING_THRESHOLD,
+    detect_drift,
+    iter_alerts,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _seed_def14a_holder(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    accession: str,
+    holder_name: str,
+    shares: str | None,
+    issuer_cik: str = "0000320193",
+    holder_role: str | None = "officer",
+    as_of: date = date(2026, 3, 1),
+    percent: str = "5.5",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO def14a_beneficial_holdings (
+            instrument_id, accession_number, issuer_cik,
+            holder_name, holder_role, shares, percent_of_class, as_of_date
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            instrument_id,
+            accession,
+            issuer_cik,
+            holder_name,
+            holder_role,
+            Decimal(shares) if shares is not None else None,
+            Decimal(percent),
+            as_of,
+        ),
+    )
+
+
+def _seed_insider_filing(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    instrument_id: int,
+    issuer_cik: str = "0000320193",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO insider_filings (accession_number, instrument_id, document_type, issuer_cik)
+        VALUES (%s, %s, '4', %s)
+        ON CONFLICT (accession_number) DO NOTHING
+        """,
+        (accession, instrument_id, issuer_cik),
+    )
+
+
+def _seed_form4_txn(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    instrument_id: int,
+    filer_cik: str,
+    filer_name: str,
+    txn_date: date,
+    post_transaction_shares: str,
+    txn_row_num: int = 1,
+) -> None:
+    """Seed both insider_filings (parent) and insider_transactions
+    (child). Mirrors the schema constraints exactly."""
+    _seed_insider_filing(conn, accession=accession, instrument_id=instrument_id)
+    conn.execute(
+        """
+        INSERT INTO insider_transactions (
+            accession_number, txn_row_num, instrument_id, filer_cik, filer_name,
+            txn_date, txn_code, shares, post_transaction_shares, is_derivative
+        ) VALUES (%s, %s, %s, %s, %s, %s, 'P', 100, %s, FALSE)
+        """,
+        (
+            accession,
+            txn_row_num,
+            instrument_id,
+            filer_cik,
+            filer_name,
+            txn_date,
+            Decimal(post_transaction_shares),
+        ),
+    )
+
+
+def _seed_form3_baseline(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    instrument_id: int,
+    filer_cik: str,
+    filer_name: str,
+    shares: str,
+    as_of_date: date = date(2025, 1, 15),
+    row_num: int = 1,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO insider_initial_holdings (
+            accession_number, row_num, instrument_id, filer_cik, filer_name,
+            security_title, is_derivative, direct_indirect, shares, as_of_date
+        ) VALUES (%s, %s, %s, %s, %s, 'Common Stock', FALSE, 'D', %s, %s)
+        """,
+        (
+            accession,
+            row_num,
+            instrument_id,
+            filer_cik,
+            filer_name,
+            Decimal(shares),
+            as_of_date,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy-path drift outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestDriftOutcomes:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=769_300, symbol="AAPL")
+        conn.commit()
+        return conn
+
+    def test_clean_reconciliation_emits_no_alert(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """DEF 14A holder shares match Form 4 cumulative within 5%
+        — no alert row written."""
+        conn = _setup
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_300,
+            accession="DEF-25-001",
+            holder_name="John Doe",
+            shares="1000000",
+        )
+        _seed_form4_txn(
+            conn,
+            accession="F4-25-001",
+            instrument_id=769_300,
+            filer_cik="0001100001",
+            filer_name="John Doe",
+            txn_date=date(2026, 2, 15),
+            post_transaction_shares="1010000",  # 1% drift, well under WARNING
+        )
+        conn.commit()
+
+        report = detect_drift(conn)
+        conn.commit()
+
+        assert report.holders_evaluated == 1
+        assert report.alerts_emitted == 0
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM def14a_drift_alerts")
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+
+    def test_5pct_drift_emits_warning(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_300,
+            accession="DEF-25-002",
+            holder_name="Jane Smith",
+            shares="1000000",
+        )
+        # 8% drift (>5%, <25%) -> warning.
+        _seed_form4_txn(
+            conn,
+            accession="F4-25-002",
+            instrument_id=769_300,
+            filer_cik="0001100002",
+            filer_name="Jane Smith",
+            txn_date=date(2026, 2, 15),
+            post_transaction_shares="920000",
+        )
+        conn.commit()
+
+        report = detect_drift(conn)
+        conn.commit()
+
+        assert report.alerts_emitted == 1
+        assert report.alerts_by_severity == {"info": 0, "warning": 1, "critical": 0}
+
+        alerts = list(iter_alerts(conn, instrument_id=769_300))
+        assert len(alerts) == 1
+        a = alerts[0]
+        assert a["severity"] == "warning"
+        assert a["matched_filer_cik"] == "0001100002"
+        assert a["def14a_shares"] == Decimal("1000000")
+        assert a["form4_cumulative"] == Decimal("920000")
+        assert a["drift_pct"] is not None
+        # 80,000 / 1,000,000 = 0.08
+        assert a["drift_pct"] >= WARNING_THRESHOLD
+        assert a["drift_pct"] < CRITICAL_THRESHOLD
+
+    def test_30pct_drift_emits_critical(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_300,
+            accession="DEF-25-003",
+            holder_name="Activist Holder",
+            shares="2000000",
+        )
+        # 30% drift -> critical.
+        _seed_form4_txn(
+            conn,
+            accession="F4-25-003",
+            instrument_id=769_300,
+            filer_cik="0001100003",
+            filer_name="Activist Holder",
+            txn_date=date(2026, 2, 15),
+            post_transaction_shares="1400000",
+        )
+        conn.commit()
+
+        report = detect_drift(conn)
+        conn.commit()
+
+        assert report.alerts_by_severity["critical"] == 1
+        alerts = list(iter_alerts(conn, severity="critical"))
+        assert alerts[0]["drift_pct"] >= CRITICAL_THRESHOLD
+
+    def test_no_form4_match_emits_info_severity(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """A DEF 14A holder with no matching Form 4 / Form 3 row
+        emits an info-severity alert so the operator sees the
+        coverage gap."""
+        conn = _setup
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_300,
+            accession="DEF-25-004",
+            holder_name="Phantom Officer",
+            shares="500000",
+        )
+        # No Form 4 or Form 3 row for "Phantom Officer".
+        conn.commit()
+
+        report = detect_drift(conn)
+        conn.commit()
+
+        assert report.alerts_emitted == 1
+        assert report.alerts_by_severity == {"info": 1, "warning": 0, "critical": 0}
+        alerts = list(iter_alerts(conn, instrument_id=769_300))
+        assert alerts[0]["severity"] == "info"
+        assert alerts[0]["matched_filer_cik"] is None
+        assert alerts[0]["form4_cumulative"] is None
+
+    def test_form3_baseline_used_when_no_form4_exists(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Officer with only a Form 3 baseline (never traded) — the
+        detector falls back to insider_initial_holdings.shares."""
+        conn = _setup
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_300,
+            accession="DEF-25-005",
+            holder_name="Quiet Officer",
+            shares="100000",
+        )
+        _seed_form3_baseline(
+            conn,
+            accession="F3-25-005",
+            instrument_id=769_300,
+            filer_cik="0001100005",
+            filer_name="Quiet Officer",
+            shares="100000",  # exact match
+        )
+        conn.commit()
+
+        report = detect_drift(conn)
+        conn.commit()
+
+        # Exact match — no drift, no alert.
+        assert report.alerts_emitted == 0
+
+    def test_form3_baseline_drift_emits_warning(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_300,
+            accession="DEF-25-006",
+            holder_name="Drifty Officer",
+            shares="100000",
+        )
+        _seed_form3_baseline(
+            conn,
+            accession="F3-25-006",
+            instrument_id=769_300,
+            filer_cik="0001100006",
+            filer_name="Drifty Officer",
+            shares="80000",  # 20% drift
+        )
+        conn.commit()
+
+        detect_drift(conn)
+        conn.commit()
+
+        alerts = list(iter_alerts(conn, instrument_id=769_300))
+        assert len(alerts) == 1
+        assert alerts[0]["severity"] == "warning"
+        assert alerts[0]["form4_cumulative"] == Decimal("80000")
+
+
+# ---------------------------------------------------------------------------
+# Match heuristics + idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestMatchHeuristics:
+    def test_role_suffix_in_def14a_name_still_matches_form4(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """``"John Doe, CEO"`` in DEF 14A matches a Form 4 filer
+        named ``"John Doe"`` — the matcher strips role suffixes."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=769_310, symbol="A")
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_310,
+            accession="DEF-25-010",
+            holder_name="John Doe, CEO",
+            shares="500000",
+        )
+        _seed_form4_txn(
+            conn,
+            accession="F4-25-010",
+            instrument_id=769_310,
+            filer_cik="0001100010",
+            filer_name="John Doe",
+            txn_date=date(2026, 2, 15),
+            post_transaction_shares="500000",
+        )
+        conn.commit()
+
+        report = detect_drift(conn)
+        conn.commit()
+
+        # Exact match — no alert.
+        assert report.alerts_emitted == 0
+        assert report.holders_evaluated == 1
+
+    def test_distinct_on_picks_latest_def14a_per_holder(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Two DEF 14A snapshots for the same holder — the detector
+        evaluates only the latest by as_of_date."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=769_320, symbol="A")
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_320,
+            accession="DEF-25-020",
+            holder_name="John Doe",
+            shares="800000",
+            as_of=date(2024, 3, 1),  # older
+        )
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_320,
+            accession="DEF-25-021",
+            holder_name="John Doe",
+            shares="1000000",
+            as_of=date(2026, 3, 1),  # latest — picked
+        )
+        _seed_form4_txn(
+            conn,
+            accession="F4-25-020",
+            instrument_id=769_320,
+            filer_cik="0001100020",
+            filer_name="John Doe",
+            txn_date=date(2026, 2, 15),
+            post_transaction_shares="1000000",
+        )
+        conn.commit()
+
+        report = detect_drift(conn)
+        conn.commit()
+
+        # Latest DEF 14A reconciles cleanly — no alert. If older
+        # snapshot were used, drift would have flagged warning.
+        assert report.holders_evaluated == 1
+        assert report.alerts_emitted == 0
+
+    def test_skips_cik_missing_sentinel_rows(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """DEF 14A rows with the CIK-MISSING sentinel are excluded
+        from drift evaluation per the design contract — the issuer
+        side is incomplete."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=769_330, symbol="A")
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_330,
+            accession="DEF-25-030",
+            holder_name="Sentinel Holder",
+            shares="500000",
+            issuer_cik="CIK-MISSING",
+        )
+        conn.commit()
+
+        report = detect_drift(conn)
+        conn.commit()
+
+        assert report.holders_evaluated == 0
+        assert report.alerts_emitted == 0
+
+
+class TestExactNameMatch:
+    """Codex pre-push review caught false positives in the prior
+    ILIKE-substring matcher. These tests pin the stricter
+    case-insensitive equality (after role-suffix strip)."""
+
+    def test_substring_does_not_falsely_match_longer_name(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """``"Ann"`` (DEF 14A) must NOT match ``"Joanne Smith"``
+        (Form 4) — the prior ILIKE pattern matched any substring."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=769_400, symbol="A")
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_400,
+            accession="DEF-25-100",
+            holder_name="Ann",
+            shares="100000",
+        )
+        _seed_form4_txn(
+            conn,
+            accession="F4-25-100",
+            instrument_id=769_400,
+            filer_cik="0001100100",
+            filer_name="Joanne Smith",
+            txn_date=date(2026, 2, 15),
+            post_transaction_shares="500000",
+        )
+        conn.commit()
+
+        detect_drift(conn)
+        conn.commit()
+
+        # Ann does NOT match Joanne — no Form 4 hit, info severity.
+        alerts = list(iter_alerts(conn, instrument_id=769_400))
+        assert len(alerts) == 1
+        assert alerts[0]["severity"] == "info"
+        assert alerts[0]["matched_filer_cik"] is None
+
+    def test_prefix_does_not_falsely_match_jr_suffix(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """``"John Doe"`` (DEF 14A) must NOT match ``"John Doe Jr"``
+        (Form 4) — different individuals."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=769_410, symbol="A")
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_410,
+            accession="DEF-25-110",
+            holder_name="John Doe",
+            shares="500000",
+        )
+        _seed_form4_txn(
+            conn,
+            accession="F4-25-110",
+            instrument_id=769_410,
+            filer_cik="0001100110",
+            filer_name="John Doe Jr",
+            txn_date=date(2026, 2, 15),
+            post_transaction_shares="100000",
+        )
+        conn.commit()
+
+        detect_drift(conn)
+        conn.commit()
+
+        alerts = list(iter_alerts(conn, instrument_id=769_410))
+        assert len(alerts) == 1
+        assert alerts[0]["severity"] == "info"
+        assert alerts[0]["matched_filer_cik"] is None
+
+    def test_dash_suffix_in_form4_filer_name_still_reconciles(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """``"John Doe"`` (DEF 14A, no role suffix) must reconcile
+        with ``"John Doe - Director"`` (Form 4). Both sides must
+        normalise via the same separator set — Codex pre-push
+        review caught the SQL-only-comma normaliser missing the
+        dash variants."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=769_415, symbol="A")
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_415,
+            accession="DEF-25-115",
+            holder_name="John Doe",
+            shares="200000",
+        )
+        _seed_form4_txn(
+            conn,
+            accession="F4-25-115",
+            instrument_id=769_415,
+            filer_cik="0001100115",
+            filer_name="John Doe - Director",
+            txn_date=date(2026, 2, 15),
+            post_transaction_shares="200000",  # exact share match
+        )
+        conn.commit()
+
+        detect_drift(conn)
+        conn.commit()
+
+        # Exact match after dash-suffix strip; no alert.
+        alerts = list(iter_alerts(conn, instrument_id=769_415))
+        assert alerts == []
+
+    def test_form4_with_null_filer_cik_still_matches_on_name(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Legacy Form 4 rows can have NULL filer_cik (the column is
+        nullable per migration 057's ADD COLUMN ... TEXT). An exact
+        name match with NULL CIK is still a real reconciliation —
+        not a coverage gap. Codex pre-push review caught the prior
+        code treating ``cik is None`` as ``unmatched``."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=769_420, symbol="A")
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_420,
+            accession="DEF-25-120",
+            holder_name="Legacy Holder",
+            shares="100000",
+        )
+        # Seed an insider_filing parent row first (FK target).
+        _seed_insider_filing(conn, accession="F4-25-120", instrument_id=769_420)
+        # Insert directly so we can null filer_cik (the test seed
+        # helper only takes a string).
+        conn.execute(
+            """
+            INSERT INTO insider_transactions (
+                accession_number, txn_row_num, instrument_id,
+                filer_cik, filer_name, txn_date, txn_code,
+                shares, post_transaction_shares, is_derivative
+            ) VALUES (%s, 1, %s, NULL, %s, %s, 'P', 100, %s, FALSE)
+            """,
+            (
+                "F4-25-120",
+                769_420,
+                "Legacy Holder",
+                date(2026, 2, 15),
+                Decimal("100000"),
+            ),
+        )
+        conn.commit()
+
+        report = detect_drift(conn)
+        conn.commit()
+
+        # Exact match on name, zero drift — no alert. The detector
+        # treats the row as matched even though filer_cik is NULL;
+        # the prior code emitted a false ``info`` coverage gap.
+        assert report.alerts_emitted == 0
+
+
+class TestStaleAlertCleanup:
+    """Codex pre-push review caught alerts staying in the table
+    after the underlying drift had reconciled. These tests pin
+    the auto-clear behaviour."""
+
+    def test_resolved_drift_removes_existing_alert(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=769_500, symbol="A")
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_500,
+            accession="DEF-25-200",
+            holder_name="Resolving Holder",
+            shares="1000000",
+        )
+        # First pass: no Form 4 row -> info-severity alert.
+        conn.commit()
+
+        first = detect_drift(conn)
+        conn.commit()
+        assert first.alerts_emitted == 1
+        assert first.alerts_by_severity["info"] == 1
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM def14a_drift_alerts WHERE instrument_id = %s", (769_500,))
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 1
+
+        # Now seed an exact-matching Form 4 row.
+        _seed_form4_txn(
+            conn,
+            accession="F4-25-200",
+            instrument_id=769_500,
+            filer_cik="0001100200",
+            filer_name="Resolving Holder",
+            txn_date=date(2026, 2, 15),
+            post_transaction_shares="1000000",
+        )
+        conn.commit()
+
+        # Second pass: reconciliation is now clean — alert cleared.
+        second = detect_drift(conn)
+        conn.commit()
+        assert second.alerts_emitted == 0
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM def14a_drift_alerts WHERE instrument_id = %s", (769_500,))
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+
+
+class TestIdempotency:
+    def test_re_running_detector_upserts_in_place(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Running the detector twice on the same data does not
+        duplicate alert rows; the existing row's detected_at is
+        refreshed."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=769_340, symbol="A")
+        _seed_def14a_holder(
+            conn,
+            instrument_id=769_340,
+            accession="DEF-25-040",
+            holder_name="Phantom",
+            shares="500000",
+        )
+        conn.commit()
+
+        first = detect_drift(conn)
+        conn.commit()
+        assert first.alerts_emitted == 1
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT alert_id, detected_at FROM def14a_drift_alerts WHERE instrument_id = %s",
+                (769_340,),
+            )
+            first_row = cur.fetchone()
+        assert first_row is not None
+        first_id = first_row["alert_id"]
+        first_detected = first_row["detected_at"]
+
+        # Re-run.
+        second = detect_drift(conn)
+        conn.commit()
+        assert second.alerts_emitted == 1
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT COUNT(*), MIN(alert_id), MAX(detected_at) FROM def14a_drift_alerts WHERE instrument_id = %s",
+                (769_340,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        # One row total — UPSERT, not INSERT.
+        assert row["count"] == 1
+        assert row["min"] == first_id
+        # detected_at was refreshed.
+        assert row["max"] >= first_detected


### PR DESCRIPTION
## What

DEF 14A vs Form 4 / Form 3 cumulative drift detector. Final PR 3 of N for #769 (PR 1: #778, PR 2: #779).

- ``sql/098_def14a_drift_alerts.sql`` — alerts table + indexes
- ``app/services/def14a_drift.py`` — detector + reader
- ``tests/test_def14a_drift.py`` — 15 integration tests

## Why

DEF 14A's Item 12 is the SEC-authoritative annual reconciliation point. The detector compares each named officer / 5%-holder's DEF 14A snapshot against our Form 4 cumulative running total + Form 3 baseline and surfaces drift on the ops monitor:

- ``info`` — DEF 14A names a holder with no matching Form 4 / Form 3 row (coverage gap)
- ``warning`` — drift >= 5% (likely missed Form 4 transaction or baseline mis-classification)
- ``critical`` — drift >= 25% (systematic coverage gap; triage first)

## Test plan

- [x] ``uv run ruff check / format / pyright`` — clean
- [x] ``uv run pytest tests/smoke + tests/test_def14a_drift.py + tests/test_def14a_ingest.py + tests/test_sec_def14a_parser.py`` — 49 pass
- [x] Codex pre-push review — clean after 3 follow-up rounds

## Codex pre-push findings (all addressed)

1. **High** — ILIKE substring matched false positives (``"Ann"`` -> ``"Joanne Smith"``; ``"John Doe"`` -> ``"John Doe Jr"``). Switched to exact case-insensitive equality after canonical role-suffix strip on both sides.
2. **Medium** — stale alerts never cleared when reconciliation resolved. Added ``_delete_alert`` path on severity=None so the table represents "open issues" not historical findings.
3. **Medium** — ``matched_cik is not None`` confused ``"found a match"`` with ``"found a CIK-bearing row"``. Some legacy Form 4 rows have NULL ``filer_cik``; their reconciliations are real. Return a separate ``matched: bool`` from the resolver.
4. **Medium** (follow-up) — SQL-side ``SPLIT_PART(filer_name, ',', 1)`` only matched the comma branch of the Python normaliser; ``"John Doe"`` vs ``"John Doe - Director"`` silently failed to reconcile. Moved the filter to Python so ``_normalise_name`` is the single canonical source.
5. **Low** — test claimed NULL filer_cik but seeded a CIK string. Replaced with raw INSERT to actually exercise the legacy path.

## End-state

Issue #769's Definition of Done is now reachable end-to-end:
- AAPL DEF 14A → parser (PR 1) → ingester (PR 2) → drift detector (PR 3) → alerts table queryable by the ops monitor.
- Drift > 5% surfaces as a warning-severity alert; Form 4 cumulative trail reconciles cleanly when matched on normalised names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)