### PR TITLE
feat(#781): 13F CUSIP resolver via fuzzy issuer-name match

### DIFF
--- a/app/services/cusip_resolver.py
+++ b/app/services/cusip_resolver.py
@@ -1,0 +1,613 @@
+"""CUSIP → instrument_id resolver via fuzzy issuer-name match (#781).
+
+Walks ``unresolved_13f_cusips`` (populated by the 13F-HR ingester
+on each unresolved CUSIP) and tries to promote rows into
+``external_identifiers`` by fuzzy-matching the filer-supplied
+``name_of_issuer`` against ``instruments.company_name``. Successful
+matches are removed from the unresolved table; rejections are
+tombstoned with ``resolution_status='unresolvable'`` so the next
+run skips them.
+
+This is the practical alternative to parsing the SEC's quarterly
+Official List of Section 13(f) Securities (PDF-only, no
+machine-readable feed). Every CUSIP that appears in any 13F-HR
+filing is by definition a 13F-eligible security; we already fetch
+the holdings during the #730 ingest so the unresolved-CUSIP set
+is populated naturally.
+
+Match strategy (deliberately conservative — false positives in
+``external_identifiers`` corrupt every downstream join):
+
+  1. **Normalise** both sides:
+     - Strip common corporate-form suffixes (``"INC"``, ``"CORP"``,
+       ``"CO"``, ``"LTD"``, ``"LLC"``, ``"PLC"``, ``"NV"``, ``"AG"``,
+       ``"SA"``, etc.) — proxies and 13F filers vary on inclusion.
+     - Strip share-class suffixes (``"CL A"``, ``"CL B"``,
+       ``"CLASS A"``, ``"COM"``, ``"COMMON"``, etc.) — the CUSIP
+       already encodes the share class via the last digit, so the
+       textual suffix is redundant noise.
+     - Drop punctuation; collapse whitespace; uppercase.
+  2. **Score** via a Jaro-Winkler-style similarity on the
+     normalised forms. Stdlib ``difflib.SequenceMatcher.ratio()``
+     is the no-dep choice here — accuracy is good enough for the
+     "Berkshire Hathaway" / "Berkshire Hathaway Inc" /
+     "Berkshire Hathaway Inc. Class B" trio that 13F filings
+     produce in practice.
+  3. **Promote** when ``ratio >= MATCH_THRESHOLD``. Below the
+     threshold, mark ``resolution_status='unresolvable'``.
+
+Deliberately *no* dependency added — stdlib ``difflib`` is enough
+for v1. If recall ever tightens, ``rapidfuzz`` would be the
+incremental upgrade.
+
+Idempotent: the resolver is safe to run repeatedly. Each
+successful promotion deletes the source row, so re-runs only see
+unresolved + tombstoned entries. Operator can clear tombstoned
+rows to force a retry once instrument coverage improves (e.g.
+after a new instrument is seeded).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Any, Final
+
+import psycopg
+import psycopg.rows
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+# Similarity floor. Tuned empirically: 0.92 is conservative enough
+# that "Apple Inc" doesn't match "Apple Hospitality REIT" but
+# "Berkshire Hathaway" matches "BERKSHIRE HATHAWAY INC". Increasing
+# to 0.95+ would push more CUSIPs into the unresolvable bucket;
+# decreasing below 0.90 starts seeing common-prefix false positives.
+MATCH_THRESHOLD: Final[float] = 0.92
+
+
+# Corporate-form suffix patterns stripped during normalisation.
+# Order matters: longer-prefix variants must precede shorter ones
+# so the stripper doesn't bail out on a partial substring.
+_CORPORATE_SUFFIXES: Final[tuple[str, ...]] = (
+    "INCORPORATED",
+    "CORPORATION",
+    "COMPANY",
+    "LIMITED",
+    "INC.",
+    "INC",
+    "CORP.",
+    "CORP",
+    "CO.",
+    "CO",
+    "LTD.",
+    "LTD",
+    "LLC",
+    "L.L.C.",
+    "PLC",
+    "P.L.C.",
+    "NV",
+    "N.V.",
+    "AG",
+    "A.G.",
+    "SA",
+    "S.A.",
+    "GMBH",
+    "AB",
+    "OYJ",
+    "ASA",
+    "PTE",
+    "BHD",
+    "TRUST",
+    "FUND",
+    "HOLDINGS",
+    "GROUP",
+)
+
+# Share-class / security-type suffix patterns. CUSIP already
+# encodes the share class via its last digit, so the textual
+# suffix is informational noise during name comparison.
+_SHARE_CLASS_PATTERNS: Final[re.Pattern[str]] = re.compile(
+    r"\b(?:"
+    r"CLASS\s+[A-Z]"
+    r"|CL\s+[A-Z]"
+    r"|COM(?:MON)?\s+(?:STK|STOCK|SHARES)?"
+    r"|PRF(?:D)?(?:\s+STK)?"
+    r"|PFD"
+    r"|ADR"
+    r"|ADS"
+    r"|REIT"
+    r"|UNITS?"
+    r"|WT"
+    r"|WAR(?:RANTS?)?"
+    r"|CAP(?:ITAL)?\s+STK"
+    r"|RIGHTS"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Punctuation stripped from both sides during normalisation. Hyphens
+# preserved (some legitimate company names — "PG&E", "BLOCK H&R" —
+# rely on them); commas / apostrophes / parens dropped.
+_PUNCTUATION_RE: Final[re.Pattern[str]] = re.compile(r"[.,'\"()\[\]/]")
+_WHITESPACE_RE: Final[re.Pattern[str]] = re.compile(r"\s+")
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ResolveReport:
+    """Per-run rollup. Drives the ops monitor's "13F coverage"
+    indicator and the operator-facing CLI summary.
+
+    Counter semantics:
+
+      * ``promotions`` — new mappings inserted into
+        ``external_identifiers``. The operator-facing chip moves
+        on this counter, not on already-resolved or conflict
+        outcomes.
+      * ``already_resolved`` — CUSIPs that were already mapped to
+        the same ``instrument_id`` (another path beat the resolver
+        to it). Source backlog row deleted; no new
+        ``external_identifiers`` row written.
+      * ``tombstoned_unresolvable`` / ``ambiguous`` / ``conflict``
+        — three distinct tombstone reasons (see
+        :data:`unresolved_13f_cusips.resolution_status`).
+    """
+
+    candidates_seen: int
+    promotions: int
+    already_resolved: int
+    tombstoned_unresolvable: int
+    tombstoned_ambiguous: int
+    tombstoned_conflict: int
+
+    @property
+    def tombstones(self) -> int:
+        """Total tombstones across all reason buckets — back-compat
+        accessor for tests / callers that don't care about the
+        breakdown."""
+        return self.tombstoned_unresolvable + self.tombstoned_ambiguous + self.tombstoned_conflict
+
+
+@dataclass(frozen=True)
+class _Match:
+    """Internal — best-match result for one unresolved CUSIP."""
+
+    instrument_id: int
+    company_name: str
+    score: float
+
+
+# ---------------------------------------------------------------------------
+# Normalisation
+# ---------------------------------------------------------------------------
+
+
+def _normalise_name(raw: str) -> str:
+    """Normalise an issuer / instrument company name for fuzzy
+    comparison.
+
+    Pipeline (order matters):
+      1. Uppercase + strip.
+      2. Drop bracketed / parenthesised qualifiers ("(NEW)").
+      3. Strip share-class suffixes via :data:`_SHARE_CLASS_PATTERNS`.
+      4. Drop punctuation per :data:`_PUNCTUATION_RE`.
+      5. Strip a trailing corporate-form suffix.
+      6. Collapse whitespace.
+
+    Returns the empty string when nothing is left after stripping —
+    the resolver treats that as "unmatchable" rather than letting
+    a degenerate result feed the similarity scorer.
+    """
+    if not raw:
+        return ""
+
+    # 1. Uppercase + trim.
+    s = raw.upper().strip()
+
+    # 2. Drop bracketed qualifiers (typical 13F / proxy footnotes:
+    # ``"BERKSHIRE HATHAWAY INC (NEW)"``, ``"AAPL [HOLDINGS]"``).
+    s = re.sub(r"[(\[][^)\]]*[)\]]", " ", s)
+
+    # 3. Strip share-class indicators (CUSIPs already encode class).
+    s = _SHARE_CLASS_PATTERNS.sub(" ", s)
+
+    # 4. Drop punctuation.
+    s = _PUNCTUATION_RE.sub(" ", s)
+
+    # 5. Strip a single trailing corporate-form suffix.
+    tokens = s.split()
+    while tokens and tokens[-1] in _CORPORATE_SUFFIXES:
+        tokens.pop()
+    s = " ".join(tokens)
+
+    # 6. Collapse whitespace.
+    return _WHITESPACE_RE.sub(" ", s).strip()
+
+
+def _similarity(a: str, b: str) -> float:
+    """Return a 0..1 similarity ratio between two normalised names.
+
+    Uses :func:`difflib.SequenceMatcher.ratio()` — a stdlib
+    no-dep choice that's good enough for the bulk of issuer-name
+    variation seen in 13F filings. ``rapidfuzz`` would be the
+    incremental upgrade if recall tightens.
+    """
+    if not a or not b:
+        return 0.0
+    return SequenceMatcher(None, a, b).ratio()
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _select_pending_unresolved(
+    conn: psycopg.Connection[tuple],
+    *,
+    limit: int = 500,
+) -> list[dict[str, Any]]:
+    """Return up to ``limit`` unresolved CUSIPs that haven't been
+    tombstoned, ordered by observation count DESC so the
+    highest-leverage entries resolve first."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT cusip, name_of_issuer, observation_count
+            FROM unresolved_13f_cusips
+            WHERE resolution_status IS NULL
+            ORDER BY observation_count DESC, last_observed_at DESC
+            LIMIT %(limit)s
+            """,
+            {"limit": limit},
+        )
+        return list(cur.fetchall())
+
+
+def _select_instrument_candidates(
+    conn: psycopg.Connection[tuple],
+) -> list[tuple[int, str]]:
+    """Return ``(instrument_id, normalised_company_name)`` pairs for
+    every instrument with a non-empty company name. Normalisation
+    happens in Python so the resolver's match logic is the single
+    canonical source.
+
+    Pulling the whole instruments universe per resolver pass is
+    fine — a typical eBull deployment carries low thousands of
+    instruments, well under the row threshold where SQL-side
+    indexed search would matter.
+    """
+    pairs: list[tuple[int, str]] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, company_name
+            FROM instruments
+            WHERE company_name IS NOT NULL
+              AND company_name <> ''
+            """
+        )
+        for row in cur.fetchall():
+            normalised = _normalise_name(str(row[1]))
+            if normalised:
+                pairs.append((int(row[0]), normalised))
+    return pairs
+
+
+def _best_match(
+    *,
+    target: str,
+    candidates: list[tuple[int, str]],
+) -> tuple[_Match | None, bool]:
+    """Return ``(best_match, is_ambiguous)``.
+
+    ``best_match`` is the highest-similarity candidate or ``None``
+    when no candidate meets the score floor. ``is_ambiguous`` is
+    ``True`` when two or more distinct candidates tied at the top
+    score — common collision: ``"ALPHABET INC CL A"`` and
+    ``"ALPHABET INC CL C"`` both normalise to ``"ALPHABET"`` after
+    share-class strip, so an unresolved CUSIP ``"ALPHABET INC CL C"``
+    has two equally-good candidates and the resolver cannot pick one
+    unambiguously. Codex pre-push review caught the prior code's
+    arbitrary first-wins behaviour.
+
+    Linear scan is fine at the candidate counts involved (low
+    thousands × ~hundreds of unresolved CUSIPs per pass = sub-second
+    on commodity hardware).
+    """
+    if not target or not candidates:
+        return (None, False)
+
+    top_score = 0.0
+    top_matches: list[_Match] = []
+    for instrument_id, candidate in candidates:
+        score = _similarity(target, candidate)
+        if score > top_score:
+            top_score = score
+            top_matches = [_Match(instrument_id=instrument_id, company_name=candidate, score=score)]
+        elif score == top_score and score > 0.0:
+            top_matches.append(_Match(instrument_id=instrument_id, company_name=candidate, score=score))
+
+    if not top_matches:
+        return (None, False)
+
+    is_ambiguous = len({m.instrument_id for m in top_matches}) > 1
+    # Return the first top-scoring match for diagnostic logging
+    # purposes; the caller treats ``is_ambiguous=True`` as a
+    # tombstone signal regardless of which match was picked.
+    return (top_matches[0], is_ambiguous)
+
+
+def _promote_to_external_identifier(
+    conn: psycopg.Connection[tuple],
+    *,
+    cusip: str,
+    instrument_id: int,
+) -> str:
+    """Try to promote a resolved CUSIP into ``external_identifiers``.
+
+    Returns one of:
+
+      * ``"inserted"`` — a new mapping was created; the source row
+        is deleted from ``unresolved_13f_cusips``.
+      * ``"already_resolved"`` — the CUSIP was already mapped to
+        the SAME instrument_id (another path beat us to it). Source
+        row deleted; not counted as a new promotion.
+      * ``"conflict"`` — the CUSIP was already mapped to a
+        DIFFERENT instrument_id. The existing mapping is preserved
+        (we never silently overwrite), the resolver does NOT delete
+        the source row, and the caller tombstones it with
+        ``resolution_status='conflict'`` so an operator can audit.
+        Codex pre-push review caught the prior code silently
+        treating a conflicting pre-existing mapping as success.
+
+    ``is_primary`` is FALSE on the new INSERT path because the
+    curated mapping (when one exists) takes precedence; the
+    resolver only adds entries that were missing entirely.
+    """
+    cusip_norm = cusip.strip().upper()
+
+    # Two-step: probe first, write second. ON CONFLICT ... DO NOTHING
+    # would silently swallow the conflict and we couldn't distinguish
+    # "race-loss / already-mapped to same iid" from "wrong-mapping".
+    # The probe + write pair is wrapped in the same transaction.
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id FROM external_identifiers
+            WHERE provider = 'sec'
+              AND identifier_type = 'cusip'
+              AND identifier_value = %s
+            """,
+            (cusip_norm,),
+        )
+        existing = cur.fetchone()
+
+    if existing is not None:
+        existing_iid = int(existing[0])
+        if existing_iid == instrument_id:
+            # Already mapped to the same instrument — source row is
+            # safely redundant.
+            conn.execute(
+                "DELETE FROM unresolved_13f_cusips WHERE cusip = %s",
+                (cusip_norm,),
+            )
+            return "already_resolved"
+        # Conflicting pre-existing mapping. Keep the existing row;
+        # leave the source row in place so the tombstone path can
+        # mark it 'conflict' for operator audit.
+        return "conflict"
+
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (
+            instrument_id, provider, identifier_type, identifier_value, is_primary
+        ) VALUES (%(iid)s, 'sec', 'cusip', %(cusip)s, FALSE)
+        """,
+        {"iid": instrument_id, "cusip": cusip_norm},
+    )
+    conn.execute(
+        "DELETE FROM unresolved_13f_cusips WHERE cusip = %s",
+        (cusip_norm,),
+    )
+    return "inserted"
+
+
+_TombstoneStatus = str  # one of 'unresolvable' | 'ambiguous' | 'conflict'
+
+
+def _tombstone(
+    conn: psycopg.Connection[tuple],
+    *,
+    cusip: str,
+    status: _TombstoneStatus,
+) -> None:
+    """Mark a CUSIP for skip on subsequent runs with a reason tag.
+
+    Statuses (must match the schema CHECK on
+    ``unresolved_13f_cusips.resolution_status``):
+
+      * ``'unresolvable'`` — no candidate met the similarity floor.
+      * ``'ambiguous'`` — multiple candidates tied at the top score
+        (e.g. Alphabet Class A vs Class C share-class collisions).
+        Operator disambiguates via the curated mapping seed.
+      * ``'conflict'`` — ``external_identifiers`` already maps this
+        CUSIP to a DIFFERENT instrument_id. Operator audits which
+        side is correct before clearing.
+
+    The row stays in the table for operator audit; clearing
+    ``resolution_status`` forces a retry on the next run.
+    """
+    conn.execute(
+        """
+        UPDATE unresolved_13f_cusips
+        SET resolution_status = %s,
+            last_observed_at = NOW()
+        WHERE cusip = %s
+        """,
+        (status, cusip.strip().upper()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def resolve_unresolved_cusips(
+    conn: psycopg.Connection[tuple],
+    *,
+    limit: int = 500,
+    threshold: float = MATCH_THRESHOLD,
+) -> ResolveReport:
+    """Run one resolver pass.
+
+    Reads up to ``limit`` pending CUSIPs from
+    ``unresolved_13f_cusips``, fuzzy-matches each against the
+    instruments universe, and promotes confident matches into
+    ``external_identifiers``. Each match decision (promote /
+    tombstone) commits in its own write — caller is responsible
+    for committing the transaction at the end.
+
+    ``threshold`` defaults to :data:`MATCH_THRESHOLD`; tests
+    override it for deterministic fuzzy-edge cases.
+    """
+    pending = _select_pending_unresolved(conn, limit=limit)
+    if not pending:
+        return ResolveReport(
+            candidates_seen=0,
+            promotions=0,
+            already_resolved=0,
+            tombstoned_unresolvable=0,
+            tombstoned_ambiguous=0,
+            tombstoned_conflict=0,
+        )
+
+    candidates = _select_instrument_candidates(conn)
+    if not candidates:
+        # Empty instruments table — every CUSIP is unresolvable
+        # by definition. Tombstone them all so the next run skips
+        # them; clearing rows is the operator path to retry once
+        # instruments are seeded.
+        for row in pending:
+            _tombstone(conn, cusip=str(row["cusip"]), status="unresolvable")
+        return ResolveReport(
+            candidates_seen=len(pending),
+            promotions=0,
+            already_resolved=0,
+            tombstoned_unresolvable=len(pending),
+            tombstoned_ambiguous=0,
+            tombstoned_conflict=0,
+        )
+
+    promotions = 0
+    already_resolved = 0
+    unresolvable = 0
+    ambiguous = 0
+    conflict = 0
+
+    for row in pending:
+        cusip = str(row["cusip"])
+        target = _normalise_name(str(row["name_of_issuer"]))
+        if not target:
+            # Issuer name normalised to empty (extreme edge — pure
+            # punctuation / suffix-only string). Tombstone.
+            _tombstone(conn, cusip=cusip, status="unresolvable")
+            unresolvable += 1
+            continue
+
+        best, is_ambiguous = _best_match(target=target, candidates=candidates)
+        if best is None or best.score < threshold:
+            _tombstone(conn, cusip=cusip, status="unresolvable")
+            unresolvable += 1
+            continue
+
+        if is_ambiguous:
+            # Two or more distinct instruments tied at the top
+            # score (typical share-class collision: Alphabet CL A
+            # vs CL C). Refuse to pick arbitrarily — operator
+            # disambiguates via the curated mapping seed.
+            _tombstone(conn, cusip=cusip, status="ambiguous")
+            ambiguous += 1
+            logger.info(
+                "13F CUSIP resolver: ambiguous %s (score=%.3f, %r); operator must disambiguate",
+                cusip,
+                best.score,
+                target,
+            )
+            continue
+
+        outcome = _promote_to_external_identifier(conn, cusip=cusip, instrument_id=best.instrument_id)
+        if outcome == "inserted":
+            promotions += 1
+            logger.info(
+                "13F CUSIP resolver: promoted %s -> instrument_id=%d (score=%.3f, %r ~ %r)",
+                cusip,
+                best.instrument_id,
+                best.score,
+                target,
+                best.company_name,
+            )
+        elif outcome == "already_resolved":
+            already_resolved += 1
+        else:  # 'conflict'
+            _tombstone(conn, cusip=cusip, status="conflict")
+            conflict += 1
+            logger.warning(
+                "13F CUSIP resolver: conflict %s — existing mapping differs from match %d",
+                cusip,
+                best.instrument_id,
+            )
+
+    return ResolveReport(
+        candidates_seen=len(pending),
+        promotions=promotions,
+        already_resolved=already_resolved,
+        tombstoned_unresolvable=unresolvable,
+        tombstoned_ambiguous=ambiguous,
+        tombstoned_conflict=conflict,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reader (exposed for ad-hoc admin queries)
+# ---------------------------------------------------------------------------
+
+
+def iter_pending_unresolved(
+    conn: psycopg.Connection[tuple],
+    *,
+    limit: int = 100,
+) -> Iterator[dict[str, Any]]:
+    """Yield unresolved CUSIPs (resolution_status IS NULL) ordered
+    by observation count DESC. Used by the operator CLI to inspect
+    the resolver backlog before triggering a manual mapping
+    upsert."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT cusip, name_of_issuer, observation_count,
+                   last_accession_number, first_observed_at, last_observed_at
+            FROM unresolved_13f_cusips
+            WHERE resolution_status IS NULL
+            ORDER BY observation_count DESC, last_observed_at DESC
+            LIMIT %s
+            """,
+            (limit,),
+        )
+        for row in cur.fetchall():
+            yield dict(row)

--- a/app/services/cusip_resolver.py
+++ b/app/services/cusip_resolver.py
@@ -228,7 +228,12 @@ def _normalise_name(raw: str) -> str:
     # 4. Drop punctuation.
     s = _PUNCTUATION_RE.sub(" ", s)
 
-    # 5. Strip a single trailing corporate-form suffix.
+    # 5. Strip every trailing corporate-form suffix token. The
+    #    while loop handles names like ``"Vanguard Group Holdings
+    #    Trust"`` where the operator-facing label stacks several
+    #    structural words; stripping just one would leave residual
+    #    noise that hurts comparison. Bot review caught the prior
+    #    "single trailing" comment.
     tokens = s.split()
     while tokens and tokens[-1] in _CORPORATE_SUFFIXES:
         tokens.pop()

--- a/app/services/cusip_resolver.py
+++ b/app/services/cusip_resolver.py
@@ -205,7 +205,8 @@ def _normalise_name(raw: str) -> str:
       2. Drop bracketed / parenthesised qualifiers ("(NEW)").
       3. Strip share-class suffixes via :data:`_SHARE_CLASS_PATTERNS`.
       4. Drop punctuation per :data:`_PUNCTUATION_RE`.
-      5. Strip a trailing corporate-form suffix.
+      5. Strip every trailing corporate-form suffix token in turn
+         (``"Vanguard Group Holdings Trust"`` -> ``"VANGUARD"``).
       6. Collapse whitespace.
 
     Returns the empty string when nothing is left after stripping —

--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -396,6 +396,38 @@ def _record_ingest_attempt(
     )
 
 
+def _record_unresolved_cusip(
+    conn: psycopg.Connection[tuple],
+    *,
+    cusip: str,
+    name_of_issuer: str,
+    accession_number: str,
+) -> None:
+    """Track a 13F-HR holding whose CUSIP didn't resolve to an
+    ``instruments`` row at ingest time. Idempotent — re-encountering
+    the same CUSIP bumps ``observation_count`` + refreshes the
+    latest filer-supplied issuer name. Resolver service (#781)
+    consumes this table.
+    """
+    conn.execute(
+        """
+        INSERT INTO unresolved_13f_cusips (
+            cusip, name_of_issuer, last_accession_number
+        ) VALUES (%(cusip)s, %(name)s, %(accession)s)
+        ON CONFLICT (cusip) DO UPDATE SET
+            name_of_issuer = EXCLUDED.name_of_issuer,
+            last_accession_number = EXCLUDED.last_accession_number,
+            observation_count = unresolved_13f_cusips.observation_count + 1,
+            last_observed_at = NOW()
+        """,
+        {
+            "cusip": cusip.strip().upper(),
+            "name": name_of_issuer,
+            "accession": accession_number,
+        },
+    )
+
+
 def _resolve_cusip_to_instrument_id(
     conn: psycopg.Connection[tuple],
     cusip: str,
@@ -925,6 +957,18 @@ def _ingest_single_accession(
         instrument_id = _resolve_cusip_to_instrument_id(conn, holding.cusip)
         if instrument_id is None:
             skipped_no_cusip += 1
+            # Track the unresolved CUSIP so the resolver service
+            # (#781) can fuzzy-match against ``instruments.
+            # company_name`` later without re-fetching the SEC
+            # archive. Idempotent — re-encountering the same CUSIP
+            # increments ``observation_count`` and refreshes the
+            # latest filer-supplied issuer name.
+            _record_unresolved_cusip(
+                conn,
+                cusip=holding.cusip,
+                name_of_issuer=holding.name_of_issuer,
+                accession_number=ref.accession_number,
+            )
             continue
         if _upsert_holding(
             conn,

--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -408,6 +408,16 @@ def _record_unresolved_cusip(
     the same CUSIP bumps ``observation_count`` + refreshes the
     latest filer-supplied issuer name. Resolver service (#781)
     consumes this table.
+
+    ``resolution_status`` is intentionally NOT reset on conflict.
+    A tombstoned CUSIP (``unresolvable`` / ``ambiguous`` /
+    ``conflict``) that re-appears in a new filing gets its
+    observation_count and last-seen name updated for audit, but
+    the resolver still skips it on the next pass. The operator
+    clears ``resolution_status`` to force a retry once the
+    underlying issue (missing instrument seed, share-class
+    disambiguation, mapping correction) is fixed. Bot review of
+    #781 caught the absence of this note.
     """
     conn.execute(
         """

--- a/sql/099_unresolved_13f_cusips.sql
+++ b/sql/099_unresolved_13f_cusips.sql
@@ -1,0 +1,82 @@
+-- 099_unresolved_13f_cusips.sql
+--
+-- Issue #781 — capture CUSIPs observed in 13F-HR holdings (#730)
+-- that didn't resolve to an ``instruments`` row at ingest time, so
+-- a downstream resolver can fuzzy-match by issuer name and populate
+-- ``external_identifiers`` without re-fetching the SEC archive.
+--
+-- This table is the practical alternative to parsing the SEC's
+-- quarterly Official List of Section 13(f) Securities (PDF-only,
+-- no machine-readable feed). Every CUSIP that appears in any 13F-HR
+-- filing must by definition be a 13F-eligible security, and we
+-- already fetch each filing's holdings during the #730 ingest —
+-- recording the unresolved (CUSIP, issuer name) pairs gives us the
+-- same coverage as the official list with one notable exception:
+-- securities that no curated 13F filer holds will never surface.
+-- That gap is acceptable for v1 because the ownership card cares
+-- about *held* positions; we'll never need to render an
+-- instrument that nobody holds.
+--
+-- The resolver service (#781 PR 2 follow-up) walks this table and:
+--   1. Fuzzy-matches ``name_of_issuer`` against
+--      ``instruments.company_name`` using a similarity threshold.
+--   2. Promotes confident matches into ``external_identifiers``
+--      with ``provider='sec', identifier_type='cusip'``.
+--   3. Drops the row from this table on successful promotion.
+--
+-- Schema decisions:
+--
+--   * Identity / dedupe = ``cusip`` only — same CUSIP in multiple
+--     filings is the same unresolved row. ``observation_count`` is
+--     incremented on each re-encounter so the operator can prioritise
+--     resolution by frequency (CUSIPs held by many filers are more
+--     valuable to map first).
+--   * ``name_of_issuer`` carries the latest filer-supplied label.
+--     Filers spell issuer names slightly differently across filings
+--     (``"BERKSHIRE HATHAWAY INC"`` vs ``"BERKSHIRE HATHAWAY"`` vs
+--     ``"BERKSHIRE HATHAWAY INC. CL B"``) — keeping the latest is a
+--     pragmatic v1 choice; a future enhancement could store every
+--     observed variant in a JSONB column for broader fuzzy matching.
+--   * ``last_accession_number`` is informational — the operator can
+--     trace back to the source filing without joining
+--     ``institutional_holdings`` (whose unresolved rows aren't
+--     persisted today).
+--   * ``resolution_status`` tombstones rejection: when a resolver
+--     run flags a CUSIP as unresolvable (no fuzzy match above
+--     threshold), set to ``'unresolvable'`` so the next run skips
+--     it. Operator can clear the row to force a retry. NULL = not
+--     yet attempted.
+
+CREATE TABLE IF NOT EXISTS unresolved_13f_cusips (
+    cusip                  TEXT PRIMARY KEY,
+    name_of_issuer         TEXT NOT NULL,
+    last_accession_number  TEXT NOT NULL,
+    observation_count      INTEGER NOT NULL DEFAULT 1,
+    resolution_status      TEXT
+        CHECK (resolution_status IS NULL OR resolution_status IN (
+            'unresolvable',   -- no candidate met the similarity threshold
+            'ambiguous',      -- two or more candidates tied at the top
+                              -- score; needs manual disambiguation (e.g.
+                              -- Alphabet Inc CL A vs CL C — same
+                              -- normalised name, different instrument_id)
+            'conflict',       -- external_identifiers already maps this
+                              -- CUSIP to a DIFFERENT instrument_id; the
+                              -- resolver refuses to silently overwrite
+            'manual_review'   -- operator-set flag for cases the
+                              -- automated path can't handle
+        )),
+    first_observed_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_observed_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Hot path for the resolver: unresolved (status IS NULL) ordered
+-- by frequency DESC so the operator sees the highest-leverage
+-- CUSIPs first.
+CREATE INDEX IF NOT EXISTS idx_unresolved_13f_cusips_pending
+    ON unresolved_13f_cusips (observation_count DESC, last_observed_at DESC)
+    WHERE resolution_status IS NULL;
+
+-- Hot path for "what did this filing's resolver pass leave open":
+-- per-accession scan for the operator-facing tooling.
+CREATE INDEX IF NOT EXISTS idx_unresolved_13f_cusips_accession
+    ON unresolved_13f_cusips (last_accession_number);

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -106,6 +106,10 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # cascade), but listing them explicitly keeps teardown
     # deterministic when a test populates filer / holding rows
     # without touching the instruments row in the same case.
+    # #781 — unresolved 13F CUSIPs tracking. No FK to instruments
+    # (PK is the CUSIP) so it's safe in any order, but listed
+    # alongside the institutional set for cohesion.
+    "unresolved_13f_cusips",
     "institutional_holdings_ingest_log",
     "institutional_holdings",
     "institutional_filers",

--- a/tests/test_cusip_resolver.py
+++ b/tests/test_cusip_resolver.py
@@ -1,0 +1,509 @@
+"""Integration tests for the 13F CUSIP resolver (#781).
+
+Exercises the full path:
+  1. Unresolved CUSIPs land in ``unresolved_13f_cusips`` (populated
+     by the 13F-HR ingester on each unresolved holding — verified
+     via the existing ingester test path; here we seed directly).
+  2. ``resolve_unresolved_cusips`` walks the table, fuzzy-matches
+     against ``instruments.company_name``, and either promotes
+     into ``external_identifiers`` or tombstones.
+  3. Idempotency: a second run on the same data is a no-op.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services.cusip_resolver import (
+    MATCH_THRESHOLD,
+    _normalise_name,
+    iter_pending_unresolved,
+    resolve_unresolved_cusips,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str, company_name: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, company_name),
+    )
+
+
+def _seed_unresolved(
+    conn: psycopg.Connection[tuple],
+    *,
+    cusip: str,
+    name_of_issuer: str,
+    accession: str = "0001234567-25-000001",
+    observation_count: int = 1,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO unresolved_13f_cusips (
+            cusip, name_of_issuer, last_accession_number, observation_count
+        ) VALUES (%s, %s, %s, %s)
+        """,
+        (cusip, name_of_issuer, accession, observation_count),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure normalisation tests (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestNormaliseName:
+    def test_strips_corporate_suffix(self) -> None:
+        assert _normalise_name("Apple Inc") == "APPLE"
+        assert _normalise_name("Berkshire Hathaway Inc.") == "BERKSHIRE HATHAWAY"
+        assert _normalise_name("Alphabet Corporation") == "ALPHABET"
+        assert _normalise_name("Vanguard Group LLC") == "VANGUARD"
+
+    def test_strips_share_class_suffix(self) -> None:
+        assert _normalise_name("Berkshire Hathaway Inc Class B") == "BERKSHIRE HATHAWAY"
+        assert _normalise_name("Alphabet Inc CL A") == "ALPHABET"
+        assert _normalise_name("Apple Inc Common Stock") == "APPLE"
+
+    def test_drops_bracketed_qualifiers(self) -> None:
+        assert _normalise_name("Apple Inc (NEW)") == "APPLE"
+
+    def test_normalises_punctuation_and_whitespace(self) -> None:
+        assert _normalise_name("  Apple,  Inc.  ") == "APPLE"
+        assert _normalise_name("BLOCK H&R") == "BLOCK H&R"  # ampersand preserved
+
+    def test_returns_empty_on_pure_suffix(self) -> None:
+        assert _normalise_name("Inc") == ""
+        assert _normalise_name("LLC") == ""
+        assert _normalise_name("") == ""
+
+
+# ---------------------------------------------------------------------------
+# End-to-end resolver tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolver:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=781_001, symbol="AAPL", company_name="Apple Inc")
+        _seed_instrument(conn, iid=781_002, symbol="BRK.B", company_name="Berkshire Hathaway Inc")
+        _seed_instrument(conn, iid=781_003, symbol="GOOG", company_name="Alphabet Inc")
+        conn.commit()
+        return conn
+
+    def test_exact_normalised_match_promotes(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        _seed_unresolved(conn, cusip="037833100", name_of_issuer="APPLE INC")
+        conn.commit()
+
+        report = resolve_unresolved_cusips(conn)
+        conn.commit()
+
+        assert report.promotions == 1
+        assert report.tombstones == 0
+
+        # external_identifiers has the new mapping.
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT instrument_id FROM external_identifiers
+                WHERE provider='sec' AND identifier_type='cusip' AND identifier_value=%s
+                """,
+                ("037833100",),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 781_001
+
+        # unresolved_13f_cusips no longer carries the row.
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM unresolved_13f_cusips WHERE cusip = %s",
+                ("037833100",),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+
+    def test_share_class_variant_matches(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """``"BERKSHIRE HATHAWAY INC CL B"`` resolves to instrument
+        with company_name ``"Berkshire Hathaway Inc"`` — share-class
+        suffix stripped by the normaliser."""
+        conn = _setup
+        _seed_unresolved(
+            conn,
+            cusip="084670702",
+            name_of_issuer="BERKSHIRE HATHAWAY INC CL B",
+        )
+        conn.commit()
+
+        report = resolve_unresolved_cusips(conn)
+        conn.commit()
+
+        assert report.promotions == 1
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT instrument_id FROM external_identifiers
+                WHERE identifier_value = '084670702'
+                """,
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 781_002
+
+    def test_no_candidate_match_tombstones(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """A CUSIP whose issuer name doesn't fuzzy-match any
+        instrument is tombstoned, not silently dropped."""
+        conn = _setup
+        _seed_unresolved(
+            conn,
+            cusip="999999999",
+            name_of_issuer="WHO KNOWS WHAT THIS IS LLC",
+        )
+        conn.commit()
+
+        report = resolve_unresolved_cusips(conn)
+        conn.commit()
+
+        assert report.promotions == 0
+        assert report.tombstones == 1
+        assert report.tombstoned_unresolvable == 1
+        assert report.tombstoned_ambiguous == 0
+        assert report.tombstoned_conflict == 0
+
+        # No external_identifiers row written.
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM external_identifiers WHERE identifier_value = '999999999'",
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+
+        # Source row is tombstoned, not deleted (audit trail
+        # preserved; operator can clear status to retry).
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT resolution_status FROM unresolved_13f_cusips WHERE cusip = %s",
+                ("999999999",),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["resolution_status"] == "unresolvable"
+
+    def test_re_run_skips_tombstoned_rows(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """A second run after tombstoning should not re-evaluate
+        the unresolvable rows. iter_pending_unresolved returns
+        only NULL-status rows."""
+        conn = _setup
+        _seed_unresolved(conn, cusip="999999999", name_of_issuer="UNKNOWN")
+        conn.commit()
+
+        first = resolve_unresolved_cusips(conn)
+        conn.commit()
+        assert first.tombstones == 1
+
+        # Second run sees zero pending.
+        second = resolve_unresolved_cusips(conn)
+        conn.commit()
+        assert second.candidates_seen == 0
+        assert second.promotions == 0
+        assert second.tombstones == 0
+
+    def test_idempotent_promotion_does_not_duplicate_external_identifier(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Running the resolver twice on the same successful match
+        produces exactly one external_identifiers row."""
+        conn = _setup
+        _seed_unresolved(conn, cusip="037833100", name_of_issuer="APPLE INC")
+        conn.commit()
+
+        resolve_unresolved_cusips(conn)
+        conn.commit()
+
+        # Re-seed (operator force-retry) and re-run.
+        _seed_unresolved(conn, cusip="037833100", name_of_issuer="APPLE INC")
+        conn.commit()
+
+        resolve_unresolved_cusips(conn)
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COUNT(*) FROM external_identifiers
+                WHERE identifier_type = 'cusip' AND identifier_value = '037833100'
+                """,
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 1
+
+    def test_high_observation_count_is_processed_first(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Resolver order is observation_count DESC so high-leverage
+        CUSIPs resolve first under a small ``limit``."""
+        conn = _setup
+        _seed_unresolved(conn, cusip="999999991", name_of_issuer="UNKNOWN A", observation_count=100)
+        _seed_unresolved(conn, cusip="037833100", name_of_issuer="APPLE INC", observation_count=5)
+        _seed_unresolved(conn, cusip="999999992", name_of_issuer="UNKNOWN B", observation_count=50)
+        conn.commit()
+
+        # iter_pending_unresolved confirms ordering.
+        pending = list(iter_pending_unresolved(conn, limit=10))
+        assert [p["cusip"] for p in pending] == ["999999991", "999999992", "037833100"]
+
+    def test_threshold_floor_blocks_marginal_match(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """A CUSIP whose name shares a common prefix with an
+        instrument but isn't the same company is tombstoned, not
+        promoted. Codex-style false-positive guard."""
+        conn = _setup
+        # "Apple Hospitality REIT" should NOT match "Apple Inc"
+        # despite the shared prefix.
+        _seed_unresolved(
+            conn,
+            cusip="037833777",
+            name_of_issuer="APPLE HOSPITALITY REIT",
+        )
+        conn.commit()
+
+        report = resolve_unresolved_cusips(conn)
+        conn.commit()
+
+        assert report.promotions == 0
+        assert report.tombstones == 1
+        assert report.tombstoned_unresolvable == 1
+
+    def test_share_class_collision_tombstones_as_ambiguous(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """``"ALPHABET INC CL A"`` and ``"ALPHABET INC CL C"`` both
+        normalise to ``"ALPHABET"`` after the share-class strip, so
+        an unresolved CUSIP for either class has two equally-good
+        candidates. The resolver refuses to pick arbitrarily and
+        tombstones the row as ``ambiguous``. Codex pre-push review
+        caught the prior code's first-wins behaviour."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=781_010, symbol="GOOGL", company_name="Alphabet Inc CL A")
+        _seed_instrument(conn, iid=781_011, symbol="GOOG", company_name="Alphabet Inc CL C")
+        _seed_unresolved(
+            conn,
+            cusip="02079K305",
+            name_of_issuer="ALPHABET INC CL C",
+        )
+        conn.commit()
+
+        report = resolve_unresolved_cusips(conn)
+        conn.commit()
+
+        assert report.promotions == 0
+        assert report.tombstoned_ambiguous == 1
+        assert report.tombstoned_unresolvable == 0
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT resolution_status FROM unresolved_13f_cusips WHERE cusip = %s",
+                ("02079K305",),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["resolution_status"] == "ambiguous"
+
+        # external_identifiers untouched.
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM external_identifiers WHERE identifier_value = '02079K305'",
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+
+    def test_pre_existing_conflict_is_preserved(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """If ``external_identifiers`` already maps the CUSIP to a
+        DIFFERENT instrument_id, the resolver MUST preserve the
+        existing mapping (never silently overwrite) and tombstone
+        the source row as ``conflict`` for operator audit. Codex
+        pre-push review caught the prior ON-CONFLICT-DO-NOTHING
+        path silently treating this as a successful promotion."""
+        conn = _setup
+        # Pre-existing (wrong) mapping — pretend the curated path
+        # wired this CUSIP to BRK.B by mistake.
+        conn.execute(
+            """
+            INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
+            VALUES (%s, 'sec', 'cusip', '037833100', TRUE)
+            """,
+            (781_002,),  # BRK.B
+        )
+        # Resolver-side: backlog says this CUSIP is "APPLE INC".
+        _seed_unresolved(conn, cusip="037833100", name_of_issuer="APPLE INC")
+        conn.commit()
+
+        report = resolve_unresolved_cusips(conn)
+        conn.commit()
+
+        # Resolver did NOT overwrite. Existing (wrong) mapping
+        # preserved; backlog row tombstoned as conflict.
+        assert report.promotions == 0
+        assert report.tombstoned_conflict == 1
+        assert report.tombstoned_unresolvable == 0
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT instrument_id FROM external_identifiers WHERE identifier_value = '037833100'",
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 781_002  # original (wrong) mapping preserved
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT resolution_status FROM unresolved_13f_cusips WHERE cusip = %s",
+                ("037833100",),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["resolution_status"] == "conflict"
+
+    def test_pre_existing_same_mapping_counts_as_already_resolved(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """If ``external_identifiers`` already maps this CUSIP to
+        the SAME instrument_id (race-loss / curated path beat us),
+        the source backlog row is safely deleted and the resolver
+        reports ``already_resolved`` instead of ``promotions``."""
+        conn = _setup
+        # Pre-existing correct mapping.
+        conn.execute(
+            """
+            INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
+            VALUES (%s, 'sec', 'cusip', '037833100', TRUE)
+            """,
+            (781_001,),  # AAPL
+        )
+        _seed_unresolved(conn, cusip="037833100", name_of_issuer="APPLE INC")
+        conn.commit()
+
+        report = resolve_unresolved_cusips(conn)
+        conn.commit()
+
+        assert report.promotions == 0
+        assert report.already_resolved == 1
+        assert report.tombstones == 0
+
+        # Backlog row removed; existing mapping unchanged.
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM unresolved_13f_cusips WHERE cusip = '037833100'")
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+
+    def test_threshold_default_value(self) -> None:
+        """Pin the conservative default. Loosening this constant
+        is a deliberate change that warrants its own PR."""
+        assert MATCH_THRESHOLD == 0.92
+
+    def test_empty_pending_returns_zero_report(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        report = resolve_unresolved_cusips(ebull_test_conn)
+        assert report.candidates_seen == 0
+        assert report.promotions == 0
+        assert report.tombstones == 0
+
+
+# ---------------------------------------------------------------------------
+# Ingester integration: unresolved CUSIPs are tracked
+# ---------------------------------------------------------------------------
+
+
+class TestIngesterTracksUnresolvedCusips:
+    """Verifies the change in app/services/institutional_holdings.py
+    that records unresolved CUSIPs into the new tracking table.
+    Pulls the existing institutional-holdings ingester test fixtures
+    by reproducing the minimal seed shape inline."""
+
+    def test_unresolved_cusip_tracked_with_observation_count(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Direct DB-level test: simulating the ingester's call to
+        _record_unresolved_cusip via two upserts on the same CUSIP
+        bumps the observation count instead of inserting a duplicate.
+        Avoids re-mocking the SEC fetcher just to exercise this
+        path — the institutional_holdings test suite covers the
+        full ingest pipeline."""
+        from app.services.institutional_holdings import _record_unresolved_cusip
+
+        conn = ebull_test_conn
+        _record_unresolved_cusip(
+            conn,
+            cusip="037833100",
+            name_of_issuer="APPLE INC",
+            accession_number="ACC-1",
+        )
+        _record_unresolved_cusip(
+            conn,
+            cusip="037833100",
+            name_of_issuer="APPLE INC. (NEW)",  # name variant
+            accession_number="ACC-2",
+        )
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT cusip, name_of_issuer, last_accession_number, observation_count
+                FROM unresolved_13f_cusips
+                WHERE cusip = '037833100'
+                """,
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["observation_count"] == 2
+        assert row["name_of_issuer"] == "APPLE INC. (NEW)"  # latest wins
+        assert row["last_accession_number"] == "ACC-2"


### PR DESCRIPTION
## What

Re-scopes #781 from PDF-list parser (SEC publishes the 13F Official List as PDF only — no machine-readable feed) to mining the 13F-HR ingest stream we already fetch.

- ``sql/099_unresolved_13f_cusips.sql`` — tracking table + CHECK enum + indexes
- ``app/services/institutional_holdings.py`` — ingester now records unresolved CUSIPs
- ``app/services/cusip_resolver.py`` — fuzzy-match resolver + probe-then-write conflict detection
- ``tests/test_cusip_resolver.py`` — 18 unit + integration tests

## Why

Every CUSIP that appears in a 13F-HR is by definition a 13F-eligible security. We already fetch each filing's holdings during the #730 ingest, so the unresolved-CUSIP set populates naturally from the data we have rather than parsing a PDF. Closes the #740 backfill bottleneck for the ownership card.

## Test plan

- [x] ``uv run ruff check / format / pyright`` — clean
- [x] ``uv run pytest tests/smoke/test_app_boots.py tests/test_cusip_resolver.py tests/test_institutional_holdings_ingester.py`` — 39 pass
- [x] Codex pre-push review — clean after 1 round of fixes (2 findings)

## Codex pre-push findings (all addressed)

1. **High** — ``_best_match`` picked arbitrary first-wins on top-score ties. ``"Alphabet Inc CL A"`` and ``"Alphabet Inc CL C"`` both normalise to ``"ALPHABET"`` after share-class strip; an unresolved CUSIP for either class has two equally-good candidates. Now returns ``is_ambiguous=True`` and the resolver tombstones with status=``ambiguous``.
2. **Medium** — ``ON CONFLICT DO NOTHING`` silently masked pre-existing different mappings as success. Replaced with probe-then-write that distinguishes ``already_resolved`` (same iid) from ``conflict`` (different iid; existing row preserved, backlog tombstoned for operator audit).

## Tradeoffs

- **Conservative threshold (0.92)** — false positives in ``external_identifiers`` corrupt every downstream join. Lower recall is preferable; rejected names go to ``unresolvable`` for operator review.
- **No new dep** — stdlib ``difflib.SequenceMatcher`` is the resolver. ``rapidfuzz`` would be the incremental upgrade if recall tightens.
- **Linear candidate scan** — fine at the candidate counts involved (low thousands of instruments × hundreds of unresolved CUSIPs per pass = sub-second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)