### PR TITLE
feat(#782): SEC N-CEN annual fund-census auto-classifier

### DIFF
--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -468,28 +468,31 @@ def classify_filer_type(
 ) -> str:
     """Map a filer CIK to one of the constrained filer_type labels.
 
-    Cross-references the ``etf_filer_cik_seeds`` curated list. CIKs
-    on that list (and ``active=TRUE``) are tagged ``'ETF'``; every
-    other discovered 13F-HR filer defaults to ``'INV'`` (the
-    general institutional-manager bucket).
+    Delegates to :func:`app.services.ncen_classifier.compose_filer_type`,
+    which composes the priority chain:
 
-    Future enhancements (out of scope for #730 PR 3):
-      * Ingest the SEC's quarterly RIC / mutual-fund registrant
-        list to auto-populate the seed table.
-      * Distinguish ``'INS'`` (insurance) and ``'BD'`` (broker-dealer)
-        based on Form CRD data — the schema already allows those
-        labels via the CHECK constraint on
-        ``institutional_filers.filer_type``.
+      1. Curated ETF seed list (``etf_filer_cik_seeds``) -> ``ETF``.
+      2. N-CEN-derived classification (``ncen_filer_classifications``,
+         #782) -> ``INS`` / ``INV`` / ``OTHER`` per the
+         investment-company-type mapping.
+      3. Default -> ``INV``.
+
+    Indirection here keeps the 13F-HR ingester unaware of the
+    individual classification sources — adding a future Form ADV /
+    FOCUS ingest for ``BD`` classification only requires
+    ``compose_filer_type`` to grow another priority tier; this
+    function (and every call site that invokes it) stays unchanged.
+
+    Broker-dealer (``BD``) is reachable from this function's enum
+    but no source today populates it — see #782 out-of-scope notes.
     """
-    cur = conn.execute(
-        """
-        SELECT 1 FROM etf_filer_cik_seeds
-        WHERE cik = %(cik)s AND active = TRUE
-        LIMIT 1
-        """,
-        {"cik": _zero_pad_cik(cik)},
-    )
-    return "ETF" if cur.fetchone() is not None else "INV"
+    # Local import to avoid a circular dependency: ncen_classifier
+    # imports from the institutional namespace for shared helpers
+    # in a future enhancement, and the test fixtures import this
+    # module before the classifier service is initialised.
+    from app.services.ncen_classifier import compose_filer_type
+
+    return compose_filer_type(conn, cik)
 
 
 def seed_etf_filer(

--- a/app/services/ncen_classifier.py
+++ b/app/services/ncen_classifier.py
@@ -1,0 +1,553 @@
+"""SEC N-CEN annual fund-census ingester + filer-type classifier (#782).
+
+Walks each curated 13F filer in ``institutional_filer_seeds``,
+discovers their latest N-CEN annual filing on SEC EDGAR, parses
+``investmentCompanyType`` from the primary doc, and stamps the
+derived filer-type onto a dedicated
+``ncen_filer_classifications`` row. The 13F-HR ingester
+(:mod:`app.services.institutional_holdings`) reads this table via
+:func:`compose_filer_type` to apply the classification in priority
+order (curated ETF list > N-CEN > default).
+
+N-CEN is the SEC's annual census filing for registered investment
+companies. The ``<investmentCompanyType>`` field carries one of
+six statutory codes:
+
+  * ``N-1A`` — open-end management company (most mutual funds
+    and ETFs). Maps to ``INV`` by default; the curated ETF seed
+    list (#742) overrides when the CIK is on the ETF list.
+  * ``N-2`` — closed-end fund or business development company.
+    Maps to ``INV``.
+  * ``N-3`` / ``N-4`` / ``N-6`` — variable insurance contracts
+    (separate accounts of insurance companies). Map to ``INS``.
+  * ``N-5`` — small business investment company. Maps to ``INV``.
+
+Broker-dealer (``BD``) classification is NOT addressable from
+N-CEN — broker-dealers file Form ADV / FOCUS reports instead.
+That's a separate ticket; v1 stays at the N-CEN-derivable subset.
+
+Idempotent: re-running on the same accession UPSERTs in place;
+re-running with a newer accession promotes via UPSERT and
+refreshes ``fetched_at``. The downstream 13F-HR ingester reads
+this table fresh on every call so a re-classification flows
+through to ``institutional_filers.filer_type`` on the next ingest
+cycle without a backfill migration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import xml.etree.ElementTree as ET  # noqa: S405 — only used to catch ET.ParseError; SEC EDGAR is the trusted source.
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from typing import Any, Final, Literal, Protocol
+
+import psycopg
+import psycopg.rows
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Provider contract
+# ---------------------------------------------------------------------------
+
+
+class SecDocFetcher(Protocol):
+    """Subset of the SEC EDGAR provider this classifier relies on.
+
+    Same contract as the institutional / blockholder / DEF 14A
+    services — the production binding is :class:`app.providers.
+    implementations.sec_edgar.SecEdgarProvider`.
+    """
+
+    def fetch_document_text(self, absolute_url: str) -> str | None: ...
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+FilerType = Literal["ETF", "INV", "INS", "BD", "OTHER"]
+
+
+@dataclass(frozen=True)
+class NCenClassification:
+    """One parsed N-CEN classification."""
+
+    cik: str
+    investment_company_type: str  # raw SEC code: 'N-1A' / 'N-2' / 'N-3' / etc.
+    derived_filer_type: FilerType
+    accession_number: str
+    filed_at: datetime
+
+
+@dataclass(frozen=True)
+class ClassifyReport:
+    """Per-batch rollup of one classifier pass.
+
+    Counter semantics:
+
+      * ``classifications_written`` — N-CEN parsed and persisted.
+      * ``no_ncen_found`` — submissions JSON valid; no N-CEN in the
+        recent-filings array (legitimate absence).
+      * ``fetch_failures`` — upstream HTTP / JSON parse failure
+        (submissions 404, malformed body, primary_doc 404).
+      * ``parse_failures`` — primary_doc fetched but XML parse /
+        validation failed.
+      * ``crash_failures`` — unexpected per-filer exception during
+        the classify + upsert + commit block (DB error, network
+        timeout escape, etc.). The batch loop catches these so a
+        single bad filer doesn't abort the rest.
+    """
+
+    filers_seen: int
+    classifications_written: int
+    no_ncen_found: int
+    parse_failures: int
+    fetch_failures: int
+    crash_failures: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Investment-company-type → filer-type mapping
+# ---------------------------------------------------------------------------
+
+
+_INVESTMENT_COMPANY_TYPE_MAP: Final[dict[str, FilerType]] = {
+    # Open-end management company (mutual fund or ETF). Defaults to
+    # INV; the curated ETF seed list overrides for known ETF CIKs
+    # via the compose function downstream.
+    "N-1A": "INV",
+    # Closed-end fund / business development company.
+    "N-2": "INV",
+    # Variable insurance separate accounts.
+    "N-3": "INS",
+    "N-4": "INS",
+    "N-6": "INS",
+    # Small business investment company.
+    "N-5": "INV",
+}
+
+
+def _derive_filer_type(investment_company_type: str) -> FilerType:
+    """Map a raw SEC investment-company-type code to our filer-type
+    enum. Unknown codes default to ``OTHER`` so a future SEC enum
+    addition surfaces in the data without breaking the classifier.
+    """
+    return _INVESTMENT_COMPANY_TYPE_MAP.get(investment_company_type.strip(), "OTHER")
+
+
+# ---------------------------------------------------------------------------
+# Pure parser
+# ---------------------------------------------------------------------------
+
+
+def _strip_ns(tag: str) -> str:
+    if "}" in tag:
+        return tag.split("}", 1)[1]
+    return tag
+
+
+def _walk_text(root: ET.Element, name: str) -> str | None:
+    for el in root.iter():
+        if _strip_ns(el.tag) == name and el.text is not None:
+            text = el.text.strip()
+            if text:
+                return text
+    return None
+
+
+def parse_ncen_primary_doc(xml: str) -> str:
+    """Extract ``investmentCompanyType`` from an N-CEN
+    ``primary_doc.xml``. Raises ``ValueError`` when the field is
+    absent — the caller treats that as a parse failure and
+    skips the filer for this run.
+    """
+    root = ET.fromstring(xml)  # noqa: S314 — SEC EDGAR is the trusted source.
+    code = _walk_text(root, "investmentCompanyType")
+    if code is None:
+        raise ValueError("N-CEN primary_doc.xml is missing <investmentCompanyType>")
+    return code
+
+
+# ---------------------------------------------------------------------------
+# URL builders
+# ---------------------------------------------------------------------------
+
+
+_SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik}.json"
+_ARCHIVE_URL = "https://www.sec.gov/Archives/edgar/data/{cik_int}/{accn_no_dashes}/{filename}"
+
+
+def _zero_pad_cik(cik: str | int) -> str:
+    return str(int(str(cik).strip())).zfill(10)
+
+
+def _accession_no_dashes(accession_number: str) -> str:
+    return accession_number.replace("-", "")
+
+
+def _submissions_url(cik: str) -> str:
+    return _SUBMISSIONS_URL.format(cik=_zero_pad_cik(cik))
+
+
+def _archive_file_url(cik: str, accession_number: str, filename: str) -> str:
+    return _ARCHIVE_URL.format(
+        cik_int=int(_zero_pad_cik(cik)),
+        accn_no_dashes=_accession_no_dashes(accession_number),
+        filename=filename,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Submissions index walker
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _NCenAccessionRef:
+    accession_number: str
+    filed_at: datetime
+
+
+def _safe_iso_date(text: str | None) -> date | None:
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _safe_iso_datetime(text: str | None) -> datetime | None:
+    parsed = _safe_iso_date(text)
+    if parsed is None:
+        return None
+    return datetime(parsed.year, parsed.month, parsed.day, tzinfo=UTC)
+
+
+def _find_latest_ncen(payload: str) -> _NCenAccessionRef | None:
+    """Walk ``data.sec.gov/submissions/CIK{cik}.json`` and return
+    the most recent N-CEN accession.
+
+    Returns ``None`` when the payload is malformed OR when no
+    N-CEN appears in the recent-filings array. The caller treats
+    both cases identically — the filer simply has no N-CEN-derived
+    classification on this pass.
+    """
+    try:
+        data: dict[str, Any] = json.loads(payload)
+    except json.JSONDecodeError:
+        logger.warning("N-CEN classifier: submissions JSON is not valid JSON")
+        return None
+
+    filings = data.get("filings", {})
+    recent = filings.get("recent", {})
+    accessions = recent.get("accessionNumber", [])
+    forms = recent.get("form", [])
+    filing_dates = recent.get("filingDate", [])
+
+    # The submissions index orders ``recent`` newest-first, so the
+    # first N-CEN match is the latest. Defensive: also tolerate
+    # ``N-CEN/A`` amendments — same form family.
+    for i, accession in enumerate(accessions):
+        if i >= len(forms):
+            break
+        form = str(forms[i]).strip()
+        if form not in ("N-CEN", "N-CEN/A"):
+            continue
+        filed_at = _safe_iso_datetime(filing_dates[i] if i < len(filing_dates) else "")
+        if filed_at is None:
+            continue
+        return _NCenAccessionRef(
+            accession_number=str(accession),
+            filed_at=filed_at,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _list_active_filer_seeds(conn: psycopg.Connection[tuple]) -> list[str]:
+    """Same active-seeds query as the 13F-HR ingester. Inlined here
+    so :mod:`app.services.institutional_holdings` doesn't need to
+    expose its private ``_list_active_filer_seeds`` helper to a
+    second consumer."""
+    cur = conn.execute("SELECT cik FROM institutional_filer_seeds WHERE active = TRUE ORDER BY cik")
+    return [_zero_pad_cik(row[0]) for row in cur.fetchall()]
+
+
+def _upsert_classification(
+    conn: psycopg.Connection[tuple],
+    classification: NCenClassification,
+) -> None:
+    """Idempotent upsert into ``ncen_filer_classifications``."""
+    conn.execute(
+        """
+        INSERT INTO ncen_filer_classifications (
+            cik, investment_company_type, derived_filer_type,
+            accession_number, filed_at
+        ) VALUES (%(cik)s, %(ict)s, %(ft)s, %(accession)s, %(filed_at)s)
+        ON CONFLICT (cik) DO UPDATE SET
+            investment_company_type = EXCLUDED.investment_company_type,
+            derived_filer_type = EXCLUDED.derived_filer_type,
+            accession_number = EXCLUDED.accession_number,
+            filed_at = EXCLUDED.filed_at,
+            fetched_at = NOW()
+        """,
+        {
+            "cik": classification.cik,
+            "ict": classification.investment_company_type,
+            "ft": classification.derived_filer_type,
+            "accession": classification.accession_number,
+            "filed_at": classification.filed_at,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-filer driver
+# ---------------------------------------------------------------------------
+
+
+_OutcomeKind = Literal["classified", "no_ncen", "fetch_failed", "parse_failed"]
+
+
+@dataclass(frozen=True)
+class _FilerOutcome:
+    """Per-filer outcome with a structured ``kind`` so the batch
+    loop can route counters correctly without parsing error
+    strings. Codex pre-push review caught the prior version that
+    keyed on ``"fetch" in error`` substring matching, which
+    incorrectly bucketed JSON-404 outcomes as parse failures.
+    """
+
+    kind: _OutcomeKind
+    classification: NCenClassification | None
+    error: str | None
+
+
+def _classify_single_filer(
+    sec: SecDocFetcher,
+    *,
+    cik: str,
+) -> _FilerOutcome:
+    """Per-filer driver. Never raises — returns an outcome record
+    so the batch loop can continue past failures."""
+    submissions_payload = sec.fetch_document_text(_submissions_url(cik))
+    if submissions_payload is None:
+        return _FilerOutcome(
+            kind="fetch_failed",
+            classification=None,
+            error="submissions JSON 404/error",
+        )
+
+    # Distinguish malformed JSON (real upstream failure) from
+    # well-formed JSON containing no N-CEN entries (legitimate
+    # absence). _find_latest_ncen previously collapsed both into
+    # None — Codex pre-push review caught the lost signal.
+    try:
+        json.loads(submissions_payload)
+    except json.JSONDecodeError:
+        return _FilerOutcome(
+            kind="fetch_failed",
+            classification=None,
+            error="submissions JSON malformed",
+        )
+
+    ref = _find_latest_ncen(submissions_payload)
+    if ref is None:
+        # JSON parsed cleanly but no N-CEN appears in the recent
+        # filings array — common case for the curated 13F seed
+        # list, many activist funds don't file N-CEN.
+        return _FilerOutcome(kind="no_ncen", classification=None, error=None)
+
+    primary_url = _archive_file_url(cik, ref.accession_number, "primary_doc.xml")
+    primary_xml = sec.fetch_document_text(primary_url)
+    if primary_xml is None:
+        return _FilerOutcome(
+            kind="fetch_failed",
+            classification=None,
+            error=f"primary_doc.xml 404 for accession {ref.accession_number}",
+        )
+
+    try:
+        ict = parse_ncen_primary_doc(primary_xml)
+    except (ValueError, ET.ParseError) as exc:
+        return _FilerOutcome(
+            kind="parse_failed",
+            classification=None,
+            error=f"parse failed: {exc}",
+        )
+
+    return _FilerOutcome(
+        kind="classified",
+        classification=NCenClassification(
+            cik=cik,
+            investment_company_type=ict,
+            derived_filer_type=_derive_filer_type(ict),
+            accession_number=ref.accession_number,
+            filed_at=ref.filed_at,
+        ),
+        error=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public batch entry point
+# ---------------------------------------------------------------------------
+
+
+def classify_filers_via_ncen(
+    conn: psycopg.Connection[tuple],
+    sec: SecDocFetcher,
+    *,
+    ciks: list[str] | None = None,
+) -> ClassifyReport:
+    """Walk active filer seeds (or an explicit ``ciks`` list) and
+    classify each via N-CEN.
+
+    Commits per-filer so a mid-batch crash leaves a partial
+    persistent state (classifications already written stay; later
+    filers are simply not yet processed).
+    """
+    if ciks is None:
+        ciks = _list_active_filer_seeds(conn)
+    if not ciks:
+        logger.info("N-CEN classifier: no active filer seeds; nothing to do")
+        return ClassifyReport(
+            filers_seen=0,
+            classifications_written=0,
+            no_ncen_found=0,
+            parse_failures=0,
+            fetch_failures=0,
+        )
+
+    classifications_written = 0
+    no_ncen_found = 0
+    parse_failures = 0
+    fetch_failures = 0
+    crash_failures = 0
+
+    for cik in ciks:
+        cik_padded = _zero_pad_cik(cik)
+        # Per-filer crash isolation wraps the FULL block — classify
+        # + upsert + commit. A DB error during the upsert or commit
+        # must not abort the rest of the batch. Codex pre-push
+        # review caught the prior version which had only
+        # _classify_single_filer inside the try.
+        try:
+            outcome = _classify_single_filer(sec, cik=cik_padded)
+            if outcome.classification is not None:
+                _upsert_classification(conn, outcome.classification)
+                conn.commit()
+        except Exception:  # noqa: BLE001 — per-filer crash must not abort batch
+            logger.exception("N-CEN classifier: filer %s raised; continuing batch", cik_padded)
+            conn.rollback()
+            crash_failures += 1
+            continue
+
+        # Counter routing keys on the structured outcome kind, not
+        # error-string substring matching. Codex pre-push review
+        # caught the prior 'fetch' substring check that bucketed
+        # JSON-404 outcomes as parse failures.
+        if outcome.kind == "classified":
+            classifications_written += 1
+        elif outcome.kind == "no_ncen":
+            no_ncen_found += 1
+        elif outcome.kind == "fetch_failed":
+            fetch_failures += 1
+        else:  # 'parse_failed'
+            parse_failures += 1
+
+    return ClassifyReport(
+        filers_seen=len(ciks),
+        classifications_written=classifications_written,
+        no_ncen_found=no_ncen_found,
+        parse_failures=parse_failures,
+        fetch_failures=fetch_failures,
+        crash_failures=crash_failures,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Compose function — used by the 13F-HR ingester
+# ---------------------------------------------------------------------------
+
+
+def compose_filer_type(
+    conn: psycopg.Connection[tuple],
+    cik: str,
+) -> FilerType:
+    """Return the canonical filer-type for a CIK in priority order:
+
+      1. Curated ETF seed list (#742) → ``ETF``.
+      2. N-CEN classification → derived_filer_type.
+      3. Default → ``INV``.
+
+    Read by :func:`app.services.institutional_holdings.
+    classify_filer_type` on every 13F-HR upsert so the latest
+    N-CEN classification flows through automatically without a
+    backfill migration. Read-only — never writes.
+    """
+    cik_padded = _zero_pad_cik(cik)
+
+    # 1. ETF curated list — highest precedence.
+    cur = conn.execute(
+        "SELECT 1 FROM etf_filer_cik_seeds WHERE cik = %s AND active = TRUE LIMIT 1",
+        (cik_padded,),
+    )
+    if cur.fetchone() is not None:
+        return "ETF"
+
+    # 2. N-CEN classification.
+    cur = conn.execute(
+        "SELECT derived_filer_type FROM ncen_filer_classifications WHERE cik = %s LIMIT 1",
+        (cik_padded,),
+    )
+    row = cur.fetchone()
+    if row is not None:
+        return row[0]  # type: ignore[no-any-return]
+
+    # 3. Default.
+    return "INV"
+
+
+# ---------------------------------------------------------------------------
+# Reader (exposed for ad-hoc admin queries)
+# ---------------------------------------------------------------------------
+
+
+def iter_classifications(
+    conn: psycopg.Connection[tuple],
+    *,
+    derived_filer_type: FilerType | None = None,
+    limit: int = 100,
+) -> Iterator[dict[str, Any]]:
+    """Yield N-CEN classification rows in fetched_at-DESC order.
+
+    ``derived_filer_type`` filter scopes to one bucket (e.g.
+    ``"INS"`` to audit insurance-product mappings); ``None``
+    returns all.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT cik, investment_company_type, derived_filer_type,
+                   accession_number, filed_at, fetched_at
+            FROM ncen_filer_classifications
+            WHERE (%(ft)s::TEXT IS NULL OR derived_filer_type = %(ft)s::TEXT)
+            ORDER BY fetched_at DESC, cik DESC
+            LIMIT %(limit)s
+            """,
+            {"ft": derived_filer_type, "limit": limit},
+        )
+        for row in cur.fetchall():
+            yield dict(row)

--- a/sql/100_ncen_filer_classifications.sql
+++ b/sql/100_ncen_filer_classifications.sql
@@ -1,0 +1,62 @@
+-- 100_ncen_filer_classifications.sql
+--
+-- Issue #782 — derive ``institutional_filers.filer_type`` beyond
+-- the curated ETF list (#742) by ingesting Form N-CEN annual fund
+-- census filings. Each fund's N-CEN carries an
+-- ``investmentCompanyType`` field (``N-1A`` / ``N-2`` / ``N-3`` /
+-- ``N-4`` / ``N-5`` / ``N-6``) that maps cleanly to our enum:
+--
+--   * ``N-1A`` (open-end management company — mutual fund or ETF)
+--     -> ``INV`` by default; the curated ETF seed list overrides
+--     this when the CIK is on the ETF list.
+--   * ``N-2`` (closed-end fund / BDC) -> ``INV``.
+--   * ``N-3`` / ``N-4`` / ``N-6`` (variable insurance contracts)
+--     -> ``INS``.
+--   * ``N-5`` (small business investment company) -> ``INV``.
+--
+-- Broker-dealer (``BD``) classification is NOT addressable from
+-- N-CEN — broker-dealers file Form ADV / FOCUS reports instead.
+-- That's a separate ticket; v1 stays at the N-CEN-derivable
+-- subset.
+--
+-- Schema decisions:
+--
+--   * Identity / dedupe = ``cik`` PK. Each filer has at most one
+--     active N-CEN classification at a time; re-running the
+--     classifier on a newer N-CEN UPSERTs in place.
+--   * ``investment_company_type`` stores the raw SEC code
+--     (``N-1A``, ``N-2``, etc.) for audit; the derived
+--     ``filer_type`` is the operator-facing enum value applied to
+--     ``institutional_filers``.
+--   * ``derived_filer_type`` mirrors the
+--     ``institutional_filers.filer_type`` CHECK enum so the
+--     compose function in :mod:`app.services.institutional_holdings`
+--     can read this column and map directly without a translation
+--     step.
+--   * ``accession_number`` + ``filed_at`` track the N-CEN that
+--     produced this classification — re-running the classifier
+--     against a newer accession (e.g. issuer changed structure)
+--     promotes the row in place.
+--
+-- _PLANNER_TABLES in tests/fixtures/ebull_test_db.py is updated
+-- in the same PR per the prevention-log entry.
+
+CREATE TABLE IF NOT EXISTS ncen_filer_classifications (
+    cik                       TEXT PRIMARY KEY,
+    investment_company_type   TEXT NOT NULL,
+    derived_filer_type        TEXT NOT NULL
+        CHECK (derived_filer_type IN ('ETF', 'INV', 'INS', 'BD', 'OTHER')),
+    accession_number          TEXT NOT NULL,
+    filed_at                  TIMESTAMPTZ NOT NULL,
+    fetched_at                TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Hot path for the per-classifier-run reader: walk the most
+-- recently classified filers first.
+CREATE INDEX IF NOT EXISTS idx_ncen_filer_classifications_fetched_at
+    ON ncen_filer_classifications (fetched_at DESC);
+
+-- Per-derived-type scan for the ops monitor's "how many INS
+-- filers have we classified" coverage chip.
+CREATE INDEX IF NOT EXISTS idx_ncen_filer_classifications_filer_type
+    ON ncen_filer_classifications (derived_filer_type);

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -115,6 +115,10 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "institutional_filers",
     "institutional_filer_seeds",
     "etf_filer_cik_seeds",
+    # #782 — N-CEN-derived filer-type classifications. No FK to
+    # other planner tables; PK is CIK. Listed here so each test
+    # starts with a clean classification state.
+    "ncen_filer_classifications",
     # #766 — 13D/G blockholders. Child-to-parent: blockholder_filings
     # FKs into blockholder_filers AND instruments. The instrument row
     # truncation further down would cascade, but listing them

--- a/tests/test_fetch_document_text_callers.py
+++ b/tests/test_fetch_document_text_callers.py
@@ -39,6 +39,7 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         #   insider_form3_ingest    — Form 3 initial-holdings XML (#768)
         #   blockholders        — Schedule 13D / 13G primary_doc XML (#766)
         #   def14a_ingest       — DEF 14A beneficial-ownership table HTML (#769)
+        #   ncen_classifier     — N-CEN annual fund-census XML (#782)
         "app/services/business_summary.py",
         "app/services/dividend_calendar.py",
         "app/services/insider_transactions.py",
@@ -47,6 +48,7 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         "app/services/institutional_holdings.py",
         "app/services/blockholders.py",
         "app/services/def14a_ingest.py",
+        "app/services/ncen_classifier.py",
         # Provider implementation owns the method itself.
         "app/providers/implementations/sec_edgar.py",
         # Bounded-concurrency wrapper (#726). Calls the method via a
@@ -70,6 +72,7 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         "tests/test_institutional_holdings_ingester.py",
         "tests/test_blockholders_ingester.py",
         "tests/test_def14a_ingest.py",
+        "tests/test_ncen_classifier.py",
         # This guard file itself references the method name in its
         # contract sentence.
         "tests/test_fetch_document_text_callers.py",

--- a/tests/test_ncen_classifier.py
+++ b/tests/test_ncen_classifier.py
@@ -1,0 +1,558 @@
+"""Integration tests for the N-CEN filer-type classifier (#782)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services.institutional_holdings import classify_filer_type, seed_etf_filer, seed_filer
+from app.services.ncen_classifier import (
+    NCenClassification,
+    _derive_filer_type,
+    classify_filers_via_ncen,
+    compose_filer_type,
+    iter_classifications,
+    parse_ncen_primary_doc,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+_NCEN_NS = "http://www.sec.gov/edgar/ncen"
+
+
+def _ncen_xml(
+    *,
+    cik: str = "0001234567",
+    investment_company_type: str = "N-1A",
+    registrant_name: str = "TEST FUND",
+) -> str:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="{_NCEN_NS}">
+  <headerData>
+    <submissionType>N-CEN</submissionType>
+    <filerInfo>
+      <filer>
+        <issuerCredentials>
+          <cik>{cik}</cik>
+        </issuerCredentials>
+      </filer>
+      <investmentCompanyType>{investment_company_type}</investmentCompanyType>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <registrantInfo>
+      <registrantFullName>{registrant_name}</registrantFullName>
+      <registrantCik>{cik}</registrantCik>
+    </registrantInfo>
+  </formData>
+</edgarSubmission>
+"""
+
+
+def _submissions_json(*, accessions: list[tuple[str, str, str]]) -> str:
+    """Same shape as data.sec.gov/submissions/CIK{cik}.json. Each
+    tuple is ``(accession_number, form, filing_date)``."""
+    return json.dumps(
+        {
+            "filings": {
+                "recent": {
+                    "accessionNumber": [a[0] for a in accessions],
+                    "form": [a[1] for a in accessions],
+                    "filingDate": [a[2] for a in accessions],
+                },
+                "files": [],
+            }
+        }
+    )
+
+
+class _InMemoryFetcher:
+    def __init__(self, payloads: dict[str, str | None]) -> None:
+        self._payloads = payloads
+        self.calls: list[str] = []
+
+    def fetch_document_text(self, absolute_url: str) -> str | None:
+        self.calls.append(absolute_url)
+        return self._payloads.get(absolute_url)
+
+
+def _archive_url(cik: str, accession: str, filename: str) -> str:
+    return f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/{accession.replace('-', '')}/{filename}"
+
+
+def _seed_classification(
+    conn: psycopg.Connection[tuple],
+    *,
+    cik: str,
+    investment_company_type: str = "N-1A",
+    derived_filer_type: str = "INV",
+    accession_number: str = "ACC-1",
+    filed_at: datetime | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO ncen_filer_classifications
+            (cik, investment_company_type, derived_filer_type,
+             accession_number, filed_at)
+        VALUES (%s, %s, %s, %s, %s)
+        """,
+        (
+            cik,
+            investment_company_type,
+            derived_filer_type,
+            accession_number,
+            filed_at or datetime(2025, 11, 6, tzinfo=UTC),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure parser + mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestParser:
+    def test_extracts_investment_company_type(self) -> None:
+        assert parse_ncen_primary_doc(_ncen_xml(investment_company_type="N-1A")) == "N-1A"
+        assert parse_ncen_primary_doc(_ncen_xml(investment_company_type="N-2")) == "N-2"
+        assert parse_ncen_primary_doc(_ncen_xml(investment_company_type="N-3")) == "N-3"
+
+    def test_missing_field_raises(self) -> None:
+        broken = _ncen_xml().replace("<investmentCompanyType>N-1A</investmentCompanyType>", "")
+        with pytest.raises(ValueError, match="investmentCompanyType"):
+            parse_ncen_primary_doc(broken)
+
+
+class TestDeriveFilerType:
+    """Pin the SEC investment-company-type → filer-type mapping."""
+
+    def test_n1a_maps_to_inv(self) -> None:
+        assert _derive_filer_type("N-1A") == "INV"
+
+    def test_n2_maps_to_inv(self) -> None:
+        assert _derive_filer_type("N-2") == "INV"
+
+    def test_variable_insurance_codes_map_to_ins(self) -> None:
+        assert _derive_filer_type("N-3") == "INS"
+        assert _derive_filer_type("N-4") == "INS"
+        assert _derive_filer_type("N-6") == "INS"
+
+    def test_n5_sbic_maps_to_inv(self) -> None:
+        assert _derive_filer_type("N-5") == "INV"
+
+    def test_unknown_code_maps_to_other(self) -> None:
+        # Unknown codes (e.g. a future SEC enum addition) default
+        # to OTHER so the data surfaces visibly without breaking
+        # the classifier.
+        assert _derive_filer_type("N-99") == "OTHER"
+        assert _derive_filer_type("") == "OTHER"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end batch classify
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyBatch:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        seed_filer(conn, cik="0001234567", label="MUTUAL FUND")
+        seed_filer(conn, cik="0007654321", label="VARIABLE INSURANCE")
+        conn.commit()
+        return conn
+
+    def test_classifies_n1a_as_inv(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        accession = "0001234567-25-000001"
+        cik = "0001234567"
+        fetcher = _InMemoryFetcher(
+            {
+                f"https://data.sec.gov/submissions/CIK{cik}.json": _submissions_json(
+                    accessions=[(accession, "N-CEN", "2025-11-14")]
+                ),
+                _archive_url(cik, accession, "primary_doc.xml"): _ncen_xml(cik=cik, investment_company_type="N-1A"),
+            }
+        )
+
+        report = classify_filers_via_ncen(conn, fetcher, ciks=[cik])
+
+        assert report.classifications_written == 1
+        assert report.no_ncen_found == 0
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT investment_company_type, derived_filer_type FROM ncen_filer_classifications WHERE cik = %s",
+                (cik,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["investment_company_type"] == "N-1A"
+        assert row["derived_filer_type"] == "INV"
+
+    def test_classifies_n3_as_ins(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        cik = "0007654321"
+        accession = "0007654321-25-000001"
+        fetcher = _InMemoryFetcher(
+            {
+                f"https://data.sec.gov/submissions/CIK{cik}.json": _submissions_json(
+                    accessions=[(accession, "N-CEN", "2025-11-14")]
+                ),
+                _archive_url(cik, accession, "primary_doc.xml"): _ncen_xml(cik=cik, investment_company_type="N-3"),
+            }
+        )
+
+        report = classify_filers_via_ncen(conn, fetcher, ciks=[cik])
+        assert report.classifications_written == 1
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT derived_filer_type FROM ncen_filer_classifications WHERE cik = %s",
+                (cik,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["derived_filer_type"] == "INS"
+
+    def test_no_ncen_in_submissions_is_counted_separately(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Filer with only 13F filings (no N-CEN) is not a failure
+        — the no_ncen_found counter increments and no row is
+        written."""
+        conn = _setup
+        cik = "0001234567"
+        fetcher = _InMemoryFetcher(
+            {
+                f"https://data.sec.gov/submissions/CIK{cik}.json": _submissions_json(
+                    accessions=[("0001234567-25-000010", "13F-HR", "2025-11-06")]
+                ),
+            }
+        )
+
+        report = classify_filers_via_ncen(conn, fetcher, ciks=[cik])
+        assert report.classifications_written == 0
+        assert report.no_ncen_found == 1
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM ncen_filer_classifications")
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+
+    def test_picks_latest_ncen(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """When the submissions index has multiple N-CEN filings,
+        the classifier picks the first (newest) match. The
+        recent-filings array is ordered newest-first by SEC
+        convention."""
+        conn = _setup
+        cik = "0001234567"
+        latest_accession = "0001234567-25-000050"
+        fetcher = _InMemoryFetcher(
+            {
+                f"https://data.sec.gov/submissions/CIK{cik}.json": _submissions_json(
+                    accessions=[
+                        (latest_accession, "N-CEN", "2025-11-14"),
+                        ("0001234567-24-000050", "N-CEN", "2024-11-14"),
+                    ]
+                ),
+                _archive_url(cik, latest_accession, "primary_doc.xml"): _ncen_xml(
+                    cik=cik, investment_company_type="N-2"
+                ),
+            }
+        )
+
+        classify_filers_via_ncen(conn, fetcher, ciks=[cik])
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT accession_number, derived_filer_type FROM ncen_filer_classifications WHERE cik = %s",
+                (cik,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["accession_number"] == latest_accession
+
+    def test_re_run_upserts_in_place(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Two passes on the same N-CEN UPSERT — one row in the
+        table, fetched_at refreshed."""
+        conn = _setup
+        cik = "0001234567"
+        accession = "0001234567-25-000001"
+        fetcher = _InMemoryFetcher(
+            {
+                f"https://data.sec.gov/submissions/CIK{cik}.json": _submissions_json(
+                    accessions=[(accession, "N-CEN", "2025-11-14")]
+                ),
+                _archive_url(cik, accession, "primary_doc.xml"): _ncen_xml(cik=cik),
+            }
+        )
+
+        first = classify_filers_via_ncen(conn, fetcher, ciks=[cik])
+        assert first.classifications_written == 1
+
+        second = classify_filers_via_ncen(conn, fetcher, ciks=[cik])
+        assert second.classifications_written == 1
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM ncen_filer_classifications WHERE cik = %s", (cik,))
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 1
+
+    def test_malformed_submissions_json_counts_as_fetch_failure(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """A 200-OK garbage submissions body must surface as a
+        fetch_failure rather than silently no-op into no_ncen.
+        Codex pre-push review caught _find_latest_ncen collapsing
+        malformed JSON into a None ref (same bucket as 'no N-CEN
+        on file')."""
+        conn = _setup
+        cik = "0001234567"
+        fetcher = _InMemoryFetcher(
+            {
+                f"https://data.sec.gov/submissions/CIK{cik}.json": "<html>500 error</html>",
+            }
+        )
+
+        report = classify_filers_via_ncen(conn, fetcher, ciks=[cik])
+        assert report.classifications_written == 0
+        assert report.no_ncen_found == 0
+        assert report.fetch_failures == 1
+        assert report.parse_failures == 0
+
+    def test_primary_doc_404_counts_as_fetch_failure(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """A submissions index that names an N-CEN whose primary
+        doc 404s is a fetch_failure, not a parse_failure. Codex
+        pre-push review caught the prior 'fetch' substring check
+        bucketing this as a parse failure."""
+        conn = _setup
+        cik = "0001234567"
+        fetcher = _InMemoryFetcher(
+            {
+                f"https://data.sec.gov/submissions/CIK{cik}.json": _submissions_json(
+                    accessions=[("0001234567-25-000001", "N-CEN", "2025-11-14")]
+                ),
+                # No payload for the primary doc URL — fetch returns None.
+            }
+        )
+
+        report = classify_filers_via_ncen(conn, fetcher, ciks=[cik])
+        assert report.fetch_failures == 1
+        assert report.parse_failures == 0
+
+    def test_upsert_failure_does_not_abort_batch(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A DB error during the upsert / commit for one filer must
+        not abort the batch — the next filer continues. Codex
+        pre-push review caught the prior code that only wrapped
+        _classify_single_filer in try/except."""
+        from typing import Any as _Any
+
+        from app.services import ncen_classifier as ncen_mod
+
+        conn = ebull_test_conn
+        seed_filer(conn, cik="0000000001", label="A")
+        seed_filer(conn, cik="0000000002", label="B")
+        conn.commit()
+
+        accession_a = "0000000001-25-000001"
+        accession_b = "0000000002-25-000001"
+        fetcher = _InMemoryFetcher(
+            {
+                "https://data.sec.gov/submissions/CIK0000000001.json": _submissions_json(
+                    accessions=[(accession_a, "N-CEN", "2025-11-14")]
+                ),
+                "https://data.sec.gov/submissions/CIK0000000002.json": _submissions_json(
+                    accessions=[(accession_b, "N-CEN", "2025-11-14")]
+                ),
+                _archive_url("0000000001", accession_a, "primary_doc.xml"): _ncen_xml(cik="0000000001"),
+                _archive_url("0000000002", accession_b, "primary_doc.xml"): _ncen_xml(cik="0000000002"),
+            }
+        )
+
+        original_upsert = ncen_mod._upsert_classification
+        calls: list[str] = []
+
+        def _failing_upsert(c: _Any, classification: NCenClassification) -> None:
+            calls.append(classification.cik)
+            if classification.cik == "0000000001":
+                raise RuntimeError("simulated DB error")
+            original_upsert(c, classification)
+
+        ncen_mod._upsert_classification = _failing_upsert  # type: ignore[assignment]
+        try:
+            report = classify_filers_via_ncen(conn, fetcher, ciks=["0000000001", "0000000002"])
+        finally:
+            ncen_mod._upsert_classification = original_upsert  # type: ignore[assignment]
+
+        # Both filers were attempted — the failure on filer A did
+        # not abort the batch.
+        assert calls == ["0000000001", "0000000002"]
+        # Filer B succeeded despite filer A's crash.
+        assert report.classifications_written == 1
+        assert report.crash_failures == 1
+        assert report.fetch_failures == 0
+        assert report.parse_failures == 0
+
+        # Filer B's row landed.
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM ncen_filer_classifications WHERE cik = %s", ("0000000002",))
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 1
+
+    def test_parse_failure_counted_separately(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        cik = "0001234567"
+        accession = "0001234567-25-000001"
+        broken_xml = _ncen_xml(cik=cik).replace("<investmentCompanyType>N-1A</investmentCompanyType>", "")
+        fetcher = _InMemoryFetcher(
+            {
+                f"https://data.sec.gov/submissions/CIK{cik}.json": _submissions_json(
+                    accessions=[(accession, "N-CEN", "2025-11-14")]
+                ),
+                _archive_url(cik, accession, "primary_doc.xml"): broken_xml,
+            }
+        )
+
+        report = classify_filers_via_ncen(conn, fetcher, ciks=[cik])
+        assert report.classifications_written == 0
+        assert report.parse_failures == 1
+
+
+# ---------------------------------------------------------------------------
+# Compose function — priority chain
+# ---------------------------------------------------------------------------
+
+
+class TestComposeFilerType:
+    def test_etf_seed_overrides_ncen(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Curated ETF list always wins, even when N-CEN says
+        N-1A → INV. (Vanguard ETFs are open-end mutual funds at
+        the registrant level but the CIK-specific share class is
+        an ETF — the curated list disambiguates.)"""
+        conn = ebull_test_conn
+        cik = "0001234567"
+        seed_filer(conn, cik=cik, label="VANGUARD ETF")
+        seed_etf_filer(conn, cik=cik, label="Vanguard S&P 500 ETF")
+        _seed_classification(conn, cik=cik, investment_company_type="N-1A", derived_filer_type="INV")
+        conn.commit()
+
+        assert compose_filer_type(conn, cik) == "ETF"
+
+    def test_ncen_classification_overrides_default(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """N-CEN-derived INS beats the INV default."""
+        conn = ebull_test_conn
+        cik = "0007654321"
+        seed_filer(conn, cik=cik, label="VARIABLE INSURANCE")
+        _seed_classification(conn, cik=cik, investment_company_type="N-3", derived_filer_type="INS")
+        conn.commit()
+
+        assert compose_filer_type(conn, cik) == "INS"
+
+    def test_no_classification_returns_inv_default(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        cik = "0009999999"
+        seed_filer(conn, cik=cik, label="UNKNOWN FILER")
+        conn.commit()
+
+        assert compose_filer_type(conn, cik) == "INV"
+
+    def test_classify_filer_type_delegates_to_compose(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Sanity check: ``classify_filer_type`` (the public name
+        called by the 13F-HR ingester) returns the same answer as
+        ``compose_filer_type`` directly."""
+        conn = ebull_test_conn
+        cik = "0001234567"
+        seed_filer(conn, cik=cik, label="TEST")
+        _seed_classification(conn, cik=cik, investment_company_type="N-3", derived_filer_type="INS")
+        conn.commit()
+
+        assert classify_filer_type(conn, cik) == "INS"
+        assert classify_filer_type(conn, cik) == compose_filer_type(conn, cik)
+
+
+# ---------------------------------------------------------------------------
+# Reader
+# ---------------------------------------------------------------------------
+
+
+class TestIterClassifications:
+    def test_filter_by_derived_filer_type(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        seed_filer(conn, cik="0000000001", label="A")
+        seed_filer(conn, cik="0000000002", label="B")
+        _seed_classification(
+            conn,
+            cik="0000000001",
+            investment_company_type="N-1A",
+            derived_filer_type="INV",
+        )
+        _seed_classification(
+            conn,
+            cik="0000000002",
+            investment_company_type="N-3",
+            derived_filer_type="INS",
+        )
+        conn.commit()
+
+        ins_only = list(iter_classifications(conn, derived_filer_type="INS"))
+        assert len(ins_only) == 1
+        assert ins_only[0]["cik"] == "0000000002"
+
+        all_rows = list(iter_classifications(conn))
+        assert len(all_rows) == 2


### PR DESCRIPTION
## What

Auto-classifies ``institutional_filers.filer_type`` beyond the curated ETF seed list (#742) by ingesting Form N-CEN annual fund-census filings.

- ``sql/100_ncen_filer_classifications.sql`` — new table for N-CEN-derived filer-type per CIK
- ``app/services/ncen_classifier.py`` — parser, batch classifier, priority-chain compose function
- ``app/services/institutional_holdings.py`` — modified ``classify_filer_type`` to delegate to ``compose_filer_type``
- ``tests/test_ncen_classifier.py`` — 21 tests

Closes #782.

## Why

13F-HR ingest (#730) defaults non-ETF filers to ``INV``. With this PR, variable insurance separate accounts (Form N-3/N-4/N-6) auto-classify as ``INS``; closed-end funds and BDCs (N-2) and SBICs (N-5) confirm as ``INV``. Operator-facing filer-type chip splits insurance vs institutions correctly without curated seed-list maintenance for the INS bucket.

## Mapping

| N-CEN ``investmentCompanyType`` | Derived ``filer_type`` | Reasoning |
|---|---|---|
| N-1A | INV (curated ETF list overrides) | Open-end mutual fund or ETF |
| N-2 | INV | Closed-end fund / BDC |
| N-3, N-4, N-6 | INS | Variable insurance separate accounts |
| N-5 | INV | SBIC |
| (unknown code) | OTHER | Loud surfacing for future SEC enum additions |

Broker-dealer (``BD``) classification stays out of scope — that's Form ADV / FOCUS territory; separate ticket.

## Priority chain

``compose_filer_type`` evaluates in order:
1. Curated ETF seed list (``etf_filer_cik_seeds``) → ``ETF``
2. N-CEN classification (``ncen_filer_classifications``) → derived value
3. Default → ``INV``

## Test plan

- [x] ``uv run ruff check / format / pyright`` — clean
- [x] ``uv run pytest tests/smoke + tests/test_ncen_classifier.py + tests/test_institutional_holdings_ingester.py`` — 42 pass
- [x] Codex pre-push review — clean after 1 round of fixes (3 findings + 1 nit)

## Codex pre-push findings (all addressed)

1. **High** — batch crash isolation only wrapped ``_classify_single_filer``; a DB error during upsert/commit aborted the whole batch. Try/except now wraps the full per-filer block including ``conn.rollback`` on exception. New test ``test_upsert_failure_does_not_abort_batch`` monkey-patches the upsert to fail.
2. **Medium** — counter routing used ``"fetch" in error_string`` substring matching, mis-bucketing primary-doc 404 outcomes as parse failures. Replaced with a structured ``_FilerOutcome.kind`` literal enum.
3. **Medium** — malformed submissions JSON silently bucketed as ``no_ncen`` (legitimate absence). ``_classify_single_filer`` now distinguishes ``JSONDecodeError`` (fetch_failed) from valid-empty-recent.
4. **Nit** — generic per-filer crash incremented ``fetch_failures``; added a dedicated ``crash_failures`` counter so the field name matches the semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)