### PR TITLE
chore: drop State Street from ETF override list (5-category render)

### DIFF
--- a/scripts/seed_holder_coverage.py
+++ b/scripts/seed_holder_coverage.py
@@ -95,14 +95,23 @@ _INSTITUTIONAL_SEEDS: list[tuple[str, str]] = [
     ("0000866787", "Wellington Management Group LLP"),
 ]
 
-# CIKs from above to also tag as ETFs. Vanguard, BlackRock, and
-# State Street are the three primary US ETF issuers; Geode Capital
-# Management runs the index-fund engine behind Fidelity's index ETFs
-# and is treated as ETF-flavoured for the operator-facing chip.
+# CIKs from above to also tag as ETFs. Two issuers are clearly
+# pure-ETF operationally: Vanguard's CIK files most of its ETFs
+# under one umbrella, BlackRock's iShares CIK is the dedicated
+# ETF-issuer entity, and Geode runs Fidelity's passive-index
+# franchise so its 13F holdings track the ETF basket.
+#
+# State Street (CIK 0000093751) is deliberately NOT tagged ETF
+# even though it's the SPDR sponsor — its 13F-HR aggregates the
+# whole institutional asset-management business, and tagging it
+# ETF would route every State-Street-held position into the ETF
+# bucket rather than the Institutions bucket on the ownership
+# card. Operators who want the SPDR-only slice can refine via
+# fund-level CIKs (each SPDR series has its own CIK) in a
+# follow-up curation pass.
 _ETF_OVERRIDES: list[tuple[str, str]] = [
     ("0000102909", "Vanguard ETF franchise"),
     ("0001364742", "iShares (BlackRock) ETF franchise"),
-    ("0000093751", "SPDR (State Street) ETF franchise"),
     ("0001029160", "Geode Capital (Fidelity index-fund engine)"),
 ]
 


### PR DESCRIPTION
## What

Removes State Street (CIK 0000093751) from the bootstrap script's ETF override list.

## Why

Live-data validation after #785 showed State Street's 13F-HR aggregates the whole institutional asset-management business, not just the SPDR franchise. Tagging it as ETF routed AAPL's 604M State-Street-held shares into the ETFs bucket, leaving the Institutions wedge empty on every instrument State Street holds.

After this change two instruments render all 5 ownership-card categories end-to-end:

| Symbol | Inst | ETFs | Blockholders | Insiders | Treasury |
|--------|------|------|--------------|----------|----------|
| **RPD** | 1.85M | 135K | 1.50M | 26 | 570K |
| **JHG** | 4.41M | 997K | 63.7M | 27 | 46K |

Operator can navigate to ``/instrument/RPD`` or ``/instrument/JHG`` to confirm the 5-category sunburst.

## Test plan

- [x] ``uv run ruff check .`` — clean
- [x] Live API verified: ``GET /instruments/RPD/institutional-holdings`` returns ``inst=1.85M etf=135K`` (post-untag); previously was ``inst=0 etf=135K``
- [x] ``GET /instruments/AAPL/institutional-holdings`` returns ``inst=604M etf=416K``; previously ``inst=0 etf=604M``

🤖 Generated with [Claude Code](https://claude.com/claude-code)