### PR TITLE
feat(#789,#794): ownership rollup Tier 0 + CIK history schema (Batch 1 of #788)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -35,8 +35,10 @@ from pydantic import BaseModel
 from app.api.auth import require_session_or_service_token
 from app.config import settings
 from app.db import get_conn
+from app.db.snapshot import snapshot_read
 from app.providers.implementations.etoro import EtoroMarketDataProvider
 from app.providers.market_data import IntradayInterval
+from app.services import ownership_rollup
 from app.services.broker_credentials import (
     CredentialNotFound,
     load_credential_for_provider_use,
@@ -3140,3 +3142,231 @@ def get_instrument_blockholders(
         totals=totals,
         blockholders=blockholders,
     )
+
+
+# ---------------------------------------------------------------------------
+# Cross-channel deduped ownership rollup — Tier 0 (#789, parent #788)
+# ---------------------------------------------------------------------------
+
+
+class _DroppedSourceModel(BaseModel):
+    source: Literal["form4", "form3", "13d", "13g", "def14a", "13f"]
+    accession_number: str
+    shares: Decimal
+    as_of_date: date | None
+
+
+class _HolderModel(BaseModel):
+    filer_cik: str | None
+    filer_name: str
+    shares: Decimal
+    pct_outstanding: Decimal
+    winning_source: Literal["form4", "form3", "13d", "13g", "def14a", "13f"]
+    winning_accession: str
+    as_of_date: date | None
+    filer_type: str | None
+    dropped_sources: list[_DroppedSourceModel]
+
+
+class _SliceModel(BaseModel):
+    category: Literal["insiders", "blockholders", "institutions", "etfs", "def14a_unmatched"]
+    label: str
+    total_shares: Decimal
+    pct_outstanding: Decimal
+    filer_count: int
+    dominant_source: Literal["form4", "form3", "13d", "13g", "def14a", "13f"] | None
+    holders: list[_HolderModel]
+
+
+class _ResidualModel(BaseModel):
+    shares: Decimal
+    pct_outstanding: Decimal
+    label: str
+    tooltip: str
+    oversubscribed: bool
+
+
+class _CategoryCoverageModel(BaseModel):
+    known_filers: int
+    estimated_universe: int | None
+    pct_universe: Decimal | None
+    state: Literal["no_data", "red", "unknown_universe", "amber", "green"]
+
+
+class _CoverageModel(BaseModel):
+    state: Literal["no_data", "red", "unknown_universe", "amber", "green"]
+    categories: dict[str, _CategoryCoverageModel]
+
+
+class _ConcentrationModel(BaseModel):
+    pct_outstanding_known: Decimal
+    info_chip: str
+
+
+class _BannerModel(BaseModel):
+    state: Literal["no_data", "red", "unknown_universe", "amber", "green"]
+    variant: Literal["error", "warning", "info", "success"]
+    headline: str
+    body: str
+
+
+class _SharesOutstandingSourceModel(BaseModel):
+    accession_number: str | None
+    concept: str | None
+    form_type: str | None
+
+
+class OwnershipRollupResponse(BaseModel):
+    """Cross-channel deduped ownership snapshot (#789).
+
+    The single denominator is ``shares_outstanding`` (XBRL DEI).
+    Treasury renders as an additive top wedge — not part of the
+    denominator, not deduped against. The ``residual`` is the
+    explicit ``Public / unattributed`` block; ``coverage`` drives the
+    banner state machine via universe coverage (NOT float
+    concentration); ``concentration`` is shown separately as an info
+    chip. See ``docs/superpowers/specs/2026-05-03-ownership-tier0-and-cik-history-design.md``
+    for the contract."""
+
+    symbol: str
+    instrument_id: int
+    shares_outstanding: Decimal | None
+    shares_outstanding_as_of: date | None
+    shares_outstanding_source: _SharesOutstandingSourceModel
+    treasury_shares: Decimal | None
+    treasury_as_of: date | None
+    slices: list[_SliceModel]
+    residual: _ResidualModel
+    concentration: _ConcentrationModel
+    coverage: _CoverageModel
+    banner: _BannerModel
+    computed_at: datetime
+
+
+def _rollup_to_response(
+    rollup: ownership_rollup.OwnershipRollup,
+) -> OwnershipRollupResponse:
+    return OwnershipRollupResponse(
+        symbol=rollup.symbol,
+        instrument_id=rollup.instrument_id,
+        shares_outstanding=rollup.shares_outstanding,
+        shares_outstanding_as_of=rollup.shares_outstanding_as_of,
+        shares_outstanding_source=_SharesOutstandingSourceModel(
+            accession_number=rollup.shares_outstanding_source.accession_number,
+            concept=rollup.shares_outstanding_source.concept,
+            form_type=rollup.shares_outstanding_source.form_type,
+        ),
+        treasury_shares=rollup.treasury_shares,
+        treasury_as_of=rollup.treasury_as_of,
+        slices=[
+            _SliceModel(
+                category=s.category,
+                label=s.label,
+                total_shares=s.total_shares,
+                pct_outstanding=s.pct_outstanding,
+                filer_count=s.filer_count,
+                dominant_source=s.dominant_source,
+                holders=[
+                    _HolderModel(
+                        filer_cik=h.filer_cik,
+                        filer_name=h.filer_name,
+                        shares=h.shares,
+                        pct_outstanding=h.pct_outstanding,
+                        winning_source=h.winning_source,
+                        winning_accession=h.winning_accession,
+                        as_of_date=h.as_of_date,
+                        filer_type=h.filer_type,
+                        dropped_sources=[
+                            _DroppedSourceModel(
+                                source=d.source,
+                                accession_number=d.accession_number,
+                                shares=d.shares,
+                                as_of_date=d.as_of_date,
+                            )
+                            for d in h.dropped_sources
+                        ],
+                    )
+                    for h in s.holders
+                ],
+            )
+            for s in rollup.slices
+        ],
+        residual=_ResidualModel(
+            shares=rollup.residual.shares,
+            pct_outstanding=rollup.residual.pct_outstanding,
+            label=rollup.residual.label,
+            tooltip=rollup.residual.tooltip,
+            oversubscribed=rollup.residual.oversubscribed,
+        ),
+        concentration=_ConcentrationModel(
+            pct_outstanding_known=rollup.concentration.pct_outstanding_known,
+            info_chip=rollup.concentration.info_chip,
+        ),
+        coverage=_CoverageModel(
+            state=rollup.coverage.state,
+            categories={
+                k: _CategoryCoverageModel(
+                    known_filers=c.known_filers,
+                    estimated_universe=c.estimated_universe,
+                    pct_universe=c.pct_universe,
+                    state=c.state,
+                )
+                for k, c in rollup.coverage.categories.items()
+            },
+        ),
+        banner=_BannerModel(
+            state=rollup.banner.state,
+            variant=rollup.banner.variant,
+            headline=rollup.banner.headline,
+            body=rollup.banner.body,
+        ),
+        computed_at=rollup.computed_at,
+    )
+
+
+@router.get(
+    "/{symbol}/ownership-rollup",
+    response_model=OwnershipRollupResponse,
+)
+def get_instrument_ownership_rollup(
+    symbol: str,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> OwnershipRollupResponse:
+    """Cross-channel deduped ownership rollup. Tier 0 of #788.
+
+    Reads run inside one ``snapshot_read`` block so the per-slice
+    totals, residual, and coverage banner all reconcile against a
+    single REPEATABLE READ snapshot. Codex spec review caught a
+    prior anti-pattern that would have produced a SAVEPOINT instead
+    of a fresh snapshot on the pooled connection.
+
+    Empty / pre-ingest state: ``slices=[]``, banner state = either
+    ``no_data`` (no XBRL outstanding) or ``unknown_universe``
+    (outstanding present but no per-category universe estimates yet).
+    Both render 200 OK with the appropriate banner. 404 is reserved
+    for unknown symbols.
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with snapshot_read(conn):
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT instrument_id, symbol FROM instruments
+                WHERE UPPER(symbol) = %(s)s
+                ORDER BY is_primary_listing DESC, instrument_id ASC
+                LIMIT 1
+                """,
+                {"s": symbol_clean},
+            )
+            inst_row = cur.fetchone()
+        if inst_row is None:
+            raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+        rollup = ownership_rollup.get_ownership_rollup(
+            conn,
+            symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+            instrument_id=int(inst_row["instrument_id"]),  # type: ignore[arg-type]
+        )
+    return _rollup_to_response(rollup)

--- a/app/services/def14a_drift.py
+++ b/app/services/def14a_drift.py
@@ -67,6 +67,11 @@ from typing import Any
 import psycopg
 import psycopg.rows
 
+from app.services.holder_name_resolver import (
+    normalise_name,
+    resolve_holder_to_filer,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -181,131 +186,13 @@ def _compute_drift_pct(
     return diff / def14a_shares
 
 
-def _normalise_name(holder_name: str) -> str:
-    """Normalise a holder / filer name for exact case-insensitive
-    match.
-
-    Strips:
-      * Leading / trailing whitespace
-      * Trailing role suffixes (``", CEO"`` / ``" - Director"``)
-
-    Returns the lowercase residual. Used on both sides of the
-    DEF 14A holder ↔ Form 4 filer match — the proxy name is
-    normalised once when building the SQL parameter, the Form 4
-    filer name is normalised in SQL via ``LOWER(...)``.
-
-    Codex pre-push review caught the prior ILIKE-substring approach
-    matching false positives (``"Ann"`` -> ``"Joanne Smith"``;
-    ``"John Doe"`` -> ``"John Doe Jr"``). Exact match after
-    role-suffix strip is conservative — name variants fall through
-    to the info-severity coverage gap, which v2's curated holder→
-    filer mapping seed table will resolve.
-    """
-    base = holder_name.strip()
-    for sep in (",", " - ", " — ", " – "):
-        if sep in base:
-            base = base.split(sep, 1)[0].strip()
-            break
-    return base.lower()
-
-
-def _resolve_holder_match(
-    conn: psycopg.Connection[tuple],
-    *,
-    instrument_id: int,
-    holder_name: str,
-) -> tuple[bool, str | None, Decimal | None]:
-    """Resolve a DEF 14A holder against Form 4 + Form 3 baseline.
-
-    Returns ``(matched, matched_filer_cik, form4_cumulative_shares)``:
-
-      * ``matched`` is ``True`` when a Form 4 or Form 3 row was
-        found whose normalised filer name equals the normalised
-        holder name. Distinct from ``matched_filer_cik`` because
-        legacy Form 4 rows can have NULL ``filer_cik`` — a zero
-        drift on a NULL-CIK row is still a real reconciliation,
-        not a coverage gap. Codex pre-push review caught this.
-      * ``matched_filer_cik`` is the resolved CIK (when present)
-        or ``None`` for legacy rows.
-      * ``form4_cumulative_shares`` is the latest
-        ``post_transaction_shares`` for the matched filer, or the
-        Form 3 baseline ``shares`` when no Form 4 row exists.
-
-    Match precedence:
-      1. Latest Form 4 ``post_transaction_shares`` for the same
-         instrument whose ``_normalise_name(filer_name)`` equals
-         the normalised holder name. Tie-broken by ``txn_date DESC,
-         id DESC``.
-      2. Falling back to ``insider_initial_holdings`` (Form 3
-         baseline) when no Form 4 row matches.
-      3. Otherwise ``(False, None, None)`` — coverage gap.
-
-    Implementation note: candidate filers are fetched in bulk per
-    instrument and filtered in Python via ``_normalise_name`` so the
-    full role-suffix strip (``,`` / ` - ` / ` — ` / ` – ``) is the
-    single canonical source. An earlier draft did the strip in SQL
-    via ``SPLIT_PART(..., ',', 1)``, which only matched the comma
-    case and silently failed for the dash variants. Codex pre-push
-    review caught the SQL-vs-Python normalisation drift.
-    """
-    normalised = _normalise_name(holder_name)
-    if not normalised:
-        return (False, None, None)
-
-    # Try Form 4 first — the cumulative running total. The
-    # ``DISTINCT ON (filer_cik, filer_name)`` cap pre-collapses
-    # multi-transaction filer histories to one row each (the
-    # latest), so the Python filter sees one row per filer
-    # regardless of an issuer's transaction volume. A
-    # COALESCE-keyed ``filer_cik`` keeps NULL-CIK rows
-    # individually addressable rather than collapsed to a single
-    # NULL bucket. Bot review caught the prior unbounded fetch.
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            """
-            SELECT DISTINCT ON (COALESCE(filer_cik, ''), filer_name)
-                filer_cik, filer_name, post_transaction_shares
-            FROM insider_transactions
-            WHERE instrument_id = %(iid)s
-              AND post_transaction_shares IS NOT NULL
-            ORDER BY COALESCE(filer_cik, ''), filer_name,
-                     txn_date DESC NULLS LAST, id DESC
-            """,
-            {"iid": instrument_id},
-        )
-        for row in cur.fetchall():
-            if _normalise_name(str(row["filer_name"])) == normalised:
-                return (
-                    True,
-                    str(row["filer_cik"]) if row["filer_cik"] is not None else None,
-                    row["post_transaction_shares"],
-                )
-
-    # Fall back to Form 3 baseline. Same DISTINCT ON cap so the
-    # Python filter never sees more than one row per filer.
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            """
-            SELECT DISTINCT ON (COALESCE(filer_cik, ''), filer_name)
-                filer_cik, filer_name, shares
-            FROM insider_initial_holdings
-            WHERE instrument_id = %(iid)s
-              AND shares IS NOT NULL
-              AND is_derivative = FALSE
-            ORDER BY COALESCE(filer_cik, ''), filer_name,
-                     as_of_date DESC NULLS LAST
-            """,
-            {"iid": instrument_id},
-        )
-        for row in cur.fetchall():
-            if _normalise_name(str(row["filer_name"])) == normalised:
-                return (
-                    True,
-                    str(row["filer_cik"]) if row["filer_cik"] is not None else None,
-                    row["shares"],
-                )
-
-    return (False, None, None)
+_normalise_name = normalise_name
+_resolve_holder_match = resolve_holder_to_filer
+# Keep the underscore-prefixed names for in-module callers; the
+# canonical implementation now lives in
+# ``app.services.holder_name_resolver`` so the ownership-rollup
+# service (#789) shares the same match semantics. Codex spec review
+# flagged the duplication risk before #789 landed.
 
 
 def _delete_alert(

--- a/app/services/holder_name_resolver.py
+++ b/app/services/holder_name_resolver.py
@@ -1,0 +1,181 @@
+"""Holder-name → filer CIK resolver shared between DEF 14A drift
+detection and the ownership-rollup service.
+
+DEF 14A's beneficial-ownership table stores ``holder_name`` only — no
+``filer_cik`` — because SEC's proxy-statement schema names individuals
+without requiring an EDGAR identifier. To dedup DEF 14A rows against
+Form 4 / Form 3 / 13D/G winners we have to resolve the holder name to
+a filer_cik first, then run the canonical CIK-priority dedup.
+
+This module is the single source of truth for that resolution. It
+was lifted from ``def14a_drift._normalise_name`` +
+``def14a_drift._resolve_holder_match`` so the ownership-rollup
+service (#789) and the drift detector (#769) cannot drift apart on
+match semantics — Codex spec review caught the duplication risk on
+the v1 spec for #789.
+
+Match precedence:
+
+  1. Latest Form 4 ``post_transaction_shares`` for the same instrument
+     whose normalised filer_name equals the normalised holder_name.
+     Tie-broken by ``txn_date DESC, id DESC``.
+  2. Falling back to ``insider_initial_holdings`` (Form 3 baseline)
+     when no Form 4 row matches. Same DISTINCT ON cap.
+  3. Otherwise ``(False, None, None)`` — a coverage gap from the
+     drift detector's perspective; for the ownership-rollup the row
+     goes to the ``def14a_unmatched`` slice.
+
+Match accepts ``filer_cik IS NULL`` rows: legacy / backfilled Form 4
+rows can carry NULL CIK and a clean reconciliation on such a row is
+still a real reconciliation, not a coverage gap.
+
+NULL-CIK identity uses ``LOWER(TRIM(filer_name))`` so two distinct
+NULL-CIK officers do not collapse into one bucket. Codex review
+caught the prior over-collapse on the v3 spec for #789.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import psycopg
+import psycopg.rows
+
+
+def normalise_name(holder_name: str) -> str:
+    """Normalise a holder / filer name for exact case-insensitive
+    match.
+
+    Strips:
+      * Leading / trailing whitespace
+      * Trailing role suffixes after the first separator (``", CEO"``
+        / ``" - Director"`` / ``" — Director"`` / ``" – Director"``).
+
+    Returns the lowercase residual. Used on both sides of the
+    DEF 14A holder ↔ Form 4 filer match — the proxy name is
+    normalised once when building the SQL parameter, the Form 4
+    filer name is normalised in Python so the strip semantics stay
+    in one place.
+
+    Codex pre-push review (on the original DEF 14A drift PR) caught
+    the prior ILIKE-substring approach matching false positives
+    (``"Ann"`` -> ``"Joanne Smith"``; ``"John Doe"`` -> ``"John Doe
+    Jr"``). Exact match after role-suffix strip is conservative —
+    name variants fall through to the unmatched bucket, which the
+    follow-on curated holder→filer mapping seed table (#790's
+    territory) will resolve.
+    """
+    base = holder_name.strip()
+    for sep in (",", " - ", " — ", " – "):
+        if sep in base:
+            base = base.split(sep, 1)[0].strip()
+            break
+    return base.lower()
+
+
+def resolve_holder_to_filer(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    holder_name: str,
+) -> tuple[bool, str | None, Decimal | None]:
+    """Resolve a DEF 14A holder against Form 4 + Form 3 baseline.
+
+    Returns ``(matched, matched_filer_cik, latest_known_shares)``:
+
+      * ``matched`` is ``True`` when a Form 4 or Form 3 row was found
+        whose normalised filer name equals the normalised holder
+        name. Distinct from ``matched_filer_cik`` because legacy
+        Form 4 rows can have NULL ``filer_cik`` — a zero-drift
+        reconciliation on a NULL-CIK row is still a real
+        reconciliation, not a coverage gap.
+      * ``matched_filer_cik`` is the resolved CIK (when present) or
+        ``None`` for legacy NULL-CIK rows.
+      * ``latest_known_shares`` is the latest Form 4
+        ``post_transaction_shares`` for the matched filer, falling
+        back to the Form 3 baseline ``shares`` when no Form 4 row
+        exists.
+
+    Implementation note: candidate filers are fetched in bulk per
+    instrument and filtered in Python via :func:`normalise_name` so
+    the role-suffix strip is the single canonical source. An earlier
+    draft did the strip in SQL via ``SPLIT_PART(..., ',', 1)``,
+    which only matched the comma case and silently failed for the
+    dash variants.
+    """
+    normalised = normalise_name(holder_name)
+    if not normalised:
+        return (False, None, None)
+
+    # Form 4 first — the cumulative running total. The DISTINCT ON cap
+    # pre-collapses multi-transaction filer histories to one row each
+    # (the latest), so the Python filter sees one row per filer
+    # regardless of an issuer's transaction volume. COALESCE-keyed
+    # filer_cik keeps NULL-CIK rows individually addressable rather
+    # than collapsed to a single NULL bucket.
+    #
+    # CIK-preference re-sort: the DB's natural ASC ordering on
+    # ``COALESCE(filer_cik, '')`` puts NULL-CIK rows first, so a
+    # filer with both a legacy NULL-CIK row and a newer CIK-backed
+    # row would resolve to ``(matched=True, cik=None)`` even though
+    # the canonical CIK is on file. Re-sort the fetchall so non-NULL
+    # CIK rows match first; legacy rows still match when nothing
+    # better exists. Codex pre-push review (Batch 1 of #788) caught
+    # this.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT ON (COALESCE(filer_cik, ''), filer_name)
+                filer_cik, filer_name, post_transaction_shares
+            FROM insider_transactions
+            WHERE instrument_id = %(iid)s
+              AND post_transaction_shares IS NOT NULL
+            ORDER BY COALESCE(filer_cik, ''), filer_name,
+                     txn_date DESC NULLS LAST, id DESC
+            """,
+            {"iid": instrument_id},
+        )
+        rows = sorted(
+            cur.fetchall(),
+            key=lambda r: (r["filer_cik"] is None, str(r.get("filer_name") or "")),
+        )
+        for row in rows:
+            if normalise_name(str(row["filer_name"])) == normalised:
+                return (
+                    True,
+                    str(row["filer_cik"]) if row["filer_cik"] is not None else None,
+                    row["post_transaction_shares"],
+                )
+
+    # Fall back to Form 3 baseline. Same DISTINCT ON cap so the
+    # Python filter never sees more than one row per filer.
+    # (insider_initial_holdings.filer_cik is NOT NULL by schema, so
+    # the CIK-preference re-sort is a no-op here — kept for
+    # symmetry / future-proofing.)
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT ON (COALESCE(filer_cik, ''), filer_name)
+                filer_cik, filer_name, shares
+            FROM insider_initial_holdings
+            WHERE instrument_id = %(iid)s
+              AND shares IS NOT NULL
+              AND is_derivative = FALSE
+            ORDER BY COALESCE(filer_cik, ''), filer_name,
+                     as_of_date DESC NULLS LAST
+            """,
+            {"iid": instrument_id},
+        )
+        rows = sorted(
+            cur.fetchall(),
+            key=lambda r: (r["filer_cik"] is None, str(r.get("filer_name") or "")),
+        )
+        for row in rows:
+            if normalise_name(str(row["filer_name"])) == normalised:
+                return (
+                    True,
+                    str(row["filer_cik"]) if row["filer_cik"] is not None else None,
+                    row["shares"],
+                )
+
+    return (False, None, None)

--- a/app/services/instrument_history.py
+++ b/app/services/instrument_history.py
@@ -1,0 +1,187 @@
+"""Instrument CIK / symbol history helpers (#794 — Batch 1 schema).
+
+The schema is designed to record the canonical chain of CIKs and
+symbols for one instrument across rebrands, reorgs, and ticker
+changes (FB → META, BBBY → BBBYQ at delisting). Every filings table
+in the repo already keys on ``instrument_id``, so the read side
+already survives a rename **if** the ingester resolved the
+historical CIK to the same instrument_id at write time.
+
+This module is the small public surface used by:
+
+  * The Tier 0 ownership-rollup service (#789), which calls
+    :func:`historical_ciks_for` so dedup and provenance code paths
+    have a stable list of every CIK ever associated with an
+    instrument.
+  * The Batch 7 symbol-change ingester, which will use
+    :func:`instrument_id_for_historical_cik` to resolve a filing
+    under a historical CIK back to the current instrument_id at
+    write time.
+
+After Batch 1 the only data in these tables is one
+``imported`` row per instrument seeded by
+:func:`backfill_current_history` — which the migration script
+``scripts/backfill_instrument_history.py`` runs idempotently on
+deploy.
+
+The Batch 7 ingester adds rows with ``source_event IN ('rebrand',
+'reorg', 'merger', 'spinoff')`` and closes out the prior current
+row by setting ``effective_to``. The DB-level invariants
+(EXCLUDE no-overlap, partial UNIQUE on ``(instrument_id) WHERE
+effective_to IS NULL``, CHECK ordered ranges) make a half-applied
+ingest fail loud rather than silently produce two current chains.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import psycopg
+import psycopg.rows
+
+
+def historical_ciks_for(conn: psycopg.Connection[tuple], instrument_id: int) -> Sequence[str]:
+    """Every CIK ever associated with this instrument, oldest-first.
+
+    Returns ``[]`` for an instrument with no
+    ``instrument_cik_history`` row (e.g. seeded but not yet
+    backfilled). Callers should treat the empty case as "use the
+    current ``instrument_sec_profile.cik``" — see Batch 7 for the
+    full ingester wiring.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT cik
+            FROM instrument_cik_history
+            WHERE instrument_id = %s
+            ORDER BY effective_from ASC
+            """,
+            (instrument_id,),
+        )
+        return [str(row[0]) for row in cur.fetchall()]
+
+
+def current_cik_for(conn: psycopg.Connection[tuple], instrument_id: int) -> str | None:
+    """The current (``effective_to IS NULL``) CIK for an instrument,
+    or ``None`` when the instrument has no history row yet.
+
+    The DB-level partial UNIQUE INDEX guarantees at most one current
+    row per instrument, so this returns either zero or one match.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT cik
+            FROM instrument_cik_history
+            WHERE instrument_id = %s
+              AND effective_to IS NULL
+            """,
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+    return str(row[0]) if row is not None else None
+
+
+def instrument_id_for_historical_cik(conn: psycopg.Connection[tuple], cik: str) -> int | None:
+    """Resolve a CIK (current or historical) to an instrument_id.
+
+    Returns ``None`` when the CIK has never been associated with any
+    instrument. Used by the Batch 7 ingester to route a filing under
+    a historical CIK to the right instrument.
+
+    A CIK can in principle map to multiple instruments at different
+    times (e.g. a parent that spun off a subsidiary; the spinoff
+    might briefly carry the parent's CIK before EDGAR assigns its
+    own). The schema doesn't forbid this, so this helper returns the
+    instrument whose history range contains the latest known
+    ``effective_to`` (i.e. the most recent owner). Callers that need
+    historical resolution by date should use
+    :func:`instrument_id_for_cik_at_date`.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id
+            FROM instrument_cik_history
+            WHERE cik = %s
+            ORDER BY (effective_to IS NULL) DESC,
+                     effective_to DESC NULLS LAST,
+                     effective_from DESC
+            LIMIT 1
+            """,
+            (cik,),
+        )
+        row = cur.fetchone()
+    return int(row[0]) if row is not None else None
+
+
+def backfill_current_history(conn: psycopg.Connection[tuple]) -> tuple[int, int]:
+    """Seed one ``imported`` row per instrument in both history tables.
+
+    Idempotent: re-running on a DB that already has the rows is a
+    no-op via ``ON CONFLICT DO NOTHING``. Returns
+    ``(cik_rows_inserted, symbol_rows_inserted)``.
+
+    Caveats:
+
+      * **CIK history** seeds from ``instrument_sec_profile.cik`` —
+        the current CIK. Instruments with no SEC profile row (non-US
+        listings, pre-ingest stubs) are skipped silently.
+      * **Symbol history** seeds from ``instruments.symbol``. No
+        synthesis from ``instrument_sec_profile.former_names`` —
+        former_names is **company-name** history, not symbol history.
+        Synthesising symbols from name changes would record fake
+        chains (e.g. "Facebook, Inc." → "FB" before the actual rebrand
+        date). The Batch 7 ingester writes real symbol-change events
+        from the EDGAR per-accession ticker tagging.
+      * ``effective_from`` is the instrument's ``first_seen_at::date``.
+        That's a deploy-time hint; the actual SEC association may
+        pre-date our ingestion. Acceptable because the only consumer
+        in Batch 1 is :func:`historical_ciks_for`, which doesn't use
+        ``effective_from`` for filtering.
+    """
+    cik_inserted = _backfill_cik_history(conn)
+    sym_inserted = _backfill_symbol_history(conn)
+    return cik_inserted, sym_inserted
+
+
+def _backfill_cik_history(conn: psycopg.Connection[tuple]) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO instrument_cik_history (
+                instrument_id, cik, effective_from, effective_to, source_event
+            )
+            SELECT i.instrument_id,
+                   p.cik,
+                   COALESCE(i.first_seen_at::date, CURRENT_DATE),
+                   NULL,
+                   'imported'
+            FROM instruments i
+            JOIN instrument_sec_profile p ON p.instrument_id = i.instrument_id
+            WHERE p.cik IS NOT NULL
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        return cur.rowcount if cur.rowcount is not None and cur.rowcount >= 0 else 0
+
+
+def _backfill_symbol_history(conn: psycopg.Connection[tuple]) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO instrument_symbol_history (
+                instrument_id, symbol, effective_from, effective_to, source_event
+            )
+            SELECT i.instrument_id,
+                   i.symbol,
+                   COALESCE(i.first_seen_at::date, CURRENT_DATE),
+                   NULL,
+                   'imported'
+            FROM instruments i
+            WHERE i.symbol IS NOT NULL
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        return cur.rowcount if cur.rowcount is not None and cur.rowcount >= 0 else 0

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -600,6 +600,14 @@ def _compute_coverage(
 def _per_category_state(known: int, estimate: int | None, pct_universe: Decimal | None) -> CoverageState:
     if estimate is None:
         return "unknown_universe"
+    # ``estimate=0`` is a real seeded value distinct from NULL — it
+    # means "we know the SEC universe for this category on this
+    # instrument is empty" (e.g. an issuer with no expected 13F
+    # filers). Treat as vacuously green: 0 known of 0 expected =
+    # complete coverage. Claude PR review (PR 798) caught the prior
+    # collapse to ``unknown_universe`` that lost this distinction.
+    if estimate == 0:
+        return "green"
     if pct_universe is None:
         return "unknown_universe"
     if pct_universe < Decimal("0.50"):
@@ -890,7 +898,16 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
 
 
 _CANONICAL_UNION_SQL = """
-WITH form4_latest AS (
+WITH latest_13f_period AS (
+    -- Single MAX scan instead of a correlated subquery on every
+    -- 13F candidate row. Claude PR review (PR 798) caught the prior
+    -- correlated form as a latent O(N-subqueries) perf regression for
+    -- high-13F-filer instruments.
+    SELECT MAX(period_of_report) AS period_of_report
+    FROM institutional_holdings
+    WHERE instrument_id = %(iid)s
+),
+form4_latest AS (
     SELECT DISTINCT ON (
         CASE WHEN filer_cik IS NOT NULL
              THEN 'CIK:' || filer_cik
@@ -983,10 +1000,7 @@ FROM institutional_holdings h
 JOIN institutional_filers f USING (filer_id)
 WHERE h.instrument_id = %(iid)s
   AND h.is_put_call IS NULL
-  AND h.period_of_report = (
-      SELECT MAX(period_of_report) FROM institutional_holdings
-      WHERE instrument_id = %(iid)s
-  )
+  AND h.period_of_report = (SELECT period_of_report FROM latest_13f_period)
 """
 """SQL building the canonical-holder candidate set per instrument.
 

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -1,0 +1,999 @@
+"""Tier 0 ownership rollup (#789, parent #788).
+
+Cross-channel deduped ownership snapshot for one instrument, derived
+from Form 4 + Form 3 + 13D/G + DEF 14A + 13F under the SEC Rule
+13d-3 beneficial-ownership semantic. Single denominator
+(``shares_outstanding`` from XBRL DEI), explicit
+``Public / unattributed`` residual wedge, and a coverage banner that
+distinguishes *float concentration* from *universe coverage* — see
+``docs/superpowers/specs/2026-05-03-ownership-tier0-and-cik-history-design.md``
+for the full design.
+
+Two ship-blockers from the codex audit (2026-05-03) that this module
+closes:
+
+  * **Wrong denominator** — the prior frontend math used
+    ``shares_outstanding + treasury_shares``; the canonical
+    denominator is ``shares_outstanding`` only, with treasury
+    rendered as an additive top wedge.
+  * **No cross-channel dedup** — the prior pipeline summed Form 4 +
+    13D/A + 13F + DEF 14A as a partition (e.g. Cohen on GME read as
+    ~75M shares because his Form 4 cumulative AND his 13D/A row
+    both contributed). Dedup priority is
+    ``form4 > form3 > 13d/g > def14a > 13f`` per CIK match, with
+    DEF 14A enriched via :mod:`app.services.holder_name_resolver`
+    before dedup runs (DEF 14A has no filer_cik in the schema).
+
+The reader uses :func:`app.db.snapshot.snapshot_read` at the FastAPI
+handler layer to keep every read inside one REPEATABLE READ
+transaction so the per-slice numbers, residual, and coverage all
+reconcile.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+import psycopg.rows
+
+from app.services.holder_name_resolver import resolve_holder_to_filer
+
+# ---------------------------------------------------------------------------
+# Public dataclasses (mirrored to Pydantic models in the API layer)
+# ---------------------------------------------------------------------------
+
+
+SliceCategory = Literal["insiders", "blockholders", "institutions", "etfs", "def14a_unmatched"]
+SourceTag = Literal["form4", "form3", "13d", "13g", "def14a", "13f"]
+CoverageState = Literal["no_data", "red", "unknown_universe", "amber", "green"]
+
+
+@dataclass(frozen=True)
+class DroppedSource:
+    """Provenance for a losing source in the dedup race. Surfaces in
+    the Batch 3 provenance footer so the operator can see "Form 4
+    won; the 13D/A you'd expect to see also reports 36.85M for the
+    same filer". One row per losing source per holder."""
+
+    source: SourceTag
+    accession_number: str
+    shares: Decimal
+    as_of_date: date | None
+
+
+@dataclass(frozen=True)
+class Holder:
+    """A canonical holder after cross-channel dedup. ``winning_source``
+    decides which slice this holder lands in (insiders /
+    blockholders / institutions / etfs)."""
+
+    filer_cik: str | None
+    filer_name: str
+    shares: Decimal
+    pct_outstanding: Decimal
+    winning_source: SourceTag
+    winning_accession: str
+    as_of_date: date | None
+    filer_type: str | None  # 13F filer-type tag; None for non-13F survivors
+    dropped_sources: tuple[DroppedSource, ...]
+
+
+@dataclass(frozen=True)
+class OwnershipSlice:
+    """One slice on the ownership card (insiders, blockholders, etc.).
+    ``filer_count`` is the number of *deduped* holders contributing
+    to ``total_shares`` — a category that resolved 7 holders shows
+    7 here even when the underlying 13F filings had option exposure
+    rows on top of the equity rows."""
+
+    category: SliceCategory
+    label: str
+    total_shares: Decimal
+    pct_outstanding: Decimal
+    filer_count: int
+    dominant_source: SourceTag | None
+    holders: tuple[Holder, ...]
+
+
+@dataclass(frozen=True)
+class ResidualBlock:
+    """``Public / unattributed`` wedge. ``oversubscribed=True`` when
+    deduped slices + treasury exceed shares_outstanding (stale
+    13F + fresh Form 4 / 13D mix); residual clamps to 0 in that
+    case and the frontend renders the warning bar."""
+
+    shares: Decimal
+    pct_outstanding: Decimal
+    label: str
+    tooltip: str
+    oversubscribed: bool
+
+
+@dataclass(frozen=True)
+class CategoryCoverage:
+    known_filers: int
+    estimated_universe: int | None
+    pct_universe: Decimal | None
+    state: CoverageState
+
+
+@dataclass(frozen=True)
+class CoverageReport:
+    state: CoverageState
+    categories: dict[str, CategoryCoverage]
+
+
+@dataclass(frozen=True)
+class ConcentrationInfo:
+    """Float concentration shown as an info chip — NOT the banner
+    driver. ``pct_outstanding_known`` is sum of deduped slices
+    over outstanding; treasury is excluded from the numerator
+    because the issuer doesn't 'invest' in itself."""
+
+    pct_outstanding_known: Decimal
+    info_chip: str
+
+
+@dataclass(frozen=True)
+class BannerCopy:
+    state: CoverageState
+    variant: Literal["error", "warning", "info", "success"]
+    headline: str
+    body: str
+
+
+@dataclass(frozen=True)
+class SharesOutstandingSource:
+    accession_number: str | None
+    concept: str | None
+    form_type: str | None
+
+
+@dataclass(frozen=True)
+class OwnershipRollup:
+    symbol: str
+    instrument_id: int
+    shares_outstanding: Decimal | None
+    shares_outstanding_as_of: date | None
+    shares_outstanding_source: SharesOutstandingSource
+    treasury_shares: Decimal | None
+    treasury_as_of: date | None
+    slices: tuple[OwnershipSlice, ...]
+    residual: ResidualBlock
+    concentration: ConcentrationInfo
+    coverage: CoverageReport
+    banner: BannerCopy
+    computed_at: datetime
+
+    @classmethod
+    def no_data(cls, symbol: str, instrument_id: int) -> OwnershipRollup:
+        """Empty payload for the ``no_data`` state (no XBRL outstanding
+        on file). 200 OK with the red banner, not 503 — that way the
+        frontend renders a uniform empty state and a sync-trigger
+        CTA rather than crashing on a non-2xx response."""
+        residual = ResidualBlock(
+            shares=Decimal(0),
+            pct_outstanding=Decimal(0),
+            label="Public / unattributed",
+            tooltip=_RESIDUAL_TOOLTIP,
+            oversubscribed=False,
+        )
+        coverage = CoverageReport(state="no_data", categories={})
+        banner = _banner_for_state("no_data", coverage, Decimal(0))
+        return cls(
+            symbol=symbol,
+            instrument_id=instrument_id,
+            shares_outstanding=None,
+            shares_outstanding_as_of=None,
+            shares_outstanding_source=SharesOutstandingSource(None, None, None),
+            treasury_shares=None,
+            treasury_as_of=None,
+            slices=(),
+            residual=residual,
+            concentration=ConcentrationInfo(
+                pct_outstanding_known=Decimal(0),
+                info_chip="No shares-outstanding figure on file.",
+            ),
+            coverage=coverage,
+            banner=banner,
+            computed_at=datetime.now(tz=UTC),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers: candidate collection + dedup
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Candidate:
+    """One row in the canonical-holder union before dedup. Mutable so
+    the DEF 14A enrichment step can append rows in Python after the
+    SQL-side union has run."""
+
+    source: SourceTag
+    priority_rank: int
+    filer_cik: str | None
+    filer_name: str
+    filer_type: str | None
+    shares: Decimal
+    as_of_date: date | None
+    accession_number: str
+    source_row_id: int
+
+
+def _identity_key(filer_cik: str | None, filer_name: str) -> str:
+    """Cross-source dedup key.
+
+    CIK when present (every modern Form 4 / 13F / 13D / Form 3 row);
+    falls back to ``LOWER(TRIM(filer_name))`` for legacy NULL-CIK
+    rows so two distinct NULL-CIK filers do not collapse into one
+    bucket. Mirrors the SQL DISTINCT ON expression in
+    :func:`_collect_canonical_holders_sql`. Codex review (v3 spec
+    pass) caught the prior over-collapse bug.
+    """
+    if filer_cik is not None and filer_cik.strip():
+        return f"CIK:{filer_cik.strip()}"
+    return f"NAME:{filer_name.strip().lower()}"
+
+
+_PRIORITY_RANK: dict[SourceTag, int] = {
+    "form4": 1,
+    "form3": 2,
+    "13d": 3,
+    "13g": 3,
+    "def14a": 4,
+    "13f": 5,
+}
+
+_RESIDUAL_TOOLTIP = (
+    "Shares outstanding minus all known regulated filings and "
+    "treasury. Includes retail, undeclared institutional, and any "
+    "filer outside our coverage cohort."
+)
+
+
+def _collect_canonical_holders_sql(conn: psycopg.Connection[Any], instrument_id: int) -> list[_Candidate]:
+    """Union Form 4 + Form 3 + 13D/G + 13F into one candidate list.
+
+    DEF 14A is unioned in Python after the holder-name resolver runs
+    (DEF 14A's schema has no filer_cik). The SQL pre-collapses each
+    source to one row per CIK-or-name identity to keep the Python
+    dedup pass O(N).
+
+    ``filer_type`` is carried through here because the slice
+    bucketer (institutions vs ETFs) depends on it post-dedup. Codex
+    v2 review caught a prior version that dropped it.
+    """
+    rows: list[_Candidate] = []
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_CANONICAL_UNION_SQL, {"iid": instrument_id})
+        for row in cur.fetchall():
+            shares = row.get("shares")
+            if shares is None:
+                continue
+            rows.append(
+                _Candidate(
+                    source=str(row["source"]),  # type: ignore[arg-type]
+                    priority_rank=int(row["priority_rank"]),  # type: ignore[arg-type]
+                    filer_cik=(str(row["filer_cik"]) if row.get("filer_cik") is not None else None),
+                    filer_name=str(row["filer_name"]),  # type: ignore[arg-type]
+                    filer_type=(str(row["filer_type"]) if row.get("filer_type") is not None else None),
+                    shares=Decimal(shares),
+                    as_of_date=row.get("as_of_date"),  # type: ignore[arg-type]
+                    accession_number=str(row["accession_number"]),  # type: ignore[arg-type]
+                    source_row_id=int(row["source_row_id"]),  # type: ignore[arg-type]
+                )
+            )
+    return rows
+
+
+def _enrich_and_union_def14a(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    sql_candidates: list[_Candidate],
+) -> tuple[list[_Candidate], list[_Candidate]]:
+    """Resolve each DEF 14A holder to a filer_cik and union into the
+    candidate set. Returns ``(matched_candidates, unmatched_candidates)``.
+
+    Matched DEF 14A rows enter dedup with their resolved CIK; they
+    will lose the priority race against Form 4 / 13D in almost every
+    case (rank 4 > rank 1/3) but the dropped accession ships in the
+    survivor's ``dropped_sources`` for provenance.
+
+    Unmatched DEF 14A rows go directly to the ``def14a_unmatched``
+    slice keyed on the holder name — no CIK is available to dedup
+    against. These are mostly named officers in the proxy who never
+    filed a Form 4 / Form 3.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT holding_id, holder_name, shares, as_of_date,
+                   accession_number
+            FROM def14a_beneficial_holdings
+            WHERE instrument_id = %s
+              AND shares IS NOT NULL
+            """,
+            (instrument_id,),
+        )
+        def14a_rows = cur.fetchall()
+
+    matched: list[_Candidate] = list(sql_candidates)
+    unmatched: list[_Candidate] = []
+    for row in def14a_rows:
+        is_matched, cik, _known_shares = resolve_holder_to_filer(
+            conn,
+            instrument_id=instrument_id,
+            holder_name=str(row["holder_name"]),  # type: ignore[arg-type]
+        )
+        candidate = _Candidate(
+            source="def14a",
+            priority_rank=_PRIORITY_RANK["def14a"],
+            filer_cik=cik,
+            filer_name=str(row["holder_name"]),  # type: ignore[arg-type]
+            filer_type=None,
+            shares=Decimal(row["shares"]),  # type: ignore[arg-type]
+            as_of_date=row.get("as_of_date"),  # type: ignore[arg-type]
+            accession_number=str(row["accession_number"]),  # type: ignore[arg-type]
+            source_row_id=int(row["holding_id"]),  # type: ignore[arg-type]
+        )
+        # Use the resolver's ``matched`` flag, not just ``cik is not
+        # None``. The resolver returns ``matched=True, cik=None`` for a
+        # legacy NULL-CIK Form 4 row that name-matches the holder; that
+        # is a clean reconciliation, not a coverage gap. Routing it to
+        # ``unmatched`` would have lost the holder twice — once from
+        # the ``insiders`` slice (DEF 14A loses priority to the legacy
+        # Form 4 it matched) and once again on the chart because the
+        # resolver couldn't pin a CIK. Codex pre-push review (Batch 1
+        # of #788) caught this.
+        if is_matched:
+            matched.append(candidate)
+        else:
+            unmatched.append(candidate)
+    return matched, unmatched
+
+
+def _dedup_by_priority(candidates: Iterable[_Candidate]) -> list[Holder]:
+    """Group candidates by identity key, pick the highest-priority
+    survivor per group, ship the losers as ``dropped_sources``.
+
+    Tie-break sequence — applied via a chain of stable sorts (last
+    sort = most significant):
+
+      1. ``priority_rank`` ascending (lower wins: form4=1 beats 13f=5)
+      2. ``as_of_date`` descending (newest wins; NULL last)
+      3. ``accession_number`` descending (lex-larger = later in the
+         filer-year sequence wins)
+      4. ``source_row_id`` descending (final pin against ties)
+
+    Matches the SQL DISTINCT ON ordering in
+    :data:`_CANONICAL_UNION_SQL` and the pinned spec sequence Codex
+    reviewed.
+    """
+    groups: dict[str, list[_Candidate]] = {}
+    for c in candidates:
+        groups.setdefault(_identity_key(c.filer_cik, c.filer_name), []).append(c)
+
+    survivors: list[Holder] = []
+    for cands in groups.values():
+        # Stable sorts applied bottom-up so the final ordering is
+        # priority_rank → as_of_date desc → accession desc → row_id desc.
+        cands.sort(key=lambda c: c.source_row_id, reverse=True)
+        cands.sort(key=lambda c: c.accession_number, reverse=True)
+        cands.sort(key=lambda c: c.as_of_date or date.min, reverse=True)
+        cands.sort(key=lambda c: c.priority_rank)
+        winner = cands[0]
+        losers = cands[1:]
+        survivors.append(
+            Holder(
+                filer_cik=winner.filer_cik,
+                filer_name=winner.filer_name,
+                shares=winner.shares,
+                pct_outstanding=Decimal(0),  # filled by _build_slice once denom known
+                winning_source=winner.source,
+                winning_accession=winner.accession_number,
+                as_of_date=winner.as_of_date,
+                filer_type=winner.filer_type,
+                dropped_sources=tuple(
+                    DroppedSource(
+                        source=loser.source,
+                        accession_number=loser.accession_number,
+                        shares=loser.shares,
+                        as_of_date=loser.as_of_date,
+                    )
+                    for loser in losers
+                ),
+            )
+        )
+    return survivors
+
+
+# ---------------------------------------------------------------------------
+# Slice + residual + coverage assembly
+# ---------------------------------------------------------------------------
+
+
+_SLICE_LABELS: dict[SliceCategory, str] = {
+    "insiders": "Insiders",
+    "blockholders": "Blockholders",
+    "institutions": "Institutions",
+    "etfs": "ETFs",
+    "def14a_unmatched": "Proxy-only (DEF 14A)",
+}
+
+
+def _bucket_into_slices(
+    survivors: list[Holder],
+    unmatched_def14a: list[_Candidate],
+    outstanding: Decimal,
+) -> list[OwnershipSlice]:
+    """Split deduped survivors into slices by ``winning_source``
+    (and ``filer_type`` for 13F)."""
+    by_category: dict[SliceCategory, list[Holder]] = {
+        "insiders": [],
+        "blockholders": [],
+        "institutions": [],
+        "etfs": [],
+    }
+    for h in survivors:
+        if h.winning_source in ("form4", "form3", "def14a"):
+            by_category["insiders"].append(h)
+        elif h.winning_source in ("13d", "13g"):
+            by_category["blockholders"].append(h)
+        elif h.winning_source == "13f":
+            if (h.filer_type or "").upper() == "ETF":
+                by_category["etfs"].append(h)
+            else:
+                by_category["institutions"].append(h)
+        else:
+            raise ValueError(f"unknown winning_source {h.winning_source!r}")
+
+    slices: list[OwnershipSlice] = []
+    for category, holders in by_category.items():
+        if not holders:
+            continue
+        slices.append(_build_slice(category, holders, outstanding))
+
+    if unmatched_def14a:
+        unmatched_holders = [
+            Holder(
+                filer_cik=None,
+                filer_name=c.filer_name,
+                shares=c.shares,
+                pct_outstanding=Decimal(0),
+                winning_source="def14a",
+                winning_accession=c.accession_number,
+                as_of_date=c.as_of_date,
+                filer_type=None,
+                dropped_sources=(),
+            )
+            for c in unmatched_def14a
+        ]
+        slices.append(_build_slice("def14a_unmatched", unmatched_holders, outstanding))
+    return slices
+
+
+def _build_slice(
+    category: SliceCategory,
+    holders: list[Holder],
+    outstanding: Decimal,
+) -> OwnershipSlice:
+    holders.sort(key=lambda h: h.shares, reverse=True)
+    total = sum((h.shares for h in holders), Decimal(0))
+    pct_total = total / outstanding if outstanding > 0 else Decimal(0)
+    sources: dict[SourceTag, Decimal] = {}
+    for h in holders:
+        sources[h.winning_source] = sources.get(h.winning_source, Decimal(0)) + h.shares
+    dominant: SourceTag | None = None
+    if sources:
+        dominant = max(sources.keys(), key=lambda s: sources[s])
+    enriched_holders = tuple(
+        Holder(
+            filer_cik=h.filer_cik,
+            filer_name=h.filer_name,
+            shares=h.shares,
+            pct_outstanding=(h.shares / outstanding) if outstanding > 0 else Decimal(0),
+            winning_source=h.winning_source,
+            winning_accession=h.winning_accession,
+            as_of_date=h.as_of_date,
+            filer_type=h.filer_type,
+            dropped_sources=h.dropped_sources,
+        )
+        for h in holders
+    )
+    return OwnershipSlice(
+        category=category,
+        label=_SLICE_LABELS[category],
+        total_shares=total,
+        pct_outstanding=pct_total,
+        filer_count=len(holders),
+        dominant_source=dominant,
+        holders=enriched_holders,
+    )
+
+
+def _compute_residual(
+    outstanding: Decimal,
+    slices: Sequence[OwnershipSlice],
+    treasury: Decimal | None,
+) -> ResidualBlock:
+    """Compute the ``Public / unattributed`` residual.
+
+    Stale-mixed-date inputs (fresh Form 4 + old 13F) can leave the
+    raw residual negative — we clamp to 0 and surface
+    ``oversubscribed=True`` so the frontend renders a warning bar.
+    The category-counted slices use deduped totals, so the only path
+    to oversubscription is the snapshot-lag class of bug, not a
+    dedup mistake."""
+    treasury_d = treasury if treasury is not None else Decimal(0)
+    sum_known = sum((s.total_shares for s in slices), Decimal(0))
+    raw = outstanding - sum_known - treasury_d
+    clamped = raw if raw > 0 else Decimal(0)
+    pct = clamped / outstanding if outstanding > 0 else Decimal(0)
+    return ResidualBlock(
+        shares=clamped,
+        pct_outstanding=pct,
+        label="Public / unattributed",
+        tooltip=_RESIDUAL_TOOLTIP,
+        oversubscribed=raw < 0,
+    )
+
+
+def _compute_concentration(outstanding: Decimal, slices: Sequence[OwnershipSlice]) -> ConcentrationInfo:
+    """Float concentration — sum-of-deduped-slices / outstanding.
+    Treasury excluded (the issuer doesn't invest in itself)."""
+    sum_known = sum((s.total_shares for s in slices), Decimal(0))
+    pct = sum_known / outstanding if outstanding > 0 else Decimal(0)
+    return ConcentrationInfo(
+        pct_outstanding_known=pct,
+        info_chip=f"Known filers hold {pct * 100:.2f}% of float.",
+    )
+
+
+_CATEGORY_ORDER: tuple[SliceCategory, ...] = (
+    "insiders",
+    "blockholders",
+    "institutions",
+    "etfs",
+)
+
+
+def _compute_coverage(
+    slices: Sequence[OwnershipSlice],
+    estimates: dict[str, int | None],
+) -> CoverageReport:
+    """Build per-category coverage + the fold-up banner state.
+
+    The fold uses ``no_data > red > unknown_universe > amber > green``
+    where the worst-of across categories wins. ``unknown_universe``
+    ranks worse than ``amber`` because a category without an
+    estimate is genuinely unknown — Codex v2 review caught the prior
+    rule that let one well-seeded category mask blind spots in the
+    others.
+    """
+    by_category = {s.category: s for s in slices}
+    cats: dict[str, CategoryCoverage] = {}
+    for category in _CATEGORY_ORDER:
+        slc = by_category.get(category)
+        known = slc.filer_count if slc is not None else 0
+        estimate = estimates.get(category)
+        pct_universe: Decimal | None = None
+        if estimate is not None and estimate > 0:
+            pct_universe = Decimal(known) / Decimal(estimate)
+        per_state = _per_category_state(known, estimate, pct_universe)
+        cats[category] = CategoryCoverage(
+            known_filers=known,
+            estimated_universe=estimate,
+            pct_universe=pct_universe,
+            state=per_state,
+        )
+    fold_state = _worst_of(cats[c].state for c in _CATEGORY_ORDER)
+    return CoverageReport(state=fold_state, categories=cats)
+
+
+def _per_category_state(known: int, estimate: int | None, pct_universe: Decimal | None) -> CoverageState:
+    if estimate is None:
+        return "unknown_universe"
+    if pct_universe is None:
+        return "unknown_universe"
+    if pct_universe < Decimal("0.50"):
+        return "red"
+    if pct_universe < Decimal("0.80"):
+        return "amber"
+    return "green"
+
+
+_STATE_RANK: dict[CoverageState, int] = {
+    "no_data": 0,
+    "red": 1,
+    "unknown_universe": 2,
+    "amber": 3,
+    "green": 4,
+}
+
+
+def _worst_of(states: Iterable[CoverageState]) -> CoverageState:
+    """Lower rank = worse. Default green when there are no
+    categories (vacuously satisfied) — but the caller never reaches
+    this branch with the no_data short-circuit."""
+    worst: CoverageState | None = None
+    for s in states:
+        if worst is None or _STATE_RANK[s] < _STATE_RANK[worst]:
+            worst = s
+    return worst if worst is not None else "green"
+
+
+def _banner_for_state(
+    state: CoverageState,
+    coverage: CoverageReport,
+    pct_concentration: Decimal,
+) -> BannerCopy:
+    if state == "no_data":
+        return BannerCopy(
+            state="no_data",
+            variant="error",
+            headline="Cannot compute ownership",
+            body=(
+                "XBRL shares outstanding not on file. Trigger fundamentals sync, or wait for the next scheduled run."
+            ),
+        )
+    unknown_cats = sorted(cat for cat, cov in coverage.categories.items() if cov.state == "unknown_universe")
+    if state == "red":
+        worst = _worst_named_category(coverage)
+        return BannerCopy(
+            state="red",
+            variant="error",
+            headline="Coverage incomplete",
+            body=(
+                f"Coverage incomplete in {worst.category} — do not use for "
+                f"investment decisions. {worst.known_filers} of "
+                f"{worst.estimated_universe} known filers in "
+                f"{worst.category}; {len(unknown_cats)} categories without "
+                f"an estimate."
+            ),
+        )
+    if state == "unknown_universe":
+        return BannerCopy(
+            state="unknown_universe",
+            variant="warning",
+            headline="Coverage estimate not available",
+            body=(
+                f"Coverage estimate not available for "
+                f"{', '.join(unknown_cats) or 'all categories'}. Known "
+                f"filings represent {pct_concentration * 100:.2f}% of float. "
+                f"Treat as best-effort until coverage expansion lands (#790)."
+            ),
+        )
+    if state == "amber":
+        worst = _worst_named_category(coverage)
+        return BannerCopy(
+            state="amber",
+            variant="warning",
+            headline="Limited coverage",
+            body=(f"Limited coverage in {worst.category} — verify against SEC EDGAR for major positions."),
+        )
+    return BannerCopy(
+        state="green",
+        variant="success",
+        headline="Coverage sufficient",
+        body="Universe coverage ≥ 80% across all four categories.",
+    )
+
+
+@dataclass(frozen=True)
+class _WorstNamed:
+    category: str
+    known_filers: int
+    estimated_universe: int
+
+
+def _worst_named_category(coverage: CoverageReport) -> _WorstNamed:
+    """Pick the category in worst state with non-null estimate. Used
+    only when the fold returned red/amber, so at least one such
+    category exists by construction.
+
+    Iterates categories in declaration order so two categories tied
+    on state pick the first one (deterministic, matches the
+    ``_CATEGORY_ORDER`` tuple)."""
+    best_rank = max(_STATE_RANK.values()) + 1
+    chosen: _WorstNamed | None = None
+    for cat_name in _CATEGORY_ORDER:
+        cov = coverage.categories.get(cat_name)
+        if cov is None or cov.estimated_universe is None:
+            continue
+        rank = _STATE_RANK[cov.state]
+        if rank < best_rank:
+            best_rank = rank
+            chosen = _WorstNamed(
+                category=cat_name,
+                known_filers=cov.known_filers,
+                estimated_universe=cov.estimated_universe,
+            )
+    if chosen is None:
+        # Defensive fallback — caller only invokes this on red/amber
+        # which by construction means at least one named category
+        # has a non-null estimate.
+        return _WorstNamed(category="unknown", known_filers=0, estimated_universe=0)
+    return chosen
+
+
+# ---------------------------------------------------------------------------
+# Inputs: shares_outstanding + treasury
+# ---------------------------------------------------------------------------
+
+
+def _read_shares_outstanding(
+    conn: psycopg.Connection[Any], instrument_id: int
+) -> tuple[Decimal | None, date | None, SharesOutstandingSource]:
+    """Latest XBRL DEI / us-gaap shares-outstanding figure.
+
+    Reuses the ``instrument_share_count_latest`` view (migration 052)
+    which already prefers DEI > us-gaap for the canonical
+    point-in-time count. Provenance fields (accession, form_type)
+    land in Batch 3 — Tier 0 ships them as ``None``.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT latest_shares, as_of_date, source_taxonomy
+            FROM instrument_share_count_latest
+            WHERE instrument_id = %s
+            """,
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+    if row is None or row.get("latest_shares") is None:
+        return None, None, SharesOutstandingSource(None, None, None)
+    return (
+        Decimal(row["latest_shares"]),  # type: ignore[arg-type]
+        row.get("as_of_date"),  # type: ignore[arg-type]
+        SharesOutstandingSource(
+            accession_number=None,
+            concept=(
+                "EntityCommonStockSharesOutstanding"
+                if str(row["source_taxonomy"]) == "dei"
+                else "CommonStockSharesOutstanding"
+            ),
+            form_type=None,
+        ),
+    )
+
+
+def _read_treasury(conn: psycopg.Connection[Any], instrument_id: int) -> tuple[Decimal | None, date | None]:
+    """Latest non-null ``treasury_shares`` from ``financial_periods``.
+
+    Mirrors the frontend ``pickLatestBalance`` walk-the-rows
+    semantic: the most recent quarterly row with a non-null
+    treasury value wins. Returns ``(None, None)`` when no row
+    has the column populated."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT treasury_shares, period_end_date
+            FROM financial_periods
+            WHERE instrument_id = %s
+              AND superseded_at IS NULL
+              AND treasury_shares IS NOT NULL
+              AND period_type IN ('Q1','Q2','Q3','Q4')
+            ORDER BY period_end_date DESC,
+                     filed_date DESC NULLS LAST
+            LIMIT 1
+            """,
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None, None
+    return Decimal(row["treasury_shares"]), row.get("period_end_date")  # type: ignore[arg-type]
+
+
+def _read_universe_estimates(conn: psycopg.Connection[Any], instrument_id: int) -> dict[str, int | None]:
+    """Per-category universe estimates. Tier 0 returns NULL for every
+    category — the per-instrument 13F filer-count ingest lands in
+    #790 / Batch 2, after which institutions starts returning a
+    real number. Other categories never get estimates in the
+    visible roadmap; they stay NULL until a curated seed lands."""
+    return {
+        "insiders": None,
+        "blockholders": None,
+        "institutions": None,
+        "etfs": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_id: int) -> OwnershipRollup:
+    """Build the rollup payload for one instrument.
+
+    The caller MUST already be inside :func:`app.db.snapshot.snapshot_read`
+    so every read in this function lands on the same REPEATABLE READ
+    snapshot. The function does NOT open its own transaction; doing
+    so on a pooled connection that already has an implicit READ
+    COMMITTED tx open would produce a SAVEPOINT instead of a fresh
+    snapshot, with the isolation change silently ignored. Codex spec
+    review caught the v1 spec attempting the inner-transaction
+    anti-pattern.
+    """
+    outstanding, outstanding_as_of, outstanding_source = _read_shares_outstanding(conn, instrument_id)
+    if outstanding is None or outstanding <= 0:
+        return OwnershipRollup.no_data(symbol=symbol, instrument_id=instrument_id)
+    treasury, treasury_as_of = _read_treasury(conn, instrument_id)
+    sql_candidates = _collect_canonical_holders_sql(conn, instrument_id)
+    matched, unmatched_def14a = _enrich_and_union_def14a(conn, instrument_id, sql_candidates)
+    survivors = _dedup_by_priority(matched)
+    slices = _bucket_into_slices(survivors, unmatched_def14a, outstanding)
+    residual = _compute_residual(outstanding, slices, treasury)
+    concentration = _compute_concentration(outstanding, slices)
+    estimates = _read_universe_estimates(conn, instrument_id)
+    coverage = _compute_coverage(slices, estimates)
+    banner = _banner_for_state(coverage.state, coverage, concentration.pct_outstanding_known)
+    return OwnershipRollup(
+        symbol=symbol,
+        instrument_id=instrument_id,
+        shares_outstanding=outstanding,
+        shares_outstanding_as_of=outstanding_as_of,
+        shares_outstanding_source=outstanding_source,
+        treasury_shares=treasury,
+        treasury_as_of=treasury_as_of,
+        slices=tuple(slices),
+        residual=residual,
+        concentration=concentration,
+        coverage=coverage,
+        banner=banner,
+        computed_at=datetime.now(tz=UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SQL: canonical-holder union (Form 4 + Form 3 + 13D/G + 13F)
+# ---------------------------------------------------------------------------
+#
+# DEF 14A is unioned in Python via :func:`_enrich_and_union_def14a`
+# because its schema has no ``filer_cik`` and the holder-name resolver
+# is in Python (kept there so the role-suffix strip stays the single
+# source of truth — see ``app.services.holder_name_resolver``).
+
+
+# Joint 13D/G filings — design note for future readers / reviewers:
+#
+# A multi-reporter 13D/G filing has N rows in ``blockholder_filings``
+# (one per reporting person). SEC Rule 13d-1 requires every joint
+# reporter to claim the SAME beneficial ownership figure on the cover
+# page; the figures in ``aggregate_amount_owned`` therefore overlap.
+# Summing across joint reporters double-counts the underlying block.
+#
+# The CTE below intentionally collapses to one row per accession via
+# ``DISTINCT ON (accession_number) ORDER BY ... aggregate_amount_owned
+# DESC``, mirroring the existing ``/blockholders`` reader's
+# ``per_accession_block`` MAX rollup (see ``app/api/instruments.py``
+# ``get_instrument_blockholders``). Joint co-reporters lose visibility
+# in the rollup chart by design — they share beneficial ownership with
+# the canonical primary reporter and would inflate the slice total if
+# included.
+#
+# Codex pre-push review for Batch 1 of #788 flagged this as data loss.
+# REBUTTED: the joint-filer collapse is the SEC-canonical interpretation
+# (overlap = same beneficial ownership) and matches the existing
+# blockholders reader. Per-reporter visibility lands in Batch 3's
+# provenance footer (``additional_reporters`` count + the dropped
+# accessions in the holder's ``dropped_sources``).
+
+
+_CANONICAL_UNION_SQL = """
+WITH form4_latest AS (
+    SELECT DISTINCT ON (
+        CASE WHEN filer_cik IS NOT NULL
+             THEN 'CIK:' || filer_cik
+             ELSE 'NAME:' || LOWER(TRIM(filer_name)) END
+    )
+        filer_cik, filer_name, post_transaction_shares,
+        txn_date, accession_number, id
+    FROM insider_transactions
+    WHERE instrument_id = %(iid)s
+      AND post_transaction_shares IS NOT NULL
+      AND is_derivative = FALSE
+    ORDER BY
+        CASE WHEN filer_cik IS NOT NULL
+             THEN 'CIK:' || filer_cik
+             ELSE 'NAME:' || LOWER(TRIM(filer_name)) END,
+        txn_date DESC NULLS LAST, id DESC
+),
+blocks AS (
+    SELECT DISTINCT ON (accession_number)
+           filing_id, accession_number, submission_type,
+           aggregate_amount_owned, filed_at, filer_id
+    FROM blockholder_filings
+    WHERE instrument_id = %(iid)s
+      AND aggregate_amount_owned IS NOT NULL
+    ORDER BY accession_number, aggregate_amount_owned DESC NULLS LAST
+)
+SELECT 'form4'::text AS source, 1 AS priority_rank,
+       filer_cik, filer_name,
+       NULL::text AS filer_type,
+       post_transaction_shares::numeric AS shares,
+       txn_date AS as_of_date,
+       accession_number,
+       id AS source_row_id
+FROM form4_latest
+
+UNION ALL
+
+SELECT 'form3'::text AS source, 2 AS priority_rank,
+       iih.filer_cik, iih.filer_name,
+       NULL::text AS filer_type,
+       iih.shares::numeric AS shares,
+       iih.as_of_date,
+       iih.accession_number,
+       iih.id AS source_row_id
+FROM insider_initial_holdings iih
+WHERE iih.instrument_id = %(iid)s
+  AND iih.shares IS NOT NULL
+  AND iih.is_derivative = FALSE
+  AND NOT EXISTS (
+      SELECT 1 FROM insider_transactions it
+      WHERE it.instrument_id = iih.instrument_id
+        AND it.post_transaction_shares IS NOT NULL
+        AND it.is_derivative = FALSE
+        AND (
+            (it.filer_cik IS NOT NULL AND iih.filer_cik IS NOT NULL
+             AND it.filer_cik = iih.filer_cik)
+            OR
+            (it.filer_cik IS NULL AND iih.filer_cik IS NULL
+             AND LOWER(TRIM(it.filer_name)) = LOWER(TRIM(iih.filer_name)))
+        )
+  )
+
+UNION ALL
+
+SELECT
+    CASE WHEN bf.submission_type LIKE 'SCHEDULE 13D%%' THEN '13d'
+         ELSE '13g' END AS source,
+    3 AS priority_rank,
+    COALESCE(bf.reporter_cik, f.cik) AS filer_cik,
+    COALESCE(bf.reporter_name, f.name) AS filer_name,
+    NULL::text AS filer_type,
+    blocks.aggregate_amount_owned::numeric AS shares,
+    blocks.filed_at::date AS as_of_date,
+    blocks.accession_number,
+    blocks.filing_id AS source_row_id
+FROM blocks
+JOIN blockholder_filings bf ON bf.filing_id = blocks.filing_id
+JOIN blockholder_filers f ON f.filer_id = blocks.filer_id
+
+UNION ALL
+
+SELECT '13f'::text AS source, 5 AS priority_rank,
+       f.cik AS filer_cik, f.name AS filer_name,
+       COALESCE(f.filer_type, 'OTHER') AS filer_type,
+       h.shares::numeric AS shares,
+       h.period_of_report AS as_of_date,
+       h.accession_number,
+       h.holding_id AS source_row_id
+FROM institutional_holdings h
+JOIN institutional_filers f USING (filer_id)
+WHERE h.instrument_id = %(iid)s
+  AND h.is_put_call IS NULL
+  AND h.period_of_report = (
+      SELECT MAX(period_of_report) FROM institutional_holdings
+      WHERE instrument_id = %(iid)s
+  )
+"""
+"""SQL building the canonical-holder candidate set per instrument.
+
+The Python pass deduplicates across sources (Form 4 > Form 3 > 13D/G >
+13F) using the ``CIK-or-name`` identity and the pinned tie-break
+sequence. The SQL only collapses *within* each source so the Python
+pass sees one row per filer per source.
+
+DEF 14A rows are unioned in Python after the holder-name resolver runs.
+"""

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -895,6 +895,23 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
 # blockholders reader. Per-reporter visibility lands in Batch 3's
 # provenance footer (``additional_reporters`` count + the dropped
 # accessions in the holder's ``dropped_sources``).
+#
+# ``_CANONICAL_UNION_SQL``: the union template that builds the
+# canonical-holder candidate set per instrument. The Python pass
+# deduplicates across sources (Form 4 > Form 3 > 13D/G > 13F) using
+# the ``CIK-or-name`` identity and the pinned tie-break sequence. The
+# SQL only collapses *within* each source so the Python pass sees one
+# row per filer per source. DEF 14A rows are unioned in Python after
+# the holder-name resolver runs.
+#
+# Note: the JOIN ``blockholder_filings bf ON bf.filing_id =
+# blocks.filing_id`` is on the PK of ``blockholder_filings`` and
+# therefore one-to-one — no fan-out is possible regardless of how many
+# joint reporters share an accession. Claude PR review (PR 798) round
+# 2 flagged this as a potential re-fan; REBUTTED because filing_id is
+# the BIGSERIAL PRIMARY KEY (migration 095). The `blocks` CTE
+# deliberately picks ONE filing_id per accession (the
+# largest-aggregate row) and the join returns that one row.
 
 
 _CANONICAL_UNION_SQL = """
@@ -1001,13 +1018,4 @@ JOIN institutional_filers f USING (filer_id)
 WHERE h.instrument_id = %(iid)s
   AND h.is_put_call IS NULL
   AND h.period_of_report = (SELECT period_of_report FROM latest_13f_period)
-"""
-"""SQL building the canonical-holder candidate set per instrument.
-
-The Python pass deduplicates across sources (Form 4 > Form 3 > 13D/G >
-13F) using the ``CIK-or-name`` identity and the pinned tie-break
-sequence. The SQL only collapses *within* each source so the Python
-pass sees one row per filer per source.
-
-DEF 14A rows are unioned in Python after the holder-name resolver runs.
 """

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -1111,6 +1111,33 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Prevention: every `ConnectionPool(...)` call in the codebase must pass: (a) `kwargs={"keepalives": 1, "keepalives_idle": 30, "keepalives_interval": 10, "keepalives_count": 3}` for libpq-level dead-peer detection; (b) `check=ConnectionPool.check_connection` for SELECT 1 validation on every checkout (~1ms overhead, catches conns the OS hasn't yet flagged); (c) `max_idle=600.0` and `max_lifetime=1800.0` to proactively recycle conns so a single bad conn cannot wedge the pool for the rest of uptime; (d) `timeout=15.0` so a saturated/wedged pool surfaces as a 503 instead of an indefinite event-loop block. Use the `_open_pool` helper in `app/main.py` rather than calling `ConnectionPool(...)` directly — adding a third pool with raw constructor args is the regression shape this entry exists to catch.
 - Enforced in: this prevention log; `app/main.py::_open_pool` centralises the config; `tests/test_main_pool_hardening.py` pins it. Companion: `uvicorn --reload-dir app` (in `.vscode/tasks.json`, `Makefile`, `stack-restart.ps1`, `README.md`) so test/doc edits don't churn the worker through reload races, which is one path that turns flaky pooled conns into observed wedges.
 
+### Correlated scalar subquery inside a UNION-of-sources CTE
+
+- First seen in: PR #798 review (Batch 1 of #788, ownership rollup
+  service).
+- Symptom: `_CANONICAL_UNION_SQL` used
+  `WHERE h.period_of_report = (SELECT MAX(period_of_report) FROM
+  institutional_holdings WHERE instrument_id = %(iid)s)` inline on the
+  13F branch of a five-source UNION ALL. The subquery is correlated on
+  `instrument_id` and Postgres re-evaluates it for every candidate
+  `institutional_holdings` row scanned — for high-13F-filer instruments
+  (>300 13F-HR rows for the latest quarter) that's hundreds of MAX
+  scans per request inside the rollup endpoint's hot path. The pattern
+  is especially attractive in multi-source UNIONs because each branch
+  feels self-contained and the CTE-promotion isn't visually obvious.
+- Prevention: when a UNION ALL branch needs a scalar bound (latest
+  period, max date, etc.) and the bound is keyed on the same instrument
+  / entity that the outer query is already filtered by, hoist the
+  bound into a leading CTE that runs once per request:
+  `WITH latest_X AS (SELECT MAX(...) ... WHERE entity = %(eid)s)`,
+  then reference `(SELECT col FROM latest_X)` from inside the UNION
+  branch. Self-review prompt: grep new SQL changes for `SELECT MAX(`
+  / `SELECT MIN(` inside a UNION branch's WHERE clause and flag for
+  CTE promotion.
+- Enforced in: this prevention log; `app/services/ownership_rollup.py`
+  promotes `latest_13f_period` to a leading CTE in the v3 spec
+  implementation.
+
 ### Column-side casts in WHERE clauses defeat indexes
 
 - First seen in: #669 review (PR #679).

--- a/docs/superpowers/specs/2026-05-03-ownership-tier0-and-cik-history-design.md
+++ b/docs/superpowers/specs/2026-05-03-ownership-tier0-and-cik-history-design.md
@@ -1,0 +1,887 @@
+# Ownership Tier 0 + CIK history schema — design (#789 + #794-schema)
+
+**Revision history:**
+
+- v1 — initial spec.
+- v2 — Codex spec review (2026-05-03) found 6 issues. Fixes:
+  - DEF 14A has no `filer_cik`, so the priority dedup must enrich
+    DEF 14A holders with a name-resolved CIK first (via
+    `def14a_drift._resolve_holder_match`, lifted to a shared module).
+  - Use `snapshot_read(conn)` around the whole handler — pooled
+    connections already opened an implicit READ COMMITTED tx, so a
+    later `conn.transaction()` becomes a SAVEPOINT and the isolation
+    change never takes effect.
+  - Coverage banner cannot use `sum(slices)/outstanding` (= float
+    concentration) as a completeness signal — retail-heavy names
+    would be permanently red. Banner is now driven by **universe
+    coverage** (`known_filers / estimated_universe` per category)
+    with explicit NULL-tolerant fallback for the v1 unknown-universe
+    case. Concentration shown separately as an info chip.
+  - History tables get the missing temporal invariants: `CHECK
+    (effective_to IS NULL OR effective_to > effective_from)`, partial
+    UNIQUE on `(instrument_id) WHERE effective_to IS NULL`, and a GIST
+    `EXCLUDE` against overlapping date ranges.
+  - Residual math clamps to 0 with an `oversubscribed: bool` flag for
+    operator-facing copy when stale mixed-date inputs would yield a
+    negative residual.
+  - Dedup tie-break sequence pinned: `priority_rank ASC, as_of_date
+    DESC NULLS LAST, accession_number DESC, source_row_id DESC`.
+  - #794 stays schema-only; the spec no longer claims this batch closes
+    the BBBY case. Synthetic symbol-history backfill from
+    `former_names` (which is **name** history, not symbol history) is
+    dropped — only the current symbol is seeded with `effective_from
+    = first_seen_at`. The BBBY case closes in Batch 7 alongside the
+    actual symbol-change ingester.
+
+## Goal
+
+Make the per-instrument ownership card production-trustworthy: unify the
+denominator on `shares_outstanding` (XBRL DEI), dedup holders across
+13F / 13D/G / DEF 14A / Form 4 / Form 3 by CIK with priority `Form 4 >
+13D/G > DEF 14A > 13F`, render an explicit "Public / unattributed"
+residual wedge, surface coverage with an honest banner that distinguishes
+*float concentration* from *universe coverage*, repair the
+`insider_initial_holdings.value_owned` schema drift, and lay the
+CIK-history schema so the BBBY-style ticker-rename case can be wired up
+in Batch 7.
+
+Two ship-blockers from the codex audit (2026-05-03) close in this PR:
+
+1. **Wrong denominator** — frontend uses `shares_outstanding +
+   treasury_shares`; backend contract uses `shares_outstanding`. Treasury
+   wedges every other category down by the treasury fraction.
+2. **No cross-channel dedup** — Cohen on GME is summed across
+   `insider_transactions` (Form 4) + `blockholder_filings` (13D/A) for
+   ~75M shares; reality is ~38M.
+
+Plus the pre-existing `insider_initial_holdings.value_owned` column
+drift (migration 093 `CREATE TABLE IF NOT EXISTS` no-op'd onto an older
+table shape) which silently breaks the Form 3 baseline reader on every
+instrument.
+
+## Non-goals
+
+- Coverage **expansion** (top 150 13F seed list, Form 3 backfill,
+  Soros/Geode disambig, backfill-on-activation). Ship in Batch 2
+  (#791 + #790).
+- Provenance footer, methodology disclosure, accession links, freshness
+  chips on the new endpoint. Ship in Batch 3 (#792).
+- First-run ingest progress, ingest-health page. Ship in Batch 4
+  (#793 + #797 B4).
+- N-PORT mutual fund stream, FINRA short interest. Batches 5 + 6.
+- **Closing the BBBY case end-to-end**. The schema lands here so Batch 7
+  has somewhere to write to, but the BBBY ownership card is *not*
+  production-trustworthy at the end of this batch — it stays unchanged.
+  Batch 7 ships the symbol-change ingester + the
+  `HistoricalSymbolCallout` UI + reorg test fixtures.
+- Adjacent bugs (13F dup-key race, sync_runs FK race, rogue created_at
+  poller, test-seed cleanup, stray auth FATAL). Batch 8.
+
+## Settled-decision impact
+
+Touched:
+
+- **Identifier strategy: filing lookup rule** — already settled that SEC
+  uses CIK, not symbol. This batch installs the CIK-history schema so
+  Batch 7 can enforce the rule on the ingest side. The reader path is
+  unchanged this batch (every filings table already keys on
+  `instrument_id`); the helper `historical_ciks_for(instrument_id)`
+  exists as a stub with one row per current instrument.
+- **Provider design rule** — the new `ownership_rollup` service lives
+  at `app/services/`, not in any provider module.
+- **Auditability** — every dedup decision keeps the losing source's
+  accession in `dropped_sources` so the Batch 3 provenance footer can
+  surface it without a second query.
+
+No settled decisions changed.
+
+## Prevention-log entries that apply
+
+| Entry | How this batch respects it |
+|---|---|
+| `CREATE TABLE IF NOT EXISTS does not add columns to pre-existing tables` | Migration 101 uses `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`. Schema-drift smoke gate (B5 of #797) lands in this PR to prevent recurrence. |
+| `JOIN fan-out inflates aggregate totals` | Dedup builds the canonical-holder set in a CTE before SUM. |
+| `Bucket-arithmetic double-counting` | Dedup happens by `filer_cik` once, then slice rollups use the survivor set only. |
+| `When a migration adds any table with a FK relationship, update _PLANNER_TABLES` | Migrations 102 + 103 add new FK tables; `_PLANNER_TABLES` updated. |
+| `Frontend async render-surface isolation` | New `useAsync` usage on the rollup endpoint mirrors the existing pattern. |
+| `New TEXT columns in migrations need CHECK constraints or Literal types` | Both `source_event` columns CHECK-constrained. |
+| `Multi-query read handlers must use a single snapshot` | Endpoint uses `snapshot_read(conn)` around the whole handler — including symbol resolution. v1 spec error caught by Codex. |
+| `Don't add scheduling or job execution to the API process` | No scheduler / executor changes. |
+| `Internal exception text leaked into HTTP response bodies` | New endpoint returns sanitised detail. |
+
+## Migrations
+
+### `sql/101_insider_initial_holdings_value_owned.sql`
+
+```sql
+ALTER TABLE insider_initial_holdings
+    ADD COLUMN IF NOT EXISTS value_owned NUMERIC(18, 6);
+
+COMMENT ON COLUMN insider_initial_holdings.value_owned IS
+    'Form 3 valueOwnedFollowingTransaction alternative to shares. SEC '
+    'allows EITHER shares OR value (fractional-undivided-interest '
+    'securities use the value branch). Recovery for migration 093 '
+    'CREATE TABLE IF NOT EXISTS no-op on pre-existing schema.';
+```
+
+### `sql/102_instrument_cik_history.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS instrument_cik_history (
+    instrument_id   BIGINT NOT NULL REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    cik             TEXT NOT NULL,
+    effective_from  DATE NOT NULL,
+    effective_to    DATE,
+    source_event    TEXT NOT NULL CHECK (source_event IN
+        ('imported', 'rebrand', 'reorg', 'merger', 'spinoff', 'manual')),
+    PRIMARY KEY (instrument_id, cik, effective_from),
+    CONSTRAINT instrument_cik_history_dates_ordered
+        CHECK (effective_to IS NULL OR effective_to > effective_from)
+);
+
+-- One "current" CIK per instrument. Manual reorg insert that forgets
+-- to close out the prior current row blows up loud at the DB.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_instrument_cik_history_current
+    ON instrument_cik_history (instrument_id)
+    WHERE effective_to IS NULL;
+
+-- Non-overlapping ranges per instrument. GIST EXCLUDE with a daterange
+-- so two historical CIK chains for one instrument cannot overlap in
+-- time. Half-open daterange [from, to) where to=NULL becomes 'infinity'.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+ALTER TABLE instrument_cik_history
+    ADD CONSTRAINT instrument_cik_history_no_overlap
+    EXCLUDE USING GIST (
+        instrument_id WITH =,
+        daterange(effective_from, effective_to, '[)') WITH &&
+    );
+
+CREATE INDEX IF NOT EXISTS idx_instrument_cik_history_cik
+    ON instrument_cik_history (cik);
+
+COMMENT ON TABLE instrument_cik_history IS
+    'CIK chain per instrument with effective-date ranges. Reader path '
+    'on the ownership card uses this to resolve filings under a '
+    'historical CIK back to the current instrument_id (#794). '
+    'effective_to NULL = current. EXCLUDE constraint forbids overlapping '
+    'ranges; UNIQUE INDEX forbids two "current" rows per instrument.';
+```
+
+### `sql/103_instrument_symbol_history.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS instrument_symbol_history (
+    instrument_id   BIGINT NOT NULL REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    symbol          TEXT NOT NULL,
+    effective_from  DATE NOT NULL,
+    effective_to    DATE,
+    source_event    TEXT NOT NULL CHECK (source_event IN
+        ('imported', 'rebrand', 'delisting', 'relisting', 'manual')),
+    PRIMARY KEY (instrument_id, symbol, effective_from),
+    CONSTRAINT instrument_symbol_history_dates_ordered
+        CHECK (effective_to IS NULL OR effective_to > effective_from)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_instrument_symbol_history_current
+    ON instrument_symbol_history (instrument_id)
+    WHERE effective_to IS NULL;
+
+ALTER TABLE instrument_symbol_history
+    ADD CONSTRAINT instrument_symbol_history_no_overlap
+    EXCLUDE USING GIST (
+        instrument_id WITH =,
+        daterange(effective_from, effective_to, '[)') WITH &&
+    );
+
+CREATE INDEX IF NOT EXISTS idx_instrument_symbol_history_symbol
+    ON instrument_symbol_history (symbol);
+
+COMMENT ON TABLE instrument_symbol_history IS
+    'Symbol history per instrument with effective-date ranges. '
+    'Symbol-clash guard: every row scoped to one instrument_id by PK. '
+    'Synthetic backfill from former_names is NOT performed — '
+    'former_names is name history, not symbol history. The actual '
+    'symbol-change ingest lands in Batch 7.';
+```
+
+### Backfill semantics — `scripts/backfill_instrument_history.py`
+
+Idempotent. For each row in `instruments` joined to
+`instrument_sec_profile`:
+
+- Insert one `instrument_cik_history` row:
+  `(instrument_id, sec_profile.cik, effective_from = COALESCE(first_seen_at::date, CURRENT_DATE), effective_to = NULL, source_event = 'imported')`
+  with `ON CONFLICT DO NOTHING`.
+- Insert one `instrument_symbol_history` row for the **current symbol
+  only**:
+  `(instrument_id, symbol, effective_from = COALESCE(first_seen_at::date, CURRENT_DATE), effective_to = NULL, source_event = 'imported')`
+  with `ON CONFLICT DO NOTHING`.
+
+No synthesis from `former_names`. Re-running the script after Batch 7
+ingests real symbol-change events is safe — the conflict clauses
+no-op on existing rows.
+
+## API: `/api/instruments/{symbol}/ownership-rollup`
+
+### Coverage model — two distinct metrics
+
+This is the v2 spec's biggest change after Codex review. Two metrics
+ship in the payload, one of them drives the banner.
+
+**Float concentration** (`pct_outstanding_known`):
+- Definition: `sum(slice.total_shares) / shares_outstanding`.
+- Tells the operator: "X% of the float is held by filers we have on
+  record." For retail-heavy names this can legitimately be 30%
+  (because retail genuinely owns 70%) and that does NOT mean ingest
+  is incomplete.
+- Always computable. Surfaces as an info chip ("Known filers hold
+  X% of float"). Does NOT drive the banner.
+
+**Universe coverage** (`known_filers / estimated_universe`):
+- Per-category:
+  - **institutions:** known = `count(distinct filer_cik)` for the
+    latest 13F period; estimated = the per-instrument 13F filer
+    count from EDGAR full-text search (NULL until that ingest
+    pipeline lands — see #790).
+  - **blockholders:** known = `count(distinct filer_cik)` for active
+    13D/G chains; estimated = NULL (no canonical estimate; SEC
+    doesn't publish total ≥5% holder counts per instrument).
+  - **insiders:** known = `count(distinct filer_cik)` for Form 4 +
+    Form 3 baseline; estimated = NULL until #790 ships the
+    `instrument_named_insiders` count (DEF 14A roster size).
+  - **etfs:** known = `count(distinct filer_cik)` for ETF 13F
+    filers; estimated = NULL.
+- Tells the operator: "We have visibility on Y of Z filers SEC says
+  exist for this instrument." This is the actual ingest-completeness
+  signal.
+
+**Banner state machine** (driven by universe coverage):
+
+Per-category state (fold over the four tracked categories — insiders,
+blockholders, institutions, etfs):
+
+**Single canonical enum:** `no_data | red | unknown_universe | amber | green`.
+Used identically as the per-category state, the banner state, and the
+response payload value.
+
+| Per-category state | Condition |
+|---|---|
+| `no_data` | `shares_outstanding IS NULL` (overrides every per-category state) |
+| `unknown_universe` | `estimated_universe IS NULL` |
+| `red` | `known_filers / estimated_universe < 0.50` |
+| `amber` | `0.50 ≤ known_filers / estimated_universe < 0.80` |
+| `green` | `known_filers / estimated_universe ≥ 0.80` |
+
+**Banner state is the worst-of across categories**, with this strict
+priority (worst → best): `no_data > red > unknown_universe > amber > green`.
+The reason `unknown_universe` ranks worse than `amber`: a category with
+an estimate and 65% coverage is *known* to be partial; a category
+without an estimate is *unknown*, so the operator gets less
+reassurance. Promoting `unknown_universe` to merely "amber-ish" would
+let one well-seeded category mask blind spots in others — Codex flagged
+this on the v2 review.
+
+| Banner state | Render |
+|---|---|
+| `no_data` | Red banner. "Cannot compute ownership — XBRL shares outstanding not on file. Trigger fundamentals sync." |
+| `red` | Red banner. "Coverage incomplete in `{worst_category}` — do not use for investment decisions. `{known}` of `{estimated}` known filers in `{worst_category}`; `{unknown_count}` categories without an estimate." |
+| `unknown_universe` | Yellow banner. "Coverage estimate not available for `{unknown_categories_list}`. Known filings represent `{pct}`% of float. Treat as best-effort until coverage expansion lands (#790)." |
+| `amber` | Amber banner. "Limited coverage in `{worst_category}` — verify against SEC EDGAR for major positions." |
+| `green` | Green badge. "Coverage ≥ 80% universe coverage across all four categories." |
+
+In v1 every instrument lands in the `unknown_universe` state because no
+estimates are seeded. That's the honest answer and the banner says so
+explicitly. As #790 lands per-category estimates one at a time, the
+banner stays in `unknown_universe` until **every** category has an
+estimate; then it can finally settle into `green` / `amber` / `red`.
+
+### Response shape
+
+```jsonc
+{
+  "symbol": "GME",
+  "instrument_id": 730001,
+  "shares_outstanding": 448375157,
+  "shares_outstanding_as_of": "2026-03-18",
+  "shares_outstanding_source": {
+    "accession_number": "0001326380-25-...",
+    "concept": "EntityCommonStockSharesOutstanding",
+    "form_type": "10-Q"
+  },
+  "treasury_shares": 0,
+  "treasury_as_of": null,
+  "slices": [
+    {
+      "category": "insiders",
+      "label": "Insiders",
+      "total_shares": 38353123,
+      "pct_outstanding": 0.0856,
+      "filer_count": 5,
+      "dominant_source": "form4",
+      "holders": [
+        {
+          "filer_cik": "0001767470",
+          "filer_name": "Cohen Ryan",
+          "shares": 36847842,
+          "pct_outstanding": 0.0822,
+          "winning_source": "form4",
+          "winning_accession": "0001767470-25-000003",
+          "as_of_date": "2025-08-12",
+          "dropped_sources": [
+            {"source": "13d", "accession": "0001767470-25-000001", "shares": 36847842}
+          ]
+        }
+      ]
+    },
+    {"category": "blockholders", "...": "..."},
+    {"category": "institutions", "...": "..."},
+    {"category": "etfs", "...": "..."},
+    {"category": "def14a_unmatched", "...": "..."}
+  ],
+  "residual": {
+    "shares": 408456901,
+    "pct_outstanding": 0.9112,
+    "label": "Public / unattributed",
+    "tooltip": "Shares outstanding minus all known regulated filings and treasury. Includes retail, undeclared institutional, and any filer outside our coverage cohort.",
+    "oversubscribed": false
+  },
+  "concentration": {
+    "pct_outstanding_known": 0.0856,
+    "info_chip": "Known filers hold 8.56% of float."
+  },
+  "coverage": {
+    "state": "unknown_universe",
+    "categories": {
+      "insiders":     {"known_filers": 5, "estimated_universe": null, "pct_universe": null},
+      "blockholders": {"known_filers": 1, "estimated_universe": null, "pct_universe": null},
+      "institutions": {"known_filers": 7, "estimated_universe": null, "pct_universe": null},
+      "etfs":         {"known_filers": 4, "estimated_universe": null, "pct_universe": null}
+    }
+  },
+  "banner": {
+    "state": "unknown_universe",
+    "variant": "warning",
+    "headline": "Coverage estimate not available",
+    "body": "Known filings represent 8.56% of float. Universe estimate per category not yet seeded (#790). Treat as best-effort."
+  },
+  "computed_at": "2026-05-03T14:21:09Z"
+}
+```
+
+### Dedup priority + DEF 14A enrichment
+
+**Sources:** `form4`, `form3`, `13d`, `13g`, `def14a`, `13f`.
+**Priority rank** (lower = wins):
+
+| Source | Rank | as_of column |
+|---|---|---|
+| `form4` | 1 | `txn_date` |
+| `form3` | 2 | `as_of_date` |
+| `13d` | 3 | `filed_at` |
+| `13g` | 3 | `filed_at` |
+| `def14a` | 4 | `as_of_date` |
+| `13f` | 5 | `period_of_report` |
+
+**Tie-break:** `priority_rank ASC, as_of_date DESC NULLS LAST,
+accession_number DESC, source_row_id DESC`.
+
+**DEF 14A enrichment** — DEF 14A holders carry `holder_name` only, no
+`filer_cik`. Before they enter dedup the rollup service calls
+`resolve_holder_to_filer_cik(conn, instrument_id, holder_name)` —
+extracted from `def14a_drift._resolve_holder_match` into a shared
+module `app/services/holder_name_resolver.py` so both consumers
+share one source of truth. The resolver returns `(matched_filer_cik,
+matched_via_source)`:
+
+- If the resolver returns a CIK, the DEF 14A row enters dedup with
+  `filer_cik = matched_cik`. Form 4 will win the priority race
+  (rank 1 < rank 4) so the DEF 14A row will lose, but its accession
+  ships in `dropped_sources` for provenance.
+- If the resolver returns no CIK, the DEF 14A row goes to the
+  `def14a_unmatched` slice keyed on `holder_name` (no CIK is available
+  to dedup against). These are mostly named officers who appear in
+  the proxy but never filed a Form 4 — rare but real.
+
+The resolver is the same code path the existing DEF 14A drift detector
+uses, so the consistency story is "if drift detection sees a match,
+ownership rollup also sees it; if drift detection treats it as a
+coverage gap, ownership rollup sends it to the unmatched slice."
+
+**SQL implementation** for the `form4 ∪ form3 ∪ 13d ∪ 13g ∪ 13f` union:
+
+**Identity key** (used for both dedup and Form 3 suppression):
+
+```
+identity := CASE
+    WHEN filer_cik IS NOT NULL THEN 'CIK:' || filer_cik
+    ELSE 'NAME:' || LOWER(TRIM(filer_name))
+END
+```
+
+This convention follows the existing repo pattern (`def14a_drift._normalise_name`,
+`get_instrument_blockholders` reporter-identity fallback). Codex v2
+review caught the prior version where Form 3 suppression collapsed every
+NULL-CIK Form 4 row into one bucket and over-suppressed unrelated
+NULL-CIK Form 3 filers — the identity key fixes that by name-falling
+back per row.
+
+**Canonical-holder union SQL** (5 sources; DEF 14A union'd in Python):
+
+```sql
+WITH canonical_holders AS (
+    -- Form 4 latest cumulative per filer
+    SELECT 'form4'::text AS source, 1 AS priority_rank,
+           filer_cik, filer_name,
+           NULL::text AS filer_type,
+           post_transaction_shares AS shares,
+           txn_date AS as_of_date,
+           accession_number,
+           id AS source_row_id
+    FROM (
+        SELECT DISTINCT ON (
+            CASE WHEN filer_cik IS NOT NULL
+                 THEN 'CIK:' || filer_cik
+                 ELSE 'NAME:' || LOWER(TRIM(filer_name)) END
+        )
+            filer_cik, filer_name, post_transaction_shares,
+            txn_date, accession_number, id
+        FROM insider_transactions
+        WHERE instrument_id = %(iid)s
+          AND post_transaction_shares IS NOT NULL
+          AND is_derivative = FALSE
+        ORDER BY
+            CASE WHEN filer_cik IS NOT NULL
+                 THEN 'CIK:' || filer_cik
+                 ELSE 'NAME:' || LOWER(TRIM(filer_name)) END,
+            txn_date DESC NULLS LAST, id DESC
+    ) AS form4_latest
+
+    UNION ALL
+
+    -- Form 3 baseline only for filers with NO Form 4 row sharing the
+    -- same identity. Identity uses CIK when present, else
+    -- normalised name — so two distinct NULL-CIK officers don't
+    -- silently suppress each other.
+    SELECT 'form3'::text AS source, 2 AS priority_rank,
+           iih.filer_cik, iih.filer_name,
+           NULL::text AS filer_type,
+           iih.shares, iih.as_of_date,
+           iih.accession_number, iih.id AS source_row_id
+    FROM insider_initial_holdings iih
+    WHERE iih.instrument_id = %(iid)s
+      AND iih.shares IS NOT NULL
+      AND iih.is_derivative = FALSE
+      AND NOT EXISTS (
+          SELECT 1 FROM insider_transactions it
+          WHERE it.instrument_id = iih.instrument_id
+            AND it.post_transaction_shares IS NOT NULL
+            AND it.is_derivative = FALSE
+            AND (
+                (it.filer_cik IS NOT NULL AND iih.filer_cik IS NOT NULL
+                 AND it.filer_cik = iih.filer_cik)
+                OR
+                (it.filer_cik IS NULL AND iih.filer_cik IS NULL
+                 AND LOWER(TRIM(it.filer_name)) = LOWER(TRIM(iih.filer_name)))
+            )
+      )
+
+    UNION ALL
+
+    -- 13D/G per-block (joint-filer collapse already at reader layer)
+    SELECT
+        CASE WHEN bf.submission_type LIKE 'SCHEDULE 13D%' THEN '13d'
+             ELSE '13g' END AS source,
+        3 AS priority_rank,
+        COALESCE(bf.reporter_cik, f.cik) AS filer_cik,
+        COALESCE(bf.reporter_name, f.name) AS filer_name,
+        NULL::text AS filer_type,
+        block.aggregate_amount_owned AS shares,
+        block.filed_at::date AS as_of_date,
+        block.accession_number,
+        block.filing_id AS source_row_id
+    FROM (
+        -- Per-accession-block max-aggregate, mirrors the existing
+        -- /blockholders rollup (joint reporters collapsed to MAX).
+        SELECT DISTINCT ON (accession_number)
+               filing_id, accession_number, submission_type,
+               aggregate_amount_owned, filed_at, filer_id
+        FROM blockholder_filings
+        WHERE instrument_id = %(iid)s
+          AND aggregate_amount_owned IS NOT NULL
+        ORDER BY accession_number, aggregate_amount_owned DESC NULLS LAST
+    ) AS block
+    JOIN blockholder_filings bf ON bf.filing_id = block.filing_id
+    JOIN blockholder_filers f ON f.filer_id = block.filer_id
+
+    UNION ALL
+
+    -- 13F latest period only, equity-only. ``filer_type`` is carried
+    -- through here because the slice bucketer (institutions vs ETFs)
+    -- depends on it post-dedup. Codex v2 caught that v1's UNION
+    -- dropped the column.
+    SELECT '13f'::text AS source, 5 AS priority_rank,
+           f.cik AS filer_cik, f.name AS filer_name,
+           COALESCE(f.filer_type, 'OTHER') AS filer_type,
+           h.shares, h.period_of_report AS as_of_date,
+           h.accession_number, h.holding_id AS source_row_id
+    FROM institutional_holdings h
+    JOIN institutional_filers f USING (filer_id)
+    WHERE h.instrument_id = %(iid)s
+      AND h.is_put_call IS NULL
+      AND h.period_of_report = (
+          SELECT MAX(period_of_report) FROM institutional_holdings
+          WHERE instrument_id = %(iid)s
+      )
+
+    -- DEF 14A union'd in Python after the holder-name resolver runs
+    -- (no filer_cik in def14a_beneficial_holdings — the resolver
+    -- enriches holder_name → filer_cik before dedup). DEF 14A rows
+    -- carry filer_type=NULL.
+)
+SELECT DISTINCT ON (
+    CASE WHEN filer_cik IS NOT NULL
+         THEN 'CIK:' || filer_cik
+         ELSE 'NAME:' || LOWER(TRIM(filer_name)) END
+)
+    *
+FROM canonical_holders
+ORDER BY
+    CASE WHEN filer_cik IS NOT NULL
+         THEN 'CIK:' || filer_cik
+         ELSE 'NAME:' || LOWER(TRIM(filer_name)) END,
+    priority_rank ASC,
+    as_of_date DESC NULLS LAST,
+    accession_number DESC,
+    source_row_id DESC
+```
+
+After dedup `filer_type` survives only on rows whose winning source is
+`13f` (the only source where `filer_type` is meaningful). The bucketer
+uses it directly:
+
+```python
+def _bucket_into_slices(survivors: list[CanonicalHolder]) -> list[OwnershipSlice]:
+    insiders, blocks, instits, etfs, def14a_unmatched = [], [], [], [], []
+    for h in survivors:
+        if h.source in ("form4", "form3"):
+            insiders.append(h)
+        elif h.source in ("13d", "13g"):
+            blocks.append(h)
+        elif h.source == "def14a":
+            # def14a winners are rare (priority 4 — only fires when no
+            # higher source has the holder); they go into insiders if
+            # the resolver matched a Form 4 filer, else def14a_unmatched.
+            insiders.append(h)
+        elif h.source == "13f":
+            if h.filer_type == "ETF":
+                etfs.append(h)
+            else:
+                instits.append(h)
+        else:
+            raise ValueError(f"unknown source {h.source}")
+    return [...]
+```
+
+The `'__NAME__:' || filer_name` fallback handles legacy NULL-CIK rows
+the same way `def14a_drift._resolve_holder_match` does — keeps them
+addressable rather than collapsed into one bucket.
+
+DEF 14A rows get unioned in Python after the SQL pass:
+
+```python
+def _enrich_and_union_def14a(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    sql_survivors: list[CanonicalHolder],
+) -> list[CanonicalHolder]:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT * FROM def14a_beneficial_holdings WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        def14a_rows = cur.fetchall()
+    enriched = []
+    unmatched = []
+    for row in def14a_rows:
+        cik = resolve_holder_to_filer_cik(conn, instrument_id, row["holder_name"])
+        candidate = CanonicalHolder(
+            source="def14a", priority_rank=4,
+            filer_cik=cik, filer_name=row["holder_name"],
+            shares=row["shares"], as_of_date=row["as_of_date"],
+            accession_number=row["accession_number"],
+            source_row_id=row["holding_id"],
+        )
+        (enriched if cik else unmatched).append(candidate)
+    # Re-run dedup with DEF 14A inserted; record which ones lost.
+    return _dedup(sql_survivors + enriched), unmatched
+```
+
+### Slice categorisation
+
+| Bucket | Survivors | Notes |
+|---|---|---|
+| `insiders` | Form 4 + Form 3 winners | |
+| `blockholders` | 13D/G winners | One block per accession (joint reporters collapse pre-dedup) |
+| `institutions` | 13F winners with `filer_type IN ('INV','INS','BD','OTHER')` | Equity-only |
+| `etfs` | 13F winners with `filer_type = 'ETF'` | |
+| `def14a_unmatched` | DEF 14A rows the resolver couldn't match | Rare; often named officers without Form 4 |
+
+Treasury is its own additive top wedge sourced from the
+`pickLatestBalance` mirror server-side.
+
+### Residual math + oversubscription guard
+
+```python
+def _compute_residual(outstanding, slices, treasury):
+    sum_known = sum(s.total_shares for s in slices)
+    raw = outstanding - sum_known - (treasury or 0)
+    return ResidualBlock(
+        shares=max(raw, 0),
+        pct_outstanding=max(raw, 0) / outstanding,
+        oversubscribed=raw < 0,
+        label="Public / unattributed",
+        tooltip="...",
+    )
+```
+
+Frontend renders the wedge with its actual size; when
+`oversubscribed=true` a red info bar shows above the chart: "Category
+totals exceed shares outstanding by X. Likely cause: stale 13F
+quarter combined with fresh Form 4 / 13D. Awaiting next 13F cycle."
+
+### Reader implementation
+
+`app/services/ownership_rollup.py`:
+
+```python
+def get_ownership_rollup(
+    conn: psycopg.Connection[Any], instrument_id: int
+) -> OwnershipRollup:
+    # Caller (the FastAPI handler) must already be inside snapshot_read;
+    # this service does not open its own transaction.
+    outstanding = _read_shares_outstanding(conn, instrument_id)
+    treasury = _read_treasury(conn, instrument_id)
+    if outstanding is None:
+        return OwnershipRollup.no_data(instrument_id)
+    holders_no_def14a = _collect_canonical_holders_sql(conn, instrument_id)
+    holders_with_def14a, unmatched_def14a = _enrich_and_union_def14a(
+        conn, instrument_id, holders_no_def14a
+    )
+    survivors = _dedup_by_priority(holders_with_def14a)
+    slices = _bucket_into_slices(survivors)
+    if unmatched_def14a:
+        slices.append(_build_def14a_unmatched_slice(unmatched_def14a, outstanding))
+    residual = _compute_residual(outstanding, slices, treasury)
+    coverage = _compute_coverage(slices, conn, instrument_id)
+    banner = _compute_banner_state(outstanding, coverage)
+    return OwnershipRollup(...)
+```
+
+### Endpoint
+
+```python
+@router.get(
+    "/{symbol}/ownership-rollup",
+    response_model=OwnershipRollupResponse,
+)
+def get_instrument_ownership_rollup(
+    symbol: str,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> OwnershipRollupResponse:
+    """Cross-channel deduped ownership rollup. Tier 0 of #788."""
+    with snapshot_read(conn):
+        instrument_id = _resolve_instrument_id(conn, symbol)
+        rollup = ownership_rollup.get_ownership_rollup(conn, instrument_id)
+    return _to_response_model(rollup)
+```
+
+Empty / pre-ingest state: `slices=[]`, `coverage.state='unknown_universe'`
+(or `'no_data'` if `shares_outstanding IS NULL`), residual = outstanding.
+200 OK with the warning banner. 404 reserved for unknown symbol. The
+endpoint never returns 503 — `no_data` is a banner state, not an error.
+
+## Frontend
+
+### `frontend/src/api/ownership.ts`
+
+New module — single `fetchOwnershipRollup(symbol)` function returning
+the typed payload. Replaces three of the existing five fetches in
+`OwnershipPanel.tsx`:
+
+- `fetchInstitutionalHoldings` — replaced
+- `fetchBlockholders` — replaced
+- `fetchInsiderTransactions` + `fetchInsiderBaseline` — replaced
+
+`fetchInstrumentFinancials("balance")` stays for non-ownership
+balance-sheet rows on the L1 page; the rollup endpoint sources
+`shares_outstanding` and `treasury_shares` server-side.
+
+L2 page (`OwnershipPage.tsx`) keeps its existing fetches because it
+needs the per-filer drilldown shape that the rollup endpoint
+deliberately doesn't return at full granularity (top-50 only). Batch 3
+expands the rollup payload with a `per_filer_detail_url` link instead
+of inlining hundreds of filers.
+
+### `OwnershipPanel.tsx`
+
+- Drop `shares_outstanding + treasury_shares` math at L505. Denominator
+  is `data.outstanding` from the rollup response.
+- Drop the multi-fetch `useAsync` wiring; replace with one
+  `fetchOwnershipRollup` call.
+- Render the banner driven by `rollup.banner.state`:
+  - `no_data` → red banner with sync-trigger CTA copy
+  - `unknown_universe` → yellow banner with the explicit "Estimate
+    not available" copy
+  - `red` / `amber` / `green` → matching variant
+- Render the residual wedge with the new label "Public / unattributed".
+- Treasury renders as a category wedge on top, additive — same as today
+  but with the corrected denominator.
+- Concentration info chip below banner: "Known filers hold X% of float."
+- Oversubscription warning bar above the chart when
+  `rollup.residual.oversubscribed=true`.
+
+### `OwnershipPage.tsx` (L2)
+
+- Drop `shares_outstanding + treasury_shares` math at L331. Denominator
+  is `outstanding` only.
+- L1 wedge label fix is **out of scope** for this batch (Batch 2 #791).
+
+### `ownershipRings.ts`
+
+- Drop treasury-in-denominator math at the call sites.
+- Update comment header to document the corrected denominator semantics.
+- Cross-category oversubscription guard stays.
+
+## Tests
+
+### Backend
+
+`tests/test_ownership_rollup.py` (new):
+
+- `test_dedup_form4_beats_13d_for_same_cik` — Cohen on GME shape.
+- `test_joint_filer_13d_collapses_to_one_block` — verify rollup respects
+  the existing reader's per-accession MAX collapse.
+- `test_13f_loses_to_13g_on_same_cik` — 13G 5%, 13F same filer 4.9%.
+- `test_def14a_resolver_matches_form4_filer` — DEF 14A holder name
+  resolves to a Form 4 filer_cik via the shared resolver. Form 4 wins
+  priority; DEF 14A row's accession lands in `dropped_sources`.
+- `test_def14a_unmatched_when_resolver_fails` — proxy-only holder with
+  no Form 4 / Form 3, expect `def14a_unmatched` slice membership.
+- `test_dedup_tie_break_uses_accession_then_row_id` — two rows same
+  source / same as_of_date, deterministic ordering.
+- `test_residual_label_and_value` — fixture with 30% known + 10%
+  treasury, residual=60% with `oversubscribed=false`.
+- `test_residual_oversubscribed_flag` — fixture where holders sum to
+  110% of outstanding, residual=0 with `oversubscribed=true`.
+- `test_coverage_state_no_data` — instrument with NULL outstanding.
+- `test_coverage_state_unknown_universe_default` — no estimates seeded.
+- `test_coverage_state_red_when_universe_below_50` — fixture with
+  estimate=100, known=30 → red banner.
+- `test_coverage_state_amber_when_50_to_80` — fixture with 65%
+  universe coverage in worst category.
+- `test_coverage_state_green_when_all_above_80` — fixture with every
+  category-with-estimate ≥ 80%.
+- `test_concentration_info_chip_always_present` — chip text reflects
+  `pct_outstanding_known` regardless of banner state.
+- `test_treasury_excluded_from_concentration_numerator` — fixture
+  with 10% treasury, 50% known, concentration = 50% (not 60%).
+- `test_snapshot_isolation_holds_under_concurrent_write` — start two
+  threads, one writes a new Form 4 mid-rollup, expect rollup to see
+  the pre-write snapshot.
+- `test_holder_name_resolver_extraction_parity` — assert the lifted
+  `holder_name_resolver.resolve_holder_to_filer_cik` returns the same
+  result as the original `def14a_drift._resolve_holder_match` for a
+  matrix of input names.
+
+### Smoke / migration
+
+`tests/smoke/test_app_boots.py` — extend with
+`test_insider_initial_holdings_value_owned_column_exists` against the
+live DB.
+
+`tests/smoke/test_schema_drift.py` (new — pulls B5 of #797 forward):
+
+For every migration in `sql/`, parse the `CREATE TABLE` blocks and
+assert every declared column exists in `information_schema.columns`.
+Fails fast on missing columns. Tolerates extra columns (added by later
+ALTER TABLE migrations).
+
+`tests/test_instrument_history.py` (new):
+
+- `test_cik_history_overlap_rejected` — insert overlapping ranges,
+  expect `IntegrityError` from EXCLUDE constraint.
+- `test_cik_history_two_current_rejected` — two rows with `effective_to
+  IS NULL` for the same instrument, expect `IntegrityError`.
+- `test_cik_history_inverted_range_rejected` — `effective_to <
+  effective_from`, expect `IntegrityError`.
+- `test_symbol_history_same_symbol_two_instruments_allowed` — symbol
+  reused across instruments at different times, expect both inserts
+  succeed (PK is per-instrument).
+- `test_backfill_idempotent` — run the backfill script twice, assert
+  no row count change second time.
+- `test_historical_ciks_for_returns_imported_row` — after backfill, the
+  helper returns the seeded CIK.
+
+### Frontend
+
+`frontend/src/components/instrument/OwnershipPanel.test.tsx` (extend):
+
+- Snapshot fixture with GME-shaped rollup → single Cohen insider row,
+  no double-count, residual = "Public / unattributed",
+  unknown_universe banner.
+- Treasury-bearing fixture (AAPL synthetic): treasury wedge added,
+  denominator unchanged, residual still > 0.
+- Banner state machine: 5 fixtures — `no_data`, `unknown_universe`,
+  `red`, `amber`, `green` — each asserts the right banner variant +
+  copy.
+- Oversubscription warning bar fixture: `residual.oversubscribed=true`
+  asserts the warning copy renders above the chart.
+
+`frontend/src/api/ownership.test.ts` (new): contract test against a
+captured live response fixture from the dev DB.
+
+## File touchpoints
+
+- `sql/101_insider_initial_holdings_value_owned.sql` (new)
+- `sql/102_instrument_cik_history.sql` (new — incl. btree_gist + EXCLUDE)
+- `sql/103_instrument_symbol_history.sql` (new — incl. EXCLUDE)
+- `app/services/ownership_rollup.py` (new)
+- `app/services/holder_name_resolver.py` (new — lifted from
+  `def14a_drift._normalise_name` + `_resolve_holder_match`)
+- `app/services/def14a_drift.py` (refactor — import from
+  `holder_name_resolver` instead of inline private helpers)
+- `app/services/instrument_history.py` (new — `historical_ciks_for(iid)`)
+- `app/api/instruments.py` (new endpoint, `snapshot_read` wrap)
+- `scripts/backfill_instrument_history.py` (new, idempotent, current
+  symbol + current CIK only)
+- `tests/test_ownership_rollup.py` (new)
+- `tests/test_instrument_history.py` (new)
+- `tests/test_holder_name_resolver.py` (new — extraction parity)
+- `tests/smoke/test_app_boots.py` (extend)
+- `tests/smoke/test_schema_drift.py` (new — B5 of #797 pulled forward)
+- `tests/fixtures/ebull_test_db.py` (`_PLANNER_TABLES` extended)
+- `frontend/src/api/ownership.ts` (new)
+- `frontend/src/api/ownership.test.ts` (new)
+- `frontend/src/components/instrument/OwnershipPanel.tsx` (rewrite
+  body, banner, residual relabel, oversubscription warning)
+- `frontend/src/components/instrument/OwnershipPanel.test.tsx` (extend)
+- `frontend/src/components/instrument/ownershipRings.ts` (drop
+  treasury-in-denominator math)
+- `frontend/src/pages/OwnershipPage.tsx` (denominator fix only)
+
+## Open questions
+
+1. ~~`estimated_universe` for institutions~~ — resolved: NULL in v1,
+   filled in by #790 alongside the per-instrument 13F filer-count
+   ingest. Banner reflects the unknown-universe state honestly.
+2. **`shares_outstanding` source** — reuse `instrument_share_count_latest`
+   view. Confirmed.
+3. **Endpoint version** — single-version v1.
+
+## Codex spec review
+
+v2 ready for re-review:
+
+```
+codex.cmd exec resume --last "Re-review the spec at docs/superpowers/specs/2026-05-03-ownership-tier0-and-cik-history-design.md after the v2 revision. Confirm fixes for the 6 prior findings and call out any new gaps. Reply terse."
+```

--- a/frontend/src/api/ownership.ts
+++ b/frontend/src/api/ownership.ts
@@ -1,0 +1,162 @@
+/**
+ * Client for /instruments/{symbol}/ownership-rollup (#789, parent
+ * #788).
+ *
+ * Cross-channel deduped ownership snapshot: insiders + blockholders +
+ * institutions + ETFs + def14a-unmatched, all keyed on a single
+ * ``shares_outstanding`` denominator. The single endpoint replaces
+ * three of the five fetches the prior ``OwnershipPanel`` made
+ * (institutional / blockholders / insiders) so the panel can render
+ * one consistent snapshot without race-induced double-counting.
+ *
+ * Banner state machine (driven server-side from per-category
+ * universe coverage, NOT float concentration):
+ *
+ *   * ``no_data`` — XBRL ``shares_outstanding`` not on file.
+ *   * ``unknown_universe`` — outstanding present but per-category
+ *     universe estimates are NULL (Tier 0 default until #790).
+ *   * ``red`` / ``amber`` / ``green`` — only after #790 seeds
+ *     per-category estimates.
+ *
+ * Concentration (sum of slices / outstanding) ships as a separate
+ * info chip — Codex review of the v2 spec caught the prior banner
+ * design that conflated concentration with coverage.
+ */
+
+import { apiFetch } from "@/api/client";
+
+export type OwnershipSourceTag =
+  | "form4"
+  | "form3"
+  | "13d"
+  | "13g"
+  | "def14a"
+  | "13f";
+
+export type OwnershipSliceCategory =
+  | "insiders"
+  | "blockholders"
+  | "institutions"
+  | "etfs"
+  | "def14a_unmatched";
+
+export type OwnershipCoverageState =
+  | "no_data"
+  | "red"
+  | "unknown_universe"
+  | "amber"
+  | "green";
+
+export type OwnershipBannerVariant = "error" | "warning" | "info" | "success";
+
+export interface OwnershipDroppedSource {
+  readonly source: OwnershipSourceTag;
+  readonly accession_number: string;
+  /** Decimal-as-string. */
+  readonly shares: string;
+  readonly as_of_date: string | null;
+}
+
+export interface OwnershipHolder {
+  readonly filer_cik: string | null;
+  readonly filer_name: string;
+  /** Decimal-as-string. */
+  readonly shares: string;
+  /** Decimal-as-string fraction (e.g. ``"0.0822"`` = 8.22%). */
+  readonly pct_outstanding: string;
+  readonly winning_source: OwnershipSourceTag;
+  readonly winning_accession: string;
+  readonly as_of_date: string | null;
+  /** 13F filer-type tag — only populated for 13F survivors. */
+  readonly filer_type: string | null;
+  /**
+   * One row per losing source for this canonical holder. Surfaces
+   * in the Batch 3 provenance footer so the operator can see the
+   * full set of accessions that referred to this holder, even
+   * though only one supplied the share count used.
+   */
+  readonly dropped_sources: readonly OwnershipDroppedSource[];
+}
+
+export interface OwnershipSlice {
+  readonly category: OwnershipSliceCategory;
+  readonly label: string;
+  /** Decimal-as-string. */
+  readonly total_shares: string;
+  readonly pct_outstanding: string;
+  readonly filer_count: number;
+  readonly dominant_source: OwnershipSourceTag | null;
+  readonly holders: readonly OwnershipHolder[];
+}
+
+export interface OwnershipResidual {
+  readonly shares: string;
+  readonly pct_outstanding: string;
+  readonly label: string;
+  readonly tooltip: string;
+  /** True when slice totals + treasury exceed shares_outstanding
+   *  (stale 13F + fresh Form 4/13D mix). The renderer shows a
+   *  warning bar above the chart in this case; residual itself is
+   *  clamped to 0. */
+  readonly oversubscribed: boolean;
+}
+
+export interface OwnershipCategoryCoverage {
+  readonly known_filers: number;
+  readonly estimated_universe: number | null;
+  readonly pct_universe: string | null;
+  readonly state: OwnershipCoverageState;
+}
+
+export interface OwnershipCoverage {
+  /** Worst-of fold across the four tracked categories (insiders,
+   *  blockholders, institutions, etfs). ``unknown_universe`` ranks
+   *  worse than ``amber`` so a single well-seeded category cannot
+   *  mask blind spots in the others. */
+  readonly state: OwnershipCoverageState;
+  readonly categories: Readonly<Record<string, OwnershipCategoryCoverage>>;
+}
+
+export interface OwnershipConcentration {
+  readonly pct_outstanding_known: string;
+  readonly info_chip: string;
+}
+
+export interface OwnershipBanner {
+  readonly state: OwnershipCoverageState;
+  readonly variant: OwnershipBannerVariant;
+  readonly headline: string;
+  readonly body: string;
+}
+
+export interface OwnershipSharesOutstandingSource {
+  readonly accession_number: string | null;
+  readonly concept: string | null;
+  readonly form_type: string | null;
+}
+
+export interface OwnershipRollupResponse {
+  readonly symbol: string;
+  readonly instrument_id: number;
+  /** Decimal-as-string; null when XBRL has no figure on file (= the
+   *  ``no_data`` banner state). */
+  readonly shares_outstanding: string | null;
+  readonly shares_outstanding_as_of: string | null;
+  readonly shares_outstanding_source: OwnershipSharesOutstandingSource;
+  readonly treasury_shares: string | null;
+  readonly treasury_as_of: string | null;
+  readonly slices: readonly OwnershipSlice[];
+  readonly residual: OwnershipResidual;
+  readonly concentration: OwnershipConcentration;
+  readonly coverage: OwnershipCoverage;
+  readonly banner: OwnershipBanner;
+  readonly computed_at: string;
+}
+
+export function fetchOwnershipRollup(
+  symbol: string,
+): Promise<OwnershipRollupResponse> {
+  return apiFetch<OwnershipRollupResponse>(
+    `/instruments/${encodeURIComponent(symbol)}/ownership-rollup`,
+  );
+}

--- a/frontend/src/components/instrument/OwnershipPanel.test.ts
+++ b/frontend/src/components/instrument/OwnershipPanel.test.ts
@@ -1,485 +1,330 @@
 /**
- * Unit tests for the ownership panel's data extraction.
+ * Unit tests for the ownership panel's rollup-mapping helper
+ * (``rollupToSunburstInputs``) — the pure function that converts the
+ * deduped server payload into the chart's ``SunburstInputs`` shape.
  *
- * Focused on the Form 3 baseline merging behaviour added in #768 PR4.
- * The full panel is React+ResponsiveContainer-heavy and not amenable
- * to a fast unit test; we test the pure ``extractData`` helper that
- * decides which insider holders surface on the per-officer ring.
+ * The full panel rendering is React+ResponsiveContainer-heavy and
+ * not amenable to a fast unit test; we focus on the data
+ * transformation invariants that matter for correctness:
+ *
+ *   * Denominator stays at ``shares_outstanding`` even when treasury
+ *     > 0 (codex audit 2026-05-03 ship-blocker).
+ *   * Empty / pre-ingest payloads return ``null`` so the panel
+ *     renders the empty state.
+ *   * Per-category totals + holder lists round-trip from the rollup
+ *     into the SunburstInputs shape with no double-counting.
+ *
+ * The banner state machine + oversubscription warning are tested
+ * against the response shape directly (they are simple enum-keyed
+ * renders) — see the per-state assertions below.
  */
 
 import { describe, expect, it } from "vitest";
 
-import type { BlockholdersResponse } from "@/api/blockholders";
-import type {
-  InsiderBaselineList,
-  InsiderTransactionsList,
-} from "@/api/instruments";
-import type { InstitutionalHoldingsResponse } from "@/api/institutionalHoldings";
-import type { InstrumentFinancials } from "@/api/types";
+import type { OwnershipRollupResponse } from "@/api/ownership";
 
-import { extractData } from "./OwnershipPanel";
+import { rollupToSunburstInputs } from "./OwnershipPanel";
 
-const _BALANCE: InstrumentFinancials = {
-  symbol: "AAPL",
-  statement: "balance",
-  period: "quarterly",
-  currency: "USD",
-  source: "sec_xbrl",
-  rows: [
-    {
-      period_end: "2026-03-28",
-      values: {
-        shares_outstanding: "14000000000",
-        treasury_shares: "100000000",
-      },
+function _baseRollup(
+  overrides: Partial<OwnershipRollupResponse> = {},
+): OwnershipRollupResponse {
+  return {
+    symbol: "TEST",
+    instrument_id: 1,
+    shares_outstanding: "1000000000",
+    shares_outstanding_as_of: "2026-03-31",
+    shares_outstanding_source: {
+      accession_number: null,
+      concept: "EntityCommonStockSharesOutstanding",
+      form_type: null,
     },
-  ],
-} as unknown as InstrumentFinancials;
+    treasury_shares: null,
+    treasury_as_of: null,
+    slices: [],
+    residual: {
+      shares: "1000000000",
+      pct_outstanding: "1",
+      label: "Public / unattributed",
+      tooltip: "tooltip",
+      oversubscribed: false,
+    },
+    concentration: {
+      pct_outstanding_known: "0",
+      info_chip: "Known filers hold 0% of float.",
+    },
+    coverage: {
+      state: "unknown_universe",
+      categories: {},
+    },
+    banner: {
+      state: "unknown_universe",
+      variant: "warning",
+      headline: "Coverage estimate not available",
+      body: "Treat as best-effort.",
+    },
+    computed_at: "2026-05-03T00:00:00Z",
+    ...overrides,
+  };
+}
 
-const _EMPTY_INSTITUTIONAL: InstitutionalHoldingsResponse = {
-  symbol: "AAPL",
-  totals: null,
-  filers: [],
-};
-
-const _EMPTY_INSIDERS: InsiderTransactionsList = {
-  symbol: "AAPL",
-  rows: [],
-};
-
-const _EMPTY_BASELINE: InsiderBaselineList = {
-  symbol: "AAPL",
-  rows: [],
-};
-
-const _EMPTY_BLOCKHOLDERS: BlockholdersResponse = {
-  symbol: "AAPL",
-  totals: null,
-  blockholders: [],
-};
-
-describe("extractData — Form 3 baseline merging (#768 PR4)", () => {
-  it("returns no insider holders when both Form 4 and baseline are empty", () => {
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE, _EMPTY_BLOCKHOLDERS);
-    expect(data.insider_holders).toHaveLength(0);
-    expect(data.insiders_total).toBeNull();
+describe("rollupToSunburstInputs — denominator stays on shares_outstanding", () => {
+  it("returns null when shares_outstanding is null", () => {
+    const inputs = rollupToSunburstInputs(
+      _baseRollup({ shares_outstanding: null }),
+    );
+    expect(inputs).toBeNull();
   });
 
-  it("surfaces baseline-only filers on the insider holders list", () => {
-    const baseline: InsiderBaselineList = {
-      symbol: "AAPL",
-      rows: [
-        {
-          filer_cik: "0001000099",
-          filer_name: "Doe, Jane",
-          filer_role: "officer:CFO",
-          security_title: "Common Stock",
-          is_derivative: false,
-          direct_indirect: "D",
-          shares: "12500",
-          value_owned: null,
-          as_of_date: "2026-01-15",
-        },
-      ],
-    };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline, _EMPTY_BLOCKHOLDERS);
-    expect(data.insider_holders).toHaveLength(1);
-    expect(data.insider_holders[0]!.label).toBe("Doe, Jane");
-    expect(data.insider_holders[0]!.shares).toBe(12500);
-    expect(data.insiders_total).toBe(12500);
+  it("returns null when shares_outstanding is zero", () => {
+    const inputs = rollupToSunburstInputs(
+      _baseRollup({ shares_outstanding: "0" }),
+    );
+    expect(inputs).toBeNull();
   });
 
-  it("merges Form 4 holders with baseline filers without overlap", () => {
-    // Backend's NOT EXISTS gate guarantees no CIK overlap between
-    // the two sets, but the frontend must additionally key the
-    // baseline rows under a distinct ``baseline:`` prefix so a
-    // future bug in the gate doesn't cause two same-CIK rows to
-    // collide on the same SunburstHolder.key (Recharts would
-    // silently drop one).
-    const insiders: InsiderTransactionsList = {
-      symbol: "AAPL",
-      rows: [
-        {
-          filer_cik: "0001000001",
-          filer_name: "Smith, John",
-          txn_date: "2026-04-15",
-          post_transaction_shares: "50000",
-          is_derivative: false,
-        },
-      ] as InsiderTransactionsList["rows"],
-    };
-    const baseline: InsiderBaselineList = {
-      symbol: "AAPL",
-      rows: [
-        {
-          filer_cik: "0001000099",
-          filer_name: "Doe, Jane",
-          filer_role: "officer:CFO",
-          security_title: "Common Stock",
-          is_derivative: false,
-          direct_indirect: "D",
-          shares: "12500",
-          value_owned: null,
-          as_of_date: "2026-01-15",
-        },
-      ],
-    };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, insiders, baseline, _EMPTY_BLOCKHOLDERS);
-    expect(data.insider_holders).toHaveLength(2);
-    const keys = data.insider_holders.map((h) => h.key);
-    expect(new Set(keys).size).toBe(2); // no key collision
-    expect(keys.some((k) => k.startsWith("baseline:"))).toBe(true);
-    // Total sums Form 4 + baseline.
-    expect(data.insiders_total).toBe(62500);
-  });
-
-  it("drops baseline rows with null or non-positive shares", () => {
-    // A baseline row with a null share count (e.g. value-branch
-    // holding without a share count, or a malformed ingest) must
-    // not produce a phantom wedge.
-    const baseline: InsiderBaselineList = {
-      symbol: "AAPL",
-      rows: [
-        {
-          filer_cik: "0001000099",
-          filer_name: "Null Filer",
-          filer_role: null,
-          security_title: "Series A Units",
-          is_derivative: false,
-          direct_indirect: "D",
-          shares: null,
-          value_owned: "250000",
-          as_of_date: "2026-01-15",
-        },
-        {
-          filer_cik: "0001000100",
-          filer_name: "Zero Filer",
-          filer_role: null,
-          security_title: "Common Stock",
-          is_derivative: false,
-          direct_indirect: "D",
-          shares: "0",
-          value_owned: null,
-          as_of_date: "2026-01-15",
-        },
-      ],
-    };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline, _EMPTY_BLOCKHOLDERS);
-    expect(data.insider_holders).toHaveLength(0);
-    // Codex / bot review of #768 PR4: the freshness chip's
-    // ``insiders_as_of`` must use the same eligibility predicate as
-    // the holders builder. A null/zero-shares baseline row that
-    // never renders must not advance the chip past the actual ring.
-    expect(data.insiders_as_of).toBeNull();
-  });
-
-  it("insiders_as_of takes the max of latest Form 4 txn_date and baseline as_of_date", () => {
-    // Issuer with one Form 4 row from 2026-02-10 and one baseline
-    // row from 2026-04-01 — the baseline date is more recent so
-    // the chip's "as of" reflects the baseline.
-    const insiders: InsiderTransactionsList = {
-      symbol: "AAPL",
-      rows: [
-        {
-          filer_cik: "0001000001",
-          filer_name: "Smith, John",
-          txn_date: "2026-02-10",
-          post_transaction_shares: "100",
-          is_derivative: false,
-        },
-      ] as InsiderTransactionsList["rows"],
-    };
-    const baseline: InsiderBaselineList = {
-      symbol: "AAPL",
-      rows: [
-        {
-          filer_cik: "0001000099",
-          filer_name: "Doe, Jane",
-          filer_role: null,
-          security_title: "Common Stock",
-          is_derivative: false,
-          direct_indirect: "D",
-          shares: "5000",
-          value_owned: null,
-          as_of_date: "2026-04-01",
-        },
-      ],
-    };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, insiders, baseline, _EMPTY_BLOCKHOLDERS);
-    expect(data.insiders_as_of).toBe("2026-04-01");
-  });
-
-  it("when Form 4 is newer than baseline, insiders_as_of takes the Form 4 date (Codex coverage gap)", () => {
-    const insiders: InsiderTransactionsList = {
-      symbol: "AAPL",
-      rows: [
-        {
-          filer_cik: "0001000001",
-          filer_name: "Smith, John",
-          txn_date: "2026-04-15",
-          post_transaction_shares: "50000",
-          is_derivative: false,
-        },
-      ] as InsiderTransactionsList["rows"],
-    };
-    const baseline: InsiderBaselineList = {
-      symbol: "AAPL",
-      rows: [
-        {
-          filer_cik: "0001000099",
-          filer_name: "Doe, Jane",
-          filer_role: null,
-          security_title: "Common Stock",
-          is_derivative: false,
-          direct_indirect: "D",
-          shares: "5000",
-          value_owned: null,
-          as_of_date: "2025-11-30",
-        },
-      ],
-    };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, insiders, baseline, _EMPTY_BLOCKHOLDERS);
-    // Form 4 (2026-04-15) is newer than baseline (2025-11-30) — chip
-    // takes the Form 4 date so the chip stays in lockstep with the
-    // most recent insider activity. An older baseline never silently
-    // overrides a newer trade.
-    expect(data.insiders_as_of).toBe("2026-04-15");
-  });
-
-  it("baseline-only issuer (no Form 4 rows) still produces an Insiders as_of_date", () => {
-    const baseline: InsiderBaselineList = {
-      symbol: "AAPL",
-      rows: [
-        {
-          filer_cik: "0001000099",
-          filer_name: "Doe, Jane",
-          filer_role: null,
-          security_title: "Common Stock",
-          is_derivative: false,
-          direct_indirect: "D",
-          shares: "5000",
-          value_owned: null,
-          as_of_date: "2026-03-10",
-        },
-      ],
-    };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, baseline, _EMPTY_BLOCKHOLDERS);
-    expect(data.insiders_as_of).toBe("2026-03-10");
+  it("does NOT add treasury into total_shares (corrects #789 ship-blocker)", () => {
+    const inputs = rollupToSunburstInputs(
+      _baseRollup({
+        shares_outstanding: "1000000000",
+        treasury_shares: "200000000",
+      }),
+    );
+    expect(inputs).not.toBeNull();
+    expect(inputs!.total_shares).toBe(1_000_000_000);
+    expect(inputs!.treasury_shares).toBe(200_000_000);
   });
 });
 
-describe("extractData — blockholders 5th category (#766 PR3)", () => {
-  it("returns no blockholder holders when response totals are null", () => {
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE, _EMPTY_BLOCKHOLDERS);
-    expect(data.blockholder_holders).toHaveLength(0);
-    expect(data.blockholders_total).toBeNull();
-    expect(data.blockholders_as_of).toBeNull();
+describe("rollupToSunburstInputs — slice totals round-trip", () => {
+  it("flattens insiders + blockholders + institutions + etfs into the holders list", () => {
+    const inputs = rollupToSunburstInputs(
+      _baseRollup({
+        shares_outstanding: "1000000000",
+        slices: [
+          {
+            category: "insiders",
+            label: "Insiders",
+            total_shares: "30000000",
+            pct_outstanding: "0.03",
+            filer_count: 1,
+            dominant_source: "form4",
+            holders: [
+              {
+                filer_cik: "0001000001",
+                filer_name: "Cook Tim",
+                shares: "30000000",
+                pct_outstanding: "0.03",
+                winning_source: "form4",
+                winning_accession: "F4-001",
+                as_of_date: "2026-03-15",
+                filer_type: null,
+                dropped_sources: [],
+              },
+            ],
+          },
+          {
+            category: "institutions",
+            label: "Institutions",
+            total_shares: "200000000",
+            pct_outstanding: "0.20",
+            filer_count: 2,
+            dominant_source: "13f",
+            holders: [
+              {
+                filer_cik: "0001000010",
+                filer_name: "BlackRock",
+                shares: "120000000",
+                pct_outstanding: "0.12",
+                winning_source: "13f",
+                winning_accession: "13F-010",
+                as_of_date: "2025-12-31",
+                filer_type: "INV",
+                dropped_sources: [],
+              },
+              {
+                filer_cik: "0001000011",
+                filer_name: "State Street",
+                shares: "80000000",
+                pct_outstanding: "0.08",
+                winning_source: "13f",
+                winning_accession: "13F-011",
+                as_of_date: "2025-12-31",
+                filer_type: "INV",
+                dropped_sources: [],
+              },
+            ],
+          },
+          {
+            category: "etfs",
+            label: "ETFs",
+            total_shares: "50000000",
+            pct_outstanding: "0.05",
+            filer_count: 1,
+            dominant_source: "13f",
+            holders: [
+              {
+                filer_cik: "0001000020",
+                filer_name: "Vanguard",
+                shares: "50000000",
+                pct_outstanding: "0.05",
+                winning_source: "13f",
+                winning_accession: "13F-020",
+                as_of_date: "2025-12-31",
+                filer_type: "ETF",
+                dropped_sources: [],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(inputs).not.toBeNull();
+    expect(inputs!.institutions_total).toBe(200_000_000);
+    expect(inputs!.etfs_total).toBe(50_000_000);
+    expect(inputs!.insiders_total).toBe(30_000_000);
+    expect(inputs!.holders).toHaveLength(4);
+    const blackrock = inputs!.holders.find((h) => h.label === "BlackRock");
+    expect(blackrock?.category).toBe("institutions");
+    expect(blackrock?.shares).toBe(120_000_000);
+    const vanguard = inputs!.holders.find((h) => h.label === "Vanguard");
+    expect(vanguard?.category).toBe("etfs");
   });
 
-  it("maps each block to one holder keyed on filer_cik", () => {
-    const blockholders: BlockholdersResponse = {
-      symbol: "AAPL",
-      totals: {
-        blockholders_shares: "4500000",
-        active_shares: "1500000",
-        passive_shares: "3000000",
-        total_filers: 2,
-        as_of_date: "2025-11-06",
-      },
-      blockholders: [
-        {
-          filer_cik: "0001234567",
-          filer_name: "Test Activist Fund LP",
-          reporter_cik: "0001234567",
-          reporter_name: "Test Activist Fund LP",
-          submission_type: "SCHEDULE 13D",
-          status: "active",
-          accession_number: "0001234567-25-000001",
-          aggregate_amount_owned: "1500000",
-          percent_of_class: "5.5",
-          additional_reporters: 0,
-          date_of_event: "2025-11-03",
-          filed_at: "2025-11-06T00:00:00Z",
-        },
-        {
-          filer_cik: "0007654321",
-          filer_name: "Index Fund",
-          reporter_cik: "0007654321",
-          reporter_name: "Index Fund",
-          submission_type: "SCHEDULE 13G",
-          status: "passive",
-          accession_number: "0007654321-25-000001",
-          aggregate_amount_owned: "3000000",
-          percent_of_class: "11.0",
-          additional_reporters: 0,
-          date_of_event: "2025-09-30",
-          filed_at: "2025-10-01T00:00:00Z",
-        },
-      ],
-    };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE, blockholders);
-    expect(data.blockholder_holders).toHaveLength(2);
-    expect(data.blockholder_holders.map((h) => h.key)).toEqual([
-      "block:0001234567",
-      "block:0007654321",
+  it("derives per-category as_of_date from the latest holder date in the slice", () => {
+    const inputs = rollupToSunburstInputs(
+      _baseRollup({
+        shares_outstanding: "100000000",
+        slices: [
+          {
+            category: "insiders",
+            label: "Insiders",
+            total_shares: "30000",
+            pct_outstanding: "0.0003",
+            filer_count: 2,
+            dominant_source: "form4",
+            holders: [
+              {
+                filer_cik: "0001",
+                filer_name: "Older Holder",
+                shares: "10000",
+                pct_outstanding: "0.0001",
+                winning_source: "form4",
+                winning_accession: "F4-OLD",
+                as_of_date: "2024-01-01",
+                filer_type: null,
+                dropped_sources: [],
+              },
+              {
+                filer_cik: "0002",
+                filer_name: "Newer Holder",
+                shares: "20000",
+                pct_outstanding: "0.0002",
+                winning_source: "form4",
+                winning_accession: "F4-NEW",
+                as_of_date: "2026-04-01",
+                filer_type: null,
+                dropped_sources: [],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(inputs!.insiders_as_of).toBe("2026-04-01");
+  });
+});
+
+describe("rollupToSunburstInputs — empty / no-data cases", () => {
+  it("returns inputs with null per-category totals when no slices are present", () => {
+    const inputs = rollupToSunburstInputs(_baseRollup({ slices: [] }));
+    expect(inputs).not.toBeNull();
+    expect(inputs!.institutions_total).toBeNull();
+    expect(inputs!.etfs_total).toBeNull();
+    expect(inputs!.insiders_total).toBeNull();
+    expect(inputs!.blockholders_total).toBeNull();
+    expect(inputs!.holders).toEqual([]);
+  });
+});
+
+describe("rollupToSunburstInputs — def14a_unmatched fold (Codex review fix)", () => {
+  /**
+   * Codex pre-push review (Batch 1 of #788) caught this: the prior
+   * version dropped ``def14a_unmatched`` slices from the chart
+   * entirely. Folding into the insiders bucket keeps the chart
+   * totals reconciled with the slice table.
+   */
+  it("folds def14a_unmatched holders into the insiders bucket", () => {
+    const inputs = rollupToSunburstInputs(
+      _baseRollup({
+        shares_outstanding: "100000000",
+        slices: [
+          {
+            category: "insiders",
+            label: "Insiders",
+            total_shares: "1000000",
+            pct_outstanding: "0.01",
+            filer_count: 1,
+            dominant_source: "form4",
+            holders: [
+              {
+                filer_cik: "0001",
+                filer_name: "Officer A",
+                shares: "1000000",
+                pct_outstanding: "0.01",
+                winning_source: "form4",
+                winning_accession: "F4-A",
+                as_of_date: "2026-01-01",
+                filer_type: null,
+                dropped_sources: [],
+              },
+            ],
+          },
+          {
+            category: "def14a_unmatched",
+            label: "Proxy-only (DEF 14A)",
+            total_shares: "500000",
+            pct_outstanding: "0.005",
+            filer_count: 1,
+            dominant_source: "def14a",
+            holders: [
+              {
+                filer_cik: null,
+                filer_name: "Officer B (proxy-only)",
+                shares: "500000",
+                pct_outstanding: "0.005",
+                winning_source: "def14a",
+                winning_accession: "DEF-B",
+                as_of_date: "2026-03-01",
+                filer_type: null,
+                dropped_sources: [],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(inputs).not.toBeNull();
+    // Combined insiders total = 1M + 500k.
+    expect(inputs!.insiders_total).toBe(1_500_000);
+    // Both holders surface in the holders list under the insiders
+    // category.
+    const insiderHolders = inputs!.holders.filter((h) => h.category === "insiders");
+    expect(insiderHolders).toHaveLength(2);
+    expect(insiderHolders.map((h) => h.label).sort()).toEqual([
+      "Officer A",
+      "Officer B (proxy-only)",
     ]);
-    expect(data.blockholder_holders[0]!.shares).toBe(1500000);
-    expect(data.blockholder_holders[0]!.category).toBe("blockholders");
-    expect(data.blockholders_total).toBe(4500000);
-    expect(data.blockholders_as_of).toBe("2025-11-06");
+    // Combined as_of takes the latest of the two.
+    expect(inputs!.insiders_as_of).toBe("2026-03-01");
   });
 
-  it("collapses joint-filing reporters to one wedge per accession", () => {
-    // A joint 13D filing surfaces as 2 per-reporter rows from the
-    // backend, both pointing at the same accession with the same
-    // 1.5M-share aggregate. The frontend must dedupe by accession
-    // so the wedge count matches the backend's per-accession-block
-    // count — without this dedupe, the snapshot-lag leaf-sum bump
-    // in buildSunburstRings would inflate the category total to 3M.
-    const blockholders: BlockholdersResponse = {
-      symbol: "AAPL",
-      totals: {
-        blockholders_shares: "1500000",
-        active_shares: "1500000",
-        passive_shares: "0",
-        total_filers: 1,
-        as_of_date: "2025-11-06",
-      },
-      blockholders: [
-        {
-          filer_cik: "0001234567",
-          filer_name: "Test Activist Fund LP",
-          reporter_cik: "0001234567",
-          reporter_name: "Test Activist Fund LP",
-          submission_type: "SCHEDULE 13D",
-          status: "active",
-          accession_number: "0001234567-25-000010",
-          aggregate_amount_owned: "1500000",
-          percent_of_class: "5.5",
-          additional_reporters: 1,
-          date_of_event: "2025-11-03",
-          filed_at: "2025-11-06T00:00:00Z",
-        },
-        {
-          filer_cik: "0001234567",
-          filer_name: "Test Activist Fund LP",
-          reporter_cik: null,
-          reporter_name: "Jane Doe (managing member)",
-          submission_type: "SCHEDULE 13D",
-          status: "active",
-          accession_number: "0001234567-25-000010", // same accession!
-          aggregate_amount_owned: "1500000",
-          percent_of_class: "5.5",
-          additional_reporters: 1,
-          date_of_event: "2025-11-03",
-          filed_at: "2025-11-06T00:00:00Z",
-        },
-      ],
-    };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE, blockholders);
-    expect(data.blockholder_holders).toHaveLength(1);
-    expect(data.blockholder_holders[0]!.shares).toBe(1500000);
-  });
-
-  it("does not collide wedge keys when one submitter has two distinct holders", () => {
-    // One EDGAR submitter (same filer_cik) files for two different
-    // beneficial owners (different reporter_cik). The wedge keys
-    // must be distinct so Recharts does not silently drop one.
-    const blockholders: BlockholdersResponse = {
-      symbol: "AAPL",
-      totals: {
-        blockholders_shares: "3000000",
-        active_shares: "3000000",
-        passive_shares: "0",
-        total_filers: 2,
-        as_of_date: "2025-11-06",
-      },
-      blockholders: [
-        {
-          filer_cik: "0003333333", // shared submitter
-          filer_name: "Shared Adviser LLC",
-          reporter_cik: "0008000001",
-          reporter_name: "Beneficial Owner A",
-          submission_type: "SCHEDULE 13D",
-          status: "active",
-          accession_number: "0003333333-25-000001",
-          aggregate_amount_owned: "1000000",
-          percent_of_class: "3.5",
-          additional_reporters: 0,
-          date_of_event: "2025-11-01",
-          filed_at: "2025-11-01T00:00:00Z",
-        },
-        {
-          filer_cik: "0003333333", // shared submitter
-          filer_name: "Shared Adviser LLC",
-          reporter_cik: "0008000002",
-          reporter_name: "Beneficial Owner B",
-          submission_type: "SCHEDULE 13D",
-          status: "active",
-          accession_number: "0003333333-25-000002",
-          aggregate_amount_owned: "2000000",
-          percent_of_class: "7.0",
-          additional_reporters: 0,
-          date_of_event: "2025-11-06",
-          filed_at: "2025-11-06T00:00:00Z",
-        },
-      ],
-    };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE, blockholders);
-    expect(data.blockholder_holders).toHaveLength(2);
-    const keys = data.blockholder_holders.map((h) => h.key);
-    expect(new Set(keys).size).toBe(2);
-    expect(keys).toContain("block:0008000001");
-    expect(keys).toContain("block:0008000002");
-  });
-
-  it("drops blockholder rows with null or non-positive aggregate_amount_owned", () => {
-    // A defer-to-prior-cover-page filing carries null aggregate
-    // numbers — those rows surface in the drilldown table but
-    // cannot size a wedge. Blockholders_total still reflects the
-    // backend totals (sum across blocks with real numbers).
-    const blockholders: BlockholdersResponse = {
-      symbol: "AAPL",
-      totals: {
-        blockholders_shares: "1500000",
-        active_shares: "1500000",
-        passive_shares: "0",
-        total_filers: 1,
-        as_of_date: "2025-11-06",
-      },
-      blockholders: [
-        {
-          filer_cik: "0001234567",
-          filer_name: "Real Block",
-          reporter_cik: "0001234567",
-          reporter_name: "Real Block",
-          submission_type: "SCHEDULE 13D",
-          status: "active",
-          accession_number: "0001234567-25-000001",
-          aggregate_amount_owned: "1500000",
-          percent_of_class: "5.5",
-          additional_reporters: 0,
-          date_of_event: "2025-11-03",
-          filed_at: "2025-11-06T00:00:00Z",
-        },
-        {
-          filer_cik: "0009999999",
-          filer_name: "Defer-to-Prior Block",
-          reporter_cik: null,
-          reporter_name: "Defer-to-Prior Block",
-          submission_type: "SCHEDULE 13D/A",
-          status: "active",
-          accession_number: "0009999999-25-000001",
-          aggregate_amount_owned: null,
-          percent_of_class: null,
-          additional_reporters: 0,
-          date_of_event: "2025-11-03",
-          filed_at: "2025-11-06T00:00:00Z",
-        },
-      ],
-    };
-    const data = extractData(_BALANCE, _EMPTY_INSTITUTIONAL, _EMPTY_INSIDERS, _EMPTY_BASELINE, blockholders);
-    expect(data.blockholder_holders).toHaveLength(1);
-    expect(data.blockholder_holders[0]!.label).toBe("Real Block");
+  it("returns null insiders_total when both insiders and def14a_unmatched are absent", () => {
+    const inputs = rollupToSunburstInputs(
+      _baseRollup({
+        shares_outstanding: "100000000",
+        slices: [],
+      }),
+    );
+    expect(inputs!.insiders_total).toBeNull();
   });
 });

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -104,10 +104,15 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
     >
       {rollupState.loading ? (
         <SectionSkeleton rows={4} />
-      ) : rollupState.error !== null ? (
+      ) : rollupState.error !== null || rollupState.data === null ? (
+        // ``data === null`` should only be reachable as a defense-
+        // in-depth path: the rollup endpoint always returns at least
+        // the ``no_data`` payload shape (200 OK + empty slices), so a
+        // null body would only arise from a future middleware that
+        // unwraps the response. Surface it as an error rather than
+        // hanging on a perma-skeleton. Claude PR review (PR 798)
+        // round 2 caught the prior skeleton fallback.
         <SectionError onRetry={rollupState.refetch} />
-      ) : rollupState.data === null ? (
-        <SectionSkeleton rows={4} />
       ) : (
         <PanelBody rollup={rollupState.data} onWedgeClick={handleWedgeClick} />
       )}
@@ -176,16 +181,16 @@ export function rollupToSunburstInputs(
     insiders_slice_total === null && def14a_unmatched_total === null
       ? null
       : (insiders_slice_total ?? 0) + (def14a_unmatched_total ?? 0);
-  const insiders_as_of = sliceAsOf("insiders");
-  const def14a_as_of = sliceAsOf("def14a_unmatched");
+  // Latest as_of across {insiders, def14a_unmatched}. Sort surfaces
+  // the most recent date last; ``at(-1)`` returns it; ``?? null``
+  // handles the both-empty case. Claude PR review (PR 798) round 2
+  // pinned this idiom over nested ternaries — extends cleanly when a
+  // third source enters the fold.
   const combined_insiders_as_of =
-    insiders_as_of === null
-      ? def14a_as_of
-      : def14a_as_of === null
-      ? insiders_as_of
-      : insiders_as_of >= def14a_as_of
-      ? insiders_as_of
-      : def14a_as_of;
+    [sliceAsOf("insiders"), sliceAsOf("def14a_unmatched")]
+      .filter((d): d is string => d !== null)
+      .sort()
+      .at(-1) ?? null;
 
   return {
     // Canonical denominator: shares_outstanding only. Treasury is

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -1,52 +1,48 @@
 /**
- * Ownership reporting card (#729).
+ * Ownership card (#789, parent #788).
  *
- * Three-ring sunburst keyed on ``shares_outstanding`` as the
- * denominator. Treasury is one of the categories — the denominator
- * includes it, not free float.
+ * Cross-channel deduped ownership snapshot rendered as a three-ring
+ * sunburst against the canonical ``shares_outstanding`` denominator
+ * (XBRL DEI). Treasury renders as an additive top wedge — NOT in the
+ * denominator. Treasury-in-denominator math (the prior version's
+ * ``shares_outstanding + treasury_shares``) systematically wedged
+ * every other category down by the treasury fraction; codex audit
+ * 2026-05-03 flagged this as a ship-blocker.
  *
- *   ring 1 (inner)  — total shares outstanding (label in center hole)
- *   ring 2 (middle) — Institutions / ETFs / Insiders / Treasury,
- *                     plus a transparent residual for the unaccounted
- *                     portion.
- *   ring 3 (outer)  — per-filer / per-officer wedges, plus a
- *                     transparent within-category gap when the filer
- *                     detail is incomplete (e.g. Institutions reports
- *                     a 50% aggregate but the #740 CUSIP backfill
- *                     hasn't resolved every filer to an instrument).
+ * The panel issues exactly one fetch (``fetchOwnershipRollup``) so
+ * every slice, the residual, and the coverage banner all reconcile
+ * against a single server-side ``snapshot_read`` snapshot. The five-
+ * fetch race in the prior version is gone.
  *
- * Effective coverage depends on:
- *   * #731 — shares_outstanding + treasury_shares from financial_periods (merged)
- *   * #730 — institutional_holdings via the new reader endpoint (merged)
- *   * #740 — CUSIP backfill so the ingester resolves holdings to instrument_ids (open)
- *   * #735 — DEI projection so XBRL ownership columns (treasury, public float) flow (open)
+ * Banner state machine (server-driven):
  *
- * Click on any colored wedge → drill to the L2 ownership page with
- * the corresponding filter pre-applied.
+ *   * ``no_data`` — XBRL ``shares_outstanding`` not on file. Red
+ *     banner with a "trigger fundamentals sync" CTA copy.
+ *   * ``unknown_universe`` — outstanding present but per-category
+ *     universe estimates aren't yet seeded (Tier 0 default until
+ *     #790 lands per-instrument 13F filer counts). Yellow banner
+ *     with explicit "estimate not available" copy.
+ *   * ``red`` / ``amber`` / ``green`` — universe coverage thresholds.
+ *     Red ranks worst, then ``unknown_universe``, then amber, then
+ *     green; the worst-of fold across the four tracked categories
+ *     decides the banner. Codex v2 review pinned this ordering.
+ *
+ * Concentration (sum of slices / outstanding) ships as a separate
+ * info chip — Codex v2 review caught the prior conflation that
+ * would have permanently red-banned retail-heavy names.
  */
 
 import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { fetchBlockholders } from "@/api/blockholders";
-import type { BlockholdersResponse } from "@/api/blockholders";
-import { fetchInstitutionalHoldings } from "@/api/institutionalHoldings";
+import { fetchOwnershipRollup } from "@/api/ownership";
 import type {
-  InstitutionalFilerHolding,
-  InstitutionalHoldingsResponse,
-} from "@/api/institutionalHoldings";
-import {
-  fetchInsiderBaseline,
-  fetchInsiderTransactions,
-  fetchInstrumentFinancials,
-} from "@/api/instruments";
-import type {
-  InsiderBaselineList,
-  InsiderTransactionsList,
-} from "@/api/instruments";
-import type { InstrumentFinancials } from "@/api/types";
+  OwnershipBannerVariant,
+  OwnershipCoverageState,
+  OwnershipRollupResponse,
+  OwnershipSliceCategory,
+} from "@/api/ownership";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
-import { OwnershipFreshnessChips } from "@/components/instrument/OwnershipFreshnessChips";
 import {
   OwnershipLegend,
   OwnershipSunburst,
@@ -58,16 +54,11 @@ import {
   formatShares,
   parseShareCount,
 } from "@/components/instrument/ownershipMetrics";
-import {
-  type InsiderRowShape,
-  isBaselineHoldingRow,
-  isInsiderHoldingRow,
-} from "@/components/instrument/ownershipInsiders";
-import {
-  type SunburstHolder,
-  type SunburstInputs,
-  buildSunburstRings,
+import type {
+  SunburstHolder,
+  SunburstInputs,
 } from "@/components/instrument/ownershipRings";
+import { buildSunburstRings } from "@/components/instrument/ownershipRings";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
 
@@ -75,70 +66,9 @@ export interface OwnershipPanelProps {
   readonly symbol: string;
 }
 
-interface OwnershipData {
-  readonly outstanding: number | null;
-  readonly treasury: number | null;
-  readonly institutions_total: number | null;
-  readonly etfs_total: number | null;
-  readonly insiders_total: number | null;
-  readonly blockholders_total: number | null;
-  readonly institutional_holders: readonly SunburstHolder[];
-  readonly etf_holders: readonly SunburstHolder[];
-  readonly insider_holders: readonly SunburstHolder[];
-  readonly blockholder_holders: readonly SunburstHolder[];
-  /** 13F snapshot date — applies to both Institutions and ETFs (same
-   *  ``period_of_report`` cohort across filer types). */
-  readonly thirteen_f_as_of: string | null;
-  /** Latest Form 4 transaction date for any insider on this issuer. */
-  readonly insiders_as_of: string | null;
-  /** XBRL period_end of the row that produced ``treasury``. */
-  readonly treasury_as_of: string | null;
-  /** Latest 13D/G filed_at across the blocks on this issuer (#766). */
-  readonly blockholders_as_of: string | null;
-}
-
-function pickLatestBalance(
-  financials: InstrumentFinancials,
-  column: string,
-): number | null {
-  for (const row of financials.rows) {
-    const raw = row.values[column];
-    const parsed = parseShareCount(raw ?? null);
-    if (parsed !== null) return parsed;
-  }
-  return null;
-}
-
 export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
-  const balanceState = useAsync<InstrumentFinancials>(
-    useCallback(
-      () =>
-        fetchInstrumentFinancials(symbol, {
-          statement: "balance",
-          period: "quarterly",
-        }),
-      [symbol],
-    ),
-    [symbol],
-  );
-
-  const institutionalState = useAsync<InstitutionalHoldingsResponse>(
-    useCallback(() => fetchInstitutionalHoldings(symbol, 500), [symbol]),
-    [symbol],
-  );
-
-  const insidersState = useAsync<InsiderTransactionsList>(
-    useCallback(() => fetchInsiderTransactions(symbol, 200), [symbol]),
-    [symbol],
-  );
-
-  const baselineState = useAsync<InsiderBaselineList>(
-    useCallback(() => fetchInsiderBaseline(symbol), [symbol]),
-    [symbol],
-  );
-
-  const blockholdersState = useAsync<BlockholdersResponse>(
-    useCallback(() => fetchBlockholders(symbol, 200), [symbol]),
+  const rollupState = useAsync<OwnershipRollupResponse>(
+    useCallback(() => fetchOwnershipRollup(symbol), [symbol]),
     [symbol],
   );
 
@@ -158,462 +88,336 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
     [navigate, symbol],
   );
 
-  const isLoading =
-    balanceState.loading ||
-    institutionalState.loading ||
-    insidersState.loading ||
-    baselineState.loading ||
-    blockholdersState.loading;
-  const allErrored =
-    balanceState.error !== null &&
-    institutionalState.error !== null &&
-    insidersState.error !== null &&
-    baselineState.error !== null &&
-    blockholdersState.error !== null;
-
   return (
     <Pane
       title="Ownership"
-      source={{ providers: ["sec_13f", "sec_form3", "sec_form4", "sec_13dg", "sec_xbrl"] }}
+      source={{
+        providers: [
+          "sec_13f",
+          "sec_form3",
+          "sec_form4",
+          "sec_13dg",
+          "sec_def14a",
+          "sec_xbrl",
+        ],
+      }}
     >
-      {isLoading ? (
+      {rollupState.loading ? (
         <SectionSkeleton rows={4} />
-      ) : allErrored ? (
-        <SectionError
-          onRetry={() => {
-            balanceState.refetch();
-            institutionalState.refetch();
-            insidersState.refetch();
-            baselineState.refetch();
-            blockholdersState.refetch();
-          }}
-        />
+      ) : rollupState.error !== null ? (
+        <SectionError onRetry={rollupState.refetch} />
+      ) : rollupState.data === null ? (
+        <SectionSkeleton rows={4} />
       ) : (
-        <PanelBody
-          balance={balanceState.data}
-          institutional={institutionalState.data}
-          insiders={insidersState.data}
-          baseline={baselineState.data}
-          blockholders={blockholdersState.data}
-          onWedgeClick={handleWedgeClick}
-        />
+        <PanelBody rollup={rollupState.data} onWedgeClick={handleWedgeClick} />
       )}
     </Pane>
   );
 }
 
+/**
+ * Map the rollup response to the existing ``SunburstInputs`` shape so
+ * the chart code can render unchanged. ``shares_outstanding`` is the
+ * denominator (treasury-on-top model); per-slice totals come from
+ * the deduped rollup; per-filer holders feed the outer ring.
+ *
+ * ``def14a_unmatched`` rows fold into the ``insiders`` chart category
+ * (they are by definition named officers in the proxy with no Form 4
+ * filing on record). The slice table keeps them as a separate
+ * category for transparency, but the chart treats them as insiders so
+ * the sunburst doesn't need a fifth named category and the chart-vs-
+ * table totals stay reconciled. Codex pre-push review (Batch 1 of
+ * #788) caught the prior version that dropped them from the chart.
+ */
+export function rollupToSunburstInputs(
+  rollup: OwnershipRollupResponse,
+): SunburstInputs | null {
+  const outstanding = parseShareCount(rollup.shares_outstanding);
+  if (outstanding === null || outstanding <= 0) return null;
+  const sliceTotal = (cat: OwnershipSliceCategory): number | null => {
+    const found = rollup.slices.find((s) => s.category === cat);
+    return found === undefined ? null : parseShareCount(found.total_shares);
+  };
+  const sliceAsOf = (cat: OwnershipSliceCategory): string | null => {
+    const found = rollup.slices.find((s) => s.category === cat);
+    if (found === undefined || found.holders.length === 0) return null;
+    let latest: string | null = null;
+    for (const h of found.holders) {
+      if (h.as_of_date === null) continue;
+      if (latest === null || h.as_of_date > latest) latest = h.as_of_date;
+    }
+    return latest;
+  };
+  const flattenHolders = (
+    cat: OwnershipSliceCategory,
+    target: SunburstHolder["category"],
+  ): SunburstHolder[] => {
+    const found = rollup.slices.find((s) => s.category === cat);
+    if (found === undefined) return [];
+    const out: SunburstHolder[] = [];
+    for (const h of found.holders) {
+      const shares = parseShareCount(h.shares);
+      if (shares === null || shares <= 0) continue;
+      const key = h.filer_cik ?? `name:${h.filer_name}`;
+      out.push({ key, label: h.filer_name, shares, category: target });
+    }
+    return out;
+  };
+
+  const treasury = parseShareCount(rollup.treasury_shares);
+
+  // Insiders bucket folds in def14a_unmatched holders. Both totals
+  // and as_of dates take the max across the two slices so the chart
+  // category sums match the slice table's insiders + def14a_unmatched
+  // rows.
+  const insiders_slice_total = sliceTotal("insiders");
+  const def14a_unmatched_total = sliceTotal("def14a_unmatched");
+  const combined_insiders_total =
+    insiders_slice_total === null && def14a_unmatched_total === null
+      ? null
+      : (insiders_slice_total ?? 0) + (def14a_unmatched_total ?? 0);
+  const insiders_as_of = sliceAsOf("insiders");
+  const def14a_as_of = sliceAsOf("def14a_unmatched");
+  const combined_insiders_as_of =
+    insiders_as_of === null
+      ? def14a_as_of
+      : def14a_as_of === null
+      ? insiders_as_of
+      : insiders_as_of >= def14a_as_of
+      ? insiders_as_of
+      : def14a_as_of;
+
+  return {
+    // Canonical denominator: shares_outstanding only. Treasury is
+    // additive on top, NOT part of the denominator.
+    total_shares: outstanding,
+    holders: [
+      ...flattenHolders("institutions", "institutions"),
+      ...flattenHolders("etfs", "etfs"),
+      ...flattenHolders("insiders", "insiders"),
+      ...flattenHolders("def14a_unmatched", "insiders"),
+      ...flattenHolders("blockholders", "blockholders"),
+    ],
+    institutions_total: sliceTotal("institutions"),
+    etfs_total: sliceTotal("etfs"),
+    insiders_total: combined_insiders_total,
+    blockholders_total: sliceTotal("blockholders"),
+    treasury_shares: treasury,
+    institutions_as_of: sliceAsOf("institutions"),
+    etfs_as_of: sliceAsOf("etfs"),
+    insiders_as_of: combined_insiders_as_of,
+    treasury_as_of: rollup.treasury_as_of,
+    blockholders_as_of: sliceAsOf("blockholders"),
+  };
+}
+
+const _BANNER_VARIANT_CLASS: Record<OwnershipBannerVariant, string> = {
+  error:
+    "border-red-200 bg-red-50 text-red-900 dark:border-red-900/60 dark:bg-red-900/20 dark:text-red-200",
+  warning:
+    "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-200",
+  info: "border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200",
+  success:
+    "border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-900/60 dark:bg-emerald-900/20 dark:text-emerald-200",
+};
+
 interface PanelBodyProps {
-  readonly balance: InstrumentFinancials | null;
-  readonly institutional: InstitutionalHoldingsResponse | null;
-  readonly insiders: InsiderTransactionsList | null;
-  readonly baseline: InsiderBaselineList | null;
-  readonly blockholders: BlockholdersResponse | null;
+  readonly rollup: OwnershipRollupResponse;
   readonly onWedgeClick: (target: WedgeClick) => void;
 }
 
-/** Wraps ``renderBody`` so the freshness chip's ``today`` reference can
- *  be a stable ``useMemo`` value. Pre-fix the panel passed
- *  ``new Date()`` inline on every render, which the chip strip then
- *  treated as a new prop and re-rendered against. Captured once per
- *  mount so the chips memoise cleanly across parent re-renders. */
-function PanelBody({
-  balance,
-  institutional,
-  insiders,
-  baseline,
-  blockholders,
-  onWedgeClick,
-}: PanelBodyProps): JSX.Element {
+function PanelBody({ rollup, onWedgeClick }: PanelBodyProps): JSX.Element {
   const today = useMemo(() => new Date(), []);
-  return renderBody(
-    extractData(balance, institutional, insiders, baseline, blockholders),
-    onWedgeClick,
-    today,
-  );
-}
-
-export function extractData(
-  balance: InstrumentFinancials | null,
-  institutional: InstitutionalHoldingsResponse | null,
-  insiders: InsiderTransactionsList | null,
-  baseline: InsiderBaselineList | null,
-  blockholders: BlockholdersResponse | null,
-): OwnershipData {
-  const outstanding =
-    balance !== null ? pickLatestBalance(balance, "shares_outstanding") : null;
-  const treasury =
-    balance !== null ? pickLatestBalance(balance, "treasury_shares") : null;
-
-  const inst_totals = institutional?.totals ?? null;
-  const filers = institutional?.filers ?? [];
-  // Equity-only — option exposure double-counts the underlying.
-  const equity_filers = filers.filter((f) => f.is_put_call === null);
-
-  const institutional_holders: SunburstHolder[] = equity_filers
-    .filter((f) => f.filer_type !== "ETF")
-    .map(filerToHolder("institutions"));
-  const etf_holders: SunburstHolder[] = equity_filers
-    .filter((f) => f.filer_type === "ETF")
-    .map(filerToHolder("etfs"));
-
-  // Insider holders = Form 4 cumulative (latest post_transaction_shares
-  // per filer) + Form 3 baseline-only filers (#768 PR4) so officers
-  // who never traded after appointment surface on the per-officer
-  // ring. The backend NOT EXISTS gate guarantees no overlap between
-  // the two sets.
-  const form4_insider_holders = aggregateInsiderHoldersForSunburst(insiders);
-  const baseline_insider_holders = baselineToHolders(baseline);
-  const insider_holders: SunburstHolder[] = [
-    ...form4_insider_holders,
-    ...baseline_insider_holders,
-  ];
-
-  const institutions_total = parseShareCount(inst_totals?.institutions_shares ?? null);
-  const etfs_total = parseShareCount(inst_totals?.etfs_shares ?? null);
-
-  // Blockholders (#766): one wedge per ≥5% block. The reader
-  // returns per-reporter chain rows (matching the issue spec); the
-  // frontend dedupes by accession so joint-filing reporters
-  // collapse to a single wedge whose ``shares`` matches the
-  // backend's per-accession ``MAX(aggregate_amount_owned)`` rollup.
-  // Without this dedupe, two joint reporters claiming the same 1.5M
-  // block would surface as 2 wedges summing to 3M, which then
-  // triggers the snapshot-lag leaf-sum bump in ``buildSunburstRings``
-  // and double-counts the block in the category total. Codex
-  // pre-push review caught this.
-  const blockholder_holders: readonly SunburstHolder[] = blockholdersToHolders(blockholders);
-  const blockholders_total = parseShareCount(blockholders?.totals?.blockholders_shares ?? null);
-  const blockholders_as_of = blockholders?.totals?.as_of_date ?? null;
-  // Form 4 has no aggregate-total endpoint — sum the per-officer
-  // post-transaction balances. When no officer rows are on file the
-  // total is null (category does not render).
-  const insiders_total =
-    insider_holders.length === 0
-      ? null
-      : insider_holders.reduce((s, h) => s + h.shares, 0);
-
-  // Per-category freshness sources (#767):
-  //   * 13F (Institutions + ETFs): one shared period_of_report from
-  //     the totals row — both filer-type buckets are computed from
-  //     the same ``MAX(period_of_report)`` cohort backend-side.
-  //   * Insiders: latest txn_date observed across non-derivative
-  //     post-transaction rows. The reader endpoint exposes a
-  //     summary.latest_txn_date but the panel hits the per-row list;
-  //     derive locally so we don't add a second round trip.
-  //   * Treasury: balance-sheet row period_end that produced the
-  //     value — already the latest non-null treasury_shares row from
-  //     pickLatestBalance.
-  const thirteen_f_as_of = inst_totals?.period_of_report ?? null;
-  // Insider freshness factors in BOTH sources: latest Form 4 txn_date
-  // AND latest Form 3 baseline as_of_date. An issuer where every
-  // observed insider holds via a Form 3 grant and never trades would
-  // have no Form 4 rows at all but should still surface the latest
-  // baseline date as the Insiders chip's "as of".
-  const form4_latest =
-    insiders === null || insiders.rows.length === 0
-      ? null
-      : latestTxnDate(insiders.rows as readonly InsiderRowShape[]);
-  const baseline_latest = latestBaselineDate(baseline);
-  const insiders_as_of = maxIsoDate(form4_latest, baseline_latest);
-  const treasury_as_of =
-    treasury !== null && balance !== null ? findRowDateFor(balance, "treasury_shares") : null;
-
-  return {
-    outstanding,
-    treasury,
-    institutions_total,
-    etfs_total,
-    insiders_total,
-    blockholders_total,
-    institutional_holders,
-    etf_holders,
-    insider_holders,
-    blockholder_holders,
-    thirteen_f_as_of,
-    insiders_as_of,
-    treasury_as_of,
-    blockholders_as_of,
-  };
-}
-
-/** Map blockholder API rows into SunburstHolder wedges, deduping
- *  by accession_number so joint-filing reporters collapse to one
- *  wedge per block. The backend orders rows by
- *  ``aggregate_amount_owned DESC`` per accession, so the first
- *  occurrence of each accession is the largest-aggregate
- *  representative — keep that one and drop the rest.
- *
- *  Wedge identity uses reporter_cik (or name fallback) rather than
- *  filer_cik because two distinct beneficial owners can share one
- *  EDGAR submitter; keying on filer_cik would collide their
- *  wedges. Codex pre-push review caught this. */
-function blockholdersToHolders(
-  blockholders: BlockholdersResponse | null,
-): readonly SunburstHolder[] {
-  if (blockholders === null) return [];
-  const seen_accessions = new Set<string>();
-  const out: SunburstHolder[] = [];
-  for (const row of blockholders.blockholders) {
-    if (seen_accessions.has(row.accession_number)) continue;
-    seen_accessions.add(row.accession_number);
-    const shares = parseShareCount(row.aggregate_amount_owned);
-    if (shares === null || shares <= 0) continue;
-    const reporter_identity = row.reporter_cik ?? `name:${row.reporter_name}`;
-    out.push({
-      key: `block:${reporter_identity}`,
-      label: row.filer_name,
-      shares,
-      category: "blockholders",
-    });
-  }
-  return out;
-}
-
-/** Map baseline-API rows into the SunburstHolder shape so the
- *  ownership ring renders Form-3-only insiders alongside Form 4
- *  cumulative balances (#768 PR4). Uses the shared
- *  ``isBaselineHoldingRow`` predicate so the holders set and the
- *  freshness chip's ``as_of_date`` derivation can never drift. */
-function baselineToHolders(
-  baseline: InsiderBaselineList | null,
-): readonly SunburstHolder[] {
-  if (baseline === null || baseline.rows.length === 0) return [];
-  const out: SunburstHolder[] = [];
-  for (const row of baseline.rows) {
-    if (!isBaselineHoldingRow(row)) continue;
-    // Predicate guarantees parseShareCount > 0.
-    const shares = parseShareCount(row.shares)!;
-    // Disambiguate against any same-CIK Form 4 leaf (the backend
-    // gate excludes them but defensively suffix the key — render
-    // collisions on a flat ring would silently swap wedges).
-    const key = `baseline:${row.filer_cik}:${row.is_derivative ? "d" : "n"}`;
-    out.push({
-      key,
-      label: row.filer_name,
-      shares,
-      category: "insiders",
-    });
-  }
-  return out;
-}
-
-/** Latest ``as_of_date`` across the baseline rows that actually
- *  render. Uses the same eligibility predicate as
- *  ``baselineToHolders`` so the chip never advances past a wedge
- *  that doesn't render. */
-function latestBaselineDate(baseline: InsiderBaselineList | null): string | null {
-  if (baseline === null || baseline.rows.length === 0) return null;
-  let latest: string | null = null;
-  for (const row of baseline.rows) {
-    if (!isBaselineHoldingRow(row)) continue;
-    if (latest === null || row.as_of_date > latest) latest = row.as_of_date;
-  }
-  return latest;
-}
-
-/** Max of two ISO ``YYYY-MM-DD`` strings (lex-sortable so string
- *  compare is correct). Returns null when both are null. */
-function maxIsoDate(a: string | null, b: string | null): string | null {
-  if (a === null) return b;
-  if (b === null) return a;
-  return a >= b ? a : b;
-}
-
-function latestTxnDate(rows: readonly InsiderRowShape[]): string | null {
-  let latest: string | null = null;
-  for (const row of rows) {
-    if (!isInsiderHoldingRow(row)) continue;
-    if (latest === null || row.txn_date > latest) latest = row.txn_date;
-  }
-  return latest;
-}
-
-/** Find the period_end of the first balance-sheet row that has a
- *  non-null value for ``column``. Mirrors the iteration in
- *  ``pickLatestBalance`` so the date and value stay paired. */
-function findRowDateFor(financials: InstrumentFinancials, column: string): string | null {
-  for (const row of financials.rows) {
-    const raw = row.values[column];
-    const parsed = parseShareCount(raw ?? null);
-    if (parsed !== null) return row.period_end;
-  }
-  return null;
-}
-
-function filerToHolder(
-  category: SunburstHolder["category"],
-): (f: InstitutionalFilerHolding) => SunburstHolder {
-  return (f) => ({
-    key: f.filer_cik,
-    label: f.filer_name,
-    shares: parseShareCount(f.shares) ?? 0,
-    category,
-  });
-}
-
-function aggregateInsiderHoldersForSunburst(
-  insiders: InsiderTransactionsList | null,
-): readonly SunburstHolder[] {
-  if (insiders === null) return [];
-  const latestByFiler = new Map<
-    string,
-    { txn_date: string; shares: number; label: string }
-  >();
-  for (const row of insiders.rows as readonly InsiderRowShape[]) {
-    if (!isInsiderHoldingRow(row)) continue;
-    // Predicate above guarantees parseShareCount is non-null.
-    const shares = parseShareCount(row.post_transaction_shares)!;
-    const key = row.filer_cik ?? `name:${row.filer_name}`;
-    const existing = latestByFiler.get(key);
-    if (existing === undefined || row.txn_date > existing.txn_date) {
-      latestByFiler.set(key, {
-        txn_date: row.txn_date,
-        shares,
-        label: row.filer_name,
-      });
-    }
-  }
-  const holders: SunburstHolder[] = [];
-  for (const [key, entry] of latestByFiler.entries()) {
-    holders.push({
-      key,
-      label: entry.label,
-      shares: entry.shares,
-      category: "insiders",
-    });
-  }
-  return holders;
-}
-
-function renderBody(
-  data: OwnershipData,
-  onWedgeClick: (target: WedgeClick) => void,
-  today: Date,
-): JSX.Element {
-  if (data.outstanding === null || data.outstanding <= 0) {
+  const inputs = useMemo(() => rollupToSunburstInputs(rollup), [rollup]);
+  if (rollup.banner.state === "no_data" || inputs === null) {
     return (
-      <EmptyState
-        title="No ownership data"
-        description="Shares outstanding is not on file for this instrument yet — the ownership breakdown needs SEC XBRL coverage to compute the denominator."
-      />
+      <div className="flex flex-col gap-3">
+        <Banner banner={rollup.banner} />
+        <EmptyState
+          title="No ownership data"
+          description="XBRL shares-outstanding not yet on file for this instrument. Trigger a fundamentals sync, or wait for the next scheduled run."
+        />
+      </div>
     );
   }
-
-  // Denominator = outstanding + treasury. Operator's mental model:
-  // "100% of issued / allotted shares — some held in market, some
-  // held back in vault." Treasury renders as a category wedge.
-  const total_shares = data.outstanding + (data.treasury ?? 0);
-  const inputs: SunburstInputs = {
-    total_shares,
-    holders: [
-      ...data.institutional_holders,
-      ...data.etf_holders,
-      ...data.insider_holders,
-      ...data.blockholder_holders,
-    ],
-    institutions_total: data.institutions_total,
-    etfs_total: data.etfs_total,
-    insiders_total: data.insiders_total,
-    blockholders_total: data.blockholders_total,
-    treasury_shares: data.treasury,
-    institutions_as_of: data.thirteen_f_as_of,
-    etfs_as_of: data.thirteen_f_as_of,
-    insiders_as_of: data.insiders_as_of,
-    treasury_as_of: data.treasury_as_of,
-    blockholders_as_of: data.blockholders_as_of,
-  };
   const rings = buildSunburstRings(inputs);
   if (rings === null) {
     return (
-      <EmptyState
-        title="No ownership data"
-        description="Sunburst rings could not be derived — shares outstanding resolved to zero or the input snapshot is malformed."
-      />
+      <div className="flex flex-col gap-3">
+        <Banner banner={rollup.banner} />
+        <EmptyState
+          title="No ownership data"
+          description="Sunburst rings could not be derived — shares outstanding resolved to zero or the input snapshot is malformed."
+        />
+      </div>
     );
   }
 
-  const denom = rings.total_shares;
-  const accountedFor = rings.categories.reduce((s, c) => s + c.shares, 0);
-  const accountedPct = accountedFor / denom;
-  const oversubscribed = rings.total_shares > rings.reported_total;
+  // Use today only when the chart code passes it through; the
+  // legend/freshness chip placement follows the prior layout.
+  void today;
 
   return (
-    <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
-      <div className="flex flex-col items-center gap-3">
-        <OwnershipSunburst inputs={inputs} onWedgeClick={onWedgeClick} />
-        <OwnershipLegend rings={rings} />
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="mb-2">
-          <OwnershipFreshnessChips rings={rings} today={today} />
+    <div className="flex flex-col gap-3">
+      <Banner banner={rollup.banner} />
+      <ConcentrationChip rollup={rollup} />
+      {rollup.residual.oversubscribed && <OversubscribedWarning rollup={rollup} />}
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+        <div className="flex flex-col items-center gap-3">
+          <OwnershipSunburst inputs={inputs} onWedgeClick={onWedgeClick} />
+          <OwnershipLegend rings={rings} />
         </div>
-        <p className="mb-1 text-xs text-slate-500 dark:text-slate-400">
-          {formatShares(data.outstanding)} outstanding
-          {data.treasury !== null && data.treasury > 0 && (
-            <> + {formatShares(data.treasury)} treasury</>
-          )}
-          .
-        </p>
-        <p className="mb-2 text-xs">
-          <span className="font-medium text-slate-700 dark:text-slate-200">
-            {formatPct(accountedPct)} accounted for
-          </span>
-          {accountedPct < 0.999 && (
-            <span className="ml-1.5 text-slate-500 dark:text-slate-400">
-              · remainder is unallocated public float (gated on
-              {" "}
-              <span className="font-mono">#740</span> CUSIP backfill +{" "}
-              <span className="font-mono">#735</span> DEI projection).
-            </span>
-          )}
-          {oversubscribed && (
-            <span className="ml-1.5 text-amber-700 dark:text-amber-400">
-              · category totals exceed reported total shares by{" "}
-              {formatShares(rings.total_shares - rings.reported_total)} (snapshot lag).
-            </span>
-          )}
-        </p>
-        <table className="w-full text-sm">
-          <thead className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            <tr>
-              <th className="pb-1 text-left">Category</th>
-              <th className="pb-1 text-right">Shares</th>
-              <th className="pb-1 text-right">% of total</th>
-              <th className="pb-1 text-right">Resolved filers</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rings.categories.map((cat) => {
-              const resolvedPct =
-                cat.shares > 0 ? cat.resolved_leaf_shares / cat.shares : 0;
-              return (
-                <tr
-                  key={cat.key}
-                  className="border-t border-t-slate-100 dark:border-t-slate-800"
-                >
-                  <td className="py-1.5 text-slate-700 dark:text-slate-200">
-                    {cat.label}
-                  </td>
-                  <td className="py-1.5 text-right font-mono text-slate-700 dark:text-slate-200">
-                    {formatShares(cat.shares)}
-                  </td>
-                  <td className="py-1.5 text-right font-mono text-slate-900 dark:text-slate-100">
-                    {formatPct(cat.shares / denom)}
-                  </td>
-                  <td className="py-1.5 text-right font-mono text-slate-500 dark:text-slate-400">
-                    {cat.leaves.length === 0 && cat.shares > 0
-                      ? "—"
-                      : formatPct(resolvedPct)}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-        <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
-          Click any colored wedge for the per-filer drilldown.
-        </p>
+        <div className="min-w-0 flex-1">
+          <p className="mb-1 text-xs text-slate-500 dark:text-slate-400">
+            {rollup.shares_outstanding !== null
+              ? `${formatShares(parseShareCount(rollup.shares_outstanding) ?? 0)} outstanding`
+              : "outstanding unknown"}
+            {rollup.treasury_shares !== null
+              && parseShareCount(rollup.treasury_shares) !== null
+              && (parseShareCount(rollup.treasury_shares) ?? 0) > 0 && (
+                <> + {formatShares(parseShareCount(rollup.treasury_shares) ?? 0)} treasury</>
+              )}
+            .
+          </p>
+          <SliceTable rollup={rollup} />
+          <ResidualLine rollup={rollup} />
+          <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
+            Click any colored wedge for the per-filer drilldown.
+          </p>
+        </div>
       </div>
     </div>
   );
 }
+
+interface BannerProps {
+  readonly banner: OwnershipRollupResponse["banner"];
+}
+
+function Banner({ banner }: BannerProps): JSX.Element | null {
+  if (banner.state === "green") {
+    return (
+      <div
+        className={`rounded-md border px-3 py-2 text-xs ${_BANNER_VARIANT_CLASS.success}`}
+        role="status"
+        data-banner-state={banner.state}
+      >
+        <span className="font-medium">{banner.headline}</span>
+        <span className="ml-1.5">{banner.body}</span>
+      </div>
+    );
+  }
+  return (
+    <div
+      className={`rounded-md border px-3 py-2 text-xs ${_BANNER_VARIANT_CLASS[banner.variant]}`}
+      role="status"
+      data-banner-state={banner.state}
+    >
+      <p className="font-medium">{banner.headline}</p>
+      <p className="mt-0.5">{banner.body}</p>
+    </div>
+  );
+}
+
+interface ConcentrationChipProps {
+  readonly rollup: OwnershipRollupResponse;
+}
+
+function ConcentrationChip({ rollup }: ConcentrationChipProps): JSX.Element {
+  return (
+    <p className="text-xs text-slate-500 dark:text-slate-400" data-test="concentration-chip">
+      {rollup.concentration.info_chip}
+    </p>
+  );
+}
+
+function OversubscribedWarning({ rollup }: { rollup: OwnershipRollupResponse }): JSX.Element {
+  // The server clamped the residual to 0; surface the diagnostic so
+  // the operator knows a stale 13F + fresh Form 4/13D mix is in play.
+  void rollup;
+  return (
+    <div
+      className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-200"
+      role="status"
+      data-test="oversubscribed-warning"
+    >
+      Category totals exceed shares outstanding (likely cause: stale 13F
+      quarter combined with fresh Form 4 / 13D filings). Awaiting next
+      13F cycle for the snapshots to align.
+    </div>
+  );
+}
+
+function ResidualLine({ rollup }: { rollup: OwnershipRollupResponse }): JSX.Element {
+  const pct = parseShareCount(rollup.residual.pct_outstanding) ?? 0;
+  return (
+    <p className="mt-2 text-xs text-slate-500 dark:text-slate-400" data-test="residual-line">
+      {rollup.residual.label}: {formatPct(pct)}
+    </p>
+  );
+}
+
+interface SliceTableProps {
+  readonly rollup: OwnershipRollupResponse;
+}
+
+const _CATEGORY_ORDER_TABLE: readonly OwnershipSliceCategory[] = [
+  "insiders",
+  "blockholders",
+  "institutions",
+  "etfs",
+  "def14a_unmatched",
+];
+
+function SliceTable({ rollup }: SliceTableProps): JSX.Element {
+  const slicesByCategory = new Map(rollup.slices.map((s) => [s.category, s]));
+  const visible = _CATEGORY_ORDER_TABLE.filter((cat) => slicesByCategory.has(cat));
+  if (visible.length === 0) {
+    return (
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        No filings ingested yet.
+      </p>
+    );
+  }
+  return (
+    <table className="w-full text-sm">
+      <thead className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        <tr>
+          <th className="pb-1 text-left">Category</th>
+          <th className="pb-1 text-right">Shares</th>
+          <th className="pb-1 text-right">% of outstanding</th>
+          <th className="pb-1 text-right">Filers</th>
+        </tr>
+      </thead>
+      <tbody>
+        {visible.map((cat) => {
+          const slc = slicesByCategory.get(cat)!;
+          const shares = parseShareCount(slc.total_shares) ?? 0;
+          const pct = parseShareCount(slc.pct_outstanding) ?? 0;
+          return (
+            <tr key={cat} className="border-t border-t-slate-100 dark:border-t-slate-800">
+              <td className="py-1.5 text-slate-700 dark:text-slate-200">
+                {slc.label}
+              </td>
+              <td className="py-1.5 text-right font-mono text-slate-700 dark:text-slate-200">
+                {formatShares(shares)}
+              </td>
+              <td className="py-1.5 text-right font-mono text-slate-900 dark:text-slate-100">
+                {formatPct(pct)}
+              </td>
+              <td className="py-1.5 text-right font-mono text-slate-500 dark:text-slate-400">
+                {slc.filer_count}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+// Internal banner-state union exported solely so the test file can
+// drive snapshot fixtures without re-importing from the api module
+// (keeps the test imports tight). Codex caught a similar pattern on
+// #767's freshness chip extraction.
+export type _BannerStateForTest = OwnershipCoverageState;

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -227,7 +227,6 @@ interface PanelBodyProps {
 }
 
 function PanelBody({ rollup, onWedgeClick }: PanelBodyProps): JSX.Element {
-  const today = useMemo(() => new Date(), []);
   const inputs = useMemo(() => rollupToSunburstInputs(rollup), [rollup]);
   if (rollup.banner.state === "no_data" || inputs === null) {
     return (
@@ -253,15 +252,11 @@ function PanelBody({ rollup, onWedgeClick }: PanelBodyProps): JSX.Element {
     );
   }
 
-  // Use today only when the chart code passes it through; the
-  // legend/freshness chip placement follows the prior layout.
-  void today;
-
   return (
     <div className="flex flex-col gap-3">
       <Banner banner={rollup.banner} />
       <ConcentrationChip rollup={rollup} />
-      {rollup.residual.oversubscribed && <OversubscribedWarning rollup={rollup} />}
+      {rollup.residual.oversubscribed && <OversubscribedWarning />}
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
         <div className="flex flex-col items-center gap-3">
           <OwnershipSunburst inputs={inputs} onWedgeClick={onWedgeClick} />
@@ -331,10 +326,9 @@ function ConcentrationChip({ rollup }: ConcentrationChipProps): JSX.Element {
   );
 }
 
-function OversubscribedWarning({ rollup }: { rollup: OwnershipRollupResponse }): JSX.Element {
+function OversubscribedWarning(): JSX.Element {
   // The server clamped the residual to 0; surface the diagnostic so
   // the operator knows a stale 13F + fresh Form 4/13D mix is in play.
-  void rollup;
   return (
     <div
       className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-200"

--- a/frontend/src/components/instrument/ownershipRings.ts
+++ b/frontend/src/components/instrument/ownershipRings.ts
@@ -1,12 +1,21 @@
 /**
- * Ownership sunburst data model (#729).
+ * Ownership sunburst data model (#729, denominator corrected by
+ * #789).
  *
  * Three concentric rings keyed on a single denominator:
- * ``total_shares`` (= ``shares_outstanding + treasury_shares``).
- * Treasury counts toward the denominator because the operator's
- * mental model is "100% of issued / allotted shares — some held in
- * the market, some held back in the company's vault". Treasury
- * appears as one of the categories.
+ * ``total_shares = shares_outstanding`` (XBRL DEI). Treasury is NOT
+ * part of the denominator — it renders as an additive top wedge on
+ * top of the chart. Codex audit (2026-05-03) caught the prior
+ * ``shares_outstanding + treasury_shares`` math as a ship-blocker
+ * because any treasury > 0 systematically wedged every other
+ * category down by the treasury fraction. Backend contract
+ * (``/ownership-rollup`` endpoint) and the canonical XBRL view
+ * (``instrument_share_count_latest``) both divide by
+ * ``shares_outstanding`` only; the chart now matches.
+ *
+ * Treasury appears as one of the categories — the wedge sits on
+ * top of the deduped slices and the residual ``Public /
+ * unattributed`` block fills the remainder of the ring.
  *
  *   ring 1 (inner)  : center hole shows ``total_shares``.
  *   ring 2 (middle) : per-category wedges sized faithfully against

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -328,13 +328,13 @@ function OwnershipBody({
     [insider_holders],
   );
 
-  // Denominator = outstanding + treasury (issued/allotted). Treasury
-  // renders as a category wedge so the operator sees the issuer's
-  // held-back portion in proportion.
-  const total_shares = useMemo(
-    () => outstanding + (treasury ?? 0),
-    [outstanding, treasury],
-  );
+  // Denominator = ``shares_outstanding`` (XBRL DEI) only. Treasury is
+  // an additive category wedge on top of the chart, NOT part of the
+  // denominator. Codex audit 2026-05-03 caught the prior
+  // ``outstanding + treasury`` math as a ship-blocker — treasury > 0
+  // wedged every other category down by the treasury fraction. Spec:
+  // docs/superpowers/specs/2026-05-03-ownership-tier0-and-cik-history-design.md
+  const total_shares = useMemo(() => outstanding, [outstanding]);
 
   // Per-category freshness sources (#767).
   const thirteen_f_as_of = inst_totals?.period_of_report ?? null;

--- a/scripts/backfill_instrument_history.py
+++ b/scripts/backfill_instrument_history.py
@@ -1,0 +1,36 @@
+"""Backfill ``instrument_cik_history`` + ``instrument_symbol_history``
+with one ``imported`` row per instrument.
+
+Run via: ``uv run python scripts/backfill_instrument_history.py``
+
+Idempotent — safe to re-run after Batch 7 lands the real
+symbol-change ingester. The migrations 102/103 add the empty tables;
+this script is the deploy-time companion that seeds the current
+chain so the ownership-rollup service has a stable
+``historical_ciks_for(instrument_id)`` answer for every instrument.
+
+Pairs with migration 102 + 103 (Batch 1 of #788).
+"""
+
+from __future__ import annotations
+
+import psycopg
+
+from app.config import settings
+from app.services.instrument_history import backfill_current_history
+
+
+def main() -> None:
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.transaction():
+            cik_inserted, sym_inserted = backfill_current_history(conn)
+        print(
+            f"instrument_cik_history: inserted {cik_inserted} row(s) "
+            f"(no-op when already present).\n"
+            f"instrument_symbol_history: inserted {sym_inserted} row(s) "
+            f"(no-op when already present)."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/101_insider_initial_holdings_value_owned.sql
+++ b/sql/101_insider_initial_holdings_value_owned.sql
@@ -1,0 +1,40 @@
+-- 101_insider_initial_holdings_value_owned.sql
+--
+-- Recovery for migration 093 schema drift. The migration recorded a
+-- ``CREATE TABLE IF NOT EXISTS insider_initial_holdings`` that defined
+-- a ``value_owned NUMERIC(18, 6)`` column, but the live DB already had
+-- a pre-existing ``insider_initial_holdings`` table from a parallel
+-- experiment. ``CREATE TABLE IF NOT EXISTS`` no-ops on a name conflict
+-- and does NOT add missing columns — the migration was recorded as
+-- applied but the column never landed. Every read of
+-- ``insider_initial_holdings.value_owned`` errors with "column does
+-- not exist".
+--
+-- Recovery is column-add via ``ALTER TABLE ... ADD COLUMN IF NOT
+-- EXISTS``, the only safe shape for a column add to an existing
+-- table. Idempotent — re-running on a DB that already has the column
+-- is a no-op. ``tests/smoke/test_app_boots.py`` gains an explicit
+-- column-existence assertion in the same PR; ``tests/smoke/
+-- test_schema_drift.py`` lands alongside as the long-term prevention
+-- for this class of drift (B5 of #797 pulled forward).
+--
+-- See migration 093 for the column's role in the Form 3 baseline
+-- reader (`get_insider_summary`).
+
+ALTER TABLE insider_initial_holdings
+    ADD COLUMN IF NOT EXISTS value_owned NUMERIC(18, 6),
+    ADD COLUMN IF NOT EXISTS underlying_value NUMERIC(18, 6);
+
+COMMENT ON COLUMN insider_initial_holdings.value_owned IS
+    'Form 3 valueOwnedFollowingTransaction alternative to shares. SEC '
+    'allows EITHER shares OR value (fractional-undivided-interest '
+    'securities use the value branch). Recovery for migration 093 '
+    'CREATE TABLE IF NOT EXISTS no-op on pre-existing schema.';
+
+COMMENT ON COLUMN insider_initial_holdings.underlying_value IS
+    'Form 3 valueOwnedFollowingTransaction alternative for derivative '
+    'underlyings. Some derivative grants (performance / dollar-'
+    'denominated awards) express the underlying as a value not a '
+    'share count. Recovery for migration 093 CREATE TABLE IF NOT '
+    'EXISTS no-op on pre-existing schema. Surfaced by the schema-'
+    'drift smoke gate (B5 of #797 pulled forward into Batch 1).';

--- a/sql/102_instrument_cik_history.sql
+++ b/sql/102_instrument_cik_history.sql
@@ -1,0 +1,93 @@
+-- 102_instrument_cik_history.sql
+--
+-- CIK chain per instrument with effective-date ranges (#794 schema
+-- piece, batched alongside #789 in the ownership-card Tier 0 PR).
+--
+-- SEC's CIK is the stable identifier across rebrands, reorgs, and
+-- ticker changes (FB → META, BBBY → BBBYQ at delisting). Symbol is
+-- not stable. Today every filings table keys on ``instrument_id``,
+-- not CIK, so the read side already survives a rename if the
+-- ingester resolved the historical CIK to the same instrument_id at
+-- write time. This table records the canonical CIK chain so:
+--
+--   1. The Batch 7 symbol-change ingester can write a new row when a
+--      reorg happens, closing out the prior chain.
+--   2. The ownership-rollup service has a stable hook
+--      (``historical_ciks_for(instrument_id)``) that returns every
+--      CIK ever associated with the instrument — useful for
+--      cross-source dedup and for the diagnostic operator endpoint.
+--
+-- This migration only ships the schema + a one-row-per-instrument
+-- backfill from ``instrument_sec_profile.cik`` (the current CIK).
+-- Historical chains land in Batch 7 alongside the actual reorg
+-- ingester. The BBBY ownership card is NOT yet production-trustworthy
+-- after this migration — that's by design; the schema lands so the
+-- Batch 7 ingester has somewhere to write.
+--
+-- Temporal invariants enforced at the DB layer:
+--
+--   * ``effective_to IS NULL OR effective_to > effective_from`` — no
+--     inverted ranges, no zero-duration ranges. Codex spec review
+--     caught the v1 spec missing this.
+--   * UNIQUE INDEX on ``(instrument_id) WHERE effective_to IS NULL``
+--     — only one "current" CIK per instrument. A reorg ingester that
+--     forgets to close out the prior current row blows up loud at
+--     the DB rather than silently producing two current chains.
+--   * GIST EXCLUDE on ``daterange(effective_from, effective_to, '[)')``
+--     — no two ranges for one instrument can overlap in time.
+--     Half-open ``[from, to)`` so a chain ending on 2023-05-01 doesn't
+--     conflict with the next chain starting on 2023-05-01. ``btree_gist``
+--     is required to combine the equality on instrument_id with the
+--     range overlap on the daterange.
+--
+-- _PLANNER_TABLES in tests/fixtures/ebull_test_db.py is updated in
+-- the same PR per the prevention-log entry.
+
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+CREATE TABLE IF NOT EXISTS instrument_cik_history (
+    instrument_id   BIGINT NOT NULL
+        REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    cik             TEXT NOT NULL,
+    effective_from  DATE NOT NULL,
+    effective_to    DATE,
+    source_event    TEXT NOT NULL
+        CHECK (source_event IN
+            ('imported', 'rebrand', 'reorg', 'merger', 'spinoff', 'manual')),
+    PRIMARY KEY (instrument_id, cik, effective_from),
+    CONSTRAINT instrument_cik_history_dates_ordered
+        CHECK (effective_to IS NULL OR effective_to > effective_from)
+);
+
+-- One "current" CIK per instrument.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_instrument_cik_history_current
+    ON instrument_cik_history (instrument_id)
+    WHERE effective_to IS NULL;
+
+-- Non-overlapping date ranges per instrument. ``btree_gist`` lets us
+-- combine ``instrument_id WITH =`` (btree-shaped equality) with the
+-- daterange overlap operator ``&&`` in one EXCLUDE constraint.
+ALTER TABLE instrument_cik_history
+    ADD CONSTRAINT instrument_cik_history_no_overlap
+    EXCLUDE USING GIST (
+        instrument_id WITH =,
+        daterange(effective_from, effective_to, '[)') WITH &&
+    );
+
+-- Reverse lookup: given a CIK, which instruments has it ever been
+-- associated with? Used by the Batch 7 ingester to resolve a filing
+-- under a historical CIK back to the current instrument_id.
+CREATE INDEX IF NOT EXISTS idx_instrument_cik_history_cik
+    ON instrument_cik_history (cik);
+
+COMMENT ON TABLE instrument_cik_history IS
+    'CIK chain per instrument with effective-date ranges. Reader path '
+    'on the ownership card uses this to resolve filings under a '
+    'historical CIK back to the current instrument_id (#794). '
+    'effective_to NULL = current. EXCLUDE forbids overlapping ranges; '
+    'partial UNIQUE INDEX forbids two "current" rows per instrument.';
+
+COMMENT ON COLUMN instrument_cik_history.source_event IS
+    'How this row landed: imported (initial backfill), rebrand, '
+    'reorg, merger, spinoff, manual. CHECK-constrained so a future '
+    'parser regression cannot smuggle a seventh value.';

--- a/sql/103_instrument_symbol_history.sql
+++ b/sql/103_instrument_symbol_history.sql
@@ -1,0 +1,78 @@
+-- 103_instrument_symbol_history.sql
+--
+-- Symbol history per instrument with effective-date ranges (#794
+-- schema piece, batched alongside #789 in the ownership-card Tier 0
+-- PR).
+--
+-- Symbol is unstable across rebrands (FB → META), bankruptcy reorgs
+-- (BBBY → BBBYQ at delisting), share-class shuffles (GOOG/GOOGL),
+-- and ticker reassignment (a previously-delisted ticker reissued to
+-- a different CIK). This table records the canonical symbol chain
+-- per instrument so:
+--
+--   1. The Batch 7 symbol-change ingester can write a new row when a
+--      ticker change happens, closing out the prior chain.
+--   2. The Batch 7 frontend's ``HistoricalSymbolCallout`` can render
+--      "Filed as BBBY before 2023 reorg" when the displayed accession
+--      pre-dates the current symbol effective range.
+--
+-- Synthetic backfill from ``instrument_sec_profile.former_names`` is
+-- NOT performed here. ``former_names`` is **company-name** history
+-- (e.g. "Facebook, Inc." → "Meta Platforms, Inc."), not symbol
+-- history. SEC publishes name changes per-CIK; symbol history has to
+-- be reconstructed from EDGAR's per-accession ticker tagging or
+-- from the instrument's exchange listing history. That ingester
+-- ships in Batch 7. For Tier 0, only the current symbol is seeded —
+-- one row per instrument with ``effective_to IS NULL``.
+--
+-- Symbol-clash guard: the PK is scoped per ``instrument_id``, so a
+-- previously-used symbol later assigned to a different instrument is
+-- recorded as a separate row keyed on the new instrument_id. The
+-- two history chains never join.
+--
+-- Temporal invariants match instrument_cik_history (migration 102):
+-- ordered ranges, single-current per instrument, no overlap.
+--
+-- _PLANNER_TABLES in tests/fixtures/ebull_test_db.py is updated in
+-- the same PR per the prevention-log entry.
+
+CREATE TABLE IF NOT EXISTS instrument_symbol_history (
+    instrument_id   BIGINT NOT NULL
+        REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    symbol          TEXT NOT NULL,
+    effective_from  DATE NOT NULL,
+    effective_to    DATE,
+    source_event    TEXT NOT NULL
+        CHECK (source_event IN
+            ('imported', 'rebrand', 'delisting', 'relisting', 'manual')),
+    PRIMARY KEY (instrument_id, symbol, effective_from),
+    CONSTRAINT instrument_symbol_history_dates_ordered
+        CHECK (effective_to IS NULL OR effective_to > effective_from)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_instrument_symbol_history_current
+    ON instrument_symbol_history (instrument_id)
+    WHERE effective_to IS NULL;
+
+ALTER TABLE instrument_symbol_history
+    ADD CONSTRAINT instrument_symbol_history_no_overlap
+    EXCLUDE USING GIST (
+        instrument_id WITH =,
+        daterange(effective_from, effective_to, '[)') WITH &&
+    );
+
+CREATE INDEX IF NOT EXISTS idx_instrument_symbol_history_symbol
+    ON instrument_symbol_history (symbol);
+
+COMMENT ON TABLE instrument_symbol_history IS
+    'Symbol history per instrument with effective-date ranges. '
+    'Symbol-clash guard: every row is scoped to one instrument_id by '
+    'PK, so a reused symbol on a different instrument is a separate '
+    'chain. Synthetic backfill from former_names (which is name '
+    'history, not symbol history) is intentionally NOT done here; '
+    'real symbol-change ingest ships in Batch 7.';
+
+COMMENT ON COLUMN instrument_symbol_history.source_event IS
+    'How this row landed: imported (initial backfill), rebrand, '
+    'delisting, relisting, manual. CHECK-constrained so a future '
+    'parser regression cannot smuggle a sixth value.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -136,6 +136,12 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "def14a_ingest_log",
     "def14a_beneficial_holdings",
     "filing_events",
+    # #794 — instrument CIK and symbol history (Batch 1 of #788). FK →
+    # instruments (cascade on delete). Listed before the instruments
+    # row truncation further down so a test that populates a history
+    # row without touching the instruments row clears deterministically.
+    "instrument_cik_history",
+    "instrument_symbol_history",
     "decision_audit",  # #315 Phase 3 alerts
     "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)
     "operators",  # #315 Phase 3 alerts (cursor column)

--- a/tests/smoke/test_app_boots.py
+++ b/tests/smoke/test_app_boots.py
@@ -216,3 +216,36 @@ def test_app_lifespan_boots_and_state_is_coherent() -> None:
                     delattr(app.state, flag)
             else:
                 setattr(app.state, flag, value)
+
+
+def test_insider_initial_holdings_value_owned_column_exists() -> None:
+    """Recovery gate for migration 093 schema drift (#789).
+
+    Migration 093 created ``insider_initial_holdings`` with a
+    ``value_owned`` column, but on a DB that already had the table
+    from a parallel experiment ``CREATE TABLE IF NOT EXISTS`` was a
+    no-op and the column never landed. Migration 101 explicitly
+    ``ALTER TABLE ... ADD COLUMN IF NOT EXISTS value_owned`` to
+    repair the drift. This smoke test pins the column's existence so
+    a regression on the recovery path fails loud at boot rather than
+    silently breaking the Form 3 baseline reader.
+    """
+    import psycopg
+
+    from app.config import settings
+
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT column_name, data_type
+                FROM information_schema.columns
+                WHERE table_name = 'insider_initial_holdings'
+                  AND column_name = 'value_owned'
+                """,
+            )
+            row = cur.fetchone()
+    assert row is not None, (
+        "insider_initial_holdings.value_owned column missing — migration 101 did not apply or was no-op'd."
+    )
+    assert row[1] == "numeric", f"value_owned has unexpected type {row[1]!r}; expected NUMERIC."

--- a/tests/smoke/test_no_settings_url_in_destructive_paths.py
+++ b/tests/smoke/test_no_settings_url_in_destructive_paths.py
@@ -132,6 +132,17 @@ _ALLOWED: dict[str, str] = {
     "test_jobs_heartbeat.py": "scoped writes to job_runtime_heartbeat with per-test cleanup",
     "test_jobs_queue_recovery.py": "scoped writes to pending_job_requests + linked-run rows with per-test cleanup",
     "test_jobs_queue_boot_drain.py": "scoped writes to pending_job_requests with per-test cleanup",
+    # Read-only schema introspection. ``test_schema_drift.py`` (B5
+    # of #797 pulled forward into Batch 1 of #788) parses
+    # ``CREATE TABLE`` blocks from sql/*.sql and compares declared
+    # columns against ``information_schema.columns`` on the live dev
+    # DB to catch the migration-093 class of bug (CREATE TABLE IF
+    # NOT EXISTS no-op'd onto a pre-existing table with a different
+    # shape). The whole point of the gate is to validate against the
+    # DB the running app actually uses, so it MUST connect to
+    # ``settings.database_url``. No writes anywhere — only
+    # ``SELECT column_name FROM information_schema.columns``.
+    "smoke/test_schema_drift.py": "read-only information_schema introspection of the live dev DB schema",
 }
 
 _TESTS_DIR = Path(__file__).resolve().parents[1]

--- a/tests/smoke/test_schema_drift.py
+++ b/tests/smoke/test_schema_drift.py
@@ -1,0 +1,215 @@
+"""Schema-drift smoke gate (B5 of #797 pulled forward into Batch 1
+of #788).
+
+For every ``sql/NNN_*.sql`` migration file, parse the ``CREATE TABLE``
+statements and assert that every declared column exists in the live
+DB's ``information_schema.columns``. Catches the migration-093 class
+of bug:
+
+  * A migration declares ``CREATE TABLE IF NOT EXISTS foo (a, b, c, d)``
+  * On a DB that already has ``foo (a, b, c)`` from a parallel
+    experiment, ``CREATE TABLE IF NOT EXISTS`` no-ops and ``d`` is
+    silently missing.
+  * The migration is recorded as applied — the next reader of ``d``
+    blows up with "column does not exist" weeks later.
+
+This gate runs on every smoke pass and would have caught migration
+093 the day it landed.
+
+Tolerance:
+
+  * **Extra columns in live DB are OK.** A column added by a later
+    ``ALTER TABLE ... ADD COLUMN`` migration is a legitimate addition;
+    we only fail on columns the CREATE statement declared but the live
+    DB lacks.
+  * **VIEWs are skipped.** Only physical tables (``CREATE TABLE``) are
+    validated. Views are derived from underlying tables, so a column
+    drift on a view IS a column drift on its source table — caught
+    transitively.
+  * **Comments inside column definitions are tolerated.** The parser
+    strips ``-- ...`` and ``/* ... */`` runs before splitting on
+    commas.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import psycopg
+import pytest
+
+# Same DB-reachable probe used by test_app_boots.py — keeps the smoke
+# gate skip cleanly when there's no Postgres at all.
+
+
+def _db_reachable() -> bool:
+    try:
+        from app.config import settings
+
+        with psycopg.connect(settings.database_url, connect_timeout=2) as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+                cur.fetchone()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _db_reachable(),
+    reason="dev Postgres not reachable; schema drift gate requires the real DB",
+)
+
+
+_SQL_DIR = Path(__file__).resolve().parent.parent.parent / "sql"
+
+# Match ``CREATE TABLE [IF NOT EXISTS] name (...)`` capturing name +
+# parenthesised body. Body may contain nested parens (``CHECK (x > 0)``)
+# so the regex is permissive — we re-scan with bracket counting.
+_CREATE_TABLE_RE = re.compile(
+    r"CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+([\w.]+)\s*\(",
+    re.IGNORECASE,
+)
+
+# Recognise constraint / table-level clauses to skip when extracting
+# column names. Both bare keywords (``UNIQUE (...)``) and run-on
+# (``UNIQUE(``) need to match — strip the trailing paren so the
+# tokeniser sees the keyword regardless of whitespace.
+_NON_COLUMN_PREFIXES = (
+    "CONSTRAINT",
+    "PRIMARY",
+    "FOREIGN",
+    "UNIQUE",
+    "CHECK",
+    "EXCLUDE",
+    "LIKE",
+)
+
+
+def _first_word(part: str) -> str:
+    """Return the leading identifier-ish token, uppercased, with any
+    trailing ``(`` stripped so ``UNIQUE(...)`` and ``UNIQUE (...)``
+    both reduce to ``UNIQUE``."""
+    raw = part.split(maxsplit=1)[0]
+    # Strip any trailing punctuation (`(`, `,`, etc.) the next char is
+    # the keyword's argument list — we only want the keyword itself.
+    return re.split(r"[(,]", raw, maxsplit=1)[0].upper().strip()
+
+
+def _strip_comments(sql: str) -> str:
+    sql = re.sub(r"/\*.*?\*/", "", sql, flags=re.DOTALL)
+    sql = re.sub(r"--[^\n]*", "", sql)
+    return sql
+
+
+def _extract_create_table_blocks(sql: str) -> list[tuple[str, str]]:
+    """Return list of ``(table_name, body)`` for every CREATE TABLE in
+    the SQL text. Body is everything between the opening ``(`` and
+    the matching ``)``."""
+    out: list[tuple[str, str]] = []
+    for match in _CREATE_TABLE_RE.finditer(sql):
+        table_name = match.group(1).split(".")[-1].lower()
+        # Walk forward from the opening paren to find the matching close.
+        depth = 0
+        start = match.end() - 1  # index of '('
+        body_start = start + 1
+        for i in range(start, len(sql)):
+            c = sql[i]
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    out.append((table_name, sql[body_start:i]))
+                    break
+    return out
+
+
+def _extract_columns(body: str) -> list[str]:
+    """Split a CREATE TABLE body on commas at depth 0, then keep only
+    the entries that look like column definitions (skip CONSTRAINT /
+    PRIMARY / etc. clauses)."""
+    parts: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for c in body:
+        if c == "(":
+            depth += 1
+            current.append(c)
+        elif c == ")":
+            depth -= 1
+            current.append(c)
+        elif c == "," and depth == 0:
+            parts.append("".join(current).strip())
+            current = []
+        else:
+            current.append(c)
+    if current:
+        parts.append("".join(current).strip())
+
+    columns: list[str] = []
+    for part in parts:
+        if not part:
+            continue
+        if _first_word(part) in _NON_COLUMN_PREFIXES:
+            continue
+        # Column definition: ``name TYPE ...``. First token is the
+        # column name, possibly quoted.
+        col_name = part.split(maxsplit=1)[0].strip().strip('"').lower()
+        if col_name:
+            columns.append(col_name)
+    return columns
+
+
+def _live_columns_for(conn: psycopg.Connection[tuple], table: str) -> set[str]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT column_name FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = %s
+            """,
+            (table,),
+        )
+        return {str(r[0]) for r in cur.fetchall()}
+
+
+def test_no_create_table_column_drift() -> None:
+    """For every CREATE TABLE in ``sql/*.sql``, every declared column
+    must exist in the live DB.
+
+    Extra columns in live (added by later ALTER TABLE) are OK.
+    Missing columns are NOT OK and fail the gate.
+    """
+    files = sorted(_SQL_DIR.glob("*.sql"))
+    assert files, "no migration files found under sql/"
+
+    from app.config import settings
+
+    drift_findings: list[str] = []
+    with psycopg.connect(settings.database_url) as conn:
+        for path in files:
+            sql = _strip_comments(path.read_text(encoding="utf-8"))
+            for table, body in _extract_create_table_blocks(sql):
+                declared = set(_extract_columns(body))
+                if not declared:
+                    continue
+                live = _live_columns_for(conn, table)
+                if not live:
+                    # Table was renamed or dropped by a later migration —
+                    # not drift; skip. (A typo'd CREATE that never landed
+                    # would also surface here, but the migration runner
+                    # would have failed loudly long before this gate.)
+                    continue
+                missing = declared - live
+                if missing:
+                    drift_findings.append(
+                        f"{path.name}: table {table!r} declares columns "
+                        f"{sorted(missing)} but the live DB lacks them. "
+                        f"This is the migration-093 class of bug — "
+                        f"a CREATE TABLE IF NOT EXISTS no-op'd onto a "
+                        f"pre-existing table with a different shape."
+                    )
+
+    assert not drift_findings, "schema drift detected:\n" + "\n".join(drift_findings)

--- a/tests/test_holder_name_resolver.py
+++ b/tests/test_holder_name_resolver.py
@@ -1,0 +1,106 @@
+"""Verify the lifted ``app.services.holder_name_resolver`` returns the
+same results as the original private helpers in
+``app.services.def14a_drift`` so the two consumers (DEF 14A drift
+detector + ownership rollup) cannot drift apart on match semantics.
+
+Codex spec review caught the duplication risk on the v1 spec for
+#789; this suite is the recurring guard.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services import def14a_drift
+from app.services.holder_name_resolver import (
+    normalise_name,
+    resolve_holder_to_filer,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("John Doe", "john doe"),
+        ("  John Doe  ", "john doe"),
+        ("John Doe, CEO", "john doe"),
+        ("John Doe - Director", "john doe"),
+        ("John Doe — Director", "john doe"),
+        ("John Doe – Director", "john doe"),
+        ("ALL CAPS NAME", "all caps name"),
+        ("", ""),
+    ],
+)
+def test_normalise_name_matches_legacy(raw: str, expected: str) -> None:
+    """Public + legacy private helper return the same result."""
+    assert normalise_name(raw) == expected
+    assert def14a_drift._normalise_name(raw) == expected
+
+
+def test_resolver_matches_form4_filer(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Public ``resolve_holder_to_filer`` returns the same tuple as
+    the legacy ``def14a_drift._resolve_holder_match`` for a Form 4
+    match."""
+    conn = ebull_test_conn
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (789100, 'RES', 'Resolver Test', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+    )
+    conn.execute(
+        """
+        INSERT INTO insider_filings (
+            accession_number, instrument_id, document_type, issuer_cik
+        ) VALUES ('F4-RES-001', 789100, '4', '0000789100')
+        ON CONFLICT (accession_number) DO NOTHING
+        """,
+    )
+    conn.execute(
+        """
+        INSERT INTO insider_transactions (
+            accession_number, txn_row_num, instrument_id, filer_cik, filer_name,
+            txn_date, txn_code, shares, post_transaction_shares, is_derivative
+        ) VALUES ('F4-RES-001', 1, 789100, '0001234567', 'Holder Name',
+                  %s, 'P', 100, %s, FALSE)
+        """,
+        (date(2026, 3, 1), Decimal("250000")),
+    )
+    conn.commit()
+
+    public = resolve_holder_to_filer(conn, instrument_id=789100, holder_name="Holder Name")
+    legacy = def14a_drift._resolve_holder_match(conn, instrument_id=789100, holder_name="Holder Name")
+    assert public == legacy
+    assert public[0] is True
+    assert public[1] == "0001234567"
+    assert public[2] == Decimal("250000")
+
+
+def test_resolver_returns_no_match_for_unknown_holder(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (789101, 'RESM', 'Resolver Test 2', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+    )
+    conn.commit()
+
+    public = resolve_holder_to_filer(conn, instrument_id=789101, holder_name="Phantom Holder")
+    legacy = def14a_drift._resolve_holder_match(conn, instrument_id=789101, holder_name="Phantom Holder")
+    assert public == legacy == (False, None, None)

--- a/tests/test_instrument_history.py
+++ b/tests/test_instrument_history.py
@@ -1,0 +1,227 @@
+"""Integration tests for instrument CIK / symbol history (#794
+schema piece, Batch 1 of #788).
+
+Exercises the DB-level temporal invariants — overlap / inverted /
+single-current — and the backfill helper's idempotency.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import psycopg
+import pytest
+
+from app.services import instrument_history
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _seed_sec_profile(conn: psycopg.Connection[tuple], *, iid: int, cik: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instrument_sec_profile (instrument_id, cik)
+        VALUES (%s, %s)
+        ON CONFLICT (instrument_id) DO UPDATE SET cik = EXCLUDED.cik
+        """,
+        (iid, cik),
+    )
+
+
+class TestCikHistoryConstraints:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=794_001, symbol="HIST")
+        conn.commit()
+        return conn
+
+    def test_inverted_range_rejected(self, _setup: psycopg.Connection[tuple]) -> None:
+        """``effective_to <= effective_from`` violates the CHECK."""
+        conn = _setup
+        with pytest.raises(psycopg.errors.CheckViolation):
+            with conn.transaction():
+                conn.execute(
+                    """
+                    INSERT INTO instrument_cik_history (
+                        instrument_id, cik, effective_from, effective_to,
+                        source_event
+                    ) VALUES (%s, %s, %s, %s, %s)
+                    """,
+                    (794_001, "0000000001", date(2024, 1, 1), date(2024, 1, 1), "manual"),
+                )
+
+    def test_two_current_rows_rejected(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Partial UNIQUE INDEX forbids two ``effective_to IS NULL``
+        rows for the same instrument."""
+        conn = _setup
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            with conn.transaction():
+                conn.execute(
+                    """
+                    INSERT INTO instrument_cik_history (
+                        instrument_id, cik, effective_from, effective_to,
+                        source_event
+                    ) VALUES (%s, %s, %s, NULL, %s)
+                    """,
+                    (794_001, "0000000002", date(2020, 1, 1), "manual"),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO instrument_cik_history (
+                        instrument_id, cik, effective_from, effective_to,
+                        source_event
+                    ) VALUES (%s, %s, %s, NULL, %s)
+                    """,
+                    (794_001, "0000000003", date(2022, 1, 1), "manual"),
+                )
+
+    def test_overlapping_ranges_rejected(self, _setup: psycopg.Connection[tuple]) -> None:
+        """GIST EXCLUDE rejects overlapping date ranges per
+        instrument (half-open ``[from, to)`` semantic)."""
+        conn = _setup
+        with pytest.raises(psycopg.errors.ExclusionViolation):
+            with conn.transaction():
+                conn.execute(
+                    """
+                    INSERT INTO instrument_cik_history (
+                        instrument_id, cik, effective_from, effective_to,
+                        source_event
+                    ) VALUES (%s, %s, %s, %s, %s)
+                    """,
+                    (794_001, "0000000004", date(2020, 1, 1), date(2021, 1, 1), "rebrand"),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO instrument_cik_history (
+                        instrument_id, cik, effective_from, effective_to,
+                        source_event
+                    ) VALUES (%s, %s, %s, %s, %s)
+                    """,
+                    (794_001, "0000000005", date(2020, 6, 1), date(2021, 6, 1), "reorg"),
+                )
+
+    def test_adjacent_ranges_allowed(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Half-open ``[from, to)`` lets a chain ending on 2021-01-01
+        sit next to a chain starting 2021-01-01 without overlap."""
+        conn = _setup
+        with conn.transaction():
+            conn.execute(
+                """
+                INSERT INTO instrument_cik_history (
+                    instrument_id, cik, effective_from, effective_to,
+                    source_event
+                ) VALUES (%s, %s, %s, %s, %s)
+                """,
+                (794_001, "0000000010", date(2020, 1, 1), date(2021, 1, 1), "rebrand"),
+            )
+            conn.execute(
+                """
+                INSERT INTO instrument_cik_history (
+                    instrument_id, cik, effective_from, effective_to,
+                    source_event
+                ) VALUES (%s, %s, %s, %s, %s)
+                """,
+                (794_001, "0000000011", date(2021, 1, 1), date(2022, 1, 1), "reorg"),
+            )
+
+
+class TestSymbolHistoryClashGuard:
+    def test_same_symbol_two_instruments_allowed(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A symbol reused on a different instrument at a different
+        time is a separate chain (PK is per-instrument). Inserts on
+        both instruments succeed."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=794_010, symbol="ALPHA")
+        _seed_instrument(conn, iid=794_011, symbol="BETA")
+        conn.commit()
+
+        with conn.transaction():
+            conn.execute(
+                """
+                INSERT INTO instrument_symbol_history (
+                    instrument_id, symbol, effective_from, effective_to,
+                    source_event
+                ) VALUES (%s, %s, %s, %s, %s)
+                """,
+                (794_010, "DEAD", date(2018, 1, 1), date(2019, 1, 1), "delisting"),
+            )
+            conn.execute(
+                """
+                INSERT INTO instrument_symbol_history (
+                    instrument_id, symbol, effective_from, effective_to,
+                    source_event
+                ) VALUES (%s, %s, %s, %s, %s)
+                """,
+                (794_011, "DEAD", date(2024, 1, 1), date(2025, 1, 1), "relisting"),
+            )
+
+
+class TestBackfill:
+    def test_backfill_idempotent(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=794_020, symbol="BFIDEM")
+        _seed_sec_profile(conn, iid=794_020, cik="0000099001")
+        conn.commit()
+
+        first_cik, first_sym = instrument_history.backfill_current_history(conn)
+        conn.commit()
+        second_cik, second_sym = instrument_history.backfill_current_history(conn)
+        conn.commit()
+
+        assert first_cik >= 1
+        assert first_sym >= 1
+        assert second_cik == 0
+        assert second_sym == 0
+
+    def test_historical_ciks_for_returns_seed_row(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=794_021, symbol="HIST2")
+        _seed_sec_profile(conn, iid=794_021, cik="0000099002")
+        conn.commit()
+
+        instrument_history.backfill_current_history(conn)
+        conn.commit()
+
+        ciks = instrument_history.historical_ciks_for(conn, 794_021)
+        assert list(ciks) == ["0000099002"]
+        assert instrument_history.current_cik_for(conn, 794_021) == "0000099002"
+
+    def test_resolve_historical_cik_to_instrument(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=794_022, symbol="HIST3")
+        _seed_sec_profile(conn, iid=794_022, cik="0000099003")
+        conn.commit()
+        instrument_history.backfill_current_history(conn)
+        conn.commit()
+
+        assert instrument_history.instrument_id_for_historical_cik(conn, "0000099003") == 794_022
+        assert instrument_history.instrument_id_for_historical_cik(conn, "0000099999") is None

--- a/tests/test_ownership_rollup.py
+++ b/tests/test_ownership_rollup.py
@@ -468,6 +468,45 @@ class TestDedupPriority:
         names = sorted(h.filer_name for h in insiders.holders)
         assert names == ["Jones Jane", "Smith John"]
 
+    def test_joint_filer_13d_no_fanout_in_canonical_union(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Claude PR review round 2 (PR 798) PREVENTION: assert no
+        fan-out when a single 13D accession carries multiple
+        ``filing_id`` rows (joint reporters). The ``blocks`` CTE in
+        ``_CANONICAL_UNION_SQL`` picks one ``filing_id`` per
+        accession and the JOIN back to ``blockholder_filings`` is on
+        the PK — exactly one survivor per accession enters the
+        canonical-holder set, so the per-block aggregate is NOT
+        summed across joint reporters."""
+        conn = _setup
+        # Two reporters under one accession claiming the same
+        # aggregate_amount (SEC Rule 13d-1 requires joint reporters
+        # to claim the same beneficial ownership).
+        for reporter_name, reporter_cik in [
+            ("Joint Reporter A", "0009990001"),
+            ("Joint Reporter B", "0009990002"),
+        ]:
+            _seed_block(
+                conn,
+                accession="13D-JOINT-001",
+                instrument_id=789_001,
+                filer_cik="0009990000",
+                filer_name="Joint Filer Group",
+                submission_type="SCHEDULE 13D",
+                aggregate_shares="5000000",
+                filed_at=datetime(2025, 12, 1, tzinfo=UTC),
+                reporter_cik=reporter_cik,
+                reporter_name=reporter_name,
+            )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="GME", instrument_id=789_001)
+        block_slices = [s for s in rollup.slices if s.category == "blockholders"]
+        assert len(block_slices) == 1
+        # Exactly one block, carrying the per-accession aggregate
+        # (5M). Doubled-up to 10M would mean the JOIN re-fanned.
+        assert block_slices[0].total_shares == Decimal("5000000")
+        assert block_slices[0].filer_count == 1
+
 
 # ---------------------------------------------------------------------------
 # DEF 14A enrichment

--- a/tests/test_ownership_rollup.py
+++ b/tests/test_ownership_rollup.py
@@ -1,0 +1,850 @@
+"""Integration tests for the ownership rollup service (#789).
+
+Tests run against the real ``ebull_test`` DB so the canonical
+union SQL exercises actual joins / DISTINCT ON / NOT EXISTS
+semantics. Each scenario seeds the source tables (Form 4, Form 3,
+13D/G, 13F, DEF 14A) and asserts dedup priority, residual math,
+coverage banner, and snapshot isolation.
+
+Naming convention: instrument_id 789_xxx is reserved for this
+suite to avoid collisions with #769 (DEF 14A drift) at 769_xxx.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services import ownership_rollup
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _seed_outstanding(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    shares: str,
+    period_end: date = date(2026, 3, 31),
+    treasury: str | None = None,
+) -> None:
+    """Seed shares_outstanding (and optionally treasury_shares) via
+    ``financial_periods`` + ``financial_facts_raw`` so the
+    ``instrument_share_count_latest`` view returns the row."""
+    conn.execute(
+        """
+        INSERT INTO financial_periods (
+            instrument_id, period_end_date, period_type, fiscal_year,
+            fiscal_quarter, source, source_ref, reported_currency,
+            is_restated, is_derived, normalization_status,
+            treasury_shares, filed_date, superseded_at
+        ) VALUES (%s, %s, 'Q4', %s, 4, 'sec_xbrl', %s, 'USD',
+                  FALSE, FALSE, 'normalized',
+                  %s, %s, NULL)
+        ON CONFLICT DO NOTHING
+        """,
+        (
+            instrument_id,
+            period_end,
+            period_end.year,
+            f"OUTSTANDING-{instrument_id}-{period_end}",
+            Decimal(treasury) if treasury is not None else None,
+            datetime(period_end.year, period_end.month, 1, tzinfo=UTC),
+        ),
+    )
+    # Also seed financial_facts_raw so the share_count_history view
+    # returns the row (the view is what feeds
+    # instrument_share_count_latest).
+    conn.execute(
+        """
+        INSERT INTO financial_facts_raw (
+            instrument_id, taxonomy, concept, unit, period_end, val,
+            form_type, filed_date, accession_number,
+            fiscal_year, fiscal_period
+        ) VALUES (%s, 'dei', 'EntityCommonStockSharesOutstanding',
+                  'shares', %s, %s, '10-Q', %s, %s, %s, 'Q4')
+        ON CONFLICT DO NOTHING
+        """,
+        (
+            instrument_id,
+            period_end,
+            Decimal(shares),
+            period_end,
+            f"OUTSTANDING-{instrument_id}-{period_end}",
+            period_end.year,
+        ),
+    )
+
+
+def _seed_form4(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    instrument_id: int,
+    filer_cik: str | None,
+    filer_name: str,
+    txn_date: date,
+    post_transaction_shares: str,
+    is_derivative: bool = False,
+    txn_row_num: int = 1,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO insider_filings (
+            accession_number, instrument_id, document_type, issuer_cik
+        ) VALUES (%s, %s, '4', '0000000789')
+        ON CONFLICT (accession_number) DO NOTHING
+        """,
+        (accession, instrument_id),
+    )
+    conn.execute(
+        """
+        INSERT INTO insider_transactions (
+            accession_number, txn_row_num, instrument_id, filer_cik, filer_name,
+            txn_date, txn_code, shares, post_transaction_shares, is_derivative
+        ) VALUES (%s, %s, %s, %s, %s, %s, 'P', 100, %s, %s)
+        """,
+        (
+            accession,
+            txn_row_num,
+            instrument_id,
+            filer_cik,
+            filer_name,
+            txn_date,
+            Decimal(post_transaction_shares),
+            is_derivative,
+        ),
+    )
+
+
+def _seed_form3(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    instrument_id: int,
+    filer_cik: str | None,
+    filer_name: str,
+    shares: str,
+    as_of: date,
+    row_num: int = 1,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO insider_initial_holdings (
+            accession_number, row_num, instrument_id, filer_cik, filer_name,
+            security_title, is_derivative, direct_indirect, shares, as_of_date
+        ) VALUES (%s, %s, %s, %s, %s, 'Common Stock', FALSE, 'D', %s, %s)
+        """,
+        (accession, row_num, instrument_id, filer_cik, filer_name, Decimal(shares), as_of),
+    )
+
+
+def _seed_block(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    instrument_id: int,
+    filer_cik: str,
+    filer_name: str,
+    submission_type: str,
+    aggregate_shares: str,
+    filed_at: datetime,
+    reporter_cik: str | None = None,
+    reporter_name: str | None = None,
+) -> None:
+    """Seed both ``blockholder_filers`` and ``blockholder_filings``."""
+    conn.execute(
+        """
+        INSERT INTO blockholder_filers (cik, name)
+        VALUES (%s, %s)
+        ON CONFLICT (cik) DO NOTHING
+        """,
+        (filer_cik, filer_name),
+    )
+    status = "active" if submission_type.startswith("SCHEDULE 13D") else "passive"
+    conn.execute(
+        """
+        INSERT INTO blockholder_filings (
+            filer_id, accession_number, submission_type, status,
+            instrument_id, issuer_cik, issuer_cusip,
+            reporter_cik, reporter_no_cik, reporter_name,
+            aggregate_amount_owned, filed_at
+        )
+        SELECT filer_id, %s, %s, %s, %s, '0000000789', '999999999',
+               %s, %s, %s, %s, %s
+        FROM blockholder_filers WHERE cik = %s
+        """,
+        (
+            accession,
+            submission_type,
+            status,
+            instrument_id,
+            reporter_cik,
+            reporter_cik is None,
+            reporter_name or filer_name,
+            Decimal(aggregate_shares),
+            filed_at,
+            filer_cik,
+        ),
+    )
+
+
+def _seed_inst_holding(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    instrument_id: int,
+    filer_cik: str,
+    filer_name: str,
+    filer_type: str,
+    period_of_report: date,
+    shares: str,
+    is_put_call: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO institutional_filers (cik, name, filer_type)
+        VALUES (%s, %s, %s)
+        ON CONFLICT (cik) DO UPDATE SET filer_type = EXCLUDED.filer_type
+        """,
+        (filer_cik, filer_name, filer_type),
+    )
+    conn.execute(
+        """
+        INSERT INTO institutional_holdings (
+            filer_id, instrument_id, accession_number, period_of_report,
+            shares, voting_authority, is_put_call, filed_at
+        )
+        SELECT filer_id, %s, %s, %s, %s, 'SOLE', %s, %s
+        FROM institutional_filers WHERE cik = %s
+        """,
+        (
+            instrument_id,
+            accession,
+            period_of_report,
+            Decimal(shares),
+            is_put_call,
+            datetime(period_of_report.year, period_of_report.month, 1, tzinfo=UTC),
+            filer_cik,
+        ),
+    )
+
+
+def _seed_def14a(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    instrument_id: int,
+    holder_name: str,
+    shares: str,
+    as_of: date = date(2026, 3, 1),
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO def14a_beneficial_holdings (
+            instrument_id, accession_number, issuer_cik,
+            holder_name, holder_role, shares, percent_of_class, as_of_date
+        ) VALUES (%s, %s, '0000000789', %s, 'officer', %s, '5.5', %s)
+        """,
+        (instrument_id, accession, holder_name, Decimal(shares), as_of),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dedup priority
+# ---------------------------------------------------------------------------
+
+
+class TestDedupPriority:
+    """``form4 > form3 > 13d/g > def14a > 13f`` per CIK identity."""
+
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=789_001, symbol="GME")
+        _seed_outstanding(conn, instrument_id=789_001, shares="448375157")
+        conn.commit()
+        return conn
+
+    def test_form4_beats_13d_for_same_cik(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Cohen-on-GME shape: Form 4 cumulative + 13D/A reporting the
+        same beneficial owner. Expect a single insiders-slice row of
+        the Form 4 share count, with the 13D accession in
+        ``dropped_sources``."""
+        conn = _setup
+        cik = "0001767470"
+        _seed_form4(
+            conn,
+            accession="F4-RC-2026-001",
+            instrument_id=789_001,
+            filer_cik=cik,
+            filer_name="Cohen Ryan",
+            txn_date=date(2026, 1, 21),
+            post_transaction_shares="38347842",
+        )
+        _seed_block(
+            conn,
+            accession="13D-RC-2025-001",
+            instrument_id=789_001,
+            filer_cik=cik,
+            filer_name="Cohen Ryan",
+            submission_type="SCHEDULE 13D/A",
+            aggregate_shares="36847842",
+            filed_at=datetime(2025, 1, 29, tzinfo=UTC),
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="GME", instrument_id=789_001)
+
+        insider_slices = [s for s in rollup.slices if s.category == "insiders"]
+        assert len(insider_slices) == 1
+        cohen = insider_slices[0].holders[0]
+        assert cohen.filer_cik == cik
+        assert cohen.shares == Decimal("38347842")
+        assert cohen.winning_source == "form4"
+        assert len(cohen.dropped_sources) == 1
+        assert cohen.dropped_sources[0].source == "13d"
+        assert cohen.dropped_sources[0].accession_number == "13D-RC-2025-001"
+        # Blockholders slice should be empty — Cohen lost there.
+        assert not any(s.category == "blockholders" for s in rollup.slices)
+
+    def test_13g_beats_13f_for_same_cik(self, _setup: psycopg.Connection[tuple]) -> None:
+        """A large institution that crossed 5% files 13G AND a 13F.
+        Expect 13G winner; the 13F's accession ships as dropped."""
+        conn = _setup
+        cik = "0000102909"
+        _seed_block(
+            conn,
+            accession="13G-VG-2025-001",
+            instrument_id=789_001,
+            filer_cik=cik,
+            filer_name="VANGUARD GROUP INC",
+            submission_type="SCHEDULE 13G/A",
+            aggregate_shares="22000000",
+            filed_at=datetime(2025, 12, 31, tzinfo=UTC),
+        )
+        _seed_inst_holding(
+            conn,
+            accession="13F-VG-2025-Q4",
+            instrument_id=789_001,
+            filer_cik=cik,
+            filer_name="VANGUARD GROUP INC",
+            filer_type="ETF",
+            period_of_report=date(2025, 12, 31),
+            shares="21800000",
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="GME", instrument_id=789_001)
+
+        block_slices = [s for s in rollup.slices if s.category == "blockholders"]
+        assert len(block_slices) == 1
+        vg = block_slices[0].holders[0]
+        assert vg.filer_cik == cik
+        assert vg.winning_source == "13g"
+        assert vg.shares == Decimal("22000000")
+        # 13F lost — should be in dropped_sources.
+        assert any(d.source == "13f" for d in vg.dropped_sources)
+        # ETFs slice empty: 13F ETF row lost.
+        assert not any(s.category == "etfs" for s in rollup.slices)
+
+    def test_form3_baseline_wins_when_no_form4(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Officer with Form 3 baseline + no Form 4 — Form 3 supplies
+        the holding row."""
+        conn = _setup
+        _seed_form3(
+            conn,
+            accession="F3-OF-2024-001",
+            instrument_id=789_001,
+            filer_cik="0001234001",
+            filer_name="Director Alpha",
+            shares="50000",
+            as_of=date(2024, 1, 15),
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="GME", instrument_id=789_001)
+
+        insiders = [s for s in rollup.slices if s.category == "insiders"][0]
+        alpha = insiders.holders[0]
+        assert alpha.filer_cik == "0001234001"
+        assert alpha.winning_source == "form3"
+        assert alpha.shares == Decimal("50000")
+
+    def test_form3_suppressed_when_form4_exists_for_same_cik(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Officer with both Form 3 baseline + a Form 4 — Form 4 wins,
+        Form 3 row is filtered out at the SQL union (NOT EXISTS)
+        rather than landing as a dropped_source."""
+        conn = _setup
+        cik = "0001234002"
+        _seed_form3(
+            conn,
+            accession="F3-OF-2024-002",
+            instrument_id=789_001,
+            filer_cik=cik,
+            filer_name="Director Beta",
+            shares="50000",
+            as_of=date(2024, 1, 15),
+        )
+        _seed_form4(
+            conn,
+            accession="F4-OF-2026-002",
+            instrument_id=789_001,
+            filer_cik=cik,
+            filer_name="Director Beta",
+            txn_date=date(2026, 4, 1),
+            post_transaction_shares="125000",
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="GME", instrument_id=789_001)
+
+        insiders = [s for s in rollup.slices if s.category == "insiders"][0]
+        assert len(insiders.holders) == 1
+        beta = insiders.holders[0]
+        assert beta.winning_source == "form4"
+        assert beta.shares == Decimal("125000")
+        assert len(beta.dropped_sources) == 0  # Form 3 filtered pre-dedup
+
+    def test_null_cik_distinct_names_do_not_collapse(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Codex v3 review caught the prior bug: two NULL-CIK Form 4
+        rows with distinct names (legacy backfill data) must NOT
+        collapse into a single bucket. Identity uses the normalised
+        name when the CIK is NULL.
+
+        ``insider_initial_holdings.filer_cik`` is NOT NULL by schema
+        (Form 3 always has a CIK), so this scenario only applies to
+        legacy Form 4 rows where the early ingester left ``filer_cik
+        IS NULL``."""
+        conn = _setup
+        _seed_form4(
+            conn,
+            accession="F4-NULLCIK-001",
+            instrument_id=789_001,
+            filer_cik=None,
+            filer_name="Smith John",
+            txn_date=date(2026, 3, 1),
+            post_transaction_shares="100",
+        )
+        _seed_form4(
+            conn,
+            accession="F4-NULLCIK-002",
+            instrument_id=789_001,
+            filer_cik=None,
+            filer_name="Jones Jane",
+            txn_date=date(2026, 3, 2),
+            post_transaction_shares="200",
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="GME", instrument_id=789_001)
+
+        insiders = [s for s in rollup.slices if s.category == "insiders"][0]
+        names = sorted(h.filer_name for h in insiders.holders)
+        assert names == ["Jones Jane", "Smith John"]
+
+
+# ---------------------------------------------------------------------------
+# DEF 14A enrichment
+# ---------------------------------------------------------------------------
+
+
+class TestDef14aEnrichment:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=789_010, symbol="DEF14A")
+        _seed_outstanding(conn, instrument_id=789_010, shares="100000000")
+        conn.commit()
+        return conn
+
+    def test_resolver_matches_form4_filer(self, _setup: psycopg.Connection[tuple]) -> None:
+        """DEF 14A holder ``"Smith Jane"`` resolves to a Form 4 filer
+        with CIK ``0001100100``. Form 4 wins priority (rank 1 > rank
+        4); the DEF 14A accession ships in ``dropped_sources``."""
+        conn = _setup
+        cik = "0001100100"
+        _seed_form4(
+            conn,
+            accession="F4-SMITH-001",
+            instrument_id=789_010,
+            filer_cik=cik,
+            filer_name="Smith Jane",
+            txn_date=date(2026, 2, 15),
+            post_transaction_shares="500000",
+        )
+        _seed_def14a(
+            conn,
+            accession="DEF14A-2026-001",
+            instrument_id=789_010,
+            holder_name="Smith Jane, Director",
+            shares="500000",
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="DEF14A", instrument_id=789_010)
+
+        insiders = [s for s in rollup.slices if s.category == "insiders"][0]
+        smith = insiders.holders[0]
+        assert smith.winning_source == "form4"
+        assert smith.shares == Decimal("500000")
+        assert any(d.source == "def14a" for d in smith.dropped_sources)
+        assert not any(s.category == "def14a_unmatched" for s in rollup.slices)
+
+    def test_unmatched_def14a_lands_in_unmatched_slice(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Proxy-only holder with no Form 4 / Form 3 — ``def14a_unmatched``
+        slice surfaces the row so the operator doesn't lose it."""
+        conn = _setup
+        _seed_def14a(
+            conn,
+            accession="DEF14A-2026-002",
+            instrument_id=789_010,
+            holder_name="Doe Jonathan III",
+            shares="123456",
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="DEF14A", instrument_id=789_010)
+
+        unmatched = [s for s in rollup.slices if s.category == "def14a_unmatched"]
+        assert len(unmatched) == 1
+        assert unmatched[0].holders[0].filer_name == "Doe Jonathan III"
+        assert unmatched[0].holders[0].shares == Decimal("123456")
+
+    def test_def14a_legacy_null_cik_match_routes_to_insiders(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Codex pre-push review (Batch 1 of #788) caught this: a
+        DEF 14A holder name that resolves to a legacy NULL-CIK Form 4
+        row must route to the insiders slice (not def14a_unmatched).
+        The resolver returns ``matched=True, cik=None`` for that
+        case; my prior code branched on ``cik is not None`` and lost
+        the holder."""
+        conn = _setup
+        _seed_form4(
+            conn,
+            accession="F4-LEGACY-001",
+            instrument_id=789_010,
+            filer_cik=None,
+            filer_name="Legacy Officer",
+            txn_date=date(2024, 1, 1),
+            post_transaction_shares="42000",
+        )
+        _seed_def14a(
+            conn,
+            accession="DEF14A-2026-LEGACY",
+            instrument_id=789_010,
+            holder_name="Legacy Officer",
+            shares="42000",
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="DEF14A", instrument_id=789_010)
+        insiders = [s for s in rollup.slices if s.category == "insiders"]
+        assert len(insiders) == 1
+        legacy = insiders[0].holders[0]
+        # Legacy Form 4 with NULL CIK wins (priority 1 vs def14a's 4).
+        assert legacy.filer_name == "Legacy Officer"
+        assert legacy.winning_source == "form4"
+        assert legacy.filer_cik is None  # legacy row has no CIK
+        # DEF 14A accession should ship as a dropped source.
+        assert any(d.source == "def14a" for d in legacy.dropped_sources)
+        # def14a_unmatched slice should NOT contain this holder.
+        assert not any(s.category == "def14a_unmatched" for s in rollup.slices)
+
+    def test_resolver_prefers_cik_backed_row_over_legacy_null_cik(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Codex pre-push review (Batch 1 of #788) caught this: when
+        a filer has BOTH a legacy NULL-CIK Form 4 row and a newer
+        CIK-backed Form 4 row, ``resolve_holder_to_filer`` must
+        prefer the CIK-backed row so DEF 14A names resolve to the
+        canonical CIK identity. The prior version returned the
+        NULL-CIK row first because COALESCE(filer_cik,'') sorted
+        empty strings ahead of populated CIKs."""
+        from app.services.holder_name_resolver import resolve_holder_to_filer
+
+        conn = _setup
+        _seed_form4(
+            conn,
+            accession="F4-LEG-DUP-1",
+            instrument_id=789_010,
+            filer_cik=None,
+            filer_name="Dual Identity",
+            txn_date=date(2020, 1, 1),
+            post_transaction_shares="100",
+        )
+        _seed_form4(
+            conn,
+            accession="F4-LEG-DUP-2",
+            instrument_id=789_010,
+            filer_cik="0009999009",
+            filer_name="Dual Identity",
+            txn_date=date(2026, 1, 1),
+            post_transaction_shares="500",
+        )
+        conn.commit()
+
+        matched, cik, shares = resolve_holder_to_filer(conn, instrument_id=789_010, holder_name="Dual Identity")
+        assert matched is True
+        assert cik == "0009999009"  # CIK-backed row wins
+        assert shares == Decimal("500")
+
+
+# ---------------------------------------------------------------------------
+# Residual + concentration + treasury
+# ---------------------------------------------------------------------------
+
+
+class TestResidualAndCoverage:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=789_020, symbol="RESID")
+        # 100M outstanding, 10M treasury.
+        _seed_outstanding(conn, instrument_id=789_020, shares="100000000", treasury="10000000")
+        conn.commit()
+        return conn
+
+    def test_residual_label_and_value(self, _setup: psycopg.Connection[tuple]) -> None:
+        """30M known + 10M treasury → residual = 60M, label =
+        Public / unattributed, oversubscribed=False."""
+        conn = _setup
+        _seed_form4(
+            conn,
+            accession="F4-RESID-001",
+            instrument_id=789_020,
+            filer_cik="0009999001",
+            filer_name="Big Holder Inc",
+            txn_date=date(2026, 3, 1),
+            post_transaction_shares="30000000",
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="RESID", instrument_id=789_020)
+
+        assert rollup.residual.label == "Public / unattributed"
+        assert rollup.residual.shares == Decimal("60000000")
+        assert rollup.residual.oversubscribed is False
+        # Concentration: 30M / 100M = 30% (treasury excluded from numerator).
+        assert rollup.concentration.pct_outstanding_known == Decimal("0.30")
+
+    def test_oversubscribed_clamps_residual_to_zero(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Stale 13F + fresh 13D: holders sum to 110% of outstanding.
+        Residual clamps to 0 with ``oversubscribed=True``."""
+        conn = _setup
+        _seed_block(
+            conn,
+            accession="13D-OVER-2026-001",
+            instrument_id=789_020,
+            filer_cik="0008888001",
+            filer_name="Stale Block",
+            submission_type="SCHEDULE 13D",
+            aggregate_shares="110000000",
+            filed_at=datetime(2026, 3, 1, tzinfo=UTC),
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="RESID", instrument_id=789_020)
+
+        assert rollup.residual.shares == Decimal(0)
+        assert rollup.residual.oversubscribed is True
+
+    def test_treasury_excluded_from_concentration(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Concentration numerator = sum(slices). Treasury (10M) is
+        NOT added — concentration must stay 30% / 30M, not 40%."""
+        conn = _setup
+        _seed_form4(
+            conn,
+            accession="F4-TREAS-001",
+            instrument_id=789_020,
+            filer_cik="0009998001",
+            filer_name="Director X",
+            txn_date=date(2026, 1, 1),
+            post_transaction_shares="30000000",
+        )
+        conn.commit()
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="RESID", instrument_id=789_020)
+        assert rollup.concentration.pct_outstanding_known == Decimal("0.30")
+
+
+# ---------------------------------------------------------------------------
+# Coverage banner + states
+# ---------------------------------------------------------------------------
+
+
+class TestCoverageBanner:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=789_030, symbol="BANNER")
+        conn.commit()
+        return conn
+
+    def test_state_no_data_when_outstanding_missing(self, _setup: psycopg.Connection[tuple]) -> None:
+        """No XBRL outstanding row → banner state ``no_data``,
+        slices empty, residual=0, 200 OK semantics."""
+        conn = _setup
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="BANNER", instrument_id=789_030)
+        assert rollup.banner.state == "no_data"
+        assert rollup.banner.variant == "error"
+        assert rollup.shares_outstanding is None
+        assert rollup.slices == ()
+        assert rollup.residual.shares == Decimal(0)
+
+    def test_state_unknown_universe_default(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Outstanding present + no per-category estimates seeded
+        (Tier 0 default) → banner ``unknown_universe`` regardless
+        of the actual filer count."""
+        conn = _setup
+        _seed_outstanding(conn, instrument_id=789_030, shares="100000000")
+        _seed_form4(
+            conn,
+            accession="F4-BANNER-001",
+            instrument_id=789_030,
+            filer_cik="0007777001",
+            filer_name="Holder One",
+            txn_date=date(2026, 1, 1),
+            post_transaction_shares="1000000",
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="BANNER", instrument_id=789_030)
+        assert rollup.banner.state == "unknown_universe"
+        assert rollup.banner.variant == "warning"
+        # Per-category states should also all be unknown_universe.
+        for cov in rollup.coverage.categories.values():
+            assert cov.state == "unknown_universe"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot isolation
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotIsolation:
+    """Confirm the FastAPI handler's ``snapshot_read`` wrap holds —
+    a write committed mid-rollup must NOT alter the rollup's view."""
+
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=789_040, symbol="SNAP")
+        _seed_outstanding(conn, instrument_id=789_040, shares="100000000")
+        _seed_form4(
+            conn,
+            accession="F4-SNAP-001",
+            instrument_id=789_040,
+            filer_cik="0006666001",
+            filer_name="Snap Holder",
+            txn_date=date(2026, 1, 1),
+            post_transaction_shares="1000000",
+        )
+        conn.commit()
+        return conn
+
+    def test_snapshot_holds_under_concurrent_write(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Open a snapshot, run the rollup, write a new Form 4 from a
+        SECOND connection mid-flight, then call the rollup AGAIN on
+        the still-open snapshot. The second invocation should see
+        the same numbers as the first (REPEATABLE READ semantics)."""
+        from app.db.snapshot import snapshot_read
+        from tests.fixtures.ebull_test_db import test_database_url
+
+        conn = _setup
+        with snapshot_read(conn):
+            first = ownership_rollup.get_ownership_rollup(conn, symbol="SNAP", instrument_id=789_040)
+
+            # Concurrent write on a separate connection — must point at
+            # the same ``ebull_test`` DB the fixture seeded into, NOT
+            # the dev DB.
+            with psycopg.connect(test_database_url()) as writer:
+                writer.execute(
+                    """
+                    INSERT INTO insider_filings (
+                        accession_number, instrument_id, document_type, issuer_cik
+                    ) VALUES ('F4-SNAP-002-NEW', 789040, '4', '0000000789')
+                    """,
+                )
+                writer.execute(
+                    """
+                    INSERT INTO insider_transactions (
+                        accession_number, txn_row_num, instrument_id, filer_cik,
+                        filer_name, txn_date, txn_code, shares,
+                        post_transaction_shares, is_derivative
+                    ) VALUES ('F4-SNAP-002-NEW', 1, 789040, '0006666002',
+                              'Concurrent Holder', '2026-04-01', 'P', 100,
+                              500000, FALSE)
+                    """,
+                )
+                writer.commit()
+
+            second = ownership_rollup.get_ownership_rollup(conn, symbol="SNAP", instrument_id=789_040)
+
+        assert len(first.slices) == len(second.slices)
+        first_insiders = [s for s in first.slices if s.category == "insiders"][0]
+        second_insiders = [s for s in second.slices if s.category == "insiders"][0]
+        assert first_insiders.filer_count == second_insiders.filer_count == 1
+        # Cleanup the concurrent write so subsequent tests see a clean state
+        # (the write committed on a separate connection so the per-test
+        # truncate fixture covers it on next test, but the smoke test
+        # within this transaction needed both reads to agree first).
+
+
+# ---------------------------------------------------------------------------
+# Empty / pre-ingest state
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyStates:
+    def test_empty_cohort_residual_equals_outstanding(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Outstanding present, no filings of any kind → residual =
+        100% of outstanding, every slice missing."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=789_050, symbol="EMPTY")
+        _seed_outstanding(conn, instrument_id=789_050, shares="100000000")
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="EMPTY", instrument_id=789_050)
+        assert rollup.slices == ()
+        assert rollup.residual.shares == Decimal("100000000")
+        assert rollup.banner.state == "unknown_universe"


### PR DESCRIPTION
## Summary

- **Ship-blocker 1 (denominator)**: drop `shares_outstanding + treasury_shares` math; the canonical denominator is `shares_outstanding` only. Treasury renders as an additive top wedge.
- **Ship-blocker 2 (cross-channel dedup)**: new `/instruments/{symbol}/ownership-rollup` endpoint deduplicates Form 4 / Form 3 / 13D-G / DEF 14A / 13F by CIK identity (with name fallback) at priority `form4 > form3 > 13d/g > def14a > 13f`. Cohen-on-GME drops from ~75M to ~38M.
- **Schema-drift recovery**: migration 101 adds `insider_initial_holdings.value_owned` + `underlying_value` (migration 093's `CREATE TABLE IF NOT EXISTS` no-op'd onto a pre-existing table). The new schema-drift smoke gate (B5 of #797 pulled forward) caught the additional `underlying_value` drift that had been silently broken.
- **CIK + symbol history schema (Batch 1 of #794)**: migrations 102 + 103 install `instrument_cik_history` / `instrument_symbol_history` with the temporal invariants (ordered ranges, partial UNIQUE on current row, GIST EXCLUDE on overlap). Backfill seeds one `imported` row per instrument from the current CIK + symbol. The BBBY ticker-rename case is **not** closed end-to-end — the symbol-change ingester + frontend callout land in Batch 7.

## Test plan

- [x] `tests/test_ownership_rollup.py` — 16 cases covering dedup priority, residual oversubscription, banner state machine, snapshot isolation, joint-filer collapse, NULL-CIK identity, DEF 14A enrichment.
- [x] `tests/test_instrument_history.py` — 8 cases pinning the temporal invariants (overlap / inverted / single-current / clash-guard) + backfill idempotency.
- [x] `tests/test_holder_name_resolver.py` — 10 cases asserting parity between the lifted public API and the legacy private helpers.
- [x] `tests/smoke/test_app_boots.py::test_insider_initial_holdings_value_owned_column_exists` — recovery gate.
- [x] `tests/smoke/test_schema_drift.py` — schema-drift smoke gate (B5 of #797 pulled forward).
- [x] Frontend `OwnershipPanel.test.ts` — 8 cases covering rollup-to-sunburst mapping, treasury-not-in-denominator, def14a_unmatched fold.
- [x] Live endpoint smoke: `curl /instruments/GME/ownership-rollup` returns Cohen at 38.35M (Form 4 wins) with the 13D/A in `dropped_sources`. Residual = `Public / unattributed`. Banner = `unknown_universe` (universe estimates land in #790).
- [x] All 4 local gates: `ruff check`, `ruff format --check`, `pyright`, `pytest tests/test_ownership_rollup.py tests/test_instrument_history.py tests/test_holder_name_resolver.py tests/smoke/`.
- [x] Frontend `pnpm typecheck` + `pnpm test:unit` (830 tests).

## Codex review history

Three rounds of spec review (v1→v2→v3) closing 9 prior findings: DEF 14A holder-name resolver lift, `snapshot_read` wrap, banner driven by universe coverage (not float concentration), worst-of fold with `unknown_universe` ranked worse than `amber`, history-table temporal invariants, residual oversubscription clamp, dedup tie-break sequence, scope-down on the BBBY case, enum naming consistency.

Pre-push diff review caught 4 more: DEF 14A `matched`-flag enrichment (legacy NULL-CIK Form 4 routes to insiders, not unmatched), CIK-preference re-sort in resolver (so a filer with both legacy NULL-CIK and CIK-backed Form 4 rows resolves to the CIK identity), `def14a_unmatched` fold into the chart insiders bucket. Joint 13D/G collapse was REBUTTED with rationale (SEC-canonical: joint reporters share beneficial ownership, mirrors the existing `/blockholders` reader's per-accession MAX rollup; documented inline at the canonical-union SQL).

## Pre-existing test pollution flagged

`tests/test_migration_071_exchanges_capabilities.py` fails after `tests/test_refresh_financial_facts_parallel.py` runs in the same pytest session — the parallel test's `_seed_instrument` helper inserts `exchanges` rows without `capabilities`, persisting across pytest invocations because `exchanges` isn't in `_PLANNER_TABLES`. This is the prevention-log entry "Test seed pollution" tracked in #797 B6 and is unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)