### PR TITLE
fix(#790): Soros / Geode CIK disambiguation (Batch 2 of #788)

### DIFF
--- a/scripts/seed_holder_coverage.py
+++ b/scripts/seed_holder_coverage.py
@@ -90,7 +90,12 @@ _INSTITUTIONAL_SEEDS: list[tuple[str, str]] = [
     ("0001067983", "Berkshire Hathaway Inc."),
     ("0000354204", "T. Rowe Price Associates"),
     ("0000895421", "Capital World Investors"),
-    ("0001029160", "Geode Capital Management LLC"),
+    # Soros / Geode disambig (#790 P2 — migration 104). CIK
+    # 0001029160 is SOROS FUND MANAGEMENT LLC (verified via SEC
+    # submissions.json), NOT Geode. Real Geode Capital Management
+    # LLC is CIK 0001214717.
+    ("0001029160", "Soros Fund Management LLC"),
+    ("0001214717", "Geode Capital Management LLC"),
     ("0000200217", "Northern Trust Corp."),
     ("0000866787", "Wellington Management Group LLP"),
 ]
@@ -112,7 +117,10 @@ _INSTITUTIONAL_SEEDS: list[tuple[str, str]] = [
 _ETF_OVERRIDES: list[tuple[str, str]] = [
     ("0000102909", "Vanguard ETF franchise"),
     ("0001364742", "iShares (BlackRock) ETF franchise"),
-    ("0001029160", "Geode Capital (Fidelity index-fund engine)"),
+    # Soros / Geode disambig (#790 P2 — migration 104). The real
+    # Geode Capital Management LLC is CIK 0001214717. Soros (CIK
+    # 0001029160) is intentionally NOT in the ETF override list.
+    ("0001214717", "Geode Capital (Fidelity index-fund engine)"),
 ]
 
 # Activist hedge funds + founder-family holdcos that file 13D/G
@@ -233,6 +241,25 @@ def _seed_all(conn: psycopg.Connection[tuple]) -> None:
     for cik, label in _INSTITUTIONAL_SEEDS:
         seed_institutional_filer(conn, cik=cik, label=label)
     print(f"  {len(_INSTITUTIONAL_SEEDS)} institutional seeds upserted.")
+
+    # Stale-row reconciliation for the Soros/Geode disambig (#790 P2,
+    # migration 104). The script is upsert-only by design, but a DB
+    # that ran the pre-migration version still carries
+    # ``cik='0001029160'`` (Soros) tagged as an ETF override —
+    # re-running this script after the source change wouldn't
+    # converge without an explicit DELETE. Codex pre-push review
+    # caught this. Listed inline rather than in a generic "removed
+    # CIKs" constant because the migration is the canonical record;
+    # this DELETE is a script-level convergence guarantee, not a
+    # source-of-truth list.
+    _STALE_ETF_CIKS: tuple[str, ...] = ("0001029160",)
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM etf_filer_cik_seeds WHERE cik = ANY(%s)",
+            (list(_STALE_ETF_CIKS),),
+        )
+        if cur.rowcount and cur.rowcount > 0:
+            print(f"  removed {cur.rowcount} stale ETF override(s): {list(_STALE_ETF_CIKS)} (Soros mis-seed cleanup)")
 
     print("Seeding etf_filer_cik_seeds...")
     for cik, label in _ETF_OVERRIDES:

--- a/sql/104_fix_soros_geode_disambig.sql
+++ b/sql/104_fix_soros_geode_disambig.sql
@@ -1,0 +1,93 @@
+-- 104_fix_soros_geode_disambig.sql
+--
+-- Soros / Geode CIK disambiguation (#790 P2, Batch 2 of #788).
+--
+-- Live state pre-fix:
+--   * institutional_filer_seeds row CIK 0001029160 labelled
+--     "Geode Capital Management LLC" — WRONG. SEC submissions.json
+--     for CIK 0001029160 confirms the entity name is
+--     "SOROS FUND MANAGEMENT LLC". Verified via:
+--     https://data.sec.gov/submissions/CIK0001029160.json
+--   * etf_filer_cik_seeds row CIK 0001029160 tags it as ETF —
+--     WRONG. Soros is a hedge fund, not an ETF issuer; every Soros
+--     position is currently routed to the ETFs slice on the
+--     ownership card.
+--   * Real Geode Capital Management LLC is CIK 0001214717
+--     (verified via SEC EDGAR full-text search for 13F-HR filings;
+--     submissions.json confirms entity name). Geode operates
+--     Fidelity's passive-index funds and IS legitimately an ETF
+--     filer for the chart's filer_type split.
+--
+-- Note on the issue text: #790 cited Geode's CIK as 0001572162.
+-- That's wrong — 0001572162 is Sinclair Television of Illinois, LLC.
+-- The 0001214717 figure is what SEC EDGAR full-text search returns
+-- for 13F-HR filings whose primary_doc.xml names "GEODE CAPITAL
+-- MANAGEMENT, LLC".
+--
+-- Apply order:
+--   1. Relabel the Soros row in institutional_filer_seeds.
+--   2. Drop the bogus Soros ETF override.
+--   3. Add Geode (real CIK) to institutional_filer_seeds.
+--   4. Tag Geode (real CIK) in etf_filer_cik_seeds.
+--
+-- Idempotent: each step uses ON CONFLICT DO UPDATE / DO NOTHING /
+-- DELETE WHERE so a re-run is safe. The institutional_filers /
+-- institutional_holdings tables (which inherit from the seeds via
+-- the ingester) are NOT touched here — the next ingester run picks
+-- up the corrected name from the live SEC fetch (filer_name on
+-- institutional_filers updates via the existing ON CONFLICT path
+-- in the ingester's seed_filer code).
+
+-- Step 1: relabel CIK 0001029160 as Soros (canonical SEC name).
+UPDATE institutional_filer_seeds
+SET label = 'Soros Fund Management LLC',
+    notes = 'Was mis-labelled "Geode Capital Management" through migration 091; corrected by migration 104 (#790 P2). Routing Soros positions to the institutions slice (NOT etfs).'
+WHERE cik = '0001029160';
+
+-- Step 2: drop the bogus ETF override on Soros's CIK so the
+-- filer_type classifier no longer routes Soros positions to ETFs.
+DELETE FROM etf_filer_cik_seeds
+WHERE cik = '0001029160';
+
+-- Step 3: add real Geode Capital Management LLC (CIK 0001214717)
+-- to the institutional seed list. ``institutional_filers.filer_type``
+-- is updated by the next ingester run (filer_type lookup walks the
+-- etf_filer_cik_seeds override below).
+INSERT INTO institutional_filer_seeds (cik, label, active, notes)
+VALUES (
+    '0001214717',
+    'Geode Capital Management LLC',
+    TRUE,
+    'Operates Fidelity''s passive-index funds. Migrated in by #790 P2 alongside the Soros/Geode disambiguation.'
+)
+ON CONFLICT (cik) DO UPDATE
+SET label = EXCLUDED.label,
+    notes = EXCLUDED.notes;
+
+-- Step 4: tag the real Geode CIK as an ETF issuer so the filer_type
+-- classifier routes its 13F-HR holdings into the etfs slice.
+INSERT INTO etf_filer_cik_seeds (cik, label)
+VALUES ('0001214717', 'Geode Capital Management (Fidelity passive-index funds)')
+ON CONFLICT (cik) DO UPDATE
+SET label = EXCLUDED.label;
+
+-- Defensive: existing institutional_filers.filer_type rows for the
+-- two CIKs need to flip on the next ingester run. The filer_type
+-- column is set during seed_filer / ingester upsert from
+-- ``etf_filer_cik_seeds`` lookup, so this UPDATE preempts the
+-- mis-tagging that would otherwise persist until the next 13F-HR
+-- ingest pass touches each filer.
+UPDATE institutional_filers
+SET filer_type = 'INV',  -- INV = investment manager (hedge fund / advisor); not ETF
+    name = 'SOROS FUND MANAGEMENT LLC'
+WHERE cik = '0001029160';
+
+-- ``institutional_filers`` row for the real Geode CIK may not yet
+-- exist; the next ingester run creates it. ON CONFLICT DO UPDATE
+-- defensively handles the case where it has been ingested under a
+-- name variant.
+INSERT INTO institutional_filers (cik, name, filer_type)
+VALUES ('0001214717', 'GEODE CAPITAL MANAGEMENT, LLC', 'ETF')
+ON CONFLICT (cik) DO UPDATE
+SET name = EXCLUDED.name,
+    filer_type = 'ETF';

--- a/tests/test_seed_soros_geode_disambig.py
+++ b/tests/test_seed_soros_geode_disambig.py
@@ -1,0 +1,88 @@
+"""Regression test for the Soros/Geode CIK disambiguation (#790 P2,
+migration 104, Batch 2 of #788).
+
+Codex audit + SEC submissions.json verified that CIK 0001029160 is
+SOROS FUND MANAGEMENT LLC, not Geode Capital Management. Migration
+091's curated seed list mis-labelled the row as Geode and tagged it
+ETF, routing every Soros position into the etfs slice on the
+ownership card. Real Geode Capital Management LLC is CIK
+0001214717 (verified via SEC EDGAR full-text search for 13F-HR).
+
+Tests target the canonical seed sources (the migration SQL + the
+``scripts/seed_holder_coverage`` constants) rather than the live DB
+state — the per-test TRUNCATE in ``ebull_test_conn`` wipes the seed
+rows between tests and would force every test to re-apply the
+migration first. This file's job is "did the source-of-truth lists
+get updated", which is decidable without round-tripping through the
+DB.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.seed_holder_coverage import _ETF_OVERRIDES, _INSTITUTIONAL_SEEDS
+
+_REAL_SOROS_CIK = "0001029160"
+_REAL_GEODE_CIK = "0001214717"
+
+
+def test_soros_cik_in_seed_list_labelled_soros() -> None:
+    """The CIK that SEC says is Soros must be labelled Soros, not Geode."""
+    by_cik = dict(_INSTITUTIONAL_SEEDS)
+    label = by_cik.get(_REAL_SOROS_CIK)
+    assert label is not None, (
+        f"CIK {_REAL_SOROS_CIK} missing from _INSTITUTIONAL_SEEDS — "
+        f"the curated list dropped Soros entirely (likely a bad merge)."
+    )
+    assert "Soros" in label, (
+        f"CIK {_REAL_SOROS_CIK} mislabelled as {label!r}. "
+        f"SEC submissions.json confirms this CIK is SOROS FUND "
+        f"MANAGEMENT LLC, not Geode Capital Management."
+    )
+    assert "Geode" not in label
+
+
+def test_soros_cik_not_in_etf_override_list() -> None:
+    """Soros is a hedge fund, not an ETF issuer."""
+    etf_ciks = {cik for cik, _label in _ETF_OVERRIDES}
+    assert _REAL_SOROS_CIK not in etf_ciks, (
+        f"CIK {_REAL_SOROS_CIK} (Soros) appears in _ETF_OVERRIDES; "
+        f"every Soros position would route to the etfs slice on the "
+        f"ownership card. Soros is a hedge fund — drop the override."
+    )
+
+
+def test_real_geode_cik_in_seed_list() -> None:
+    by_cik = dict(_INSTITUTIONAL_SEEDS)
+    label = by_cik.get(_REAL_GEODE_CIK)
+    assert label is not None, f"Real Geode CIK {_REAL_GEODE_CIK} missing from _INSTITUTIONAL_SEEDS."
+    assert "Geode" in label
+
+
+def test_real_geode_cik_in_etf_override_list() -> None:
+    etf_ciks = {cik for cik, _label in _ETF_OVERRIDES}
+    assert _REAL_GEODE_CIK in etf_ciks, (
+        f"Real Geode CIK {_REAL_GEODE_CIK} missing from _ETF_OVERRIDES — "
+        f"Geode operates Fidelity's passive-index franchise and IS an "
+        f"ETF issuer for the chart's filer_type split."
+    )
+
+
+def test_migration_104_present_and_addresses_both_ciks() -> None:
+    """Pin the migration file's existence so a future cleanup that
+    drops it (or moves the fix into an earlier migration) can't
+    silently re-introduce the bug.
+
+    Verifies the migration text references both CIKs and the
+    canonical actions (Soros UPDATE label, Geode INSERT seed,
+    Geode INSERT etf override, Soros DELETE etf override)."""
+    migration = Path(__file__).resolve().parent.parent / "sql" / "104_fix_soros_geode_disambig.sql"
+    assert migration.exists(), "migration 104 missing"
+    text = migration.read_text(encoding="utf-8")
+    assert _REAL_SOROS_CIK in text
+    assert _REAL_GEODE_CIK in text
+    assert "Soros Fund Management" in text
+    assert "Geode Capital Management" in text
+    assert "DELETE FROM etf_filer_cik_seeds" in text
+    assert "INSERT INTO etf_filer_cik_seeds" in text


### PR DESCRIPTION
## Summary

- Migration 091 mis-labelled CIK `0001029160` as Geode Capital Management and tagged it ETF; SEC submissions.json confirms the entity is **Soros Fund Management LLC**. Every Soros position currently routes to the etfs slice on the ownership card.
- Real Geode Capital Management LLC is CIK `0001214717` (verified via SEC EDGAR full-text search; #790's text cited `0001572162` which is Sinclair Television — a typo in the issue).
- Migration 104 fixes the seed table state, the live `institutional_filers` rows, and the curated `scripts/seed_holder_coverage.py` constants. Codex pre-push review caught that the upsert-only script needed an explicit DELETE for the stale Soros ETF override on re-bootstrap; added.
- #791 P1 + P2 + P3 verified as already shipped by Batch 1 (PR #798) — Form 3 suppression rule already requires non-derivative + parseable post_transaction_shares; blockholder branch uses `COALESCE(reporter_name, filer_name)` so the L1 wedge label tracks the beneficial owner; `/ownership-rollup` payload has no fetch caps in the chart path.

## Test plan

- [x] `tests/test_seed_soros_geode_disambig.py` — 5 regression tests pinning the constants + migration text against future drift.
- [x] Live dev DB verification: `institutional_filer_seeds` row for `0001029160` now labelled "Soros Fund Management LLC"; `etf_filer_cik_seeds` row removed; new Geode CIK `0001214717` present in both seed + ETF override tables; `institutional_filers` row for Soros now `filer_type='INV'`, name `SOROS FUND MANAGEMENT LLC`.
- [x] All 4 local gates: `ruff check`, `ruff format --check`, `pyright`, `pytest`.
- [x] Codex pre-push diff review identified the script convergence gap; addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)