### PR TITLE
fix(#797): adjacent ownership-stack bugs (Batch 8 of #788)

### DIFF
--- a/tests/smoke/test_no_data_ingestion_runs_created_at.py
+++ b/tests/smoke/test_no_data_ingestion_runs_created_at.py
@@ -1,0 +1,94 @@
+"""Static guard: no code references ``data_ingestion_runs.created_at``
+(#797 B3 — Batch 8 of #788).
+
+The 2026-05-03 postgres log audit found a query firing every ~30s:
+
+    SELECT status FROM data_ingestion_runs
+    WHERE source LIKE 'sec_edgar_13%'
+      AND created_at > NOW() - INTERVAL '15 minutes'
+    ORDER BY created_at DESC LIMIT 2
+
+``data_ingestion_runs`` (migration 032) has ``started_at`` /
+``finished_at`` columns; there is no ``created_at`` column. The query
+errors silently every time it runs. The hunt for the source came up
+empty in the current snapshot — no procs, no views, no live
+queries — so the issue was either (a) intermittent against a prior
+build, or (b) something external (pgAdmin / DBeaver / ad-hoc
+debug script) connected to the dev DB.
+
+This smoke gate is the recurring guard: if any production source
+file references ``data_ingestion_runs`` with ``created_at``, fail
+loud at test time so the next-30s flap is caught before it lands
+in CI rather than after.
+
+Tolerated paths:
+
+  * Test files that EXPECT the bad pattern as input (none currently
+    — the codebase has zero hits).
+  * This guard's own source (the patterns are data here).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_FORBIDDEN_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Loose match — any reference to data_ingestion_runs in the same
+    # SQL block as ``created_at``. Multi-line tolerated via DOTALL.
+    re.compile(
+        r"data_ingestion_runs[\s\S]{0,200}?created_at",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"created_at[\s\S]{0,200}?data_ingestion_runs",
+        re.IGNORECASE,
+    ),
+)
+
+_SCAN_DIRS = (
+    _REPO_ROOT / "app",
+    _REPO_ROOT / "scripts",
+    _REPO_ROOT / "frontend" / "src",
+)
+
+_ALLOWED: set[str] = {
+    # The guard itself contains the patterns as data.
+    "tests/smoke/test_no_data_ingestion_runs_created_at.py",
+}
+
+
+def test_no_code_references_data_ingestion_runs_created_at() -> None:
+    """Fail if any production source file pairs
+    ``data_ingestion_runs`` with ``created_at`` — the column does
+    not exist on that table (migration 032 uses ``started_at`` /
+    ``finished_at``).
+    """
+    offenders: list[tuple[str, str]] = []
+    for scan_dir in _SCAN_DIRS:
+        if not scan_dir.exists():
+            continue
+        for path in scan_dir.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.suffix not in {".py", ".ts", ".tsx", ".sql", ".sh"}:
+                continue
+            rel = path.relative_to(_REPO_ROOT).as_posix()
+            if rel in _ALLOWED:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError, OSError:
+                continue
+            for pattern in _FORBIDDEN_PATTERNS:
+                if pattern.search(text):
+                    offenders.append((rel, pattern.pattern[:40]))
+                    break
+
+    assert not offenders, (
+        "Found code referencing ``data_ingestion_runs.created_at`` — "
+        "the table has ``started_at`` / ``finished_at``, not ``created_at`` "
+        "(migration 032). Fix the column name or, if the table moved, "
+        "update this guard. Offenders:\n" + "\n".join(f"  {f} (matched {p!r}...)" for f, p in offenders)
+    )

--- a/tests/test_refresh_financial_facts_parallel.py
+++ b/tests/test_refresh_financial_facts_parallel.py
@@ -79,13 +79,39 @@ class _FakeProvider:
 
 
 def _seed_instrument(conn: psycopg.Connection[tuple], instrument_id: int, symbol: str, cik: str) -> None:
+    # Capabilities must match the us_equity contract from migration
+    # 071/072 — ``test_us_equity_seed_includes_sec_edgar_for_filings``
+    # asserts every us_equity row has ``capabilities -> 'filings' =
+    # ['sec_edgar']``. Without it the test cross-pollinates and fails
+    # in shared pytest sessions where this fixture's rows leak. #797
+    # B6 prevention.
+    # Full us_equity capability shape (11 keys) per migration 072.
+    # ``test_us_equity_seed_full_shape`` asserts every us_equity row
+    # has all 11 keys including the empty-list ones; partial seeds
+    # drift the test in shared pytest sessions where this fixture's
+    # rows leak. #797 B6 prevention.
     conn.execute(
         """
-        INSERT INTO exchanges (exchange_id, description, country, asset_class)
-        VALUES (%s, %s, 'US', 'us_equity')
-        ON CONFLICT (exchange_id) DO NOTHING
+        INSERT INTO exchanges (exchange_id, description, country, asset_class, capabilities)
+        VALUES (%s, %s, 'US', 'us_equity', %s::jsonb)
+        ON CONFLICT (exchange_id) DO UPDATE SET
+            capabilities = EXCLUDED.capabilities
         """,
-        (f"rfp_{instrument_id}", f"Test {instrument_id}"),
+        (
+            f"rfp_{instrument_id}",
+            f"Test {instrument_id}",
+            (
+                '{"filings": ["sec_edgar"], '
+                '"fundamentals": ["sec_xbrl"], '
+                '"dividends": ["sec_dividend_summary"], '
+                '"insider": ["sec_form4"], '
+                '"analyst": [], "ratings": [], "esg": [], '
+                '"ownership": ["sec_13f", "sec_13d_13g"], '
+                '"corporate_events": ["sec_8k_events"], '
+                '"business_summary": ["sec_10k_item1"], '
+                '"officers": []}'
+            ),
+        ),
     )
     conn.execute(
         """


### PR DESCRIPTION
## Summary

Tight scope — small / verifiable items from #797. Larger items (B2 sync_runs FK race, B7 stray FATAL auth investigation) defer to focused PRs that need infrastructure-level context.

## Per sub-bug

- **B1** (13F duplicate-key race): VERIFIED already shipped. `app/services/institutional_holdings.py:625` uses `ON CONFLICT DO NOTHING` (no explicit target; catches the partial expression-based UNIQUE INDEX from migration 090). Postgres error log cited in #797 was historical.
- **B3** (rogue `data_ingestion_runs.created_at` poller): HUNT empty — no DB views / procs / triggers / active queries reference the bad pattern, no `pg_cron` jobs, no CI workflow steps. Source was either intermittent against a prior build or external (pgAdmin / debug script connected to dev DB). Recurring guard added: `tests/smoke/test_no_data_ingestion_runs_created_at.py` greps every production source file (Python + TS + SQL) for the forbidden pattern.
- **B4** (ingest-health page): SHIPPED in PR #801 (Batch 4).
- **B5** (schema-drift smoke gate): SHIPPED in PR #798 (Batch 1; `tests/smoke/test_schema_drift.py`). Caught + fixed `insider_initial_holdings.underlying_value` drift in the same PR.
- **B6** (test seed pollution): FIXED. `tests/test_refresh_financial_facts_parallel.py::_seed_instrument` inserted `exchanges` rows without `capabilities`, breaking the migration 071/072 contract for any later test observing the row (rows leak across pytest sessions because `exchanges` isn't in `_PLANNER_TABLES`). Now seeds the full 11-key us_equity capability shape verbatim.
- **B2** (sync_runs / pending_job_requests FK race): DEFERRED. Needs read+lock redesign on the dispatcher hot path; bigger than a one-line fix.
- **B7** (stray FATAL auth): DEFERRED. Operator-environment investigation only; no code change needed.

## Test plan

- [x] `tests/smoke/test_no_data_ingestion_runs_created_at.py` — recurring guard passes; no production source matches the forbidden pattern.
- [x] `tests/test_refresh_financial_facts_parallel.py` + `tests/test_migration_071_exchanges_capabilities.py` — both pass after the seed-pollution fix; previously the parallel test polluted `exchanges` causing migration 071 assertions to drift.
- [x] All 4 local gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)